### PR TITLE
feat(bridge): M4 step (i) — bridge delegates ScanRequest execution to run_scan_request

### DIFF
--- a/GeecsBluesky/CHANGELOG.md
+++ b/GeecsBluesky/CHANGELOG.md
@@ -4,6 +4,50 @@ All notable changes to `geecs-bluesky` are documented here.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.28.0] - 2026-07-10
+
+M4 step (i) — the GUI bridge reaches ScanRequest parity
+(`Planning/gui_retrofit/00_overview.md` §3–4).
+
+### Changed
+
+- **`BlueskyScanner` delegates ScanRequest execution to `run_scan_request`.**
+  `_reinitialize_from_scan_request` no longer synthesizes a legacy
+  scan-config namespace: it validates every referenced name fail-fast
+  (defaults, actions, save sets + rituals, trigger profile, scan variables)
+  and stores the **original pre-defaults** request; the scan thread then
+  runs it through the one engine definition — actions, entry rituals,
+  multi-axis grids, db_scalars, and telemetry now all run through the GUI
+  bridge. The legacy `exec_config` path is untouched.
+- **Two new optional runner hooks on `run_scan_request`** (headless callers
+  unchanged): `preflight(detectors, strict) -> list | None` — the
+  scanner-layer operator-dialog seam, called pre-claim with the fully
+  assembled detector list (`None` aborts; a reduced list is honored) — and
+  `on_scan_start(total_steps, total_shots)` — the GUI progress-totals seam.
+  Neither is called on the optimize path (an optimize preflight is a later
+  seam).
+- The bridge's preflight pipeline gained `disconnect_on_drop=False` for the
+  delegated path (the runner's `finally` owns disconnection there); the
+  exec_config path is byte-identical (default `True`).
+- The retired byte-parity pin (request noscan ≡ synthesized exec_config) is
+  replaced by the delegation-parity pin: a request through the bridge
+  produces `session.scan` kwargs identical to headless `run_scan_request`
+  (and the bridge never pre-claims — `session.scan` owns the claim and
+  self-attaches `scan.log`).
+
+### Removed
+
+- The now-orphaned GUI-refusal cluster: `raise_if_actions_present`,
+  `resolve_save_sets_checked`, and `MULTI_AXIS_MESSAGE` (their only callers
+  were the bridge refusals this release removes), plus the bridge's
+  `_request_step` machinery and `_run_request_step_scan`.
+
+### Retained
+
+- The optimize-mode refusal at `reinitialize(ScanRequest)` — wiring the
+  GUI's `optimization_loader` into the delegated path is GUI-submission
+  step (iii).
+
 ## [0.27.1] - 2026-07-10
 
 Cleanup pass 2 — the docstring condensation (audit:

--- a/GeecsBluesky/CLAUDE.md
+++ b/GeecsBluesky/CLAUDE.md
@@ -151,8 +151,10 @@ adds a staleness stage for the trigger-must-be-free-running requirement)
 (all defensive imports — headless
 installs without geecs_scanner just skip emission).  `DeviceCommandEvent`
 translation is deliberately skipped (no consumer).  Still not done in
-Bluesky mode: `ActionControl` / setup-closeout actions (see
-`Planning/gui_stewardship/00_overview.md`).  Acquisition mode is chosen by
+Bluesky mode: `ActionControl` / setup-closeout actions on the legacy
+`exec_config` path (ScanRequest submissions execute actions via the
+delegated runner — see the engine-consolidation section).  Acquisition
+mode is chosen by
 the `GEECS_BLUESKY_ACQUISITION_MODE` env var — there is no GUI toggle for it
 (intentional; bluesky is still being derisked).
 
@@ -415,9 +417,20 @@ action hooks yet, so the actions (request, experiment defaults, and
 save-set rituals) are skipped, logged (WARNING), and recorded in run
 metadata under `skipped_action_plans` (refusing would block every
 optimization the moment an experiment defines default bracket actions;
-unknown names still fail fast).  The GUI bridge's `reinitialize(ScanRequest)` still refuses
-actions/multi-axis with a pointer to `GeecsSession.run` — routing them
-through the bridge is the GUI submission milestone.  Experiment defaults
+unknown names still fail fast).  **As of 0.28.0 (M4 step i) the GUI bridge
+delegates ScanRequest execution to `run_scan_request`**:
+`reinitialize(ScanRequest)` validates every name fail-fast (discarding the
+results) and stores the **original pre-defaults** request; the scan thread
+runs it through the one engine definition, so actions, entry rituals,
+multi-axis grids, db_scalars, and telemetry all execute through the bridge
+too.  The bridge contributes its two seams via runner hooks:
+`preflight(detectors, strict)` (operator-dialog pipeline, pre-claim,
+`None` aborts; dropped devices are left connected — the runner's `finally`
+owns disconnection) and `on_scan_start(total_steps, total_shots)` (GUI
+progress totals).  The bridge never pre-claims on this path —
+`session.scan` claims and self-attaches `scan.log`.  Optimize-mode
+requests are still refused at reinitialize until GUI-submission step (iii)
+wires the `optimization_loader` into the delegated path.  Experiment defaults
 (`experiment_defaults.yaml`) fill request fields left unset — never
 overriding explicit values — and every applied default is recorded into
 the run metadata for provenance (closeout defaults append *after* the
@@ -441,9 +454,9 @@ deduped by plan name so a shared ritual runs once
 merged set: `save_set_to_devices_config`, the reserved-boundary warning, and —
 crucially — **telemetry exclusion** (`select_telemetry_variables` gets the
 merged set, so Tier-2 telemetry excludes devices in *any* named set).  Run
-metadata records the list under `save_sets`.  The GUI bridge is list-aware via
-`resolve_save_sets_checked` (unions devices; still refuses entry rituals /
-actions / multi-axis — those remain a later GUI-submission milestone).
+metadata records the list under `save_sets`.  The GUI bridge delegates to
+`run_scan_request` (0.28.0), so the union — entry rituals included —
+applies identically through the bridge.
 
 **M3c (0.24.0) — the DB-integration runtime tier, GET-SIDE ONLY.**  Two
 get-side capabilities are live, all gated by schema flags that already
@@ -538,7 +551,8 @@ Remaining items are features/tuning, not architecture — see
   geecs_scanner import (dependency direction).
 - **Pre/post-scan action sequences run on the ScanRequest path only.**
   `GeecsSession.run(request)` executes setup/per_step/closeout ActionPlans
-  (0.23.0); the legacy `exec_config` path and the GUI bridge still skip
+  (0.23.0), and since 0.28.0 the GUI bridge's delegated ScanRequest path
+  does too; the legacy `exec_config` path still skips
   `setup_action` / `closeout_action` (legacy elements' actions *are*
   executed when the element is resolved as a save set through a
   ScanRequest — the converter extracts them into entry rituals).

--- a/GeecsBluesky/geecs_bluesky/scan_request_runner.py
+++ b/GeecsBluesky/geecs_bluesky/scan_request_runner.py
@@ -69,15 +69,6 @@ from geecs_schemas.action_plan import CheckStep, RunPlanStep, SetStep
 
 logger = logging.getLogger(__name__)
 
-#: GUI-bridge refusal (the *bridge* still stages requests through the legacy
-#: exec-config machinery; the engine itself executes grids — see
-#: ``run_scan_request``).
-MULTI_AXIS_MESSAGE = (
-    "the GUI bridge does not execute multi-axis grids yet — run the request "
-    "headless via GeecsSession.run, where grid execution landed with the "
-    "M3b milestone; GUI submission is a later milestone"
-)
-
 
 # The resolver layer (ConfigResolver protocol + the production
 # ConfigsRepoResolver) lives in geecs_bluesky.config_resolver; the names
@@ -238,8 +229,7 @@ def resolve_and_validate_actions(
 
     Fail-fast, pre-claim: each name must exist (the resolver raises
     otherwise) before any hardware is touched.  The engine then compiles
-    and executes the assembled slots (:func:`assemble_action_slots`); the
-    GUI bridge still refuses them (:func:`raise_if_actions_present`).
+    and executes the assembled slots (:func:`assemble_action_slots`).
 
     Parameters
     ----------
@@ -260,23 +250,6 @@ def resolve_and_validate_actions(
             resolver.resolve_action_plan(name)
         resolved[slot] = names
     return resolved
-
-
-def raise_if_actions_present(resolved: dict[str, list[str]]) -> None:
-    """Refuse validated action bindings — **GUI-bridge path only**.
-
-    The engine executes actions (see :func:`run_scan_request`); the GUI
-    bridge still stages requests through the legacy exec-config machinery
-    and does not run them yet.  Names were already resolved and are valid.
-    """
-    present = {slot: names for slot, names in resolved.items() if names}
-    if present:
-        raise NotImplementedError(
-            f"the GUI bridge does not execute action bindings yet — run the "
-            f"request headless via GeecsSession.run (action execution landed "
-            f"with the M3b milestone); the request's action names were "
-            f"resolved and are valid: {present}"
-        )
 
 
 # ---------------------------------------------------------------------------
@@ -588,26 +561,6 @@ def compile_action_slot(
     return _slot_plan, plans
 
 
-def resolve_save_sets_checked(resolver: ConfigResolver, names: list[str]) -> SaveSet:
-    """Resolve and union several save sets, refusing rituals — **GUI-bridge only**.
-
-    Rituals are *validated* first (unknown names fail loudly), then refused —
-    the bridge does not execute them yet.  Returns the unioned save set
-    (guaranteed free of entry-level actions).
-    """
-    save_set, rituals = resolve_save_sets_and_rituals(resolver, names)
-    entry_actions = [n for slot in rituals.values() for n in slot]
-    if entry_actions:
-        raise NotImplementedError(
-            f"the GUI bridge does not execute save-set entry rituals yet — "
-            f"run the request headless via GeecsSession.run (ritual "
-            f"execution landed with the M3b milestone); save sets {names!r} "
-            f"reference entry-level setup/closeout plans, which were "
-            f"resolved and are valid: {entry_actions}"
-        )
-    return save_set
-
-
 def apply_experiment_defaults(
     request: ScanRequest, defaults: Any | None
 ) -> tuple[ScanRequest, dict[str, Any]]:
@@ -892,6 +845,8 @@ def run_scan_request(
     *,
     objective: Any | None = None,
     suggester: Any | None = None,
+    preflight: Callable[[list, bool], list | None] | None = None,
+    on_scan_start: Callable[[int, int], None] | None = None,
 ) -> str | None:
     """Execute *request* on *session*; return the run uid.
 
@@ -923,6 +878,18 @@ def run_scan_request(
         Required for ``optimize`` mode (see the module docstring's gap
         list): the evaluator/generator specs cannot be instantiated in this
         package.
+    preflight :
+        Optional scanner-layer hook (the GUI bridge's operator-dialog
+        seam), called pre-claim with the fully assembled detector list and
+        a strict flag: ``preflight(detectors, strict) -> list | None``.
+        The returned (possibly reduced) list becomes the scan's detectors;
+        ``None`` aborts the run (created devices are still disconnected).
+        Not called on the optimize path — an optimize preflight is a later
+        seam.  Headless callers omit it (behavior unchanged when ``None``).
+    on_scan_start :
+        Optional progress-totals hook (the GUI bridge's progress seam),
+        called with ``(total_steps, total_shots)`` immediately before the
+        session scan starts.  Not called on the optimize path.
 
     Returns
     -------
@@ -1038,6 +1005,18 @@ def run_scan_request(
             detectors = list(detectors) + telemetry_readables
             created.extend(telemetry_readables)
 
+        if preflight is not None:
+            # Scanner-layer seam (operator dialogs): runs pre-claim by
+            # construction — the claim happens inside session.scan below.
+            checked = preflight(detectors, mode == "strict")
+            if checked is None:
+                logger.warning(
+                    "ScanRequest preflight aborted the scan (pre-claim; no "
+                    "scan number was burned)"
+                )
+                return None
+            detectors = list(checked)
+
         md: dict[str, Any] = {"scan_request_mode": request.mode.value}
         # Provenance: which named save sets were unioned for this scan.
         md["save_sets"] = list(request.save_sets)
@@ -1060,6 +1039,8 @@ def run_scan_request(
 
         if request.mode is ScanRequestMode.NOSCAN:
             scan_info["scan_mode"] = "noscan"
+            if on_scan_start is not None:
+                on_scan_start(1, request.shots_per_step)
             return session.scan(
                 detectors=detectors,
                 motor=None,
@@ -1105,6 +1086,8 @@ def run_scan_request(
             scan_info["start"] = outer[0]
             scan_info["end"] = outer[-1]
             scan_info["step"] = (outer[1] - outer[0]) if len(outer) > 1 else 0
+        if on_scan_start is not None:
+            on_scan_start(len(positions), len(positions) * request.shots_per_step)
         return session.scan(
             detectors=detectors,
             motor=motor_arg,

--- a/GeecsBluesky/geecs_bluesky/scanner_bridge/bluesky_scanner.py
+++ b/GeecsBluesky/geecs_bluesky/scanner_bridge/bluesky_scanner.py
@@ -74,16 +74,12 @@ from geecs_bluesky.preflight import (
     run_preflight,
 )
 from geecs_bluesky.scan_request_runner import (
-    MULTI_AXIS_MESSAGE,
     ConfigResolver,
     ConfigsRepoResolver,
-    raise_if_actions_present,
     resolve_and_validate_actions,
     resolve_defaults_for,
-    resolve_movable_target,
-    resolve_save_sets_checked,
-    save_set_to_devices_config,
-    trigger_writes_from_profile,
+    resolve_save_sets_and_rituals,
+    run_scan_request,
 )
 from geecs_bluesky.scan_log import scan_log
 from geecs_bluesky.session import GeecsSession, _positions
@@ -211,8 +207,9 @@ class BlueskyScanner:
         self._optimization_loader = optimization_loader
         # ScanRequest entry (the acceptance seam of the schema milestone):
         # set by reinitialize(ScanRequest); None on the exec_config path.
+        # The scan thread delegates a stored request to run_scan_request.
         self._scan_request: ScanRequest | None = None
-        self._request_step: dict[str, Any] | None = None
+        self._request_resolver: ConfigResolver | None = None
 
         # Catch a stale env loudly rather than silently changing behavior.
         legacy_backend = os.environ.get("GEECS_BLUESKY_DEVICE_BACKEND")
@@ -277,7 +274,7 @@ class BlueskyScanner:
                 exec_config, resolver=_kwargs.get("resolver")
             )
         self._scan_request = None
-        self._request_step = None
+        self._request_resolver = None
         self._scan_config = exec_config.scan_config
 
         # Derive shots from rep_rate × wait_time (ScanOptions has no shots_per_step field)
@@ -315,113 +312,64 @@ class BlueskyScanner:
     def _reinitialize_from_scan_request(
         self, request: ScanRequest, resolver: ConfigResolver | None = None
     ) -> bool:
-        """Map a ScanRequest onto the scanner's internal exec-config shapes.
+        """Validate a ScanRequest fail-fast and store it for delegated execution.
 
-        Names are resolved **fail-fast here**, and a legacy-shaped
-        scan-config namespace is synthesized so the scan thread runs
-        byte-identically to the exec_config path (pinned by the noscan
-        parity test).  ``shots_per_step`` maps onto the legacy ``wait_time``
-        slot (ScanInfo quirk; identical metadata at the 1 Hz identity rep
-        rate); ``acquisition`` comes from the request — deliberately no env
-        override, a request declares intent.  Actions / multi-axis /
-        optimize are validated then refused (``NotImplementedError``) — run
-        those headless via ``GeecsSession.run`` until the GUI-submission
-        milestone routes them through this bridge.
+        The scan thread hands a stored request to
+        :func:`~geecs_bluesky.scan_request_runner.run_scan_request` (see
+        :meth:`_run_delegated_request`), so the full schema surface —
+        actions, entry rituals, multi-axis grids, db_scalars, telemetry —
+        runs through the one engine definition.  This method only (a)
+        resolves every referenced name so the GUI gets an immediate error,
+        discarding the results, and (b) stores state.  The **original**
+        pre-defaults request is stored — ``run_scan_request`` applies
+        experiment defaults itself, so storing a post-defaults copy would
+        apply them twice.  ``acquisition`` comes from the request —
+        deliberately no env override, a request declares intent.  Optimize
+        mode is still refused: wiring the GUI's ``optimization_loader`` into
+        the delegated path is GUI-submission step (iii).
 
         Returns ``True`` (matching :meth:`reinitialize`).
         """
-        from types import SimpleNamespace
-
         if resolver is None:
             resolver = ConfigsRepoResolver(self._experiment_dir)
 
-        request, applied_defaults = resolve_defaults_for(resolver, request)
-        if applied_defaults:
-            # Provenance: which experiment defaults filled unset fields (the
-            # stored self._scan_request is the post-defaults request).
-            logger.info(
-                "ScanRequest: applied experiment defaults: %s", applied_defaults
-            )
-
-        raise_if_actions_present(
-            resolve_and_validate_actions(request.actions, resolver)
-        )
-        if request.mode is ScanRequestMode.STEP and len(request.axes) > 1:
-            raise NotImplementedError(MULTI_AXIS_MESSAGE)
         if request.mode is ScanRequestMode.OPTIMIZE:
             raise NotImplementedError(
                 "optimize-mode ScanRequest execution through BlueskyScanner "
-                "lands with the GUI submission milestone — the scanner's "
-                "optimization path is driven by the GUI-injected "
-                "optimization_loader; use GeecsSession.run(request, "
-                "resolver, objective=..., suggester=...) headless"
+                "lands with GUI-submission step (iii), which wires the "
+                "GUI-injected optimization_loader into the delegated path; "
+                "use GeecsSession.run(request, resolver, objective=..., "
+                "suggester=...) headless"
             )
 
+        # Fail-fast validation on a LOCAL post-defaults copy; every result
+        # is discarded — run_scan_request re-resolves at execution time.
+        validated, _applied = resolve_defaults_for(resolver, request)
+        resolve_and_validate_actions(validated.actions, resolver)
+        if not validated.save_sets:
+            raise GeecsConfigurationError(
+                f"a {request.mode.value!r} ScanRequest needs at least one "
+                "save set in save_sets — without one the scan would record "
+                "nothing"
+            )
+        resolve_save_sets_and_rituals(resolver, validated.save_sets)
+        if validated.trigger_profile:
+            resolver.resolve_trigger_profile(validated.trigger_profile)
+        if validated.mode is ScanRequestMode.STEP:
+            for axis in validated.axes:
+                resolver.resolve_scan_variable(axis.variable)
+
+        # Store the ORIGINAL pre-defaults request (see docstring).
+        self._scan_request = request
+        self._request_resolver = resolver
+        self._scan_config = None
+        self._devices_config = {}
         self._acquisition_mode = (
             _FREE_RUN_MODE
             if request.acquisition is AcquisitionMode.FREE_RUN
             else _STRICT_MODE
         )
         self._shots_per_step = int(request.shots_per_step)
-
-        if not request.save_sets:
-            raise GeecsConfigurationError(
-                f"a {request.mode.value!r} ScanRequest needs at least one "
-                "save set in save_sets — without one the scan would record "
-                "nothing"
-            )
-        # Multiple named save sets union into one effective device set.
-        save_set = resolve_save_sets_checked(resolver, request.save_sets)
-        self._devices_config = save_set_to_devices_config(save_set)
-
-        if request.trigger_profile:
-            profile = resolver.resolve_trigger_profile(request.trigger_profile)
-            # Generalized multi-device ordered writes (TriggerProfile
-            # semantics); GeecsSession.shot_control builds the ordered
-            # controller from these.
-            self._shot_control = trigger_writes_from_profile(
-                profile, request.trigger_variant
-            )
-        else:
-            self._shot_control = None
-
-        if request.mode is ScanRequestMode.NOSCAN:
-            self._request_step = None
-            self._scan_config = SimpleNamespace(
-                scan_mode="noscan",
-                device_var=None,
-                start=0.0,
-                end=0.0,
-                step=0.0,
-                wait_time=request.shots_per_step,
-                additional_description=request.description,
-                background=request.background,
-            )
-        else:
-            axis = request.axes[0]
-            spec = resolver.resolve_scan_variable(axis.variable)
-            device, variable, kind, _confirm = resolve_movable_target(
-                spec, axis.variable
-            )
-            positions = axis.positions.to_values()
-            self._request_step = {
-                "device": device,
-                "variable": variable,
-                "kind": kind,
-                "positions": positions,
-            }
-            self._scan_config = SimpleNamespace(
-                scan_mode="standard",
-                device_var=f"{device}:{variable}",
-                start=positions[0],
-                end=positions[-1],
-                step=(positions[1] - positions[0]) if len(positions) > 1 else 0.0,
-                wait_time=request.shots_per_step,
-                additional_description=request.description,
-                background=request.background,
-            )
-
-        self._scan_request = request
         self._completed_shots = 0
         self._total_shots = 0
         self._total_steps = 0
@@ -432,11 +380,11 @@ class BlueskyScanner:
 
         logger.info(
             "BlueskyScanner reinitialised from ScanRequest — mode=%s, "
-            "acquisition=%s, shots_per_step=%d, devices=%s",
+            "acquisition=%s, shots_per_step=%d, save_sets=%s",
             request.mode.value,
             self._acquisition_mode,
             self._shots_per_step,
-            list(self._devices_config),
+            list(request.save_sets),
         )
         return True
 
@@ -790,23 +738,32 @@ class BlueskyScanner:
             )
         )
 
-    def _drop_devices(self, detectors: list, drop_ids: set[int]) -> list:
-        """Disconnect and remove the given devices (operator chose drop)."""
+    def _drop_devices(
+        self, detectors: list, drop_ids: set[int], *, disconnect: bool = True
+    ) -> list:
+        """Remove the given devices (operator chose drop), disconnecting by default.
+
+        ``disconnect=False`` is the delegated-request path: the runner's
+        ``finally`` owns disconnection of everything it created, so the drop
+        is logged but the device is left connected for that cleanup.
+        """
         for device in detectors:
             if id(device) in drop_ids:
                 logger.warning(
                     "Pre-flight: dropping device %s from this scan "
-                    "(operator chose drop-and-continue); disconnecting it",
+                    "(operator chose drop-and-continue)%s",
                     self._device_label(device),
+                    "; disconnecting it" if disconnect else "",
                 )
-                self._disconnect_device(device)
+                if disconnect:
+                    self._disconnect_device(device)
         remaining = [d for d in detectors if id(d) not in drop_ids]
         with self._device_lock:
             self._detectors = [d for d in self._detectors if id(d) not in drop_ids]
         return remaining
 
     def _preflight_check_sync_liveness(
-        self, detectors: list, *, strict: bool = False
+        self, detectors: list, *, strict: bool = False, disconnect_on_drop: bool = True
     ) -> list | None:
         """Pre-flight: catch dead sync devices before the claim (pipeline).
 
@@ -814,6 +771,8 @@ class BlueskyScanner:
         staleness), pre-claim so an abort burns no scan number.  Headless /
         no answer → proceed and fail loudly downstream.  The module-level
         knobs are read at call time — the hermetic tests monkeypatch them.
+        ``disconnect_on_drop=False`` (delegated-request path) keeps dropped
+        devices connected for the runner's own cleanup.
 
         Returns
         -------
@@ -824,7 +783,9 @@ class BlueskyScanner:
             detectors=detectors,
             strict=strict,
             read_liveness=self._read_gateway_liveness,
-            drop_devices=self._drop_devices,
+            drop_devices=lambda dets, ids: self._drop_devices(
+                dets, ids, disconnect=disconnect_on_drop
+            ),
             device_label=self._device_label,
             dialog_timeout=_PREFLIGHT_DIALOG_TIMEOUT_S,
         )
@@ -863,6 +824,11 @@ class BlueskyScanner:
         failed = False
         try:
             if self._abort_before_acquisition():
+                return
+            # ScanRequest path: delegate to the engine's request machinery
+            # (scan_config is None on this path — this guard runs first).
+            if getattr(self, "_scan_request", None) is not None:
+                self._run_delegated_request()
                 return
             mode = scan_config.scan_mode
             # Support both ScanMode enum and plain strings
@@ -904,50 +870,56 @@ class BlueskyScanner:
         with scan_log(scan_number, scan_folder):
             yield
 
-    def _run_request_step_scan(
-        self, scan_config: Any, request_step: dict[str, Any]
-    ) -> None:
-        """Step scan staged from a ScanRequest: kind-aware movable, explicit positions.
+    def _run_delegated_request(self) -> None:
+        """Run the stored ScanRequest through the engine's one definition.
 
-        Differs from :meth:`_run_standard_scan` only in what the request
-        already resolved: the movable honours the scan variable's ``kind``
-        (``motor`` → readback-polled :meth:`GeecsSession.motor`,
-        ``setpoint`` → :meth:`GeecsSession.settable`) and the positions come
-        from the axis (supporting explicit position lists, which the legacy
-        start/end/step shape cannot express).  Everything downstream is the
-        shared :meth:`_execute_scan` path.
+        Delegates to
+        :func:`~geecs_bluesky.scan_request_runner.run_scan_request`, so the
+        full schema surface (actions, entry rituals, multi-axis grids,
+        db_scalars, telemetry) executes identically to a headless
+        ``GeecsSession.run``.  The bridge contributes its two seams via the
+        runner hooks: the operator-dialog preflight
+        (:meth:`_delegated_preflight`) and the GUI progress totals
+        (:meth:`_on_delegated_scan_start`).  ``session.scan`` claims the
+        scan number itself on this path, and the session self-attaches
+        ``scan.log`` when *it* claimed — so the bridge must NOT pre-claim
+        here.  Exceptions propagate to :meth:`_run_scan`'s cleanup
+        (ABORTED state + disconnect).
         """
-        device = request_step["device"]
-        variable = request_step["variable"]
-        ophyd_name = safe_name(f"{device}_{variable}")
-        logger.info(
-            "Creating %s: %s / %s → name=%r",
-            request_step["kind"],
-            device,
-            variable,
-            ophyd_name,
+        request = self._scan_request
+        resolver = self._request_resolver or ConfigsRepoResolver(self._experiment_dir)
+        run_scan_request(
+            self._session,
+            request,
+            resolver,
+            preflight=self._delegated_preflight,
+            on_scan_start=self._on_delegated_scan_start,
         )
-        if request_step["kind"] == "motor":
-            movable = self._session.motor(device, variable, name=ophyd_name)
-        else:
-            movable = self._session.settable(device, variable, name=ophyd_name)
-        with self._device_lock:
-            self._motor = movable
 
-        extra_md: dict[str, Any] = {"device_var": scan_config.device_var}
-        if scan_config.additional_description:
-            extra_md["description"] = scan_config.additional_description
-        self._execute_scan(
-            scan_config, movable, list(request_step["positions"]), extra_md
+    def _delegated_preflight(self, detectors: list, strict: bool) -> list | None:
+        """Runner preflight hook: the operator-dialog pipeline, sans disconnect.
+
+        Same pipeline as the exec_config path, but dropped devices are not
+        disconnected here — on the delegated path the runner's ``finally``
+        owns disconnection of everything it created.  On abort (``None``)
+        the abort flag is set so the scan thread's cleanup reports ABORTED.
+        """
+        checked = self._preflight_check_sync_liveness(
+            detectors, strict=strict, disconnect_on_drop=False
         )
+        if checked is None:
+            self._abort_requested = True
+        return checked
+
+    def _on_delegated_scan_start(self, total_steps: int, total_shots: int) -> None:
+        """Runner totals hook: prime GUI progress and emit lifecycle states."""
+        self._total_steps = total_steps
+        self._total_shots = total_shots
+        self._set_state("INITIALIZING", total_shots=total_shots)
+        self._set_state("RUNNING")
 
     def _run_standard_scan(self, scan_config: Any) -> None:
         """Step scan: move a scan device through positions, collect shots each step."""
-        request_step = getattr(self, "_request_step", None)
-        if request_step is not None:
-            self._run_request_step_scan(scan_config, request_step)
-            return
-
         if not scan_config.device_var:
             logger.error("STANDARD scan requires device_var; got None")
             return

--- a/GeecsBluesky/geecs_bluesky/scanner_bridge/bluesky_scanner.py
+++ b/GeecsBluesky/geecs_bluesky/scanner_bridge/bluesky_scanner.py
@@ -78,8 +78,10 @@ from geecs_bluesky.scan_request_runner import (
     ConfigsRepoResolver,
     resolve_and_validate_actions,
     resolve_defaults_for,
+    resolve_movable_target,
     resolve_save_sets_and_rituals,
     run_scan_request,
+    trigger_writes_from_profile,
 )
 from geecs_bluesky.scan_log import scan_log
 from geecs_bluesky.session import GeecsSession, _positions
@@ -354,10 +356,16 @@ class BlueskyScanner:
             )
         resolve_save_sets_and_rituals(resolver, validated.save_sets)
         if validated.trigger_profile:
-            resolver.resolve_trigger_profile(validated.trigger_profile)
+            # Adapt (and discard) the writes so an unknown trigger_variant
+            # fails here, not in the scan thread.
+            profile = resolver.resolve_trigger_profile(validated.trigger_profile)
+            trigger_writes_from_profile(profile, validated.trigger_variant)
         if validated.mode is ScanRequestMode.STEP:
             for axis in validated.axes:
-                resolver.resolve_scan_variable(axis.variable)
+                # Resolve to an executable target so pseudo (composite)
+                # variables are refused here, not in the scan thread.
+                spec = resolver.resolve_scan_variable(axis.variable)
+                resolve_movable_target(spec, axis.variable)
 
         # Store the ORIGINAL pre-defaults request (see docstring).
         self._scan_request = request

--- a/GeecsBluesky/pyproject.toml
+++ b/GeecsBluesky/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-bluesky"
-version = "0.27.1"
+version = "0.28.0"
 description = "Bluesky / ophyd-async bridge for the GEECS control system"
 authors = ["Sam Barber <sbarber@lbl.gov>"]
 readme = "README.md"

--- a/GeecsBluesky/tests/test_bluesky_scanner_scan_request_seam.py
+++ b/GeecsBluesky/tests/test_bluesky_scanner_scan_request_seam.py
@@ -27,6 +27,7 @@ from geecs_schemas import (
     SaveSet,
     SaveSetEntry,
     ScanRequest,
+    PseudoScanVariable,
     ScanVariable,
     TriggerProfile,
 )
@@ -453,6 +454,44 @@ def test_unknown_action_name_still_fails_at_reinitialize() -> None:
     request = _noscan_request(actions={"setup": ["prep"]})
     with pytest.raises(GeecsConfigurationError, match="prep"):
         scanner.reinitialize(request, resolver=_resolver())  # name unknown
+
+
+def test_unknown_trigger_variant_fails_at_reinitialize() -> None:
+    """An unknown trigger_variant fails at reinitialize, not in the scan thread."""
+    profile = TriggerProfile(
+        name="HTU",
+        states={
+            "SCAN": [
+                {
+                    "device": "U_DG645_ShotControl",
+                    "variable": "Trigger.Source",
+                    "value": "External rising edges",
+                }
+            ]
+        },
+    )
+    scanner = _make_scanner(_FakeSession())
+    request = _noscan_request(trigger_profile="HTU", trigger_variant="typo")
+    with pytest.raises(GeecsConfigurationError, match="typo"):
+        scanner.reinitialize(
+            request, resolver=_resolver(trigger_profiles={"HTU": profile})
+        )
+
+
+def test_pseudo_scan_variable_fails_at_reinitialize() -> None:
+    """A pseudo (composite) variable is refused at reinitialize, not in the thread."""
+    pseudo = PseudoScanVariable(
+        kind="pseudo",
+        targets=[{"target": "U_X:Pos", "forward": "composite_var"}],
+        mode="absolute",
+    )
+    scanner = _make_scanner(_FakeSession())
+    request = _noscan_request(
+        mode="step",
+        axes=[{"variable": "combo", "positions": {"values": [0.0, 1.0]}}],
+    )
+    with pytest.raises(NotImplementedError, match="pseudo"):
+        scanner.reinitialize(request, resolver=_resolver(variables={"combo": pseudo}))
 
 
 def test_defaults_not_applied_twice(monkeypatch) -> None:

--- a/GeecsBluesky/tests/test_bluesky_scanner_scan_request_seam.py
+++ b/GeecsBluesky/tests/test_bluesky_scanner_scan_request_seam.py
@@ -1,11 +1,13 @@
-"""Tests for the BlueskyScanner ScanRequest entry (the acceptance seam).
+"""Tests for the BlueskyScanner ScanRequest entry (the delegation seam).
 
-``reinitialize`` duck-detects a :class:`~geecs_schemas.ScanRequest` and maps
-it onto the same internal machinery as the legacy ``exec_config`` path — the
-GUI keeps using ``exec_config`` untouched.  The **parity pin**: a ScanRequest
-noscan drives the exact same fake-session ``scan()`` call as the equivalent
-exec_config (at the legacy identity rep rate of 1 Hz, where the legacy
-``shots = rep_rate × wait_time`` derivation is invertible).
+``reinitialize`` duck-detects a :class:`~geecs_schemas.ScanRequest`,
+validates it fail-fast, and stores it; the scan thread then delegates to
+:func:`~geecs_bluesky.scan_request_runner.run_scan_request` so the full
+schema surface (actions, entry rituals, multi-axis grids) runs through the
+one engine definition.  The **parity pin**: a request submitted through the
+bridge produces ``session.scan`` kwargs identical to calling
+``run_scan_request`` headless on an equivalent fake session.  The bridge
+must not pre-claim a scan number on this path (``session.scan`` claims).
 """
 
 from __future__ import annotations
@@ -16,7 +18,8 @@ from types import SimpleNamespace
 import pytest
 
 from geecs_bluesky.exceptions import GeecsConfigurationError
-from geecs_bluesky.scan_request_runner import MULTI_AXIS_MESSAGE
+from geecs_bluesky.models.shot_control import ShotControlWrites
+from geecs_bluesky.scan_request_runner import run_scan_request
 from geecs_bluesky.scanner_bridge import bluesky_scanner
 from geecs_bluesky.scanner_bridge.bluesky_scanner import BlueskyScanner
 from geecs_schemas import (
@@ -59,14 +62,40 @@ class _FakeMovable:
         self.kind = kind
 
 
+class _FakeActionSignal:
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+
+class _FakeActionFactory:
+    """Recording SettableFactory for compiled action plans."""
+
+    def __init__(self) -> None:
+        self.settables: dict[tuple[str, str], _FakeActionSignal] = {}
+        self.readables: dict[tuple[str, str], _FakeActionSignal] = {}
+
+    def get_settable(self, device: str, variable: str) -> _FakeActionSignal:
+        return self.settables.setdefault(
+            (device, variable), _FakeActionSignal(f"{device}-{variable}")
+        )
+
+    def get_readable(self, device: str, variable: str) -> _FakeActionSignal:
+        return self.readables.setdefault(
+            (device, variable), _FakeActionSignal(f"{device}-{variable}")
+        )
+
+
 class _FakeSession:
-    """Records factory + scan calls (mirrors the pre-flight test fake)."""
+    """Records factory + scan calls (no ``experiment`` attr → no DB policy,
+    so telemetry stays off — M3b explicit-only behavior)."""
 
     def __init__(self) -> None:
         self.rep_rate_hz = 1.0
         self.scan_kwargs: dict | None = None
         self.shot_control_config = "unset"
         self.movables: list[_FakeMovable] = []
+        self.disconnected: list = []
+        self.action_factories: list[_FakeActionFactory] = []
 
     def detector(self, device, variables, *, save_images=False, name=None):
         return _FakeSyncDevice(device, name or device, "detector")
@@ -87,12 +116,20 @@ class _FakeSession:
         self.movables.append(movable)
         return movable
 
+    def action_signal_factory(self):
+        factory = _FakeActionFactory()
+        self.action_factories.append(factory)
+        return factory
+
     def shot_control(self, config):
         self.shot_control_config = config
 
     def scan(self, **kwargs):
         self.scan_kwargs = kwargs
         return "uid"
+
+    def disconnect(self, *devices):
+        self.disconnected.extend(devices)
 
 
 class _StubResolver:
@@ -104,11 +141,14 @@ class _StubResolver:
         trigger_profiles: dict | None = None,
         variables: dict | None = None,
         plans: dict | None = None,
+        defaults=None,
     ) -> None:
         self.save_sets = save_sets or {}
         self.trigger_profiles = trigger_profiles or {}
         self.variables = variables or {}
         self.plans = plans or {}
+        self.defaults = defaults
+        self.action_plan_resolutions: list[str] = []
 
     def resolve_save_set(self, name):
         try:
@@ -131,10 +171,14 @@ class _StubResolver:
             raise GeecsConfigurationError(f"scan variable {name!r} not found") from None
 
     def resolve_action_plan(self, name):
+        self.action_plan_resolutions.append(name)
         try:
             return self.plans[name]
         except KeyError:
             raise GeecsConfigurationError(f"action plan {name!r} not found") from None
+
+    def resolve_experiment_defaults(self):
+        return self.defaults
 
 
 def _make_scanner(session: _FakeSession) -> BlueskyScanner:
@@ -157,7 +201,7 @@ def _make_scanner(session: _FakeSession) -> BlueskyScanner:
     scanner._abort_requested = False
     scanner._optimization_loader = None
     scanner._scan_request = None
-    scanner._request_step = None
+    scanner._request_resolver = None
     scanner._scan_config = None
     scanner._RE = SimpleNamespace(
         state="idle", abort=lambda reason=None: None, _loop=None
@@ -173,6 +217,8 @@ _SAVE_SET = SaveSet(
         SaveSetEntry(device="U_Stage", scalars=["Pos"], role="snapshot"),
     ],
 )
+
+_WAIT_PLAN = ActionPlan.model_validate({"steps": [{"do": "wait", "seconds": 0.01}]})
 
 
 def _resolver(**overrides) -> _StubResolver:
@@ -200,81 +246,72 @@ def _normalize_scan_kwargs(kwargs: dict) -> dict:
     normalized["detectors"] = [
         (d._geecs_device_name, d.factory) for d in kwargs["detectors"]
     ]
-    if kwargs.get("motor") is not None:
+    motor = kwargs.get("motor")
+    if isinstance(motor, list):
+        normalized["motor"] = [
+            (m._geecs_device_name, m.variable, m.kind) for m in motor
+        ]
+    elif motor is not None:
         normalized["motor"] = (
-            kwargs["motor"]._geecs_device_name,
-            kwargs["motor"].variable,
-            kwargs["motor"].kind,
+            motor._geecs_device_name,
+            motor.variable,
+            motor.kind,
         )
+    # Compiled plan-stub callables can't be compared by value — compare
+    # their presence/None-ness (the plans behind them are pinned elsewhere).
+    for slot in ("setup", "per_step", "closeout"):
+        if slot in normalized:
+            normalized[slot] = normalized[slot] is not None
     return normalized
 
 
+def _noscan_request(**overrides) -> ScanRequest:
+    base = dict(
+        mode="noscan",
+        shots_per_step=3,
+        acquisition="free_run",
+        save_sets=["baseline"],
+        description="stats run",
+    )
+    base.update(overrides)
+    return ScanRequest.model_validate(base)
+
+
 # ---------------------------------------------------------------------------
-# THE parity pin: ScanRequest noscan ≡ exec_config noscan
+# THE parity pin: bridge-delegated request ≡ headless run_scan_request
 # ---------------------------------------------------------------------------
 
 
-def test_scan_request_noscan_parity_with_exec_config(monkeypatch) -> None:
-    """The two entry shapes drive identical fake-session scan() calls."""
-    monkeypatch.delenv("GEECS_BLUESKY_ACQUISITION_MODE", raising=False)
+def test_scan_request_delegation_parity_with_headless(monkeypatch) -> None:
+    """The bridge's delegated run produces session.scan kwargs identical to
+    calling run_scan_request headless on an equivalent fresh fake session —
+    and the bridge never pre-claims (session.scan owns the claim)."""
     claims: list = []
     _patch_claim(monkeypatch, claims)
+    request = _noscan_request()
 
-    # --- legacy exec_config path (1 Hz × 3 s wait → 3 shots) ---------------
-    exec_session = _FakeSession()
-    exec_scanner = _make_scanner(exec_session)
-    exec_config = SimpleNamespace(
-        scan_config=SimpleNamespace(
-            scan_mode="noscan",
-            device_var=None,
-            start=0.0,
-            end=0.0,
-            step=0.0,
-            wait_time=3.0,
-            additional_description="stats run",
-            background=False,
-        ),
-        options=SimpleNamespace(rep_rate_hz=1.0, acquisition_mode="free_run_time_sync"),
-        save_config=SimpleNamespace(
-            Devices={
-                "U_Ref": {"synchronous": True, "variable_list": ["Sig"]},
-                "U_Cam2": {
-                    "synchronous": True,
-                    "save_nonscalar_data": True,
-                    "variable_list": ["Val"],
-                },
-                "U_Stage": {"synchronous": False, "variable_list": ["Pos"]},
-            }
-        ),
-    )
-    assert exec_scanner.reinitialize(exec_config) is True
-    exec_scanner._run_scan(exec_scanner._scan_config)
+    bridge_session = _FakeSession()
+    scanner = _make_scanner(bridge_session)
+    assert scanner.reinitialize(request, resolver=_resolver()) is True
+    scanner._run_scan(scanner._scan_config)
 
-    # --- ScanRequest path ---------------------------------------------------
-    request_session = _FakeSession()
-    request_scanner = _make_scanner(request_session)
-    request = ScanRequest.model_validate(
-        {
-            "mode": "noscan",
-            "shots_per_step": 3,
-            "acquisition": "free_run",
-            "save_sets": ["baseline"],
-            "description": "stats run",
-        }
-    )
-    assert request_scanner.reinitialize(request, resolver=_resolver()) is True
-    request_scanner._run_scan(request_scanner._scan_config)
+    headless_session = _FakeSession()
+    run_scan_request(headless_session, request, _resolver())
 
-    assert exec_session.scan_kwargs is not None
-    assert request_session.scan_kwargs is not None
-    assert _normalize_scan_kwargs(request_session.scan_kwargs) == (
-        _normalize_scan_kwargs(exec_session.scan_kwargs)
+    assert bridge_session.scan_kwargs is not None
+    assert headless_session.scan_kwargs is not None
+    assert _normalize_scan_kwargs(bridge_session.scan_kwargs) == (
+        _normalize_scan_kwargs(headless_session.scan_kwargs)
     )
-    assert claims == ["TestExp", "TestExp"]
+    # The delegated path must NOT pre-claim: session.scan claims the number
+    # itself (and self-attaches scan.log when it claimed).
+    assert claims == []
+    # The runner's finally disconnects what it created, on both paths.
+    assert len(bridge_session.disconnected) == len(headless_session.disconnected) == 3
 
 
 # ---------------------------------------------------------------------------
-# Step scans through the seam
+# Step scans through the seam (delegated)
 # ---------------------------------------------------------------------------
 
 
@@ -307,14 +344,52 @@ def test_scan_request_step_uses_resolved_variable_kind(monkeypatch) -> None:
     assert kwargs["motor"]._geecs_device_name == "U_ESP_JetXYZ"
     assert kwargs["positions"] == [4.0, 4.5, 6.0]
     assert kwargs["shots_per_step"] == 2
-    # ScanInfo fields synthesized from the resolved axis
     assert kwargs["scan_info"]["scan_parameter"] == "U_ESP_JetXYZ:Position.Axis 3"
-    assert kwargs["scan_info"]["start"] == 4.0
-    assert kwargs["scan_info"]["end"] == 6.0
-    assert kwargs["md"]["device_var"] == "U_ESP_JetXYZ:Position.Axis 3"
+    assert kwargs["md"]["scan_variable"] == "jet_z"
+    assert claims == []
 
 
-def test_scan_request_trigger_profile_becomes_shot_control(monkeypatch) -> None:
+def test_multi_axis_request_delegates(monkeypatch) -> None:
+    """A 2-axis step request runs as an outer-product grid through the bridge."""
+    _patch_claim(monkeypatch, [])
+    session = _FakeSession()
+    scanner = _make_scanner(session)
+    resolver = _resolver(
+        variables={
+            "a": ScanVariable(target="U_X:Pos"),
+            "b": ScanVariable(target="U_Y:Pos"),
+        }
+    )
+    request = ScanRequest.model_validate(
+        {
+            "mode": "step",
+            "shots_per_step": 1,
+            "acquisition": "free_run",
+            "save_sets": ["baseline"],
+            "axes": [
+                {"variable": "a", "positions": {"start": 0, "end": 1, "step": 1}},
+                {"variable": "b", "positions": {"values": [4.0, 5.0]}},
+            ],
+        }
+    )
+    assert scanner.reinitialize(request, resolver=resolver) is True
+    scanner._run_scan(scanner._scan_config)
+
+    kwargs = session.scan_kwargs
+    assert kwargs is not None
+    assert [m._geecs_device_name for m in kwargs["motor"]] == ["U_X", "U_Y"]
+    assert kwargs["positions"] == [
+        (0.0, 4.0),
+        (0.0, 5.0),
+        (1.0, 4.0),
+        (1.0, 5.0),
+    ]
+    assert kwargs["md"]["scan_axes"] == ["a", "b"]
+
+
+def test_scan_request_trigger_profile_reaches_session(monkeypatch) -> None:
+    """The delegated run attaches the profile via session.shot_control."""
+    _patch_claim(monkeypatch, [])
     profile = TriggerProfile(
         name="HTU",
         states={
@@ -329,60 +404,148 @@ def test_scan_request_trigger_profile_becomes_shot_control(monkeypatch) -> None:
     )
     session = _FakeSession()
     scanner = _make_scanner(session)
-    request = ScanRequest.model_validate(
-        {
-            "mode": "noscan",
-            "shots_per_step": 1,
-            "acquisition": "free_run",
-            "save_sets": ["baseline"],
-            "trigger_profile": "HTU",
-        }
-    )
+    request = _noscan_request(shots_per_step=1, trigger_profile="HTU")
     scanner.reinitialize(request, resolver=_resolver(trigger_profiles={"HTU": profile}))
-    # Stored as generalized ordered writes (ShotControlWrites) — the shape
-    # GeecsSession.shot_control builds the ordered controller from.
-    assert scanner._shot_control is not None
-    assert scanner._shot_control.devices == ["U_DG645_ShotControl"]
-    assert scanner._shot_control.writes_for_state("SCAN") == [
+    scanner._run_scan(scanner._scan_config)
+
+    writes = session.shot_control_config
+    assert isinstance(writes, ShotControlWrites)
+    assert writes.devices == ["U_DG645_ShotControl"]
+    assert writes.writes_for_state("SCAN") == [
         ("U_DG645_ShotControl", "Trigger.Source", "External rising edges")
     ]
 
 
+def test_scan_request_without_profile_detaches_shot_control(monkeypatch) -> None:
+    _patch_claim(monkeypatch, [])
+    session = _FakeSession()
+    scanner = _make_scanner(session)
+    scanner.reinitialize(_noscan_request(), resolver=_resolver())
+    scanner._run_scan(scanner._scan_config)
+    assert session.shot_control_config is None
+
+
 # ---------------------------------------------------------------------------
-# Documented v1 refusals through the seam (fail at reinitialize, pre-thread)
+# Actions through the seam (delegated + fail-fast validation retained)
 # ---------------------------------------------------------------------------
 
 
-def test_multi_axis_request_refused_at_reinitialize() -> None:
+def test_actions_delegate_and_compile(monkeypatch) -> None:
+    """A setup action compiles and reaches session.scan as a non-None hook."""
+    _patch_claim(monkeypatch, [])
+    session = _FakeSession()
+    scanner = _make_scanner(session)
+    request = _noscan_request(actions={"setup": ["prep"]})
+    resolver = _resolver(plans={"prep": _WAIT_PLAN})
+    assert scanner.reinitialize(request, resolver=resolver) is True
+    scanner._run_scan(scanner._scan_config)
+
+    kwargs = session.scan_kwargs
+    assert kwargs is not None
+    assert kwargs["setup"] is not None
+    assert kwargs["per_step"] is None
+    assert kwargs["closeout"] is None
+    assert kwargs["md"]["action_plans"] == {"setup": ["prep"]}
+
+
+def test_unknown_action_name_still_fails_at_reinitialize() -> None:
     scanner = _make_scanner(_FakeSession())
+    request = _noscan_request(actions={"setup": ["prep"]})
+    with pytest.raises(GeecsConfigurationError, match="prep"):
+        scanner.reinitialize(request, resolver=_resolver())  # name unknown
+
+
+def test_defaults_not_applied_twice(monkeypatch) -> None:
+    """reinitialize validates a post-defaults COPY but stores the original —
+    run_scan_request applies defaults itself, exactly once."""
+    _patch_claim(monkeypatch, [])
+    session = _FakeSession()
+    scanner = _make_scanner(session)
+    resolver = _resolver(
+        plans={"default_prep": _WAIT_PLAN},
+        defaults={"actions": {"setup": ["default_prep"]}},
+    )
+    assert scanner.reinitialize(_noscan_request(), resolver=resolver) is True
+    # The stored request is the pre-defaults original.
+    assert list(scanner._scan_request.actions.setup) == []
+    scanner._run_scan(scanner._scan_config)
+
+    kwargs = session.scan_kwargs
+    assert kwargs is not None
+    assert kwargs["md"]["action_plans"]["setup"] == ["default_prep"]
+    assert kwargs["md"]["applied_defaults"] == {"actions.setup": ["default_prep"]}
+
+
+# ---------------------------------------------------------------------------
+# Bridge seams: preflight abort + progress totals
+# ---------------------------------------------------------------------------
+
+
+def test_delegated_preflight_abort(monkeypatch) -> None:
+    """Preflight returning None aborts pre-claim: no scan, abort flag set."""
+    _patch_claim(monkeypatch, [])
+    session = _FakeSession()
+    scanner = _make_scanner(session)
+    scanner.reinitialize(_noscan_request(), resolver=_resolver())
+    scanner._preflight_check_sync_liveness = (
+        lambda detectors, strict=False, disconnect_on_drop=True: None
+    )
+    scanner._run_scan(scanner._scan_config)
+
+    assert session.scan_kwargs is None
+    assert scanner._abort_requested is True
+    # The runner's finally still disconnects the devices it created.
+    assert len(session.disconnected) == 3
+
+
+def test_delegated_preflight_receives_assembled_detectors(monkeypatch) -> None:
+    """The bridge preflight hook sees the full detector list + strict flag."""
+    _patch_claim(monkeypatch, [])
+    session = _FakeSession()
+    scanner = _make_scanner(session)
+    scanner.reinitialize(_noscan_request(acquisition="strict"), resolver=_resolver())
+    seen: dict = {}
+
+    def _fake_preflight(detectors, *, strict=False, disconnect_on_drop=True):
+        seen["devices"] = [d._geecs_device_name for d in detectors]
+        seen["strict"] = strict
+        seen["disconnect_on_drop"] = disconnect_on_drop
+        return detectors
+
+    scanner._preflight_check_sync_liveness = _fake_preflight
+    scanner._run_scan(scanner._scan_config)
+
+    assert seen["devices"] == ["U_Ref", "U_Cam2", "U_Stage"]
+    assert seen["strict"] is True
+    assert seen["disconnect_on_drop"] is False
+    assert session.scan_kwargs is not None
+
+
+def test_delegated_totals_hook(monkeypatch) -> None:
+    """A 3-position step scan × 2 shots primes the GUI progress totals."""
+    _patch_claim(monkeypatch, [])
+    session = _FakeSession()
+    scanner = _make_scanner(session)
+    resolver = _resolver(variables={"v": ScanVariable(target="U_X:Pos")})
     request = ScanRequest.model_validate(
         {
             "mode": "step",
+            "shots_per_step": 2,
+            "acquisition": "free_run",
             "save_sets": ["baseline"],
-            "axes": [
-                {"variable": "a", "positions": {"start": 0, "end": 1, "step": 1}},
-                {"variable": "b", "positions": {"start": 0, "end": 1, "step": 1}},
-            ],
+            "axes": [{"variable": "v", "positions": {"values": [0.0, 1.0, 2.0]}}],
         }
     )
-    with pytest.raises(NotImplementedError, match=MULTI_AXIS_MESSAGE):
-        scanner.reinitialize(request, resolver=_resolver())
+    scanner.reinitialize(request, resolver=resolver)
+    scanner._run_scan(scanner._scan_config)
+
+    assert scanner._total_steps == 3
+    assert scanner._total_shots == 6
 
 
-def test_actions_validated_then_refused_at_reinitialize() -> None:
-    plan = ActionPlan.model_validate({"steps": [{"do": "wait", "seconds": 1.0}]})
-    scanner = _make_scanner(_FakeSession())
-    request = ScanRequest.model_validate(
-        {
-            "mode": "noscan",
-            "save_sets": ["baseline"],
-            "actions": {"setup": ["prep"]},
-        }
-    )
-    with pytest.raises(NotImplementedError, match="prep"):
-        scanner.reinitialize(request, resolver=_resolver(plans={"prep": plan}))
-    with pytest.raises(GeecsConfigurationError, match="prep"):
-        scanner.reinitialize(request, resolver=_resolver())  # name unknown
+# ---------------------------------------------------------------------------
+# Retained refusal (optimize awaits GUI-submission step (iii)) + state reset
+# ---------------------------------------------------------------------------
 
 
 def test_optimize_request_refused_at_reinitialize() -> None:
@@ -417,11 +580,10 @@ def test_exec_config_path_clears_request_state(monkeypatch) -> None:
             "axes": [{"variable": "v", "positions": {"start": 0, "end": 1, "step": 1}}],
         }
     )
-    scanner.reinitialize(
-        request,
-        resolver=_resolver(variables={"v": ScanVariable(target="U_X:Pos")}),
-    )
-    assert scanner._request_step is not None
+    resolver = _resolver(variables={"v": ScanVariable(target="U_X:Pos")})
+    scanner.reinitialize(request, resolver=resolver)
+    assert scanner._scan_request is not None
+    assert scanner._request_resolver is resolver
 
     exec_config = SimpleNamespace(
         scan_config=SimpleNamespace(
@@ -438,5 +600,5 @@ def test_exec_config_path_clears_request_state(monkeypatch) -> None:
         save_config=SimpleNamespace(Devices={}),
     )
     scanner.reinitialize(exec_config)
-    assert scanner._request_step is None
     assert scanner._scan_request is None
+    assert scanner._request_resolver is None

--- a/GeecsBluesky/tests/test_scan_request_runner.py
+++ b/GeecsBluesky/tests/test_scan_request_runner.py
@@ -29,7 +29,6 @@ from geecs_bluesky.scan_request_runner import (
     collect_save_set_rituals,
     merge_save_sets,
     resolve_save_sets_and_rituals,
-    resolve_save_sets_checked,
     run_scan_request,
     save_set_to_devices_config,
     trigger_writes_from_profile,
@@ -318,19 +317,6 @@ entries:
     setup: [cam_ritual]
 """
 
-# Ritual-free counterpart of UC_Aux for the GUI-bridge union test (the bridge
-# path still refuses entry rituals — a set with one would raise there).
-AUX_SAVE_SET_PLAIN = """\
-schema_version: 1
-name: UC_AuxPlain
-entries:
-  - device: U_Aux
-    scalars: [Aux1]
-  - device: U_Cam
-    scalars: [Extra]
-    images: true
-"""
-
 # New-schema save set whose entries carry setup/closeout rituals (shared
 # ritual named by both entries — must run once).
 RITUAL_SAVE_SET = """\
@@ -366,7 +352,6 @@ def configs_root(tmp_path):
     (legacy / "action_library" / "actions.yaml").write_text(LEGACY_ACTIONS)
     (legacy / "save_devices" / "RitualSet.yaml").write_text(RITUAL_SAVE_SET)
     (legacy / "save_devices" / "UC_Aux.yaml").write_text(AUX_SAVE_SET)
-    (legacy / "save_devices" / "UC_AuxPlain.yaml").write_text(AUX_SAVE_SET_PLAIN)
 
     modern = tmp_path / "ModernExp"
     (modern / "save_devices").mkdir(parents=True)
@@ -1218,13 +1203,6 @@ def test_entry_level_unknown_action_fails_validation_first() -> None:
         resolve_save_sets_and_rituals(resolver, ["s"])
 
 
-def test_bridge_path_still_refuses_entry_rituals() -> None:
-    """resolve_save_sets_checked (GUI-bridge helper) refuses with a pointer."""
-    resolver = _SaveSetResolver(_entry_action_save_set(setup=["prep_cam"]))
-    with pytest.raises(NotImplementedError, match="GeecsSession.run"):
-        resolve_save_sets_checked(resolver, ["s"])
-
-
 def test_entry_rituals_execute_between_defaults_and_request(
     legacy_resolver,
 ) -> None:
@@ -1835,12 +1813,87 @@ def test_telemetry_excludes_devices_from_all_named_sets(
     }
 
 
-def test_bridge_unions_save_sets(configs_root) -> None:
-    # The GUI-bridge path resolves the list and unions devices (still refusing
-    # rituals/actions/multi-axis elsewhere — out of scope here).
-    save_set = resolve_save_sets_checked(
-        ConfigsRepoResolver("LegacyExp", experiments_root=configs_root),
-        ["UC_Test", "UC_AuxPlain"],
+# ---------------------------------------------------------------------------
+# Runner hooks (the GUI-bridge seams): preflight + on_scan_start
+# ---------------------------------------------------------------------------
+
+
+def test_preflight_receives_assembled_detectors_and_strict(legacy_resolver) -> None:
+    """The hook sees the fully assembled detector list and the strict flag,
+    and its (possibly reduced) return is what session.scan runs with."""
+    session = _FakeSession()
+    seen: dict = {}
+
+    def preflight(detectors: list, strict: bool):
+        seen["devices"] = [d._geecs_device_name for d in detectors]
+        seen["strict"] = strict
+        return detectors[:2]  # drop the snapshot device
+
+    uid = run_scan_request(
+        session,
+        _noscan_request(acquisition="strict"),
+        legacy_resolver,
+        preflight=preflight,
     )
-    devices = {e.device for e in save_set.entries}
-    assert devices == {"U_Cam", "U_Cam2", "U_Slow", "U_Aux"}
+    assert uid == "uid-scan"
+    assert seen["strict"] is True
+    assert seen["devices"] == ["U_Cam", "U_Cam2", "U_Slow"]
+    assert [d._geecs_device_name for d in session.scan_kwargs["detectors"]] == [
+        "U_Cam",
+        "U_Cam2",
+    ]
+
+
+def test_preflight_none_aborts_without_scanning(legacy_resolver) -> None:
+    """A None return aborts pre-claim; created devices are still disconnected."""
+    session = _FakeSession()
+    result = run_scan_request(
+        session, _noscan_request(), legacy_resolver, preflight=lambda d, s: None
+    )
+    assert result is None
+    assert session.scan_kwargs is None
+    assert len(session.disconnected) == 3  # the runner's finally cleaned up
+
+
+def test_preflight_strict_flag_false_for_free_run(legacy_resolver) -> None:
+    session = _FakeSession()
+    flags: list[bool] = []
+    run_scan_request(
+        session,
+        _noscan_request(acquisition="free_run"),
+        legacy_resolver,
+        preflight=lambda detectors, strict: flags.append(strict) or detectors,
+    )
+    assert flags == [False]
+
+
+def test_on_scan_start_totals_for_noscan(legacy_resolver) -> None:
+    session = _FakeSession()
+    calls: list[tuple[int, int]] = []
+    run_scan_request(
+        session,
+        _noscan_request(),  # shots_per_step=3
+        legacy_resolver,
+        on_scan_start=lambda steps, shots: calls.append((steps, shots)),
+    )
+    assert calls == [(1, 3)]
+
+
+def test_on_scan_start_totals_for_grid(legacy_resolver) -> None:
+    """A 2×3 grid is 6 steps; totals reflect the flat outer-product length."""
+    session = _FakeSession()
+    calls: list[tuple[int, int]] = []
+    request = _noscan_request(
+        mode="step",
+        axes=[
+            {"variable": "jet_z", "positions": {"start": 0, "end": 1, "step": 1}},
+            {"variable": "jet_x", "positions": {"values": [4.0, 5.0, 6.0]}},
+        ],
+    )
+    run_scan_request(
+        session,
+        request,
+        legacy_resolver,
+        on_scan_start=lambda steps, shots: calls.append((steps, shots)),
+    )
+    assert calls == [(6, 18)]  # shots_per_step=3

--- a/Planning/cleanup_vision_v1/00_overview.md
+++ b/Planning/cleanup_vision_v1/00_overview.md
@@ -115,20 +115,26 @@ Inventoried during the pass — these are NOT in CLAUDE.md and were kept:
   `supports_device_type`, `load_camera_image_from_tiled_run`,
   `build_external_asset_documents`) — documented public surface with tests.
 
-## Deferred until M4 bridge parity (touching now is wasted work)
+## Deferred until M4 bridge parity — status 2026-07-10: step (i) LANDED
 
-M4 makes `BlueskyScanner` delegate ScanRequest execution to
-`run_scan_request`; the following are scheduled to shrink or die then:
+M4 step (i) (`vision/m4-bridge-parity`, GeecsBluesky 0.28.0) made
+`BlueskyScanner` delegate ScanRequest execution to `run_scan_request`.
+Where each item landed:
 
-- `bluesky_scanner._reinitialize_from_scan_request` (~150 lines) and the
-  `_request_step` machinery — the biggest casualty.
-- The runner's action-refusal cluster: `raise_if_actions_present`,
-  `resolve_save_sets_checked`, `MULTI_AXIS_MESSAGE` — their only callers are
-  the bridge refusals M4 removes.
-- `resolve_defaults_for` — single production caller is the bridge.
-- Reconciling the device-build twins (above).
-- Optional bridge extractions (preflight/event-translation clusters) — clean
-  seams, but not the bottleneck; avoid colliding with M4.
+- **DONE** — the runner's refusal cluster (`raise_if_actions_present`,
+  `resolve_save_sets_checked`, `MULTI_AXIS_MESSAGE`) is deleted, along with
+  the bridge's `_request_step` machinery and `_run_request_step_scan`.
+- **PARTIAL** — `_reinitialize_from_scan_request` shrank from ~150 lines of
+  namespace synthesis to ~60 lines of fail-fast validation + state storage;
+  it still exists (that is now its durable job, not debt).
+- **KEPT** — `resolve_defaults_for`: the bridge still calls it for fail-fast
+  validation (alongside `resolve_and_validate_actions` and
+  `resolve_save_sets_and_rituals`), so it is no longer a deletion candidate.
+- **STILL OPEN** — reconciling the device-build twins (above): both remain
+  live because the legacy `exec_config` path keeps
+  `_build_session_devices`; they merge when that path dies (M6).
+- **STILL OPEN** — optional bridge extractions (preflight/event-translation
+  clusters) — clean seams, but not the bottleneck.
 
 ## Deferred: analysis/ + assets/ (WIP zone — owner decision 2026-07-10)
 

--- a/Planning/gui_retrofit/00_overview.md
+++ b/Planning/gui_retrofit/00_overview.md
@@ -203,6 +203,8 @@ a hardware smoke on the daily-driver mode.
   `session.run`. Hardware smoke: a headless multi-axis + action request via
   the bridge. **This is the biggest engine step and unblocks everything
   after it.**
+  **LANDED 2026-07-10** (`vision/m4-bridge-parity`, GeecsBluesky 0.28.0 —
+  optimize refusal retained pending step (iii); hardware smoke still owed).
 - **(ii) Behind-a-flag "submit as ScanRequest" for a simple scan.** Add
   `_build_scan_request()` to the GUI and a submission flag
   (`GEECS_USE_SCAN_REQUEST`, mirroring `GEECS_USE_BLUESKY`, resolved next to


### PR DESCRIPTION
## What this is

M4 step (i) of the GUI retrofit plan (`Planning/gui_retrofit/00_overview.md` §3–4): the GUI bridge reaches **ScanRequest parity** with the headless engine. GeecsBluesky 0.27.1 → **0.28.0**.

## What delegation replaces

`BlueskyScanner._reinitialize_from_scan_request` used to synthesize a legacy scan-config `SimpleNamespace` (plus the `_request_step` side channel) and run the exec_config scan-thread body, refusing actions, entry rituals, and multi-axis grids with `NotImplementedError` pointers at `GeecsSession.run`. Now it only:

1. **Validates fail-fast** on a local post-defaults copy (defaults → actions → save sets + rituals → trigger profile → scan variables), discarding every result, so the GUI gets an immediate error pre-thread; and
2. **Stores the original pre-defaults request** + resolver (`run_scan_request` applies defaults itself — storing the post-defaults copy would prepend default action plans twice; pinned by `test_defaults_not_applied_twice`).

The scan-thread body then calls `run_scan_request(session, request, resolver, preflight=..., on_scan_start=...)` — so actions, entry rituals, multi-axis outer-product grids, db_scalars, and background telemetry all run through the **one engine definition**. The bridge never pre-claims on this path: `session.scan` claims the number and self-attaches `scan.log`. The legacy `exec_config` path is untouched.

## The two new runner hooks

Both keyword-only, default `None` — headless callers are unchanged. Neither runs on the optimize path (an optimize preflight is a later seam).

- **`preflight(detectors, strict) -> list | None`** — the scanner-layer operator-dialog seam. Called after the detector list is fully assembled (save-set devices + telemetry readables), pre-claim by construction. `None` aborts (the runner's `finally` still disconnects everything it created); a reduced list is honored. The bridge threads its existing liveness/staleness pipeline through with a new `disconnect_on_drop=False` (the runner owns disconnection on this path; exec_config path byte-identical, default `True`), and sets `_abort_requested` on abort so the thread cleanup reports ABORTED.
- **`on_scan_start(total_steps, total_shots)`** — progress totals, called immediately before `session.scan`: `(1, shots_per_step)` for noscan, `(len(positions), len(positions) × shots_per_step)` for step (flat outer-product length for grids). The bridge uses it to prime `_total_steps`/`_total_shots` and emit INITIALIZING → RUNNING.

## Deleted

- Runner refusal cluster: `raise_if_actions_present`, `resolve_save_sets_checked`, `MULTI_AXIS_MESSAGE` (their only callers were the bridge refusals this PR removes) + their tests.
- Bridge: the request→legacy-namespace synthesis, the `_request_step` machinery, and `_run_request_step_scan`.

## Retained

- The **optimize-mode refusal** at `reinitialize(ScanRequest)` (message updated) — wiring the GUI's `optimization_loader` into the delegated path is GUI-submission step (iii).
- `resolve_and_validate_actions`, `resolve_save_sets_and_rituals`, `resolve_defaults_for` — the bridge still uses them for fail-fast validation.

## The new parity pin

The old byte-parity pin (request noscan ≡ synthesized exec_config) is intentionally retired — the request path now legitimately produces richer kwargs (compiled action stubs, `save_sets` provenance, `scan_request_mode` md). Its replacement: **a request submitted through the bridge produces `session.scan` kwargs identical to headless `run_scan_request` on an equivalent fresh fake session** (`test_scan_request_delegation_parity_with_headless`), plus a no-pre-claim assertion. New coverage: multi-axis delegation, action compile-and-delegate, unknown-name fail-fast, trigger profile via `session.shot_control`, preflight abort, assembled-detector/strict-flag threading, totals hook, defaults-once, and runner-side hook tests (preflight reduce/abort, noscan + 2×3-grid totals).

## Tests

`poetry install --extras ca && poetry run pytest -q` → **416 passed, 1 skipped, 3 deselected**. Hardware smoke (headless multi-axis + action request via the bridge) still owed per the plan — noted in the planning doc.

## Docs/bookkeeping

CHANGELOG 0.28.0 entry; `GeecsBluesky/CLAUDE.md` stale bridge-refusal passages rewritten; `Planning/gui_retrofit/00_overview.md` step (i) marked landed; `Planning/cleanup_vision_v1/00_overview.md` deferred-until-M4 section updated with done/partial/kept/still-open status.

🤖 Generated with [Claude Code](https://claude.com/claude-code)