### PR TITLE
Bug Fixes and Updated functionality to ConfigEditor GUI

### DIFF
--- a/ScanAnalysis/ConfigFileGUI/config_editor_window.py
+++ b/ScanAnalysis/ConfigFileGUI/config_editor_window.py
@@ -313,7 +313,7 @@ class ConfigEditorWindow(QMainWindow):
         edit_menu.addAction(self._validate_action)
 
         # --- View menu ---
-        view_menu = menubar.addMenu("&View")
+        view_menu = menubar.addMenu("&Tools")
 
         self._toggle_yaml_action = QAction("Toggle YAML &Preview", self)
         self._toggle_yaml_action.setCheckable(True)

--- a/ScanAnalysis/ConfigFileGUI/file_list_panel.py
+++ b/ScanAnalysis/ConfigFileGUI/file_list_panel.py
@@ -15,6 +15,8 @@ from typing import Optional
 from PyQt5.QtCore import pyqtSignal
 from PyQt5.QtWidgets import (
     QAction,
+    QComboBox,
+    QFileDialog,
     QHBoxLayout,
     QInputDialog,
     QLabel,
@@ -24,7 +26,6 @@ from PyQt5.QtWidgets import (
     QMenu,
     QMessageBox,
     QPushButton,
-    QComboBox,
     QVBoxLayout,
     QWidget,
 )
@@ -58,10 +59,14 @@ class FileListPanel(QWidget):
         Emitted with the full path when a config file is selected.
     configCreated(Path)
         Emitted when a new config file is created.
+    directoryChanged(Path)
+        Emitted when the config directory changes (via *Browse…* or
+        :meth:`set_config_dir`).
     """
 
     configSelected = pyqtSignal(Path)
     configCreated = pyqtSignal(Path)
+    directoryChanged = pyqtSignal(Path)
 
     def __init__(self, parent: Optional[QWidget] = None) -> None:
         super().__init__(parent)
@@ -81,11 +86,16 @@ class FileListPanel(QWidget):
         layout = QVBoxLayout(self)
         layout.setContentsMargins(4, 4, 4, 4)
 
-        # Directory label
+        # Top row: Browse button + path label
+        top_row = QHBoxLayout()
+        self._browse_btn = QPushButton("Browse...")
+        top_row.addWidget(self._browse_btn)
+
         self._dir_label = QLabel("No directory selected")
         self._dir_label.setWordWrap(True)
         self._dir_label.setStyleSheet("color: gray; font-size: 11px;")
-        layout.addWidget(self._dir_label)
+        top_row.addWidget(self._dir_label, stretch=1)
+        layout.addLayout(top_row)
 
         # Category selector for Scan Analysis mode
         self._category_selector = QComboBox()
@@ -122,6 +132,7 @@ class FileListPanel(QWidget):
 
     def _connect_signals(self) -> None:
         """Wire up internal signals and slots."""
+        self._browse_btn.clicked.connect(self._on_browse_clicked)
         self._filter_edit.textChanged.connect(self._on_filter_changed)
         self._list_widget.currentItemChanged.connect(self._on_item_selected)
         self._list_widget.customContextMenuRequested.connect(self._on_context_menu)
@@ -158,15 +169,9 @@ class FileListPanel(QWidget):
             Directory containing YAML configuration files.
         """
         self._config_dir = dir_path
-
-        # Truncate long paths for display
-        dir_str = str(dir_path)
-        if len(dir_str) > 50:
-            dir_str = "..." + dir_str[-47:]
-        self._dir_label.setText(dir_str)
-        self._dir_label.setToolTip(str(dir_path))
-
+        self._update_path_label()
         self.refresh()
+        self.directoryChanged.emit(dir_path)
 
     def refresh(self) -> None:
         """Reload the file list from the current directory.
@@ -253,8 +258,36 @@ class FileListPanel(QWidget):
         return self._config_dir
 
     # ------------------------------------------------------------------
+    # Private helpers
+    # ------------------------------------------------------------------
+
+    def _update_path_label(self) -> None:
+        """Refresh the directory label text and tooltip."""
+        if self._config_dir is None:
+            self._dir_label.setText("No directory selected")
+            self._dir_label.setToolTip("")
+            return
+
+        dir_str = str(self._config_dir)
+        if len(dir_str) > 50:
+            dir_str = "..." + dir_str[-47:]
+        self._dir_label.setText(dir_str)
+        self._dir_label.setToolTip(str(self._config_dir))
+
+    # ------------------------------------------------------------------
     # Slots
     # ------------------------------------------------------------------
+
+    def _on_browse_clicked(self) -> None:
+        """Open a directory picker and set the selected config directory."""
+        start_dir = str(self._config_dir) if self._config_dir else ""
+        chosen = QFileDialog.getExistingDirectory(
+            self,
+            "Select device config directory",
+            start_dir,
+        )
+        if chosen:
+            self.set_config_dir(Path(chosen))
 
     def _on_item_selected(
         self, current: QListWidgetItem, _previous: QListWidgetItem

--- a/ScanAnalysis/ConfigFileGUI/scan_analyzer_editor.py
+++ b/ScanAnalysis/ConfigFileGUI/scan_analyzer_editor.py
@@ -337,6 +337,7 @@ class ScanAnalyzerEditorPanel(QWidget):
         # id
         self._id_edit = QLineEdit()
         self._id_edit.setPlaceholderText("Unique analyzer identifier")
+        self._id_edit.setToolTip("Should match the filename (without extension)")
         self._id_edit.textChanged.connect(self._emit_changed)
         form.addRow("id:", self._id_edit)
 
@@ -532,8 +533,6 @@ class ScanAnalyzerEditorPanel(QWidget):
         # --- General ---
         if self._id_edit is not None:
             self._id_edit.setText(str(data.get("id", "")))
-            self._id_edit.setReadOnly(True)
-            self._id_edit.setStyleSheet("background-color: #f0f0f0;")
 
         if self._device_name_edit is not None:
             self._device_name_edit.setText(str(data.get("device_name", "")))
@@ -699,8 +698,6 @@ class ScanAnalyzerEditorPanel(QWidget):
     def set_new_mode(self, is_new: bool) -> None:
         """Set whether the editor is in new-config or edit-existing mode.
 
-        When *is_new* is ``False``, the ``id`` field becomes read-only.
-
         Parameters
         ----------
         is_new : bool
@@ -708,12 +705,6 @@ class ScanAnalyzerEditorPanel(QWidget):
             existing file.
         """
         self._is_new = is_new
-        if self._id_edit is not None:
-            self._id_edit.setReadOnly(not is_new)
-            if is_new:
-                self._id_edit.setStyleSheet("")
-            else:
-                self._id_edit.setStyleSheet("background-color: #f0f0f0;")
 
     def clear(self) -> None:
         """Reset all fields to their default values."""
@@ -724,8 +715,6 @@ class ScanAnalyzerEditorPanel(QWidget):
 
         if self._id_edit is not None:
             self._id_edit.clear()
-            self._id_edit.setReadOnly(False)
-            self._id_edit.setStyleSheet("")
 
         if self._device_name_edit is not None:
             self._device_name_edit.clear()

--- a/ScanAnalysis/ConfigFileGUI/scan_analyzer_editor.py
+++ b/ScanAnalysis/ConfigFileGUI/scan_analyzer_editor.py
@@ -337,7 +337,9 @@ class ScanAnalyzerEditorPanel(QWidget):
         # id
         self._id_edit = QLineEdit()
         self._id_edit.setPlaceholderText("Unique analyzer identifier")
-        self._id_edit.setToolTip("Should match the filename (without extension)")
+        self._id_edit.setToolTip(
+            "Should match the YAML filename (without .yaml extension)"
+        )
         self._id_edit.textChanged.connect(self._emit_changed)
         form.addRow("id:", self._id_edit)
 

--- a/ScanAnalysis/ConfigFileGUI/scan_config_io.py
+++ b/ScanAnalysis/ConfigFileGUI/scan_config_io.py
@@ -525,12 +525,13 @@ def detect_scan_config_type(
 
 
 def list_all_analyzer_ids(root: Path) -> List[str]:
-    """Scan all analyzer YAML files and return a sorted list of ``id`` fields.
+    """Return a sorted list of analyzer IDs derived from filenames.
 
-    Reads each ``.yaml`` file in ``<root>/library/analyzers/`` and extracts
-    the top-level ``id`` key.  Files that lack an ``id`` key are skipped.
-
-    This is useful for populating autocomplete widgets in the groups editor.
+    Uses the filename stem (without ``.yaml``) of each file in
+    ``<root>/library/analyzers/`` as the canonical analyzer ID.  This
+    matches what the user sees in the tree panel and what
+    ``groups.yaml`` references, so the autocomplete is always
+    up-to-date even when internal ``id`` fields are stale.
 
     Parameters
     ----------
@@ -542,25 +543,12 @@ def list_all_analyzer_ids(root: Path) -> List[str]:
     List[str]
         Alphabetically sorted list of unique analyzer IDs.
     """
-    ids: List[str] = []
-
     try:
         analyzer_files = list_analyzer_configs(root)
     except (FileNotFoundError, NotADirectoryError) as exc:
         logger.warning("Cannot list analyzer configs: %s", exc)
-        return ids
+        return []
 
-    for filepath in analyzer_files:
-        try:
-            data = load_analyzer_yaml(filepath)
-            analyzer_id = data.get("id")
-            if analyzer_id and isinstance(analyzer_id, str):
-                ids.append(analyzer_id)
-            else:
-                logger.debug("No 'id' field in %s", filepath)
-        except (yaml.YAMLError, OSError) as exc:
-            logger.warning("Skipping %s: %s", filepath, exc)
-
-    ids = sorted(set(ids), key=str.lower)
+    ids = sorted({f.stem for f in analyzer_files}, key=str.lower)
     logger.debug("Found %d unique analyzer IDs", len(ids))
     return ids

--- a/ScanAnalysis/ConfigFileGUI/scan_tree_panel.py
+++ b/ScanAnalysis/ConfigFileGUI/scan_tree_panel.py
@@ -25,6 +25,7 @@ from PyQt5.QtWidgets import (
     QFileDialog,
     QFormLayout,
     QHBoxLayout,
+    QInputDialog,
     QLabel,
     QLineEdit,
     QMessageBox,
@@ -41,6 +42,8 @@ from .scan_config_io import (
     get_groups_file,
     list_analyzer_configs,
     list_experiment_configs,
+    load_analyzer_yaml,
+    save_analyzer_yaml,
 )
 
 logger = logging.getLogger(__name__)
@@ -105,10 +108,15 @@ class ScanTreePanel(QWidget):
         self._tree.setColumnCount(1)
         layout.addWidget(self._tree, stretch=1)
 
-        # Bottom row: Refresh + New Config buttons
+        # Bottom row: Refresh + Rename + New Config buttons
         bottom_row = QHBoxLayout()
         self._refresh_btn = QPushButton("Refresh")
         bottom_row.addWidget(self._refresh_btn)
+
+        self._rename_btn = QPushButton("Rename…")
+        self._rename_btn.setToolTip("Rename the selected config file")
+        self._rename_btn.setEnabled(False)
+        bottom_row.addWidget(self._rename_btn)
 
         self._new_config_btn = QPushButton("New Config…")
         self._new_config_btn.setToolTip(
@@ -122,8 +130,10 @@ class ScanTreePanel(QWidget):
         """Wire up internal signals and slots."""
         self._browse_btn.clicked.connect(self._on_browse_clicked)
         self._refresh_btn.clicked.connect(self.refresh)
+        self._rename_btn.clicked.connect(self._on_rename_clicked)
         self._new_config_btn.clicked.connect(self._on_new_config_clicked)
         self._tree.itemClicked.connect(self._on_item_clicked)
+        self._tree.currentItemChanged.connect(self._on_current_item_changed)
 
     # ------------------------------------------------------------------
     # Public API
@@ -262,6 +272,105 @@ class ScanTreePanel(QWidget):
         file_path = Path(path_str)
         logger.debug("Tree item selected: %s (%s)", file_path, config_type)
         self.file_selected.emit(file_path, config_type)
+
+    def _on_current_item_changed(
+        self,
+        current: Optional[QTreeWidgetItem],
+        _previous: Optional[QTreeWidgetItem],
+    ) -> None:
+        """Enable or disable the Rename button based on the selected item.
+
+        The button is enabled only when a leaf item (file) is selected
+        and the file is *not* ``groups.yaml``.
+
+        Parameters
+        ----------
+        current : QTreeWidgetItem or None
+            The newly selected item, or ``None`` if the selection was
+            cleared.
+        _previous : QTreeWidgetItem or None
+            The previously selected item (unused).
+        """
+        if current is None:
+            self._rename_btn.setEnabled(False)
+            return
+
+        config_type = current.data(0, Qt.UserRole + 1)
+        # Enable only for analyzer or experiment leaf items
+        self._rename_btn.setEnabled(config_type in ("analyzer", "experiment"))
+
+    def _on_rename_clicked(self) -> None:
+        """Rename the currently selected config file.
+
+        Shows a text input dialog pre-populated with the current
+        filename stem.  On accept the file is renamed on disk, and for
+        analyzer configs the internal ``id`` field is updated to match.
+        """
+        item = self._tree.currentItem()
+        if item is None:
+            return
+
+        path_str = item.data(0, Qt.UserRole)
+        config_type = item.data(0, Qt.UserRole + 1)
+
+        if path_str is None or config_type not in ("analyzer", "experiment"):
+            return
+
+        old_path = Path(path_str)
+        old_stem = old_path.stem
+
+        new_stem, ok = QInputDialog.getText(
+            self,
+            "Rename Config",
+            "New filename (without .yaml):",
+            QLineEdit.Normal,
+            old_stem,
+        )
+        if not ok or not new_stem.strip():
+            return
+
+        new_stem = new_stem.strip()
+
+        # Prevent no-op rename
+        if new_stem == old_stem:
+            return
+
+        new_path = old_path.parent / f"{new_stem}.yaml"
+
+        # Check for existing file
+        if new_path.exists():
+            QMessageBox.warning(
+                self,
+                "File Exists",
+                f"A file named '{new_path.name}' already exists in\n{old_path.parent}",
+            )
+            return
+
+        # Perform the rename
+        try:
+            old_path.rename(new_path)
+        except OSError as exc:
+            QMessageBox.critical(
+                self,
+                "Rename Error",
+                f"Failed to rename file:\n{exc}",
+            )
+            return
+
+        # For analyzer configs, update the internal id field
+        if config_type == "analyzer":
+            try:
+                data = load_analyzer_yaml(new_path)
+                data["id"] = new_stem
+                save_analyzer_yaml(new_path, data)
+            except Exception as exc:
+                logger.warning("Renamed file but failed to update internal id: %s", exc)
+
+        logger.info("Renamed %s → %s", old_path.name, new_path.name)
+
+        # Refresh tree and emit selection for the renamed file
+        self._build_tree()
+        self.file_selected.emit(new_path, config_type)
 
     # ------------------------------------------------------------------
     # Helpers


### PR DESCRIPTION
## Summary

Implements the Scan Configuration Editor (Phase 2) and Analysis Preview
Window (Phase 3) for the ConfigFileGUI, plus several bug fixes and UI
improvements from user testing.

## Changes

### Scan Configuration Editor (6 new modules)
- **Tree navigation** with Browse/Refresh/New Config/Rename buttons
- **Library Analyzer editor** with type switching (2D/1D), collapsible
  sections, JSON dict editors for kwargs
- **Groups editor** with autocomplete text box, per-member
  checkbox/trash controls, comment-aware YAML I/O
- **Experiment editor** with include directive management via modal
  dialog (group/ref selection, priority offset, overrides)
- **Live YAML preview** for all three config types

### Bug Fixes
- Groups YAML preview format corrected (plain names, not objects)
- Autocomplete uses filenames instead of stale internal id fields
- IncludeEntry dialog labels update dynamically
- Analyzer id field always editable

### UI Improvements
- Browse button on Device Configs tab for runtime directory switching
- Config rename with automatic internal id update
- "View" menu renamed to "Tools"
- `--scan-config-dir` CLI argument

## Files Changed (11)
- 5 modified: `config_editor_window.py`, `file_list_panel.py`,
  `yaml_preview.py`, `main.py`, `__init__.py`

## Testing
- All files pass pre-commit (ruff, ruff-format, pydocstyle)
- Manual testing verified for all three scan editor panels,
  groups YAML format, config creation/rename, and Browse functionality
