### PR TITLE
Add background_scan_number to BackgroundConfig

### DIFF
--- a/ImageAnalysis/image_analysis/processing/array2d/config_models.py
+++ b/ImageAnalysis/image_analysis/processing/array2d/config_models.py
@@ -83,6 +83,11 @@ class BackgroundConfig(BaseModel):
         Additional constant to subtract AFTER primary background (default 0).
     dynamic_computation : Optional[DynamicComputationConfig]
         Configuration for dynamic background computation (batch processing only).
+    background_scan_number : int, optional
+        Scan number to use as background source. The scan analyzer will load
+        and average all images from that scan's device folder, cache the result
+        as a .npy file, and use it as a FROM_FILE background. Takes precedence
+        over file_path when set.
     """
 
     enabled: bool = Field(True, description="Enable background processing")
@@ -100,6 +105,15 @@ class BackgroundConfig(BaseModel):
     )
     dynamic_computation: Optional[DynamicComputationConfig] = Field(
         None, description="Dynamic background computation config (batch processing)"
+    )
+    background_scan_number: Optional[int] = Field(
+        None,
+        description=(
+            "Scan number whose images are averaged to form the background. "
+            "Handled by the scan analyzer: images from that scan's device folder "
+            "are loaded, averaged, and cached as a .npy file. Takes precedence "
+            "over file_path when set."
+        ),
     )
 
     @field_validator("file_path")

--- a/ScanAnalysis/scan_analysis/analyzers/common/single_device_scan_analyzer.py
+++ b/ScanAnalysis/scan_analysis/analyzers/common/single_device_scan_analyzer.py
@@ -414,6 +414,79 @@ class SingleDeviceScanAnalyzer(ScanAnalyzer, ABC):
             bg_config.dynamic_computation.auto_save_path = Path(resolved)
             logger.info(f"Resolved background auto_save_path: {resolved}")
 
+        # Handle scan-number-based background (takes precedence over file_path)
+        if bg_config.background_scan_number is not None:
+            self._generate_scan_background(bg_config)
+
+    def _generate_scan_background(self, bg_config) -> None:
+        """Load and average all images from a background scan, cache as .npy.
+
+        Resolves the background scan's device folder using the same date and
+        experiment as the current scan. The averaged background is saved to the
+        background scan's own analysis directory so it can be reused by any
+        subsequent scan that references the same background scan number.
+
+        Parameters
+        ----------
+        bg_config : BackgroundConfig
+            The analyzer's background configuration. ``file_path`` and ``method``
+            are mutated in-place to point at the cached .npy file so that the
+            normal BackgroundManager FROM_FILE path takes over from here.
+        """
+        from geecs_data_utils import ScanPaths, ScanTag as GeecsDataScanTag
+        from image_analysis.processing.array2d.config_models import BackgroundMethod
+
+        bg_number = bg_config.background_scan_number
+
+        bg_tag = GeecsDataScanTag(
+            year=self.scan_tag.year,
+            month=self.scan_tag.month,
+            day=self.scan_tag.day,
+            number=bg_number,
+            experiment=self.scan_tag.experiment,
+        )
+        bg_scan_paths = ScanPaths(tag=bg_tag, read_mode=True)
+        bg_device_dir = bg_scan_paths.get_folder() / self.device_name
+
+        # Cache lives in the background scan's own analysis folder so any scan
+        # referencing the same background scan number shares the result.
+        cache_dir = bg_scan_paths.get_analysis_folder() / self.device_name
+        cache_path = cache_dir / f"{self.device_name}_background_avg.npy"
+
+        if cache_path.exists():
+            logger.info("Using cached scan background: %s", cache_path)
+        else:
+            image_files = sorted(bg_device_dir.glob(f"*{self.file_tail}"))
+            if not image_files:
+                raise FileNotFoundError(
+                    f"No background images found in {bg_device_dir}"
+                )
+
+            images = []
+            for f in image_files:
+                try:
+                    images.append(self.image_analyzer.load_image(f))
+                except Exception as e:
+                    logger.warning("Skipping background file %s: %s", f, e)
+
+            if not images:
+                raise ValueError(
+                    f"No valid images could be loaded from background scan {bg_number}"
+                )
+
+            avg = np.mean(np.stack(images), axis=0)
+            cache_dir.mkdir(parents=True, exist_ok=True)
+            np.save(cache_path, avg)
+            logger.info(
+                "Averaged %d images from scan %d, saved background to %s",
+                len(images),
+                bg_number,
+                cache_path,
+            )
+
+        bg_config.file_path = cache_path
+        bg_config.method = BackgroundMethod.FROM_FILE
+
     @staticmethod
     def _normalize_aux_value(value):
         if isinstance(value, np.generic):


### PR DESCRIPTION
## Human summary

long overdue PR to allow specifying simply a scan number to use for background. Note, the background is generated by loading images using the `image_analyzer.load_image()` method, so it is generic for all file types. 

The whole implementation of background subtraction is a little bit of a mess with functionality split across ScanAnalysis and ImageAnalysis. I think this could be one of the last new background types to be added so i didn't embark on a larger rearrangement. It's simple, functional implementation for now.

## AI Summary

- Adds `background_scan_number: Optional[int]` to `BackgroundConfig` in `ImageAnalysis`. This field is inert at the image analysis layer — `BackgroundManager` ignores it entirely.
- Adds `_generate_scan_background()` to `SingleDeviceScanAnalyzer` in `ScanAnalysis`. When `background_scan_number` is set, `_resolve_background_paths()` calls this method which:
  - Resolves the background scan's device folder (same date/experiment, different scan number)
  - Checks for an existing cached average at `<bg_scan_analysis_dir>/<device>/<device>_background_avg.npy`
  - If absent: loads all device images from that scan, averages them, and saves to the cache
  - Injects the cache path into `BackgroundConfig` as `FROM_FILE` so `BackgroundManager` takes over normally

Caching in the background scan's own analysis folder means any scan referencing the same background scan number reuses the result on subsequent runs.

## Usage

```yaml
background:
  background_scan_number: 3
```

## Test plan

- [x] Configure a camera config YAML with `background_scan_number` pointing to a valid background scan
- [x] Run analysis — verify background is averaged and cached on first run
- [x] Run again — verify cached `.npy` is used (no re-averaging)
- [x] Confirm `BackgroundConfig` without `background_scan_number` behaves identically to before

🤖 Generated with [Claude Code](https://claude.com/claude-code)