### PR TITLE
feat: enable auto-refresh by default in StatusDialog

### DIFF
--- a/ScanAnalysis/LiveWatchGUI/status_dialog.py
+++ b/ScanAnalysis/LiveWatchGUI/status_dialog.py
@@ -82,6 +82,7 @@ class StatusDialog(QDialog):
         self._timer.timeout.connect(self._refresh)
 
         self._build_ui()
+        self._check_auto.setChecked(True)
         self._refresh()
 
     # ------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Auto-refresh checkbox in the Analysis Status dialog is now checked by default when the dialog opens
- The 10-second refresh timer starts immediately without requiring the user to manually enable it
- Users can still uncheck the box to disable auto-refresh; the manual Refresh button is unchanged

## Test plan
- [ ] Open livewatch, click "Status…" — verify the Auto-refresh checkbox is pre-checked and the grid refreshes every ~10 s
- [ ] Uncheck Auto-refresh — verify the timer stops (grid no longer updates automatically)
- [ ] Click Refresh manually — verify it still triggers an immediate refresh regardless of checkbox state
- [ ] Close and reopen the dialog — verify it opens with auto-refresh enabled again

Closes #[issue number]

🤖 Generated with [Claude Code](https://claude.com/claude-code)