### PR TITLE
Move to best on finish

### DIFF
--- a/GEECS-Scanner-GUI/CHANGELOG.md
+++ b/GEECS-Scanner-GUI/CHANGELOG.md
@@ -3,6 +3,26 @@
 All notable changes to this package will be documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.20.0] — 2026-05-13
+
+### Added
+
+- **`move_to_best_on_finish` option for optimization scans.**
+  `BaseOptimizerConfig` gains a `move_to_best_on_finish: bool` field (default
+  `False`).  When `True`, at scan end — whether the scan completed normally or
+  was stopped early via the GUI — `ScanManager.stop_scan()` calls
+  `BaseOptimizer.best_observed_setpoint()` and sets each control device to that
+  row's values instead of restoring the pre-scan state.  Useful for leaving the
+  beamline at the empirically-best configuration the run found.  Falls back to
+  initial-state restoration (with a warning log) if `X.data` is empty, not yet
+  initialized, or all rows are errored / have a NaN objective.  Device-set
+  failures are logged and emitted as `ScanRestoreFailedEvent` (same pattern as
+  `restore_initial_state`), so the GUI accumulates them without aborting cleanup.
+- **`BaseOptimizer.best_observed_setpoint()`** — returns
+  `{variable_name: float}` for the best row in `X.data` (filtered for errors
+  and NaN objective), or `None` if no usable rows exist.  Objective direction
+  (`MAXIMIZE` / `MINIMIZE`) is respected.
+
 ## [0.19.0] — 2026-05-13
 
 ### Added

--- a/GEECS-Scanner-GUI/geecs_scanner/engine/scan_manager.py
+++ b/GEECS-Scanner-GUI/geecs_scanner/engine/scan_manager.py
@@ -720,8 +720,11 @@ class ScanManager:
         stop_saving_thread.join()
         logger.debug("Non-scalar device save states reset.")
 
-        # Step 5: Restore the initial state of devices.
-        if self.initial_state is not None:
+        # Step 5: Restore the initial state of devices, or move to best-observed
+        # setpoint when the optimizer is configured to do so.
+        if self.optimizer is not None and self.optimizer.move_to_best_on_finish:
+            self._move_to_best_observed()
+        elif self.initial_state is not None:
             self.restore_initial_state(self.initial_state)
 
         # Step 6: Execute closeout actions.  Wrapped so that a device error
@@ -1067,6 +1070,66 @@ class ScanManager:
 
         logger.debug("Initial scan variable state: %s", initial_state)
         return initial_state
+
+    def _move_to_best_observed(self) -> None:
+        """Set devices to the best-observed setpoint from the optimizer's history.
+
+        Falls back to initial-state restoration if ``best_observed_setpoint()``
+        returns None (empty data, all rows errored, or all objective values NaN).
+        Mirrors the error-handling pattern of :meth:`restore_initial_state`.
+        """
+        target = self.optimizer.best_observed_setpoint()
+
+        if target is None:
+            logger.warning(
+                "move_to_best_on_finish: no usable rows in X.data; "
+                "falling back to initial-state restoration."
+            )
+            if self.initial_state is not None:
+                self.restore_initial_state(self.initial_state)
+            return
+
+        logger.info(
+            "move_to_best_on_finish: moving devices to best-observed setpoint: %s",
+            target,
+        )
+        for device_var, value in target.items():
+            device_name, variable_name = device_var.split(":", 1)
+
+            if device_name not in self.device_manager.devices:
+                logger.warning(
+                    "move_to_best_on_finish: device %s not found; skipping %s.",
+                    device_name,
+                    device_var,
+                )
+                continue
+
+            device = self.device_manager.devices[device_name]
+            try:
+                device.set(variable_name, value)
+                logger.debug(
+                    "move_to_best_on_finish: set %s:%s → %s.",
+                    device_name,
+                    variable_name,
+                    value,
+                )
+            except DEVICE_COMMAND_ERRORS as e:
+                logger.error(
+                    "move_to_best_on_finish: failed to set %s:%s → %s (%s)",
+                    device_name,
+                    variable_name,
+                    value,
+                    type(e).__name__,
+                )
+                msg = f"{device_name}:{variable_name} → {value} ({type(e).__name__})"
+                self._emit(ScanRestoreFailedEvent(device=device_name, message=msg))
+            except Exception:
+                logger.exception(
+                    "move_to_best_on_finish: failed to set %s:%s → %s",
+                    device_name,
+                    variable_name,
+                    value,
+                )
 
     def restore_initial_state(self, initial_state):
         """Restore each device variable in *initial_state* to its pre-scan value.

--- a/GEECS-Scanner-GUI/geecs_scanner/engine/scan_manager.py
+++ b/GEECS-Scanner-GUI/geecs_scanner/engine/scan_manager.py
@@ -41,13 +41,11 @@ from geecs_scanner.engine.lifecycle import ScanLifecycleStateMachine
 from geecs_scanner.engine.models.scan_execution_config import ScanExecutionConfig
 from geecs_scanner.engine.models.scan_options import ScanOptions
 from geecs_scanner.engine.trigger_controller import TriggerController
-from geecs_scanner.engine.dialog_request import (
-    DEVICE_COMMAND_ERRORS,
-    DialogRequest,
-)
+from geecs_scanner.engine.dialog_request import DialogRequest
 from geecs_scanner.logging_setup import scan_log
 from geecs_scanner.optimization.base_optimizer import BaseOptimizer
 from geecs_scanner.utils.exceptions import (
+    DeviceCommandError,
     DeviceSynchronizationError,
     DeviceSynchronizationTimeout,
     OrphanProcessingTimeout,
@@ -1106,14 +1104,14 @@ class ScanManager:
 
             device = self.device_manager.devices[device_name]
             try:
-                device.set(variable_name, value)
+                self.cmd_executor.set(device, variable_name, value)
                 logger.debug(
                     "move_to_best_on_finish: set %s:%s → %s.",
                     device_name,
                     variable_name,
                     value,
                 )
-            except DEVICE_COMMAND_ERRORS as e:
+            except DeviceCommandError as e:
                 logger.error(
                     "move_to_best_on_finish: failed to set %s:%s → %s (%s)",
                     device_name,
@@ -1143,11 +1141,11 @@ class ScanManager:
             if device_name in self.device_manager.devices:
                 device = self.device_manager.devices[device_name]
                 try:
-                    device.set(variable_name, value)
+                    self.cmd_executor.set(device, variable_name, value)
                     logger.debug(
                         "Restored %s:%s to %s.", device_name, variable_name, value
                     )
-                except DEVICE_COMMAND_ERRORS as e:
+                except DeviceCommandError as e:
                     logger.error(
                         "Failed to restore %s:%s to %s (%s)",
                         device_name,

--- a/GEECS-Scanner-GUI/geecs_scanner/optimization/base_optimizer.py
+++ b/GEECS-Scanner-GUI/geecs_scanner/optimization/base_optimizer.py
@@ -95,6 +95,10 @@ class BaseOptimizer:
         loaded into the optimizer before the scan begins.  VOCS must be
         compatible (same variable and objective names); differing bounds
         produce warnings only.
+    move_to_best_on_finish : bool, default False
+        If True, ``best_observed_setpoint()`` is called at scan end so the
+        engine can move devices to the empirically best configuration.
+        Falls back to initial-state restoration if no usable rows exist.
 
     Attributes
     ----------
@@ -145,6 +149,7 @@ class BaseOptimizer:
         scan_data_manager: Optional["ScanDataManager"] = None,
         data_logger: Optional["DataLogger"] = None,
         seed_dump_files: Optional[List[Path]] = None,
+        move_to_best_on_finish: bool = False,
     ):
         self.vocs = vocs
         self.evaluate_function = evaluate_function
@@ -155,6 +160,7 @@ class BaseOptimizer:
         self.scan_data_manager = scan_data_manager
         self.data_logger = data_logger
         self._n_seeded: int = 0
+        self.move_to_best_on_finish: bool = move_to_best_on_finish
 
         self.xopt_config_overrides: dict[str, Any] = dict(xopt_config_overrides or {})
         self._setup_xopt(self.xopt_config_overrides)
@@ -166,6 +172,34 @@ class BaseOptimizer:
     def n_seeded(self) -> int:
         """Number of evaluations loaded from dump files before the scan started."""
         return self._n_seeded
+
+    def best_observed_setpoint(self) -> Optional[Dict[str, float]]:
+        """Return the VOCS-variable values of the best-observed row in X.data.
+
+        Returns
+        -------
+        dict or None
+            ``{variable_name: value}`` for the row with the best objective.
+            None if X.data is empty, uninitialized, or all rows are errored /
+            have a NaN objective.
+        """
+        if self.xopt is None or self.xopt.data is None or len(self.xopt.data) == 0:
+            return None
+
+        df = self.xopt.data.copy()
+        obj = self.vocs.objective_names[0]
+
+        if "xopt_error" in df.columns:
+            df = df[df["xopt_error"] != True]  # noqa: E712
+        df = df[df[obj].notna()]
+
+        if len(df) == 0:
+            return None
+
+        direction = str(self.vocs.objectives[obj]).upper()
+        idx = df[obj].idxmax() if direction == "MAXIMIZE" else df[obj].idxmin()
+
+        return {name: float(df.loc[idx, name]) for name in self.vocs.variable_names}
 
     def _setup_xopt(self, overrides: dict[str, Any]):
         generator_config: dict[str, Any] = {"name": self.generator_name}
@@ -501,4 +535,5 @@ class BaseOptimizer:
             scan_data_manager=scan_data_manager,
             data_logger=data_logger,
             seed_dump_files=resolved_seed_paths,
+            move_to_best_on_finish=config.move_to_best_on_finish,
         )

--- a/GEECS-Scanner-GUI/geecs_scanner/optimization/config_models.py
+++ b/GEECS-Scanner-GUI/geecs_scanner/optimization/config_models.py
@@ -254,6 +254,7 @@ class BaseOptimizerConfig(BaseModel):
     save_devices_file: Optional[Union[str, Path]] = None
 
     seed_dump_files: Optional[List[Union[str, Path]]] = None
+    move_to_best_on_finish: bool = False
 
     name: Optional[str] = None
     description: Optional[str] = None

--- a/GEECS-Scanner-GUI/pyproject.toml
+++ b/GEECS-Scanner-GUI/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-scanner-gui"
-version = "0.19.0"
+version = "0.20.0"
 description = ""
 authors = ["Christopher Doss <CEDoss@lbl.gov>"]
 readme = "README.md"


### PR DESCRIPTION
## Summary

- Adds `move_to_best_on_finish: bool` to `BaseOptimizerConfig` (default `False`). When `True`, at scan end (normal completion or early stop) the system moves to the empirically best-observed setpoint from `X.data` instead of restoring the pre-scan state.
- `BaseOptimizer.best_observed_setpoint()` — returns `{variable: value}` for the best `X.data` row, filtered for errors and NaN objective, respecting `MAXIMIZE`/`MINIMIZE` direction. Returns `None` if no usable rows exist (falls back to initial-state restoration with a warning log).
- `ScanManager._move_to_best_observed()` — new teardown method wired into `stop_scan()` Step 5, mirroring `restore_initial_state()` error handling. Device-set failures emit `ScanRestoreFailedEvent` so the GUI shows a summary dialog at DONE/ABORTED.
- Cleanup: both `_move_to_best_observed()` and `restore_initial_state()` now use `cmd_executor.set()` instead of raw `device.set()`, picking up retry logic and `DeviceCommandEvent` emission.

## Test plan

- [x] Run a small (5-iteration) BO scan with `move_to_best_on_finish: true` — confirm devices end at the best-observed setpoint (visible in logs and device monitor)
- [x] Stop a scan mid-run via the GUI stop button — confirm move-to-best still triggers (routes through same `stop_scan()` finally block)
- [x] Force an evaluator crash on iteration 0 — confirm fallback to initial-state restoration with warning log
- [x] Confirm `move_to_best_on_finish: false` (or omitted) preserves existing behavior exactly

🤖 Generated with [Claude Code](https://claude.com/claude-code)