### PR TITLE
Small updates to set up default analysis for UC_UndulatorRad2 and modify save paths for cam analysis

### DIFF
--- a/GEECS-PythonAPI/geecs_python_api/controls/data_acquisition/configs/experiments/Undulator/aux_configs/camera_analysis_settings.yaml
+++ b/GEECS-PythonAPI/geecs_python_api/controls/data_acquisition/configs/experiments/Undulator/aux_configs/camera_analysis_settings.yaml
@@ -210,19 +210,18 @@ UC_VisaEBeam8:
   Blue Centroid X: 222
   Blue Centroid Y: 249
 
-
 UC_UndulatorRad2:
-  Background Level: 15
+  Background Level: 1
   Left ROI: 1
   Top ROI: 1
   Size_X: 2590
   Size_Y: 2040
   Median Filter Size: 5
-  Median Filter Cycles: 1
+  Median Filter Cycles: 0
   Gaussian Filter Size: 3
   Gaussian Filter Cycles: 0
   Threshold: 0
   Rotate: 0
   Calibration: 0.0000075
-  Apply Mask: True  
+  Apply Mask: False
   Plot Scale: 20

--- a/GEECS-PythonAPI/geecs_python_api/controls/data_acquisition/configs/experiments/Undulator/save_devices/visa1_spectrometer_setup.yaml
+++ b/GEECS-PythonAPI/geecs_python_api/controls/data_acquisition/configs/experiments/Undulator/save_devices/visa1_spectrometer_setup.yaml
@@ -1,5 +1,6 @@
 Devices:
   UC_UndulatorRad2:
+    post_analysis_class: CameraImageAnalysis
     save_nonscalar_data: true
     scan_setup:
       Analysis:

--- a/GEECS-PythonAPI/geecs_python_api/controls/data_acquisition/configs/experiments/Undulator/save_devices/visa2_spectrometer_setup.yaml
+++ b/GEECS-PythonAPI/geecs_python_api/controls/data_acquisition/configs/experiments/Undulator/save_devices/visa2_spectrometer_setup.yaml
@@ -1,5 +1,6 @@
 Devices:
   UC_UndulatorRad2:
+    post_analysis_class: CameraImageAnalysis
     save_nonscalar_data: true
     scan_setup:
       Analysis:

--- a/GEECS-PythonAPI/geecs_python_api/controls/data_acquisition/configs/experiments/Undulator/save_devices/visa3_spectrometer_setup.yaml
+++ b/GEECS-PythonAPI/geecs_python_api/controls/data_acquisition/configs/experiments/Undulator/save_devices/visa3_spectrometer_setup.yaml
@@ -1,5 +1,6 @@
 Devices:
   UC_UndulatorRad2:
+    post_analysis_class: CameraImageAnalysis
     save_nonscalar_data: true
     scan_setup:
       Analysis:

--- a/GEECS-PythonAPI/geecs_python_api/controls/data_acquisition/configs/experiments/Undulator/save_devices/visa4_spectrometer_setup.yaml
+++ b/GEECS-PythonAPI/geecs_python_api/controls/data_acquisition/configs/experiments/Undulator/save_devices/visa4_spectrometer_setup.yaml
@@ -1,5 +1,6 @@
 Devices:
   UC_UndulatorRad2:
+    post_analysis_class: CameraImageAnalysis
     save_nonscalar_data: true
     scan_setup:
       Analysis:

--- a/GEECS-PythonAPI/geecs_python_api/controls/data_acquisition/configs/experiments/Undulator/save_devices/visa5_spectrometer_setup.yaml
+++ b/GEECS-PythonAPI/geecs_python_api/controls/data_acquisition/configs/experiments/Undulator/save_devices/visa5_spectrometer_setup.yaml
@@ -1,5 +1,6 @@
 Devices:
   UC_UndulatorRad2:
+    post_analysis_class: CameraImageAnalysis
     save_nonscalar_data: true
     scan_setup:
       Analysis:

--- a/GEECS-PythonAPI/geecs_python_api/controls/data_acquisition/configs/experiments/Undulator/save_devices/visa6_spectrometer_setup.yaml
+++ b/GEECS-PythonAPI/geecs_python_api/controls/data_acquisition/configs/experiments/Undulator/save_devices/visa6_spectrometer_setup.yaml
@@ -1,5 +1,6 @@
 Devices:
   UC_UndulatorRad2:
+    post_analysis_class: CameraImageAnalysis
     save_nonscalar_data: true
     scan_setup:
       Analysis:

--- a/GEECS-PythonAPI/geecs_python_api/controls/data_acquisition/configs/experiments/Undulator/save_devices/visa7_spectrometer_setup.yaml
+++ b/GEECS-PythonAPI/geecs_python_api/controls/data_acquisition/configs/experiments/Undulator/save_devices/visa7_spectrometer_setup.yaml
@@ -1,5 +1,6 @@
 Devices:
   UC_UndulatorRad2:
+    post_analysis_class: CameraImageAnalysis
     save_nonscalar_data: true
     scan_setup:
       Analysis:

--- a/GEECS-PythonAPI/geecs_python_api/controls/data_acquisition/configs/experiments/Undulator/save_devices/visa8_spectrometer_setup.yaml
+++ b/GEECS-PythonAPI/geecs_python_api/controls/data_acquisition/configs/experiments/Undulator/save_devices/visa8_spectrometer_setup.yaml
@@ -1,5 +1,6 @@
 Devices:
   UC_UndulatorRad2:
+    post_analysis_class: CameraImageAnalysis
     save_nonscalar_data: true
     scan_setup:
       Analysis:

--- a/ScanAnalysis/scan_analysis/analyzers/Undulator/CameraImageAnalysis.py
+++ b/ScanAnalysis/scan_analysis/analyzers/Undulator/CameraImageAnalysis.py
@@ -41,10 +41,8 @@ class CameraImageAnalysis(ScanAnalysis):
 
         # organize various paths
         self.path_dict = {'data_img': Path(scan_directory) / f"{device_name}",
-                          'save': scan_directory,
-                          'cam_configs': get_full_config_path(self.experiment_dir,
-                                                             'aux_configs',
-                                                             'camera_analysis_settings.yaml')
+                          'save': scan_directory.parent.parent / 'analysis' / scan_directory.name / f"{device_name}" / "CameraImageAnalysis",
+                          'cam_configs': get_full_config_path(self.experiment_dir, 'aux_configs', 'camera_analysis_settings.yaml')
                           }
 
         # if self.camera_analysis_config_path.exists():
@@ -393,6 +391,10 @@ class CameraImageAnalysis(ScanAnalysis):
         if self.initialize_analysis():
             return
 
+        # if saving, make sure save location exists
+        if flag_save and not self.path_dict['save'].exists():
+            self.path_dict['save'].mkdir(parents=True)
+
         # attempt analysis
         try:
 
@@ -421,10 +423,11 @@ def testing_routine():
 
     # define scan information
     scan = {'year': '2024',
-            'month': 'Oct',
-            'day': '31',
-            'num': 53}
-    device_name = "UC_VisaEBeam1"
+            'month': 'Nov',
+            'day': '19',
+            'num': 15}
+    # device_name = "UC_VisaEBeam1"
+    device_name = "UC_UndulatorRad2"
 
     # initialize data interface and analysis class
     data_interface = DataInterface()

--- a/ScanAnalysis/scan_analysis/analyzers/Undulator/VisaEBeamAnalysis.py
+++ b/ScanAnalysis/scan_analysis/analyzers/Undulator/VisaEBeamAnalysis.py
@@ -26,6 +26,9 @@ class VisaEBeamAnalysis(CameraImageAnalysis):
         super().__init__(scan_directory, device_name, use_gui=use_gui, experiment_dir=experiment_dir,
                          flag_logging=flag_logging, flag_save_images=flag_save_images)
 
+        # reset save path to this analysis folder
+        self.path_dict['save'] = self.path_dict['save'].parent / "VisaEBeamAnalysis"
+
     def create_cross_mask(self, image, cross_center, angle, cross_height=54,
                           cross_width=54, thickness=10):
         """
@@ -138,10 +141,10 @@ def testing_routine():
 
     # define scan information
     scan = {'year': '2024',
-            'month': 'Oct',
-            'day': '31',
-            'num': 53}
-    device_name = "UC_VisaEBeam1"
+            'month': 'Nov',
+            'day': '19',
+            'num': 15}
+    device_name = "UC_VisaEBeam2"
 
     # initialize data interface and analysis class
     data_interface = DataInterface()


### PR DESCRIPTION
Set up default analysis for UC_UndulatorRad2 to be CameraImageAnalysis until a more specific analysis exists. Modified the save paths for CameraImageAnalysis and VisaEBeamAnalysis to point to the analysis folder rather than the scan folder.