### PR TITLE
Fix triage --date month folder (06-Jun not 06-June)

### DIFF
--- a/GEECS-LogTriage/CHANGELOG.md
+++ b/GEECS-LogTriage/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to `geecs-log-triage` will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.4] — 2026-06-29
+
+### Fixed
+- `harvester.day_folder_for` built the month segment with `strftime('%B')` (the
+  full month name, e.g. `06-June`), but the GEECS folder convention uses the
+  3-letter abbreviation (`06-Jun`). As a result `--date`/`--experiment` triage
+  silently resolved to a non-existent folder and reported **0 scans examined**
+  for every month except May (where the full name and abbreviation coincide) —
+  which is why the May validation set never caught it. `day_folder_for` now
+  delegates to `geecs_data_utils.ScanPaths.get_daily_scan_folder`, the canonical
+  (locale-independent) path builder, and a new `tests/test_harvester_paths.py`
+  pins the abbreviated-month convention across non-May months.
+
 ## [0.2.3] — 2026-06-26
 
 ### Changed

--- a/GEECS-LogTriage/geecs_log_triage/harvester.py
+++ b/GEECS-LogTriage/geecs_log_triage/harvester.py
@@ -17,7 +17,7 @@ from datetime import date, datetime, timedelta, timezone
 from pathlib import Path
 from typing import Iterable, Optional
 
-from geecs_data_utils import LogEntry, ScanPaths, load_scan_log
+from geecs_data_utils import LogEntry, ScanPaths, ScanTag, load_scan_log
 from geecs_log_triage.classifier import classify
 from geecs_log_triage.fingerprint import (
     _extract_traceback_signature,
@@ -173,14 +173,21 @@ def day_folder_for(target: date, experiment: str) -> Path:
     """
     if ScanPaths.paths_config is None:
         ScanPaths.reload_paths_config(default_experiment=experiment)
-    base = Path(ScanPaths.paths_config.base_path)
-    return (
-        base
-        / experiment
-        / f"Y{target.year}"
-        / f"{target.month:02d}-{target.strftime('%B')}"
-        / f"{target.strftime('%y_%m%d')}"
+    # Delegate the folder-name convention to ScanPaths so there is a single
+    # source of truth. In particular the month segment is the locale-independent
+    # 3-letter abbreviation (``06-Jun``, via ``calendar.month_name[m][:3]``) —
+    # building it here with ``strftime('%B')`` produced the full name (``06-June``)
+    # and silently resolved to a non-existent folder for every month except May.
+    # ``get_daily_scan_folder`` returns ``.../YY_MMDD/scans``; the day folder is
+    # its parent.
+    tag = ScanTag(
+        year=target.year,
+        month=target.month,
+        day=target.day,
+        number=0,
+        experiment=experiment,
     )
+    return ScanPaths.get_daily_scan_folder(tag=tag).parent
 
 
 def _iter_scan_folders_for_date(

--- a/GEECS-LogTriage/pyproject.toml
+++ b/GEECS-LogTriage/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-log-triage"
-version = "0.2.3"
+version = "0.2.4"
 description = "Harvest, classify, and aggregate errors from GEECS scan execution logs."
 authors = ["Sam Barber <sbarber@lbl.gov>"]
 readme = "README.md"

--- a/GEECS-LogTriage/tests/test_harvester_paths.py
+++ b/GEECS-LogTriage/tests/test_harvester_paths.py
@@ -1,0 +1,49 @@
+"""Path-resolution tests for the harvester's date -> day-folder mapping.
+
+Regression coverage for the month-folder convention: the GEECS layout uses the
+locale-independent 3-letter month abbreviation (``06-Jun``), not the full month
+name. ``day_folder_for`` previously built the segment with ``strftime('%B')``
+(``06-June``), which resolved to a non-existent folder for every month except
+May — so triage silently reported zero scans. These tests would have caught it.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from types import SimpleNamespace
+
+import pytest
+
+from geecs_data_utils import ScanPaths
+from geecs_log_triage.harvester import day_folder_for
+
+
+@pytest.fixture
+def fake_base(monkeypatch, tmp_path):
+    """Give ScanPaths a deterministic base path (no config.ini / lab network)."""
+    monkeypatch.setattr(
+        ScanPaths, "paths_config", SimpleNamespace(base_path=str(tmp_path))
+    )
+    return tmp_path
+
+
+@pytest.mark.parametrize(
+    "month, token",
+    [
+        (1, "01-Jan"),
+        (2, "02-Feb"),
+        (5, "05-May"),  # the month that masked the bug (full == abbreviated)
+        (6, "06-Jun"),  # the month that exposed it
+        (12, "12-Dec"),
+    ],
+)
+def test_day_folder_uses_abbreviated_month(fake_base, month, token):
+    folder = day_folder_for(date(2026, month, 15), "Thomson")
+    assert folder == fake_base / "Thomson" / "Y2026" / token / f"26_{month:02d}15"
+
+
+def test_day_folder_is_parent_of_scans(fake_base):
+    # day_folder_for returns the day folder (the parent of ``scans/``).
+    folder = day_folder_for(date(2026, 6, 29), "Thomson")
+    assert folder.name == "26_0629"
+    assert (folder / "scans").name == "scans"


### PR DESCRIPTION
## Summary

`geecs-log-triage`'s `--date`/`--experiment` mode silently returned **0 scans
examined** for every month except May. Root cause: `harvester.day_folder_for`
built the month folder segment with `strftime('%B')` — the *full* month name
(`06-June`) — but the GEECS folder convention uses the 3-letter abbreviation
(`06-Jun`, via `calendar.month_name[m][:3]`). The resolved path never existed,
so triage found nothing and reported a clean, empty result.

May masked the bug — `"May"` is both the full name and the abbreviation — which
is exactly why the existing May validation set (2026-05-08) never caught it.

## Fix

- `day_folder_for` now delegates to `geecs_data_utils.ScanPaths.get_daily_scan_folder`,
  the canonical (locale-independent) path builder, instead of re-deriving the
  convention with `strftime`. Single source of truth.
- New `tests/test_harvester_paths.py` pins the abbreviated-month convention
  across non-May months (Jan/Feb/May/Jun/Dec) — these would have failed on the
  old code.

## Verification

- Full `geecs-log-triage` suite: 51 passed (6 new).
- End-to-end: `geecs-log-triage --date 2026-06-29 --experiment Thomson --scan 28`
  now resolves the scan (`total_scans_examined: 1`, was `0`).

`geecs-log-triage` 0.2.3 → 0.2.4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)