### PR TITLE
feat(scan-analysis): waterfall_sort_key bypasses binning for parameter scans

### DIFF
--- a/ScanAnalysis/CHANGELOG.md
+++ b/ScanAnalysis/CHANGELOG.md
@@ -3,6 +3,19 @@
 All notable changes to this package will be documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [1.3.6] — 2026-05-20
+
+### Changed
+- `Array1DScanAnalyzer._postprocess_scan` now bypasses scan-parameter
+  binning and falls through to `_postprocess_noscan` when
+  `waterfall_sort_key` is set in `renderer_kwargs`. Previously the sort
+  key only took effect on noscan data; for parameter scans the waterfall
+  was always binned by the scan parameter, so the kwarg had no observable
+  effect. With this change you can render every shot of a parameter scan
+  as a waterfall row ordered by any s-file column (e.g. a downstream
+  diagnostic) — at the cost of the per-bin averaged spectra, which are
+  not produced in this mode. Behavior with no sort key is unchanged.
+
 ## [1.3.5] — 2026-05-20
 
 ### Fixed

--- a/ScanAnalysis/CHANGELOG.md
+++ b/ScanAnalysis/CHANGELOG.md
@@ -16,6 +16,18 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   diagnostic) — at the cost of the per-bin averaged spectra, which are
   not produced in this mode. Behavior with no sort key is unchanged.
 
+### Fixed
+- Waterfall sort-key filtering in `_postprocess_noscan` is now
+  NaN-aware. Previously a single missing or NaN value in the chosen
+  auxiliary column poisoned `mean()` / `std()`, making the
+  sigma-based outlier filter reject every shot ("kept 0 of N"). Now
+  shots with a non-finite sort value are dropped up front with a
+  warning; if none remain, rendering is skipped with a clear log line
+  instead of producing an empty figure. Also drops the
+  `else float(shot_num)` fallback in the lookup: mixing shot indices
+  with real sort-key values would silently corrupt the same
+  mean/std-based filter on partially-populated columns.
+
 ## [1.3.5] — 2026-05-20
 
 ### Fixed

--- a/ScanAnalysis/pyproject.toml
+++ b/ScanAnalysis/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "scananalysis"
-version = "1.3.5"
+version = "1.3.6"
 description = "Modules for performing analyses routines on full scans"
 authors = ["Christopher Doss <CEDoss@lbl.gov>", "Sam Barber <sbarber@lbl.gov"]
 readme = "README.md"

--- a/ScanAnalysis/scan_analysis/analyzers/common/array1d_scan_analysis.py
+++ b/ScanAnalysis/scan_analysis/analyzers/common/array1d_scan_analysis.py
@@ -330,9 +330,29 @@ class Array1DScanAnalyzer(SingleDeviceScanAnalyzer):
         For 1D line/spectrum data with a scanned parameter, this creates:
         - Individual averaged spectra per bin
         - A waterfall plot showing all bins sorted by scan parameter
+
+        When ``waterfall_sort_key`` is set in ``renderer_kwargs``, the
+        binning step is bypassed entirely and rendering falls through to
+        :meth:`_postprocess_noscan`, which produces a per-shot waterfall
+        sorted by the chosen s-file column. Use this when you want to see
+        every shot ordered by a different observable than the scan
+        parameter (e.g. a downstream diagnostic) — the per-bin averaged
+        spectra are not generated in this mode.
         """
         from scan_analysis.analyzers.renderers.config import RenderContext
         from concurrent.futures import ThreadPoolExecutor, as_completed
+
+        # When a sort key is provided, treat the scan as if it were a
+        # noscan for rendering purposes: every shot becomes a waterfall
+        # row ordered by the chosen s-file column rather than by bin.
+        if self.renderer_kwargs.get("waterfall_sort_key"):
+            logger.info(
+                "waterfall_sort_key=%r set; bypassing binning and rendering "
+                "per-shot waterfall via _postprocess_noscan",
+                self.renderer_kwargs["waterfall_sort_key"],
+            )
+            self._postprocess_noscan()
+            return
 
         # Get binned data (handles both per_shot and per_bin modes)
         binned_data = self.get_binned_data()

--- a/ScanAnalysis/scan_analysis/analyzers/common/array1d_scan_analysis.py
+++ b/ScanAnalysis/scan_analysis/analyzers/common/array1d_scan_analysis.py
@@ -277,8 +277,13 @@ class Array1DScanAnalyzer(SingleDeviceScanAnalyzer):
                         row = self.auxiliary_data.loc[
                             self.auxiliary_data["Shotnumber"] == shot_num, sort_column
                         ]
+                        # Use NaN as the sentinel for "no value"; the filter
+                        # below drops any shot whose sort value isn't finite.
+                        # Falling back to float(shot_num) would mix scales
+                        # (shot indices vs. real sort-key values), which
+                        # breaks mean/std-based outlier filtering.
                         ctx.parameter_value = (
-                            float(row.iloc[0]) if not row.empty else float(shot_num)
+                            float(row.iloc[0]) if not row.empty else float("nan")
                         )
                         ctx.scan_parameter = sort_column
                     else:
@@ -287,6 +292,24 @@ class Array1DScanAnalyzer(SingleDeviceScanAnalyzer):
                     contexts.append(ctx)
 
             if sort_column is not None:
+                # Drop shots whose sort-key value is missing or non-finite.
+                # Without this, even a single NaN poisons mean()/std() and
+                # the outlier filter rejects every shot.
+                n_before = len(contexts)
+                contexts = [c for c in contexts if np.isfinite(c.parameter_value)]
+                n_invalid = n_before - len(contexts)
+                if n_invalid:
+                    logger.warning(
+                        f"Waterfall sort: dropped {n_invalid} shot(s) with "
+                        f"non-finite {sort_column!r} values."
+                    )
+                if not contexts:
+                    logger.warning(
+                        f"Waterfall sort: no shots have a valid {sort_column!r} "
+                        "value; skipping summary figure."
+                    )
+                    return
+
                 sort_bounds = self.renderer_kwargs.get("waterfall_sort_bounds")
                 sort_sigma = self.renderer_kwargs.get("waterfall_sort_sigma", 3.0)
                 n_before = len(contexts)


### PR DESCRIPTION
## Summary
Extends the existing `waterfall_sort_key` kwarg to work on parameter scans, not just noscans.

- Before: setting `waterfall_sort_key` on a parameter scan had no observable effect — `_postprocess_scan` always binned by the scan parameter, and the sort key was passed into `renderer_kwargs` but the data was already aggregated.
- After: when `waterfall_sort_key` is set, `_postprocess_scan` delegates to `_postprocess_noscan`, which produces a per-shot waterfall ordered by the chosen s-file column.
- Behavior with no sort key is identical to before (binned-by-scan-parameter waterfall).
- Bumps `scan-analysis` to 1.3.6 (patch — opt-in via existing kwarg, no behavior change otherwise).

## Tradeoff
In sort-key mode, per-bin averaged spectra are not produced (you're rendering every shot individually). That's the intended use case: when the operator wants to see all shots ordered by a downstream diagnostic rather than by scan parameter.

## Test plan
- [x] Full `ScanAnalysis` test suite passes (74 passed, 3 skipped).
- [x] Run a known parameter scan twice — once without `waterfall_sort_key` (binned-by-scan-parameter waterfall) and once with it set to an s-file column (per-shot waterfall ordered by that column). Confirm:
  - [x] Without the kwarg: identical output to current master.
  - [x] With the kwarg: per-shot rows, ordered by the chosen column, with the existing sigma/bounds filter applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)