### PR TITLE
fix: formalise Python 3.11 minimum and align mysql-connector-python

### DIFF
--- a/GEECS-PythonAPI/CHANGELOG.md
+++ b/GEECS-PythonAPI/CHANGELOG.md
@@ -3,11 +3,21 @@
 All notable changes to this package will be documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
-## [0.4.3] — 2026-05-11
+## [0.5.0] — 2026-05-11
+
+### Changed
+- **Python 3.11 now required** when used alongside `geecs-scanner-gui` /
+  `GeecsBluesky`. Constraint updated from `>=3.10` to `>=3.11`.
+- `pyproject.toml`: bump `mysql-connector-python` from `^8.2.0` to `^9.7.0` to
+  align with `GeecsBluesky` and make the full monorepo co-installable.
 
 ### Changed
 - `pyproject.toml`: bump `mysql-connector-python` from `^8.2.0` to `^9.7.0` to
   align with `GeecsBluesky` and make the full monorepo co-installable.
+
+## [0.4.3] — 2026-05-11 *(superseded by 0.5.0)*
+
+*(Rolled into 0.5.0 — do not install this version separately.)*
 
 ## [0.4.2] — 2026-05-08
 

--- a/GEECS-PythonAPI/CHANGELOG.md
+++ b/GEECS-PythonAPI/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this package will be documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.4.3] — 2026-05-11
+
+### Changed
+- `pyproject.toml`: bump `mysql-connector-python` from `^8.2.0` to `^9.7.0` to
+  align with `GeecsBluesky` and make the full monorepo co-installable.
+
 ## [0.4.2] — 2026-05-08
 
 ### Removed

--- a/GEECS-PythonAPI/pyproject.toml
+++ b/GEECS-PythonAPI/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-pythonapi"
-version = "0.4.2"
+version = "0.4.3"
 description = "Python interface to GEECS control system"
 authors = ["Guillaume Plateau <guillaume.plateau@tausystems.com>", "Sam Barber <sbarber@lbl.gov>"]
 readme = "README.md"
@@ -29,7 +29,7 @@ screeninfo = "^0.8.1"
 # other
 python-dotenv = "^1.0.0"
 progressbar2 = "^4.2.0"
-mysql-connector-python = "^8.2.0"
+mysql-connector-python = "^9.7.0"
 
 # internal libraries
 ImageAnalysis = { path = "../ImageAnalysis", develop = true }

--- a/GEECS-PythonAPI/pyproject.toml
+++ b/GEECS-PythonAPI/pyproject.toml
@@ -1,13 +1,13 @@
 [tool.poetry]
 name = "geecs-pythonapi"
-version = "0.4.3"
+version = "0.5.0"
 description = "Python interface to GEECS control system"
 authors = ["Guillaume Plateau <guillaume.plateau@tausystems.com>", "Sam Barber <sbarber@lbl.gov>"]
 readme = "README.md"
 packages = [{include = "geecs_python_api"}]
 
 [tool.poetry.dependencies]
-python = ">=3.10,<3.12"
+python = ">=3.11,<3.12"
 
 # numerical packages
 numpy = ">=2.0,<3.0"

--- a/GEECS-Scanner-GUI/CHANGELOG.md
+++ b/GEECS-Scanner-GUI/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to this package will be documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.17.0] — 2026-05-11
+
+### Changed
+- **Python 3.11 now required.** `GeecsBluesky` (a hard dependency) requires
+  `>=3.11` via `ophyd-async`; the `pyproject.toml` constraint is updated to
+  reflect this. Users on 3.10 must upgrade before installing.
+
 ## [0.16.0] — 2026-05-08
 
 ### Changed — Bold Refactor: Delete and Extract

--- a/GEECS-Scanner-GUI/README.md
+++ b/GEECS-Scanner-GUI/README.md
@@ -1,6 +1,6 @@
 # Data Acquisition Module
 
-This is a GUI wrapper for the Python-based data acquisition module in 
+This is a GUI wrapper for the Python-based data acquisition module in
 `./geecs_scanner/data_acquisition/` that utilizes `GEECS-PythonAPI`.  It was originally
 developed for HTU, but it is designed to be generally usable by any
 experiment using the GEECS/Master Control environment.
@@ -20,13 +20,15 @@ While Master Control scans save everything, will crash or slowdown at any device
 
 ## Installation
 
-Requires GEECS-Plugins installed somewhere, Python 3.10, and Poetry.  Can be run off of the Z: drive version, but it is not recommended to edit this version directly.  Beyond basic usage, we recommend cloning your own copy of the repo with `Github Desktop`.
+Requires GEECS-Plugins installed somewhere, **Python 3.11**, and Poetry.  Can be run off of the Z: drive version, but it is not recommended to edit this version directly.  Beyond basic usage, we recommend cloning your own copy of the repo with `Github Desktop`.
 
-Python 3.10 can be installed from the following link:
-```link
-https://www.python.org/downloads/release/python-31011/
+Python 3.11 can be installed from the following link:
 ```
-Can download and use the `Windows installer (64-bit)` link.  Remember to select the "Add to Path" checkbox at the bottom of the installation window.
+https://www.python.org/downloads/release/python-31113/
+```
+Download and run the `Windows installer (64-bit)`.  Remember to check **"Add Python to PATH"** at the bottom of the installation window.
+
+> **Upgrading from Python 3.10?** See the [Migrating from Python 3.10](#migrating-from-python-310) section below.
 
 For Poetry, install using their official command-line
 ```link
@@ -49,7 +51,7 @@ For the `GEECS user data location` information, you will need to copy the existi
 
 Alternatively, you can use the included bash script `GEECS_Scanner.sh` to launch the version of the GUI on the Z drive.  This can be modified if needed.
 
-Note:  this may not work if your default python version is not 3.10.  You can see what python version your system defaults to by typing `python --verison`.  If you are experiencing troubles with poetry here, might need to manually specify which python version to use in these two commands.
+Note:  this may not work if your default python version is not 3.11.  You can see what python version your system defaults to by typing `python --version`.  If you are experiencing troubles with poetry here, you may need to manually specify the Python version — see [Migrating from Python 3.10](#migrating-from-python-310) below.
 
 ### Setting up the environment for development
 
@@ -57,11 +59,11 @@ Open a terminal.  Change directory to this folder (the one with `pyproject.toml`
 ```commandline
 poetry install
 ```
-If this doesn't work, you have too many python versions installed on your computer.  To specify, go to `Edit the system environment variables` in your Windows search bar and look up where Python 3.10 lives in your Path variable.  Copy the entire path to the `python.exe` file and use that with poetry.
+If this doesn't work, you have too many python versions installed on your computer.  To specify, go to `Edit the system environment variables` in your Windows search bar and look up where Python 3.11 lives in your Path variable.  Copy the entire path to the `python.exe` file and use that with poetry.
 
-For example, if my Python 3.10 executable is in `C:\Users\loasis.LOASIS\AppData\Local\Programs\Python\Python310\python.exe` then I run the commands
+For example, if my Python 3.11 executable is in `C:\Users\loasis.LOASIS\AppData\Local\Programs\Python\Python311\python.exe` then I run the commands
 ```commandline
-poetry env use C:\Users\loasis.LOASIS\AppData\Local\Programs\Python\Python310\python.exe
+poetry env use C:\Users\loasis.LOASIS\AppData\Local\Programs\Python\Python311\python.exe
 poetry install
 ```
 
@@ -88,7 +90,7 @@ The gui's themselves are developed using `pyqt5`, which is a python package for 
 
 ## Tutorial
 
-This section serves as a guide to running the software once you are able to successfully launch it.  
+This section serves as a guide to running the software once you are able to successfully launch it.
 
 ### Experiment Config
 
@@ -131,7 +133,7 @@ You have the option to save and load presets for scans.  When you have configure
 
 As with Master Control, `Start` will start the scan, `Stop` will stop it.  If a scan is stopped partway through, the data that was saved is still accessible through the data folder.
 
-Notes:  Things seem to crash if you immediately try to stop a scan after starting one.  Also starting a scan with no save elements also seems to cause issues.  
+Notes:  Things seem to crash if you immediately try to stop a scan after starting one.  Also starting a scan with no save elements also seems to cause issues.
 
 ### Multiscanner
 
@@ -145,7 +147,7 @@ To add more functionality, you can enable the `Scan Commands` checkbox to enable
 
 ## Core Classes
 
-TODO, right now files are separated by GUI window and each python file contains all functionality.  `RunControl.py` is the interface between the main window GUI `GEECSScanner.py` and the backend managed by `geecs_python_api/controls/data_acquisition/scan_manager.py`.  
+TODO, right now files are separated by GUI window and each python file contains all functionality.  `RunControl.py` is the interface between the main window GUI `GEECSScanner.py` and the backend managed by `geecs_python_api/controls/data_acquisition/scan_manager.py`.
 
 ## Future Improvements
 
@@ -159,6 +161,33 @@ Current improvements on the wishlist:
 * GUI for viewing/editing the actions defined in `actions.yaml`, as well as executing actions without running a scan
 * Checkbox to toggle if scan variables return to original position after the scan or not
 * Long-term goal, implement an "optimization" scan with Xopt
+
+## Migrating from Python 3.10
+
+As of v0.17.0, **Python 3.11 is required**.  If you previously had a working
+environment on Python 3.10, follow these steps:
+
+1. **Install Python 3.11** from:
+   ```
+   https://www.python.org/downloads/release/python-31113/
+   ```
+   Use the `Windows installer (64-bit)`.  Check **"Add Python to PATH"** during install.
+
+2. **Remove your old Poetry environment** (from this folder):
+   ```commandline
+   poetry env remove --all
+   ```
+
+3. **Point Poetry at Python 3.11 and reinstall:**
+   ```commandline
+   poetry env use python3.11
+   poetry install
+   ```
+   If `python3.11` isn't found, use the full path instead:
+   ```commandline
+   poetry env use C:\Users\<yourname>\AppData\Local\Programs\Python\Python311\python.exe
+   poetry install
+   ```
 
 ## Known Bugs
 

--- a/GEECS-Scanner-GUI/pyproject.toml
+++ b/GEECS-Scanner-GUI/pyproject.toml
@@ -1,13 +1,13 @@
 [tool.poetry]
 name = "geecs-scanner-gui"
-version = "0.16.0"
+version = "0.17.0"
 description = ""
 authors = ["Christopher Doss <CEDoss@lbl.gov>"]
 readme = "README.md"
 packages = [{include = "geecs_scanner"}]
 
 [tool.poetry.dependencies]
-python = ">=3.10,<3.12"
+python = ">=3.11,<3.12"
 PyQt5 = {version = "^5.15.9", markers = "sys_platform == 'win32'" }
 pyqt5-tools = {version = "^5.15.9.3.3", markers = "sys_platform == 'win32'" }
 geecs-pythonapi = {path = "../GEECS-PythonAPI", develop = true}


### PR DESCRIPTION
## Summary
Follow-up to #376 (merged before all commits landed).

- `GEECS-PythonAPI` 0.4.2 → 0.5.0: bump `mysql-connector-python` `^8.2.0` → `^9.7.0` to align with GeecsBluesky and make the full monorepo co-installable
- `GEECS-Scanner-GUI` 0.16.0 → 0.17.0: update `python` constraint from `>=3.10` to `>=3.11` (GeecsBluesky has required 3.11 since April 19 — making this explicit so pip/Poetry reject 3.10 immediately)
- `GEECS-PythonAPI`: same python constraint update `>=3.10` → `>=3.11`
- `GEECS-Scanner-GUI/README.md`: update installer link to Python 3.11 and add a step-by-step **Migrating from Python 3.10** section for existing users

## Test plan
- [ ] Fresh `pip install ./GEECS-Scanner-GUI` into clean Python 3.11 venv passes (verified locally before this PR)
- [ ] RTD build goes green (covered by #376)

🤖 Generated with [Claude Code](https://claude.com/claude-code)