### PR TITLE
05152024 mag spec charge fix chris

### DIFF
--- a/ImageAnalysis/image_analysis/analyzers/UC_GenericMagSpecCam.py
+++ b/ImageAnalysis/image_analysis/analyzers/UC_GenericMagSpecCam.py
@@ -120,7 +120,7 @@ class UC_GenericMagSpecCamAnalyzer(LabviewImageAnalyzer):
         clipped_percentage = analyze.calculate_clipped_percentage(image)
         self.print_time(" Calculate Clipped Percentage")
 
-        charge_arr = analyze.calculate_charge_density_distribution(image, self.transverse_calibration)
+        charge_arr = analyze.calculate_charge_density_distribution(image, energy_arr)
         self.print_time(" Charge Projection:")
 
         if charge_on_camera == 0:

--- a/ImageAnalysis/image_analysis/analyzers/online_analysis_modules/mag_spec_analysis.py
+++ b/ImageAnalysis/image_analysis/analyzers/online_analysis_modules/mag_spec_analysis.py
@@ -38,8 +38,9 @@ def calculate_projected_beam_size(image, calibration_factor):
     return axis_arr, proj_arr, beam_size
 
 
-def calculate_charge_density_distribution(image, calibration_factor):
-    charge_arr = np.sum(image, axis=0) * calibration_factor
+def calculate_charge_density_distribution(image, energy_axis):
+    calibration_array = np.ediff1d(energy_axis, to_end=energy_axis[-1]-energy_axis[-2])
+    charge_arr = np.sum(image, axis=0) / calibration_array
     return charge_arr
 
 

--- a/ImageAnalysis/tests/labview_analyzer_unit_tests/test_ACaveMagCam3.py
+++ b/ImageAnalysis/tests/labview_analyzer_unit_tests/test_ACaveMagCam3.py
@@ -72,17 +72,17 @@ class TestACaveMagCam3Analyze(unittest.TestCase):
         self.assertAlmostEqual(analyze_dict["camera_clipping_factor"], 0.42678, delta=1e-4)
         self.assertEqual(analyze_dict["camera_saturation_counts"], 49)
         self.assertAlmostEqual(analyze_dict["total_charge_pC"], 671992.75, delta=1e-1)
-        self.assertAlmostEqual(analyze_dict["peak_charge_pc/MeV"], 48442.74, delta=1e-1)
+        self.assertAlmostEqual(analyze_dict["peak_charge_pc/MeV"], 577284.42, delta=1e-1)
         self.assertAlmostEqual(analyze_dict["peak_charge_energy_MeV"], 82.8332077, delta=1e-4)
-        self.assertAlmostEqual(analyze_dict["weighted_average_energy_MeV"], 82.90576452951896, delta=1e-4)
-        self.assertAlmostEqual(analyze_dict["energy_spread_weighted_rms_MeV"], 0.4254417441866327, delta=1e-4)
-        self.assertAlmostEqual(analyze_dict["energy_spread_percent"], 0.5131630431260932, delta=1e-4)
+        self.assertAlmostEqual(analyze_dict["weighted_average_energy_MeV"], 82.9020, delta=1e-4)
+        self.assertAlmostEqual(analyze_dict["energy_spread_weighted_rms_MeV"], 0.4248, delta=1e-4)
+        self.assertAlmostEqual(analyze_dict["energy_spread_percent"], 0.5125, delta=1e-4)
         self.assertAlmostEqual(analyze_dict["weighted_average_beam_size_um"], 3.21847, delta=1e-4)
         self.assertAlmostEqual(analyze_dict["projected_beam_size_um"], 4.07075, delta=1e-4)
         self.assertAlmostEqual(analyze_dict["beam_tilt_um/MeV"], 4.3162045059, delta=1e-4)
         self.assertAlmostEqual(analyze_dict["beam_tilt_intercept_um"], -333.19934, delta=1e-4)
         self.assertAlmostEqual(analyze_dict["beam_tilt_intercept_100MeV_um"], 98.42110, delta=1e-4)
-        self.assertAlmostEqual(analyze_dict["optimization_factor"], 3.46646, delta=1e-4)
+        self.assertAlmostEqual(analyze_dict["optimization_factor"], 40.8544, delta=1e-4)
         self.assertAlmostEqual(analyze_dict["fwhm_percent"], 1.41698, delta=1e-3)
 
         # Next we test the Labview adapter method of calling this analyzer
@@ -95,7 +95,7 @@ class TestACaveMagCam3Analyze(unittest.TestCase):
         np.testing.assert_array_equal(np.array(default_roi), np.array([112, 278, 23, 1072]))
 
         # I have to make a really strange shape in order for the large bounds above to work with the small image below
-        big_elliptical_gaussian = generate_elliptical_gaussian(amplitude, 113, 24, center_x, center_y,
+        big_elliptical_gaussian = generate_elliptical_gaussian(amplitude, 113, 25, center_x, center_y,
                                                                sigma_x, sigma_y, angle_deg)
         test_array_shape = np.shape(big_elliptical_gaussian[default_roi[0]:default_roi[1],
                                     default_roi[2]:default_roi[3]])

--- a/ImageAnalysis/tests/labview_analyzer_unit_tests/test_HiResMagSpec.py
+++ b/ImageAnalysis/tests/labview_analyzer_unit_tests/test_HiResMagSpec.py
@@ -70,7 +70,7 @@ class TestHiResMagSpecAnalyze(unittest.TestCase):
         self.assertAlmostEqual(analyze_dict["camera_clipping_factor"], 0.42678, delta=1e-4)
         self.assertEqual(analyze_dict["camera_saturation_counts"], 49)
         self.assertAlmostEqual(analyze_dict["total_charge_pC"], 671992.75, delta=1e-1)
-        self.assertAlmostEqual(analyze_dict["peak_charge_pc/MeV"], 48442.74, delta=1e-1)
+        self.assertAlmostEqual(analyze_dict["peak_charge_pc/MeV"], 2581184.18, delta=1e-1)
         self.assertAlmostEqual(analyze_dict["peak_charge_energy_MeV"], 89.51816, delta=1e-4)
         self.assertAlmostEqual(analyze_dict["weighted_average_energy_MeV"], 89.53399, delta=1e-4)
         self.assertAlmostEqual(analyze_dict["energy_spread_weighted_rms_MeV"], 0.09497, delta=1e-4)
@@ -80,7 +80,7 @@ class TestHiResMagSpecAnalyze(unittest.TestCase):
         self.assertAlmostEqual(analyze_dict["beam_tilt_um/MeV"], 19.30100, delta=1e-4)
         self.assertAlmostEqual(analyze_dict["beam_tilt_intercept_um"], -1703.46109, delta=1e-4)
         self.assertAlmostEqual(analyze_dict["beam_tilt_intercept_100MeV_um"], 226.63913, delta=1e-4)
-        self.assertAlmostEqual(analyze_dict["optimization_factor"], 0.783622, delta=1e-4)
+        self.assertAlmostEqual(analyze_dict["optimization_factor"], 41.7426, delta=1e-4)
         self.assertAlmostEqual(analyze_dict["fwhm_percent"], 0.2934, delta=1e-2)
 
         # Here I am only checking that the labview wrapper function is working properly by checking the output shapes


### PR DESCRIPTION
Had a wrong calculation for charge density.  Now I am appropriately using the energy axis.  Should work for both HiResMagCam and ACaveMagCam3.