### PR TITLE
cleanup(vision-v1) pass 1: dead code, dedup, stale refs, resolver split

### DIFF
--- a/GeecsBluesky/CHANGELOG.md
+++ b/GeecsBluesky/CHANGELOG.md
@@ -4,6 +4,46 @@ All notable changes to `geecs-bluesky` are documented here.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.27.0] - 2026-07-10
+
+Cleanup pass 1 (audit: `Planning/cleanup_vision_v1/00_overview.md`) — no
+behavior change.
+
+### Changed
+
+- **`ConfigResolver` / `ConfigsRepoResolver` moved to
+  `geecs_bluesky/config_resolver.py`** (a pure relocation — the resolver
+  layer shared no private helpers with the execution code). Both names are
+  still importable from `scan_request_runner` (re-exported), so the existing
+  import surface is unchanged.
+- `BlueskyScanner._build_positions` now delegates to the session's
+  `_positions` (was a near-verbatim copy of the start/end/step → linspace
+  rule).
+
+### Removed
+
+- Dead GUI-compat shims on `BlueskyScanner`: `dialog_queue` and
+  `restore_failures` (the GUI stopped reading them when `ScanManager`
+  dropped them; `last_reinit_error` stays — the GUI reads it), plus the
+  unused `_ScanConfig` import shim and `_CONNECT_TIMEOUT` constant.
+- The singular `resolve_save_set_checked` / `resolve_save_set_and_rituals`
+  pair — superseded by the plural M4 step-0 forms
+  (`resolve_save_sets_checked` / `resolve_save_sets_and_rituals`); no
+  production caller remained. Their tests were ported to the plural forms.
+- `utils.build_signal_attrs` — its attr-collision disambiguation was never
+  wired into any detector (all call `safe_name` directly); test-only.
+
+### Fixed
+
+- **Stale-reference sweep (~20 sites):** docstring cross-references to the
+  deleted direct-backend device classes (`GeecsTriggerable`, `GeecsMotor`,
+  `GeecsSettable`, `GeecsGenericDetector`, `GeecsTimestampedReadable`,
+  `GeecsSnapshotReadable`) now point at the `Ca*` classes; the
+  `devices/ca/*` module headers describe what each device *is* instead of
+  comparing it to a deleted class; `step_scan.py`'s module example no longer
+  shows the deleted host/port constructor (rewritten against `GeecsSession`
+  factories); `CLAUDE.md` acquisition-mode dispatch names corrected.
+
 ## [0.26.0] - 2026-07-10
 
 ### Added

--- a/GeecsBluesky/CLAUDE.md
+++ b/GeecsBluesky/CLAUDE.md
@@ -49,13 +49,15 @@ geecs_bluesky/
   preflight.py              # Pre-flight checks as a pipeline (pass/ask/abort);
                             #   GatewayLivenessCheck + FreeRunStalenessCheck,
                             #   run pre-claim, questions via OperatorChannel
-  scan_request_runner.py    # run a geecs_schemas.ScanRequest: ConfigResolver
-                            #   protocol + ConfigsRepoResolver (new-schema YAML
-                            #   or legacy-convert), SaveSet→devices_config and
+  config_resolver.py        # ConfigResolver protocol + ConfigsRepoResolver:
+                            #   ScanRequest names → schema models (new-schema
+                            #   YAML directly, else legacy-convert)
+  scan_request_runner.py    # run a geecs_schemas.ScanRequest:
+                            #   SaveSet→devices_config and
                             #   TriggerProfile→ShotControlWrites (ordered,
-                            #   multi-device) adapters, action slot assembly
-                            #   (§4.4b layers) + compile + signal prefetch,
-                            #   multi-axis grid execution
+                            #   multi-device) adapters, save-set union,
+                            #   action slot assembly (§4.4b layers) + compile
+                            #   + signal prefetch, multi-axis grid execution
   scanner_bridge/
     bluesky_scanner.py      # BlueskyScanner — ScanManager-compatible GUI bridge
                             #   (reinitialize also accepts a ScanRequest)
@@ -109,7 +111,7 @@ geecs_bluesky/
   models/
     shot_control.py         # ShotControlConfig / ShotControlState — validated YAML
   exceptions.py             # scan-level errors; wire-level ones re-exported from the gateway
-  utils.py                  # safe_name() / build_signal_attrs()
+  utils.py                  # safe_name()
 
 The GEECS access-layer core (``transport/``, ``db/``, ``pv_naming``,
 ``FakeGeecsServer``, wire-level exceptions) lives in **GeecsCAGateway** — this
@@ -241,8 +243,8 @@ difference lives entirely in the per-config YAML.
 a `GEECS_BLUESKY_ACQUISITION_MODE` env override (env wins), default strict.
 `_classify_device_roles` assigns each save device a role from the mode: free-run
 → first sync device is `reference`, later sync devices are `contributor`
-(`GeecsTimestampedReadable`), async are `snapshot`; strict → all sync are
-`triggered` (`GeecsGenericDetector`).  STANDARD and NOSCAN share one
+(`CaTimestampedReadable`), async are `snapshot`; strict → all sync are
+`triggered` (`CaGenericDetector`).  STANDARD and NOSCAN share one
 `_run_step_scan` body (NOSCAN = `motor=None`, one no-move bin).
 
 ### Tiled integration

--- a/GeecsBluesky/geecs_bluesky/config_resolver.py
+++ b/GeecsBluesky/geecs_bluesky/config_resolver.py
@@ -1,0 +1,366 @@
+"""Resolve the names a ScanRequest carries into validated schema models.
+
+:class:`ConfigResolver` is the protocol; :class:`ConfigsRepoResolver` is the
+production implementation over the real configs-repo layout
+(``scanner_configs/experiments/<Experiment>/``).  A YAML file carrying a
+``schema_version`` key loads as the new schema directly; anything else is
+converted from its legacy dialect via :mod:`geecs_schemas.convert` — so the
+whole existing config corpus is usable immediately, no flag day.
+
+Execution of a resolved request lives in
+:mod:`geecs_bluesky.scan_request_runner`.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Protocol, runtime_checkable
+
+import yaml
+
+from geecs_bluesky.exceptions import GeecsConfigurationError
+from geecs_bluesky.scanner_configs import SHOT_CONTROL_FOLDER, scanner_configs_base
+from geecs_schemas import (
+    ActionPlan,
+    ActionPlanLibrary,
+    ExperimentDefaults,
+    SaveSet,
+    ScanVariables,
+    ScanVariableSpec,
+    TriggerProfile,
+)
+from geecs_schemas.convert import (
+    convert_action_library,
+    convert_save_element,
+    convert_scan_variables,
+    convert_shot_control,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# ConfigResolver protocol
+# ---------------------------------------------------------------------------
+
+
+@runtime_checkable
+class ConfigResolver(Protocol):
+    """Resolves the names a ScanRequest carries into schema models."""
+
+    def resolve_save_set(self, name: str) -> SaveSet:
+        """Return the save set called *name*."""
+        ...
+
+    def resolve_trigger_profile(self, name: str) -> TriggerProfile:
+        """Return the trigger profile called *name*."""
+        ...
+
+    def resolve_scan_variable(self, name: str) -> ScanVariableSpec:
+        """Return the scan-variable entry called *name*."""
+        ...
+
+    def resolve_action_plan(self, name: str) -> ActionPlan:
+        """Return the action plan called *name*."""
+        ...
+
+    def resolve_experiment_defaults(self) -> ExperimentDefaults | None:
+        """Return the experiment's defaults, or ``None`` if none are declared.
+
+        Defaults apply where the request is silent (default trigger
+        profile; default setup/closeout plans prepended); what was applied
+        is recorded for provenance (see
+        :func:`geecs_bluesky.scan_request_runner.apply_experiment_defaults`).
+        Resolvers without this method are tolerated (no defaults).
+        """
+        ...
+
+
+class ConfigsRepoResolver:
+    """Resolver over the real configs-repo layout, converter-backed.
+
+    Reads ``scanner_configs/experiments/<experiment>/`` (the same resolution
+    roots as :func:`geecs_bluesky.scanner_configs.scanner_configs_base`):
+
+    - ``save_devices/<name>.yaml`` — save sets (legacy save elements)
+    - ``shot_control_configurations/<name>.yaml`` — trigger profiles
+    - ``scan_devices/scan_variables.yaml`` (new schema) or the legacy
+      ``scan_devices/scan_devices.yaml`` + ``scan_devices/composite_variables.yaml``
+      pair — the scan-variable catalog
+    - ``action_library/actions.yaml`` — the action-plan library
+
+    A file whose top level carries ``schema_version`` is loaded as the new
+    schema; anything else goes through the matching legacy converter — so
+    the existing corpus works unchanged and files can migrate one at a time.
+
+    Parameters
+    ----------
+    experiment :
+        Experiment folder name under ``scanner_configs/experiments``.
+    experiments_root :
+        Override for the experiments root (tests); defaults to the
+        production resolution (``GEECS_SCANNER_CONFIG_DIR`` env var or
+        config.ini), resolved lazily on first use.
+    """
+
+    SAVE_SET_FOLDER = "save_devices"
+    TRIGGER_FOLDER = SHOT_CONTROL_FOLDER
+    SCAN_VARIABLES_FOLDER = "scan_devices"
+    ACTION_FOLDER = "action_library"
+
+    def __init__(
+        self, experiment: str, experiments_root: str | Path | None = None
+    ) -> None:
+        self._experiment = experiment
+        self._experiments_root = (
+            Path(experiments_root) if experiments_root is not None else None
+        )
+        self._scan_variables_cache: ScanVariables | None = None
+        self._action_library_cache: ActionPlanLibrary | None = None
+        # Plans extracted by the save-element converter (legacy
+        # setup_action / closeout_action / scan_setup become named plans
+        # referenced from the entries) — they live beside the element, not
+        # in the experiment's action library, so name resolution falls back
+        # to them after the library.
+        self._extracted_element_actions: dict[str, ActionPlan] = {}
+
+    @property
+    def _root(self) -> Path:
+        root = self._experiments_root or scanner_configs_base()
+        return root / self._experiment
+
+    @staticmethod
+    def _strip_yaml_suffix(name: str) -> str:
+        for suffix in (".yaml", ".yml"):
+            if name.endswith(suffix):
+                return name[: -len(suffix)]
+        return name
+
+    def _load_yaml(self, path: Path, kind: str, name: str) -> dict:
+        """Load one YAML mapping, failing loudly with the config kind/name."""
+        if not path.exists():
+            raise GeecsConfigurationError(
+                f"{kind} {name!r} not found for experiment "
+                f"{self._experiment!r}: no file at {path}"
+            )
+        document = yaml.safe_load(path.read_text())
+        if document is None:
+            document = {}
+        if not isinstance(document, dict):
+            raise GeecsConfigurationError(
+                f"{kind} {name!r}: expected a YAML mapping at the top of "
+                f"{path}, got {type(document).__name__}"
+            )
+        return document
+
+    def resolve_save_set(self, name: str) -> SaveSet:
+        """Load the save set *name* (new schema, else converted save element).
+
+        Parameters
+        ----------
+        name :
+            File stem under ``save_devices/`` (``.yaml`` optional).
+
+        Returns
+        -------
+        SaveSet
+            The validated save set.
+
+        Raises
+        ------
+        GeecsConfigurationError
+            If the file is missing or is an action-only legacy element
+            (nothing to record).
+        """
+        stem = self._strip_yaml_suffix(name)
+        path = self._root / self.SAVE_SET_FOLDER / f"{stem}.yaml"
+        document = self._load_yaml(path, "save set", name)
+        if "schema_version" in document:
+            return SaveSet.model_validate(document)
+        result = convert_save_element(document, name=stem)
+        for note in result.notes:
+            logger.info("save set %s (converted from legacy): %s", stem, note)
+        # The converter extracts element-level setup/closeout (and per-device
+        # scan_setup) into named plans referenced from the entries; remember
+        # them so resolve_action_plan can validate those references.
+        self._extracted_element_actions.update(result.actions)
+        if result.save_set is None:
+            raise GeecsConfigurationError(
+                f"save set {name!r} ({path}) is an action-only legacy element "
+                "— it lists no devices to record"
+            )
+        return result.save_set
+
+    def resolve_trigger_profile(self, name: str) -> TriggerProfile:
+        """Load the trigger profile *name* (new schema, else converted).
+
+        Parameters
+        ----------
+        name :
+            File stem under ``shot_control_configurations/``.
+
+        Returns
+        -------
+        TriggerProfile
+            The validated profile.
+
+        Raises
+        ------
+        GeecsConfigurationError
+            If the file is missing or names no trigger device.
+        """
+        stem = self._strip_yaml_suffix(name)
+        path = self._root / self.TRIGGER_FOLDER / f"{stem}.yaml"
+        document = self._load_yaml(path, "trigger profile", name)
+        if "schema_version" in document:
+            return TriggerProfile.model_validate(document)
+        profile = convert_shot_control(document, name=stem)
+        if profile is None:
+            raise GeecsConfigurationError(
+                f"trigger profile {name!r} ({path}) is empty / names no "
+                "device — it cannot drive a scan's trigger"
+            )
+        return profile
+
+    def _scan_variables_catalog(self) -> ScanVariables:
+        """Load (and cache) the experiment's scan-variable catalog."""
+        if self._scan_variables_cache is not None:
+            return self._scan_variables_cache
+        folder = self._root / self.SCAN_VARIABLES_FOLDER
+        new_schema = folder / "scan_variables.yaml"
+        if new_schema.exists():
+            document = self._load_yaml(new_schema, "scan variables", "catalog")
+            catalog = ScanVariables.model_validate(document)
+        else:
+            scan_devices = folder / "scan_devices.yaml"
+            composites = folder / "composite_variables.yaml"
+            if not scan_devices.exists() and not composites.exists():
+                raise GeecsConfigurationError(
+                    f"no scan-variable catalog for experiment "
+                    f"{self._experiment!r}: expected {new_schema} or the "
+                    f"legacy pair in {folder}"
+                )
+            catalog = convert_scan_variables(
+                scan_devices if scan_devices.exists() else None,
+                composites if composites.exists() else None,
+            )
+        self._scan_variables_cache = catalog
+        return catalog
+
+    def resolve_scan_variable(self, name: str) -> ScanVariableSpec:
+        """Look up the scan variable *name* in the experiment catalog.
+
+        Parameters
+        ----------
+        name :
+            Friendly variable name (a key of the catalog).
+
+        Returns
+        -------
+        ScanVariable or PseudoScanVariable
+            The catalog entry.
+
+        Raises
+        ------
+        GeecsConfigurationError
+            If the name is not in the catalog (known names are listed).
+        """
+        catalog = self._scan_variables_catalog()
+        try:
+            return catalog.variables[name]
+        except KeyError:
+            raise GeecsConfigurationError(
+                f"scan variable {name!r} is not in the "
+                f"{self._experiment!r} catalog. Known variables: "
+                f"{sorted(catalog.variables)}"
+            ) from None
+
+    def _action_library(self) -> ActionPlanLibrary:
+        """Load (and cache) the experiment's action-plan library."""
+        if self._action_library_cache is not None:
+            return self._action_library_cache
+        path = self._root / self.ACTION_FOLDER / "actions.yaml"
+        document = self._load_yaml(path, "action library", "actions")
+        if "schema_version" in document:
+            library = ActionPlanLibrary.model_validate(document)
+        else:
+            library = convert_action_library(document)
+        self._action_library_cache = library
+        return library
+
+    def resolve_action_plan(self, name: str) -> ActionPlan:
+        """Look up the action plan *name* in the experiment library.
+
+        Parameters
+        ----------
+        name :
+            Plan name (a key of the action library).
+
+        Returns
+        -------
+        ActionPlan
+            The named plan.
+
+        Raises
+        ------
+        GeecsConfigurationError
+            If the name is not in the library (known names are listed).
+        """
+        # Plans the save-element converter extracted resolve first: they
+        # live beside their element (their `<element>_setup` names cannot
+        # collide with library names in practice), and an experiment may
+        # have converted elements without having an action library at all.
+        plan = self._extracted_element_actions.get(name)
+        if plan is not None:
+            return plan
+        library = self._action_library()
+        try:
+            return library.plans[name]
+        except KeyError:
+            raise GeecsConfigurationError(
+                f"action plan {name!r} is not in the {self._experiment!r} "
+                f"action library. Known plans: {sorted(library.plans)}"
+            ) from None
+
+    def action_plan_registry(self) -> dict[str, ActionPlan]:
+        """Return every named plan visible to nested ``run`` steps.
+
+        The experiment's action library plus the plans the save-element
+        converter extracted (which win on a name collision, matching
+        :meth:`resolve_action_plan`'s lookup order).  An experiment without
+        an action library still gets its extracted element plans.
+
+        Returns
+        -------
+        dict
+            ``{plan_name: ActionPlan}``.
+        """
+        plans: dict[str, ActionPlan] = {}
+        try:
+            plans.update(self._action_library().plans)
+        except GeecsConfigurationError:
+            pass  # no actions.yaml — extracted element plans may still exist
+        plans.update(self._extracted_element_actions)
+        return plans
+
+    DEFAULTS_FILE = "experiment_defaults.yaml"
+
+    def resolve_experiment_defaults(self) -> ExperimentDefaults | None:
+        """Load and validate the experiment's defaults file, if one exists.
+
+        Reads ``<experiment>/experiment_defaults.yaml`` into the
+        :class:`~geecs_schemas.ExperimentDefaults` model (there is no
+        legacy dialect behind it — the legacy scanner kept these choices in
+        GUI state).
+
+        Returns
+        -------
+        ExperimentDefaults or None
+            The validated defaults, or ``None`` when no file exists.
+        """
+        path = self._root / self.DEFAULTS_FILE
+        if not path.exists():
+            return None
+        document = self._load_yaml(path, "experiment defaults", self.DEFAULTS_FILE)
+        return ExperimentDefaults.model_validate(document)

--- a/GeecsBluesky/geecs_bluesky/devices/ca/generic_detector.py
+++ b/GeecsBluesky/geecs_bluesky/devices/ca/generic_detector.py
@@ -1,21 +1,18 @@
 """CaGenericDetector — the scanner's triggered detector over the CA gateway.
 
-The CA counterpart of
-:class:`~geecs_bluesky.devices.generic_detector.GeecsGenericDetector`: one
+One
 readable signal per variable, ``trigger()`` gated on ``acq_timestamp`` (via
 :class:`~geecs_bluesky.devices.ca.triggerable.CaTriggerable`'s persistent CA
 monitor), the schema-v1 sync-device companion columns on every read, and native
 non-scalar file saving.
 
-The companion-column and asset logic is the *shared* domain layer — this class
-composes the same :class:`~geecs_bluesky.devices.shot_id.ShotIdSupport` and
-:class:`~geecs_bluesky.devices.nonscalar_save.NonScalarSaveSupport` mixins the
-direct detector uses (same tracker, data keys, save-path column, and
-Resource/Datum documents).  Only the transport differs: ``acq_timestamp`` comes
-from the CA monitor cache instead of the TCP shot cache, and the
+The companion-column and asset logic is the *shared* domain layer
+(:class:`~geecs_bluesky.devices.shot_id.ShotIdSupport` and
+:class:`~geecs_bluesky.devices.nonscalar_save.NonScalarSaveSupport` mixins);
+``acq_timestamp`` comes from the CA monitor cache, and the
 ``localsavingpath`` / ``save`` controls are CA signals that read the gateway
 readback PV and write its ``…:SP`` setpoint (which forwards to the GEECS UDP
-set), instead of direct UDP signals.
+set).
 """
 
 from __future__ import annotations

--- a/GeecsBluesky/geecs_bluesky/devices/ca/motor.py
+++ b/GeecsBluesky/geecs_bluesky/devices/ca/motor.py
@@ -1,7 +1,6 @@
 """CaMotor — position-feedback motor driven through the CA gateway.
 
-The CA counterpart of :class:`~geecs_bluesky.devices.motor.GeecsMotor`.  Two
-layers of convergence:
+Two layers of convergence:
 
 1. The gateway's ``…:SP`` write forwards to the GEECS UDP set, which itself
    blocks until the device reports the set converged (per the DB tolerance) or

--- a/GeecsBluesky/geecs_bluesky/devices/ca/settable.py
+++ b/GeecsBluesky/geecs_bluesky/devices/ca/settable.py
@@ -3,8 +3,7 @@
 The gateway exposes a settable GEECS variable as two PVs: a readback
 (``[Experiment:]Device:Variable``, fed by the device stream) and a setpoint
 (``…:SP``, whose CA puts the gateway forwards to the device over UDP).  This
-device writes the setpoint and reads back the real value — the CA counterpart of
-:class:`~geecs_bluesky.devices.settable.GeecsSettable`.
+device writes the setpoint and reads back the real value.
 
 Completion semantics — CaSettable already waits
 -----------------------------------------------

--- a/GeecsBluesky/geecs_bluesky/devices/ca/snapshot.py
+++ b/GeecsBluesky/geecs_bluesky/devices/ca/snapshot.py
@@ -1,7 +1,6 @@
 """CaSnapshotReadable — asynchronous GEECS readback sampled per event row.
 
-The CA counterpart of
-:class:`~geecs_bluesky.devices.snapshot.GeecsSnapshotReadable`: latest streamed
+Latest streamed
 values from the gateway readback PVs, read when a Bluesky event is recorded.
 No ``acq_timestamp`` gating and no shot-id companion columns — intended for
 asynchronous state/readback devices (stages, slow controls) snapshotted

--- a/GeecsBluesky/geecs_bluesky/devices/ca/timestamped_readable.py
+++ b/GeecsBluesky/geecs_bluesky/devices/ca/timestamped_readable.py
@@ -1,14 +1,11 @@
 """CaTimestampedReadable — free-run sync contributor over the CA gateway.
 
-The CA counterpart of
-:class:`~geecs_bluesky.devices.timestamped_readable.GeecsTimestampedReadable`:
-read like a snapshot (no blocking ``trigger()``, so it never gates the event
+Read like a snapshot (no blocking ``trigger()``, so it never gates the event
 row) but carrying the sync-device companion columns labeled relative to the
 reference.  The labeling semantics — row shot-id peeking, bounded grace wait,
-offset/valid emission — are the *shared*
-:class:`~geecs_bluesky.devices.contributor.FreeRunContributorSupport` mixin
-(the same code the direct contributor runs); this class supplies the CA
-transport underneath: ``acq_timestamp`` from the persistent gateway monitor
+offset/valid emission — are the shared
+:class:`~geecs_bluesky.devices.contributor.FreeRunContributorSupport` mixin;
+this class supplies the CA transport underneath: ``acq_timestamp`` from the persistent gateway monitor
 (:class:`~geecs_bluesky.devices.ca.triggerable.CaAcqTimestampReadable`), and
 ``localsavingpath`` / ``save`` controls as CA signals writing the gateway
 ``…:SP`` setpoints.

--- a/GeecsBluesky/geecs_bluesky/devices/ca/triggerable.py
+++ b/GeecsBluesky/geecs_bluesky/devices/ca/triggerable.py
@@ -4,14 +4,12 @@ The GEECS shot signal is the device's ``acq_timestamp`` advancing once per
 shot.  Over the gateway that is a readback PV; a **persistent CA monitor** on
 it (started at ``connect()``) feeds a local cache and an event queue:
 
-* :class:`CaAcqTimestampReadable` — readable signals plus the monitor/cache.
-  ``_last_acq`` is the CA-side analogue of the direct backend's TCP shot
-  cache; free-run *contributors* build on this (no blocking trigger).
+* :class:`CaAcqTimestampReadable` — readable signals plus the monitor/cache
+  (``_last_acq``); free-run *contributors* build on this (no blocking trigger).
 * :class:`CaTriggerable` — adds ``trigger()``, which blocks until the queue
-  delivers a value different from the baseline — the CA-sourced analogue of
-  :class:`~geecs_bluesky.devices.triggerable.GeecsTriggerable`.
+  delivers a value different from the baseline.
 
-Like ``GeecsTriggerable``, the stale-frame drain and baseline capture happen
+The stale-frame drain and baseline capture happen
 **synchronously inside** ``trigger()``, before the status is returned — so a
 shot fired immediately after ``bps.trigger`` (the strict single-shot pattern:
 trigger → fire → wait) can never land in a blind window between baselining and

--- a/GeecsBluesky/geecs_bluesky/devices/contributor.py
+++ b/GeecsBluesky/geecs_bluesky/devices/contributor.py
@@ -23,7 +23,7 @@ on the direct backend, from the persistent CA monitor cache on the CA backend),
 plus the :class:`~geecs_bluesky.devices.shot_id.ShotIdSupport` and
 :class:`~geecs_bluesky.devices.nonscalar_save.NonScalarSaveSupport` mixins whose
 helpers it emits through.  Both
-:class:`~geecs_bluesky.devices.timestamped_readable.GeecsTimestampedReadable`
+:class:`~geecs_bluesky.devices.ca.timestamped_readable.CaTimestampedReadable`
 (direct) and the CA contributor compose it, so the labeling semantics cannot
 diverge between backends.
 """

--- a/GeecsBluesky/geecs_bluesky/exceptions.py
+++ b/GeecsBluesky/geecs_bluesky/exceptions.py
@@ -47,7 +47,7 @@ __all__ = [
 class GeecsTriggerTimeoutError(GeecsError):
     """``acq_timestamp`` did not advance within the trigger timeout.
 
-    Raised by :class:`~geecs_bluesky.devices.triggerable.GeecsTriggerable`
+    Raised by :class:`~geecs_bluesky.devices.ca.triggerable.CaTriggerable`
     when no new shot arrives within ``_trigger_timeout`` seconds.  Typical
     causes: DG645 not firing, camera not acquiring, or trigger cable fault.
     """
@@ -80,7 +80,7 @@ class GeecsQuiescenceTimeoutError(GeecsError):
 class GeecsMotorTimeoutError(GeecsError):
     """Motor did not reach the target position within ``move_timeout``.
 
-    Raised by :class:`~geecs_bluesky.devices.motor.GeecsMotor` when the
+    Raised by :class:`~geecs_bluesky.devices.ca.motor.CaMotor` when the
     position polling loop expires.  Possible causes: stage stall, mechanical
     obstruction, wrong tolerance, or very long move.  Do not auto-retry —
     a stalled stage may need operator intervention.

--- a/GeecsBluesky/geecs_bluesky/plans/free_run_step_scan.py
+++ b/GeecsBluesky/geecs_bluesky/plans/free_run_step_scan.py
@@ -9,7 +9,7 @@ How a row is built
 Only the reference is Triggerable, so :func:`bluesky.plan_stubs.trigger_and_read`
 waits exclusively on its ``acq_timestamp`` advance ("a physical shot
 happened — emit a row").  Contributors
-(:class:`~geecs_bluesky.devices.timestamped_readable.GeecsTimestampedReadable`)
+(:class:`~geecs_bluesky.devices.ca.timestamped_readable.CaTimestampedReadable`)
 are then read without triggering: each labels its latest cached data with
 ``shot_id`` / ``shot_offset`` / ``valid`` relative to the reference's accepted
 shot.  Snapshot devices are sampled as-is.  Missing or slow devices never
@@ -82,7 +82,7 @@ def geecs_free_run_step_scan(
     motor:
         Any Movable/settable device — a stage axis, power supply, pressure
         controller, etc. (anything with ``set() → status``, e.g. built on
-        :class:`~geecs_bluesky.devices.settable.GeecsSettable`).  A
+        :class:`~geecs_bluesky.devices.ca.settable.CaSettable`).  A
         **sequence** of Movables is a multi-axis grid scan (one motor per
         axis, outermost first; each position is then a tuple aligned with
         the motors, and only the axes whose target changed are re-moved).
@@ -94,13 +94,13 @@ def geecs_free_run_step_scan(
         tuples for a grid.
     reference:
         The pacemaker — a Triggerable sync device
-        (:class:`~geecs_bluesky.devices.generic_detector.GeecsGenericDetector`)
+        (:class:`~geecs_bluesky.devices.ca.generic_detector.CaGenericDetector`)
         with shot IDs configured.  Its awaited ``acq_timestamp`` advance
         defines each event row.
     detectors:
         Non-triggerable contributors and snapshots
-        (:class:`~geecs_bluesky.devices.timestamped_readable.GeecsTimestampedReadable`,
-        :class:`~geecs_bluesky.devices.snapshot.GeecsSnapshotReadable`).
+        (:class:`~geecs_bluesky.devices.ca.timestamped_readable.CaTimestampedReadable`,
+        :class:`~geecs_bluesky.devices.ca.snapshot.CaSnapshotReadable`).
         Contributors are auto-anchored to *reference* (existing grace-wait
         settings are preserved).
     shots_per_step:

--- a/GeecsBluesky/geecs_bluesky/plans/single_shot.py
+++ b/GeecsBluesky/geecs_bluesky/plans/single_shot.py
@@ -9,7 +9,7 @@ initiation and the wait::
     bps.wait(group)                          # every detector saw the shot
     create / read / save                     # one complete event row
 
-Ordering is load-bearing: :class:`~geecs_bluesky.devices.triggerable.GeecsTriggerable`
+Ordering is load-bearing: :class:`~geecs_bluesky.devices.ca.triggerable.CaTriggerable`
 baselines its ``acq_timestamp`` synchronously inside ``trigger()``, so a shot
 fired any time after the trigger messages are processed cannot be missed.
 A detector that does not respond to the fired shot raises
@@ -237,7 +237,7 @@ def geecs_confirm_quiescent(
 ):
     """Wait until no sync device's ``acq_timestamp`` advances for *quiet_s*.
 
-    The inverse of :meth:`~geecs_bluesky.devices.triggerable.GeecsTriggerable.trigger`
+    The inverse of :meth:`~geecs_bluesky.devices.ca.triggerable.CaTriggerable.trigger`
     (which waits for an advance): this confirms the free-running trigger has
     *stopped* after the controller was put in single-shot (``ARMED``) mode, so
     plan-owned single-shot firing can begin without mistaking a residual

--- a/GeecsBluesky/geecs_bluesky/plans/step_scan.py
+++ b/GeecsBluesky/geecs_bluesky/plans/step_scan.py
@@ -16,37 +16,28 @@ How it fits into Bluesky
 Shot synchronisation
 --------------------
 Detectors that inherit from
-:class:`~geecs_bluesky.devices.triggerable.GeecsTriggerable` complete their
+:class:`~geecs_bluesky.devices.ca.triggerable.CaTriggerable` complete their
 ``trigger()`` call by waiting for the hardware ``acq_timestamp`` variable to
 advance — the real shot timestamp from the DG645 delay generator.  This is
 robust to device restarts (shot numbers drift; timestamps don't).
 
-Example::
+Example (devices built and connected through a
+:class:`~geecs_bluesky.session.GeecsSession`)::
 
     import numpy as np
-    from bluesky import RunEngine
-    from geecs_bluesky.devices.generic_detector import GeecsGenericDetector
-    from geecs_bluesky.devices.motor import GeecsMotor
+    from geecs_bluesky.session import GeecsSession
     from geecs_bluesky.plans.step_scan import geecs_step_scan
 
-    RE = RunEngine()
+    session = GeecsSession(experiment="Undulator")
+    motor = session.motor("U_ESP_JetXYZ", "Position.Axis 1", name="jet_x")
+    det = session.detector("U_ProbeCam", ["MeanCounts"], name="probe_cam")
 
-    motor = GeecsMotor("U_ESP_JetXYZ", "Position.Axis 1",
-                       "192.168.8.198", 65158,
-                       name="jet_x", units="mm")
-    det = GeecsGenericDetector("U_ProbeCam", ["MeanCounts"],
-                               "192.168.8.50", 64000,
-                               name="probe_cam")
-
-    await motor.connect()
-    await det.connect()
-
-    RE(geecs_step_scan(
+    session.RE(geecs_step_scan(
         motor=motor,
         positions=np.linspace(0, 5, 6),
         detectors=[det],
         shots_per_step=5,
-        md={"sample": "He jet", "operator": "jdoe"},
+        md={"sample": "He jet"},
     ))
 """
 
@@ -162,9 +153,9 @@ def geecs_step_scan(
     ----------
     motor:
         Any :class:`~bluesky.protocols.Movable` device — a stage axis
-        (:class:`~geecs_bluesky.devices.motor.GeecsMotor`), power supply,
+        (:class:`~geecs_bluesky.devices.ca.motor.CaMotor`), power supply,
         pressure controller, etc. (anything with ``set() → status``, e.g.
-        built on :class:`~geecs_bluesky.devices.settable.GeecsSettable`).
+        built on :class:`~geecs_bluesky.devices.ca.settable.CaSettable`).
         The name follows the bluesky ``scan(detectors, motor, ...)``
         convention.  A **sequence** of Movables is a multi-axis grid scan
         (one motor per axis, outermost first; each position is then a tuple

--- a/GeecsBluesky/geecs_bluesky/plans/t0_sync.py
+++ b/GeecsBluesky/geecs_bluesky/plans/t0_sync.py
@@ -40,7 +40,7 @@ def geecs_t0_sync(
     ----------
     devices:
         Sync devices exposing ``last_acq_timestamp`` and ``seed_shot_id()``
-        (e.g. :class:`~geecs_bluesky.devices.generic_detector.GeecsGenericDetector`).
+        (e.g. :class:`~geecs_bluesky.devices.ca.generic_detector.CaGenericDetector`).
     window_s:
         Acceptance window for the timestamp spread.  Default ``0.2`` —
         comfortably above NTP skew (~50 ms) and far below a 1 s trigger

--- a/GeecsBluesky/geecs_bluesky/scan_request_runner.py
+++ b/GeecsBluesky/geecs_bluesky/scan_request_runner.py
@@ -23,11 +23,9 @@ This module owns the mapping:
   name so a shared ritual runs once (:func:`resolve_save_sets_and_rituals`).
   Everything downstream — ``save_set_to_devices_config``, telemetry
   exclusion, the reserved-boundary warning — operates on the merged set.
-- :class:`ConfigsRepoResolver` reads the real configs repository
-  (``scanner_configs/experiments/<Experiment>/``): a YAML file carrying a
-  ``schema_version`` key loads as the new schema directly; anything else is
-  converted from its legacy dialect via :mod:`geecs_schemas.convert` — so the
-  whole existing config corpus is usable immediately, no flag day.
+- :class:`ConfigsRepoResolver` (in :mod:`geecs_bluesky.config_resolver`,
+  re-exported here) reads the real configs repository — new-schema YAML
+  directly, anything else through the legacy converters.
 - Pure mapping helpers derive the engine shapes from the schemas:
   :func:`save_set_to_devices_config` (SaveSet → the ``devices_config`` dict
   ``BlueskyScanner._build_session_devices`` / the session factories expect,
@@ -82,11 +80,14 @@ from __future__ import annotations
 import itertools
 import logging
 from collections.abc import Mapping
-from pathlib import Path
-from typing import Any, Callable, Protocol, runtime_checkable
+from typing import Any, Callable
 
-import yaml
-
+# ConfigsRepoResolver is re-exported: the existing import surface
+# (bridge, tests, notebooks) gets both names from this module.
+from geecs_bluesky.config_resolver import (  # noqa: F401
+    ConfigResolver,
+    ConfigsRepoResolver,
+)
 from geecs_bluesky.db_runtime import (
     GeecsDbScalarPolicy,
     ScalarPolicyProvider,
@@ -96,13 +97,10 @@ from geecs_bluesky.db_runtime import (
 from geecs_bluesky.exceptions import GeecsConfigurationError
 from geecs_bluesky.models.shot_control import ShotControlWrites
 from geecs_bluesky.plans.action_compiler import compile_action_plan
-from geecs_bluesky.scanner_configs import SHOT_CONTROL_FOLDER, scanner_configs_base
 from geecs_schemas import (
     ActionBindings,
     ActionPlan,
-    ActionPlanLibrary,
     AcquisitionMode,
-    ExperimentDefaults,
     PseudoScanVariable,
     SaveRole,
     SaveSet,
@@ -110,18 +108,11 @@ from geecs_schemas import (
     ScanRequest,
     ScanRequestMode,
     ScanVariable,
-    ScanVariables,
     ScanVariableSpec,
     TriggerProfile,
     TriggerState,
 )
 from geecs_schemas.action_plan import CheckStep, RunPlanStep, SetStep
-from geecs_schemas.convert import (
-    convert_action_library,
-    convert_save_element,
-    convert_scan_variables,
-    convert_shot_control,
-)
 
 logger = logging.getLogger(__name__)
 
@@ -135,330 +126,9 @@ MULTI_AXIS_MESSAGE = (
 )
 
 
-# ---------------------------------------------------------------------------
-# ConfigResolver protocol
-# ---------------------------------------------------------------------------
-
-
-@runtime_checkable
-class ConfigResolver(Protocol):
-    """Resolves the names a ScanRequest carries into schema models."""
-
-    def resolve_save_set(self, name: str) -> SaveSet:
-        """Return the save set called *name*."""
-        ...
-
-    def resolve_trigger_profile(self, name: str) -> TriggerProfile:
-        """Return the trigger profile called *name*."""
-        ...
-
-    def resolve_scan_variable(self, name: str) -> ScanVariableSpec:
-        """Return the scan-variable entry called *name*."""
-        ...
-
-    def resolve_action_plan(self, name: str) -> ActionPlan:
-        """Return the action plan called *name*."""
-        ...
-
-    def resolve_experiment_defaults(self) -> ExperimentDefaults | None:
-        """Return the experiment's defaults, or ``None`` if none are declared.
-
-        Defaults apply where the request is silent (default trigger
-        profile; default setup/closeout plans prepended); what was applied
-        is recorded for provenance (see
-        :func:`apply_experiment_defaults`).  Resolvers without this method
-        are tolerated (no defaults).
-        """
-        ...
-
-
-class ConfigsRepoResolver:
-    """Resolver over the real configs-repo layout, converter-backed.
-
-    Reads ``scanner_configs/experiments/<experiment>/`` (the same resolution
-    roots as :func:`geecs_bluesky.scanner_configs.scanner_configs_base`):
-
-    - ``save_devices/<name>.yaml`` — save sets (legacy save elements)
-    - ``shot_control_configurations/<name>.yaml`` — trigger profiles
-    - ``scan_devices/scan_variables.yaml`` (new schema) or the legacy
-      ``scan_devices/scan_devices.yaml`` + ``scan_devices/composite_variables.yaml``
-      pair — the scan-variable catalog
-    - ``action_library/actions.yaml`` — the action-plan library
-
-    A file whose top level carries ``schema_version`` is loaded as the new
-    schema; anything else goes through the matching legacy converter — so
-    the existing corpus works unchanged and files can migrate one at a time.
-
-    Parameters
-    ----------
-    experiment :
-        Experiment folder name under ``scanner_configs/experiments``.
-    experiments_root :
-        Override for the experiments root (tests); defaults to the
-        production resolution (``GEECS_SCANNER_CONFIG_DIR`` env var or
-        config.ini), resolved lazily on first use.
-    """
-
-    SAVE_SET_FOLDER = "save_devices"
-    TRIGGER_FOLDER = SHOT_CONTROL_FOLDER
-    SCAN_VARIABLES_FOLDER = "scan_devices"
-    ACTION_FOLDER = "action_library"
-
-    def __init__(
-        self, experiment: str, experiments_root: str | Path | None = None
-    ) -> None:
-        self._experiment = experiment
-        self._experiments_root = (
-            Path(experiments_root) if experiments_root is not None else None
-        )
-        self._scan_variables_cache: ScanVariables | None = None
-        self._action_library_cache: ActionPlanLibrary | None = None
-        # Plans extracted by the save-element converter (legacy
-        # setup_action / closeout_action / scan_setup become named plans
-        # referenced from the entries) — they live beside the element, not
-        # in the experiment's action library, so name resolution falls back
-        # to them after the library.
-        self._extracted_element_actions: dict[str, ActionPlan] = {}
-
-    @property
-    def _root(self) -> Path:
-        root = self._experiments_root or scanner_configs_base()
-        return root / self._experiment
-
-    @staticmethod
-    def _strip_yaml_suffix(name: str) -> str:
-        for suffix in (".yaml", ".yml"):
-            if name.endswith(suffix):
-                return name[: -len(suffix)]
-        return name
-
-    def _load_yaml(self, path: Path, kind: str, name: str) -> dict:
-        """Load one YAML mapping, failing loudly with the config kind/name."""
-        if not path.exists():
-            raise GeecsConfigurationError(
-                f"{kind} {name!r} not found for experiment "
-                f"{self._experiment!r}: no file at {path}"
-            )
-        document = yaml.safe_load(path.read_text())
-        if document is None:
-            document = {}
-        if not isinstance(document, dict):
-            raise GeecsConfigurationError(
-                f"{kind} {name!r}: expected a YAML mapping at the top of "
-                f"{path}, got {type(document).__name__}"
-            )
-        return document
-
-    def resolve_save_set(self, name: str) -> SaveSet:
-        """Load the save set *name* (new schema, else converted save element).
-
-        Parameters
-        ----------
-        name :
-            File stem under ``save_devices/`` (``.yaml`` optional).
-
-        Returns
-        -------
-        SaveSet
-            The validated save set.
-
-        Raises
-        ------
-        GeecsConfigurationError
-            If the file is missing or is an action-only legacy element
-            (nothing to record).
-        """
-        stem = self._strip_yaml_suffix(name)
-        path = self._root / self.SAVE_SET_FOLDER / f"{stem}.yaml"
-        document = self._load_yaml(path, "save set", name)
-        if "schema_version" in document:
-            return SaveSet.model_validate(document)
-        result = convert_save_element(document, name=stem)
-        for note in result.notes:
-            logger.info("save set %s (converted from legacy): %s", stem, note)
-        # The converter extracts element-level setup/closeout (and per-device
-        # scan_setup) into named plans referenced from the entries; remember
-        # them so resolve_action_plan can validate those references.
-        self._extracted_element_actions.update(result.actions)
-        if result.save_set is None:
-            raise GeecsConfigurationError(
-                f"save set {name!r} ({path}) is an action-only legacy element "
-                "— it lists no devices to record"
-            )
-        return result.save_set
-
-    def resolve_trigger_profile(self, name: str) -> TriggerProfile:
-        """Load the trigger profile *name* (new schema, else converted).
-
-        Parameters
-        ----------
-        name :
-            File stem under ``shot_control_configurations/``.
-
-        Returns
-        -------
-        TriggerProfile
-            The validated profile.
-
-        Raises
-        ------
-        GeecsConfigurationError
-            If the file is missing or names no trigger device.
-        """
-        stem = self._strip_yaml_suffix(name)
-        path = self._root / self.TRIGGER_FOLDER / f"{stem}.yaml"
-        document = self._load_yaml(path, "trigger profile", name)
-        if "schema_version" in document:
-            return TriggerProfile.model_validate(document)
-        profile = convert_shot_control(document, name=stem)
-        if profile is None:
-            raise GeecsConfigurationError(
-                f"trigger profile {name!r} ({path}) is empty / names no "
-                "device — it cannot drive a scan's trigger"
-            )
-        return profile
-
-    def _scan_variables_catalog(self) -> ScanVariables:
-        """Load (and cache) the experiment's scan-variable catalog."""
-        if self._scan_variables_cache is not None:
-            return self._scan_variables_cache
-        folder = self._root / self.SCAN_VARIABLES_FOLDER
-        new_schema = folder / "scan_variables.yaml"
-        if new_schema.exists():
-            document = self._load_yaml(new_schema, "scan variables", "catalog")
-            catalog = ScanVariables.model_validate(document)
-        else:
-            scan_devices = folder / "scan_devices.yaml"
-            composites = folder / "composite_variables.yaml"
-            if not scan_devices.exists() and not composites.exists():
-                raise GeecsConfigurationError(
-                    f"no scan-variable catalog for experiment "
-                    f"{self._experiment!r}: expected {new_schema} or the "
-                    f"legacy pair in {folder}"
-                )
-            catalog = convert_scan_variables(
-                scan_devices if scan_devices.exists() else None,
-                composites if composites.exists() else None,
-            )
-        self._scan_variables_cache = catalog
-        return catalog
-
-    def resolve_scan_variable(self, name: str) -> ScanVariableSpec:
-        """Look up the scan variable *name* in the experiment catalog.
-
-        Parameters
-        ----------
-        name :
-            Friendly variable name (a key of the catalog).
-
-        Returns
-        -------
-        ScanVariable or PseudoScanVariable
-            The catalog entry.
-
-        Raises
-        ------
-        GeecsConfigurationError
-            If the name is not in the catalog (known names are listed).
-        """
-        catalog = self._scan_variables_catalog()
-        try:
-            return catalog.variables[name]
-        except KeyError:
-            raise GeecsConfigurationError(
-                f"scan variable {name!r} is not in the "
-                f"{self._experiment!r} catalog. Known variables: "
-                f"{sorted(catalog.variables)}"
-            ) from None
-
-    def _action_library(self) -> ActionPlanLibrary:
-        """Load (and cache) the experiment's action-plan library."""
-        if self._action_library_cache is not None:
-            return self._action_library_cache
-        path = self._root / self.ACTION_FOLDER / "actions.yaml"
-        document = self._load_yaml(path, "action library", "actions")
-        if "schema_version" in document:
-            library = ActionPlanLibrary.model_validate(document)
-        else:
-            library = convert_action_library(document)
-        self._action_library_cache = library
-        return library
-
-    def resolve_action_plan(self, name: str) -> ActionPlan:
-        """Look up the action plan *name* in the experiment library.
-
-        Parameters
-        ----------
-        name :
-            Plan name (a key of the action library).
-
-        Returns
-        -------
-        ActionPlan
-            The named plan.
-
-        Raises
-        ------
-        GeecsConfigurationError
-            If the name is not in the library (known names are listed).
-        """
-        # Plans the save-element converter extracted resolve first: they
-        # live beside their element (their `<element>_setup` names cannot
-        # collide with library names in practice), and an experiment may
-        # have converted elements without having an action library at all.
-        plan = self._extracted_element_actions.get(name)
-        if plan is not None:
-            return plan
-        library = self._action_library()
-        try:
-            return library.plans[name]
-        except KeyError:
-            raise GeecsConfigurationError(
-                f"action plan {name!r} is not in the {self._experiment!r} "
-                f"action library. Known plans: {sorted(library.plans)}"
-            ) from None
-
-    def action_plan_registry(self) -> dict[str, ActionPlan]:
-        """Return every named plan visible to nested ``run`` steps.
-
-        The experiment's action library plus the plans the save-element
-        converter extracted (which win on a name collision, matching
-        :meth:`resolve_action_plan`'s lookup order).  An experiment without
-        an action library still gets its extracted element plans.
-
-        Returns
-        -------
-        dict
-            ``{plan_name: ActionPlan}``.
-        """
-        plans: dict[str, ActionPlan] = {}
-        try:
-            plans.update(self._action_library().plans)
-        except GeecsConfigurationError:
-            pass  # no actions.yaml — extracted element plans may still exist
-        plans.update(self._extracted_element_actions)
-        return plans
-
-    DEFAULTS_FILE = "experiment_defaults.yaml"
-
-    def resolve_experiment_defaults(self) -> ExperimentDefaults | None:
-        """Load and validate the experiment's defaults file, if one exists.
-
-        Reads ``<experiment>/experiment_defaults.yaml`` into the
-        :class:`~geecs_schemas.ExperimentDefaults` model (there is no
-        legacy dialect behind it — the legacy scanner kept these choices in
-        GUI state).
-
-        Returns
-        -------
-        ExperimentDefaults or None
-            The validated defaults, or ``None`` when no file exists.
-        """
-        path = self._root / self.DEFAULTS_FILE
-        if not path.exists():
-            return None
-        document = self._load_yaml(path, "experiment defaults", self.DEFAULTS_FILE)
-        return ExperimentDefaults.model_validate(document)
+# The resolver layer (ConfigResolver protocol + the production
+# ConfigsRepoResolver) lives in geecs_bluesky.config_resolver; the names
+# are re-exported here for the existing import surface.
 
 
 # ---------------------------------------------------------------------------
@@ -745,36 +415,6 @@ def collect_save_set_rituals(save_set: SaveSet) -> dict[str, list[str]]:
     return rituals
 
 
-def resolve_save_set_and_rituals(
-    resolver: ConfigResolver, name: str
-) -> tuple[SaveSet, dict[str, list[str]]]:
-    """Resolve a save set and validate its entry-level ritual references.
-
-    Every referenced plan name is resolved against the action library now
-    (fail-fast, pre-claim); execution happens later through the assembled
-    slots (:func:`assemble_action_slots`).
-
-    Parameters
-    ----------
-    resolver :
-        Where names are looked up.
-    name :
-        The save set name.
-
-    Returns
-    -------
-    tuple
-        ``(save_set, rituals)`` — the resolved save set and its
-        de-duplicated ``{"setup": [...], "closeout": [...]}`` ritual names.
-    """
-    save_set = resolver.resolve_save_set(name)
-    rituals = collect_save_set_rituals(save_set)
-    for names in rituals.values():
-        for action_name in names:
-            resolver.resolve_action_plan(action_name)
-    return save_set, rituals
-
-
 def _merge_two_entries(existing: SaveSetEntry, addition: SaveSetEntry) -> SaveSetEntry:
     """Merge a second entry for the same device into the first (union rule).
 
@@ -891,8 +531,7 @@ def resolve_save_sets_and_rituals(
     setup/closeout rituals across **all** sets, de-duplicated by plan name
     (so a ritual shared by two sets still runs once). Every referenced ritual
     plan name is validated against the action library now (fail-fast,
-    pre-claim), exactly as :func:`resolve_save_set_and_rituals` does for one
-    set.
+    pre-claim).
 
     Parameters
     ----------
@@ -1139,47 +778,12 @@ def compile_action_slot(
     return _slot_plan, plans
 
 
-def resolve_save_set_checked(resolver: ConfigResolver, name: str) -> SaveSet:
-    """Resolve a save set, refusing entry-level rituals — **GUI-bridge path only**.
-
-    The engine executes entry rituals (see
-    :func:`resolve_save_set_and_rituals` / :func:`run_scan_request`); the
-    GUI bridge stages requests through the legacy exec-config machinery and
-    does not run them yet.  References are *validated* first (unknown names
-    fail loudly), then refused.
-
-    Parameters
-    ----------
-    resolver :
-        Where names are looked up.
-    name :
-        The save set name.
-
-    Returns
-    -------
-    SaveSet
-        The resolved save set (guaranteed free of entry-level actions).
-    """
-    save_set, rituals = resolve_save_set_and_rituals(resolver, name)
-    entry_actions = [n for names in rituals.values() for n in names]
-    if entry_actions:
-        raise NotImplementedError(
-            f"the GUI bridge does not execute save-set entry rituals yet — "
-            f"run the request headless via GeecsSession.run (ritual "
-            f"execution landed with the M3b milestone); save set {name!r} "
-            f"references entry-level setup/closeout plans, which were "
-            f"resolved and are valid: {entry_actions}"
-        )
-    return save_set
-
-
 def resolve_save_sets_checked(resolver: ConfigResolver, names: list[str]) -> SaveSet:
     """Resolve and union several save sets, refusing rituals — **GUI-bridge only**.
 
-    The multi-set counterpart of :func:`resolve_save_set_checked`: every name
-    in *names* is resolved, the sets are unioned into one effective SaveSet
-    (:func:`merge_save_sets`), and any entry-level ritual (collected across
-    all named sets) is *validated* then refused — the GUI bridge stages
+    Every name in *names* is resolved, the sets are unioned into one effective
+    SaveSet (:func:`merge_save_sets`), and any entry-level ritual (collected
+    across all named sets) is *validated* then refused — the GUI bridge stages
     requests through the legacy exec-config machinery and does not run rituals
     yet. The bridge still refuses actions/multi-axis elsewhere; this only
     makes the save-set resolution list-aware.

--- a/GeecsBluesky/geecs_bluesky/scanner_bridge/bluesky_scanner.py
+++ b/GeecsBluesky/geecs_bluesky/scanner_bridge/bluesky_scanner.py
@@ -41,13 +41,9 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
-import queue
 import threading
 from contextlib import contextmanager
 from typing import Any, Callable
-
-import numpy as np
-
 
 from geecs_bluesky.devices.ca._pv import GATEWAY_DISCONNECTED
 from geecs_bluesky.exceptions import GeecsConfigurationError
@@ -94,20 +90,12 @@ from geecs_bluesky.scan_request_runner import (
     trigger_writes_from_profile,
 )
 from geecs_bluesky.scan_log import scan_log
-from geecs_bluesky.session import GeecsSession
+from geecs_bluesky.session import GeecsSession, _positions
 from geecs_bluesky.utils import safe_name
 from geecs_schemas import AcquisitionMode, ScanRequest, ScanRequestMode
 
-# ScanConfig / ScanMode are only imported for type hints; duck-typing is used at
-# runtime so this module can be imported without geecs_data_utils installed.
-try:
-    from geecs_data_utils import ScanConfig as _ScanConfig  # noqa: F401
-except Exception:
-    _ScanConfig = None  # type: ignore[assignment,misc]
-
 logger = logging.getLogger(__name__)
 
-_CONNECT_TIMEOUT = 20.0
 _DISCONNECT_TIMEOUT = 10.0
 _THREAD_JOIN_TIMEOUT = 15.0
 
@@ -162,13 +150,9 @@ def _cfg_field(cfg: Any, key: str, default: Any) -> Any:
 
 def _build_positions(scan_config: Any) -> list[float]:
     """Convert ScanConfig start/end/step to an explicit list of positions."""
-    start = float(scan_config.start)
-    end = float(scan_config.end)
-    step = float(scan_config.step)
-    if step == 0 or start == end:
-        return [start]
-    n = max(2, round(abs(end - start) / abs(step)) + 1)
-    return list(np.linspace(start, end, n))
+    return _positions(
+        float(scan_config.start), float(scan_config.end), float(scan_config.step)
+    )
 
 
 class BlueskyScanner:
@@ -226,11 +210,8 @@ class BlueskyScanner:
         self._RE = self._session.RE
         self._RE.subscribe(self._on_document)
 
-        # GUI compatibility shims
-        self.dialog_queue: queue.Queue = (
-            queue.Queue()
-        )  # always empty; RE uses bps.pause()
-        self.restore_failures: list = []  # no legacy device restore needed
+        # GUI compatibility: the GUI reads this defensively for both backends
+        # (never populated on the Bluesky path — reinitialize raises instead).
         self.last_reinit_error: str | None = None
         self._on_event = on_event
         self._current_state = self._scan_state("IDLE")

--- a/GeecsBluesky/geecs_bluesky/utils.py
+++ b/GeecsBluesky/geecs_bluesky/utils.py
@@ -14,36 +14,3 @@ def safe_name(s: str) -> str:
     """
     cleaned = re.sub(r"[^a-zA-Z0-9_]", "_", s).strip("_").lower()
     return cleaned or "var"
-
-
-def build_signal_attrs(variable_list: list[str]) -> list[tuple[str, str]]:
-    """Map each GEECS variable to a unique ophyd-async attribute name.
-
-    Applies :func:`safe_name` to every variable and disambiguates collisions by
-    appending ``_2``, ``_3``, … in input order.  Centralises the attr-naming
-    loop the detector classes share so signal creation and the legacy
-    ``device variable`` header map (see each device's ``_column_headers``)
-    cannot drift.
-
-    Parameters
-    ----------
-    variable_list:
-        GEECS variable names, in the order they should be exposed.
-
-    Returns
-    -------
-    list[tuple[str, str]]
-        ``(attr, variable)`` pairs, one per input variable, ``attr`` unique.
-    """
-    used_attrs: set[str] = set()
-    pairs: list[tuple[str, str]] = []
-    for var in variable_list:
-        attr = safe_name(var)
-        if attr in used_attrs:
-            i = 2
-            while f"{attr}_{i}" in used_attrs:
-                i += 1
-            attr = f"{attr}_{i}"
-        used_attrs.add(attr)
-        pairs.append((attr, var))
-    return pairs

--- a/GeecsBluesky/pyproject.toml
+++ b/GeecsBluesky/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-bluesky"
-version = "0.26.0"
+version = "0.27.0"
 description = "Bluesky / ophyd-async bridge for the GEECS control system"
 authors = ["Sam Barber <sbarber@lbl.gov>"]
 readme = "README.md"

--- a/GeecsBluesky/tests/test_scan_request_runner.py
+++ b/GeecsBluesky/tests/test_scan_request_runner.py
@@ -28,8 +28,6 @@ from geecs_bluesky.scan_request_runner import (
     build_action_registry,
     collect_save_set_rituals,
     merge_save_sets,
-    resolve_save_set_and_rituals,
-    resolve_save_set_checked,
     resolve_save_sets_and_rituals,
     resolve_save_sets_checked,
     run_scan_request,
@@ -1208,23 +1206,23 @@ def _entry_action_save_set(**entry_overrides) -> SaveSet:
     return SaveSet.model_validate({"name": "s", "entries": [entry]})
 
 
-def test_resolve_save_set_and_rituals_validates_names() -> None:
+def test_resolve_save_sets_and_rituals_validates_names() -> None:
     resolver = _SaveSetResolver(_entry_action_save_set(setup=["prep_cam"]))
-    save_set, rituals = resolve_save_set_and_rituals(resolver, "s")
+    save_set, rituals = resolve_save_sets_and_rituals(resolver, ["s"])
     assert rituals == {"setup": ["prep_cam"], "closeout": []}
 
 
 def test_entry_level_unknown_action_fails_validation_first() -> None:
     resolver = _SaveSetResolver(_entry_action_save_set(setup=["nope"]))
     with pytest.raises(GeecsConfigurationError, match="nope"):
-        resolve_save_set_and_rituals(resolver, "s")
+        resolve_save_sets_and_rituals(resolver, ["s"])
 
 
 def test_bridge_path_still_refuses_entry_rituals() -> None:
-    """resolve_save_set_checked (GUI-bridge helper) refuses with a pointer."""
+    """resolve_save_sets_checked (GUI-bridge helper) refuses with a pointer."""
     resolver = _SaveSetResolver(_entry_action_save_set(setup=["prep_cam"]))
     with pytest.raises(NotImplementedError, match="GeecsSession.run"):
-        resolve_save_set_checked(resolver, "s")
+        resolve_save_sets_checked(resolver, ["s"])
 
 
 def test_entry_rituals_execute_between_defaults_and_request(

--- a/GeecsBluesky/tests/test_utils.py
+++ b/GeecsBluesky/tests/test_utils.py
@@ -1,10 +1,10 @@
-"""Tests for safe_name / build_signal_attrs and device legacy header maps."""
+"""Tests for safe_name and device legacy header maps."""
 
 from __future__ import annotations
 
 import pytest
 
-from geecs_bluesky.utils import build_signal_attrs, safe_name
+from geecs_bluesky.utils import safe_name
 
 pytest.importorskip("aioca")  # devices are CA-backed
 
@@ -21,15 +21,6 @@ def test_safe_name_mangles_and_lowercases() -> None:
     assert safe_name("Wavelength (nm)") == "wavelength__nm"
     assert safe_name("Position.Axis 1") == "position_axis_1"
     assert safe_name("") == "var"
-
-
-def test_build_signal_attrs_disambiguates_collisions() -> None:
-    # Two variables that mangle to the same attr get _2 appended in order.
-    pairs = build_signal_attrs(["A (x)", "A [x]", "B"])
-    attrs = [attr for attr, _ in pairs]
-    assert attrs == ["a__x", "a__x_2", "b"]
-    # The original variable name is preserved alongside each attr.
-    assert pairs == [("a__x", "A (x)"), ("a__x_2", "A [x]"), ("b", "B")]
 
 
 def test_generic_detector_column_headers() -> None:

--- a/GeecsCAGateway/CHANGELOG.md
+++ b/GeecsCAGateway/CHANGELOG.md
@@ -3,6 +3,29 @@
 All notable changes to `geecs-ca-gateway` are documented here, following
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and semantic versioning.
 
+## [0.12.0] - 2026-07-10
+
+Cleanup pass 1 (audit: `Planning/cleanup_vision_v1/00_overview.md`) — no
+behavior change.
+
+### Changed
+
+- The numeric wire-value coercion (`float` → int-if-whole → fallback str),
+  previously duplicated in `tcp_subscriber` and `udp_client`, is now the
+  shared `transport/_coerce.coerce_scalar`. The fake device server keeps its
+  own copy deliberately (test/prod decoupling).
+- `config.py` module docstring no longer describes the shipped DB-driven
+  config path (`from_geecs_experiment`) as future work; `naming.py`'s
+  docstring condensed to a pointer at `pv_naming` (the policy home).
+
+### Removed
+
+- `GeecsDb.list_devices()` — zero consumers anywhere in the workspace (the
+  config path uses the batched `get_experiment_devices`).
+- `FakeGeecsDevice.fire_shot()` — its only consumer was GeecsBluesky's
+  deleted direct-backend test suite (bluesky tests use ophyd-async mock
+  backends now); its docstring pointed at a deleted class path.
+
 ## [0.11.0] - 2026-07-09
 
 ### Added

--- a/GeecsCAGateway/CLAUDE.md
+++ b/GeecsCAGateway/CLAUDE.md
@@ -66,7 +66,7 @@ geecs_ca_gateway/
 
 Dependency direction: **GeecsBluesky depends on this package, never the other
 way around**. GeecsBluesky imports the *library* parts (`GeecsDb`, `pv_naming`,
-exceptions, `FakeGeecsServer`) and consumes the *service* (the PVs, via stock
+exceptions) and consumes the *service* (the PVs, via stock
 ophyd-async EPICS signals). The gateway also imports `geecs-schemas` for
 schema-validated derived-channel overlay files. The gateway env is deliberately
 slim: caproto + pydantic + geecs-schemas + mysql-connector + PyYAML — no
@@ -150,7 +150,8 @@ One asyncio event loop runs everything:
   in-process asyncio UDP+TCP server speaking the real wire protocol (5 Hz
   pushes, ACK/exe replies). The whole suite is offline: no hardware, no lab
   network, no CA client needed (tests drive channels directly via
-  `channel.write`). GeecsBluesky's tests import it from here too.
+  `channel.write`). GeecsBluesky no longer imports it — its hermetic tests
+  use ophyd-async mock backends instead.
 - `pytest` runs `asyncio_mode = "auto"` and deselects `integration` (lab-DB)
   tests by default; `fake_server` marks tests that open localhost sockets.
 - Test files map to layers: `test_naming` / `test_channels` /

--- a/GeecsCAGateway/geecs_ca_gateway/config.py
+++ b/GeecsCAGateway/geecs_ca_gateway/config.py
@@ -1,9 +1,9 @@
 """Declarative configuration for the GEECS → EPICS CA gateway.
 
-The gateway is driven entirely by a :class:`GatewayConfig`.  For the proof of
-concept these are constructed by hand (see ``demo.py``); the intended next step
-is to generate them from the GEECS experiment database dict, pulling per-variable
-units/precision/limits from the attributes database.
+The gateway is driven entirely by a :class:`GatewayConfig`.  Production
+configs are generated from the GEECS experiment database
+(:meth:`GatewayConfig.from_geecs_experiment`, pulling per-variable
+units/limits/dtype); hand-built configs remain possible (see ``demo.py``).
 """
 
 from __future__ import annotations

--- a/GeecsCAGateway/geecs_ca_gateway/db/geecs_db.py
+++ b/GeecsCAGateway/geecs_ca_gateway/db/geecs_db.py
@@ -308,50 +308,6 @@ class GeecsDb:
         return str(row[0]).strip()
 
     @classmethod
-    def list_devices(
-        cls, experiment: Optional[str] = None, *, enabled_only: bool = False
-    ) -> list[str]:
-        """Return all device names, optionally filtered by experiment.
-
-        Parameters
-        ----------
-        experiment:
-            If given, only return devices belonging to this experiment
-            (e.g. ``"Undulator"``).
-        enabled_only:
-            If true (only meaningful with ``experiment``), return only devices
-            whose ``expt_device.enabled`` field is ``"yes"``.  A device may
-            belong to an experiment but be disabled.
-        """
-        try:
-            import mysql.connector
-        except ImportError as exc:
-            raise ImportError(
-                "mysql-connector-python is required for DB lookups."
-            ) from exc
-
-        conn = _connect_mysql(mysql.connector)
-        try:
-            cur = conn.cursor()
-            if experiment is not None:
-                query = (
-                    "SELECT DISTINCT ed.device FROM expt_device ed "
-                    "JOIN expt e ON e.name = ed.expt "
-                    "WHERE e.name = %s"
-                )
-                if enabled_only:
-                    query += " AND LOWER(ed.enabled) = 'yes'"
-                query += " ORDER BY ed.device"
-                cur.execute(query, (experiment,))
-            else:
-                cur.execute("SELECT name FROM device ORDER BY name")
-            rows = cur.fetchall()
-        finally:
-            conn.close()
-
-        return [r[0] for r in rows]
-
-    @classmethod
     def get_subscribed_variables(
         cls, experiment: str, *, enabled_only: bool = True
     ) -> dict:

--- a/GeecsCAGateway/geecs_ca_gateway/naming.py
+++ b/GeecsCAGateway/geecs_ca_gateway/naming.py
@@ -1,16 +1,7 @@
-"""GEECS name → EPICS Channel Access PV name mapping.
+"""Gateway-local alias for the shared naming policy.
 
-The normalization policy is shared with the CA-backed ophyd-async devices that
-consume these PVs — it lives in :mod:`geecs_ca_gateway.pv_naming` (the one module
-both the gateway *producer* and the device *consumer* import) so the two can
-never drift.  This module re-exports it under the gateway's local name.
-
-Full PV names (``[Experiment:]Device:Variable``) are assembled by
-:meth:`geecs_ca_gateway.config.DeviceSpec.pv_name_for`; the shared policy only
-normalizes individual name components (runs of non-``[A-Za-z0-9_]`` → ``_`` — the
-dot is critical: EPICS reads ``.`` as the record/field separator, so
-``Trigger.Source`` → ``Trigger_Source``).  The mapping is deliberately lossy;
-the gateway keeps the authoritative ``geecs_var ↔ PV`` manifest.
+The normalization policy itself lives in :mod:`geecs_ca_gateway.pv_naming`
+(the one module both producer and consumers import — see its docstring).
 """
 
 from __future__ import annotations

--- a/GeecsCAGateway/geecs_ca_gateway/testing/fake_device_server.py
+++ b/GeecsCAGateway/geecs_ca_gateway/testing/fake_device_server.py
@@ -1,13 +1,5 @@
 """Fake GEECS device server speaking the real UDP/TCP wire protocol.
 
-.. note::
-
-   :meth:`FakeGeecsDevice.fire_shot` advances the ``acq_timestamp`` variable
-   to simulate a laser shot.  Tests that exercise
-   :class:`~geecs_bluesky.devices.triggerable.GeecsTriggerable` should include
-   ``"acq_timestamp": 1000.0`` in the device variables and call
-   ``device.fire_shot()`` (from a background task) to unblock ``trigger()``.
-
 Runs entirely in-process on localhost, no real hardware required.
 Use ``FakeGeecsServer`` as an async context manager in tests.
 
@@ -94,23 +86,6 @@ class FakeGeecsDevice:
             val = self.variables[v]
             parts.append(f"{v} nval,{val} nvar")
         return f"{self.name}>>{shot}>>" + ",".join(parts)
-
-    def fire_shot(self) -> None:
-        """Simulate a laser shot by advancing ``acq_timestamp``.
-
-        Increments ``acq_timestamp`` by 1.0 (or sets it to
-        ``time.time()`` if the variable is not already present).
-        Call this from a background task in tests that exercise
-        :class:`~geecs_bluesky.devices.triggerable.GeecsTriggerable`.
-        """
-        import time
-
-        if "acq_timestamp" in self.variables:
-            self.variables["acq_timestamp"] = (
-                float(self.variables["acq_timestamp"]) + 1.0
-            )
-        else:
-            self.variables["acq_timestamp"] = float(time.time())
 
     def build_exe_response(self, var: str, error: bool = False) -> str:
         """Build a GEECS exe-response string for ``var``."""

--- a/GeecsCAGateway/geecs_ca_gateway/transport/_coerce.py
+++ b/GeecsCAGateway/geecs_ca_gateway/transport/_coerce.py
@@ -1,0 +1,18 @@
+"""Shared wire-value coercion for the GEECS transport layers."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def coerce_scalar(s: str) -> Any:
+    """Best-effort numeric conversion; non-numeric text passes through as-is.
+
+    Lossy for text that merely *looks* numeric (``'007'`` → ``7``) — string-typed
+    variables must bypass this (the subscriber's ``text_variables`` parameter).
+    """
+    try:
+        f = float(s)
+        return int(f) if f == int(f) and "." not in s else f
+    except ValueError:
+        return s

--- a/GeecsCAGateway/geecs_ca_gateway/transport/tcp_subscriber.py
+++ b/GeecsCAGateway/geecs_ca_gateway/transport/tcp_subscriber.py
@@ -27,6 +27,8 @@ import re
 import struct
 from typing import Any, Callable, Awaitable, Collection, Sequence
 
+from ._coerce import coerce_scalar
+
 logger = logging.getLogger(__name__)
 
 Callback = Callable[[dict[str, Any]], Awaitable[None] | None]
@@ -249,7 +251,7 @@ def _parse_subscription(
     and is tokenised by *pattern* — see :func:`_compile_frame_pattern`.
 
     Values of variables in ``text_variables`` are returned as the exact raw
-    text; all others are numerically coerced via :func:`_coerce`.
+    text; all others are numerically coerced via :func:`coerce_scalar`.
     """
     if pattern is None:
         return {}
@@ -262,18 +264,7 @@ def _parse_subscription(
     for match in pattern.finditer(payload):
         var = match.group("name")
         raw_val = match.group("value")
-        result[var] = raw_val if var in text_variables else _coerce(raw_val.strip())
+        result[var] = (
+            raw_val if var in text_variables else coerce_scalar(raw_val.strip())
+        )
     return result
-
-
-def _coerce(s: str) -> Any:
-    """Best-effort numeric conversion; non-numeric text passes through as-is.
-
-    Lossy for text that merely *looks* numeric (``'007'`` → ``7``) — string-typed
-    variables must bypass this via the ``text_variables`` parse parameter.
-    """
-    try:
-        f = float(s)
-        return int(f) if f == int(f) and "." not in s else f
-    except ValueError:
-        return s

--- a/GeecsCAGateway/geecs_ca_gateway/transport/udp_client.py
+++ b/GeecsCAGateway/geecs_ca_gateway/transport/udp_client.py
@@ -33,6 +33,8 @@ from geecs_ca_gateway.exceptions import (
     GeecsConnectionError,
 )
 
+from ._coerce import coerce_scalar
+
 logger = logging.getLogger(__name__)
 
 _ACK_TIMEOUT = 1.5  # seconds
@@ -421,10 +423,4 @@ def _parse_exe_response(msg: str, device_name: str = "", variable: str = "") -> 
     if status_field.startswith("error"):
         detail = status_field.split(",", 1)[1].strip() if "," in status_field else ""
         raise GeecsCommandFailedError(device_name, variable, detail or status_field)
-    raw_value = parts[2]
-    # Try to coerce to numeric
-    try:
-        f = float(raw_value)
-        return int(f) if f == int(f) and "." not in raw_value else f
-    except ValueError:
-        return raw_value
+    return coerce_scalar(parts[2])

--- a/GeecsCAGateway/pyproject.toml
+++ b/GeecsCAGateway/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-ca-gateway"
-version = "0.11.0"
+version = "0.12.0"
 description = "EPICS Channel Access soft-IOC gateway exposing GEECS devices as PVs"
 authors = ["Sam Barber <sbarber@lbl.gov>"]
 readme = "README.md"

--- a/Planning/cleanup_vision_v1/00_overview.md
+++ b/Planning/cleanup_vision_v1/00_overview.md
@@ -1,0 +1,130 @@
+# feat/vision-v1 cleanup — audit findings and decisions
+
+Four-angle audit of GeecsBluesky + GeecsCAGateway (2026-07-10, on
+feat/vision-v1 after M4 step 0 / #477): dead code, docstring bloat,
+duplication, and module structure. This file records what we changed, what we
+deliberately kept, and what is deferred — so a later pass doesn't re-litigate
+the same calls.
+
+Baseline numbers at audit time: geecs_bluesky 15,170 lines (34%
+docstring+comment; scan_request_runner.py alone 844 docstring lines of 1,940);
+geecs_ca_gateway 4,544 lines (29%, mostly load-bearing wire-protocol/DB
+semantics).
+
+## PR 1 (this change): dead code, dedup, stale references, resolver split
+
+- **Deleted dead code**
+  - `bluesky_scanner.py`: `_ScanConfig` import shim, `_CONNECT_TIMEOUT`,
+    `dialog_queue`, `restore_failures` (the GUI stopped reading the latter
+    two when `ScanManager` dropped them; verified no consumer).
+    `last_reinit_error` KEPT — `geecs_scanner.py` reads it defensively.
+  - `scan_request_runner.py`: the singular `resolve_save_set_checked` +
+    `resolve_save_set_and_rituals` chain — superseded by the plural M4
+    step-0 forms, no production caller (tests ported to the plural forms).
+  - `utils.py`: `build_signal_attrs` — its collision-disambiguation loop was
+    never wired into any detector (they all call `safe_name` directly);
+    test-only. If attr-collision safety is ever wanted, re-add it *wired in*.
+  - Gateway: `GeecsDb.list_devices()` (zero consumers; the config path uses
+    the batched `get_experiment_devices`), `FakeGeecsDevice.fire_shot()`
+    (its only consumer was the deleted direct-backend test suite).
+- **Deduplicated**
+  - `_build_positions` (bridge) now delegates to `session._positions` — the
+    one true accidental copy of the start/end/step → linspace rule.
+  - Gateway transport: the numeric-coercion idiom (`float` → int-if-whole →
+    fallback str) triplicated across `tcp_subscriber`/`udp_client`/fake
+    server → shared `transport/_coerce.coerce_scalar` for the two production
+    copies. The fake server deliberately keeps its own copy (test/prod
+    decoupling).
+- **Stale references fixed** (~20 sites): every docstring cross-reference to
+  the deleted direct-backend classes (`GeecsTriggerable`, `GeecsMotor`,
+  `GeecsSettable`, `GeecsGenericDetector`, `GeecsTimestampedReadable`,
+  `GeecsSnapshotReadable`) → the `Ca*` paths; the `devices/ca/*` module
+  headers no longer define themselves as "the CA counterpart of" deleted
+  classes; `step_scan.py`'s usage example no longer shows the deleted
+  host/port constructor (rewritten against `GeecsSession` factories);
+  `GeecsBluesky/CLAUDE.md` acquisition-mode names; gateway `CLAUDE.md`'s
+  claim that GeecsBluesky imports the fake server; gateway `config.py`
+  module docstring describing the shipped DB-driven config path as future
+  work.
+- **Split**: `ConfigResolver` + `ConfigsRepoResolver` →
+  `geecs_bluesky/config_resolver.py` (~320 self-contained lines out of the
+  runner; zero shared privates with execution code). Both names re-exported
+  from `scan_request_runner` so the existing import surface is unchanged.
+
+## PR 2 (planned): the docstring pass
+
+The runner is a ~760-line module wearing an 844-line docstring coat; package
+wide ~1,000 doc lines are removable with zero contract loss. Rules:
+
+- Docstrings state the **contract** (what/args/returns/raises + non-obvious
+  invariant), numpy style, concise.
+- Design **why**/history/verification anecdotes live in the package
+  `CLAUDE.md` or `Planning/` — most already do; the code copy shrinks to a
+  one-line pointer. Every load-bearing warning ("accepted window, do not
+  fix", "never gate a shot on telemetry", "do not regress to
+  datatype=float") is already in `GeecsBluesky/CLAUDE.md` — cut the code
+  copy, never the CLAUDE.md copy.
+- Known duplication hotspots: the save-set union rule (written out 4×),
+  db_runtime module docstring (≈ verbatim CLAUDE.md M3c), single_shot's
+  40-line RunEngine source quote, action_compiler legacy-equivalence told
+  3×, the Gate-2 orphan-frame essay in every plan file.
+- Gateway: light touch only — condense `udp_client`'s thrice-stated exe-reply
+  correlation rationale and `config.py`'s incident retellings; **do not cut**
+  the wire-protocol/DB-inheritance semantics (see "keep" below).
+
+## Deliberately KEPT (do not "clean up" later)
+
+- **Gateway wire-protocol + DB-inheritance commentary**
+  (`transport/udp_client.py`, `tcp_subscriber.py`, `channels.py`,
+  `db/geecs_db.py`, `gateway.py` timestamp/supervisor comments): these
+  encode observed real-hardware semantics that exist nowhere else — e.g.
+  the reasoning that stops someone "fixing" the deliberately-loose
+  comma-tolerant frame parser. High risk if cut.
+- **`GeecsDb.get_scan_boundary_writes`** — reserved read-only query for a
+  possible DB set-side re-enable (M3c decision); has a pinned test.
+- **The fail-loud vs operator-tolerant device-build twins**
+  (`_build_request_detectors` in the runner vs `_build_session_devices` /
+  `_classify_device_roles` in the bridge) — deliberate parallel, reconcile
+  when M4 bridge parity makes the bridge delegate, not before.
+- **`session.py`** — healthiest file (21% docstring, mostly API contract);
+  the eight near-identical device factories are cohesive and readable; a
+  table-driven factory would hurt clarity.
+- `_defaults_flag` (runner) — single caller but a well-named tolerance
+  contract; inlining produces a nested-ternary mess.
+- Test-only-but-public asset API (`register_geecs_handlers`,
+  `supports_device_type`, `load_camera_image_from_tiled_run`,
+  `build_external_asset_documents`) — documented public surface with tests.
+
+## Deferred until M4 bridge parity (touching now is wasted work)
+
+M4 makes `BlueskyScanner` delegate ScanRequest execution to
+`run_scan_request`; the following are scheduled to shrink or die then:
+
+- `bluesky_scanner._reinitialize_from_scan_request` (~150 lines) and the
+  `_request_step` machinery — the biggest casualty.
+- The runner's action-refusal cluster: `raise_if_actions_present`,
+  `resolve_save_sets_checked`, `MULTI_AXIS_MESSAGE` — their only callers are
+  the bridge refusals M4 removes.
+- `resolve_defaults_for` — single production caller is the bridge.
+- Reconciling the device-build twins (above).
+- Optional bridge extractions (preflight/event-translation clusters) — clean
+  seams, but not the bottleneck; avoid colliding with M4.
+
+## Deferred: analysis/ + assets/ (WIP zone — owner decision 2026-07-10)
+
+The post-run analysis workflow is still being designed; consolidating
+scaffolding mid-design is churn. Parked until that design settles:
+
+- `analysis/camera.py` ↔ `analysis/assets.py` share four byte-identical
+  helpers (`_day_analysis_dir_from_asset`, `_iter_primary_events`,
+  `_optional_int`, `_optional_str`) and parallel orchestrators → merge into
+  a shared `analysis/_tiled_common.py`; camera keeps only image-specific
+  parts.
+- `analysis/assets.py: run_tiled_asset_analysis` — public entry point with
+  zero consumers (its camera sibling is notebook-used).
+- `analysis/image_analysis.py: resolve_image_analysis_config_dir` —
+  test-only compat alias.
+- `read_tiled_config()` duplicated between `tiled_integration.py` and
+  `assets/tiled_readback.py`; `read_geecs_root_map` re-parses `[Paths]`
+  keys that `data_paths` readers already return (three independent `[Paths]`
+  parsers exist across the repo).


### PR DESCRIPTION
Audit-driven cleanup of **GeecsBluesky** + **GeecsCAGateway** — pass 1 of 2 (pass 2 is the docstring condensation). No behavior change. The full audit findings, and the deliberate **keep / defer** decisions (gateway wire-protocol commentary, M4-scheduled deletions, the analysis/assets WIP zone), are recorded in `Planning/cleanup_vision_v1/00_overview.md` so a later pass doesn't re-litigate them.

## GeecsBluesky 0.27.0

**Split**
- `ConfigResolver` + `ConfigsRepoResolver` → new `geecs_bluesky/config_resolver.py` (pure relocation; ~320 self-contained lines out of `scan_request_runner.py`, zero shared privates with execution code). Both names re-exported from `scan_request_runner` — the existing import surface is unchanged.

**Deleted dead code**
- Bridge: `dialog_queue`, `restore_failures` (GUI stopped reading them when `ScanManager` dropped them — verified no consumer; `last_reinit_error` stays, the GUI reads it), `_ScanConfig` import shim, `_CONNECT_TIMEOUT`.
- Runner: the singular `resolve_save_set_checked` / `resolve_save_set_and_rituals` chain — superseded by the plural M4 step-0 forms, no production caller. Tests ported to the plural forms (behavioral pins kept).
- `utils.build_signal_attrs` — its collision-disambiguation was never wired into any detector; test-only.

**Dedup**
- Bridge `_build_positions` now delegates to the session's `_positions` (was a near-verbatim copy).

**Stale-reference sweep (~20 sites)**
- Every docstring cross-reference to the deleted direct-backend classes (`GeecsTriggerable`, `GeecsMotor`, `GeecsSettable`, `GeecsGenericDetector`, `GeecsTimestampedReadable`, `GeecsSnapshotReadable`) → the `Ca*` paths; `devices/ca/*` headers now say what each device *is* rather than comparing to a deleted class; `step_scan.py`'s example no longer shows the deleted host/port constructor (rewritten against `GeecsSession` factories, signatures verified); `CLAUDE.md` acquisition-mode names fixed.

## GeecsCAGateway 0.12.0

- **Deleted**: `GeecsDb.list_devices()` (zero consumers), `FakeGeecsDevice.fire_shot()` (only consumer was the deleted direct-backend suite; docstring pointed at a deleted class path).
- **Dedup**: shared `transport/_coerce.coerce_scalar` for the coercion idiom duplicated in `tcp_subscriber` + `udp_client` (fake server keeps its copy deliberately — test/prod decoupling).
- **Doc fixes**: `config.py` docstring described the shipped DB-driven config path as future work; `naming.py` condensed to a pointer at `pv_naming`; `CLAUDE.md` no longer claims GeecsBluesky imports the fake server.

## Verification
- GeecsBluesky: **407 passed**, 1 skipped
- GeecsCAGateway: **158 passed**
- Re-export identity checked (`scan_request_runner.ConfigResolver is config_resolver.ConfigResolver`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)