### PR TITLE
Moved GoogleDocsID functionality to the Data-Utils directory

### DIFF
--- a/GEECS-Data-Utils/geecs_data_utils/__init__.py
+++ b/GEECS-Data-Utils/geecs_data_utils/__init__.py
@@ -26,6 +26,7 @@ from geecs_data_utils.config_roots import (
     image_analysis_config,
     scan_analysis_config,
 )
+from geecs_data_utils.doc_id_lookup import DocIDLookup, EXPERIMENT_FILE_IDS
 
 __all__ = [
     "ScanData",
@@ -39,4 +40,6 @@ __all__ = [
     "ConfigDirManager",
     "image_analysis_config",
     "scan_analysis_config",
+    "DocIDLookup",
+    "EXPERIMENT_FILE_IDS",
 ]

--- a/GEECS-Data-Utils/geecs_data_utils/doc_id_lookup.py
+++ b/GEECS-Data-Utils/geecs_data_utils/doc_id_lookup.py
@@ -2,6 +2,18 @@
 
 This module provides date-aware Document ID resolution by downloading and caching
 .tsv files from Google Drive that map dates (MM-DD-YY format) to Document IDs.
+
+The ``DocIDLookup`` class is the primary interface: given an experiment name and
+a Google Drive file ID, it downloads the corresponding ``doc_index.tsv``, caches
+it locally, and provides fast date-to-Document-ID lookups.
+
+Examples
+--------
+>>> from geecs_data_utils.doc_id_lookup import DocIDLookup, EXPERIMENT_FILE_IDS
+>>> lookup = DocIDLookup("Undulator", EXPERIMENT_FILE_IDS["Undulator"])
+>>> lookup.refresh()
+True
+>>> doc_id = lookup.get_document_id(2026, 4, 16)
 """
 
 from __future__ import annotations
@@ -22,8 +34,9 @@ EXPERIMENT_FILE_IDS: Dict[str, str] = {
 class DocIDLookup:
     """Download and cache Google Drive doc_index.tsv files for date-aware Document ID lookup.
 
-    Each experiment has its own .tsv file on Google Drive that maps dates (MM-DD-YY format)
-    to Document IDs. This class handles downloading, caching, and querying these files.
+    Each experiment has its own .tsv file on Google Drive that maps dates
+    (MM-DD-YY format) to Document IDs.  This class handles downloading,
+    caching, and querying these files.
 
     Parameters
     ----------
@@ -32,7 +45,8 @@ class DocIDLookup:
     file_id : str
         Google Drive file ID for the experiment's doc_index.tsv file.
     cache_dir : Path, optional
-        Directory to cache downloaded .tsv files. Defaults to ~/.cache/LiveWatchGUI/
+        Directory to cache downloaded .tsv files.
+        Defaults to ``~/.cache/geecs_data_utils/``.
     """
 
     def __init__(
@@ -47,7 +61,7 @@ class DocIDLookup:
 
         # Set up cache directory
         if cache_dir is None:
-            cache_dir = Path.home() / ".cache" / "LiveWatchGUI"
+            cache_dir = Path.home() / ".cache" / "geecs_data_utils"
         self.cache_dir = Path(cache_dir)
         self.cache_dir.mkdir(parents=True, exist_ok=True)
 
@@ -155,7 +169,7 @@ class DocIDLookup:
             return False
 
         try:
-            with open(self.cache_file, "r", encoding="utf-8") as f:
+            with open(self.cache_file, encoding="utf-8") as f:
                 content = f.read()
             self._mapping = self._parse_tsv(content)
             logger.debug(
@@ -171,7 +185,7 @@ class DocIDLookup:
     def _download_from_drive(self) -> bool:
         """Download .tsv file from Google Drive.
 
-        Uses the Google Drive export URL to download the file as TSV format.
+        Uses the Google Drive direct download URL to fetch the file.
 
         Returns
         -------
@@ -194,7 +208,11 @@ class DocIDLookup:
 
             # Add User-Agent header to avoid being blocked by Google Drive
             headers = {
-                "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36"
+                "User-Agent": (
+                    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+                    "AppleWebKit/537.36 (KHTML, like Gecko) "
+                    "Chrome/91.0.4472.124 Safari/537.36"
+                )
             }
 
             response = requests.get(
@@ -219,7 +237,8 @@ class DocIDLookup:
     def _parse_tsv(self, content: str) -> Dict[str, str]:
         """Parse TSV content and return date-to-DocID mapping.
 
-        Expected format:
+        Expected format::
+
             Date (MM-DD-YY) | Document ID
             01-15-26        | 1abc2def3ghi4jkl5mno6pqr7stu8vwx
             01-16-26        | 2bcd3efg4hij5klm6nop7qrs8tuv9wxy

--- a/GEECS-Data-Utils/pyproject.toml
+++ b/GEECS-Data-Utils/pyproject.toml
@@ -33,6 +33,7 @@ nptdms = "^1.10"
 pydantic = "^2.0"
 duckdb = ">=1.4.4,<2.0"
 pyyaml = "^6.0.3"
+requests = "^2.28.0"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.0"

--- a/ScanAnalysis/LiveWatchGUI/live_watch_window.py
+++ b/ScanAnalysis/LiveWatchGUI/live_watch_window.py
@@ -617,16 +617,48 @@ class LiveWatchWindow(QMainWindow):
         self._set_running_ui(True)
 
     def _stop_worker(self) -> None:
-        """Request the worker to stop gracefully."""
+        """Request the worker to stop gracefully.
+
+        Disconnects the log-handler signal *before* requesting stop to
+        prevent cross-thread signal deadlocks during QThread teardown.
+        The signal is reconnected in :meth:`_on_worker_finished`.
+        """
         if self._worker is not None:
+            # Prevent double-click while stopping
+            self.btn_start_stop.setEnabled(False)
+
+            # Disconnect log signal to avoid cross-thread deadlock during
+            # the shutdown sequence (observer.stop / observer.join may
+            # trigger log messages from the worker thread).
+            if self._log_handler is not None:
+                try:
+                    self._log_handler.emitter.log_record.disconnect(self._on_log_record)
+                except TypeError:
+                    pass  # already disconnected
+
             logger.info("Stopping LiveWatch...")
             self._worker.request_stop()
             # Don't block the GUI; the finished signal will clean up
 
     def _on_worker_finished(self) -> None:
-        """Clean up after the worker thread exits."""
-        self._set_running_ui(False)
+        """Clean up after the worker thread exits.
+
+        Waits briefly for the QThread to fully terminate, then
+        reconnects the log-handler signal and re-enables the UI.
+        """
+        if self._worker is not None:
+            # Ensure the QThread is fully dead before releasing the reference
+            self._worker.wait(3000)
         self._worker = None
+
+        # Reconnect log handler for the next run
+        if self._log_handler is not None:
+            try:
+                self._log_handler.emitter.log_record.connect(self._on_log_record)
+            except TypeError:
+                pass  # already connected
+
+        self._set_running_ui(False)
 
     # ------------------------------------------------------------------
     # Slot: Status updates
@@ -718,6 +750,7 @@ class LiveWatchWindow(QMainWindow):
     def _set_running_ui(self, running: bool) -> None:
         """Enable/disable widgets based on whether the worker is running."""
         self.btn_start_stop.setText("■  Stop" if running else "▶  Start")
+        self.btn_start_stop.setEnabled(True)  # re-enable after _stop_worker disabled it
 
         # Disable config fields while running to prevent mid-run changes
         self.combo_experiment.setEnabled(not running)
@@ -742,16 +775,27 @@ class LiveWatchWindow(QMainWindow):
     # ------------------------------------------------------------------
 
     def closeEvent(self, event) -> None:
-        """Ensure the worker is stopped before the window closes."""
-        if self._worker is not None and self._worker.isRunning():
-            self._worker.request_stop()
-            self._worker.wait(5000)  # wait up to 5 seconds
-        # Remove log handler to avoid dangling references
+        """Ensure the worker is stopped before the window closes.
+
+        Closes the log handler *first* to prevent cross-thread signal
+        emission during the shutdown wait, then stops the worker.
+        """
+        # Close the log handler first to stop cross-thread signal emission
         if self._log_handler is not None:
+            self._log_handler.close()
+            try:
+                self._log_handler.emitter.log_record.disconnect(self._on_log_record)
+            except TypeError:
+                pass
             for name in (
                 "scan_analysis.live_task_runner",
                 "scan_analysis.task_queue",
                 "LiveWatchGUI",
             ):
                 logging.getLogger(name).removeHandler(self._log_handler)
+
+        # Now safe to stop the worker — no log signals can deadlock
+        if self._worker is not None and self._worker.isRunning():
+            self._worker.request_stop()
+            self._worker.wait(5000)  # wait up to 5 seconds
         super().closeEvent(event)

--- a/ScanAnalysis/LiveWatchGUI/live_watch_window.py
+++ b/ScanAnalysis/LiveWatchGUI/live_watch_window.py
@@ -33,7 +33,7 @@ from PyQt5.QtWidgets import (
     QFileDialog,
 )
 
-from .doc_id_lookup import DocIDLookup, EXPERIMENT_FILE_IDS
+from geecs_data_utils.doc_id_lookup import DocIDLookup, EXPERIMENT_FILE_IDS
 from .log_handler import QtLogHandler
 from .worker import LiveWatchConfig, LiveWatchWorker
 

--- a/ScanAnalysis/LiveWatchGUI/log_handler.py
+++ b/ScanAnalysis/LiveWatchGUI/log_handler.py
@@ -43,15 +43,27 @@ class QtLogHandler(logging.Handler):
 
     def __init__(self, level: int = logging.DEBUG):
         super().__init__(level)
+        self._closed = False
         self.emitter = _LogSignalEmitter()
         self.setFormatter(
             logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s")
         )
 
     def emit(self, record: logging.LogRecord) -> None:
-        """Format *record* and emit it via the Qt signal."""
+        """Format *record* and emit it via the Qt signal.
+
+        Silently drops records after :meth:`close` has been called to
+        prevent cross-thread signal emission during shutdown.
+        """
+        if self._closed:
+            return
         try:
             msg = self.format(record)
             self.emitter.log_record.emit(msg, record.levelname)
         except Exception:  # pragma: no cover – never let logging crash the app
             self.handleError(record)
+
+    def close(self) -> None:
+        """Mark the handler as closed so no further signals are emitted."""
+        self._closed = True
+        super().close()

--- a/ScanAnalysis/LiveWatchGUI/worker.py
+++ b/ScanAnalysis/LiveWatchGUI/worker.py
@@ -25,29 +25,34 @@ logger = logging.getLogger(__name__)
 def _stop_runner_with_timeout(runner: LiveTaskRunner, timeout: float = 5.0) -> None:
     """Stop a LiveTaskRunner with a timeout to prevent indefinite blocking.
 
+    Calls ``observer.stop()`` (non-blocking signal) then ``observer.join()``
+    with a bounded timeout.  Previous versions spawned a daemon thread for
+    this, but that created orphaned threads that could emit Qt signals after
+    the QThread had already finished — leading to intermittent GUI freezes.
+
     Parameters
     ----------
     runner : LiveTaskRunner
         The runner to stop.
     timeout : float
-        Maximum time to wait for runner.stop() to complete (seconds).
+        Maximum time to wait for the observer thread to finish (seconds).
     """
+    try:
+        runner.observer.stop()  # non-blocking: signals the observer to exit
+    except Exception as exc:
+        logger.warning("Error calling observer.stop(): %s", exc)
+        return
 
-    def stop_in_thread():
-        try:
-            runner.stop()
-        except Exception as exc:
-            logger.warning("Error in runner.stop(): %s", exc)
-
-    stop_thread = threading.Thread(target=stop_in_thread, daemon=True)
-    stop_thread.start()
-    stop_thread.join(timeout=timeout)
-
-    if stop_thread.is_alive():
-        logger.warning(
-            "runner.stop() did not complete within %s seconds, continuing anyway",
-            timeout,
-        )
+    try:
+        runner.observer.join(timeout=timeout)
+        if runner.observer.is_alive():
+            logger.warning(
+                "PollingObserver did not stop within %s seconds; "
+                "abandoning join to avoid blocking the QThread",
+                timeout,
+            )
+    except Exception as exc:
+        logger.warning("Error joining observer: %s", exc)
 
 
 @dataclass


### PR DESCRIPTION
Commit 1: Fix GUI lockup after Stop button
Problem: The LiveWatch GUI intermittently froze ("Not Responding") after pressing Stop, even after the status showed "Stopped" and log messages appeared.

Root causes identified and fixed:

Cross-thread Qt signal deadlock — [QtLogHandler.emit()](vscode-webview://0o1atil2i98967at4ji6hnht42e86oltdv3lvd9vm3b5j1fn17ej/GEECS-Plugins/ScanAnalysis/LiveWatchGUI/log_handler.py:52) was emitting signals from the worker thread into the GUI thread during QThread teardown. Added a _closed flag and [close()](vscode-webview://0o1atil2i98967at4ji6hnht42e86oltdv3lvd9vm3b5j1fn17ej/GEECS-Plugins/ScanAnalysis/LiveWatchGUI/log_handler.py:66) method to suppress emissions after shutdown.

Orphaned daemon threads — [_stop_runner_with_timeout()](vscode-webview://0o1atil2i98967at4ji6hnht42e86oltdv3lvd9vm3b5j1fn17ej/GEECS-Plugins/ScanAnalysis/LiveWatchGUI/worker.py:25) previously spawned daemon threads that could outlive the QThread and emit signals into dead QObjects. Replaced with inline observer.stop() / observer.join(timeout).

Shutdown ordering — [_stop_worker()](vscode-webview://0o1atil2i98967at4ji6hnht42e86oltdv3lvd9vm3b5j1fn17ej/GEECS-Plugins/ScanAnalysis/LiveWatchGUI/live_watch_window.py:619) now disconnects the log signal before requesting stop; [_on_worker_finished()](vscode-webview://0o1atil2i98967at4ji6hnht42e86oltdv3lvd9vm3b5j1fn17ej/GEECS-Plugins/ScanAnalysis/LiveWatchGUI/live_watch_window.py:643) waits for the QThread and reconnects the signal; [closeEvent()](vscode-webview://0o1atil2i98967at4ji6hnht42e86oltdv3lvd9vm3b5j1fn17ej/GEECS-Plugins/ScanAnalysis/LiveWatchGUI/live_watch_window.py:777) closes the log handler first.

Start button stays disabled — [_set_running_ui()](vscode-webview://0o1atil2i98967at4ji6hnht42e86oltdv3lvd9vm3b5j1fn17ej/GEECS-Plugins/ScanAnalysis/LiveWatchGUI/live_watch_window.py:750) now re-enables the Start/Stop button after state transitions.

Files changed:

ScanAnalysis/LiveWatchGUI/log_handler.py
ScanAnalysis/LiveWatchGUI/worker.py
ScanAnalysis/LiveWatchGUI/live_watch_window.py
Commit 2: Relocate doc_id_lookup.py to geecs-data-utils
Motivation: Per PR review feedback, doc_id_lookup.py implements core data interfacing (Google Drive document ID resolution via .tsv files) that doesn't belong in the GUI package. Relocated to geecs-data-utils where it can be shared across projects.

Changes:

Created [GEECS-Data-Utils/geecs_data_utils/doc_id_lookup.py](vscode-webview://0o1atil2i98967at4ji6hnht42e86oltdv3lvd9vm3b5j1fn17ej/GEECS-Plugins/GEECS-Data-Utils/geecs_data_utils/doc_id_lookup.py) — relocated module with cache directory changed from ~/.cache/LiveWatchGUI/ to ~/.cache/geecs_data_utils/
Modified [GEECS-Data-Utils/pyproject.toml](vscode-webview://0o1atil2i98967at4ji6hnht42e86oltdv3lvd9vm3b5j1fn17ej/GEECS-Plugins/GEECS-Data-Utils/pyproject.toml:36) — added requests = "^2.28.0" dependency
Modified [GEECS-Data-Utils/geecs_data_utils/__init__.py](vscode-webview://0o1atil2i98967at4ji6hnht42e86oltdv3lvd9vm3b5j1fn17ej/GEECS-Plugins/GEECS-Data-Utils/geecs_data_utils/__init__.py:29) — exports DocIDLookup and EXPERIMENT_FILE_IDS
Modified [ScanAnalysis/LiveWatchGUI/live_watch_window.py](vscode-webview://0o1atil2i98967at4ji6hnht42e86oltdv3lvd9vm3b5j1fn17ej/GEECS-Plugins/ScanAnalysis/LiveWatchGUI/live_watch_window.py:36) — import changed from from .doc_id_lookup import ... to from geecs_data_utils.doc_id_lookup import ...
Deleted ScanAnalysis/LiveWatchGUI/doc_id_lookup.py
All pre-commit checks pass for both commits (ruff, ruff-format, pydocstyle, trailing whitespace, AST check, etc.).