### PR TITLE
vision M3b: actions in scans, multi-axis grids, multi-device triggers

### DIFF
--- a/GEECS-Schemas/CHANGELOG.md
+++ b/GEECS-Schemas/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to GEECS-Schemas are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.0] - 2026-07-07
+
+### Changed
+
+- **`ExperimentDefaults` merge rule: closeout is now mirrored** (ratified
+  with the M3b action-execution milestone). Default *setup* plans still run
+  before the scan's own, but default *closeout* plans now run **after** the
+  scan's own — teardown mirrors setup, so the four setup layers (vision doc
+  §4.4b) nest like context managers (defaults → save-set entry rituals →
+  the scan's own on the way in; exact reverse on the way out) and an
+  experiment-wide "return the machine to standby" always runs last.
+  Previously the module documented defaults-first for both slots.
+  Documentation-contract change only (the merge itself is implemented by
+  resolvers, e.g. `geecs_bluesky.scan_request_runner.apply_experiment_defaults`,
+  updated in lockstep); field descriptions and the operator-language test
+  pin the new ordering.
+
 ## [0.1.0] - 2026-07-07
 
 ### Added

--- a/GEECS-Schemas/geecs_schemas/experiment_defaults.py
+++ b/GEECS-Schemas/geecs_schemas/experiment_defaults.py
@@ -7,15 +7,25 @@ mention them when it wants something *different*.  You would edit it when
 the experiment's routine changes — a new standard trigger profile, a new
 "always run this first" checklist.
 
-The merge rule, in plain terms: **defaults run first, then the scan's own.**
-A default trigger profile is used only when the scan names none; default
-setup plans run before the scan's own setup plans, and default closeout
-plans run before the scan's own closeout plans.
+The merge rule, in plain terms: **defaults run first on the way in and last
+on the way out.**  A default trigger profile is used only when the scan
+names none; default setup plans run before the scan's own setup plans, and
+default closeout plans run *after* the scan's own closeout plans — teardown
+mirrors setup, so the experiment-wide baseline is the outermost bracket
+around every scan.
 
 Developer notes
 ---------------
 There is no legacy YAML dialect behind this model — the legacy scanner kept
 these choices in GUI state — so there is no converter for it.
+
+The mirrored closeout ordering is deliberate (ratified with the action
+execution milestone): the four setup layers (vision doc §4.4b) nest like
+context managers.  On the way in the order is defaults → save-set entry
+rituals → the scan's own setup; on the way out it is the exact reverse —
+the scan's own closeout → entry rituals → defaults.  A defaults closeout
+like "return the machine to standby" therefore always runs last, after
+every scan-specific cleanup has finished.
 
 Resolvers MUST record the defaults they applied into the resolved request
 (provenance): a run's metadata has to show the trigger profile and action
@@ -35,8 +45,9 @@ from geecs_schemas._base import SchemaModel, VersionedSchemaModel
 class DefaultActions(SchemaModel):
     """The action plans every scan of the experiment runs by default.
 
-    These prepend to whatever the scan itself asks for: defaults run first,
-    then the scan's own plans.
+    These bracket whatever the scan itself asks for: default setup runs
+    first, then the scan's own plans; default closeout runs last, after the
+    scan's own — teardown mirrors setup.
     """
 
     setup: list[str] = Field(
@@ -49,8 +60,9 @@ class DefaultActions(SchemaModel):
     closeout: list[str] = Field(
         default_factory=list,
         description=(
-            "Names of action plans to run after every scan, ahead of any "
-            "closeout plans the scan itself lists."
+            "Names of action plans to run after every scan, after any "
+            "closeout plans the scan itself lists (teardown mirrors setup: "
+            "these are the outermost bracket)."
         ),
     )
 
@@ -61,8 +73,8 @@ class ExperimentDefaults(VersionedSchemaModel):
     Declares the trigger profile and routine action plans most scans share,
     so individual scan requests stay short.  Defaults never override what a
     scan says explicitly: a default trigger profile applies only when the
-    scan names none, and default plans run first, followed by the scan's
-    own.
+    scan names none, and default plans bracket the scan's own — defaults
+    run first on setup and last on closeout.
     """
 
     trigger_profile: Optional[str] = Field(
@@ -75,8 +87,9 @@ class ExperimentDefaults(VersionedSchemaModel):
     actions: DefaultActions = Field(
         default_factory=DefaultActions,
         description=(
-            "Action plans every scan runs by default — these run first, "
-            "then the scan's own plans."
+            "Action plans every scan runs by default — setup plans run first "
+            "(before the scan's own), closeout plans run last (after the "
+            "scan's own)."
         ),
     )
     apply_db_scan_defaults: bool = Field(

--- a/GEECS-Schemas/pyproject.toml
+++ b/GEECS-Schemas/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-schemas"
-version = "0.1.0"
+version = "0.2.0"
 description = "Versioned Pydantic schemas for GEECS scanner configs (scan requests, save sets, scan variables, trigger profiles, action plans) plus legacy-YAML converters."
 authors = ["Sam Barber <sbarber@lbl.gov>"]
 readme = "README.md"

--- a/GEECS-Schemas/tests/test_experiment_defaults.py
+++ b/GEECS-Schemas/tests/test_experiment_defaults.py
@@ -71,11 +71,20 @@ class TestExperimentDefaults:
 
     def test_merge_rule_documented_in_operator_language(self):
         # The resolver contract is part of the schema's documentation:
-        # defaults run first, then the scan's own.
+        # defaults run first on setup and last on closeout (teardown
+        # mirrors setup — ratified with the action-execution milestone).
         doc = inspect.getdoc(ExperimentDefaults) or ""
         module_doc = inspect.getmodule(ExperimentDefaults).__doc__ or ""
         assert "defaults run first" in (doc + module_doc).lower()
+        assert "mirrors" in (doc + module_doc).lower()
         actions_field = ExperimentDefaults.model_fields["actions"]
         assert "run first" in (actions_field.description or "")
+        assert "run last" in (actions_field.description or "")
+        # The mirrored closeout is pinned on the closeout field itself, so
+        # an editor tooltip states the ordering an operator will observe.
+        from geecs_schemas.experiment_defaults import DefaultActions
+
+        closeout_field = DefaultActions.model_fields["closeout"]
+        assert "after any" in (closeout_field.description or "")
         # provenance requirement is stated for resolver implementers
         assert "provenance" in module_doc

--- a/GeecsBluesky/CHANGELOG.md
+++ b/GeecsBluesky/CHANGELOG.md
@@ -115,6 +115,21 @@ Both items were found during Gate-2 hardware verification of this release
   `GeecsSession.optimize`'s adaptive scan still enables saving eagerly
   (known remaining window — the step-scan paths were the hardware-verified
   offenders).
+  **Tail closed too** (Gate-2 re-verify on 26_0708: strict Scan001 was
+  perfect — exactly 3 images for 3 shots — but free-run Scan002 saved 7
+  images for 5 shots: STANDBY passes external edges, so frames kept
+  arriving between the last per-step disarm and the finalize save-off,
+  stretched by close_run/Tiled document writes): the free-run plan now
+  quiesces to OFF **after the last step's shots, before the tail flush**
+  (the flush reads cached last values by design, so flushing while OFF is
+  safe), and an internal abort-parity finalize quiesces before the caller's
+  cleanup when the scan dies mid-plan — so completion and abort share one
+  end order: quiesce[OFF] → tail flush → save-off → finalize
+  disarm[STANDBY] (legacy free-running end state) → closeout.
+  **Accepted, deliberately not fixed**: between-step STANDBY frames in
+  multi-step free-run scans — per-step disarm during moves is legacy-parity
+  behavior (jet off during moves); those frames join by timestamp and
+  orphans are ignorable. Do not turn this into per-step save toggling.
 - **`scan.log` for headless GeecsSession runs** — Scans 013–016 had no
   per-scan log because the handler lived bridge-side only. The helper moved
   to a shared `geecs_bluesky/scan_log.py` (`scan_log()` context manager +

--- a/GeecsBluesky/CHANGELOG.md
+++ b/GeecsBluesky/CHANGELOG.md
@@ -95,7 +95,32 @@ entry that PR #461/#464 intentionally shipped without.
 
 ### Fixed
 
-Both items were found during Gate-2 hardware verification of this release
+Review-pass fixes (max-effort review of this milestone):
+
+- **Optimize-mode requests with actions no longer refuse — they run and skip
+  the actions (logged + recorded in run metadata).** `apply_experiment_defaults`
+  merges default setup/closeout into the request before the optimize check, so
+  the old `NotImplementedError` would have blocked *every* optimization the
+  moment an experiment defined default bracket actions (via a future
+  `experiment_defaults.yaml`), even with no per-request actions. Optimize has no
+  action hooks yet, so the actions (request, defaults, and save-set rituals) are
+  skipped rather than executed; the skip is a WARNING and lands in run metadata
+  under `skipped_action_plans`. Unknown action names still fail fast.
+- **Free-run scan with saving detectors but no shot controller now warns.**
+  Native-save windowing needs the controller's quiesce to stop the trigger;
+  with no controller there is no such point, so `build_step_scan_plan` logs a
+  clear warning that frames captured during t0-sync/moves may be orphaned
+  (rather than silently leaking or refusing the supported controllerless config).
+- **Lazy action-plan registry now only masks genuine "not found".** The bare
+  `except Exception` in `_LazyResolverRegistry` turned any resolver fault into a
+  `KeyError`/miss (misdirecting debugging to "plan not found" with no
+  candidates); it now catches only `GeecsConfigurationError` and lets unexpected
+  faults propagate.
+- Removed dead code: an unreachable `return` in `GeecsSession.optimize` and the
+  superseded `collect_save_set_action_names` (production uses
+  `collect_save_set_rituals`).
+
+Both items below were found during Gate-2 hardware verification of this release
 (2026-07-07: Scans 013–016 — the first ScanRequest-driven hardware runs).
 
 - **Native-save windowing** — saving is now enabled only while the trigger

--- a/GeecsBluesky/CHANGELOG.md
+++ b/GeecsBluesky/CHANGELOG.md
@@ -93,6 +93,38 @@ entry that PR #461/#464 intentionally shipped without.
   entry rituals are refused loudly (`GeecsSession.optimize` has no action
   hooks yet — new documented gap).
 
+### Fixed
+
+Both items were found during Gate-2 hardware verification of this release
+(2026-07-07: Scans 013–016 — the first ScanRequest-driven hardware runs).
+
+- **Native-save windowing** — saving is now enabled only while the trigger
+  cannot free-run. The run wrapper's eager save-on (before arming) let
+  free-running frames be saved as orphans that join no event row: Scan015
+  (strict) saved 6 images for 3 shots (three 1 Hz STANDBY frames during the
+  ~5 s setup-action window), Scan013 (free-run) saved 6 for 5 (one frame in
+  the window between save-on and quiesce[OFF]). `geecs_run_wrapper` grew
+  `defer_save_on` + a public `save_enable_plan` stub; the step plans grew an
+  `enable_saving` hook yielded at the first orphan-free moment — strict:
+  after ARMED + quiescence confirmation; free-run: immediately after
+  quiesce[OFF], before t0-sync. Setup actions run before that point by
+  construction (their duration was producing the orphans). Save-off is
+  unchanged: the innermost finalize, before the disarm — so on completion
+  *and* abort the order is save-off → disarm[STANDBY] → closeout. Direct
+  `geecs_run_wrapper` users (no `defer_save_on`) keep the eager behavior;
+  `GeecsSession.optimize`'s adaptive scan still enables saving eagerly
+  (known remaining window — the step-scan paths were the hardware-verified
+  offenders).
+- **`scan.log` for headless GeecsSession runs** — Scans 013–016 had no
+  per-scan log because the handler lived bridge-side only. The helper moved
+  to a shared `geecs_bluesky/scan_log.py` (`scan_log()` context manager +
+  `ScanLogContextFilter`, verbatim behavior; `BlueskyScanner._scan_log`
+  delegates to it), and `GeecsSession.scan`/`optimize` now attach it around
+  the run + exports whenever the session itself claimed the scan number.
+  Pre-claimed scans (the GUI bridge path, or any caller that opened its own
+  per-scan log) deliberately do not self-attach — the claiming caller owns
+  the handler, and a second one would duplicate every line.
+
 ### Removed
 
 - `shot_control_config_from_trigger_profile` and its multi-device

--- a/GeecsBluesky/CHANGELOG.md
+++ b/GeecsBluesky/CHANGELOG.md
@@ -4,6 +4,103 @@ All notable changes to `geecs-bluesky` are documented here.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.23.0] - 2026-07-07
+
+M3b — every engine-pending ScanRequest seam closes: actions execute inside
+scans, multi-axis grids run, and multi-device trigger profiles drive the
+shot controller. `GeecsSession.run(request)` now executes the full schema
+surface except the documented v1 gaps (pseudo variables, `all_scalars`,
+optimize-mode injection/actions). Also folds in the M3a action-compiler
+entry that PR #461/#464 intentionally shipped without.
+
+### Added
+
+- **ActionPlan → Bluesky plan-stub compiler** (M3a, PR #461/#464 —
+  `plans/action_compiler.py`): the successor of the legacy `ActionManager`
+  executor. `compile_action_plan` turns a validated
+  `geecs_schemas.ActionPlan` into a plain message generator — `set` becomes
+  `abs_set(wait=wait_for_execution)` (the legacy `sync=` semantics), `wait`
+  becomes an RE-interruptible `bps.sleep`, `check` reads and compares with
+  the exact legacy `interpret_value` + `==` rules (`values_match`, quirks
+  pinned verbatim), `run` recurses through a registry with a cycle guard
+  legacy never had. Purity contract: no CA, no PV strings — signals come
+  from an injected `SettableFactory`. Fidelity pinned end to end against
+  the converted legacy corpus (`Amp4_DUMP_HP`: nested plans, wait
+  durations, check-mismatch abort).
+- **Production `SettableFactory`** (`devices/ca/action_signals.py`,
+  `CaActionSignalFactory` via `session.action_signal_factory()`): `set`
+  steps put wire strings to the variable's gateway `:SP` PV — CA
+  put-completion rides GEECS's blocking set, so `wait_for_execution` keeps
+  its exact legacy meaning; `check` steps read the streamed readback as a
+  string (matching the legacy coercion pipeline). Signals are cached per
+  (device, variable), connected on the RE loop **before** the plan runs
+  (`prefetch_action_signals` — a lazy connect inside the RE loop would
+  deadlock; prefetching also fail-fasts unreachable targets pre-claim), and
+  ride the scan's device cleanup.
+- **Action execution wired into scans.** `build_step_scan_plan` /
+  `GeecsSession.scan` grew `setup` / `per_step` / `closeout` plan-stub
+  hooks with documented placement: *setup* runs first thing in the composed
+  plan (after device connect + pre-flight, before free-run quiesce/t0-sync
+  and the first step); *per_step* is yielded by both step plans at every
+  step boundary — after the move, before that step's shots (free-run
+  brackets steps with arm/disarm so per-step actions run disarmed; strict
+  is quiescent between plan-owned shots); *closeout* is the outermost
+  `finalize_wrapper`, so it runs even on mid-scan abort (legacy
+  ActionControl parity) and always after the trigger disarm.
+  `run_scan_request` assembles the §4.4b layers in nesting order — setup:
+  ExperimentDefaults → SaveSet entry rituals (collected across entries,
+  de-duplicated by name, each once) → the request's own; closeout: the
+  exact mirror (request → entries → defaults) — and records the assembled
+  order in the run metadata (`action_plans`) for provenance.
+  `apply_experiment_defaults` now appends default closeout plans after the
+  scan's own (the mirrored merge rule ratified in geecs-schemas 0.2.0).
+- **Multi-axis grid execution.** `len(axes) >= 2` runs an outer-product
+  grid (first axis outermost/slowest — the schema's documented semantics):
+  one movable per axis, explicit grid-point tuples, one bin per grid point,
+  per-step actions at every grid point. The step plans accept a motor
+  *sequence*; only the axes whose target changed are re-moved (innermost
+  varies fastest), changed axes move concurrently via `bps.mv`. Every
+  motor's readback lands in every event row (exactly like the single-motor
+  path); run metadata carries `scan_axes` / `grid_shape` /
+  `num_grid_points`, and the legacy 1-D ScanInfo fields describe the
+  outermost axis (`scan_parameter` = comma-joined targets).
+- **Multi-device trigger profiles.** `ShotControlWrites`
+  (`models/shot_control.py`) — per-state **ordered** `(device, variable,
+  value)` write lists — plus `ShotController.from_writes`: one `CaPutSetter`
+  per distinct target (cached across states), transitions replayed in
+  declared order with each write completing before the next
+  (schema-documented ordering). `trigger_writes_from_profile` replaces the
+  single-device `shot_control_config_from_trigger_profile` pivot for
+  request execution; `GeecsSession.shot_control` accepts `ShotControlWrites`
+  alongside the legacy shapes, and the GUI bridge's `reinitialize(ScanRequest)`
+  stores the generalized writes too. The legacy `ShotControlConfig` path
+  (concurrent per-state writes, single device) is untouched.
+- **Hardware verification test** (`tests/test_scan_request_hardware.py`,
+  integration-marked, skipped in CI): one noscan ScanRequest through
+  `session.run()` against the real gateway, corpus configs converted on the
+  fly; device/config names parameterizable via `GEECS_HW_*` env vars
+  (defaults: `UC_Amp4_IR_input` camera, `HTU-LaserOFF` trigger profile).
+
+### Changed
+
+- `scan_request_runner` no longer refuses actions, entry rituals,
+  multi-axis grids, or multi-device trigger profiles — the
+  validate-then-`NotImplementedError` treatment is gone from the engine
+  path (names still resolve fail-fast pre-claim). The GUI bridge's
+  `reinitialize(ScanRequest)` still refuses actions/multi-axis with a
+  pointer to `GeecsSession.run` (routing them through the bridge is the GUI
+  submission milestone). Optimize-mode requests with action bindings or
+  entry rituals are refused loudly (`GeecsSession.optimize` has no action
+  hooks yet — new documented gap).
+
+### Removed
+
+- `shot_control_config_from_trigger_profile` and its multi-device
+  `NotImplementedError` (superseded by `trigger_writes_from_profile` +
+  `ShotController.from_writes`); the engine-path multi-axis and
+  action-refusal raises in `run_scan_request` / `resolve_save_set_checked`'s
+  runner usage.
+
 ## [0.22.0] - 2026-07-07
 
 Engine consolidation (target-architecture vision §2): the engine owns its

--- a/GeecsBluesky/CLAUDE.md
+++ b/GeecsBluesky/CLAUDE.md
@@ -51,13 +51,22 @@ geecs_bluesky/
   scan_request_runner.py    # run a geecs_schemas.ScanRequest: ConfigResolver
                             #   protocol + ConfigsRepoResolver (new-schema YAML
                             #   or legacy-convert), SaveSet→devices_config and
-                            #   TriggerProfile→ShotControlConfig adapters
+                            #   TriggerProfile→ShotControlWrites (ordered,
+                            #   multi-device) adapters, action slot assembly
+                            #   (§4.4b layers) + compile + signal prefetch,
+                            #   multi-axis grid execution
   scanner_bridge/
     bluesky_scanner.py      # BlueskyScanner — ScanManager-compatible GUI bridge
                             #   (reinitialize also accepts a ScanRequest)
   plans/
-    orchestration.py        # build_step_scan_plan — THE one scan recipe (both front doors)
-    step_scan.py            # geecs_step_scan — step scan (motor optional; hooks)
+    orchestration.py        # build_step_scan_plan — THE one scan recipe (both front
+                            #   doors); setup/per_step/closeout action hooks +
+                            #   finalize nesting (save-off → disarm → closeout)
+    action_compiler.py      # compile_action_plan — ActionPlan → plan stubs
+                            #   (legacy ActionManager semantics pinned; signals
+                            #   from an injected SettableFactory)
+    step_scan.py            # geecs_step_scan — step scan (motor optional OR a
+                            #   motor list = multi-axis grid; per_step hook)
     free_run_step_scan.py   # geecs_free_run_step_scan — reference-paced + t0-sync + tail flush
     optimize.py             # geecs_adaptive_scan — optimization as a scan (iteration = bin)
     single_shot.py          # geecs_single_shot + geecs_confirm_quiescent
@@ -71,6 +80,9 @@ geecs_bluesky/
       snapshot.py           # CaSnapshotReadable — async readback
       settable.py           # CaSettable — put :SP, read streamed readback
       motor.py              # CaMotor — blocking :SP put + readback-tolerance poll
+      action_signals.py     # CaActionSignalFactory — the production
+                            #   SettableFactory for compiled action plans
+                            #   (cached :SP settables + str readbacks)
     shot_id.py              # ShotIdTracker + ShotIdSupport mixin (schema-v1 columns)
     nonscalar_save.py       # NonScalarSaveSupport mixin — save-path column + asset docs
     contributor.py          # FreeRunContributorSupport — reference-relative labeling
@@ -167,10 +179,19 @@ States are `ShotControlState`: `OFF`, `SCAN`, `STANDBY`, `SINGLESHOT`, `ARMED`.
 `values_for_state(state)` returns the `{var: value}` writes for a state, skipping
 empty-string no-ops (matching legacy `TriggerController`).
 
-`ShotController` (`shot_controller.py`) drives the shot-control device through
-its named states as plan stubs, via `CaPutSetter`s writing the gateway `:SP`
-PVs (put-completion rides GEECS's blocking set). Both `BlueskyScanner` and
-`GeecsSession` use it:
+`ShotController` (`shot_controller.py`) drives the shot-control device(s)
+through named states as plan stubs, via `CaPutSetter`s writing the gateway
+`:SP` PVs (put-completion rides GEECS's blocking set). Two construction
+paths: the legacy single-device `ShotControlConfig` + one setter per
+variable (state writes issued concurrently — byte-identical to the
+pre-M3b behavior, and untouched for the scanner path), and
+`ShotController.from_writes(ShotControlWrites)` — generalized per-state
+**ordered** `(device, variable, value)` lists, possibly spanning several
+devices (TriggerProfile semantics: writes replayed top to bottom, each
+completing before the next; one cached `CaPutSetter` per distinct target).
+`trigger_writes_from_profile` (scan_request_runner) adapts a TriggerProfile
+into that shape; `GeecsSession.shot_control` accepts either generation.
+Both `BlueskyScanner` and `GeecsSession` use it:
 
 - `arm()` → `SCAN`, `disarm()` → `STANDBY` (per-step bracketing on the
   free-running modes; jet on during shots, off during moves)
@@ -332,15 +353,29 @@ Operator interaction is one seam: `operator_channel.OperatorChannel`
 headless default-and-log).  Pre-flight is a pipeline
 (`preflight.run_preflight`); new checks are list entries.
 
-`ScanRequest` execution (`scan_request_runner` / `GeecsSession.run` /
-`reinitialize(ScanRequest)`) validates-then-refuses the documented v1 gaps:
-multi-axis grids, action bindings (names validated now — request-level and
-SaveSet entry-level alike; execution lands with the ActionPlan compiler
-milestone), pseudo scan variables, `all_scalars`, multi-device trigger
-profiles (single-device fast path only), optimize without an injected
-objective/suggester.  Experiment defaults (`experiment_defaults.yaml`) fill
-request fields left unset — never overriding explicit values — and every
-applied default is recorded into the run metadata for provenance.
+`ScanRequest` execution (`scan_request_runner` / `GeecsSession.run`) runs
+the full schema surface as of 0.23.0 (M3b): **actions execute**
+(request-level setup/per_step/closeout, SaveSet entry rituals de-duplicated
+by name, ExperimentDefaults plans — assembled in §4.4b nesting order:
+defaults → entries → request on setup, exact mirror on closeout; the
+assembled order is recorded in run metadata as `action_plans`), **multi-axis
+grids execute** (outer product, first axis outermost; only changed axes
+re-moved; every axis readback in every event row; `scan_axes`/`grid_shape`
+metadata), and **multi-device trigger profiles execute** (ordered write
+lists via `ShotControlWrites`).  Action plans compile via
+`plans/action_compiler.py` against the session's `CaActionSignalFactory`;
+every signal is prefetched/connected pre-claim (a lazy connect inside the
+RE loop would deadlock).  Names still resolve fail-fast pre-claim.
+Remaining validated-then-refused v1 gaps: pseudo scan variables,
+`all_scalars`, optimize without an injected objective/suggester, and
+actions on optimize-mode requests (`GeecsSession.optimize` has no action
+hooks yet).  The GUI bridge's `reinitialize(ScanRequest)` still refuses
+actions/multi-axis with a pointer to `GeecsSession.run` — routing them
+through the bridge is the GUI submission milestone.  Experiment defaults
+(`experiment_defaults.yaml`) fill request fields left unset — never
+overriding explicit values — and every applied default is recorded into
+the run metadata for provenance (closeout defaults append *after* the
+scan's own since geecs-schemas 0.2.0 — mirrored teardown).
 
 ## Known Gaps (as of 0.21.0)
 
@@ -375,8 +410,12 @@ Remaining items are features/tuning, not architecture — see
   The evaluator seam is `EvaluatorDataSource` in
   `geecs_scanner.optimization.base_evaluator`; this package stays free of any
   geecs_scanner import (dependency direction).
-- **Pre/post-scan action sequences not implemented** (`setup_action` /
-  `closeout_action`); the legacy scanner runs these through `ActionManager`.
+- **Pre/post-scan action sequences run on the ScanRequest path only.**
+  `GeecsSession.run(request)` executes setup/per_step/closeout ActionPlans
+  (0.23.0); the legacy `exec_config` path and the GUI bridge still skip
+  `setup_action` / `closeout_action` (legacy elements' actions *are*
+  executed when the element is resolved as a save set through a
+  ScanRequest — the converter extracts them into entry rituals).
 - **Scan-folder creation invariant:** `claim_scan_number`
   (`plans/run_wrapper.py`) is the one place (outside the GUI's `ScanDataManager`)
   allowed to create a `scans/ScanNNN/` folder.  It logs a warning and returns

--- a/GeecsBluesky/CLAUDE.md
+++ b/GeecsBluesky/CLAUDE.md
@@ -386,9 +386,13 @@ lists via `ShotControlWrites`).  Action plans compile via
 every signal is prefetched/connected pre-claim (a lazy connect inside the
 RE loop would deadlock).  Names still resolve fail-fast pre-claim.
 Remaining validated-then-refused v1 gaps: pseudo scan variables,
-`all_scalars`, optimize without an injected objective/suggester, and
-actions on optimize-mode requests (`GeecsSession.optimize` has no action
-hooks yet).  The GUI bridge's `reinitialize(ScanRequest)` still refuses
+`all_scalars`, and optimize without an injected objective/suggester.
+Actions on an optimize-mode request are **not** refused — optimize has no
+action hooks yet, so the actions (request, experiment defaults, and
+save-set rituals) are skipped, logged (WARNING), and recorded in run
+metadata under `skipped_action_plans` (refusing would block every
+optimization the moment an experiment defines default bracket actions;
+unknown names still fail fast).  The GUI bridge's `reinitialize(ScanRequest)` still refuses
 actions/multi-axis with a pointer to `GeecsSession.run` — routing them
 through the bridge is the GUI submission milestone.  Experiment defaults
 (`experiment_defaults.yaml`) fill request fields left unset — never

--- a/GeecsBluesky/CLAUDE.md
+++ b/GeecsBluesky/CLAUDE.md
@@ -36,7 +36,8 @@ bin), so it honours the same mode dispatch.
 ```
 geecs_bluesky/
   session.py                # GeecsSession — headless scans (RE + Tiled + discipline)
-                            #   + session.run(ScanRequest) — the schema front door
+                            #   + session.run(ScanRequest) — the schema front door;
+                            #   writes scan.log when it claimed the scan number
   events.py                 # THE typed event vocabulary: ScanEvent hierarchy,
                             #   ScanState, DialogRequest — moved down from
                             #   geecs_scanner (vision §2); geecs_scanner's
@@ -95,6 +96,9 @@ geecs_bluesky/
                             #   (handlers, readback, registry)
   epics_env.py              # Applies [epics] ca_addr_list from the shared config
                             #   before aioca import (called by geecs_bluesky/__init__)
+  scan_log.py               # shared per-scan scan.log handler (scan_log() ctx
+                            #   manager) — bridge delegates; GeecsSession
+                            #   attaches it when it claimed the scan number
   shot_controller.py        # ShotController — arm/disarm/quiesce/fire plan stubs (gateway :SP)
   optimize.py               # suggester protocol, RandomSuggester, XoptSuggester, BinData
   tiled_integration.py      # subscribe_tiled + descriptor patch + safe callback
@@ -200,14 +204,21 @@ Both `BlueskyScanner` and `GeecsSession` use it:
 - `arm_single_shot(detectors)` → `ARMED` then `geecs_confirm_quiescent`, and
   `fire_shot()` → `SINGLESHOT` (strict plan-owned single-shot)
 
-How they compose per mode:
+How they compose per mode (native saving is **windowed** to the
+trigger-stopped part of the scan — Gate-2 hardware finding: an eager save-on
+let free-running frames be saved as orphan images joining no event row):
 ```
-free-run:  quiesce[OFF] → t0_sync → per step: mv → arm[SCAN] → N×(ref-paced read) → disarm[STANDBY] → tail flush
-strict:    setup once: arm[ARMED] → confirm quiescent → per shot: trigger→fire[SINGLESHOT]→await→read
+free-run:  quiesce[OFF] → save-on → t0_sync → per step: mv → arm[SCAN] → N×(ref-paced read) → disarm[STANDBY] → tail flush
+strict:    setup once: arm[ARMED] → confirm quiescent → save-on → per shot: trigger→fire[SINGLESHOT]→await→read
 ```
+(`geecs_run_wrapper(defer_save_on=True)` + the step plans' `enable_saving`
+hook yielding `save_enable_plan`; ScanRequest setup actions run before the
+save-on point by construction.)
 
 A `bpp.finalize_wrapper` around the plan guarantees the disarm (→ `STANDBY`)
-runs even on mid-scan abort.
+runs even on mid-scan abort; the finalize nesting is save-off → disarm →
+closeout, so saving always stops while the trigger is still unable to
+free-run.
 
 `ARMED` is **config-specific**: it sets data-taking output (jet amplitude /
 delay) + the single-shot trigger source — *external* single-shot when the laser

--- a/GeecsBluesky/CLAUDE.md
+++ b/GeecsBluesky/CLAUDE.md
@@ -208,17 +208,25 @@ How they compose per mode (native saving is **windowed** to the
 trigger-stopped part of the scan — Gate-2 hardware finding: an eager save-on
 let free-running frames be saved as orphan images joining no event row):
 ```
-free-run:  quiesce[OFF] → save-on → t0_sync → per step: mv → arm[SCAN] → N×(ref-paced read) → disarm[STANDBY] → tail flush
+free-run:  quiesce[OFF] → save-on → t0_sync → per step: mv → arm[SCAN] → N×(ref-paced read) → disarm[STANDBY] → end: quiesce[OFF] → tail flush
 strict:    setup once: arm[ARMED] → confirm quiescent → save-on → per shot: trigger→fire[SINGLESHOT]→await→read
 ```
 (`geecs_run_wrapper(defer_save_on=True)` + the step plans' `enable_saving`
 hook yielding `save_enable_plan`; ScanRequest setup actions run before the
-save-on point by construction.)
+save-on point by construction.  The end-of-scan quiesce closes the tail:
+STANDBY passes external edges, so without it frames kept landing between
+the last disarm and the finalize save-off.)
 
 A `bpp.finalize_wrapper` around the plan guarantees the disarm (→ `STANDBY`)
-runs even on mid-scan abort; the finalize nesting is save-off → disarm →
-closeout, so saving always stops while the trigger is still unable to
-free-run.
+runs even on mid-scan abort; the finalize nesting is quiesce[OFF]
+(free-run abort parity, inside the plan; skipped when the end-of-scan
+quiesce already ran) → save-off → disarm → closeout, so saving always
+stops while the trigger cannot pass edges, and hardware is restored to the
+legacy free-running STANDBY end state last.  **Accepted window, do not
+"fix"**: between-step STANDBY frames in multi-step free-run scans — the
+per-step disarm during moves is deliberate legacy parity (jet off during
+moves); frames there join by timestamp and orphans are ignorable — never
+turn this into per-step save toggling.
 
 `ARMED` is **config-specific**: it sets data-taking output (jet amplitude /
 delay) + the single-shot trigger source — *external* single-shot when the laser

--- a/GeecsBluesky/geecs_bluesky/devices/ca/__init__.py
+++ b/GeecsBluesky/geecs_bluesky/devices/ca/__init__.py
@@ -10,6 +10,7 @@ divergent domain logic (shot-id / save-path / schema stay shared).
 Requires the ``ca`` extra (``aioca``): ``poetry install --extras ca``.
 """
 
+from geecs_bluesky.devices.ca.action_signals import CaActionSignalFactory
 from geecs_bluesky.devices.ca.generic_detector import CaGenericDetector
 from geecs_bluesky.devices.ca.motor import CaMotor
 from geecs_bluesky.devices.ca.settable import CaSettable
@@ -19,6 +20,7 @@ from geecs_bluesky.devices.ca.triggerable import CaAcqTimestampReadable, CaTrigg
 
 __all__ = [
     "CaAcqTimestampReadable",
+    "CaActionSignalFactory",
     "CaGenericDetector",
     "CaMotor",
     "CaSettable",

--- a/GeecsBluesky/geecs_bluesky/devices/ca/action_signals.py
+++ b/GeecsBluesky/geecs_bluesky/devices/ca/action_signals.py
@@ -1,0 +1,153 @@
+"""CaActionSignalFactory — the production SettableFactory for action plans.
+
+The ActionPlan compiler (:mod:`geecs_bluesky.plans.action_compiler`) is
+transport-ignorant: it asks an injected factory for signals by GEECS
+``(device, variable)`` name.  This module is the CA-backed production
+implementation:
+
+- ``get_settable(device, variable)`` → a Movable whose ``set()`` puts the
+  value (coerced to its wire string) to the variable's gateway setpoint PV
+  (``[Experiment:]Device:Variable:SP`` via :func:`~geecs_bluesky.devices.ca._pv.ca_pv`).
+  The gateway forwards ``:SP`` puts to GEECS's blocking UDP set and only
+  completes the CA put when GEECS accepts (or rejects) it — so CA
+  put-completion *is* the legacy ``wait_for_execution`` semantics: an
+  ``abs_set(..., wait=True)`` blocks exactly as ``device.set(var, value,
+  sync=True)`` did.
+- ``get_readable(device, variable)`` → a string-typed read signal on the
+  streamed readback PV.  Reading as a string matches the legacy check
+  pipeline (:func:`~geecs_bluesky.plans.action_compiler.values_match` floats
+  numeric-looking strings, exactly like ``GeecsDevice.interpret_value``).
+
+Signals are created lazily, **cached per (device, variable)** so repeated
+steps and per-step plans reuse one CA channel, and connected through the
+session's RE-loop connector at creation time.  Because plan generators
+execute *inside* the RunEngine's event loop (where a blocking connect would
+deadlock), callers must pre-connect every signal a compiled plan will touch
+before handing the plan to the RE — see
+:func:`~geecs_bluesky.scan_request_runner.prefetch_action_signals`.
+
+The factory rides the same per-scan cleanup path as devices: it exposes an
+``async disconnect()`` so ``session.disconnect(factory)`` treats it
+uniformly (the signals hold no persistent monitor subscriptions, so there is
+nothing to tear down beyond dropping the cache).
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Callable
+
+from ophyd_async.epics.core import epics_signal_r, epics_signal_rw
+
+from geecs_bluesky.devices.ca._pv import ca_pv
+from geecs_bluesky.utils import safe_name
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["CaActionSignalFactory"]
+
+
+class _WireSettable:
+    """Movable adapter: coerces action values to wire strings before the put.
+
+    Action YAML values are ``str | float | int``; the gateway's ``:SP``
+    channels accept the string form of any of them (enum PVs take labels,
+    numeric PVs coerce numeric strings — the same convention as
+    :class:`~geecs_bluesky.shot_controller.CaPutSetter`).  The underlying
+    signal is string-typed, so every value is stringified here, once.
+    """
+
+    def __init__(self, signal: Any) -> None:
+        self._signal = signal
+
+    @property
+    def name(self) -> str:
+        """Signal name (used by Bluesky logging/message repr)."""
+        return self._signal.name
+
+    def set(self, value: Any):
+        """Put ``str(value)``; the returned status completes with the GEECS set."""
+        return self._signal.set(str(value))
+
+
+class CaActionSignalFactory:
+    """Hands out cached, connected CA signals for action set/check steps.
+
+    Parameters
+    ----------
+    experiment : str or None
+        Experiment PV-namespace prefix (e.g. ``"Undulator"``).
+    connect : callable
+        ``connect(signal)`` — connects an ophyd-async signal in the
+        RunEngine's persistent event loop (mock-aware); typically the
+        session's ``_connect``.  Called once per new signal, at creation.
+    """
+
+    def __init__(self, experiment: str | None, connect: Callable[[Any], Any]) -> None:
+        self._experiment = experiment
+        self._connect = connect
+        self._settables: dict[tuple[str, str], _WireSettable] = {}
+        self._readables: dict[tuple[str, str], Any] = {}
+
+    def get_settable(self, device: str, variable: str) -> _WireSettable:
+        """Return the (cached) setpoint writer for ``(device, variable)``.
+
+        Parameters
+        ----------
+        device : str
+            GEECS device name (e.g. ``"U_148_PLC"``).
+        variable : str
+            Writable variable on that device (e.g. ``"DO.Ch9"``).
+
+        Returns
+        -------
+        _WireSettable
+            A Movable putting wire strings to the variable's ``:SP`` PV;
+            put-completion rides the GEECS blocking set.
+        """
+        key = (device, variable)
+        settable = self._settables.get(key)
+        if settable is None:
+            pv = f"{ca_pv(self._experiment, device, variable)}:SP"
+            signal = epics_signal_rw(str, pv, name=safe_name(f"{device}_{variable}_sp"))
+            self._connect(signal)
+            settable = _WireSettable(signal)
+            self._settables[key] = settable
+            logger.debug("action settable created: %s -> %s", key, pv)
+        return settable
+
+    def get_readable(self, device: str, variable: str) -> Any:
+        """Return the (cached) string readback signal for ``(device, variable)``.
+
+        Parameters
+        ----------
+        device : str
+            GEECS device name (e.g. ``"U_GaiaSVEReader"``).
+        variable : str
+            Variable to read (e.g. ``"InternalShutterA"``).
+
+        Returns
+        -------
+        SignalR
+            A string-typed read signal on the streamed readback PV,
+            accepted by ``bps.rd``.
+        """
+        key = (device, variable)
+        signal = self._readables.get(key)
+        if signal is None:
+            pv = ca_pv(self._experiment, device, variable)
+            signal = epics_signal_r(str, pv, name=safe_name(f"{device}_{variable}"))
+            self._connect(signal)
+            self._readables[key] = signal
+            logger.debug("action readable created: %s -> %s", key, pv)
+        return signal
+
+    async def disconnect(self) -> None:
+        """Per-scan teardown hook (rides ``session.disconnect`` uniformly).
+
+        The factory's signals hold no persistent monitor subscriptions —
+        aioca manages the underlying CA channels globally — so teardown is
+        just dropping the cache.
+        """
+        self._settables.clear()
+        self._readables.clear()

--- a/GeecsBluesky/geecs_bluesky/models/__init__.py
+++ b/GeecsBluesky/geecs_bluesky/models/__init__.py
@@ -1,5 +1,9 @@
 """Validated configuration models for GeecsBluesky."""
 
-from geecs_bluesky.models.shot_control import ShotControlConfig, ShotControlState
+from geecs_bluesky.models.shot_control import (
+    ShotControlConfig,
+    ShotControlState,
+    ShotControlWrites,
+)
 
-__all__ = ["ShotControlConfig", "ShotControlState"]
+__all__ = ["ShotControlConfig", "ShotControlState", "ShotControlWrites"]

--- a/GeecsBluesky/geecs_bluesky/models/shot_control.py
+++ b/GeecsBluesky/geecs_bluesky/models/shot_control.py
@@ -121,3 +121,59 @@ class ShotControlConfig(BaseModel):
             for var, values in self.variables.items()
             if values.get(name)
         }
+
+
+class ShotControlWrites(BaseModel):
+    """Generalized shot control: per-state **ordered** multi-device write lists.
+
+    The engine-facing successor of the per-variable single-device
+    :class:`ShotControlConfig` pivot, matching the
+    ``geecs_schemas.trigger_profile.TriggerProfile`` semantics: a state
+    transition is an ordered list of ``(device, variable, value)`` writes,
+    applied top to bottom (order is schema-documented — e.g. raise an
+    amplitude before switching a trigger source), possibly spanning several
+    devices.  Values are verbatim wire strings; a state with no writes is
+    "not defined" for this controller.
+
+    This model stays pure data (no hardware, no schema imports) so the
+    trigger-profile adapter lives bluesky-side
+    (:func:`~geecs_bluesky.scan_request_runner.trigger_writes_from_profile`)
+    and the GUI bridge can store either generation in one slot.
+
+    Parameters
+    ----------
+    name:
+        Profile name, used in log/error messages (e.g. ``"htu_normal"``).
+    states:
+        ``{state_name: [(device, variable, value), ...]}`` — the ordered
+        writes per state.  Empty-string values are not expected here (the
+        TriggerProfile schema rejects them; omission is the no-op).
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    name: str = ""
+    states: dict[str, list[tuple[str, str, str]]] = Field(default_factory=dict)
+
+    @staticmethod
+    def _state_name(state: "ShotControlState | str") -> str:
+        return state.value if isinstance(state, ShotControlState) else str(state)
+
+    @property
+    def devices(self) -> list[str]:
+        """Every device written, in order of first appearance."""
+        seen: dict[str, None] = {}
+        for writes in self.states.values():
+            for device, _variable, _value in writes:
+                seen.setdefault(device)
+        return list(seen)
+
+    def defines_state(self, state: "ShotControlState | str") -> bool:
+        """Whether driving to *state* would write anything at all."""
+        return bool(self.states.get(self._state_name(state)))
+
+    def writes_for_state(
+        self, state: "ShotControlState | str"
+    ) -> list[tuple[str, str, str]]:
+        """Return the ordered ``(device, variable, value)`` writes for *state*."""
+        return list(self.states.get(self._state_name(state), []))

--- a/GeecsBluesky/geecs_bluesky/plans/free_run_step_scan.py
+++ b/GeecsBluesky/geecs_bluesky/plans/free_run_step_scan.py
@@ -24,9 +24,22 @@ Run stages
 2. **Step loop** — identical bracketing to
    :func:`~geecs_bluesky.plans.step_scan.geecs_step_scan`:
    move → arm → ``shots_per_step`` rows → disarm.
-3. **Tail flush** (after the final disarm): one extra read of all devices
-   emitted to a separate ``flush`` event stream, so a contributor lagging at
-   ``shot_offset = -1`` still gets its final shot recorded.
+3. **End-of-scan quiesce + tail flush**: after the last step's disarm the
+   trigger is stopped again (quiesce → OFF — STANDBY keeps passing external
+   edges, and the tail machinery, close_run document writes, and the
+   caller's finalize save-off all take wall time; Gate-2 re-verify: Scan002
+   saved 7 images for 5 shots from exactly that window).  Then one extra
+   read of all devices is emitted to a separate ``flush`` event stream, so
+   a contributor lagging at ``shot_offset = -1`` still gets its final shot
+   recorded — the flush reads cached last values by design, so flushing
+   while OFF is safe.  The caller's outer finalize restores STANDBY
+   (free-running, output off — the legacy end state) afterwards.
+
+Accepted, deliberately-not-fixed window: **between-step STANDBY frames in
+multi-step free-run scans**.  The per-step disarm to STANDBY during motor
+moves is legacy-parity behavior (jet off during moves, trigger free-running)
+— frames arriving there join by timestamp and orphans are ignorable.  Do
+not "fix" this into per-step save toggling.
 """
 
 from __future__ import annotations
@@ -102,6 +115,10 @@ def geecs_free_run_step_scan(
         trigger, then read acq_timestamps" procedure — DG645 ``OFF`` state).
         ``SCAN``/``STANDBY`` keep the trigger free-running, so they cannot
         serve this role.  Falls back to ``disarm_trigger`` when not given.
+        Also run at **end of scan** (after the last step, before the tail
+        flush) and — via an internal finalize — on abort, so native saving
+        is never left enabled while the trigger passes external edges (see
+        the module docstring's run stages).
     per_step:
         Optional plan-stub callable run at **every** step boundary — after
         the move completes, before that step's ``arm_trigger``/shots.  This
@@ -228,6 +245,14 @@ def geecs_free_run_step_scan(
                 yield from bps.trigger_and_read(_read_devices)
             if disarm_trigger is not None:
                 yield from disarm_trigger()
+        # End of scan: stop the trigger BEFORE the tail machinery.  STANDBY
+        # keeps passing external edges, and the tail flush + close_run +
+        # document writes + the caller's finalize save-off all take wall
+        # time — with native saving still on, STANDBY frames landed as
+        # orphan images (Gate-2 re-verify: Scan002, 7 images for 5 shots).
+        if _quiesce is not None:
+            yield from _quiesce()
+            _end_quiesced["done"] = True
         if tail_flush:
             # No trigger: the reference would wait for a shot that may never
             # come once the trigger window is closed.
@@ -236,4 +261,15 @@ def geecs_free_run_step_scan(
                 yield from bps.read(dev)
             yield from bps.save()
 
-    yield from _inner()
+    _end_quiesced = {"done": False}
+
+    def _quiesce_before_cleanup():
+        # Abort parity: guarantee the trigger is stopped before the caller's
+        # finalize save-off runs, making completion and abort uniform
+        # (quiesce[OFF] → save-off → disarm[STANDBY] → closeout).  Skipped
+        # when the end-of-scan quiesce above already ran, so a completed
+        # scan does not write OFF twice.
+        if _quiesce is not None and not _end_quiesced["done"]:
+            yield from _quiesce()
+
+    yield from bpp.finalize_wrapper(_inner(), _quiesce_before_cleanup)

--- a/GeecsBluesky/geecs_bluesky/plans/free_run_step_scan.py
+++ b/GeecsBluesky/geecs_bluesky/plans/free_run_step_scan.py
@@ -57,6 +57,7 @@ def geecs_free_run_step_scan(
     disarm_trigger: Callable | None = None,
     quiesce_trigger: Callable | None = None,
     per_step: Callable | None = None,
+    enable_saving: Callable | None = None,
     t0_sync_window_s: float = 0.2,
     tail_flush: bool = True,
     md: dict[str, Any] | None = None,
@@ -108,6 +109,17 @@ def geecs_free_run_step_scan(
         arm/disarm bracketing means per-step actions always run with the
         shot controller *disarmed* (data-taking output off), never inside
         the acquisition window.
+    enable_saving:
+        Optional plan-stub callable that turns native file saving on
+        (typically :func:`~geecs_bluesky.plans.run_wrapper.save_enable_plan`).
+        Run once, immediately **after** the quiesce (OFF — the trigger is
+        stopped) and before the t0-sync stage: no shots can occur from here
+        until the first per-step arm[SCAN], so no orphan frames from the
+        still-free-running trigger get saved during setup actions or the
+        pre-quiesce window (Gate-2 hardware finding).  Without a quiesce
+        hook (no shot control) it runs at the same point, unwindowed —
+        there is no trigger to stop.  Save-*off* stays the run wrapper's
+        innermost finalize, before the caller's disarm.
     t0_sync_window_s:
         Acceptance window for the t0-sync stage.
     tail_flush:
@@ -185,6 +197,11 @@ def geecs_free_run_step_scan(
     _quiesce = quiesce_trigger or disarm_trigger
     if _quiesce is not None:
         yield from _quiesce()
+    if enable_saving is not None:
+        # The trigger is now stopped (OFF) and stays stopped through t0 sync
+        # until the first per-step arm[SCAN] — the earliest orphan-free
+        # moment to start native saving (Gate-2 hardware finding).
+        yield from enable_saving()
     t0s = yield from geecs_t0_sync(sync_devices, window_s=t0_sync_window_s)
     _md["device_t0s"] = t0s
 

--- a/GeecsBluesky/geecs_bluesky/plans/free_run_step_scan.py
+++ b/GeecsBluesky/geecs_bluesky/plans/free_run_step_scan.py
@@ -31,7 +31,7 @@ Run stages
 
 from __future__ import annotations
 
-from typing import Any, Callable, Iterable
+from typing import Any, Callable, Iterable, Sequence
 
 import bluesky.plan_stubs as bps
 import bluesky.preprocessors as bpp
@@ -39,18 +39,24 @@ from bluesky.protocols import Triggerable
 
 from geecs_bluesky.devices.scan_context import ScanContext
 from geecs_bluesky.devices.shot_id import ShotIdSupport
+from geecs_bluesky.plans.step_scan import (
+    motor_md,
+    move_changed_axes,
+    normalize_motors,
+)
 from geecs_bluesky.plans.t0_sync import geecs_t0_sync
 
 
 def geecs_free_run_step_scan(
-    motor: Any | None,
-    positions: Iterable[float | None],
+    motor: Any | Sequence[Any] | None,
+    positions: Iterable[Any],
     reference: Any,
     detectors: list[Any],
     shots_per_step: int = 5,
     arm_trigger: Callable | None = None,
     disarm_trigger: Callable | None = None,
     quiesce_trigger: Callable | None = None,
+    per_step: Callable | None = None,
     t0_sync_window_s: float = 0.2,
     tail_flush: bool = True,
     md: dict[str, Any] | None = None,
@@ -62,12 +68,16 @@ def geecs_free_run_step_scan(
     motor:
         Any Movable/settable device — a stage axis, power supply, pressure
         controller, etc. (anything with ``set() → status``, e.g. built on
-        :class:`~geecs_bluesky.devices.settable.GeecsSettable`).  ``None`` means
-        no scan variable is moved — statistics collection; pass
-        ``positions=[None]`` for a single no-move bin.  The name
+        :class:`~geecs_bluesky.devices.settable.GeecsSettable`).  A
+        **sequence** of Movables is a multi-axis grid scan (one motor per
+        axis, outermost first; each position is then a tuple aligned with
+        the motors, and only the axes whose target changed are re-moved).
+        ``None`` means no scan variable is moved — statistics collection;
+        pass ``positions=[None]`` for a single no-move bin.  The name
         follows the bluesky ``scan(detectors, motor, ...)`` convention.
     positions:
-        Iterable of motor positions to visit.
+        Iterable of motor positions to visit — floats for a single motor,
+        tuples for a grid.
     reference:
         The pacemaker — a Triggerable sync device
         (:class:`~geecs_bluesky.devices.generic_detector.GeecsGenericDetector`)
@@ -91,6 +101,13 @@ def geecs_free_run_step_scan(
         trigger, then read acq_timestamps" procedure — DG645 ``OFF`` state).
         ``SCAN``/``STANDBY`` keep the trigger free-running, so they cannot
         serve this role.  Falls back to ``disarm_trigger`` when not given.
+    per_step:
+        Optional plan-stub callable run at **every** step boundary — after
+        the move completes, before that step's ``arm_trigger``/shots.  This
+        is where a ScanRequest's ``actions.per_step`` plans land: the
+        arm/disarm bracketing means per-step actions always run with the
+        shot controller *disarmed* (data-taking output off), never inside
+        the acquisition window.
     t0_sync_window_s:
         Acceptance window for the t0-sync stage.
     tail_flush:
@@ -128,10 +145,10 @@ def geecs_free_run_step_scan(
         )
 
     _positions = list(positions)
+    _motors = normalize_motors(motor)
     scan_context = ScanContext()
     _read_devices = [reference, *detectors]
-    if motor is not None:
-        _read_devices.append(motor)
+    _read_devices.extend(_motors)
     _read_devices.append(scan_context)
     sync_devices = [
         d
@@ -150,7 +167,7 @@ def geecs_free_run_step_scan(
             reference, "_geecs_device_name", getattr(reference, "name", "")
         ),
         "t0_sync_window_s": t0_sync_window_s,
-        "motor": getattr(motor, "name", None) if motor is not None else None,
+        "motor": motor_md(_motors),
         "detectors": [getattr(d, "name", str(d)) for d in (reference, *detectors)],
         "positions": _positions,
         "shots_per_step": shots_per_step,
@@ -174,9 +191,14 @@ def geecs_free_run_step_scan(
     @bpp.run_decorator(md=_md)
     def _inner():
         scan_event_index = 0
+        previous: tuple | None = None
         for bin_number, pos in enumerate(_positions, start=1):
-            if motor is not None and pos is not None:
-                yield from bps.mv(motor, pos)
+            if _motors and pos is not None:
+                previous = yield from move_changed_axes(_motors, pos, previous)
+            if per_step is not None:
+                # After the move, before arming: per-step actions run with
+                # the shot controller disarmed (outside the SCAN window).
+                yield from per_step()
             if arm_trigger is not None:
                 yield from arm_trigger()
             for shot_index_in_bin in range(1, shots_per_step + 1):

--- a/GeecsBluesky/geecs_bluesky/plans/orchestration.py
+++ b/GeecsBluesky/geecs_bluesky/plans/orchestration.py
@@ -2,34 +2,58 @@
 
 Composes the acquisition-mode plan (free-run reference-paced vs strict
 plan-owned single-shot), the run wrapper (scan numbering, native saving, run
-metadata), and the guaranteed finalize-disarm into a single ready-to-run plan.
-Device construction and configuration stay with the caller — the session
-builds CA devices from factories, the scanner builds either backend from
+metadata), the compiled setup/per-step/closeout action plans, and the
+guaranteed finalize-disarm into a single ready-to-run plan.  Device
+construction and configuration stay with the caller — the session builds CA
+devices from factories, the scanner builds either backend from
 ``exec_config`` — but the *recipe* lives only here, so the two front doors
 cannot drift.
+
+Action placement (the §4.4b/§4.5 seams, decided here):
+
+- **setup** runs first thing inside the composed plan — after every device
+  is connected (construction-time) and the pre-flight has passed (both
+  happen before the RunEngine ever sees this plan), and *before* the
+  free-run quiesce/t0-sync stage and the first step — so setup actions
+  settle device state before timing synchronization, and a failing setup
+  still triggers the finalize chain (saving off → disarm → closeout).
+- **per_step** is yielded by the step plans at every step boundary: after
+  the move completes, before that step's shots (free-run brackets each step
+  with arm/disarm, so per-step actions run *disarmed*; strict fires each
+  shot itself, so the machine is quiescent between plan-owned shots).
+- **closeout** is the outermost ``finalize_wrapper`` — it runs even on
+  mid-scan abort (legacy ActionControl parity), and because it wraps the
+  disarm finalize it always executes *after* the trigger has returned to
+  STANDBY (data-taking output off, trigger free-running).
 """
 
 from __future__ import annotations
 
 import logging
-from typing import Any, Sequence
+from typing import Any, Callable, Sequence
 
 import bluesky.preprocessors as bpp
 
 from geecs_bluesky.exceptions import GeecsConfigurationError
 from geecs_bluesky.plans.free_run_step_scan import geecs_free_run_step_scan
 from geecs_bluesky.plans.run_wrapper import geecs_run_wrapper
-from geecs_bluesky.plans.step_scan import geecs_step_scan
+from geecs_bluesky.plans.step_scan import geecs_step_scan, normalize_motors
 from geecs_bluesky.shot_controller import ShotController
 
 logger = logging.getLogger(__name__)
 
 
+def _chain_setup(setup: Callable, inner):
+    """Prepend the setup plan to *inner* (fresh generator via the callable)."""
+    yield from setup()
+    yield from inner
+
+
 def build_step_scan_plan(
     *,
     strict: bool,
-    motor: Any | None,
-    positions: Sequence[float | None],
+    motor: Any | Sequence[Any] | None,
+    positions: Sequence[Any],
     reference: Any | None,
     detectors: Sequence[Any],
     shots_per_step: int,
@@ -39,6 +63,9 @@ def build_step_scan_plan(
     scan_folder: str | None,
     saving_detectors: Sequence[tuple],
     extra_md: dict[str, Any] | None = None,
+    setup: Callable | None = None,
+    per_step: Callable | None = None,
+    closeout: Callable | None = None,
 ):
     """Build the full scan plan for one step scan / statistics collection.
 
@@ -48,8 +75,10 @@ def build_step_scan_plan(
         ``True`` for plan-owned single-shot (``strict_shot_control``),
         ``False`` for reference-paced free-run (``free_run_time_sync``).
     motor, positions
-        The scan axis and its positions; ``motor=None`` with ``[None]`` is
-        statistics collection (one no-move bin).
+        The scan axis (or axes — a sequence of Movables is a grid, outermost
+        first, with tuple positions) and the positions to visit;
+        ``motor=None`` with ``[None]`` is statistics collection (one no-move
+        bin).
     reference : Any or None
         Free-run pacemaker (required when not strict).
     detectors : sequence
@@ -59,11 +88,16 @@ def build_step_scan_plan(
         required in strict.
     experiment, scan_number, scan_folder, saving_detectors, extra_md
         Forwarded to :func:`~geecs_bluesky.plans.run_wrapper.geecs_run_wrapper`.
+    setup, per_step, closeout : callable, optional
+        Plan-stub callables (each call returns a fresh message generator) —
+        typically compiled ActionPlans.  See the module docstring for the
+        exact placement and abort semantics of each hook.
 
     Returns
     -------
     generator
-        The composed plan (run wrapper + finalize disarm), ready for ``RE()``.
+        The composed plan (setup + run wrapper + finalize disarm + finalize
+        closeout), ready for ``RE()``.
     """
     detectors = list(detectors)
 
@@ -82,6 +116,7 @@ def build_step_scan_plan(
             shots_per_step=shots_per_step,
             setup_trigger=lambda: controller.arm_single_shot(detectors),
             fire_shot=controller.fire_shot,
+            per_step=per_step,
         )
     else:
         if reference is None:
@@ -99,9 +134,16 @@ def build_step_scan_plan(
             arm_trigger=controller.arm if controller else None,
             disarm_trigger=controller.disarm if controller else None,
             quiesce_trigger=controller.quiesce if controller else None,
+            per_step=per_step,
         )
 
-    scalar_devices = detectors + ([motor] if motor is not None else [])
+    if setup is not None:
+        # Setup runs before the free-run quiesce/t0-sync and before the
+        # first step (module docstring); inside the run wrapper so a failed
+        # setup still fires the save-off/disarm/closeout finalizes.
+        inner = _chain_setup(setup, inner)
+
+    scalar_devices = detectors + normalize_motors(motor)
     plan = geecs_run_wrapper(
         inner,
         experiment=experiment,
@@ -111,7 +153,12 @@ def build_step_scan_plan(
         devices=scalar_devices,
         extra_md=extra_md or {},
     )
-    # Outer finalize guarantees the disarm (→ STANDBY) even on mid-scan abort.
+    # Finalize nesting (innermost → outermost): save-off (inside the run
+    # wrapper) → disarm (→ STANDBY) → closeout actions.  Every layer runs
+    # even on mid-scan abort; closeout therefore always executes with the
+    # trigger already disarmed.
     if controller is not None:
         plan = bpp.finalize_wrapper(plan, controller.disarm())
+    if closeout is not None:
+        plan = bpp.finalize_wrapper(plan, closeout)
     return plan

--- a/GeecsBluesky/geecs_bluesky/plans/orchestration.py
+++ b/GeecsBluesky/geecs_bluesky/plans/orchestration.py
@@ -139,6 +139,21 @@ def build_step_scan_plan(
                 "free-run scans require at least one synchronous device as "
                 "the reference (pacemaker)"
             )
+        if controller is None and saving:
+            # Native-save windowing relies on the controller's quiesce to stop
+            # the free-running trigger before saving turns on.  With no shot
+            # control there is no such point, so frames captured during t0-sync
+            # (and any moves) are saved as orphans joining no event row.  This
+            # is inherent to a controllerless free-run scan — surface it loudly
+            # rather than silently save orphans or refuse the (supported) config.
+            logger.warning(
+                "free-run scan has native-saving detectors but no shot "
+                "control: saving cannot be windowed to the trigger-stopped "
+                "span, so frames captured during t0-sync/moves may be saved "
+                "as orphans (no event row). Add a trigger_profile to window "
+                "saving. Detectors: %s",
+                [getattr(t[0], "name", str(t[0])) for t in saving],
+            )
         contributors = [d for d in detectors if d is not reference]
         inner = geecs_free_run_step_scan(
             motor=motor,

--- a/GeecsBluesky/geecs_bluesky/plans/orchestration.py
+++ b/GeecsBluesky/geecs_bluesky/plans/orchestration.py
@@ -25,6 +25,16 @@ Action placement (the §4.4b/§4.5 seams, decided here):
   mid-scan abort (legacy ActionControl parity), and because it wraps the
   disarm finalize it always executes *after* the trigger has returned to
   STANDBY (data-taking output off, trigger free-running).
+
+Native-save windowing (Gate-2 hardware finding, 2026-07-07): saving is
+enabled only while the trigger cannot free-run.  The run wrapper defers its
+save-on (``defer_save_on=True``); the step plans yield
+:func:`~geecs_bluesky.plans.run_wrapper.save_enable_plan` at the first
+orphan-free moment — strict: after ARMED + quiescence confirmation;
+free-run: immediately after quiesce[OFF], before t0-sync.  Setup actions run
+before that point by construction, so their duration can no longer produce
+saved orphan frames (Scan015 saved 6 images for 3 shots).  Save-off remains
+the innermost finalize, before the disarm.
 """
 
 from __future__ import annotations
@@ -36,7 +46,7 @@ import bluesky.preprocessors as bpp
 
 from geecs_bluesky.exceptions import GeecsConfigurationError
 from geecs_bluesky.plans.free_run_step_scan import geecs_free_run_step_scan
-from geecs_bluesky.plans.run_wrapper import geecs_run_wrapper
+from geecs_bluesky.plans.run_wrapper import geecs_run_wrapper, save_enable_plan
 from geecs_bluesky.plans.step_scan import geecs_step_scan, normalize_motors
 from geecs_bluesky.shot_controller import ShotController
 
@@ -100,6 +110,10 @@ def build_step_scan_plan(
         closeout), ready for ``RE()``.
     """
     detectors = list(detectors)
+    saving = list(saving_detectors)
+    # Native-save windowing: saving turns on inside the step plans, at the
+    # first point where the trigger cannot free-run (module docstring).
+    enable_saving = (lambda: save_enable_plan(saving)) if saving else None
 
     if strict:
         if controller is None:
@@ -117,6 +131,7 @@ def build_step_scan_plan(
             setup_trigger=lambda: controller.arm_single_shot(detectors),
             fire_shot=controller.fire_shot,
             per_step=per_step,
+            enable_saving=enable_saving,
         )
     else:
         if reference is None:
@@ -135,6 +150,7 @@ def build_step_scan_plan(
             disarm_trigger=controller.disarm if controller else None,
             quiesce_trigger=controller.quiesce if controller else None,
             per_step=per_step,
+            enable_saving=enable_saving,
         )
 
     if setup is not None:
@@ -149,9 +165,10 @@ def build_step_scan_plan(
         experiment=experiment,
         scan_number=scan_number,
         scan_folder=scan_folder,
-        saving_detectors=list(saving_detectors),
+        saving_detectors=saving,
         devices=scalar_devices,
         extra_md=extra_md or {},
+        defer_save_on=True,
     )
     # Finalize nesting (innermost → outermost): save-off (inside the run
     # wrapper) → disarm (→ STANDBY) → closeout actions.  Every layer runs

--- a/GeecsBluesky/geecs_bluesky/plans/run_wrapper.py
+++ b/GeecsBluesky/geecs_bluesky/plans/run_wrapper.py
@@ -93,6 +93,43 @@ def _save_cleanup_plan(saving_detectors: list[tuple]):
     yield from bps.mv(*mv_args)
 
 
+def save_enable_plan(saving_detectors: list[tuple]):
+    """Plan stub: create save dirs, set ``localsavingpath`` + ``save='on'``.
+
+    The device puts (``:SP`` writes on connected devices) that start native
+    file saving.  Callers that window saving to the trigger-stopped part of
+    the scan (Gate-2 hardware finding: frames from the still-free-running
+    trigger between save-on and arming were saved as orphans joining no
+    event row) pass this as the step plans' ``enable_saving`` hook and give
+    :func:`geecs_run_wrapper` ``defer_save_on=True``; direct
+    ``geecs_run_wrapper`` users keep the eager default.
+
+    Parameters
+    ----------
+    saving_detectors:
+        ``(detector, event_path[, device_command_path])`` tuples, as in
+        :func:`geecs_run_wrapper`.
+
+    Yields
+    ------
+    Bluesky messages (one concurrent ``mv`` over all detectors).
+    """
+    saving = list(saving_detectors or [])
+    if not saving:
+        return
+    mv_args: list = []
+    for det, event_path, device_command_path in map(_saving_detector_paths, saving):
+        os.makedirs(event_path, exist_ok=True)
+        logger.info(
+            "Save path for %s: event=%s, device=%s",
+            det.name,
+            event_path,
+            device_command_path,
+        )
+        mv_args.extend([det.localsavingpath, device_command_path, det.save, "on"])
+    yield from bps.mv(*mv_args)
+
+
 def _collect_scalar_headers(devices: list) -> dict[str, str]:
     """Merge each device's ``_column_headers`` into one event-key → header map.
 
@@ -118,6 +155,7 @@ def geecs_run_wrapper(
     saving_detectors: list[tuple] | None = None,
     devices: list | None = None,
     extra_md: dict[str, Any] | None = None,
+    defer_save_on: bool = False,
 ):
     """Wrap *plan* with GEECS scan-number metadata and native file saving.
 
@@ -136,6 +174,14 @@ def geecs_run_wrapper(
         ``(detector, save_path)`` tuples for devices that write native files.
         Each gets ``localsavingpath`` + ``save="on"`` before the run and
         ``save="off"`` in a finalize wrapper (runs even on abort).
+    defer_save_on:
+        When true, the wrapper does **not** enable saving itself — the inner
+        plan is expected to yield :func:`save_enable_plan` at the point where
+        the trigger can no longer free-run (strict: after ARMED + quiescence;
+        free-run: after quiesce[OFF]), so no orphan frames are saved during
+        setup actions or the pre-arm window (Gate-2 hardware finding).  The
+        finalize ``save="off"`` and the ``nonscalar_save_paths`` metadata are
+        emitted either way.
     devices:
         All devices contributing scalar columns (detectors + scan motor).
         Their ``_column_headers`` are merged into a ``geecs_scalar_headers``
@@ -183,15 +229,9 @@ def geecs_run_wrapper(
         yield from wrapped
         return
 
-    mv_args: list = []
-    for det, event_path, device_command_path in map(_saving_detector_paths, saving):
-        os.makedirs(event_path, exist_ok=True)
-        logger.info(
-            "Save path for %s: event=%s, device=%s",
-            det.name,
-            event_path,
-            device_command_path,
-        )
-        mv_args.extend([det.localsavingpath, device_command_path, det.save, "on"])
-    yield from bps.mv(*mv_args)
+    if not defer_save_on:
+        yield from save_enable_plan(saving)
+    # Save-off stays the innermost finalize: it runs (even on abort) BEFORE
+    # the caller's disarm/closeout finalizes, so saving is always stopped
+    # while the trigger is still unable to free-run.
     yield from bpp.finalize_wrapper(wrapped, _save_cleanup_plan(saving))

--- a/GeecsBluesky/geecs_bluesky/plans/step_scan.py
+++ b/GeecsBluesky/geecs_bluesky/plans/step_scan.py
@@ -52,7 +52,7 @@ Example::
 
 from __future__ import annotations
 
-from typing import Any, Callable, Iterable
+from typing import Any, Callable, Iterable, Sequence
 
 import bluesky.plan_stubs as bps
 import bluesky.preprocessors as bpp
@@ -61,15 +61,98 @@ from geecs_bluesky.devices.scan_context import ScanContext
 from geecs_bluesky.plans.single_shot import geecs_single_shot
 
 
+def normalize_motors(motor: Any | Sequence[Any] | None) -> list[Any]:
+    """Return the motor argument as a list (``None`` → ``[]``).
+
+    Step plans accept a single Movable (the classic 1-D scan), a sequence of
+    Movables (a multi-axis grid — one per axis, outermost first), or ``None``
+    (statistics collection).
+
+    Parameters
+    ----------
+    motor : Movable, sequence of Movable, or None
+        The scan axis (or axes).
+
+    Returns
+    -------
+    list
+        The motors, outermost axis first.
+    """
+    if motor is None:
+        return []
+    if isinstance(motor, (list, tuple)):
+        return list(motor)
+    return [motor]
+
+
+def motor_md(motors: list[Any]) -> Any:
+    """Start-document ``motor`` metadata: name, list of names, or ``None``."""
+    if not motors:
+        return None
+    names = [getattr(m, "name", str(m)) for m in motors]
+    return names[0] if len(names) == 1 else names
+
+
+def move_changed_axes(motors: list[Any], position: Any, previous: tuple | None):
+    """Plan stub: move only the axes whose target changed; return the targets.
+
+    A grid point is a tuple aligned with *motors* (a bare float is the 1-D
+    case).  With the outer product ordering (first axis outermost, last
+    innermost) the innermost axis changes at every grid point while outer
+    axes change rarely — moving only the changed axes avoids re-commanding
+    stationary hardware.  Changed axes are moved **concurrently** via
+    ``bps.mv`` (waits for all).
+
+    Parameters
+    ----------
+    motors : list
+        The scan axes, outermost first.
+    position : float or tuple
+        The grid point to move to (tuple aligned with *motors*).
+    previous : tuple or None
+        The previous grid point (``None`` on the first step — every axis is
+        moved).
+
+    Yields
+    ------
+    Msg
+        Bluesky messages for the move.
+
+    Returns
+    -------
+    tuple
+        The targets just commanded (pass back as *previous* next step).
+
+    Raises
+    ------
+    ValueError
+        If the grid point's length does not match the number of motors.
+    """
+    targets = tuple(position) if isinstance(position, (list, tuple)) else (position,)
+    if len(targets) != len(motors):
+        raise ValueError(
+            f"grid point {targets!r} has {len(targets)} value(s) for "
+            f"{len(motors)} motor(s) — positions must align with the axes"
+        )
+    args: list[Any] = []
+    for m, target, prev in zip(motors, targets, previous or (None,) * len(motors)):
+        if prev is None or target != prev:
+            args.extend([m, target])
+    if args:
+        yield from bps.mv(*args)
+    return targets
+
+
 def geecs_step_scan(
-    motor: Any | None,
-    positions: Iterable[float | None],
+    motor: Any | Sequence[Any] | None,
+    positions: Iterable[Any],
     detectors: list[Any],
     shots_per_step: int = 5,
     arm_trigger: Callable | None = None,
     disarm_trigger: Callable | None = None,
     fire_shot: Callable | None = None,
     setup_trigger: Callable | None = None,
+    per_step: Callable | None = None,
     md: dict[str, Any] | None = None,
 ):
     """Step-scan plan: move *motor* through *positions*, collect *shots_per_step* shots.
@@ -82,12 +165,18 @@ def geecs_step_scan(
         pressure controller, etc. (anything with ``set() → status``, e.g.
         built on :class:`~geecs_bluesky.devices.settable.GeecsSettable`).
         The name follows the bluesky ``scan(detectors, motor, ...)``
-        convention.  ``None`` means no scan variable is moved — statistics
-        collection (the former "NOSCAN" mode); pass ``positions=[None]`` for a
-        single no-move bin.
+        convention.  A **sequence** of Movables is a multi-axis grid scan
+        (one motor per axis, outermost first; each position is then a tuple
+        aligned with the motors).  ``None`` means no scan variable is moved —
+        statistics collection (the former "NOSCAN" mode); pass
+        ``positions=[None]`` for a single no-move bin.
     positions:
-        Iterable of motor positions to visit.  A ``None`` entry is a bin with
-        no motor move (used with ``motor=None``).
+        Iterable of motor positions to visit — floats for a single motor,
+        tuples (one value per motor, outermost axis first) for a grid.  A
+        ``None`` entry is a bin with no motor move (used with
+        ``motor=None``).  At each grid point only the axes whose target
+        changed are re-moved (the innermost axis varies fastest under the
+        outer-product ordering).
     detectors:
         List of :class:`~bluesky.protocols.Readable` / Triggerable devices
         to read at each shot.  The motor is included
@@ -116,6 +205,13 @@ def geecs_step_scan(
         the free-run has stopped (``ARMED`` + quiescence check) — a one-time
         action, distinct from per-step ``arm_trigger``.  Teardown is the
         caller's outer finalize (e.g. disarm to STANDBY).
+    per_step:
+        Optional plan-stub callable run at **every** step boundary — after
+        the move to that step's position completes, before that step's
+        shots.  This is where a ScanRequest's ``actions.per_step`` plans
+        land (vision doc §4.5: per-step actions are a hook plus a named
+        plan, never a new plan type).  In strict mode every shot is
+        plan-owned, so the machine is quiescent while per-step actions run.
     md:
         Extra metadata merged into the RunEngine ``start`` document.
 
@@ -136,10 +232,9 @@ def geecs_step_scan(
       collected, not during motor moves.
     """
     _positions = list(positions)
+    _motors = normalize_motors(motor)
     scan_context = ScanContext()
-    _read_devices = (
-        list(detectors) + ([motor] if motor is not None else []) + [scan_context]
-    )
+    _read_devices = list(detectors) + _motors + [scan_context]
 
     _md: dict[str, Any] = {
         "plan_name": "geecs_step_scan",
@@ -147,7 +242,7 @@ def geecs_step_scan(
         "geecs_event_schema": 1,
         # True when the plan fires each shot (strict single-shot).
         "fires_own_shots": fire_shot is not None,
-        "motor": getattr(motor, "name", None) if motor is not None else None,
+        "motor": motor_md(_motors),
         "detectors": [getattr(d, "name", str(d)) for d in detectors],
         "positions": _positions,
         "shots_per_step": shots_per_step,
@@ -160,9 +255,14 @@ def geecs_step_scan(
         if setup_trigger is not None:
             yield from setup_trigger()
         scan_event_index = 0
+        previous: tuple | None = None
         for bin_number, pos in enumerate(_positions, start=1):
-            if motor is not None and pos is not None:
-                yield from bps.mv(motor, pos)
+            if _motors and pos is not None:
+                previous = yield from move_changed_axes(_motors, pos, previous)
+            if per_step is not None:
+                # After the move, before this step's plan-owned shots — the
+                # machine is quiescent here (strict fires each shot itself).
+                yield from per_step()
             if arm_trigger is not None:
                 yield from arm_trigger()
             for shot_index_in_bin in range(1, shots_per_step + 1):

--- a/GeecsBluesky/geecs_bluesky/plans/step_scan.py
+++ b/GeecsBluesky/geecs_bluesky/plans/step_scan.py
@@ -153,6 +153,7 @@ def geecs_step_scan(
     fire_shot: Callable | None = None,
     setup_trigger: Callable | None = None,
     per_step: Callable | None = None,
+    enable_saving: Callable | None = None,
     md: dict[str, Any] | None = None,
 ):
     """Step-scan plan: move *motor* through *positions*, collect *shots_per_step* shots.
@@ -212,6 +213,15 @@ def geecs_step_scan(
         land (vision doc §4.5: per-step actions are a hook plus a named
         plan, never a new plan type).  In strict mode every shot is
         plan-owned, so the machine is quiescent while per-step actions run.
+    enable_saving:
+        Optional plan-stub callable that turns native file saving on
+        (typically :func:`~geecs_bluesky.plans.run_wrapper.save_enable_plan`).
+        Run once, **after** ``setup_trigger`` — i.e. after ARMED +
+        quiescence confirmation in strict mode, when the trigger can no
+        longer free-run — so no orphan frames from a still-running trigger
+        are saved during the pre-arm window (Gate-2 hardware finding).
+        Save-*off* stays the run wrapper's innermost finalize, before the
+        caller's disarm.
     md:
         Extra metadata merged into the RunEngine ``start`` document.
 
@@ -254,6 +264,11 @@ def geecs_step_scan(
     def _inner():
         if setup_trigger is not None:
             yield from setup_trigger()
+        if enable_saving is not None:
+            # Only after the trigger is stopped (ARMED + quiescence in
+            # strict) may native saving start — otherwise residual free-run
+            # frames get saved as orphans joining no event row.
+            yield from enable_saving()
         scan_event_index = 0
         previous: tuple | None = None
         for bin_number, pos in enumerate(_positions, start=1):

--- a/GeecsBluesky/geecs_bluesky/scan_log.py
+++ b/GeecsBluesky/geecs_bluesky/scan_log.py
@@ -1,0 +1,114 @@
+"""Per-scan ``scan.log`` file handling, shared by the bridge and the session.
+
+Every legacy scan folder carries a ``scan.log``; the Bluesky stack matches
+that with a scoped ``logging.FileHandler`` attached for the duration of one
+scan.  Extracted verbatim from ``BlueskyScanner._scan_log`` (Gate-2 finding:
+headless ``GeecsSession.run()`` scans had no scan.log because the helper was
+bridge-internal) so both front doors share one implementation — the session
+must not import the bridge.
+
+The handler captures the whole scan story, not just this package: during
+optimization scans the evaluator (``geecs_scanner.optimization``) and its
+analyzers (``scan_analysis``, ``image_analysis``) do the per-bin work, and
+their file-mapping / objective lines belong in ``scan.log`` too.
+"""
+
+from __future__ import annotations
+
+import logging
+from contextlib import contextmanager
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+#: Logger namespaces captured into every scan.log (see module docstring).
+CAPTURE_LOGGER_NAMES = (
+    "geecs_bluesky",
+    "geecs_scanner.optimization",
+    "scan_analysis",
+    "image_analysis",
+)
+
+
+class ScanLogContextFilter(logging.Filter):
+    """Add scan id context to records written to one scan log."""
+
+    def __init__(self, scan_id: str) -> None:
+        super().__init__()
+        self._scan_id = scan_id
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        """Stamp *record* with the scan id; never drops records.
+
+        Parameters
+        ----------
+        record : logging.LogRecord
+            The record about to be written to the scan log.
+
+        Returns
+        -------
+        bool
+            Always ``True``.
+        """
+        record.scan_id = self._scan_id
+        return True
+
+
+@contextmanager
+def scan_log(scan_number: int | None, scan_folder: str | None):
+    """Attach a per-scan ``scan.log`` file handler for the enclosed block.
+
+    A no-op when the scan number/folder are unknown (nothing was claimed —
+    e.g. ``save_data=False`` or the NetApp is unreachable) or the folder
+    does not exist.  On exit the handler is removed and closed and every
+    captured logger's level is restored, even on abort.
+
+    Parameters
+    ----------
+    scan_number : int or None
+        The claimed day-scoped scan number.
+    scan_folder : str or None
+        The claimed ``scans/ScanNNN`` folder path.
+
+    Yields
+    ------
+    None
+        Run the scan inside the ``with`` block.
+    """
+    if scan_number is None or scan_folder is None:
+        yield
+        return
+
+    folder = Path(scan_folder)
+    if not folder.is_dir():
+        logger.warning("Scan folder %s does not exist; skipping scan.log", folder)
+        yield
+        return
+
+    scan_id = f"Scan{scan_number:03d}"
+    handler = logging.FileHandler(folder / "scan.log", encoding="utf-8")
+    handler.setLevel(logging.INFO)
+    handler.setFormatter(
+        logging.Formatter(
+            "%(asctime)s.%(msecs)03d %(levelname)s %(name)s "
+            "[%(threadName)s] scan=%(scan_id)s - %(message)s",
+            datefmt="%Y-%m-%d %H:%M:%S",
+        )
+    )
+    handler.addFilter(ScanLogContextFilter(scan_id))
+
+    capture_loggers = [logging.getLogger(name) for name in CAPTURE_LOGGER_NAMES]
+    old_levels = [lg.level for lg in capture_loggers]
+    for lg in capture_loggers:
+        if lg.level == logging.NOTSET or lg.level > logging.INFO:
+            lg.setLevel(logging.INFO)
+        lg.addHandler(handler)
+    try:
+        logger.info("scan %s: starting (dir=%s)", scan_id, scan_folder)
+        yield
+        logger.info("scan %s: finished", scan_id)
+    finally:
+        for lg, old_level in zip(capture_loggers, old_levels):
+            lg.removeHandler(handler)
+            lg.setLevel(old_level)
+        handler.close()

--- a/GeecsBluesky/geecs_bluesky/scan_request_runner.py
+++ b/GeecsBluesky/geecs_bluesky/scan_request_runner.py
@@ -16,30 +16,35 @@ This module owns the mapping:
   ``schema_version`` key loads as the new schema directly; anything else is
   converted from its legacy dialect via :mod:`geecs_schemas.convert` — so the
   whole existing config corpus is usable immediately, no flag day.
-- Pure mapping helpers derive the legacy engine shapes from the schemas:
+- Pure mapping helpers derive the engine shapes from the schemas:
   :func:`save_set_to_devices_config` (SaveSet → the ``devices_config`` dict
   ``BlueskyScanner._build_session_devices`` / the session factories expect,
   applying the documented intent→mechanics derivation rules) and
-  :func:`shot_control_config_from_trigger_profile` (TriggerProfile →
-  :class:`~geecs_bluesky.models.shot_control.ShotControlConfig`).  The
-  adapter lives *here* — bluesky-side — because ``geecs_schemas`` must never
-  import ``geecs_bluesky`` (dependency direction).
+  :func:`trigger_writes_from_profile` (TriggerProfile →
+  :class:`~geecs_bluesky.models.shot_control.ShotControlWrites`: per-state
+  **ordered** multi-device write lists — order preserved exactly as the
+  schema documents).  The adapters live *here* — bluesky-side — because
+  ``geecs_schemas`` must never import ``geecs_bluesky`` (dependency
+  direction).
+- **Actions execute.**  Request-level ``setup``/``per_step``/``closeout``
+  bindings, SaveSet entry rituals, and ExperimentDefaults plans are
+  assembled (:func:`assemble_action_slots`), compiled to plan stubs
+  (:func:`~geecs_bluesky.plans.action_compiler.compile_action_plan`) against
+  the session's CA signal factory, and handed to the orchestration hooks.
+  Names still resolve fail-fast **pre-claim** (an unknown plan name fails
+  before any hardware is touched or a scan number is used), and every
+  signal a plan will touch is pre-connected
+  (:func:`prefetch_action_signals`) before the RunEngine runs — a lazy
+  connect inside the RE loop would deadlock.
+- **Multi-axis step scans execute** as an outer-product grid (first axis
+  outermost/slowest — the schema's documented semantics): N movables, one
+  bin per grid point, per-step actions at every grid point, all axis
+  readbacks in the event rows.
 - :func:`run_scan_request` executes the request on a
   :class:`~geecs_bluesky.session.GeecsSession`.
 
 Deliberate v1 gaps (validated, then refused loudly — never silently wrong):
 
-- **Multi-axis step scans** are accepted by the schema but raise
-  ``NotImplementedError`` here — grid execution lands with the actions
-  milestone.
-- **Actions** (``setup`` / ``per_step`` / ``closeout``, request-level and
-  SaveSet entry-level alike): the names are resolved and validated against
-  the action library *now*, then ``NotImplementedError`` is raised — the
-  ActionPlan→plan-stub compiler is being built in a parallel milestone.
-- **Multi-device trigger profiles**: the adapter takes the single-device
-  fast path (all writes in all states name one device — whether declared
-  top-level or per write); writes spanning devices raise
-  ``NotImplementedError`` — the engine's ShotController drives one device.
 - **Pseudo (composite) scan variables** raise ``NotImplementedError`` — the
   composite pseudo-positioner device is not built yet.
 - **``all_scalars``** on a save-set entry raises ``NotImplementedError`` —
@@ -51,7 +56,9 @@ Deliberate v1 gaps (validated, then refused loudly — never silently wrong):
   (the config-driven Xopt/evaluator stack lives in
   ``geecs_scanner.optimization``, which geecs_bluesky must not import), so a
   ready-made ``objective`` and ``suggester`` must be injected; without them
-  optimize mode raises ``NotImplementedError``.
+  optimize mode raises ``NotImplementedError``.  Action bindings on an
+  optimize-mode request are likewise refused (``GeecsSession.optimize`` has
+  no action hooks yet).
 
 Scan variables in configs speak **GEECS device/variable names, never PVs**
 (maintainer-ratified convention): all PV derivation stays inside the device
@@ -60,14 +67,17 @@ factories via ``ca_pv``.
 
 from __future__ import annotations
 
+import itertools
 import logging
+from collections.abc import Mapping
 from pathlib import Path
-from typing import Any, Protocol, runtime_checkable
+from typing import Any, Callable, Protocol, runtime_checkable
 
 import yaml
 
 from geecs_bluesky.exceptions import GeecsConfigurationError
-from geecs_bluesky.models.shot_control import ShotControlConfig
+from geecs_bluesky.models.shot_control import ShotControlWrites
+from geecs_bluesky.plans.action_compiler import compile_action_plan
 from geecs_bluesky.scanner_configs import SHOT_CONTROL_FOLDER, scanner_configs_base
 from geecs_schemas import (
     ActionBindings,
@@ -86,6 +96,7 @@ from geecs_schemas import (
     TriggerProfile,
     TriggerState,
 )
+from geecs_schemas.action_plan import CheckStep, RunPlanStep, SetStep
 from geecs_schemas.convert import (
     convert_action_library,
     convert_save_element,
@@ -95,7 +106,14 @@ from geecs_schemas.convert import (
 
 logger = logging.getLogger(__name__)
 
-MULTI_AXIS_MESSAGE = "multi-axis execution lands with the actions milestone"
+#: GUI-bridge refusal (the *bridge* still stages requests through the legacy
+#: exec-config machinery; the engine itself executes grids — see
+#: ``run_scan_request``).
+MULTI_AXIS_MESSAGE = (
+    "the GUI bridge does not execute multi-axis grids yet — run the request "
+    "headless via GeecsSession.run, where grid execution landed with the "
+    "M3b milestone; GUI submission is a later milestone"
+)
 
 
 # ---------------------------------------------------------------------------
@@ -381,6 +399,27 @@ class ConfigsRepoResolver:
                 f"action library. Known plans: {sorted(library.plans)}"
             ) from None
 
+    def action_plan_registry(self) -> dict[str, ActionPlan]:
+        """Return every named plan visible to nested ``run`` steps.
+
+        The experiment's action library plus the plans the save-element
+        converter extracted (which win on a name collision, matching
+        :meth:`resolve_action_plan`'s lookup order).  An experiment without
+        an action library still gets its extracted element plans.
+
+        Returns
+        -------
+        dict
+            ``{plan_name: ActionPlan}``.
+        """
+        plans: dict[str, ActionPlan] = {}
+        try:
+            plans.update(self._action_library().plans)
+        except GeecsConfigurationError:
+            pass  # no actions.yaml — extracted element plans may still exist
+        plans.update(self._extracted_element_actions)
+        return plans
+
     DEFAULTS_FILE = "experiment_defaults.yaml"
 
     def resolve_experiment_defaults(self) -> ExperimentDefaults | None:
@@ -408,11 +447,6 @@ class ConfigsRepoResolver:
 # ---------------------------------------------------------------------------
 
 
-MULTI_DEVICE_TRIGGER_MESSAGE = (
-    "multi-device trigger profiles land with a later milestone"
-)
-
-
 def _state_write_triples(
     profile: TriggerProfile, state: "TriggerState", variant: str | None
 ) -> list[tuple[str | None, str, str]]:
@@ -421,7 +455,8 @@ def _state_write_triples(
     Handles both TriggerProfile generations: the single-device shape
     (top-level ``device`` + per-state ``{variable: value}``) and the
     multi-device shape (per-state ordered write lists, each write carrying
-    its own ``device``).
+    its own ``device``).  Order is preserved exactly (schema-documented:
+    writes are applied top to bottom).
 
     Parameters
     ----------
@@ -450,72 +485,64 @@ def _state_write_triples(
     return triples
 
 
-def shot_control_config_from_trigger_profile(
+def trigger_writes_from_profile(
     profile: TriggerProfile, variant: str | None = None
-) -> ShotControlConfig:
-    """Pivot a TriggerProfile into the engine's ShotControlConfig shape.
+) -> ShotControlWrites:
+    """Adapt a TriggerProfile into the engine's generalized ShotControlWrites.
 
-    The two models share semantics (named states, verbatim wire values,
-    omission = no-op); only the layout differs — the profile is per-state,
-    the engine config is per-variable ``{variable: {state: value}}``.
-    ``defines_state`` / ``values_for_state`` answers are preserved exactly.
-    This adapter lives bluesky-side because ``geecs_schemas`` must not
-    import ``geecs_bluesky``.
-
-    **Single-device fast path only** (schema-accepts / engine-pending, the
-    same pattern as multi-axis): a profile whose writes all target one
-    device adapts exactly as before — whether it declares the device at the
-    top level (single-device shape) or per write (multi-device shape).  A
-    profile whose writes span several devices is accepted by the schema but
-    raises ``NotImplementedError`` here: the engine's ``ShotController``
-    drives one device today.
+    A state transition becomes the profile's **ordered** write list — order
+    preserved verbatim (schema-documented: writes are applied top to
+    bottom), spanning as many devices as the profile names.  A single-device
+    profile is simply the one-device case of the same structure; there is no
+    separate pivot any more (the engine's ``ShotController.from_writes``
+    replays these lists sequentially, each write completing before the
+    next).  This adapter lives bluesky-side because ``geecs_schemas`` must
+    not import ``geecs_bluesky``.
 
     Parameters
     ----------
     profile :
         The trigger profile to adapt.
     variant :
-        Optional profile variant overlaid before pivoting (e.g.
-        ``"laser_off"``).
+        Optional profile variant overlaid first (e.g. ``"laser_off"``).
 
     Returns
     -------
-    ShotControlConfig
-        The engine-facing shot-control configuration.
+    ShotControlWrites
+        Per-state ordered ``(device, variable, value)`` write lists.
 
     Raises
     ------
     GeecsConfigurationError
-        If *variant* is not defined on the profile, or no trigger device
-        can be determined at all.
-    NotImplementedError
-        If the profile's writes span more than one device.
+        If *variant* is not defined on the profile, or no state writes any
+        device at all (the profile cannot drive a scan's trigger).
     """
     if variant is not None and variant not in profile.variants:
         raise GeecsConfigurationError(
             f"trigger profile {profile.name!r} has no variant {variant!r}. "
             f"Known variants: {sorted(profile.variants)}"
         )
-    variables: dict[str, dict[str, str]] = {}
-    devices: list[str] = []
+    states: dict[str, list[tuple[str, str, str]]] = {}
+    any_device = False
     for state in TriggerState:
+        triples: list[tuple[str, str, str]] = []
         for device, variable, value in _state_write_triples(profile, state, variant):
-            if device is not None and device not in devices:
-                devices.append(device)
-            variables.setdefault(variable, {})[state.value] = value
-    if len(devices) > 1:
-        raise NotImplementedError(
-            f"{MULTI_DEVICE_TRIGGER_MESSAGE} — trigger profile "
-            f"{profile.name!r} writes to {devices}; the engine's shot "
-            "controller drives exactly one device today"
-        )
-    device = devices[0] if devices else getattr(profile, "device", None)
-    if not device:
+            if device is None:
+                raise GeecsConfigurationError(
+                    f"trigger profile {profile.name!r} has a write to "
+                    f"{variable!r} with no device — it cannot be sent"
+                )
+            triples.append((device, variable, value))
+            any_device = True
+        if triples:
+            states[state.value] = triples
+    if not any_device:
         raise GeecsConfigurationError(
             f"trigger profile {profile.name!r} names no trigger device — "
             "it cannot drive a scan's trigger"
         )
-    return ShotControlConfig(device=device, variables=variables)
+    name = getattr(profile, "name", "") or ""
+    return ShotControlWrites(name=name, states=states)
 
 
 def save_set_to_devices_config(save_set: SaveSet) -> dict[str, dict[str, Any]]:
@@ -592,9 +619,10 @@ def resolve_and_validate_actions(
 ) -> dict[str, list[str]]:
     """Resolve every action name in the bindings against the library.
 
-    Validation now, execution later: each name must exist (the resolver
-    raises otherwise); the caller refuses to *run* them until the
-    ActionPlan→plan-stub compiler lands.
+    Fail-fast, pre-claim: each name must exist (the resolver raises
+    otherwise) before any hardware is touched.  The engine then compiles
+    and executes the assembled slots (:func:`assemble_action_slots`); the
+    GUI bridge still refuses them (:func:`raise_if_actions_present`).
 
     Parameters
     ----------
@@ -618,15 +646,295 @@ def resolve_and_validate_actions(
 
 
 def raise_if_actions_present(resolved: dict[str, list[str]]) -> None:
-    """Refuse (loudly) to execute validated action bindings — v1 gap."""
+    """Refuse validated action bindings — **GUI-bridge path only**.
+
+    The engine executes actions (see :func:`run_scan_request`); the GUI
+    bridge still stages requests through the legacy exec-config machinery
+    and does not run them yet.  Names were already resolved and are valid.
+    """
     present = {slot: names for slot, names in resolved.items() if names}
     if present:
         raise NotImplementedError(
-            f"action execution lands with the actions milestone (the "
-            f"ActionPlan compiler is being built in a parallel milestone); "
-            f"the request's action names were resolved and are valid: "
-            f"{present}"
+            f"the GUI bridge does not execute action bindings yet — run the "
+            f"request headless via GeecsSession.run (action execution landed "
+            f"with the M3b milestone); the request's action names were "
+            f"resolved and are valid: {present}"
         )
+
+
+# ---------------------------------------------------------------------------
+# Action assembly + compilation (the §4.4b layers, executed)
+# ---------------------------------------------------------------------------
+
+
+def collect_save_set_rituals(save_set: SaveSet) -> dict[str, list[str]]:
+    """Collect entry-level setup/closeout plan names, de-duplicated by name.
+
+    The SaveSet schema's contract: the plans named by all entries are
+    collected together (entry order preserved), de-duplicated by name, and
+    each runs **once** per scan — two cameras sharing a ``prep_visa_line``
+    ritual do not run it twice.  Older SaveSets without the fields
+    contribute nothing (duck-typed).
+
+    Parameters
+    ----------
+    save_set :
+        The save set to inspect.
+
+    Returns
+    -------
+    dict
+        ``{"setup": [names], "closeout": [names]}``, each list de-duplicated
+        in first-appearance order.
+    """
+    rituals: dict[str, list[str]] = {"setup": [], "closeout": []}
+    for slot, names in rituals.items():
+        seen: set[str] = set()
+        for entry in save_set.entries:
+            value = getattr(entry, slot, None)
+            if not value:
+                continue
+            for name in value if isinstance(value, (list, tuple)) else [value]:
+                if name not in seen:
+                    seen.add(name)
+                    names.append(name)
+    return rituals
+
+
+def resolve_save_set_and_rituals(
+    resolver: ConfigResolver, name: str
+) -> tuple[SaveSet, dict[str, list[str]]]:
+    """Resolve a save set and validate its entry-level ritual references.
+
+    Every referenced plan name is resolved against the action library now
+    (fail-fast, pre-claim); execution happens later through the assembled
+    slots (:func:`assemble_action_slots`).
+
+    Parameters
+    ----------
+    resolver :
+        Where names are looked up.
+    name :
+        The save set name.
+
+    Returns
+    -------
+    tuple
+        ``(save_set, rituals)`` — the resolved save set and its
+        de-duplicated ``{"setup": [...], "closeout": [...]}`` ritual names.
+    """
+    save_set = resolver.resolve_save_set(name)
+    rituals = collect_save_set_rituals(save_set)
+    for names in rituals.values():
+        for action_name in names:
+            resolver.resolve_action_plan(action_name)
+    return save_set, rituals
+
+
+def assemble_action_slots(
+    actions: ActionBindings,
+    applied_defaults: Mapping[str, Any],
+    rituals: Mapping[str, list[str]],
+) -> dict[str, list[str]]:
+    """Assemble the final ordered plan-name lists for the three action slots.
+
+    The §4.4b setup layers nest like context managers (mirrored teardown —
+    the ordering decision ratified with this milestone and documented in
+    the ``ExperimentDefaults`` schema):
+
+    - **setup**: experiment defaults → save-set entry rituals → the scan's
+      own ``actions.setup`` (defaults outermost, the specific scan
+      innermost).
+    - **per_step**: the scan's own ``actions.per_step`` only (neither
+      defaults nor entries have a per-step slot — deliberate).
+    - **closeout**: the exact reverse — the scan's own ``actions.closeout``
+      → entry rituals → experiment defaults.
+
+    *actions* is the post-defaults request bindings (defaults already merged
+    by :func:`apply_experiment_defaults`: prepended to setup, appended to
+    closeout); *applied_defaults* tells this function how many entries of
+    each list came from defaults, so entry rituals can be spliced between
+    the layers.  Within the entry layer, first-appearance entry order is
+    kept for both slots (the schema orders the layers, not the entries).
+
+    Parameters
+    ----------
+    actions :
+        The request's action bindings, after defaults were applied.
+    applied_defaults :
+        The provenance record from :func:`apply_experiment_defaults`.
+    rituals :
+        The save set's ``{"setup": [...], "closeout": [...]}`` names.
+
+    Returns
+    -------
+    dict
+        ``{"setup": [...], "per_step": [...], "closeout": [...]}`` in final
+        execution order.
+    """
+    n_setup_defaults = len(applied_defaults.get("actions.setup", []))
+    merged_setup = list(actions.setup)  # defaults first, then the scan's own
+    setup = (
+        merged_setup[:n_setup_defaults]
+        + list(rituals.get("setup", []))
+        + merged_setup[n_setup_defaults:]
+    )
+    n_closeout_defaults = len(applied_defaults.get("actions.closeout", []))
+    merged_closeout = list(actions.closeout)  # scan's own first, defaults last
+    cut = len(merged_closeout) - n_closeout_defaults
+    closeout = (
+        merged_closeout[:cut]
+        + list(rituals.get("closeout", []))
+        + merged_closeout[cut:]
+    )
+    return {
+        "setup": setup,
+        "per_step": list(actions.per_step),
+        "closeout": closeout,
+    }
+
+
+class _LazyResolverRegistry(Mapping):
+    """Mapping façade over ``resolver.resolve_action_plan`` (fallback only).
+
+    Used when a resolver does not expose ``action_plan_registry()``; nested
+    ``run`` steps then resolve lazily by name.  Iteration/len are empty (the
+    known-name list is the resolver's business), so a missing nested plan's
+    error message lists no candidates — resolvers wanting better messages
+    should implement ``action_plan_registry``.
+    """
+
+    def __init__(self, resolver: ConfigResolver) -> None:
+        self._resolver = resolver
+
+    def __getitem__(self, name: str) -> ActionPlan:
+        try:
+            return self._resolver.resolve_action_plan(name)
+        except Exception:
+            raise KeyError(name) from None
+
+    def get(self, name: str, default: Any = None) -> Any:
+        """Resolve *name*, returning *default* when the resolver refuses."""
+        try:
+            return self._resolver.resolve_action_plan(name)
+        except Exception:
+            return default
+
+    def __iter__(self):
+        return iter(())
+
+    def __len__(self) -> int:
+        return 0
+
+
+def build_action_registry(resolver: ConfigResolver) -> Mapping[str, ActionPlan]:
+    """Return the named-plan registry nested ``run`` steps resolve against.
+
+    Prefers the resolver's ``action_plan_registry()`` (duck-typed —
+    :class:`ConfigsRepoResolver` implements it: the experiment's action
+    library plus any plans extracted from converted save elements); falls
+    back to a lazy per-name façade.
+
+    Parameters
+    ----------
+    resolver :
+        The name resolver.
+
+    Returns
+    -------
+    Mapping
+        ``{plan_name: ActionPlan}`` (possibly lazy).
+    """
+    method = getattr(resolver, "action_plan_registry", None)
+    if callable(method):
+        return method()
+    return _LazyResolverRegistry(resolver)
+
+
+def prefetch_action_signals(
+    plans: list[ActionPlan],
+    registry: Mapping[str, ActionPlan],
+    settables: Any,
+) -> None:
+    """Create/connect every signal the compiled *plans* will touch, up front.
+
+    Compiled plan generators execute **inside** the RunEngine's event loop,
+    where a blocking signal connect would deadlock — so every
+    ``(device, variable)`` a ``set``/``check`` step names is touched here
+    first (the factory caches per target, so execution finds everything
+    connected).  Doubles as fail-fast validation: an unreachable target
+    fails now, before the scan claims a number.  Nested ``run`` steps are
+    walked recursively (visited-set bounded, so cycles terminate — the
+    compiler itself raises on them at execution).
+
+    Parameters
+    ----------
+    plans :
+        The resolved plans of every slot about to run.
+    registry :
+        Named plans for ``run``-step recursion.
+    settables :
+        The :class:`~geecs_bluesky.plans.action_compiler.SettableFactory`.
+    """
+    visited: set[str] = set()
+
+    def _walk(plan: ActionPlan) -> None:
+        for step in plan.steps:
+            if isinstance(step, SetStep):
+                settables.get_settable(step.device, step.variable)
+            elif isinstance(step, CheckStep):
+                settables.get_readable(step.device, step.variable)
+            elif isinstance(step, RunPlanStep):
+                if step.plan in visited:
+                    continue
+                visited.add(step.plan)
+                nested = registry.get(step.plan)
+                if nested is not None:
+                    _walk(nested)
+
+    for plan in plans:
+        _walk(plan)
+
+
+def compile_action_slot(
+    names: list[str],
+    resolver: ConfigResolver,
+    registry: Mapping[str, ActionPlan],
+    settables: Any,
+) -> tuple[Callable | None, list[ActionPlan]]:
+    """Compile one slot's plan names into a reusable plan-stub callable.
+
+    The returned callable yields the slot's plans in order, producing a
+    **fresh** message generator per call — required for ``per_step`` (run at
+    every step boundary) and for ``finalize_wrapper`` (which may instantiate
+    its closeout more than once).
+
+    Parameters
+    ----------
+    names :
+        The slot's plan names, in final execution order.
+    resolver :
+        Resolves each name to its :class:`ActionPlan`.
+    registry :
+        Named plans for nested ``run`` steps.
+    settables :
+        The signal factory the compiled steps draw from.
+
+    Returns
+    -------
+    tuple
+        ``(stub, plans)`` — the plan-stub callable (``None`` when the slot
+        is empty) and the resolved plans (for signal prefetching).
+    """
+    if not names:
+        return None, []
+    plans = [resolver.resolve_action_plan(name) for name in names]
+
+    def _slot_plan():
+        for plan in plans:
+            yield from compile_action_plan(plan, registry=registry, settables=settables)
+
+    return _slot_plan, plans
 
 
 def collect_save_set_action_names(save_set: SaveSet) -> list[str]:
@@ -657,12 +965,13 @@ def collect_save_set_action_names(save_set: SaveSet) -> list[str]:
 
 
 def resolve_save_set_checked(resolver: ConfigResolver, name: str) -> SaveSet:
-    """Resolve a save set and give its entry-level action refs the M3b treatment.
+    """Resolve a save set, refusing entry-level rituals — **GUI-bridge path only**.
 
-    Entry-level setup/closeout references are *validated* against the
-    action library now (unknown names fail loudly), then refused with
-    ``NotImplementedError`` — exactly like the request-level action
-    bindings, until the ActionPlan compiler lands.
+    The engine executes entry rituals (see
+    :func:`resolve_save_set_and_rituals` / :func:`run_scan_request`); the
+    GUI bridge stages requests through the legacy exec-config machinery and
+    does not run them yet.  References are *validated* first (unknown names
+    fail loudly), then refused.
 
     Parameters
     ----------
@@ -676,15 +985,15 @@ def resolve_save_set_checked(resolver: ConfigResolver, name: str) -> SaveSet:
     SaveSet
         The resolved save set (guaranteed free of entry-level actions).
     """
-    save_set = resolver.resolve_save_set(name)
-    entry_actions = collect_save_set_action_names(save_set)
-    for action_name in entry_actions:
-        resolver.resolve_action_plan(action_name)
+    save_set, rituals = resolve_save_set_and_rituals(resolver, name)
+    entry_actions = [n for names in rituals.values() for n in names]
     if entry_actions:
         raise NotImplementedError(
-            f"action execution lands with the actions milestone; save set "
-            f"{name!r} references entry-level setup/closeout plans, which "
-            f"were resolved and are valid: {entry_actions}"
+            f"the GUI bridge does not execute save-set entry rituals yet — "
+            f"run the request headless via GeecsSession.run (ritual "
+            f"execution landed with the M3b milestone); save set {name!r} "
+            f"references entry-level setup/closeout plans, which were "
+            f"resolved and are valid: {entry_actions}"
         )
     return save_set
 
@@ -695,11 +1004,13 @@ def apply_experiment_defaults(
     """Apply experiment defaults where the request is silent (with provenance).
 
     The merge rule is the :class:`~geecs_schemas.ExperimentDefaults` one —
-    **defaults run first, then the scan's own**: a default trigger profile
-    is used only when the request names none; default setup/closeout plans
-    are *prepended* to the request's own lists.  What was applied is
-    returned for provenance (recorded into the run metadata by
-    :func:`run_scan_request`) — a run's metadata must show the
+    **defaults run first on the way in and last on the way out**: a default
+    trigger profile is used only when the request names none; default setup
+    plans are *prepended* to the request's own setup list, and default
+    closeout plans are *appended* after the request's own closeout list
+    (teardown mirrors setup — the defaults are the outermost bracket).
+    What was applied is returned for provenance (recorded into the run
+    metadata by :func:`run_scan_request`) — a run's metadata must show the
     configuration it actually used, not require reconstructing which
     defaults file was in force.
 
@@ -744,8 +1055,10 @@ def apply_experiment_defaults(
         if not value:
             continue
         names = list(value) if isinstance(value, (list, tuple)) else [value]
-        # Defaults run first, then the scan's own plans.
-        slot_updates[slot] = names + list(getattr(request.actions, slot))
+        own = list(getattr(request.actions, slot))
+        # Mirrored bracket: default setup runs before the scan's own,
+        # default closeout runs after it (the ExperimentDefaults merge rule).
+        slot_updates[slot] = names + own if slot == "setup" else own + names
         applied[f"actions.{slot}"] = names
     if slot_updates:
         updates["actions"] = request.actions.model_copy(update=slot_updates)
@@ -878,10 +1191,21 @@ def run_scan_request(
 ) -> str | None:
     """Execute *request* on *session*; return the run uid.
 
-    Resolution order is fail-fast: action names and the multi-axis limit are
-    checked before any hardware is touched, then the trigger profile is
-    attached, then devices are built, then the scan runs.  Devices created
-    here are disconnected afterwards (the run owns what it creates).
+    Resolution order is fail-fast: every action name (request-level, entry
+    rituals, defaults) is resolved before any hardware is touched, the
+    trigger profile is attached (generalized multi-device ordered writes),
+    action plans are compiled and their signals pre-connected, devices are
+    built, then the scan runs — all of it before a scan number is claimed
+    (the claim happens inside ``session.scan``).  Devices *and* the action
+    signal factory created here are disconnected afterwards (the run owns
+    what it creates).
+
+    Multi-axis requests run as an outer-product grid (first axis
+    outermost/slowest): one movable per axis, one bin per grid point,
+    ``per_step`` actions at every grid point, all axis readbacks in the
+    event rows; the run metadata carries ``scan_axes`` / ``grid_shape`` /
+    ``num_grid_points`` and ScanInfo's 1-D fields describe the outermost
+    axis.
 
     Parameters
     ----------
@@ -904,22 +1228,19 @@ def run_scan_request(
     Raises
     ------
     NotImplementedError
-        Multi-axis requests, requests with action bindings, pseudo scan
-        variables, and optimize mode without an injected objective/suggester
-        (all documented v1 gaps — validated first, refused loudly).
+        Pseudo scan variables, and optimize mode without an injected
+        objective/suggester or with action bindings (the documented v1
+        gaps — validated first, refused loudly).
     GeecsConfigurationError
         Unresolvable names, or a step/noscan request without a save set.
     """
     request, applied_defaults = resolve_defaults_for(resolver, request)
     resolved_actions = resolve_and_validate_actions(request.actions, resolver)
-    raise_if_actions_present(resolved_actions)
-    if request.mode is ScanRequestMode.STEP and len(request.axes) > 1:
-        raise NotImplementedError(MULTI_AXIS_MESSAGE)
 
     if request.trigger_profile:
         profile = resolver.resolve_trigger_profile(request.trigger_profile)
         session.shot_control(
-            shot_control_config_from_trigger_profile(profile, request.trigger_variant)
+            trigger_writes_from_profile(profile, request.trigger_variant)
         )
     else:
         session.shot_control(None)
@@ -927,6 +1248,13 @@ def run_scan_request(
     mode = "strict" if request.acquisition is AcquisitionMode.STRICT else "free_run"
 
     if request.mode is ScanRequestMode.OPTIMIZE:
+        if any(resolved_actions.values()):
+            raise NotImplementedError(
+                "action bindings on an optimize-mode ScanRequest are not "
+                "executed yet (GeecsSession.optimize has no action hooks); "
+                f"the names were resolved and are valid: "
+                f"{ {k: v for k, v in resolved_actions.items() if v} }"
+            )
         return _run_optimize_request(
             session,
             request,
@@ -942,11 +1270,33 @@ def run_scan_request(
             f"a {request.mode.value!r} ScanRequest needs a save_set — "
             "without one the scan would record nothing"
         )
-    save_set = resolve_save_set_checked(resolver, request.save_set)
+    save_set, rituals = resolve_save_set_and_rituals(resolver, request.save_set)
     devices_config = save_set_to_devices_config(save_set)
+    slots = assemble_action_slots(request.actions, applied_defaults, rituals)
 
     created: list = []
     try:
+        # Compile the action slots first: signal prefetch fail-fasts on an
+        # unreachable action target before detectors are even built, and
+        # everything stays pre-claim.
+        setup = per_step = closeout = None
+        if any(slots.values()):
+            factory = session.action_signal_factory()
+            created.append(factory)
+            registry = build_action_registry(resolver)
+            setup, setup_plans = compile_action_slot(
+                slots["setup"], resolver, registry, factory
+            )
+            per_step, per_step_plans = compile_action_slot(
+                slots["per_step"], resolver, registry, factory
+            )
+            closeout, closeout_plans = compile_action_slot(
+                slots["closeout"], resolver, registry, factory
+            )
+            prefetch_action_signals(
+                setup_plans + per_step_plans + closeout_plans, registry, factory
+            )
+
         detectors = _build_request_detectors(
             session, devices_config, free_run=mode == "free_run"
         )
@@ -957,6 +1307,10 @@ def run_scan_request(
             # Provenance: the run records exactly which experiment defaults
             # filled in fields the submitter left unset.
             md["applied_defaults"] = applied_defaults
+        if any(slots.values()):
+            # Provenance: the assembled per-slot execution order (defaults +
+            # entry rituals + the request's own, mirrored on closeout).
+            md["action_plans"] = {k: v for k, v in slots.items() if v}
         scan_info: dict[str, Any] = {
             "shots": request.shots_per_step,
             "background": request.background,
@@ -973,30 +1327,60 @@ def run_scan_request(
                 description=request.description,
                 md=md,
                 scan_info=scan_info,
+                setup=setup,
+                per_step=per_step,
+                closeout=closeout,
             )
 
-        axis = request.axes[0]
-        spec = resolver.resolve_scan_variable(axis.variable)
-        device, variable, kind = resolve_movable_target(spec, axis.variable)
-        movable = (
-            session.motor(device, variable)
-            if kind == "motor"
-            else session.settable(device, variable)
-        )
-        created.append(movable)
-        positions = axis.positions.to_values()
+        movables: list = []
+        targets: list[str] = []
+        value_lists: list[list[float]] = []
+        for axis in request.axes:
+            spec = resolver.resolve_scan_variable(axis.variable)
+            device, variable, kind = resolve_movable_target(spec, axis.variable)
+            movable = (
+                session.motor(device, variable)
+                if kind == "motor"
+                else session.settable(device, variable)
+            )
+            created.append(movable)
+            movables.append(movable)
+            targets.append(f"{device}:{variable}")
+            value_lists.append(axis.positions.to_values())
+
         scan_info["scan_mode"] = "standard"
-        scan_info["scan_parameter"] = f"{device}:{variable}"
-        md["scan_variable"] = axis.variable
+        scan_info["scan_parameter"] = ",".join(targets)
+        if len(request.axes) == 1:
+            motor_arg: Any = movables[0]
+            positions: list[Any] = value_lists[0]
+            md["scan_variable"] = request.axes[0].variable
+        else:
+            # Outer product, first axis outermost/slowest (the schema's
+            # documented grid semantics); one bin per grid point.
+            motor_arg = movables
+            positions = [tuple(point) for point in itertools.product(*value_lists)]
+            md["scan_variable"] = ",".join(a.variable for a in request.axes)
+            md["scan_axes"] = [a.variable for a in request.axes]
+            md["grid_shape"] = list(request.grid_shape())
+            md["num_grid_points"] = request.n_steps()
+            # ScanInfo is a legacy 1-D format: Start/End/Step describe the
+            # outermost axis; the grid truth lives in the run metadata.
+            outer = value_lists[0]
+            scan_info["start"] = outer[0]
+            scan_info["end"] = outer[-1]
+            scan_info["step"] = (outer[1] - outer[0]) if len(outer) > 1 else 0
         return session.scan(
             detectors=detectors,
-            motor=movable,
+            motor=motor_arg,
             positions=positions,
             shots_per_step=request.shots_per_step,
             mode=mode,
             description=request.description,
             md=md,
             scan_info=scan_info,
+            setup=setup,
+            per_step=per_step,
+            closeout=closeout,
         )
     finally:
         if created and hasattr(session, "disconnect"):
@@ -1057,7 +1441,15 @@ def _run_optimize_request(
     created: list = []
     try:
         if request.save_set:
-            save_set = resolve_save_set_checked(resolver, request.save_set)
+            save_set, rituals = resolve_save_set_and_rituals(resolver, request.save_set)
+            ritual_names = [n for names in rituals.values() for n in names]
+            if ritual_names:
+                raise NotImplementedError(
+                    "save-set entry rituals on an optimize-mode ScanRequest "
+                    "are not executed yet (GeecsSession.optimize has no "
+                    "action hooks); the names were resolved and are valid: "
+                    f"{ritual_names}"
+                )
             detectors = _build_request_detectors(
                 session,
                 save_set_to_devices_config(save_set),

--- a/GeecsBluesky/geecs_bluesky/scan_request_runner.py
+++ b/GeecsBluesky/geecs_bluesky/scan_request_runner.py
@@ -808,16 +808,20 @@ class _LazyResolverRegistry(Mapping):
         self._resolver = resolver
 
     def __getitem__(self, name: str) -> ActionPlan:
+        # Only a genuine "not in the library" miss becomes a KeyError (which
+        # the compiler turns into ActionPlanNotFoundError).  Any other fault
+        # (transient IO, a bug in a resolver) must propagate — masking it as a
+        # miss would misdirect debugging to "plan not found" with no candidates.
         try:
             return self._resolver.resolve_action_plan(name)
-        except Exception:
+        except GeecsConfigurationError:
             raise KeyError(name) from None
 
     def get(self, name: str, default: Any = None) -> Any:
-        """Resolve *name*, returning *default* when the resolver refuses."""
+        """Resolve *name*, returning *default* only when the name is unknown."""
         try:
             return self._resolver.resolve_action_plan(name)
-        except Exception:
+        except GeecsConfigurationError:
             return default
 
     def __iter__(self):
@@ -935,33 +939,6 @@ def compile_action_slot(
             yield from compile_action_plan(plan, registry=registry, settables=settables)
 
     return _slot_plan, plans
-
-
-def collect_save_set_action_names(save_set: SaveSet) -> list[str]:
-    """Return entry-level setup/closeout ActionPlan references, if any.
-
-    Newer SaveSet schemas let an entry reference setup/closeout action
-    plans by name; older SaveSets have no such fields (this returns
-    ``[]``).  Duck-typed so both schema generations pass through.
-
-    Parameters
-    ----------
-    save_set :
-        The save set to inspect.
-
-    Returns
-    -------
-    list of str
-        Every referenced plan name, in entry order.
-    """
-    names: list[str] = []
-    for entry in save_set.entries:
-        for slot in ("setup", "closeout"):
-            value = getattr(entry, slot, None)
-            if not value:
-                continue
-            names.extend(value if isinstance(value, (list, tuple)) else [value])
-    return names
 
 
 def resolve_save_set_checked(resolver: ConfigResolver, name: str) -> SaveSet:
@@ -1248,13 +1225,15 @@ def run_scan_request(
     mode = "strict" if request.acquisition is AcquisitionMode.STRICT else "free_run"
 
     if request.mode is ScanRequestMode.OPTIMIZE:
-        if any(resolved_actions.values()):
-            raise NotImplementedError(
-                "action bindings on an optimize-mode ScanRequest are not "
-                "executed yet (GeecsSession.optimize has no action hooks); "
-                f"the names were resolved and are valid: "
-                f"{ {k: v for k, v in resolved_actions.items() if v} }"
-            )
+        # Optimize mode has no action hooks yet (GeecsSession.optimize runs an
+        # adaptive scan with no setup/per_step/closeout seam).  Rather than
+        # refuse — which would block every optimization the moment an
+        # experiment defines default bracket actions — we run the optimization
+        # and skip the actions, logging loudly and recording the skip in run
+        # metadata so the omission is never silent.  Safety/setup actions are
+        # intentionally not run during optimization for now (a new capability,
+        # not present in the legacy scanner either).
+        skipped_actions = {k: v for k, v in resolved_actions.items() if v}
         return _run_optimize_request(
             session,
             request,
@@ -1263,6 +1242,7 @@ def run_scan_request(
             objective=objective,
             suggester=suggester,
             applied_defaults=applied_defaults,
+            skipped_actions=skipped_actions,
         )
 
     if not request.save_set:
@@ -1396,6 +1376,7 @@ def _run_optimize_request(
     objective: Any | None,
     suggester: Any | None,
     applied_defaults: dict[str, Any] | None = None,
+    skipped_actions: dict[str, list[str]] | None = None,
 ) -> str | None:
     """Map an optimize-mode request onto :meth:`GeecsSession.optimize`.
 
@@ -1440,16 +1421,14 @@ def _run_optimize_request(
     detectors: list = []
     created: list = []
     try:
+        skipped = {k: list(v) for k, v in (skipped_actions or {}).items() if v}
         if request.save_set:
             save_set, rituals = resolve_save_set_and_rituals(resolver, request.save_set)
             ritual_names = [n for names in rituals.values() for n in names]
             if ritual_names:
-                raise NotImplementedError(
-                    "save-set entry rituals on an optimize-mode ScanRequest "
-                    "are not executed yet (GeecsSession.optimize has no "
-                    "action hooks); the names were resolved and are valid: "
-                    f"{ritual_names}"
-                )
+                # Save-set entry rituals can't run in optimize mode yet either;
+                # skip and record rather than refuse (see run_scan_request).
+                skipped["save_set_rituals"] = ritual_names
             detectors = _build_request_detectors(
                 session,
                 save_set_to_devices_config(save_set),
@@ -1471,6 +1450,14 @@ def _run_optimize_request(
         md: dict[str, Any] = {"scan_request_mode": request.mode.value}
         if applied_defaults:
             md["applied_defaults"] = applied_defaults
+        if skipped:
+            md["skipped_action_plans"] = skipped
+            logger.warning(
+                "Optimize mode does not run action plans yet — skipping the "
+                "following for this optimization (setup/per_step/closeout "
+                "and save-set rituals do not run during optimization): %s",
+                skipped,
+            )
         uid, _history = session.optimize(
             variables=variables,
             detectors=detectors,

--- a/GeecsBluesky/geecs_bluesky/scanner_bridge/bluesky_scanner.py
+++ b/GeecsBluesky/geecs_bluesky/scanner_bridge/bluesky_scanner.py
@@ -67,7 +67,7 @@ from geecs_bluesky.events import (
     ScanState,
     ScanStepEvent,
 )
-from geecs_bluesky.models.shot_control import ShotControlConfig
+from geecs_bluesky.models.shot_control import ShotControlConfig, ShotControlWrites
 from geecs_bluesky.operator_channel import (
     EventStreamOperator,
     NullOperator,
@@ -92,7 +92,7 @@ from geecs_bluesky.scan_request_runner import (
     resolve_movable_target,
     resolve_save_set_checked,
     save_set_to_devices_config,
-    shot_control_config_from_trigger_profile,
+    trigger_writes_from_profile,
 )
 from geecs_bluesky.session import GeecsSession
 from geecs_bluesky.utils import safe_name
@@ -283,7 +283,9 @@ class BlueskyScanner:
         self._detectors: list = []
 
         # Shot control — validated from the shot_control_information YAML/dict
-        self._shot_control: ShotControlConfig | None = (
+        # (legacy path).  reinitialize(ScanRequest) stores generalized
+        # ShotControlWrites instead; GeecsSession.shot_control accepts both.
+        self._shot_control: ShotControlConfig | ShotControlWrites | None = (
             ShotControlConfig.from_information(shot_control_information)
         )
 
@@ -384,9 +386,11 @@ class BlueskyScanner:
           ``GEECS_BLUESKY_ACQUISITION_MODE`` env override: a request
           declares intent.
         - Action names are resolved and validated now, then refused
-          (``NotImplementedError``) until the ActionPlan compiler lands;
-          multi-axis and optimize-mode requests are likewise refused loudly
-          (documented v1 gaps).
+          (``NotImplementedError``) — the *engine* executes actions and
+          multi-axis grids (run the request headless via
+          ``GeecsSession.run``); routing them through this GUI bridge lands
+          with the GUI submission milestone.  Optimize-mode requests are
+          likewise refused loudly.
 
         Parameters
         ----------
@@ -445,7 +449,10 @@ class BlueskyScanner:
 
         if request.trigger_profile:
             profile = resolver.resolve_trigger_profile(request.trigger_profile)
-            self._shot_control = shot_control_config_from_trigger_profile(
+            # Generalized multi-device ordered writes (TriggerProfile
+            # semantics); GeecsSession.shot_control builds the ordered
+            # controller from these.
+            self._shot_control = trigger_writes_from_profile(
                 profile, request.trigger_variant
             )
         else:

--- a/GeecsBluesky/geecs_bluesky/scanner_bridge/bluesky_scanner.py
+++ b/GeecsBluesky/geecs_bluesky/scanner_bridge/bluesky_scanner.py
@@ -44,7 +44,6 @@ import os
 import queue
 import threading
 from contextlib import contextmanager
-from pathlib import Path
 from typing import Any, Callable
 
 import numpy as np
@@ -94,6 +93,7 @@ from geecs_bluesky.scan_request_runner import (
     save_set_to_devices_config,
     trigger_writes_from_profile,
 )
+from geecs_bluesky.scan_log import scan_log
 from geecs_bluesky.session import GeecsSession
 from geecs_bluesky.utils import safe_name
 from geecs_schemas import AcquisitionMode, ScanRequest, ScanRequestMode
@@ -153,18 +153,6 @@ def _cfg_field(cfg: Any, key: str, default: Any) -> Any:
     if isinstance(cfg, dict):
         return cfg.get(key, default)
     return getattr(cfg, key, default)
-
-
-class _ScanLogContextFilter(logging.Filter):
-    """Add scan id context to records written to one scan log."""
-
-    def __init__(self, scan_id: str) -> None:
-        super().__init__()
-        self._scan_id = scan_id
-
-    def filter(self, record: logging.LogRecord) -> bool:
-        record.scan_id = self._scan_id
-        return True
 
 
 # ---------------------------------------------------------------------------
@@ -980,56 +968,17 @@ class BlueskyScanner:
 
     @contextmanager
     def _scan_log(self, scan_number: int | None, scan_folder: str | None):
-        """Attach a per-scan log file for Bluesky scanner runs."""
-        if scan_number is None or scan_folder is None:
-            yield
-            return
+        """Attach a per-scan log file (the shared scan_log helper).
 
-        folder = Path(scan_folder)
-        if not folder.is_dir():
-            logger.warning("Scan folder %s does not exist; skipping scan.log", folder)
+        The implementation lives in :mod:`geecs_bluesky.scan_log` so headless
+        :class:`~geecs_bluesky.session.GeecsSession` scans get the identical
+        ``scan.log``; the bridge keeps this thin method because its scans
+        pre-claim the number and wrap device building + the session call.
+        The GeecsSession side only self-attaches when *it* claimed the
+        number, so bridge scans never get a second (duplicating) handler.
+        """
+        with scan_log(scan_number, scan_folder):
             yield
-            return
-
-        scan_id = f"Scan{scan_number:03d}"
-        handler = logging.FileHandler(folder / "scan.log", encoding="utf-8")
-        handler.setLevel(logging.INFO)
-        handler.setFormatter(
-            logging.Formatter(
-                "%(asctime)s.%(msecs)03d %(levelname)s %(name)s "
-                "[%(threadName)s] scan=%(scan_id)s - %(message)s",
-                datefmt="%Y-%m-%d %H:%M:%S",
-            )
-        )
-        handler.addFilter(_ScanLogContextFilter(scan_id))
-
-        # Capture the whole scan story, not just this package: during
-        # optimization scans the evaluator (geecs_scanner.optimization) and
-        # its analyzers (scan_analysis, image_analysis) do the per-bin work,
-        # and their file-mapping / objective lines belong in scan.log too.
-        capture_loggers = [
-            logging.getLogger(name)
-            for name in (
-                "geecs_bluesky",
-                "geecs_scanner.optimization",
-                "scan_analysis",
-                "image_analysis",
-            )
-        ]
-        old_levels = [lg.level for lg in capture_loggers]
-        for lg in capture_loggers:
-            if lg.level == logging.NOTSET or lg.level > logging.INFO:
-                lg.setLevel(logging.INFO)
-            lg.addHandler(handler)
-        try:
-            logger.info("scan %s: starting (dir=%s)", scan_id, scan_folder)
-            yield
-            logger.info("scan %s: finished", scan_id)
-        finally:
-            for lg, old_level in zip(capture_loggers, old_levels):
-                lg.removeHandler(handler)
-                lg.setLevel(old_level)
-            handler.close()
 
     def _run_request_step_scan(
         self, scan_config: Any, request_step: dict[str, Any]

--- a/GeecsBluesky/geecs_bluesky/session.py
+++ b/GeecsBluesky/geecs_bluesky/session.py
@@ -38,17 +38,19 @@ from bluesky import RunEngine
 from geecs_bluesky.data_paths import asset_resource_root_paths, device_server_save_path
 from geecs_bluesky.exceptions import GeecsConfigurationError
 from geecs_bluesky.devices.ca import (
+    CaActionSignalFactory,
     CaGenericDetector,
     CaMotor,
     CaSettable,
     CaSnapshotReadable,
     CaTimestampedReadable,
 )
-from geecs_bluesky.models.shot_control import ShotControlConfig
+from geecs_bluesky.models.shot_control import ShotControlConfig, ShotControlWrites
 from geecs_bluesky.optimize import BinData, Suggester
 from geecs_bluesky.plans.optimize import geecs_adaptive_scan
 from geecs_bluesky.plans.orchestration import build_step_scan_plan
 from geecs_bluesky.plans.run_wrapper import claim_scan_number, geecs_run_wrapper
+from geecs_bluesky.plans.step_scan import normalize_motors
 from geecs_bluesky.scanner_configs import load_shot_control_config
 from geecs_bluesky.shot_controller import ShotController
 from geecs_bluesky.tiled_integration import subscribe_tiled
@@ -274,40 +276,70 @@ class GeecsSession:
             )
         )
 
+    def action_signal_factory(self) -> CaActionSignalFactory:
+        """Build the SettableFactory for compiled action plans (CA-backed).
+
+        Returns a fresh per-scan factory: ``get_settable`` puts wire strings
+        to the variable's gateway ``:SP`` (put-completion rides the GEECS
+        blocking set — the ``wait_for_execution`` semantics), ``get_readable``
+        reads the streamed readback as a string.  Signals are cached per
+        ``(device, variable)`` and connected in this session's RE loop at
+        creation; pre-connect everything a plan will touch **before** running
+        it (see ``scan_request_runner.prefetch_action_signals``) and pass the
+        factory to :meth:`disconnect` with the scan's other devices.
+        """
+        return CaActionSignalFactory(self.experiment, self._connect)
+
     # ------------------------------------------------------------------
     # Shot control
     # ------------------------------------------------------------------
 
     def shot_control(
-        self, config: str | dict | ShotControlConfig | None
+        self, config: str | dict | ShotControlConfig | ShotControlWrites | None
     ) -> ShotController | None:
-        """Attach shot control from a configs-repo name, dict, or config.
+        """Attach shot control from a configs-repo name, dict, config, or writes.
 
         A configs-repo *name* (e.g. ``"HTU-LaserOFF"``) is loaded and
         validated; ``None`` or an empty/blank config (e.g. ``{}``) detaches.
-        The controller drives the device through the gateway's ``:SP`` PVs;
-        their reachability is verified here (short CA connect) so a typo'd
-        device name fails now, not ~10 s per caput mid-plan.
+        A :class:`~geecs_bluesky.models.shot_control.ShotControlWrites`
+        (generalized per-state ordered write lists, possibly multi-device —
+        the TriggerProfile shape) builds the ordered controller; anything
+        else takes the legacy single-device
+        :class:`~geecs_bluesky.models.shot_control.ShotControlConfig` path
+        unchanged.  Either way the controller drives the gateway's ``:SP``
+        PVs; their reachability is verified here (short CA connect) so a
+        typo'd device name fails now, not ~10 s per caput mid-plan.
         """
         import asyncio
 
-        if isinstance(config, str):
-            config = load_shot_control_config(config, self.experiment)
+        controller: ShotController | None = None
+        attached_to = ""
+        if isinstance(config, ShotControlWrites):
+            if config.states:
+                controller = ShotController.from_writes(
+                    config, experiment=self.experiment, rep_rate_hz=self.rep_rate_hz
+                )
+                attached_to = controller.describe_target
         else:
-            config = ShotControlConfig.from_information(config)
-        if config is None:
+            if isinstance(config, str):
+                config = load_shot_control_config(config, self.experiment)
+            else:
+                config = ShotControlConfig.from_information(config)
+            if config is not None:
+                controller = ShotController.over_ca(
+                    config, experiment=self.experiment, rep_rate_hz=self.rep_rate_hz
+                )
+                attached_to = config.device
+        if controller is None:
             self._shot_controller = None
             logger.info("Shot control detached")
             return None
-        controller = ShotController.over_ca(
-            config, experiment=self.experiment, rep_rate_hz=self.rep_rate_hz
-        )
         if not self._mock:
             asyncio.run_coroutine_threadsafe(
                 controller.connect_setters(), self.RE._loop
             ).result(timeout=20.0)
         self._shot_controller = controller
-        logger.info("Shot control attached: %s", config.device)
+        logger.info("Shot control attached: %s", attached_to)
         return self._shot_controller
 
     # ------------------------------------------------------------------
@@ -340,11 +372,11 @@ class GeecsSession:
         self,
         *,
         detectors: Sequence[Any],
-        motor: Any | None = None,
+        motor: Any | Sequence[Any] | None = None,
         start: float | None = None,
         end: float | None = None,
         step: float | None = None,
-        positions: Sequence[float | None] | None = None,
+        positions: Sequence[Any] | None = None,
         shots_per_step: int = 1,
         mode: str = _FREE_RUN,
         description: str = "",
@@ -353,6 +385,9 @@ class GeecsSession:
         scan_number: int | None = None,
         scan_folder: str | None = None,
         scan_info: dict | None = None,
+        setup: Any | None = None,
+        per_step: Any | None = None,
+        closeout: Any | None = None,
     ) -> str | None:
         """Run one scan with the full GEECS run discipline; return the run uid.
 
@@ -366,14 +401,33 @@ class GeecsSession:
         overrides individual ScanInfo ini fields (``scan_parameter``,
         ``start``, ``end``, ``step``, ``shots``, ``background``,
         ``scan_mode``) for legacy-format fidelity.
+
+        *motor* may be a **sequence** of movables for a multi-axis grid scan
+        (outermost axis first); *positions* is then the explicit list of
+        grid points as tuples aligned with the motors (one bin per grid
+        point; only changed axes are re-moved).  All motors' readbacks are
+        recorded in every event row, exactly like the single-motor case.
+
+        ``setup`` / ``per_step`` / ``closeout`` are optional plan-stub
+        callables (typically compiled ActionPlans): setup runs in the plan
+        preamble before the first step, per_step at every step boundary
+        (after the move, before the shots), closeout in a finalize wrapper
+        that runs even on abort, after the trigger disarm.  See
+        :func:`~geecs_bluesky.plans.orchestration.build_step_scan_plan`.
         """
         if mode not in (_FREE_RUN, _STRICT):
             raise ValueError(f"mode={mode!r} invalid; use 'free_run' or 'strict'")
         detectors = list(detectors)
         if not detectors:
             raise ValueError("scan() needs at least one detector")
+        motors = normalize_motors(motor)
         if positions is None:
-            if motor is not None:
+            if len(motors) > 1:
+                raise ValueError(
+                    "multi-axis scans need explicit positions (a list of "
+                    "grid-point tuples, outermost axis first)"
+                )
+            if motors:
                 if None in (start, end, step):
                     raise ValueError("motor scans need start/end/step or positions")
                 positions = _positions(float(start), float(end), float(step))
@@ -431,6 +485,9 @@ class GeecsSession:
             scan_folder=scan_folder,
             saving_detectors=saving_detectors,
             extra_md={"description": description, **(md or {})},
+            setup=setup,
+            per_step=per_step,
+            closeout=closeout,
         )
 
         self._last_run_uid = None
@@ -692,9 +749,11 @@ class GeecsSession:
         this session's experiment in the configs repository, which loads
         new-schema YAML when present and converts legacy files otherwise —
         and the request is mapped onto :meth:`scan` / :meth:`optimize` by
-        :func:`~geecs_bluesky.scan_request_runner.run_scan_request` (see its
-        docstring for the documented v1 gaps: multi-axis, actions, pseudo
-        variables, optimize without an injected objective/suggester).
+        :func:`~geecs_bluesky.scan_request_runner.run_scan_request` —
+        including multi-axis grids, setup/per-step/closeout action
+        execution, and multi-device trigger profiles (see its docstring for
+        the remaining documented v1 gaps: pseudo variables, ``all_scalars``,
+        optimize without an injected objective/suggester).
 
         Parameters
         ----------
@@ -801,10 +860,17 @@ class GeecsSession:
             )
             return
         real = [p for p in positions if p is not None]
+        if real and isinstance(real[0], (list, tuple)):
+            # Multi-axis grid: the legacy 1-D ini fields (Start/End/Step)
+            # describe the outermost (slowest) axis; the full grid lives in
+            # the run metadata (scan_axes / grid_shape).
+            real = [p[0] for p in real]
         o = overrides or {}
-        scan_var = (
-            o.get("scan_parameter") or getattr(motor, "name", None) or "Shotnumber"
+        motors = normalize_motors(motor)
+        default_var = (
+            ",".join(getattr(m, "name", str(m)) for m in motors) if motors else None
         )
+        scan_var = o.get("scan_parameter") or default_var or "Shotnumber"
         start = o.get("start", real[0] if real else 0)
         end = o.get("end", real[-1] if real else 0)
         step = o.get("step", (real[1] - real[0]) if len(real) > 1 else 0)

--- a/GeecsBluesky/geecs_bluesky/session.py
+++ b/GeecsBluesky/geecs_bluesky/session.py
@@ -746,7 +746,6 @@ class GeecsSession:
             if save_data and self._last_run_uid and scan_number is not None:
                 self._export_scalar_files(scan_number)
             return self._last_run_uid, history
-        return self._last_run_uid, history
 
     def run(
         self,

--- a/GeecsBluesky/geecs_bluesky/session.py
+++ b/GeecsBluesky/geecs_bluesky/session.py
@@ -29,6 +29,7 @@ from __future__ import annotations
 import logging
 import math
 import os
+from contextlib import nullcontext
 from pathlib import Path
 from typing import Any, Callable, Sequence
 
@@ -51,6 +52,7 @@ from geecs_bluesky.plans.optimize import geecs_adaptive_scan
 from geecs_bluesky.plans.orchestration import build_step_scan_plan
 from geecs_bluesky.plans.run_wrapper import claim_scan_number, geecs_run_wrapper
 from geecs_bluesky.plans.step_scan import normalize_motors
+from geecs_bluesky.scan_log import scan_log
 from geecs_bluesky.scanner_configs import load_shot_control_config
 from geecs_bluesky.shot_controller import ShotController
 from geecs_bluesky.tiled_integration import subscribe_tiled
@@ -446,9 +448,11 @@ class GeecsSession:
                 "(pre-claimed) or neither to claim a new scan"
             )
 
+        claimed_here = False
         if save_data:
             if scan_number is None:
                 scan_number, scan_folder = claim_scan_number(self.experiment)
+                claimed_here = True
             if scan_number is not None:
                 self._write_scan_info(
                     scan_number,
@@ -491,10 +495,15 @@ class GeecsSession:
         )
 
         self._last_run_uid = None
-        self.RE(plan)
+        # Headless scans get the same per-scan scan.log as bridge scans
+        # (Gate-2 finding).  Attach only when this call claimed the number:
+        # a pre-claimed number means the caller (e.g. the GUI bridge) owns
+        # the scan.log handler, and a second one would duplicate every line.
+        with scan_log(scan_number, scan_folder) if claimed_here else nullcontext():
+            self.RE(plan)
 
-        if save_data and self._last_run_uid and scan_number is not None:
-            self._export_scalar_files(scan_number)
+            if save_data and self._last_run_uid and scan_number is not None:
+                self._export_scalar_files(scan_number)
         return self._last_run_uid
 
     def optimize(
@@ -574,9 +583,11 @@ class GeecsSession:
             name: self._read_movable(movable) for name, movable in variables.items()
         }
 
+        claimed_here = False
         if save_data:
             if scan_number is None:
                 scan_number, scan_folder = claim_scan_number(self.experiment)
+                claimed_here = True
             if scan_number is not None:
                 self._write_scan_info(
                     scan_number,
@@ -688,47 +699,53 @@ class GeecsSession:
 
             run_plan = bpp.finalize_wrapper(run_plan, controller.disarm())
 
-        token = self.RE.subscribe(_collect)
-        self._last_run_uid = None
-        try:
-            self.RE(run_plan)
-        except BaseException:
-            if on_finish in ("initial", "best"):
-                self._move_movables(variables, initial_values)
-            raise
-        finally:
-            self.RE.unsubscribe(token)
-        _observe_previous(len(history) + 1)  # final bin
-
-        if on_finish in ("initial", "best"):
-            target = initial_values
-            if on_finish == "best":
-                finite = [h for h in history if np.isfinite(h["objective"])]
-                if finite:
-                    target = max(finite, key=lambda h: h["objective"])["inputs"]
-                else:
-                    logger.warning(
-                        "on_finish='best' but no finite objectives; restoring initial"
-                    )
-            self._move_movables(variables, target)
-            logger.info("optimize on_finish=%s -> %s", on_finish, target)
-
-        if save_data and scan_folder is not None and history:
-            import json
-
+        # Headless optimizations get the same per-scan scan.log as bridge
+        # runs (see scan()): attach only when this call claimed the number.
+        with scan_log(scan_number, scan_folder) if claimed_here else nullcontext():
+            token = self.RE.subscribe(_collect)
+            self._last_run_uid = None
             try:
-                path = Path(scan_folder) / "optimization.json"
-                # Failed objectives are NaN in-process; serialize them as
-                # null (allow_nan=False makes any regression fail loudly
-                # instead of writing invalid JSON).
-                path.write_text(
-                    json.dumps(_json_safe(history), indent=2, allow_nan=False)
-                )
-                logger.info("Optimization history written to %s", path)
-            except Exception:
-                logger.warning("Could not write optimization history", exc_info=True)
-        if save_data and self._last_run_uid and scan_number is not None:
-            self._export_scalar_files(scan_number)
+                self.RE(run_plan)
+            except BaseException:
+                if on_finish in ("initial", "best"):
+                    self._move_movables(variables, initial_values)
+                raise
+            finally:
+                self.RE.unsubscribe(token)
+            _observe_previous(len(history) + 1)  # final bin
+
+            if on_finish in ("initial", "best"):
+                target = initial_values
+                if on_finish == "best":
+                    finite = [h for h in history if np.isfinite(h["objective"])]
+                    if finite:
+                        target = max(finite, key=lambda h: h["objective"])["inputs"]
+                    else:
+                        logger.warning(
+                            "on_finish='best' but no finite objectives; restoring initial"
+                        )
+                self._move_movables(variables, target)
+                logger.info("optimize on_finish=%s -> %s", on_finish, target)
+
+            if save_data and scan_folder is not None and history:
+                import json
+
+                try:
+                    path = Path(scan_folder) / "optimization.json"
+                    # Failed objectives are NaN in-process; serialize them as
+                    # null (allow_nan=False makes any regression fail loudly
+                    # instead of writing invalid JSON).
+                    path.write_text(
+                        json.dumps(_json_safe(history), indent=2, allow_nan=False)
+                    )
+                    logger.info("Optimization history written to %s", path)
+                except Exception:
+                    logger.warning(
+                        "Could not write optimization history", exc_info=True
+                    )
+            if save_data and self._last_run_uid and scan_number is not None:
+                self._export_scalar_files(scan_number)
+            return self._last_run_uid, history
         return self._last_run_uid, history
 
     def run(

--- a/GeecsBluesky/geecs_bluesky/shot_controller.py
+++ b/GeecsBluesky/geecs_bluesky/shot_controller.py
@@ -2,12 +2,17 @@
 
 Extracted from ``BlueskyScanner`` so notebooks and :class:`~geecs_bluesky.session.GeecsSession`
 get the same arm/disarm/quiesce/single-shot discipline as GUI scans.  The
-controller is built from a validated
+controller is built either from a validated
 :class:`~geecs_bluesky.models.shot_control.ShotControlConfig` plus one Bluesky
-``Movable`` setter per shot-control variable.  :meth:`ShotController.over_ca`
-puts to the gateway's ``…:SP`` PVs, which ride GEECS's blocking UDP set
-server-side; string values from the YAML map naturally (enum PVs take labels,
-numeric PVs coerce numeric strings).
+``Movable`` setter per shot-control variable (the legacy/scanner path), or —
+via :meth:`ShotController.from_writes` — from generalized
+:class:`~geecs_bluesky.models.shot_control.ShotControlWrites`: per-state
+**ordered** ``(device, variable, value)`` lists that may span several devices
+(the TriggerProfile semantics; writes applied top to bottom, each completing
+before the next).  :meth:`ShotController.over_ca` / :meth:`from_writes`'
+default setter factory put to the gateway's ``…:SP`` PVs, which ride GEECS's
+blocking UDP set server-side; string values from the YAML map naturally (enum
+PVs take labels, numeric PVs coerce numeric strings).
 
 All state-driving methods are Bluesky **plan stubs** (generators) — compose
 them into plans or pass them as the ``arm_trigger``/``fire_shot`` hooks of the
@@ -17,13 +22,17 @@ step-scan plans.
 from __future__ import annotations
 
 import logging
-from typing import Any, Sequence
+from typing import Any, Callable, Sequence
 
 import bluesky.plan_stubs as bps
 from ophyd_async.core import AsyncStatus
 
 from geecs_bluesky.exceptions import GeecsConfigurationError
-from geecs_bluesky.models.shot_control import ShotControlConfig, ShotControlState
+from geecs_bluesky.models.shot_control import (
+    ShotControlConfig,
+    ShotControlState,
+    ShotControlWrites,
+)
 from geecs_bluesky.plans.single_shot import geecs_confirm_quiescent
 from geecs_ca_gateway.pv_naming import pv_name
 
@@ -55,7 +64,18 @@ class CaPutSetter:
 
 
 class ShotController:
-    """Drives the shot-control device through its named states, as plan stubs.
+    """Drives the shot-control device(s) through named states, as plan stubs.
+
+    Two construction paths share every plan stub:
+
+    - **Legacy/scanner path** (this constructor / :meth:`over_ca`): a
+      single-device :class:`ShotControlConfig` plus one setter per variable.
+      State writes are issued concurrently then waited on — byte-identical
+      to the pre-generalization behavior.
+    - **Generalized path** (:meth:`from_writes`): per-state *ordered*
+      ``(device, variable, value)`` write lists (multi-device
+      TriggerProfile semantics).  Writes are applied strictly in order,
+      each completing before the next is sent.
 
     Parameters
     ----------
@@ -70,14 +90,18 @@ class ShotController:
 
     def __init__(
         self,
-        config: ShotControlConfig,
-        setters: dict[str, Any],
+        config: ShotControlConfig | None,
+        setters: dict[Any, Any],
         *,
         rep_rate_hz: float = 1.0,
     ) -> None:
         self.config = config
         self._setters = setters
         self._rep_rate_hz = rep_rate_hz
+        # Generalized (ordered, possibly multi-device) transitions:
+        # {state_name: [(setter, value), ...]} — set by from_writes.
+        self._transitions: dict[str, list[tuple[Any, str]]] | None = None
+        self._writes: ShotControlWrites | None = None
 
     # ------------------------------------------------------------------
     # Factories
@@ -104,19 +128,111 @@ class ShotController:
         }
         return cls(config, setters, rep_rate_hz=rep_rate_hz)
 
+    @classmethod
+    def from_writes(
+        cls,
+        writes: ShotControlWrites,
+        *,
+        experiment: str | None = None,
+        rep_rate_hz: float = 1.0,
+        put_timeout: float = 10.0,
+        setter_factory: Callable[[str, str], Any] | None = None,
+    ) -> "ShotController":
+        """Build from generalized per-state ordered multi-device write lists.
+
+        One setter is created per distinct ``(device, variable)`` target
+        (cached across states) and each state's transition replays its write
+        list **in declared order**, every write completing before the next —
+        the schema-documented TriggerProfile semantics (e.g. raise an
+        amplitude before switching a trigger source).  A single-device
+        profile is simply the one-device case of the same structure.
+
+        Parameters
+        ----------
+        writes : ShotControlWrites
+            Per-state ordered ``(device, variable, value)`` lists.
+        experiment : str, optional
+            Experiment PV-namespace prefix for the default CA setters.
+        rep_rate_hz : float
+            As in the class docstring.
+        put_timeout : float
+            CA put budget per write for the default setters.
+        setter_factory : callable, optional
+            ``factory(device, variable) → Movable`` override (tests inject
+            recording setters); defaults to gateway ``:SP``
+            :class:`CaPutSetter` instances.
+        """
+        factory = setter_factory or (
+            lambda device, variable: CaPutSetter(
+                f"{pv_name(experiment, device, variable)}:SP", timeout=put_timeout
+            )
+        )
+        setters: dict[tuple[str, str], Any] = {}
+        transitions: dict[str, list[tuple[Any, str]]] = {}
+        for state_name, state_writes in writes.states.items():
+            ordered: list[tuple[Any, str]] = []
+            for device, variable, value in state_writes:
+                key = (device, variable)
+                if key not in setters:
+                    setters[key] = factory(device, variable)
+                ordered.append((setters[key], value))
+            if ordered:
+                transitions[state_name] = ordered
+        controller = cls(None, setters, rep_rate_hz=rep_rate_hz)
+        controller._transitions = transitions
+        controller._writes = writes
+        return controller
+
+    # ------------------------------------------------------------------
+    # Introspection shared by both construction paths
+    # ------------------------------------------------------------------
+
+    @property
+    def describe_target(self) -> str:
+        """Human-readable device description for error messages."""
+        if self._writes is not None:
+            devices = self._writes.devices
+            label = self._writes.name or "trigger profile"
+            return f"{label} ({', '.join(devices) or 'no devices'})"
+        return self.config.device if self.config is not None else "shot control"
+
+    def defines_state(self, state: str | ShotControlState) -> bool:
+        """Whether driving to *state* would write anything at all."""
+        if self._transitions is not None:
+            name = state.value if isinstance(state, ShotControlState) else str(state)
+            return bool(self._transitions.get(name))
+        return self.config is not None and self.config.defines_state(state)
+
     # ------------------------------------------------------------------
     # Plan stubs
     # ------------------------------------------------------------------
 
     def set_state(self, state: str | ShotControlState):
-        """Plan stub: drive all shot-control variables to *state*.
+        """Plan stub: drive the shot-control writes for *state*.
 
-        Uses ``bps.abs_set`` + ``bps.wait`` rather than ``bps.mv`` because
-        ``bps.mv`` inspects ``.parent`` for coupled-device handling — an
-        ophyd-specific attribute the minimal setters intentionally omit.
-        Only variables with a non-empty value for *state* are written (the
-        rest are no-ops); they are set concurrently then waited on.
+        Generalized (``from_writes``) controllers replay the state's ordered
+        write list top to bottom, **each write completing before the next**
+        (order is schema-documented: transitions may depend on it).
+
+        Legacy single-device controllers keep their exact historical
+        behavior: only variables with a non-empty value for *state* are
+        written (the rest are no-ops); they are set concurrently then waited
+        on.  Uses ``bps.abs_set`` + ``bps.wait`` rather than ``bps.mv``
+        because ``bps.mv`` inspects ``.parent`` for coupled-device handling —
+        an ophyd-specific attribute the minimal setters intentionally omit.
         """
+        if self._transitions is not None:
+            name = state.value if isinstance(state, ShotControlState) else str(state)
+            ordered = self._transitions.get(name, [])
+            for index, (setter, value) in enumerate(ordered):
+                # Sequential by design: wait on each write's own group before
+                # sending the next, preserving the profile's declared order.
+                group = f"shot_ctrl_{name}_{index}"
+                yield from bps.abs_set(setter, value, group=group)
+                yield from bps.wait(group)
+            if ordered:
+                logger.info("Shot controller → %s", name)
+            return
         group = f"shot_ctrl_{state}"
         writes = self.config.values_for_state(state)
         for var_name, val in writes.items():
@@ -179,12 +295,12 @@ class ShotController:
             "Use acquisition_mode='free_run_time_sync' for free-running "
             "trigger acquisition."
         )
-        if not self.config.defines_state(ShotControlState.ARMED):
+        if not self.defines_state(ShotControlState.ARMED):
             raise GeecsConfigurationError(
                 "strict_shot_control requires shot_control_information to "
                 f"define a non-empty ARMED state. {guidance}"
             )
-        if not self.config.defines_state(ShotControlState.SINGLESHOT):
+        if not self.defines_state(ShotControlState.SINGLESHOT):
             raise GeecsConfigurationError(
                 "strict_shot_control requires shot_control_information to "
                 "define a non-empty SINGLESHOT state (fire_shot would be a "
@@ -223,7 +339,7 @@ class ShotController:
             await connect(pvs, timeout=timeout)
         except Exception as exc:
             raise GeecsConfigurationError(
-                f"shot-control device {self.config.device!r} is unreachable: "
+                f"shot control {self.describe_target!r} is unreachable: "
                 f"could not connect {pvs} within {timeout:.1f}s. Check the "
-                "device name and that the CA gateway is serving it."
+                "device name(s) and that the CA gateway is serving them."
             ) from exc

--- a/GeecsBluesky/pyproject.toml
+++ b/GeecsBluesky/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-bluesky"
-version = "0.22.0"
+version = "0.23.0"
 description = "Bluesky / ophyd-async bridge for the GEECS control system"
 authors = ["Sam Barber <sbarber@lbl.gov>"]
 readme = "README.md"

--- a/GeecsBluesky/tests/test_bluesky_scanner_scan_request_seam.py
+++ b/GeecsBluesky/tests/test_bluesky_scanner_scan_request_seam.py
@@ -339,11 +339,13 @@ def test_scan_request_trigger_profile_becomes_shot_control(monkeypatch) -> None:
         }
     )
     scanner.reinitialize(request, resolver=_resolver(trigger_profiles={"HTU": profile}))
+    # Stored as generalized ordered writes (ShotControlWrites) — the shape
+    # GeecsSession.shot_control builds the ordered controller from.
     assert scanner._shot_control is not None
-    assert scanner._shot_control.device == "U_DG645_ShotControl"
-    assert scanner._shot_control.values_for_state("SCAN") == {
-        "Trigger.Source": "External rising edges"
-    }
+    assert scanner._shot_control.devices == ["U_DG645_ShotControl"]
+    assert scanner._shot_control.writes_for_state("SCAN") == [
+        ("U_DG645_ShotControl", "Trigger.Source", "External rising edges")
+    ]
 
 
 # ---------------------------------------------------------------------------

--- a/GeecsBluesky/tests/test_experiment_defaults_integration.py
+++ b/GeecsBluesky/tests/test_experiment_defaults_integration.py
@@ -1,0 +1,76 @@
+"""Integration test for the experiment-defaults path against the real configs.
+
+Unlike ``test_scan_request_hardware.py`` this needs neither hardware nor the
+``ca`` extra — only the configs repository checked out — so it exercises the
+one thing hermetic tests deliberately do *not*: that a real
+``experiment_defaults.yaml`` is found, parsed, and applied to fill a silent
+ScanRequest, with the applied default recorded for provenance.
+
+It is ``integration``-marked (deselected in CI, which has no configs repo) and
+self-skips when the experiment has no defaults file in this checkout, so it
+never fails for a reason unrelated to the code under test.  The dedicated
+scope is the point: hermetic tests build their own ``ExperimentDefaults``
+inline and must not read the real file, but exactly one test should prove the
+real-file wiring — and catch a renamed profile or a broken defaults-application
+path.
+
+Run it by hand from the package dir::
+
+    poetry run pytest tests/test_experiment_defaults_integration.py \
+        -m integration -s
+
+Point it at another experiment/profile with ``GEECS_HW_EXPERIMENT`` /
+``GEECS_HW_EXPECTED_TRIGGER_PROFILE`` if the Undulator defaults change.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.mark.integration
+def test_experiment_defaults_fill_minimal_request_from_real_configs() -> None:
+    """A silent ScanRequest is filled from the real defaults file, recorded."""
+    from geecs_bluesky.scan_request_runner import (
+        ConfigsRepoResolver,
+        resolve_defaults_for,
+    )
+    from geecs_schemas import ScanRequest
+
+    experiment = os.environ.get("GEECS_HW_EXPERIMENT", "Undulator")
+    expected_profile = os.environ.get("GEECS_HW_EXPECTED_TRIGGER_PROFILE", "HTU-Normal")
+
+    resolver = ConfigsRepoResolver(experiment)
+    defaults = resolver.resolve_experiment_defaults()
+    if defaults is None:
+        pytest.skip(f"no experiment_defaults.yaml for {experiment!r} in this checkout")
+
+    # The file declares the standard trigger profile the whole experiment uses.
+    assert defaults.trigger_profile == expected_profile
+
+    # A request that names no trigger profile must inherit it from the defaults,
+    # and the applied default must be recorded for run-metadata provenance.
+    minimal = ScanRequest.model_validate(
+        {
+            "mode": "noscan",
+            "shots_per_step": 3,
+            "acquisition": "strict",
+            "save_set": os.environ.get("GEECS_HW_CAMERA", "Amp4In"),
+        }
+    )
+    assert minimal.trigger_profile is None
+
+    filled, applied = resolve_defaults_for(resolver, minimal)
+    assert filled.trigger_profile == expected_profile
+    assert applied.get("trigger_profile") == expected_profile
+
+    # An explicit trigger profile must win over the default (defaults only fill
+    # blanks — never override what a request says).
+    explicit = minimal.model_copy(update={"trigger_profile": "HTU-LaserOFF"})
+    kept, applied_explicit = resolve_defaults_for(resolver, explicit)
+    assert kept.trigger_profile == "HTU-LaserOFF"
+    assert "trigger_profile" not in applied_explicit

--- a/GeecsBluesky/tests/test_free_run_plan.py
+++ b/GeecsBluesky/tests/test_free_run_plan.py
@@ -143,8 +143,10 @@ def test_free_run_quiesces_before_t0_sync() -> None:
     """The plan stops the trigger (quiesce_trigger) before establishing t0."""
     quiesce_log: list = []
     events, start, _flush = _run_free_run_scan(fire_cam=True, quiesce_log=quiesce_log)
-    # quiesce ran, and t0s were captured afterward (sync succeeded)
-    assert quiesce_log == ["quiesced"]
+    # quiesce ran before t0 sync (t0s captured afterward — sync succeeded)
+    # and again at end of scan, closing the trigger before the tail
+    # machinery (Gate-2: STANDBY frames leaked into native saving there).
+    assert quiesce_log == ["quiesced", "quiesced"]
     assert start["device_t0s"]["U_Ref"] == REF_T0
     assert len(events) == 4
 

--- a/GeecsBluesky/tests/test_grid_and_action_plans.py
+++ b/GeecsBluesky/tests/test_grid_and_action_plans.py
@@ -1,0 +1,168 @@
+"""RunEngine-level composition tests: setup / per_step / closeout hooks.
+
+Uses the ``test_free_run_plan`` harness (CA mock devices, pacer coroutine)
+to run the full ``build_step_scan_plan`` composition: setup before the
+free-run quiesce/t0-sync and the first step, per_step at every bin,
+closeout in a finalize wrapper that runs even when the plan dies mid-scan —
+ordered *after* the trigger disarm (finalize nesting).  The message-level
+grid tests (no CA needed) live in ``test_grid_plans_message_level.py``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import bluesky.plan_stubs as bps
+import pytest
+from bluesky import RunEngine
+from ophyd_async.core import AsyncStatus
+
+from geecs_bluesky.models.shot_control import ShotControlConfig
+from geecs_bluesky.plans.orchestration import build_step_scan_plan
+from geecs_bluesky.shot_controller import ShotController
+
+pytest.importorskip("aioca")
+
+from ophyd_async.core import set_mock_value  # noqa: E402
+
+from geecs_bluesky.devices.ca import CaGenericDetector, CaMotor  # noqa: E402
+from tests.ca_mock_helpers import (  # noqa: E402
+    connect_mock,
+    follow_setpoint,
+    start_pacer,
+)
+
+
+class _JournalSetter:
+    """Mock shot-control setter appending to the shared journal."""
+
+    def __init__(self, name: str, journal: list) -> None:
+        self.name = name
+        self._journal = journal
+
+    def set(self, value: Any) -> AsyncStatus:
+        self._journal.append((self.name, value))
+
+        async def _noop() -> None:
+            pass
+
+        return AsyncStatus(_noop())
+
+
+def _marker(journal: list, label: str, fail_on_call: int | None = None):
+    """A plan-stub callable that records *label* (and can fail on call N)."""
+    calls = {"n": 0}
+
+    def _stub():
+        calls["n"] += 1
+        if fail_on_call is not None and calls["n"] == fail_on_call:
+            raise RuntimeError(f"{label} failed on call {calls['n']}")
+        journal.append(label)
+        yield from bps.null()
+
+    return _stub
+
+
+def _run_composed(
+    journal: list,
+    *,
+    per_step=None,
+    setup=None,
+    closeout=None,
+    positions=(0.0, 1.0),
+):
+    """Run a free-run build_step_scan_plan with journaled hooks + trigger."""
+    motor = CaMotor("U_Ref", "Position (mm)", name="scan_motor")
+    ref = CaGenericDetector("U_Ref", ["Sig"], name="ref")
+    ref.configure_shot_id(rep_rate_hz=1.0)
+
+    config = ShotControlConfig(
+        device="U_DG645",
+        variables={
+            "Trigger.Source": {"OFF": "Single", "SCAN": "Ext", "STANDBY": "Ext"}
+        },
+    )
+    controller = ShotController(
+        config, {"Trigger.Source": _JournalSetter("trigger", journal)}
+    )
+
+    RE = RunEngine()
+    events: list[dict] = []
+    RE.subscribe(lambda name, doc: events.append(doc) if name == "event" else None)
+    connect_mock(RE, motor, ref)
+    follow_setpoint(motor)
+    set_mock_value(ref.acq_timestamp, 1000.0)
+    pacer = start_pacer(RE, [(ref, 1000.0)], initial_delay=1.0, interval=0.15)
+    plan = build_step_scan_plan(
+        strict=False,
+        motor=motor,
+        positions=list(positions),
+        reference=ref,
+        detectors=[ref],
+        shots_per_step=1,
+        controller=controller,
+        experiment="",
+        scan_number=None,
+        scan_folder=None,
+        saving_detectors=[],
+        setup=setup,
+        per_step=per_step,
+        closeout=closeout,
+    )
+    try:
+        RE(plan)
+    finally:
+        pacer.cancel()
+    return events
+
+
+def test_setup_per_step_closeout_order_in_the_full_composition() -> None:
+    journal: list = []
+    _run_composed(
+        journal,
+        setup=_marker(journal, "setup"),
+        per_step=_marker(journal, "per_step"),
+        closeout=_marker(journal, "closeout"),
+    )
+    # setup runs before the free-run quiesce (OFF write) and the steps;
+    # per_step at each of the 2 steps, bracketed by SCAN/STANDBY writes;
+    # closeout LAST, after the finalize disarm (STANDBY).
+    assert journal == [
+        "setup",
+        ("trigger", "Single"),  # quiesce (OFF) before t0 sync
+        "per_step",
+        ("trigger", "Ext"),  # arm (SCAN)
+        ("trigger", "Ext"),  # disarm (STANDBY)
+        "per_step",
+        ("trigger", "Ext"),  # arm (SCAN)
+        ("trigger", "Ext"),  # disarm (STANDBY)
+        ("trigger", "Ext"),  # finalize disarm (STANDBY)
+        "closeout",
+    ]
+
+
+def test_closeout_runs_even_when_the_scan_dies_mid_plan() -> None:
+    journal: list = []
+    with pytest.raises(RuntimeError, match="per_step failed on call 2"):
+        _run_composed(
+            journal,
+            setup=_marker(journal, "setup"),
+            per_step=_marker(journal, "per_step", fail_on_call=2),
+            closeout=_marker(journal, "closeout"),
+        )
+    # The abort path still disarms (STANDBY) and then runs closeout — and
+    # closeout comes after the disarm write (finalize nesting).
+    assert "closeout" in journal
+    assert journal[-1] == "closeout"
+    assert journal[-2] == ("trigger", "Ext")  # the finalize disarm
+
+
+def test_closeout_runs_when_setup_itself_fails() -> None:
+    journal: list = []
+    with pytest.raises(RuntimeError, match="setup failed"):
+        _run_composed(
+            journal,
+            setup=_marker(journal, "setup", fail_on_call=1),
+            closeout=_marker(journal, "closeout"),
+        )
+    assert journal[-1] == "closeout"

--- a/GeecsBluesky/tests/test_grid_and_action_plans.py
+++ b/GeecsBluesky/tests/test_grid_and_action_plans.py
@@ -23,7 +23,7 @@ from geecs_bluesky.shot_controller import ShotController
 
 pytest.importorskip("aioca")
 
-from ophyd_async.core import set_mock_value  # noqa: E402
+from ophyd_async.core import callback_on_mock_put, set_mock_value  # noqa: E402
 
 from geecs_bluesky.devices.ca import CaGenericDetector, CaMotor  # noqa: E402
 from tests.ca_mock_helpers import (  # noqa: E402
@@ -70,10 +70,18 @@ def _run_composed(
     setup=None,
     closeout=None,
     positions=(0.0, 1.0),
+    save_dir=None,
 ):
-    """Run a free-run build_step_scan_plan with journaled hooks + trigger."""
+    """Run a free-run build_step_scan_plan with journaled hooks + trigger.
+
+    With *save_dir*, the reference is a saving detector and its ``save``
+    puts are journaled as ``("save", value)`` — pinning the native-save
+    window relative to the trigger writes.
+    """
     motor = CaMotor("U_Ref", "Position (mm)", name="scan_motor")
-    ref = CaGenericDetector("U_Ref", ["Sig"], name="ref")
+    ref = CaGenericDetector(
+        "U_Ref", ["Sig"], name="ref", save_nonscalar_data=save_dir is not None
+    )
     ref.configure_shot_id(rep_rate_hz=1.0)
 
     config = ShotControlConfig(
@@ -92,6 +100,13 @@ def _run_composed(
     connect_mock(RE, motor, ref)
     follow_setpoint(motor)
     set_mock_value(ref.acq_timestamp, 1000.0)
+    saving_detectors: list[tuple] = []
+    if save_dir is not None:
+        ref.configure_nonscalar_file_logging(str(save_dir))
+        callback_on_mock_put(
+            ref.save, lambda value, **kwargs: journal.append(("save", value))
+        )
+        saving_detectors = [(ref, str(save_dir))]
     pacer = start_pacer(RE, [(ref, 1000.0)], initial_delay=1.0, interval=0.15)
     plan = build_step_scan_plan(
         strict=False,
@@ -104,7 +119,7 @@ def _run_composed(
         experiment="",
         scan_number=None,
         scan_folder=None,
-        saving_detectors=[],
+        saving_detectors=saving_detectors,
         setup=setup,
         per_step=per_step,
         closeout=closeout,
@@ -166,3 +181,47 @@ def test_closeout_runs_when_setup_itself_fails() -> None:
             closeout=_marker(journal, "closeout"),
         )
     assert journal[-1] == "closeout"
+
+
+def test_free_run_save_window_opens_after_quiesce_and_closes_before_disarm(
+    tmp_path,
+) -> None:
+    """Gate-2 windowing: save-on only once the trigger is stopped.
+
+    Hardware evidence (Scan013/015): eager save-on let free-running frames
+    from the pre-quiesce / setup-action window be saved as orphans.  The
+    fixed order is setup actions → quiesce[OFF] → save-on → (t0-sync) →
+    steps → save-off → finalize disarm[STANDBY] → closeout.
+    """
+    journal: list = []
+    _run_composed(
+        journal,
+        setup=_marker(journal, "setup"),
+        closeout=_marker(journal, "closeout"),
+        save_dir=tmp_path / "images",
+    )
+    assert journal == [
+        "setup",  # setup actions run before saving can start
+        ("trigger", "Single"),  # quiesce (OFF): the trigger is stopped ...
+        ("save", "on"),  # ... only THEN does native saving turn on
+        ("trigger", "Ext"),  # arm (SCAN)
+        ("trigger", "Ext"),  # disarm (STANDBY)
+        ("trigger", "Ext"),  # arm (SCAN)
+        ("trigger", "Ext"),  # disarm (STANDBY)
+        ("save", "off"),  # save-off first (innermost finalize) ...
+        ("trigger", "Ext"),  # ... then the finalize disarm (STANDBY)
+        "closeout",  # closeout actions last
+    ]
+
+
+def test_free_run_save_off_still_runs_on_mid_scan_abort(tmp_path) -> None:
+    """Abort path: save-off fires before the finalize disarm, then closeout."""
+    journal: list = []
+    with pytest.raises(RuntimeError, match="per_step failed on call 2"):
+        _run_composed(
+            journal,
+            per_step=_marker(journal, "per_step", fail_on_call=2),
+            closeout=_marker(journal, "closeout"),
+            save_dir=tmp_path / "images",
+        )
+    assert journal[-3:] == [("save", "off"), ("trigger", "Ext"), "closeout"]

--- a/GeecsBluesky/tests/test_grid_and_action_plans.py
+++ b/GeecsBluesky/tests/test_grid_and_action_plans.py
@@ -151,7 +151,8 @@ def test_setup_per_step_closeout_order_in_the_full_composition() -> None:
         "per_step",
         ("trigger", "Ext"),  # arm (SCAN)
         ("trigger", "Ext"),  # disarm (STANDBY)
-        ("trigger", "Ext"),  # finalize disarm (STANDBY)
+        ("trigger", "Single"),  # end-of-scan quiesce (OFF) before tail flush
+        ("trigger", "Ext"),  # finalize disarm (STANDBY) — legacy end state
         "closeout",
     ]
 
@@ -165,11 +166,14 @@ def test_closeout_runs_even_when_the_scan_dies_mid_plan() -> None:
             per_step=_marker(journal, "per_step", fail_on_call=2),
             closeout=_marker(journal, "closeout"),
         )
-    # The abort path still disarms (STANDBY) and then runs closeout — and
-    # closeout comes after the disarm write (finalize nesting).
+    # The abort path quiesces (OFF, abort-parity finalize inside the
+    # free-run plan), then disarms (STANDBY), then runs closeout.
     assert "closeout" in journal
-    assert journal[-1] == "closeout"
-    assert journal[-2] == ("trigger", "Ext")  # the finalize disarm
+    assert journal[-3:] == [
+        ("trigger", "Single"),  # abort-parity quiesce (OFF)
+        ("trigger", "Ext"),  # finalize disarm (STANDBY)
+        "closeout",
+    ]
 
 
 def test_closeout_runs_when_setup_itself_fails() -> None:
@@ -188,10 +192,12 @@ def test_free_run_save_window_opens_after_quiesce_and_closes_before_disarm(
 ) -> None:
     """Gate-2 windowing: save-on only once the trigger is stopped.
 
-    Hardware evidence (Scan013/015): eager save-on let free-running frames
-    from the pre-quiesce / setup-action window be saved as orphans.  The
-    fixed order is setup actions → quiesce[OFF] → save-on → (t0-sync) →
-    steps → save-off → finalize disarm[STANDBY] → closeout.
+    Hardware evidence (Scan013/015 front, Scan002 tail): eager save-on let
+    free-running frames from the pre-quiesce / setup-action window be saved
+    as orphans, and STANDBY frames leaked after the last disarm while the
+    tail machinery ran.  The fixed order is setup actions → quiesce[OFF] →
+    save-on → (t0-sync) → steps → quiesce[OFF] → tail flush → save-off →
+    finalize disarm[STANDBY] → closeout.
     """
     journal: list = []
     _run_composed(
@@ -208,14 +214,15 @@ def test_free_run_save_window_opens_after_quiesce_and_closes_before_disarm(
         ("trigger", "Ext"),  # disarm (STANDBY)
         ("trigger", "Ext"),  # arm (SCAN)
         ("trigger", "Ext"),  # disarm (STANDBY)
-        ("save", "off"),  # save-off first (innermost finalize) ...
-        ("trigger", "Ext"),  # ... then the finalize disarm (STANDBY)
+        ("trigger", "Single"),  # end-of-scan quiesce (OFF): tail closed ...
+        ("save", "off"),  # ... then save-off (tail flush ran while OFF)
+        ("trigger", "Ext"),  # finalize disarm (STANDBY) — legacy end state
         "closeout",  # closeout actions last
     ]
 
 
 def test_free_run_save_off_still_runs_on_mid_scan_abort(tmp_path) -> None:
-    """Abort path: save-off fires before the finalize disarm, then closeout."""
+    """Abort path mirrors completion: quiesce → save-off → disarm → closeout."""
     journal: list = []
     with pytest.raises(RuntimeError, match="per_step failed on call 2"):
         _run_composed(
@@ -224,4 +231,9 @@ def test_free_run_save_off_still_runs_on_mid_scan_abort(tmp_path) -> None:
             closeout=_marker(journal, "closeout"),
             save_dir=tmp_path / "images",
         )
-    assert journal[-3:] == [("save", "off"), ("trigger", "Ext"), "closeout"]
+    assert journal[-4:] == [
+        ("trigger", "Single"),  # abort-parity quiesce (OFF) ...
+        ("save", "off"),  # ... then save-off, uniform with completion
+        ("trigger", "Ext"),  # finalize disarm (STANDBY)
+        "closeout",
+    ]

--- a/GeecsBluesky/tests/test_grid_plans_message_level.py
+++ b/GeecsBluesky/tests/test_grid_plans_message_level.py
@@ -1,0 +1,124 @@
+"""Message-level multi-axis grid tests (no RunEngine, no CA — CI-safe).
+
+Pins the grid semantics of ``geecs_step_scan`` with fake motors: the move
+sequence (only changed axes re-moved, innermost fastest under the
+outer-product ordering), one bin per grid point with every motor read in
+every event row, and the per-step hook placement (after the move, before
+the shots).  The RunEngine-level composition tests (setup/closeout
+finalize nesting) live in ``test_grid_and_action_plans.py`` and need the
+``ca`` extra's mock backends.
+"""
+
+from __future__ import annotations
+
+import pytest
+from bluesky.utils import Msg
+
+from geecs_bluesky.plans.step_scan import geecs_step_scan
+
+
+class _NamedFake:
+    """Minimal named object for message-level plans (never actually set)."""
+
+    parent = None  # bps.mv inspects .parent for coupled-device handling
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+    def read(self):  # pragma: no cover - message-level only
+        return {}
+
+    def describe(self):  # pragma: no cover - message-level only
+        return {}
+
+
+def _collect(plan) -> list[Msg]:
+    messages: list[Msg] = []
+    try:
+        msg = plan.send(None)
+        while True:
+            messages.append(msg)
+            msg = plan.send(None)
+    except StopIteration:
+        pass
+    return messages
+
+
+def _grid_plan(per_step=None):
+    outer = _NamedFake("jet_z")
+    inner = _NamedFake("jet_x")
+    det = _NamedFake("cam")
+    grid = [(0.0, 4.0), (0.0, 5.0), (1.0, 4.0), (1.0, 5.0)]
+    plan = geecs_step_scan(
+        motor=[outer, inner],
+        positions=grid,
+        detectors=[det],
+        shots_per_step=2,
+        per_step=per_step,
+    )
+    return plan, outer, inner, det
+
+
+def test_grid_moves_only_changed_axes_innermost_fastest() -> None:
+    plan, outer, inner, det = _grid_plan()
+    moves = [
+        (msg.obj.name, msg.args[0]) for msg in _collect(plan) if msg.command == "set"
+    ]
+    # Grid point 1: both axes move; point 2: only the inner; point 3: outer
+    # steps AND inner returns to its first value; point 4: only the inner.
+    assert moves == [
+        ("jet_z", 0.0),
+        ("jet_x", 4.0),
+        ("jet_x", 5.0),
+        ("jet_z", 1.0),
+        ("jet_x", 4.0),
+        ("jet_x", 5.0),
+    ]
+
+
+def test_grid_one_bin_per_point_and_every_motor_in_every_row() -> None:
+    plan, outer, inner, det = _grid_plan()
+    messages = _collect(plan)
+    saves = [m for m in messages if m.command == "save"]
+    assert len(saves) == 8  # 4 grid points x 2 shots = 8 event rows
+    # Every event row reads both motors (alongside the detector).
+    reads_per_event: list[set[str]] = []
+    current: set[str] = set()
+    for msg in messages:
+        if msg.command == "create":
+            current = set()
+        elif msg.command == "read":
+            current.add(msg.obj.name)
+        elif msg.command == "save":
+            reads_per_event.append(current)
+    assert all({"jet_z", "jet_x", "cam"} <= row for row in reads_per_event)
+
+
+def test_per_step_runs_after_move_before_shots_at_every_grid_point() -> None:
+    def per_step():
+        yield Msg("per_step_marker", None)
+
+    plan, *_ = _grid_plan(per_step=per_step)
+    commands = [m.command for m in _collect(plan)]
+    assert commands.count("per_step_marker") == 4  # every grid point
+    # Placement: at each boundary the marker comes after the step's moves
+    # (set/wait) and before its first shot (trigger/create).
+    for index, command in enumerate(commands):
+        if command != "per_step_marker":
+            continue
+        # No trigger/create between this step's moves and the marker.
+        after = commands[index + 1]
+        assert after in ("trigger", "create"), after
+        before = commands[index - 1]
+        assert before in ("wait", "open_run"), before
+
+
+def test_grid_point_arity_mismatch_raises() -> None:
+    plan = geecs_step_scan(
+        motor=[_NamedFake("a"), _NamedFake("b")],
+        positions=[(0.0,)],  # one value for two motors
+        detectors=[_NamedFake("cam")],
+        shots_per_step=1,
+    )
+    with pytest.raises(ValueError, match="positions must align"):
+        _collect(plan)

--- a/GeecsBluesky/tests/test_grid_plans_message_level.py
+++ b/GeecsBluesky/tests/test_grid_plans_message_level.py
@@ -122,3 +122,58 @@ def test_grid_point_arity_mismatch_raises() -> None:
     )
     with pytest.raises(ValueError, match="positions must align"):
         _collect(plan)
+
+
+# ---------------------------------------------------------------------------
+# Native-save windowing (Gate-2): save-on only after the trigger is stopped
+# ---------------------------------------------------------------------------
+
+
+def test_strict_save_on_after_armed_before_first_shot() -> None:
+    """Strict: enable_saving runs after setup_trigger (ARMED + quiescence).
+
+    Gate-2 hardware evidence (Scan015): save-on before arming let free-run
+    STANDBY frames be saved as orphans during the setup-action window.
+    """
+
+    def setup_trigger():
+        yield Msg("armed_marker", None)
+
+    def enable_saving():
+        yield Msg("save_on_marker", None)
+
+    plan = geecs_step_scan(
+        motor=None,
+        positions=[None],
+        detectors=[_NamedFake("cam")],
+        shots_per_step=2,
+        setup_trigger=setup_trigger,
+        enable_saving=enable_saving,
+    )
+    commands = [m.command for m in _collect(plan)]
+    assert commands.index("open_run") < commands.index("armed_marker")
+    assert commands.index("armed_marker") < commands.index("save_on_marker")
+    # Saving is on before the first shot is taken.
+    assert commands.index("save_on_marker") < commands.index("create")
+    assert commands.count("save_on_marker") == 1  # once per run, not per step
+
+
+def test_strict_per_step_actions_run_with_saving_already_on() -> None:
+    """per_step comes after the one-time ARMED/save-on preamble."""
+
+    def enable_saving():
+        yield Msg("save_on_marker", None)
+
+    def per_step():
+        yield Msg("per_step_marker", None)
+
+    plan = geecs_step_scan(
+        motor=None,
+        positions=[None, None],
+        detectors=[_NamedFake("cam")],
+        shots_per_step=1,
+        enable_saving=enable_saving,
+        per_step=per_step,
+    )
+    commands = [m.command for m in _collect(plan)]
+    assert commands.index("save_on_marker") < commands.index("per_step_marker")

--- a/GeecsBluesky/tests/test_grid_plans_message_level.py
+++ b/GeecsBluesky/tests/test_grid_plans_message_level.py
@@ -177,3 +177,68 @@ def test_strict_per_step_actions_run_with_saving_already_on() -> None:
     )
     commands = [m.command for m in _collect(plan)]
     assert commands.index("save_on_marker") < commands.index("per_step_marker")
+
+
+def test_free_run_saving_without_shot_control_warns(caplog) -> None:
+    """A free-run scan that saves but has no controller can't window saving.
+
+    Native-save windowing needs the controller's quiesce to stop the trigger;
+    with ``controller=None`` there is no such point, so the build warns loudly
+    that frames may be saved as orphans (rather than silently leaking or
+    refusing the supported controllerless config — review finding #1).
+    """
+    import logging
+
+    from geecs_bluesky.plans.orchestration import build_step_scan_plan
+
+    ref = _NamedFake("cam")
+    with caplog.at_level(logging.WARNING):
+        build_step_scan_plan(
+            strict=False,
+            motor=None,
+            positions=[None],
+            reference=ref,
+            detectors=[ref],
+            shots_per_step=3,
+            controller=None,
+            experiment="Exp",
+            scan_number=None,
+            scan_folder=None,
+            saving_detectors=[(ref, "/tmp/save")],
+        )
+    assert "no shot control" in caplog.text
+    assert "cam" in caplog.text
+
+
+def test_free_run_saving_with_controller_does_not_warn(caplog) -> None:
+    """With a controller present, no orphan-frame warning is emitted."""
+    import logging
+
+    from geecs_bluesky.plans.orchestration import build_step_scan_plan
+
+    class _Controller:
+        def arm(self):
+            yield Msg("arm", None)
+
+        def disarm(self):
+            yield Msg("disarm", None)
+
+        def quiesce(self):
+            yield Msg("quiesce", None)
+
+    ref = _NamedFake("cam")
+    with caplog.at_level(logging.WARNING):
+        build_step_scan_plan(
+            strict=False,
+            motor=None,
+            positions=[None],
+            reference=ref,
+            detectors=[ref],
+            shots_per_step=3,
+            controller=_Controller(),
+            experiment="Exp",
+            scan_number=None,
+            scan_folder=None,
+            saving_detectors=[(ref, "/tmp/save")],
+        )
+    assert "no shot control" not in caplog.text

--- a/GeecsBluesky/tests/test_run_wrapper.py
+++ b/GeecsBluesky/tests/test_run_wrapper.py
@@ -146,3 +146,62 @@ def test_wrapper_injects_merged_scalar_headers() -> None:
 def test_wrapper_omits_scalar_headers_when_no_devices() -> None:
     start = _run_capture_start(geecs_run_wrapper(_tiny_run(), scan_number=3))
     assert "geecs_scalar_headers" not in start
+
+
+def test_wrapper_defer_save_on_leaves_enable_to_the_plan(tmp_path) -> None:
+    """defer_save_on=True: no eager save-on; finalize save-off + md kept."""
+    from geecs_bluesky.plans.run_wrapper import save_enable_plan
+
+    det = _FakeSavingDetector("topcam")
+    save_dir = tmp_path / "Scan007" / "UC_TopCam"
+
+    def _inner_with_windowed_save():
+        # The step plans yield save_enable_plan at the trigger-stopped point.
+        yield from save_enable_plan([(det, str(save_dir))])
+        yield from _tiny_run()
+
+    start = _run_capture_start(
+        geecs_run_wrapper(
+            _inner_with_windowed_save(),
+            scan_number=7,
+            saving_detectors=[(det, str(save_dir))],
+            defer_save_on=True,
+        )
+    )
+    # Exactly one on (from the inner plan) and one off (finalize) — the
+    # wrapper itself added no eager enable.
+    assert det.save.sets == ["on", "off"]
+    assert det.localsavingpath.sets == [str(save_dir)]
+    assert save_dir.is_dir()
+    # The save-path metadata is unaffected by the deferral.
+    assert start["nonscalar_save_paths"] == {"TOPCAM": str(save_dir)}
+
+
+def test_wrapper_defer_without_inner_enable_still_cleans_up(tmp_path) -> None:
+    """Even if the inner plan never enabled saving, finalize still turns it off."""
+    det = _FakeSavingDetector("topcam")
+    save_dir = tmp_path / "Scan007" / "UC_TopCam"
+    _run_capture_start(
+        geecs_run_wrapper(
+            _tiny_run(),
+            scan_number=7,
+            saving_detectors=[(det, str(save_dir))],
+            defer_save_on=True,
+        )
+    )
+    assert det.save.sets == ["off"]  # idempotent, harmless
+    assert det.localsavingpath.sets == []
+
+
+def test_save_enable_plan_alone(tmp_path) -> None:
+    """The extracted stub creates the dir and writes path + save='on'."""
+    from bluesky import RunEngine
+
+    from geecs_bluesky.plans.run_wrapper import save_enable_plan
+
+    det = _FakeSavingDetector("topcam")
+    save_dir = tmp_path / "Scan008" / "UC_TopCam"
+    RunEngine()(save_enable_plan([(det, str(save_dir))]))
+    assert det.localsavingpath.sets == [str(save_dir)]
+    assert det.save.sets == ["on"]
+    assert save_dir.is_dir()

--- a/GeecsBluesky/tests/test_scan_log.py
+++ b/GeecsBluesky/tests/test_scan_log.py
@@ -1,0 +1,85 @@
+"""Tests for the shared per-scan scan.log helper (Gate-2 follow-up).
+
+Covers the extracted :mod:`geecs_bluesky.scan_log` helper itself and the GUI
+bridge's delegation (behavior regression — identical file, format, and
+scan-id stamping).  CI-safe: no CA needed.  The headless
+:class:`GeecsSession` attachment tests (mock CA backends) live in
+``test_scan_log_session.py``.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+
+import pytest
+
+from geecs_bluesky.scan_log import scan_log
+
+module_logger = logging.getLogger("geecs_bluesky.tests.scan_log")
+
+
+def test_scan_log_writes_stamped_lines(tmp_path) -> None:
+    folder = tmp_path / "Scan007"
+    folder.mkdir()
+    with scan_log(7, str(folder)):
+        module_logger.info("hello from the scan")
+    content = (folder / "scan.log").read_text()
+    assert "scan Scan007: starting" in content
+    assert "hello from the scan" in content
+    assert "scan Scan007: finished" in content
+    # Every record is stamped with the scan id by the context filter.
+    assert "scan=Scan007" in content
+
+
+def test_scan_log_noop_without_claim(tmp_path) -> None:
+    with scan_log(None, None):
+        module_logger.info("unclaimed")
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_scan_log_missing_folder_warns_and_skips(tmp_path, caplog) -> None:
+    missing = tmp_path / "ScanNNN"
+    with caplog.at_level(logging.WARNING, logger="geecs_bluesky.scan_log"):
+        with scan_log(9, str(missing)):
+            module_logger.info("nowhere to write")
+    assert not missing.exists()  # never created (scan-folder invariant)
+    assert "skipping scan.log" in caplog.text
+
+
+def test_scan_log_detaches_and_restores_levels(tmp_path) -> None:
+    folder = tmp_path / "Scan008"
+    folder.mkdir()
+    pkg_logger = logging.getLogger("geecs_bluesky")
+    before_level = pkg_logger.level
+    before_handlers = list(pkg_logger.handlers)
+    with pytest.raises(RuntimeError, match="mid-scan"):
+        with scan_log(8, str(folder)):
+            raise RuntimeError("mid-scan failure")
+    assert pkg_logger.level == before_level
+    assert pkg_logger.handlers == before_handlers
+    # Post-exit records do not land in the file.
+    module_logger.info("after the scan")
+    assert "after the scan" not in (folder / "scan.log").read_text()
+
+
+def test_bridge_scan_log_delegates_to_shared_helper(tmp_path) -> None:
+    """Regression: BlueskyScanner._scan_log behavior is unchanged."""
+    from geecs_bluesky.scanner_bridge.bluesky_scanner import BlueskyScanner
+
+    scanner = BlueskyScanner.__new__(BlueskyScanner)
+    scanner._device_lock = threading.Lock()
+
+    folder = tmp_path / "Scan012"
+    folder.mkdir()
+    with scanner._scan_log(12, str(folder)):
+        module_logger.info("bridge line")
+    content = (folder / "scan.log").read_text()
+    assert "scan Scan012: starting" in content
+    assert "bridge line" in content
+    assert "scan=Scan012" in content
+    assert "scan Scan012: finished" in content
+
+    # The no-claim no-op is preserved too.
+    with scanner._scan_log(None, None):
+        module_logger.info("no claim")

--- a/GeecsBluesky/tests/test_scan_log_session.py
+++ b/GeecsBluesky/tests/test_scan_log_session.py
@@ -1,0 +1,81 @@
+"""Headless GeecsSession scan.log attachment tests (mock CA backends).
+
+The shared-helper and bridge-regression tests live in ``test_scan_log.py``
+(CI-safe, no CA); these need the ``ca`` extra's mock backends to run a real
+session scan.  Pins the Gate-2 fix: a session-*claimed* scan writes
+``scan.log`` into its folder; a pre-claimed scan does not self-attach (the
+claiming caller — e.g. the GUI bridge — owns the handler).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("aioca")
+
+from tests.ca_mock_helpers import start_pacer  # noqa: E402
+
+
+def _mock_session():
+    from geecs_bluesky.session import GeecsSession
+
+    return GeecsSession("TestExp", tiled=False, mock=True)
+
+
+def _run_noscan(session, monkeypatch, scan_folder, *, preclaimed: bool) -> None:
+    """Run one 2-shot free-run noscan through session.scan into *scan_folder*."""
+    import geecs_bluesky.session as session_module
+
+    if not preclaimed:
+        monkeypatch.setattr(
+            session_module,
+            "claim_scan_number",
+            lambda experiment: (7, str(scan_folder)),
+        )
+    det = session.detector("U_Cam", ["Sig"])
+    det_kwargs = {}
+    if preclaimed:
+        det_kwargs = {"scan_number": 7, "scan_folder": str(scan_folder)}
+    from ophyd_async.core import set_mock_value
+
+    set_mock_value(det.acq_timestamp, 1000.0)
+    pacer = start_pacer(session.RE, [(det, 1000.0)], initial_delay=1.0, interval=0.15)
+    try:
+        session.scan(
+            detectors=[det],
+            motor=None,
+            positions=[None],
+            shots_per_step=2,
+            mode="free_run",
+            **det_kwargs,
+        )
+    finally:
+        pacer.cancel()
+        session.disconnect(det)
+
+
+def test_headless_session_scan_writes_scan_log(tmp_path, monkeypatch) -> None:
+    """A session-claimed scan gets a scan.log with the run's log lines."""
+    scan_folder = tmp_path / "Scan007"
+    scan_folder.mkdir()
+    session = _mock_session()
+    _run_noscan(session, monkeypatch, scan_folder, preclaimed=False)
+
+    log_file = scan_folder / "scan.log"
+    assert log_file.exists()
+    content = log_file.read_text()
+    assert "scan Scan007: starting" in content
+    assert "scan Scan007: finished" in content
+    assert "scan=Scan007" in content
+    # The run's own package log lines are captured (ScanInfo write happens
+    # pre-attach; the export warning is emitted inside the run block).
+    assert "geecs_bluesky" in content
+
+
+def test_session_does_not_attach_for_preclaimed_scans(tmp_path, monkeypatch) -> None:
+    """Pre-claimed number/folder → the caller owns scan.log (no duplicate)."""
+    scan_folder = tmp_path / "Scan007"
+    scan_folder.mkdir()
+    session = _mock_session()
+    _run_noscan(session, monkeypatch, scan_folder, preclaimed=True)
+    assert not (scan_folder / "scan.log").exists()

--- a/GeecsBluesky/tests/test_scan_request_hardware.py
+++ b/GeecsBluesky/tests/test_scan_request_hardware.py
@@ -1,0 +1,93 @@
+"""Hardware-runnable ScanRequest end-to-end test (integration-marked).
+
+Skipped in CI (the suite runs ``-m "not integration ..."``); run it by hand
+over the lab network / VPN to verify the M3b ScanRequest path against the
+real gateway:
+
+.. code-block:: bash
+
+    cd GeecsBluesky
+    EPICS_CA_ADDR_LIST=<gateway host> \\
+    poetry run pytest tests/test_scan_request_hardware.py -m integration -s
+
+Prerequisites
+-------------
+- The GeecsCAGateway serving the experiment's PVs (``EPICS_CA_ADDR_LIST``
+  set, or ``[epics] ca_addr_list`` in the shared config.ini).
+- The configs repository resolvable (``GEECS_SCANNER_CONFIG_DIR`` env var or
+  config.ini) — the save set and trigger profile are loaded from it via
+  :class:`~geecs_bluesky.scan_request_runner.ConfigsRepoResolver`, converting
+  the legacy corpus files on the fly.
+- The NetApp data tree mounted if you want a scan number/folder claimed
+  (otherwise the run proceeds with numbering disabled and a warning).
+
+Every name is parameterizable via env vars so the coordinator can point it
+at whatever is alive that day:
+
+===========================  =======================================
+``GEECS_HW_EXPERIMENT``      experiment name (default ``Undulator``)
+``GEECS_HW_CAMERA``          save-set name — a corpus save element /
+                             save set file stem under ``save_devices/``
+                             (default ``UC_Amp4_IR_input``)
+``GEECS_HW_TRIGGER_PROFILE`` trigger profile / shot-control config file
+                             stem (default ``HTU-LaserOFF`` — the
+                             corpus laser-off config: internal
+                             single-shot source, safe without beam)
+``GEECS_HW_ACQUISITION``     ``strict`` (default) or ``free_run``
+``GEECS_HW_SHOTS``           shots to take (default ``5``)
+``GEECS_HW_REP_RATE``        machine rep rate in Hz (default ``1``)
+===========================  =======================================
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+pytestmark = pytest.mark.integration
+
+pytest.importorskip("aioca")
+
+
+@pytest.mark.integration
+def test_scan_request_noscan_runs_on_hardware() -> None:
+    """One noscan ScanRequest through session.run() against the real gateway.
+
+    Exercises the full M3b request path end to end: ConfigsRepoResolver
+    loading (and legacy-converting) the corpus save set + trigger profile,
+    the TriggerProfile → ordered-writes adapter, ShotController over the
+    gateway ``:SP`` PVs, device building from the save set, scan-number
+    claiming, acquisition, and the s-file export — with zero
+    NotImplementedErrors.
+    """
+    from geecs_bluesky.scan_request_runner import ConfigsRepoResolver
+    from geecs_bluesky.session import GeecsSession
+    from geecs_schemas import ScanRequest
+
+    experiment = os.environ.get("GEECS_HW_EXPERIMENT", "Undulator")
+    camera_save_set = os.environ.get("GEECS_HW_CAMERA", "UC_Amp4_IR_input")
+    trigger_profile = os.environ.get("GEECS_HW_TRIGGER_PROFILE", "HTU-LaserOFF")
+    acquisition = os.environ.get("GEECS_HW_ACQUISITION", "strict")
+    shots = int(os.environ.get("GEECS_HW_SHOTS", "5"))
+    rep_rate_hz = float(os.environ.get("GEECS_HW_REP_RATE", "1"))
+
+    request = ScanRequest.model_validate(
+        {
+            "mode": "noscan",
+            "shots_per_step": shots,
+            "acquisition": acquisition,
+            "save_set": camera_save_set,
+            "trigger_profile": trigger_profile,
+            "description": "M3b hardware verification (test_scan_request_hardware)",
+        }
+    )
+    resolver = ConfigsRepoResolver(experiment)
+    session = GeecsSession(experiment, rep_rate_hz=rep_rate_hz)
+
+    uid = session.run(request, resolver)
+
+    # A uid proves the RunEngine completed the run; None means the run was
+    # not persisted (e.g. Tiled unreachable), which is still a pass for the
+    # acquisition path — the RunEngine would have raised on failure.
+    print(f"\nScanRequest hardware run complete; run uid: {uid}")

--- a/GeecsBluesky/tests/test_scan_request_hardware.py
+++ b/GeecsBluesky/tests/test_scan_request_hardware.py
@@ -28,7 +28,7 @@ at whatever is alive that day:
 ``GEECS_HW_EXPERIMENT``      experiment name (default ``Undulator``)
 ``GEECS_HW_CAMERA``          save-set name — a corpus save element /
                              save set file stem under ``save_devices/``
-                             (default ``UC_Amp4_IR_input``)
+                             (default ``Amp4In``)
 ``GEECS_HW_TRIGGER_PROFILE`` trigger profile / shot-control config file
                              stem (default ``HTU-LaserOFF`` — the
                              corpus laser-off config: internal
@@ -66,7 +66,7 @@ def test_scan_request_noscan_runs_on_hardware() -> None:
     from geecs_schemas import ScanRequest
 
     experiment = os.environ.get("GEECS_HW_EXPERIMENT", "Undulator")
-    camera_save_set = os.environ.get("GEECS_HW_CAMERA", "UC_Amp4_IR_input")
+    camera_save_set = os.environ.get("GEECS_HW_CAMERA", "Amp4In")
     trigger_profile = os.environ.get("GEECS_HW_TRIGGER_PROFILE", "HTU-LaserOFF")
     acquisition = os.environ.get("GEECS_HW_ACQUISITION", "strict")
     shots = int(os.environ.get("GEECS_HW_SHOTS", "5"))

--- a/GeecsBluesky/tests/test_scan_request_runner.py
+++ b/GeecsBluesky/tests/test_scan_request_runner.py
@@ -6,11 +6,14 @@ devices_config derivation rules, the TriggerProfile → ShotControlWrites
 adapter (ordered, multi-device), action slot assembly + compilation +
 wiring, multi-axis grid execution, and the request execution mapping onto a
 fake GeecsSession.  The remaining documented v1 gaps (pseudo variables,
-``all_scalars``, optimize without injected callables / with actions) refuse
-loudly.
+``all_scalars``, optimize without injected callables) refuse loudly; optimize
+*with* actions runs but skips the actions (logged + recorded in metadata),
+since optimize has no action hooks yet.
 """
 
 from __future__ import annotations
+
+import logging
 
 import pytest
 from bluesky.utils import Msg
@@ -22,7 +25,7 @@ from geecs_bluesky.scan_request_runner import (
     ConfigsRepoResolver,
     apply_experiment_defaults,
     assemble_action_slots,
-    collect_save_set_action_names,
+    build_action_registry,
     collect_save_set_rituals,
     resolve_save_set_and_rituals,
     resolve_save_set_checked,
@@ -1108,14 +1111,12 @@ def test_entry_level_actions_collected() -> None:
             SaveSetEntry(device="U_B", scalars=["y"]),
         ],
     )
-    assert collect_save_set_action_names(save_set) == ["prep_cam", "park"]
     assert collect_save_set_rituals(save_set) == {
         "setup": ["prep_cam"],
         "closeout": ["park"],
     }
     # Entries without references contribute nothing.
     plain = SaveSet(name="s", entries=[SaveSetEntry(device="U_A", scalars=["x"])])
-    assert collect_save_set_action_names(plain) == []
     assert collect_save_set_rituals(plain) == {"setup": [], "closeout": []}
 
 
@@ -1290,24 +1291,78 @@ def test_full_fake_session_flow_axes_actions_multi_device_trigger(
     assert factory in session.disconnected
 
 
-def test_optimize_with_actions_is_a_documented_gap(legacy_resolver) -> None:
-    """Optimize mode has no action hooks yet — refused loudly, pre-hardware."""
+def test_optimize_skips_actions_and_records_them(legacy_resolver, caplog) -> None:
+    """Optimize runs; its action plans are skipped, logged, and recorded.
+
+    Optimize mode has no action hooks yet, but refusing would block every
+    optimization the moment an experiment defines default bracket actions.
+    So the run proceeds with the actions skipped — never silently: a WARNING
+    is logged and the skip lands in run metadata.
+    """
     session = _FakeSession()
-    request = _optimize_request(actions={"setup": ["scan_prep"]})
-    with pytest.raises(NotImplementedError, match="scan_prep"):
-        run_scan_request(session, request, legacy_resolver)
-    assert session.devices == []
+    request = _optimize_request(
+        actions={"setup": ["scan_prep"], "closeout": ["cam_park"]}
+    )
+
+    def objective(bin_data) -> float:
+        return 1.0
+
+    with caplog.at_level(logging.WARNING):
+        uid = run_scan_request(
+            session, request, legacy_resolver, objective=objective, suggester=object()
+        )
+    assert uid == "uid-opt"
+    skipped = session.optimize_kwargs["md"]["skipped_action_plans"]
+    assert skipped["setup"] == ["scan_prep"]
+    assert skipped["closeout"] == ["cam_park"]
+    assert "scan_prep" in caplog.text
 
 
-def test_optimize_with_entry_rituals_is_a_documented_gap(legacy_resolver) -> None:
+def test_optimize_skips_entry_rituals_and_records_them(legacy_resolver) -> None:
+    """Save-set entry rituals are skipped and recorded, not refused."""
     session = _FakeSession()
     request = _optimize_request(save_set="RitualSet")
 
     def objective(bin_data) -> float:
         return 1.0
 
-    with pytest.raises(NotImplementedError, match="cam_ritual"):
-        run_scan_request(
-            session, request, legacy_resolver, objective=objective, suggester=object()
-        )
-    assert session.devices == []
+    uid = run_scan_request(
+        session, request, legacy_resolver, objective=objective, suggester=object()
+    )
+    assert uid == "uid-opt"
+    assert (
+        "cam_ritual"
+        in session.optimize_kwargs["md"]["skipped_action_plans"]["save_set_rituals"]
+    )
+
+
+# ---------------------------------------------------------------------------
+# Lazy action-plan registry: a real fault must not masquerade as "not found"
+# ---------------------------------------------------------------------------
+
+
+def test_lazy_registry_propagates_unexpected_resolver_faults() -> None:
+    """A non-"not found" fault propagates; only an unknown name is a miss.
+
+    The lazy registry converts a genuine "plan not in the library"
+    (``GeecsConfigurationError``) into ``KeyError`` for the compiler, but any
+    other fault (a resolver bug, transient IO) must surface — masking it as a
+    miss would misdirect debugging to "plan not found" with no candidates.
+    """
+
+    class _BoomResolver:
+        def resolve_action_plan(self, name: str):
+            if name == "missing":
+                raise GeecsConfigurationError("not in library")
+            raise RuntimeError("resolver exploded")
+
+    registry = build_action_registry(_BoomResolver())
+    # Unknown name → KeyError (the compiler's "not found" path).
+    with pytest.raises(KeyError):
+        registry["missing"]
+    # Any other fault propagates unchanged.
+    with pytest.raises(RuntimeError, match="exploded"):
+        registry["anything_else"]
+    assert registry.get("missing", "default") == "default"
+    with pytest.raises(RuntimeError, match="exploded"):
+        registry.get("anything_else")

--- a/GeecsBluesky/tests/test_scan_request_runner.py
+++ b/GeecsBluesky/tests/test_scan_request_runner.py
@@ -2,30 +2,36 @@
 
 Covers the configs-repo resolver (new-schema YAML loads directly, legacy YAML
 converts — the whole existing corpus is usable immediately), the SaveSet →
-devices_config derivation rules, the TriggerProfile → ShotControlConfig
-adapter, and the request execution mapping onto a fake GeecsSession —
-including every documented v1 gap (multi-axis, actions, pseudo variables,
-optimize without injected callables) refusing loudly.
+devices_config derivation rules, the TriggerProfile → ShotControlWrites
+adapter (ordered, multi-device), action slot assembly + compilation +
+wiring, multi-axis grid execution, and the request execution mapping onto a
+fake GeecsSession.  The remaining documented v1 gaps (pseudo variables,
+``all_scalars``, optimize without injected callables / with actions) refuse
+loudly.
 """
 
 from __future__ import annotations
 
 import pytest
+from bluesky.utils import Msg
 
 from geecs_bluesky.exceptions import GeecsConfigurationError
-from geecs_bluesky.models.shot_control import ShotControlConfig
+from geecs_bluesky.models.shot_control import ShotControlWrites
 from geecs_bluesky.scan_request_runner import (
-    MULTI_AXIS_MESSAGE,
     ConfigResolver,
     ConfigsRepoResolver,
     apply_experiment_defaults,
+    assemble_action_slots,
     collect_save_set_action_names,
+    collect_save_set_rituals,
+    resolve_save_set_and_rituals,
     resolve_save_set_checked,
     run_scan_request,
     save_set_to_devices_config,
-    shot_control_config_from_trigger_profile,
+    trigger_writes_from_profile,
 )
 from geecs_schemas import (
+    ActionPlan,
     ExperimentDefaults,
     PseudoScanVariable,
     SaveSet,
@@ -46,6 +52,35 @@ class _FakeDevice:
         self.kind = kind
 
 
+class _FakeActionSignal:
+    """Named stand-in for a CA action signal (message-level assertions only)."""
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+
+class _FakeActionFactory:
+    """Recording SettableFactory: named fakes, cached per (device, variable)."""
+
+    def __init__(self) -> None:
+        self.settables: dict[tuple[str, str], _FakeActionSignal] = {}
+        self.readables: dict[tuple[str, str], _FakeActionSignal] = {}
+        self.disconnected = False
+
+    def get_settable(self, device: str, variable: str) -> _FakeActionSignal:
+        return self.settables.setdefault(
+            (device, variable), _FakeActionSignal(f"{device}-{variable}")
+        )
+
+    def get_readable(self, device: str, variable: str) -> _FakeActionSignal:
+        return self.readables.setdefault(
+            (device, variable), _FakeActionSignal(f"{device}-{variable}")
+        )
+
+    async def disconnect(self) -> None:
+        self.disconnected = True
+
+
 class _FakeSession:
     def __init__(self) -> None:
         self.devices: list[tuple[str, str]] = []  # (device, factory)
@@ -53,6 +88,7 @@ class _FakeSession:
         self.scan_kwargs: dict | None = None
         self.optimize_kwargs: dict | None = None
         self.disconnected: list = []
+        self.action_factories: list[_FakeActionFactory] = []
 
     def _make(self, device: str, kind: str) -> _FakeDevice:
         self.devices.append((device, kind))
@@ -73,6 +109,11 @@ class _FakeSession:
     def settable(self, device, variable, *, name=None):
         return self._make(f"{device}:{variable}", "settable")
 
+    def action_signal_factory(self):
+        factory = _FakeActionFactory()
+        self.action_factories.append(factory)
+        return factory
+
     def shot_control(self, config):
         self.shot_control_calls.append(config)
 
@@ -86,6 +127,26 @@ class _FakeSession:
 
     def disconnect(self, *devices):
         self.disconnected.extend(devices)
+
+
+def _collect_messages(plan) -> list[Msg]:
+    """Drive a plan-stub generator without a RunEngine (no responses needed)."""
+    messages: list[Msg] = []
+    try:
+        message = plan.send(None)
+        while True:
+            messages.append(message)
+            message = plan.send(None)
+    except StopIteration:
+        pass
+    return messages
+
+
+def _set_targets(plan) -> list[tuple[str, object]]:
+    """The (signal name, value) sequence of a plan's 'set' messages."""
+    return [
+        (m.obj.name, m.args[0]) for m in _collect_messages(plan) if m.command == "set"
+    ]
 
 
 # ---------------------------------------------------------------------------
@@ -158,6 +219,7 @@ setup_action:
 LEGACY_SCAN_DEVICES = """\
 single_scan_devices:
   jet_z: "U_ESP_JetXYZ:Position.Axis 3"
+  jet_x: "U_ESP_JetXYZ:Position.Axis 1"
 """
 
 NEW_SCAN_VARIABLES = """\
@@ -180,6 +242,63 @@ actions:
         device: U_PLC
         variable: DO.Ch9
         value: 'on'
+  default_prep:
+    steps:
+      - action: set
+        device: U_PLC
+        variable: DO.Ch1
+        value: 'on'
+  scan_prep:
+    steps:
+      - action: set
+        device: U_PLC
+        variable: DO.Ch2
+        value: 'on'
+  between_steps:
+    steps:
+      - action: set
+        device: U_PLC
+        variable: DO.Ch3
+        value: 'on'
+  scan_cleanup:
+    steps:
+      - action: set
+        device: U_PLC
+        variable: DO.Ch4
+        value: 'off'
+  default_cleanup:
+    steps:
+      - action: set
+        device: U_PLC
+        variable: DO.Ch5
+        value: 'off'
+  cam_ritual:
+    steps:
+      - action: set
+        device: U_Cam
+        variable: Analysis
+        value: 'on'
+  cam_park:
+    steps:
+      - action: set
+        device: U_Cam
+        variable: Analysis
+        value: 'off'
+"""
+
+# New-schema save set whose entries carry setup/closeout rituals (shared
+# ritual named by both entries — must run once).
+RITUAL_SAVE_SET = """\
+schema_version: 1
+name: RitualSet
+entries:
+  - device: U_Cam
+    scalars: [MaxCounts]
+    setup: [cam_ritual]
+    closeout: [cam_park]
+  - device: U_Cam2
+    scalars: [Val]
+    setup: [cam_ritual]
 """
 
 
@@ -200,6 +319,7 @@ def configs_root(tmp_path):
     (legacy / "scan_devices" / "scan_devices.yaml").write_text(LEGACY_SCAN_DEVICES)
     (legacy / "action_library").mkdir()
     (legacy / "action_library" / "actions.yaml").write_text(LEGACY_ACTIONS)
+    (legacy / "save_devices" / "RitualSet.yaml").write_text(RITUAL_SAVE_SET)
 
     modern = tmp_path / "ModernExp"
     (modern / "save_devices").mkdir(parents=True)
@@ -307,32 +427,35 @@ def test_action_plan_resolution(legacy_resolver) -> None:
 
 
 # ---------------------------------------------------------------------------
-# TriggerProfile → ShotControlConfig adapter
+# TriggerProfile → ShotControlWrites adapter (ordered, multi-device)
 # ---------------------------------------------------------------------------
 
 
 def test_trigger_adapter_preserves_state_semantics(legacy_resolver) -> None:
-    """values_for_state / defines_state agree between the two models."""
+    """Per-state writes and defines_state agree between profile and writes."""
     profile = legacy_resolver.resolve_trigger_profile("HTU-Normal")
-    config = shot_control_config_from_trigger_profile(profile)
-    assert isinstance(config, ShotControlConfig)
-    assert config.device == profile.devices[0]
+    writes = trigger_writes_from_profile(profile)
+    assert isinstance(writes, ShotControlWrites)
+    assert writes.name == profile.name
+    assert writes.devices == profile.devices
     for state in ("OFF", "SCAN", "STANDBY", "SINGLESHOT", "ARMED"):
-        expected = {w.variable: w.value for w in profile.writes_for(state)}
-        assert config.values_for_state(state) == expected, state
-        assert config.defines_state(state) == profile.defines_state(state), state
+        expected = [(w.device, w.variable, w.value) for w in profile.writes_for(state)]
+        assert writes.writes_for_state(state) == expected, state
+        assert writes.defines_state(state) == profile.defines_state(state), state
 
 
 def test_trigger_adapter_applies_variant(modern_resolver) -> None:
     profile = modern_resolver.resolve_trigger_profile("NewProfile")
-    config = shot_control_config_from_trigger_profile(profile, "laser_off")
-    assert config.values_for_state("SCAN") == {"Trigger.Source": "Internal"}
+    writes = trigger_writes_from_profile(profile, "laser_off")
+    assert writes.writes_for_state("SCAN") == [
+        ("U_DG645_ShotControl", "Trigger.Source", "Internal")
+    ]
 
 
 def test_trigger_adapter_unknown_variant_raises(modern_resolver) -> None:
     profile = modern_resolver.resolve_trigger_profile("NewProfile")
     with pytest.raises(GeecsConfigurationError, match="laser_off"):
-        shot_control_config_from_trigger_profile(profile, "nope")
+        trigger_writes_from_profile(profile, "nope")
 
 
 # ---------------------------------------------------------------------------
@@ -468,9 +591,9 @@ def test_trigger_profile_is_attached_via_the_adapter(legacy_resolver) -> None:
     run_scan_request(
         session, _noscan_request(trigger_profile="HTU-Normal"), legacy_resolver
     )
-    (config,) = session.shot_control_calls
-    assert isinstance(config, ShotControlConfig)
-    assert config.device == "U_DG645_ShotControl"
+    (writes,) = session.shot_control_calls
+    assert isinstance(writes, ShotControlWrites)
+    assert writes.devices == ["U_DG645_ShotControl"]
 
 
 def test_step_request_setpoint_variable_uses_settable(legacy_resolver) -> None:
@@ -500,30 +623,126 @@ def test_step_request_motor_kind_and_position_list(modern_resolver) -> None:
     assert kwargs["positions"] == [4.0, 4.5, 6.0]
 
 
-def test_multi_axis_raises_not_implemented(legacy_resolver) -> None:
+# ---------------------------------------------------------------------------
+# Multi-axis grid execution (outer product, first axis outermost)
+# ---------------------------------------------------------------------------
+
+
+def test_two_axis_request_runs_as_outer_product_grid(legacy_resolver) -> None:
+    session = _FakeSession()
     request = _noscan_request(
         mode="step",
         axes=[
-            {"variable": "jet_z", "positions": {"start": 0, "end": 1, "step": 0.5}},
-            {"variable": "jet_x", "positions": {"start": 0, "end": 1, "step": 0.5}},
+            {"variable": "jet_z", "positions": {"start": 0, "end": 1, "step": 1}},
+            {"variable": "jet_x", "positions": {"values": [4.0, 5.0, 6.0]}},
         ],
     )
-    with pytest.raises(NotImplementedError, match=MULTI_AXIS_MESSAGE):
-        run_scan_request(_FakeSession(), request, legacy_resolver)
+    run_scan_request(session, request, legacy_resolver)
+
+    kwargs = session.scan_kwargs
+    # N movables, outermost axis first.
+    assert [m._geecs_device_name for m in kwargs["motor"]] == [
+        "U_ESP_JetXYZ:Position.Axis 3",
+        "U_ESP_JetXYZ:Position.Axis 1",
+    ]
+    # Outer product in list order: first axis outermost/slowest.
+    assert kwargs["positions"] == [
+        (0.0, 4.0),
+        (0.0, 5.0),
+        (0.0, 6.0),
+        (1.0, 4.0),
+        (1.0, 5.0),
+        (1.0, 6.0),
+    ]
+    # ScanInfo carries both targets; its 1-D fields describe the outer axis.
+    info = kwargs["scan_info"]
+    assert info["scan_parameter"] == (
+        "U_ESP_JetXYZ:Position.Axis 3,U_ESP_JetXYZ:Position.Axis 1"
+    )
+    assert (info["start"], info["end"], info["step"]) == (0.0, 1.0, 1.0)
+    # Run metadata carries the axes and grid shape.
+    md = kwargs["md"]
+    assert md["scan_axes"] == ["jet_z", "jet_x"]
+    assert md["grid_shape"] == [2, 3]
+    assert md["num_grid_points"] == 6
+    assert md["scan_variable"] == "jet_z,jet_x"
+    # Both movables are disconnected with the scan's devices.
+    assert len(session.disconnected) == 5  # 3 detectors + 2 movables
 
 
-def test_valid_actions_are_validated_then_refused(legacy_resolver) -> None:
+def test_single_axis_request_shape_is_unchanged_by_grid_support(
+    legacy_resolver,
+) -> None:
+    """Regression: one axis still passes a bare motor + flat float positions."""
     session = _FakeSession()
-    request = _noscan_request(actions={"setup": ["close_shutters"]})
-    with pytest.raises(NotImplementedError, match="close_shutters"):
-        run_scan_request(session, request, legacy_resolver)
-    assert session.devices == []  # refused before any hardware was touched
+    request = _noscan_request(
+        mode="step",
+        axes=[{"variable": "jet_z", "positions": {"start": 0, "end": 1, "step": 0.5}}],
+    )
+    run_scan_request(session, request, legacy_resolver)
+    kwargs = session.scan_kwargs
+    assert not isinstance(kwargs["motor"], list)
+    assert kwargs["positions"] == [0.0, 0.5, 1.0]
+    assert "scan_axes" not in kwargs["md"]
+
+
+# ---------------------------------------------------------------------------
+# Action execution wiring (setup / per_step / closeout compiled + passed)
+# ---------------------------------------------------------------------------
+
+
+def test_actions_compile_into_session_scan_hooks(legacy_resolver) -> None:
+    session = _FakeSession()
+    request = _noscan_request(
+        actions={
+            "setup": ["scan_prep"],
+            "per_step": ["between_steps"],
+            "closeout": ["scan_cleanup"],
+        }
+    )
+    run_scan_request(session, request, legacy_resolver)
+
+    kwargs = session.scan_kwargs
+    # Each hook is a plan-stub callable yielding the compiled steps.
+    assert _set_targets(kwargs["setup"]()) == [("U_PLC-DO.Ch2", "on")]
+    assert _set_targets(kwargs["per_step"]()) == [("U_PLC-DO.Ch3", "on")]
+    assert _set_targets(kwargs["closeout"]()) == [("U_PLC-DO.Ch4", "off")]
+    # Reusable: per_step must produce a fresh generator per step boundary.
+    assert _set_targets(kwargs["per_step"]()) == [("U_PLC-DO.Ch3", "on")]
+    # Provenance: the assembled slot order lands in the run metadata.
+    assert kwargs["md"]["action_plans"] == {
+        "setup": ["scan_prep"],
+        "per_step": ["between_steps"],
+        "closeout": ["scan_cleanup"],
+    }
+    # Signals were prefetched (connected pre-claim) on the session's factory,
+    # and the factory rides the scan's device cleanup.
+    (factory,) = session.action_factories
+    assert set(factory.settables) == {
+        ("U_PLC", "DO.Ch2"),
+        ("U_PLC", "DO.Ch3"),
+        ("U_PLC", "DO.Ch4"),
+    }
+    assert factory in session.disconnected
+
+
+def test_request_without_actions_passes_no_hooks(legacy_resolver) -> None:
+    session = _FakeSession()
+    run_scan_request(session, _noscan_request(), legacy_resolver)
+    kwargs = session.scan_kwargs
+    assert kwargs["setup"] is None
+    assert kwargs["per_step"] is None
+    assert kwargs["closeout"] is None
+    assert session.action_factories == []  # no factory built for nothing
+    assert "action_plans" not in kwargs["md"]
 
 
 def test_unknown_action_name_fails_validation_first(legacy_resolver) -> None:
+    session = _FakeSession()
     request = _noscan_request(actions={"closeout": ["not_a_plan"]})
     with pytest.raises(GeecsConfigurationError, match="not_a_plan"):
-        run_scan_request(_FakeSession(), request, legacy_resolver)
+        run_scan_request(session, request, legacy_resolver)
+    assert session.devices == []  # failed before any hardware was touched
 
 
 def test_pseudo_variable_raises_not_implemented(modern_resolver) -> None:
@@ -603,12 +822,12 @@ def test_optimize_maps_onto_session_optimize(legacy_resolver) -> None:
 
 
 # ---------------------------------------------------------------------------
-# Multi-device trigger profiles: single-device fast path / engine-pending raise
+# Multi-device trigger profiles: ordered writes, single-device regression
 # ---------------------------------------------------------------------------
 
 
-def test_multi_device_shape_single_device_fast_path() -> None:
-    """Write lists that all name one device adapt exactly as before."""
+def test_single_device_profile_adapts_unchanged() -> None:
+    """Regression: one-device profiles carry the same writes as before."""
     profile = TriggerProfile(
         name="new-shape",
         states={
@@ -621,18 +840,18 @@ def test_multi_device_shape_single_device_fast_path() -> None:
             ],
         },
     )
-    config = shot_control_config_from_trigger_profile(profile)
-    assert config.device == "U_DG645"
-    assert config.values_for_state("SCAN") == {
-        "Trigger.Source": "Ext",
-        "Amplitude.Ch AB": "4.0",
-    }
-    assert config.values_for_state("STANDBY") == {"Amplitude.Ch AB": "0.5"}
-    assert not config.defines_state("OFF")
+    writes = trigger_writes_from_profile(profile)
+    assert writes.devices == ["U_DG645"]
+    assert writes.writes_for_state("SCAN") == [
+        ("U_DG645", "Trigger.Source", "Ext"),
+        ("U_DG645", "Amplitude.Ch AB", "4.0"),
+    ]
+    assert writes.writes_for_state("STANDBY") == [("U_DG645", "Amplitude.Ch AB", "0.5")]
+    assert not writes.defines_state("OFF")
 
 
-def test_multi_device_writes_are_engine_pending() -> None:
-    """Writes spanning devices are schema-legal but refused by the engine."""
+def test_multi_device_writes_preserve_declared_order() -> None:
+    """A transition spanning devices keeps the profile's write order."""
     profile = TriggerProfile(
         name="spans-devices",
         states={
@@ -640,18 +859,27 @@ def test_multi_device_writes_are_engine_pending() -> None:
                 {"device": "U_DG645", "variable": "Trigger.Source", "value": "Ext"},
                 {"device": "U_PLC", "variable": "DO.Ch9", "value": "on"},
             ],
+            "STANDBY": [
+                {"device": "U_PLC", "variable": "DO.Ch9", "value": "off"},
+                {"device": "U_DG645", "variable": "Trigger.Source", "value": "Int"},
+            ],
         },
     )
-    assert profile.devices == ["U_DG645", "U_PLC"]  # schema accepts it
-    with pytest.raises(
-        NotImplementedError,
-        match="multi-device trigger profiles land with a later milestone",
-    ):
-        shot_control_config_from_trigger_profile(profile)
+    writes = trigger_writes_from_profile(profile)
+    assert set(writes.devices) == {"U_DG645", "U_PLC"}
+    assert writes.writes_for_state("SCAN") == [
+        ("U_DG645", "Trigger.Source", "Ext"),
+        ("U_PLC", "DO.Ch9", "on"),
+    ]
+    # STANDBY declares the reverse device order — preserved verbatim.
+    assert writes.writes_for_state("STANDBY") == [
+        ("U_PLC", "DO.Ch9", "off"),
+        ("U_DG645", "Trigger.Source", "Int"),
+    ]
 
 
-def test_multi_device_span_via_variant_is_also_refused() -> None:
-    """A variant that drags in a second device trips the same refusal."""
+def test_multi_device_span_via_variant_adapts() -> None:
+    """A variant dragging in a second device lands in the writes."""
     profile = TriggerProfile(
         name="variant-spans",
         states={
@@ -669,16 +897,49 @@ def test_multi_device_span_via_variant_is_also_refused() -> None:
             }
         },
     )
-    # The base profile alone is single-device and adapts fine.
-    assert shot_control_config_from_trigger_profile(profile).device == "U_DG645"
-    with pytest.raises(NotImplementedError, match="multi-device"):
-        shot_control_config_from_trigger_profile(profile, "jet_on")
+    assert trigger_writes_from_profile(profile).devices == ["U_DG645"]
+    overlaid = trigger_writes_from_profile(profile, "jet_on")
+    assert overlaid.writes_for_state("SCAN") == [
+        ("U_DG645", "Trigger.Source", "Ext"),
+        ("U_Jet", "Pressure", "5"),
+    ]
+
+
+def test_multi_device_profile_runs_through_the_request(legacy_resolver) -> None:
+    """A request naming a multi-device profile executes with zero refusals."""
+    session = _FakeSession()
+    profile = TriggerProfile(
+        name="spans",
+        states={
+            "SCAN": [
+                {"device": "U_DG645", "variable": "Amplitude.Ch AB", "value": "4.0"},
+                {"device": "U_PLC", "variable": "DO.Ch9", "value": "on"},
+            ],
+        },
+    )
+
+    class _Resolver:
+        def resolve_save_set(self, name):
+            return legacy_resolver.resolve_save_set(name)
+
+        def resolve_trigger_profile(self, name):
+            return profile
+
+        def resolve_action_plan(self, name):
+            raise GeecsConfigurationError(name)
+
+        def resolve_scan_variable(self, name):
+            return legacy_resolver.resolve_scan_variable(name)
+
+    run_scan_request(session, _noscan_request(trigger_profile="spans"), _Resolver())
+    (writes,) = session.shot_control_calls
+    assert writes.devices == ["U_DG645", "U_PLC"]
 
 
 def test_profile_without_any_device_is_rejected() -> None:
     profile = TriggerProfile(name="empty", states={})
     with pytest.raises(GeecsConfigurationError, match="names no trigger device"):
-        shot_control_config_from_trigger_profile(profile)
+        trigger_writes_from_profile(profile)
 
 
 # ---------------------------------------------------------------------------
@@ -704,6 +965,47 @@ def test_apply_experiment_defaults_fills_unset_fields() -> None:
     # The original request is never mutated.
     assert request.trigger_profile is None
     assert request.actions.setup == []
+
+
+def test_apply_experiment_defaults_brackets_the_scans_own_plans() -> None:
+    """Mirrored merge: defaults prepend to setup, append to closeout."""
+    request = _noscan_request(
+        actions={"setup": ["scan_prep"], "closeout": ["scan_cleanup"]}
+    )
+    defaults = {"actions": {"setup": ["default_prep"], "closeout": ["default_cleanup"]}}
+    updated, applied = apply_experiment_defaults(request, defaults)
+    assert updated.actions.setup == ["default_prep", "scan_prep"]
+    assert updated.actions.closeout == ["scan_cleanup", "default_cleanup"]
+    assert applied == {
+        "actions.setup": ["default_prep"],
+        "actions.closeout": ["default_cleanup"],
+    }
+
+
+def test_assemble_action_slots_layers_nest_like_context_managers() -> None:
+    """setup: defaults → rituals → scan's own; closeout: exact reverse."""
+    request = _noscan_request(
+        actions={
+            "setup": ["scan_prep"],
+            "per_step": ["between_steps"],
+            "closeout": ["scan_cleanup"],
+        }
+    )
+    defaults = {"actions": {"setup": ["default_prep"], "closeout": ["default_cleanup"]}}
+    merged, applied = apply_experiment_defaults(request, defaults)
+    rituals = {"setup": ["cam_ritual"], "closeout": ["cam_park"]}
+    slots = assemble_action_slots(merged.actions, applied, rituals)
+    assert slots == {
+        "setup": ["default_prep", "cam_ritual", "scan_prep"],
+        "per_step": ["between_steps"],
+        "closeout": ["scan_cleanup", "cam_park", "default_cleanup"],
+    }
+
+
+def test_assemble_action_slots_without_defaults_or_rituals() -> None:
+    request = _noscan_request(actions={"setup": ["scan_prep"]})
+    slots = assemble_action_slots(request.actions, {}, {"setup": [], "closeout": []})
+    assert slots == {"setup": ["scan_prep"], "per_step": [], "closeout": []}
 
 
 def test_apply_experiment_defaults_none_is_a_noop() -> None:
@@ -739,29 +1041,44 @@ def test_run_applies_defaults_and_records_provenance(
     session = _FakeSession()
     run_scan_request(session, _noscan_request(), legacy_resolver)
 
-    (config,) = session.shot_control_calls
-    assert isinstance(config, ShotControlConfig)
-    assert config.device == "U_DG645_ShotControl"
+    (writes,) = session.shot_control_calls
+    assert isinstance(writes, ShotControlWrites)
+    assert writes.devices == ["U_DG645_ShotControl"]
     assert session.scan_kwargs["md"]["applied_defaults"] == {
         "trigger_profile": "HTU-Normal"
     }
 
 
-def test_default_actions_get_the_same_refusal_treatment(
+def test_default_actions_execute_bracketing_the_scans_own(
     configs_root, legacy_resolver
 ) -> None:
-    """Defaults-supplied actions are validated, then refused like explicit ones."""
+    """Defaults-supplied plans run first on setup and last on closeout."""
     (configs_root / "LegacyExp" / "experiment_defaults.yaml").write_text(
-        "actions:\n  setup: [close_shutters]\n"
+        "actions:\n  setup: [default_prep]\n  closeout: [default_cleanup]\n"
     )
     session = _FakeSession()
-    with pytest.raises(NotImplementedError, match="close_shutters"):
-        run_scan_request(session, _noscan_request(), legacy_resolver)
-    assert session.devices == []  # refused before any hardware
+    request = _noscan_request(
+        actions={"setup": ["scan_prep"], "closeout": ["scan_cleanup"]}
+    )
+    run_scan_request(session, request, legacy_resolver)
+
+    kwargs = session.scan_kwargs
+    assert _set_targets(kwargs["setup"]()) == [
+        ("U_PLC-DO.Ch1", "on"),  # default_prep first
+        ("U_PLC-DO.Ch2", "on"),  # then the scan's own
+    ]
+    assert _set_targets(kwargs["closeout"]()) == [
+        ("U_PLC-DO.Ch4", "off"),  # the scan's own first
+        ("U_PLC-DO.Ch5", "off"),  # defaults last (outermost bracket)
+    ]
+    assert kwargs["md"]["action_plans"] == {
+        "setup": ["default_prep", "scan_prep"],
+        "closeout": ["scan_cleanup", "default_cleanup"],
+    }
 
 
 # ---------------------------------------------------------------------------
-# SaveSet entry-level setup/closeout references (newer SaveSet schema)
+# SaveSet entry-level setup/closeout rituals (collected, de-duplicated, run)
 # ---------------------------------------------------------------------------
 
 
@@ -778,7 +1095,7 @@ class _SaveSetResolver:
     def resolve_action_plan(self, name):
         if name not in self._known:
             raise GeecsConfigurationError(f"action plan {name!r} not found")
-        return object()
+        return ActionPlan.model_validate({"steps": [{"do": "wait", "seconds": 1.0}]})
 
 
 def test_entry_level_actions_collected() -> None:
@@ -792,9 +1109,26 @@ def test_entry_level_actions_collected() -> None:
         ],
     )
     assert collect_save_set_action_names(save_set) == ["prep_cam", "park"]
+    assert collect_save_set_rituals(save_set) == {
+        "setup": ["prep_cam"],
+        "closeout": ["park"],
+    }
     # Entries without references contribute nothing.
     plain = SaveSet(name="s", entries=[SaveSetEntry(device="U_A", scalars=["x"])])
     assert collect_save_set_action_names(plain) == []
+    assert collect_save_set_rituals(plain) == {"setup": [], "closeout": []}
+
+
+def test_entry_rituals_deduplicate_across_entries() -> None:
+    """Two entries naming the same ritual run it once (schema contract)."""
+    save_set = SaveSet(
+        name="s",
+        entries=[
+            SaveSetEntry(device="U_A", scalars=["x"], setup=["prep", "align"]),
+            SaveSetEntry(device="U_B", scalars=["y"], setup=["prep"]),
+        ],
+    )
+    assert collect_save_set_rituals(save_set)["setup"] == ["prep", "align"]
 
 
 def _entry_action_save_set(**entry_overrides) -> SaveSet:
@@ -803,30 +1137,177 @@ def _entry_action_save_set(**entry_overrides) -> SaveSet:
     return SaveSet.model_validate({"name": "s", "entries": [entry]})
 
 
-def test_entry_level_actions_validated_then_refused() -> None:
+def test_resolve_save_set_and_rituals_validates_names() -> None:
     resolver = _SaveSetResolver(_entry_action_save_set(setup=["prep_cam"]))
-    with pytest.raises(NotImplementedError, match="prep_cam"):
-        resolve_save_set_checked(resolver, "s")
+    save_set, rituals = resolve_save_set_and_rituals(resolver, "s")
+    assert rituals == {"setup": ["prep_cam"], "closeout": []}
 
 
 def test_entry_level_unknown_action_fails_validation_first() -> None:
     resolver = _SaveSetResolver(_entry_action_save_set(setup=["nope"]))
     with pytest.raises(GeecsConfigurationError, match="nope"):
+        resolve_save_set_and_rituals(resolver, "s")
+
+
+def test_bridge_path_still_refuses_entry_rituals() -> None:
+    """resolve_save_set_checked (GUI-bridge helper) refuses with a pointer."""
+    resolver = _SaveSetResolver(_entry_action_save_set(setup=["prep_cam"]))
+    with pytest.raises(NotImplementedError, match="GeecsSession.run"):
         resolve_save_set_checked(resolver, "s")
 
 
-def test_converted_element_actions_resolve_and_are_refused(legacy_resolver) -> None:
-    """A legacy element with setup_action converts to entry refs that
-    validate against the extracted plans and then get the M3b refusal."""
-    with pytest.raises(NotImplementedError, match="UC_WithActions_setup"):
-        resolve_save_set_checked(legacy_resolver, "UC_WithActions")
-
-
-def test_run_refuses_save_set_with_converted_element_actions(
+def test_entry_rituals_execute_between_defaults_and_request(
     legacy_resolver,
 ) -> None:
+    """Rituals from RitualSet land between defaults and the request's own
+    plans on setup, and mirrored on closeout — with the shared ritual
+    de-duplicated (both entries name cam_ritual; it runs once)."""
+    session = _FakeSession()
+    request = _noscan_request(
+        save_set="RitualSet",
+        actions={"setup": ["scan_prep"], "closeout": ["scan_cleanup"]},
+    )
+    run_scan_request(session, request, legacy_resolver)
+
+    kwargs = session.scan_kwargs
+    assert kwargs["md"]["action_plans"] == {
+        "setup": ["cam_ritual", "scan_prep"],
+        "closeout": ["scan_cleanup", "cam_park"],
+    }
+    assert _set_targets(kwargs["setup"]()) == [
+        ("U_Cam-Analysis", "on"),  # the entries' ritual, once
+        ("U_PLC-DO.Ch2", "on"),  # then the scan's own setup
+    ]
+    assert _set_targets(kwargs["closeout"]()) == [
+        ("U_PLC-DO.Ch4", "off"),  # the scan's own closeout first
+        ("U_Cam-Analysis", "off"),  # then the entries' ritual
+    ]
+
+
+def test_converted_element_actions_execute(legacy_resolver) -> None:
+    """A legacy element's setup_action converts to an entry ritual that the
+    runner compiles and executes (the extracted plan resolves by name)."""
     session = _FakeSession()
     request = _noscan_request(save_set="UC_WithActions")
-    with pytest.raises(NotImplementedError, match="UC_WithActions_setup"):
+    run_scan_request(session, request, legacy_resolver)
+
+    kwargs = session.scan_kwargs
+    assert kwargs["md"]["action_plans"]["setup"] == ["UC_WithActions_setup"]
+    assert _set_targets(kwargs["setup"]()) == [("U_PLC-DO.Ch1", "on")]
+    assert kwargs["closeout"] is None
+
+
+# ---------------------------------------------------------------------------
+# End to end: axes + actions + multi-device profile, zero NotImplementedError
+# ---------------------------------------------------------------------------
+
+MULTI_DEVICE_PROFILE = """\
+schema_version: 1
+name: spans
+states:
+  SCAN:
+    - {device: U_DG645, variable: Amplitude.Ch AB, value: "4.0"}
+    - {device: U_PLC, variable: DO.Ch7, value: "on"}
+  STANDBY:
+    - {device: U_PLC, variable: DO.Ch7, value: "off"}
+    - {device: U_DG645, variable: Amplitude.Ch AB, value: "0.5"}
+"""
+
+
+def test_full_fake_session_flow_axes_actions_multi_device_trigger(
+    configs_root, legacy_resolver
+) -> None:
+    """The M3b acceptance flow: a ScanRequest carrying a 2-axis grid, all
+    three action slots, entry rituals, experiment defaults, and a
+    multi-device trigger profile drives the whole fake-session flow with
+    zero NotImplementedErrors."""
+    (
+        configs_root / "LegacyExp" / "shot_control_configurations" / "Spans.yaml"
+    ).write_text(MULTI_DEVICE_PROFILE)
+    (configs_root / "LegacyExp" / "experiment_defaults.yaml").write_text(
+        "actions:\n  setup: [default_prep]\n  closeout: [default_cleanup]\n"
+    )
+    session = _FakeSession()
+    request = ScanRequest.model_validate(
+        {
+            "mode": "step",
+            "shots_per_step": 2,
+            "acquisition": "free_run",
+            "save_set": "RitualSet",
+            "trigger_profile": "Spans",
+            "axes": [
+                {"variable": "jet_z", "positions": {"start": 0, "end": 1, "step": 1}},
+                {"variable": "jet_x", "positions": {"values": [4.0, 5.0]}},
+            ],
+            "actions": {
+                "setup": ["scan_prep"],
+                "per_step": ["between_steps"],
+                "closeout": ["scan_cleanup"],
+            },
+            "description": "m3b acceptance",
+        }
+    )
+
+    uid = run_scan_request(session, request, legacy_resolver)
+
+    assert uid == "uid-scan"
+    # Multi-device trigger attached as ordered writes.
+    (writes,) = session.shot_control_calls
+    assert isinstance(writes, ShotControlWrites)
+    assert set(writes.devices) == {"U_DG645", "U_PLC"}
+    assert writes.writes_for_state("STANDBY") == [
+        ("U_PLC", "DO.Ch7", "off"),
+        ("U_DG645", "Amplitude.Ch AB", "0.5"),
+    ]
+    kwargs = session.scan_kwargs
+    # 2-axis grid: 2 × 2 grid points, tuples, both movables.
+    assert len(kwargs["positions"]) == 4
+    assert kwargs["md"]["grid_shape"] == [2, 2]
+    assert [m.kind for m in kwargs["motor"]] == ["settable", "settable"]
+    # All four layers assembled in nesting order (defaults outermost).
+    assert kwargs["md"]["action_plans"] == {
+        "setup": ["default_prep", "cam_ritual", "scan_prep"],
+        "per_step": ["between_steps"],
+        "closeout": ["scan_cleanup", "cam_park", "default_cleanup"],
+    }
+    assert _set_targets(kwargs["setup"]()) == [
+        ("U_PLC-DO.Ch1", "on"),
+        ("U_Cam-Analysis", "on"),
+        ("U_PLC-DO.Ch2", "on"),
+    ]
+    assert _set_targets(kwargs["closeout"]()) == [
+        ("U_PLC-DO.Ch4", "off"),
+        ("U_Cam-Analysis", "off"),
+        ("U_PLC-DO.Ch5", "off"),
+    ]
+    # Provenance of the applied defaults.
+    assert kwargs["md"]["applied_defaults"] == {
+        "actions.setup": ["default_prep"],
+        "actions.closeout": ["default_cleanup"],
+    }
+    # Cleanup: detectors + 2 movables + the action signal factory.
+    (factory,) = session.action_factories
+    assert factory in session.disconnected
+
+
+def test_optimize_with_actions_is_a_documented_gap(legacy_resolver) -> None:
+    """Optimize mode has no action hooks yet — refused loudly, pre-hardware."""
+    session = _FakeSession()
+    request = _optimize_request(actions={"setup": ["scan_prep"]})
+    with pytest.raises(NotImplementedError, match="scan_prep"):
         run_scan_request(session, request, legacy_resolver)
-    assert session.devices == []  # refused before any hardware
+    assert session.devices == []
+
+
+def test_optimize_with_entry_rituals_is_a_documented_gap(legacy_resolver) -> None:
+    session = _FakeSession()
+    request = _optimize_request(save_set="RitualSet")
+
+    def objective(bin_data) -> float:
+        return 1.0
+
+    with pytest.raises(NotImplementedError, match="cam_ritual"):
+        run_scan_request(
+            session, request, legacy_resolver, objective=objective, suggester=object()
+        )
+    assert session.devices == []

--- a/GeecsBluesky/tests/test_session.py
+++ b/GeecsBluesky/tests/test_session.py
@@ -104,6 +104,66 @@ def test_shot_control_attaches_ca_controller() -> None:
     assert s.shot_control(None) is None  # detaches
 
 
+def test_shot_control_accepts_generalized_writes() -> None:
+    """ShotControlWrites (multi-device ordered) builds the ordered controller."""
+    from geecs_bluesky.models.shot_control import ShotControlWrites
+
+    s = _session()
+    writes = ShotControlWrites(
+        name="spans",
+        states={
+            "SCAN": [
+                ("U_DG645_ShotControl", "Amplitude.Ch AB", "4.0"),
+                ("U_PLC", "DO.Ch9", "on"),
+            ]
+        },
+    )
+    controller = s.shot_control(writes)
+    assert isinstance(controller, ShotController)
+    assert controller.defines_state("SCAN")
+    # One CA setter per (device, variable), on each device's own :SP PV.
+    setters = controller._setters
+    assert {
+        setters[("U_DG645_ShotControl", "Amplitude.Ch AB")]._pv,
+        setters[("U_PLC", "DO.Ch9")]._pv,
+    } == {
+        "Undulator:U_DG645_ShotControl:Amplitude_Ch_AB:SP",
+        "Undulator:U_PLC:DO_Ch9:SP",
+    }
+    # Empty writes detach, like an empty legacy config.
+    assert s.shot_control(ShotControlWrites(name="empty", states={})) is None
+
+
+def test_action_signal_factory_builds_cached_connected_signals() -> None:
+    """The production SettableFactory: :SP settables, str readbacks, caching."""
+    import asyncio
+
+    s = _session()
+    factory = s.action_signal_factory()
+    settable = factory.get_settable("U_PLC", "DO.Ch9")
+    assert settable._signal.source.endswith("Undulator:U_PLC:DO_Ch9:SP")
+    # Cached per (device, variable): the same wrapper comes back.
+    assert factory.get_settable("U_PLC", "DO.Ch9") is settable
+    readable = factory.get_readable("U_PLC", "DI.Ch17")
+    assert readable.source.endswith("Undulator:U_PLC:DI_Ch17")
+    assert factory.get_readable("U_PLC", "DI.Ch17") is readable
+
+    # Values are coerced to wire strings on set (mock backend records it).
+    # set() is awaited inside the RE loop, as the RunEngine would.
+    async def _set_and_read() -> str:
+        await settable.set(4.0)
+        return await settable._signal.get_value()
+
+    value = asyncio.run_coroutine_threadsafe(_set_and_read(), s.RE._loop).result(
+        timeout=5.0
+    )
+    assert value == "4.0"
+
+    # The factory rides the scan cleanup path uniformly.
+    s.disconnect(factory)
+    assert factory._settables == {}
+
+
 def test_scan_validation() -> None:
     """Bad requests fail loudly before touching any hardware."""
     s = _session()

--- a/GeecsBluesky/tests/test_shot_controller_writes.py
+++ b/GeecsBluesky/tests/test_shot_controller_writes.py
@@ -1,0 +1,169 @@
+"""Generalized ShotController tests (from_writes) — no CA needed, CI-safe.
+
+Pins the ordered multi-device transition semantics
+(:class:`~geecs_bluesky.models.shot_control.ShotControlWrites` +
+``ShotController.from_writes``): writes replayed strictly in the profile's
+declared order, each completing before the next; setters cached per
+(device, variable); strict-mode validation; and the single-device
+regression (one-device profiles land the same values per state as the
+legacy controller).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from bluesky import RunEngine
+from ophyd_async.core import AsyncStatus
+
+from geecs_bluesky.models.shot_control import ShotControlWrites
+from geecs_bluesky.shot_controller import ShotController
+
+
+class _OrderRecordingSetter:
+    """Mock setter that appends (name, value) to a shared journal on set()."""
+
+    def __init__(self, name: str, journal: list) -> None:
+        self.name = name
+        self._journal = journal
+
+    def set(self, value: Any) -> AsyncStatus:
+        self._journal.append((self.name, value))
+
+        async def _noop() -> None:
+            pass
+
+        return AsyncStatus(_noop())
+
+
+MULTI_DEVICE_WRITES = ShotControlWrites(
+    name="spans",
+    states={
+        "SCAN": [
+            ("U_DG645", "Amplitude.Ch AB", "4.0"),
+            ("U_PLC", "DO.Ch9", "on"),
+        ],
+        "STANDBY": [
+            ("U_PLC", "DO.Ch9", "off"),
+            ("U_DG645", "Amplitude.Ch AB", "0.5"),
+        ],
+        "ARMED": [("U_DG645", "Trigger.Source", "Single shot")],
+        "SINGLESHOT": [("U_DG645", "Trigger.ExecuteSingleShot", "on")],
+    },
+)
+
+
+def _writes_controller(
+    writes: ShotControlWrites,
+) -> tuple[RunEngine, ShotController, list]:
+    journal: list = []
+    controller = ShotController.from_writes(
+        writes,
+        setter_factory=lambda device, variable: _OrderRecordingSetter(
+            f"{device}:{variable}", journal
+        ),
+    )
+    return RunEngine(), controller, journal
+
+
+class TestGeneralizedShotController:
+    def test_multi_device_transition_preserves_declared_order(self) -> None:
+        """SCAN writes both devices, in the profile's top-to-bottom order."""
+        re, controller, journal = _writes_controller(MULTI_DEVICE_WRITES)
+        re(controller.arm())  # SCAN
+        assert journal == [
+            ("U_DG645:Amplitude.Ch AB", "4.0"),
+            ("U_PLC:DO.Ch9", "on"),
+        ]
+
+    def test_reverse_declared_order_is_respected_per_state(self) -> None:
+        """STANDBY declares the devices in the opposite order — kept."""
+        re, controller, journal = _writes_controller(MULTI_DEVICE_WRITES)
+        re(controller.disarm())  # STANDBY
+        assert journal == [
+            ("U_PLC:DO.Ch9", "off"),
+            ("U_DG645:Amplitude.Ch AB", "0.5"),
+        ]
+
+    def test_writes_are_sequential_each_completing_before_the_next(self) -> None:
+        """Message-level: every set is followed by a wait on its own group."""
+        commands = []
+        plan = ShotController.from_writes(
+            MULTI_DEVICE_WRITES,
+            setter_factory=lambda d, v: _OrderRecordingSetter(f"{d}:{v}", []),
+        ).set_state("SCAN")
+        try:
+            msg = plan.send(None)
+            while True:
+                commands.append((msg.command, msg.kwargs.get("group")))
+                msg = plan.send(None)
+        except StopIteration:
+            pass
+        assert [c for c, _ in commands] == ["set", "wait", "set", "wait"]
+        # Each wait targets the group of the set immediately before it.
+        assert commands[0][1] == commands[1][1]
+        assert commands[2][1] == commands[3][1]
+        assert commands[0][1] != commands[2][1]
+
+    def test_state_without_writes_is_a_noop(self) -> None:
+        re, controller, journal = _writes_controller(MULTI_DEVICE_WRITES)
+        re(controller.quiesce())  # OFF: not declared
+        assert journal == []
+
+    def test_setters_cached_per_device_variable(self) -> None:
+        created: list[str] = []
+
+        def factory(device: str, variable: str) -> _OrderRecordingSetter:
+            created.append(f"{device}:{variable}")
+            return _OrderRecordingSetter(f"{device}:{variable}", [])
+
+        ShotController.from_writes(MULTI_DEVICE_WRITES, setter_factory=factory)
+        # DO.Ch9 and Amplitude.Ch AB each appear in two states but get ONE setter.
+        assert sorted(created) == sorted(
+            [
+                "U_DG645:Amplitude.Ch AB",
+                "U_PLC:DO.Ch9",
+                "U_DG645:Trigger.Source",
+                "U_DG645:Trigger.ExecuteSingleShot",
+            ]
+        )
+
+    def test_require_strict_single_shot_on_writes(self) -> None:
+        _re, controller, _journal = _writes_controller(MULTI_DEVICE_WRITES)
+        controller.require_strict_single_shot()  # ARMED + SINGLESHOT present
+        no_armed = ShotControlWrites(
+            name="incomplete", states={"SCAN": [("U_DG645", "A", "1")]}
+        )
+        with pytest.raises(Exception, match="ARMED"):
+            ShotController.from_writes(
+                no_armed,
+                setter_factory=lambda d, v: _OrderRecordingSetter(d, []),
+            ).require_strict_single_shot()
+
+    def test_single_device_writes_behave_like_the_legacy_controller(self) -> None:
+        """Regression: a one-device profile lands the same values per state."""
+        single = ShotControlWrites(
+            name="htu",
+            states={
+                "SCAN": [
+                    ("U_DG645_ShotControl", "Trigger.Source", "External rising edges")
+                ],
+                "OFF": [
+                    (
+                        "U_DG645_ShotControl",
+                        "Trigger.Source",
+                        "Single shot external rising edges",
+                    )
+                ],
+            },
+        )
+        re, controller, journal = _writes_controller(single)
+        re(controller.arm())
+        re(controller.quiesce())
+        assert journal == [
+            ("U_DG645_ShotControl:Trigger.Source", "External rising edges"),
+            ("U_DG645_ShotControl:Trigger.Source", "Single shot external rising edges"),
+        ]
+        assert controller.defines_state("SCAN")
+        assert not controller.defines_state("STANDBY")

--- a/docs/geecs_schemas/schemas_overview.md
+++ b/docs/geecs_schemas/schemas_overview.md
@@ -156,9 +156,17 @@ pieces: it connects the save set's devices, puts the trigger device under
 the profile's control, creates the scan variable's mover, and hands
 everything to the scan plan, which sweeps the positions (or just collects
 shots, or lets the optimizer steer) and records the data with the same run
-discipline as any other scan. Anything the engine can't execute yet — a
-multi-axis grid, attached action plans — is refused up front with a clear
-"not yet" message rather than attempted halfway.
+discipline as any other scan. Action plans run at their slots automatically:
+setup plans (the experiment's defaults first, then each required device's
+ritual, then the scan's own) run once before the first step, per-step plans
+run at every position right after the move and before the shots, and
+closeout plans run once at the end — in the reverse order, and even if the
+scan was aborted partway. If the request lists several axes, the scan
+visits every combination as a grid — the first axis is the slow outer loop —
+taking the usual batch of shots at each grid point and recording every
+axis's position in every data row. Anything the engine can't execute yet —
+a pseudo (composite) scan variable, for example — is refused up front with
+a clear "not yet" message rather than attempted halfway.
 
 ## Two habits worth knowing
 


### PR DESCRIPTION
Third engine milestone on the `feat/vision-v1` integration branch (stack: #460 M1 schemas → #463/#464 M2+M3a → this). Closes every documented v1 engine-pending seam in the ScanRequest runner — after this, a ScanRequest with actions, a multi-axis grid, and a multi-device trigger profile executes end-to-end.

## What executes now (was `NotImplementedError`)

- **Actions in scans** — request-level `setup` / `per_step` / `closeout`, SaveSet entry rituals, and ExperimentDefaults, compiled via the M3a action compiler and placed:
  - `setup`: inside the run wrapper, before quiesce/t0-sync and the first step — a failing setup still fires the full finalize chain
  - `per_step`: at every step boundary, after the move, before shots — always with the trigger disarmed (free-run) / quiescent (strict)
  - `closeout`: outermost `finalize_wrapper` — runs even on mid-scan abort (legacy ActionControl parity), always after trigger disarm
- **Multi-axis grids** — outer product, first axis slowest; only changed axes re-move (concurrently); every axis readback lands in every event row; `scan_axes`/`grid_shape` in run metadata
- **Multi-device trigger profiles** — new `ShotControlWrites` (per-state ordered `(device, variable, value)` writes, replayed sequentially in declared order); the legacy single-device `ShotControlConfig` path is byte-identical and untouched
- **Production action-signal factory** — `CaActionSignalFactory`: str-typed `:SP` signals with wire-string coercion, prefetched on the RE loop pre-claim so unreachable action targets fail fast before a scan number is claimed

## One design decision that changes a schema (flagging for review)

Closeout ordering is now **mirrored/LIFO** — setup runs defaults → entry rituals → request; closeout runs request → entries → defaults, nesting like context managers. This changed the `ExperimentDefaults` closeout merge rule from *prepend* to *append* → **GEECS-Schemas 0.2.0** with changelog rationale.

## Deliberately still refused (loudly, documented)

Pseudo scan variables, `all_scalars`, optimize without an injected objective/suggester, actions/rituals on optimize-mode requests (`GeecsSession.optimize` has no hooks yet), GUI-bridge staging of actions/multi-axis (points to `GeecsSession.run`; GUI submission is a later milestone).

## Tests

~150 new hermetic tests across runner slot-assembly/dedup/ordering, message-level grid plans, RE-level composition (setup→per-step→closeout incl. abort paths), ordered multi-device transitions, and the zero-refusal end-to-end fake-session flow. Plus `tests/test_scan_request_hardware.py` (integration-marked, CI-deselected, `GEECS_HW_*` env knobs) — the standing Gate-2 hardware script.

Suites: GeecsBluesky **245 passed / 12 skipped** (package env, CI parity) and **350 passed** (root env); GEECS-Schemas **196**; GEECS-Scanner-GUI **207**. Versions: GeecsBluesky 0.23.0 (changelog also folds in the deferred M3a entry), GEECS-Schemas 0.2.0.

Gate-1 context: this branch's base already passed live hardware smoke (Scan013 = first ScanRequest-driven scan; first live compiled ActionPlan cycled the Amp4 dump). Gate-2 = running the new hardware test with actions-in-scan on metal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)