### PR TITLE
fix(scanner,api): log noise reduction and exe timeout fix

### DIFF
--- a/GEECS-PythonAPI/CHANGELOG.md
+++ b/GEECS-PythonAPI/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this package will be documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.5.2] — 2026-05-11
+
+### Fixed
+- `EventHandler.unregister` no longer warns when called on a known event with
+  an empty subscriber dict. The check `if not subs` was treating an empty `{}`
+  the same as a missing event; corrected to `if event_name not in self.events`
+  so the silent no-op matches the documented behaviour.
+
 ## [0.5.1] — 2026-05-11
 
 ### Fixed

--- a/GEECS-PythonAPI/geecs_python_api/controls/devices/geecs_device.py
+++ b/GEECS-PythonAPI/geecs_python_api/controls/devices/geecs_device.py
@@ -386,7 +386,7 @@ class GeecsDevice:
         self,
         variable: str,
         value: Any,
-        exec_timeout: Optional[float] = 10.0,
+        exec_timeout: Optional[float] = 60.0,
         attempts_max: int = 5,
         sync: bool = True,
     ) -> Any:
@@ -409,7 +409,7 @@ class GeecsDevice:
         self,
         variable: str,
         value: Any,
-        exec_timeout: Optional[float] = 10.0,
+        exec_timeout: Optional[float] = 60.0,
         attempts_max: int = 5,
         sync: bool = True,
     ) -> Optional["AsyncResult"]:

--- a/GEECS-PythonAPI/geecs_python_api/controls/interface/event_handler.py
+++ b/GEECS-PythonAPI/geecs_python_api/controls/interface/event_handler.py
@@ -70,11 +70,10 @@ class EventHandler:
 
     def unregister(self, event_name: str, subscriber_name: str) -> None:
         """Unregister a subscriber from an event (no-op if absent)."""
-        subs = self.events.get(event_name)
-        if not subs:
+        if event_name not in self.events:
             logger.warning("attempted to unregister from unknown event %s", event_name)
             return
-        subs.pop(subscriber_name, None)
+        self.events[event_name].pop(subscriber_name, None)
         logger.debug('unregistered "%s" from event %s', subscriber_name, event_name)
 
     def unregister_all(self) -> None:

--- a/GEECS-PythonAPI/geecs_python_api/controls/interface/event_handler.py
+++ b/GEECS-PythonAPI/geecs_python_api/controls/interface/event_handler.py
@@ -71,7 +71,6 @@ class EventHandler:
     def unregister(self, event_name: str, subscriber_name: str) -> None:
         """Unregister a subscriber from an event (no-op if absent)."""
         if event_name not in self.events:
-            logger.warning("attempted to unregister from unknown event %s", event_name)
             return
         self.events[event_name].pop(subscriber_name, None)
         logger.debug('unregistered "%s" from event %s', subscriber_name, event_name)

--- a/GEECS-PythonAPI/pyproject.toml
+++ b/GEECS-PythonAPI/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-pythonapi"
-version = "0.5.1"
+version = "0.5.2"
 description = "Python interface to GEECS control system"
 authors = ["Guillaume Plateau <guillaume.plateau@tausystems.com>", "Sam Barber <sbarber@lbl.gov>"]
 readme = "README.md"

--- a/GEECS-Scanner-GUI/CHANGELOG.md
+++ b/GEECS-Scanner-GUI/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to this package will be documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.17.2] — 2026-05-11
+
+### Changed
+- `ActionManager.add_action` no longer emits a WARNING when overwriting an
+  existing action — this fires on every scan after the first and is expected
+  behaviour. Downgraded to INFO so it remains visible in scan logs.
+
 ## [0.17.1] — 2026-05-11
 
 ### Changed

--- a/GEECS-Scanner-GUI/CHANGELOG.md
+++ b/GEECS-Scanner-GUI/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to this package will be documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.17.1] — 2026-05-11
+
+### Changed
+- **Improved scan log context**: shot control name/variables, full device list
+  (sync / non-scalar / async), estimated acquisition time, and scan options are
+  now logged at INFO level at the start of every scan log, making post-hoc
+  troubleshooting easier without changing the log file's INFO threshold.
+- **Clearer ECS dump messaging**: `generate_live_ECS_dump` now logs an INFO
+  line before attempting the MC command and a descriptive WARNING (naming the
+  MC IP) when the command goes unacknowledged, replacing the generic debug/warning
+  messages that gave no indication of what was failing or why.
+
 ## [0.17.0] — 2026-05-11
 
 ### Changed

--- a/GEECS-Scanner-GUI/geecs_scanner/engine/action_manager.py
+++ b/GEECS-Scanner-GUI/geecs_scanner/engine/action_manager.py
@@ -93,10 +93,10 @@ class ActionManager:
         """Add or overwrite an action sequence in the in-memory library."""
         try:
             if action_name in self.actions:
-                logger.warning("Overwriting existing action: %s", action_name)
+                logger.info("Overwriting existing action: %s", action_name)
 
             self.actions[action_name] = action_seq
-            logger.debug("Added action sequence: %s", action_name)
+            logger.info("Added action sequence: %s", action_name)
 
         except Exception:
             logger.exception("Failed to add action %s", action_name)

--- a/GEECS-Scanner-GUI/geecs_scanner/engine/file_mover.py
+++ b/GEECS-Scanner-GUI/geecs_scanner/engine/file_mover.py
@@ -26,6 +26,32 @@ from geecs_scanner.utils.retry import retry
 logger = logging.getLogger(__name__)
 
 
+@dataclass(frozen=True)
+class FileSavePolicy:
+    """File-saving behaviour for a device type."""
+
+    expected_files: int = 1
+    exact_name_match: bool = False
+    variant_suffixes: tuple[str, ...] = ()
+
+
+_DEFAULT_POLICY = FileSavePolicy()
+
+_DEVICE_TYPE_POLICY: dict[str, FileSavePolicy] = {
+    "FROG": FileSavePolicy(expected_files=2),
+    "PicoscopeV2": FileSavePolicy(expected_files=2),
+    "Thorlabs CCS175 Spectrometer": FileSavePolicy(expected_files=2),
+    "RohdeSchwarz_RTA4000": FileSavePolicy(expected_files=2),
+    "ThorlabsWFS": FileSavePolicy(expected_files=2),
+    "MagSpecCamera": FileSavePolicy(
+        exact_name_match=True, variant_suffixes=("-interp", "-interpSpec", "-interpDiv")
+    ),
+    "MagSpecStitcher": FileSavePolicy(
+        exact_name_match=True, variant_suffixes=("-interp", "-interpSpec", "-interpDiv")
+    ),
+}
+
+
 @dataclass
 class FileMoveTask:
     """Task definition for moving and renaming a device file after acquisition."""
@@ -125,9 +151,10 @@ class FileMover:
         shot_index = task.shot_index
 
         home_dir = source_dir.parent
+        policy = _DEVICE_TYPE_POLICY.get(device_type or "", _DEFAULT_POLICY)
 
         try:
-            if device_type in ["MagSpecStitcher", "MagSpecCamera"]:
+            if policy.exact_name_match:
                 variant_dirs = [
                     d
                     for d in home_dir.iterdir()
@@ -144,18 +171,7 @@ class FileMover:
                 f"Cannot read source directory {home_dir} for device {device_name}"
             ) from exc
 
-        if device_type in [
-            "PicoscopeV2",
-            "FROG",
-            "Thorlabs CCS175 Spectrometer",
-            "RohdeSchwarz_RTA4000",
-            "ThorlabsWFS",
-        ]:
-            expected_file_count = 2
-        elif device_type in ["MagSpecStitcher", "MagSpecCamera"]:
-            expected_file_count = 1
-        else:
-            expected_file_count = 1
+        expected_file_count = policy.expected_files
 
         if not self.save_local:
             time.sleep(0.1)
@@ -205,12 +221,8 @@ class FileMover:
 
                     self._move_file(task, file, variant.name)
 
-                    if device_type in ["MagSpecStitcher", "MagSpecCamera"]:
-                        task.suffix = "-interp"
-                        self._process_variant_file(task)
-                        task.suffix = "-interpSpec"
-                        self._process_variant_file(task)
-                        task.suffix = "-interpDiv"
+                    for suffix in policy.variant_suffixes:
+                        task.suffix = suffix
                         self._process_variant_file(task)
 
                     if task.files_found_so_far >= expected_file_count:

--- a/GEECS-Scanner-GUI/geecs_scanner/engine/file_mover.py
+++ b/GEECS-Scanner-GUI/geecs_scanner/engine/file_mover.py
@@ -47,7 +47,7 @@ _DEVICE_TYPE_POLICY: dict[str, FileSavePolicy] = {
         exact_name_match=True, variant_suffixes=("-interp", "-interpSpec", "-interpDiv")
     ),
     "MagSpecStitcher": FileSavePolicy(
-        exact_name_match=True, variant_suffixes=("-interp", "-interpSpec", "-interpDiv")
+        exact_name_match=True, variant_suffixes=("-interpSpec", "-interpDiv")
     ),
 }
 

--- a/GEECS-Scanner-GUI/geecs_scanner/engine/scan_manager.py
+++ b/GEECS-Scanner-GUI/geecs_scanner/engine/scan_manager.py
@@ -458,18 +458,39 @@ class ScanManager:
                             "scan config: NOSCAN, %.1fs acquisition",
                             self.scan_config.wait_time,
                         )
+                if self.shot_control is not None:
+                    logger.info(
+                        "shot control: %s, variables: %s",
+                        self.shot_control.name,
+                        self.shot_control_variables,
+                    )
+                else:
+                    logger.info("shot control: not configured")
+                all_devices = list(self.device_manager.devices.keys())
+                logger.info(
+                    "save devices (%d total): sync=%s, non-scalar=%s, async=%s",
+                    len(all_devices),
+                    self.device_manager.event_driven_observables,
+                    self.device_manager.non_scalar_saving_devices,
+                    [
+                        d
+                        for d in all_devices
+                        if d not in self.device_manager.event_driven_observables
+                        and d not in self.device_manager.non_scalar_saving_devices
+                    ],
+                )
                 self.pre_logging_setup()
 
                 if self.scan_config:
                     self.estimate_acquisition_time()
-                    logger.debug(
+                    logger.info(
                         "Estimated acquisition time: %s seconds.", self.acquisition_time
                     )
                 self._set_state(
                     ScanState.INITIALIZING,
                     total_shots=int(self.acquisition_time * self.options.rep_rate_hz),
                 )
-                logger.debug("scan options: %s", self.options)
+                logger.info("scan options: %s", self.options)
 
                 if self.stop_scanning_thread_event.is_set():
                     raise ScanAbortedError("Stop requested after prelogging")
@@ -919,7 +940,9 @@ class ScanManager:
         if self.shot_control is None:
             logger.error("Cannot enable live ECS dump without shot control device")
             return
-        logger.debug("sending comands to MC to generate ECS live dump")
+        logger.info(
+            "Sending ECS configuration dump command to Master Control at %s", client_ip
+        )
 
         steps = ["Save Live Expt Devices Configuration>>ScanStart"]
 
@@ -927,7 +950,12 @@ class ScanManager:
             success = self.shot_control.dev_udp.send_scan_cmd(step, client_ip=client_ip)
             time.sleep(0.5)
             if not success:
-                logger.warning("Failed to generate an ECS live dump")
+                logger.warning(
+                    "Master Control at %s did not acknowledge ECS dump command — "
+                    "MC may be offline or unavailable. Scan will continue without "
+                    "an ECS configuration dump.",
+                    client_ip,
+                )
                 break
 
     def _generate_scan_steps(self) -> List[Dict[str, Any]]:

--- a/GEECS-Scanner-GUI/pyproject.toml
+++ b/GEECS-Scanner-GUI/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-scanner-gui"
-version = "0.17.0"
+version = "0.17.1"
 description = ""
 authors = ["Christopher Doss <CEDoss@lbl.gov>"]
 readme = "README.md"

--- a/GEECS-Scanner-GUI/pyproject.toml
+++ b/GEECS-Scanner-GUI/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-scanner-gui"
-version = "0.17.1"
+version = "0.17.2"
 description = ""
 authors = ["Christopher Doss <CEDoss@lbl.gov>"]
 readme = "README.md"


### PR DESCRIPTION
## Summary
- Reduce diagnostic noise in scan logs (spurious warnings, ECS dump messaging)
- Improve scan log context and action manager logging
- Refactor `file_mover.py` device-type handling into a `FileSavePolicy` registry; remove `-interp` variant lookup for `MagSpecStitcher` (directory never populated at Undulator)
- Silence spurious `EventHandler` unregister warning in the API
- Increase `GeecsDevice.set()` exe timeout from 10s → 60s to accommodate slow motion stages (ack timeout remains at 1.5s — the two phases are separate)

## Test plan
- [x] Run a scan at Undulator and confirm no spurious `No file found in U_BCaveMagSpec-interp` warnings
- [x] Run a scan with a slow motion stage (e.g. `U_ModeImagerESP`) and confirm move completes without `GeecsDeviceExeTimeout`
- [ ] Confirm `MagSpecCamera` devices still process `-interp`, `-interpSpec`, and `-interpDiv` variants
- [ ] Confirm triage report for a clean run shows zero `hardware_issue` entries for known-noise fingerprints

🤖 Generated with [Claude Code](https://claude.com/claude-code)