### PR TITLE
HDF5/openPMD: Add requirements.txt

### DIFF
--- a/openPMD-CCD/requirements.txt
+++ b/openPMD-CCD/requirements.txt
@@ -1,0 +1,4 @@
+pillow
+python-dateutil
+numpy
+h5py>=2.5.0


### PR DESCRIPTION
Adds all dependnecies for HDF5 writing.

Install via;
```
python -m pip install openPMD-CCD/requirements.txt
```