### PR TITLE
Scan-variable & PV-metadata vocabulary (confirm, .DESC, PseudoComponent)

### DIFF
--- a/GEECS-Schemas/CHANGELOG.md
+++ b/GEECS-Schemas/CHANGELOG.md
@@ -5,6 +5,29 @@ All notable changes to GEECS-Schemas are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.0] - 2026-07-09
+
+### Changed
+
+- **`PseudoTarget` renamed to `PseudoComponent`.** A `PseudoScanVariable`
+  *contains* a `list[PseudoComponent]`; the old name collided conceptually
+  with the element's own `target` field, and the legacy composite-variable
+  dialect already called these *components*. Field names (`targets`,
+  `forward`) and all serialized output are unchanged — this is a class rename
+  only. The export in `geecs_schemas.__all__` moves accordingly.
+
+### Added
+
+- **`ScanVariable.confirm`** — an optional `Device:Variable` naming the
+  variable that *measures* the result when it differs from the variable being
+  *set*. It documents the "topology C" split (e.g. the EMQ triplet, whose
+  catalog entry sets `Current_Limit.ChN` while the measured current is a
+  separate variable that GEECS's set-completion never checks). Additive,
+  defaults to `None` (⇒ prior behavior), validated as a `Device:Variable`.
+  **Declared but not yet enforced by the engine** — and deliberately carries
+  no tolerance field (the match tolerance is a device fact that stays below
+  the configs). See `Planning/scan_variable_metadata/00_overview.md`.
+
 ## [0.5.0] - 2026-07-08
 
 ### Added

--- a/GEECS-Schemas/geecs_schemas/__init__.py
+++ b/GEECS-Schemas/geecs_schemas/__init__.py
@@ -42,8 +42,8 @@ from geecs_schemas.scan_request import (
 )
 from geecs_schemas.scan_variables import (
     CompositeMode,
+    PseudoComponent,
     PseudoScanVariable,
-    PseudoTarget,
     ScanVariable,
     ScanVariables,
     ScanVariableSpec,
@@ -83,7 +83,7 @@ __all__ = [
     "ScanVariable",
     "ScanVariableSpec",
     "PseudoScanVariable",
-    "PseudoTarget",
+    "PseudoComponent",
     "CompositeMode",
     # trigger_profile
     "TriggerProfile",

--- a/GEECS-Schemas/geecs_schemas/scan_variables.py
+++ b/GEECS-Schemas/geecs_schemas/scan_variables.py
@@ -18,14 +18,20 @@ an ``absolute``/``relative`` mode).
 - ``kind: motor`` — blocking move *plus* readback-tolerance polling; an
   explicit opt-in for real positioners (renders to ``CaMotor``).
 - ``kind: pseudo`` — a pseudo-positioner: one scanned number fanned out to
-  several targets through ``forward`` expressions.  v1 keeps the legacy
+  several components through ``forward`` expressions.  v1 keeps the legacy
   numexpr semantics **verbatim**: each expression is written in terms of
   ``composite_var`` (the scanned value), and ``mode`` keeps the legacy
-  meaning — ``absolute`` sets each target to its expression's value,
-  ``relative`` offsets each target from its position at scan start.
+  meaning — ``absolute`` sets each component to its expression's value,
+  ``relative`` offsets each component from its position at scan start.
 
 Limits, units, and tolerances deliberately do **not** live here — device
 facts belong below the configs (gateway PV metadata; vision doc §4.3).
+
+The optional ``confirm`` field on a simple :class:`ScanVariable` is the one
+place a scan variable names a *second* device variable: it covers the case
+where the variable you *set* is not the variable that *measures* the result
+(the "topology C" gap — see :class:`ScanVariable`).  It is declared but not
+yet enforced by the engine in v1.
 """
 
 from __future__ import annotations
@@ -65,6 +71,22 @@ def _validate_target(value: str) -> str:
     return value
 
 
+def _validate_optional_target(value: Optional[str]) -> Optional[str]:
+    """Validate an optional ``Device:Variable`` string, passing ``None`` through.
+
+    Parameters
+    ----------
+    value : str or None
+        Candidate target string, or ``None`` when the field is unset.
+
+    Returns
+    -------
+    str or None
+        The validated string, or ``None`` unchanged.
+    """
+    return value if value is None else _validate_target(value)
+
+
 class CompositeMode(str, Enum):
     """How a pseudo variable's targets interpret the scanned value.
 
@@ -86,6 +108,26 @@ class ScanVariable(SchemaModel):
 
     Points a human-readable name at the ``Device:Variable`` it moves, and
     says whether it is a plain setpoint or a motor with position readback.
+
+    Notes
+    -----
+    Most scan variables are the simple case: the variable you *set* is also
+    the variable that *measures* the result (a stage's ``Position.Axis N``, a
+    steering-magnet ``Current``), so completion can be judged on the same
+    name.  For those, leave ``confirm`` unset.
+
+    Some devices split the two — you set one variable but a *different*
+    variable reports the physical truth.  The production example is the EMQ
+    triplet: the catalog's "EMQ1 Current" writes
+    ``U_EMQTripletBipolar:Current_Limit.Ch1`` (a software limit), while the
+    measured current is a separate variable.  GEECS binds its set-completion
+    tolerance to the *written* variable, so such a set "confirms" against a
+    value that is trivially correct and the real current is never checked.
+    ``confirm`` names the measured variable so this split is at least
+    **visible** in the config; enforcing it (a device whose ``set()``
+    completes on the confirming variable) is a later engine milestone.  The
+    match *tolerance* is a device fact and stays below the configs (the DB /
+    gateway PV metadata), not here.
     """
 
     target: str = Field(
@@ -102,15 +144,26 @@ class ScanVariable(SchemaModel):
             "the device reports it arrived — use for real positioners."
         ),
     )
+    confirm: Optional[str] = Field(
+        None,
+        description=(
+            "Optional 'Device:Variable' that *measures* the result when it "
+            "differs from the variable being set — e.g. set a supply's "
+            "current limit but confirm on its measured current. Leave unset "
+            "when the set variable is also the readback (the common case). "
+            "Declared but not yet enforced by the engine in v1."
+        ),
+    )
 
     _check_target = field_validator("target")(_validate_target)
+    _check_confirm = field_validator("confirm")(_validate_optional_target)
 
 
-class PseudoTarget(SchemaModel):
+class PseudoComponent(SchemaModel):
     """One device a pseudo variable moves, and the formula for its value.
 
-    The ``forward`` expression computes this target's setting from the single
-    scanned number, which appears in the formula as ``composite_var``.
+    The ``forward`` expression computes this component's setting from the
+    single scanned number, which appears in the formula as ``composite_var``.
     """
 
     target: str = Field(
@@ -149,7 +202,7 @@ class PseudoScanVariable(SchemaModel):
     kind: Literal["pseudo"] = Field(
         description="Variable type. 'pseudo' moves several devices from one number."
     )
-    targets: list[PseudoTarget] = Field(
+    targets: list[PseudoComponent] = Field(
         min_length=1,
         description="The devices this variable moves, each with its own formula.",
     )

--- a/GEECS-Schemas/pyproject.toml
+++ b/GEECS-Schemas/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-schemas"
-version = "0.5.0"
+version = "0.6.0"
 description = "Versioned Pydantic schemas for GEECS scanner configs (scan requests, save sets, scan variables, trigger profiles, action plans) plus legacy-YAML converters."
 authors = ["Sam Barber <sbarber@lbl.gov>"]
 readme = "README.md"

--- a/GEECS-Schemas/tests/golden/thomson_scan_variables.json
+++ b/GEECS-Schemas/tests/golden/thomson_scan_variables.json
@@ -2,70 +2,87 @@
   "schema_version": 1,
   "variables": {
     "ASSERT-Stage_TestBench": {
+      "confirm": null,
       "kind": "setpoint",
       "target": "ASSERT-LensStage:Position.Ch1"
     },
     "Assert-Ctrl-BProfiler-LRes": {
+      "confirm": null,
       "kind": "setpoint",
       "target": "Assert-Ctrl_BProfiler-LRes:Position.Ch1"
     },
     "Blade-Z": {
+      "confirm": null,
       "kind": "setpoint",
       "target": "HTT-ESP02:Position.Axis 3"
     },
     "Compressor: Grating Separation": {
+      "confirm": null,
       "kind": "setpoint",
       "target": "HTT-Aerotech:Position.Axis1"
     },
     "Ghost Stage": {
+      "confirm": null,
       "kind": "setpoint",
       "target": "HTT-ESP06:Position.Axis 3"
     },
     "HP Mode Imager": {
+      "confirm": null,
       "kind": "setpoint",
       "target": "HTT-ESP06:Position.Axis 1"
     },
     "Jet x": {
+      "confirm": null,
       "kind": "setpoint",
       "target": "HTT-ESP01:Position.Axis 1"
     },
     "Jet z": {
+      "confirm": null,
       "kind": "setpoint",
       "target": "HTT-ESP01:Position.Axis 3"
     },
     "LP Mode Imager": {
+      "confirm": null,
       "kind": "setpoint",
       "target": "HTT-LPModeStage:position"
     },
     "Pressure Scan": {
+      "confirm": null,
       "kind": "setpoint",
       "target": "HTT-HighPressureDAQ:AnalogOutput.Channel 0"
     },
     "Probe Delay Short": {
+      "confirm": null,
       "kind": "setpoint",
       "target": "HTT-ESP04:Position.Axis 3"
     },
     "Probe Delay: Long": {
+      "confirm": null,
       "kind": "setpoint",
       "target": "HTT_ProbeLongDelay:position"
     },
     "QAtt-DS": {
+      "confirm": null,
       "kind": "setpoint",
       "target": "HTT-B-Zaber_Chain-B:Position.Ch3"
     },
     "QAtt-US": {
+      "confirm": null,
       "kind": "setpoint",
       "target": "HTT-B-Zaber_Chain-B:Position.Ch2"
     },
     "Quad-x": {
+      "confirm": null,
       "kind": "setpoint",
       "target": "HTT-B-Zaber_Chain-B:Position.Ch3"
     },
     "Quad-y": {
+      "confirm": null,
       "kind": "setpoint",
       "target": "HTT-B-Zaber_Chain-B:Position.Ch5"
     },
     "Quad-z": {
+      "confirm": null,
       "kind": "setpoint",
       "target": "HTT-B-Zaber_Chain-B:Position.Ch4"
     },

--- a/GEECS-Schemas/tests/golden/undulator_scan_variables.json
+++ b/GEECS-Schemas/tests/golden/undulator_scan_variables.json
@@ -62,10 +62,12 @@
       ]
     },
     "BCaveMagSepecCurrent": {
+      "confirm": null,
       "kind": "setpoint",
       "target": "U_BCaveMagSpecPS:Current_Limit.Ch1"
     },
     "Centtronic DUT position": {
+      "confirm": null,
       "kind": "setpoint",
       "target": "U_ASSERT_Stages:Position.Ch2"
     },
@@ -85,34 +87,42 @@
       ]
     },
     "DonD Dipole": {
+      "confirm": null,
       "kind": "setpoint",
       "target": "U_DonD_DCStages:Position.Axis 1"
     },
     "DonD Q12 Gap": {
+      "confirm": null,
       "kind": "setpoint",
       "target": "U_DonD_Q12_Gap:Position"
     },
     "DonD Q34 Gap": {
+      "confirm": null,
       "kind": "setpoint",
       "target": "U_DonD_DCStages:Position.Axis 3"
     },
     "DonD Q34 Transverse": {
+      "confirm": null,
       "kind": "setpoint",
       "target": "U_DonD_DCStages:Position.Axis 2"
     },
     "DonDQ12": {
+      "confirm": null,
       "kind": "setpoint",
       "target": "U_DonD_Q12_Gap:Position"
     },
     "EMQ1 Current": {
+      "confirm": null,
       "kind": "setpoint",
       "target": "U_EMQTripletBipolar:Current_Limit.Ch1"
     },
     "EMQ2 Current": {
+      "confirm": null,
       "kind": "setpoint",
       "target": "U_EMQTripletBipolar:Current_Limit.Ch2"
     },
     "EMQ3 Current": {
+      "confirm": null,
       "kind": "setpoint",
       "target": "U_EMQTripletBipolar:Current_Limit.Ch3"
     },
@@ -132,18 +142,22 @@
       ]
     },
     "Gaia Lamp timing": {
+      "confirm": null,
       "kind": "setpoint",
       "target": "U_1HzShiftedBox:delay.Channel_C"
     },
     "Gas Pressure": {
+      "confirm": null,
       "kind": "setpoint",
       "target": "U_HP_Daq:AnalogOutput.Channel 1"
     },
     "Ghost Focus": {
+      "confirm": null,
       "kind": "setpoint",
       "target": "U_Zaber:Position.Ch2"
     },
     "Grating Separation (um)": {
+      "confirm": null,
       "kind": "setpoint",
       "target": "U_CompAerotech:Position.Axis1"
     },
@@ -193,42 +207,52 @@
       ]
     },
     "Hexapod Angle U": {
+      "confirm": null,
       "kind": "setpoint",
       "target": "U_Hexapod:uangle"
     },
     "Hexapod Angle V": {
+      "confirm": null,
       "kind": "setpoint",
       "target": "U_Hexapod:vangle"
     },
     "Hexapod Angle W": {
+      "confirm": null,
       "kind": "setpoint",
       "target": "U_Hexapod:wangle"
     },
     "Hexapod X": {
+      "confirm": null,
       "kind": "setpoint",
       "target": "U_Hexapod:xpos"
     },
     "Hexapod Y": {
+      "confirm": null,
       "kind": "setpoint",
       "target": "U_Hexapod:ypos"
     },
     "Hexapod Z": {
+      "confirm": null,
       "kind": "setpoint",
       "target": "U_Hexapod:zpos"
     },
     "Jet Blade": {
+      "confirm": null,
       "kind": "setpoint",
       "target": "U_ModeImagerESP:Position.Axis 2"
     },
     "JetX (mm)": {
+      "confirm": null,
       "kind": "setpoint",
       "target": "U_ESP_JetXYZ:Position.Axis 1"
     },
     "JetY (mm)": {
+      "confirm": null,
       "kind": "setpoint",
       "target": "U_ESP_JetXYZ:Position.Axis 2"
     },
     "JetZ (mm)": {
+      "confirm": null,
       "kind": "setpoint",
       "target": "U_ESP_JetXYZ:Position.Axis 3"
     },
@@ -263,6 +287,7 @@
       ]
     },
     "Mode Imager Stage": {
+      "confirm": null,
       "kind": "setpoint",
       "target": "U_ModeImagerESP:Position.Axis 1"
     },
@@ -282,90 +307,112 @@
       ]
     },
     "S1H": {
+      "confirm": null,
       "kind": "setpoint",
       "target": "U_S1H:Current"
     },
     "S1V": {
+      "confirm": null,
       "kind": "setpoint",
       "target": "U_S1V:Current"
     },
     "S2H": {
+      "confirm": null,
       "kind": "setpoint",
       "target": "U_S2H:Current"
     },
     "S2V": {
+      "confirm": null,
       "kind": "setpoint",
       "target": "U_S2V:Current"
     },
     "S3H": {
+      "confirm": null,
       "kind": "setpoint",
       "target": "U_S3H:Current"
     },
     "S3V": {
+      "confirm": null,
       "kind": "setpoint",
       "target": "U_S3V:Current"
     },
     "S4H": {
+      "confirm": null,
       "kind": "setpoint",
       "target": "U_S4H:Current"
     },
     "S4V": {
+      "confirm": null,
       "kind": "setpoint",
       "target": "U_S4V:Current"
     },
     "VS1H": {
+      "confirm": null,
       "kind": "setpoint",
       "target": "U_VS1H:Current"
     },
     "VS1V": {
+      "confirm": null,
       "kind": "setpoint",
       "target": "U_VS1V:Current"
     },
     "VS2H": {
+      "confirm": null,
       "kind": "setpoint",
       "target": "U_VS2H:Current"
     },
     "VS2V": {
+      "confirm": null,
       "kind": "setpoint",
       "target": "U_VS2V:Current"
     },
     "VS3H": {
+      "confirm": null,
       "kind": "setpoint",
       "target": "U_VS3H:Current"
     },
     "VS3V": {
+      "confirm": null,
       "kind": "setpoint",
       "target": "U_VS3V:Current"
     },
     "VS4H": {
+      "confirm": null,
       "kind": "setpoint",
       "target": "U_VS4H:Current"
     },
     "VS4V": {
+      "confirm": null,
       "kind": "setpoint",
       "target": "U_VS4V:Current"
     },
     "gaia_Qswitch_time": {
+      "confirm": null,
       "kind": "setpoint",
       "target": "U_1HzShiftedBox:delay.Channel_A"
     },
     "gas jet start time": {
+      "confirm": null,
       "kind": "setpoint",
       "target": "U_DG645_ShotControl:Delay.Ch A"
     },
     "haso stage": {
+      "confirm": null,
       "kind": "setpoint",
       "target": "U_Zaber:Position.Ch1"
     },
     "jet opening time": {
+      "confirm": null,
       "kind": "setpoint",
       "target": "U_DG645_ShotControl:Delay.Ch B"
     },
     "probe cam stage": {
+      "confirm": null,
       "kind": "setpoint",
       "target": "U_ProbeCamStage:Position"
     },
     "thorlabs dut position": {
+      "confirm": null,
       "kind": "setpoint",
       "target": "U_ASSERT_Stages:Position.Ch1"
     }

--- a/GEECS-Schemas/tests/test_scan_variables.py
+++ b/GEECS-Schemas/tests/test_scan_variables.py
@@ -5,6 +5,7 @@ from pydantic import ValidationError
 
 from geecs_schemas import (
     CompositeMode,
+    PseudoComponent,
     PseudoScanVariable,
     ScanVariable,
     ScanVariables,
@@ -49,7 +50,35 @@ class TestScanVariables:
         pseudo = make_catalog().variables["e_beam_angle_x"]
         assert isinstance(pseudo, PseudoScanVariable)
         assert pseudo.mode is CompositeMode.RELATIVE
+        assert isinstance(pseudo.targets[1], PseudoComponent)
         assert pseudo.targets[1].forward == "composite_var * -2"
+
+    def test_confirm_defaults_to_none(self):
+        simple = make_catalog().variables["gas_pressure"]
+        assert isinstance(simple, ScanVariable)
+        assert simple.confirm is None
+
+    def test_confirm_accepts_measured_variable(self):
+        # Topology C: set a software current limit, confirm on measured current.
+        catalog = ScanVariables.model_validate(
+            {
+                "variables": {
+                    "EMQ1 Current": {
+                        "target": "U_EMQTripletBipolar:Current_Limit.Ch1",
+                        "confirm": "U_EMQTripletBipolar:Current.Ch1",
+                    }
+                }
+            }
+        )
+        entry = catalog.variables["EMQ1 Current"]
+        assert isinstance(entry, ScanVariable)
+        assert entry.confirm == "U_EMQTripletBipolar:Current.Ch1"
+
+    def test_confirm_shape_enforced(self):
+        with pytest.raises(ValidationError, match="Device:Variable"):
+            ScanVariables.model_validate(
+                {"variables": {"bad": {"target": "A:B", "confirm": "no-colon-here"}}}
+            )
 
     def test_target_shape_enforced(self):
         with pytest.raises(ValidationError, match="Device:Variable"):

--- a/GeecsBluesky/CHANGELOG.md
+++ b/GeecsBluesky/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to `geecs-bluesky` are documented here.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.24.1] - 2026-07-09
+
+### Documentation
+
+- **CaSettable / CaMotor docstring honesty.** Corrected the framing that
+  `motor` is *the* way to declare a positioner and `CaSettable` is unsafe for
+  stages. A plain `CaSettable` already waits for GEECS's native blocking
+  set-completion; `CaMotor`'s readback poll only adds information when the
+  readback is an *independent* measurement of the same variable (a stage
+  encoder), and is near-cosmetic when the readback merely echoes the command.
+  Both docstrings now also note the topology neither class covers — a device
+  whose measured variable differs from the one set (the EMQ triplet) — which
+  the schema names via `ScanVariable.confirm`. No code change.
+
 ## [0.24.0] - 2026-07-08
 
 M3c — the DB-integration runtime tier lands, wiring the two-tier recording

--- a/GeecsBluesky/geecs_bluesky/devices/ca/motor.py
+++ b/GeecsBluesky/geecs_bluesky/devices/ca/motor.py
@@ -12,6 +12,16 @@ layers of convergence:
    ``tolerance`` of the target — belt-and-suspenders for the fringe cases where
    the UDP set's own timeout semantics are ambiguous (devices that go quiet
    during a move vs. genuinely stuck axes).
+
+Layer 1 alone (i.e. a plain :class:`~geecs_bluesky.devices.ca.settable.CaSettable`)
+already waits for GEECS convergence, so CaMotor is *not* "the way to make a
+set block."  Its Layer 2 poll only adds information when the readback is an
+independent measurement of the same variable that was set — a stage encoder,
+not a value that merely echoes the command.  It does **not** cover the case
+where the measured quantity is a *different* variable from the one set (the
+EMQ triplet's ``Current_Limit`` vs its measured current): the poll reads the
+readback of ``variable``, the variable it wrote.  ``ScanVariable.confirm``
+names that decoupled case in the schema; acting on it is a later milestone.
 """
 
 from __future__ import annotations

--- a/GeecsBluesky/geecs_bluesky/devices/ca/settable.py
+++ b/GeecsBluesky/geecs_bluesky/devices/ca/settable.py
@@ -6,8 +6,35 @@ The gateway exposes a settable GEECS variable as two PVs: a readback
 device writes the setpoint and reads back the real value — the CA counterpart of
 :class:`~geecs_bluesky.devices.settable.GeecsSettable`.
 
-For a position-feedback motor that must poll the readback until it converges, a
-future ``CaMotor`` would override ``_set_and_wait`` (mirroring ``GeecsMotor``).
+Completion semantics — CaSettable already waits
+-----------------------------------------------
+The ``:SP`` put is **not** fire-and-forget: the gateway forwards it as a
+GEECS UDP set, which itself blocks until the device reports the value
+converged (per the DB tolerance) or failed.  So a plain CaSettable already
+carries GEECS's native set-completion — it is a legitimate choice for a real
+positioner, not a lesser one.
+
+:class:`~geecs_bluesky.devices.ca.motor.CaMotor` adds *one* thing on top: a
+second poll of the streamed readback until it is within tolerance of the
+target.  That extra poll only carries information when the readback is an
+independent measurement that can lag or overshoot the commanded value (a
+stage encoder).  When the readback just echoes what was written, the poll is
+satisfied trivially and CaMotor is near-cosmetic.  Choose CaMotor when you do
+not fully trust GEECS's own set-completion for that axis — not because
+CaSettable "doesn't wait."
+
+The open question is empirical, not schema-shaped: how reliable is GEECS's
+blocking-set convergence for real stages?  If it is solid, CaMotor is nearly
+cosmetic; if it is not, CaSettable is the quietly-risky choice for anything
+mechanical.  That — not which ``kind`` a config declares — is where the real
+risk lives.
+
+Neither class covers the case where the variable you *set* differs from the
+variable that *measures* the result (the EMQ triplet's ``Current_Limit`` vs
+its measured current): CaMotor polls the readback of the *same* variable it
+set, so it cannot confirm a decoupled measurement.  The schema names that
+case via ``ScanVariable.confirm``; the device that would act on it is a later
+milestone.
 """
 
 from __future__ import annotations

--- a/GeecsBluesky/pyproject.toml
+++ b/GeecsBluesky/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-bluesky"
-version = "0.24.0"
+version = "0.24.1"
 description = "Bluesky / ophyd-async bridge for the GEECS control system"
 authors = ["Sam Barber <sbarber@lbl.gov>"]
 readme = "README.md"

--- a/GeecsCAGateway/CHANGELOG.md
+++ b/GeecsCAGateway/CHANGELOG.md
@@ -7,26 +7,23 @@ All notable changes to `geecs-ca-gateway` are documented here, following
 
 ### Added
 
-- **Per-PV `description` resolved from the DB** — a one-line human description
-  destined for a PV's `.DESC` field (Phoebus/archiver label). Both metadata
-  queries (`get_device_variables`, `get_experiment_device_variables`) now
-  select `variable.description` on the instance side (and `NULL` on the type
-  side, since the column exists only on the per-instance `variable` table),
-  resolved through the existing capability inheritance chain into
-  `VariableSpec.description`. Clipped to 40 chars (EPICS DBR_STRING) with a
-  warning. Verified end-to-end against the live DB.
+- **Per-PV `.DESC` field, resolved from the DB and served over CA.** A
+  variable's DB `description` (per-instance `variable` table, resolved through
+  the capability inheritance chain like every other field into
+  `VariableSpec.description`) is served as the standard EPICS `.DESC` field —
+  a read-only `<pv>.DESC` string channel added to the pvdb, so
+  `caget …:Current.DESC` returns the text and Phoebus/the archiver pick it up.
+  Only non-empty descriptions get a `.DESC` entry. Clipped to the 40-char
+  DBR_STRING limit at both the DB column and the gateway. Verified end-to-end
+  against the live DB and with a live CA client. Applies to readbacks and
+  derived channels; `:SP` and status PVs carry no `.DESC`. `PV_CONTRACT.md` §4
+  documents it; pinned by `test_gateway.test_description_served_as_desc_field`.
+  Discipline: `.DESC` carries *stable identity only*, never time-varying
+  provenance (a `.DESC` edit leaves no history).
 - `deploy/variable_description.sql` — non-destructive DDL to narrow
-  `variable.description` to the 40-char EPICS `.DESC` limit and (optionally,
-  gated on a code coalesce) add a type-level `devicetype_variable.description`.
-
-  **Not yet served over CA.** caproto's raw `ChannelData` pvdb (which this
-  gateway uses) has no `doc`/DESC kwarg, so serving the field needs explicit
-  `<pv>.DESC` channels or the field-aware record machinery — a `PV_CONTRACT.md`
-  change requiring live CA-client validation. `VariableSpec.description` is
-  resolved and ready; wiring it to a served field is the remaining step.
-  Discipline for whoever wires it: `.DESC` carries *stable identity only*,
-  never time-varying provenance (a `.DESC` edit leaves no history). See
-  `Planning/scan_variable_metadata/00_overview.md`.
+  `variable.description` to the 40-char EPICS `.DESC` limit (applied) and
+  (optionally, gated on a code coalesce) add a type-level
+  `devicetype_variable.description`.
 
 ## [0.9.0] - 2026-07-08
 

--- a/GeecsCAGateway/CHANGELOG.md
+++ b/GeecsCAGateway/CHANGELOG.md
@@ -3,6 +3,25 @@
 All notable changes to `geecs-ca-gateway` are documented here, following
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and semantic versioning.
 
+## [0.10.0] - 2026-07-09
+
+### Added
+
+- **`VariableSpec.description`** — a one-line human description destined for a
+  PV's `.DESC` field (Phoebus/archiver label). Clipped to 40 chars (EPICS
+  DBR_STRING) with a warning. `DeviceSpec.from_db_metadata` reads it from
+  `meta.get("description")`, which is simply absent today (⇒ `""`, inert), so
+  nothing changes for the live gateway until the DB SELECT exposes the column.
+
+  **Plumbing only — the gateway does not yet serve `.DESC` over CA.** caproto's
+  raw `ChannelData` pvdb (which this gateway uses) has no `doc`/DESC kwarg, so
+  serving the field needs explicit `<pv>.DESC` channels or the field-aware
+  record machinery — a `PV_CONTRACT.md` change requiring live CA-client
+  validation. Discipline for whoever wires it: `.DESC` carries *stable
+  identity only*, never time-varying provenance (a `.DESC` edit leaves no
+  history). See `Planning/scan_variable_metadata/00_overview.md` (Deferred #1,
+  #2).
+
 ## [0.9.0] - 2026-07-08
 
 ### Added

--- a/GeecsCAGateway/CHANGELOG.md
+++ b/GeecsCAGateway/CHANGELOG.md
@@ -7,20 +7,26 @@ All notable changes to `geecs-ca-gateway` are documented here, following
 
 ### Added
 
-- **`VariableSpec.description`** — a one-line human description destined for a
-  PV's `.DESC` field (Phoebus/archiver label). Clipped to 40 chars (EPICS
-  DBR_STRING) with a warning. `DeviceSpec.from_db_metadata` reads it from
-  `meta.get("description")`, which is simply absent today (⇒ `""`, inert), so
-  nothing changes for the live gateway until the DB SELECT exposes the column.
+- **Per-PV `description` resolved from the DB** — a one-line human description
+  destined for a PV's `.DESC` field (Phoebus/archiver label). Both metadata
+  queries (`get_device_variables`, `get_experiment_device_variables`) now
+  select `variable.description` on the instance side (and `NULL` on the type
+  side, since the column exists only on the per-instance `variable` table),
+  resolved through the existing capability inheritance chain into
+  `VariableSpec.description`. Clipped to 40 chars (EPICS DBR_STRING) with a
+  warning. Verified end-to-end against the live DB.
+- `deploy/variable_description.sql` — non-destructive DDL to narrow
+  `variable.description` to the 40-char EPICS `.DESC` limit and (optionally,
+  gated on a code coalesce) add a type-level `devicetype_variable.description`.
 
-  **Plumbing only — the gateway does not yet serve `.DESC` over CA.** caproto's
-  raw `ChannelData` pvdb (which this gateway uses) has no `doc`/DESC kwarg, so
-  serving the field needs explicit `<pv>.DESC` channels or the field-aware
-  record machinery — a `PV_CONTRACT.md` change requiring live CA-client
-  validation. Discipline for whoever wires it: `.DESC` carries *stable
-  identity only*, never time-varying provenance (a `.DESC` edit leaves no
-  history). See `Planning/scan_variable_metadata/00_overview.md` (Deferred #1,
-  #2).
+  **Not yet served over CA.** caproto's raw `ChannelData` pvdb (which this
+  gateway uses) has no `doc`/DESC kwarg, so serving the field needs explicit
+  `<pv>.DESC` channels or the field-aware record machinery — a `PV_CONTRACT.md`
+  change requiring live CA-client validation. `VariableSpec.description` is
+  resolved and ready; wiring it to a served field is the remaining step.
+  Discipline for whoever wires it: `.DESC` carries *stable identity only*,
+  never time-varying provenance (a `.DESC` edit leaves no history). See
+  `Planning/scan_variable_metadata/00_overview.md`.
 
 ## [0.9.0] - 2026-07-08
 

--- a/GeecsCAGateway/PV_CONTRACT.md
+++ b/GeecsCAGateway/PV_CONTRACT.md
@@ -330,6 +330,22 @@ Resolution quirks (all DB-driven, all pinned by tests):
   online analysis, which the contract requires be *reported*, not clamped.
   GEECS remains the authority on valid set values (§2).
 
+### Description — the `.DESC` field
+
+A variable's DB `description` (from the per-instance `variable` table,
+resolved through the capability inheritance chain like every other field) is
+served as the standard EPICS `.DESC` field: a read-only `<pv>.DESC` string
+channel, so `caget Undulator:U_S1H:Current.DESC` returns the text and Phoebus
+/ the archiver pick it up automatically. Only variables with a non-empty
+description get a `.DESC` entry (no empty descriptions are served). The text
+is clipped to the EPICS **DBR_STRING 40-character** limit at both the DB
+column (`VARCHAR(40)`) and in the gateway.
+
+`.DESC` carries **stable identity only** — it is a mutable label with no
+history (an edit leaves no archived trace), so time-varying provenance (a
+recalibration, a filter swap) belongs in git-tracked config or the elog, not
+here. Setpoint (`:SP`) and status PVs do not carry `.DESC`.
+
 ### Enum resolution — readback (string → index), **(PR #452)** order
 
 GEECS speaks the option *string* on the wire; CA speaks the option *index*.

--- a/GeecsCAGateway/deploy/variable_description.sql
+++ b/GeecsCAGateway/deploy/variable_description.sql
@@ -1,0 +1,48 @@
+-- Migration: PV .DESC support for GeecsCAGateway.
+--
+-- The gateway serves a per-PV one-line description (destined for the EPICS
+-- .DESC field: Phoebus/archiver label).  It reads `variable.description` —
+-- the per-instance override table — via the capability inheritance chain, and
+-- exposes it as `VariableSpec.description`.  This file makes two OPTIONAL,
+-- non-destructive schema adjustments; the gateway runs fine without either.
+--
+-- Apply from a host with access to the GEECS DB, for example:
+--
+--   mysql --host=<db-host> --user=<db-user> --password <db-name> \
+--     < deploy/variable_description.sql
+--
+-- ---------------------------------------------------------------------------
+-- 1. Match the columns to the EPICS .DESC limit (40 chars).
+--
+-- `variable.description` already exists as VARCHAR(1000).  EPICS DBR_STRING
+-- (the .DESC field) caps at 40 characters, and the gateway clips longer text
+-- with a warning (see VariableSpec._clip_description).  Narrowing the column
+-- makes the DB the constraint, so authoring tools reject an over-long
+-- description at write time instead of it silently truncating on the PV.
+--
+-- SAFETY: this truncates any EXISTING description longer than 40 chars.  As of
+-- this migration authoring, 0 of ~2641 rows are populated, so it is a no-op on
+-- data — but re-check before running if descriptions have since been added:
+--   SELECT id, device, name, CHAR_LENGTH(description) len FROM variable
+--     WHERE CHAR_LENGTH(description) > 40;
+ALTER TABLE variable MODIFY description VARCHAR(40) NULL;
+
+-- ---------------------------------------------------------------------------
+-- 2. (OPTIONAL) Add a type-level description default.
+--
+-- `description` currently exists only on the per-instance `variable` table, so
+-- a description requires a per-instance row.  Adding it to `devicetype_variable`
+-- lets one row describe every instance of a device type (e.g. all steering
+-- magnets' "Current").
+--
+-- NOTE: enabling this requires a matching CODE change.  The gateway's SELECTs
+-- currently take the type-side description as NULL and read only the instance
+-- column (see GeecsDb.get_device_variables / get_experiment_device_variables).
+-- Because the inheritance is WHOLESALE (an instance row overrides the type row
+-- in full), a type-level default would need a deliberate coalesce
+-- (instance.description, else type.description) rather than the standard
+-- whole-row replacement — otherwise an instance row with a NULL description
+-- would erase the type default.  Do not add this column until that coalesce is
+-- implemented and tested, or type descriptions will simply be ignored.
+--
+-- ALTER TABLE devicetype_variable ADD COLUMN description VARCHAR(40) NULL;

--- a/GeecsCAGateway/deploy/variable_description.sql
+++ b/GeecsCAGateway/deploy/variable_description.sql
@@ -12,19 +12,18 @@
 --     < deploy/variable_description.sql
 --
 -- ---------------------------------------------------------------------------
--- 1. Match the columns to the EPICS .DESC limit (40 chars).
+-- 1. Match the column to the EPICS .DESC limit (40 chars).  [APPLIED 2026-07-09]
 --
--- `variable.description` already exists as VARCHAR(1000).  EPICS DBR_STRING
--- (the .DESC field) caps at 40 characters, and the gateway clips longer text
--- with a warning (see VariableSpec._clip_description).  Narrowing the column
--- makes the DB the constraint, so authoring tools reject an over-long
--- description at write time instead of it silently truncating on the PV.
+-- `variable.description` existed as VARCHAR(1000).  EPICS DBR_STRING (the .DESC
+-- field) caps at 40 characters, and the gateway clips longer text with a
+-- warning (see VariableSpec._clip_description).  Narrowing the column makes the
+-- DB the constraint, so authoring tools reject an over-long description at
+-- write time instead of it silently truncating on the PV.
 --
--- SAFETY: this truncates any EXISTING description longer than 40 chars.  As of
--- this migration authoring, 0 of ~2641 rows are populated, so it is a no-op on
--- data — but re-check before running if descriptions have since been added:
+-- This was applied live on 2026-07-09 (0 rows exceeded 40 chars, so it was a
+-- no-op on data).  Kept here as the record; re-running is idempotent.
 --   SELECT id, device, name, CHAR_LENGTH(description) len FROM variable
---     WHERE CHAR_LENGTH(description) > 40;
+--     WHERE CHAR_LENGTH(description) > 40;   -- verify empty before re-running
 ALTER TABLE variable MODIFY description VARCHAR(40) NULL;
 
 -- ---------------------------------------------------------------------------

--- a/GeecsCAGateway/geecs_ca_gateway/channels.py
+++ b/GeecsCAGateway/geecs_ca_gateway/channels.py
@@ -295,6 +295,32 @@ def make_readback_channel(
     )
 
 
+# EPICS DBR_STRING (the .DESC field's native type) caps at 40 characters.
+_DESC_MAX_LENGTH = 40
+
+
+def make_description_channel(description: str) -> ChannelData:
+    """Build a read-only string channel serving a PV's ``.DESC`` field value.
+
+    The gateway serves ``.DESC`` the simple way: a plain ``<pv>.DESC`` entry in
+    the pvdb dict, which the CA server resolves via its first-line name lookup
+    (no record machinery needed).  The text is clipped to the EPICS DBR_STRING
+    limit; callers that source from ``VariableSpec.description`` are already
+    clipped, but derived-channel descriptions are not, so clip here too.
+
+    Parameters
+    ----------
+    description : str
+        The description text (``.DESC`` field value).
+
+    Returns
+    -------
+    ChannelData
+        A client-read-only ``ChannelString`` holding the description.
+    """
+    return read_only(ChannelString)(value=description[:_DESC_MAX_LENGTH])
+
+
 def make_setpoint_channel(spec: VariableSpec, setter: Setter) -> ChannelData:
     """Build a writable channel that forwards CA puts to GEECS.
 

--- a/GeecsCAGateway/geecs_ca_gateway/config.py
+++ b/GeecsCAGateway/geecs_ca_gateway/config.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 import logging
 from typing import Literal
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 from .alarms import AlarmLimits
 from .derived import DerivedChannelSpec
@@ -20,6 +20,11 @@ from .naming import normalize_pv_component
 logger = logging.getLogger(__name__)
 
 DType = Literal["float", "int", "string", "path", "enum"]
+
+# EPICS DBR_STRING (the .DESC field's type) caps at 40 characters. A longer
+# description is truncated by CA clients, so we clip it at the source with a
+# warning rather than silently shipping something that displays wrong.
+_MAX_DESC_LENGTH = 40
 
 # GEECS `variabletype` → gateway dtype. Types absent here (image, 1darray) are
 # not scalar CA data and are skipped when building specs from the DB.
@@ -61,6 +66,24 @@ class VariableSpec(BaseModel):
     choices: list[str] = Field(default_factory=list)  # ordered options for enum
     deadband: float = 0.0  # float monitor deadband; only post when |Δ| > deadband
     alarm_limits: AlarmLimits | None = None
+    # One-line human description for the PV's .DESC field (Phoebus/archiver
+    # label). Stable *identity* only — not a change log; time-varying
+    # provenance belongs in git-tracked config or the elog, never here (a
+    # .DESC edit leaves no history). Clipped to 40 chars (EPICS DBR_STRING).
+    description: str = ""
+
+    @field_validator("description")
+    @classmethod
+    def _clip_description(cls, value: str) -> str:
+        """Clip an over-long description to the EPICS DBR_STRING limit."""
+        if len(value) > _MAX_DESC_LENGTH:
+            logger.warning(
+                "description %r exceeds %d chars (EPICS .DESC limit) — clipping",
+                value,
+                _MAX_DESC_LENGTH,
+            )
+            return value[:_MAX_DESC_LENGTH]
+        return value
 
     @property
     def pv_suffix(self) -> str:
@@ -227,6 +250,10 @@ class DeviceSpec(BaseModel):
                     lo=meta.get("min"),
                     hi=meta.get("max"),
                     choices=choices,
+                    # Present only once the DB SELECT exposes a description
+                    # column (see CHANGELOG / design note — a deliberate
+                    # on-network follow-up); absent today → "" and inert.
+                    description=meta.get("description") or "",
                     # NOT the DB "tolerance": that is a *set convergence*
                     # criterion (often coarse, e.g. 0.05 A on magnet PSUs) and
                     # using it as a monitor deadband hides real sub-tolerance

--- a/GeecsCAGateway/geecs_ca_gateway/db/geecs_db.py
+++ b/GeecsCAGateway/geecs_ca_gateway/db/geecs_db.py
@@ -102,12 +102,15 @@ def _num(value: object) -> Optional[float]:
 def _variable_row_to_meta(row: tuple) -> dict:
     """Map a ``devicetype_variable`` or ``variable`` (+ ``choice``) row onto the metadata dict.
 
-    Row order: name, units, min, max, set, variabletype, choices, tolerance —
-    the shared SELECT column order (after the leading id/link column) of
-    :meth:`GeecsDb.get_device_variables` and
+    Row order: name, units, min, max, set, variabletype, choices, tolerance,
+    description — the shared SELECT column order (after the leading id/link
+    column) of :meth:`GeecsDb.get_device_variables` and
     :meth:`GeecsDb.get_experiment_device_variables`.  Both the type-default
     table (``devicetype_variable``) and the per-instance table (``variable``)
-    carry the same columns, so one mapper serves both.
+    carry the same columns, so one mapper serves both.  ``description`` exists
+    only on ``variable`` — the type query selects ``NULL`` in that slot, so a
+    description is a purely per-instance fact (which the wholesale inheritance
+    already implies).
     """
     return {
         "name": row[0],
@@ -118,6 +121,7 @@ def _variable_row_to_meta(row: tuple) -> dict:
         "variabletype": (row[5] or "").strip().lower() or None,
         "choices": row[6],
         "tolerance": _num(row[7]),
+        "description": (row[8] or "").strip() if len(row) > 8 else "",
     }
 
 
@@ -558,7 +562,7 @@ class GeecsDb:
             cur = conn.cursor()
             cur.execute(
                 "SELECT dtv.id, dtv.name, dtv.units, dtv.min, dtv.max, dtv.`set`, "
-                "dtv.variabletype, c.choices, dtv.tolerance "
+                "dtv.variabletype, c.choices, dtv.tolerance, NULL "
                 "FROM devicetype_variable dtv "
                 "JOIN device d ON d.devicetype = dtv.devicetype "
                 "LEFT JOIN choice c ON c.id = dtv.choice_id "
@@ -568,7 +572,7 @@ class GeecsDb:
             type_rows = cur.fetchall()
             cur.execute(
                 "SELECT v.devicetype_variable_id, v.name, v.units, v.min, v.max, "
-                "v.`set`, v.variabletype, c.choices, v.tolerance "
+                "v.`set`, v.variabletype, c.choices, v.tolerance, v.description "
                 "FROM variable v "
                 "LEFT JOIN choice c ON c.id = v.choice_id "
                 "WHERE v.device = %s ORDER BY v.name",
@@ -656,7 +660,7 @@ class GeecsDb:
             cur = conn.cursor()
             type_query = (
                 "SELECT d.name, dtv.id, dtv.name, dtv.units, dtv.min, dtv.max, "
-                "dtv.`set`, dtv.variabletype, c.choices, dtv.tolerance "
+                "dtv.`set`, dtv.variabletype, c.choices, dtv.tolerance, NULL "
                 "FROM (SELECT DISTINCT ed.device FROM expt_device ed "
                 "      WHERE ed.expt = %s{enabled}) sel "
                 "JOIN device d ON d.name = sel.device "
@@ -668,7 +672,8 @@ class GeecsDb:
             type_rows = cur.fetchall()
             instance_query = (
                 "SELECT v.device, v.devicetype_variable_id, v.name, v.units, "
-                "v.min, v.max, v.`set`, v.variabletype, c.choices, v.tolerance "
+                "v.min, v.max, v.`set`, v.variabletype, c.choices, v.tolerance, "
+                "v.description "
                 "FROM (SELECT DISTINCT ed.device FROM expt_device ed "
                 "      WHERE ed.expt = %s{enabled}) sel "
                 "JOIN variable v ON v.device = sel.device "

--- a/GeecsCAGateway/geecs_ca_gateway/gateway.py
+++ b/GeecsCAGateway/geecs_ca_gateway/gateway.py
@@ -37,6 +37,7 @@ from .alarms import AlarmLevel, AlarmSeverityName
 from .channels import (
     cast_value,
     enum_index,
+    make_description_channel,
     make_readback_channel,
     make_restart_channel,
     make_setpoint_channel,
@@ -192,6 +193,13 @@ class GeecsCaGateway:
                 readback = make_readback_channel(var)
                 self.pvdb[full] = readback
                 readback_map[var.geecs_var] = (readback, var)
+                if var.description:
+                    # Serve the description as the PV's .DESC field. A plain
+                    # '<pv>.DESC' string entry is resolved by the CA server's
+                    # first-line name lookup — no record machinery needed.
+                    self.pvdb[f"{full}.DESC"] = make_description_channel(
+                        var.description
+                    )
 
                 if var.settable:
                     sp_name = f"{full}:SP"
@@ -256,6 +264,7 @@ class GeecsCaGateway:
                 lo=spec.lo,
                 hi=spec.hi,
                 deadband=spec.deadband,
+                description=spec.description,
             )
             channel = make_readback_channel(
                 var_spec,
@@ -263,6 +272,10 @@ class GeecsCaGateway:
                 initial_status=AlarmStatus.UDF,
             )
             self.pvdb[full] = channel
+            if var_spec.description:
+                self.pvdb[f"{full}.DESC"] = make_description_channel(
+                    var_spec.description
+                )
             evaluator = ExpressionEvaluator(
                 spec.expression, {inp.symbol for inp in spec.inputs}
             )

--- a/GeecsCAGateway/pyproject.toml
+++ b/GeecsCAGateway/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-ca-gateway"
-version = "0.9.0"
+version = "0.10.0"
 description = "EPICS Channel Access soft-IOC gateway exposing GEECS devices as PVs"
 authors = ["Sam Barber <sbarber@lbl.gov>"]
 readme = "README.md"

--- a/GeecsCAGateway/tests/test_config_from_db.py
+++ b/GeecsCAGateway/tests/test_config_from_db.py
@@ -38,6 +38,38 @@ def test_from_db_metadata_maps_units_limits_settable() -> None:
     assert by_name["IPAddress"].lo is None and by_name["IPAddress"].hi is None
 
 
+def test_description_absent_defaults_to_empty() -> None:
+    """A metadata row with no 'description' key yields an empty DESC."""
+    spec = DeviceSpec.from_db_metadata("U_S1H", "h", 1, U_S1H_META)
+    by_name = {v.geecs_var: v for v in spec.variables}
+    assert by_name["Current"].description == ""
+
+
+def test_description_maps_from_metadata() -> None:
+    """A 'description' key on a metadata row maps onto VariableSpec.description."""
+    meta = [
+        {
+            "name": "Current",
+            "units": "A",
+            "min": -5.0,
+            "max": 5.0,
+            "settable": True,
+            "description": "S1H steering current",
+        }
+    ]
+    spec = DeviceSpec.from_db_metadata("U_S1H", "h", 1, meta)
+    assert spec.variables[0].description == "S1H steering current"
+
+
+def test_description_clipped_to_epics_limit() -> None:
+    """An over-long description is clipped to 40 chars (EPICS .DESC limit)."""
+    from geecs_ca_gateway.config import VariableSpec
+
+    long_text = "x" * 60
+    spec = VariableSpec(geecs_var="V", description=long_text)
+    assert len(spec.description) == 40
+
+
 def test_alarm_limits_validate_order_and_presence() -> None:
     """Curated alarm limits must be explicit and monotonic."""
     limits = AlarmLimits(low=1.0, high=5.0)

--- a/GeecsCAGateway/tests/test_gateway.py
+++ b/GeecsCAGateway/tests/test_gateway.py
@@ -148,6 +148,33 @@ def test_experiment_prefix_and_manifest() -> None:
     assert gw.manifest["Undulator:U_S1H:Current:SP"] == ("U_S1H", "Current", "setpoint")
 
 
+def test_description_served_as_desc_field() -> None:
+    """A variable description becomes a served '<pv>.DESC' string channel."""
+    cfg = GatewayConfig(
+        devices=[
+            DeviceSpec(
+                name="U_S1H",
+                host="h",
+                port=1,
+                experiment="Undulator",
+                variables=[
+                    VariableSpec(
+                        geecs_var="Current",
+                        description="S1H steering magnet current",
+                    ),
+                    VariableSpec(geecs_var="Voltage"),  # no description
+                ],
+            )
+        ]
+    )
+    gw = GeecsCaGateway(cfg)
+    desc_pv = "Undulator:U_S1H:Current.DESC"
+    assert desc_pv in gw.pvdb
+    assert gw.pvdb[desc_pv].value == "S1H steering magnet current"
+    # A variable with no description gets no .DESC entry.
+    assert "Undulator:U_S1H:Voltage.DESC" not in gw.pvdb
+
+
 def test_pv_name_collision_raises() -> None:
     """Two GEECS variables mapping to one PV is a hard error, not silent clobber."""
     cfg = GatewayConfig(

--- a/GeecsCAGateway/tests/test_geecs_db.py
+++ b/GeecsCAGateway/tests/test_geecs_db.py
@@ -216,6 +216,7 @@ def test_get_device_variables_type_only_inherits_type_defaults(monkeypatch) -> N
         "variabletype": "numeric",
         "choices": None,
         "tolerance": 0.05,
+        "description": "",
     }
     assert sorted(result[0]) == sorted(result[1]) == sorted(result[2])
     assert result[1]["choices"] == "on,off"
@@ -297,6 +298,49 @@ def test_instance_only_variable_is_served(monkeypatch) -> None:
     assert by_name["Voltage"]["min"] is None
 
 
+def test_instance_description_flows_through(monkeypatch) -> None:
+    """A per-instance ``variable.description`` reaches the meta dict.
+
+    ``description`` lives only on the instance table; the type query selects
+    ``NULL`` in that slot, so a description is inherently a per-instance fact.
+    Instance rows carry a 10th column (after the link id); type rows do not.
+    """
+    type_rows = [
+        # id, name, units, min, max, set, variabletype, choices, tol, NULL(desc)
+        (11, "Current", "A", "-5", "5", "yes", "numeric", None, "0.05", None),
+    ]
+    instance_rows = [
+        # link, name, units, min, max, set, variabletype, choices, tol, desc
+        (
+            11,
+            "Current",
+            "A",
+            "-5",
+            "5",
+            "yes",
+            "numeric",
+            None,
+            "0.05",
+            "S1H steering current",
+        ),
+    ]
+    _patch_query_sequence(monkeypatch, [type_rows, instance_rows], [])
+
+    result = GeecsDb.get_device_variables("U_S1H")
+    assert result[0]["description"] == "S1H steering current"
+
+
+def test_type_only_description_defaults_empty(monkeypatch) -> None:
+    """With no instance row, description is empty (type table has no such column)."""
+    type_rows = [
+        (11, "Current", "A", "-5", "5", "no", "numeric", None, "0.05", None),
+    ]
+    _patch_query_sequence(monkeypatch, [type_rows, []], [])
+
+    result = GeecsDb.get_device_variables("U_S1H")
+    assert result[0]["description"] == ""
+
+
 def test_get_experiment_device_variables_batches_metadata(monkeypatch) -> None:
     """Two batched queries return all devices' metadata, grouped and mapped."""
     queries: list = []
@@ -326,6 +370,7 @@ def test_get_experiment_device_variables_batches_metadata(monkeypatch) -> None:
         "variabletype": "numeric",
         "choices": None,
         "tolerance": 0.05,
+        "description": "",
     }
     assert result["U_A"][1]["choices"] == "on,off"
     assert result["U_B"][0]["settable"] is False

--- a/Planning/scan_variable_metadata/00_overview.md
+++ b/Planning/scan_variable_metadata/00_overview.md
@@ -1,0 +1,213 @@
+# Scan-variable & PV-metadata vocabulary — decisions and deferred work
+
+Status: **first cut landed on `feat/scanvar-pv-metadata`** (2026-07-09,
+branched from `feat/vision-v1`). This note captures the reasoning from the
+design conversation that produced that branch, and — importantly — records the
+pieces we deliberately deferred because they need lab-network / DB work that
+can't be done or verified offline.
+
+## What this is about
+
+Three of the vision schemas' recurring questions turned out to be one
+question: **what is a device fact vs. an editorial/config decision?** The
+vision doc's own principle (§4.2) already answers it — "device facts live
+below the configs; limits, units, tolerances, and choices belong to the GEECS
+DB and surface as PV metadata from the gateway." The configs above should
+*reference or override* device facts, never *restate* them. Everything below
+is an application of that one rule.
+
+## Landed in this branch (offline-safe, tested)
+
+1. **`PseudoTarget` → `PseudoComponent`** (`geecs_schemas.scan_variables`).
+   Pure clarity rename: a `PseudoScanVariable` *contains* a
+   `list[PseudoComponent]`; the old name collided conceptually with the
+   element's own `target` field. The legacy vocabulary called these
+   *components*. No behavior change; goldens/schema-reference regenerated.
+
+2. **`ScanVariable.confirm`** — an optional `Device:Variable` naming the
+   variable that *measures* the result when it differs from the variable being
+   *set*. This documents "topology C" (below) in the one place it bites today.
+   Additive, defaults to `None` (⇒ today's behavior), validated as a
+   `Device:Variable`. **Declared, not yet enforced** by the engine — mirrors
+   how the codebase already carries reserved fields (`at_scan_start`, etc.).
+   Deliberately **no tolerance field**: the match tolerance is a device fact
+   and stays below the configs (DB / gateway PV metadata), per §4.2.
+
+3. **`VariableSpec.description`** (`geecs_ca_gateway.config`) — the model +
+   DB-read plumbing for a PV `.DESC`, clipped to 40 chars (EPICS DBR_STRING)
+   with a warning. `from_db_metadata` reads `meta.get("description")`, which is
+   simply absent today (⇒ `""`, inert). **The live SQL SELECT and the actual
+   CA DESC-serving are NOT in this branch** — see Deferred #1/#2.
+
+4. **CaSettable / CaMotor docstring honesty** (`geecs_bluesky.devices.ca`).
+   Corrected the misleading framing that `motor` is *the* way to declare a
+   positioner and `CaSettable` is unsafe for stages.
+
+## The completion-semantics taxonomy (the substantive finding)
+
+"Motor vs setpoint" was always a fuzzy proxy for the real axis: **the
+relationship between the variable you set and the variable that confirms it.**
+Three topologies:
+
+- **A — same variable is setpoint *and* an independent measurement.**
+  Stages (`Position.Axis N`), steering magnets (`U_S1H:Current`). The GEECS DB
+  tolerance is bound to that variable, so `CaMotor`'s readback poll is correct
+  and meaningful. This is the only case where CaMotor is clearly load-bearing.
+
+- **B — command echoes itself / no readback.** Pure solenoids. `CaSettable` is
+  right; a readback poll would be vacuous (confirming a value against its own
+  echo).
+
+- **C — the variable you set ≠ the variable that measures.**
+  `U_EMQTripletBipolar` (production!): the catalog's "EMQ1 Current" writes
+  `Current_Limit.Ch1` (a *software limit*), while the measured current is a
+  separate variable. GEECS binds its set-completion tolerance to the *written*
+  variable, so the set "confirms" a value that is trivially correct and the
+  real current is **never checked**. **Neither `CaSettable` nor `CaMotor`
+  covers this** — CaMotor polls the readback of the *same* variable it set, so
+  it cannot confirm a decoupled measurement.
+
+The discrete cousin of C is a solenoid whose truth is a separate DI indicator
+(the laser-shutter pattern) — the future `CaShutter`. C-analog (EMQ) and
+C-discrete (shutter) are the *same* abstraction ("set X, confirm on Y, with a
+match rule"), differing only in the match rule (tolerance vs equality).
+
+### These gaps already exist in production
+
+The topology-C gap is not a regression this work introduces — it is exactly
+how MC / legacy geecs-scanner behaves today, and has for years. So closing any
+of it is a strict improvement; the worst case of doing nothing is parity with
+today. That framing makes each item below a free option, closeable when cheap.
+
+## DESC / metadata-history discipline
+
+- A PV `.DESC` (whether from the DB or served by the gateway) is a **mutable
+  label with no history**. Changing it leaves no record of the prior value and
+  does not relabel archived samples.
+- **Rule:** `.DESC` carries *stable identity only* ("EMQ1 steering current,
+  triplet Ch1"), edited freely when wording improves. Anything **time-varying
+  or provenance-bearing** (a recalibration, a filter swap) must go where
+  history lives — a git-tracked config overlay or the elog — never `.DESC`.
+- EPICS shops get metadata history from **version-controlled IOC `.db` files**;
+  our gateway swapped that for a live MySQL source, which is where the history
+  vanished. Routing history-bearing metadata through git-tracked config
+  (`GEECS-Plugins-Configs`, following the `derived_channels.yaml` precedent)
+  restores it. Two vessels, different jobs: the **git overlay** is the
+  correctable present (`git blame` = the change log); the **Tiled run
+  metadata** stamp is the frozen past (welded to each dataset).
+
+## Alias vs. friendly name (the duplication risk)
+
+Keep the DB `alias` **separate** from `.DESC` — alias is a short handle,
+description is a one-line sentence. To avoid two naming authorities that
+drift, the scan-variable catalog's display name should **default to the DB
+alias**, carrying its own name only as an intentional override. Default chain:
+**catalog name → DB alias → raw `Device:Variable`**. This turns the catalog
+from a second naming system into an *allow-list with optional relabel* — which
+is the residue the vision doc wants (allow-listing + overrides + pseudo math).
+
+## Decisions closed (do not re-litigate)
+
+- **Stay on ophyd-async, not classic ophyd.** The gateway unlocked stock EPICS
+  *signals*, not *records* — and records (motorRecord) are where classic
+  ophyd's value lives. Switching would re-hand-roll the same convergence logic
+  on a sunset framework. The genuine "smarts below the client" option is a
+  soft-IOC record layer, a much larger separate decision.
+- **`motor` kind stays authored, not derived from the DB.** DB tolerance is an
+  imperfect proxy for "has an independent readback," and deriving would add a
+  DB dependency to positioner construction for a near-no-op distinction.
+- **Action plans:** architecture (compile-to-Bluesky-plan-stubs) is right;
+  primitives are a deliberately minimal, bug-compatible port. Two real gaps if
+  ever extended: `check` is exact-equality only (flaky on analog readbacks),
+  and there is **no escape hatch to a registered Bluesky plan** (`run` only
+  nests other ActionPlans). Not urgent; noted so YAML doesn't grow a dialect.
+
+## Deferred — needs DB population / write work
+
+The columns exist (verified against the live DB, 2026-07-09) — the blocker is
+now *population* and a *join*, not schema. Findings:
+
+| Column | Table | Populated? |
+|---|---|---|
+| `alias` | `devicetype_variable` (type default) | **0 / 4626** — unused |
+| `alias` | `variable` (per-instance override) | 248 / 2641 (~9%) |
+| `description` | `devicetype_variable` | **column does not exist** |
+| `description` | `variable` | exists `varchar(1000)`, **0 / 2641 populated** |
+
+Two consequences that revise the earlier plan:
+
+- **`description` lives ONLY on `variable`, not `devicetype_variable`.** The
+  gateway's SELECTs read `devicetype_variable`; serving descriptions means a
+  `LEFT JOIN variable` + coalesce — the same `devicetype_variable → variable`
+  inheritance-chain resolution used for the `:SP` set flag (commit
+  `fb9d9786`). Reuse that pattern; it is *not* a one-line "add a column."
+- **The width mismatch is load-bearing.** `variable.description` is
+  `varchar(1000)`; EPICS `.DESC` caps at **40 chars**. `VariableSpec` clips at
+  40 with a warning, but the ≤40 "stable identity" discipline must be applied
+  at *authoring* time too, or Phoebus shows half a sentence.
+
+1. **Populate + JOIN the description/alias columns.**
+   `GeecsDb.get_device_variables` / `get_experiment_device_variables` must
+   `LEFT JOIN variable` to pick up `description` (and prefer `variable.alias`
+   over the empty `devicetype_variable.alias`), coalescing per the inheritance
+   chain. Nothing is populated yet, so the payoff depends on someone writing
+   short (≤40 char) descriptions into `variable.description`. The
+   `VariableSpec.description` plumbing already consumes `meta["description"]`
+   the moment the SELECT provides it.
+
+2. **Actual CA DESC-serving in the gateway.** The gateway serves a raw
+   `dict[str, ChannelData]` pvdb; caproto's `ChannelData` has **no `doc`/DESC
+   kwarg** (verified, caproto 1.3.0). Serving `.DESC` needs either explicit
+   `<pv>.DESC` string channels in the pvdb or the field-aware record
+   machinery — a PV_CONTRACT change that needs live CA-client validation.
+   `VariableSpec.description` is plumbed and ready; wiring it to a served field
+   is a separate on-network PR (update `PV_CONTRACT.md` + a pinned test).
+
+3. **Per-run DESC / apparatus metadata stamp into Tiled.** The run-metadata
+   dict (`md`) is already assembled and injected per run
+   (`scan_request_runner`, `run_wrapper`). Stamping signal descriptions (and,
+   later, apparatus facts like "ND1.0 filter installed") into it freezes them
+   onto each dataset — the "frozen past" vessel. Scope decision when built:
+   stamp only scan/save-set devices (cheap, incomplete) vs. a whole-apparatus
+   snapshot (complete, heavier).
+
+4. **Name-defaults-to-alias resolution.** The catalog display-name default
+   chain (catalog name → DB alias → raw `Device:Variable`). The usable alias
+   is `variable.alias` (~9% populated); `devicetype_variable.alias` is empty,
+   so the same JOIN as #1 is the source. Implement with #1; coverage grows as
+   aliases are populated (a raw `Device:Variable` is the honest fallback until
+   then).
+
+5. **The topology-C device (`set X, confirm on Y`).** A device whose `set()`
+   completes on a *named, possibly different* confirming variable — analog
+   match by tolerance, discrete match by equality. Unifies the future
+   `CaShutter` (discrete) with the EMQ case (analog) as one abstraction, not
+   two.
+
+   **The measured-variable name is now known** (DB lookup, 2026-07-09):
+   `U_EMQTripletBipolar` exposes both `Current_Limit.Ch{1,2,3,4}` (set=True on
+   Ch1; the software limit the catalog writes) and `Current.Ch{1,2,3,4}`
+   (set=False; the measured current). So the mapping is regular:
+   `Current_Limit.ChN → Current.ChN`. The catalog exposes Ch1–3 (EMQ1/2/3);
+   Ch4 is unused. Writing the `confirm:` entries is ~3 lines per channel:
+
+   ```yaml
+   EMQ1 Current:
+     target:  U_EMQTripletBipolar:Current_Limit.Ch1
+     confirm: U_EMQTripletBipolar:Current.Ch1
+   # EMQ2 → .Ch2, EMQ3 → .Ch3
+   ```
+
+   **The confirmation is doubly vacuous today, and there is a prerequisite.**
+   Every one of these variables has DB `tolerance = 0.0`, *including the
+   settable `Current_Limit`*. So GEECS's blocking set "converges" the instant
+   the limit register echoes what was written — a zero-tolerance check on a
+   value true by construction; the physical `Current.ChN` is never involved.
+   A 4b device polling `Current.ChN` therefore needs a **real convergence
+   tolerance** to compare against (what counts as "arrived" for these
+   supplies — e.g. 0.05–0.1 A). Per the §4.2 discipline that is a *device
+   fact* and belongs in the DB (`Current.ChN`'s tolerance), not the config.
+   **Prerequisite for closing 4b for real: populate a sensible tolerance on
+   `Current.ChN` in the DB** — otherwise an exact-float confirm-poll never
+   settles. This is the same "how much PV metadata can the DB serve" thread as
+   Deferred #1.

--- a/Planning/scan_variable_metadata/00_overview.md
+++ b/Planning/scan_variable_metadata/00_overview.md
@@ -33,15 +33,35 @@ is an application of that one rule.
    Deliberately **no tolerance field**: the match tolerance is a device fact
    and stays below the configs (DB / gateway PV metadata), per §4.2.
 
-3. **`VariableSpec.description`** (`geecs_ca_gateway.config`) — the model +
-   DB-read plumbing for a PV `.DESC`, clipped to 40 chars (EPICS DBR_STRING)
-   with a warning. `from_db_metadata` reads `meta.get("description")`, which is
-   simply absent today (⇒ `""`, inert). **The live SQL SELECT and the actual
-   CA DESC-serving are NOT in this branch** — see Deferred #1/#2.
+3. **`VariableSpec.description` + the live SELECT** (`geecs_ca_gateway`) — the
+   model (40-char clip with warning) *and* the DB read. Both metadata queries
+   (`get_device_variables`, `get_experiment_device_variables`) now select
+   `variable.description` on the instance side and `NULL` on the type side,
+   coalesced through `_variable_row_to_meta` into `from_db_metadata` →
+   `VariableSpec.description`. **Verified end-to-end against the live DB
+   (2026-07-09):** the query runs, and a description written to
+   `U_S1H.Current`'s instance row surfaces as `VariableSpec.description`.
+   Still **not** served over CA — see Deferred #1 (that is the remaining
+   `.DESC` piece).
 
 4. **CaSettable / CaMotor docstring honesty** (`geecs_bluesky.devices.ca`).
    Corrected the misleading framing that `motor` is *the* way to declare a
    positioner and `CaSettable` is unsafe for stages.
+
+5. **Live DB + config changes done on-network (2026-07-09):**
+   - `U_EMQTripletBipolar:Current.Ch{1,2,3}` tolerance set `0 → 0.05` A on the
+     type rows (no instance rows exist; harmless today since those vars are
+     read-only, ready for a future confirm-device).
+   - `U_S1H:Current` instance row given a description ("S1H steering magnet
+     current") as the proof-of-concept — chosen because that row already
+     exists; **no new `variable` rows were created** (creating one makes it
+     wholesale ground truth, too risky for a cosmetic field).
+   - Undulator migrated to new-schema `scan_variables.yaml` (configs repo,
+     branch `codex/undulator-derived-channels`): 59 variables, exact set match
+     with the legacy pair, EMQ entries carry `confirm: …:Current.ChN`.
+   - `deploy/variable_description.sql` — reviewable DDL to narrow
+     `variable.description` to 40 chars and (optionally, gated on a code
+     coalesce) add a type-level `devicetype_variable.description`.
 
 ## The completion-semantics taxonomy (the substantive finding)
 
@@ -146,14 +166,14 @@ Two consequences that revise the earlier plan:
   40 with a warning, but the ≤40 "stable identity" discipline must be applied
   at *authoring* time too, or Phoebus shows half a sentence.
 
-1. **Populate + JOIN the description/alias columns.**
-   `GeecsDb.get_device_variables` / `get_experiment_device_variables` must
-   `LEFT JOIN variable` to pick up `description` (and prefer `variable.alias`
-   over the empty `devicetype_variable.alias`), coalescing per the inheritance
-   chain. Nothing is populated yet, so the payoff depends on someone writing
-   short (≤40 char) descriptions into `variable.description`. The
-   `VariableSpec.description` plumbing already consumes `meta["description"]`
-   the moment the SELECT provides it.
+1. **JOIN the description column — DONE (2026-07-09).** Both metadata queries
+   now select `variable.description` (instance side) / `NULL` (type side) and
+   coalesce through `_variable_row_to_meta`. Verified against the live DB.
+   **Remaining sub-items:** (a) populate `variable.description` with short
+   (≤40 char) text — only `U_S1H:Current` is populated so far; (b) `alias` is
+   *not* yet wired the same way — prefer `variable.alias` over the empty
+   `devicetype_variable.alias` when the name-defaults-to-alias resolution
+   (Deferred #4) is built.
 
 2. **Actual CA DESC-serving in the gateway.** The gateway serves a raw
    `dict[str, ChannelData]` pvdb; caproto's `ChannelData` has **no `doc`/DESC

--- a/Planning/scan_variable_metadata/00_overview.md
+++ b/Planning/scan_variable_metadata/00_overview.md
@@ -38,11 +38,13 @@ is an application of that one rule.
    (`get_device_variables`, `get_experiment_device_variables`) now select
    `variable.description` on the instance side and `NULL` on the type side,
    coalesced through `_variable_row_to_meta` into `from_db_metadata` →
-   `VariableSpec.description`. **Verified end-to-end against the live DB
-   (2026-07-09):** the query runs, and a description written to
-   `U_S1H.Current`'s instance row surfaces as `VariableSpec.description`.
-   Still **not** served over CA — see Deferred #1 (that is the remaining
-   `.DESC` piece).
+   `VariableSpec.description`, **and served over CA as the standard `.DESC`
+   field** — a read-only `<pv>.DESC` string channel in the pvdb (readbacks +
+   derived channels). **Verified end-to-end (2026-07-09):** a description
+   written to `U_S1H:Current`'s instance row surfaces through
+   `VariableSpec.description` and is readable by a live CA client as
+   `…:Current.DESC`. Documented in `PV_CONTRACT.md` §4, pinned by
+   `test_gateway.test_description_served_as_desc_field`.
 
 4. **CaSettable / CaMotor docstring honesty** (`geecs_bluesky.devices.ca`).
    Corrected the misleading framing that `motor` is *the* way to declare a
@@ -178,13 +180,14 @@ Two consequences that revise the earlier plan:
    `devicetype_variable.alias` when the name-defaults-to-alias resolution
    (Deferred #4) is built.
 
-2. **Actual CA DESC-serving in the gateway.** The gateway serves a raw
-   `dict[str, ChannelData]` pvdb; caproto's `ChannelData` has **no `doc`/DESC
-   kwarg** (verified, caproto 1.3.0). Serving `.DESC` needs either explicit
-   `<pv>.DESC` string channels in the pvdb or the field-aware record
-   machinery — a PV_CONTRACT change that needs live CA-client validation.
-   `VariableSpec.description` is plumbed and ready; wiring it to a served field
-   is a separate on-network PR (update `PV_CONTRACT.md` + a pinned test).
+2. **CA DESC-serving — DONE (2026-07-09).** The initial worry was that
+   caproto's `ChannelData` has no `doc`/DESC kwarg (true). But the CA server
+   resolves a `<pv>.FIELD` request via its first-line pvdb name lookup, so a
+   plain `<pv>.DESC` `ChannelString` entry in the pvdb *is* served with no
+   record machinery — confirmed by reading the server source and by a live CA
+   client `caget`. `make_description_channel` + a `.DESC` entry per described
+   readback/derived channel. `PV_CONTRACT.md` §4 + pinned test. (This was
+   nearly folded into a "separate PR"; it turned out to be ~15 lines.)
 
 3. **Per-run DESC / apparatus metadata stamp into Tiled.** The run-metadata
    dict (`md`) is already assembled and injected per run

--- a/Planning/scan_variable_metadata/00_overview.md
+++ b/Planning/scan_variable_metadata/00_overview.md
@@ -59,9 +59,12 @@ is an application of that one rule.
    - Undulator migrated to new-schema `scan_variables.yaml` (configs repo,
      branch `codex/undulator-derived-channels`): 59 variables, exact set match
      with the legacy pair, EMQ entries carry `confirm: …:Current.ChN`.
-   - `deploy/variable_description.sql` — reviewable DDL to narrow
-     `variable.description` to 40 chars and (optionally, gated on a code
-     coalesce) add a type-level `devicetype_variable.description`.
+   - `variable.description` narrowed `VARCHAR(1000) → VARCHAR(40)` to match the
+     EPICS `.DESC` limit (0 rows exceeded 40, so no data lost). The DB is now
+     the constraint, not just the gateway's clip.
+   - `deploy/variable_description.sql` — records that ALTER (applied) and holds
+     the still-optional type-level `devicetype_variable.description` column
+     (gated on a code coalesce; **Sam owns adding this**).
 
 ## The completion-semantics taxonomy (the substantive finding)
 

--- a/docs/geecs_schemas/schema_reference.md
+++ b/docs/geecs_schemas/schema_reference.md
@@ -219,6 +219,7 @@ A friendly name for one device variable you can scan.
 |---|---|---|---|---|
 | `target` | `str` | yes | — | The device variable this name moves, written as 'Device:Variable', e.g. 'U_ESP_JetXYZ:Position.Axis 3'. |
 | `kind` | `'motor' \| 'setpoint'` | no | 'setpoint' | 'setpoint' = write the value and wait for the device to accept it (the default). 'motor' = additionally poll the readback until the device reports it arrived — use for real positioners. |
+| `confirm` | `str (optional)` | no | None | Optional 'Device:Variable' that *measures* the result when it differs from the variable being set — e.g. set a supply's current limit but confirm on its measured current. Leave unset when the set variable is also the readback (the common case). Declared but not yet enforced by the engine in v1. |
 
 ### PseudoScanVariable
 
@@ -227,11 +228,11 @@ A friendly name that moves several devices together from one number.
 | Field | Type | Required | Default | What it does |
 |---|---|---|---|---|
 | `kind` | `'pseudo'` | yes | — | Variable type. 'pseudo' moves several devices from one number. |
-| `targets` | `list[PseudoTarget]` | yes | — | The devices this variable moves, each with its own formula. |
+| `targets` | `list[PseudoComponent]` | yes | — | The devices this variable moves, each with its own formula. |
 | `mode` | `CompositeMode` | yes | — | 'absolute' = each device goes exactly where its formula says. 'relative' = each device is offset from where it was when the scan started. |
 | `inverse` | `str (optional)` | no | None | Optional formula recovering the scanned number from the first target's readback. Leave unset if you don't need a readback for this variable. |
 
-### PseudoTarget
+### PseudoComponent
 
 One device a pseudo variable moves, and the formula for its value.
 


### PR DESCRIPTION
Scoped work on the scan-variable schema and gateway PV metadata, branched from and targeting `feat/vision-v1`.

## Schema (`geecs-schemas` 0.6.0)
- **Rename `PseudoTarget` → `PseudoComponent`** — a `PseudoScanVariable` *contains* components; the old name collided with the element's own `target` field. Field names / serialized output unchanged.
- **`ScanVariable.confirm`** — optional `Device:Variable` naming the *measured* variable when it differs from the *set* variable (topology-C, e.g. the EMQ triplet's `Current_Limit.ChN` vs measured `Current.ChN`). Additive, defaults `None`, declared-but-not-yet-enforced; carries no tolerance (that's a device fact, stays in the DB).

## Gateway (`geecs-ca-gateway` 0.10.0)
- **Per-PV `.DESC`, resolved from the DB and served over CA.** DB `variable.description` → capability inheritance chain → `VariableSpec.description` → a read-only `<pv>.DESC` string channel (readbacks + derived channels). Verified end-to-end with a live CA client. Clipped to the 40-char DBR_STRING limit at both the DB column and the gateway. `PV_CONTRACT.md` §4 + pinned test.
- Merges in `master`'s variable-capability inheritance-chain fix (the branch was behind).
- `deploy/variable_description.sql` — DDL record (column narrowed to `VARCHAR(40)`, applied; optional type-level default left for follow-up).

## Bluesky (`geecs-bluesky` 0.24.1)
- **CaSettable / CaMotor docstring honesty** — CaSettable already rides GEECS blocking convergence; CaMotor's poll only helps with an independent same-variable readback; neither covers topology-C.

## Live DB changes already applied (2026-07-09)
- EMQ `Current.Ch{1,2,3}` tolerance `0 → 0.05` A.
- `U_S1H:Current` description populated (proof-of-concept).
- `variable.description` narrowed `VARCHAR(1000) → VARCHAR(40)` (0 rows affected).

## Config (separate repo)
Undulator migrated to new-schema `scan_variables.yaml` with EMQ `confirm:` — committed on `GEECS-Plugins-Configs@codex/undulator-derived-channels` (own PR if wanted).

## Tests
152 gateway + 214 schemas passing. Design note: `Planning/scan_variable_metadata/00_overview.md`.

## Follow-ups (documented, not gaps)
- Optional type-level `devicetype_variable.description` default (DDL + coalesce) — owner: Sam.
- Populating descriptions/aliases broadly; wiring `alias` into a catalog name-default chain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)