### PR TITLE
docs: mark geecs-plugins-bluesky as a standalone clone, not a worktree

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,9 +60,15 @@ The `**/.claude/worktrees/` pattern in `.gitignore` is a safety net for this
 case, but the right fix is to launch from the repo root.
 
 Remove worktrees after their PR is merged unless they are intentionally
-long-lived for a distinct development stream (currently only
-`geecs-plugins-bluesky` qualifies, and it sits as a sibling because it
-predates this policy and would be expensive to relocate).
+long-lived for a distinct development stream.
+
+`geecs-plugins-bluesky` (a sibling directory of this checkout) is **no longer
+a worktree** — it has been promoted to its own standalone clone with an
+independent `.git`, sharing only the `GEECS-BELLA/GEECS-Plugins` origin. Treat
+it as a separate clone, not a linked worktree of this checkout: changes flow
+between the two only through git (push/pull/PR), and each has its own local
+Claude context (sessions and memory are keyed by directory path). It keeps its
+own nested worktrees under `.claude/worktrees/`.
 
 ## Python & Tooling
 


### PR DESCRIPTION
## Summary

`geecs-plugins-bluesky` has been promoted from a linked git *worktree* of the main `GEECS-Plugins` checkout to its **own standalone clone** (independent `.git`, sharing only the `GEECS-BELLA/GEECS-Plugins` origin). This updates the worktree-policy section of the root `CLAUDE.md` so it no longer describes it as a long-lived sibling *worktree*.

## Changes

- Reword the worktree-removal policy paragraph to state that `geecs-plugins-bluesky` is now a separate clone, not a worktree.
- Note that the two clones sync only through git (push/pull/PR) and each keeps its own local Claude context (sessions + memory are keyed by directory path).

Docs-only; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)