### PR TITLE
Add context manager for HtuExp

### DIFF
--- a/GEECS-PythonAPI/geecs_python_api/controls/experiment/htu.py
+++ b/GEECS-PythonAPI/geecs_python_api/controls/experiment/htu.py
@@ -28,6 +28,13 @@ class HtuExp(Experiment):
 
         self.__initialized = True
 
+    def __enter__(self):
+        return self
+    
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.close()
+        # TODO: do we need to del HtuExp.instance here?
+
     def connect(self, laser: bool = False, jet: bool = False, diagnostics: bool = False, transport: bool = False):
         # Devices
         if isinstance(self.laser, Laser):

--- a/GEECS-PythonAPI/tests/test_geecs_python_api/controls/test_htu_exp.py
+++ b/GEECS-PythonAPI/tests/test_geecs_python_api/controls/test_htu_exp.py
@@ -14,12 +14,9 @@ class HtuExpTestCase(unittest.TestCase):
         self.htu.close()
 
     def test_htu_exp_read_database(self):
-        self.htu = HtuExp(get_info=True)
-
-        self.assertEqual(self.htu.exp_name, "Undulator")
-        self.assertEqual(GeecsDevice.exp_info['name'], "Undulator")
-
-        self.htu.close()
+        with HtuExp(get_info=True) as self.htu:
+            self.assertEqual(self.htu.exp_name, "Undulator")
+            self.assertEqual(GeecsDevice.exp_info['name'], "Undulator")
 
     def tearDown(self):
         # reset singleton


### PR DESCRIPTION
Makes it possible to use HtuExp() in a with clause, which closes the instance at the end. 
