### PR TITLE
Image analysis return type 05142025

### DIFF
--- a/ImageAnalysis/image_analysis/base.py
+++ b/ImageAnalysis/image_analysis/base.py
@@ -4,7 +4,7 @@ import configparser
 import numpy as np
 from numpy.typing import NDArray
 from pathlib import Path
-from typing import TYPE_CHECKING, Optional, Union, Type, Any
+from typing import TYPE_CHECKING, Optional, Union, Any
 if TYPE_CHECKING:
     from .types import Array2D
 
@@ -70,7 +70,6 @@ class ImageAnalyzer:
         # Subclasses can process config as needed.
         self.config = config
 
-
     def analyze_image(self,
                       image: Array2D,
                       auxiliary_data: Optional[dict] = None
@@ -100,13 +99,16 @@ class ImageAnalyzer:
     def analyze_image_file(self,
                            image_filepath: Path,
                            auxiliary_data: Optional[dict] = None
-                           )-> dict[str, Union[float, int, str, np.ndarray]]:
+                           ) -> dict[str, Union[float, int, str, np.ndarray]]:
         """
         Method to enable the use of a file path rather than Array2D.
 
          Parameters
          ----------
          image_filepath : Path
+         auxiliary_data : dict
+            Additional data used by the image analyzer for this image, such as
+            image range.
 
         Returns
         -------
@@ -119,7 +121,7 @@ class ImageAnalyzer:
 
         return self.analyze_image(image, auxiliary_data)
 
-    def load_image(self, file_path:Path)->Array2D:
+    def load_image(self, file_path: Path) -> Array2D:
         """
         load an image from a path. By default, the read_imaq_png function is used.
         For file types not directly supported by this method, e.g. .himg files from a
@@ -138,7 +140,6 @@ class ImageAnalyzer:
         image = read_imaq_image(file_path)
 
         return image
-
 
     def build_return_dictionary(self, return_image: Optional[NDArray] = None,
                                 return_scalars: Optional[dict[str, Union[int, float]]] = None,
@@ -212,7 +213,6 @@ class ImageAnalyzer:
             "analyzer_return_lineouts": return_lineouts,
         }
         return return_dictionary
-
 
     def build_input_parameter_dictionary(self) -> dict:
         """Compiles list of class variables into a dictionary

--- a/ImageAnalysis/image_analysis/base.py
+++ b/ImageAnalysis/image_analysis/base.py
@@ -170,7 +170,7 @@ class ImageAnalyzer:
                 Dictionary with the correctly formatted returns that labview adapters is expecting.
                 "analyzer_input_parameters": input_parameters
                 "analyzer_return_dictionary": return_scalars
-                "processed_image_uint16": uint_image
+                "processed_image": return_image (with identical type as input argument)
                 "analyzer_return_lineouts": return_lineouts
             """
 

--- a/ImageAnalysis/image_analysis/base.py
+++ b/ImageAnalysis/image_analysis/base.py
@@ -174,11 +174,6 @@ class ImageAnalyzer:
                 "analyzer_return_lineouts": return_lineouts
             """
 
-        if return_image is not None:
-            uint_image = return_image.astype(np.uint16)
-        else:
-            uint_image = None
-
         if return_scalars is None:
             return_scalars = dict()
         elif not isinstance(return_scalars, dict):
@@ -213,7 +208,7 @@ class ImageAnalyzer:
         return_dictionary = {
             "analyzer_input_parameters": input_parameters,
             "analyzer_return_dictionary": return_scalars,
-            "processed_image_uint16": uint_image,
+            "processed_image": return_image,
             "analyzer_return_lineouts": return_lineouts,
         }
         return return_dictionary

--- a/ImageAnalysis/image_analysis/labview_adapters.py
+++ b/ImageAnalysis/image_analysis/labview_adapters.py
@@ -110,7 +110,10 @@ def parse_results_to_labview(return_dictionary, key_list_name):
         - 2D double array
 
     """
-    return_image = return_dictionary['processed_image_uint16']
+    return_image = return_dictionary['processed_image']
+    if return_image is not None:
+        return_image = return_image.astype(np.uint16)
+
     scalar_dict = return_dictionary['analyzer_return_dictionary']
     return_lineouts = return_dictionary['analyzer_return_lineouts']
 

--- a/ImageAnalysis/image_analysis/labview_adapters.py
+++ b/ImageAnalysis/image_analysis/labview_adapters.py
@@ -109,9 +109,18 @@ def parse_results_to_labview(return_dictionary, key_list_name):
         - 1D double array
         - 2D double array
 
+    Raises:
+    --------
+    TypeError:  if the return image cannot be cast as an unsigned uint16 array
+
     """
     return_image = return_dictionary['processed_image']
     if return_image is not None:
+        if np.min(return_image) < 0:
+            raise TypeError("Return image cannot be cast as np.uint16.  Some pixels are < 0")
+        if np.max(return_image) > 2e16-1:
+            raise TypeError("Return image cannot be cast as np.uint16.  Some pixels are > 2e16-1")
+
         return_image = return_image.astype(np.uint16)
 
     scalar_dict = return_dictionary['analyzer_return_dictionary']

--- a/ImageAnalysis/image_analysis/labview_adapters.py
+++ b/ImageAnalysis/image_analysis/labview_adapters.py
@@ -108,19 +108,11 @@ def parse_results_to_labview(return_dictionary, key_list_name):
         - 2D uint16 array
         - 1D double array
         - 2D double array
-
-    Raises:
-    --------
-    TypeError:  if the return image cannot be cast as an unsigned uint16 array
-
     """
+
     return_image = return_dictionary['processed_image']
     if return_image is not None:
-        if np.min(return_image) < 0:
-            raise TypeError("Return image cannot be cast as np.uint16.  Some pixels are < 0")
-        if np.max(return_image) > 2e16-1:
-            raise TypeError("Return image cannot be cast as np.uint16.  Some pixels are > 2e16-1")
-
+        validate_uint16_castable(return_image)
         return_image = return_image.astype(np.uint16)
 
     scalar_dict = return_dictionary['analyzer_return_dictionary']
@@ -131,6 +123,24 @@ def parse_results_to_labview(return_dictionary, key_list_name):
 
     labview_return = (return_image, return_scalars, return_lineouts)
     return labview_return
+
+
+def validate_uint16_castable(array):
+    """
+    Checks if a given array could be converted to an unsigned 16 bit array.  Raises a Type Error if not
+
+    Parameters
+    ----------
+    array:
+        An image that may or may not be formatted to accommodate uint16 conversion
+    """
+    if array is not None:
+        if np.iscomplexobj(array):
+            raise TypeError("Image cannot contain complex values")
+        if not np.isfinite(array).all():
+            raise TypeError("Array contains NaNs or infinite values.")
+        if np.any((array < 0) | (array > np.iinfo(np.uint16).max)):
+            raise TypeError("Array values out of uint16 range")
 
 
 def read_keys_of_interest(key_list_name):

--- a/ScanAnalysis/scan_analysis/analyzers/common/array2D_scan_analysis.py
+++ b/ScanAnalysis/scan_analysis/analyzers/common/array2D_scan_analysis.py
@@ -22,10 +22,10 @@ method of the base ImageAnalysis. This dict looks like this:
         return_dictionary = {
             "analyzer_input_parameters": input_parameters,
             "analyzer_return_dictionary": return_scalars,
-            "processed_image_uint16": uint_image,
+            "processed_image": image of the type in the analyzer's return,
             "analyzer_return_lineouts": return_lineouts,
         }
-The 'processed_image_uint16' item is the on that will be used to generate the visualized data.
+The 'processed_image' item is the on that will be used to generate the visualized data.
 The "analyzer_return_dictionary" contains a dict[str, float] that is used to write scalar
 data to the 'sxxx.txt' file.
 There is a rudimentary way to handle other types of return data using "analyzer_return_lineouts".
@@ -178,11 +178,11 @@ class Array2DScanAnalysis(ScanAnalysis):
             logging.warning(f"Analyzer returned non-dict result for shot {shot_num}.")
             return shot_num, None, {}
 
-        if "processed_image_uint16" not in results_dict:
-            logging.warning(f"Shot {shot_num}: 'processed_image_uint16' key not found in analyzer result.")
+        if "processed_image" not in results_dict:
+            logging.warning(f"Shot {shot_num}: 'processed_image' key not found in analyzer result.")
             image = None
         else:
-            image = results_dict.get("processed_image_uint16")
+            image = results_dict.get("processed_image")
 
         analysis = results_dict.get("analyzer_return_dictionary", {})
         if not isinstance(analysis, dict):
@@ -213,7 +213,7 @@ class Array2DScanAnalysis(ScanAnalysis):
             If no processed image is returned but analysis results are available,
             update the auxiliary data and log the outcome, but do not add to self.data.
             """
-            image = analysis_result.get("processed_image_uint16")
+            image = analysis_result.get("processed_image")
             analysis = analysis_result.get("analyzer_return_dictionary", {})
 
             # Always update auxiliary data if analysis exists.
@@ -287,7 +287,7 @@ class Array2DScanAnalysis(ScanAnalysis):
                     # If using the process pool, result is a tuple: (shot_num, image, analysis).
                     if isinstance(result, tuple):
                         _, image, analysis = result
-                        analysis_result = {"processed_image_uint16": image, "analyzer_return_dictionary": analysis}
+                        analysis_result = {"processed_image": image, "analyzer_return_dictionary": analysis}
                     else:
                         analysis_result = result
                     process_success(shot_num, analysis_result)
@@ -581,8 +581,8 @@ class Array2DScanAnalysis(ScanAnalysis):
             # Use the injected image analyzer
             logging.info(f'attempting to process {file_path}')
             results_dict = self.image_analyzer.analyze_image_file(image_filepath=file_path)
-            # Expecting results_dict to have keys: 'processed_image_uint16' and 'analyzer_return_dictionary'
-            image = results_dict.get("processed_image_uint16")
+            # Expecting results_dict to have keys: 'processed_image' and 'analyzer_return_dictionary'
+            image = results_dict.get("processed_image")
             if image is not None:
                 image = image.astype(np.uint16)
                 self.data['shot_num'].append(shot_num)


### PR DESCRIPTION
Here's the solution to Issue #159 that we discussed.

- `np.uint16` is no longer enforced at the image analyzer level
- It is instead enforced just before returning back to Labview
- A TypeError will be raised if the image contains pixels that are less than 0 or greater than 2e16-1
- The key name has been changed from `processed_image_uint16` to `processed_image`.  Most notably Array2DScanAnalysis had a lot of these instances but there could be more outside of ImageAnalysis and ScanAnalysis packages.