### PR TITLE
Suppress known Zaber warning during scanner moves

### DIFF
--- a/GEECS-Scanner-GUI/CHANGELOG.md
+++ b/GEECS-Scanner-GUI/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this package will be documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.29.1] — 2026-07-07
+
+### Fixed
+- Suppressed the known benign Zaber `WL` warning for
+  `HTT-B-Zaber_Chain-B:Position.Ch6` set commands during non-Bluesky scans.
+  The warning is still logged, and the scan step still validates the
+  reported/read-back position against the configured tolerance before
+  continuing.
+
 ## [0.29.0] — 2026-06-24
 
 ### Changed (BREAKING — Xopt 2.6 → 3.1 upgrade)

--- a/GEECS-Scanner-GUI/geecs_scanner/engine/device_command_executor.py
+++ b/GEECS-Scanner-GUI/geecs_scanner/engine/device_command_executor.py
@@ -12,6 +12,9 @@ from geecs_python_api.controls.interface.geecs_errors import (
     GeecsDeviceExeTimeout,
 )
 
+from geecs_scanner.engine.device_error_suppression import (
+    DeviceErrorSuppressionPolicy,
+)
 from geecs_scanner.engine.dialog_request import DEVICE_COMMAND_ERRORS
 from geecs_scanner.engine.scan_events import DeviceCommandEvent
 from geecs_scanner.utils.exceptions import DeviceCommandError
@@ -37,8 +40,10 @@ class DeviceCommandExecutor:
       refused the command; retrying is reasonable.
     - ``GeecsDeviceExeTimeout`` — escalate immediately.  The device is hung;
       retrying the same command makes it worse.
-    - ``GeecsDeviceCommandFailed`` — escalate immediately.  A hardware-level
-      failure; retry will not fix it.
+    - ``GeecsDeviceCommandFailed`` — escalate immediately unless the configured
+      suppression policy classifies it as a known benign warning.  Suppressed
+      failures are logged and still go through scan-step tolerance validation
+      before acquisition continues.
 
     Attributes
     ----------
@@ -58,12 +63,16 @@ class DeviceCommandExecutor:
         max_retries: int = 3,
         retry_delay: float = 0.5,
         on_event: Optional[Callable[[ScanEvent], None]] = None,
+        suppression_policy: Optional[DeviceErrorSuppressionPolicy] = None,
     ):
         self.on_escalate = on_escalate
         self.stop_event = stop_event
         self.max_retries = max_retries
         self.retry_delay = retry_delay
         self.on_event = on_event
+        self.suppression_policy = (
+            suppression_policy or DeviceErrorSuppressionPolicy.default()
+        )
 
     def _emit(self, event: ScanEvent) -> None:
         if self.on_event is not None:
@@ -149,6 +158,25 @@ class DeviceCommandExecutor:
                 device_name, f"set {variable}", variable=variable
             ) from exc
         except GeecsDeviceCommandFailed as exc:
+            suppressed = self.suppression_policy.suppress_result_for(
+                device_name=device_name,
+                variable=variable,
+                exc=exc,
+            )
+            if suppressed is not None:
+                self._emit(
+                    DeviceCommandEvent(
+                        device=device_name, variable=variable, outcome="suppressed"
+                    )
+                )
+                logger.warning(
+                    "[%s] suppressing known benign set warning for %s: %s",
+                    device_name,
+                    variable,
+                    exc,
+                )
+                return suppressed
+
             self._emit(
                 DeviceCommandEvent(
                     device=device_name, variable=variable, outcome="failed"
@@ -240,6 +268,10 @@ class DeviceCommandExecutor:
             self.stop_event.set()
 
         return abort
+
+    def suppresses_set_failure(self, device_name: str, variable: str) -> bool:
+        """Return True when any rule allows this set failure to be considered."""
+        return self.suppression_policy.suppresses_set_failure(device_name, variable)
 
     # ------------------------------------------------------------------
     # Internal helpers

--- a/GEECS-Scanner-GUI/geecs_scanner/engine/device_error_suppression.py
+++ b/GEECS-Scanner-GUI/geecs_scanner/engine/device_error_suppression.py
@@ -1,0 +1,120 @@
+"""Policy objects for known benign device command warnings."""
+
+from __future__ import annotations
+
+import ast
+from dataclasses import dataclass
+from typing import Any, Iterable
+
+from geecs_python_api.controls.interface.geecs_errors import GeecsDeviceCommandFailed
+
+
+@dataclass(frozen=True)
+class SuppressedSetErrorRule:
+    """Rule for a known benign device set warning.
+
+    ``variable=None`` means any set variable on the exact device can match,
+    provided the hardware error text also contains all required fragments.
+    """
+
+    device: str
+    variable: str | None
+    required_fragments: tuple[str, ...]
+
+    def applies_to(self, *, device_name: str, variable: str) -> bool:
+        """Return True when this rule targets the device variable."""
+        return device_name == self.device and (
+            self.variable is None or variable == self.variable
+        )
+
+    def matches(
+        self,
+        *,
+        device_name: str,
+        variable: str,
+        error_text: str = "",
+    ) -> bool:
+        """Return True when this rule applies to the set failure."""
+        if not self.applies_to(device_name=device_name, variable=variable):
+            return False
+        return all(fragment in error_text for fragment in self.required_fragments)
+
+
+@dataclass(frozen=True)
+class SuppressedSetResult:
+    """Return marker for a suppressed set warning and its reported readback."""
+
+    readback: Any
+
+
+DEFAULT_SUPPRESSED_SET_ERROR_RULES = (
+    SuppressedSetErrorRule(
+        device="HTT-B-Zaber_Chain-B",
+        variable="Position.Ch6",
+        required_fragments=(
+            "Zaber A Series.lvlib:Error Query.vi<ERR>",
+            "reports 1 warnings:",
+            " WL",
+        ),
+    ),
+)
+
+
+class DeviceErrorSuppressionPolicy:
+    """Match device command failures that may be logged instead of escalated."""
+
+    def __init__(self, rules: Iterable[SuppressedSetErrorRule] = ()):
+        self.rules = tuple(rules)
+
+    @classmethod
+    def default(cls) -> "DeviceErrorSuppressionPolicy":
+        """Return scanner defaults for known benign command warnings."""
+        return cls(rules=DEFAULT_SUPPRESSED_SET_ERROR_RULES)
+
+    def suppresses_set_failure(self, device_name: str, variable: str) -> bool:
+        """Return True when any rule targets this device variable."""
+        return any(
+            rule.applies_to(device_name=device_name, variable=variable)
+            for rule in self.rules
+        )
+
+    def suppress_result_for(
+        self,
+        *,
+        device_name: str,
+        variable: str,
+        exc: GeecsDeviceCommandFailed,
+    ) -> SuppressedSetResult | None:
+        """Return a suppressed result when *exc* matches a known benign warning."""
+        if not exc.command.lower().startswith("set"):
+            return None
+
+        error_text = "\n".join(
+            str(part)
+            for part in (exc.error_detail, exc.actual_value, str(exc))
+            if part is not None
+        )
+        for rule in self.rules:
+            if rule.variable is not None and exc.command != f"set{variable}":
+                continue
+            if rule.matches(
+                device_name=device_name,
+                variable=variable,
+                error_text=error_text,
+            ):
+                return SuppressedSetResult(_coerce_actual_value(exc.actual_value))
+
+        return None
+
+
+def _coerce_actual_value(value: str | None) -> Any:
+    """Best-effort conversion of a device response value into a numeric readback."""
+    if value is None:
+        return None
+    try:
+        return ast.literal_eval(value)
+    except (SyntaxError, ValueError):
+        try:
+            return float(value)
+        except ValueError:
+            return value

--- a/GEECS-Scanner-GUI/geecs_scanner/engine/scan_events.py
+++ b/GEECS-Scanner-GUI/geecs_scanner/engine/scan_events.py
@@ -139,13 +139,16 @@ class DeviceCommandEvent(ScanEvent):
         - ``"sent"``     — command dispatched; response not yet known.
         - ``"accepted"`` — device acknowledged the command.
         - ``"rejected"`` — :class:`GeecsDeviceCommandRejected` raised.
-        - ``"failed"``   — :class:`GeecsDeviceCommandFailed` raised.
-        - ``"timeout"``  — :class:`GeecsDeviceExeTimeout` raised.
+        - ``"failed"``     — :class:`GeecsDeviceCommandFailed` raised.
+        - ``"timeout"``    — :class:`GeecsDeviceExeTimeout` raised.
+        - ``"suppressed"`` — a known benign hardware warning was logged and ignored.
     """
 
     device: str = ""
     variable: str = ""
-    outcome: Literal["sent", "accepted", "rejected", "failed", "timeout"] = "sent"
+    outcome: Literal[
+        "sent", "accepted", "rejected", "failed", "timeout", "suppressed"
+    ] = "sent"
 
 
 # ---------------------------------------------------------------------------

--- a/GEECS-Scanner-GUI/geecs_scanner/engine/scan_executor.py
+++ b/GEECS-Scanner-GUI/geecs_scanner/engine/scan_executor.py
@@ -16,6 +16,7 @@ from xopt.vocs import random_inputs
 
 from geecs_python_api.controls.devices.geecs_device import GeecsDevice
 from geecs_scanner.engine.device_command_executor import DeviceCommandExecutor
+from geecs_scanner.engine.device_error_suppression import SuppressedSetResult
 from geecs_scanner.engine.models.scan_options import ScanOptions
 from geecs_scanner.engine.trigger_controller import TriggerController
 from geecs_scanner.optimization.base_optimizer import BaseOptimizer
@@ -207,21 +208,48 @@ class ScanStepExecutor:
                 logger.info("[%s] setting %s → %s", device_name, var_name, set_val)
                 tol = _get_tolerance(device, device_name, var_name)
                 ret_val = self.cmd_executor.set(device, var_name, set_val)
+                suppressed_set_warning = False
+
+                if isinstance(ret_val, SuppressedSetResult):
+                    suppressed_set_warning = True
+                    ret_val = ret_val.readback
 
                 # device.set() returns None when the device rejected the command
                 # via the UDP listener thread (exception raised there, not here).
                 if ret_val is None:
-                    raise DeviceCommandError(
-                        device_name, f"set {var_name}", variable=var_name
-                    )
+                    if self.cmd_executor.suppresses_set_failure(device_name, var_name):
+                        suppressed_set_warning = True
+                        logger.warning(
+                            "[%s] set %s returned no value after a known benign "
+                            "warning; reading back before continuing",
+                            device_name,
+                            var_name,
+                        )
+                        ret_val = self.cmd_executor.get(device, var_name)
+                    if ret_val is None:
+                        raise DeviceCommandError(
+                            device_name, f"set {var_name}", variable=var_name
+                        )
 
-                if ret_val - tol <= set_val <= ret_val + tol:
+                try:
+                    within_tolerance = ret_val - tol <= set_val <= ret_val + tol
+                except TypeError as exc:
+                    if suppressed_set_warning:
+                        raise DeviceCommandError(
+                            device_name, f"set {var_name}", variable=var_name
+                        ) from exc
+                    raise
+                if within_tolerance:
                     logger.debug(
                         "[%s] %s=%s within tolerance %s",
                         device_name,
                         var_name,
                         ret_val,
                         tol,
+                    )
+                elif suppressed_set_warning:
+                    raise DeviceCommandError(
+                        device_name, f"set {var_name}", variable=var_name
                     )
                 else:
                     logger.warning(

--- a/GEECS-Scanner-GUI/pyproject.toml
+++ b/GEECS-Scanner-GUI/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-scanner-gui"
-version = "0.29.0"
+version = "0.29.1"
 
 
 description = ""

--- a/GEECS-Scanner-GUI/tests/engine/test_event_emission.py
+++ b/GEECS-Scanner-GUI/tests/engine/test_event_emission.py
@@ -20,6 +20,11 @@ from geecs_python_api.controls.interface.geecs_errors import (
 )
 from geecs_data_utils import ScanConfig, ScanMode
 from geecs_scanner.engine.device_command_executor import DeviceCommandExecutor
+from geecs_scanner.engine.device_error_suppression import (
+    DeviceErrorSuppressionPolicy,
+    SuppressedSetErrorRule,
+    SuppressedSetResult,
+)
 from geecs_scanner.engine.models.scan_options import ScanOptions
 from geecs_scanner.engine.scan_events import (
     DeviceCommandEvent,
@@ -63,6 +68,32 @@ class _AlwaysFailDevice(FakeScanDevice):
 class _HappyGetDevice(FakeScanDevice):
     def get(self, variable):
         return 5.0
+
+
+class _ZaberWarningDevice(FakeScanDevice):
+    def __init__(self):
+        super().__init__("HTT-B-Zaber_Chain-B")
+
+    def set(self, variable, value, **kw):
+        self._set_call_count += 1
+        raise GeecsDeviceCommandFailed(
+            self.name,
+            f"set{variable}",
+            "Zaber A Series.lvlib:Error Query.vi<ERR>\n"
+            "Instrument 06 0 reports 1 warnings:  WL",
+            actual_value="3.5",
+        )
+
+
+class _DeviceWideWarningDevice(FakeScanDevice):
+    def set(self, variable, value, **kw):
+        self._set_call_count += 1
+        raise GeecsDeviceCommandFailed(
+            self.name,
+            f"set{variable}",
+            "known benign warning",
+            actual_value="7.0",
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -125,6 +156,40 @@ class TestDeviceCommandSetEvents:
 
         outcomes = {e.outcome for e in _cmd_events(events)}
         assert "failed" in outcomes
+
+    def test_specific_zaber_warning_emits_suppressed_outcome(self):
+        events: List[ScanEvent] = []
+        result = self._exe(events).set(_ZaberWarningDevice(), "Position.Ch6", 3.5)
+
+        assert isinstance(result, SuppressedSetResult)
+        assert result.readback == 3.5
+        outcomes = {e.outcome for e in _cmd_events(events)}
+        assert "suppressed" in outcomes
+
+    def test_device_wide_rule_suppresses_any_set_variable(self):
+        events: List[ScanEvent] = []
+        policy = DeviceErrorSuppressionPolicy(
+            rules=(
+                SuppressedSetErrorRule(
+                    device="AnyVarDevice",
+                    variable=None,
+                    required_fragments=("known benign warning",),
+                ),
+            )
+        )
+        exe = DeviceCommandExecutor(
+            max_retries=1,
+            retry_delay=0.0,
+            on_event=events.append,
+            suppression_policy=policy,
+        )
+
+        result = exe.set(_DeviceWideWarningDevice("AnyVarDevice"), "VarA", 7.0)
+
+        assert isinstance(result, SuppressedSetResult)
+        assert result.readback == 7.0
+        outcomes = {e.outcome for e in _cmd_events(events)}
+        assert "suppressed" in outcomes
 
     def test_event_carries_device_and_variable_names(self):
         events: List[ScanEvent] = []

--- a/GEECS-Scanner-GUI/tests/engine/test_scan_executor.py
+++ b/GEECS-Scanner-GUI/tests/engine/test_scan_executor.py
@@ -8,6 +8,10 @@ from __future__ import annotations
 
 
 from geecs_python_api.controls.interface.geecs_errors import GeecsDeviceCommandFailed
+from geecs_scanner.engine.device_error_suppression import (
+    DeviceErrorSuppressionPolicy,
+    SuppressedSetErrorRule,
+)
 
 from tests.engine.conftest import FakeScanDevice
 
@@ -22,6 +26,21 @@ _TOLERANCE = 100.0  # wide tolerance so all tests pass unless we want failure
 def _exp_info_for(device_name: str, var_name: str, tolerance: float = _TOLERANCE):
     """Return a minimal fake exp_info dict for one device variable."""
     return {device_name: {var_name: {"tolerance": tolerance}}}
+
+
+class _NoneReturningZaberDevice(FakeScanDevice):
+    def __init__(self, readback: float):
+        super().__init__("HTT-B-Zaber_Chain-B")
+        self._readback = readback
+        self._get_call_count = 0
+
+    def set(self, variable, value, **_kw):
+        self._set_call_count += 1
+        return None
+
+    def get(self, variable):
+        self._get_call_count += 1
+        return self._readback
 
 
 # ---------------------------------------------------------------------------
@@ -159,4 +178,79 @@ class TestRetryExhaustion:
         )
         executor.cmd_executor.on_escalate = lambda exc, ctx: True
         executor.move_devices_parallel_by_device({"BadDev:V": 1.0}, False)
+        assert executor.stop_scanning_thread_event.is_set()
+
+
+class TestSuppressedSetWarnings:
+    def test_specific_zaber_none_result_reads_back_and_continues(self, make_executor):
+        device = _NoneReturningZaberDevice(readback=3.0)
+        executor = make_executor(
+            devices={"HTT-B-Zaber_Chain-B": device},
+            exp_info_devices=_exp_info_for(
+                "HTT-B-Zaber_Chain-B", "Position.Ch6", tolerance=0.1
+            ),
+        )
+
+        executor.move_devices_parallel_by_device(
+            {"HTT-B-Zaber_Chain-B:Position.Ch6": 3.0}, False
+        )
+
+        assert device._set_call_count == 1
+        assert device._get_call_count == 1
+
+    def test_device_wide_none_result_reads_back_and_continues(self, make_executor):
+        device = _NoneReturningZaberDevice(readback=3.0)
+        device.name = "DeviceWide"
+        executor = make_executor(
+            devices={"DeviceWide": device},
+            exp_info_devices=_exp_info_for("DeviceWide", "AnyPosition", tolerance=0.1),
+        )
+        executor.cmd_executor.suppression_policy = DeviceErrorSuppressionPolicy(
+            rules=(
+                SuppressedSetErrorRule(
+                    device="DeviceWide",
+                    variable=None,
+                    required_fragments=("unused for listener-thread path",),
+                ),
+            )
+        )
+
+        executor.move_devices_parallel_by_device({"DeviceWide:AnyPosition": 3.0}, False)
+
+        assert device._set_call_count == 1
+        assert device._get_call_count == 1
+
+    def test_specific_zaber_none_result_escalates_when_readback_misses_tolerance(
+        self, make_executor
+    ):
+        device = _NoneReturningZaberDevice(readback=4.0)
+        executor = make_executor(
+            devices={"HTT-B-Zaber_Chain-B": device},
+            exp_info_devices=_exp_info_for(
+                "HTT-B-Zaber_Chain-B", "Position.Ch6", tolerance=0.1
+            ),
+        )
+        executor.cmd_executor.on_escalate = lambda exc, ctx: True
+
+        executor.move_devices_parallel_by_device(
+            {"HTT-B-Zaber_Chain-B:Position.Ch6": 3.0}, False
+        )
+
+        assert executor.stop_scanning_thread_event.is_set()
+
+    def test_other_none_result_still_escalates(self, make_executor):
+        class _NoneReturningDevice(FakeScanDevice):
+            def set(self, variable, value, **_kw):
+                self._set_call_count += 1
+                return None
+
+        device = _NoneReturningDevice("OtherDev")
+        executor = make_executor(
+            devices={"OtherDev": device},
+            exp_info_devices=_exp_info_for("OtherDev", "V"),
+        )
+        executor.cmd_executor.on_escalate = lambda exc, ctx: True
+
+        executor.move_devices_parallel_by_device({"OtherDev:V": 1.0}, False)
+
         assert executor.stop_scanning_thread_event.is_set()


### PR DESCRIPTION
## Summary
- Add a scanner-layer suppression policy for known benign device set warnings.
- Suppress only the Zaber `WL` warning for `HTT-B-Zaber_Chain-B:Position.Ch6` by default.
- For a suppressed warning, continue only if the value reported in the set response, or a synchronous `get()` fallback when `set()` returns `None`, passes the existing tolerance check. This does not wait for a TCP subscription update.
- Keep all other set failures, get failures, timeouts, and rejected commands on the existing escalation path.

Closes #450

## Test plan
- `MPLCONFIGDIR=/private/tmp PYTHONPATH=. poetry run pytest tests/engine/test_event_emission.py tests/engine/test_scan_executor.py`
- Commit hooks passed: ruff, ruff-format, pydocstyle, and standard pre-commit checks.

## Hardware test request for @rmig27
This branch is ready for testing on the Zaber stage that was producing the repeated continue/abort popup.

### Testing from a fork checkout
If your local `GEECS-Plugins` folder is cloned from your fork, you can still test this branch from the main repository. Open a terminal in your local `GEECS-Plugins` folder and run:

```bash
git status
git fetch https://github.com/GEECS-BELLA/GEECS-Plugins.git codex/zaber-warning-suppression:test-zaber-warning
git switch test-zaber-warning
cd GEECS-Scanner-GUI
poetry install
```

Then launch the Scanner GUI the same way you normally do and run the same optimization scan that was producing the popup.

Expected behavior:
- The Zaber move should still happen.
- The specific `WL` warning for `HTT-B-Zaber_Chain-B:Position.Ch6` should be logged as a warning.
- The scan should continue automatically if the set response or fallback `get()` value is within tolerance.
- Any other command failure should still show the normal continue/abort prompt.

If Git says `test-zaber-warning` already exists, run:

```bash
git switch test-zaber-warning
git pull --ff-only https://github.com/GEECS-BELLA/GEECS-Plugins.git codex/zaber-warning-suppression
```

Please comment on this PR with whether the popup disappears and whether the stage continues stepping through the scan.