### PR TITLE
fix(scan-analysis): init stateful_results to prevent AttributeError on batch failure

### DIFF
--- a/ScanAnalysis/CHANGELOG.md
+++ b/ScanAnalysis/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this package will be documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [1.3.4] — 2026-05-20
+
+### Fixed
+- `SingleDeviceScanAnalyzer.__init__` now initializes `self.stateful_results
+  = {}`. Previously it was only set in `cleanup()` or after a successful
+  `analyze_image_batch()` call. When `_run_batch_analysis` silently swallowed
+  an exception from the underlying ImageAnalyzer (e.g. a `BeamAnalyzer` whose
+  `camera_config.background` is null, leading to a `NoneType` access on its
+  background manager), `_prepare_per_shot_units` would then raise
+  `AttributeError: ... has no attribute 'stateful_results'`.
+
 ## [1.3.3] — 2026-05-19
 
 ### Changed

--- a/ScanAnalysis/pyproject.toml
+++ b/ScanAnalysis/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "scananalysis"
-version = "1.3.3"
+version = "1.3.4"
 description = "Modules for performing analyses routines on full scans"
 authors = ["Christopher Doss <CEDoss@lbl.gov>", "Sam Barber <sbarber@lbl.gov"]
 readme = "README.md"

--- a/ScanAnalysis/scan_analysis/analyzers/common/single_device_scan_analyzer.py
+++ b/ScanAnalysis/scan_analysis/analyzers/common/single_device_scan_analyzer.py
@@ -113,6 +113,10 @@ class SingleDeviceScanAnalyzer(ScanAnalyzer, ABC):
         self.saved_avg_data_paths: Dict[int, Path] = {}
         self.data_device_name: str = data_device_name or device_name
         self.results: dict = {}
+        # Set here (not just in cleanup) so that downstream consumers like
+        # _prepare_per_shot_units still work if _run_batch_analysis silently
+        # fails before populating this dict.
+        self.stateful_results: dict = {}
 
         # Define flags
         self.flag_save_data = flag_save_data


### PR DESCRIPTION
## Summary
- `SingleDeviceScanAnalyzer.__init__` now initializes `self.stateful_results = {}`. Previously it was only set in `cleanup()` or after a successful `analyze_image_batch()` call.
- Bumps `scan-analysis` to 1.3.4 (patch).

## Root cause / failure path
When `camera_config.background` is `None`, `create_background_manager_from_config` returns `None`, so a 2D analyzer ends up with `self.background_manager = None`. Its `analyze_image_batch` then raises `AttributeError` calling `.generate_dynamic_background` on `None`. `SingleDeviceScanAnalyzer._run_batch_analysis` swallows the exception with a warning, but `self.stateful_results` was never initialized — so the subsequent `_prepare_per_shot_units` dict-spread raises:

```
AttributeError: 'Array2DScanAnalyzer' object has no attribute 'stateful_results'
```

This PR fixes the cascade by giving `stateful_results` a default. The underlying `NoneType` access in `StandardAnalyzer.analyze_image_batch` is the upstream root cause and is being addressed in a separate ImageAnalysis PR.

## Test plan
- [x] Re-run a scan analysis on a `BeamAnalyzer` whose camera config has no `background:` section and confirm no `AttributeError` is raised (instead: warning about batch failure, then graceful per-shot processing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)