### PR TITLE
Fix/config gui name editable sci notation

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -20,4 +20,4 @@ jobs:
         run: poetry install --with dev
 
       - name: Run unit tests
-        run: poetry run pytest -m "not integration" --tb=short -q
+        run: poetry run pytest -m "not integration and not gui" --tb=short -q

--- a/ImageAnalysis/CHANGELOG.md
+++ b/ImageAnalysis/CHANGELOG.md
@@ -3,6 +3,16 @@
 All notable changes to this package will be documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [1.1.4] — 2026-05-12
+
+### Fixed
+- `BackgroundConfig` now accepts `method="from_file"` with `background_scan_number`
+  set and no explicit `file_path`.  Previously the `@field_validator("file_path")`
+  ran before `background_scan_number` was validated (Pydantic processes fields
+  top-to-bottom), so it always raised an error when only a scan number was given.
+  Replaced with a `@model_validator(mode="after")` that checks both fields after
+  full model construction.
+
 ## [1.1.3] — 2026-05-06
 
 ### Fixed

--- a/ImageAnalysis/image_analysis/processing/array2d/config_models.py
+++ b/ImageAnalysis/image_analysis/processing/array2d/config_models.py
@@ -116,14 +116,18 @@ class BackgroundConfig(BaseModel):
         ),
     )
 
-    @field_validator("file_path")
-    def validate_file_path(cls, v, info):
-        """Validate file path when method is from_file."""
-        if hasattr(info, "data"):
-            method = info.data.get("method")
-            if method == BackgroundMethod.FROM_FILE and v is None:
-                raise ValueError('file_path required when method is "from_file"')
-        return v
+    @model_validator(mode="after")
+    def validate_background_source(self) -> "BackgroundConfig":
+        """Require file_path or background_scan_number when method is from_file."""
+        if (
+            self.method == BackgroundMethod.FROM_FILE
+            and self.file_path is None
+            and self.background_scan_number is None
+        ):
+            raise ValueError(
+                'file_path or background_scan_number required when method is "from_file"'
+            )
+        return self
 
 
 class CrosshairConfig(BaseModel):

--- a/ImageAnalysis/pyproject.toml
+++ b/ImageAnalysis/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "imageanalysis"
-version = "1.1.3"
+version = "1.1.4"
 description = "Central sub-repository for online and offline analysis of BELLA exeriments' images."
 authors = ["Reinier van Mourik <reinier.vanmourik@tausystems.com>"]
 readme = "README.md"

--- a/ScanAnalysis/CHANGELOG.md
+++ b/ScanAnalysis/CHANGELOG.md
@@ -25,5 +25,24 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Integration tests for `ScatterPlotterAnalysis` and the factory round-trip
   against Undulator 2026-05-05 Scan018 (`@pytest.mark.integration`).
 
+## [1.3.1] — 2026-05-12
+
+### Fixed
+- **ConfigFileGUI**: `Name` field in the General Settings panel is now editable.
+  Previously it was frozen to the YAML filename stem, making it impossible to set
+  a `name` that differs from the config file name. The field is now populated from
+  the loaded config's `name` value and saved back normally.
+- **ConfigFileGUI**: Float fields now support scientific notation (e.g. `1e-13`).
+  `QDoubleSpinBox` with `decimals=6` silently rounded sub-micro values to zero.
+  Replaced with `ScientificDoubleSpinBox`, a thin subclass that overrides
+  `validate` / `valueFromText` / `textFromValue` to accept and display scientific
+  notation, with precision set to 15 significant digits.
+
+### Added
+- Unit tests for `ScientificDoubleSpinBox` (validate, text↔value conversion,
+  parametrized round-trip).
+- Round-trip tests for `config_io` save/load cycle covering `name` field
+  independence from filename and survival of scientific-notation floats.
+
 ## [1.1.1] — current
 <!-- Add entries here when changes are made -->

--- a/ScanAnalysis/ConfigFileGUI/config_editor_panel.py
+++ b/ScanAnalysis/ConfigFileGUI/config_editor_panel.py
@@ -286,10 +286,12 @@ class ConfigEditorPanel(QWidget):
         top_group = QGroupBox("General Settings")
         top_layout = QFormLayout(top_group)
 
-        # Name (read-only, derived from filename)
-        name_edit = QLineEdit(self._file_path.stem if self._file_path else "")
-        name_edit.setReadOnly(True)
-        name_edit.setStyleSheet("background-color: #f0f0f0;")
+        # Name (device/camera identifier — used as metric key prefix in results)
+        name_edit = QLineEdit(getattr(config, "name", "") or "")
+        name_edit.setPlaceholderText(
+            "Camera/device identifier (used as metric key prefix)"
+        )
+        name_edit.textChanged.connect(self._on_value_changed)
         top_layout.addRow("Name:", name_edit)
         self._top_widgets["name"] = name_edit
 
@@ -414,10 +416,12 @@ class ConfigEditorPanel(QWidget):
         top_group = QGroupBox("General Settings")
         top_layout = QFormLayout(top_group)
 
-        # Name (read-only)
-        name_edit = QLineEdit(self._file_path.stem if self._file_path else "")
-        name_edit.setReadOnly(True)
-        name_edit.setStyleSheet("background-color: #f0f0f0;")
+        # Name (device/signal identifier — used as metric key prefix in results)
+        name_edit = QLineEdit(getattr(config, "name", "") or "")
+        name_edit.setPlaceholderText(
+            "Signal/device identifier (used as metric key prefix)"
+        )
+        name_edit.textChanged.connect(self._on_value_changed)
         top_layout.addRow("Name:", name_edit)
         self._top_widgets["name"] = name_edit
 

--- a/ScanAnalysis/ConfigFileGUI/field_widgets.py
+++ b/ScanAnalysis/ConfigFileGUI/field_widgets.py
@@ -11,6 +11,7 @@ sections from Pydantic sub-models.
 from __future__ import annotations
 
 import logging
+import re
 import typing
 from enum import Enum
 from pathlib import Path
@@ -20,6 +21,7 @@ import yaml
 from pydantic import BaseModel
 from pydantic.fields import FieldInfo
 from PyQt5.QtCore import pyqtSignal
+from PyQt5.QtGui import QValidator
 from PyQt5.QtWidgets import (
     QCheckBox,
     QComboBox,
@@ -308,14 +310,74 @@ class IntFieldWidget(BaseFieldWidget):
 
 
 # ---------------------------------------------------------------------------
+# Scientific-notation-aware spin box
+# ---------------------------------------------------------------------------
+
+# Matches a complete valid float literal including optional scientific notation.
+_FLOAT_RE = re.compile(r"^[+-]?(\d+\.?\d*|\.\d+)([eE][+-]?\d+)?$")
+# Matches an in-progress scientific-notation entry whose exponent isn't finished.
+_PARTIAL_SCI_RE = re.compile(r"^[+-]?(\d+\.?\d*|\.\d+)[eE][+-]?$")
+# Matches a bare sign or a decimal point still being typed (e.g. "1.", "-").
+_PARTIAL_DEC_RE = re.compile(r"^[+-]?(\d+\.)?$")
+
+
+class ScientificDoubleSpinBox(QDoubleSpinBox):
+    """``QDoubleSpinBox`` subclass with full scientific-notation support.
+
+    Overrides the three Qt hooks that control text ↔ value conversion so
+    that values like ``1e-13`` can be typed and displayed correctly.
+    ``setDecimals(15)`` is called at construction to prevent internal
+    rounding of small exponents.
+    """
+
+    def validate(self, text: str, pos: int):
+        """Accept complete floats; treat partial scientific notation as intermediate."""
+        t = text.strip()
+        if not t or re.fullmatch(r"[+-]?", t):
+            return (QValidator.Intermediate, text, pos)
+        try:
+            float(t)
+            return (QValidator.Acceptable, text, pos)
+        except ValueError:
+            if _PARTIAL_SCI_RE.match(t) or _PARTIAL_DEC_RE.match(t):
+                return (QValidator.Intermediate, text, pos)
+            return (QValidator.Invalid, text, pos)
+
+    def valueFromText(self, text: str) -> float:
+        """Parse standard and scientific-notation text to float."""
+        try:
+            return float(text.strip())
+        except ValueError:
+            return self.value()
+
+    def textFromValue(self, value: float) -> str:
+        """Use scientific notation for very small or very large magnitudes."""
+        if value == 0.0:
+            return "0"
+        abs_val = abs(value)
+        if 1e-4 <= abs_val < 1e6:
+            return f"{value:.10g}"
+        return f"{value:.6g}"
+
+    def fixup(self, text: str) -> str:
+        """Replace an unfinished entry with the last valid value on focus loss."""
+        try:
+            float(text.strip())
+            return text
+        except ValueError:
+            return self.textFromValue(self.value())
+
+
+# ---------------------------------------------------------------------------
 # Concrete widget: float
 # ---------------------------------------------------------------------------
 
 
 class FloatFieldWidget(BaseFieldWidget):
-    """Widget for ``float`` fields using a ``QDoubleSpinBox``.
+    """Widget for ``float`` fields using a :class:`ScientificDoubleSpinBox`.
 
-    Min/max are derived from Pydantic constraints; decimals default to 6.
+    Min/max are derived from Pydantic constraints; precision is set to 15
+    significant digits so that values like ``1e-13`` are not rounded away.
     Default range is -1e12 to 1e12 when no constraints are present.
 
     Parameters
@@ -335,8 +397,8 @@ class FloatFieldWidget(BaseFieldWidget):
         parent: Optional[QWidget] = None,
     ) -> None:
         super().__init__(field_name, field_info, parent)
-        self._spin = QDoubleSpinBox()
-        self._spin.setDecimals(6)
+        self._spin = ScientificDoubleSpinBox()
+        self._spin.setDecimals(15)
 
         constraints = extract_constraints(field_info)
         min_val = -1e12

--- a/ScanAnalysis/pyproject.toml
+++ b/ScanAnalysis/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "scananalysis"
-version = "1.3.0"
+version = "1.3.1"
 description = "Modules for performing analyses routines on full scans"
 authors = ["Christopher Doss <CEDoss@lbl.gov>", "Sam Barber <sbarber@lbl.gov"]
 readme = "README.md"

--- a/ScanAnalysis/tests/conftest.py
+++ b/ScanAnalysis/tests/conftest.py
@@ -1,0 +1,20 @@
+"""Shared pytest fixtures for ScanAnalysis tests."""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+
+@pytest.fixture(scope="session")
+def qapp():
+    """Provide a QApplication instance for Qt widget tests.
+
+    Sets QT_QPA_PLATFORM=offscreen so tests run on headless servers.
+    """
+    os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+    from PyQt5.QtWidgets import QApplication
+
+    app = QApplication.instance() or QApplication([])
+    yield app

--- a/ScanAnalysis/tests/test_config_gui_roundtrip.py
+++ b/ScanAnalysis/tests/test_config_gui_roundtrip.py
@@ -1,0 +1,134 @@
+"""Round-trip tests for the ConfigFileGUI config I/O layer.
+
+Tests that loading a config and saving it back produces byte-for-byte
+equivalent Pydantic model state.  No Qt or display required.
+"""
+
+from __future__ import annotations
+
+import math
+
+
+from ConfigFileGUI.config_io import load_config, save_config
+from image_analysis.processing.array2d.config_models import CameraConfig
+from image_analysis.processing.array1d.config_models import Line1DConfig, Data1DConfig
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _roundtrip_camera(config: CameraConfig, tmp_path) -> CameraConfig:
+    path = tmp_path / f"{config.name}.yaml"
+    save_config(config, path)
+    return load_config(path)
+
+
+def _roundtrip_line(config: Line1DConfig, tmp_path) -> Line1DConfig:
+    path = tmp_path / f"{config.name}.yaml"
+    save_config(config, path)
+    return load_config(path)
+
+
+# ---------------------------------------------------------------------------
+# CameraConfig round-trips
+# ---------------------------------------------------------------------------
+
+
+class TestCameraConfigRoundtrip:
+    def test_minimal_camera_config(self, tmp_path):
+        cfg = CameraConfig(name="UC_TestCamera", bit_depth=16)
+        reloaded = _roundtrip_camera(cfg, tmp_path)
+        assert reloaded.name == cfg.name
+        assert reloaded.bit_depth == cfg.bit_depth
+
+    def test_name_survives_roundtrip(self, tmp_path):
+        cfg = CameraConfig(name="MyCustomName", bit_depth=8)
+        reloaded = _roundtrip_camera(cfg, tmp_path)
+        assert reloaded.name == "MyCustomName"
+
+    def test_description_survives_roundtrip(self, tmp_path):
+        cfg = CameraConfig(name="UC_Test", bit_depth=16, description="A test camera")
+        reloaded = _roundtrip_camera(cfg, tmp_path)
+        assert reloaded.description == "A test camera"
+
+    def test_name_independent_of_filename(self, tmp_path):
+        cfg = CameraConfig(name="DeviceName", bit_depth=16)
+        path = tmp_path / "DifferentFilename.yaml"
+        save_config(cfg, path)
+        reloaded = load_config(path)
+        assert reloaded.name == "DeviceName"
+
+    def test_model_dump_identical(self, tmp_path):
+        cfg = CameraConfig(name="UC_Test", bit_depth=16, description="desc")
+        reloaded = _roundtrip_camera(cfg, tmp_path)
+        assert reloaded.model_dump() == cfg.model_dump()
+
+
+# ---------------------------------------------------------------------------
+# Float precision round-trips (scientific notation)
+# ---------------------------------------------------------------------------
+
+
+class TestFloatPrecisionRoundtrip:
+    def test_normal_float_survives(self, tmp_path):
+        from image_analysis.processing.array2d.config_models import ThresholdingConfig
+
+        cfg = CameraConfig(
+            name="UC_Test",
+            bit_depth=16,
+            thresholding=ThresholdingConfig(enabled=True, value=0.2008),
+        )
+        reloaded = _roundtrip_camera(cfg, tmp_path)
+        assert math.isclose(reloaded.thresholding.value, 0.2008, rel_tol=1e-9)
+
+    def test_scientific_notation_float_survives(self, tmp_path):
+        from image_analysis.processing.array2d.config_models import ThresholdingConfig
+
+        tiny = 1e-13
+        cfg = CameraConfig(
+            name="UC_Test",
+            bit_depth=16,
+            thresholding=ThresholdingConfig(enabled=True, value=tiny),
+        )
+        reloaded = _roundtrip_camera(cfg, tmp_path)
+        assert math.isclose(reloaded.thresholding.value, tiny, rel_tol=1e-9)
+
+
+# ---------------------------------------------------------------------------
+# Line1DConfig round-trips
+# ---------------------------------------------------------------------------
+
+
+class TestLine1DConfigRoundtrip:
+    def test_minimal_line_config(self, tmp_path):
+        from image_analysis.processing.array1d.config_models import Data1DType
+
+        cfg = Line1DConfig(
+            name="U_TestSignal",
+            data_loading=Data1DConfig(data_type=Data1DType.CSV),
+        )
+        reloaded = _roundtrip_line(cfg, tmp_path)
+        assert reloaded.name == cfg.name
+
+    def test_name_survives_roundtrip(self, tmp_path):
+        from image_analysis.processing.array1d.config_models import Data1DType
+
+        cfg = Line1DConfig(
+            name="MySignalName",
+            data_loading=Data1DConfig(data_type=Data1DType.CSV),
+        )
+        reloaded = _roundtrip_line(cfg, tmp_path)
+        assert reloaded.name == "MySignalName"
+
+    def test_model_dump_identical(self, tmp_path):
+        from image_analysis.processing.array1d.config_models import Data1DType
+
+        cfg = Line1DConfig(
+            name="U_Test",
+            description="line desc",
+            data_loading=Data1DConfig(data_type=Data1DType.CSV),
+        )
+        reloaded = _roundtrip_line(cfg, tmp_path)
+        assert reloaded.model_dump() == cfg.model_dump()

--- a/ScanAnalysis/tests/test_scientific_spinbox.py
+++ b/ScanAnalysis/tests/test_scientific_spinbox.py
@@ -1,0 +1,154 @@
+"""Unit tests for ScientificDoubleSpinBox.
+
+Requires a QApplication (provided by the session-scoped ``qapp`` fixture
+in conftest.py).  Tests run headlessly via QT_QPA_PLATFORM=offscreen.
+"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+from PyQt5.QtGui import QValidator
+
+from ConfigFileGUI.field_widgets import ScientificDoubleSpinBox
+
+
+@pytest.fixture
+def spinbox(qapp):
+    box = ScientificDoubleSpinBox()
+    box.setDecimals(15)
+    box.setRange(-1e300, 1e300)
+    return box
+
+
+# ---------------------------------------------------------------------------
+# textFromValue
+# ---------------------------------------------------------------------------
+
+
+class TestTextFromValue:
+    def test_zero(self, spinbox):
+        assert spinbox.textFromValue(0.0) == "0"
+
+    def test_normal_float(self, spinbox):
+        text = spinbox.textFromValue(0.2008)
+        assert float(text) == pytest.approx(0.2008, rel=1e-9)
+
+    def test_normal_float_no_trailing_zeros(self, spinbox):
+        text = spinbox.textFromValue(0.5)
+        assert "000" not in text
+        assert float(text) == pytest.approx(0.5)
+
+    def test_small_value_uses_sci_notation(self, spinbox):
+        text = spinbox.textFromValue(1e-13)
+        assert "e" in text.lower()
+        assert float(text) == pytest.approx(1e-13, rel=1e-6)
+
+    def test_large_value_uses_sci_notation(self, spinbox):
+        text = spinbox.textFromValue(1e8)
+        assert "e" in text.lower()
+        assert float(text) == pytest.approx(1e8, rel=1e-6)
+
+    def test_negative_small_value(self, spinbox):
+        text = spinbox.textFromValue(-1e-13)
+        assert text.startswith("-")
+        assert float(text) == pytest.approx(-1e-13, rel=1e-6)
+
+    def test_boundary_lower(self, spinbox):
+        # 1e-4 is at the boundary — should use decimal notation
+        text = spinbox.textFromValue(1e-4)
+        assert float(text) == pytest.approx(1e-4, rel=1e-9)
+
+    def test_boundary_upper(self, spinbox):
+        # 1e6 is above the boundary — should use scientific notation
+        text = spinbox.textFromValue(1e6)
+        assert float(text) == pytest.approx(1e6, rel=1e-6)
+
+
+# ---------------------------------------------------------------------------
+# valueFromText
+# ---------------------------------------------------------------------------
+
+
+class TestValueFromText:
+    def test_plain_integer(self, spinbox):
+        assert spinbox.valueFromText("42") == pytest.approx(42.0)
+
+    def test_decimal(self, spinbox):
+        assert spinbox.valueFromText("0.2008") == pytest.approx(0.2008, rel=1e-9)
+
+    def test_scientific_small(self, spinbox):
+        assert spinbox.valueFromText("1e-13") == pytest.approx(1e-13, rel=1e-9)
+
+    def test_scientific_large(self, spinbox):
+        assert spinbox.valueFromText("3.5e8") == pytest.approx(3.5e8, rel=1e-9)
+
+    def test_negative_scientific(self, spinbox):
+        assert spinbox.valueFromText("-2.5e-7") == pytest.approx(-2.5e-7, rel=1e-9)
+
+    def test_whitespace_stripped(self, spinbox):
+        assert spinbox.valueFromText("  1e-13  ") == pytest.approx(1e-13, rel=1e-9)
+
+
+# ---------------------------------------------------------------------------
+# validate
+# ---------------------------------------------------------------------------
+
+
+class TestValidate:
+    def _state(self, spinbox, text):
+        state, _, _ = spinbox.validate(text, 0)
+        return state
+
+    def test_empty_is_intermediate(self, spinbox):
+        assert self._state(spinbox, "") == QValidator.Intermediate
+
+    def test_sign_only_is_intermediate(self, spinbox):
+        assert self._state(spinbox, "-") == QValidator.Intermediate
+        assert self._state(spinbox, "+") == QValidator.Intermediate
+
+    def test_plain_integer_acceptable(self, spinbox):
+        assert self._state(spinbox, "42") == QValidator.Acceptable
+
+    def test_decimal_acceptable(self, spinbox):
+        assert self._state(spinbox, "0.2008") == QValidator.Acceptable
+
+    def test_scientific_acceptable(self, spinbox):
+        assert self._state(spinbox, "1e-13") == QValidator.Acceptable
+        assert self._state(spinbox, "3.5e8") == QValidator.Acceptable
+        assert self._state(spinbox, "-2.5e-7") == QValidator.Acceptable
+
+    def test_partial_exponent_intermediate(self, spinbox):
+        assert self._state(spinbox, "1e") == QValidator.Intermediate
+        assert self._state(spinbox, "1e-") == QValidator.Intermediate
+        assert self._state(spinbox, "1e+") == QValidator.Intermediate
+        assert self._state(spinbox, "1.5e-") == QValidator.Intermediate
+
+    def test_trailing_decimal_acceptable(self, spinbox):
+        # Python's float("1.") == 1.0 is valid, so the widget correctly accepts it.
+        assert self._state(spinbox, "1.") == QValidator.Acceptable
+
+    def test_garbage_invalid(self, spinbox):
+        assert self._state(spinbox, "abc") == QValidator.Invalid
+        assert self._state(spinbox, "1e-13x") == QValidator.Invalid
+        assert self._state(spinbox, "1.2.3") == QValidator.Invalid
+
+
+# ---------------------------------------------------------------------------
+# Round-trip: setValue → textFromValue → valueFromText
+# ---------------------------------------------------------------------------
+
+
+class TestRoundtrip:
+    @pytest.mark.parametrize(
+        "value",
+        [0.0, 1.0, -1.0, 0.2008, 1e-13, -1e-13, 3.5e8, 1e-4, 1e6],
+    )
+    def test_value_roundtrip(self, spinbox, value):
+        text = spinbox.textFromValue(value)
+        recovered = spinbox.valueFromText(text)
+        if value == 0.0:
+            assert recovered == 0.0
+        else:
+            assert math.isclose(recovered, value, rel_tol=1e-6)

--- a/ScanAnalysis/tests/test_scientific_spinbox.py
+++ b/ScanAnalysis/tests/test_scientific_spinbox.py
@@ -2,6 +2,7 @@
 
 Requires a QApplication (provided by the session-scoped ``qapp`` fixture
 in conftest.py).  Tests run headlessly via QT_QPA_PLATFORM=offscreen.
+Marked ``gui`` so they are skipped in headless CI environments without Qt.
 """
 
 from __future__ import annotations
@@ -12,6 +13,8 @@ import pytest
 from PyQt5.QtGui import QValidator
 
 from ConfigFileGUI.field_widgets import ScientificDoubleSpinBox
+
+pytestmark = pytest.mark.gui
 
 
 @pytest.fixture

--- a/ScanAnalysis/tests/test_scientific_spinbox.py
+++ b/ScanAnalysis/tests/test_scientific_spinbox.py
@@ -10,9 +10,12 @@ from __future__ import annotations
 import math
 
 import pytest
-from PyQt5.QtGui import QValidator
 
-from ConfigFileGUI.field_widgets import ScientificDoubleSpinBox
+pytest.importorskip("PyQt5", reason="PyQt5 not installed — skipping gui tests")
+
+from PyQt5.QtGui import QValidator  # noqa: E402
+
+from ConfigFileGUI.field_widgets import ScientificDoubleSpinBox  # noqa: E402
 
 pytestmark = pytest.mark.gui
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ markers = [
     "integration: requires external resources (data or hardware) — skipped in CI",
     "data: requires network-mounted GEECS data (combine with integration)",
     "hardware: requires live GEECS devices (combine with integration)",
+    "gui: requires a display and Qt — skipped in headless CI",
 ]
 # Exclude pre-existing test stubs that require optional/unavailable deps
 norecursedirs = [


### PR DESCRIPTION
fixed two small bugs:

i) the 'name' field in the ImageAnalyzer configs was frozen, but, this actually needs to be an editable field. The config name is independent from the 'name' field in the config.
ii) allow arbitrary precision for numeric entries which is essential for things like vignette correction.

Add some unit tests to verify things like loaded configs dump identical configs to prevent drift between configs and config editor

closes #383 
closes #382