### PR TITLE
Improve device synchronization

### DIFF
--- a/GEECS-Scanner-GUI/geecs_scanner/data_acquisition/scan_manager.py
+++ b/GEECS-Scanner-GUI/geecs_scanner/data_acquisition/scan_manager.py
@@ -654,7 +654,7 @@ class ScanManager:
 
         # Original timeout-based synchronization method
         logger.info("Using timeout-based synchronization method")
-        timeout = 25.5  # seconds
+        timeout = 15.5  # seconds
         start_time = time.time()
         while not self.data_logger.devices_synchronized:
             if time.time() - start_time > timeout:


### PR DESCRIPTION
small bug fix: during the 'non global time synchronization', the stop_scan() method was erroneously being called. Now, we raise a custom error when the synch fails and cleanly exit the scan. This should prevent hard crashes when devices fail to synch