### PR TITLE
Add local external asset readback helpers

### DIFF
--- a/GeecsBluesky/CHANGELOG.md
+++ b/GeecsBluesky/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to `geecs-bluesky` are documented here.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.12.1] - 2026-06-23
+
+### Added
+
+- Local external asset readback helpers for registering GEECS handlers with
+  `event_model.Filler` and filling ordered Bluesky document streams.
+- Camera shot document helpers for building fillable Resource/Datum docs from
+  existing legacy scan folders by date, scan number, device, and shot number.
+- `external_asset_readback.ipynb` to demonstrate local camera asset filling,
+  including a parameterized existing-scan lookup and a no-hardware synthetic
+  PNG smoke test.
+
+### Fixed
+
+- `GeecsCameraImageHandler` now accepts Resource document metadata such as
+  `data_key`, matching how `event_model.Filler` instantiates handlers from
+  GEECS Resource documents.
+
 ## [0.12.0] - 2026-06-23
 
 ### Added

--- a/GeecsBluesky/geecs_bluesky/assets/__init__.py
+++ b/GeecsBluesky/geecs_bluesky/assets/__init__.py
@@ -9,6 +9,13 @@ from geecs_bluesky.assets.registry import (
     native_file_filename,
     supports_device_type,
 )
+from geecs_bluesky.assets.readback import (
+    build_camera_shot_documents,
+    fill_geecs_documents,
+    geecs_asset_handler_registry,
+    make_geecs_filler,
+    register_geecs_handlers,
+)
 from geecs_bluesky.assets.specs import (
     FROG_DEVICE_TYPE,
     GEECS_CAMERA_IMAGE,
@@ -38,8 +45,13 @@ __all__ = [
     "THORLABS_CCS175_SPECTROMETER_DEVICE_TYPE",
     "THORLABS_WFS_DEVICE_TYPE",
     "camera_image_filename",
+    "build_camera_shot_documents",
+    "fill_geecs_documents",
+    "geecs_asset_handler_registry",
     "get_asset_definitions",
     "get_single_asset_definition",
+    "make_geecs_filler",
     "native_file_filename",
+    "register_geecs_handlers",
     "supports_device_type",
 ]

--- a/GeecsBluesky/geecs_bluesky/assets/handlers.py
+++ b/GeecsBluesky/geecs_bluesky/assets/handlers.py
@@ -22,6 +22,8 @@ class GeecsCameraImageHandler:
         resource_path: str | Path,
         *,
         root: str | Path | None = None,
+        data_key: str | None = None,
+        **resource_kwargs: object,
     ) -> None:
         """Create a handler for a resource path.
 
@@ -31,11 +33,17 @@ class GeecsCameraImageHandler:
             Absolute path to the image, or path relative to *root*.
         root:
             Optional storage root used when *resource_path* is relative.
+        data_key:
+            Optional event data key recorded in the Resource document metadata.
+        **resource_kwargs:
+            Additional Resource metadata ignored by this thin file reader.
         """
         path = Path(resource_path)
         if root is not None and not path.is_absolute():
             path = Path(root) / path
         self.path = path
+        self.data_key = data_key
+        self.resource_kwargs = resource_kwargs
 
     def __call__(self) -> np.ndarray:
         """Return the image payload as a NumPy array."""

--- a/GeecsBluesky/geecs_bluesky/assets/readback.py
+++ b/GeecsBluesky/geecs_bluesky/assets/readback.py
@@ -1,0 +1,291 @@
+"""Local readback helpers for GEECS external assets."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping, Sequence
+from pathlib import Path
+import time
+from typing import Protocol, TypeAlias
+from uuid import uuid4
+
+from event_model import Filler
+
+from geecs_bluesky.assets.handlers import GeecsCameraImageHandler
+from geecs_bluesky.assets.registry import get_single_asset_definition
+from geecs_bluesky.assets.specs import GEECS_CAMERA_IMAGE
+
+HandlerRegistry: TypeAlias = dict[str, type[GeecsCameraImageHandler]]
+Document: TypeAlias = tuple[str, dict[str, object]]
+
+
+class HandlerRegistrar(Protocol):
+    """Object that can register event-model style asset handlers."""
+
+    def register_handler(
+        self,
+        spec: str,
+        handler: type[GeecsCameraImageHandler],
+        overwrite: bool = False,
+    ) -> None:
+        """Register *handler* for *spec*."""
+
+
+def geecs_asset_handler_registry() -> HandlerRegistry:
+    """Return the local handler registry for supported GEECS asset specs."""
+    return {GEECS_CAMERA_IMAGE: GeecsCameraImageHandler}
+
+
+def register_geecs_handlers(
+    registrar: HandlerRegistrar,
+    *,
+    overwrite: bool = False,
+) -> None:
+    """Register supported GEECS asset handlers on an existing filler/router.
+
+    Parameters
+    ----------
+    registrar:
+        Object exposing ``register_handler(spec, handler, overwrite=False)``.
+        This includes :class:`event_model.Filler`.
+    overwrite:
+        Whether to replace an existing handler for the same asset spec.
+    """
+    for spec, handler in geecs_asset_handler_registry().items():
+        registrar.register_handler(spec, handler, overwrite=overwrite)
+
+
+def make_geecs_filler(
+    *,
+    root_map: Mapping[str, str] | None = None,
+    include: Iterable[str] | None = None,
+    exclude: Iterable[str] | None = None,
+    inplace: bool = False,
+    retry_intervals: Sequence[float] | None = None,
+) -> Filler:
+    """Create an :class:`event_model.Filler` with GEECS handlers registered.
+
+    Parameters
+    ----------
+    root_map:
+        Optional mapping from Resource document roots to locally visible roots.
+    include:
+        Optional event data keys to fill.
+    exclude:
+        Optional event data keys to leave unfilled.
+    inplace:
+        Whether filled documents should mutate the input documents.
+    retry_intervals:
+        Optional retry delays used while opening not-yet-visible native files.
+
+    Returns
+    -------
+    event_model.Filler
+        Filler configured with the currently supported GEECS asset handlers.
+    """
+    return Filler(
+        geecs_asset_handler_registry(),
+        root_map=dict(root_map or {}),
+        include=include,
+        exclude=exclude,
+        inplace=inplace,
+        retry_intervals=None if retry_intervals is None else list(retry_intervals),
+    )
+
+
+def fill_geecs_documents(
+    documents: Iterable[Document],
+    *,
+    root_map: Mapping[str, str] | None = None,
+    include: Iterable[str] | None = None,
+    exclude: Iterable[str] | None = None,
+    retry_intervals: Sequence[float] | None = None,
+) -> list[Document]:
+    """Fill external GEECS assets in a stream of Bluesky documents.
+
+    Parameters
+    ----------
+    documents:
+        Iterable of ``(name, document)`` pairs in Bluesky document order.
+    root_map:
+        Optional mapping from Resource document roots to locally visible roots.
+    include:
+        Optional event data keys to fill.
+    exclude:
+        Optional event data keys to leave unfilled.
+    retry_intervals:
+        Optional retry delays used while opening not-yet-visible native files.
+
+    Returns
+    -------
+    list[tuple[str, dict]]
+        Filled document stream. Event documents containing supported external
+        assets have datum IDs replaced with loaded payloads.
+    """
+    filler = make_geecs_filler(
+        root_map=root_map,
+        include=include,
+        exclude=exclude,
+        retry_intervals=retry_intervals,
+    )
+    return [filler(name, doc) for name, doc in documents]
+
+
+def build_camera_shot_documents(
+    *,
+    year: int,
+    month: int | str,
+    day: int,
+    scan_number: int,
+    device_name: str,
+    shot_number: int,
+    experiment: str | None = None,
+    base_directory: str | Path | None = None,
+    device_type: str | None = None,
+) -> tuple[list[Document], Path]:
+    """Build fillable Resource/Datum/Event docs for an existing camera shot.
+
+    This is intended for notebook readback tests against historical scan
+    folders. It resolves the legacy post-filemover camera filename such as
+    ``Scan042_UC_TopView_001.png`` and represents it as a
+    ``GEECS_CAMERA_IMAGE`` external asset.
+
+    Parameters
+    ----------
+    year, month, day:
+        Date of the scan. ``month`` may be an integer or month name accepted by
+        :class:`geecs_data_utils.scan_paths.ScanPaths`.
+    scan_number:
+        GEECS scan number for that day.
+    device_name:
+        Camera device name and scan-folder subdirectory.
+    shot_number:
+        Legacy shot number in the device image filename.
+    experiment:
+        Optional experiment name. If omitted, ``ScanPaths`` uses the configured
+        default experiment.
+    base_directory:
+        Optional GEECS data root. If omitted, ``ScanPaths`` uses the configured
+        base path.
+    device_type:
+        Optional device type. If omitted, the live GEECS database is queried.
+
+    Returns
+    -------
+    list[tuple[str, dict]], pathlib.Path
+        Ordered Bluesky document stream and the resolved image file path.
+
+    Raises
+    ------
+    FileNotFoundError
+        If the scan folder or requested camera shot file cannot be found.
+    ValueError
+        If the resolved device type is not registered as a single camera asset.
+    """
+    from geecs_data_utils.scan_paths import ScanPaths
+
+    if device_type is None:
+        from geecs_bluesky.db.geecs_db import GeecsDb
+
+        device_type = GeecsDb.get_device_type(device_name)
+
+    definition = get_single_asset_definition(device_type)
+    if definition is None or definition.spec != GEECS_CAMERA_IMAGE:
+        raise ValueError(
+            f"Device type {device_type!r} is not registered as a single "
+            "camera image asset."
+        )
+
+    tag = ScanPaths.get_scan_tag(
+        year=year,
+        month=month,
+        day=day,
+        number=scan_number,
+        experiment=experiment,
+    )
+    scan_paths = ScanPaths(tag=tag, base_directory=base_directory)
+    scan_folder = scan_paths.get_folder()
+    if scan_folder is None:
+        raise FileNotFoundError(f"Could not resolve scan folder for {tag}")
+
+    file_path = scan_paths.build_asset_path(
+        shot=shot_number,
+        device=device_name,
+        ext="png",
+    )
+    if not file_path.exists():
+        file_map = scan_paths.build_device_file_map(device_name, ".png")
+        try:
+            file_path = file_map[shot_number]
+        except KeyError as exc:
+            raise FileNotFoundError(
+                "Could not find camera shot file for "
+                f"{tag}, device={device_name!r}, shot={shot_number}. "
+                f"Expected {file_path}."
+            ) from exc
+
+    data_key = definition.event_key(device_name)
+    resource_uid = str(uuid4())
+    datum_id = f"{resource_uid}/0"
+    start_uid = str(uuid4())
+    descriptor_uid = str(uuid4())
+    now = time.time()
+    resource_path = file_path.relative_to(scan_folder).as_posix()
+
+    documents: list[Document] = [
+        ("start", {"uid": start_uid, "time": now, "scan_id": scan_number}),
+        (
+            "descriptor",
+            {
+                "uid": descriptor_uid,
+                "run_start": start_uid,
+                "time": now,
+                "name": "primary",
+                "data_keys": {
+                    data_key: {
+                        "source": f"geecs://{device_name}/{definition.event_field}",
+                        "dtype": "array",
+                        "shape": [],
+                        "external": "OLD:",
+                    }
+                },
+                "configuration": {},
+                "object_keys": {device_name: [data_key]},
+                "hints": {},
+            },
+        ),
+        (
+            "resource",
+            {
+                "uid": resource_uid,
+                "spec": GEECS_CAMERA_IMAGE,
+                "root": str(scan_folder),
+                "resource_path": resource_path,
+                "resource_kwargs": {"data_key": data_key},
+                "path_semantics": "posix",
+            },
+        ),
+        ("datum", {"datum_id": datum_id, "resource": resource_uid, "datum_kwargs": {}}),
+        (
+            "event",
+            {
+                "uid": str(uuid4()),
+                "descriptor": descriptor_uid,
+                "time": now,
+                "seq_num": 1,
+                "data": {data_key: datum_id},
+                "timestamps": {data_key: now},
+                "filled": {data_key: False},
+            },
+        ),
+        (
+            "stop",
+            {
+                "uid": str(uuid4()),
+                "run_start": start_uid,
+                "time": now,
+                "exit_status": "success",
+                "num_events": {"primary": 1},
+            },
+        ),
+    ]
+    return documents, file_path

--- a/GeecsBluesky/notebooks/README.md
+++ b/GeecsBluesky/notebooks/README.md
@@ -25,3 +25,6 @@ Before committing notebook changes:
 - `bluesky_hardware_smoke.ipynb` — run `BlueskyScanner` NOSCAN and optional
   STANDARD scans from a notebook, collect event documents, and confirm scan
   folder metadata.
+- `external_asset_readback.ipynb` — fill GEECS camera external asset
+  Resource/Datum documents locally into NumPy arrays, including a parameterized
+  existing-scan lookup and a synthetic no-hardware smoke test.

--- a/GeecsBluesky/notebooks/external_asset_readback.ipynb
+++ b/GeecsBluesky/notebooks/external_asset_readback.ipynb
@@ -1,0 +1,294 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "asset-readback-title",
+   "metadata": {},
+   "source": [
+    "# External Asset Readback\n",
+    "\n",
+    "Use this notebook to check that GEECS external asset Resource/Datum documents can be filled locally into image arrays. Server-side Tiled handler installation is intentionally out of scope here."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "imports",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pathlib import Path\n",
+    "from tempfile import TemporaryDirectory\n",
+    "from uuid import uuid4\n",
+    "\n",
+    "import matplotlib.pyplot as plt\n",
+    "import numpy as np\n",
+    "import png\n",
+    "\n",
+    "from geecs_bluesky.assets import (\n",
+    "    GEECS_CAMERA_IMAGE,\n",
+    "    build_camera_shot_documents,\n",
+    "    fill_geecs_documents,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fill-documents-heading",
+   "metadata": {},
+   "source": [
+    "## Fill Documents From A Run\n",
+    "\n",
+    "`DOCUMENTS` should be a Bluesky document stream in `(name, doc)` order. This can come from a RunEngine callback during a notebook scan, a local document cache, or a Tiled/databroker client once that retrieval path is chosen."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "document-parameters",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "DOCUMENTS = []\n",
+    "ROOT_MAP = {}\n",
+    "IMAGE_FIELD = \"\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fill-documents",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "filled_documents = fill_geecs_documents(\n",
+    "    DOCUMENTS,\n",
+    "    root_map=ROOT_MAP,\n",
+    "    retry_intervals=[0.001, 0.01, 0.1, 0.5, 1.0],\n",
+    ")\n",
+    "events = [doc for name, doc in filled_documents if name == \"event\"]\n",
+    "available_fields = sorted(events[0][\"data\"]) if events else []\n",
+    "\n",
+    "if not events:\n",
+    "    print(\"No documents configured yet. Set DOCUMENTS to a run document stream.\")\n",
+    "else:\n",
+    "    if not IMAGE_FIELD:\n",
+    "        image_candidates = [\n",
+    "            field for field in available_fields if field.endswith(\"-image\")\n",
+    "        ]\n",
+    "        IMAGE_FIELD = image_candidates[0] if image_candidates else available_fields[0]\n",
+    "    image = events[0][\"data\"][IMAGE_FIELD]\n",
+    "    print(\n",
+    "        IMAGE_FIELD,\n",
+    "        type(image),\n",
+    "        getattr(image, \"shape\", None),\n",
+    "        getattr(image, \"dtype\", None),\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "plot-image",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if events and IMAGE_FIELD:\n",
+    "    plt.imshow(events[0][\"data\"][IMAGE_FIELD], cmap=\"gray\")\n",
+    "    plt.axis(\"off\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "archived-camera-heading",
+   "metadata": {},
+   "source": [
+    "## Existing Scan Camera Shot\n",
+    "\n",
+    "Set these parameters to an existing camera shot. The helper resolves the scan folder through `geecs_data_utils.ScanPaths`, queries the live GEECS DB for the device type, builds Resource/Datum/Event docs, and fills the image through the local handler."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "archived-camera-parameters",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "RUN_ARCHIVED_CAMERA_LOOKUP = False\n",
+    "\n",
+    "EXPERIMENT = \"Undulator\"\n",
+    "YEAR = 2026\n",
+    "MONTH = 6\n",
+    "DAY = 23\n",
+    "SCAN_NUMBER = 1\n",
+    "DEVICE_NAME = \"UC_Amp2_IR_input\"\n",
+    "SHOT_NUMBER = 1\n",
+    "BASE_DIRECTORY = None"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "archived-camera-fill",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "camera_image = None\n",
+    "camera_field = \"\"\n",
+    "camera_file = None\n",
+    "\n",
+    "if RUN_ARCHIVED_CAMERA_LOOKUP:\n",
+    "    camera_docs, camera_file = build_camera_shot_documents(\n",
+    "        year=YEAR,\n",
+    "        month=MONTH,\n",
+    "        day=DAY,\n",
+    "        scan_number=SCAN_NUMBER,\n",
+    "        device_name=DEVICE_NAME,\n",
+    "        shot_number=SHOT_NUMBER,\n",
+    "        experiment=EXPERIMENT,\n",
+    "        base_directory=BASE_DIRECTORY,\n",
+    "    )\n",
+    "    filled_camera_docs = fill_geecs_documents(camera_docs, retry_intervals=[])\n",
+    "    camera_event = next(doc for name, doc in filled_camera_docs if name == \"event\")\n",
+    "    camera_field = next(iter(camera_event[\"data\"]))\n",
+    "    camera_image = camera_event[\"data\"][camera_field]\n",
+    "\n",
+    "    print(camera_file)\n",
+    "    print(camera_field, type(camera_image), camera_image.shape, camera_image.dtype)\n",
+    "else:\n",
+    "    print(\"Set RUN_ARCHIVED_CAMERA_LOOKUP = True after entering a real scan.\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "archived-camera-plot",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if camera_image is not None:\n",
+    "    plt.imshow(camera_image, cmap=\"gray\")\n",
+    "    plt.axis(\"off\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "synthetic-smoke-heading",
+   "metadata": {},
+   "source": [
+    "## Local Synthetic Smoke Test\n",
+    "\n",
+    "This creates a temporary GEECS-style camera PNG and a minimal Resource/Datum/Event stream, then fills the datum ID into a NumPy array. It does not touch hardware or Tiled."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "synthetic-smoke",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with TemporaryDirectory() as temp_dir:\n",
+    "    root = Path(temp_dir) / \"Scan001\"\n",
+    "    image_path = root / \"UC_TopView\" / \"UC_TopView_1.000.png\"\n",
+    "    image_path.parent.mkdir(parents=True)\n",
+    "\n",
+    "    expected = np.array([[1, 2], [3, 4]], dtype=np.uint8)\n",
+    "    with image_path.open(\"wb\") as stream:\n",
+    "        png.Writer(width=2, height=2, greyscale=True, bitdepth=8).write(\n",
+    "            stream, expected.tolist()\n",
+    "        )\n",
+    "\n",
+    "    start_uid = str(uuid4())\n",
+    "    descriptor_uid = str(uuid4())\n",
+    "    resource_uid = str(uuid4())\n",
+    "    datum_id = f\"{resource_uid}/0\"\n",
+    "\n",
+    "    docs = [\n",
+    "        (\"start\", {\"uid\": start_uid, \"time\": 0}),\n",
+    "        (\n",
+    "            \"descriptor\",\n",
+    "            {\n",
+    "                \"uid\": descriptor_uid,\n",
+    "                \"run_start\": start_uid,\n",
+    "                \"time\": 0,\n",
+    "                \"name\": \"primary\",\n",
+    "                \"data_keys\": {\n",
+    "                    \"uc_topview-image\": {\n",
+    "                        \"source\": \"geecs://UC_TopView/image\",\n",
+    "                        \"dtype\": \"array\",\n",
+    "                        \"shape\": [],\n",
+    "                        \"external\": \"OLD:\",\n",
+    "                    }\n",
+    "                },\n",
+    "                \"configuration\": {},\n",
+    "                \"object_keys\": {\"uc_topview\": [\"uc_topview-image\"]},\n",
+    "                \"hints\": {},\n",
+    "            },\n",
+    "        ),\n",
+    "        (\n",
+    "            \"resource\",\n",
+    "            {\n",
+    "                \"uid\": resource_uid,\n",
+    "                \"spec\": GEECS_CAMERA_IMAGE,\n",
+    "                \"root\": str(root),\n",
+    "                \"resource_path\": \"UC_TopView/UC_TopView_1.000.png\",\n",
+    "                \"resource_kwargs\": {\"data_key\": \"uc_topview-image\"},\n",
+    "                \"path_semantics\": \"posix\",\n",
+    "            },\n",
+    "        ),\n",
+    "        (\"datum\", {\"datum_id\": datum_id, \"resource\": resource_uid, \"datum_kwargs\": {}}),\n",
+    "        (\n",
+    "            \"event\",\n",
+    "            {\n",
+    "                \"uid\": str(uuid4()),\n",
+    "                \"descriptor\": descriptor_uid,\n",
+    "                \"time\": 0,\n",
+    "                \"seq_num\": 1,\n",
+    "                \"data\": {\"uc_topview-image\": datum_id},\n",
+    "                \"timestamps\": {\"uc_topview-image\": 0},\n",
+    "                \"filled\": {\"uc_topview-image\": False},\n",
+    "            },\n",
+    "        ),\n",
+    "        (\n",
+    "            \"stop\",\n",
+    "            {\n",
+    "                \"uid\": str(uuid4()),\n",
+    "                \"run_start\": start_uid,\n",
+    "                \"time\": 1,\n",
+    "                \"exit_status\": \"success\",\n",
+    "                \"num_events\": {\"primary\": 1},\n",
+    "            },\n",
+    "        ),\n",
+    "    ]\n",
+    "\n",
+    "    filled = fill_geecs_documents(docs, retry_intervals=[])\n",
+    "    event = next(doc for name, doc in filled if name == \"event\")\n",
+    "    image = event[\"data\"][\"uc_topview-image\"]\n",
+    "    np.testing.assert_array_equal(image, expected)\n",
+    "    print(type(image), image.shape, image.dtype)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/GeecsBluesky/pyproject.toml
+++ b/GeecsBluesky/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-bluesky"
-version = "0.12.0"
+version = "0.12.1"
 description = "Bluesky / ophyd-async bridge for the GEECS control system"
 authors = ["Sam Barber <sbarber@lbl.gov>"]
 readme = "README.md"

--- a/GeecsBluesky/tests/test_assets.py
+++ b/GeecsBluesky/tests/test_assets.py
@@ -6,6 +6,7 @@ import numpy as np
 import png
 from bluesky import RunEngine
 import bluesky.plan_stubs as bps
+from event_model import Filler
 
 from geecs_bluesky.assets import (
     FROG_DEVICE_TYPE,
@@ -20,10 +21,14 @@ from geecs_bluesky.assets import (
     THORLABS_CCS175_SPECTROMETER_DEVICE_TYPE,
     THORLABS_WFS_DEVICE_TYPE,
     GeecsCameraImageHandler,
+    build_camera_shot_documents,
     camera_image_filename,
+    fill_geecs_documents,
+    geecs_asset_handler_registry,
     get_asset_definitions,
     get_single_asset_definition,
     native_file_filename,
+    register_geecs_handlers,
     supports_device_type,
 )
 from geecs_bluesky.devices.nonscalar_save import NonScalarSaveSupport
@@ -269,6 +274,20 @@ def test_camera_image_handler_loads_png(tmp_path) -> None:
     np.testing.assert_array_equal(handler(), expected)
 
 
+def test_geecs_handler_registry_maps_camera_spec() -> None:
+    """The public readback registry should expose the camera image handler."""
+    registry = geecs_asset_handler_registry()
+    assert registry == {GEECS_CAMERA_IMAGE: GeecsCameraImageHandler}
+
+
+def test_register_geecs_handlers_adds_camera_spec_to_filler() -> None:
+    """The registration helper should configure an existing filler."""
+    filler = Filler({}, inplace=False, retry_intervals=[])
+    register_geecs_handlers(filler, overwrite=True)
+
+    assert filler.handler_registry[GEECS_CAMERA_IMAGE] is GeecsCameraImageHandler
+
+
 def test_nonscalar_save_support_emits_camera_asset_docs(tmp_path) -> None:
     """NonScalarSaveSupport should pair datum readings with Resource/Datum docs."""
     scan_folder = tmp_path / "scans" / "Scan042"
@@ -373,3 +392,79 @@ def test_run_engine_emits_external_asset_docs_from_readable(tmp_path) -> None:
     assert event["filled"]["uc_topview-image"] is False
     assert resource["root"] == str(scan_folder)
     assert resource["resource_path"] == "UC_TopView/UC_TopView_1000.500.png"
+
+
+def test_geecs_documents_fill_camera_image_asset(tmp_path) -> None:
+    """GEECS Resource/Datum docs should fill camera datum IDs into arrays."""
+    scan_folder = tmp_path / "scans" / "Scan042"
+    image_path = scan_folder / "UC_TopView" / "UC_TopView_1000.500.png"
+    image_path.parent.mkdir(parents=True)
+    expected = np.array([[10, 20], [30, 40]], dtype=np.uint8)
+    with image_path.open("wb") as stream:
+        png.Writer(width=2, height=2, greyscale=True, bitdepth=8).write(
+            stream, expected.tolist()
+        )
+
+    emitter = _ReadableAssetEmitter()
+    emitter.configure_nonscalar_file_logging(scan_folder / "UC_TopView")
+    emitter.configure_external_asset_logging(
+        scan_number=42,
+        asset_definitions=get_asset_definitions(POINTGREY_CAMERA_DEVICE_TYPE),
+        root_path=scan_folder,
+    )
+    docs = []
+
+    def plan():
+        yield from bps.open_run()
+        yield from bps.create()
+        yield from bps.read(emitter)
+        yield from bps.save()
+        yield from bps.close_run()
+
+    RunEngine({})(plan(), lambda name, doc: docs.append((name, doc)))
+
+    filled_docs = fill_geecs_documents(docs, retry_intervals=[])
+    event = next(doc for name, doc in filled_docs if name == "event")
+    original_event = next(doc for name, doc in docs if name == "event")
+
+    assert original_event["filled"]["uc_topview-image"] is False
+    assert (
+        event["filled"]["uc_topview-image"]
+        == original_event["data"]["uc_topview-image"]
+    )
+    np.testing.assert_array_equal(event["data"]["uc_topview-image"], expected)
+
+
+def test_build_camera_shot_documents_resolves_legacy_scan_file(tmp_path) -> None:
+    """Camera shot helper should resolve existing legacy scan-folder images."""
+    scan_folder = (
+        tmp_path / "Undulator" / "Y2026" / "06-Jun" / "26_0623" / "scans" / "Scan042"
+    )
+    image_path = scan_folder / "UC_TopView" / "Scan042_UC_TopView_001.png"
+    image_path.parent.mkdir(parents=True)
+    expected = np.array([[5, 6], [7, 8]], dtype=np.uint8)
+    with image_path.open("wb") as stream:
+        png.Writer(width=2, height=2, greyscale=True, bitdepth=8).write(
+            stream, expected.tolist()
+        )
+
+    docs, resolved_path = build_camera_shot_documents(
+        year=2026,
+        month=6,
+        day=23,
+        scan_number=42,
+        device_name="UC_TopView",
+        shot_number=1,
+        experiment="Undulator",
+        base_directory=tmp_path,
+        device_type=POINTGREY_CAMERA_DEVICE_TYPE,
+    )
+
+    assert resolved_path == image_path
+    resource = next(doc for name, doc in docs if name == "resource")
+    assert resource["root"] == str(scan_folder)
+    assert resource["resource_path"] == "UC_TopView/Scan042_UC_TopView_001.png"
+
+    filled_docs = fill_geecs_documents(docs, retry_intervals=[])
+    event = next(doc for name, doc in filled_docs if name == "event")
+    np.testing.assert_array_equal(event["data"]["uc_topview-image"], expected)


### PR DESCRIPTION
## Summary
- add local GEECS external asset readback helpers around event_model.Filler
- make GeecsCameraImageHandler tolerate Resource metadata such as data_key
- add a camera shot helper that resolves existing legacy scan-folder images by year/month/day/scan/device/shot, queries the GEECS DB for device type by default, and builds fillable Resource/Datum docs
- add a local external asset readback notebook with a gated existing-scan lookup and a synthetic camera PNG smoke test
- bump geecs-bluesky to 0.12.1 and update the changelog

## Verification
- PYTHONPATH=GeecsBluesky:GEECS-Data-Utils python -m pytest GeecsBluesky/tests/test_assets.py -q
- PYTHONPATH=GeecsBluesky:GEECS-Data-Utils python -m ruff check GeecsBluesky/geecs_bluesky/assets GeecsBluesky/tests/test_assets.py
- PYTHONPATH=GeecsBluesky:GEECS-Data-Utils python -m ruff format --check GeecsBluesky/geecs_bluesky/assets GeecsBluesky/tests/test_assets.py
- PYTHONPATH=GeecsBluesky:GEECS-Data-Utils python -m pydocstyle GeecsBluesky/geecs_bluesky/assets GeecsBluesky/tests/test_assets.py --convention=numpy
- PYTHONPATH=GeecsBluesky:GEECS-Data-Utils python -m compileall -q GeecsBluesky/geecs_bluesky/assets GeecsBluesky/tests/test_assets.py
- PYTHONPATH=... python -m pytest GeecsBluesky/tests -m 'not integration' --tb=short -q (rerun outside sandbox for fake-server sockets)
- jupyter nbconvert --execute --to notebook --stdout --ExecutePreprocessor.kernel_name=geecs-assets-readback GeecsBluesky/notebooks/external_asset_readback.ipynb