### PR TITLE
Use canonical roots for external assets

### DIFF
--- a/GeecsBluesky/CHANGELOG.md
+++ b/GeecsBluesky/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to `geecs-bluesky` are documented here.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.13.2] - 2026-06-26
+
+### Changed
+
+- External asset Resource documents now use the configured device-server data
+  root as their canonical `root` when available, with POSIX `resource_path`
+  values below that root, instead of always using the scan folder as root.
+- Resource path construction now normalizes Windows and POSIX separators before
+  computing relative paths.
+
+### Documentation
+
+- Updated the external-assets roadmap to describe canonical Resource writing,
+  reader-side root mapping, and the pre-production/test status of current Tiled
+  data.
+
 ## [0.13.1] - 2026-06-25
 
 ### Fixed

--- a/GeecsBluesky/geecs_bluesky/assets/registry.py
+++ b/GeecsBluesky/geecs_bluesky/assets/registry.py
@@ -24,6 +24,14 @@ from geecs_bluesky.utils import safe_name
 FilePathBuilder = Callable[[str | Path, int, str, float], Path]
 
 
+def _normalize_path_string(path: str | Path) -> str:
+    """Return *path* with POSIX separators and no trailing slash."""
+    normalized = str(path).replace("\\", "/")
+    while "//" in normalized:
+        normalized = normalized.replace("//", "/")
+    return normalized.rstrip("/")
+
+
 def camera_image_filename(
     scan_number: int,
     device_name: str,
@@ -119,9 +127,21 @@ class AssetDefinition:
         """Return the expected native file path for one event."""
         return self.path_builder(save_path, scan_number, device_name, acq_timestamp)
 
-    def resource_path(self, *, root: str | Path, file_path: str | Path) -> str:
+    def resource_path(
+        self,
+        *,
+        root: str | Path,
+        file_path: str | Path,
+        local_root: str | Path | None = None,
+    ) -> str:
         """Return the POSIX resource path for *file_path* relative to *root*."""
-        return Path(file_path).relative_to(root).as_posix()
+        base = _normalize_path_string(local_root or root)
+        path = _normalize_path_string(file_path)
+        if path == base:
+            return ""
+        if not path.startswith(f"{base}/"):
+            raise ValueError(f"{file_path!r} is not under resource root {base!r}")
+        return path.removeprefix(f"{base}/")
 
     def companion_file_paths(
         self,

--- a/GeecsBluesky/geecs_bluesky/devices/nonscalar_save.py
+++ b/GeecsBluesky/geecs_bluesky/devices/nonscalar_save.py
@@ -48,7 +48,8 @@ class NonScalarSaveSupport:
     _nonscalar_save_path: Path | None = None
     _asset_definitions: tuple[AssetDefinition, ...] = ()
     _asset_scan_number: int | None = None
-    _asset_root_path: Path | None = None
+    _asset_root_path: str | None = None
+    _asset_local_root_path: str | None = None
     _pending_asset_docs: deque[Asset]
 
     def _init_save_signals(
@@ -84,16 +85,22 @@ class NonScalarSaveSupport:
         scan_number: int,
         asset_definitions: tuple[AssetDefinition, ...],
         root_path: str | Path | None = None,
+        local_root_path: str | Path | None = None,
     ) -> None:
         """Configure Bluesky external asset docs for native file-saving devices."""
         self._asset_definitions = tuple(asset_definitions)
         self._asset_scan_number = scan_number
         if root_path is not None:
-            self._asset_root_path = Path(root_path)
+            self._asset_root_path = str(root_path)
         elif self._nonscalar_save_path is not None:
-            self._asset_root_path = self._nonscalar_save_path.parent
+            self._asset_root_path = str(self._nonscalar_save_path.parent)
         else:
             self._asset_root_path = None
+        self._asset_local_root_path = (
+            str(local_root_path)
+            if local_root_path is not None
+            else self._asset_root_path
+        )
         self._pending_asset_docs = deque()
 
     def _save_path_datakey(self) -> dict[str, DataKey]:
@@ -180,6 +187,7 @@ class NonScalarSaveSupport:
         if (
             self._nonscalar_save_path is None
             or self._asset_root_path is None
+            or self._asset_local_root_path is None
             or self._asset_scan_number is None
             or acq_timestamp is None
             or not math.isfinite(float(acq_timestamp))
@@ -206,7 +214,11 @@ class NonScalarSaveSupport:
         )
         if companion_paths:
             resource_kwargs["companion_resource_paths"] = [
-                definition.resource_path(root=self._asset_root_path, file_path=path)
+                definition.resource_path(
+                    root=self._asset_root_path,
+                    file_path=path,
+                    local_root=self._asset_local_root_path,
+                )
                 for path in companion_paths
             ]
 
@@ -217,7 +229,9 @@ class NonScalarSaveSupport:
             resource_path=definition.resource_path(
                 root=self._asset_root_path,
                 file_path=file_path,
+                local_root=self._asset_local_root_path,
             ),
+            path_semantics="posix",
             uid=resource_uid,
         )
         datum = Datum(

--- a/GeecsBluesky/geecs_bluesky/scanner_bridge/bluesky_scanner.py
+++ b/GeecsBluesky/geecs_bluesky/scanner_bridge/bluesky_scanner.py
@@ -509,6 +509,47 @@ class BlueskyScanner:
         return cfg["Paths"].get("geecs_device_server_data_base_path") or None
 
     @staticmethod
+    def _read_local_data_base_path() -> str | None:
+        """Read the scanner-local path for the shared GEECS data root."""
+        config_path = Path.home() / ".config" / "geecs_python_api" / "config.ini"
+        if not config_path.exists():
+            return None
+
+        cfg = ConfigParser()
+        cfg.read(config_path)
+        if "Paths" not in cfg:
+            return None
+        return cfg["Paths"].get("GEECS_DATA_LOCAL_BASE_PATH") or None
+
+    @staticmethod
+    def _asset_resource_root_paths() -> tuple[str | None, str | None]:
+        """Return ``(canonical_root, local_root)`` for external asset docs."""
+        canonical_root = BlueskyScanner._read_device_server_data_base_path()
+        if not canonical_root:
+            return None, None
+
+        local_root = BlueskyScanner._read_local_data_base_path()
+        if local_root:
+            return canonical_root, local_root
+
+        try:
+            from geecs_data_utils import ScanPaths
+        except Exception:
+            logger.warning(
+                "Could not import geecs_data_utils; using scan-folder asset roots"
+            )
+            return None, None
+
+        paths_config = getattr(ScanPaths, "paths_config", None)
+        base_path = getattr(paths_config, "base_path", None)
+        if base_path is None:
+            logger.warning(
+                "ScanPaths.paths_config is not loaded; using scan-folder asset roots"
+            )
+            return None, None
+        return canonical_root, str(base_path)
+
+    @staticmethod
     def _device_server_save_path(save_path: str) -> str:
         """Return the path to send to device ``localsavingpath`` controls."""
         device_server_base_path = BlueskyScanner._read_device_server_data_base_path()
@@ -966,10 +1007,14 @@ class BlueskyScanner:
                                 device_name
                             )
                             if asset_definitions:
+                                asset_root, asset_local_root = (
+                                    self._asset_resource_root_paths()
+                                )
                                 det.configure_external_asset_logging(
                                     scan_number=scan_number,
                                     asset_definitions=asset_definitions,
-                                    root_path=scan_folder,
+                                    root_path=asset_root or scan_folder,
+                                    local_root_path=asset_local_root or scan_folder,
                                 )
                         self._saving_detectors.append(
                             (det, save_path, device_save_path)

--- a/GeecsBluesky/pyproject.toml
+++ b/GeecsBluesky/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-bluesky"
-version = "0.13.1"
+version = "0.13.2"
 description = "Bluesky / ophyd-async bridge for the GEECS control system"
 authors = ["Sam Barber <sbarber@lbl.gov>"]
 readme = "README.md"

--- a/GeecsBluesky/tests/test_assets.py
+++ b/GeecsBluesky/tests/test_assets.py
@@ -120,6 +120,36 @@ def test_camera_definition_builds_file_and_resource_paths(tmp_path) -> None:
     )
 
 
+def test_camera_definition_builds_cross_os_resource_paths() -> None:
+    """Registry resource paths should not depend on the local OS path parser."""
+    definition = get_single_asset_definition("Point Grey Camera")
+    assert definition is not None
+
+    assert (
+        definition.resource_path(
+            root="Z:/data",
+            file_path=(
+                r"Z:\data\Undulator\Y2026\06-Jun\26_0625\scans"
+                r"\Scan001\UC_Amp4_IR_input\UC_Amp4_IR_input_3865254648.364.png"
+            ),
+        )
+        == "Undulator/Y2026/06-Jun/26_0625/scans/Scan001/"
+        "UC_Amp4_IR_input/UC_Amp4_IR_input_3865254648.364.png"
+    )
+    assert (
+        definition.resource_path(
+            root="Z:/data",
+            local_root="/Volumes/hdna2/data",
+            file_path=(
+                "/Volumes/hdna2/data/Undulator/Y2026/06-Jun/26_0625/scans/"
+                "Scan001/UC_Amp4_IR_input/UC_Amp4_IR_input_3865254648.364.png"
+            ),
+        )
+        == "Undulator/Y2026/06-Jun/26_0625/scans/Scan001/"
+        "UC_Amp4_IR_input/UC_Amp4_IR_input_3865254648.364.png"
+    )
+
+
 def test_tdms_device_types_register_primary_file_with_index_companion(tmp_path) -> None:
     """Scope/spectrometer TDMS devices should register a TDMS asset."""
     tdms_device_types = (
@@ -319,12 +349,46 @@ def test_nonscalar_save_support_emits_camera_asset_docs(tmp_path) -> None:
     datum = docs[1][1]
     assert resource["root"] == str(scan_folder)
     assert resource["resource_path"] == "UC_TopView/UC_TopView_1000.500.png"
+    assert resource["path_semantics"] == "posix"
     assert resource["spec"] == GEECS_CAMERA_IMAGE
     assert resource["resource_kwargs"] == {"data_key": data_key}
     assert datum["datum_id"] == datum_id
     assert datum["resource"] == resource["uid"]
     assert datum["datum_kwargs"] == {}
     assert list(emitter.collect_asset_docs()) == []
+
+
+def test_nonscalar_save_support_emits_canonical_resource_root(tmp_path) -> None:
+    """Resource docs should support canonical roots distinct from local roots."""
+    data_root = tmp_path / "data"
+    scan_folder = (
+        data_root / "Undulator" / "Y2026" / "06-Jun" / "26_0625" / "scans" / "Scan001"
+    )
+    save_path = scan_folder / "UC_TopView"
+    emitter = _AssetEmitter()
+    emitter.configure_nonscalar_file_logging(save_path)
+    emitter.configure_external_asset_logging(
+        scan_number=1,
+        asset_definitions=get_asset_definitions(POINTGREY_CAMERA_DEVICE_TYPE),
+        root_path="Z:/data",
+        local_root_path=data_root,
+    )
+
+    reading = {}
+    emitter._emit_asset_readings(
+        reading,
+        event_timestamp=123.0,
+        acq_timestamp=3865254648.364,
+    )
+    resource = list(emitter.collect_asset_docs())[0][1]
+
+    assert reading["uc_topview-image"]["value"]
+    assert resource["root"] == "Z:/data"
+    assert resource["path_semantics"] == "posix"
+    assert resource["resource_path"] == (
+        "Undulator/Y2026/06-Jun/26_0625/scans/Scan001/"
+        "UC_TopView/UC_TopView_3865254648.364.png"
+    )
 
 
 def test_nonscalar_save_support_records_tdms_companion_paths(tmp_path) -> None:

--- a/Planning/external_assets/00_overview.md
+++ b/Planning/external_assets/00_overview.md
@@ -45,6 +45,10 @@ Implemented pieces:
 - Device-server save paths are translated from the scanner-local mount path to
   the configured LabVIEW/device-server base path before writing
   `localsavingpath`.
+- Resource documents use a canonical data root from
+  `geecs_device_server_data_base_path` when available and POSIX
+  `resource_path` values below that root. The scanner-local data root is used
+  only to compute the relative path.
 - Tiled ingestion is guarded so an external-asset persistence failure warns and
   disables that callback instead of aborting a scan.
 - `tiled_external_asset_readback.ipynb` demonstrates the local-first archive
@@ -102,6 +106,11 @@ The main remaining gap is Tiled-side support for these custom GEECS asset specs.
 Until the lab Tiled server has matching readers/adapters, GEECS datum IDs are
 stored as ordinary event metadata there rather than being fully fillable through
 Tiled.
+
+The current Tiled catalog contents are pre-production/test data. Once the asset
+schema and acquisition behavior settle, it is reasonable to purge those test
+runs and start the production catalog from the finalized Resource/Datum
+contract.
 
 ## Validation Snapshot
 
@@ -283,8 +292,8 @@ Conceptually:
 Resource
   uid: ...
   spec: GEECS_CAMERA_IMAGE
-  root: /Volumes/hdna2/data/Undulator/Y2026/.../scans/Scan042
-  resource_path: UC_Amp2_IR_input/UC_Amp2_IR_input_1234567890.123.png
+  root: Z:/data
+  resource_path: Undulator/Y2026/.../scans/Scan042/UC_Amp2_IR_input/UC_Amp2_IR_input_1234567890.123.png
   resource_kwargs: {}
   path_semantics: posix
 
@@ -304,10 +313,11 @@ Use `root` + `resource_path` rather than storing only absolute strings in the
 event. This gives future clients a clean place to handle mount differences
 between lab machines, analysis workstations, and archives.
 
-For the first implementation, choose `root` so a normal consumer with the
-NetApp mapped can access the file directly from `root / resource_path`. The
-exact split can be adjusted, but it should not require consumers to know GEECS
-scan-folder conventions just to resolve the file.
+For Bluesky-written runs, prefer a canonical data root rather than the scan
+folder as `root`. In the current lab configuration that canonical root is the
+device-server data root, typically `Z:/data`. The `resource_path` is then the
+POSIX-style path below that root. Consumers that see the NetApp through a
+different mount point use `root_map` to translate only the root.
 
 ### File Completion
 
@@ -455,8 +465,9 @@ a later PR explicitly scopes it:
 
 Resolved choices:
 
-- `root` should be the scan folder, so `root / resource_path` directly resolves
-  to the native file for a consumer with the NetApp mounted.
+- Resource docs for Bluesky-written runs should use the canonical data root as
+  `root` and a POSIX path below that root as `resource_path`. Local readers use
+  `root_map` when their mount point differs from the canonical root.
 - Event field names should follow the current GeecsBluesky safe-name convention:
   `<safe_device_name>-<safe_asset_field>`, for example `uc_topview-image`.
 - Asset docs should be emitted during acquisition for deterministic native file
@@ -479,16 +490,14 @@ that Tiled ingestion/readback works in the lab environment.
 
 ## Recommended Next PRs
 
-1. Promote the notebook-proven Tiled camera readback path into a stable, small
-   API surface for "date/scan/device/shot -> filled camera asset"; keep the
-   notebook as a thin example.
-2. Add opt-in integration coverage for that API using a known archived run and
-   local root mapping.
-3. Run a fresh strict `ARMED` native-save hardware check after PR #441 and
+1. Add opt-in integration coverage for the Tiled camera readback API using a
+   known archived run and local root mapping.
+2. Run a fresh strict `ARMED` native-save hardware check after canonical
+   Resource writing lands and
    confirm event count, file count, and asset fill agree.
-4. Define the minimal post-run feature-extraction result schema for analysis and
+3. Define the minimal post-run feature-extraction result schema for analysis and
    optimization consumers.
-5. Implement a small post-run analysis runner that consumes Bluesky runs, fills
+4. Implement a small post-run analysis runner that consumes Bluesky runs, fills
    image assets in chunks, and writes derived results linked to the raw run.
-6. Add HASO/scope-specific handlers only after the camera/Tiled path is proven
+5. Add HASO/scope-specific handlers only after the camera/Tiled path is proven
    end-to-end.


### PR DESCRIPTION
## Summary
- emit external asset Resource docs with the configured device-server data root as the canonical root when available
- compute POSIX resource_path values below that root using the scanner-local data root only for relative path calculation
- make registry resource path construction tolerant of Windows and POSIX separators
- update external-assets planning notes and bump geecs-bluesky to 0.13.2

## Validation
- Focused asset and Tiled readback pytest passed
- Ruff, pydocstyle, compileall, and diff whitespace checks passed for touched Python files
