### PR TITLE
feature: new and improved actions (closeout)

### DIFF
--- a/GEECS-Scanner-GUI/scanner_configs/experiments/Undulator/action_library/actions.yaml
+++ b/GEECS-Scanner-GUI/scanner_configs/experiments/Undulator/action_library/actions.yaml
@@ -1,4 +1,36 @@
 actions:
+  Amp4_DUMP_HP:
+    steps:
+    - action: execute
+      action_name: close_gaia_internal_shutters
+    - action: set
+      device: U_148_PLC
+      value: 'off'
+      variable: DO.Ch9
+    - action: wait
+      wait: 3
+    - action: get
+      device: U_148_PLC
+      expected_value: 'off'
+      variable: DI.Ch17
+    - action: execute
+      action_name: open_gaia_internal_shutters
+  Amp4_SEND_HP_TO_TARGET:
+    steps:
+    - action: execute
+      action_name: close_gaia_internal_shutters
+    - action: set
+      device: U_148_PLC
+      value: 'on'
+      variable: DO.Ch9
+    - action: wait
+      wait: 3
+    - action: get
+      device: U_148_PLC
+      expected_value: 'off'
+      variable: DI.Ch18
+    - action: execute
+      action_name: open_gaia_internal_shutters
   close_gaia_internal_shutters:
     steps:
     - action: set
@@ -27,6 +59,26 @@ actions:
       action_name: insert_gaia_stops
     - action: execute
       action_name: open_gaia_internal_shutters
+  experiment_CLOSEOUT:
+    steps:
+    - action: execute
+      action_name: dump_gaia_on_stops
+    - action: execute
+      action_name: Amp4_DUMP_HP
+    - action: execute
+      action_name: zero_steering_magnets
+    - action: execute
+      action_name: zero_visa_magnets
+    - action: execute
+      action_name: zero_emq_magnets
+    - action: execute
+      action_name: zero_pressure_voltage
+    - action: execute
+      action_name: zero_chicane_magnets
+    - action: execute
+      action_name: zero_magspec_currents
+    - action: execute
+      action_name: pmq_REMOVE
   insert_gaia_stops:
     steps:
     - action: set
@@ -38,7 +90,7 @@ actions:
       value: 'on'
       variable: DO.Ch2
     - action: wait
-      wait: 1
+      wait: 3
     - action: get
       device: U_148_PLC
       expected_value: 'on'
@@ -47,14 +99,6 @@ actions:
       device: U_148_PLC
       expected_value: 'on'
       variable: DI.Ch3
-  insert_pmqs:
-    steps:
-    - action: execute
-      action_name: insert_gaia_stops
-    - action: set
-      device: U_Hexapod
-      value: -20
-      variable: ypos
   open_gaia_internal_shutters:
     steps:
     - action: set
@@ -75,6 +119,22 @@ actions:
       device: U_GaiaSVEReader
       expected_value: 1
       variable: InternalShutterB
+  pmq_INSERT:
+    steps:
+    - action: execute
+      action_name: Amp4_DUMP_HP
+    - action: set
+      device: U_Hexapod
+      value: 18.5
+      variable: ypos
+  pmq_REMOVE:
+    steps:
+    - action: execute
+      action_name: Amp4_DUMP_HP
+    - action: set
+      device: U_Hexapod
+      value: -22
+      variable: ypos
   remove_gaia_stops:
     steps:
     - action: set
@@ -95,14 +155,6 @@ actions:
       device: U_148_PLC
       expected_value: 'on'
       variable: DI.Ch4
-  remove_pmqs:
-    steps:
-    - action: execute
-      action_name: insert_gaia_stops
-    - action: set
-      device: U_Hexapod
-      value: -22
-      variable: ypos
   remove_visa_plungers:
     steps:
     - action: set
@@ -145,55 +197,175 @@ actions:
       device: U_PLC
       value: 'off'
       variable: DO.Ch19
-  test_HP_laser_dump_amp4:
+  zero_chicane_magnets:
     steps:
-    - action: execute
-      action_name: close_gaia_internal_shutters
     - action: set
-      device: U_148_PLC
+      device: U_ChicaneInner
+      value: 0
+      variable: Current
+      wait_for_execution: true
+    - action: set
+      device: U_ChicaneInner
+      value: 0
+      variable: Current
+      wait_for_execution: true
+    - action: set
+      device: U_ChicaneOuter
       value: 'off'
-      variable: DO.Ch9
-    - action: wait
-      wait: 3
-    - action: get
-      device: U_148_PLC
-      expected_value: 'off'
-      variable: DI.Ch17
-    - action: execute
-      action_name: open_gaia_internal_shutters
-  test_send_HP_beam_past_AMP4_dump:
-    steps:
-    - action: execute
-      action_name: close_gaia_internal_shutters
+      variable: Enable_Output
+      wait_for_execution: true
     - action: set
-      device: U_148_PLC
-      value: 'on'
-      variable: DO.Ch9
-    - action: wait
-      wait: 3
-    - action: get
-      device: U_148_PLC
-      expected_value: 'off'
-      variable: DI.Ch18
-    - action: execute
-      action_name: open_gaia_internal_shutters
-  visa1_energy:
+      device: U_ChicaneInner
+      value: 'off'
+      variable: Enable_Output
+      wait_for_execution: true
+  zero_emq_magnets:
     steps:
     - action: set
-      device: U_GaiaSVEReader
-      value: 1
-      variable: InternalShutterA
+      device: U_EMQTripletBipolar
+      value: 0
+      variable: Current_Limit.Ch1
+      wait_for_execution: true
     - action: set
-      device: U_GaiaSVEReader
-      value: 1
-      variable: InternalShutterB
-    - action: wait
-      wait: 2
-    - action: get
-      device: U_GaiaSVEReader
-      expected_value: 1
-      variable: InternalShutterA
-    - action: get
-      device: U_GaiaSVEReader
-      expected_value: 1
-      variable: InternalShutterB
+      device: U_EMQTripletBipolar
+      value: 0
+      variable: Current_Limit.Ch2
+      wait_for_execution: true
+    - action: set
+      device: U_EMQTripletBipolar
+      value: 0
+      variable: Current_Limit.Ch3
+      wait_for_execution: true
+    - action: set
+      device: U_EMQTripletBipolar
+      value: 'off'
+      variable: Enable_Output.Ch1
+      wait_for_execution: true
+    - action: set
+      device: U_EMQTripletBipolar
+      value: 'off'
+      variable: Enable_Output.Ch2
+      wait_for_execution: true
+    - action: set
+      device: U_EMQTripletBipolar
+      value: 'off'
+      variable: Enable_Output.Ch3
+      wait_for_execution: true
+  zero_magspec_currents:
+    steps:
+    - action: set
+      device: U_EMQTripletBipolar
+      value: 0
+      variable: Current_Limit.Ch4
+      wait_for_execution: true
+    - action: set
+      device: U_ACaveMagSpecPS
+      value: 0
+      variable: Current
+      wait_for_execution: true
+    - action: set
+      device: U_BCaveMagSpecPS
+      value: 0
+      variable: Current_Limit.Ch1
+      wait_for_execution: true
+  zero_pressure_voltage:
+    steps:
+    - action: set
+      device: U_HP_Daq
+      value: 0
+      variable: AnalogOutput.Channel 1
+      wait_for_execution: true
+  zero_steering_magnets:
+    steps:
+    - action: set
+      device: U_S1H
+      value: 0
+      variable: Current
+      wait_for_execution: true
+    - action: set
+      device: U_S1V
+      value: 0
+      variable: Current
+      wait_for_execution: true
+    - action: set
+      device: U_S2H
+      value: 0
+      variable: Current
+      wait_for_execution: true
+    - action: set
+      device: U_S2V
+      value: 0
+      variable: Current
+      wait_for_execution: true
+    - action: set
+      device: U_S3H
+      value: 0
+      variable: Current
+      wait_for_execution: true
+    - action: set
+      device: U_S3V
+      value: 0
+      variable: Current
+      wait_for_execution: true
+    - action: set
+      device: U_S4H
+      value: 0
+      variable: Current
+      wait_for_execution: true
+    - action: set
+      device: U_S4V
+      value: 0
+      variable: Current
+      wait_for_execution: true
+  zero_visa_magnets:
+    steps:
+    - action: set
+      device: U_VS1H
+      value: 0
+      variable: Current
+      wait_for_execution: true
+    - action: set
+      device: U_VS1V
+      value: 0
+      variable: Current
+      wait_for_execution: true
+    - action: set
+      device: U_VS2H
+      value: 0
+      variable: Current
+      wait_for_execution: true
+    - action: set
+      device: U_VS2V
+      value: 0
+      variable: Current
+      wait_for_execution: true
+    - action: set
+      device: U_VS3H
+      value: 0
+      variable: Current
+      wait_for_execution: true
+    - action: set
+      device: U_VS3V
+      value: 0
+      variable: Current
+      wait_for_execution: true
+    - action: set
+      device: U_VS4H
+      value: 0
+      variable: Current
+      wait_for_execution: true
+    - action: set
+      device: U_VS4V
+      value: 0
+      variable: Current
+      wait_for_execution: true
+    - action: set
+      device: U_VS5H
+      value: 0
+      variable: Current
+      wait_for_execution: true
+    - action: set
+      device: U_VS5V
+      value: 0
+      variable: Current
+      wait_for_execution: true

--- a/GEECS-Scanner-GUI/scanner_configs/experiments/Undulator/action_library/assigned_actions.yaml
+++ b/GEECS-Scanner-GUI/scanner_configs/experiments/Undulator/action_library/assigned_actions.yaml
@@ -1,5 +1,6 @@
 assigned_actions:
-- name: test_HP_laser_dump_amp4
-- name: test_send_HP_beam_past_AMP4_dump
+- name: Amp4_DUMP_HP
+- name: Amp4_SEND_HP_TO_TARGET
 - element_filename: visa9_spectrometer_setup.yaml
   name: setup_action
+- name: experiment_CLOSEOUT


### PR DESCRIPTION
Renamed some actions so that they are more clear (ie: they don't say "test" anymore).  Additionally, added actions to assist with end-of-day closing operations (block the laser, zero all the magnets, remove the pmq, etc.)

Two questions:
- Is it worth "disabling" the magnets in addition to zeroing out their currents?
- Right now I just reuse the existing macros for dumping the laser on amp4, dumping the gaia on the stops, and removing the pmq triplet.  All of these macros individually call the macro that toggles the gaia internal shutters, when in reality we really only need to do this once.  This might be annoying since these internal shutters will commonly not toggle when asked to, so it may be worthwhile to replace these macros with a closeout-specific macro that just turns off the gaia internal shutters and never turns it back on.

Feel free to merge this into master if it looks good.