### PR TITLE
Increase float precision in set command formatting

### DIFF
--- a/GEECS-PythonAPI/geecs_python_api/controls/devices/geecs_device.py
+++ b/GEECS-PythonAPI/geecs_python_api/controls/devices/geecs_device.py
@@ -418,8 +418,8 @@ class GeecsDevice:
             cmd_str = f"set{variable}>>{value}"
             cmd_label = f"set({variable}, {value})"
         elif isinstance(value, float):
-            cmd_str = f"set{variable}>>{value:.6f}"
-            cmd_label = f"set({variable}, {value:.6f})"
+            cmd_str = f"set{variable}>>{value:.12f}"
+            cmd_label = f"set({variable}, {value:.12f})"
         elif isinstance(value, bool):
             cmd_str = f"set{variable}>>{int(value)}"
             cmd_label = f"set({variable}, {value})"


### PR DESCRIPTION
Updated float formatting in set command strings from 6 to 12 decimal places to improve precision when setting device variables.