### PR TITLE
tooling: scripts/commit.sh + three pre-commit hook additions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,6 +24,11 @@ repos:
       - id: check-yaml
         args: [--unsafe]
         exclude: "(^extras/|.*/third_party_sdks/|.*_ui\\.py$|.*/tests/)"
+      - id: check-toml
+      - id: check-added-large-files
+        args: [--maxkb=1024]
+      - id: mixed-line-ending
+        args: [--fix=lf]
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.9.9

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,7 +81,13 @@ own nested worktrees under `.claude/worktrees/`.
   main dev environment. Each subpackage can also be installed standalone.
 - **Linting:** `ruff` (replaces flake8/isort) + `pydocstyle` (numpy convention)
 - **Pre-commit hooks:** ruff, ruff-format, pydocstyle, check-yaml, check-json,
-  check-ast — run automatically on commit
+  check-ast — run automatically on commit. The auto-fixing hooks rewrite files
+  during the commit, which aborts that commit ("files were modified by this
+  hook") so you re-stage and retry — and on *merge* commits triggers a
+  stash/restore conflict that can silently abort. Use **`scripts/commit.sh -m
+  "..."`** (after `git add`): it applies the auto-fixes first, re-stages them,
+  then commits, so the commit succeeds on the first try. Any `git commit` args
+  pass through.
 - **Docs:** MkDocs (root `pyproject.toml`) — `mkdocs serve` from repo root
 
 ## Code Style Conventions

--- a/scripts/commit.sh
+++ b/scripts/commit.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+#
+# commit.sh — commit with pre-commit's auto-fixes applied *first*.
+#
+# Why this exists
+# ---------------
+# pre-commit's auto-fixing hooks (ruff-format, ruff --fix, trailing-whitespace,
+# end-of-file-fixer) rewrite files during the commit-time hook run. When they
+# do, pre-commit *fails the commit* ("files were modified by this hook") so you
+# re-stage the fixes and try again. On a merge commit it goes further: pre-commit
+# stashes unstaged changes, a hook rewrites a staged file, and restoring the
+# stash conflicts — the commit aborts, often silently if you only skim the tail
+# of the output. This bites hardest in many-file / merge / agent-driven commits.
+#
+# What it does
+# ------------
+# Runs pre-commit on the staged files FIRST (applying auto-fixes), re-stages
+# exactly those files, then commits. The commit-time hook run is then a clean
+# no-op — the fixers are idempotent — so the commit succeeds on the first try,
+# with the check-* hooks (ast, yaml, merge-conflict, no-commit-to-branch, …)
+# still enforced as a final gate. All arguments pass through to `git commit`.
+#
+# Usage
+# -----
+#   git add <files>
+#   scripts/commit.sh -m "your message"      # any `git commit` args work
+#
+# It does NOT stage anything you did not `git add` yourself — it only re-stages
+# the files that were already staged (capturing the auto-fixes to them).
+set -euo pipefail
+
+# The files staged for this commit, recorded NUL-delimited in a temp file
+# (space-safe; bash variables cannot hold NUL, so a file — not a var).
+staged="$(mktemp)"
+trap 'rm -f "$staged"' EXIT
+git diff --cached --name-only -z >"$staged"
+if [ ! -s "$staged" ]; then
+    echo "commit.sh: nothing staged — 'git add' your changes first." >&2
+    exit 1
+fi
+
+# Prefer a pre-commit on PATH; fall back to the Poetry environment.
+if command -v pre-commit >/dev/null 2>&1; then
+    pc() { pre-commit "$@"; }
+else
+    pc() { poetry run pre-commit "$@"; }
+fi
+
+# Apply auto-fixes to the staged set (pre-commit defaults to the staged files).
+# It exits non-zero when it rewrites a file — expected here, so don't abort.
+pc run || true
+
+# Re-stage exactly the originally-staged files so the fixes are included.
+# `xargs -0 ... < file` is portable across BSD (macOS) and GNU xargs.
+xargs -0 git add -- <"$staged"
+
+# Commit. The commit-time hook run is now clean, so this passes on the first try.
+git commit "$@"


### PR DESCRIPTION
Two small dev-tooling improvements to master.

## 1. `scripts/commit.sh` — commit with pre-commit auto-fixes applied first
The auto-fixing hooks (`ruff-format`, `ruff --fix`, `trailing-whitespace`, `end-of-file-fixer`) rewrite files during the commit hook run, which **aborts the commit** so you re-stage and retry — and on **merge commits** triggers a stash/restore conflict that can silently abort. `scripts/commit.sh` runs pre-commit on the staged files first, re-stages the fixes, then commits — so the commit lands on the first try (`check-*` gates still enforced).

```
git add <files>
scripts/commit.sh -m "message"     # any git commit args pass through
```
Only re-stages files you already staged (NUL-safe temp file; portable BSD/GNU xargs). Falls back to `poetry run pre-commit`. Documented in root `CLAUDE.md`. Dogfooded — every commit on this branch was made with it.

## 2. Three pre-commit hook additions (verified clean across the tree)
- **`check-toml`** — Poetry monorepo with a dozen `pyproject.toml`s; a malformed one breaks everything. (No offenders today.)
- **`check-added-large-files` (`--maxkb=1024`)** — stops accidental big data/image commits in a DAQ/analysis repo. (Nothing tracked exceeds 1 MB.)
- **`mixed-line-ending` (`--fix=lf`)** — Mac + Windows control machines; normalizes CRLF/LF. (The only CRLF file lives under the excluded `extras/`, so zero churn.)

`pre-commit.ci` (CI-side auto-fixing) is deliberately deferred to a later day.

🤖 Generated with [Claude Code](https://claude.com/claude-code)