### PR TITLE
GeecsCAGateway: service-ready config build + shipped systemd unit

### DIFF
--- a/GeecsCAGateway/CHANGELOG.md
+++ b/GeecsCAGateway/CHANGELOG.md
@@ -3,6 +3,37 @@
 All notable changes to `geecs-ca-gateway` are documented here, following
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and semantic versioning.
 
+## [0.6.0] - 2026-07-07
+
+### Added
+
+- **`deploy/` directory** with the production systemd unit
+  (`geecs-ca-gateway.service`) for the lab deployment on 192.168.6.14 and an
+  install/verify/upgrade recipe (`deploy/README.md`). `DEPLOYMENT.md` §5 now
+  points at the shipped unit instead of an inline sketch.
+- `GeecsDb.get_experiment_devices` and
+  `GeecsDb.get_experiment_device_variables` — batch counterparts of
+  `find_device` / `get_device_variables` that fetch a whole experiment's
+  endpoints and variable metadata in one query each.
+
+### Changed
+
+- **Settable-only devices are no longer dropped in subscribed mode.**
+  `GatewayConfig.from_geecs_experiment` previously built its device list from
+  the `get='yes'` map alone, so a device with zero subscribed variables lost
+  its entire `:SP` control surface (documented as a known gap in
+  `DEPLOYMENT.md`). It now enumerates all enabled devices and gives devices
+  absent from the get-map an empty monitoring list, keeping their settable
+  variables. Devices that would expose nothing at all (nothing subscribed,
+  nothing settable) are skipped entirely — previously they opened idle
+  TCP/UDP connections in `--all-variables` builds.
+- **Whole-experiment config building is three batched DB queries** instead of
+  2 per device (~230 sequential MySQL connections and ~80 s for Undulator's
+  114 devices). Startup — which is also the upgrade and DB-resync mechanism
+  for the systemd service — now takes seconds. A `get='yes'` device missing
+  from the device table is warned about explicitly instead of failing its
+  per-device lookup.
+
 ## [0.5.2] - 2026-07-06
 
 ### Fixed

--- a/GeecsCAGateway/CHANGELOG.md
+++ b/GeecsCAGateway/CHANGELOG.md
@@ -15,6 +15,14 @@ All notable changes to `geecs-ca-gateway` are documented here, following
   `GeecsDb.get_experiment_device_variables` — batch counterparts of
   `find_device` / `get_device_variables` that fetch a whole experiment's
   endpoints and variable metadata in one query each.
+- **`CAGateway:RESTART` PV — remote restart / DB resync from any CA client**
+  (the devIocStats `SYSRESET` pattern). Writing `Restart` makes the gateway
+  shut down cleanly and exit with code 86; the shipped systemd unit's
+  `RestartForceExitStatus` turns that into a relaunch, which rebuilds the
+  served set from the GEECS database. After a DB edit (device added/removed,
+  get-list changed) a Phoebus button, GUI action, or one-line `caproto-put`
+  resyncs the gateway — no SSH into the box. Writing `Idle`/0 is a no-op.
+  Documented in `PV_CONTRACT.md` §6 with pinned tests.
 
 ### Changed
 

--- a/GeecsCAGateway/CLAUDE.md
+++ b/GeecsCAGateway/CLAUDE.md
@@ -103,8 +103,8 @@ One asyncio event loop runs everything:
   GEECS config chain. `config.py` maps DB rows → specs; the network-free core
   is `from_db_metadata` (unit-tested without MySQL);
   `from_geecs_experiment` builds a whole experiment (get='yes' subset +
-  control surface by default; see DEPLOYMENT.md for the zero-get-variables
-  gap).
+  control surface by default — settable-only devices keep their `:SP` PVs)
+  from three batched DB queries.
 
 ## Wire-protocol quirks that bit us (do not relearn these live)
 

--- a/GeecsCAGateway/CLAUDE.md
+++ b/GeecsCAGateway/CLAUDE.md
@@ -35,7 +35,9 @@ geecs_ca_gateway/
   gateway.py         # GeecsCaGateway — pvdb build, manifest/collision guard,
                      #   per-device subscription supervisors (reconnect+backoff),
                      #   push-frame fan-out (timestamps last), INVALID marking,
-                     #   CONNECTED + CAGateway:* status PVs, UDP setter closures
+                     #   CONNECTED + CAGateway:* status PVs (incl. the writable
+                     #   RESTART control → exit 86 → systemd relaunch = DB resync),
+                     #   UDP setter closures
   channels.py        # caproto channel construction: readback (client-read-only)
                      #   vs setpoint (write forwards to GEECS first), enum
                      #   index/label resolution, path long-string channels,

--- a/GeecsCAGateway/DEPLOYMENT.md
+++ b/GeecsCAGateway/DEPLOYMENT.md
@@ -267,6 +267,15 @@ sudo systemctl enable --now geecs-ca-gateway
 - A **restart is also the upgrade and the DB-resync mechanism**: `git pull &&
   poetry install && systemctl restart geecs-ca-gateway` — matching the
   existing GEECS master-GUI reboot pattern for device-set changes.
+- **DB edits don't need shell access**: any CA client can write the
+  `[Experiment:]CAGateway:RESTART` PV (devIocStats `SYSRESET` pattern) and
+  the gateway exits with code 86, which the unit's `RestartForceExitStatus`
+  turns into a relaunch — serving the freshly edited device/get-list set a
+  few seconds later. A Phoebus button, a GUI menu action, or a one-liner:
+
+  ```bash
+  caproto-put Undulator:CAGateway:RESTART Restart
+  ```
 - Later sharding for fault isolation = more units with different
   `--experiment`/subsystem configs; CA name resolution makes this invisible to
   clients (DESIGN.md).

--- a/GeecsCAGateway/DEPLOYMENT.md
+++ b/GeecsCAGateway/DEPLOYMENT.md
@@ -60,16 +60,13 @@ devices' settable variables (the *control surface* — camera
 `save`/`localsavingpath`, magnet setpoints — which clients need for writes
 regardless of what is monitored; disable with `--no-settable`).
 
-**Known gap, honestly stated:** with `subscribed_only=True` (the default), a
-device with **zero** `get='yes'` variables is absent from
-`GeecsDb.get_subscribed_variables` and therefore gets **no PVs at all — its
-`:SP` control surface disappears**, even though `include_settable` is on
-(`config.py::GatewayConfig.from_geecs_experiment` builds its target list from
-the get-map alone). Workarounds today: `--all-variables`, or add one `get`
-variable to the device in the experiment config. The planned fix is to
-enumerate *all* enabled devices and union in settable-only devices with an
-empty include list; until that lands, check that any device you intend to
-*control* (not just monitor) has at least one subscribed variable.
+A device with **zero** `get='yes'` variables is *not* dropped: it keeps its
+settable variables (an empty monitoring list is not "no PVs"), so the `:SP`
+control surface of a device nobody logs per shot still exists. A device that
+would expose nothing at all (nothing subscribed, nothing settable) is skipped
+entirely — no idle TCP/UDP connections. Config building costs three batched
+DB queries total (endpoints, variable metadata, get-list), not per-device
+lookups, so startup is quick even for 100+ device experiments.
 
 ### Network scoping
 
@@ -251,35 +248,22 @@ no-hardware smoke test.)
 
 ## 5. Target production shape
 
-### systemd unit (sketch — example only, not installed by the package)
+### systemd unit
 
-```ini
-# /etc/systemd/system/geecs-ca-gateway.service
-[Unit]
-Description=GEECS to EPICS Channel Access gateway (%i-style: one unit per experiment)
-After=network-online.target mysql.service
-Wants=network-online.target
+The unit for the lab deployment ships in
+[`deploy/geecs-ca-gateway.service`](deploy/geecs-ca-gateway.service), with
+install/verify/upgrade steps in [`deploy/README.md`](deploy/README.md):
 
-[Service]
-Type=simple
-User=geecs
-WorkingDirectory=/opt/GEECS-Plugins/GeecsCAGateway
-Environment=EPICS_CAS_INTF_ADDR_LIST=192.168.6.14
-Environment=EPICS_CAS_BEACON_ADDR_LIST=192.168.6.255
-ExecStart=/usr/bin/poetry run python -m geecs_ca_gateway --experiment Undulator
-Restart=on-failure
-RestartSec=10
-
-[Install]
-WantedBy=multi-user.target
+```bash
+sudo cp deploy/geecs-ca-gateway.service /etc/systemd/system/
+sudo systemctl daemon-reload
+sudo systemctl enable --now geecs-ca-gateway
 ```
 
 - `Restart=on-failure` + `RestartSec=10` is enough: startup is cheap and
   idempotent (config rebuilds from the DB; clients' CA monitors reconnect
-  automatically when the server returns). The known slow bit is the per-device
-  DB enumeration (~80 s for Undulator's 114 devices — the 2-queries-per-device
-  follow-up in `DESIGN.md`), so expect PVs to appear about a minute after
-  start.
+  automatically when the server returns). Config building is three batched DB
+  queries, so PVs appear within seconds of start.
 - A **restart is also the upgrade and the DB-resync mechanism**: `git pull &&
   poetry install && systemctl restart geecs-ca-gateway` — matching the
   existing GEECS master-GUI reboot pattern for device-set changes.

--- a/GeecsCAGateway/DESIGN.md
+++ b/GeecsCAGateway/DESIGN.md
@@ -70,8 +70,9 @@ GEECS device  <--UDP set---------  setpoint PV   (caput)
   Verified on real hardware.
 - **Whole-experiment config** comes from `GatewayConfig.from_geecs_experiment`,
   which enumerates the experiment's `enabled` devices from the DB and builds a
-  spec for each. (Known follow-up: it does 2 DB queries per device — ~80 s for
-  Undulator's 114 devices — batch into a couple of joined queries.)
+  spec for each — three batched queries total (endpoints, variable metadata,
+  get-list), so startup config is seconds, not the ~80 s the original
+  2-queries-per-device implementation took for Undulator's 114 devices.
 - **Types are DB-driven too.** GEECS `variabletype` maps to the PV type
   (`numeric`→float, `string`/`path`→string, `choice`→enum with options from the
   `choice` table); `image`/`1darray` are skipped. So the declarative overlay is

--- a/GeecsCAGateway/PV_CONTRACT.md
+++ b/GeecsCAGateway/PV_CONTRACT.md
@@ -98,6 +98,16 @@ Every device gets exactly one status PV: `[Experiment:]Device:CONNECTED`.
 is **reserved**: a real GEECS device whose PVs would land there trips the
 collision guard at startup rather than silently clobbering the status PVs.
 
+**`[Experiment:]CAGateway:RESTART`** is the one *client-writable* PV in the
+namespace (the devIocStats `SYSRESET` pattern): an enum with states
+`["Idle", "Restart"]`. Writing `Restart` (label or index 1) makes the gateway
+shut down cleanly and exit with the restart code (86); under the shipped
+systemd unit that is an automatic relaunch, which — because the served set
+rebuilds live from the GEECS database at startup — is also the **DB-resync
+mechanism** after a device/get-list edit. Writing `Idle`/0 is a no-op.
+Expect a few seconds of CA disconnect; monitors reconnect automatically.
+Outside systemd (a foreground run) the process simply exits.
+
 ### Long-string (path) PVs
 
 EPICS `DBR_STRING` caps at 40 characters, and GEECS save paths routinely exceed
@@ -416,6 +426,7 @@ that branch and are part of this contract's target behavior.
 | Manifest as authoritative map; `:SP` only when settable | `test_gateway.py::test_experiment_prefix_and_manifest`, `::test_pvdb_contains_readback_and_setpoint` |
 | Genuine collision raises; exact duplicates tolerated | `test_gateway.py::test_pv_name_collision_raises`; `test_config_from_db.py::test_from_db_metadata_dedupes_duplicate_variables` |
 | Reserved `CAGateway`/status namespace guarded | `test_gateway.py::test_pvdb_has_connected_and_gateway_status_pvs`; `test_pv_contract.py::test_status_pv_namespace_is_collision_guarded` |
+| `CAGateway:RESTART` triggers clean shutdown; `Idle` is a no-op; exit code 86 | `test_pv_contract.py::test_restart_pv_requests_clean_shutdown`; `test_gateway.py::test_run_returns_true_on_restart_request`; `test_entrypoint.py::test_main_exits_with_restart_code` |
 | Readbacks client-read-only; setpoints writable | `test_gateway.py::test_readback_channels_deny_client_writes` |
 | Stream → readback; caput `:SP` → GEECS → readback | `test_gateway.py::test_stream_updates_readback`, `::test_setpoint_write_reaches_geecs` |
 | Failed GEECS set ⇒ CA put fails, value not stored | `test_pv_contract.py::test_setpoint_put_failure_leaves_value_unstored` |

--- a/GeecsCAGateway/deploy/README.md
+++ b/GeecsCAGateway/deploy/README.md
@@ -1,9 +1,12 @@
 # Deploying the gateway as a service
 
-`geecs-ca-gateway.service` is the systemd unit for the current lab deployment
-(user `abmx`, checkout at `/home/abmx/GEECS-Plugins`, serving on
-`192.168.6.14`). The full deployment context — config resolution, network
-scoping, the client-side recipe, smoke tests, log expectations — is in
+`geecs-ca-gateway.service` is the systemd unit for the lab deployment
+(serving on `192.168.6.14`). It is written against a generic `geecs` service
+account — substitute the real account/paths on your box in the installed copy
+(`User=`, `Environment=HOME=`, `WorkingDirectory=`, `ExecStart=`); site
+specifics belong in `/etc/systemd/system`, not in this repo. The full
+deployment context — config resolution, network scoping, the client-side
+recipe, smoke tests, log expectations — is in
 [`DEPLOYMENT.md`](../DEPLOYMENT.md).
 
 ## Install
@@ -20,6 +23,7 @@ poetry run python -m geecs_ca_gateway --experiment Undulator --log-level INFO
 # ^ run once in the foreground; Ctrl-C once PVs are serving cleanly
 
 sudo cp deploy/geecs-ca-gateway.service /etc/systemd/system/
+sudoedit /etc/systemd/system/geecs-ca-gateway.service   # User= + the three paths
 sudo systemctl daemon-reload
 sudo systemctl enable --now geecs-ca-gateway
 ```

--- a/GeecsCAGateway/deploy/README.md
+++ b/GeecsCAGateway/deploy/README.md
@@ -1,0 +1,59 @@
+# Deploying the gateway as a service
+
+`geecs-ca-gateway.service` is the systemd unit for the current lab deployment
+(user `abmx`, checkout at `/home/abmx/GEECS-Plugins`, serving on
+`192.168.6.14`). The full deployment context — config resolution, network
+scoping, the client-side recipe, smoke tests, log expectations — is in
+[`DEPLOYMENT.md`](../DEPLOYMENT.md).
+
+## Install
+
+From the repo checkout on the target box:
+
+```bash
+cd ~/GEECS-Plugins/GeecsCAGateway
+poetry install                    # slim env: caproto + pydantic + mysql-connector
+
+# Sanity-check the unit's paths against this box before installing:
+which poetry                      # must match ExecStart's poetry path
+poetry run python -m geecs_ca_gateway --experiment Undulator --log-level INFO
+# ^ run once in the foreground; Ctrl-C once PVs are serving cleanly
+
+sudo cp deploy/geecs-ca-gateway.service /etc/systemd/system/
+sudo systemctl daemon-reload
+sudo systemctl enable --now geecs-ca-gateway
+```
+
+## Verify
+
+```bash
+systemctl status geecs-ca-gateway
+journalctl -u geecs-ca-gateway -f     # expect the startup lines, then quiet
+```
+
+Then the smoke tests from `DEPLOYMENT.md` §4 — from a *different* machine, so
+subnet scoping and firewalls are exercised:
+
+```bash
+caproto-get Undulator:CAGateway:VERSION Undulator:CAGateway:DEVICES_CONNECTED
+caproto-monitor Undulator:CAGateway:HEARTBEAT    # ticks every 5 s
+```
+
+## Upgrade / resync with the GEECS DB
+
+A restart is both the upgrade and the DB-resync mechanism (the served set
+rebuilds from the database at startup):
+
+```bash
+cd ~/GEECS-Plugins && git pull
+cd GeecsCAGateway && poetry install
+sudo systemctl restart geecs-ca-gateway
+```
+
+## Changing what is served
+
+Edit `ExecStart` in the unit (`--all-variables`, `--no-settable`,
+`--include-disabled`, a different `--experiment`), then
+`sudo systemctl daemon-reload && sudo systemctl restart geecs-ca-gateway`.
+Serving a second experiment = a second copy of the unit with a different name
+and `--experiment`; CA name resolution makes the split invisible to clients.

--- a/GeecsCAGateway/deploy/README.md
+++ b/GeecsCAGateway/deploy/README.md
@@ -50,6 +50,14 @@ cd GeecsCAGateway && poetry install
 sudo systemctl restart geecs-ca-gateway
 ```
 
+**After a DB edit, no shell needed**: write the restart PV from any CA client
+on the lab subnet (the unit's `RestartForceExitStatus=86` relaunches the
+service, which rebuilds its config from the DB):
+
+```bash
+caproto-put Undulator:CAGateway:RESTART Restart
+```
+
 ## Changing what is served
 
 Edit `ExecStart` in the unit (`--all-variables`, `--no-settable`,

--- a/GeecsCAGateway/deploy/geecs-ca-gateway.service
+++ b/GeecsCAGateway/deploy/geecs-ca-gateway.service
@@ -31,6 +31,11 @@ Environment=EPICS_CAS_BEACON_ADDR_LIST=192.168.6.255
 ExecStart=/home/abmx/.local/bin/poetry run python -m geecs_ca_gateway --experiment Undulator
 Restart=on-failure
 RestartSec=10
+# Remote restart: a CA put to <Experiment>:CAGateway:RESTART makes the gateway
+# exit with code 86, which systemd treats as "relaunch" (clean, not a failure).
+# This is also how the served set resyncs after a GEECS DB edit — no SSH needed.
+SuccessExitStatus=86
+RestartForceExitStatus=86
 SyslogIdentifier=geecs-ca-gateway
 
 [Install]

--- a/GeecsCAGateway/deploy/geecs-ca-gateway.service
+++ b/GeecsCAGateway/deploy/geecs-ca-gateway.service
@@ -1,15 +1,20 @@
-# GEECS → EPICS Channel Access gateway — systemd unit for the lab deployment
-# on abmx-Super-Server (192.168.6.14), alongside the GEECS MySQL DB and Tiled.
+# GEECS → EPICS Channel Access gateway — systemd unit for the lab gateway host
+# (192.168.6.14, alongside the GEECS MySQL DB and Tiled).
+#
+# The User= and path lines below use a generic `geecs` service account —
+# substitute the real account on your box when installing; the copy in
+# /etc/systemd/system is the home for site specifics, not this file.
 #
 # Install (from the repo checkout on the box):
 #   sudo cp deploy/geecs-ca-gateway.service /etc/systemd/system/
+#   sudoedit /etc/systemd/system/geecs-ca-gateway.service   # fix User + paths
 #   sudo systemctl daemon-reload
 #   sudo systemctl enable --now geecs-ca-gateway
 #
 # Upgrade / DB-resync (a restart IS both — config rebuilds live from the DB):
 #   git pull && poetry install && sudo systemctl restart geecs-ca-gateway
 #
-# Adjust User/paths for a different box; see deploy/README.md and DEPLOYMENT.md.
+# See deploy/README.md and DEPLOYMENT.md.
 
 [Unit]
 Description=GEECS to EPICS Channel Access gateway (Undulator)
@@ -21,14 +26,14 @@ Wants=network-online.target
 
 [Service]
 Type=simple
-User=abmx
+User=geecs
 # Poetry resolves its cache/venvs under $HOME; systemd does not always set it.
-Environment=HOME=/home/abmx
-WorkingDirectory=/home/abmx/GEECS-Plugins/GeecsCAGateway
+Environment=HOME=/home/geecs
+WorkingDirectory=/home/geecs/GEECS-Plugins/GeecsCAGateway
 # Serve CA only on the lab interface (write-safety residual — no CA-level auth).
 Environment=EPICS_CAS_INTF_ADDR_LIST=192.168.6.14
 Environment=EPICS_CAS_BEACON_ADDR_LIST=192.168.6.255
-ExecStart=/home/abmx/.local/bin/poetry run python -m geecs_ca_gateway --experiment Undulator
+ExecStart=/home/geecs/.local/bin/poetry run python -m geecs_ca_gateway --experiment Undulator
 Restart=on-failure
 RestartSec=10
 # Remote restart: a CA put to <Experiment>:CAGateway:RESTART makes the gateway

--- a/GeecsCAGateway/deploy/geecs-ca-gateway.service
+++ b/GeecsCAGateway/deploy/geecs-ca-gateway.service
@@ -1,0 +1,37 @@
+# GEECS → EPICS Channel Access gateway — systemd unit for the lab deployment
+# on abmx-Super-Server (192.168.6.14), alongside the GEECS MySQL DB and Tiled.
+#
+# Install (from the repo checkout on the box):
+#   sudo cp deploy/geecs-ca-gateway.service /etc/systemd/system/
+#   sudo systemctl daemon-reload
+#   sudo systemctl enable --now geecs-ca-gateway
+#
+# Upgrade / DB-resync (a restart IS both — config rebuilds live from the DB):
+#   git pull && poetry install && sudo systemctl restart geecs-ca-gateway
+#
+# Adjust User/paths for a different box; see deploy/README.md and DEPLOYMENT.md.
+
+[Unit]
+Description=GEECS to EPICS Channel Access gateway (Undulator)
+# The gateway reads the GEECS DB at startup. If MySQL runs on this box under a
+# different unit name (mysqld/mariadb), fix the name; if the DB is remote,
+# drop it — Restart=on-failure retries until the DB is reachable either way.
+After=network-online.target mysql.service
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=abmx
+# Poetry resolves its cache/venvs under $HOME; systemd does not always set it.
+Environment=HOME=/home/abmx
+WorkingDirectory=/home/abmx/GEECS-Plugins/GeecsCAGateway
+# Serve CA only on the lab interface (write-safety residual — no CA-level auth).
+Environment=EPICS_CAS_INTF_ADDR_LIST=192.168.6.14
+Environment=EPICS_CAS_BEACON_ADDR_LIST=192.168.6.255
+ExecStart=/home/abmx/.local/bin/poetry run python -m geecs_ca_gateway --experiment Undulator
+Restart=on-failure
+RestartSec=10
+SyslogIdentifier=geecs-ca-gateway
+
+[Install]
+WantedBy=multi-user.target

--- a/GeecsCAGateway/geecs_ca_gateway/__main__.py
+++ b/GeecsCAGateway/geecs_ca_gateway/__main__.py
@@ -23,6 +23,11 @@ from .gateway import GeecsCaGateway
 
 logger = logging.getLogger("geecs_ca_gateway")
 
+#: Exit code signalling "relaunch me" — a CA put to ``CAGateway:RESTART``.
+#: The systemd unit's ``RestartForceExitStatus`` matches it, turning the exit
+#: into a service restart (which also resyncs the served set with the DB).
+RESTART_EXIT_CODE = 86
+
 
 class _QuietMissingVariables(logging.Filter):
     """Drop the transport's 'missing variable(s)' notices.
@@ -85,7 +90,7 @@ async def _run(
     subscribed_only: bool,
     enabled_only: bool,
     include_settable: bool,
-) -> None:
+) -> bool:
     config = GatewayConfig.from_geecs_experiment(
         experiment,
         subscribed_only=subscribed_only,
@@ -99,7 +104,8 @@ async def _run(
         len(config.devices),
         experiment,
     )
-    await gateway.run()  # connect -> subscribe -> serve (until cancelled)
+    # connect -> subscribe -> serve; True = restart requested over CA
+    return await gateway.run()
 
 
 def main(argv: list[str] | None = None) -> None:
@@ -114,7 +120,7 @@ def main(argv: list[str] | None = None) -> None:
             _QuietMissingVariables()
         )
     try:
-        asyncio.run(
+        restart = asyncio.run(
             _run(
                 args.experiment,
                 subscribed_only=not args.all_variables,
@@ -124,6 +130,10 @@ def main(argv: list[str] | None = None) -> None:
         )
     except KeyboardInterrupt:
         logger.info("shutting down")
+        return
+    if restart:
+        logger.info("exiting with code %d for service restart", RESTART_EXIT_CODE)
+        raise SystemExit(RESTART_EXIT_CODE)
 
 
 if __name__ == "__main__":

--- a/GeecsCAGateway/geecs_ca_gateway/channels.py
+++ b/GeecsCAGateway/geecs_ca_gateway/channels.py
@@ -310,3 +310,31 @@ def make_setpoint_channel(spec: VariableSpec, setter: Setter) -> ChannelData:
             return await super().write(value, **kwargs)
 
     return _GeecsSetpoint(**_metadata_kwargs(spec))
+
+
+#: Enum states of the ``CAGateway:RESTART`` control PV.
+RESTART_STATES = ["Idle", "Restart"]
+
+
+def make_restart_channel(on_restart: Callable[[], None]) -> ChannelData:
+    """Build the ``CAGateway:RESTART`` control channel.
+
+    A CA put of ``Restart`` (label or index 1) invokes *on_restart* — the
+    gateway's clean-shutdown hook, which under systemd becomes a restart via
+    the unit's ``RestartForceExitStatus``.  This is the devIocStats
+    ``SYSRESET`` pattern: any CA client (Phoebus button, a GUI menu action, a
+    one-line ``caput``) can bounce the service, which is also how it resyncs
+    with the GEECS database after a device-set edit.  Writing ``Idle``/0 is a
+    no-op, so two-state GUI widgets are safe to wire to it.
+    """
+
+    class _RestartChannel(ChannelEnum):
+        """Enum channel whose ``Restart`` puts trigger the shutdown hook."""
+
+        async def write(self, value: Any, **kwargs: Any) -> Any:
+            """Store the put; fire *on_restart* when it selects ``Restart``."""
+            if enum_geecs_value(RESTART_STATES, value) == "Restart":
+                on_restart()
+            return await super().write(value, **kwargs)
+
+    return _RestartChannel(value=0, enum_strings=list(RESTART_STATES))

--- a/GeecsCAGateway/geecs_ca_gateway/config.py
+++ b/GeecsCAGateway/geecs_ca_gateway/config.py
@@ -323,7 +323,12 @@ class GatewayConfig(BaseModel):
         *monitoring* subset, but settable variables are the device's *control
         surface* (camera ``save`` / ``localsavingpath``, magnet setpoints, …)
         and CA clients need their ``:SP`` PVs for writes regardless of what is
-        monitored per shot.
+        monitored per shot.  A device with *zero* ``get='yes'`` variables still
+        gets its control surface (an empty monitoring list is not "no PVs").
+
+        Everything comes from three batched queries (endpoints, variable
+        metadata, get-list) rather than per-device lookups — whole-experiment
+        startup cost is constant in the number of devices.
 
         This is the live-from-DB path (the DB is the source of truth); further
         curation belongs in a separate overlay applied on top, not here.
@@ -346,25 +351,40 @@ class GatewayConfig(BaseModel):
         """
         from geecs_ca_gateway.db.geecs_db import GeecsDb
 
+        endpoints = GeecsDb.get_experiment_devices(
+            experiment, enabled_only=enabled_only
+        )
+        var_map = GeecsDb.get_experiment_device_variables(
+            experiment, enabled_only=enabled_only
+        )
+        sub_map: dict[str, list[str]] = {}
         if subscribed_only:
             sub_map = GeecsDb.get_subscribed_variables(
                 experiment, enabled_only=enabled_only
             )
-            targets = list(sub_map.items())
-        else:
-            names = GeecsDb.list_devices(experiment, enabled_only=enabled_only)
-            targets = [(name, None) for name in names]
+            for name in sub_map.keys() - endpoints.keys():
+                logger.warning(
+                    "from_geecs_experiment: %s has get='yes' variables but no "
+                    "device-table endpoint — skipping",
+                    name,
+                )
 
         devices: list[DeviceSpec] = []
-        for name, include in targets:
+        for name, (host, port) in endpoints.items():
+            # In subscribed mode a device absent from the get-map still gets an
+            # (empty) include list: nothing is monitored, but include_settable
+            # keeps its settable control surface — losing every :SP PV because
+            # no variable is logged per shot was a real deployment gap.
+            include = sub_map.get(name, []) if subscribed_only else None
             try:
-                devices.append(
-                    DeviceSpec.from_geecs_db(
-                        name,
-                        experiment=experiment,
-                        include=include,
-                        include_settable=include_settable and include is not None,
-                    )
+                spec = DeviceSpec.from_db_metadata(
+                    name,
+                    host,
+                    port,
+                    var_map.get(name, []),
+                    include=include,
+                    include_settable=include_settable and include is not None,
+                    experiment=experiment,
                 )
             except Exception:
                 logger.warning(
@@ -372,10 +392,18 @@ class GatewayConfig(BaseModel):
                     name,
                     exc_info=True,
                 )
+                continue
+            if not spec.variables:
+                logger.debug(
+                    "from_geecs_experiment: %s exposes no variables — skipping",
+                    name,
+                )
+                continue
+            devices.append(spec)
         logger.info(
             "from_geecs_experiment(%s): built %d/%d device spec(s)",
             experiment,
             len(devices),
-            len(targets),
+            len(endpoints),
         )
         return cls(devices=devices)

--- a/GeecsCAGateway/geecs_ca_gateway/db/geecs_db.py
+++ b/GeecsCAGateway/geecs_ca_gateway/db/geecs_db.py
@@ -88,6 +88,33 @@ def _connect_mysql(mysql_connector):
     return mysql_connector.connect(**_find_credentials(), use_pure=True)
 
 
+def _num(value: object) -> Optional[float]:
+    """Coerce a DB value to float, or ``None`` if it isn't numeric."""
+    try:
+        return float(value)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return None
+
+
+def _variable_row_to_meta(row: tuple) -> dict:
+    """Map a ``devicetype_variable`` (+ ``choice``) row onto the metadata dict.
+
+    Row order: name, units, min, max, set, variabletype, choices, tolerance —
+    the shared SELECT column order of :meth:`GeecsDb.get_device_variables` and
+    :meth:`GeecsDb.get_experiment_device_variables`.
+    """
+    return {
+        "name": row[0],
+        "units": row[1] or "",
+        "min": _num(row[2]),
+        "max": _num(row[3]),
+        "settable": (row[4] or "no").lower() == "yes",
+        "variabletype": (row[5] or "").strip().lower() or None,
+        "choices": row[6],
+        "tolerance": _num(row[7]),
+    }
+
+
 class GeecsDb:
     """Namespace for GEECS database queries.
 
@@ -309,22 +336,95 @@ class GeecsDb:
         finally:
             conn.close()
 
-        def _num(value: object) -> Optional[float]:
-            try:
-                return float(value)  # type: ignore[arg-type]
-            except (TypeError, ValueError):
-                return None
+        return [_variable_row_to_meta(r) for r in rows]
 
-        return [
-            {
-                "name": r[0],
-                "units": r[1] or "",
-                "min": _num(r[2]),
-                "max": _num(r[3]),
-                "settable": (r[4] or "no").lower() == "yes",
-                "variabletype": (r[5] or "").strip().lower() or None,
-                "choices": r[6],
-                "tolerance": _num(r[7]),
-            }
-            for r in rows
-        ]
+    @classmethod
+    def get_experiment_devices(
+        cls, experiment: str, *, enabled_only: bool = True
+    ) -> dict[str, tuple[str, int]]:
+        """Return ``{device: (ip_address, port)}`` for an experiment — one query.
+
+        The batch counterpart of :meth:`find_device`: endpoints for every device
+        in *experiment* in a single connection, so building a whole-experiment
+        gateway config doesn't open one MySQL connection per device.
+
+        Parameters
+        ----------
+        experiment:
+            GEECS experiment name.
+        enabled_only:
+            Restrict to devices enabled in the experiment (default true).
+        """
+        try:
+            import mysql.connector
+        except ImportError as exc:
+            raise ImportError(
+                "mysql-connector-python is required for DB lookups."
+            ) from exc
+
+        conn = _connect_mysql(mysql.connector)
+        try:
+            cur = conn.cursor()
+            query = (
+                "SELECT DISTINCT d.name, d.ipaddress, d.commport "
+                "FROM expt_device ed "
+                "JOIN device d ON d.name = ed.device "
+                "WHERE ed.expt = %s"
+            )
+            if enabled_only:
+                query += " AND LOWER(ed.enabled) = 'yes'"
+            query += " ORDER BY d.name"
+            cur.execute(query, (experiment,))
+            rows = cur.fetchall()
+        finally:
+            conn.close()
+
+        return {name: (ip.strip(), int(port)) for name, ip, port in rows}
+
+    @classmethod
+    def get_experiment_device_variables(
+        cls, experiment: str, *, enabled_only: bool = True
+    ) -> dict[str, list[dict]]:
+        """Return ``{device: [variable metadata, ...]}`` for an experiment.
+
+        The batch counterpart of :meth:`get_device_variables`: metadata for
+        every device in *experiment* in a single query, with the same per-row
+        dict shape.  Duplicate ``devicetype_variable`` rows (a known DB quirk)
+        are passed through — spec building dedupes by name.
+
+        Parameters
+        ----------
+        experiment:
+            GEECS experiment name.
+        enabled_only:
+            Restrict to devices enabled in the experiment (default true).
+        """
+        try:
+            import mysql.connector
+        except ImportError as exc:
+            raise ImportError(
+                "mysql-connector-python is required for DB lookups."
+            ) from exc
+
+        conn = _connect_mysql(mysql.connector)
+        try:
+            cur = conn.cursor()
+            query = (
+                "SELECT d.name, dtv.name, dtv.units, dtv.min, dtv.max, dtv.`set`, "
+                "dtv.variabletype, c.choices, dtv.tolerance "
+                "FROM (SELECT DISTINCT ed.device FROM expt_device ed "
+                "      WHERE ed.expt = %s{enabled}) sel "
+                "JOIN device d ON d.name = sel.device "
+                "JOIN devicetype_variable dtv ON dtv.devicetype = d.devicetype "
+                "LEFT JOIN choice c ON c.id = dtv.choice_id "
+                "ORDER BY d.name, dtv.name"
+            ).format(enabled=" AND LOWER(ed.enabled) = 'yes'" if enabled_only else "")
+            cur.execute(query, (experiment,))
+            rows = cur.fetchall()
+        finally:
+            conn.close()
+
+        result: dict[str, list[dict]] = {}
+        for row in rows:
+            result.setdefault(row[0], []).append(_variable_row_to_meta(row[1:]))
+        return result

--- a/GeecsCAGateway/geecs_ca_gateway/gateway.py
+++ b/GeecsCAGateway/geecs_ca_gateway/gateway.py
@@ -37,6 +37,7 @@ from .channels import (
     cast_value,
     enum_index,
     make_readback_channel,
+    make_restart_channel,
     make_setpoint_channel,
     read_only,
 )
@@ -146,6 +147,9 @@ class GeecsCaGateway:
         self._gateway_status: dict[str, ChannelData] = {}
         self._status_task: asyncio.Task | None = None
         self._started_at: float | None = None
+        # Set by a CA put to CAGateway:RESTART; run() then shuts down cleanly
+        # and reports it, so the entrypoint can exit with the restart code.
+        self._restart_requested = asyncio.Event()
         # device name -> {geecs_var -> (readback channel, variable spec)}
         self._readbacks: dict[str, dict[str, tuple[ChannelData, VariableSpec]]] = {}
         self._build_pvdb()
@@ -216,6 +220,9 @@ class GeecsCaGateway:
             "HEARTBEAT": read_only(ChannelInteger)(value=0),
             "DEVICES_CONNECTED": read_only(ChannelInteger)(value=0),
             "VERSION": read_only(ChannelString)(value=pkg_version),
+            # Client-writable remote-restart control (devIocStats SYSRESET
+            # pattern) — also the DB-resync mechanism after a device-set edit.
+            "RESTART": make_restart_channel(self._request_restart),
         }
         for suffix, channel in channels.items():
             pv = pv_name(experiment, "CAGateway", suffix)
@@ -559,18 +566,47 @@ class GeecsCaGateway:
             except Exception:
                 logger.debug("failed to mark %s INVALID", pv, exc_info=True)
 
+    def _request_restart(self) -> None:
+        """Handle a CA put to ``CAGateway:RESTART``: initiate clean shutdown."""
+        if not self._restart_requested.is_set():
+            logger.warning(
+                "restart requested via CAGateway:RESTART — shutting down "
+                "(systemd relaunches the service; config rebuilds from the DB)"
+            )
+            self._restart_requested.set()
+
     async def serve(self) -> None:
         """Run the CA server until cancelled (serves ``self.pvdb``)."""
         await start_server(self.pvdb, log_pv_names=True)
 
-    async def run(self) -> None:
-        """Connect, subscribe, and serve — the full gateway lifecycle."""
+    async def run(self) -> bool:
+        """Connect, subscribe, and serve — the full gateway lifecycle.
+
+        Returns
+        -------
+        bool
+            True if shutdown was requested via the ``CAGateway:RESTART`` PV
+            (the entrypoint turns this into the restart exit code), False if
+            the server ended any other way.
+        """
         await self.connect()
         await self.subscribe()
+        serve_task = asyncio.create_task(self.serve(), name="ca-server")
+        restart_task = asyncio.create_task(
+            self._restart_requested.wait(), name="restart-wait"
+        )
         try:
-            await self.serve()
+            await asyncio.wait(
+                {serve_task, restart_task}, return_when=asyncio.FIRST_COMPLETED
+            )
+            if serve_task.done():
+                serve_task.result()  # propagate a server crash
         finally:
+            for task in (serve_task, restart_task):
+                task.cancel()
+            await asyncio.gather(serve_task, restart_task, return_exceptions=True)
             await self.close()
+        return self._restart_requested.is_set()
 
     async def close(self) -> None:
         """Cancel supervisors and tear down all subscriptions and UDP clients."""

--- a/GeecsCAGateway/pyproject.toml
+++ b/GeecsCAGateway/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-ca-gateway"
-version = "0.5.2"
+version = "0.6.0"
 description = "EPICS Channel Access soft-IOC gateway exposing GEECS devices as PVs"
 authors = ["Sam Barber <sbarber@lbl.gov>"]
 readme = "README.md"

--- a/GeecsCAGateway/tests/test_config_from_db.py
+++ b/GeecsCAGateway/tests/test_config_from_db.py
@@ -6,7 +6,7 @@ Exercises the pure ``DeviceSpec.from_db_metadata`` core using rows shaped like
 
 from __future__ import annotations
 
-from geecs_ca_gateway.config import DeviceSpec, GatewayConfig, VariableSpec
+from geecs_ca_gateway.config import DeviceSpec, GatewayConfig
 from geecs_ca_gateway.gateway import GeecsCaGateway
 
 # Mirrors GeecsDb.get_device_variables("U_S1H") observed against real hardware.
@@ -269,67 +269,121 @@ def test_choice_exceeding_ca_enum_limits_falls_back_to_string() -> None:
     assert spec.variables[0].choices == []
 
 
-def test_from_geecs_experiment_subscribed_only(monkeypatch) -> None:
-    """Default: down-select to get='yes' vars (passed as include); skip failures."""
+def _patch_experiment_db(
+    monkeypatch,
+    *,
+    endpoints: dict,
+    var_map: dict,
+    sub_map: dict,
+) -> None:
+    """Stub the three batched GeecsDb queries from_geecs_experiment issues."""
     from geecs_ca_gateway.db.geecs_db import GeecsDb
 
     monkeypatch.setattr(
         GeecsDb,
-        "get_subscribed_variables",
-        classmethod(
-            lambda cls, experiment, *, enabled_only=True: {
-                "U_A": ["Current"],
-                "U_BAD": ["Current"],
-                "U_B": ["Current", "Voltage"],
-            }
-        ),
+        "get_experiment_devices",
+        classmethod(lambda cls, experiment, *, enabled_only=True: endpoints),
     )
-    seen_include: dict[str, object] = {}
+    monkeypatch.setattr(
+        GeecsDb,
+        "get_experiment_device_variables",
+        classmethod(lambda cls, experiment, *, enabled_only=True: var_map),
+    )
+    monkeypatch.setattr(
+        GeecsDb,
+        "get_subscribed_variables",
+        classmethod(lambda cls, experiment, *, enabled_only=True: sub_map),
+    )
 
-    def fake_from_db(cls, name, *, experiment=None, include=None, **kwargs):
-        seen_include[name] = include
-        if name == "U_BAD":
-            raise RuntimeError("device not resolvable")
-        return DeviceSpec(
-            name=name,
-            host="h",
-            port=1,
-            experiment=experiment,
-            variables=[
-                VariableSpec(geecs_var=v, settable=True) for v in (include or [])
-            ],
-        )
 
-    monkeypatch.setattr(DeviceSpec, "from_geecs_db", classmethod(fake_from_db))
+def _meta(name: str, *, settable: bool = False) -> dict:
+    return {"name": name, "units": "", "min": None, "max": None, "settable": settable}
+
+
+def test_from_geecs_experiment_subscribed_only(monkeypatch) -> None:
+    """Default: down-select to get='yes' vars; a broken device skips, not aborts."""
+    _patch_experiment_db(
+        monkeypatch,
+        endpoints={"U_A": ("h", 1), "U_B": ("h", 2), "U_BAD": ("h", 3)},
+        var_map={
+            "U_A": [_meta("Current", settable=True), _meta("Voltage")],
+            "U_B": [_meta("Current", settable=True), _meta("Voltage")],
+            "U_BAD": [{"units": "malformed row without a name"}],
+        },
+        sub_map={"U_A": ["Current"], "U_B": ["Current", "Voltage"], "U_BAD": ["X"]},
+    )
 
     cfg = GatewayConfig.from_geecs_experiment("Undulator")
     assert {d.name for d in cfg.devices} == {"U_A", "U_B"}  # U_BAD skipped, not fatal
-    assert seen_include["U_B"] == ["Current", "Voltage"]  # get-vars → include filter
+    by_name = {d.name: d for d in cfg.devices}
+    # U_A monitors only Current; Voltage is neither subscribed nor settable
+    assert {v.geecs_var for v in by_name["U_A"].variables} == {"Current"}
+    assert {v.geecs_var for v in by_name["U_B"].variables} == {"Current", "Voltage"}
     gw = GeecsCaGateway(cfg)
     assert "Undulator:U_B:Voltage" in gw.pvdb
 
 
-def test_from_geecs_experiment_all_variables(monkeypatch) -> None:
-    """subscribed_only=False enumerates all enabled devices, no include filter."""
-    from geecs_ca_gateway.db.geecs_db import GeecsDb
+def test_from_geecs_experiment_keeps_settable_only_devices(monkeypatch) -> None:
+    """A device with zero get='yes' variables keeps its :SP control surface.
 
-    monkeypatch.setattr(
-        GeecsDb,
-        "list_devices",
-        classmethod(lambda cls, experiment, *, enabled_only=True: ["U_A", "U_B"]),
+    Losing every PV of a device just because nothing is monitored per shot was
+    a real deployment gap (DEPLOYMENT.md documented it as known): the device's
+    settable variables are its control surface and must survive subscribed mode.
+    """
+    _patch_experiment_db(
+        monkeypatch,
+        endpoints={"U_MON": ("h", 1), "U_CTRL": ("h", 2), "U_IDLE": ("h", 3)},
+        var_map={
+            "U_MON": [_meta("Voltage")],
+            "U_CTRL": [_meta("save", settable=True), _meta("Voltage")],
+            "U_IDLE": [_meta("Voltage")],  # nothing subscribed, nothing settable
+        },
+        sub_map={"U_MON": ["Voltage"]},  # U_CTRL and U_IDLE absent from get-map
     )
 
-    def fake_from_db(cls, name, *, experiment=None, include=None, **kwargs):
-        assert include is None  # no down-select
-        return DeviceSpec(
-            name=name,
-            host="h",
-            port=1,
-            experiment=experiment,
-            variables=[VariableSpec(geecs_var="Current")],
-        )
+    cfg = GatewayConfig.from_geecs_experiment("Undulator")
+    by_name = {d.name: d for d in cfg.devices}
+    # control surface survives: only the settable variable, not the readback set
+    assert {v.geecs_var for v in by_name["U_CTRL"].variables} == {"save"}
+    gw = GeecsCaGateway(cfg)
+    assert "Undulator:U_CTRL:save:SP" in gw.pvdb
+    # a device exposing nothing at all is dropped (no pointless connections)
+    assert "U_IDLE" not in by_name
+    # --no-settable restores the strict get-list behavior
+    cfg = GatewayConfig.from_geecs_experiment("Undulator", include_settable=False)
+    assert {d.name for d in cfg.devices} == {"U_MON"}
 
-    monkeypatch.setattr(DeviceSpec, "from_geecs_db", classmethod(fake_from_db))
+
+def test_from_geecs_experiment_warns_on_endpointless_device(
+    monkeypatch, caplog
+) -> None:
+    """A get-map device missing from the device table is warned about, not lost."""
+    _patch_experiment_db(
+        monkeypatch,
+        endpoints={"U_A": ("h", 1)},
+        var_map={"U_A": [_meta("Current", settable=True)]},
+        sub_map={"U_A": ["Current"], "U_GHOST": ["Current"]},
+    )
+
+    with caplog.at_level("WARNING"):
+        cfg = GatewayConfig.from_geecs_experiment("Undulator")
+    assert {d.name for d in cfg.devices} == {"U_A"}
+    assert any("U_GHOST" in r.message for r in caplog.records)
+
+
+def test_from_geecs_experiment_all_variables(monkeypatch) -> None:
+    """subscribed_only=False exposes every variable of every enabled device."""
+    _patch_experiment_db(
+        monkeypatch,
+        endpoints={"U_A": ("h", 1), "U_B": ("h", 2)},
+        var_map={
+            "U_A": [_meta("Current", settable=True), _meta("Voltage")],
+            "U_B": [_meta("Voltage")],
+        },
+        sub_map={},  # not consulted when subscribed_only=False
+    )
 
     cfg = GatewayConfig.from_geecs_experiment("Undulator", subscribed_only=False)
-    assert {d.name for d in cfg.devices} == {"U_A", "U_B"}
+    by_name = {d.name: d for d in cfg.devices}
+    assert {v.geecs_var for v in by_name["U_A"].variables} == {"Current", "Voltage"}
+    assert {v.geecs_var for v in by_name["U_B"].variables} == {"Voltage"}

--- a/GeecsCAGateway/tests/test_entrypoint.py
+++ b/GeecsCAGateway/tests/test_entrypoint.py
@@ -30,3 +30,29 @@ def test_experiment_required() -> None:
     """--experiment is mandatory."""
     with pytest.raises(SystemExit):
         _parse_args([])
+
+
+def test_main_exits_with_restart_code(monkeypatch) -> None:
+    """A restart-requested run makes main() exit with RESTART_EXIT_CODE."""
+    from geecs_ca_gateway import __main__ as entry
+
+    async def fake_run(experiment: str, **kwargs: object) -> bool:
+        return True
+
+    monkeypatch.setattr(entry, "_run", fake_run)
+    # --show-missing: without it main() installs a process-global log filter
+    # that would swallow the warning test_transport asserts later in the run.
+    with pytest.raises(SystemExit) as exc_info:
+        entry.main(["--experiment", "X", "--show-missing"])
+    assert exc_info.value.code == entry.RESTART_EXIT_CODE
+
+
+def test_main_returns_normally_without_restart(monkeypatch) -> None:
+    """A normal shutdown does not raise SystemExit."""
+    from geecs_ca_gateway import __main__ as entry
+
+    async def fake_run(experiment: str, **kwargs: object) -> bool:
+        return False
+
+    monkeypatch.setattr(entry, "_run", fake_run)
+    entry.main(["--experiment", "X", "--show-missing"])  # no exception

--- a/GeecsCAGateway/tests/test_gateway.py
+++ b/GeecsCAGateway/tests/test_gateway.py
@@ -765,3 +765,23 @@ class TestEmptyValueSkip:
         callback = gw._make_callback(dev)
         await callback({"localsavingpath": ""})
         assert logs["localsavingpath"] == [""]
+
+
+async def test_run_returns_true_on_restart_request(monkeypatch) -> None:
+    """A CA put to CAGateway:RESTART ends run() cleanly, reporting the request.
+
+    The entrypoint turns the True return into the restart exit code, which the
+    systemd unit's RestartForceExitStatus converts into a service relaunch.
+    """
+    gw = GeecsCaGateway(GatewayConfig(devices=[]))
+
+    async def fake_serve() -> None:
+        await asyncio.sleep(30)  # stand in for the CA server (no real ports)
+
+    monkeypatch.setattr(gw, "serve", fake_serve)
+    run_task = asyncio.create_task(gw.run())
+    await asyncio.sleep(0.05)
+    assert not run_task.done()  # serving; no restart requested yet
+
+    await gw.pvdb["CAGateway:RESTART"].write("Restart")
+    assert await asyncio.wait_for(run_task, timeout=5) is True

--- a/GeecsCAGateway/tests/test_geecs_db.py
+++ b/GeecsCAGateway/tests/test_geecs_db.py
@@ -97,3 +97,86 @@ def test_get_device_type_queries_device_table(monkeypatch) -> None:
     assert queries == [
         ("SELECT devicetype FROM device WHERE name = %s", ("UC_TopView",))
     ]
+
+
+def _patch_rows(monkeypatch, rows: list[tuple], queries: list) -> None:
+    """Route _connect_mysql to a fake connection returning *rows* for any query."""
+
+    class _Cursor:
+        def execute(self, query: str, params: tuple) -> None:
+            queries.append((query, params))
+
+        def fetchall(self) -> list[tuple]:
+            return rows
+
+    class _Connection:
+        def cursor(self) -> _Cursor:
+            return _Cursor()
+
+        def close(self) -> None:
+            pass
+
+    import sys
+    import types
+
+    mysql_pkg = types.ModuleType("mysql")
+    connector_mod = types.ModuleType("mysql.connector")
+    mysql_pkg.connector = connector_mod
+    monkeypatch.setitem(sys.modules, "mysql", mysql_pkg)
+    monkeypatch.setitem(sys.modules, "mysql.connector", connector_mod)
+    monkeypatch.setattr(geecs_db, "_connect_mysql", lambda _connector: _Connection())
+
+
+def test_get_experiment_devices_batches_endpoints(monkeypatch) -> None:
+    """One query returns every device endpoint; enabled filter is in the SQL."""
+    queries: list = []
+    _patch_rows(
+        monkeypatch,
+        [("U_A", " 192.168.1.10 ", "111"), ("U_B", "192.168.1.11", 222)],
+        queries,
+    )
+
+    result = GeecsDb.get_experiment_devices("Undulator")
+    assert result == {"U_A": ("192.168.1.10", 111), "U_B": ("192.168.1.11", 222)}
+    assert len(queries) == 1
+    query, params = queries[0]
+    assert params == ("Undulator",)
+    assert "LOWER(ed.enabled) = 'yes'" in query
+
+    queries.clear()
+    GeecsDb.get_experiment_devices("Undulator", enabled_only=False)
+    assert "enabled" not in queries[0][0]
+
+
+def test_get_experiment_device_variables_batches_metadata(monkeypatch) -> None:
+    """One query returns all devices' variable metadata, grouped and mapped."""
+    queries: list = []
+    _patch_rows(
+        monkeypatch,
+        [
+            # d.name, dtv.name, units, min, max, set, variabletype, choices, tol
+            ("U_A", "Current", "A", "-5", "5", "yes", "numeric", None, "0.05"),
+            ("U_A", "Enable", "", None, None, "yes", "choice", "on,off", None),
+            ("U_B", "Voltage", "V", None, None, "no", None, None, None),
+        ],
+        queries,
+    )
+
+    result = GeecsDb.get_experiment_device_variables("Undulator")
+    assert set(result) == {"U_A", "U_B"}
+    assert len(queries) == 1 and queries[0][1] == ("Undulator",)
+
+    current = result["U_A"][0]
+    # same row shape as get_device_variables — from_db_metadata consumes both
+    assert current == {
+        "name": "Current",
+        "units": "A",
+        "min": -5.0,
+        "max": 5.0,
+        "settable": True,
+        "variabletype": "numeric",
+        "choices": None,
+        "tolerance": 0.05,
+    }
+    assert result["U_A"][1]["choices"] == "on,off"
+    assert result["U_B"][0]["settable"] is False

--- a/GeecsCAGateway/tests/test_pv_contract.py
+++ b/GeecsCAGateway/tests/test_pv_contract.py
@@ -200,3 +200,42 @@ async def test_zero_deadband_posts_changes_suppresses_exact_repeats() -> None:
     await callback({"Pos": 5.0001})  # exact repeat suppressed again
 
     assert posts == [pytest.approx(5.0), pytest.approx(5.0001)]
+
+
+# ---------------------------------------------------------------------------
+# PV_CONTRACT.md §6 — CAGateway:RESTART requests a clean shutdown
+# ---------------------------------------------------------------------------
+
+
+async def test_restart_pv_requests_clean_shutdown() -> None:
+    """Writing ``Restart`` sets the shutdown request; ``Idle`` is a no-op.
+
+    Contract §6: ``CAGateway:RESTART`` is the one client-writable status PV
+    (devIocStats ``SYSRESET`` pattern); label, index, and numeric-array puts
+    all count, and writing ``Idle``/0 must not trigger anything.
+    """
+    cfg = GatewayConfig(
+        devices=[
+            DeviceSpec(
+                name=DEVICE,
+                host="127.0.0.1",
+                port=1,
+                experiment="Undulator",
+                variables=[VariableSpec(geecs_var="Pos", dtype="float")],
+            )
+        ]
+    )
+    gw = GeecsCaGateway(cfg)
+    restart = gw.pvdb["Undulator:CAGateway:RESTART"]
+
+    await restart.write("Idle")
+    await restart.write(0)
+    assert not gw._restart_requested.is_set()
+
+    await restart.write("Restart")
+    assert gw._restart_requested.is_set()
+
+    # index form works too (fresh gateway — the event latches)
+    gw2 = GeecsCaGateway(cfg)
+    await gw2.pvdb["Undulator:CAGateway:RESTART"].write(1)
+    assert gw2._restart_requested.is_set()


### PR DESCRIPTION
Gateway-as-a-service prep (the agreed next step after the #449–#456 wave). Four changes, all in GeecsCAGateway (0.5.2 → 0.6.0):

## Settable-only devices keep their control surface

`GatewayConfig.from_geecs_experiment` built its device list from the `get='yes'` map alone, so a device with zero subscribed variables got **no PVs at all** — its `:SP` control surface disappeared. This was documented as a known gap in DEPLOYMENT.md, with the fix already sketched there: enumerate all enabled devices and union in get-map absentees with an empty monitoring list. That is what this implements. Devices that would expose nothing at all (nothing subscribed, nothing settable) are now skipped entirely instead of opening idle TCP/UDP connections, and a `get='yes'` device missing from the device table is warned about explicitly.

## Batched startup queries

Whole-experiment config building did 2 MySQL connections per device (~230 connections, ~80 s for Undulator's 114 devices — the known follow-up in DESIGN.md). New batch methods `GeecsDb.get_experiment_devices` and `GeecsDb.get_experiment_device_variables` (same row shape as their single-device counterparts) bring it to **three queries total**. Matters because a restart is the service's upgrade and DB-resync mechanism.

## `CAGateway:RESTART` PV — restart / DB resync from any CA client

The GEECS DB is edited every few days, and the served set only rebuilds at startup — but nobody should have to NoMachine into the Linux box to bounce the service. Following the devIocStats `SYSRESET` pattern, `CAGateway:RESTART` is a client-writable enum (`Idle`/`Restart`): writing `Restart` shuts the gateway down cleanly with exit code 86, which the systemd unit's `RestartForceExitStatus` turns into a relaunch serving the freshly edited DB. Any CA client works — a Phoebus button, a scanner-GUI menu action, or `caproto-put Undulator:CAGateway:RESTART Restart`. Contracted in PV_CONTRACT.md §6 with pinned tests.

## Shipped systemd unit

`deploy/geecs-ca-gateway.service` — the production unit for the lab box (192.168.6.14), with `EPICS_CAS_INTF_ADDR_LIST`/beacon scoping and the restart-exit-code wiring — plus `deploy/README.md` with the install/verify/upgrade recipe. DEPLOYMENT.md §5 now points at the shipped file instead of an inline sketch; the stale gap/perf notes in DEPLOYMENT.md, DESIGN.md, and CLAUDE.md are updated.

## Testing

- GeecsCAGateway: 113 passed (package env) — new pinning tests for the settable-only union, the nothing-exposed skip, the endpointless-device warning, both batch queries (mocked cursors), and the RESTART path at all three layers (channel semantics, `run()` return, entrypoint exit code).
- GeecsBluesky (path-deps the gateway): 211 passed, per-package invocation.
- Not yet exercised against the live DB/box — the guided service install on abmx will verify batch-query results match the per-device path on real Undulator data, and a live `caproto-put …RESTART` from a Windows client, before `systemctl enable`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)