### PR TITLE
Debug file moving for async devices

### DIFF
--- a/GEECS-Scanner-GUI/geecs_scanner/data_acquisition/data_logger.py
+++ b/GEECS-Scanner-GUI/geecs_scanner/data_acquisition/data_logger.py
@@ -1329,6 +1329,11 @@ class DataLogger:
                         self.virtual_variable_value
                     )
 
+                # Increment shot index and update logging context before processing devices
+                # This ensures both sync and async devices use the same shot number
+                self.shot_index += 1
+                update_context({"shot_id": str(self.shot_index)})
+
                 # Update with async observable values
                 self._update_async_observables(
                     self.device_manager.async_observables, elapsed_time
@@ -1341,9 +1346,6 @@ class DataLogger:
 
                 # Trigger the beep in the background
                 self.sound_player.play_beep()  # Play the beep sound
-                self.shot_index += 1
-                # Stamp the current shot number into the logging context
-                update_context({"shot_id": str(self.shot_index)})
 
             self.log_entries[elapsed_time].update(
                 {


### PR DESCRIPTION
devices that were saving non scalar data but not 'synchronous' were not properly moving files. Now, FIleMove tasks get created for async devices. 

Tested/verified on HTU january 30, 2026, scan 3 for example