### PR TITLE
Gateway docs: PV_CONTRACT.md, DEPLOYMENT.md, CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@ tooling. Each subdirectory is an independent Python package with its own
 | `GEECS-Scanner-GUI/` | PyQt5 DAQ front-end: scans, save elements, optimization (Xopt) |
 | `GEECS-Data-Utils/` | Scan path navigation, scalar loading, binning, Parquet database |
 | `GeecsBluesky/` | Bluesky RunEngine backend: BlueskyScanner + headless GeecsSession, CA-backed ophyd-async devices (via GeecsCAGateway), Tiled integration |
-| `GeecsCAGateway/` | The GEECS access layer: UDP/TCP wire protocol, experiment DB, PV naming, and the caproto CA gateway serving GEECS devices as PVs (readback + `:SP`) for Phoebus/Archiver/ophyd-async |
+| `GeecsCAGateway/` | The GEECS access layer: UDP/TCP wire protocol, experiment DB, PV naming, and the caproto CA gateway serving GEECS devices as PVs (readback + `:SP`) for Phoebus/Archiver/ophyd-async — see its `PV_CONTRACT.md` (client API contract), `DEPLOYMENT.md`, and `DESIGN.md` |
 | `LogMaker4GoogleDocs/` | Google Docs/Drive API wrapper for automated experiment logs |
 | `GEECS-PythonAPI/` | Low-level device TCP layer — **under refactoring, do not touch** |
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -206,7 +206,10 @@ Every package has a `CHANGELOG.md` following
 `GEECS-Scanner-GUI/`, `GEECS-PythonAPI/`, `GEECS-Data-Utils/`,
 `ScanAnalysis/`, `ImageAnalysis/`, `LogMaker4GoogleDocs/`.
 
-Git tags on merge to master: `geecs-scanner-v0.8.0`, `geecs-python-api-v0.3.1`, etc.
+Git tags (`geecs-scanner-v0.8.0` style) are cut at **milestones** — a state
+deployed across experiments or one we may need to reproduce (e.g. the
+access-layer landing, 2026-07-06) — not on every merge. The per-package
+`CHANGELOG.md` + `pyproject.toml` versions are the routine record.
 
 ## Cross-package invariants
 

--- a/GeecsCAGateway/CLAUDE.md
+++ b/GeecsCAGateway/CLAUDE.md
@@ -1,0 +1,186 @@
+# GeecsCAGateway — Developer Context for Claude
+
+The GEECS **access layer**: this package owns the GEECS UDP/TCP wire protocol,
+the experiment MySQL database client, the PV naming contract, and a caproto
+**Channel Access soft-IOC** that mirrors GEECS devices as EPICS PVs (readback +
+`:SP` setpoints). Every EPICS-ecosystem consumer — GeecsBluesky's ophyd-async
+devices, Phoebus displays, the planned Archiver Appliance — talks to GEECS
+through these PVs instead of growing its own bespoke bridge.
+
+```
+GEECS device  --TCP push stream-->  readback PV   (caget / camonitor)
+GEECS device  <--blocking UDP set--  setpoint PV  (caput …:SP)
+```
+
+This is **load-bearing infrastructure**, not a prototype: Bluesky GUI scans on
+the Windows control machines and Phoebus displays consume it live. Treat its
+externally observable behavior as a contract — the three deep references are:
+
+- **`PV_CONTRACT.md`** — the normative API contract for every CA client
+  (naming, types, timestamps + the frame-ordering guarantee, alarm policy,
+  collision and failure semantics). Behavior changes that touch it must update
+  it and its pinned tests in the same PR.
+- **`DEPLOYMENT.md`** — launch/CLI, config resolution, the current dev
+  deployment on 192.168.6.14 and its risks, the client-side recipe (Windows
+  included), smoke tests, target systemd shape.
+- **`DESIGN.md`** — why this exists (Path A vs B), the caproto decision,
+  regime fitness, foundational decisions, honest gaps.
+
+## Package Layout
+
+```
+geecs_ca_gateway/
+  __main__.py        # python -m geecs_ca_gateway --experiment NAME (CLI; console
+                     #   script `geecs-ca-gateway`) — DB-driven config, then run()
+  gateway.py         # GeecsCaGateway — pvdb build, manifest/collision guard,
+                     #   per-device subscription supervisors (reconnect+backoff),
+                     #   push-frame fan-out (timestamps last), INVALID marking,
+                     #   CONNECTED + CAGateway:* status PVs, UDP setter closures
+  channels.py        # caproto channel construction: readback (client-read-only)
+                     #   vs setpoint (write forwards to GEECS first), enum
+                     #   index/label resolution, path long-string channels,
+                     #   cast/unwrap helpers
+  config.py          # Pydantic models: GatewayConfig / DeviceSpec / VariableSpec;
+                     #   DB→dtype mapping incl. choice-descriptor quirks;
+                     #   from_db_metadata (pure) / from_geecs_db / from_geecs_experiment
+  pv_naming.py       # THE shared naming policy (producer + consumers import it)
+  naming.py          # thin re-export of pv_naming for gateway-local use
+  transport/
+    udp_client.py    # GeecsUdpClient — cmd/ACK/exe protocol, exchange lock,
+                     #   exe-reply correlation, local-IP detection (VPN/PPP)
+    tcp_subscriber.py# GeecsTcpSubscriber — framed Wait>> subscription, push
+                     #   listener, name-anchored frame parser, text_variables
+  db/
+    geecs_db.py      # GeecsDb — MySQL lookups (device endpoint/type, variables
+                     #   + metadata, experiment device list, get='yes' subset);
+                     #   credentials from config.ini → Configurations.INI
+  testing/
+    fake_device_server.py  # FakeGeecsServer / FakeGeecsDevice — in-process
+                           #   UDP/TCP server speaking the real wire protocol
+  exceptions.py      # GeecsError tree (connection / rejected / failed / not-found);
+                     #   GeecsBluesky's scan-level exceptions subclass these
+  demo.py            # offline self-checking demo over the fake server
+```
+
+Dependency direction: **GeecsBluesky depends on this package, never the other
+way around**. GeecsBluesky imports the *library* parts (`GeecsDb`, `pv_naming`,
+exceptions, `FakeGeecsServer`) and consumes the *service* (the PVs, via stock
+ophyd-async EPICS signals). The gateway env is deliberately slim: caproto +
+pydantic + mysql-connector — no ophyd/bluesky/pandas.
+
+## Architecture
+
+One asyncio event loop runs everything:
+
+- **`GeecsCaGateway` (the supervisor)** builds the `pvdb` at construction time
+  (no network), then `run()` = `connect()` (UDP clients) → `subscribe()` (one
+  supervising task per device + a 5 s status loop) → `serve()` (caproto CA
+  server). The **manifest** (`PV → (device, geecs_var, kind)`) is both the
+  authoritative reverse map (PV naming is lossy) and the startup collision
+  guard: exact DB duplicates are tolerated, genuine collisions raise.
+- **Per-device UDP client** (`GeecsUdpClient`) handles sets/gets: send command,
+  await ACK on the cmd socket, await exe reply on cmd_port+1. One in-flight
+  exchange per device (lock). Setpoint puts get a 30 s budget (CaMotor's move
+  contract — GEECS sets block until convergence); gets keep 10 s.
+- **Per-device TCP subscriber** (`GeecsTcpSubscriber`) sends `Wait>>var1,var2`
+  (4-byte big-endian length framing) and receives ~1–5 Hz push frames. Each
+  device's subscription runs under a **supervisor** that reconnects with
+  exponential backoff (0.5→30 s) on an *actual socket drop* — silence is not a
+  drop (GEECS devices legitimately idle for seconds). While down: readbacks go
+  INVALID/COMM, `CONNECTED` goes MAJOR; recovery is automatic and the
+  change-suppression cache is cleared so the first frame always posts.
+- **Fan-out** (`_make_callback`): each frame is stamped from the timestamp
+  ladder (`acq_timestamp` then `systimestamp`, LabVIEW→Unix), values are
+  cast/enum-resolved per spec, exact repeats suppressed (deadband default 0.0),
+  and **timestamp-ladder variables are posted last** so a client triggering on
+  `acq_timestamp` observes the completed frame (PV_CONTRACT.md §3).
+- **channels/naming**: `channels.py` is the only caproto-typed layer (kept
+  swappable per DESIGN.md's PVA-later plan). Readback channels deny client
+  writes (access rights READ); setpoint channels forward to GEECS *before*
+  storing, so a failed set fails the caput. `pv_naming.py` is the one shared
+  naming module; full names are assembled by `DeviceSpec.pv_name_for`.
+- **db/**: `GeecsDb` is class-method-only, credentials cached from the standard
+  GEECS config chain. `config.py` maps DB rows → specs; the network-free core
+  is `from_db_metadata` (unit-tested without MySQL);
+  `from_geecs_experiment` builds a whole experiment (get='yes' subset +
+  control surface by default; see DEPLOYMENT.md for the zero-get-variables
+  gap).
+
+## Wire-protocol quirks that bit us (do not relearn these live)
+
+- **UDP exe replies must be correlated.** A slow device blows the exe timeout;
+  the next command's future would then be resolved by the *stale* reply —
+  values desync from variables (shipped bug, fixed 0.5.1). Exe replies name
+  their variable in field 2, either bare (`Var`) or as the hardware's command
+  echo (`getVar`/`setVar`) — accept both, drop everything else with a warning.
+  The bare `accepted`/`ok` **ACK carries no identifying field and cannot be
+  correlated** — accepted limitation, documented in PV_CONTRACT.md §7.
+- **Push frames cannot be comma-tokenized.** Values contain commas (save
+  paths!), `>>`, even newlines. The parser anchors on the *subscribed variable
+  names* + ` nval,`/` nvar` tokens, longest names first. Residual ambiguity (a
+  value containing a full pair-boundary lookalike) is inherent to the format
+  and documented — do not "fix" it into a stricter parser that drops path
+  values.
+- **Numeric coercion is lossy for text.** `'007'` → 7 → `"7"`. String/path/enum
+  variables must be passed to the subscriber as `text_variables` so the exact
+  wire text survives (enum labels like `"1.0"` need this too).
+- **Exe status is `"no error,"`, not the documented `"ok,"`** — match the
+  prefix. Real hardware also differs from protocol docs in the echo field
+  (above); when in doubt trust the legacy GEECS-PythonAPI parser and the fake
+  server, which encode observed behavior.
+- **Numeric enum labels resolve by value, never index** (`"2.000000"` is the
+  label `"2"`, not index 2 — DG645 configs have labels `["1","2","5"]`).
+  Index-interpretation is a fallback reserved for fully non-numeric label sets
+  (PR #452; PV_CONTRACT.md §4).
+- **DB `tolerance` is a set-convergence criterion, not a monitor deadband.**
+  Wiring it as a deadband froze sub-tolerance motion out of readbacks, scan
+  rows, and s-files (shipped bug, fixed 0.5.1). Deadband stays 0.0.
+- **Local-IP detection at connect time** — binding UDP to `""` raises
+  `EADDRNOTAVAIL` on macOS PPP/VPN links; the client probes the OS route and
+  binds explicitly. One device's bind failure must not abort the gateway
+  (per-device skip, 0.5.1).
+
+## Testing infrastructure
+
+- **`FakeGeecsServer` / `FakeGeecsDevice`** (`geecs_ca_gateway.testing`) — an
+  in-process asyncio UDP+TCP server speaking the real wire protocol (5 Hz
+  pushes, ACK/exe replies). The whole suite is offline: no hardware, no lab
+  network, no CA client needed (tests drive channels directly via
+  `channel.write`). GeecsBluesky's tests import it from here too.
+- `pytest` runs `asyncio_mode = "auto"` and deselects `integration` (lab-DB)
+  tests by default; `fake_server` marks tests that open localhost sockets.
+- Test files map to layers: `test_naming` / `test_channels` /
+  `test_config_from_db` (pure units), `test_transport` +
+  `test_udp_reply_correlation` (wire protocol; the latter injects datagrams
+  with no sockets), `test_gateway` (fake-server end-to-end),
+  `test_pv_contract` (thin example-tests pinning PV_CONTRACT.md claims),
+  `test_geecs_db` / `test_entrypoint` (mocked DB / CLI).
+- **When you change externally observable behavior**: update `PV_CONTRACT.md`,
+  and add/adjust its pinned test in the same PR. The contract's test map is the
+  index.
+
+```bash
+cd GeecsCAGateway
+poetry install
+poetry run pytest tests -q          # offline, green with no lab access
+poetry run python -m geecs_ca_gateway.demo   # serve fake PVs, poke with caget
+```
+
+## Config resolution
+
+No package-owned config file. `~/.config/geecs_python_api/config.ini`
+(`[Paths] geecs_data`) → `{geecs_data}/Configurations.INI` (`[Database]`) →
+the GEECS DB as the live source of truth for the served set. `EPICS_CAS_*`
+env vars scope the server subnet; client-side addressing (`[epics]
+ca_addr_list`, applied by geecs_bluesky at import) is documented in
+`DEPLOYMENT.md` §3. Restarting the gateway *is* the DB-resync mechanism.
+
+## Ground rules
+
+- **Never let producer and consumer naming drift** — the policy lives only in
+  `pv_naming.py`; GeecsBluesky imports the same module. No copies.
+- **Scalars/controls only; images stay off CA** (distributed PVA workstream,
+  DESIGN.md). Don't add image PVs here.
+- Follow the repo-wide conventions (root `CLAUDE.md`): Pydantic v2, NumPy
+  docstrings, type hints, `poetry version` + `CHANGELOG.md` on every
+  code-changing PR.

--- a/GeecsCAGateway/DEPLOYMENT.md
+++ b/GeecsCAGateway/DEPLOYMENT.md
@@ -1,0 +1,317 @@
+# GeecsCAGateway — Deployment
+
+How the gateway is launched, where it currently runs, how clients point at it,
+how to check it is alive, and what the production shape should become. The PV
+semantics clients rely on are in `PV_CONTRACT.md`; design rationale is in
+`DESIGN.md`.
+
+---
+
+## 1. Launching the gateway
+
+```bash
+cd GeecsCAGateway
+poetry install                     # caproto + pydantic + mysql-connector; no ophyd/bluesky
+poetry run python -m geecs_ca_gateway --experiment Undulator
+```
+
+(`geecs-ca-gateway` is also installed as a console script — same entry point.)
+
+Actual CLI flags (`geecs_ca_gateway/__main__.py`):
+
+| Flag | Default | Meaning |
+|---|---|---|
+| `--experiment NAME` | *required* | GEECS experiment name; also the PV namespace prefix |
+| `--all-variables` | off | Expose every device variable, not just the `get='yes'` monitoring set |
+| `--no-settable` | off | Do *not* add settable (control-surface) variables to the subscribed set |
+| `--include-disabled` | off | Include devices not `enabled` in the experiment |
+| `--show-missing` | off | Keep the transport's "missing variable(s)" notices (quiet by default — subscribed-but-idle variables are normal for monitoring) |
+| `--log-level LEVEL` | `INFO` | Python logging level |
+
+Startup is fault-tolerant per device: unreachable devices are not fatal (their
+PVs sit INVALID and reconnect automatically), a device whose UDP bind fails is
+skipped loudly (readbacks still stream; its `:SP` puts raise), and a device
+whose DB spec cannot be built is skipped with a warning. See
+`PV_CONTRACT.md` §7.
+
+### Config resolution
+
+The gateway reads no config file of its own. Everything comes from:
+
+1. **`~/.config/geecs_python_api/config.ini`** — `[Paths] geecs_data` points at
+   the GEECS user-data directory (the same file every GEECS-Plugins package
+   reads).
+2. **`{geecs_data}/Configurations.INI`** — `[Database]` section
+   (`ipaddress`, `port`, `name`, `user`, `password`) for the MySQL connection.
+3. **The GEECS database** — the source of truth for the served set: devices,
+   endpoints, variables, types, units, limits, settability. On a DB change,
+   restart the gateway (this matches the existing master-GUI reboot pattern;
+   hot reload is a later nicety).
+
+MySQL access uses the pure-Python connector (`use_pure=True`) — the C extension
+has crashed silently on the lab Windows machines.
+
+### Experiment selection and `subscribed_only` semantics
+
+The default served set is the experiment's **per-shot monitoring subset**: each
+enabled device's `get='yes'` variables from `expt_device_variable` (~377 PVs
+for Undulator instead of the ~8600-variable firehose), **plus** each of those
+devices' settable variables (the *control surface* — camera
+`save`/`localsavingpath`, magnet setpoints — which clients need for writes
+regardless of what is monitored; disable with `--no-settable`).
+
+**Known gap, honestly stated:** with `subscribed_only=True` (the default), a
+device with **zero** `get='yes'` variables is absent from
+`GeecsDb.get_subscribed_variables` and therefore gets **no PVs at all — its
+`:SP` control surface disappears**, even though `include_settable` is on
+(`config.py::GatewayConfig.from_geecs_experiment` builds its target list from
+the get-map alone). Workarounds today: `--all-variables`, or add one `get`
+variable to the device in the experiment config. The planned fix is to
+enumerate *all* enabled devices and union in settable-only devices with an
+empty include list; until that lands, check that any device you intend to
+*control* (not just monitor) has at least one subscribed variable.
+
+### Network scoping
+
+Which subnet the CA server serves/beacons on is controlled by the standard
+EPICS server env vars, set in the deployment environment:
+
+```bash
+export EPICS_CAS_INTF_ADDR_LIST="192.168.6.14"     # serve only on the lab interface
+export EPICS_CAS_BEACON_ADDR_LIST="192.168.6.255"  # beacon to the lab subnet
+```
+
+Serving CA only on the intended subnet is the write-safety residual from
+`DESIGN.md` — GEECS enforces value limits server-side, but there is no CA-level
+auth.
+
+---
+
+## 2. Current dev deployment — and its risks
+
+The gateway currently runs on the lab server **192.168.6.14**, alongside:
+
+- the GEECS MySQL database (which the gateway itself reads at startup),
+- the Tiled server (`http://192.168.6.14:8000`) and its metadata database.
+
+This is fine for the pilot; name it for what it is — a stack of load-bearing
+services on one box. Plainly:
+
+- **Single point of failure.** One host outage takes down device PVs (Bluesky
+  scans, Phoebus displays), the experiment DB, *and* Tiled data access at once.
+  Nothing else in the lab restores any of them automatically.
+- **Resource contention.** MySQL, Tiled ingestion, and the gateway's asyncio
+  loop share CPU/RAM/disk I/O. The gateway is light (~100 updates/s), but a
+  heavy Tiled write burst or a runaway query degrades everything together.
+- **Upgrade coupling.** An OS upgrade or reboot for any one service (e.g. the
+  22.04 migration) is downtime for all of them, and Python/library upgrades on
+  a shared host risk cross-breaking environments. Keep each service in its own
+  venv/poetry env at minimum.
+- **Storage growth.** Tiled's data and metadata grow with every scan; MySQL
+  grows slowly; logs grow steadily. Unmonitored, the shared disk filling up is
+  the most likely way this box fails.
+
+Storage placement rules:
+
+- **Large scan/image files belong on the NetApp** (the data share) — Tiled
+  should *reference* assets on NetApp, not ingest bulk image data onto the
+  server's local disk.
+- **The Tiled metadata database stays on proper local/server storage with
+  backups.** Do **not** move a live database onto NetApp — SQLite (and DB
+  engines generally) over SMB/NFS is a corruption lottery (locking semantics,
+  cache coherence). Local disk + scheduled backup dumps is the right split:
+  metadata local, assets on NetApp.
+- The gateway itself is stateless (everything rebuilds from the DB at startup)
+  — it needs no storage beyond logs.
+
+---
+
+## 3. Client-side recipe
+
+Battle-tested on the Windows control machines (live sessions, 2026-07-06).
+
+### Point CA clients at the gateway
+
+Preferred — the shared GEECS config file, so the gateway host lives with the
+other infrastructure addresses instead of in every shell:
+
+```ini
+# ~/.config/geecs_python_api/config.ini
+[epics]
+ca_addr_list = 192.168.6.14
+# ca_auto_addr_list = NO    # optional; defaults to NO when applied from here
+```
+
+`geecs_bluesky` applies this **at package import** (before any CA library
+loads — libca reads the env when its context is created): it sets
+`EPICS_CA_ADDR_LIST` from `ca_addr_list`, and `EPICS_CA_AUTO_ADDR_LIST`
+(default `NO` — a directed address list plus broadcast is rarely intended).
+
+**An exported `EPICS_CA_ADDR_LIST` always wins** over the config value
+(`os.environ.setdefault` semantics) — so a shell override for testing behaves
+as expected, and a stale export can silently shadow the config: check the env
+first when name resolution misbehaves.
+
+### Switch the Scanner GUI onto the Bluesky/CA backend
+
+```powershell
+# PowerShell
+$env:GEECS_USE_BLUESKY = "1"                          # 1/true/yes/on → BlueskyScanner
+$env:GEECS_BLUESKY_ACQUISITION_MODE = "strict_shot_control"   # or free_run_time_sync
+```
+
+```bat
+:: cmd.exe — note: no quotes, no $env:
+set GEECS_USE_BLUESKY=1
+set GEECS_BLUESKY_ACQUISITION_MODE=strict_shot_control
+```
+
+Both variables must be set in the **same shell that launches the GUI**
+(PowerShell `$env:` and cmd `set` affect only that process tree, not the
+system). `GEECS_BLUESKY_ACQUISITION_MODE` defaults to strict; strict requires a
+reachable shot-control device with an `ARMED` state — use `free_run_time_sync`
+for free-running trigger acquisition.
+
+### Windows notes
+
+- **The caRepeater PATH warning is benign.** On first CA use you may see
+  `Unable to spawn caRepeater` / caRepeater-not-in-PATH. The executable ships
+  *inside* the `epicscorelibs` wheel (which `aioca` bundles — no system EPICS
+  install exists to put it on PATH). Everything works without the repeater
+  when a single CA client runs per host; to silence the warning, add its
+  directory to PATH. Locate it with:
+
+  ```powershell
+  poetry run python -c "import pathlib, epicscorelibs; print(next(pathlib.Path(epicscorelibs.__file__).parent.rglob('caRepeater*')))"
+  ```
+
+- **Firewall rules** — Channel Access uses:
+
+  | Port | Protocol | Purpose |
+  |---|---|---|
+  | 5064 | UDP | name-resolution search (client → gateway) |
+  | 5064 | TCP | circuit: data, monitors, puts |
+  | 5065 | UDP | server beacons |
+
+  Client machines need outbound UDP+TCP 5064 to the gateway host (and UDP 5065
+  inbound for beacons, though clients work without them). Windows Defender
+  prompts on first use — allow for the lab (private) network profile.
+
+- **Reachability check** (TCP side only — `Test-NetConnection` cannot probe
+  UDP, so name resolution can still fail with this green):
+
+  ```powershell
+  Test-NetConnection 192.168.6.14 -Port 5064
+  ```
+
+---
+
+## 4. Smoke tests — "is it alive?"
+
+Copy-pasteable, using the caproto CLI tools that ship with the gateway's own
+environment (`poetry run` from `GeecsCAGateway/`; plain `caget`/`caput` from
+EPICS base work identically). Substitute your experiment/device.
+
+```bash
+# 1. Gateway process up and serving? (heartbeat ticks every 5 s)
+poetry run caproto-get Undulator:CAGateway:VERSION Undulator:CAGateway:UPTIME
+poetry run caproto-monitor Undulator:CAGateway:HEARTBEAT   # Ctrl-C after a couple of ticks
+
+# 2. Is a given device live behind it?
+poetry run caproto-get Undulator:U_S1H:CONNECTED           # → Connected
+poetry run caproto-get Undulator:CAGateway:DEVICES_CONNECTED
+
+# 3. Readback streaming? (should tick with the device's ~1–5 Hz stream)
+poetry run caproto-monitor Undulator:U_S1H:Current
+
+# 4. Write path (pick a harmless settable variable; put-completion = GEECS
+#    convergence, so this blocks until the device converges)
+poetry run caproto-get Undulator:U_S1H:Current             # note the value
+poetry run caproto-put Undulator:U_S1H:Current:SP <same value>
+```
+
+Interpretation:
+
+- Step 1 fails → gateway down, or name resolution broken
+  (`EPICS_CA_ADDR_LIST`, firewall — §3).
+- Step 2 shows `Disconnected` / MAJOR → gateway fine, that device off or
+  unreachable; readbacks are stale (INVALID) until it returns.
+- Step 3 silent but step 2 `Connected` → the variable simply isn't streaming
+  right now (analysis off, idle scope) — normal for a monitoring gateway.
+- Step 4 raises → see `PV_CONTRACT.md` §7 (a put failure is a *GEECS* set
+  failure or a startup UDP-bind skip, reported honestly).
+
+No `python -m geecs_ca_gateway.smoke` helper is shipped: a useful one needs a
+CA client dependency and network-timeout handling that don't fit in a
+hermetically-testable ~60 lines, and the four commands above cover the need.
+(Offline, `python -m geecs_ca_gateway.demo` remains the self-checking
+no-hardware smoke test.)
+
+---
+
+## 5. Target production shape
+
+### systemd unit (sketch — example only, not installed by the package)
+
+```ini
+# /etc/systemd/system/geecs-ca-gateway.service
+[Unit]
+Description=GEECS to EPICS Channel Access gateway (%i-style: one unit per experiment)
+After=network-online.target mysql.service
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=geecs
+WorkingDirectory=/opt/GEECS-Plugins/GeecsCAGateway
+Environment=EPICS_CAS_INTF_ADDR_LIST=192.168.6.14
+Environment=EPICS_CAS_BEACON_ADDR_LIST=192.168.6.255
+ExecStart=/usr/bin/poetry run python -m geecs_ca_gateway --experiment Undulator
+Restart=on-failure
+RestartSec=10
+
+[Install]
+WantedBy=multi-user.target
+```
+
+- `Restart=on-failure` + `RestartSec=10` is enough: startup is cheap and
+  idempotent (config rebuilds from the DB; clients' CA monitors reconnect
+  automatically when the server returns). The known slow bit is the per-device
+  DB enumeration (~80 s for Undulator's 114 devices — the 2-queries-per-device
+  follow-up in `DESIGN.md`), so expect PVs to appear about a minute after
+  start.
+- A **restart is also the upgrade and the DB-resync mechanism**: `git pull &&
+  poetry install && systemctl restart geecs-ca-gateway` — matching the
+  existing GEECS master-GUI reboot pattern for device-set changes.
+- Later sharding for fault isolation = more units with different
+  `--experiment`/subsystem configs; CA name resolution makes this invisible to
+  clients (DESIGN.md).
+
+### Log expectations
+
+journald captures stdout (`%(asctime)s %(levelname)s %(name)s: %(message)s`).
+A healthy steady state is **quiet**. What you should see:
+
+- Startup: `from_geecs_experiment(...): built N/M device spec(s)`,
+  `serving N PV(s) across M device(s)`, `opened UDP to N/M device(s)`,
+  `started N subscription supervisor(s)`, then one `X: subscription live` per
+  device.
+- State changes only, once per episode: `X: unreachable/dropped; retrying (up
+  to every 30s)` (warning) and `X: reconnected` (info). No per-attempt
+  tracebacks for devices that are simply off.
+- One-time warnings worth acting on: `PV name collision` (fatal),
+  `UDP bind/connect ... failed — starting without it` (that device's `:SP` is
+  dead until restart), per-variable coercion/enum-mismatch warnings (DB type
+  hygiene), `Discarding UDP reply ...` (a slow device blew its exe budget).
+
+Anything *chatty* at steady state is a bug or a DB hygiene problem — the
+"missing variable(s)" notices are already filtered by default.
+
+### Archiver volume — pointer
+
+When the Archiver Appliance lands, per-PV archive-rate control belongs in the
+**MDEL/ADEL (archive event mask) split or the appliance's sampling policies —
+not in the value deadband**, which must stay 0.0 (suppressing real
+sub-tolerance motion from live monitors was a shipped production bug). The full
+plan, including the `DBE_LOG`-gated-by-DB-tolerance option, is in `DESIGN.md`
+→ "Honest gaps / next steps" → *Archive-rate control*.

--- a/GeecsCAGateway/PV_CONTRACT.md
+++ b/GeecsCAGateway/PV_CONTRACT.md
@@ -1,0 +1,440 @@
+# GeecsCAGateway — PV Contract
+
+This is the **normative contract** between the gateway (PV producer) and every
+Channel Access client — GeecsBluesky's CA-backed ophyd-async devices, Phoebus
+displays, the planned Archiver Appliance, ad-hoc `caget`/`camonitor` use.
+Clients (including GeecsBluesky) *consume* this contract; the gateway owns it.
+If gateway behavior and this document disagree, one of them has a bug — fix it
+here or there, never by letting them drift silently.
+
+Every claim below is traceable to code, and every stated example is pinned by a
+test — see the [test map](#pinned-by-test-map) at the end. Items marked
+**(PR #452)** describe behavior that lands with the `fix/strict-shot-plausibles`
+branch (gateway 0.5.2), which merges before this document does.
+
+Code anchors: `geecs_ca_gateway/pv_naming.py`, `config.py`, `channels.py`,
+`gateway.py`, `transport/`. Design rationale lives in `DESIGN.md`; operations
+in `DEPLOYMENT.md`.
+
+---
+
+## 1. PV naming
+
+### Namespace
+
+```
+[Experiment:]Device:Variable          readback
+[Experiment:]Device:Variable:SP       setpoint (only when the variable is settable)
+[Experiment:]Device:CONNECTED         per-device status
+[Experiment:]CAGateway:<SUFFIX>       gateway self-diagnostics
+```
+
+Example: `Undulator:U_S1H:Current` and `Undulator:U_S1H:Current:SP`.
+
+- `:` is the **reserved namespace separator**, applied only between components
+  (`pv_naming.pv_name`). It never appears inside a component.
+- The experiment prefix is optional at the model level (`DeviceSpec.experiment`);
+  the production entry point (`python -m geecs_ca_gateway --experiment NAME`)
+  always sets it, so deployed PVs are three-component. Falsy parts (`None`/`""`)
+  simply drop out of the join.
+- The device component defaults to the GEECS device name
+  (`DeviceSpec.pv_prefix`); the variable component defaults to the GEECS
+  variable name (`VariableSpec.pv_suffix`). Both can be overridden per-spec
+  (`prefix=` / `pv=`) for curation.
+
+### Component normalization (`pv_naming.normalize_component`)
+
+Within a single component, only `[A-Za-z0-9_]` survives. The exact
+transformation is:
+
+1. Leading/trailing whitespace is stripped.
+2. Every **run** of characters outside `[A-Za-z0-9_]` — spaces, dots, dashes,
+   parentheses, slashes, anything — collapses to a **single** underscore
+   (regex `[^A-Za-z0-9_]+` → `_`).
+3. Leading and trailing underscores produced by step 2 are stripped.
+
+Examples (each pinned by a test):
+
+| GEECS name           | PV component     | Why it matters |
+|----------------------|------------------|----------------|
+| `Trigger.Source`     | `Trigger_Source` | **The dot is critical**: EPICS parses `.` as the record/field separator, so `Dev:Trigger.Source` would read as field `.Source` of record `Dev:Trigger` |
+| `Jet X pos`          | `Jet_X_pos`      | spaces |
+| `Beam-Current (A)`   | `Beam_Current_A` | run of ` (` collapses to one `_`; trailing `)` stripped |
+| `  padded  name  `   | `padded_name`    | whitespace + run collapsing |
+
+This policy lives in **`geecs_ca_gateway.pv_naming`** — the one module both the
+gateway (producer) and GeecsBluesky's CA devices (consumer) import — so the two
+sides can never drift. `geecs_ca_gateway.naming` is a thin re-export.
+
+### The mapping is lossy — use the manifest
+
+`Trigger.Source` and `Trigger Source` normalize to the same PV component.
+**Never reverse-engineer a GEECS name from a PV string.** The gateway holds the
+authoritative bidirectional map in `GeecsCaGateway.manifest`
+(`PV → (device, geecs_var, kind)` where kind is `"readback"`, `"setpoint"`, or
+`"status"`).
+
+### Setpoint PVs — `:SP`
+
+A variable whose DB `set` flag is `yes` gets a companion setpoint PV at the
+literal suffix `:SP` appended to the full readback name. Non-settable variables
+(including the intrinsic timestamp variables) have **no** `:SP` PV.
+
+### Per-device status PV — `CONNECTED`
+
+Every device gets exactly one status PV: `[Experiment:]Device:CONNECTED`.
+
+- Type: enum with `enum_strings = ["Disconnected", "Connected"]`
+  (index 0 = Disconnected, 1 = Connected).
+- Severity: `NO_ALARM` while connected; **`MAJOR_ALARM`** with status `COMM`
+  while the device's TCP subscription is down.
+- Client-read-only.
+
+### Gateway self-diagnostics — the reserved `CAGateway` namespace
+
+`[Experiment:]CAGateway:{UPTIME, HEARTBEAT, DEVICES_CONNECTED, VERSION}`
+(devIocStats-style; updated by a 5 s status loop; `UPTIME` in seconds,
+`VERSION` is the installed package version). The `CAGateway` device component
+is **reserved**: a real GEECS device whose PVs would land there trips the
+collision guard at startup rather than silently clobbering the status PVs.
+
+### Long-string (path) PVs
+
+EPICS `DBR_STRING` caps at 40 characters, and GEECS save paths routinely exceed
+that. Path-typed variables are therefore served as **char-array PVs**
+(`ChannelChar`, capacity 512, UTF-8) per the standard EPICS long-string
+convention (areaDetector `FilePath` does the same). Clients should read/write
+them as long strings (`caget -S`, ophyd-async handles it natively). Plain
+`string` variables stay native 40-char string PVs.
+
+---
+
+## 2. Readbacks vs setpoints
+
+```
+GEECS device  --TCP push stream (~1–5 Hz)-->  readback PV   (caget / camonitor)
+GEECS device  <--blocking UDP set-----------  setpoint PV   (caput :SP)
+```
+
+### Readbacks
+
+- Driven exclusively by the device's TCP subscription stream; the gateway fans
+  each push frame into the device's readback PVs.
+- **Client-read-only** (CA access rights = READ). A `caput` to a readback fails
+  cleanly at the client. This is load-bearing: a client write that *stuck*
+  would poison the change-suppression cache and freeze the PV at the client's
+  value until the hardware next changed (a real, shipped bug — fixed in 0.5.0).
+- `caget` serves the cached last value; `camonitor` receives a post per changed
+  frame. There is no polling of the device.
+
+### Setpoints
+
+- A `caput` to `…:SP` is forwarded to the device over GEECS's **blocking UDP
+  set** *before* the value is stored locally. GEECS sets do not return until
+  the device reports convergence (or an error), so **CA put-completion means
+  GEECS convergence** — `caput -c` / ophyd-async `set().wait()` block for the
+  physical move.
+- If the GEECS set fails (rejection, error, timeout), the setter raises, the
+  value is **not** stored, and the CA put fails. Correct put semantics: a
+  failed put leaves the setpoint PV unchanged.
+- **Set timeout: 30 s default, configurable** (`GeecsCaGateway(set_timeout_s=…)`).
+  This deliberately matches `CaMotor._DEFAULT_MOVE_TIMEOUT` (30 s) in
+  GeecsBluesky — "a slow axis is not a dead one". A legitimate 10–30 s stage
+  move must not be failed mid-flight. Gets keep the transport's short 10 s
+  default: a read that takes 10 s *is* a dead device.
+- The setpoint PV reflects the last *successfully forwarded* put, not the
+  device readback. Read state from the readback PV; the `:SP` value is the
+  commanded value.
+- Write safety: GEECS enforces DB value limits server-side and returns an error
+  the setter propagates, so an out-of-range `caput` fails correctly. The
+  DB-derived limits on the PV are **display** limits (a UX hint), not
+  gateway-enforced control limits — see §4.
+
+---
+
+## 3. Timestamps
+
+### PVs carry GEECS acquisition time, not gateway receive time
+
+Every readback post from a push frame is stamped with a wall-clock timestamp
+extracted from the frame via the device's **timestamp ladder**
+(`DeviceSpec.timestamp_vars`, default `["acq_timestamp", "systimestamp"]`):
+
+- `acq_timestamp` — true shot time; present only on triggered devices.
+  Preferred.
+- `systimestamp` — present on every device. Fallback.
+
+Both are LabVIEW-epoch (1904-01-01) seconds; the gateway converts to Unix epoch
+by subtracting `2_082_844_800`. A missing rung falls through to the next; a
+non-positive (pre-1970, i.e. implausible) result is rejected and also falls
+through. If no rung yields a plausible time, caproto defaults to receive time.
+
+### The timestamp variables are also PVs — carrying the RAW LabVIEW value
+
+`Device:acq_timestamp` and `Device:systimestamp` exist as float readback PVs on
+every device, holding the **raw LabVIEW-epoch value** (not Unix-converted).
+That is deliberate: the same raw value is stamped on saved external assets
+(images), so these PVs are the per-device acquisition/synchronicity signal.
+They are read-only and have no `:SP`.
+
+### The `0.0` pre-acquisition placeholder
+
+Every float readback channel (including `acq_timestamp`) initializes to `0.0`
+before its first update. Clients must treat a **non-positive** `acq_timestamp`
+as "no acquisition yet", never as a shot at the epoch. GeecsBluesky's
+`CaAcqTimestampReadable` reads non-positive as `None` for exactly this reason.
+(Non-triggered devices never push `acq_timestamp`, so their PV stays `0.0`
+forever — normal, not an error.)
+
+### Frame-completeness ordering guarantee (PR #452)
+
+**All data variables of a push frame are posted to their PVs before the frame's
+timestamp variable(s).** Each PV write is an `await`; without this ordering, a
+frame that happened to list `acq_timestamp` first could complete a strict-mode
+Bluesky `CaTriggerable.trigger()` on the new shot id while the data PVs still
+held the previous frame — pairing shot N's id with shot N−1's values.
+
+Contract for clients: **a monitor callback on `acq_timestamp` (or
+`systimestamp`) observes the completed frame** — every data PV of that frame
+already holds the frame's values. Among the data variables themselves, device
+payload order is preserved (the reorder is a stable sort on
+"is-a-timestamp-variable").
+
+Clients must therefore trigger/latch on the timestamp PVs, not on a data PV,
+when they need whole-frame consistency. (Cross-*device* correlation remains out
+of scope — that is Bluesky's job, see DESIGN.md "scope boundaries".)
+
+---
+
+## 4. Type mapping
+
+### DB `variabletype` → PV dtype
+
+| DB `variabletype` | dtype    | caproto channel | Notes |
+|-------------------|----------|-----------------|-------|
+| `numeric`         | `float`  | `ChannelDouble` | precision + EGU from DB |
+| `string`          | `string` | `ChannelString` | native 40-char string |
+| `path`            | `path`   | `ChannelChar` (512, UTF-8) | long-string convention, §1 |
+| `choice`          | `enum`   | `ChannelEnum`   | options from the `choice` table |
+| `image`, `1darray`| —        | **skipped**     | not scalar CA data |
+| *(absent/unknown)*| `float`  | `ChannelDouble` | default |
+
+Resolution quirks (all DB-driven, all pinned by tests):
+
+- The `choice` table's low IDs double as **type descriptors**: when the
+  `choices` column is a bare descriptor word (`numeric`, `string`, `path`,
+  `image`, `1darray`), it is the *authoritative* type — even when
+  `variabletype` says `choice`. (`variabletype='choice'` + `choices='image'`
+  is an image variable streaming raw bytes, not a one-option enum.)
+- A blank `variabletype` with a real comma-separated option list infers `enum`.
+- A `choice` with no options, more than **16** options, or any option label
+  longer than **26** characters cannot be a CA enum (`DBR_ENUM` limits) and
+  degrades to a plain string PV — the option text still round-trips verbatim;
+  only the dropdown is lost.
+- `int` exists as a dtype (served as `ChannelInteger`) but is reachable only
+  via an explicit `dtypes=` override — the DB never produces it.
+- Metadata: DB `units` → EGU; DB `min`/`max` → **display** limits only, never
+  enforced control limits. caproto enforces control limits on write and would
+  reject faithful-but-out-of-range readbacks — notably `NaN` from a failed
+  online analysis, which the contract requires be *reported*, not clamped.
+  GEECS remains the authority on valid set values (§2).
+
+### Enum resolution — readback (string → index), **(PR #452)** order
+
+GEECS speaks the option *string* on the wire; CA speaks the option *index*.
+Readback resolution (`channels.enum_index`) is, in order:
+
+1. **Exact label match** — wire text equals a choice verbatim.
+2. **Numeric-value match** — if the wire text parses as a number, compare by
+   *value* against every choice that itself parses as a number: `"2.000000"`
+   matches the label `"2"`. Devices stream numeric option values in arbitrary
+   float formatting (DG645-style trigger configs have labels like
+   `["1", "2", "5"]`), so a numeric label is matched by **value**, never
+   mistaken for an index — treating `"2.0"` as index 2 would silently select
+   `"5"`.
+3. **Index fallback** — *only* when no choice is numeric (e.g. labels
+   `["Off", "On"]` with wire value `"1"`), a numeric wire value is interpreted
+   as the option index.
+
+If numeric labels exist but nothing value-matches, the update is **skipped with
+a warning** (returns `None`) rather than guessed. Unresolvable values never
+move the PV.
+
+Setpoint direction (`enum_geecs_value`): a CA put by index or by label maps to
+the GEECS option string, which is what the UDP set carries.
+
+### Verbatim wire-text passthrough
+
+String, path, **and enum** variables reach the gateway as the **exact raw wire
+text** — they are excluded from the stream's numeric coercion, which is lossy
+for text: `'007'` → `7` → `"7"`, `'1.10'` → `"1.1"`, `'1e5'` → `"100000.0"`.
+Contract: **`'007'` stays `'007'`** on a string PV, and a numeric-looking enum
+label like `"1.0"` survives verbatim for `enum_index`. Numeric variables keep
+the historical coercion (int when integral and undotted, else float).
+
+### Float deadband policy — default 0.0
+
+- The per-variable monitor deadband defaults to **0.0**: every frame whose
+  value *changed* posts; only **exact repeats** (and NaN→NaN) are suppressed,
+  so a static device costs no CA/archiver traffic while every real change is
+  visible. At the ~1–5 Hz GEECS stream rate, bandwidth is a non-issue.
+- **The DB `tolerance` field is a *set-convergence* criterion, never a monitor
+  deadband.** Through 0.5.0 it was wired as the deadband and suppressed real
+  sub-tolerance motion from every value monitor — including recorded scan rows
+  and s-files (observed live on a magnet PSU: it moved, the readback froze).
+  Fixed in 0.5.1; do not reintroduce. Archive-volume control belongs in an
+  archive event mask (MDEL/ADEL split) or the Archiver Appliance's sampling
+  policies — see DESIGN.md.
+- After a reconnect the suppression cache is cleared, so the **first frame
+  always posts** even if unchanged (this also clears INVALID severity).
+- A non-zero deadband remains available per-variable (`VariableSpec.deadband`)
+  as explicit curation; nothing DB-driven sets one.
+
+---
+
+## 5. Alarm / severity policy
+
+What severity means **today**:
+
+| Condition | PV | Severity / status |
+|---|---|---|
+| Device TCP subscription live | readbacks | `NO_ALARM` (plain value writes reset severity) |
+| Device TCP subscription dropped / unreachable | all of that device's **readback** PVs | **`INVALID_ALARM`**, status `COMM` — data is stale, last value retained |
+| Same event | that device's `CONNECTED` PV | value `Disconnected`, **`MAJOR_ALARM`**, status `COMM` |
+| Recovery (first live frame / reconnect) | both | automatic return to `NO_ALARM` |
+
+So: **INVALID on a readback means "not live", not "bad value"** — the held
+value is the last known good one. `CONNECTED` is the explicit liveness signal
+for Phoebus/alarm layers; prefer it over inferring liveness from data severity.
+
+**Not yet implemented** (be honest with your displays):
+
+- No value-based alarms: DB min/max are display limits only; there are no
+  HIHI/HIGH/LOW/LOLO thresholds, so a readback never goes `MINOR`/`MAJOR` on
+  value. A NaN or out-of-range value arrives as a plain `NO_ALARM` update.
+- No archive deadbands (MDEL/ADEL split) — planned with the Archiver Appliance
+  (DESIGN.md "Honest gaps").
+- A device merely going *quiet* raises no alarm and does not age severity —
+  GEECS devices are legitimately silent for seconds (waiting on triggers, slow
+  online analysis). Only an actual socket drop marks INVALID. The known gap —
+  hard power-off with the socket left open (no TCP FIN) — is deferred to TCP
+  keepalive.
+- Setpoint PVs carry no alarm semantics; a failed put raises at the client
+  instead.
+
+---
+
+## 6. Collision rules
+
+At `pvdb` build time (startup), every PV registers in the manifest:
+
+- **Exact duplicates are tolerated**: the same `(device, geecs_var, kind)`
+  registering the same PV twice is a no-op. The GEECS DB genuinely lists some
+  variables more than once (real case: `U_GhostFilters`), and
+  `from_db_metadata` also dedupes rows defensively.
+- **Genuine collisions raise**: a *different* source mapping to an existing PV
+  name (e.g. `Trigger.Source` and `Trigger Source` on one device, both
+  normalizing to `Trigger_Source`) raises `ValueError` at startup. Never a
+  silent clobber; the gateway refuses to start until the overlay renames one.
+- **The status namespace is reserved**: per-device `…:CONNECTED` and the
+  `[Experiment:]CAGateway:*` diagnostics go through the same guard, so a GEECS
+  variable named `CONNECTED` or a device named `CAGateway` is a startup error,
+  not a shadowed status PV.
+
+---
+
+## 7. Failure semantics
+
+### Per-device startup fault tolerance
+
+- One device failing its UDP bind at `connect()` (e.g. an unroutable IP making
+  local-interface detection fall back to `""` → `EADDRNOTAVAIL` on PPP/VPN
+  links) is **logged loudly and skipped**; the other N−1 devices start
+  normally. The skipped device's readbacks still stream over TCP; only its
+  setpoint writes fail — with **`GeecsConnectionError`** ("bind failed at
+  startup") — until the gateway restarts.
+- Devices unreachable over TCP at startup are also non-fatal: the per-device
+  supervisor retries with exponential backoff (0.5 s → 30 s cap by default),
+  and the PVs sit at INVALID / `CONNECTED=Disconnected` until the device
+  appears. Down/up transitions are logged once per episode, not per attempt.
+- Whole-experiment config build (`from_geecs_experiment`) skips (with a
+  warning) any device whose spec cannot be built from the DB.
+
+### UDP reply correlation — and the uncorrelatable ACK
+
+The GEECS set/get exchange is command → ACK (same port) → exe reply (port+1).
+Exchanges on one device are serialized by a lock, but a **late** exe reply from
+a timed-out exchange can arrive during the next one. Exe replies name their
+variable (field 2, either bare `Var` or the hardware's command echo
+`getVar`/`setVar` — both accepted), so each exchange only accepts replies
+matching its own variable; everything else — including malformed replies with
+fewer than four `>>` fields, which carry no attributable variable — is logged
+at warning level and **discarded**, and a genuinely lost reply surfaces as an
+exe timeout rather than a mis-attributed value.
+
+**Documented limitation**: the ACK is a bare `accepted`/`ok` token with no
+identifying field and *cannot* be correlated. A stale positive ACK from an
+abandoned exchange is indistinguishable from the real one — and harmless, since
+the real ACK is then dropped as stale and the exe stage still correlates by
+variable. A stale *negative* ACK could spuriously fail an exchange that would
+have succeeded; at GEECS's one-command-at-a-time pace this is accepted risk.
+
+### TCP push-frame parsing — anchored on subscribed names
+
+Push frames are `Dev>>shot>>var1 nval,val1 nvar,var2 nval,val2 nvar…`. Values
+may contain commas (paths), `>>`, even newlines — so the frame is **not**
+comma-tokenized. The parser anchors on the *subscribed variable names* (known
+from the DB, never containing commas) followed by the literal ` nval,` token,
+taking the value non-greedily up to the ` nvar` at a genuine pair boundary;
+longer names are tried first so a name that is a prefix of another cannot
+shadow it. Unsubscribed pairs in the frame are skipped cleanly.
+
+**Documented residual ambiguity**, inherent to the wire format: a value that
+itself contains the full boundary text `` nvar,<comma-free-text> nval,`` is
+indistinguishable from a real pair boundary and will be truncated there. (The
+legacy GEECS-PythonAPI parser truncates at the *first* ` nvar` regardless, so
+this parser is strictly more tolerant.)
+
+### Stream-value fan-out failures
+
+A frame value that cannot be coerced to its PV's dtype (a DB type mismatch), or
+an enum value that does not resolve, is skipped with a **once-per-variable**
+warning (not ~5 Hz spam); the PV keeps its previous value. A callback exception
+never kills the listener.
+
+---
+
+## Pinned-by test map
+
+All in `GeecsCAGateway/tests/` unless noted. Rows marked *(PR #452)* land with
+that branch and are part of this contract's target behavior.
+
+| Contract claim | Pinned by |
+|---|---|
+| Component normalization (dot, spaces, runs, strip) | `test_naming.py::test_dot_becomes_underscore`, `::test_spaces_collapse_to_underscores`, `::test_mixed_bad_chars_collapse` |
+| `[Experiment:]Device:Variable` assembly, prefix optional, overrides | `test_naming.py::test_pv_name_for_with_experiment_prefix`, `::test_pv_name_for_without_experiment`, `::test_variable_spec_explicit_pv_wins`, `::test_device_prefix_defaults_to_name`; `test_pv_contract.py::test_pv_name_drops_falsy_parts_and_normalizes` |
+| Manifest as authoritative map; `:SP` only when settable | `test_gateway.py::test_experiment_prefix_and_manifest`, `::test_pvdb_contains_readback_and_setpoint` |
+| Genuine collision raises; exact duplicates tolerated | `test_gateway.py::test_pv_name_collision_raises`; `test_config_from_db.py::test_from_db_metadata_dedupes_duplicate_variables` |
+| Reserved `CAGateway`/status namespace guarded | `test_gateway.py::test_pvdb_has_connected_and_gateway_status_pvs`; `test_pv_contract.py::test_status_pv_namespace_is_collision_guarded` |
+| Readbacks client-read-only; setpoints writable | `test_gateway.py::test_readback_channels_deny_client_writes` |
+| Stream → readback; caput `:SP` → GEECS → readback | `test_gateway.py::test_stream_updates_readback`, `::test_setpoint_write_reaches_geecs` |
+| Failed GEECS set ⇒ CA put fails, value not stored | `test_pv_contract.py::test_setpoint_put_failure_leaves_value_unstored` |
+| 30 s configurable set budget; 10 s get budget | `test_gateway.py::test_setpoint_write_uses_move_budget_timeout`, `::test_set_timeout_is_configurable`, `::test_get_uses_standard_exe_timeout` |
+| Timestamp ladder, LabVIEW→Unix, implausible rejected | `test_gateway.py::test_extract_timestamp_converts_labview_to_unix`, `::test_extract_timestamp_ladder_prefers_first_present`, `::test_extract_timestamp_none_when_absent_or_implausible`; `test_config_from_db.py::test_timestamp_ladder_default_prefers_acq_then_sys` |
+| PV stamped with device time; timestamp PVs carry raw LabVIEW value | `test_gateway.py::test_pv_timestamp_from_systimestamp`, `::test_timestamp_vars_exposed_as_pvs_with_raw_value` |
+| `0.0` pre-acquisition placeholder | `test_pv_contract.py::test_float_readback_initializes_to_zero_placeholder` |
+| Frame ordering: data before timestamps *(PR #452)* | `test_gateway.py::test_callback_posts_timestamp_variables_last` |
+| DB type mapping, descriptors, enum degradation, blank-type inference | `test_config_from_db.py::test_from_db_metadata_maps_variable_types`, `::test_choice_pointing_at_type_descriptor_is_skipped`, `::test_blank_variabletype_inferred_from_choices`, `::test_choice_without_options_falls_back_to_string`, `::test_choice_exceeding_ca_enum_limits_falls_back_to_string` |
+| Long-string path PVs (>40 chars round-trip both directions) | `test_channels.py::test_cast_path_decodes_char_arrays`, `::test_path_readback_holds_long_string`, `::test_path_setpoint_forwards_full_text` |
+| Enum label↔index both directions over the gateway | `test_channels.py::test_enum_index_maps_label_to_index`, `::test_enum_geecs_value_index_and_label`; `test_gateway.py::test_enum_readback_and_setpoint` |
+| Enum numeric-label value-match, no index guess *(PR #452)* | `test_channels.py::test_enum_index_numeric_labels_match_by_value_not_index`, `::test_enum_index_numeric_labels_no_value_match_is_none`, `::test_enum_index_index_fallback_only_without_numeric_labels` |
+| Verbatim text passthrough (`'007'`, `'1.10'`, `'1e5'`) | `test_transport.py::TestTcpSubscriber::test_string_value_reaches_callback_verbatim`, `::TestSubscriptionFrameParsing::test_string_dtype_values_pass_through_verbatim` |
+| Deadband 0.0 from DB (`tolerance` never a deadband) | `test_pv_contract.py::test_db_tolerance_is_not_used_as_monitor_deadband` |
+| Zero deadband: every change posts, exact repeats suppressed | `test_pv_contract.py::test_zero_deadband_posts_changes_suppresses_exact_repeats` |
+| Explicit non-zero deadband suppression | `test_gateway.py::test_deadband_suppresses_small_changes` |
+| Display (not control) limits; NaN readback reported | `test_config_from_db.py::test_pvdb_built_from_db_spec_has_limits`; `test_gateway.py::test_nan_readback_accepted_despite_limits` |
+| INVALID on drop, auto-recovery; CONNECTED MAJOR while down | `test_gateway.py::test_reconnect_and_validity`, `::test_set_connected_updates_pv_severity_and_count` |
+| Per-device bind-failure tolerance; clean caput error afterward | `test_gateway.py::test_one_device_bind_failure_does_not_abort_startup`, `::test_setpoint_write_without_udp_client_raises_cleanly` |
+| UDP reply correlation, echo form, malformed/stale discard | `test_udp_reply_correlation.py` (whole module) |
+| TCP parse anchoring: commas/`>>` in values, prefix names, unsubscribed pairs | `test_transport.py::TestSubscriptionFrameParsing` (whole class) |
+| Uncoercible value: skip + warn once | `test_gateway.py::test_uncoercible_value_warns_once_and_skips` |

--- a/GeecsCAGateway/README.md
+++ b/GeecsCAGateway/README.md
@@ -23,6 +23,19 @@ protocol (`geecs_ca_gateway.transport`), the experiment database
 Bluesky side consumes the PVs as a service (stock ophyd-async EPICS signals)
 and imports only the library parts (`GeecsDb`, `pv_naming`).
 
+## Documentation
+
+- **[`PV_CONTRACT.md`](PV_CONTRACT.md)** — the normative contract every CA
+  client relies on: PV naming, readback/setpoint semantics, timestamps and
+  the frame-ordering guarantee, type mapping, alarm policy, collision and
+  failure semantics. Every claim is pinned by a test.
+- **[`DEPLOYMENT.md`](DEPLOYMENT.md)** — launching the gateway (CLI, config
+  resolution), the current dev deployment and its risks, the client-side
+  recipe (including Windows), smoke tests, and the target systemd shape.
+- **[`DESIGN.md`](DESIGN.md)** — why the gateway exists (one standard access
+  layer vs N bespoke bridges), the caproto decision, foundational decisions,
+  and the honest gap list.
+
 ## Try it (offline, no hardware or lab network)
 
 ```bash
@@ -37,20 +50,20 @@ serves PVs you can poke with real CA tools (`caget`/`camonitor`/`caput`).
 poetry run pytest        # offline tests (fake server)
 ```
 
-## Status — proof of concept
+## Status — in production use
 
-Working: dynamic PVs from a `GatewayConfig`, stream→readback, caput→UDP set,
-units/precision metadata, offline fake-server tests.
+Working and load-bearing: DB-driven whole-experiment config
+(`python -m geecs_ca_gateway --experiment NAME`), stream→readback with GEECS
+timestamps, caput→blocking UDP set, per-device reconnect supervisors with
+INVALID/`CONNECTED` liveness, units/precision/limits metadata, offline
+fake-server tests. Bluesky GUI scans and Phoebus displays consume it live.
 
-Deliberately deferred (the honest gap list):
+Deliberately deferred (the honest gap list — details in `DESIGN.md`):
 
-- **Reconnect supervisor** — `GeecsTcpSubscriber` exits on a dropped connection;
-  surviving a device power-cycle needs a supervising retry loop. This is the one
-  piece that earns the "robust as the legacy SVE tool" claim.
-- **DB-driven config** — specs are hand-built; the next step is generating them
-  from the GEECS database dict + attributes DB (units/precision/limits).
-- **Full metadata contract** — alarm limits, deadbands beyond units/precision.
-- **Sharding + systemd** — one central process today; shard by subsystem for
-  fault isolation in production (CA name resolution makes this invisible to
-  clients).
+- **Full alarm metadata** — no value-based alarms (HIHI/…) yet; severity means
+  liveness only (`PV_CONTRACT.md` §5).
+- **Archive-rate control** — MDEL/ADEL split when the Archiver Appliance
+  lands; the value deadband stays 0.0.
+- **Sharding + systemd** — one central process today; target shape sketched in
+  `DEPLOYMENT.md` §5.
 - **Images stay off CA** — scalars/controls only, by design.

--- a/GeecsCAGateway/tests/test_pv_contract.py
+++ b/GeecsCAGateway/tests/test_pv_contract.py
@@ -1,0 +1,202 @@
+"""Thin example-tests pinning claims made in ``PV_CONTRACT.md``.
+
+Each test here backs a specific statement in the contract document that no
+existing test already covers; the document's "Pinned-by test map" is the index.
+Broader behavioral coverage lives in the layer test files (``test_naming``,
+``test_channels``, ``test_gateway``, ``test_transport``, …) — do not duplicate
+it here, reference it from the contract instead.
+
+No sockets, no CA server: these tests exercise the naming/config/channel
+helpers and the gateway's fan-out callback directly.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from geecs_ca_gateway.channels import make_readback_channel, make_setpoint_channel
+from geecs_ca_gateway.config import DeviceSpec, GatewayConfig, VariableSpec
+from geecs_ca_gateway.gateway import GeecsCaGateway
+from geecs_ca_gateway.pv_naming import pv_name
+
+DEVICE = "U_ESP_JetXYZ"
+
+
+# ---------------------------------------------------------------------------
+# PV_CONTRACT.md §1 — naming
+# ---------------------------------------------------------------------------
+
+
+def test_pv_name_drops_falsy_parts_and_normalizes() -> None:
+    """Falsy namespace parts drop out; every component is normalized.
+
+    Contract §1: the experiment prefix is optional — an absent (``""``/``None``)
+    part simply drops out of the ``:``-join — and ``:`` is applied only between
+    components, never inside one.
+    """
+    assert pv_name("", "U_S1H", "Current") == "U_S1H:Current"
+    assert pv_name(None, "U_S1H", "Current") == "U_S1H:Current"
+    assert (
+        pv_name("Undulator", "U DG645", "Trigger.Source")
+        == "Undulator:U_DG645:Trigger_Source"
+    )
+
+
+# ---------------------------------------------------------------------------
+# PV_CONTRACT.md §6 — the reserved status namespace is collision-guarded
+# ---------------------------------------------------------------------------
+
+
+def test_status_pv_namespace_is_collision_guarded() -> None:
+    """A device/variable shadowing a status PV is a startup error, not a clobber.
+
+    Contract §6: per-device ``…:CONNECTED`` and ``[Experiment:]CAGateway:*``
+    go through the same collision guard as data PVs.
+    """
+    # A GEECS variable literally named CONNECTED collides with the status PV.
+    shadow_var = GatewayConfig(
+        devices=[
+            DeviceSpec(
+                name="U_Dev",
+                host="h",
+                port=1,
+                variables=[VariableSpec(geecs_var="CONNECTED")],
+            )
+        ]
+    )
+    with pytest.raises(ValueError, match="collision"):
+        GeecsCaGateway(shadow_var)
+
+    # A GEECS device named CAGateway collides with the gateway diagnostics.
+    shadow_dev = GatewayConfig(
+        devices=[
+            DeviceSpec(
+                name="CAGateway",
+                host="h",
+                port=1,
+                experiment="Test",
+                variables=[VariableSpec(geecs_var="UPTIME")],
+            )
+        ]
+    )
+    with pytest.raises(ValueError, match="collision"):
+        GeecsCaGateway(shadow_dev)
+
+
+# ---------------------------------------------------------------------------
+# PV_CONTRACT.md §2 — setpoint put failure leaves the PV unchanged
+# ---------------------------------------------------------------------------
+
+
+async def test_setpoint_put_failure_leaves_value_unstored() -> None:
+    """A failing GEECS set fails the CA put and does NOT store the value.
+
+    Contract §2: the setter runs *before* the value is stored, so a rejected /
+    failed / timed-out GEECS set leaves the ``:SP`` PV at its previous value.
+    """
+
+    class _Boom(RuntimeError):
+        pass
+
+    async def failing_setter(value: Any) -> Any:
+        raise _Boom("GEECS set failed")
+
+    channel = make_setpoint_channel(
+        VariableSpec(geecs_var="Current", dtype="float", settable=True),
+        failing_setter,
+    )
+    before = channel.value
+    with pytest.raises(_Boom):
+        await channel.write(4.2)
+    assert channel.value == before  # not stored — put fails atomically
+
+
+# ---------------------------------------------------------------------------
+# PV_CONTRACT.md §3 — the 0.0 pre-acquisition placeholder
+# ---------------------------------------------------------------------------
+
+
+def test_float_readback_initializes_to_zero_placeholder() -> None:
+    """Float readbacks (incl. acq_timestamp) hold 0.0 before any update.
+
+    Contract §3: clients must treat a non-positive ``acq_timestamp`` as
+    "no acquisition yet" — 0.0 is the channel's pre-acquisition placeholder,
+    never a shot at the epoch.
+    """
+    channel = make_readback_channel(
+        VariableSpec(geecs_var="acq_timestamp", dtype="float")
+    )
+    assert float(channel.value) == 0.0
+
+
+# ---------------------------------------------------------------------------
+# PV_CONTRACT.md §4 — deadband policy
+# ---------------------------------------------------------------------------
+
+
+def test_db_tolerance_is_not_used_as_monitor_deadband() -> None:
+    """DB ``tolerance`` is a set-convergence criterion — deadband stays 0.0.
+
+    Contract §4: through 0.5.0 the DB tolerance was wired as the monitor
+    deadband and hid real sub-tolerance motion from readbacks (and therefore
+    from recorded scan rows and s-files). Regression guard for the 0.5.1 fix.
+    """
+    meta = [
+        {
+            "name": "Current",
+            "units": "A",
+            "min": -5.0,
+            "max": 5.0,
+            "settable": True,
+            "variabletype": "numeric",
+            "choices": None,
+            "tolerance": 0.05,  # coarse magnet-PSU convergence criterion
+        }
+    ]
+    spec = DeviceSpec.from_db_metadata("U_S1H", "h", 1, meta)
+    assert spec.variables[0].deadband == 0.0
+
+
+class _RecordingChannel:
+    """Fake readback channel recording every posted value."""
+
+    def __init__(self, posts: list[float]) -> None:
+        self._posts = posts
+
+    async def write(self, value: Any, **kwargs: Any) -> None:
+        """Record the value instead of writing a caproto channel."""
+        self._posts.append(value)
+
+
+async def test_zero_deadband_posts_changes_suppresses_exact_repeats() -> None:
+    """At deadband 0.0 every changed frame posts; exact repeats are suppressed.
+
+    Contract §4: a sub-tolerance change (e.g. 5.0 → 5.0001) MUST post — only
+    a frame whose value is exactly unchanged is skipped, so static devices
+    stay silent without hiding real motion.
+    """
+    cfg = GatewayConfig(
+        devices=[
+            DeviceSpec(
+                name=DEVICE,
+                host="127.0.0.1",
+                port=1,
+                variables=[VariableSpec(geecs_var="Pos", dtype="float")],
+            )
+        ]
+    )
+    gw = GeecsCaGateway(cfg)
+    posts: list[float] = []
+    _channel, spec = gw._readbacks[DEVICE]["Pos"]
+    assert spec.deadband == 0.0  # the contract default
+    gw._readbacks[DEVICE]["Pos"] = (_RecordingChannel(posts), spec)
+    callback = gw._make_callback(cfg.devices[0])
+
+    await callback({"Pos": 5.0})  # first frame posts
+    await callback({"Pos": 5.0})  # exact repeat suppressed
+    await callback({"Pos": 5.0001})  # sub-tolerance change still posts
+    await callback({"Pos": 5.0001})  # exact repeat suppressed again
+
+    assert posts == [pytest.approx(5.0), pytest.approx(5.0001)]


### PR DESCRIPTION
Docs wave, part 1 — the gateway becomes a documented infrastructure boundary. Three new documents plus 6 thin contract-example tests (93→96 passing in the package env... 96 including the setpoint-enum fix that rode #452).

- **PV_CONTRACT.md** — the normative contract every CA client codes against (GeecsBluesky consumes it, doesn't own it): naming/normalization, `:SP` semantics (put-completion = GEECS convergence, 30 s budget), timestamp policy including the #452 frame-completeness ordering guarantee, the enum resolution ladder, verbatim-text passthrough, deadband policy (and why DB `tolerance` is never a deadband), honest alarm status (liveness only today), collision rules, failure semantics. Ends with a claim→test map.
- **DEPLOYMENT.md** — CLI/config chain, the `subscribed_only` gap stated honestly, the live-verified client recipe (`[epics] ca_addr_list`, `GEECS_USE_BLUESKY`, PowerShell vs cmd, caRepeater, CA port table), a copy-pasteable smoke sequence, the 192.168.6.14 co-location risk writeup (Tiled metadata DB stays on local disk; assets on NetApp), and a target systemd sketch.
- **CLAUDE.md** — the per-package agent context the root CLAUDE.md has promised since the #449 review.

Writing the contract surfaced one real bug (the setpoint-direction enum index-guess), fixed on #452 where its readback twin lives.

**Merge after #452** (documents its guarantees). No version bumps — docs and tests only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)