### PR TITLE
Add gateway derived-channel overlays

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,7 +105,8 @@ GEECS-Data-Utils     →  (no intra-repo deps — foundational data layer)
 LogMaker4GoogleDocs  →  (no intra-repo deps — pure Google API wrapper)
 
 ImageAnalysis        →  GEECS-Data-Utils
-GeecsCAGateway       →  (no intra-repo deps — the GEECS access layer:
+GeecsCAGateway       →  GEECS-Schemas (schema-only vocabulary for optional
+                        derived-channel overlays; otherwise the GEECS access layer:
                         wire protocol, DB, PV naming, CA server)
 GeecsBluesky         →  GEECS-Data-Utils, GeecsCAGateway
                         (+ ImageAnalysis, optional via the `analysis` extra —

--- a/GEECS-Schemas/CHANGELOG.md
+++ b/GEECS-Schemas/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to GEECS-Schemas are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.0] - 2026-07-08
+
+### Added
+
+- `DerivedChannels` schema for CA gateway derived readbacks: operator-curated
+  read-only float PVs computed from one source device's numeric push-frame
+  values. Schema version 1 enforces same-source-device inputs so calculations
+  such as Convectron pressure from one DAQ analog input are frame-coherent.
+
 ## [0.2.0] - 2026-07-07
 
 ### Changed

--- a/GEECS-Schemas/geecs_schemas/__init__.py
+++ b/GEECS-Schemas/geecs_schemas/__init__.py
@@ -2,9 +2,9 @@
 
 Configs are schemas; YAML is just serialization.  This package is the single
 home of the models (vision doc §4): scan requests, save sets, scan variables,
-trigger profiles, and action plans — plus converters from every legacy YAML
-dialect (``geecs_schemas.convert``) and a Markdown reference generator
-(``geecs_schemas.docgen``).
+trigger profiles, action plans, and gateway derived channels — plus converters
+from every legacy YAML dialect (``geecs_schemas.convert``) and a Markdown
+reference generator (``geecs_schemas.docgen``).
 
 It depends on Pydantic only, so anything — engine, GUI, scripts, docs
 tooling — can import it without dragging in hardware or analysis stacks.
@@ -19,6 +19,11 @@ from geecs_schemas.action_plan import (
     RunPlanStep,
     SetStep,
     WaitStep,
+)
+from geecs_schemas.derived_channels import (
+    DerivedChannel,
+    DerivedChannels,
+    DerivedInput,
 )
 from geecs_schemas.experiment_defaults import DefaultActions, ExperimentDefaults
 from geecs_schemas.save_set import SaveRole, SaveSet, SaveSetEntry
@@ -65,6 +70,10 @@ __all__ = [
     "OptimizationSpec",
     "EvaluatorSpec",
     "GeneratorSpec",
+    # derived_channels
+    "DerivedChannels",
+    "DerivedChannel",
+    "DerivedInput",
     # save_set
     "SaveSet",
     "SaveSetEntry",
@@ -105,4 +114,5 @@ SCHEMA_REGISTRY: dict[str, type[VersionedSchemaModel]] = {
     "action_plan": ActionPlan,
     "action_plan_library": ActionPlanLibrary,
     "experiment_defaults": ExperimentDefaults,
+    "derived_channels": DerivedChannels,
 }

--- a/GEECS-Schemas/geecs_schemas/derived_channels.py
+++ b/GEECS-Schemas/geecs_schemas/derived_channels.py
@@ -1,0 +1,186 @@
+"""DerivedChannels — computed PV declarations for the CA gateway.
+
+This document declares operator-curated read-only PVs that the CA gateway
+computes from one source device's numeric push-frame values.  Use it for
+semantic quantities such as a Convectron pressure PV derived from a DAQ analog
+input voltage, where the result should be visible to Phoebus, archiving, and
+CA-backed clients like any other gateway readback.
+"""
+
+from __future__ import annotations
+
+from pydantic import Field, model_validator
+
+from geecs_schemas._base import SchemaModel, VersionedSchemaModel
+
+
+class DerivedInput(SchemaModel):
+    """One source variable bound to a symbol in a derived-channel formula."""
+
+    symbol: str = Field(
+        description=(
+            "Python-style symbol used in the expression, e.g. 'v' for a "
+            "voltage input. Must be a valid identifier and must not shadow a "
+            "reserved math function or constant."
+        )
+    )
+    device: str = Field(
+        description=(
+            "GEECS source device that provides this input variable, e.g. "
+            "'U_DaqPad1'. All inputs for one derived channel must come from "
+            "the same source device in schema version 1."
+        )
+    )
+    variable: str = Field(
+        description=(
+            "GEECS source variable on the input device, e.g. "
+            "'Analog Input 10'. The gateway subscribes to it even if it is not "
+            "exposed as its own raw readback PV."
+        )
+    )
+
+    @model_validator(mode="after")
+    def _validate_symbol(self) -> "DerivedInput":
+        if not self.symbol.isidentifier():
+            raise ValueError(f"input symbol {self.symbol!r} is not a valid identifier")
+        if self.symbol in {
+            "acos",
+            "asin",
+            "atan",
+            "cos",
+            "e",
+            "exp",
+            "isfinite",
+            "log",
+            "log10",
+            "pi",
+            "sin",
+            "sqrt",
+            "tan",
+            "tau",
+        }:
+            raise ValueError(f"input symbol {self.symbol!r} is reserved")
+        return self
+
+
+class DerivedChannel(SchemaModel):
+    """One read-only float PV computed from a numeric expression.
+
+    The output PV is named from ``device`` and ``variable`` using the gateway's
+    usual PV normalization, with the experiment prefix supplied by the gateway
+    launch config unless this entry overrides it.
+    """
+
+    device: str = Field(
+        description=(
+            "Device component of the output PV, e.g. 'U_ChamberVac' for "
+            "'Undulator:U_ChamberVac:Pressure'. This may be semantic and does "
+            "not need to be a real GEECS hardware device."
+        )
+    )
+    variable: str = Field(
+        description=(
+            "Variable component of the output PV, e.g. 'Pressure'. The gateway "
+            "normalizes it using the same rules as raw GEECS variables."
+        )
+    )
+    expression: str = Field(
+        min_length=1,
+        description=(
+            "Numeric formula for the output value, using input symbols and the "
+            "gateway's restricted arithmetic subset. Example: '10**(v - 5)'."
+        ),
+    )
+    inputs: list[DerivedInput] = Field(
+        min_length=1,
+        description=(
+            "Input variables available to the expression. In schema version 1 "
+            "all inputs for a derived channel must come from one source device, "
+            "so the calculation is coherent within a single push frame."
+        ),
+    )
+    experiment: str | None = Field(
+        None,
+        description=(
+            "Optional experiment prefix override for the output PV. Leave unset "
+            "to use the gateway's launched experiment."
+        ),
+    )
+    pv: str | None = Field(
+        None,
+        description=(
+            "Optional explicit output PV variable component. Leave unset to use "
+            "the 'variable' field."
+        ),
+    )
+    egu: str = Field(
+        "",
+        description="Engineering units displayed by CA clients, e.g. 'Torr'.",
+    )
+    precision: int = Field(
+        3,
+        ge=0,
+        description="Number of decimal places CA clients should display.",
+    )
+    lo: float | None = Field(
+        None,
+        description=(
+            "Optional lower display limit for the output PV. This is metadata "
+            "only; it is not an alarm or control limit."
+        ),
+    )
+    hi: float | None = Field(
+        None,
+        description=(
+            "Optional upper display limit for the output PV. This is metadata "
+            "only; it is not an alarm or control limit."
+        ),
+    )
+    deadband: float = Field(
+        0.0,
+        ge=0,
+        description=(
+            "Monitor deadband for the computed float value. Leave at 0.0 to "
+            "post every changed value and suppress only exact repeats."
+        ),
+    )
+    description: str = Field(
+        "",
+        description=(
+            "Operator-facing note describing what the derived PV represents, "
+            "for example the gauge model or calibration provenance."
+        ),
+    )
+
+    @property
+    def source_device(self) -> str:
+        """Return the single source device for this derived channel."""
+        return self.inputs[0].device
+
+    @model_validator(mode="after")
+    def _validate_channel(self) -> "DerivedChannel":
+        symbols = [inp.symbol for inp in self.inputs]
+        if len(set(symbols)) != len(symbols):
+            raise ValueError("derived-channel input symbols must be unique")
+        source_devices = {inp.device for inp in self.inputs}
+        if len(source_devices) != 1:
+            raise ValueError(
+                "derived-channel inputs must come from one source device in v1"
+            )
+        return self
+
+
+class DerivedChannels(VersionedSchemaModel):
+    """A file of computed read-only PVs for the CA gateway.
+
+    Load this file at gateway startup to add semantic, derived readbacks on top
+    of the raw GEECS database-driven PV set.
+    """
+
+    derived_channels: list[DerivedChannel] = Field(
+        default_factory=list,
+        description=(
+            "Derived PVs to expose. Each entry computes one read-only float PV "
+            "from one source device's numeric push-frame values."
+        ),
+    )

--- a/GEECS-Schemas/geecs_schemas/docgen.py
+++ b/GEECS-Schemas/geecs_schemas/docgen.py
@@ -173,16 +173,16 @@ description: "HTU standing defaults"
     "derived_channels": """\
 schema_version: 1
 derived_channels:
-  - device: U_ChamberVac
+  - device: TargetChamberPressure
     variable: Pressure
-    expression: "10**(v - 5)"
+    expression: "10**(v - 6)"
     inputs:
       - symbol: v
-        device: U_DaqPad1
-        variable: "Analog Input 10"
+        device: U_VacuumGauge
+        variable: "AI_mean.Channel 0"
     egu: Torr
-    precision: 3
-    description: "Convectron pressure from DAQ analog input 10"
+    precision: 6
+    description: "Convectron pressure from U_VacuumGauge analog input 0"
 """,
 }
 

--- a/GEECS-Schemas/geecs_schemas/docgen.py
+++ b/GEECS-Schemas/geecs_schemas/docgen.py
@@ -170,6 +170,20 @@ actions:
 background_telemetry: true   # soft-log every live device not in the save set
 description: "HTU standing defaults"
 """,
+    "derived_channels": """\
+schema_version: 1
+derived_channels:
+  - device: U_ChamberVac
+    variable: Pressure
+    expression: "10**(v - 5)"
+    inputs:
+      - symbol: v
+        device: U_DaqPad1
+        variable: "Analog Input 10"
+    egu: Torr
+    precision: 3
+    description: "Convectron pressure from DAQ analog input 10"
+""",
 }
 
 

--- a/GEECS-Schemas/poetry.lock
+++ b/GEECS-Schemas/poetry.lock
@@ -13,24 +13,6 @@ files = [
 ]
 
 [[package]]
-name = "caproto"
-version = "1.3.0"
-description = "a sans-I/O implementation of the EPICS Channel Access protocol"
-optional = false
-python-versions = ">=3.8"
-groups = ["main"]
-files = [
-    {file = "caproto-1.3.0-py3-none-any.whl", hash = "sha256:fa623c4a7d7c3537fc41ce023b7c72922b8819ab88bf9abc527e3ac594634180"},
-    {file = "caproto-1.3.0.tar.gz", hash = "sha256:ea74f433297e895695c80a706a2389f745a94d756b5835c80af73af3df585cba"},
-]
-
-[package.extras]
-async = ["curio (>=1.2)", "trio (>=0.12.1)"]
-complete = ["curio (>=1.2)", "dpkt", "netifaces", "numpy", "trio (>=0.12.1)"]
-standard = ["dpkt", "netifaces", "numpy"]
-test = ["codecov", "coverage", "curio", "curio (>=1.2)", "dpkt", "epics-pypdb", "netifaces", "numpy", "ophyd", "parsimonious", "pyepics (>=3.4.2)", "pytest", "pytest-rerunfailures", "pytest-timeout", "pytest-xdist", "trio (>=0.12.1)", "trio (>=0.18.0)"]
-
-[[package]]
 name = "colorama"
 version = "0.4.6"
 description = "Cross-platform colored terminal text."
@@ -44,23 +26,6 @@ files = [
 ]
 
 [[package]]
-name = "geecs-schemas"
-version = "0.3.0"
-description = "Versioned Pydantic schemas for GEECS scanner configs (scan requests, save sets, scan variables, trigger profiles, action plans) plus legacy-YAML converters."
-optional = false
-python-versions = ">=3.11,<3.12"
-groups = ["main"]
-files = []
-develop = true
-
-[package.dependencies]
-pydantic = "^2.0"
-
-[package.source]
-type = "directory"
-url = "../GEECS-Schemas"
-
-[[package]]
 name = "iniconfig"
 version = "2.3.0"
 description = "brain-dead simple config-ini parsing"
@@ -71,48 +36,6 @@ files = [
     {file = "iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12"},
     {file = "iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730"},
 ]
-
-[[package]]
-name = "mysql-connector-python"
-version = "9.7.0"
-description = "A self-contained Python driver for communicating with MySQL servers, using an API that is compliant with the Python Database API Specification v2.0 (PEP 249)."
-optional = false
-python-versions = ">=3.10"
-groups = ["main"]
-files = [
-    {file = "mysql_connector_python-9.7.0-cp310-cp310-macosx_14_0_arm64.whl", hash = "sha256:ee90c5f44f706f012be17f03f6ad158ff96e7f2dcc077896fe4537d3d28b3cf4"},
-    {file = "mysql_connector_python-9.7.0-cp310-cp310-macosx_14_0_x86_64.whl", hash = "sha256:a2f371ab69d65c61136c51ad7026017400166cef3c959cab7a9fb668c7acbfba"},
-    {file = "mysql_connector_python-9.7.0-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:9bdfc2d4c4444cd1cc79cc6487c047b28fe2b26d0327b27eb9f5737bb553cb5c"},
-    {file = "mysql_connector_python-9.7.0-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:6546e0b60c275409a5add9e3308c3897fcf478d1338cd845b1664c1a8946f72f"},
-    {file = "mysql_connector_python-9.7.0-cp310-cp310-win_amd64.whl", hash = "sha256:c51be697bfdfdf63bb71c5ecc51f7c6faf4aaa3d14a0136fa16e97cc37df1185"},
-    {file = "mysql_connector_python-9.7.0-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:b5cb8a3ba42b539f79cd13e4c8376d28506f3180f7079c9b04ea7bfd0424fb03"},
-    {file = "mysql_connector_python-9.7.0-cp311-cp311-macosx_14_0_x86_64.whl", hash = "sha256:5492d57a6a0e5127a928290737fbb91b66b46d31dac8de3e7604e550bf3b3a6e"},
-    {file = "mysql_connector_python-9.7.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:daf70f7da64a2e7c17e6dfd1fc98d2deb653fd955d0bd0b1fef246356e682b0f"},
-    {file = "mysql_connector_python-9.7.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:b8d3d6f32b95ae1d0a2f29d1a2b4e628849bcf7e84a70dc56c85b4929361d86b"},
-    {file = "mysql_connector_python-9.7.0-cp311-cp311-win_amd64.whl", hash = "sha256:079ce68d617250ef5cefffd5243056dc9f87c6034c804235fd6f45a0daf5a6ae"},
-    {file = "mysql_connector_python-9.7.0-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:2eae45230b5cbd783d68bdfe8b05ad9b4ebd06799f8d302a6169d7f025572baf"},
-    {file = "mysql_connector_python-9.7.0-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:15106ed73d74487f86de6b1859ff7f362efca7c7f9c494497ccb7439d3139fe6"},
-    {file = "mysql_connector_python-9.7.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:45491d4ce56722cb335e6d0bde2d4f4a98b7073421bd02a04ad5e6220d69e499"},
-    {file = "mysql_connector_python-9.7.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:d5924a76b530159c02f2fe8da4d3c6377ce1f5e195827e8ecbd36124673651d3"},
-    {file = "mysql_connector_python-9.7.0-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:e3842ecd62391a28c1dda5eb817f40418715e68482a8c146b3c478ac8bb7a23f"},
-    {file = "mysql_connector_python-9.7.0-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:9da73e212bb08e4df286506ffbda943063bbce448375a7db29748bb367f4e0af"},
-    {file = "mysql_connector_python-9.7.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:39bf31cdbe920eae08801eb829584dc27f70dadbdb3a5c3b78402f54cea87ab0"},
-    {file = "mysql_connector_python-9.7.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:236a4b8abfac8217517ce9e9edc735decf55282ada3890b3cd33770009f33d68"},
-    {file = "mysql_connector_python-9.7.0-cp313-cp313-win_amd64.whl", hash = "sha256:229ffce2333b88b59f8f034881e12dc85b309615338be9f843ed63923db99d52"},
-    {file = "mysql_connector_python-9.7.0-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:9e17ceb79c1c4c137a5994f8ca8c6a1ce8ebf83eda3ccc21dd67f2c1398680f0"},
-    {file = "mysql_connector_python-9.7.0-cp314-cp314-macosx_14_0_x86_64.whl", hash = "sha256:272c4e8263f6a514e4ae65e9553ed214fc9d4cf1f0f6bedca30def20c2ae1d52"},
-    {file = "mysql_connector_python-9.7.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:9549a2974353407427b574f005c92f03972e303182b4c3b4a272bf4ca10855ed"},
-    {file = "mysql_connector_python-9.7.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:ea4e05ab864ab8b0b5066d885d89ca51e5ba1320dba520c20a6f9388a8eca022"},
-    {file = "mysql_connector_python-9.7.0-cp314-cp314-win_amd64.whl", hash = "sha256:5a5abbc152bc28cb2e64a04605ecd9941eff6b0dc5f9528cb84adb873e9a1e49"},
-    {file = "mysql_connector_python-9.7.0-py2.py3-none-any.whl", hash = "sha256:af80b1e7179d5c2d983cf62470ad9b134a7e9ef05cf31108ae587f15873530cc"},
-    {file = "mysql_connector_python-9.7.0.tar.gz", hash = "sha256:933887e71c871b6e9d8908459fe8303ebcf8feb5cc1e1c49caa6490e525cf78e"},
-]
-
-[package.extras]
-dns-srv = ["dnspython (==2.6.1)"]
-gssapi = ["gssapi (==1.8.3)"]
-telemetry = ["opentelemetry-api (==1.33.1)", "opentelemetry-exporter-otlp-proto-http (==1.33.1)", "opentelemetry-sdk (==1.33.1)"]
-webauthn = ["fido2 (==1.1.2)"]
 
 [[package]]
 name = "packaging"
@@ -335,47 +258,12 @@ pygments = ">=2.7.2"
 dev = ["argcomplete", "attrs (>=19.2)", "hypothesis (>=3.56)", "mock", "requests", "setuptools", "xmlschema"]
 
 [[package]]
-name = "pytest-asyncio"
-version = "1.4.0"
-description = "Pytest support for asyncio"
-optional = false
-python-versions = ">=3.10"
-groups = ["dev"]
-files = [
-    {file = "pytest_asyncio-1.4.0-py3-none-any.whl", hash = "sha256:933ca923a23075a87fb7070c0ec272a6848489824d887c85c812670932835aa1"},
-    {file = "pytest_asyncio-1.4.0.tar.gz", hash = "sha256:c6c0d2259945122819f171a32ecea2c349ead889ee28176caaf492143424be42"},
-]
-
-[package.dependencies]
-pytest = ">=8.4,<10"
-typing-extensions = {version = ">=4.12", markers = "python_version < \"3.13\""}
-
-[package.extras]
-docs = ["sphinx (>=5.3)", "sphinx-rtd-theme (>=1)", "sphinx-tabs (>=3.5)"]
-testing = ["coverage (>=6.2)", "hypothesis (>=5.7.1)"]
-
-[[package]]
-name = "pytest-timeout"
-version = "2.4.0"
-description = "pytest plugin to abort hanging tests"
-optional = false
-python-versions = ">=3.7"
-groups = ["dev"]
-files = [
-    {file = "pytest_timeout-2.4.0-py3-none-any.whl", hash = "sha256:c42667e5cdadb151aeb5b26d114aff6bdf5a907f176a007a30b940d3d865b5c2"},
-    {file = "pytest_timeout-2.4.0.tar.gz", hash = "sha256:7e68e90b01f9eff71332b25001f85c75495fc4e3a836701876183c4bcfd0540a"},
-]
-
-[package.dependencies]
-pytest = ">=7.0.0"
-
-[[package]]
 name = "pyyaml"
 version = "6.0.3"
 description = "YAML parser and emitter for Python"
 optional = false
 python-versions = ">=3.8"
-groups = ["main"]
+groups = ["dev"]
 files = [
     {file = "PyYAML-6.0.3-cp38-cp38-macosx_10_13_x86_64.whl", hash = "sha256:c2514fceb77bc5e7a2f7adfaa1feb2fb311607c9cb518dbc378688ec73d8292f"},
     {file = "PyYAML-6.0.3-cp38-cp38-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9c57bb8c96f6d1808c030b1687b9b5fb476abaa47f0db9c0101f5e9f394e97f4"},
@@ -454,14 +342,14 @@ files = [
 
 [[package]]
 name = "typing-extensions"
-version = "4.15.0"
+version = "4.16.0"
 description = "Backported and Experimental Type Hints for Python 3.9+"
 optional = false
 python-versions = ">=3.9"
-groups = ["main", "dev"]
+groups = ["main"]
 files = [
-    {file = "typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548"},
-    {file = "typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466"},
+    {file = "typing_extensions-4.16.0-py3-none-any.whl", hash = "sha256:481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8"},
+    {file = "typing_extensions-4.16.0.tar.gz", hash = "sha256:dc983d19a509c94dba722ee6abd33940f7c05a89e243c47e907eb4db6f1a43e5"},
 ]
 
 [[package]]
@@ -482,4 +370,4 @@ typing-extensions = ">=4.12.0"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<3.12"
-content-hash = "a92fd57190892b84ab91cbc3e77812d4daf078d9e9295700a895f7b31ed12b1e"
+content-hash = "110c606d762838adda88f789d83876d5ff72ce7af20ea4dfc26daee4947614ed"

--- a/GEECS-Schemas/pyproject.toml
+++ b/GEECS-Schemas/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-schemas"
-version = "0.2.0"
+version = "0.3.0"
 description = "Versioned Pydantic schemas for GEECS scanner configs (scan requests, save sets, scan variables, trigger profiles, action plans) plus legacy-YAML converters."
 authors = ["Sam Barber <sbarber@lbl.gov>"]
 readme = "README.md"

--- a/GEECS-Schemas/tests/test_derived_channels.py
+++ b/GEECS-Schemas/tests/test_derived_channels.py
@@ -11,18 +11,18 @@ def make_document() -> DerivedChannels:
         {
             "derived_channels": [
                 {
-                    "device": "U_ChamberVac",
+                    "device": "TargetChamberPressure",
                     "variable": "Pressure",
-                    "expression": "10**(v - 5)",
+                    "expression": "10**(v - 6)",
                     "inputs": [
                         {
                             "symbol": "v",
-                            "device": "U_DaqPad1",
-                            "variable": "Analog Input 10",
+                            "device": "U_VacuumGauge",
+                            "variable": "AI_mean.Channel 0",
                         }
                     ],
                     "egu": "Torr",
-                    "precision": 3,
+                    "precision": 6,
                 }
             ]
         }

--- a/GEECS-Schemas/tests/test_derived_channels.py
+++ b/GEECS-Schemas/tests/test_derived_channels.py
@@ -1,0 +1,110 @@
+"""Model tests for derived CA gateway channels."""
+
+import pytest
+from pydantic import ValidationError
+
+from geecs_schemas import DerivedChannels
+
+
+def make_document() -> DerivedChannels:
+    return DerivedChannels.model_validate(
+        {
+            "derived_channels": [
+                {
+                    "device": "U_ChamberVac",
+                    "variable": "Pressure",
+                    "expression": "10**(v - 5)",
+                    "inputs": [
+                        {
+                            "symbol": "v",
+                            "device": "U_DaqPad1",
+                            "variable": "Analog Input 10",
+                        }
+                    ],
+                    "egu": "Torr",
+                    "precision": 3,
+                }
+            ]
+        }
+    )
+
+
+class TestDerivedChannels:
+    def test_round_trip(self):
+        document = make_document()
+        again = DerivedChannels.model_validate(document.model_dump(mode="json"))
+        assert again == document
+
+    def test_same_source_device_enforced(self):
+        with pytest.raises(ValidationError, match="one source device"):
+            DerivedChannels.model_validate(
+                {
+                    "derived_channels": [
+                        {
+                            "device": "U_ChamberVac",
+                            "variable": "PressureRatio",
+                            "expression": "a / b",
+                            "inputs": [
+                                {
+                                    "symbol": "a",
+                                    "device": "U_DaqPad1",
+                                    "variable": "Analog Input 10",
+                                },
+                                {
+                                    "symbol": "b",
+                                    "device": "U_DaqPad2",
+                                    "variable": "Analog Input 1",
+                                },
+                            ],
+                        }
+                    ]
+                }
+            )
+
+    def test_input_symbols_must_be_unique(self):
+        with pytest.raises(ValidationError, match="symbols must be unique"):
+            DerivedChannels.model_validate(
+                {
+                    "derived_channels": [
+                        {
+                            "device": "U_ChamberVac",
+                            "variable": "Pressure",
+                            "expression": "a + a",
+                            "inputs": [
+                                {
+                                    "symbol": "a",
+                                    "device": "U_DaqPad1",
+                                    "variable": "Analog Input 10",
+                                },
+                                {
+                                    "symbol": "a",
+                                    "device": "U_DaqPad1",
+                                    "variable": "Analog Input 11",
+                                },
+                            ],
+                        }
+                    ]
+                }
+            )
+
+    def test_unknown_field_fails_loudly(self):
+        with pytest.raises(ValidationError, match="units"):
+            DerivedChannels.model_validate(
+                {
+                    "derived_channels": [
+                        {
+                            "device": "U_ChamberVac",
+                            "variable": "Pressure",
+                            "expression": "v",
+                            "inputs": [
+                                {
+                                    "symbol": "v",
+                                    "device": "U_DaqPad1",
+                                    "variable": "Analog Input 10",
+                                }
+                            ],
+                            "units": "Torr",
+                        }
+                    ]
+                }
+            )

--- a/GeecsCAGateway/CHANGELOG.md
+++ b/GeecsCAGateway/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to `geecs-ca-gateway` are documented here, following
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and semantic versioning.
 
+## [0.8.0] - 2026-07-08
+
+### Added
+
+- Derived numeric channels loaded from a `geecs-schemas` YAML/JSON overlay via
+  `--derived-channels PATH`. Each entry declares a read-only float PV computed
+  from a restricted arithmetic expression over one source device's numeric
+  push-frame values. This initial implementation is same-source-device only,
+  so examples like a Convectron pressure PV derived from one DAQ analog input
+  are frame-coherent without introducing cross-device latest-value semantics.
+
 ## [0.7.0] - 2026-07-08
 
 ### Added

--- a/GeecsCAGateway/CHANGELOG.md
+++ b/GeecsCAGateway/CHANGELOG.md
@@ -16,6 +16,12 @@ All notable changes to `geecs-ca-gateway` are documented here, following
   implementation is same-source-device only, so examples like a Convectron
   pressure PV derived from one DAQ analog input are frame-coherent without
   introducing cross-device latest-value semantics.
+- Derived PVs report operator-visible failure states: `INVALID/UDF` until first
+  successful compute or while inputs are missing/non-numeric, `INVALID/CALC` on
+  expression runtime failure, and `INVALID/COMM` when the source device
+  disconnects. Repeated identical INVALID failures publish only the transition;
+  the next successful compute clears severity even if the numeric value is
+  unchanged.
 
 ## [0.7.0] - 2026-07-08
 

--- a/GeecsCAGateway/CHANGELOG.md
+++ b/GeecsCAGateway/CHANGELOG.md
@@ -7,12 +7,15 @@ All notable changes to `geecs-ca-gateway` are documented here, following
 
 ### Added
 
-- Derived numeric channels loaded from a `geecs-schemas` YAML/JSON overlay via
-  `--derived-channels PATH`. Each entry declares a read-only float PV computed
-  from a restricted arithmetic expression over one source device's numeric
-  push-frame values. This initial implementation is same-source-device only,
-  so examples like a Convectron pressure PV derived from one DAQ analog input
-  are frame-coherent without introducing cross-device latest-value semantics.
+- Derived numeric channels loaded from a `geecs-schemas` YAML/JSON overlay.
+  The gateway auto-loads the configs-repo convention
+  `scanner_configs/experiments/<Experiment>/gateway/derived_channels.yaml`
+  when present, with `--derived-channels PATH` as an explicit override. Each
+  entry declares a read-only float PV computed from a restricted arithmetic
+  expression over one source device's numeric push-frame values. This initial
+  implementation is same-source-device only, so examples like a Convectron
+  pressure PV derived from one DAQ analog input are frame-coherent without
+  introducing cross-device latest-value semantics.
 
 ## [0.7.0] - 2026-07-08
 

--- a/GeecsCAGateway/CLAUDE.md
+++ b/GeecsCAGateway/CLAUDE.md
@@ -67,8 +67,10 @@ geecs_ca_gateway/
 Dependency direction: **GeecsBluesky depends on this package, never the other
 way around**. GeecsBluesky imports the *library* parts (`GeecsDb`, `pv_naming`,
 exceptions, `FakeGeecsServer`) and consumes the *service* (the PVs, via stock
-ophyd-async EPICS signals). The gateway env is deliberately slim: caproto +
-pydantic + mysql-connector — no ophyd/bluesky/pandas.
+ophyd-async EPICS signals). The gateway also imports `geecs-schemas` for
+schema-validated derived-channel overlay files. The gateway env is deliberately
+slim: caproto + pydantic + geecs-schemas + mysql-connector + PyYAML — no
+ophyd/bluesky/pandas.
 
 ## Architecture
 

--- a/GeecsCAGateway/DEPLOYMENT.md
+++ b/GeecsCAGateway/DEPLOYMENT.md
@@ -25,7 +25,7 @@ Actual CLI flags (`geecs_ca_gateway/__main__.py`):
 | `--all-variables` | off | Expose every device variable, not just the `get='yes'` monitoring set |
 | `--no-settable` | off | Do *not* add settable (control-surface) variables to the subscribed set |
 | `--include-disabled` | off | Include devices not `enabled` in the experiment |
-| `--derived-channels PATH` | unset | Load a geecs-schemas YAML/JSON derived-channel overlay and expose computed read-only numeric PVs |
+| `--derived-channels PATH` | configs-repo convention if present | Load a geecs-schemas YAML/JSON derived-channel overlay and expose computed read-only numeric PVs |
 | `--show-missing` | off | Keep the transport's "missing variable(s)" notices (quiet by default — subscribed-but-idle variables are normal for monitoring) |
 | `--log-level LEVEL` | `INFO` | Python logging level |
 
@@ -49,9 +49,20 @@ The gateway reads no config file of its own. Everything comes from:
    restart the gateway (this matches the existing master-GUI reboot pattern;
    hot reload is a later nicety).
 
-Optional derived readbacks come from a schema-validated overlay file passed by
-`--derived-channels`. The file is not a replacement for the DB; it only adds
-computed numeric PVs on top of the DB-backed raw device set:
+Optional derived readbacks come from a schema-validated overlay file in the
+configs repo. By convention, the gateway auto-loads:
+
+```text
+GEECS-Plugins-Configs/
+  scanner_configs/
+    experiments/
+      <Experiment>/
+        gateway/
+          derived_channels.yaml
+```
+
+The file is not a replacement for the DB; it only adds computed numeric PVs on
+top of the DB-backed raw device set:
 
 ```yaml
 schema_version: 1
@@ -67,9 +78,17 @@ derived_channels:
     description: "Convectron pressure from DAQ analog input 10"
 ```
 
-For the systemd service, install the file on the gateway host and add
-`--derived-channels /path/to/derived_channels.yaml` to `ExecStart`; then a
-normal restart reloads both the DB-backed raw PVs and the derived overlay.
+The configs repo root is resolved the same way as scanner configs:
+`GEECS_SCANNER_CONFIG_DIR` may point directly at
+`scanner_configs/experiments`, `GEECS_PLUGINS_CONFIGS` may point at the
+configs repo root, or `~/.config/geecs_python_api/config.ini`
+`[Paths] scanner_config_root_path` may point at the configs repo root. If the
+conventional file is absent, the gateway starts normally with no derived PVs.
+Use `--derived-channels /path/to/file.yaml` only to override the convention.
+
+For the systemd service, keep a checked-out configs repo on the gateway host
+and ensure one of those resolution paths is configured; then a normal restart
+reloads both the DB-backed raw PVs and the derived overlay.
 
 MySQL access uses the pure-Python connector (`use_pure=True`) — the C extension
 has crashed silently on the lab Windows machines.

--- a/GeecsCAGateway/DEPLOYMENT.md
+++ b/GeecsCAGateway/DEPLOYMENT.md
@@ -25,6 +25,7 @@ Actual CLI flags (`geecs_ca_gateway/__main__.py`):
 | `--all-variables` | off | Expose every device variable, not just the `get='yes'` monitoring set |
 | `--no-settable` | off | Do *not* add settable (control-surface) variables to the subscribed set |
 | `--include-disabled` | off | Include devices not `enabled` in the experiment |
+| `--derived-channels PATH` | unset | Load a geecs-schemas YAML/JSON derived-channel overlay and expose computed read-only numeric PVs |
 | `--show-missing` | off | Keep the transport's "missing variable(s)" notices (quiet by default — subscribed-but-idle variables are normal for monitoring) |
 | `--log-level LEVEL` | `INFO` | Python logging level |
 
@@ -47,6 +48,28 @@ The gateway reads no config file of its own. Everything comes from:
    endpoints, variables, types, units, limits, settability. On a DB change,
    restart the gateway (this matches the existing master-GUI reboot pattern;
    hot reload is a later nicety).
+
+Optional derived readbacks come from a schema-validated overlay file passed by
+`--derived-channels`. The file is not a replacement for the DB; it only adds
+computed numeric PVs on top of the DB-backed raw device set:
+
+```yaml
+schema_version: 1
+derived_channels:
+  - device: U_ChamberVac
+    variable: Pressure
+    expression: "10**(v - 5)"
+    inputs:
+      - symbol: v
+        device: U_DaqPad1
+        variable: "Analog Input 10"
+    egu: Torr
+    description: "Convectron pressure from DAQ analog input 10"
+```
+
+For the systemd service, install the file on the gateway host and add
+`--derived-channels /path/to/derived_channels.yaml` to `ExecStart`; then a
+normal restart reloads both the DB-backed raw PVs and the derived overlay.
 
 MySQL access uses the pure-Python connector (`use_pure=True`) — the C extension
 has crashed silently on the lab Windows machines.

--- a/GeecsCAGateway/DEPLOYMENT.md
+++ b/GeecsCAGateway/DEPLOYMENT.md
@@ -67,15 +67,16 @@ top of the DB-backed raw device set:
 ```yaml
 schema_version: 1
 derived_channels:
-  - device: U_ChamberVac
+  - device: TargetChamberPressure
     variable: Pressure
-    expression: "10**(v - 5)"
+    expression: "10**(v - 6)"
     inputs:
       - symbol: v
-        device: U_DaqPad1
-        variable: "Analog Input 10"
+        device: U_VacuumGauge
+        variable: "AI_mean.Channel 0"
     egu: Torr
-    description: "Convectron pressure from DAQ analog input 10"
+    precision: 6
+    description: "Convectron pressure from U_VacuumGauge analog input 0"
 ```
 
 The configs repo root is resolved the same way as scanner configs:
@@ -262,6 +263,9 @@ poetry run caproto-get Undulator:CAGateway:DEVICES_CONNECTED
 
 # 3. Readback streaming? (should tick with the device's ~1–5 Hz stream)
 poetry run caproto-monitor Undulator:U_S1H:Current
+
+# 3b. Derived readback loaded from the configs repo? (example: target chamber)
+poetry run caproto-get -a Undulator:TargetChamberPressure:Pressure
 
 # 4. Write path (pick a harmless settable variable; put-completion = GEECS
 #    convergence, so this blocks until the device converges)

--- a/GeecsCAGateway/PV_CONTRACT.md
+++ b/GeecsCAGateway/PV_CONTRACT.md
@@ -245,14 +245,15 @@ Example Convectron-style declaration shape:
 ```yaml
 schema_version: 1
 derived_channels:
-  - device: U_ChamberVac
+  - device: TargetChamberPressure
     variable: Pressure
-    expression: "10**(v - 5)"
+    expression: "10**(v - 6)"
     inputs:
       - symbol: v
-        device: U_DaqPad1
-        variable: "Analog Input 10"
+        device: U_VacuumGauge
+        variable: "AI_mean.Channel 0"
     egu: Torr
+    precision: 6
 ```
 
 Cross-device latest-value expressions, staleness windows, enum/string bad-state

--- a/GeecsCAGateway/PV_CONTRACT.md
+++ b/GeecsCAGateway/PV_CONTRACT.md
@@ -218,10 +218,12 @@ of scope — that is Bluesky's job, see DESIGN.md "scope boundaries".)
 
 ### Derived numeric channels
 
-The gateway can load a `geecs-schemas` `DerivedChannels` YAML/JSON overlay
-(`--derived-channels PATH`) that exposes additional read-only float PVs
-computed from one source device's numeric push-frame values. The v1 schema is
-intentionally narrow:
+The gateway can load a `geecs-schemas` `DerivedChannels` YAML/JSON overlay from
+the configs repo convention
+`scanner_configs/experiments/<Experiment>/gateway/derived_channels.yaml` (or an
+explicit `--derived-channels PATH` override). That overlay exposes additional
+read-only float PVs computed from one source device's numeric push-frame
+values. The v1 schema is intentionally narrow:
 
 - A derived channel has one output PV (`device`, `variable`, optional
   `experiment`/`pv` override) and one arithmetic expression.

--- a/GeecsCAGateway/PV_CONTRACT.md
+++ b/GeecsCAGateway/PV_CONTRACT.md
@@ -256,6 +256,22 @@ derived_channels:
     precision: 6
 ```
 
+Derived PV alarm states differ intentionally from raw float readbacks before
+first data: a derived output starts at `INVALID_ALARM`/`UDF` until its first
+successful computation, rather than serving a valid-looking `0.0` placeholder.
+Once live, successful computations write `NO_ALARM`. Failure modes are:
+
+| Condition | Derived PV severity / status |
+|---|---|
+| Never successfully computed, missing/empty input, or non-numeric input | `INVALID_ALARM` / `UDF` |
+| Expression runtime failure, such as division by zero | `INVALID_ALARM` / `CALC` |
+| Source device TCP subscription dropped / unreachable | `INVALID_ALARM` / `COMM` |
+| Recovery after any failure | Next successful computation writes `NO_ALARM` even when the numeric value is unchanged |
+
+Repeated failures with the same INVALID status do not re-publish on every
+source frame; the gateway publishes the transition and keeps the PV invalid
+until a successful computation clears it.
+
 Cross-device latest-value expressions, staleness windows, enum/string bad-state
 expressions, and shot-synchronized analysis products are outside v1.
 
@@ -492,6 +508,7 @@ that branch and are part of this contract's target behavior.
 | Derived-channel manifest kind and numeric output PV metadata | `test_derived_channels.py::test_derived_pvdb_has_numeric_readback_and_manifest` |
 | Derived-channel expression subset and same-source-device v1 rule | `test_derived_channels.py::test_expression_evaluator_supports_convectron_formula`, `::test_expression_evaluator_rejects_non_numeric_python`, `::test_derived_channel_schema_is_single_source_device_v1` |
 | Derived values evaluate from one source frame; derived-only inputs are subscribed without raw PVs | `test_derived_channels.py::test_derived_channel_updates_from_same_source_frame`, `::test_derived_only_input_is_subscribed_without_raw_pv` |
+| Derived alarm states: initial/missing input UDF, expression failure CALC, reconnect recovery with unchanged value, repeated INVALID transition-only | `test_derived_channels.py::test_derived_pvdb_has_numeric_readback_and_manifest`, `::test_missing_derived_input_marks_invalid_udf`, `::test_derived_expression_failure_marks_invalid_calc`, `::test_derived_reconnect_clears_invalid_even_when_value_unchanged`, `::test_repeated_derived_failure_does_not_republish_invalid` |
 | DB type mapping, descriptors, enum degradation, blank-type inference | `test_config_from_db.py::test_from_db_metadata_maps_variable_types`, `::test_choice_pointing_at_type_descriptor_is_skipped`, `::test_blank_variabletype_inferred_from_choices`, `::test_choice_without_options_falls_back_to_string`, `::test_choice_exceeding_ca_enum_limits_falls_back_to_string` |
 | Long-string path PVs (>40 chars round-trip both directions) | `test_channels.py::test_cast_path_decodes_char_arrays`, `::test_path_readback_holds_long_string`, `::test_path_setpoint_forwards_full_text` |
 | Enum label↔index both directions over the gateway | `test_channels.py::test_enum_index_maps_label_to_index`, `::test_enum_geecs_value_index_and_label`; `test_gateway.py::test_enum_readback_and_setpoint` |

--- a/GeecsCAGateway/PV_CONTRACT.md
+++ b/GeecsCAGateway/PV_CONTRACT.md
@@ -25,6 +25,7 @@ in `DEPLOYMENT.md`.
 ```
 [Experiment:]Device:Variable          readback
 [Experiment:]Device:Variable:SP       setpoint (only when the variable is settable)
+[Experiment:]Device:Variable          derived readback (when declared)
 [Experiment:]Device:CONNECTED         per-device status
 [Experiment:]CAGateway:<SUFFIX>       gateway self-diagnostics
 ```
@@ -71,8 +72,9 @@ sides can never drift. `geecs_ca_gateway.naming` is a thin re-export.
 `Trigger.Source` and `Trigger Source` normalize to the same PV component.
 **Never reverse-engineer a GEECS name from a PV string.** The gateway holds the
 authoritative bidirectional map in `GeecsCaGateway.manifest`
-(`PV → (device, geecs_var, kind)` where kind is `"readback"`, `"setpoint"`, or
-`"status"`).
+(`PV → (device, geecs_var, kind)` where kind is `"readback"`, `"setpoint"`,
+`"derived"`, or `"status"`). For derived PVs, the manifest device is the
+source GEECS device whose frame drives the calculation.
 
 ### Setpoint PVs — `:SP`
 
@@ -213,6 +215,46 @@ payload order is preserved (the reorder is a stable sort on
 Clients must therefore trigger/latch on the timestamp PVs, not on a data PV,
 when they need whole-frame consistency. (Cross-*device* correlation remains out
 of scope — that is Bluesky's job, see DESIGN.md "scope boundaries".)
+
+### Derived numeric channels
+
+The gateway can load a `geecs-schemas` `DerivedChannels` YAML/JSON overlay
+(`--derived-channels PATH`) that exposes additional read-only float PVs
+computed from one source device's numeric push-frame values. The v1 schema is
+intentionally narrow:
+
+- A derived channel has one output PV (`device`, `variable`, optional
+  `experiment`/`pv` override) and one arithmetic expression.
+- Inputs bind expression symbols to `(device, variable)` sources, but **all
+  inputs must come from the same source device**. The gateway evaluates the
+  expression once per source frame, after raw data PVs are posted and before
+  that frame's timestamp PVs are posted. Therefore a client latching on the
+  source device's timestamp observes raw and derived values from the same
+  completed frame.
+- The expression subset is numeric arithmetic only: literals, input symbols,
+  `+ - * / % **`, unary `+/-`, and a small whitelist of `math` functions such
+  as `sqrt`, `exp`, `log`, and `log10`. Arbitrary Python, attributes,
+  indexing, comparisons, and conditionals are rejected during gateway startup.
+- Inputs may be subscribed solely for the calculation; they do not need to be
+  exposed as their own readback PVs.
+
+Example Convectron-style declaration shape:
+
+```yaml
+schema_version: 1
+derived_channels:
+  - device: U_ChamberVac
+    variable: Pressure
+    expression: "10**(v - 5)"
+    inputs:
+      - symbol: v
+        device: U_DaqPad1
+        variable: "Analog Input 10"
+    egu: Torr
+```
+
+Cross-device latest-value expressions, staleness windows, enum/string bad-state
+expressions, and shot-synchronized analysis products are outside v1.
 
 ---
 
@@ -444,6 +486,9 @@ that branch and are part of this contract's target behavior.
 | PV stamped with device time; timestamp PVs carry raw LabVIEW value | `test_gateway.py::test_pv_timestamp_from_systimestamp`, `::test_timestamp_vars_exposed_as_pvs_with_raw_value` |
 | `0.0` pre-acquisition placeholder | `test_pv_contract.py::test_float_readback_initializes_to_zero_placeholder` |
 | Frame ordering: data before timestamps *(PR #452)* | `test_gateway.py::test_callback_posts_timestamp_variables_last` |
+| Derived-channel manifest kind and numeric output PV metadata | `test_derived_channels.py::test_derived_pvdb_has_numeric_readback_and_manifest` |
+| Derived-channel expression subset and same-source-device v1 rule | `test_derived_channels.py::test_expression_evaluator_supports_convectron_formula`, `::test_expression_evaluator_rejects_non_numeric_python`, `::test_derived_channel_schema_is_single_source_device_v1` |
+| Derived values evaluate from one source frame; derived-only inputs are subscribed without raw PVs | `test_derived_channels.py::test_derived_channel_updates_from_same_source_frame`, `::test_derived_only_input_is_subscribed_without_raw_pv` |
 | DB type mapping, descriptors, enum degradation, blank-type inference | `test_config_from_db.py::test_from_db_metadata_maps_variable_types`, `::test_choice_pointing_at_type_descriptor_is_skipped`, `::test_blank_variabletype_inferred_from_choices`, `::test_choice_without_options_falls_back_to_string`, `::test_choice_exceeding_ca_enum_limits_falls_back_to_string` |
 | Long-string path PVs (>40 chars round-trip both directions) | `test_channels.py::test_cast_path_decodes_char_arrays`, `::test_path_readback_holds_long_string`, `::test_path_setpoint_forwards_full_text` |
 | Enum label↔index both directions over the gateway | `test_channels.py::test_enum_index_maps_label_to_index`, `::test_enum_geecs_value_index_and_label`; `test_gateway.py::test_enum_readback_and_setpoint` |

--- a/GeecsCAGateway/deploy/README.md
+++ b/GeecsCAGateway/deploy/README.md
@@ -95,7 +95,8 @@ DB-backed config.
 ## Changing what is served
 
 Edit `ExecStart` in the unit (`--all-variables`, `--no-settable`,
-`--include-disabled`, a different `--experiment`), then
+`--include-disabled`, `--derived-channels /path/to/derived_channels.yaml`, a
+different `--experiment`), then
 `sudo systemctl daemon-reload && sudo systemctl restart geecs-ca-gateway`.
 Serving a second experiment = a second copy of the unit with a different name
 and `--experiment`; CA name resolution makes the split invisible to clients.

--- a/GeecsCAGateway/deploy/README.md
+++ b/GeecsCAGateway/deploy/README.md
@@ -95,8 +95,15 @@ DB-backed config.
 ## Changing what is served
 
 Edit `ExecStart` in the unit (`--all-variables`, `--no-settable`,
-`--include-disabled`, `--derived-channels /path/to/derived_channels.yaml`, a
-different `--experiment`), then
+`--include-disabled`, an explicit `--derived-channels /path/to/file.yaml`
+override, a different `--experiment`), then
 `sudo systemctl daemon-reload && sudo systemctl restart geecs-ca-gateway`.
 Serving a second experiment = a second copy of the unit with a different name
 and `--experiment`; CA name resolution makes the split invisible to clients.
+
+Derived channels normally do not require an `ExecStart` edit: put
+`derived_channels.yaml` under
+`GEECS-Plugins-Configs/scanner_configs/experiments/<Experiment>/gateway/` and
+restart the gateway. The service discovers that file through
+`GEECS_SCANNER_CONFIG_DIR`, `GEECS_PLUGINS_CONFIGS`, or
+`config.ini [Paths] scanner_config_root_path`.

--- a/GeecsCAGateway/geecs_ca_gateway/__main__.py
+++ b/GeecsCAGateway/geecs_ca_gateway/__main__.py
@@ -20,7 +20,7 @@ import logging
 from pathlib import Path
 
 from .config import GatewayConfig
-from .derived import load_derived_channels
+from .derived import default_derived_channels_path, load_derived_channels
 from .gateway import GeecsCaGateway
 
 logger = logging.getLogger("geecs_ca_gateway")
@@ -78,8 +78,9 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         type=Path,
         help=(
             "YAML/JSON derived-channel overlay validated by geecs-schemas. "
-            "The file adds read-only computed numeric PVs on top of the DB "
-            "device set."
+            "Defaults to the configs-repo convention "
+            "scanner_configs/experiments/<experiment>/gateway/"
+            "derived_channels.yaml when that file exists."
         ),
     )
     parser.add_argument(
@@ -110,11 +111,15 @@ async def _run(
         include_settable=include_settable,
     )
     if derived_channels_path is not None:
-        config.derived_channels = load_derived_channels(derived_channels_path)
+        path = derived_channels_path
+    else:
+        path = default_derived_channels_path(experiment)
+    if path is not None:
+        config.derived_channels = load_derived_channels(path)
         logger.info(
             "loaded %d derived channel(s) from %s",
             len(config.derived_channels),
-            derived_channels_path,
+            path,
         )
     gateway = GeecsCaGateway(config)
     logger.info(

--- a/GeecsCAGateway/geecs_ca_gateway/__main__.py
+++ b/GeecsCAGateway/geecs_ca_gateway/__main__.py
@@ -17,8 +17,10 @@ from __future__ import annotations
 import argparse
 import asyncio
 import logging
+from pathlib import Path
 
 from .config import GatewayConfig
+from .derived import load_derived_channels
 from .gateway import GeecsCaGateway
 
 logger = logging.getLogger("geecs_ca_gateway")
@@ -72,6 +74,15 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         help="Include devices not enabled in the experiment.",
     )
     parser.add_argument(
+        "--derived-channels",
+        type=Path,
+        help=(
+            "YAML/JSON derived-channel overlay validated by geecs-schemas. "
+            "The file adds read-only computed numeric PVs on top of the DB "
+            "device set."
+        ),
+    )
+    parser.add_argument(
         "--show-missing",
         action="store_true",
         help="Log the transport's 'missing variable(s)' notices (quiet by default).",
@@ -90,6 +101,7 @@ async def _run(
     subscribed_only: bool,
     enabled_only: bool,
     include_settable: bool,
+    derived_channels_path: Path | None = None,
 ) -> bool:
     config = GatewayConfig.from_geecs_experiment(
         experiment,
@@ -97,6 +109,13 @@ async def _run(
         enabled_only=enabled_only,
         include_settable=include_settable,
     )
+    if derived_channels_path is not None:
+        config.derived_channels = load_derived_channels(derived_channels_path)
+        logger.info(
+            "loaded %d derived channel(s) from %s",
+            len(config.derived_channels),
+            derived_channels_path,
+        )
     gateway = GeecsCaGateway(config)
     logger.info(
         "serving %d PV(s) across %d device(s) for experiment %r",
@@ -126,6 +145,7 @@ def main(argv: list[str] | None = None) -> None:
                 subscribed_only=not args.all_variables,
                 enabled_only=not args.include_disabled,
                 include_settable=not args.no_settable,
+                derived_channels_path=args.derived_channels,
             )
         )
     except KeyboardInterrupt:

--- a/GeecsCAGateway/geecs_ca_gateway/channels.py
+++ b/GeecsCAGateway/geecs_ca_gateway/channels.py
@@ -20,6 +20,9 @@ from typing import Any, Awaitable, Callable
 
 from caproto import (
     AccessRights,
+    AlarmSeverity,
+    AlarmStatus,
+    ChannelAlarm,
     ChannelChar,
     ChannelData,
     ChannelDouble,
@@ -228,9 +231,19 @@ def _initial(dtype: DType) -> Any:
     return ""
 
 
-def _metadata_kwargs(spec: VariableSpec) -> dict[str, Any]:
+def _metadata_kwargs(
+    spec: VariableSpec,
+    *,
+    initial_severity: AlarmSeverity | None = None,
+    initial_status: AlarmStatus | None = None,
+) -> dict[str, Any]:
     """Caproto kwargs (value + EGU/precision/limits) for a scalar channel."""
     kwargs: dict[str, Any] = {"value": _initial(spec.dtype)}
+    if initial_severity is not None or initial_status is not None:
+        kwargs["alarm"] = ChannelAlarm(
+            severity=initial_severity or AlarmSeverity.NO_ALARM,
+            status=initial_status or AlarmStatus.NO_ALARM,
+        )
     if spec.dtype == "float":
         kwargs["precision"] = spec.precision
     if spec.dtype in ("float", "int"):
@@ -246,15 +259,40 @@ def _metadata_kwargs(spec: VariableSpec) -> dict[str, Any]:
     return kwargs
 
 
-def make_readback_channel(spec: VariableSpec) -> ChannelData:
+def make_readback_channel(
+    spec: VariableSpec,
+    *,
+    initial_severity: AlarmSeverity | None = None,
+    initial_status: AlarmStatus | None = None,
+) -> ChannelData:
     """Build a client-read-only channel populated by the subscription stream."""
     if spec.dtype == "enum":
-        return read_only(ChannelEnum)(value=0, enum_strings=list(spec.choices))
+        kwargs: dict[str, Any] = {"value": 0, "enum_strings": list(spec.choices)}
+        if initial_severity is not None or initial_status is not None:
+            kwargs["alarm"] = ChannelAlarm(
+                severity=initial_severity or AlarmSeverity.NO_ALARM,
+                status=initial_status or AlarmStatus.NO_ALARM,
+            )
+        return read_only(ChannelEnum)(**kwargs)
     if spec.dtype == "path":
-        return read_only(ChannelChar)(
-            value="", string_encoding="utf-8", max_length=_PATH_MAX_LENGTH
+        kwargs = {
+            "value": "",
+            "string_encoding": "utf-8",
+            "max_length": _PATH_MAX_LENGTH,
+        }
+        if initial_severity is not None or initial_status is not None:
+            kwargs["alarm"] = ChannelAlarm(
+                severity=initial_severity or AlarmSeverity.NO_ALARM,
+                status=initial_status or AlarmStatus.NO_ALARM,
+            )
+        return read_only(ChannelChar)(**kwargs)
+    return read_only(_SCALAR_BASE[spec.dtype])(
+        **_metadata_kwargs(
+            spec,
+            initial_severity=initial_severity,
+            initial_status=initial_status,
         )
-    return read_only(_SCALAR_BASE[spec.dtype])(**_metadata_kwargs(spec))
+    )
 
 
 def make_setpoint_channel(spec: VariableSpec, setter: Setter) -> ChannelData:

--- a/GeecsCAGateway/geecs_ca_gateway/config.py
+++ b/GeecsCAGateway/geecs_ca_gateway/config.py
@@ -14,6 +14,7 @@ from typing import Literal
 from pydantic import BaseModel, Field
 
 from .alarms import AlarmLimits
+from .derived import DerivedChannelSpec
 from .naming import normalize_pv_component
 
 logger = logging.getLogger(__name__)
@@ -297,6 +298,7 @@ class GatewayConfig(BaseModel):
     """Top-level gateway configuration: the set of devices to serve."""
 
     devices: list[DeviceSpec] = Field(default_factory=list)
+    derived_channels: list[DerivedChannelSpec] = Field(default_factory=list)
 
     @classmethod
     def from_geecs_experiment(

--- a/GeecsCAGateway/geecs_ca_gateway/derived.py
+++ b/GeecsCAGateway/geecs_ca_gateway/derived.py
@@ -1,0 +1,147 @@
+"""Derived numeric channel loading and expression evaluation."""
+
+from __future__ import annotations
+
+import ast
+import json
+import math
+from pathlib import Path
+from typing import Any
+
+from geecs_schemas import (
+    DerivedChannel as DerivedChannelSpec,
+    DerivedChannels,
+    DerivedInput as DerivedInputSpec,
+)
+
+from .naming import normalize_pv_component
+
+_ALLOWED_FUNCS = {
+    name: getattr(math, name)
+    for name in (
+        "acos",
+        "asin",
+        "atan",
+        "cos",
+        "exp",
+        "isfinite",
+        "log",
+        "log10",
+        "sin",
+        "sqrt",
+        "tan",
+    )
+}
+_ALLOWED_CONSTS = {"e": math.e, "pi": math.pi, "tau": math.tau}
+_RESERVED_NAMES = set(_ALLOWED_FUNCS) | set(_ALLOWED_CONSTS)
+_ALLOWED_BINOPS = (ast.Add, ast.Sub, ast.Mult, ast.Div, ast.Pow, ast.Mod)
+_ALLOWED_UNARYOPS = (ast.UAdd, ast.USub)
+
+__all__ = [
+    "DerivedChannelSpec",
+    "DerivedChannels",
+    "DerivedExpressionError",
+    "DerivedInputSpec",
+    "ExpressionEvaluator",
+    "derived_pv_name",
+    "load_derived_channels",
+]
+
+
+class DerivedExpressionError(ValueError):
+    """Raised when a derived-channel expression is outside the supported subset."""
+
+
+def derived_pv_name(
+    spec: DerivedChannelSpec, default_experiment: str | None = None
+) -> str:
+    """Return the full output PV name for a derived-channel declaration."""
+    parts: list[str] = []
+    experiment = spec.experiment or default_experiment
+    if experiment:
+        parts.append(normalize_pv_component(experiment))
+    parts.append(normalize_pv_component(spec.device))
+    parts.append(normalize_pv_component(spec.pv or spec.variable))
+    return ":".join(parts)
+
+
+def load_derived_channels(path: str | Path) -> list[DerivedChannelSpec]:
+    """Load a YAML or JSON derived-channel document from *path*."""
+    config_path = Path(path)
+    if config_path.suffix.lower() == ".json":
+        data = json.loads(config_path.read_text(encoding="utf-8"))
+    else:
+        try:
+            import yaml
+        except ImportError as exc:
+            raise ImportError(
+                "PyYAML is required to load derived-channel YAML files. "
+                "Install the GeecsCAGateway package dependencies."
+            ) from exc
+        data = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    document = DerivedChannels.model_validate(data or {})
+    return list(document.derived_channels)
+
+
+class ExpressionEvaluator:
+    """Compile and evaluate a restricted numeric expression."""
+
+    def __init__(self, expression: str, symbols: set[str]) -> None:
+        self.expression = expression
+        self.symbols = symbols
+        try:
+            tree = ast.parse(expression, mode="eval")
+        except SyntaxError as exc:
+            raise DerivedExpressionError(str(exc)) from exc
+        self._validate_node(tree)
+        self._code = compile(tree, "<derived-channel>", "eval")
+
+    def evaluate(self, values: dict[str, float]) -> float:
+        """Evaluate the expression with numeric input values."""
+        missing = self.symbols - values.keys()
+        if missing:
+            raise KeyError(f"missing derived-channel input(s): {sorted(missing)}")
+        namespace: dict[str, Any] = {}
+        namespace.update(_ALLOWED_FUNCS)
+        namespace.update(_ALLOWED_CONSTS)
+        namespace.update(values)
+        result = eval(self._code, {"__builtins__": {}}, namespace)  # noqa: S307
+        return float(result)
+
+    def _validate_node(self, node: ast.AST) -> None:
+        if isinstance(node, ast.Expression):
+            self._validate_node(node.body)
+            return
+        if isinstance(node, ast.Constant):
+            if not isinstance(node.value, (int, float)):
+                raise DerivedExpressionError("only numeric constants are allowed")
+            return
+        if isinstance(node, ast.Name):
+            if node.id not in self.symbols and node.id not in _RESERVED_NAMES:
+                raise DerivedExpressionError(f"unknown name in expression: {node.id}")
+            return
+        if isinstance(node, ast.BinOp):
+            if not isinstance(node.op, _ALLOWED_BINOPS):
+                raise DerivedExpressionError("unsupported binary operator")
+            self._validate_node(node.left)
+            self._validate_node(node.right)
+            return
+        if isinstance(node, ast.UnaryOp):
+            if not isinstance(node.op, _ALLOWED_UNARYOPS):
+                raise DerivedExpressionError("unsupported unary operator")
+            self._validate_node(node.operand)
+            return
+        if isinstance(node, ast.Call):
+            if (
+                not isinstance(node.func, ast.Name)
+                or node.func.id not in _ALLOWED_FUNCS
+            ):
+                raise DerivedExpressionError("only whitelisted math calls are allowed")
+            if node.keywords:
+                raise DerivedExpressionError("keyword arguments are not allowed")
+            for arg in node.args:
+                self._validate_node(arg)
+            return
+        raise DerivedExpressionError(
+            f"unsupported expression element: {type(node).__name__}"
+        )

--- a/GeecsCAGateway/geecs_ca_gateway/derived.py
+++ b/GeecsCAGateway/geecs_ca_gateway/derived.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 import ast
+import configparser
 import json
 import math
+import os
 from pathlib import Path
 from typing import Any
 
@@ -36,6 +38,8 @@ _ALLOWED_CONSTS = {"e": math.e, "pi": math.pi, "tau": math.tau}
 _RESERVED_NAMES = set(_ALLOWED_FUNCS) | set(_ALLOWED_CONSTS)
 _ALLOWED_BINOPS = (ast.Add, ast.Sub, ast.Mult, ast.Div, ast.Pow, ast.Mod)
 _ALLOWED_UNARYOPS = (ast.UAdd, ast.USub)
+GATEWAY_CONFIG_FOLDER = "gateway"
+DERIVED_CHANNELS_FILENAME = "derived_channels.yaml"
 
 __all__ = [
     "DerivedChannelSpec",
@@ -43,8 +47,10 @@ __all__ = [
     "DerivedExpressionError",
     "DerivedInputSpec",
     "ExpressionEvaluator",
+    "default_derived_channels_path",
     "derived_pv_name",
     "load_derived_channels",
+    "scanner_configs_base",
 ]
 
 
@@ -81,6 +87,43 @@ def load_derived_channels(path: str | Path) -> list[DerivedChannelSpec]:
         data = yaml.safe_load(config_path.read_text(encoding="utf-8"))
     document = DerivedChannels.model_validate(data or {})
     return list(document.derived_channels)
+
+
+def scanner_configs_base() -> Path | None:
+    """Resolve the configs repo ``scanner_configs/experiments`` base if known.
+
+    Resolution mirrors the scanner/Bluesky production path without importing
+    either package:
+
+    1. ``GEECS_SCANNER_CONFIG_DIR`` points directly at
+       ``scanner_configs/experiments``.
+    2. ``GEECS_PLUGINS_CONFIGS`` points at the configs repo root.
+    3. ``~/.config/geecs_python_api/config.ini`` has
+       ``[Paths] scanner_config_root_path`` pointing at the configs repo root.
+    """
+    env = os.environ.get("GEECS_SCANNER_CONFIG_DIR")
+    if env:
+        return Path(env).expanduser().resolve()
+    repo_env = os.environ.get("GEECS_PLUGINS_CONFIGS")
+    if repo_env:
+        return Path(repo_env).expanduser().resolve() / "scanner_configs" / "experiments"
+    config_ini = Path("~/.config/geecs_python_api/config.ini").expanduser()
+    if config_ini.exists():
+        parser = configparser.ConfigParser()
+        parser.read(config_ini)
+        root = parser.get("Paths", "scanner_config_root_path", fallback=None)
+        if root:
+            return Path(root).expanduser().resolve() / "scanner_configs" / "experiments"
+    return None
+
+
+def default_derived_channels_path(experiment: str) -> Path | None:
+    """Return the conventional configs-repo derived-channel file, if present."""
+    base = scanner_configs_base()
+    if base is None:
+        return None
+    path = base / experiment / GATEWAY_CONFIG_FOLDER / DERIVED_CHANNELS_FILENAME
+    return path if path.exists() else None
 
 
 class ExpressionEvaluator:

--- a/GeecsCAGateway/geecs_ca_gateway/derived.py
+++ b/GeecsCAGateway/geecs_ca_gateway/derived.py
@@ -74,18 +74,21 @@ def derived_pv_name(
 def load_derived_channels(path: str | Path) -> list[DerivedChannelSpec]:
     """Load a YAML or JSON derived-channel document from *path*."""
     config_path = Path(path)
-    if config_path.suffix.lower() == ".json":
-        data = json.loads(config_path.read_text(encoding="utf-8"))
-    else:
-        try:
-            import yaml
-        except ImportError as exc:
-            raise ImportError(
-                "PyYAML is required to load derived-channel YAML files. "
-                "Install the GeecsCAGateway package dependencies."
-            ) from exc
-        data = yaml.safe_load(config_path.read_text(encoding="utf-8"))
-    document = DerivedChannels.model_validate(data or {})
+    try:
+        if config_path.suffix.lower() == ".json":
+            data = json.loads(config_path.read_text(encoding="utf-8"))
+        else:
+            try:
+                import yaml
+            except ImportError as exc:
+                raise ImportError(
+                    "PyYAML is required to load derived-channel YAML files. "
+                    "Install the GeecsCAGateway package dependencies."
+                ) from exc
+            data = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+        document = DerivedChannels.model_validate(data or {})
+    except Exception as exc:
+        raise ValueError(f"failed to load derived channels from {config_path}") from exc
     return list(document.derived_channels)
 
 

--- a/GeecsCAGateway/geecs_ca_gateway/gateway.py
+++ b/GeecsCAGateway/geecs_ca_gateway/gateway.py
@@ -515,6 +515,8 @@ class GeecsCaGateway:
     ) -> None:
         """Mark a derived PV invalid and clear its deadband cache."""
         self._derived_last_written.pop(pv, None)
+        if channel.severity == AlarmSeverity.INVALID_ALARM and channel.status == status:
+            return
         try:
             await channel.write(
                 channel.value,

--- a/GeecsCAGateway/geecs_ca_gateway/gateway.py
+++ b/GeecsCAGateway/geecs_ca_gateway/gateway.py
@@ -42,8 +42,9 @@ from .channels import (
     make_setpoint_channel,
     read_only,
 )
-from .pv_naming import pv_name
 from .config import GatewayConfig, VariableSpec
+from .derived import DerivedChannelSpec, ExpressionEvaluator, derived_pv_name
+from .pv_naming import pv_name
 
 logger = logging.getLogger(__name__)
 
@@ -168,6 +169,12 @@ class GeecsCaGateway:
         self._restart_requested = asyncio.Event()
         # device name -> {geecs_var -> (readback channel, variable spec)}
         self._readbacks: dict[str, dict[str, tuple[ChannelData, VariableSpec]]] = {}
+        # source device -> derived channel specs evaluated from that device's frame
+        self._derived_by_source: dict[
+            str, list[tuple[DerivedChannelSpec, ChannelData, ExpressionEvaluator, str]]
+        ] = {}
+        # full derived PV name -> last value written, for deadband suppression
+        self._derived_last_written: dict[str, Any] = {}
         self._build_pvdb()
 
     # ------------------------------------------------------------------
@@ -218,7 +225,46 @@ class GeecsCaGateway:
                 self.pvdb[conn_pv] = conn
                 self._connected[dev.name] = conn
 
+        self._build_derived_pvs()
         self._build_gateway_status_pvs()
+
+    def _default_experiment(self) -> str | None:
+        """Return the first configured experiment prefix, if any."""
+        return next((d.experiment for d in self.config.devices if d.experiment), None)
+
+    def _build_derived_pvs(self) -> None:
+        """Build read-only PVs for configured derived channels."""
+        if not self.config.derived_channels:
+            return
+        source_devices = {dev.name for dev in self.config.devices}
+        default_experiment = self._default_experiment()
+        for spec in self.config.derived_channels:
+            if spec.source_device not in source_devices:
+                raise ValueError(
+                    f"Derived channel {spec.device}:{spec.variable} references "
+                    f"unknown source device {spec.source_device!r}"
+                )
+            full = derived_pv_name(spec, default_experiment)
+            if not self._register(full, spec.source_device, spec.variable, "derived"):
+                continue
+            var_spec = VariableSpec(
+                geecs_var=spec.variable,
+                pv=spec.pv,
+                dtype="float",
+                egu=spec.egu,
+                precision=spec.precision,
+                lo=spec.lo,
+                hi=spec.hi,
+                deadband=spec.deadband,
+            )
+            channel = make_readback_channel(var_spec)
+            self.pvdb[full] = channel
+            evaluator = ExpressionEvaluator(
+                spec.expression, {inp.symbol for inp in spec.inputs}
+            )
+            self._derived_by_source.setdefault(spec.source_device, []).append(
+                (spec, channel, evaluator, full)
+            )
 
     def _build_gateway_status_pvs(self) -> None:
         """Expose gateway self-diagnostics under ``[Experiment:]CAGateway:*``."""
@@ -321,6 +367,136 @@ class GeecsCaGateway:
             "status": _ALARM_STATUS[evaluation.level],
         }
 
+    async def _write_stream_value(
+        self,
+        device_name: str,
+        var: str,
+        raw: Any,
+        channel: ChannelData,
+        spec: VariableSpec,
+        extra: dict[str, Any],
+    ) -> None:
+        """Cast and write one raw stream value into its readback PV."""
+        if (
+            spec.dtype in ("float", "int", "enum")
+            and isinstance(raw, str)
+            and not raw.strip()
+        ):
+            # Devices push '' for numeric/enum values they haven't computed yet
+            # (camera analysis fields before the first acquisition, idle devices'
+            # whole frames). Not a type mismatch — skip quietly and leave the PV
+            # at its previous/placeholder value until real data arrives.
+            # (string/path dtypes are exempt: '' is a legitimate value there,
+            # e.g. a cleared save path.)
+            logger.debug("%s: %s is empty (no value yet); skipping", device_name, var)
+            return
+        try:
+            if spec.dtype == "enum":
+                value = enum_index(spec.choices, raw)
+                if value is None:
+                    self._warn_once(
+                        device_name,
+                        var,
+                        f"{device_name}: {var}={raw!r} not in enum choices "
+                        f"{spec.choices}; ignoring (DB choice mismatch?)",
+                    )
+                    return
+            else:
+                value = cast_value(spec.dtype, raw)
+        except (ValueError, TypeError):
+            self._warn_once(
+                device_name,
+                var,
+                f"{device_name}: {var}={raw!r} is not a {spec.dtype} "
+                f"(likely a DB variabletype mismatch); ignoring this variable",
+            )
+            return
+
+        # Deadband / change suppression: don't re-post an unchanged value
+        # (floats within the deadband). Keeps CA + archiver traffic to real
+        # changes; a static device costs nothing.
+        last_map = self._last_written.setdefault(device_name, {})
+        prev = last_map.get(var, _UNSET)
+        if prev is not _UNSET:
+            if spec.dtype == "float":
+                both_nan = math.isnan(value) and math.isnan(prev)
+                if both_nan or abs(value - prev) <= spec.deadband:
+                    return
+            elif value == prev:
+                return
+        last_map[var] = value
+        try:
+            # Curated value-alarm severity rides the live write (device
+            # disconnect/stale INVALID is handled separately by
+            # _mark_device_invalid). verify_value is disabled only when we
+            # supply alarm state, so caproto's native limit evaluation never
+            # fights the overlay (the single-evaluator contract).
+            alarm_kwargs = self._alarm_write_kwargs(device_name, var, spec, value)
+            await channel.write(
+                value,
+                **extra,
+                **alarm_kwargs,
+                verify_value=not bool(alarm_kwargs),
+            )
+        except Exception:
+            self._warn_once(
+                device_name,
+                var,
+                f"{device_name}: failed to write PV {var}={value!r} "
+                f"(skipping this variable)",
+            )
+
+    async def _write_derived_channels(
+        self, device_name: str, update: dict[str, Any], extra: dict[str, Any]
+    ) -> None:
+        """Evaluate derived PVs whose inputs are present in this source frame."""
+        for spec, channel, evaluator, pv in self._derived_by_source.get(
+            device_name, []
+        ):
+            values: dict[str, float] = {}
+            missing = False
+            for inp in spec.inputs:
+                raw = update.get(inp.variable, _UNSET)
+                if raw is _UNSET or (isinstance(raw, str) and not raw.strip()):
+                    missing = True
+                    break
+                try:
+                    values[inp.symbol] = float(raw)
+                except (TypeError, ValueError):
+                    self._warn_once(
+                        device_name,
+                        spec.variable,
+                        f"{device_name}: derived PV {pv} input "
+                        f"{inp.variable}={raw!r} is not numeric; skipping",
+                    )
+                    missing = True
+                    break
+            if missing:
+                continue
+            try:
+                value = evaluator.evaluate(values)
+            except Exception:
+                self._warn_once(
+                    device_name,
+                    spec.variable,
+                    f"{device_name}: derived PV {pv} expression failed; skipping",
+                )
+                continue
+            prev = self._derived_last_written.get(pv, _UNSET)
+            if prev is not _UNSET:
+                both_nan = math.isnan(value) and math.isnan(prev)
+                if both_nan or abs(value - prev) <= spec.deadband:
+                    continue
+            self._derived_last_written[pv] = value
+            try:
+                await channel.write(value, **extra)
+            except Exception:
+                self._warn_once(
+                    device_name,
+                    spec.variable,
+                    f"{device_name}: failed to write derived PV {pv}={value!r}",
+                )
+
     def _make_callback(self, dev):
         """Return the subscription callback that fans a push frame into PVs.
 
@@ -340,87 +516,35 @@ class GeecsCaGateway:
             ``acq_timestamp`` observes the completed frame.  Each PV write is
             an ``await``, so posting the shot id first would let a strict-mode
             Bluesky ``CaTriggerable`` complete its ``trigger()`` on the new
-            shot while the data PVs still hold the previous frame's values.
-            The stable sort preserves the device's payload order among the
-            data variables themselves.
+            shot while the data PVs still hold the previous frame's values. The
+            stable split preserves device payload order among data variables;
+            derived channels post after raw data and before timestamps.
             """
             timestamp = _extract_timestamp(update, ts_vars)
             extra = {"timestamp": timestamp} if timestamp is not None else {}
-            last_map = self._last_written.setdefault(device_name, {})
-            for var, raw in sorted(update.items(), key=lambda kv: kv[0] in ts_vars):
+            data_items = [
+                (var, raw) for var, raw in update.items() if var not in ts_vars
+            ]
+            timestamp_items = [
+                (var, raw) for var, raw in update.items() if var in ts_vars
+            ]
+            for var, raw in data_items:
                 entry = readback_map.get(var)
                 if entry is None:
                     continue
                 channel, spec = entry
-                if (
-                    spec.dtype in ("float", "int", "enum")
-                    and isinstance(raw, str)
-                    and not raw.strip()
-                ):
-                    # Devices push '' for numeric/enum values they haven't
-                    # computed yet (camera analysis fields before the first
-                    # acquisition, idle devices' whole frames). Not a type
-                    # mismatch — skip quietly and leave the PV at its
-                    # previous/placeholder value until real data arrives.
-                    # (string/path dtypes are exempt: '' is a legitimate
-                    # value there, e.g. a cleared save path.)
-                    logger.debug(
-                        "%s: %s is empty (no value yet); skipping",
-                        device_name,
-                        var,
-                    )
+                await self._write_stream_value(
+                    device_name, var, raw, channel, spec, extra
+                )
+            await self._write_derived_channels(device_name, update, extra)
+            for var, raw in timestamp_items:
+                entry = readback_map.get(var)
+                if entry is None:
                     continue
-                try:
-                    if spec.dtype == "enum":
-                        value = enum_index(spec.choices, raw)
-                        if value is None:
-                            self._warn_once(
-                                device_name,
-                                var,
-                                f"{device_name}: {var}={raw!r} not in enum choices "
-                                f"{spec.choices}; ignoring (DB choice mismatch?)",
-                            )
-                            continue
-                    else:
-                        value = cast_value(spec.dtype, raw)
-                except (ValueError, TypeError):
-                    self._warn_once(
-                        device_name,
-                        var,
-                        f"{device_name}: {var}={raw!r} is not a {spec.dtype} "
-                        f"(likely a DB variabletype mismatch); ignoring this variable",
-                    )
-                    continue
-
-                # Deadband / change suppression: don't re-post an unchanged value
-                # (floats within the deadband). Keeps CA + archiver traffic to
-                # real changes; a static device costs nothing.
-                prev = last_map.get(var, _UNSET)
-                if prev is not _UNSET:
-                    if spec.dtype == "float":
-                        both_nan = math.isnan(value) and math.isnan(prev)
-                        if both_nan or abs(value - prev) <= spec.deadband:
-                            continue
-                    elif value == prev:
-                        continue
-                last_map[var] = value
-                try:
-                    alarm_kwargs = self._alarm_write_kwargs(
-                        device_name, var, spec, value
-                    )
-                    await channel.write(
-                        value,
-                        **extra,
-                        **alarm_kwargs,
-                        verify_value=not bool(alarm_kwargs),
-                    )
-                except Exception:
-                    self._warn_once(
-                        device_name,
-                        var,
-                        f"{device_name}: failed to write PV {var}={value!r} "
-                        f"(skipping this variable)",
-                    )
+                channel, spec = entry
+                await self._write_stream_value(
+                    device_name, var, raw, channel, spec, extra
+                )
 
         return callback
 
@@ -489,7 +613,14 @@ class GeecsCaGateway:
         # Subscribe to data variables plus the timestamp ladder (deduped, order
         # preserved) so the device pushes the timestamp alongside the data.
         data_vars = [v.geecs_var for v in dev.variables]
-        variables = list(dict.fromkeys(data_vars + dev.timestamp_vars))
+        derived_inputs = [
+            inp.variable
+            for spec, _channel, _evaluator, _pv in self._derived_by_source.get(
+                dev.name, []
+            )
+            for inp in spec.inputs
+        ]
+        variables = list(dict.fromkeys(data_vars + derived_inputs + dev.timestamp_vars))
         # Text-typed variables must reach cast_value as the exact wire text —
         # numeric coercion round-trips '007' → 7 → "7", mangling string PVs.
         # Enums are included too: choice labels are strings, and a numeric-
@@ -605,7 +736,7 @@ class GeecsCaGateway:
         recovery is automatic — only the disconnect transition is set here.
         """
         for pv, (dev, _var, kind) in self.manifest.items():
-            if dev != device or kind != "readback":
+            if dev != device or kind not in ("readback", "derived"):
                 continue
             channel = self.pvdb[pv]
             try:

--- a/GeecsCAGateway/geecs_ca_gateway/gateway.py
+++ b/GeecsCAGateway/geecs_ca_gateway/gateway.py
@@ -257,7 +257,11 @@ class GeecsCaGateway:
                 hi=spec.hi,
                 deadband=spec.deadband,
             )
-            channel = make_readback_channel(var_spec)
+            channel = make_readback_channel(
+                var_spec,
+                initial_severity=AlarmSeverity.INVALID_ALARM,
+                initial_status=AlarmStatus.UDF,
+            )
             self.pvdb[full] = channel
             evaluator = ExpressionEvaluator(
                 spec.expression, {inp.symbol for inp in spec.inputs}
@@ -465,22 +469,25 @@ class GeecsCaGateway:
                 except (TypeError, ValueError):
                     self._warn_once(
                         device_name,
-                        spec.variable,
+                        pv,
                         f"{device_name}: derived PV {pv} input "
-                        f"{inp.variable}={raw!r} is not numeric; skipping",
+                        f"{inp.variable}={raw!r} is not numeric; marking INVALID",
                     )
                     missing = True
                     break
             if missing:
+                await self._mark_derived_invalid(channel, pv, AlarmStatus.UDF)
                 continue
             try:
                 value = evaluator.evaluate(values)
             except Exception:
                 self._warn_once(
                     device_name,
-                    spec.variable,
-                    f"{device_name}: derived PV {pv} expression failed; skipping",
+                    pv,
+                    f"{device_name}: derived PV {pv} expression failed; "
+                    "marking INVALID",
                 )
+                await self._mark_derived_invalid(channel, pv, AlarmStatus.CALC)
                 continue
             prev = self._derived_last_written.get(pv, _UNSET)
             if prev is not _UNSET:
@@ -489,13 +496,34 @@ class GeecsCaGateway:
                     continue
             self._derived_last_written[pv] = value
             try:
-                await channel.write(value, **extra)
+                await channel.write(
+                    value,
+                    **extra,
+                    severity=AlarmSeverity.NO_ALARM,
+                    status=AlarmStatus.NO_ALARM,
+                    verify_value=False,
+                )
             except Exception:
                 self._warn_once(
                     device_name,
-                    spec.variable,
+                    pv,
                     f"{device_name}: failed to write derived PV {pv}={value!r}",
                 )
+
+    async def _mark_derived_invalid(
+        self, channel: ChannelData, pv: str, status: AlarmStatus
+    ) -> None:
+        """Mark a derived PV invalid and clear its deadband cache."""
+        self._derived_last_written.pop(pv, None)
+        try:
+            await channel.write(
+                channel.value,
+                severity=AlarmSeverity.INVALID_ALARM,
+                status=status,
+                verify_value=False,
+            )
+        except Exception:
+            logger.debug("failed to mark derived PV %s INVALID", pv, exc_info=True)
 
     def _make_callback(self, dev):
         """Return the subscription callback that fans a push frame into PVs.
@@ -639,6 +667,10 @@ class GeecsCaGateway:
                 # Clear the deadband cache so the first frame always posts (and
                 # clears any INVALID left from the drop), even if unchanged.
                 self._last_written[dev.name] = {}
+                for _spec, _channel, _evaluator, pv in self._derived_by_source.get(
+                    dev.name, []
+                ):
+                    self._derived_last_written.pop(pv, None)
                 if dev.name in self._down_logged:
                     self._down_logged.discard(dev.name)
                     logger.info("%s: reconnected", dev.name)
@@ -739,6 +771,8 @@ class GeecsCaGateway:
             if dev != device or kind not in ("readback", "derived"):
                 continue
             channel = self.pvdb[pv]
+            if kind == "derived":
+                self._derived_last_written.pop(pv, None)
             try:
                 await channel.write(
                     channel.value,

--- a/GeecsCAGateway/poetry.lock
+++ b/GeecsCAGateway/poetry.lock
@@ -44,6 +44,23 @@ files = [
 ]
 
 [[package]]
+name = "geecs-schemas"
+version = "0.2.0"
+description = "Versioned Pydantic schemas for GEECS scanner configs (scan requests, save sets, scan variables, trigger profiles, action plans) plus legacy-YAML converters."
+optional = false
+python-versions = ">=3.11,<3.12"
+groups = ["main"]
+files = []
+develop = true
+
+[package.dependencies]
+pydantic = "^2.0"
+
+[package.source]
+type = "directory"
+url = "../GEECS-Schemas"
+
+[[package]]
 name = "iniconfig"
 version = "2.3.0"
 description = "brain-dead simple config-ini parsing"
@@ -353,6 +370,89 @@ files = [
 pytest = ">=7.0.0"
 
 [[package]]
+name = "pyyaml"
+version = "6.0.3"
+description = "YAML parser and emitter for Python"
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "PyYAML-6.0.3-cp38-cp38-macosx_10_13_x86_64.whl", hash = "sha256:c2514fceb77bc5e7a2f7adfaa1feb2fb311607c9cb518dbc378688ec73d8292f"},
+    {file = "PyYAML-6.0.3-cp38-cp38-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9c57bb8c96f6d1808c030b1687b9b5fb476abaa47f0db9c0101f5e9f394e97f4"},
+    {file = "PyYAML-6.0.3-cp38-cp38-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:efd7b85f94a6f21e4932043973a7ba2613b059c4a000551892ac9f1d11f5baf3"},
+    {file = "PyYAML-6.0.3-cp38-cp38-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:22ba7cfcad58ef3ecddc7ed1db3409af68d023b7f940da23c6c2a1890976eda6"},
+    {file = "PyYAML-6.0.3-cp38-cp38-musllinux_1_2_x86_64.whl", hash = "sha256:6344df0d5755a2c9a276d4473ae6b90647e216ab4757f8426893b5dd2ac3f369"},
+    {file = "PyYAML-6.0.3-cp38-cp38-win32.whl", hash = "sha256:3ff07ec89bae51176c0549bc4c63aa6202991da2d9a6129d7aef7f1407d3f295"},
+    {file = "PyYAML-6.0.3-cp38-cp38-win_amd64.whl", hash = "sha256:5cf4e27da7e3fbed4d6c3d8e797387aaad68102272f8f9752883bc32d61cb87b"},
+    {file = "pyyaml-6.0.3-cp310-cp310-macosx_10_13_x86_64.whl", hash = "sha256:214ed4befebe12df36bcc8bc2b64b396ca31be9304b8f59e25c11cf94a4c033b"},
+    {file = "pyyaml-6.0.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:02ea2dfa234451bbb8772601d7b8e426c2bfa197136796224e50e35a78777956"},
+    {file = "pyyaml-6.0.3-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b30236e45cf30d2b8e7b3e85881719e98507abed1011bf463a8fa23e9c3e98a8"},
+    {file = "pyyaml-6.0.3-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:66291b10affd76d76f54fad28e22e51719ef9ba22b29e1d7d03d6777a9174198"},
+    {file = "pyyaml-6.0.3-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9c7708761fccb9397fe64bbc0395abcae8c4bf7b0eac081e12b809bf47700d0b"},
+    {file = "pyyaml-6.0.3-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:418cf3f2111bc80e0933b2cd8cd04f286338bb88bdc7bc8e6dd775ebde60b5e0"},
+    {file = "pyyaml-6.0.3-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:5e0b74767e5f8c593e8c9b5912019159ed0533c70051e9cce3e8b6aa699fcd69"},
+    {file = "pyyaml-6.0.3-cp310-cp310-win32.whl", hash = "sha256:28c8d926f98f432f88adc23edf2e6d4921ac26fb084b028c733d01868d19007e"},
+    {file = "pyyaml-6.0.3-cp310-cp310-win_amd64.whl", hash = "sha256:bdb2c67c6c1390b63c6ff89f210c8fd09d9a1217a465701eac7316313c915e4c"},
+    {file = "pyyaml-6.0.3-cp311-cp311-macosx_10_13_x86_64.whl", hash = "sha256:44edc647873928551a01e7a563d7452ccdebee747728c1080d881d68af7b997e"},
+    {file = "pyyaml-6.0.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:652cb6edd41e718550aad172851962662ff2681490a8a711af6a4d288dd96824"},
+    {file = "pyyaml-6.0.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:10892704fc220243f5305762e276552a0395f7beb4dbf9b14ec8fd43b57f126c"},
+    {file = "pyyaml-6.0.3-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:850774a7879607d3a6f50d36d04f00ee69e7fc816450e5f7e58d7f17f1ae5c00"},
+    {file = "pyyaml-6.0.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b8bb0864c5a28024fac8a632c443c87c5aa6f215c0b126c449ae1a150412f31d"},
+    {file = "pyyaml-6.0.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:1d37d57ad971609cf3c53ba6a7e365e40660e3be0e5175fa9f2365a379d6095a"},
+    {file = "pyyaml-6.0.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:37503bfbfc9d2c40b344d06b2199cf0e96e97957ab1c1b546fd4f87e53e5d3e4"},
+    {file = "pyyaml-6.0.3-cp311-cp311-win32.whl", hash = "sha256:8098f252adfa6c80ab48096053f512f2321f0b998f98150cea9bd23d83e1467b"},
+    {file = "pyyaml-6.0.3-cp311-cp311-win_amd64.whl", hash = "sha256:9f3bfb4965eb874431221a3ff3fdcddc7e74e3b07799e0e84ca4a0f867d449bf"},
+    {file = "pyyaml-6.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7f047e29dcae44602496db43be01ad42fc6f1cc0d8cd6c83d342306c32270196"},
+    {file = "pyyaml-6.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fc09d0aa354569bc501d4e787133afc08552722d3ab34836a80547331bb5d4a0"},
+    {file = "pyyaml-6.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9149cad251584d5fb4981be1ecde53a1ca46c891a79788c0df828d2f166bda28"},
+    {file = "pyyaml-6.0.3-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5fdec68f91a0c6739b380c83b951e2c72ac0197ace422360e6d5a959d8d97b2c"},
+    {file = "pyyaml-6.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ba1cc08a7ccde2d2ec775841541641e4548226580ab850948cbfda66a1befcdc"},
+    {file = "pyyaml-6.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8dc52c23056b9ddd46818a57b78404882310fb473d63f17b07d5c40421e47f8e"},
+    {file = "pyyaml-6.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:41715c910c881bc081f1e8872880d3c650acf13dfa8214bad49ed4cede7c34ea"},
+    {file = "pyyaml-6.0.3-cp312-cp312-win32.whl", hash = "sha256:96b533f0e99f6579b3d4d4995707cf36df9100d67e0c8303a0c55b27b5f99bc5"},
+    {file = "pyyaml-6.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:5fcd34e47f6e0b794d17de1b4ff496c00986e1c83f7ab2fb8fcfe9616ff7477b"},
+    {file = "pyyaml-6.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:64386e5e707d03a7e172c0701abfb7e10f0fb753ee1d773128192742712a98fd"},
+    {file = "pyyaml-6.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8da9669d359f02c0b91ccc01cac4a67f16afec0dac22c2ad09f46bee0697eba8"},
+    {file = "pyyaml-6.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2283a07e2c21a2aa78d9c4442724ec1eb15f5e42a723b99cb3d822d48f5f7ad1"},
+    {file = "pyyaml-6.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ee2922902c45ae8ccada2c5b501ab86c36525b883eff4255313a253a3160861c"},
+    {file = "pyyaml-6.0.3-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a33284e20b78bd4a18c8c2282d549d10bc8408a2a7ff57653c0cf0b9be0afce5"},
+    {file = "pyyaml-6.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0f29edc409a6392443abf94b9cf89ce99889a1dd5376d94316ae5145dfedd5d6"},
+    {file = "pyyaml-6.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f7057c9a337546edc7973c0d3ba84ddcdf0daa14533c2065749c9075001090e6"},
+    {file = "pyyaml-6.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:eda16858a3cab07b80edaf74336ece1f986ba330fdb8ee0d6c0d68fe82bc96be"},
+    {file = "pyyaml-6.0.3-cp313-cp313-win32.whl", hash = "sha256:d0eae10f8159e8fdad514efdc92d74fd8d682c933a6dd088030f3834bc8e6b26"},
+    {file = "pyyaml-6.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:79005a0d97d5ddabfeeea4cf676af11e647e41d81c9a7722a193022accdb6b7c"},
+    {file = "pyyaml-6.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:5498cd1645aa724a7c71c8f378eb29ebe23da2fc0d7a08071d89469bf1d2defb"},
+    {file = "pyyaml-6.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:8d1fab6bb153a416f9aeb4b8763bc0f22a5586065f86f7664fc23339fc1c1fac"},
+    {file = "pyyaml-6.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:34d5fcd24b8445fadc33f9cf348c1047101756fd760b4dacb5c3e99755703310"},
+    {file = "pyyaml-6.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:501a031947e3a9025ed4405a168e6ef5ae3126c59f90ce0cd6f2bfc477be31b7"},
+    {file = "pyyaml-6.0.3-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b3bc83488de33889877a0f2543ade9f70c67d66d9ebb4ac959502e12de895788"},
+    {file = "pyyaml-6.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c458b6d084f9b935061bc36216e8a69a7e293a2f1e68bf956dcd9e6cbcd143f5"},
+    {file = "pyyaml-6.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7c6610def4f163542a622a73fb39f534f8c101d690126992300bf3207eab9764"},
+    {file = "pyyaml-6.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5190d403f121660ce8d1d2c1bb2ef1bd05b5f68533fc5c2ea899bd15f4399b35"},
+    {file = "pyyaml-6.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:4a2e8cebe2ff6ab7d1050ecd59c25d4c8bd7e6f400f5f82b96557ac0abafd0ac"},
+    {file = "pyyaml-6.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:93dda82c9c22deb0a405ea4dc5f2d0cda384168e466364dec6255b293923b2f3"},
+    {file = "pyyaml-6.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:02893d100e99e03eda1c8fd5c441d8c60103fd175728e23e431db1b589cf5ab3"},
+    {file = "pyyaml-6.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c1ff362665ae507275af2853520967820d9124984e0f7466736aea23d8611fba"},
+    {file = "pyyaml-6.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6adc77889b628398debc7b65c073bcb99c4a0237b248cacaf3fe8a557563ef6c"},
+    {file = "pyyaml-6.0.3-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a80cb027f6b349846a3bf6d73b5e95e782175e52f22108cfa17876aaeff93702"},
+    {file = "pyyaml-6.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:00c4bdeba853cc34e7dd471f16b4114f4162dc03e6b7afcc2128711f0eca823c"},
+    {file = "pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:66e1674c3ef6f541c35191caae2d429b967b99e02040f5ba928632d9a7f0f065"},
+    {file = "pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65"},
+    {file = "pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9"},
+    {file = "pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b"},
+    {file = "pyyaml-6.0.3-cp39-cp39-macosx_10_13_x86_64.whl", hash = "sha256:b865addae83924361678b652338317d1bd7e79b1f4596f96b96c77a5a34b34da"},
+    {file = "pyyaml-6.0.3-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:c3355370a2c156cffb25e876646f149d5d68f5e0a3ce86a5084dd0b64a994917"},
+    {file = "pyyaml-6.0.3-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3c5677e12444c15717b902a5798264fa7909e41153cdf9ef7ad571b704a63dd9"},
+    {file = "pyyaml-6.0.3-cp39-cp39-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5ed875a24292240029e4483f9d4a4b8a1ae08843b9c54f43fcc11e404532a8a5"},
+    {file = "pyyaml-6.0.3-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0150219816b6a1fa26fb4699fb7daa9caf09eb1999f3b70fb6e786805e80375a"},
+    {file = "pyyaml-6.0.3-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:fa160448684b4e94d80416c0fa4aac48967a969efe22931448d853ada8baf926"},
+    {file = "pyyaml-6.0.3-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:27c0abcb4a5dac13684a37f76e701e054692a9b2d3064b70f5e4eb54810553d7"},
+    {file = "pyyaml-6.0.3-cp39-cp39-win32.whl", hash = "sha256:1ebe39cb5fc479422b83de611d14e2c0d3bb2a18bbcb01f229ab3cfbd8fee7a0"},
+    {file = "pyyaml-6.0.3-cp39-cp39-win_amd64.whl", hash = "sha256:2e71d11abed7344e42a8849600193d15b6def118602c4c176f748e4583246007"},
+    {file = "pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f"},
+]
+
+[[package]]
 name = "typing-extensions"
 version = "4.15.0"
 description = "Backported and Experimental Type Hints for Python 3.9+"
@@ -382,4 +482,4 @@ typing-extensions = ">=4.12.0"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<3.12"
-content-hash = "f74a1ef17e5fcdf201f708c3d4f0ab6a053b6a7ec0320dd2e93c8f8b0c7acc1d"
+content-hash = "a92fd57190892b84ab91cbc3e77812d4daf078d9e9295700a895f7b31ed12b1e"

--- a/GeecsCAGateway/pyproject.toml
+++ b/GeecsCAGateway/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-ca-gateway"
-version = "0.7.0"
+version = "0.8.0"
 description = "EPICS Channel Access soft-IOC gateway exposing GEECS devices as PVs"
 authors = ["Sam Barber <sbarber@lbl.gov>"]
 readme = "README.md"
@@ -13,6 +13,8 @@ geecs-ca-gateway = "geecs_ca_gateway.__main__:main"
 python = ">=3.11,<3.12"
 caproto = ">=1.1"
 pydantic = ">=2"
+geecs-schemas = { path = "../GEECS-Schemas", develop = true }
+pyyaml = "^6.0"
 # This package IS the GEECS access layer: the UDP/TCP wire protocol
 # (transport/), the experiment database (db/), the PV naming contract
 # (pv_naming), and the CA server that mirrors it all as EPICS PVs.

--- a/GeecsCAGateway/tests/test_derived_channels.py
+++ b/GeecsCAGateway/tests/test_derived_channels.py
@@ -361,6 +361,54 @@ async def test_missing_derived_input_marks_invalid_udf() -> None:
     assert int(pressure.status) == int(AlarmStatus.UDF)
 
 
+async def test_repeated_derived_failure_does_not_republish_invalid(monkeypatch) -> None:
+    """A persistently failing derived PV publishes only the INVALID transition."""
+    cfg = GatewayConfig(
+        devices=[
+            DeviceSpec(
+                name="U_DaqPad1",
+                host="127.0.0.1",
+                port=1,
+                experiment="Undulator",
+                variables=[VariableSpec(geecs_var="Analog Input 10", dtype="float")],
+            )
+        ],
+        derived_channels=[
+            DerivedChannelSpec(
+                device="U_ChamberVac",
+                variable="Pressure",
+                expression="1 / v",
+                inputs=[
+                    DerivedInputSpec(
+                        symbol="v",
+                        device="U_DaqPad1",
+                        variable="Analog Input 10",
+                    )
+                ],
+            )
+        ],
+    )
+    gw = GeecsCaGateway(cfg)
+    pressure = gw.pvdb["Undulator:U_ChamberVac:Pressure"]
+    callback = gw._make_callback(cfg.devices[0])
+    writes = 0
+    original_write = pressure.write
+
+    async def counted_write(*args, **kwargs):
+        nonlocal writes
+        writes += 1
+        return await original_write(*args, **kwargs)
+
+    monkeypatch.setattr(pressure, "write", counted_write)
+
+    await callback({"Analog Input 10": 0.0})
+    await callback({"Analog Input 10": 0.0})
+
+    assert writes == 1
+    assert int(pressure.severity) == int(AlarmSeverity.INVALID_ALARM)
+    assert int(pressure.status) == int(AlarmStatus.CALC)
+
+
 async def test_derived_reconnect_clears_invalid_even_when_value_unchanged() -> None:
     """Derived deadband cache is cleared so reconnect recovery always posts."""
     port = _free_port()

--- a/GeecsCAGateway/tests/test_derived_channels.py
+++ b/GeecsCAGateway/tests/test_derived_channels.py
@@ -70,22 +70,24 @@ def test_load_derived_channels_yaml(tmp_path) -> None:
         """
 schema_version: 1
 derived_channels:
-  - device: U_ChamberVac
+  - device: TargetChamberPressure
     variable: Pressure
-    expression: "10**(v - 5)"
+    expression: "10**(v - 6)"
     inputs:
       - symbol: v
-        device: U_DaqPad1
-        variable: "Analog Input 10"
+        device: U_VacuumGauge
+        variable: "AI_mean.Channel 0"
     egu: Torr
+    precision: 6
 """,
         encoding="utf-8",
     )
 
     [spec] = load_derived_channels(path)
-    assert spec.device == "U_ChamberVac"
-    assert spec.inputs[0].variable == "Analog Input 10"
+    assert spec.device == "TargetChamberPressure"
+    assert spec.inputs[0].variable == "AI_mean.Channel 0"
     assert spec.egu == "Torr"
+    assert spec.precision == 6
 
 
 def test_default_derived_channels_path_from_configs_repo_env(

--- a/GeecsCAGateway/tests/test_derived_channels.py
+++ b/GeecsCAGateway/tests/test_derived_channels.py
@@ -13,7 +13,9 @@ from geecs_ca_gateway.derived import (
     DerivedExpressionError,
     DerivedInputSpec,
     ExpressionEvaluator,
+    default_derived_channels_path,
     load_derived_channels,
+    scanner_configs_base,
 )
 from geecs_ca_gateway.gateway import GeecsCaGateway
 from geecs_ca_gateway.testing.fake_device_server import FakeGeecsDevice, FakeGeecsServer
@@ -84,6 +86,30 @@ derived_channels:
     assert spec.device == "U_ChamberVac"
     assert spec.inputs[0].variable == "Analog Input 10"
     assert spec.egu == "Torr"
+
+
+def test_default_derived_channels_path_from_configs_repo_env(
+    monkeypatch, tmp_path
+) -> None:
+    """The production configs repo convention is discoverable by experiment."""
+    repo = tmp_path / "GEECS-Plugins-Configs"
+    path = (
+        repo
+        / "scanner_configs"
+        / "experiments"
+        / "Undulator"
+        / "gateway"
+        / "derived_channels.yaml"
+    )
+    path.parent.mkdir(parents=True)
+    path.write_text("schema_version: 1\nderived_channels: []\n", encoding="utf-8")
+
+    monkeypatch.delenv("GEECS_SCANNER_CONFIG_DIR", raising=False)
+    monkeypatch.setenv("GEECS_PLUGINS_CONFIGS", str(repo))
+
+    assert scanner_configs_base() == repo / "scanner_configs" / "experiments"
+    assert default_derived_channels_path("Undulator") == path
+    assert default_derived_channels_path("Missing") is None
 
 
 def test_derived_pvdb_has_numeric_readback_and_manifest() -> None:

--- a/GeecsCAGateway/tests/test_derived_channels.py
+++ b/GeecsCAGateway/tests/test_derived_channels.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 import asyncio
+import socket
 
 import pytest
+from caproto import AlarmSeverity, AlarmStatus
 from pydantic import ValidationError
 
 from geecs_ca_gateway.config import DeviceSpec, GatewayConfig, VariableSpec
@@ -23,6 +25,15 @@ from geecs_ca_gateway.testing.fake_device_server import FakeGeecsDevice, FakeGee
 pytestmark = pytest.mark.fake_server
 
 
+def _free_port() -> int:
+    """Return an available localhost TCP port."""
+    sock = socket.socket()
+    sock.bind(("127.0.0.1", 0))
+    _, port = sock.getsockname()
+    sock.close()
+    return port
+
+
 async def _wait_until(predicate, timeout: float = 6.0, interval: float = 0.05) -> bool:
     """Poll ``predicate`` until true or ``timeout`` elapses."""
     waited = 0.0
@@ -32,6 +43,21 @@ async def _wait_until(predicate, timeout: float = 6.0, interval: float = 0.05) -
         await asyncio.sleep(interval)
         waited += interval
     return predicate()
+
+
+async def _start_on_port(device: FakeGeecsDevice, port: int) -> FakeGeecsServer:
+    """Start a fake server bound to a specific localhost port."""
+    last_error: OSError | None = None
+    for _ in range(10):
+        srv = FakeGeecsServer(device, host="127.0.0.1", port=port)
+        try:
+            await srv.start()
+            return srv
+        except OSError as exc:
+            last_error = exc
+            await asyncio.sleep(0.05)
+    assert last_error is not None
+    raise last_error
 
 
 def test_expression_evaluator_supports_convectron_formula() -> None:
@@ -88,6 +114,15 @@ derived_channels:
     assert spec.inputs[0].variable == "AI_mean.Channel 0"
     assert spec.egu == "Torr"
     assert spec.precision == 6
+
+
+def test_load_derived_channels_error_names_path(tmp_path) -> None:
+    """Bad overlay files fail with the offending path in the exception."""
+    path = tmp_path / "derived_channels.yaml"
+    path.write_text("derived_channels: [", encoding="utf-8")
+
+    with pytest.raises(ValueError, match=str(path)):
+        load_derived_channels(path)
 
 
 def test_default_derived_channels_path_from_configs_repo_env(
@@ -149,6 +184,8 @@ def test_derived_pvdb_has_numeric_readback_and_manifest() -> None:
     assert pv in gw.pvdb
     assert gw.pvdb[pv].units == "Torr"
     assert gw.pvdb[pv].precision == 4
+    assert int(gw.pvdb[pv].severity) == int(AlarmSeverity.INVALID_ALARM)
+    assert int(gw.pvdb[pv].status) == int(AlarmStatus.UDF)
     assert gw.manifest[pv] == ("U_DaqPad1", "Pressure", "derived")
 
 
@@ -238,3 +275,145 @@ async def test_derived_only_input_is_subscribed_without_raw_pv() -> None:
             assert await _wait_until(lambda: pressure.value == pytest.approx(1.0))
         finally:
             await gw.close()
+
+
+async def test_derived_expression_failure_marks_invalid_calc() -> None:
+    """Persistent runtime failures do not leave the last good value looking live."""
+    cfg = GatewayConfig(
+        devices=[
+            DeviceSpec(
+                name="U_DaqPad1",
+                host="127.0.0.1",
+                port=1,
+                experiment="Undulator",
+                variables=[VariableSpec(geecs_var="Analog Input 10", dtype="float")],
+            )
+        ],
+        derived_channels=[
+            DerivedChannelSpec(
+                device="U_ChamberVac",
+                variable="Pressure",
+                expression="1 / v",
+                inputs=[
+                    DerivedInputSpec(
+                        symbol="v",
+                        device="U_DaqPad1",
+                        variable="Analog Input 10",
+                    )
+                ],
+            )
+        ],
+    )
+    gw = GeecsCaGateway(cfg)
+    pressure = gw.pvdb["Undulator:U_ChamberVac:Pressure"]
+    callback = gw._make_callback(cfg.devices[0])
+
+    await callback({"Analog Input 10": 2.0})
+    assert pressure.value == pytest.approx(0.5)
+    assert int(pressure.severity) == int(AlarmSeverity.NO_ALARM)
+
+    await callback({"Analog Input 10": 0.0})
+    assert pressure.value == pytest.approx(0.5)
+    assert int(pressure.severity) == int(AlarmSeverity.INVALID_ALARM)
+    assert int(pressure.status) == int(AlarmStatus.CALC)
+
+    await callback({"Analog Input 10": 4.0})
+    assert pressure.value == pytest.approx(0.25)
+    assert int(pressure.severity) == int(AlarmSeverity.NO_ALARM)
+    assert int(pressure.status) == int(AlarmStatus.NO_ALARM)
+
+
+async def test_missing_derived_input_marks_invalid_udf() -> None:
+    """A mistyped or absent source variable does not serve a valid-looking zero."""
+    cfg = GatewayConfig(
+        devices=[
+            DeviceSpec(
+                name="U_DaqPad1",
+                host="127.0.0.1",
+                port=1,
+                experiment="Undulator",
+                variables=[],
+            )
+        ],
+        derived_channels=[
+            DerivedChannelSpec(
+                device="U_ChamberVac",
+                variable="Pressure",
+                expression="10**(v - 5)",
+                inputs=[
+                    DerivedInputSpec(
+                        symbol="v",
+                        device="U_DaqPad1",
+                        variable="Analog Input 10",
+                    )
+                ],
+            )
+        ],
+    )
+    gw = GeecsCaGateway(cfg)
+    pressure = gw.pvdb["Undulator:U_ChamberVac:Pressure"]
+    callback = gw._make_callback(cfg.devices[0])
+
+    await callback({"Other Input": 5.0})
+
+    assert pressure.value == pytest.approx(0.0)
+    assert int(pressure.severity) == int(AlarmSeverity.INVALID_ALARM)
+    assert int(pressure.status) == int(AlarmStatus.UDF)
+
+
+async def test_derived_reconnect_clears_invalid_even_when_value_unchanged() -> None:
+    """Derived deadband cache is cleared so reconnect recovery always posts."""
+    port = _free_port()
+    device = FakeGeecsDevice("U_DaqPad1", variables={"Analog Input 10": 5.0})
+    srv = await _start_on_port(device, port)
+    cfg = GatewayConfig(
+        devices=[
+            DeviceSpec(
+                name="U_DaqPad1",
+                host="127.0.0.1",
+                port=port,
+                experiment="Undulator",
+                variables=[],
+            )
+        ],
+        derived_channels=[
+            DerivedChannelSpec(
+                device="U_ChamberVac",
+                variable="Pressure",
+                expression="10**(v - 5)",
+                inputs=[
+                    DerivedInputSpec(
+                        symbol="v",
+                        device="U_DaqPad1",
+                        variable="Analog Input 10",
+                    )
+                ],
+            )
+        ],
+    )
+    gw = GeecsCaGateway(cfg, reconnect_min_s=0.2, reconnect_max_s=0.4)
+    await gw.connect()
+    await gw.subscribe()
+    pressure = gw.pvdb["Undulator:U_ChamberVac:Pressure"]
+    try:
+        assert await _wait_until(lambda: pressure.value == pytest.approx(1.0))
+        assert int(pressure.severity) == int(AlarmSeverity.NO_ALARM)
+
+        await srv.stop()
+        assert await _wait_until(
+            lambda: int(pressure.severity) == int(AlarmSeverity.INVALID_ALARM)
+        )
+
+        srv2 = await _start_on_port(
+            FakeGeecsDevice("U_DaqPad1", variables={"Analog Input 10": 5.0}),
+            port,
+        )
+        try:
+            assert await _wait_until(
+                lambda: int(pressure.severity) == int(AlarmSeverity.NO_ALARM)
+                and pressure.value == pytest.approx(1.0)
+            )
+        finally:
+            await srv2.stop()
+    finally:
+        await gw.close()

--- a/GeecsCAGateway/tests/test_derived_channels.py
+++ b/GeecsCAGateway/tests/test_derived_channels.py
@@ -1,0 +1,212 @@
+"""Tests for gateway-local derived numeric channels."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+from pydantic import ValidationError
+
+from geecs_ca_gateway.config import DeviceSpec, GatewayConfig, VariableSpec
+from geecs_ca_gateway.derived import (
+    DerivedChannelSpec,
+    DerivedExpressionError,
+    DerivedInputSpec,
+    ExpressionEvaluator,
+    load_derived_channels,
+)
+from geecs_ca_gateway.gateway import GeecsCaGateway
+from geecs_ca_gateway.testing.fake_device_server import FakeGeecsDevice, FakeGeecsServer
+
+pytestmark = pytest.mark.fake_server
+
+
+async def _wait_until(predicate, timeout: float = 6.0, interval: float = 0.05) -> bool:
+    """Poll ``predicate`` until true or ``timeout`` elapses."""
+    waited = 0.0
+    while waited < timeout:
+        if predicate():
+            return True
+        await asyncio.sleep(interval)
+        waited += interval
+    return predicate()
+
+
+def test_expression_evaluator_supports_convectron_formula() -> None:
+    """The restricted evaluator supports numeric Convectron-style formulas."""
+    evaluator = ExpressionEvaluator("10**(v - 5)", {"v"})
+    assert evaluator.evaluate({"v": 5.0}) == pytest.approx(1.0)
+    assert evaluator.evaluate({"v": 6.0}) == pytest.approx(10.0)
+
+
+def test_expression_evaluator_rejects_non_numeric_python() -> None:
+    """Expressions are arithmetic, not arbitrary Python."""
+    with pytest.raises(DerivedExpressionError):
+        ExpressionEvaluator("__import__('os').system('true')", {"v"})
+    with pytest.raises(DerivedExpressionError):
+        ExpressionEvaluator("v.real", {"v"})
+
+
+def test_derived_channel_schema_is_single_source_device_v1() -> None:
+    """v1 derived channels are same-source-device only."""
+    with pytest.raises(ValidationError, match="one source device"):
+        DerivedChannelSpec(
+            device="U_ChamberVac",
+            variable="Pressure",
+            expression="a + b",
+            inputs=[
+                DerivedInputSpec(symbol="a", device="U_DaqPad1", variable="AI 1"),
+                DerivedInputSpec(symbol="b", device="U_DaqPad2", variable="AI 1"),
+            ],
+        )
+
+
+def test_load_derived_channels_yaml(tmp_path) -> None:
+    """The production overlay file path loads through geecs-schemas."""
+    path = tmp_path / "derived_channels.yaml"
+    path.write_text(
+        """
+schema_version: 1
+derived_channels:
+  - device: U_ChamberVac
+    variable: Pressure
+    expression: "10**(v - 5)"
+    inputs:
+      - symbol: v
+        device: U_DaqPad1
+        variable: "Analog Input 10"
+    egu: Torr
+""",
+        encoding="utf-8",
+    )
+
+    [spec] = load_derived_channels(path)
+    assert spec.device == "U_ChamberVac"
+    assert spec.inputs[0].variable == "Analog Input 10"
+    assert spec.egu == "Torr"
+
+
+def test_derived_pvdb_has_numeric_readback_and_manifest() -> None:
+    """A derived spec creates one read-only float PV."""
+    cfg = GatewayConfig(
+        devices=[
+            DeviceSpec(
+                name="U_DaqPad1",
+                host="h",
+                port=1,
+                experiment="Undulator",
+                variables=[VariableSpec(geecs_var="Analog Input 10", dtype="float")],
+            )
+        ],
+        derived_channels=[
+            DerivedChannelSpec(
+                device="U_ChamberVac",
+                variable="Pressure",
+                expression="10**(v - 5)",
+                inputs=[
+                    DerivedInputSpec(
+                        symbol="v",
+                        device="U_DaqPad1",
+                        variable="Analog Input 10",
+                    )
+                ],
+                egu="Torr",
+                precision=4,
+            )
+        ],
+    )
+    gw = GeecsCaGateway(cfg)
+
+    pv = "Undulator:U_ChamberVac:Pressure"
+    assert pv in gw.pvdb
+    assert gw.pvdb[pv].units == "Torr"
+    assert gw.pvdb[pv].precision == 4
+    assert gw.manifest[pv] == ("U_DaqPad1", "Pressure", "derived")
+
+
+async def test_derived_channel_updates_from_same_source_frame() -> None:
+    """A source frame writes raw inputs first, then the derived output."""
+    labview = 2_082_844_800 + 1_782_949_690.5
+    device = FakeGeecsDevice(
+        "U_DaqPad1",
+        variables={"Analog Input 10": 6.0, "systimestamp": labview},
+    )
+    async with FakeGeecsServer(device) as srv:
+        cfg = GatewayConfig(
+            devices=[
+                DeviceSpec(
+                    name="U_DaqPad1",
+                    host=srv.host,
+                    port=srv.port,
+                    experiment="Undulator",
+                    variables=[
+                        VariableSpec(geecs_var="Analog Input 10", dtype="float")
+                    ],
+                )
+            ],
+            derived_channels=[
+                DerivedChannelSpec(
+                    device="U_ChamberVac",
+                    variable="Pressure",
+                    expression="10**(v - 5)",
+                    inputs=[
+                        DerivedInputSpec(
+                            symbol="v",
+                            device="U_DaqPad1",
+                            variable="Analog Input 10",
+                        )
+                    ],
+                )
+            ],
+        )
+        gw = GeecsCaGateway(cfg)
+        await gw.connect()
+        await gw.subscribe()
+        raw = gw.pvdb["Undulator:U_DaqPad1:Analog_Input_10"]
+        pressure = gw.pvdb["Undulator:U_ChamberVac:Pressure"]
+        try:
+            assert await _wait_until(lambda: pressure.value == pytest.approx(10.0))
+            assert raw.value == pytest.approx(6.0)
+            assert pressure.timestamp == pytest.approx(1_782_949_690.5, abs=1e-3)
+        finally:
+            await gw.close()
+
+
+async def test_derived_only_input_is_subscribed_without_raw_pv() -> None:
+    """A derived input need not be exposed as its own readback PV."""
+    device = FakeGeecsDevice("U_DaqPad1", variables={"Analog Input 10": 5.0})
+    async with FakeGeecsServer(device) as srv:
+        cfg = GatewayConfig(
+            devices=[
+                DeviceSpec(
+                    name="U_DaqPad1",
+                    host=srv.host,
+                    port=srv.port,
+                    experiment="Undulator",
+                    variables=[],
+                )
+            ],
+            derived_channels=[
+                DerivedChannelSpec(
+                    device="U_ChamberVac",
+                    variable="Pressure",
+                    expression="10**(v - 5)",
+                    inputs=[
+                        DerivedInputSpec(
+                            symbol="v",
+                            device="U_DaqPad1",
+                            variable="Analog Input 10",
+                        )
+                    ],
+                )
+            ],
+        )
+        gw = GeecsCaGateway(cfg)
+        assert "Undulator:U_DaqPad1:Analog_Input_10" not in gw.pvdb
+        await gw.connect()
+        await gw.subscribe()
+        pressure = gw.pvdb["Undulator:U_ChamberVac:Pressure"]
+        try:
+            assert await _wait_until(lambda: pressure.value == pytest.approx(1.0))
+        finally:
+            await gw.close()

--- a/GeecsCAGateway/tests/test_entrypoint.py
+++ b/GeecsCAGateway/tests/test_entrypoint.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import pytest
 
 from geecs_ca_gateway.__main__ import _parse_args
+from geecs_ca_gateway.config import GatewayConfig
 
 
 def test_defaults() -> None:
@@ -71,3 +72,63 @@ def test_main_returns_normally_without_restart(monkeypatch) -> None:
         ["--experiment", "X", "--derived-channels", "derived.yaml", "--show-missing"]
     )  # no exception
     assert seen["derived_channels_path"] == Path("derived.yaml")
+
+
+async def test_run_loads_default_derived_channels_from_configs_repo(
+    monkeypatch, tmp_path
+) -> None:
+    """Without an explicit path, _run loads the configs-repo convention file."""
+    from geecs_ca_gateway import __main__ as entry
+
+    repo = tmp_path / "GEECS-Plugins-Configs"
+    path = (
+        repo
+        / "scanner_configs"
+        / "experiments"
+        / "Undulator"
+        / "gateway"
+        / "derived_channels.yaml"
+    )
+    path.parent.mkdir(parents=True)
+    path.write_text(
+        """
+schema_version: 1
+derived_channels:
+  - device: U_ChamberVac
+    variable: Pressure
+    expression: "v"
+    inputs:
+      - symbol: v
+        device: U_DaqPad1
+        variable: "Analog Input 10"
+""",
+        encoding="utf-8",
+    )
+    monkeypatch.delenv("GEECS_SCANNER_CONFIG_DIR", raising=False)
+    monkeypatch.setenv("GEECS_PLUGINS_CONFIGS", str(repo))
+    monkeypatch.setattr(
+        entry.GatewayConfig,
+        "from_geecs_experiment",
+        classmethod(lambda cls, *args, **kwargs: GatewayConfig()),
+    )
+    seen: dict[str, GatewayConfig] = {}
+
+    class FakeGateway:
+        def __init__(self, config: GatewayConfig) -> None:
+            seen["config"] = config
+            self.pvdb = {}
+
+        async def run(self) -> bool:
+            return False
+
+    monkeypatch.setattr(entry, "GeecsCaGateway", FakeGateway)
+
+    restart = await entry._run(
+        "Undulator",
+        subscribed_only=True,
+        enabled_only=True,
+        include_settable=True,
+    )
+
+    assert restart is False
+    assert seen["config"].derived_channels[0].device == "U_ChamberVac"

--- a/GeecsCAGateway/tests/test_entrypoint.py
+++ b/GeecsCAGateway/tests/test_entrypoint.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 
 from geecs_ca_gateway.__main__ import _parse_args
@@ -13,6 +15,7 @@ def test_defaults() -> None:
     assert args.experiment == "Undulator"
     assert args.all_variables is False
     assert args.include_disabled is False
+    assert args.derived_channels is None
     assert args.show_missing is False
 
 
@@ -24,6 +27,12 @@ def test_flags() -> None:
     assert args.all_variables is True
     assert args.include_disabled is True
     assert args.show_missing is True
+
+
+def test_derived_channels_path_flag() -> None:
+    """A derived-channel overlay path is parsed for startup loading."""
+    args = _parse_args(["--experiment", "X", "--derived-channels", "derived.yaml"])
+    assert args.derived_channels == Path("derived.yaml")
 
 
 def test_experiment_required() -> None:
@@ -51,8 +60,14 @@ def test_main_returns_normally_without_restart(monkeypatch) -> None:
     """A normal shutdown does not raise SystemExit."""
     from geecs_ca_gateway import __main__ as entry
 
+    seen: dict[str, object] = {}
+
     async def fake_run(experiment: str, **kwargs: object) -> bool:
+        seen.update(kwargs)
         return False
 
     monkeypatch.setattr(entry, "_run", fake_run)
-    entry.main(["--experiment", "X", "--show-missing"])  # no exception
+    entry.main(
+        ["--experiment", "X", "--derived-channels", "derived.yaml", "--show-missing"]
+    )  # no exception
+    assert seen["derived_channels_path"] == Path("derived.yaml")


### PR DESCRIPTION
## Summary

- add `DerivedChannels` schema to `GEECS-Schemas`
- add gateway support for schema-validated derived numeric readbacks
- auto-load `scanner_configs/experiments/<Experiment>/gateway/derived_channels.yaml` from the configs repo when present
- keep `--derived-channels PATH` as an explicit override
- document the production path and add a derived-PV smoke test

## Review follow-up

- fixed derived reconnect recovery by clearing `_derived_last_written` for source-device derived PVs on reconnect and INVALID transitions
- derived PVs now initialize as `INVALID/UDF` until the first successful compute, avoiding valid-looking placeholder `0.0` values
- missing or non-numeric derived inputs mark the output `INVALID/UDF`
- persistent expression/runtime failures mark the output `INVALID/CALC` instead of holding a stale good value
- repeated identical derived INVALID states are transition-only and do not re-publish on every failing frame
- bad derived-channel config loads now include the offending file path in the exception
- added regression tests for reconnect with unchanged value, missing input, division-by-zero/runtime failure, initial INVALID state, repeated INVALID suppression, and corrupt YAML path reporting
- documented derived PV alarm semantics in `PV_CONTRACT.md` and `CHANGELOG.md`

## Validation

- `GEECS-Schemas`: `poetry run pytest tests/test_derived_channels.py tests/test_docgen.py -q` -> `91 passed`
- `GeecsCAGateway`: `poetry run pytest tests/test_derived_channels.py tests/test_entrypoint.py -q` -> `20 passed`
- commit hooks passed `ruff`, `ruff-format`, and `pydocstyle`
- earlier full gateway suite on this branch: `123 passed`
- live gateway smoke test: configs repo branch loaded `Undulator:TargetChamberPressure:Pressure`, and Phoebus displayed pressure from `U_VacuumGauge:AI_mean.Channel 0`

## Configs repo companion

Companion config PR: https://github.com/GEECS-BELLA/GEECS-Plugins-Configs/pull/12

It adds the tested `scanner_configs/experiments/Undulator/gateway/derived_channels.yaml` file.
