### PR TITLE
ci: split GeecsBluesky fake-server tests

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -26,6 +26,6 @@ jobs:
         working-directory: GeecsBluesky
         run: poetry install --with dev
 
-      - name: Run GeecsBluesky unit tests
+      - name: Run GeecsBluesky pure unit tests
         working-directory: GeecsBluesky
-        run: poetry run pytest tests/test_assets.py tests/test_geecs_db.py -m "not integration" --tb=short -q
+        run: poetry run pytest tests -m "not integration and not fake_server" --tb=short -q

--- a/GeecsBluesky/CHANGELOG.md
+++ b/GeecsBluesky/CHANGELOG.md
@@ -12,6 +12,12 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   `FakeGeecsServer` TCP/UDP integration tests via a dedicated `fake_server`
   marker, so unit-test CI can avoid opening localhost sockets.
 
+### Fixed
+
+- Hardened fake-server tests and socket teardown with bounded per-test timeouts,
+  explicit background server shutdown, TCP subscriber cleanup, and retry logic
+  for local UDP/TCP port collisions.
+
 ## [0.12.1] - 2026-06-23
 
 ### Added

--- a/GeecsBluesky/CHANGELOG.md
+++ b/GeecsBluesky/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to `geecs-bluesky` are documented here.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.11.1] - 2026-06-23
+
+### Changed
+
+- Split GeecsBluesky pytest selection into pure unit tests and socket-based
+  `FakeGeecsServer` TCP/UDP integration tests via a dedicated `fake_server`
+  marker, so unit-test CI can avoid opening localhost sockets.
+
 ## [0.11.0] - 2026-06-23
 
 ### Added

--- a/GeecsBluesky/CLAUDE.md
+++ b/GeecsBluesky/CLAUDE.md
@@ -290,6 +290,12 @@ simulate hardware shot events in tests.
 `test_bluesky_scanner.py` (top-level, run with `poetry run python
 test_bluesky_scanner.py`) requires lab network access.  Tests three scenarios
 against real hardware: NOSCAN, STANDARD step scan, NOSCAN with DG645 shot control.
+The opt-in pytest case
+`test_bluesky_scanner_full_output_hardware_integration` requires
+`GEECS_BLUESKY_FULL_OUTPUT_TEST=1` and `poetry install --extras tiled`; it runs a
+real STANDARD scan with native camera saving enabled and verifies the scan
+folder, `ScanInfo`, `scan.log`, legacy scalar files, analysis s-file, saved
+camera images, and event save-path metadata.
 
 ## Configuration
 
@@ -324,9 +330,9 @@ architecture — see `Planning/acquisition_modes/00_overview.md` "Deferred".
   `_UdpSetter` + `ShotControlConfig`).  Plans, devices, `geecs_run_wrapper`, and
   the schema are reusable; a future `ShotController` helper would give notebooks
   full parity (jet gating / single-shot firing).
-- **Scalar s-files / TDMS output not produced** — Bluesky writes to Tiled only.
-  `ScanAnalysis` still reads s-files; a Tiled→s-file exporter is deferred until
-  the free-run event shape has survived real use.
+- **Scalar s-files are exported from Tiled best-effort** after a scan when the
+  Tiled client extra is installed and the run can be read back.  Legacy TDMS
+  output is not produced.
 - **Optimization and Background scan modes not implemented.**  For optimization,
   start from the unified `BaseEvaluator` / `BaseOptimizer` surface in
   `GEECS-Scanner-GUI`, not the removed `MultiDeviceScanEvaluator` /

--- a/GeecsBluesky/README.md
+++ b/GeecsBluesky/README.md
@@ -137,16 +137,21 @@ internal `asyncio.Lock` serialises them automatically.
 ## Running the tests
 
 ```bash
-poetry run pytest tests/ -v
+poetry run pytest tests -m "not integration and not fake_server" -v
+poetry run pytest tests -m "fake_server and not integration" -v
 ```
 
-All tests run against `FakeGeecsServer` on localhost — no real hardware required.
+Pure unit tests do not open sockets. Tests marked `fake_server` use
+`FakeGeecsServer` on localhost TCP/UDP sockets and require no real hardware.
+Tests marked `integration` touch external lab services and are skipped by
+default in CI.
 
 A hardware integration test (`test_bluesky_scanner.py`) exercises NOSCAN, STANDARD
 step scan, and DG645 shot control against real lab devices:
 
 ```bash
 poetry run python test_bluesky_scanner.py
+poetry run pytest test_bluesky_scanner.py -m "integration and hardware" -v
 ```
 
 ## Architecture notes

--- a/GeecsBluesky/README.md
+++ b/GeecsBluesky/README.md
@@ -32,8 +32,8 @@ the detector `acq_timestamp` and the configured save directory; file names
 remain hardware-native and should be joined by `acq_timestamp`.
 
 Still open (features, not architecture): setup/closeout actions,
-background/optimization modes, legacy s-file/TDMS output, and a reusable
-shot-controller for notebook parity.  See `ROADMAP.md` and
+background/optimization modes, legacy TDMS output, and a reusable shot-controller
+for notebook parity.  See `ROADMAP.md` and
 `Planning/acquisition_modes/`.
 
 ## Requirements
@@ -152,6 +152,18 @@ step scan, and DG645 shot control against real lab devices:
 ```bash
 poetry run python test_bluesky_scanner.py
 poetry run pytest test_bluesky_scanner.py -m "integration and hardware" -v
+```
+
+An opt-in full-output hardware test runs a real STANDARD scan with native camera
+saving enabled and verifies the scan folder, `ScanInfo`, `scan.log`, legacy
+scalar files, analysis s-file, saved camera images, and event save-path metadata.
+It requires the Tiled client extra because scalar/s-file export reads the run
+back from Tiled:
+
+```bash
+poetry install --extras tiled
+GEECS_BLUESKY_TEST_CAMERA=UC_Amp2_IR_input GEECS_BLUESKY_FULL_OUTPUT_TEST=1 \
+  poetry run pytest test_bluesky_scanner.py::test_bluesky_scanner_full_output_hardware_integration -v -s
 ```
 
 ## Architecture notes

--- a/GeecsBluesky/geecs_bluesky/devices/geecs_device.py
+++ b/GeecsBluesky/geecs_bluesky/devices/geecs_device.py
@@ -160,14 +160,17 @@ class GeecsDevice(StandardReadable):
         self, host: str, port: int, variables: list[str]
     ) -> None:
         """Background task: maintain TCP subscription and update shot cache."""
+        sub = GeecsTcpSubscriber(host, port)
         try:
-            async with GeecsTcpSubscriber(host, port) as sub:
-                await sub.subscribe(variables, self._on_tcp_push)
-                await asyncio.sleep(float("inf"))
+            await sub.connect()
+            await sub.subscribe(variables, self._on_tcp_push)
+            await asyncio.sleep(float("inf"))
         except asyncio.CancelledError:
             pass
         except Exception:
             logger.exception("TCP subscription failed for %s", self.name)
+        finally:
+            await sub.close()
 
     def _on_tcp_push(self, frame: dict[str, Any]) -> None:
         """Callback invoked on each 5-Hz TCP push frame."""

--- a/GeecsBluesky/geecs_bluesky/scanner_bridge/bluesky_scanner.py
+++ b/GeecsBluesky/geecs_bluesky/scanner_bridge/bluesky_scanner.py
@@ -44,6 +44,7 @@ import os
 import queue
 import threading
 from configparser import ConfigParser
+from contextlib import contextmanager, nullcontext
 from pathlib import Path, PureWindowsPath
 from typing import Any, Callable
 
@@ -162,6 +163,18 @@ class _SafeDocumentCallback:
                 name,
                 exc_info=True,
             )
+
+
+class _ScanLogContextFilter(logging.Filter):
+    """Add scan id context to records written to one scan log."""
+
+    def __init__(self, scan_id: str) -> None:
+        super().__init__()
+        self._scan_id = scan_id
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        record.scan_id = self._scan_id
+        return True
 
 
 class _UdpSetter:
@@ -786,6 +799,45 @@ class BlueskyScanner:
         except OSError:
             logger.warning("Could not write ScanInfo to %s", path, exc_info=True)
 
+    @contextmanager
+    def _scan_log(self, scan_number: int | None, scan_folder: str | None):
+        """Attach a per-scan log file for Bluesky scanner runs."""
+        if scan_number is None or scan_folder is None:
+            yield
+            return
+
+        folder = Path(scan_folder)
+        if not folder.is_dir():
+            logger.warning("Scan folder %s does not exist; skipping scan.log", folder)
+            yield
+            return
+
+        scan_id = f"Scan{scan_number:03d}"
+        handler = logging.FileHandler(folder / "scan.log", encoding="utf-8")
+        handler.setLevel(logging.INFO)
+        handler.setFormatter(
+            logging.Formatter(
+                "%(asctime)s.%(msecs)03d %(levelname)s %(name)s "
+                "[%(threadName)s] scan=%(scan_id)s - %(message)s",
+                datefmt="%Y-%m-%d %H:%M:%S",
+            )
+        )
+        handler.addFilter(_ScanLogContextFilter(scan_id))
+
+        package_logger = logging.getLogger("geecs_bluesky")
+        old_level = package_logger.level
+        if old_level == logging.NOTSET or old_level > logging.INFO:
+            package_logger.setLevel(logging.INFO)
+        package_logger.addHandler(handler)
+        try:
+            logger.info("scan %s: starting (dir=%s)", scan_id, scan_folder)
+            yield
+            logger.info("scan %s: finished", scan_id)
+        finally:
+            package_logger.removeHandler(handler)
+            handler.close()
+            package_logger.setLevel(old_level)
+
     def _export_scalar_files(self, scan_number: int) -> None:
         """Write legacy ScanData/s-file from the just-recorded Tiled run.
 
@@ -1111,10 +1163,16 @@ class BlueskyScanner:
         # Outer finalize ensures disarm even on mid-step abort
         if disarm is not None:
             plan = bpp.finalize_wrapper(plan, self._disarm_trigger())
-        self._set_state("RUNNING")
-        self._last_run_uid = None
-        self._RE(plan)
+        log_context = (
+            self._scan_log(scan_number, scan_folder)
+            if scan_number is not None and scan_folder is not None
+            else nullcontext()
+        )
+        with log_context:
+            self._set_state("RUNNING")
+            self._last_run_uid = None
+            self._RE(plan)
 
-        # After the run completes, export legacy scalar files from Tiled.
-        if scan_number is not None and scan_folder is not None:
-            self._export_scalar_files(scan_number)
+            # After the run completes, export legacy scalar files from Tiled.
+            if scan_number is not None and scan_folder is not None:
+                self._export_scalar_files(scan_number)

--- a/GeecsBluesky/geecs_bluesky/testing/fake_device_server.py
+++ b/GeecsBluesky/geecs_bluesky/testing/fake_device_server.py
@@ -28,6 +28,7 @@ Framing: 4-byte big-endian signed int length prefix + ASCII payload.
 from __future__ import annotations
 
 import asyncio
+import errno
 import logging
 import struct
 from dataclasses import dataclass, field
@@ -37,6 +38,19 @@ logger = logging.getLogger(__name__)
 
 _PUSH_HZ = 5.0
 _PUSH_INTERVAL = 1.0 / _PUSH_HZ
+
+
+async def _close_writer(writer: asyncio.StreamWriter, timeout: float = 1.0) -> None:
+    """Close a stream writer, aborting the transport if graceful close stalls."""
+    writer.close()
+    try:
+        await asyncio.wait_for(writer.wait_closed(), timeout=timeout)
+    except Exception:
+        transport = getattr(writer, "transport", None) or getattr(
+            writer, "_transport", None
+        )
+        if transport is not None:
+            transport.abort()
 
 
 # ---------------------------------------------------------------------------
@@ -230,8 +244,7 @@ class _TcpSubscriptionHandler:
                 await asyncio.sleep(_PUSH_INTERVAL)
         finally:
             try:
-                self._writer.close()
-                await self._writer.wait_closed()
+                await _close_writer(self._writer)
             except Exception:
                 pass
 
@@ -267,27 +280,45 @@ class FakeGeecsServer:
         self.port = port
         self._udp_transport: asyncio.DatagramTransport | None = None
         self._tcp_server: asyncio.Server | None = None
+        self._tcp_writers: set[asyncio.StreamWriter] = set()
+        self._tcp_handler_tasks: set[asyncio.Task[Any]] = set()
 
     async def start(self) -> None:
         """Start UDP and TCP listeners."""
         loop = asyncio.get_running_loop()
+        bind_attempts = 10 if self.port == 0 else 1
+        last_error: OSError | None = None
 
-        # UDP
-        udp_transport, _ = await loop.create_datagram_endpoint(
-            lambda: _GeecsUdpProtocol(self._device),
-            local_addr=(self.host, self.port),
-        )
-        self._udp_transport = udp_transport  # type: ignore[assignment]
-        udp_port = udp_transport.get_extra_info("sockname")[1]
+        for _attempt in range(bind_attempts):
+            udp_transport: asyncio.BaseTransport | None = None
+            try:
+                # UDP
+                udp_transport, _ = await loop.create_datagram_endpoint(
+                    lambda: _GeecsUdpProtocol(self._device),
+                    local_addr=(self.host, self.port),
+                )
+                udp_port = udp_transport.get_extra_info("sockname")[1]
 
-        # TCP on the same port number
-        self._tcp_server = await asyncio.start_server(
-            self._handle_tcp,
-            host=self.host,
-            port=udp_port,
-        )
+                # TCP on the same port number
+                self._tcp_server = await asyncio.start_server(
+                    self._handle_tcp,
+                    host=self.host,
+                    port=udp_port,
+                )
+                self._udp_transport = udp_transport  # type: ignore[assignment]
+                self.port = udp_port
+                break
+            except OSError as exc:
+                if udp_transport is not None:
+                    udp_transport.close()
+                if self.port != 0 or exc.errno != errno.EADDRINUSE:
+                    raise
+                last_error = exc
+                await asyncio.sleep(0)
+        else:
+            assert last_error is not None
+            raise last_error
 
-        self.port = udp_port
         logger.info(
             "FakeGeecsServer '%s' listening on %s:%s (UDP+TCP)",
             self._device.name,
@@ -296,20 +327,48 @@ class FakeGeecsServer:
         )
 
     async def stop(self) -> None:
-        """Shut down both listeners."""
+        """Shut down listeners and active TCP subscriptions."""
         if self._tcp_server is not None:
             self._tcp_server.close()
             await self._tcp_server.wait_closed()
+            self._tcp_server = None
+
+        writers = list(self._tcp_writers)
+        self._tcp_writers.clear()
+        if writers:
+            await asyncio.gather(
+                *(_close_writer(writer) for writer in writers),
+                return_exceptions=True,
+            )
+
+        handler_tasks = [
+            task
+            for task in self._tcp_handler_tasks
+            if task is not asyncio.current_task() and not task.done()
+        ]
+        if handler_tasks:
+            await asyncio.gather(*handler_tasks, return_exceptions=True)
+
         if self._udp_transport is not None:
             self._udp_transport.close()
+            self._udp_transport = None
 
     async def _handle_tcp(
         self,
         reader: asyncio.StreamReader,
         writer: asyncio.StreamWriter,
     ) -> None:
-        handler = _TcpSubscriptionHandler(self._device, reader, writer)
-        await handler.run()
+        task = asyncio.current_task()
+        if task is not None:
+            self._tcp_handler_tasks.add(task)
+        self._tcp_writers.add(writer)
+        try:
+            handler = _TcpSubscriptionHandler(self._device, reader, writer)
+            await handler.run()
+        finally:
+            self._tcp_writers.discard(writer)
+            if task is not None:
+                self._tcp_handler_tasks.discard(task)
 
     async def __aenter__(self) -> "FakeGeecsServer":
         """Start the server and return ``self``."""

--- a/GeecsBluesky/geecs_bluesky/transport/tcp_subscriber.py
+++ b/GeecsBluesky/geecs_bluesky/transport/tcp_subscriber.py
@@ -83,9 +83,13 @@ class GeecsTcpSubscriber:
         if self._writer is not None:
             try:
                 self._writer.close()
-                await self._writer.wait_closed()
+                await asyncio.wait_for(self._writer.wait_closed(), timeout=1.0)
             except Exception:
-                pass
+                transport = getattr(self._writer, "transport", None) or getattr(
+                    self._writer, "_transport", None
+                )
+                if transport is not None:
+                    transport.abort()
             self._writer = None
         self._reader = None
 

--- a/GeecsBluesky/geecs_bluesky/transport/udp_client.py
+++ b/GeecsBluesky/geecs_bluesky/transport/udp_client.py
@@ -22,6 +22,7 @@ connections (where the probed IP happens to be the default one anyway).
 from __future__ import annotations
 
 import asyncio
+import errno
 import logging
 import socket
 from typing import Any
@@ -160,26 +161,44 @@ class GeecsUdpClient:
 
         loop = asyncio.get_running_loop()
 
-        cmd_proto = _Oneshot()
-        cmd_transport, _ = await loop.create_datagram_endpoint(
-            lambda: cmd_proto,
-            local_addr=(self._local_host, 0),
-            family=socket.AF_INET,
-        )
-        self._cmd_transport = cmd_transport  # type: ignore[assignment]
-        self._cmd_proto = cmd_proto
-        self._cmd_port = cmd_transport.get_extra_info("sockname")[1]
+        last_error: OSError | None = None
+        for _attempt in range(10):
+            cmd_transport: asyncio.BaseTransport | None = None
+            try:
+                cmd_proto = _Oneshot()
+                cmd_transport, _ = await loop.create_datagram_endpoint(
+                    lambda: cmd_proto,
+                    local_addr=(self._local_host, 0),
+                    family=socket.AF_INET,
+                )
+                cmd_port = cmd_transport.get_extra_info("sockname")[1]
 
-        # exe socket binds to cmd_port + 1 — may fail if that port is taken.
-        exe_proto = _Oneshot()
-        exe_transport, _ = await loop.create_datagram_endpoint(
-            lambda: exe_proto,
-            local_addr=(self._local_host, self._cmd_port + 1),
-            family=socket.AF_INET,
-        )
-        self._exe_transport = exe_transport  # type: ignore[assignment]
-        self._exe_proto = exe_proto
-        self._exe_port = self._cmd_port + 1
+                # exe socket binds to cmd_port + 1 — may fail if that port is taken.
+                exe_proto = _Oneshot()
+                exe_transport, _ = await loop.create_datagram_endpoint(
+                    lambda: exe_proto,
+                    local_addr=(self._local_host, cmd_port + 1),
+                    family=socket.AF_INET,
+                )
+            except OSError as exc:
+                if cmd_transport is not None:
+                    cmd_transport.close()
+                if exc.errno != errno.EADDRINUSE:
+                    raise
+                last_error = exc
+                await asyncio.sleep(0)
+                continue
+
+            self._cmd_transport = cmd_transport  # type: ignore[assignment]
+            self._cmd_proto = cmd_proto
+            self._cmd_port = cmd_port
+            self._exe_transport = exe_transport  # type: ignore[assignment]
+            self._exe_proto = exe_proto
+            self._exe_port = cmd_port + 1
+            break
+        else:
+            assert last_error is not None
+            raise last_error
 
         logger.debug(
             "GeecsUdpClient bound: local=%s cmd=%s exe=%s → device %s:%s",

--- a/GeecsBluesky/poetry.lock
+++ b/GeecsBluesky/poetry.lock
@@ -2297,6 +2297,21 @@ docs = ["sphinx (>=5.3)", "sphinx-rtd-theme (>=1)"]
 testing = ["coverage (>=6.2)", "hypothesis (>=5.7.1)"]
 
 [[package]]
+name = "pytest-timeout"
+version = "2.4.0"
+description = "pytest plugin to abort hanging tests"
+optional = false
+python-versions = ">=3.7"
+groups = ["dev"]
+files = [
+    {file = "pytest_timeout-2.4.0-py3-none-any.whl", hash = "sha256:c42667e5cdadb151aeb5b26d114aff6bdf5a907f176a007a30b940d3d865b5c2"},
+    {file = "pytest_timeout-2.4.0.tar.gz", hash = "sha256:7e68e90b01f9eff71332b25001f85c75495fc4e3a836701876183c4bcfd0540a"},
+]
+
+[package.dependencies]
+pytest = ">=7.0.0"
+
+[[package]]
 name = "python-dateutil"
 version = "2.9.0.post0"
 description = "Extensions to the standard Python datetime module"
@@ -3374,4 +3389,4 @@ tiled = ["tiled"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<3.12"
-content-hash = "7adbe80e0abba1293d6d32030dba18b8a8ddc6ed7e9f865e6ee5bb182aae8867"
+content-hash = "8098c5c54f60f5f7f353cf2c2475b8b5348fe3601a2b969984da15fe12cbda9c"

--- a/GeecsBluesky/pyproject.toml
+++ b/GeecsBluesky/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-bluesky"
-version = "0.11.0"
+version = "0.11.1"
 description = "Bluesky / ophyd-async bridge for the GEECS control system"
 authors = ["Sam Barber <sbarber@lbl.gov>"]
 readme = "README.md"
@@ -41,4 +41,6 @@ build-backend = "poetry.core.masonry.api"
 asyncio_mode = "auto"
 markers = [
     "integration: tests that touch external lab services such as the GEECS database",
+    "hardware: tests that require live GEECS devices",
+    "fake_server: tests that use local FakeGeecsServer TCP/UDP sockets",
 ]

--- a/GeecsBluesky/pyproject.toml
+++ b/GeecsBluesky/pyproject.toml
@@ -32,6 +32,7 @@ tiled = ["tiled"]
 [tool.poetry.group.dev.dependencies]
 pytest = ">=7.0"
 pytest-asyncio = ">=0.23"
+pytest-timeout = "^2.4.0"
 
 [build-system]
 requires = ["poetry-core"]

--- a/GeecsBluesky/test_bluesky_scanner.py
+++ b/GeecsBluesky/test_bluesky_scanner.py
@@ -23,6 +23,8 @@ import logging
 import time
 from types import SimpleNamespace
 
+import pytest
+
 from geecs_bluesky.scanner_bridge import BlueskyScanner
 
 logging.basicConfig(level=logging.INFO, format="%(name)s %(levelname)s %(message)s")
@@ -81,21 +83,6 @@ def _make_exec_config(
     )
 
 
-passed: list[str] = []
-failed: list[str] = []
-
-
-def check(label: str, condition: bool, detail: str = "") -> None:
-    """Print pass/fail and accumulate results."""
-    if condition:
-        print(f"  ✓  {label}")
-        passed.append(label)
-    else:
-        msg = label + (f" — {detail}" if detail else "")
-        print(f"  ✗  {msg}")
-        failed.append(msg)
-
-
 def poll(scanner: BlueskyScanner) -> None:
     """Block until the scanner finishes, printing progress."""
     while scanner.is_scanning_active():
@@ -105,135 +92,157 @@ def poll(scanner: BlueskyScanner) -> None:
     print()
 
 
-# ---------------------------------------------------------------------------
-# Scenario 1: NOSCAN (no shot control)
-# ---------------------------------------------------------------------------
-print("\n=== Scenario 1: NOSCAN — UC_TopView, no shot control ===")
+def run_hardware_scan_checks() -> list[str]:
+    """Run the hardware checks and return any failed labels."""
+    passed: list[str] = []
+    failed: list[str] = []
 
-scanner1 = BlueskyScanner(experiment_dir="Undulator")
-scanner1.reinitialize(
-    exec_config=_make_exec_config(
-        "noscan",
-        description="BlueskyScanner NOSCAN test",
+    def check(label: str, condition: bool, detail: str = "") -> None:
+        """Print pass/fail and accumulate results."""
+        if condition:
+            print(f"  ✓  {label}")
+            passed.append(label)
+        else:
+            msg = label + (f" — {detail}" if detail else "")
+            print(f"  ✗  {msg}")
+            failed.append(msg)
+
+    # -----------------------------------------------------------------------
+    # Scenario 1: NOSCAN (no shot control)
+    # -----------------------------------------------------------------------
+    print("\n=== Scenario 1: NOSCAN — UC_TopView, no shot control ===")
+
+    scanner1 = BlueskyScanner(experiment_dir="Undulator")
+    scanner1.reinitialize(
+        exec_config=_make_exec_config(
+            "noscan",
+            description="BlueskyScanner NOSCAN test",
+        )
     )
-)
-scanner1.start_scan_thread()
-poll(scanner1)
+    scanner1.start_scan_thread()
+    poll(scanner1)
 
-check(
-    "NOSCAN: event count",
-    scanner1._completed_shots == SHOTS_PER_STEP,
-    f"expected {SHOTS_PER_STEP}, got {scanner1._completed_shots}",
-)
-
-# ---------------------------------------------------------------------------
-# Scenario 2: STANDARD step scan (no shot control)
-# ---------------------------------------------------------------------------
-print("\n=== Scenario 2: STANDARD — JetXYZ 4→5 mm, UC_TopView ===")
-
-POSITIONS = 3  # 4.0, 4.5, 5.0
-EXPECTED = POSITIONS * SHOTS_PER_STEP
-
-scanner2 = BlueskyScanner(experiment_dir="Undulator")
-events2: list[dict] = []
-scanner2._RE.subscribe(
-    lambda name, doc: events2.append(doc) if name == "event" else None
-)
-
-scanner2.reinitialize(
-    exec_config=_make_exec_config(
-        "standard",
-        device_var="U_ESP_JetXYZ:Position.Axis 1",
-        start=4.0,
-        end=5.0,
-        step=0.5,
-        description="BlueskyScanner STANDARD test",
-    )
-)
-scanner2.start_scan_thread()
-poll(scanner2)
-
-check(
-    "STANDARD: event count",
-    len(events2) == EXPECTED,
-    f"expected {EXPECTED}, got {len(events2)}",
-)
-motor_key = next(
-    (k for k in (events2[0]["data"] if events2 else {}) if "position" in k), None
-)
-check(
-    "STANDARD: motor readback in every event",
-    motor_key is not None and all(motor_key in e["data"] for e in events2),
-)
-check(
-    "STANDARD: acq_timestamp in every event",
-    all(any("acq_timestamp" in k for k in e["data"]) for e in events2),
-)
-
-# ---------------------------------------------------------------------------
-# Scenario 3: NOSCAN with shot control (U_DG645_ShotControl)
-# ---------------------------------------------------------------------------
-print("\n=== Scenario 3: NOSCAN with shot control (U_DG645_ShotControl) ===")
-
-scanner3 = BlueskyScanner(
-    experiment_dir="Undulator",
-    shot_control_information=SHOT_CONTROL_INFO,
-)
-scanner3.reinitialize(
-    exec_config=_make_exec_config(
-        "noscan",
-        description="BlueskyScanner shot-control test",
-    )
-)
-
-# Subscribe to see what's happening
-events3: list[dict] = []
-scanner3._RE.subscribe(
-    lambda name, doc: events3.append(doc) if name == "event" else None
-)
-
-scanner3.start_scan_thread()
-poll(scanner3)
-
-check(
-    "SHOT CTRL NOSCAN: event count",
-    scanner3._completed_shots == SHOTS_PER_STEP,
-    f"expected {SHOTS_PER_STEP}, got {scanner3._completed_shots}",
-)
-
-# Verify DG645 returned to STANDBY after scan.
-# Query the device directly via its UDP client (re-use geecs_data_utils DB lookup).
-try:
-    import asyncio
-
-    from geecs_bluesky.db.geecs_db import GeecsDb
-    from geecs_bluesky.transport.udp_client import GeecsUdpClient
-
-    host, port = GeecsDb.find_device("U_DG645_ShotControl")
-    udp = GeecsUdpClient(host, port, device_name="U_DG645_ShotControl")
-
-    async def _read_trigger_source() -> str:
-        await udp.connect()
-        val = await udp.get("Trigger.Source")
-        await udp.close()
-        return str(val)
-
-    trigger_source = asyncio.run(_read_trigger_source())
-    print(f"  DG645 Trigger.Source after scan: {trigger_source!r}")
     check(
-        "SHOT CTRL NOSCAN: Trigger.Source returned to STANDBY value",
-        trigger_source == "External rising edges",
-        f"got {trigger_source!r}",
+        "NOSCAN: event count",
+        scanner1._completed_shots == SHOTS_PER_STEP,
+        f"expected {SHOTS_PER_STEP}, got {scanner1._completed_shots}",
     )
-except Exception as exc:
-    print(f"  Could not verify DG645 state: {exc}")
-    failed.append("SHOT CTRL NOSCAN: DG645 post-scan readback (exception)")
 
-# ---------------------------------------------------------------------------
-# Summary
-# ---------------------------------------------------------------------------
-print(f"\n=== Results: {len(passed)} passed, {len(failed)} failed ===")
-for f in failed:
-    print(f"  FAILED: {f}")
-if not failed:
-    print("ALL CHECKS PASSED")
+    # -----------------------------------------------------------------------
+    # Scenario 2: STANDARD step scan (no shot control)
+    # -----------------------------------------------------------------------
+    print("\n=== Scenario 2: STANDARD — JetXYZ 4→5 mm, UC_TopView ===")
+
+    positions = 3  # 4.0, 4.5, 5.0
+    expected = positions * SHOTS_PER_STEP
+
+    scanner2 = BlueskyScanner(experiment_dir="Undulator")
+    events2: list[dict] = []
+    scanner2._RE.subscribe(
+        lambda name, doc: events2.append(doc) if name == "event" else None
+    )
+
+    scanner2.reinitialize(
+        exec_config=_make_exec_config(
+            "standard",
+            device_var="U_ESP_JetXYZ:Position.Axis 1",
+            start=4.0,
+            end=5.0,
+            step=0.5,
+            description="BlueskyScanner STANDARD test",
+        )
+    )
+    scanner2.start_scan_thread()
+    poll(scanner2)
+
+    check(
+        "STANDARD: event count",
+        len(events2) == expected,
+        f"expected {expected}, got {len(events2)}",
+    )
+    motor_key = next(
+        (k for k in (events2[0]["data"] if events2 else {}) if "position" in k),
+        None,
+    )
+    check(
+        "STANDARD: motor readback in every event",
+        motor_key is not None and all(motor_key in e["data"] for e in events2),
+    )
+    check(
+        "STANDARD: acq_timestamp in every event",
+        all(any("acq_timestamp" in k for k in e["data"]) for e in events2),
+    )
+
+    # -----------------------------------------------------------------------
+    # Scenario 3: NOSCAN with shot control (U_DG645_ShotControl)
+    # -----------------------------------------------------------------------
+    print("\n=== Scenario 3: NOSCAN with shot control (U_DG645_ShotControl) ===")
+
+    scanner3 = BlueskyScanner(
+        experiment_dir="Undulator",
+        shot_control_information=SHOT_CONTROL_INFO,
+    )
+    scanner3.reinitialize(
+        exec_config=_make_exec_config(
+            "noscan",
+            description="BlueskyScanner shot-control test",
+        )
+    )
+
+    events3: list[dict] = []
+    scanner3._RE.subscribe(
+        lambda name, doc: events3.append(doc) if name == "event" else None
+    )
+
+    scanner3.start_scan_thread()
+    poll(scanner3)
+
+    check(
+        "SHOT CTRL NOSCAN: event count",
+        scanner3._completed_shots == SHOTS_PER_STEP,
+        f"expected {SHOTS_PER_STEP}, got {scanner3._completed_shots}",
+    )
+
+    try:
+        import asyncio
+
+        from geecs_bluesky.db.geecs_db import GeecsDb
+        from geecs_bluesky.transport.udp_client import GeecsUdpClient
+
+        host, port = GeecsDb.find_device("U_DG645_ShotControl")
+        udp = GeecsUdpClient(host, port, device_name="U_DG645_ShotControl")
+
+        async def _read_trigger_source() -> str:
+            await udp.connect()
+            val = await udp.get("Trigger.Source")
+            await udp.close()
+            return str(val)
+
+        trigger_source = asyncio.run(_read_trigger_source())
+        print(f"  DG645 Trigger.Source after scan: {trigger_source!r}")
+        check(
+            "SHOT CTRL NOSCAN: Trigger.Source returned to STANDBY value",
+            trigger_source == "External rising edges",
+            f"got {trigger_source!r}",
+        )
+    except Exception as exc:
+        print(f"  Could not verify DG645 state: {exc}")
+        failed.append("SHOT CTRL NOSCAN: DG645 post-scan readback (exception)")
+
+    print(f"\n=== Results: {len(passed)} passed, {len(failed)} failed ===")
+    for failure in failed:
+        print(f"  FAILED: {failure}")
+    if not failed:
+        print("ALL CHECKS PASSED")
+    return failed
+
+
+@pytest.mark.integration
+@pytest.mark.hardware
+def test_bluesky_scanner_hardware_integration() -> None:
+    """Run the real-lab BlueskyScanner hardware smoke checks."""
+    assert not run_hardware_scan_checks()
+
+
+if __name__ == "__main__":
+    raise SystemExit(1 if run_hardware_scan_checks() else 0)

--- a/GeecsBluesky/test_bluesky_scanner.py
+++ b/GeecsBluesky/test_bluesky_scanner.py
@@ -13,19 +13,27 @@ Scenarios
              Verifies: N positions × M shots events, motor readback in each event.
 3. NOSCAN with shot control — as scenario 1 but with U_DG645_ShotControl wired;
              Verifies: DG645 Trigger.Source returns to STANDBY after scan.
+4. Full-output STANDARD — opt-in scan with native camera saving enabled.
+             Verifies: scan folder, ScanInfo, scan.log, scalar files, s-file,
+             saved images, and event save-path metadata.
 
 Run from GeecsBluesky/:
     poetry run python test_bluesky_scanner.py
     GEECS_BLUESKY_TEST_CAMERA=UC_Amp2_IR_input poetry run python test_bluesky_scanner.py
     poetry run pytest test_bluesky_scanner.py -m "integration and hardware" -v
+    poetry install --extras tiled
+    GEECS_BLUESKY_TEST_CAMERA=UC_Amp2_IR_input GEECS_BLUESKY_FULL_OUTPUT_TEST=1 \
+        poetry run pytest test_bluesky_scanner.py::test_bluesky_scanner_full_output_hardware_integration -v -s
 """
 
 from __future__ import annotations
 
 import asyncio
+import importlib.util
 import logging
 import os
 import time
+from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
@@ -80,6 +88,7 @@ def _make_exec_config(
     end: float = 1.0,
     step: float = 0.5,
     description: str = "",
+    detector_devices: dict | None = None,
 ) -> SimpleNamespace:
     """Build a fully duck-typed ScanExecutionConfig — no geecs_scanner import needed."""
     scan_config = SimpleNamespace(
@@ -94,7 +103,7 @@ def _make_exec_config(
     return SimpleNamespace(
         scan_config=scan_config,
         options=SimpleNamespace(rep_rate_hz=REP_RATE_HZ),
-        save_config=SimpleNamespace(Devices=DETECTOR_DEVICES),
+        save_config=SimpleNamespace(Devices=detector_devices or DETECTOR_DEVICES),
     )
 
 
@@ -270,11 +279,177 @@ def run_hardware_scan_checks() -> list[str]:
     return failed
 
 
+def _analysis_sfile_for(scan_folder: Path) -> Path:
+    scan_number = int(scan_folder.name.removeprefix("Scan"))
+    parts = list(scan_folder.parts)
+    parts[-2] = "analysis"
+    return Path(*parts[:-1]) / f"s{scan_number}.txt"
+
+
+def _wait_for_nonempty_files(
+    folder: Path, *, since: float, timeout: float = 15.0
+) -> list[Path]:
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        files = [
+            path
+            for path in folder.rglob("*")
+            if path.is_file()
+            and path.stat().st_size > 0
+            and path.stat().st_mtime >= since - 1.0
+        ]
+        if files:
+            return sorted(files)
+        time.sleep(0.5)
+    return []
+
+
+def _has_tiled_client() -> bool:
+    """Return whether the Tiled client needed for scalar export is installed."""
+    try:
+        return importlib.util.find_spec("tiled.client") is not None
+    except ModuleNotFoundError:
+        return False
+
+
+def run_hardware_full_output_checks() -> list[str]:
+    """Run one live scan and verify on-disk scan artifacts."""
+    passed: list[str] = []
+    failed: list[str] = []
+
+    def check(label: str, condition: bool, detail: str = "") -> None:
+        if condition:
+            print(f"  ✓  {label}")
+            passed.append(label)
+        else:
+            msg = label + (f" — {detail}" if detail else "")
+            print(f"  ✗  {msg}")
+            failed.append(msg)
+
+    if not _has_tiled_client():
+        check(
+            "FULL OUTPUT: Tiled client dependency is installed",
+            False,
+            "run `poetry install --extras tiled` before enabling "
+            "GEECS_BLUESKY_FULL_OUTPUT_TEST=1",
+        )
+        return failed
+
+    if not preflight_hardware():
+        return ["hardware preflight"]
+
+    print(
+        f"\n=== Full-output STANDARD scan: U_ESP_JetXYZ fixed at 4 mm, "
+        f"{TEST_CAMERA_DEVICE} saving enabled ==="
+    )
+
+    detector_devices = {
+        TEST_CAMERA_DEVICE: {
+            "variable_list": ["acq_timestamp"],
+            "synchronous": True,
+            "save_nonscalar_data": True,
+        },
+    }
+    scanner = BlueskyScanner(experiment_dir="Undulator")
+    events: list[dict] = []
+    scanner._RE.subscribe(
+        lambda name, doc: events.append(doc) if name == "event" else None
+    )
+    scanner.reinitialize(
+        exec_config=_make_exec_config(
+            "standard",
+            device_var="U_ESP_JetXYZ:Position.Axis 1",
+            start=4.0,
+            end=4.0,
+            step=0.5,
+            description="BlueskyScanner full-output hardware test",
+            detector_devices=detector_devices,
+        )
+    )
+
+    started_at = time.time()
+    scanner.start_scan_thread()
+    poll(scanner)
+
+    check(
+        "FULL OUTPUT: event count",
+        len(events) == SHOTS_PER_STEP,
+        f"expected {SHOTS_PER_STEP}, got {len(events)}",
+    )
+    save_path = scanner._nonscalar_save_paths.get(TEST_CAMERA_DEVICE)
+    check(
+        "FULL OUTPUT: scanner configured native-save path",
+        bool(save_path),
+    )
+    if not save_path:
+        return failed
+
+    camera_folder = Path(save_path)
+    scan_folder = camera_folder.parent
+    scan_number = int(scan_folder.name.removeprefix("Scan"))
+    scan_data_file = scan_folder / f"ScanDataScan{scan_number:03d}.txt"
+    analysis_sfile = _analysis_sfile_for(scan_folder)
+    scan_info = scan_folder / f"ScanInfo{scan_folder.name}.ini"
+    scan_log = scan_folder / "scan.log"
+
+    native_files = _wait_for_nonempty_files(camera_folder, since=started_at)
+    print(f"  scan folder: {scan_folder}")
+    print(f"  native camera folder: {camera_folder}")
+    for path in native_files:
+        print(f"  native file: {path}")
+
+    check("FULL OUTPUT: scan folder exists", scan_folder.is_dir(), str(scan_folder))
+    check("FULL OUTPUT: ScanInfo ini exists", scan_info.is_file(), str(scan_info))
+    check(
+        "FULL OUTPUT: scan.log exists",
+        scan_log.is_file() and scan_log.stat().st_size > 0,
+        str(scan_log),
+    )
+    check(
+        "FULL OUTPUT: ScanData scalar file exists",
+        scan_data_file.is_file() and scan_data_file.stat().st_size > 0,
+        str(scan_data_file),
+    )
+    check(
+        "FULL OUTPUT: analysis s-file exists",
+        analysis_sfile.is_file() and analysis_sfile.stat().st_size > 0,
+        str(analysis_sfile),
+    )
+    check(
+        "FULL OUTPUT: native camera files saved",
+        bool(native_files),
+        str(camera_folder),
+    )
+    check(
+        "FULL OUTPUT: nonscalar save path in events",
+        all(
+            any("nonscalar_save_path" in key for key in event["data"])
+            for event in events
+        ),
+    )
+
+    print(f"\n=== Full-output results: {len(passed)} passed, {len(failed)} failed ===")
+    for failure in failed:
+        print(f"  FAILED: {failure}")
+    if not failed:
+        print("ALL FULL-OUTPUT CHECKS PASSED")
+    return failed
+
+
 @pytest.mark.integration
 @pytest.mark.hardware
 def test_bluesky_scanner_hardware_integration() -> None:
     """Run the real-lab BlueskyScanner hardware smoke checks."""
     assert not run_hardware_scan_checks()
+
+
+@pytest.mark.integration
+@pytest.mark.hardware
+def test_bluesky_scanner_full_output_hardware_integration() -> None:
+    """Run a real scan and verify scan folder, scalar, log, and native files."""
+    if os.environ.get("GEECS_BLUESKY_FULL_OUTPUT_TEST") != "1":
+        pytest.skip("set GEECS_BLUESKY_FULL_OUTPUT_TEST=1 to run full-output scan")
+    assert not run_hardware_full_output_checks()
 
 
 if __name__ == "__main__":

--- a/GeecsBluesky/tests/conftest.py
+++ b/GeecsBluesky/tests/conftest.py
@@ -1,0 +1,15 @@
+"""Shared pytest configuration for GeecsBluesky tests."""
+
+from __future__ import annotations
+
+import pytest
+
+
+def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
+    """Bound fake-server tests so socket/thread leaks fail fast."""
+    timeout = pytest.mark.timeout(30)
+    for item in items:
+        if item.get_closest_marker("fake_server") and not item.get_closest_marker(
+            "timeout"
+        ):
+            item.add_marker(timeout)

--- a/GeecsBluesky/tests/fake_server_helpers.py
+++ b/GeecsBluesky/tests/fake_server_helpers.py
@@ -1,0 +1,136 @@
+"""Helpers for bounded fake-server tests."""
+
+from __future__ import annotations
+
+import asyncio
+import queue
+import threading
+from collections.abc import Callable, Sequence
+from contextlib import AbstractContextManager, AsyncExitStack
+from types import TracebackType
+from typing import Any
+
+from bluesky import RunEngine
+from ophyd_async.core import Device
+
+from geecs_bluesky.testing.fake_device_server import FakeGeecsDevice, FakeGeecsServer
+
+FireCallback = Callable[[Sequence[FakeGeecsDevice]], None]
+
+
+class BackgroundFakeServers(AbstractContextManager["BackgroundFakeServers"]):
+    """Run one or more fake servers in a stoppable background thread."""
+
+    def __init__(
+        self,
+        devices: FakeGeecsDevice | Sequence[FakeGeecsDevice],
+        *,
+        fire: FireCallback | None = None,
+        initial_delay: float = 0.0,
+        interval: float = 0.1,
+        startup_timeout: float = 5.0,
+        shutdown_timeout: float = 5.0,
+    ) -> None:
+        self._devices = (
+            [devices] if isinstance(devices, FakeGeecsDevice) else list(devices)
+        )
+        self._fire = fire
+        self._initial_delay = initial_delay
+        self._interval = interval
+        self._startup_timeout = startup_timeout
+        self._shutdown_timeout = shutdown_timeout
+        self._ready = threading.Event()
+        self._stop = threading.Event()
+        self._errors: queue.SimpleQueue[BaseException] = queue.SimpleQueue()
+        self._thread = threading.Thread(
+            target=self._run,
+            name="fake-geecs-server",
+            daemon=True,
+        )
+        self.endpoints: list[tuple[str, int]] = []
+
+    @property
+    def endpoint(self) -> tuple[str, int]:
+        """Return the first server endpoint."""
+        return self.endpoints[0]
+
+    def __enter__(self) -> "BackgroundFakeServers":
+        self._thread.start()
+        if not self._ready.wait(timeout=self._startup_timeout):
+            self._stop.set()
+            self._thread.join(timeout=self._shutdown_timeout)
+            self._raise_thread_error()
+            raise TimeoutError("FakeGeecsServer failed to start")
+        self._raise_thread_error()
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> bool | None:
+        self._stop.set()
+        self._thread.join(timeout=self._shutdown_timeout)
+        if self._thread.is_alive() and exc_type is None:
+            raise TimeoutError("FakeGeecsServer thread failed to stop")
+        if exc_type is None:
+            self._raise_thread_error()
+        return None
+
+    def _run(self) -> None:
+        try:
+            asyncio.run(self._main())
+        except BaseException as exc:
+            self._errors.put(exc)
+            self._ready.set()
+
+    async def _main(self) -> None:
+        async with AsyncExitStack() as stack:
+            servers = [
+                await stack.enter_async_context(FakeGeecsServer(device))
+                for device in self._devices
+            ]
+            self.endpoints = [(server.host, server.port) for server in servers]
+            self._ready.set()
+
+            if self._initial_delay:
+                await self._sleep_until_stopped(self._initial_delay)
+
+            while not self._stop.is_set():
+                if self._fire is not None:
+                    self._fire(self._devices)
+                await self._sleep_until_stopped(self._interval)
+
+    async def _sleep_until_stopped(self, duration: float) -> None:
+        loop = asyncio.get_running_loop()
+        deadline = loop.time() + duration
+        while not self._stop.is_set():
+            remaining = deadline - loop.time()
+            if remaining <= 0:
+                return
+            await asyncio.sleep(min(remaining, 0.05))
+
+    def _raise_thread_error(self) -> None:
+        try:
+            error = self._errors.get_nowait()
+        except queue.Empty:
+            return
+        raise RuntimeError("FakeGeecsServer thread failed") from error
+
+
+def connect_devices(re: RunEngine, *devices: Device, timeout: float = 10.0) -> None:
+    """Connect devices on the RunEngine event loop."""
+    for device in devices:
+        asyncio.run_coroutine_threadsafe(device.connect(), re._loop).result(
+            timeout=timeout
+        )
+
+
+def disconnect_devices(re: RunEngine, *devices: Any, timeout: float = 10.0) -> None:
+    """Best-effort disconnect for devices connected on the RunEngine loop."""
+    for device in devices:
+        disconnect = getattr(device, "disconnect", None)
+        if disconnect is None:
+            continue
+        asyncio.run_coroutine_threadsafe(disconnect(), re._loop).result(timeout=timeout)

--- a/GeecsBluesky/tests/test_count_plan.py
+++ b/GeecsBluesky/tests/test_count_plan.py
@@ -19,6 +19,8 @@ from geecs_bluesky.signals import geecs_signal_r, geecs_signal_rw
 from geecs_bluesky.testing.fake_device_server import FakeGeecsDevice, FakeGeecsServer
 from geecs_bluesky.transport.udp_client import GeecsUdpClient
 
+pytestmark = pytest.mark.fake_server
+
 _DEV = "U_TestDevice"
 
 

--- a/GeecsBluesky/tests/test_count_plan.py
+++ b/GeecsBluesky/tests/test_count_plan.py
@@ -8,7 +8,6 @@ Two levels of testing:
 from __future__ import annotations
 
 import asyncio
-import threading
 
 import pytest
 import bluesky.plans as bp
@@ -18,6 +17,11 @@ from geecs_bluesky.devices.geecs_device import GeecsDevice
 from geecs_bluesky.signals import geecs_signal_r, geecs_signal_rw
 from geecs_bluesky.testing.fake_device_server import FakeGeecsDevice, FakeGeecsServer
 from geecs_bluesky.transport.udp_client import GeecsUdpClient
+from tests.fake_server_helpers import (
+    BackgroundFakeServers,
+    connect_devices,
+    disconnect_devices,
+)
 
 pytestmark = pytest.mark.fake_server
 
@@ -139,70 +143,23 @@ class TestDeviceAPI:
             assert "fake_motor-position" in reading
 
 
-# ---------------------------------------------------------------------------
-# RunEngine integration test (synchronous, server in background thread)
-# ---------------------------------------------------------------------------
-
-
-def _run_server(
-    device: FakeGeecsDevice, ready: threading.Event, host_port: list
-) -> None:
-    """Target for the background thread: run the fake server until stop is requested."""
-
-    async def _main() -> None:
-        async with FakeGeecsServer(device) as srv:
-            host_port.extend([srv.host, srv.port])
-            ready.set()
-            # Run until cancelled from outside
-            try:
-                await asyncio.Event().wait()
-            except asyncio.CancelledError:
-                pass
-
-    loop = asyncio.new_event_loop()
-    task_holder: list[asyncio.Task] = []
-
-    async def _wrapper() -> None:
-        task = loop.create_task(_main())
-        task_holder.append(task)
-        await task
-
-    try:
-        loop.run_until_complete(_wrapper())
-    except Exception:
-        pass
-    finally:
-        loop.close()
-
-
 def test_bluesky_count_plan(sim_device: FakeGeecsDevice) -> None:
     """Smoke test: ``count([motor], num=3)`` collects 3 events."""
-    ready = threading.Event()
-    host_port: list = []
+    with BackgroundFakeServers(sim_device) as server:
+        host, port = server.endpoint
+        motor = FakeMotor(host, port)
 
-    srv_thread = threading.Thread(
-        target=_run_server,
-        args=(sim_device, ready, host_port),
-        daemon=True,
-    )
-    srv_thread.start()
-    ready.wait(timeout=5.0)
-    assert host_port, "Server failed to start"
+        events: list[dict] = []
+        RE = RunEngine()
+        RE.subscribe(lambda name, doc: events.append(doc) if name == "event" else None)
 
-    host, port = host_port[0], host_port[1]
+        connect_devices(RE, motor)
+        try:
+            RE(bp.count([motor], num=3))
+        finally:
+            disconnect_devices(RE, motor)
 
-    # Connect the device in its own event loop (ophyd-async requires this)
-    motor = FakeMotor(host, port)
-    asyncio.run(motor.connect())
-
-    # Collect data
-    events: list[dict] = []
-    RE = RunEngine()
-    RE.subscribe(lambda name, doc: events.append(doc) if name == "event" else None)
-
-    RE(bp.count([motor], num=3))
-
-    assert len(events) == 3, f"Expected 3 events, got {len(events)}"
-    for ev in events:
-        assert "fake_motor-position" in ev["data"]
-        assert "fake_motor-velocity" in ev["data"]
+        assert len(events) == 3, f"Expected 3 events, got {len(events)}"
+        for ev in events:
+            assert "fake_motor-position" in ev["data"]
+            assert "fake_motor-velocity" in ev["data"]

--- a/GeecsBluesky/tests/test_free_run_plan.py
+++ b/GeecsBluesky/tests/test_free_run_plan.py
@@ -9,9 +9,7 @@ static pre-scan caches.
 
 from __future__ import annotations
 
-import asyncio
 import math
-import threading
 
 import bluesky.plan_stubs as bps
 import pytest
@@ -22,49 +20,17 @@ from geecs_bluesky.devices.motor import GeecsMotor
 from geecs_bluesky.devices.snapshot import GeecsSnapshotReadable
 from geecs_bluesky.devices.timestamped_readable import GeecsTimestampedReadable
 from geecs_bluesky.plans.free_run_step_scan import geecs_free_run_step_scan
-from geecs_bluesky.testing.fake_device_server import FakeGeecsDevice, FakeGeecsServer
+from geecs_bluesky.testing.fake_device_server import FakeGeecsDevice
+from tests.fake_server_helpers import (
+    BackgroundFakeServers,
+    connect_devices,
+    disconnect_devices,
+)
 
 pytestmark = pytest.mark.fake_server
 
 REF_T0 = 1000.0
 CAM_T0 = 1000.05
-
-
-def _run_servers_with_firer(
-    fake_ref: FakeGeecsDevice,
-    fake_cam: FakeGeecsDevice,
-    ready: threading.Event,
-    host_port: list,
-    fire_cam: bool = True,
-    initial_delay: float = 1.0,
-    interval: float = 0.3,
-) -> None:
-    """Thread target: serve both fakes; fire shots together after a delay."""
-
-    async def _main() -> None:
-        async with (
-            FakeGeecsServer(fake_ref) as s_ref,
-            FakeGeecsServer(fake_cam) as s_cam,
-        ):
-            host_port.extend([s_ref.host, s_ref.port, s_cam.host, s_cam.port])
-            ready.set()
-            try:
-                await asyncio.sleep(initial_delay)
-                while True:
-                    fake_ref.fire_shot()
-                    if fire_cam:
-                        fake_cam.fire_shot()
-                    await asyncio.sleep(interval)
-            except asyncio.CancelledError:
-                pass
-
-    loop = asyncio.new_event_loop()
-    try:
-        loop.run_until_complete(_main())
-    except Exception:
-        pass
-    finally:
-        loop.close()
 
 
 def _run_free_run_scan(
@@ -87,29 +53,11 @@ def _run_free_run_scan(
         name="U_Cam",
         variables={"Val": 2.0, "acq_timestamp": CAM_T0},
     )
-    ready = threading.Event()
-    host_port: list = []
-    srv_thread = threading.Thread(
-        target=_run_servers_with_firer,
-        args=(fake_ref, fake_cam, ready, host_port),
-        kwargs={"fire_cam": fire_cam},
-        daemon=True,
-    )
-    srv_thread.start()
-    ready.wait(timeout=5.0)
-    assert len(host_port) == 4, "Servers failed to start"
-    ref_host, ref_port, cam_host, cam_port = host_port
 
-    motor = GeecsMotor("U_Ref", "Position (mm)", ref_host, ref_port, name="scan_motor")
-    ref = GeecsGenericDetector("U_Ref", ["Sig"], ref_host, ref_port, name="ref")
-    cam = GeecsTimestampedReadable("U_Cam", ["Val"], cam_host, cam_port, name="cam")
-    snapshot = GeecsSnapshotReadable(
-        "U_Ref", ["Position (mm)"], ref_host, ref_port, name="async_snapshot"
-    )
-    ref.configure_shot_id(rep_rate_hz=1.0)
-    cam.configure_shot_id(rep_rate_hz=1.0)
-    if not fire_cam:
-        cam.set_reference(ref, grace_wait_s=0.05)  # don't pay grace on a dead camera
+    def fire(devices: list[FakeGeecsDevice]) -> None:
+        devices[0].fire_shot()
+        if fire_cam:
+            devices[1].fire_shot()
 
     descriptors: dict[str, str] = {}  # descriptor uid → stream name
     primary_events: list[dict] = []
@@ -125,33 +73,64 @@ def _run_free_run_scan(
             stream = descriptors.get(doc["descriptor"], "")
             (flush_events if stream == "flush" else primary_events).append(doc)
 
-    RE = RunEngine()
-    RE.subscribe(collect)
-    for dev in (motor, ref, cam, snapshot):
-        asyncio.run_coroutine_threadsafe(dev.connect(), RE._loop).result(timeout=10)
+    with BackgroundFakeServers(
+        [fake_ref, fake_cam],
+        fire=fire,
+        initial_delay=1.0,
+        interval=0.3,
+    ) as server:
+        (ref_host, ref_port), (cam_host, cam_port) = server.endpoints
 
-    if statistics:
-        plan_motor, positions, shots = None, [None], 4
-    else:
-        plan_motor, positions, shots = motor, [0.0, 1.0], 2
-
-    quiesce = None
-    if quiesce_log is not None:
-
-        def quiesce():
-            quiesce_log.append("quiesced")
-            yield from bps.null()
-
-    RE(
-        geecs_free_run_step_scan(
-            motor=plan_motor,
-            positions=positions,
-            reference=ref,
-            detectors=[cam, snapshot],
-            shots_per_step=shots,
-            quiesce_trigger=quiesce,
+        motor = GeecsMotor(
+            "U_Ref", "Position (mm)", ref_host, ref_port, name="scan_motor"
         )
-    )
+        ref = GeecsGenericDetector("U_Ref", ["Sig"], ref_host, ref_port, name="ref")
+        cam = GeecsTimestampedReadable("U_Cam", ["Val"], cam_host, cam_port, name="cam")
+        snapshot = GeecsSnapshotReadable(
+            "U_Ref", ["Position (mm)"], ref_host, ref_port, name="async_snapshot"
+        )
+        ref.configure_shot_id(rep_rate_hz=1.0)
+        cam.configure_shot_id(rep_rate_hz=1.0)
+        if not fire_cam:
+            cam.set_reference(
+                ref, grace_wait_s=0.05
+            )  # don't pay grace on a dead camera
+
+        RE = RunEngine()
+        RE.subscribe(collect)
+        connect_devices(RE, motor, ref, cam, snapshot)
+
+        if statistics:
+            plan_motor, positions, shots = None, [None], 4
+        else:
+            plan_motor, positions, shots = motor, [0.0, 1.0], 2
+
+        quiesce = None
+        if quiesce_log is not None:
+
+            def quiesce():
+                quiesce_log.append("quiesced")
+                yield from bps.null()
+
+        try:
+            RE(
+                geecs_free_run_step_scan(
+                    motor=plan_motor,
+                    positions=positions,
+                    reference=ref,
+                    detectors=[cam, snapshot],
+                    shots_per_step=shots,
+                    quiesce_trigger=quiesce,
+                )
+            )
+        finally:
+            disconnect_devices(
+                RE,
+                motor,
+                ref,
+                cam,
+                snapshot,
+            )
     return primary_events, start_docs[0], flush_events
 
 

--- a/GeecsBluesky/tests/test_free_run_plan.py
+++ b/GeecsBluesky/tests/test_free_run_plan.py
@@ -14,6 +14,7 @@ import math
 import threading
 
 import bluesky.plan_stubs as bps
+import pytest
 from bluesky import RunEngine
 
 from geecs_bluesky.devices.generic_detector import GeecsGenericDetector
@@ -22,6 +23,8 @@ from geecs_bluesky.devices.snapshot import GeecsSnapshotReadable
 from geecs_bluesky.devices.timestamped_readable import GeecsTimestampedReadable
 from geecs_bluesky.plans.free_run_step_scan import geecs_free_run_step_scan
 from geecs_bluesky.testing.fake_device_server import FakeGeecsDevice, FakeGeecsServer
+
+pytestmark = pytest.mark.fake_server
 
 REF_T0 = 1000.0
 CAM_T0 = 1000.05

--- a/GeecsBluesky/tests/test_motor_and_trigger.py
+++ b/GeecsBluesky/tests/test_motor_and_trigger.py
@@ -6,7 +6,6 @@ All tests use FakeGeecsServer — no real hardware required.
 from __future__ import annotations
 
 import asyncio
-import threading
 
 import pytest
 from bluesky import RunEngine
@@ -18,6 +17,11 @@ from geecs_bluesky.devices.snapshot import GeecsSnapshotReadable
 from geecs_bluesky.exceptions import GeecsTriggerTimeoutError
 from geecs_bluesky.plans.step_scan import geecs_step_scan
 from geecs_bluesky.testing.fake_device_server import FakeGeecsDevice, FakeGeecsServer
+from tests.fake_server_helpers import (
+    BackgroundFakeServers,
+    connect_devices,
+    disconnect_devices,
+)
 
 pytestmark = pytest.mark.fake_server
 
@@ -224,98 +228,51 @@ class TestGeecsTriggerable:
 # ---------------------------------------------------------------------------
 
 
-def _run_server_with_shot_firer(
-    device: FakeGeecsDevice,
-    ready: threading.Event,
-    host_port: list,
-    shot_interval: float = 0.15,
-) -> None:
-    """Background thread: run the fake server and fire shots periodically."""
-
-    async def _main() -> None:
-        async with FakeGeecsServer(device) as srv:
-            host_port.extend([srv.host, srv.port])
-            ready.set()
-            try:
-                while True:
-                    await asyncio.sleep(shot_interval)
-                    device.fire_shot()
-            except asyncio.CancelledError:
-                pass
-
-    loop = asyncio.new_event_loop()
-    task_holder: list = []
-
-    async def _wrapper() -> None:
-        task = loop.create_task(_main())
-        task_holder.append(task)
-        await task
-
-    try:
-        loop.run_until_complete(_wrapper())
-    except Exception:
-        pass
-    finally:
-        loop.close()
-
-
 def test_geecs_step_scan_collects_events(combined_device: FakeGeecsDevice) -> None:
     """End-to-end: step scan over 2 positions × 2 shots = 4 event documents."""
-    ready = threading.Event()
-    host_port: list = []
+    with BackgroundFakeServers(
+        combined_device,
+        fire=lambda devices: devices[0].fire_shot(),
+        interval=0.15,
+    ) as server:
+        host, port = server.endpoint
 
-    srv_thread = threading.Thread(
-        target=_run_server_with_shot_firer,
-        args=(combined_device, ready, host_port),
-        daemon=True,
-    )
-    srv_thread.start()
-    ready.wait(timeout=5.0)
-    assert host_port, "Server failed to start"
-
-    host, port = host_port[0], host_port[1]
-
-    # The RunEngine owns a persistent asyncio loop running in a background thread.
-    # Devices must be connected in *that* loop so their transports are registered
-    # with the same selector the RE uses for all I/O.  Use run_coroutine_threadsafe
-    # to schedule the connect coroutines into the RE's loop synchronously.
-    motor = GeecsMotor("U_Combined", "Position (mm)", host, port, name="scan_motor")
-    det = GeecsGenericDetector(
-        "U_Combined",
-        ["Signal"],
-        host,
-        port,
-        name="scan_det",
-    )
-    async_snapshot = GeecsSnapshotReadable(
-        "U_Combined",
-        ["Position (mm)"],
-        host,
-        port,
-        name="async_snapshot",
-    )
-
-    events: list[dict] = []
-    RE = RunEngine()
-    RE.subscribe(lambda name, doc: events.append(doc) if name == "event" else None)
-
-    # Connect in RE's loop (blocks until both connects complete)
-    asyncio.run_coroutine_threadsafe(motor.connect(), RE._loop).result(timeout=10)
-    asyncio.run_coroutine_threadsafe(det.connect(), RE._loop).result(timeout=10)
-    asyncio.run_coroutine_threadsafe(async_snapshot.connect(), RE._loop).result(
-        timeout=10
-    )
-
-    # Run the step scan
-    RE(
-        geecs_step_scan(
-            motor=motor,
-            positions=[0.0, 1.0],
-            detectors=[det, async_snapshot],
-            shots_per_step=2,
-            md={"test": True},
+        # The RunEngine owns a persistent asyncio loop running in a background thread.
+        # Devices must be connected in that loop so their transports are registered
+        # with the same selector the RE uses for all I/O.
+        motor = GeecsMotor("U_Combined", "Position (mm)", host, port, name="scan_motor")
+        det = GeecsGenericDetector(
+            "U_Combined",
+            ["Signal"],
+            host,
+            port,
+            name="scan_det",
         )
-    )
+        async_snapshot = GeecsSnapshotReadable(
+            "U_Combined",
+            ["Position (mm)"],
+            host,
+            port,
+            name="async_snapshot",
+        )
+
+        events: list[dict] = []
+        RE = RunEngine()
+        RE.subscribe(lambda name, doc: events.append(doc) if name == "event" else None)
+
+        connect_devices(RE, motor, det, async_snapshot)
+        try:
+            RE(
+                geecs_step_scan(
+                    motor=motor,
+                    positions=[0.0, 1.0],
+                    detectors=[det, async_snapshot],
+                    shots_per_step=2,
+                    md={"test": True},
+                )
+            )
+        finally:
+            disconnect_devices(RE, motor, det, async_snapshot)
 
     # 2 positions × 2 shots = 4 events
     assert len(events) == 4, f"Expected 4 events, got {len(events)}"
@@ -340,34 +297,34 @@ def test_geecs_step_scan_statistics_collection(
     Routes statistics collection through the same plan as a motor scan; the
     only difference is no scan variable is moved and there is a single bin.
     """
-    ready = threading.Event()
-    host_port: list = []
-    srv_thread = threading.Thread(
-        target=_run_server_with_shot_firer,
-        args=(combined_device, ready, host_port),
-        daemon=True,
-    )
-    srv_thread.start()
-    ready.wait(timeout=5.0)
-    assert host_port, "Server failed to start"
-    host, port = host_port[0], host_port[1]
+    with BackgroundFakeServers(
+        combined_device,
+        fire=lambda devices: devices[0].fire_shot(),
+        interval=0.15,
+    ) as server:
+        host, port = server.endpoint
 
-    det = GeecsGenericDetector("U_Combined", ["Signal"], host, port, name="scan_det")
-
-    events: list[dict] = []
-    RE = RunEngine()
-    RE.subscribe(lambda name, doc: events.append(doc) if name == "event" else None)
-    asyncio.run_coroutine_threadsafe(det.connect(), RE._loop).result(timeout=10)
-
-    RE(
-        geecs_step_scan(
-            motor=None,
-            positions=[None],
-            detectors=[det],
-            shots_per_step=3,
-            md={"test": True},
+        det = GeecsGenericDetector(
+            "U_Combined", ["Signal"], host, port, name="scan_det"
         )
-    )
+
+        events: list[dict] = []
+        RE = RunEngine()
+        RE.subscribe(lambda name, doc: events.append(doc) if name == "event" else None)
+        connect_devices(RE, det)
+
+        try:
+            RE(
+                geecs_step_scan(
+                    motor=None,
+                    positions=[None],
+                    detectors=[det],
+                    shots_per_step=3,
+                    md={"test": True},
+                )
+            )
+        finally:
+            disconnect_devices(RE, det)
 
     assert len(events) == 3, f"Expected 3 events, got {len(events)}"
     for ev in events:

--- a/GeecsBluesky/tests/test_motor_and_trigger.py
+++ b/GeecsBluesky/tests/test_motor_and_trigger.py
@@ -19,6 +19,8 @@ from geecs_bluesky.exceptions import GeecsTriggerTimeoutError
 from geecs_bluesky.plans.step_scan import geecs_step_scan
 from geecs_bluesky.testing.fake_device_server import FakeGeecsDevice, FakeGeecsServer
 
+pytestmark = pytest.mark.fake_server
+
 
 # ---------------------------------------------------------------------------
 # Fixtures

--- a/GeecsBluesky/tests/test_shot_control.py
+++ b/GeecsBluesky/tests/test_shot_control.py
@@ -78,6 +78,7 @@ def _make_scanner_with_mock_setters() -> tuple[BlueskyScanner, dict[str, _MockSe
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.fake_server
 class TestUdpSetter:
     async def test_set_string_value(self) -> None:
         """set() delivers a string value to the fake device."""
@@ -219,6 +220,7 @@ def combined_device() -> FakeGeecsDevice:
     )
 
 
+@pytest.mark.fake_server
 class TestStepScanArmDisarmOrdering:
     def test_arm_disarm_ordering(self, combined_device: FakeGeecsDevice) -> None:
         """arm runs after move, disarm runs after shots — verified per step.

--- a/GeecsBluesky/tests/test_shot_control.py
+++ b/GeecsBluesky/tests/test_shot_control.py
@@ -8,8 +8,6 @@ Covers:
 
 from __future__ import annotations
 
-import asyncio
-import threading
 from typing import Any
 
 import pytest
@@ -23,6 +21,11 @@ from geecs_bluesky.models.shot_control import ShotControlConfig
 from geecs_bluesky.scanner_bridge.bluesky_scanner import BlueskyScanner, _UdpSetter
 from geecs_bluesky.testing.fake_device_server import FakeGeecsDevice, FakeGeecsServer
 from geecs_bluesky.transport.udp_client import GeecsUdpClient
+from tests.fake_server_helpers import (
+    BackgroundFakeServers,
+    connect_devices,
+    disconnect_devices,
+)
 
 # Shot control config matching the real U_DG645_ShotControl YAML
 SHOT_CONTROL_VARS = {
@@ -175,39 +178,6 @@ class TestSetTriggerState:
 # ---------------------------------------------------------------------------
 
 
-def _run_server_with_shot_firer(
-    device: FakeGeecsDevice,
-    ready: threading.Event,
-    host_port: list,
-    shot_interval: float = 0.15,
-) -> None:
-    """Background thread: run the fake server and fire shots periodically."""
-
-    async def _main() -> None:
-        async with FakeGeecsServer(device) as srv:
-            host_port.extend([srv.host, srv.port])
-            ready.set()
-            try:
-                while True:
-                    await asyncio.sleep(shot_interval)
-                    device.fire_shot()
-            except asyncio.CancelledError:
-                pass
-
-    loop = asyncio.new_event_loop()
-
-    async def _wrapper() -> None:
-        task = loop.create_task(_main())
-        await task
-
-    try:
-        loop.run_until_complete(_wrapper())
-    except Exception:
-        pass
-    finally:
-        loop.close()
-
-
 @pytest.fixture
 def combined_device() -> FakeGeecsDevice:
     return FakeGeecsDevice(
@@ -229,52 +199,51 @@ class TestStepScanArmDisarmOrdering:
           step 1: arm(events=0) → 2 shots → disarm(events=2)
           step 2: arm(events=2) → 2 shots → disarm(events=4)
         """
-        ready = threading.Event()
-        host_port: list = []
+        with BackgroundFakeServers(
+            combined_device,
+            fire=lambda devices: devices[0].fire_shot(),
+            interval=0.15,
+        ) as server:
+            host, port = server.endpoint
 
-        srv_thread = threading.Thread(
-            target=_run_server_with_shot_firer,
-            args=(combined_device, ready, host_port),
-            daemon=True,
-        )
-        srv_thread.start()
-        ready.wait(timeout=5.0)
-        assert host_port, "FakeGeecsServer failed to start"
-        host, port = host_port[0], host_port[1]
-
-        motor = GeecsMotor("U_Combined", "Position (mm)", host, port, name="test_motor")
-        det = GeecsGenericDetector(
-            "U_Combined", ["Signal"], host, port, name="test_det"
-        )
-
-        events: list[dict] = []
-        arm_at: list[int] = []
-        disarm_at: list[int] = []
-
-        def mock_arm():
-            arm_at.append(len(events))
-            yield from []
-
-        def mock_disarm():
-            disarm_at.append(len(events))
-            yield from []
-
-        RE = RunEngine()
-        RE.subscribe(lambda name, doc: events.append(doc) if name == "event" else None)
-
-        asyncio.run_coroutine_threadsafe(motor.connect(), RE._loop).result(timeout=10)
-        asyncio.run_coroutine_threadsafe(det.connect(), RE._loop).result(timeout=10)
-
-        RE(
-            geecs_step_scan(
-                motor=motor,
-                positions=[0.0, 1.0],
-                detectors=[det],
-                shots_per_step=2,
-                arm_trigger=mock_arm,
-                disarm_trigger=mock_disarm,
+            motor = GeecsMotor(
+                "U_Combined", "Position (mm)", host, port, name="test_motor"
             )
-        )
+            det = GeecsGenericDetector(
+                "U_Combined", ["Signal"], host, port, name="test_det"
+            )
+
+            events: list[dict] = []
+            arm_at: list[int] = []
+            disarm_at: list[int] = []
+
+            def mock_arm():
+                arm_at.append(len(events))
+                yield from []
+
+            def mock_disarm():
+                disarm_at.append(len(events))
+                yield from []
+
+            RE = RunEngine()
+            RE.subscribe(
+                lambda name, doc: events.append(doc) if name == "event" else None
+            )
+
+            connect_devices(RE, motor, det)
+            try:
+                RE(
+                    geecs_step_scan(
+                        motor=motor,
+                        positions=[0.0, 1.0],
+                        detectors=[det],
+                        shots_per_step=2,
+                        arm_trigger=mock_arm,
+                        disarm_trigger=mock_disarm,
+                    )
+                )
+            finally:
+                disconnect_devices(RE, motor, det)
 
         assert len(events) == 4, f"Expected 4 events, got {len(events)}"
         assert arm_at == [0, 2], f"arm called at wrong event counts: {arm_at}"
@@ -284,38 +253,36 @@ class TestStepScanArmDisarmOrdering:
         self, combined_device: FakeGeecsDevice
     ) -> None:
         """arm_trigger=None runs normally — backward compat with internal trigger."""
-        ready = threading.Event()
-        host_port: list = []
+        with BackgroundFakeServers(
+            combined_device,
+            fire=lambda devices: devices[0].fire_shot(),
+            interval=0.15,
+        ) as server:
+            host, port = server.endpoint
 
-        srv_thread = threading.Thread(
-            target=_run_server_with_shot_firer,
-            args=(combined_device, ready, host_port),
-            daemon=True,
-        )
-        srv_thread.start()
-        ready.wait(timeout=5.0)
-        host, port = host_port[0], host_port[1]
-
-        motor = GeecsMotor(
-            "U_Combined", "Position (mm)", host, port, name="test_motor2"
-        )
-        det = GeecsGenericDetector(
-            "U_Combined", ["Signal"], host, port, name="test_det2"
-        )
-
-        events: list[dict] = []
-        RE = RunEngine()
-        RE.subscribe(lambda name, doc: events.append(doc) if name == "event" else None)
-        asyncio.run_coroutine_threadsafe(motor.connect(), RE._loop).result(timeout=10)
-        asyncio.run_coroutine_threadsafe(det.connect(), RE._loop).result(timeout=10)
-
-        RE(
-            geecs_step_scan(
-                motor=motor,
-                positions=[0.0],
-                detectors=[det],
-                shots_per_step=3,
+            motor = GeecsMotor(
+                "U_Combined", "Position (mm)", host, port, name="test_motor2"
             )
-        )
+            det = GeecsGenericDetector(
+                "U_Combined", ["Signal"], host, port, name="test_det2"
+            )
+
+            events: list[dict] = []
+            RE = RunEngine()
+            RE.subscribe(
+                lambda name, doc: events.append(doc) if name == "event" else None
+            )
+            connect_devices(RE, motor, det)
+            try:
+                RE(
+                    geecs_step_scan(
+                        motor=motor,
+                        positions=[0.0],
+                        detectors=[det],
+                        shots_per_step=3,
+                    )
+                )
+            finally:
+                disconnect_devices(RE, motor, det)
 
         assert len(events) == 3

--- a/GeecsBluesky/tests/test_shot_id.py
+++ b/GeecsBluesky/tests/test_shot_id.py
@@ -122,6 +122,7 @@ def _sync_device(name: str, acq_timestamp: float) -> FakeGeecsDevice:
     )
 
 
+@pytest.mark.fake_server
 class TestGeecsT0Sync:
     async def test_seeds_all_devices_from_common_shot(self) -> None:
         """Timestamps within the window seed every tracker with its own t0."""
@@ -231,6 +232,7 @@ class TestGeecsT0Sync:
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.fake_server
 async def test_detector_emits_nan_companions_before_first_shot() -> None:
     """All described companion columns appear even with no shot data yet."""
     # Empty value → push frame pair never parses → cache never gets the key

--- a/GeecsBluesky/tests/test_single_shot_plan.py
+++ b/GeecsBluesky/tests/test_single_shot_plan.py
@@ -6,8 +6,8 @@ No free-running firer here: the fake device fires **only** when the plan's
 
 from __future__ import annotations
 
-import asyncio
-import threading
+from collections.abc import Iterator
+from contextlib import contextmanager
 
 import bluesky.plan_stubs as bps
 import pytest
@@ -21,7 +21,12 @@ from geecs_bluesky.exceptions import (
 )
 from geecs_bluesky.plans.single_shot import geecs_confirm_quiescent
 from geecs_bluesky.plans.step_scan import geecs_step_scan
-from geecs_bluesky.testing.fake_device_server import FakeGeecsDevice, FakeGeecsServer
+from geecs_bluesky.testing.fake_device_server import FakeGeecsDevice
+from tests.fake_server_helpers import (
+    BackgroundFakeServers,
+    connect_devices,
+    disconnect_devices,
+)
 
 
 class _StubTsDevice:
@@ -74,140 +79,117 @@ def test_confirm_quiescent_no_sync_devices_is_noop() -> None:
     _drive(geecs_confirm_quiescent([object()], quiet_s=0.5))
 
 
-def _run_server(
-    device: FakeGeecsDevice, ready: threading.Event, host_port: list
-) -> None:
-    """Thread target: serve the fake device; never fire on its own."""
-
-    async def _main() -> None:
-        async with FakeGeecsServer(device) as srv:
-            host_port.extend([srv.host, srv.port])
-            ready.set()
-            await asyncio.sleep(3600)
-
-    loop = asyncio.new_event_loop()
-    try:
-        loop.run_until_complete(_main())
-    except Exception:
-        pass
-    finally:
-        loop.close()
-
-
-def _setup_scan() -> tuple[
-    FakeGeecsDevice, GeecsMotor, GeecsGenericDetector, RunEngine, list
+@contextmanager
+def _setup_scan() -> Iterator[
+    tuple[FakeGeecsDevice, GeecsMotor, GeecsGenericDetector, RunEngine, list]
 ]:
     fake = FakeGeecsDevice(
         name="U_Combined",
         variables={"Position (mm)": 0.0, "Sig": 1.0, "acq_timestamp": 1000.0},
     )
-    ready = threading.Event()
-    host_port: list = []
-    threading.Thread(
-        target=_run_server, args=(fake, ready, host_port), daemon=True
-    ).start()
-    ready.wait(timeout=5.0)
-    assert host_port, "Server failed to start"
-    host, port = host_port
+    with BackgroundFakeServers(fake) as server:
+        host, port = server.endpoint
 
-    motor = GeecsMotor("U_Combined", "Position (mm)", host, port, name="scan_motor")
-    cam = GeecsGenericDetector("U_Combined", ["Sig"], host, port, name="cam")
-    cam.configure_shot_id(rep_rate_hz=1.0)
+        motor = GeecsMotor("U_Combined", "Position (mm)", host, port, name="scan_motor")
+        cam = GeecsGenericDetector("U_Combined", ["Sig"], host, port, name="cam")
+        cam.configure_shot_id(rep_rate_hz=1.0)
 
-    events: list[dict] = []
-    RE = RunEngine()
-    RE.subscribe(lambda name, doc: events.append(doc) if name == "event" else None)
-    for dev in (motor, cam):
-        asyncio.run_coroutine_threadsafe(dev.connect(), RE._loop).result(timeout=10)
-    return fake, motor, cam, RE, events
+        events: list[dict] = []
+        RE = RunEngine()
+        RE.subscribe(lambda name, doc: events.append(doc) if name == "event" else None)
+        connect_devices(RE, motor, cam)
+        try:
+            yield fake, motor, cam, RE, events
+        finally:
+            disconnect_devices(RE, motor, cam)
 
 
 @pytest.mark.fake_server
 def test_strict_scan_fires_each_shot_itself() -> None:
     """One fire → one complete row; no free-running trigger required."""
-    fake, motor, cam, RE, events = _setup_scan()
-    fire_count = 0
+    with _setup_scan() as (fake, motor, cam, RE, events):
+        fire_count = 0
 
-    def fire():
-        nonlocal fire_count
-        fire_count += 1
-        fake.fire_shot()
-        yield from bps.null()
+        def fire():
+            nonlocal fire_count
+            fire_count += 1
+            fake.fire_shot()
+            yield from bps.null()
 
-    RE(
-        geecs_step_scan(
-            motor=motor,
-            positions=[0.0, 1.0],
-            detectors=[cam],
-            shots_per_step=2,
-            fire_shot=fire,
+        RE(
+            geecs_step_scan(
+                motor=motor,
+                positions=[0.0, 1.0],
+                detectors=[cam],
+                shots_per_step=2,
+                fire_shot=fire,
+            )
         )
-    )
 
-    assert fire_count == 4
-    assert len(events) == 4
-    # Plan-owned shots are consecutive: the trigger only ticks when fired
-    assert [ev["data"]["cam-shot_id"] for ev in events] == [1, 2, 3, 4]
-    for ev in events:
-        assert ev["data"]["cam-valid"] is True
-        assert ev["data"]["cam-shot_offset"] == 0
+        assert fire_count == 4
+        assert len(events) == 4
+        # Plan-owned shots are consecutive: the trigger only ticks when fired
+        assert [ev["data"]["cam-shot_id"] for ev in events] == [1, 2, 3, 4]
+        for ev in events:
+            assert ev["data"]["cam-valid"] is True
+            assert ev["data"]["cam-shot_offset"] == 0
 
 
 @pytest.mark.fake_server
 def test_strict_scan_setup_trigger_runs_once_before_shots() -> None:
     """setup_trigger (arm + confirm) runs once at scan start, not per shot."""
-    fake, motor, cam, RE, events = _setup_scan()
-    calls = {"setup": 0, "fire": 0}
+    with _setup_scan() as (fake, _motor, cam, RE, events):
+        calls = {"setup": 0, "fire": 0}
 
-    def setup():
-        calls["setup"] += 1
-        yield from bps.null()
+        def setup():
+            calls["setup"] += 1
+            yield from bps.null()
 
-    def fire():
-        calls["fire"] += 1
-        fake.fire_shot()
-        yield from bps.null()
+        def fire():
+            calls["fire"] += 1
+            fake.fire_shot()
+            yield from bps.null()
 
-    RE(
-        geecs_step_scan(
-            motor=None,
-            positions=[None],
-            detectors=[cam],
-            shots_per_step=3,
-            setup_trigger=setup,
-            fire_shot=fire,
+        RE(
+            geecs_step_scan(
+                motor=None,
+                positions=[None],
+                detectors=[cam],
+                shots_per_step=3,
+                setup_trigger=setup,
+                fire_shot=fire,
+            )
         )
-    )
 
-    assert calls["setup"] == 1, "setup_trigger must run exactly once"
-    assert calls["fire"] == 3
-    assert len(events) == 3
-    # Start doc records that the plan fired its own shots
-    assert all(ev["data"]["cam-valid"] for ev in events)
+        assert calls["setup"] == 1, "setup_trigger must run exactly once"
+        assert calls["fire"] == 3
+        assert len(events) == 3
+        # Start doc records that the plan fired its own shots
+        assert all(ev["data"]["cam-valid"] for ev in events)
 
 
 @pytest.mark.fake_server
 def test_strict_scan_hard_fails_when_device_misses_the_shot() -> None:
     """A device not responding to the plan's own shot aborts the scan."""
-    fake, motor, cam, RE, events = _setup_scan()
-    cam._trigger_timeout = 0.5  # keep the failure fast
+    with _setup_scan() as (_fake, motor, cam, RE, events):
+        cam._trigger_timeout = 0.5  # keep the failure fast
 
-    def dead_fire():
-        # Trigger source broken: nothing fires, the camera never advances
-        yield from bps.null()
+        def dead_fire():
+            # Trigger source broken: nothing fires, the camera never advances
+            yield from bps.null()
 
-    with pytest.raises(Exception) as excinfo:
-        RE(
-            geecs_step_scan(
-                motor=motor,
-                positions=[0.0],
-                detectors=[cam],
-                shots_per_step=1,
-                fire_shot=dead_fire,
+        with pytest.raises(Exception) as excinfo:
+            RE(
+                geecs_step_scan(
+                    motor=motor,
+                    positions=[0.0],
+                    detectors=[cam],
+                    shots_per_step=1,
+                    fire_shot=dead_fire,
+                )
             )
+        # The timeout names the offending device through the status failure
+        assert "U_Combined" in str(excinfo.value) or isinstance(
+            excinfo.value.__cause__, GeecsTriggerTimeoutError
         )
-    # The timeout names the offending device through the status failure
-    assert "U_Combined" in str(excinfo.value) or isinstance(
-        excinfo.value.__cause__, GeecsTriggerTimeoutError
-    )
-    assert events == []
+        assert events == []

--- a/GeecsBluesky/tests/test_single_shot_plan.py
+++ b/GeecsBluesky/tests/test_single_shot_plan.py
@@ -122,6 +122,7 @@ def _setup_scan() -> tuple[
     return fake, motor, cam, RE, events
 
 
+@pytest.mark.fake_server
 def test_strict_scan_fires_each_shot_itself() -> None:
     """One fire → one complete row; no free-running trigger required."""
     fake, motor, cam, RE, events = _setup_scan()
@@ -152,6 +153,7 @@ def test_strict_scan_fires_each_shot_itself() -> None:
         assert ev["data"]["cam-shot_offset"] == 0
 
 
+@pytest.mark.fake_server
 def test_strict_scan_setup_trigger_runs_once_before_shots() -> None:
     """setup_trigger (arm + confirm) runs once at scan start, not per shot."""
     fake, motor, cam, RE, events = _setup_scan()
@@ -184,6 +186,7 @@ def test_strict_scan_setup_trigger_runs_once_before_shots() -> None:
     assert all(ev["data"]["cam-valid"] for ev in events)
 
 
+@pytest.mark.fake_server
 def test_strict_scan_hard_fails_when_device_misses_the_shot() -> None:
     """A device not responding to the plan's own shot aborts the scan."""
     fake, motor, cam, RE, events = _setup_scan()

--- a/GeecsBluesky/tests/test_timestamped_readable.py
+++ b/GeecsBluesky/tests/test_timestamped_readable.py
@@ -81,6 +81,7 @@ async def test_set_reference_does_not_adopt_the_reference() -> None:
     assert ref.name == "ref"
 
 
+@pytest.mark.fake_server
 async def test_matched_shot_is_valid() -> None:
     """Both devices caught the same physical trigger → offset 0, valid."""
     async with AsyncExitStack() as stack:
@@ -102,6 +103,7 @@ async def test_matched_shot_is_valid() -> None:
             assert key in reading, f"described key {key} missing from reading"
 
 
+@pytest.mark.fake_server
 async def test_missed_shots_are_invalid_with_real_offset() -> None:
     """Contributor stuck while the reference advances → negative offset, invalid."""
     async with AsyncExitStack() as stack:
@@ -119,6 +121,7 @@ async def test_missed_shots_are_invalid_with_real_offset() -> None:
         assert reading["cam-val"]["value"] == pytest.approx(2.0)
 
 
+@pytest.mark.fake_server
 async def test_grace_wait_recovers_late_frame() -> None:
     """A frame arriving within the grace window flips the row to valid."""
     async with AsyncExitStack() as stack:
@@ -139,6 +142,7 @@ async def test_grace_wait_recovers_late_frame() -> None:
         assert reading["cam-acq_timestamp"]["value"] == pytest.approx(CAM_T0 + 1.0)
 
 
+@pytest.mark.fake_server
 async def test_no_reference_never_claims_validity() -> None:
     """Without a reference the offset is NaN and valid is False."""
     async with AsyncExitStack() as stack:
@@ -152,6 +156,7 @@ async def test_no_reference_never_claims_validity() -> None:
         assert reading["cam-valid"]["value"] is False
 
 
+@pytest.mark.fake_server
 async def test_save_nonscalar_emits_save_path_column() -> None:
     """A free-run contributor with save_nonscalar_data saves files like the reference."""
     fake_cam = FakeGeecsDevice(
@@ -188,6 +193,7 @@ async def test_save_nonscalar_emits_save_path_column() -> None:
             assert key in reading, f"described key {key} missing from reading"
 
 
+@pytest.mark.fake_server
 async def test_t0_sync_seeds_timestamped_readables() -> None:
     """The t0-sync stage treats contributors like any other sync device."""
     async with AsyncExitStack() as stack:

--- a/GeecsBluesky/tests/test_timestamped_readable.py
+++ b/GeecsBluesky/tests/test_timestamped_readable.py
@@ -50,6 +50,15 @@ async def _setup(stack: AsyncExitStack):
     )
     await ref.connect()
     await cam.connect()
+
+    async def disconnect_devices() -> None:
+        await asyncio.gather(
+            asyncio.wait_for(ref.disconnect(), timeout=3.0),
+            asyncio.wait_for(cam.disconnect(), timeout=3.0),
+            return_exceptions=True,
+        )
+
+    stack.push_async_callback(disconnect_devices)
     ref.configure_shot_id(rep_rate_hz=1.0)
     cam.configure_shot_id(rep_rate_hz=1.0)
     cam.set_reference(ref)
@@ -91,7 +100,7 @@ async def test_matched_shot_is_valid() -> None:
         await _wait_for_ts(ref, REF_T0 + 1.0)
         await _wait_for_ts(cam, CAM_T0 + 1.0)
 
-        reading = await cam.read()
+        reading = await asyncio.wait_for(cam.read(), timeout=3.0)
         assert reading["cam-shot_id"]["value"] == 2
         assert reading["cam-shot_offset"]["value"] == 0
         assert reading["cam-valid"]["value"] is True
@@ -113,7 +122,7 @@ async def test_missed_shots_are_invalid_with_real_offset() -> None:
         fake_ref.variables["acq_timestamp"] = REF_T0 + 2.0
         await _wait_for_ts(ref, REF_T0 + 2.0)
 
-        reading = await cam.read()
+        reading = await asyncio.wait_for(cam.read(), timeout=3.0)
         assert reading["cam-shot_id"]["value"] == 1
         assert reading["cam-shot_offset"]["value"] == -2
         assert reading["cam-valid"]["value"] is False
@@ -135,7 +144,7 @@ async def test_grace_wait_recovers_late_frame() -> None:
             fake_cam.variables["acq_timestamp"] = CAM_T0 + 1.0
 
         task = asyncio.create_task(deliver_late_frame())
-        reading = await cam.read()
+        reading = await asyncio.wait_for(cam.read(), timeout=3.0)
         await task
         assert reading["cam-shot_offset"]["value"] == 0
         assert reading["cam-valid"]["value"] is True
@@ -150,7 +159,7 @@ async def test_no_reference_never_claims_validity() -> None:
         cam.set_reference(ref, grace_wait_s=0.0)
         cam._reference = None  # simulate unanchored standalone use
 
-        reading = await cam.read()
+        reading = await asyncio.wait_for(cam.read(), timeout=3.0)
         assert reading["cam-shot_id"]["value"] == 1
         assert math.isnan(reading["cam-shot_offset"]["value"])
         assert reading["cam-valid"]["value"] is False
@@ -178,19 +187,22 @@ async def test_save_nonscalar_emits_save_path_column() -> None:
             save_nonscalar_data=True,
         )
         await cam.connect()
-        cam.configure_shot_id(rep_rate_hz=1.0)
-        # The writable save-control signals exist (used by the scanner's
-        # _scan_with_saving to turn saving on/off)
-        assert hasattr(cam, "localsavingpath")
-        assert hasattr(cam, "save")
-        cam.configure_nonscalar_file_logging("/data/Scan001/U_Cam")
+        try:
+            cam.configure_shot_id(rep_rate_hz=1.0)
+            # The writable save-control signals exist (used by the scanner's
+            # _scan_with_saving to turn saving on/off)
+            assert hasattr(cam, "localsavingpath")
+            assert hasattr(cam, "save")
+            cam.configure_nonscalar_file_logging("/data/Scan001/U_Cam")
 
-        desc = await cam.describe()
-        assert desc["cam-nonscalar_save_path"]["dtype"] == "string"
-        reading = await cam.read()
-        assert reading["cam-nonscalar_save_path"]["value"] == "/data/Scan001/U_Cam"
-        for key in desc:
-            assert key in reading, f"described key {key} missing from reading"
+            desc = await asyncio.wait_for(cam.describe(), timeout=3.0)
+            assert desc["cam-nonscalar_save_path"]["dtype"] == "string"
+            reading = await asyncio.wait_for(cam.read(), timeout=3.0)
+            assert reading["cam-nonscalar_save_path"]["value"] == "/data/Scan001/U_Cam"
+            for key in desc:
+                assert key in reading, f"described key {key} missing from reading"
+        finally:
+            await asyncio.wait_for(cam.disconnect(), timeout=3.0)
 
 
 @pytest.mark.fake_server

--- a/GeecsBluesky/tests/test_transport.py
+++ b/GeecsBluesky/tests/test_transport.py
@@ -13,6 +13,8 @@ from geecs_bluesky.testing.fake_device_server import FakeGeecsDevice, FakeGeecsS
 from geecs_bluesky.transport.udp_client import GeecsUdpClient
 from geecs_bluesky.transport.tcp_subscriber import GeecsTcpSubscriber
 
+pytestmark = pytest.mark.fake_server
+
 
 # ---------------------------------------------------------------------------
 # Fixtures

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,7 @@ markers = [
     "integration: requires external resources (data or hardware) — skipped in CI",
     "data: requires network-mounted GEECS data (combine with integration)",
     "hardware: requires live GEECS devices (combine with integration)",
+    "fake_server: uses local FakeGeecsServer TCP/UDP sockets; CI-safe but not pure unit",
     "gui: requires a display and Qt — skipped in headless CI",
 ]
 # Exclude pre-existing test stubs that require optional/unavailable deps


### PR DESCRIPTION
## Summary
- add explicit pytest markers for GeecsBluesky fake-server socket tests and hardware tests
- split GeecsBluesky CI into pure unit and localhost FakeGeecsServer integration selections
- harden the fake-server suite with per-test timeouts, bounded background server teardown, and explicit RunEngine-device cleanup
- fix socket lifecycle edge cases surfaced by the suite: UDP adjacent-port collisions, TCP subscriber cleanup on cancellation, and FakeGeecsServer active-client shutdown
- make the hardware smoke script import-safe under pytest while preserving direct execution
- add per-scan `scan.log` creation for `BlueskyScanner` runs
- add an opt-in full-output hardware test that enables native camera saving and verifies scan folder, `ScanInfo`, `scan.log`, `ScanData`, analysis s-file, saved camera images, and event save-path metadata
- document the full-output hardware test and its `poetry install --extras tiled` / `GEECS_BLUESKY_FULL_OUTPUT_TEST=1` requirements

## Tests
- `pre-commit run --files GeecsBluesky/geecs_bluesky/scanner_bridge/bluesky_scanner.py GeecsBluesky/test_bluesky_scanner.py GeecsBluesky/README.md GeecsBluesky/CLAUDE.md`
- `poetry check`
- `poetry run pytest tests -m "not integration and not fake_server" --tb=short -q`
- `poetry run pytest tests -m "fake_server and not integration" --tb=short -q -W error::pytest.PytestUnraisableExceptionWarning`
- `GEECS_BLUESKY_TEST_CAMERA=UC_Amp2_IR_input poetry run pytest test_bluesky_scanner.py -m "integration and hardware" -v --tb=short`
- `poetry install --extras tiled`
- `GEECS_BLUESKY_TEST_CAMERA=UC_Amp2_IR_input GEECS_BLUESKY_FULL_OUTPUT_TEST=1 poetry run pytest test_bluesky_scanner.py::test_bluesky_scanner_full_output_hardware_integration -v -s --tb=short`

Full-output hardware run produced and verified:
- `/Volumes/hdna2/data/Undulator/Y2026/06-Jun/26_0624/scans/Scan006`
- `ScanInfoScan006.ini`
- `scan.log`
- `ScanDataScan006.txt`
- `/Volumes/hdna2/data/Undulator/Y2026/06-Jun/26_0624/analysis/s6.txt`
- four nonempty `UC_Amp2_IR_input_*.png` files under the scan camera folder
