### PR TITLE
fix: default Standard1DAnalyzer to ThreadPoolExecutor to avoid BrokenProcessPool

### DIFF
--- a/ImageAnalysis/image_analysis/offline_analyzers/line_stitcher.py
+++ b/ImageAnalysis/image_analysis/offline_analyzers/line_stitcher.py
@@ -41,12 +41,6 @@ class LineStitcher(LineAnalyzer):
         Passed through to LineAnalyzer for metric naming.
     """
 
-    # Threads avoid spawning subprocesses that re-import matplotlib and crash
-    # in GUI contexts where no QApplication exists in the worker process.
-    # Threads also share instance state, so load_image's write to
-    # self._device_in_filename is visible to analyze_image on the same shot.
-    run_analyze_image_asynchronously = True
-
     def __init__(
         self,
         line_config_name: str,

--- a/ImageAnalysis/image_analysis/offline_analyzers/line_stitcher.py
+++ b/ImageAnalysis/image_analysis/offline_analyzers/line_stitcher.py
@@ -41,6 +41,12 @@ class LineStitcher(LineAnalyzer):
         Passed through to LineAnalyzer for metric naming.
     """
 
+    # Threads avoid spawning subprocesses that re-import matplotlib and crash
+    # in GUI contexts where no QApplication exists in the worker process.
+    # Threads also share instance state, so load_image's write to
+    # self._device_in_filename is visible to analyze_image on the same shot.
+    run_analyze_image_asynchronously = True
+
     def __init__(
         self,
         line_config_name: str,

--- a/ImageAnalysis/image_analysis/offline_analyzers/standard_1d_analyzer.py
+++ b/ImageAnalysis/image_analysis/offline_analyzers/standard_1d_analyzer.py
@@ -64,7 +64,6 @@ class Standard1DAnalyzer(ImageAnalyzer):
 
         # Store analyzer state
         self.line_config_name = line_config_name
-        self.run_analyze_image_asynchronously = False
 
         # Storage for metadata from read_1d_data
         self.data_metadata: Optional[Dict[str, str]] = None

--- a/ImageAnalysis/image_analysis/offline_analyzers/standard_1d_analyzer.py
+++ b/ImageAnalysis/image_analysis/offline_analyzers/standard_1d_analyzer.py
@@ -53,6 +53,9 @@ class Standard1DAnalyzer(ImageAnalyzer):
         line_config_name: str,
     ):
         """Initialize the standard 1D analyzer with external configuration."""
+        # Initialize base class first so any defaults it sets can be overridden below.
+        super().__init__()
+
         # Load line configuration
         try:
             self.line_config = load_line_config(line_config_name)
@@ -64,12 +67,10 @@ class Standard1DAnalyzer(ImageAnalyzer):
 
         # Store analyzer state
         self.line_config_name = line_config_name
+        self.run_analyze_image_asynchronously = True
 
         # Storage for metadata from read_1d_data
         self.data_metadata: Optional[Dict[str, str]] = None
-
-        # Initialize base class
-        super().__init__()
 
     def load_image(self, file_path: Path) -> Array1D:
         """Load 1D data from file using configured data loader.


### PR DESCRIPTION
## Summary
- Moves `super().__init__()` to the top of `Standard1DAnalyzer.__init__()` so base-class defaults are set before instance attributes, not after
- Changes `self.run_analyze_image_asynchronously` default from `False` to `True`, making all `Standard1DAnalyzer` subclasses (including `LineStitcher`) use `ThreadPoolExecutor` by default

## Why
`ProcessPoolExecutor` spawns fresh subprocesses on Windows that must re-import `matplotlib.pyplot` (module-level import in `standard_1d_analyzer.py`). Without a `QApplication` in the worker process, matplotlib crashes on backend initialization, causing workers to terminate abruptly — the `BrokenProcessPool` error seen in livewatch.

`ThreadPoolExecutor` shares the parent process's already-initialized environment, avoiding the crash. It is also appropriate for `Standard1DAnalyzer`'s workload (I/O-bound file reads + numpy ops that release the GIL).

Moving `super().__init__()` first is the correct pattern: base-class defaults should be established before subclass values override them, not after.

Closes #341

## Test plan
- [ ] CI pre-commit checks pass
- [ ] Deploy to livewatch server and run one HTT MagSpec scan
- [ ] Confirm livewatch log shows `Using ThreadPoolExecutor` for the stitcher task
- [ ] Confirm `HTT-C23_MagSpecAnalysis/` directory is created with stitched TSV files
- [ ] Confirm stitcher task shows `done` in the status dialog

🤖 Generated with [Claude Code](https://claude.com/claude-code)