### PR TITLE
Feature/frog noise subtraction

### DIFF
--- a/ImageAnalysis/image_analysis/algorithms/_frog_dll_worker.py
+++ b/ImageAnalysis/image_analysis/algorithms/_frog_dll_worker.py
@@ -103,7 +103,7 @@ def main():
     # ----------------------------------------------------------------
     # _NoiseSubtraction — background subtraction on raw trace
     # ----------------------------------------------------------------
-    noise_fn = frog._NoiseSubtraction
+    noise_fn = frog["_NoiseSubtraction@24"]
     noise_fn.restype = None
     noise_fn(
         ctypes.cast(rawdata, ctypes.POINTER(ctypes.c_double)),

--- a/ImageAnalysis/image_analysis/algorithms/_frog_dll_worker.py
+++ b/ImageAnalysis/image_analysis/algorithms/_frog_dll_worker.py
@@ -103,7 +103,7 @@ def main():
     # ----------------------------------------------------------------
     # _NoiseSubtraction — background subtraction on raw trace
     # ----------------------------------------------------------------
-    noise_fn = frog["_NoiseSubtraction"]
+    noise_fn = frog._NoiseSubtraction
     noise_fn.restype = None
     noise_fn(
         ctypes.cast(rawdata, ctypes.POINTER(ctypes.c_double)),

--- a/ImageAnalysis/image_analysis/algorithms/_frog_dll_worker.py
+++ b/ImageAnalysis/image_analysis/algorithms/_frog_dll_worker.py
@@ -33,7 +33,9 @@ Params JSON format:
         "run_type": 1,
         "max_iterations": 200,
         "target_error": 0.005,
-        "max_time_seconds": 60
+        "max_time_seconds": 60,
+        "noise_subtype": 4,
+        "noise_rad": 1.0
     }
 """
 
@@ -78,6 +80,8 @@ def main():
     max_iterations = params.get("max_iterations", 200)
     target_error = params.get("target_error", 0.005)
     max_time_seconds = params.get("max_time_seconds", 60)
+    noise_subtype = params.get("noise_subtype", 4)
+    noise_rad = params.get("noise_rad", 1.0)
 
     # Read input trace
     with open(input_path, "rb") as f:
@@ -95,6 +99,23 @@ def main():
 
     # Load DLL
     frog = ctypes.WinDLL(dll_path)
+
+    # ----------------------------------------------------------------
+    # _NoiseSubtraction — background subtraction on raw trace
+    # ----------------------------------------------------------------
+    noise_fn = frog["_NoiseSubtraction"]
+    noise_fn.restype = None
+    noise_fn(
+        ctypes.cast(rawdata, ctypes.POINTER(ctypes.c_double)),
+        ctypes.c_int32(ntau),
+        ctypes.c_int32(nw),
+        ctypes.c_int32(noise_subtype),
+        ctypes.c_double(noise_rad),
+    )
+    print(
+        "_NoiseSubtraction: subtype={0}, rad={1}".format(noise_subtype, noise_rad),
+        file=sys.stderr,
+    )
 
     # Seed the C runtime RNG before DLLInit.
     # The FROG DLL uses rand() internally to generate a random initial

--- a/ImageAnalysis/image_analysis/algorithms/frog_dll_retrieval.py
+++ b/ImageAnalysis/image_analysis/algorithms/frog_dll_retrieval.py
@@ -75,6 +75,8 @@ class FrogRetrievalConfig(BaseModel):
         5.0, description="Max wall-clock time for retrieval [s]"
     )
     max_iterations: int = Field(1000000000, description="Max iterations for retrieval")
+    noise_subtype: int = Field(4, description="NoiseSubtraction SUBTYPE parameter")
+    noise_rad: float = Field(1.0, description="NoiseSubtraction RAD parameter")
 
 
 @dataclass
@@ -239,6 +241,8 @@ class FrogDllRetrieval:
         max_iterations: int = 200,
         target_error: float = 0.005,
         max_time_seconds: float = 60.0,
+        noise_subtype: int = 4,
+        noise_rad: float = 1.0,
         timeout: float = 120.0,
     ) -> FrogRetrievalResult:
         """Run the FROG retrieval algorithm on a Grenouille trace.
@@ -269,6 +273,10 @@ class FrogDllRetrieval:
             Target FROG error for early stopping (default 0.005).
         max_time_seconds : float
             Maximum wall-clock time for the retrieval loop in seconds (default 60).
+        noise_subtype : int
+            SUBTYPE argument passed to _NoiseSubtraction (default 4).
+        noise_rad : float
+            RAD argument passed to _NoiseSubtraction (default 1.0).
         timeout : float
             Maximum time for the entire subprocess in seconds (default 120).
 
@@ -356,6 +364,8 @@ class FrogDllRetrieval:
                 "max_iterations": max_iterations,
                 "target_error": target_error,
                 "max_time_seconds": max_time_seconds,
+                "noise_subtype": noise_subtype,
+                "noise_rad": noise_rad,
             }
             json.dump(params, f_params)
 

--- a/ImageAnalysis/image_analysis/offline_analyzers/grenouille_analyzer.py
+++ b/ImageAnalysis/image_analysis/offline_analyzers/grenouille_analyzer.py
@@ -110,6 +110,8 @@ class GrenouilleAnalyzer(StandardAnalyzer):
             target_error=self.analysis_config.target_error,
             max_time_seconds=self.analysis_config.max_time_seconds,
             max_iterations=self.analysis_config.max_iterations,
+            noise_subtype=self.analysis_config.noise_subtype,
+            noise_rad=self.analysis_config.noise_rad,
         )
 
         scalar_results = {


### PR DESCRIPTION
There was a 'background subtraction' algorithm from the frog dll that was not implemented in the frog_retrieval in algorithms. The functionality has now been added, and the defaults are the same as what is used in the original Labview vi.