### PR TITLE
Bluesky progress events + dead-contributor pre-flight dialog

### DIFF
--- a/GEECS-Scanner-GUI/CHANGELOG.md
+++ b/GEECS-Scanner-GUI/CHANGELOG.md
@@ -3,6 +3,32 @@
 All notable changes to this package will be documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.32.0] — 2026-07-07
+
+### Added
+
+- **`DialogRequest` grew optional `title`, `continue_label`, and
+  `abort_label` fields** so a request author can own the dialog wording —
+  used by GeecsBluesky's free-run pre-flight dead-contributor dialog
+  ("Drop && Continue" vs "Abort Scan") emitted through the existing
+  `ScanDialogEvent` channel. Unset fields keep the legacy device-command
+  rendering byte-for-byte; existing positional `(exc, context)`
+  construction is pinned unchanged. See
+  `Planning/gui_stewardship/00_overview.md` §4.
+
+### Changed
+
+- **`show_device_error_dialog` honors the request's custom title/labels**
+  via a new pure helper `_resolve_dialog_content` (requests with custom
+  fields render `str(exc)` verbatim as the body; plain requests keep the
+  device-command message construction). With this plus GeecsBluesky
+  0.21.0's `ScanStepEvent` emission, the Bluesky backend drives the GUI
+  progress bar and operator dialogs with **no changes to the GUI event
+  handlers** (`_handle_scan_event` / `_on_step_event` / `_on_dialog_event`).
+- `engine/dialog_request.py` module docstring updated — it described the
+  removed 200 ms QTimer/`dialog_queue` pattern (flagged in
+  `Planning/gui_stewardship/00_overview.md` §6).
+
 ## [0.31.0] — 2026-07-06
 
 ### Added

--- a/GEECS-Scanner-GUI/CLAUDE.md
+++ b/GEECS-Scanner-GUI/CLAUDE.md
@@ -130,7 +130,8 @@ argument wins, else the `GEECS_USE_BLUESKY` env var (`1/true/yes/on` →
 Bluesky), else legacy. The GUI constructs `RunControl` without the argument,
 so the env var is the supported way to switch a GUI session's backend.
 Both backends receive the same `on_event` callback; the Bluesky backend
-currently emits lifecycle events only (no step/dialog events — see
+emits lifecycle, step/progress, and pre-flight dialog events (no
+`DeviceCommandEvent` translation — deliberate; see
 `Planning/gui_stewardship/00_overview.md`).
 
 ## Threading Model
@@ -329,9 +330,9 @@ optimization setup) and into richer event emission from `BlueskyScanner`.
 
 ## Known Tech Debt
 
-- **Bluesky backend emits lifecycle events only**: no `ScanStepEvent`, so the
-  progress bar does not advance in Bluesky mode; no `ScanDialogEvent`, so no
-  operator dialogs.  See `Planning/gui_stewardship/00_overview.md` §4–5.
+- **Bluesky backend does not translate `DeviceCommandEvent`s** (deliberate —
+  nothing consumes them).  Step/progress and pre-flight dialog events landed
+  2026-07-07; see `Planning/gui_stewardship/00_overview.md` §4–5.
 - **Stale docstrings referencing the removed 200 ms timer**: e.g. the
   `engine/dialog_request.py` module docstring and `ScanDialogEvent`'s
   "In Block 7 ..." note.  Fix in the next code PR touching those files.

--- a/GEECS-Scanner-GUI/geecs_scanner/app/gui_dialogs.py
+++ b/GEECS-Scanner-GUI/geecs_scanner/app/gui_dialogs.py
@@ -87,6 +87,29 @@ def _build_device_error_message(exc: Exception) -> tuple[str, str]:
     return title, body
 
 
+def _resolve_dialog_content(request: DialogRequest) -> tuple[str, str, str, str]:
+    """Return ``(title, body, continue_label, abort_label)`` for *request*.
+
+    Requests carrying their own ``title`` or button labels (e.g. the Bluesky
+    pre-flight stale-device dialog) use ``str(request.exc)`` verbatim as the
+    body \u2014 the request author owns the wording of what each button means.
+    Plain requests keep the legacy device-command-error message construction.
+    """
+    if request.title or request.continue_label or request.abort_label:
+        title = request.title or "Device Error"
+        body = str(request.exc)
+    else:
+        title, body = _build_device_error_message(request.exc)
+    if request.context:
+        body += f"\n\n{request.context}"
+    return (
+        title,
+        body,
+        request.continue_label or "Continue",
+        request.abort_label or "Abort",
+    )
+
+
 # ---------------------------------------------------------------------------
 # Main-thread dialog display  (call only from the Qt main thread)
 # ---------------------------------------------------------------------------
@@ -105,9 +128,7 @@ def show_device_error_dialog(request: DialogRequest) -> None:
     """
     from PyQt5.QtWidgets import QApplication, QMessageBox
 
-    title, body = _build_device_error_message(request.exc)
-    if request.context:
-        body += f"\n\n{request.context}"
+    title, body, continue_label, abort_label = _resolve_dialog_content(request)
     logger.warning(
         "Showing device error dialog to user — %s: %s",
         type(request.exc).__name__,
@@ -126,7 +147,8 @@ def show_device_error_dialog(request: DialogRequest) -> None:
     msg_box.setWindowTitle(title)
     msg_box.setText(body)
     msg_box.setStandardButtons(QMessageBox.Ok | QMessageBox.Abort)
-    msg_box.button(QMessageBox.Ok).setText("Continue")
+    msg_box.button(QMessageBox.Ok).setText(continue_label)
+    msg_box.button(QMessageBox.Abort).setText(abort_label)
     msg_box.setDefaultButton(QMessageBox.Abort)
 
     response = msg_box.exec_()

--- a/GEECS-Scanner-GUI/geecs_scanner/engine/dialog_request.py
+++ b/GEECS-Scanner-GUI/geecs_scanner/engine/dialog_request.py
@@ -1,14 +1,20 @@
 """Thread-safe dialog request type and device-error escalation helpers.
 
-Worker threads that encounter a device error create a :class:`DialogRequest`,
-put it on ``ScanManager.dialog_queue``, and block on ``response_event.wait()``.
-The Qt main thread (via the 200 ms QTimer in ``GEECSScannerWindow``) drains the
-queue and shows the dialog.  The actual Qt code lives in
-``geecs_scanner.app.gui_dialogs`` so this module stays import-safe in headless
-environments.
+Worker threads that need an operator decision create a :class:`DialogRequest`,
+emit it inside a ``ScanDialogEvent`` through the ``on_event`` callback, and
+block on ``response_event.wait()``.  The GUI receives the event on the Qt main
+thread (via the ``_scan_event_received`` pyqtSignal), shows the dialog, and
+answers by writing ``abort[0]`` and setting ``response_event``.  The actual Qt
+code lives in ``geecs_scanner.app.gui_dialogs`` so this module stays
+import-safe in headless environments.
+
+Both scan backends use this channel: the legacy engine for device-command
+escalation, and ``BlueskyScanner`` (GeecsBluesky) for pre-flight operator
+dialogs — the latter imports this module defensively, so it must stay free of
+Qt and of heavyweight imports.
 
 Issue #312 tracking note: the old module called Qt directly from worker threads
-(unsafe).  The queue-based pattern implemented here resolves that.
+(unsafe).  The request/response pattern implemented here resolves that.
 """
 
 from __future__ import annotations
@@ -93,10 +99,22 @@ class DialogRequest:
     Parameters
     ----------
     exc :
-        The device exception that triggered the dialog.
+        The exception that triggered the dialog.  For requests carrying
+        their own ``title``/labels, ``str(exc)`` is the full operator-facing
+        dialog body.
     context :
         Optional extra information shown in the dialog body — e.g. the full
         list of variables being set for a device when the error occurred.
+    title :
+        Optional dialog window title.  ``None`` (legacy device-command
+        requests) keeps the title derived from the exception type.
+    continue_label :
+        Optional text for the non-abort button (e.g. ``"Drop && Continue"``).
+        ``None`` keeps the default ``"Continue"``.  When set, the dialog body
+        is ``str(exc)`` verbatim — the request author owns the wording of
+        what "continue" means.
+    abort_label :
+        Optional text for the abort button.  ``None`` keeps ``"Abort"``.
     response_event :
         Set by the main thread once the user has responded.
     abort :
@@ -106,5 +124,8 @@ class DialogRequest:
 
     exc: Exception
     context: Optional[str] = None
+    title: Optional[str] = None
+    continue_label: Optional[str] = None
+    abort_label: Optional[str] = None
     response_event: threading.Event = field(default_factory=threading.Event)
     abort: list[bool] = field(default_factory=lambda: [False])

--- a/GEECS-Scanner-GUI/pyproject.toml
+++ b/GEECS-Scanner-GUI/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-scanner-gui"
-version = "0.31.0"
+version = "0.32.0"
 
 
 description = ""

--- a/GEECS-Scanner-GUI/tests/app/test_gui_dialogs.py
+++ b/GEECS-Scanner-GUI/tests/app/test_gui_dialogs.py
@@ -1,0 +1,119 @@
+"""Pin the dialog-request shape shared with the Bluesky pre-flight dialogs.
+
+``BlueskyScanner`` (GeecsBluesky) raises pre-claim operator dialogs through
+the same channel the legacy engine uses: a ``DialogRequest`` carried by a
+``ScanDialogEvent`` into ``show_device_error_dialog``.  These tests pin the
+request fields it relies on (``title`` / ``continue_label`` / ``abort_label``)
+and the content resolution the GUI handler performs — without any Qt display
+(``_resolve_dialog_content`` is the pure part of ``show_device_error_dialog``).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+from geecs_scanner.engine.dialog_request import DialogRequest
+from geecs_scanner.engine.scan_events import ScanDialogEvent
+
+# ``geecs_scanner.app``'s package __init__ imports the editor windows and so
+# PyQt5 (a Windows-only dependency), but ``gui_dialogs`` itself is import-safe
+# without Qt (PyQt5 is imported inside the display function).  Load the module
+# straight from its file to keep this test hermetic on non-Windows CI.
+_GUI_DIALOGS_PATH = (
+    Path(__file__).parents[2] / "geecs_scanner" / "app" / "gui_dialogs.py"
+)
+_spec = importlib.util.spec_from_file_location(
+    "_gui_dialogs_under_test", _GUI_DIALOGS_PATH
+)
+_gui_dialogs = importlib.util.module_from_spec(_spec)
+assert _spec.loader is not None
+_spec.loader.exec_module(_gui_dialogs)
+_resolve_dialog_content = _gui_dialogs._resolve_dialog_content
+
+
+def test_plain_request_keeps_legacy_device_error_message() -> None:
+    """Requests without custom fields render exactly as before."""
+    request = DialogRequest(exc=RuntimeError("boom"))
+
+    title, body, continue_label, abort_label = _resolve_dialog_content(request)
+
+    assert title == "Device Error"
+    assert "boom" in body
+    assert "Click  Continue  to proceed" in body  # legacy instruction footer
+    assert continue_label == "Continue"
+    assert abort_label == "Abort"
+
+
+def test_plain_request_context_is_appended() -> None:
+    request = DialogRequest(exc=RuntimeError("boom"), context="var list: a, b")
+
+    _title, body, _continue, _abort = _resolve_dialog_content(request)
+
+    assert body.endswith("var list: a, b")
+
+
+def test_custom_request_uses_exc_message_and_labels_verbatim() -> None:
+    """The Bluesky pre-flight request shape: title + labels + full body."""
+    message = (
+        "Synchronous device(s) look dead: U_Cam4 (last frame 12 s ago). "
+        "Drop them and continue the scan without their data, or abort."
+    )
+    request = DialogRequest(
+        exc=RuntimeError(message),
+        title="Dead Contributor Device(s)",
+        continue_label="Drop && Continue",
+        abort_label="Abort Scan",
+    )
+
+    title, body, continue_label, abort_label = _resolve_dialog_content(request)
+
+    assert title == "Dead Contributor Device(s)"
+    assert body == message  # verbatim — no device-command boilerplate
+    assert continue_label == "Drop && Continue"
+    assert abort_label == "Abort Scan"
+
+
+def test_custom_request_context_still_appended() -> None:
+    request = DialogRequest(
+        exc=RuntimeError("body"),
+        context="extra detail",
+        title="Trigger May Be Off",
+        continue_label="Start Anyway",
+    )
+
+    _title, body, continue_label, abort_label = _resolve_dialog_content(request)
+
+    assert body == "body\n\nextra detail"
+    assert continue_label == "Start Anyway"
+    assert abort_label == "Abort"  # unset label falls back to the default
+
+
+def test_scan_dialog_event_carries_the_extended_request() -> None:
+    """The event shape the Bluesky backend emits is accepted unchanged."""
+    request = DialogRequest(
+        exc=RuntimeError("reference looks dead"),
+        title="Reference Device Looks Dead",
+        continue_label="Try Anyway",
+        abort_label="Abort Scan",
+    )
+    event = ScanDialogEvent(request=request)
+
+    assert event.request is request
+    # Response channel unchanged: consumer writes abort[0] + sets the event.
+    assert event.request.abort == [False]
+    assert not event.request.response_event.is_set()
+    event.request.abort[0] = True
+    event.request.response_event.set()
+    assert request.abort == [True]
+    assert request.response_event.is_set()
+
+
+def test_legacy_positional_construction_is_unchanged() -> None:
+    """Existing callers pass (exc, context) positionally — must still work."""
+    request = DialogRequest(RuntimeError("x"), "some context")
+
+    assert request.context == "some context"
+    assert request.title is None
+    assert request.continue_label is None
+    assert request.abort_label is None

--- a/GeecsBluesky/CHANGELOG.md
+++ b/GeecsBluesky/CHANGELOG.md
@@ -4,6 +4,36 @@ All notable changes to `geecs-bluesky` are documented here.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.21.0] - 2026-07-07
+
+### Added
+
+- **GUI progress events in Bluesky mode** — `BlueskyScanner._on_document`
+  now emits a `ScanStepEvent` (shot-level, `phase="completed"`) for every
+  Bluesky event document through the same `on_event` callback as the
+  lifecycle events, so the Scanner GUI progress bar advances identically
+  for both backends with no GUI changes (`shots_completed` = running
+  event-document count, clamped at `total_shots` so the free-run
+  tail-flush overcount stays cosmetic; step index derived from the
+  schema-v1 `bin_number` column). Closes the "progress bar never advances
+  in Bluesky mode" gap — see `Planning/gui_stewardship/00_overview.md` §5.
+- **Free-run dead-contributor pre-flight dialog** — before a
+  `free_run_time_sync` scan claims its folder (so an abort burns no scan
+  number), every synchronous device's persistent-monitor cache
+  (`_last_acq`) is checked for freshness (default threshold 10 s
+  wall-clock; one ~2 s re-check grace for just-connected monitors).
+  Stale devices raise an operator dialog through the legacy channel
+  (`DialogRequest` inside a `ScanDialogEvent`): stale contributors offer
+  drop-and-continue (devices disconnected, removed from the detector
+  list, logged loudly) vs abort; a stale reference (pacemaker) is
+  abort-only in v1 (second button is a clearly-labeled "Try Anyway");
+  all-stale blames the trigger ("may be off / not free-running") instead
+  of the cameras. Headless (`on_event=None`), missing geecs_scanner, or
+  an unanswered dialog (30 s timeout) preserve today's behavior — proceed
+  and let t0 sync fail loudly. New `GeecsStaleDevicesError` carries the
+  operator-facing message. Implements the stewardship plan's first
+  concrete use case (`Planning/gui_stewardship/00_overview.md` §4).
+
 ## [0.20.0] - 2026-07-06
 
 ### Added

--- a/GeecsBluesky/CHANGELOG.md
+++ b/GeecsBluesky/CHANGELOG.md
@@ -17,29 +17,51 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   tail-flush overcount stays cosmetic; step index derived from the
   schema-v1 `bin_number` column). Closes the "progress bar never advances
   in Bluesky mode" gap — see `Planning/gui_stewardship/00_overview.md` §5.
-- **Dead sync-device pre-flight dialog (both acquisition modes)** — before
-  a scan claims its folder (so an abort burns no scan number), every
-  synchronous device's persistent-monitor cache
-  (`_last_acq`) is checked for freshness (default threshold 10 s
-  wall-clock; one ~2 s re-check grace for just-connected monitors).
-  Stale devices raise an operator dialog through the legacy channel
-  (`DialogRequest` inside a `ScanDialogEvent`): stale contributors offer
-  drop-and-continue (devices disconnected, removed from the detector
-  list, logged loudly) vs abort; a stale reference (pacemaker) is
-  abort-only in v1 (second button is a clearly-labeled "Try Anyway");
-  all-stale blames the trigger ("may be off / not free-running") instead
-  of the cameras. Headless (`on_event=None`), missing geecs_scanner, or
+- **Gateway-liveness pre-flight dialog (both acquisition modes)** — every
+  CA sync device now carries a non-readable `connected_status` child on the
+  gateway's per-device `[Experiment:]Device:CONNECTED` status PV (enum
+  `Disconnected`/`Connected`, MAJOR severity while the device's TCP stream
+  is down — PV_CONTRACT.md §1/§5), created outside
+  `add_children_as_readables()` so it never appears in event rows or
+  `describe()`. This is the authoritative, mode-independent liveness
+  signal: **the gateway serves every DB device's data PVs whether or not
+  the device is up, so CA-connect success never implied device liveness**
+  (an OFF camera's PVs connect fine — the root cause of the 2026-07-07
+  strict Scan006 incident, where a dead camera burned all three refires
+  post-claim). Before a scan claims its folder (so an abort burns no scan
+  number), `BlueskyScanner._preflight_check_sync_liveness` reads each sync
+  device's `connected_status` from the scan thread
+  (`run_coroutine_threadsafe` on the RE loop, 2 s budget, **fail-open**: an
+  unreadable CONNECTED PV — e.g. an old gateway without status PVs — logs
+  at DEBUG and reads as live). Devices reporting DISCONNECTED raise an
+  operator dialog through the legacy channel (`DialogRequest` inside a
+  `ScanDialogEvent`): drop-and-continue (disconnected, removed from the
+  detector list, logged loudly) vs abort; a disconnected free-run reference
+  (pacemaker) is abort-only in v1 (second button is a clearly-labeled
+  "Try Anyway"). In free-run mode a second stage keeps the `acq_timestamp`
+  staleness check (threshold 10 s — now relevant *only* here — with one
+  ~2 s re-check grace) for the trigger-must-be-free-running requirement,
+  now unambiguous: all devices CONNECTED but all frames stale → "trigger
+  appears to be off" dialog (Start Anyway / Abort); the residual
+  CONNECTED-but-stale contributor with a fresh reference keeps the drop
+  dialog (the fresh reference proves the trigger runs, so it is a
+  per-device acquisition problem). Strict mode is liveness-only — the
+  previous differential-staleness heuristic is removed (CONNECTED is
+  authoritative; frames are not needed pre-scan since the trigger may sit
+  OFF until ARMED). Headless (`on_event=None`), missing geecs_scanner, or
   an unanswered dialog (30 s timeout) preserve today's behavior — proceed
-  and fail loudly downstream (t0 sync in free-run, refire exhaustion in
-  strict). In `strict_shot_control` only **differential** staleness (some
-  devices fresh, some not) raises the dialog — all-stale is a legitimate
-  pre-scan state there (the trigger may sit OFF; ARMED starts it), and
-  strict has no pacemaker so no reference case. Live-motivated twice over:
-  the 2026-07-06 free-run t0-sync abort and the 2026-07-07 strict Scan006,
-  where an OFF camera burned all three refires post-claim. New
-  `GeecsStaleDevicesError` carries the operator-facing message. Implements
-  the stewardship plan's first concrete use case
-  (`Planning/gui_stewardship/00_overview.md` §4).
+  and fail loudly downstream. New `GeecsDeviceDownError` carries the
+  disconnected-device message; `GeecsStaleDevicesError` remains for the
+  free-run staleness dialogs. Implements the stewardship plan's first
+  concrete use case (`Planning/gui_stewardship/00_overview.md` §4).
+- **Refire gated on gateway liveness** — `geecs_single_shot`'s bounded
+  refire now reads the frameless device's `connected_status` (via `bps.rd`
+  in plan context) before re-firing: a device reporting DISCONNECTED gets
+  no refire — the plan raises `GeecsDeviceDownError` immediately, naming
+  the device as down ("went down mid-scan — not a frame drop"), instead of
+  burning ~3 s attempts against hardware that cannot answer. A live or
+  unreadable status (fail-open) keeps the existing `max_refires` semantics
+  for genuine frame drops.
 
 ## [0.20.0] - 2026-07-06
 

--- a/GeecsBluesky/CHANGELOG.md
+++ b/GeecsBluesky/CHANGELOG.md
@@ -17,9 +17,9 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   tail-flush overcount stays cosmetic; step index derived from the
   schema-v1 `bin_number` column). Closes the "progress bar never advances
   in Bluesky mode" gap — see `Planning/gui_stewardship/00_overview.md` §5.
-- **Free-run dead-contributor pre-flight dialog** — before a
-  `free_run_time_sync` scan claims its folder (so an abort burns no scan
-  number), every synchronous device's persistent-monitor cache
+- **Dead sync-device pre-flight dialog (both acquisition modes)** — before
+  a scan claims its folder (so an abort burns no scan number), every
+  synchronous device's persistent-monitor cache
   (`_last_acq`) is checked for freshness (default threshold 10 s
   wall-clock; one ~2 s re-check grace for just-connected monitors).
   Stale devices raise an operator dialog through the legacy channel
@@ -30,9 +30,16 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   all-stale blames the trigger ("may be off / not free-running") instead
   of the cameras. Headless (`on_event=None`), missing geecs_scanner, or
   an unanswered dialog (30 s timeout) preserve today's behavior — proceed
-  and let t0 sync fail loudly. New `GeecsStaleDevicesError` carries the
-  operator-facing message. Implements the stewardship plan's first
-  concrete use case (`Planning/gui_stewardship/00_overview.md` §4).
+  and fail loudly downstream (t0 sync in free-run, refire exhaustion in
+  strict). In `strict_shot_control` only **differential** staleness (some
+  devices fresh, some not) raises the dialog — all-stale is a legitimate
+  pre-scan state there (the trigger may sit OFF; ARMED starts it), and
+  strict has no pacemaker so no reference case. Live-motivated twice over:
+  the 2026-07-06 free-run t0-sync abort and the 2026-07-07 strict Scan006,
+  where an OFF camera burned all three refires post-claim. New
+  `GeecsStaleDevicesError` carries the operator-facing message. Implements
+  the stewardship plan's first concrete use case
+  (`Planning/gui_stewardship/00_overview.md` §4).
 
 ## [0.20.0] - 2026-07-06
 

--- a/GeecsBluesky/CLAUDE.md
+++ b/GeecsBluesky/CLAUDE.md
@@ -108,7 +108,8 @@ legacy).  That path loads the selected shot-control YAML and passes it as
 BlueskyScanner emits `ScanLifecycleEvent`s through it via `_set_state`,
 shot-level `ScanStepEvent`s per event document via `_on_document` (so the
 GUI progress bar works in Bluesky mode), and pre-flight `ScanDialogEvent`s
-from the free-run dead-contributor check (all defensive imports — headless
+from the dead-sync-device check (both modes; strict dialogs only on
+differential staleness) (all defensive imports — headless
 installs without geecs_scanner just skip emission).  `DeviceCommandEvent`
 translation is deliberately skipped (no consumer).  Still not done in
 Bluesky mode: `ActionControl` / setup-closeout actions (see

--- a/GeecsBluesky/CLAUDE.md
+++ b/GeecsBluesky/CLAUDE.md
@@ -108,8 +108,10 @@ legacy).  That path loads the selected shot-control YAML and passes it as
 BlueskyScanner emits `ScanLifecycleEvent`s through it via `_set_state`,
 shot-level `ScanStepEvent`s per event document via `_on_document` (so the
 GUI progress bar works in Bluesky mode), and pre-flight `ScanDialogEvent`s
-from the dead-sync-device check (both modes; strict dialogs only on
-differential staleness) (all defensive imports — headless
+from the gateway-liveness check (both modes: each sync device's
+`connected_status` — the gateway `CONNECTED` PV — is read pre-claim; free-run
+adds a staleness stage for the trigger-must-be-free-running requirement)
+(all defensive imports — headless
 installs without geecs_scanner just skip emission).  `DeviceCommandEvent`
 translation is deliberately skipped (no consumer).  Still not done in
 Bluesky mode: `ActionControl` / setup-closeout actions (see
@@ -217,6 +219,11 @@ backend reached verified live parity (Scans 007–015, 2026-07-03/04); a stale
   `acq_timestamp` feeding a local cache/queue (the CA analogue of the old TCP
   shot cache). Non-positive timestamps are ignored: `0.0` is the gateway
   channel's pre-acquisition placeholder, so "never acquired" reads as `None`.
+  Also carries a non-readable `connected_status` child on the gateway's
+  per-device `CONNECTED` PV (created outside `add_children_as_readables()`,
+  so never in event rows) — the authoritative liveness signal consumed by
+  the scanner pre-flight and the strict refire gate; only the exact
+  `"Disconnected"` reading means down (fail-open otherwise).
 - **`CaTriggerable`** — `trigger()` completes when `acq_timestamp` advances.
   The stale-drain and baseline happen **synchronously in `trigger()`** so a
   shot fired immediately after `bps.trigger` (strict single-shot) can't be
@@ -307,8 +314,11 @@ Remaining items are features/tuning, not architecture — see
 - **`DeviceCommandEvent`s are not translated** (deliberate — the GUI does
   not render them; see `Planning/gui_stewardship/00_overview.md` §5).
   Lifecycle, step/progress, and pre-flight dialog events are emitted as of
-  0.21.0; the free-run pre-flight staleness threshold (10 s) still needs a
-  lab session of tuning against real rep rates.
+  0.21.0.  Pre-flight liveness is CONNECTED-based (the gateway serves every
+  DB device's data PVs whether or not the device is up, so CA-connect
+  success never implied liveness); the 10 s staleness threshold now only
+  matters for the free-run trigger-off check and still needs a lab session
+  of tuning against real rep rates.
 - **Scalar s-files are exported from Tiled best-effort** after a scan when the
   Tiled client extra is installed and the run can be read back.  Legacy TDMS
   output is not produced.

--- a/GeecsBluesky/CLAUDE.md
+++ b/GeecsBluesky/CLAUDE.md
@@ -104,12 +104,14 @@ scanner.stop_scanning_thread()      # RE.abort() + thread join
 session, the `GEECS_USE_BLUESKY` env var (resolved by
 `geecs_scanner.engine.backend_selection`; explicit argument wins, default
 legacy).  That path loads the selected shot-control YAML and passes it as
-`shot_control_information`, and passes the `on_event` callback
-(BlueskyScanner emits `ScanLifecycleEvent`s through it via `_set_state`).
-Still not done in Bluesky mode: `ActionControl` / setup-closeout actions, and
-translating per-shot Bluesky documents into the richer `ScanStepEvent` /
-`DeviceCommandEvent` stream (only lifecycle events are emitted — so the GUI
-progress bar does not advance in Bluesky mode; see
+`shot_control_information`, and passes the `on_event` callback:
+BlueskyScanner emits `ScanLifecycleEvent`s through it via `_set_state`,
+shot-level `ScanStepEvent`s per event document via `_on_document` (so the
+GUI progress bar works in Bluesky mode), and pre-flight `ScanDialogEvent`s
+from the free-run dead-contributor check (all defensive imports — headless
+installs without geecs_scanner just skip emission).  `DeviceCommandEvent`
+translation is deliberately skipped (no consumer).  Still not done in
+Bluesky mode: `ActionControl` / setup-closeout actions (see
 `Planning/gui_stewardship/00_overview.md`).  Acquisition mode is chosen by
 the `GEECS_BLUESKY_ACQUISITION_MODE` env var — there is no GUI toggle for it
 (intentional; bluesky is still being derisked).
@@ -289,7 +291,7 @@ api_key = <key>
 
 `GeecsDb` reads `Configurations.INI` (in `geecs_data`) for MySQL credentials.
 
-## Known Gaps (as of 0.19.0)
+## Known Gaps (as of 0.21.0)
 
 The acquisition-modes architecture is complete and hardware-verified (both
 modes, including single-shot; GUI-launched scans verified live 2026-07-06).
@@ -301,14 +303,11 @@ Remaining items are features/tuning, not architecture — see
   reachable shot-control device, strict aborts before acquisition
   (`GeecsConfigurationError`); use `free_run_time_sync` for free-running
   trigger acquisition.
-- **Only lifecycle `ScanEvent`s are emitted** via `on_event` (through
-  `_set_state`).  Per-shot/step Bluesky documents are not translated into the
-  richer `ScanStepEvent` / `DeviceCommandEvent` stream, so the GUI progress
-  bar does not advance in Bluesky mode and no operator dialogs
-  (`ScanDialogEvent`) can be raised.  `ScanStepEvent` emission and a
-  pre-flight dead-contributor dialog are the recommended next investments —
-  see `Planning/gui_stewardship/00_overview.md` §4–5.
-  (`DeviceCommandEvent` translation may never be needed.)
+- **`DeviceCommandEvent`s are not translated** (deliberate — the GUI does
+  not render them; see `Planning/gui_stewardship/00_overview.md` §5).
+  Lifecycle, step/progress, and pre-flight dialog events are emitted as of
+  0.21.0; the free-run pre-flight staleness threshold (10 s) still needs a
+  lab session of tuning against real rep rates.
 - **Scalar s-files are exported from Tiled best-effort** after a scan when the
   Tiled client extra is installed and the run can be read back.  Legacy TDMS
   output is not produced.

--- a/GeecsBluesky/geecs_bluesky/devices/ca/_pv.py
+++ b/GeecsBluesky/geecs_bluesky/devices/ca/_pv.py
@@ -26,6 +26,15 @@ from geecs_ca_gateway.pv_naming import pv_name
 #: ``ophyd_async.epics.core._signal.split_protocol_from_pv``.
 CA_TRANSPORT_PREFIX = "ca://"
 
+#: The gateway per-device status PV (``[Experiment:]Device:CONNECTED``,
+#: PV_CONTRACT.md §1) value meaning the device's TCP stream is down
+#: (enum_strings = ["Disconnected", "Connected"]; MAJOR severity while down).
+#: Liveness convention shared by every consumer in this package: ONLY this
+#: exact choice string reads as down — anything else (``"Connected"``, a mock
+#: backend's ``""`` default, or an unreadable PV) is treated as live, so a
+#: gateway without status PVs can never block a scan (fail-open).
+GATEWAY_DISCONNECTED = "Disconnected"
+
 
 def ca_pv(experiment: str | None, device: str, variable: str) -> str:
     """Gateway PV name for ``(experiment, device, variable)``, pinned to CA.

--- a/GeecsBluesky/geecs_bluesky/devices/ca/triggerable.py
+++ b/GeecsBluesky/geecs_bluesky/devices/ca/triggerable.py
@@ -54,6 +54,13 @@ class CaAcqTimestampReadable(StandardReadable):
     ``_last_acq`` (latest value) and ``_shot_queue`` (bounded update stream)
     current.
 
+    A non-readable ``connected_status`` child reads the gateway's per-device
+    liveness PV (``[Experiment:]Device:CONNECTED``): the authoritative
+    mode-independent "is this device's TCP stream up" signal.  It is a child
+    (so it connects/mocks with the device) but never part of ``read()`` /
+    ``describe()``.  Consumers: the scanner's pre-flight liveness check and
+    the strict single-shot refire gate.
+
     Parameters
     ----------
     device : str
@@ -110,6 +117,21 @@ class CaAcqTimestampReadable(StandardReadable):
             self.acq_timestamp = epics_signal_r(
                 float, ca_pv(experiment, device, self._acq_timestamp_variable)
             )
+        # Liveness signal — the gateway's per-device status PV
+        # ``[Experiment:]Device:CONNECTED`` (PV_CONTRACT.md §1: enum with
+        # choices ["Disconnected", "Connected"], MAJOR severity + status COMM
+        # while the device's TCP stream is down; composed like any variable —
+        # no ``:SP``, no variable suffix beyond the literal ``CONNECTED``).
+        # Deliberately created OUTSIDE ``add_children_as_readables()`` so it
+        # never appears in event rows or ``describe()``: gateway liveness is
+        # pre-flight / plan metadata, not shot data.  Read as ``str`` (CA
+        # serves the enum *choice string* for a string read); only the exact
+        # :data:`~geecs_bluesky.devices.ca._pv.GATEWAY_DISCONNECTED` value
+        # means down, so a mock backend's ``""`` default — and any gateway
+        # old enough to lack status PVs — reads as live (fail-open).
+        self.connected_status = epics_signal_r(
+            str, ca_pv(experiment, device, "CONNECTED")
+        )
         super().__init__(name=name)
         # Persistent-monitor state (populated by _on_acq_timestamp): the latest
         # seen value, and a bounded queue of updates trigger() waits on.

--- a/GeecsBluesky/geecs_bluesky/exceptions.py
+++ b/GeecsBluesky/geecs_bluesky/exceptions.py
@@ -30,6 +30,7 @@ __all__ = [
     "GeecsMotorTimeoutError",
     "GeecsT0SyncError",
     "GeecsConfigurationError",
+    "GeecsDeviceDownError",
     "GeecsStaleDevicesError",
 ]
 
@@ -130,12 +131,35 @@ class GeecsConfigurationError(GeecsError):
     """Runtime configuration is incomplete or inconsistent."""
 
 
+class GeecsDeviceDownError(GeecsError):
+    """A device's gateway ``CONNECTED`` PV reports ``Disconnected``.
+
+    The gateway serves every DB device's PVs whether or not the device's TCP
+    stream is up, so CA-connect success never implied device liveness; the
+    per-device ``[Experiment:]Device:CONNECTED`` status PV is the
+    authoritative signal (PV_CONTRACT.md §1/§5).  Raised (or carried inside
+    the pre-claim operator dialog) when that PV says a device is down:
+    by ``BlueskyScanner._preflight_check_sync_liveness`` before a scan, and
+    by :func:`~geecs_bluesky.plans.single_shot.geecs_single_shot` when a
+    no-frame device turns out to be disconnected mid-scan (re-firing cannot
+    help a dead device).  The message is operator-facing.
+    """
+
+    def __init__(self, message: str, device_name: str | None = None) -> None:
+        self.device_name = device_name
+        super().__init__(message)
+
+
 class GeecsStaleDevicesError(GeecsError):
-    """Synchronous device(s) look dead in the free-run pre-flight check.
+    """Free-run sync device(s) are CONNECTED but have no fresh frames.
 
     Carried inside the pre-claim operator dialog raised by
-    ``BlueskyScanner._preflight_check_free_run_freshness`` when a device's
-    cached ``acq_timestamp`` is missing or too old before a free-run scan.
-    The message is operator-facing: it names the stale device(s), how stale
-    they are, and what the dialog's options mean.
+    ``BlueskyScanner._preflight_check_sync_liveness`` (free-run mode only,
+    after the gateway-liveness stage passed) when cached ``acq_timestamp``
+    frames are missing or too old — all-stale means the trigger is probably
+    off / not free-running; a stale subset is a per-device acquisition
+    problem.  Genuinely *dead* devices are :class:`GeecsDeviceDownError`
+    territory (the ``CONNECTED`` PV), not this.  The message is
+    operator-facing: it names the stale device(s), how stale they are, and
+    what the dialog's options mean.
     """

--- a/GeecsBluesky/geecs_bluesky/exceptions.py
+++ b/GeecsBluesky/geecs_bluesky/exceptions.py
@@ -30,6 +30,7 @@ __all__ = [
     "GeecsMotorTimeoutError",
     "GeecsT0SyncError",
     "GeecsConfigurationError",
+    "GeecsStaleDevicesError",
 ]
 
 
@@ -127,3 +128,14 @@ class GeecsT0SyncError(GeecsError):
 
 class GeecsConfigurationError(GeecsError):
     """Runtime configuration is incomplete or inconsistent."""
+
+
+class GeecsStaleDevicesError(GeecsError):
+    """Synchronous device(s) look dead in the free-run pre-flight check.
+
+    Carried inside the pre-claim operator dialog raised by
+    ``BlueskyScanner._preflight_check_free_run_freshness`` when a device's
+    cached ``acq_timestamp`` is missing or too old before a free-run scan.
+    The message is operator-facing: it names the stale device(s), how stale
+    they are, and what the dialog's options mean.
+    """

--- a/GeecsBluesky/geecs_bluesky/plans/single_shot.py
+++ b/GeecsBluesky/geecs_bluesky/plans/single_shot.py
@@ -28,7 +28,9 @@ import bluesky.plan_stubs as bps
 from bluesky.protocols import Triggerable
 from bluesky.utils import FailedStatus, short_uid
 
+from geecs_bluesky.devices.ca._pv import GATEWAY_DISCONNECTED
 from geecs_bluesky.exceptions import (
+    GeecsDeviceDownError,
     GeecsQuiescenceTimeoutError,
     GeecsTriggerTimeoutError,
 )
@@ -48,6 +50,46 @@ def _no_frame_device(exc: BaseException) -> str:
     if isinstance(cause, GeecsTriggerTimeoutError):
         return cause.device_name
     return "unknown device"
+
+
+def _confirm_device_down(devices: Sequence[Any], device_name: str):
+    """Plan: ``True`` iff the named device's gateway ``CONNECTED`` PV says down.
+
+    Distinguishes the two causes of a no-frame timeout: a dropped frame
+    (device live — re-firing recovers) vs a device that went down mid-scan
+    (its TCP stream to the gateway died — re-firing cannot help).  The
+    frameless device is matched by GEECS device name (``_geecs_device_name``,
+    falling back to the ophyd name) against *devices*, and its
+    ``connected_status`` signal is read in plan context via ``bps.rd``.
+
+    **Fail-open**: no matching device, no ``connected_status`` attribute, or
+    a failed read (old gateway without status PVs) all return ``False``
+    ("not confirmed down"), preserving the refire behavior.  Only the exact
+    :data:`~geecs_bluesky.devices.ca._pv.GATEWAY_DISCONNECTED` choice string
+    confirms the device is down — a mock backend's ``""`` default reads live.
+    """
+    device = next(
+        (
+            obj
+            for obj in devices
+            if device_name
+            in (getattr(obj, "_geecs_device_name", None), getattr(obj, "name", None))
+        ),
+        None,
+    )
+    signal = getattr(device, "connected_status", None)
+    if signal is None:
+        return False
+    try:
+        value = yield from bps.rd(signal)
+    except Exception:
+        logger.debug(
+            "CONNECTED read failed for %s; assuming live (fail-open)",
+            device_name,
+            exc_info=True,
+        )
+        return False
+    return value == GATEWAY_DISCONNECTED
 
 
 def geecs_single_shot(
@@ -80,6 +122,14 @@ def geecs_single_shot(
     known ~1% frame-drop intermittency) and aborted the whole campaign.  At a
     ~1.2% drop rate a 100-shot campaign aborts with ~70% probability without
     refire; a missed pulse never yields a frame, so only re-firing recovers.
+
+    **Refire is gated on gateway liveness.**  Before re-firing, the frameless
+    device's ``connected_status`` (the gateway ``CONNECTED`` PV) is read: if
+    the device reports Disconnected, the timeout was not a frame drop — the
+    device went down mid-scan — and :exc:`~geecs_bluesky.exceptions.GeecsDeviceDownError`
+    is raised immediately instead of burning refires against dead hardware.
+    A live (or unreadable — fail-open) status keeps the bounded-refire
+    behavior.
 
     Parameters
     ----------
@@ -148,6 +198,20 @@ def geecs_single_shot(
             #   fire + wait), so the stale FailedStatus is caught and merely
             #   consumes one refire instead of aborting the scan — no
             #   cancellation machinery needed.
+            #
+            # Refire is gated on gateway liveness: a no-frame timeout from a
+            # device whose CONNECTED PV reports Disconnected is not a frame
+            # drop — the device went down mid-scan, and re-firing burns
+            # attempts (~3 s each) against hardware that cannot answer.
+            device_name = _no_frame_device(exc)
+            down = yield from _confirm_device_down(devices, device_name)
+            if down:
+                raise GeecsDeviceDownError(
+                    f"{device_name}: the gateway reports this device "
+                    "DISCONNECTED — it went down mid-scan (not a frame "
+                    "drop; re-firing cannot help). Check the GEECS device.",
+                    device_name=device_name,
+                ) from exc
             if attempt == attempts:
                 raise
             logger.warning(
@@ -155,7 +219,7 @@ def geecs_single_shot(
                 "(known camera frame-drop intermittency, ~1%% observed)",
                 attempt,
                 attempts,
-                _no_frame_device(exc),
+                device_name,
             )
         else:
             break

--- a/GeecsBluesky/geecs_bluesky/scanner_bridge/bluesky_scanner.py
+++ b/GeecsBluesky/geecs_bluesky/scanner_bridge/bluesky_scanner.py
@@ -43,6 +43,7 @@ import logging
 import os
 import queue
 import threading
+import time
 from contextlib import contextmanager
 from pathlib import Path
 from typing import Any, Callable
@@ -50,7 +51,7 @@ from typing import Any, Callable
 import numpy as np
 
 
-from geecs_bluesky.exceptions import GeecsConfigurationError
+from geecs_bluesky.exceptions import GeecsConfigurationError, GeecsStaleDevicesError
 from geecs_bluesky.models.shot_control import ShotControlConfig
 from geecs_bluesky.plans.run_wrapper import claim_scan, claim_scan_number
 from geecs_bluesky.session import GeecsSession
@@ -65,20 +66,55 @@ except Exception:
 
 try:
     from geecs_scanner.engine.scan_events import (
+        ScanDialogEvent,
         ScanEvent,
         ScanLifecycleEvent,
         ScanState,
+        ScanStepEvent,
     )
 except Exception:
+    ScanDialogEvent = None  # type: ignore[assignment]
     ScanEvent = Any  # type: ignore[misc,assignment]
     ScanLifecycleEvent = None  # type: ignore[assignment]
     ScanState = None  # type: ignore[assignment]
+    ScanStepEvent = None  # type: ignore[assignment]
+
+# DialogRequest lives in a separate geecs_scanner module (it pulls in
+# geecs_python_api), so it gets its own defensive import: without it no
+# operator dialogs can be raised and pre-flight checks fall back to today's
+# fail-loud behavior (proceed; t0 sync aborts on genuinely dead devices).
+try:
+    from geecs_scanner.engine.dialog_request import DialogRequest
+except Exception:
+    DialogRequest = None  # type: ignore[assignment,misc]
 
 logger = logging.getLogger(__name__)
 
 _CONNECT_TIMEOUT = 20.0
 _DISCONNECT_TIMEOUT = 10.0
 _THREAD_JOIN_TIMEOUT = 15.0
+
+# Seconds between the LabVIEW epoch (1904-01-01) and the Unix epoch
+# (1970-01-01).  Device ``acq_timestamp`` values are LabVIEW-epoch.
+_LABVIEW_EPOCH_OFFSET = 2_082_844_800
+
+# Free-run pre-flight freshness: a synchronous device whose cached
+# ``acq_timestamp`` is older than this (wall-clock seconds; control machines
+# are NTP-synced) — or that has no cached frame at all — is considered stale.
+# The trigger free-runs before a free-run scan, so live devices have frames
+# no older than one trigger period.
+_STALE_SYNC_THRESHOLD_S = 10.0
+
+# Grace period before re-checking: a just-connected persistent monitor may not
+# have delivered its first frame yet, so one stale verdict gets a second look
+# after roughly one trigger period.
+_STALE_RECHECK_WAIT_S = 2.0
+
+# How long the scan thread waits for the operator to answer a pre-flight
+# dialog.  On timeout the scan proceeds with today's default behavior
+# (fail-loud at t0 sync) — a headless or unattended scan must never hang on a
+# dialog nobody will answer.
+_PREFLIGHT_DIALOG_TIMEOUT_S = 30.0
 
 _STRICT_MODE = "strict_shot_control"
 _FREE_RUN_MODE = "free_run_time_sync"
@@ -206,6 +242,7 @@ class BlueskyScanner:
             )
 
         self._total_shots: int = 0
+        self._total_steps: int = 0
         self._completed_shots: int = 0
         # uid of the most recent run's start document (for the Tiled exporter)
         self._last_run_uid: str | None = None
@@ -262,6 +299,7 @@ class BlueskyScanner:
 
         self._completed_shots = 0
         self._total_shots = 0
+        self._total_steps = 0
         self._session.rep_rate_hz = self._rep_rate_hz
 
         # Disconnect any leftover devices from a previous scan
@@ -422,6 +460,51 @@ class BlueskyScanner:
             self._last_run_uid = doc.get("uid")
         elif name == "event":
             self._completed_shots += 1
+            self._emit_step_progress(doc)
+
+    def _emit_step_progress(self, doc: dict) -> None:
+        """Emit a :class:`ScanStepEvent` for one Bluesky event document.
+
+        Runs on the RunEngine thread — thread-safe the same way the lifecycle
+        events are: the GUI's ``on_event`` hops to the Qt main thread via the
+        ``_scan_event_received`` pyqtSignal, so events may be emitted from any
+        thread.
+
+        One event document is one completed shot, so every document carries a
+        shot-level progress update (``phase="completed"``); the GUI computes
+        its progress fraction from ``shots_completed`` against the
+        ``total_shots`` it cached from the INITIALIZING lifecycle event.  The
+        step index is derived from the schema-v1 ``bin_number`` column when
+        present (1-based → 0-based), else 0.
+
+        ``shots_completed`` is clamped at ``total_shots``: free-run scans emit
+        one extra tail-flush event document (known, cosmetic overcount), and
+        the progress bar must not report beyond 100 %.
+        """
+        if self._on_event is None or ScanStepEvent is None:
+            return
+        shots = self._completed_shots
+        if self._total_shots:
+            shots = min(shots, self._total_shots)
+        data = doc.get("data") or {}
+        try:
+            step_index = int(data.get("bin_number", 1)) - 1
+        except (TypeError, ValueError):
+            step_index = 0
+        step_index = max(step_index, 0)
+        if self._total_steps:
+            step_index = min(step_index, self._total_steps - 1)
+        try:
+            self._on_event(
+                ScanStepEvent(
+                    step_index=step_index,
+                    total_steps=self._total_steps,
+                    shots_completed=shots,
+                    phase="completed",
+                )
+            )
+        except Exception:
+            logger.debug("on_event callback raised; ignoring", exc_info=True)
 
     @staticmethod
     def _scan_state(state_name: str):
@@ -474,6 +557,228 @@ class BlueskyScanner:
             "aborting the scan before it reaches the RunEngine"
         )
         return True
+
+    # ------------------------------------------------------------------
+    # Free-run pre-flight: dead-contributor detection + operator dialog
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _device_label(device: Any) -> str:
+        """Return the GEECS device name for operator-facing messages."""
+        return str(
+            getattr(device, "_geecs_device_name", getattr(device, "name", device))
+        )
+
+    @staticmethod
+    def _find_stale_sync_devices(
+        sync_devices: list,
+    ) -> list[tuple[Any, float | None]]:
+        """Return ``(device, age_seconds_or_None)`` for stale sync devices.
+
+        A device is stale when its persistent-monitor cache (``_last_acq``,
+        LabVIEW-epoch seconds) is ``None`` (no frame seen since connect) or
+        older than :data:`_STALE_SYNC_THRESHOLD_S` against the NTP-synced
+        wall clock.  ``None`` age means "never acquired".
+        """
+        now_labview = time.time() + _LABVIEW_EPOCH_OFFSET
+        stale: list[tuple[Any, float | None]] = []
+        for device in sync_devices:
+            last = device._last_acq
+            if last is None:
+                stale.append((device, None))
+                continue
+            age = now_labview - float(last)
+            if age > _STALE_SYNC_THRESHOLD_S:
+                stale.append((device, age))
+        return stale
+
+    def _request_operator_decision(
+        self,
+        exc: Exception,
+        *,
+        title: str,
+        continue_label: str,
+        abort_label: str = "Abort Scan",
+        context: str | None = None,
+    ) -> str:
+        """Emit a ``ScanDialogEvent`` and wait for the operator's answer.
+
+        Reuses the legacy dialog channel end to end: the request is a
+        :class:`~geecs_scanner.engine.dialog_request.DialogRequest`, carried
+        by a ``ScanDialogEvent`` through the same ``on_event`` callback the
+        lifecycle events use; the GUI renders it on the Qt main thread and
+        answers by writing ``request.abort[0]`` and setting
+        ``request.response_event``, on which this (scan) thread blocks.
+
+        Returns
+        -------
+        str
+            ``"continue"`` or ``"abort"`` when the consumer answered;
+            ``"default"`` when there is no consumer (headless), the event
+            types are unavailable, or no answer arrived within
+            :data:`_PREFLIGHT_DIALOG_TIMEOUT_S` — callers must then preserve
+            today's behavior (proceed, fail loudly later).
+        """
+        if self._on_event is None or ScanDialogEvent is None or DialogRequest is None:
+            return "default"
+        request = DialogRequest(
+            exc=exc,
+            context=context,
+            title=title,
+            continue_label=continue_label,
+            abort_label=abort_label,
+        )
+        try:
+            self._on_event(ScanDialogEvent(request=request))
+        except Exception:
+            logger.debug("on_event callback raised; ignoring", exc_info=True)
+            return "default"
+        if not request.response_event.wait(timeout=_PREFLIGHT_DIALOG_TIMEOUT_S):
+            logger.warning(
+                "Pre-flight dialog %r got no response within %.0f s — "
+                "proceeding with default behavior",
+                title,
+                _PREFLIGHT_DIALOG_TIMEOUT_S,
+            )
+            return "default"
+        return "abort" if request.abort[0] else "continue"
+
+    def _preflight_check_free_run_freshness(self, detectors: list) -> list | None:
+        """Free-run pre-flight: catch dead sync devices before the claim.
+
+        Checks every synchronous device's cached ``acq_timestamp`` freshness
+        (the trigger free-runs before a free-run scan, so live devices have
+        fresh frames) and, when something looks dead, asks the operator via
+        the legacy dialog channel — all *before* the scan folder is claimed,
+        so an abort here burns no scan number.
+
+        Outcomes:
+
+        - every sync device fresh → detectors returned unchanged;
+        - some contributors stale, reference fresh → operator chooses between
+          dropping the stale devices (disconnected, removed from the list)
+          and aborting;
+        - the reference (pacemaker) stale → abort-only v1 (the second button
+          is a clearly-labeled "try anyway" because the dialog channel always
+          offers two options);
+        - ALL sync devices stale → the trigger is probably off / not
+          free-running; the dialog says so instead of accusing every camera;
+        - headless / no consumer / no answer → today's behavior is preserved:
+          proceed and let t0 sync fail loudly.
+
+        Returns
+        -------
+        list or None
+            The (possibly reduced) detector list to proceed with, or ``None``
+            when the operator chose to abort.
+        """
+        sync_devices = [d for d in detectors if hasattr(d, "_last_acq")]
+        if not sync_devices:
+            return detectors
+
+        stale = self._find_stale_sync_devices(sync_devices)
+        if stale and _STALE_RECHECK_WAIT_S > 0:
+            # A just-connected monitor may not have delivered its first frame
+            # yet; give the free-running trigger one more period.
+            time.sleep(_STALE_RECHECK_WAIT_S)
+            stale = self._find_stale_sync_devices(sync_devices)
+        if not stale:
+            return detectors
+
+        def _describe(device: Any, age: float | None) -> str:
+            if age is None:
+                return f"{self._device_label(device)} (no frames since connect)"
+            return f"{self._device_label(device)} (last frame {age:.0f} s ago)"
+
+        details = ", ".join(_describe(dev, age) for dev, age in stale)
+        stale_ids = {id(dev) for dev, _age in stale}
+        reference = sync_devices[0]
+
+        if len(stale) == len(sync_devices):
+            # Every sync device is stale — the likely culprit is the trigger,
+            # not N simultaneously dead cameras.
+            exc = GeecsStaleDevicesError(
+                f"No synchronous device has a fresh frame ({details}). "
+                "The trigger may be off / not free-running — free-run scans "
+                "need the trigger free-running before start. Starting anyway "
+                "will fail at t0 sync if nothing is firing."
+            )
+            decision = self._request_operator_decision(
+                exc,
+                title="Trigger May Be Off",
+                continue_label="Start Anyway",
+            )
+            if decision == "abort":
+                logger.warning("Pre-flight: operator aborted (all sync stale)")
+                return None
+            logger.warning(
+                "Pre-flight: proceeding with all sync devices stale (%s) — "
+                "t0 sync will fail loudly if the trigger is really off",
+                details,
+            )
+            return detectors
+
+        if id(reference) in stale_ids:
+            # v1: a dead reference (pacemaker) is abort-only — promotion is
+            # deliberately out of scope; the "continue" button is a clearly
+            # labeled try-anyway because the dialog always offers two options.
+            exc = GeecsStaleDevicesError(
+                f"The free-run reference (pacemaker) device looks dead: "
+                f"{details}. The scan cannot pace without it; aborting is "
+                "recommended. Trying anyway will fail at t0 sync if it is "
+                "really dead."
+            )
+            decision = self._request_operator_decision(
+                exc,
+                title="Reference Device Looks Dead",
+                continue_label="Try Anyway",
+            )
+            if decision == "abort":
+                logger.warning("Pre-flight: operator aborted (stale reference)")
+                return None
+            logger.warning(
+                "Pre-flight: proceeding with a stale reference (%s) — "
+                "t0 sync will fail loudly if it is really dead",
+                details,
+            )
+            return detectors
+
+        # Some-but-not-all contributors stale, reference fresh: offer to drop
+        # the dead devices and take the scan without them.
+        exc = GeecsStaleDevicesError(
+            f"Synchronous device(s) look dead: {details}. "
+            "Drop them and continue the scan without their data, or abort."
+        )
+        decision = self._request_operator_decision(
+            exc,
+            title="Dead Contributor Device(s)",
+            continue_label="Drop && Continue",
+        )
+        if decision == "abort":
+            logger.warning("Pre-flight: operator aborted (stale contributors)")
+            return None
+        if decision == "default":
+            logger.warning(
+                "Pre-flight: stale contributor(s) %s but no operator answer — "
+                "proceeding unchanged; t0 sync will fail loudly if they are "
+                "really dead",
+                details,
+            )
+            return detectors
+
+        # Drop: disconnect the stale devices and remove them everywhere the
+        # cleanup path would otherwise touch them.
+        for device, _age in stale:
+            logger.warning(
+                "Pre-flight: dropping dead contributor %s from this scan "
+                "(operator chose drop-and-continue); disconnecting it",
+                self._device_label(device),
+            )
+            self._disconnect_device(device)
+        remaining = [d for d in detectors if id(d) not in stale_ids]
+        with self._device_lock:
+            self._detectors = [d for d in self._detectors if id(d) not in stale_ids]
+        return remaining
 
     @staticmethod
     def _log_claimed_scan_failure(
@@ -806,6 +1111,7 @@ class BlueskyScanner:
             max_iterations = len(_build_positions(scan_config))
             n_shots = max_iterations * self._shots_per_step
             self._total_shots = n_shots
+            self._total_steps = max_iterations
             self._set_state("INITIALIZING", total_shots=n_shots)
             logger.info(
                 "Optimization: up to %d iteration(s) × %d shots = %d events, "
@@ -883,6 +1189,16 @@ class BlueskyScanner:
             )
         self._session.shot_control(self._shot_control)
 
+        if not strict:
+            checked = self._preflight_check_free_run_freshness(detectors)
+            if checked is None:
+                # Mirror the _abort_before_acquisition path: setting the flag
+                # makes the scan thread's cleanup report ABORTED and
+                # disconnect every connected device — before any claim.
+                self._abort_requested = True
+                return
+            detectors = checked
+
         if self._abort_before_acquisition():
             return
 
@@ -890,6 +1206,7 @@ class BlueskyScanner:
 
         n_shots = len(positions) * self._shots_per_step
         self._total_shots = n_shots
+        self._total_steps = len(positions)
         self._set_state("INITIALIZING", total_shots=n_shots)
         logger.info(
             "%s: %d step(s) × %d shots/step = %d total events",

--- a/GeecsBluesky/geecs_bluesky/scanner_bridge/bluesky_scanner.py
+++ b/GeecsBluesky/geecs_bluesky/scanner_bridge/bluesky_scanner.py
@@ -51,7 +51,12 @@ from typing import Any, Callable
 import numpy as np
 
 
-from geecs_bluesky.exceptions import GeecsConfigurationError, GeecsStaleDevicesError
+from geecs_bluesky.devices.ca._pv import GATEWAY_DISCONNECTED
+from geecs_bluesky.exceptions import (
+    GeecsConfigurationError,
+    GeecsDeviceDownError,
+    GeecsStaleDevicesError,
+)
 from geecs_bluesky.models.shot_control import ShotControlConfig
 from geecs_bluesky.plans.run_wrapper import claim_scan, claim_scan_number
 from geecs_bluesky.session import GeecsSession
@@ -98,11 +103,19 @@ _THREAD_JOIN_TIMEOUT = 15.0
 # (1970-01-01).  Device ``acq_timestamp`` values are LabVIEW-epoch.
 _LABVIEW_EPOCH_OFFSET = 2_082_844_800
 
-# Free-run pre-flight freshness: a synchronous device whose cached
+# Pre-flight read budget for a device's gateway ``CONNECTED`` PV.  Read from
+# the scan thread via run_coroutine_threadsafe on the RE loop; on timeout or
+# error the device is treated as live (fail-open) — an old gateway without
+# status PVs must never block a scan.
+_LIVENESS_READ_TIMEOUT_S = 2.0
+
+# Free-run pre-flight freshness (free-run mode ONLY — liveness itself comes
+# from the gateway ``CONNECTED`` PV): a synchronous device whose cached
 # ``acq_timestamp`` is older than this (wall-clock seconds; control machines
 # are NTP-synced) — or that has no cached frame at all — is considered stale.
 # The trigger free-runs before a free-run scan, so live devices have frames
-# no older than one trigger period.
+# no older than one trigger period; all-CONNECTED-but-all-stale therefore
+# means the trigger is off / not free-running.
 _STALE_SYNC_THRESHOLD_S = 10.0
 
 # Grace period before re-checking: a just-connected persistent monitor may not
@@ -559,7 +572,7 @@ class BlueskyScanner:
         return True
 
     # ------------------------------------------------------------------
-    # Free-run pre-flight: dead-contributor detection + operator dialog
+    # Pre-flight: gateway liveness (both modes) + free-run staleness
     # ------------------------------------------------------------------
 
     @staticmethod
@@ -568,6 +581,39 @@ class BlueskyScanner:
         return str(
             getattr(device, "_geecs_device_name", getattr(device, "name", device))
         )
+
+    def _read_gateway_liveness(self, device: Any) -> bool:
+        """Read the device's gateway ``CONNECTED`` PV; ``False`` means down.
+
+        The gateway serves every DB device's data PVs whether or not the
+        device's TCP stream is up, so CA-connect success never implied
+        liveness; the per-device ``CONNECTED`` status PV (enum
+        ``Disconnected``/``Connected``, MAJOR while down — PV_CONTRACT.md
+        §1/§5) is the authoritative, acquisition-mode-independent signal.
+
+        Runs on the scan thread, so the signal's coroutine is dispatched to
+        the RunEngine loop via ``run_coroutine_threadsafe`` (the same pattern
+        as device connect/disconnect) with a short budget.  **Fail-open**: a
+        missing ``connected_status`` attribute, a read error, or a timeout
+        (e.g. an old gateway without status PVs) is logged at DEBUG and
+        treated as live — liveness checking must never block a scan.  Only
+        the exact ``Disconnected`` choice string reads as down.
+        """
+        signal = getattr(device, "connected_status", None)
+        if signal is None:
+            return True
+        try:
+            value = asyncio.run_coroutine_threadsafe(
+                signal.get_value(), self._RE._loop
+            ).result(timeout=_LIVENESS_READ_TIMEOUT_S)
+        except Exception:
+            logger.debug(
+                "CONNECTED read failed for %s; treating as live (fail-open)",
+                self._device_label(device),
+                exc_info=True,
+            )
+            return True
+        return str(value) != GATEWAY_DISCONNECTED
 
     @staticmethod
     def _find_stale_sync_devices(
@@ -643,42 +689,68 @@ class BlueskyScanner:
             return "default"
         return "abort" if request.abort[0] else "continue"
 
-    def _preflight_check_sync_freshness(
+    def _drop_devices(self, detectors: list, drop_ids: set[int]) -> list:
+        """Disconnect and remove the given devices (operator chose drop)."""
+        for device in detectors:
+            if id(device) in drop_ids:
+                logger.warning(
+                    "Pre-flight: dropping device %s from this scan "
+                    "(operator chose drop-and-continue); disconnecting it",
+                    self._device_label(device),
+                )
+                self._disconnect_device(device)
+        remaining = [d for d in detectors if id(d) not in drop_ids]
+        with self._device_lock:
+            self._detectors = [d for d in self._detectors if id(d) not in drop_ids]
+        return remaining
+
+    def _preflight_check_sync_liveness(
         self, detectors: list, *, strict: bool = False
     ) -> list | None:
         """Pre-flight: catch dead sync devices before the claim.
 
-        Checks every synchronous device's cached ``acq_timestamp`` freshness
-        and, when something looks dead, asks the operator via the legacy
-        dialog channel — all *before* the scan folder is claimed, so an abort
-        here burns no scan number.
+        Two stages, both *before* the scan folder is claimed (so an abort
+        here burns no scan number), both asking the operator through the
+        legacy dialog channel when something is wrong.
 
-        Free-run outcomes (the trigger free-runs before a free-run scan, so
-        live devices always have fresh frames):
+        **Stage 1 — gateway liveness (both modes).**  Each synchronous
+        device's ``connected_status`` (the gateway's per-device ``CONNECTED``
+        PV) is read; a device reporting ``Disconnected`` is genuinely down —
+        its TCP stream to the gateway is dead.  This is the authoritative
+        signal: the gateway serves every DB device's data PVs regardless of
+        device state, so CA-connect success never implied liveness (an OFF
+        camera's PVs connect fine).  Outcomes:
 
-        - every sync device fresh → detectors returned unchanged;
-        - some contributors stale, reference fresh → operator chooses between
-          dropping the stale devices (disconnected, removed from the list)
-          and aborting;
-        - the reference (pacemaker) stale → abort-only v1 (the second button
-          is a clearly-labeled "try anyway" because the dialog channel always
-          offers two options);
-        - ALL sync devices stale → the trigger is probably off / not
-          free-running; the dialog says so instead of accusing every camera.
+        - a disconnected *reference* (free-run pacemaker) → abort-only v1
+          (the second button is a clearly-labeled "Try Anyway" because the
+          dialog channel always offers two options; promotion is deferred);
+        - any other disconnected device(s), either mode → drop-and-continue
+          (disconnected devices removed from the list) vs abort;
+        - an unreadable ``CONNECTED`` PV (old gateway, timeout) → fail-open:
+          logged at DEBUG, treated as live.
 
-        Strict outcomes differ in one deliberate way: ALL-stale is a
-        *legitimate* pre-scan state (the trigger may sit OFF before a strict
-        scan; ``ARMED`` starts it), so it proceeds silently — only
-        **differential** staleness (some devices fresh, some not, which can
-        only mean genuinely dead devices) raises the drop-or-abort dialog.
-        Without this check a dead camera in strict mode burned every refire
-        (~9 s) and aborted *after* the claim (live-observed 2026-07-07,
-        Scan006). Strict mode has no pacemaker, so there is no
-        reference-special case.
+        **Stage 2 — free-run staleness (free-run mode ONLY).**  With every
+        device CONNECTED, cached ``acq_timestamp`` freshness now answers one
+        remaining question: *is the trigger free-running?* (a free-run scan
+        requires it).  All devices CONNECTED but all frames stale → the
+        "trigger may be off" dialog (Start Anyway / Abort).  The residual
+        case — a CONNECTED-but-stale contributor while the reference frames —
+        keeps the drop-or-abort dialog: the fresh reference proves the
+        trigger is running, so this is a per-device acquisition problem
+        (e.g. camera acquisition stopped while its TCP stream stays up), for
+        which drop is the right offer and trigger-off wording would be wrong.
+        A CONNECTED-but-stale *reference* keeps the abort-only dialog.
+
+        Strict mode runs stage 1 only: frames are not needed before a strict
+        scan (the trigger may legitimately sit OFF; ``ARMED`` starts it), and
+        with ``CONNECTED`` authoritative there is no differential-staleness
+        inference left to make.  (The previous staleness heuristic burned
+        every refire post-claim on an OFF camera — live-observed 2026-07-07,
+        Scan006 — because CA-connect could not see the device was down.)
 
         Headless / no consumer / no answer → today's behavior is preserved:
-        proceed and fail loudly downstream (t0 sync in free-run, refire
-        exhaustion in strict).
+        proceed and fail loudly downstream (t0 sync in free-run, the
+        liveness-gated refire path in strict).
 
         Returns
         -------
@@ -690,6 +762,82 @@ class BlueskyScanner:
         if not sync_devices:
             return detectors
 
+        # ---- Stage 1: gateway liveness (mode-independent) ----------------
+        dead = [d for d in sync_devices if not self._read_gateway_liveness(d)]
+        if dead:
+            dead_ids = {id(d) for d in dead}
+            details = ", ".join(
+                f"{self._device_label(d)} (gateway reports DISCONNECTED)" for d in dead
+            )
+            reference = sync_devices[0]
+
+            if not strict and id(reference) in dead_ids:
+                # v1: a dead reference (pacemaker) is abort-only — promotion
+                # is deliberately out of scope. (Strict mode has no pacemaker;
+                # a dead first device there is just another droppable device.)
+                exc = GeecsDeviceDownError(
+                    f"The free-run reference (pacemaker) device is down: "
+                    f"{details}. The gateway's CONNECTED PV says its TCP "
+                    "stream is dead — the scan cannot pace without it; "
+                    "aborting is recommended. Trying anyway will fail at "
+                    "t0 sync.",
+                    device_name=self._device_label(reference),
+                )
+                decision = self._request_operator_decision(
+                    exc,
+                    title="Reference Device Disconnected",
+                    continue_label="Try Anyway",
+                )
+                if decision == "abort":
+                    logger.warning(
+                        "Pre-flight: operator aborted (reference disconnected)"
+                    )
+                    return None
+                logger.warning(
+                    "Pre-flight: proceeding with a DISCONNECTED reference "
+                    "(%s) — t0 sync will fail loudly",
+                    details,
+                )
+                # The operator explicitly opted in; skip further pre-flight
+                # dialogs rather than stack a staleness dialog on top.
+                return detectors
+
+            exc = GeecsDeviceDownError(
+                f"Synchronous device(s) are down: {details}. The gateway's "
+                "CONNECTED PV says their TCP stream is dead (an off/crashed "
+                "GEECS device — its data PVs still connect, so this is the "
+                "authoritative check). Drop them and continue the scan "
+                "without their data, or abort."
+            )
+            decision = self._request_operator_decision(
+                exc,
+                title="Disconnected Device(s)",
+                continue_label="Drop && Continue",
+            )
+            if decision == "abort":
+                logger.warning("Pre-flight: operator aborted (disconnected devices)")
+                return None
+            if decision == "default":
+                logger.warning(
+                    "Pre-flight: device(s) %s are DISCONNECTED per the "
+                    "gateway but no operator answer — proceeding unchanged; "
+                    "the scan will fail loudly downstream (t0 sync in "
+                    "free-run, device-down abort in strict)",
+                    details,
+                )
+                return detectors
+            detectors = self._drop_devices(detectors, dead_ids)
+            sync_devices = [d for d in detectors if hasattr(d, "_last_acq")]
+            if not sync_devices:
+                return detectors
+
+        # ---- Stage 2: free-run trigger/staleness check --------------------
+        if strict:
+            # Frames are not needed before a strict scan (the trigger may
+            # legitimately sit OFF; ARMED starts it) and CONNECTED already
+            # answered liveness — nothing left to check.
+            return detectors
+
         stale = self._find_stale_sync_devices(sync_devices)
         if stale and _STALE_RECHECK_WAIT_S > 0:
             # A just-connected monitor may not have delivered its first frame
@@ -697,17 +845,6 @@ class BlueskyScanner:
             time.sleep(_STALE_RECHECK_WAIT_S)
             stale = self._find_stale_sync_devices(sync_devices)
         if not stale:
-            return detectors
-
-        if strict and len(stale) == len(sync_devices):
-            # Legitimate strict-mode state: the trigger can be OFF before a
-            # strict scan (ARMED starts it), leaving every cache stale.
-            # Only differential staleness is diagnostic in strict mode.
-            logger.info(
-                "Pre-flight: all synchronous devices stale before a strict "
-                "scan — expected when the trigger is off pre-scan; ARMED "
-                "will start it"
-            )
             return detectors
 
         def _describe(device: Any, age: float | None) -> str:
@@ -720,13 +857,14 @@ class BlueskyScanner:
         reference = sync_devices[0]
 
         if len(stale) == len(sync_devices):
-            # Every sync device is stale — the likely culprit is the trigger,
-            # not N simultaneously dead cameras.
+            # Every sync device is CONNECTED but frameless — unambiguous now:
+            # the trigger is off / not free-running.
             exc = GeecsStaleDevicesError(
-                f"No synchronous device has a fresh frame ({details}). "
-                "The trigger may be off / not free-running — free-run scans "
-                "need the trigger free-running before start. Starting anyway "
-                "will fail at t0 sync if nothing is firing."
+                f"All synchronous devices are CONNECTED per the gateway but "
+                f"none has a fresh frame ({details}). The trigger appears to "
+                "be off / not free-running — free-run scans need the trigger "
+                "free-running before start. Starting anyway will fail at "
+                "t0 sync if nothing is firing."
             )
             decision = self._request_operator_decision(
                 exc,
@@ -743,21 +881,18 @@ class BlueskyScanner:
             )
             return detectors
 
-        if not strict and id(reference) in stale_ids:
-            # v1: a dead reference (pacemaker) is abort-only — promotion is
-            # deliberately out of scope; the "continue" button is a clearly
-            # labeled try-anyway because the dialog always offers two options.
-            # (Strict mode has no pacemaker; a stale first device there is
-            # just another droppable device, handled below.)
+        if id(reference) in stale_ids:
+            # v1: a frameless reference (pacemaker) is abort-only, same as a
+            # disconnected one — promotion is deliberately out of scope.
             exc = GeecsStaleDevicesError(
-                f"The free-run reference (pacemaker) device looks dead: "
-                f"{details}. The scan cannot pace without it; aborting is "
-                "recommended. Trying anyway will fail at t0 sync if it is "
-                "really dead."
+                f"The free-run reference (pacemaker) device is CONNECTED but "
+                f"has no fresh frames: {details}. The scan cannot pace "
+                "without it; aborting is recommended. Trying anyway will "
+                "fail at t0 sync if it is really not acquiring."
             )
             decision = self._request_operator_decision(
                 exc,
-                title="Reference Device Looks Dead",
+                title="Reference Device Not Acquiring",
                 continue_label="Try Anyway",
             )
             if decision == "abort":
@@ -765,21 +900,24 @@ class BlueskyScanner:
                 return None
             logger.warning(
                 "Pre-flight: proceeding with a stale reference (%s) — "
-                "t0 sync will fail loudly if it is really dead",
+                "t0 sync will fail loudly if it is really not acquiring",
                 details,
             )
             return detectors
 
-        # Some-but-not-all sync devices stale (free-run: contributors with the
-        # reference fresh; strict: any subset — differential staleness can
-        # only mean genuinely dead devices): offer to drop them.
+        # Residual case: CONNECTED-but-stale contributor(s) while the
+        # reference frames.  The fresh reference proves the trigger is
+        # running, so this is a per-device acquisition problem (camera
+        # acquisition stopped while its TCP stream stays up) — offer to drop.
         exc = GeecsStaleDevicesError(
-            f"Synchronous device(s) look dead: {details}. "
-            "Drop them and continue the scan without their data, or abort."
+            f"Synchronous device(s) are CONNECTED but not producing frames: "
+            f"{details}. The reference is framing, so the trigger is "
+            "running — these devices are not acquiring. Drop them and "
+            "continue the scan without their data, or abort."
         )
         decision = self._request_operator_decision(
             exc,
-            title="Dead Sync Device(s)",
+            title="Device(s) Not Acquiring",
             continue_label="Drop && Continue",
         )
         if decision == "abort":
@@ -788,26 +926,12 @@ class BlueskyScanner:
         if decision == "default":
             logger.warning(
                 "Pre-flight: stale sync device(s) %s but no operator answer — "
-                "proceeding unchanged; the scan will fail loudly downstream "
-                "(t0 sync in free-run, refire exhaustion in strict) if they "
-                "are really dead",
+                "proceeding unchanged; t0 sync will fail loudly if they are "
+                "really not acquiring",
                 details,
             )
             return detectors
-
-        # Drop: disconnect the stale devices and remove them everywhere the
-        # cleanup path would otherwise touch them.
-        for device, _age in stale:
-            logger.warning(
-                "Pre-flight: dropping dead contributor %s from this scan "
-                "(operator chose drop-and-continue); disconnecting it",
-                self._device_label(device),
-            )
-            self._disconnect_device(device)
-        remaining = [d for d in detectors if id(d) not in stale_ids]
-        with self._device_lock:
-            self._detectors = [d for d in self._detectors if id(d) not in stale_ids]
-        return remaining
+        return self._drop_devices(detectors, stale_ids)
 
     @staticmethod
     def _log_claimed_scan_failure(
@@ -1218,7 +1342,7 @@ class BlueskyScanner:
             )
         self._session.shot_control(self._shot_control)
 
-        checked = self._preflight_check_sync_freshness(detectors, strict=strict)
+        checked = self._preflight_check_sync_liveness(detectors, strict=strict)
         if checked is None:
             # Mirror the _abort_before_acquisition path: setting the flag
             # makes the scan thread's cleanup report ABORTED and

--- a/GeecsBluesky/geecs_bluesky/scanner_bridge/bluesky_scanner.py
+++ b/GeecsBluesky/geecs_bluesky/scanner_bridge/bluesky_scanner.py
@@ -643,16 +643,18 @@ class BlueskyScanner:
             return "default"
         return "abort" if request.abort[0] else "continue"
 
-    def _preflight_check_free_run_freshness(self, detectors: list) -> list | None:
-        """Free-run pre-flight: catch dead sync devices before the claim.
+    def _preflight_check_sync_freshness(
+        self, detectors: list, *, strict: bool = False
+    ) -> list | None:
+        """Pre-flight: catch dead sync devices before the claim.
 
         Checks every synchronous device's cached ``acq_timestamp`` freshness
-        (the trigger free-runs before a free-run scan, so live devices have
-        fresh frames) and, when something looks dead, asks the operator via
-        the legacy dialog channel — all *before* the scan folder is claimed,
-        so an abort here burns no scan number.
+        and, when something looks dead, asks the operator via the legacy
+        dialog channel — all *before* the scan folder is claimed, so an abort
+        here burns no scan number.
 
-        Outcomes:
+        Free-run outcomes (the trigger free-runs before a free-run scan, so
+        live devices always have fresh frames):
 
         - every sync device fresh → detectors returned unchanged;
         - some contributors stale, reference fresh → operator chooses between
@@ -662,9 +664,21 @@ class BlueskyScanner:
           is a clearly-labeled "try anyway" because the dialog channel always
           offers two options);
         - ALL sync devices stale → the trigger is probably off / not
-          free-running; the dialog says so instead of accusing every camera;
-        - headless / no consumer / no answer → today's behavior is preserved:
-          proceed and let t0 sync fail loudly.
+          free-running; the dialog says so instead of accusing every camera.
+
+        Strict outcomes differ in one deliberate way: ALL-stale is a
+        *legitimate* pre-scan state (the trigger may sit OFF before a strict
+        scan; ``ARMED`` starts it), so it proceeds silently — only
+        **differential** staleness (some devices fresh, some not, which can
+        only mean genuinely dead devices) raises the drop-or-abort dialog.
+        Without this check a dead camera in strict mode burned every refire
+        (~9 s) and aborted *after* the claim (live-observed 2026-07-07,
+        Scan006). Strict mode has no pacemaker, so there is no
+        reference-special case.
+
+        Headless / no consumer / no answer → today's behavior is preserved:
+        proceed and fail loudly downstream (t0 sync in free-run, refire
+        exhaustion in strict).
 
         Returns
         -------
@@ -683,6 +697,17 @@ class BlueskyScanner:
             time.sleep(_STALE_RECHECK_WAIT_S)
             stale = self._find_stale_sync_devices(sync_devices)
         if not stale:
+            return detectors
+
+        if strict and len(stale) == len(sync_devices):
+            # Legitimate strict-mode state: the trigger can be OFF before a
+            # strict scan (ARMED starts it), leaving every cache stale.
+            # Only differential staleness is diagnostic in strict mode.
+            logger.info(
+                "Pre-flight: all synchronous devices stale before a strict "
+                "scan — expected when the trigger is off pre-scan; ARMED "
+                "will start it"
+            )
             return detectors
 
         def _describe(device: Any, age: float | None) -> str:
@@ -718,10 +743,12 @@ class BlueskyScanner:
             )
             return detectors
 
-        if id(reference) in stale_ids:
+        if not strict and id(reference) in stale_ids:
             # v1: a dead reference (pacemaker) is abort-only — promotion is
             # deliberately out of scope; the "continue" button is a clearly
             # labeled try-anyway because the dialog always offers two options.
+            # (Strict mode has no pacemaker; a stale first device there is
+            # just another droppable device, handled below.)
             exc = GeecsStaleDevicesError(
                 f"The free-run reference (pacemaker) device looks dead: "
                 f"{details}. The scan cannot pace without it; aborting is "
@@ -743,25 +770,27 @@ class BlueskyScanner:
             )
             return detectors
 
-        # Some-but-not-all contributors stale, reference fresh: offer to drop
-        # the dead devices and take the scan without them.
+        # Some-but-not-all sync devices stale (free-run: contributors with the
+        # reference fresh; strict: any subset — differential staleness can
+        # only mean genuinely dead devices): offer to drop them.
         exc = GeecsStaleDevicesError(
             f"Synchronous device(s) look dead: {details}. "
             "Drop them and continue the scan without their data, or abort."
         )
         decision = self._request_operator_decision(
             exc,
-            title="Dead Contributor Device(s)",
+            title="Dead Sync Device(s)",
             continue_label="Drop && Continue",
         )
         if decision == "abort":
-            logger.warning("Pre-flight: operator aborted (stale contributors)")
+            logger.warning("Pre-flight: operator aborted (stale sync devices)")
             return None
         if decision == "default":
             logger.warning(
-                "Pre-flight: stale contributor(s) %s but no operator answer — "
-                "proceeding unchanged; t0 sync will fail loudly if they are "
-                "really dead",
+                "Pre-flight: stale sync device(s) %s but no operator answer — "
+                "proceeding unchanged; the scan will fail loudly downstream "
+                "(t0 sync in free-run, refire exhaustion in strict) if they "
+                "are really dead",
                 details,
             )
             return detectors
@@ -1189,15 +1218,14 @@ class BlueskyScanner:
             )
         self._session.shot_control(self._shot_control)
 
-        if not strict:
-            checked = self._preflight_check_free_run_freshness(detectors)
-            if checked is None:
-                # Mirror the _abort_before_acquisition path: setting the flag
-                # makes the scan thread's cleanup report ABORTED and
-                # disconnect every connected device — before any claim.
-                self._abort_requested = True
-                return
-            detectors = checked
+        checked = self._preflight_check_sync_freshness(detectors, strict=strict)
+        if checked is None:
+            # Mirror the _abort_before_acquisition path: setting the flag
+            # makes the scan thread's cleanup report ABORTED and
+            # disconnect every connected device — before any claim.
+            self._abort_requested = True
+            return
+        detectors = checked
 
         if self._abort_before_acquisition():
             return

--- a/GeecsBluesky/pyproject.toml
+++ b/GeecsBluesky/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-bluesky"
-version = "0.20.0"
+version = "0.21.0"
 description = "Bluesky / ophyd-async bridge for the GEECS control system"
 authors = ["Sam Barber <sbarber@lbl.gov>"]
 readme = "README.md"

--- a/GeecsBluesky/tests/test_bluesky_scanner_progress_and_preflight.py
+++ b/GeecsBluesky/tests/test_bluesky_scanner_progress_and_preflight.py
@@ -309,8 +309,13 @@ def test_fresh_devices_no_dialog_no_behavior_change(monkeypatch) -> None:
     assert claims == ["TestExp"]
 
 
-def test_strict_mode_skips_preflight(monkeypatch) -> None:
-    """The pre-flight is free-run only — strict scans never see a dialog."""
+def test_strict_all_stale_proceeds_silently(monkeypatch) -> None:
+    """Strict + ALL sync devices stale → no dialog, proceed.
+
+    All-stale is a legitimate strict-mode pre-scan state: the trigger can sit
+    OFF before a strict scan (ARMED starts it), leaving every cache stale.
+    Only differential staleness is diagnostic there.
+    """
     _patch_dialog_channel(monkeypatch)
     claims: list = []
     _patch_claim(monkeypatch, claims)
@@ -328,6 +333,66 @@ def test_strict_mode_skips_preflight(monkeypatch) -> None:
 
     assert not any(isinstance(e, _FakeDialogEvent) for e in events)
     assert session.scan_kwargs is not None
+
+
+def test_strict_differential_stale_raises_drop_dialog(monkeypatch) -> None:
+    """Strict + one stale among fresh devices → drop dialog, device removed.
+
+    Live-observed 2026-07-07 (Scan006): a camera that was simply OFF ran a
+    strict scan into 3 wasted refires and a post-claim abort. Differential
+    staleness (some fresh, some stale) can only mean genuinely dead devices,
+    so strict mode now gets the same pre-claim dialog as free-run.
+    """
+    _patch_dialog_channel(monkeypatch)
+    claims: list = []
+    _patch_claim(monkeypatch, claims)
+    session = _FakeSession(last_acq={"U_Cam2": _stale()})
+    scanner = _make_scanner(
+        session,
+        {
+            "U_Cam1": {"synchronous": True, "variable_list": ["Sig"]},
+            "U_Cam2": {"synchronous": True, "variable_list": ["Val"]},
+        },
+        mode="strict_shot_control",
+    )
+    scanner._shot_control = object()
+    answers: dict = {}
+    events: list = []
+    consumer = _dialog_consumer(events, claims, answers, abort=False)
+    scanner._on_event = consumer
+
+    scanner._execute_scan(_noscan_config(), motor=None, positions=[None])
+
+    assert answers["claims_at_dialog"] == []  # asked before any claim
+    assert session.scan_kwargs is not None
+    names = [d._geecs_device_name for d in session.scan_kwargs["detectors"]]
+    assert names == ["U_Cam1"]  # stale device dropped
+
+
+def test_strict_differential_stale_abort_is_pre_claim(monkeypatch) -> None:
+    """Strict differential staleness + operator abort → nothing claimed."""
+    _patch_dialog_channel(monkeypatch)
+    claims: list = []
+    _patch_claim(monkeypatch, claims)
+    session = _FakeSession(last_acq={"U_Cam2": _stale()})
+    scanner = _make_scanner(
+        session,
+        {
+            "U_Cam1": {"synchronous": True, "variable_list": ["Sig"]},
+            "U_Cam2": {"synchronous": True, "variable_list": ["Val"]},
+        },
+        mode="strict_shot_control",
+    )
+    scanner._shot_control = object()
+    answers: dict = {}
+    events: list = []
+    scanner._on_event = _dialog_consumer(events, claims, answers, abort=True)
+
+    scanner._execute_scan(_noscan_config(), motor=None, positions=[None])
+
+    assert claims == []
+    assert session.scan_kwargs is None
+    assert scanner._abort_requested
 
 
 # ---------------------------------------------------------------------------

--- a/GeecsBluesky/tests/test_bluesky_scanner_progress_and_preflight.py
+++ b/GeecsBluesky/tests/test_bluesky_scanner_progress_and_preflight.py
@@ -1,0 +1,617 @@
+"""Tests for BlueskyScanner GUI progress events and the free-run pre-flight.
+
+Item 1 — ``ScanStepEvent`` emission: every Bluesky event document emits a
+shot-level progress event through ``on_event`` (same channel and thread
+semantics as the lifecycle events), clamped at ``total_shots`` so the free-run
+tail-flush overcount stays cosmetic.
+
+Item 2 — dead-contributor pre-flight (free-run mode only): before the scan
+folder is claimed, synchronous devices whose persistent-monitor cache
+(``_last_acq``) is missing or stale raise an operator dialog through the
+legacy ``ScanDialogEvent``/``DialogRequest`` channel.  Outcomes: drop stale
+contributors and continue, abort pre-claim, abort-only for a stale reference,
+trigger-off wording when everything is stale, and today's proceed-and-fail-
+loudly default when headless or unanswered.
+
+See ``Planning/gui_stewardship/00_overview.md`` §4–5.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from dataclasses import dataclass, field
+from types import SimpleNamespace
+
+from geecs_bluesky.scanner_bridge import bluesky_scanner
+from geecs_bluesky.scanner_bridge.bluesky_scanner import BlueskyScanner
+
+# ---------------------------------------------------------------------------
+# Fakes (no network / DB / CA / Qt)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _FakeStepEvent:
+    """Stands in for geecs_scanner.engine ScanStepEvent."""
+
+    step_index: int = 0
+    total_steps: int = 0
+    shots_completed: int = 0
+    phase: str = "started"
+
+
+@dataclass
+class _FakeDialogEvent:
+    """Stands in for geecs_scanner.engine ScanDialogEvent."""
+
+    request: object = None
+
+
+@dataclass
+class _FakeDialogRequest:
+    """Stands in for geecs_scanner.engine.dialog_request.DialogRequest."""
+
+    exc: Exception
+    context: str | None = None
+    title: str | None = None
+    continue_label: str | None = None
+    abort_label: str | None = None
+    response_event: threading.Event = field(default_factory=threading.Event)
+    abort: list[bool] = field(default_factory=lambda: [False])
+
+
+class _FakeSyncDevice:
+    """Sync device fake: carries the persistent-monitor cache ``_last_acq``."""
+
+    def __init__(self, device: str, name: str, last_acq: float | None) -> None:
+        self.name = name  # ophyd (safe) name
+        self._geecs_device_name = device
+        self._last_acq = last_acq
+
+    def trigger(self) -> None:  # reference-capable, like CaGenericDetector
+        raise NotImplementedError("not exercised by these tests")
+
+
+class _FakeSnapshotDevice:
+    """Async snapshot fake: deliberately has NO ``_last_acq`` attribute."""
+
+    def __init__(self, device: str, name: str) -> None:
+        self.name = name
+        self._geecs_device_name = device
+
+
+def _labview_now() -> float:
+    return time.time() + bluesky_scanner._LABVIEW_EPOCH_OFFSET
+
+
+def _fresh() -> float:
+    return _labview_now() - 1.0
+
+
+def _stale() -> float:
+    return _labview_now() - 60.0
+
+
+class _FakeSession:
+    """Session fake whose factories attach per-device ``_last_acq`` caches."""
+
+    def __init__(self, last_acq: dict[str, float | None] | None = None) -> None:
+        self._last_acq = last_acq or {}
+        self.scan_kwargs: dict | None = None
+
+    def _cache_for(self, device: str) -> float | None:
+        if device in self._last_acq:
+            return self._last_acq[device]
+        return _fresh()
+
+    def detector(self, device, variables, *, save_images=False, name=None):
+        return _FakeSyncDevice(device, name or device, self._cache_for(device))
+
+    def contributor(self, device, variables, *, save_images=False, name=None):
+        return _FakeSyncDevice(device, name or device, self._cache_for(device))
+
+    def snapshot(self, device, variables, *, name=None):
+        return _FakeSnapshotDevice(device, name or device)
+
+    def shot_control(self, config):
+        pass
+
+    def scan(self, **kwargs):
+        self.scan_kwargs = kwargs
+        return "uid"
+
+
+def _make_scanner(
+    session: _FakeSession,
+    devices_config: dict | None = None,
+    mode: str = "free_run_time_sync",
+) -> BlueskyScanner:
+    scanner = BlueskyScanner.__new__(BlueskyScanner)
+    scanner._session = session
+    scanner._experiment_dir = "TestExp"
+    scanner._devices_config = devices_config or {}
+    scanner._acquisition_mode = mode
+    scanner._shot_control = None
+    scanner._shots_per_step = 2
+    scanner._detectors = []
+    scanner._motor = None
+    scanner._device_lock = threading.Lock()
+    scanner._on_event = None
+    scanner._current_state = None
+    scanner._total_shots = 0
+    scanner._total_steps = 0
+    scanner._completed_shots = 0
+    scanner._abort_requested = False
+    scanner._optimization_loader = None
+    scanner._RE = SimpleNamespace(
+        state="idle", abort=lambda reason=None: None, _loop=None
+    )
+    return scanner
+
+
+def _noscan_config() -> SimpleNamespace:
+    return SimpleNamespace(
+        scan_mode="noscan",
+        device_var=None,
+        start=0.0,
+        end=0.0,
+        step=0.0,
+        wait_time=1.0,
+        additional_description="",
+        background=False,
+    )
+
+
+def _patch_dialog_channel(monkeypatch) -> None:
+    """Route dialog emission through the fakes (env-independent tests)."""
+    monkeypatch.setattr(bluesky_scanner, "ScanDialogEvent", _FakeDialogEvent)
+    monkeypatch.setattr(bluesky_scanner, "DialogRequest", _FakeDialogRequest)
+    monkeypatch.setattr(bluesky_scanner, "_STALE_RECHECK_WAIT_S", 0.0)
+
+
+def _patch_claim(monkeypatch, claims: list, result=(None, None)) -> None:
+    monkeypatch.setattr(
+        bluesky_scanner,
+        "claim_scan_number",
+        lambda experiment: claims.append(experiment) or result,
+    )
+
+
+def _dialog_consumer(events: list, claims: list, answers: dict, *, abort: bool | None):
+    """Return an on_event callback answering dialog requests inline.
+
+    ``abort=None`` leaves the request unanswered (timeout path).  Records the
+    claim count observed at dialog time so tests can assert nothing was
+    claimed before the operator was asked.
+    """
+
+    def on_event(event) -> None:
+        events.append(event)
+        if isinstance(event, _FakeDialogEvent):
+            answers["claims_at_dialog"] = list(claims)
+            answers["request"] = event.request
+            if abort is not None:
+                event.request.abort[0] = abort
+                event.request.response_event.set()
+
+    return on_event
+
+
+# ---------------------------------------------------------------------------
+# Item 1 — step/progress events from event documents
+# ---------------------------------------------------------------------------
+
+
+def test_event_documents_emit_step_progress(monkeypatch) -> None:
+    """One ScanStepEvent per event document, with running shot counts."""
+    monkeypatch.setattr(bluesky_scanner, "ScanStepEvent", _FakeStepEvent)
+    events: list = []
+    scanner = _make_scanner(_FakeSession())
+    scanner._on_event = events.append
+    scanner._total_shots = 4
+    scanner._total_steps = 2
+
+    scanner._on_document("start", {"uid": "abc"})
+    for bin_number in (1, 1, 2, 2):
+        scanner._on_document("event", {"data": {"bin_number": bin_number}})
+
+    assert scanner._last_run_uid == "abc"
+    step_events = [e for e in events if isinstance(e, _FakeStepEvent)]
+    assert [e.shots_completed for e in step_events] == [1, 2, 3, 4]
+    assert [e.step_index for e in step_events] == [0, 0, 1, 1]
+    assert all(e.total_steps == 2 for e in step_events)
+    assert all(e.phase == "completed" for e in step_events)
+
+
+def test_progress_clamps_at_total_shots_for_tail_flush(monkeypatch) -> None:
+    """The free-run tail-flush extra event document must not exceed 100 %."""
+    monkeypatch.setattr(bluesky_scanner, "ScanStepEvent", _FakeStepEvent)
+    events: list = []
+    scanner = _make_scanner(_FakeSession())
+    scanner._on_event = events.append
+    scanner._total_shots = 2
+    scanner._total_steps = 1
+
+    scanner._on_document("event", {"data": {"bin_number": 1}})
+    scanner._on_document("event", {"data": {"bin_number": 1}})
+    # Tail flush: one extra event on the flush stream (no bin_number here).
+    scanner._on_document("event", {"data": {}})
+
+    assert [e.shots_completed for e in events] == [1, 2, 2]
+    assert events[-1].step_index == 0  # clamped inside [0, total_steps)
+    # The raw counter still overcounts (known, cosmetic) but the estimate
+    # exposed to pollers is clamped too.
+    assert scanner._completed_shots == 3
+    assert scanner.estimate_current_completion() == 1.0
+
+
+def test_progress_without_callback_or_event_type_is_silent(monkeypatch) -> None:
+    """No consumer or no geecs_scanner installed → counting still works."""
+    scanner = _make_scanner(_FakeSession())
+    scanner._total_shots = 2
+    scanner._on_document("event", {"data": {"bin_number": 1}})  # _on_event None
+
+    events: list = []
+    scanner._on_event = events.append
+    monkeypatch.setattr(bluesky_scanner, "ScanStepEvent", None)
+    scanner._on_document("event", {"data": {"bin_number": 1}})
+
+    assert events == []
+    assert scanner._completed_shots == 2
+
+
+def test_progress_survives_raising_callback(monkeypatch) -> None:
+    """A misbehaving on_event consumer must not break document handling."""
+    monkeypatch.setattr(bluesky_scanner, "ScanStepEvent", _FakeStepEvent)
+
+    def bad_callback(event) -> None:
+        raise RuntimeError("GUI went away")
+
+    scanner = _make_scanner(_FakeSession())
+    scanner._on_event = bad_callback
+    scanner._total_shots = 2
+    scanner._on_document("event", {"data": {"bin_number": 1}})
+    assert scanner._completed_shots == 1
+
+
+# ---------------------------------------------------------------------------
+# Item 2 — free-run pre-flight: fresh devices are untouched
+# ---------------------------------------------------------------------------
+
+
+def test_fresh_devices_no_dialog_no_behavior_change(monkeypatch) -> None:
+    """All sync devices fresh → no dialog, scan proceeds with every device."""
+    _patch_dialog_channel(monkeypatch)
+    claims: list = []
+    _patch_claim(monkeypatch, claims)
+    session = _FakeSession()  # every device defaults to a fresh cache
+    scanner = _make_scanner(
+        session,
+        {
+            "U_Ref": {"synchronous": True, "variable_list": ["Sig"]},
+            "U_Cam2": {"synchronous": True, "variable_list": ["Val"]},
+            "U_Stage": {"synchronous": False, "variable_list": ["Pos"]},
+        },
+    )
+    events: list = []
+    scanner._on_event = events.append
+
+    scanner._execute_scan(_noscan_config(), motor=None, positions=[None])
+
+    assert not any(isinstance(e, _FakeDialogEvent) for e in events)
+    assert session.scan_kwargs is not None
+    assert [d._geecs_device_name for d in session.scan_kwargs["detectors"]] == [
+        "U_Ref",
+        "U_Cam2",
+        "U_Stage",
+    ]
+    assert claims == ["TestExp"]
+
+
+def test_strict_mode_skips_preflight(monkeypatch) -> None:
+    """The pre-flight is free-run only — strict scans never see a dialog."""
+    _patch_dialog_channel(monkeypatch)
+    claims: list = []
+    _patch_claim(monkeypatch, claims)
+    session = _FakeSession(last_acq={"U_Cam": None})
+    scanner = _make_scanner(
+        session,
+        {"U_Cam": {"synchronous": True, "variable_list": ["Sig"]}},
+        mode="strict_shot_control",
+    )
+    scanner._shot_control = object()
+    events: list = []
+    scanner._on_event = events.append
+
+    scanner._execute_scan(_noscan_config(), motor=None, positions=[None])
+
+    assert not any(isinstance(e, _FakeDialogEvent) for e in events)
+    assert session.scan_kwargs is not None
+
+
+# ---------------------------------------------------------------------------
+# Item 2 — stale contributor: drop-and-continue / abort
+# ---------------------------------------------------------------------------
+
+
+def test_stale_contributor_drop_removes_and_disconnects(monkeypatch) -> None:
+    """Operator answers drop → device disconnected, removed, scan proceeds."""
+    _patch_dialog_channel(monkeypatch)
+    claims: list = []
+    _patch_claim(monkeypatch, claims)
+    session = _FakeSession(last_acq={"U_Cam2": _stale()})
+    scanner = _make_scanner(
+        session,
+        {
+            "U_Ref": {"synchronous": True, "variable_list": ["Sig"]},
+            "U_Cam2": {"synchronous": True, "variable_list": ["Val"]},
+            "U_Stage": {"synchronous": False, "variable_list": ["Pos"]},
+        },
+    )
+    disconnected: list[str] = []
+    scanner._disconnect_device = lambda dev: disconnected.append(dev._geecs_device_name)
+    events: list = []
+    answers: dict = {}
+    scanner._on_event = _dialog_consumer(events, claims, answers, abort=False)
+
+    scanner._execute_scan(_noscan_config(), motor=None, positions=[None])
+
+    # Nothing was claimed before the operator was asked.
+    assert answers["claims_at_dialog"] == []
+    request = answers["request"]
+    assert "U_Cam2" in str(request.exc)
+    assert "s ago" in str(request.exc)  # says how stale
+    assert request.continue_label is not None
+    assert "drop" in request.continue_label.lower()
+    # The stale device was disconnected and removed; the scan proceeded.
+    assert disconnected == ["U_Cam2"]
+    assert session.scan_kwargs is not None
+    assert [d._geecs_device_name for d in session.scan_kwargs["detectors"]] == [
+        "U_Ref",
+        "U_Stage",
+    ]
+    assert [d._geecs_device_name for d in scanner._detectors] == ["U_Ref", "U_Stage"]
+    assert claims == ["TestExp"]
+
+
+def test_stale_contributor_abort_is_pre_claim(monkeypatch) -> None:
+    """Operator answers abort → clean pre-claim abort, devices disconnected."""
+    _patch_dialog_channel(monkeypatch)
+    monkeypatch.setattr(bluesky_scanner, "ScanState", None)
+    claims: list = []
+    _patch_claim(monkeypatch, claims)
+    session = _FakeSession(last_acq={"U_Cam2": None})
+    scanner = _make_scanner(
+        session,
+        {
+            "U_Ref": {"synchronous": True, "variable_list": ["Sig"]},
+            "U_Cam2": {"synchronous": True, "variable_list": ["Val"]},
+        },
+    )
+    disconnected: list[str] = []
+    scanner._disconnect_device = lambda dev: disconnected.append(dev._geecs_device_name)
+    events: list = []
+    answers: dict = {}
+    scanner._on_event = _dialog_consumer(events, claims, answers, abort=True)
+
+    scanner._run_scan(_noscan_config())
+
+    assert claims == [], "no scan folder may be claimed for an aborted scan"
+    assert session.scan_kwargs is None
+    assert scanner.current_state == "aborted"
+    # The scan thread's cleanup disconnected everything that had connected.
+    assert set(disconnected) == {"U_Ref", "U_Cam2"}
+
+
+# ---------------------------------------------------------------------------
+# Item 2 — stale reference: abort-only v1
+# ---------------------------------------------------------------------------
+
+
+def test_stale_reference_dialog_is_abort_only_v1(monkeypatch) -> None:
+    """A dead pacemaker offers abort (recommended) vs clearly-labeled retry."""
+    _patch_dialog_channel(monkeypatch)
+    monkeypatch.setattr(bluesky_scanner, "ScanState", None)
+    claims: list = []
+    _patch_claim(monkeypatch, claims)
+    session = _FakeSession(last_acq={"U_Ref": _stale()})
+    scanner = _make_scanner(
+        session,
+        {
+            "U_Ref": {"synchronous": True, "variable_list": ["Sig"]},
+            "U_Cam2": {"synchronous": True, "variable_list": ["Val"]},
+        },
+    )
+    events: list = []
+    answers: dict = {}
+    scanner._on_event = _dialog_consumer(events, claims, answers, abort=True)
+
+    scanner._run_scan(_noscan_config())
+
+    request = answers["request"]
+    assert "reference" in str(request.exc).lower()
+    assert "U_Ref" in str(request.exc)
+    # No drop offer — the second option is a clearly-labeled try-anyway.
+    assert "anyway" in request.continue_label.lower()
+    assert claims == []
+    assert scanner.current_state == "aborted"
+
+
+def test_stale_reference_try_anyway_proceeds_with_full_list(monkeypatch) -> None:
+    """Choosing try-anyway preserves today's behavior (t0 sync fails loudly)."""
+    _patch_dialog_channel(monkeypatch)
+    claims: list = []
+    _patch_claim(monkeypatch, claims)
+    session = _FakeSession(last_acq={"U_Ref": _stale()})
+    scanner = _make_scanner(
+        session,
+        {
+            "U_Ref": {"synchronous": True, "variable_list": ["Sig"]},
+            "U_Cam2": {"synchronous": True, "variable_list": ["Val"]},
+        },
+    )
+    events: list = []
+    answers: dict = {}
+    scanner._on_event = _dialog_consumer(events, claims, answers, abort=False)
+
+    scanner._execute_scan(_noscan_config(), motor=None, positions=[None])
+
+    assert session.scan_kwargs is not None
+    assert [d._geecs_device_name for d in session.scan_kwargs["detectors"]] == [
+        "U_Ref",
+        "U_Cam2",
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Item 2 — all sync devices stale: the trigger is probably off
+# ---------------------------------------------------------------------------
+
+
+def test_all_stale_dialog_blames_the_trigger(monkeypatch) -> None:
+    """When every sync device is stale, the message says trigger-off."""
+    _patch_dialog_channel(monkeypatch)
+    monkeypatch.setattr(bluesky_scanner, "ScanState", None)
+    claims: list = []
+    _patch_claim(monkeypatch, claims)
+    session = _FakeSession(last_acq={"U_Ref": None, "U_Cam2": _stale()})
+    scanner = _make_scanner(
+        session,
+        {
+            "U_Ref": {"synchronous": True, "variable_list": ["Sig"]},
+            "U_Cam2": {"synchronous": True, "variable_list": ["Val"]},
+        },
+    )
+    events: list = []
+    answers: dict = {}
+    scanner._on_event = _dialog_consumer(events, claims, answers, abort=True)
+
+    scanner._run_scan(_noscan_config())
+
+    request = answers["request"]
+    assert "trigger may be off" in str(request.exc)
+    assert claims == []
+    assert scanner.current_state == "aborted"
+
+
+# ---------------------------------------------------------------------------
+# Item 2 — headless / no answer: today's behavior is preserved
+# ---------------------------------------------------------------------------
+
+
+def test_headless_stale_contributor_proceeds_unchanged(monkeypatch) -> None:
+    """on_event=None → no dialog machinery, scan proceeds with all devices."""
+    _patch_dialog_channel(monkeypatch)
+    claims: list = []
+    _patch_claim(monkeypatch, claims)
+    session = _FakeSession(last_acq={"U_Cam2": None})
+    scanner = _make_scanner(
+        session,
+        {
+            "U_Ref": {"synchronous": True, "variable_list": ["Sig"]},
+            "U_Cam2": {"synchronous": True, "variable_list": ["Val"]},
+        },
+    )
+    scanner._on_event = None
+
+    scanner._execute_scan(_noscan_config(), motor=None, positions=[None])
+
+    assert session.scan_kwargs is not None
+    assert [d._geecs_device_name for d in session.scan_kwargs["detectors"]] == [
+        "U_Ref",
+        "U_Cam2",
+    ]
+    assert claims == ["TestExp"]
+
+
+def test_unanswered_dialog_times_out_and_proceeds(monkeypatch) -> None:
+    """No response within the (shortened) timeout → proceed unchanged."""
+    _patch_dialog_channel(monkeypatch)
+    monkeypatch.setattr(bluesky_scanner, "_PREFLIGHT_DIALOG_TIMEOUT_S", 0.05)
+    claims: list = []
+    _patch_claim(monkeypatch, claims)
+    session = _FakeSession(last_acq={"U_Cam2": None})
+    scanner = _make_scanner(
+        session,
+        {
+            "U_Ref": {"synchronous": True, "variable_list": ["Sig"]},
+            "U_Cam2": {"synchronous": True, "variable_list": ["Val"]},
+        },
+    )
+    events: list = []
+    answers: dict = {}
+    scanner._on_event = _dialog_consumer(events, claims, answers, abort=None)
+
+    scanner._execute_scan(_noscan_config(), motor=None, positions=[None])
+
+    assert any(isinstance(e, _FakeDialogEvent) for e in events)
+    assert session.scan_kwargs is not None
+    assert [d._geecs_device_name for d in session.scan_kwargs["detectors"]] == [
+        "U_Ref",
+        "U_Cam2",
+    ]
+    assert claims == ["TestExp"]
+
+
+def test_missing_dialog_types_proceed_unchanged(monkeypatch) -> None:
+    """geecs_scanner not importable (standalone install) → default behavior."""
+    monkeypatch.setattr(bluesky_scanner, "ScanDialogEvent", None)
+    monkeypatch.setattr(bluesky_scanner, "DialogRequest", None)
+    monkeypatch.setattr(bluesky_scanner, "_STALE_RECHECK_WAIT_S", 0.0)
+    claims: list = []
+    _patch_claim(monkeypatch, claims)
+    session = _FakeSession(last_acq={"U_Cam2": None})
+    scanner = _make_scanner(
+        session,
+        {
+            "U_Ref": {"synchronous": True, "variable_list": ["Sig"]},
+            "U_Cam2": {"synchronous": True, "variable_list": ["Val"]},
+        },
+    )
+    events: list = []
+    scanner._on_event = events.append
+
+    scanner._execute_scan(_noscan_config(), motor=None, positions=[None])
+
+    assert session.scan_kwargs is not None
+    assert len(session.scan_kwargs["detectors"]) == 2
+
+
+# ---------------------------------------------------------------------------
+# Item 2 — the stale re-check gives a just-connected monitor a second look
+# ---------------------------------------------------------------------------
+
+
+def test_recheck_clears_transiently_stale_device(monkeypatch) -> None:
+    """A device whose first frame lands during the grace wait is not flagged."""
+    _patch_dialog_channel(monkeypatch)
+    claims: list = []
+    _patch_claim(monkeypatch, claims)
+    session = _FakeSession(last_acq={"U_Cam2": None})
+    scanner = _make_scanner(
+        session,
+        {
+            "U_Ref": {"synchronous": True, "variable_list": ["Sig"]},
+            "U_Cam2": {"synchronous": True, "variable_list": ["Val"]},
+        },
+    )
+    events: list = []
+    scanner._on_event = events.append
+
+    original_sleep = bluesky_scanner.time.sleep
+
+    def frame_arrives_during_grace(seconds: float) -> None:
+        for det in scanner._detectors:
+            if det._geecs_device_name == "U_Cam2":
+                det._last_acq = _fresh()
+        original_sleep(0)
+
+    monkeypatch.setattr(bluesky_scanner, "_STALE_RECHECK_WAIT_S", 0.01)
+    monkeypatch.setattr(bluesky_scanner.time, "sleep", frame_arrives_during_grace)
+
+    scanner._execute_scan(_noscan_config(), motor=None, positions=[None])
+
+    assert not any(isinstance(e, _FakeDialogEvent) for e in events)
+    assert session.scan_kwargs is not None
+    assert len(session.scan_kwargs["detectors"]) == 2

--- a/GeecsBluesky/tests/test_bluesky_scanner_progress_and_preflight.py
+++ b/GeecsBluesky/tests/test_bluesky_scanner_progress_and_preflight.py
@@ -1,23 +1,28 @@
-"""Tests for BlueskyScanner GUI progress events and the free-run pre-flight.
+"""Tests for BlueskyScanner GUI progress events and the pre-flight checks.
 
 Item 1 — ``ScanStepEvent`` emission: every Bluesky event document emits a
 shot-level progress event through ``on_event`` (same channel and thread
 semantics as the lifecycle events), clamped at ``total_shots`` so the free-run
 tail-flush overcount stays cosmetic.
 
-Item 2 — dead-contributor pre-flight (free-run mode only): before the scan
-folder is claimed, synchronous devices whose persistent-monitor cache
-(``_last_acq``) is missing or stale raise an operator dialog through the
-legacy ``ScanDialogEvent``/``DialogRequest`` channel.  Outcomes: drop stale
-contributors and continue, abort pre-claim, abort-only for a stale reference,
-trigger-off wording when everything is stale, and today's proceed-and-fail-
-loudly default when headless or unanswered.
+Item 2 — pre-flight liveness (both modes) + free-run staleness: before the
+scan folder is claimed, every synchronous device's gateway ``CONNECTED`` PV
+(``connected_status``) is read — a device reporting Disconnected raises an
+operator dialog through the legacy ``ScanDialogEvent``/``DialogRequest``
+channel (drop-and-continue vs abort; abort-only for a disconnected free-run
+reference; fail-open when the PV is unreadable).  In free-run mode a second
+stage checks ``acq_timestamp`` freshness for the trigger-must-be-free-running
+requirement: all CONNECTED but all stale → the trigger-off dialog; the
+residual CONNECTED-but-stale contributor keeps the drop dialog.  Strict runs
+the liveness stage only (frames are not needed pre-scan).  Headless /
+unanswered → today's proceed-and-fail-loudly default.
 
 See ``Planning/gui_stewardship/00_overview.md`` §4–5.
 """
 
 from __future__ import annotations
 
+import asyncio
 import threading
 import time
 from dataclasses import dataclass, field
@@ -61,13 +66,36 @@ class _FakeDialogRequest:
     abort: list[bool] = field(default_factory=lambda: [False])
 
 
-class _FakeSyncDevice:
-    """Sync device fake: carries the persistent-monitor cache ``_last_acq``."""
+class _FakeConnectedSignal:
+    """Stands in for the ``connected_status`` ``epics_signal_r`` (str read).
 
-    def __init__(self, device: str, name: str, last_acq: float | None) -> None:
+    ``value`` may be an Exception instance to simulate an unreadable
+    ``CONNECTED`` PV (old gateway without status PVs → fail-open).
+    """
+
+    def __init__(self, value: str | Exception = "Connected") -> None:
+        self.value = value
+
+    async def get_value(self) -> str:
+        if isinstance(self.value, Exception):
+            raise self.value
+        return self.value
+
+
+class _FakeSyncDevice:
+    """Sync device fake: ``_last_acq`` cache + gateway ``connected_status``."""
+
+    def __init__(
+        self,
+        device: str,
+        name: str,
+        last_acq: float | None,
+        connected: str | Exception = "Connected",
+    ) -> None:
         self.name = name  # ophyd (safe) name
         self._geecs_device_name = device
         self._last_acq = last_acq
+        self.connected_status = _FakeConnectedSignal(connected)
 
     def trigger(self) -> None:  # reference-capable, like CaGenericDetector
         raise NotImplementedError("not exercised by these tests")
@@ -94,10 +122,19 @@ def _stale() -> float:
 
 
 class _FakeSession:
-    """Session fake whose factories attach per-device ``_last_acq`` caches."""
+    """Session fake whose factories attach ``_last_acq`` + ``connected_status``.
 
-    def __init__(self, last_acq: dict[str, float | None] | None = None) -> None:
+    ``connected`` maps device name → ``CONNECTED`` reading: ``"Connected"``
+    (default), ``"Disconnected"``, or an Exception for an unreadable PV.
+    """
+
+    def __init__(
+        self,
+        last_acq: dict[str, float | None] | None = None,
+        connected: dict[str, str | Exception] | None = None,
+    ) -> None:
         self._last_acq = last_acq or {}
+        self._connected = connected or {}
         self.scan_kwargs: dict | None = None
 
     def _cache_for(self, device: str) -> float | None:
@@ -105,11 +142,18 @@ class _FakeSession:
             return self._last_acq[device]
         return _fresh()
 
+    def _connected_for(self, device: str) -> str | Exception:
+        return self._connected.get(device, "Connected")
+
     def detector(self, device, variables, *, save_images=False, name=None):
-        return _FakeSyncDevice(device, name or device, self._cache_for(device))
+        return _FakeSyncDevice(
+            device, name or device, self._cache_for(device), self._connected_for(device)
+        )
 
     def contributor(self, device, variables, *, save_images=False, name=None):
-        return _FakeSyncDevice(device, name or device, self._cache_for(device))
+        return _FakeSyncDevice(
+            device, name or device, self._cache_for(device), self._connected_for(device)
+        )
 
     def snapshot(self, device, variables, *, name=None):
         return _FakeSnapshotDevice(device, name or device)
@@ -120,6 +164,20 @@ class _FakeSession:
     def scan(self, **kwargs):
         self.scan_kwargs = kwargs
         return "uid"
+
+
+# The liveness read dispatches the signal coroutine to the RE loop via
+# run_coroutine_threadsafe (the scanner's connect/disconnect pattern), so the
+# fake RE needs a real event loop running in a background thread.
+_LOOP: asyncio.AbstractEventLoop | None = None
+
+
+def _bg_loop() -> asyncio.AbstractEventLoop:
+    global _LOOP
+    if _LOOP is None:
+        _LOOP = asyncio.new_event_loop()
+        threading.Thread(target=_LOOP.run_forever, daemon=True).start()
+    return _LOOP
 
 
 def _make_scanner(
@@ -145,7 +203,7 @@ def _make_scanner(
     scanner._abort_requested = False
     scanner._optimization_loader = None
     scanner._RE = SimpleNamespace(
-        state="idle", abort=lambda reason=None: None, _loop=None
+        state="idle", abort=lambda reason=None: None, _loop=_bg_loop()
     )
     return scanner
 
@@ -276,16 +334,16 @@ def test_progress_survives_raising_callback(monkeypatch) -> None:
 
 
 # ---------------------------------------------------------------------------
-# Item 2 — free-run pre-flight: fresh devices are untouched
+# Item 2 — pre-flight liveness: connected + fresh devices are untouched
 # ---------------------------------------------------------------------------
 
 
 def test_fresh_devices_no_dialog_no_behavior_change(monkeypatch) -> None:
-    """All sync devices fresh → no dialog, scan proceeds with every device."""
+    """All sync devices CONNECTED and fresh → no dialog, every device kept."""
     _patch_dialog_channel(monkeypatch)
     claims: list = []
     _patch_claim(monkeypatch, claims)
-    session = _FakeSession()  # every device defaults to a fresh cache
+    session = _FakeSession()  # every device defaults to Connected + fresh
     scanner = _make_scanner(
         session,
         {
@@ -309,44 +367,70 @@ def test_fresh_devices_no_dialog_no_behavior_change(monkeypatch) -> None:
     assert claims == ["TestExp"]
 
 
-def test_strict_all_stale_proceeds_silently(monkeypatch) -> None:
-    """Strict + ALL sync devices stale → no dialog, proceed.
+# ---------------------------------------------------------------------------
+# Item 2 — liveness: a DISCONNECTED device raises the dialog in either mode
+# ---------------------------------------------------------------------------
 
-    All-stale is a legitimate strict-mode pre-scan state: the trigger can sit
-    OFF before a strict scan (ARMED starts it), leaving every cache stale.
-    Only differential staleness is diagnostic there.
+
+def test_disconnected_contributor_free_run_drop_removes_and_disconnects(
+    monkeypatch,
+) -> None:
+    """Free-run + gateway says a contributor is down → drop dialog, pre-claim.
+
+    The device's frames may even be recent (a just-crashed device) — the
+    CONNECTED PV alone is authoritative, so the dialog fires regardless of
+    the staleness heuristic.
     """
     _patch_dialog_channel(monkeypatch)
     claims: list = []
     _patch_claim(monkeypatch, claims)
-    session = _FakeSession(last_acq={"U_Cam": None})
+    session = _FakeSession(connected={"U_Cam2": "Disconnected"})
     scanner = _make_scanner(
         session,
-        {"U_Cam": {"synchronous": True, "variable_list": ["Sig"]}},
-        mode="strict_shot_control",
+        {
+            "U_Ref": {"synchronous": True, "variable_list": ["Sig"]},
+            "U_Cam2": {"synchronous": True, "variable_list": ["Val"]},
+            "U_Stage": {"synchronous": False, "variable_list": ["Pos"]},
+        },
     )
-    scanner._shot_control = object()
+    disconnected: list[str] = []
+    scanner._disconnect_device = lambda dev: disconnected.append(dev._geecs_device_name)
     events: list = []
-    scanner._on_event = events.append
+    answers: dict = {}
+    scanner._on_event = _dialog_consumer(events, claims, answers, abort=False)
 
     scanner._execute_scan(_noscan_config(), motor=None, positions=[None])
 
-    assert not any(isinstance(e, _FakeDialogEvent) for e in events)
+    # Nothing was claimed before the operator was asked.
+    assert answers["claims_at_dialog"] == []
+    request = answers["request"]
+    assert "U_Cam2" in str(request.exc)
+    assert "DISCONNECTED" in str(request.exc)  # liveness, not staleness, wording
+    assert "stale" not in str(request.exc).lower()
+    assert "drop" in request.continue_label.lower()
+    # The dead device was disconnected and removed; the scan proceeded.
+    assert disconnected == ["U_Cam2"]
     assert session.scan_kwargs is not None
+    assert [d._geecs_device_name for d in session.scan_kwargs["detectors"]] == [
+        "U_Ref",
+        "U_Stage",
+    ]
+    assert [d._geecs_device_name for d in scanner._detectors] == ["U_Ref", "U_Stage"]
+    assert claims == ["TestExp"]
 
 
-def test_strict_differential_stale_raises_drop_dialog(monkeypatch) -> None:
-    """Strict + one stale among fresh devices → drop dialog, device removed.
+def test_disconnected_device_strict_drop_works(monkeypatch) -> None:
+    """Strict + gateway says a device is down → same drop dialog, pre-claim.
 
-    Live-observed 2026-07-07 (Scan006): a camera that was simply OFF ran a
-    strict scan into 3 wasted refires and a post-claim abort. Differential
-    staleness (some fresh, some stale) can only mean genuinely dead devices,
-    so strict mode now gets the same pre-claim dialog as free-run.
+    Live motivation (2026-07-07, Scan006): an OFF camera's data PVs still
+    CA-connected fine (the gateway serves everything in the DB), so the scan
+    ran into 3 wasted refires and a post-claim abort.  The CONNECTED PV now
+    catches it before the claim, mode-independently.
     """
     _patch_dialog_channel(monkeypatch)
     claims: list = []
     _patch_claim(monkeypatch, claims)
-    session = _FakeSession(last_acq={"U_Cam2": _stale()})
+    session = _FakeSession(connected={"U_Cam2": "Disconnected"})
     scanner = _make_scanner(
         session,
         {
@@ -358,23 +442,23 @@ def test_strict_differential_stale_raises_drop_dialog(monkeypatch) -> None:
     scanner._shot_control = object()
     answers: dict = {}
     events: list = []
-    consumer = _dialog_consumer(events, claims, answers, abort=False)
-    scanner._on_event = consumer
+    scanner._on_event = _dialog_consumer(events, claims, answers, abort=False)
 
     scanner._execute_scan(_noscan_config(), motor=None, positions=[None])
 
     assert answers["claims_at_dialog"] == []  # asked before any claim
+    assert "DISCONNECTED" in str(answers["request"].exc)
     assert session.scan_kwargs is not None
     names = [d._geecs_device_name for d in session.scan_kwargs["detectors"]]
-    assert names == ["U_Cam1"]  # stale device dropped
+    assert names == ["U_Cam1"]  # dead device dropped
 
 
-def test_strict_differential_stale_abort_is_pre_claim(monkeypatch) -> None:
-    """Strict differential staleness + operator abort → nothing claimed."""
+def test_disconnected_device_strict_abort_is_pre_claim(monkeypatch) -> None:
+    """Strict + disconnected device + operator abort → nothing claimed."""
     _patch_dialog_channel(monkeypatch)
     claims: list = []
     _patch_claim(monkeypatch, claims)
-    session = _FakeSession(last_acq={"U_Cam2": _stale()})
+    session = _FakeSession(connected={"U_Cam2": "Disconnected"})
     scanner = _make_scanner(
         session,
         {
@@ -395,13 +479,184 @@ def test_strict_differential_stale_abort_is_pre_claim(monkeypatch) -> None:
     assert scanner._abort_requested
 
 
+def test_disconnected_reference_free_run_is_abort_only(monkeypatch) -> None:
+    """A DISCONNECTED pacemaker offers abort vs clearly-labeled try-anyway."""
+    _patch_dialog_channel(monkeypatch)
+    monkeypatch.setattr(bluesky_scanner, "ScanState", None)
+    claims: list = []
+    _patch_claim(monkeypatch, claims)
+    session = _FakeSession(connected={"U_Ref": "Disconnected"})
+    scanner = _make_scanner(
+        session,
+        {
+            "U_Ref": {"synchronous": True, "variable_list": ["Sig"]},
+            "U_Cam2": {"synchronous": True, "variable_list": ["Val"]},
+        },
+    )
+    events: list = []
+    answers: dict = {}
+    scanner._on_event = _dialog_consumer(events, claims, answers, abort=True)
+
+    scanner._run_scan(_noscan_config())
+
+    request = answers["request"]
+    assert "reference" in str(request.exc).lower()
+    assert "U_Ref" in str(request.exc)
+    assert "DISCONNECTED" in str(request.exc)
+    # No drop offer — the second option is a clearly-labeled try-anyway.
+    assert "anyway" in request.continue_label.lower()
+    assert claims == []
+    assert scanner.current_state == "aborted"
+
+
 # ---------------------------------------------------------------------------
-# Item 2 — stale contributor: drop-and-continue / abort
+# Item 2 — liveness fail-open: an unreadable CONNECTED PV never blocks a scan
 # ---------------------------------------------------------------------------
 
 
-def test_stale_contributor_drop_removes_and_disconnects(monkeypatch) -> None:
-    """Operator answers drop → device disconnected, removed, scan proceeds."""
+def test_connected_unreadable_fails_open(monkeypatch) -> None:
+    """CONNECTED read raising (old gateway) → no dialog, no crash, proceed."""
+    _patch_dialog_channel(monkeypatch)
+    claims: list = []
+    _patch_claim(monkeypatch, claims)
+    session = _FakeSession(
+        connected={
+            "U_Ref": RuntimeError("no CONNECTED PV on this gateway"),
+            "U_Cam2": RuntimeError("no CONNECTED PV on this gateway"),
+        }
+    )
+    scanner = _make_scanner(
+        session,
+        {
+            "U_Ref": {"synchronous": True, "variable_list": ["Sig"]},
+            "U_Cam2": {"synchronous": True, "variable_list": ["Val"]},
+        },
+    )
+    events: list = []
+    scanner._on_event = events.append
+
+    scanner._execute_scan(_noscan_config(), motor=None, positions=[None])
+
+    assert not any(isinstance(e, _FakeDialogEvent) for e in events)
+    assert session.scan_kwargs is not None
+    assert len(session.scan_kwargs["detectors"]) == 2
+    assert claims == ["TestExp"]
+
+
+def test_connected_read_timeout_fails_open(monkeypatch) -> None:
+    """A hanging CONNECTED read (dead IOC link) times out and reads as live."""
+    _patch_dialog_channel(monkeypatch)
+    monkeypatch.setattr(bluesky_scanner, "_LIVENESS_READ_TIMEOUT_S", 0.05)
+    claims: list = []
+    _patch_claim(monkeypatch, claims)
+
+    class _HangingSignal:
+        async def get_value(self) -> str:
+            await asyncio.sleep(30.0)
+            return "Connected"
+
+    session = _FakeSession()
+    scanner = _make_scanner(
+        session,
+        {"U_Ref": {"synchronous": True, "variable_list": ["Sig"]}},
+    )
+    events: list = []
+    scanner._on_event = events.append
+
+    original_detector = session.detector
+
+    def hanging_detector(device, variables, **kwargs):
+        det = original_detector(device, variables, **kwargs)
+        det.connected_status = _HangingSignal()
+        return det
+
+    session.detector = hanging_detector
+
+    scanner._execute_scan(_noscan_config(), motor=None, positions=[None])
+
+    assert not any(isinstance(e, _FakeDialogEvent) for e in events)
+    assert session.scan_kwargs is not None
+    assert claims == ["TestExp"]
+
+
+# ---------------------------------------------------------------------------
+# Item 2 — strict mode is liveness-only: staleness never dialogs there
+# ---------------------------------------------------------------------------
+
+
+def test_strict_all_stale_proceeds_silently(monkeypatch) -> None:
+    """Strict + all CONNECTED + ALL frames stale → no dialog, proceed.
+
+    Frames are not needed before a strict scan: the trigger legitimately
+    sits OFF (ARMED starts it), leaving every cache stale.  CONNECTED said
+    the devices are live, and that is the whole strict pre-flight.
+    """
+    _patch_dialog_channel(monkeypatch)
+    claims: list = []
+    _patch_claim(monkeypatch, claims)
+    session = _FakeSession(last_acq={"U_Cam": None})
+    scanner = _make_scanner(
+        session,
+        {"U_Cam": {"synchronous": True, "variable_list": ["Sig"]}},
+        mode="strict_shot_control",
+    )
+    scanner._shot_control = object()
+    events: list = []
+    scanner._on_event = events.append
+
+    scanner._execute_scan(_noscan_config(), motor=None, positions=[None])
+
+    assert not any(isinstance(e, _FakeDialogEvent) for e in events)
+    assert session.scan_kwargs is not None
+
+
+def test_strict_differential_stale_proceeds_silently(monkeypatch) -> None:
+    """Strict + CONNECTED devices with mixed frame ages → no dialog.
+
+    The previous differential-staleness heuristic is gone: CONNECTED is the
+    authoritative liveness signal, so a connected-but-frameless device before
+    a strict scan (trigger off, camera armed late, …) is not diagnosable as
+    dead and must not dialog.
+    """
+    _patch_dialog_channel(monkeypatch)
+    claims: list = []
+    _patch_claim(monkeypatch, claims)
+    session = _FakeSession(last_acq={"U_Cam2": _stale()})
+    scanner = _make_scanner(
+        session,
+        {
+            "U_Cam1": {"synchronous": True, "variable_list": ["Sig"]},
+            "U_Cam2": {"synchronous": True, "variable_list": ["Val"]},
+        },
+        mode="strict_shot_control",
+    )
+    scanner._shot_control = object()
+    events: list = []
+    scanner._on_event = events.append
+
+    scanner._execute_scan(_noscan_config(), motor=None, positions=[None])
+
+    assert not any(isinstance(e, _FakeDialogEvent) for e in events)
+    assert session.scan_kwargs is not None
+    names = [d._geecs_device_name for d in session.scan_kwargs["detectors"]]
+    assert names == ["U_Cam1", "U_Cam2"]  # nothing dropped
+    assert claims == ["TestExp"]
+
+
+# ---------------------------------------------------------------------------
+# Item 2 — free-run residual case: CONNECTED-but-stale contributor
+# ---------------------------------------------------------------------------
+
+
+def test_stale_connected_contributor_keeps_drop_dialog(monkeypatch) -> None:
+    """CONNECTED contributor with no frames + fresh reference → drop dialog.
+
+    The residual staleness case: the fresh reference proves the trigger is
+    running, so a frameless-but-CONNECTED contributor is a per-device
+    acquisition problem (camera acquisition stopped while its TCP stream is
+    up) — the drop-or-abort dialog is kept for it, with not-acquiring (not
+    dead-device) wording.
+    """
     _patch_dialog_channel(monkeypatch)
     claims: list = []
     _patch_claim(monkeypatch, claims)
@@ -427,6 +682,7 @@ def test_stale_contributor_drop_removes_and_disconnects(monkeypatch) -> None:
     request = answers["request"]
     assert "U_Cam2" in str(request.exc)
     assert "s ago" in str(request.exc)  # says how stale
+    assert "CONNECTED" in str(request.exc)  # liveness already vouched for it
     assert request.continue_label is not None
     assert "drop" in request.continue_label.lower()
     # The stale device was disconnected and removed; the scan proceeded.
@@ -470,12 +726,12 @@ def test_stale_contributor_abort_is_pre_claim(monkeypatch) -> None:
 
 
 # ---------------------------------------------------------------------------
-# Item 2 — stale reference: abort-only v1
+# Item 2 — CONNECTED-but-stale reference: abort-only v1
 # ---------------------------------------------------------------------------
 
 
 def test_stale_reference_dialog_is_abort_only_v1(monkeypatch) -> None:
-    """A dead pacemaker offers abort (recommended) vs clearly-labeled retry."""
+    """A CONNECTED but frameless pacemaker offers abort vs labeled retry."""
     _patch_dialog_channel(monkeypatch)
     monkeypatch.setattr(bluesky_scanner, "ScanState", None)
     claims: list = []
@@ -535,7 +791,11 @@ def test_stale_reference_try_anyway_proceeds_with_full_list(monkeypatch) -> None
 
 
 def test_all_stale_dialog_blames_the_trigger(monkeypatch) -> None:
-    """When every sync device is stale, the message says trigger-off."""
+    """All CONNECTED but no fresh frames anywhere → trigger-off wording.
+
+    Now unambiguous: the liveness stage already confirmed every device's TCP
+    stream is up, so a total absence of frames can only be the trigger.
+    """
     _patch_dialog_channel(monkeypatch)
     monkeypatch.setattr(bluesky_scanner, "ScanState", None)
     claims: list = []
@@ -555,7 +815,8 @@ def test_all_stale_dialog_blames_the_trigger(monkeypatch) -> None:
     scanner._run_scan(_noscan_config())
 
     request = answers["request"]
-    assert "trigger may be off" in str(request.exc)
+    assert "trigger appears to be off" in str(request.exc)
+    assert "CONNECTED" in str(request.exc)
     assert claims == []
     assert scanner.current_state == "aborted"
 
@@ -565,12 +826,17 @@ def test_all_stale_dialog_blames_the_trigger(monkeypatch) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_headless_stale_contributor_proceeds_unchanged(monkeypatch) -> None:
-    """on_event=None → no dialog machinery, scan proceeds with all devices."""
+def test_headless_disconnected_device_proceeds_unchanged(monkeypatch) -> None:
+    """on_event=None → no dialog machinery, scan proceeds with all devices.
+
+    Even a device the gateway reports DISCONNECTED must not block a headless
+    scan — it proceeds and fails loudly downstream (t0 sync / device-down
+    abort in the plan).
+    """
     _patch_dialog_channel(monkeypatch)
     claims: list = []
     _patch_claim(monkeypatch, claims)
-    session = _FakeSession(last_acq={"U_Cam2": None})
+    session = _FakeSession(connected={"U_Cam2": "Disconnected"})
     scanner = _make_scanner(
         session,
         {
@@ -596,7 +862,7 @@ def test_unanswered_dialog_times_out_and_proceeds(monkeypatch) -> None:
     monkeypatch.setattr(bluesky_scanner, "_PREFLIGHT_DIALOG_TIMEOUT_S", 0.05)
     claims: list = []
     _patch_claim(monkeypatch, claims)
-    session = _FakeSession(last_acq={"U_Cam2": None})
+    session = _FakeSession(connected={"U_Cam2": "Disconnected"})
     scanner = _make_scanner(
         session,
         {

--- a/GeecsBluesky/tests/test_single_shot_plan.py
+++ b/GeecsBluesky/tests/test_single_shot_plan.py
@@ -17,6 +17,7 @@ from bluesky import RunEngine
 from bluesky.utils import FailedStatus
 
 from geecs_bluesky.exceptions import (
+    GeecsDeviceDownError,
     GeecsQuiescenceTimeoutError,
     GeecsTriggerTimeoutError,
 )
@@ -197,9 +198,12 @@ def _single_shot_run(devices, fire, **kwargs):
 
 
 def test_single_shot_refires_after_missed_frame(caplog) -> None:
-    """A no-frame first fire is retried; the second fire completes the row."""
+    """Timeout with the device CONNECTED per the gateway → refire recovers."""
     with _setup_scan() as (_motor, cam, RE, events):
         cam._trigger_timeout = 0.5  # keep the missed attempt fast
+        # Explicitly live per the gateway status PV: the refire gate must
+        # read this and keep today's bounded-refire behavior.
+        set_mock_value(cam.connected_status, "Connected")
         calls = {"fire": 0}
         state = {"t": 1000.0}
 
@@ -226,6 +230,37 @@ def test_single_shot_refires_after_missed_frame(caplog) -> None:
         msg = warnings[0].getMessage()
         assert "U_Combined" in msg  # names the device that produced no frame
         assert "attempt 1 of 3" in msg
+
+
+def test_single_shot_dead_device_fails_immediately_without_refire() -> None:
+    """Timeout + gateway says the device is DISCONNECTED → no refire, one fire.
+
+    A device that went down mid-scan is not a frame drop: re-firing burns
+    ~3 s attempts against hardware that cannot answer.  The refire gate reads
+    the frameless device's ``connected_status`` and raises immediately,
+    naming the device as down.
+    """
+    with _setup_scan() as (_motor, cam, RE, events):
+        cam._trigger_timeout = 0.5
+        set_mock_value(cam.connected_status, "Disconnected")
+        calls = {"fire": 0}
+
+        def dead_fire():
+            calls["fire"] += 1
+            yield from bps.null()  # device is down; nothing ever frames
+
+        with pytest.raises(GeecsDeviceDownError) as excinfo:
+            RE(_single_shot_run([cam], dead_fire, max_refires=2))
+
+        assert calls["fire"] == 1  # exactly one fire — refires were skipped
+        assert excinfo.value.device_name == "U_Combined"
+        msg = str(excinfo.value)
+        assert "U_Combined" in msg
+        assert "DISCONNECTED" in msg
+        assert "went down mid-scan" in msg
+        # The original no-frame FailedStatus rides on __cause__ for forensics.
+        assert isinstance(excinfo.value.__cause__, FailedStatus)
+        assert events == []  # a failed shot records nothing
 
 
 def test_single_shot_refire_exhaustion_propagates() -> None:

--- a/Planning/gui_stewardship/00_overview.md
+++ b/Planning/gui_stewardship/00_overview.md
@@ -203,56 +203,25 @@ in both cases without claiming a folder.
 | Scan-thread → Qt-main-thread bridge | `_scan_event_received` pyqtSignal → `_handle_scan_event` → `_on_dialog_event` → `show_device_error_dialog` | Exists **and already renders dialog events** on the legacy path |
 | `on_event` plumbed to BlueskyScanner | `RunControl` passes the same callback to both backends | Exists |
 
-### What is missing
+### Landed (2026-07-07 — GeecsBluesky 0.21.0, GUI 0.32.0)
 
-1. **BlueskyScanner never emits `ScanDialogEvent`** — `_set_state` emits
-   lifecycle events only. (It also imports the event types defensively, so
-   the addition is symmetric with existing code.)
-2. **A pre-flight staleness check** in `_execute_scan` between
-   `_build_session_devices()` and `claim_scan()`: read each contributor's
-   cached `acq_timestamp`, flag devices whose last shot is older than a
-   threshold (something like `max(3/rep_rate_hz, a few seconds)`; `None` =
-   never acquired = dead).
-3. **Dialog wording.** `show_device_error_dialog` renders any
-   `DialogRequest`, but its text is phrased for device-command errors
-   (Abort/Continue). "Continue" must clearly mean *"drop U_Cam4 and take
-   the scan without it"*. Either a `kind`/message field on the request or a
-   second small dialog function.
-4. **Actually dropping the device**: on "continue", remove the stale device
-   from the detector list (and disconnect it) before handing the list to
-   `GeecsSession.scan()`. In free-run mode, if the stale device is the
-   *reference* (pacemaker), the next sync device must be promoted — that is
-   the one genuinely subtle bit.
-
-### Smallest honest implementation
-
-In `BlueskyScanner` (all on the scan thread, before the RunEngine is
-involved, so a blocking `response_event.wait(timeout)` is safe):
-
-```
-detectors = self._build_session_devices()
-stale = self._find_stale_contributors(detectors)      # new, ~30 lines
-for dev in stale:
-    request = DialogRequest(exc=StaleContributorError(dev), context=...)
-    self._emit_dialog(request)                        # new: on_event(ScanDialogEvent(request))
-    if not request.response_event.wait(timeout=120) or request.abort[0]:
-        self._set_state("ABORTED"); return            # before claim_scan — no folder burned
-    detectors = drop_and_disconnect(detectors, dev)   # promote reference if needed
-scan_tag, scan_folder = claim_scan(...)               # unchanged
-```
-
-Headless (`GeecsSession` direct, tests, no `on_event`): no callback wired →
-auto-abort, same as `escalate_device_error` does today — fail-loud behavior
-is preserved as the default, the dialog is strictly an upgrade when a human
-is attached.
-
-**Effort class: small.** Roughly a day of focused work plus one lab session
-to tune the staleness threshold and verify the reference-promotion case. No
-new architecture — every channel it needs already exists and is tested on
-the legacy path. The two design decisions worth thinking about first: the
-staleness threshold, and whether reference promotion in free-run mode is
-in-scope for v1 (a defensible v1: if the *reference* is dead, offer
-abort-only).
+`BlueskyScanner._preflight_check_free_run_freshness` runs in
+`_execute_scan`'s pre-claim seam (free-run mode only): each sync device's
+`_last_acq` cache is checked against a 10 s wall-clock threshold (`None` =
+never acquired; one ~2 s re-check grace for just-connected monitors), and
+stale devices raise a `DialogRequest`-in-`ScanDialogEvent` through the
+legacy channel. Stale contributors → drop-and-continue (disconnect + remove
+from the detector list) vs abort; stale *reference* → abort-only v1 (the
+second button is a clearly-labeled "Try Anyway" — promotion deferred);
+all-stale → the dialog blames the trigger ("may be off / not
+free-running"). Headless / no consumer / unanswered (30 s timeout) →
+today's fail-loud proceed is preserved. `DialogRequest` grew optional
+`title`/`continue_label`/`abort_label` fields so the dialog wording is
+owned by the request; `show_device_error_dialog` honors them
+(`_resolve_dialog_content`) and is otherwise unchanged. Pinned by
+`GeecsBluesky/tests/test_bluesky_scanner_progress_and_preflight.py` and
+`GEECS-Scanner-GUI/tests/app/test_gui_dialogs.py`. Still owed a lab
+session: tune the staleness threshold against real rep rates.
 
 ---
 
@@ -272,11 +241,13 @@ option: Block 7 is *done* — what remains is teaching `BlueskyScanner` to
 speak the full event vocabulary the GUI already consumes. And most of that
 is disproportionately cheap:
 
-- **Step/progress events:** `BlueskyScanner._on_document` already counts
-  event documents; emitting a `ScanStepEvent(shots_completed=...)` there is
-  a handful of lines and makes the progress bar work in Bluesky mode. This
-  is the best value-per-line change available in the whole package.
-- **Dialog events:** the §4 use case.
+- **Step/progress events: LANDED 2026-07-07** (GeecsBluesky 0.21.0) —
+  `_on_document` emits a shot-level `ScanStepEvent(phase="completed")` per
+  event document (clamped at `total_shots` against the free-run tail-flush
+  overcount; step index from `bin_number`), so the progress bar works in
+  Bluesky mode with zero GUI changes.
+- **Dialog events: LANDED 2026-07-07** — the §4 use case (see §4's
+  "Landed" section).
 - **`DeviceCommandEvent` translation:** probably *never* worth it — the
   GUI doesn't render them, and the GeecsBluesky CLAUDE.md already suspects
   they "may not need to be" translated. Skip unless something consumes them.
@@ -297,8 +268,9 @@ legacy path is deleted and if a second front-end consumer actually appears.
 Concretely, in order:
 
 1. Emit `ScanStepEvent` from `BlueskyScanner._on_document` (progress bar in
-   Bluesky mode). Tiny.
+   Bluesky mode). Tiny. **Landed 2026-07-07.**
 2. Implement the dead-contributor pre-flight dialog (§4). Small.
+   **Landed 2026-07-07.**
 3. Freeze the legacy engine: no further decomposition, no new event types,
    bug fixes only.
 4. Skip `DeviceCommandEvent` translation and any speculative GUI
@@ -341,9 +313,11 @@ Not done / for later:
 
 - `Planning/STATUS.md` needs no banner — it was already deleted (2026-05-28,
   PR #388); its fate is recorded in §2. Do not resurrect it.
-- Stale *docstrings* referencing the 200 ms timer remain in code (e.g.
-  `engine/dialog_request.py` module docstring, `ScanDialogEvent`'s
-  "In Block 7 ..." note). Docstrings are code; fix them in the next code PR
-  that touches those files, not in this docs branch.
+- Stale *docstrings* referencing the 200 ms timer remain in code
+  (`ScanDialogEvent`'s "In Block 7 ..." note; the
+  `engine/dialog_request.py` module docstring was fixed 2026-07-07 when
+  the pre-flight dialog work touched that file). Docstrings are code; fix
+  them in the next code PR that touches those files, not in this docs
+  branch.
 - Block 4's missing CI guard (engine tests in a Qt-less env) is a
   nice-to-have; add it opportunistically if CI is being touched anyway.

--- a/Planning/gui_stewardship/00_overview.md
+++ b/Planning/gui_stewardship/00_overview.md
@@ -205,23 +205,44 @@ in both cases without claiming a folder.
 
 ### Landed (2026-07-07 — GeecsBluesky 0.21.0, GUI 0.32.0)
 
-`BlueskyScanner._preflight_check_free_run_freshness` runs in
-`_execute_scan`'s pre-claim seam (free-run mode only): each sync device's
-`_last_acq` cache is checked against a 10 s wall-clock threshold (`None` =
-never acquired; one ~2 s re-check grace for just-connected monitors), and
-stale devices raise a `DialogRequest`-in-`ScanDialogEvent` through the
-legacy channel. Stale contributors → drop-and-continue (disconnect + remove
-from the detector list) vs abort; stale *reference* → abort-only v1 (the
-second button is a clearly-labeled "Try Anyway" — promotion deferred);
-all-stale → the dialog blames the trigger ("may be off / not
-free-running"). Headless / no consumer / unanswered (30 s timeout) →
-today's fail-loud proceed is preserved. `DialogRequest` grew optional
-`title`/`continue_label`/`abort_label` fields so the dialog wording is
-owned by the request; `show_device_error_dialog` honors them
-(`_resolve_dialog_content`) and is otherwise unchanged. Pinned by
-`GeecsBluesky/tests/test_bluesky_scanner_progress_and_preflight.py` and
-`GEECS-Scanner-GUI/tests/app/test_gui_dialogs.py`. Still owed a lab
-session: tune the staleness threshold against real rep rates.
+Liveness is **CONNECTED-based**, superseding the original staleness
+heuristic (maintainer decision 2026-07-07): the gateway serves a per-device
+`[Experiment:]Device:CONNECTED` status PV (enum Disconnected/Connected,
+MAJOR severity while the device's TCP stream is down —
+`GeecsCAGateway/PV_CONTRACT.md` §1/§5), and every CA sync device exposes it
+as a non-readable `connected_status` child (never in event rows or
+`describe()`). This closes the actual gap: the gateway serves every DB
+device's data PVs whether or not the device is up, so CA-connect success
+never detected a dead device.
+
+`BlueskyScanner._preflight_check_sync_liveness` runs in `_execute_scan`'s
+pre-claim seam, **both modes**: each sync device's `connected_status` is
+read from the scan thread (`run_coroutine_threadsafe` on the RE loop, 2 s
+budget, fail-open — an unreadable CONNECTED PV logs at DEBUG and reads as
+live, so an old gateway can never block a scan). DISCONNECTED devices raise
+a `DialogRequest`-in-`ScanDialogEvent` through the legacy channel:
+drop-and-continue (disconnect + remove from the detector list) vs abort; a
+disconnected free-run *reference* → abort-only v1 (the second button is a
+clearly-labeled "Try Anyway" — promotion deferred). Free-run then keeps the
+`acq_timestamp` staleness check (10 s threshold — only relevant here now;
+~2 s re-check grace) purely for the trigger-must-be-free-running
+requirement: all CONNECTED + all stale → "trigger appears to be off"
+(Start Anyway / Abort); the residual CONNECTED-but-stale contributor with a
+fresh reference keeps the drop dialog (the fresh reference proves the
+trigger runs — a per-device acquisition problem, not a trigger problem).
+Strict is liveness-only (frames are not needed pre-scan; the trigger may
+sit OFF until ARMED — the earlier differential-staleness inference is
+removed). Headless / no consumer / unanswered (30 s timeout) → today's
+fail-loud proceed is preserved. Mid-scan, `geecs_single_shot`'s bounded
+refire is gated on the same signal: a no-frame device reporting
+DISCONNECTED raises `GeecsDeviceDownError` immediately ("went down
+mid-scan — not a frame drop") instead of burning refires.
+`DialogRequest` grew optional `title`/`continue_label`/`abort_label` fields
+so the dialog wording is owned by the request; `show_device_error_dialog`
+honors them (`_resolve_dialog_content`) and is otherwise unchanged. Pinned
+by `GeecsBluesky/tests/test_bluesky_scanner_progress_and_preflight.py`,
+`GeecsBluesky/tests/test_single_shot_plan.py` (refire gating), and
+`GEECS-Scanner-GUI/tests/app/test_gui_dialogs.py`.
 
 ---
 


### PR DESCRIPTION
The two GUI items recommended by the stewardship assessment (`Planning/gui_stewardship/00_overview.md`), now landed.

## 1. Progress bar works in Bluesky mode (the audit's "best value-per-line change")

`BlueskyScanner._on_document` emits a shot-level `ScanStepEvent` per event document — `shots_completed` clamped at `total_shots` (absorbs the free-run tail-flush overcount), schema-v1 `bin_number` as `step_index`. The GUI's existing Block-7 handler consumes it as-is: **zero GUI changes for the bar**, both backends now speak the same event vocabulary. Optimization scans emit progress too. No `DeviceCommandEvent` (no consumer — deliberate).

## 2. Dead-contributor pre-flight dialog (free-run only)

At the pre-claim seam: any synchronous device whose `acq_timestamp` cache is >10 s stale (2 s re-check grace for fresh connects) raises an operator dialog through the **legacy `DialogRequest` channel** — same event bridge, same Qt rendering path, production-tested. Outcomes:

- Stale contributor(s): **Drop && Continue** (disconnected, removed, logged loudly) or **Abort** — pre-claim, no scan number burned.
- Stale **reference**: abort-only v1 (the second button is a clearly-labeled "Try Anyway" that preserves today's fail-loud t0-sync path; no reference promotion — deferred per the doc).
- **All** stale: the message blames the trigger ("may be off / not free-running"), not the cameras.
- Headless (`on_event=None`), geecs_scanner not importable, or dialog unanswered after 30 s: **proceed unchanged** — a scan can never hang on a dialog nobody will answer. `GeecsSession` untouched; dependency direction preserved via defensive imports.

`DialogRequest` gains optional `title`/`continue_label`/`abort_label` (legacy positional construction pinned byte-identical).

## Tests / versions

21 new tests (15 GeecsBluesky, 6 GUI incl. legacy-rendering pins). Suites: GeecsBluesky 226, Scanner-GUI 202 — green. GeecsBluesky 0.21.0, GEECS-Scanner-GUI 0.32.0. Stewardship doc updated to "landed"; stale docstrings fixed per its ledger.

Follow-up (lab): tune the 10 s staleness threshold; live-check the dialog by starting a free-run scan with one camera off — expect the dialog instead of the t0-sync abort observed 2026-07-06.

**Coordination note**: bumps GeecsBluesky — if the gateway-as-a-service branch also touches that package, whichever merges second needs the usual changelog reconcile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)