### PR TITLE
Scanner gui crashes 04 09 2026

### DIFF
--- a/GEECS-Scanner-GUI/geecs_scanner/app/action_library.py
+++ b/GEECS-Scanner-GUI/geecs_scanner/app/action_library.py
@@ -389,16 +389,19 @@ class ActionLibrary(QWidget):
         )
         if reply == QMessageBox.Yes:
             # Read current version of file and delete only the specified element if it exists
-            actions_data_actual = read_yaml_file_to_dict(self.actions_file)
+            if self.actions_file.exists():
+                actions_data_actual = read_yaml_file_to_dict(self.actions_file)
 
-            if name in actions_data_actual["actions"]:
-                del actions_data_actual["actions"][name]
-                write_dict_to_yaml_file(
-                    filename=self.actions_file, dictionary=actions_data_actual
-                )
-                logger.info("Removed action '%s' from '%s'", name, self.actions_file)
-            else:
-                logger.info("Removed action '%s' from unsaved dictionary", name)
+                if name in actions_data_actual["actions"]:
+                    del actions_data_actual["actions"][name]
+                    write_dict_to_yaml_file(
+                        filename=self.actions_file, dictionary=actions_data_actual
+                    )
+                    logger.info(
+                        "Removed action '%s' from '%s'", name, self.actions_file
+                    )
+                else:
+                    logger.info("Removed action '%s' from unsaved dictionary", name)
 
             # Also delete from the GUI's version (leaving other changes unsaved)
             del self.actions_data["actions"][name]

--- a/GEECS-Scanner-GUI/geecs_scanner/app/geecs_scanner.py
+++ b/GEECS-Scanner-GUI/geecs_scanner/app/geecs_scanner.py
@@ -394,7 +394,7 @@ class GEECSScannerWindow(QMainWindow):
             and self.ui.experimentDisplay.isEnabled()
         ):
             experiment_names = [
-                f.stem for f in AppPaths.BASE_PATH.iterdir() if f.is_dir()
+                f.stem for f in AppPaths.base_path().iterdir() if f.is_dir()
             ]
             display_completer_list(self, self.ui.experimentDisplay, experiment_names)
             return True


### PR DESCRIPTION
Fixed two Scanner GUI crashes, referenced in issues #224 and #307

- Crash when selecting experiment tab:  this was a quick fix, as at some point the `BASE_PATH` of the ApplicationPaths class was changed from a variable to a function called `base_path()`.  Just needed to switch to the correct reference.
- Crash when deleting action in action library:  this one only occurred in "fresh" action libraries with no previous actions.  Basically, the file that saves actions for the experiment does not exist yet, and so deleting from this file results in a FileNotFoundError.  I put a quick existence check before reading this file.


closes #224 and #307