### PR TITLE
refactor(devices): one blessed gateway :SP put primitive (GatewaySetpointPut)

### DIFF
--- a/GeecsBluesky/CHANGELOG.md
+++ b/GeecsBluesky/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to `geecs-bluesky` are documented here.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.28.1] - 2026-07-10
+
+### Fixed
+
+- **Action set/check steps now work on numeric PVs.** `CaActionSignalFactory`
+  built `str`-typed ophyd signals for `:SP` settables and readbacks; a float
+  PV (e.g. `Position.Axis 1:SP`) then failed at connect ("inferred datatype
+  float cannot be coerced to str") — found by the first hardware set-step on
+  a numeric variable (M4 step-(i) smoke). Settables now put the wire string
+  via raw CA (the hardware-proven `CaPutSetter` convention — CA converts to
+  the PV's native type), with a dtype-inferred probe signal preserving the
+  pre-claim fail-fast; readables are dtype-inferred (like telemetry).
+  `values_match` handles native numerics with the legacy quirks intact. New
+  `tests/test_action_signals.py` pins the factory (it previously had no
+  hermetic coverage — which is how this survived to hardware).
+
 ## [0.28.0] - 2026-07-10
 
 M4 step (i) — the GUI bridge reaches ScanRequest parity

--- a/GeecsBluesky/CHANGELOG.md
+++ b/GeecsBluesky/CHANGELOG.md
@@ -16,9 +16,15 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   via raw CA (the hardware-proven `CaPutSetter` convention — CA converts to
   the PV's native type), with a dtype-inferred probe signal preserving the
   pre-claim fail-fast; readables are dtype-inferred (like telemetry).
-  `values_match` handles native numerics with the legacy quirks intact. New
-  `tests/test_action_signals.py` pins the factory (it previously had no
-  hermetic coverage — which is how this survived to hardware).
+  `values_match` handles native numerics with the legacy quirks intact.
+- **The raw put uses the bare PV name.** `ca_pv()` returns the ophyd
+  signal-URI form (`ca://<name>`); ophyd strips the scheme, raw aioca does
+  not — a schemed name CA-searches for a PV that does not exist and hangs
+  for the full timeout (live-found during the M4 step-(i) smoke as "the
+  closeout hang", issue #490; the smoke now passes end-to-end on hardware,
+  closeout set-steps included). New `tests/test_action_signals.py` pins the
+  factory, including the bare-name invariant (it previously had no hermetic
+  coverage — which is how both bugs survived to hardware).
 
 ## [0.28.0] - 2026-07-10
 

--- a/GeecsBluesky/CHANGELOG.md
+++ b/GeecsBluesky/CHANGELOG.md
@@ -4,6 +4,31 @@ All notable changes to `geecs-bluesky` are documented here.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.29.0] - 2026-07-10
+
+### Changed
+
+- **One blessed gateway `:SP` put primitive.** Three call sites implemented
+  "write a value to a gateway setpoint with GEECS-completion semantics"
+  independently — `CaMotor`'s Layer-1 ophyd signal put, `ShotController`'s
+  `CaPutSetter` raw caput, and the action factory's `_WireSettable` raw caput
+  — and each independently decided the PV addressing dialect (ophyd `ca://`
+  URI vs bare EPICS name), which tripled the suspect list during the
+  closeout-hang diagnosis and produced the actual bug (issue #490; see the
+  put-pathway discussion in PR #489). All three now delegate to
+  `devices/ca/gateway_put.GatewaySetpointPut`, the single owner of the
+  addressing rule (`bare_pv` strips `ca://`, rejects other schemes), the
+  wire-value conventions (`str` for shot control, `wire_value` for actions,
+  pass-through for typed motor signals), the timeout policy, `AsyncStatus`
+  wrapping, and mock support. Per-consumer semantics are preserved exactly:
+  `CaPutSetter` is now a thin pin of the primitive with byte-identical wire
+  behavior (always-string puts, 10 s budget), `CaSettable`/`CaMotor`/
+  `CaConfirmSettable` keep their typed setpoint signal as the transport and
+  mock seam (`CaMotor` keeps `move_timeout` as the put budget), and action
+  settables keep the wire-value convention and the issue-#490 bare-name
+  invariant. New `tests/test_gateway_put.py` pins the addressing rule
+  centrally, including that the primitive strips/rejects schemed names.
+
 ## [0.28.1] - 2026-07-10
 
 ### Fixed

--- a/GeecsBluesky/CLAUDE.md
+++ b/GeecsBluesky/CLAUDE.md
@@ -88,6 +88,10 @@ geecs_bluesky/
       action_signals.py     # CaActionSignalFactory — the production
                             #   SettableFactory for compiled action plans
                             #   (cached :SP settables + str readbacks)
+      gateway_put.py        # GatewaySetpointPut — THE one gateway :SP put
+                            #   primitive (addressing rule ca://-vs-bare,
+                            #   wire conventions, timeout, mock); every
+                            #   setpoint pathway delegates (issue #490)
     shot_id.py              # ShotIdTracker + ShotIdSupport mixin (schema-v1 columns)
     nonscalar_save.py       # NonScalarSaveSupport mixin — save-path column + asset docs
     contributor.py          # FreeRunContributorSupport — reference-relative labeling

--- a/GeecsBluesky/geecs_bluesky/devices/ca/action_signals.py
+++ b/GeecsBluesky/geecs_bluesky/devices/ca/action_signals.py
@@ -6,17 +6,20 @@ transport-ignorant: it asks an injected factory for signals by GEECS
 implementation:
 
 - ``get_settable(device, variable)`` → a Movable whose ``set()`` puts the
-  value (coerced to its wire string) to the variable's gateway setpoint PV
-  (``[Experiment:]Device:Variable:SP`` via :func:`~geecs_bluesky.devices.ca._pv.ca_pv`).
-  The gateway forwards ``:SP`` puts to GEECS's blocking UDP set and only
-  completes the CA put when GEECS accepts (or rejects) it — so CA
-  put-completion *is* the legacy ``wait_for_execution`` semantics: an
-  ``abs_set(..., wait=True)`` blocks exactly as ``device.set(var, value,
-  sync=True)`` did.
-- ``get_readable(device, variable)`` → a string-typed read signal on the
-  streamed readback PV.  Reading as a string matches the legacy check
-  pipeline (:func:`~geecs_bluesky.plans.action_compiler.values_match` floats
-  numeric-looking strings, exactly like ``GeecsDevice.interpret_value``).
+  value's **wire string via raw CA** (the hardware-proven
+  :class:`~geecs_bluesky.shot_controller.CaPutSetter` convention: CA
+  converts the string to the PV's native type server-side, so the put works
+  on float, enum, and string ``:SP`` channels alike — a *typed* ophyd
+  signal connect-fails when the PV's inferred type disagrees).  The gateway
+  forwards ``:SP`` puts to GEECS's blocking UDP set and only completes the
+  CA put when GEECS accepts (or rejects) it — so put-completion *is* the
+  legacy ``wait_for_execution`` semantics.  A dtype-inferred probe signal
+  is still connected at creation, preserving the pre-claim fail-fast (a
+  missing PV fails before any scan number is claimed).
+- ``get_readable(device, variable)`` → a **native-typed** read signal
+  (dtype inferred from the PV, like telemetry) on the streamed readback.
+  :func:`~geecs_bluesky.plans.action_compiler.values_match` handles both
+  string and numeric actuals, quirks preserved.
 
 Signals are created lazily, **cached per (device, variable)** so repeated
 steps and per-step plans reuse one CA channel, and connected through the
@@ -37,7 +40,8 @@ from __future__ import annotations
 import logging
 from typing import Any, Callable
 
-from ophyd_async.epics.core import epics_signal_r, epics_signal_rw
+from ophyd_async.core import AsyncStatus
+from ophyd_async.epics.core import epics_signal_r
 
 from geecs_bluesky.devices.ca._pv import ca_pv
 from geecs_bluesky.utils import safe_name
@@ -48,26 +52,42 @@ __all__ = ["CaActionSignalFactory"]
 
 
 class _WireSettable:
-    """Movable adapter: coerces action values to wire strings before the put.
+    """Movable: puts the wire string to the ``:SP`` PV via raw CA.
 
-    Action YAML values are ``str | float | int``; the gateway's ``:SP``
-    channels accept the string form of any of them (enum PVs take labels,
-    numeric PVs coerce numeric strings — the same convention as
-    :class:`~geecs_bluesky.shot_controller.CaPutSetter`).  The underlying
-    signal is string-typed, so every value is stringified here, once.
+    Action YAML values are ``str | float | int``; CA converts the string
+    form to the PV's native type (enum labels, numeric strings) — the same
+    convention as :class:`~geecs_bluesky.shot_controller.CaPutSetter`, and
+    the reason this is a raw ``caput`` rather than a typed ophyd signal
+    (which connect-fails on a float ``:SP``).  In mock mode the put is
+    recorded on ``last_mock_put`` and completes immediately.
     """
 
-    def __init__(self, signal: Any) -> None:
-        self._signal = signal
+    def __init__(
+        self, pv: str, name: str, *, mock: bool = False, timeout: float = 30.0
+    ) -> None:
+        self._pv = pv
+        self.name = name
+        self._mock = mock
+        self._timeout = timeout
+        self.last_mock_put: str | None = None
 
-    @property
-    def name(self) -> str:
-        """Signal name (used by Bluesky logging/message repr)."""
-        return self._signal.name
-
-    def set(self, value: Any):
+    def set(self, value: Any) -> AsyncStatus:
         """Put ``str(value)``; the returned status completes with the GEECS set."""
-        return self._signal.set(str(value))
+        wire = str(value)
+
+        if self._mock:
+
+            async def _record() -> None:
+                self.last_mock_put = wire
+
+            return AsyncStatus(_record())
+
+        async def _do() -> None:
+            from aioca import caput  # deferred: needs the `ca` extra
+
+            await caput(self._pv, wire, wait=True, timeout=self._timeout)
+
+        return AsyncStatus(_do())
 
 
 class CaActionSignalFactory:
@@ -83,11 +103,19 @@ class CaActionSignalFactory:
         session's ``_connect``.  Called once per new signal, at creation.
     """
 
-    def __init__(self, experiment: str | None, connect: Callable[[Any], Any]) -> None:
+    def __init__(
+        self,
+        experiment: str | None,
+        connect: Callable[[Any], Any],
+        *,
+        mock: bool = False,
+    ) -> None:
         self._experiment = experiment
         self._connect = connect
+        self._mock = mock
         self._settables: dict[tuple[str, str], _WireSettable] = {}
         self._readables: dict[tuple[str, str], Any] = {}
+        self._probes: dict[tuple[str, str], Any] = {}
 
     def get_settable(self, device: str, variable: str) -> _WireSettable:
         """Return the (cached) setpoint writer for ``(device, variable)``.
@@ -109,9 +137,13 @@ class CaActionSignalFactory:
         settable = self._settables.get(key)
         if settable is None:
             pv = f"{ca_pv(self._experiment, device, variable)}:SP"
-            signal = epics_signal_rw(str, pv, name=safe_name(f"{device}_{variable}_sp"))
-            self._connect(signal)
-            settable = _WireSettable(signal)
+            name = safe_name(f"{device}_{variable}_sp")
+            # dtype-inferred probe: proves the PV exists/connects (pre-claim
+            # fail-fast) without imposing a type the PV may not have.
+            probe = epics_signal_r(None, pv, name=f"{name}_probe")
+            self._connect(probe)
+            self._probes[key] = probe
+            settable = _WireSettable(pv, name, mock=self._mock)
             self._settables[key] = settable
             logger.debug("action settable created: %s -> %s", key, pv)
         return settable
@@ -129,14 +161,14 @@ class CaActionSignalFactory:
         Returns
         -------
         SignalR
-            A string-typed read signal on the streamed readback PV,
-            accepted by ``bps.rd``.
+            A native-typed (dtype-inferred) read signal on the streamed
+            readback PV, accepted by ``bps.rd``.
         """
         key = (device, variable)
         signal = self._readables.get(key)
         if signal is None:
             pv = ca_pv(self._experiment, device, variable)
-            signal = epics_signal_r(str, pv, name=safe_name(f"{device}_{variable}"))
+            signal = epics_signal_r(None, pv, name=safe_name(f"{device}_{variable}"))
             self._connect(signal)
             self._readables[key] = signal
             logger.debug("action readable created: %s -> %s", key, pv)
@@ -151,3 +183,4 @@ class CaActionSignalFactory:
         """
         self._settables.clear()
         self._readables.clear()
+        self._probes.clear()

--- a/GeecsBluesky/geecs_bluesky/devices/ca/action_signals.py
+++ b/GeecsBluesky/geecs_bluesky/devices/ca/action_signals.py
@@ -5,12 +5,13 @@ transport-ignorant: it asks an injected factory for signals by GEECS
 ``(device, variable)`` name.  This module is the CA-backed production
 implementation:
 
-- ``get_settable(device, variable)`` → a Movable whose ``set()`` puts the
-  value's **wire string via raw CA** (the hardware-proven
-  :class:`~geecs_bluesky.shot_controller.CaPutSetter` convention: CA
-  converts the string to the PV's native type server-side, so the put works
-  on float, enum, and string ``:SP`` channels alike — a *typed* ophyd
-  signal connect-fails when the PV's inferred type disagrees).  The gateway
+- ``get_settable(device, variable)`` → a Movable putting the value's **wire
+  form via raw CA** — the shared put primitive
+  (:class:`~geecs_bluesky.devices.ca.gateway_put.GatewaySetpointPut` with the
+  :func:`~geecs_bluesky.devices.ca.gateway_put.wire_value` convention: native
+  numerics, strings CA-converted server-side, so the put works on float,
+  enum, and string ``:SP`` channels alike — a *typed* ophyd signal
+  connect-fails when the PV's inferred type disagrees).  The gateway
   forwards ``:SP`` puts to GEECS's blocking UDP set and only completes the
   CA put when GEECS accepts (or rejects) it — so put-completion *is* the
   legacy ``wait_for_execution`` semantics.  A dtype-inferred probe signal
@@ -40,57 +41,19 @@ from __future__ import annotations
 import logging
 from typing import Any, Callable
 
-from ophyd_async.core import AsyncStatus
 from ophyd_async.epics.core import epics_signal_r
 
 from geecs_bluesky.devices.ca._pv import ca_pv
+from geecs_bluesky.devices.ca.gateway_put import GatewaySetpointPut, wire_value
 from geecs_bluesky.utils import safe_name
 
 logger = logging.getLogger(__name__)
 
 __all__ = ["CaActionSignalFactory"]
 
-
-class _WireSettable:
-    """Movable: puts the wire string to the ``:SP`` PV via raw CA.
-
-    Action YAML values are ``str | float | int``; CA converts the string
-    form to the PV's native type (enum labels, numeric strings) — the same
-    convention as :class:`~geecs_bluesky.shot_controller.CaPutSetter`, and
-    the reason this is a raw ``caput`` rather than a typed ophyd signal
-    (which connect-fails on a float ``:SP``).  In mock mode the put is
-    recorded on ``last_mock_put`` and completes immediately.
-    """
-
-    def __init__(
-        self, pv: str, name: str, *, mock: bool = False, timeout: float = 30.0
-    ) -> None:
-        self._pv = pv
-        self.name = name
-        self._mock = mock
-        self._timeout = timeout
-        self.last_mock_put: str | None = None
-
-    def set(self, value: Any) -> AsyncStatus:
-        """Put the value; the returned status completes with the GEECS set."""
-        # Numbers go natively (DBR_DOUBLE — a string put-with-callback to a
-        # float gateway channel can hang; observed live 2026-07-10); strings
-        # (enum labels, 'on'/'off') go as the wire string, CA-converted.
-        wire = value if isinstance(value, (int, float)) else str(value)
-
-        if self._mock:
-
-            async def _record() -> None:
-                self.last_mock_put = str(wire)
-
-            return AsyncStatus(_record())
-
-        async def _do() -> None:
-            from aioca import caput  # deferred: needs the `ca` extra
-
-            await caput(self._pv, wire, wait=True, timeout=self._timeout)
-
-        return AsyncStatus(_do())
+#: Per-put budget for action set steps (a GEECS set that has not completed in
+#: 30 s is stuck, not slow).
+_ACTION_PUT_TIMEOUT = 30.0
 
 
 class CaActionSignalFactory:
@@ -116,11 +79,11 @@ class CaActionSignalFactory:
         self._experiment = experiment
         self._connect = connect
         self._mock = mock
-        self._settables: dict[tuple[str, str], _WireSettable] = {}
+        self._settables: dict[tuple[str, str], GatewaySetpointPut] = {}
         self._readables: dict[tuple[str, str], Any] = {}
         self._probes: dict[tuple[str, str], Any] = {}
 
-    def get_settable(self, device: str, variable: str) -> _WireSettable:
+    def get_settable(self, device: str, variable: str) -> GatewaySetpointPut:
         """Return the (cached) setpoint writer for ``(device, variable)``.
 
         Parameters
@@ -132,8 +95,8 @@ class CaActionSignalFactory:
 
         Returns
         -------
-        _WireSettable
-            A Movable putting wire strings to the variable's ``:SP`` PV;
+        GatewaySetpointPut
+            A Movable putting wire values to the variable's ``:SP`` PV;
             put-completion rides the GEECS blocking set.
         """
         key = (device, variable)
@@ -146,11 +109,16 @@ class CaActionSignalFactory:
             probe = epics_signal_r(None, pv, name=f"{name}_probe")
             self._connect(probe)
             self._probes[key] = probe
-            # ca_pv returns the ophyd signal-URI form ("ca://<name>"); ophyd
-            # strips the scheme, raw aioca does NOT — a schemed name searches
-            # for a PV that does not exist and hangs forever (live-found
-            # 2026-07-10, issue #490).
-            settable = _WireSettable(pv.removeprefix("ca://"), name, mock=self._mock)
+            # ca_pv returns the ophyd signal-URI form ("ca://<name>"); the
+            # primitive strips it for the raw put — a schemed name hangs
+            # forever under aioca (issue #490; rule lives in gateway_put).
+            settable = GatewaySetpointPut(
+                pv,
+                name=name,
+                coerce=wire_value,
+                timeout=_ACTION_PUT_TIMEOUT,
+                mock=self._mock,
+            )
             self._settables[key] = settable
             logger.debug("action settable created: %s -> %s", key, pv)
         return settable

--- a/GeecsBluesky/geecs_bluesky/devices/ca/action_signals.py
+++ b/GeecsBluesky/geecs_bluesky/devices/ca/action_signals.py
@@ -72,13 +72,16 @@ class _WireSettable:
         self.last_mock_put: str | None = None
 
     def set(self, value: Any) -> AsyncStatus:
-        """Put ``str(value)``; the returned status completes with the GEECS set."""
-        wire = str(value)
+        """Put the value; the returned status completes with the GEECS set."""
+        # Numbers go natively (DBR_DOUBLE — a string put-with-callback to a
+        # float gateway channel can hang; observed live 2026-07-10); strings
+        # (enum labels, 'on'/'off') go as the wire string, CA-converted.
+        wire = value if isinstance(value, (int, float)) else str(value)
 
         if self._mock:
 
             async def _record() -> None:
-                self.last_mock_put = wire
+                self.last_mock_put = str(wire)
 
             return AsyncStatus(_record())
 
@@ -143,7 +146,11 @@ class CaActionSignalFactory:
             probe = epics_signal_r(None, pv, name=f"{name}_probe")
             self._connect(probe)
             self._probes[key] = probe
-            settable = _WireSettable(pv, name, mock=self._mock)
+            # ca_pv returns the ophyd signal-URI form ("ca://<name>"); ophyd
+            # strips the scheme, raw aioca does NOT — a schemed name searches
+            # for a PV that does not exist and hangs forever (live-found
+            # 2026-07-10, issue #490).
+            settable = _WireSettable(pv.removeprefix("ca://"), name, mock=self._mock)
             self._settables[key] = settable
             logger.debug("action settable created: %s -> %s", key, pv)
         return settable

--- a/GeecsBluesky/geecs_bluesky/devices/ca/confirm.py
+++ b/GeecsBluesky/geecs_bluesky/devices/ca/confirm.py
@@ -145,8 +145,9 @@ class CaConfirmSettable(CaSettable):
         loop = asyncio.get_running_loop()
 
         # Layer 1: the gateway :SP put rides the blocking GEECS UDP set on
-        # `variable` — this only confirms *that* variable, not the target.
-        await self._setpoint.set(value)
+        # `variable` — this only confirms *that* variable, not the target —
+        # through the shared put primitive (inherited from CaSettable).
+        await self._put.put(value)
 
         # Layer 2: poll the confirming variable until it matches.
         deadline = loop.time() + self._timeout

--- a/GeecsBluesky/geecs_bluesky/devices/ca/gateway_put.py
+++ b/GeecsBluesky/geecs_bluesky/devices/ca/gateway_put.py
@@ -1,0 +1,182 @@
+"""GatewaySetpointPut — the one blessed gateway ``:SP`` put primitive.
+
+Three call sites used to implement "write a value to a gateway ``:SP`` with
+GEECS-completion semantics" independently: :class:`~geecs_bluesky.devices.ca.
+settable.CaSettable`/``CaMotor``'s Layer-1 ophyd signal put, ``ShotController``'s
+``CaPutSetter`` raw caput, and the action factory's wire settable raw caput.
+Each pathway independently decided the PV **addressing dialect** — ophyd's
+``ca://`` signal URI vs the bare EPICS name aioca expects — and one got it
+wrong: a raw caput to a ``ca://…`` name CA-searches for a PV nothing serves
+and hangs for the full timeout (issue #490, the 2026-07-10 closeout hang).
+This module is the consolidation: one primitive owns the addressing rule,
+the wire-value conventions, the timeout policy, the ``AsyncStatus`` wrapping,
+and mock support; every consumer delegates.  (The legacy engine learned the
+same lesson as ``DeviceCommandExecutor`` — its single blessed command path.)
+
+Two transports, one policy owner:
+
+- **raw CA** (``setpoint_pv=…``) — ``aioca.caput(bare_name, wire, wait=True,
+  timeout=…)``.  Names are normalized by :func:`bare_pv`: the ophyd ``ca://``
+  scheme is stripped (aioca treats a scheme as part of the PV name), any other
+  scheme is rejected.  The gateway forwards ``:SP`` puts to GEECS's blocking
+  UDP set and only completes the CA put when GEECS accepts (or rejects) it —
+  so put-completion *is* the legacy ``wait_for_execution`` semantics.
+- **ophyd signal** (``signal=…``) — delegates to ``signal.set(...)`` on a
+  typed ``epics_signal_rw`` built from the ``ca://`` URI form (ophyd parses
+  the scheme itself; see :mod:`geecs_bluesky.devices.ca._pv`).  Used by
+  ``CaSettable``/``CaMotor`` Layer 1, whose typed signal doubles as the
+  connect-time dtype check and the mock-backend seam
+  (``tests/ca_mock_helpers.follow_setpoint``).
+
+Wire-value conventions (the ``coerce`` parameter — each consumer's pinned,
+hardware-proven convention; do not "unify" them without live verification):
+
+- ``str`` — everything stringified: the ShotController convention (enum
+  labels pass through; the gateway's typed channel coerces numeric strings).
+- :func:`wire_value` — native numerics, wire string otherwise: the
+  action-plan convention (a *string* put-with-callback to a float gateway
+  channel can hang; observed live 2026-07-10, issue #490).
+- ``None`` — pass through untouched: the typed-signal (motor) convention.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Callable
+
+from ophyd_async.core import AsyncStatus
+
+from geecs_bluesky.devices.ca._pv import CA_TRANSPORT_PREFIX
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["GatewaySetpointPut", "bare_pv", "wire_value"]
+
+
+def bare_pv(pv: str) -> str:
+    """Normalize *pv* for raw-aioca use: strip ``ca://``, reject other schemes.
+
+    ophyd strips the ``ca://`` scheme before its backend stores the PV; raw
+    aioca does **not** — it treats the scheme as part of the name, so a
+    schemed put CA-searches for a PV nothing serves and hangs for the full
+    timeout (issue #490).  This is the one place that rule lives.
+
+    Parameters
+    ----------
+    pv : str
+        A gateway PV name, bare (``Expt:Dev:Var:SP``) or in the ophyd
+        signal-URI form (``ca://Expt:Dev:Var:SP``).
+
+    Returns
+    -------
+    str
+        The bare EPICS name.
+
+    Raises
+    ------
+    ValueError
+        If a scheme other than ``ca://`` remains — a raw CA put can never
+        address it.
+    """
+    name = pv.removeprefix(CA_TRANSPORT_PREFIX)
+    if "://" in name:
+        raise ValueError(
+            f"raw CA put needs a bare EPICS name or a ca:// URI, got {pv!r} "
+            "(aioca treats a scheme as part of the PV name — issue #490)"
+        )
+    return name
+
+
+def wire_value(value: Any) -> Any:
+    """Action-plan wire convention: native numerics, wire string otherwise.
+
+    Numbers go natively (DBR_DOUBLE — a string put-with-callback to a float
+    gateway channel can hang; observed live 2026-07-10); strings (enum
+    labels, ``'on'``/``'off'``) go as the wire string, CA-converted to the
+    PV's native type server-side.
+    """
+    return value if isinstance(value, (int, float)) else str(value)
+
+
+class GatewaySetpointPut:
+    """Movable putting one value to a gateway setpoint PV, GEECS-blocking.
+
+    Parameters
+    ----------
+    setpoint_pv : str, optional
+        Raw-CA transport: the ``:SP`` PV name — bare or in the ``ca://`` URI
+        form, normalized by :func:`bare_pv`.  Exactly one of ``setpoint_pv``
+        / ``signal``.
+    signal : SignalRW, optional
+        Ophyd-signal transport: an already-built typed ``:SP`` signal; puts
+        delegate to ``signal.set()`` (mock-aware via ``connect(mock=True)``).
+    coerce : callable, optional
+        ``value → wire value``, applied once per put; ``None`` passes the
+        value through untouched.  See the module docstring for the pinned
+        conventions.
+    timeout : float, optional
+        Default per-put budget in seconds.  ``None`` (signal transport only)
+        defers to the signal's own default.
+    name : str
+        Movable name (Bluesky logging / message repr).
+    mock : bool
+        Raw transport only: record puts on ``last_mock_put`` (as the string
+        form of the wire value) instead of touching CA.
+    """
+
+    def __init__(
+        self,
+        setpoint_pv: str | None = None,
+        *,
+        signal: Any = None,
+        coerce: Callable[[Any], Any] | None = None,
+        timeout: float | None = 10.0,
+        name: str = "",
+        mock: bool = False,
+    ) -> None:
+        if (setpoint_pv is None) == (signal is None):
+            raise ValueError("exactly one of setpoint_pv / signal is required")
+        if signal is not None and mock:
+            raise ValueError(
+                "mock puts belong to the raw-CA transport; a signal-backed "
+                "put mocks through the signal's own connect(mock=True)"
+            )
+        if signal is None and timeout is None:
+            raise ValueError("the raw-CA transport requires a put timeout")
+        self._pv = bare_pv(setpoint_pv) if setpoint_pv is not None else None
+        self._signal = signal
+        self._coerce = coerce
+        self._timeout = timeout
+        self.name = name
+        self._mock = mock
+        self.last_mock_put: str | None = None
+
+    async def put(self, value: Any, timeout: float | None = None) -> None:
+        """Put *value*; returns when the gateway completes the GEECS set.
+
+        Parameters
+        ----------
+        value : Any
+            The value to write; ``coerce`` is applied first.
+        timeout : float, optional
+            Per-put override of the constructor's budget (e.g. a motor's
+            ``move_timeout`` — a slow axis is not a dead one).
+        """
+        wire = self._coerce(value) if self._coerce is not None else value
+        budget = self._timeout if timeout is None else timeout
+        if self._mock:
+            self.last_mock_put = str(wire)
+            return
+        if self._signal is not None:
+            if budget is None:
+                await self._signal.set(wire)
+            else:
+                await self._signal.set(wire, timeout=budget)
+            return
+        from aioca import caput  # deferred: needs the `ca` extra
+
+        await caput(self._pv, wire, wait=True, timeout=budget)
+
+    def set(self, value: Any) -> AsyncStatus:
+        """Movable: put *value*; the status completes with the GEECS set."""
+        return AsyncStatus(self.put(value))

--- a/GeecsBluesky/geecs_bluesky/devices/ca/motor.py
+++ b/GeecsBluesky/geecs_bluesky/devices/ca/motor.py
@@ -101,8 +101,9 @@ class CaMotor(CaSettable):
         loop = asyncio.get_running_loop()
         deadline = loop.time() + self._move_timeout
 
-        # Layer 1: the gateway :SP put rides the blocking GEECS UDP set.
-        await self._setpoint.set(value, timeout=self._move_timeout)
+        # Layer 1: the gateway :SP put rides the blocking GEECS UDP set,
+        # through the shared put primitive with move_timeout as its budget.
+        await self._put.put(value, timeout=self._move_timeout)
 
         # Layer 2: confirm the streamed readback converged.
         position = getattr(self, self._readback_attr_name)

--- a/GeecsBluesky/geecs_bluesky/devices/ca/settable.py
+++ b/GeecsBluesky/geecs_bluesky/devices/ca/settable.py
@@ -22,6 +22,7 @@ from ophyd_async.core import AsyncStatus, StandardReadable
 from ophyd_async.epics.core import epics_signal_r, epics_signal_rw
 
 from geecs_bluesky.devices.ca._pv import ca_pv
+from geecs_bluesky.devices.ca.gateway_put import GatewaySetpointPut
 
 logger = logging.getLogger(__name__)
 
@@ -66,6 +67,11 @@ class CaSettable(StandardReadable):
         # Setpoint is not a child readable (no feedback loop): set() writes it,
         # read() reflects the streamed readback instead.
         self._setpoint = epics_signal_rw(datatype, f"{readback_pv}:SP")
+        # Layer-1 puts ride the shared gateway-put primitive (the one owner
+        # of addressing/coercion/timeout policy); the typed signal stays the
+        # transport — connect-time dtype check and the mock-backend seam.
+        # timeout=None defers to the signal's own default per put.
+        self._put = GatewaySetpointPut(signal=self._setpoint, timeout=None)
         with self.add_children_as_readables():
             setattr(self, _readback_attr, epics_signal_r(datatype, readback_pv))
         super().__init__(name=name)
@@ -96,6 +102,6 @@ class CaSettable(StandardReadable):
 
     async def _set_and_wait(self, value: float) -> None:
         """Write the setpoint and wait ``settle_time`` (subclasses may poll)."""
-        await self._setpoint.set(value)
+        await self._put.put(value)
         if self._settle_time > 0:
             await asyncio.sleep(self._settle_time)

--- a/GeecsBluesky/geecs_bluesky/session.py
+++ b/GeecsBluesky/geecs_bluesky/session.py
@@ -365,13 +365,13 @@ class GeecsSession:
         Returns a fresh per-scan factory: ``get_settable`` puts wire strings
         to the variable's gateway ``:SP`` (put-completion rides the GEECS
         blocking set — the ``wait_for_execution`` semantics), ``get_readable``
-        reads the streamed readback as a string.  Signals are cached per
+        reads the streamed readback natively typed.  Signals are cached per
         ``(device, variable)`` and connected in this session's RE loop at
         creation; pre-connect everything a plan will touch **before** running
         it (see ``scan_request_runner.prefetch_action_signals``) and pass the
         factory to :meth:`disconnect` with the scan's other devices.
         """
-        return CaActionSignalFactory(self.experiment, self._connect)
+        return CaActionSignalFactory(self.experiment, self._connect, mock=self._mock)
 
     # ------------------------------------------------------------------
     # Shot control

--- a/GeecsBluesky/geecs_bluesky/shot_controller.py
+++ b/GeecsBluesky/geecs_bluesky/shot_controller.py
@@ -15,8 +15,8 @@ import logging
 from typing import Any, Callable, Sequence
 
 import bluesky.plan_stubs as bps
-from ophyd_async.core import AsyncStatus
 
+from geecs_bluesky.devices.ca.gateway_put import GatewaySetpointPut
 from geecs_bluesky.exceptions import GeecsConfigurationError
 from geecs_bluesky.models.shot_control import (
     ShotControlConfig,
@@ -29,28 +29,22 @@ from geecs_ca_gateway.pv_naming import pv_name
 logger = logging.getLogger(__name__)
 
 
-class CaPutSetter:
+class CaPutSetter(GatewaySetpointPut):
     """Minimal Bluesky Movable: puts one value to a gateway setpoint PV.
 
     The gateway's ``:SP`` write forwards to the GEECS UDP set and only
     completes when GEECS accepts (or rejects) it, so put-completion carries the
     same semantics as the direct UDP ACK.  Values are sent as strings (labels
     for enum PVs; numeric strings are coerced by the gateway's typed channel).
+
+    A thin pin of the shared put primitive
+    (:class:`~geecs_bluesky.devices.ca.gateway_put.GatewaySetpointPut`) to
+    the hardware-proven shot-control convention: raw CA, every value as its
+    wire string, 10 s default budget.
     """
 
     def __init__(self, setpoint_pv: str, timeout: float = 10.0) -> None:
-        self._pv = setpoint_pv
-        self._timeout = timeout
-
-    def set(self, value: Any) -> AsyncStatus:
-        """Put *value*; resolves when the gateway completes the GEECS set."""
-
-        async def _do() -> None:
-            from aioca import caput  # deferred: needs the `ca` extra
-
-            await caput(self._pv, str(value), wait=True, timeout=self._timeout)
-
-        return AsyncStatus(_do())
+        super().__init__(setpoint_pv, coerce=str, timeout=timeout)
 
 
 class ShotController:
@@ -102,9 +96,9 @@ class ShotController:
         put_timeout: float = 10.0,
     ) -> "ShotController":
         """Build with gateway ``:SP`` setters (no DB lookup, no connection dance)."""
-        # Bare PV names (no ca:// transport prefix): CaPutSetter talks to aioca
-        # directly, not through ophyd-async's transport-prefix parsing — aioca
-        # is the CA transport, and it treats the prefix as part of the PV name.
+        # Bare PV names: CaPutSetter talks to aioca directly, so the name must
+        # not carry the ophyd ca:// scheme — the addressing rule lives in
+        # gateway_put.bare_pv (issue #490).
         setters = {
             var: CaPutSetter(
                 f"{pv_name(experiment, config.device, var)}:SP", timeout=put_timeout

--- a/GeecsBluesky/pyproject.toml
+++ b/GeecsBluesky/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-bluesky"
-version = "0.28.0"
+version = "0.28.1"
 description = "Bluesky / ophyd-async bridge for the GEECS control system"
 authors = ["Sam Barber <sbarber@lbl.gov>"]
 readme = "README.md"

--- a/GeecsBluesky/pyproject.toml
+++ b/GeecsBluesky/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-bluesky"
-version = "0.28.1"
+version = "0.29.0"
 description = "Bluesky / ophyd-async bridge for the GEECS control system"
 authors = ["Sam Barber <sbarber@lbl.gov>"]
 readme = "README.md"

--- a/GeecsBluesky/tests/test_action_signals.py
+++ b/GeecsBluesky/tests/test_action_signals.py
@@ -1,0 +1,95 @@
+"""CaActionSignalFactory — the CA-backed production SettableFactory.
+
+Pins the CA-native put convention (raw wire-string caput, so numeric ``:SP``
+PVs work — the bug found by the first hardware set-step on a float PV) and
+the dtype-inferred probe/readable behavior.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("aioca")  # devices are CA-backed
+
+import bluesky.plan_stubs as bps  # noqa: E402
+from bluesky.run_engine import RunEngine  # noqa: E402
+
+from geecs_bluesky.devices.ca.action_signals import CaActionSignalFactory  # noqa: E402
+
+
+class _Recorder:
+    """Fake session connector: records signals, never touches CA."""
+
+    def __init__(self, fail: bool = False) -> None:
+        self.connected: list = []
+        self.fail = fail
+
+    def __call__(self, signal) -> None:
+        if self.fail:
+            raise ConnectionError(f"no such PV: {signal.name}")
+        self.connected.append(signal)
+
+
+def test_settable_puts_wire_string_on_numeric_value() -> None:
+    """A float action value is put as its wire string (works on float PVs)."""
+    connect = _Recorder()
+    factory = CaActionSignalFactory("Undulator", connect, mock=True)
+    settable = factory.get_settable("U_ESP_JetXYZ", "Position.Axis 1")
+
+    RE = RunEngine(context_managers=[])
+
+    def plan():
+        yield from bps.abs_set(settable, 5.0, wait=True)
+
+    RE(plan())
+    assert settable.last_mock_put == "5.0"
+    # dtype-inferred probe was connected (the pre-claim fail-fast)
+    assert len(connect.connected) == 1
+    assert connect.connected[0].name.endswith("_probe")
+
+
+def test_settable_puts_enum_label_unchanged() -> None:
+    connect = _Recorder()
+    factory = CaActionSignalFactory("Undulator", connect, mock=True)
+    settable = factory.get_settable("U_DG645_ShotControl", "Trigger.Source")
+
+    RE = RunEngine(context_managers=[])
+    RE(bps.abs_set(settable, "External rising edges", wait=True))
+    assert settable.last_mock_put == "External rising edges"
+
+
+def test_settable_cached_per_target() -> None:
+    connect = _Recorder()
+    factory = CaActionSignalFactory("Undulator", connect, mock=True)
+    a = factory.get_settable("U_A", "V")
+    b = factory.get_settable("U_A", "V")
+    assert a is b
+    assert len(connect.connected) == 1  # one probe, cached
+
+
+def test_settable_failfast_when_probe_cannot_connect() -> None:
+    """An unreachable :SP fails at creation (pre-claim), not mid-plan."""
+    factory = CaActionSignalFactory("Undulator", _Recorder(fail=True), mock=True)
+    with pytest.raises(ConnectionError):
+        factory.get_settable("U_Nope", "Missing")
+
+
+async def test_readable_is_dtype_inferred() -> None:
+    """get_readable infers the PV's native type (float stays float)."""
+    from ophyd_async.testing import set_mock_value
+
+    created: list = []
+    factory = CaActionSignalFactory("Undulator", created.append, mock=True)
+    signal = factory.get_readable("U_EMQTripletBipolar", "Current.Ch1")
+    await signal.connect(mock=True)
+    set_mock_value(signal, 2.5)
+    assert await signal.get_value() == 2.5
+
+
+async def test_disconnect_drops_caches() -> None:
+    factory = CaActionSignalFactory("Undulator", _Recorder(), mock=True)
+    factory.get_settable("U_A", "V")
+    factory.get_readable("U_A", "V")
+    await factory.disconnect()
+    assert factory._settables == {} and factory._readables == {}
+    assert factory._probes == {}

--- a/GeecsBluesky/tests/test_action_signals.py
+++ b/GeecsBluesky/tests/test_action_signals.py
@@ -30,6 +30,16 @@ class _Recorder:
         self.connected.append(signal)
 
 
+def test_settable_pv_has_no_transport_scheme() -> None:
+    """The raw-CA put must use the bare PV name — ophyd strips ``ca://``,
+    aioca does not (a schemed name searches forever; issue #490)."""
+    factory = CaActionSignalFactory("Undulator", _Recorder(), mock=True)
+    settable = factory.get_settable("U_ESP_JetXYZ", "Position.Axis 1")
+    assert not settable._pv.startswith("ca://")
+    assert settable._pv == "Undulator:U_ESP_JetXYZ:Position_Axis_1:SP"
+    # the probe keeps the ophyd signal-URI form (ophyd handles the scheme)
+
+
 def test_settable_puts_wire_string_on_numeric_value() -> None:
     """A float action value is put as its wire string (works on float PVs)."""
     connect = _Recorder()

--- a/GeecsBluesky/tests/test_gateway_put.py
+++ b/GeecsBluesky/tests/test_gateway_put.py
@@ -1,0 +1,160 @@
+"""GatewaySetpointPut — the one blessed gateway ``:SP`` put primitive.
+
+Pins the centralized addressing rule (``ca://`` stripped for raw CA, other
+schemes rejected — issue #490), each consumer's wire-value convention (the
+ShotController always-string pin must stay byte-identical — hardware-proven),
+the timeout policy, ``AsyncStatus`` wrapping, and mock behavior.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("aioca")  # the raw transport needs the `ca` extra
+
+import aioca  # noqa: E402
+
+from geecs_bluesky.devices.ca.gateway_put import (  # noqa: E402
+    GatewaySetpointPut,
+    bare_pv,
+    wire_value,
+)
+from geecs_bluesky.shot_controller import CaPutSetter  # noqa: E402
+
+
+class _CaputRecorder:
+    """Stands in for ``aioca.caput``: records every call, resolves at once."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple] = []
+
+    async def __call__(self, pv, value, **kwargs) -> None:
+        self.calls.append((pv, value, kwargs))
+
+
+@pytest.fixture()
+def caput(monkeypatch) -> _CaputRecorder:
+    recorder = _CaputRecorder()
+    monkeypatch.setattr(aioca, "caput", recorder)
+    return recorder
+
+
+class _SignalRecorder:
+    """Stands in for a typed ophyd ``:SP`` signal: records ``set`` calls."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple] = []
+
+    async def set(self, value, **kwargs) -> None:
+        self.calls.append((value, kwargs))
+
+
+# ---------------------------------------------------------------------------
+# The addressing rule — the one place the ophyd-vs-aioca dialect is decided
+# ---------------------------------------------------------------------------
+
+
+def test_bare_pv_strips_the_ca_scheme() -> None:
+    assert bare_pv("ca://Undulator:U_Dev:Var:SP") == "Undulator:U_Dev:Var:SP"
+
+
+def test_bare_pv_passes_bare_names_through() -> None:
+    assert bare_pv("Undulator:U_Dev:Var:SP") == "Undulator:U_Dev:Var:SP"
+
+
+@pytest.mark.parametrize("pv", ["pva://Undulator:U_Dev:Var:SP", "http://x/y"])
+def test_bare_pv_rejects_non_ca_schemes(pv: str) -> None:
+    with pytest.raises(ValueError):
+        bare_pv(pv)
+
+
+def test_primitive_normalizes_schemed_names_at_construction() -> None:
+    """The issue-#490 invariant: a raw put never sees a ``ca://`` name."""
+    put = GatewaySetpointPut("ca://Undulator:U_Dev:Var:SP", mock=True)
+    assert put._pv == "Undulator:U_Dev:Var:SP"
+
+
+# ---------------------------------------------------------------------------
+# Constructor policy
+# ---------------------------------------------------------------------------
+
+
+def test_exactly_one_transport_is_required() -> None:
+    with pytest.raises(ValueError):
+        GatewaySetpointPut()
+    with pytest.raises(ValueError):
+        GatewaySetpointPut("X:SP", signal=_SignalRecorder())
+
+
+def test_mock_is_raw_transport_only() -> None:
+    with pytest.raises(ValueError):
+        GatewaySetpointPut(signal=_SignalRecorder(), mock=True)
+
+
+def test_raw_transport_requires_a_timeout() -> None:
+    with pytest.raises(ValueError):
+        GatewaySetpointPut("X:SP", timeout=None)
+
+
+# ---------------------------------------------------------------------------
+# Raw-CA transport: wire conventions and timeout policy
+# ---------------------------------------------------------------------------
+
+
+async def test_shot_control_convention_is_byte_identical(caput) -> None:
+    """CaPutSetter: every value goes as its wire string, 10 s default budget
+    (the hardware-proven ShotController behavior — do not drift this)."""
+    setter = CaPutSetter("Undulator:U_DG645_ShotControl:Amplitude_Ch_AB:SP")
+    await setter.set(4.0)
+    assert caput.calls == [
+        (
+            "Undulator:U_DG645_ShotControl:Amplitude_Ch_AB:SP",
+            "4.0",
+            {"wait": True, "timeout": 10.0},
+        )
+    ]
+
+
+async def test_wire_value_convention_sends_numerics_natively(caput) -> None:
+    """The action convention: native numbers, strings as wire strings."""
+    put = GatewaySetpointPut("X:SP", coerce=wire_value, timeout=30.0)
+    await put.put(5.0)
+    await put.put("External rising edges")
+    assert caput.calls == [
+        ("X:SP", 5.0, {"wait": True, "timeout": 30.0}),
+        ("X:SP", "External rising edges", {"wait": True, "timeout": 30.0}),
+    ]
+
+
+async def test_per_put_timeout_overrides_the_default(caput) -> None:
+    put = GatewaySetpointPut("X:SP", timeout=10.0)
+    await put.put(1.0, timeout=45.0)
+    assert caput.calls[0][2]["timeout"] == 45.0
+
+
+async def test_mock_records_instead_of_touching_ca(caput) -> None:
+    put = GatewaySetpointPut("X:SP", coerce=wire_value, mock=True)
+    await put.set(4.0)
+    assert put.last_mock_put == "4.0"
+    assert caput.calls == []
+
+
+# ---------------------------------------------------------------------------
+# Signal transport: CaSettable/CaMotor Layer-1 semantics
+# ---------------------------------------------------------------------------
+
+
+async def test_signal_transport_defers_to_signal_default_timeout() -> None:
+    """timeout=None → the signal's own default (the CaSettable behavior)."""
+    signal = _SignalRecorder()
+    put = GatewaySetpointPut(signal=signal, timeout=None)
+    await put.put(3.5)
+    assert signal.calls == [(3.5, {})]
+
+
+async def test_signal_transport_passes_the_move_budget_through() -> None:
+    """A per-put timeout reaches signal.set (CaMotor's move_timeout)."""
+    signal = _SignalRecorder()
+    put = GatewaySetpointPut(signal=signal, timeout=None)
+    await put.put(3.5, timeout=30.0)
+    assert signal.calls == [(3.5, {"timeout": 30.0})]

--- a/GeecsBluesky/tests/test_session.py
+++ b/GeecsBluesky/tests/test_session.py
@@ -135,29 +135,27 @@ def test_shot_control_accepts_generalized_writes() -> None:
 
 
 def test_action_signal_factory_builds_cached_connected_signals() -> None:
-    """The production SettableFactory: :SP settables, str readbacks, caching."""
+    """The production SettableFactory: CA-native :SP puts, dtype-inferred reads."""
     import asyncio
 
     s = _session()
     factory = s.action_signal_factory()
     settable = factory.get_settable("U_PLC", "DO.Ch9")
-    assert settable._signal.source.endswith("Undulator:U_PLC:DO_Ch9:SP")
+    assert settable._pv.endswith("Undulator:U_PLC:DO_Ch9:SP")
     # Cached per (device, variable): the same wrapper comes back.
     assert factory.get_settable("U_PLC", "DO.Ch9") is settable
     readable = factory.get_readable("U_PLC", "DI.Ch17")
     assert readable.source.endswith("Undulator:U_PLC:DI_Ch17")
     assert factory.get_readable("U_PLC", "DI.Ch17") is readable
 
-    # Values are coerced to wire strings on set (mock backend records it).
-    # set() is awaited inside the RE loop, as the RunEngine would.
-    async def _set_and_read() -> str:
+    # Values are coerced to wire strings on set (mock session records the
+    # put — raw CA in production, per the CaPutSetter convention, so numeric
+    # :SP PVs accept the put).  set() is awaited inside the RE loop.
+    async def _set() -> None:
         await settable.set(4.0)
-        return await settable._signal.get_value()
 
-    value = asyncio.run_coroutine_threadsafe(_set_and_read(), s.RE._loop).result(
-        timeout=5.0
-    )
-    assert value == "4.0"
+    asyncio.run_coroutine_threadsafe(_set(), s.RE._loop).result(timeout=5.0)
+    assert settable.last_mock_put == "4.0"
 
     # The factory rides the scan cleanup path uniformly.
     s.disconnect(factory)


### PR DESCRIPTION
> [!NOTE]
> **Stacked on #489** (`fix/action-signals-ca-native`) — the first two commits here are #489's. Review only the top commit (`refactor(devices): consolidate all gateway :SP puts onto GatewaySetpointPut`); the diff collapses to it once #489 merges.

## Why

Three separate implementations of "write a value to a gateway `:SP` with GEECS-completion semantics" existed: `CaMotor`'s Layer-1 ophyd signal put (`devices/ca/motor.py`), `CaPutSetter`'s raw aioca caput (`shot_controller.py`), and `_WireSettable`'s raw caput (`devices/ca/action_signals.py`, post-#489). Each pathway independently decided the PV addressing dialect (ophyd `ca://` signal URI vs the bare EPICS name aioca expects) — which tripled the suspect list during the 2026-07-10 closeout-hang diagnosis and produced the actual bug (#490: `_WireSettable` raw-caputting a `ca://…` name that nothing serves). The legacy engine had already learned this lesson: `DeviceCommandExecutor` was its single blessed command path.

## What

**New `devices/ca/gateway_put.py`** — `GatewaySetpointPut`, the one owner of:

- **the addressing rule**: `bare_pv()` strips the ophyd `ca://` scheme for raw-aioca use and rejects any other scheme (the centralized #490 rule, with tests asserting the primitive strips/rejects schemed names)
- **the wire-value conventions** (`coerce`): `str` = the hardware-proven shot-control convention; `wire_value` (native numerics, wire strings otherwise) = the action convention; `None` = pass-through for typed signals
- **timeout policy** (constructor default + per-put override), **`AsyncStatus` wrapping**, and **mock support** (`last_mock_put`)
- **two transports**: raw CA (`aioca.caput(bare_name, …, wait=True)`) and ophyd-signal (delegates to a typed `epics_signal_rw`, which stays the connect-time dtype check and the mock-backend seam for `follow_setpoint`)

**All consumers delegate, semantics preserved exactly:**

- `CaPutSetter` → thin subclass pin: `coerce=str`, 10 s default — byte-identical wire behavior (`caput(pv, str(value), wait=True, timeout=10.0)`, pinned by test). `ShotController` construction paths and `connect_setters` untouched.
- `CaActionSignalFactory` → hands out the primitive directly (`coerce=wire_value`, 30 s, mock-aware) + keeps the dtype-inferred probe and the #490 bare-name invariant (existing `test_action_signals.py` pins stay green, including `settable._pv` and `last_mock_put`).
- `CaSettable` / `CaMotor` / `CaConfirmSettable` → Layer-1 puts go through a signal-backed primitive; `CaMotor` keeps `move_timeout` as the put budget, `CaSettable` keeps the signal's own default timeout.

## Testing

- New `tests/test_gateway_put.py` (13 tests): addressing rule (strip `ca://`, reject `pva://`), constructor policy, byte-identical `CaPutSetter` convention, wire-value convention, timeout override, mock recording, signal-transport timeout semantics.
- Full GeecsBluesky suite: **439 passed, 1 skipped** — existing `test_action_signals` / `test_shot_control` / `test_ca_devices` pins untouched.

Minor bump to 0.29.0 + CHANGELOG; module added to the package CLAUDE.md layout.

Refs #489, closes nothing new (#490 already closed by #489's branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)