### PR TITLE
Add suffix option to flatten_beam_stats and BeamAnalyzer

### DIFF
--- a/ImageAnalysis/image_analysis/algorithms/basic_beam_stats.py
+++ b/ImageAnalysis/image_analysis/algorithms/basic_beam_stats.py
@@ -265,7 +265,9 @@ def beam_profile_stats(img: np.ndarray) -> BeamStats:
 
 
 def flatten_beam_stats(
-    stats: BeamStats, prefix: Optional[Union[str, None]] = None
+    stats: BeamStats,
+    prefix: Optional[Union[str, None]] = None,
+    suffix: Optional[Union[str, None]] = None,
 ) -> dict[str, float]:
     """Flatten a :class:`BeamStats` instance into a dictionary.
 
@@ -275,18 +277,26 @@ def flatten_beam_stats(
         The beam statistics to flatten.
     prefix : str, None
         Optional prefix to prepend to each key.
+    suffix : str, None
+        Optional suffix to append to each key (underscore is auto-prepended).
+        Useful for distinguishing multiple analysis variations (e.g., "curtis"
+        becomes "_curtis" in the key).
 
     Returns
     -------
     dict[str, float]
         Dictionary mapping field names to values. Keys are of the form
-        ``"{prefix}_{section}_{field}"`` when ``prefix`` is provided,
-        otherwise ``"{section}_{field}"``.
+        ``"{prefix}_{section}_{field}{suffix}"`` when both are provided,
+        ``"{prefix}_{section}_{field}"`` when only prefix is provided,
+        ``"{section}_{field}{suffix}"`` when only suffix is provided,
+        or ``"{section}_{field}"`` when neither is provided.
     """
     flat: dict[str, float] = {}
+    suffix_str = f"_{suffix}" if suffix else ""
     for field in stats._fields:
         nested = getattr(stats, field)
         for k, v in nested._asdict().items():
             key = f"{prefix}_{field}_{k}" if prefix else f"{field}_{k}"
+            key = f"{key}{suffix_str}"
             flat[key] = v
     return flat

--- a/ImageAnalysis/image_analysis/offline_analyzers/beam_analyzer.py
+++ b/ImageAnalysis/image_analysis/offline_analyzers/beam_analyzer.py
@@ -130,6 +130,7 @@ class BeamAnalyzer(StandardAnalyzer):
         self,
         camera_config_name: str,
         name_suffix: Optional[str] = None,
+        metric_suffix: Optional[str] = None,
     ):
         """Initialize the beam analyzer with external configuration.
 
@@ -142,9 +143,17 @@ class BeamAnalyzer(StandardAnalyzer):
             Useful for distinguishing multiple analysis passes on the same camera.
             For example, use "_variation" to distinguish variation analysis results
             from standard analysis results.
+        metric_suffix : str, optional
+            Suffix to append to all metric names (underscore is auto-prepended).
+            For example, "curtis" becomes "_curtis" in the output keys.
+            Useful for tracking different analysis variations while keeping the
+            same camera name. (e.g., "camera_x_rms_curtis").
         """
         # Initialize parent class
         super().__init__(camera_config_name)
+
+        # Store metric suffix for use in analyze_image
+        self.metric_suffix = metric_suffix
 
         # Apply name suffix if provided
         if name_suffix:
@@ -182,6 +191,7 @@ class BeamAnalyzer(StandardAnalyzer):
         beam_stats_flat = flatten_beam_stats(
             beam_profile_stats(processed_image),
             prefix=self.camera_config.name,
+            suffix=self.metric_suffix,
         )
 
         # Build result with beam-specific data


### PR DESCRIPTION
# Add `metric_suffix` parameter to `BeamAnalyzer` for custom metric naming

## Changes Made

1. __`basic_beam_stats.py`__: Added `suffix` parameter to `flatten_beam_stats()` with auto-prepended underscore
2. __`BeamAnalyzer`__: Added `metric_suffix` parameter to `__init__()` and passed it to `flatten_beam_stats()` in `analyze_image()`

## Usage in config for ScanAnalysis

### In YAML config (via kwargs):

```yaml
analyzers:
  - type: array2d
    device_name: UC_ALineEBeam3
    image_analyzer:
      analyzer_class: image_analysis.offline_analyzers.beam_analyzer.BeamAnalyzer
      camera_config_name: UC_ALineEBeam3
      kwargs:
        metric_suffix: "curtis"  # No underscore needed - it's auto-prepended
```

### Direct Python usage:

```python
from image_analysis.offline_analyzers.beam_analyzer import BeamAnalyzer

analyzer = BeamAnalyzer(
    camera_config_name="UC_ALineEBeam3",
    metric_suffix="curtis"  # Will become "_curtis" automatically
)
result = analyzer.analyze_image(image)
# result.scalars will contain keys like:
# - UC_ALineEBeam3_x_rms_curtis
# - UC_ALineEBeam3_y_fwhm_curtis
# - UC_ALineEBeam3_image_total_curtis
```
