### PR TITLE
Warn on missing TCP subscription variables

### DIFF
--- a/GeecsBluesky/CHANGELOG.md
+++ b/GeecsBluesky/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to `geecs-bluesky` are documented here.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.8.2] - 2026-06-16
+
+### Fixed
+
+- TCP subscriptions now warn and continue when a subscribed variable is absent
+  from a push frame instead of letting the listener fail.
+
 ## [0.8.1] - 2026-06-16
 
 ### Removed

--- a/GeecsBluesky/geecs_bluesky/testing/fake_device_server.py
+++ b/GeecsBluesky/geecs_bluesky/testing/fake_device_server.py
@@ -75,7 +75,9 @@ class FakeGeecsDevice:
         """Format the 5-Hz push message for the requested variables."""
         parts = []
         for v in var_names:
-            val = self.variables.get(v, 0.0)
+            if v not in self.variables:
+                continue
+            val = self.variables[v]
             parts.append(f"{v} nval,{val} nvar")
         return f"{self.name}>>{shot}>>" + ",".join(parts)
 

--- a/GeecsBluesky/geecs_bluesky/transport/tcp_subscriber.py
+++ b/GeecsBluesky/geecs_bluesky/transport/tcp_subscriber.py
@@ -61,6 +61,7 @@ class GeecsTcpSubscriber:
         self._reader: asyncio.StreamReader | None = None
         self._writer: asyncio.StreamWriter | None = None
         self._listen_task: asyncio.Task | None = None
+        self._warned_missing_variables: set[str] = set()
 
     async def connect(self) -> None:
         """Open the TCP connection."""
@@ -122,15 +123,17 @@ class GeecsTcpSubscriber:
         self._writer.write(struct.pack(">i", len(cmd)) + cmd)
         await self._writer.drain()
         logger.debug("TCP subscribed: %s", variables)
+        self._warned_missing_variables.clear()
 
         self._listen_task = asyncio.create_task(
-            self._listen_loop(callback),
+            self._listen_loop(callback, variables),
             name=f"tcp-sub[{self._host}:{self._port}]",
         )
 
-    async def _listen_loop(self, callback: Callback) -> None:
+    async def _listen_loop(self, callback: Callback, variables: list[str]) -> None:
         """Read framed messages in a loop and dispatch to callback."""
         assert self._reader is not None
+        subscribed = tuple(variables)
         try:
             while True:
                 # Read 4-byte header
@@ -143,10 +146,20 @@ class GeecsTcpSubscriber:
                 logger.debug("TCP rx: %r", msg)
 
                 parsed = _parse_subscription(msg)
+                self._warn_missing_variables(subscribed, parsed)
                 if parsed:
-                    result = callback(parsed)
-                    if asyncio.iscoroutine(result):
-                        await result
+                    try:
+                        result = callback(parsed)
+                        if asyncio.iscoroutine(result):
+                            await result
+                    except Exception:
+                        logger.warning(
+                            "TCP subscription callback failed for %s:%s; "
+                            "continuing listener",
+                            self._host,
+                            self._port,
+                            exc_info=True,
+                        )
 
         except asyncio.IncompleteReadError:
             logger.debug("TCP connection closed by server")
@@ -154,6 +167,25 @@ class GeecsTcpSubscriber:
             pass
         except Exception:
             logger.exception("unexpected error in TCP listener")
+
+    def _warn_missing_variables(
+        self, variables: tuple[str, ...], frame: dict[str, Any]
+    ) -> None:
+        """Warn once for subscribed variables absent from a TCP push frame."""
+        missing = [
+            var
+            for var in variables
+            if var not in frame and var not in self._warned_missing_variables
+        ]
+        if not missing:
+            return
+        self._warned_missing_variables.update(missing)
+        logger.warning(
+            "TCP subscription from %s:%s missing variable(s) in push frame: %s",
+            self._host,
+            self._port,
+            ", ".join(missing),
+        )
 
 
 def _parse_subscription(msg: str) -> dict[str, Any]:

--- a/GeecsBluesky/pyproject.toml
+++ b/GeecsBluesky/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-bluesky"
-version = "0.8.1"
+version = "0.8.2"
 description = "Bluesky / ophyd-async bridge for the GEECS control system"
 authors = ["Sam Barber <sbarber@lbl.gov>"]
 readme = "README.md"

--- a/GeecsBluesky/tests/test_transport.py
+++ b/GeecsBluesky/tests/test_transport.py
@@ -4,6 +4,8 @@ All tests run against ``FakeGeecsServer`` on localhost — no real hardware requ
 """
 
 import asyncio
+import logging
+
 import pytest
 
 from geecs_bluesky.exceptions import GeecsCommandFailedError
@@ -152,3 +154,52 @@ class TestTcpSubscriber:
         assert len(received) >= 1
         assert "Position (mm)" in received[0]
         assert "Velocity (mm/s)" in received[0]
+
+    async def test_missing_variable_warns_and_continues(
+        self, fake_device: FakeGeecsDevice, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Missing subscribed variables should warn without stopping updates."""
+        received: list[dict] = []
+
+        def on_update(update: dict) -> None:
+            received.append(update)
+
+        caplog.set_level(logging.WARNING, logger="geecs_bluesky.transport")
+        async with FakeGeecsServer(fake_device) as srv:
+            async with GeecsTcpSubscriber(srv.host, srv.port) as sub:
+                await sub.subscribe(["Position (mm)", "Not In Frame"], on_update)
+                await asyncio.sleep(0.5)
+
+        assert len(received) >= 2
+        assert all("Position (mm)" in update for update in received)
+        assert all("Not In Frame" not in update for update in received)
+        missing_warnings = [
+            record
+            for record in caplog.records
+            if "missing variable(s) in push frame" in record.message
+        ]
+        assert len(missing_warnings) == 1
+        assert "Not In Frame" in missing_warnings[0].message
+
+    async def test_callback_keyerror_does_not_stop_listener(
+        self, fake_device: FakeGeecsDevice, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A callback assuming a missing key should not kill the TCP listener."""
+        calls = 0
+
+        def on_update(update: dict) -> None:
+            nonlocal calls
+            calls += 1
+            update["Not In Frame"]
+
+        caplog.set_level(logging.WARNING, logger="geecs_bluesky.transport")
+        async with FakeGeecsServer(fake_device) as srv:
+            async with GeecsTcpSubscriber(srv.host, srv.port) as sub:
+                await sub.subscribe(["Position (mm)", "Not In Frame"], on_update)
+                await asyncio.sleep(0.5)
+
+        assert calls >= 2
+        assert any(
+            "TCP subscription callback failed" in record.message
+            for record in caplog.records
+        )


### PR DESCRIPTION
## Summary
- warn once when a subscribed variable is absent from a TCP push frame
- keep the TCP listener alive if subscription callbacks raise on missing data
- update the fake GEECS server to omit unknown TCP variables instead of fabricating zeros
- add regression coverage and bump geecs-bluesky to 0.8.2

## Verification
- poetry run pytest tests/test_transport.py (11 passed)
- ruff check GeecsBluesky/geecs_bluesky/transport/tcp_subscriber.py GeecsBluesky/geecs_bluesky/testing/fake_device_server.py GeecsBluesky/tests/test_transport.py
- py_compile on touched Python files
- hardware smoke against UC_TopView: subscribed to acq_timestamp plus bogus variable; warning emitted, acq_timestamp frames continued, missing variable absent (frames=2, good_frames=2, missing_frames=0)