### PR TITLE
Fix camera asset readback filename resolution

### DIFF
--- a/GeecsBluesky/CHANGELOG.md
+++ b/GeecsBluesky/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to `geecs-bluesky` are documented here.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.12.3] - 2026-06-24
+
+### Fixed
+
+- Existing-scan camera asset readback now resolves both legacy
+  `ScanNNN_Device_001.png` files and Bluesky/native `Device_<acq_timestamp>.png`
+  files. The notebook helper accepts an explicit acquisition timestamp or maps
+  a shot number to timestamp-sorted native files when no legacy shot-number file
+  exists.
+
 ## [0.12.2] - 2026-06-24
 
 ### Changed

--- a/GeecsBluesky/geecs_bluesky/assets/readback.py
+++ b/GeecsBluesky/geecs_bluesky/assets/readback.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Iterable, Mapping, Sequence
 from pathlib import Path
+import re
 import time
 from typing import Protocol, TypeAlias
 from uuid import uuid4
@@ -16,6 +17,49 @@ from geecs_bluesky.assets.specs import GEECS_CAMERA_IMAGE
 
 HandlerRegistry: TypeAlias = dict[str, type[GeecsCameraImageHandler]]
 Document: TypeAlias = tuple[str, dict[str, object]]
+
+
+def _timestamp_token(acq_timestamp: float | str) -> str:
+    """Return the native GEECS timestamp filename token."""
+    return f"{float(acq_timestamp):.3f}"
+
+
+def _native_timestamp_path(
+    scan_folder: Path,
+    *,
+    device_name: str,
+    acq_timestamp: float | str,
+) -> Path:
+    """Return the native Bluesky/GEECS camera file path for a timestamp."""
+    return (
+        scan_folder
+        / device_name
+        / f"{device_name}_{_timestamp_token(acq_timestamp)}.png"
+    )
+
+
+def _native_timestamp_file_map(scan_folder: Path, device_name: str) -> dict[int, Path]:
+    """Return 1-based shot index to native timestamp-named camera files."""
+    device_folder = scan_folder / device_name
+    if not device_folder.exists():
+        return {}
+
+    pattern = re.compile(rf"^{re.escape(device_name)}_(\d+(?:\.\d+)?).png$")
+    timestamped_files: list[tuple[float, Path]] = []
+    for file_path in device_folder.iterdir():
+        if not file_path.is_file():
+            continue
+        match = pattern.match(file_path.name)
+        if match:
+            timestamped_files.append((float(match.group(1)), file_path))
+
+    return {
+        index: file_path
+        for index, (_timestamp, file_path) in enumerate(
+            sorted(timestamped_files, key=lambda item: item[0]),
+            start=1,
+        )
+    }
 
 
 class HandlerRegistrar(Protocol):
@@ -137,7 +181,8 @@ def build_camera_shot_documents(
     day: int,
     scan_number: int,
     device_name: str,
-    shot_number: int,
+    shot_number: int | None = None,
+    acq_timestamp: float | str | None = None,
     experiment: str | None = None,
     base_directory: str | Path | None = None,
     device_type: str | None = None,
@@ -145,9 +190,9 @@ def build_camera_shot_documents(
     """Build fillable Resource/Datum/Event docs for an existing camera shot.
 
     This is intended for notebook readback tests against historical scan
-    folders. It resolves the legacy post-filemover camera filename such as
-    ``Scan042_UC_TopView_001.png`` and represents it as a
-    ``GEECS_CAMERA_IMAGE`` external asset.
+    folders. It supports both legacy post-filemover camera filenames such as
+    ``Scan042_UC_TopView_001.png`` and direct Bluesky/native filenames such as
+    ``UC_TopView_1234567890.123.png``.
 
     Parameters
     ----------
@@ -159,7 +204,13 @@ def build_camera_shot_documents(
     device_name:
         Camera device name and scan-folder subdirectory.
     shot_number:
-        Legacy shot number in the device image filename.
+        Shot number to resolve. For legacy files, this is the zero-padded number
+        in ``ScanNNN_Device_001.png``. For native timestamp files without an
+        explicit ``acq_timestamp``, this is interpreted as a 1-based index into
+        the device folder's timestamp-sorted native files.
+    acq_timestamp:
+        Optional native acquisition timestamp. When supplied, this is used to
+        construct the direct Bluesky/native filename first.
     experiment:
         Optional experiment name. If omitted, ``ScanPaths`` uses the configured
         default experiment.
@@ -182,6 +233,9 @@ def build_camera_shot_documents(
         If the resolved device type is not registered as a single camera asset.
     """
     from geecs_data_utils.scan_paths import ScanPaths
+
+    if shot_number is None and acq_timestamp is None:
+        raise ValueError("Either shot_number or acq_timestamp must be provided.")
 
     if device_type is None:
         from geecs_bluesky.db.geecs_db import GeecsDb
@@ -207,21 +261,44 @@ def build_camera_shot_documents(
     if scan_folder is None:
         raise FileNotFoundError(f"Could not resolve scan folder for {tag}")
 
-    file_path = scan_paths.build_asset_path(
-        shot=shot_number,
-        device=device_name,
-        ext="png",
-    )
-    if not file_path.exists():
-        file_map = scan_paths.build_device_file_map(device_name, ".png")
-        try:
-            file_path = file_map[shot_number]
-        except KeyError as exc:
-            raise FileNotFoundError(
-                "Could not find camera shot file for "
-                f"{tag}, device={device_name!r}, shot={shot_number}. "
-                f"Expected {file_path}."
-            ) from exc
+    attempted_paths: list[Path] = []
+    file_path: Path | None = None
+
+    if acq_timestamp is not None:
+        candidate = _native_timestamp_path(
+            scan_folder,
+            device_name=device_name,
+            acq_timestamp=acq_timestamp,
+        )
+        attempted_paths.append(candidate)
+        if candidate.exists():
+            file_path = candidate
+
+    if file_path is None and shot_number is not None:
+        legacy_candidate = scan_paths.build_asset_path(
+            shot=shot_number,
+            device=device_name,
+            ext="png",
+        )
+        attempted_paths.append(legacy_candidate)
+        if legacy_candidate.exists():
+            file_path = legacy_candidate
+
+    if file_path is None and shot_number is not None:
+        legacy_file_map = scan_paths.build_device_file_map(device_name, ".png")
+        file_path = legacy_file_map.get(shot_number)
+
+    if file_path is None and shot_number is not None:
+        native_file_map = _native_timestamp_file_map(scan_folder, device_name)
+        file_path = native_file_map.get(shot_number)
+
+    if file_path is None:
+        attempted = ", ".join(str(path) for path in attempted_paths) or "(none)"
+        raise FileNotFoundError(
+            "Could not find camera image file for "
+            f"{tag}, device={device_name!r}, shot={shot_number}, "
+            f"acq_timestamp={acq_timestamp!r}. Tried {attempted}."
+        )
 
     data_key = definition.event_key(device_name)
     resource_uid = str(uuid4())

--- a/GeecsBluesky/notebooks/external_asset_readback.ipynb
+++ b/GeecsBluesky/notebooks/external_asset_readback.ipynb
@@ -105,7 +105,7 @@
    "source": [
     "## Existing Scan Camera Shot\n",
     "\n",
-    "Set these parameters to an existing camera shot. The helper resolves the scan folder through `geecs_data_utils.ScanPaths`, queries the live GEECS DB for the device type, builds Resource/Datum/Event docs, and fills the image through the local handler."
+    "Set these parameters to an existing camera shot. The helper resolves the scan folder through `geecs_data_utils.ScanPaths`, queries the live GEECS DB for the device type, builds Resource/Datum/Event docs, and fills the image through the local handler. It supports both legacy `ScanNNN_Device_001.png` files and Bluesky/native `Device_<acq_timestamp>.png` files."
    ]
   },
   {
@@ -124,6 +124,7 @@
     "SCAN_NUMBER = 1\n",
     "DEVICE_NAME = \"UC_Amp2_IR_input\"\n",
     "SHOT_NUMBER = 1\n",
+    "ACQ_TIMESTAMP = None\n",
     "BASE_DIRECTORY = None"
    ]
   },
@@ -146,6 +147,7 @@
     "        scan_number=SCAN_NUMBER,\n",
     "        device_name=DEVICE_NAME,\n",
     "        shot_number=SHOT_NUMBER,\n",
+    "        acq_timestamp=ACQ_TIMESTAMP,\n",
     "        experiment=EXPERIMENT,\n",
     "        base_directory=BASE_DIRECTORY,\n",
     "    )\n",

--- a/GeecsBluesky/pyproject.toml
+++ b/GeecsBluesky/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-bluesky"
-version = "0.12.2"
+version = "0.12.3"
 description = "Bluesky / ophyd-async bridge for the GEECS control system"
 authors = ["Sam Barber <sbarber@lbl.gov>"]
 readme = "README.md"

--- a/GeecsBluesky/tests/test_assets.py
+++ b/GeecsBluesky/tests/test_assets.py
@@ -468,3 +468,77 @@ def test_build_camera_shot_documents_resolves_legacy_scan_file(tmp_path) -> None
     filled_docs = fill_geecs_documents(docs, retry_intervals=[])
     event = next(doc for name, doc in filled_docs if name == "event")
     np.testing.assert_array_equal(event["data"]["uc_topview-image"], expected)
+
+
+def test_build_camera_shot_documents_resolves_native_timestamp_file(tmp_path) -> None:
+    """Camera shot helper should resolve direct Bluesky timestamp filenames."""
+    scan_folder = (
+        tmp_path / "Undulator" / "Y2026" / "06-Jun" / "26_0623" / "scans" / "Scan014"
+    )
+    image_path = scan_folder / "UC_Amp2_IR_input" / "UC_Amp2_IR_input_1000.500.png"
+    image_path.parent.mkdir(parents=True)
+    expected = np.array([[1, 3], [5, 7]], dtype=np.uint8)
+    with image_path.open("wb") as stream:
+        png.Writer(width=2, height=2, greyscale=True, bitdepth=8).write(
+            stream, expected.tolist()
+        )
+
+    docs, resolved_path = build_camera_shot_documents(
+        year=2026,
+        month=6,
+        day=23,
+        scan_number=14,
+        device_name="UC_Amp2_IR_input",
+        shot_number=1,
+        acq_timestamp=1000.5,
+        experiment="Undulator",
+        base_directory=tmp_path,
+        device_type=POINTGREY_CAMERA_DEVICE_TYPE,
+    )
+
+    assert resolved_path == image_path
+    resource = next(doc for name, doc in docs if name == "resource")
+    assert resource["resource_path"] == "UC_Amp2_IR_input/UC_Amp2_IR_input_1000.500.png"
+
+    filled_docs = fill_geecs_documents(docs, retry_intervals=[])
+    event = next(doc for name, doc in filled_docs if name == "event")
+    np.testing.assert_array_equal(event["data"]["uc_amp2_ir_input-image"], expected)
+
+
+def test_build_camera_shot_documents_maps_shot_to_native_timestamp_file(
+    tmp_path,
+) -> None:
+    """Camera shot helper should map shot number onto sorted native files."""
+    scan_folder = (
+        tmp_path / "Undulator" / "Y2026" / "06-Jun" / "26_0623" / "scans" / "Scan014"
+    )
+    device_folder = scan_folder / "UC_Amp2_IR_input"
+    device_folder.mkdir(parents=True)
+
+    first = np.array([[1, 1], [1, 1]], dtype=np.uint8)
+    second = np.array([[2, 2], [2, 2]], dtype=np.uint8)
+    for image_path, image in (
+        (device_folder / "UC_Amp2_IR_input_1000.500.png", first),
+        (device_folder / "UC_Amp2_IR_input_1001.500.png", second),
+    ):
+        with image_path.open("wb") as stream:
+            png.Writer(width=2, height=2, greyscale=True, bitdepth=8).write(
+                stream, image.tolist()
+            )
+
+    docs, resolved_path = build_camera_shot_documents(
+        year=2026,
+        month=6,
+        day=23,
+        scan_number=14,
+        device_name="UC_Amp2_IR_input",
+        shot_number=2,
+        experiment="Undulator",
+        base_directory=tmp_path,
+        device_type=POINTGREY_CAMERA_DEVICE_TYPE,
+    )
+
+    assert resolved_path == device_folder / "UC_Amp2_IR_input_1001.500.png"
+    filled_docs = fill_geecs_documents(docs, retry_intervals=[])
+    event = next(doc for name, doc in filled_docs if name == "event")
+    np.testing.assert_array_equal(event["data"]["uc_amp2_ir_input-image"], second)


### PR DESCRIPTION
## Summary
- resolve existing camera assets from either legacy ScanNNN_Device_001.png filenames or Bluesky/native Device_<acq_timestamp>.png filenames
- allow archived readback callers to pass ACQ_TIMESTAMP explicitly, while preserving SHOT_NUMBER lookup for legacy files
- fall back to timestamp-sorted native camera files so notebook readback works for Bluesky-created scan folders

## Validation
- pytest GeecsBluesky/tests/test_assets.py -q
- ruff check GeecsBluesky/geecs_bluesky/assets GeecsBluesky/tests/test_assets.py
- ruff format --check GeecsBluesky/geecs_bluesky/assets GeecsBluesky/tests/test_assets.py
- pydocstyle GeecsBluesky/geecs_bluesky/assets GeecsBluesky/tests/test_assets.py --convention=numpy
- compileall -q GeecsBluesky/geecs_bluesky/assets GeecsBluesky/tests/test_assets.py
- executed GeecsBluesky/notebooks/external_asset_readback.ipynb with archived lookup disabled
- verified an archived Bluesky camera lookup resolves a native timestamp filename and fills the image as a uint16 array

## Note
When ACQ_TIMESTAMP is omitted for native timestamp files, SHOT_NUMBER is interpreted as a 1-based index into timestamp-sorted files. That keeps the notebook useful during the scanner transition, but exact event semantics should eventually come from the Bluesky/Tiled document stream.