### PR TITLE
fix(docs): add missing mkdocs-git-revision-date-localized-plugin to RTD requirements

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,4 @@
 mkdocs-material
 mkdocstrings[python]
 mkdocs-jupyter>=0.24
+mkdocs-git-revision-date-localized-plugin


### PR DESCRIPTION
## Why

ReadTheDocs builds have been failing since PR #407 (commit da63c337) with:

\`\`\`
ERROR -  Config value 'plugins': The \"git-revision-date-localized\" plugin is not installed
\`\`\`

#407 added the \`git-revision-date-localized\` plugin to \`mkdocs.yml\` (to show "last updated" timestamps on doc pages) but the corresponding PyPI package was never added to \`docs/requirements.txt\`. RTD installs from that file, so the plugin was missing in the build environment and mkdocs aborted on config validation before even attempting to render any pages.

## What

One-line add to \`docs/requirements.txt\`:

\`\`\`
mkdocs-git-revision-date-localized-plugin
\`\`\`

Verified: plugin installs cleanly in a fresh venv, imports without issue (\`from mkdocs_git_revision_date_localized_plugin.plugin import GitRevisionDateLocalizedPlugin\`).

## Test plan

- [ ] RTD build on this PR completes successfully
- [ ] Built site shows "Last updated" timestamps on doc pages (the plugin's intended effect)

🤖 Generated with [Claude Code](https://claude.com/claude-code)