### PR TITLE
fix(gateway): coerce_scalar passes non-finite numerics through as raw string

### DIFF
--- a/GeecsCAGateway/CHANGELOG.md
+++ b/GeecsCAGateway/CHANGELOG.md
@@ -3,6 +3,16 @@
 All notable changes to `geecs-ca-gateway` are documented here, following
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and semantic versioning.
 
+## [0.12.2] - 2026-07-10
+
+### Fixed
+
+- `transport/_coerce.coerce_scalar` no longer crashes with an uncaught
+  `OverflowError` on infinite numeric wire values (`"inf"`, `"1e400"`, ...):
+  non-finite numerics now pass through as the raw string, matching the
+  existing `"nan"` behavior. Latent since the original inline copies;
+  found in the PR #481 adversarial review.
+
 ## [0.12.1] - 2026-07-10
 
 Cleanup pass 2 (docstrings/comments only; AST-verified no code change).

--- a/GeecsCAGateway/geecs_ca_gateway/transport/_coerce.py
+++ b/GeecsCAGateway/geecs_ca_gateway/transport/_coerce.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import math
 from typing import Any
 
 
@@ -10,9 +11,12 @@ def coerce_scalar(s: str) -> Any:
 
     Lossy for text that merely *looks* numeric (``'007'`` → ``7``) — string-typed
     variables must bypass this (the subscriber's ``text_variables`` parameter).
+    Non-finite numerics (``inf``/``nan``) pass through as the raw string.
     """
     try:
         f = float(s)
-        return int(f) if f == int(f) and "." not in s else f
     except ValueError:
         return s
+    if not math.isfinite(f):
+        return s
+    return int(f) if f == int(f) and "." not in s else f

--- a/GeecsCAGateway/pyproject.toml
+++ b/GeecsCAGateway/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-ca-gateway"
-version = "0.12.1"
+version = "0.12.2"
 description = "EPICS Channel Access soft-IOC gateway exposing GEECS devices as PVs"
 authors = ["Sam Barber <sbarber@lbl.gov>"]
 readme = "README.md"

--- a/GeecsCAGateway/tests/test_coerce.py
+++ b/GeecsCAGateway/tests/test_coerce.py
@@ -1,0 +1,74 @@
+"""Tests for wire-value coercion."""
+
+from __future__ import annotations
+
+
+from geecs_ca_gateway.transport._coerce import coerce_scalar
+
+
+class TestCoerceScalar:
+    """Test coerce_scalar behavior across numeric and non-numeric inputs."""
+
+    def test_integer_string(self) -> None:
+        """Integer strings coerce to int."""
+        assert coerce_scalar("5") == 5
+        assert coerce_scalar("0") == 0
+        assert coerce_scalar("-42") == -42
+
+    def test_leading_zeros(self) -> None:
+        """Leading zeros are dropped (lossy)."""
+        assert coerce_scalar("007") == 7
+        assert coerce_scalar("0005") == 5
+
+    def test_float_string_with_decimal(self) -> None:
+        """Floats with decimal points stay as floats."""
+        assert coerce_scalar("5.0") == 5.0
+        assert coerce_scalar("3.14") == 3.14
+        assert coerce_scalar("-2.5") == -2.5
+
+    def test_scientific_notation_whole(self) -> None:
+        """Scientific notation that resolves to a whole number returns int."""
+        # "1e5" = 100000.0, which equals int(100000), and has no "."
+        result = coerce_scalar("1e5")
+        assert result == 100000
+        assert isinstance(result, int)
+
+    def test_scientific_notation_fractional(self) -> None:
+        """Scientific notation with fractional exponent returns float."""
+        result = coerce_scalar("1.5e2")
+        assert result == 150.0
+        assert isinstance(result, float)
+
+    def test_non_numeric_string(self) -> None:
+        """Non-numeric strings pass through unchanged."""
+        assert coerce_scalar("abc") == "abc"
+        assert coerce_scalar("hello") == "hello"
+        assert coerce_scalar("") == ""
+
+    def test_positive_infinity(self) -> None:
+        """Positive infinity passes through as raw string."""
+        assert coerce_scalar("inf") == "inf"
+        assert coerce_scalar("Infinity") == "Infinity"
+
+    def test_negative_infinity(self) -> None:
+        """Negative infinity passes through as raw string."""
+        assert coerce_scalar("-inf") == "-inf"
+        assert coerce_scalar("-Infinity") == "-Infinity"
+
+    def test_large_exponent_infinity(self) -> None:
+        """Sufficiently large exponent that overflows to infinity passes through."""
+        assert coerce_scalar("1e400") == "1e400"
+
+    def test_nan(self) -> None:
+        """NaN passes through as raw string (pre-existing behavior)."""
+        assert coerce_scalar("nan") == "nan"
+        assert coerce_scalar("NaN") == "NaN"
+
+    def test_mixed_case_infinity(self) -> None:
+        """Case variations of infinity are handled."""
+        # Python's float() accepts "inf" and "Infinity" (case-insensitive on some platforms)
+        result_1 = coerce_scalar("inf")
+        result_2 = coerce_scalar("INF")
+        # Both should pass through as strings (non-finite)
+        assert isinstance(result_1, str)
+        assert isinstance(result_2, str)


### PR DESCRIPTION
## Summary

- Fixed latent `OverflowError` crash in `coerce_scalar` when encountering infinite numeric wire values (`"inf"`, `"1e400"`, etc.). The bug predates the shared helper; all three original inline copies had it.
- Non-finite numerics (`inf`/`nan`) now pass through as raw strings, matching existing `"nan"` behavior.
- Added comprehensive test coverage for all numeric coercion paths including edge cases.

## Test Coverage

Created `tests/test_coerce.py` with 11 test cases covering:
- Integer strings (`"5"` → 5)
- Floats with decimals (`"5.0"` → 5.0)
- Scientific notation (`"1e5"` → 100000, `"1e400"` → `"1e400"`)
- Non-numeric strings (`"abc"` → `"abc"`)
- Non-finite values (`"inf"` → `"inf"`, `"-inf"` → `"-inf"`, `"nan"` → `"nan"`)

All 169 tests pass (158 existing + 11 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)