### PR TITLE
vision M3c: DB-runtime tier (db_scalars, scan start/end writes, background telemetry) + s-file acq_timestamp

### DIFF
--- a/GEECS-Data-Utils/geecs_data_utils/tiled_export.py
+++ b/GEECS-Data-Utils/geecs_data_utils/tiled_export.py
@@ -32,11 +32,14 @@ import pandas as pd
 
 logger = logging.getLogger(__name__)
 
-# Derived companion columns (event-schema v1) that must not appear in the legacy
-# scalar file.  Any event-stream column not named in ``geecs_scalar_headers`` is
-# dropped anyway; this set documents the intent.
+# Derived companion columns (event-schema v1) normally kept out of the legacy
+# scalar file.  Emission is driven entirely by ``geecs_scalar_headers`` (any
+# event-stream column not named there is dropped), so this set only documents
+# the intent — it is not an active filter.  Exception: ``-acq_timestamp`` is
+# deliberately surfaced (added to a device's headers) for file/image-saving
+# devices so saved files tie back to scan rows; it stays out for pure-scalar
+# devices.
 _COMPANION_SUFFIXES = (
-    "-acq_timestamp",
     "-t0_acq_timestamp",
     "-shot_id",
     "-shot_offset",

--- a/GEECS-Schemas/CHANGELOG.md
+++ b/GEECS-Schemas/CHANGELOG.md
@@ -5,6 +5,25 @@ All notable changes to GEECS-Schemas are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.0] - 2026-07-08
+
+### Changed
+
+- **Reserved the DB set-side scan-write fields — not honored; get-side
+  `db_scalars` / telemetry unchanged.**  `SaveSetEntry.at_scan_start` /
+  `at_scan_end` and `ExperimentDefaults.apply_db_scan_defaults` are kept in
+  the schema but their field descriptions and the surrounding docstrings now
+  state clearly that the DB **set-side** (scan start/end writes from the
+  `set='yes'` rows) is **not applied in this version**: the engine sets up
+  triggering via the TriggerProfile / shot controller and camera saving via
+  its own save-windowing, so DB boundary writes would race the shot
+  controller (on the DG645 the `set='yes'` rows are the very
+  trigger/amplitude variables it drives).  The fields are reserved for a
+  possible future re-enable.  No fields were removed, so existing configs
+  still validate.  The **get-side** — `SaveSetEntry.db_scalars` /
+  `all_scalars` (standard telemetry) and the `background_telemetry` defaults
+  — is unchanged and still honored.
+
 ## [0.3.0] - 2026-07-08
 
 ### Added

--- a/GEECS-Schemas/README.md
+++ b/GEECS-Schemas/README.md
@@ -57,13 +57,15 @@ schema-side only in M1), `PositionRange` / `PositionList`, `ActionBindings`
 `EvaluatorSpec`, `GeneratorSpec` — covers the legacy Xopt VOCS surface),
 `SaveSetEntry` / `SaveRole` (entries carry optional `setup` / `closeout`
 action-plan name references — the device's ritual travels with it through
-composition — plus the DB scan-default surfaces: `at_scan_start` /
-`at_scan_end` per-variable overrides of the DB's start/end writes, where a
-value replaces the DB's, an explicit `null` suppresses the write, and
-absence inherits; and `db_scalars`, on by default for new configs, making
-the DB's scan-logging telemetry the standard scalar source with `scalars`
-as additive extras — converted legacy elements carry an explicit
-`db_scalars: false` to preserve their exact old behavior),
+composition — plus the DB scan-default surfaces: `db_scalars`, on by default
+for new configs, making the DB's scan-logging telemetry the standard scalar
+source with `scalars` as additive extras — converted legacy elements carry
+an explicit `db_scalars: false` to preserve their exact old behavior; and
+the reserved `at_scan_start` / `at_scan_end` fields, which would override
+the DB's set-side start/end writes but are **not honored in this version**
+— the set-side is disabled (triggering and camera saving are handled by the
+trigger profile / shot controller and the scanner's save-windowing), and the
+fields are kept for a possible future re-enable),
 `ScanVariable` / `PseudoScanVariable`, `TriggerWrite` /
 `TriggerVariant` / `TriggerState`, `DefaultActions`, and the four action
 step types.

--- a/GEECS-Schemas/geecs_schemas/experiment_defaults.py
+++ b/GEECS-Schemas/geecs_schemas/experiment_defaults.py
@@ -31,6 +31,16 @@ Resolvers MUST record the defaults they applied into the resolved request
 (provenance): a run's metadata has to show the trigger profile and action
 plans it *actually* used, not require the reader to reconstruct which
 defaults file was in force at the time.
+
+DB scan defaults — what is honored
+----------------------------------
+The get-side DB defaults (``background_telemetry``, and per-device
+``db_scalars`` on the save set) ARE honored.  The set-side
+(``apply_db_scan_defaults`` — the database's ``set='yes'`` scan start/end
+writes) is **reserved and not currently honored**: the engine sets up
+triggering via the trigger profile / shot controller and camera saving via
+its own save-windowing, so DB boundary writes are intentionally disabled in
+this version.  The field is kept for a possible future re-enable.
 """
 
 from __future__ import annotations
@@ -95,12 +105,16 @@ class ExperimentDefaults(VersionedSchemaModel):
     apply_db_scan_defaults: bool = Field(
         True,
         description=(
-            "Honor the GEECS experiment database's scan-start/end writes "
-            "(MySQL table expt_device_variable: rows with set='yes', "
-            "writing their startvalue/endvalue) for devices taking part in "
-            "a scan. On by default, matching how MC behaves; turn off to "
-            "run the experiment purely from config files, ignoring the "
-            "database's start/end writes everywhere."
+            "RESERVED AND NOT CURRENTLY HONORED. The DB set-side scan "
+            "start/end writes (MySQL table expt_device_variable: rows with "
+            "set='yes', writing their startvalue/endvalue) are disabled in "
+            "this version — triggering is set up via the trigger profile / "
+            "shot controller and camera saving via the scanner's own "
+            "save-windowing, so the database's boundary writes are not "
+            "applied regardless of this flag. Kept for a possible future "
+            "re-enable. Note this is the set-side only: the get-side "
+            "'db_scalars' (standard telemetry) and 'background_telemetry' "
+            "are honored as normal."
         ),
     )
     background_telemetry: bool = Field(

--- a/GEECS-Schemas/geecs_schemas/save_set.py
+++ b/GEECS-Schemas/geecs_schemas/save_set.py
@@ -131,9 +131,11 @@ class SaveSetEntry(SchemaModel):
 
     The soft tier (background telemetry, see the module docstring) never
     gets scan-start/end writes either — writing to a possibly-dead device
-    would block, and softness means never waiting.  Soft-tier columns carry
-    their own ``acq_timestamp`` plus a validity marker for downstream
-    alignment; strict-mode completeness applies to required devices only.
+    would block, and softness means never waiting.  Soft-tier columns are
+    plain per-row snapshot values (read once per event row, best-effort); they
+    do **not** carry the per-shot ``acq_timestamp``/validity labeling that
+    Tier-1 synchronous devices do, and strict-mode completeness applies to
+    required devices only.
     """
 
     device: str = Field(

--- a/GEECS-Schemas/geecs_schemas/save_set.py
+++ b/GEECS-Schemas/geecs_schemas/save_set.py
@@ -107,27 +107,33 @@ class SaveSetEntry(SchemaModel):
     with the device when entries are composed into bigger save sets, while
     the plan itself stays a single named, editable object.
 
-    **Runtime contract for the DB scan defaults** (``at_scan_start`` /
-    ``at_scan_end`` / ``db_scalars``): the GEECS experiment database (MySQL)
-    holds per-experiment device-variable policy in its
+    **Runtime contract for the DB scan defaults**: the GEECS experiment
+    database (MySQL) holds per-experiment device-variable policy in its
     ``expt_device_variable`` table (joined to devices via ``expt_device``).
-    Rows with ``set='yes'`` name variables the scan machinery writes at scan
-    boundaries, using the row's ``startvalue`` / ``endvalue`` — exactly what
-    MC applies at scan start/end; rows with ``get='yes'`` mark scan-logged
-    telemetry.
-    The engine reads those ``set='yes'`` start/end rows **only for devices
-    participating in the scan**, always skips ``save`` /
-    ``localsavingpath`` (native saving is owned by the run discipline, not
-    per-device DB rows), applies this entry's ``at_scan_start`` /
-    ``at_scan_end`` overrides on top, and records every write it actually
-    applied into the run's metadata for provenance.  The DB rows
-    themselves get no schema — device facts live below the configs.
+    Rows with ``get='yes'`` mark scan-logged telemetry; rows with
+    ``set='yes'`` name variables MC writes at scan boundaries using the row's
+    ``startvalue`` / ``endvalue``.
 
-    The soft tier (background telemetry, see the module docstring) gets
-    **no** scan-start/end writes — writing to a possibly-dead device would
-    block, and softness means never waiting.  Soft-tier columns carry their
-    own ``acq_timestamp`` plus a validity marker for downstream alignment;
-    strict-mode completeness applies to required devices only.
+    - **``db_scalars`` IS honored (get-side).**  For a device recorded with
+      ``db_scalars=True`` (the default) the engine records its ``get='yes'``
+      variables (``all_scalars=True`` records every DB variable).  This is
+      the standard telemetry list; ``scalars`` adds extras on top.
+    - **``at_scan_start`` / ``at_scan_end`` are NOT honored in this version
+      (set-side, reserved).**  The DB set-side scan start/end writes are
+      intentionally disabled: the engine sets up triggering via the
+      TriggerProfile / shot controller and camera saving via its own
+      save-windowing, so writing the ``set='yes'`` rows at scan boundaries
+      would race the shot controller (on the DG645 the ``set='yes'`` rows
+      are the very trigger/amplitude variables the shot controller drives)
+      and duplicate the scanner's own saving.  These override fields are
+      kept on record for a possible future re-enable; a config that still
+      sets them is honored by nothing today (the engine logs one warning).
+
+    The soft tier (background telemetry, see the module docstring) never
+    gets scan-start/end writes either — writing to a possibly-dead device
+    would block, and softness means never waiting.  Soft-tier columns carry
+    their own ``acq_timestamp`` plus a validity marker for downstream
+    alignment; strict-mode completeness applies to required devices only.
     """
 
     device: str = Field(
@@ -205,24 +211,29 @@ class SaveSetEntry(SchemaModel):
     at_scan_start: dict[str, Optional[str]] = Field(
         default_factory=dict,
         description=(
-            "Per-variable tweaks to what the GEECS experiment database "
-            "writes to this device when a scan starts (its "
-            "expt_device_variable rows with set='yes'; the sent value is "
-            "the row's startvalue). Three cases: a variable you don't "
-            "mention keeps its database behavior; 'Variable: \"value\"' "
-            "sends your value instead of the database's; 'Variable: null' "
-            "suppresses the database write entirely (nothing is sent)."
+            "RESERVED AND NOT APPLIED in this version. The DB set-side scan "
+            "start/end writes are intentionally disabled: the engine sets up "
+            "triggering via the trigger profile / shot controller and camera "
+            "saving via its own save-windowing, so writing the database's "
+            "set='yes' start values here would race the shot controller. Kept "
+            "for a possible future re-enable — a config that sets it is not an "
+            "error but has no effect today (the engine logs a warning). When "
+            "honored again, it would tweak the database's scan-start writes "
+            "per variable (unmentioned = database value, a value = replace, "
+            "null = suppress)."
         ),
     )
     at_scan_end: dict[str, Optional[str]] = Field(
         default_factory=dict,
         description=(
-            "Per-variable tweaks to what the GEECS experiment database "
-            "writes to this device when a scan ends (its "
-            "expt_device_variable rows with set='yes'; the sent value is "
-            "the row's endvalue) — same three cases as 'at_scan_start': "
-            "unmentioned = database behavior, a value = replace the "
-            "database's value, null = suppress the write entirely."
+            "RESERVED AND NOT APPLIED in this version — the scan-end "
+            "counterpart of 'at_scan_start'. The DB set-side scan start/end "
+            "writes are intentionally disabled (triggering is owned by the "
+            "trigger profile / shot controller, camera saving by the "
+            "scanner's save-windowing), so this has no effect today; it is "
+            "kept for a possible future re-enable. When honored again, it "
+            "would tweak the database's scan-end writes per variable (same "
+            "three cases as 'at_scan_start')."
         ),
     )
 

--- a/GEECS-Schemas/pyproject.toml
+++ b/GEECS-Schemas/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-schemas"
-version = "0.3.0"
+version = "0.4.0"
 description = "Versioned Pydantic schemas for GEECS scanner configs (scan requests, save sets, scan variables, trigger profiles, action plans) plus legacy-YAML converters."
 authors = ["Sam Barber <sbarber@lbl.gov>"]
 readme = "README.md"

--- a/GeecsBluesky/CHANGELOG.md
+++ b/GeecsBluesky/CHANGELOG.md
@@ -13,6 +13,14 @@ already existed; the schema is untouched.
 
 ### Added
 
+- **`acq_timestamp` now appears in the legacy s-file for image/file-saving
+  devices.**  A device that saves non-scalar data (`save_nonscalar_data=True` —
+  `CaGenericDetector`, `CaTimestampedReadable`) surfaces its `acq_timestamp` as
+  a legacy scalar column (`<device> acq_timestamp`), so saved files tie back to
+  scan rows (the saved image filenames are stamped with it).  Previously an
+  images-only save produced an s-file with only `Bin # / scan / Shotnumber` and
+  no way to correlate rows to files from the s-file alone.  `acq_timestamp`
+  stays an excluded companion column for pure-scalar devices.
 - **db_scalars resolution (Tier 1).**  A save-set entry's recorded scalars are
   now its DB `get='yes'` variables (from `expt_device_variable`) unioned with
   its explicit `scalars` list (`db_scalars=True`, the default);

--- a/GeecsBluesky/CHANGELOG.md
+++ b/GeecsBluesky/CHANGELOG.md
@@ -51,13 +51,23 @@ possible future re-enable but are not applied.
 - **Background telemetry tier (Tier 2).**  Every live experiment device with a
   `get='yes'` variable not in the save set is recorded as best-effort snapshot
   columns via the new soft `CaTelemetryReadable`: read-only, sampled once per
-  event row, never waited on — a signal read that fails degrades to a NaN cell
-  instead of aborting, and a device unreachable at scan start is dropped with a
-  log line (`GeecsSession.telemetry` returns `None`).  Telemetry columns carry
-  the `telemetry_<device>-` name prefix so they are distinguishable from Tier-1
-  save-set data (see `EVENT_SCHEMA.md`); selection is recorded in run metadata
-  under `background_telemetry`.  Gated on `ScanRequest.background_telemetry`
-  (else `ExperimentDefaults.background_telemetry`, default true).
+  event row, never waited on — a signal read that fails degrades to a
+  dtype-appropriate null cell (NaN for a numeric column, `""` for a string
+  column) instead of aborting, and a device unreachable at scan start is dropped
+  with a log line (`GeecsSession.telemetry` returns `None`).  Telemetry is
+  **dtype-tolerant, per-variable**: each signal's type is inferred from its PV
+  (`epics_signal_r(datatype=None, …)`), so numeric variables stay numeric
+  (float) for downstream analysis while enum/string/path variables — e.g.
+  `U_VisaPlungers` `DigitalOutput.Channel N` — are logged as their string/label
+  value.  A single non-numeric `get='yes'` variable no longer fails to connect
+  and take the whole device (including its numeric columns) down with it: **no
+  telemetry variable or device is dropped for a type reason** — only a
+  genuinely unreachable device degrades to a dropped device.  If we `get` it,
+  we log it.  Telemetry columns carry the `telemetry_<device>-` name prefix so
+  they are distinguishable from Tier-1 save-set data (see `EVENT_SCHEMA.md`);
+  selection is recorded in run metadata under `background_telemetry`.  Gated on
+  `ScanRequest.background_telemetry` (else
+  `ExperimentDefaults.background_telemetry`, default true).
 - New `geecs_bluesky/db_runtime.py` — the pure resolution logic plus the
   DB-backed `GeecsDbScalarPolicy` provider (the one place touching `GeecsDb`),
   failure-tolerant: a DB lookup that fails degrades to empty policy with a

--- a/GeecsBluesky/CHANGELOG.md
+++ b/GeecsBluesky/CHANGELOG.md
@@ -4,6 +4,63 @@ All notable changes to `geecs-bluesky` are documented here.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.24.0] - 2026-07-08
+
+M3c — the DB-integration runtime tier lands, wiring the two-tier recording
+model (`SaveSetEntry` runtime contract, `ExperimentDefaults`) into
+`GeecsSession.run`.  All three capabilities are gated by the schema flags that
+already existed; the schema is untouched.
+
+### Added
+
+- **db_scalars resolution (Tier 1).**  A save-set entry's recorded scalars are
+  now its DB `get='yes'` variables (from `expt_device_variable`) unioned with
+  its explicit `scalars` list (`db_scalars=True`, the default);
+  `all_scalars=True` unions every DB variable instead; `db_scalars=False` (what
+  the legacy converter pins) records only the explicit list.  Resolution is a
+  pure function (`db_runtime.resolve_entry_scalars`) threaded through
+  `save_set_to_devices_config(save_set, scalar_policy)`.  With no DB policy
+  (the GUI-bridge path, or off the lab network) only the explicit list is
+  recorded — strictly additive over M3b.  `all_scalars` is no longer a blanket
+  `NotImplementedError`: it resolves when a policy is present, and only raises
+  on the no-policy path.
+- **Scan start/end DB writes (participants-only).**  For devices participating
+  in the scan (save-set devices + scan-variable devices — never every
+  experiment device), the `set='yes'` rows' `startvalue` is written at scan
+  start and `endvalue` at scan end, through the same CA `:SP` setpoint path as
+  action plans.  Per-entry `at_scan_start` / `at_scan_end` overrides layer on
+  top (value replaces, explicit `null` suppresses, absence keeps the DB value);
+  `save` / `localsavingpath` are always skipped.  Start writes run after setup
+  actions / before acquisition (chained into the setup hook); end writes run in
+  the finalize chain so they execute even on abort (chained into the closeout
+  hook, which `build_step_scan_plan` wraps in a `finalize_wrapper`).  Gated on
+  `ExperimentDefaults.apply_db_scan_defaults` (default true).  Every write
+  actually applied is recorded in run metadata under `db_scan_writes` for
+  provenance.
+- **Background telemetry tier (Tier 2).**  Every live experiment device with a
+  `get='yes'` variable not in the save set is recorded as best-effort snapshot
+  columns via the new soft `CaTelemetryReadable`: read-only, sampled once per
+  event row, never waited on — a signal read that fails degrades to a NaN cell
+  instead of aborting, and a device unreachable at scan start is dropped with a
+  log line (`GeecsSession.telemetry` returns `None`).  Telemetry columns carry
+  the `telemetry_<device>-` name prefix so they are distinguishable from Tier-1
+  save-set data (see `EVENT_SCHEMA.md`); selection is recorded in run metadata
+  under `background_telemetry`.  Gated on `ScanRequest.background_telemetry`
+  (else `ExperimentDefaults.background_telemetry`, default true).
+- New `geecs_bluesky/db_runtime.py` — the pure resolution logic plus the
+  DB-backed `GeecsDbScalarPolicy` provider (the one place touching `GeecsDb`),
+  failure-tolerant: a DB lookup that fails degrades to empty policy with a
+  warning, so a scan never aborts because the DB was briefly unreachable.
+
+### Notes
+
+- Optimize mode resolves `db_scalars` (recorded-scalar consistency) but does
+  **not** run the DB start/end writes or telemetry yet (no scan-boundary hook
+  on `GeecsSession.optimize`) — skip-and-record, mirroring the action-skip
+  posture; recorded in run metadata under `db_scan_runtime`.
+- Requires the gateway ≥ 0.9.0 (new `GeecsDb.get_all_experiment_variables` and
+  `GeecsDb.get_scan_boundary_writes`).
+
 ## [0.23.0] - 2026-07-07
 
 M3b — every engine-pending ScanRequest seam closes: actions execute inside

--- a/GeecsBluesky/CHANGELOG.md
+++ b/GeecsBluesky/CHANGELOG.md
@@ -8,8 +8,18 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 M3c — the DB-integration runtime tier lands, wiring the two-tier recording
 model (`SaveSetEntry` runtime contract, `ExperimentDefaults`) into
-`GeecsSession.run`.  All three capabilities are gated by the schema flags that
-already existed; the schema is untouched.
+`GeecsSession.run`.  **Get-side only:** `db_scalars` (Tier 1 recorded
+scalars) and background telemetry (Tier 2) are honored; the DB **set-side**
+(scan start/end writes from the `set='yes'` rows) is intentionally
+**disabled** in this version.  Live DB inspection showed the boundary writes
+would race the shot controller / TriggerProfile on the DG645
+(`U_DG645_ShotControl`'s `set='yes'` rows are the `Trigger.Source` /
+`Amplitude.Ch AB` variables the shot controller already drives), and the
+remaining `set='yes'` rows are almost all `save` / `localsavingpath` (the
+scanner owns saving via its save-windowing).  The reserved schema fields
+(`SaveSetEntry.at_scan_start` / `at_scan_end`,
+`ExperimentDefaults.apply_db_scan_defaults`) are kept on record for a
+possible future re-enable but are not applied.
 
 ### Added
 
@@ -32,19 +42,12 @@ already existed; the schema is untouched.
   recorded — strictly additive over M3b.  `all_scalars` is no longer a blanket
   `NotImplementedError`: it resolves when a policy is present, and only raises
   on the no-policy path.
-- **Scan start/end DB writes (participants-only).**  For devices participating
-  in the scan (save-set devices + scan-variable devices — never every
-  experiment device), the `set='yes'` rows' `startvalue` is written at scan
-  start and `endvalue` at scan end, through the same CA `:SP` setpoint path as
-  action plans.  Per-entry `at_scan_start` / `at_scan_end` overrides layer on
-  top (value replaces, explicit `null` suppresses, absence keeps the DB value);
-  `save` / `localsavingpath` are always skipped.  Start writes run after setup
-  actions / before acquisition (chained into the setup hook); end writes run in
-  the finalize chain so they execute even on abort (chained into the closeout
-  hook, which `build_step_scan_plan` wraps in a `finalize_wrapper`).  Gated on
-  `ExperimentDefaults.apply_db_scan_defaults` (default true).  Every write
-  actually applied is recorded in run metadata under `db_scan_writes` for
-  provenance.
+- **Scan start/end DB writes — set-side, intentionally disabled.**  The DB
+  `set='yes'` boundary writes are **not** applied by the engine in this
+  version (see the version summary above for the DG645-conflict rationale).
+  A save-set entry that still carries `at_scan_start` / `at_scan_end` is not
+  an error — the engine logs one WARNING naming the device and records
+  nothing; the values are inert.  No `db_scan_writes` metadata is produced.
 - **Background telemetry tier (Tier 2).**  Every live experiment device with a
   `get='yes'` variable not in the save set is recorded as best-effort snapshot
   columns via the new soft `CaTelemetryReadable`: read-only, sampled once per
@@ -63,11 +66,13 @@ already existed; the schema is untouched.
 ### Notes
 
 - Optimize mode resolves `db_scalars` (recorded-scalar consistency) but does
-  **not** run the DB start/end writes or telemetry yet (no scan-boundary hook
-  on `GeecsSession.optimize`) — skip-and-record, mirroring the action-skip
-  posture; recorded in run metadata under `db_scan_runtime`.
-- Requires the gateway ≥ 0.9.0 (new `GeecsDb.get_all_experiment_variables` and
-  `GeecsDb.get_scan_boundary_writes`).
+  **not** run background telemetry yet (no scan-boundary hook on
+  `GeecsSession.optimize`) — skip-and-record; recorded in run metadata under
+  `db_scan_runtime`.  The set-side is disabled everywhere in this version.
+- Requires the gateway ≥ 0.9.0 (new `GeecsDb.get_all_experiment_variables`).
+  `GeecsDb.get_scan_boundary_writes` also lands in 0.9.0 as a reserved,
+  currently-unused query (the set-side is disabled) — not consumed by the
+  engine.
 
 ## [0.23.0] - 2026-07-07
 

--- a/GeecsBluesky/CLAUDE.md
+++ b/GeecsBluesky/CLAUDE.md
@@ -418,8 +418,17 @@ the DB blipped):
 - **Background telemetry (Tier 2).**  Every live device with a `get='yes'`
   variable not in the save set → soft `CaTelemetryReadable` columns
   (`telemetry_<device>-…`): read-only, never waited on (a failed read is a
-  NaN cell, a dead-at-start device is dropped with a log line via
-  `session.telemetry` returning `None`).  Gated on
+  dtype-appropriate null cell — NaN for numeric, `""` for string — and a
+  dead-at-start device is dropped with a log line via `session.telemetry`
+  returning `None`).  Telemetry is **dtype-tolerant, per-variable**: signal
+  type is inferred from the PV (`epics_signal_r(datatype=None, …)`), so
+  numerics stay float (downstream analysis unaffected) while enum/string/path
+  variables (e.g. `U_VisaPlungers` `DigitalOutput.Channel N`) are logged as
+  their label string.  **No telemetry variable — and no telemetry device — is
+  dropped for a *type* reason** (one awkward non-numeric channel must never
+  take the device's other columns down; do NOT regress this back to a forced
+  `datatype=float`).  A device is dropped only when genuinely unreachable.
+  The rule: if we `get` it, we log it.  Gated on
   `ScanRequest.background_telemetry` else the experiment default; selection
   recorded (`background_telemetry`).  **Softness vs synchronicity are
   mutually exclusive — telemetry must never gate a shot; do not make it

--- a/GeecsBluesky/CLAUDE.md
+++ b/GeecsBluesky/CLAUDE.md
@@ -400,12 +400,13 @@ overriding explicit values — and every applied default is recorded into
 the run metadata for provenance (closeout defaults append *after* the
 scan's own since geecs-schemas 0.2.0 — mirrored teardown).
 
-**M3c (0.24.0) — the DB-integration runtime tier, two-tier recording now
-live.**  Three capabilities, all gated by schema flags that already existed
-(the schema is untouched); the pure resolution logic lives in
-`geecs_bluesky/db_runtime.py`, the one place touching `GeecsDb` is its
-failure-tolerant `GeecsDbScalarPolicy` (a DB lookup that fails degrades to
-empty policy + a warning — a scan never aborts because the DB blipped):
+**M3c (0.24.0) — the DB-integration runtime tier, GET-SIDE ONLY.**  Two
+get-side capabilities are live, all gated by schema flags that already
+existed (the schema fields are untouched — only descriptions changed); the
+pure resolution logic lives in `geecs_bluesky/db_runtime.py`, the one place
+touching `GeecsDb` is its failure-tolerant `GeecsDbScalarPolicy` (a DB lookup
+that fails degrades to empty policy + a warning — a scan never aborts because
+the DB blipped):
 
 - **db_scalars (Tier 1 recorded scalars).**  A `SaveSetEntry`'s recorded
   scalars = its DB `get='yes'` variables ∪ its explicit `scalars`
@@ -414,16 +415,6 @@ empty policy + a warning — a scan never aborts because the DB blipped):
   `save_set_to_devices_config(save_set, scalar_policy)` threads it; with no
   policy (GUI bridge / off-network) only the explicit list is recorded — M3b
   behavior, strictly additive.
-- **Scan start/end DB writes (participants-only).**  For scan participants
-  (save-set devices + scan-variable devices — **not** every experiment
-  device), `set='yes'` rows' `startvalue` write at start and `endvalue` at
-  end, through the same CA `:SP` path actions use.  `at_scan_start` /
-  `at_scan_end` overrides layer on (value replaces, explicit `null`
-  suppresses, absence = DB value); `save` / `localsavingpath` always skipped.
-  Start writes chain into the setup hook (after setup actions, before
-  acquisition); end writes chain into the closeout hook (finalize — runs on
-  abort).  Gated on `ExperimentDefaults.apply_db_scan_defaults`; applied
-  writes recorded in run metadata (`db_scan_writes`).
 - **Background telemetry (Tier 2).**  Every live device with a `get='yes'`
   variable not in the save set → soft `CaTelemetryReadable` columns
   (`telemetry_<device>-…`): read-only, never waited on (a failed read is a
@@ -434,11 +425,28 @@ empty policy + a warning — a scan never aborts because the DB blipped):
   mutually exclusive — telemetry must never gate a shot; do not make it
   participate in shot completion.**
 
-Optimize mode resolves db_scalars but does not run start/end writes or
-telemetry yet (no scan-boundary hook on `GeecsSession.optimize`) — recorded as
-`db_scan_runtime` in metadata.  Adding a new analyzer/writer still must not
-create scan folders (cross-package invariant); M3c is scanner-side but touches
-no scan-folder creation.
+**Set-side (DB scan start/end writes) is intentionally DISABLED / reserved.**
+The `set='yes'` boundary writes are *not* applied by the engine.  Live DB
+inspection showed they would race the shot controller / TriggerProfile on the
+DG645 — `U_DG645_ShotControl`'s `set='yes'` rows are `Trigger.Source` and
+`Amplitude.Ch AB`, the very variables the ShotController already drives — and
+the remaining `set='yes'` rows are almost all `save` / `localsavingpath`,
+which the scanner owns through its save-windowing.  So triggering is set up
+via the TriggerProfile / shot controller and camera saving via the scanner's
+own windowing, never via DB boundary writes.  The reserved schema fields
+(`SaveSetEntry.at_scan_start` / `at_scan_end`,
+`ExperimentDefaults.apply_db_scan_defaults`) are kept for a possible future
+re-enable; a config that still sets them draws one `logger.warning`
+(`warn_if_reserved_boundary_overrides`) and is otherwise inert (no boundary
+write, no setup/closeout chaining, no `db_scan_writes` metadata).  The
+gateway's `GeecsDb.get_scan_boundary_writes` remains a reserved read-only
+library query, not consumed by the engine.
+
+Optimize mode resolves db_scalars but does not run telemetry yet (no
+scan-boundary hook on `GeecsSession.optimize`) — recorded as
+`db_scan_runtime` in metadata; the set-side is disabled everywhere.  Adding a
+new analyzer/writer still must not create scan folders (cross-package
+invariant); M3c is scanner-side but touches no scan-folder creation.
 
 ## Known Gaps (as of 0.21.0)
 

--- a/GeecsBluesky/CLAUDE.md
+++ b/GeecsBluesky/CLAUDE.md
@@ -400,6 +400,46 @@ overriding explicit values — and every applied default is recorded into
 the run metadata for provenance (closeout defaults append *after* the
 scan's own since geecs-schemas 0.2.0 — mirrored teardown).
 
+**M3c (0.24.0) — the DB-integration runtime tier, two-tier recording now
+live.**  Three capabilities, all gated by schema flags that already existed
+(the schema is untouched); the pure resolution logic lives in
+`geecs_bluesky/db_runtime.py`, the one place touching `GeecsDb` is its
+failure-tolerant `GeecsDbScalarPolicy` (a DB lookup that fails degrades to
+empty policy + a warning — a scan never aborts because the DB blipped):
+
+- **db_scalars (Tier 1 recorded scalars).**  A `SaveSetEntry`'s recorded
+  scalars = its DB `get='yes'` variables ∪ its explicit `scalars`
+  (`db_scalars=True`, default); `all_scalars=True` unions *every* DB variable;
+  `db_scalars=False` (the legacy-converter pin) = explicit-only.
+  `save_set_to_devices_config(save_set, scalar_policy)` threads it; with no
+  policy (GUI bridge / off-network) only the explicit list is recorded — M3b
+  behavior, strictly additive.
+- **Scan start/end DB writes (participants-only).**  For scan participants
+  (save-set devices + scan-variable devices — **not** every experiment
+  device), `set='yes'` rows' `startvalue` write at start and `endvalue` at
+  end, through the same CA `:SP` path actions use.  `at_scan_start` /
+  `at_scan_end` overrides layer on (value replaces, explicit `null`
+  suppresses, absence = DB value); `save` / `localsavingpath` always skipped.
+  Start writes chain into the setup hook (after setup actions, before
+  acquisition); end writes chain into the closeout hook (finalize — runs on
+  abort).  Gated on `ExperimentDefaults.apply_db_scan_defaults`; applied
+  writes recorded in run metadata (`db_scan_writes`).
+- **Background telemetry (Tier 2).**  Every live device with a `get='yes'`
+  variable not in the save set → soft `CaTelemetryReadable` columns
+  (`telemetry_<device>-…`): read-only, never waited on (a failed read is a
+  NaN cell, a dead-at-start device is dropped with a log line via
+  `session.telemetry` returning `None`).  Gated on
+  `ScanRequest.background_telemetry` else the experiment default; selection
+  recorded (`background_telemetry`).  **Softness vs synchronicity are
+  mutually exclusive — telemetry must never gate a shot; do not make it
+  participate in shot completion.**
+
+Optimize mode resolves db_scalars but does not run start/end writes or
+telemetry yet (no scan-boundary hook on `GeecsSession.optimize`) — recorded as
+`db_scan_runtime` in metadata.  Adding a new analyzer/writer still must not
+create scan folders (cross-package invariant); M3c is scanner-side but touches
+no scan-folder creation.
+
 ## Known Gaps (as of 0.21.0)
 
 The acquisition-modes architecture is complete and hardware-verified (both

--- a/GeecsBluesky/EVENT_SCHEMA.md
+++ b/GeecsBluesky/EVENT_SCHEMA.md
@@ -62,8 +62,7 @@ ScanRequest runs (`GeecsSession.run`) may also add, for provenance:
 |---|---|
 | `applied_defaults` | Experiment-defaults fields that filled a silent request |
 | `action_plans` | Assembled per-slot action execution order |
-| `db_scan_writes` | DB start/end setpoint writes actually applied (M3c): `{at_scan_start: [...], at_scan_end: [...]}`, each write `{device, variable, value, source}` (`source` = `db` or `override`) |
-| `background_telemetry` | `{device: [variables]}` recorded as Tier-2 telemetry (M3c; present only when telemetry ran) |
+| `background_telemetry` | `{device: [variables]}` recorded as Tier-2 telemetry (M3c get-side; present only when telemetry ran) |
 
 **`scan_id` note:** `scan_id` has no uniqueness contract in Bluesky — the
 day-scoped number resets to 1 each day, which is fine (`uid` is the real key).

--- a/GeecsBluesky/EVENT_SCHEMA.md
+++ b/GeecsBluesky/EVENT_SCHEMA.md
@@ -56,6 +56,15 @@ Free-run mode adds:
 | `device_t0s` | device → t0 `acq_timestamp` captured by the t0-sync stage |
 | `t0_sync_window_s` | Acceptance window used by the t0-sync stage |
 
+ScanRequest runs (`GeecsSession.run`) may also add, for provenance:
+
+| Key | Meaning |
+|---|---|
+| `applied_defaults` | Experiment-defaults fields that filled a silent request |
+| `action_plans` | Assembled per-slot action execution order |
+| `db_scan_writes` | DB start/end setpoint writes actually applied (M3c): `{at_scan_start: [...], at_scan_end: [...]}`, each write `{device, variable, value, source}` (`source` = `db` or `override`) |
+| `background_telemetry` | `{device: [variables]}` recorded as Tier-2 telemetry (M3c; present only when telemetry ran) |
+
 **`scan_id` note:** `scan_id` has no uniqueness contract in Bluesky — the
 day-scoped number resets to 1 each day, which is fine (`uid` is the real key).
 Never look a run up by `scan_id` alone; qualify with the day, or use
@@ -91,6 +100,20 @@ truthfully-labeled data for realignment downstream by `shot_id`).
 
 **Per snapshot device** (asynchronous, no `acq_timestamp`) — every row: its
 data variables, sampled at row emission. No companion columns.
+
+**Background-telemetry columns** (Tier 2, best-effort) — every live experiment
+device with a `get='yes'` variable *not* in the save set is recorded as soft
+snapshot columns read from the gateway monitor cache. They are distinguished
+from Tier-1 save-set data by a **device-name prefix**: the ophyd device is
+`telemetry_<device>`, so every column it contributes is keyed
+`telemetry_<device>-<safe_var>`. Telemetry is read-only, sampled once per row,
+**never waited on** — a value that cannot be read (a device that went dead
+mid-scan) is a NaN cell, and a device unreachable at scan start is dropped with
+a log line, never a dialog or abort. Telemetry columns are **not** added to
+`geecs_scalar_headers` (they are Tier 2, not legacy s-file scalars). The
+start-doc `background_telemetry` key (present only when telemetry ran) records
+the `{device: [variables]}` actually selected. This is an additive
+device-name convention, not a new schema field — it does not bump the version.
 
 **Free-run tail flush:** after the last shot, free-run runs emit one final
 event on a separate `flush` stream (one extra read of all devices) so a

--- a/GeecsBluesky/EVENT_SCHEMA.md
+++ b/GeecsBluesky/EVENT_SCHEMA.md
@@ -105,10 +105,21 @@ device with a `get='yes'` variable *not* in the save set is recorded as soft
 snapshot columns read from the gateway monitor cache. They are distinguished
 from Tier-1 save-set data by a **device-name prefix**: the ophyd device is
 `telemetry_<device>`, so every column it contributes is keyed
-`telemetry_<device>-<safe_var>`. Telemetry is read-only, sampled once per row,
-**never waited on** — a value that cannot be read (a device that went dead
-mid-scan) is a NaN cell, and a device unreachable at scan start is dropped with
-a log line, never a dialog or abort. Telemetry columns are **not** added to
+`telemetry_<device>-<safe_var>`. Telemetry is **dtype-tolerant**: each column's
+type is inferred from its PV — numeric variables stay numeric (float) so
+downstream telemetry analysis keeps working, while enum/string/path variables
+(e.g. `U_VisaPlungers` `DigitalOutput.Channel N`) are recorded as their
+string/label value. A telemetry column set may therefore mix float and string
+columns; do not assume every telemetry column is float. Typing is
+**per-variable** — one non-numeric variable is captured as a string and never
+drops the device's other (numeric) columns. Telemetry is read-only, sampled
+once per row, **never waited on** — a value that cannot be read (a device that
+went dead mid-scan) degrades to a dtype-appropriate null cell (NaN for a
+numeric column, `""` for a string column), and a device unreachable at scan
+start is dropped with a log line, never a dialog or abort. No telemetry
+variable — and no telemetry device — is dropped for a *type* reason; only a
+genuinely unreachable device degrades to a dropped device. Telemetry columns
+are **not** added to
 `geecs_scalar_headers` (they are Tier 2, not legacy s-file scalars). The
 start-doc `background_telemetry` key (present only when telemetry ran) records
 the `{device: [variables]}` actually selected. This is an additive

--- a/GeecsBluesky/geecs_bluesky/db_runtime.py
+++ b/GeecsBluesky/geecs_bluesky/db_runtime.py
@@ -1,9 +1,9 @@
-"""DB-integration runtime (M3c): the two-tier recording model, wired.
+"""DB-integration runtime (M3c): the get-side two-tier recording model, wired.
 
 This module turns the GEECS experiment database's per-experiment
-device-variable policy (MySQL table ``expt_device_variable``) into the three
-runtime capabilities the schema already describes (see the ``SaveSetEntry``
-runtime contract in :mod:`geecs_schemas.save_set`, and
+device-variable policy (MySQL table ``expt_device_variable``) into the two
+**get-side** runtime capabilities the schema describes (see the
+``SaveSetEntry`` runtime contract in :mod:`geecs_schemas.save_set`, and
 :class:`~geecs_schemas.experiment_defaults.ExperimentDefaults`):
 
 1. **db_scalars resolution** (Tier 1 recorded scalars).  For a save-set entry
@@ -13,34 +13,36 @@ runtime contract in :mod:`geecs_schemas.save_set`, and
    device instead of just the ``get='yes'`` subset; ``db_scalars=False`` (what
    the legacy converter pins) records only the explicit ``scalars``.
 
-2. **Scan start/end DB writes** (participants-only).  For devices
-   **participating** in the scan (save-set devices + scan-variable devices —
-   not every experiment device), the ``set='yes'`` rows' ``startvalue`` is
-   written at scan start and ``endvalue`` at scan end, with the entry's
-   ``at_scan_start`` / ``at_scan_end`` overrides layered on top (a value
-   replaces the DB value, an explicit ``None`` suppresses the write, absence
-   keeps the DB value).  ``save`` / ``localsavingpath`` are always skipped
-   (native saving is owned by the run discipline).
-
-3. **Background telemetry tier** (Tier 2).  Every live experiment device with
+2. **Background telemetry tier** (Tier 2).  Every live experiment device with
    a ``get='yes'`` variable that is *not* in the save set is recorded as
    best-effort snapshot columns — read-only, never waited on, a dead device
    dropped with a log line.  Selection of which ``(device, variables)`` become
    telemetry is pure here; the soft read lives in
    :class:`~geecs_bluesky.devices.ca.telemetry.CaTelemetryReadable`.
 
+The **set-side** (DB scan start/end writes, from the ``set='yes'`` rows'
+``startvalue``/``endvalue``) is **intentionally disabled** in this version.
+Live DB inspection showed the boundary writes would race the shot
+controller / TriggerProfile on the DG645 (``U_DG645_ShotControl`` has
+``set='yes'`` rows for ``Trigger.Source`` and ``Amplitude.Ch AB`` — the very
+variables the shot controller already drives), and the remaining ``set='yes'``
+rows are almost all ``save`` / ``localsavingpath`` (which the scanner owns
+through its save-windowing).  The engine sets up triggering via the
+TriggerProfile/shot controller and camera saving via its own save-windowing,
+so DB set-side writes are not honored.  The reserved-but-not-honored
+schema fields (``SaveSetEntry.at_scan_start`` / ``at_scan_end`` and
+``ExperimentDefaults.apply_db_scan_defaults``) are kept on record for a
+possible future re-enable, and the gateway's
+:meth:`~geecs_ca_gateway.db.geecs_db.GeecsDb.get_scan_boundary_writes` query
+remains a reserved read-only library method (not consumed by the engine).
+
 Everything in this module is a **pure function** except the thin
 :class:`GeecsDbScalarPolicy` provider, which is the one place that touches
-:class:`~geecs_ca_gateway.db.geecs_db.GeecsDb`.  The provider caches its three
-queries per experiment and **tolerates a missing/incompletely-curated DB**
-(the maintainer's known curation caveat): a lookup failure logs and yields
+:class:`~geecs_ca_gateway.db.geecs_db.GeecsDb`.  The provider caches its two
+get-side queries per experiment and **tolerates a missing/incompletely-curated
+DB** (the maintainer's known curation caveat): a lookup failure logs and yields
 empty policy rather than aborting the scan.  Keeping the policy separable is
 what makes the resolution logic testable with no MySQL access.
-
-The engine never talks to the DB at *write* time: the DB only supplies which
-variables and what values; the writes themselves ride the same CA ``:SP``
-setpoint path that action plans use (see
-:func:`~geecs_bluesky.scan_request_runner.make_boundary_write_plan`).
 """
 
 from __future__ import annotations
@@ -53,34 +55,6 @@ from geecs_schemas import SaveSet
 
 logger = logging.getLogger(__name__)
 
-#: Variables that are never DB-driven scan-boundary writes — native saving is
-#: owned by the run discipline, not per-device ``expt_device_variable`` rows.
-SUPPRESSED_BOUNDARY_VARIABLES = frozenset({"save", "localsavingpath"})
-
-
-@dataclass(frozen=True)
-class BoundaryWrite:
-    """One resolved scan-boundary setpoint write.
-
-    Attributes
-    ----------
-    device : str
-        GEECS device name.
-    variable : str
-        Variable to write (a ``set='yes'`` row's variable).
-    value : str
-        The wire-string value to send (the DB startvalue/endvalue, or an
-        override).
-    source : str
-        Provenance tag: ``"db"`` (from the row) or ``"override"`` (replaced by
-        an entry's ``at_scan_start`` / ``at_scan_end``).
-    """
-
-    device: str
-    variable: str
-    value: str
-    source: str = "db"
-
 
 @runtime_checkable
 class ScalarPolicyProvider(Protocol):
@@ -89,7 +63,9 @@ class ScalarPolicyProvider(Protocol):
     The seam between the pure resolution logic and
     :class:`~geecs_ca_gateway.db.geecs_db.GeecsDb`.  Every method returns an
     empty result rather than raising when the DB is unavailable or a device
-    is uncurated.
+    is uncurated.  This covers only the **get-side** (subscribed ``get='yes'``
+    variables + all-variables queries); the set-side is disabled (see the
+    module docstring).
     """
 
     def get_variables(self, device: str) -> list[str]:
@@ -104,24 +80,16 @@ class ScalarPolicyProvider(Protocol):
         """Return ``{device: [get='yes' vars]}`` for the whole experiment."""
         ...
 
-    def boundary_writes(self, device: str) -> list[dict]:
-        """Return the device's ``set='yes'`` start/end rows (may be empty).
-
-        Each row is ``{"variable", "startvalue", "endvalue"}`` with string or
-        ``None`` values (as :meth:`GeecsDb.get_scan_boundary_writes` returns).
-        """
-        ...
-
 
 @dataclass
 class GeecsDbScalarPolicy:
     """DB-backed :class:`ScalarPolicyProvider`, one batched query per kind.
 
     Wraps :class:`~geecs_ca_gateway.db.geecs_db.GeecsDb` for one experiment,
-    caching each of its three whole-experiment queries on first use.  Every
-    query is wrapped so a DB failure (off the lab network, a missing table, an
-    uncurated experiment) degrades to empty policy with a single warning — a
-    scan must never abort because the DB was briefly unreachable.
+    caching each of its two get-side whole-experiment queries on first use.
+    Every query is wrapped so a DB failure (off the lab network, a missing
+    table, an uncurated experiment) degrades to empty policy with a single
+    warning — a scan must never abort because the DB was briefly unreachable.
 
     Parameters
     ----------
@@ -139,7 +107,6 @@ class GeecsDbScalarPolicy:
     db: object | None = None
     _subscribed: Optional[dict[str, list[str]]] = field(default=None, init=False)
     _all: Optional[dict[str, list[str]]] = field(default=None, init=False)
-    _boundary: Optional[dict[str, list[dict]]] = field(default=None, init=False)
 
     def _geecs_db(self) -> object:
         if self.db is not None:
@@ -182,22 +149,6 @@ class GeecsDbScalarPolicy:
                 self._all = {}
         return self._all
 
-    def _boundary_by_device(self) -> dict[str, list[dict]]:
-        if self._boundary is None:
-            try:
-                self._boundary = self._geecs_db().get_scan_boundary_writes(
-                    self.experiment, enabled_only=self.enabled_only
-                )
-            except Exception:
-                logger.warning(
-                    "Could not read set='yes' scan boundary writes for "
-                    "experiment %r; no DB-driven start/end writes will be applied",
-                    self.experiment,
-                    exc_info=True,
-                )
-                self._boundary = {}
-        return self._boundary
-
     def get_variables(self, device: str) -> list[str]:
         """Return *device*'s ``get='yes'`` variables (empty if uncurated)."""
         return list(self.subscribed_by_device().get(device, []))
@@ -205,10 +156,6 @@ class GeecsDbScalarPolicy:
     def all_variables(self, device: str) -> list[str]:
         """Return every tracked variable for *device* (empty if uncurated)."""
         return list(self._all_by_device().get(device, []))
-
-    def boundary_writes(self, device: str) -> list[dict]:
-        """Return *device*'s ``set='yes'`` start/end rows (empty if none)."""
-        return list(self._boundary_by_device().get(device, []))
 
 
 def resolve_entry_scalars(
@@ -270,133 +217,6 @@ def resolve_entry_scalars(
             seen.add(var)
             ordered.append(var)
     return ordered
-
-
-def resolve_boundary_writes(
-    device: str,
-    rows: list[dict],
-    *,
-    which: str,
-    overrides: dict[str, Optional[str]],
-) -> list[BoundaryWrite]:
-    """Resolve one device's start or end setpoint writes (DB + overrides).
-
-    Applies the three override cases documented on ``SaveSetEntry``:
-
-    - a variable absent from *overrides* uses the DB value (the row's
-      ``startvalue`` / ``endvalue``);
-    - a variable mapped to a non-``None`` value replaces the DB value;
-    - a variable mapped to ``None`` suppresses the write entirely.
-
-    A DB row whose value is null and which no override replaces contributes no
-    write (there is nothing to send).  ``save`` / ``localsavingpath`` rows are
-    always dropped.  Overrides naming a variable with no DB row are honored as
-    forced writes (``source="override"``) so an entry can add a boundary write
-    the DB did not curate — except a ``None`` override for such a variable,
-    which is a no-op.
-
-    Parameters
-    ----------
-    device : str
-        GEECS device name.
-    rows : list of dict
-        The device's ``set='yes'`` rows
-        (``{"variable", "startvalue", "endvalue"}``).
-    which : str
-        ``"start"`` or ``"end"`` — selects the row column.
-    overrides : dict
-        The entry's ``at_scan_start`` or ``at_scan_end`` mapping.
-
-    Returns
-    -------
-    list of BoundaryWrite
-        Ordered writes to apply (DB row order; forced overrides appended).
-    """
-    if which not in ("start", "end"):
-        raise ValueError(f"which={which!r} must be 'start' or 'end'")
-    column = "startvalue" if which == "start" else "endvalue"
-    overrides = overrides or {}
-    writes: list[BoundaryWrite] = []
-    handled: set[str] = set()
-    for row in rows:
-        variable = row["variable"]
-        if variable in SUPPRESSED_BOUNDARY_VARIABLES:
-            continue
-        handled.add(variable)
-        if variable in overrides:
-            override = overrides[variable]
-            if override is None:
-                logger.debug(
-                    "scan %s write for %s:%s suppressed by override",
-                    which,
-                    device,
-                    variable,
-                )
-                continue
-            writes.append(BoundaryWrite(device, variable, str(override), "override"))
-            continue
-        db_value = row.get(column)
-        if db_value is None:
-            continue
-        writes.append(BoundaryWrite(device, variable, str(db_value), "db"))
-    # Overrides for variables the DB did not curate: honor a value as a forced
-    # write; a None override for an uncurated variable is simply a no-op.
-    for variable, override in overrides.items():
-        if variable in handled or variable in SUPPRESSED_BOUNDARY_VARIABLES:
-            continue
-        if override is None:
-            continue
-        writes.append(BoundaryWrite(device, variable, str(override), "override"))
-    return writes
-
-
-def collect_scan_boundary_writes(
-    participants: dict[str, dict[str, dict[str, Optional[str]]]],
-    provider: ScalarPolicyProvider | None,
-) -> tuple[list[BoundaryWrite], list[BoundaryWrite]]:
-    """Resolve start and end writes for every participating device.
-
-    Participants are the devices taking part in the scan (save-set devices +
-    scan-variable devices) — never every experiment device (the maintainer's
-    explicit decision).  Each maps to its ``at_scan_start`` / ``at_scan_end``
-    override dicts.
-
-    Parameters
-    ----------
-    participants : dict
-        ``{device: {"at_scan_start": {...}, "at_scan_end": {...}}}``.  A
-        device with no overrides still participates (empty dicts).
-    provider : ScalarPolicyProvider or None
-        Supplies the ``set='yes'`` rows; ``None`` means no DB writes at all
-        (only forced overrides survive).
-
-    Returns
-    -------
-    tuple
-        ``(start_writes, end_writes)`` in device then row order.
-    """
-    start: list[BoundaryWrite] = []
-    end: list[BoundaryWrite] = []
-    for device in participants:
-        overrides = participants[device]
-        rows = provider.boundary_writes(device) if provider is not None else []
-        start.extend(
-            resolve_boundary_writes(
-                device,
-                rows,
-                which="start",
-                overrides=overrides.get("at_scan_start", {}),
-            )
-        )
-        end.extend(
-            resolve_boundary_writes(
-                device,
-                rows,
-                which="end",
-                overrides=overrides.get("at_scan_end", {}),
-            )
-        )
-    return start, end
 
 
 def select_telemetry_variables(

--- a/GeecsBluesky/geecs_bluesky/db_runtime.py
+++ b/GeecsBluesky/geecs_bluesky/db_runtime.py
@@ -1,0 +1,437 @@
+"""DB-integration runtime (M3c): the two-tier recording model, wired.
+
+This module turns the GEECS experiment database's per-experiment
+device-variable policy (MySQL table ``expt_device_variable``) into the three
+runtime capabilities the schema already describes (see the ``SaveSetEntry``
+runtime contract in :mod:`geecs_schemas.save_set`, and
+:class:`~geecs_schemas.experiment_defaults.ExperimentDefaults`):
+
+1. **db_scalars resolution** (Tier 1 recorded scalars).  For a save-set entry
+   with ``db_scalars=True`` (the default), the scalars recorded for the device
+   are its DB ``get='yes'`` variables **unioned** with the entry's explicit
+   ``scalars`` list; ``all_scalars=True`` unions *every* DB variable for the
+   device instead of just the ``get='yes'`` subset; ``db_scalars=False`` (what
+   the legacy converter pins) records only the explicit ``scalars``.
+
+2. **Scan start/end DB writes** (participants-only).  For devices
+   **participating** in the scan (save-set devices + scan-variable devices —
+   not every experiment device), the ``set='yes'`` rows' ``startvalue`` is
+   written at scan start and ``endvalue`` at scan end, with the entry's
+   ``at_scan_start`` / ``at_scan_end`` overrides layered on top (a value
+   replaces the DB value, an explicit ``None`` suppresses the write, absence
+   keeps the DB value).  ``save`` / ``localsavingpath`` are always skipped
+   (native saving is owned by the run discipline).
+
+3. **Background telemetry tier** (Tier 2).  Every live experiment device with
+   a ``get='yes'`` variable that is *not* in the save set is recorded as
+   best-effort snapshot columns — read-only, never waited on, a dead device
+   dropped with a log line.  Selection of which ``(device, variables)`` become
+   telemetry is pure here; the soft read lives in
+   :class:`~geecs_bluesky.devices.ca.telemetry.CaTelemetryReadable`.
+
+Everything in this module is a **pure function** except the thin
+:class:`GeecsDbScalarPolicy` provider, which is the one place that touches
+:class:`~geecs_ca_gateway.db.geecs_db.GeecsDb`.  The provider caches its three
+queries per experiment and **tolerates a missing/incompletely-curated DB**
+(the maintainer's known curation caveat): a lookup failure logs and yields
+empty policy rather than aborting the scan.  Keeping the policy separable is
+what makes the resolution logic testable with no MySQL access.
+
+The engine never talks to the DB at *write* time: the DB only supplies which
+variables and what values; the writes themselves ride the same CA ``:SP``
+setpoint path that action plans use (see
+:func:`~geecs_bluesky.scan_request_runner.make_boundary_write_plan`).
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import Optional, Protocol, runtime_checkable
+
+from geecs_schemas import SaveSet
+
+logger = logging.getLogger(__name__)
+
+#: Variables that are never DB-driven scan-boundary writes — native saving is
+#: owned by the run discipline, not per-device ``expt_device_variable`` rows.
+SUPPRESSED_BOUNDARY_VARIABLES = frozenset({"save", "localsavingpath"})
+
+
+@dataclass(frozen=True)
+class BoundaryWrite:
+    """One resolved scan-boundary setpoint write.
+
+    Attributes
+    ----------
+    device : str
+        GEECS device name.
+    variable : str
+        Variable to write (a ``set='yes'`` row's variable).
+    value : str
+        The wire-string value to send (the DB startvalue/endvalue, or an
+        override).
+    source : str
+        Provenance tag: ``"db"`` (from the row) or ``"override"`` (replaced by
+        an entry's ``at_scan_start`` / ``at_scan_end``).
+    """
+
+    device: str
+    variable: str
+    value: str
+    source: str = "db"
+
+
+@runtime_checkable
+class ScalarPolicyProvider(Protocol):
+    """Supplies per-device DB variable policy for one experiment.
+
+    The seam between the pure resolution logic and
+    :class:`~geecs_ca_gateway.db.geecs_db.GeecsDb`.  Every method returns an
+    empty result rather than raising when the DB is unavailable or a device
+    is uncurated.
+    """
+
+    def get_variables(self, device: str) -> list[str]:
+        """Return the device's ``get='yes'`` variables (may be empty)."""
+        ...
+
+    def all_variables(self, device: str) -> list[str]:
+        """Return every variable the experiment tracks for *device* (may be empty)."""
+        ...
+
+    def subscribed_by_device(self) -> dict[str, list[str]]:
+        """Return ``{device: [get='yes' vars]}`` for the whole experiment."""
+        ...
+
+    def boundary_writes(self, device: str) -> list[dict]:
+        """Return the device's ``set='yes'`` start/end rows (may be empty).
+
+        Each row is ``{"variable", "startvalue", "endvalue"}`` with string or
+        ``None`` values (as :meth:`GeecsDb.get_scan_boundary_writes` returns).
+        """
+        ...
+
+
+@dataclass
+class GeecsDbScalarPolicy:
+    """DB-backed :class:`ScalarPolicyProvider`, one batched query per kind.
+
+    Wraps :class:`~geecs_ca_gateway.db.geecs_db.GeecsDb` for one experiment,
+    caching each of its three whole-experiment queries on first use.  Every
+    query is wrapped so a DB failure (off the lab network, a missing table, an
+    uncurated experiment) degrades to empty policy with a single warning — a
+    scan must never abort because the DB was briefly unreachable.
+
+    Parameters
+    ----------
+    experiment : str
+        GEECS experiment name.
+    enabled_only : bool
+        Restrict to devices enabled in the experiment (default true).
+    db : type, optional
+        The ``GeecsDb`` class (injectable for tests); imported lazily by
+        default so this module has no hard dependency on the ``ca`` DB stack.
+    """
+
+    experiment: str
+    enabled_only: bool = True
+    db: object | None = None
+    _subscribed: Optional[dict[str, list[str]]] = field(default=None, init=False)
+    _all: Optional[dict[str, list[str]]] = field(default=None, init=False)
+    _boundary: Optional[dict[str, list[dict]]] = field(default=None, init=False)
+
+    def _geecs_db(self) -> object:
+        if self.db is not None:
+            return self.db
+        from geecs_ca_gateway.db.geecs_db import GeecsDb
+
+        self.db = GeecsDb
+        return GeecsDb
+
+    def subscribed_by_device(self) -> dict[str, list[str]]:
+        """Return ``{device: [get='yes' vars]}`` (cached; empty on DB failure)."""
+        if self._subscribed is None:
+            try:
+                self._subscribed = self._geecs_db().get_subscribed_variables(
+                    self.experiment, enabled_only=self.enabled_only
+                )
+            except Exception:
+                logger.warning(
+                    "Could not read get='yes' variables for experiment %r; "
+                    "db_scalars and background telemetry will use no DB rows",
+                    self.experiment,
+                    exc_info=True,
+                )
+                self._subscribed = {}
+        return self._subscribed
+
+    def _all_by_device(self) -> dict[str, list[str]]:
+        if self._all is None:
+            try:
+                self._all = self._geecs_db().get_all_experiment_variables(
+                    self.experiment, enabled_only=self.enabled_only
+                )
+            except Exception:
+                logger.warning(
+                    "Could not read all variables for experiment %r; "
+                    "all_scalars entries will fall back to get='yes'/explicit",
+                    self.experiment,
+                    exc_info=True,
+                )
+                self._all = {}
+        return self._all
+
+    def _boundary_by_device(self) -> dict[str, list[dict]]:
+        if self._boundary is None:
+            try:
+                self._boundary = self._geecs_db().get_scan_boundary_writes(
+                    self.experiment, enabled_only=self.enabled_only
+                )
+            except Exception:
+                logger.warning(
+                    "Could not read set='yes' scan boundary writes for "
+                    "experiment %r; no DB-driven start/end writes will be applied",
+                    self.experiment,
+                    exc_info=True,
+                )
+                self._boundary = {}
+        return self._boundary
+
+    def get_variables(self, device: str) -> list[str]:
+        """Return *device*'s ``get='yes'`` variables (empty if uncurated)."""
+        return list(self.subscribed_by_device().get(device, []))
+
+    def all_variables(self, device: str) -> list[str]:
+        """Return every tracked variable for *device* (empty if uncurated)."""
+        return list(self._all_by_device().get(device, []))
+
+    def boundary_writes(self, device: str) -> list[dict]:
+        """Return *device*'s ``set='yes'`` start/end rows (empty if none)."""
+        return list(self._boundary_by_device().get(device, []))
+
+
+def resolve_entry_scalars(
+    device: str,
+    explicit: list[str],
+    *,
+    db_scalars: bool,
+    all_scalars: bool,
+    provider: ScalarPolicyProvider | None,
+) -> list[str]:
+    """Resolve the recorded scalar list for one save-set entry.
+
+    The rules (from the ``SaveSetEntry`` docstring):
+
+    - ``db_scalars=False`` → only the explicit list (the legacy converter pins
+      this, preserving each converted element's exact behavior).
+    - ``db_scalars=True``, ``all_scalars=False`` → the DB ``get='yes'``
+      variables ∪ the explicit list.
+    - ``db_scalars=True``, ``all_scalars=True`` → every DB variable for the
+      device ∪ the explicit list.
+
+    The union preserves order: the DB variables first (in DB order), then any
+    explicit variable not already present.  When no *provider* is available (no
+    DB access, the GUI-bridge path) the DB contribution is empty and only the
+    explicit list is recorded — the same shape M3b produced, so the DB tier is
+    strictly additive.
+
+    Parameters
+    ----------
+    device : str
+        GEECS device name (for the DB lookup).
+    explicit : list of str
+        The entry's explicit ``scalars`` list.
+    db_scalars : bool
+        The entry's ``db_scalars`` flag.
+    all_scalars : bool
+        The entry's ``all_scalars`` flag.
+    provider : ScalarPolicyProvider or None
+        Where DB variables come from; ``None`` means no DB contribution.
+
+    Returns
+    -------
+    list of str
+        The resolved recorded scalar list, in stable order.
+    """
+    if not db_scalars:
+        return list(explicit)
+    db_vars: list[str] = []
+    if provider is not None:
+        db_vars = (
+            provider.all_variables(device)
+            if all_scalars
+            else provider.get_variables(device)
+        )
+    ordered: list[str] = []
+    seen: set[str] = set()
+    for var in list(db_vars) + list(explicit):
+        if var not in seen:
+            seen.add(var)
+            ordered.append(var)
+    return ordered
+
+
+def resolve_boundary_writes(
+    device: str,
+    rows: list[dict],
+    *,
+    which: str,
+    overrides: dict[str, Optional[str]],
+) -> list[BoundaryWrite]:
+    """Resolve one device's start or end setpoint writes (DB + overrides).
+
+    Applies the three override cases documented on ``SaveSetEntry``:
+
+    - a variable absent from *overrides* uses the DB value (the row's
+      ``startvalue`` / ``endvalue``);
+    - a variable mapped to a non-``None`` value replaces the DB value;
+    - a variable mapped to ``None`` suppresses the write entirely.
+
+    A DB row whose value is null and which no override replaces contributes no
+    write (there is nothing to send).  ``save`` / ``localsavingpath`` rows are
+    always dropped.  Overrides naming a variable with no DB row are honored as
+    forced writes (``source="override"``) so an entry can add a boundary write
+    the DB did not curate — except a ``None`` override for such a variable,
+    which is a no-op.
+
+    Parameters
+    ----------
+    device : str
+        GEECS device name.
+    rows : list of dict
+        The device's ``set='yes'`` rows
+        (``{"variable", "startvalue", "endvalue"}``).
+    which : str
+        ``"start"`` or ``"end"`` — selects the row column.
+    overrides : dict
+        The entry's ``at_scan_start`` or ``at_scan_end`` mapping.
+
+    Returns
+    -------
+    list of BoundaryWrite
+        Ordered writes to apply (DB row order; forced overrides appended).
+    """
+    if which not in ("start", "end"):
+        raise ValueError(f"which={which!r} must be 'start' or 'end'")
+    column = "startvalue" if which == "start" else "endvalue"
+    overrides = overrides or {}
+    writes: list[BoundaryWrite] = []
+    handled: set[str] = set()
+    for row in rows:
+        variable = row["variable"]
+        if variable in SUPPRESSED_BOUNDARY_VARIABLES:
+            continue
+        handled.add(variable)
+        if variable in overrides:
+            override = overrides[variable]
+            if override is None:
+                logger.debug(
+                    "scan %s write for %s:%s suppressed by override",
+                    which,
+                    device,
+                    variable,
+                )
+                continue
+            writes.append(BoundaryWrite(device, variable, str(override), "override"))
+            continue
+        db_value = row.get(column)
+        if db_value is None:
+            continue
+        writes.append(BoundaryWrite(device, variable, str(db_value), "db"))
+    # Overrides for variables the DB did not curate: honor a value as a forced
+    # write; a None override for an uncurated variable is simply a no-op.
+    for variable, override in overrides.items():
+        if variable in handled or variable in SUPPRESSED_BOUNDARY_VARIABLES:
+            continue
+        if override is None:
+            continue
+        writes.append(BoundaryWrite(device, variable, str(override), "override"))
+    return writes
+
+
+def collect_scan_boundary_writes(
+    participants: dict[str, dict[str, dict[str, Optional[str]]]],
+    provider: ScalarPolicyProvider | None,
+) -> tuple[list[BoundaryWrite], list[BoundaryWrite]]:
+    """Resolve start and end writes for every participating device.
+
+    Participants are the devices taking part in the scan (save-set devices +
+    scan-variable devices) — never every experiment device (the maintainer's
+    explicit decision).  Each maps to its ``at_scan_start`` / ``at_scan_end``
+    override dicts.
+
+    Parameters
+    ----------
+    participants : dict
+        ``{device: {"at_scan_start": {...}, "at_scan_end": {...}}}``.  A
+        device with no overrides still participates (empty dicts).
+    provider : ScalarPolicyProvider or None
+        Supplies the ``set='yes'`` rows; ``None`` means no DB writes at all
+        (only forced overrides survive).
+
+    Returns
+    -------
+    tuple
+        ``(start_writes, end_writes)`` in device then row order.
+    """
+    start: list[BoundaryWrite] = []
+    end: list[BoundaryWrite] = []
+    for device in participants:
+        overrides = participants[device]
+        rows = provider.boundary_writes(device) if provider is not None else []
+        start.extend(
+            resolve_boundary_writes(
+                device,
+                rows,
+                which="start",
+                overrides=overrides.get("at_scan_start", {}),
+            )
+        )
+        end.extend(
+            resolve_boundary_writes(
+                device,
+                rows,
+                which="end",
+                overrides=overrides.get("at_scan_end", {}),
+            )
+        )
+    return start, end
+
+
+def select_telemetry_variables(
+    save_set: SaveSet | None,
+    subscribed_by_device: dict[str, list[str]],
+) -> dict[str, list[str]]:
+    """Select the Tier-2 background-telemetry ``{device: [variables]}``.
+
+    Every experiment device with a ``get='yes'`` variable that is **not** in
+    the save set becomes telemetry.  A device already in the save set is
+    excluded wholesale (its data is Tier-1, with guarantees) — telemetry never
+    duplicates a required device's columns.
+
+    Parameters
+    ----------
+    save_set : SaveSet or None
+        The scan's save set (its entry devices are the Tier-1 set); ``None``
+        means no required devices, so every subscribed device is telemetry.
+    subscribed_by_device : dict
+        ``{device: [get='yes' variables]}`` for the whole experiment.
+
+    Returns
+    -------
+    dict
+        ``{device: [variables]}`` for telemetry, save-set devices removed,
+        empty-variable devices dropped.
+    """
+    required = set()
+    if save_set is not None:
+        required = {entry.device for entry in save_set.entries}
+    selected: dict[str, list[str]] = {}
+    for device, variables in subscribed_by_device.items():
+        if device in required:
+            continue
+        variables = [v for v in variables if v]
+        if variables:
+            selected[device] = list(variables)
+    return selected

--- a/GeecsBluesky/geecs_bluesky/devices/ca/__init__.py
+++ b/GeecsBluesky/geecs_bluesky/devices/ca/__init__.py
@@ -15,6 +15,7 @@ from geecs_bluesky.devices.ca.generic_detector import CaGenericDetector
 from geecs_bluesky.devices.ca.motor import CaMotor
 from geecs_bluesky.devices.ca.settable import CaSettable
 from geecs_bluesky.devices.ca.snapshot import CaSnapshotReadable
+from geecs_bluesky.devices.ca.telemetry import CaTelemetryReadable
 from geecs_bluesky.devices.ca.timestamped_readable import CaTimestampedReadable
 from geecs_bluesky.devices.ca.triggerable import CaAcqTimestampReadable, CaTriggerable
 
@@ -25,6 +26,7 @@ __all__ = [
     "CaMotor",
     "CaSettable",
     "CaSnapshotReadable",
+    "CaTelemetryReadable",
     "CaTimestampedReadable",
     "CaTriggerable",
 ]

--- a/GeecsBluesky/geecs_bluesky/devices/ca/generic_detector.py
+++ b/GeecsBluesky/geecs_bluesky/devices/ca/generic_detector.py
@@ -83,6 +83,14 @@ class CaGenericDetector(ShotIdSupport, NonScalarSaveSupport, CaTriggerable):
         }
         self._save_nonscalar_data = save_nonscalar_data
         if save_nonscalar_data:
+            # A file/image-saving device surfaces acq_timestamp as an s-file
+            # column so saved files tie back to scan rows (legacy parity — the
+            # saved filenames are stamped with it, and an images-only device
+            # otherwise contributes no scalar column at all). For a pure-scalar
+            # device acq_timestamp stays an excluded companion column.
+            self._column_headers[f"{name}-{safe_name(acq_timestamp_variable)}"] = (
+                f"{device} {acq_timestamp_variable}"
+            )
             # Writable controls, not readable signals (mirrors the direct
             # NonScalarSaveSupport._init_save_signals): read the gateway
             # readback, write the :SP setpoint (→ GEECS UDP set). Requires the

--- a/GeecsBluesky/geecs_bluesky/devices/ca/telemetry.py
+++ b/GeecsBluesky/geecs_bluesky/devices/ca/telemetry.py
@@ -1,0 +1,145 @@
+"""CaTelemetryReadable — the soft Tier-2 background-telemetry device (M3c).
+
+Tier 2 of the two-tier recording model (see the ``SaveSetEntry`` module
+docstring in :mod:`geecs_schemas.save_set`): every live experiment device with
+a ``get='yes'`` variable that is *not* in the scan's save set is recorded as
+best-effort snapshot columns, read from the gateway's always-on monitor cache.
+
+The non-negotiable contract, enforced here:
+
+- **read-only** — no ``:SP`` signals, no ``trigger()``; the device is a plain
+  :class:`~bluesky.protocols.Readable` sampled once per event row;
+- **never waited on / never blocks or aborts a scan** — :meth:`read` catches
+  every per-signal failure and substitutes NaN, so a value that cannot be read
+  (a device that went dead mid-scan) degrades a single cell to NaN rather than
+  raising into the plan;
+- **dead device dropped with a log line, not an error** — a device that fails
+  to connect at scan start is dropped by the caller
+  (:func:`~geecs_bluesky.scan_request_runner.build_telemetry_readables`) with a
+  warning; it never becomes a dialog or an abort.
+
+Telemetry columns are **prefixed to distinguish them from Tier-1 save-set
+data** in the event schema: the ophyd device name is ``telemetry_<device>`` and
+every column therefore begins ``telemetry_<device>-`` (``EVENT_SCHEMA.md`` §
+"Background telemetry columns").  This is a device-name convention, not a new
+schema field — additive, so it does not bump the schema version.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from ophyd_async.core import StandardReadable
+from ophyd_async.epics.core import epics_signal_r
+
+from geecs_bluesky.devices.ca._pv import ca_pv
+from geecs_bluesky.utils import safe_name
+
+logger = logging.getLogger(__name__)
+
+#: Ophyd-name prefix marking a device as Tier-2 telemetry (so every event
+#: column it contributes starts ``telemetry_...``).
+TELEMETRY_NAME_PREFIX = "telemetry_"
+
+
+class CaTelemetryReadable(StandardReadable):
+    """Soft, read-only GEECS readable for background telemetry over gateway PVs.
+
+    Structurally a :class:`~geecs_bluesky.devices.ca.snapshot.CaSnapshotReadable`
+    (float readback signals sampled per row) but with a **fault-tolerant**
+    :meth:`read` that never propagates an exception: a signal that fails to
+    read yields NaN for its value instead of aborting the plan.  This is the
+    softness half of the two-tier model — telemetry can never gate a shot.
+
+    Parameters
+    ----------
+    device : str
+        GEECS device name.
+    variable_list : str or list of str
+        Variable name(s) to expose as read-only float signals.
+    experiment : str, optional
+        Experiment PV-namespace prefix (e.g. ``"Undulator"``).
+    name : str, optional
+        Ophyd-async device name; defaults to ``telemetry_<device>`` so the
+        columns are self-identifying.  A caller-supplied name must keep the
+        :data:`TELEMETRY_NAME_PREFIX` for the schema marking to hold.
+    datatype : type
+        Scalar CA datatype for the variables (default ``float``).
+    """
+
+    def __init__(
+        self,
+        device: str,
+        variable_list: str | list[str],
+        *,
+        experiment: str | None = None,
+        name: str | None = None,
+        datatype: type = float,
+    ) -> None:
+        if isinstance(variable_list, str):
+            variable_list = [variable_list]
+        self._geecs_device_name = device
+        name = name or f"{TELEMETRY_NAME_PREFIX}{safe_name(device)}"
+        self._telemetry_signals: list = []
+        with self.add_children_as_readables():
+            for var in variable_list:
+                signal = epics_signal_r(datatype, ca_pv(experiment, device, var))
+                setattr(self, safe_name(var), signal)
+                self._telemetry_signals.append(signal)
+        super().__init__(name=name)
+        # Telemetry columns are marked by the device-name prefix, not folded
+        # into geecs_scalar_headers: they are Tier 2, not legacy s-file scalars,
+        # so the Tiled→s-file exporter must not rename them as save-set data.
+        self._column_headers: dict[str, str] = {}
+
+    async def read(self) -> dict[str, Any]:
+        """Read all telemetry signals, substituting NaN for any that fail.
+
+        Overrides :meth:`StandardReadable.read` so one unreadable signal (a
+        device that went dead mid-scan) degrades to a NaN cell rather than
+        raising into ``trigger_and_read`` and aborting the scan — the soft-tier
+        guarantee.  Reads are issued concurrently; the row's timestamp is best
+        effort.
+
+        Returns
+        -------
+        dict
+            The ophyd reading dict, with failed signals reported as NaN.
+        """
+        import asyncio
+        import time
+
+        signals = list(self._telemetry_signals)
+        results = await asyncio.gather(
+            *(sig.read() for sig in signals), return_exceptions=True
+        )
+        reading: dict[str, Any] = {}
+        for sig, result in zip(signals, results):
+            if isinstance(result, BaseException):
+                logger.debug(
+                    "telemetry read failed for %s (%s); recording NaN",
+                    getattr(sig, "name", sig),
+                    self._geecs_device_name,
+                    exc_info=result,
+                )
+                now = time.time()
+                for key in _reading_keys(sig):
+                    reading[key] = {
+                        "value": float("nan"),
+                        "timestamp": now,
+                        "alarm_severity": 3,  # INVALID
+                    }
+            else:
+                reading.update(result)
+        return reading
+
+
+def _reading_keys(signal: Any) -> list[str]:
+    """Best-effort event-key list for *signal* (its ophyd name).
+
+    A read signal reports one key equal to its name; falling back to the name
+    keeps a failed read's NaN cell aligned with the descriptor's stable shape.
+    """
+    name = getattr(signal, "name", None)
+    return [name] if name else []

--- a/GeecsBluesky/geecs_bluesky/devices/ca/telemetry.py
+++ b/GeecsBluesky/geecs_bluesky/devices/ca/telemetry.py
@@ -52,20 +52,33 @@ class CaTelemetryReadable(StandardReadable):
     read yields NaN for its value instead of aborting the plan.  This is the
     softness half of the two-tier model — telemetry can never gate a shot.
 
+    Signal datatype is **inferred per-variable** from the PV's native CA type
+    (``epics_signal_r(datatype=None, …)``): numeric PVs stay ``float`` so
+    downstream telemetry analysis keeps working, while enum/string PVs (e.g.
+    ``U_VisaPlungers`` ``DigitalOutput.Channel N``) are captured as their
+    string/label value instead of failing to connect.  This is what keeps the
+    tier's rule honest — *if we ``get`` it, we log it*: a non-numeric
+    ``get='yes'`` variable no longer drops the whole device on a type mismatch.
+    Type tolerance is per-variable, never whole-device.
+
     Parameters
     ----------
     device : str
         GEECS device name.
     variable_list : str or list of str
-        Variable name(s) to expose as read-only float signals.
+        Variable name(s) to expose as read-only signals (dtype inferred per PV).
     experiment : str, optional
         Experiment PV-namespace prefix (e.g. ``"Undulator"``).
     name : str, optional
         Ophyd-async device name; defaults to ``telemetry_<device>`` so the
         columns are self-identifying.  A caller-supplied name must keep the
         :data:`TELEMETRY_NAME_PREFIX` for the schema marking to hold.
-    datatype : type
-        Scalar CA datatype for the variables (default ``float``).
+    datatype : type, optional
+        Scalar CA datatype for the variables.  Defaults to ``None`` — let
+        ophyd-async infer each PV's native type (float for numeric, str for
+        enum/string).  A caller may pin an explicit type, but the default
+        inference is what makes telemetry dtype-tolerant; forcing ``float``
+        here reintroduces the connect-time drop for non-numeric variables.
     """
 
     def __init__(
@@ -75,7 +88,7 @@ class CaTelemetryReadable(StandardReadable):
         *,
         experiment: str | None = None,
         name: str | None = None,
-        datatype: type = float,
+        datatype: type | None = None,
     ) -> None:
         if isinstance(variable_list, str):
             variable_list = [variable_list]
@@ -94,18 +107,21 @@ class CaTelemetryReadable(StandardReadable):
         self._column_headers: dict[str, str] = {}
 
     async def read(self) -> dict[str, Any]:
-        """Read all telemetry signals, substituting NaN for any that fail.
+        """Read all telemetry signals, substituting a null cell for any that fail.
 
         Overrides :meth:`StandardReadable.read` so one unreadable signal (a
-        device that went dead mid-scan) degrades to a NaN cell rather than
+        device that went dead mid-scan) degrades to a null cell rather than
         raising into ``trigger_and_read`` and aborting the scan — the soft-tier
-        guarantee.  Reads are issued concurrently; the row's timestamp is best
-        effort.
+        guarantee.  The substituted value is dtype-appropriate: ``NaN`` for a
+        numeric signal, ``""`` for a string/enum signal (so a failed read never
+        forces a string column to hold a float).  Reads are issued
+        concurrently; the row's timestamp is best effort.
 
         Returns
         -------
         dict
-            The ophyd reading dict, with failed signals reported as NaN.
+            The ophyd reading dict, with failed signals reported as a
+            dtype-appropriate null (NaN for numeric, ``""`` for string).
         """
         import asyncio
         import time
@@ -118,15 +134,16 @@ class CaTelemetryReadable(StandardReadable):
         for sig, result in zip(signals, results):
             if isinstance(result, BaseException):
                 logger.debug(
-                    "telemetry read failed for %s (%s); recording NaN",
+                    "telemetry read failed for %s (%s); recording null cell",
                     getattr(sig, "name", sig),
                     self._geecs_device_name,
                     exc_info=result,
                 )
                 now = time.time()
+                fill = await _null_value_for(sig)
                 for key in _reading_keys(sig):
                     reading[key] = {
-                        "value": float("nan"),
+                        "value": fill,
                         "timestamp": now,
                         "alarm_severity": 3,  # INVALID
                     }
@@ -135,11 +152,29 @@ class CaTelemetryReadable(StandardReadable):
         return reading
 
 
+async def _null_value_for(signal: Any) -> Any:
+    """Dtype-appropriate null for a signal whose read failed.
+
+    A numeric signal degrades to ``NaN``; a string/enum signal degrades to
+    ``""`` so a failed read never forces a string telemetry column to carry a
+    float.  The dtype is taken from the signal's *cached* descriptor (set at
+    connect, no network I/O); if even that is unavailable we fall back to NaN.
+    """
+    try:
+        desc = await signal.describe()
+    except Exception:
+        return float("nan")
+    for entry in desc.values():
+        if entry.get("dtype") == "string":
+            return ""
+    return float("nan")
+
+
 def _reading_keys(signal: Any) -> list[str]:
     """Best-effort event-key list for *signal* (its ophyd name).
 
     A read signal reports one key equal to its name; falling back to the name
-    keeps a failed read's NaN cell aligned with the descriptor's stable shape.
+    keeps a failed read's null cell aligned with the descriptor's stable shape.
     """
     name = getattr(signal, "name", None)
     return [name] if name else []

--- a/GeecsBluesky/geecs_bluesky/devices/ca/timestamped_readable.py
+++ b/GeecsBluesky/geecs_bluesky/devices/ca/timestamped_readable.py
@@ -74,6 +74,12 @@ class CaTimestampedReadable(
         }
         self._save_nonscalar_data = save_nonscalar_data
         if save_nonscalar_data:
+            # A file/image-saving device surfaces acq_timestamp as an s-file
+            # column so saved files tie back to scan rows (legacy parity); a
+            # pure-scalar device keeps it as an excluded companion column.
+            self._column_headers[f"{name}-{safe_name(acq_timestamp_variable)}"] = (
+                f"{device} {acq_timestamp_variable}"
+            )
             # Writable controls, not readable signals: read the gateway
             # readback, write the :SP setpoint (→ GEECS UDP set).
             for attr in ("localsavingpath", "save"):

--- a/GeecsBluesky/geecs_bluesky/scan_request_runner.py
+++ b/GeecsBluesky/geecs_bluesky/scan_request_runner.py
@@ -1306,8 +1306,10 @@ def build_telemetry_readables(
     Returns
     -------
     tuple
-        ``(readables, selected)`` — the connected telemetry devices and the
-        ``{device: [variables]}`` selection (recorded in run metadata).
+        ``(readables, recorded)`` — the connected telemetry devices and the
+        ``{device: [variables]}`` map of **only those that connected**
+        (recorded in run metadata; devices dropped as unreachable are excluded
+        so the metadata matches the columns that actually exist).
     """
     if scalar_policy is None:
         return [], {}
@@ -1315,11 +1317,17 @@ def build_telemetry_readables(
         save_set, scalar_policy.subscribed_by_device()
     )
     readables: list = []
+    recorded: dict[str, list[str]] = {}
     for device, variables in selected.items():
         readable = session.telemetry(device, variables)
         if readable is not None:
             readables.append(readable)
-    return readables, selected
+            recorded[device] = list(variables)
+    # Record only the devices that actually connected: a device dropped as
+    # unreachable at scan start contributes no columns, so the start-doc
+    # metadata must not advertise them (EVENT_SCHEMA.md contract — the key
+    # reflects what was recorded, not what was selected).
+    return readables, recorded
 
 
 def run_scan_request(
@@ -1629,6 +1637,9 @@ def _run_optimize_request(
         scalar_policy = make_scalar_policy(session)
         if request.save_set:
             save_set, rituals = resolve_save_set_and_rituals(resolver, request.save_set)
+            # Reserved DB set-side overrides are inert here too — warn once, as
+            # on the scan/noscan path, so the promise holds in every mode.
+            warn_if_reserved_boundary_overrides(save_set)
             ritual_names = [n for names in rituals.values() for n in names]
             if ritual_names:
                 # Save-set entry rituals can't run in optimize mode yet either;

--- a/GeecsBluesky/geecs_bluesky/scan_request_runner.py
+++ b/GeecsBluesky/geecs_bluesky/scan_request_runner.py
@@ -76,10 +76,8 @@ from typing import Any, Callable, Protocol, runtime_checkable
 import yaml
 
 from geecs_bluesky.db_runtime import (
-    BoundaryWrite,
     GeecsDbScalarPolicy,
     ScalarPolicyProvider,
-    collect_scan_boundary_writes,
     resolve_entry_scalars,
     select_telemetry_variables,
 )
@@ -1214,12 +1212,12 @@ def _build_request_detectors(
 
 
 # ---------------------------------------------------------------------------
-# DB-integration runtime (M3c): db_scalars, start/end writes, telemetry
+# DB-integration runtime (M3c): db_scalars + background telemetry (get-side)
 # ---------------------------------------------------------------------------
 
 
 def make_scalar_policy(session: Any) -> ScalarPolicyProvider | None:
-    """Build the DB scalar/boundary policy provider for *session*'s experiment.
+    """Build the get-side DB scalar policy provider for *session*'s experiment.
 
     Returns a :class:`~geecs_bluesky.db_runtime.GeecsDbScalarPolicy` bound to
     the session's experiment.  The provider itself is failure-tolerant (a DB
@@ -1244,130 +1242,41 @@ def make_scalar_policy(session: Any) -> ScalarPolicyProvider | None:
     return GeecsDbScalarPolicy(experiment)
 
 
-def participants_from_save_set_and_axes(
-    save_set: SaveSet | None,
-    axis_devices: list[str],
-) -> dict[str, dict[str, dict[str, Any]]]:
-    """Assemble the participating-device → override-dicts map for DB writes.
+def warn_if_reserved_boundary_overrides(save_set: SaveSet | None) -> None:
+    """Warn once if any entry sets the reserved (not-honored) set-side fields.
 
-    Participants are exactly the save-set devices plus the scan-variable
-    devices — **not** every experiment device (the maintainer's explicit
-    decision).  Each save-set entry contributes its ``at_scan_start`` /
-    ``at_scan_end`` override dicts; a scan-variable device with no save-set
-    entry participates with empty overrides (so its own ``set='yes'`` rows
-    still fire).
+    ``SaveSetEntry.at_scan_start`` / ``at_scan_end`` are **reserved and not
+    applied in this version**: the engine sets up triggering via the
+    TriggerProfile/shot controller and camera saving via its own
+    save-windowing, so DB set-side scan start/end writes are intentionally
+    disabled (they would race the shot controller on the DG645).  A config
+    that still sets them is not an error — it is honored by a future
+    re-enable — but the operator should know the values are inert now, so we
+    log one WARNING naming the device(s).
 
     Parameters
     ----------
     save_set :
-        The scan's save set (``None`` for a save-set-less scan).
-    axis_devices :
-        Device names of the scan variables (movables).
-
-    Returns
-    -------
-    dict
-        ``{device: {"at_scan_start": {...}, "at_scan_end": {...}}}``.
+        The scan's save set (``None`` = nothing to check).
     """
-    participants: dict[str, dict[str, dict[str, Any]]] = {}
-    if save_set is not None:
-        for entry in save_set.entries:
-            participants[entry.device] = {
-                "at_scan_start": dict(getattr(entry, "at_scan_start", {}) or {}),
-                "at_scan_end": dict(getattr(entry, "at_scan_end", {}) or {}),
-            }
-    for device in axis_devices:
-        participants.setdefault(device, {"at_scan_start": {}, "at_scan_end": {}})
-    return participants
-
-
-def make_boundary_write_plan(
-    writes: list[BoundaryWrite], factory: Any
-) -> Callable | None:
-    """Compile resolved boundary writes into a reusable plan-stub callable.
-
-    Each write is issued as a blocking ``abs_set(..., wait=True)`` against the
-    variable's CA setpoint (the same ``:SP`` path action plans use — the
-    factory's ``get_settable``), sequentially in the given order.  Returns a
-    callable producing a **fresh** generator per call (required for the
-    finalize path, which may re-instantiate the end writes on abort).  Signals
-    must be pre-connected before the RE runs (see
-    :func:`prefetch_boundary_signals`).
-
-    Parameters
-    ----------
-    writes :
-        The resolved :class:`~geecs_bluesky.db_runtime.BoundaryWrite` list.
-    factory :
-        The action :class:`SettableFactory` (``session.action_signal_factory``
-        output) — its ``get_settable`` yields the ``:SP`` movable.
-
-    Returns
-    -------
-    callable or None
-        A plan-stub callable, or ``None`` when there are no writes.
-    """
-    if not writes:
-        return None
-    import bluesky.plan_stubs as bps
-
-    def _plan():
-        for write in writes:
-            settable = factory.get_settable(write.device, write.variable)
-            logger.info(
-                "DB scan write (%s): %s:%s = %r",
-                write.source,
-                write.device,
-                write.variable,
-                write.value,
-            )
-            yield from bps.abs_set(settable, write.value, wait=True)
-
-    return _plan
-
-
-def _chain_plan_stubs(
-    first: Callable | None, second: Callable | None
-) -> Callable | None:
-    """Return a callable running *first* then *second* (each a fresh generator).
-
-    Used to graft the DB start/end writes onto the compiled action slots:
-    start writes run *after* setup actions, end writes run *before* the
-    action closeout (so the closeout finalize still nests correctly).  Either
-    argument may be ``None`` (identity — the other is returned unchanged).
-    """
-    if first is None:
-        return second
-    if second is None:
-        return first
-
-    def _chained():
-        yield from first()
-        yield from second()
-
-    return _chained
-
-
-def _write_record(write: BoundaryWrite) -> dict[str, str]:
-    """Serialize a :class:`BoundaryWrite` for run-metadata provenance."""
-    return {
-        "device": write.device,
-        "variable": write.variable,
-        "value": write.value,
-        "source": write.source,
-    }
-
-
-def prefetch_boundary_signals(writes: list[BoundaryWrite], factory: Any) -> None:
-    """Pre-connect the ``:SP`` signal for every boundary write.
-
-    A blocking connect inside the RunEngine loop would deadlock, so every
-    ``(device, variable)`` a write touches is created/connected here first
-    (the factory caches per target).  Fail-fast: an unreachable setpoint fails
-    now, before the scan claims a number.
-    """
-    for write in writes:
-        factory.get_settable(write.device, write.variable)
+    if save_set is None:
+        return
+    devices = [
+        entry.device
+        for entry in save_set.entries
+        if getattr(entry, "at_scan_start", None) or getattr(entry, "at_scan_end", None)
+    ]
+    if devices:
+        logger.warning(
+            "save set %r sets the reserved DB scan start/end fields "
+            "(at_scan_start / at_scan_end) on %s, but the set-side is disabled "
+            "in this version and these values are NOT applied — triggering is "
+            "owned by the TriggerProfile/shot controller and camera saving by "
+            "the scanner's save-windowing (kept reserved for a possible future "
+            "re-enable)",
+            save_set.name,
+            ", ".join(devices),
+        )
 
 
 def build_telemetry_readables(
@@ -1508,31 +1417,24 @@ def run_scan_request(
         )
     save_set, rituals = resolve_save_set_and_rituals(resolver, request.save_set)
 
-    # M3c DB-integration runtime tier.  The policy provider is failure-tolerant
-    # (empty policy on a missing/unreachable DB), so it never aborts a scan.
+    # M3c DB-integration runtime tier — get-side only.  The policy provider is
+    # failure-tolerant (empty policy on a missing/unreachable DB), so it never
+    # aborts a scan.  The DB set-side (scan start/end writes) is intentionally
+    # disabled in this version (see the module docstring); a config that still
+    # sets the reserved at_scan_start / at_scan_end fields gets one warning.
     scalar_policy = make_scalar_policy(session)
     devices_config = save_set_to_devices_config(save_set, scalar_policy)
     slots = assemble_action_slots(request.actions, applied_defaults, rituals)
+    warn_if_reserved_boundary_overrides(save_set)
 
-    # Resolve the scan-variable device names up front (participants for the
-    # DB start/end writes = save-set devices + scan-variable devices).  Full
-    # movable construction happens later; only the names are needed here.
-    axis_devices: list[str] = []
+    # Resolve the scan-variable movable targets up front (full movable
+    # construction happens later; only the (device, variable, kind) triples
+    # are needed here for the standard-scan build below).
     axis_resolved: list[tuple[str, str, str]] = []
     for axis in request.axes:
         spec = resolver.resolve_scan_variable(axis.variable)
         device, variable, kind = resolve_movable_target(spec, axis.variable)
-        axis_devices.append(device)
         axis_resolved.append((device, variable, kind))
-
-    apply_db_writes = _defaults_flag(defaults, "apply_db_scan_defaults", True)
-    start_writes: list[BoundaryWrite] = []
-    end_writes: list[BoundaryWrite] = []
-    if apply_db_writes:
-        participants = participants_from_save_set_and_axes(save_set, axis_devices)
-        start_writes, end_writes = collect_scan_boundary_writes(
-            participants, scalar_policy
-        )
 
     telemetry_enabled = (
         request.background_telemetry
@@ -1544,13 +1446,9 @@ def run_scan_request(
     try:
         # Compile the action slots first: signal prefetch fail-fasts on an
         # unreachable action target before detectors are even built, and
-        # everything stays pre-claim.  The same action signal factory drives
-        # the DB start/end setpoint writes (M3c), so create it whenever either
-        # actions or DB writes are present.
+        # everything stays pre-claim.
         setup = per_step = closeout = None
-        boundary_start_plan = boundary_end_plan = None
-        need_factory = any(slots.values()) or bool(start_writes or end_writes)
-        if need_factory:
+        if any(slots.values()):
             factory = session.action_signal_factory()
             created.append(factory)
             registry = build_action_registry(resolver)
@@ -1566,18 +1464,6 @@ def run_scan_request(
             prefetch_action_signals(
                 setup_plans + per_step_plans + closeout_plans, registry, factory
             )
-            # DB start/end writes ride the same :SP setpoint path; pre-connect
-            # their signals (a lazy connect inside the RE loop would deadlock).
-            prefetch_boundary_signals(start_writes + end_writes, factory)
-            boundary_start_plan = make_boundary_write_plan(start_writes, factory)
-            boundary_end_plan = make_boundary_write_plan(end_writes, factory)
-
-        # Start writes run after setup actions, before acquisition (they are
-        # chained into the setup hook); end writes run in the finalize chain
-        # so they execute even on abort (chained into the closeout hook, which
-        # build_step_scan_plan wraps in a finalize_wrapper).
-        setup = _chain_plan_stubs(setup, boundary_start_plan)
-        closeout = _chain_plan_stubs(boundary_end_plan, closeout)
 
         detectors = _build_request_detectors(
             session, devices_config, free_run=mode == "free_run"
@@ -1603,12 +1489,6 @@ def run_scan_request(
             # Provenance: the assembled per-slot execution order (defaults +
             # entry rituals + the request's own, mirrored on closeout).
             md["action_plans"] = {k: v for k, v in slots.items() if v}
-        if start_writes or end_writes:
-            # Provenance: every DB-driven start/end write actually applied.
-            md["db_scan_writes"] = {
-                "at_scan_start": [_write_record(w) for w in start_writes],
-                "at_scan_end": [_write_record(w) for w in end_writes],
-            }
         if telemetry_enabled and telemetry_selected:
             md["background_telemetry"] = {
                 dev: list(vars_) for dev, vars_ in telemetry_selected.items()
@@ -1743,9 +1623,9 @@ def _run_optimize_request(
     try:
         skipped = {k: list(v) for k, v in (skipped_actions or {}).items() if v}
         # db_scalars resolution applies to optimize too (recorded-scalar
-        # consistency); the DB start/end writes and background telemetry do
-        # not run in optimize mode yet (no scan-boundary hook on
-        # GeecsSession.optimize) — same skip-and-record posture as actions.
+        # consistency); background telemetry does not run in optimize mode yet
+        # (no scan-boundary hook on GeecsSession.optimize).  The DB set-side
+        # (scan start/end writes) is disabled everywhere in this version.
         scalar_policy = make_scalar_policy(session)
         if request.save_set:
             save_set, rituals = resolve_save_set_and_rituals(resolver, request.save_set)
@@ -1783,13 +1663,12 @@ def _run_optimize_request(
                 "and save-set rituals do not run during optimization): %s",
                 skipped,
             )
-        # DB scan-boundary writes and background telemetry are not wired into
-        # optimize mode yet (GeecsSession.optimize has no scan-boundary hook);
-        # db_scalars resolution above still applies.  Recorded for provenance.
+        # Background telemetry is not wired into optimize mode yet
+        # (GeecsSession.optimize has no scan-boundary hook); db_scalars
+        # resolution above still applies.  The DB set-side is disabled
+        # everywhere in this version.  Recorded for provenance.
         md["db_scan_runtime"] = {
             "db_scalars": "applied",
-            "at_scan_start_writes": "not_run_in_optimize",
-            "at_scan_end_writes": "not_run_in_optimize",
             "background_telemetry": "not_run_in_optimize",
         }
         uid, _history = session.optimize(

--- a/GeecsBluesky/geecs_bluesky/scan_request_runner.py
+++ b/GeecsBluesky/geecs_bluesky/scan_request_runner.py
@@ -75,6 +75,14 @@ from typing import Any, Callable, Protocol, runtime_checkable
 
 import yaml
 
+from geecs_bluesky.db_runtime import (
+    BoundaryWrite,
+    GeecsDbScalarPolicy,
+    ScalarPolicyProvider,
+    collect_scan_boundary_writes,
+    resolve_entry_scalars,
+    select_telemetry_variables,
+)
 from geecs_bluesky.exceptions import GeecsConfigurationError
 from geecs_bluesky.models.shot_control import ShotControlWrites
 from geecs_bluesky.plans.action_compiler import compile_action_plan
@@ -545,7 +553,10 @@ def trigger_writes_from_profile(
     return ShotControlWrites(name=name, states=states)
 
 
-def save_set_to_devices_config(save_set: SaveSet) -> dict[str, dict[str, Any]]:
+def save_set_to_devices_config(
+    save_set: SaveSet,
+    scalar_policy: "ScalarPolicyProvider | None" = None,
+) -> dict[str, dict[str, Any]]:
     """Derive the legacy ``devices_config`` shape from a SaveSet.
 
     Applies the documented intent→mechanics derivation rules
@@ -553,17 +564,31 @@ def save_set_to_devices_config(save_set: SaveSet) -> dict[str, dict[str, Any]]:
 
     - ``synchronous`` is derived from the entry's role: ``snapshot`` →
       asynchronous, everything else → synchronous.
-    - ``images`` → ``save_nonscalar_data``; ``scalars`` → ``variable_list``
-      (``acq_timestamp`` stays implicit — the device layer always records it).
+    - ``images`` → ``save_nonscalar_data``; the recorded ``variable_list`` is
+      the entry's resolved scalar set (``acq_timestamp`` stays implicit — the
+      device layer always records it).
     - Role overrides shape the **ordering** (the downstream classifier
       assigns free-run roles by position): a ``reference``-flagged entry is
       moved first; ``contributor``-flagged entries are placed after the
       unmarked synchronous ones so they never inherit pacemaker duty.
 
+    The recorded ``variable_list`` follows the ``SaveSetEntry`` ``db_scalars``
+    contract (M3c), delegated to
+    :func:`~geecs_bluesky.db_runtime.resolve_entry_scalars`: with a
+    *scalar_policy* provider, ``db_scalars=True`` unions the device's DB
+    ``get='yes'`` variables (or every DB variable when ``all_scalars=True``)
+    with the explicit list; ``db_scalars=False`` records only the explicit
+    list (the legacy-converter pin).  Without a provider (the GUI-bridge path
+    or no DB access) only the explicit list is recorded — the M3b behavior,
+    with ``all_scalars`` still a documented gap.
+
     Parameters
     ----------
     save_set :
         The save set to translate.
+    scalar_policy :
+        Optional DB policy provider (M3c); ``None`` keeps the M3b
+        explicit-only behavior.
 
     Returns
     -------
@@ -577,8 +602,9 @@ def save_set_to_devices_config(save_set: SaveSet) -> dict[str, dict[str, Any]]:
         If more than one entry claims the ``reference`` role, or if every
         synchronous entry is ``contributor``-flagged (no pacemaker left).
     NotImplementedError
-        For ``all_scalars`` entries without an explicit ``scalars`` list —
-        enumerating a device's scalars needs the DB-backed validation pass.
+        For ``all_scalars`` entries without an explicit ``scalars`` list when
+        no *scalar_policy* is available — enumerating a device's scalars needs
+        the DB (which the provider supplies).
     """
     references = [e for e in save_set.entries if e.role is SaveRole.REFERENCE]
     if len(references) > 1:
@@ -599,17 +625,24 @@ def save_set_to_devices_config(save_set: SaveSet) -> dict[str, dict[str, Any]]:
 
     config: dict[str, dict[str, Any]] = {}
     for entry in references + unmarked + contributors + snapshots:
-        if entry.all_scalars and not entry.scalars:
+        if entry.all_scalars and not entry.scalars and scalar_policy is None:
             raise NotImplementedError(
                 f"save set {save_set.name!r}, device {entry.device!r}: "
-                "all_scalars needs the DB-backed scalar enumeration, which "
-                "lands with save-set validation — list the scalars "
-                "explicitly for now"
+                "all_scalars needs the DB-backed scalar enumeration — run the "
+                "request through GeecsSession.run (which supplies the DB "
+                "policy) or list the scalars explicitly"
             )
+        variable_list = resolve_entry_scalars(
+            entry.device,
+            list(entry.scalars),
+            db_scalars=entry.db_scalars,
+            all_scalars=entry.all_scalars,
+            provider=scalar_policy,
+        )
         config[entry.device] = {
             "synchronous": entry.role is not SaveRole.SNAPSHOT,
             "save_nonscalar_data": entry.images,
-            "variable_list": list(entry.scalars),
+            "variable_list": variable_list,
         }
     return config
 
@@ -1045,6 +1078,16 @@ def apply_experiment_defaults(
     return request, applied
 
 
+def resolve_experiment_defaults(resolver: ConfigResolver) -> Any | None:
+    """Return the resolver's experiment defaults, or ``None`` (tolerantly).
+
+    Resolvers without a ``resolve_experiment_defaults`` method are treated as
+    having no defaults.
+    """
+    resolve = getattr(resolver, "resolve_experiment_defaults", None)
+    return resolve() if callable(resolve) else None
+
+
 def resolve_defaults_for(
     resolver: ConfigResolver, request: ScanRequest
 ) -> tuple[ScanRequest, dict[str, Any]]:
@@ -1065,9 +1108,21 @@ def resolve_defaults_for(
     tuple
         As :func:`apply_experiment_defaults`.
     """
-    resolve = getattr(resolver, "resolve_experiment_defaults", None)
-    defaults = resolve() if callable(resolve) else None
-    return apply_experiment_defaults(request, defaults)
+    return apply_experiment_defaults(request, resolve_experiment_defaults(resolver))
+
+
+def _defaults_flag(defaults: Any | None, name: str, fallback: bool) -> bool:
+    """Read a boolean flag off the experiment defaults (model or mapping).
+
+    Returns *fallback* when there are no defaults or the flag is absent.
+    """
+    if defaults is None:
+        return fallback
+    if isinstance(defaults, dict):
+        value = defaults.get(name, fallback)
+    else:
+        value = getattr(defaults, name, fallback)
+    return fallback if value is None else bool(value)
 
 
 # ---------------------------------------------------------------------------
@@ -1158,6 +1213,206 @@ def _build_request_detectors(
     return detectors
 
 
+# ---------------------------------------------------------------------------
+# DB-integration runtime (M3c): db_scalars, start/end writes, telemetry
+# ---------------------------------------------------------------------------
+
+
+def make_scalar_policy(session: Any) -> ScalarPolicyProvider | None:
+    """Build the DB scalar/boundary policy provider for *session*'s experiment.
+
+    Returns a :class:`~geecs_bluesky.db_runtime.GeecsDbScalarPolicy` bound to
+    the session's experiment.  The provider itself is failure-tolerant (a DB
+    lookup that fails degrades to empty policy with a warning), so this never
+    raises for a missing DB; ``None`` is returned only when the session does
+    not expose an ``experiment`` attribute (defensive — every real session
+    does).
+
+    Parameters
+    ----------
+    session :
+        The :class:`~geecs_bluesky.session.GeecsSession` (duck-typed).
+
+    Returns
+    -------
+    ScalarPolicyProvider or None
+        A DB-backed policy provider, or ``None`` when no experiment is known.
+    """
+    experiment = getattr(session, "experiment", None)
+    if not experiment:
+        return None
+    return GeecsDbScalarPolicy(experiment)
+
+
+def participants_from_save_set_and_axes(
+    save_set: SaveSet | None,
+    axis_devices: list[str],
+) -> dict[str, dict[str, dict[str, Any]]]:
+    """Assemble the participating-device → override-dicts map for DB writes.
+
+    Participants are exactly the save-set devices plus the scan-variable
+    devices — **not** every experiment device (the maintainer's explicit
+    decision).  Each save-set entry contributes its ``at_scan_start`` /
+    ``at_scan_end`` override dicts; a scan-variable device with no save-set
+    entry participates with empty overrides (so its own ``set='yes'`` rows
+    still fire).
+
+    Parameters
+    ----------
+    save_set :
+        The scan's save set (``None`` for a save-set-less scan).
+    axis_devices :
+        Device names of the scan variables (movables).
+
+    Returns
+    -------
+    dict
+        ``{device: {"at_scan_start": {...}, "at_scan_end": {...}}}``.
+    """
+    participants: dict[str, dict[str, dict[str, Any]]] = {}
+    if save_set is not None:
+        for entry in save_set.entries:
+            participants[entry.device] = {
+                "at_scan_start": dict(getattr(entry, "at_scan_start", {}) or {}),
+                "at_scan_end": dict(getattr(entry, "at_scan_end", {}) or {}),
+            }
+    for device in axis_devices:
+        participants.setdefault(device, {"at_scan_start": {}, "at_scan_end": {}})
+    return participants
+
+
+def make_boundary_write_plan(
+    writes: list[BoundaryWrite], factory: Any
+) -> Callable | None:
+    """Compile resolved boundary writes into a reusable plan-stub callable.
+
+    Each write is issued as a blocking ``abs_set(..., wait=True)`` against the
+    variable's CA setpoint (the same ``:SP`` path action plans use — the
+    factory's ``get_settable``), sequentially in the given order.  Returns a
+    callable producing a **fresh** generator per call (required for the
+    finalize path, which may re-instantiate the end writes on abort).  Signals
+    must be pre-connected before the RE runs (see
+    :func:`prefetch_boundary_signals`).
+
+    Parameters
+    ----------
+    writes :
+        The resolved :class:`~geecs_bluesky.db_runtime.BoundaryWrite` list.
+    factory :
+        The action :class:`SettableFactory` (``session.action_signal_factory``
+        output) — its ``get_settable`` yields the ``:SP`` movable.
+
+    Returns
+    -------
+    callable or None
+        A plan-stub callable, or ``None`` when there are no writes.
+    """
+    if not writes:
+        return None
+    import bluesky.plan_stubs as bps
+
+    def _plan():
+        for write in writes:
+            settable = factory.get_settable(write.device, write.variable)
+            logger.info(
+                "DB scan write (%s): %s:%s = %r",
+                write.source,
+                write.device,
+                write.variable,
+                write.value,
+            )
+            yield from bps.abs_set(settable, write.value, wait=True)
+
+    return _plan
+
+
+def _chain_plan_stubs(
+    first: Callable | None, second: Callable | None
+) -> Callable | None:
+    """Return a callable running *first* then *second* (each a fresh generator).
+
+    Used to graft the DB start/end writes onto the compiled action slots:
+    start writes run *after* setup actions, end writes run *before* the
+    action closeout (so the closeout finalize still nests correctly).  Either
+    argument may be ``None`` (identity — the other is returned unchanged).
+    """
+    if first is None:
+        return second
+    if second is None:
+        return first
+
+    def _chained():
+        yield from first()
+        yield from second()
+
+    return _chained
+
+
+def _write_record(write: BoundaryWrite) -> dict[str, str]:
+    """Serialize a :class:`BoundaryWrite` for run-metadata provenance."""
+    return {
+        "device": write.device,
+        "variable": write.variable,
+        "value": write.value,
+        "source": write.source,
+    }
+
+
+def prefetch_boundary_signals(writes: list[BoundaryWrite], factory: Any) -> None:
+    """Pre-connect the ``:SP`` signal for every boundary write.
+
+    A blocking connect inside the RunEngine loop would deadlock, so every
+    ``(device, variable)`` a write touches is created/connected here first
+    (the factory caches per target).  Fail-fast: an unreachable setpoint fails
+    now, before the scan claims a number.
+    """
+    for write in writes:
+        factory.get_settable(write.device, write.variable)
+
+
+def build_telemetry_readables(
+    session: Any,
+    save_set: SaveSet | None,
+    scalar_policy: ScalarPolicyProvider | None,
+) -> tuple[list, dict[str, list[str]]]:
+    """Build the Tier-2 background-telemetry readables (soft, dropped-if-dead).
+
+    Selects every experiment device with a ``get='yes'`` variable not in the
+    save set (:func:`~geecs_bluesky.db_runtime.select_telemetry_variables`),
+    then builds one soft telemetry readable per device via
+    ``session.telemetry`` — which returns ``None`` for a device unreachable at
+    scan start (dropped with a log line, never an abort).  Devices that connect
+    are appended to the scan's read set as extra columns; the softness (never
+    waited on) lives in the device's own tolerant ``read``.
+
+    Parameters
+    ----------
+    session :
+        The session (its ``telemetry`` factory connects each device softly).
+    save_set :
+        The scan's save set (its devices are excluded from telemetry).
+    scalar_policy :
+        Supplies ``get='yes'`` variables; ``None`` means no telemetry.
+
+    Returns
+    -------
+    tuple
+        ``(readables, selected)`` — the connected telemetry devices and the
+        ``{device: [variables]}`` selection (recorded in run metadata).
+    """
+    if scalar_policy is None:
+        return [], {}
+    selected = select_telemetry_variables(
+        save_set, scalar_policy.subscribed_by_device()
+    )
+    readables: list = []
+    for device, variables in selected.items():
+        readable = session.telemetry(device, variables)
+        if readable is not None:
+            readables.append(readable)
+    return readables, selected
+
+
 def run_scan_request(
     session: Any,
     request: ScanRequest,
@@ -1211,7 +1466,8 @@ def run_scan_request(
     GeecsConfigurationError
         Unresolvable names, or a step/noscan request without a save set.
     """
-    request, applied_defaults = resolve_defaults_for(resolver, request)
+    defaults = resolve_experiment_defaults(resolver)
+    request, applied_defaults = apply_experiment_defaults(request, defaults)
     resolved_actions = resolve_and_validate_actions(request.actions, resolver)
 
     if request.trigger_profile:
@@ -1251,16 +1507,50 @@ def run_scan_request(
             "without one the scan would record nothing"
         )
     save_set, rituals = resolve_save_set_and_rituals(resolver, request.save_set)
-    devices_config = save_set_to_devices_config(save_set)
+
+    # M3c DB-integration runtime tier.  The policy provider is failure-tolerant
+    # (empty policy on a missing/unreachable DB), so it never aborts a scan.
+    scalar_policy = make_scalar_policy(session)
+    devices_config = save_set_to_devices_config(save_set, scalar_policy)
     slots = assemble_action_slots(request.actions, applied_defaults, rituals)
+
+    # Resolve the scan-variable device names up front (participants for the
+    # DB start/end writes = save-set devices + scan-variable devices).  Full
+    # movable construction happens later; only the names are needed here.
+    axis_devices: list[str] = []
+    axis_resolved: list[tuple[str, str, str]] = []
+    for axis in request.axes:
+        spec = resolver.resolve_scan_variable(axis.variable)
+        device, variable, kind = resolve_movable_target(spec, axis.variable)
+        axis_devices.append(device)
+        axis_resolved.append((device, variable, kind))
+
+    apply_db_writes = _defaults_flag(defaults, "apply_db_scan_defaults", True)
+    start_writes: list[BoundaryWrite] = []
+    end_writes: list[BoundaryWrite] = []
+    if apply_db_writes:
+        participants = participants_from_save_set_and_axes(save_set, axis_devices)
+        start_writes, end_writes = collect_scan_boundary_writes(
+            participants, scalar_policy
+        )
+
+    telemetry_enabled = (
+        request.background_telemetry
+        if request.background_telemetry is not None
+        else _defaults_flag(defaults, "background_telemetry", True)
+    )
 
     created: list = []
     try:
         # Compile the action slots first: signal prefetch fail-fasts on an
         # unreachable action target before detectors are even built, and
-        # everything stays pre-claim.
+        # everything stays pre-claim.  The same action signal factory drives
+        # the DB start/end setpoint writes (M3c), so create it whenever either
+        # actions or DB writes are present.
         setup = per_step = closeout = None
-        if any(slots.values()):
+        boundary_start_plan = boundary_end_plan = None
+        need_factory = any(slots.values()) or bool(start_writes or end_writes)
+        if need_factory:
             factory = session.action_signal_factory()
             created.append(factory)
             registry = build_action_registry(resolver)
@@ -1276,11 +1566,33 @@ def run_scan_request(
             prefetch_action_signals(
                 setup_plans + per_step_plans + closeout_plans, registry, factory
             )
+            # DB start/end writes ride the same :SP setpoint path; pre-connect
+            # their signals (a lazy connect inside the RE loop would deadlock).
+            prefetch_boundary_signals(start_writes + end_writes, factory)
+            boundary_start_plan = make_boundary_write_plan(start_writes, factory)
+            boundary_end_plan = make_boundary_write_plan(end_writes, factory)
+
+        # Start writes run after setup actions, before acquisition (they are
+        # chained into the setup hook); end writes run in the finalize chain
+        # so they execute even on abort (chained into the closeout hook, which
+        # build_step_scan_plan wraps in a finalize_wrapper).
+        setup = _chain_plan_stubs(setup, boundary_start_plan)
+        closeout = _chain_plan_stubs(boundary_end_plan, closeout)
 
         detectors = _build_request_detectors(
             session, devices_config, free_run=mode == "free_run"
         )
         created.extend(detectors)
+
+        telemetry_selected: dict[str, list[str]] = {}
+        if telemetry_enabled:
+            telemetry_readables, telemetry_selected = build_telemetry_readables(
+                session, save_set, scalar_policy
+            )
+            # Telemetry is soft: appended to the read set as extra snapshot
+            # columns, never as the reference (index 0 stays the save set's).
+            detectors = list(detectors) + telemetry_readables
+            created.extend(telemetry_readables)
 
         md: dict[str, Any] = {"scan_request_mode": request.mode.value}
         if applied_defaults:
@@ -1291,6 +1603,16 @@ def run_scan_request(
             # Provenance: the assembled per-slot execution order (defaults +
             # entry rituals + the request's own, mirrored on closeout).
             md["action_plans"] = {k: v for k, v in slots.items() if v}
+        if start_writes or end_writes:
+            # Provenance: every DB-driven start/end write actually applied.
+            md["db_scan_writes"] = {
+                "at_scan_start": [_write_record(w) for w in start_writes],
+                "at_scan_end": [_write_record(w) for w in end_writes],
+            }
+        if telemetry_enabled and telemetry_selected:
+            md["background_telemetry"] = {
+                dev: list(vars_) for dev, vars_ in telemetry_selected.items()
+            }
         scan_info: dict[str, Any] = {
             "shots": request.shots_per_step,
             "background": request.background,
@@ -1315,9 +1637,7 @@ def run_scan_request(
         movables: list = []
         targets: list[str] = []
         value_lists: list[list[float]] = []
-        for axis in request.axes:
-            spec = resolver.resolve_scan_variable(axis.variable)
-            device, variable, kind = resolve_movable_target(spec, axis.variable)
+        for (device, variable, kind), axis in zip(axis_resolved, request.axes):
             movable = (
                 session.motor(device, variable)
                 if kind == "motor"
@@ -1422,6 +1742,11 @@ def _run_optimize_request(
     created: list = []
     try:
         skipped = {k: list(v) for k, v in (skipped_actions or {}).items() if v}
+        # db_scalars resolution applies to optimize too (recorded-scalar
+        # consistency); the DB start/end writes and background telemetry do
+        # not run in optimize mode yet (no scan-boundary hook on
+        # GeecsSession.optimize) — same skip-and-record posture as actions.
+        scalar_policy = make_scalar_policy(session)
         if request.save_set:
             save_set, rituals = resolve_save_set_and_rituals(resolver, request.save_set)
             ritual_names = [n for names in rituals.values() for n in names]
@@ -1431,7 +1756,7 @@ def _run_optimize_request(
                 skipped["save_set_rituals"] = ritual_names
             detectors = _build_request_detectors(
                 session,
-                save_set_to_devices_config(save_set),
+                save_set_to_devices_config(save_set, scalar_policy),
                 free_run=mode == "free_run",
             )
             created.extend(detectors)
@@ -1458,6 +1783,15 @@ def _run_optimize_request(
                 "and save-set rituals do not run during optimization): %s",
                 skipped,
             )
+        # DB scan-boundary writes and background telemetry are not wired into
+        # optimize mode yet (GeecsSession.optimize has no scan-boundary hook);
+        # db_scalars resolution above still applies.  Recorded for provenance.
+        md["db_scan_runtime"] = {
+            "db_scalars": "applied",
+            "at_scan_start_writes": "not_run_in_optimize",
+            "at_scan_end_writes": "not_run_in_optimize",
+            "background_telemetry": "not_run_in_optimize",
+        }
         uid, _history = session.optimize(
             variables=variables,
             detectors=detectors,

--- a/GeecsBluesky/geecs_bluesky/session.py
+++ b/GeecsBluesky/geecs_bluesky/session.py
@@ -259,6 +259,12 @@ class GeecsSession:
         never an error** — so this returns ``None`` after warning instead of
         propagating (unlike the strict device factories, whose failures fail
         loudly).
+
+        The telemetry readable infers each variable's dtype from its PV
+        (numeric stays float, enum/string is captured as a label), so a device
+        is dropped here only when it is genuinely unreachable — never for a
+        variable *type* mismatch.  A single non-numeric ``get='yes'`` variable
+        no longer takes the device's other columns down with it.
         """
         det = CaTelemetryReadable(
             device,

--- a/GeecsBluesky/geecs_bluesky/session.py
+++ b/GeecsBluesky/geecs_bluesky/session.py
@@ -44,6 +44,7 @@ from geecs_bluesky.devices.ca import (
     CaMotor,
     CaSettable,
     CaSnapshotReadable,
+    CaTelemetryReadable,
     CaTimestampedReadable,
 )
 from geecs_bluesky.models.shot_control import ShotControlConfig, ShotControlWrites
@@ -241,6 +242,40 @@ class GeecsSession:
                 name=name or safe_name(device),
             )
         )
+
+    def telemetry(
+        self,
+        device: str,
+        variables: list[str],
+        *,
+        name: str | None = None,
+    ) -> CaTelemetryReadable | None:
+        """Soft Tier-2 telemetry readable; ``None`` if the device is unreachable.
+
+        Builds a :class:`~geecs_bluesky.devices.ca.telemetry.CaTelemetryReadable`
+        (read-only, fault-tolerant read) and connects it.  A connect failure
+        means the device is dead/unreachable at scan start — the background
+        telemetry contract says such a device is **dropped with a log line,
+        never an error** — so this returns ``None`` after warning instead of
+        propagating (unlike the strict device factories, whose failures fail
+        loudly).
+        """
+        det = CaTelemetryReadable(
+            device,
+            variables,
+            experiment=self.experiment,
+            name=name,
+        )
+        try:
+            return self._connect(det)
+        except Exception:
+            logger.warning(
+                "Dropping background-telemetry device %s: unreachable at scan "
+                "start (soft tier — never aborts the scan)",
+                device,
+                exc_info=True,
+            )
+            return None
 
     def motor(
         self,

--- a/GeecsBluesky/pyproject.toml
+++ b/GeecsBluesky/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-bluesky"
-version = "0.23.0"
+version = "0.24.0"
 description = "Bluesky / ophyd-async bridge for the GEECS control system"
 authors = ["Sam Barber <sbarber@lbl.gov>"]
 readme = "README.md"

--- a/GeecsBluesky/tests/test_ca_devices.py
+++ b/GeecsBluesky/tests/test_ca_devices.py
@@ -668,3 +668,58 @@ async def test_all_ca_devices_define_disconnect() -> None:
         await dev.connect(mock=True)
         assert asyncio.iscoroutinefunction(dev.disconnect), type(dev).__name__
         await dev.disconnect()  # must not raise
+
+
+def test_saving_device_surfaces_acq_timestamp_in_sfile_headers() -> None:
+    """A file/image-saving device adds acq_timestamp as an s-file column.
+
+    Saved image filenames are stamped with acq_timestamp, so surfacing it as a
+    legacy scalar column lets saved files tie back to scan rows — an
+    images-only device otherwise contributes no scalar column at all. A
+    pure-scalar device keeps acq_timestamp as an excluded companion column.
+    """
+    saving = CaGenericDetector(
+        "UC_Amp2_IR_input",
+        ["centroidx"],
+        experiment="Undulator",
+        name="amp",
+        save_nonscalar_data=True,
+    )
+    assert saving._column_headers["amp-acq_timestamp"] == (
+        "UC_Amp2_IR_input acq_timestamp"
+    )
+    assert saving._column_headers["amp-centroidx"] == "UC_Amp2_IR_input centroidx"
+
+    scalar_only = CaGenericDetector(
+        "UC_Amp2_IR_input",
+        ["centroidx"],
+        experiment="Undulator",
+        name="amp2",
+        save_nonscalar_data=False,
+    )
+    assert "amp2-acq_timestamp" not in scalar_only._column_headers
+
+    # An images-only save (no other scalars) still yields the acq_timestamp
+    # column — the one column that ties the saved frames to the rows.
+    images_only = CaGenericDetector(
+        "UC_Amp2_IR_input",
+        [],
+        experiment="Undulator",
+        name="cam",
+        save_nonscalar_data=True,
+    )
+    assert images_only._column_headers == {
+        "cam-acq_timestamp": "UC_Amp2_IR_input acq_timestamp"
+    }
+
+    # Same for the free-run contributor.
+    contributor = CaTimestampedReadable(
+        "UC_TopView",
+        ["centroidx"],
+        experiment="Undulator",
+        name="con",
+        save_nonscalar_data=True,
+    )
+    assert contributor._column_headers["con-acq_timestamp"] == (
+        "UC_TopView acq_timestamp"
+    )

--- a/GeecsBluesky/tests/test_db_runtime.py
+++ b/GeecsBluesky/tests/test_db_runtime.py
@@ -1,16 +1,16 @@
-"""Hermetic unit tests for the M3c DB-integration runtime (pure logic).
+"""Hermetic unit tests for the M3c DB-integration runtime (get-side, pure logic).
 
 No MySQL, no gateway, no network — a fake :class:`ScalarPolicyProvider` stands
 in for :class:`~geecs_ca_gateway.db.geecs_db.GeecsDb`.  Covers:
 
 - db_scalars resolution (True = get∪explicit, all_scalars = all∪explicit,
   False = explicit-only, no-provider = explicit-only);
-- start/end write selection (set='yes' rows, save/localsavingpath skipped,
-  override value / null-suppression / absent cases, uncurated-variable
-  forced override);
-- participants assembly (save-set devices + scan-variable devices);
 - telemetry selection (get='yes'-not-in-save-set, empty dropped);
 - GeecsDbScalarPolicy tolerance (a DB failure degrades to empty policy).
+
+The DB set-side (scan start/end writes) is intentionally disabled in this
+version, so there is no boundary-write resolution to test here (see the
+reserved-not-honored WARNING test in ``test_scan_request_runner.py``).
 """
 
 from __future__ import annotations
@@ -19,8 +19,6 @@ import logging
 
 from geecs_bluesky.db_runtime import (
     GeecsDbScalarPolicy,
-    collect_scan_boundary_writes,
-    resolve_boundary_writes,
     resolve_entry_scalars,
     select_telemetry_variables,
 )
@@ -28,17 +26,15 @@ from geecs_schemas import SaveSet, SaveSetEntry
 
 
 class _FakePolicy:
-    """In-memory ScalarPolicyProvider (no DB)."""
+    """In-memory get-side ScalarPolicyProvider (no DB)."""
 
     def __init__(
         self,
         subscribed: dict[str, list[str]] | None = None,
         all_vars: dict[str, list[str]] | None = None,
-        boundary: dict[str, list[dict]] | None = None,
     ) -> None:
         self._subscribed = subscribed or {}
         self._all = all_vars or {}
-        self._boundary = boundary or {}
 
     def get_variables(self, device: str) -> list[str]:
         return list(self._subscribed.get(device, []))
@@ -48,9 +44,6 @@ class _FakePolicy:
 
     def subscribed_by_device(self) -> dict[str, list[str]]:
         return dict(self._subscribed)
-
-    def boundary_writes(self, device: str) -> list[dict]:
-        return list(self._boundary.get(device, []))
 
 
 # ---------------------------------------------------------------------------
@@ -103,117 +96,6 @@ def test_no_provider_is_explicit_only_even_with_db_scalars_true() -> None:
 
 
 # ---------------------------------------------------------------------------
-# start/end write selection
-# ---------------------------------------------------------------------------
-
-
-def _rows() -> list[dict]:
-    return [
-        {"variable": "TriggerMode", "startvalue": "Scan", "endvalue": "Standby"},
-        {"variable": "Shutter", "startvalue": "Open", "endvalue": "Closed"},
-        {"variable": "save", "startvalue": "on", "endvalue": "off"},
-        {"variable": "localsavingpath", "startvalue": "C:/x", "endvalue": "C:/x"},
-    ]
-
-
-def test_start_writes_use_startvalue_and_skip_save_paths() -> None:
-    writes = resolve_boundary_writes("U_DG", _rows(), which="start", overrides={})
-    assert [(w.variable, w.value, w.source) for w in writes] == [
-        ("TriggerMode", "Scan", "db"),
-        ("Shutter", "Open", "db"),
-    ]
-
-
-def test_end_writes_use_endvalue() -> None:
-    writes = resolve_boundary_writes("U_DG", _rows(), which="end", overrides={})
-    assert [(w.variable, w.value) for w in writes] == [
-        ("TriggerMode", "Standby"),
-        ("Shutter", "Closed"),
-    ]
-
-
-def test_override_value_replaces_db_value() -> None:
-    writes = resolve_boundary_writes(
-        "U_DG", _rows(), which="start", overrides={"TriggerMode": "Single"}
-    )
-    trig = next(w for w in writes if w.variable == "TriggerMode")
-    assert trig.value == "Single"
-    assert trig.source == "override"
-
-
-def test_null_override_suppresses_the_write() -> None:
-    writes = resolve_boundary_writes(
-        "U_DG", _rows(), which="start", overrides={"TriggerMode": None}
-    )
-    assert [w.variable for w in writes] == ["Shutter"]
-
-
-def test_absent_override_uses_db_value() -> None:
-    writes = resolve_boundary_writes(
-        "U_DG", _rows(), which="start", overrides={"Shutter": "Half"}
-    )
-    trig = next(w for w in writes if w.variable == "TriggerMode")
-    assert trig.value == "Scan" and trig.source == "db"
-
-
-def test_null_db_value_without_override_is_no_write() -> None:
-    rows = [{"variable": "Foo", "startvalue": None, "endvalue": "1"}]
-    assert resolve_boundary_writes("U_D", rows, which="start", overrides={}) == []
-    end = resolve_boundary_writes("U_D", rows, which="end", overrides={})
-    assert [(w.variable, w.value) for w in end] == [("Foo", "1")]
-
-
-def test_forced_override_for_uncurated_variable() -> None:
-    # A variable with no DB row but an override value → a forced write.
-    writes = resolve_boundary_writes(
-        "U_DG", _rows(), which="start", overrides={"NewVar": "7"}
-    )
-    forced = next(w for w in writes if w.variable == "NewVar")
-    assert forced.value == "7" and forced.source == "override"
-
-
-def test_null_override_for_uncurated_variable_is_noop() -> None:
-    writes = resolve_boundary_writes(
-        "U_DG", _rows(), which="start", overrides={"NewVar": None}
-    )
-    assert all(w.variable != "NewVar" for w in writes)
-
-
-# ---------------------------------------------------------------------------
-# participants collection
-# ---------------------------------------------------------------------------
-
-
-def test_collect_boundary_writes_participants_only() -> None:
-    policy = _FakePolicy(
-        boundary={
-            "U_DG": [{"variable": "Mode", "startvalue": "A", "endvalue": "B"}],
-            "U_NotAParticipant": [
-                {"variable": "X", "startvalue": "1", "endvalue": "2"}
-            ],
-        }
-    )
-    participants = {
-        "U_DG": {"at_scan_start": {}, "at_scan_end": {}},
-    }
-    start, end = collect_scan_boundary_writes(participants, policy)
-    assert [(w.device, w.variable) for w in start] == [("U_DG", "Mode")]
-    # A device with rows but not in the participants map contributes nothing.
-    assert all(w.device != "U_NotAParticipant" for w in start + end)
-
-
-def test_collect_boundary_writes_no_provider_only_forced_overrides() -> None:
-    participants = {
-        "U_DG": {"at_scan_start": {"Mode": "A"}, "at_scan_end": {}},
-    }
-    start, end = collect_scan_boundary_writes(participants, None)
-    assert [(w.device, w.variable, w.source) for w in start] == [
-        ("U_DG", "Mode", "override")
-    ]
-    assert end == []
-
-
-# ---------------------------------------------------------------------------
 # telemetry selection
 # ---------------------------------------------------------------------------
 
@@ -248,10 +130,6 @@ class _RaisingDb:
     def get_all_experiment_variables(experiment, *, enabled_only=True):
         raise RuntimeError("no network")
 
-    @staticmethod
-    def get_scan_boundary_writes(experiment, *, enabled_only=True):
-        raise RuntimeError("no network")
-
 
 def test_policy_degrades_to_empty_on_db_failure(caplog) -> None:
     policy = GeecsDbScalarPolicy("Undulator", db=_RaisingDb)
@@ -259,7 +137,6 @@ def test_policy_degrades_to_empty_on_db_failure(caplog) -> None:
         assert policy.subscribed_by_device() == {}
         assert policy.get_variables("U_Cam") == []
         assert policy.all_variables("U_Cam") == []
-        assert policy.boundary_writes("U_Cam") == []
     assert any("Could not read" in r.message for r in caplog.records)
 
 

--- a/GeecsBluesky/tests/test_db_runtime.py
+++ b/GeecsBluesky/tests/test_db_runtime.py
@@ -1,0 +1,281 @@
+"""Hermetic unit tests for the M3c DB-integration runtime (pure logic).
+
+No MySQL, no gateway, no network — a fake :class:`ScalarPolicyProvider` stands
+in for :class:`~geecs_ca_gateway.db.geecs_db.GeecsDb`.  Covers:
+
+- db_scalars resolution (True = get∪explicit, all_scalars = all∪explicit,
+  False = explicit-only, no-provider = explicit-only);
+- start/end write selection (set='yes' rows, save/localsavingpath skipped,
+  override value / null-suppression / absent cases, uncurated-variable
+  forced override);
+- participants assembly (save-set devices + scan-variable devices);
+- telemetry selection (get='yes'-not-in-save-set, empty dropped);
+- GeecsDbScalarPolicy tolerance (a DB failure degrades to empty policy).
+"""
+
+from __future__ import annotations
+
+import logging
+
+from geecs_bluesky.db_runtime import (
+    GeecsDbScalarPolicy,
+    collect_scan_boundary_writes,
+    resolve_boundary_writes,
+    resolve_entry_scalars,
+    select_telemetry_variables,
+)
+from geecs_schemas import SaveSet, SaveSetEntry
+
+
+class _FakePolicy:
+    """In-memory ScalarPolicyProvider (no DB)."""
+
+    def __init__(
+        self,
+        subscribed: dict[str, list[str]] | None = None,
+        all_vars: dict[str, list[str]] | None = None,
+        boundary: dict[str, list[dict]] | None = None,
+    ) -> None:
+        self._subscribed = subscribed or {}
+        self._all = all_vars or {}
+        self._boundary = boundary or {}
+
+    def get_variables(self, device: str) -> list[str]:
+        return list(self._subscribed.get(device, []))
+
+    def all_variables(self, device: str) -> list[str]:
+        return list(self._all.get(device, []))
+
+    def subscribed_by_device(self) -> dict[str, list[str]]:
+        return dict(self._subscribed)
+
+    def boundary_writes(self, device: str) -> list[dict]:
+        return list(self._boundary.get(device, []))
+
+
+# ---------------------------------------------------------------------------
+# db_scalars resolution
+# ---------------------------------------------------------------------------
+
+
+def test_db_scalars_true_unions_get_yes_with_explicit() -> None:
+    policy = _FakePolicy(subscribed={"U_Cam": ["MaxCounts", "centroidx"]})
+    out = resolve_entry_scalars(
+        "U_Cam", ["Extra"], db_scalars=True, all_scalars=False, provider=policy
+    )
+    # DB get='yes' first (DB order), then explicit extras not already present.
+    assert out == ["MaxCounts", "centroidx", "Extra"]
+
+
+def test_db_scalars_true_dedupes_overlap() -> None:
+    policy = _FakePolicy(subscribed={"U_Cam": ["MaxCounts", "centroidx"]})
+    out = resolve_entry_scalars(
+        "U_Cam", ["centroidx"], db_scalars=True, all_scalars=False, provider=policy
+    )
+    assert out == ["MaxCounts", "centroidx"]
+
+
+def test_all_scalars_unions_every_db_variable() -> None:
+    policy = _FakePolicy(
+        subscribed={"U_Cam": ["MaxCounts"]},
+        all_vars={"U_Cam": ["MaxCounts", "centroidx", "Exposure"]},
+    )
+    out = resolve_entry_scalars(
+        "U_Cam", [], db_scalars=True, all_scalars=True, provider=policy
+    )
+    assert out == ["MaxCounts", "centroidx", "Exposure"]
+
+
+def test_db_scalars_false_is_explicit_only() -> None:
+    policy = _FakePolicy(subscribed={"U_Cam": ["MaxCounts", "centroidx"]})
+    out = resolve_entry_scalars(
+        "U_Cam", ["Val"], db_scalars=False, all_scalars=False, provider=policy
+    )
+    # The legacy-converter pin: only the explicit list, DB ignored entirely.
+    assert out == ["Val"]
+
+
+def test_no_provider_is_explicit_only_even_with_db_scalars_true() -> None:
+    out = resolve_entry_scalars(
+        "U_Cam", ["Val"], db_scalars=True, all_scalars=False, provider=None
+    )
+    assert out == ["Val"]
+
+
+# ---------------------------------------------------------------------------
+# start/end write selection
+# ---------------------------------------------------------------------------
+
+
+def _rows() -> list[dict]:
+    return [
+        {"variable": "TriggerMode", "startvalue": "Scan", "endvalue": "Standby"},
+        {"variable": "Shutter", "startvalue": "Open", "endvalue": "Closed"},
+        {"variable": "save", "startvalue": "on", "endvalue": "off"},
+        {"variable": "localsavingpath", "startvalue": "C:/x", "endvalue": "C:/x"},
+    ]
+
+
+def test_start_writes_use_startvalue_and_skip_save_paths() -> None:
+    writes = resolve_boundary_writes("U_DG", _rows(), which="start", overrides={})
+    assert [(w.variable, w.value, w.source) for w in writes] == [
+        ("TriggerMode", "Scan", "db"),
+        ("Shutter", "Open", "db"),
+    ]
+
+
+def test_end_writes_use_endvalue() -> None:
+    writes = resolve_boundary_writes("U_DG", _rows(), which="end", overrides={})
+    assert [(w.variable, w.value) for w in writes] == [
+        ("TriggerMode", "Standby"),
+        ("Shutter", "Closed"),
+    ]
+
+
+def test_override_value_replaces_db_value() -> None:
+    writes = resolve_boundary_writes(
+        "U_DG", _rows(), which="start", overrides={"TriggerMode": "Single"}
+    )
+    trig = next(w for w in writes if w.variable == "TriggerMode")
+    assert trig.value == "Single"
+    assert trig.source == "override"
+
+
+def test_null_override_suppresses_the_write() -> None:
+    writes = resolve_boundary_writes(
+        "U_DG", _rows(), which="start", overrides={"TriggerMode": None}
+    )
+    assert [w.variable for w in writes] == ["Shutter"]
+
+
+def test_absent_override_uses_db_value() -> None:
+    writes = resolve_boundary_writes(
+        "U_DG", _rows(), which="start", overrides={"Shutter": "Half"}
+    )
+    trig = next(w for w in writes if w.variable == "TriggerMode")
+    assert trig.value == "Scan" and trig.source == "db"
+
+
+def test_null_db_value_without_override_is_no_write() -> None:
+    rows = [{"variable": "Foo", "startvalue": None, "endvalue": "1"}]
+    assert resolve_boundary_writes("U_D", rows, which="start", overrides={}) == []
+    end = resolve_boundary_writes("U_D", rows, which="end", overrides={})
+    assert [(w.variable, w.value) for w in end] == [("Foo", "1")]
+
+
+def test_forced_override_for_uncurated_variable() -> None:
+    # A variable with no DB row but an override value → a forced write.
+    writes = resolve_boundary_writes(
+        "U_DG", _rows(), which="start", overrides={"NewVar": "7"}
+    )
+    forced = next(w for w in writes if w.variable == "NewVar")
+    assert forced.value == "7" and forced.source == "override"
+
+
+def test_null_override_for_uncurated_variable_is_noop() -> None:
+    writes = resolve_boundary_writes(
+        "U_DG", _rows(), which="start", overrides={"NewVar": None}
+    )
+    assert all(w.variable != "NewVar" for w in writes)
+
+
+# ---------------------------------------------------------------------------
+# participants collection
+# ---------------------------------------------------------------------------
+
+
+def test_collect_boundary_writes_participants_only() -> None:
+    policy = _FakePolicy(
+        boundary={
+            "U_DG": [{"variable": "Mode", "startvalue": "A", "endvalue": "B"}],
+            "U_NotAParticipant": [
+                {"variable": "X", "startvalue": "1", "endvalue": "2"}
+            ],
+        }
+    )
+    participants = {
+        "U_DG": {"at_scan_start": {}, "at_scan_end": {}},
+    }
+    start, end = collect_scan_boundary_writes(participants, policy)
+    assert [(w.device, w.variable) for w in start] == [("U_DG", "Mode")]
+    # A device with rows but not in the participants map contributes nothing.
+    assert all(w.device != "U_NotAParticipant" for w in start + end)
+
+
+def test_collect_boundary_writes_no_provider_only_forced_overrides() -> None:
+    participants = {
+        "U_DG": {"at_scan_start": {"Mode": "A"}, "at_scan_end": {}},
+    }
+    start, end = collect_scan_boundary_writes(participants, None)
+    assert [(w.device, w.variable, w.source) for w in start] == [
+        ("U_DG", "Mode", "override")
+    ]
+    assert end == []
+
+
+# ---------------------------------------------------------------------------
+# telemetry selection
+# ---------------------------------------------------------------------------
+
+
+def test_telemetry_selects_get_yes_not_in_save_set() -> None:
+    save_set = SaveSet(name="s", entries=[SaveSetEntry(device="U_Cam", scalars=["x"])])
+    subscribed = {
+        "U_Cam": ["MaxCounts"],  # in save set → excluded wholesale
+        "U_Press": ["Pressure"],  # not in save set → telemetry
+        "U_Empty": [],  # no get-vars → dropped
+    }
+    selected = select_telemetry_variables(save_set, subscribed)
+    assert selected == {"U_Press": ["Pressure"]}
+
+
+def test_telemetry_no_save_set_selects_everything() -> None:
+    subscribed = {"U_A": ["v1"], "U_B": ["v2"]}
+    assert select_telemetry_variables(None, subscribed) == subscribed
+
+
+# ---------------------------------------------------------------------------
+# GeecsDbScalarPolicy tolerance (no real DB)
+# ---------------------------------------------------------------------------
+
+
+class _RaisingDb:
+    @staticmethod
+    def get_subscribed_variables(experiment, *, enabled_only=True):
+        raise RuntimeError("no network")
+
+    @staticmethod
+    def get_all_experiment_variables(experiment, *, enabled_only=True):
+        raise RuntimeError("no network")
+
+    @staticmethod
+    def get_scan_boundary_writes(experiment, *, enabled_only=True):
+        raise RuntimeError("no network")
+
+
+def test_policy_degrades_to_empty_on_db_failure(caplog) -> None:
+    policy = GeecsDbScalarPolicy("Undulator", db=_RaisingDb)
+    with caplog.at_level(logging.WARNING):
+        assert policy.subscribed_by_device() == {}
+        assert policy.get_variables("U_Cam") == []
+        assert policy.all_variables("U_Cam") == []
+        assert policy.boundary_writes("U_Cam") == []
+    assert any("Could not read" in r.message for r in caplog.records)
+
+
+class _CountingDb:
+    calls = 0
+
+    @classmethod
+    def get_subscribed_variables(cls, experiment, *, enabled_only=True):
+        cls.calls += 1
+        return {"U_Cam": ["MaxCounts"]}
+
+
+def test_policy_caches_queries() -> None:
+    _CountingDb.calls = 0
+    policy = GeecsDbScalarPolicy("Undulator", db=_CountingDb)
+    policy.get_variables("U_Cam")
+    policy.get_variables("U_Other")
+    policy.subscribed_by_device()
+    assert _CountingDb.calls == 1  # one batched query, cached

--- a/GeecsBluesky/tests/test_scan_request_runner.py
+++ b/GeecsBluesky/tests/test_scan_request_runner.py
@@ -1570,3 +1570,68 @@ def test_no_provider_leaves_m3b_behavior_unchanged(legacy_resolver) -> None:
     run_scan_request(session, _db_noscan_request(), legacy_resolver)
     assert "db_scan_writes" not in session.scan_kwargs["md"]
     assert "background_telemetry" not in session.scan_kwargs["md"]
+
+
+def test_telemetry_metadata_excludes_dropped_devices(
+    monkeypatch, legacy_resolver
+) -> None:
+    """md background_telemetry records only devices that connected (review P2).
+
+    A device dropped as unreachable at scan start contributes no columns, so
+    the start-doc must not advertise it (EVENT_SCHEMA.md contract).
+    """
+    policy = _M3cPolicy(
+        subscribed={
+            "U_Press": ["Pressure"],  # live → recorded
+            "U_Dead": ["X"],  # unreachable → dropped, must be absent from md
+        }
+    )
+    _install_policy(monkeypatch, policy)
+    session = _M3cSession()
+    session.dead_devices = {"U_Dead"}
+    run_scan_request(session, _db_noscan_request(), legacy_resolver)
+    recorded = session.scan_kwargs["md"]["background_telemetry"]
+    assert recorded == {"U_Press": ["Pressure"]}
+    assert "U_Dead" not in recorded
+
+
+def test_optimize_warns_on_reserved_boundary_fields(
+    monkeypatch, legacy_resolver, caplog
+) -> None:
+    """Optimize mode also warns once on reserved at_scan_start/at_scan_end (P3).
+
+    The reserved-field warning must fire in every mode that resolves a save set,
+    not only scan/noscan — optimize ignores the set-side too.
+    """
+    _install_policy(monkeypatch, _M3cPolicy())
+    session = _M3cSession()
+    save_set = SaveSet(
+        name="ReservedSet",
+        entries=[
+            SaveSetEntry(
+                device="U_DG645_ShotControl",
+                scalars=["x"],
+                at_scan_start={"Trigger.Source": "External"},
+            )
+        ],
+    )
+    monkeypatch.setattr(legacy_resolver, "resolve_save_set", lambda name: save_set)
+
+    def objective(bin_data) -> float:
+        return 1.0
+
+    with caplog.at_level(logging.WARNING):
+        run_scan_request(
+            session,
+            _optimize_request(save_set="X"),
+            legacy_resolver,
+            objective=objective,
+            suggester=object(),
+        )
+    reserved = [
+        r
+        for r in caplog.records
+        if "reserved DB scan start/end fields" in r.getMessage()
+    ]
+    assert len(reserved) == 1
+    assert "U_DG645_ShotControl" in reserved[0].getMessage()

--- a/GeecsBluesky/tests/test_scan_request_runner.py
+++ b/GeecsBluesky/tests/test_scan_request_runner.py
@@ -1366,3 +1366,239 @@ def test_lazy_registry_propagates_unexpected_resolver_faults() -> None:
     assert registry.get("missing", "default") == "default"
     with pytest.raises(RuntimeError, match="exploded"):
         registry.get("anything_else")
+
+
+# ---------------------------------------------------------------------------
+# M3c: DB-integration runtime (db_scalars, start/end writes, telemetry)
+# ---------------------------------------------------------------------------
+
+
+class _M3cPolicy:
+    """In-memory ScalarPolicyProvider for the runner integration tests."""
+
+    def __init__(self, subscribed=None, all_vars=None, boundary=None) -> None:
+        self._subscribed = subscribed or {}
+        self._all = all_vars or {}
+        self._boundary = boundary or {}
+
+    def get_variables(self, device):
+        return list(self._subscribed.get(device, []))
+
+    def all_variables(self, device):
+        return list(self._all.get(device, []))
+
+    def subscribed_by_device(self):
+        return dict(self._subscribed)
+
+    def boundary_writes(self, device):
+        return list(self._boundary.get(device, []))
+
+
+class _M3cSession(_FakeSession):
+    """Fake session exposing experiment + soft telemetry factory."""
+
+    experiment = "TestExp"
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.telemetry_calls: list = []
+        self.dead_devices: set = set()
+
+    def telemetry(self, device, variables, *, name=None):
+        self.telemetry_calls.append((device, list(variables)))
+        if device in self.dead_devices:
+            return None  # unreachable at scan start → dropped
+        return self._make(f"telemetry:{device}", "telemetry")
+
+
+def _install_policy(monkeypatch, policy) -> None:
+    """Force run_scan_request to use *policy* instead of a real GeecsDb."""
+    import geecs_bluesky.scan_request_runner as runner
+
+    monkeypatch.setattr(runner, "make_scalar_policy", lambda session: policy)
+
+
+def _db_noscan_request(**overrides):
+    base = dict(
+        mode="noscan",
+        shots_per_step=2,
+        acquisition="strict",
+        save_set="UC_Test",
+    )
+    base.update(overrides)
+    return ScanRequest.model_validate(base)
+
+
+def test_db_scalars_union_reaches_devices_config(monkeypatch, legacy_resolver) -> None:
+    # UC_Test's converted element pins db_scalars=False per device, so its
+    # recorded list stays explicit-only.  Verify the resolver-level policy is
+    # threaded by checking a save set with db_scalars left at the True default.
+    policy = _M3cPolicy(subscribed={"U_Cam": ["MaxCounts", "centroidx"]})
+    save_set = SaveSet(
+        name="s",
+        entries=[SaveSetEntry(device="U_Cam", scalars=["Extra"])],  # db_scalars=True
+    )
+    config = save_set_to_devices_config(save_set, policy)
+    assert config["U_Cam"]["variable_list"] == ["MaxCounts", "centroidx", "Extra"]
+
+
+def test_converted_legacy_element_pins_db_scalars_false(legacy_resolver) -> None:
+    # The legacy converter sets db_scalars=False, so even with a policy the
+    # recorded scalars are exactly the element's explicit variable_list.
+    policy = _M3cPolicy(subscribed={"U_Cam": ["ShouldNotAppear"]})
+    save_set = legacy_resolver.resolve_save_set("UC_Test")
+    config = save_set_to_devices_config(save_set, policy)
+    assert "ShouldNotAppear" not in config["U_Cam"]["variable_list"]
+    assert config["U_Cam"]["variable_list"] == ["MaxCounts"]
+
+
+def test_start_writes_run_in_setup_end_writes_in_closeout(
+    monkeypatch, legacy_resolver
+) -> None:
+    policy = _M3cPolicy(
+        subscribed={"U_Cam": [], "U_Cam2": [], "U_Slow": []},
+        boundary={
+            "U_Cam": [
+                {"variable": "Mode", "startvalue": "Scan", "endvalue": "Idle"},
+                {"variable": "save", "startvalue": "on", "endvalue": "off"},
+            ]
+        },
+    )
+    _install_policy(monkeypatch, policy)
+    session = _M3cSession()
+    run_scan_request(session, _db_noscan_request(), legacy_resolver)
+
+    kwargs = session.scan_kwargs
+    # Start writes are chained into the setup hook (after any setup actions).
+    start = _set_targets(kwargs["setup"]())
+    assert ("U_Cam-Mode", "Scan") in start
+    assert not any(name.endswith("-save") for name, _ in start)  # save skipped
+    # End writes are chained into the closeout hook (finalize path).
+    end = _set_targets(kwargs["closeout"]())
+    assert ("U_Cam-Mode", "Idle") in end
+    # Provenance recorded.
+    writes = kwargs["md"]["db_scan_writes"]
+    assert writes["at_scan_start"][0]["variable"] == "Mode"
+    assert writes["at_scan_end"][0]["value"] == "Idle"
+
+
+def test_start_end_writes_apply_overrides(monkeypatch, legacy_resolver) -> None:
+    policy = _M3cPolicy(
+        boundary={
+            "U_Cam": [
+                {"variable": "Mode", "startvalue": "Scan", "endvalue": "Idle"},
+                {"variable": "Gate", "startvalue": "1", "endvalue": "0"},
+            ]
+        },
+    )
+    _install_policy(monkeypatch, policy)
+    session = _M3cSession()
+    # Override Mode's start value; suppress Gate entirely.
+    save_set = SaveSet(
+        name="s",
+        entries=[
+            SaveSetEntry(
+                device="U_Cam",
+                scalars=["x"],
+                at_scan_start={"Mode": "Single", "Gate": None},
+            )
+        ],
+    )
+    monkeypatch.setattr(legacy_resolver, "resolve_save_set", lambda name: save_set)
+    run_scan_request(session, _db_noscan_request(save_set="X"), legacy_resolver)
+    start = _set_targets(session.scan_kwargs["setup"]())
+    assert ("U_Cam-Mode", "Single") in start
+    assert not any(name == "U_Cam-Gate" for name, _ in start)  # suppressed
+
+
+def test_apply_db_scan_defaults_off_skips_writes(monkeypatch, legacy_resolver) -> None:
+    policy = _M3cPolicy(
+        boundary={"U_Cam": [{"variable": "Mode", "startvalue": "S", "endvalue": "E"}]}
+    )
+    _install_policy(monkeypatch, policy)
+    monkeypatch.setattr(
+        legacy_resolver,
+        "resolve_experiment_defaults",
+        lambda: ExperimentDefaults.model_validate(
+            {"schema_version": 1, "apply_db_scan_defaults": False}
+        ),
+    )
+    session = _M3cSession()
+    run_scan_request(session, _db_noscan_request(), legacy_resolver)
+    assert "db_scan_writes" not in session.scan_kwargs["md"]
+
+
+def test_telemetry_selects_non_saveset_devices(monkeypatch, legacy_resolver) -> None:
+    policy = _M3cPolicy(
+        subscribed={
+            "U_Cam": ["MaxCounts"],  # in save set (UC_Test) → excluded
+            "U_Press": ["Pressure"],  # not in save set → telemetry
+        }
+    )
+    _install_policy(monkeypatch, policy)
+    session = _M3cSession()
+    run_scan_request(session, _db_noscan_request(), legacy_resolver)
+    assert session.telemetry_calls == [("U_Press", ["Pressure"])]
+    # Telemetry device appended to the read set, never the reference.
+    assert ("telemetry:U_Press", "telemetry") in session.devices
+    assert session.scan_kwargs["md"]["background_telemetry"] == {
+        "U_Press": ["Pressure"]
+    }
+
+
+def test_telemetry_dead_device_dropped_not_raised(
+    monkeypatch, legacy_resolver, caplog
+) -> None:
+    policy = _M3cPolicy(subscribed={"U_Press": ["Pressure"]})
+    _install_policy(monkeypatch, policy)
+    session = _M3cSession()
+    session.dead_devices = {"U_Press"}
+    # Must not raise even though the telemetry device is unreachable.
+    run_scan_request(session, _db_noscan_request(), legacy_resolver)
+    # Attempted, returned None → not in the read set.
+    assert session.telemetry_calls == [("U_Press", ["Pressure"])]
+    assert not any(d[0].startswith("telemetry:") for d in session.devices)
+
+
+def test_background_telemetry_off_skips_telemetry(monkeypatch, legacy_resolver) -> None:
+    policy = _M3cPolicy(subscribed={"U_Press": ["Pressure"]})
+    _install_policy(monkeypatch, policy)
+    session = _M3cSession()
+    run_scan_request(
+        session,
+        _db_noscan_request(background_telemetry=False),
+        legacy_resolver,
+    )
+    assert session.telemetry_calls == []
+    assert "background_telemetry" not in session.scan_kwargs["md"]
+
+
+def test_request_telemetry_flag_overrides_experiment_default(
+    monkeypatch, legacy_resolver
+) -> None:
+    policy = _M3cPolicy(subscribed={"U_Press": ["Pressure"]})
+    _install_policy(monkeypatch, policy)
+    # Experiment default off, request explicitly on → telemetry runs.
+    monkeypatch.setattr(
+        legacy_resolver,
+        "resolve_experiment_defaults",
+        lambda: ExperimentDefaults.model_validate(
+            {"schema_version": 1, "background_telemetry": False}
+        ),
+    )
+    session = _M3cSession()
+    run_scan_request(
+        session,
+        _db_noscan_request(background_telemetry=True),
+        legacy_resolver,
+    )
+    assert session.telemetry_calls == [("U_Press", ["Pressure"])]
+
+
+def test_no_provider_leaves_m3b_behavior_unchanged(legacy_resolver) -> None:
+    # A session with no experiment attribute → no policy → no DB writes, no
+    # telemetry, explicit-only scalars (the M3b path, still green).
+    session = _FakeSession()
+    run_scan_request(session, _db_noscan_request(), legacy_resolver)
+    assert "db_scan_writes" not in session.scan_kwargs["md"]
+    assert "background_telemetry" not in session.scan_kwargs["md"]

--- a/GeecsBluesky/tests/test_scan_request_runner.py
+++ b/GeecsBluesky/tests/test_scan_request_runner.py
@@ -1369,17 +1369,17 @@ def test_lazy_registry_propagates_unexpected_resolver_faults() -> None:
 
 
 # ---------------------------------------------------------------------------
-# M3c: DB-integration runtime (db_scalars, start/end writes, telemetry)
+# M3c: DB-integration runtime (get-side: db_scalars + telemetry; set-side
+# disabled — reserved fields warn and are not applied)
 # ---------------------------------------------------------------------------
 
 
 class _M3cPolicy:
-    """In-memory ScalarPolicyProvider for the runner integration tests."""
+    """In-memory get-side ScalarPolicyProvider for the runner integration tests."""
 
-    def __init__(self, subscribed=None, all_vars=None, boundary=None) -> None:
+    def __init__(self, subscribed=None, all_vars=None) -> None:
         self._subscribed = subscribed or {}
         self._all = all_vars or {}
-        self._boundary = boundary or {}
 
     def get_variables(self, device):
         return list(self._subscribed.get(device, []))
@@ -1389,9 +1389,6 @@ class _M3cPolicy:
 
     def subscribed_by_device(self):
         return dict(self._subscribed)
-
-    def boundary_writes(self, device):
-        return list(self._boundary.get(device, []))
 
 
 class _M3cSession(_FakeSession):
@@ -1452,80 +1449,51 @@ def test_converted_legacy_element_pins_db_scalars_false(legacy_resolver) -> None
     assert config["U_Cam"]["variable_list"] == ["MaxCounts"]
 
 
-def test_start_writes_run_in_setup_end_writes_in_closeout(
-    monkeypatch, legacy_resolver
+def test_reserved_boundary_fields_warn_and_are_not_applied(
+    monkeypatch, legacy_resolver, caplog
 ) -> None:
-    policy = _M3cPolicy(
-        subscribed={"U_Cam": [], "U_Cam2": [], "U_Slow": []},
-        boundary={
-            "U_Cam": [
-                {"variable": "Mode", "startvalue": "Scan", "endvalue": "Idle"},
-                {"variable": "save", "startvalue": "on", "endvalue": "off"},
-            ]
-        },
-    )
-    _install_policy(monkeypatch, policy)
+    """A SaveSet entry that sets the reserved set-side fields is inert + warned.
+
+    The DB set-side (scan start/end writes) is disabled in this version.  An
+    entry that still carries ``at_scan_start`` / ``at_scan_end`` must NOT
+    produce any boundary write, must NOT chain anything into the
+    setup/closeout hooks, and must NOT record ``db_scan_writes`` metadata —
+    but the operator gets exactly one WARNING naming the device so they know
+    the values are inert.  The scan itself still runs.
+    """
+    _install_policy(monkeypatch, _M3cPolicy())
     session = _M3cSession()
-    run_scan_request(session, _db_noscan_request(), legacy_resolver)
-
-    kwargs = session.scan_kwargs
-    # Start writes are chained into the setup hook (after any setup actions).
-    start = _set_targets(kwargs["setup"]())
-    assert ("U_Cam-Mode", "Scan") in start
-    assert not any(name.endswith("-save") for name, _ in start)  # save skipped
-    # End writes are chained into the closeout hook (finalize path).
-    end = _set_targets(kwargs["closeout"]())
-    assert ("U_Cam-Mode", "Idle") in end
-    # Provenance recorded.
-    writes = kwargs["md"]["db_scan_writes"]
-    assert writes["at_scan_start"][0]["variable"] == "Mode"
-    assert writes["at_scan_end"][0]["value"] == "Idle"
-
-
-def test_start_end_writes_apply_overrides(monkeypatch, legacy_resolver) -> None:
-    policy = _M3cPolicy(
-        boundary={
-            "U_Cam": [
-                {"variable": "Mode", "startvalue": "Scan", "endvalue": "Idle"},
-                {"variable": "Gate", "startvalue": "1", "endvalue": "0"},
-            ]
-        },
-    )
-    _install_policy(monkeypatch, policy)
-    session = _M3cSession()
-    # Override Mode's start value; suppress Gate entirely.
     save_set = SaveSet(
-        name="s",
+        name="ReservedSet",
         entries=[
             SaveSetEntry(
-                device="U_Cam",
+                device="U_DG645_ShotControl",
                 scalars=["x"],
-                at_scan_start={"Mode": "Single", "Gate": None},
+                at_scan_start={"Trigger.Source": "External"},
+                at_scan_end={"Amplitude.Ch AB": "0"},
             )
         ],
     )
     monkeypatch.setattr(legacy_resolver, "resolve_save_set", lambda name: save_set)
-    run_scan_request(session, _db_noscan_request(save_set="X"), legacy_resolver)
-    start = _set_targets(session.scan_kwargs["setup"]())
-    assert ("U_Cam-Mode", "Single") in start
-    assert not any(name == "U_Cam-Gate" for name, _ in start)  # suppressed
 
+    with caplog.at_level(logging.WARNING):
+        run_scan_request(session, _db_noscan_request(save_set="X"), legacy_resolver)
 
-def test_apply_db_scan_defaults_off_skips_writes(monkeypatch, legacy_resolver) -> None:
-    policy = _M3cPolicy(
-        boundary={"U_Cam": [{"variable": "Mode", "startvalue": "S", "endvalue": "E"}]}
-    )
-    _install_policy(monkeypatch, policy)
-    monkeypatch.setattr(
-        legacy_resolver,
-        "resolve_experiment_defaults",
-        lambda: ExperimentDefaults.model_validate(
-            {"schema_version": 1, "apply_db_scan_defaults": False}
-        ),
-    )
-    session = _M3cSession()
-    run_scan_request(session, _db_noscan_request(), legacy_resolver)
-    assert "db_scan_writes" not in session.scan_kwargs["md"]
+    # Exactly one reserved-not-honored warning, naming the device.
+    reserved = [
+        r
+        for r in caplog.records
+        if "reserved DB scan start/end fields" in r.getMessage()
+    ]
+    assert len(reserved) == 1
+    assert "U_DG645_ShotControl" in reserved[0].getMessage()
+
+    # The scan ran, but nothing was chained and no set-side metadata recorded.
+    kwargs = session.scan_kwargs
+    assert kwargs["setup"] is None
+    assert kwargs["closeout"] is None
+    assert "db_scan_writes" not in kwargs["md"]
+    assert "db_scan_runtime" not in kwargs["md"]
 
 
 def test_telemetry_selects_non_saveset_devices(monkeypatch, legacy_resolver) -> None:

--- a/GeecsBluesky/tests/test_telemetry_device.py
+++ b/GeecsBluesky/tests/test_telemetry_device.py
@@ -2,8 +2,12 @@
 
 Mock backends, no gateway.  Verifies the softness contract: telemetry columns
 carry the ``telemetry_`` name prefix, a read returns values normally, and a
-failing signal read degrades to a NaN cell rather than raising into the plan
-(so telemetry can never abort a scan).
+failing signal read degrades to a dtype-appropriate null cell (NaN for numeric,
+``""`` for string) rather than raising into the plan (so telemetry can never
+abort a scan).  Also pins the M3c type-tolerance fix: signal dtype is inferred
+per-variable (``datatype=None`` default), so a device mixing a numeric and an
+enum/string ``get='yes'`` variable logs both — the string var is captured as a
+label and the device is not dropped for its type.
 """
 
 from __future__ import annotations
@@ -16,10 +20,35 @@ pytest.importorskip("aioca")  # CA backend needs the `ca` extra
 
 from ophyd_async.core import set_mock_value  # noqa: E402
 
+import geecs_bluesky.devices.ca.telemetry as telemetry_mod  # noqa: E402
 from geecs_bluesky.devices.ca.telemetry import (  # noqa: E402
     TELEMETRY_NAME_PREFIX,
     CaTelemetryReadable,
 )
+
+
+def _build_typed_telemetry(
+    monkeypatch, device, variable_list, dtype_by_var, **kwargs
+) -> CaTelemetryReadable:
+    """Build a telemetry device whose per-variable signal dtypes are pinned.
+
+    Mock backends cannot infer a PV's native CA type (there is no live PV to
+    connect to), so ``datatype=None`` inference always resolves to float under
+    mock.  This helper stands in for that inference by pinning each variable's
+    signal dtype explicitly — the same per-column outcome real ``datatype=None``
+    inference produces on live PVs (numeric → float column, enum/string → string
+    column), letting a hermetic test exercise a MIX of dtypes in one device.
+    """
+    real_signal_r = telemetry_mod.epics_signal_r
+
+    def _typed_signal_r(datatype, read_pv, *args, **inner):
+        for var, dtype in dtype_by_var.items():
+            if read_pv.endswith(var):
+                return real_signal_r(dtype, read_pv, *args, **inner)
+        return real_signal_r(datatype, read_pv, *args, **inner)
+
+    monkeypatch.setattr(telemetry_mod, "epics_signal_r", _typed_signal_r)
+    return CaTelemetryReadable(device, variable_list, **kwargs)
 
 
 async def test_telemetry_columns_carry_the_prefix() -> None:
@@ -59,6 +88,92 @@ async def test_failing_signal_read_degrades_to_nan_not_raise(monkeypatch) -> Non
     assert math.isnan(reading["telemetry_press-pressure"]["value"])
     assert reading["telemetry_press-pressure"]["alarm_severity"] == 3  # INVALID
     assert reading["telemetry_press-temp"]["value"] == 300.0
+
+
+async def test_default_signal_datatype_is_inferred_not_forced_float() -> None:
+    """The default is ``datatype=None`` (inference), not the old float-only.
+
+    Forcing ``float`` was the bug: an enum/string ``get='yes'`` PV failed to
+    connect and the caller dropped the whole device.  Pinning the default to
+    ``None`` lets ophyd-async infer each PV's native type on live PVs (numeric
+    stays float, enum/string becomes a label string).
+    """
+    import inspect
+
+    default = (
+        inspect.signature(CaTelemetryReadable.__init__).parameters["datatype"].default
+    )
+    assert default is None
+
+
+async def test_mixed_numeric_and_string_vars_both_logged(monkeypatch) -> None:
+    """A device mixing a numeric var and a string/enum var: both are captured.
+
+    Regression pin for the M3c telemetry type-drop bug.  ``U_VisaPlungers``-
+    style enum PVs (``DigitalOutput.Channel N``) must be logged as their label
+    string while the numeric var stays numeric, and the device must NOT be
+    dropped for the string var's type.  On the old float-only construction the
+    string signal would fail to connect and the whole device (including its
+    numeric column) would be dropped by the caller.
+    """
+    dev = _build_typed_telemetry(
+        monkeypatch,
+        "U_VisaPlungers",
+        ["Pressure", "DigitalOutput.Channel 3"],
+        {"Pressure": float, "Channel_3": str},
+        name="telemetry_visaplungers",
+    )
+    await dev.connect(mock=True)  # must NOT raise a type-coercion error
+
+    set_mock_value(dev.pressure, 2.5)
+    set_mock_value(getattr(dev, "digitaloutput_channel_3"), "DigitalOutput.Channel 3")
+
+    desc = await dev.describe()
+    # Numeric var stays numeric; string/enum var is a string column.
+    assert desc["telemetry_visaplungers-pressure"]["dtype"] == "number"
+    assert desc["telemetry_visaplungers-digitaloutput_channel_3"]["dtype"] == "string"
+
+    reading = await dev.read()
+    # Both columns present — neither the string var nor the device is dropped.
+    assert reading["telemetry_visaplungers-pressure"]["value"] == 2.5
+    assert (
+        reading["telemetry_visaplungers-digitaloutput_channel_3"]["value"]
+        == "DigitalOutput.Channel 3"
+    )
+
+
+async def test_failed_read_of_string_signal_degrades_to_empty_string(
+    monkeypatch,
+) -> None:
+    """A string signal whose read fails yields ``""`` — not a NaN float.
+
+    The soft-tier null substitution is dtype-aware: a failed numeric read is
+    NaN, a failed string read is ``""``, so a dead read never forces a string
+    telemetry column to hold a float.
+    """
+    dev = _build_typed_telemetry(
+        monkeypatch,
+        "U_VisaPlungers",
+        ["Pressure", "DigitalOutput.Channel 3"],
+        {"Pressure": float, "Channel_3": str},
+        name="telemetry_visaplungers",
+    )
+    await dev.connect(mock=True)
+    set_mock_value(dev.pressure, 2.5)
+
+    channel = getattr(dev, "digitaloutput_channel_3")
+
+    async def _boom() -> dict:
+        raise TimeoutError("device gone")
+
+    monkeypatch.setattr(channel, "read", _boom)
+
+    reading = await dev.read()  # must NOT raise
+    assert reading["telemetry_visaplungers-pressure"]["value"] == 2.5
+    assert reading["telemetry_visaplungers-digitaloutput_channel_3"]["value"] == ""
+    assert (
+        reading["telemetry_visaplungers-digitaloutput_channel_3"]["alarm_severity"] == 3
+    )
 
 
 async def test_telemetry_is_read_only_no_setpoint_signals() -> None:

--- a/GeecsBluesky/tests/test_telemetry_device.py
+++ b/GeecsBluesky/tests/test_telemetry_device.py
@@ -1,0 +1,69 @@
+"""Hermetic tests for CaTelemetryReadable — the soft Tier-2 telemetry device.
+
+Mock backends, no gateway.  Verifies the softness contract: telemetry columns
+carry the ``telemetry_`` name prefix, a read returns values normally, and a
+failing signal read degrades to a NaN cell rather than raising into the plan
+(so telemetry can never abort a scan).
+"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+pytest.importorskip("aioca")  # CA backend needs the `ca` extra
+
+from ophyd_async.core import set_mock_value  # noqa: E402
+
+from geecs_bluesky.devices.ca.telemetry import (  # noqa: E402
+    TELEMETRY_NAME_PREFIX,
+    CaTelemetryReadable,
+)
+
+
+async def test_telemetry_columns_carry_the_prefix() -> None:
+    dev = CaTelemetryReadable("U_Press", ["Pressure"], experiment="Undulator")
+    await dev.connect(mock=True)
+    assert dev.name.startswith(TELEMETRY_NAME_PREFIX)
+    desc = await dev.describe()
+    assert all(key.startswith(TELEMETRY_NAME_PREFIX) for key in desc)
+    # Not folded into the s-file header map (Tier 2, not save-set scalars).
+    assert dev._column_headers == {}
+
+
+async def test_telemetry_reads_values_normally() -> None:
+    # safe_name lowercases variable names into attrs and event keys.
+    dev = CaTelemetryReadable("U_Press", ["Pressure", "Temp"], name="telemetry_press")
+    await dev.connect(mock=True)
+    set_mock_value(dev.pressure, 1.5)
+    set_mock_value(dev.temp, 300.0)
+    reading = await dev.read()
+    assert reading["telemetry_press-pressure"]["value"] == 1.5
+    assert reading["telemetry_press-temp"]["value"] == 300.0
+
+
+async def test_failing_signal_read_degrades_to_nan_not_raise(monkeypatch) -> None:
+    dev = CaTelemetryReadable("U_Press", ["Pressure", "Temp"], name="telemetry_press")
+    await dev.connect(mock=True)
+    set_mock_value(dev.temp, 300.0)
+
+    # Simulate a dead device: pressure's read raises (a CA fault mid-scan).
+    async def _boom() -> dict:
+        raise TimeoutError("device gone")
+
+    monkeypatch.setattr(dev.pressure, "read", _boom)
+
+    reading = await dev.read()  # must NOT raise
+    # The failed signal is a NaN cell; the healthy one still reports its value.
+    assert math.isnan(reading["telemetry_press-pressure"]["value"])
+    assert reading["telemetry_press-pressure"]["alarm_severity"] == 3  # INVALID
+    assert reading["telemetry_press-temp"]["value"] == 300.0
+
+
+async def test_telemetry_is_read_only_no_setpoint_signals() -> None:
+    dev = CaTelemetryReadable("U_Press", ["Pressure"])
+    await dev.connect(mock=True)
+    assert not hasattr(dev, "save")
+    assert not hasattr(dev, "localsavingpath")
+    assert not hasattr(dev, "_setpoint")

--- a/GeecsCAGateway/CHANGELOG.md
+++ b/GeecsCAGateway/CHANGELOG.md
@@ -17,6 +17,12 @@ All notable changes to `geecs-ca-gateway` are documented here, following
     (`{device: [{"variable", "startvalue", "endvalue"}, ...]}`, values as raw
     wire strings or `None`), i.e. the Master-Control scan start/end write
     policy.  Row order is preserved so writes replay in a stable sequence.
+    **Reserved / currently unused:** the GeecsBluesky engine does not apply
+    these DB set-side boundary writes in the current version (the set-side is
+    intentionally disabled — triggering is owned by the trigger profile /
+    shot controller and camera saving by the scanner's save-windowing).  Kept
+    as a read-only library query for inspection and a possible future DB
+    scan-write feature.
 
 ## [0.8.0] - 2026-07-08
 

--- a/GeecsCAGateway/CHANGELOG.md
+++ b/GeecsCAGateway/CHANGELOG.md
@@ -3,6 +3,21 @@
 All notable changes to `geecs-ca-gateway` are documented here, following
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and semantic versioning.
 
+## [0.9.0] - 2026-07-08
+
+### Added
+
+- Two `GeecsDb` query methods backing the GeecsBluesky M3c DB-integration
+  runtime (library-only; the gateway server is unchanged):
+  - `get_all_experiment_variables(experiment)` — every `expt_device_variable`
+    row per device (`{device: [variablename, ...]}`, deduped), the
+    `all_scalars` counterpart of `get_subscribed_variables` (`get='yes'`).
+  - `get_scan_boundary_writes(experiment)` — the `set='yes'` rows'
+    `startvalue` / `endvalue` per device
+    (`{device: [{"variable", "startvalue", "endvalue"}, ...]}`, values as raw
+    wire strings or `None`), i.e. the Master-Control scan start/end write
+    policy.  Row order is preserved so writes replay in a stable sequence.
+
 ## [0.8.0] - 2026-07-08
 
 ### Added

--- a/GeecsCAGateway/geecs_ca_gateway/db/geecs_db.py
+++ b/GeecsCAGateway/geecs_ca_gateway/db/geecs_db.py
@@ -332,6 +332,127 @@ class GeecsDb:
         return result
 
     @classmethod
+    def get_all_experiment_variables(
+        cls, experiment: str, *, enabled_only: bool = True
+    ) -> dict[str, list[str]]:
+        """Return ``{device: [variablename, ...]}`` for every ``expt_device_variable`` row.
+
+        The ``all_scalars`` counterpart of :meth:`get_subscribed_variables`:
+        every variable the experiment tracks for a device instance, not just
+        the ``get='yes'`` subset.  Order is stable (device, then variable)
+        and duplicates are collapsed.
+
+        Parameters
+        ----------
+        experiment:
+            GEECS experiment name.
+        enabled_only:
+            Restrict to devices enabled in the experiment (default true).
+
+        Returns
+        -------
+        dict
+            Device name → ordered list of variable names.  Devices with no
+            rows are absent.
+        """
+        try:
+            import mysql.connector
+        except ImportError as exc:
+            raise ImportError(
+                "mysql-connector-python is required for DB lookups."
+            ) from exc
+
+        conn = _connect_mysql(mysql.connector)
+        try:
+            cur = conn.cursor()
+            query = (
+                "SELECT DISTINCT ed.device, edv.variablename "
+                "FROM expt_device_variable edv "
+                "JOIN expt_device ed ON ed.id = edv.expt_device_id "
+                "WHERE ed.expt = %s"
+            )
+            if enabled_only:
+                query += " AND LOWER(ed.enabled) = 'yes'"
+            query += " ORDER BY ed.device, edv.variablename"
+            cur.execute(query, (experiment,))
+            rows = cur.fetchall()
+        finally:
+            conn.close()
+
+        result: dict[str, list[str]] = {}
+        for device, variablename in rows:
+            bucket = result.setdefault(device, [])
+            if variablename not in bucket:
+                bucket.append(variablename)
+        return result
+
+    @classmethod
+    def get_scan_boundary_writes(
+        cls, experiment: str, *, enabled_only: bool = True
+    ) -> dict[str, list[dict]]:
+        """Return the ``set='yes'`` scan start/end writes per device.
+
+        ``expt_device_variable`` rows with ``set='yes'`` name the variables
+        the scan machinery writes at scan boundaries — exactly what Master
+        Control applies: the row's ``startvalue`` at scan start and
+        ``endvalue`` at scan end (see the ``SaveSetEntry`` runtime contract in
+        ``geecs_schemas.save_set``).  The values are returned as raw wire
+        strings (or ``None`` when the DB column is null); the caller decides
+        which participating devices to write and layers per-scan overrides on
+        top.  Row order is preserved (the DB's ``id`` order) so writes replay
+        in a stable sequence.
+
+        Parameters
+        ----------
+        experiment:
+            GEECS experiment name.
+        enabled_only:
+            Restrict to devices enabled in the experiment (default true).
+
+        Returns
+        -------
+        dict
+            Device name → ordered list of
+            ``{"variable": str, "startvalue": str|None, "endvalue": str|None}``
+            dicts, one per ``set='yes'`` row.  Devices with no such rows are
+            absent.
+        """
+        try:
+            import mysql.connector
+        except ImportError as exc:
+            raise ImportError(
+                "mysql-connector-python is required for DB lookups."
+            ) from exc
+
+        conn = _connect_mysql(mysql.connector)
+        try:
+            cur = conn.cursor()
+            query = (
+                "SELECT ed.device, edv.variablename, edv.startvalue, edv.endvalue "
+                "FROM expt_device_variable edv "
+                "JOIN expt_device ed ON ed.id = edv.expt_device_id "
+                "WHERE ed.expt = %s AND edv.`set` = 'yes'"
+            )
+            if enabled_only:
+                query += " AND LOWER(ed.enabled) = 'yes'"
+            query += " ORDER BY ed.device, edv.id"
+            cur.execute(query, (experiment,))
+            rows = cur.fetchall()
+        finally:
+            conn.close()
+
+        result: dict[str, list[dict]] = {}
+        for device, variablename, startvalue, endvalue in rows:
+            result.setdefault(device, []).append(
+                {
+                    "variable": variablename,
+                    "startvalue": None if startvalue is None else str(startvalue),
+                    "endvalue": None if endvalue is None else str(endvalue),
+                }
+            )
+        return result
+
+    @classmethod
     def get_device_variables(cls, device_name: str) -> list[dict]:
         """Return variable metadata for *device_name*.
 

--- a/GeecsCAGateway/geecs_ca_gateway/db/geecs_db.py
+++ b/GeecsCAGateway/geecs_ca_gateway/db/geecs_db.py
@@ -393,14 +393,21 @@ class GeecsDb:
         """Return the ``set='yes'`` scan start/end writes per device.
 
         ``expt_device_variable`` rows with ``set='yes'`` name the variables
-        the scan machinery writes at scan boundaries — exactly what Master
-        Control applies: the row's ``startvalue`` at scan start and
-        ``endvalue`` at scan end (see the ``SaveSetEntry`` runtime contract in
-        ``geecs_schemas.save_set``).  The values are returned as raw wire
-        strings (or ``None`` when the DB column is null); the caller decides
-        which participating devices to write and layers per-scan overrides on
-        top.  Row order is preserved (the DB's ``id`` order) so writes replay
-        in a stable sequence.
+        Master Control writes at scan boundaries — the row's ``startvalue`` at
+        scan start and ``endvalue`` at scan end.  The values are returned as
+        raw wire strings (or ``None`` when the DB column is null).  Row order
+        is preserved (the DB's ``id`` order) so writes replay in a stable
+        sequence.
+
+        .. note::
+
+           **Reserved / not currently consumed by the engine.**  This is a
+           read-only library query; the GeecsBluesky engine does *not* apply
+           these DB set-side boundary writes in the current version (the
+           set-side is intentionally disabled — triggering is owned by the
+           trigger profile / shot controller and camera saving by the
+           scanner's save-windowing).  The method is kept for inspection and
+           for a possible future DB scan-write feature.
 
         Parameters
         ----------

--- a/GeecsCAGateway/pyproject.toml
+++ b/GeecsCAGateway/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-ca-gateway"
-version = "0.8.0"
+version = "0.9.0"
 description = "EPICS Channel Access soft-IOC gateway exposing GEECS devices as PVs"
 authors = ["Sam Barber <sbarber@lbl.gov>"]
 readme = "README.md"

--- a/GeecsCAGateway/tests/test_geecs_db.py
+++ b/GeecsCAGateway/tests/test_geecs_db.py
@@ -183,6 +183,61 @@ def test_get_experiment_device_variables_batches_metadata(monkeypatch) -> None:
     assert result["U_B"][0]["settable"] is False
 
 
+def test_get_all_experiment_variables_groups_and_dedupes(monkeypatch) -> None:
+    """Every expt_device_variable row per device, deduped, in stable order."""
+    queries: list = []
+    _patch_rows(
+        monkeypatch,
+        [
+            ("U_A", "MaxCounts"),
+            ("U_A", "centroidx"),
+            ("U_A", "centroidx"),  # duplicate DB row (known quirk) → collapsed
+            ("U_B", "Pressure"),
+        ],
+        queries,
+    )
+
+    result = GeecsDb.get_all_experiment_variables("Undulator")
+    assert result == {"U_A": ["MaxCounts", "centroidx"], "U_B": ["Pressure"]}
+    assert len(queries) == 1 and queries[0][1] == ("Undulator",)
+    assert "LOWER(ed.enabled) = 'yes'" in queries[0][0]
+
+    queries.clear()
+    GeecsDb.get_all_experiment_variables("Undulator", enabled_only=False)
+    assert "enabled" not in queries[0][0]
+
+
+def test_get_scan_boundary_writes_returns_set_yes_rows(monkeypatch) -> None:
+    """set='yes' rows carry startvalue/endvalue as strings (None preserved)."""
+    queries: list = []
+    _patch_rows(
+        monkeypatch,
+        [
+            ("U_DG", "TriggerMode", "Scan", "Standby"),
+            ("U_DG", "Amplitude", 4.0, None),  # numeric coerced to str; None kept
+            ("U_Cam", "Shutter", "Open", "Closed"),
+        ],
+        queries,
+    )
+
+    result = GeecsDb.get_scan_boundary_writes("Undulator")
+    assert result["U_DG"] == [
+        {"variable": "TriggerMode", "startvalue": "Scan", "endvalue": "Standby"},
+        {"variable": "Amplitude", "startvalue": "4.0", "endvalue": None},
+    ]
+    assert result["U_Cam"] == [
+        {"variable": "Shutter", "startvalue": "Open", "endvalue": "Closed"}
+    ]
+    assert len(queries) == 1 and queries[0][1] == ("Undulator",)
+    query = queries[0][0]
+    assert "`set` = 'yes'" in query
+    assert "LOWER(ed.enabled) = 'yes'" in query
+
+    queries.clear()
+    GeecsDb.get_scan_boundary_writes("Undulator", enabled_only=False)
+    assert "enabled" not in queries[0][0]
+
+
 def test_get_ca_alarm_limits_returns_validated_rows(monkeypatch) -> None:
     """Optional alarm-limit rows are keyed by device/variable."""
     queries: list = []

--- a/docs/geecs_schemas/schemas_overview.md
+++ b/docs/geecs_schemas/schemas_overview.md
@@ -23,10 +23,12 @@ a dialog if one dies), their images are saved if asked, and their
 setup/closeout rituals run around the scan. Each entry records the device's
 standard telemetry (what the device database marks for scan logging) by
 default, plus any extra scalars you list. You don't declare timestamps or
-synchronization flags any more — the scanner works those out. The database's
-scan-start/end writes still apply, and an entry can override any of them per
-variable: replace the value, or suppress the write entirely with `null`.
-Devices *not* in the save set are still logged in the background — see
+synchronization flags any more — the scanner works those out. (The
+database's *set-side* scan-start/end writes are **not applied in this
+version** — the scanner handles triggering and camera saving itself; the
+per-entry `at_scan_start` / `at_scan_end` override fields are reserved for a
+possible future re-enable.) Devices *not* in the save set are still logged
+in the background — see
 "Required devices vs background telemetry" below, including the box on
 where these database facts live.
 
@@ -90,9 +92,9 @@ from" below), kept because keeping it is free.
     | Column | Meaning |
     |---|---|
     | `get` | `'yes'` = the variable is subscribed/logged for scans — the source of a device's standard telemetry (`db_scalars`) and of background telemetry |
-    | `set` | `'yes'` = the scan machinery writes this variable at scan boundaries |
-    | `startvalue` | the value written at scan start (what `at_scan_start` overrides) |
-    | `endvalue` | the value written at scan end (what `at_scan_end` overrides) |
+    | `set` | `'yes'` = MC writes this variable at scan boundaries (the *set-side*; **not applied by the current engine** — reserved) |
+    | `startvalue` | the value MC writes at scan start (the reserved `at_scan_start` would override it) |
+    | `endvalue` | the value MC writes at scan end (the reserved `at_scan_end` would override it) |
 
     The database rows themselves get no schema in this package — device
     facts live below the configs; the configs only *override* them.


### PR DESCRIPTION
Fourth engine milestone on `feat/vision-v1` (stack: #465 M3b → #466/#467 gateway → this). Activates the DB-backed scan setup the schema declared back in M1, plus a small s-file fix Sam flagged from a live scan.

## What M3c adds (all gated by flags that already existed in the schema — schema untouched)

- **db_scalars resolution (Tier 1).** A SaveSet entry's recorded scalars = DB `get='yes'` ∪ its explicit `scalars` (`db_scalars=True`, default); `all_scalars=True` unions every DB variable; `db_scalars=False` (the legacy-converter pin) = explicit-only. Pure resolver behind a `ScalarPolicyProvider` seam; no provider (GUI bridge / off-network) = explicit-only, i.e. exact M3b behavior — strictly additive.
- **Scan start/end DB writes, participants-only.** For scan participants (save-set + scan-variable devices, **not** every experiment device), `expt_device_variable` `set='yes'` rows write `startvalue` at scan start / `endvalue` at scan end, through the same CA `:SP` path actions use. `at_scan_start`/`at_scan_end` overrides layer on (value replaces, explicit `null` suppresses, absence = DB value); `save`/`localsavingpath` always skipped. Start writes chain into the setup hook (before acquisition); end writes into the closeout hook (finalize → run on mid-scan abort). Gated on `ExperimentDefaults.apply_db_scan_defaults`; applied writes recorded in run metadata (`db_scan_writes`).
- **Background telemetry (Tier 2).** Every live `get='yes'` device not in the save set → soft read-only `CaTelemetryReadable` columns (`telemetry_<device>-<var>`): never waited on, a failed read is a NaN cell, a dead-at-start device is dropped with a log line. Gated on `ScanRequest.background_telemetry` else the experiment default. **Softness and synchronicity are mutually exclusive — telemetry never gates a shot.**
- New `GeecsDb.get_all_experiment_variables` + `get_scan_boundary_writes` (following the established `get_subscribed_variables` join pattern; `set` reserved-word escaped, values as wire strings). `GeecsDbScalarPolicy` caches three whole-experiment queries and degrades to empty+warning on any DB failure — a scan never aborts because the DB blipped.

Optimize mode resolves db_scalars but skips start/end writes + telemetry (no scan-boundary hook on `GeecsSession.optimize` yet) — skip-and-record (`db_scan_runtime` metadata).

## Also here (separate commit): s-file `acq_timestamp` fix

Sam observed a live images-only scan produced an s-file with only `Bin #/scan/Shotnumber` — no column tying the saved frames to rows. acq_timestamp reaches Tiled fine (it's the shot-id source) but was excluded from the legacy s-file as a companion column, and the detector filtered it out of its header map unconditionally. Now a device saving non-scalar data surfaces acq_timestamp as an s-file column (`<device> acq_timestamp`, matching legacy camera behavior); stays excluded for pure-scalar devices.

## Verification

Hermetic (DB mocked): GeecsBluesky **400 passed** / 1 skip (package env, `--extras ca`, CI-parity), GeecsCAGateway **141**, GEECS-Schemas **209** (untouched). The new `GeecsDb` SQL was reviewed against the established working query in the same file. Versions: GeecsBluesky **0.24.0**, GeecsCAGateway **0.9.0**.

## ⚠️ Owed before merge: live verification (some of it actuates hardware)

- **Safe / read-only:** the s-file `acq_timestamp` column on a real camera scan; db_scalars pulling a device's DB `get='yes'` scalars into the s-file; telemetry columns appearing for live non-save-set devices (and a dead one dropped, not aborting).
- **Actuates hardware (do deliberately):** the scan start/end DB writes physically move participant devices to their `startvalue`/`endvalue`. Needs a chosen-safe experiment/device and a confirmation that end-writes fire on abort. Not run yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)