### PR TITLE
chore: bump image-analysis to 1.1.2

### DIFF
--- a/ImageAnalysis/CHANGELOG.md
+++ b/ImageAnalysis/CHANGELOG.md
@@ -3,6 +3,19 @@
 All notable changes to this package will be documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [1.1.2] — 2026-05-06
+
+### Fixed
+- `BeamAnalyzer` now reports `x_CoM`, `y_CoM`, and `peak_location` in the
+  full-sensor coordinate system rather than in the ROI-local frame.
+  `beam_profile_stats` gains an `roi_offset` parameter; `BeamAnalyzer`
+  passes `(roi.x_min, roi.y_min)` automatically when an ROI is configured.
+  Width stats (`rms`, `fwhm`) are unaffected by the offset.
+- `apply_roi_cropping` no longer raises `ValueError` when the configured ROI
+  extends beyond the actual image dimensions. Boundaries are now clamped to
+  the image size with a `WARNING` log message. If clamping leaves a zero-area
+  ROI the full image is returned.
+
 ## [1.1.1] — 2026-05-06
 
 ### Removed

--- a/ImageAnalysis/pyproject.toml
+++ b/ImageAnalysis/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "imageanalysis"
-version = "1.1.1"
+version = "1.1.2"
 description = "Central sub-repository for online and offline analysis of BELLA exeriments' images."
 authors = ["Reinier van Mourik <reinier.vanmourik@tausystems.com>"]
 readme = "README.md"


### PR DESCRIPTION
## Summary
- Version bump and CHANGELOG entry missed from PR #357 (merged before the bump commit was added)
- No code changes — only `pyproject.toml` and `CHANGELOG.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)