### PR TITLE
chore: add Claude Code project config

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,5 @@
+{
+  "permissions": {
+    "defaultMode": "acceptEdits"
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,11 @@ GEECS-Scanner-GUI/xopt optimizer tests.ipynb
 GEECS-Scanner-GUI/testing.ipynb
 
 # -----------------------------
+# Claude Code
+# -----------------------------
+.claude/settings.local.json
+
+# -----------------------------
 # Editors / OS files
 # -----------------------------
 .DS_Store


### PR DESCRIPTION
## Summary

- Adds `.claude/settings.json` with `defaultMode: acceptEdits` so contributors using Claude Code get file edits auto-approved without constant prompts
- Gitignores `.claude/settings.local.json` so personal/local overrides (e.g. stronger permission modes) stay out of the repo

## Notes

`.claude/settings.local.json` is the right place for personal Claude Code overrides (not committed). The committed `settings.json` is intentionally conservative — safe for any contributor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)