### PR TITLE
fix: handle null SHA on first push of a new branch in pre-commit CI

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -23,4 +23,8 @@ jobs:
           if [ -z "$FROM_REF" ]; then
             FROM_REF="${{ github.event.before }}"
           fi
+          # First push of a new branch has a null SHA for before — fall back to merge-base with default branch.
+          if [ "$FROM_REF" = "0000000000000000000000000000000000000000" ]; then
+            FROM_REF=$(git merge-base HEAD origin/master 2>/dev/null || git merge-base HEAD origin/main 2>/dev/null || git rev-parse HEAD^)
+          fi
           pre-commit run --from-ref "$FROM_REF" --to-ref "${{ github.sha }}" --show-diff-on-failure --color always


### PR DESCRIPTION
## Summary
- Adds a null-SHA guard to the pre-commit workflow so the first push of any new branch no longer fails

## Problem
When a branch is pushed for the first time, `github.event.before` is `0000000000000000000000000000000000000000` (the null SHA). Passing this to `pre-commit run --from-ref` causes `git diff` to fail with `fatal: Invalid revision range`, which exits with code 3 and marks the check as failed — even though the code itself is fine.

This was observed on PRs #340 and #343, where the first push run always failed and the PR-triggered run always passed.

## Fix
After falling back to `github.event.before`, check if it's the null SHA. If so, resolve the merge-base with `origin/master` (falling back to `origin/main`, then `HEAD^`) so pre-commit runs only on the commits that are new to the branch.

## Test plan
- [ ] Merge this PR
- [ ] Open a new branch, push a single commit, and confirm the first push CI run passes (not just the PR-triggered run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)