### PR TITLE
fix(image-analysis): LineStitcher now actually stitches sibling devices

### DIFF
--- a/ImageAnalysis/image_analysis/analyzers/line_stitcher.py
+++ b/ImageAnalysis/image_analysis/analyzers/line_stitcher.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Union
 
 import numpy as np
 
@@ -136,6 +136,34 @@ class LineStitcher(LineAnalyzer):
         )
 
         return combined
+
+    def analyze_image_file(
+        self,
+        image_filepath: Union[Path, list[Path]],
+        auxiliary_data: Optional[Dict] = None,
+    ) -> ImageAnalyzerResult:
+        """Atomically load (multi-device) + analyze.
+
+        Overrides :meth:`Standard1DAnalyzer.analyze_image_file`. The
+        Standard1D version calls ``read_1d_data`` on a single file and
+        bypasses ``load_image`` entirely — fine for vanilla 1D
+        analyzers but it leaves :meth:`load_image` (which does the
+        multi-device concatenation) unused for a LineStitcher. This
+        override goes through ``self.load_image`` so sibling-device
+        files actually get stitched in before downstream analysis.
+
+        ``LineStitcher.load_image`` populates ``self.data_metadata``
+        from the master device's result, so the inherited
+        ``_build_input_parameters`` keeps producing the right units /
+        labels.
+        """
+        image_filepath = Path(image_filepath)
+        combined = self.load_image(image_filepath)
+
+        aux = dict(auxiliary_data or {})
+        aux.setdefault("file_path", image_filepath)
+
+        return self.analyze_image(combined, aux)
 
     def analyze_image(
         self, image: Array1D, auxiliary_data: Optional[Dict] = None

--- a/ImageAnalysis/tests/analyzers/test_line_stitcher.py
+++ b/ImageAnalysis/tests/analyzers/test_line_stitcher.py
@@ -16,6 +16,10 @@ import numpy as np
 import pytest
 
 from image_analysis.analyzers.line_stitcher import LineStitcher
+from image_analysis.config.array1d_processing import (
+    Data1DConfig,
+    Line1DConfig,
+)
 from image_analysis.types import ImageAnalyzerResult
 
 
@@ -43,3 +47,69 @@ class TestLineStitcherScanFolderInvariant:
         # Critical: no side-effect creation of the scan folder or its children.
         assert not stale.parent.parent.exists()
         assert not (stale.parent.parent / "stitched").exists()
+
+
+class TestLineStitcherMultiDeviceLoading:
+    """End-to-end test that ``analyze_image_file`` actually stitches siblings.
+
+    Regression coverage for the FROG-era refactor of
+    ``Standard1DAnalyzer.analyze_image_file``, which fused load+analyze by
+    calling ``read_1d_data`` directly and bypassed any subclass's
+    overridden ``load_image``. That silently broke LineStitcher: the
+    diagnostic loaded, the analyzer ran, the output looked plausible —
+    but ``sibling_devices`` data never made it in. This test sets up a
+    minimal three-device scan dir and asserts the stitched output spans
+    all three x-ranges.
+    """
+
+    def _write_tsv(self, path: Path, xs, ys) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        data = np.column_stack([xs, ys])
+        np.savetxt(path, data, delimiter="\t")
+
+    def _make_line_config(self) -> Line1DConfig:
+        return Line1DConfig(
+            data_loading=Data1DConfig(
+                data_type="tsv",
+                delimiter="\t",
+                x_column=0,
+                y_column=1,
+            ),
+        )
+
+    def test_analyze_image_file_pulls_sibling_data(self, tmp_path):
+        """The stitched output must contain data from every sibling device."""
+        # Three devices, each covering a distinct x-range. After
+        # stitching the result should span the union of all three.
+        scan_dir = tmp_path / "scans" / "Scan001"
+        master = scan_dir / "DevA" / "Scan001_DevA_001.tsv"
+        sib1 = scan_dir / "DevB" / "Scan001_DevB_001.tsv"
+        sib2 = scan_dir / "DevC" / "Scan001_DevC_001.tsv"
+
+        # Disjoint x-ranges with constant y per device so it's obvious
+        # whether the segment made it in.
+        self._write_tsv(master, np.arange(0.0, 5.0, 1.0), np.full(5, 10.0))
+        self._write_tsv(sib1, np.arange(5.0, 10.0, 1.0), np.full(5, 20.0))
+        self._write_tsv(sib2, np.arange(10.0, 15.0, 1.0), np.full(5, 30.0))
+
+        stitcher = LineStitcher(
+            line_config=self._make_line_config(),
+            sibling_devices=["DevB", "DevC"],
+            name="stitched",
+        )
+
+        result = stitcher.analyze_image_file(master)
+
+        assert result.line_data is not None
+        x = result.line_data[:, 0]
+        y = result.line_data[:, 1]
+
+        # All three segments present:
+        assert np.any(y == 10.0), "master segment dropped"
+        assert np.any(y == 20.0), "DevB sibling dropped — analyze_image_file bypass?"
+        assert np.any(y == 30.0), "DevC sibling dropped"
+
+        # And concatenation produced a sorted x-axis spanning the union.
+        assert x.min() == pytest.approx(0.0)
+        assert x.max() == pytest.approx(14.0)
+        assert (np.diff(x) >= 0).all(), "stitched output not sorted by x"


### PR DESCRIPTION
## The bug

User hit this in production while running the MagSpec stitcher:

```python
diag = load_diagnostic(\"PW-MagSpectStitcher\")
scan_analyzer = create_scan_analyzer(diag)
result = scan_analyzer.run_analysis(scan_tag=test_tag)
```

Diagnostic loaded. Analyzer ran. Output looked plausible. But sibling device data never made it into the stitched output — it was just the master file.

## Root cause

The FROG-era refactor of `Standard1DAnalyzer.analyze_image_file` fused load+analyze by reading the input file directly via `read_1d_data` instead of delegating to `self.load_image()`. That's correct for the standard 1D path — it prevents per-shot state from leaking between analyzer calls.

But `LineStitcher` overrides `load_image()` to do the multi-device concatenation:

```python
# LineStitcher.load_image (line 60+)
master_result = read_1d_data(file_path, data_config)
segments = [master_result.data]
for device in self.sibling_devices:
    sibling_path = base_dir / device / sibling_filename
    segments.append(read_1d_data(sibling_path, data_config).data)
combined = np.concatenate(segments, axis=0)
combined = combined[combined[:, 0].argsort()]
```

After the FROG refactor, that override was **dead code** — `Standard1DAnalyzer.analyze_image_file` never called it.

## Fix

`LineStitcher` gets its own `analyze_image_file` that re-fuses the operation through its `load_image`:

```python
def analyze_image_file(self, image_filepath, auxiliary_data=None):
    image_filepath = Path(image_filepath)
    combined = self.load_image(image_filepath)  # ← now we go through the override
    aux = dict(auxiliary_data or {})
    aux.setdefault(\"file_path\", image_filepath)
    return self.analyze_image(combined, aux)
```

Matches the contract in `ImageAnalysis/CLAUDE.md`:

> Implement `analyze_image_file(path, aux)` if your analyzer needs to coordinate load and analyze (rare).

## Test coverage

The bug was invisible to the existing test suite — the only LineStitcher test pinned the scan-folder-creation invariant on the save path, not the load path. Added:

* `TestLineStitcherMultiDeviceLoading::test_analyze_image_file_pulls_sibling_data` — sets up a synthetic three-device scan dir with disjoint x-ranges and constant y per device, calls `stitcher.analyze_image_file(master)`, and asserts the output contains y-values from both siblings plus the master. The pre-fix code emits only the master's y-values, so this test fails against unpatched line_stitcher.py.

Also asserts the stitched x-axis spans the union range and is sorted — pinning the existing `load_image` contract.

## Tests

- [x] 218 existing IA tests still pass
- [x] 1 new test passes; verified it would fail without the fix (master-only output doesn't contain DevB/DevC y-values)
- [x] pre-commit clean (ruff, ruff-format, pydocstyle)

🤖 Generated with [Claude Code](https://claude.com/claude-code)