### PR TITLE
docs: add skills overview and contributor guide

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -125,14 +125,47 @@ Every package has a `CHANGELOG.md` following
 
 Git tags on merge to master: `geecs-scanner-v0.8.0`, `geecs-python-api-v0.3.1`, etc.
 
-## Architectural Roadmap
+## Known debt we have deliberately deferred
 
-A full refactor roadmap lives in `ROADMAP.md` in separate branch. Read it before
-making major structural changes. Key points:
+Items below are *known* and *intentionally not being fixed right now*. If you
+look at them and think "this is bad, let me fix it" — please don't. The
+deferral is deliberate; the rationale is below. If you encounter a feature
+request whose natural scope overlaps one of these, that's the right time to
+revisit. Speculative cleanup is not.
 
-- The goal is a headless-capable scan engine with explicit state, a typed event
-  stream, and a single `DeviceCommandExecutor` owning all device interactions
-- `ScanManager` can already run headlessly — the GUI adds display and dialogs only
-- `device.set()` calls are currently scattered; consolidation is Block 6 of the
-  roadmap and requires earlier blocks to be in place first
-- Breaking changes are acceptable in the name of better organisation
+- **`GEECS-Scanner-GUI/geecs_scanner/app/app_controller.py` is a thin
+  pass-through layer.** It was extracted from the main window during the bold
+  refactor (PR landed May 2026) and ended up as a side struct that adds an
+  indirection without removing complexity. We considered reverting; the cost
+  of churn outweighs the benefit at this point. Leave it; it's harmless. Do
+  not invest in extending it.
+
+- **`GEECS-Scanner-GUI/geecs_scanner/engine/data_logger.py` and
+  `device_manager.py` lack behavioral tests for several internal paths.** The
+  code works in production; a future Bluesky-backed scan path may obsolete
+  significant parts of these modules. Adding deep tests now risks pinning
+  internals we don't intend to keep. If you need to *change* DataLogger or
+  DeviceManager, write tests for the specific behavior you're modifying as
+  part of that change.
+
+- **`ScanConfig` lives in `geecs_data_utils` rather than
+  `geecs_scanner.engine.models`.** This is logically backwards (engine config
+  in the data-utils package) but the migration touches many files across two
+  packages and has no forcing function. Defer until a feature naturally takes
+  you into that area.
+
+- **`GEECS-Scanner-GUI/geecs_scanner/app/geecs_scanner.py` is ~2200 lines and
+  mixes seven concerns** (save-element list management, scan variable
+  handling, presets, shot calculation, scan submission, optimization config,
+  toolbar/menu wiring). Adding a new scan mode currently touches six places.
+  Documented organizational debt; the fix is concern-cluster extraction (or a
+  base class for editor windows). Wait for a specific feature ("add a new
+  scan mode," "add a new editor") to drive the refactor with bounded scope.
+
+- **`GEECS-PythonAPI` is being refactored elsewhere.** Don't add features here
+  or restructure it. Other packages use it through `ScanDevice` and the
+  database dict lookup; treat that as the public surface.
+
+If you find yourself adding to this list, consider whether you're capturing
+real institutional knowledge or accumulating procrastination. Both are
+possible.

--- a/docs/geecs_scanner/troubleshooting.md
+++ b/docs/geecs_scanner/troubleshooting.md
@@ -2,7 +2,7 @@
 
 This page is a starter index for the failures you're most likely to encounter and what to do about each. It's organized by where the problem becomes visible — the GUI, a scan that aborts, missing data, etc.
 
-For a structured analysis of a specific scan's log, run the `triage` tool:
+For a structured analysis of a specific scan's log, run the [`/triage` skill](../skills/overview.md) from a Claude Code session, or call the underlying CLI directly:
 
 ```bash
 poetry run triage path/to/Scan042/Scan042.log
@@ -110,7 +110,7 @@ This used to happen when a worker thread blocked on a dialog that was supposed t
 
 In the meantime: from the terminal that launched the GUI, Ctrl+C will hit the engine. If the scan thread is stuck on hardware, you may need to kill the Python process and look at the device that wasn't responding.
 
-## When `triage` says it's a code bug
+## When [`/triage`](../skills/overview.md) says it's a code bug
 
 Open an issue with:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,6 +10,7 @@ A collection of Python tools for laser-plasma experiments at [Lawrence Berkeley 
 | **Add a device to a scan** | [Save Elements](geecs_scanner/save_elements.md) — the YAML format for what to record |
 | **Find your data on disk** | [Scan Output Structure](geecs_scanner/scan_output_structure.md) — what's in `Scan###/` and how to load each file |
 | **Diagnose why a scan failed** | [Troubleshooting](geecs_scanner/troubleshooting.md) — common errors and what they mean |
+| **Diagnose recurring scan failures with /triage** | [Skills — Overview](skills/overview.md) |
 | **Analyze images from a camera** | [Image Analysis — Basic Offline Analysis](image_analysis/examples/basic_offline_analysis.ipynb) |
 | **Find the right analyzer for your diagnostic** | [Analyzer Index](image_analysis/analyzer_index.md) — beam profile, FROG, magspec, ICT, HASO |
 | **Run analysis across a scan** | [Scan Analysis — Basic Usage](scan_analysis/examples/basic_usage.ipynb) |

--- a/docs/skills/overview.md
+++ b/docs/skills/overview.md
@@ -1,0 +1,69 @@
+# Skills
+
+A **skill** in this repository is a markdown command file under `.claude/commands/` that wraps a CLI tool and is invoked as a slash command from a [Claude Code](https://claude.ai/code) session. The pattern works because of a clean layering: a deterministic Python CLI does the structured, reproducible work — parsing logs, querying databases, walking scan folders — and the agent handles the parts that benefit from language understanding: summarizing findings, locating relevant source code, drafting GitHub issues, asking clarifying questions. Each layer is independently testable and independently useful. The CLI can be run by a script or a human without an agent; the agent can be swapped out without changing the CLI. The same separation that makes the scan engine's typed event stream robust applies here: a well-defined contract between a deterministic core and a flexible consumer.
+
+## Shipped skills
+
+### /triage — diagnose scan failures and draft bug reports
+
+`/triage` walks one or more scan logs, groups errors into stable fingerprints, classifies each fingerprint as a bug candidate, hardware issue, config issue, or operator error, and then — for each bug candidate — locates the relevant source code, reasons about why the failure happens, and drafts a GitHub issue for your review before filing anything.
+
+**When to use it:**
+
+- A scan just aborted and you want to know whether the cause was hardware, misconfiguration, or a code bug.
+- You want a weekly sweep across a date range to find recurring patterns before they accumulate into a backlog.
+
+**Typical invocations:**
+
+```
+/triage --date 2026-05-08 --experiment HTU
+```
+
+```
+/triage --date 2026-05-08 --experiment HTU --scan 42
+```
+
+```
+/triage --date-range 2026-05-01:2026-05-08 --experiment HTU
+```
+
+```
+/triage --scan-folder /path/to/Scan037
+```
+
+**What happens:**
+
+The agent runs the underlying `geecs-log-triage` CLI twice: once as JSON (for its own analysis) and once as markdown (written as `triage.md` next to the scan data for human reference). It prints a one-paragraph summary — scans examined, total errors, count per classification — and then for each `bug_candidate` fingerprint it reads the relevant source code, writes a draft issue body with a root-cause hypothesis and a suggested fix, and shows all drafts before asking which ones to file. Fingerprints that already have an open GitHub issue are skipped automatically.
+
+Hardware issues, config issues, and operator errors appear in the summary but do not produce issues unless you ask explicitly.
+
+**Underlying CLI:**
+
+If you want the triage report without the agent layer:
+
+```bash
+cd GEECS-LogTriage
+poetry run geecs-log-triage --date 2026-05-08 --experiment HTU
+# writes triage.md next to the scan data
+
+poetry run geecs-log-triage --date 2026-05-08 --experiment HTU --format json
+# emits TriageReport JSON to stdout
+
+poetry run geecs-log-triage --scan-folder /path/to/Scan037
+# single-scan mode; prints markdown to stdout
+```
+
+The `TriageReport` JSON can be piped into any downstream tool — a notebook, a dashboard, another script — without involving the agent at all.
+
+## Installation
+
+The skill file ships with the repository at `.claude/commands/triage.md`. If Claude Code is configured to read project-level commands (the default when you open the monorepo root), `/triage` is available immediately after cloning. No extra installation step is needed for the slash command itself.
+
+The underlying CLI requires a one-time setup:
+
+```bash
+cd GEECS-LogTriage
+poetry install
+```
+
+Run this once from the monorepo root. After that, the agent and the CLI both work from the same poetry environment.

--- a/docs/skills/writing_a_skill.md
+++ b/docs/skills/writing_a_skill.md
@@ -1,0 +1,82 @@
+# Writing a Skill
+
+This page is for contributors who want to add a new skill to the repository. Read the [Skills Overview](overview.md) first if you haven't — it covers what a skill is and why the pattern exists.
+
+## The two-layer pattern
+
+Every skill has exactly two parts:
+
+**A Python CLI tool** that does the deterministic work. It accepts well-typed arguments, produces structured output (JSON to stdout, markdown to disk), and has no dependency on any agent or LLM. It can be run by a human, a script, or a CI job. It can be tested with pytest against fixtures. It has a version and a changelog.
+
+**A markdown slash command** in `.claude/commands/<name>.md` that wraps invocation of the CLI and describes to the agent how to interpret and act on the output. The markdown file is the UX layer for agentic use; it documents the argument forms, the expected output shape, and what the agent should do at each stage.
+
+The separation matters for the same reason the scanner engine's typed event stream matters: the CLI is the stable contract. The agent is a consumer of that contract, not part of its implementation. When you upgrade the LLM, the CLI doesn't change. When you want to run the CLI in a notebook, you don't need the agent. When you want to test the skill end-to-end, you test the CLI against real or synthetic inputs and separately test that the command file's instructions produce sensible agent behavior on known CLI output.
+
+## How /triage is built
+
+`/triage` is the reference implementation. Walking through it concretely is more useful than abstract guidelines.
+
+**The CLI** lives in `GEECS-LogTriage/`. Its entry point is `geecs_log_triage.cli:main`, registered in `pyproject.toml` as `geecs-log-triage`. The CLI walks one or more scan folders, parses each `scan.log` file, normalizes errors into stable fingerprints via `ErrorFingerprint` (exception type + file + function, hashed to a short string), classifies each fingerprint as `bug_candidate`, `hardware_issue`, `config_issue`, or `operator_error`, and assembles a `TriageReport` Pydantic model.
+
+**Output shape.** The CLI has two output modes controlled by `--format`:
+
+- Default (no flag): writes a human-readable markdown summary as `triage.md` alongside the scan data. Good for a lab operator reading the file directly.
+- `--format json`: serializes the `TriageReport` to stdout as JSON. Good for the agent — structured, typed, and parseable without screen-scraping.
+
+The agent uses both. It runs the CLI twice: once with `--format json` to get the structured data it reasons over, and once without to produce the human-readable file that persists on disk. This is the standard contract: **JSON to stdout for the agent, markdown to disk for the human**.
+
+**The slash command** lives at `.claude/commands/triage.md`. It defines five stages:
+
+1. Environment check — verify the poetry env is ready before running anything.
+2. Generate the report — run both CLI invocations described above.
+3. Summarise — print a brief count of errors and classifications.
+4. Analyze bug candidates — for each `bug_candidate` fingerprint, locate the relevant source file in the monorepo, read the failing function, form a root-cause hypothesis, and draft a GitHub issue.
+5. Confirm and file — show all drafts, ask which to file, run `gh issue create` for each confirmed one.
+
+The markdown file is instruction, not code. It describes what the agent should do with the CLI output. It does not contain any Python. It does not hard-code paths that could drift.
+
+## The contract worth standardizing
+
+For any new skill, follow this convention:
+
+| Layer | What it does | Output |
+|---|---|---|
+| CLI | Deterministic work: parse, query, classify, compute | JSON to stdout (`--format json`), markdown file to disk (default) |
+| Slash command | Agentic UX: invoke CLI, interpret output, reason, act | Agent conversation; optional side effects (issues filed, files written) |
+
+Keeping these two forms of output separate — machine-readable JSON for the agent, human-readable markdown for the operator — means both audiences get what they need without either compromising the other. A triage report that's easy to read in a terminal is not necessarily easy to parse reliably; a report that's easy to parse is not necessarily readable. Emit both.
+
+## Adding a new skill
+
+**Step 1: build the CLI tool.** Create a new package in the monorepo following the existing pattern (`GEECS-LogTriage/` is the template). The CLI should:
+
+- Accept well-typed arguments via `argparse` or `click`.
+- Return exit code 0 on success, non-zero on failure.
+- Write `--format json` output to stdout with a stable schema (a Pydantic model is the right choice).
+- Write the human-readable default output to a predictable location on disk (next to the data it analyzed).
+- Have tests that run against synthetic fixtures without network access.
+
+**Step 2: write the slash command.** Create `.claude/commands/<name>.md`. The file should cover:
+
+- What arguments the underlying CLI accepts, with examples for each common form.
+- How to check that the environment is ready before running.
+- What the agent should do with each part of the CLI output.
+- What the agent should show the user and when to ask for confirmation before taking irreversible actions (filing issues, moving files, etc.).
+
+Keep the instruction file honest about what the agent cannot do reliably — hallucinating bug fixes without reading the source code, for example. Name those boundaries explicitly so the skill degrades gracefully when it hits them.
+
+**Step 3: document it** in [Skills — Overview](overview.md). Add a section following the `/triage` pattern: what problem it solves, when to use it, a worked invocation, and the CLI surface for users who want to skip the agent layer.
+
+## Candidate next skills
+
+These are worth building when you've heard the same question twice from different people — not speculatively:
+
+**`/scan-info`** — given a scan number (and optionally an experiment and date), summarize what the scan was: scan type, devices, variable range, shot count, any errors in the log. The CLI would wrap `geecs_data_utils.ScanPaths` and the log parser from `GEECS-LogTriage`. The agent would add context: "this device had a timeout on step 3, and the next scan that day worked fine."
+
+**`/find-scans`** — query the scan database by date range, experiment, scan variable, or device name. Returns matching scan numbers. The CLI is a thin wrapper around `geecs_data_utils`; the agent surfaces the results in a way that's useful for deciding which scan to load into a notebook.
+
+**`/diff-scans`** — compare two scans by scan number. Difference in scalar summary statistics, device lists, log error counts. Useful for "scan 42 worked, scan 43 didn't — what changed?" The output is a structured diff; the agent interprets what's significant.
+
+**`/issue-from-log`** — given a scan log path, draft a GitHub issue with the full context pre-filled: scan tag, exception, traceback, save element YAML, config version. Overlaps with `/triage` for the single-scan case, but without the classification step — useful when you already know something is a bug and just want the issue written.
+
+**`/save-element-check`** — validate a save element YAML against the live experiment database. The CLI queries the database, checks that each device and variable exists, and reports missing entries. The agent explains what each missing entry probably means and suggests corrections.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -39,6 +39,10 @@ nav:
       - Notes and Discussions:
           - Bayesian optimization for e-beam brightness: geecs_scanner/notes_and_discussions/optimization/bayesian optimization for e-beam brightness.md
 
+  - Skills:
+      - Overview: skills/overview.md
+      - Writing a Skill: skills/writing_a_skill.md
+
   - Image Analysis:
       - Overview: image_analysis/overview.md
       - Analyzer Index: image_analysis/analyzer_index.md


### PR DESCRIPTION
## Summary

- New `docs/skills/overview.md` — user-facing landing page for skills: what `/triage` does, invocation examples, the underlying CLI surface, and installation
- New `docs/skills/writing_a_skill.md` — contributor guide: the two-layer CLI+slash-command pattern, how `/triage` is built as the reference implementation, the JSON/markdown output contract, and candidate next skills
- New **Skills** tab in nav (between Scanner GUI and Image Analysis)
- `docs/index.md`: added `/triage` row to the "Where to start" table
- `docs/geecs_scanner/troubleshooting.md`: bare `triage` mentions linked to `skills/overview.md`

## Test plan

- [ ] `poetry run mkdocs build` completes with no errors and no new warnings
- [ ] Skills tab appears in nav
- [ ] Both new pages render without errors
- [ ] Cross-links from troubleshooting.md resolve correctly

🤖 Generated with [Claude Code](https://claude.ai/claude-code)