### PR TITLE
Allow extra fields & arbitrary types in models for image analysis

### DIFF
--- a/ImageAnalysis/image_analysis/processing/array1d/config_models.py
+++ b/ImageAnalysis/image_analysis/processing/array1d/config_models.py
@@ -16,7 +16,7 @@ from pathlib import Path
 from typing import Optional, List
 
 import numpy as np
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field, field_validator, ConfigDict
 
 
 class Data1DType(str, Enum):
@@ -362,6 +362,11 @@ class Line1DConfig(BaseModel):
     pipeline : PipelineConfig, optional
         Pipeline orchestration configuration
     """
+
+    model_config = ConfigDict(
+        extra="allow",
+        arbitrary_types_allowed=True,
+    )
 
     name: str = Field(..., description="Configuration name/identifier")
     description: str = Field(

--- a/ImageAnalysis/image_analysis/processing/array2d/config_models.py
+++ b/ImageAnalysis/image_analysis/processing/array2d/config_models.py
@@ -6,7 +6,7 @@ including background computation, masking, filtering, and geometric transforms.
 All models use Pydantic for validation and automatic YAML/JSON serialization.
 """
 
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field, field_validator, ConfigDict
 from typing import Optional, Tuple, List, Union, Dict
 from pathlib import Path
 from enum import Enum
@@ -460,6 +460,11 @@ class CameraConfig(BaseModel):
     transforms : Optional[TransformConfig]
         Geometric transformation configuration.
     """
+
+    model_config = ConfigDict(
+        extra="allow",
+        arbitrary_types_allowed=True,
+    )
 
     name: str = Field(..., description="Camera identifier/name")
     description: Optional[str] = Field(None, description="Camera description")


### PR DESCRIPTION
allowing arbitrary types allows greater flexibility in building derived classes of the standard analyzers and allowing control of these attributes through the config file.