### PR TITLE
M4 step (0): ScanRequest references a list of named save sets (union)

### DIFF
--- a/GEECS-Schemas/CHANGELOG.md
+++ b/GEECS-Schemas/CHANGELOG.md
@@ -5,6 +5,29 @@ All notable changes to GEECS-Schemas are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.0] - 2026-07-10
+
+### Changed
+
+- **`ScanRequest.save_set` renamed to `save_sets: list[str]`** (breaking-ish
+  field rename). A scan request now references a **list** of named save sets
+  instead of one, so operators mix and match named diagnostic groups (laser
+  cams, aux diagnostics, e-beam profiles) per scan; the engine resolves each
+  named set and unions their devices. A before-validator coerces a bare
+  string to a single-element list, so `save_sets="Amp4In"` and
+  `save_sets=["Amp4In"]` both validate (canonical stored form is the list) —
+  single-set ergonomics are preserved. The "a step/noscan request needs a
+  save set" rule is unchanged (still a runtime check in `run_scan_request`,
+  now adapted to the empty-list case). No serialized alias is kept.
+- **`convert_scan_preset` emits `save_sets = <referenced element names>`**
+  instead of a single synthetic per-preset save set. The legacy preset's
+  `Devices` list maps to `save_sets` verbatim and the engine unions them at
+  run time — the synthetic merged set is no longer needed. `PresetConversion`
+  still offers `composed_save_set` as a convenience for callers that want the
+  pre-merged set as one object; the converted request no longer depends on it.
+- Regenerated `docs/geecs_schemas/schema_reference.md` and the
+  `focuscan_scan_request.json` golden for the renamed field.
+
 ## [0.7.0] - 2026-07-09
 
 ### Changed

--- a/GEECS-Schemas/geecs_schemas/convert/presets.py
+++ b/GEECS-Schemas/geecs_schemas/convert/presets.py
@@ -25,10 +25,13 @@ Mapping:
 - ``Background`` → ``mode: noscan`` + ``background: true`` — background was
   never a distinct acquisition behaviour, only a metadata flag.
 - ``Info`` → ``description``.
-- ``Devices`` names several save *elements*; a :class:`ScanRequest` names
-  one save *set*.  When the converted elements are supplied, they are
-  composed into a single save set named after the preset; otherwise the
-  referenced element names are returned for later composition.
+- ``Devices`` names several save *elements*; a :class:`ScanRequest` names a
+  **list** of save sets (``save_sets``) and the engine unions their devices
+  at run time.  The converted request's ``save_sets`` is therefore the list
+  of referenced element names verbatim — no synthetic per-preset merged set
+  is needed.  For callers that still want the pre-merged set as one object,
+  passing the converted elements composes ``composed_save_set`` as a
+  convenience (:func:`compose_save_sets`); the request does not depend on it.
 
 Not expressed by legacy presets (left at schema defaults): ``acquisition``,
 ``trigger_profile``, ``actions``.
@@ -71,12 +74,14 @@ class PresetConversion:
     Attributes
     ----------
     scan_request : ScanRequest
-        The converted request; its ``save_set`` names the composed set.
+        The converted request; its ``save_sets`` list names the referenced
+        save elements (the engine unions them at run time).
     element_names : list of str
         The legacy save-element names the preset referenced.
     composed_save_set : SaveSet or None
-        The union of those elements as one save set — only when the caller
-        supplied the converted elements.
+        The union of those elements as one save set — a convenience, only
+        when the caller supplied the converted elements; the request itself
+        does not depend on it.
     notes : list of str
         Non-fatal information recorded during conversion.
     """
@@ -212,11 +217,15 @@ def convert_scan_preset(
             "the legacy preset dialect.)"
         )
 
+    # ``Devices`` names the referenced save elements; the request's save_sets
+    # is that list verbatim (the engine unions them at run time — no synthetic
+    # per-preset merged set).
+    element_names = list(document.get("Devices") or [])
     request: dict = {
         "mode": _MODE_MAP[legacy_mode],
         "description": document.get("Info") or "",
         "background": legacy_mode == "Background",
-        "save_set": preset_name,
+        "save_sets": element_names,
     }
     if legacy_mode == "1D Scan":
         for key in ("Variable", "Start", "Stop", "Step Size", "Shot per Step"):
@@ -243,7 +252,6 @@ def convert_scan_preset(
             )
         request["shots_per_step"] = document["Num Shots"]
 
-    element_names = list(document.get("Devices") or [])
     notes: list[str] = []
     composed: Optional[SaveSet] = None
     if save_sets is not None:

--- a/GEECS-Schemas/geecs_schemas/docgen.py
+++ b/GEECS-Schemas/geecs_schemas/docgen.py
@@ -63,7 +63,7 @@ axes:
   #   positions: {values: [1.5, 2.0, 2.5]}
 shots_per_step: 10
 acquisition: free_run
-save_set: undulator_baseline
+save_sets: [undulator_baseline, aux_diagnostics]  # unioned; a bare string also works
 trigger_profile: htu_shot_control
 actions:
   setup: [pre_scan_ebeam]

--- a/GEECS-Schemas/geecs_schemas/scan_request.py
+++ b/GEECS-Schemas/geecs_schemas/scan_request.py
@@ -39,7 +39,7 @@ from __future__ import annotations
 from enum import Enum
 from typing import Optional, Union
 
-from pydantic import Field, model_validator
+from pydantic import Field, field_validator, model_validator
 
 from geecs_schemas._base import SchemaModel, VersionedSchemaModel
 
@@ -364,7 +364,7 @@ class ScanRequest(VersionedSchemaModel):
     """One complete scan, ready to submit: what to do, what to save, how to trigger.
 
     Fill in the mode (sweep / stand still / optimize), the axis (or axes) to
-    sweep, how many shots per position, and the names of the save set,
+    sweep, how many shots per position, and the names of the save sets,
     trigger profile, and action plans to use.  Saving a request you like
     *is* a preset.
 
@@ -376,10 +376,14 @@ class ScanRequest(VersionedSchemaModel):
 
     Notes
     -----
-    Name-valued fields (``save_set``, ``trigger_profile``, entries in
+    Name-valued fields (``save_sets``, ``trigger_profile``, entries in
     ``actions``) are resolved against the experiment's config library at
     submission time; this model checks shape and mode consistency, not name
-    existence.
+    existence.  ``save_sets`` is a list — the engine resolves each named set
+    and **unions** their devices into the recorded device set (a device in
+    more than one set is merged), so operators mix and match named
+    diagnostic groups per scan.  A bare string is accepted for the
+    single-set case and stored as a one-element list.
 
     v1 grid semantics are a plain outer product in list order.  Traversal
     ordering options (snake/raster, per-axis direction) are deliberately not
@@ -419,12 +423,14 @@ class ScanRequest(VersionedSchemaModel):
             "and matches devices up by timestamp."
         ),
     )
-    save_set: Optional[str] = Field(
-        None,
+    save_sets: list[str] = Field(
+        default_factory=list,
         description=(
-            "Name of the save set listing the devices this scan REQUIRES — "
-            "the ones that get guarantees (completeness, dialogs, images, "
-            "rituals). Unset means no required devices beyond scan "
+            "Names of the save sets — reusable named device groups — "
+            "recorded for this scan; devices are unioned across them. Each "
+            "names the devices that get guarantees (completeness, dialogs, "
+            "images, rituals). A bare string is accepted and stored as a "
+            "one-element list. Empty means no required devices beyond scan "
             "bookkeeping."
         ),
     )
@@ -483,6 +489,30 @@ class ScanRequest(VersionedSchemaModel):
             "allowed with) mode 'optimize'."
         ),
     )
+
+    @field_validator("save_sets", mode="before")
+    @classmethod
+    def _coerce_save_sets(cls, value: object) -> object:
+        """Coerce a bare save-set name to a single-element list.
+
+        ``save_sets="Amp4In"`` and ``save_sets=["Amp4In"]`` both validate;
+        the canonical stored form is always the list. Anything else (a real
+        list, or a value of the wrong type) is passed through unchanged for
+        the normal list validation to accept or reject.
+
+        Parameters
+        ----------
+        value : object
+            The raw ``save_sets`` value before validation.
+
+        Returns
+        -------
+        object
+            ``[value]`` when *value* is a string, otherwise *value* unchanged.
+        """
+        if isinstance(value, str):
+            return [value]
+        return value
 
     @model_validator(mode="after")
     def _check_mode_consistency(self) -> "ScanRequest":

--- a/GEECS-Schemas/pyproject.toml
+++ b/GEECS-Schemas/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-schemas"
-version = "0.7.0"
+version = "0.8.0"
 description = "Versioned Pydantic schemas for GEECS scanner configs (scan requests, save sets, scan variables, trigger profiles, action plans) plus legacy-YAML converters."
 authors = ["Sam Barber <sbarber@lbl.gov>"]
 readme = "README.md"

--- a/GEECS-Schemas/tests/golden/focuscan_scan_request.json
+++ b/GEECS-Schemas/tests/golden/focuscan_scan_request.json
@@ -20,7 +20,9 @@
   "description": "Focus Scan",
   "mode": "step",
   "optimization": null,
-  "save_set": "00_focuscan",
+  "save_sets": [
+    "LP-FocusDiagnostics"
+  ],
   "schema_version": 1,
   "shots_per_step": 10,
   "trigger_profile": null,

--- a/GEECS-Schemas/tests/test_converters.py
+++ b/GEECS-Schemas/tests/test_converters.py
@@ -300,6 +300,9 @@ class TestPresets:
         assert request.grid_shape() == (17,)
         assert request.shots_per_step == 10
         assert conversion.element_names == ["LP-FocusDiagnostics"]
+        # save_sets names the referenced elements verbatim (the engine unions
+        # them at run time — no synthetic per-preset merged set).
+        assert request.save_sets == ["LP-FocusDiagnostics"]
         assert_matches_golden(
             request.model_dump(mode="json"), "focuscan_scan_request.json"
         )

--- a/GEECS-Schemas/tests/test_corpus_integration.py
+++ b/GEECS-Schemas/tests/test_corpus_integration.py
@@ -175,7 +175,7 @@ class TestFullCorpus:
                     if set(known) >= set(convert_scan_preset(path).element_names)
                     else None,
                 )
-                assert conversion.scan_request.save_set == path.stem
+                assert conversion.scan_request.save_sets == conversion.element_names
                 converted += 1
         assert converted >= 12
 

--- a/GEECS-Schemas/tests/test_scan_request.py
+++ b/GEECS-Schemas/tests/test_scan_request.py
@@ -23,7 +23,7 @@ def make_step_request(**overrides):
             }
         ],
         "shots_per_step": 10,
-        "save_set": "undulator_baseline",
+        "save_sets": ["undulator_baseline"],
         "trigger_profile": "htu_shot_control",
     }
     base.update(overrides)
@@ -67,13 +67,30 @@ class TestScanRequest:
                 ],
                 "shots_per_step": 10,
                 "acquisition": "free_run",
-                "save_set": "undulator_baseline",
+                "save_sets": ["undulator_baseline", "aux_diagnostics"],
                 "trigger_profile": "htu_laser_off",
                 "actions": {"setup": ["pre_scan_ebeam"], "closeout": []},
                 "description": "jet z scan with probe",
             }
         )
         assert request.actions.setup == ["pre_scan_ebeam"]
+        assert request.save_sets == ["undulator_baseline", "aux_diagnostics"]
+
+    def test_save_sets_bare_string_coerces_to_list(self):
+        # Single-set ergonomics: a bare string validates to a one-element list
+        # (canonical stored form is always the list).
+        request = make_step_request(save_sets="Amp4In")
+        assert request.save_sets == ["Amp4In"]
+
+    def test_save_sets_list_preserved(self):
+        request = make_step_request(save_sets=["laser_cams", "ebeam_profiles"])
+        assert request.save_sets == ["laser_cams", "ebeam_profiles"]
+
+    def test_save_sets_absent_defaults_empty(self):
+        # The schema does not require save_sets; the "needs a save set" rule
+        # for step/noscan is a runtime check in run_scan_request, not here.
+        request = ScanRequest.model_validate({"mode": "noscan", "shots_per_step": 5})
+        assert request.save_sets == []
 
     def test_two_axis_grid_round_trip(self):
         request = make_step_request(

--- a/GeecsBluesky/CHANGELOG.md
+++ b/GeecsBluesky/CHANGELOG.md
@@ -14,8 +14,11 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   effective `SaveSet` before deriving the recorded device set. Per-device
   union rule (documented in the `scan_request_runner` module docstring and
   `merge_save_sets`): `scalars` union order-preserving/deduped, `images` /
-  `db_scalars` / `all_scalars` OR together (True wins), the first non-`None`
-  `role` is kept, and entry-level `setup`/`closeout` ritual name lists union
+  `db_scalars` / `all_scalars` OR together (True wins), the single non-`None`
+  `role` is used — **conflicting explicit roles across the sets raise** (role
+  sets the pacemaker/contributor/snapshot semantics, so a device required by
+  more than one set must not disagree on it) — and entry-level
+  `setup`/`closeout` ritual name lists union
   (deduped). Entry-level rituals are collected across *all* named sets,
   deduped by plan name so a shared ritual runs once
   (`resolve_save_sets_and_rituals`). `save_set_to_devices_config`, the

--- a/GeecsBluesky/CHANGELOG.md
+++ b/GeecsBluesky/CHANGELOG.md
@@ -4,6 +4,32 @@ All notable changes to `geecs-bluesky` are documented here.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.25.0] - 2026-07-10
+
+### Changed
+
+- **Multi-save-set union in the runner (M4 step 0).** `ScanRequest` now
+  carries `save_sets: list[str]` (was `save_set`); `run_scan_request` and the
+  optimize path resolve **each** named save set and union them into one
+  effective `SaveSet` before deriving the recorded device set. Per-device
+  union rule (documented in the `scan_request_runner` module docstring and
+  `merge_save_sets`): `scalars` union order-preserving/deduped, `images` /
+  `db_scalars` / `all_scalars` OR together (True wins), the first non-`None`
+  `role` is kept, and entry-level `setup`/`closeout` ritual name lists union
+  (deduped). Entry-level rituals are collected across *all* named sets,
+  deduped by plan name so a shared ritual runs once
+  (`resolve_save_sets_and_rituals`). `save_set_to_devices_config`, the
+  reserved-boundary warning, and the run metadata (`save_sets` provenance
+  key) all operate on the merged set.
+- **Telemetry exclusion spans all named sets (M3c).**
+  `select_telemetry_variables` is now passed the merged save set, so Tier-2
+  background telemetry correctly excludes every device in *any* of the named
+  sets.
+- **GUI bridge is list-aware.** `BlueskyScanner._reinitialize_from_scan_request`
+  resolves `save_sets` via the new `resolve_save_sets_checked` (union of
+  devices; still refuses entry rituals / actions / multi-axis grids — routing
+  those through the bridge remains a later milestone).
+
 ## [0.24.1] - 2026-07-09
 
 ### Documentation

--- a/GeecsBluesky/CLAUDE.md
+++ b/GeecsBluesky/CLAUDE.md
@@ -400,6 +400,26 @@ overriding explicit values — and every applied default is recorded into
 the run metadata for provenance (closeout defaults append *after* the
 scan's own since geecs-schemas 0.2.0 — mirrored teardown).
 
+**M4 step 0 (0.25.0) — multiple save sets union.**  `ScanRequest` now carries
+`save_sets: list[str]` (was the single `save_set`); a bare string still
+validates (coerced to a one-element list by a schema before-validator).
+`run_scan_request` (and the optimize path) resolve **each** named save set and
+union them into one effective `SaveSet` (`merge_save_sets`) before deriving the
+recorded device set, so operators mix and match named diagnostic groups per
+scan.  Per-device union rule (documented on `merge_save_sets` and in the
+`scan_request_runner` module docstring): `scalars` union
+order-preserving/deduped, `images`/`db_scalars`/`all_scalars` OR together (True
+wins), first non-`None` `role` kept, entry-level `setup`/`closeout` ritual name
+lists union (deduped).  Entry rituals are collected across *all* named sets,
+deduped by plan name so a shared ritual runs once
+(`resolve_save_sets_and_rituals`).  Everything downstream operates on the
+merged set: `save_set_to_devices_config`, the reserved-boundary warning, and —
+crucially — **telemetry exclusion** (`select_telemetry_variables` gets the
+merged set, so Tier-2 telemetry excludes devices in *any* named set).  Run
+metadata records the list under `save_sets`.  The GUI bridge is list-aware via
+`resolve_save_sets_checked` (unions devices; still refuses entry rituals /
+actions / multi-axis — those remain a later GUI-submission milestone).
+
 **M3c (0.24.0) — the DB-integration runtime tier, GET-SIDE ONLY.**  Two
 get-side capabilities are live, all gated by schema flags that already
 existed (the schema fields are untouched — only descriptions changed); the
@@ -416,7 +436,8 @@ the DB blipped):
   policy (GUI bridge / off-network) only the explicit list is recorded — M3b
   behavior, strictly additive.
 - **Background telemetry (Tier 2).**  Every live device with a `get='yes'`
-  variable not in the save set → soft `CaTelemetryReadable` columns
+  variable not in *any* named save set (the merged set — see M4 above) → soft
+  `CaTelemetryReadable` columns
   (`telemetry_<device>-…`): read-only, never waited on (a failed read is a
   dtype-appropriate null cell — NaN for numeric, `""` for string — and a
   dead-at-start device is dropped with a log line via `session.telemetry`

--- a/GeecsBluesky/CLAUDE.md
+++ b/GeecsBluesky/CLAUDE.md
@@ -409,7 +409,9 @@ recorded device set, so operators mix and match named diagnostic groups per
 scan.  Per-device union rule (documented on `merge_save_sets` and in the
 `scan_request_runner` module docstring): `scalars` union
 order-preserving/deduped, `images`/`db_scalars`/`all_scalars` OR together (True
-wins), first non-`None` `role` kept, entry-level `setup`/`closeout` ritual name
+wins), the single non-`None` `role` used — **conflicting explicit roles across
+the sets raise** (role sets the pacemaker/contributor/snapshot semantics, so
+overlapping sets must not disagree) — entry-level `setup`/`closeout` ritual name
 lists union (deduped).  Entry rituals are collected across *all* named sets,
 deduped by plan name so a shared ritual runs once
 (`resolve_save_sets_and_rituals`).  Everything downstream operates on the

--- a/GeecsBluesky/geecs_bluesky/scan_request_runner.py
+++ b/GeecsBluesky/geecs_bluesky/scan_request_runner.py
@@ -16,7 +16,8 @@ This module owns the mapping:
   (:func:`merge_save_sets`) so operators mix and match named diagnostic
   groups per scan.  The per-device union rule: ``scalars`` union
   (order-preserving, deduped), ``images`` / ``db_scalars`` / ``all_scalars``
-  OR together (True wins), the first non-``None`` ``role`` is kept, and the
+  OR together (True wins), the single non-``None`` ``role`` is used (a device
+  the sets require with *conflicting* explicit roles is an error), and the
   entry-level ``setup`` / ``closeout`` ritual name lists union (deduped).
   Entry-level rituals are collected across *all* named sets, deduped by plan
   name so a shared ritual runs once (:func:`resolve_save_sets_and_rituals`).
@@ -780,11 +781,18 @@ def _merge_two_entries(existing: SaveSetEntry, addition: SaveSetEntry) -> SaveSe
     The documented per-device union rule (see :func:`merge_save_sets`):
     ``scalars`` union order-preserving and deduped, the boolean flags
     (``images`` / ``db_scalars`` / ``all_scalars``) OR together (True wins),
-    the first non-``None`` ``role`` is kept, and the entry-level
-    ``setup`` / ``closeout`` ritual name lists union (deduped, first
-    appearance). Reserved ``at_scan_start`` / ``at_scan_end`` maps merge
+    the single non-``None`` ``role`` is used — **conflicting explicit roles
+    across the sets raise** (:class:`GeecsConfigurationError`) rather than
+    resolving by list order, since role sets the acquisition semantics — and
+    the entry-level ``setup`` / ``closeout`` ritual name lists union (deduped,
+    first appearance). Reserved ``at_scan_start`` / ``at_scan_end`` maps merge
     key-wise (existing wins on a key clash) — they are inert in this version,
     so the choice only affects the one warning they draw.
+
+    Raises
+    ------
+    GeecsConfigurationError
+        If the two entries give the same device different explicit roles.
     """
 
     def _union(first: list[str], second: list[str]) -> list[str]:
@@ -793,6 +801,26 @@ def _merge_two_entries(existing: SaveSetEntry, addition: SaveSetEntry) -> SaveSe
             if item not in merged:
                 merged.append(item)
         return merged
+
+    # Role sets the acquisition guarantees (reference / contributor / snapshot
+    # pacemaker wiring in save_set_to_devices_config). Two named sets that
+    # both require the same device but disagree on its explicit role would
+    # otherwise be resolved by save_sets list order — silently giving the scan
+    # the wrong synchronization semantics. Refuse it (matching the legacy
+    # preset composer), rather than pick by order.
+    if (
+        existing.role is not None
+        and addition.role is not None
+        and existing.role != addition.role
+    ):
+        raise GeecsConfigurationError(
+            f"save-set union: device {existing.device!r} has conflicting "
+            f"explicit roles across the named save sets "
+            f"({existing.role.value!r} vs {addition.role.value!r}). Role sets "
+            f"the acquisition semantics, so a device required by more than one "
+            f"set must not disagree on it — give it the same role, or leave it "
+            f"unset, in the overlapping sets."
+        )
 
     return SaveSetEntry(
         device=existing.device,
@@ -819,9 +847,10 @@ def merge_save_sets(save_sets: list[SaveSet], name: str = "merged") -> SaveSet:
     - a device in only one set is carried over unchanged;
     - a device in more than one set is **merged** — ``scalars`` union
       (order-preserving, deduped), ``images`` / ``db_scalars`` /
-      ``all_scalars`` OR together (True wins), the first non-``None`` ``role``
-      is kept, and the entry-level ``setup`` / ``closeout`` ritual name lists
-      union (deduped).
+      ``all_scalars`` OR together (True wins), the single non-``None`` ``role``
+      is used (**conflicting explicit roles raise** — role sets the
+      acquisition semantics, so overlapping sets must not disagree), and the
+      entry-level ``setup`` / ``closeout`` ritual name lists union (deduped).
 
     A single-element list resolves to that set unchanged (cheap identity for
     the common single-set case).

--- a/GeecsBluesky/geecs_bluesky/scan_request_runner.py
+++ b/GeecsBluesky/geecs_bluesky/scan_request_runner.py
@@ -7,10 +7,21 @@ the engine here: a client builds a
 This module owns the mapping:
 
 - A :class:`ConfigResolver` turns the request's *names* into schema models —
-  ``save_set`` → :class:`~geecs_schemas.save_set.SaveSet`,
+  each name in ``save_sets`` → a :class:`~geecs_schemas.save_set.SaveSet`,
   ``trigger_profile`` → :class:`~geecs_schemas.trigger_profile.TriggerProfile`,
   an axis variable → a :class:`~geecs_schemas.scan_variables.ScanVariable`,
   action names → :class:`~geecs_schemas.action_plan.ActionPlan`.
+- **Multiple save sets union.**  ``ScanRequest.save_sets`` is a list; the
+  engine resolves each named set and unions them into one effective SaveSet
+  (:func:`merge_save_sets`) so operators mix and match named diagnostic
+  groups per scan.  The per-device union rule: ``scalars`` union
+  (order-preserving, deduped), ``images`` / ``db_scalars`` / ``all_scalars``
+  OR together (True wins), the first non-``None`` ``role`` is kept, and the
+  entry-level ``setup`` / ``closeout`` ritual name lists union (deduped).
+  Entry-level rituals are collected across *all* named sets, deduped by plan
+  name so a shared ritual runs once (:func:`resolve_save_sets_and_rituals`).
+  Everything downstream — ``save_set_to_devices_config``, telemetry
+  exclusion, the reserved-boundary warning — operates on the merged set.
 - :class:`ConfigsRepoResolver` reads the real configs repository
   (``scanner_configs/experiments/<Experiment>/``): a YAML file carrying a
   ``schema_version`` key loads as the new schema directly; anything else is
@@ -94,6 +105,7 @@ from geecs_schemas import (
     PseudoScanVariable,
     SaveRole,
     SaveSet,
+    SaveSetEntry,
     ScanRequest,
     ScanRequestMode,
     ScanVariable,
@@ -762,6 +774,132 @@ def resolve_save_set_and_rituals(
     return save_set, rituals
 
 
+def _merge_two_entries(existing: SaveSetEntry, addition: SaveSetEntry) -> SaveSetEntry:
+    """Merge a second entry for the same device into the first (union rule).
+
+    The documented per-device union rule (see :func:`merge_save_sets`):
+    ``scalars`` union order-preserving and deduped, the boolean flags
+    (``images`` / ``db_scalars`` / ``all_scalars``) OR together (True wins),
+    the first non-``None`` ``role`` is kept, and the entry-level
+    ``setup`` / ``closeout`` ritual name lists union (deduped, first
+    appearance). Reserved ``at_scan_start`` / ``at_scan_end`` maps merge
+    key-wise (existing wins on a key clash) — they are inert in this version,
+    so the choice only affects the one warning they draw.
+    """
+
+    def _union(first: list[str], second: list[str]) -> list[str]:
+        merged = list(first)
+        for item in second:
+            if item not in merged:
+                merged.append(item)
+        return merged
+
+    return SaveSetEntry(
+        device=existing.device,
+        scalars=_union(list(existing.scalars), list(addition.scalars)),
+        all_scalars=existing.all_scalars or addition.all_scalars,
+        images=existing.images or addition.images,
+        role=existing.role if existing.role is not None else addition.role,
+        setup=_union(list(existing.setup), list(addition.setup)),
+        closeout=_union(list(existing.closeout), list(addition.closeout)),
+        db_scalars=existing.db_scalars or addition.db_scalars,
+        at_scan_start={**addition.at_scan_start, **existing.at_scan_start},
+        at_scan_end={**addition.at_scan_end, **existing.at_scan_end},
+    )
+
+
+def merge_save_sets(save_sets: list[SaveSet], name: str = "merged") -> SaveSet:
+    """Union several resolved save sets into one effective save set.
+
+    ``ScanRequest.save_sets`` names a list of save sets; the engine records
+    the **union** of their devices so operators mix and match named
+    diagnostic groups per scan. The union rule, applied device by device
+    (first appearance across the list order preserved):
+
+    - a device in only one set is carried over unchanged;
+    - a device in more than one set is **merged** — ``scalars`` union
+      (order-preserving, deduped), ``images`` / ``db_scalars`` /
+      ``all_scalars`` OR together (True wins), the first non-``None`` ``role``
+      is kept, and the entry-level ``setup`` / ``closeout`` ritual name lists
+      union (deduped).
+
+    A single-element list resolves to that set unchanged (cheap identity for
+    the common single-set case).
+
+    Parameters
+    ----------
+    save_sets :
+        The resolved save sets to union, in ``ScanRequest.save_sets`` order.
+    name :
+        Name for the merged set (used in downstream error/warn messages).
+
+    Returns
+    -------
+    SaveSet
+        One save set whose entries are the deduped union of every input.
+    """
+    if len(save_sets) == 1:
+        return save_sets[0]
+    merged: dict[str, SaveSetEntry] = {}
+    for save_set in save_sets:
+        for entry in save_set.entries:
+            existing = merged.get(entry.device)
+            merged[entry.device] = (
+                entry.model_copy(deep=True)
+                if existing is None
+                else _merge_two_entries(existing, entry)
+            )
+    return SaveSet(name=name, entries=list(merged.values()))
+
+
+def resolve_save_sets_and_rituals(
+    resolver: ConfigResolver, names: list[str], *, merged_name: str = "merged"
+) -> tuple[SaveSet, dict[str, list[str]]]:
+    """Resolve every named save set, union them, and collect all rituals.
+
+    Resolves each name in *names* to a :class:`SaveSet`, merges them into one
+    effective save set (:func:`merge_save_sets`), and collects the entry-level
+    setup/closeout rituals across **all** sets, de-duplicated by plan name
+    (so a ritual shared by two sets still runs once). Every referenced ritual
+    plan name is validated against the action library now (fail-fast,
+    pre-claim), exactly as :func:`resolve_save_set_and_rituals` does for one
+    set.
+
+    Parameters
+    ----------
+    resolver :
+        Where names are looked up.
+    names :
+        The save-set names (``ScanRequest.save_sets``); must be non-empty.
+    merged_name :
+        Name for the merged set (used in downstream messages).
+
+    Returns
+    -------
+    tuple
+        ``(merged_save_set, rituals)`` — the unioned save set and its
+        de-duplicated ``{"setup": [...], "closeout": [...]}`` ritual names
+        collected across every named set.
+    """
+    resolved = [resolver.resolve_save_set(name) for name in names]
+    merged = merge_save_sets(resolved, name=merged_name)
+    # Collect rituals across ALL sets (not just the merged entries): a ritual
+    # is deduped by plan name across the whole selection so it runs once.
+    rituals: dict[str, list[str]] = {"setup": [], "closeout": []}
+    seen: dict[str, set[str]] = {"setup": set(), "closeout": set()}
+    for save_set in resolved:
+        per_set = collect_save_set_rituals(save_set)
+        for slot in ("setup", "closeout"):
+            for action_name in per_set[slot]:
+                if action_name not in seen[slot]:
+                    seen[slot].add(action_name)
+                    rituals[slot].append(action_name)
+    for slot_names in rituals.values():
+        for action_name in slot_names:
+            resolver.resolve_action_plan(action_name)
+    return merged, rituals
+
+
 def assemble_action_slots(
     actions: ActionBindings,
     applied_defaults: Mapping[str, Any],
@@ -1001,6 +1139,42 @@ def resolve_save_set_checked(resolver: ConfigResolver, name: str) -> SaveSet:
             f"run the request headless via GeecsSession.run (ritual "
             f"execution landed with the M3b milestone); save set {name!r} "
             f"references entry-level setup/closeout plans, which were "
+            f"resolved and are valid: {entry_actions}"
+        )
+    return save_set
+
+
+def resolve_save_sets_checked(resolver: ConfigResolver, names: list[str]) -> SaveSet:
+    """Resolve and union several save sets, refusing rituals — **GUI-bridge only**.
+
+    The multi-set counterpart of :func:`resolve_save_set_checked`: every name
+    in *names* is resolved, the sets are unioned into one effective SaveSet
+    (:func:`merge_save_sets`), and any entry-level ritual (collected across
+    all named sets) is *validated* then refused — the GUI bridge stages
+    requests through the legacy exec-config machinery and does not run rituals
+    yet. The bridge still refuses actions/multi-axis elsewhere; this only
+    makes the save-set resolution list-aware.
+
+    Parameters
+    ----------
+    resolver :
+        Where names are looked up.
+    names :
+        The save-set names (``ScanRequest.save_sets``).
+
+    Returns
+    -------
+    SaveSet
+        The unioned save set (guaranteed free of entry-level actions).
+    """
+    save_set, rituals = resolve_save_sets_and_rituals(resolver, names)
+    entry_actions = [n for slot in rituals.values() for n in slot]
+    if entry_actions:
+        raise NotImplementedError(
+            f"the GUI bridge does not execute save-set entry rituals yet — "
+            f"run the request headless via GeecsSession.run (ritual "
+            f"execution landed with the M3b milestone); save sets {names!r} "
+            f"reference entry-level setup/closeout plans, which were "
             f"resolved and are valid: {entry_actions}"
         )
     return save_set
@@ -1418,12 +1592,14 @@ def run_scan_request(
             skipped_actions=skipped_actions,
         )
 
-    if not request.save_set:
+    if not request.save_sets:
         raise GeecsConfigurationError(
-            f"a {request.mode.value!r} ScanRequest needs a save_set — "
-            "without one the scan would record nothing"
+            f"a {request.mode.value!r} ScanRequest needs at least one save "
+            "set in save_sets — without one the scan would record nothing"
         )
-    save_set, rituals = resolve_save_set_and_rituals(resolver, request.save_set)
+    # Multiple named save sets union into one effective save set (devices
+    # deduped/merged; rituals collected across all sets, deduped by name).
+    save_set, rituals = resolve_save_sets_and_rituals(resolver, request.save_sets)
 
     # M3c DB-integration runtime tier — get-side only.  The policy provider is
     # failure-tolerant (empty policy on a missing/unreachable DB), so it never
@@ -1489,6 +1665,8 @@ def run_scan_request(
             created.extend(telemetry_readables)
 
         md: dict[str, Any] = {"scan_request_mode": request.mode.value}
+        # Provenance: which named save sets were unioned for this scan.
+        md["save_sets"] = list(request.save_sets)
         if applied_defaults:
             # Provenance: the run records exactly which experiment defaults
             # filled in fields the submitter left unset.
@@ -1635,8 +1813,10 @@ def _run_optimize_request(
         # (no scan-boundary hook on GeecsSession.optimize).  The DB set-side
         # (scan start/end writes) is disabled everywhere in this version.
         scalar_policy = make_scalar_policy(session)
-        if request.save_set:
-            save_set, rituals = resolve_save_set_and_rituals(resolver, request.save_set)
+        if request.save_sets:
+            save_set, rituals = resolve_save_sets_and_rituals(
+                resolver, request.save_sets
+            )
             # Reserved DB set-side overrides are inert here too — warn once, as
             # on the scan/noscan path, so the promise holds in every mode.
             warn_if_reserved_boundary_overrides(save_set)
@@ -1664,6 +1844,9 @@ def _run_optimize_request(
             created.append(movable)
 
         md: dict[str, Any] = {"scan_request_mode": request.mode.value}
+        if request.save_sets:
+            # Provenance: which named save sets were unioned for this scan.
+            md["save_sets"] = list(request.save_sets)
         if applied_defaults:
             md["applied_defaults"] = applied_defaults
         if skipped:

--- a/GeecsBluesky/geecs_bluesky/scanner_bridge/bluesky_scanner.py
+++ b/GeecsBluesky/geecs_bluesky/scanner_bridge/bluesky_scanner.py
@@ -89,7 +89,7 @@ from geecs_bluesky.scan_request_runner import (
     resolve_and_validate_actions,
     resolve_defaults_for,
     resolve_movable_target,
-    resolve_save_set_checked,
+    resolve_save_sets_checked,
     save_set_to_devices_config,
     trigger_writes_from_profile,
 )
@@ -427,12 +427,14 @@ class BlueskyScanner:
         )
         self._shots_per_step = int(request.shots_per_step)
 
-        if not request.save_set:
+        if not request.save_sets:
             raise GeecsConfigurationError(
-                f"a {request.mode.value!r} ScanRequest needs a save_set — "
-                "without one the scan would record nothing"
+                f"a {request.mode.value!r} ScanRequest needs at least one "
+                "save set in save_sets — without one the scan would record "
+                "nothing"
             )
-        save_set = resolve_save_set_checked(resolver, request.save_set)
+        # Multiple named save sets union into one effective device set.
+        save_set = resolve_save_sets_checked(resolver, request.save_sets)
         self._devices_config = save_set_to_devices_config(save_set)
 
         if request.trigger_profile:

--- a/GeecsBluesky/pyproject.toml
+++ b/GeecsBluesky/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-bluesky"
-version = "0.24.1"
+version = "0.25.0"
 description = "Bluesky / ophyd-async bridge for the GEECS control system"
 authors = ["Sam Barber <sbarber@lbl.gov>"]
 readme = "README.md"

--- a/GeecsBluesky/tests/test_bluesky_scanner_scan_request_seam.py
+++ b/GeecsBluesky/tests/test_bluesky_scanner_scan_request_seam.py
@@ -258,7 +258,7 @@ def test_scan_request_noscan_parity_with_exec_config(monkeypatch) -> None:
             "mode": "noscan",
             "shots_per_step": 3,
             "acquisition": "free_run",
-            "save_set": "baseline",
+            "save_sets": ["baseline"],
             "description": "stats run",
         }
     )
@@ -294,7 +294,7 @@ def test_scan_request_step_uses_resolved_variable_kind(monkeypatch) -> None:
             "mode": "step",
             "shots_per_step": 2,
             "acquisition": "free_run",
-            "save_set": "baseline",
+            "save_sets": ["baseline"],
             "axes": [{"variable": "jet_z", "positions": {"values": [4.0, 4.5, 6.0]}}],
         }
     )
@@ -334,7 +334,7 @@ def test_scan_request_trigger_profile_becomes_shot_control(monkeypatch) -> None:
             "mode": "noscan",
             "shots_per_step": 1,
             "acquisition": "free_run",
-            "save_set": "baseline",
+            "save_sets": ["baseline"],
             "trigger_profile": "HTU",
         }
     )
@@ -358,7 +358,7 @@ def test_multi_axis_request_refused_at_reinitialize() -> None:
     request = ScanRequest.model_validate(
         {
             "mode": "step",
-            "save_set": "baseline",
+            "save_sets": ["baseline"],
             "axes": [
                 {"variable": "a", "positions": {"start": 0, "end": 1, "step": 1}},
                 {"variable": "b", "positions": {"start": 0, "end": 1, "step": 1}},
@@ -375,7 +375,7 @@ def test_actions_validated_then_refused_at_reinitialize() -> None:
     request = ScanRequest.model_validate(
         {
             "mode": "noscan",
-            "save_set": "baseline",
+            "save_sets": ["baseline"],
             "actions": {"setup": ["prep"]},
         }
     )
@@ -390,7 +390,7 @@ def test_optimize_request_refused_at_reinitialize() -> None:
     request = ScanRequest.model_validate(
         {
             "mode": "optimize",
-            "save_set": "baseline",
+            "save_sets": ["baseline"],
             "optimization": {
                 "variables": {"jet_z": [0.0, 1.0]},
                 "evaluator": {"module": "m", "class": "C"},
@@ -413,7 +413,7 @@ def test_exec_config_path_clears_request_state(monkeypatch) -> None:
         {
             "mode": "step",
             "shots_per_step": 1,
-            "save_set": "baseline",
+            "save_sets": ["baseline"],
             "axes": [{"variable": "v", "positions": {"start": 0, "end": 1, "step": 1}}],
         }
     )

--- a/GeecsBluesky/tests/test_experiment_defaults_integration.py
+++ b/GeecsBluesky/tests/test_experiment_defaults_integration.py
@@ -59,7 +59,7 @@ def test_experiment_defaults_fill_minimal_request_from_real_configs() -> None:
             "mode": "noscan",
             "shots_per_step": 3,
             "acquisition": "strict",
-            "save_set": os.environ.get("GEECS_HW_CAMERA", "Amp4In"),
+            "save_sets": [os.environ.get("GEECS_HW_CAMERA", "Amp4In")],
         }
     )
     assert minimal.trigger_profile is None

--- a/GeecsBluesky/tests/test_scan_request_hardware.py
+++ b/GeecsBluesky/tests/test_scan_request_hardware.py
@@ -66,7 +66,15 @@ def test_scan_request_noscan_runs_on_hardware() -> None:
     from geecs_schemas import ScanRequest
 
     experiment = os.environ.get("GEECS_HW_EXPERIMENT", "Undulator")
-    camera_save_set = os.environ.get("GEECS_HW_CAMERA", "Amp4In")
+    # One or more save sets, comma-separated — the engine unions their devices
+    # (M4 multi-save-set). Default is a single set, so single-set runs are
+    # unchanged; set e.g. GEECS_HW_CAMERA="Amp4In,AuxDiagnostics" to exercise
+    # the union on hardware.
+    save_sets = [
+        name.strip()
+        for name in os.environ.get("GEECS_HW_CAMERA", "Amp4In").split(",")
+        if name.strip()
+    ]
     trigger_profile = os.environ.get("GEECS_HW_TRIGGER_PROFILE", "HTU-LaserOFF")
     acquisition = os.environ.get("GEECS_HW_ACQUISITION", "strict")
     shots = int(os.environ.get("GEECS_HW_SHOTS", "5"))
@@ -77,9 +85,9 @@ def test_scan_request_noscan_runs_on_hardware() -> None:
             "mode": "noscan",
             "shots_per_step": shots,
             "acquisition": acquisition,
-            "save_set": camera_save_set,
+            "save_sets": save_sets,
             "trigger_profile": trigger_profile,
-            "description": "M3b hardware verification (test_scan_request_hardware)",
+            "description": "M4 hardware verification (test_scan_request_hardware)",
         }
     )
     resolver = ConfigsRepoResolver(experiment)

--- a/GeecsBluesky/tests/test_scan_request_runner.py
+++ b/GeecsBluesky/tests/test_scan_request_runner.py
@@ -27,8 +27,11 @@ from geecs_bluesky.scan_request_runner import (
     assemble_action_slots,
     build_action_registry,
     collect_save_set_rituals,
+    merge_save_sets,
     resolve_save_set_and_rituals,
     resolve_save_set_checked,
+    resolve_save_sets_and_rituals,
+    resolve_save_sets_checked,
     run_scan_request,
     save_set_to_devices_config,
     trigger_writes_from_profile,
@@ -289,6 +292,35 @@ actions:
         value: 'off'
 """
 
+# Second save set in the LegacyExp experiment for the multi-save-set (M4)
+# union tests: a fresh device (U_Aux) plus one device (U_Cam) that overlaps
+# UC_Test — merged per the documented union rule (scalars unioned, images
+# OR'd True, entry ritual unioned once).
+AUX_SAVE_SET = """\
+schema_version: 1
+name: UC_Aux
+entries:
+  - device: U_Aux
+    scalars: [Aux1]
+  - device: U_Cam
+    scalars: [Extra]
+    images: true
+    setup: [cam_ritual]
+"""
+
+# Ritual-free counterpart of UC_Aux for the GUI-bridge union test (the bridge
+# path still refuses entry rituals — a set with one would raise there).
+AUX_SAVE_SET_PLAIN = """\
+schema_version: 1
+name: UC_AuxPlain
+entries:
+  - device: U_Aux
+    scalars: [Aux1]
+  - device: U_Cam
+    scalars: [Extra]
+    images: true
+"""
+
 # New-schema save set whose entries carry setup/closeout rituals (shared
 # ritual named by both entries — must run once).
 RITUAL_SAVE_SET = """\
@@ -323,6 +355,8 @@ def configs_root(tmp_path):
     (legacy / "action_library").mkdir()
     (legacy / "action_library" / "actions.yaml").write_text(LEGACY_ACTIONS)
     (legacy / "save_devices" / "RitualSet.yaml").write_text(RITUAL_SAVE_SET)
+    (legacy / "save_devices" / "UC_Aux.yaml").write_text(AUX_SAVE_SET)
+    (legacy / "save_devices" / "UC_AuxPlain.yaml").write_text(AUX_SAVE_SET_PLAIN)
 
     modern = tmp_path / "ModernExp"
     (modern / "save_devices").mkdir(parents=True)
@@ -545,7 +579,7 @@ def _noscan_request(**overrides) -> ScanRequest:
         mode="noscan",
         shots_per_step=3,
         acquisition="free_run",
-        save_set="UC_Test",
+        save_sets=["UC_Test"],
         description="stats",
     )
     base.update(overrides)
@@ -617,7 +651,7 @@ def test_step_request_motor_kind_and_position_list(modern_resolver) -> None:
     session = _FakeSession()
     request = _noscan_request(
         mode="step",
-        save_set="NewSet",
+        save_sets=["NewSet"],
         axes=[{"variable": "jet_z", "positions": {"values": [4.0, 4.5, 6.0]}}],
     )
     run_scan_request(session, request, modern_resolver)
@@ -751,7 +785,7 @@ def test_unknown_action_name_fails_validation_first(legacy_resolver) -> None:
 def test_pseudo_variable_raises_not_implemented(modern_resolver) -> None:
     request = _noscan_request(
         mode="step",
-        save_set="NewSet",
+        save_sets=["NewSet"],
         axes=[{"variable": "combo", "positions": {"start": 0, "end": 1, "step": 1}}],
     )
     with pytest.raises(NotImplementedError, match="pseudo"):
@@ -759,10 +793,8 @@ def test_pseudo_variable_raises_not_implemented(modern_resolver) -> None:
 
 
 def test_noscan_without_save_set_is_rejected(legacy_resolver) -> None:
-    with pytest.raises(GeecsConfigurationError, match="save_set"):
-        run_scan_request(
-            _FakeSession(), _noscan_request(save_set=None), legacy_resolver
-        )
+    with pytest.raises(GeecsConfigurationError, match="save set"):
+        run_scan_request(_FakeSession(), _noscan_request(save_sets=[]), legacy_resolver)
 
 
 def _optimize_request(**overrides) -> ScanRequest:
@@ -770,7 +802,7 @@ def _optimize_request(**overrides) -> ScanRequest:
         mode="optimize",
         shots_per_step=5,
         acquisition="free_run",
-        save_set="UC_Test",
+        save_sets=["UC_Test"],
         optimization={
             "variables": {"jet_z": [0.0, 1.0], "U_S1H:Current": [-2.0, 2.0]},
             "objectives": {"counts": "MAXIMIZE"},
@@ -1165,7 +1197,7 @@ def test_entry_rituals_execute_between_defaults_and_request(
     de-duplicated (both entries name cam_ritual; it runs once)."""
     session = _FakeSession()
     request = _noscan_request(
-        save_set="RitualSet",
+        save_sets=["RitualSet"],
         actions={"setup": ["scan_prep"], "closeout": ["scan_cleanup"]},
     )
     run_scan_request(session, request, legacy_resolver)
@@ -1189,7 +1221,7 @@ def test_converted_element_actions_execute(legacy_resolver) -> None:
     """A legacy element's setup_action converts to an entry ritual that the
     runner compiles and executes (the extracted plan resolves by name)."""
     session = _FakeSession()
-    request = _noscan_request(save_set="UC_WithActions")
+    request = _noscan_request(save_sets=["UC_WithActions"])
     run_scan_request(session, request, legacy_resolver)
 
     kwargs = session.scan_kwargs
@@ -1234,7 +1266,7 @@ def test_full_fake_session_flow_axes_actions_multi_device_trigger(
             "mode": "step",
             "shots_per_step": 2,
             "acquisition": "free_run",
-            "save_set": "RitualSet",
+            "save_sets": ["RitualSet"],
             "trigger_profile": "Spans",
             "axes": [
                 {"variable": "jet_z", "positions": {"start": 0, "end": 1, "step": 1}},
@@ -1321,7 +1353,7 @@ def test_optimize_skips_actions_and_records_them(legacy_resolver, caplog) -> Non
 def test_optimize_skips_entry_rituals_and_records_them(legacy_resolver) -> None:
     """Save-set entry rituals are skipped and recorded, not refused."""
     session = _FakeSession()
-    request = _optimize_request(save_set="RitualSet")
+    request = _optimize_request(save_sets=["RitualSet"])
 
     def objective(bin_data) -> float:
         return 1.0
@@ -1420,7 +1452,7 @@ def _db_noscan_request(**overrides):
         mode="noscan",
         shots_per_step=2,
         acquisition="strict",
-        save_set="UC_Test",
+        save_sets=["UC_Test"],
     )
     base.update(overrides)
     return ScanRequest.model_validate(base)
@@ -1477,7 +1509,7 @@ def test_reserved_boundary_fields_warn_and_are_not_applied(
     monkeypatch.setattr(legacy_resolver, "resolve_save_set", lambda name: save_set)
 
     with caplog.at_level(logging.WARNING):
-        run_scan_request(session, _db_noscan_request(save_set="X"), legacy_resolver)
+        run_scan_request(session, _db_noscan_request(save_sets=["X"]), legacy_resolver)
 
     # Exactly one reserved-not-honored warning, naming the device.
     reserved = [
@@ -1623,7 +1655,7 @@ def test_optimize_warns_on_reserved_boundary_fields(
     with caplog.at_level(logging.WARNING):
         run_scan_request(
             session,
-            _optimize_request(save_set="X"),
+            _optimize_request(save_sets=["X"]),
             legacy_resolver,
             objective=objective,
             suggester=object(),
@@ -1635,3 +1667,124 @@ def test_optimize_warns_on_reserved_boundary_fields(
     ]
     assert len(reserved) == 1
     assert "U_DG645_ShotControl" in reserved[0].getMessage()
+
+
+# ---------------------------------------------------------------------------
+# M4: multiple save sets union into one effective device set
+# ---------------------------------------------------------------------------
+
+
+def test_merge_save_sets_unions_devices_and_merges_overlap() -> None:
+    a = SaveSet(
+        name="A",
+        entries=[
+            SaveSetEntry(device="U_Cam", scalars=["MaxCounts"], setup=["r1"]),
+            SaveSetEntry(device="U_Slow", role="snapshot"),
+        ],
+    )
+    b = SaveSet(
+        name="B",
+        entries=[
+            SaveSetEntry(
+                device="U_Cam",
+                scalars=["Extra"],
+                images=True,
+                all_scalars=True,
+                setup=["r1", "r2"],
+            ),
+            SaveSetEntry(device="U_Aux", scalars=["Aux1"]),
+        ],
+    )
+    merged = merge_save_sets([a, b], name="merged")
+    by_device = {e.device: e for e in merged.entries}
+    # union of devices, first-appearance order across the list
+    assert [e.device for e in merged.entries] == ["U_Cam", "U_Slow", "U_Aux"]
+    cam = by_device["U_Cam"]
+    # scalars union order-preserving/deduped, images + all_scalars OR True,
+    # entry rituals unioned once (deduped)
+    assert cam.scalars == ["MaxCounts", "Extra"]
+    assert cam.images is True
+    assert cam.all_scalars is True
+    assert cam.setup == ["r1", "r2"]
+    # role: first non-None kept (U_Slow's snapshot survives; U_Cam has none)
+    assert cam.role is None
+    assert by_device["U_Slow"].role.value == "snapshot"
+
+
+def test_merge_save_sets_single_element_is_identity() -> None:
+    only = SaveSet(name="s", entries=[SaveSetEntry(device="U_A", scalars=["x"])])
+    assert merge_save_sets([only]) is only
+
+
+def test_two_save_sets_record_union_of_devices(legacy_resolver) -> None:
+    session = _FakeSession()
+    request = _noscan_request(save_sets=["UC_Test", "UC_Aux"])
+    run_scan_request(session, request, legacy_resolver)
+    # UC_Test = {U_Cam(sync), U_Cam2(sync), U_Slow(async)}, UC_Aux adds U_Aux
+    # (sync) and overlaps U_Cam (merged).  Free-run roles by position: first
+    # sync = reference detector, later sync = contributor, async = snapshot.
+    assert session.devices == [
+        ("U_Cam", "detector"),
+        ("U_Cam2", "contributor"),
+        ("U_Aux", "contributor"),
+        ("U_Slow", "snapshot"),
+    ]
+    # provenance: both named sets recorded
+    assert session.scan_kwargs["md"]["save_sets"] == ["UC_Test", "UC_Aux"]
+
+
+def test_two_save_sets_merge_overlapping_device_config(legacy_resolver) -> None:
+    # U_Cam is in both UC_Test (MaxCounts, images) and UC_Aux (Extra, images):
+    # the merged devices_config unions its scalars and keeps images on.
+    merged, _rituals = resolve_save_sets_and_rituals(
+        legacy_resolver, ["UC_Test", "UC_Aux"]
+    )
+    config = save_set_to_devices_config(merged)
+    assert config["U_Cam"]["variable_list"] == ["MaxCounts", "Extra"]
+    assert config["U_Cam"]["save_nonscalar_data"] is True
+    assert "U_Aux" in config
+
+
+def test_two_save_sets_ritual_deduped_once(legacy_resolver) -> None:
+    # UC_Aux's U_Cam entry names cam_ritual; RitualSet also names it.  Across
+    # the two named sets the ritual is collected once (deduped by plan name).
+    _merged, rituals = resolve_save_sets_and_rituals(
+        legacy_resolver, ["RitualSet", "UC_Aux"]
+    )
+    assert rituals["setup"].count("cam_ritual") == 1
+
+
+def test_telemetry_excludes_devices_from_all_named_sets(
+    monkeypatch, legacy_resolver
+) -> None:
+    # A device in ANY named set must be excluded from Tier-2 telemetry: pass
+    # the merged save set (all devices across all sets) to the selector.
+    policy = _M3cPolicy(
+        subscribed={
+            "U_Cam": ["MaxCounts"],  # in UC_Test → excluded
+            "U_Aux": ["Aux1"],  # in UC_Aux → excluded
+            "U_Press": ["Pressure"],  # in neither → telemetry
+        }
+    )
+    _install_policy(monkeypatch, policy)
+    session = _M3cSession()
+    run_scan_request(
+        session,
+        _db_noscan_request(save_sets=["UC_Test", "UC_Aux"]),
+        legacy_resolver,
+    )
+    assert session.telemetry_calls == [("U_Press", ["Pressure"])]
+    assert session.scan_kwargs["md"]["background_telemetry"] == {
+        "U_Press": ["Pressure"]
+    }
+
+
+def test_bridge_unions_save_sets(configs_root) -> None:
+    # The GUI-bridge path resolves the list and unions devices (still refusing
+    # rituals/actions/multi-axis elsewhere — out of scope here).
+    save_set = resolve_save_sets_checked(
+        ConfigsRepoResolver("LegacyExp", experiments_root=configs_root),
+        ["UC_Test", "UC_AuxPlain"],
+    )
+    devices = {e.device for e in save_set.entries}
+    assert devices == {"U_Cam", "U_Cam2", "U_Slow", "U_Aux"}

--- a/GeecsBluesky/tests/test_scan_request_runner.py
+++ b/GeecsBluesky/tests/test_scan_request_runner.py
@@ -1716,6 +1716,26 @@ def test_merge_save_sets_single_element_is_identity() -> None:
     assert merge_save_sets([only]) is only
 
 
+def test_merge_save_sets_conflicting_roles_raise() -> None:
+    """Same device with different explicit roles across sets is an error.
+
+    Role wires the reference/contributor/snapshot semantics, so resolving it by
+    save_sets list order would silently give the scan the wrong synchronization
+    for a required device — refuse instead (review finding on #479).
+    """
+    a = SaveSet(name="A", entries=[SaveSetEntry(device="U_Cam", role="reference")])
+    b = SaveSet(name="B", entries=[SaveSetEntry(device="U_Cam", role="snapshot")])
+    with pytest.raises(GeecsConfigurationError, match="conflicting"):
+        merge_save_sets([a, b])
+    # Order must not change the outcome: the reverse also raises.
+    with pytest.raises(GeecsConfigurationError, match="conflicting"):
+        merge_save_sets([b, a])
+    # Same role, or one side unset, is fine — no raise, the role survives.
+    unset = SaveSet(name="C", entries=[SaveSetEntry(device="U_Cam")])
+    merged = merge_save_sets([a, unset])
+    assert merged.entries[0].role.value == "reference"
+
+
 def test_two_save_sets_record_union_of_devices(legacy_resolver) -> None:
     session = _FakeSession()
     request = _noscan_request(save_sets=["UC_Test", "UC_Aux"])

--- a/docs/geecs_schemas/schema_reference.md
+++ b/docs/geecs_schemas/schema_reference.md
@@ -19,7 +19,7 @@ One complete scan, ready to submit: what to do, what to save, how to trigger.
 | `axes` | `list[ScanAxis]` | no | empty | For step scans: what to sweep. One entry is a simple 1-D scan; several entries form a grid visiting every combination, with the first axis as the outermost (slowest) loop and the last as the innermost (fastest). Leave empty for noscan and optimize. |
 | `shots_per_step` | `int` | no | 1 | How many shots to take at each scan position / grid point (or in total for a noscan). |
 | `acquisition` | `AcquisitionMode` | no | 'strict' | 'strict' fires shot by shot and guarantees every device is in every row; 'free_run' lets the trigger run at the machine rate and matches devices up by timestamp. |
-| `save_set` | `str (optional)` | no | None | Name of the save set listing the devices this scan REQUIRES — the ones that get guarantees (completeness, dialogs, images, rituals). Unset means no required devices beyond scan bookkeeping. |
+| `save_sets` | `list[str]` | no | empty | Names of the save sets — reusable named device groups — recorded for this scan; devices are unioned across them. Each names the devices that get guarantees (completeness, dialogs, images, rituals). A bare string is accepted and stored as a one-element list. Empty means no required devices beyond scan bookkeeping. |
 | `background_telemetry` | `bool (optional)` | no | None | Also log every other live experiment device as best-effort snapshot columns — the variables the GEECS experiment database marks for scan logging (MySQL table expt_device_variable, get='yes') — read from the gateway's always-on monitor cache: read-only and never waited on, so it cannot slow or stall the scan; dead devices are dropped with a log line, never a dialog or abort. Leave unset to inherit the experiment default; set true/false to override for this scan. |
 | `trigger_profile` | `str (optional)` | no | None | Name of the trigger profile that drives the shot trigger. Unset means the scan does not manage the trigger. |
 | `trigger_variant` | `str (optional)` | no | None | Optional variant of the trigger profile to use, e.g. 'laser_off'. Leave unset for the profile's base behaviour. |
@@ -42,7 +42,7 @@ axes:
   #   positions: {values: [1.5, 2.0, 2.5]}
 shots_per_step: 10
 acquisition: free_run
-save_set: undulator_baseline
+save_sets: [undulator_baseline, aux_diagnostics]  # unioned; a bare string also works
 trigger_profile: htu_shot_control
 actions:
   setup: [pre_scan_ebeam]

--- a/docs/geecs_schemas/schemas_overview.md
+++ b/docs/geecs_schemas/schemas_overview.md
@@ -127,7 +127,7 @@ flowchart LR
     SCAN(("the scan"))
 
     SR -- "axes: jet_z, ..." --> SV
-    SR -- "save_set: baseline" --> SS
+    SR -- "save_sets: [baseline, ...]" --> SS
     SR -- "trigger_profile: htu" --> TP
     SR -- "actions: [...]" --> AP
     SV --> SCAN


### PR DESCRIPTION
First build of the M4 GUI arc (`Planning/gui_retrofit/00_overview.md` step 0). A scan names **`save_sets: list[str]`** instead of one `save_set`, so operators mix and match named diagnostic groups (laser cams, aux, e-beam profiles) per scan; the engine resolves each named `SaveSet` and **unions** their devices.

## Change
- **Schema:** `ScanRequest.save_set` → `save_sets: list[str]`, before-validator coerces a bare string to `[str]` (single-set ergonomics). Clean rename. Step/noscan still requires a non-empty list.
- **Runner:** `merge_save_sets` unions device-by-device (scalars union, images/db_scalars/all_scalars OR, first role, rituals unioned once); rituals collected across all sets deduped by name; `md["save_sets"]` recorded.
- **Telemetry (M3c):** Tier-2 excludes devices from **any** named set.
- **Bridge:** `resolve_save_sets_checked` (union; still refuses actions/multi-axis — step (i)).
- **Converter:** `convert_scan_preset` emits `save_sets = referenced element names`.
- Goldens + schema reference regenerated (no-drift green). GEECS-Schemas 0.8.0, GeecsBluesky 0.25.0.

## Verified
- Hermetic: GEECS-Schemas **218**, GeecsBluesky **284** (7 new union tests).
- **Hardware** (free-run noscan, `save_sets=["Amp4In","Amp4Out"]`): run `25222169` — `md['save_sets']=['Amp4In','Amp4Out']`, both cameras built as detectors (2 in t0-sync), both present in the event stream. The union lands.

Next: M4 step (i) — bridge parity via `run_scan_request` delegation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)