### PR TITLE
feat(scan-analysis/configgui): Literal-dropdown widget + collapsible image section

### DIFF
--- a/ScanAnalysis/CHANGELOG.md
+++ b/ScanAnalysis/CHANGELOG.md
@@ -3,6 +3,28 @@
 All notable changes to this package will be documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [1.8.1] — 2026-05-28
+
+ConfigFileGUI quality-of-life: validated dropdowns for `Literal[...]`
+fields and a collapsible image section in the scan-analyzer editor.
+
+### Added
+- `LiteralFieldWidget` in `field_widgets.py`. `Literal["a", "b", ...]`
+  fields on Pydantic models are now rendered as a `QComboBox`
+  populated with the literal arguments, instead of falling through to
+  the string-input fallback. Dispatched before the `Enum` case in
+  `create_field_widget` and handles bare `Literal[...]` as well as the
+  inner type of `Optional[Literal[...]]`. First concrete user is
+  `FromCurrentScanSpec.method` (`Literal["median", "percentile"]`) in
+  the scan field's `background_source.from_current_scan` editor.
+- Collapse toggle on the **Image** group in `scan_analyzer_editor.py`.
+  A `QToolButton` (▼ / ▶) in the type-discriminator row hides the
+  embedded `ConfigEditorPanel` while leaving the type combo visible,
+  so users can fold the long camera/line form away without losing
+  sight of the current image kind. The toggle is orthogonal to the
+  `(none)` discriminator hide — both states are tracked separately
+  and ANDed in `_refresh_image_panel_visibility`.
+
 ## [1.8.0] — 2026-05-27
 
 ConfigFileGUI rewrite against the PR-E unified-diagnostic surface

--- a/ScanAnalysis/ConfigFileGUI/field_widgets.py
+++ b/ScanAnalysis/ConfigFileGUI/field_widgets.py
@@ -15,7 +15,18 @@ import re
 import typing
 from enum import Enum
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple, Type, Union, get_args, get_origin
+from typing import (
+    Any,
+    Dict,
+    List,
+    Literal,
+    Optional,
+    Tuple,
+    Type,
+    Union,
+    get_args,
+    get_origin,
+)
 
 import yaml
 from pydantic import BaseModel
@@ -574,6 +585,83 @@ class EnumFieldWidget(BaseFieldWidget):
 
 
 # ---------------------------------------------------------------------------
+# Concrete widget: Literal[...]
+# ---------------------------------------------------------------------------
+
+
+class LiteralFieldWidget(BaseFieldWidget):
+    """Widget for ``Literal[...]`` fields using a ``QComboBox``.
+
+    For Pydantic fields typed as e.g. ``Literal["median", "percentile"]``.
+    Each Literal argument becomes a dropdown entry, with the raw value
+    stored as item data so :meth:`get_value` returns the original
+    ``str`` / ``int`` / etc. unchanged.
+
+    Parameters
+    ----------
+    field_name : str
+        Pydantic field name.
+    field_info : FieldInfo
+        Pydantic field descriptor.
+    choices : tuple
+        The ``typing.get_args`` of the Literal annotation — the
+        allowed values.
+    parent : QWidget, optional
+        Parent widget.
+    """
+
+    def __init__(
+        self,
+        field_name: str,
+        field_info: FieldInfo,
+        choices: Tuple[Any, ...],
+        parent: Optional[QWidget] = None,
+    ) -> None:
+        super().__init__(field_name, field_info, parent)
+        self._choices = choices
+        self._combo = QComboBox()
+
+        for choice in choices:
+            self._combo.addItem(str(choice), choice)
+
+        self._row_layout.addWidget(self._combo, stretch=1)
+        self._combo.currentIndexChanged.connect(self.valueChanged.emit)
+
+        # Apply default
+        default = getattr(field_info, "default", PydanticUndefined)
+        if default is not PydanticUndefined and default is not None:
+            self.set_value(default)
+
+    def get_value(self) -> Any:
+        """Return the raw value of the currently selected literal.
+
+        Returns
+        -------
+        Any
+            The selected Literal argument exactly as declared
+            (str / int / etc.), or ``None`` if no selection.
+        """
+        return self._combo.currentData()
+
+    def set_value(self, value: Any) -> None:
+        """Set the combo box to the entry matching ``value``.
+
+        Parameters
+        ----------
+        value : Any
+            One of the Literal arguments, or a string representation
+            of one. No-op if no match.
+        """
+        if value is None:
+            return
+        for i in range(self._choices.__len__()):
+            stored = self._combo.itemData(i)
+            if stored == value or str(stored) == str(value):
+                self._combo.setCurrentIndex(i)
+                return
+
+
+# ---------------------------------------------------------------------------
 # Concrete widget: Optional[X] wrapper
 # ---------------------------------------------------------------------------
 
@@ -1098,16 +1186,18 @@ def create_field_widget(
     The resolution order is:
 
     1. ``Optional[X]`` → wrap the inner widget in :class:`OptionalFieldWidget`
-    2. ``Enum`` subclass → :class:`EnumFieldWidget`
-    3. ``bool`` → :class:`BoolFieldWidget`  (checked before ``int``!)
-    4. ``int`` → :class:`IntFieldWidget`
-    5. ``float`` → :class:`FloatFieldWidget`
-    6. ``str`` → :class:`StringFieldWidget`
-    7. ``Tuple[int, int]`` → :class:`TupleFieldWidget`
-    8. ``List[BaseModel]`` → :class:`ListFieldWidget`
-    9. ``Dict`` → :class:`DictFieldWidget`
-    10. ``Path`` or union containing ``Path`` → :class:`PathFieldWidget`
-    11. Fallback → :class:`StringFieldWidget` with ``str()`` conversion
+    2. ``Literal[...]`` → :class:`LiteralFieldWidget`  (checked before
+       ``Enum`` since Literal has no class to subclass-check against)
+    3. ``Enum`` subclass → :class:`EnumFieldWidget`
+    4. ``bool`` → :class:`BoolFieldWidget`  (checked before ``int``!)
+    5. ``int`` → :class:`IntFieldWidget`
+    6. ``float`` → :class:`FloatFieldWidget`
+    7. ``str`` → :class:`StringFieldWidget`
+    8. ``Tuple[int, int]`` → :class:`TupleFieldWidget`
+    9. ``List[BaseModel]`` → :class:`ListFieldWidget`
+    10. ``Dict`` → :class:`DictFieldWidget`
+    11. ``Path`` or union containing ``Path`` → :class:`PathFieldWidget`
+    12. Fallback → :class:`StringFieldWidget` with ``str()`` conversion
     """
     # --- 1. Optional[X] ---------------------------------------------------
     if _is_optional(field_type):
@@ -1157,6 +1247,14 @@ def _create_inner_widget(
     """
     origin = get_origin(field_type)
     args = get_args(field_type)
+
+    # --- Literal[...] ------------------------------------------------------
+    # Must come before Enum (Literal has no class to subclass-check against
+    # but its origin is the Literal special form). Handles both bare
+    # Literal["a", "b"] and the inner type of Optional[Literal["a", "b"]]
+    # since the Optional case unwraps and recurses.
+    if origin is Literal:
+        return LiteralFieldWidget(field_name, field_info, args, parent)
 
     # --- Enum --------------------------------------------------------------
     if isinstance(field_type, type) and issubclass(field_type, Enum):

--- a/ScanAnalysis/ConfigFileGUI/scan_analyzer_editor.py
+++ b/ScanAnalysis/ConfigFileGUI/scan_analyzer_editor.py
@@ -37,6 +37,7 @@ from PyQt5.QtWidgets import (
     QLabel,
     QLineEdit,
     QPlainTextEdit,
+    QToolButton,
     QVBoxLayout,
     QWidget,
 )
@@ -243,7 +244,20 @@ class ScanAnalyzerEditorPanel(QWidget):
         self._image_box = QGroupBox("Image")
         image_layout = QVBoxLayout(self._image_box)
 
+        # Header row: collapse toggle + type discriminator combo. The
+        # toggle hides the embedded ConfigEditorPanel below while leaving
+        # the type combo visible, so users can see the current image
+        # kind at a glance even when the form is folded away.
         type_row = QHBoxLayout()
+        self._image_collapse_btn = QToolButton()
+        self._image_collapse_btn.setText("▼")
+        self._image_collapse_btn.setToolTip("Collapse image config")
+        self._image_collapse_btn.setStyleSheet(
+            "QToolButton { border: none; font-size: 10px; }"
+        )
+        self._image_collapse_btn.clicked.connect(self._on_image_collapse_clicked)
+        type_row.addWidget(self._image_collapse_btn)
+
         type_row.addWidget(QLabel("type:"))
         self._image_type_combo = QComboBox()
         self._image_type_combo.addItems(
@@ -264,6 +278,12 @@ class ScanAnalyzerEditorPanel(QWidget):
         self._image_panel = ConfigEditorPanel()
         self._image_panel.valueChanged.connect(self._on_value_changed)
         image_layout.addWidget(self._image_panel, stretch=1)
+
+        # User-controlled toggle state. ``_image_active`` (set in
+        # ``_apply_image_kind``) is the orthogonal signal that there's
+        # actually something to show; ``_refresh_image_panel_visibility``
+        # ANDs the two.
+        self._image_expanded = True
 
         outer.addWidget(self._image_box, stretch=1)
 
@@ -301,12 +321,12 @@ class ScanAnalyzerEditorPanel(QWidget):
         model).
         """
         if kind == self._TYPE_NONE:
-            self._image_panel.setVisible(False)
             self._image_active = False
+            self._refresh_image_panel_visibility()
             return
 
-        self._image_panel.setVisible(True)
         self._image_active = True
+        self._refresh_image_panel_visibility()
 
         if kind == self._TYPE_CAMERA:
             model_cls, cep_type = self._camera_classes()
@@ -399,6 +419,42 @@ class ScanAnalyzerEditorPanel(QWidget):
             return
         self._apply_image_kind(new_kind, payload=None)
         self._on_value_changed()
+
+    def _on_image_collapse_clicked(self) -> None:
+        """Toggle the user-controlled expanded/collapsed state.
+
+        Flips ``_image_expanded`` and updates panel visibility through
+        the same helper that ``_apply_image_kind`` uses, so the
+        user-controlled toggle and the discriminator-driven hide stay
+        consistent.
+        """
+        self._image_expanded = not self._image_expanded
+        self._refresh_image_panel_visibility()
+
+    def _refresh_image_panel_visibility(self) -> None:
+        """Show the image ConfigEditorPanel only when active **and** expanded.
+
+        Two orthogonal signals decide whether the embedded
+        ``ConfigEditorPanel`` is visible:
+
+        * ``_image_active`` — set by ``_apply_image_kind`` based on the
+          discriminator (False for ``(none)``, True for ``camera`` /
+          ``line``).
+        * ``_image_expanded`` — user-controlled collapse toggle in the
+          header row.
+
+        Also keeps the toggle button's arrow glyph and tooltip in sync.
+        """
+        visible = self._image_active and self._image_expanded
+        self._image_panel.setVisible(visible)
+        # Update the toggle glyph + tooltip regardless of active state,
+        # so the button always reflects the user's last preference.
+        if self._image_expanded:
+            self._image_collapse_btn.setText("▼")
+            self._image_collapse_btn.setToolTip("Collapse image config")
+        else:
+            self._image_collapse_btn.setText("▶")
+            self._image_collapse_btn.setToolTip("Expand image config")
 
     # ------------------------------------------------------------------
     # Public API

--- a/ScanAnalysis/pyproject.toml
+++ b/ScanAnalysis/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "scananalysis"
-version = "1.8.0"
+version = "1.8.1"
 description = "Modules for performing analyses routines on full scans"
 authors = ["Christopher Doss <CEDoss@lbl.gov>", "Sam Barber <sbarber@lbl.gov"]
 readme = "README.md"


### PR DESCRIPTION
Two ConfigFileGUI quality-of-life additions that surfaced while editing a diagnostic config with a \`from_current_scan\` dynamic background.

## 1. \`LiteralFieldWidget\` (\`field_widgets.py\`)

Pydantic \`Literal[\"a\", \"b\", ...]\` fields fell through to the \`StringFieldWidget\` fallback, so the user got a free-form text input where only a fixed set of values is valid. Now \`Literal\` types render as a \`QComboBox\` populated with the literal arguments.

- Dispatched **before** the \`Enum\` case in \`create_field_widget\` (Literal has no class to subclass-check against, but its origin is the \`Literal\` special form).
- Handles both bare \`Literal[X, Y]\` and the inner type of \`Optional[Literal[X, Y]]\` — the existing Optional-wrap recursion calls \`_create_inner_widget\` on the inner type, so a single dispatch case covers both.
- Stores the raw literal value as item data so \`get_value\` returns the original \`str\` / \`int\` unchanged (clean YAML serialisation, no \`!!python/object/apply:\` tags).

**First concrete user:** \`FromCurrentScanSpec.method\` — \`Literal[\"median\", \"percentile\"]\` — in the scan field's \`background_source.from_current_scan\` editor. Before this PR, the user could type any string and the loader would reject it; now it's a validated dropdown.

## 2. Collapsible image section (\`scan_analyzer_editor.py\`)

The embedded \`ConfigEditorPanel\` for \`CameraConfig\` / \`Line1DConfig\` is tall — when the user wants to focus on the \`image_analyzer\` or \`scan\` fields, the form gets in the way. Added a \`QToolButton\` (▼ / ▶) in the type-discriminator row that hides the panel while leaving the type combo visible, so the current image kind stays visible at a glance.

The toggle is **orthogonal** to the \`(none)\` discriminator hide. \`_image_active\` (the discriminator signal) and \`_image_expanded\` (the user toggle) are tracked separately and ANDed in \`_refresh_image_panel_visibility\`. Picking \`(none)\` hides the panel regardless of toggle state; picking \`camera\` / \`line\` respects the user's last toggle.

Glyph and tooltip update in lockstep with the toggle state (▼ = "Collapse image config" when expanded, ▶ = "Expand image config" when collapsed).

## Versioning

ScanAnalysis 1.8.0 → 1.8.1 (patch — no public-API change, GUI-only).

## Test plan

- [x] \`pre-commit run --all-files\` clean
- [x] All 17 \`test_config_gui_roundtrip\` tests pass (offscreen Qt)
- [ ] Manual: open the editor, change \`scan.background_source.from_current_scan.method\` — verify it's a dropdown with exactly \"median\" and \"percentile\"
- [ ] Manual: click the ▼ next to \"type:\" — image form collapses, type combo stays visible; click ▶ — expands
- [ ] Manual: with image collapsed, pick \"(none)\" — no change; pick \"camera\" — panel stays collapsed (user's last preference respected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)