### PR TITLE
Update pre-commit hook args for no-commit-to-branch

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,6 +9,8 @@ repos:
     rev: v5.0.0
     hooks:
       - id: no-commit-to-branch
+        args: [--branch, main, --branch, master]
+        stages: [commit]
       - id: trailing-whitespace
       - id: end-of-file-fixer
         exclude: "(^extras/|.*/third_party_sdks/)"


### PR DESCRIPTION
Configured the no-commit-to-branch hook to block commits to both 'main' and 'master' branches and specified it to run at the commit stage.