### PR TITLE
Planning: target-architecture vision (guiding star)

### DIFF
--- a/Planning/vision/00_target_architecture.md
+++ b/Planning/vision/00_target_architecture.md
@@ -222,6 +222,36 @@ the right abstraction — they survive. What changes:
   one-PV client, and "what state is the trigger in?" has one answer for every
   tool — instead of each client privately replaying a write-matrix.
 
+### 4.4b The four layers of scan setup
+
+"Setup" is not one thing; the design gives each kind its own home, from
+universal to specific (each layer extends the ones above it, and the
+resolver records everything applied, so provenance shows the full stack):
+
+1. **DB experiment table** — device-level baseline applied to *every* scan
+   (e.g. analysis→on at scan start, off at end). Deliberately inflexible:
+   it is the invariant, and — because Master Control reads the same table —
+   the layer that keeps device behavior identical whichever stack runs the
+   scan during the transition. Fits the "device facts live below the
+   configs" principle. (Open: whether the Python scanner honors it today or
+   it is MC-only; and the table's exact vocabulary — to be checked against
+   the live DB.)
+2. **ExperimentDefaults** — experiment-wide YAML defaults (default trigger
+   profile, standard setup/closeout actions), applied where a ScanRequest
+   is silent, always recorded.
+3. **SaveSet entry `setup`/`closeout`** — the device's traveling ritual:
+   selecting the element brings its preparation along (WedgeInsert is the
+   exemplar).
+4. **ScanRequest `actions`** — this specific scan's procedure, including
+   `per_step`.
+
+The old system's limitation — exactly one global "scan" behavior in the DB
+— becomes a feature in this picture: the base layer *should* be invariant;
+per-scan-type flexibility lives in the layers above. TriggerProfile is the
+sibling mechanism for the *synchronous* machine states (multi-device
+ordered writes per state; `htu-normal` / `htu-nogas`-style named profiles
+are the operator shortcuts).
+
 ### 4.5 ActionPlans (today: action library + setup/closeout)
 
 In a Bluesky world, an action sequence *is* a plan. The action YAML (steps of

--- a/Planning/vision/00_target_architecture.md
+++ b/Planning/vision/00_target_architecture.md
@@ -244,8 +244,16 @@ resolver records everything applied, so provenance shows the full stack):
    behaves as today. Precedence: DB row → entry override → actions.
    **Verified against the live DB (2026-07-07)**: the table is
    `expt_device_variable(expt_device_id, variablename, get, set,
-   defaultvalue, startvalue, endvalue)`. Consumption rule: honor rows with
-   `set='yes'` and non-empty start/end — that filter separates the real
+   defaultvalue, startvalue, endvalue)`. **Table precision matters — three
+   DB tables carry a `set` flag with different meanings**:
+   `devicetype_variable.set` is the *capability* ("writable at all"; the
+   gateway builds its `:SP` surface and PV metadata from it),
+   `variable.set` is the per-device-instance definition (MC territory), and
+   `expt_device_variable.set` is the per-experiment *scan-write policy*
+   ("the scan machinery writes this variable") — while
+   `expt_device_variable.get` is the monitoring policy the gateway's
+   subscription list uses. Consumption rule for this layer: honor rows with
+   `expt_device_variable.set='yes'` and non-empty start/end — that filter separates the real
    baseline (Undulator: 92 rows, `save on→off` / `Analysis on→on` with
    deliberate per-device exceptions) from bulk-filled defaults on get-only
    rows (450 noise rows). Two implementation rules: (a) variables the run

--- a/Planning/vision/00_target_architecture.md
+++ b/Planning/vision/00_target_architecture.md
@@ -138,12 +138,21 @@ Everything a client submits is one model. Presets are saved ScanRequests;
 MultiScanner is a queue of them (and maps naturally onto queueserver later);
 `ScanInfo` and run metadata are projections of it.
 
+Scans may have one axis or several: `axes` form an outer product (first axis
+outermost/slowest), each grid point is one bin, and the step plan grows
+N-motor support — a native Bluesky idiom, not a new plan type. Honest
+caveat: acquisition and the data model handle grids naturally, but
+**ScanAnalysis today assumes a single scan parameter** for binning and
+rendering — multi-dimensional *analysis* is its own future thread, not
+implied by this schema.
+
 ```yaml
 schema_version: 1
 mode: step            # step | noscan | optimize
-variable: jet_z       # name from ScanVariables (absent for noscan)
-positions: {start: 4.0, end: 6.0, step: 0.5}
-shots_per_step: 10
+axes:                 # one axis = classic 1-D scan; several = a grid
+  - {variable: jet_z, positions: {start: 4.0, end: 6.0, step: 0.5}}
+  # - {variable: jet_x, positions: {start: -1.0, end: 1.0, step: 0.5}}
+shots_per_step: 10    # per grid point; each grid point is one bin
 acquisition: free_run # free_run | strict
 save_set: undulator_baseline      # name of a SaveSet
 trigger_profile: htu_laser_off    # name of a TriggerProfile
@@ -265,7 +274,31 @@ Already pointed the right way; the vision just finishes the thought:
 - One `config.ini` for infrastructure addresses (DB, Tiled, `[epics]`);
   everything experiment-shaped lives in the configs repo as schemas.
 
-## 7. What this doc is not
+## 7. Documentation is a deliverable
+
+The operator manual is maintainable by one person only if it cannot drift:
+
+- **Plain language lives in the schemas.** Every model field carries an
+  operator-voiced `description`; every model docstring opens with an
+  operator paragraph. A CI test fails when a field lacks operator language —
+  documentation debt is structurally impossible in the schema layer.
+- **The reference regenerates from code** (`geecs_schemas.docgen` → Markdown
+  field tables + validated examples); GUI editors consume the same
+  descriptions as tooltips. One sentence, written once, appears in the
+  manual and under the operator's cursor.
+- **Narrative is hand-written and thin**: a "how the configs fit together"
+  overview, and per-milestone operating walkthroughs (the docs site's
+  headless-screenshot workflow covers GUI pages).
+- **Standing rule for the vision build: a milestone PR is not complete
+  without its manual pages**, exactly as with tests.
+
+Also on the configs themselves: the sidecar configs repo gains a
+validation hook (pre-commit/CI importing `geecs_schemas`) so a bad config
+fails at commit rather than at scan time, and anything still living
+machine-locally (`~/.local/share/geecs_scanner`) migrates into the repo so
+provisioning a control machine is clone + config.ini.
+
+## 8. What this doc is not
 
 - Not a schedule. Sequencing lives in the planning docs and is gated on
   evidence (parity checklist + production confidence before deletion;

--- a/Planning/vision/00_target_architecture.md
+++ b/Planning/vision/00_target_architecture.md
@@ -1,0 +1,272 @@
+# Target architecture — the guiding star
+
+Status: **vision document** (2026-07-07). This is what the system looks like
+when the EPICS/Bluesky commitment is complete — a direction to steer by, not
+a step-by-step plan. Nothing here is a promise or a schedule. When a design
+decision comes up, the question this doc answers is: *does the change move us
+toward or away from this picture?*
+
+The one-sentence thesis:
+
+> **GEECS devices are IOCs. Scans are plans. Configs are schemas. Front-ends
+> are clients.**
+
+Everything below is that sentence applied to each part of the system.
+
+---
+
+## 1. The layer cake
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│ FRONT-ENDS (replaceable clients)                                │
+│   Scanner GUI (thin: editors + run console)   Phoebus displays  │
+│   notebooks / scripts          (future: web console, qserver)   │
+├─────────────────────────────────────────────────────────────────┤
+│ ENGINE  (geecs_bluesky — one engine, no bridge)                 │
+│   GeecsSession = run discipline (numbering, paths, Tiled,       │
+│   shot control, roles) · plans (step/free-run/single-shot/      │
+│   optimize) · CA device family · typed event stream ·           │
+│   OperatorChannel (dialogs)                                     │
+├─────────────────────────────────────────────────────────────────┤
+│ SCHEMAS (versioned Pydantic models; YAML is just serialization) │
+│   ScanRequest · SaveSet · ScanVariables · TriggerProfile ·      │
+│   ActionPlan · Diagnostics/Groups · OptimizationSpec            │
+├─────────────────────────────────────────────────────────────────┤
+│ DATA   (Tiled catalog + NetApp files + event schema v1)         │
+│   runs in Tiled · native files joined by acq_timestamp          │
+│   (geecs_data_utils.native_files) · analysis results as         │
+│   derived Tiled runs · legacy s-files as an export              │
+├─────────────────────────────────────────────────────────────────┤
+│ ACCESS LAYER (GeecsCAGateway — the ONLY GEECS-protocol speaker) │
+│   caproto CA server · PV_CONTRACT.md is the API · CONNECTED     │
+│   liveness · :SP setpoints ride blocking sets · systemd service │
+│   → Archiver Appliance (curated PVs) · → image sidecar (view)   │
+├─────────────────────────────────────────────────────────────────┤
+│ GEECS (LabVIEW devices, MySQL device DB, native file saving)    │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+Two rules make the cake hold its shape:
+
+- **Nothing above the access layer speaks GEECS TCP/UDP.** If a feature needs
+  a new fact from a device, the gateway learns to serve it as a PV (or PV
+  metadata) and the contract documents it. This week's liveness work is the
+  template: the scanner didn't grow a TCP client to ask "are you alive?" —
+  it read the `CONNECTED` PV the gateway already served.
+- **Nothing below the front-ends imports a front-end.** The engine emits
+  typed events and asks questions through an injected channel; it never knows
+  whether a Qt dialog, a web page, or a log line answers.
+
+## 2. One engine, no bridge
+
+`BlueskyScanner` exists to serve two masters during the transition. In the
+target picture it dissolves:
+
+- **`GeecsSession` is the engine.** The GUI (or any client) builds a
+  `ScanRequest` (§4.1) and calls `session.run(request)`. What remains of the
+  scanner is a small `SessionRunner` utility — a thread, an abort flag, and
+  event fan-out; ~200 lines with no scan knowledge of its own.
+- **The event vocabulary moves down.** `ScanEvent`, `ScanStepEvent`,
+  `DialogRequest` etc. are engine concepts that today live in
+  `geecs_scanner` (a front-end package) for historical reasons, forcing the
+  engine to import its own vocabulary defensively. They move to the engine
+  (or a small neutral package); front-ends import them from below. The
+  try/except import dance disappears.
+- **Operator interaction is one seam.** Today's pre-flight dialogs, refire
+  policies, and future "are you sure" moments all flow through a single
+  injected `OperatorChannel`: `ask(question, options, default, timeout) →
+  answer`. The GUI binds it to Qt dialogs; headless binds it to
+  default-and-log; a web console binds it to a websocket. The engine never
+  contains dialog plumbing again — it contains *questions*.
+- **Pre-flight is a pipeline, not methods.** Liveness (CONNECTED), trigger
+  running (free-run), disk reachability, config sanity — declarative checks
+  that run before the claim, each yielding pass / ask-operator / abort. New
+  checks are additions to a list, not new branches in a 1500-line class.
+
+## 3. What the commitment deletes
+
+The deletion is the unlock, not just a cleanup. When the legacy engine goes:
+
+- `ScanManager`, `DataLogger`, `DeviceManager`, `ScanStepExecutor`,
+  `FileMover`, `TriggerController`, `DeviceCommandExecutor` and their tests —
+  the entire parallel engine.
+- **GEECS-PythonAPI retires.** Its device layer (TCP subscriptions,
+  `ScanDevice`) served the legacy engine; its DB layer already moved to the
+  gateway. What survives is only whatever config-ini reading hasn't already
+  migrated to `geecs_data_utils`.
+- The GUI's dual-backend seams (`RunControl`'s two constructors,
+  `GEECS_USE_BLUESKY`) — one engine, no toggle.
+- The event types' defensive imports, the bridge's duck-typed protocol
+  (`device_requirements`, `on_finish`, …) — replaced by declared interfaces
+  once there is exactly one consumer chain.
+
+**Gate, not date:** deletion happens when a written parity checklist is done
+(setup/closeout actions on the Bluesky path, background scan mode decision,
+MultiScanner/preset compatibility, ECS dump story) **and** some agreed period
+of routine production scanning never reached for the legacy toggle. Evidence-
+gated, like everything else this month.
+
+## 4. The schema redesign
+
+The current config landscape grew one YAML dialect at a time: save elements,
+scan devices + composite variables, timing configs, action library, presets,
+optimizer configs, diagnostics. The diagnostics/groups redesign (unified
+`image:`/`scan:` schema, Pydantic-validated, one loader) is the model for
+what the rest become. Principles:
+
+- **Pydantic-first.** Every config is a versioned model (`schema_version`)
+  in one home; YAML is serialization. Loaders validate on read; GUI editors
+  and scripts share the same models; migration converters live next to the
+  schema they migrate.
+- **Declare intent, derive mechanics.** Configs written for the legacy
+  engine encode *how* (force-appended variables, synchronous flags, per-state
+  write matrices). Bluesky-era configs declare *what*, and the engine derives
+  the rest — the auto-provisioning and role-classification work already
+  showed the derivations are computable.
+- **Device facts live below the configs.** Limits, units, tolerances, and
+  choices belong to the GEECS DB and should surface as **PV metadata from the
+  gateway** (EGU, DRVL/DRVH, enum strings — the CA-native way). Client YAML
+  then stops repeating facts the control system already knows, and Phoebus
+  gets them for free.
+
+### 4.1 ScanRequest — the one submission object
+
+Everything a client submits is one model. Presets are saved ScanRequests;
+MultiScanner is a queue of them (and maps naturally onto queueserver later);
+`ScanInfo` and run metadata are projections of it.
+
+```yaml
+schema_version: 1
+mode: step            # step | noscan | optimize
+variable: jet_z       # name from ScanVariables (absent for noscan)
+positions: {start: 4.0, end: 6.0, step: 0.5}
+shots_per_step: 10
+acquisition: free_run # free_run | strict
+save_set: undulator_baseline      # name of a SaveSet
+trigger_profile: htu_laser_off    # name of a TriggerProfile
+actions: {setup: [pre_scan_ebeam], closeout: []}   # named ActionPlans
+description: "jet z scan with probe"
+# optimize mode adds an optimization: block (VOCS, objective, generator)
+```
+
+### 4.2 SaveSet (today: save elements)
+
+A device entry declares what to record; roles and bookkeeping variables are
+derived (first sync device = free-run reference unless overridden;
+`acq_timestamp` is always implicit — the device layer already enforces this).
+
+```yaml
+# before (legacy save element)              # after (SaveSet entry)
+UC_Amp4_IR_input:                           - device: UC_Amp4_IR_input
+  synchronous: true                           images: true
+  save_nonscalar_data: true                   scalars: [MaxCounts, centroidx]
+  variable_list: [acq_timestamp,            - device: U_HP_Daq
+    MaxCounts, centroidx]                     scalars: [ch1]
+                                              role: snapshot   # only overrides
+```
+
+Device-name spelling is validated against the DB at load (the case-drift
+lesson, 2026-07-06), not at first CA timeout.
+
+### 4.3 ScanVariables (today: scan_devices.yaml + composite_variables.yaml)
+
+Scan variables become declared positioners rendered by a factory to
+`CaSettable` / `CaMotor` / `CaCompositeSettable` (the composite = a pseudo-
+positioner with forward/inverse expressions — same math as today's numexpr,
+now living where motion abstractions belong). Limits/units come from gateway
+PV metadata; YAML adds only what GEECS doesn't know:
+
+```yaml
+jet_z:
+  target: U_ESP_JetXYZ:Position.Axis 3
+  kind: motor            # blocking move + readback tolerance
+e_beam_energy:           # composite
+  kind: pseudo
+  targets: [U_EMQ1:Current, U_EMQ2:Current]
+  forward: "..."         # expressions, as today
+  inverse: "..."
+```
+
+### 4.4 TriggerProfile (today: timing/shot-control configs)
+
+The state *names* (OFF / STANDBY / SCAN / SINGLESHOT / ARMED) proved to be
+the right abstraction — they survive. What changes:
+
+- A profile is a validated model; the laser-on/off duality becomes explicit
+  **profile variants** (`armed: external` vs `armed: internal`) instead of
+  parallel look-alike YAML files.
+- **Trigger state becomes EPICS-visible**: the gateway (or a thin timing
+  helper on top of it) exposes a `TRIG:STATE` enum PV that applies a
+  profile's writes atomically. Then Phoebus shows and sets the machine
+  trigger state with a button, the engine's `ShotController` becomes a
+  one-PV client, and "what state is the trigger in?" has one answer for every
+  tool — instead of each client privately replaying a write-matrix.
+
+### 4.5 ActionPlans (today: action library + setup/closeout)
+
+In a Bluesky world, an action sequence *is* a plan. The action YAML (steps of
+set / wait / read-and-check) compiles to plan stubs executed by the same
+RunEngine — which means actions get abort, logging, event emission, refire-
+style policies, and OperatorChannel questions for free, instead of the
+legacy ActionManager's parallel executor. `setup:`/`closeout:` in a
+ScanRequest are just named ActionPlans run inside the scan plan's preamble/
+finalizer (the hook seams already exist in `orchestration.py`).
+
+### 4.6 Diagnostics, analysis, optimization
+
+Already pointed the right way; the vision just finishes the thought:
+
+- Diagnostics/groups stay as designed (they are the schema template).
+- Optimization stays "a scan with a suggester" (`optimize:` block in
+  ScanRequest); evaluator/analyzer wiring keeps flowing through the
+  diagnostics schema.
+- Analysis results land in Tiled as derived runs (the parked "analysis
+  artifacts in Tiled" design); `LiveTaskRunner` eventually subscribes to the
+  run catalog instead of watching s-files. s-files and legacy scalar exports
+  remain **exports**, produced for compatibility, never load-bearing.
+
+## 5. Front-ends in the target picture
+
+- **Scanner GUI thins to three jobs**: schema-driven editors (SaveSets,
+  ScanVariables, TriggerProfiles, ActionPlans — forms over Pydantic models),
+  a run console (event-stream consumer: progress, dialogs via
+  OperatorChannel, log tail), and submission (build a ScanRequest). No engine
+  logic. Whether it stays PyQt or ever becomes a web console is then a
+  low-stakes choice, because it's *replaceable*.
+- **Phoebus** owns synoptics, trigger state (§4.4), device health
+  (`CONNECTED` walls), and archived-PV browsing.
+- **Notebooks/scripts** use `GeecsSession` directly — already true today,
+  kept sacred: every feature must work headless first.
+- **queueserver** is the natural future home for MultiScanner-style queues
+  of ScanRequests; explicitly *not* current-phase work.
+
+## 6. Observability & ops (the surrounding envelope)
+
+- Gateway runs as a systemd service with smoke tests (landed 2026-07-07).
+- Archiver Appliance archives a curated PV subset (gateway health, device
+  CONNECTED, trigger state, key readbacks) — the Citadel replacement.
+- The image sidecar (NTNDArray live view) stays view-only; native GEECS
+  file saving remains the authoritative image path until proven otherwise.
+- One `config.ini` for infrastructure addresses (DB, Tiled, `[epics]`);
+  everything experiment-shaped lives in the configs repo as schemas.
+
+## 7. What this doc is not
+
+- Not a schedule. Sequencing lives in the planning docs and is gated on
+  evidence (parity checklist + production confidence before deletion;
+  deletion before schema redesign; schema redesign before GUI rebuild).
+- Not a rewrite plan. Every schema ships with a converter from the current
+  YAML; the diagnostics migration is the precedent for doing this without a
+  flag day.
+- Not finished thinking. Open questions worth keeping visible:
+  - Where exactly do the schema models live (`geecs_data_utils` vs a new
+    lean `geecs_schemas` package)? Data-utils is already accused of being
+    "scattered"; a schemas package may be the cleaner home.
+  - Does `TRIG:STATE` live in the gateway proper or a tiny timing IOC beside
+    it? (Gateway purism says it's a 1:1 GEECS mirror; pragmatism says one
+    enum PV is cheap. Decide when building it.)
+  - How much PV metadata (limits/units) can the gateway serve from the DB
+    without the DB schema itself becoming the bottleneck?
+  - ECS dumps and background scans: parity items or retired concepts? The
+    parity checklist must answer, not assume.

--- a/Planning/vision/00_target_architecture.md
+++ b/Planning/vision/00_target_architecture.md
@@ -242,9 +242,21 @@ resolver records everything applied, so provenance shows the full stack):
    `at_scan_start:` / `at_scan_end:` maps — a value overrides the DB's, an
    explicit null suppresses the write; MC keeps reading the raw table and
    behaves as today. Precedence: DB row → entry override → actions.
-   (Gated on inspecting the real table: whether the Python scanner honors
-   it today or it is MC-only, and its exact vocabulary — schema fields are
-   not guessed before the table is read.)
+   **Verified against the live DB (2026-07-07)**: the table is
+   `expt_device_variable(expt_device_id, variablename, get, set,
+   defaultvalue, startvalue, endvalue)`. Consumption rule: honor rows with
+   `set='yes'` and non-empty start/end — that filter separates the real
+   baseline (Undulator: 92 rows, `save on→off` / `Analysis on→on` with
+   deliberate per-device exceptions) from bulk-filled defaults on get-only
+   rows (450 noise rows). Two implementation rules: (a) variables the run
+   discipline already owns (`save`/`localsavingpath`) are SKIPPED — the
+   engine's native-saving machinery supersedes them; (b) the `Analysis on`
+   rows close a real Bluesky-path gap today — cameras with analysis off
+   push empty-string scalars (the `''` flood observed at gateway startup),
+   which MC scans never showed because this table fixed it at scan start.
+   Open MC-semantics question: rows applied to all enabled devices or only
+   scan participants (default: participants only; confirm against MC when
+   convenient).
 2. **ExperimentDefaults** — experiment-wide YAML defaults (default trigger
    profile, standard setup/closeout actions), applied where a ScanRequest
    is silent, always recorded.

--- a/Planning/vision/00_target_architecture.md
+++ b/Planning/vision/00_target_architecture.md
@@ -91,10 +91,12 @@ The deletion is the unlock, not just a cleanup. When the legacy engine goes:
 - `ScanManager`, `DataLogger`, `DeviceManager`, `ScanStepExecutor`,
   `FileMover`, `TriggerController`, `DeviceCommandExecutor` and their tests —
   the entire parallel engine.
-- **GEECS-PythonAPI retires.** Its device layer (TCP subscriptions,
-  `ScanDevice`) served the legacy engine; its DB layer already moved to the
-  gateway. What survives is only whatever config-ini reading hasn't already
-  migrated to `geecs_data_utils`.
+- **The scanner stack drops GEECS-PythonAPI.** The package itself stays —
+  it is a perfectly good standalone scripting toolkit that others use to
+  build small device scripts, and that use is welcome. The goal is only
+  that `geecs-scanner` (and the engine stack) no longer import it: its
+  device layer served the legacy engine, and its DB layer already moved to
+  the gateway. Post-deletion it is a sibling tool, not a dependency.
 - The GUI's dual-backend seams (`RunControl`'s two constructors,
   `GEECS_USE_BLUESKY`) — one engine, no toggle.
 - The event types' defensive imports, the bridge's duck-typed protocol
@@ -212,6 +214,18 @@ style policies, and OperatorChannel questions for free, instead of the
 legacy ActionManager's parallel executor. `setup:`/`closeout:` in a
 ScanRequest are just named ActionPlans run inside the scan plan's preamble/
 finalizer (the hook seams already exist in `orchestration.py`).
+
+**The acceptance test for this design** — "I want actions between each scan
+step": *not* a new plan type, *not* a new schema. `ScanRequest.actions`
+grows a `per_step:` slot (same ActionPlan type, same editor, same
+validation), and the step plan yields the compiled stubs at its existing
+step boundary — `per_step` customization is a native Bluesky idiom the plan
+machinery was designed for. Contrast the legacy answer to the same request
+(touch ScanStepExecutor, ActionManager, the config models, and the GUI —
+the "adding a scan mode touches six places" complaint). New capability
+must be composition — a hook plus a named plan — never a new dialect; when
+a feature seems to demand a new plan type, that is the smell to stop and
+re-check.
 
 ### 4.6 Diagnostics, analysis, optimization
 

--- a/Planning/vision/00_target_architecture.md
+++ b/Planning/vision/00_target_architecture.md
@@ -180,6 +180,45 @@ UC_Amp4_IR_input:                           - device: UC_Amp4_IR_input
 Device-name spelling is validated against the DB at load (the case-drift
 lesson, 2026-07-06), not at first CA timeout.
 
+### 4.2b The two-tier recording model
+
+"Required" and "recorded" are orthogonal axes, and both legacy systems
+collapsed them: MC subscribed everything (one dead device of 117 could
+stall or kill a scan — making "is everything on and error-free?" a
+cumbersome, usually unnecessary burden), while GEECS-Scanner went opt-in
+(scans became robust, but the background logging of everything else was
+lost). The access layer dissolves the dilemma:
+
+- **Tier 1 — Required (the SaveSet).** Opt-in and explicit, exactly as
+  GEECS-Scanner pioneered. These devices get every guarantee: pre-flight
+  liveness dialogs, role assignment, strict-mode row completeness, refire,
+  abort semantics. Images are only ever recorded here. Scalars default to
+  the DB's `get='yes'` list (`db_scalars: true`) with the explicit
+  `scalars` field as additive extras; converted legacy elements keep
+  `db_scalars: false` for exact behavioral fidelity.
+- **Tier 2 — Background telemetry (soft).** Every enabled experiment
+  device with `get='yes'` variables not in the SaveSet is recorded as
+  best-effort snapshot columns sampled from the gateway's monitor cache,
+  carrying their own `acq_timestamp` + validity for downstream alignment.
+  Read-only (no scan start/end writes — writes to dead devices block),
+  never waited on, dead devices dropped at scan start with one log line —
+  never a dialog, never an abort. Toggleable (`background_telemetry`,
+  default on).
+
+**Why this is safe now when it wasn't before**: legacy subscription meant
+per-scan TCP connections, so a dead device cost timeouts and stalls. Over
+the gateway, monitors run permanently — a dead device is just stale PVs
+with `CONNECTED=false`, and reading cached values costs zero wait.
+Background recording structurally cannot hurt a scan.
+
+The operator's one-hand rule: **required devices get guarantees;
+everything else is logged if alive.** Needing a device synchronous to
+shots is the *definition* of required — softness and synchronicity are
+mutually exclusive by design. A side effect: the DB's `get` flags return
+to being a slow-moving statement of standard telemetry, and per-scan
+intent lives entirely in version-controlled configs — no more editing DB
+entries to change a scan.
+
 ### 4.3 ScanVariables (today: scan_devices.yaml + composite_variables.yaml)
 
 Scan variables become declared positioners rendered by a factory to

--- a/Planning/vision/00_target_architecture.md
+++ b/Planning/vision/00_target_architecture.md
@@ -265,9 +265,13 @@ resolver records everything applied, so provenance shows the full stack):
    rows close a real Bluesky-path gap today — cameras with analysis off
    push empty-string scalars (the `''` flood observed at gateway startup),
    which MC scans never showed because this table fixed it at scan start.
-   Open MC-semantics question: rows applied to all enabled devices or only
-   scan participants (default: participants only; confirm against MC when
-   convenient).
+   **Decided (maintainer, 2026-07-07): rows apply to scan participants
+   only** (SaveSet devices and axis-target devices), never the whole
+   experiment. Schema surfaces: SaveSet entry `at_scan_start`/`at_scan_end`
+   override maps (null suppresses), opt-in `db_scalars` (record the
+   device's DB get='yes' telemetry without hand-listing), and an
+   experiment-wide `apply_db_scan_defaults` switch (default true = MC
+   parity).
 2. **ExperimentDefaults** — experiment-wide YAML defaults (default trigger
    profile, standard setup/closeout actions), applied where a ScanRequest
    is silent, always recorded.

--- a/Planning/vision/00_target_architecture.md
+++ b/Planning/vision/00_target_architecture.md
@@ -246,9 +246,12 @@ resolver records everything applied, so provenance shows the full stack):
    `expt_device_variable(expt_device_id, variablename, get, set,
    defaultvalue, startvalue, endvalue)`. **Table precision matters — three
    DB tables carry a `set` flag with different meanings**:
-   `devicetype_variable.set` is the *capability* ("writable at all"; the
-   gateway builds its `:SP` surface and PV metadata from it),
-   `variable.set` is the per-device-instance definition (MC territory), and
+   capability is an *inheritance chain* — `devicetype_variable` defines the
+   type default (settability, limits, units, tolerance) which every device
+   instance inherits unless overridden by a `variable` row (live DB: 1032
+   instance rows differ from type defaults, including settability flips);
+   the gateway must resolve the chain, not just the type table (known gap,
+   fix pending the whole-row-vs-field-by-field MC semantics answer) — and
    `expt_device_variable.set` is the per-experiment *scan-write policy*
    ("the scan machinery writes this variable") — while
    `expt_device_variable.get` is the monitoring policy the gateway's

--- a/Planning/vision/00_target_architecture.md
+++ b/Planning/vision/00_target_architecture.md
@@ -375,6 +375,21 @@ Two recurring cases with standard EPICS answers our stack is shaped for
   with alarm limits living on the physical quantity. A deliberate, small
   dent in the gateway's 1:1-mirror purity, same category as `TRIG:STATE`;
   40 years of calc-record precedent says this belongs in the IOC layer.
+  Placement when built: the `DerivedChannel` model joins `geecs_schemas`
+  (the vocabulary package sits at the bottom of the import graph; the
+  gateway gaining that one pydantic-only dep is a deliberate, ratify-then
+  layering change) so derived channels get operator descriptions, docgen,
+  and the no-drift guard like every other config. Coherence rules:
+  **same-device multi-input calcs are frame-coherent** (computed once per
+  pushed frame under the existing ordering guarantee — rigorous);
+  **cross-device calcs are latest-value semantics** (the honest EPICS calc
+  answer — fine for slow/ambient quantities, guarded by a declared
+  staleness window that drives the PV to INVALID severity rather than
+  serving mixed-epoch numbers); **shot-synchronized combinations are
+  analysis, not derived channels** — if the inputs need a shot in common,
+  that is what the event rows' shot-id alignment machinery is for,
+  downstream. The shutter `kind` likewise joins the ScanVariables catalog
+  at its milestone (the designed kind-extension point).
 - **Two-state positioners with limit feedback (shutters).** Solenoid
   command + inserted/removed switches = the discrete cousin of `CaMotor`:
   a small `CaShutter` whose `set()` completes when the corresponding limit

--- a/Planning/vision/00_target_architecture.md
+++ b/Planning/vision/00_target_architecture.md
@@ -362,6 +362,29 @@ Already pointed the right way; the vision just finishes the thought:
   run catalog instead of watching s-files. s-files and legacy scalar exports
   remain **exports**, produced for compatibility, never load-bearing.
 
+### 4.7 Device-intelligence patterns (future, named so they're ready)
+
+Two recurring cases with standard EPICS answers our stack is shaped for
+(neither is current-phase work):
+
+- **Derived channels (the calc-record equivalent).** Config-driven derived
+  readbacks evaluated in the gateway's fan-out: a YAML declaration (name,
+  input variables, expression, units) serves e.g. a Convectron gauge's
+  pressure computed from its raw voltage — one formula, versioned in the
+  configs repo, visible to every consumer (scan rows, Phoebus, archiver),
+  with alarm limits living on the physical quantity. A deliberate, small
+  dent in the gateway's 1:1-mirror purity, same category as `TRIG:STATE`;
+  40 years of calc-record precedent says this belongs in the IOC layer.
+- **Two-state positioners with limit feedback (shutters).** Solenoid
+  command + inserted/removed switches = the discrete cousin of `CaMotor`:
+  a small `CaShutter` whose `set()` completes when the corresponding limit
+  switch confirms (timeout names the missing switch; both-true or
+  neither = loud fault). Optionally a gateway-derived state enum
+  (Inserted/Removed/Moving/Fault) for displays and the archiver. Payoff
+  already visible in the corpus: legacy shutter actions use blind
+  `wait: 3.0` steps — limit-confirmed completion makes them event-driven
+  and turns a jammed shutter from silently-absorbed into an honest error.
+
 ## 5. Front-ends in the target picture
 
 - **Scanner GUI thins to three jobs**: schema-driven editors (SaveSets,

--- a/Planning/vision/00_target_architecture.md
+++ b/Planning/vision/00_target_architecture.md
@@ -199,6 +199,14 @@ e_beam_energy:           # composite
   inverse: "..."
 ```
 
+Configs speak **GEECS device/variable names, never PV names** — the domain
+identity that the DB validates, MC displays, and filenames carry. The PV
+encoding (`[Experiment:]Device:Variable`, `:SP`) is derived in exactly one
+place (the gateway's naming module / `ca_pv()`), inside the device
+factories; nothing above them sees a PV string. Named extension point: if a
+non-GEECS EPICS device ever joins, a ScanVariables entry grows an optional
+`pv:` escape hatch — an additive field, not a redesign.
+
 ### 4.4 TriggerProfile (today: timing/shot-control configs)
 
 The state *names* (OFF / STANDBY / SCAN / SINGLESHOT / ARMED) proved to be

--- a/Planning/vision/00_target_architecture.md
+++ b/Planning/vision/00_target_architecture.md
@@ -233,9 +233,18 @@ resolver records everything applied, so provenance shows the full stack):
    it is the invariant, and — because Master Control reads the same table —
    the layer that keeps device behavior identical whichever stack runs the
    scan during the transition. Fits the "device facts live below the
-   configs" principle. (Open: whether the Python scanner honors it today or
-   it is MC-only; and the table's exact vocabulary — to be checked against
-   the live DB.)
+   configs" principle. Surfacing: through the access layer's *library* half
+   (`GeecsDb`) — the ConfigResolver queries each SaveSet device's
+   scan-start/end rows and synthesizes them as layer-1 setup/closeout
+   writes, provenance-recorded; not live data, so no PVs needed (a
+   read-only info PV for Phoebus display is separable, later).
+   Overridable without touching MC: SaveSet entries grow optional
+   `at_scan_start:` / `at_scan_end:` maps — a value overrides the DB's, an
+   explicit null suppresses the write; MC keeps reading the raw table and
+   behaves as today. Precedence: DB row → entry override → actions.
+   (Gated on inspecting the real table: whether the Python scanner honors
+   it today or it is MC-only, and its exact vocabulary — schema fields are
+   not guessed before the table is read.)
 2. **ExperimentDefaults** — experiment-wide YAML defaults (default trigger
    profile, standard setup/closeout actions), applied where a ScanRequest
    is silent, always recorded.


### PR DESCRIPTION
The 'future directions / vision' document requested after the 2026-07-06/07 sprint: what the ideal, clean organization of our functionality looks like once the EPICS/Bluesky commitment is complete. A guiding star for design decisions — explicitly not a schedule or step-by-step plan.

Covers: the layer cake and its two load-bearing rules; one-engine-no-bridge (BlueskyScanner dissolves into GeecsSession + a thin SessionRunner; event types move down; OperatorChannel as the single dialog seam; pre-flight as a declarative pipeline); what legacy deletion removes (including GEECS-PythonAPI retirement); and the schema redesign — ScanRequest, SaveSet, ScanVariables, TriggerProfile (with trigger state as an EPICS-visible enum PV), ActionPlans-as-plans — with before/after YAML sketches and the principle set (Pydantic-first, declare intent / derive mechanics, device facts live below the configs as PV metadata). Ends with the evidence gates and honest open questions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)