### PR TITLE
Fix heartbeat race condition causing duplicate gdoc uploads

### DIFF
--- a/ScanAnalysis/scan_analysis/task_queue.py
+++ b/ScanAnalysis/scan_analysis/task_queue.py
@@ -384,6 +384,10 @@ def run_worklist(
                 raw = analyzer.run_analysis(tag)
                 if raw:
                     display_files = [str(p) for p in raw]
+            # Stop heartbeat before writing final status to prevent a race where
+            # the heartbeat thread overwrites state="done" back to state="claimed".
+            stop_event.set()
+            hb_thread.join(timeout=HEARTBEAT_INTERVAL_SECONDS)
             update_status(
                 scan_folder,
                 analyzer_id,
@@ -420,6 +424,8 @@ def run_worklist(
                     )
         except Exception as exc:  # pragma: no cover - log failure and continue
             logger.exception("Analyzer %s failed on %s: %s", analyzer_id, tag, exc)
+            stop_event.set()
+            hb_thread.join(timeout=HEARTBEAT_INTERVAL_SECONDS)
             update_status(
                 scan_folder,
                 analyzer_id,
@@ -431,8 +437,8 @@ def run_worklist(
                 last_heartbeat=None,
             )
         finally:
-            stop_event.set()
-            hb_thread.join(timeout=HEARTBEAT_INTERVAL_SECONDS)
+            stop_event.set()  # idempotent safety net
+            hb_thread.join(timeout=HEARTBEAT_INTERVAL_SECONDS)  # safe to join twice
             analyzer.cleanup()
 
 


### PR DESCRIPTION
## Summary

- The heartbeat thread writes `state="claimed"` every 30 s and was only stopped in `finally`, after `update_status(state="done")` in `try`
- If the heartbeat fired between the `"done"` write and `stop_event.set()`, it would overwrite the status back to `"claimed"`
- On the next `process_new()` poll the task appeared stale-claimed and was re-run, triggering a duplicate gdoc upload

## Fix

In `run_worklist()` (`task_queue.py`):
- Call `stop_event.set()` + `hb_thread.join()` immediately **before** `update_status(state="done")` in the success path
- Same in the `except` block before `update_status(state="failed")`
- Both calls are kept in `finally` as idempotent safety nets (safe to call `set()` twice / join an already-joined thread)

## Test plan

- [ ] Run a live analysis session and confirm no duplicate gdoc links appear for the last analyzed diagnostic
- [ ] Confirm analyzers still complete and status files correctly show `state: done` after each run

🤖 Generated with [Claude Code](https://claude.com/claude-code)