### PR TITLE
establish whether or not a geecs device is off or on upon instantiation

### DIFF
--- a/GEECS-PythonAPI/geecs_python_api/controls/devices/geecs_device.py
+++ b/GEECS-PythonAPI/geecs_python_api/controls/devices/geecs_device.py
@@ -121,12 +121,17 @@ class GeecsDevice:
                     if self.dev_tcp is None:
                         try:
                             self.dev_tcp = TcpSubscriber(owner=self)
-                            ###try to connect a TCP subscriber to see if device is on and accessible
-                            is_device_on = self.dev_tcp.connect()
                         except Exception:
                             api_error.error('Failed to connect a TCP subscriber', 'GeecsDevice class, method "__init__"')
+                        
                 else:
                     api_error.warning(f'Device "{self.__dev_name}" not found', 'GeecsDevice class, method "__init__"')
+                
+                if self.dev_tcp:
+                    ###try to connect a TCP subscriber to see if device is on and accessible
+                    is_device_on = self.dev_tcp.connect()
+                else: 
+                    is_device_on = False
                 
                 if not is_device_on:
                     api_error.error(f'Failed establish test connection, {self.__dev_name} likely not on', 'GeecsDevice class, method "init_resources"')

--- a/GEECS-PythonAPI/geecs_python_api/controls/devices/geecs_device.py
+++ b/GEECS-PythonAPI/geecs_python_api/controls/devices/geecs_device.py
@@ -58,7 +58,7 @@ class GeecsDevice:
         self.use_alias_in_TCP_subscription = True
 
         self.setpoints: dict[VarAlias, Any] = {}
-        self.state: dict[VarAlias, Any] = {'fresh': True,"shot number":None,"GEECS device error":False}
+        self.state: dict[VarAlias, Any] = {'fresh': False,"shot number":None,"GEECS device error":False, "Device alive on instantiation":False}
         
         self.generic_vars = ['Device Status', 'device error', 'device preset']
 
@@ -121,10 +121,20 @@ class GeecsDevice:
                     if self.dev_tcp is None:
                         try:
                             self.dev_tcp = TcpSubscriber(owner=self)
+                            ###try to connect a TCP subscriber to see if device is on and accessible
+                            is_device_on = self.dev_tcp.connect()
                         except Exception:
-                            api_error.error('Failed creating TCP subscriber', 'GeecsDevice class, method "__init__"')
+                            api_error.error('Failed to connect a TCP subscriber', 'GeecsDevice class, method "__init__"')
                 else:
                     api_error.warning(f'Device "{self.__dev_name}" not found', 'GeecsDevice class, method "__init__"')
+                
+                if not is_device_on:
+                    api_error.error(f'Failed establish test connection, {self.__dev_name} likely not on', 'GeecsDevice class, method "init_resources"')
+                    self.close()
+                else:
+                    ###close out the test tcp subscriber
+                    self.dev_tcp.close()
+                    self.state["Device alive on instantiation"] = True
         else:
             try:
                 self.close()

--- a/GEECS-PythonAPI/geecs_python_api/controls/interface/tcp_subscriber.py
+++ b/GEECS-PythonAPI/geecs_python_api/controls/interface/tcp_subscriber.py
@@ -47,10 +47,12 @@ class TcpSubscriber:
             self.host = self.owner.dev_ip
             self.port = self.owner.dev_port
             self.connected = True
-
-        except Exception:
-            api_error.error(f'Failed to connect TCP client ({self.owner.get_name()})',
-                            'TcpSubscriber class, method "connect"')
+        
+        except (TimeoutError, InterruptedError) as e:
+            api_error.error(
+                f'Error while connecting TCP client ({self.owner.get_name()}): {e}',
+                'TcpSubscriber class, method "connect"'
+            )
             self.sock = None
             self.host = ''
             self.port = -1


### PR DESCRIPTION
Small improvement. Realized there didn't seem to be a good way to establish whether a device was off/on after instantiation of a GeecsDevice. Just made use of dev_tcp.connect() to see if a connection is possible. If yes, flip a boolean in the state dict, if not, throw an error and close the device. Closing the device prevents inadvertently getting stuck in long timeout loops trying to set/get parameters from a device. 