### PR TITLE
Add no_data task state and analysis status dialog

### DIFF
--- a/ScanAnalysis/LiveWatchGUI/live_watch_window.py
+++ b/ScanAnalysis/LiveWatchGUI/live_watch_window.py
@@ -35,6 +35,7 @@ from PyQt5.QtWidgets import (
 
 from geecs_data_utils.doc_id_lookup import DocIDLookup, EXPERIMENT_FILE_IDS
 from .log_handler import QtLogHandler
+from .status_dialog import StatusDialog
 from .worker import LiveWatchConfig, LiveWatchWorker
 
 logger = logging.getLogger(__name__)
@@ -117,6 +118,7 @@ class LiveWatchWindow(QMainWindow):
         self._worker: Optional[LiveWatchWorker] = None
         self._log_handler: Optional[QtLogHandler] = None
         self._doc_id_lookup: Optional[DocIDLookup] = None
+        self._status_dialog: Optional[StatusDialog] = None
 
         # Build UI
         central = QWidget()
@@ -354,6 +356,15 @@ class LiveWatchWindow(QMainWindow):
         self.btn_start_stop.clicked.connect(self._on_start_stop)
         layout.addWidget(self.btn_start_stop)
 
+        self.btn_status = QPushButton("Status…")
+        self.btn_status.setMinimumHeight(36)
+        self.btn_status.setToolTip(
+            "Open the status overview grid for the selected date.\n"
+            "Shows per-scan, per-analyzer task states."
+        )
+        self.btn_status.clicked.connect(self._on_show_status)
+        layout.addWidget(self.btn_status)
+
         layout.addSpacing(20)
 
         self.label_status = QLabel("● Idle")
@@ -584,6 +595,55 @@ class LiveWatchWindow(QMainWindow):
             rerun_completed=self.check_rerun_completed.isChecked(),
             rerun_failed=self.check_rerun_failed.isChecked(),
         )
+
+    # ------------------------------------------------------------------
+    # Slot: Status dialog
+    # ------------------------------------------------------------------
+
+    def _on_show_status(self) -> None:
+        """Open (or refresh and raise) the status overview dialog."""
+        config = self._build_config()
+        date_tag = config.to_scan_tag()
+        analyzer_ids = self._get_analyzer_ids(config)
+        base_directory = self._get_base_directory()
+
+        if self._status_dialog is None or not self._status_dialog.isVisible():
+            self._status_dialog = StatusDialog(
+                date_tag, analyzer_ids, base_directory, parent=self
+            )
+            self._status_dialog.show()
+        else:
+            self._status_dialog.update_config(date_tag, analyzer_ids, base_directory)
+            self._status_dialog.raise_()
+            self._status_dialog.activateWindow()
+
+    def _get_analyzer_ids(self, config: "LiveWatchConfig") -> list[str]:
+        """Return ordered analyzer IDs for the current experiment config."""
+        try:
+            from scan_analysis.task_queue import load_analyzers_from_config
+
+            analyzers = load_analyzers_from_config(
+                config.analyzer_group, config_dir=config.config_dir
+            )
+            ids = []
+            for a in analyzers:
+                aid = getattr(a, "id", None) or getattr(a, "device_name", None)
+                if not aid:
+                    aid = f"{a.__class__.__name__}_{getattr(a, 'device_name', '')}"
+                ids.append(aid)
+            return ids
+        except Exception as exc:
+            logger.warning("Could not load analyzer IDs for status dialog: %s", exc)
+            return []
+
+    def _get_base_directory(self) -> Optional[Path]:
+        """Return the configured data base directory, or None."""
+        try:
+            from geecs_data_utils import ScanPaths
+
+            return ScanPaths.paths_config.base_path
+        except Exception:
+            return None
 
     # ------------------------------------------------------------------
     # Slot: Start / Stop

--- a/ScanAnalysis/LiveWatchGUI/status_dialog.py
+++ b/ScanAnalysis/LiveWatchGUI/status_dialog.py
@@ -1,0 +1,311 @@
+"""Status overview dialog for LiveWatch analysis.
+
+Opens a modeless dialog showing a scan × analyzer grid for the selected day,
+with colour-coded cells for each task state.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+from PyQt5.QtCore import Qt, QTimer
+from PyQt5.QtGui import QColor
+from PyQt5.QtWidgets import (
+    QCheckBox,
+    QDialog,
+    QHBoxLayout,
+    QLabel,
+    QPushButton,
+    QSizePolicy,
+    QTableWidget,
+    QTableWidgetItem,
+    QVBoxLayout,
+)
+
+from geecs_data_utils import ScanTag
+from scan_analysis.task_queue import TaskStatus, read_day_statuses
+
+logger = logging.getLogger(__name__)
+
+# State → (background colour, display label)
+_STATE_STYLE: Dict[str, Tuple[QColor, str]] = {
+    "done": (QColor(144, 238, 144), "done"),
+    "failed": (QColor(255, 160, 122), "failed"),
+    "claimed": (QColor(255, 215, 0), "claimed"),
+    "no_data": (QColor(176, 196, 222), "no data"),
+    "queued": (QColor(220, 220, 220), "queued"),
+}
+_DEFAULT_STYLE: Tuple[QColor, str] = (QColor(245, 245, 245), "—")
+
+_AUTO_REFRESH_MS = 10_000
+
+
+class StatusDialog(QDialog):
+    """Modeless scan × analyzer status grid.
+
+    Parameters
+    ----------
+    date_tag : ScanTag
+        Identifies the day and experiment to inspect.
+    analyzer_ids : list[str]
+        Ordered list of analyzer IDs (column headers).  Any extra IDs found
+        in on-disk status files are appended as additional columns.
+    base_directory : Path or None
+        Root data directory; ``None`` defers to the configured default.
+    parent : QWidget or None
+        Optional parent widget.
+    """
+
+    def __init__(
+        self,
+        date_tag: ScanTag,
+        analyzer_ids: List[str],
+        base_directory: Optional[Path],
+        parent=None,
+    ):
+        super().__init__(parent)
+        self.setWindowTitle("Analysis Status")
+        self.setMinimumSize(700, 320)
+        self.resize(900, 480)
+        # Keep the dialog on top of its parent but allow it to be moved freely.
+        self.setWindowFlags(self.windowFlags() | Qt.Window)
+
+        self._date_tag = date_tag
+        self._analyzer_ids = list(analyzer_ids)
+        self._base_directory = base_directory
+
+        self._timer = QTimer(self)
+        self._timer.setInterval(_AUTO_REFRESH_MS)
+        self._timer.timeout.connect(self._refresh)
+
+        self._build_ui()
+        self._refresh()
+
+    # ------------------------------------------------------------------
+    # Public API — called by the parent window to update config
+    # ------------------------------------------------------------------
+
+    def update_config(
+        self,
+        date_tag: ScanTag,
+        analyzer_ids: List[str],
+        base_directory: Optional[Path],
+    ) -> None:
+        """Apply new date / analyzer list and immediately refresh."""
+        self._date_tag = date_tag
+        self._analyzer_ids = list(analyzer_ids)
+        self._base_directory = base_directory
+        self._refresh()
+
+    # ------------------------------------------------------------------
+    # UI construction
+    # ------------------------------------------------------------------
+
+    def _build_ui(self) -> None:
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(8, 8, 8, 8)
+        layout.setSpacing(6)
+
+        # ── top bar ──────────────────────────────────────────────────
+        top = QHBoxLayout()
+
+        self._label_summary = QLabel("—")
+        self._label_summary.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Fixed)
+        top.addWidget(self._label_summary)
+
+        self._check_auto = QCheckBox("Auto-refresh (10 s)")
+        self._check_auto.toggled.connect(self._on_auto_toggled)
+        top.addWidget(self._check_auto)
+
+        self._btn_refresh = QPushButton("Refresh")
+        self._btn_refresh.clicked.connect(self._refresh)
+        top.addWidget(self._btn_refresh)
+
+        layout.addLayout(top)
+
+        # ── legend ───────────────────────────────────────────────────
+        legend = QHBoxLayout()
+        legend.setSpacing(12)
+        for state, (colour, label) in _STATE_STYLE.items():
+            chip = QLabel(f"  {label}  ")
+            chip.setAutoFillBackground(True)
+            p = chip.palette()
+            p.setColor(chip.backgroundRole(), colour)
+            chip.setPalette(p)
+            chip.setAlignment(Qt.AlignCenter)
+            legend.addWidget(chip)
+        legend.addStretch()
+        layout.addLayout(legend)
+
+        # ── table ────────────────────────────────────────────────────
+        self._table = QTableWidget()
+        self._table.setEditTriggers(QTableWidget.NoEditTriggers)
+        self._table.setSelectionMode(QTableWidget.NoSelection)
+        self._table.horizontalHeader().setStretchLastSection(False)
+        self._table.verticalHeader().setVisible(False)
+        self._table.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
+        layout.addWidget(self._table)
+
+    # ------------------------------------------------------------------
+    # Auto-refresh
+    # ------------------------------------------------------------------
+
+    def _on_auto_toggled(self, checked: bool) -> None:
+        if checked:
+            self._timer.start()
+        else:
+            self._timer.stop()
+
+    # ------------------------------------------------------------------
+    # Data loading
+    # ------------------------------------------------------------------
+
+    def _load_statuses(
+        self,
+    ) -> Tuple[List[int], List[str], Dict[int, Dict[str, TaskStatus]]]:
+        """Return (sorted scan numbers, ordered analyzer IDs, scan→id→status map)."""
+        scan_map = read_day_statuses(
+            self._date_tag, base_directory=self._base_directory
+        )
+
+        # Merge any extra analyzer IDs found on disk into the column list.
+        known = set(self._analyzer_ids)
+        extra: List[str] = []
+        for by_id in scan_map.values():
+            for aid in by_id:
+                if aid not in known:
+                    extra.append(aid)
+                    known.add(aid)
+
+        return list(scan_map), list(self._analyzer_ids) + extra, scan_map
+
+    # ------------------------------------------------------------------
+    # Table population
+    # ------------------------------------------------------------------
+
+    def _refresh(self) -> None:
+        scan_numbers, analyzer_ids, scan_map = self._load_statuses()
+        self._populate_table(scan_numbers, analyzer_ids, scan_map)
+        self._update_summary(scan_numbers, analyzer_ids, scan_map)
+
+    def _populate_table(
+        self,
+        scan_numbers: List[int],
+        analyzer_ids: List[str],
+        scan_map: Dict[int, Dict[str, TaskStatus]],
+    ) -> None:
+        n_rows = len(scan_numbers)
+        n_cols = 1 + len(analyzer_ids)  # scan-number column + one per analyzer
+
+        self._table.setRowCount(n_rows)
+        self._table.setColumnCount(n_cols)
+
+        headers = ["Scan #"] + analyzer_ids
+        self._table.setHorizontalHeaderLabels(headers)
+
+        now = datetime.now(timezone.utc)
+
+        for row, scan_num in enumerate(scan_numbers):
+            # Scan number cell
+            num_item = QTableWidgetItem(str(scan_num))
+            num_item.setTextAlignment(Qt.AlignCenter)
+            self._table.setItem(row, 0, num_item)
+
+            by_id = scan_map.get(scan_num, {})
+            for col_offset, aid in enumerate(analyzer_ids):
+                status = by_id.get(aid)
+                item = self._make_cell(status, now)
+                self._table.setItem(row, 1 + col_offset, item)
+
+        self._table.resizeColumnsToContents()
+
+    @staticmethod
+    def _make_cell(status: Optional[TaskStatus], now: datetime) -> QTableWidgetItem:
+        if status is None:
+            colour, label = _DEFAULT_STYLE
+            tooltip = ""
+        else:
+            colour, label = _STATE_STYLE.get(status.state, _DEFAULT_STYLE)
+            tooltip = StatusDialog._build_tooltip(status, now)
+
+        item = QTableWidgetItem(label)
+        item.setTextAlignment(Qt.AlignCenter)
+        item.setBackground(colour)
+        if tooltip:
+            item.setToolTip(tooltip)
+        return item
+
+    @staticmethod
+    def _build_tooltip(status: TaskStatus, now: datetime) -> str:
+        if status.state == "failed" and status.error:
+            return f"Error: {status.error}"
+        if status.state == "claimed":
+            parts: List[str] = []
+            if status.claimed_by:
+                parts.append(f"Worker: {status.claimed_by}")
+            hb_str = status.last_heartbeat or status.claimed_at
+            if hb_str:
+                try:
+                    hb_dt = datetime.fromisoformat(hb_str)
+                    if hb_dt.tzinfo is None:
+                        hb_dt = hb_dt.replace(tzinfo=timezone.utc)
+                    elapsed = int((now - hb_dt).total_seconds())
+                    parts.append(f"Last heartbeat: {elapsed}s ago")
+                except Exception:
+                    pass
+            return "\n".join(parts)
+        return ""
+
+    # ------------------------------------------------------------------
+    # Summary label
+    # ------------------------------------------------------------------
+
+    def _update_summary(
+        self,
+        scan_numbers: List[int],
+        analyzer_ids: List[str],
+        scan_map: Dict[int, Dict[str, TaskStatus]],
+    ) -> None:
+        if not scan_numbers:
+            date_str = (
+                f"{self._date_tag.year:04d}-{self._date_tag.month:02d}"
+                f"-{self._date_tag.day:02d}"
+            )
+            self._label_summary.setText(f"No scans found for {date_str}")
+            return
+
+        counts: Dict[str, int] = {s: 0 for s in _STATE_STYLE}
+        total = 0
+        for scan_num in scan_numbers:
+            by_id = scan_map.get(scan_num, {})
+            for aid in analyzer_ids:
+                status = by_id.get(aid)
+                state = status.state if status else "queued"
+                total += 1
+                if state in counts:
+                    counts[state] += 1
+
+        parts = [f"{len(scan_numbers)} scan(s)"]
+        parts.append(f"{counts['done']}/{total} done")
+        if counts["claimed"]:
+            parts.append(f"{counts['claimed']} running")
+        if counts["failed"]:
+            parts.append(f"{counts['failed']} failed")
+        if counts["no_data"]:
+            parts.append(f"{counts['no_data']} no data")
+        if counts["queued"]:
+            parts.append(f"{counts['queued']} queued")
+
+        self._label_summary.setText("  |  ".join(parts))
+
+    # ------------------------------------------------------------------
+    # Cleanup
+    # ------------------------------------------------------------------
+
+    def closeEvent(self, event) -> None:
+        """Stop the auto-refresh timer before closing."""
+        self._timer.stop()
+        super().closeEvent(event)

--- a/ScanAnalysis/scan_analysis/analyzers/common/single_device_scan_analyzer.py
+++ b/ScanAnalysis/scan_analysis/analyzers/common/single_device_scan_analyzer.py
@@ -34,7 +34,7 @@ import pandas as pd
 import numpy as np
 
 # --- Local / Project Imports ---
-from scan_analysis.base import ScanAnalyzer
+from scan_analysis.base import DataUnavailableWarning, ScanAnalyzer
 
 # --- Type-Checking Imports ---
 if TYPE_CHECKING:
@@ -45,15 +45,6 @@ if TYPE_CHECKING:
 PRINT_TRACEBACK = True
 
 logger = logging.getLogger(__name__)
-
-
-class DataUnavailableWarning(Exception):
-    """Raised when a device's data directory is missing or empty for a scan.
-
-    This is an expected condition when an analyzer is configured for a device
-    that was not active during a particular scan.  It is caught separately from
-    unexpected errors so that a clean warning is logged without a traceback.
-    """
 
 
 # %% TypedDict Definitions
@@ -212,7 +203,7 @@ class SingleDeviceScanAnalyzer(ScanAnalyzer, ABC):
 
         except DataUnavailableWarning as e:
             logger.warning(str(e))
-            return None
+            raise
         except Exception as e:
             if PRINT_TRACEBACK:
                 print(traceback.format_exc())

--- a/ScanAnalysis/scan_analysis/base.py
+++ b/ScanAnalysis/scan_analysis/base.py
@@ -35,6 +35,16 @@ class DataLengthError(ValueError):
     pass
 
 
+class DataUnavailableWarning(Exception):
+    """Raised when a device's data directory is missing or empty for a scan.
+
+    This is an expected condition when an analyzer is configured for a device
+    that was not active during a particular scan.  It is caught separately from
+    unexpected errors so that a clean warning is logged without a traceback,
+    and the task queue records the state as ``no_data`` rather than ``failed``.
+    """
+
+
 class ScanParameter(NamedTuple):
     """Lightweight wrapper for scan parameter string with common renderings."""
 

--- a/ScanAnalysis/scan_analysis/live_task_runner.py
+++ b/ScanAnalysis/scan_analysis/live_task_runner.py
@@ -9,7 +9,6 @@ the highest-priority queued tasks.
 from __future__ import annotations
 
 import logging
-import re
 from pathlib import Path
 from queue import Queue
 from typing import Iterable, Optional
@@ -19,6 +18,7 @@ from geecs_data_utils.config_roots import image_analysis_config, scan_analysis_c
 from scan_analysis.gdoc_upload import resolve_document_id
 from scan_analysis.task_queue import (
     build_worklist,
+    extract_scan_number,
     init_status_for_scan,
     load_analyzers_from_config,
     reset_status_for_scan,
@@ -28,16 +28,6 @@ from watchdog.events import FileSystemEventHandler
 from watchdog.observers.polling import PollingObserver
 
 logger = logging.getLogger(__name__)
-
-SFILE_REGEX = re.compile(r"^s(?P<num>\d+)\.txt$", re.IGNORECASE)
-
-
-def extract_scan_number(filename: str) -> Optional[int]:
-    """Return scan number from an s-file name like s123.txt."""
-    m = SFILE_REGEX.match(filename)
-    if m:
-        return int(m["num"])
-    return None
 
 
 class AnalysisEventHandler(FileSystemEventHandler):

--- a/ScanAnalysis/scan_analysis/task_queue.py
+++ b/ScanAnalysis/scan_analysis/task_queue.py
@@ -6,13 +6,14 @@ Single-app assumptions:
 - Per-scan status files stored under `<scan_folder>/analysis_status/<analyzer_id>.yaml`.
 - Worklist sorted by (priority, scan_number).
 
-States: queued -> claimed -> done/failed.
+States: queued -> claimed -> done/failed/no_data.
 """
 
 from __future__ import annotations
 
 import logging
 import os
+import re
 import socket
 import tempfile
 import threading
@@ -24,6 +25,7 @@ from typing import Dict, Iterable, List, Optional
 import yaml
 
 from geecs_data_utils import ScanPaths, ScanTag
+from scan_analysis.base import DataUnavailableWarning
 from scan_analysis.config.analyzer_factory import create_analyzer
 from scan_analysis.config.config_loader import load_experiment_config
 from scan_analysis.gdoc_upload import upload_links_to_gdoc, upload_summary_to_gdoc
@@ -33,6 +35,14 @@ logger = logging.getLogger(__name__)
 STATUS_DIR_NAME = "analysis_status"
 HEARTBEAT_INTERVAL_SECONDS = 30
 CLAIM_STALE_AFTER_SECONDS = 180
+
+SFILE_REGEX = re.compile(r"^s(?P<num>\d+)\.txt$", re.IGNORECASE)
+
+
+def extract_scan_number(filename: str) -> Optional[int]:
+    """Return scan number from an s-file name like ``s123.txt``, or None."""
+    m = SFILE_REGEX.match(filename)
+    return int(m["num"]) if m else None
 
 
 @dataclass
@@ -176,6 +186,74 @@ def read_statuses(scan_folder: Path) -> List[TaskStatus]:
         except Exception as exc:  # pragma: no cover - log and skip
             logger.warning("Failed to read status %s: %s", f, exc)
     return statuses
+
+
+def read_day_statuses(
+    date_tag: ScanTag,
+    *,
+    base_directory: Optional[Path] = None,
+) -> Dict[int, Dict[str, "TaskStatus"]]:
+    """Return all task statuses for every scan discovered on a given day.
+
+    Scans are discovered by looking for s-files under the day's ``analysis/``
+    folder (the same folder that :class:`~scan_analysis.live_task_runner.LiveTaskRunner`
+    watches).
+
+    Parameters
+    ----------
+    date_tag : ScanTag
+        Identifies the experiment and date to inspect.  The ``number`` field
+        is ignored — all scans for the day are returned.
+    base_directory : Path, optional
+        Root data directory; ``None`` defers to the configured default.
+
+    Returns
+    -------
+    dict[int, dict[str, TaskStatus]]
+        ``{scan_number: {analyzer_id: TaskStatus}}`` sorted by scan number.
+    """
+    scan_map: Dict[int, Dict[str, TaskStatus]] = {}
+
+    try:
+        daily_scans = ScanPaths.get_daily_scan_folder(
+            tag=date_tag, base_directory=base_directory
+        )
+        scan_root = daily_scans.parent / "analysis"
+    except Exception as exc:
+        logger.warning("read_day_statuses: could not resolve scan root: %s", exc)
+        return scan_map
+
+    if not scan_root.exists():
+        return scan_map
+
+    for f in scan_root.iterdir():
+        if not f.is_file():
+            continue
+        num = extract_scan_number(f.name)
+        if num is None:
+            continue
+
+        tag = ScanTag(
+            year=date_tag.year,
+            month=date_tag.month,
+            day=date_tag.day,
+            number=num,
+            experiment=date_tag.experiment,
+        )
+        try:
+            scan_folder = ScanPaths.get_scan_folder_path(
+                tag=tag, base_directory=base_directory
+            )
+            statuses = read_statuses(scan_folder)
+        except Exception as exc:
+            logger.warning(
+                "read_day_statuses: could not read statuses for scan %d: %s", num, exc
+            )
+            statuses = []
+
+        scan_map[num] = {s.analyzer_id: s for s in statuses}
+
+    return dict(sorted(scan_map.items()))
 
 
 def update_status(
@@ -444,6 +522,21 @@ def run_worklist(
                         display_files=display_files,
                         document_id=document_id,
                     )
+        except DataUnavailableWarning:
+            # Device did not record data for this scan — expected, not an error.
+            stop_event.set()
+            hb_thread.join(timeout=HEARTBEAT_INTERVAL_SECONDS)
+            update_status(
+                scan_folder,
+                analyzer_id,
+                priority=priority,
+                state="no_data",
+                error=None,
+                claimed_by=None,
+                claimed_at=None,
+                last_heartbeat=None,
+            )
+            logger.info("run_worklist: no_data scan=%s analyzer=%s", tag, analyzer_id)
         except Exception as exc:  # pragma: no cover - log failure and continue
             logger.exception("Analyzer %s failed on %s: %s", analyzer_id, tag, exc)
             stop_event.set()


### PR DESCRIPTION
## Human Summary

Added some library code collect the current status of all running analyzers. Added a button and dialog window that displays and auto updates these statuses like below:
<img width="1102" height="501" alt="image" src="https://github.com/user-attachments/assets/8d8e2ed9-ad7f-4823-9590-09563b15b70a" />

Added new status of 'no data' rather than just flag 'no data' scans as 'done'

## AI Summary

- New `no_data` task state for analyzers that ran cleanly but found no device data (diagnostic wasn't active for that scan) — distinct from `failed`, which signals a real error
- `read_day_statuses()` added to `task_queue`: returns `{scan_number: {analyzer_id: TaskStatus}}` for a full day, usable by notebooks and CLI tools without touching the runner
- `extract_scan_number()` moved from `live_task_runner` to `task_queue` where it logically belongs
- Modeless status overview dialog in the LiveWatch GUI — a scan × analyzer grid openable at any time via a new "Status…" button, including while the runner is active

## Backend details

`DataUnavailableWarning` was previously swallowed inside `_run_analysis_core()` and returned `None`, which was indistinguishable from a successful run with no display files. It is now re-raised (after logging) so `run_worklist()` can catch it specifically and write `state=no_data`. The broad `except Exception` path still writes `state=failed` as before. `DataUnavailableWarning` was also moved from `single_device_scan_analyzer` to `base.py` so `task_queue` can import it without depending on the analyzer layer.

## Status dialog

One row per scan discovered for the selected day, one column per analyzer from the loaded config. Cells are colour-coded by state (done=green, failed=salmon, claimed=gold, no_data=steel-blue, queued=gray). Failed cells show the error message as a tooltip; claimed cells show the worker host and time since last heartbeat. A summary line shows counts per state. Manual refresh button and optional 10-second auto-refresh. All scan discovery and status reading is handled by `read_day_statuses()` in `task_queue` — no filesystem logic in the GUI layer.

## Test plan

- [x] Open Status dialog on a day with completed scans; verify grid populates correctly
- [x] Confirm a diagnostic that was off during a scan shows `no data` (not `failed` or `done`)
- [x] Confirm a misconfigured analyzer still shows `failed`
- [x] Open dialog while runner is active; verify auto-refresh updates `claimed` → `done` as tasks finish
- [x] Change date in main window, re-click Status…, verify dialog refreshes to new day

🤖 Generated with [Claude Code](https://claude.com/claude-code)