### PR TITLE
Fix UDP exe timeout: surface errors, drain stale buffer, user dialog on failure

### DIFF
--- a/GEECS-PythonAPI/geecs_python_api/controls/devices/geecs_device.py
+++ b/GEECS-PythonAPI/geecs_python_api/controls/devices/geecs_device.py
@@ -386,7 +386,7 @@ class GeecsDevice:
         self,
         variable: str,
         value: Any,
-        exec_timeout: Optional[float] = 120.0,
+        exec_timeout: Optional[float] = 30.0,
         attempts_max: int = 5,
         sync: bool = True,
     ) -> Any:
@@ -440,7 +440,7 @@ class GeecsDevice:
         self._cleanup_threads()
 
         if sync:
-            self.wait_for_all_cmds(timeout=120.0)
+            self.wait_for_all_cmds(timeout=exec_timeout or 30.0)
             with GeecsDevice.threads_lock:
                 self._process_command(
                     cmd_str,
@@ -449,9 +449,19 @@ class GeecsDevice:
                     attempts_max=attempts_max,
                 )
                 assert self.dev_udp is not None
-                self.dev_udp.cmd_checker.wait_for_exe(
-                    cmd_tag=cmd_label, timeout=exec_timeout, sync=sync
+                exe_response = self.dev_udp.cmd_checker.listen(
+                    cmd_tag=cmd_label, timeout=exec_timeout
                 )
+                if not exe_response:
+                    from geecs_python_api.controls.interface.geecs_errors import (
+                        GeecsDeviceExeTimeout,
+                    )
+
+                    raise GeecsDeviceExeTimeout(
+                        device_name=self.get_name(),
+                        command=cmd_str,
+                        timeout=exec_timeout or 0.0,
+                    )
         elif exec_timeout and exec_timeout > 0:
             with GeecsDevice.threads_lock:
                 assert self.dev_udp is not None
@@ -685,7 +695,7 @@ class GeecsDevice:
                     ipv4=(self.dev_ip, self.dev_port), msg=cmd_str
                 )
                 if sent:
-                    accepted = self.dev_udp.ack_cmd(timeout=5.0)
+                    accepted = self.dev_udp.ack_cmd(timeout=1.5)
                 else:
                     time.sleep(0.1)
                     continue

--- a/GEECS-PythonAPI/geecs_python_api/controls/devices/geecs_device.py
+++ b/GEECS-PythonAPI/geecs_python_api/controls/devices/geecs_device.py
@@ -449,6 +449,9 @@ class GeecsDevice:
                     attempts_max=attempts_max,
                 )
                 assert self.dev_udp is not None
+                # Drain any stale response from a previous timed-out command
+                # before listening for this command's exe response.
+                self.dev_udp.cmd_checker.drain()
                 exe_response = self.dev_udp.cmd_checker.listen(
                     cmd_tag=cmd_label, timeout=exec_timeout
                 )

--- a/GEECS-PythonAPI/geecs_python_api/controls/devices/geecs_device.py
+++ b/GEECS-PythonAPI/geecs_python_api/controls/devices/geecs_device.py
@@ -386,7 +386,7 @@ class GeecsDevice:
         self,
         variable: str,
         value: Any,
-        exec_timeout: Optional[float] = 30.0,
+        exec_timeout: Optional[float] = 10.0,
         attempts_max: int = 5,
         sync: bool = True,
     ) -> Any:
@@ -440,7 +440,7 @@ class GeecsDevice:
         self._cleanup_threads()
 
         if sync:
-            self.wait_for_all_cmds(timeout=exec_timeout or 30.0)
+            self.wait_for_all_cmds(timeout=exec_timeout or 10.0)
             with GeecsDevice.threads_lock:
                 self._process_command(
                     cmd_str,

--- a/GEECS-PythonAPI/geecs_python_api/controls/interface/geecs_errors.py
+++ b/GEECS-PythonAPI/geecs_python_api/controls/interface/geecs_errors.py
@@ -37,6 +37,30 @@ class GeecsDeviceCommandRejected(Exception):
         )
 
 
+class GeecsDeviceExeTimeout(Exception):
+    """Raised when a device accepts a command but no execution response arrives within timeout.
+
+    This is a communication-layer failure - the command was ACK'd but the device
+    never sent back an execution confirmation on the exe port.
+    Could indicate:
+    - Network packet loss on the exe response
+    - Device hung mid-execution
+    - UDP pipeline failure
+
+    This happens in _execute() when listen() returns empty after exec_timeout seconds.
+    See issue #312 for the planned GUI thread refactor.
+    """
+
+    def __init__(self, device_name: str, command: str, timeout: float):
+        self.device_name = device_name
+        self.command = command
+        self.timeout = timeout
+        super().__init__(
+            f"Device '{device_name}' command '{command}' timed out after {timeout:.1f}s "
+            f"waiting for execution response"
+        )
+
+
 class GeecsDeviceCommandFailed(Exception):
     """Raised when a device accepts a command but fails to execute it.
 

--- a/GEECS-PythonAPI/geecs_python_api/controls/interface/udp_handler.py
+++ b/GEECS-PythonAPI/geecs_python_api/controls/interface/udp_handler.py
@@ -84,7 +84,7 @@ class UdpHandler:
             return False
 
     def ack_cmd(
-        self, sock: Optional[socket.socket] = None, timeout: Optional[float] = 5.0
+        self, sock: Optional[socket.socket] = None, timeout: Optional[float] = 1.5
     ) -> bool:
         """Wait for an ack ('accepted' or 'ok') on `sock` (defaults to cmd socket) within timeout."""
         accepted = False

--- a/GEECS-PythonAPI/geecs_python_api/controls/interface/udp_handler.py
+++ b/GEECS-PythonAPI/geecs_python_api/controls/interface/udp_handler.py
@@ -270,6 +270,24 @@ class UdpServer:
             logger.exception("failed waiting for command execution")
         return exe_thread, stop_event
 
+    def drain(self) -> None:
+        """Discard any data already sitting in the socket receive buffer.
+
+        Call this before starting a fresh listen() to ensure stale responses
+        from a previous timed-out command do not pollute the next read.
+        """
+        if not self.sock:
+            return
+        try:
+            while True:
+                rlist, _, _ = select.select([self.sock], [], [], 0.0)
+                if not rlist:
+                    break
+                self.sock.recvfrom(self.buffer_size)
+                logger.debug("drain: discarded stale exe response")
+        except Exception:
+            logger.debug("drain: ignored error while draining socket", exc_info=True)
+
     def create_thread(self, cmd_tag: str, timeout: Optional[float] = 5.0) -> ThreadInfo:
         """Create a listening thread and its stop_event for the given tag/timeout."""
         stop_event = Event()

--- a/GEECS-Scanner-GUI/geecs_scanner/data_acquisition/action_manager.py
+++ b/GEECS-Scanner-GUI/geecs_scanner/data_acquisition/action_manager.py
@@ -76,55 +76,6 @@ from geecs_scanner.data_acquisition.schemas.actions import (
 logger = logging.getLogger(__name__)
 
 
-def prompt_user_device_timeout(device_name: str, command: str, timeout: float) -> bool:
-    """Show a warning dialog when a device exe response times out after all retries.
-
-    Blocks the calling (scan worker) thread until the user responds.
-
-    Parameters
-    ----------
-    device_name : str
-        Name of the device that timed out.
-    command : str
-        The command string that was sent (e.g. ``'setTrigger>>SCAN'``).
-    timeout : float
-        The timeout that elapsed, in seconds.
-
-    Returns
-    -------
-    bool
-        ``True`` if the user chose to abort the scan, ``False`` to continue.
-
-    Notes
-    -----
-    This dialog is shown from the scan worker thread, which is technically
-    unsafe for Qt GUI operations. See issue #312 for the planned refactor
-    to emit a signal and show the dialog on the main GUI thread.
-    """
-    import sys
-
-    from PyQt5.QtWidgets import QApplication, QMessageBox
-
-    if not QApplication.instance():
-        QApplication(sys.argv)
-
-    msg_box = QMessageBox()
-    msg_box.setIcon(QMessageBox.Warning)
-    msg_box.setWindowTitle("Device Timeout")
-    msg_box.setText(
-        f"Device '{device_name}' did not respond to command:\n"
-        f"    {command}\n\n"
-        f"No execution response received within {timeout:.1f}s.\n\n"
-        f"Please fix the hardware manually, then choose Continue to proceed "
-        f"with the scan or Abort to stop it."
-    )
-    msg_box.setStandardButtons(QMessageBox.Ok | QMessageBox.Abort)
-    msg_box.button(QMessageBox.Ok).setText("Continue")
-    msg_box.setDefaultButton(QMessageBox.Abort)
-    response = msg_box.exec_()
-    return response == QMessageBox.Abort
-
-
 class ActionManager:
     """Manage and execute complex device actions with nested action support.
 

--- a/GEECS-Scanner-GUI/geecs_scanner/data_acquisition/action_manager.py
+++ b/GEECS-Scanner-GUI/geecs_scanner/data_acquisition/action_manager.py
@@ -76,6 +76,55 @@ from geecs_scanner.data_acquisition.schemas.actions import (
 logger = logging.getLogger(__name__)
 
 
+def prompt_user_device_timeout(device_name: str, command: str, timeout: float) -> bool:
+    """Show a warning dialog when a device exe response times out after all retries.
+
+    Blocks the calling (scan worker) thread until the user responds.
+
+    Parameters
+    ----------
+    device_name : str
+        Name of the device that timed out.
+    command : str
+        The command string that was sent (e.g. ``'setTrigger>>SCAN'``).
+    timeout : float
+        The timeout that elapsed, in seconds.
+
+    Returns
+    -------
+    bool
+        ``True`` if the user chose to abort the scan, ``False`` to continue.
+
+    Notes
+    -----
+    This dialog is shown from the scan worker thread, which is technically
+    unsafe for Qt GUI operations. See issue #312 for the planned refactor
+    to emit a signal and show the dialog on the main GUI thread.
+    """
+    import sys
+
+    from PyQt5.QtWidgets import QApplication, QMessageBox
+
+    if not QApplication.instance():
+        QApplication(sys.argv)
+
+    msg_box = QMessageBox()
+    msg_box.setIcon(QMessageBox.Warning)
+    msg_box.setWindowTitle("Device Timeout")
+    msg_box.setText(
+        f"Device '{device_name}' did not respond to command:\n"
+        f"    {command}\n\n"
+        f"No execution response received within {timeout:.1f}s.\n\n"
+        f"Please fix the hardware manually, then choose Continue to proceed "
+        f"with the scan or Abort to stop it."
+    )
+    msg_box.setStandardButtons(QMessageBox.Ok | QMessageBox.Abort)
+    msg_box.button(QMessageBox.Ok).setText("Continue")
+    msg_box.setDefaultButton(QMessageBox.Abort)
+    response = msg_box.exec_()
+    return response == QMessageBox.Abort
+
+
 class ActionManager:
     """Manage and execute complex device actions with nested action support.
 

--- a/GEECS-Scanner-GUI/geecs_scanner/data_acquisition/gui_dialogs.py
+++ b/GEECS-Scanner-GUI/geecs_scanner/data_acquisition/gui_dialogs.py
@@ -1,0 +1,60 @@
+"""GUI dialog helpers for scan data-acquisition error handling.
+
+These dialogs are currently shown from the scan worker thread, which is
+technically unsafe for Qt GUI operations.  See issue #312 for the planned
+refactor to emit signals and show dialogs on the main GUI thread instead.
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+
+logger = logging.getLogger(__name__)
+
+
+def prompt_user_device_timeout(device_name: str, command: str, timeout: float) -> bool:
+    """Show a warning dialog when a device exe response times out after all retries.
+
+    Blocks the calling (scan worker) thread until the user responds.
+
+    Parameters
+    ----------
+    device_name : str
+        Name of the device that timed out.
+    command : str
+        The command string that was sent (e.g. ``'setTrigger>>SCAN'``).
+    timeout : float
+        The timeout that elapsed, in seconds.
+
+    Returns
+    -------
+    bool
+        ``True`` if the user chose to abort the scan, ``False`` to continue.
+
+    Notes
+    -----
+    See issue #312 — this dialog is shown from the scan worker thread, which
+    is technically unsafe.  It will be moved to the main GUI thread via signals
+    in a future refactor.
+    """
+    from PyQt5.QtWidgets import QApplication, QMessageBox
+
+    if not QApplication.instance():
+        QApplication(sys.argv)
+
+    msg_box = QMessageBox()
+    msg_box.setIcon(QMessageBox.Warning)
+    msg_box.setWindowTitle("Device Timeout")
+    msg_box.setText(
+        f"Device '{device_name}' did not respond to command:\n"
+        f"    {command}\n\n"
+        f"No execution response received within {timeout:.1f}s.\n\n"
+        f"Please fix the hardware manually, then choose Continue to proceed "
+        f"with the scan or Abort to stop it."
+    )
+    msg_box.setStandardButtons(QMessageBox.Ok | QMessageBox.Abort)
+    msg_box.button(QMessageBox.Ok).setText("Continue")
+    msg_box.setDefaultButton(QMessageBox.Abort)
+    response = msg_box.exec_()
+    return response == QMessageBox.Abort

--- a/GEECS-Scanner-GUI/geecs_scanner/data_acquisition/scan_executor.py
+++ b/GEECS-Scanner-GUI/geecs_scanner/data_acquisition/scan_executor.py
@@ -515,7 +515,7 @@ class ScanStepExecutor:
                 GeecsDeviceCommandFailed,
                 GeecsDeviceExeTimeout,
             )
-            from geecs_scanner.data_acquisition.action_manager import (
+            from geecs_scanner.data_acquisition.gui_dialogs import (
                 prompt_user_device_timeout,
             )
 

--- a/GEECS-Scanner-GUI/geecs_scanner/data_acquisition/scan_executor.py
+++ b/GEECS-Scanner-GUI/geecs_scanner/data_acquisition/scan_executor.py
@@ -513,6 +513,10 @@ class ScanStepExecutor:
             from geecs_python_api.controls.interface.geecs_errors import (
                 GeecsDeviceCommandRejected,
                 GeecsDeviceCommandFailed,
+                GeecsDeviceExeTimeout,
+            )
+            from geecs_scanner.data_acquisition.action_manager import (
+                prompt_user_device_timeout,
             )
 
             device = self.device_manager.devices.get(device_name)
@@ -600,6 +604,29 @@ class ScanStepExecutor:
                                 device_name,
                             )
                             self.stop_scanning_thread_event.set()
+                            return
+
+                    except GeecsDeviceExeTimeout as e:
+                        logger.error(
+                            "[%s] EXE TIMEOUT: %s (attempt %d/%d)",
+                            device_name,
+                            e,
+                            attempt + 1,
+                            max_retries,
+                        )
+                        if attempt < max_retries - 1:
+                            time.sleep(retry_delay)
+                        else:
+                            logger.error(
+                                "[%s] Exe timeout persists after all retry attempts. "
+                                "Prompting user.",
+                                device_name,
+                            )
+                            abort = prompt_user_device_timeout(
+                                e.device_name, e.command, e.timeout
+                            )
+                            if abort:
+                                self.stop_scanning_thread_event.set()
                             return
 
                 if not success:

--- a/GEECS-Scanner-GUI/geecs_scanner/data_acquisition/scan_manager.py
+++ b/GEECS-Scanner-GUI/geecs_scanner/data_acquisition/scan_manager.py
@@ -99,8 +99,10 @@ from dataclasses import fields
 
 from geecs_python_api.controls.devices.scan_device import ScanDevice
 from geecs_python_api.controls.interface.geecs_errors import (
+    GeecsDeviceExeTimeout,
     GeecsDeviceInstantiationError,
 )
+from geecs_scanner.data_acquisition.action_manager import prompt_user_device_timeout
 from geecs_scanner.utils.exceptions import OrphanProcessingTimeout
 
 
@@ -381,8 +383,24 @@ class ScanManager:
                 variable_settings = self.shot_control_variables[variable]
                 set_value = variable_settings.get(state, "")
                 if set_value:
-                    results.append(self.shot_control.set(variable, set_value))
-                    logger.info("Setting %s to %s", variable, set_value)
+                    try:
+                        results.append(
+                            self.shot_control.set(variable, set_value, exec_timeout=2.0)
+                        )
+                        logger.info("Setting %s to %s", variable, set_value)
+                    except GeecsDeviceExeTimeout as e:
+                        logger.error(
+                            "Trigger variable '%s' timed out on state '%s': %s",
+                            variable,
+                            state,
+                            e,
+                        )
+                        abort = prompt_user_device_timeout(
+                            e.device_name, e.command, e.timeout
+                        )
+                        if abort:
+                            self.stop_scanning_thread_event.set()
+                        return results
             logger.info("Trigger turned to state %s.", state)
         else:
             logger.error("Invalid trigger state: %s", state)

--- a/GEECS-Scanner-GUI/geecs_scanner/data_acquisition/scan_manager.py
+++ b/GEECS-Scanner-GUI/geecs_scanner/data_acquisition/scan_manager.py
@@ -385,7 +385,7 @@ class ScanManager:
                 if set_value:
                     try:
                         results.append(
-                            self.shot_control.set(variable, set_value, exec_timeout=2.0)
+                            self.shot_control.set(variable, set_value, exec_timeout=0.5)
                         )
                         logger.info("Setting %s to %s", variable, set_value)
                     except GeecsDeviceExeTimeout as e:

--- a/GEECS-Scanner-GUI/geecs_scanner/data_acquisition/scan_manager.py
+++ b/GEECS-Scanner-GUI/geecs_scanner/data_acquisition/scan_manager.py
@@ -102,7 +102,7 @@ from geecs_python_api.controls.interface.geecs_errors import (
     GeecsDeviceExeTimeout,
     GeecsDeviceInstantiationError,
 )
-from geecs_scanner.data_acquisition.action_manager import prompt_user_device_timeout
+from geecs_scanner.data_acquisition.gui_dialogs import prompt_user_device_timeout
 from geecs_scanner.utils.exceptions import OrphanProcessingTimeout
 
 


### PR DESCRIPTION
## Summary

- **Root cause**: `GeecsDevice.set()` had a hardcoded `wait_for_all_cmds(timeout=120.0)` and a 120s default `exec_timeout`, causing `set` calls to hang silently for up to 2 minutes when no exe response arrived
- **Silent failure**: `UdpServer.listen()` returned `""` on timeout with no error surfaced to the caller
- **Stale buffer**: after a timeout, the late-arriving exe response sat in the socket buffer and was consumed by the _next_ `listen()` call, suppressing the timeout and updating device state with wrong data

## Changes

**`geecs_python_api/controls/interface/geecs_errors.py`**
- Add `GeecsDeviceExeTimeout` exception (fields: `device_name`, `command`, `timeout`) for silent exe timeouts, distinct from `GeecsDeviceCommandRejected` (ack failure) and `GeecsDeviceCommandFailed` (hardware error)

**`geecs_python_api/controls/interface/udp_handler.py`**
- Reduce `ack_cmd` default timeout 5.0s → 1.5s
- Add `UdpServer.drain()` — flushes stale data from the exe socket buffer before each fresh `listen()`

**`geecs_python_api/controls/devices/geecs_device.py`**
- `set()` default `exec_timeout`: 120s → 10s
- Sync path: wire `wait_for_all_cmds` to `exec_timeout` (was hardcoded 120s)
- Sync path: call `drain()` then `listen()` directly; raise `GeecsDeviceExeTimeout` if response is empty

**`geecs_scanner/data_acquisition/gui_dialogs.py`** _(new file)_
- `prompt_user_device_timeout()`: shows a `QMessageBox` from the scan worker thread on repeated exe timeout, giving the user Continue or Abort options (see issue #312 for future signal-based refactor)

**`geecs_scanner/data_acquisition/scan_executor.py`**
- Catch `GeecsDeviceExeTimeout` in `set_device_variables()` retry loop; show dialog after all retries exhausted; set `stop_scanning_thread_event` on abort

**`geecs_scanner/data_acquisition/scan_manager.py`**
- `_set_trigger()`: pass `exec_timeout=0.5` (digital toggles are fast); catch `GeecsDeviceExeTimeout`, show dialog, abort scan if user requests

## Test plan

- [x] Confirm normal `set` calls complete without regression
- [x] Force a timeout (e.g. `exec_timeout=0.0001`) and verify `GeecsDeviceExeTimeout` is raised, the user dialog appears, and subsequent `set` calls are not polluted by stale exe responses
- [x] Verify the abort path sets `stop_scanning_thread_event` and halts the scan cleanly

Closes #312 (partially — dialog logic tracked there for future signal-based refactor). Closes #278 

🤖 Generated with [Claude Code](https://claude.com/claude-code)