### PR TITLE
feat(image-analysis): add TW/J scalar to FROG retrieval

### DIFF
--- a/ImageAnalysis/CHANGELOG.md
+++ b/ImageAnalysis/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this package will be documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [1.1.5] — 2026-05-19
+
+### Added
+- `FrogRetrievalResult.tw_per_joule` property — peak power per unit energy
+  (TW/J), computed as `1000 / (sum(temporal_intensity) * dt)` with `dt` in
+  femtoseconds. Matches the LabVIEW Grenouille analysis scalar.
+- `GrenouilleAnalyzer` now emits `{camera_name}_tw_per_joule` in its scalar
+  results.
+
 ## [1.1.4] — 2026-05-12
 
 ### Changed

--- a/ImageAnalysis/image_analysis/algorithms/frog_dll_retrieval.py
+++ b/ImageAnalysis/image_analysis/algorithms/frog_dll_retrieval.py
@@ -165,6 +165,19 @@ class FrogRetrievalResult:
         """E-field intensity |E(t)|^2."""
         return np.square(self.amplitude)
 
+    @property
+    def tw_per_joule(self) -> float:
+        """Peak power per unit energy (TW/J).
+
+        Computed as ``1000 / (sum(temporal_intensity) * dt)`` with ``dt`` in
+        femtoseconds, matching the LabVIEW Grenouille analysis. The factor of
+        1000 converts 1/fs (10^15 1/s) to TW/J (10^12 1/s). Assumes
+        ``temporal_intensity`` is peak-normalized to 1, which is the FROG.dll
+        convention.
+        """
+        dt = self.time[1] - self.time[0]
+        return 1000.0 / (np.sum(self.temporal_intensity) * dt)
+
 
 class FrogDllRetrieval:
     """High-level interface to the FROG DLL pulse retrieval algorithm.

--- a/ImageAnalysis/image_analysis/offline_analyzers/grenouille_analyzer.py
+++ b/ImageAnalysis/image_analysis/offline_analyzers/grenouille_analyzer.py
@@ -119,6 +119,7 @@ class GrenouilleAnalyzer(StandardAnalyzer):
             f"{self.camera_name}_spectral_fwhm": result.spectral_fwhm,
             f"{self.camera_name}_frog_error": result.frog_error,
             f"{self.camera_name}_frog_iterations": result.num_iterations,
+            f"{self.camera_name}_tw_per_joule": result.tw_per_joule,
         }
 
         # Pad shorter array with NaN to match lengths

--- a/ImageAnalysis/pyproject.toml
+++ b/ImageAnalysis/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "imageanalysis"
-version = "1.1.4"
+version = "1.1.5"
 description = "Central sub-repository for online and offline analysis of BELLA exeriments' images."
 authors = ["Reinier van Mourik <reinier.vanmourik@tausystems.com>"]
 readme = "README.md"


### PR DESCRIPTION
## Summary
- Adds `FrogRetrievalResult.tw_per_joule` property — peak power per unit energy (TW/J), computed as `1000 / (sum(temporal_intensity) * dt)` with `dt` in femtoseconds. Mirrors the existing LabVIEW Grenouille scalar.
- `GrenouilleAnalyzer` now emits `{camera_name}_tw_per_joule` alongside `temporal_fwhm`, `spectral_fwhm`, etc.
- Bumps `image-analysis` to 1.1.5 (patch — additive, no existing behavior changed).

## Notes
- Assumes `temporal_intensity` (the `field` array from FROG.dll) is peak-normalized to 1, which is the DLL convention and matches what the LabVIEW snippet relies on.
- The `1000` factor converts 1/fs → TW/J.

## Test plan
- [x] Run `GrenouilleAnalyzer` on a representative Grenouille scan and confirm `<cam>_tw_per_joule` appears in the scalar results.
- [x] Spot-check the value against the LabVIEW output for the same shot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)