### PR TITLE
fix(geecs-database): force pure Python mysql connector to prevent Windows crash

### DIFF
--- a/GEECS-PythonAPI/CHANGELOG.md
+++ b/GEECS-PythonAPI/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this package will be documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.5.1] — 2026-05-11
+
+### Fixed
+- `GeecsDatabase._get_db()`: added `use_pure=True` to `mysql.connector.connect()`.
+  The `mysql-connector-python` 9.x C extension DLL crashes silently on Windows,
+  killing the process before any Python exception can be raised. The pure Python
+  connector is functionally identical for all queries this codebase makes and is
+  safe on all platforms.
+
 ## [0.5.0] — 2026-05-11
 
 ### Changed

--- a/GEECS-PythonAPI/geecs_python_api/controls/interface/geecs_database.py
+++ b/GEECS-PythonAPI/geecs_python_api/controls/interface/geecs_database.py
@@ -127,6 +127,7 @@ class GeecsDatabase:
             user=GeecsDatabase.username,
             password=GeecsDatabase.password,
             database=GeecsDatabase.name,
+            use_pure=True,  # C extension DLL crashes silently on Windows with 9.x
         )
         return db
 

--- a/GEECS-PythonAPI/pyproject.toml
+++ b/GEECS-PythonAPI/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-pythonapi"
-version = "0.5.0"
+version = "0.5.1"
 description = "Python interface to GEECS control system"
 authors = ["Guillaume Plateau <guillaume.plateau@tausystems.com>", "Sam Barber <sbarber@lbl.gov>"]
 readme = "README.md"


### PR DESCRIPTION
## Summary

- `GeecsDatabase._get_db()`: add `use_pure=True` to `mysql.connector.connect()`
- The `mysql-connector-python` 9.x C extension DLL crashes silently on Windows (HTU-CR-1), killing the process at the OS level with no Python exception
- Diagnosed by step-by-step debug script: adding `flush=True` to prints confirmed the crash was exactly on the `connect()` call; replacing with `use_pure=True` survived and the GUI launched and ran scans successfully
- Pure Python connector is functionally identical for all queries this codebase makes (basic SELECTs + one UPDATE at startup/scan setup); safe on all platforms

## Test plan

- [ ] Run GUI on HTU-CR-1 Windows machine — should launch without crash
- [ ] Confirm scans complete normally
- [ ] Verify no regressions on Mac dev machines (pure Python connector already default fallback on ARM)

🤖 Generated with [Claude Code](https://claude.com/claude-code)