### PR TITLE
feat(geecs-bluesky): DG645 shot control arm/disarm, ScanExecutionConfig API, tests

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,6 +12,7 @@ tooling. Each subdirectory is an independent Python package with its own
 | `ImageAnalysis/` | Per-image analysis: pipelines, offline analyzers, config models |
 | `GEECS-Scanner-GUI/` | PyQt5 DAQ front-end: scans, save elements, optimization (Xopt) |
 | `GEECS-Data-Utils/` | Scan path navigation, scalar loading, binning, Parquet database |
+| `GeecsBluesky/` | Bluesky RunEngine backend: BlueskyScanner, ophyd-async GEECS devices, Tiled integration |
 | `LogMaker4GoogleDocs/` | Google Docs/Drive API wrapper for automated experiment logs |
 | `GEECS-PythonAPI/` | Low-level device TCP layer — **under refactoring, do not touch** |
 

--- a/GeecsBluesky/CHANGELOG.md
+++ b/GeecsBluesky/CHANGELOG.md
@@ -4,6 +4,49 @@ All notable changes to `geecs-bluesky` are documented here.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.3.0] - 2026-05-08
+
+### Added
+
+- **DG645 shot control — per-step arm/disarm** — `BlueskyScanner` accepts an
+  optional `shot_control_information` dict (matching the GEECS Scanner GUI timing
+  YAML format).  The DG645 is armed to `SCAN` state after each motor move and
+  disarmed to `STANDBY` after shots are collected, keeping the trigger off during
+  motion.  A `bpp.finalize_wrapper` guarantees disarm even on mid-step abort.
+- **`_UdpSetter`** — minimal Bluesky `Movable` wrapping a single GEECS UDP
+  variable as a string-typed settable.  Used internally for shot control; avoids
+  ophyd device overhead and works for both numeric delays and string state words.
+- **`geecs_step_scan` arm/disarm parameters** — `arm_trigger` and `disarm_trigger`
+  optional callables added to `geecs_step_scan`.  Each is a plan generator called
+  after the motor move (arm) and after shots are collected (disarm) per step.
+- **`BlueskyScanner._build_shot_controller()`** — resolves the shot control device
+  from the GEECS MySQL DB and creates one `_UdpSetter` per configured variable.
+- **`_set_trigger_state(state)`** — Bluesky plan stub that drives all shot control
+  variables to a named state (`SCAN`, `STANDBY`, `OFF`, `SINGLESHOT`).  Empty-string
+  values in the YAML are skipped (matching legacy `TriggerController` behaviour).
+  Uses `bps.abs_set` + `bps.wait` rather than `bps.mv` to avoid the `.parent`
+  attribute requirement of `bps.mv`.
+- **`tests/test_shot_control.py`** — 10 unit tests covering `_UdpSetter`,
+  `_set_trigger_state`, and arm/disarm ordering in `geecs_step_scan`.  All run
+  against `FakeGeecsServer` — no hardware required.
+- **`test_bluesky_scanner.py`** — hardware integration test with three scenarios:
+  NOSCAN (UC_TopView), STANDARD step scan (U_ESP_JetXYZ 4→5 mm), and NOSCAN with
+  DG645 shot control.  Verifies event counts, motor readback, `acq_timestamp`
+  presence, and post-scan DG645 `Trigger.Source` state.  All 6 checks pass on
+  real lab hardware.
+- **`mysql-connector-python`** added as a direct Poetry dependency (previously
+  required manual installation).
+
+### Changed
+
+- **`BlueskyScanner.reinitialize(exec_config)`** — now accepts a duck-typed
+  `ScanExecutionConfig` object (or any `SimpleNamespace` with `.scan_config`,
+  `.options`, `.save_config` attributes).  `shots_per_step` is derived from
+  `rep_rate_hz × wait_time` (rounded, minimum 1) since `ScanOptions` has no
+  explicit shots field.  Replaces the previous `config_dictionary` dict handoff.
+- **`BlueskyScanner.start_scan_thread()`** — takes no arguments; uses the config
+  stored by `reinitialize()`.
+
 ## [0.2.0] - 2026-05-07
 
 ### Added

--- a/GeecsBluesky/CLAUDE.md
+++ b/GeecsBluesky/CLAUDE.md
@@ -1,0 +1,219 @@
+# GeecsBluesky — Developer Context for Claude
+
+Bridges the GEECS hardware control system to the
+[Bluesky](https://blueskyproject.io/) experiment orchestration ecosystem.
+The primary product is `BlueskyScanner` — a drop-in replacement for
+`ScanManager` that routes all scan execution through a Bluesky `RunEngine`.
+
+## Why This Exists
+
+The legacy `ScanManager` in `GEECS-Scanner-GUI/` is a monolith that mixes device
+I/O, file writing, state management, and threading.  `BlueskyScanner` replaces it
+with a Bluesky plan that is:
+
+- **Testable without hardware** — `FakeGeecsServer` runs an in-process UDP/TCP
+  device; all unit tests use it
+- **Observable** — every shot emits a Bluesky event document; Tiled persists them
+- **Composable** — plans (`geecs_step_scan`) are plain generators; wrappers
+  (`bpp.finalize_wrapper`) guarantee cleanup on abort
+
+## Package Layout
+
+```
+geecs_bluesky/
+  scanner_bridge/
+    bluesky_scanner.py      # BlueskyScanner — ScanManager-compatible public API
+  plans/
+    step_scan.py            # geecs_step_scan — step scan plan with arm/disarm
+  devices/
+    geecs_device.py         # GeecsDevice — StandardReadable base; shared UDP lifecycle
+    settable.py             # GeecsSettable — Movable base; UDP set + polling convergence
+    motor.py                # GeecsMotor — axis device; from_db_axis() factory
+    generic_detector.py     # GeecsGenericDetector — dynamic variable list + save signals
+    triggerable.py          # GeecsTriggerable — acq_timestamp-gated trigger
+    camera.py               # GeecsCameraBase — thin camera subclass
+  transport/
+    udp_client.py           # GeecsUdpClient — asyncio UDP; two-stage ACK/EXE protocol
+    tcp_subscriber.py       # GeecsTcpSubscriber — framed TCP push at ~5 Hz
+  backends/                 # ophyd-async SignalBackend wired to UDP/TCP
+  db/
+    geecs_db.py             # GeecsDb — MySQL lookup: device name → (host, port)
+  testing/
+    fake_device_server.py   # FakeGeecsServer / FakeGeecsDevice — in-process test server
+  signals.py                # geecs_signal_rw / geecs_signal_r helpers
+  exceptions.py             # GeecsDeviceNotFoundError and friends
+  utils.py                  # safe_name() — device name → valid Python identifier
+```
+
+## BlueskyScanner — Key Design Points
+
+### Public API (matches ScanManager)
+
+```python
+scanner = BlueskyScanner(
+    experiment_dir="Undulator",
+    shot_control_information=shot_ctrl_yaml_dict,  # optional
+)
+scanner.reinitialize(exec_config)   # stores config; no hardware yet
+scanner.start_scan_thread()         # launches scan in background thread
+scanner.is_scanning_active()        # → bool
+scanner.estimate_current_completion()  # → 0.0–1.0
+scanner.stop_scanning_thread()      # RE.abort() + thread join
+```
+
+`RunControl` in `GEECS-Scanner-GUI` switches between `ScanManager` and
+`BlueskyScanner` via a `use_bluesky=True` flag.  The API surface is intentionally
+identical so no GUI code changes are needed.
+
+### exec_config duck-typing
+
+`reinitialize(exec_config)` accepts any object with:
+- `.scan_config` — object with `scan_mode`, `device_var`, `start`, `end`, `step`,
+  `wait_time`, `additional_description`
+- `.options` — object with `rep_rate_hz`
+- `.save_config` — object with `.Devices` dict (device name → config dict or
+  Pydantic model with `variable_list`, `save_nonscalar_data`)
+
+In production this is `ScanExecutionConfig`.  In the hardware integration test it
+is a `SimpleNamespace` to avoid cross-package imports.
+
+### shots_per_step derivation
+
+`ScanOptions` has no explicit shots field.  `shots_per_step` is derived as:
+```python
+max(1, round(rep_rate_hz * wait_time))
+```
+
+### Shot control — per-step arm/disarm
+
+The DG645 fires autonomously at the machine rep rate.  Software controls which
+state the outputs are in — `SCAN` (live) vs `STANDBY` (blocked) — so the trigger
+is only active while shots are being collected, not during motor moves.
+
+Flow per step:
+```
+bps.mv(motor, pos) → arm_trigger() [→ SCAN] → N × trigger_and_read → disarm_trigger() [→ STANDBY]
+```
+
+`_UdpSetter` is a minimal Bluesky `Movable` (has `.set(value) → AsyncStatus`) that
+wraps a single GEECS variable over a shared `GeecsUdpClient`.  It intentionally
+omits `.parent` (an ophyd-specific attribute) so `bps.abs_set` + `bps.wait` must
+be used instead of `bps.mv` when setting shot control variables.
+
+`_set_trigger_state(state)` drives all configured variables to a named state.
+Empty-string values in the YAML are skipped — they mean "no-op for this state"
+(matching legacy `TriggerController` behaviour).
+
+A `bpp.finalize_wrapper` around the scan plan guarantees `disarm_trigger()` runs
+even on mid-step abort.
+
+### Tiled integration
+
+`BlueskyScanner.__init__` reads `[tiled] uri` and `[tiled] api_key` from
+`~/.config/geecs_python_api/config.ini` and subscribes a `TiledWriter` to the
+`RunEngine`.  All event documents (start, descriptor, event, stop) are written to
+the Tiled catalog at `http://192.168.6.14:8000`.  Silently skips if the server is
+unreachable or `tiled[client]` is not installed.
+
+### Threading model
+
+The `RunEngine` runs in a background thread (`bluesky-scan`).  The RE's internal
+`asyncio` event loop is persistent — devices are connected into it and remain
+connected across the scan.  `RunEngine(context_managers=[])` disables SIGINT
+handling, which fails when the RE is not on the main thread.
+
+Device connect/disconnect uses `asyncio.run_coroutine_threadsafe(...).result(timeout=...)`.
+
+## Device Layer
+
+### GeecsDevice
+
+Base class (`StandardReadable`).  One shared `GeecsUdpClient` per device instance;
+all signals share it.  The UDP client's `asyncio.Lock` serialises concurrent
+get/set calls.
+
+### GeecsTriggerable
+
+`trigger()` waits for `acq_timestamp` to advance (event-driven via `asyncio.Queue`
+populated by the TCP subscriber).  No polling.  Robust to device restarts because
+it tracks the timestamp value, not a shot counter.
+
+### GeecsMotor
+
+`set(pos)` sends a UDP move command then polls `Position` until within tolerance
+(`move_timeout=30 s`).  Factory: `GeecsMotor.from_db_axis(device, variable, name=...)`.
+
+### GeecsGenericDetector
+
+Dynamically creates one signal per variable in `variable_list`.  Optional
+`save_nonscalar_data=True` adds `localsavingpath` and `save` signals; the
+`_scan_with_saving` plan wrapper sets these before the scan and clears them in
+a finalise wrapper.
+
+## Transport Layer
+
+### GeecsUdpClient
+
+Two-stage protocol: command sent to port N, ACK received on port N, EXE response
+received on port N+1.  ACK format: `"get{var}>>>>accepted"`.  EXE success:
+`"no error,"`.  Holds an `asyncio.Lock` for serialisation.
+
+Local IP detected at connect time via a no-op UDP socket against the OS routing
+table — handles VPN/PPP lab links.
+
+### GeecsTcpSubscriber
+
+Framed TCP: 4-byte big-endian length prefix + JSON payload.  Pushed by device at
+~5 Hz.  Feeds a shared `_shot_cache` dict; `GeecsTriggerable` watches for
+`acq_timestamp` advances via an `asyncio.Queue`.
+
+## Test Infrastructure
+
+### FakeGeecsServer / FakeGeecsDevice
+
+An in-process UDP/TCP server that speaks the real GEECS wire protocol.  Use as an
+async context manager:
+
+```python
+device = FakeGeecsDevice("U_DG645", variables={"Trigger.Source": "External rising edges"})
+async with FakeGeecsServer(device) as srv:
+    udp = GeecsUdpClient(srv.host, srv.port, device_name="U_DG645")
+    await udp.connect()
+    val = await udp.get("Trigger.Source")
+```
+
+`device.fire_shot()` advances `acq_timestamp` and broadcasts a TCP push — used to
+simulate hardware shot events in tests.
+
+### Hardware integration test
+
+`test_bluesky_scanner.py` (top-level, run with `poetry run python
+test_bluesky_scanner.py`) requires lab network access.  Tests three scenarios
+against real hardware: NOSCAN, STANDARD step scan, NOSCAN with DG645 shot control.
+
+## Configuration
+
+All runtime config reads from `~/.config/geecs_python_api/config.ini`:
+
+```ini
+[Paths]
+geecs_data = /path/to/user data   # must point to dir containing Configurations.INI
+
+[tiled]
+uri = http://192.168.6.14:8000
+api_key = <key>
+```
+
+`GeecsDb` reads `Configurations.INI` (in `geecs_data`) for MySQL credentials.
+
+## Known Gaps (as of 0.3.0)
+
+- `shot_control_information` is not yet threaded through `RunControl` when
+  `use_bluesky=True` — BlueskyScanner gets no shot control in GUI mode.
+  Deferred until the GUI/RunControl refactor in the parallel worktree lands.
+- Scalar s-files / TDMS output not produced — Bluesky writes to Tiled only.
+  `ScanAnalysis` still reads s-files; data pipeline transition is an open question.
+- Optimization and Background scan modes not implemented.
+- Pre/post-scan action sequences not implemented.
+- `_claim_scan_number()` logs an error and returns `None` silently if
+  `geecs_data_utils` is unavailable or the NetApp is not mounted.

--- a/GeecsBluesky/README.md
+++ b/GeecsBluesky/README.md
@@ -37,21 +37,22 @@ $VENV/bin/pip install "ophyd-async>=0.16,<1.0" "bluesky>=1.12" -q
 $VENV/bin/pip install "pytest>=7" "pytest-asyncio>=0.23" -q
 ```
 
-### DB lookup (optional)
+### DB lookup
 
 `GeecsDevice.from_db()` resolves `(host, port)` from the GEECS MySQL database.
-It requires `geecs-pythonapi`, which is not on PyPI — install from the monorepo:
+`mysql-connector-python` is included as a direct Poetry dependency and is
+installed automatically by `poetry install`.
 
-```bash
-VENV=$(poetry env info --path)
-$VENV/bin/pip install -e ../GEECS-PythonAPI --no-deps
-# geecs-pythonapi transitive deps (add any that are missing):
-$VENV/bin/pip install mysql-connector-python python-dateutil
+The package reads DB credentials from the standard GEECS user-data directory.
+Configure the path in `~/.config/geecs_python_api/config.ini`:
+
+```ini
+[Paths]
+geecs_data = /path/to/user data   # directory containing Configurations.INI
 ```
 
-The package reads DB credentials from
-`~/Desktop/Github_repos/user\ data/Configurations.INI` (the standard GEECS
-user-data directory).
+`Configurations.INI` in that directory provides the `[Database]` section
+(host, port, name, user, password).
 
 ## Quick start
 
@@ -115,7 +116,14 @@ internal `asyncio.Lock` serialises them automatically.
 poetry run pytest tests/ -v
 ```
 
-All 14+ tests run against `FakeGeecsServer` on localhost — no real hardware required.
+All tests run against `FakeGeecsServer` on localhost — no real hardware required.
+
+A hardware integration test (`test_bluesky_scanner.py`) exercises NOSCAN, STANDARD
+step scan, and DG645 shot control against real lab devices:
+
+```bash
+poetry run python test_bluesky_scanner.py
+```
 
 ## Architecture notes
 

--- a/GeecsBluesky/ROADMAP.md
+++ b/GeecsBluesky/ROADMAP.md
@@ -1,9 +1,9 @@
 # GeecsBluesky — Roadmap
 
-Current status (2026-04-21): BlueskyScanner runs STANDARD and NOSCAN scans
-end-to-end against real hardware.  Motor motion, DG645-gated detector
-triggering, scan numbering, per-device image saving, and the ScanManager-
-compatible bridge API are all working.
+Current status (2026-05-08): MVP complete and hardware-verified.
+`BlueskyScanner` runs STANDARD and NOSCAN scans end-to-end against real lab
+hardware with per-step DG645 shot control and Tiled data persistence.
+All unit tests pass without hardware; hardware integration test passes all checks.
 
 ---
 
@@ -20,104 +20,90 @@ compatible bridge API are all working.
       `variable_list`; `localsavingpath` / `save` signals when
       `save_nonscalar_data=True`.
 - [x] **BlueskyScanner bridge** — ScanManager-compatible API; STANDARD and
-      NOSCAN modes; `dialog_queue` / `restore_failures` shims.
+      NOSCAN modes; `dialog_queue` / `restore_failures` shims for GUI compat.
+- [x] **ScanExecutionConfig API** — `reinitialize(exec_config)` accepts the
+      validated `ScanExecutionConfig` Pydantic model produced by the GUI; duck-
+      typed at runtime so the hardware test works without importing
+      `geecs_scanner`.  `shots_per_step` derived from `rep_rate_hz × wait_time`.
+- [x] **Shot control — per-step arm/disarm** — `_UdpSetter` + `_set_trigger_state`;
+      DG645 armed to SCAN after each motor move, disarmed to STANDBY after shots.
+      `bpp.finalize_wrapper` guarantees disarm on abort.  `geecs_step_scan` has
+      `arm_trigger` / `disarm_trigger` parameters.
 - [x] **Scan numbering** — `ScanPaths.get_next_scan_tag()` claimed before
       detectors are built so save paths are known at device-build time.
 - [x] **Per-device image saving** — `_scan_with_saving` plan wrapper sets
-      `localsavingpath` and `save="on"` concurrently (single `bps.mv` fanout)
-      before scan; `bpp.finalize_wrapper` sets `save="off"` even on abort.
-- [x] **shots_per_step** — explicit key in `config_dictionary`; not derived
-      from `wait_time`; hardware timing left to DG645.
+      `localsavingpath` and `save="on"` concurrently before scan; finalise
+      wrapper sets `save="off"` even on abort.
+- [x] **Tiled integration** — `TiledWriter` subscribed to RunEngine on init;
+      reads URI + API key from `~/.config/geecs_python_api/config.ini`; skips
+      silently if server is unreachable.
+- [x] **FakeGeecsServer** — in-process fake device server using real wire
+      protocol; `device.fire_shot()` advances `acq_timestamp` and broadcasts
+      TCP push; used for all unit tests.
+- [x] **Unit tests** — `tests/test_shot_control.py` (10 tests covering
+      `_UdpSetter`, `_set_trigger_state`, arm/disarm ordering; no hardware).
+- [x] **Hardware integration test** — `test_bluesky_scanner.py`; 3 scenarios,
+      6 checks; all pass on real lab hardware (UC_TopView, U_ESP_JetXYZ,
+      U_DG645_ShotControl).
 
 ---
 
-## 1. Error Handling — Exceptions + Interactive Recovery
+## Open Questions / Strategic Decisions
 
-### 1a. Exception taxonomy  ← *in progress*
+These require discussion before implementation — see brainstorm notes.
 
-Define a typed hierarchy in `geecs_bluesky/exceptions.py`:
+### Data pipeline transition
 
-```
-GeecsError
-├── GeecsConnectionError        # transport-level — device unreachable
-├── GeecsCommandError           # device responded but rejected/failed
-│   ├── GeecsCommandRejectedError   # no ACK (device offline/busy)
-│   └── GeecsCommandFailedError     # ACK but device returned error status
-├── GeecsTriggerTimeoutError    # acq_timestamp didn't advance in time
-├── GeecsMotorTimeoutError      # position didn't converge in move_timeout
-└── GeecsDeviceNotFoundError    # DB lookup failed
-```
+`ScanAnalysis` and everything downstream reads s-files and TDMS written by the
+legacy `ScanManager`.  `BlueskyScanner` writes to Tiled only.
 
-Raise typed exceptions from transport and device layers; keep devices
-ignorant of dialogs or queues.
+Options:
+- **Tiled reader for ScanAnalysis** — add a Tiled-backed data source alongside
+  the existing file reader; cold-turkey cutover deferred.
+- **BlueskyScanner also writes s-files** — transitional shim; buys time for
+  ScanAnalysis migration; acknowledged as unpleasant.
+- **Accept cold-turkey** — new scans from Bluesky path only queryable via Tiled;
+  old analysis tools stop working for new data until ported.
 
-### 1b. RE-pause-based interactive recovery
+No decision yet.  Defer until BlueskyScanner is actually the production path.
 
-**Critical design constraint**: BlueskyScanner runs an asyncio event loop in
-a background thread.  The existing scanner's `threading.Event.wait()` pattern
-**must not be used inside a plan** — it would freeze the TCP subscriber and
-all async device tasks.
+### GUI / RunControl integration
 
-Use `bps.pause()` instead:
+`RunControl` has `use_bluesky=True` flag but `shot_control_information` is not
+yet threaded through — BlueskyScanner gets no shot control in GUI mode.
+Deferred until the parallel GUI/RunControl refactor lands in master.
 
-```python
-# Inside a plan wrapper in bluesky_scanner.py:
-try:
-    yield from bps.mv(motor, pos)
-except GeecsCommandError as e:
-    dialog_queue.put(DialogRequest(exc=e, ...))
-    yield from bps.pause()   # RE freezes; event loop stays alive
-    # user fixes device, clicks Continue → RE.resume(); plan retries
-    # user clicks Abort       → RE.abort(); finalize_wrapper cleans up
-```
+### Optimization scans
 
-Retry policy (silent retries before showing dialog) belongs in the plan
-wrapper, not in the device.
-
-### 1c. GUI adaptation — reactive state monitoring
-
-**The GUI should subscribe to RE state changes, not poll `dialog_queue` on a
-timer.**  The RE already emits state transitions (idle → running → paused →
-…).  When the RE transitions to `"paused"`, the GUI drains `dialog_queue`
-(which carries error details) and shows the dialog.  This replaces the
-200 ms timer loop in the existing scanner and eliminates dialog latency.
-
-`BlueskyScanner` should set the interface; the GUI adapts to it — not the
-other way around.
+Bluesky + Xopt may naturally handle what `base_optimizer.py` does today.  The
+existing optimization execution could become deprecated rather than ported.
+Requires a deeper dive.
 
 ---
 
-## 2. Tiled Server — Centralized Scalar Storage
+## Near-Term Implementation Work
 
-**What**: All event data (motor positions, detector scalars, metadata) stored
-in a queryable database accessible from any machine.
+Small, well-scoped items that don't require strategic decisions:
 
-**Architecture**:
-- Run `tiled serve catalog` on the Linux DB machine (192.168.6.14).
-- `BlueskyScanner.__init__` subscribes a `TiledWriter` — every event document
-  is written automatically.
-- Data queryable from Jupyter via
-  `tiled.client.from_uri("http://192.168.6.14:8000")`.
-
-**Setup** (on DB machine):
-```bash
-pip install tiled[server]
-tiled catalog create --init-db catalog.db
-tiled serve catalog catalog.db --host 0.0.0.0 --port 8000
-```
+- **Background scan mode** — BACKGROUND adds a flag to scan metadata; trivial
+  addition as a third branch in `_run_scan`.
+- **Scan number error visibility** — `_claim_scan_number` should log `ERROR`
+  (not silently return `None`) when the scan folder cannot be created.
+- **Pre/post-scan actions** — action sequences (set variable, wait, check
+  condition) are not yet supported; straightforward once the action model is
+  understood.
+- **Windows install verification** — `poetry install` in `GeecsBluesky/` has
+  not been verified on Windows; `mysql-connector-python` platform behaviour
+  worth checking before lab deployment.
 
 ---
 
-## 3. Longer-Term
+## Longer-Term
 
-- **Optimization scans**: wrap `xopt` or `scipy.optimize` in a Bluesky plan;
-  the GUI already has an optimization mode.
-- **Composite variables**: two motors moving together; implement as a custom
+- **Optimization scans** — wrap Xopt in a Bluesky plan; decisions pending on
+  whether to port or deprecate the existing optimizer.
+- **Composite variables** — two motors moving together; implement as a custom
   plan calling `bps.mv(m1, p1, m2, p2)`.
-- **Live plotting**: `BestEffortCallback` or custom Bokeh subscriber that
-  updates during the scan.
-- **Config format**: replace `config_dictionary` (legacy GUI format) with a
-  proper dataclass/Pydantic model on the BlueskyScanner side; GUI serializes
-  to it.
-- **Separate repo**: once stable, publish `geecs-bluesky` to PyPI for use at
-  other GEECS-based labs.
+- **Live plotting** — `BestEffortCallback` or custom Bokeh subscriber.
+- **Separate repo / PyPI** — once stable, publish `geecs-bluesky` to PyPI for
+  use at other GEECS-based labs.

--- a/GeecsBluesky/TILED_SETUP.md
+++ b/GeecsBluesky/TILED_SETUP.md
@@ -1,140 +1,58 @@
-# Tiled Integration — Current State & Next Steps
+# Tiled Integration — Current State
 
 ## What Is This
 
-Tiled is the persistent scalar/metadata store for all GEECS bluesky scans.
+Tiled is the persistent scalar/metadata store for all GEECS Bluesky scans.
 Every scan that runs through `BlueskyScanner` writes start/stop/event documents
 to a Tiled catalog on the DB server (`192.168.6.14`).  Data is then queryable
 from any Python session on the network without touching the raw data files.
 
 ---
 
-## Infrastructure State (as of 2026-05-07)
+## Infrastructure State (as of 2026-05-08)
 
 ### DB Server — `192.168.6.14`
 
-- OS: Ubuntu 22.04.5 LTS (upgraded from 18.04 this session)
+- OS: Ubuntu 22.04.5 LTS
 - Python: 3.10.12
 - Tiled: 0.2.9 installed via `pip install 'tiled[server]'` into `~/.local`
 - Running as systemd service: `sudo systemctl status tiled`
 - Catalog DB: `~/tiled/catalog.db` (SQLite, metadata index)
-- File storage: `~/tiled/` (arrays/images)
-- **Missing:** SQLite tabular storage (`~/tiled/tabular.db`) — causes 500 error
-  when TiledWriter tries to write event tables. See Next Steps.
+- Tabular storage: `~/tiled/tabular.db` (SQLite, event tables)
+- File storage: `~/tiled/storage/`
+- API key: stable — set via `TILED_SINGLE_USER_API_KEY` env var, stored in
+  `~/.config/geecs_python_api/config.ini` on all client machines
 
-Current `systemd` service (`/etc/systemd/system/tiled.service`) uses CLI flags.
-**This needs to be replaced with a config file** (see Next Steps).
+### Client machines
 
-API key is auto-generated on each restart and stored in `~/.config/geecs_python_api/config.ini`.
-**This needs to be made stable** (see Next Steps).
+`BlueskyScanner` auto-reads Tiled URI + API key from
+`~/.config/geecs_python_api/config.ini` under `[tiled]`:
 
-### Windows DAQ Machine — `HTU-CR-1`
-
-- Branch: `geecs-bluesky-detectors`
-- `BlueskyScanner` auto-reads Tiled URI + API key from
-  `%USERPROFILE%\.config\geecs_python_api\config.ini` under `[tiled]`
-- `tiled[client]` installed in the Scanner GUI poetry env
-- TiledWriter subscribes successfully on startup (confirmed in logs)
-- **Issue:** scans fail mid-write due to missing tabular storage on server
-
-### Mac (development)
-
-- `[tiled]` section in `~/.config/geecs_python_api/config.ini`
-- Read access confirmed: `c = from_uri("http://192.168.6.14:8000", api_key=...)`
-- Catalog currently has 2 partial runs (scan 14 and 15) from testing
+```ini
+[tiled]
+uri = http://192.168.6.14:8000
+api_key = <stable key>
+```
 
 ---
 
 ## What Works
 
-- BlueskyScanner connects to Tiled on startup ✓
+- `BlueskyScanner` connects to Tiled on startup and subscribes `TiledWriter` ✓
 - Run start/stop metadata written to catalog ✓
-- Scan number, scan folder, device list in metadata ✓
-- File images saved to network drive per-shot ✓
-- Catalog readable from Mac via Python ✓
+- Event documents (motor positions, detector scalars, timestamps) written ✓
+- Scan number, scan folder, device list in run start metadata ✓
+- DG645 shot control arm/disarm per step ✓
+- Catalog readable from any network-connected Python session ✓
+- Hardware integration test (`test_bluesky_scanner.py`) passes all 6 checks ✓
 
-## What Is Broken
+## Known Limitations
 
-- **500 error on event table write** — `SQLAdapter` needs SQLite/SQL storage
-  but server only has `FileStorage`. Fix: add `tabular.db` to server config.
-- **API key regenerates on restart** — needs stable key via env var.
-- **Shot control (DG645) not integrated** — BlueskyScanner doesn't yet
-  arm/disarm the DG645. Tested with UC_TopView in internal trigger mode.
-
----
-
-## Next Steps (in order)
-
-### 1. Switch server to config-file approach + fix storage (immediate)
-
-Generate a stable API key on the server:
-```bash
-openssl rand -hex 32
-# copy output
-echo 'export TILED_SINGLE_USER_API_KEY="<paste key here>"' >> ~/.bashrc
-source ~/.bashrc
-```
-
-Create `~/tiled/config.yml`:
-```yaml
-authentication:
-  single_user_api_key: ${TILED_SINGLE_USER_API_KEY}
-  allow_anonymous_access: false
-uvicorn:
-  host: 0.0.0.0
-  port: 8000
-trees:
-  - path: /
-    tree: catalog
-    args:
-      uri: "sqlite:////home/abmx/tiled/catalog.db"
-      writable_storage:
-        - "/home/abmx/tiled/storage"
-        - "sqlite:////home/abmx/tiled/tabular.db"
-      readable_storage:
-        - "/home/abmx/tiled/storage"
-      init_if_not_exists: true
-```
-
-Update systemd service:
-```ini
-[Unit]
-Description=Tiled Data Server
-After=network.target
-
-[Service]
-User=abmx
-EnvironmentFile=/home/abmx/.bashrc
-ExecStart=/home/abmx/.local/bin/tiled serve config /home/abmx/tiled/config.yml
-Restart=on-failure
-
-[Install]
-WantedBy=multi-user.target
-```
-
-Update `[tiled]` in `config.ini` on all machines with the new stable key.
-
-### 2. DG645 shot control integration
-
-`BlueskyScanner` needs to arm the shot controller before a scan and disarm
-after.  The legacy `ScanManager` does this via device set calls.  In the
-Bluesky backend this belongs as a plan wrapper around the scan — arm before
-`_scan_with_saving`, disarm in the `finalize_wrapper`.
-
-Key questions to resolve:
-- Which GEECS variable arms/disarms the DG645?
-- Should it be a `GeecsSettable` device or a raw UDP call?
-
-### 3. PR and merge `geecs-bluesky-detectors`
-
-Once steps 1-2 are verified end-to-end with a real scan (DG645 running,
-events appearing in Tiled), open a PR to merge into master.
-
-### 4. Longer term
-
-- Add scan metadata to Tiled: scan config YAML, operator name, description
-- Live plotting subscriber (BestEffortCallback or Bokeh)
-- Read Tiled data in ScanAnalysis post-processing pipeline
+- **No s-file / TDMS output** — `BlueskyScanner` writes to Tiled only.
+  `ScanAnalysis` and other downstream tools still read s-files.  Data pipeline
+  transition is an open strategic question (see `ROADMAP.md`).
+- **Tiled not yet read by ScanAnalysis** — post-scan analysis continues to use
+  the legacy file-based path.
 
 ---
 
@@ -145,13 +63,14 @@ events appearing in Tiled), open a PR to merge into master.
 sudo systemctl status tiled
 sudo journalctl -u tiled --no-pager | tail -30
 
-# Read catalog from Python (Mac or any machine with tiled[client])
+# Read catalog from Python (any machine with tiled[client])
 from tiled.client import from_uri
 c = from_uri("http://192.168.6.14:8000", api_key="<key>")
 run = c.values().last()
 print(run.metadata["start"])
+df = run["primary"].read()
 
-# On Windows: start GUI with Bluesky backend
-cd /z/software/control-all-loasis/HTU/Active\ Version/GEECS-Plugins/GEECS-Scanner-GUI
-poetry run python main.py
+# Run hardware integration test (requires lab network)
+cd GeecsBluesky
+poetry run python test_bluesky_scanner.py
 ```

--- a/GeecsBluesky/geecs_bluesky/plans/step_scan.py
+++ b/GeecsBluesky/geecs_bluesky/plans/step_scan.py
@@ -51,7 +51,7 @@ Example::
 
 from __future__ import annotations
 
-from typing import Any, Iterable
+from typing import Any, Callable, Iterable
 
 import bluesky.plan_stubs as bps
 import bluesky.preprocessors as bpp
@@ -62,6 +62,8 @@ def geecs_step_scan(
     positions: Iterable[float],
     detectors: list[Any],
     shots_per_step: int = 5,
+    arm_trigger: Callable | None = None,
+    disarm_trigger: Callable | None = None,
     md: dict[str, Any] | None = None,
 ):
     """Step-scan plan: move *motor* through *positions*, collect *shots_per_step* shots.
@@ -79,6 +81,14 @@ def geecs_step_scan(
         automatically so its position is recorded in every event document.
     shots_per_step:
         Number of shots to collect at each motor position.  Default: ``5``.
+    arm_trigger:
+        Optional callable returning a plan generator that arms the shot
+        controller (e.g. sets DG645 outputs to SCAN state).  Called after
+        each motor move, before collecting shots.
+    disarm_trigger:
+        Optional callable returning a plan generator that disarms the shot
+        controller (e.g. sets DG645 outputs to STANDBY state).  Called after
+        collecting shots at each step, before the next motor move.
     md:
         Extra metadata merged into the RunEngine ``start`` document.
 
@@ -94,6 +104,9 @@ def geecs_step_scan(
     * Non-Triggerable devices in *detectors* are read without calling
       ``trigger()`` (standard :func:`bluesky.plan_stubs.trigger_and_read`
       behaviour).
+    * ``arm_trigger`` / ``disarm_trigger`` bracket the per-step acquisition
+      window so the shot controller is only active while shots are being
+      collected, not during motor moves.
     """
     _positions = list(positions)
     _read_devices = list(detectors) + [motor]
@@ -112,7 +125,11 @@ def geecs_step_scan(
     def _inner():
         for pos in _positions:
             yield from bps.mv(motor, pos)
+            if arm_trigger is not None:
+                yield from arm_trigger()
             for _shot in range(shots_per_step):
                 yield from bps.trigger_and_read(_read_devices)
+            if disarm_trigger is not None:
+                yield from disarm_trigger()
 
     yield from _inner()

--- a/GeecsBluesky/geecs_bluesky/scanner_bridge/bluesky_scanner.py
+++ b/GeecsBluesky/geecs_bluesky/scanner_bridge/bluesky_scanner.py
@@ -452,16 +452,24 @@ class BlueskyScanner:
         yield from self._set_trigger_state("STANDBY")
 
     def _set_trigger_state(self, state: str):
-        """Bluesky plan stub: drive all shot control variables to *state*."""
+        """Bluesky plan stub: drive all shot control variables to *state*.
+
+        Uses ``bps.abs_set`` + ``bps.wait`` rather than ``bps.mv`` because
+        ``bps.mv`` inspects ``.parent`` for coupled-device handling — an
+        ophyd-specific attribute that ``_UdpSetter`` intentionally omits.
+        All active variables are set concurrently then waited on as a group.
+        """
         if not self._shot_control_setters:
             return
-        mv_args: list = []
+        group = f"shot_ctrl_{state}"
+        n_set = 0
         for var_name, setter in self._shot_control_setters.items():
             val = self._shot_control_variables[var_name].get(state)
-            if val is not None:
-                mv_args.extend([setter, val])
-        if mv_args:
-            yield from bps.mv(*mv_args)
+            if val:  # skip None and empty string (matches TriggerController)
+                yield from bps.abs_set(setter, val, group=group)
+                n_set += 1
+        if n_set:
+            yield from bps.wait(group)
             logger.info("Shot controller → %s", state)
 
     def _run_scan(self, scan_config: Any) -> None:

--- a/GeecsBluesky/geecs_bluesky/scanner_bridge/bluesky_scanner.py
+++ b/GeecsBluesky/geecs_bluesky/scanner_bridge/bluesky_scanner.py
@@ -44,12 +44,14 @@ from typing import Any
 import numpy as np
 from bluesky import RunEngine
 import bluesky.plan_stubs as bps
-import bluesky.plans as bp
 import bluesky.preprocessors as bpp
+
+from ophyd_async.core import AsyncStatus
 
 from geecs_bluesky.devices.generic_detector import GeecsGenericDetector
 from geecs_bluesky.devices.motor import GeecsMotor
 from geecs_bluesky.plans.step_scan import geecs_step_scan
+from geecs_bluesky.transport.udp_client import GeecsUdpClient
 from geecs_bluesky.utils import safe_name
 
 # ScanConfig / ScanMode are only imported for type hints; duck-typing is used at
@@ -63,6 +65,27 @@ logger = logging.getLogger(__name__)
 
 _CONNECT_TIMEOUT = 20.0
 _DISCONNECT_TIMEOUT = 10.0
+
+
+class _UdpSetter:
+    """Minimal Bluesky Movable: sets one GEECS variable via a shared UDP client.
+
+    Values are sent as strings, matching the GEECS wire protocol and the
+    shot-control YAML format (which may contain numeric strings or words
+    like ``"on"``/``"off"``).
+    """
+
+    def __init__(self, udp: GeecsUdpClient, variable: str) -> None:
+        self._udp = udp
+        self._variable = variable
+
+    def set(self, value: Any) -> AsyncStatus:
+        """Send *value* to the device; resolves when the UDP ACK is received."""
+
+        async def _do() -> None:
+            await self._udp.set(self._variable, str(value))
+
+        return AsyncStatus(_do())
 
 
 # ---------------------------------------------------------------------------
@@ -172,6 +195,15 @@ class BlueskyScanner:
         self._detectors: list = []
         # Subset of detectors that save per-shot files: list of (detector, path)
         self._saving_detectors: list[tuple] = []
+
+        # Shot control — parsed from shot_control_information YAML
+        self._shot_control_device_name: str | None = None
+        self._shot_control_variables: dict[str, dict] = {}
+        self._shot_control_udp: GeecsUdpClient | None = None
+        self._shot_control_setters: dict[str, _UdpSetter] = {}
+        if shot_control_information:
+            self._shot_control_device_name = shot_control_information.get("device")
+            self._shot_control_variables = shot_control_information.get("variables", {})
 
         # Lock for serialising _motor create/destroy across threads
         self._device_lock = threading.Lock()
@@ -355,7 +387,7 @@ class BlueskyScanner:
             logger.debug("disconnect raised for %s", device, exc_info=True)
 
     def _disconnect_devices_sync(self) -> None:
-        """Disconnect motor + detectors if they exist (called from non-scan threads)."""
+        """Disconnect motor, detectors, and shot controller (called from non-scan threads)."""
         with self._device_lock:
             if self._motor is not None:
                 self._disconnect_device(self._motor)
@@ -364,6 +396,70 @@ class BlueskyScanner:
                 self._disconnect_device(det)
             self._detectors = []
             self._saving_detectors = []
+
+        if self._shot_control_udp is not None:
+            try:
+                asyncio.run_coroutine_threadsafe(
+                    self._shot_control_udp.close(), self._RE._loop
+                ).result(timeout=_DISCONNECT_TIMEOUT)
+            except Exception:
+                logger.debug("Shot control UDP close raised", exc_info=True)
+            self._shot_control_udp = None
+            self._shot_control_setters = {}
+
+    def _build_shot_controller(self) -> None:
+        """Resolve the shot control device and create one _UdpSetter per variable.
+
+        Silently skips if no shot control device is configured or the DB
+        lookup fails, so scans without trigger control still run (e.g. in
+        internal-trigger test mode).
+        """
+        if not self._shot_control_device_name or not self._shot_control_variables:
+            logger.debug("No shot control device configured — trigger control disabled")
+            return
+        try:
+            from geecs_bluesky.db.geecs_db import GeecsDb
+
+            host, port = GeecsDb.find_device(self._shot_control_device_name)
+            udp = GeecsUdpClient(host, port, device_name=self._shot_control_device_name)
+            asyncio.run_coroutine_threadsafe(udp.connect(), self._RE._loop).result(
+                timeout=_CONNECT_TIMEOUT
+            )
+            self._shot_control_udp = udp
+            self._shot_control_setters = {
+                var: _UdpSetter(udp, var) for var in self._shot_control_variables
+            }
+            logger.info(
+                "Shot controller ready: %s (%d variables)",
+                self._shot_control_device_name,
+                len(self._shot_control_setters),
+            )
+        except Exception:
+            logger.warning(
+                "Could not build shot controller — trigger control disabled",
+                exc_info=True,
+            )
+
+    def _arm_trigger(self):
+        """Bluesky plan stub: set all shot control variables to SCAN state."""
+        yield from self._set_trigger_state("SCAN")
+
+    def _disarm_trigger(self):
+        """Bluesky plan stub: set all shot control variables to STANDBY state."""
+        yield from self._set_trigger_state("STANDBY")
+
+    def _set_trigger_state(self, state: str):
+        """Bluesky plan stub: drive all shot control variables to *state*."""
+        if not self._shot_control_setters:
+            return
+        mv_args: list = []
+        for var_name, setter in self._shot_control_setters.items():
+            val = self._shot_control_variables[var_name].get(state)
+            if val is not None:
+                mv_args.extend([setter, val])
+        if mv_args:
+            yield from bps.mv(*mv_args)
+            logger.info("Shot controller → %s", state)
 
     def _run_scan(self, scan_config: Any) -> None:
         """Scan thread body: create devices, run plan, clean up."""
@@ -519,18 +615,26 @@ class BlueskyScanner:
         if scan_config.additional_description:
             md["description"] = scan_config.additional_description
 
-        self._RE(
-            _scan_with_saving(
-                geecs_step_scan(
-                    motor=motor,
-                    positions=positions,
-                    detectors=list(self._detectors),
-                    shots_per_step=self._shots_per_step,
-                    md=md,
-                ),
-                saving_detectors=list(self._saving_detectors),
-            )
+        self._build_shot_controller()
+        arm = self._arm_trigger if self._shot_control_setters else None
+        disarm = self._disarm_trigger if self._shot_control_setters else None
+
+        plan = _scan_with_saving(
+            geecs_step_scan(
+                motor=motor,
+                positions=positions,
+                detectors=list(self._detectors),
+                shots_per_step=self._shots_per_step,
+                arm_trigger=arm,
+                disarm_trigger=disarm,
+                md=md,
+            ),
+            saving_detectors=list(self._saving_detectors),
         )
+        # Outer finalize ensures disarm even on mid-step abort
+        if disarm is not None:
+            plan = bpp.finalize_wrapper(plan, self._disarm_trigger())
+        self._RE(plan)
 
     def _run_noscan(self, scan_config: Any) -> None:
         """Fixed-position data collection — count plan if detectors present."""
@@ -565,9 +669,23 @@ class BlueskyScanner:
             md["scan_number"] = scan_number
         if scan_folder is not None:
             md["scan_folder"] = scan_folder
-        self._RE(
-            _scan_with_saving(
-                bp.count(self._detectors, num=n_shots, md=md),
-                saving_detectors=list(self._saving_detectors),
-            )
+        self._build_shot_controller()
+        arm = self._arm_trigger if self._shot_control_setters else None
+        disarm = self._disarm_trigger if self._shot_control_setters else None
+
+        @bpp.run_decorator(md=md)
+        def _noscan_plan():
+            if arm is not None:
+                yield from arm()
+            for _ in range(n_shots):
+                yield from bps.trigger_and_read(self._detectors)
+            if disarm is not None:
+                yield from disarm()
+
+        plan = _scan_with_saving(
+            _noscan_plan(),
+            saving_detectors=list(self._saving_detectors),
         )
+        if disarm is not None:
+            plan = bpp.finalize_wrapper(plan, self._disarm_trigger())
+        self._RE(plan)

--- a/GeecsBluesky/geecs_bluesky/scanner_bridge/bluesky_scanner.py
+++ b/GeecsBluesky/geecs_bluesky/scanner_bridge/bluesky_scanner.py
@@ -146,8 +146,11 @@ class BlueskyScanner:
     experiment_dir:
         Experiment name (currently unused; reserved for future path integration).
     shot_control_information:
-        Shot-controller YAML config dict (currently unused; reserved for future
-        DG645 integration).
+        Shot-controller YAML config dict with keys ``"device"`` (GEECS device
+        name) and ``"variables"`` (mapping of variable name → state → value,
+        where states are ``"OFF"``, ``"SCAN"``, ``"STANDBY"``,
+        ``"SINGLESHOT"``).  When provided, the DG645 is armed before each
+        acquisition step and disarmed after.
     tiled_uri:
         URI of the Tiled catalog server (e.g. ``"http://192.168.6.14:8000"``).
         When provided, a :class:`~bluesky.callbacks.tiled_writer.TiledWriter`

--- a/GeecsBluesky/poetry.lock
+++ b/GeecsBluesky/poetry.lock
@@ -1062,6 +1062,48 @@ msgpack = ">=0.5.2"
 numpy = ">=1.9.0"
 
 [[package]]
+name = "mysql-connector-python"
+version = "9.7.0"
+description = "A self-contained Python driver for communicating with MySQL servers, using an API that is compliant with the Python Database API Specification v2.0 (PEP 249)."
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+files = [
+    {file = "mysql_connector_python-9.7.0-cp310-cp310-macosx_14_0_arm64.whl", hash = "sha256:ee90c5f44f706f012be17f03f6ad158ff96e7f2dcc077896fe4537d3d28b3cf4"},
+    {file = "mysql_connector_python-9.7.0-cp310-cp310-macosx_14_0_x86_64.whl", hash = "sha256:a2f371ab69d65c61136c51ad7026017400166cef3c959cab7a9fb668c7acbfba"},
+    {file = "mysql_connector_python-9.7.0-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:9bdfc2d4c4444cd1cc79cc6487c047b28fe2b26d0327b27eb9f5737bb553cb5c"},
+    {file = "mysql_connector_python-9.7.0-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:6546e0b60c275409a5add9e3308c3897fcf478d1338cd845b1664c1a8946f72f"},
+    {file = "mysql_connector_python-9.7.0-cp310-cp310-win_amd64.whl", hash = "sha256:c51be697bfdfdf63bb71c5ecc51f7c6faf4aaa3d14a0136fa16e97cc37df1185"},
+    {file = "mysql_connector_python-9.7.0-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:b5cb8a3ba42b539f79cd13e4c8376d28506f3180f7079c9b04ea7bfd0424fb03"},
+    {file = "mysql_connector_python-9.7.0-cp311-cp311-macosx_14_0_x86_64.whl", hash = "sha256:5492d57a6a0e5127a928290737fbb91b66b46d31dac8de3e7604e550bf3b3a6e"},
+    {file = "mysql_connector_python-9.7.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:daf70f7da64a2e7c17e6dfd1fc98d2deb653fd955d0bd0b1fef246356e682b0f"},
+    {file = "mysql_connector_python-9.7.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:b8d3d6f32b95ae1d0a2f29d1a2b4e628849bcf7e84a70dc56c85b4929361d86b"},
+    {file = "mysql_connector_python-9.7.0-cp311-cp311-win_amd64.whl", hash = "sha256:079ce68d617250ef5cefffd5243056dc9f87c6034c804235fd6f45a0daf5a6ae"},
+    {file = "mysql_connector_python-9.7.0-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:2eae45230b5cbd783d68bdfe8b05ad9b4ebd06799f8d302a6169d7f025572baf"},
+    {file = "mysql_connector_python-9.7.0-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:15106ed73d74487f86de6b1859ff7f362efca7c7f9c494497ccb7439d3139fe6"},
+    {file = "mysql_connector_python-9.7.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:45491d4ce56722cb335e6d0bde2d4f4a98b7073421bd02a04ad5e6220d69e499"},
+    {file = "mysql_connector_python-9.7.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:d5924a76b530159c02f2fe8da4d3c6377ce1f5e195827e8ecbd36124673651d3"},
+    {file = "mysql_connector_python-9.7.0-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:e3842ecd62391a28c1dda5eb817f40418715e68482a8c146b3c478ac8bb7a23f"},
+    {file = "mysql_connector_python-9.7.0-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:9da73e212bb08e4df286506ffbda943063bbce448375a7db29748bb367f4e0af"},
+    {file = "mysql_connector_python-9.7.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:39bf31cdbe920eae08801eb829584dc27f70dadbdb3a5c3b78402f54cea87ab0"},
+    {file = "mysql_connector_python-9.7.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:236a4b8abfac8217517ce9e9edc735decf55282ada3890b3cd33770009f33d68"},
+    {file = "mysql_connector_python-9.7.0-cp313-cp313-win_amd64.whl", hash = "sha256:229ffce2333b88b59f8f034881e12dc85b309615338be9f843ed63923db99d52"},
+    {file = "mysql_connector_python-9.7.0-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:9e17ceb79c1c4c137a5994f8ca8c6a1ce8ebf83eda3ccc21dd67f2c1398680f0"},
+    {file = "mysql_connector_python-9.7.0-cp314-cp314-macosx_14_0_x86_64.whl", hash = "sha256:272c4e8263f6a514e4ae65e9553ed214fc9d4cf1f0f6bedca30def20c2ae1d52"},
+    {file = "mysql_connector_python-9.7.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:9549a2974353407427b574f005c92f03972e303182b4c3b4a272bf4ca10855ed"},
+    {file = "mysql_connector_python-9.7.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:ea4e05ab864ab8b0b5066d885d89ca51e5ba1320dba520c20a6f9388a8eca022"},
+    {file = "mysql_connector_python-9.7.0-cp314-cp314-win_amd64.whl", hash = "sha256:5a5abbc152bc28cb2e64a04605ecd9941eff6b0dc5f9528cb84adb873e9a1e49"},
+    {file = "mysql_connector_python-9.7.0-py2.py3-none-any.whl", hash = "sha256:af80b1e7179d5c2d983cf62470ad9b134a7e9ef05cf31108ae587f15873530cc"},
+    {file = "mysql_connector_python-9.7.0.tar.gz", hash = "sha256:933887e71c871b6e9d8908459fe8303ebcf8feb5cc1e1c49caa6490e525cf78e"},
+]
+
+[package.extras]
+dns-srv = ["dnspython (==2.6.1)"]
+gssapi = ["gssapi (==1.8.3)"]
+telemetry = ["opentelemetry-api (==1.33.1)", "opentelemetry-exporter-otlp-proto-http (==1.33.1)", "opentelemetry-sdk (==1.33.1)"]
+webauthn = ["fido2 (==1.1.2)"]
+
+[[package]]
 name = "ndindex"
 version = "1.10.1"
 description = "A Python library for manipulating indices of ndarrays."
@@ -3025,4 +3067,4 @@ tiled = ["tiled"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<3.12"
-content-hash = "4174b66192ca2b3210339e6ebccb5c2d1655791a001aa837574a61c27ff84529"
+content-hash = "3847f97558fe8922f276b5d5bbf809e76c331774d18041f6545df19d92a6d5f7"

--- a/GeecsBluesky/pyproject.toml
+++ b/GeecsBluesky/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-bluesky"
-version = "0.2.0"
+version = "0.3.0"
 description = "Bluesky / ophyd-async bridge for the GEECS control system"
 authors = ["Sam Barber <sbarber@lbl.gov>"]
 readme = "README.md"

--- a/GeecsBluesky/pyproject.toml
+++ b/GeecsBluesky/pyproject.toml
@@ -21,6 +21,7 @@ bluesky = ">=1.12"
 pandas = ">=2.1.1"
 nptdms = "^1.10.0"
 tiled = {version = ">=0.2", extras = ["client"], optional = true}
+mysql-connector-python = "^9.7.0"
 
 [tool.poetry.extras]
 tiled = ["tiled"]

--- a/GeecsBluesky/test_bluesky_scanner.py
+++ b/GeecsBluesky/test_bluesky_scanner.py
@@ -1,14 +1,17 @@
 """BlueskyScanner bridge — hardware integration test.
 
 Exercises the ScanManager-compatible API that RunControl uses, without launching
-the GUI.  Requires the lab network (GEECS DB + UC_ModeImager + U_ESP_JetXYZ).
+the GUI.  Requires lab network access (GEECS DB + UC_TopView + U_ESP_JetXYZ +
+U_DG645_ShotControl).
 
 Scenarios
 ---------
-1. NOSCAN  — fixed-position collection from UC_ModeImager (save enabled)
-             Verifies: scan folder created, save-path signals sent, N events.
-2. STANDARD — step scan U_ESP_JetXYZ 4→5 mm with UC_ModeImager as detector
+1. NOSCAN  — fixed-position collection from UC_TopView (acq_timestamp only)
+             Verifies: N events collected.
+2. STANDARD — step scan U_ESP_JetXYZ 4→5 mm with UC_TopView as detector
              Verifies: N positions × M shots events, motor readback in each event.
+3. NOSCAN with shot control — as scenario 1 but with U_DG645_ShotControl wired;
+             Verifies: DG645 Trigger.Source returns to STANDBY after scan.
 
 Run from GeecsBluesky/:
     poetry run python test_bluesky_scanner.py
@@ -17,23 +20,66 @@ Run from GeecsBluesky/:
 from __future__ import annotations
 
 import logging
-import os
 import time
-
-from geecs_data_utils import ScanConfig, ScanMode
+from types import SimpleNamespace
 
 from geecs_bluesky.scanner_bridge import BlueskyScanner
 
 logging.basicConfig(level=logging.INFO, format="%(name)s %(levelname)s %(message)s")
 
-MOTOR_DEVICE_VAR = "U_ESP_JetXYZ:Position.Axis 1"
 DETECTOR_DEVICES = {
-    "UC_ModeImager": {
-        "variable_list": ["hardware_timestamp"],
-        "save_nonscalar_data": True,
+    "UC_TopView": {
+        "variable_list": ["acq_timestamp"],
+        "save_nonscalar_data": False,
     },
 }
+
+SHOT_CONTROL_INFO = {
+    "device": "U_DG645_ShotControl",
+    "variables": {
+        "Trigger.ExecuteSingleShot": {
+            "OFF": "",
+            "SCAN": "",
+            "SINGLESHOT": "on",
+            "STANDBY": "",
+        },
+        "Trigger.Source": {
+            "OFF": "Single shot external rising edges",
+            "SCAN": "External rising edges",
+            "STANDBY": "External rising edges",
+        },
+    },
+}
+
 SHOTS_PER_STEP = 3
+REP_RATE_HZ = 1.0
+
+
+def _make_exec_config(
+    scan_mode: str,
+    wait_time: float = SHOTS_PER_STEP / REP_RATE_HZ,
+    device_var: str | None = None,
+    start: float = 0.0,
+    end: float = 1.0,
+    step: float = 0.5,
+    description: str = "",
+) -> SimpleNamespace:
+    """Build a fully duck-typed ScanExecutionConfig — no geecs_scanner import needed."""
+    scan_config = SimpleNamespace(
+        scan_mode=scan_mode,
+        device_var=device_var,
+        start=start,
+        end=end,
+        step=step,
+        wait_time=wait_time,
+        additional_description=description,
+    )
+    return SimpleNamespace(
+        scan_config=scan_config,
+        options=SimpleNamespace(rep_rate_hz=REP_RATE_HZ),
+        save_config=SimpleNamespace(Devices=DETECTOR_DEVICES),
+    )
+
 
 passed: list[str] = []
 failed: list[str] = []
@@ -45,13 +91,13 @@ def check(label: str, condition: bool, detail: str = "") -> None:
         print(f"  ✓  {label}")
         passed.append(label)
     else:
-        msg = f"{label}" + (f" — {detail}" if detail else "")
+        msg = label + (f" — {detail}" if detail else "")
         print(f"  ✗  {msg}")
         failed.append(msg)
 
 
 def poll(scanner: BlueskyScanner) -> None:
-    """Block until scanner finishes, printing progress."""
+    """Block until the scanner finishes, printing progress."""
     while scanner.is_scanning_active():
         pct = scanner.estimate_current_completion() * 100
         print(f"  {pct:.0f}%", end="\r")
@@ -59,115 +105,135 @@ def poll(scanner: BlueskyScanner) -> None:
     print()
 
 
-# ──────────────────────────────────────────────────────────────────────────────
-# Scenario 1: NOSCAN with save enabled
-# ──────────────────────────────────────────────────────────────────────────────
-print("\n=== Scenario 1: NOSCAN (UC_ModeImager, save_nonscalar_data=True) ===")
+# ---------------------------------------------------------------------------
+# Scenario 1: NOSCAN (no shot control)
+# ---------------------------------------------------------------------------
+print("\n=== Scenario 1: NOSCAN — UC_TopView, no shot control ===")
 
-scanner = BlueskyScanner(experiment_dir="Undulator")
-scanner.reinitialize(
-    config_dictionary={
-        "shots_per_step": SHOTS_PER_STEP,
-        "Devices": DETECTOR_DEVICES,
-    }
+scanner1 = BlueskyScanner(experiment_dir="Undulator")
+scanner1.reinitialize(
+    exec_config=_make_exec_config(
+        "noscan",
+        description="BlueskyScanner NOSCAN test",
+    )
 )
-
-scan_config = ScanConfig(
-    scan_mode=ScanMode.NOSCAN,
-    additional_description="BlueskyScanner NOSCAN save test",
-)
-
-scanner.start_scan_thread(scan_config)
-poll(scanner)
+scanner1.start_scan_thread()
+poll(scanner1)
 
 check(
-    "NOSCAN: events collected",
-    scanner._completed_shots == SHOTS_PER_STEP,
-    f"expected {SHOTS_PER_STEP}, got {scanner._completed_shots}",
+    "NOSCAN: event count",
+    scanner1._completed_shots == SHOTS_PER_STEP,
+    f"expected {SHOTS_PER_STEP}, got {scanner1._completed_shots}",
 )
 
-# Verify the scan folder and UC_ModeImager subdirectory were created.
-# _saving_detectors is cleared on disconnect, so we reconstruct the expected path.
-scan_folder_root = "/Volumes/hdna2/data/Undulator"
-today_dirs = []
-if os.path.isdir(scan_folder_root):
-    # Walk to find the most recently written scan folder (crude but sufficient)
-    for root, dirs, _ in os.walk(scan_folder_root):
-        for d in dirs:
-            if d.startswith("Scan") and d[4:].isdigit():
-                today_dirs.append(os.path.join(root, d))
-
-save_dir_found = any(
-    os.path.isdir(os.path.join(d, "UC_ModeImager")) for d in today_dirs
-)
-check(
-    "NOSCAN: UC_ModeImager save directory created",
-    save_dir_found,
-    "no Scan*/UC_ModeImager dir found under NetApp mount",
-)
-
-# ──────────────────────────────────────────────────────────────────────────────
-# Scenario 2: STANDARD step scan with motor + detector
-# ──────────────────────────────────────────────────────────────────────────────
-print("\n=== Scenario 2: STANDARD scan (JetXYZ 4→5 mm, UC_ModeImager) ===")
+# ---------------------------------------------------------------------------
+# Scenario 2: STANDARD step scan (no shot control)
+# ---------------------------------------------------------------------------
+print("\n=== Scenario 2: STANDARD — JetXYZ 4→5 mm, UC_TopView ===")
 
 POSITIONS = 3  # 4.0, 4.5, 5.0
-EXPECTED_EVENTS = POSITIONS * SHOTS_PER_STEP
+EXPECTED = POSITIONS * SHOTS_PER_STEP
 
 scanner2 = BlueskyScanner(experiment_dir="Undulator")
+events2: list[dict] = []
+scanner2._RE.subscribe(
+    lambda name, doc: events2.append(doc) if name == "event" else None
+)
+
 scanner2.reinitialize(
-    config_dictionary={
-        "shots_per_step": SHOTS_PER_STEP,
-        "Devices": DETECTOR_DEVICES,
-    }
+    exec_config=_make_exec_config(
+        "standard",
+        device_var="U_ESP_JetXYZ:Position.Axis 1",
+        start=4.0,
+        end=5.0,
+        step=0.5,
+        description="BlueskyScanner STANDARD test",
+    )
 )
-
-events: list[dict] = []
-
-
-def collect(name: str, doc: dict) -> None:
-    """RE callback: accumulate event documents and print per-shot summary."""
-    if name == "event":
-        events.append(doc)
-        step = len(events)
-        pos = doc["data"].get("u_esp_jetxyz_position_axis_1-position", "?")
-        ts = doc["data"].get("uc_modeimager-hardware_timestamp", "?")
-        print(f"  event {step:2d}: motor={pos}  hw_ts={ts}")
-
-
-scanner2._RE.subscribe(collect)
-
-scan_config2 = ScanConfig(
-    scan_mode=ScanMode.STANDARD,
-    device_var=MOTOR_DEVICE_VAR,
-    start=4.0,
-    end=5.0,
-    step=0.5,
-    additional_description="BlueskyScanner STANDARD scan test",
-)
-
-scanner2.start_scan_thread(scan_config2)
+scanner2.start_scan_thread()
 poll(scanner2)
 
 check(
     "STANDARD: event count",
-    len(events) == EXPECTED_EVENTS,
-    f"expected {EXPECTED_EVENTS}, got {len(events)}",
+    len(events2) == EXPECTED,
+    f"expected {EXPECTED}, got {len(events2)}",
+)
+motor_key = next(
+    (k for k in (events2[0]["data"] if events2 else {}) if "position" in k), None
 )
 check(
     "STANDARD: motor readback in every event",
-    all("u_esp_jetxyz_position_axis_1-position" in e["data"] for e in events),
+    motor_key is not None and all(motor_key in e["data"] for e in events2),
 )
 check(
-    "STANDARD: detector reading in every event",
-    all("uc_modeimager-hardware_timestamp" in e["data"] for e in events),
+    "STANDARD: acq_timestamp in every event",
+    all(any("acq_timestamp" in k for k in e["data"]) for e in events2),
 )
 
-# ──────────────────────────────────────────────────────────────────────────────
+# ---------------------------------------------------------------------------
+# Scenario 3: NOSCAN with shot control (U_DG645_ShotControl)
+# ---------------------------------------------------------------------------
+print("\n=== Scenario 3: NOSCAN with shot control (U_DG645_ShotControl) ===")
+
+scanner3 = BlueskyScanner(
+    experiment_dir="Undulator",
+    shot_control_information=SHOT_CONTROL_INFO,
+)
+scanner3.reinitialize(
+    exec_config=_make_exec_config(
+        "noscan",
+        description="BlueskyScanner shot-control test",
+    )
+)
+
+# Subscribe to see what's happening
+events3: list[dict] = []
+scanner3._RE.subscribe(
+    lambda name, doc: events3.append(doc) if name == "event" else None
+)
+
+scanner3.start_scan_thread()
+poll(scanner3)
+
+check(
+    "SHOT CTRL NOSCAN: event count",
+    scanner3._completed_shots == SHOTS_PER_STEP,
+    f"expected {SHOTS_PER_STEP}, got {scanner3._completed_shots}",
+)
+
+# Verify DG645 returned to STANDBY after scan.
+# Query the device directly via its UDP client (re-use geecs_data_utils DB lookup).
+try:
+    import asyncio
+
+    from geecs_bluesky.db.geecs_db import GeecsDb
+    from geecs_bluesky.transport.udp_client import GeecsUdpClient
+
+    host, port = GeecsDb.find_device("U_DG645_ShotControl")
+    udp = GeecsUdpClient(host, port, device_name="U_DG645_ShotControl")
+
+    async def _read_trigger_source() -> str:
+        await udp.connect()
+        val = await udp.get("Trigger.Source")
+        await udp.close()
+        return str(val)
+
+    trigger_source = asyncio.run(_read_trigger_source())
+    print(f"  DG645 Trigger.Source after scan: {trigger_source!r}")
+    check(
+        "SHOT CTRL NOSCAN: Trigger.Source returned to STANDBY value",
+        trigger_source == "External rising edges",
+        f"got {trigger_source!r}",
+    )
+except Exception as exc:
+    print(f"  Could not verify DG645 state: {exc}")
+    failed.append("SHOT CTRL NOSCAN: DG645 post-scan readback (exception)")
+
+# ---------------------------------------------------------------------------
 # Summary
-# ──────────────────────────────────────────────────────────────────────────────
+# ---------------------------------------------------------------------------
 print(f"\n=== Results: {len(passed)} passed, {len(failed)} failed ===")
 for f in failed:
     print(f"  FAILED: {f}")
 if not failed:
-    print("ALL CHECKS PASSED ✓")
+    print("ALL CHECKS PASSED")

--- a/GeecsBluesky/tests/test_shot_control.py
+++ b/GeecsBluesky/tests/test_shot_control.py
@@ -1,0 +1,312 @@
+"""Unit tests for shot control arm/disarm — no real hardware required.
+
+Covers:
+- _UdpSetter: string/numeric values sent correctly over fake UDP
+- _set_trigger_state: empty-string values skipped, correct per-state dispatch
+- geecs_step_scan: arm called after move, disarm after shots, per step
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+from typing import Any
+
+import pytest
+from bluesky import RunEngine
+from ophyd_async.core import AsyncStatus
+
+from geecs_bluesky.devices.camera import GeecsCameraBase
+from geecs_bluesky.devices.motor import GeecsMotor
+from geecs_bluesky.plans.step_scan import geecs_step_scan
+from geecs_bluesky.scanner_bridge.bluesky_scanner import BlueskyScanner, _UdpSetter
+from geecs_bluesky.testing.fake_device_server import FakeGeecsDevice, FakeGeecsServer
+from geecs_bluesky.transport.udp_client import GeecsUdpClient
+
+# Shot control config matching the real U_DG645_ShotControl YAML
+SHOT_CONTROL_VARS = {
+    "Trigger.ExecuteSingleShot": {
+        "OFF": "",
+        "SCAN": "",
+        "SINGLESHOT": "on",
+        "STANDBY": "",
+    },
+    "Trigger.Source": {
+        "OFF": "Single shot external rising edges",
+        "SCAN": "External rising edges",
+        "STANDBY": "External rising edges",
+    },
+}
+
+
+# ---------------------------------------------------------------------------
+# Helper
+# ---------------------------------------------------------------------------
+
+
+class _MockSetter:
+    """Records set() calls; no network needed."""
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+        self.calls: list[Any] = []
+
+    def set(self, value: Any) -> AsyncStatus:
+        self.calls.append(value)
+
+        async def _noop() -> None:
+            pass
+
+        return AsyncStatus(_noop())
+
+
+def _make_scanner_with_mock_setters() -> tuple[BlueskyScanner, dict[str, _MockSetter]]:
+    """Build a BlueskyScanner shell with injected mock setters (no __init__)."""
+    scanner = BlueskyScanner.__new__(BlueskyScanner)
+    scanner._RE = RunEngine()
+    scanner._shot_control_variables = SHOT_CONTROL_VARS
+    mock_setters = {var: _MockSetter(var) for var in SHOT_CONTROL_VARS}
+    scanner._shot_control_setters = mock_setters
+    return scanner, mock_setters
+
+
+# ---------------------------------------------------------------------------
+# _UdpSetter
+# ---------------------------------------------------------------------------
+
+
+class TestUdpSetter:
+    async def test_set_string_value(self) -> None:
+        """set() delivers a string value to the fake device."""
+        device = FakeGeecsDevice(
+            name="U_DG645_ShotControl",
+            variables={"Trigger.Source": "Single shot external rising edges"},
+        )
+        async with FakeGeecsServer(device) as srv:
+            udp = GeecsUdpClient(srv.host, srv.port, device_name="U_DG645_ShotControl")
+            await udp.connect()
+            setter = _UdpSetter(udp, "Trigger.Source")
+            await setter.set("External rising edges")
+            assert device.variables["Trigger.Source"] == "External rising edges"
+            await udp.close()
+
+    async def test_set_returns_async_status(self) -> None:
+        device = FakeGeecsDevice(
+            name="U_DG645_ShotControl",
+            variables={"Trigger.Source": "Single shot external rising edges"},
+        )
+        async with FakeGeecsServer(device) as srv:
+            udp = GeecsUdpClient(srv.host, srv.port, device_name="U_DG645_ShotControl")
+            await udp.connect()
+            setter = _UdpSetter(udp, "Trigger.Source")
+            status = setter.set("External rising edges")
+            assert isinstance(status, AsyncStatus)
+            await status
+            await udp.close()
+
+    async def test_set_numeric_value_sent_as_string(self) -> None:
+        """Numeric values are stringified; the fake server coerces back to float."""
+        device = FakeGeecsDevice(
+            name="U_DG645_ShotControl",
+            variables={"Delay": 0.0},
+        )
+        async with FakeGeecsServer(device) as srv:
+            udp = GeecsUdpClient(srv.host, srv.port, device_name="U_DG645_ShotControl")
+            await udp.connect()
+            setter = _UdpSetter(udp, "Delay")
+            await setter.set(0.001)
+            assert device.variables["Delay"] == pytest.approx(0.001)
+            await udp.close()
+
+
+# ---------------------------------------------------------------------------
+# _set_trigger_state
+# ---------------------------------------------------------------------------
+
+
+class TestSetTriggerState:
+    def test_scan_state_skips_empty_variables(self) -> None:
+        """SCAN state: Trigger.ExecuteSingleShot (empty) must be skipped."""
+        scanner, setters = _make_scanner_with_mock_setters()
+        scanner._RE(scanner._set_trigger_state("SCAN"))
+
+        assert setters["Trigger.ExecuteSingleShot"].calls == []
+        assert setters["Trigger.Source"].calls == ["External rising edges"]
+
+    def test_standby_state_skips_empty_variables(self) -> None:
+        """STANDBY state: same empty-value skipping as SCAN."""
+        scanner, setters = _make_scanner_with_mock_setters()
+        scanner._RE(scanner._set_trigger_state("STANDBY"))
+
+        assert setters["Trigger.ExecuteSingleShot"].calls == []
+        assert setters["Trigger.Source"].calls == ["External rising edges"]
+
+    def test_singleshot_sets_execute_variable(self) -> None:
+        """SINGLESHOT: ExecuteSingleShot gets 'on'; Source has no SINGLESHOT entry."""
+        scanner, setters = _make_scanner_with_mock_setters()
+        scanner._RE(scanner._set_trigger_state("SINGLESHOT"))
+
+        assert setters["Trigger.ExecuteSingleShot"].calls == ["on"]
+        assert setters["Trigger.Source"].calls == []
+
+    def test_off_state_sets_source(self) -> None:
+        """OFF state: Source set to single-shot mode string."""
+        scanner, setters = _make_scanner_with_mock_setters()
+        scanner._RE(scanner._set_trigger_state("OFF"))
+
+        assert setters["Trigger.ExecuteSingleShot"].calls == []
+        assert setters["Trigger.Source"].calls == ["Single shot external rising edges"]
+
+    def test_no_setters_is_noop(self) -> None:
+        """Empty setters dict produces an empty plan without error."""
+        scanner = BlueskyScanner.__new__(BlueskyScanner)
+        scanner._RE = RunEngine()
+        scanner._shot_control_variables = {}
+        scanner._shot_control_setters = {}
+        scanner._RE(scanner._set_trigger_state("SCAN"))  # must not raise
+
+
+# ---------------------------------------------------------------------------
+# geecs_step_scan arm/disarm ordering
+# ---------------------------------------------------------------------------
+
+
+def _run_server_with_shot_firer(
+    device: FakeGeecsDevice,
+    ready: threading.Event,
+    host_port: list,
+    shot_interval: float = 0.15,
+) -> None:
+    """Background thread: run the fake server and fire shots periodically."""
+
+    async def _main() -> None:
+        async with FakeGeecsServer(device) as srv:
+            host_port.extend([srv.host, srv.port])
+            ready.set()
+            try:
+                while True:
+                    await asyncio.sleep(shot_interval)
+                    device.fire_shot()
+            except asyncio.CancelledError:
+                pass
+
+    loop = asyncio.new_event_loop()
+
+    async def _wrapper() -> None:
+        task = loop.create_task(_main())
+        await task
+
+    try:
+        loop.run_until_complete(_wrapper())
+    except Exception:
+        pass
+    finally:
+        loop.close()
+
+
+@pytest.fixture
+def combined_device() -> FakeGeecsDevice:
+    return FakeGeecsDevice(
+        name="U_Combined",
+        variables={
+            "Position (mm)": 0.0,
+            "SavedFile": "/data/shot001.tif",
+            "acq_timestamp": 1000.0,
+        },
+    )
+
+
+class TestStepScanArmDisarmOrdering:
+    def test_arm_disarm_ordering(self, combined_device: FakeGeecsDevice) -> None:
+        """arm runs after move, disarm runs after shots — verified per step.
+
+        With 2 positions × 2 shots:
+          step 1: arm(events=0) → 2 shots → disarm(events=2)
+          step 2: arm(events=2) → 2 shots → disarm(events=4)
+        """
+        ready = threading.Event()
+        host_port: list = []
+
+        srv_thread = threading.Thread(
+            target=_run_server_with_shot_firer,
+            args=(combined_device, ready, host_port),
+            daemon=True,
+        )
+        srv_thread.start()
+        ready.wait(timeout=5.0)
+        assert host_port, "FakeGeecsServer failed to start"
+        host, port = host_port[0], host_port[1]
+
+        motor = GeecsMotor("U_Combined", "Position (mm)", host, port, name="test_motor")
+        cam = GeecsCameraBase("U_Combined", host, port, name="test_cam")
+
+        events: list[dict] = []
+        arm_at: list[int] = []
+        disarm_at: list[int] = []
+
+        def mock_arm():
+            arm_at.append(len(events))
+            yield from []
+
+        def mock_disarm():
+            disarm_at.append(len(events))
+            yield from []
+
+        RE = RunEngine()
+        RE.subscribe(lambda name, doc: events.append(doc) if name == "event" else None)
+
+        asyncio.run_coroutine_threadsafe(motor.connect(), RE._loop).result(timeout=10)
+        asyncio.run_coroutine_threadsafe(cam.connect(), RE._loop).result(timeout=10)
+
+        RE(
+            geecs_step_scan(
+                motor=motor,
+                positions=[0.0, 1.0],
+                detectors=[cam],
+                shots_per_step=2,
+                arm_trigger=mock_arm,
+                disarm_trigger=mock_disarm,
+            )
+        )
+
+        assert len(events) == 4, f"Expected 4 events, got {len(events)}"
+        assert arm_at == [0, 2], f"arm called at wrong event counts: {arm_at}"
+        assert disarm_at == [2, 4], f"disarm called at wrong event counts: {disarm_at}"
+
+    def test_no_arm_disarm_still_collects_events(
+        self, combined_device: FakeGeecsDevice
+    ) -> None:
+        """arm_trigger=None runs normally — backward compat with internal trigger."""
+        ready = threading.Event()
+        host_port: list = []
+
+        srv_thread = threading.Thread(
+            target=_run_server_with_shot_firer,
+            args=(combined_device, ready, host_port),
+            daemon=True,
+        )
+        srv_thread.start()
+        ready.wait(timeout=5.0)
+        host, port = host_port[0], host_port[1]
+
+        motor = GeecsMotor(
+            "U_Combined", "Position (mm)", host, port, name="test_motor2"
+        )
+        cam = GeecsCameraBase("U_Combined", host, port, name="test_cam2")
+
+        events: list[dict] = []
+        RE = RunEngine()
+        RE.subscribe(lambda name, doc: events.append(doc) if name == "event" else None)
+        asyncio.run_coroutine_threadsafe(motor.connect(), RE._loop).result(timeout=10)
+        asyncio.run_coroutine_threadsafe(cam.connect(), RE._loop).result(timeout=10)
+
+        RE(
+            geecs_step_scan(
+                motor=motor,
+                positions=[0.0],
+                detectors=[cam],
+                shots_per_step=3,
+            )
+        )
+
+        assert len(events) == 3


### PR DESCRIPTION
## Summary

- **Per-step DG645 shot control** — `BlueskyScanner` accepts `shot_control_information` (matching the existing timing YAML format). The DG645 is armed to `SCAN` after each motor move and disarmed to `STANDBY` after shots, keeping the trigger off during motion. A `finalize_wrapper` guarantees disarm on abort.
- **`geecs_step_scan` arm/disarm parameters** — `arm_trigger` / `disarm_trigger` optional plan callables added; called per step around the acquisition window.
- **`_UdpSetter`** — minimal Bluesky `Movable` wrapping a single GEECS variable over UDP; used internally for shot control without ophyd device overhead.
- **`ScanExecutionConfig` API** — `reinitialize(exec_config)` now accepts the validated Pydantic model from the GUI; `shots_per_step` derived from `rep_rate_hz × wait_time`.
- **Unit tests** (`tests/test_shot_control.py`) — 10 tests covering `_UdpSetter`, `_set_trigger_state`, and arm/disarm ordering; all run against `FakeGeecsServer`, no hardware required.
- **Hardware integration test** (`test_bluesky_scanner.py`) — 3 scenarios (NOSCAN, STANDARD step scan, NOSCAN with DG645 shot control); all 6 checks pass on real lab hardware (UC_TopView, U_ESP_JetXYZ 4→5 mm, U_DG645_ShotControl).
- **`mysql-connector-python`** added as a direct Poetry dependency.
- **Docs** — new `GeecsBluesky/CLAUDE.md`; CHANGELOG 0.3.0; ROADMAP, TILED_SETUP, README refreshed; root CLAUDE.md updated.

## Test plan

- [ ] `poetry run pytest tests/ -v` — all tests pass (no hardware needed)
- [ ] `poetry run python test_bluesky_scanner.py` — all 6 checks pass (requires lab network + UC_TopView, U_ESP_JetXYZ, U_DG645_ShotControl)

🤖 Generated with [Claude Code](https://claude.com/claude-code)