### PR TITLE
docs: regroup mkdocs nav by purpose (Acquisition / Analysis / Platform)

### DIFF
--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -8,16 +8,34 @@ The site is organised into top-level tabs in `mkdocs.yml`'s `nav:`. The
 canonical ordering is:
 
 ```
-Home → Tutorials → <per-package tabs> → Skills
+Home → Tutorials → Acquisition → Analysis → Platform → Skills
 ```
+
+The middle three are **purpose groups**, not one-tab-per-package. Each
+groups the packages that serve a shared audience, and each opens on a
+short section-index landing page (`docs/<group>/index.md`, surfaced via the
+`navigation.indexes` theme feature) that orients the reader and links to the
+constituent packages:
+
+- **Acquisition** — running scans on the beamline. Currently the Scanner
+  GUI; future acquisition backends (e.g. a Bluesky-driven scanner) join here.
+- **Analysis** — turning acquired data into results: Image Analysis, Scan
+  Analysis, and the Data Utils path/loading layer they build on.
+- **Platform** — the access-and-contract layer everything sits on: the
+  Python API (device transport + DB), the GEECS Gateway (EPICS soft-IOC),
+  and GEECS Schemas (the typed scan-config contract).
+
+Inside a group, each package is its own nav **section** (`navigation.sections`)
+and follows roughly Diátaxis: Overview (explanation), Tutorial (when
+applicable), How-To pages, Examples (notebooks), API Reference
+(mkdocstrings-generated). To document a new package, add a section under the
+group that matches its audience rather than creating a new top-level tab —
+that one-tab-per-package sprawl is exactly what the purpose grouping replaced.
 
 The Tutorials tab is the cross-package, user-facing entry point — it holds
 the end-to-end walkthroughs (currently Analysis; Acquisition is stubbed
-and eventually replaces the existing `geecs_scanner/tutorial.md`). Each
-per-package tab is owned by the package it documents and follows roughly
-Diátaxis: Overview (explanation), Tutorial (when applicable), How-To
-pages, Examples (notebooks), API Reference (mkdocstrings-generated).
-Skills sits last because it's experimental tooling rather than core suite.
+and eventually replaces the existing `geecs_scanner/tutorial.md`). Skills
+sits last because it's experimental tooling rather than core suite.
 
 ## When to put what where
 

--- a/docs/acquisition/index.md
+++ b/docs/acquisition/index.md
@@ -1,0 +1,27 @@
+# Acquisition
+
+Running scans on the beamline — configuring what gets saved, driving the
+scan, and capturing per-shot data and images into a structured scan folder.
+
+<div class="grid cards" markdown>
+
+-   :material-camera-iris:{ .lg .middle } **Scanner GUI**
+
+    ---
+
+    The PyQt5 data-acquisition application: connect to GEECS devices,
+    manage save elements, run single scans or multi-scan batches, and
+    drive Xopt-based optimization. The engine underneath is also usable
+    as a headless library from your own scripts.
+
+    [:octicons-arrow-right-24: Overview](../geecs_scanner/overview.md) ·
+    [Your first scan](../geecs_scanner/tutorial.md) ·
+    [Installation](../geecs_scanner/installation.md)
+
+</div>
+
+New to acquisition? The cross-package
+[Acquisition tutorial](../tutorials/acquisition.md) is the guided entry
+point; the Scanner GUI's own
+[Your First Scan](../geecs_scanner/tutorial.md) walkthrough goes deeper on
+the application itself.

--- a/docs/analysis/index.md
+++ b/docs/analysis/index.md
@@ -1,0 +1,47 @@
+# Analysis
+
+Everything for turning acquired scan data into results — per-image
+processing, per-scan orchestration, and the path/loading layer they both
+build on. If you have a scan folder on the data server and want to make
+sense of what's in it, start here.
+
+<div class="grid cards" markdown>
+
+-   :material-image-filter-center-focus:{ .lg .middle } **Image Analysis**
+
+    ---
+
+    Per-shot image processing: YAML-described pipelines (background,
+    masking, filtering, geometric transforms, thresholding) and
+    specialised analyzers for beam profile, FROG, magspec, HASO
+    wavefront, and 1D traces.
+
+    [:octicons-arrow-right-24: Overview](../image_analysis/overview.md) ·
+    [Analyzer index](../image_analysis/analyzer_index.md)
+
+-   :material-chart-areaspline:{ .lg .middle } **Scan Analysis**
+
+    ---
+
+    Orchestrates analysis across a complete scan — shot binning, per-bin
+    processing, summary-figure rendering, s-file appending — interactively
+    or as a `LiveTaskRunner` that processes scans as they complete.
+
+    [:octicons-arrow-right-24: Overview](../scan_analysis/overview.md)
+
+-   :material-database-search:{ .lg .middle } **Data Utils**
+
+    ---
+
+    The foundational data layer: resolve `(experiment, date, scan_number)`
+    to an on-disk path, load s-files, and use the common data structures
+    the rest of the suite is built on. Usually a dependency, sometimes a
+    direct import for ad-hoc exploration.
+
+    [:octicons-arrow-right-24: Overview](../geecs_data_utils/overview.md)
+
+</div>
+
+New to the analysis side? The cross-package
+[Analysis tutorial](../tutorials/analysis.md) walks the end-to-end path:
+configure analyzers, run them over a scan, and read the results back.

--- a/docs/platform/index.md
+++ b/docs/platform/index.md
@@ -1,0 +1,51 @@
+# Platform
+
+The access-and-contract layer everything else sits on: how you talk to
+GEECS devices, how GEECS is exposed to the wider EPICS ecosystem, and how a
+scan and its data are described.
+
+<div class="grid cards" markdown>
+
+-   :material-lan-connect:{ .lg .middle } **Python API**
+
+    ---
+
+    The low-level Python interface to the GEECS control system — the
+    GEECS wire protocol (UDP command/response, TCP live subscription),
+    device and variable objects, the experiment database, and the shared
+    [`config.ini`](../geecs_python_api/scripting_guide.md). Most tools use
+    it indirectly; the scripting guide covers direct use.
+
+    [:octicons-arrow-right-24: Overview](../geecs_python_api/overview.md) ·
+    [Scripting guide](../geecs_python_api/scripting_guide.md)
+
+-   :material-transit-connection-variant:{ .lg .middle } **GEECS Gateway**
+
+    ---
+
+    The GEECS access layer as an EPICS soft-IOC: a caproto Channel Access
+    server that mirrors GEECS devices as PVs, so Phoebus, an Archiver
+    Appliance, or ophyd-async / Bluesky can talk to GEECS like any other
+    IOC — no bespoke bridge required.
+
+    [:octicons-arrow-right-24: Client overview](../geecs_gateway/client_overview.md)
+
+-   :material-file-tree:{ .lg .middle } **GEECS Schemas**
+
+    ---
+
+    The typed contract for how a scan is described: the handful of config
+    kinds that drive the engine, in plain language, plus a per-field
+    reference generated straight from the code so it can never drift.
+
+    [:octicons-arrow-right-24: Scanner configs](../geecs_schemas/schemas_overview.md) ·
+    [Running a scan](../geecs_schemas/running_a_scan.md) ·
+    [Schema reference](../geecs_schemas/schema_reference.md)
+
+</div>
+
+!!! note "Python API is under refactoring"
+
+    The Python API is being reworked. Treat `ScanDevice` and the
+    experiment-database lookup as the stable public surface; other
+    internals may move.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -42,74 +42,81 @@ nav:
       - Acquisition: tutorials/acquisition.md
       - Analysis: tutorials/analysis.md
 
-  - GEECS Scanner GUI:
-      - Overview: geecs_scanner/overview.md
-      - Installation & Setup: geecs_scanner/installation.md
-      - Tutorial — Your First Scan: geecs_scanner/tutorial.md
-      - Save Elements: geecs_scanner/save_elements.md
-      - Scan Output Structure: geecs_scanner/scan_output_structure.md
-      - Running Optimizations: geecs_scanner/optimization.md
-      - Troubleshooting: geecs_scanner/troubleshooting.md
-      - Extending the Scanner: geecs_scanner/extending.md
-      - Architecture: geecs_scanner/architecture.md
-      - API Reference:
-          - Engine Configuration Models: geecs_scanner/api/engine_models.md
-          - Scan Events: geecs_scanner/api/scan_events.md
-          - Optimization:
-              - Base Evaluator: geecs_scanner/api/optimization/base_evaluator.md
-              - Base Optimizer: geecs_scanner/api/optimization/base_optimizer.md
-              - Generators:
-                  - Generator Factory: geecs_scanner/api/optimization/generators/generator_factory.md
-                  - Cheetah Generator: geecs_scanner/api/optimization/generators/cheetah_generator.md
-      - Examples:
-          - Basic Optimization Setup: geecs_scanner/examples/optimization/optimization_example.ipynb
-      - Notes and Discussions:
-          - Bayesian optimization for e-beam brightness: geecs_scanner/notes_and_discussions/optimization/bayesian optimization for e-beam brightness.md
+  # Purpose-grouped tabs. Each group opens on its section-index landing
+  # page (navigation.indexes) and holds one section per package, so the
+  # top-level nav is organised by what you're trying to do rather than
+  # one tab per package. To document a new package, add a section under
+  # the group that matches its audience.
+  - Acquisition:
+      - acquisition/index.md
+      - Scanner GUI:
+          - Overview: geecs_scanner/overview.md
+          - Installation & Setup: geecs_scanner/installation.md
+          - Tutorial — Your First Scan: geecs_scanner/tutorial.md
+          - Save Elements: geecs_scanner/save_elements.md
+          - Scan Output Structure: geecs_scanner/scan_output_structure.md
+          - Running Optimizations: geecs_scanner/optimization.md
+          - Troubleshooting: geecs_scanner/troubleshooting.md
+          - Extending the Scanner: geecs_scanner/extending.md
+          - Architecture: geecs_scanner/architecture.md
+          - API Reference:
+              - Engine Configuration Models: geecs_scanner/api/engine_models.md
+              - Scan Events: geecs_scanner/api/scan_events.md
+              - Optimization:
+                  - Base Evaluator: geecs_scanner/api/optimization/base_evaluator.md
+                  - Base Optimizer: geecs_scanner/api/optimization/base_optimizer.md
+                  - Generators:
+                      - Generator Factory: geecs_scanner/api/optimization/generators/generator_factory.md
+                      - Cheetah Generator: geecs_scanner/api/optimization/generators/cheetah_generator.md
+          - Examples:
+              - Basic Optimization Setup: geecs_scanner/examples/optimization/optimization_example.ipynb
+          - Notes and Discussions:
+              - Bayesian optimization for e-beam brightness: geecs_scanner/notes_and_discussions/optimization/bayesian optimization for e-beam brightness.md
 
-  - Image Analysis:
-      - Overview: image_analysis/overview.md
-      - Analyzer Index: image_analysis/analyzer_index.md
-      - API Reference:
-          - Core Modules: image_analysis/api/core_modules.md
-      - Examples:
-          - Basic Offline Analysis: image_analysis/examples/basic_usage_image_analyzer.ipynb
-          - Basic Usage — 1D Analyzer: image_analysis/examples/basic_usage_1D_analyzer.ipynb
-          - Grenouille Analysis: image_analysis/examples/grenouille_analysis.ipynb
-          - HasoLift Analysis: image_analysis/examples/HasoLift_analysis.ipynb
+  - Analysis:
+      - analysis/index.md
+      - Image Analysis:
+          - Overview: image_analysis/overview.md
+          - Analyzer Index: image_analysis/analyzer_index.md
+          - API Reference:
+              - Core Modules: image_analysis/api/core_modules.md
+          - Examples:
+              - Basic Offline Analysis: image_analysis/examples/basic_usage_image_analyzer.ipynb
+              - Basic Usage — 1D Analyzer: image_analysis/examples/basic_usage_1D_analyzer.ipynb
+              - Grenouille Analysis: image_analysis/examples/grenouille_analysis.ipynb
+              - HasoLift Analysis: image_analysis/examples/HasoLift_analysis.ipynb
+      - Scan Analysis:
+          - Overview: scan_analysis/overview.md
+          - API Reference:
+              - Core Modules: scan_analysis/api/base.md
+          - Examples:
+              - Basic Usage (2D): scan_analysis/examples/basic_usage.ipynb
+              - Basic Usage (1D): scan_analysis/examples/basic_usage_1D.ipynb
+              - Live Watch: scan_analysis/examples/live_watch.ipynb
+              - GDoc Upload: scan_analysis/examples/gdoc_upload.ipynb
+              - Scatter Plot Analysis: scan_analysis/examples/scatter_plot_analysis.ipynb
+      - Data Utils:
+          - Overview: geecs_data_utils/overview.md
+          - API Reference:
+              - Core Modules: geecs_data_utils/api/core_modules.md
+          - Examples:
+              - Basic Usage: geecs_data_utils/examples/basic_usage.ipynb
+              - Correlation Analysis: geecs_data_utils/examples/correlation_analysis.ipynb
+              - Scan Database Utils: geecs_data_utils/examples/scans_database_utils.ipynb
 
-  - Scan Analysis:
-      - Overview: scan_analysis/overview.md
-      - API Reference:
-          - Core Modules: scan_analysis/api/base.md
-      - Examples:
-          - Basic Usage (2D): scan_analysis/examples/basic_usage.ipynb
-          - Basic Usage (1D): scan_analysis/examples/basic_usage_1D.ipynb
-          - Live Watch: scan_analysis/examples/live_watch.ipynb
-          - GDoc Upload: scan_analysis/examples/gdoc_upload.ipynb
-          - Scatter Plot Analysis: scan_analysis/examples/scatter_plot_analysis.ipynb
-
-  - GEECS Python API:
-      - Overview: geecs_python_api/overview.md
-      - Scripting Guide: geecs_python_api/scripting_guide.md
-      - API Reference:
-          - Controls: geecs_python_api/api/controls.md
-
-  - Data Utils:
-      - Overview: geecs_data_utils/overview.md
-      - API Reference:
-          - Core Modules: geecs_data_utils/api/core_modules.md
-      - Examples:
-          - Basic Usage: geecs_data_utils/examples/basic_usage.ipynb
-          - Correlation Analysis: geecs_data_utils/examples/correlation_analysis.ipynb
-          - Scan Database Utils: geecs_data_utils/examples/scans_database_utils.ipynb
-
-  - GEECS Schemas:
-      - Scanner Configs Overview: geecs_schemas/schemas_overview.md
-      - Running a Scan: geecs_schemas/running_a_scan.md
-      - Schema Reference: geecs_schemas/schema_reference.md
-
-  - GEECS Gateway:
-      - Client Overview: geecs_gateway/client_overview.md
+  - Platform:
+      - platform/index.md
+      - Python API:
+          - Overview: geecs_python_api/overview.md
+          - Scripting Guide: geecs_python_api/scripting_guide.md
+          - API Reference:
+              - Controls: geecs_python_api/api/controls.md
+      - GEECS Gateway:
+          - Client Overview: geecs_gateway/client_overview.md
+      - GEECS Schemas:
+          - Scanner Configs Overview: geecs_schemas/schemas_overview.md
+          - Running a Scan: geecs_schemas/running_a_scan.md
+          - Schema Reference: geecs_schemas/schema_reference.md
 
   # Skills is intentionally last — experimental (agentic tooling), not core suite.
   - Skills:


### PR DESCRIPTION
## Why

The published docs site had grown to **ten top-level tabs** — one per package (Scanner GUI, Image Analysis, Scan Analysis, Python API, Data Utils, Schemas, Gateway, plus Home/Tutorials/Skills). Flagged by the maintainer as hard to navigate. This regroups the nav **by audience/purpose** instead of one-tab-per-package.

## What changed

Top-level tabs collapse from **10 → 6**:

`Home · Tutorials · Acquisition · Analysis · Platform · Skills`

| Group | Packages (now nav *sections*, not tabs) |
|---|---|
| **Acquisition** | Scanner GUI |
| **Analysis** | Image Analysis, Scan Analysis, Data Utils |
| **Platform** | Python API, GEECS Gateway, GEECS Schemas |

- Each group opens on a short **section-index landing page** (`docs/{acquisition,analysis,platform}/index.md`) via the `navigation.indexes` theme feature — it orients the reader and links to the constituent packages with grid cards.
- Each package is now a nav **section** under its group (`navigation.sections`); every existing page is preserved at its existing path, so all relative links still resolve.
- This is a **pure IA/nav reorganization** — no page content was rewritten. The only new content is the three small landing pages.
- `docs/CLAUDE.md` updated to document the new canonical ordering and the "add a section under the matching group" rule that replaces one-tab-per-package sprawl.

## Verification

- `poetry run mkdocs build` exits **0**, no broken-link or nav warnings introduced.
- Rendered top-level tabs confirmed to be exactly the six above; Platform/Analysis/Acquisition sections nest correctly.
- `pre-commit run` (check-yaml etc.) passes on all changed files.
- The one `--strict` warning (`GEECS-Data-Utils/.../scan_paths.py:333` griffe docstring/signature mismatch) is **pre-existing** and unrelated to this change.

## Note for review — Schemas placement

Following the maintainer's stated grouping, **GEECS Schemas** lives under **Platform** (Gateway + Schemas + Python API = the access/contract layer). Its content ("Scanner Configs, Explained", "Running a scan the new way") is fairly acquisition-flavoured, so if you'd rather it sit under **Acquisition**, it's a one-block move in `mkdocs.yml` + a card swap between the two landing pages — happy to adjust.

🤖 Generated with [Claude Code](https://claude.com/claude-code)