### PR TITLE
Gateway capability-chain fix + PV_CONTRACT set-flag precision

### DIFF
--- a/GeecsCAGateway/CHANGELOG.md
+++ b/GeecsCAGateway/CHANGELOG.md
@@ -3,6 +3,29 @@
 All notable changes to `geecs-ca-gateway` are documented here, following
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and semantic versioning.
 
+## [0.6.1] - 2026-07-07
+
+### Fixed
+
+- **Variable capability/metadata now resolves the full GEECS inheritance
+  chain** instead of reading `devicetype_variable` alone. Per the
+  maintainer-confirmed semantics, a per-instance row in the `variable` table
+  (linked via `variable.devicetype_variable_id`) replaces its type row
+  **wholesale** — settability, name, units, limits, tolerance, choices all
+  come from the instance row, with no field-level fallback (instance NULL
+  limits mean *no* limits). Live-DB evidence for the gap: 1032 instance rows
+  differed from their type defaults, including settability flips — instance-
+  settable variables were served without their `:SP` PVs, and instance
+  limits/tolerances were served wrong. Instance rows with a NULL or dangling
+  type link define instance-only variables and are now served as well (keyed
+  by name, so a same-named type row is replaced rather than colliding on one
+  PV name). Both `GeecsDb.get_device_variables` and the batched
+  `GeecsDb.get_experiment_device_variables` apply the same resolution.
+
+  **Operational note:** the gateway serves *more* PVs after this fix —
+  instance-settable variables gain their `:SP` setpoints — so a gateway
+  restart (e.g. via `CAGateway:RESTART`) is needed to pick them up.
+
 ## [0.6.0] - 2026-07-07
 
 ### Added

--- a/GeecsCAGateway/PV_CONTRACT.md
+++ b/GeecsCAGateway/PV_CONTRACT.md
@@ -82,13 +82,20 @@ Non-settable variables (including the intrinsic timestamp variables) have
 **no** `:SP` PV.
 
 Table precision (three DB tables carry a `set` flag with different meanings):
-the gateway's settable surface comes from `devicetype_variable.set` — the
-variable *class* capability, alongside min/max/units/tolerance/choices.
-`expt_device_variable.set` is a per-experiment *scan-write policy* flag (Master
-Control's scan start/end machinery) and plays no role in `:SP` creation;
-`expt_device_variable.get` selects the monitored/readback subscription set;
-`variable.set` is the per-device-instance definition table, not consumed by
-the gateway.
+**capability is an inheritance chain** — `devicetype_variable` defines the
+type default (settability, min/max/units/tolerance/choices) which every
+device instance inherits **unless overridden by a row in `variable`** (the
+per-instance definition table). `expt_device_variable.set` is a
+per-experiment *scan-write policy* flag (Master Control's scan start/end
+machinery) and plays no role in `:SP` creation; `expt_device_variable.get`
+selects the monitored/readback subscription set.
+
+**Known gap (2026-07-07, live-DB verified):** the gateway currently resolves
+capability/metadata from `devicetype_variable` only, ignoring `variable`
+overrides — 1032 live rows differ from their type defaults, including
+instance-level settability flips whose `:SP` PVs are therefore missing
+today. Fix pending one MC-semantics question (whole-row vs field-by-field
+override resolution).
 
 ### Per-device status PV — `CONNECTED`
 

--- a/GeecsCAGateway/PV_CONTRACT.md
+++ b/GeecsCAGateway/PV_CONTRACT.md
@@ -76,9 +76,19 @@ authoritative bidirectional map in `GeecsCaGateway.manifest`
 
 ### Setpoint PVs — `:SP`
 
-A variable whose DB `set` flag is `yes` gets a companion setpoint PV at the
-literal suffix `:SP` appended to the full readback name. Non-settable variables
-(including the intrinsic timestamp variables) have **no** `:SP` PV.
+A variable whose **`devicetype_variable.set`** flag is `yes` gets a companion
+setpoint PV at the literal suffix `:SP` appended to the full readback name.
+Non-settable variables (including the intrinsic timestamp variables) have
+**no** `:SP` PV.
+
+Table precision (three DB tables carry a `set` flag with different meanings):
+the gateway's settable surface comes from `devicetype_variable.set` — the
+variable *class* capability, alongside min/max/units/tolerance/choices.
+`expt_device_variable.set` is a per-experiment *scan-write policy* flag (Master
+Control's scan start/end machinery) and plays no role in `:SP` creation;
+`expt_device_variable.get` selects the monitored/readback subscription set;
+`variable.set` is the per-device-instance definition table, not consumed by
+the gateway.
 
 ### Per-device status PV — `CONNECTED`
 

--- a/GeecsCAGateway/PV_CONTRACT.md
+++ b/GeecsCAGateway/PV_CONTRACT.md
@@ -90,12 +90,15 @@ per-experiment *scan-write policy* flag (Master Control's scan start/end
 machinery) and plays no role in `:SP` creation; `expt_device_variable.get`
 selects the monitored/readback subscription set.
 
-**Known gap (2026-07-07, live-DB verified):** the gateway currently resolves
-capability/metadata from `devicetype_variable` only, ignoring `variable`
-overrides — 1032 live rows differ from their type defaults, including
-instance-level settability flips whose `:SP` PVs are therefore missing
-today. Fix pending one MC-semantics question (whole-row vs field-by-field
-override resolution).
+The gateway resolves this chain **whole-row** (maintainer-confirmed
+semantics, 2026-07-07): when a `variable` row exists for a device+variable
+(linked via `variable.devicetype_variable_id`), *every* served field —
+settability, name, units, limits, tolerance, choices — comes from that
+instance row, with no field-level fallback to the type defaults (an instance
+row with NULL limits means that instance has no limits). Instance rows are
+ground truth; an instance row with no surviving type link (NULL or dangling
+`devicetype_variable_id`) defines an instance-only variable and is served
+too. Pinned by the inheritance-chain tests in `tests/test_geecs_db.py`.
 
 ### Per-device status PV — `CONNECTED`
 

--- a/GeecsCAGateway/geecs_ca_gateway/db/geecs_db.py
+++ b/GeecsCAGateway/geecs_ca_gateway/db/geecs_db.py
@@ -97,11 +97,14 @@ def _num(value: object) -> Optional[float]:
 
 
 def _variable_row_to_meta(row: tuple) -> dict:
-    """Map a ``devicetype_variable`` (+ ``choice``) row onto the metadata dict.
+    """Map a ``devicetype_variable`` or ``variable`` (+ ``choice``) row onto the metadata dict.
 
     Row order: name, units, min, max, set, variabletype, choices, tolerance —
-    the shared SELECT column order of :meth:`GeecsDb.get_device_variables` and
-    :meth:`GeecsDb.get_experiment_device_variables`.
+    the shared SELECT column order (after the leading id/link column) of
+    :meth:`GeecsDb.get_device_variables` and
+    :meth:`GeecsDb.get_experiment_device_variables`.  Both the type-default
+    table (``devicetype_variable``) and the per-instance table (``variable``)
+    carry the same columns, so one mapper serves both.
     """
     return {
         "name": row[0],
@@ -113,6 +116,76 @@ def _variable_row_to_meta(row: tuple) -> dict:
         "choices": row[6],
         "tolerance": _num(row[7]),
     }
+
+
+def _merge_variable_rows(
+    type_rows: list[tuple], instance_rows: list[tuple]
+) -> list[dict]:
+    """Resolve the GEECS capability inheritance chain for one device.
+
+    ``devicetype_variable`` rows define type defaults which a device instance
+    inherits *unless* a row exists for that device+variable in the ``variable``
+    table — and when one exists it is used **wholesale**: every field comes
+    from the instance row, with no field-level fallback.  An instance row with
+    NULL limits means that instance has *no* limits, even if the type row has
+    them.  The link is explicit: ``variable.devicetype_variable_id →
+    devicetype_variable.id``.
+
+    Parameters
+    ----------
+    type_rows:
+        ``(id, name, units, min, max, set, variabletype, choices, tolerance)``
+        rows from ``devicetype_variable``.
+    instance_rows:
+        ``(devicetype_variable_id, name, units, min, max, set, variabletype,
+        choices, tolerance)`` rows from ``variable`` for the same device.
+
+    Returns
+    -------
+    list[dict]
+        Metadata dicts (:func:`_variable_row_to_meta` shape) in type-row
+        order, with overridden entries replaced in place; instance-only
+        variables are appended at the end.
+
+    Notes
+    -----
+    An instance row whose ``devicetype_variable_id`` is NULL or points at no
+    type row of this device defines an *instance-only* variable.  It has no
+    explicit link to key on, so it is keyed by ``name`` instead: a same-named
+    type row is replaced (instance rows are ground truth) rather than served
+    alongside it — two entries normalizing to one PV name would otherwise
+    collide at gateway startup.
+    """
+    linked: dict[object, tuple] = {}
+    unlinked: list[tuple] = []
+    for row in instance_rows:
+        if row[0] is None:
+            unlinked.append(row)
+        else:
+            linked[row[0]] = row
+
+    result: list[dict] = []
+    used_links: set = set()
+    for row in type_rows:
+        instance = linked.get(row[0])
+        if instance is not None:
+            used_links.add(row[0])
+            result.append(_variable_row_to_meta(instance[1:]))
+        else:
+            result.append(_variable_row_to_meta(row[1:]))
+
+    # Dangling links (type row absent) behave like instance-only variables.
+    unlinked.extend(row for link, row in linked.items() if link not in used_links)
+    for row in unlinked:
+        meta = _variable_row_to_meta(row[1:])
+        replaced = False
+        for i, existing in enumerate(result):
+            if existing["name"] == meta["name"]:
+                result[i] = meta
+                replaced = True
+        if not replaced:
+            result.append(meta)
+    return result
 
 
 class GeecsDb:
@@ -312,6 +385,10 @@ class GeecsDb:
         ``"string"``, ``"path"``, ``"image"``, ``"1darray"``, …), ``choices``
         (comma-separated option string from the ``choice`` table for ``choice``
         variables, else ``None``), and ``tolerance`` (numeric, or ``None``).
+
+        Metadata resolves the capability inheritance chain: type defaults come
+        from ``devicetype_variable``; a per-instance row in ``variable``
+        replaces its type row **wholesale** (see :func:`_merge_variable_rows`).
         """
         try:
             import mysql.connector
@@ -324,7 +401,7 @@ class GeecsDb:
         try:
             cur = conn.cursor()
             cur.execute(
-                "SELECT dtv.name, dtv.units, dtv.min, dtv.max, dtv.`set`, "
+                "SELECT dtv.id, dtv.name, dtv.units, dtv.min, dtv.max, dtv.`set`, "
                 "dtv.variabletype, c.choices, dtv.tolerance "
                 "FROM devicetype_variable dtv "
                 "JOIN device d ON d.devicetype = dtv.devicetype "
@@ -332,11 +409,20 @@ class GeecsDb:
                 "WHERE d.name = %s ORDER BY dtv.name",
                 (device_name,),
             )
-            rows = cur.fetchall()
+            type_rows = cur.fetchall()
+            cur.execute(
+                "SELECT v.devicetype_variable_id, v.name, v.units, v.min, v.max, "
+                "v.`set`, v.variabletype, c.choices, v.tolerance "
+                "FROM variable v "
+                "LEFT JOIN choice c ON c.id = v.choice_id "
+                "WHERE v.device = %s ORDER BY v.name",
+                (device_name,),
+            )
+            instance_rows = cur.fetchall()
         finally:
             conn.close()
 
-        return [_variable_row_to_meta(r) for r in rows]
+        return _merge_variable_rows(type_rows, instance_rows)
 
     @classmethod
     def get_experiment_devices(
@@ -388,9 +474,11 @@ class GeecsDb:
         """Return ``{device: [variable metadata, ...]}`` for an experiment.
 
         The batch counterpart of :meth:`get_device_variables`: metadata for
-        every device in *experiment* in a single query, with the same per-row
-        dict shape.  Duplicate ``devicetype_variable`` rows (a known DB quirk)
-        are passed through — spec building dedupes by name.
+        every device in *experiment* in two batched queries (type defaults +
+        per-instance overrides), with the same per-row dict shape and the same
+        wholesale inheritance-chain resolution (see
+        :func:`_merge_variable_rows`).  Duplicate ``devicetype_variable`` rows
+        (a known DB quirk) are passed through — spec building dedupes by name.
 
         Parameters
         ----------
@@ -406,25 +494,46 @@ class GeecsDb:
                 "mysql-connector-python is required for DB lookups."
             ) from exc
 
+        enabled = " AND LOWER(ed.enabled) = 'yes'" if enabled_only else ""
         conn = _connect_mysql(mysql.connector)
         try:
             cur = conn.cursor()
-            query = (
-                "SELECT d.name, dtv.name, dtv.units, dtv.min, dtv.max, dtv.`set`, "
-                "dtv.variabletype, c.choices, dtv.tolerance "
+            type_query = (
+                "SELECT d.name, dtv.id, dtv.name, dtv.units, dtv.min, dtv.max, "
+                "dtv.`set`, dtv.variabletype, c.choices, dtv.tolerance "
                 "FROM (SELECT DISTINCT ed.device FROM expt_device ed "
                 "      WHERE ed.expt = %s{enabled}) sel "
                 "JOIN device d ON d.name = sel.device "
                 "JOIN devicetype_variable dtv ON dtv.devicetype = d.devicetype "
                 "LEFT JOIN choice c ON c.id = dtv.choice_id "
                 "ORDER BY d.name, dtv.name"
-            ).format(enabled=" AND LOWER(ed.enabled) = 'yes'" if enabled_only else "")
-            cur.execute(query, (experiment,))
-            rows = cur.fetchall()
+            ).format(enabled=enabled)
+            cur.execute(type_query, (experiment,))
+            type_rows = cur.fetchall()
+            instance_query = (
+                "SELECT v.device, v.devicetype_variable_id, v.name, v.units, "
+                "v.min, v.max, v.`set`, v.variabletype, c.choices, v.tolerance "
+                "FROM (SELECT DISTINCT ed.device FROM expt_device ed "
+                "      WHERE ed.expt = %s{enabled}) sel "
+                "JOIN variable v ON v.device = sel.device "
+                "LEFT JOIN choice c ON c.id = v.choice_id "
+                "ORDER BY v.device, v.name"
+            ).format(enabled=enabled)
+            cur.execute(instance_query, (experiment,))
+            instance_rows = cur.fetchall()
         finally:
             conn.close()
 
-        result: dict[str, list[dict]] = {}
-        for row in rows:
-            result.setdefault(row[0], []).append(_variable_row_to_meta(row[1:]))
-        return result
+        type_by_device: dict[str, list[tuple]] = {}
+        for row in type_rows:
+            type_by_device.setdefault(row[0], []).append(row[1:])
+        instance_by_device: dict[str, list[tuple]] = {}
+        for row in instance_rows:
+            instance_by_device.setdefault(row[0], []).append(row[1:])
+
+        return {
+            device: _merge_variable_rows(
+                type_by_device.get(device, []), instance_by_device.get(device, [])
+            )
+            for device in sorted(type_by_device.keys() | instance_by_device.keys())
+        }

--- a/GeecsCAGateway/pyproject.toml
+++ b/GeecsCAGateway/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-ca-gateway"
-version = "0.6.0"
+version = "0.6.1"
 description = "EPICS Channel Access soft-IOC gateway exposing GEECS devices as PVs"
 authors = ["Sam Barber <sbarber@lbl.gov>"]
 readme = "README.md"

--- a/GeecsCAGateway/tests/test_geecs_db.py
+++ b/GeecsCAGateway/tests/test_geecs_db.py
@@ -148,23 +148,171 @@ def test_get_experiment_devices_batches_endpoints(monkeypatch) -> None:
     assert "enabled" not in queries[0][0]
 
 
-def test_get_experiment_device_variables_batches_metadata(monkeypatch) -> None:
-    """One query returns all devices' variable metadata, grouped and mapped."""
+def _patch_query_sequence(
+    monkeypatch, responses: list[list[tuple]], queries: list
+) -> None:
+    """Route _connect_mysql to a fake returning responses[i] for the i-th query."""
+
+    class _Cursor:
+        def __init__(self) -> None:
+            self._rows: list[tuple] = []
+
+        def execute(self, query: str, params: tuple) -> None:
+            self._rows = responses[len(queries)]
+            queries.append((query, params))
+
+        def fetchall(self) -> list[tuple]:
+            return self._rows
+
+    class _Connection:
+        def __init__(self) -> None:
+            self._cursor = _Cursor()
+
+        def cursor(self) -> _Cursor:
+            return self._cursor
+
+        def close(self) -> None:
+            pass
+
+    mysql_pkg = types.ModuleType("mysql")
+    connector_mod = types.ModuleType("mysql.connector")
+    mysql_pkg.connector = connector_mod
+    monkeypatch.setitem(sys.modules, "mysql", mysql_pkg)
+    monkeypatch.setitem(sys.modules, "mysql.connector", connector_mod)
+    monkeypatch.setattr(geecs_db, "_connect_mysql", lambda _connector: _Connection())
+
+
+# devicetype_variable rows: (id, name, units, min, max, set, variabletype,
+# choices, tolerance) — the type-default half of the capability chain.
+_TYPE_ROWS = [
+    (11, "Current", "A", "-5", "5", "no", "numeric", None, "0.05"),
+    (12, "Enable", "", None, None, "yes", "choice", "on,off", None),
+    (13, "Voltage", "V", "-10", "10", "yes", "numeric", None, "0.1"),
+]
+
+
+def test_get_device_variables_type_only_inherits_type_defaults(monkeypatch) -> None:
+    """No instance rows: metadata comes from devicetype_variable unchanged.
+
+    Regression guard: the meta dict shape for the plain (inherited) case is
+    exactly what config.from_db_metadata has always consumed.
+    """
     queries: list = []
-    _patch_rows(
-        monkeypatch,
-        [
-            # d.name, dtv.name, units, min, max, set, variabletype, choices, tol
-            ("U_A", "Current", "A", "-5", "5", "yes", "numeric", None, "0.05"),
-            ("U_A", "Enable", "", None, None, "yes", "choice", "on,off", None),
-            ("U_B", "Voltage", "V", None, None, "no", None, None, None),
-        ],
-        queries,
-    )
+    _patch_query_sequence(monkeypatch, [_TYPE_ROWS, []], queries)
+
+    result = GeecsDb.get_device_variables("U_S1H")
+    assert len(queries) == 2
+    assert queries[0][1] == ("U_S1H",) and queries[1][1] == ("U_S1H",)
+    assert "devicetype_variable" in queries[0][0]
+    assert "FROM variable v" in queries[1][0]
+
+    assert result[0] == {
+        "name": "Current",
+        "units": "A",
+        "min": -5.0,
+        "max": 5.0,
+        "settable": False,
+        "variabletype": "numeric",
+        "choices": None,
+        "tolerance": 0.05,
+    }
+    assert sorted(result[0]) == sorted(result[1]) == sorted(result[2])
+    assert result[1]["choices"] == "on,off"
+    assert result[2]["settable"] is True
+
+
+def test_instance_row_overrides_type_row_wholesale(monkeypatch) -> None:
+    """An instance `variable` row replaces its type row wholesale, not per field.
+
+    Settability flips no→yes (the missing-:SP live case), instance NULL limits
+    erase the type limits, and units/tolerance/choices all come from the
+    instance row — no field-level fallback to the type defaults.
+    """
+    instance_rows = [
+        # (devicetype_variable_id, name, units, min, max, set, variabletype,
+        #  choices, tolerance)
+        (11, "Current", "mA", None, None, "yes", "numeric", None, None),
+        (12, "Enable", "", None, None, "yes", "choice", "off,auto,on", "0.5"),
+    ]
+    _patch_query_sequence(monkeypatch, [_TYPE_ROWS, instance_rows], [])
+
+    result = GeecsDb.get_device_variables("U_S1H")
+    by_name = {m["name"]: m for m in result}
+
+    current = by_name["Current"]
+    assert current["settable"] is True  # no→yes flip: gains its :SP PV
+    assert current["units"] == "mA"
+    assert current["min"] is None and current["max"] is None  # NULL erases limits
+    assert current["tolerance"] is None  # NULL erases type tolerance too
+
+    enable = by_name["Enable"]
+    assert enable["choices"] == "off,auto,on"  # instance choice_id join wins
+    assert enable["tolerance"] == 0.5
+
+    # Voltage has no instance row — inherited type defaults untouched.
+    assert by_name["Voltage"]["settable"] is True
+    assert by_name["Voltage"]["min"] == -10.0
+
+
+def test_instance_set_flip_yes_to_no_loses_settability(monkeypatch) -> None:
+    """A yes→no instance override makes a type-settable variable read-only."""
+    instance_rows = [
+        (13, "Voltage", "V", "-10", "10", "no", "numeric", None, "0.1"),
+    ]
+    _patch_query_sequence(monkeypatch, [_TYPE_ROWS, instance_rows], [])
+
+    result = GeecsDb.get_device_variables("U_S1H")
+    by_name = {m["name"]: m for m in result}
+    assert by_name["Voltage"]["settable"] is False
+
+
+def test_instance_only_variable_is_served(monkeypatch) -> None:
+    """Instance rows with a NULL or dangling type link still get served.
+
+    They define instance-only variables and are keyed by name: a same-named
+    type row is replaced (instance rows are ground truth, and two entries
+    would collide on one PV name), otherwise the variable is appended.
+    """
+    instance_rows = [
+        # NULL link, no same-named type row: pure instance-only variable.
+        (None, "LocalOnly", "mm", "0", "1", "yes", "numeric", None, None),
+        # Dangling link (no type row id 999): same treatment.
+        (999, "Orphan", "", None, None, "no", "string", None, None),
+        # NULL link but colliding name: replaces the type row, no duplicate.
+        (None, "Voltage", "kV", None, None, "no", "numeric", None, None),
+    ]
+    _patch_query_sequence(monkeypatch, [_TYPE_ROWS, instance_rows], [])
+
+    result = GeecsDb.get_device_variables("U_S1H")
+    names = [m["name"] for m in result]
+    assert names == ["Current", "Enable", "Voltage", "LocalOnly", "Orphan"]
+
+    by_name = {m["name"]: m for m in result}
+    assert by_name["LocalOnly"]["settable"] is True
+    assert by_name["Orphan"]["variabletype"] == "string"
+    # the name-keyed collision: instance row wins, type limits gone
+    assert by_name["Voltage"]["units"] == "kV"
+    assert by_name["Voltage"]["settable"] is False
+    assert by_name["Voltage"]["min"] is None
+
+
+def test_get_experiment_device_variables_batches_metadata(monkeypatch) -> None:
+    """Two batched queries return all devices' metadata, grouped and mapped."""
+    queries: list = []
+    type_rows = [
+        # d.name, dtv.id, dtv.name, units, min, max, set, variabletype,
+        # choices, tol
+        ("U_A", 1, "Current", "A", "-5", "5", "yes", "numeric", None, "0.05"),
+        ("U_A", 2, "Enable", "", None, None, "yes", "choice", "on,off", None),
+        ("U_B", 3, "Voltage", "V", None, None, "no", None, None, None),
+    ]
+    _patch_query_sequence(monkeypatch, [type_rows, []], queries)
 
     result = GeecsDb.get_experiment_device_variables("Undulator")
     assert set(result) == {"U_A", "U_B"}
-    assert len(queries) == 1 and queries[0][1] == ("Undulator",)
+    assert len(queries) == 2
+    assert queries[0][1] == queries[1][1] == ("Undulator",)
+    assert all("LOWER(ed.enabled) = 'yes'" in q for q, _ in queries)
 
     current = result["U_A"][0]
     # same row shape as get_device_variables — from_db_metadata consumes both
@@ -180,3 +328,37 @@ def test_get_experiment_device_variables_batches_metadata(monkeypatch) -> None:
     }
     assert result["U_A"][1]["choices"] == "on,off"
     assert result["U_B"][0]["settable"] is False
+
+    queries.clear()
+    _patch_query_sequence(monkeypatch, [type_rows, []], queries)
+    GeecsDb.get_experiment_device_variables("Undulator", enabled_only=False)
+    assert all("enabled" not in q for q, _ in queries)
+
+
+def test_get_experiment_device_variables_resolves_instance_overrides(
+    monkeypatch,
+) -> None:
+    """The experiment-wide variant applies the same wholesale resolution."""
+    type_rows = [
+        ("U_A", 1, "Current", "A", "-5", "5", "no", "numeric", None, "0.05"),
+        ("U_B", 2, "Voltage", "V", "-10", "10", "yes", "numeric", None, None),
+    ]
+    instance_rows = [
+        # v.device, v.devicetype_variable_id, v.name, units, min, max, set,
+        # variabletype, choices, tol
+        ("U_A", 1, "Current", "A", "-1", "1", "yes", "numeric", None, None),
+        # instance-only variable on a device with no type rows at all
+        ("U_C", None, "Special", "", None, None, "yes", "string", None, None),
+    ]
+    _patch_query_sequence(monkeypatch, [type_rows, instance_rows], [])
+
+    result = GeecsDb.get_experiment_device_variables("Undulator")
+    assert set(result) == {"U_A", "U_B", "U_C"}
+
+    current = result["U_A"][0]
+    assert current["settable"] is True  # instance no→yes flip
+    assert (current["min"], current["max"]) == (-1.0, 1.0)
+    assert current["tolerance"] is None  # wholesale: type tolerance erased
+
+    assert result["U_B"][0]["settable"] is True  # untouched inheritance
+    assert result["U_C"][0]["name"] == "Special"  # instance-only device served


### PR DESCRIPTION
Started as a one-paragraph docs precision fix; the precision check uncovered a real gap, now fixed in the same PR.

## The semantics (maintainer-confirmed, live-DB verified)

GEECS variable capability/metadata is a **whole-row inheritance chain**: `devicetype_variable` defines type defaults (settability, limits, units, tolerance, choices); a `variable` row for a specific device instance, when present, is ground truth **wholesale** — all fields, either/or, no field-level fallback. Meanwhile `expt_device_variable.get/set` are per-experiment *policy* flags (subscription list / MC's scan start-end writes) and play no role in capability.

## The gap and the fix

The gateway resolved metadata from `devicetype_variable` only. Live DB: **1032 instance rows differ from their type defaults**, including settability flips (`TS-PR4000 valve`, `TS-hexapod hexinit`: type `no`, instance `yes`) — those variables had **no `:SP` PV at all**, and instance limits/tolerances were served wrong (e.g. hexapod ±25 served as ±10).

Both metadata queries now merge type + instance rows whole-row (keyed by the explicit `devicetype_variable_id` link; instance-only variables with NULL/dangling links served, name-keyed, replacing same-named type rows so the startup collision guard can't trip). The returned meta shape is byte-identical — zero caller changes. 6 new tests incl. the set-flip, NULL-erasure, and instance-only cases; suite 118 passed.

**Operational**: the gateway serves *more* PVs after this merges (instance-settable variables gain their missing `:SP`) — restart the service to pick them up.

GeecsCAGateway 0.6.1. PV_CONTRACT updated with the resolved inheritance-chain statement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)