### PR TITLE
Planning: cutover strategy — parallel branch, gut-first, per-facility deployment

### DIFF
--- a/Planning/cutover_strategy/00_overview.md
+++ b/Planning/cutover_strategy/00_overview.md
@@ -8,18 +8,21 @@ remains the foundation.
 ## The decision
 
 **The gut runs as a branch experiment with a clean abort.** A second
-integration branch (`feat/vision-v2` or similar) is cut from
-`feat/vision-v1`; the gut sequence and any greenfield-GUI work land THERE.
+integration branch — **`feat/greenfield-epics-bluesky-gui`** (named
+2026-07-10; carries the gut G1–G3 as well as the GUI work) — is cut from
+`feat/vision-v1`; the gut sequence and greenfield-GUI work land THERE.
 `feat/vision-v1` stays the known-good, coexistence-capable fallback.
 
 Branch discipline (strict, or the experiment fails by sync cost):
 
-- Syncs flow one way: master → v1 → v2. After the branch point, **v1
-  receives only master syncs and critical engine fixes; all new
-  development lands on v2.**
-- Path-independent work stays on v1: the deployment recipe, the step-(i)
-  hardware smoke, the s-file coverage check — an abort must lose nothing
-  operational.
+- Syncs flow one way: master → v1 → v2.
+- **The division is by path-dependence, not by date**: v1 continues to
+  receive everything BOTH futures need — gateway features (alarm limits,
+  derived channels, status PVs, …), schemas, GeecsBluesky engine fixes,
+  the deployment recipe, hardware smokes, the s-file coverage check. An
+  abort must strand nothing. Only work **exclusive to the gut/greenfield
+  direction** (GUI changes, legacy-engine deletion, anything touching
+  files the gut removes) lands on v2. v1→v2 merges flow routinely.
 - **Commit/abort checkpoint** (time-boxed — the abort option decays):
   after (a) G1 lands on v2 with the suite green, (b) G2-retrofit runs one
   real hardware scan, and (c) a greenfield screen-map + one working screen
@@ -76,13 +79,17 @@ every legacy engine module mapped; see PR discussion).
   `_build_session_devices` twin, exec_config duck-typing) once G2 lands.
   The bridge becomes a thin request adapter; the device-build twins
   reconcile here.
-- **G-actions — re-home manual actions** (decision pending, maintainer
-  leaning discussed): the ActionLibrary "perform action" feature is already
-  dark under Bluesky (`action_control = None`). Recommended: a
-  bluesky-native ActionControl running named `ActionPlan`s through the
-  engine's existing `compile_action_plan` + `CaActionSignalFactory` — turns
-  a feature regression into a schema consolidation. Until then the feature
-  stays dark, ActionManager stays alive for the dialog's condition checks.
+- **G-actions — re-home manual actions (DECIDED 2026-07-10: yes).**
+  Diagnosis confirmed: every piece already exists (ActionPlan schemas,
+  `compile_action_plan` plan stubs, `CaActionSignalFactory`, resolver-side
+  legacy-YAML conversion) — only the interactive entry point was never
+  wired. Scope: (1) `GeecsSession.run_action(name)` — resolve → compile →
+  prefetch signals → `RE(stub())`, outside any scan; (2) a bluesky-native
+  ActionControl adapter for the GUI, including `return_device_value`
+  re-homed onto a gateway PV read (condition checks + step-list live
+  gets). Once landed, **ActionManager + DeviceCommandExecutor move from
+  the keep-list to the cut-list** (sequence G-actions before or with the
+  PR that deletes them).
 
 Known follow-ups that do NOT block the gut: `geecs_python_api` remains a
 GUI dependency (ScanDevice live readback/manual-set in the main window, DB

--- a/Planning/cutover_strategy/00_overview.md
+++ b/Planning/cutover_strategy/00_overview.md
@@ -7,6 +7,25 @@ remains the foundation.
 
 ## The decision
 
+**The gut runs as a branch experiment with a clean abort.** A second
+integration branch (`feat/vision-v2` or similar) is cut from
+`feat/vision-v1`; the gut sequence and any greenfield-GUI work land THERE.
+`feat/vision-v1` stays the known-good, coexistence-capable fallback.
+
+Branch discipline (strict, or the experiment fails by sync cost):
+
+- Syncs flow one way: master → v1 → v2. After the branch point, **v1
+  receives only master syncs and critical engine fixes; all new
+  development lands on v2.**
+- Path-independent work stays on v1: the deployment recipe, the step-(i)
+  hardware smoke, the s-file coverage check — an abort must lose nothing
+  operational.
+- **Commit/abort checkpoint** (time-boxed — the abort option decays):
+  after (a) G1 lands on v2 with the suite green, (b) G2-retrofit runs one
+  real hardware scan, and (c) a greenfield screen-map + one working screen
+  exist, explicitly decide: commit (v1 freezes to pure fallback) or abort
+  (delete v2, resume the coexistence plan on v1).
+
 **`feat/vision-v1` is a fully parallel branch.** It is never tip-toed back
 into master; master merges *into* it regularly, and the final merge the
 other way is effectively "master becomes vision" at cutover. Consequence:
@@ -28,7 +47,7 @@ conscious yes/no on whether the new engine needs an equivalent. Master's
 active development is mostly ScanAnalysis/ImageAnalysis, which merge
 cleanly; delete/modify conflicts on gutted files resolve as "keep deleted."
 
-## The gut sequence (PRs to feat/vision-v1)
+## The gut sequence (PRs to the v2 experiment branch)
 
 Cut list verified by a full consumer audit 2026-07-10 (every importer of
 every legacy engine module mapped; see PR discussion).

--- a/Planning/cutover_strategy/00_overview.md
+++ b/Planning/cutover_strategy/00_overview.md
@@ -91,11 +91,22 @@ every legacy engine module mapped; see PR discussion).
   the keep-list to the cut-list** (sequence G-actions before or with the
   PR that deletes them).
 
-Known follow-ups that do NOT block the gut: `geecs_python_api` remains a
-GUI dependency (ScanDevice live readback/manual-set in the main window, DB
-lookups, error types) — it drops at M5 at the earliest, not here. Verify
-GeecsBluesky's s-file export covers every scan mode relied on
-(noscan/1-D/optimization/background) before G1 removes the legacy producer.
+Known follow-ups that do NOT block the gut:
+
+- **`geecs_python_api` in the OLD GUI is left untouched and dies with it
+  at cutover** — its usages (ScanDevice live readback/manual-set, DB
+  autocompletes, error types) are not worth replacing in code that is
+  being retired. **GEECS-Console never acquires the dependency**
+  (decided 2026-07-10): manual set/readback goes through gateway PVs
+  (CA monitor on the readback, put to ``:SP`` riding GEECS's native
+  blocking set), DB autocompletes through **`GeecsDb`** (the clean
+  interface), error types from the geecs-bluesky/gateway exception tree.
+  One capability note: the ScanDevice path also handled *composite*
+  manual-set; GEECS-Console's manual panel is scalar-only at birth
+  (composites arrive with the pseudo-variable runtime, if ever).
+- Verify GeecsBluesky's s-file export covers every scan mode relied on
+  (noscan/1-D/optimization/background) before G1 removes the legacy
+  producer.
 
 ## M6 = a per-experiment deployment event, not a code event
 
@@ -135,10 +146,9 @@ gateway host.
   2026-07-10. The control-room word for the operator front-end, distinct
   from the `geecs-bluesky` library. (`geecs-bluesky-scanner` rejected as
   too close to `geecs-bluesky`.)
-- Day-1 dependency target: PySide6 + geecs-bluesky + geecs-schemas —
-  decide whether the manual set/readback panel goes through the gateway
-  (no `geecs_python_api` dependency from birth) or carries ScanDevice
-  temporarily.
+- **Day-1 dependencies: PySide6 + geecs-bluesky + geecs-schemas.
+  No `geecs_python_api`, ever** (decided 2026-07-10) — manual
+  set/readback via gateway PVs, DB autocompletes via `GeecsDb`.
 
 ## TDMS (decided 2026-07-10)
 

--- a/Planning/cutover_strategy/00_overview.md
+++ b/Planning/cutover_strategy/00_overview.md
@@ -126,18 +126,67 @@ verification lives), soak, then facility #2 as the first true test of the
 recipe. Pre-work: one sanity pass that nothing assumes a single global
 gateway host.
 
-## M6 gate list (draft — to finalize with the maintainer)
+## Greenfield GUI — settled parameters (2026-07-10)
 
-- N consecutive ops days on the request path at facility #1: strict +
-  free-run + DG645, at least one action-bearing scan, zero master
-  fallbacks.
-- Optimization verified once end-to-end (after G-actions/step-(iii)
-  equivalent wiring).
-- s-file outputs confirmed for every mode ScanAnalysis consumes; TDMS
-  reliance explicitly confirmed dead or replaced.
+- **Toolkit: PySide6** (LGPL — this repo is public; Qt-official; Qt
+  Designer `.ui` files keep the human-layout capability, and `.ui` XML is
+  agent-editable).
+- **New top-level package** (clean separation; the old GUI package dies
+  whole at cutover). Name TBD — shortlist: `geecs-console` (recommended:
+  the control-room word for the operator front-end, distinct from the
+  `geecs-bluesky` library), `scan-console`, `beamline-console`.
+  `geecs-bluesky-scanner` rejected (too close to `geecs-bluesky`).
+- Day-1 dependency target: PySide6 + geecs-bluesky + geecs-schemas —
+  decide whether the manual set/readback panel goes through the gateway
+  (no `geecs_python_api` dependency from birth) or carries ScanDevice
+  temporarily.
+
+## TDMS (decided 2026-07-10)
+
+- **On-shot TDMS: dropped.** It was a poorly-implemented Master Control
+  preservation and was not in use.
+- **End-of-scan TDMS conversion: possible future exporter** for LabVIEW
+  tooling — naturally a post-scan Tiled→TDMS converter alongside the
+  existing s-file exporter (analysis-side, needs no scanner integration).
+  Not scheduled, not a gate.
+
+## M6 gate: the validation scenario matrix
+
+Decided: the soak criterion is **a scenario checklist, not N days** — a
+list of scans to run at facility #1 under breaking conditions, each
+checked off once. Draft matrix (maintainer edits):
+
+*Modes ×* *trigger regimes*:
+- noscan / 1-D step / multi-axis grid / background — each in strict
+  (DG645 ARMED/SINGLESHOT) and free-run (jet bracketing) where applicable
+- optimization run end-to-end (after G-actions / optimize wiring)
+- a save-set-union scan (two named sets) and a composite-variable scan
+
+*Actions*: request setup/closeout · save-set rituals · experiment-defaults
+bracket · per-step actions at grid points
+
+*Failure drills*:
+- device off at preflight → operator drop + reference promotion
+- device dies mid-scan → error dialog path, clean abort
+- free-run trigger off → staleness dialog wording
+- DB unreachable → scan proceeds with explicit-only scalars (no abort)
+- Tiled down → scan proceeds (soft-fail), s-files still written
+- NetApp unmounted → claim refuses gracefully, no empty folder planted
+- operator abort mid-scan → STANDBY restore, save-off before trigger can
+  pass edges, no orphan images
+- config errors (unknown names, conflicting save-set roles, bad trigger
+  variant) → fail at submit, no scan number burned
+
+*Data integrity per mode*: s-file complete · images join event rows ·
+telemetry columns present · scan.log written · ScanInfo fields correct.
+
+## Other M6 gates
+
 - Deployment recipe executed clean on facility #2's machine.
-- Config corpus migration decided (recommendation: opportunistic — a file
-  migrates to new schema when first edited — plus a one-shot conversion
-  script held in reserve).
+- **Config corpus migration: on a named branch of the configs repo**
+  (GEECS-Plugins-Configs — the corpus lives there, not here), e.g.
+  `schema-v1-migration`, coordinated with the cutover. Opportunistic
+  migration (file converts when first edited) + a one-shot conversion
+  script, landing on that branch.
 - Explicitly non-blocking unless ops says otherwise: pseudo scan
-  variables, `all_scalars`, legacy TDMS scan-summary output.
+  variables, `all_scalars`, TDMS outputs (see above).

--- a/Planning/cutover_strategy/00_overview.md
+++ b/Planning/cutover_strategy/00_overview.md
@@ -1,0 +1,117 @@
+# Cutover strategy — feat/vision-v1 as a parallel branch, gut-first
+
+Decided 2026-07-10 (maintainer + agent discussion). This note supersedes the
+incremental coexistence sequencing in `Planning/gui_retrofit/00_overview.md`
+§4 steps (ii)–(iv); step (i) (bridge parity, PR #485) is unaffected and
+remains the foundation.
+
+## The decision
+
+**`feat/vision-v1` is a fully parallel branch.** It is never tip-toed back
+into master; master merges *into* it regularly, and the final merge the
+other way is effectively "master becomes vision" at cutover. Consequence:
+the coexistence machinery planned for M4 steps (ii)–(iv) — the
+`GEECS_USE_SCAN_REQUEST` flag, dual submission paths, flag-flip default —
+protected a same-branch incremental rollout that will never happen. It is
+dropped. The legacy scan engine is deleted on this branch **now**, so every
+subsequent build (GUI submission, editors, optimization wiring) targets one
+architecture.
+
+**The fallback story changes shape and we accept it**: instead of an env
+var mid-ops-day, the deployment-time fallback is *check out master on the
+control machine* (~minutes). First soak days are chosen accordingly
+(low-stakes ops).
+
+**The translation rule** (the price of the parallel branch, made explicit):
+a master fix touching legacy scan behavior no longer merges — it gets a
+conscious yes/no on whether the new engine needs an equivalent. Master's
+active development is mostly ScanAnalysis/ImageAnalysis, which merge
+cleanly; delete/modify conflicts on gutted files resolve as "keep deleted."
+
+## The gut sequence (PRs to feat/vision-v1)
+
+Cut list verified by a full consumer audit 2026-07-10 (every importer of
+every legacy engine module mapped; see PR discussion).
+
+- **G1 — delete the legacy scan engine** (deletion-only; GUI stays
+  bluesky-only via the existing exec_config submission):
+  - Delete: `engine/scan_manager.py`, `default_scan_manager.py`,
+    `data_logger.py`, `device_manager.py`, `scan_executor.py`,
+    `scan_data_manager.py`, `trigger_controller.py`, `file_mover.py`,
+    `lifecycle.py`, their tests, RunControl's legacy branch,
+    `ScanExecutionConfig.to_device_manager_dict`.
+  - **First edit `engine/__init__.py`** — it eagerly imports everything;
+    pruning it is the single mandatory ordering constraint.
+  - Collapse `backend_selection` to a bluesky-default stub.
+  - Strip the `TYPE_CHECKING`-only `DataLogger`/`ScanDataManager` hints in
+    `optimization/base_evaluator.py` / `base_optimizer.py`.
+  - **Keep (not legacy, despite living in `engine/`):** `ActionManager` +
+    `DeviceCommandExecutor` (ActionLibrary GUI), `sound_player`
+    (action_control + multi_scanner jingles), `DatabaseDictLookup`,
+    the `scan_events`/`dialog_request` shims, all of `engine/models/`
+    (GUI→backend contract, also used by optimization).
+- **G2 — GUI builds a `ScanRequest` natively.** `_build_scan_request`
+  replaces `_build_exec_config`; no flag, one submission shape. Absorbs the
+  old steps (ii)–(iv).
+- **G3 — delete the bridge's exec_config path** (`_execute_scan`,
+  `_build_session_devices` twin, exec_config duck-typing) once G2 lands.
+  The bridge becomes a thin request adapter; the device-build twins
+  reconcile here.
+- **G-actions — re-home manual actions** (decision pending, maintainer
+  leaning discussed): the ActionLibrary "perform action" feature is already
+  dark under Bluesky (`action_control = None`). Recommended: a
+  bluesky-native ActionControl running named `ActionPlan`s through the
+  engine's existing `compile_action_plan` + `CaActionSignalFactory` — turns
+  a feature regression into a schema consolidation. Until then the feature
+  stays dark, ActionManager stays alive for the dialog's condition checks.
+
+Known follow-ups that do NOT block the gut: `geecs_python_api` remains a
+GUI dependency (ScanDevice live readback/manual-set in the main window, DB
+lookups, error types) — it drops at M5 at the earliest, not here. Verify
+GeecsBluesky's s-file export covers every scan mode relied on
+(noscan/1-D/optimization/background) before G1 removes the legacy producer.
+
+## M6 = a per-experiment deployment event, not a code event
+
+Two facilities, two independent Linux centers (each hosting its own MySQL
+with the identical schema). Decision: **one gateway + Tiled stack per
+facility machine — separate deployments, consolidated recipe.**
+
+- Gateway placement is dictated by physics: it speaks UDP/TCP to that
+  facility's devices and reads that facility's local MySQL. No
+  cross-subnet routing project.
+- Fault isolation: one facility's incident/maintenance never stops the
+  other's DAQ. Experiments run on different schedules; coupling their
+  infrastructure means coordinating maintenance forever.
+- The config chain already supports it natively (per-machine `config.ini` →
+  `Configurations.INI` → local DB; per-control-machine CA `addr_list`; the
+  `[Experiment:]` PV prefix keeps namespaces distinct).
+- The solo-maintainer investment goes into the **recipe**: turn
+  `GeecsCAGateway/DEPLOYMENT.md` into a turnkey artifact (systemd units +
+  install script or compose file), versioned in git, so facility #2 is an
+  hour's work and both stay in lockstep.
+- Central consolidation belongs at the **monitoring layer** (a future
+  archiver pulling from both CA servers), never at the access layer.
+  A central Tiled is a possible later analytics consolidation; not now
+  (writes fail soft, but mixed topology = two mental models).
+
+Rollout order: cut over facility #1 (HTU/Undulator — where all hardware
+verification lives), soak, then facility #2 as the first true test of the
+recipe. Pre-work: one sanity pass that nothing assumes a single global
+gateway host.
+
+## M6 gate list (draft — to finalize with the maintainer)
+
+- N consecutive ops days on the request path at facility #1: strict +
+  free-run + DG645, at least one action-bearing scan, zero master
+  fallbacks.
+- Optimization verified once end-to-end (after G-actions/step-(iii)
+  equivalent wiring).
+- s-file outputs confirmed for every mode ScanAnalysis consumes; TDMS
+  reliance explicitly confirmed dead or replaced.
+- Deployment recipe executed clean on facility #2's machine.
+- Config corpus migration decided (recommendation: opportunistic — a file
+  migrates to new schema when first edited — plus a one-shot conversion
+  script held in reserve).
+- Explicitly non-blocking unless ops says otherwise: pseudo scan
+  variables, `all_scalars`, legacy TDMS scan-summary output.

--- a/Planning/cutover_strategy/00_overview.md
+++ b/Planning/cutover_strategy/00_overview.md
@@ -131,11 +131,10 @@ gateway host.
 - **Toolkit: PySide6** (LGPL — this repo is public; Qt-official; Qt
   Designer `.ui` files keep the human-layout capability, and `.ui` XML is
   agent-editable).
-- **New top-level package** (clean separation; the old GUI package dies
-  whole at cutover). Name TBD — shortlist: `geecs-console` (recommended:
-  the control-room word for the operator front-end, distinct from the
-  `geecs-bluesky` library), `scan-console`, `beamline-console`.
-  `geecs-bluesky-scanner` rejected (too close to `geecs-bluesky`).
+- **New top-level package: `GEECS-Console` (`geecs_console`)** — decided
+  2026-07-10. The control-room word for the operator front-end, distinct
+  from the `geecs-bluesky` library. (`geecs-bluesky-scanner` rejected as
+  too close to `geecs-bluesky`.)
 - Day-1 dependency target: PySide6 + geecs-bluesky + geecs-schemas —
   decide whether the manual set/readback panel goes through the gateway
   (no `geecs_python_api` dependency from birth) or carries ScanDevice

--- a/Planning/cutover_strategy/01_gui_feature_inventory.md
+++ b/Planning/cutover_strategy/01_gui_feature_inventory.md
@@ -58,14 +58,24 @@ IP → the ECS-dump decision.
 - The Google-Docs scanlog menu item is hardcoded to HTU/Undulator
   (`HTUparameters.ini` logid).
 
-## Maintainer decisions needed
+## Maintainer decisions (DECIDED 2026-07-10)
 
-1. **ECS dump / Master Control IP** — legacy Master Control integration;
-   keep (re-home) or drop with the Master Control retirement?
-2. **MultiScanner** — queueserver replacement vs plain drop (either way it
-   does not carry as-is).
-3. **`get-only` composite mode** — editor can author it, runtime support
-   never landed; drop from the editor or implement?
-4. Dead features (log box, `run` action type, `add_all_variables`,
-   unwired refresh button) — default plan is drop-with-the-rebuild unless
-   flagged.
+1. **ECS dump / Master Control IP — DROP.** The dump was a bespoke
+   full-PV-space snapshot at scan start, requested over IP from the
+   MasterControl client (buggy anyway). Its standard successor already
+   exists in the stack: the **Bluesky baseline stream**
+   (`SupplementalData.baseline` — declared devices read once at run start
+   and once at run end, into the run's own document stream, queryable from
+   Tiled). If/when a full-space snapshot is wanted, wire gateway PVs as
+   baseline readables — no client commands, no separate dump file. The
+   future archiver makes even that largely moot (snapshot = timestamp
+   query). Not scheduled; recorded as the pattern to use.
+2. **MultiScanner — plain DROP for now.** Queueserver remains the noted
+   replacement pattern if batch sequencing is wanted later.
+3. **`get-only` composite mode — DROP** (editor authors it, no runtime
+   ever supported it, and it didn't make sense).
+4. **Dead features — DROP** (in-GUI log box, `run` action type,
+   `add_all_variables`, unwired refresh button).
+
+Still open: ActionControl re-homing (rec: bluesky-native execution of named
+ActionPlans via the engine compiler) — G-actions in `00_overview.md`.

--- a/Planning/cutover_strategy/01_gui_feature_inventory.md
+++ b/Planning/cutover_strategy/01_gui_feature_inventory.md
@@ -1,0 +1,71 @@
+# GEECS-Scanner-GUI — operator feature inventory (2026-07-10)
+
+Full functional sweep of the GUI on feat/vision-v1 (main window
+`geecs_scanner.py`, all dialogs/menus/.ui files). This is the requirements
+document for the v2 GUI decision (greenfield vs retrofit): every capability,
+its backing layer, and a disposition. Backing legend: LEGACY = legacy scan
+engine (dies in the gut) · BLUESKY = already dual-backend · PYAPI =
+geecs_python_api (backend-independent) · ACTIONMGR = ActionManager via
+action_control (dark under bluesky today) · OS/WEB · GUISTATE = pure
+GUI+YAML.
+
+## Disposition summary
+
+| Disposition | Count | Capabilities |
+|---|---|---|
+| **CARRY** (day-1 in any GUI) | 21 | experiment select · rep-rate · timing-config selector · config bootstrap dialog · save-element lists+delete · scan-mode radios (noscan/1D/optimization/background) · 1D variable picker (completer) · scan params + live shot-count · step-list popup · optimization-config dropdown · scan description · manual set/readback (ScanDevice) · presets save/apply/delete · start · stop · progress bar/status light/scan-number · device-error Continue/Abort dialog · restore-failures summary · reinit-failure dialog · dark mode · title/icon |
+| **RE-HOME** (needs a bluesky/gateway backend) | 4 | ActionLibrary/save-element **live action execution** (ACTIONMGR — already dark under bluesky) · **per-shot beeps** (driven only by legacy DataLogger — also already dark under bluesky; re-drive from `ScanStepEvent` GUI-side) · ECS dump / Master Control IP (legacy `enable_live_ECS_dump` — or drop) |
+| **M5-EDITOR** (config surfaces) | 5 | SaveElementEditor · ScanVariableEditor · ShotControlEditor · ActionLibrary (editing half) · config-repair dialog (overlaps CARRY) |
+| **OPS-TOOL** (scan-independent; portable menu items) | ~7 | open experiment-config folder · open user config · open today's scan folder · GitHub page · Google-Docs scanlog (**HTU-hardcoded** via LogMaker `logid`) · randomized beeps · CLI logging flags/rotating file log |
+| **REPLACE-WITH-STANDARD** | 1 | MultiScanner → **bluesky-queueserver** (confirmed: pure GUI polling of the main window — `apply_preset_from_name` + `is_ready_for_scan` — zero engine coupling of its own) |
+| **DROP-CANDIDATE** (maintainer confirm) | ~8 | MultiScanner (alt) · scanlog for non-HTU · ECS dump (alt) · in-GUI log box (wired code commented out) · `run` action type (unimplemented) · `add_all_variables` flag (disabled) · `get-only` composite mode (editor authors it; runtime support unclear) · `btnRefreshOptConfigs` (never connected) |
+
+Menu-bar Options (auto-persisted to config.ini): on-shot TDMS, save-direct-
+on-network, global time sync + tolerance → CARRY as options; Master Control
+IP → the ECS-dump decision.
+
+## The long tail — conveniences that bite operators if lost in a rebuild
+
+1. **Click-to-complete popups on every read-only field** (experiment, scan
+   variable, timing, device/variable fields in all four editors) — operators
+   rely on these instead of typing.
+2. Step-list popup with **live TCP resolution of relative composites**.
+3. abs/rel label swap on start/stop fields by composite mode.
+4. 10 s scan-number expiry timer + "No Scans Today" / Current-vs-Previous.
+5. `MAXIMUM_SCAN_SIZE=1e6` runaway-scan guard pre-submit.
+6. Conflicting-save-element detection with a specific error dialog.
+7. Assigned-action quick-access buttons (persisted, incl. import from a
+   save-element's setup/closeout).
+8. MultiScanner copy-row/copy-list/split-list + start-position ergonomics.
+9. **Execute-gating checkboxes** on ActionLibrary/SaveElementEditor
+   (prevent accidental live device commands).
+10. Enter-key-swallowing dummy default buttons in editors.
+11. Config auto-repair prompt on startup.
+12. Dark mode applied to child windows too.
+13. Randomized-beeps morale feature.
+14. `known_scan_number` caching (avoids filesystem hammering).
+15. Menu options auto-persist with no explicit save.
+
+## Notable findings
+
+- **Two features are ALREADY dark under bluesky today**: manual action
+  execution (`action_control = None`) and per-shot beeps (SoundPlayer is
+  driven only by legacy DataLogger). The gut changes nothing for them; the
+  v2 work should light both up properly (actions → engine's
+  `compile_action_plan` path; beeps → GUI-side off `ScanStepEvent`).
+- `geecs_python_api` backs the manual set/readback (ScanDevice) and DB
+  autocompletes — backend-independent, survives the gut, drops at M5+.
+- The Google-Docs scanlog menu item is hardcoded to HTU/Undulator
+  (`HTUparameters.ini` logid).
+
+## Maintainer decisions needed
+
+1. **ECS dump / Master Control IP** — legacy Master Control integration;
+   keep (re-home) or drop with the Master Control retirement?
+2. **MultiScanner** — queueserver replacement vs plain drop (either way it
+   does not carry as-is).
+3. **`get-only` composite mode** — editor can author it, runtime support
+   never landed; drop from the editor or implement?
+4. Dead features (log box, `run` action type, `add_all_variables`,
+   unwired refresh button) — default plan is drop-with-the-rebuild unless
+   flagged.

--- a/Planning/gui_retrofit/00_overview.md
+++ b/Planning/gui_retrofit/00_overview.md
@@ -182,6 +182,12 @@ Keep the event/progress/dialog seam **as-is** — it is downstream of both
 
 ---
 
+> **2026-07-10 strategy update:** steps (ii)–(iv) below are superseded —
+> `feat/vision-v1` is now treated as a fully parallel branch and the legacy
+> engine is deleted on it directly (no coexistence flag). See
+> `Planning/cutover_strategy/00_overview.md` for the gut sequence (G1–G3)
+> and the per-facility deployment plan. Step (i) is unaffected.
+
 ## 4. Incremental sequence
 
 Each step leaves the GUI working and the legacy path fully intact. Each is


### PR DESCRIPTION
Records the strategy decisions from today's discussion:

- **feat/vision-v1 is a fully parallel branch** — legacy engine gets deleted on it directly instead of the flag-gated coexistence plan (M4 steps (ii)–(iv) superseded; step (i)/#485 unaffected and foundational).
- **Gut sequence G1–G3** with the exact cut/keep lists from the full consumer audit (every importer of every legacy engine module mapped): what dies cleanly, what must stay (ActionManager, sound_player, DatabaseDictLookup, engine/models), and the `engine/__init__.py` ordering constraint.
- **M6 reframed as a per-facility deployment event**: two independent Linux centers (each with its own identical-schema MySQL), one gateway+Tiled stack per facility, investment goes into a turnkey deployment recipe. Central consolidation deferred to the monitoring layer (archiver), never the access layer.
- **Draft M6 gate list** including the soak criterion, s-file/TDMS confirmation, and recipe-on-facility-#2 verification.
- Open decision flagged: re-homing ActionControl (manual actions) onto the engine's action compiler.

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)