### PR TITLE
docs: vision consolidation sweep (schema reference + drift guard, run-a-scan, gateway client)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,6 +12,7 @@ tooling. Each subdirectory is an independent Python package with its own
 | `ImageAnalysis/` | Per-image analysis: pipelines, offline analyzers, config models |
 | `GEECS-Scanner-GUI/` | PyQt5 DAQ front-end: scans, save elements, optimization (Xopt) |
 | `GEECS-Data-Utils/` | Scan path navigation, scalar loading, binning, Parquet database |
+| `GEECS-Schemas/` | Pydantic-only config vocabulary: versioned schemas for every scanner config kind (scan request, save set, scan variables, trigger profile, action plans, derived channels) + legacy-YAML converters + the docgen Markdown reference generator. Depends on pydantic alone — importable from anywhere |
 | `GeecsBluesky/` | Bluesky RunEngine backend: BlueskyScanner + headless GeecsSession, CA-backed ophyd-async devices (via GeecsCAGateway), Tiled integration |
 | `GeecsCAGateway/` | The GEECS access layer: UDP/TCP wire protocol, experiment DB, PV naming, and the caproto CA gateway serving GEECS devices as PVs (readback + `:SP`) for Phoebus/Archiver/ophyd-async — see its `PV_CONTRACT.md` (client API contract), `DEPLOYMENT.md`, and `DESIGN.md` |
 | `LogMaker4GoogleDocs/` | Google Docs/Drive API wrapper for automated experiment logs |
@@ -103,12 +104,13 @@ against each package's `[tool.poetry.dependencies]` (intra-repo path deps).
 ```
 GEECS-Data-Utils     →  (no intra-repo deps — foundational data layer)
 LogMaker4GoogleDocs  →  (no intra-repo deps — pure Google API wrapper)
+GEECS-Schemas        →  (no intra-repo deps — pydantic-only config vocabulary)
 
 ImageAnalysis        →  GEECS-Data-Utils
 GeecsCAGateway       →  GEECS-Schemas (schema-only vocabulary for optional
                         derived-channel overlays; otherwise the GEECS access layer:
                         wire protocol, DB, PV naming, CA server)
-GeecsBluesky         →  GEECS-Data-Utils, GeecsCAGateway
+GeecsBluesky         →  GEECS-Data-Utils, GeecsCAGateway, GEECS-Schemas
                         (+ ImageAnalysis, optional via the `analysis` extra —
                         post-run image analysis over archived Tiled runs)
 GEECS-PythonAPI      →  GEECS-Data-Utils
@@ -208,7 +210,7 @@ Every package has a `CHANGELOG.md` following
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format:
 `GEECS-Scanner-GUI/`, `GEECS-PythonAPI/`, `GEECS-Data-Utils/`,
 `ScanAnalysis/`, `ImageAnalysis/`, `LogMaker4GoogleDocs/`,
-`GeecsBluesky/`, `GeecsCAGateway/`.
+`GeecsBluesky/`, `GeecsCAGateway/`, `GEECS-Schemas/`.
 
 Git tags (`geecs-scanner-v0.8.0` style) are cut at **milestones** — a state
 deployed across experiments or one we may need to reproduce (e.g. the

--- a/GEECS-Schemas/CHANGELOG.md
+++ b/GEECS-Schemas/CHANGELOG.md
@@ -5,6 +5,29 @@ All notable changes to GEECS-Schemas are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.0] - 2026-07-08
+
+### Added
+
+- **Published schema reference + no-drift guard.** `geecs_schemas.docgen` now
+  emits the committed docs page directly: `render_page()` prepends a
+  do-not-edit header to `render_reference()`, `write_page()` writes it, and
+  `python -m geecs_schemas.docgen` (or
+  `tests/generate_schema_reference.py`) regenerates
+  `docs/geecs_schemas/schema_reference.md`. A new no-drift test
+  (`tests/test_schema_reference.py`) fails CI if the committed page falls out
+  of step with the schema field descriptions, so the published reference can
+  never silently drift from the code.
+
+### Fixed
+
+- **Markdown table rendering in the generated reference.** Table cells
+  containing `|` (union types like `PositionRange | PositionList`, `Literal`
+  renderings) are now escaped so they no longer split columns, and Pydantic
+  discriminated unions (`Annotated[Union[...], discriminator=...]`) render as
+  the clean underlying union (`list[SetStep | WaitStep | CheckStep |
+  RunPlanStep]`) instead of the raw `Annotated[...]` wrapper.
+
 ## [0.4.0] - 2026-07-08
 
 ### Changed

--- a/GEECS-Schemas/geecs_schemas/docgen.py
+++ b/GEECS-Schemas/geecs_schemas/docgen.py
@@ -8,14 +8,22 @@ code.  GUI tooltips are expected to consume the same descriptions.
 Dependency-free by design (standard library + Pydantic introspection only) —
 no mkdocs plugins, no YAML library.  ``render_reference()`` emits one big
 Markdown string; the docs build decides where to put it.
+
+The published copy lives at ``docs/geecs_schemas/schema_reference.md`` and is
+regenerated with ``python -m geecs_schemas.docgen`` (or
+``tests/generate_schema_reference.py``).  ``tests/test_schema_reference.py`` is
+a no-drift guard: it fails CI if the committed page falls out of step with the
+schemas, so the reference can never silently rot.
 """
 
 from __future__ import annotations
 
+import argparse
 import inspect
 import types
 import typing
 from enum import Enum
+from pathlib import Path
 from typing import Any, Iterator, Mapping, Optional
 
 from pydantic import BaseModel
@@ -23,6 +31,21 @@ from pydantic.fields import FieldInfo
 from pydantic_core import PydanticUndefined
 
 from geecs_schemas import SCHEMA_REGISTRY
+
+# Marker line that prefixes the committed Markdown page so a reader (or a stray
+# editor) knows not to hand-edit it.  The no-drift test compares the file with
+# this header line stripped, so wording changes here never break the guard.
+GENERATED_HEADER = (
+    "<!-- GENERATED FILE — do not edit by hand.\n"
+    "     Regenerate with:  python -m geecs_schemas.docgen\n"
+    "     (or GEECS-Schemas/tests/generate_schema_reference.py).\n"
+    "     A no-drift test (tests/test_schema_reference.py) fails CI if this\n"
+    "     file falls out of step with the schema field descriptions. -->"
+)
+
+# Path to the committed docs page, relative to the repo root.  Kept here so the
+# generator, the regenerator script, and the no-drift test all agree on it.
+REFERENCE_PAGE = Path("docs/geecs_schemas/schema_reference.md")
 
 # Hand-written example YAML per registry kind, shown under each top-level
 # model's reference section. Kept here (not in docstrings) so examples can
@@ -204,6 +227,13 @@ def _type_name(annotation: Any) -> str:
         return "None"
     origin = typing.get_origin(annotation)
     args = typing.get_args(annotation)
+    # Unwrap Annotated[T, ...] (Pydantic discriminated unions arrive as
+    # Annotated[Union[...], FieldInfo(discriminator=...)]) to the underlying
+    # type — the metadata is noise in an operator reference.
+    if origin is not None and getattr(origin, "__name__", "") == "Annotated":
+        return _type_name(args[0])
+    if hasattr(annotation, "__metadata__"):  # typing.Annotated instance
+        return _type_name(annotation.__origin__)
     if origin in (typing.Union, types.UnionType):
         parts = [_type_name(a) for a in args if a is not type(None)]
         rendered = " | ".join(parts)
@@ -296,6 +326,26 @@ def iter_nested_models(
         yield from _walk(field.annotation)
 
 
+def _escape_cell(text: str) -> str:
+    r"""Escape a Markdown table cell so pipes don't split columns.
+
+    A ``|`` inside a cell (common in union types like ``A | B`` and in
+    ``Literal`` renderings) must be escaped as ``\|`` or it is read as a
+    column separator and breaks the table.
+
+    Parameters
+    ----------
+    text : str
+        Raw cell text.
+
+    Returns
+    -------
+    str
+        Cell text safe to place between table pipes.
+    """
+    return text.replace("|", "\\|")
+
+
 def render_model_markdown(model: type[BaseModel], example: str | None = None) -> str:
     """Render one model as a Markdown reference section.
 
@@ -321,11 +371,12 @@ def render_model_markdown(model: type[BaseModel], example: str | None = None) ->
         "|---|---|---|---|---|",
     ]
     for name, field in model.model_fields.items():
-        description = " ".join((field.description or "").split())
+        description = _escape_cell(" ".join((field.description or "").split()))
         required = "yes" if field.is_required() else "no"
+        type_name = _escape_cell(_type_name(field.annotation))
+        default = _escape_cell(_default_repr(field))
         lines.append(
-            f"| `{name}` | `{_type_name(field.annotation)}` | {required} "
-            f"| {_default_repr(field)} | {description} |"
+            f"| `{name}` | `{type_name}` | {required} | {default} | {description} |"
         )
     lines.append("")
     if example:
@@ -363,3 +414,78 @@ def render_reference(
             out.append(render_model_markdown(nested))
         documented.add(model)
     return "\n".join(out)
+
+
+def render_page(
+    registry: Optional[Mapping[str, type[BaseModel]]] = None,
+) -> str:
+    """Render the committed docs page: the generated-header line plus reference.
+
+    Parameters
+    ----------
+    registry : mapping, optional
+        kind → model mapping; defaults to
+        :data:`geecs_schemas.SCHEMA_REGISTRY`.
+
+    Returns
+    -------
+    str
+        The full Markdown page (header comment + reference body), the exact
+        text written to :data:`REFERENCE_PAGE`.
+    """
+    return f"{GENERATED_HEADER}\n\n{render_reference(registry)}\n"
+
+
+def _repo_root() -> Path:
+    """Return the repository root (three levels above this module).
+
+    Returns
+    -------
+    pathlib.Path
+        ``<repo>/`` — the parent of ``GEECS-Schemas/``.
+    """
+    # docgen.py → geecs_schemas/ → GEECS-Schemas/ → <repo root>
+    return Path(__file__).resolve().parents[2]
+
+
+def write_page(path: Optional[Path] = None) -> Path:
+    """Write the reference page to disk and return where it was written.
+
+    Parameters
+    ----------
+    path : pathlib.Path, optional
+        Destination file; defaults to ``<repo>/`` + :data:`REFERENCE_PAGE`.
+
+    Returns
+    -------
+    pathlib.Path
+        The path written.
+    """
+    destination = path if path is not None else _repo_root() / REFERENCE_PAGE
+    destination.write_text(render_page(), encoding="utf-8")
+    return destination
+
+
+def main(argv: Optional[list[str]] = None) -> None:
+    """CLI entry point: regenerate the committed schema-reference page.
+
+    Parameters
+    ----------
+    argv : list of str, optional
+        Argument vector; defaults to ``sys.argv[1:]``.
+    """
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "-o",
+        "--output",
+        type=Path,
+        default=None,
+        help="Destination file (default: <repo>/docs/geecs_schemas/schema_reference.md).",
+    )
+    args = parser.parse_args(argv)
+    written = write_page(args.output)
+    print(f"wrote {written}")
+
+
+if __name__ == "__main__":
+    main()

--- a/GEECS-Schemas/pyproject.toml
+++ b/GEECS-Schemas/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-schemas"
-version = "0.4.0"
+version = "0.5.0"
 description = "Versioned Pydantic schemas for GEECS scanner configs (scan requests, save sets, scan variables, trigger profiles, action plans) plus legacy-YAML converters."
 authors = ["Sam Barber <sbarber@lbl.gov>"]
 readme = "README.md"

--- a/GEECS-Schemas/tests/generate_schema_reference.py
+++ b/GEECS-Schemas/tests/generate_schema_reference.py
@@ -1,0 +1,22 @@
+"""Regenerate the committed schema-reference docs page from the schemas.
+
+Run after an *intentional* change to any schema field description, then review
+the diff and commit the updated page:
+
+    poetry run python GEECS-Schemas/tests/generate_schema_reference.py
+
+This is the same output the no-drift guard (``tests/test_schema_reference.py``)
+checks, so a green ``pytest`` after regenerating means the page is in step.
+"""
+
+from geecs_schemas.docgen import write_page
+
+
+def main() -> None:
+    """Write ``docs/geecs_schemas/schema_reference.md`` from the schemas."""
+    written = write_page()
+    print(f"wrote {written}")
+
+
+if __name__ == "__main__":
+    main()

--- a/GEECS-Schemas/tests/test_schema_reference.py
+++ b/GEECS-Schemas/tests/test_schema_reference.py
@@ -1,0 +1,59 @@
+"""No-drift guard for the committed schema-reference docs page.
+
+``docs/geecs_schemas/schema_reference.md`` is generated from the schema field
+descriptions by ``geecs_schemas.docgen``.  This test fails CI if the committed
+page falls out of step with the schemas, so the published reference can never
+silently drift from the code.  When a field description legitimately changes,
+regenerate the page::
+
+    poetry run python GEECS-Schemas/tests/generate_schema_reference.py
+
+and commit the updated Markdown alongside the schema change.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from geecs_schemas.docgen import (
+    GENERATED_HEADER,
+    REFERENCE_PAGE,
+    render_page,
+    render_reference,
+)
+
+# test file → tests/ → GEECS-Schemas/ → <repo root>
+REPO_ROOT = Path(__file__).resolve().parents[2]
+COMMITTED_PAGE = REPO_ROOT / REFERENCE_PAGE
+
+
+def _strip_header(text: str) -> str:
+    """Return *text* with the leading generated-header comment removed.
+
+    The header wording is documentation for humans and may be reworded without
+    touching the schemas; stripping it keeps the drift check about the schema
+    content, not the boilerplate.
+    """
+    if text.startswith(GENERATED_HEADER):
+        return text[len(GENERATED_HEADER) :].lstrip("\n")
+    return text
+
+
+@pytest.mark.skipif(
+    not COMMITTED_PAGE.exists(),
+    reason=f"committed reference page not found at {COMMITTED_PAGE}",
+)
+def test_committed_reference_matches_schemas():
+    """The committed page (sans header) equals a fresh render of the schemas."""
+    committed = _strip_header(COMMITTED_PAGE.read_text(encoding="utf-8")).strip()
+    fresh = render_reference().strip()
+    assert committed == fresh, (
+        "docs/geecs_schemas/schema_reference.md is out of date — regenerate it "
+        "with `poetry run python GEECS-Schemas/tests/generate_schema_reference.py` "
+        "and commit the result."
+    )
+
+
+def test_render_page_carries_generated_header():
+    """The generated page always starts with the do-not-edit header."""
+    assert render_page().startswith(GENERATED_HEADER)

--- a/docs/geecs_gateway/client_overview.md
+++ b/docs/geecs_gateway/client_overview.md
@@ -1,0 +1,138 @@
+# GEECS Gateway — client orientation
+
+The **GeecsCAGateway** is the GEECS access layer: a caproto Channel Access
+soft-IOC that mirrors GEECS devices as EPICS PVs, so any EPICS-ecosystem
+consumer — Phoebus displays, an Archiver Appliance, ophyd-async / Bluesky — can
+talk to GEECS the same way it talks to any IOC, without growing its own bespoke
+bridge.
+
+```
+GEECS device  --TCP push stream-->  readback PV   (caget / camonitor)
+GEECS device  <--blocking UDP set--  setpoint PV  (caput …:SP)
+```
+
+This page is a client-facing orientation: enough to connect a display or a
+consumer and read the values correctly. It is **not** the normative contract.
+The authoritative, test-pinned detail lives in the package alongside the code:
+
+- **`GeecsCAGateway/PV_CONTRACT.md`** — the normative API contract (naming,
+  types, timestamps, alarms, collision and failure semantics; every claim
+  pinned by a test).
+- **`GeecsCAGateway/DEPLOYMENT.md`** — launch/CLI, config resolution, and the
+  client-side addressing recipe (including Windows).
+
+These files stay in the package and are not published on this site; treat them
+as the source of truth if anything here and there ever disagree.
+
+## PV naming
+
+A PV name is the GEECS names joined by `:`, one component per level:
+
+```
+[Experiment:]Device:Variable          readback
+[Experiment:]Device:Variable:SP       setpoint (only when the variable is settable)
+[Experiment:]Device:CONNECTED         per-device liveness
+```
+
+Example: `Undulator:U_S1H:Current` and its setpoint `Undulator:U_S1H:Current:SP`.
+
+**Within a component**, only `[A-Za-z0-9_]` survive: dots, spaces, dashes,
+parentheses — any run of other characters — collapse to a single underscore
+(`Trigger.Source` → `Trigger_Source`, `Jet X pos` → `Jet_X_pos`). The dot
+collapse matters because EPICS reads `.` as the record/field separator.
+
+The mapping is **lossy** — `Trigger.Source` and `Trigger Source` both normalize
+to `Trigger_Source` — so never reverse-engineer a GEECS name from a PV string.
+The gateway holds the authoritative reverse map (`PV → (device, variable,
+kind)`) in its manifest, and a genuine collision is a startup error, never a
+silent clobber.
+
+## Readbacks vs setpoints
+
+- **Readbacks are client-read-only**, driven purely by the device's TCP push
+  stream (~1–5 Hz). `caget` serves the last cached value; `camonitor` posts once
+  per changed frame. A write to a readback PV fails cleanly at the client.
+- **Setpoints (`…:SP`)** forward the value to the device over GEECS's *blocking*
+  UDP set before storing it locally, so **put-completion means GEECS
+  convergence** — `caput -c` / ophyd-async `set().wait()` block for the physical
+  move (30 s default budget). A failed set raises and leaves the `:SP` PV
+  unchanged. Read state from the readback PV; the `:SP` value is the last
+  *commanded* value, not the device readback.
+
+Long GEECS save paths exceed the 40-char EPICS string limit, so path-typed
+variables are served as char-array (long-string) PVs — read/write them with
+`caget -S` / `caput -S` (ophyd-async handles this natively).
+
+## Liveness — the `CONNECTED` PV
+
+Every device has one `[Experiment:]Device:CONNECTED` PV: an enum
+(`Disconnected` / `Connected`), `MAJOR_ALARM` while the device's TCP
+subscription is down. **Prefer it as the liveness signal** over inferring
+liveness from data — the gateway serves a device's data PVs whether or not the
+device is up, and a merely *quiet* device (idling between triggers) is not a
+dead one.
+
+When a device's subscription drops, its readbacks go `INVALID` / `COMM` and hold
+their last value — so `INVALID` on a readback means "not live", not "bad value".
+Recovery is automatic on the next live frame.
+
+## Frame-ordering guarantee
+
+All data variables of a push frame are posted to their PVs **before** that
+frame's timestamp variable(s). So a monitor callback on a device's
+`acq_timestamp` (or `systimestamp`) observes a **completed frame** — every data
+PV of that frame already holds the frame's values. Clients that need
+whole-frame consistency should trigger/latch on the timestamp PV, not on a data
+PV. (Cross-*device* correlation is out of scope for the gateway — that is
+Bluesky's job.)
+
+The timestamp variables are themselves float readback PVs carrying the **raw
+LabVIEW-epoch** value; the same raw value is stamped on saved external assets
+(images), which is how saved files tie back to acquisition. A non-positive
+`acq_timestamp` means "no acquisition yet" (the `0.0` pre-acquisition
+placeholder), never a shot at the epoch.
+
+## Curated alarm limits (gateway 0.7.0)
+
+Value-based alarms are an **optional curated overlay** from a MySQL
+`ca_alarm_limits` table keyed by `(experiment, device, variable)`. Only non-null
+thresholds apply, and only to served numeric readbacks; a crossed limit sets the
+configured severity (`MINOR` / `MAJOR` / `INVALID`) with status `LOW` / `LOLO` /
+`HIGH` / `HIHI`. The table is optional — if it is absent, the IOC starts with no
+value alarms.
+
+Database `min` / `max` remain **display** limits only (a UX hint), never
+gateway-enforced control limits: GEECS stays the authority on valid set values,
+and a faithful-but-out-of-range readback (notably a `NaN` from a failed online
+analysis) is reported, not clamped.
+
+## Derived numeric channels (gateway 0.8.0)
+
+The gateway can expose additional **read-only float PVs** computed from one
+source device's numeric push-frame values — for example a Convectron pressure
+derived from a vacuum-gauge analog input. The v1 schema is deliberately narrow:
+one output PV, one arithmetic expression (numeric operators and a small `math`
+whitelist — no arbitrary Python), and **all inputs must come from the same
+source device**, so a client latching on that device's timestamp observes raw
+and derived values from the same completed frame.
+
+Derived PVs carry honest alarm states, distinct from raw readbacks:
+
+| Condition | Derived PV severity / status |
+|---|---|
+| Never computed, missing/empty or non-numeric input | `INVALID` / `UDF` |
+| Expression runtime failure (e.g. division by zero) | `INVALID` / `CALC` |
+| Source device subscription dropped | `INVALID` / `COMM` |
+| Recovery after any failure | next successful computation writes `NO_ALARM` |
+
+The declaration shape is the `derived_channels` config kind — see the
+[Schema reference](../geecs_schemas/schema_reference.md) for its fields, and
+`GeecsCAGateway/PV_CONTRACT.md` §3 for the normative behavior.
+
+## Reading more
+
+For anything load-bearing — the full type-mapping table, enum resolution rules,
+UDP/TCP failure semantics, and the complete alarm policy — read
+`GeecsCAGateway/PV_CONTRACT.md` in the source tree. For getting a client
+connected (addressing, environment, Windows), read
+`GeecsCAGateway/DEPLOYMENT.md`.

--- a/docs/geecs_scanner/api/scan_events.md
+++ b/docs/geecs_scanner/api/scan_events.md
@@ -2,13 +2,13 @@
 
 The typed event hierarchy emitted by the scan engine. Every state transition, every device command, every error, and every dialog request is delivered as an instance of one of these classes through the `on_event` callback registered with `ScanManager`.
 
-The narrative description of when each event fires and how to consume them lives at [Architecture — Event vocabulary](../architecture.md#event-vocabulary). This page is the formal API.
+The narrative description of when each event fires and how to consume them lives at [Architecture — Event vocabulary](../architecture.md#event-vocabulary). This page is the formal API. The vocabulary now lives in `geecs_bluesky.events`; `geecs_scanner.engine.scan_events` remains a re-export shim so existing imports keep working.
 
 ## ScanState
 
 The lifecycle states a scan can be in. Inherits `str` so values serialise naturally to JSON and log messages.
 
-::: geecs_scanner.engine.scan_events.ScanState
+::: geecs_bluesky.events.ScanState
     options:
       show_source: false
       show_root_heading: false
@@ -17,7 +17,7 @@ The lifecycle states a scan can be in. Inherits `str` so values serialise natura
 
 ## Base event
 
-::: geecs_scanner.engine.scan_events.ScanEvent
+::: geecs_bluesky.events.ScanEvent
     options:
       show_source: false
       show_root_heading: false
@@ -27,7 +27,7 @@ The lifecycle states a scan can be in. Inherits `str` so values serialise natura
 
 ## Lifecycle events
 
-::: geecs_scanner.engine.scan_events.ScanLifecycleEvent
+::: geecs_bluesky.events.ScanLifecycleEvent
     options:
       show_source: false
       show_root_heading: false
@@ -37,7 +37,7 @@ The lifecycle states a scan can be in. Inherits `str` so values serialise natura
 
 ## Step progress
 
-::: geecs_scanner.engine.scan_events.ScanStepEvent
+::: geecs_bluesky.events.ScanStepEvent
     options:
       show_source: false
       show_root_heading: false
@@ -47,7 +47,7 @@ The lifecycle states a scan can be in. Inherits `str` so values serialise natura
 
 ## Device command outcomes
 
-::: geecs_scanner.engine.scan_events.DeviceCommandEvent
+::: geecs_bluesky.events.DeviceCommandEvent
     options:
       show_source: false
       show_root_heading: false
@@ -57,7 +57,7 @@ The lifecycle states a scan can be in. Inherits `str` so values serialise natura
 
 ## Errors and restore failures
 
-::: geecs_scanner.engine.scan_events.ScanErrorEvent
+::: geecs_bluesky.events.ScanErrorEvent
     options:
       show_source: false
       show_root_heading: false
@@ -65,7 +65,7 @@ The lifecycle states a scan can be in. Inherits `str` so values serialise natura
       merge_init_into_class: true
       heading_level: 3
 
-::: geecs_scanner.engine.scan_events.ScanRestoreFailedEvent
+::: geecs_bluesky.events.ScanRestoreFailedEvent
     options:
       show_source: false
       show_root_heading: false
@@ -75,7 +75,7 @@ The lifecycle states a scan can be in. Inherits `str` so values serialise natura
 
 ## Dialog requests
 
-::: geecs_scanner.engine.scan_events.ScanDialogEvent
+::: geecs_bluesky.events.ScanDialogEvent
     options:
       show_source: false
       show_root_heading: false

--- a/docs/geecs_schemas/running_a_scan.md
+++ b/docs/geecs_schemas/running_a_scan.md
@@ -1,0 +1,168 @@
+# Running a scan the new way
+
+This page explains, in plain language, how a scan is described and what happens
+to its data when it runs on the new engine. If you want the map of the five
+config kinds first, read [Scanner Configs, Explained](schemas_overview.md); for
+the exact fields of each config, see the
+[Schema reference](schema_reference.md). This page is about the *run*: what you
+submit, what fills the gaps, and where the data lands.
+
+## One document describes the whole scan
+
+A **scan request** is the complete description of one scan — the single document
+you submit. It says what kind of scan it is (sweep a variable, sit still and
+collect shots, or let an optimizer drive), which positions to visit and how many
+shots to take, and — by name — which save set, trigger profile, and action plans
+to use. A saved preset *is* a scan request.
+
+You rarely have to spell out everything. Whatever the request leaves silent is
+filled from the experiment's standing defaults, and every value that gets filled
+in this way is **recorded in the run's metadata** so the record shows what the
+scan actually used, not what some defaults file happened to say at the time.
+
+### The four layers that decide what a scan does
+
+When a request is silent on something, the answer comes from a fixed stack of
+sources. From the bottom up:
+
+1. **The GEECS experiment database** (MySQL) — the per-device, per-variable
+   facts: which variables are logged for scans (`get='yes'`), their types,
+   units, and limits. This is the bedrock the configs sit on; it is not itself a
+   config file you edit here.
+2. **`experiment_defaults.yaml`** — the experiment's standing choices: the
+   default trigger profile, the setup/closeout plans every scan runs, and
+   whether background telemetry is on. Applied only where the request is silent;
+   it never overrides a value the request states explicitly.
+3. **Save-set entry rituals** — each required device can carry its own
+   `setup`/`closeout` action plans, so a device's ritual travels with it into
+   any scan whose save set includes that entry.
+4. **The scan request's own fields** — the most specific layer; anything stated
+   here wins.
+
+Setup plans nest like context managers on the way in — defaults first, then the
+save-set entry rituals, then the scan's own — and unwind in the exact reverse on
+the way out, so an experiment-wide "return the machine to standby" always runs
+last. The assembled order is recorded in the run metadata (`action_plans`).
+
+## Everything happens through actions, not database writes
+
+Scan-start, scan-end, and between-step operations are all expressed as **action
+plans** — named checklists of steps (set a variable, wait, check a readback, run
+another plan). A scan request points at them in three slots:
+
+- **setup** — before the first step,
+- **per_step** — at every position, right after the move and before the shots,
+- **closeout** — once at the end, in reverse order, and even if the scan aborts.
+
+Alongside actions, three other mechanisms shape the run, and none of them is a
+database write:
+
+- the **save set's entry rituals** (per-device setup/closeout, layer 3 above),
+- **`experiment_defaults.yaml`** actions (layer 2),
+- the **trigger profile** — the machine's OFF / STANDBY / SCAN / SINGLESHOT /
+  ARMED states, each an ordered list of device writes, driven by the shot
+  controller,
+- the scanner's **save-windowing** — native camera saving is switched on only
+  for the trigger-stopped part of the scan, so free-running frames are never
+  saved as orphan images.
+
+If you remember configuring scan behavior through the database's scan-start /
+scan-end values, that is the part that has moved.
+
+## The database set-side is intentionally disabled
+
+The GEECS database can, in principle, write device values at scan boundaries
+(the `set='yes'` rows with their `startvalue` / `endvalue`). **The engine does
+not apply those writes** — the set-side is reserved, not honored. The reason is
+concrete: triggering and camera saving are first-class engine features now, so
+the database's boundary writes would race the shot controller on the DG645 (the
+`set='yes'` rows are the very trigger and amplitude variables the shot
+controller already drives). The reserved schema fields
+(`SaveSetEntry.at_scan_start` / `at_scan_end`,
+`ExperimentDefaults.apply_db_scan_defaults`) are kept for a possible future
+re-enable; a config that still sets them logs one warning and is otherwise
+inert.
+
+The database **get-side** is very much live — it is what decides what gets
+recorded, described next.
+
+## The two-tier recording model
+
+"Required" and "recorded" used to be the same decision. They are two decisions
+now, split across two tiers.
+
+### Tier 1 — the save set (required devices)
+
+The save set is the list of devices the scan *requires*: they get completeness
+guarantees, a dialog if one dies, their images saved when asked, and their
+setup/closeout rituals run around the scan.
+
+What gets recorded for a Tier-1 device is its **`db_scalars` resolution**: by
+default (`db_scalars=true`) the recorded scalars are the device's database
+`get='yes'` variables **∪** any explicit `scalars` you list; `all_scalars=true`
+unions every database variable; `db_scalars=false` (the pin the legacy converter
+emits) records the explicit list only. Images are always Tier-1 — file saving
+needs coordination with the device, so there is no soft version of it.
+
+Tier-1 data goes to **both** destinations: the legacy on-disk s-file
+(`ScanDataScanNNN.txt` and the `analysis/sNNN.txt` copy) **and** the Tiled
+catalog.
+
+### Tier 2 — background telemetry
+
+Every live experiment device with a `get='yes'` variable that is **not** in the
+save set is still recorded — as soft, read-only snapshot columns read straight
+from the gateway's always-on monitor cache. This tier is safe by construction:
+
+- it is **read-only** and **never waited on**, so it can never slow or stall a
+  shot;
+- it is **dtype-tolerant** — each column's type is inferred from its PV, so a
+  numeric variable stays numeric while an enum or string variable (a plunger
+  position, a digital-output label) is logged as its label. A telemetry column
+  set can mix float and string columns; one awkward non-numeric channel never
+  drops the device's other columns;
+- a device that is **dead at scan start is dropped with a log line** — no
+  dialog, no abort; a value that can't be read mid-scan degrades to a
+  type-appropriate null cell.
+
+Background telemetry is **Tiled-only — it does not go to the s-file.** That was
+a deliberate decision: the s-file is the legacy Tier-1 scalar contract that
+downstream GEECS analysis consumes, and Tier-2 telemetry is a new, best-effort
+record that lives alongside it in Tiled rather than reshaping the legacy file.
+
+Telemetry is on by default for the experiment
+(`ExperimentDefaults.background_telemetry`) and can be overridden per scan
+(`ScanRequest.background_telemetry`). The `{device: [variables]}` actually
+selected is recorded in the run metadata.
+
+### The one-question test for which tier a device belongs to
+
+Does any analysis need the device **shot-by-shot**? If yes, it is Tier-1 by
+definition — synchronicity means waiting, and only required devices are waited
+on. If no, it can stay Tier-2 — softness means never waiting, and the two are
+mutually exclusive.
+
+## Where the data lands
+
+- **The s-file** (`ScanDataScanNNN.txt`, copied to `analysis/sNNN.txt`) carries
+  the Tier-1 scalars. For **image / file-saving devices**, the device's
+  **`acq_timestamp`** column now appears in the s-file as well — the raw device
+  acquisition timestamp that ties each saved frame back to its scan row. It is
+  surfaced only for file-saving devices; pure-scalar devices don't get it.
+- **Tiled** holds the full per-shot event stream: Tier-1 data *and* the Tier-2
+  background-telemetry columns (keyed `telemetry_<device>-<variable>`), plus the
+  schema-v1 companion columns. The s-file is exported from the Tiled run
+  best-effort after the scan.
+
+Join saved files to scan rows by a device's `acq_timestamp`, never by the
+derived `shot_id` (which counts trigger opportunities, not rows). The full
+per-column contract is `GeecsBluesky/EVENT_SCHEMA.md` in the source tree.
+
+## Two habits worth keeping
+
+- **Typos fail loudly.** Configs are validated when loaded — a misspelled key is
+  an immediate error naming the bad field, resolved fail-fast *before* any
+  hardware is touched or a scan number is used up.
+- **You describe intent, not mechanics.** Timestamp bookkeeping, synchronization
+  flags, and parallel laser-off files are gone on purpose — the engine derives
+  them, and legacy files convert automatically on load.

--- a/docs/geecs_schemas/schema_reference.md
+++ b/docs/geecs_schemas/schema_reference.md
@@ -1,0 +1,512 @@
+<!-- GENERATED FILE — do not edit by hand.
+     Regenerate with:  python -m geecs_schemas.docgen
+     (or GEECS-Schemas/tests/generate_schema_reference.py).
+     A no-drift test (tests/test_schema_reference.py) fails CI if this
+     file falls out of step with the schema field descriptions. -->
+
+# GEECS config schema reference
+
+## `scan_request`
+
+### ScanRequest
+
+One complete scan, ready to submit: what to do, what to save, how to trigger.
+
+| Field | Type | Required | Default | What it does |
+|---|---|---|---|---|
+| `schema_version` | `int` | no | 1 | Format version of this config file. Leave at 1 — tools update this automatically when the file format changes. |
+| `mode` | `ScanRequestMode` | yes | — | What kind of scan: 'step' sweeps one or more axes, 'noscan' collects shots without moving anything, 'optimize' lets an algorithm pick the settings. |
+| `axes` | `list[ScanAxis]` | no | empty | For step scans: what to sweep. One entry is a simple 1-D scan; several entries form a grid visiting every combination, with the first axis as the outermost (slowest) loop and the last as the innermost (fastest). Leave empty for noscan and optimize. |
+| `shots_per_step` | `int` | no | 1 | How many shots to take at each scan position / grid point (or in total for a noscan). |
+| `acquisition` | `AcquisitionMode` | no | 'strict' | 'strict' fires shot by shot and guarantees every device is in every row; 'free_run' lets the trigger run at the machine rate and matches devices up by timestamp. |
+| `save_set` | `str (optional)` | no | None | Name of the save set listing the devices this scan REQUIRES — the ones that get guarantees (completeness, dialogs, images, rituals). Unset means no required devices beyond scan bookkeeping. |
+| `background_telemetry` | `bool (optional)` | no | None | Also log every other live experiment device as best-effort snapshot columns — the variables the GEECS experiment database marks for scan logging (MySQL table expt_device_variable, get='yes') — read from the gateway's always-on monitor cache: read-only and never waited on, so it cannot slow or stall the scan; dead devices are dropped with a log line, never a dialog or abort. Leave unset to inherit the experiment default; set true/false to override for this scan. |
+| `trigger_profile` | `str (optional)` | no | None | Name of the trigger profile that drives the shot trigger. Unset means the scan does not manage the trigger. |
+| `trigger_variant` | `str (optional)` | no | None | Optional variant of the trigger profile to use, e.g. 'laser_off'. Leave unset for the profile's base behaviour. |
+| `actions` | `ActionBindings` | no | ActionBindings(setup=[], per_step=[], closeout=[]) | Named action plans to run before the scan (setup), between steps (per_step), and after it (closeout). |
+| `description` | `str` | no | '' | Free-text note about this scan; it ends up in the scan's metadata and the experiment log. |
+| `background` | `bool` | no | False | Mark this scan's data as background/calibration shots so analysis can find them later. |
+| `optimization` | `OptimizationSpec (optional)` | no | None | The optimization problem definition. Required for (and only allowed with) mode 'optimize'. |
+
+Example:
+
+```yaml
+schema_version: 1
+mode: step
+axes:
+  - variable: jet_z
+    positions: {start: 4.0, end: 6.0, step: 0.5}
+  # add more axes to scan a grid — the first axis is the outermost
+  # (slowest) loop, the last the innermost (fastest), e.g.:
+  # - variable: gas_pressure
+  #   positions: {values: [1.5, 2.0, 2.5]}
+shots_per_step: 10
+acquisition: free_run
+save_set: undulator_baseline
+trigger_profile: htu_shot_control
+actions:
+  setup: [pre_scan_ebeam]
+  per_step: []
+  closeout: []
+description: "jet z scan with probe"
+```
+
+### ScanAxis
+
+One swept variable and the positions it visits.
+
+| Field | Type | Required | Default | What it does |
+|---|---|---|---|---|
+| `variable` | `str` | yes | — | The friendly name of the variable this axis sweeps (from the experiment's scan-variables catalog). |
+| `positions` | `PositionRange \| PositionList` | yes | — | The positions this axis visits, either as {start, end, step} or as {values: [...]}. |
+
+### PositionRange
+
+Scan positions given as start / end / step size.
+
+| Field | Type | Required | Default | What it does |
+|---|---|---|---|---|
+| `start` | `float` | yes | — | First position of the sweep. |
+| `end` | `float` | yes | — | Last position of the sweep. |
+| `step` | `float` | yes | — | Spacing between positions. Its sign is ignored — the sweep direction comes from start and end. |
+
+### PositionList
+
+Scan positions given as an explicit list of values.
+
+| Field | Type | Required | Default | What it does |
+|---|---|---|---|---|
+| `values` | `list[float]` | yes | — | The exact positions to visit, in the order given. |
+
+### ActionBindings
+
+Which named action plans run around (and inside) the scan.
+
+| Field | Type | Required | Default | What it does |
+|---|---|---|---|---|
+| `setup` | `list[str]` | no | empty | Plans to run once before the scan starts. |
+| `per_step` | `list[str]` | no | empty | Plans to run between scan steps — after each move, before the shots at that position. |
+| `closeout` | `list[str]` | no | empty | Plans to run once after the scan finishes (even on abort). |
+
+### OptimizationSpec
+
+The optimization problem: what to vary, within what limits, to improve what.
+
+| Field | Type | Required | Default | What it does |
+|---|---|---|---|---|
+| `variables` | `dict[str, tuple[float, float]]` | yes | — | What the optimizer may move and how far, as 'variable name: [lowest, highest]'. Names may be scan-variable names or 'Device:Variable' strings. |
+| `objectives` | `dict[str, str]` | no | empty | What counts as better, as 'objective name: MINIMIZE' or 'objective name: MAXIMIZE'. May be empty for algorithms that only model observables (BAX). |
+| `observables` | `list[str]` | no | empty | Extra measured quantities the algorithm should track without optimizing them, e.g. ['x_CoM']. |
+| `constraints` | `dict[str, tuple[str, float]]` | no | empty | Hard limits on measured quantities, as 'name: [LESS_THAN or GREATER_THAN, value]'. Usually empty. |
+| `evaluator` | `EvaluatorSpec` | yes | — | The analysis code that scores each iteration. |
+| `generator` | `GeneratorSpec` | yes | — | The algorithm that proposes the next settings. |
+| `max_iterations` | `int (optional)` | no | None | Stop after this many optimization iterations. Leave unset to run until stopped by hand. |
+| `seed_dump_files` | `list[str]` | no | empty | Optional earlier results (ECS dump files) used to warm-start the optimizer. Usually empty. |
+| `move_to_best_on_finish` | `bool` | no | False | After the optimization ends, drive the variables back to the best settings found. |
+
+### EvaluatorSpec
+
+Which analysis code turns raw shots into the number being optimized.
+
+| Field | Type | Required | Default | What it does |
+|---|---|---|---|---|
+| `module` | `str` | yes | — | Python import path of the evaluator module, e.g. 'geecs_scanner.optimization.evaluators.beam_sum_counts_evaluator'. |
+| `class_name` | `str` | yes | — | Name of the evaluator class inside that module. |
+| `kwargs` | `dict` | no | empty | Settings passed to the evaluator when it is created — e.g. which diagnostics/analyzers it should read. Free-form: each evaluator documents its own options. |
+
+### GeneratorSpec
+
+Which optimization algorithm proposes the next settings.
+
+| Field | Type | Required | Default | What it does |
+|---|---|---|---|---|
+| `name` | `str` | yes | — | Name of the optimization algorithm, e.g. 'bayes_default', 'random', or 'multipoint_bax_alignment_l2'. |
+| `options` | `dict` | no | empty | Algorithm-specific tuning options. Free-form: each generator documents its own options (legacy 'xopt_config_overrides'). |
+
+## `save_set`
+
+### SaveSet
+
+The devices a scan *requires* — its participation list, not a logging list.
+
+| Field | Type | Required | Default | What it does |
+|---|---|---|---|---|
+| `schema_version` | `int` | no | 1 | Format version of this config file. Leave at 1 — tools update this automatically when the file format changes. |
+| `name` | `str` | yes | — | The name scans use to refer to this save set. |
+| `entries` | `list[SaveSetEntry]` | yes | — | The devices to record, one entry per device. |
+| `description` | `str` | no | '' | Optional note about what this save set is for. |
+
+Example:
+
+```yaml
+schema_version: 1
+name: undulator_baseline
+# the REQUIRED devices — everything else is still logged in the background
+entries:
+  - device: UC_Amp4_IR_input
+    images: true                     # images are always required-tier
+    scalars: [MaxCounts, centroidx]  # extras beyond the DB's standard telemetry
+  - device: U_HP_Daq
+    db_scalars: false                # record ONLY the listed scalars, not the DB set
+    scalars: [AnalogOutput.Channel 1]
+    at_scan_start: {Analysis: "on"}  # replace the DB's scan-start value
+    at_scan_end: {Analysis: null}    # suppress the DB's scan-end write
+  - device: U_BCaveHallProbe
+    scalars: [Field, Rawfield]
+    role: snapshot
+  - device: UC_UndulatorRad2
+    images: true
+    scalars: [MeanCounts]
+    # this device's ritual travels with it: these named plans run once
+    # before/after any scan whose save set includes this entry
+    setup: [visa1_spectrometer_setup]
+    closeout: [visa1_spectrometer_closeout]
+```
+
+### SaveSetEntry
+
+One *required* device of a scan and the guarantees it gets.
+
+| Field | Type | Required | Default | What it does |
+|---|---|---|---|---|
+| `device` | `str` | yes | — | GEECS device name exactly as it appears in the GEECS experiment database (MySQL), e.g. 'UC_ALineEbeam1'. Spelling (including case) is checked against the database when the config is loaded. |
+| `scalars` | `list[str]` | no | empty | EXTRA scalar readings to record beyond the device's standard telemetry — the variables the GEECS experiment database marks for scan logging (MySQL table expt_device_variable, get='yes'), which 'db_scalars' records by default. E.g. ['MaxCounts', 'centroidx']. Usually empty — list variables here only when you need something the database doesn't mark. |
+| `all_scalars` | `bool` | no | False | Record every scalar variable the device publishes instead of naming them one by one. If 'scalars' is also given, the explicit list wins. |
+| `images` | `bool` | no | False | Save the device's images / non-scalar files (camera frames, traces) alongside the scalar data. |
+| `role` | `SaveRole (optional)` | no | None | Override for how this device is synchronized with shots. Leave unset to let the scanner decide; set 'snapshot' for slow readbacks that don't produce one value per shot. |
+| `setup` | `list[str]` | no | empty | Names of action plans that must run before any scan that records this device — its setup ritual (turn analysis on, insert a stage, ...). The plans named by all entries of a save set are collected together, de-duplicated by name, and each runs once before the scan. |
+| `closeout` | `list[str]` | no | empty | Names of action plans that run after any scan that records this device — its cleanup ritual. Collected and de-duplicated the same way as 'setup', and run once after the scan (even on abort). |
+| `db_scalars` | `bool` | no | True | Record every variable the GEECS experiment database marks for scan logging for this device (MySQL table expt_device_variable, column get='yes') — the MC-style 'standard telemetry', and the default scalar source for a required device. The 'scalars' list adds extras on top. Turn off to record only what 'scalars' lists explicitly (converted legacy elements do this, preserving their exact old behavior). |
+| `at_scan_start` | `dict[str, str (optional)]` | no | empty | RESERVED AND NOT APPLIED in this version. The DB set-side scan start/end writes are intentionally disabled: the engine sets up triggering via the trigger profile / shot controller and camera saving via its own save-windowing, so writing the database's set='yes' start values here would race the shot controller. Kept for a possible future re-enable — a config that sets it is not an error but has no effect today (the engine logs a warning). When honored again, it would tweak the database's scan-start writes per variable (unmentioned = database value, a value = replace, null = suppress). |
+| `at_scan_end` | `dict[str, str (optional)]` | no | empty | RESERVED AND NOT APPLIED in this version — the scan-end counterpart of 'at_scan_start'. The DB set-side scan start/end writes are intentionally disabled (triggering is owned by the trigger profile / shot controller, camera saving by the scanner's save-windowing), so this has no effect today; it is kept for a possible future re-enable. When honored again, it would tweak the database's scan-end writes per variable (same three cases as 'at_scan_start'). |
+
+## `scan_variables`
+
+### ScanVariables
+
+The experiment's catalog of scannable variables, keyed by friendly name.
+
+| Field | Type | Required | Default | What it does |
+|---|---|---|---|---|
+| `schema_version` | `int` | no | 1 | Format version of this config file. Leave at 1 — tools update this automatically when the file format changes. |
+| `variables` | `dict[str, ScanVariable \| PseudoScanVariable]` | yes | — | All scannable variables, keyed by the friendly name shown when setting up a scan. |
+
+Example:
+
+```yaml
+schema_version: 1
+variables:
+  jet_z:
+    target: "U_ESP_JetXYZ:Position.Axis 3"
+    kind: motor
+  gas_pressure:
+    target: "U_HP_Daq:AnalogOutput.Channel 1"
+  e_beam_angle_x:
+    kind: pseudo
+    mode: relative
+    targets:
+      - target: "U_S3H:Current"
+        forward: "composite_var * 1"
+      - target: "U_S4H:Current"
+        forward: "composite_var * -2"
+```
+
+### ScanVariable
+
+A friendly name for one device variable you can scan.
+
+| Field | Type | Required | Default | What it does |
+|---|---|---|---|---|
+| `target` | `str` | yes | — | The device variable this name moves, written as 'Device:Variable', e.g. 'U_ESP_JetXYZ:Position.Axis 3'. |
+| `kind` | `'motor' \| 'setpoint'` | no | 'setpoint' | 'setpoint' = write the value and wait for the device to accept it (the default). 'motor' = additionally poll the readback until the device reports it arrived — use for real positioners. |
+
+### PseudoScanVariable
+
+A friendly name that moves several devices together from one number.
+
+| Field | Type | Required | Default | What it does |
+|---|---|---|---|---|
+| `kind` | `'pseudo'` | yes | — | Variable type. 'pseudo' moves several devices from one number. |
+| `targets` | `list[PseudoTarget]` | yes | — | The devices this variable moves, each with its own formula. |
+| `mode` | `CompositeMode` | yes | — | 'absolute' = each device goes exactly where its formula says. 'relative' = each device is offset from where it was when the scan started. |
+| `inverse` | `str (optional)` | no | None | Optional formula recovering the scanned number from the first target's readback. Leave unset if you don't need a readback for this variable. |
+
+### PseudoTarget
+
+One device a pseudo variable moves, and the formula for its value.
+
+| Field | Type | Required | Default | What it does |
+|---|---|---|---|---|
+| `target` | `str` | yes | — | The device variable to move, written as 'Device:Variable', e.g. 'U_S1H:Current'. |
+| `forward` | `str` | yes | — | Formula for this device's value in terms of the scanned number, written with 'composite_var' as the scanned value — e.g. 'composite_var * -2' or '8.5 + (composite_var-10)*2.5'. |
+
+## `trigger_profile`
+
+### TriggerProfile
+
+The device writes that drive the machine through its trigger states.
+
+| Field | Type | Required | Default | What it does |
+|---|---|---|---|---|
+| `schema_version` | `int` | no | 1 | Format version of this config file. Leave at 1 — tools update this automatically when the file format changes. |
+| `name` | `str` | yes | — | The name scans use to refer to this trigger profile. |
+| `states` | `dict[TriggerState, list[TriggerWrite]]` | no | empty | For each trigger state, the writes that put the machine into it, applied in order from top to bottom. A transition may write several devices. Omit a device variable from a state to leave it untouched. |
+| `variants` | `dict[str, TriggerVariant]` | no | empty | Named alternative operating conditions (e.g. 'laser_off'), each listing only the writes that differ from the base states. |
+| `description` | `str` | no | '' | Optional note about what setup this profile is for. |
+
+Example:
+
+```yaml
+schema_version: 1
+name: htu_shot_control
+# each state lists its writes IN ORDER (top to bottom); a transition may
+# touch several devices
+states:
+  OFF:
+    - {device: U_DG645_ShotControl, variable: Amplitude.Ch AB, value: "0.5"}
+    - {device: U_DG645_ShotControl, variable: Trigger.Source,
+       value: Single shot external rising edges}
+  STANDBY:
+    - {device: U_DG645_ShotControl, variable: Amplitude.Ch AB, value: "0.5"}
+    - {device: U_DG645_ShotControl, variable: Trigger.Source,
+       value: External rising edges}
+  SCAN:
+    - {device: U_DG645_ShotControl, variable: Amplitude.Ch AB, value: "4.0"}
+    - {device: U_DG645_ShotControl, variable: Trigger.Source,
+       value: External rising edges}
+    - {device: U_GasJetPLC, variable: DO.Jet, value: "on"}
+  ARMED:
+    - {device: U_DG645_ShotControl, variable: Amplitude.Ch AB, value: "4.0"}
+    - {device: U_DG645_ShotControl, variable: Trigger.Source,
+       value: Single shot external rising edges}
+  SINGLESHOT:
+    - {device: U_DG645_ShotControl, variable: Trigger.ExecuteSingleShot,
+       value: "on"}
+variants:
+  laser_off:
+    states:
+      OFF:
+        - {device: U_DG645_ShotControl, variable: Trigger.Source,
+           value: Single shot}
+      SCAN:
+        - {device: U_DG645_ShotControl, variable: Trigger.Source,
+           value: Internal}
+      ARMED:
+        - {device: U_DG645_ShotControl, variable: Trigger.Source,
+           value: Single shot}
+```
+
+### TriggerWrite
+
+One device variable set during a state transition.
+
+| Field | Type | Required | Default | What it does |
+|---|---|---|---|---|
+| `device` | `str` | yes | — | The device to write to, e.g. 'U_DG645_ShotControl' or a gas-jet controller — any settable device can take part in a transition. |
+| `variable` | `str` | yes | — | Which variable on the device to set, e.g. 'Trigger.Source'. |
+| `value` | `str` | yes | — | The value to send, exactly as the device expects it — a number as text ('4.0'), a word ('on'), or a device option name ('External rising edges'). |
+
+### TriggerVariant
+
+A named operating condition that tweaks a few writes of the profile.
+
+| Field | Type | Required | Default | What it does |
+|---|---|---|---|---|
+| `states` | `dict[TriggerState, list[TriggerWrite]]` | yes | — | Only the writes that differ from the base profile, per state. A write here replaces the base write to the same device variable; writes to new device variables are added after the base ones. Anything not listed keeps its base value. |
+| `description` | `str` | no | '' | Optional note about when to use this variant. |
+
+## `action_plan`
+
+### ActionPlan
+
+An ordered checklist of steps the scanner runs for you.
+
+| Field | Type | Required | Default | What it does |
+|---|---|---|---|---|
+| `schema_version` | `int` | no | 1 | Format version of this config file. Leave at 1 — tools update this automatically when the file format changes. |
+| `steps` | `list[SetStep \| WaitStep \| CheckStep \| RunPlanStep]` | yes | — | The steps to perform, in order from top to bottom. |
+| `description` | `str` | no | '' | Optional note to your future self about what this plan does and when to use it. |
+
+Example:
+
+```yaml
+schema_version: 1
+description: "Zero the pressure voltage and confirm the PLC output"
+steps:
+  - do: set
+    device: U_HP_Daq
+    variable: AnalogOutput.Channel 1
+    value: 0
+  - do: wait
+    seconds: 3
+  - do: check
+    device: U_148_PLC
+    variable: DI.Ch17
+    expected: "off"
+  - do: run
+    plan: close_gaia_internal_shutters
+```
+
+### SetStep
+
+One step that sets a device variable to a value.
+
+| Field | Type | Required | Default | What it does |
+|---|---|---|---|---|
+| `do` | `'set'` | yes | — | Step type. 'set' writes a value to a device variable. |
+| `device` | `str` | yes | — | Name of the device to command, e.g. 'U_148_PLC'. |
+| `variable` | `str` | yes | — | Which variable on the device to set, e.g. 'DO.Ch9'. |
+| `value` | `str \| float \| int` | yes | — | The value to write — a number, or a word the device understands such as 'on' or 'off'. |
+| `wait_for_execution` | `bool` | no | True | Wait for the device to confirm the change before moving to the next step. Leave on unless you know the step is fire-and-forget. |
+
+### WaitStep
+
+One step that simply pauses for a number of seconds.
+
+| Field | Type | Required | Default | What it does |
+|---|---|---|---|---|
+| `do` | `'wait'` | yes | — | Step type. 'wait' pauses the plan for a fixed time. |
+| `seconds` | `float` | yes | — | How long to pause, in seconds (must be greater than 0). |
+
+### CheckStep
+
+One step that reads a device variable and verifies its value.
+
+| Field | Type | Required | Default | What it does |
+|---|---|---|---|---|
+| `do` | `'check'` | yes | — | Step type. 'check' reads a device variable and stops the plan with an error if the value is not what you expected. |
+| `device` | `str` | yes | — | Name of the device to read, e.g. 'U_GaiaSVEReader'. |
+| `variable` | `str` | yes | — | Which variable on the device to read, e.g. 'InternalShutterA'. |
+| `expected` | `str \| float \| int` | yes | — | The value the reading must match for the plan to continue — a number or a word such as 'on'. |
+
+### RunPlanStep
+
+One step that runs another named action plan.
+
+| Field | Type | Required | Default | What it does |
+|---|---|---|---|---|
+| `do` | `'run'` | yes | — | Step type. 'run' executes another named plan from the library. |
+| `plan` | `str` | yes | — | Name of the plan to run, as listed in the action library. |
+
+## `action_plan_library`
+
+### ActionPlanLibrary
+
+The collection of all named action plans for an experiment.
+
+| Field | Type | Required | Default | What it does |
+|---|---|---|---|---|
+| `schema_version` | `int` | no | 1 | Format version of this config file. Leave at 1 — tools update this automatically when the file format changes. |
+| `plans` | `dict[str, ActionPlan]` | yes | — | All named plans, keyed by the name used to invoke them. |
+
+Example:
+
+```yaml
+schema_version: 1
+plans:
+  zero_pressure_voltage:
+    steps:
+      - do: set
+        device: U_HP_Daq
+        variable: AnalogOutput.Channel 1
+        value: 0
+  experiment_closeout:
+    steps:
+      - do: run
+        plan: zero_pressure_voltage
+```
+
+## `experiment_defaults`
+
+### ExperimentDefaults
+
+Per-experiment fallbacks applied where a scan request is silent.
+
+| Field | Type | Required | Default | What it does |
+|---|---|---|---|---|
+| `schema_version` | `int` | no | 1 | Format version of this config file. Leave at 1 — tools update this automatically when the file format changes. |
+| `trigger_profile` | `str (optional)` | no | None | Name of the trigger profile to use when a scan doesn't name one. Leave unset if scans must always choose explicitly. |
+| `actions` | `DefaultActions` | no | DefaultActions(setup=[], closeout=[]) | Action plans every scan runs by default — setup plans run first (before the scan's own), closeout plans run last (after the scan's own). |
+| `apply_db_scan_defaults` | `bool` | no | True | RESERVED AND NOT CURRENTLY HONORED. The DB set-side scan start/end writes (MySQL table expt_device_variable: rows with set='yes', writing their startvalue/endvalue) are disabled in this version — triggering is set up via the trigger profile / shot controller and camera saving via the scanner's own save-windowing, so the database's boundary writes are not applied regardless of this flag. Kept for a possible future re-enable. Note this is the set-side only: the get-side 'db_scalars' (standard telemetry) and 'background_telemetry' are honored as normal. |
+| `background_telemetry` | `bool` | no | True | Log every live experiment device that is not in a scan's save set as best-effort snapshot columns — the variables the GEECS experiment database marks for scan logging (MySQL table expt_device_variable, get='yes') — read from the gateway's always-on monitor cache. Safe by construction: read-only and never waited on, so it cannot slow or stall a scan — a dead device is just dropped with a log line. On by default so no data is silently lost; individual scans can override with their own 'background_telemetry' setting. |
+| `description` | `str` | no | '' | Optional note about what these defaults are for. |
+
+Example:
+
+```yaml
+schema_version: 1
+# applied only where a scan request is silent: defaults run first,
+# then the scan's own
+trigger_profile: htu_shot_control
+actions:
+  setup: [pre_scan_checklist]
+  closeout: [experiment_closeout]
+background_telemetry: true   # soft-log every live device not in the save set
+description: "HTU standing defaults"
+```
+
+### DefaultActions
+
+The action plans every scan of the experiment runs by default.
+
+| Field | Type | Required | Default | What it does |
+|---|---|---|---|---|
+| `setup` | `list[str]` | no | empty | Names of action plans to run before every scan, ahead of any setup plans the scan itself lists. |
+| `closeout` | `list[str]` | no | empty | Names of action plans to run after every scan, after any closeout plans the scan itself lists (teardown mirrors setup: these are the outermost bracket). |
+
+## `derived_channels`
+
+### DerivedChannels
+
+A file of computed read-only PVs for the CA gateway.
+
+| Field | Type | Required | Default | What it does |
+|---|---|---|---|---|
+| `schema_version` | `int` | no | 1 | Format version of this config file. Leave at 1 — tools update this automatically when the file format changes. |
+| `derived_channels` | `list[DerivedChannel]` | no | empty | Derived PVs to expose. Each entry computes one read-only float PV from one source device's numeric push-frame values. |
+
+Example:
+
+```yaml
+schema_version: 1
+derived_channels:
+  - device: TargetChamberPressure
+    variable: Pressure
+    expression: "10**(v - 6)"
+    inputs:
+      - symbol: v
+        device: U_VacuumGauge
+        variable: "AI_mean.Channel 0"
+    egu: Torr
+    precision: 6
+    description: "Convectron pressure from U_VacuumGauge analog input 0"
+```
+
+### DerivedChannel
+
+One read-only float PV computed from a numeric expression.
+
+| Field | Type | Required | Default | What it does |
+|---|---|---|---|---|
+| `device` | `str` | yes | — | Device component of the output PV, e.g. 'U_ChamberVac' for 'Undulator:U_ChamberVac:Pressure'. This may be semantic and does not need to be a real GEECS hardware device. |
+| `variable` | `str` | yes | — | Variable component of the output PV, e.g. 'Pressure'. The gateway normalizes it using the same rules as raw GEECS variables. |
+| `expression` | `str` | yes | — | Numeric formula for the output value, using input symbols and the gateway's restricted arithmetic subset. Example: '10**(v - 5)'. |
+| `inputs` | `list[DerivedInput]` | yes | — | Input variables available to the expression. In schema version 1 all inputs for a derived channel must come from one source device, so the calculation is coherent within a single push frame. |
+| `experiment` | `str (optional)` | no | None | Optional experiment prefix override for the output PV. Leave unset to use the gateway's launched experiment. |
+| `pv` | `str (optional)` | no | None | Optional explicit output PV variable component. Leave unset to use the 'variable' field. |
+| `egu` | `str` | no | '' | Engineering units displayed by CA clients, e.g. 'Torr'. |
+| `precision` | `int` | no | 3 | Number of decimal places CA clients should display. |
+| `lo` | `float (optional)` | no | None | Optional lower display limit for the output PV. This is metadata only; it is not an alarm or control limit. |
+| `hi` | `float (optional)` | no | None | Optional upper display limit for the output PV. This is metadata only; it is not an alarm or control limit. |
+| `deadband` | `float` | no | 0.0 | Monitor deadband for the computed float value. Leave at 0.0 to post every changed value and suppress only exact repeats. |
+| `description` | `str` | no | '' | Operator-facing note describing what the derived PV represents, for example the gauge model or calibration provenance. |
+
+### DerivedInput
+
+One source variable bound to a symbol in a derived-channel formula.
+
+| Field | Type | Required | Default | What it does |
+|---|---|---|---|---|
+| `symbol` | `str` | yes | — | Python-style symbol used in the expression, e.g. 'v' for a voltage input. Must be a valid identifier and must not shadow a reserved math function or constant. |
+| `device` | `str` | yes | — | GEECS source device that provides this input variable, e.g. 'U_DaqPad1'. All inputs for one derived channel must come from the same source device in schema version 1. |
+| `variable` | `str` | yes | — | GEECS source variable on the input device, e.g. 'Analog Input 10'. The gateway subscribes to it even if it is not exposed as its own raw readback PV. |

--- a/docs/geecs_schemas/schemas_overview.md
+++ b/docs/geecs_schemas/schemas_overview.md
@@ -180,6 +180,12 @@ a clear "not yet" message rather than attempted halfway.
   laser-off files: those are gone on purpose. The scanner derives them, and
   the old files convert automatically.
 
-*(The detailed per-field reference — every field, its type, default, and
-what it does — is generated from these same schemas; see the GEECS-Schemas
-package README for how to render it.)*
+## Where to next
+
+- **[Running a scan the new way](running_a_scan.md)** — the run itself: the
+  four-layer setup, the two-tier recording model in full, why the database
+  set-side is disabled, and where the data lands.
+- **[Schema reference](schema_reference.md)** — the detailed per-field
+  reference: every field, its type, default, and what it does. It is generated
+  straight from these same schemas (a no-drift test keeps it honest), so it can
+  never disagree with what the scanner actually accepts.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -105,6 +105,11 @@ nav:
 
   - GEECS Schemas:
       - Scanner Configs Overview: geecs_schemas/schemas_overview.md
+      - Running a Scan: geecs_schemas/running_a_scan.md
+      - Schema Reference: geecs_schemas/schema_reference.md
+
+  - GEECS Gateway:
+      - Client Overview: geecs_gateway/client_overview.md
 
   # Skills is intentionally last — experimental (agentic tooling), not core suite.
   - Skills:


### PR DESCRIPTION
Consolidation docs sweep of the stable engine/schema/gateway surface (operator manual + GUI docs deferred until the new GUI exists).

## Added
- **Published schema reference with a no-drift guard** (`docs/geecs_schemas/schema_reference.md`) generated from `docgen.render_reference()`; `test_schema_reference.py` fails if the committed page diverges from the schemas. Regenerate via `python -m geecs_schemas.docgen`. Fixed two generator bugs found while wiring it (pipe-escaping in union-type table cells; `Annotated` discriminated-union unwrap). GEECS-Schemas 0.4.0 → 0.5.0.
- **Operator narrative** (`running_a_scan.md`) — ScanRequest + four-layer setup, actions vs DB writes, set-side reserved/disabled (DG645 race), two-tier recording (Tier-1 db_scalars s-file+Tiled; Tier-2 telemetry dtype-tolerant, Tiled-only, never gates a shot), acq_timestamp in the s-file.
- **Gateway client page** (`geecs_gateway/client_overview.md`) — PV naming, CONNECTED liveness, frame-ordering, alarm overlay, derived channels; links PV_CONTRACT.md as normative.

## Fixed
- Root `CLAUDE.md` dependency graph: GEECS-Schemas node + `GeecsBluesky → GEECS-Schemas` edge; GEECS-Schemas added to the repo map.
- **Pre-existing mkdocs build crash**: `geecs_scanner/api/scan_events.md` pointed mkdocstrings at the M2 re-export shim (unresolvable cross-package alias); repointed to `geecs_bluesky.events`. **`mkdocs build` now exits 0.**

## Verified
`mkdocs build` exits 0 (25 pre-existing warnings, no errors); GEECS-Schemas 211 passed (incl. no-drift guard); pre-commit clean; all three new pages render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)