### PR TITLE
Map Tiled camera asset roots locally

### DIFF
--- a/GeecsBluesky/CHANGELOG.md
+++ b/GeecsBluesky/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to `geecs-bluesky` are documented here.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.13.1] - 2026-06-25
+
+### Fixed
+
+- Tiled-backed local camera readback now maps Windows/device-server data roots
+  such as `Z:/data` to local data mounts such as `/Volumes/hdna2/data` before
+  constructing Resource/Datum documents, avoiding OS-dependent
+  `Path.relative_to` failures.
+
+### Documentation
+
+- Added the external-assets roadmap/status document with the current
+  acquisition, local-fill, root-mapping, and post-run-analysis next steps.
+
 ## [0.13.0] - 2026-06-24
 
 ### Changed
@@ -16,6 +30,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - The standalone hardware smoke harness now runs no-shot-control scenarios in
   explicit `free_run_time_sync` mode and uses true ARMED strict mode for
   shot-control/full-output checks.
+
 ### Added
 
 - Added Tiled-backed local camera asset readback helpers. Archived Bluesky runs

--- a/GeecsBluesky/geecs_bluesky/assets/tiled_readback.py
+++ b/GeecsBluesky/geecs_bluesky/assets/tiled_readback.py
@@ -52,6 +52,24 @@ def read_tiled_config() -> tuple[str | None, str | None]:
     return cfg["tiled"].get("uri") or None, cfg["tiled"].get("api_key") or None
 
 
+def read_geecs_root_map() -> dict[str, str]:
+    """Read a device-server to local data-root map from the GEECS config."""
+    config_path = Path.home() / ".config" / "geecs_python_api" / "config.ini"
+    if not config_path.exists():
+        return {}
+
+    cfg = configparser.ConfigParser()
+    cfg.read(config_path)
+    if "Paths" not in cfg:
+        return {}
+
+    remote_root = cfg["Paths"].get("geecs_device_server_data_base_path")
+    local_root = cfg["Paths"].get("GEECS_DATA_LOCAL_BASE_PATH")
+    if not remote_root or not local_root:
+        return {}
+    return {remote_root: local_root}
+
+
 def load_tiled_client(
     *,
     tiled_uri: str | None = None,
@@ -185,6 +203,7 @@ def resolve_camera_asset_from_event(
     event: Mapping[str, Any],
     device_name: str,
     device_type: str | None = None,
+    root_map: Mapping[str, str] | None = None,
 ) -> TiledCameraAsset:
     """Resolve a camera asset from archived Tiled run metadata and one event.
 
@@ -207,7 +226,11 @@ def resolve_camera_asset_from_event(
     event_dict = dict(event)
     start_dict = dict(start_doc)
     scan_number = _required_int(start_dict, "scan_number")
-    scan_folder = _required_path(start_dict, "scan_folder")
+    effective_root_map = dict(root_map or read_geecs_root_map())
+    scan_folder = _mapped_path(
+        _required_str(start_dict, "scan_folder"),
+        effective_root_map,
+    )
     data_key = definition.event_key(device_name)
     acq_key = f"{safe_name(device_name)}-acq_timestamp"
     save_path_key = f"{safe_name(device_name)}-nonscalar_save_path"
@@ -215,7 +238,7 @@ def resolve_camera_asset_from_event(
     acq_timestamp = _required_float(event_dict, acq_key)
     save_path_value = event_dict.get(save_path_key)
     save_path = (
-        Path(str(save_path_value))
+        _mapped_path(str(save_path_value), effective_root_map)
         if not _is_missing(save_path_value)
         else scan_folder / device_name
     )
@@ -272,10 +295,11 @@ def load_camera_image_from_tiled_run(
         event=event,
         device_name=device_name,
         device_type=device_type,
+        root_map=root_map,
     )
     filled_docs = fill_geecs_documents(
         asset.documents,
-        root_map=root_map,
+        root_map=root_map or read_geecs_root_map(),
         include=[asset.data_key],
         retry_intervals=retry_intervals,
     )
@@ -439,11 +463,32 @@ def _required_float(mapping: Mapping[str, Any], key: str) -> float:
     return float(value)
 
 
-def _required_path(mapping: Mapping[str, Any], key: str) -> Path:
+def _required_str(mapping: Mapping[str, Any], key: str) -> str:
     value = mapping.get(key)
     if _is_missing(value):
         raise KeyError(f"start document is missing {key!r}")
-    return Path(str(value))
+    return str(value)
+
+
+def _mapped_path(value: str, root_map: Mapping[str, str]) -> Path:
+    """Return *value* as a local path after applying a tolerant root map."""
+    normalized_value = _normalize_path_string(value)
+    for remote_root, local_root in root_map.items():
+        normalized_remote = _normalize_path_string(str(remote_root))
+        if normalized_value == normalized_remote or normalized_value.startswith(
+            f"{normalized_remote}/"
+        ):
+            relative = normalized_value.removeprefix(normalized_remote).lstrip("/")
+            return Path(str(local_root)).joinpath(*relative.split("/"))
+    return Path(value)
+
+
+def _normalize_path_string(value: str) -> str:
+    """Normalize Windows/POSIX separators for prefix comparisons."""
+    normalized = value.replace("\\", "/")
+    while "//" in normalized:
+        normalized = normalized.replace("//", "/")
+    return normalized.rstrip("/")
 
 
 def _datum_id_from_event(value: Any) -> str:

--- a/GeecsBluesky/pyproject.toml
+++ b/GeecsBluesky/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-bluesky"
-version = "0.13.0"
+version = "0.13.1"
 description = "Bluesky / ophyd-async bridge for the GEECS control system"
 authors = ["Sam Barber <sbarber@lbl.gov>"]
 readme = "README.md"

--- a/GeecsBluesky/tests/test_tiled_asset_readback.py
+++ b/GeecsBluesky/tests/test_tiled_asset_readback.py
@@ -12,6 +12,7 @@ import png
 import pytest
 
 from geecs_bluesky.assets.specs import POINTGREY_CAMERA_DEVICE_TYPE
+from geecs_bluesky.assets import tiled_readback
 from geecs_bluesky.assets.tiled_readback import (
     event_by_scan_event_index,
     find_geecs_run,
@@ -207,6 +208,73 @@ def test_load_camera_image_from_tiled_run_uses_event_timestamp(
 
     assert loaded.asset.file_path == device_folder / "UC_Amp2_IR_input_1001.500.png"
     np.testing.assert_array_equal(loaded.image, second)
+
+
+def test_load_camera_image_from_tiled_run_maps_windows_root(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Windows scan metadata should fill from the configured local root map."""
+    local_data_root = tmp_path / "hdna2" / "data"
+    local_scan_folder = (
+        local_data_root
+        / "Undulator"
+        / "Y2026"
+        / "06-Jun"
+        / "26_0625"
+        / "scans"
+        / "Scan001"
+    )
+    device_folder = local_scan_folder / "UC_Amp4_IR_input"
+    device_folder.mkdir(parents=True)
+    expected = np.array([[4, 4], [8, 8]], dtype=np.uint8)
+    image_path = device_folder / "UC_Amp4_IR_input_3865254648.364.png"
+    with image_path.open("wb") as stream:
+        png.Writer(width=2, height=2, greyscale=True, bitdepth=8).write(
+            stream, expected.tolist()
+        )
+
+    start_doc = {
+        "uid": "run-uid",
+        "time": datetime(
+            2026, 6, 25, tzinfo=ZoneInfo("America/Los_Angeles")
+        ).timestamp(),
+        "scan_number": 1,
+        "scan_folder": (r"Z:\data\Undulator\Y2026\06-Jun\26_0625\scans\Scan001"),
+        "experiment": "Undulator",
+    }
+    table = pd.DataFrame(
+        [
+            {
+                "scan_event_index": 5,
+                "uc_amp4_ir_input-acq_timestamp": 3865254648.364,
+                "uc_amp4_ir_input-nonscalar_save_path": (
+                    r"Z:\data\Undulator\Y2026\06-Jun\26_0625\scans"
+                    r"\Scan001\UC_Amp4_IR_input"
+                ),
+                "uc_amp4_ir_input-image": "resource-uid/0",
+            },
+        ]
+    )
+    monkeypatch.setattr(
+        tiled_readback,
+        "read_geecs_root_map",
+        lambda: {"Z:/data": str(local_data_root)},
+    )
+
+    loaded = load_camera_image_from_tiled_run(
+        _FakeRun(start_doc, table),
+        device_name="UC_Amp4_IR_input",
+        shot_number=5,
+        device_type=POINTGREY_CAMERA_DEVICE_TYPE,
+        retry_intervals=[],
+    )
+
+    assert loaded.asset.file_path == image_path
+    assert loaded.asset.resource_path == (
+        "UC_Amp4_IR_input/UC_Amp4_IR_input_3865254648.364.png"
+    )
+    np.testing.assert_array_equal(loaded.image, expected)
 
 
 def test_find_geecs_run_matches_scan_identity_by_date() -> None:

--- a/Planning/external_assets/00_overview.md
+++ b/Planning/external_assets/00_overview.md
@@ -1,0 +1,494 @@
+# Bluesky External Assets and Analysis Roadmap
+
+## Purpose
+
+This document sketches the path for representing native GEECS nonscalar files
+as Bluesky external assets while preserving the current GEECS scan-folder
+layout. The immediate goal is not to rewrite detector file saving. The goal is
+to make files already written by GEECS/LabVIEW devices visible to Bluesky,
+databroker/Tiled, notebooks, and later analysis tools through the standard
+external asset model.
+
+The first implementation has now proven the path with native saved camera image
+files. HASO, richer scope trace handling, post-run analysis logging, and
+optimization should build on the same foundation later.
+
+## Current State
+
+As of 2026-06-25, GeecsBluesky can command native nonscalar saving by setting
+device `localsavingpath` and `save` controls, emit Bluesky `Resource`/`Datum`
+documents for supported native files, preserve the existing string save-path
+fields for compatibility, and locally fill camera image assets from Tiled run
+metadata.
+
+Implemented pieces:
+
+- `geecs_bluesky.assets` contains asset specs, registry definitions, document
+  construction helpers, and a camera image handler.
+- Asset behavior is keyed by GEECS database device type, not by individual
+  device name.
+- `GeecsDb.get_device_type(device_name)` resolves device type strings from the
+  real GEECS database.
+- The registry covers the known native nonscalar file conventions from the
+  legacy file mover policy:
+  - `"Point Grey Camera"` camera PNG files
+  - `"FROG"` spatial and temporal image directories
+  - TDMS pair devices such as `"PicoscopeV2"`,
+    `"Thorlabs CCS175 Spectrometer"`, `"RohdeSchwarz_RTA4000"`, and
+    `"ThorlabsWFS"`
+  - `"MagSpecCamera"` and `"MagSpecStitcher"` image/text variants
+- Sync native-file-saving detectors emit datum-id event fields plus
+  `Resource`/`Datum` docs during acquisition.
+- Existing `<device>-nonscalar_save_path` string fields are kept for now.
+- Unregistered device types are ignored by the asset layer rather than breaking
+  acquisition.
+- Device-server save paths are translated from the scanner-local mount path to
+  the configured LabVIEW/device-server base path before writing
+  `localsavingpath`.
+- Tiled ingestion is guarded so an external-asset persistence failure warns and
+  disables that callback instead of aborting a scan.
+- `tiled_external_asset_readback.ipynb` demonstrates the local-first archive
+  readback path: user enters date, scan number, device, and shot number; the
+  helper queries Tiled for the real event row, resolves the datum ID, and fills
+  the camera image locally.
+- `load_camera_image_from_tiled(...)` and
+  `load_camera_image_from_tiled_run(...)` provide the notebook-proven library
+  path for camera images.
+- Local readback can map Windows/device-server roots such as `Z:/data` to local
+  mounts such as `/Volumes/hdna2/data` via explicit `root_map` or the shared
+  GEECS config.
+- Strict shot-control fallback was removed in PR #441. `strict_shot_control`
+  now means true plan-owned single-shot with a reachable `ARMED` shot-control
+  state. Free-running behavior should be requested explicitly with
+  `free_run_time_sync`.
+
+Important discoveries:
+
+- The database device type string for ordinary cameras is
+  `"Point Grey Camera"`, with spaces. It is not `PointGreyCamera`.
+- Direct LabVIEW/native saving writes raw filenames such as
+  `<device_name>_<acq_timestamp>.png` inside the device directory.
+- The legacy file mover later prepends `ScanXXX_` and may translate acquisition
+  timestamps to shot-number-based filenames. That legacy post-processing name
+  is not the filename emitted directly by the device server.
+- Asset field names should not be normalized into a new semantic style. They
+  should preserve the registry's native names, such as `interpSpec` and
+  `interpDiv`, and then pass through the existing GeecsBluesky safe-name logic.
+- On non-Windows scanner hosts, the path sent to device servers must use the
+  configured `geecs_device_server_data_base_path` such as `Z:/data`, even when
+  the scanner itself reads files through `/Volumes/hdna2/data`.
+
+During a run, events include enough context to locate native files:
+
+- scan folder metadata in the start document
+- nonscalar save directory metadata
+- per-event `acq_timestamp`
+- detector/device identity
+- datum IDs for registered external assets
+
+The system is now partway through the desired shift:
+
+```text
+legacy compatibility:
+  event data still contains save path + timestamp fields
+
+current Bluesky direction:
+  event data contains datum_id for registered native files
+  Resource/Datum docs describe where the native file lives
+  handlers know how to open that file when requested
+```
+
+The main remaining gap is Tiled-side support for these custom GEECS asset specs.
+Until the lab Tiled server has matching readers/adapters, GEECS datum IDs are
+stored as ordinary event metadata there rather than being fully fillable through
+Tiled.
+
+## Validation Snapshot
+
+Hardware validation has covered:
+
+- real database lookup for camera device type resolution
+- NOSCAN and STANDARD scanner acquisition
+- DG645 strict shot-control NOSCAN acquisition
+- native saved camera assets with `Resource`/`Datum` documents
+- emitted resource paths resolving to real PNG files on disk
+- scanner-local to device-server path translation
+- local Tiled readback of a camera asset from an archived Bluesky run
+
+Known example for local readback validation:
+
+```text
+experiment: Undulator
+date: 2026-06-24
+scan: Scan006
+device: UC_Amp2_IR_input
+shot: 2
+```
+
+`UC_Amp2_IR_input` was used for the clean native-save hardware smoke test.
+`UC_TopView` was reachable but had a physical camera/save issue during testing,
+so it should not be treated as the validation source for this checkpoint.
+
+On 2026-06-25, a GUI-launched strict-shot-control scan on Windows produced
+matching event/file counts, but the requested shot count was observed as `n+1`
+relative to the UI request. That appears separate from asset association and is
+likely tied to the scanner's time-derived `shots_per_step` model; track it as a
+scan-configuration semantics issue, not an external-assets blocker.
+
+## Design Principle
+
+Asset behavior should be keyed by **GEECS device type**, not by individual
+device name.
+
+For example, `UC_TopView` should not be special-cased. The database should tell
+the backend that `UC_TopView` is a `"Point Grey Camera"` device, and the asset
+system should look up the registered behavior for that type.
+
+This keeps the model scalable:
+
+```text
+device name -> GeecsDb -> device type -> asset registry -> asset docs/handler
+```
+
+## Proposed Package Boundaries
+
+```text
+geecs_data_utils.io
+  Generic file readers.
+  No Bluesky.
+  No ImageAnalyzer.
+  No optimization.
+
+geecs_bluesky.assets
+  Asset spec names.
+  Device-type asset registry.
+  Resource/Datum document emission.
+  Handler classes.
+
+geecs_bluesky.analysis
+  Bluesky-run-to-analysis adapters.
+  Analysis result logging.
+  Derived-run helpers.
+
+image_analysis
+  Per-image science logic.
+  Feature extraction.
+
+scan_analysis
+  Legacy scan-folder analysis plus reusable aggregation/reporting pieces.
+```
+
+## Phase 1: External Asset Foundation
+
+### Goals
+
+- Define a small `geecs_bluesky.assets` layer.
+- Add a device-type asset registry.
+- Emit formal Bluesky external asset references for native GEECS files.
+- Keep physical files in the normal `Scan###` directory tree.
+- Preserve scan-folder compatibility with the legacy GEECS ecosystem.
+
+Status: implemented in the current PR for the first supported device classes,
+with compatibility fields preserved.
+
+### MVP Target
+
+Start with native camera PNG files written by GEECS camera devices. This is now
+implemented for `"Point Grey Camera"` devices.
+
+Direct native camera files:
+
+```text
+<scan_folder>/<device_name>/<device_name>_<acq_timestamp>.png
+```
+
+where `acq_timestamp` is formatted to three decimal places.
+
+The legacy file mover may later rewrite or copy these into names such as
+`ScanXXX_<device_name>_<shot_number>.png`. The asset registry should point at
+the direct native save first, because that is the file available during Bluesky
+acquisition.
+
+The exact registry entry should be keyed by the database device type, for
+example:
+
+```text
+device_type: Point Grey Camera
+spec: GEECS_CAMERA_IMAGE
+extension: .png
+event field: image
+handler: GeecsCameraImageHandler
+```
+
+Do not hardcode `UC_TopView` behavior except in tests or examples.
+
+`"Point Grey Camera"` is the GEECS database device type used for all basic
+cameras, regardless of actual manufacturer. Conceptually this is closer to a
+generic NI-IMAQ camera type, but the asset registry should use the database
+string as it exists today.
+
+### Registry Shape
+
+The registry should encode file conventions by device type:
+
+```python
+AssetDefinition(
+    device_type="Point Grey Camera",
+    spec="GEECS_CAMERA_IMAGE",
+    event_field="image",
+    extensions=(".png",),
+    files_from_event=...,
+    handler="GeecsCameraImageHandler",
+)
+```
+
+The `files_from_event` logic should be able to use:
+
+- device name
+- device type
+- scan number
+- scan folder
+- nonscalar save directory
+- event timestamp / `acq_timestamp`
+- detector event field names
+
+Some device types emit multiple files for one event. The current PR handles the
+known multi-file conventions from the scanner file mover policy, but new device
+types should still be added explicitly and tested against real database device
+type strings.
+
+### Database Requirement
+
+`GeecsDb` exposes a lightweight query for device type:
+
+```python
+GeecsDb.get_device_type("UC_TopView") -> "Point Grey Camera"
+```
+
+Use `GEECS-PythonAPI` only as a reference for table/column names if needed.
+Do not import or depend on it from `GeecsBluesky`.
+
+This should continue to be tested with the real lab database when available,
+because stale assumptions about device type strings are easy to miss in pure
+unit tests.
+
+### Asset Document Shape
+
+For the MVP, prefer standard `Resource`/`Datum` external asset docs unless a
+specific databroker/Tiled constraint requires `StreamResource`/`StreamDatum`.
+
+Conceptually:
+
+```text
+Resource
+  uid: ...
+  spec: GEECS_CAMERA_IMAGE
+  root: /Volumes/hdna2/data/Undulator/Y2026/.../scans/Scan042
+  resource_path: UC_Amp2_IR_input/UC_Amp2_IR_input_1234567890.123.png
+  resource_kwargs: {}
+  path_semantics: posix
+
+Datum
+  datum_id: ...
+  resource: <resource uid>
+  datum_kwargs: {}
+
+Event
+  data:
+    uc_amp2_ir_input-image: <datum_id>
+  filled:
+    uc_amp2_ir_input-image: false
+```
+
+Use `root` + `resource_path` rather than storing only absolute strings in the
+event. This gives future clients a clean place to handle mount differences
+between lab machines, analysis workstations, and archives.
+
+For the first implementation, choose `root` so a normal consumer with the
+NetApp mapped can access the file directly from `root / resource_path`. The
+exact split can be adjusted, but it should not require consumers to know GEECS
+scan-folder conventions just to resolve the file.
+
+### File Completion
+
+The file may not exist at the exact instant the event document is assembled.
+For the camera MVP this should not block the design, because the filename is
+deterministic and files are expected to appear quickly.
+
+Implementation options:
+
+- emit deterministic asset docs during acquisition and let the handler retry
+  briefly if the file is not visible yet
+- defer asset association until after the run if a device type cannot provide
+  deterministic per-event filenames
+
+For cameras, prefer emitting asset docs during acquisition. This is the path
+needed for live consumers, and the filename is deterministic from the scan
+context, device name, and event `acq_timestamp`.
+
+The registry should allow post-run association eventually for device types that
+cannot provide deterministic per-event filenames.
+
+## Phase 2: Reader and Handler Layer
+
+Generic file readers have landed in `geecs_data_utils.io`, and
+`geecs_bluesky.assets.handlers` contains a thin camera image handler.
+
+Initial handler:
+
+```text
+GEECS_CAMERA_IMAGE
+  -> geecs_data_utils.io image reader
+  -> np.ndarray
+```
+
+Handlers should be thin I/O adapters:
+
+```text
+Resource + Datum -> loaded array/object
+```
+
+They should not run scientific analysis, make plots, decide pass/fail, or
+aggregate scan results.
+
+Status: implemented for camera images, including local Tiled event lookup and
+local fill. Text-array and TDMS-oriented specs are represented in the registry,
+but richer handler/readback behavior should be validated separately before
+relying on them for analysis.
+
+## Phase 3: Post-Run Analysis
+
+After native files can be represented and filled as external assets, add a
+post-run analysis layer that consumes Bluesky/Tiled runs.
+
+Desired flow:
+
+```text
+raw run
+  scalar data
+  external asset references
+
+post-run analysis job
+  stream events
+  fill assets event-by-event or in chunks
+  call ImageAnalysis feature extractors
+  persist derived results linked to the raw run
+```
+
+This should not route Bluesky runs through legacy scan-folder reconstruction
+unless the input is truly a legacy scan. For Bluesky runs, the event/resource
+model should already encode which file belongs to which shot.
+
+Possible output forms:
+
+- derived analysis run linked to the raw run UID
+- analysis event stream
+- Parquet/CSV summary indexed by run UID and scan number
+- processed external assets such as plots, reports, or normalized arrays
+
+The analysis product should record:
+
+- raw run UID
+- analysis code version
+- analysis configuration
+- input asset IDs or resource IDs
+- derived scalar/table/asset outputs
+
+## Phase 4: Optimization
+
+Optimization should use a narrow feature-extraction contract, not the full
+legacy `ScanAnalysis` orchestration.
+
+Conceptual loop:
+
+```text
+Xopt asks for next point
+Bluesky moves hardware and acquires shot(s)
+asset handler fills required image/trace data
+feature extractor computes objective/constraints
+Xopt receives result
+Bluesky records objective diagnostics
+```
+
+The optimizer usually needs a small, explicit result:
+
+```text
+objective
+constraints
+diagnostic scalars
+optional references to raw/derived assets
+```
+
+Do not block Phase 1/2 on optimization design. The asset model is the data
+access foundation optimization will need later.
+
+## Deferred Scope
+
+Do not include the following in the first external-assets implementation unless
+a later PR explicitly scopes it:
+
+- HASO `.himg` handling
+- full scope trace interpretation beyond native TDMS asset references
+- direct HDF5/Zarr/TIFF writing by Bluesky
+- post-run analysis result persistence
+- Xopt integration
+- new user-facing config schemas
+- splitting `geecs-bluesky` into a separate repo
+
+## Remaining Work
+
+- Add proper Tiled/databroker readers/adapters for custom GEECS asset specs so
+  assets are fillable through Tiled instead of stored only as datum-id metadata.
+- Decide whether Bluesky native-save runs need a finalization/mover step for
+  legacy filename compatibility, or whether direct native filenames are the
+  canonical Bluesky path.
+- Add opt-in integration coverage for local Tiled camera fill using a known run
+  such as 2026-06-24 Scan006 / `UC_Amp2_IR_input`.
+- Investigate the GUI/requested-shot-count `n+1` behavior separately from
+  external-asset readback.
+- Expand handler validation beyond camera PNGs only when there is a concrete
+  consumer for those file types.
+- Design the post-run analysis output contract for derived scalars, tables, and
+  processed assets linked to the raw run.
+
+## Testing Strategy
+
+Resolved choices:
+
+- `root` should be the scan folder, so `root / resource_path` directly resolves
+  to the native file for a consumer with the NetApp mounted.
+- Event field names should follow the current GeecsBluesky safe-name convention:
+  `<safe_device_name>-<safe_asset_field>`, for example `uc_topview-image`.
+- Asset docs should be emitted during acquisition for deterministic native file
+  conventions, especially camera images.
+
+No-hardware tests should continue to cover:
+
+1. Create a temporary scan-like folder with a synthetic camera PNG named using
+   the GEECS convention.
+2. Generate a synthetic Bluesky run containing an event with matching
+   `acq_timestamp` and a `"Point Grey Camera"` device type.
+3. Emit `Resource`/`Datum` docs for that image.
+4. Fill the event through the `GEECS_CAMERA_IMAGE` handler.
+5. Assert the filled value is the expected NumPy array.
+
+This proves the path construction, asset docs, handler registration, and fill
+behavior without requiring live hardware. A separate hardware harness or
+notebook should validate that real devices produce the expected filenames and
+that Tiled ingestion/readback works in the lab environment.
+
+## Recommended Next PRs
+
+1. Promote the notebook-proven Tiled camera readback path into a stable, small
+   API surface for "date/scan/device/shot -> filled camera asset"; keep the
+   notebook as a thin example.
+2. Add opt-in integration coverage for that API using a known archived run and
+   local root mapping.
+3. Run a fresh strict `ARMED` native-save hardware check after PR #441 and
+   confirm event count, file count, and asset fill agree.
+4. Define the minimal post-run feature-extraction result schema for analysis and
+   optimization consumers.
+5. Implement a small post-run analysis runner that consumes Bluesky runs, fills
+   image assets in chunks, and writes derived results linked to the raw run.
+6. Add HASO/scope-specific handlers only after the camera/Tiled path is proven
+   end-to-end.


### PR DESCRIPTION
## Summary
- map Windows/device-server data roots to local data mounts before constructing local Resource/Datum docs for Tiled camera readback
- read the default root map from the shared GEECS config while still allowing explicit root_map overrides
- add regression coverage for Windows-style metadata filling from a local POSIX path
- add the external-assets roadmap/status doc and bump geecs-bluesky to 0.13.1

## Validation
- Focused Tiled asset readback pytest passed
- Ruff, pydocstyle, and compileall passed for touched Python files
- A real archived Tiled camera image was loaded locally through the mapped-root path
