### PR TITLE
Put list of variables expected by LabView in config file

### DIFF
--- a/ImageAnalysis/image_analysis/labview_adapters_config.json
+++ b/ImageAnalysis/image_analysis/labview_adapters_config.json
@@ -1,0 +1,40 @@
+{
+  "UC_HiResMagCam": {
+    "keys_of_interest": [
+      "camera_clipping_factor",
+      "camera_saturation_counts",
+      "total_charge_pC",
+      "peak_charge_pc/MeV",
+      "peak_charge_energy_MeV",
+      "weighted_average_energy_MeV",
+      "energy_spread_weighted_rms_MeV",
+      "energy_spread_percent",
+      "weighted_average_beam_size_um",
+      "projected_beam_size_um",
+      "beam_tilt_um/MeV",
+      "beam_tilt_intercept_um",
+      "beam_tilt_intercept_100MeV_um",
+      "optimization_factor",
+      "fwhm_percent"
+    ]
+  },
+  "UC_ACaveMagCam3": {
+    "keys_of_interest": [
+      "camera_clipping_factor",
+      "camera_saturation_counts",
+      "total_charge_pC",
+      "peak_charge_pc/MeV",
+      "peak_charge_energy_MeV",
+      "weighted_average_energy_MeV",
+      "energy_spread_weighted_rms_MeV",
+      "energy_spread_percent",
+      "weighted_average_beam_size_um",
+      "projected_beam_size_um",
+      "beam_tilt_um/MeV",
+      "beam_tilt_intercept_um",
+      "beam_tilt_intercept_100MeV_um",
+      "optimization_factor",
+      "fwhm_percent"
+    ]
+  }
+}

--- a/ImageAnalysis/tests/chris_UnitTests/test_HiResMagSpec.py
+++ b/ImageAnalysis/tests/chris_UnitTests/test_HiResMagSpec.py
@@ -98,6 +98,7 @@ class TestHiResMagSpecAnalyze(unittest.TestCase):
         self.assertAlmostEqual(analyze_dict["beam_tilt_intercept_um"], -1703.46109, delta=1e-4)
         self.assertAlmostEqual(analyze_dict["beam_tilt_intercept_100MeV_um"], 226.63913, delta=1e-4)
         self.assertAlmostEqual(analyze_dict["optimization_factor"], 0.783622, delta=1e-4)
+        self.assertAlmostEqual(analyze_dict["fwhm_percent"], 0.2934, delta=1e-2)
 
         # Here I am only checking that the labview wrapper function is working properly by checking the output shapes
 
@@ -111,7 +112,10 @@ class TestHiResMagSpecAnalyze(unittest.TestCase):
         returned_image_labview, analyze_dict_labview, lineouts_labview = labview_function_caller.analyze_labview_image(
             camera_name, elliptical_gaussian_array, background=None)
         np.testing.assert_array_equal(np.shape(returned_image_labview), test_array_shape)
-        np.testing.assert_array_equal(np.shape(analyze_dict_labview), np.array([14, ]))
+
+        # TODO: fill in
+        self.assertListEqual(analyze_dict_labview.keys(), xxx_expected_keys_xxx)
+
         np.testing.assert_array_equal(np.shape(lineouts_labview), np.array([2, test_array_shape[1]]))
 
 


### PR DESCRIPTION
To clean up labview_adapters.py, and have access to the list of variables in other modules, put the list of variables in a separate config file.

Combining my "to-do" branches into a single branch.  Want to include my new ALine analyzer before working on cleaning up labview analyzers and the unit tests