### PR TITLE
tooling: commit.sh — tolerate staged deletions in the re-stage step

### DIFF
--- a/scripts/commit.sh
+++ b/scripts/commit.sh
@@ -32,7 +32,8 @@ set -euo pipefail
 # The files staged for this commit, recorded NUL-delimited in a temp file
 # (space-safe; bash variables cannot hold NUL, so a file — not a var).
 staged="$(mktemp)"
-trap 'rm -f "$staged"' EXIT
+existing="$(mktemp)"
+trap 'rm -f "$staged" "$existing"' EXIT
 git diff --cached --name-only -z >"$staged"
 if [ ! -s "$staged" ]; then
     echo "commit.sh: nothing staged — 'git add' your changes first." >&2
@@ -50,9 +51,23 @@ fi
 # It exits non-zero when it rewrites a file — expected here, so don't abort.
 pc run || true
 
-# Re-stage exactly the originally-staged files so the fixes are included.
+# Re-stage exactly the originally-staged files so the fixes are included —
+# but only those that still exist on disk. A staged *deletion* is in neither
+# the index nor the worktree, so `git add` (even with -A) rejects its pathspec
+# as fatal; and there is nothing to re-stage anyway, since no hook can have
+# rewritten a file that does not exist. The deletion stays staged as-is.
+while IFS= read -r -d '' path; do
+    if [ -e "$path" ] || [ -L "$path" ]; then
+        printf '%s\0' "$path"
+    fi
+done <"$staged" >"$existing"
+
+# Skip when everything staged was a deletion (empty input would make GNU
+# xargs still run `git add --` once, and BSD xargs skip it — moot it).
 # `xargs -0 ... < file` is portable across BSD (macOS) and GNU xargs.
-xargs -0 git add -- <"$staged"
+if [ -s "$existing" ]; then
+    xargs -0 git add -- <"$existing"
+fi
 
 # Commit. The commit-time hook run is now clean, so this passes on the first try.
 git commit "$@"


### PR DESCRIPTION
## Problem

`scripts/commit.sh` fails whenever the staged set contains deleted files. It snapshots the staged paths, runs pre-commit, then re-stages via `xargs -0 git add --` — but a staged deletion exists in neither the index nor the worktree, so `git add` rejects its pathspec as fatal, and `set -euo pipefail` aborts the script before the commit. Hit in practice on #487 (~15 `git rm`'d files).

Note: `git add -A --` / `--all` does **not** fix this — empirically it fails with the same `pathspec did not match any files` error once the path is gone from both index and worktree.

## Fix

Filter the re-stage list to paths that still exist on disk (`-e` or `-L` for symlinks). Staged deletions need no re-staging — no hook can have rewritten a file that doesn't exist — so the deletion simply stays staged from the original `git add`. When everything staged was a deletion, the `xargs` call is skipped entirely (avoids GNU-xargs' run-once-on-empty-input behavior).

## Testing

Scratch repo with a local auto-fixing pre-commit hook (appends a marker + exits 1, like ruff-format):

- **deletion + modification staged** → old script: fatal at the `git add` step; new script: single commit containing both the deletions and the hook-rewritten modification, hooks green
- **filename with spaces** → NUL-delimited path handling preserved
- **all-deletions commit** → hook skips (no files), commit succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)