### PR TITLE
fix: beam position stats in full-image coordinates; clamp oversized ROI

### DIFF
--- a/ImageAnalysis/image_analysis/algorithms/basic_beam_stats.py
+++ b/ImageAnalysis/image_analysis/algorithms/basic_beam_stats.py
@@ -10,7 +10,7 @@ such as :mod:`image_analysis.algorithms.beam_slopes`.
 
 from __future__ import annotations
 
-from typing import NamedTuple, Optional, Set, Union
+from typing import NamedTuple, Optional, Set, Tuple, Union
 import logging
 
 import numpy as np
@@ -97,20 +97,23 @@ def _antidiag_projection(img: np.ndarray) -> np.ndarray:
     return np.array([np.diag(flipped, k=k).sum() for k in range(-(h - 1), w)])
 
 
-def _projection_to_line_data(projection: np.ndarray) -> np.ndarray:
+def _projection_to_line_data(projection: np.ndarray, offset: int = 0) -> np.ndarray:
     """Convert a 1D projection array to Nx2 format for LineBasicStats.
 
     Parameters
     ----------
     projection : np.ndarray
         1D projection array
+    offset : int
+        Coordinate of the first element in the projection within the parent
+        (full-image) coordinate system.  Defaults to 0 (no offset).
 
     Returns
     -------
     np.ndarray
-        Nx2 array where column 0 is index coordinates and column 1 is projection values
+        Nx2 array where column 0 is coordinates and column 1 is projection values
     """
-    x_coords = np.arange(len(projection))
+    x_coords = np.arange(len(projection)) + offset
     return np.column_stack([x_coords, projection])
 
 
@@ -135,16 +138,30 @@ def _line_stats_to_projection_stats(line_stats: LineBasicStats) -> ProjectionSta
     )
 
 
-def beam_profile_stats(img: np.ndarray) -> BeamStats:
+def beam_profile_stats(
+    img: np.ndarray,
+    roi_offset: Tuple[int, int] = (0, 0),
+) -> BeamStats:
     """Compute basic beam profile statistics from a 2-D image.
 
     Computes projection statistics (CoM, rms, fwhm, peak_location) along
     four axes (x, y, x_45, y_45) and image-level totals (total, peak_value).
 
+    Position statistics (CoM, peak_location) along the x and y axes are
+    expressed in the coordinate system of the *parent* image when
+    ``roi_offset`` is supplied.  Width statistics (rms, fwhm) are unaffected
+    by the offset.  The 45° diagonal projections are always in local
+    (cropped-image) index space.
+
     Parameters
     ----------
     img : np.ndarray
-        2D image array
+        2D image array (may already be ROI-cropped).
+    roi_offset : tuple of int, optional
+        ``(x_offset, y_offset)`` — pixel coordinate of the top-left corner of
+        ``img`` within the full sensor frame.  Use ``(roi.x_min, roi.y_min)``
+        when ``img`` is the result of an ROI crop.  Defaults to ``(0, 0)``
+        (no offset — stats are in the local frame).
 
     Returns
     -------
@@ -164,15 +181,22 @@ def beam_profile_stats(img: np.ndarray) -> BeamStats:
             image=nan_img, x=nan_proj, y=nan_proj, x_45=nan_proj, y_45=nan_proj
         )
 
-    # Standard x/y projections
+    x_offset, y_offset = roi_offset
+
+    # Standard x/y projections — offset coordinates so stats are in the
+    # full-image (global) coordinate system.
     x_stats = _line_stats_to_projection_stats(
-        LineBasicStats(line_data=_projection_to_line_data(img.sum(axis=0)))
+        LineBasicStats(
+            line_data=_projection_to_line_data(img.sum(axis=0), offset=x_offset)
+        )
     )
     y_stats = _line_stats_to_projection_stats(
-        LineBasicStats(line_data=_projection_to_line_data(img.sum(axis=1)))
+        LineBasicStats(
+            line_data=_projection_to_line_data(img.sum(axis=1), offset=y_offset)
+        )
     )
 
-    # 45° projections
+    # 45° projections — diagonal index space; no simple global offset applies.
     x45_stats = _line_stats_to_projection_stats(
         LineBasicStats(line_data=_projection_to_line_data(_diag_projection(img)))
     )

--- a/ImageAnalysis/image_analysis/offline_analyzers/beam_analyzer.py
+++ b/ImageAnalysis/image_analysis/offline_analyzers/beam_analyzer.py
@@ -150,8 +150,14 @@ class BeamAnalyzer(StandardAnalyzer):
 
         processed_image = initial_result.processed_image
 
+        # Position stats are expressed in the full-image coordinate system by
+        # passing the ROI origin offset so that CoM and peak_location reflect
+        # the beam position on the sensor, not within the cropped sub-region.
+        roi = self.camera_config.roi
+        roi_offset = (roi.x_min, roi.y_min) if roi is not None else (0, 0)
+
         # Always: basic beam stats (projections along x, y, x_45, y_45)
-        beam_stats = beam_profile_stats(processed_image)
+        beam_stats = beam_profile_stats(processed_image, roi_offset=roi_offset)
         scalars = flatten_beam_stats(
             beam_stats,
             prefix=self.camera_config.name,

--- a/ImageAnalysis/image_analysis/processing/array2d/masking.py
+++ b/ImageAnalysis/image_analysis/processing/array2d/masking.py
@@ -149,6 +149,12 @@ def apply_roi_cropping(image: Array2D, config: ROIConfig) -> Array2D:
     """
     Crop image to specified region of interest.
 
+    If the configured ROI extends beyond the actual image dimensions the
+    boundaries are clamped to the image size and a warning is logged.  This
+    avoids hard failures when a config written for a larger sensor is applied
+    to a smaller image (e.g. binned or test data).  If after clamping the ROI
+    has zero area, the full image is returned.
+
     Parameters
     ----------
     image : Array2D
@@ -161,28 +167,40 @@ def apply_roi_cropping(image: Array2D, config: ROIConfig) -> Array2D:
     Array2D
         Cropped image containing only the specified ROI.
 
-    Raises
-    ------
-    ValueError
-        If ROI boundaries are outside image dimensions.
-
     """
     height, width = image.shape
 
-    # Validate ROI boundaries
-    if config.x_min < 0 or config.x_max > width:
-        raise ValueError(
-            f"X boundaries [{config.x_min}, {config.x_max}] outside image width {width}"
-        )
-    if config.y_min < 0 or config.y_max > height:
-        raise ValueError(
-            f"Y boundaries [{config.y_min}, {config.y_max}] outside image height {height}"
+    x_min = max(0, config.x_min)
+    x_max = min(width, config.x_max)
+    y_min = max(0, config.y_min)
+    y_max = min(height, config.y_max)
+
+    if (
+        x_min != config.x_min
+        or x_max != config.x_max
+        or y_min != config.y_min
+        or y_max != config.y_max
+    ):
+        logger.warning(
+            "ROI [x=%d:%d, y=%d:%d] exceeds image dimensions (%dx%d); "
+            "clamped to [x=%d:%d, y=%d:%d].",
+            config.x_min,
+            config.x_max,
+            config.y_min,
+            config.y_max,
+            width,
+            height,
+            x_min,
+            x_max,
+            y_min,
+            y_max,
         )
 
-    # Crop the image
-    cropped_image = image[config.y_min : config.y_max, config.x_min : config.x_max]
+    if x_min >= x_max or y_min >= y_max:
+        logger.warning("Clamped ROI has zero area; returning full image.")
+        return image.copy()
 
-    return cropped_image
+    return image[y_min:y_max, x_min:x_max]
 
 
 def apply_circular_mask(image: Array2D, config: CircularMaskConfig) -> Array2D:

--- a/ImageAnalysis/tests/analyzers/test_beam_analyzer.py
+++ b/ImageAnalysis/tests/analyzers/test_beam_analyzer.py
@@ -12,6 +12,7 @@ from image_analysis.offline_analyzers.beam_analyzer import BeamAnalyzer
 from image_analysis.processing.array2d.config_models import (
     BackgroundConfig,
     CameraConfig,
+    ROIConfig,
 )
 from image_analysis.tools.synthetic_generators import gaussian_beam_2d
 
@@ -133,6 +134,80 @@ class TestBeamAnalyzerResult:
         result = analyzer.analyze_image(img)
         assert "horizontal_projection" in result.render_data
         assert "vertical_projection" in result.render_data
+
+
+class TestBeamAnalyzerROICoordinates:
+    """CoM and peak_location are expressed in full-image coordinates when ROI is set."""
+
+    def test_roi_offset_applied_to_x_com(self):
+        """x_CoM reflects the beam position in the full sensor frame, not the crop."""
+        # Beam centred at global pixel (col=120, row=80) in a 200x200 image
+        global_col, global_row = 120, 80
+        img = gaussian_beam_2d(
+            shape=(200, 200), center=(global_row, global_col), sigma=(8.0, 8.0), seed=10
+        )
+
+        # ROI that contains the beam; origin at (x_min=100, y_min=60)
+        roi = ROIConfig(x_min=100, x_max=200, y_min=60, y_max=140)
+        config = CameraConfig(name="roi_cam", bit_depth=16, roi=roi)
+        analyzer = BeamAnalyzer(config)
+        result = analyzer.analyze_image(img)
+
+        # CoM should be close to the global position, not local (20, 20)
+        assert abs(result.scalars["roi_cam_x_CoM"] - global_col) < 1.5
+        assert abs(result.scalars["roi_cam_y_CoM"] - global_row) < 1.5
+
+    def test_roi_offset_not_applied_without_roi(self):
+        """Without ROI, CoM is in the full-image frame (offset is trivially 0)."""
+        global_col, global_row = 64, 64
+        img = gaussian_beam_2d(
+            shape=(128, 128), center=(global_row, global_col), sigma=(8.0, 8.0), seed=11
+        )
+        config = CameraConfig(name="no_roi_cam", bit_depth=16)
+        analyzer = BeamAnalyzer(config)
+        result = analyzer.analyze_image(img)
+
+        assert abs(result.scalars["no_roi_cam_x_CoM"] - global_col) < 1.5
+        assert abs(result.scalars["no_roi_cam_y_CoM"] - global_row) < 1.5
+
+    def test_roi_width_stats_unchanged_by_offset(self):
+        """rms and fwhm are identical with or without a non-zero ROI origin."""
+        img = gaussian_beam_2d(
+            shape=(100, 100), center=(50.0, 50.0), sigma=(6.0, 6.0), seed=12
+        )
+
+        # No ROI — full image
+        cfg_full = CameraConfig(name="full", bit_depth=16)
+        result_full = BeamAnalyzer(cfg_full).analyze_image(img)
+
+        # ROI that covers the same area but with a non-zero origin
+        # (by putting the beam inside a larger image with an offset ROI)
+        img_large = gaussian_beam_2d(
+            shape=(200, 200), center=(150.0, 150.0), sigma=(6.0, 6.0), seed=12
+        )
+        roi = ROIConfig(x_min=100, x_max=200, y_min=100, y_max=200)
+        cfg_roi = CameraConfig(name="roi", bit_depth=16, roi=roi)
+        result_roi = BeamAnalyzer(cfg_roi).analyze_image(img_large)
+
+        assert result_roi.scalars["roi_x_rms"] == pytest.approx(
+            result_full.scalars["full_x_rms"], rel=0.01
+        )
+        assert result_roi.scalars["roi_y_rms"] == pytest.approx(
+            result_full.scalars["full_y_rms"], rel=0.01
+        )
+
+    def test_oversized_roi_is_clamped_not_raised(self):
+        """BeamAnalyzer does not raise when the configured ROI exceeds the image."""
+        img = gaussian_beam_2d(shape=(50, 50), center=(25.0, 25.0), seed=13)
+
+        # ROI claims a 200x200 region on a 50x50 image — should be clamped
+        roi = ROIConfig(x_min=0, x_max=200, y_min=0, y_max=200)
+        config = CameraConfig(name="big_roi_cam", bit_depth=16, roi=roi)
+        analyzer = BeamAnalyzer(config)
+
+        result = analyzer.analyze_image(img)  # must not raise
+        assert result.processed_image is not None
+        assert result.processed_image.shape == (50, 50)  # clamped to actual image
 
 
 class TestBeamAnalyzerUpdateConfig:

--- a/ImageAnalysis/tests/processing/test_masking.py
+++ b/ImageAnalysis/tests/processing/test_masking.py
@@ -38,6 +38,54 @@ class TestROICropping:
         result = apply_roi_cropping(image, config)
         assert np.array_equal(result, image)
 
+    # ------------------------------------------------------------------
+    # Clamping: ROI larger than actual image
+    # ------------------------------------------------------------------
+
+    def test_clamps_x_max_to_image_width(self):
+        """ROI x_max beyond image width is clamped; no exception raised."""
+        image = np.ones((10, 10), dtype=np.float64)
+        # x_max=20 exceeds width=10
+        config = ROIConfig(x_min=0, x_max=20, y_min=0, y_max=5)
+        result = apply_roi_cropping(image, config)
+        assert result.shape == (5, 10)  # clamped to full width
+
+    def test_clamps_y_max_to_image_height(self):
+        """ROI y_max beyond image height is clamped; no exception raised."""
+        image = np.ones((10, 10), dtype=np.float64)
+        config = ROIConfig(x_min=0, x_max=5, y_min=0, y_max=20)
+        result = apply_roi_cropping(image, config)
+        assert result.shape == (10, 5)  # clamped to full height
+
+    def test_clamped_result_contains_correct_pixels(self):
+        """After clamping the returned data matches the valid sub-region."""
+        image = np.arange(100, dtype=np.float64).reshape(10, 10)
+        # x_max=15 clamped to 10, y_max=15 clamped to 10
+        config = ROIConfig(x_min=2, x_max=15, y_min=3, y_max=15)
+        result = apply_roi_cropping(image, config)
+        expected = image[3:10, 2:10]
+        assert np.array_equal(result, expected)
+
+    def test_clamp_emits_warning(self, caplog):
+        """A logger warning is emitted when the ROI is clamped."""
+        import logging
+
+        image = np.ones((10, 10), dtype=np.float64)
+        config = ROIConfig(x_min=0, x_max=20, y_min=0, y_max=5)
+        with caplog.at_level(
+            logging.WARNING, logger="image_analysis.processing.array2d.masking"
+        ):
+            apply_roi_cropping(image, config)
+        assert any("clamped" in record.message.lower() for record in caplog.records)
+
+    def test_zero_area_after_clamp_returns_full_image(self):
+        """When clamping leaves a zero-area ROI, the full image is returned."""
+        image = np.arange(100, dtype=np.float64).reshape(10, 10)
+        # x_min=15 clamped to 15, x_max=20 clamped to 10 → x_min >= x_max → zero area
+        config = ROIConfig(x_min=15, x_max=20, y_min=0, y_max=5)
+        result = apply_roi_cropping(image, config)
+        assert result.shape == image.shape
+
 
 class TestCircularMask:
     """Tests for apply_circular_mask().

--- a/ImageAnalysis/tests/tools/test_basic_beam_stats.py
+++ b/ImageAnalysis/tests/tools/test_basic_beam_stats.py
@@ -121,5 +121,86 @@ def test_flatten_beam_stats_include_empty_set():
     assert flat == {}
 
 
+# ---------------------------------------------------------------------------
+# roi_offset parameter in beam_profile_stats
+# ---------------------------------------------------------------------------
+
+
+class TestBeamProfileStatsROIOffset:
+    """Position stats shift by the ROI offset; width stats are unaffected."""
+
+    def _single_pixel_image(self, shape=(20, 30), hot_row=10, hot_col=15):
+        """Image with a single bright pixel at (hot_row, hot_col)."""
+        img = np.zeros(shape, dtype=float)
+        img[hot_row, hot_col] = 1.0
+        return img
+
+    def test_default_offset_is_zero(self):
+        """beam_profile_stats() with no roi_offset equals (0, 0)."""
+        img = self._single_pixel_image(hot_row=5, hot_col=8)
+        stats_default = bbs.beam_profile_stats(img)
+        stats_zero = bbs.beam_profile_stats(img, roi_offset=(0, 0))
+        assert stats_default.x.CoM == pytest.approx(stats_zero.x.CoM)
+        assert stats_default.y.CoM == pytest.approx(stats_zero.y.CoM)
+
+    def test_x_offset_shifts_x_com(self):
+        """x_CoM increases by x_offset when roi_offset is applied."""
+        img = self._single_pixel_image(hot_row=5, hot_col=8)
+        x_offset = 100
+        stats_local = bbs.beam_profile_stats(img)
+        stats_global = bbs.beam_profile_stats(img, roi_offset=(x_offset, 0))
+        assert stats_global.x.CoM == pytest.approx(stats_local.x.CoM + x_offset)
+
+    def test_y_offset_shifts_y_com(self):
+        """y_CoM increases by y_offset when roi_offset is applied."""
+        img = self._single_pixel_image(hot_row=5, hot_col=8)
+        y_offset = 50
+        stats_local = bbs.beam_profile_stats(img)
+        stats_global = bbs.beam_profile_stats(img, roi_offset=(0, y_offset))
+        assert stats_global.y.CoM == pytest.approx(stats_local.y.CoM + y_offset)
+
+    def test_x_offset_shifts_peak_location(self):
+        """x peak_location is also shifted by x_offset."""
+        img = self._single_pixel_image(hot_row=5, hot_col=8)
+        x_offset = 37
+        stats_local = bbs.beam_profile_stats(img)
+        stats_global = bbs.beam_profile_stats(img, roi_offset=(x_offset, 0))
+        assert stats_global.x.peak_location == pytest.approx(
+            stats_local.x.peak_location + x_offset
+        )
+
+    def test_offset_does_not_affect_rms(self):
+        """rms (beam width) is independent of ROI position offset."""
+        img = np.zeros((40, 60), dtype=float)
+        # Broad Gaussian-like profile — use a real 2D image
+        from image_analysis.tools.synthetic_generators import gaussian_beam_2d
+
+        img = gaussian_beam_2d(shape=(40, 60), center=(20.0, 30.0), seed=7)
+        stats_no_offset = bbs.beam_profile_stats(img)
+        stats_offset = bbs.beam_profile_stats(img, roi_offset=(200, 300))
+        assert stats_offset.x.rms == pytest.approx(stats_no_offset.x.rms, rel=1e-9)
+        assert stats_offset.y.rms == pytest.approx(stats_no_offset.y.rms, rel=1e-9)
+
+    def test_offset_does_not_affect_fwhm(self):
+        """fwhm (beam width) is independent of ROI position offset."""
+        from image_analysis.tools.synthetic_generators import gaussian_beam_2d
+
+        img = gaussian_beam_2d(shape=(40, 60), center=(20.0, 30.0), seed=8)
+        stats_no_offset = bbs.beam_profile_stats(img)
+        stats_offset = bbs.beam_profile_stats(img, roi_offset=(500, 100))
+        assert stats_offset.x.fwhm == pytest.approx(stats_no_offset.x.fwhm, rel=1e-9)
+        assert stats_offset.y.fwhm == pytest.approx(stats_no_offset.y.fwhm, rel=1e-9)
+
+    def test_image_stats_unaffected_by_offset(self):
+        """Total intensity and peak value are not changed by roi_offset."""
+        img = self._single_pixel_image(hot_row=3, hot_col=12)
+        stats_local = bbs.beam_profile_stats(img)
+        stats_global = bbs.beam_profile_stats(img, roi_offset=(99, 77))
+        assert stats_global.image.total == pytest.approx(stats_local.image.total)
+        assert stats_global.image.peak_value == pytest.approx(
+            stats_local.image.peak_value
+        )
+
+
 if __name__ == "__main__":
     pytest.main()


### PR DESCRIPTION
## Summary

- **CoM coordinate correction**: `beam_profile_stats` now accepts `roi_offset=(x_min, y_min)`. When a `BeamAnalyzer` has an ROI configured, it passes `(roi.x_min, roi.y_min)` so that `x_CoM`, `y_CoM`, and `peak_location` are expressed in the full sensor coordinate system instead of the local cropped-image frame. Width stats (`rms`, `fwhm`) are invariant to this shift. The 45° diagonal stats remain in local index space (no simple global mapping applies there).
- **ROI clamping**: `apply_roi_cropping` no longer raises `ValueError` when the configured ROI extends beyond the actual image. Instead it clamps to valid bounds and logs a `WARNING`. If the clamped ROI has zero area, the full image is returned. This is the correct fallback when a config written for a larger sensor is run against smaller/test images.

## What changed

| File | Change |
|---|---|
| `image_analysis/processing/array2d/masking.py` | Clamp+warn instead of raise in `apply_roi_cropping` |
| `image_analysis/algorithms/basic_beam_stats.py` | Add `roi_offset` param to `beam_profile_stats`; apply to x/y projections |
| `image_analysis/offline_analyzers/beam_analyzer.py` | Extract ROI offset from config and pass to `beam_profile_stats` |
| `tests/processing/test_masking.py` | 5 new clamping tests |
| `tests/tools/test_basic_beam_stats.py` | 7 new ROI-offset tests |
| `tests/analyzers/test_beam_analyzer.py` | 4 new end-to-end coordinate tests |

## Test plan

- [x] `poetry run pytest ImageAnalysis/tests/ -q` — 154 passed, 0 failures
- [x] Pre-commit hooks (ruff, ruff-format, pydocstyle) — all pass
- [x] `test_roi_offset_applied_to_x_com`: beam at global col=120 with ROI x_min=100 → x_CoM ≈ 120 ✓ (was ≈ 20)
- [x] `test_oversized_roi_is_clamped_not_raised`: ROI 200×200 on 50×50 image → no exception ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)