### PR TITLE
docs: define agent and worktree policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,8 @@
+# Codex Instructions
+
+Use the repository's `CLAUDE.md` files as the authoritative agent
+instructions.
+
+Before making changes, read the root `CLAUDE.md` and any package-level
+`CLAUDE.md` that applies to the files being touched. Do not duplicate guidance
+in `AGENTS.md`; update the relevant `CLAUDE.md` instead.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,6 +18,25 @@ tooling. Each subdirectory is an independent Python package with its own
 
 Each subpackage has its own `CLAUDE.md` with deep architectural detail.
 
+## Agent & Worktree Policy
+
+`CLAUDE.md` files are the canonical agent/developer instructions for this
+repository. `AGENTS.md` exists only as a Codex compatibility shim that points
+Codex to the root and package-level `CLAUDE.md` files. Do not duplicate policy
+between `AGENTS.md` and `CLAUDE.md`; update the relevant `CLAUDE.md` instead.
+
+Worktrees should live outside the repository checkout, as siblings of the main
+clone, and should use stable names that describe the intended feature or fix.
+For example, keep the main checkout at `GEECS-Plugins/` and create worktrees
+such as `GEECS-Plugins-pulse-duration-jitter/`,
+`GEECS-Plugins-interlock-suggestions/`, or
+`GEECS-Plugins-bluesky-detectors/` next to it.
+
+Do not create worktrees inside the repository root, inside subpackages, or
+under tool-generated paths such as `.claude/worktrees/`. Remove worktrees after
+their PR is merged unless they are intentionally long-lived for a distinct
+development stream.
+
 ## Python & Tooling
 
 - **Python:** `>=3.10, <3.12` across all packages (Scanner GUI is `<3.11`)


### PR DESCRIPTION
## Summary
- Add root AGENTS.md as a Codex compatibility shim that points to CLAUDE.md
- Document that CLAUDE.md files are canonical for agent/developer instructions
- Define the worktree policy: sibling worktrees with descriptive names, no repo-internal worktrees

## Testing
- pre-commit hooks ran during commit