### PR TITLE
fix(scan-analysis): stop swallowing real errors in _run_analysis_core

### DIFF
--- a/ScanAnalysis/CHANGELOG.md
+++ b/ScanAnalysis/CHANGELOG.md
@@ -3,6 +3,20 @@
 All notable changes to this package will be documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [1.3.5] — 2026-05-20
+
+### Fixed
+- `SingleDeviceScanAnalyzer._run_analysis_core` no longer swallows
+  unexpected exceptions. Previously the outer `except Exception` printed
+  a local traceback, logged a warning, and returned `None`. Because
+  `task_queue.run_worklist` treats a `None` return as "no display
+  files" and unconditionally writes `state="done"`, real analysis
+  failures were being marked as completed successfully. Exceptions now
+  propagate to `run_worklist`, which catches them and writes
+  `state="failed"` with the error message (matching the existing
+  `DataUnavailableWarning` → `state="no_data"` handling). The unused
+  `PRINT_TRACEBACK` module-level flag and `traceback` import are removed.
+
 ## [1.3.4] — 2026-05-20
 
 ### Fixed

--- a/ScanAnalysis/pyproject.toml
+++ b/ScanAnalysis/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "scananalysis"
-version = "1.3.4"
+version = "1.3.5"
 description = "Modules for performing analyses routines on full scans"
 authors = ["Christopher Doss <CEDoss@lbl.gov>", "Sam Barber <sbarber@lbl.gov"]
 readme = "README.md"

--- a/ScanAnalysis/scan_analysis/analyzers/common/single_device_scan_analyzer.py
+++ b/ScanAnalysis/scan_analysis/analyzers/common/single_device_scan_analyzer.py
@@ -22,7 +22,6 @@ from __future__ import annotations
 # --- Standard Library ---
 import logging
 import re
-import traceback
 import pickle
 from abc import ABC
 from concurrent.futures import ProcessPoolExecutor, ThreadPoolExecutor, as_completed
@@ -41,8 +40,6 @@ if TYPE_CHECKING:
     from image_analysis.types import ImageAnalyzerResult
     from image_analysis.base import ImageAnalyzer
     from scan_analysis.analyzers.renderers import BaseRenderer
-
-PRINT_TRACEBACK = True
 
 logger = logging.getLogger(__name__)
 
@@ -179,8 +176,18 @@ class SingleDeviceScanAnalyzer(ScanAnalyzer, ABC):
 
         Returns
         -------
-        list[str | pathlib.Path] or None
-            Paths to generated artifacts to display, or None on failure.
+        list[str | pathlib.Path]
+            Paths to generated artifacts to display.
+
+        Raises
+        ------
+        DataUnavailableWarning
+            If the device data directory is missing or empty. Callers are
+            expected to log this as a non-error skip.
+        Exception
+            Any unhandled error from the analysis pipeline propagates so the
+            task queue marks the task as ``failed`` (with a captured error
+            message) rather than silently writing ``done`` with no artifacts.
         """
         try:
             self.renderer.display_contents = []
@@ -211,11 +218,6 @@ class SingleDeviceScanAnalyzer(ScanAnalyzer, ABC):
         except DataUnavailableWarning as e:
             logger.warning(str(e))
             raise
-        except Exception as e:
-            if PRINT_TRACEBACK:
-                print(traceback.format_exc())
-            logger.warning(f"Warning: Data analysis failed due to: {e}")
-            return None
 
     def _process_all_shots(self):
         """Load data files, run batch analysis (optional), then mode-based analysis."""


### PR DESCRIPTION
## Summary
- `SingleDeviceScanAnalyzer._run_analysis_core` no longer swallows unexpected exceptions. Previously the outer `except Exception` printed a local traceback, logged a warning, and returned `None`. Because `task_queue.run_worklist` treats a `None` return as "no display files" and unconditionally writes `state="done"`, real analysis crashes were being marked as completed successfully.
- Exceptions now propagate to `run_worklist`, which already has the right handler that writes `state="failed"` with the error message — matching how the existing `DataUnavailableWarning` re-raise routes to `state="no_data"`.
- Drops the now-unused `PRINT_TRACEBACK` module-level flag and `traceback` import.
- Bumps `scan-analysis` to 1.3.5 (patch).

## Why this matters
Real failures (e.g. the `BeamAnalyzer` null-bg cascade that motivated #394) were being silently marked `done` in the livewatch task queue. Operators would see tasks complete instantly with no traceback, no error status, no clue. With this fix, the same crash would be surfaced as `state="failed"` with the captured error and full traceback logged by `run_worklist` via `logger.exception(...)`.

## Test plan
- [x] Full `ScanAnalysis` test suite passes (74 passed, 3 skipped).
- [ ] Manual: introduce a deliberate bug in an analyzer (or run a known-bad config like the null-bg `BeamAnalyzer` that motivated #394 before its fix lands) and confirm the task's status YAML records `state: failed` with a non-empty `error` field.

## Related
- Built on top of #394 (defensive init of `stateful_results`).
- Independent of #395 (ImageAnalysis null-bg root cause), but the two together close the full cascade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)