### PR TITLE
Add cross-device derived channel freshness

### DIFF
--- a/GEECS-Schemas/CHANGELOG.md
+++ b/GEECS-Schemas/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to GEECS-Schemas are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.0] - 2026-07-09
+
+### Changed
+
+- `DerivedChannels` now allows cross-device input sets when the derived channel
+  declares a positive `stale_after` freshness window. Same-device expressions
+  remain frame-coherent and do not require `stale_after`.
+
 ## [0.3.0] - 2026-07-08
 
 ### Added

--- a/GEECS-Schemas/geecs_schemas/derived_channels.py
+++ b/GEECS-Schemas/geecs_schemas/derived_channels.py
@@ -1,10 +1,9 @@
 """DerivedChannels — computed PV declarations for the CA gateway.
 
 This document declares operator-curated read-only PVs that the CA gateway
-computes from one source device's numeric push-frame values.  Use it for
-semantic quantities such as a Convectron pressure PV derived from a DAQ analog
-input voltage, where the result should be visible to Phoebus, archiving, and
-CA-backed clients like any other gateway readback.
+computes from numeric push-frame values.  Same-device inputs are evaluated from
+one coherent source frame.  Cross-device inputs use latest-value semantics and
+must declare a freshness window with ``stale_after``.
 """
 
 from __future__ import annotations
@@ -27,8 +26,8 @@ class DerivedInput(SchemaModel):
     device: str = Field(
         description=(
             "GEECS source device that provides this input variable, e.g. "
-            "'U_DaqPad1'. All inputs for one derived channel must come from "
-            "the same source device in schema version 1."
+            "'U_DaqPad1'. Inputs may span devices only when the derived "
+            "channel declares stale_after."
         )
     )
     variable: str = Field(
@@ -94,9 +93,18 @@ class DerivedChannel(SchemaModel):
     inputs: list[DerivedInput] = Field(
         min_length=1,
         description=(
-            "Input variables available to the expression. In schema version 1 "
-            "all inputs for a derived channel must come from one source device, "
-            "so the calculation is coherent within a single push frame."
+            "Input variables available to the expression. Inputs from one "
+            "source device are frame-coherent; inputs spanning devices use "
+            "latest-value semantics and require stale_after."
+        ),
+    )
+    stale_after: float | None = Field(
+        None,
+        gt=0,
+        description=(
+            "Maximum input age in seconds for latest-value derived channels. "
+            "Required when inputs span more than one source device. Leave unset "
+            "for same-device frame-coherent expressions."
         ),
     )
     experiment: str | None = Field(
@@ -154,18 +162,28 @@ class DerivedChannel(SchemaModel):
 
     @property
     def source_device(self) -> str:
-        """Return the single source device for this derived channel."""
+        """Return the first source device for backward-compatible consumers."""
         return self.inputs[0].device
+
+    @property
+    def source_devices(self) -> set[str]:
+        """Return the set of source devices for this derived channel."""
+        return {inp.device for inp in self.inputs}
+
+    @property
+    def is_cross_device(self) -> bool:
+        """Return whether this derived channel spans multiple source devices."""
+        return len(self.source_devices) > 1
 
     @model_validator(mode="after")
     def _validate_channel(self) -> "DerivedChannel":
         symbols = [inp.symbol for inp in self.inputs]
         if len(set(symbols)) != len(symbols):
             raise ValueError("derived-channel input symbols must be unique")
-        source_devices = {inp.device for inp in self.inputs}
-        if len(source_devices) != 1:
+        if self.is_cross_device and self.stale_after is None:
             raise ValueError(
-                "derived-channel inputs must come from one source device in v1"
+                "derived-channel stale_after is required when inputs span "
+                "multiple source devices"
             )
         return self
 
@@ -181,6 +199,7 @@ class DerivedChannels(VersionedSchemaModel):
         default_factory=list,
         description=(
             "Derived PVs to expose. Each entry computes one read-only float PV "
-            "from one source device's numeric push-frame values."
+            "from numeric push-frame values. Cross-device entries use "
+            "latest-value semantics with stale_after."
         ),
     )

--- a/GEECS-Schemas/pyproject.toml
+++ b/GEECS-Schemas/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-schemas"
-version = "0.3.0"
+version = "0.4.0"
 description = "Versioned Pydantic schemas for GEECS scanner configs (scan requests, save sets, scan variables, trigger profiles, action plans) plus legacy-YAML converters."
 authors = ["Sam Barber <sbarber@lbl.gov>"]
 readme = "README.md"

--- a/GEECS-Schemas/tests/test_derived_channels.py
+++ b/GEECS-Schemas/tests/test_derived_channels.py
@@ -35,8 +35,8 @@ class TestDerivedChannels:
         again = DerivedChannels.model_validate(document.model_dump(mode="json"))
         assert again == document
 
-    def test_same_source_device_enforced(self):
-        with pytest.raises(ValidationError, match="one source device"):
+    def test_cross_device_requires_stale_after(self):
+        with pytest.raises(ValidationError, match="stale_after is required"):
             DerivedChannels.model_validate(
                 {
                     "derived_channels": [
@@ -60,6 +60,37 @@ class TestDerivedChannels:
                     ]
                 }
             )
+
+    def test_cross_device_with_stale_after_is_allowed(self):
+        document = DerivedChannels.model_validate(
+            {
+                "derived_channels": [
+                    {
+                        "device": "LaserPermit",
+                        "variable": "OK",
+                        "expression": "pressure < 1e-5 and ready > 0",
+                        "inputs": [
+                            {
+                                "symbol": "pressure",
+                                "device": "TargetChamberPressure",
+                                "variable": "Pressure",
+                            },
+                            {
+                                "symbol": "ready",
+                                "device": "Amp4Shutter",
+                                "variable": "Ready",
+                            },
+                        ],
+                        "stale_after": 2.0,
+                    }
+                ]
+            }
+        )
+
+        [channel] = document.derived_channels
+        assert channel.is_cross_device
+        assert channel.source_devices == {"TargetChamberPressure", "Amp4Shutter"}
+        assert channel.stale_after == 2.0
 
     def test_input_symbols_must_be_unique(self):
         with pytest.raises(ValidationError, match="symbols must be unique"):

--- a/GeecsCAGateway/CHANGELOG.md
+++ b/GeecsCAGateway/CHANGELOG.md
@@ -3,6 +3,19 @@
 All notable changes to `geecs-ca-gateway` are documented here, following
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and semantic versioning.
 
+## [0.9.0] - 2026-07-09
+
+### Added
+
+- Cross-device derived channels with latest-value semantics. A derived channel
+  whose inputs span multiple source devices now recomputes when any input
+  source updates, uses the latest cached numeric values from the other inputs,
+  and requires `stale_after` to mark the output `INVALID/UDF` when any input is
+  missing or stale.
+- Boolean/comparison expressions for derived status PVs. Expressions such as
+  `pressure < 1e-5 and ready > 0` are accepted and publish as float values
+  `1.0` or `0.0`.
+
 ## [0.8.0] - 2026-07-08
 
 ### Added

--- a/GeecsCAGateway/DEPLOYMENT.md
+++ b/GeecsCAGateway/DEPLOYMENT.md
@@ -62,7 +62,8 @@ GEECS-Plugins-Configs/
 ```
 
 The file is not a replacement for the DB; it only adds computed numeric PVs on
-top of the DB-backed raw device set:
+top of the DB-backed raw device set. Same-device inputs are computed from one
+coherent source frame:
 
 ```yaml
 schema_version: 1
@@ -77,6 +78,27 @@ derived_channels:
     egu: Torr
     precision: 6
     description: "Convectron pressure from U_VacuumGauge analog input 0"
+```
+
+Cross-device derived PVs use latest-value semantics and must declare
+`stale_after`. The gateway recomputes when any input updates and marks the
+output `INVALID/UDF` if any input is missing or stale:
+
+```yaml
+schema_version: 1
+derived_channels:
+  - device: LaserPermit
+    variable: OK
+    expression: "pressure < 1e-5 and ready > 0"
+    inputs:
+      - symbol: pressure
+        device: TargetChamberPressure
+        variable: Pressure
+      - symbol: ready
+        device: Amp4Shutter
+        variable: Ready
+    stale_after: 2.0
+    description: "Latest-value software permit for laser shots"
 ```
 
 The configs repo root is resolved the same way as scanner configs:

--- a/GeecsCAGateway/PV_CONTRACT.md
+++ b/GeecsCAGateway/PV_CONTRACT.md
@@ -223,20 +223,28 @@ the configs repo convention
 `scanner_configs/experiments/<Experiment>/gateway/derived_channels.yaml` (or an
 explicit `--derived-channels PATH` override). That overlay exposes additional
 read-only float PVs computed from one source device's numeric push-frame
-values. The v1 schema is intentionally narrow:
+values, or from multiple source devices with explicit latest-value freshness
+semantics.
 
 - A derived channel has one output PV (`device`, `variable`, optional
   `experiment`/`pv` override) and one arithmetic expression.
-- Inputs bind expression symbols to `(device, variable)` sources, but **all
-  inputs must come from the same source device**. The gateway evaluates the
+- Inputs bind expression symbols to `(device, variable)` sources.
+- Same-device inputs are **frame-coherent**. The gateway evaluates the
   expression once per source frame, after raw data PVs are posted and before
   that frame's timestamp PVs are posted. Therefore a client latching on the
   source device's timestamp observes raw and derived values from the same
   completed frame.
+- Cross-device inputs use **latest-value semantics**. A cross-device derived
+  PV recomputes when any input source updates, using the latest cached numeric
+  values from the other sources. Such entries must declare `stale_after`
+  seconds; if any input is missing or older than that window, the output PV is
+  `INVALID_ALARM` / `UDF`.
 - The expression subset is numeric arithmetic only: literals, input symbols,
-  `+ - * / % **`, unary `+/-`, and a small whitelist of `math` functions such
-  as `sqrt`, `exp`, `log`, and `log10`. Arbitrary Python, attributes,
-  indexing, comparisons, and conditionals are rejected during gateway startup.
+  `+ - * / % **`, comparisons, boolean `and` / `or` / `not`, unary `+/-`, and
+  a small whitelist of `math` functions such as `sqrt`, `exp`, `log`, and
+  `log10`. Arbitrary Python, attributes, indexing, and conditionals are
+  rejected during gateway startup. Boolean/status expressions are stored as
+  `1.0` or `0.0` on the float PV.
 - Inputs may be subscribed solely for the calculation; they do not need to be
   exposed as their own readback PVs.
 
@@ -272,8 +280,9 @@ Repeated failures with the same INVALID status do not re-publish on every
 source frame; the gateway publishes the transition and keeps the PV invalid
 until a successful computation clears it.
 
-Cross-device latest-value expressions, staleness windows, enum/string bad-state
-expressions, and shot-synchronized analysis products are outside v1.
+Enum/string bad-state expressions and shot-synchronized analysis products are
+outside v1. If inputs need a shared shot id, compute the result in analysis,
+not as a gateway derived PV.
 
 ---
 
@@ -506,8 +515,9 @@ that branch and are part of this contract's target behavior.
 | `0.0` pre-acquisition placeholder | `test_pv_contract.py::test_float_readback_initializes_to_zero_placeholder` |
 | Frame ordering: data before timestamps *(PR #452)* | `test_gateway.py::test_callback_posts_timestamp_variables_last` |
 | Derived-channel manifest kind and numeric output PV metadata | `test_derived_channels.py::test_derived_pvdb_has_numeric_readback_and_manifest` |
-| Derived-channel expression subset and same-source-device v1 rule | `test_derived_channels.py::test_expression_evaluator_supports_convectron_formula`, `::test_expression_evaluator_rejects_non_numeric_python`, `::test_derived_channel_schema_is_single_source_device_v1` |
+| Derived-channel expression subset and cross-device `stale_after` schema rule | `test_derived_channels.py::test_expression_evaluator_supports_convectron_formula`, `::test_expression_evaluator_supports_status_logic`, `::test_expression_evaluator_rejects_non_numeric_python`, `::test_derived_channel_schema_requires_stale_after_for_cross_device` |
 | Derived values evaluate from one source frame; derived-only inputs are subscribed without raw PVs | `test_derived_channels.py::test_derived_channel_updates_from_same_source_frame`, `::test_derived_only_input_is_subscribed_without_raw_pv` |
+| Cross-device derived values use latest fresh inputs and invalidate on stale input or source disconnect | `test_derived_channels.py::test_cross_device_derived_channel_uses_latest_values`, `::test_cross_device_derived_channel_marks_stale_input_invalid`, `::test_cross_device_source_disconnect_marks_dependent_derived_invalid` |
 | Derived alarm states: initial/missing input UDF, expression failure CALC, reconnect recovery with unchanged value, repeated INVALID transition-only | `test_derived_channels.py::test_derived_pvdb_has_numeric_readback_and_manifest`, `::test_missing_derived_input_marks_invalid_udf`, `::test_derived_expression_failure_marks_invalid_calc`, `::test_derived_reconnect_clears_invalid_even_when_value_unchanged`, `::test_repeated_derived_failure_does_not_republish_invalid` |
 | DB type mapping, descriptors, enum degradation, blank-type inference | `test_config_from_db.py::test_from_db_metadata_maps_variable_types`, `::test_choice_pointing_at_type_descriptor_is_skipped`, `::test_blank_variabletype_inferred_from_choices`, `::test_choice_without_options_falls_back_to_string`, `::test_choice_exceeding_ca_enum_limits_falls_back_to_string` |
 | Long-string path PVs (>40 chars round-trip both directions) | `test_channels.py::test_cast_path_decodes_char_arrays`, `::test_path_readback_holds_long_string`, `::test_path_setpoint_forwards_full_text` |

--- a/GeecsCAGateway/geecs_ca_gateway/derived.py
+++ b/GeecsCAGateway/geecs_ca_gateway/derived.py
@@ -37,7 +37,9 @@ _ALLOWED_FUNCS = {
 _ALLOWED_CONSTS = {"e": math.e, "pi": math.pi, "tau": math.tau}
 _RESERVED_NAMES = set(_ALLOWED_FUNCS) | set(_ALLOWED_CONSTS)
 _ALLOWED_BINOPS = (ast.Add, ast.Sub, ast.Mult, ast.Div, ast.Pow, ast.Mod)
-_ALLOWED_UNARYOPS = (ast.UAdd, ast.USub)
+_ALLOWED_UNARYOPS = (ast.UAdd, ast.USub, ast.Not)
+_ALLOWED_BOOLOPS = (ast.And, ast.Or)
+_ALLOWED_CMPOPS = (ast.Eq, ast.NotEq, ast.Lt, ast.LtE, ast.Gt, ast.GtE)
 GATEWAY_CONFIG_FOLDER = "gateway"
 DERIVED_CHANNELS_FILENAME = "derived_channels.yaml"
 
@@ -130,7 +132,7 @@ def default_derived_channels_path(experiment: str) -> Path | None:
 
 
 class ExpressionEvaluator:
-    """Compile and evaluate a restricted numeric expression."""
+    """Compile and evaluate a restricted numeric/status expression."""
 
     def __init__(self, expression: str, symbols: set[str]) -> None:
         self.expression = expression
@@ -143,7 +145,11 @@ class ExpressionEvaluator:
         self._code = compile(tree, "<derived-channel>", "eval")
 
     def evaluate(self, values: dict[str, float]) -> float:
-        """Evaluate the expression with numeric input values."""
+        """Evaluate the expression with numeric input values.
+
+        Boolean/status expressions are accepted and stored as ``1.0``/``0.0``
+        on the derived float PV.
+        """
         missing = self.symbols - values.keys()
         if missing:
             raise KeyError(f"missing derived-channel input(s): {sorted(missing)}")
@@ -171,6 +177,20 @@ class ExpressionEvaluator:
                 raise DerivedExpressionError("unsupported binary operator")
             self._validate_node(node.left)
             self._validate_node(node.right)
+            return
+        if isinstance(node, ast.BoolOp):
+            if not isinstance(node.op, _ALLOWED_BOOLOPS):
+                raise DerivedExpressionError("unsupported boolean operator")
+            for value in node.values:
+                self._validate_node(value)
+            return
+        if isinstance(node, ast.Compare):
+            self._validate_node(node.left)
+            for op in node.ops:
+                if not isinstance(op, _ALLOWED_CMPOPS):
+                    raise DerivedExpressionError("unsupported comparison operator")
+            for comparator in node.comparators:
+                self._validate_node(comparator)
             return
         if isinstance(node, ast.UnaryOp):
             if not isinstance(node.op, _ALLOWED_UNARYOPS):

--- a/GeecsCAGateway/geecs_ca_gateway/gateway.py
+++ b/GeecsCAGateway/geecs_ca_gateway/gateway.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import math
+from dataclasses import dataclass
 from typing import Any
 
 from caproto import (
@@ -77,6 +78,26 @@ _ALARM_STATUS = {
     AlarmLevel.HIGH: AlarmStatus.HIGH,
     AlarmLevel.HIHI: AlarmStatus.HIHI,
 }
+
+_DerivedInputKey = tuple[str, str]
+
+
+@dataclass(frozen=True)
+class _DerivedRuntime:
+    """Runtime state for one derived PV."""
+
+    spec: DerivedChannelSpec
+    channel: ChannelData
+    evaluator: ExpressionEvaluator
+    pv: str
+
+
+@dataclass(frozen=True)
+class _DerivedInputValue:
+    """Latest numeric value observed for one derived input."""
+
+    value: float
+    received_at: float
 
 
 def _extract_timestamp(update: dict[str, Any], ts_vars: list[str]) -> float | None:
@@ -169,10 +190,10 @@ class GeecsCaGateway:
         self._restart_requested = asyncio.Event()
         # device name -> {geecs_var -> (readback channel, variable spec)}
         self._readbacks: dict[str, dict[str, tuple[ChannelData, VariableSpec]]] = {}
-        # source device -> derived channel specs evaluated from that device's frame
-        self._derived_by_source: dict[
-            str, list[tuple[DerivedChannelSpec, ChannelData, ExpressionEvaluator, str]]
-        ] = {}
+        # source device -> derived channel runtimes that depend on that source.
+        self._derived_by_source: dict[str, list[_DerivedRuntime]] = {}
+        # (source device, source variable) -> latest numeric value + receive time.
+        self._derived_input_cache: dict[_DerivedInputKey, _DerivedInputValue] = {}
         # full derived PV name -> last value written, for deadband suppression
         self._derived_last_written: dict[str, Any] = {}
         self._build_pvdb()
@@ -239,10 +260,11 @@ class GeecsCaGateway:
         source_devices = {dev.name for dev in self.config.devices}
         default_experiment = self._default_experiment()
         for spec in self.config.derived_channels:
-            if spec.source_device not in source_devices:
+            unknown_sources = sorted(spec.source_devices - source_devices)
+            if unknown_sources:
                 raise ValueError(
                     f"Derived channel {spec.device}:{spec.variable} references "
-                    f"unknown source device {spec.source_device!r}"
+                    f"unknown source device(s) {unknown_sources!r}"
                 )
             full = derived_pv_name(spec, default_experiment)
             if not self._register(full, spec.source_device, spec.variable, "derived"):
@@ -266,9 +288,9 @@ class GeecsCaGateway:
             evaluator = ExpressionEvaluator(
                 spec.expression, {inp.symbol for inp in spec.inputs}
             )
-            self._derived_by_source.setdefault(spec.source_device, []).append(
-                (spec, channel, evaluator, full)
-            )
+            runtime = _DerivedRuntime(spec, channel, evaluator, full)
+            for source in sorted(spec.source_devices):
+                self._derived_by_source.setdefault(source, []).append(runtime)
 
     def _build_gateway_status_pvs(self) -> None:
         """Expose gateway self-diagnostics under ``[Experiment:]CAGateway:*``."""
@@ -453,62 +475,119 @@ class GeecsCaGateway:
     async def _write_derived_channels(
         self, device_name: str, update: dict[str, Any], extra: dict[str, Any]
     ) -> None:
-        """Evaluate derived PVs whose inputs are present in this source frame."""
-        for spec, channel, evaluator, pv in self._derived_by_source.get(
-            device_name, []
-        ):
-            values: dict[str, float] = {}
-            missing = False
-            for inp in spec.inputs:
-                raw = update.get(inp.variable, _UNSET)
-                if raw is _UNSET or (isinstance(raw, str) and not raw.strip()):
-                    missing = True
-                    break
-                try:
-                    values[inp.symbol] = float(raw)
-                except (TypeError, ValueError):
-                    self._warn_once(
-                        device_name,
-                        pv,
-                        f"{device_name}: derived PV {pv} input "
-                        f"{inp.variable}={raw!r} is not numeric; marking INVALID",
-                    )
-                    missing = True
-                    break
-            if missing:
-                await self._mark_derived_invalid(channel, pv, AlarmStatus.UDF)
+        """Evaluate derived PVs affected by this source frame."""
+        runtimes = self._derived_by_source.get(device_name, [])
+        if not runtimes:
+            return
+        now = asyncio.get_running_loop().time()
+        self._update_derived_input_cache(device_name, update, runtimes, now)
+        evaluated: set[str] = set()
+        for runtime in runtimes:
+            if runtime.pv in evaluated:
+                continue
+            evaluated.add(runtime.pv)
+            values = self._derived_values(runtime, now)
+            if values is None:
+                await self._mark_derived_invalid(
+                    runtime.channel, runtime.pv, AlarmStatus.UDF
+                )
                 continue
             try:
-                value = evaluator.evaluate(values)
+                value = runtime.evaluator.evaluate(values)
             except Exception:
                 self._warn_once(
                     device_name,
-                    pv,
-                    f"{device_name}: derived PV {pv} expression failed; "
+                    runtime.pv,
+                    f"{device_name}: derived PV {runtime.pv} expression failed; "
                     "marking INVALID",
                 )
-                await self._mark_derived_invalid(channel, pv, AlarmStatus.CALC)
+                await self._mark_derived_invalid(
+                    runtime.channel, runtime.pv, AlarmStatus.CALC
+                )
                 continue
-            prev = self._derived_last_written.get(pv, _UNSET)
-            if prev is not _UNSET:
-                both_nan = math.isnan(value) and math.isnan(prev)
-                if both_nan or abs(value - prev) <= spec.deadband:
-                    continue
-            self._derived_last_written[pv] = value
+            output_extra = extra if not runtime.spec.is_cross_device else {}
+            await self._write_derived_value(runtime, value, output_extra)
+
+    def _update_derived_input_cache(
+        self,
+        device_name: str,
+        update: dict[str, Any],
+        runtimes: list[_DerivedRuntime],
+        received_at: float,
+    ) -> None:
+        """Cache numeric inputs from one source frame for derived channels."""
+        seen_inputs = {
+            inp.variable
+            for runtime in runtimes
+            for inp in runtime.spec.inputs
+            if inp.device == device_name
+        }
+        for variable in seen_inputs:
+            key = (device_name, variable)
+            raw = update.get(variable, _UNSET)
+            if raw is _UNSET or (isinstance(raw, str) and not raw.strip()):
+                self._derived_input_cache.pop(key, None)
+                continue
             try:
-                await channel.write(
-                    value,
-                    **extra,
-                    severity=AlarmSeverity.NO_ALARM,
-                    status=AlarmStatus.NO_ALARM,
-                    verify_value=False,
-                )
-            except Exception:
-                self._warn_once(
-                    device_name,
-                    pv,
-                    f"{device_name}: failed to write derived PV {pv}={value!r}",
-                )
+                value = float(raw)
+            except (TypeError, ValueError):
+                self._derived_input_cache.pop(key, None)
+                for runtime in runtimes:
+                    if any(
+                        inp.device == device_name and inp.variable == variable
+                        for inp in runtime.spec.inputs
+                    ):
+                        self._warn_once(
+                            device_name,
+                            runtime.pv,
+                            f"{device_name}: derived PV {runtime.pv} input "
+                            f"{variable}={raw!r} is not numeric; marking INVALID",
+                        )
+                continue
+            self._derived_input_cache[key] = _DerivedInputValue(value, received_at)
+
+    def _derived_values(
+        self, runtime: _DerivedRuntime, now: float
+    ) -> dict[str, float] | None:
+        """Return expression values for a runtime, or None when invalid/stale."""
+        values: dict[str, float] = {}
+        for inp in runtime.spec.inputs:
+            cached = self._derived_input_cache.get((inp.device, inp.variable))
+            if cached is None:
+                return None
+            if (
+                runtime.spec.stale_after is not None
+                and now - cached.received_at > runtime.spec.stale_after
+            ):
+                return None
+            values[inp.symbol] = cached.value
+        return values
+
+    async def _write_derived_value(
+        self, runtime: _DerivedRuntime, value: float, extra: dict[str, Any]
+    ) -> None:
+        """Write one computed derived value, applying deadband suppression."""
+        prev = self._derived_last_written.get(runtime.pv, _UNSET)
+        if prev is not _UNSET:
+            both_nan = math.isnan(value) and math.isnan(prev)
+            if both_nan or abs(value - prev) <= runtime.spec.deadband:
+                return
+        self._derived_last_written[runtime.pv] = value
+        try:
+            await runtime.channel.write(
+                value,
+                **extra,
+                severity=AlarmSeverity.NO_ALARM,
+                status=AlarmStatus.NO_ALARM,
+                verify_value=False,
+            )
+        except Exception:
+            self._warn_once(
+                runtime.spec.source_device,
+                runtime.pv,
+                f"{runtime.spec.source_device}: failed to write derived PV "
+                f"{runtime.pv}={value!r}",
+            )
 
     async def _mark_derived_invalid(
         self, channel: ChannelData, pv: str, status: AlarmStatus
@@ -645,10 +724,9 @@ class GeecsCaGateway:
         data_vars = [v.geecs_var for v in dev.variables]
         derived_inputs = [
             inp.variable
-            for spec, _channel, _evaluator, _pv in self._derived_by_source.get(
-                dev.name, []
-            )
-            for inp in spec.inputs
+            for runtime in self._derived_by_source.get(dev.name, [])
+            for inp in runtime.spec.inputs
+            if inp.device == dev.name
         ]
         variables = list(dict.fromkeys(data_vars + derived_inputs + dev.timestamp_vars))
         # Text-typed variables must reach cast_value as the exact wire text —
@@ -669,10 +747,11 @@ class GeecsCaGateway:
                 # Clear the deadband cache so the first frame always posts (and
                 # clears any INVALID left from the drop), even if unchanged.
                 self._last_written[dev.name] = {}
-                for _spec, _channel, _evaluator, pv in self._derived_by_source.get(
-                    dev.name, []
-                ):
-                    self._derived_last_written.pop(pv, None)
+                for runtime in self._derived_by_source.get(dev.name, []):
+                    self._derived_last_written.pop(runtime.pv, None)
+                for key in list(self._derived_input_cache):
+                    if key[0] == dev.name:
+                        self._derived_input_cache.pop(key, None)
                 if dev.name in self._down_logged:
                     self._down_logged.discard(dev.name)
                     logger.info("%s: reconnected", dev.name)
@@ -770,11 +849,9 @@ class GeecsCaGateway:
         recovery is automatic — only the disconnect transition is set here.
         """
         for pv, (dev, _var, kind) in self.manifest.items():
-            if dev != device or kind not in ("readback", "derived"):
+            if dev != device or kind != "readback":
                 continue
             channel = self.pvdb[pv]
-            if kind == "derived":
-                self._derived_last_written.pop(pv, None)
             try:
                 await channel.write(
                     channel.value,
@@ -784,6 +861,13 @@ class GeecsCaGateway:
                 )
             except Exception:
                 logger.debug("failed to mark %s INVALID", pv, exc_info=True)
+        for key in list(self._derived_input_cache):
+            if key[0] == device:
+                self._derived_input_cache.pop(key, None)
+        for runtime in self._derived_by_source.get(device, []):
+            await self._mark_derived_invalid(
+                runtime.channel, runtime.pv, AlarmStatus.COMM
+            )
 
     def _request_restart(self) -> None:
         """Handle a CA put to ``CAGateway:RESTART``: initiate clean shutdown."""

--- a/GeecsCAGateway/poetry.lock
+++ b/GeecsCAGateway/poetry.lock
@@ -45,7 +45,7 @@ files = [
 
 [[package]]
 name = "geecs-schemas"
-version = "0.3.0"
+version = "0.4.0"
 description = "Versioned Pydantic schemas for GEECS scanner configs (scan requests, save sets, scan variables, trigger profiles, action plans) plus legacy-YAML converters."
 optional = false
 python-versions = ">=3.11,<3.12"

--- a/GeecsCAGateway/pyproject.toml
+++ b/GeecsCAGateway/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-ca-gateway"
-version = "0.8.0"
+version = "0.9.0"
 description = "EPICS Channel Access soft-IOC gateway exposing GEECS devices as PVs"
 authors = ["Sam Barber <sbarber@lbl.gov>"]
 readme = "README.md"

--- a/GeecsCAGateway/tests/test_derived_channels.py
+++ b/GeecsCAGateway/tests/test_derived_channels.py
@@ -75,9 +75,18 @@ def test_expression_evaluator_rejects_non_numeric_python() -> None:
         ExpressionEvaluator("v.real", {"v"})
 
 
-def test_derived_channel_schema_is_single_source_device_v1() -> None:
-    """v1 derived channels are same-source-device only."""
-    with pytest.raises(ValidationError, match="one source device"):
+def test_expression_evaluator_supports_status_logic() -> None:
+    """Restricted expressions support comparisons and boolean operators."""
+    evaluator = ExpressionEvaluator(
+        "pressure < 1e-5 and ready > 0", {"pressure", "ready"}
+    )
+    assert evaluator.evaluate({"pressure": 1e-6, "ready": 1.0}) == pytest.approx(1.0)
+    assert evaluator.evaluate({"pressure": 1e-4, "ready": 1.0}) == pytest.approx(0.0)
+
+
+def test_derived_channel_schema_requires_stale_after_for_cross_device() -> None:
+    """Cross-device derived channels must declare freshness semantics."""
+    with pytest.raises(ValidationError, match="stale_after is required"):
         DerivedChannelSpec(
             device="U_ChamberVac",
             variable="Pressure",
@@ -275,6 +284,170 @@ async def test_derived_only_input_is_subscribed_without_raw_pv() -> None:
             assert await _wait_until(lambda: pressure.value == pytest.approx(1.0))
         finally:
             await gw.close()
+
+
+async def test_cross_device_derived_channel_uses_latest_values() -> None:
+    """Cross-device derived channels recompute from latest fresh inputs."""
+    cfg = GatewayConfig(
+        devices=[
+            DeviceSpec(
+                name="TargetChamberPressure",
+                host="127.0.0.1",
+                port=1,
+                experiment="Undulator",
+                variables=[VariableSpec(geecs_var="Pressure", dtype="float")],
+            ),
+            DeviceSpec(
+                name="Amp4Shutter",
+                host="127.0.0.1",
+                port=2,
+                experiment="Undulator",
+                variables=[VariableSpec(geecs_var="Ready", dtype="float")],
+            ),
+        ],
+        derived_channels=[
+            DerivedChannelSpec(
+                device="LaserPermit",
+                variable="OK",
+                expression="pressure < 1e-5 and ready > 0",
+                inputs=[
+                    DerivedInputSpec(
+                        symbol="pressure",
+                        device="TargetChamberPressure",
+                        variable="Pressure",
+                    ),
+                    DerivedInputSpec(
+                        symbol="ready",
+                        device="Amp4Shutter",
+                        variable="Ready",
+                    ),
+                ],
+                stale_after=2.0,
+            )
+        ],
+    )
+    gw = GeecsCaGateway(cfg)
+    permit = gw.pvdb["Undulator:LaserPermit:OK"]
+    pressure_callback = gw._make_callback(cfg.devices[0])
+    shutter_callback = gw._make_callback(cfg.devices[1])
+
+    await pressure_callback({"Pressure": 1e-6})
+    assert int(permit.severity) == int(AlarmSeverity.INVALID_ALARM)
+    assert int(permit.status) == int(AlarmStatus.UDF)
+
+    await shutter_callback({"Ready": 1.0})
+    assert permit.value == pytest.approx(1.0)
+    assert int(permit.severity) == int(AlarmSeverity.NO_ALARM)
+
+    await pressure_callback({"Pressure": 1e-4})
+    assert permit.value == pytest.approx(0.0)
+    assert int(permit.severity) == int(AlarmSeverity.NO_ALARM)
+
+
+async def test_cross_device_derived_channel_marks_stale_input_invalid() -> None:
+    """Cross-device derived channels require all inputs to be fresh."""
+    cfg = GatewayConfig(
+        devices=[
+            DeviceSpec(
+                name="TargetChamberPressure",
+                host="127.0.0.1",
+                port=1,
+                experiment="Undulator",
+                variables=[VariableSpec(geecs_var="Pressure", dtype="float")],
+            ),
+            DeviceSpec(
+                name="Amp4Shutter",
+                host="127.0.0.1",
+                port=2,
+                experiment="Undulator",
+                variables=[VariableSpec(geecs_var="Ready", dtype="float")],
+            ),
+        ],
+        derived_channels=[
+            DerivedChannelSpec(
+                device="LaserPermit",
+                variable="OK",
+                expression="pressure < 1e-5 and ready > 0",
+                inputs=[
+                    DerivedInputSpec(
+                        symbol="pressure",
+                        device="TargetChamberPressure",
+                        variable="Pressure",
+                    ),
+                    DerivedInputSpec(
+                        symbol="ready",
+                        device="Amp4Shutter",
+                        variable="Ready",
+                    ),
+                ],
+                stale_after=0.01,
+            )
+        ],
+    )
+    gw = GeecsCaGateway(cfg)
+    permit = gw.pvdb["Undulator:LaserPermit:OK"]
+    pressure_callback = gw._make_callback(cfg.devices[0])
+    shutter_callback = gw._make_callback(cfg.devices[1])
+
+    await pressure_callback({"Pressure": 1e-6})
+    await asyncio.sleep(0.02)
+    await shutter_callback({"Ready": 1.0})
+
+    assert int(permit.severity) == int(AlarmSeverity.INVALID_ALARM)
+    assert int(permit.status) == int(AlarmStatus.UDF)
+
+
+async def test_cross_device_source_disconnect_marks_dependent_derived_invalid() -> None:
+    """A disconnect from any input source marks the derived PV COMM invalid."""
+    cfg = GatewayConfig(
+        devices=[
+            DeviceSpec(
+                name="TargetChamberPressure",
+                host="127.0.0.1",
+                port=1,
+                experiment="Undulator",
+                variables=[VariableSpec(geecs_var="Pressure", dtype="float")],
+            ),
+            DeviceSpec(
+                name="Amp4Shutter",
+                host="127.0.0.1",
+                port=2,
+                experiment="Undulator",
+                variables=[VariableSpec(geecs_var="Ready", dtype="float")],
+            ),
+        ],
+        derived_channels=[
+            DerivedChannelSpec(
+                device="LaserPermit",
+                variable="OK",
+                expression="pressure < 1e-5 and ready > 0",
+                inputs=[
+                    DerivedInputSpec(
+                        symbol="pressure",
+                        device="TargetChamberPressure",
+                        variable="Pressure",
+                    ),
+                    DerivedInputSpec(
+                        symbol="ready",
+                        device="Amp4Shutter",
+                        variable="Ready",
+                    ),
+                ],
+                stale_after=2.0,
+            )
+        ],
+    )
+    gw = GeecsCaGateway(cfg)
+    permit = gw.pvdb["Undulator:LaserPermit:OK"]
+
+    await gw._make_callback(cfg.devices[0])({"Pressure": 1e-6})
+    await gw._make_callback(cfg.devices[1])({"Ready": 1.0})
+    assert int(permit.severity) == int(AlarmSeverity.NO_ALARM)
+
+    await gw._mark_device_invalid("Amp4Shutter")
+
+    assert int(permit.severity) == int(AlarmSeverity.INVALID_ALARM)
+    assert int(permit.status) == int(AlarmStatus.COMM)
 
 
 async def test_derived_expression_failure_marks_invalid_calc() -> None:

--- a/docs/geecs_schemas/schema_reference.md
+++ b/docs/geecs_schemas/schema_reference.md
@@ -463,7 +463,7 @@ A file of computed read-only PVs for the CA gateway.
 | Field | Type | Required | Default | What it does |
 |---|---|---|---|---|
 | `schema_version` | `int` | no | 1 | Format version of this config file. Leave at 1 — tools update this automatically when the file format changes. |
-| `derived_channels` | `list[DerivedChannel]` | no | empty | Derived PVs to expose. Each entry computes one read-only float PV from one source device's numeric push-frame values. |
+| `derived_channels` | `list[DerivedChannel]` | no | empty | Derived PVs to expose. Each entry computes one read-only float PV from numeric push-frame values. Cross-device entries use latest-value semantics with stale_after. |
 
 Example:
 
@@ -491,7 +491,8 @@ One read-only float PV computed from a numeric expression.
 | `device` | `str` | yes | — | Device component of the output PV, e.g. 'U_ChamberVac' for 'Undulator:U_ChamberVac:Pressure'. This may be semantic and does not need to be a real GEECS hardware device. |
 | `variable` | `str` | yes | — | Variable component of the output PV, e.g. 'Pressure'. The gateway normalizes it using the same rules as raw GEECS variables. |
 | `expression` | `str` | yes | — | Numeric formula for the output value, using input symbols and the gateway's restricted arithmetic subset. Example: '10**(v - 5)'. |
-| `inputs` | `list[DerivedInput]` | yes | — | Input variables available to the expression. In schema version 1 all inputs for a derived channel must come from one source device, so the calculation is coherent within a single push frame. |
+| `inputs` | `list[DerivedInput]` | yes | — | Input variables available to the expression. Inputs from one source device are frame-coherent; inputs spanning devices use latest-value semantics and require stale_after. |
+| `stale_after` | `float (optional)` | no | None | Maximum input age in seconds for latest-value derived channels. Required when inputs span more than one source device. Leave unset for same-device frame-coherent expressions. |
 | `experiment` | `str (optional)` | no | None | Optional experiment prefix override for the output PV. Leave unset to use the gateway's launched experiment. |
 | `pv` | `str (optional)` | no | None | Optional explicit output PV variable component. Leave unset to use the 'variable' field. |
 | `egu` | `str` | no | '' | Engineering units displayed by CA clients, e.g. 'Torr'. |
@@ -508,5 +509,5 @@ One source variable bound to a symbol in a derived-channel formula.
 | Field | Type | Required | Default | What it does |
 |---|---|---|---|---|
 | `symbol` | `str` | yes | — | Python-style symbol used in the expression, e.g. 'v' for a voltage input. Must be a valid identifier and must not shadow a reserved math function or constant. |
-| `device` | `str` | yes | — | GEECS source device that provides this input variable, e.g. 'U_DaqPad1'. All inputs for one derived channel must come from the same source device in schema version 1. |
+| `device` | `str` | yes | — | GEECS source device that provides this input variable, e.g. 'U_DaqPad1'. Inputs may span devices only when the derived channel declares stale_after. |
 | `variable` | `str` | yes | — | GEECS source variable on the input device, e.g. 'Analog Input 10'. The gateway subscribes to it even if it is not exposed as its own raw readback PV. |


### PR DESCRIPTION
## Summary
- add stale_after to derived-channel schema and require it for cross-device inputs
- evaluate cross-device derived PVs with latest-value semantics, missing/stale input invalidation, and source-disconnect COMM invalidation
- extend restricted expressions with comparisons and boolean operators for status PVs, emitted as 1.0/0.0
- update deployment/PV contract docs plus schema and gateway changelogs

## Notes
- same-device derived channels remain frame-coherent and keep source-frame timestamps
- cross-device derived channels intentionally use gateway receive-time freshness, not shot-coherent alignment
- stale PVs become invalid when an affected source update triggers recomputation; this PR does not add a proactive timer for completely quiet sources

## Tests
- GEECS-Schemas: poetry run pytest tests/test_derived_channels.py tests/test_docgen.py -q
- GeecsCAGateway: poetry run pytest tests/test_derived_channels.py tests/test_entrypoint.py -q