### PR TITLE
docs: refresh ImageAnalysis CLAUDE.md + overview after #412

### DIFF
--- a/ImageAnalysis/CLAUDE.md
+++ b/ImageAnalysis/CLAUDE.md
@@ -112,13 +112,18 @@ from image_analysis.config import load_camera_config
 cfg = load_camera_config("UC_GaiaMode")  # finds UC_GaiaMode.yaml in configs repo
 ```
 
-`CameraConfig` fields (all processing sections are `Optional` — omit to skip):
+`CameraConfig` fields (all processing sections are `Optional` — omit to skip).
+Post-#412 the schema runs `extra="forbid"`: unknown keys are rejected at
+load time rather than silently allowed. `name` is gone — analyzer
+identity lives on the diagnostic (`output_name`); `camera_type` was
+deprecated and removed:
 
 ```python
 class CameraConfig(BaseModel):
-    name: str
+    type: Literal["camera"] = "camera"          # discriminator for the unified-diagnostic union
     description: Optional[str]
-    bit_depth: int = 16          # 8, 10, 12, 14, 16, 32
+    metadata: Optional[Dict[str, Any]]          # documentary only — location, notes, spatial_calibration, etc.
+    bit_depth: int = 16                         # 8, 10, 12, 14, 16, 32
 
     roi: Optional[ROIConfig]                    # x_min, x_max, y_min, y_max (pixels)
     background: Optional[BackgroundConfig]      # method, file_path, constant_level, additional_constant
@@ -148,9 +153,11 @@ from image_analysis.config import load_line_config
 cfg = load_line_config("U_BCaveICT")
 ```
 
+Same `extra="forbid"` policy and missing-`name` rationale as `CameraConfig`:
+
 ```python
 class Line1DConfig(BaseModel):
-    name: str
+    type: Literal["line"] = "line"  # discriminator for the unified-diagnostic union
     description: str
     data_loading: Data1DConfig      # data_type (tek_scope_hdf5, tdms_scope, csv, tsv, npy),
                                     # trace_index, x_column, y_column, delimiter
@@ -196,16 +203,25 @@ analyzer = create_image_analyzer(diag)         # → ImageAnalyzer instance
 ```python
 analyzer = StandardAnalyzer(
     camera_config=cfg,       # typed CameraConfig (load via load_camera_config)
-    name_suffix=None,        # Appended to camera name
-    metric_suffix=None,      # Appended to all scalar metric keys
+    output_name=None,        # output identifier; defaults to None in Mode-1
+                             # (scalar keys are bare). Mode-2 factory passes
+                             # diag.effective_output_name automatically.
 )
 ```
+
+Post-#412 the analyzer emits **bare scalar keys** (`"x_CoM"`, `"image_total"`,
+…) regardless of `output_name`. ScanAnalysis is the sole layer that
+applies the `output_name` prefix and `metric_suffix` to scalars when it
+stores per-shot results. `output_name` is stored on the analyzer purely
+so downstream consumers (output-dir labelling in `SingleDeviceScanAnalyzer`;
+per-file paths in MagSpec) can read a stable identifier off the instance.
 
 Key methods:
 - `preprocess_image(image) -> np.ndarray` — applies full processing pipeline
 - `analyze_image(image, auxiliary_data) -> ImageAnalyzerResult` — data_type="2d"
 - `analyze_image_file(path, auxiliary_data)` — canonical scan-pipeline entry
 - `render_image(result, vmin, vmax, cmap, ...) -> (Figure, Axes)` — static method
+- `output_name` property — returns the configured output identifier (or `None`)
 
 ### `Standard1DAnalyzer` (1D foundation)
 
@@ -227,8 +243,11 @@ Adds beam-specific metrics (centroid, size, moments). Uses `analysis:` section o
 
 ### `LineAnalyzer(Standard1DAnalyzer)`
 
-Adds statistics: CoM, FWHM, RMS, peak analysis. Supports `metric_suffix` for
-distinguishing variants (e.g., "before_foil" vs "after_foil").
+Adds statistics: CoM, FWHM, RMS, peak analysis. Forwards `output_name` to
+the Standard1D parent like every other analyzer in the family. For
+"variant" use cases (e.g. before_foil vs after_foil) the diagnostic config
+declares `metric_suffix` at the diagnostic layer; ScanAnalysis applies it
+to all scalar keys.
 
 ### `ICT1DAnalyzer(Standard1DAnalyzer)`
 
@@ -281,8 +300,12 @@ Same pattern but inherit from `Standard1DAnalyzer`, take a typed
   defined in the analyzer class. Validated at `__init__` time, not at config-load time.
 - **Scale factors applied first** — `x_scale_factor` / `y_scale_factor` run before
   ROI, so ROI boundaries and thresholds should be specified in scaled units.
-- **`metric_suffix`** — Use when the same physical device has multiple analysis
-  variants in one scan (e.g., two ROI regions). Keeps scalar keys unique.
+- **Output naming lives at the diagnostic layer (#412)** — analyzers emit
+  **bare** scalar keys; `DiagnosticAnalysisConfig.output_name` and
+  `metric_suffix` (read by ScanAnalysis) namespace them on the way to disk
+  and in-memory consumers. See `ScanAnalysis/CLAUDE.md` for the full
+  contract and the override use cases (output_name=UC_TopView_left vs
+  output_name=UC_TopView_right for two variants of the same camera).
 - **Nx2 convention for 1D data** — Column 0 is always x (independent), column 1
   is always y (dependent). `read_1d_data()` enforces this.
 

--- a/docs/image_analysis/overview.md
+++ b/docs/image_analysis/overview.md
@@ -135,10 +135,14 @@ analyzer = create_image_analyzer(diag)
 result = analyzer.analyze_image(my_image_array)
 
 # 2. From a programmatically-built CameraConfig
-from image_analysis.config import CameraConfig, BackgroundConfig
+from image_analysis.config import CameraConfig
 from image_analysis.analyzers.beam_analyzer import BeamAnalyzer
 
-config = CameraConfig(name="my_cam", bit_depth=16)
+# CameraConfig has no ``name`` field after #412 — analyzer identity flows
+# through the diagnostic config's ``output_name`` (or the analyzer's
+# ``output_name=`` kwarg for direct construction). Standalone notebook
+# use leaves it unset; scalar keys come out bare.
+config = CameraConfig(bit_depth=16)
 analyzer = BeamAnalyzer(config)
 result = analyzer.analyze_image(my_image_array)
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -1645,18 +1645,21 @@ test = ["objgraph", "psutil", "setuptools"]
 
 [[package]]
 name = "griffe"
-version = "1.7.3"
+version = "1.15.0"
 description = "Signatures for entire Python programs. Extract the structure, the frame, the skeleton of your project, to generate API documentation or find breaking changes in your API."
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 groups = ["main"]
 files = [
-    {file = "griffe-1.7.3-py3-none-any.whl", hash = "sha256:c6b3ee30c2f0f17f30bcdef5068d6ab7a2a4f1b8bf1a3e74b56fffd21e1c5f75"},
-    {file = "griffe-1.7.3.tar.gz", hash = "sha256:52ee893c6a3a968b639ace8015bec9d36594961e156e23315c8e8e51401fa50b"},
+    {file = "griffe-1.15.0-py3-none-any.whl", hash = "sha256:6f6762661949411031f5fcda9593f586e6ce8340f0ba88921a0f2ef7a81eb9a3"},
+    {file = "griffe-1.15.0.tar.gz", hash = "sha256:7726e3afd6f298fbc3696e67958803e7ac843c1cfe59734b6251a40cdbfb5eea"},
 ]
 
 [package.dependencies]
 colorama = ">=0.4"
+
+[package.extras]
+pypi = ["pip (>=24.0)", "platformdirs (>=4.2)", "wheel (>=0.42)"]
 
 [[package]]
 name = "h11"
@@ -7131,4 +7134,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<3.12"
-content-hash = "1ee5b9c1ee3b3d3f68557ad83a4910fd04a1f6e87d92141512a5880325541644"
+content-hash = "0e1cd397347ff6736925c758a2a61b5ae17701088ec367e04381c17feb2dabb2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,13 @@ mkdocs-autorefs = "^1.4"
 mkdocs-git-revision-date-localized-plugin = "^1.2"  # "Last updated" footer per page
 nbconvert = "^7.0"  # Needed for Jupyter notebook output stripping
 tomli = "^2.2.1"
+# Pin griffe <2.0 until mkdocstrings + mkdocstrings-python both reach the
+# 2.x line that supports griffe 2.x. The currently-pinned mkdocstrings
+# (^0.28.2) pulls in mkdocstrings-python 1.16.x, which does
+# ``from griffe import Alias`` — gone in griffe 2.0, so the build dies
+# with ``ImportError: cannot import name 'Alias' from 'griffe'``.
+# Drop this pin when bumping mkdocstrings to ^0.29 / ^1.0 as a follow-up.
+griffe = "<2.0"
 
 [tool.poetry.group.dev.dependencies]
 geecs-scanner-gui = { path = "GEECS-Scanner-GUI", develop = true }


### PR DESCRIPTION
Follow-up to #420 — fixes two reference docs that taught the pre-#412 API, and along the way restores the docs site build.

## What changed

**`ImageAnalysis/CLAUDE.md`** — four places that had drifted:

* `CameraConfig` / `Line1DConfig` schemas — drop `name: str` (gone), add `type:` discriminator, add typed `metadata` field, call out the new `extra=\"forbid\"` policy
* `StandardAnalyzer` constructor example — drop `name_suffix=` / `metric_suffix=` kwargs (removed), add `output_name=`, explain the \"bare keys / ScanAnalysis prefixes once\" contract
* `LineAnalyzer` description — strip the \"Supports `metric_suffix` for variants\" claim; that field is now on the diagnostic, not the analyzer
* Key Design Decisions — replace the `metric_suffix` bullet with one that points readers at the diagnostic-layer output naming and `ScanAnalysis/CLAUDE.md`

**`docs/image_analysis/overview.md:141`** — strip `name=\"my_cam\"` from the programmatic `CameraConfig(...)` example. Pre-#420 that worked via `extra=\"allow\"`; post-#420 with `extra=\"forbid\"` it raises a ValidationError. Now reads `CameraConfig(bit_depth=16)` with a paragraph explaining the new identity model.

**`pyproject.toml`** — pin `griffe <2.0` to unbreak `mkdocs build`. See the build-fix commit below.

## The build fix that ended up in this PR

When I first opened this PR I claimed the build was broken by a pre-existing dep issue and waved it as \"not blocking.\" Reviewer pushed back — was the build actually working anywhere? Investigated and found it wasn't:

* `griffe` had been auto-resolved to 2.0.2 (public module namespace reorganised into submodules).
* `mkdocstrings = \"^0.28.2\"` still pulls `mkdocstrings-python 1.16.x`, which does `from griffe import Alias` — gone in griffe 2.0.
* Result: `mkdocs build` exits 1 with `ImportError: cannot import name 'Alias' from 'griffe'` and produces no `site/` directory.

So the published docs weren't getting updates from CI either. Stopgap fix: pin `griffe <2.0` in `pyproject.toml`. Lockfile now resolves to griffe 1.15.0 and the build works end-to-end.

This is intentionally narrow — the proper fix is bumping `mkdocstrings` to a version that supports griffe 2.x (`^0.29` / `^1.0`), which is a larger dependency upgrade and worth a separate PR.

## Out of scope

Two notebooks (`pulse_duration_jitter_analysis.ipynb`, `xopt_run_inspection.ipynb`) still reference the old API in code cells. Updating them requires re-executing to refresh output cells, so they belong in a separate follow-up.

## Tests

- [x] All remaining `metric_suffix` references in the touched files are intentional (documenting the new contract). Verified by grep.
- [x] `mkdocs build` exit 0 + populated `site/` directory.
- [x] New `CameraConfig(bit_depth=16)` example renders correctly in `site/image_analysis/overview/index.html`.
- [x] Only pre-existing warnings (griffe parameter-signature mismatches, mkdocs-jupyter alt-text warnings) — no new errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)