### PR TITLE
fix(pythonapi): remove module-level MySQL connection in scan_device.py

### DIFF
--- a/GEECS-PythonAPI/CHANGELOG.md
+++ b/GEECS-PythonAPI/CHANGELOG.md
@@ -3,6 +3,16 @@
 All notable changes to this package will be documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.5.1] — 2026-05-11
+
+### Fixed
+- `scan_device.py`: removed module-level `GeecsDatabase.collect_exp_info()` call
+  that opened a live MySQL connection at import time. On Windows lab machines this
+  caused a silent C-level crash in `mysql.connector` before the GUI could display.
+  `GeecsDevice.exp_info` is populated on demand by `DatabaseDictLookup.reload()`
+  before any `ScanDevice` is instantiated, so eager loading was redundant.
+- `scan_device.py`: removed now-unused `load_config` import.
+
 ## [0.5.0] — 2026-05-11
 
 ### Changed

--- a/GEECS-PythonAPI/geecs_python_api/controls/devices/scan_device.py
+++ b/GEECS-PythonAPI/geecs_python_api/controls/devices/scan_device.py
@@ -8,20 +8,9 @@ from typing import Optional, Any, Dict, Union
 import time
 import numexpr as ne
 
-from geecs_python_api.controls.interface.geecs_database import (
-    GeecsDatabase,
-    load_config,
-)
 from geecs_python_api.controls.devices.geecs_device import GeecsDevice
 
 logger = logging.getLogger(__name__)
-
-# Load experiment info globally
-try:
-    expt = load_config().get("Experiment", "expt")
-    GeecsDevice.exp_info = GeecsDatabase.collect_exp_info(expt)
-except AttributeError:
-    logger.exception("Could not load experiment info due to error in config.ini file")
 
 
 class CompositeDeviceError(Exception):

--- a/GEECS-PythonAPI/pyproject.toml
+++ b/GEECS-PythonAPI/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-pythonapi"
-version = "0.5.0"
+version = "0.5.1"
 description = "Python interface to GEECS control system"
 authors = ["Guillaume Plateau <guillaume.plateau@tausystems.com>", "Sam Barber <sbarber@lbl.gov>"]
 readme = "README.md"


### PR DESCRIPTION
## Summary

- `scan_device.py` was calling `GeecsDatabase.collect_exp_info()` at **module import time**, which opened a live MySQL TCP connection to the GEECS database server before any user code ran.
- On Windows lab machines (Z drive), this caused a **silent C-level crash** in `mysql.connector`, making the GEECS Scanner GUI silently exit on startup with no error output and no exception.
- `GeecsDevice.exp_info` is already populated by `DatabaseDictLookup.reload()` before any `ScanDevice` is instantiated — the eager import-time call was redundant.
- Removed the 5-line module-level block and the now-unused `load_config` import.

## Root cause diagnosis

Diagnosed via a step-by-step `debug.py` on the lab machine (HTU-CR-1, Z drive). Last output before crash:
```
14:02:04 INFO geecs_python_api.controls.interface.geecs_database - database config loaded for loasis@192.168.6.14
14:02:04 INFO numexpr.utils - NumExpr defaulting to 8 threads.
[silent exit]
```
The `except AttributeError` guard did not help because the crash is C-level (mysql.connector DLL), not a Python exception.

## Test plan

- [ ] On HTU-CR-1 (Z drive), checkout this branch and run `poetry run python debug.py` — should now reach "ALL CHECKS PASSED"
- [ ] Run `poetry run python main.py` — GUI should open
- [ ] Verify a no-scan still works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)