### PR TITLE
Fix scan closeout: write scalar files first, catch device errors, parallel disconnect

### DIFF
--- a/GEECS-Data-Utils/CHANGELOG.md
+++ b/GEECS-Data-Utils/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog — geecs-data-utils
+
+All notable changes to this package will be documented here.
+Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+## [0.2.1] — current
+<!-- Add entries here when changes are made -->

--- a/GEECS-PythonAPI/CHANGELOG.md
+++ b/GEECS-PythonAPI/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog — geecs-python-api
+
+All notable changes to this package will be documented here.
+Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+## [0.3.1] — 2026-04-13
+
+### Fixed
+- `dequeue_command()` now catches `GeecsDeviceCommandRejected` (logged as
+  warning) and bare `Exception` (logged as error) so rejected commands never
+  produce unhandled "Exception in thread" output in daemon threads
+- `_process_command()` guards against `dev_udp is None` (device already closed)
+  with an early return instead of a bare `assert`, eliminating `AssertionError`
+  tracebacks when dequeue threads outlive `device.close()`

--- a/GEECS-PythonAPI/geecs_python_api/controls/devices/geecs_device.py
+++ b/GEECS-PythonAPI/geecs_python_api/controls/devices/geecs_device.py
@@ -677,10 +677,19 @@ class GeecsDevice:
         attempts_max: int = 5,
     ) -> None:
         """Send command and optionally start its listener thread upon ack."""
+        if self.dev_udp is None:
+            logger.debug(
+                'UDP handler closed before "%s" could be processed; skipping', cmd_label
+            )
+            return
         accepted = False
         try:
             for attempt in range(attempts_max):
-                assert self.dev_udp is not None
+                if self.dev_udp is None:
+                    logger.debug(
+                        'UDP handler closed mid-retry for "%s"; aborting', cmd_label
+                    )
+                    return
                 sent = self.dev_udp.send_cmd(
                     ipv4=(self.dev_ip, self.dev_port), msg=cmd_str
                 )

--- a/GEECS-PythonAPI/geecs_python_api/controls/devices/geecs_device.py
+++ b/GEECS-PythonAPI/geecs_python_api/controls/devices/geecs_device.py
@@ -652,6 +652,10 @@ class GeecsDevice:
     # ---- Command queueing ---------------------------------------------------
     def dequeue_command(self) -> None:
         """Process all queued commands sequentially."""
+        from geecs_python_api.controls.interface.geecs_errors import (
+            GeecsDeviceCommandRejected,
+        )
+
         self._cleanup_threads()
         with GeecsDevice.threads_lock:
             while not self.queue_cmds.empty():
@@ -668,6 +672,18 @@ class GeecsDevice:
                     time.sleep(0.5)
                 except queue.Empty:
                     break
+                except GeecsDeviceCommandRejected:
+                    logger.warning(
+                        'command rejected during dequeue for "%s:%s"; continuing',
+                        self.get_name(),
+                        cmd_label,
+                    )
+                except Exception:
+                    logger.exception(
+                        'unexpected error during dequeue for "%s:%s"',
+                        self.get_name(),
+                        cmd_label,
+                    )
 
     def _process_command(
         self,

--- a/GEECS-PythonAPI/pyproject.toml
+++ b/GEECS-PythonAPI/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-pythonapi"
-version = "0.3.0"
+version = "0.3.1"
 description = "Python interface to GEECS control system"
 authors = ["Guillaume Plateau <guillaume.plateau@tausystems.com>", "Sam Barber <sbarber@lbl.gov>"]
 readme = "README.md"

--- a/GEECS-Scanner-GUI/CHANGELOG.md
+++ b/GEECS-Scanner-GUI/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Changelog — geecs-scanner
+
+All notable changes to this package will be documented here.
+Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+## [0.8.0] — 2026-04-13
+
+### Fixed
+- `stop_scan()` now writes scalar data files before any device interaction,
+  ensuring `ScanData*.txt` and `s*.txt` are always produced even if a closeout
+  action fails (closes #309)
+- Closeout action failure no longer aborts the remaining shutdown sequence
+- `_clear_existing_devices()` now disconnects devices in parallel via
+  `ThreadPoolExecutor`, eliminating O(N) serial teardown (closes #308)
+- `_stop_saving_devices()` dispatches `save=off` to all camera devices in
+  parallel; per-command exceptions are caught individually so one failure does
+  not skip remaining devices
+
+### Removed
+- Deprecated `save_data` boolean flag removed from `ScanManager`

--- a/GEECS-Scanner-GUI/geecs_scanner/data_acquisition/action_manager.py
+++ b/GEECS-Scanner-GUI/geecs_scanner/data_acquisition/action_manager.py
@@ -548,10 +548,27 @@ class ActionManager:
         >>> ActionManager._set_device(device, 'mode', 'calibration', sync=False)
         # Sets device mode asynchronously
         """
-        result = device.set(variable, value, sync=sync)
-        logger.info(
-            "Set %s:%s to %s. Result: %s", device.get_name(), variable, value, result
+        from geecs_python_api.controls.interface.geecs_errors import (
+            GeecsDeviceCommandRejected,
         )
+
+        try:
+            result = device.set(variable, value, sync=sync)
+            logger.info(
+                "Set %s:%s to %s. Result: %s",
+                device.get_name(),
+                variable,
+                value,
+                result,
+            )
+        except GeecsDeviceCommandRejected as e:
+            logger.warning(
+                "Set %s:%s to %s — command rejected, continuing: %s",
+                device.get_name(),
+                variable,
+                value,
+                e,
+            )
 
     def _get_device(self, device: ScanDevice, variable: str, expected_value: Any):
         """

--- a/GEECS-Scanner-GUI/geecs_scanner/data_acquisition/device_manager.py
+++ b/GEECS-Scanner-GUI/geecs_scanner/data_acquisition/device_manager.py
@@ -530,17 +530,30 @@ class DeviceManager:
         Unsubscribe from all currently active devices and reset the device registry.
 
         This method safely closes all device connections, unsubscribes from variable monitoring,
-        and clears the internal device dictionary. It is typically called when reloading a new
-        configuration or resetting the scan environment.
+        and clears the internal device dictionary. Disconnections run in parallel so that scans
+        with many subscribed devices close out quickly (#308).
         """
-        for device_name, device in self.devices.items():
-            try:
-                logger.info("Attempting to unsubscribe from %s...", device_name)
-                device.unsubscribe_var_values()
-                device.close()
-                logger.info("Successfully unsubscribed from %s.", device_name)
-            except Exception:
-                logger.exception("Error unsubscribing from %s", device_name)
+        from concurrent.futures import ThreadPoolExecutor, as_completed
+
+        def _disconnect(device_name, device):
+            logger.info("Attempting to unsubscribe from %s...", device_name)
+            device.unsubscribe_var_values()
+            device.close()
+            logger.info("Successfully unsubscribed from %s.", device_name)
+
+        devices_snapshot = dict(self.devices)
+        if devices_snapshot:
+            with ThreadPoolExecutor(max_workers=len(devices_snapshot)) as executor:
+                futures = {
+                    executor.submit(_disconnect, name, dev): name
+                    for name, dev in devices_snapshot.items()
+                }
+                for future in as_completed(futures):
+                    device_name = futures[future]
+                    try:
+                        future.result()
+                    except Exception:
+                        logger.exception("Error unsubscribing from %s", device_name)
 
         self.devices = {}
 

--- a/GEECS-Scanner-GUI/geecs_scanner/data_acquisition/scan_manager.py
+++ b/GEECS-Scanner-GUI/geecs_scanner/data_acquisition/scan_manager.py
@@ -858,10 +858,11 @@ class ScanManager:
         """Reset save paths for non-scalar devices in parallel.
 
         Dispatches save=off and localsavingpath reset commands to all camera
-        devices concurrently using synchronous calls so that all commands are
-        fully acknowledged before this method returns.  Using sync=True avoids
-        a race condition where device UDP sockets are closed by
-        _clear_existing_devices() while async dequeue threads are still running.
+        devices concurrently using fire-and-forget (sync=False) calls so that
+        the thread returns as soon as all UDP packets have been queued.  The
+        race between dequeue threads and device.close() is handled in
+        GeecsDevice._process_command, which checks dev_udp and returns cleanly
+        if the socket has already been closed.
 
         Note: stop_logging() is *not* called here.  The caller seals
         self.results with stop_logging() before starting this as a background
@@ -875,18 +876,8 @@ class ScanManager:
 
         def _reset_device(device_name, device):
             logger.info("Setting save to off for %s", device_name)
-            try:
-                device.set("save", "off", sync=True)
-            except Exception:
-                logger.warning(
-                    "Failed to set save=off for %s", device_name, exc_info=True
-                )
-            try:
-                device.set("localsavingpath", "c:\\temp", sync=True)
-            except Exception:
-                logger.warning(
-                    "Failed to reset localsavingpath for %s", device_name, exc_info=True
-                )
+            device.set("save", "off", sync=False)
+            device.set("localsavingpath", "c:\\temp", sync=False)
             logger.info("Save state reset for %s", device_name)
 
         devices = {

--- a/GEECS-Scanner-GUI/geecs_scanner/data_acquisition/scan_manager.py
+++ b/GEECS-Scanner-GUI/geecs_scanner/data_acquisition/scan_manager.py
@@ -811,11 +811,16 @@ class ScanManager:
 
         self.data_logger.file_mover.shutdown(wait=False)  # queue already drained
 
-        # Step 4: Restore the initial state of devices.
+        # Step 4: Wait for save=off to complete before restore or closeout,
+        # since closeout actions may talk to the same camera devices.
+        stop_saving_thread.join()
+        logger.info("Non-scalar device save states reset.")
+
+        # Step 5: Restore the initial state of devices.
         if self.initial_state is not None:
             self.restore_initial_state(self.initial_state)
 
-        # Step 5: Execute closeout actions.  Wrapped so that a device error
+        # Step 6: Execute closeout actions.  Wrapped so that a device error
         # (e.g. GeecsDeviceCommandRejected) cannot prevent data already
         # written above from being preserved.
         if self.device_manager.scan_closeout_action is not None:
@@ -840,10 +845,6 @@ class ScanManager:
         self.scan_step_start_time = 0
         self.scan_step_end_time = 0
         self.data_logger.idle_time = 0
-
-        # Step 6: Wait for camera save=off to complete before closing devices.
-        stop_saving_thread.join()
-        logger.info("Non-scalar device save states reset.")
 
         # Step 7: Reset the device manager.
         self.device_manager.reset()

--- a/GEECS-Scanner-GUI/geecs_scanner/data_acquisition/scan_manager.py
+++ b/GEECS-Scanner-GUI/geecs_scanner/data_acquisition/scan_manager.py
@@ -208,7 +208,6 @@ class ScanManager:
         self.data_logger = DataLogger(
             experiment_dir, self.device_manager
         )  # Initialize DataLogger
-        self.save_data = True
 
         self.shot_control: Optional[ScanDevice] = None
         self.shot_control_variables = None
@@ -578,11 +577,7 @@ class ScanManager:
                     )
                 logger.info("options dict: %s", self.options_dict)
                 # Start data logging
-                if self.save_data:
-                    logger.info("add data saving here")
-                    self.results = self.data_logger.start_logging()
-                else:
-                    logger.info("not doing any data saving")
+                self.results = self.data_logger.start_logging()
 
                 if self.shot_control is not None:
                     self.synchronize_devices()
@@ -748,14 +743,12 @@ class ScanManager:
         """
         Stop the scan, save data, and restore initial device states.
 
-        Shutdown order is chosen to get scalar data on disk as quickly as
-        possible and to overlap the slow camera save=off / sleep(2) work
-        with restore / closeout steps:
+        Shutdown order:
 
         1. Trigger → STANDBY (no new shots)
-        2. _stop_saving_devices() starts in background thread (save=off + sleep)
-        3. stop_logging() seals self.results; process_results() + _make_sFile()
-        4. file-mover drain
+        2. stop_logging() seals self.results; process_results() + _make_sFile()
+        3. file-mover drain
+        4. _stop_saving_devices() in background thread (parallel save=off + sleep)
         5. restore initial state, closeout actions
         6. join background thread  ← must precede device_manager.reset()
         7. device_manager.reset()
@@ -766,64 +759,63 @@ class ScanManager:
             DataFrame containing the processed and saved scan data.
         """
         log_df = pd.DataFrame()
-        stop_saving_thread = None
 
         # Step 1: Trigger to standby — no new shots from here on.
         self._set_trigger("STANDBY")
 
-        if self.save_data:
-            # Step 2: Kick off camera save=off immediately — independent of
-            # scalar file writing; its 2 s sleep runs in parallel with steps
-            # 3-6 below.  Must join before device_manager.reset().
-            stop_saving_thread = threading.Thread(
-                target=self._stop_saving_devices,
-                name="stop-saving-devices",
-                daemon=True,
+        # Step 2: Seal self.results and write scalar files before any device
+        # interaction that could fail (restore, closeout).
+        self.data_logger.stop_logging()
+        log_df = self.scan_data_manager.process_results(self.results)
+        self.scan_data_manager._make_sFile(log_df)
+
+        # Signal that the scan is no longer live so orphaned files
+        # are no longer skipped during task processing.
+        self.data_logger.file_mover.scan_is_live = False
+
+        # Re-queue tasks that failed during live acquisition (file may
+        # not have been on disk yet when the worker first checked).
+        self.data_logger.file_mover._post_process_orphan_task()
+        try:
+            self._join_file_mover_queue(timeout=30.0)
+        except OrphanProcessingTimeout:
+            logger.error(
+                "Orphan task queue did not drain within 30 s. "
+                "Some files may not have been moved — check the scan directory manually."
             )
-            stop_saving_thread.start()
 
-            # Step 3: Seal self.results and write scalar files.
-            self.data_logger.stop_logging()
-            log_df = self.scan_data_manager.process_results(self.results)
-            self.scan_data_manager._make_sFile(log_df)
-
-            # Signal that the scan is no longer live so orphaned files
-            # are no longer skipped during task processing.
-            self.data_logger.file_mover.scan_is_live = False
-
-            # Re-queue tasks that failed during live acquisition (file may
-            # not have been on disk yet when the worker first checked).
-            self.data_logger.file_mover._post_process_orphan_task()
+        if self.save_local:
+            # Sweep the filesystem for any remaining unmatched files
+            # and create new tasks for them based on the log DataFrame.
+            self.data_logger.file_mover._post_process_orphaned_files(
+                log_df=log_df,
+                device_save_paths_mapping=self.scan_data_manager.device_save_paths_mapping,
+            )
             try:
                 self._join_file_mover_queue(timeout=30.0)
             except OrphanProcessingTimeout:
                 logger.error(
-                    "Orphan task queue did not drain within 30 s. "
+                    "Filesystem sweep tasks did not drain within 30 s. "
                     "Some files may not have been moved — check the scan directory manually."
                 )
 
-            if self.save_local:
-                # Sweep the filesystem for any remaining unmatched files
-                # and create new tasks for them based on the log DataFrame.
-                self.data_logger.file_mover._post_process_orphaned_files(
-                    log_df=log_df,
-                    device_save_paths_mapping=self.scan_data_manager.device_save_paths_mapping,
-                )
-                try:
-                    self._join_file_mover_queue(timeout=30.0)
-                except OrphanProcessingTimeout:
-                    logger.error(
-                        "Filesystem sweep tasks did not drain within 30 s. "
-                        "Some files may not have been moved — check the scan directory manually."
-                    )
+        self.data_logger.file_mover.shutdown(wait=False)  # queue already drained
 
-            self.data_logger.file_mover.shutdown(wait=False)  # queue already drained
+        # Step 3: Dispatch camera save=off in a background thread — its 2 s
+        # sleep overlaps with restore / closeout below.
+        # Must join before device_manager.reset().
+        stop_saving_thread = threading.Thread(
+            target=self._stop_saving_devices,
+            name="stop-saving-devices",
+            daemon=True,
+        )
+        stop_saving_thread.start()
 
-        # Step 5: Restore the initial state of devices.
+        # Step 4: Restore the initial state of devices.
         if self.initial_state is not None:
             self.restore_initial_state(self.initial_state)
 
-        # Step 6: Execute closeout actions.  Wrapped so that a device error
+        # Step 5: Execute closeout actions.  Wrapped so that a device error
         # (e.g. GeecsDeviceCommandRejected) cannot prevent data already
         # written above from being preserved.
         if self.device_manager.scan_closeout_action is not None:
@@ -849,44 +841,61 @@ class ScanManager:
         self.scan_step_end_time = 0
         self.data_logger.idle_time = 0
 
-        # Step 7: Wait for camera save=off to complete before closing devices.
-        if stop_saving_thread is not None:
-            stop_saving_thread.join()
-            logger.info("Non-scalar device save states reset.")
+        # Step 6: Wait for camera save=off to complete before closing devices.
+        stop_saving_thread.join()
+        logger.info("Non-scalar device save states reset.")
 
-        # Step 8: Reset the device manager to clear up the current subscribers.
+        # Step 7: Reset the device manager.
         self.device_manager.reset()
 
-        # Step 9: Require reinitialization before the next scan.
+        # Step 8: Require reinitialization before the next scan.
         self.initialization_success = False
 
         return log_df
 
     def _stop_saving_devices(self):
-        """Reset save paths for non-scalar devices.
+        """Reset save paths for non-scalar devices in parallel.
 
-        Disables saving for all non-scalar devices and resets their local save
-        paths to a temporary directory.  Waits for the async commands to land.
+        Dispatches save=off and localsavingpath reset commands to all camera
+        devices concurrently, then waits 2 s for the async UDP commands to land.
 
-        Note: stop_logging() is *not* called here.  The caller is responsible
-        for calling data_logger.stop_logging() before invoking this method so
-        that the two can be sequenced independently (e.g. stop_logging in the
-        main thread to seal results, then _stop_saving_devices in a background
-        thread to overlap with restore / closeout work).
+        Note: stop_logging() is *not* called here.  The caller seals
+        self.results with stop_logging() before starting this as a background
+        thread, allowing the two to overlap.
 
         Notes
         -----
         Intended for internal use during scan shutdown or interruption.
         """
-        for device_name in self.device_manager.non_scalar_saving_devices:
-            device = self.device_manager.devices.get(device_name)
-            if device:
-                logger.info("Setting save to off for %s", device_name)
-                device.set("save", "off", sync=False)
-                device.set("localsavingpath", "c:\\temp", sync=False)
-                logger.info("Save path reset for %s", device_name)
-            else:
-                logger.warning("Device %s not found in DeviceManager.", device_name)
+        from concurrent.futures import ThreadPoolExecutor, as_completed
+
+        def _reset_device(device_name, device):
+            logger.info("Setting save to off for %s", device_name)
+            device.set("save", "off", sync=False)
+            device.set("localsavingpath", "c:\\temp", sync=False)
+            logger.info("Save path reset for %s", device_name)
+
+        devices = {
+            name: dev
+            for name in self.device_manager.non_scalar_saving_devices
+            if (dev := self.device_manager.devices.get(name)) is not None
+        }
+        for name in set(self.device_manager.non_scalar_saving_devices) - set(devices):
+            logger.warning("Device %s not found in DeviceManager.", name)
+
+        if devices:
+            with ThreadPoolExecutor(max_workers=len(devices)) as executor:
+                futures = {
+                    executor.submit(_reset_device, name, dev): name
+                    for name, dev in devices.items()
+                }
+                for future in as_completed(futures):
+                    try:
+                        future.result()
+                    except Exception:
+                        logger.exception(
+                            "Error resetting save state for %s", futures[future]
+                        )
 
         time.sleep(2)  # Ensure asynchronous commands have time to finish
         logger.info("scanning has stopped for all devices.")
@@ -949,8 +958,6 @@ class ScanManager:
             Manages device configurations and interactions
         self.scan_data_manager : ScanDataManager
             Handles scan data path and file management
-        self.save_data : bool
-            Flag indicating whether data should be saved during the scan
 
         Notes
         -----
@@ -989,19 +996,16 @@ class ScanManager:
         self.scan_steps = self._generate_scan_steps()
         logger.info("steps for the scan are : %s", self.scan_steps)
 
-        if self.save_data:
-            self.scan_data_manager.configure_device_save_paths(
-                save_local=self.save_local
-            )
-            self.data_logger.save_local = self.save_local
-            self.data_logger.set_device_save_paths_mapping(
-                self.scan_data_manager.device_save_paths_mapping
-            )
-            self.data_logger.scan_number = (
-                self.scan_data_manager.scan_number_int
-            )  # TODO replace with a `set` func.
+        self.scan_data_manager.configure_device_save_paths(save_local=self.save_local)
+        self.data_logger.save_local = self.save_local
+        self.data_logger.set_device_save_paths_mapping(
+            self.scan_data_manager.device_save_paths_mapping
+        )
+        self.data_logger.scan_number = (
+            self.scan_data_manager.scan_number_int
+        )  # TODO replace with a `set` func.
 
-            self.scan_data_manager.write_scan_info_ini(self.scan_config)
+        self.scan_data_manager.write_scan_info_ini(self.scan_config)
 
         # Handle scan variables and ensure devices are initialized in DeviceManager
         logger.info("scan config in pre logging is this: %s", self.scan_config)

--- a/GEECS-Scanner-GUI/geecs_scanner/data_acquisition/scan_manager.py
+++ b/GEECS-Scanner-GUI/geecs_scanner/data_acquisition/scan_manager.py
@@ -858,7 +858,10 @@ class ScanManager:
         """Reset save paths for non-scalar devices in parallel.
 
         Dispatches save=off and localsavingpath reset commands to all camera
-        devices concurrently, then waits 2 s for the async UDP commands to land.
+        devices concurrently using synchronous calls so that all commands are
+        fully acknowledged before this method returns.  Using sync=True avoids
+        a race condition where device UDP sockets are closed by
+        _clear_existing_devices() while async dequeue threads are still running.
 
         Note: stop_logging() is *not* called here.  The caller seals
         self.results with stop_logging() before starting this as a background
@@ -872,9 +875,19 @@ class ScanManager:
 
         def _reset_device(device_name, device):
             logger.info("Setting save to off for %s", device_name)
-            device.set("save", "off", sync=False)
-            device.set("localsavingpath", "c:\\temp", sync=False)
-            logger.info("Save path reset for %s", device_name)
+            try:
+                device.set("save", "off", sync=True)
+            except Exception:
+                logger.warning(
+                    "Failed to set save=off for %s", device_name, exc_info=True
+                )
+            try:
+                device.set("localsavingpath", "c:\\temp", sync=True)
+            except Exception:
+                logger.warning(
+                    "Failed to reset localsavingpath for %s", device_name, exc_info=True
+                )
+            logger.info("Save state reset for %s", device_name)
 
         devices = {
             name: dev
@@ -898,7 +911,6 @@ class ScanManager:
                             "Error resetting save state for %s", futures[future]
                         )
 
-        time.sleep(2)  # Ensure asynchronous commands have time to finish
         logger.info("scanning has stopped for all devices.")
 
     def save_hiatus(self, hiatus_period: float):

--- a/GEECS-Scanner-GUI/geecs_scanner/data_acquisition/scan_manager.py
+++ b/GEECS-Scanner-GUI/geecs_scanner/data_acquisition/scan_manager.py
@@ -747,8 +747,8 @@ class ScanManager:
 
         1. Trigger → STANDBY (no new shots)
         2. stop_logging() seals self.results; process_results() + _make_sFile()
-        3. file-mover drain
-        4. _stop_saving_devices() in background thread (parallel save=off + sleep)
+        3. _stop_saving_devices() in background thread (parallel save=off + sleep)
+        4. file-mover drain  (overlaps with step 3)
         5. restore initial state, closeout actions
         6. join background thread  ← must precede device_manager.reset()
         7. device_manager.reset()
@@ -768,6 +768,16 @@ class ScanManager:
         self.data_logger.stop_logging()
         log_df = self.scan_data_manager.process_results(self.results)
         self.scan_data_manager._make_sFile(log_df)
+
+        # Step 3: Dispatch camera save=off in a background thread so its 2 s
+        # sleep overlaps with file-mover, restore, and closeout below.
+        # Must join before device_manager.reset().
+        stop_saving_thread = threading.Thread(
+            target=self._stop_saving_devices,
+            name="stop-saving-devices",
+            daemon=True,
+        )
+        stop_saving_thread.start()
 
         # Signal that the scan is no longer live so orphaned files
         # are no longer skipped during task processing.
@@ -800,16 +810,6 @@ class ScanManager:
                 )
 
         self.data_logger.file_mover.shutdown(wait=False)  # queue already drained
-
-        # Step 3: Dispatch camera save=off in a background thread — its 2 s
-        # sleep overlaps with restore / closeout below.
-        # Must join before device_manager.reset().
-        stop_saving_thread = threading.Thread(
-            target=self._stop_saving_devices,
-            name="stop-saving-devices",
-            daemon=True,
-        )
-        stop_saving_thread.start()
 
         # Step 4: Restore the initial state of devices.
         if self.initial_state is not None:

--- a/GEECS-Scanner-GUI/geecs_scanner/data_acquisition/scan_manager.py
+++ b/GEECS-Scanner-GUI/geecs_scanner/data_acquisition/scan_manager.py
@@ -753,9 +753,9 @@ class ScanManager:
         with restore / closeout steps:
 
         1. Trigger → STANDBY (no new shots)
-        2. stop_logging() seals self.results
-        3. process_results() + file-mover + _make_sFile() — data on disk
-        4. _stop_saving_devices() in background thread (save=off + sleep)
+        2. _stop_saving_devices() starts in background thread (save=off + sleep)
+        3. stop_logging() seals self.results; process_results() + _make_sFile()
+        4. file-mover drain
         5. restore initial state, closeout actions
         6. join background thread  ← must precede device_manager.reset()
         7. device_manager.reset()
@@ -768,16 +768,22 @@ class ScanManager:
         log_df = pd.DataFrame()
         stop_saving_thread = None
 
-        # Step 1: Trigger to standby immediately — no new shots from here on.
+        # Step 1: Trigger to standby — no new shots from here on.
         self._set_trigger("STANDBY")
 
         if self.save_data:
-            # Step 2: Seal self.results so process_results() sees a consistent
-            # snapshot.  save=off / sleep is handled in the background thread.
-            self.data_logger.stop_logging()
+            # Step 2: Kick off camera save=off immediately — independent of
+            # scalar file writing; its 2 s sleep runs in parallel with steps
+            # 3-6 below.  Must join before device_manager.reset().
+            stop_saving_thread = threading.Thread(
+                target=self._stop_saving_devices,
+                name="stop-saving-devices",
+                daemon=True,
+            )
+            stop_saving_thread.start()
 
-            # Step 3: Write scalar data files before any device interaction
-            # that could fail (restore, closeout).
+            # Step 3: Seal self.results and write scalar files.
+            self.data_logger.stop_logging()
             log_df = self.scan_data_manager.process_results(self.results)
             self.scan_data_manager._make_sFile(log_df)
 
@@ -812,16 +818,6 @@ class ScanManager:
                     )
 
             self.data_logger.file_mover.shutdown(wait=False)  # queue already drained
-
-            # Step 4: set save=off for camera devices and wait 2 s for async
-            # commands to complete — run in the background so it overlaps with
-            # restore / closeout below.  Must join before device_manager.reset().
-            stop_saving_thread = threading.Thread(
-                target=self._stop_saving_devices,
-                name="stop-saving-devices",
-                daemon=True,
-            )
-            stop_saving_thread.start()
 
         # Step 5: Restore the initial state of devices.
         if self.initial_state is not None:

--- a/GEECS-Scanner-GUI/geecs_scanner/data_acquisition/scan_manager.py
+++ b/GEECS-Scanner-GUI/geecs_scanner/data_acquisition/scan_manager.py
@@ -876,8 +876,18 @@ class ScanManager:
 
         def _reset_device(device_name, device):
             logger.info("Setting save to off for %s", device_name)
-            device.set("save", "off", sync=False)
-            device.set("localsavingpath", "c:\\temp", sync=False)
+            try:
+                device.set("save", "off", sync=False)
+            except Exception:
+                logger.warning(
+                    "Failed to set save=off for %s", device_name, exc_info=True
+                )
+            try:
+                device.set("localsavingpath", "c:\\temp", sync=False)
+            except Exception:
+                logger.warning(
+                    "Failed to reset localsavingpath for %s", device_name, exc_info=True
+                )
             logger.info("Save state reset for %s", device_name)
 
         devices = {

--- a/GEECS-Scanner-GUI/geecs_scanner/data_acquisition/scan_manager.py
+++ b/GEECS-Scanner-GUI/geecs_scanner/data_acquisition/scan_manager.py
@@ -752,6 +752,10 @@ class ScanManager:
         devices to their original state, turning the trigger back on, saving
         scan data if enabled, and resetting internal state.
 
+        Scalar data files (ScanData*.txt, s*.txt) are written as the very first
+        save step so that a failure in any subsequent closeout action cannot
+        prevent data from reaching disk.
+
         Returns
         -------
         pandas.DataFrame
@@ -760,28 +764,11 @@ class ScanManager:
         log_df = pd.DataFrame()
 
         if self.save_data:
-            # Step 1: Stop data logging and handle device saving states
+            # Step 1: Stop data logging and handle device saving states.
             self._stop_saving_devices()
 
-        # Step 5: Restore the initial state of devices
-        if self.initial_state is not None:
-            self.restore_initial_state(self.initial_state)
-
-        # Step 4: Turn the trigger back on
-        self._set_trigger("STANDBY")
-
-        if self.device_manager.scan_closeout_action is not None:
-            logger.info("Attempting to execute closeout actions.")
-            logger.info("Action list %s", self.device_manager.scan_closeout_action)
-
-            self.action_manager.add_action(
-                action_name="closeout_action",
-                action_seq=self.device_manager.scan_closeout_action,
-            )
-            self.action_manager.execute_action("closeout_action")
-
-        if self.save_data:
-            # Step 6: Process results, save to disk, and log data
+            # Step 2: Write scalar data files immediately — before restore,
+            # trigger changes, or closeout actions that could fail.
             log_df = self.scan_data_manager.process_results(self.results)
 
             # Signal that the scan is no longer live so orphaned files
@@ -818,8 +805,32 @@ class ScanManager:
                 wait=False
             )  # queue already drained above
 
-            # Step 8: create sfile in analysis folder
+            # Step 3: Write sfile to analysis folder.
             self.scan_data_manager._make_sFile(log_df)
+
+        # Step 4: Restore the initial state of devices.
+        if self.initial_state is not None:
+            self.restore_initial_state(self.initial_state)
+
+        # Step 5: Set trigger to standby.
+        self._set_trigger("STANDBY")
+
+        # Step 6: Execute closeout actions.  Wrapped so that a device error
+        # (e.g. GeecsDeviceCommandRejected) cannot prevent data already
+        # written above from being preserved.
+        if self.device_manager.scan_closeout_action is not None:
+            logger.info("Attempting to execute closeout actions.")
+            logger.info("Action list %s", self.device_manager.scan_closeout_action)
+            try:
+                self.action_manager.add_action(
+                    action_name="closeout_action",
+                    action_seq=self.device_manager.scan_closeout_action,
+                )
+                self.action_manager.execute_action("closeout_action")
+            except Exception:
+                logger.exception(
+                    "Closeout action failed — scan data has already been written."
+                )
 
         if self.scan_config.scan_mode == ScanMode.OPTIMIZATION:
             scan_dir = self.scan_data_manager.data_txt_path.parent

--- a/GEECS-Scanner-GUI/geecs_scanner/data_acquisition/scan_manager.py
+++ b/GEECS-Scanner-GUI/geecs_scanner/data_acquisition/scan_manager.py
@@ -748,13 +748,17 @@ class ScanManager:
         """
         Stop the scan, save data, and restore initial device states.
 
-        This method finalizes the scan by performing closeout actions, restoring
-        devices to their original state, turning the trigger back on, saving
-        scan data if enabled, and resetting internal state.
+        Shutdown order is chosen to get scalar data on disk as quickly as
+        possible and to overlap the slow camera save=off / sleep(2) work
+        with restore / closeout steps:
 
-        Scalar data files (ScanData*.txt, s*.txt) are written as the very first
-        save step so that a failure in any subsequent closeout action cannot
-        prevent data from reaching disk.
+        1. Trigger → STANDBY (no new shots)
+        2. stop_logging() seals self.results
+        3. process_results() + file-mover + _make_sFile() — data on disk
+        4. _stop_saving_devices_non_scalar() in background thread (save=off + sleep)
+        5. restore initial state, closeout actions
+        6. join background thread  ← must precede device_manager.reset()
+        7. device_manager.reset()
 
         Returns
         -------
@@ -762,13 +766,19 @@ class ScanManager:
             DataFrame containing the processed and saved scan data.
         """
         log_df = pd.DataFrame()
+        stop_saving_thread = None
+
+        # Step 1: Trigger to standby immediately — no new shots from here on.
+        self._set_trigger("STANDBY")
 
         if self.save_data:
-            # Step 1: Stop data logging and handle device saving states.
-            self._stop_saving_devices()
+            # Step 2: Seal self.results so process_results() sees a consistent
+            # snapshot.  The rest of _stop_saving_devices (save=off, sleep) is
+            # handled in the background thread below.
+            self.data_logger.stop_logging()
 
-            # Step 2: Write scalar data files immediately — before restore,
-            # trigger changes, or closeout actions that could fail.
+            # Step 3: Write scalar data files before any device interaction
+            # that could fail (restore, closeout).
             log_df = self.scan_data_manager.process_results(self.results)
 
             # Signal that the scan is no longer live so orphaned files
@@ -801,19 +811,23 @@ class ScanManager:
                         "Some files may not have been moved — check the scan directory manually."
                     )
 
-            self.data_logger.file_mover.shutdown(
-                wait=False
-            )  # queue already drained above
+            self.data_logger.file_mover.shutdown(wait=False)  # queue already drained
 
-            # Step 3: Write sfile to analysis folder.
             self.scan_data_manager._make_sFile(log_df)
 
-        # Step 4: Restore the initial state of devices.
+            # Step 4: set save=off for camera devices and wait 2 s for async
+            # commands to complete — run in the background so it overlaps with
+            # restore / closeout below.  Must join before device_manager.reset().
+            stop_saving_thread = threading.Thread(
+                target=self._stop_saving_devices_non_scalar,
+                name="stop-saving-devices",
+                daemon=True,
+            )
+            stop_saving_thread.start()
+
+        # Step 5: Restore the initial state of devices.
         if self.initial_state is not None:
             self.restore_initial_state(self.initial_state)
-
-        # Step 5: Set trigger to standby.
-        self._set_trigger("STANDBY")
 
         # Step 6: Execute closeout actions.  Wrapped so that a device error
         # (e.g. GeecsDeviceCommandRejected) cannot prevent data already
@@ -841,10 +855,15 @@ class ScanManager:
         self.scan_step_end_time = 0
         self.data_logger.idle_time = 0
 
-        # Step 10: Reset the device manager to clear up the current subscribers
+        # Step 7: Wait for camera save=off to complete before closing devices.
+        if stop_saving_thread is not None:
+            stop_saving_thread.join()
+            logger.info("Non-scalar device save states reset.")
+
+        # Step 8: Reset the device manager to clear up the current subscribers.
         self.device_manager.reset()
 
-        # Step 11: Set the initialization flag back to False and require reinitialization to be called again
+        # Step 9: Require reinitialization before the next scan.
         self.initialization_success = False
 
         return log_df
@@ -880,6 +899,30 @@ class ScanManager:
 
         time.sleep(2)  # Ensure asynchronous commands have time to finish
         logger.info("scanning has stopped for all devices.")
+
+    def _stop_saving_devices_non_scalar(self):
+        """Reset save paths for non-scalar devices without stopping the data logger.
+
+        Called from a background thread in stop_scan() after stop_logging() has
+        already been called in the main thread.  Runs the slow save=off / sleep
+        work concurrently with restore / closeout steps.
+
+        Notes
+        -----
+        Intended for internal use during scan shutdown only.
+        """
+        for device_name in self.device_manager.non_scalar_saving_devices:
+            device = self.device_manager.devices.get(device_name)
+            if device:
+                logger.info("Setting save to off for %s", device_name)
+                device.set("save", "off", sync=False)
+                device.set("localsavingpath", "c:\\temp", sync=False)
+                logger.info("Save path reset for %s", device_name)
+            else:
+                logger.warning("Device %s not found in DeviceManager.", device_name)
+
+        time.sleep(2)  # Ensure asynchronous commands have time to finish
+        logger.info("Non-scalar device save states reset.")
 
     def save_hiatus(self, hiatus_period: float):
         """

--- a/GEECS-Scanner-GUI/geecs_scanner/data_acquisition/scan_manager.py
+++ b/GEECS-Scanner-GUI/geecs_scanner/data_acquisition/scan_manager.py
@@ -755,7 +755,7 @@ class ScanManager:
         1. Trigger → STANDBY (no new shots)
         2. stop_logging() seals self.results
         3. process_results() + file-mover + _make_sFile() — data on disk
-        4. _stop_saving_devices_non_scalar() in background thread (save=off + sleep)
+        4. _stop_saving_devices() in background thread (save=off + sleep)
         5. restore initial state, closeout actions
         6. join background thread  ← must precede device_manager.reset()
         7. device_manager.reset()
@@ -773,13 +773,13 @@ class ScanManager:
 
         if self.save_data:
             # Step 2: Seal self.results so process_results() sees a consistent
-            # snapshot.  The rest of _stop_saving_devices (save=off, sleep) is
-            # handled in the background thread below.
+            # snapshot.  save=off / sleep is handled in the background thread.
             self.data_logger.stop_logging()
 
             # Step 3: Write scalar data files before any device interaction
             # that could fail (restore, closeout).
             log_df = self.scan_data_manager.process_results(self.results)
+            self.scan_data_manager._make_sFile(log_df)
 
             # Signal that the scan is no longer live so orphaned files
             # are no longer skipped during task processing.
@@ -813,13 +813,11 @@ class ScanManager:
 
             self.data_logger.file_mover.shutdown(wait=False)  # queue already drained
 
-            self.scan_data_manager._make_sFile(log_df)
-
             # Step 4: set save=off for camera devices and wait 2 s for async
             # commands to complete — run in the background so it overlaps with
             # restore / closeout below.  Must join before device_manager.reset().
             stop_saving_thread = threading.Thread(
-                target=self._stop_saving_devices_non_scalar,
+                target=self._stop_saving_devices,
                 name="stop-saving-devices",
                 daemon=True,
             )
@@ -869,47 +867,20 @@ class ScanManager:
         return log_df
 
     def _stop_saving_devices(self):
-        """
-        Stop data logging and reset save paths for non-scalar devices.
+        """Reset save paths for non-scalar devices.
 
-        This method disables saving for all non-scalar devices and resets their
-        local save paths to a temporary directory. It ensures that all asynchronous
-        save commands have time to complete.
+        Disables saving for all non-scalar devices and resets their local save
+        paths to a temporary directory.  Waits for the async commands to land.
+
+        Note: stop_logging() is *not* called here.  The caller is responsible
+        for calling data_logger.stop_logging() before invoking this method so
+        that the two can be sequenced independently (e.g. stop_logging in the
+        main thread to seal results, then _stop_saving_devices in a background
+        thread to overlap with restore / closeout work).
 
         Notes
         -----
         Intended for internal use during scan shutdown or interruption.
-        """
-        # Stop data logging
-        self.data_logger.stop_logging()
-
-        # Handle device saving states
-        for device_name in self.device_manager.non_scalar_saving_devices:
-            device = self.device_manager.devices.get(device_name)
-            if device:
-                logger.info("Setting save to off for %s", device_name)
-                device.set("save", "off", sync=False)
-                logger.info("Setting save to off for %s complete", device_name)
-                device.set("localsavingpath", "c:\\temp", sync=False)
-                logger.info(
-                    "Setting save path back to temp for %s complete", device_name
-                )
-            else:
-                logger.warning("Device %s not found in DeviceManager.", device_name)
-
-        time.sleep(2)  # Ensure asynchronous commands have time to finish
-        logger.info("scanning has stopped for all devices.")
-
-    def _stop_saving_devices_non_scalar(self):
-        """Reset save paths for non-scalar devices without stopping the data logger.
-
-        Called from a background thread in stop_scan() after stop_logging() has
-        already been called in the main thread.  Runs the slow save=off / sleep
-        work concurrently with restore / closeout steps.
-
-        Notes
-        -----
-        Intended for internal use during scan shutdown only.
         """
         for device_name in self.device_manager.non_scalar_saving_devices:
             device = self.device_manager.devices.get(device_name)
@@ -922,7 +893,7 @@ class ScanManager:
                 logger.warning("Device %s not found in DeviceManager.", device_name)
 
         time.sleep(2)  # Ensure asynchronous commands have time to finish
-        logger.info("Non-scalar device save states reset.")
+        logger.info("scanning has stopped for all devices.")
 
     def save_hiatus(self, hiatus_period: float):
         """

--- a/GEECS-Scanner-GUI/pyproject.toml
+++ b/GEECS-Scanner-GUI/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-scanner-gui"
-version = "0.7.1"
+version = "0.8.0"
 description = ""
 authors = ["Christopher Doss <CEDoss@lbl.gov>"]
 readme = "README.md"

--- a/ImageAnalysis/CHANGELOG.md
+++ b/ImageAnalysis/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog — image-analysis
+
+All notable changes to this package will be documented here.
+Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+## [1.1.0] — current
+<!-- Add entries here when changes are made -->

--- a/LogMaker4GoogleDocs/CHANGELOG.md
+++ b/LogMaker4GoogleDocs/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog — logmaker-4-googledocs
+
+All notable changes to this package will be documented here.
+Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+## [0.1.0] — current
+<!-- Add entries here when changes are made -->

--- a/ScanAnalysis/CHANGELOG.md
+++ b/ScanAnalysis/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog — scan-analysis
+
+All notable changes to this package will be documented here.
+Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+## [1.1.1] — current
+<!-- Add entries here when changes are made -->


### PR DESCRIPTION
Closes #308, closes #309.

## Root causes

1. **`stop_scan()` ordering** (#309): Scalar data files were written *after* closeout actions. A `GeecsDeviceCommandRejected` from any device in the closeout sequence propagated as `ActionError` and crashed `stop_scan()` before `process_results()` or `_make_sFile()` ever ran — no `ScanData*.txt`, no `s*.txt`.

2. **Unhandled command rejection** (#309): A single rejected command aborted all remaining closeout steps.

3. **Serial device disconnect** (#308): `_clear_existing_devices()` disconnected one device at a time.

4. **`GeecsDeviceCommandRejected` in dequeue threads** (found during testing): `dequeue_command` only caught `queue.Empty`, so rejected commands escaped as unhandled exceptions in `UdpServer-dequeue` daemon threads — hard crash output to stderr.

5. **`assert self.dev_udp is not None` race** (found during testing): After scan close, dequeue threads spawned by `UdpServer.listen()` could outlive `device.close()`. The bare `assert` caused `AssertionError` tracebacks instead of a clean exit.

## Changes

### `scan_manager.stop_scan()` — reorder + parallelise + remove deprecated flag

New shutdown order:

| Step | Action |
|------|--------|
| 1 | `_set_trigger("STANDBY")` — no new shots |
| 2 | `stop_logging()` → `process_results()` → `_make_sFile()` — scalar files written **first** |
| 3 | `_stop_saving_devices()` launched in a background thread (parallel `save=off` via `ThreadPoolExecutor`, fire-and-forget) |
| 4 | File-mover drain — overlaps with step 3 |
| 5 | `stop_saving_thread.join()` — wait before closeout touches the same devices |
| 6 | `restore_initial_state()`, closeout actions (wrapped in `try/except`) |
| 7 | `device_manager.reset()` |

- `_stop_saving_devices()` dispatches all `save=off` / `localsavingpath` UDP sends in parallel via `ThreadPoolExecutor` with per-command `try/except` so one failure doesn't skip the other.
- Removed the long-deprecated `save_data` boolean flag.
- Closeout wrapped in `try/except` so a failure is logged without preventing already-written data from being preserved.

### `action_manager._set_device()` — catch rejected commands (#309)

Catches `GeecsDeviceCommandRejected` and logs a `warning` instead of propagating.

### `device_manager._clear_existing_devices()` — parallel disconnect (#308)

Replaces the serial `for` loop with `ThreadPoolExecutor`.

### `GeecsDevice._process_command()` — guard against closed socket

Replaces `assert self.dev_udp is not None` with an early-return guard (checked before and inside the retry loop) so dequeue threads that outlive `device.close()` exit cleanly with a debug log.

### `GeecsDevice.dequeue_command()` — catch rejected commands

Catches `GeecsDeviceCommandRejected` (warning) and bare `Exception` (error) in the dequeue loop so daemon threads never produce unhandled "Exception in thread" output.

## Version bumps

- `geecs-scanner` 0.7.1 → **0.8.0** (minor: meaningful behaviour change to shutdown sequence)
- `geecs-python-api` 0.3.0 → **0.3.1** (patch: dequeue bug fix)

## Test plan

- [x] Run a scan with a closeout action where one device rejects a command — verify `ScanData*.txt` and `s*.txt` are written, remaining closeout steps continue, error is logged
- [x] Run a normal scan to completion — verify no regression in data files or device restore
- [x] Run a scan with many subscribed devices and confirm closeout is fast (seconds, not 20+ s)
- [x] Verify no "Exception in thread" output in the logs after scan end

🤖 Generated with [Claude Code](https://claude.com/claude-code)