### PR TITLE
Allow partial LineStitcher outputs

### DIFF
--- a/ImageAnalysis/CHANGELOG.md
+++ b/ImageAnalysis/CHANGELOG.md
@@ -12,6 +12,15 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   source id as the analyzer id for direct single-diagnostic runs, matching the
   group-loader/LiveWatch naming contract without adding a YAML field.
 
+### Changed
+
+- `LineStitcher` now stitches and saves the available lineout segments when
+  one or more sibling device files are missing, instead of failing the whole
+  shot. Missing siblings are recorded in result metadata (`warnings`,
+  `missing_sibling_devices`, `missing_sibling_files`) so ScanAnalysis/LiveWatch
+  can surface the incomplete data product while preserving the useful stitched
+  TSV.
+
 ## [1.10.0] — 2026-06-30
 
 ### Added

--- a/ImageAnalysis/image_analysis/analyzers/line_stitcher.py
+++ b/ImageAnalysis/image_analysis/analyzers/line_stitcher.py
@@ -83,6 +83,10 @@ class LineStitcher(LineAnalyzer):
         base_dir = file_path.parent.parent
         data_config = self.line_config.data_loading
 
+        loaded_devices = [master_device]
+        missing_sibling_devices: list[str] = []
+        missing_sibling_files: list[str] = []
+
         # Master file — also sets self.data_metadata
         master_result = read_1d_data(file_path, data_config)
         self.data_metadata = {
@@ -118,14 +122,25 @@ class LineStitcher(LineAnalyzer):
             sibling_filename = filename.replace(device_in_filename, sibling_in_file, 1)
             sibling_path = base_dir / device / sibling_filename
             if not sibling_path.exists():
-                raise FileNotFoundError(
-                    f"Missing data file for device '{device}': {sibling_path}"
+                missing_sibling_devices.append(device)
+                missing_sibling_files.append(str(sibling_path))
+                logger.warning(
+                    "Missing data file for device %r; stitching available "
+                    "segments without %s",
+                    device,
+                    sibling_path,
                 )
+                continue
             segments.append(read_1d_data(sibling_path, data_config).data)
+            loaded_devices.append(device)
 
         # Concatenate and sort by x
         combined = np.concatenate(segments, axis=0)
         combined = combined[combined[:, 0].argsort()]
+
+        self._last_loaded_devices = loaded_devices
+        self._last_missing_sibling_devices = missing_sibling_devices
+        self._last_missing_sibling_files = missing_sibling_files
 
         logger.info(
             "Loaded %d segments (%d total points) from master '%s', shot '%s'",
@@ -163,7 +178,24 @@ class LineStitcher(LineAnalyzer):
         aux = dict(auxiliary_data or {})
         aux.setdefault("file_path", image_filepath)
 
-        return self.analyze_image(combined, aux)
+        result = self.analyze_image(combined, aux)
+        missing_devices = getattr(self, "_last_missing_sibling_devices", [])
+        if missing_devices:
+            missing_files = getattr(self, "_last_missing_sibling_files", [])
+            warnings = result.metadata.setdefault("warnings", [])
+            if isinstance(warnings, str):
+                warnings = [warnings]
+                result.metadata["warnings"] = warnings
+            warnings.append(
+                "Missing sibling data for "
+                f"{', '.join(missing_devices)}; stitched available segments only."
+            )
+            result.metadata["missing_sibling_devices"] = list(missing_devices)
+            result.metadata["missing_sibling_files"] = list(missing_files)
+        result.metadata["loaded_devices"] = list(
+            getattr(self, "_last_loaded_devices", [])
+        )
+        return result
 
     def analyze_image(
         self, image: Array1D, auxiliary_data: Optional[Dict] = None

--- a/ImageAnalysis/tests/analyzers/test_line_stitcher.py
+++ b/ImageAnalysis/tests/analyzers/test_line_stitcher.py
@@ -113,3 +113,45 @@ class TestLineStitcherMultiDeviceLoading:
         assert x.min() == pytest.approx(0.0)
         assert x.max() == pytest.approx(14.0)
         assert (np.diff(x) >= 0).all(), "stitched output not sorted by x"
+
+    def test_analyze_image_file_keeps_available_segments_when_sibling_missing(
+        self, tmp_path, caplog
+    ):
+        """A missing sibling is missing data, not a failed stitched product."""
+        scan_dir = tmp_path / "scans" / "Scan001"
+        master = scan_dir / "DevA" / "Scan001_DevA_001.tsv"
+        sib2 = scan_dir / "DevC" / "Scan001_DevC_001.tsv"
+
+        self._write_tsv(master, np.arange(0.0, 5.0, 1.0), np.full(5, 10.0))
+        self._write_tsv(sib2, np.arange(10.0, 15.0, 1.0), np.full(5, 30.0))
+
+        stitcher = LineStitcher(
+            line_config=self._make_line_config(),
+            sibling_devices=["DevB", "DevC"],
+            name="stitched",
+        )
+
+        with caplog.at_level("WARNING"):
+            result = stitcher.analyze_image_file(master)
+
+        assert result.line_data is not None
+        x = result.line_data[:, 0]
+        y = result.line_data[:, 1]
+        assert np.any(y == 10.0), "master segment dropped"
+        assert not np.any(y == 20.0), "missing DevB segment should not appear"
+        assert np.any(y == 30.0), "available DevC segment dropped"
+        assert x.min() == pytest.approx(0.0)
+        assert x.max() == pytest.approx(14.0)
+        assert (np.diff(x) >= 0).all(), "partial stitched output not sorted by x"
+
+        assert result.metadata["loaded_devices"] == ["DevA", "DevC"]
+        assert result.metadata["missing_sibling_devices"] == ["DevB"]
+        assert (
+            "Scan001/DevB/Scan001_DevB_001.tsv"
+            in result.metadata["missing_sibling_files"][0]
+        )
+        assert "Missing sibling data for DevB" in result.metadata["warnings"][0]
+        assert "Missing data file for device 'DevB'" in caplog.text
+
+        stitched_path = scan_dir / "stitched" / "Scan001_stitched_001.tsv"
+        assert stitched_path.exists()

--- a/ScanAnalysis/CHANGELOG.md
+++ b/ScanAnalysis/CHANGELOG.md
@@ -15,6 +15,11 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   update rows used for the legacy mutable `analysis/sNNN.txt` append, so
   generated scalar values remain recoverable if the watched s-file copy is
   deleted or regenerated.
+- `SingleDeviceScanAnalyzer` now logs analyzer-supplied result warnings from
+  the parent process after per-shot/per-bin workers return. This lets LiveWatch
+  surface incomplete-but-usable results such as `LineStitcher` shots with
+  missing sibling device files, while keeping the successful analysis state and
+  saved outputs.
 
 ### Changed
 

--- a/ScanAnalysis/scan_analysis/analyzers/common/single_device_scan_analyzer.py
+++ b/ScanAnalysis/scan_analysis/analyzers/common/single_device_scan_analyzer.py
@@ -741,6 +741,17 @@ class SingleDeviceScanAnalyzer(ScanAnalyzer, ABC):
         """
         return result.processed_image is not None or result.line_data is not None
 
+    def _log_result_warnings(self, unit_key, result: ImageAnalyzerResult) -> None:
+        """Log analyzer-supplied warnings in the parent LiveWatch process."""
+        metadata = result.metadata or {}
+        warnings = metadata.get("warnings") or metadata.get("analysis_warnings")
+        if not warnings:
+            return
+        if isinstance(warnings, str):
+            warnings = [warnings]
+        for warning in warnings:
+            logger.warning("Unit %s: %s", unit_key, warning)
+
     def _analyze_per_shot(self) -> None:
         """Fused per-shot pipeline using ``analyze_image_file``.
 
@@ -785,6 +796,7 @@ class SingleDeviceScanAnalyzer(ScanAnalyzer, ABC):
                 shot_num = futures[future]
                 try:
                     result: ImageAnalyzerResult = future.result()
+                    self._log_result_warnings(shot_num, result)
                     self._consume_result(shot_num, [shot_num], result)
                 except Exception as e:
                     logger.error(f"Analysis failed for shot {shot_num}: {e}")
@@ -845,6 +857,7 @@ class SingleDeviceScanAnalyzer(ScanAnalyzer, ABC):
                     result: ImageAnalyzerResult = self.image_analyzer.analyze_image(
                         averaged, aux
                     )
+                    self._log_result_warnings(bin_key, result)
                     self._consume_result(bin_key, bin_shots, result)
                 except Exception as e:
                     logger.error(f"Analysis failed for bin {bin_key}: {e}")

--- a/ScanAnalysis/tests/analyzers/test_result_warnings.py
+++ b/ScanAnalysis/tests/analyzers/test_result_warnings.py
@@ -1,0 +1,54 @@
+"""Tests for analyzer-supplied warning propagation."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import numpy as np
+
+from image_analysis.types import ImageAnalyzerResult
+from scan_analysis.analyzers.common.single_device_scan_analyzer import (
+    SingleDeviceScanAnalyzer,
+)
+
+
+class _Renderer:
+    display_contents = []
+
+
+class TestResultWarnings:
+    """Warnings embedded in analyzer results are logged in the parent process."""
+
+    def test_log_result_warnings_accepts_list_metadata(self, caplog):
+        analyzer = SingleDeviceScanAnalyzer(
+            device_name="DevA",
+            image_analyzer=SimpleNamespace(),
+            renderer=_Renderer(),
+        )
+        result = ImageAnalyzerResult(
+            data_type="1d",
+            line_data=np.column_stack([[0.0, 1.0], [2.0, 3.0]]),
+            metadata={"warnings": ["Missing sibling data for DevB"]},
+        )
+
+        with caplog.at_level("WARNING"):
+            analyzer._log_result_warnings(4, result)
+
+        assert "Unit 4: Missing sibling data for DevB" in caplog.text
+
+    def test_log_result_warnings_accepts_string_metadata(self, caplog):
+        analyzer = SingleDeviceScanAnalyzer(
+            device_name="DevA",
+            image_analyzer=SimpleNamespace(),
+            renderer=_Renderer(),
+        )
+        result = ImageAnalyzerResult(
+            data_type="1d",
+            line_data=np.column_stack([[0.0, 1.0], [2.0, 3.0]]),
+            metadata={"analysis_warnings": "Partial stitch"},
+        )
+
+        with caplog.at_level("WARNING"):
+            analyzer._log_result_warnings("average", result)
+
+        assert "Unit average: Partial stitch" in caplog.text


### PR DESCRIPTION
## Summary
- stitch and save available LineStitcher segments when sibling files are missing
- record loaded and missing sibling devices/files in result metadata with analyzer warnings
- log analyzer-supplied warnings from the ScanAnalysis parent process so LiveWatch can surface partial-output warnings

## Tests
- poetry run pytest tests/analyzers/test_line_stitcher.py
- poetry run pytest tests/analyzers/test_result_warnings.py
- pre-commit hooks during commit