### PR TITLE
GUI stewardship assessment + stale developer-doc refresh

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,6 +108,8 @@ ImageAnalysis        →  GEECS-Data-Utils
 GeecsCAGateway       →  (no intra-repo deps — the GEECS access layer:
                         wire protocol, DB, PV naming, CA server)
 GeecsBluesky         →  GEECS-Data-Utils, GeecsCAGateway
+                        (+ ImageAnalysis, optional via the `analysis` extra —
+                        post-run image analysis over archived Tiled runs)
 GEECS-PythonAPI      →  GEECS-Data-Utils
 ScanAnalysis         →  GEECS-Data-Utils, ImageAnalysis, LogMaker4GoogleDocs
 GEECS-Scanner-GUI    →  GEECS-PythonAPI, ImageAnalysis, ScanAnalysis,
@@ -204,7 +206,8 @@ cd GEECS-PythonAPI   && poetry version patch   # 0.3.0 → 0.3.1
 Every package has a `CHANGELOG.md` following
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format:
 `GEECS-Scanner-GUI/`, `GEECS-PythonAPI/`, `GEECS-Data-Utils/`,
-`ScanAnalysis/`, `ImageAnalysis/`, `LogMaker4GoogleDocs/`.
+`ScanAnalysis/`, `ImageAnalysis/`, `LogMaker4GoogleDocs/`,
+`GeecsBluesky/`, `GeecsCAGateway/`.
 
 Git tags on merge to master: `geecs-scanner-v0.8.0`, `geecs-python-api-v0.3.1`, etc.
 

--- a/GEECS-Scanner-GUI/CLAUDE.md
+++ b/GEECS-Scanner-GUI/CLAUDE.md
@@ -26,19 +26,24 @@ geecs_scanner/
     shot_control_editor.py    # Dialog: timing/trigger device configuration
     action_library.py         # Dialog: scripted action sequences
     multi_scanner.py          # Dialog: batch scan queue
+    gui_dialogs.py            # Qt dialog helpers (device-error dialogs; main thread only)
     gui/                      # Qt Designer *_ui.py files (auto-generated)
     lib/
       action_control.py       # Standalone ActionManager wrapper (used by GUI outside scans)
       gui_utilities.py        # YAML loading, misc helpers
   engine/
     scan_manager.py           # Central scan orchestrator (runs in a thread)
+    backend_selection.py      # Legacy-vs-Bluesky backend resolution (GEECS_USE_BLUESKY)
+    lifecycle.py              # ScanLifecycleStateMachine (extracted from ScanManager)
     device_manager.py         # Device subscriptions + config loading
     data_logger.py            # Per-shot data polling + file management
+    file_mover.py             # Worker-thread file move/retry logic (extracted from DataLogger)
     scan_executor.py          # Step-by-step scan execution logic
+    default_scan_manager.py   # Run ScanManager headless (no GUI) from default configs
     action_manager.py         # Automated action execution
     scan_data_manager.py      # Output path setup, data conversion, file I/O
     device_command_executor.py # Single policy point for all device.set()/get() calls
-    scan_events.py            # Typed ScanEvent hierarchy + ScanState enum (Block 3)
+    scan_events.py            # Typed ScanEvent hierarchy + ScanState enum
     database_dict_lookup.py   # GEECS device database query interface
     trigger_controller.py     # Timing/trigger management (OFF/STANDBY/SCAN/SINGLESHOT)
     dialog_request.py         # Thread-safe dialog request type + escalation helpers
@@ -80,8 +85,12 @@ uncaught exceptions to the logger, then creates and shows `GEECSScannerWindow`.
 - Manages the list of available vs. selected save elements
 - Four scan modes (radio buttons): **No-Scan**, **1D Scan**, **Optimization**,
   **Background**
-- 200ms `QTimer` polling `update_gui_status()` → updates progress bar and
-  status text without blocking the Qt event loop
+- Event-driven status: the engine's `on_event` callback feeds the
+  `_scan_event_received` pyqtSignal, whose main-thread handler
+  (`_handle_scan_event`) updates the progress bar, status light, and buttons.
+  There is **no polling timer** for scan state (the old 200 ms `QTimer` was
+  removed in D5); the only remaining timer is a 10 s `scan_number_timer`
+  that expires the cached scan-number display.
 - Launches all auxiliary dialogs (SaveElementEditor, ShotControlEditor, etc.)
 
 ## Scan Execution Flow
@@ -108,8 +117,21 @@ User clicks Start
             wait_for_acquisition()
             DataLogger logs per-shot heartbeat + updates shot_id context
         stop_scan()                       (data written before device teardown)
-  GUI QTimer polls ScanManager.estimate_current_completion() every 200ms
+  GUI updates arrive as ScanEvents: on_event → _scan_event_received pyqtSignal
+  → _handle_scan_event on the Qt main thread (no polling)
 ```
+
+### Scan backends
+
+`RunControl` owns one of two interchangeable backends: the legacy
+`ScanManager` (default) or `BlueskyScanner` from GeecsBluesky. Selection is
+resolved by `engine/backend_selection.py`: an explicit `use_bluesky`
+argument wins, else the `GEECS_USE_BLUESKY` env var (`1/true/yes/on` →
+Bluesky), else legacy. The GUI constructs `RunControl` without the argument,
+so the env var is the supported way to switch a GUI session's backend.
+Both backends receive the same `on_event` callback; the Bluesky backend
+currently emits lifecycle events only (no step/dialog events — see
+`Planning/gui_stewardship/00_overview.md`).
 
 ## Threading Model
 
@@ -198,9 +220,11 @@ Retry policy (per error type):
 - `GeecsDeviceExeTimeout` → escalate immediately (device hung; retry makes it worse)
 - `GeecsDeviceCommandFailed` → escalate immediately (hardware error)
 
-Escalation calls `on_escalate(exc, context) -> bool` on the main thread via
-`ScanManager.dialog_queue` + `DialogRequest`.  `True` = Abort (sets `stop_event`);
-`False` = Continue.
+Escalation wraps the exception in a `DialogRequest` and emits a
+`ScanDialogEvent`; the GUI renders it on the Qt main thread
+(`app/gui_dialogs.show_device_error_dialog`) while the scan thread blocks on
+`request.response_event`.  `True` = Abort (sets `stop_event`);
+`False` = Continue.  (The old `ScanManager.dialog_queue` is gone.)
 
 Scanner exception hierarchy (`utils/exceptions.py`):
 ```
@@ -220,12 +244,14 @@ ScanError
 `GeecsDeviceInstantiationError` (from the API layer) is caught at device-open
 boundaries and re-raised or logged with context.
 
-## Scan Event System (Block 3)
+## Scan Event System
 
 The engine emits a typed event stream via an `on_event` callback injected at
-construction time.  The GUI does not yet consume this stream (Block 7 will replace
-the 200 ms polling timer); the callback is intended for headless consumers, tests,
-and future GUI wiring.
+construction time.  The GUI consumes this stream: `RunControl` wires
+`on_event` to the window's `_scan_event_received` pyqtSignal, and
+`_handle_scan_event` dispatches to per-type handlers on the Qt main thread
+(progress, status light, restore-failure warnings, device-error dialogs).
+The same callback also serves headless consumers and tests.
 
 ### Event hierarchy (`engine/scan_events.py`)
 
@@ -237,7 +263,8 @@ ScanEvent
 ├── DeviceCommandEvent   device, variable, outcome ("accepted"/"rejected"/"failed"/"timeout")
 ├── ScanErrorEvent       message, recoverable: bool, exc: BaseException | None
 ├── ScanRestoreFailedEvent  device, message
-└── ScanDialogEvent      request: DialogRequest  — for Block 7 GUI wiring
+└── ScanDialogEvent      request: DialogRequest  — rendered by the GUI as a
+                         modal device-error dialog (app/gui_dialogs.py)
 ```
 
 `ScanState` is a `str, enum.Enum` — values serialise naturally to JSON / log messages.
@@ -284,32 +311,33 @@ guaranteed shot count.
 8. `geecs_scanner/engine/models/scan_execution_config.py` — validated scan config model
 9. `geecs_scanner/app/save_element_editor.py` — pattern for YAML-backed dialogs
 
-## Current Direction: Decompose Phase
+## Current Direction: Stewardship
 
-The event stream, `DeviceCommandExecutor`, state machine, and `pyqtSignal` bridge
-are now in place.  The next work is to **remove complexity** using those structures,
-not add more.  See `Planning/STATUS.md` (in the repo root) for the ordered steps.
+The old refactor roadmap ("Blocks", decompose steps D1–D5, tracked in the
+now-deleted `Planning/STATUS.md`) **completed**: the typed event stream, the
+`pyqtSignal` bridge, `FileMover` and `ScanLifecycleStateMachine` extraction,
+phased `_start_scan()`, and removal of the 200 ms polling timer all landed.
+The GUI is fully event-driven on the legacy path.
 
-Success criterion: every class can be described in one sentence without the word "and".
-
-The five decompose steps in order:
-1. **D1** — Behavioral tests for `DataLogger` (safety net before touching it)
-2. **D2** — Extract `FileMover` into its own module (`engine/file_mover.py`)
-3. **D3** — Extract `ScanLifecycleStateMachine` into `engine/lifecycle.py`
-4. **D4** — Make `ScanManager._start_scan()` readable via named phase methods
-5. **D5** — Remove the 200ms polling `QTimer` from `GEECSScannerWindow`
+Current direction is stewardship, not decomposition — see
+`Planning/gui_stewardship/00_overview.md` (repo root) for the audit,
+strategic frame, and recommended investments. In short: the legacy engine
+(`ScanManager`/`DataLogger`/`DeviceManager`) is frozen (bug fixes only)
+while the Bluesky backend grows; GUI investment goes into the durable
+front-end jobs (config editing, progress display, operator dialogs,
+optimization setup) and into richer event emission from `BlueskyScanner`.
 
 ## Known Tech Debt
 
-- **Dead `on_device_error`**: `ScanManager.__init__` assigns it on `ScanStepExecutor`
-  and `ScanDataManager`; neither reads it (both use `cmd_executor`).  Remove during D4.
-- **`DataLogger` contains `FileMover`**: ~400 lines of worker-thread logic that
-  has no business living inside the logger.  Addressed by D2.
-- **`ScanManager` is still ~1100 lines**: mixes orchestration, state management,
-  device lifecycle, and scan math.  D3 extracts the state machine; D4 phases `_start_scan()`.
-- **200ms `QTimer` races with event handlers**: `update_gui_status()` still fires every
-  200ms even though events now drive the scan state.  Addressed by D5.
-- **DEBUG `logger.info` in `geecs_scanner.py`**: line ~1647 — remove when touching that file.
+- **Bluesky backend emits lifecycle events only**: no `ScanStepEvent`, so the
+  progress bar does not advance in Bluesky mode; no `ScanDialogEvent`, so no
+  operator dialogs.  See `Planning/gui_stewardship/00_overview.md` §4–5.
+- **Stale docstrings referencing the removed 200 ms timer**: e.g. the
+  `engine/dialog_request.py` module docstring and `ScanDialogEvent`'s
+  "In Block 7 ..." note.  Fix in the next code PR touching those files.
+- **`ScanManager` is still ~1200 lines** even after the state-machine and
+  phase extractions.  Frozen by policy — do not decompose further; the
+  Bluesky path replaces it.
 - **`GeecsDevice` `None` return on hardware rejection**: `device.set()` can return `None`
   when `GeecsDeviceCommandFailed` is raised in the UDP listener thread.  Guarded in
   `scan_executor.py` with a `None` check; root fix requires API changes.

--- a/GeecsBluesky/CLAUDE.md
+++ b/GeecsBluesky/CLAUDE.md
@@ -4,8 +4,10 @@ Bridges the GEECS hardware control system to the
 [Bluesky](https://blueskyproject.io/) experiment orchestration ecosystem.
 The primary product is `BlueskyScanner` — a RunEngine-backed scan executor
 designed to become a `ScanManager` replacement.  It runs from the
-`GEECS-Scanner-GUI` (`use_bluesky=True`) and has been hardware-verified for both
-acquisition modes (free-run and strict) including DG645 shot control.
+`GEECS-Scanner-GUI` (`use_bluesky=True`, or the `GEECS_USE_BLUESKY` env var
+for a stock GUI session) and has been hardware-verified for both acquisition
+modes (free-run and strict) including DG645 shot control; first GUI-launched
+scans ran in production on 2026-07-06.
 
 ## Two acquisition modes (the core architecture)
 
@@ -56,6 +58,14 @@ geecs_bluesky/
     nonscalar_save.py       # NonScalarSaveSupport mixin — save-path column + asset docs
     contributor.py          # FreeRunContributorSupport — reference-relative labeling
     scan_context.py         # ScanContext — bin_number / shot_index_in_bin / scan_event_index
+  analysis/                 # Post-run analysis contracts: models (AnalysisResult,
+                            #   FeatureRow, provenance), derived analysis runs
+                            #   published to Tiled, ImageAnalyzerAdapter, camera
+                            #   end-to-end analysis over archived Tiled runs
+  assets/                   # External asset helpers for native GEECS files
+                            #   (handlers, readback, registry)
+  epics_env.py              # Applies [epics] ca_addr_list from the shared config
+                            #   before aioca import (called by geecs_bluesky/__init__)
   shot_controller.py        # ShotController — arm/disarm/quiesce/fire plan stubs (gateway :SP)
   optimize.py               # suggester protocol, RandomSuggester, XoptSuggester, BinData
   tiled_integration.py      # subscribe_tiled + descriptor patch + safe callback
@@ -90,14 +100,19 @@ scanner.stop_scanning_thread()      # RE.abort() + thread join
 ```
 
 `RunControl` in `GEECS-Scanner-GUI` switches between `ScanManager` and
-`BlueskyScanner` via `use_bluesky=True`.  That path now loads the selected
-shot-control YAML and passes it as `shot_control_information`, and passes the
-`on_event` callback (BlueskyScanner emits `ScanLifecycleEvent`s through it via
-`_set_state`).  Still not done in Bluesky mode: `ActionControl` /
-setup-closeout actions, and translating per-shot Bluesky documents into the
-richer `ScanStepEvent` / `DeviceCommandEvent` stream (only lifecycle events are
-emitted).  Acquisition mode is chosen by the `GEECS_BLUESKY_ACQUISITION_MODE`
-env var — there is no GUI toggle (intentional; bluesky is experimental).
+`BlueskyScanner` via an explicit `use_bluesky=True` or, for a stock GUI
+session, the `GEECS_USE_BLUESKY` env var (resolved by
+`geecs_scanner.engine.backend_selection`; explicit argument wins, default
+legacy).  That path loads the selected shot-control YAML and passes it as
+`shot_control_information`, and passes the `on_event` callback
+(BlueskyScanner emits `ScanLifecycleEvent`s through it via `_set_state`).
+Still not done in Bluesky mode: `ActionControl` / setup-closeout actions, and
+translating per-shot Bluesky documents into the richer `ScanStepEvent` /
+`DeviceCommandEvent` stream (only lifecycle events are emitted — so the GUI
+progress bar does not advance in Bluesky mode; see
+`Planning/gui_stewardship/00_overview.md`).  Acquisition mode is chosen by
+the `GEECS_BLUESKY_ACQUISITION_MODE` env var — there is no GUI toggle for it
+(intentional; bluesky is still being derisked).
 
 ### exec_config duck-typing
 
@@ -228,40 +243,24 @@ Hermetic testing uses ophyd-async mock backends (`tests/ca_mock_helpers.py`):
 `set_mock_value` on `acq_timestamp` is a shot, `start_pacer` on the RE loop is
 the free-running trigger, `follow_setpoint` stands in for GEECS convergence.
 
-## Transport Layer (gateway-facing — devices do not use it)
+## Transport Layer — moved to GeecsCAGateway
 
-### GeecsUdpClient
-
-Two-stage protocol: command sent to port N, ACK received on port N, EXE response
-received on port N+1.  ACK format: `"get{var}>>>>accepted"`.  EXE success:
-`"no error,"`.  Holds an `asyncio.Lock` for serialisation.
-
-Local IP detected at connect time via a no-op UDP socket against the OS routing
-table — handles VPN/PPP lab links.
-
-### GeecsTcpSubscriber
-
-Framed TCP: 4-byte big-endian length prefix + JSON payload.  Pushed by device at
-~5 Hz.  Feeds a shared `_shot_cache` dict; `GeecsTriggerable` watches for
-`acq_timestamp` advances via an `asyncio.Queue`.
+The GEECS wire-protocol transport (`GeecsUdpClient`, `GeecsTcpSubscriber`)
+no longer lives in this package: it moved to
+`GeecsCAGateway/geecs_ca_gateway/transport/`, alongside the DB layer and PV
+naming.  This package touches GEECS devices **only** through the gateway's
+CA PVs; it imports the gateway's library modules (`GeecsDb`, `pv_naming`,
+wire-level exceptions) and never the transport or the server.  See
+`GeecsCAGateway/README.md` and `GeecsCAGateway/DESIGN.md` for the protocol
+details that used to be documented here.
 
 ## Test Infrastructure
 
-### FakeGeecsServer / FakeGeecsDevice
-
-An in-process UDP/TCP server that speaks the real GEECS wire protocol.  Use as an
-async context manager:
-
-```python
-device = FakeGeecsDevice("U_DG645", variables={"Trigger.Source": "External rising edges"})
-async with FakeGeecsServer(device) as srv:
-    udp = GeecsUdpClient(srv.host, srv.port, device_name="U_DG645")
-    await udp.connect()
-    val = await udp.get("Trigger.Source")
-```
-
-`device.fire_shot()` advances `acq_timestamp` and broadcasts a TCP push — used to
-simulate hardware shot events in tests.
+`FakeGeecsServer` / `FakeGeecsDevice` (the in-process UDP/TCP server that
+speaks the real GEECS wire protocol) also moved to GeecsCAGateway
+(`geecs_ca_gateway.testing`).  This package's hermetic tests are built on
+ophyd-async **mock backends** instead (`tests/ca_mock_helpers.py`) — see the
+Device Layer section above.
 
 ### Hardware integration test
 
@@ -290,19 +289,26 @@ api_key = <key>
 
 `GeecsDb` reads `Configurations.INI` (in `geecs_data`) for MySQL credentials.
 
-## Known Gaps (as of 0.8.0)
+## Known Gaps (as of 0.19.0)
 
 The acquisition-modes architecture is complete and hardware-verified (both
-modes, including single-shot).  Remaining items are features/tuning, not
-architecture — see `Planning/acquisition_modes/00_overview.md` "Deferred".
+modes, including single-shot; GUI-launched scans verified live 2026-07-06).
+Remaining items are features/tuning, not architecture — see
+`Planning/acquisition_modes/00_overview.md` "Deferred".
 
 - **Strict single-shot needs an `ARMED` state** in the shot-control YAML to
-  engage.  The experiment configs gained one on the `geecs-plugins-configs`
-  branch `add-bluesky-armed-shot-control`.  Without `ARMED` or a reachable
-  shot-control device, strict aborts before acquisition.
+  engage (the production experiment configs have one).  Without `ARMED` or a
+  reachable shot-control device, strict aborts before acquisition
+  (`GeecsConfigurationError`); use `free_run_time_sync` for free-running
+  trigger acquisition.
 - **Only lifecycle `ScanEvent`s are emitted** via `on_event` (through
   `_set_state`).  Per-shot/step Bluesky documents are not translated into the
-  richer `ScanStepEvent` / `DeviceCommandEvent` stream (and may not need to be).
+  richer `ScanStepEvent` / `DeviceCommandEvent` stream, so the GUI progress
+  bar does not advance in Bluesky mode and no operator dialogs
+  (`ScanDialogEvent`) can be raised.  `ScanStepEvent` emission and a
+  pre-flight dead-contributor dialog are the recommended next investments —
+  see `Planning/gui_stewardship/00_overview.md` §4–5.
+  (`DeviceCommandEvent` translation may never be needed.)
 - **Scalar s-files are exported from Tiled best-effort** after a scan when the
   Tiled client extra is installed and the run can be read back.  Legacy TDMS
   output is not produced.

--- a/Planning/gui_stewardship/00_overview.md
+++ b/Planning/gui_stewardship/00_overview.md
@@ -1,0 +1,349 @@
+# GUI Stewardship — where GEECS-Scanner-GUI actually stands (2026-07-06)
+
+This document answers the question "is this GUI good? is it correct? what do
+we still owe it?" as of the day the first GUI-launched Bluesky scans ran on
+Windows (2026-07-06). It replaces the old `Planning/STATUS.md` roadmap, which
+was deleted on 2026-05-28 (PR #388) and never got a successor — which is
+exactly why the old "Block 3 / Block 7" vocabulary started to feel stale: the
+plan file disappeared while the package CLAUDE.md kept referring to it.
+
+**Headline finding of the audit: the old roadmap is not stale because the
+work stalled — it is stale because the work finished.** Every block and every
+decompose step that STATUS.md tracked landed on the legacy scan path. The
+docs (GEECS-Scanner-GUI/CLAUDE.md in particular) were never updated to say
+so, and kept describing a pre-completion world: a 200 ms polling timer that
+no longer exists, a GUI that "does not yet consume" an event stream it has
+consumed for over a month. Those doc sections are fixed alongside this
+document.
+
+The open question is therefore not "finish the roadmap" — it is "what does
+the GUI owe the *Bluesky* path, now that the engine underneath it is being
+replaced?" That is what the rest of this document is about.
+
+---
+
+## 1. Glossary — the old jargon, decoded once
+
+These terms come from the deleted `Planning/STATUS.md`. They are kept here
+only so old commit messages and memories stay readable; new work should not
+use them.
+
+- **Block 3 — "typed event stream."** Instead of the GUI asking the scan
+  engine "how are you doing?" every 200 ms, the engine *tells* interested
+  parties what happened, as it happens, by calling an `on_event` callback
+  with small typed objects (`ScanLifecycleEvent`, `ScanStepEvent`,
+  `DeviceCommandEvent`, `ScanErrorEvent`, `ScanRestoreFailedEvent`,
+  `ScanDialogEvent`). Defined in
+  `GEECS-Scanner-GUI/geecs_scanner/engine/scan_events.py`.
+- **Block 7 — "event-driven GUI."** Wire that event stream into the Qt main
+  window: a `pyqtSignal` carries each event from the scan thread to the Qt
+  main thread, handlers update the progress bar / status light / buttons,
+  and the 200 ms polling `QTimer` is deleted.
+- **D1–D5 — the "Decompose" steps.** Five ordered refactoring steps to
+  shrink the legacy engine: D1 = behavioral tests for `DataLogger`; D2 =
+  extract `FileMover` to its own module; D3 = extract the scan-state machine
+  to `engine/lifecycle.py`; D4 = split `ScanManager._start_scan()` into
+  named phases; D5 = remove the 200 ms polling timer (the last piece of
+  Block 7).
+- **Legacy path / legacy engine.** `ScanManager` + `DataLogger` +
+  `DeviceManager` + friends in `geecs_scanner/engine/` — the original
+  scan executor that talks to devices over the GEECS UDP/TCP API directly.
+- **Bluesky path.** `BlueskyScanner`
+  (`GeecsBluesky/geecs_bluesky/scanner_bridge/bluesky_scanner.py`), a
+  drop-in replacement for `ScanManager` that delegates the actual run
+  discipline to `GeecsSession` and the Bluesky `RunEngine`, with devices
+  reached as EPICS PVs served by `GeecsCAGateway`.
+- **RunControl.** The thin GUI-side object
+  (`geecs_scanner/app/run_control.py`) that owns whichever scan backend is
+  active and forwards start/stop/progress calls. It picks the backend at
+  construction: legacy by default, Bluesky when the `GEECS_USE_BLUESKY`
+  env var is truthy (`engine/backend_selection.py`).
+
+---
+
+## 2. Audit — the old roadmap vs. the code
+
+Verified against the worktree at master `2c6c9abe` (2026-07-06). "STATUS.md"
+below means its final version, recovered from git
+(`git show 0bf0ed72~1:Planning/STATUS.md`).
+
+| Roadmap item | Plain meaning | Verdict | Evidence |
+|---|---|---|---|
+| Block 3 | Typed event stream from the engine | **Landed** | `engine/scan_events.py`; emitted by `ScanManager`, `ScanStepExecutor`, `DeviceCommandExecutor`; pinned by `tests/engine/test_event_emission.py` |
+| Block 5 | Scan state machine (`ScanState`, `PAUSED_ON_ERROR`) | **Landed** | `ScanState` in `scan_events.py`; state machine now lives in `engine/lifecycle.py` (D3) |
+| Block 6 | `DeviceCommandExecutor` as the single device-command policy point | **Landed** | `engine/device_command_executor.py`; retry/escalate policy per error type |
+| Block 7 | Event-driven GUI, kill the polling timer | **Landed (legacy path)** | `geecs_scanner.py`: `_scan_event_received = pyqtSignal(object)` (line ~116), `_handle_scan_event` dispatches lifecycle/step/restore/dialog events; **no 200 ms timer exists** — the only remaining `QTimer` is a 10 s `scan_number_timer` that expires a cached scan-number display, which is a display-freshness detail, not scan polling |
+| D1 | Behavioral tests for `DataLogger` | **Landed** | `tests/engine/test_data_logger.py` |
+| D2 | Extract `FileMover` | **Landed** | `engine/file_mover.py`; `DataLogger.file_mover` is injected (`Optional[FileMover] = None`) |
+| D3 | Extract `ScanLifecycleStateMachine` | **Landed** | `engine/lifecycle.py` |
+| D4 | `_start_scan()` as a readable recipe | **Landed** | `scan_manager.py`: `_phase1_pre_scan()` / `_phase2_acquire()` called from a short `_start_scan()`; the dead `on_device_error` attribute flagged for removal "during D4" is gone |
+| D5 | Remove the 200 ms `QTimer` | **Landed** | See Block 7. `update_gui_status()` now covers only the RunControl-is-None and multiscan/action-library cases and is called directly at those transitions; its docstring says exactly this |
+| Block 4 (deferred) | Engine importable without Qt | **Effectively landed in code; CI guard never added** | `grep PyQt5 engine/` finds only a docstring mention (`backend_selection.py` advertising itself as PyQt5-free); no CI job runs `tests/engine/` in a Qt-less env |
+| Block 2 (deferred) | Move `ScanConfig` out of `geecs_data_utils` | **Not done — still deliberately deferred** | Root `CLAUDE.md` "Known debt we have deliberately deferred"; no forcing function yet |
+| `Planning/STATUS.md` itself | The ordered plan file | **Deleted 2026-05-28 (PR #388)**, no successor until this document | `git log --diff-filter=D -- Planning/STATUS.md` |
+| Dialog machinery (part of Blocks 6/7) | Thread-safe operator dialogs from the scan thread | **Landed (legacy path)** | `engine/dialog_request.py` (`DialogRequest` with `response_event` + `abort[0]`); `ScanDialogEvent` → GUI `_on_dialog_event` → `app/gui_dialogs.show_device_error_dialog`; the old `dialog_queue` is gone from `scan_manager.py` |
+
+### What the access-layer pivot changed
+
+Nothing in the roadmap was *invalidated* by the pivot to
+GeecsCAGateway + GeecsSession + BlueskyScanner. What changed is the value of
+each piece:
+
+- **Made MORE valuable:** the Block 3/7 infrastructure. The
+  `on_event` callback + `pyqtSignal` bridge is precisely the seam through
+  which *any* backend talks to the GUI — `RunControl` passes the same
+  `on_event` to `ScanManager` and `BlueskyScanner` alike, and
+  `BlueskyScanner` already emits `ScanLifecycleEvent`s through it
+  (`_set_state`). The event vocabulary is the GUI's future API.
+- **Made LESS valuable:** any further decomposition or feature work on the
+  legacy engine (`ScanManager`, `DataLogger`, `DeviceManager`). Those
+  modules are now one of two backends, and the intended direction is that
+  the Bluesky path replaces them. The root CLAUDE.md already warns against
+  deep-testing `data_logger.py` / `device_manager.py` internals for this
+  reason. The D-steps were finished before the pivot hardened, so nothing
+  was wasted — but D-style work should not continue.
+- **Superseded:** the *planning apparatus* (STATUS.md's block numbering).
+  Current planning lives in per-topic folders under `Planning/`
+  (`acquisition_modes/`, `geecs_session/`, `scan_finalization_refactor/`,
+  `external_assets/`, and now `gui_stewardship/`).
+
+### One consequence nobody wrote down
+
+Deleting the polling timer (D5) quietly removed the only mechanism that
+could have shown scan progress for a backend that doesn't emit step events.
+The GUI progress bar is driven exclusively by `ScanStepEvent.shots_completed`
+now — and `BlueskyScanner` emits **lifecycle events only**. So in Bluesky
+mode today the status light works (INITIALIZING → orange, RUNNING → red,
+DONE → green) but **the progress bar never advances** during the scan.
+`BlueskyScanner.estimate_current_completion()` exists and is accurate (it
+counts event documents in `_on_document`), but nothing calls it anymore.
+This is the single cheapest, highest-visibility gap on the Bluesky path —
+see §5.
+
+---
+
+## 3. The strategic frame
+
+Today, both scan backends live behind `RunControl`:
+
+```
+GEECSScannerWindow ── RunControl ──┬── ScanManager        (legacy; default)
+        ▲                          └── BlueskyScanner     (GEECS_USE_BLUESKY=1)
+        │ on_event → pyqtSignal            │
+        └──────────────────────────────────┘  GeecsSession → RunEngine → CA devices
+                                                              → GeecsCAGateway PVs
+```
+
+Both backends receive the same `on_event` callback and satisfy the same
+duck-typed surface (`reinitialize`, `start_scan_thread`,
+`is_scanning_active`, `stop_scanning_thread`, ...). The GUI does not know or
+care which is active.
+
+**The GUI's durable jobs** — things no backend change removes:
+
+- **Scan submission and config editing.** Save elements, scan variables and
+  composites, timing/shot-control configs, presets, the MultiScanner queue,
+  optimization configs. This is the bulk of `geecs_scanner.py` and all the
+  editor dialogs, and it is genuinely useful, battle-tested UI.
+- **Progress and status display.** Consuming the event stream.
+- **Operator decision dialogs.** A scan thread hits something it can't
+  decide alone ("device X failed — abort or continue?"); a human answers.
+  The request/response machinery for this exists and works on the legacy
+  path.
+- **Optimization setup.** Building the Xopt config and injecting the
+  `optimization_loader` bridge into `BlueskyScanner`.
+
+**The GUI's shrinking jobs** — things moving out from under it:
+
+- **Engine orchestration.** Run discipline (scan numbering, folder claiming,
+  shot control bracketing, t0 sync, event schema, Tiled writes, s-file
+  export) is owned by `GeecsSession`; `BlueskyScanner` is a thin adapter
+  from `ScanExecutionConfig` shapes onto `GeecsSession.scan()`.
+- **Device management.** Device I/O is now CA signals against gateway PVs;
+  the GUI-side `DeviceManager` subscription machinery only matters to the
+  legacy path.
+
+So the honest answer to "is this GUI good?": **the front-end half is good
+and getting more valuable; the engine half is good but scheduled to
+fossilize.** Correctness on the legacy path is pinned by the engine test
+suite (event emission, data logger, scan executor tests). The Bluesky path
+is correct where exercised (hardware-verified both acquisition modes,
+GUI-launched 2026-07-06) but its GUI integration is thin: lifecycle events
+only, no progress, no dialogs, no setup/closeout actions.
+
+---
+
+## 4. First concrete use case: the dead-contributor dialog
+
+**The problem, as observed live (2026-07-06):** a free-run scan with one
+dead camera aborts at t0 sync. This is deliberate fail-loud behavior —
+`geecs_t0_sync` (`GeecsBluesky/geecs_bluesky/plans/t0_sync.py`) retries,
+names the stale device(s) whose cached `acq_timestamp` isn't advancing, and
+raises `GeecsT0SyncError`. Correct, but operator-hostile in the common case:
+the operator would usually rather drop the dead camera and take the scan
+than lose the run. Worse, t0 sync runs inside the plan, *after* the scan
+folder is claimed — so the abort burns a scan number on a scan that never
+took data.
+
+**Desired behavior:** after devices connect but **before the scan folder is
+claimed**, check each contributor's `acq_timestamp` freshness. If one looks
+dead, ask the operator: *"U_Cam4 looks dead (no shots for 12 s) — drop it
+and continue, or abort?"* Then either proceed without it or abort cleanly,
+in both cases without claiming a folder.
+
+### What already exists (more than you'd think)
+
+| Piece | Where | Status |
+|---|---|---|
+| Staleness signal | `CaAcqTimestampReadable` keeps a persistent CA monitor on each device's `acq_timestamp`; "never acquired" reads as `None` | Exists |
+| Staleness detection logic | `geecs_t0_sync` already computes exactly this and names laggards — just too late in the sequence | Exists (wrong place) |
+| The pre-claim seam | `BlueskyScanner._execute_scan()` is explicitly structured so "everything that can fail runs before the scan folder is claimed", and `_abort_before_acquisition()` is already checked at that point | Exists |
+| Request/response channel | `DialogRequest` (`geecs_scanner/engine/dialog_request.py`): worker fills it, blocks on `response_event.wait()`; consumer writes `abort[0]` and sets the event. Thread-safe, headless-safe (`escalate_device_error` auto-aborts when no callback is wired) | Exists |
+| Event type to carry it | `ScanDialogEvent(request=...)` in `engine/scan_events.py` | Exists |
+| Scan-thread → Qt-main-thread bridge | `_scan_event_received` pyqtSignal → `_handle_scan_event` → `_on_dialog_event` → `show_device_error_dialog` | Exists **and already renders dialog events** on the legacy path |
+| `on_event` plumbed to BlueskyScanner | `RunControl` passes the same callback to both backends | Exists |
+
+### What is missing
+
+1. **BlueskyScanner never emits `ScanDialogEvent`** — `_set_state` emits
+   lifecycle events only. (It also imports the event types defensively, so
+   the addition is symmetric with existing code.)
+2. **A pre-flight staleness check** in `_execute_scan` between
+   `_build_session_devices()` and `claim_scan()`: read each contributor's
+   cached `acq_timestamp`, flag devices whose last shot is older than a
+   threshold (something like `max(3/rep_rate_hz, a few seconds)`; `None` =
+   never acquired = dead).
+3. **Dialog wording.** `show_device_error_dialog` renders any
+   `DialogRequest`, but its text is phrased for device-command errors
+   (Abort/Continue). "Continue" must clearly mean *"drop U_Cam4 and take
+   the scan without it"*. Either a `kind`/message field on the request or a
+   second small dialog function.
+4. **Actually dropping the device**: on "continue", remove the stale device
+   from the detector list (and disconnect it) before handing the list to
+   `GeecsSession.scan()`. In free-run mode, if the stale device is the
+   *reference* (pacemaker), the next sync device must be promoted — that is
+   the one genuinely subtle bit.
+
+### Smallest honest implementation
+
+In `BlueskyScanner` (all on the scan thread, before the RunEngine is
+involved, so a blocking `response_event.wait(timeout)` is safe):
+
+```
+detectors = self._build_session_devices()
+stale = self._find_stale_contributors(detectors)      # new, ~30 lines
+for dev in stale:
+    request = DialogRequest(exc=StaleContributorError(dev), context=...)
+    self._emit_dialog(request)                        # new: on_event(ScanDialogEvent(request))
+    if not request.response_event.wait(timeout=120) or request.abort[0]:
+        self._set_state("ABORTED"); return            # before claim_scan — no folder burned
+    detectors = drop_and_disconnect(detectors, dev)   # promote reference if needed
+scan_tag, scan_folder = claim_scan(...)               # unchanged
+```
+
+Headless (`GeecsSession` direct, tests, no `on_event`): no callback wired →
+auto-abort, same as `escalate_device_error` does today — fail-loud behavior
+is preserved as the default, the dialog is strictly an upgrade when a human
+is attached.
+
+**Effort class: small.** Roughly a day of focused work plus one lab session
+to tune the staleness threshold and verify the reference-promotion case. No
+new architecture — every channel it needs already exists and is tested on
+the legacy path. The two design decisions worth thinking about first: the
+staleness threshold, and whether reference promotion in free-run mode is
+in-scope for v1 (a defensible v1: if the *reference* is dead, offer
+abort-only).
+
+---
+
+## 5. The investment question (solo-maintainer framing)
+
+Three options, in increasing ambition:
+
+**(a) Minimal.** Keep the PyQt GUI exactly as it is; add dialog events (and
+similar operator affordances) only where lab operations actually demand
+them — the dead-contributor dialog being the first. Cost: near zero beyond
+each demanded feature. Risk: the Bluesky path's GUI experience stays
+noticeably worse than legacy (no progress bar) even as it becomes the daily
+driver.
+
+**(b) "Finish Block 7 on the Bluesky path."** The audit reframes this
+option: Block 7 is *done* — what remains is teaching `BlueskyScanner` to
+speak the full event vocabulary the GUI already consumes. And most of that
+is disproportionately cheap:
+
+- **Step/progress events:** `BlueskyScanner._on_document` already counts
+  event documents; emitting a `ScanStepEvent(shots_completed=...)` there is
+  a handful of lines and makes the progress bar work in Bluesky mode. This
+  is the best value-per-line change available in the whole package.
+- **Dialog events:** the §4 use case.
+- **`DeviceCommandEvent` translation:** probably *never* worth it — the
+  GUI doesn't render them, and the GeecsBluesky CLAUDE.md already suspects
+  they "may not need to be" translated. Skip unless something consumes them.
+
+Meanwhile the legacy path fossilizes: bug fixes only, no new events, no
+decomposition, deletion when the Bluesky path covers all daily modes
+(needs: background mode, setup/closeout actions, and a season of routine
+use).
+
+**(c) Long-term thinning.** The GUI becomes a pure front-end over
+`GeecsSession` (or a queueserver), opening the door to non-Qt alternatives
+(web UI, bluesky-widgets). **This is named here for honesty, not for
+action: it is not current-phase work.** It only makes sense after the
+legacy path is deleted and if a second front-end consumer actually appears.
+
+### Recommendation: (a) + (b)-lite
+
+Concretely, in order:
+
+1. Emit `ScanStepEvent` from `BlueskyScanner._on_document` (progress bar in
+   Bluesky mode). Tiny.
+2. Implement the dead-contributor pre-flight dialog (§4). Small.
+3. Freeze the legacy engine: no further decomposition, no new event types,
+   bug fixes only.
+4. Skip `DeviceCommandEvent` translation and any speculative GUI
+   restructuring (the seven-concerns debt in `geecs_scanner.py` stays
+   deferred per root CLAUDE.md).
+
+**Forcing functions to revisit:**
+
+- *Revisit (c)* when the legacy path is actually deleted, or when a real
+  second consumer of the event stream appears (web status page,
+  queueserver, a second control room).
+- *Revisit GUI restructuring* when a feature demands touching three or more
+  of `geecs_scanner.py`'s concern clusters at once (e.g. "add a new scan
+  mode").
+- *Revisit option (b)-full* (rich per-device GUI feedback) if operators ask
+  "which device is slow right now?" during scans — that is the question
+  `DeviceCommandEvent` answers.
+
+---
+
+## 6. Documentation cleanup (what this change does, and what remains)
+
+Done alongside this document (docs-only, this branch):
+
+- **GEECS-Scanner-GUI/CLAUDE.md** — removed the 200 ms-timer/pre-Block-7
+  descriptions (main-window bullet, scan-flow footer, event-system intro,
+  stale Known Tech Debt entries); pointed "Current Direction" here instead
+  of at the deleted `Planning/STATUS.md`; documented the
+  `GEECS_USE_BLUESKY` backend switch.
+- **GeecsBluesky/CLAUDE.md** — added the missing `analysis/` and `assets/`
+  subpackages to the layout; re-dated "Known Gaps" (was "as of 0.8.0";
+  package is at 0.19.0) and pruned gaps that closed; replaced the
+  Transport-Layer section that described code now living in GeecsCAGateway;
+  noted the `GEECS_USE_BLUESKY` switch.
+- **Root CLAUDE.md** — dependency graph now shows the optional
+  `GeecsBluesky → ImageAnalysis` edge (the `analysis` extra); the
+  CHANGELOG enumeration includes `GeecsBluesky/` and `GeecsCAGateway/`.
+
+Not done / for later:
+
+- `Planning/STATUS.md` needs no banner — it was already deleted (2026-05-28,
+  PR #388); its fate is recorded in §2. Do not resurrect it.
+- Stale *docstrings* referencing the 200 ms timer remain in code (e.g.
+  `engine/dialog_request.py` module docstring, `ScanDialogEvent`'s
+  "In Block 7 ..." note). Docstrings are code; fix them in the next code PR
+  that touches those files, not in this docs branch.
+- Block 4's missing CI guard (engine tests in a Qt-less env) is a
+  nice-to-have; add it opportunistically if CI is being touched anyway.


### PR DESCRIPTION
Docs wave, part 2 — answers "is this GUI good? is it correct?" with an audit instead of memory.

**Headline: the old Block/decompose roadmap finished and the docs never caught up.** `Planning/STATUS.md` was deleted 2026-05-28 with D1–D5 complete; Block 7 (event-driven GUI) actually landed — the 200 ms polling timer is gone, the GUI consumes the typed event stream and renders operator dialogs on the legacy path. The developer CLAUDE.md files still described the pre-completion world, which is exactly why the terminology "felt really old".

- **`Planning/gui_stewardship/00_overview.md`** — the audit table (item → verdict → evidence), the GUI's durable vs shrinking jobs under the access-layer architecture, the dead-contributor pre-flight dialog as the first concrete use case (exists/missing map + small-effort sketch), and investment options with a recommendation.
- **Notable audit find:** in Bluesky mode the progress bar never advances — removing the polling timer removed the only thing that read `estimate_current_completion()`, and `BlueskyScanner` emits lifecycle events only. Teaching it `ScanStepEvent` (the shot counter already lives in `_on_document`) is the best value-per-line change available.
- **Recommended default:** (1) emit `ScanStepEvent` from the Bluesky path; (2) ship the dead-contributor pre-flight dialog (~a day + one lab session — every channel it needs is production-tested on the legacy path); (3) freeze the legacy engine to bug-fixes; skip `DeviceCommandEvent` translation (no consumer). The thin-front-end/web/queueserver future is named honestly as not-current-phase.
- **CLAUDE.md refreshes**: GUI (Block-7 reality, `GEECS_USE_BLUESKY` backend switch, tech debt pruned), GeecsBluesky (layout completed, Known Gaps re-dated from 0.8.0, transport sections now point at GeecsCAGateway), root (dependency-graph edge verified and added, changelog list completed).

Docs only; no version bumps. Independent of the open code PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)