### PR TITLE
Add CA alarm limit overlay

### DIFF
--- a/GeecsCAGateway/CHANGELOG.md
+++ b/GeecsCAGateway/CHANGELOG.md
@@ -3,6 +3,27 @@
 All notable changes to `geecs-ca-gateway` are documented here, following
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and semantic versioning.
 
+## [0.7.0] - 2026-07-08
+
+### Added
+
+- **Optional `ca_alarm_limits` MySQL overlay for curated scalar value alarms.**
+  Enabled rows are keyed by `(experiment, device, variable)` and provide
+  `LOLO` / `LOW` / `HIGH` / `HIHI` thresholds with configured severities.
+  The table is optional during rollout: if it is absent or unreadable, the
+  gateway starts with no value alarms.  Rows attach only to served numeric
+  readbacks; DB `min` / `max` remain display metadata and are never treated as
+  alarm limits.
+- `deploy/ca_alarm_limits.sql`, a non-destructive DDL snippet for creating the
+  optional alarm-limit table. Dropping the table restores pre-0.7 behavior.
+
+### Changed
+
+- Live numeric readback writes now recompute curated value-alarm severity.
+  Device disconnects still take precedence: stale readbacks remain
+  `INVALID/COMM` until the next live frame, which then reports either
+  `NO_ALARM` or the active value alarm.
+
 ## [0.6.0] - 2026-07-07
 
 ### Added

--- a/GeecsCAGateway/PV_CONTRACT.md
+++ b/GeecsCAGateway/PV_CONTRACT.md
@@ -308,20 +308,26 @@ What severity means **today**:
 
 | Condition | PV | Severity / status |
 |---|---|---|
-| Device TCP subscription live | readbacks | `NO_ALARM` (plain value writes reset severity) |
+| Device TCP subscription live, no configured value alarm active | readbacks | `NO_ALARM` |
+| Device TCP subscription live, configured scalar limit crossed | that numeric readback | configured severity (`MINOR_ALARM`, `MAJOR_ALARM`, or `INVALID_ALARM`) with status `LOW`, `LOLO`, `HIGH`, or `HIHI` |
 | Device TCP subscription dropped / unreachable | all of that device's **readback** PVs | **`INVALID_ALARM`**, status `COMM` — data is stale, last value retained |
 | Same event | that device's `CONNECTED` PV | value `Disconnected`, **`MAJOR_ALARM`**, status `COMM` |
-| Recovery (first live frame / reconnect) | both | automatic return to `NO_ALARM` |
+| Recovery (first live frame / reconnect) | both | automatic return to live-value severity (`NO_ALARM` unless a configured value alarm is active) |
 
 So: **INVALID on a readback means "not live", not "bad value"** — the held
 value is the last known good one. `CONNECTED` is the explicit liveness signal
 for Phoebus/alarm layers; prefer it over inferring liveness from data severity.
 
+Value-based alarms are an explicit curated overlay from the optional
+`ca_alarm_limits` MySQL table, keyed by `(experiment, device, variable)`.
+Only non-null threshold columns apply. The gateway validates rows at startup,
+attaches them only to served numeric readbacks, and treats the table as optional:
+if it is absent during rollout, the IOC starts with no value alarms. DB `min` /
+`max` remain display metadata and are **never** interpreted as alarm limits.
+
 **Not yet implemented** (be honest with your displays):
 
-- No value-based alarms: DB min/max are display limits only; there are no
-  HIHI/HIGH/LOW/LOLO thresholds, so a readback never goes `MINOR`/`MAJOR` on
-  value. A NaN or out-of-range value arrives as a plain `NO_ALARM` update.
+- No enum/string bad-state alarms yet; v1 value alarms are scalar limits only.
 - No archive deadbands (MDEL/ADEL split) — planned with the Archiver Appliance
   (DESIGN.md "Honest gaps").
 - A device merely going *quiet* raises no alarm and does not age severity —
@@ -444,6 +450,8 @@ that branch and are part of this contract's target behavior.
 | Zero deadband: every change posts, exact repeats suppressed | `test_pv_contract.py::test_zero_deadband_posts_changes_suppresses_exact_repeats` |
 | Explicit non-zero deadband suppression | `test_gateway.py::test_deadband_suppresses_small_changes` |
 | Display (not control) limits; NaN readback reported | `test_config_from_db.py::test_pvdb_built_from_db_spec_has_limits`; `test_gateway.py::test_nan_readback_accepted_despite_limits` |
+| Optional `ca_alarm_limits` table; curated scalar alarms attach only to served numeric readbacks | `test_geecs_db.py::test_get_ca_alarm_limits_returns_validated_rows`, `::test_get_ca_alarm_limits_missing_table_is_fail_open`; `test_config_from_db.py::test_alarm_limits_validate_order_and_presence`, `::test_from_geecs_experiment_attaches_numeric_alarm_limits` |
+| Value alarm severity/status on live readbacks; disconnect INVALID wins until next live frame | `test_gateway.py::test_value_alarm_limits_set_live_readback_severity`, `::test_invalid_liveness_overrides_value_alarm_until_live_frame` |
 | INVALID on drop, auto-recovery; CONNECTED MAJOR while down | `test_gateway.py::test_reconnect_and_validity`, `::test_set_connected_updates_pv_severity_and_count` |
 | Per-device bind-failure tolerance; clean caput error afterward | `test_gateway.py::test_one_device_bind_failure_does_not_abort_startup`, `::test_setpoint_write_without_udp_client_raises_cleanly` |
 | UDP reply correlation, echo form, malformed/stale discard | `test_udp_reply_correlation.py` (whole module) |

--- a/GeecsCAGateway/PV_CONTRACT.md
+++ b/GeecsCAGateway/PV_CONTRACT.md
@@ -324,6 +324,9 @@ Only non-null threshold columns apply. The gateway validates rows at startup,
 attaches them only to served numeric readbacks, and treats the table as optional:
 if it is absent during rollout, the IOC starts with no value alarms. DB `min` /
 `max` remain display metadata and are **never** interpreted as alarm limits.
+Curated alarm thresholds are evaluated only by the gateway overlay; they are not
+exported as native DBR_CTRL alarm/warning limit metadata, because caproto would
+otherwise run a second independent limit evaluator on every write.
 
 **Not yet implemented** (be honest with your displays):
 

--- a/GeecsCAGateway/deploy/README.md
+++ b/GeecsCAGateway/deploy/README.md
@@ -62,6 +62,23 @@ service, which rebuilds its config from the DB):
 caproto-put Undulator:CAGateway:RESTART Restart
 ```
 
+## CA alarm limits table
+
+The curated alarm overlay lives in the existing GEECS MySQL database as
+`ca_alarm_limits`. Apply the migration once per database before entering alarm
+rows:
+
+```bash
+cd ~/GEECS-Plugins/GeecsCAGateway
+mysql --host=<db-host> --user=<db-user> --password <db-name> \
+  < deploy/ca_alarm_limits.sql
+```
+
+The table is optional from the gateway's perspective: if it is absent, startup
+continues with no curated value alarms. After editing rows in `ca_alarm_limits`,
+restart through the service or `Undulator:CAGateway:RESTART` so the gateway
+reloads the DB-backed config.
+
 ## Changing what is served
 
 Edit `ExecStart` in the unit (`--all-variables`, `--no-settable`,

--- a/GeecsCAGateway/deploy/README.md
+++ b/GeecsCAGateway/deploy/README.md
@@ -79,6 +79,19 @@ continues with no curated value alarms. After editing rows in `ca_alarm_limits`,
 restart through the service or `Undulator:CAGateway:RESTART` so the gateway
 reloads the DB-backed config.
 
+To smoke-test one configured row, drive the readback into one of its alarm
+bands and read the PV with status metadata:
+
+```bash
+caproto-get -a Undulator:U_S1H:Current
+```
+
+For example, with `high=2.5`, `hihi=4.5`, and the default high severity of
+`MINOR`, a live `U_S1H:Current` value of `3 A` should report `HIGH` /
+`MINOR_ALARM` in CA clients such as Phoebus. If you edit the DB row and do not
+see the metadata or severity change, restart the gateway so it reloads the
+DB-backed config.
+
 ## Changing what is served
 
 Edit `ExecStart` in the unit (`--all-variables`, `--no-settable`,

--- a/GeecsCAGateway/deploy/ca_alarm_limits.sql
+++ b/GeecsCAGateway/deploy/ca_alarm_limits.sql
@@ -1,0 +1,40 @@
+-- Migration: add optional curated value-alarm limits to the existing GEECS
+-- MySQL database used by GeecsCAGateway.
+--
+-- Rollout is non-destructive for gateway startup: the gateway treats this table
+-- as optional and starts with no value alarms when it is absent.  To remove the
+-- overlay after testing:
+--
+--   DROP TABLE ca_alarm_limits;
+--
+-- Apply from a host with access to the GEECS DB, for example:
+--
+--   mysql --host=<db-host> --user=<db-user> --password <db-name> \
+--     < deploy/ca_alarm_limits.sql
+
+CREATE TABLE IF NOT EXISTS ca_alarm_limits (
+  experiment VARCHAR(128) NOT NULL,
+  device VARCHAR(128) NOT NULL,
+  `variable` VARCHAR(128) NOT NULL,
+
+  lolo DOUBLE NULL,
+  low DOUBLE NULL,
+  high DOUBLE NULL,
+  hihi DOUBLE NULL,
+
+  lolo_severity ENUM('MINOR', 'MAJOR', 'INVALID') NOT NULL DEFAULT 'MAJOR',
+  low_severity  ENUM('MINOR', 'MAJOR', 'INVALID') NOT NULL DEFAULT 'MINOR',
+  high_severity ENUM('MINOR', 'MAJOR', 'INVALID') NOT NULL DEFAULT 'MINOR',
+  hihi_severity ENUM('MINOR', 'MAJOR', 'INVALID') NOT NULL DEFAULT 'MAJOR',
+
+  hysteresis DOUBLE NULL,
+  enabled BOOLEAN NOT NULL DEFAULT TRUE,
+  description TEXT NULL,
+
+  updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+    ON UPDATE CURRENT_TIMESTAMP,
+
+  PRIMARY KEY (experiment, device, `variable`),
+  CONSTRAINT fk_ca_alarm_limits_device
+    FOREIGN KEY (device) REFERENCES device(name)
+);

--- a/GeecsCAGateway/deploy/ca_alarm_limits.sql
+++ b/GeecsCAGateway/deploy/ca_alarm_limits.sql
@@ -34,7 +34,5 @@ CREATE TABLE IF NOT EXISTS ca_alarm_limits (
   updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
     ON UPDATE CURRENT_TIMESTAMP,
 
-  PRIMARY KEY (experiment, device, `variable`),
-  CONSTRAINT fk_ca_alarm_limits_device
-    FOREIGN KEY (device) REFERENCES device(name)
+  PRIMARY KEY (experiment, device, `variable`)
 );

--- a/GeecsCAGateway/geecs_ca_gateway/alarms.py
+++ b/GeecsCAGateway/geecs_ca_gateway/alarms.py
@@ -1,0 +1,145 @@
+"""Alarm-limit policy for gateway readback PVs.
+
+The GEECS database's existing ``min``/``max`` metadata is not alarm policy:
+those fields are command/display metadata and are often meaningless for
+read-only variables.  This module models the optional ``ca_alarm_limits`` table,
+which is an explicit, curated overlay for value-based CA alarms.
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+
+class AlarmSeverityName(str, Enum):
+    """EPICS alarm severities supported by the curated limit overlay."""
+
+    MINOR = "MINOR"
+    MAJOR = "MAJOR"
+    INVALID = "INVALID"
+
+
+class AlarmLevel(str, Enum):
+    """Named scalar alarm thresholds in EPICS limit-alarm order."""
+
+    LOLO = "LOLO"
+    LOW = "LOW"
+    HIGH = "HIGH"
+    HIHI = "HIHI"
+
+
+class AlarmEvaluation(BaseModel):
+    """Result of evaluating one value against an alarm limit policy."""
+
+    model_config = ConfigDict(frozen=True)
+
+    level: AlarmLevel
+    severity: AlarmSeverityName
+
+
+class AlarmLimits(BaseModel):
+    """Curated scalar alarm thresholds for one gateway readback PV.
+
+    ``None`` means that threshold is not configured.  Hysteresis, when set,
+    delays clearing an already-active threshold until the value has moved back
+    inside the limit by at least that amount.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    lolo: float | None = None
+    low: float | None = None
+    high: float | None = None
+    hihi: float | None = None
+    lolo_severity: AlarmSeverityName = AlarmSeverityName.MAJOR
+    low_severity: AlarmSeverityName = AlarmSeverityName.MINOR
+    high_severity: AlarmSeverityName = AlarmSeverityName.MINOR
+    hihi_severity: AlarmSeverityName = AlarmSeverityName.MAJOR
+    hysteresis: float | None = Field(default=None, ge=0)
+    description: str = ""
+
+    @model_validator(mode="after")
+    def _validate_limits(self) -> "AlarmLimits":
+        """Require at least one threshold and enforce monotonic ordering."""
+        ordered = [
+            (AlarmLevel.LOLO, self.lolo),
+            (AlarmLevel.LOW, self.low),
+            (AlarmLevel.HIGH, self.high),
+            (AlarmLevel.HIHI, self.hihi),
+        ]
+        configured = [(name, value) for name, value in ordered if value is not None]
+        if not configured:
+            raise ValueError("at least one alarm threshold must be configured")
+        for (left_name, left), (right_name, right) in zip(configured, configured[1:]):
+            if left >= right:
+                raise ValueError(
+                    f"alarm limits must increase from LOLO to HIHI; "
+                    f"{left_name.value}={left} is not below {right_name.value}={right}"
+                )
+        return self
+
+    def evaluate(
+        self, value: float, previous: AlarmLevel | None = None
+    ) -> AlarmEvaluation | None:
+        """Evaluate *value* and return its active alarm, if any.
+
+        Parameters
+        ----------
+        value : float
+            Live scalar readback value.
+        previous : AlarmLevel, optional
+            Previously active threshold for hysteresis handling.
+
+        Returns
+        -------
+        AlarmEvaluation or None
+            Active threshold/severity, or ``None`` when the value is normal.
+        """
+        current = self._direct_evaluate(value)
+        if self.hysteresis is None or self.hysteresis == 0 or previous is None:
+            return current
+        if current is not None and current.level != previous:
+            return current
+        if current is not None:
+            return current
+        if self._inside_hysteresis_band(value, previous):
+            return self._evaluation_for(previous)
+        return None
+
+    def _direct_evaluate(self, value: float) -> AlarmEvaluation | None:
+        """Evaluate without considering hysteresis."""
+        if self.hihi is not None and value >= self.hihi:
+            return self._evaluation_for(AlarmLevel.HIHI)
+        if self.high is not None and value >= self.high:
+            return self._evaluation_for(AlarmLevel.HIGH)
+        if self.lolo is not None and value <= self.lolo:
+            return self._evaluation_for(AlarmLevel.LOLO)
+        if self.low is not None and value <= self.low:
+            return self._evaluation_for(AlarmLevel.LOW)
+        return None
+
+    def _inside_hysteresis_band(self, value: float, level: AlarmLevel) -> bool:
+        """Return whether *level* should remain active under hysteresis."""
+        if self.hysteresis is None:
+            return False
+        if level is AlarmLevel.HIHI and self.hihi is not None:
+            return value >= self.hihi - self.hysteresis
+        if level is AlarmLevel.HIGH and self.high is not None:
+            return value >= self.high - self.hysteresis
+        if level is AlarmLevel.LOLO and self.lolo is not None:
+            return value <= self.lolo + self.hysteresis
+        if level is AlarmLevel.LOW and self.low is not None:
+            return value <= self.low + self.hysteresis
+        return False
+
+    def _evaluation_for(self, level: AlarmLevel) -> AlarmEvaluation:
+        """Build the evaluation object for *level*."""
+        severities = {
+            AlarmLevel.LOLO: self.lolo_severity,
+            AlarmLevel.LOW: self.low_severity,
+            AlarmLevel.HIGH: self.high_severity,
+            AlarmLevel.HIHI: self.hihi_severity,
+        }
+        return AlarmEvaluation(level=level, severity=severities[level])

--- a/GeecsCAGateway/geecs_ca_gateway/alarms.py
+++ b/GeecsCAGateway/geecs_ca_gateway/alarms.py
@@ -100,13 +100,11 @@ class AlarmLimits(BaseModel):
         current = self._direct_evaluate(value)
         if self.hysteresis is None or self.hysteresis == 0 or previous is None:
             return current
-        if current is not None and current.level != previous:
-            return current
-        if current is not None:
+        if current is not None and _more_extreme(current.level, previous):
             return current
         if self._inside_hysteresis_band(value, previous):
             return self._evaluation_for(previous)
-        return None
+        return current
 
     def _direct_evaluate(self, value: float) -> AlarmEvaluation | None:
         """Evaluate without considering hysteresis."""
@@ -143,3 +141,12 @@ class AlarmLimits(BaseModel):
             AlarmLevel.HIHI: self.hihi_severity,
         }
         return AlarmEvaluation(level=level, severity=severities[level])
+
+
+def _more_extreme(current: AlarmLevel, previous: AlarmLevel) -> bool:
+    """Return whether *current* is farther out of range than *previous*."""
+    more_extreme_than = {
+        AlarmLevel.HIGH: {AlarmLevel.HIHI},
+        AlarmLevel.LOW: {AlarmLevel.LOLO},
+    }
+    return current in more_extreme_than.get(previous, set())

--- a/GeecsCAGateway/geecs_ca_gateway/channels.py
+++ b/GeecsCAGateway/geecs_ca_gateway/channels.py
@@ -243,6 +243,16 @@ def _metadata_kwargs(spec: VariableSpec) -> dict[str, Any]:
             kwargs["lower_disp_limit"] = spec.lo
         if spec.hi is not None:
             kwargs["upper_disp_limit"] = spec.hi
+        if spec.alarm_limits is not None:
+            limits = spec.alarm_limits
+            if limits.lolo is not None:
+                kwargs["lower_alarm_limit"] = limits.lolo
+            if limits.low is not None:
+                kwargs["lower_warning_limit"] = limits.low
+            if limits.high is not None:
+                kwargs["upper_warning_limit"] = limits.high
+            if limits.hihi is not None:
+                kwargs["upper_alarm_limit"] = limits.hihi
     return kwargs
 
 

--- a/GeecsCAGateway/geecs_ca_gateway/channels.py
+++ b/GeecsCAGateway/geecs_ca_gateway/channels.py
@@ -243,16 +243,6 @@ def _metadata_kwargs(spec: VariableSpec) -> dict[str, Any]:
             kwargs["lower_disp_limit"] = spec.lo
         if spec.hi is not None:
             kwargs["upper_disp_limit"] = spec.hi
-        if spec.alarm_limits is not None:
-            limits = spec.alarm_limits
-            if limits.lolo is not None:
-                kwargs["lower_alarm_limit"] = limits.lolo
-            if limits.low is not None:
-                kwargs["lower_warning_limit"] = limits.low
-            if limits.high is not None:
-                kwargs["upper_warning_limit"] = limits.high
-            if limits.hihi is not None:
-                kwargs["upper_alarm_limit"] = limits.hihi
     return kwargs
 
 

--- a/GeecsCAGateway/geecs_ca_gateway/config.py
+++ b/GeecsCAGateway/geecs_ca_gateway/config.py
@@ -13,6 +13,7 @@ from typing import Literal
 
 from pydantic import BaseModel, Field
 
+from .alarms import AlarmLimits
 from .naming import normalize_pv_component
 
 logger = logging.getLogger(__name__)
@@ -58,6 +59,7 @@ class VariableSpec(BaseModel):
     hi: float | None = None
     choices: list[str] = Field(default_factory=list)  # ordered options for enum
     deadband: float = 0.0  # float monitor deadband; only post when |Δ| > deadband
+    alarm_limits: AlarmLimits | None = None
 
     @property
     def pv_suffix(self) -> str:
@@ -357,6 +359,7 @@ class GatewayConfig(BaseModel):
         var_map = GeecsDb.get_experiment_device_variables(
             experiment, enabled_only=enabled_only
         )
+        alarm_map = GeecsDb.get_ca_alarm_limits(experiment)
         sub_map: dict[str, list[str]] = {}
         if subscribed_only:
             sub_map = GeecsDb.get_subscribed_variables(
@@ -399,7 +402,29 @@ class GatewayConfig(BaseModel):
                     name,
                 )
                 continue
+            for var in spec.variables:
+                alarm_limits = alarm_map.get((name, var.geecs_var))
+                if alarm_limits is None:
+                    continue
+                if var.dtype not in ("float", "int"):
+                    logger.warning(
+                        "from_geecs_experiment: ignoring alarm limits for "
+                        "%s/%s because dtype=%s is not numeric",
+                        name,
+                        var.geecs_var,
+                        var.dtype,
+                    )
+                    continue
+                var.alarm_limits = alarm_limits
             devices.append(spec)
+        served = {(dev.name, var.geecs_var) for dev in devices for var in dev.variables}
+        for device, variable in sorted(set(alarm_map) - served):
+            logger.warning(
+                "from_geecs_experiment: ignoring alarm limits for %s/%s because "
+                "that variable is not served by the gateway",
+                device,
+                variable,
+            )
         logger.info(
             "from_geecs_experiment(%s): built %d/%d device spec(s)",
             experiment,

--- a/GeecsCAGateway/geecs_ca_gateway/db/geecs_db.py
+++ b/GeecsCAGateway/geecs_ca_gateway/db/geecs_db.py
@@ -22,6 +22,9 @@ import os
 from pathlib import Path
 from typing import Optional
 
+from pydantic import ValidationError
+
+from geecs_ca_gateway.alarms import AlarmLimits
 from geecs_ca_gateway.exceptions import GeecsDeviceNotFoundError
 
 logger = logging.getLogger(__name__)
@@ -113,6 +116,26 @@ def _variable_row_to_meta(row: tuple) -> dict:
         "choices": row[6],
         "tolerance": _num(row[7]),
     }
+
+
+def _alarm_row_to_limits(row: tuple) -> AlarmLimits:
+    """Map a ``ca_alarm_limits`` row onto an :class:`AlarmLimits` model.
+
+    Row order is the SELECT order in :meth:`GeecsDb.get_ca_alarm_limits`, after
+    experiment/device/variable.
+    """
+    return AlarmLimits(
+        lolo=_num(row[0]),
+        low=_num(row[1]),
+        high=_num(row[2]),
+        hihi=_num(row[3]),
+        lolo_severity=row[4] or "MAJOR",
+        low_severity=row[5] or "MINOR",
+        high_severity=row[6] or "MINOR",
+        hihi_severity=row[7] or "MAJOR",
+        hysteresis=_num(row[8]),
+        description=row[9] or "",
+    )
 
 
 class GeecsDb:
@@ -427,4 +450,78 @@ class GeecsDb:
         result: dict[str, list[dict]] = {}
         for row in rows:
             result.setdefault(row[0], []).append(_variable_row_to_meta(row[1:]))
+        return result
+
+    @classmethod
+    def get_ca_alarm_limits(cls, experiment: str) -> dict[tuple[str, str], AlarmLimits]:
+        """Return enabled curated CA alarm limits for *experiment*.
+
+        The ``ca_alarm_limits`` table is an optional overlay.  If the table is
+        absent during rollout, or if the lookup otherwise fails, the gateway
+        starts with no value alarms rather than failing the whole IOC.  Invalid
+        rows are skipped with a warning.
+
+        Parameters
+        ----------
+        experiment : str
+            GEECS experiment name.
+
+        Returns
+        -------
+        dict
+            ``(device, variable)`` → validated alarm limits.
+        """
+        try:
+            import mysql.connector
+        except ImportError as exc:
+            raise ImportError(
+                "mysql-connector-python is required for DB lookups."
+            ) from exc
+
+        try:
+            conn = _connect_mysql(mysql.connector)
+        except Exception:
+            logger.info(
+                "ca_alarm_limits lookup failed before query; starting without "
+                "curated value alarms",
+                exc_info=True,
+            )
+            return {}
+        try:
+            cur = conn.cursor()
+            try:
+                cur.execute(
+                    "SELECT experiment, device, `variable`, "
+                    "lolo, low, high, hihi, "
+                    "lolo_severity, low_severity, high_severity, hihi_severity, "
+                    "hysteresis, description "
+                    "FROM ca_alarm_limits "
+                    "WHERE experiment = %s AND enabled = TRUE "
+                    "ORDER BY device, variable",
+                    (experiment,),
+                )
+                rows = cur.fetchall()
+            except Exception:
+                logger.info(
+                    "ca_alarm_limits lookup failed or table is absent; "
+                    "starting without curated value alarms",
+                    exc_info=True,
+                )
+                return {}
+        finally:
+            conn.close()
+
+        result: dict[tuple[str, str], AlarmLimits] = {}
+        for row in rows:
+            _experiment, device, variable = row[:3]
+            try:
+                result[(device, variable)] = _alarm_row_to_limits(row[3:])
+            except ValidationError:
+                logger.warning(
+                    "skipping invalid ca_alarm_limits row for %s/%s in %s",
+                    device,
+                    variable,
+                    experiment,
+                    exc_info=True,
+                )
         return result

--- a/GeecsCAGateway/geecs_ca_gateway/db/geecs_db.py
+++ b/GeecsCAGateway/geecs_ca_gateway/db/geecs_db.py
@@ -138,6 +138,11 @@ def _alarm_row_to_limits(row: tuple) -> AlarmLimits:
     )
 
 
+def _is_missing_table_error(exc: Exception) -> bool:
+    """Return whether *exc* is MySQL's ER_NO_SUCH_TABLE rollout case."""
+    return getattr(exc, "errno", None) == 1146
+
+
 class GeecsDb:
     """Namespace for GEECS database queries.
 
@@ -481,7 +486,7 @@ class GeecsDb:
         try:
             conn = _connect_mysql(mysql.connector)
         except Exception:
-            logger.info(
+            logger.warning(
                 "ca_alarm_limits lookup failed before query; starting without "
                 "curated value alarms",
                 exc_info=True,
@@ -501,12 +506,18 @@ class GeecsDb:
                     (experiment,),
                 )
                 rows = cur.fetchall()
-            except Exception:
-                logger.info(
-                    "ca_alarm_limits lookup failed or table is absent; "
-                    "starting without curated value alarms",
-                    exc_info=True,
-                )
+            except Exception as exc:
+                if _is_missing_table_error(exc):
+                    logger.info(
+                        "ca_alarm_limits table is absent; starting without "
+                        "curated value alarms"
+                    )
+                else:
+                    logger.warning(
+                        "ca_alarm_limits lookup failed; starting without "
+                        "curated value alarms",
+                        exc_info=True,
+                    )
                 return {}
         finally:
             conn.close()

--- a/GeecsCAGateway/geecs_ca_gateway/gateway.py
+++ b/GeecsCAGateway/geecs_ca_gateway/gateway.py
@@ -408,9 +408,12 @@ class GeecsCaGateway:
                     alarm_kwargs = self._alarm_write_kwargs(
                         device_name, var, spec, value
                     )
-                    await channel.write(value, **extra)
-                    if alarm_kwargs:
-                        await channel.alarm.write(**alarm_kwargs)
+                    await channel.write(
+                        value,
+                        **extra,
+                        **alarm_kwargs,
+                        verify_value=not bool(alarm_kwargs),
+                    )
                 except Exception:
                     self._warn_once(
                         device_name,
@@ -610,6 +613,7 @@ class GeecsCaGateway:
                     channel.value,
                     severity=AlarmSeverity.INVALID_ALARM,
                     status=AlarmStatus.COMM,
+                    verify_value=False,
                 )
             except Exception:
                 logger.debug("failed to mark %s INVALID", pv, exc_info=True)

--- a/GeecsCAGateway/geecs_ca_gateway/gateway.py
+++ b/GeecsCAGateway/geecs_ca_gateway/gateway.py
@@ -33,6 +33,7 @@ from geecs_ca_gateway.exceptions import GeecsConnectionError
 from geecs_ca_gateway.transport.tcp_subscriber import GeecsTcpSubscriber
 from geecs_ca_gateway.transport.udp_client import GeecsUdpClient
 
+from .alarms import AlarmLevel, AlarmSeverityName
 from .channels import (
     cast_value,
     enum_index,
@@ -62,6 +63,19 @@ _UNSET = object()
 # axis is not a dead one". Gets keep the shorter GeecsUdpClient default — a
 # read that takes 10 s *is* a dead device.
 _SET_EXE_TIMEOUT = 30.0
+
+_ALARM_SEVERITY = {
+    AlarmSeverityName.MINOR: AlarmSeverity.MINOR_ALARM,
+    AlarmSeverityName.MAJOR: AlarmSeverity.MAJOR_ALARM,
+    AlarmSeverityName.INVALID: AlarmSeverity.INVALID_ALARM,
+}
+
+_ALARM_STATUS = {
+    AlarmLevel.LOLO: AlarmStatus.LOLO,
+    AlarmLevel.LOW: AlarmStatus.LOW,
+    AlarmLevel.HIGH: AlarmStatus.HIGH,
+    AlarmLevel.HIHI: AlarmStatus.HIHI,
+}
 
 
 def _extract_timestamp(update: dict[str, Any], ts_vars: list[str]) -> float | None:
@@ -129,6 +143,8 @@ class GeecsCaGateway:
         # (device, geecs_var) that have already logged a coercion warning, so a
         # mistyped variable warns once instead of every ~5 Hz frame.
         self._coerce_warned: set[tuple[str, str]] = set()
+        # Last active value-alarm threshold, for per-PV hysteresis handling.
+        self._value_alarm_levels: dict[tuple[str, str], AlarmLevel | None] = {}
         # devices currently logged as down, for one-line state-change logging
         # (a warning when it goes down, an info when it reconnects).
         self._down_logged: set[str] = set()
@@ -278,6 +294,33 @@ class GeecsCaGateway:
             self._coerce_warned.add(key)
             logger.warning(message)
 
+    def _alarm_write_kwargs(
+        self, device: str, geecs_var: str, spec: VariableSpec, value: Any
+    ) -> dict[str, Any]:
+        """Return caproto alarm kwargs for a live readback write.
+
+        Disconnect/stale INVALID is handled separately by
+        :meth:`_mark_device_invalid`.  This method only evaluates live values
+        against curated scalar alarm limits.
+        """
+        limits = spec.alarm_limits
+        if limits is None:
+            return {}
+        key = (device, geecs_var)
+        try:
+            numeric = float(value)
+        except (TypeError, ValueError):
+            self._value_alarm_levels[key] = None
+            return {"severity": AlarmSeverity.NO_ALARM, "status": AlarmStatus.NO_ALARM}
+        evaluation = limits.evaluate(numeric, self._value_alarm_levels.get(key))
+        self._value_alarm_levels[key] = None if evaluation is None else evaluation.level
+        if evaluation is None:
+            return {"severity": AlarmSeverity.NO_ALARM, "status": AlarmStatus.NO_ALARM}
+        return {
+            "severity": _ALARM_SEVERITY[evaluation.severity],
+            "status": _ALARM_STATUS[evaluation.level],
+        }
+
     def _make_callback(self, dev):
         """Return the subscription callback that fans a push frame into PVs.
 
@@ -362,7 +405,12 @@ class GeecsCaGateway:
                         continue
                 last_map[var] = value
                 try:
+                    alarm_kwargs = self._alarm_write_kwargs(
+                        device_name, var, spec, value
+                    )
                     await channel.write(value, **extra)
+                    if alarm_kwargs:
+                        await channel.alarm.write(**alarm_kwargs)
                 except Exception:
                     self._warn_once(
                         device_name,

--- a/GeecsCAGateway/pyproject.toml
+++ b/GeecsCAGateway/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-ca-gateway"
-version = "0.6.0"
+version = "0.7.0"
 description = "EPICS Channel Access soft-IOC gateway exposing GEECS devices as PVs"
 authors = ["Sam Barber <sbarber@lbl.gov>"]
 readme = "README.md"

--- a/GeecsCAGateway/tests/test_channels.py
+++ b/GeecsCAGateway/tests/test_channels.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import pytest
 
+from geecs_ca_gateway.alarms import AlarmLimits
 from geecs_ca_gateway.channels import (
     cast_value,
     enum_geecs_value,
@@ -126,6 +127,19 @@ async def test_path_setpoint_forwards_full_text() -> None:
     # A char-array put (integer codes) decodes to the same text.
     await channel.write([ord(c) for c in _LONG_PATH])
     assert sent[-1] == _LONG_PATH
+
+
+def test_alarm_limits_do_not_populate_native_caproto_thresholds() -> None:
+    """Curated alarm limits are evaluated by the gateway overlay only."""
+    channel = make_readback_channel(
+        VariableSpec(
+            geecs_var="Current",
+            dtype="float",
+            alarm_limits=AlarmLimits(high=2.5),
+        )
+    )
+
+    assert channel.upper_warning_limit != 2.5
 
 
 class TestEnumGeecsValueNumericLabels:

--- a/GeecsCAGateway/tests/test_config_from_db.py
+++ b/GeecsCAGateway/tests/test_config_from_db.py
@@ -48,6 +48,20 @@ def test_alarm_limits_validate_order_and_presence() -> None:
         AlarmLimits(low=5.0, high=1.0)
 
 
+def test_alarm_limits_hysteresis_holds_level_before_stepdown() -> None:
+    """HIHI stays active through its hysteresis band before dropping to HIGH."""
+    limits = AlarmLimits(high=4.0, hihi=5.0, hysteresis=0.1)
+
+    assert limits.evaluate(5.1).level == "HIHI"
+    held = limits.evaluate(4.95, previous=limits.evaluate(5.1).level)
+    assert held is not None
+    assert held.level == "HIHI"
+
+    stepped_down = limits.evaluate(4.89, previous=held.level)
+    assert stepped_down is not None
+    assert stepped_down.level == "HIGH"
+
+
 def test_from_geecs_experiment_attaches_numeric_alarm_limits(monkeypatch) -> None:
     """DB alarm rows attach only to served numeric readback variables."""
     monkeypatch.setattr(

--- a/GeecsCAGateway/tests/test_config_from_db.py
+++ b/GeecsCAGateway/tests/test_config_from_db.py
@@ -6,7 +6,11 @@ Exercises the pure ``DeviceSpec.from_db_metadata`` core using rows shaped like
 
 from __future__ import annotations
 
+import pytest
+
+from geecs_ca_gateway.alarms import AlarmLimits
 from geecs_ca_gateway.config import DeviceSpec, GatewayConfig
+from geecs_ca_gateway.db.geecs_db import GeecsDb
 from geecs_ca_gateway.gateway import GeecsCaGateway
 
 # Mirrors GeecsDb.get_device_variables("U_S1H") observed against real hardware.
@@ -32,6 +36,58 @@ def test_from_db_metadata_maps_units_limits_settable() -> None:
 
     # units default to empty; missing limits stay None
     assert by_name["IPAddress"].lo is None and by_name["IPAddress"].hi is None
+
+
+def test_alarm_limits_validate_order_and_presence() -> None:
+    """Curated alarm limits must be explicit and monotonic."""
+    limits = AlarmLimits(low=1.0, high=5.0)
+    assert limits.low == 1.0
+    with pytest.raises(ValueError, match="at least one"):
+        AlarmLimits()
+    with pytest.raises(ValueError, match="increase"):
+        AlarmLimits(low=5.0, high=1.0)
+
+
+def test_from_geecs_experiment_attaches_numeric_alarm_limits(monkeypatch) -> None:
+    """DB alarm rows attach only to served numeric readback variables."""
+    monkeypatch.setattr(
+        GeecsDb,
+        "get_experiment_devices",
+        classmethod(lambda cls, experiment, enabled_only=True: {"U_A": ("h", 1)}),
+    )
+    monkeypatch.setattr(
+        GeecsDb,
+        "get_experiment_device_variables",
+        classmethod(
+            lambda cls, experiment, enabled_only=True: {
+                "U_A": [
+                    {
+                        "name": "Current",
+                        "units": "A",
+                        "min": -5.0,
+                        "max": 5.0,
+                        "settable": True,
+                        "variabletype": "numeric",
+                    }
+                ]
+            }
+        ),
+    )
+    monkeypatch.setattr(
+        GeecsDb,
+        "get_subscribed_variables",
+        classmethod(lambda cls, experiment, enabled_only=True: {"U_A": ["Current"]}),
+    )
+    monkeypatch.setattr(
+        GeecsDb,
+        "get_ca_alarm_limits",
+        classmethod(
+            lambda cls, experiment: {("U_A", "Current"): AlarmLimits(high=4.0)}
+        ),
+    )
+
+    cfg = GatewayConfig.from_geecs_experiment("Undulator")
+    assert cfg.devices[0].variables[0].alarm_limits == AlarmLimits(high=4.0)
 
 
 def test_include_filters_variables() -> None:

--- a/GeecsCAGateway/tests/test_gateway.py
+++ b/GeecsCAGateway/tests/test_gateway.py
@@ -257,6 +257,69 @@ async def test_value_alarm_limits_set_live_readback_severity() -> None:
     assert int(rb.status) == int(AlarmStatus.NO_ALARM)
 
 
+async def test_high_only_alarm_row_does_not_trigger_native_low_alarm() -> None:
+    """A partial curated row must not activate caproto's native limit evaluator."""
+    cfg = GatewayConfig(
+        devices=[
+            DeviceSpec(
+                name=DEVICE,
+                host="127.0.0.1",
+                port=1,
+                variables=[
+                    VariableSpec(
+                        geecs_var="Position",
+                        dtype="float",
+                        alarm_limits=AlarmLimits(high=5.0),
+                    )
+                ],
+            )
+        ]
+    )
+    gw = GeecsCaGateway(cfg)
+    rb = gw.pvdb[f"{DEVICE}:Position"]
+    callback = gw._make_callback(cfg.devices[0])
+
+    await callback({"Position": -1.0})
+
+    assert rb.value == pytest.approx(-1.0)
+    assert int(rb.severity) == int(AlarmSeverity.NO_ALARM)
+    assert int(rb.status) == int(AlarmStatus.NO_ALARM)
+
+
+async def test_alarm_hysteresis_holds_hihi_before_stepping_down() -> None:
+    """HIHI does not chatter to HIGH until value exits the hysteresis band."""
+    cfg = GatewayConfig(
+        devices=[
+            DeviceSpec(
+                name=DEVICE,
+                host="127.0.0.1",
+                port=1,
+                variables=[
+                    VariableSpec(
+                        geecs_var="Position",
+                        dtype="float",
+                        alarm_limits=AlarmLimits(high=4.0, hihi=5.0, hysteresis=0.1),
+                    )
+                ],
+            )
+        ]
+    )
+    gw = GeecsCaGateway(cfg)
+    rb = gw.pvdb[f"{DEVICE}:Position"]
+    callback = gw._make_callback(cfg.devices[0])
+
+    await callback({"Position": 5.1})
+    assert int(rb.status) == int(AlarmStatus.HIHI)
+
+    await callback({"Position": 4.95})
+    assert int(rb.status) == int(AlarmStatus.HIHI)
+    assert int(rb.severity) == int(AlarmSeverity.MAJOR_ALARM)
+
+    await callback({"Position": 4.89})
+    assert int(rb.status) == int(AlarmStatus.HIGH)
+    assert int(rb.severity) == int(AlarmSeverity.MINOR_ALARM)
+
+
 async def test_invalid_liveness_overrides_value_alarm_until_live_frame() -> None:
     """A disconnect still reports INVALID/COMM; the next live value recomputes."""
     cfg = _alarm_config()

--- a/GeecsCAGateway/tests/test_gateway.py
+++ b/GeecsCAGateway/tests/test_gateway.py
@@ -16,9 +16,10 @@ import socket
 from typing import Any
 
 import pytest
-from caproto import AlarmSeverity
+from caproto import AlarmSeverity, AlarmStatus
 from geecs_ca_gateway.testing.fake_device_server import FakeGeecsDevice, FakeGeecsServer
 
+from geecs_ca_gateway.alarms import AlarmLimits
 from geecs_ca_gateway.config import DeviceSpec, GatewayConfig, VariableSpec
 from geecs_ca_gateway.gateway import GeecsCaGateway, _extract_timestamp
 
@@ -101,6 +102,26 @@ def _config(host: str, port: int) -> GatewayConfig:
                         geecs_var="Position", dtype="float", settable=True, egu="mm"
                     ),
                     VariableSpec(geecs_var="acq_timestamp", dtype="float"),
+                ],
+            )
+        ]
+    )
+
+
+def _alarm_config() -> GatewayConfig:
+    """Return a network-free config with scalar alarm limits."""
+    return GatewayConfig(
+        devices=[
+            DeviceSpec(
+                name=DEVICE,
+                host="127.0.0.1",
+                port=1,
+                variables=[
+                    VariableSpec(
+                        geecs_var="Position",
+                        dtype="float",
+                        alarm_limits=AlarmLimits(high=5.0, hihi=10.0),
+                    )
                 ],
             )
         ]
@@ -211,6 +232,49 @@ async def test_reconnect_and_validity() -> None:
             await srv2.stop()
     finally:
         await gw.close()
+
+
+async def test_value_alarm_limits_set_live_readback_severity() -> None:
+    """Curated scalar limits set MINOR/MAJOR severity on live values."""
+    cfg = _alarm_config()
+    gw = GeecsCaGateway(cfg)
+    rb = gw.pvdb[f"{DEVICE}:Position"]
+    callback = gw._make_callback(cfg.devices[0])
+
+    await callback({"Position": 7.0})
+    assert rb.value == pytest.approx(7.0)
+    assert int(rb.severity) == int(AlarmSeverity.MINOR_ALARM)
+    assert int(rb.status) == int(AlarmStatus.HIGH)
+
+    await callback({"Position": 11.0})
+    assert rb.value == pytest.approx(11.0)
+    assert int(rb.severity) == int(AlarmSeverity.MAJOR_ALARM)
+    assert int(rb.status) == int(AlarmStatus.HIHI)
+
+    await callback({"Position": 4.0})
+    assert rb.value == pytest.approx(4.0)
+    assert int(rb.severity) == int(AlarmSeverity.NO_ALARM)
+    assert int(rb.status) == int(AlarmStatus.NO_ALARM)
+
+
+async def test_invalid_liveness_overrides_value_alarm_until_live_frame() -> None:
+    """A disconnect still reports INVALID/COMM; the next live value recomputes."""
+    cfg = _alarm_config()
+    gw = GeecsCaGateway(cfg)
+    rb = gw.pvdb[f"{DEVICE}:Position"]
+    callback = gw._make_callback(cfg.devices[0])
+
+    await callback({"Position": 7.0})
+    assert int(rb.severity) == int(AlarmSeverity.MINOR_ALARM)
+
+    await gw._mark_device_invalid(DEVICE)
+    assert int(rb.severity) == int(AlarmSeverity.INVALID_ALARM)
+    assert int(rb.status) == int(AlarmStatus.COMM)
+
+    gw._last_written[DEVICE] = {}
+    await callback({"Position": 4.0})
+    assert int(rb.severity) == int(AlarmSeverity.NO_ALARM)
+    assert int(rb.status) == int(AlarmStatus.NO_ALARM)
 
 
 async def test_timestamp_vars_exposed_as_pvs_with_raw_value() -> None:

--- a/GeecsCAGateway/tests/test_geecs_db.py
+++ b/GeecsCAGateway/tests/test_geecs_db.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import sys
 import types
 
-
+from geecs_ca_gateway.alarms import AlarmLimits, AlarmSeverityName
 from geecs_ca_gateway.db import geecs_db
 from geecs_ca_gateway.db.geecs_db import GeecsDb
 
@@ -180,3 +180,67 @@ def test_get_experiment_device_variables_batches_metadata(monkeypatch) -> None:
     }
     assert result["U_A"][1]["choices"] == "on,off"
     assert result["U_B"][0]["settable"] is False
+
+
+def test_get_ca_alarm_limits_returns_validated_rows(monkeypatch) -> None:
+    """Optional alarm-limit rows are keyed by device/variable."""
+    queries: list = []
+    _patch_rows(
+        monkeypatch,
+        [
+            (
+                "Undulator",
+                "U_A",
+                "Current",
+                None,
+                "1.0",
+                "4.0",
+                "5.0",
+                None,
+                "MINOR",
+                "MINOR",
+                "MAJOR",
+                "0.1",
+                "current alarm",
+            )
+        ],
+        queries,
+    )
+
+    result = GeecsDb.get_ca_alarm_limits("Undulator")
+    assert queries and "ca_alarm_limits" in queries[0][0]
+    assert result == {
+        ("U_A", "Current"): AlarmLimits(
+            low=1.0,
+            high=4.0,
+            hihi=5.0,
+            high_severity=AlarmSeverityName.MINOR,
+            hihi_severity=AlarmSeverityName.MAJOR,
+            hysteresis=0.1,
+            description="current alarm",
+        )
+    }
+
+
+def test_get_ca_alarm_limits_missing_table_is_fail_open(monkeypatch) -> None:
+    """The optional alarm table can be absent during rollout."""
+
+    class _Cursor:
+        def execute(self, _query: str, _params: tuple) -> None:
+            raise RuntimeError("table does not exist")
+
+    class _Connection:
+        def cursor(self) -> _Cursor:
+            return _Cursor()
+
+        def close(self) -> None:
+            pass
+
+    mysql_pkg = types.ModuleType("mysql")
+    connector_mod = types.ModuleType("mysql.connector")
+    mysql_pkg.connector = connector_mod
+    monkeypatch.setitem(sys.modules, "mysql", mysql_pkg)
+    monkeypatch.setitem(sys.modules, "mysql.connector", connector_mod)
+    monkeypatch.setattr(geecs_db, "_connect_mysql", lambda _connector: _Connection())
+
+    assert GeecsDb.get_ca_alarm_limits("Undulator") == {}

--- a/GeecsCAGateway/tests/test_geecs_db.py
+++ b/GeecsCAGateway/tests/test_geecs_db.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import sys
 import types
 
@@ -222,12 +223,16 @@ def test_get_ca_alarm_limits_returns_validated_rows(monkeypatch) -> None:
     }
 
 
-def test_get_ca_alarm_limits_missing_table_is_fail_open(monkeypatch) -> None:
+def test_get_ca_alarm_limits_missing_table_is_fail_open(monkeypatch, caplog) -> None:
     """The optional alarm table can be absent during rollout."""
+    caplog.set_level(logging.INFO)
+
+    class _MissingTableError(Exception):
+        errno = 1146
 
     class _Cursor:
         def execute(self, _query: str, _params: tuple) -> None:
-            raise RuntimeError("table does not exist")
+            raise _MissingTableError("table does not exist")
 
     class _Connection:
         def cursor(self) -> _Cursor:
@@ -244,3 +249,29 @@ def test_get_ca_alarm_limits_missing_table_is_fail_open(monkeypatch) -> None:
     monkeypatch.setattr(geecs_db, "_connect_mysql", lambda _connector: _Connection())
 
     assert GeecsDb.get_ca_alarm_limits("Undulator") == {}
+    assert "table is absent" in caplog.text
+
+
+def test_get_ca_alarm_limits_query_failure_is_warning(monkeypatch, caplog) -> None:
+    """Unexpected DB errors stay fail-open but are visible above INFO."""
+
+    class _Cursor:
+        def execute(self, _query: str, _params: tuple) -> None:
+            raise RuntimeError("permission denied")
+
+    class _Connection:
+        def cursor(self) -> _Cursor:
+            return _Cursor()
+
+        def close(self) -> None:
+            pass
+
+    mysql_pkg = types.ModuleType("mysql")
+    connector_mod = types.ModuleType("mysql.connector")
+    mysql_pkg.connector = connector_mod
+    monkeypatch.setitem(sys.modules, "mysql", mysql_pkg)
+    monkeypatch.setitem(sys.modules, "mysql.connector", connector_mod)
+    monkeypatch.setattr(geecs_db, "_connect_mysql", lambda _connector: _Connection())
+
+    assert GeecsDb.get_ca_alarm_limits("Undulator") == {}
+    assert "ca_alarm_limits lookup failed" in caplog.text


### PR DESCRIPTION
## Summary

- add optional DB-backed `ca_alarm_limits` overlay for scalar CA value alarms
- apply LOLO/LOW/HIGH/HIHI severity/status from the curated overlay as the single value-alarm evaluator
- keep DB `min`/`max` as display metadata only; they are not interpreted as alarm limits
- do not export curated alarm thresholds as native DBR_CTRL alarm/warning metadata, avoiding caproto native limit-alarm conflicts
- add deployment SQL plus docs for applying the table and smoke-testing one configured row

## Review follow-up

- fixed native caproto limit-alarm interference by removing threshold metadata from channel construction and bypassing caproto numeric verification for overlay-managed writes
- removed separate steady-state `alarm.write()` fan-out by writing the value and computed alarm metadata together
- fixed HIHI/HIGH and LOLO/LOW hysteresis step-down behavior
- made missing table rollout fail-open at INFO, while unexpected DB lookup failures log at WARNING
- removed the optional overlay FK into the core `device` table
- added regression tests for high-only rows, hysteresis behavior, DB rollout errors, and the absence of native caproto threshold metadata

## Validation

- `poetry run pytest tests/test_channels.py tests/test_config_from_db.py tests/test_geecs_db.py tests/test_gateway.py -q` -> `76 passed`
- commit hooks passed `ruff`, `ruff-format`, and `pydocstyle`
- live gateway smoke test on this branch:
  - DB row: `Undulator`, `U_S1H`, `Current`, `lolo=-4.5`, `low=-2.5`, `high=2.5`, `hihi=4.5`, severities `MAJOR/MINOR/MINOR/MAJOR`, `hysteresis=0.05`
  - with `U_S1H:Current = 3 A`, CA/Phoebus reported `HIGH` / `MINOR_ALARM`, as expected

## Notes

- This intentionally keeps alarm validation local to `GeecsCAGateway`; it does not add a `geecs-schemas` dependency.
- The table is optional during rollout. If it is absent, the gateway starts with no curated value alarms.
- Derived-channel schema/evaluator work is in a separate branch and is not part of this PR.
