### PR TITLE
cleanup(vision-v1) pass 2: docstring condensation (docs-only, AST-verified)

### DIFF
--- a/GeecsBluesky/CHANGELOG.md
+++ b/GeecsBluesky/CHANGELOG.md
@@ -4,6 +4,34 @@ All notable changes to `geecs-bluesky` are documented here.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.27.1] - 2026-07-10
+
+Cleanup pass 2 — the docstring condensation (audit:
+`Planning/cleanup_vision_v1/00_overview.md`). Docstrings/comments only;
+every modified file verified AST-identical to the previous version with
+docstrings stripped (zero code change), full suite green.
+
+### Changed
+
+- **~880 net lines of documentation redundancy removed across 27 files.**
+  Docstrings now state the contract (what/args/raises + non-obvious
+  invariants); design rationale, history narration, and verification
+  anecdotes whose canonical copy lives in `CLAUDE.md` are cut to one-line
+  pointers. Highlights: the save-set union rule is stated once (on
+  `merge_save_sets`) instead of four times; `db_runtime`'s module docstring
+  no longer duplicates the CLAUDE.md M3c section; `single_shot`'s 40-line
+  RunEngine source quote is an 8-line conclusion; `action_compiler`'s
+  legacy-equivalence story is told once instead of three times;
+  `shot_controller`'s ordered-writes semantics live once, on `from_writes`.
+- Load-bearing warnings whose only copy is the code were kept verbatim and
+  are now inventoried in the audit doc (e.g. the cold-cache baseline-get
+  race in `CaTriggerable._wait_for_shot`, the refire no-cancellation
+  conclusion in `single_shot`, the `Reference()` re-parenting note in
+  `contributor`).
+- Stale claims fixed in passing: `settable.py`/`motor.py` no longer describe
+  the shipped `CaConfirmSettable` as a future milestone; `shot_id.py` no
+  longer references the deleted `geecs_device.GeecsDevice`.
+
 ## [0.27.0] - 2026-07-10
 
 Cleanup pass 1 (audit: `Planning/cleanup_vision_v1/00_overview.md`) — no

--- a/GeecsBluesky/geecs_bluesky/config_resolver.py
+++ b/GeecsBluesky/geecs_bluesky/config_resolver.py
@@ -157,21 +157,10 @@ class ConfigsRepoResolver:
     def resolve_save_set(self, name: str) -> SaveSet:
         """Load the save set *name* (new schema, else converted save element).
 
-        Parameters
-        ----------
-        name :
-            File stem under ``save_devices/`` (``.yaml`` optional).
-
-        Returns
-        -------
-        SaveSet
-            The validated save set.
-
         Raises
         ------
         GeecsConfigurationError
-            If the file is missing or is an action-only legacy element
-            (nothing to record).
+            Missing file, or an action-only legacy element (nothing to record).
         """
         stem = self._strip_yaml_suffix(name)
         path = self._root / self.SAVE_SET_FOLDER / f"{stem}.yaml"
@@ -195,20 +184,10 @@ class ConfigsRepoResolver:
     def resolve_trigger_profile(self, name: str) -> TriggerProfile:
         """Load the trigger profile *name* (new schema, else converted).
 
-        Parameters
-        ----------
-        name :
-            File stem under ``shot_control_configurations/``.
-
-        Returns
-        -------
-        TriggerProfile
-            The validated profile.
-
         Raises
         ------
         GeecsConfigurationError
-            If the file is missing or names no trigger device.
+            Missing file, or a profile that names no trigger device.
         """
         stem = self._strip_yaml_suffix(name)
         path = self._root / self.TRIGGER_FOLDER / f"{stem}.yaml"
@@ -251,20 +230,10 @@ class ConfigsRepoResolver:
     def resolve_scan_variable(self, name: str) -> ScanVariableSpec:
         """Look up the scan variable *name* in the experiment catalog.
 
-        Parameters
-        ----------
-        name :
-            Friendly variable name (a key of the catalog).
-
-        Returns
-        -------
-        ScanVariable or PseudoScanVariable
-            The catalog entry.
-
         Raises
         ------
         GeecsConfigurationError
-            If the name is not in the catalog (known names are listed).
+            Unknown name (the error lists the known variables).
         """
         catalog = self._scan_variables_catalog()
         try:
@@ -292,20 +261,10 @@ class ConfigsRepoResolver:
     def resolve_action_plan(self, name: str) -> ActionPlan:
         """Look up the action plan *name* in the experiment library.
 
-        Parameters
-        ----------
-        name :
-            Plan name (a key of the action library).
-
-        Returns
-        -------
-        ActionPlan
-            The named plan.
-
         Raises
         ------
         GeecsConfigurationError
-            If the name is not in the library (known names are listed).
+            Unknown name (the error lists the known plans).
         """
         # Plans the save-element converter extracted resolve first: they
         # live beside their element (their `<element>_setup` names cannot
@@ -326,15 +285,8 @@ class ConfigsRepoResolver:
     def action_plan_registry(self) -> dict[str, ActionPlan]:
         """Return every named plan visible to nested ``run`` steps.
 
-        The experiment's action library plus the plans the save-element
-        converter extracted (which win on a name collision, matching
-        :meth:`resolve_action_plan`'s lookup order).  An experiment without
-        an action library still gets its extracted element plans.
-
-        Returns
-        -------
-        dict
-            ``{plan_name: ActionPlan}``.
+        The action library plus converter-extracted element plans (extracted
+        plans win on collision, matching :meth:`resolve_action_plan`).
         """
         plans: dict[str, ActionPlan] = {}
         try:
@@ -347,17 +299,10 @@ class ConfigsRepoResolver:
     DEFAULTS_FILE = "experiment_defaults.yaml"
 
     def resolve_experiment_defaults(self) -> ExperimentDefaults | None:
-        """Load and validate the experiment's defaults file, if one exists.
+        """Load ``<experiment>/experiment_defaults.yaml``; ``None`` if absent.
 
-        Reads ``<experiment>/experiment_defaults.yaml`` into the
-        :class:`~geecs_schemas.ExperimentDefaults` model (there is no
-        legacy dialect behind it — the legacy scanner kept these choices in
-        GUI state).
-
-        Returns
-        -------
-        ExperimentDefaults or None
-            The validated defaults, or ``None`` when no file exists.
+        No legacy dialect exists behind it (the legacy scanner kept these
+        choices in GUI state).
         """
         path = self._root / self.DEFAULTS_FILE
         if not path.exists():

--- a/GeecsBluesky/geecs_bluesky/db_runtime.py
+++ b/GeecsBluesky/geecs_bluesky/db_runtime.py
@@ -1,48 +1,22 @@
 """DB-integration runtime (M3c): the get-side two-tier recording model, wired.
 
-This module turns the GEECS experiment database's per-experiment
-device-variable policy (MySQL table ``expt_device_variable``) into the two
-**get-side** runtime capabilities the schema describes (see the
-``SaveSetEntry`` runtime contract in :mod:`geecs_schemas.save_set`, and
-:class:`~geecs_schemas.experiment_defaults.ExperimentDefaults`):
+Turns the GEECS experiment DB's per-experiment variable policy
+(``expt_device_variable``) into the two **get-side** runtime capabilities the
+schema describes (the ``SaveSetEntry`` runtime contract in
+:mod:`geecs_schemas.save_set`):
 
-1. **db_scalars resolution** (Tier 1 recorded scalars).  For a save-set entry
-   with ``db_scalars=True`` (the default), the scalars recorded for the device
-   are its DB ``get='yes'`` variables **unioned** with the entry's explicit
-   ``scalars`` list; ``all_scalars=True`` unions *every* DB variable for the
-   device instead of just the ``get='yes'`` subset; ``db_scalars=False`` (what
-   the legacy converter pins) records only the explicit ``scalars``.
-
-2. **Background telemetry tier** (Tier 2).  Every live experiment device with
-   a ``get='yes'`` variable that is *not* in the save set is recorded as
-   best-effort snapshot columns — read-only, never waited on, a dead device
-   dropped with a log line.  Selection of which ``(device, variables)`` become
-   telemetry is pure here; the soft read lives in
+1. **db_scalars resolution** (Tier 1 recorded scalars) —
+   :func:`resolve_entry_scalars`.
+2. **Background telemetry selection** (Tier 2) —
+   :func:`select_telemetry_variables`; the soft read lives in
    :class:`~geecs_bluesky.devices.ca.telemetry.CaTelemetryReadable`.
 
-The **set-side** (DB scan start/end writes, from the ``set='yes'`` rows'
-``startvalue``/``endvalue``) is **intentionally disabled** in this version.
-Live DB inspection showed the boundary writes would race the shot
-controller / TriggerProfile on the DG645 (``U_DG645_ShotControl`` has
-``set='yes'`` rows for ``Trigger.Source`` and ``Amplitude.Ch AB`` — the very
-variables the shot controller already drives), and the remaining ``set='yes'``
-rows are almost all ``save`` / ``localsavingpath`` (which the scanner owns
-through its save-windowing).  The engine sets up triggering via the
-TriggerProfile/shot controller and camera saving via its own save-windowing,
-so DB set-side writes are not honored.  The reserved-but-not-honored
-schema fields (``SaveSetEntry.at_scan_start`` / ``at_scan_end`` and
-``ExperimentDefaults.apply_db_scan_defaults``) are kept on record for a
-possible future re-enable, and the gateway's
-:meth:`~geecs_ca_gateway.db.geecs_db.GeecsDb.get_scan_boundary_writes` query
-remains a reserved read-only library method (not consumed by the engine).
-
-Everything in this module is a **pure function** except the thin
-:class:`GeecsDbScalarPolicy` provider, which is the one place that touches
-:class:`~geecs_ca_gateway.db.geecs_db.GeecsDb`.  The provider caches its two
-get-side queries per experiment and **tolerates a missing/incompletely-curated
-DB** (the maintainer's known curation caveat): a lookup failure logs and yields
-empty policy rather than aborting the scan.  Keeping the policy separable is
-what makes the resolution logic testable with no MySQL access.
+The **set-side** (DB scan start/end writes) is intentionally disabled: the
+boundary writes would race the shot controller / TriggerProfile on the DG645,
+so the reserved schema fields stay inert.  Everything here is a pure function
+except :class:`GeecsDbScalarPolicy`, the one failure-tolerant place touching
+``GeecsDb`` — a scan must never abort because the DB blipped.  Design
+rationale: ``GeecsBluesky/CLAUDE.md`` (M3c).
 """
 
 from __future__ import annotations
@@ -168,20 +142,12 @@ def resolve_entry_scalars(
 ) -> list[str]:
     """Resolve the recorded scalar list for one save-set entry.
 
-    The rules (from the ``SaveSetEntry`` docstring):
-
-    - ``db_scalars=False`` → only the explicit list (the legacy converter pins
-      this, preserving each converted element's exact behavior).
-    - ``db_scalars=True``, ``all_scalars=False`` → the DB ``get='yes'``
-      variables ∪ the explicit list.
-    - ``db_scalars=True``, ``all_scalars=True`` → every DB variable for the
-      device ∪ the explicit list.
-
-    The union preserves order: the DB variables first (in DB order), then any
-    explicit variable not already present.  When no *provider* is available (no
-    DB access, the GUI-bridge path) the DB contribution is empty and only the
-    explicit list is recorded — the same shape M3b produced, so the DB tier is
-    strictly additive.
+    ``db_scalars=False`` → only the explicit list; ``db_scalars=True`` → the
+    DB ``get='yes'`` variables ∪ the explicit list (``all_scalars=True``
+    widens the DB side to every DB variable).  Order is stable: DB variables
+    first, then any explicit variable not already present.  With no
+    *provider* (no DB access) only the explicit list is recorded — the DB
+    tier is strictly additive.
 
     Parameters
     ----------

--- a/GeecsBluesky/geecs_bluesky/devices/ca/confirm.py
+++ b/GeecsBluesky/geecs_bluesky/devices/ca/confirm.py
@@ -1,46 +1,20 @@
 """CaConfirmSettable — the topology-C device: set X, confirm on Y.
 
-``CaSettable``/``CaMotor`` both poll (or trust GEECS to converge) the
-readback of the **same** variable they wrote.  Some devices split the two:
-you set one variable, but a *different* variable measures the physical
-result.  The production example is the EMQ triplet: the catalog's "EMQ1
-Current" writes ``U_EMQTripletBipolar:Current_Limit.Ch1`` (a software limit
-GEECS's own blocking set trivially confirms — the limit register echoes what
-was written), while the real current is the separate ``Current.Ch1``
-variable, which the write never touches.
+Some devices split command and measurement: you set one variable, but a
+*different* variable measures the physical result (the EMQ triplet writes
+``Current_Limit.ChN``, a software limit, while the measured current is the
+separate ``Current.ChN``).  ``ScanVariable.confirm`` names this second
+variable in the schema (``geecs_schemas.scan_variables``); this device acts
+on it.
 
-``ScanVariable.confirm`` names this second variable in the schema
-(``geecs_schemas.scan_variables``); this device is what acts on it.
+Completion is two layers: (1) the gateway ``…:SP`` write rides GEECS's own
+blocking set on ``variable`` — which says nothing about the confirming
+variable — then (2) a poll on the confirming variable's streamed readback:
+analog (float) match by tolerance, discrete (string) match by exact equality.
 
-Completion semantics
----------------------
-1. The gateway's ``…:SP`` write on ``variable`` forwards to the GEECS UDP set,
-   which blocks until *that* variable's own convergence criterion is met (the
-   same Layer-1 wait every ``CaSettable`` gets) — this says nothing about the
-   confirming variable.
-2. A poll on the **confirming variable's** streamed readback then waits for it
-   to match the target: analog (float) match by tolerance, discrete
-   (string/enum, e.g. a future ``CaShutter``) match by exact equality.
-
-Defaults come from a live characterization of
-``U_EMQTripletBipolar:Current.ChN`` (no beam, 2026-07-09,
-``Planning/scan_variable_metadata/00_overview.md`` Deferred #5): jitter
-0.01 A, response lag <1 s, settles within ~3 frames.  ``tolerance=0.05``
-(5x the observed jitter) and ``timeout=10.0`` (comfortably past the settle
-time) are sized from those numbers, not guessed.
-
-Recorded event-row column, deliberately
-----------------------------------------
-As a scan axis, this device's own readable data is the **written** variable's
-streamed value (``variable``, e.g. ``Current_Limit.Ch1``) — the same
-"motor column" shape as ``CaSettable``/``CaMotor``.  The **confirming**
-variable (``Current.Ch1``) is intentionally *not* a child readable here (see
-below) and so does not appear in the event row unless it is separately in the
-scan's save set.  For an operator-facing "EMQ current" scan this can be
-surprising — the recorded "motor" value is the commanded limit, not the
-measured current that was actually confirmed — so include the confirming
-variable in the save set when the measured value itself matters to the
-analysis, not just the pass/fail of confirmation.
+Defaults (``tolerance=0.05``, ``timeout=10.0``) are sized from a live no-beam
+characterization of ``U_EMQTripletBipolar:Current.ChN`` (details in
+``GeecsBluesky/CLAUDE.md`` and ``Planning/scan_variable_metadata/``).
 """
 
 from __future__ import annotations
@@ -67,6 +41,12 @@ ConfirmValue = Union[float, str]
 class CaConfirmSettable(CaSettable):
     """Writes ``variable``, confirms completion on a *different* variable.
 
+    The recorded event-row column is the **written** variable's streamed
+    value — the same "motor column" shape as ``CaSettable``/``CaMotor``.
+    The confirming variable never appears in the event row unless it is
+    separately in the scan's save set; include it there when the measured
+    value itself matters, not just the pass/fail of confirmation.
+
     Parameters
     ----------
     device : str
@@ -85,11 +65,9 @@ class CaConfirmSettable(CaSettable):
     name : str
         ophyd-async device name (namespaces the event keys).
     tolerance : float
-        Analog (float) match tolerance for the confirming variable.
-        ``set()`` resolves when ``|confirm_readback - target| <= tolerance``.
-        Default ``0.05`` — see the module docstring for where this number
-        comes from.  Ignored for a discrete (string) target, which matches by
-        exact equality instead.
+        Analog (float) match tolerance: ``set()`` resolves when
+        ``|confirm_readback - target| <= tolerance``.  Ignored for a
+        discrete (string) target, which matches by exact equality.
     timeout : float
         Maximum seconds to wait for the confirming variable to match, after
         the ``:SP`` write's own convergence.  Default ``10.0``.
@@ -125,12 +103,9 @@ class CaConfirmSettable(CaSettable):
             datatype=datatype,
         )
         # A plain (non-child) readable: the confirming variable is not this
-        # device's own data (it may live on a different GEECS device
-        # entirely), so it must not appear as an event-row column here — the
-        # confirming device's own save set, if any, is the place that reads it.
-        # Same datatype as the target variable: for the common analog case
-        # (float in, float confirm) that's the natural default; a discrete
-        # confirm target (string/enum) passes datatype=str for both.
+        # device's own data (it may live on another GEECS device entirely),
+        # so it must not become an event-row column here.  Same datatype as
+        # the target variable (str for a discrete confirm target).
         self._confirm_readback = epics_signal_r(
             datatype, ca_pv(experiment, confirm_device, confirm_variable)
         )
@@ -211,12 +186,9 @@ def _matches(
 ) -> bool:
     """Analog match by tolerance for a numeric ``datatype``, exact equality otherwise.
 
-    Dispatches on the device's declared ``datatype``, not on whether *current*
-    happens to be parseable as a float: a discrete (``str``) confirming
-    variable — e.g. a future ``CaShutter``'s inserted/removed limit switch —
-    must match by exact equality even when its label looks numeric (``"1.0"``
-    vs ``"1.04"``), never by coercing both sides to float and comparing within
-    tolerance.
+    Dispatch is on the declared ``datatype``, never on whether *current*
+    parses as a float: a ``str`` confirm target must match by exact equality
+    even when its label looks numeric.
     """
     if datatype is str:
         return current == target

--- a/GeecsBluesky/geecs_bluesky/devices/ca/generic_detector.py
+++ b/GeecsBluesky/geecs_bluesky/devices/ca/generic_detector.py
@@ -1,18 +1,13 @@
 """CaGenericDetector — the scanner's triggered detector over the CA gateway.
 
-One
-readable signal per variable, ``trigger()`` gated on ``acq_timestamp`` (via
-:class:`~geecs_bluesky.devices.ca.triggerable.CaTriggerable`'s persistent CA
-monitor), the schema-v1 sync-device companion columns on every read, and native
-non-scalar file saving.
-
-The companion-column and asset logic is the *shared* domain layer
-(:class:`~geecs_bluesky.devices.shot_id.ShotIdSupport` and
-:class:`~geecs_bluesky.devices.nonscalar_save.NonScalarSaveSupport` mixins);
-``acq_timestamp`` comes from the CA monitor cache, and the
-``localsavingpath`` / ``save`` controls are CA signals that read the gateway
-readback PV and write its ``…:SP`` setpoint (which forwards to the GEECS UDP
-set).
+One readable signal per variable, ``trigger()`` gated on ``acq_timestamp``
+(via :class:`~geecs_bluesky.devices.ca.triggerable.CaTriggerable`'s
+persistent CA monitor), the schema-v1 sync-device companion columns on every
+read (:class:`~geecs_bluesky.devices.shot_id.ShotIdSupport`), and native
+non-scalar file saving
+(:class:`~geecs_bluesky.devices.nonscalar_save.NonScalarSaveSupport`; the
+``localsavingpath`` / ``save`` controls write the gateway ``…:SP``, which
+forwards to the GEECS UDP set).
 """
 
 from __future__ import annotations

--- a/GeecsBluesky/geecs_bluesky/devices/ca/motor.py
+++ b/GeecsBluesky/geecs_bluesky/devices/ca/motor.py
@@ -2,25 +2,19 @@
 
 Two layers of convergence:
 
-1. The gateway's ``…:SP`` write forwards to the GEECS UDP set, which itself
-   blocks until the device reports the set converged (per the DB tolerance) or
-   failed — so the CA put *already* carries GEECS's native convergence.  It is
-   given the full ``move_timeout`` budget rather than the short CA default,
-   since a slow axis is not a dead one.
+1. The gateway's ``…:SP`` write rides the blocking GEECS UDP set (given the
+   full ``move_timeout`` budget rather than the short CA default — a slow
+   axis is not a dead one), so the put already carries GEECS's native
+   convergence; a plain CaSettable is not "non-blocking."
 2. A readback polling loop then confirms the *streamed* position is within
-   ``tolerance`` of the target — belt-and-suspenders for the fringe cases where
-   the UDP set's own timeout semantics are ambiguous (devices that go quiet
-   during a move vs. genuinely stuck axes).
+   ``tolerance`` of the target — belt-and-suspenders for devices whose UDP
+   set-completion semantics are ambiguous.  It only adds information when
+   the readback is an independent measurement (a stage encoder), not an
+   echo of the command.
 
-Layer 1 alone (i.e. a plain :class:`~geecs_bluesky.devices.ca.settable.CaSettable`)
-already waits for GEECS convergence, so CaMotor is *not* "the way to make a
-set block."  Its Layer 2 poll only adds information when the readback is an
-independent measurement of the same variable that was set — a stage encoder,
-not a value that merely echoes the command.  It does **not** cover the case
-where the measured quantity is a *different* variable from the one set (the
-EMQ triplet's ``Current_Limit`` vs its measured current): the poll reads the
-readback of ``variable``, the variable it wrote.  ``ScanVariable.confirm``
-names that decoupled case in the schema; acting on it is a later milestone.
+The poll reads the readback of the *same* variable it set; the decoupled
+set-X-confirm-Y case is
+:class:`~geecs_bluesky.devices.ca.confirm.CaConfirmSettable`.
 """
 
 from __future__ import annotations

--- a/GeecsBluesky/geecs_bluesky/devices/ca/settable.py
+++ b/GeecsBluesky/geecs_bluesky/devices/ca/settable.py
@@ -2,38 +2,15 @@
 
 The gateway exposes a settable GEECS variable as two PVs: a readback
 (``[Experiment:]Device:Variable``, fed by the device stream) and a setpoint
-(``…:SP``, whose CA puts the gateway forwards to the device over UDP).  This
-device writes the setpoint and reads back the real value.
+(``…:SP``, forwarded to the device over UDP).  This device writes the
+setpoint and reads back the real value.
 
-Completion semantics — CaSettable already waits
------------------------------------------------
-The ``:SP`` put is **not** fire-and-forget: the gateway forwards it as a
-GEECS UDP set, which itself blocks until the device reports the value
-converged (per the DB tolerance) or failed.  So a plain CaSettable already
-carries GEECS's native set-completion — it is a legitimate choice for a real
-positioner, not a lesser one.
-
-:class:`~geecs_bluesky.devices.ca.motor.CaMotor` adds *one* thing on top: a
-second poll of the streamed readback until it is within tolerance of the
-target.  That extra poll only carries information when the readback is an
-independent measurement that can lag or overshoot the commanded value (a
-stage encoder).  When the readback just echoes what was written, the poll is
-satisfied trivially and CaMotor is near-cosmetic.  Choose CaMotor when you do
-not fully trust GEECS's own set-completion for that axis — not because
-CaSettable "doesn't wait."
-
-The open question is empirical, not schema-shaped: how reliable is GEECS's
-blocking-set convergence for real stages?  If it is solid, CaMotor is nearly
-cosmetic; if it is not, CaSettable is the quietly-risky choice for anything
-mechanical.  That — not which ``kind`` a config declares — is where the real
-risk lives.
-
-Neither class covers the case where the variable you *set* differs from the
-variable that *measures* the result (the EMQ triplet's ``Current_Limit`` vs
-its measured current): CaMotor polls the readback of the *same* variable it
-set, so it cannot confirm a decoupled measurement.  The schema names that
-case via ``ScanVariable.confirm``; the device that would act on it is a later
-milestone.
+The ``:SP`` put is not fire-and-forget: it rides GEECS's native **blocking**
+set, which completes only when the device reports convergence (per the DB
+tolerance) or failure — a plain CaSettable already waits.
+:class:`~geecs_bluesky.devices.ca.motor.CaMotor` adds an independent
+readback-tolerance poll on top; the decoupled set-X-confirm-Y case is
+:class:`~geecs_bluesky.devices.ca.confirm.CaConfirmSettable`.
 """
 
 from __future__ import annotations

--- a/GeecsBluesky/geecs_bluesky/devices/ca/telemetry.py
+++ b/GeecsBluesky/geecs_bluesky/devices/ca/telemetry.py
@@ -1,28 +1,18 @@
 """CaTelemetryReadable — the soft Tier-2 background-telemetry device (M3c).
 
-Tier 2 of the two-tier recording model (see the ``SaveSetEntry`` module
-docstring in :mod:`geecs_schemas.save_set`): every live experiment device with
-a ``get='yes'`` variable that is *not* in the scan's save set is recorded as
-best-effort snapshot columns, read from the gateway's always-on monitor cache.
+Tier 2 of the two-tier recording model: every live experiment device with a
+``get='yes'`` variable *not* in the scan's save set is recorded as
+best-effort, read-only snapshot columns.  Two load-bearing rules:
 
-The non-negotiable contract, enforced here:
+- **Telemetry must never gate a shot** — never waited on; a failed read
+  degrades a single cell to a dtype-appropriate null, never an abort.
+- **No telemetry variable or device is dropped for a *type* reason** —
+  dtype is inferred per PV; a device is dropped (with a log line, by the
+  caller) only when genuinely unreachable.
 
-- **read-only** — no ``:SP`` signals, no ``trigger()``; the device is a plain
-  :class:`~bluesky.protocols.Readable` sampled once per event row;
-- **never waited on / never blocks or aborts a scan** — :meth:`read` catches
-  every per-signal failure and substitutes NaN, so a value that cannot be read
-  (a device that went dead mid-scan) degrades a single cell to NaN rather than
-  raising into the plan;
-- **dead device dropped with a log line, not an error** — a device that fails
-  to connect at scan start is dropped by the caller
-  (:func:`~geecs_bluesky.scan_request_runner.build_telemetry_readables`) with a
-  warning; it never becomes a dialog or an abort.
-
-Telemetry columns are **prefixed to distinguish them from Tier-1 save-set
-data** in the event schema: the ophyd device name is ``telemetry_<device>`` and
-every column therefore begins ``telemetry_<device>-`` (``EVENT_SCHEMA.md`` §
-"Background telemetry columns").  This is a device-name convention, not a new
-schema field — additive, so it does not bump the schema version.
+Columns are prefixed ``telemetry_<device>-`` (``EVENT_SCHEMA.md`` §
+"Background telemetry columns").  Design rationale:
+``GeecsBluesky/CLAUDE.md`` (M3c background telemetry).
 """
 
 from __future__ import annotations
@@ -46,20 +36,12 @@ TELEMETRY_NAME_PREFIX = "telemetry_"
 class CaTelemetryReadable(StandardReadable):
     """Soft, read-only GEECS readable for background telemetry over gateway PVs.
 
-    Structurally a :class:`~geecs_bluesky.devices.ca.snapshot.CaSnapshotReadable`
-    (float readback signals sampled per row) but with a **fault-tolerant**
-    :meth:`read` that never propagates an exception: a signal that fails to
-    read yields NaN for its value instead of aborting the plan.  This is the
-    softness half of the two-tier model — telemetry can never gate a shot.
-
-    Signal datatype is **inferred per-variable** from the PV's native CA type
-    (``epics_signal_r(datatype=None, …)``): numeric PVs stay ``float`` so
-    downstream telemetry analysis keeps working, while enum/string PVs (e.g.
-    ``U_VisaPlungers`` ``DigitalOutput.Channel N``) are captured as their
-    string/label value instead of failing to connect.  This is what keeps the
-    tier's rule honest — *if we ``get`` it, we log it*: a non-numeric
-    ``get='yes'`` variable no longer drops the whole device on a type mismatch.
-    Type tolerance is per-variable, never whole-device.
+    A fault-tolerant :meth:`read` never propagates an exception: a signal
+    that fails to read yields a null cell instead of aborting the plan —
+    telemetry can never gate a shot.  Signal datatype is inferred
+    per-variable from the PV's native CA type: numeric PVs stay ``float``,
+    enum/string PVs are captured as their label string.  Type tolerance is
+    per-variable, never whole-device.
 
     Parameters
     ----------
@@ -70,15 +52,13 @@ class CaTelemetryReadable(StandardReadable):
     experiment : str, optional
         Experiment PV-namespace prefix (e.g. ``"Undulator"``).
     name : str, optional
-        Ophyd-async device name; defaults to ``telemetry_<device>`` so the
-        columns are self-identifying.  A caller-supplied name must keep the
-        :data:`TELEMETRY_NAME_PREFIX` for the schema marking to hold.
+        Ophyd-async device name; defaults to ``telemetry_<device>``.  A
+        caller-supplied name must keep the :data:`TELEMETRY_NAME_PREFIX`
+        for the schema marking to hold.
     datatype : type, optional
-        Scalar CA datatype for the variables.  Defaults to ``None`` — let
-        ophyd-async infer each PV's native type (float for numeric, str for
-        enum/string).  A caller may pin an explicit type, but the default
-        inference is what makes telemetry dtype-tolerant; forcing ``float``
-        here reintroduces the connect-time drop for non-numeric variables.
+        Scalar CA datatype.  Default ``None`` — infer each PV's native type.
+        Do not force ``float`` here: that reintroduces the connect-time drop
+        for non-numeric variables.
     """
 
     def __init__(
@@ -109,19 +89,15 @@ class CaTelemetryReadable(StandardReadable):
     async def read(self) -> dict[str, Any]:
         """Read all telemetry signals, substituting a null cell for any that fail.
 
-        Overrides :meth:`StandardReadable.read` so one unreadable signal (a
-        device that went dead mid-scan) degrades to a null cell rather than
-        raising into ``trigger_and_read`` and aborting the scan — the soft-tier
-        guarantee.  The substituted value is dtype-appropriate: ``NaN`` for a
-        numeric signal, ``""`` for a string/enum signal (so a failed read never
-        forces a string column to hold a float).  Reads are issued
+        The soft-tier guarantee: one unreadable signal degrades to a
+        dtype-appropriate null (``NaN`` for numeric, ``""`` for string/enum)
+        rather than raising into ``trigger_and_read``.  Reads are issued
         concurrently; the row's timestamp is best effort.
 
         Returns
         -------
         dict
-            The ophyd reading dict, with failed signals reported as a
-            dtype-appropriate null (NaN for numeric, ``""`` for string).
+            The ophyd reading dict, with failed signals reported as nulls.
         """
         import asyncio
         import time

--- a/GeecsBluesky/geecs_bluesky/devices/ca/timestamped_readable.py
+++ b/GeecsBluesky/geecs_bluesky/devices/ca/timestamped_readable.py
@@ -2,13 +2,13 @@
 
 Read like a snapshot (no blocking ``trigger()``, so it never gates the event
 row) but carrying the sync-device companion columns labeled relative to the
-reference.  The labeling semantics — row shot-id peeking, bounded grace wait,
-offset/valid emission — are the shared
-:class:`~geecs_bluesky.devices.contributor.FreeRunContributorSupport` mixin;
-this class supplies the CA transport underneath: ``acq_timestamp`` from the persistent gateway monitor
+reference — the shared
+:class:`~geecs_bluesky.devices.contributor.FreeRunContributorSupport` mixin.
+This class supplies the CA transport underneath: ``acq_timestamp`` from the
+persistent gateway monitor
 (:class:`~geecs_bluesky.devices.ca.triggerable.CaAcqTimestampReadable`), and
-``localsavingpath`` / ``save`` controls as CA signals writing the gateway
-``…:SP`` setpoints.
+``localsavingpath`` / ``save`` controls writing the gateway ``…:SP``
+setpoints.
 """
 
 from __future__ import annotations

--- a/GeecsBluesky/geecs_bluesky/devices/ca/triggerable.py
+++ b/GeecsBluesky/geecs_bluesky/devices/ca/triggerable.py
@@ -1,30 +1,19 @@
 """CA acq_timestamp-monitored readables: the shot-aware CA device bases.
 
 The GEECS shot signal is the device's ``acq_timestamp`` advancing once per
-shot.  Over the gateway that is a readback PV; a **persistent CA monitor** on
-it (started at ``connect()``) feeds a local cache and an event queue:
+shot.  A **persistent CA monitor** on that PV (started at ``connect()``,
+stopped by ``disconnect()``) feeds a local cache and a bounded drop-oldest
+event queue:
 
 * :class:`CaAcqTimestampReadable` — readable signals plus the monitor/cache
   (``_last_acq``); free-run *contributors* build on this (no blocking trigger).
 * :class:`CaTriggerable` — adds ``trigger()``, which blocks until the queue
   delivers a value different from the baseline.
 
-The stale-frame drain and baseline capture happen
-**synchronously inside** ``trigger()``, before the status is returned — so a
-shot fired immediately after ``bps.trigger`` (the strict single-shot pattern:
-trigger → fire → wait) can never land in a blind window between baselining and
-waiting and be missed.  Free-run behavior is hardware-verified (one Bluesky row
-per real shot, no coalescing).
-
-The event queue is **bounded** (drop-oldest ring, ``_shot_queue_maxsize``):
-only ``trigger()`` ever drains it, so contributors and idle detectors would
-otherwise accumulate one float per machine shot for as long as the persistent
-monitor lives.  Dropping the oldest entry preserves the no-blind-window
-guarantee — see :meth:`CaAcqTimestampReadable._on_acq_timestamp`.
-
-Instances are torn down with :meth:`CaAcqTimestampReadable.disconnect`, which
-unsubscribes the persistent monitor so per-scan device objects do not stay
-reachable (and firing) through the signal cache's callback reference.
+The stale-frame drain and baseline capture happen **synchronously inside**
+``trigger()`` so an immediately-fired shot cannot be missed — see
+:meth:`CaTriggerable.trigger`.  Design rationale: ``GeecsBluesky/CLAUDE.md``
+(Device Layer).
 """
 
 from __future__ import annotations
@@ -79,13 +68,10 @@ class CaAcqTimestampReadable(StandardReadable):
     _acq_timestamp_variable : str
         GEECS variable that advances per shot.  Default ``"acq_timestamp"``.
     _shot_queue_maxsize : int
-        Bound on the shot-update queue (default 32).  Only ``trigger()``
-        drains the queue, so without a bound an idle device (a free-run
-        contributor, or a detector between scans) accumulates one float per
-        machine shot for as long as the monitor lives — tens of thousands
-        per hour at typical rep rates.  32 comfortably covers the real need
-        (updates arriving between ``trigger()``'s baseline capture and the
-        awaited get: at most rep-rate × trigger-timeout, ~15 at 5 Hz / 3 s).
+        Bound on the shot-update queue (default 32 — comfortably above the
+        worst case of rep-rate × trigger-timeout updates between baseline
+        and the awaited get).  Only ``trigger()`` drains the queue, so an
+        unbounded queue would grow one float per machine shot on idle devices.
     """
 
     _acq_timestamp_variable: str = "acq_timestamp"
@@ -115,18 +101,12 @@ class CaAcqTimestampReadable(StandardReadable):
             self.acq_timestamp = epics_signal_r(
                 float, ca_pv(experiment, device, self._acq_timestamp_variable)
             )
-        # Liveness signal — the gateway's per-device status PV
-        # ``[Experiment:]Device:CONNECTED`` (PV_CONTRACT.md §1: enum with
-        # choices ["Disconnected", "Connected"], MAJOR severity + status COMM
-        # while the device's TCP stream is down; composed like any variable —
-        # no ``:SP``, no variable suffix beyond the literal ``CONNECTED``).
-        # Deliberately created OUTSIDE ``add_children_as_readables()`` so it
-        # never appears in event rows or ``describe()``: gateway liveness is
-        # pre-flight / plan metadata, not shot data.  Read as ``str`` (CA
-        # serves the enum *choice string* for a string read); only the exact
-        # :data:`~geecs_bluesky.devices.ca._pv.GATEWAY_DISCONNECTED` value
-        # means down, so a mock backend's ``""`` default — and any gateway
-        # old enough to lack status PVs — reads as live (fail-open).
+        # Liveness signal — the gateway's per-device ``CONNECTED`` status PV
+        # (PV_CONTRACT.md §1).  Created OUTSIDE add_children_as_readables()
+        # so it never appears in event rows or describe(): liveness is
+        # pre-flight / plan metadata, not shot data.  Read as str; only the
+        # exact "Disconnected" value means down (fail-open — a mock backend's
+        # "" default and a status-PV-less old gateway both read as live).
         self.connected_status = epics_signal_r(
             str, ca_pv(experiment, device, "CONNECTED")
         )
@@ -156,13 +136,10 @@ class CaAcqTimestampReadable(StandardReadable):
     async def disconnect(self) -> None:
         """Stop the persistent ``acq_timestamp`` monitor and drop shot state.
 
-        The per-scan teardown hook: the scanner bridge's
-        ``_disconnect_devices_sync`` runs ``device.disconnect()`` as a
-        coroutine on the RunEngine loop after every scan.  Unsubscribing
-        removes the signal cache's reference back to this instance (its
-        ``_on_acq_timestamp`` bound method) — without it, every per-scan
-        device object stays alive and keeps enqueuing monitor updates for
-        the rest of the process.
+        Per-scan teardown hook (scanner bridge ``_disconnect_devices_sync``).
+        Unsubscribing removes the signal cache's reference to this instance's
+        bound callback — without it every per-scan device object stays alive
+        and keeps enqueuing monitor updates for the rest of the process.
 
         Idempotent; ``connect()`` may be called again to resubscribe.
         """
@@ -179,24 +156,14 @@ class CaAcqTimestampReadable(StandardReadable):
     def _on_acq_timestamp(self, reading: dict[str, Any]) -> None:
         """Monitor callback: cache the latest value and queue the update.
 
-        Non-positive values are ignored: a real GEECS ``acq_timestamp`` is a
-        LabVIEW-epoch time (~3.9e9), while ``0.0`` is the gateway channel's
-        initial placeholder before the device's first acquisition — treating it
-        as data would fake a t0 and make the placeholder→first-frame jump look
-        like a shot.  "Never acquired" therefore reads as ``_last_acq is None``
-        on both backends.
-
-        The queue is a **drop-oldest ring** bounded at ``_shot_queue_maxsize``:
-        when full, the oldest entry is discarded to admit the newest, so an
-        idle device (nothing draining the queue) holds a fixed handful of
-        floats instead of one per machine shot.  This preserves ``trigger()``'s
+        Non-positive values are ignored — ``0.0`` is the gateway channel's
+        pre-acquisition placeholder, so "never acquired" reads as ``None``.
+        The queue is a drop-oldest ring; this preserves ``trigger()``'s
         no-blind-window guarantee: the queue is drained empty at baseline
-        capture, so anything dropped afterwards is *older* than an update
-        still enqueued — and every post-baseline update satisfies the
-        ``!= t0`` shot test, so a newer survivor detects the shot just as
-        well.  Callback and consumers share the RE event loop (no awaits
-        between the full-check and the put), so the two-step replace is
-        race-free.
+        capture, so anything dropped afterwards is older than a surviving
+        update, and every post-baseline update passes the ``!= t0`` shot
+        test.  Callback and consumers share the RE event loop, so the
+        two-step replace is race-free.
         """
         value = reading[self.acq_timestamp.name]["value"]
         if value is None or value <= 0:
@@ -228,15 +195,10 @@ class CaTriggerable(CaAcqTimestampReadable):
 
         The stale-update drain and baseline capture happen synchronously
         *here*, not in the returned coroutine — so a shot fired immediately
-        after this call (the strict single-shot pattern) can never be missed.
-
-        The drain runs on the cold path too (``_last_acq is None``): the only
-        thing it can discard there is a stale CA *subscribe replay* (the
-        monitor's initial current-value update after a (re)connect, which can
-        carry an old positive timestamp) that arrived between connect and this
-        call.  It can never discard a real requested shot — nothing fires
-        before ``trigger()`` returns — and in free-run mode pre-trigger frames
-        are exactly what "wait for the *next* shot" must ignore.
+        after this call (the strict single-shot pattern) can never land in a
+        blind window and be missed (pinned by a mock race test).  The drain
+        can never discard a real requested shot: nothing fires before
+        ``trigger()`` returns.
         """
         t0 = self._last_acq
         while not self._shot_queue.empty():
@@ -246,16 +208,11 @@ class CaTriggerable(CaAcqTimestampReadable):
     async def _wait_for_shot(self, t0: float | None) -> None:
         """Wait for the next monitor update carrying a new ``acq_timestamp``.
 
-        Cold-cache path (``t0 is None``): there is deliberately **no CA-get
-        baseline** here.  A baseline get raced the shot itself — a first
-        acquisition landing inside the get's round-trip became the baseline,
-        the queued equal value failed the ``!= t0`` test, and the strict
-        single shot timed out.  It is also unnecessary: ``trigger()`` drained
-        everything older (including any stale subscribe replay, which arrives
-        at connect time — seconds before any trigger), and on an established
-        monitor every subsequent update is a genuinely new frame.  So on a
-        cold cache the first positive arrival after ``trigger()`` *is* the
-        shot, with no baseline to mistake it for.
+        Cold-cache path (``t0 is None``): deliberately **no CA-get baseline**
+        — a baseline get raced the shot itself (a first acquisition landing
+        inside the get's round-trip became the baseline and the strict single
+        shot timed out).  ``trigger()`` already drained anything older, so on
+        a cold cache the first positive arrival *is* the shot.
         """
         logger.debug(
             "%s: waiting for %s to advance past %s (timeout=%.1fs)",

--- a/GeecsBluesky/geecs_bluesky/devices/contributor.py
+++ b/GeecsBluesky/geecs_bluesky/devices/contributor.py
@@ -11,21 +11,16 @@ companion columns of the event schema contract:
 * ``<dev>-valid`` — ``shot_offset == 0``
 
 Data values are always the device's latest real data, truthfully labeled: a
-long-exposure camera whose frame for shot N arrives late lands at
-``shot_offset = -1`` with shot N−1's values, and downstream realignment is a
-per-device shift keyed on ``shot_id``.  An optional bounded **grace wait**
-(default one push period) raises the offset-0 fraction by giving the device's
-frame time to arrive after the reference accepts the shot.
+late frame lands at a negative ``shot_offset`` with the earlier shot's
+values, and downstream realignment is a per-device shift keyed on
+``shot_id``.  An optional bounded **grace wait** (default one push period)
+raises the offset-0 fraction.
 
-This mixin is the *shared* domain layer — transport-agnostic by construction.
-It requires the host to provide ``last_acq_timestamp`` (from the TCP shot cache
-on the direct backend, from the persistent CA monitor cache on the CA backend),
-plus the :class:`~geecs_bluesky.devices.shot_id.ShotIdSupport` and
-:class:`~geecs_bluesky.devices.nonscalar_save.NonScalarSaveSupport` mixins whose
-helpers it emits through.  Both
-:class:`~geecs_bluesky.devices.ca.timestamped_readable.CaTimestampedReadable`
-(direct) and the CA contributor compose it, so the labeling semantics cannot
-diverge between backends.
+This mixin is the transport-agnostic domain layer: the host provides
+``last_acq_timestamp`` plus the
+:class:`~geecs_bluesky.devices.shot_id.ShotIdSupport` and
+:class:`~geecs_bluesky.devices.nonscalar_save.NonScalarSaveSupport` mixins
+whose helpers it emits through.
 """
 
 from __future__ import annotations

--- a/GeecsBluesky/geecs_bluesky/devices/nonscalar_save.py
+++ b/GeecsBluesky/geecs_bluesky/devices/nonscalar_save.py
@@ -3,13 +3,12 @@
 GEECS cameras write image files natively once their ``localsavingpath`` and
 ``save`` variables are set.  Bluesky/Tiled do not store the images; they record
 the scanner-owned save directory (``<dev>-nonscalar_save_path``) and the device
-``acq_timestamp`` so notebooks join events to native timestamped files by
-timestamp, not by a synthetic shot counter.
+``acq_timestamp`` so events join to native timestamped files by timestamp,
+never by a synthetic shot counter.
 
-This mixin gives both the triggered detector (strict / free-run reference)
-and the free-run contributor one implementation of that capability, so the two
-cannot diverge.  Host devices create their own ``localsavingpath`` / ``save``
-control signals (CA signals writing the gateway ``:SP`` setpoints).
+Shared by the triggered detector and the free-run contributor so the asset
+contract cannot diverge.  Host devices create their own ``localsavingpath`` /
+``save`` control signals (CA signals writing the gateway ``:SP`` setpoints).
 """
 
 from __future__ import annotations

--- a/GeecsBluesky/geecs_bluesky/devices/shot_id.py
+++ b/GeecsBluesky/geecs_bluesky/devices/shot_id.py
@@ -1,24 +1,17 @@
 """ShotIdTracker — per-device physical trigger-opportunity numbering.
 
-A device's *shot ID* is the index of the external-trigger tick its acquisition
-belongs to.  It is derived from the device's own ``acq_timestamp`` history, so
-it is immune to clock skew between control machines: two devices saw the same
-physical trigger if and only if their shot IDs are equal (given t0s captured
-on the same physical shot — see :mod:`geecs_bluesky.plans.t0_sync`).
-
-The ID advances **incrementally**::
+A device's *shot ID* is the index of the external-trigger tick its
+acquisition belongs to, derived from the device's own ``acq_timestamp``
+history (immune to clock skew between control machines).  The ID advances
+**incrementally**::
 
     delta = round((acq_timestamp - last_acq_timestamp) * rep_rate_hz)
     shot_id = last_shot_id + max(delta, 1)
 
-rather than absolutely from t0.  Absolute derivation accumulates rep-rate
-error over a run (a 0.05% rate mismatch misquantizes after ~30 minutes at
-1 Hz); incremental derivation resets the error on every shot.
-
-Shot IDs are matching machinery and diagnostics, **not** a file-join key —
-files join to events by device ``acq_timestamp``.  Jumps greater than 1
-across stage-move dead time are expected; cross-device matching is equality,
-never consecutiveness.
+so rep-rate error resets on every shot instead of accumulating from t0.
+Cross-device matching is shot-ID **equality** (given t0s captured on the same
+physical shot — :mod:`geecs_bluesky.plans.t0_sync`), never consecutiveness;
+files join to events by device ``acq_timestamp``, not by ``shot_id``.
 """
 
 from __future__ import annotations
@@ -123,10 +116,10 @@ class ShotIdTracker:
 class ShotIdSupport:
     """Mixin for GEECS devices that derive shot IDs from their ``acq_timestamp``.
 
-    Cooperates with :class:`~geecs_bluesky.devices.geecs_device.GeecsDevice`
-    (uses its ``_shot_cache``).  Hosts gain ``configure_shot_id()`` /
-    ``seed_shot_id()`` and the ``last_acq_timestamp`` accessor used by the
-    coordinated t0-sync stage (:func:`~geecs_bluesky.plans.t0_sync.geecs_t0_sync`).
+    Hosts gain ``configure_shot_id()`` / ``seed_shot_id()`` and the
+    ``last_acq_timestamp`` accessor used by the coordinated t0-sync stage
+    (:func:`~geecs_bluesky.plans.t0_sync.geecs_t0_sync`).  CA hosts override
+    ``last_acq_timestamp`` with their persistent-monitor cache.
     """
 
     _acq_timestamp_variable: str = "acq_timestamp"

--- a/GeecsBluesky/geecs_bluesky/events.py
+++ b/GeecsBluesky/geecs_bluesky/events.py
@@ -6,12 +6,7 @@ one of these types, delivered through an ``on_event`` callback injected by the
 consumer.  Front-ends (the Scanner GUI, headless scripts, tests) import these
 types *from the engine*; ``geecs_scanner.engine.scan_events`` and
 ``geecs_scanner.engine.dialog_request`` are re-export shims kept for
-compatibility.
-
-Historically these types lived in ``geecs_scanner`` (a front-end package),
-forcing the engine to import its own vocabulary defensively via try/except.
-They moved here verbatim — semantics unchanged — so the engine owns its
-vocabulary and front-ends import from below.
+compatibility (see ``GeecsBluesky/CLAUDE.md``, engine consolidation).
 
 The event sequence for a successful 1D scan looks like::
 

--- a/GeecsBluesky/geecs_bluesky/exceptions.py
+++ b/GeecsBluesky/geecs_bluesky/exceptions.py
@@ -171,15 +171,13 @@ class GeecsConfigurationError(GeecsError):
 class GeecsDeviceDownError(GeecsError):
     """A device's gateway ``CONNECTED`` PV reports ``Disconnected``.
 
-    The gateway serves every DB device's PVs whether or not the device's TCP
-    stream is up, so CA-connect success never implied device liveness; the
-    per-device ``[Experiment:]Device:CONNECTED`` status PV is the
-    authoritative signal (PV_CONTRACT.md §1/§5).  Raised (or carried inside
-    the pre-claim operator dialog) when that PV says a device is down:
-    by ``BlueskyScanner._preflight_check_sync_liveness`` before a scan, and
-    by :func:`~geecs_bluesky.plans.single_shot.geecs_single_shot` when a
-    no-frame device turns out to be disconnected mid-scan (re-firing cannot
-    help a dead device).  The message is operator-facing.
+    ``CONNECTED`` is the authoritative liveness signal — CA-connect success
+    never implies device liveness (PV_CONTRACT.md §1/§5; rationale in
+    ``GeecsBluesky/CLAUDE.md``).  Raised, or carried inside the pre-claim
+    operator dialog, by the pre-flight liveness check and by
+    :func:`~geecs_bluesky.plans.single_shot.geecs_single_shot` when a
+    no-frame device turns out to be disconnected mid-scan.  The message is
+    operator-facing.
     """
 
     def __init__(self, message: str, device_name: str | None = None) -> None:
@@ -190,15 +188,11 @@ class GeecsDeviceDownError(GeecsError):
 class GeecsStaleDevicesError(GeecsError):
     """Free-run sync device(s) are CONNECTED but have no fresh frames.
 
-    Carried inside the pre-claim operator dialog raised by
-    ``BlueskyScanner._preflight_check_sync_liveness`` (free-run mode only,
-    after the gateway-liveness stage passed) when cached ``acq_timestamp``
-    frames are missing or too old — all-stale means the trigger is probably
-    off / not free-running; a stale subset is a per-device acquisition
-    problem.  Genuinely *dead* devices are :class:`GeecsDeviceDownError`
-    territory (the ``CONNECTED`` PV), not this.  The message is
-    operator-facing: it names the stale device(s), how stale they are, and
-    what the dialog's options mean.
+    Carried inside the pre-claim operator dialog raised by the free-run
+    staleness check: all-stale means the trigger is probably off / not
+    free-running; a stale subset is a per-device acquisition problem.
+    Genuinely *dead* devices are :class:`GeecsDeviceDownError` territory.
+    The message is operator-facing.
     """
 
 
@@ -212,12 +206,9 @@ class ActionCheckFailedError(GeecsError):
 
     Raised by the compiled action plan (see
     :func:`~geecs_bluesky.plans.action_compiler.compile_action_plan`) when a
-    ``check`` step's readback differs from its ``expected`` value.  This is
-    the strict-mode counterpart of the legacy ActionManager mismatch, which
-    prompted the operator and auto-aborted when headless — here the plan
-    always stops, so the mismatch is never papered over.  The message is
-    operator-facing: it names the device, the variable, what was expected,
-    and what actually came back.
+    ``check`` step's readback differs from its ``expected`` value.  The plan
+    always stops here — a mismatch is never papered over.  The message is
+    operator-facing.
     """
 
     def __init__(
@@ -243,9 +234,7 @@ class ActionPlanNotFoundError(GeecsError):
 
     Raised while a compiled action plan executes a nested ``run`` step whose
     ``plan`` name has no entry in the plan registry — typically a renamed or
-    deleted plan that something still points at.  The legacy ActionManager
-    raised ``ActionError("Action '<name>' is not defined.")`` for the same
-    situation.
+    deleted plan that something still points at.
     """
 
     def __init__(self, plan_name: str, known_plans: list[str] | None = None) -> None:
@@ -266,10 +255,8 @@ class ActionPlanCycleError(GeecsError):
     """Nested ``run`` steps form a loop, so the plan would never finish.
 
     Raised before recursing into a nested plan whose name is already on the
-    execution stack (for example plan A runs B, and B runs A again).  The
-    legacy ActionManager had no such guard — a cyclic library recursed until
-    Python's recursion limit; here the cycle is reported up front with the
-    chain of plan names that closes the loop.
+    execution stack (for example plan A runs B, and B runs A again); the
+    message shows the chain of plan names that closes the loop.
     """
 
     def __init__(self, chain: list[str]) -> None:

--- a/GeecsBluesky/geecs_bluesky/plans/action_compiler.py
+++ b/GeecsBluesky/geecs_bluesky/plans/action_compiler.py
@@ -1,44 +1,27 @@
 """Compile :class:`~geecs_schemas.action_plan.ActionPlan` into Bluesky plan stubs.
 
-The successor of the legacy ``ActionManager`` executor
-(``geecs_scanner.engine.action_manager``): an action plan — set a device
-variable, wait, check a readback, run another named plan — becomes a plain
-Bluesky message generator, so action sequences inherit the RunEngine's
-abort, pause, and document machinery instead of running through a bespoke
-executor.
+An action plan — set a device variable, wait, check a readback, run another
+named plan — becomes a plain Bluesky message generator, so action sequences
+inherit the RunEngine's abort, pause, and document machinery.
 
-Legacy semantics preserved verbatim
------------------------------------
-- ``set`` — the legacy executor called ``device.set(variable, value,
-  sync=step.wait_for_execution)``: a blocking set-and-wait when
-  ``wait_for_execution`` is true (the default), fire-and-forget otherwise.
-  Here that becomes ``bps.abs_set(signal, value, wait=wait_for_execution)``.
-- ``wait`` — legacy ``time.sleep(seconds)`` becomes ``bps.sleep(seconds)``
-  (RunEngine-interruptible, no blocking).
-- ``check`` — the legacy ``GetStep`` compared ``device.get(variable) ==
-  expected`` with plain equality, where the device layer had already coerced
-  the wire string to ``float`` when it parses as one
-  (``GeecsDevice.interpret_value``).  :func:`values_match` reproduces exactly
-  that: coerce the *actual* reading (string → float when parseable), then
-  compare with ``==`` — no tolerance.  A mismatch raises
-  :class:`~geecs_bluesky.exceptions.ActionCheckFailedError`, matching the
-  legacy headless behaviour (auto-abort; the GUI prompt is a front-end
-  concern, not an executor one).
-- ``run`` — nested plans resolve by name from the registry and recurse,
-  like the legacy ``ExecuteStep``.  A missing name raises
-  :class:`~geecs_bluesky.exceptions.ActionPlanNotFoundError` (legacy:
-  ``ActionError("Action '<name>' is not defined.")``).  Cycles raise
-  :class:`~geecs_bluesky.exceptions.ActionPlanCycleError` — an improvement
-  over legacy, which had no cycle guard and recursed to the interpreter
-  limit.
+Legacy ``ActionManager`` semantics are pinned here (the one canonical
+statement):
 
-Purity contract
----------------
-This module never touches Channel Access, sessions, or PV strings.  It
-receives GEECS device/variable names from the schema and asks the injected
-:class:`SettableFactory` for signals; PV derivation is entirely the
-factory's business (production factories hand out CA-backed signals whose
-``:SP`` puts ride GEECS blocking sets).
+- ``set`` → ``bps.abs_set(signal, value, wait=wait_for_execution)``
+  (blocking set-and-wait by default, fire-and-forget otherwise).
+- ``wait`` → ``bps.sleep(seconds)`` (RunEngine-interruptible).
+- ``check`` → :func:`values_match`: float-coerce the *actual* reading when
+  it parses, then plain ``==`` — no tolerance, no coercion of the expected
+  side.  A mismatch raises
+  :class:`~geecs_bluesky.exceptions.ActionCheckFailedError` (legacy
+  headless auto-abort; the GUI prompt is a front-end concern).
+- ``run`` → resolve by name from the registry and recurse.  A missing name
+  raises :class:`~geecs_bluesky.exceptions.ActionPlanNotFoundError`; cycles
+  raise :class:`~geecs_bluesky.exceptions.ActionPlanCycleError` (legacy had
+  no cycle guard).
+
+Purity contract: this module never touches Channel Access, sessions, or PV
+strings — signals come from the injected :class:`SettableFactory`.
 """
 
 from __future__ import annotations
@@ -83,52 +66,21 @@ class SettableFactory(Protocol):
     """
 
     def get_settable(self, device: str, variable: str) -> Movable:
-        """Return a settable signal for a ``set`` step.
-
-        Parameters
-        ----------
-        device : str
-            GEECS device name (e.g. ``"U_148_PLC"``).
-        variable : str
-            Writable variable on that device (e.g. ``"DO.Ch9"``).
-
-        Returns
-        -------
-        Movable
-            An ophyd-async style signal accepted by ``bps.abs_set``.
-        """
+        """Return a settable signal (accepted by ``bps.abs_set``) for a ``set`` step."""
         ...
 
     def get_readable(self, device: str, variable: str) -> Readable:
-        """Return a readable signal for a ``check`` step.
-
-        Parameters
-        ----------
-        device : str
-            GEECS device name (e.g. ``"U_GaiaSVEReader"``).
-        variable : str
-            Variable to read on that device (e.g. ``"InternalShutterA"``).
-
-        Returns
-        -------
-        Readable
-            An ophyd-async style signal accepted by ``bps.rd``.
-        """
+        """Return a readable signal (accepted by ``bps.rd``) for a ``check`` step."""
         ...
 
 
 def values_match(expected: object, actual: object) -> bool:
     """Compare a ``check`` step reading against its expected value, legacy-style.
 
-    The legacy pipeline was: the device layer coerced the wire string to
-    ``float`` when it parses as one (``GeecsDevice.interpret_value``:
-    ``try: return float(val_string) except: return val_string``), and the
-    ActionManager then compared with plain ``==`` — no tolerance, and no
-    coercion of the *expected* side.  This reproduces exactly that, including
-    its quirks: a numeric expected value matches a device reporting ``"25"``
-    (the actual is floated first), but a *string* expected value like ``"25"``
-    does **not** match a numeric-looking readback (legacy floated it to
-    ``25.0``, and ``25.0 == "25"`` is false).
+    Legacy comparison rules (see the module docstring), quirks included: a
+    numeric expected matches a device reporting ``"25"`` (the actual is
+    floated first), but a *string* expected ``"25"`` does **not** match a
+    numeric-looking readback.
 
     Parameters
     ----------
@@ -158,11 +110,10 @@ def compile_action_plan(
 ) -> MsgGenerator:
     """Compile an :class:`ActionPlan` into a Bluesky plan executing its steps.
 
-    Steps run strictly in order, exactly like the legacy ActionManager:
-    ``set`` writes a value (blocking on completion unless the step says
-    ``wait_for_execution: false``), ``wait`` sleeps, ``check`` reads a value
-    and stops the plan on a mismatch, and ``run`` executes another named
-    plan from *registry*.
+    Steps run strictly in order: ``set`` writes a value (blocking on
+    completion unless the step says ``wait_for_execution: false``), ``wait``
+    sleeps, ``check`` reads a value and stops the plan on a mismatch, and
+    ``run`` executes another named plan from *registry*.
 
     Parameters
     ----------
@@ -188,8 +139,7 @@ def compile_action_plan(
     ActionPlanNotFoundError
         When a ``run`` step names a plan missing from *registry*.
     ActionPlanCycleError
-        When nested ``run`` steps form a loop (legacy had no guard for this;
-        it would recurse until Python's recursion limit).
+        When nested ``run`` steps form a loop.
     """
     yield from _compile(plan, registry, settables, stack=())
 
@@ -200,30 +150,11 @@ def _compile(
     settables: SettableFactory,
     stack: tuple[str, ...],
 ) -> MsgGenerator:
-    """Execute *plan*'s steps; *stack* is the chain of nested plan names.
-
-    Parameters
-    ----------
-    plan : ActionPlan
-        The plan whose steps to execute.
-    registry : Mapping[str, ActionPlan]
-        Named plans available to ``run`` steps.
-    settables : SettableFactory
-        Signal source for ``set`` / ``check`` steps.
-    stack : tuple of str
-        Names of the plans currently executing above this one (cycle guard).
-
-    Yields
-    ------
-    Msg
-        Bluesky messages for the RunEngine.
-    """
+    """Execute *plan*'s steps; *stack* is the chain of nested plan names (cycle guard)."""
     for step in plan.steps:
         if isinstance(step, SetStep):
             signal = settables.get_settable(step.device, step.variable)
-            # Legacy: device.set(variable, value, sync=wait_for_execution) —
-            # sync=True blocks until the device confirms, sync=False is
-            # fire-and-forget.  abs_set(wait=...) is the message-level twin.
+            # Legacy sync semantics — see the module docstring.
             yield from bps.abs_set(signal, step.value, wait=step.wait_for_execution)
         elif isinstance(step, WaitStep):
             yield from bps.sleep(step.seconds)

--- a/GeecsBluesky/geecs_bluesky/plans/free_run_step_scan.py
+++ b/GeecsBluesky/geecs_bluesky/plans/free_run_step_scan.py
@@ -25,21 +25,16 @@ Run stages
    :func:`~geecs_bluesky.plans.step_scan.geecs_step_scan`:
    move → arm → ``shots_per_step`` rows → disarm.
 3. **End-of-scan quiesce + tail flush**: after the last step's disarm the
-   trigger is stopped again (quiesce → OFF — STANDBY keeps passing external
-   edges, and the tail machinery, close_run document writes, and the
-   caller's finalize save-off all take wall time; Gate-2 re-verify: Scan002
-   saved 7 images for 5 shots from exactly that window).  Then one extra
-   read of all devices is emitted to a separate ``flush`` event stream, so
-   a contributor lagging at ``shot_offset = -1`` still gets its final shot
-   recorded — the flush reads cached last values by design, so flushing
-   while OFF is safe.  The caller's outer finalize restores STANDBY
-   (free-running, output off — the legacy end state) afterwards.
+   trigger is stopped again (quiesce → OFF; STANDBY keeps passing external
+   edges, which saved orphan frames during the tail window — Gate-2).  Then
+   one extra read of all devices goes to a separate ``flush`` event stream,
+   so a contributor lagging at ``shot_offset = -1`` still gets its final
+   shot recorded (the flush reads cached last values, so flushing while OFF
+   is safe).  The caller's outer finalize restores STANDBY afterwards.
 
-Accepted, deliberately-not-fixed window: **between-step STANDBY frames in
-multi-step free-run scans**.  The per-step disarm to STANDBY during motor
-moves is legacy-parity behavior (jet off during moves, trigger free-running)
-— frames arriving there join by timestamp and orphans are ignorable.  Do
-not "fix" this into per-step save toggling.
+Between-step STANDBY frames in multi-step scans are an accepted window —
+do not "fix" into per-step save toggling.  Design rationale:
+``GeecsBluesky/CLAUDE.md`` (shot-control composition per mode).
 """
 
 from __future__ import annotations
@@ -110,32 +105,24 @@ def geecs_free_run_step_scan(
         window (e.g. DG645 SCAN / STANDBY), as in the strict plan.
     quiesce_trigger:
         Optional plan-stub callable that *stops* the free-running trigger
-        before t0 sync, so every device's cache settles to the same last
-        physical shot for a clean timestamp read (the legacy "disable the
-        trigger, then read acq_timestamps" procedure — DG645 ``OFF`` state).
-        ``SCAN``/``STANDBY`` keep the trigger free-running, so they cannot
-        serve this role.  Falls back to ``disarm_trigger`` when not given.
-        Also run at **end of scan** (after the last step, before the tail
-        flush) and — via an internal finalize — on abort, so native saving
-        is never left enabled while the trigger passes external edges (see
-        the module docstring's run stages).
+        (DG645 ``OFF``) before t0 sync, so every device's cache settles to
+        the same last physical shot.  ``SCAN``/``STANDBY`` keep the trigger
+        free-running, so they cannot serve this role.  Falls back to
+        ``disarm_trigger`` when not given.  Also run at **end of scan** and
+        — via an internal finalize — on abort, so native saving is never
+        left enabled while the trigger passes external edges.
     per_step:
         Optional plan-stub callable run at **every** step boundary — after
-        the move completes, before that step's ``arm_trigger``/shots.  This
-        is where a ScanRequest's ``actions.per_step`` plans land: the
-        arm/disarm bracketing means per-step actions always run with the
-        shot controller *disarmed* (data-taking output off), never inside
-        the acquisition window.
+        the move completes, before that step's ``arm_trigger``/shots.  A
+        ScanRequest's ``actions.per_step`` plans land here; the arm/disarm
+        bracketing means they always run *disarmed*.
     enable_saving:
         Optional plan-stub callable that turns native file saving on
         (typically :func:`~geecs_bluesky.plans.run_wrapper.save_enable_plan`).
-        Run once, immediately **after** the quiesce (OFF — the trigger is
-        stopped) and before the t0-sync stage: no shots can occur from here
-        until the first per-step arm[SCAN], so no orphan frames from the
-        still-free-running trigger get saved during setup actions or the
-        pre-quiesce window (Gate-2 hardware finding).  Without a quiesce
-        hook (no shot control) it runs at the same point, unwindowed —
-        there is no trigger to stop.  Save-*off* stays the run wrapper's
+        Run once, immediately after the quiesce and before t0 sync — the
+        earliest orphan-free moment (Gate-2 save windowing:
+        ``GeecsBluesky/CLAUDE.md``).  Without a quiesce hook it runs at the
+        same point, unwindowed.  Save-*off* stays the run wrapper's
         innermost finalize, before the caller's disarm.
     t0_sync_window_s:
         Acceptance window for the t0-sync stage.
@@ -205,19 +192,14 @@ def geecs_free_run_step_scan(
     }
 
     # t0 sync runs before the run opens so the captured t0s can land in the
-    # start document.  Quiesce first — actually *stop* the free-running trigger
-    # (DG645 OFF / single-shot source) so every device's cache settles to the
-    # same last physical shot before the read (the legacy "disable trigger,
-    # then read acq_timestamps" procedure).  STANDBY keeps the trigger
-    # free-running on real hardware, so fall back to it only when no dedicated
-    # quiesce action was supplied.  No-op when there is no shot control.
+    # start document.  Quiesce first (stop the trigger) so every device's
+    # cache settles to the same last physical shot; no-op without shot control.
     _quiesce = quiesce_trigger or disarm_trigger
     if _quiesce is not None:
         yield from _quiesce()
     if enable_saving is not None:
-        # The trigger is now stopped (OFF) and stays stopped through t0 sync
-        # until the first per-step arm[SCAN] — the earliest orphan-free
-        # moment to start native saving (Gate-2 hardware finding).
+        # Trigger stopped through t0 sync until the first arm[SCAN] — the
+        # earliest orphan-free moment to start native saving (Gate-2).
         yield from enable_saving()
     t0s = yield from geecs_t0_sync(sync_devices, window_s=t0_sync_window_s)
     _md["device_t0s"] = t0s
@@ -245,11 +227,8 @@ def geecs_free_run_step_scan(
                 yield from bps.trigger_and_read(_read_devices)
             if disarm_trigger is not None:
                 yield from disarm_trigger()
-        # End of scan: stop the trigger BEFORE the tail machinery.  STANDBY
-        # keeps passing external edges, and the tail flush + close_run +
-        # document writes + the caller's finalize save-off all take wall
-        # time — with native saving still on, STANDBY frames landed as
-        # orphan images (Gate-2 re-verify: Scan002, 7 images for 5 shots).
+        # End of scan: stop the trigger BEFORE the tail machinery — STANDBY
+        # passes external edges, so orphan frames get saved otherwise (Gate-2).
         if _quiesce is not None:
             yield from _quiesce()
             _end_quiesced["done"] = True

--- a/GeecsBluesky/geecs_bluesky/plans/optimize.py
+++ b/GeecsBluesky/geecs_bluesky/plans/optimize.py
@@ -63,10 +63,8 @@ def geecs_adaptive_scan(
         ``propose(iteration) -> {variable_name: value} | None``.  Called before
         each bin; ``None`` ends the run early (generator converged / budget
         spent).  Evaluating the previous bin and telling the generator happen
-        inside this callable, on the caller's side.  The plan invokes it on a
-        worker thread (it may block on filesystem/analysis work) and idles
-        with ``bps.sleep`` polls until it returns, so the RunEngine event
-        loop is never blocked by the evaluation.
+        inside this callable, on the caller's side; it may block (see the
+        module docstring's threading contract).
     detectors:
         Devices read every shot.  With *reference* set (free-run) the first
         trigger belongs to the reference; otherwise strict semantics apply.
@@ -134,12 +132,9 @@ def geecs_adaptive_scan(
     def _inner():
         if not free_run and setup_trigger is not None:
             yield from setup_trigger()
-        # propose() chains into the objective evaluation — bounded native-file
-        # waits, ScanAnalysis analyzers, generator ask/tell — which can block
-        # for seconds.  This generator is iterated by the RunEngine *on its
-        # event-loop thread*, so calling propose inline would freeze the loop
-        # (pause/abort, subscriptions, everything scheduled on it).  Run it on
-        # a worker thread instead and idle with RE-friendly sleeps.
+        # propose() can block for seconds; run it on a worker thread and idle
+        # with RE-friendly sleeps so the RE loop stays responsive (module
+        # docstring).
         propose_pool = ThreadPoolExecutor(
             max_workers=1, thread_name_prefix="geecs-propose"
         )

--- a/GeecsBluesky/geecs_bluesky/plans/orchestration.py
+++ b/GeecsBluesky/geecs_bluesky/plans/orchestration.py
@@ -9,32 +9,23 @@ devices from factories, the scanner builds either backend from
 ``exec_config`` — but the *recipe* lives only here, so the two front doors
 cannot drift.
 
-Action placement (the §4.4b/§4.5 seams, decided here):
+Action placement (the §4.4b/§4.5 slots, decided here):
 
-- **setup** runs first thing inside the composed plan — after every device
-  is connected (construction-time) and the pre-flight has passed (both
-  happen before the RunEngine ever sees this plan), and *before* the
-  free-run quiesce/t0-sync stage and the first step — so setup actions
-  settle device state before timing synchronization, and a failing setup
-  still triggers the finalize chain (saving off → disarm → closeout).
-- **per_step** is yielded by the step plans at every step boundary: after
-  the move completes, before that step's shots (free-run brackets each step
-  with arm/disarm, so per-step actions run *disarmed*; strict fires each
-  shot itself, so the machine is quiescent between plan-owned shots).
-- **closeout** is the outermost ``finalize_wrapper`` — it runs even on
-  mid-scan abort (legacy ActionControl parity), and because it wraps the
-  disarm finalize it always executes *after* the trigger has returned to
-  STANDBY (data-taking output off, trigger free-running).
+- **setup** — first thing inside the composed plan, before the free-run
+  quiesce/t0-sync stage and the first step; a failing setup still triggers
+  the finalize chain (save-off → disarm → closeout).
+- **per_step** — yielded by the step plans at every step boundary, after
+  the move and before that step's shots (always with the shot controller
+  disarmed / the machine quiescent).
+- **closeout** — the outermost ``finalize_wrapper``; runs even on mid-scan
+  abort, always after the disarm finalize has restored STANDBY.
 
-Native-save windowing (Gate-2 hardware finding, 2026-07-07): saving is
-enabled only while the trigger cannot free-run.  The run wrapper defers its
-save-on (``defer_save_on=True``); the step plans yield
+Native-save windowing (Gate-2): saving is enabled only while the trigger
+cannot free-run — the run wrapper defers save-on (``defer_save_on=True``)
+and the step plans yield
 :func:`~geecs_bluesky.plans.run_wrapper.save_enable_plan` at the first
-orphan-free moment — strict: after ARMED + quiescence confirmation;
-free-run: immediately after quiesce[OFF], before t0-sync.  Setup actions run
-before that point by construction, so their duration can no longer produce
-saved orphan frames (Scan015 saved 6 images for 3 shots).  Save-off remains
-the innermost finalize, before the disarm.
+orphan-free moment; save-off remains the innermost finalize.  Design
+rationale: ``GeecsBluesky/CLAUDE.md`` (shot-control composition per mode).
 """
 
 from __future__ import annotations
@@ -140,12 +131,9 @@ def build_step_scan_plan(
                 "the reference (pacemaker)"
             )
         if controller is None and saving:
-            # Native-save windowing relies on the controller's quiesce to stop
-            # the free-running trigger before saving turns on.  With no shot
-            # control there is no such point, so frames captured during t0-sync
-            # (and any moves) are saved as orphans joining no event row.  This
-            # is inherent to a controllerless free-run scan — surface it loudly
-            # rather than silently save orphans or refuse the (supported) config.
+            # No shot control means no quiesce point to window saving on, so
+            # orphan frames are inherent to a controllerless free-run scan —
+            # surface it loudly rather than refuse the (supported) config.
             logger.warning(
                 "free-run scan has native-saving detectors but no shot "
                 "control: saving cannot be windowed to the trigger-stopped "
@@ -169,9 +157,8 @@ def build_step_scan_plan(
         )
 
     if setup is not None:
-        # Setup runs before the free-run quiesce/t0-sync and before the
-        # first step (module docstring); inside the run wrapper so a failed
-        # setup still fires the save-off/disarm/closeout finalizes.
+        # Inside the run wrapper so a failed setup still fires the
+        # save-off/disarm/closeout finalizes (module docstring).
         inner = _chain_setup(setup, inner)
 
     scalar_devices = detectors + normalize_motors(motor)
@@ -185,10 +172,8 @@ def build_step_scan_plan(
         extra_md=extra_md or {},
         defer_save_on=True,
     )
-    # Finalize nesting (innermost → outermost): save-off (inside the run
-    # wrapper) → disarm (→ STANDBY) → closeout actions.  Every layer runs
-    # even on mid-scan abort; closeout therefore always executes with the
-    # trigger already disarmed.
+    # Finalize nesting (innermost → outermost): save-off → disarm → closeout;
+    # every layer runs even on mid-scan abort.
     if controller is not None:
         plan = bpp.finalize_wrapper(plan, controller.disarm())
     if closeout is not None:

--- a/GeecsBluesky/geecs_bluesky/plans/run_wrapper.py
+++ b/GeecsBluesky/geecs_bluesky/plans/run_wrapper.py
@@ -98,9 +98,8 @@ def save_enable_plan(saving_detectors: list[tuple]):
 
     The device puts (``:SP`` writes on connected devices) that start native
     file saving.  Callers that window saving to the trigger-stopped part of
-    the scan (Gate-2 hardware finding: frames from the still-free-running
-    trigger between save-on and arming were saved as orphans joining no
-    event row) pass this as the step plans' ``enable_saving`` hook and give
+    the scan (Gate-2 save windowing: ``GeecsBluesky/CLAUDE.md``) pass this
+    as the step plans' ``enable_saving`` hook and give
     :func:`geecs_run_wrapper` ``defer_save_on=True``; direct
     ``geecs_run_wrapper`` users keep the eager default.
 
@@ -176,12 +175,10 @@ def geecs_run_wrapper(
         ``save="off"`` in a finalize wrapper (runs even on abort).
     defer_save_on:
         When true, the wrapper does **not** enable saving itself — the inner
-        plan is expected to yield :func:`save_enable_plan` at the point where
-        the trigger can no longer free-run (strict: after ARMED + quiescence;
-        free-run: after quiesce[OFF]), so no orphan frames are saved during
-        setup actions or the pre-arm window (Gate-2 hardware finding).  The
-        finalize ``save="off"`` and the ``nonscalar_save_paths`` metadata are
-        emitted either way.
+        plan yields :func:`save_enable_plan` once the trigger can no longer
+        free-run (Gate-2 save windowing: ``GeecsBluesky/CLAUDE.md``).  The
+        finalize ``save="off"`` and the ``nonscalar_save_paths`` metadata
+        are emitted either way.
     devices:
         All devices contributing scalar columns (detectors + scan motor).
         Their ``_column_headers`` are merged into a ``geecs_scalar_headers``

--- a/GeecsBluesky/geecs_bluesky/plans/single_shot.py
+++ b/GeecsBluesky/geecs_bluesky/plans/single_shot.py
@@ -102,34 +102,19 @@ def geecs_single_shot(
 
     If a triggered device produces no frame for a fire (the group wait fails
     with :exc:`~bluesky.utils.FailedStatus`), the shot is re-fired up to
-    *max_refires* times before the failure propagates.
+    *max_refires* times before the failure propagates.  Strict semantics
+    survive refire: a failed attempt records nothing, and the next attempt's
+    ``trigger()`` re-baselines and drains any orphan frame
+    (:class:`~geecs_bluesky.devices.ca.triggerable.CaTriggerable`), so every
+    recorded row is one physical shot.  Refire — not a longer timeout — is
+    the recovery because a missed pulse never yields a frame (live-verified;
+    numbers in ``GeecsBluesky/CHANGELOG.md`` 0.20.0).
 
-    **Why refire preserves strict semantics.**  A failed attempt records
-    nothing: ``create``/``read``/``save`` run only after the group wait
-    succeeds, so no event row exists for the failed fire.  A device that
-    *did* capture the failed fire holds an orphan frame, but the next
-    attempt's ``trigger()`` re-baselines against it and drains the shot queue
-    synchronously (:class:`~geecs_bluesky.devices.ca.triggerable.CaTriggerable`'s
-    warm-path drain), so its fresh status only completes on a frame from the
-    new fire.  Every recorded row therefore remains one physical shot across
-    all devices.
-
-    **Why refire (not a longer timeout).**  Live evidence, 2026-07-06
-    Undulator Scan011 (first GUI optimization campaign): 84 SINGLESHOT fires
-    produced 83 camera frames; fire→frame offset over the 83 good shots was
-    median 0.21 s (max 1.06 s) against the 3.0 s trigger timeout — ample
-    margin.  The one unmatched fire produced no frame *ever* (the Basler's
-    known ~1% frame-drop intermittency) and aborted the whole campaign.  At a
-    ~1.2% drop rate a 100-shot campaign aborts with ~70% probability without
-    refire; a missed pulse never yields a frame, so only re-firing recovers.
-
-    **Refire is gated on gateway liveness.**  Before re-firing, the frameless
-    device's ``connected_status`` (the gateway ``CONNECTED`` PV) is read: if
-    the device reports Disconnected, the timeout was not a frame drop — the
-    device went down mid-scan — and :exc:`~geecs_bluesky.exceptions.GeecsDeviceDownError`
-    is raised immediately instead of burning refires against dead hardware.
-    A live (or unreadable — fail-open) status keeps the bounded-refire
-    behavior.
+    Refire is gated on gateway liveness: a frameless device whose
+    ``CONNECTED`` PV reads Disconnected went down mid-scan, so
+    :exc:`~geecs_bluesky.exceptions.GeecsDeviceDownError` is raised instead
+    of burning refires; a live or unreadable status (fail-open) keeps the
+    bounded-refire behavior.
 
     Parameters
     ----------
@@ -163,46 +148,13 @@ def geecs_single_shot(
             if triggerables:
                 yield from bps.wait(group=grp)
         except FailedStatus as exc:
-            # The RunEngine (bluesky 1.15.1, run_engine.py) reports a failed
-            # status via _status_object_completed:
-            #
-            #     raise FailedStatus(ret) from exc
-            #   except Exception as e:
-            #       self._exception = e
-            #       fut.set_exception(e)
-            #       ...
-            #       fut.exception()   # squash "never retrieved" at teardown
-            #
-            # and the run loop throws that stashed exception into the plan at
-            # the next message boundary:
-            #
-            #     if self._exception is not None:
-            #         stashed_exception = self._exception
-            #         self._exception = None
-            #     ...
-            #     msg = self._plan_stack[-1].throw(stashed_exception or resp)
-            #
-            # Consequences for statuses abandoned by a failed attempt:
-            # - A pending status that later *succeeds* (its device did frame)
-            #   just resolves its uncollected future — completely inert.
-            # - A pending status that later *errors* (a second device also
-            #   missed) is NOT mere log noise: its FailedStatus lands in
-            #   RE._exception and is thrown at the plan's next yield.  In
-            #   practice all of an attempt's statuses share the same ~3 s
-            #   deadline (triggered within milliseconds of each other), so
-            #   co-missing devices error effectively together and the single
-            #   RE._exception slot is consumed right here at the wait (later
-            #   stashes overwrite earlier ones; the prefetched fut.exception()
-            #   keeps teardown quiet).  If a straggler does land inside the
-            #   next attempt, this try wraps the *whole* attempt (trigger +
-            #   fire + wait), so the stale FailedStatus is caught and merely
-            #   consumes one refire instead of aborting the scan — no
-            #   cancellation machinery needed.
-            #
-            # Refire is gated on gateway liveness: a no-frame timeout from a
-            # device whose CONNECTED PV reports Disconnected is not a frame
-            # drop — the device went down mid-scan, and re-firing burns
-            # attempts (~3 s each) against hardware that cannot answer.
+            # No cancellation of abandoned statuses is needed: the RunEngine
+            # stashes a late FailedStatus and throws it into the plan at the
+            # next yield, but co-missing devices share the same ~3 s deadline
+            # so the stash is consumed right here at the wait; a straggler
+            # that lands inside the next attempt is caught by this same try
+            # (it wraps the whole attempt: trigger + fire + wait) and merely
+            # consumes one refire instead of aborting the scan.
             device_name = _no_frame_device(exc)
             down = yield from _confirm_device_down(devices, device_name)
             if down:

--- a/GeecsBluesky/geecs_bluesky/plans/step_scan.py
+++ b/GeecsBluesky/geecs_bluesky/plans/step_scan.py
@@ -3,23 +3,9 @@
 Moves a motor through a sequence of positions, collects ``shots_per_step``
 shots from one or more detectors at each step, and emits Bluesky event
 documents for downstream consumers (live callbacks, Databroker, etc.).
-
-How it fits into Bluesky
-------------------------
-* :func:`bluesky.plan_stubs.mv` moves the motor by calling ``motor.set(pos)``
-  and waiting for the returned :class:`~ophyd_async.core.AsyncStatus`.
-* :func:`bluesky.plan_stubs.trigger_and_read` calls ``trigger()`` on every
-  :class:`~bluesky.protocols.Triggerable` detector, waits for all triggers
-  to complete, then reads all devices in the list (including the motor, so
-  motor position is recorded alongside detector data in each event document).
-
-Shot synchronisation
---------------------
-Detectors that inherit from
-:class:`~geecs_bluesky.devices.ca.triggerable.CaTriggerable` complete their
-``trigger()`` call by waiting for the hardware ``acq_timestamp`` variable to
-advance — the real shot timestamp from the DG645 delay generator.  This is
-robust to device restarts (shot numbers drift; timestamps don't).
+:class:`~geecs_bluesky.devices.ca.triggerable.CaTriggerable` detectors
+complete ``trigger()`` when their hardware ``acq_timestamp`` advances;
+shot-ID mechanics are covered in ``GeecsBluesky/CLAUDE.md`` (Device Layer).
 
 Example (devices built and connected through a
 :class:`~geecs_bluesky.session.GeecsSession`)::
@@ -191,46 +177,28 @@ def geecs_step_scan(
         (arm waiters → fire → await → read) instead of waiting on a
         free-running trigger.  This is the strict-shot-control contract.
     setup_trigger:
-        Optional plan-stub callable run *once* at the start of the run (after
-        ``open_run``, before the first step).  Used by plan-owned single-shot
-        strict mode to arm the controller into single-shot mode and confirm
-        the free-run has stopped (``ARMED`` + quiescence check) — a one-time
-        action, distinct from per-step ``arm_trigger``.  Teardown is the
-        caller's outer finalize (e.g. disarm to STANDBY).
+        Optional plan-stub callable run *once* at the start of the run
+        (after ``open_run``, before the first step).  Strict mode uses it to
+        arm single-shot and confirm the free-run has stopped (``ARMED`` +
+        quiescence check); teardown is the caller's outer finalize.
     per_step:
         Optional plan-stub callable run at **every** step boundary — after
-        the move to that step's position completes, before that step's
-        shots.  This is where a ScanRequest's ``actions.per_step`` plans
-        land (vision doc §4.5: per-step actions are a hook plus a named
-        plan, never a new plan type).  In strict mode every shot is
-        plan-owned, so the machine is quiescent while per-step actions run.
+        the move completes, before that step's shots.  A ScanRequest's
+        ``actions.per_step`` plans land here; in strict mode every shot is
+        plan-owned, so the machine is quiescent while they run.
     enable_saving:
         Optional plan-stub callable that turns native file saving on
         (typically :func:`~geecs_bluesky.plans.run_wrapper.save_enable_plan`).
-        Run once, **after** ``setup_trigger`` — i.e. after ARMED +
-        quiescence confirmation in strict mode, when the trigger can no
-        longer free-run — so no orphan frames from a still-running trigger
-        are saved during the pre-arm window (Gate-2 hardware finding).
-        Save-*off* stays the run wrapper's innermost finalize, before the
-        caller's disarm.
+        Run once, **after** ``setup_trigger`` — when the trigger can no
+        longer free-run, so no orphan frames get saved (Gate-2 save
+        windowing: ``GeecsBluesky/CLAUDE.md``).  Save-*off* stays the run
+        wrapper's innermost finalize, before the caller's disarm.
     md:
         Extra metadata merged into the RunEngine ``start`` document.
 
     Yields
     ------
     Bluesky messages — pass this generator to a :class:`~bluesky.RunEngine`.
-
-    Notes
-    -----
-    * The motor is appended to the read list for every shot so that each
-      event document records the actual motor readback alongside detector
-      data.
-    * Non-Triggerable devices in *detectors* are read without calling
-      ``trigger()`` (standard :func:`bluesky.plan_stubs.trigger_and_read`
-      behaviour).
-    * ``arm_trigger`` / ``disarm_trigger`` bracket the per-step acquisition
-      window so the shot controller is only active while shots are being
-      collected, not during motor moves.
     """
     _positions = list(positions)
     _motors = normalize_motors(motor)
@@ -256,9 +224,7 @@ def geecs_step_scan(
         if setup_trigger is not None:
             yield from setup_trigger()
         if enable_saving is not None:
-            # Only after the trigger is stopped (ARMED + quiescence in
-            # strict) may native saving start — otherwise residual free-run
-            # frames get saved as orphans joining no event row.
+            # Saving starts only after the trigger is stopped (Gate-2).
             yield from enable_saving()
         scan_event_index = 0
         previous: tuple | None = None

--- a/GeecsBluesky/geecs_bluesky/plans/t0_sync.py
+++ b/GeecsBluesky/geecs_bluesky/plans/t0_sync.py
@@ -1,19 +1,16 @@
 """geecs_t0_sync — coordinated t0 capture for cross-device shot matching.
 
-Formalizes the fast t0 procedure from the legacy DAQ: with the shot-control
-outputs disarmed (devices no longer firing), every sync device's TCP cache
-holds the frame from the last physical trigger.  The control machines are
-NTP-synced far better than the trigger period, so if the cached
-``acq_timestamp`` values all fall within a small acceptance window they were
-produced by the **same physical trigger** — each device's value becomes its
-own t0 (physical shot 1), and shot IDs derived from those t0s are directly
-comparable across devices (see
+With the shot-control outputs disarmed, every sync device's cache holds the
+frame from the last physical trigger.  The control machines are NTP-synced
+far better than the trigger period, so cached ``acq_timestamp`` values
+within a small acceptance window came from the **same physical trigger** —
+each device's value becomes its own t0 (physical shot 1), making derived
+shot IDs directly comparable across devices (see
 :class:`~geecs_bluesky.devices.shot_id.ShotIdTracker`).
 
-Run this stage once per free-run scan, after ``open_run`` is prepared but
-before the first trigger arm.  Strict-mode scans may run it too so their rows
-carry comparable shot IDs; if skipped there, devices self-seed on their first
-awaited shot.
+Run once per free-run scan, before the first trigger arm.  Strict-mode scans
+may run it too; if skipped there, devices self-seed on their first awaited
+shot.
 """
 
 from __future__ import annotations

--- a/GeecsBluesky/geecs_bluesky/preflight.py
+++ b/GeecsBluesky/geecs_bluesky/preflight.py
@@ -1,27 +1,15 @@
 """Pre-flight checks as a pipeline (vision doc §2).
 
-A pre-flight check is an object with one job: look at the scan about to start
-and return one of three outcomes — *pass*, *ask the operator a question*, or
-*abort*.  The runner (:func:`run_preflight`) executes a list of checks in
-order, routing every question through the injected
+A check inspects the scan about to start and returns *pass*, *ask the
+operator a question*, or *abort*; :func:`run_preflight` executes a list of
+checks in order, routing questions through the injected
 :class:`~geecs_bluesky.operator_channel.OperatorChannel`.  New checks are
-additions to the list, not new branches in the scanner class.
+additions to the list, not new branches in the scanner class.  All checks run
+**before the scan folder is claimed**, so an abort here burns no scan number.
 
-All checks run **before the scan folder is claimed**, so an abort here burns
-no scan number.  The two checks below carry today's exact semantics, moved
-verbatim from ``BlueskyScanner._preflight_check_sync_liveness``:
-
-- :class:`GatewayLivenessCheck` — reads each synchronous device's gateway
-  ``CONNECTED`` PV (both acquisition modes; fail-open on an unreadable PV).
-- :class:`FreeRunStalenessCheck` — free-run mode only: with every device
-  CONNECTED, cached ``acq_timestamp`` freshness answers "is the trigger
-  free-running?" (all-stale → trigger-off wording; a stale contributor while
-  the reference frames → per-device drop offer; stale reference →
-  abort-only v1).
-
-Headless / no consumer / no answer → today's behavior is preserved: the check
-passes unchanged and the scan fails loudly downstream (t0 sync in free-run,
-the liveness-gated refire path in strict).
+Today's checks: :class:`GatewayLivenessCheck` (both modes) and
+:class:`FreeRunStalenessCheck` (free-run only).  Headless / no answer → the
+check passes unchanged and the scan fails loudly downstream.
 """
 
 from __future__ import annotations
@@ -58,20 +46,17 @@ class PreflightContext:
     Parameters
     ----------
     detectors :
-        The detector list the scan will run with.  Checks may replace it
-        (e.g. after an operator chose drop-and-continue).
+        The detector list the scan will run with; checks may replace it.
     strict :
-        ``True`` for ``strict_shot_control`` acquisition, ``False`` for
-        free-run.
+        ``True`` for ``strict_shot_control``, ``False`` for free-run.
     read_liveness :
-        ``read_liveness(device) -> bool`` — reads the device's gateway
-        ``CONNECTED`` PV; must be fail-open (unreadable → ``True``).
+        ``read_liveness(device) -> bool`` — gateway ``CONNECTED`` read; must
+        be fail-open (unreadable → ``True``).
     drop_devices :
         ``drop_devices(detectors, drop_ids) -> remaining`` — disconnects and
-        removes the given devices (by ``id()``), returning the survivors.
+        removes the given devices (by ``id()``).
     device_label :
-        ``device_label(device) -> str`` — the GEECS device name for
-        operator-facing messages.
+        ``device_label(device) -> str`` — GEECS device name for messages.
     dialog_timeout :
         Per-question wait budget, in seconds (``None`` → channel default).
     """
@@ -238,22 +223,12 @@ def run_preflight(
 class GatewayLivenessCheck:
     """Catch dead sync devices via the gateway ``CONNECTED`` PV (both modes).
 
-    Each synchronous device's ``connected_status`` (the gateway's per-device
-    ``CONNECTED`` PV) is read; a device reporting ``Disconnected`` is
-    genuinely down — its TCP stream to the gateway is dead.  This is the
-    authoritative signal: the gateway serves every DB device's data PVs
-    regardless of device state, so CA-connect success never implied liveness
-    (an OFF camera's PVs connect fine).  Outcomes:
-
-    - a disconnected *reference* (free-run pacemaker) → abort-only v1
-      (the second button is a clearly-labeled "Try Anyway" because the
-      dialog channel always offers two options; promotion is deferred) —
-      and, on opt-in, later checks are skipped rather than stacking a
-      staleness dialog on top;
-    - any other disconnected device(s), either mode → drop-and-continue
-      (disconnected devices removed from the list) vs abort;
-    - an unreadable ``CONNECTED`` PV (old gateway, timeout) → fail-open:
-      the injected ``read_liveness`` treats it as live.
+    ``CONNECTED`` is the authoritative liveness signal — CA-connect success
+    never implied device liveness (see ``GeecsBluesky/CLAUDE.md``).  Outcomes:
+    a disconnected free-run *reference* → abort-recommended dialog ("Try
+    Anyway" opt-in skips later checks); any other disconnected device(s) →
+    drop-and-continue vs abort; an unreadable ``CONNECTED`` PV → fail-open
+    (the injected ``read_liveness`` treats it as live).
     """
 
     def __call__(self, ctx: PreflightContext) -> CheckResult:
@@ -396,30 +371,20 @@ class FreeRunStalenessCheck:
     """Free-run only: is the trigger free-running? (staleness heuristics).
 
     With every device CONNECTED (the liveness check ran first), cached
-    ``acq_timestamp`` freshness answers one remaining question: *is the
-    trigger free-running?* (a free-run scan requires it).  All devices
-    CONNECTED but all frames stale → the "trigger may be off" dialog (Start
-    Anyway / Abort).  The residual case — a CONNECTED-but-stale contributor
-    while the reference frames — keeps the drop-or-abort dialog: the fresh
-    reference proves the trigger is running, so this is a per-device
-    acquisition problem (e.g. camera acquisition stopped while its TCP
-    stream stays up), for which drop is the right offer and trigger-off
-    wording would be wrong.  A CONNECTED-but-stale *reference* keeps the
-    abort-only dialog.
-
+    ``acq_timestamp`` freshness answers whether the trigger is free-running.
+    All frames stale → the "trigger may be off" dialog; a stale contributor
+    while the reference frames → per-device drop offer (the fresh reference
+    proves the trigger is running); a stale *reference* → abort-only (v1).
     Strict mode passes immediately: frames are not needed before a strict
-    scan (the trigger may legitimately sit OFF; ``ARMED`` starts it), and
-    with ``CONNECTED`` authoritative there is no differential-staleness
-    inference left to make.
+    scan (the trigger may legitimately sit OFF; ``ARMED`` starts it).
 
     Parameters
     ----------
     threshold_s :
         Frame age beyond which a device counts as stale.
     recheck_wait_s :
-        Grace period before re-checking: a just-connected persistent monitor
-        may not have delivered its first frame yet, so one stale verdict
-        gets a second look after roughly one trigger period.
+        Grace period before one re-check (a just-connected monitor may not
+        have delivered its first frame yet).
     """
 
     threshold_s: float

--- a/GeecsBluesky/geecs_bluesky/scan_request_runner.py
+++ b/GeecsBluesky/geecs_bluesky/scan_request_runner.py
@@ -1,78 +1,31 @@
-"""Run a ScanRequest: resolve config names, map onto the existing machinery.
+"""Run a ScanRequest: resolve config names, map onto the session machinery.
 
-The one submission object of the target architecture (vision doc §4.1) meets
-the engine here: a client builds a
-:class:`~geecs_schemas.scan_request.ScanRequest` and calls
-``session.run(request)`` (or hands it to ``BlueskyScanner.reinitialize``).
-This module owns the mapping:
+``session.run(request)`` (or ``BlueskyScanner.reinitialize``) hands a
+:class:`~geecs_schemas.scan_request.ScanRequest` here.  :func:`run_scan_request`
 
-- A :class:`ConfigResolver` turns the request's *names* into schema models —
-  each name in ``save_sets`` → a :class:`~geecs_schemas.save_set.SaveSet`,
-  ``trigger_profile`` → :class:`~geecs_schemas.trigger_profile.TriggerProfile`,
-  an axis variable → a :class:`~geecs_schemas.scan_variables.ScanVariable`,
-  action names → :class:`~geecs_schemas.action_plan.ActionPlan`.
-- **Multiple save sets union.**  ``ScanRequest.save_sets`` is a list; the
-  engine resolves each named set and unions them into one effective SaveSet
-  (:func:`merge_save_sets`) so operators mix and match named diagnostic
-  groups per scan.  The per-device union rule: ``scalars`` union
-  (order-preserving, deduped), ``images`` / ``db_scalars`` / ``all_scalars``
-  OR together (True wins), the single non-``None`` ``role`` is used (a device
-  the sets require with *conflicting* explicit roles is an error), and the
-  entry-level ``setup`` / ``closeout`` ritual name lists union (deduped).
-  Entry-level rituals are collected across *all* named sets, deduped by plan
-  name so a shared ritual runs once (:func:`resolve_save_sets_and_rituals`).
-  Everything downstream — ``save_set_to_devices_config``, telemetry
-  exclusion, the reserved-boundary warning — operates on the merged set.
-- :class:`ConfigsRepoResolver` (in :mod:`geecs_bluesky.config_resolver`,
-  re-exported here) reads the real configs repository — new-schema YAML
-  directly, anything else through the legacy converters.
-- Pure mapping helpers derive the engine shapes from the schemas:
-  :func:`save_set_to_devices_config` (SaveSet → the ``devices_config`` dict
-  ``BlueskyScanner._build_session_devices`` / the session factories expect,
-  applying the documented intent→mechanics derivation rules) and
-  :func:`trigger_writes_from_profile` (TriggerProfile →
-  :class:`~geecs_bluesky.models.shot_control.ShotControlWrites`: per-state
-  **ordered** multi-device write lists — order preserved exactly as the
-  schema documents).  The adapters live *here* — bluesky-side — because
-  ``geecs_schemas`` must never import ``geecs_bluesky`` (dependency
-  direction).
-- **Actions execute.**  Request-level ``setup``/``per_step``/``closeout``
-  bindings, SaveSet entry rituals, and ExperimentDefaults plans are
-  assembled (:func:`assemble_action_slots`), compiled to plan stubs
-  (:func:`~geecs_bluesky.plans.action_compiler.compile_action_plan`) against
-  the session's CA signal factory, and handed to the orchestration hooks.
-  Names still resolve fail-fast **pre-claim** (an unknown plan name fails
-  before any hardware is touched or a scan number is used), and every
-  signal a plan will touch is pre-connected
-  (:func:`prefetch_action_signals`) before the RunEngine runs — a lazy
-  connect inside the RE loop would deadlock.
-- **Multi-axis step scans execute** as an outer-product grid (first axis
-  outermost/slowest — the schema's documented semantics): N movables, one
-  bin per grid point, per-step actions at every grid point, all axis
-  readbacks in the event rows.
-- :func:`run_scan_request` executes the request on a
+- resolves every config *name* through a :class:`ConfigResolver`
+  (:mod:`geecs_bluesky.config_resolver`, re-exported here);
+- unions the named save sets into one effective SaveSet — the per-device
+  union rule is documented on :func:`merge_save_sets`; everything downstream
+  (devices config, telemetry exclusion, boundary warning) sees the merged set;
+- adapts schemas to engine shapes (:func:`save_set_to_devices_config`,
+  :func:`trigger_writes_from_profile`) — adapters live bluesky-side because
+  ``geecs_schemas`` must never import ``geecs_bluesky``;
+- assembles and compiles action slots in §4.4b nesting order
+  (:func:`assemble_action_slots`), with fail-fast pre-claim name resolution
+  and every plan signal pre-connected (:func:`prefetch_action_signals` — a
+  lazy connect inside the RE loop would deadlock);
+- executes noscan/step (multi-axis = outer-product grid, first axis
+  outermost) and optimize modes on a
   :class:`~geecs_bluesky.session.GeecsSession`.
 
 Deliberate v1 gaps (validated, then refused loudly — never silently wrong):
+pseudo scan variables, ``all_scalars``, and optimize without an injected
+``objective``/``suggester`` (the Xopt stack lives in
+``geecs_scanner.optimization``, which this package must not import).
 
-- **Pseudo (composite) scan variables** raise ``NotImplementedError`` — the
-  composite pseudo-positioner device is not built yet.
-- **``all_scalars``** on a save-set entry raises ``NotImplementedError`` —
-  enumerating a device's scalar variables needs the DB-backed validation
-  pass.
-- **Optimize mode** maps onto :meth:`GeecsSession.optimize` as far as its
-  signature allows: variables, iteration/shot counts, ``on_finish``.  The
-  ``evaluator``/``generator`` specs cannot be instantiated in this package
-  (the config-driven Xopt/evaluator stack lives in
-  ``geecs_scanner.optimization``, which geecs_bluesky must not import), so a
-  ready-made ``objective`` and ``suggester`` must be injected; without them
-  optimize mode raises ``NotImplementedError``.  Action bindings on an
-  optimize-mode request are likewise refused (``GeecsSession.optimize`` has
-  no action hooks yet).
-
-Scan variables in configs speak **GEECS device/variable names, never PVs**
-(maintainer-ratified convention): all PV derivation stays inside the device
-factories via ``ca_pv``.
+Configs speak GEECS device/variable names, never PVs (ratified convention);
+PV derivation stays inside the device factories.
 """
 
 from __future__ import annotations
@@ -141,25 +94,9 @@ def _state_write_triples(
 ) -> list[tuple[str | None, str, str]]:
     """Normalize one state's writes to ``(device, variable, value)`` triples.
 
-    Handles both TriggerProfile generations: the single-device shape
-    (top-level ``device`` + per-state ``{variable: value}``) and the
-    multi-device shape (per-state ordered write lists, each write carrying
-    its own ``device``).  Order is preserved exactly (schema-documented:
-    writes are applied top to bottom).
-
-    Parameters
-    ----------
-    profile :
-        The trigger profile.
-    state :
-        The state whose writes to normalize.
-    variant :
-        Optional variant overlay.
-
-    Returns
-    -------
-    list of tuple
-        The state's writes as ``(device, variable, value)``.
+    Handles both TriggerProfile generations (single-device dict shape and
+    multi-device ordered write lists); order is preserved exactly
+    (schema-documented: writes apply top to bottom).
     """
     writes = profile.writes_for(state, variant)
     if isinstance(writes, dict):
@@ -177,16 +114,11 @@ def _state_write_triples(
 def trigger_writes_from_profile(
     profile: TriggerProfile, variant: str | None = None
 ) -> ShotControlWrites:
-    """Adapt a TriggerProfile into the engine's generalized ShotControlWrites.
+    """Adapt a TriggerProfile into the engine's ShotControlWrites.
 
-    A state transition becomes the profile's **ordered** write list — order
-    preserved verbatim (schema-documented: writes are applied top to
-    bottom), spanning as many devices as the profile names.  A single-device
-    profile is simply the one-device case of the same structure; there is no
-    separate pivot any more (the engine's ``ShotController.from_writes``
-    replays these lists sequentially, each write completing before the
-    next).  This adapter lives bluesky-side because ``geecs_schemas`` must
-    not import ``geecs_bluesky``.
+    Each state becomes the profile's **ordered** write list (possibly
+    spanning several devices); ``ShotController.from_writes`` replays them
+    sequentially, each write completing before the next.
 
     Parameters
     ----------
@@ -195,16 +127,10 @@ def trigger_writes_from_profile(
     variant :
         Optional profile variant overlaid first (e.g. ``"laser_off"``).
 
-    Returns
-    -------
-    ShotControlWrites
-        Per-state ordered ``(device, variable, value)`` write lists.
-
     Raises
     ------
     GeecsConfigurationError
-        If *variant* is not defined on the profile, or no state writes any
-        device at all (the profile cannot drive a scan's trigger).
+        Unknown *variant*, or the profile writes no device at all.
     """
     if variant is not None and variant not in profile.variants:
         raise GeecsConfigurationError(
@@ -240,52 +166,29 @@ def save_set_to_devices_config(
 ) -> dict[str, dict[str, Any]]:
     """Derive the legacy ``devices_config`` shape from a SaveSet.
 
-    Applies the documented intent→mechanics derivation rules
-    (``geecs_schemas.save_set`` module docstring):
-
-    - ``synchronous`` is derived from the entry's role: ``snapshot`` →
-      asynchronous, everything else → synchronous.
-    - ``images`` → ``save_nonscalar_data``; the recorded ``variable_list`` is
-      the entry's resolved scalar set (``acq_timestamp`` stays implicit — the
-      device layer always records it).
-    - Role overrides shape the **ordering** (the downstream classifier
-      assigns free-run roles by position): a ``reference``-flagged entry is
-      moved first; ``contributor``-flagged entries are placed after the
-      unmarked synchronous ones so they never inherit pacemaker duty.
-
-    The recorded ``variable_list`` follows the ``SaveSetEntry`` ``db_scalars``
-    contract (M3c), delegated to
-    :func:`~geecs_bluesky.db_runtime.resolve_entry_scalars`: with a
-    *scalar_policy* provider, ``db_scalars=True`` unions the device's DB
-    ``get='yes'`` variables (or every DB variable when ``all_scalars=True``)
-    with the explicit list; ``db_scalars=False`` records only the explicit
-    list (the legacy-converter pin).  Without a provider (the GUI-bridge path
-    or no DB access) only the explicit list is recorded — the M3b behavior,
-    with ``all_scalars`` still a documented gap.
-
-    Parameters
-    ----------
-    save_set :
-        The save set to translate.
-    scalar_policy :
-        Optional DB policy provider (M3c); ``None`` keeps the M3b
-        explicit-only behavior.
+    Applies the intent→mechanics rules documented in ``geecs_schemas.save_set``:
+    ``snapshot`` role → asynchronous, ``images`` → ``save_nonscalar_data``,
+    and role overrides shape the **ordering** (the downstream classifier
+    assigns free-run roles by position: reference first, contributors after
+    the unmarked synchronous entries).  Each recorded ``variable_list`` is
+    resolved per the ``db_scalars`` contract via
+    :func:`~geecs_bluesky.db_runtime.resolve_entry_scalars`; with
+    *scalar_policy* ``None`` (GUI bridge / off-network) only explicit scalars
+    are recorded.
 
     Returns
     -------
     dict
-        ``{device_name: {"synchronous": bool, "save_nonscalar_data": bool,
+        ``{device: {"synchronous": bool, "save_nonscalar_data": bool,
         "variable_list": [...]}}`` in role-derived order.
 
     Raises
     ------
     GeecsConfigurationError
-        If more than one entry claims the ``reference`` role, or if every
-        synchronous entry is ``contributor``-flagged (no pacemaker left).
+        More than one ``reference`` entry, or contributors with no possible
+        pacemaker.
     NotImplementedError
-        For ``all_scalars`` entries without an explicit ``scalars`` list when
-        no *scalar_policy* is available — enumerating a device's scalars needs
-        the DB (which the provider supplies).
+        ``all_scalars`` without an explicit list and no *scalar_policy*.
     """
     references = [e for e in save_set.entries if e.role is SaveRole.REFERENCE]
     if len(references) > 1:
@@ -384,22 +287,8 @@ def raise_if_actions_present(resolved: dict[str, list[str]]) -> None:
 def collect_save_set_rituals(save_set: SaveSet) -> dict[str, list[str]]:
     """Collect entry-level setup/closeout plan names, de-duplicated by name.
 
-    The SaveSet schema's contract: the plans named by all entries are
-    collected together (entry order preserved), de-duplicated by name, and
-    each runs **once** per scan — two cameras sharing a ``prep_visa_line``
-    ritual do not run it twice.  Older SaveSets without the fields
-    contribute nothing (duck-typed).
-
-    Parameters
-    ----------
-    save_set :
-        The save set to inspect.
-
-    Returns
-    -------
-    dict
-        ``{"setup": [names], "closeout": [names]}``, each list de-duplicated
-        in first-appearance order.
+    A ritual shared by several entries runs **once** per scan.  Returns
+    ``{"setup": [names], "closeout": [names]}`` in first-appearance order.
     """
     rituals: dict[str, list[str]] = {"setup": [], "closeout": []}
     for slot, names in rituals.items():
@@ -416,23 +305,16 @@ def collect_save_set_rituals(save_set: SaveSet) -> dict[str, list[str]]:
 
 
 def _merge_two_entries(existing: SaveSetEntry, addition: SaveSetEntry) -> SaveSetEntry:
-    """Merge a second entry for the same device into the first (union rule).
+    """Merge a second entry for the same device into the first.
 
-    The documented per-device union rule (see :func:`merge_save_sets`):
-    ``scalars`` union order-preserving and deduped, the boolean flags
-    (``images`` / ``db_scalars`` / ``all_scalars``) OR together (True wins),
-    the single non-``None`` ``role`` is used — **conflicting explicit roles
-    across the sets raise** (:class:`GeecsConfigurationError`) rather than
-    resolving by list order, since role sets the acquisition semantics — and
-    the entry-level ``setup`` / ``closeout`` ritual name lists union (deduped,
-    first appearance). Reserved ``at_scan_start`` / ``at_scan_end`` maps merge
-    key-wise (existing wins on a key clash) — they are inert in this version,
-    so the choice only affects the one warning they draw.
+    Applies the per-device union rule documented on :func:`merge_save_sets`.
+    Reserved ``at_scan_start`` / ``at_scan_end`` maps merge key-wise
+    (existing wins; inert fields, so this only affects the reserved warning).
 
     Raises
     ------
     GeecsConfigurationError
-        If the two entries give the same device different explicit roles.
+        The two entries give the same device different explicit roles.
     """
 
     def _union(first: list[str], second: list[str]) -> list[str]:
@@ -442,12 +324,8 @@ def _merge_two_entries(existing: SaveSetEntry, addition: SaveSetEntry) -> SaveSe
                 merged.append(item)
         return merged
 
-    # Role sets the acquisition guarantees (reference / contributor / snapshot
-    # pacemaker wiring in save_set_to_devices_config). Two named sets that
-    # both require the same device but disagree on its explicit role would
-    # otherwise be resolved by save_sets list order — silently giving the scan
-    # the wrong synchronization semantics. Refuse it (matching the legacy
-    # preset composer), rather than pick by order.
+    # Conflicting explicit roles must raise, never resolve by list order —
+    # role sets the scan's synchronization semantics (pacemaker wiring).
     if (
         existing.role is not None
         and addition.role is not None
@@ -526,28 +404,14 @@ def resolve_save_sets_and_rituals(
 ) -> tuple[SaveSet, dict[str, list[str]]]:
     """Resolve every named save set, union them, and collect all rituals.
 
-    Resolves each name in *names* to a :class:`SaveSet`, merges them into one
-    effective save set (:func:`merge_save_sets`), and collects the entry-level
-    setup/closeout rituals across **all** sets, de-duplicated by plan name
-    (so a ritual shared by two sets still runs once). Every referenced ritual
-    plan name is validated against the action library now (fail-fast,
-    pre-claim).
-
-    Parameters
-    ----------
-    resolver :
-        Where names are looked up.
-    names :
-        The save-set names (``ScanRequest.save_sets``); must be non-empty.
-    merged_name :
-        Name for the merged set (used in downstream messages).
+    Rituals are collected across **all** sets, deduped by plan name (a shared
+    ritual runs once), and every referenced plan name is validated fail-fast
+    pre-claim.
 
     Returns
     -------
     tuple
-        ``(merged_save_set, rituals)`` — the unioned save set and its
-        de-duplicated ``{"setup": [...], "closeout": [...]}`` ritual names
-        collected across every named set.
+        ``(merged_save_set, {"setup": [...], "closeout": [...]})``.
     """
     resolved = [resolver.resolve_save_set(name) for name in names]
     merged = merge_save_sets(resolved, name=merged_name)
@@ -575,33 +439,17 @@ def assemble_action_slots(
 ) -> dict[str, list[str]]:
     """Assemble the final ordered plan-name lists for the three action slots.
 
-    The §4.4b setup layers nest like context managers (mirrored teardown —
-    the ordering decision ratified with this milestone and documented in
-    the ``ExperimentDefaults`` schema):
+    The §4.4b layers nest like context managers (mirrored teardown, per the
+    ``ExperimentDefaults`` schema):
 
-    - **setup**: experiment defaults → save-set entry rituals → the scan's
-      own ``actions.setup`` (defaults outermost, the specific scan
-      innermost).
-    - **per_step**: the scan's own ``actions.per_step`` only (neither
-      defaults nor entries have a per-step slot — deliberate).
-    - **closeout**: the exact reverse — the scan's own ``actions.closeout``
-      → entry rituals → experiment defaults.
+    - **setup**: experiment defaults → save-set entry rituals → the scan's own
+    - **per_step**: the scan's own only (deliberate — no other layer has one)
+    - **closeout**: the exact reverse of setup
 
-    *actions* is the post-defaults request bindings (defaults already merged
-    by :func:`apply_experiment_defaults`: prepended to setup, appended to
-    closeout); *applied_defaults* tells this function how many entries of
-    each list came from defaults, so entry rituals can be spliced between
-    the layers.  Within the entry layer, first-appearance entry order is
-    kept for both slots (the schema orders the layers, not the entries).
-
-    Parameters
-    ----------
-    actions :
-        The request's action bindings, after defaults were applied.
-    applied_defaults :
-        The provenance record from :func:`apply_experiment_defaults`.
-    rituals :
-        The save set's ``{"setup": [...], "closeout": [...]}`` names.
+    *actions* is the post-defaults bindings (:func:`apply_experiment_defaults`
+    prepends defaults to setup, appends to closeout); *applied_defaults* says
+    how many entries came from defaults so *rituals* can be spliced between
+    the layers.
 
     Returns
     -------
@@ -671,20 +519,8 @@ class _LazyResolverRegistry(Mapping):
 def build_action_registry(resolver: ConfigResolver) -> Mapping[str, ActionPlan]:
     """Return the named-plan registry nested ``run`` steps resolve against.
 
-    Prefers the resolver's ``action_plan_registry()`` (duck-typed —
-    :class:`ConfigsRepoResolver` implements it: the experiment's action
-    library plus any plans extracted from converted save elements); falls
-    back to a lazy per-name façade.
-
-    Parameters
-    ----------
-    resolver :
-        The name resolver.
-
-    Returns
-    -------
-    Mapping
-        ``{plan_name: ActionPlan}`` (possibly lazy).
+    Prefers the resolver's duck-typed ``action_plan_registry()``; falls back
+    to a lazy per-name façade.
     """
     method = getattr(resolver, "action_plan_registry", None)
     if callable(method):
@@ -699,23 +535,10 @@ def prefetch_action_signals(
 ) -> None:
     """Create/connect every signal the compiled *plans* will touch, up front.
 
-    Compiled plan generators execute **inside** the RunEngine's event loop,
-    where a blocking signal connect would deadlock — so every
-    ``(device, variable)`` a ``set``/``check`` step names is touched here
-    first (the factory caches per target, so execution finds everything
-    connected).  Doubles as fail-fast validation: an unreachable target
-    fails now, before the scan claims a number.  Nested ``run`` steps are
-    walked recursively (visited-set bounded, so cycles terminate — the
-    compiler itself raises on them at execution).
-
-    Parameters
-    ----------
-    plans :
-        The resolved plans of every slot about to run.
-    registry :
-        Named plans for ``run``-step recursion.
-    settables :
-        The :class:`~geecs_bluesky.plans.action_compiler.SettableFactory`.
+    Plan generators execute **inside** the RunEngine loop, where a lazy
+    connect would deadlock — so every target is connected here, pre-claim
+    (doubling as fail-fast validation).  Nested ``run`` steps are walked
+    recursively (visited-set bounded).
     """
     visited: set[str] = set()
 
@@ -745,27 +568,14 @@ def compile_action_slot(
 ) -> tuple[Callable | None, list[ActionPlan]]:
     """Compile one slot's plan names into a reusable plan-stub callable.
 
-    The returned callable yields the slot's plans in order, producing a
-    **fresh** message generator per call — required for ``per_step`` (run at
-    every step boundary) and for ``finalize_wrapper`` (which may instantiate
-    its closeout more than once).
-
-    Parameters
-    ----------
-    names :
-        The slot's plan names, in final execution order.
-    resolver :
-        Resolves each name to its :class:`ActionPlan`.
-    registry :
-        Named plans for nested ``run`` steps.
-    settables :
-        The signal factory the compiled steps draw from.
+    The callable produces a **fresh** message generator per call — required
+    for ``per_step`` and for ``finalize_wrapper`` re-instantiation.
 
     Returns
     -------
     tuple
-        ``(stub, plans)`` — the plan-stub callable (``None`` when the slot
-        is empty) and the resolved plans (for signal prefetching).
+        ``(stub, plans)`` — stub is ``None`` when the slot is empty; plans
+        feed signal prefetching.
     """
     if not names:
         return None, []
@@ -781,24 +591,9 @@ def compile_action_slot(
 def resolve_save_sets_checked(resolver: ConfigResolver, names: list[str]) -> SaveSet:
     """Resolve and union several save sets, refusing rituals — **GUI-bridge only**.
 
-    Every name in *names* is resolved, the sets are unioned into one effective
-    SaveSet (:func:`merge_save_sets`), and any entry-level ritual (collected
-    across all named sets) is *validated* then refused — the GUI bridge stages
-    requests through the legacy exec-config machinery and does not run rituals
-    yet. The bridge still refuses actions/multi-axis elsewhere; this only
-    makes the save-set resolution list-aware.
-
-    Parameters
-    ----------
-    resolver :
-        Where names are looked up.
-    names :
-        The save-set names (``ScanRequest.save_sets``).
-
-    Returns
-    -------
-    SaveSet
-        The unioned save set (guaranteed free of entry-level actions).
+    Rituals are *validated* first (unknown names fail loudly), then refused —
+    the bridge does not execute them yet.  Returns the unioned save set
+    (guaranteed free of entry-level actions).
     """
     save_set, rituals = resolve_save_sets_and_rituals(resolver, names)
     entry_actions = [n for slot in rituals.values() for n in slot]
@@ -818,32 +613,16 @@ def apply_experiment_defaults(
 ) -> tuple[ScanRequest, dict[str, Any]]:
     """Apply experiment defaults where the request is silent (with provenance).
 
-    The merge rule is the :class:`~geecs_schemas.ExperimentDefaults` one —
-    **defaults run first on the way in and last on the way out**: a default
-    trigger profile is used only when the request names none; default setup
-    plans are *prepended* to the request's own setup list, and default
-    closeout plans are *appended* after the request's own closeout list
-    (teardown mirrors setup — the defaults are the outermost bracket).
-    What was applied is returned for provenance (recorded into the run
-    metadata by :func:`run_scan_request`) — a run's metadata must show the
-    configuration it actually used, not require reconstructing which
-    defaults file was in force.
-
-    Parameters
-    ----------
-    request :
-        The submitted request.
-    defaults :
-        The experiment defaults — an
-        :class:`~geecs_schemas.ExperimentDefaults` model or a plain mapping
-        of the same shape; ``None`` means no defaults.
+    :class:`~geecs_schemas.ExperimentDefaults` merge rule — defaults are the
+    outermost bracket: default setup *prepends*, default closeout *appends*,
+    a default trigger profile fills only an unset one.  Never overrides an
+    explicit request value.
 
     Returns
     -------
     tuple
-        ``(request, applied)`` — the (possibly copied and updated) request
-        and a ``{field: value}`` record of every default applied (empty
-        when nothing was).
+        ``(request, applied)`` — the updated request and a ``{field: value}``
+        provenance record of every default applied (goes into run metadata).
     """
 
     def _field(source: Any, name: str) -> Any:
@@ -899,19 +678,7 @@ def resolve_defaults_for(
     """Apply the resolver's experiment defaults to *request* (tolerantly).
 
     Resolvers without a ``resolve_experiment_defaults`` method are treated
-    as having no defaults.
-
-    Parameters
-    ----------
-    resolver :
-        The name resolver.
-    request :
-        The submitted request.
-
-    Returns
-    -------
-    tuple
-        As :func:`apply_experiment_defaults`.
+    as having no defaults.  Returns as :func:`apply_experiment_defaults`.
     """
     return apply_experiment_defaults(request, resolve_experiment_defaults(resolver))
 
@@ -940,25 +707,13 @@ def resolve_movable_target(
 ) -> tuple[str, str, str, str | None]:
     """Return ``(device, variable, kind, confirm)`` for a plain scan variable.
 
-    Parameters
-    ----------
-    spec :
-        The catalog entry.
-    name :
-        The friendly name (for error messages).
-
-    Returns
-    -------
-    tuple
-        Device name, variable name, the entry's kind, and its optional
-        ``confirm`` target (``"Device:Variable"``, or ``None`` when the set
-        variable is also the readback — the common case).
+    ``confirm`` is the entry's optional ``"Device:Variable"`` confirming
+    target (``None`` when the set variable is also the readback).
 
     Raises
     ------
     NotImplementedError
-        For pseudo (composite) variables — the composite pseudo-positioner
-        device is not built yet.
+        Pseudo (composite) variables — the pseudo-positioner is not built yet.
     """
     if isinstance(spec, PseudoScanVariable):
         raise NotImplementedError(
@@ -1002,27 +757,12 @@ def _build_request_detectors(
 ) -> list:
     """Create session devices from a derived devices_config, roles by order.
 
-    Mirrors the role rules of ``BlueskyScanner._classify_device_roles``:
-    free-run → first synchronous entry is the reference (built with
-    :meth:`GeecsSession.detector`), later synchronous entries are
-    contributors; strict → every synchronous entry is a triggered detector;
-    asynchronous entries are snapshots.  This is the *headless* build:
-    failures propagate (fail loudly) — operator drop/promote interaction is
-    the scanner layer's job.
-
-    Parameters
-    ----------
-    session :
-        The :class:`~geecs_bluesky.session.GeecsSession` (duck-typed).
-    devices_config :
-        Output of :func:`save_set_to_devices_config`.
-    free_run :
-        Whether the scan runs in free-run acquisition.
-
-    Returns
-    -------
-    list
-        Connected devices, reference first.
+    Mirrors ``BlueskyScanner._classify_device_roles``: free-run → first
+    synchronous entry is the reference, later ones contributors; strict →
+    all synchronous entries triggered; asynchronous → snapshots.  This is
+    the *headless* build — failures propagate (fail loudly); operator
+    drop/promote interaction is the scanner layer's job.  Returns connected
+    devices, reference first.
     """
     detectors: list = []
     reference_assigned = False
@@ -1082,19 +822,10 @@ def make_scalar_policy(session: Any) -> ScalarPolicyProvider | None:
 def warn_if_reserved_boundary_overrides(save_set: SaveSet | None) -> None:
     """Warn once if any entry sets the reserved (not-honored) set-side fields.
 
-    ``SaveSetEntry.at_scan_start`` / ``at_scan_end`` are **reserved and not
-    applied in this version**: the engine sets up triggering via the
-    TriggerProfile/shot controller and camera saving via its own
-    save-windowing, so DB set-side scan start/end writes are intentionally
-    disabled (they would race the shot controller on the DG645).  A config
-    that still sets them is not an error — it is honored by a future
-    re-enable — but the operator should know the values are inert now, so we
-    log one WARNING naming the device(s).
-
-    Parameters
-    ----------
-    save_set :
-        The scan's save set (``None`` = nothing to check).
+    ``at_scan_start`` / ``at_scan_end`` are reserved and inert — the DB
+    set-side is intentionally disabled (rationale:
+    ``GeecsBluesky/CLAUDE.md``, M3c set-side section).  One WARNING names
+    the offending device(s); not an error.
     """
     if save_set is None:
         return
@@ -1123,30 +854,17 @@ def build_telemetry_readables(
 ) -> tuple[list, dict[str, list[str]]]:
     """Build the Tier-2 background-telemetry readables (soft, dropped-if-dead).
 
-    Selects every experiment device with a ``get='yes'`` variable not in the
-    save set (:func:`~geecs_bluesky.db_runtime.select_telemetry_variables`),
-    then builds one soft telemetry readable per device via
-    ``session.telemetry`` — which returns ``None`` for a device unreachable at
-    scan start (dropped with a log line, never an abort).  Devices that connect
-    are appended to the scan's read set as extra columns; the softness (never
-    waited on) lives in the device's own tolerant ``read``.
-
-    Parameters
-    ----------
-    session :
-        The session (its ``telemetry`` factory connects each device softly).
-    save_set :
-        The scan's save set (its devices are excluded from telemetry).
-    scalar_policy :
-        Supplies ``get='yes'`` variables; ``None`` means no telemetry.
+    One soft readable per experiment device with a ``get='yes'`` variable not
+    in *save_set*; ``session.telemetry`` returns ``None`` for a device
+    unreachable at scan start (dropped with a log line, never an abort).
+    ``scalar_policy`` ``None`` means no telemetry.
 
     Returns
     -------
     tuple
-        ``(readables, recorded)`` — the connected telemetry devices and the
+        ``(readables, recorded)`` — connected devices and the
         ``{device: [variables]}`` map of **only those that connected**
-        (recorded in run metadata; devices dropped as unreachable are excluded
-        so the metadata matches the columns that actually exist).
+        (run-metadata key must match the columns that actually exist).
     """
     if scalar_policy is None:
         return [], {}
@@ -1235,14 +953,10 @@ def run_scan_request(
     mode = "strict" if request.acquisition is AcquisitionMode.STRICT else "free_run"
 
     if request.mode is ScanRequestMode.OPTIMIZE:
-        # Optimize mode has no action hooks yet (GeecsSession.optimize runs an
-        # adaptive scan with no setup/per_step/closeout seam).  Rather than
-        # refuse — which would block every optimization the moment an
-        # experiment defines default bracket actions — we run the optimization
-        # and skip the actions, logging loudly and recording the skip in run
-        # metadata so the omission is never silent.  Safety/setup actions are
-        # intentionally not run during optimization for now (a new capability,
-        # not present in the legacy scanner either).
+        # Optimize has no action hooks yet: skip actions (never refuse — that
+        # would block optimization wherever defaults define bracket actions),
+        # log loudly, and record the skip in run metadata (never silent).
+        # Rationale: GeecsBluesky/CLAUDE.md (engine consolidation).
         skipped_actions = {k: v for k, v in resolved_actions.items() if v}
         return _run_optimize_request(
             session,
@@ -1264,11 +978,8 @@ def run_scan_request(
     # deduped/merged; rituals collected across all sets, deduped by name).
     save_set, rituals = resolve_save_sets_and_rituals(resolver, request.save_sets)
 
-    # M3c DB-integration runtime tier — get-side only.  The policy provider is
-    # failure-tolerant (empty policy on a missing/unreachable DB), so it never
-    # aborts a scan.  The DB set-side (scan start/end writes) is intentionally
-    # disabled in this version (see the module docstring); a config that still
-    # sets the reserved at_scan_start / at_scan_end fields gets one warning.
+    # M3c get-side runtime: failure-tolerant policy provider (a DB blip never
+    # aborts a scan); the DB set-side stays disabled (reserved fields warn).
     scalar_policy = make_scalar_policy(session)
     devices_config = save_set_to_devices_config(save_set, scalar_policy)
     slots = assemble_action_slots(request.actions, applied_defaults, rituals)
@@ -1467,10 +1178,8 @@ def _run_optimize_request(
     created: list = []
     try:
         skipped = {k: list(v) for k, v in (skipped_actions or {}).items() if v}
-        # db_scalars resolution applies to optimize too (recorded-scalar
-        # consistency); background telemetry does not run in optimize mode yet
-        # (no scan-boundary hook on GeecsSession.optimize).  The DB set-side
-        # (scan start/end writes) is disabled everywhere in this version.
+        # db_scalars applies to optimize too; telemetry does not run here yet
+        # (no scan-boundary hook); the DB set-side stays disabled everywhere.
         scalar_policy = make_scalar_policy(session)
         if request.save_sets:
             save_set, rituals = resolve_save_sets_and_rituals(
@@ -1517,9 +1226,8 @@ def _run_optimize_request(
                 "and save-set rituals do not run during optimization): %s",
                 skipped,
             )
-        # Background telemetry is not wired into optimize mode yet
-        # (GeecsSession.optimize has no scan-boundary hook); db_scalars
-        # resolution above still applies.  The DB set-side is disabled
+        # Telemetry is not wired into optimize yet; db_scalars above applies.
+        # The DB set-side is disabled
         # everywhere in this version.  Recorded for provenance.
         md["db_scan_runtime"] = {
             "db_scalars": "applied",

--- a/GeecsBluesky/geecs_bluesky/scanner_bridge/bluesky_scanner.py
+++ b/GeecsBluesky/geecs_bluesky/scanner_bridge/bluesky_scanner.py
@@ -48,12 +48,8 @@ from typing import Any, Callable
 from geecs_bluesky.devices.ca._pv import GATEWAY_DISCONNECTED
 from geecs_bluesky.exceptions import GeecsConfigurationError
 
-# The event vocabulary lives in this package now (geecs_bluesky.events);
-# geecs_scanner.engine.scan_events / dialog_request are re-export shims of
-# these same classes, so isinstance checks agree across both import paths.
-# The names are bound at module level (not referenced via the events module)
-# because hermetic tests monkeypatch them to simulate a consumer-less
-# environment — the `is None` guards downstream are that test seam.
+# Bound at module level (not via the events module) because hermetic tests
+# monkeypatch these names — the `is None` guards downstream are that seam.
 from geecs_bluesky.events import (
     DialogRequest,
     ScanDialogEvent,
@@ -99,36 +95,25 @@ logger = logging.getLogger(__name__)
 _DISCONNECT_TIMEOUT = 10.0
 _THREAD_JOIN_TIMEOUT = 15.0
 
-# Seconds between the LabVIEW epoch (1904-01-01) and the Unix epoch
-# (1970-01-01).  Device ``acq_timestamp`` values are LabVIEW-epoch.  Defined
-# in geecs_bluesky.preflight (which owns the staleness math now); the alias
-# stays because tests and external callers reference it here.
+# LabVIEW→Unix epoch offset; owned by geecs_bluesky.preflight, aliased here
+# because tests and external callers reference it at this path.
 _LABVIEW_EPOCH_OFFSET = LABVIEW_EPOCH_OFFSET
 
-# Pre-flight read budget for a device's gateway ``CONNECTED`` PV.  Read from
-# the scan thread via run_coroutine_threadsafe on the RE loop; on timeout or
-# error the device is treated as live (fail-open) — an old gateway without
-# status PVs must never block a scan.
+# CONNECTED-PV read budget; on timeout/error the device counts as live
+# (fail-open — an old gateway without status PVs must never block a scan).
 _LIVENESS_READ_TIMEOUT_S = 2.0
 
-# Free-run pre-flight freshness (free-run mode ONLY — liveness itself comes
-# from the gateway ``CONNECTED`` PV): a synchronous device whose cached
-# ``acq_timestamp`` is older than this (wall-clock seconds; control machines
-# are NTP-synced) — or that has no cached frame at all — is considered stale.
-# The trigger free-runs before a free-run scan, so live devices have frames
-# no older than one trigger period; all-CONNECTED-but-all-stale therefore
-# means the trigger is off / not free-running.
+# Free-run pre-flight freshness (free-run ONLY): a sync device with no cached
+# frame newer than this is stale; all-CONNECTED-but-all-stale means the
+# trigger is off / not free-running.
 _STALE_SYNC_THRESHOLD_S = 10.0
 
-# Grace period before re-checking: a just-connected persistent monitor may not
-# have delivered its first frame yet, so one stale verdict gets a second look
-# after roughly one trigger period.
+# One stale verdict gets a second look after ~one trigger period (a fresh
+# monitor may not have delivered its first frame yet).
 _STALE_RECHECK_WAIT_S = 2.0
 
-# How long the scan thread waits for the operator to answer a pre-flight
-# dialog.  On timeout the scan proceeds with today's default behavior
-# (fail-loud at t0 sync) — a headless or unattended scan must never hang on a
-# dialog nobody will answer.
+# Pre-flight dialog wait; on timeout the scan proceeds (fail-loud at t0
+# sync) — an unattended scan must never hang on an unanswered dialog.
 _PREFLIGHT_DIALOG_TIMEOUT_S = 30.0
 
 _STRICT_MODE = "strict_shot_control"
@@ -229,10 +214,7 @@ class BlueskyScanner:
         self._scan_request: ScanRequest | None = None
         self._request_step: dict[str, Any] | None = None
 
-        # Devices are CA-backed only (the direct UDP/TCP backend was removed
-        # once the CA backend reached verified parity; the GeecsCAGateway is
-        # the one component that speaks GEECS wire protocol). Catch a stale
-        # environment loudly rather than silently changing behavior.
+        # Catch a stale env loudly rather than silently changing behavior.
         legacy_backend = os.environ.get("GEECS_BLUESKY_DEVICE_BACKEND")
         if legacy_backend and legacy_backend.strip().lower() != "ca":
             raise ValueError(
@@ -335,44 +317,18 @@ class BlueskyScanner:
     ) -> bool:
         """Map a ScanRequest onto the scanner's internal exec-config shapes.
 
-        The acceptance seam of the schema milestone: the request's names are
-        resolved (save set → ``devices_config``, trigger profile →
-        :class:`~geecs_bluesky.models.shot_control.ShotControlConfig`, axis
-        variable → device/variable/kind) **here, fail-fast**, and a
-        legacy-shaped scan-config namespace is synthesized so the scan
-        thread (``_run_scan`` → ``_execute_scan``) runs byte-identically to
-        the exec_config path — pinned by the noscan parity test.
+        Names are resolved **fail-fast here**, and a legacy-shaped
+        scan-config namespace is synthesized so the scan thread runs
+        byte-identically to the exec_config path (pinned by the noscan
+        parity test).  ``shots_per_step`` maps onto the legacy ``wait_time``
+        slot (ScanInfo quirk; identical metadata at the 1 Hz identity rep
+        rate); ``acquisition`` comes from the request — deliberately no env
+        override, a request declares intent.  Actions / multi-axis /
+        optimize are validated then refused (``NotImplementedError``) — run
+        those headless via ``GeecsSession.run`` until the GUI-submission
+        milestone routes them through this bridge.
 
-        Mapping notes:
-
-        - ``shots_per_step`` is declared directly by the request (no
-          rep-rate × wait-time derivation).  The synthesized namespace maps
-          it back onto the legacy ``wait_time`` slot, preserving the
-          legacy-format ScanInfo quirk (the ini records wait_time under
-          "Shots per step"); at the legacy identity rep rate of 1 Hz the two
-          paths produce identical metadata.
-        - ``acquisition`` comes from the request — deliberately **no**
-          ``GEECS_BLUESKY_ACQUISITION_MODE`` env override: a request
-          declares intent.
-        - Action names are resolved and validated now, then refused
-          (``NotImplementedError``) — the *engine* executes actions and
-          multi-axis grids (run the request headless via
-          ``GeecsSession.run``); routing them through this GUI bridge lands
-          with the GUI submission milestone.  Optimize-mode requests are
-          likewise refused loudly.
-
-        Parameters
-        ----------
-        request :
-            The scan request to stage.
-        resolver :
-            Name resolver; defaults to the configs-repo resolver for this
-            scanner's experiment.
-
-        Returns
-        -------
-        bool
-            ``True`` (matching :meth:`reinitialize`).
+        Returns ``True`` (matching :meth:`reinitialize`).
         """
         from types import SimpleNamespace
 
@@ -854,32 +810,15 @@ class BlueskyScanner:
     ) -> list | None:
         """Pre-flight: catch dead sync devices before the claim (pipeline).
 
-        A thin call into the declarative pipeline in
-        :mod:`geecs_bluesky.preflight` — two checks, both *before* the scan
-        folder is claimed (so an abort here burns no scan number), asking
-        the operator through the injected channel when something is wrong:
-
-        - :class:`~geecs_bluesky.preflight.GatewayLivenessCheck` — each sync
-          device's gateway ``CONNECTED`` PV, both modes (fail-open on an
-          unreadable PV; abort-only for a dead free-run reference;
-          drop-and-continue otherwise).
-        - :class:`~geecs_bluesky.preflight.FreeRunStalenessCheck` — free-run
-          only: is the trigger free-running? (all-stale → trigger-off
-          wording; stale reference → abort-only v1; stale contributor →
-          drop offer).
-
-        Headless / no consumer / no answer → today's behavior is preserved:
-        proceed and fail loudly downstream (t0 sync in free-run, the
-        liveness-gated refire path in strict).  The module-level knobs
-        (``_STALE_SYNC_THRESHOLD_S``, ``_STALE_RECHECK_WAIT_S``,
-        ``_PREFLIGHT_DIALOG_TIMEOUT_S``) are read here at call time — the
-        hermetic tests monkeypatch them.
+        Thin call into :mod:`geecs_bluesky.preflight` (liveness + free-run
+        staleness), pre-claim so an abort burns no scan number.  Headless /
+        no answer → proceed and fail loudly downstream.  The module-level
+        knobs are read at call time — the hermetic tests monkeypatch them.
 
         Returns
         -------
         list or None
-            The (possibly reduced) detector list to proceed with, or ``None``
-            when the operator chose to abort.
+            The (possibly reduced) detector list, or ``None`` on abort.
         """
         ctx = PreflightContext(
             detectors=detectors,
@@ -1051,37 +990,21 @@ class BlueskyScanner:
     def _merge_optimization_device_requirements(self, requirements: Any) -> None:
         """Merge optimizer ``device_requirements`` into the save-device set.
 
-        Legacy parity: ``ScanManager`` feeds ``optimizer.device_requirements``
-        (shape ``{"Devices": {name: cfg}}``, auto-generated by the optimizer
-        config from the evaluator's analyzers with a synchronous +
-        ``save_nonscalar_data=True`` + ``acq_timestamp`` template) through
-        ``device_manager.load_from_dictionary``, so every device the
-        objective needs is acquired and natively saved without being on the
-        GUI save list.  Mirrored here on ``self._devices_config`` before
-        :meth:`_build_session_devices` runs:
+        Legacy parity (``ScanManager`` → ``load_from_dictionary``): every
+        device the objective needs is acquired and natively saved without
+        being on the GUI save list.  A required device absent from the GUI
+        list is appended after the GUI devices (the pacemaker choice is
+        unchanged); one already listed keeps its GUI config and only gains
+        missing variables.
 
-        - a required device absent from the GUI list is added with the
-          requirement's own config (flags default to the legacy
-          ``DeviceConfig`` defaults when the requirement omits them); it is
-          appended after the GUI devices, so the free-run reference
-          (pacemaker) choice is unchanged;
-        - a device already on the GUI list keeps its GUI config and only
-          gains required variables it was missing (the legacy
-          ``subscribe_var_values`` extension).
+        Device names match **case-insensitively** (``str.casefold``) —
+        GEECS itself is case-inconsistent about device-name spelling, and a
+        wrong-case duplicate entry fails every CA PV connect (CA names are
+        case-sensitive; live-observed).  On a hit the requirement merges
+        under the GUI's spelling, logged at INFO.
 
-        Device names are matched **case-insensitively** (``str.casefold``):
-        GEECS itself is case-inconsistent about device-name spelling (the DB
-        may say ``UC_Amp4_IR_input`` while native files say
-        ``UC_Amp4_IR_Input``), so optimizer configs drift.  On a
-        case-insensitive hit the requirement merges into the *existing*
-        entry under the GUI's spelling — the GUI/DB spelling is the one
-        whose CA PVs actually connect (CA names are case-sensitive) — and
-        the difference is logged at INFO.  Live-observed 2026-07-06: a
-        wrong-case duplicate entry NotConnectedError'd on every PV.
-
-        *requirements* is duck-typed off the bridge object (``Any``): a
-        ``{"Devices": ...}`` mapping, or ``None``/empty when the bridge
-        exposes no requirements (unchanged behavior).
+        *requirements* is duck-typed: a ``{"Devices": ...}`` mapping, or
+        ``None``/empty (unchanged behavior).
         """
         devices = (
             requirements.get("Devices") if isinstance(requirements, dict) else None

--- a/GeecsBluesky/geecs_bluesky/session.py
+++ b/GeecsBluesky/geecs_bluesky/session.py
@@ -838,19 +838,12 @@ class GeecsSession:
     ) -> str | None:
         """Run one :class:`~geecs_schemas.scan_request.ScanRequest`; return the uid.
 
-        The submission front door of the target architecture (vision doc
-        §4.1): the request's names (save set, trigger profile, scan
-        variables, action plans) are resolved through *resolver* — by
-        default a
-        :class:`~geecs_bluesky.scan_request_runner.ConfigsRepoResolver` over
-        this session's experiment in the configs repository, which loads
-        new-schema YAML when present and converts legacy files otherwise —
-        and the request is mapped onto :meth:`scan` / :meth:`optimize` by
-        :func:`~geecs_bluesky.scan_request_runner.run_scan_request` —
-        including multi-axis grids, setup/per-step/closeout action
-        execution, and multi-device trigger profiles (see its docstring for
-        the remaining documented v1 gaps: pseudo variables, ``all_scalars``,
-        optimize without an injected objective/suggester).
+        The schema submission front door: names resolve through *resolver*
+        (default: :class:`~geecs_bluesky.config_resolver.ConfigsRepoResolver`
+        over this session's experiment) and the request is mapped onto
+        :meth:`scan` / :meth:`optimize` by
+        :func:`~geecs_bluesky.scan_request_runner.run_scan_request` (see its
+        docstring for the documented v1 gaps).
 
         Parameters
         ----------

--- a/GeecsBluesky/geecs_bluesky/shot_controller.py
+++ b/GeecsBluesky/geecs_bluesky/shot_controller.py
@@ -1,22 +1,12 @@
 """ShotController — reusable trigger/shot-control bracketing as plan stubs.
 
-Extracted from ``BlueskyScanner`` so notebooks and :class:`~geecs_bluesky.session.GeecsSession`
-get the same arm/disarm/quiesce/single-shot discipline as GUI scans.  The
-controller is built either from a validated
-:class:`~geecs_bluesky.models.shot_control.ShotControlConfig` plus one Bluesky
-``Movable`` setter per shot-control variable (the legacy/scanner path), or —
-via :meth:`ShotController.from_writes` — from generalized
-:class:`~geecs_bluesky.models.shot_control.ShotControlWrites`: per-state
-**ordered** ``(device, variable, value)`` lists that may span several devices
-(the TriggerProfile semantics; writes applied top to bottom, each completing
-before the next).  :meth:`ShotController.over_ca` / :meth:`from_writes`'
-default setter factory put to the gateway's ``…:SP`` PVs, which ride GEECS's
-blocking UDP set server-side; string values from the YAML map naturally (enum
-PVs take labels, numeric PVs coerce numeric strings).
-
-All state-driving methods are Bluesky **plan stubs** (generators) — compose
-them into plans or pass them as the ``arm_trigger``/``fire_shot`` hooks of the
-step-scan plans.
+Drives the shot-control device(s) through named states via setters putting
+to the gateway ``…:SP`` PVs (which ride GEECS's blocking UDP set).  Two
+construction paths — legacy single-device config vs generalized ordered
+multi-device writes — are documented on :class:`ShotController` and
+:meth:`ShotController.from_writes`.  All state-driving methods are Bluesky
+**plan stubs** (generators).  Design rationale: ``GeecsBluesky/CLAUDE.md``
+(Shot control).
 """
 
 from __future__ import annotations
@@ -66,16 +56,11 @@ class CaPutSetter:
 class ShotController:
     """Drives the shot-control device(s) through named states, as plan stubs.
 
-    Two construction paths share every plan stub:
-
-    - **Legacy/scanner path** (this constructor / :meth:`over_ca`): a
-      single-device :class:`ShotControlConfig` plus one setter per variable.
-      State writes are issued concurrently then waited on — byte-identical
-      to the pre-generalization behavior.
-    - **Generalized path** (:meth:`from_writes`): per-state *ordered*
-      ``(device, variable, value)`` write lists (multi-device
-      TriggerProfile semantics).  Writes are applied strictly in order,
-      each completing before the next is sent.
+    Two construction paths share every plan stub: the legacy/scanner path
+    (this constructor / :meth:`over_ca` — a single-device
+    :class:`ShotControlConfig`, state writes issued concurrently, the
+    pre-generalization behavior) and the generalized multi-device path
+    (:meth:`from_writes`, which documents the ordered-write semantics).
 
     Parameters
     ----------
@@ -211,15 +196,11 @@ class ShotController:
         """Plan stub: drive the shot-control writes for *state*.
 
         Generalized (``from_writes``) controllers replay the state's ordered
-        write list top to bottom, **each write completing before the next**
-        (order is schema-documented: transitions may depend on it).
-
-        Legacy single-device controllers keep their exact historical
-        behavior: only variables with a non-empty value for *state* are
-        written (the rest are no-ops); they are set concurrently then waited
-        on.  Uses ``bps.abs_set`` + ``bps.wait`` rather than ``bps.mv``
-        because ``bps.mv`` inspects ``.parent`` for coupled-device handling —
-        an ophyd-specific attribute the minimal setters intentionally omit.
+        write list top to bottom, **each write completing before the next**.
+        Legacy single-device controllers write only the variables with a
+        non-empty value for *state*, concurrently, then wait.  Uses
+        ``bps.abs_set`` + ``bps.wait`` rather than ``bps.mv`` because
+        ``bps.mv`` inspects ``.parent``, which the minimal setters omit.
         """
         if self._transitions is not None:
             name = state.value if isinstance(state, ShotControlState) else str(state)

--- a/GeecsBluesky/pyproject.toml
+++ b/GeecsBluesky/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-bluesky"
-version = "0.27.0"
+version = "0.27.1"
 description = "Bluesky / ophyd-async bridge for the GEECS control system"
 authors = ["Sam Barber <sbarber@lbl.gov>"]
 readme = "README.md"

--- a/GeecsCAGateway/CHANGELOG.md
+++ b/GeecsCAGateway/CHANGELOG.md
@@ -3,6 +3,19 @@
 All notable changes to `geecs-ca-gateway` are documented here, following
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and semantic versioning.
 
+## [0.12.1] - 2026-07-10
+
+Cleanup pass 2 (docstrings/comments only; AST-verified no code change).
+
+### Changed
+
+- `config.py`: the deadband-vs-tolerance incident retelling condensed to the
+  rule + a CLAUDE.md-quirks pointer (the rule itself — deadband stays 0.0,
+  DB `tolerance` is a set-convergence criterion — is unchanged). The
+  wire-protocol and DB-inheritance commentary in `transport/`, `channels.py`,
+  `db/geecs_db.py`, and `gateway.py` was deliberately left intact (audit:
+  load-bearing, canonical only in code).
+
 ## [0.12.0] - 2026-07-10
 
 Cleanup pass 1 (audit: `Planning/cleanup_vision_v1/00_overview.md`) — no

--- a/GeecsCAGateway/geecs_ca_gateway/config.py
+++ b/GeecsCAGateway/geecs_ca_gateway/config.py
@@ -254,15 +254,10 @@ class DeviceSpec(BaseModel):
                     # column (see CHANGELOG / design note — a deliberate
                     # on-network follow-up); absent today → "" and inert.
                     description=meta.get("description") or "",
-                    # NOT the DB "tolerance": that is a *set convergence*
-                    # criterion (often coarse, e.g. 0.05 A on magnet PSUs) and
-                    # using it as a monitor deadband hides real sub-tolerance
-                    # motion from readback PVs — and therefore from every
-                    # recorded event row and s-file (observed live: a magnet
-                    # move within tolerance left the readback frozen).
-                    # Deadband 0.0 posts every changed frame and suppresses
-                    # only exact repeats; at the ~1-5 Hz GEECS stream rate
-                    # bandwidth is a non-issue.
+                    # Deadband stays 0.0 — the DB "tolerance" is a *set
+                    # convergence* criterion, NOT a monitor deadband; wiring
+                    # it here froze sub-tolerance motion out of readbacks
+                    # (shipped bug; see CLAUDE.md quirks).
                     deadband=0.0,
                 )
             )

--- a/GeecsCAGateway/pyproject.toml
+++ b/GeecsCAGateway/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-ca-gateway"
-version = "0.12.0"
+version = "0.12.1"
 description = "EPICS Channel Access soft-IOC gateway exposing GEECS devices as PVs"
 authors = ["Sam Barber <sbarber@lbl.gov>"]
 readme = "README.md"

--- a/Planning/cleanup_vision_v1/00_overview.md
+++ b/Planning/cleanup_vision_v1/00_overview.md
@@ -51,26 +51,46 @@ semantics).
   runner; zero shared privates with execution code). Both names re-exported
   from `scan_request_runner` so the existing import surface is unchanged.
 
-## PR 2 (planned): the docstring pass
+## PR 2 (landed): the docstring pass
 
-The runner is a ~760-line module wearing an 844-line docstring coat; package
-wide ~1,000 doc lines are removable with zero contract loss. Rules:
+~880 net doc lines removed across 28 files (every file AST-verified
+code-identical). The rules that governed it — and still govern future doc
+edits in these packages:
 
 - Docstrings state the **contract** (what/args/returns/raises + non-obvious
   invariant), numpy style, concise.
 - Design **why**/history/verification anecdotes live in the package
-  `CLAUDE.md` or `Planning/` — most already do; the code copy shrinks to a
-  one-line pointer. Every load-bearing warning ("accepted window, do not
-  fix", "never gate a shot on telemetry", "do not regress to
-  datatype=float") is already in `GeecsBluesky/CLAUDE.md` — cut the code
-  copy, never the CLAUDE.md copy.
-- Known duplication hotspots: the save-set union rule (written out 4×),
-  db_runtime module docstring (≈ verbatim CLAUDE.md M3c), single_shot's
-  40-line RunEngine source quote, action_compiler legacy-equivalence told
-  3×, the Gate-2 orphan-frame essay in every plan file.
-- Gateway: light touch only — condense `udp_client`'s thrice-stated exe-reply
-  correlation rationale and `config.py`'s incident retellings; **do not cut**
-  the wire-protocol/DB-inheritance semantics (see "keep" below).
+  `CLAUDE.md` or `Planning/` — the code copy is a one-line pointer. A
+  warning was only condensed after **verifying** its canonical copy exists
+  in CLAUDE.md; cut the code copy, never the CLAUDE.md copy.
+- LOC is a symptom, not a goal. Deliberately NOT cut despite being
+  "redundant" by line count: `udp_client.py`'s three correlation passages
+  (each carries a different load-bearing angle where a reader needs it),
+  `run_scan_request`'s dense contract docstring, `_defaults_flag`,
+  session's eight parallel factories.
+
+### Load-bearing warnings whose ONLY copy is the code (do not cut)
+
+Inventoried during the pass — these are NOT in CLAUDE.md and were kept:
+
+- `devices/ca/triggerable.py::_wait_for_shot` — cold-cache path has
+  deliberately no CA-get baseline (a baseline get raced the shot itself).
+- `devices/ca/triggerable.py::_on_acq_timestamp` — drop-oldest preserves the
+  no-blind-window guarantee; callback/consumers share the RE loop so the
+  two-step replace is race-free.
+- `devices/ca/triggerable.py::disconnect` — unsubscribing removes the cache's
+  callback reference, else per-scan device objects leak.
+- `plans/single_shot.py` — a straggling completion inside the next attempt is
+  caught by the same try and consumes one refire; no cancellation machinery
+  is needed.
+- `plans/free_run_step_scan.py` — a non-Triggerable reference silently
+  corrupts data (the `TypeError` rationale).
+- `plans/t0_sync.py` — never proceed unseeded; shot IDs from unsynchronized
+  t0s are not comparable.
+- `shot_controller.py::set_state` — `bps.abs_set` not `bps.mv` (mv inspects
+  `.parent`, which the minimal setters omit).
+- `devices/contributor.py::set_reference` — a bare Device attribute would
+  re-parent the pacemaker and `separate_devices` would silently drop it.
 
 ## Deliberately KEPT (do not "clean up" later)
 


### PR DESCRIPTION
Replaces #482 (auto-closed by GitHub when its stacked base branch was deleted on the #481 merge — same commit, now based directly on feat/vision-v1).

The docstring pass: **~880 net lines of documentation redundancy removed across 28 files** — GeecsBluesky 0.27.1 + GeecsCAGateway 0.12.1. Zero code change, mechanically proven: every modified `.py` is **AST-identical to its previous version with docstrings stripped**.

## The rule (recorded in `Planning/cleanup_vision_v1/00_overview.md`)

- Docstrings state the **contract**: what / args / raises + non-obvious invariants, numpy style.
- Design rationale/history/anecdotes whose canonical copy lives in `GeecsBluesky/CLAUDE.md` shrink to a one-line pointer — condensed only after **verifying** the CLAUDE.md copy exists.
- **LOC is a symptom, not a goal.** Deliberately left intact: `udp_client.py`'s three correlation passages (each load-bearing where it sits), `run_scan_request`'s dense contract docstring, session's eight parallel factories, all gateway wire-protocol/DB-inheritance commentary.
- **Warnings whose only copy is the code were kept verbatim** and inventoried in the audit doc (cold-cache baseline-get race, refire no-cancellation conclusion, `Reference()` re-parenting, never-proceed-unseeded t0, `abs_set`-not-`mv`, …).

## Highlights

- Save-set union rule stated **once** (on `merge_save_sets`) instead of 4×; `scan_request_runner.py` now 1,939 → **1,180** lines across the two passes.
- `db_runtime.py` module docstring no longer duplicates CLAUDE.md M3c; `single_shot.py`'s 40-line RunEngine source quote → 8-line conclusion; `action_compiler.py`'s legacy-equivalence told once instead of 3×.
- Stale claims fixed: `settable.py`/`motor.py` no longer describe the shipped `CaConfirmSettable` as future work; `shot_id.py` no longer references the deleted `geecs_device.GeecsDevice`.

## Verification

- AST-neutrality: **28/28 modified files NEUTRAL** (docstring-stripped ASTs identical)
- GeecsBluesky: **407 passed**, 1 skipped · GeecsCAGateway: **158 passed**
- ruff / ruff-format / pydocstyle (numpy) all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)