### PR TITLE
Fix orphan file-move drain throughput (v0.8.2)

### DIFF
--- a/GEECS-Scanner-GUI/CHANGELOG.md
+++ b/GEECS-Scanner-GUI/CHANGELOG.md
@@ -19,6 +19,11 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   post-scan drain. No new files are written after the scan ends, so the
   delay serves no purpose and was costing ~2 s of wall time for a typical
   60-task backlog across 16 workers
+- `PermissionError` on `file.is_file()` inside `_process_task` no longer
+  crashes the entire task. When a device holds a write lock on a file at
+  the moment the worker tries to stat it, the file is now skipped and the
+  task continues; the retry or end-of-scan orphan sweep picks it up once
+  the lock is released
 
 ## [0.8.1] — 2026-04-15
 

--- a/GEECS-Scanner-GUI/CHANGELOG.md
+++ b/GEECS-Scanner-GUI/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to this package will be documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.8.2] — 2026-04-15
+
+### Fixed
+- Orphan file-move tasks now drain in parallel instead of serially. The
+  0.5 s retry delay was previously applied inside `move_files_by_timestamp`
+  (the queueing call), which caused `_post_process_orphan_task` to sleep
+  0.5 s per task before each enqueue — serialising the entire drain through
+  a single thread regardless of the 16-worker pool. The sleep is now applied
+  inside `_process_task` (the worker), so all orphan tasks are queued
+  immediately and processed concurrently, improving end-of-scan drain
+  throughput from ~2 files/s to ~32 files/s
+
 ## [0.8.1] — 2026-04-15
 
 ### Fixed

--- a/GEECS-Scanner-GUI/CHANGELOG.md
+++ b/GEECS-Scanner-GUI/CHANGELOG.md
@@ -13,7 +13,12 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   a single thread regardless of the 16-worker pool. The sleep is now applied
   inside `_process_task` (the worker), so all orphan tasks are queued
   immediately and processed concurrently, improving end-of-scan drain
-  throughput from ~2 files/s to ~32 files/s
+  throughput from ~2 files/s to ~20 files/s
+- `_post_process_orphan_task` now resets `retry_count` to 0 before
+  re-queuing each task, eliminating the 0.5 s per-worker sleep during the
+  post-scan drain. No new files are written after the scan ends, so the
+  delay serves no purpose and was costing ~2 s of wall time for a typical
+  60-task backlog across 16 workers
 
 ## [0.8.1] — 2026-04-15
 

--- a/GEECS-Scanner-GUI/geecs_scanner/data_acquisition/data_logger.py
+++ b/GEECS-Scanner-GUI/geecs_scanner/data_acquisition/data_logger.py
@@ -635,6 +635,9 @@ class FileMover:
         orphan_snapshot = list(self.orphan_tasks)
         self.orphan_tasks.clear()
         for task in orphan_snapshot:
+            task.retry_count = (
+                0  # No new files are being written at scan end; skip the retry sleep.
+            )
             self.move_files_by_timestamp(task)
 
     def shutdown(self, wait: bool = True) -> None:

--- a/GEECS-Scanner-GUI/geecs_scanner/data_acquisition/data_logger.py
+++ b/GEECS-Scanner-GUI/geecs_scanner/data_acquisition/data_logger.py
@@ -225,6 +225,13 @@ class FileMover:
         - For MagSpec (and others devices), looks for and processes additional variant files
          with known suffixes.
         """
+        # Give the device time to finish writing before retrying.  The sleep
+        # lives here (in the worker) rather than in move_files_by_timestamp so
+        # that _post_process_orphan_task can queue all orphan tasks at once and
+        # let the 16 workers drain them in parallel instead of serially.
+        if task.retry_count > 0:
+            time.sleep(0.5)
+
         source_dir = task.source_dir
         target_dir = task.target_dir
         device_name = task.device_name
@@ -486,8 +493,6 @@ class FileMover:
             The task containing file movement parameters such as source and target directories,
             device name, expected timestamp, and shot index.
         """
-        if task.retry_count > 0:
-            time.sleep(0.5)
         self.task_queue.put(task)
 
     def _post_process_orphaned_files(

--- a/GEECS-Scanner-GUI/geecs_scanner/data_acquisition/data_logger.py
+++ b/GEECS-Scanner-GUI/geecs_scanner/data_acquisition/data_logger.py
@@ -286,7 +286,12 @@ class FileMover:
             adjusted_target_dir.mkdir(parents=True, exist_ok=True)
 
             for file in variant.glob("*"):
-                if not file.is_file():
+                try:
+                    if not file.is_file():
+                        continue
+                except OSError:
+                    # File is locked for writing by the device; skip and let
+                    # the retry or orphan sweep pick it up later.
                     continue
 
                 # if the file has been checked already e.g. orphaned, skip when the scan is live.

--- a/GEECS-Scanner-GUI/pyproject.toml
+++ b/GEECS-Scanner-GUI/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-scanner-gui"
-version = "0.8.1"
+version = "0.8.2"
 description = ""
 authors = ["Christopher Doss <CEDoss@lbl.gov>"]
 readme = "README.md"


### PR DESCRIPTION
## Summary

Three improvements to end-of-scan file-move reliability and throughput:

- **Parallel orphan drain**: `_post_process_orphan_task` previously called `move_files_by_timestamp` in a loop that slept 0.5 s *before queuing* each task — serialising the entire drain through a single thread regardless of the 16-worker pool (~2 files/s). Sleep moved into `_process_task` (the worker) so all orphan tasks are queued immediately and drained in parallel
- **No sleep at scan end**: `_post_process_orphan_task` now resets `retry_count` to 0 before re-queuing, skipping the 0.5 s worker sleep entirely. No new files are written after the scan ends, so the delay serves no purpose. Combined with the above, throughput improved from ~2 files/s to ~70 files/s (<1 s for a 70-file backlog, confirmed in production testing)
- **Locked-file resilience**: `PermissionError` on `file.is_file()` (e.g. device holds a write lock on a partially-written file) no longer crashes the entire task and silently drops it. The locked file is skipped and picked up by the retry cycle or end-of-scan orphan sweep

## Stacking note

Branches from `fix/gui-dialog-thread-safety` (#318). After #318 merges, rebase this branch onto master before merging.

## Test plan

- [x] Artificially built a ~70-file orphan backlog by redirecting save path mid-scan; confirmed drain completes in <1 s on this branch vs ~35 s on master
- [x] Confirmed normal scan (no orphans) is unaffected
- [x] Confirmed retried tasks (files that appear late) still get the 0.5 s retry gap during live acquisition
- [x] `PermissionError` on locked file no longer surfaces as "Error processing task" in log

🤖 Generated with [Claude Code](https://claude.com/claude-code)