### PR TITLE
Emit external asset docs for native saves

### DIFF
--- a/GeecsBluesky/CHANGELOG.md
+++ b/GeecsBluesky/CHANGELOG.md
@@ -24,6 +24,13 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Tiled persistence failures no longer abort scans. GEECS native-file asset
   datum IDs are stored as ordinary Tiled event metadata until the Tiled server
   has readers for the custom GEECS asset specs.
+- Native-save device commands now translate scanner-local save folders to
+  `geecs_device_server_data_base_path` from the user config before writing
+  `localsavingpath`, so tests run from macOS/Linux can still command
+  Windows-visible device paths such as `Z:\data`.
+- External asset paths now use the direct native device filename
+  (`Device_<acq_timestamp>.<ext>`) rather than the legacy post-move renamed
+  filename.
 
 ## [0.11.0] - 2026-06-23
 

--- a/GeecsBluesky/CHANGELOG.md
+++ b/GeecsBluesky/CHANGELOG.md
@@ -15,7 +15,9 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - `NonScalarSaveSupport.collect_asset_docs()` queues one Resource/Datum pair per
   native file and records `.tdms_index` companion paths for TDMS assets.
 - The standalone `test_bluesky_scanner.py` hardware script now preflights the
-  required lab devices and reports unreachable hardware before running scenarios.
+  required lab devices and reports unreachable hardware before running
+  scenarios. Its camera device can be overridden with
+  `GEECS_BLUESKY_TEST_CAMERA`.
 
 ### Fixed
 

--- a/GeecsBluesky/CHANGELOG.md
+++ b/GeecsBluesky/CHANGELOG.md
@@ -14,6 +14,14 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   registered assets add datum-id event fields plus matching Resource/Datum docs.
 - `NonScalarSaveSupport.collect_asset_docs()` queues one Resource/Datum pair per
   native file and records `.tdms_index` companion paths for TDMS assets.
+- The standalone `test_bluesky_scanner.py` hardware script now preflights the
+  required lab devices and reports unreachable hardware before running scenarios.
+
+### Fixed
+
+- Tiled persistence failures no longer abort scans. GEECS native-file asset
+  datum IDs are stored as ordinary Tiled event metadata until the Tiled server
+  has readers for the custom GEECS asset specs.
 
 ## [0.11.0] - 2026-06-23
 

--- a/GeecsBluesky/CHANGELOG.md
+++ b/GeecsBluesky/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to `geecs-bluesky` are documented here.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.12.0] - 2026-06-23
+
+### Added
+
+- Native-file-saving sync devices now emit Bluesky external asset references
+  when their database device type is registered in `geecs_bluesky.assets`.
+  Acquisition still records the existing `nonscalar_save_path` string column;
+  registered assets add datum-id event fields plus matching Resource/Datum docs.
+- `NonScalarSaveSupport.collect_asset_docs()` queues one Resource/Datum pair per
+  native file and records `.tdms_index` companion paths for TDMS assets.
+
 ## [0.11.0] - 2026-06-23
 
 ### Added

--- a/GeecsBluesky/geecs_bluesky/assets/registry.py
+++ b/GeecsBluesky/geecs_bluesky/assets/registry.py
@@ -31,8 +31,9 @@ def camera_image_filename(
 ) -> str:
     """Return the native GEECS camera image filename.
 
-    GEECS camera files are named by scan number, device name, and the device
-    acquisition timestamp rounded to milliseconds.
+    GEECS device servers write native files by device name and acquisition
+    timestamp. Legacy scan finalization may rename files later, but external
+    assets should point at the native direct-save filename.
     """
     return native_file_filename(
         scan_number=scan_number,
@@ -50,9 +51,7 @@ def native_file_filename(
 ) -> str:
     """Return the native GEECS filename for one timestamped device file."""
     normalized_extension = extension if extension.startswith(".") else f".{extension}"
-    return (
-        f"Scan{scan_number:03d}_{device_name}_{acq_timestamp:.3f}{normalized_extension}"
-    )
+    return f"{device_name}_{acq_timestamp:.3f}{normalized_extension}"
 
 
 def _camera_image_path(

--- a/GeecsBluesky/geecs_bluesky/devices/generic_detector.py
+++ b/GeecsBluesky/geecs_bluesky/devices/generic_detector.py
@@ -132,6 +132,7 @@ class GeecsGenericDetector(
         if has_shot_ids:
             desc.update(self._shot_id_datakeys())
         desc.update(self._save_path_datakey())
+        desc.update(self._asset_datakeys())
         return desc
 
     async def read(self) -> dict[str, Reading]:
@@ -174,4 +175,5 @@ class GeecsGenericDetector(
             )
 
         self._emit_save_path_reading(reading, event_timestamp)
+        self._emit_asset_readings(reading, event_timestamp, acq_timestamp)
         return reading

--- a/GeecsBluesky/geecs_bluesky/devices/nonscalar_save.py
+++ b/GeecsBluesky/geecs_bluesky/devices/nonscalar_save.py
@@ -18,13 +18,23 @@ client) and call :meth:`_init_save_signals` from its ``__init__``.
 
 from __future__ import annotations
 
+import logging
+import math
+import uuid
+from collections import deque
+from collections.abc import Iterator
 from pathlib import Path
 
+from bluesky.protocols import Asset
 from bluesky.protocols import Reading
 from event_model import DataKey
+from event_model.documents import Datum, PartialResource
 
+from geecs_bluesky.assets import AssetDefinition
 from geecs_bluesky.signals import geecs_signal_rw
 from geecs_bluesky.transport.udp_client import GeecsUdpClient
+
+logger = logging.getLogger(__name__)
 
 
 class NonScalarSaveSupport:
@@ -36,6 +46,10 @@ class NonScalarSaveSupport:
 
     _save_nonscalar_data: bool = False
     _nonscalar_save_path: Path | None = None
+    _asset_definitions: tuple[AssetDefinition, ...] = ()
+    _asset_scan_number: int | None = None
+    _asset_root_path: Path | None = None
+    _pending_asset_docs: deque[Asset]
 
     def _init_save_signals(
         self,
@@ -64,6 +78,24 @@ class NonScalarSaveSupport:
         """Record the scanner-owned save directory for the ``nonscalar_save_path`` column."""
         self._nonscalar_save_path = Path(save_path)
 
+    def configure_external_asset_logging(
+        self,
+        *,
+        scan_number: int,
+        asset_definitions: tuple[AssetDefinition, ...],
+        root_path: str | Path | None = None,
+    ) -> None:
+        """Configure Bluesky external asset docs for native file-saving devices."""
+        self._asset_definitions = tuple(asset_definitions)
+        self._asset_scan_number = scan_number
+        if root_path is not None:
+            self._asset_root_path = Path(root_path)
+        elif self._nonscalar_save_path is not None:
+            self._asset_root_path = self._nonscalar_save_path.parent
+        else:
+            self._asset_root_path = None
+        self._pending_asset_docs = deque()
+
     def _save_path_datakey(self) -> dict[str, DataKey]:
         """Describe the ``nonscalar_save_path`` column (when saving)."""
         if not self._save_nonscalar_data:
@@ -75,6 +107,21 @@ class NonScalarSaveSupport:
                 "dtype": "string",
                 "shape": [],
             }
+        }
+
+    def _asset_datakeys(self) -> dict[str, DataKey]:
+        """Describe external asset datum-id columns for registered native files."""
+        if not self._save_nonscalar_data or not self._asset_definitions:
+            return {}
+        device_name = getattr(self, "_geecs_device_name", self.name)
+        return {
+            definition.event_key(device_name): {
+                "source": f"geecs://{device_name}/{definition.event_field}",
+                "dtype": "array",
+                "shape": [],
+                "external": "OLD:",
+            }
+            for definition in self._asset_definitions
         }
 
     def _emit_save_path_reading(
@@ -92,3 +139,99 @@ class NonScalarSaveSupport:
             timestamp=event_timestamp,
             alarm_severity=0,
         )
+
+    def _emit_asset_readings(
+        self,
+        reading: dict[str, Reading],
+        event_timestamp: float,
+        acq_timestamp: float | None,
+    ) -> None:
+        """Add datum-id readings and queue matching Resource/Datum documents."""
+        if not self._save_nonscalar_data or not self._asset_definitions:
+            return
+
+        if not hasattr(self, "_pending_asset_docs"):
+            self._pending_asset_docs = deque()
+
+        device_name = getattr(self, "_geecs_device_name", self.name)
+        for definition in self._asset_definitions:
+            data_key = definition.event_key(device_name)
+            datum_id = ""
+            try:
+                datum_id = self._queue_asset_docs(definition, acq_timestamp)
+            except Exception:
+                logger.warning(
+                    "Could not build external asset docs for %s %s",
+                    device_name,
+                    definition.event_field,
+                    exc_info=True,
+                )
+            reading[data_key] = Reading(
+                value=datum_id,
+                timestamp=event_timestamp,
+                alarm_severity=0,
+            )
+
+    def _queue_asset_docs(
+        self,
+        definition: AssetDefinition,
+        acq_timestamp: float | None,
+    ) -> str:
+        if (
+            self._nonscalar_save_path is None
+            or self._asset_root_path is None
+            or self._asset_scan_number is None
+            or acq_timestamp is None
+            or not math.isfinite(float(acq_timestamp))
+        ):
+            return ""
+
+        device_name = getattr(self, "_geecs_device_name", self.name)
+        file_path = definition.file_path(
+            save_path=self._nonscalar_save_path,
+            scan_number=self._asset_scan_number,
+            device_name=device_name,
+            acq_timestamp=float(acq_timestamp),
+        )
+        resource_uid = str(uuid.uuid4())
+        datum_id = f"{resource_uid}/0"
+        resource_kwargs: dict[str, object] = {
+            "data_key": definition.event_key(device_name),
+        }
+        companion_paths = definition.companion_file_paths(
+            save_path=self._nonscalar_save_path,
+            scan_number=self._asset_scan_number,
+            device_name=device_name,
+            acq_timestamp=float(acq_timestamp),
+        )
+        if companion_paths:
+            resource_kwargs["companion_resource_paths"] = [
+                definition.resource_path(root=self._asset_root_path, file_path=path)
+                for path in companion_paths
+            ]
+
+        resource = PartialResource(
+            resource_kwargs=resource_kwargs,
+            root=str(self._asset_root_path),
+            spec=definition.spec,
+            resource_path=definition.resource_path(
+                root=self._asset_root_path,
+                file_path=file_path,
+            ),
+            uid=resource_uid,
+        )
+        datum = Datum(
+            datum_id=datum_id,
+            resource=resource_uid,
+            datum_kwargs={},
+        )
+        self._pending_asset_docs.append(("resource", resource))
+        self._pending_asset_docs.append(("datum", datum))
+        return datum_id
+
+    def collect_asset_docs(self) -> Iterator[Asset]:
+        """Yield queued external asset documents for the most recent read."""
+        if not hasattr(self, "_pending_asset_docs"):
+            self._pending_asset_docs = deque()
+        while self._pending_asset_docs:
+            yield self._pending_asset_docs.popleft()

--- a/GeecsBluesky/geecs_bluesky/devices/timestamped_readable.py
+++ b/GeecsBluesky/geecs_bluesky/devices/timestamped_readable.py
@@ -141,6 +141,7 @@ class GeecsTimestampedReadable(
         """Describe hardware signals plus the sync-device companion columns."""
         desc = await super().describe()
         desc.update(self._save_path_datakey())
+        desc.update(self._asset_datakeys())
         if self._shot_id_tracker is None:
             return desc
         prefix = self.name
@@ -170,11 +171,12 @@ class GeecsTimestampedReadable(
             time.monotonic(),
         )
         self._emit_save_path_reading(reading, event_timestamp)
+        acq_timestamp = self.last_acq_timestamp
+        self._emit_asset_readings(reading, event_timestamp, acq_timestamp)
         if tracker is None:
             return reading
 
         prefix = self.name
-        acq_timestamp = self.last_acq_timestamp
         reading[f"{prefix}-acq_timestamp"] = Reading(
             value=acq_timestamp if acq_timestamp is not None else float("nan"),
             timestamp=event_timestamp,

--- a/GeecsBluesky/geecs_bluesky/plans/run_wrapper.py
+++ b/GeecsBluesky/geecs_bluesky/plans/run_wrapper.py
@@ -16,12 +16,28 @@ from __future__ import annotations
 
 import logging
 import os
+from collections.abc import Sequence
 from typing import Any
 
 import bluesky.plan_stubs as bps
 import bluesky.preprocessors as bpp
 
 logger = logging.getLogger(__name__)
+
+
+def _saving_detector_paths(item: Sequence) -> tuple[Any, str, str]:
+    """Return ``(detector, event_path, device_command_path)`` for one save item."""
+    if len(item) == 2:
+        det, event_path = item
+        device_command_path = event_path
+    elif len(item) == 3:
+        det, event_path, device_command_path = item
+    else:
+        raise ValueError(
+            "saving_detectors entries must be (detector, event_path) or "
+            "(detector, event_path, device_command_path)"
+        )
+    return det, str(event_path), str(device_command_path)
 
 
 def claim_scan_number(experiment: str = "") -> tuple[int | None, str | None]:
@@ -61,7 +77,9 @@ def _save_cleanup_plan(saving_detectors: list[tuple]):
     if not saving_detectors:
         return
     mv_args: list = []
-    for det, _path in saving_detectors:
+    for det, _event_path, _device_command_path in map(
+        _saving_detector_paths, saving_detectors
+    ):
         mv_args.extend([det.save, "off"])
         logger.debug("Saving disabled for %s", det.name)
     yield from bps.mv(*mv_args)
@@ -141,7 +159,10 @@ def geecs_run_wrapper(
         md["scan_folder"] = scan_folder
     if saving:
         md["nonscalar_save_paths"] = {
-            getattr(det, "_geecs_device_name", det.name): path for det, path in saving
+            getattr(det, "_geecs_device_name", det.name): event_path
+            for det, event_path, _device_command_path in map(
+                _saving_detector_paths, saving
+            )
         }
     scalar_headers = _collect_scalar_headers(devices or [])
     if scalar_headers:
@@ -155,9 +176,14 @@ def geecs_run_wrapper(
         return
 
     mv_args: list = []
-    for det, path in saving:
-        os.makedirs(path, exist_ok=True)
-        logger.info("Save path for %s: %s", det.name, path)
-        mv_args.extend([det.localsavingpath, path, det.save, "on"])
+    for det, event_path, device_command_path in map(_saving_detector_paths, saving):
+        os.makedirs(event_path, exist_ok=True)
+        logger.info(
+            "Save path for %s: event=%s, device=%s",
+            det.name,
+            event_path,
+            device_command_path,
+        )
+        mv_args.extend([det.localsavingpath, device_command_path, det.save, "on"])
     yield from bps.mv(*mv_args)
     yield from bpp.finalize_wrapper(wrapped, _save_cleanup_plan(saving))

--- a/GeecsBluesky/geecs_bluesky/scanner_bridge/bluesky_scanner.py
+++ b/GeecsBluesky/geecs_bluesky/scanner_bridge/bluesky_scanner.py
@@ -43,6 +43,8 @@ import logging
 import os
 import queue
 import threading
+from configparser import ConfigParser
+from pathlib import Path, PureWindowsPath
 from typing import Any, Callable
 
 import numpy as np
@@ -108,6 +110,27 @@ def _prepare_descriptor_for_tiled(doc: dict) -> dict:
             data_key.pop("external", None)
             data_key["geecs_external_asset"] = True
     return doc
+
+
+def _translate_save_path_for_device_server(
+    save_path: str | Path,
+    *,
+    local_base_path: str | Path,
+    device_server_base_path: str,
+) -> str:
+    """Translate a local scan path to the path understood by GEECS devices."""
+    local_path = Path(save_path)
+    local_base = Path(local_base_path)
+    try:
+        relative_path = local_path.relative_to(local_base)
+    except ValueError:
+        logger.warning(
+            "Native save path %s is not under local base path %s; using local path",
+            local_path,
+            local_base,
+        )
+        return str(local_path)
+    return str(PureWindowsPath(device_server_base_path, *relative_path.parts))
 
 
 def _cfg_field(cfg: Any, key: str, default: Any) -> Any:
@@ -458,6 +481,46 @@ class BlueskyScanner:
         api_key = cfg["tiled"].get("api_key") or None
         logger.debug("Tiled config loaded from %s — uri=%s", config_path, uri)
         return uri, api_key
+
+    @staticmethod
+    def _read_device_server_data_base_path() -> str | None:
+        """Read the data base path visible from GEECS device-server hosts."""
+        config_path = Path.home() / ".config" / "geecs_python_api" / "config.ini"
+        if not config_path.exists():
+            return None
+
+        cfg = ConfigParser()
+        cfg.read(config_path)
+        if "Paths" not in cfg:
+            return None
+        return cfg["Paths"].get("geecs_device_server_data_base_path") or None
+
+    @staticmethod
+    def _device_server_save_path(save_path: str) -> str:
+        """Return the path to send to device ``localsavingpath`` controls."""
+        device_server_base_path = BlueskyScanner._read_device_server_data_base_path()
+        if not device_server_base_path:
+            return save_path
+        try:
+            from geecs_data_utils import ScanPaths
+        except Exception:
+            logger.warning(
+                "Could not import geecs_data_utils; using local save path for device"
+            )
+            return save_path
+
+        paths_config = getattr(ScanPaths, "paths_config", None)
+        local_base_path = getattr(paths_config, "base_path", None)
+        if local_base_path is None:
+            logger.warning(
+                "ScanPaths.paths_config is not loaded; using local save path for device"
+            )
+            return save_path
+        return _translate_save_path_for_device_server(
+            save_path,
+            local_base_path=local_base_path,
+            device_server_base_path=device_server_base_path,
+        )
 
     def _subscribe_tiled(self, tiled_uri: str, api_key: str | None = None) -> None:
         """Subscribe a TiledWriter to the RunEngine.
@@ -821,6 +884,7 @@ class BlueskyScanner:
                     saves_files = role in ("reference", "triggered", "contributor")
                     if saves_files and save_nonscalar and scan_folder is not None:
                         save_path = os.path.join(scan_folder, device_name)
+                        device_save_path = self._device_server_save_path(save_path)
                         det.configure_nonscalar_file_logging(save_path)
                         if scan_number is not None:
                             asset_definitions = self._asset_definitions_for_device(
@@ -832,7 +896,9 @@ class BlueskyScanner:
                                     asset_definitions=asset_definitions,
                                     root_path=scan_folder,
                                 )
-                        self._saving_detectors.append((det, save_path))
+                        self._saving_detectors.append(
+                            (det, save_path, device_save_path)
+                        )
                         self._nonscalar_save_paths[device_name] = save_path
                 logger.info(
                     "Detector ready: %s (role=%s, %d variables, save_nonscalar=%s)",

--- a/GeecsBluesky/geecs_bluesky/scanner_bridge/bluesky_scanner.py
+++ b/GeecsBluesky/geecs_bluesky/scanner_bridge/bluesky_scanner.py
@@ -52,6 +52,8 @@ import bluesky.preprocessors as bpp
 
 from ophyd_async.core import AsyncStatus
 
+from geecs_bluesky.assets import AssetDefinition, get_asset_definitions
+from geecs_bluesky.db.geecs_db import GeecsDb
 from geecs_bluesky.devices.generic_detector import GeecsGenericDetector
 from geecs_bluesky.devices.motor import GeecsMotor
 from geecs_bluesky.devices.snapshot import GeecsSnapshotReadable
@@ -702,7 +704,9 @@ class BlueskyScanner:
                 exc_info=True,
             )
 
-    def _build_detectors(self, scan_folder: str | None = None) -> None:
+    def _build_detectors(
+        self, scan_folder: str | None = None, scan_number: int | None = None
+    ) -> None:
         """Create and connect detector devices from ``self._devices_config``.
 
         Each device's role is decided by :meth:`_classify_device_roles` from
@@ -772,6 +776,16 @@ class BlueskyScanner:
                     if saves_files and save_nonscalar and scan_folder is not None:
                         save_path = os.path.join(scan_folder, device_name)
                         det.configure_nonscalar_file_logging(save_path)
+                        if scan_number is not None:
+                            asset_definitions = self._asset_definitions_for_device(
+                                device_name
+                            )
+                            if asset_definitions:
+                                det.configure_external_asset_logging(
+                                    scan_number=scan_number,
+                                    asset_definitions=asset_definitions,
+                                    root_path=scan_folder,
+                                )
                         self._saving_detectors.append((det, save_path))
                         self._nonscalar_save_paths[device_name] = save_path
                 logger.info(
@@ -787,6 +801,29 @@ class BlueskyScanner:
                     device_name,
                     exc_info=True,
                 )
+
+    def _asset_definitions_for_device(
+        self, device_name: str
+    ) -> tuple[AssetDefinition, ...]:
+        """Return registered external asset definitions for *device_name*."""
+        try:
+            device_type = GeecsDb.get_device_type(device_name)
+        except Exception:
+            logger.warning(
+                "Could not resolve device type for %s; external asset docs disabled",
+                device_name,
+                exc_info=True,
+            )
+            return ()
+
+        definitions = get_asset_definitions(device_type)
+        if not definitions:
+            logger.debug(
+                "No external asset registry entry for %s device type %r",
+                device_name,
+                device_type,
+            )
+        return definitions
 
     def _run_standard_scan(self, scan_config: Any) -> None:
         """Step scan: move a scan device through positions, collect shots each step."""
@@ -852,7 +889,7 @@ class BlueskyScanner:
         scan_number, scan_folder = self._claim_scan_number()
         if scan_number is not None and scan_folder is not None:
             self._write_scan_info_ini(scan_config, scan_number, scan_folder)
-        self._build_detectors(scan_folder=scan_folder)
+        self._build_detectors(scan_folder=scan_folder, scan_number=scan_number)
 
         n_steps = len(positions)
         n_shots = n_steps * self._shots_per_step

--- a/GeecsBluesky/geecs_bluesky/scanner_bridge/bluesky_scanner.py
+++ b/GeecsBluesky/geecs_bluesky/scanner_bridge/bluesky_scanner.py
@@ -94,11 +94,51 @@ _FREE_RUN_MODE = "free_run_time_sync"
 _VALID_ACQUISITION_MODES = (_STRICT_MODE, _FREE_RUN_MODE)
 
 
+def _prepare_descriptor_for_tiled(doc: dict) -> dict:
+    """Store GEECS external asset datum IDs as internal Tiled metadata.
+
+    The RunEngine document stream still emits formal Resource/Datum docs for
+    GEECS native files.  The current lab Tiled server does not yet have readers
+    for those custom asset specs, so letting TiledWriter register them as
+    external data sources aborts the scan on ``stop``.  Until the server has
+    GEECS-aware adapters, Tiled stores the datum-id strings in its event table.
+    """
+    for data_key in doc.get("data_keys", {}).values():
+        if str(data_key.get("source", "")).startswith("geecs://"):
+            data_key.pop("external", None)
+            data_key["geecs_external_asset"] = True
+    return doc
+
+
 def _cfg_field(cfg: Any, key: str, default: Any) -> Any:
     """Read *key* from a device config that may be a dict or a Pydantic model."""
     if isinstance(cfg, dict):
         return cfg.get(key, default)
     return getattr(cfg, key, default)
+
+
+class _SafeDocumentCallback:
+    """Document callback wrapper that logs and disables itself on failure."""
+
+    def __init__(self, callback: Callable[[str, dict], None], label: str) -> None:
+        self._callback = callback
+        self._label = label
+        self._enabled = True
+
+    def __call__(self, name: str, doc: dict) -> None:
+        """Forward one document unless the wrapped callback has already failed."""
+        if not self._enabled:
+            return
+        try:
+            self._callback(name, doc)
+        except Exception:
+            self._enabled = False
+            logger.warning(
+                "%s failed while handling %s document; disabling callback",
+                self._label,
+                name,
+                exc_info=True,
+            )
 
 
 class _UdpSetter:
@@ -437,7 +477,13 @@ class BlueskyScanner:
 
         try:
             client = from_uri(tiled_uri, api_key=api_key)
-            writer = TiledWriter(client)
+            writer = _SafeDocumentCallback(
+                TiledWriter(
+                    client,
+                    patches={"descriptor": _prepare_descriptor_for_tiled},
+                ),
+                label="TiledWriter",
+            )
             self._tiled_token = self._RE.subscribe(writer)
             logger.info("TiledWriter subscribed — catalog at %s", tiled_uri)
         except Exception:

--- a/GeecsBluesky/pyproject.toml
+++ b/GeecsBluesky/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-bluesky"
-version = "0.11.0"
+version = "0.12.0"
 description = "Bluesky / ophyd-async bridge for the GEECS control system"
 authors = ["Sam Barber <sbarber@lbl.gov>"]
 readme = "README.md"

--- a/GeecsBluesky/test_bluesky_scanner.py
+++ b/GeecsBluesky/test_bluesky_scanner.py
@@ -19,11 +19,15 @@ Run from GeecsBluesky/:
 
 from __future__ import annotations
 
+import asyncio
 import logging
+import sys
 import time
 from types import SimpleNamespace
 
+from geecs_bluesky.db.geecs_db import GeecsDb
 from geecs_bluesky.scanner_bridge import BlueskyScanner
+from geecs_bluesky.transport.udp_client import GeecsUdpClient
 
 logging.basicConfig(level=logging.INFO, format="%(name)s %(levelname)s %(message)s")
 
@@ -53,6 +57,12 @@ SHOT_CONTROL_INFO = {
 
 SHOTS_PER_STEP = 3
 REP_RATE_HZ = 1.0
+
+PREFLIGHT_READS = {
+    "UC_TopView": ("acq_timestamp",),
+    "U_ESP_JetXYZ": ("Position.Axis 1",),
+    "U_DG645_ShotControl": ("Trigger.Source",),
+}
 
 
 def _make_exec_config(
@@ -103,6 +113,39 @@ def poll(scanner: BlueskyScanner) -> None:
         print(f"  {pct:.0f}%", end="\r")
         time.sleep(0.5)
     print()
+
+
+async def _preflight_device(device_name: str, variables: tuple[str, ...]) -> None:
+    """Verify one required hardware device is reachable before scan scenarios."""
+    host, port = GeecsDb.find_device(device_name)
+    udp = GeecsUdpClient(host, port, device_name=device_name)
+    await udp.connect()
+    try:
+        for variable in variables:
+            await udp.get(variable)
+    finally:
+        await udp.close()
+
+
+def preflight_hardware() -> bool:
+    """Return whether all required hardware devices are reachable."""
+    ok = True
+    print("\n=== Hardware preflight ===")
+    for device_name, variables in PREFLIGHT_READS.items():
+        try:
+            asyncio.run(_preflight_device(device_name, variables))
+        except Exception as exc:
+            ok = False
+            print(f"  ✗  {device_name}: unavailable ({exc})")
+        else:
+            print(f"  ✓  {device_name}: reachable")
+    if not ok:
+        print("\nHardware preflight failed; turn on the devices above and rerun.")
+    return ok
+
+
+if not preflight_hardware():
+    sys.exit(2)
 
 
 # ---------------------------------------------------------------------------

--- a/GeecsBluesky/test_bluesky_scanner.py
+++ b/GeecsBluesky/test_bluesky_scanner.py
@@ -1,26 +1,29 @@
 """BlueskyScanner bridge — hardware integration test.
 
 Exercises the ScanManager-compatible API that RunControl uses, without launching
-the GUI.  Requires lab network access (GEECS DB + UC_TopView + U_ESP_JetXYZ +
-U_DG645_ShotControl).
+the GUI.  Requires lab network access (GEECS DB + one camera + U_ESP_JetXYZ +
+U_DG645_ShotControl).  The camera defaults to UC_TopView and can be overridden
+with ``GEECS_BLUESKY_TEST_CAMERA``.
 
 Scenarios
 ---------
-1. NOSCAN  — fixed-position collection from UC_TopView (acq_timestamp only)
+1. NOSCAN  — fixed-position collection from the camera (acq_timestamp only)
              Verifies: N events collected.
-2. STANDARD — step scan U_ESP_JetXYZ 4→5 mm with UC_TopView as detector
+2. STANDARD — step scan U_ESP_JetXYZ 4→5 mm with the camera as detector
              Verifies: N positions × M shots events, motor readback in each event.
 3. NOSCAN with shot control — as scenario 1 but with U_DG645_ShotControl wired;
              Verifies: DG645 Trigger.Source returns to STANDBY after scan.
 
 Run from GeecsBluesky/:
     poetry run python test_bluesky_scanner.py
+    GEECS_BLUESKY_TEST_CAMERA=UC_Amp2_IR_input poetry run python test_bluesky_scanner.py
 """
 
 from __future__ import annotations
 
 import asyncio
 import logging
+import os
 import sys
 import time
 from types import SimpleNamespace
@@ -31,8 +34,10 @@ from geecs_bluesky.transport.udp_client import GeecsUdpClient
 
 logging.basicConfig(level=logging.INFO, format="%(name)s %(levelname)s %(message)s")
 
+TEST_CAMERA_DEVICE = os.environ.get("GEECS_BLUESKY_TEST_CAMERA", "UC_TopView")
+
 DETECTOR_DEVICES = {
-    "UC_TopView": {
+    TEST_CAMERA_DEVICE: {
         "variable_list": ["acq_timestamp"],
         "save_nonscalar_data": False,
     },
@@ -59,7 +64,7 @@ SHOTS_PER_STEP = 3
 REP_RATE_HZ = 1.0
 
 PREFLIGHT_READS = {
-    "UC_TopView": ("acq_timestamp",),
+    TEST_CAMERA_DEVICE: ("acq_timestamp",),
     "U_ESP_JetXYZ": ("Position.Axis 1",),
     "U_DG645_ShotControl": ("Trigger.Source",),
 }
@@ -151,7 +156,7 @@ if not preflight_hardware():
 # ---------------------------------------------------------------------------
 # Scenario 1: NOSCAN (no shot control)
 # ---------------------------------------------------------------------------
-print("\n=== Scenario 1: NOSCAN — UC_TopView, no shot control ===")
+print(f"\n=== Scenario 1: NOSCAN — {TEST_CAMERA_DEVICE}, no shot control ===")
 
 scanner1 = BlueskyScanner(experiment_dir="Undulator")
 scanner1.reinitialize(
@@ -172,7 +177,7 @@ check(
 # ---------------------------------------------------------------------------
 # Scenario 2: STANDARD step scan (no shot control)
 # ---------------------------------------------------------------------------
-print("\n=== Scenario 2: STANDARD — JetXYZ 4→5 mm, UC_TopView ===")
+print(f"\n=== Scenario 2: STANDARD — JetXYZ 4→5 mm, {TEST_CAMERA_DEVICE} ===")
 
 POSITIONS = 3  # 4.0, 4.5, 5.0
 EXPECTED = POSITIONS * SHOTS_PER_STEP

--- a/GeecsBluesky/tests/test_assets.py
+++ b/GeecsBluesky/tests/test_assets.py
@@ -70,14 +70,14 @@ def test_pointgrey_camera_registry_entry() -> None:
 
 
 def test_camera_image_filename_uses_geecs_convention() -> None:
-    """Camera filenames are based on scan number, device name, and timestamp."""
+    """Camera filenames are based on device name and timestamp."""
     assert (
         camera_image_filename(
             scan_number=7,
             device_name="UC_TopView",
             acq_timestamp=1234567890.1234,
         )
-        == "Scan007_UC_TopView_1234567890.123.png"
+        == "UC_TopView_1234567890.123.png"
     )
 
 
@@ -90,7 +90,7 @@ def test_native_file_filename_normalizes_extension() -> None:
             acq_timestamp=1234567890.1234,
             extension="tdms",
         )
-        == "Scan007_U_PicoScope_1234567890.123.tdms"
+        == "U_PicoScope_1234567890.123.tdms"
     )
 
 
@@ -108,10 +108,10 @@ def test_camera_definition_builds_file_and_resource_paths(tmp_path) -> None:
         acq_timestamp=1000.5,
     )
 
-    assert file_path == save_path / "Scan042_UC_TopView_1000.500.png"
+    assert file_path == save_path / "UC_TopView_1000.500.png"
     assert (
         definition.resource_path(root=root, file_path=file_path)
-        == "scans/Scan042/UC_TopView/Scan042_UC_TopView_1000.500.png"
+        == "scans/Scan042/UC_TopView/UC_TopView_1000.500.png"
     )
 
 
@@ -139,13 +139,13 @@ def test_tdms_device_types_register_primary_file_with_index_companion(tmp_path) 
         assert definition.extensions == (".tdms",)
         assert definition.companion_extensions == (".tdms_index",)
         assert definition.handler_class is None
-        assert file_path == save_path / "Scan003_U_Scope_42.125.tdms"
+        assert file_path == save_path / "U_Scope_42.125.tdms"
         assert definition.companion_file_paths(
             save_path=save_path,
             scan_number=3,
             device_name="U_Scope",
             acq_timestamp=42.125,
-        ) == (save_path / "Scan003_U_Scope_42.125.tdms_index",)
+        ) == (save_path / "U_Scope_42.125.tdms_index",)
         assert supports_device_type(device_type)
 
 
@@ -175,7 +175,7 @@ def test_frog_registers_spatial_and_temporal_camera_assets(tmp_path) -> None:
         / "scans"
         / "Scan015"
         / "U_FROG_Grenouille-Spatial"
-        / "Scan015_U_FROG_Grenouille_10.000.png"
+        / "U_FROG_Grenouille_10.000.png"
     )
     assert by_field["Temporal"].file_path(
         save_path=save_path,
@@ -187,7 +187,7 @@ def test_frog_registers_spatial_and_temporal_camera_assets(tmp_path) -> None:
         / "scans"
         / "Scan015"
         / "U_FROG_Grenouille-Temporal"
-        / "Scan015_U_FROG_Grenouille_10.000.png"
+        / "U_FROG_Grenouille_10.000.png"
     )
 
 
@@ -222,7 +222,7 @@ def test_magspec_camera_registers_image_and_variant_assets(tmp_path) -> None:
         / "scans"
         / "Scan042"
         / "U_BCaveMagSpec-interp"
-        / "Scan042_U_BCaveMagSpec_1000.500.png"
+        / "U_BCaveMagSpec_1000.500.png"
     )
     assert by_field["interpSpec"].file_path(
         save_path=save_path,
@@ -234,7 +234,7 @@ def test_magspec_camera_registers_image_and_variant_assets(tmp_path) -> None:
         / "scans"
         / "Scan042"
         / "U_BCaveMagSpec-interpSpec"
-        / "Scan042_U_BCaveMagSpec_1000.500.txt"
+        / "U_BCaveMagSpec_1000.500.txt"
     )
 
 
@@ -253,7 +253,7 @@ def test_magspec_stitcher_omits_interp_image_asset() -> None:
 def test_camera_image_handler_loads_png(tmp_path) -> None:
     """The camera handler should delegate PNG decoding to geecs_data_utils.io."""
     root = tmp_path / "root"
-    image_path = root / "Scan001" / "UC_TopView" / "Scan001_UC_TopView_1.000.png"
+    image_path = root / "Scan001" / "UC_TopView" / "UC_TopView_1.000.png"
     image_path.parent.mkdir(parents=True)
 
     expected = np.array([[1, 2], [3, 4]], dtype=np.uint8)
@@ -263,7 +263,7 @@ def test_camera_image_handler_loads_png(tmp_path) -> None:
         )
 
     handler = GeecsCameraImageHandler(
-        "Scan001/UC_TopView/Scan001_UC_TopView_1.000.png",
+        "Scan001/UC_TopView/UC_TopView_1.000.png",
         root=root,
     )
     np.testing.assert_array_equal(handler(), expected)
@@ -299,7 +299,7 @@ def test_nonscalar_save_support_emits_camera_asset_docs(tmp_path) -> None:
     resource = docs[0][1]
     datum = docs[1][1]
     assert resource["root"] == str(scan_folder)
-    assert resource["resource_path"] == "UC_TopView/Scan042_UC_TopView_1000.500.png"
+    assert resource["resource_path"] == "UC_TopView/UC_TopView_1000.500.png"
     assert resource["spec"] == GEECS_CAMERA_IMAGE
     assert resource["resource_kwargs"] == {"data_key": data_key}
     assert datum["datum_id"] == datum_id
@@ -331,9 +331,9 @@ def test_nonscalar_save_support_records_tdms_companion_paths(tmp_path) -> None:
     resource = docs[0][1]
 
     assert reading["u_scope-tdms"]["value"]
-    assert resource["resource_path"] == "U_Scope/Scan003_U_Scope_42.125.tdms"
+    assert resource["resource_path"] == "U_Scope/U_Scope_42.125.tdms"
     assert resource["resource_kwargs"]["companion_resource_paths"] == [
-        "U_Scope/Scan003_U_Scope_42.125.tdms_index"
+        "U_Scope/U_Scope_42.125.tdms_index"
     ]
 
 
@@ -372,4 +372,4 @@ def test_run_engine_emits_external_asset_docs_from_readable(tmp_path) -> None:
     assert event["data"]["uc_topview-image"] == datum["datum_id"]
     assert event["filled"]["uc_topview-image"] is False
     assert resource["root"] == str(scan_folder)
-    assert resource["resource_path"] == "UC_TopView/Scan042_UC_TopView_1000.500.png"
+    assert resource["resource_path"] == "UC_TopView/UC_TopView_1000.500.png"

--- a/GeecsBluesky/tests/test_assets.py
+++ b/GeecsBluesky/tests/test_assets.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import numpy as np
 import png
+from bluesky import RunEngine
+import bluesky.plan_stubs as bps
 
 from geecs_bluesky.assets import (
     FROG_DEVICE_TYPE,
@@ -24,6 +26,34 @@ from geecs_bluesky.assets import (
     native_file_filename,
     supports_device_type,
 )
+from geecs_bluesky.devices.nonscalar_save import NonScalarSaveSupport
+
+
+class _AssetEmitter(NonScalarSaveSupport):
+    """Minimal object exposing the NonScalarSaveSupport asset-doc methods."""
+
+    name = "uc_topview"
+    parent = None
+    _geecs_device_name = "UC_TopView"
+    _save_nonscalar_data = True
+
+
+class _ReadableAssetEmitter(_AssetEmitter):
+    """Minimal Bluesky-readable object backed by an external asset."""
+
+    def describe(self):
+        """Return the external asset data keys."""
+        return self._asset_datakeys()
+
+    def read(self):
+        """Return one datum id and queue the matching Resource/Datum docs."""
+        reading = {}
+        self._emit_asset_readings(
+            reading,
+            event_timestamp=123.0,
+            acq_timestamp=1000.5,
+        )
+        return reading
 
 
 def test_pointgrey_camera_registry_entry() -> None:
@@ -237,3 +267,109 @@ def test_camera_image_handler_loads_png(tmp_path) -> None:
         root=root,
     )
     np.testing.assert_array_equal(handler(), expected)
+
+
+def test_nonscalar_save_support_emits_camera_asset_docs(tmp_path) -> None:
+    """NonScalarSaveSupport should pair datum readings with Resource/Datum docs."""
+    scan_folder = tmp_path / "scans" / "Scan042"
+    save_path = scan_folder / "UC_TopView"
+    emitter = _AssetEmitter()
+    emitter.configure_nonscalar_file_logging(save_path)
+    emitter.configure_external_asset_logging(
+        scan_number=42,
+        asset_definitions=get_asset_definitions(POINTGREY_CAMERA_DEVICE_TYPE),
+        root_path=scan_folder,
+    )
+
+    data_key = "uc_topview-image"
+    data_keys = emitter._asset_datakeys()
+    assert data_keys[data_key]["external"] == "OLD:"
+
+    reading = {}
+    emitter._emit_asset_readings(
+        reading,
+        event_timestamp=123.0,
+        acq_timestamp=1000.5,
+    )
+    datum_id = reading[data_key]["value"]
+    assert datum_id
+
+    docs = list(emitter.collect_asset_docs())
+    assert [name for name, _doc in docs] == ["resource", "datum"]
+    resource = docs[0][1]
+    datum = docs[1][1]
+    assert resource["root"] == str(scan_folder)
+    assert resource["resource_path"] == "UC_TopView/Scan042_UC_TopView_1000.500.png"
+    assert resource["spec"] == GEECS_CAMERA_IMAGE
+    assert resource["resource_kwargs"] == {"data_key": data_key}
+    assert datum["datum_id"] == datum_id
+    assert datum["resource"] == resource["uid"]
+    assert datum["datum_kwargs"] == {}
+    assert list(emitter.collect_asset_docs()) == []
+
+
+def test_nonscalar_save_support_records_tdms_companion_paths(tmp_path) -> None:
+    """TDMS assets should include their index file as resource metadata."""
+    scan_folder = tmp_path / "scans" / "Scan003"
+    save_path = scan_folder / "U_Scope"
+    emitter = _AssetEmitter()
+    emitter._geecs_device_name = "U_Scope"
+    emitter.configure_nonscalar_file_logging(save_path)
+    emitter.configure_external_asset_logging(
+        scan_number=3,
+        asset_definitions=get_asset_definitions(PICOSCOPE_V2_DEVICE_TYPE),
+        root_path=scan_folder,
+    )
+
+    reading = {}
+    emitter._emit_asset_readings(
+        reading,
+        event_timestamp=123.0,
+        acq_timestamp=42.125,
+    )
+    docs = list(emitter.collect_asset_docs())
+    resource = docs[0][1]
+
+    assert reading["u_scope-tdms"]["value"]
+    assert resource["resource_path"] == "U_Scope/Scan003_U_Scope_42.125.tdms"
+    assert resource["resource_kwargs"]["companion_resource_paths"] == [
+        "U_Scope/Scan003_U_Scope_42.125.tdms_index"
+    ]
+
+
+def test_run_engine_emits_external_asset_docs_from_readable(tmp_path) -> None:
+    """RunEngine should emit queued Resource/Datum docs with the event."""
+    scan_folder = tmp_path / "scans" / "Scan042"
+    emitter = _ReadableAssetEmitter()
+    emitter.configure_nonscalar_file_logging(scan_folder / "UC_TopView")
+    emitter.configure_external_asset_logging(
+        scan_number=42,
+        asset_definitions=get_asset_definitions(POINTGREY_CAMERA_DEVICE_TYPE),
+        root_path=scan_folder,
+    )
+    docs = []
+
+    def plan():
+        yield from bps.open_run()
+        yield from bps.create()
+        yield from bps.read(emitter)
+        yield from bps.save()
+        yield from bps.close_run()
+
+    RunEngine({})(plan(), lambda name, doc: docs.append((name, doc)))
+
+    assert [name for name, _doc in docs] == [
+        "start",
+        "descriptor",
+        "resource",
+        "datum",
+        "event",
+        "stop",
+    ]
+    event = next(doc for name, doc in docs if name == "event")
+    resource = next(doc for name, doc in docs if name == "resource")
+    datum = next(doc for name, doc in docs if name == "datum")
+    assert event["data"]["uc_topview-image"] == datum["datum_id"]
+    assert event["filled"]["uc_topview-image"] is False
+    assert resource["root"] == str(scan_folder)
+    assert resource["resource_path"] == "UC_TopView/Scan042_UC_TopView_1000.500.png"

--- a/GeecsBluesky/tests/test_bluesky_scanner_gui_bridge.py
+++ b/GeecsBluesky/tests/test_bluesky_scanner_gui_bridge.py
@@ -11,6 +11,7 @@ from geecs_bluesky.scanner_bridge.bluesky_scanner import (
     BlueskyScanner,
     _prepare_descriptor_for_tiled,
     _SafeDocumentCallback,
+    _translate_save_path_for_device_server,
 )
 
 
@@ -91,6 +92,17 @@ def test_safe_document_callback_warns_and_disables(caplog) -> None:
 
     assert calls == ["start", "event"]
     assert "Storage failed while handling event document" in caplog.text
+
+
+def test_translate_save_path_for_device_server() -> None:
+    """Mac/Linux scan paths should translate to the configured device path."""
+    path = _translate_save_path_for_device_server(
+        "/Volumes/hdna2/data/Undulator/Y2026/06-Jun/26_0623/scans/Scan011/UC_Cam",
+        local_base_path="/Volumes/hdna2/data",
+        device_server_base_path="Z:/data",
+    )
+
+    assert path == r"Z:\data\Undulator\Y2026\06-Jun\26_0623\scans\Scan011\UC_Cam"
 
 
 # ---------------------------------------------------------------------------

--- a/GeecsBluesky/tests/test_bluesky_scanner_gui_bridge.py
+++ b/GeecsBluesky/tests/test_bluesky_scanner_gui_bridge.py
@@ -2,11 +2,16 @@
 
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass
 from types import SimpleNamespace
 
 from geecs_bluesky.scanner_bridge import bluesky_scanner
-from geecs_bluesky.scanner_bridge.bluesky_scanner import BlueskyScanner
+from geecs_bluesky.scanner_bridge.bluesky_scanner import (
+    BlueskyScanner,
+    _prepare_descriptor_for_tiled,
+    _SafeDocumentCallback,
+)
 
 
 @dataclass
@@ -39,6 +44,53 @@ def test_set_state_emits_gui_lifecycle_event(monkeypatch) -> None:
 
     assert scanner.current_state == "done"
     assert events == [_FakeLifecycleEvent(state="done", total_shots=12)]
+
+
+def test_prepare_descriptor_for_tiled_internalizes_geecs_assets() -> None:
+    """Tiled should store GEECS asset datum ids without registering readers."""
+    doc = {
+        "data_keys": {
+            "uc_topview-image": {
+                "source": "geecs://UC_TopView/image",
+                "external": "OLD:",
+                "dtype": "array",
+            },
+            "external-hdf5": {
+                "source": "AD_HDF5",
+                "external": "STREAM:",
+                "dtype": "array",
+            },
+            "scalar": {"source": "sim://scalar", "dtype": "number"},
+        }
+    }
+
+    patched = _prepare_descriptor_for_tiled(doc)
+
+    geecs_key = patched["data_keys"]["uc_topview-image"]
+    assert "external" not in geecs_key
+    assert geecs_key["geecs_external_asset"] is True
+    assert patched["data_keys"]["external-hdf5"]["external"] == "STREAM:"
+    assert "external" not in patched["data_keys"]["scalar"]
+
+
+def test_safe_document_callback_warns_and_disables(caplog) -> None:
+    """Persistence callbacks should not be able to abort acquisition."""
+    calls: list[str] = []
+
+    def callback(name: str, _doc: dict) -> None:
+        calls.append(name)
+        if name == "event":
+            raise RuntimeError("storage failed")
+
+    safe_callback = _SafeDocumentCallback(callback, label="Storage")
+
+    with caplog.at_level(logging.WARNING):
+        safe_callback("start", {})
+        safe_callback("event", {})
+        safe_callback("stop", {})
+
+    assert calls == ["start", "event"]
+    assert "Storage failed while handling event document" in caplog.text
 
 
 # ---------------------------------------------------------------------------

--- a/GeecsBluesky/tests/test_run_wrapper.py
+++ b/GeecsBluesky/tests/test_run_wrapper.py
@@ -108,6 +108,25 @@ def test_wrapper_brackets_native_saving(tmp_path) -> None:
     assert start["nonscalar_save_paths"] == {"TOPCAM": str(save_dir)}
 
 
+def test_wrapper_uses_device_command_path_separately(tmp_path) -> None:
+    """Native-save metadata path and device-visible path may differ."""
+    det = _FakeSavingDetector("topcam")
+    save_dir = tmp_path / "Scan007" / "UC_TopCam"
+    device_path = r"Z:\data\Undulator\Y2026\06-Jun\26_0623\scans\Scan007\UC_TopCam"
+    start = _run_capture_start(
+        geecs_run_wrapper(
+            _tiny_run(),
+            scan_number=7,
+            saving_detectors=[(det, str(save_dir), device_path)],
+        )
+    )
+
+    assert det.localsavingpath.sets == [device_path]
+    assert det.save.sets == ["on", "off"]
+    assert save_dir.is_dir()
+    assert start["nonscalar_save_paths"] == {"TOPCAM": str(save_dir)}
+
+
 def test_wrapper_injects_merged_scalar_headers() -> None:
     dev_a = _FakeHeaderedDevice(
         "wavemeter", {"wavemeter-wavelength_nm": "UC_Wavemeter Wavelength (nm)"}


### PR DESCRIPTION
## Summary
- wire registered native-file-saving devices to emit Bluesky Resource/Datum docs during acquisition
- preserve the existing nonscalar_save_path event column while adding datum-id event fields for registered assets
- translate scanner-local save folders to geecs_device_server_data_base_path for device localsavingpath commands, so macOS/Linux tests can command Windows-visible paths such as Z:\data
- use the direct native device filename convention for asset resource paths: Device_<acq_timestamp>.<ext>
- keep GEECS external asset datum IDs as ordinary Tiled event metadata until the lab Tiled server has readers for the custom GEECS asset specs
- add hardware-script preflight checks for the test camera, U_ESP_JetXYZ, and U_DG645_ShotControl; the camera defaults to UC_TopView and can be overridden with GEECS_BLUESKY_TEST_CAMERA
- add unit coverage for camera assets, TDMS companion paths, RunEngine Resource/Datum emission, Tiled descriptor fallback, persistence callback isolation, and split event/device save paths

## Behavior notes
- unregistered device types and device-type lookup failures keep the current behavior and do not emit asset docs
- event metadata and Resource root/resource_path use the local/readable scan folder; device save commands use the device-server-visible base path when configured
- TDMS assets record the .tdms_index path as companion resource metadata
- RunEngine subscribers still see Resource/Datum docs; Tiled stores the datum-id strings for geecs:// asset keys rather than registering unsupported external readers
- TiledWriter failures now warn and disable that callback instead of aborting acquisition
- Bluesky direct native saves currently leave the raw device filenames in the scan folder; the legacy post-scan mover/renamer is still a separate future concern if we want legacy moved-file names

## Tests
- PYTHONPATH=GeecsBluesky:GEECS-Data-Utils python -m pytest GeecsBluesky/tests/test_assets.py GeecsBluesky/tests/test_geecs_db.py GeecsBluesky/tests/test_bluesky_scanner_gui_bridge.py -m "not integration" --tb=short -q
- PYTHONPATH=GeecsBluesky:GEECS-Data-Utils python -m pytest GeecsBluesky/tests/test_geecs_db.py -m integration --tb=short -q
- PYTHONPATH=GeecsBluesky:GEECS-Data-Utils python -m pytest GeecsBluesky/tests/test_assets.py GeecsBluesky/tests/test_run_wrapper.py GeecsBluesky/tests/test_bluesky_scanner_gui_bridge.py -m "not integration" --tb=short -q
- PYTHONPATH=GeecsBluesky:GEECS-Data-Utils python -m ruff check GeecsBluesky/geecs_bluesky/assets GeecsBluesky/geecs_bluesky/plans/run_wrapper.py GeecsBluesky/geecs_bluesky/scanner_bridge/bluesky_scanner.py GeecsBluesky/tests/test_assets.py GeecsBluesky/tests/test_run_wrapper.py GeecsBluesky/tests/test_bluesky_scanner_gui_bridge.py
- PYTHONPATH=GeecsBluesky:GEECS-Data-Utils python -m pydocstyle GeecsBluesky/geecs_bluesky/assets GeecsBluesky/geecs_bluesky/plans/run_wrapper.py GeecsBluesky/geecs_bluesky/scanner_bridge/bluesky_scanner.py GeecsBluesky/tests/test_assets.py GeecsBluesky/tests/test_run_wrapper.py GeecsBluesky/tests/test_bluesky_scanner_gui_bridge.py --convention=numpy
- PYTHONPATH=GeecsBluesky:GEECS-Data-Utils python -m compileall -q GeecsBluesky/geecs_bluesky/assets GeecsBluesky/geecs_bluesky/plans/run_wrapper.py GeecsBluesky/geecs_bluesky/scanner_bridge/bluesky_scanner.py GeecsBluesky/tests/test_assets.py GeecsBluesky/tests/test_run_wrapper.py GeecsBluesky/tests/test_bluesky_scanner_gui_bridge.py
- poetry check --lock

## Hardware verification
- Config translation check: /Volumes/hdna2/data/... translates to Z:\data\... for device localsavingpath commands
- UC_Amp2_IR_input shot-control NOSCAN with save_nonscalar_data=True: 3 events, 3 Resource docs, 3 Datum docs, emitted resource paths all existed as PNG files, stop document reached, no Tiled abort
- Standalone test_bluesky_scanner.py default camera: hardware preflight passed for UC_TopView, U_ESP_JetXYZ, and U_DG645_ShotControl; NOSCAN, STANDARD motor scan, and DG645 shot-control NOSCAN all passed (6 passed, 0 failed)
- Standalone test_bluesky_scanner.py with GEECS_BLUESKY_TEST_CAMERA=UC_Amp2_IR_input: hardware preflight passed and all scenarios passed (6 passed, 0 failed)