### PR TITLE
feat(image-analysis): LineAnalyzer metric_prefix, broader bg file types, null-bg guard

### DIFF
--- a/ImageAnalysis/CHANGELOG.md
+++ b/ImageAnalysis/CHANGELOG.md
@@ -3,6 +3,35 @@
 All notable changes to this package will be documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [1.2.0] — 2026-05-20
+
+### Added
+- `LineAnalyzer` now accepts a `metric_prefix` constructor arg that overrides
+  the `line_config.name`-derived prefix on scalar metric keys. Lets one
+  `Line1DConfig` be reused across multiple analyzer instances that report
+  under different names — e.g. a stitcher that loads from a per-device
+  config but emits metrics under a composite name.
+- 1D background subtraction `FROM_FILE` now supports every format the line
+  loader understands (npy, csv, tsv, tek_scope_hdf5, tdms_scope). The
+  background file is read via `read_1d_data` using the same `data_loading`
+  config the line itself uses. Previously only `.npy` / `.npz` were
+  accepted.
+
+### Fixed
+- `StandardAnalyzer.analyze_image_batch` no longer raises `AttributeError`
+  when the camera config has no `background:` section (in which case
+  `background_manager` is `None`).
+
+### Changed (breaking — internal/config-level)
+- `LineStitcher` constructor: `output_folder` and `output_label` kwargs are
+  replaced by a single `name` kwarg that drives the metric prefix, the
+  output subdirectory, and the output filename label. Existing YAML configs
+  must update from `output_folder`/`output_label` to `name`.
+- `compute_background` (in `processing/array1d/background.py`) now accepts
+  a `data_loading: Optional[Data1DConfig]` argument, required for the
+  `FROM_FILE` method. Pipeline callers already pass it through; direct
+  callers of this helper must update.
+
 ## [1.1.5] — 2026-05-19
 
 ### Added

--- a/ImageAnalysis/image_analysis/offline_analyzers/line_analyzer.py
+++ b/ImageAnalysis/image_analysis/offline_analyzers/line_analyzer.py
@@ -50,12 +50,19 @@ class LineAnalyzer(Standard1DAnalyzer):
         For example, "calibrated" becomes "_calibrated" in the output keys.
         Useful for tracking different analysis variations while keeping the
         same line name (e.g., "spectrum_CoM_calibrated").
+    metric_prefix : str, optional
+        Override the prefix used for scalar metric keys. Defaults to
+        ``line_config.name``. Useful when one ``Line1DConfig`` is reused by
+        multiple analyzer instances that should report under different names
+        (e.g., a stitcher that loads from a per-device config but emits
+        metrics under a composite name).
     """
 
     def __init__(
         self,
         line_config_name: Union[str, Line1DConfig],
         metric_suffix: Optional[str] = None,
+        metric_prefix: Optional[str] = None,
     ):
         """Initialize the line analyzer with external configuration.
 
@@ -68,16 +75,21 @@ class LineAnalyzer(Standard1DAnalyzer):
             Suffix to append to all metric names (underscore is auto-prepended).
             For example, "calibrated" becomes "_calibrated" in the output keys.
             Useful for distinguishing multiple analysis passes on the same line.
+        metric_prefix : str, optional
+            Override the prefix used for scalar metric keys. Defaults to
+            ``line_config.name``.
         """
         # Initialize parent class
         super().__init__(line_config_name)
 
-        # Store metric suffix for use in analyze_image
+        # Store metric suffix/prefix for use in analyze_image
         self.metric_suffix = metric_suffix
+        self.metric_prefix = metric_prefix
 
         logger.info(
-            "Initialized LineAnalyzer for line: %s%s",
+            "Initialized LineAnalyzer for line: %s%s%s",
             self.line_config.name,
+            f" (prefix: {metric_prefix})" if metric_prefix else "",
             f" (suffix: {metric_suffix})" if metric_suffix else "",
         )
 
@@ -117,9 +129,8 @@ class LineAnalyzer(Standard1DAnalyzer):
         )
 
         # Generate scalars dict with prefix and optional suffix
-        scalars = line_stats.to_dict(
-            prefix=self.line_config.name, suffix=self.metric_suffix
-        )
+        prefix = self.metric_prefix or self.line_config.name
+        scalars = line_stats.to_dict(prefix=prefix, suffix=self.metric_suffix)
 
         # Build result with line-specific data
         result = ImageAnalyzerResult(

--- a/ImageAnalysis/image_analysis/offline_analyzers/line_stitcher.py
+++ b/ImageAnalysis/image_analysis/offline_analyzers/line_stitcher.py
@@ -37,6 +37,11 @@ class LineStitcher(LineAnalyzer):
         Device names to load in addition to the master. Order determines
         how ties are broken when energies overlap, but the data is always
         sorted by x after concatenation.
+    name : str
+        Identifier for this stitcher instance. Used as the metric prefix
+        (so scalars are named ``<name>_CoM``, ``<name>_fwhm``, etc.), as
+        the subdirectory under the scan folder where stitched lineouts
+        are saved, and as the label embedded in the output filename.
     metric_suffix : str, optional
         Passed through to LineAnalyzer for metric naming.
     """
@@ -45,14 +50,16 @@ class LineStitcher(LineAnalyzer):
         self,
         line_config_name: str,
         sibling_devices: List[str],
+        name: str,
         metric_suffix: Optional[str] = None,
-        output_folder: str = "stitched_files",
-        output_label: str = "stitched_data",
     ):
-        super().__init__(line_config_name, metric_suffix)
+        super().__init__(
+            line_config_name,
+            metric_suffix=metric_suffix,
+            metric_prefix=name,
+        )
         self.sibling_devices = sibling_devices
-        self.output_folder = output_folder
-        self.output_label = output_label
+        self.name = name
         self._device_in_filename: Optional[str] = None
 
     def load_image(self, file_path: Path) -> Array1D:
@@ -161,9 +168,9 @@ class LineStitcher(LineAnalyzer):
 
         scan_dir = file_path.parent.parent
         shot_num = file_path.stem.rsplit("_", 1)[-1]
-        new_stem = f"{scan_dir.name}_{self.output_label}_{shot_num}"
+        new_stem = f"{scan_dir.name}_{self.name}_{shot_num}"
 
-        output_dir = scan_dir / self.output_folder
+        output_dir = scan_dir / self.name
         output_dir.mkdir(parents=True, exist_ok=True)
 
         metadata = result.metadata or {}

--- a/ImageAnalysis/image_analysis/offline_analyzers/standard_analyzer.py
+++ b/ImageAnalysis/image_analysis/offline_analyzers/standard_analyzer.py
@@ -168,8 +168,11 @@ class StandardAnalyzer(ImageAnalyzer):
             Original images and empty stateful results dict
         """
         # Generate dynamic background if configured
-        # This computes and saves the background but doesn't apply it
-        self.background_manager.generate_dynamic_background(images)
+        # This computes and saves the background but doesn't apply it.
+        # background_manager is None when camera_config has no background section
+        # at all, in which case there is nothing to compute.
+        if self.background_manager is not None:
+            self.background_manager.generate_dynamic_background(images)
 
         # Return ORIGINAL images (not processed)
         # Processing happens in analyze_image() for each image

--- a/ImageAnalysis/image_analysis/processing/array1d/background.py
+++ b/ImageAnalysis/image_analysis/processing/array1d/background.py
@@ -17,13 +17,15 @@ from typing import Optional
 
 import numpy as np
 
-from .config_models import BackgroundConfig, BackgroundMethod
+from .config_models import BackgroundConfig, BackgroundMethod, Data1DConfig
 
 logger = logging.getLogger(__name__)
 
 
 def compute_background(
-    data: np.ndarray, config: BackgroundConfig
+    data: np.ndarray,
+    config: BackgroundConfig,
+    data_loading: Optional[Data1DConfig] = None,
 ) -> Optional[np.ndarray]:
     """Compute background for 1D data based on configuration.
 
@@ -33,6 +35,11 @@ def compute_background(
         Input data in Nx2 format (x, y)
     config : BackgroundConfig
         Background configuration
+    data_loading : Data1DConfig, optional
+        Loader config used when ``method == FROM_FILE`` to read the
+        background file. Typically the same ``data_loading`` config the
+        line itself uses, passed through by the pipeline. Required when
+        ``method == FROM_FILE``.
 
     Returns
     -------
@@ -60,8 +67,13 @@ def compute_background(
         return background
 
     elif config.method == BackgroundMethod.FROM_FILE:
-        # Load background from file
-        background = load_background_from_file(config.background_file)
+        if data_loading is None:
+            raise ValueError(
+                "FROM_FILE background requires a data_loading config to know "
+                "how to read the file. Pipeline callers should pass through "
+                "the Line1DConfig.data_loading."
+            )
+        background = load_background_from_file(config.background_file, data_loading)
         logger.info(f"Loaded background from file: {config.background_file}")
         return background
 
@@ -114,15 +126,22 @@ def subtract_background(
     return result
 
 
-def load_background_from_file(file_path: Path) -> np.ndarray:
-    """Load background data from a file.
+def load_background_from_file(
+    file_path: Path, data_loading: Data1DConfig
+) -> np.ndarray:
+    """Load background data from a file using the shared 1D loader.
 
-    Supports NPY and NPZ formats.
+    Delegates to :func:`image_analysis.data_1d_utils.read_1d_data`, so any
+    format the line analyzer can read (npy, csv, tsv, tek_scope_hdf5,
+    tdms_scope) is also a valid background file.
 
     Parameters
     ----------
     file_path : Path
         Path to background file
+    data_loading : Data1DConfig
+        Loader config describing how to read the file. Pass the same
+        ``data_loading`` config the line itself uses.
 
     Returns
     -------
@@ -133,31 +152,17 @@ def load_background_from_file(file_path: Path) -> np.ndarray:
     ------
     FileNotFoundError
         If file doesn't exist
-    ValueError
-        If file format is unsupported or data format is invalid
     """
-    file_path = Path(file_path)
+    # Local import to avoid the package init cycle between data_1d_utils
+    # and processing.array1d.config_models.
+    from image_analysis.data_1d_utils import read_1d_data
 
+    file_path = Path(file_path)
     if not file_path.exists():
         raise FileNotFoundError(f"Background file not found: {file_path}")
 
-    suffix = file_path.suffix.lower()
+    background = read_1d_data(file_path, data_loading).data
 
-    if suffix == ".npy":
-        background = np.load(file_path)
-    elif suffix == ".npz":
-        # For NPZ files, assume the array is stored with key 'background'
-        # or use the first array if no 'background' key exists
-        npz_data = np.load(file_path)
-        if "background" in npz_data:
-            background = npz_data["background"]
-        else:
-            # Use first array
-            background = npz_data[npz_data.files[0]]
-    else:
-        raise ValueError(f"Unsupported file format: {suffix}. Use .npy or .npz")
-
-    # Validate format
     if background.ndim != 2 or background.shape[1] != 2:
         raise ValueError(
             f"Background file must contain Nx2 array, got shape {background.shape}"

--- a/ImageAnalysis/image_analysis/processing/array1d/config_models.py
+++ b/ImageAnalysis/image_analysis/processing/array1d/config_models.py
@@ -155,7 +155,12 @@ class BackgroundConfig(BaseModel):
         default=None, description="Constant value to subtract from y-values"
     )
     background_file: Optional[Path] = Field(
-        default=None, description="Path to background file (NPY or NPZ format)"
+        default=None,
+        description=(
+            "Path to background file. Loaded via the same 1D reader as the "
+            "line data, so any supported data_type (npy, csv, tsv, "
+            "tek_scope_hdf5, tdms_scope) is accepted."
+        ),
     )
 
     @field_validator("constant_value")

--- a/ImageAnalysis/image_analysis/processing/array1d/pipeline.py
+++ b/ImageAnalysis/image_analysis/processing/array1d/pipeline.py
@@ -98,7 +98,9 @@ def apply_line_processing_pipeline(
 
         elif step == PipelineStepType.BACKGROUND:
             if config.background is not None:
-                background = compute_background(processed, config.background)
+                background = compute_background(
+                    processed, config.background, config.data_loading
+                )
                 processed = subtract_background(processed, background)
                 if return_intermediate:
                     intermediate["background"] = processed.copy()

--- a/ImageAnalysis/pyproject.toml
+++ b/ImageAnalysis/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "imageanalysis"
-version = "1.1.5"
+version = "1.2.0"
 description = "Central sub-repository for online and offline analysis of BELLA exeriments' images."
 authors = ["Reinier van Mourik <reinier.vanmourik@tausystems.com>"]
 readme = "README.md"

--- a/ImageAnalysis/tests/analyzers/test_line_analyzer.py
+++ b/ImageAnalysis/tests/analyzers/test_line_analyzer.py
@@ -42,6 +42,10 @@ class TestLineAnalyzerInstantiation:
         analyzer = LineAnalyzer(_make_line_config(), metric_suffix="v2")
         assert analyzer.metric_suffix == "v2"
 
+    def test_accepts_metric_prefix(self):
+        analyzer = LineAnalyzer(_make_line_config(), metric_prefix="MyStitcher")
+        assert analyzer.metric_prefix == "MyStitcher"
+
 
 class TestLineAnalyzerScalars:
     """Scalar presence and finiteness."""
@@ -118,3 +122,9 @@ class TestLineAnalyzerResult:
         analyzer = LineAnalyzer(_make_line_config("line"), metric_suffix="cal")
         result = analyzer.analyze_image(_make_data())
         assert "line_CoM_cal" in result.scalars
+
+    def test_metric_prefix_overrides_line_name(self):
+        analyzer = LineAnalyzer(_make_line_config("line"), metric_prefix="stitched")
+        result = analyzer.analyze_image(_make_data())
+        assert "stitched_CoM" in result.scalars
+        assert "line_CoM" not in result.scalars


### PR DESCRIPTION
## Summary
- **`LineAnalyzer.metric_prefix`** — new constructor arg that overrides the `line_config.name`-derived prefix on scalar metric keys, so one `Line1DConfig` can be reused across analyzer instances reporting under different names.
- **`LineStitcher` kwarg cleanup** — `output_folder` and `output_label` collapse into a single `name` kwarg that drives the metric prefix, output subdirectory, and filename label. **Live YAML configs must update.**
- **1D background `FROM_FILE` now accepts any 1D loader format** — npy, csv, tsv, tek_scope_hdf5, tdms_scope. `load_background_from_file` delegates to `read_1d_data`, using the same `data_loading` config the line itself uses. Previously only `.npy`/`.npz` worked.
- **Null-background guard in `StandardAnalyzer.analyze_image_batch`** — fixes the upstream cause of the `AttributeError: ... no attribute 'stateful_results'` cascade seen in ScanAnalysis when a camera config has no `background:` section. (Paired with GEECS-Plugins#394 for the downstream defensive fix.)
- Bumps `image-analysis` 1.1.5 → 1.2.0 (new features + a small breaking change to the LineStitcher kwargs and to `compute_background`'s signature).

## Migration notes
- `LineStitcher` YAML: rename `output_folder`/`output_label` → `name`.
  ```yaml
  # before
  kwargs:
    line_config_name: PW-InterpSpec-stitcher
    sibling_devices: [...]
    output_folder: PW_MagSpecStitched
    output_label: PW_MagSpecStitched
  # after
  kwargs:
    line_config_name: PW-InterpSpec-stitcher
    sibling_devices: [...]
    name: PW-MagSpecStitched
  ```
- Direct callers of `compute_background(data, config)` must now pass `data_loading=...` for `FROM_FILE` to work. The standard pipeline already does this.

## Test plan
- [x] Full ImageAnalysis test suite passes (156 passed, 1 skipped) including two new `metric_prefix` tests.
- [x] Re-run a real `LineStitcher` analysis (e.g. `PW-MagSpectStitcher`) with the updated YAML and confirm scalars are named `<name>_CoM`, etc., and the output TSV lands at `<scan_dir>/<name>/...`.
- [x] Re-run a `LineAnalyzer` scan that uses a TSV background file to confirm it loads.
- [x] Re-run a `BeamAnalyzer` whose camera config has no `background:` section and confirm `analyze_image_batch` no longer raises.

🤖 Generated with [Claude Code](https://claude.com/claude-code)