### PR TITLE
GEECS-Console 0.1.1: visual treatment (screen map parity)

### DIFF
--- a/GEECS-Console/CHANGELOG.md
+++ b/GEECS-Console/CHANGELOG.md
@@ -4,6 +4,35 @@ All notable changes to GEECS-Console are documented here.  Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versioning is
 semantic.
 
+## [0.1.1] - 2026-07-10
+
+### Added
+
+- Visual treatment to match screen map v0.1: a packaged Qt stylesheet
+  (`geecs_console/app/style.qss`, applied application-wide at window
+  construction) implementing the approved screen-map palette and widget
+  treatments — panel group boxes with small uppercase dim legends, primary
+  blue Start / danger-outline Stop, white 1px-bordered inputs and lists,
+  accent radios, thin green progress bar, dim monospace status bar and
+  hints, dark monospace log tail.
+- Health chips render as rounded pills with a per-status colored dot
+  (grey unknown / green ok / amber warn / red down); `HealthStatus` gains
+  `WARN`.  The Now panel's state text renders as a pill (colored dot +
+  uppercase state word).
+- Screen-map layout parity in the `.ui`: session bar in its own panel,
+  save-set lists stacked vertically with Add/Remove between them, submit
+  row in a panel with the `request → validate → submit` hint, 26/46/28
+  column proportions, 10px outer margins with 8px gaps.
+
+### Changed
+
+- Spin boxes use `NoButtons` (plain fields per the screen map; the native
+  macOS button geometry drew outside the styled border).  Values adjust
+  by typing, arrow keys, or wheel.
+- The experiment combo shows a `select experiment…` placeholder when the
+  configs repo lists experiments but none is selected yet (it previously
+  rendered blank until the dropdown was opened).
+
 ## [0.1.0] - 2026-07-10
 
 ### Added

--- a/GEECS-Console/geecs_console/app/main_window.py
+++ b/GEECS-Console/geecs_console/app/main_window.py
@@ -20,6 +20,7 @@ from typing import Callable, Optional
 from PySide6.QtCore import QFile, QTimer
 from PySide6.QtUiTools import QUiLoader
 from PySide6.QtWidgets import (
+    QApplication,
     QComboBox,
     QDoubleSpinBox,
     QLabel,
@@ -46,12 +47,39 @@ from geecs_console.request_builder import (
     estimate_total_shots,
 )
 from geecs_console.services.configs import ConsoleConfigs
-from geecs_console.services.health import HealthProbe, StubHealth
+from geecs_console.services.health import HealthProbe, HealthStatus, StubHealth
 from geecs_console.submission import Submitter, make_bluesky_submitter
 
 _UI_PATH = Path(__file__).parent / "ui" / "main_window.ui"
+_QSS_PATH = Path(__file__).parent / "style.qss"
 
 _SCAN_NUMBER_EXPIRY_MS = 10_000
+
+#: Screen-map semantic colors (see style.qss header for the full palette).
+_COLOR_DIM = "#6b7681"
+_COLOR_GREY = "#b9c0c7"
+_COLOR_GREEN = "#2f9e63"
+_COLOR_AMBER = "#d9a21b"
+_COLOR_RED = "#c4453a"
+
+_HEALTH_DOT_COLORS = {
+    HealthStatus.OK: _COLOR_GREEN,
+    HealthStatus.WARN: _COLOR_AMBER,
+    HealthStatus.DOWN: _COLOR_RED,
+    HealthStatus.UNKNOWN: _COLOR_GREY,
+}
+
+#: ScanState value → state-pill dot color (grey covers idle/unknown).
+_STATE_DOT_COLORS = {
+    "running": _COLOR_GREEN,
+    "done": _COLOR_GREEN,
+    "complete": _COLOR_GREEN,
+    "completed": _COLOR_GREEN,
+    "initializing": _COLOR_AMBER,
+    "aborted": _COLOR_RED,
+    "error": _COLOR_RED,
+    "failed": _COLOR_RED,
+}
 
 
 def _package_version() -> str:
@@ -60,6 +88,20 @@ def _package_version() -> str:
         return importlib.metadata.version("geecs-console")
     except importlib.metadata.PackageNotFoundError:
         return "dev"
+
+
+def load_stylesheet() -> str:
+    """Read the packaged QSS, resolving the ui-directory asset token.
+
+    Returns
+    -------
+    str
+        The stylesheet text with ``@UI_DIR@`` replaced by the absolute
+        path of the packaged ``ui/`` directory (combo/spin arrow SVGs).
+    """
+    qss = _QSS_PATH.read_text(encoding="utf-8")
+    ui_dir = (Path(__file__).parent / "ui").as_posix()
+    return qss.replace("@UI_DIR@", ui_dir)
 
 
 class MainWindow(QMainWindow):
@@ -102,6 +144,7 @@ class MainWindow(QMainWindow):
         self._total_shots = 0
         self._shot_count_valid = False
 
+        self._apply_stylesheet()
         self._load_ui()
         self._bind_widgets()
         self._build_menus()
@@ -116,11 +159,18 @@ class MainWindow(QMainWindow):
 
         self._populate_from_configs()
         self._refresh_health()
+        self._set_state_pill("idle")
         self._on_mode_changed()
 
     # ------------------------------------------------------------------
     # Construction
     # ------------------------------------------------------------------
+
+    def _apply_stylesheet(self) -> None:
+        """Apply the packaged QSS application-wide (once per process)."""
+        app = QApplication.instance()
+        if app is not None and not app.styleSheet():
+            app.setStyleSheet(load_stylesheet())
 
     def _load_ui(self) -> None:
         """Load the Designer .ui as the central widget."""
@@ -134,6 +184,14 @@ class MainWindow(QMainWindow):
         if self._ui is None:
             raise RuntimeError(f"Failed to load {_UI_PATH}: {loader.errorString()}")
         self.setCentralWidget(self._ui)
+        # Screen-map column proportions (R2 26% | center 46% | right 28%).
+        # QUiLoader ignores the .ui stretch attribute, so set it here.
+        from PySide6.QtWidgets import QHBoxLayout
+
+        columns = self._ui.findChild(QHBoxLayout, "columns_layout")
+        if columns is not None:
+            for index, stretch in enumerate((26, 46, 28)):
+                columns.setStretch(index, stretch)
 
     def _child(self, cls: type, name: str):
         """Return the named child widget, failing loudly when missing."""
@@ -281,7 +339,13 @@ class MainWindow(QMainWindow):
         if self._configs.experiment:
             self.experiment_combo.setCurrentText(self._configs.experiment)
         else:
+            # Populated but nothing selected: show a placeholder rather
+            # than rendering blank (the combo is editable, so its line
+            # edit carries the hint until the operator picks one).
             self.experiment_combo.setCurrentIndex(-1)
+            line_edit = self.experiment_combo.lineEdit()
+            if line_edit is not None:
+                line_edit.setPlaceholderText("select experiment…")
         self.experiment_combo.blockSignals(False)
 
         self.available_list.clear()
@@ -306,12 +370,31 @@ class MainWindow(QMainWindow):
         self._refresh_union_preview()
         self._refresh_shot_count()
 
+    @staticmethod
+    def _chip_markup(name: str, status: HealthStatus) -> str:
+        """Rich-text pill body for one R1 health chip: colored dot + text.
+
+        Parameters
+        ----------
+        name : str
+            The chip's service name (``gateway`` / ``tiled`` / ``db``).
+        status : HealthStatus
+            The polled status (drives the dot color).
+
+        Returns
+        -------
+        str
+            QLabel rich text — the pill border/background come from QSS.
+        """
+        color = _HEALTH_DOT_COLORS.get(status, _COLOR_GREY)
+        return f'<span style="color:{color};">●</span> {name}: {status.value}'
+
     def _refresh_health(self) -> None:
         """Poll the health probe into the R1 chips."""
         report = self._health.poll()
-        self.gateway_chip.setText(f"gateway: {report.gateway.value}")
-        self.tiled_chip.setText(f"tiled: {report.tiled.value}")
-        self.db_chip.setText(f"db: {report.db.value}")
+        self.gateway_chip.setText(self._chip_markup("gateway", report.gateway))
+        self.tiled_chip.setText(self._chip_markup("tiled", report.tiled))
+        self.db_chip.setText(self._chip_markup("db", report.db))
 
     # ------------------------------------------------------------------
     # Form state (the round-trip surface tests exercise)
@@ -629,9 +712,23 @@ class MainWindow(QMainWindow):
         if text.startswith("Scan "):
             self.scan_number_label.setText(f"{text} (previous)")
 
+    def _set_state_pill(self, state: str) -> None:
+        """Render the R6 state pill: colored dot + uppercase state word.
+
+        Parameters
+        ----------
+        state : str
+            A ``ScanState`` value (e.g. ``"running"``); dot color is green
+            for running/done, amber for initializing, red for aborted or
+            error, grey otherwise (idle).
+        """
+        word = (state or "idle").strip()
+        color = _STATE_DOT_COLORS.get(word.lower(), _COLOR_GREY)
+        self.state_pill.setText(f'<span style="color:{color};">●</span> {word.upper()}')
+
     def _on_scan_state(self, state: str) -> None:
         """Update the state pill and button gating on lifecycle events."""
-        self.state_pill.setText(state)
+        self._set_state_pill(state)
         self._refresh_submit_enabled()
 
     def _on_totals_known(self, total_shots: int) -> None:

--- a/GEECS-Console/geecs_console/app/style.qss
+++ b/GEECS-Console/geecs_console/app/style.qss
@@ -1,0 +1,475 @@
+/* GEECS-Console visual treatment — matches the approved screen map v0.1.
+ *
+ * Palette (wireframe chrome from the screen-map artifact):
+ *   --w-bg      #eceef0   window background
+ *   --w-panel   #fbfcfd   group-box panel
+ *   --w-line    #b9c0c7   1px borders
+ *   --w-ink     #2a323a   primary text
+ *   --w-dim     #6b7681   secondary text / legends / hints
+ *   --w-accent  #2e7fb8   primary action + checked radio
+ *   --run       #2f9e63   green semantic
+ *   --warn      #d9a21b   amber semantic
+ *   --abort     #c4453a   red semantic / danger
+ *
+ * Loaded by geecs_console.app.main_window.load_stylesheet(), which replaces
+ * the @UI_DIR@ token with the absolute path of the packaged ui/ directory
+ * (for the combo-box arrow asset).
+ */
+
+QMainWindow,
+QWidget#ConsoleRoot {
+    background-color: #eceef0;
+}
+
+QWidget {
+    font-size: 12px;
+    color: #2a323a;
+}
+
+/* ------------------------------------------------------------------ */
+/* Group boxes: crisp 1px border, panel background, small dim legend  */
+/* on the border (title text is uppercased in the .ui — QSS has no    */
+/* text-transform).                                                   */
+/* ------------------------------------------------------------------ */
+
+QGroupBox {
+    background-color: #fbfcfd;
+    border: 1px solid #b9c0c7;
+    border-radius: 4px;
+    margin-top: 8px;
+    padding: 8px;
+    font-size: 11px;
+    font-weight: 600;
+    color: #6b7681;
+}
+
+QGroupBox::title {
+    subcontrol-origin: margin;
+    subcontrol-position: top left;
+    left: 8px;
+    top: 2px;
+    padding: 0px 5px;
+    background-color: #fbfcfd;
+    color: #6b7681;
+}
+
+/* Children reset the group box's legend font. */
+QGroupBox QLabel,
+QGroupBox QRadioButton,
+QGroupBox QCheckBox {
+    font-size: 12px;
+    font-weight: normal;
+    color: #2a323a;
+}
+
+QLabel {
+    background: transparent;
+}
+
+/* ------------------------------------------------------------------ */
+/* Buttons                                                            */
+/* ------------------------------------------------------------------ */
+
+QPushButton {
+    background-color: qlineargradient(x1: 0, y1: 0, x2: 0, y2: 1,
+                                      stop: 0 #fdfdfd, stop: 1 #eef0f2);
+    border: 1px solid #b9c0c7;
+    border-radius: 3px;
+    padding: 4px 12px;
+    color: #2a323a;
+    font-size: 12px;
+    font-weight: normal;
+}
+
+QPushButton:hover {
+    background-color: qlineargradient(x1: 0, y1: 0, x2: 0, y2: 1,
+                                      stop: 0 #ffffff, stop: 1 #f2f4f6);
+    border-color: #a5adb5;
+}
+
+QPushButton:pressed {
+    background-color: #e4e7ea;
+}
+
+QPushButton:disabled {
+    background-color: #f2f3f5;
+    border-color: #d3d8dc;
+    color: #9aa4ad;
+}
+
+/* Primary: Start scan */
+QPushButton#r5_start_button {
+    background-color: #2e7fb8;
+    border: 1px solid #2e7fb8;
+    color: #ffffff;
+    font-weight: 600;
+    padding: 5px 16px;
+}
+
+QPushButton#r5_start_button:hover {
+    background-color: #1d6da6;
+    border-color: #1d6da6;
+}
+
+QPushButton#r5_start_button:pressed {
+    background-color: #175d8f;
+}
+
+QPushButton#r5_start_button:disabled {
+    background-color: #b9d2e4;
+    border-color: #b9d2e4;
+    color: #f3f7fa;
+}
+
+/* Danger outline: Stop */
+QPushButton#r5_stop_button {
+    background-color: #ffffff;
+    border: 1px solid #c4453a;
+    color: #c4453a;
+    padding: 5px 16px;
+}
+
+QPushButton#r5_stop_button:hover {
+    background-color: #fbf1f0;
+}
+
+QPushButton#r5_stop_button:pressed {
+    background-color: #f5e0de;
+}
+
+QPushButton#r5_stop_button:disabled {
+    background-color: #fbfbfb;
+    border-color: #ddc7c4;
+    color: #d3a49f;
+}
+
+/* ------------------------------------------------------------------ */
+/* Inputs: white, 1px line border, 3px radius                         */
+/* ------------------------------------------------------------------ */
+
+QLineEdit {
+    background-color: #ffffff;
+    border: 1px solid #b9c0c7;
+    border-radius: 3px;
+    padding: 3px 6px;
+    color: #2a323a;
+    selection-background-color: #dcebf5;
+    selection-color: #2a323a;
+}
+
+QLineEdit:focus {
+    border-color: #2e7fb8;
+}
+
+QLineEdit:disabled {
+    background-color: #f2f3f5;
+    color: #9aa4ad;
+}
+
+QComboBox {
+    background-color: #ffffff;
+    border: 1px solid #b9c0c7;
+    border-radius: 3px;
+    padding: 3px 20px 3px 6px;
+    color: #2a323a;
+    selection-background-color: #dcebf5;
+    selection-color: #2a323a;
+}
+
+QComboBox:focus {
+    border-color: #2e7fb8;
+}
+
+QComboBox:disabled {
+    background-color: #f2f3f5;
+    color: #9aa4ad;
+}
+
+QComboBox::drop-down {
+    subcontrol-origin: padding;
+    subcontrol-position: center right;
+    width: 18px;
+    border: none;
+}
+
+QComboBox::down-arrow {
+    image: url("@UI_DIR@/arrow_down.svg");
+    width: 8px;
+    height: 8px;
+}
+
+QComboBox QAbstractItemView {
+    background-color: #ffffff;
+    border: 1px solid #b9c0c7;
+    selection-background-color: #dcebf5;
+    selection-color: #2a323a;
+    outline: none;
+}
+
+QSpinBox,
+QDoubleSpinBox {
+    background-color: #ffffff;
+    border: 1px solid #b9c0c7;
+    border-radius: 3px;
+    padding: 3px 4px 3px 6px;
+    color: #2a323a;
+    selection-background-color: #dcebf5;
+    selection-color: #2a323a;
+}
+
+QSpinBox:focus,
+QDoubleSpinBox:focus {
+    border-color: #2e7fb8;
+}
+
+QSpinBox:disabled,
+QDoubleSpinBox:disabled {
+    background-color: #f2f3f5;
+    color: #9aa4ad;
+}
+
+/* Spin buttons are disabled in the .ui (QAbstractSpinBox::NoButtons):
+ * on macOS the native button geometry draws outside the QSS border and
+ * looks detached, and the screen map's number fields are plain inputs.
+ * Typing, arrow keys, and wheel still adjust values. */
+
+/* ------------------------------------------------------------------ */
+/* Lists                                                              */
+/* ------------------------------------------------------------------ */
+
+QListWidget {
+    background-color: #ffffff;
+    border: 1px solid #b9c0c7;
+    border-radius: 3px;
+    outline: none;
+}
+
+QListWidget::item {
+    padding: 3px 8px;
+    border-bottom: 1px solid #eef1f3;
+    color: #2a323a;
+}
+
+QListWidget::item:selected {
+    background-color: #dcebf5;
+    color: #2a323a;
+}
+
+QListWidget::item:hover {
+    background-color: #f0f5f9;
+}
+
+/* ------------------------------------------------------------------ */
+/* Radios: accent when checked                                        */
+/* ------------------------------------------------------------------ */
+
+QRadioButton {
+    spacing: 5px;
+}
+
+QRadioButton::indicator {
+    width: 13px;
+    height: 13px;
+    border: 1px solid #6b7681;
+    border-radius: 7px;
+    background-color: #ffffff;
+}
+
+QRadioButton::indicator:hover {
+    border-color: #2e7fb8;
+}
+
+QRadioButton::indicator:checked {
+    border: 1px solid #2e7fb8;
+    background-color: qradialgradient(cx: 0.5, cy: 0.5, radius: 0.5,
+                                      fx: 0.5, fy: 0.5,
+                                      stop: 0.50 #2e7fb8, stop: 0.62 #ffffff,
+                                      stop: 1 #ffffff);
+}
+
+QRadioButton:disabled {
+    color: #9aa4ad;
+}
+
+QRadioButton::indicator:disabled {
+    border-color: #c9cfd5;
+    background-color: #f2f3f5;
+}
+
+/* ------------------------------------------------------------------ */
+/* Progress bar: thin, rounded, green chunk                           */
+/* ------------------------------------------------------------------ */
+
+QProgressBar {
+    background-color: #ffffff;
+    border: 1px solid #b9c0c7;
+    border-radius: 6px;
+    min-height: 12px;
+    max-height: 12px;
+    text-align: center;
+    font-size: 9px;
+    color: #6b7681;
+}
+
+QProgressBar::chunk {
+    background-color: #2f9e63;
+    border-radius: 5px;
+}
+
+/* ------------------------------------------------------------------ */
+/* Menu bar + status bar chrome                                       */
+/* ------------------------------------------------------------------ */
+
+QMenuBar {
+    background-color: #f2f4f5;
+    border-bottom: 1px solid #b9c0c7;
+    color: #2a323a;
+}
+
+QMenuBar::item {
+    padding: 3px 9px;
+    background: transparent;
+    border-radius: 3px;
+}
+
+QMenuBar::item:selected {
+    background-color: #dde4ea;
+}
+
+QMenu {
+    background-color: #fbfcfd;
+    border: 1px solid #b9c0c7;
+    color: #2a323a;
+}
+
+QMenu::item {
+    padding: 4px 18px;
+}
+
+QMenu::item:selected {
+    background-color: #dcebf5;
+}
+
+QMenu::item:disabled {
+    color: #9aa4ad;
+}
+
+QStatusBar {
+    background-color: #f2f4f5;
+    border-top: 1px solid #b9c0c7;
+    color: #6b7681;
+}
+
+QStatusBar QLabel {
+    font-family: "SF Mono", "Menlo", "Consolas", "DejaVu Sans Mono", monospace;
+    font-size: 11px;
+    color: #6b7681;
+    background: transparent;
+}
+
+QStatusBar::item {
+    border: none;
+}
+
+/* ------------------------------------------------------------------ */
+/* R1 health chips: small rounded pills (dot colored in rich text)    */
+/* ------------------------------------------------------------------ */
+
+QLabel#r1_gateway_chip,
+QLabel#r1_tiled_chip,
+QLabel#r1_db_chip {
+    background-color: #ffffff;
+    border: 1px solid #b9c0c7;
+    border-radius: 9px;
+    padding: 1px 8px;
+    font-family: "SF Mono", "Menlo", "Consolas", "DejaVu Sans Mono", monospace;
+    font-size: 11px;
+    color: #6b7681;
+}
+
+/* ------------------------------------------------------------------ */
+/* Dim field labels and hint lines                                    */
+/* ------------------------------------------------------------------ */
+
+QLabel#r1_experiment_label,
+QLabel#r1_rep_rate_label,
+QLabel#r1_trigger_label,
+QLabel#r3_variable_label,
+QLabel#r3_start_label,
+QLabel#r3_stop_label,
+QLabel#r3_step_label,
+QLabel#r3_variable2_label,
+QLabel#r3_start2_label,
+QLabel#r3_stop2_label,
+QLabel#r3_step2_label,
+QLabel#r3_shots_label,
+QLabel#r3_acquisition_label,
+QLabel#r3_description_label,
+QLabel#r7_readback_title {
+    color: #6b7681;
+}
+
+QLabel#r2_available_label,
+QLabel#r2_selected_label,
+QLabel#r2_union_label,
+QLabel#r2_hint_label,
+QLabel#r3_shot_count_label {
+    color: #6b7681;
+    font-size: 11px;
+}
+
+QLabel#r5_hint_label {
+    font-family: "SF Mono", "Menlo", "Consolas", "DejaVu Sans Mono", monospace;
+    font-size: 11px;
+    color: #6b7681;
+}
+
+/* R6: state pill (dot colored in rich text) + monospace scan number */
+QLabel#r6_state_pill {
+    font-weight: 600;
+    color: #2a323a;
+}
+
+QLabel#r6_scan_number_label {
+    font-family: "SF Mono", "Menlo", "Consolas", "DejaVu Sans Mono", monospace;
+    font-size: 11px;
+    color: #6b7681;
+}
+
+/* ------------------------------------------------------------------ */
+/* R6 log tail: dark, monospace, no focus ring                        */
+/* ------------------------------------------------------------------ */
+
+QPlainTextEdit#r6_log_tail {
+    background-color: #202830;
+    color: #9fb4c4;
+    border: 1px solid #202830;
+    border-radius: 3px;
+    padding: 4px 6px;
+    font-family: "SF Mono", "Menlo", "Consolas", "DejaVu Sans Mono", monospace;
+    font-size: 11px;
+    selection-background-color: #3a4a58;
+    selection-color: #e8eef3;
+}
+
+QPlainTextEdit#r6_log_tail:focus {
+    border: 1px solid #202830;
+    outline: none;
+}
+
+/* Scrollbars inside the dark log tail stay subtle. */
+QPlainTextEdit#r6_log_tail QScrollBar:vertical {
+    background: #202830;
+    width: 8px;
+}
+
+QPlainTextEdit#r6_log_tail QScrollBar::handle:vertical {
+    background: #3a4a58;
+    border-radius: 4px;
+    min-height: 20px;
+}
+
+QPlainTextEdit#r6_log_tail QScrollBar::add-line:vertical,
+QPlainTextEdit#r6_log_tail QScrollBar::sub-line:vertical {
+    height: 0px;
+}

--- a/GEECS-Console/geecs_console/app/ui/arrow_down.svg
+++ b/GEECS-Console/geecs_console/app/ui/arrow_down.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="8" height="8" viewBox="0 0 8 8"><path d="M1.2 2.7 L4 5.4 L6.8 2.7" fill="none" stroke="#6b7681" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round"/></svg>

--- a/GEECS-Console/geecs_console/app/ui/main_window.ui
+++ b/GEECS-Console/geecs_console/app/ui/main_window.ui
@@ -6,9 +6,28 @@
    <string>GEECS Console</string>
   </property>
   <layout class="QVBoxLayout" name="root_layout">
-   <!-- R1: session bar -->
+   <property name="leftMargin">
+    <number>10</number>
+   </property>
+   <property name="topMargin">
+    <number>10</number>
+   </property>
+   <property name="rightMargin">
+    <number>10</number>
+   </property>
+   <property name="bottomMargin">
+    <number>10</number>
+   </property>
+   <property name="spacing">
+    <number>8</number>
+   </property>
+   <!-- R1: session bar (untitled group box = the screen map's session panel) -->
    <item>
-    <layout class="QHBoxLayout" name="r1_session_bar">
+    <widget class="QGroupBox" name="r1_group">
+     <layout class="QHBoxLayout" name="r1_session_bar">
+      <property name="spacing">
+       <number>8</number>
+      </property>
      <item>
       <widget class="QLabel" name="r1_experiment_label">
        <property name="text">
@@ -35,6 +54,12 @@
      </item>
      <item>
       <widget class="QDoubleSpinBox" name="r1_rep_rate">
+       <property name="buttonSymbols">
+        <enum>QAbstractSpinBox::NoButtons</enum>
+       </property>
+       <property name="maximumWidth">
+        <number>90</number>
+       </property>
        <property name="decimals">
         <number>2</number>
        </property>
@@ -100,100 +125,95 @@
        </property>
       </widget>
      </item>
-     <item>
-      <widget class="QLabel" name="r1_db_chip">
-       <property name="text">
-        <string>db: unknown</string>
-       </property>
-      </widget>
-     </item>
-    </layout>
+      <item>
+       <widget class="QLabel" name="r1_db_chip">
+        <property name="text">
+         <string>db: unknown</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
    </item>
    <!-- Three columns: R2 | R3+R4+R5 | R6+R7 -->
    <item>
-    <layout class="QHBoxLayout" name="columns_layout">
+    <layout class="QHBoxLayout" name="columns_layout" stretch="26,46,28">
+     <property name="spacing">
+      <number>10</number>
+     </property>
      <!-- R2: save sets -->
      <item>
       <widget class="QGroupBox" name="r2_group">
        <property name="title">
-        <string>Save sets</string>
+        <string>SAVE SETS</string>
        </property>
        <layout class="QVBoxLayout" name="r2_layout">
+        <property name="spacing">
+         <number>8</number>
+        </property>
         <item>
-         <layout class="QHBoxLayout" name="r2_lists_layout">
+         <widget class="QLabel" name="r2_available_label">
+          <property name="text">
+           <string>available</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QListWidget" name="r2_available_list"/>
+        </item>
+        <item>
+         <layout class="QHBoxLayout" name="r2_buttons_layout">
           <item>
-           <layout class="QVBoxLayout" name="r2_available_layout">
-            <item>
-             <widget class="QLabel" name="r2_available_label">
-              <property name="text">
-               <string>Available</string>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="QListWidget" name="r2_available_list"/>
-            </item>
-           </layout>
+           <spacer name="r2_buttons_spacer_left">
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>10</width>
+              <height>10</height>
+             </size>
+            </property>
+           </spacer>
           </item>
           <item>
-           <layout class="QVBoxLayout" name="r2_buttons_layout">
-            <item>
-             <spacer name="r2_buttons_spacer_top">
-              <property name="orientation">
-               <enum>Qt::Vertical</enum>
-              </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>20</width>
-                <height>40</height>
-               </size>
-              </property>
-             </spacer>
-            </item>
-            <item>
-             <widget class="QPushButton" name="r2_add_button">
-              <property name="text">
-               <string>Add →</string>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="QPushButton" name="r2_remove_button">
-              <property name="text">
-               <string>← Remove</string>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <spacer name="r2_buttons_spacer_bottom">
-              <property name="orientation">
-               <enum>Qt::Vertical</enum>
-              </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>20</width>
-                <height>40</height>
-               </size>
-              </property>
-             </spacer>
-            </item>
-           </layout>
+           <widget class="QPushButton" name="r2_add_button">
+            <property name="text">
+             <string>↓ Add</string>
+            </property>
+           </widget>
           </item>
           <item>
-           <layout class="QVBoxLayout" name="r2_selected_layout">
-            <item>
-             <widget class="QLabel" name="r2_selected_label">
-              <property name="text">
-               <string>Selected</string>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="QListWidget" name="r2_selected_list"/>
-            </item>
-           </layout>
+           <widget class="QPushButton" name="r2_remove_button">
+            <property name="text">
+             <string>↑ Remove</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <spacer name="r2_buttons_spacer_right">
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>10</width>
+              <height>10</height>
+             </size>
+            </property>
+           </spacer>
           </item>
          </layout>
+        </item>
+        <item>
+         <widget class="QLabel" name="r2_selected_label">
+          <property name="text">
+           <string>selected</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QListWidget" name="r2_selected_list"/>
         </item>
         <item>
          <widget class="QLabel" name="r2_union_label">
@@ -218,12 +238,18 @@
      <!-- Middle column: R3 scan form, R4 presets, R5 submit row -->
      <item>
       <layout class="QVBoxLayout" name="middle_column">
+        <property name="spacing">
+         <number>8</number>
+        </property>
        <item>
         <widget class="QGroupBox" name="r3_group">
          <property name="title">
-          <string>Scan</string>
+          <string>SCAN</string>
          </property>
          <layout class="QVBoxLayout" name="r3_layout">
+        <property name="spacing">
+         <number>8</number>
+        </property>
           <item>
            <layout class="QHBoxLayout" name="r3_mode_layout">
             <item>
@@ -264,10 +290,36 @@
               </property>
              </widget>
             </item>
+            <item>
+             <spacer name="r3_mode_spacer">
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>10</width>
+                <height>10</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
            </layout>
           </item>
           <item>
            <layout class="QGridLayout" name="r3_axes_layout">
+            <item row="0" column="8">
+             <spacer name="r3_axes_spacer">
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>10</width>
+                <height>10</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
             <item row="0" column="0">
              <widget class="QLabel" name="r3_variable_label">
               <property name="text">
@@ -294,6 +346,12 @@
             </item>
             <item row="0" column="3">
              <widget class="QDoubleSpinBox" name="r3_start">
+       <property name="buttonSymbols">
+        <enum>QAbstractSpinBox::NoButtons</enum>
+       </property>
+       <property name="maximumWidth">
+        <number>110</number>
+       </property>
               <property name="decimals">
                <number>6</number>
               </property>
@@ -314,6 +372,12 @@
             </item>
             <item row="0" column="5">
              <widget class="QDoubleSpinBox" name="r3_stop">
+       <property name="buttonSymbols">
+        <enum>QAbstractSpinBox::NoButtons</enum>
+       </property>
+       <property name="maximumWidth">
+        <number>110</number>
+       </property>
               <property name="value">
                <double>1.000000000000000</double>
               </property>
@@ -337,6 +401,12 @@
             </item>
             <item row="0" column="7">
              <widget class="QDoubleSpinBox" name="r3_step">
+       <property name="buttonSymbols">
+        <enum>QAbstractSpinBox::NoButtons</enum>
+       </property>
+       <property name="maximumWidth">
+        <number>110</number>
+       </property>
               <property name="value">
                <double>1.000000000000000</double>
               </property>
@@ -377,6 +447,12 @@
             </item>
             <item row="1" column="3">
              <widget class="QDoubleSpinBox" name="r3_start2">
+       <property name="buttonSymbols">
+        <enum>QAbstractSpinBox::NoButtons</enum>
+       </property>
+       <property name="maximumWidth">
+        <number>110</number>
+       </property>
               <property name="decimals">
                <number>6</number>
               </property>
@@ -397,6 +473,12 @@
             </item>
             <item row="1" column="5">
              <widget class="QDoubleSpinBox" name="r3_stop2">
+       <property name="buttonSymbols">
+        <enum>QAbstractSpinBox::NoButtons</enum>
+       </property>
+       <property name="maximumWidth">
+        <number>110</number>
+       </property>
               <property name="value">
                <double>1.000000000000000</double>
               </property>
@@ -420,6 +502,12 @@
             </item>
             <item row="1" column="7">
              <widget class="QDoubleSpinBox" name="r3_step2">
+       <property name="buttonSymbols">
+        <enum>QAbstractSpinBox::NoButtons</enum>
+       </property>
+       <property name="maximumWidth">
+        <number>110</number>
+       </property>
               <property name="value">
                <double>1.000000000000000</double>
               </property>
@@ -447,6 +535,12 @@
             </item>
             <item>
              <widget class="QSpinBox" name="r3_shots_per_step">
+       <property name="buttonSymbols">
+        <enum>QAbstractSpinBox::NoButtons</enum>
+       </property>
+       <property name="maximumWidth">
+        <number>90</number>
+       </property>
               <property name="minimum">
                <number>1</number>
               </property>
@@ -510,9 +604,12 @@
        <item>
         <widget class="QGroupBox" name="r4_group">
          <property name="title">
-          <string>Presets</string>
+          <string>PRESETS</string>
          </property>
          <layout class="QHBoxLayout" name="r4_layout">
+        <property name="spacing">
+         <number>8</number>
+        </property>
           <item>
            <widget class="QComboBox" name="r4_preset_combo">
             <property name="minimumWidth">
@@ -534,63 +631,104 @@
             </property>
            </widget>
           </item>
+          <item>
+           <spacer name="r4_spacer">
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>10</width>
+              <height>10</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
          </layout>
         </widget>
        </item>
        <item>
-        <layout class="QHBoxLayout" name="r5_submit_row">
-         <item>
-          <widget class="QPushButton" name="r5_stop_button">
-           <property name="text">
-            <string>Stop</string>
-           </property>
-           <property name="enabled">
-            <bool>false</bool>
-           </property>
-           <property name="styleSheet">
-            <string>QPushButton:enabled { background-color: #b71c1c; color: white; }</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <spacer name="r5_spacer">
-           <property name="orientation">
-            <enum>Qt::Horizontal</enum>
-           </property>
-           <property name="sizeHint" stdset="0">
-            <size>
-             <width>40</width>
-             <height>20</height>
-            </size>
-           </property>
-          </spacer>
-         </item>
-         <item>
-          <widget class="QPushButton" name="r5_start_button">
-           <property name="text">
-            <string>Start</string>
-           </property>
-           <property name="enabled">
-            <bool>false</bool>
-           </property>
-           <property name="default">
-            <bool>true</bool>
-           </property>
-          </widget>
-         </item>
-        </layout>
+        <widget class="QGroupBox" name="r5_group">
+         <layout class="QHBoxLayout" name="r5_submit_row">
+          <property name="spacing">
+           <number>8</number>
+          </property>
+          <item>
+           <widget class="QLabel" name="r5_hint_label">
+            <property name="text">
+             <string>request → validate → submit</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <spacer name="r5_spacer">
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>40</width>
+              <height>20</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+          <item>
+           <widget class="QPushButton" name="r5_stop_button">
+            <property name="text">
+             <string>■ Stop</string>
+            </property>
+            <property name="enabled">
+             <bool>false</bool>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QPushButton" name="r5_start_button">
+            <property name="text">
+             <string>▶ Start scan</string>
+            </property>
+            <property name="enabled">
+             <bool>false</bool>
+            </property>
+            <property name="default">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
+        <spacer name="middle_column_spacer">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>10</width>
+           <height>10</height>
+          </size>
+         </property>
+        </spacer>
        </item>
       </layout>
      </item>
      <!-- Right column: R6 now panel, R7 device panel -->
      <item>
       <layout class="QVBoxLayout" name="right_column">
+        <property name="spacing">
+         <number>8</number>
+        </property>
        <item>
         <widget class="QGroupBox" name="r6_group">
          <property name="title">
-          <string>Now</string>
+          <string>NOW</string>
          </property>
          <layout class="QVBoxLayout" name="r6_layout">
+        <property name="spacing">
+         <number>8</number>
+        </property>
           <item>
            <layout class="QHBoxLayout" name="r6_status_layout">
             <item>
@@ -645,9 +783,12 @@
        <item>
         <widget class="QGroupBox" name="r7_group">
          <property name="title">
-          <string>Device panel</string>
+          <string>DEVICE PANEL</string>
          </property>
          <layout class="QVBoxLayout" name="r7_layout">
+        <property name="spacing">
+         <number>8</number>
+        </property>
           <item>
            <widget class="QComboBox" name="r7_device_combo">
             <property name="editable">

--- a/GEECS-Console/geecs_console/services/health.py
+++ b/GEECS-Console/geecs_console/services/health.py
@@ -19,6 +19,8 @@ class HealthStatus(str, Enum):
     ----------
     OK : str
         The service answered a probe.
+    WARN : str
+        The service answered but reported a degraded condition.
     DOWN : str
         The service failed a probe.
     UNKNOWN : str
@@ -26,6 +28,7 @@ class HealthStatus(str, Enum):
     """
 
     OK = "ok"
+    WARN = "warn"
     DOWN = "down"
     UNKNOWN = "unknown"
 

--- a/GEECS-Console/pyproject.toml
+++ b/GEECS-Console/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-console"
-version = "0.1.0"
+version = "0.1.1"
 description = "Greenfield PySide6 operator console for GEECS (Bluesky/gateway architecture)"
 authors = ["Sam Barber <sbarber@lbl.gov>"]
 readme = "README.md"

--- a/GEECS-Console/tests/test_main_window.py
+++ b/GEECS-Console/tests/test_main_window.py
@@ -109,7 +109,21 @@ class TestConstruction:
             configs=FakeConfigs(), health=FakeHealth(), submitter=FakeSubmitter()
         )
         qtbot.addWidget(win)
-        assert win.gateway_chip.text() == "gateway: down"
+        # Chips are rich-text pills (colored dot + text) — check the text part.
+        assert "gateway: down" in win.gateway_chip.text()
+
+    def test_stylesheet_loads_and_applies(self, qtbot, window):
+        """The packaged QSS must load non-empty and apply application-wide."""
+        from PySide6.QtWidgets import QApplication
+
+        from geecs_console.app.main_window import load_stylesheet
+
+        qss = load_stylesheet()
+        assert qss.strip()
+        assert "@UI_DIR@" not in qss  # asset token resolved to a real path
+        assert "QGroupBox" in qss
+        # The window's constructor applied it to the running application.
+        assert QApplication.instance().styleSheet().strip()
 
 
 class TestModeRadios:
@@ -249,7 +263,8 @@ class TestNowAndDevicePanel:
         window.events.handle(
             ScanStepEvent(step_index=0, total_steps=2, shots_completed=10)
         )
-        assert window.state_pill.text() == "running"
+        # The pill is rich text (colored dot + uppercase word).
+        assert "RUNNING" in window.state_pill.text()
         assert window.progress_bar.maximum() == 20
         assert window.progress_bar.value() == 10
         assert "running" in window.log_tail.toPlainText()


### PR DESCRIPTION
Makes the console visually match the approved screen-map artifact (v0.1). The previous state was structurally correct but stock unstyled Qt.

## What changed

- **Packaged QSS** (`geecs_console/app/style.qss`, loaded via `load_stylesheet()` and applied application-wide at window construction): screen-map palette (`#eceef0` window / `#fbfcfd` panels / `#b9c0c7` lines / `#2a323a` ink / `#6b7681` dim / `#2e7fb8` accent), group boxes with small uppercase dim legends on the border, primary blue Start / danger-outline Stop, white 1px-bordered inputs + lists (`#dcebf5` selection), accent radios, thin rounded green progress bar, dim monospace status bar.
- **Widget-level polish**: health chips are rounded pills with per-status colored dots (grey unknown / green ok / amber warn / red down — `HealthStatus` gains `WARN`); the Now state text is a pill (dot + uppercase word, green RUNNING/DONE, amber INITIALIZING, red ABORTED, grey idle); dark monospace log tail (`#202830` / `#9fb4c4`); mono scan-number label; dim union/hint lines.
- **Layout parity in the `.ui`**: session bar in its own panel, save-set lists stacked vertically (available → Add/Remove → selected, as in the mockup), submit row in a panel with the `request → validate → submit` hint, 26/46/28 column proportions (set in code — QUiLoader ignores the .ui stretch attribute), 10px outer margins / 8px gaps, axis rows left-packed.
- **Left native on purpose**: spin *buttons* are disabled (`NoButtons`) rather than styled — macOS draws the native button geometry outside the QSS border and it looked detached; the mockup's number fields are plain inputs anyway. Values adjust by typing / arrow keys / wheel. Everything else styled cleanly.
- **Experiment combo**: not a population bug — `ConsoleConfigs.listing()` lists the experiments folders correctly; the combo just rendered blank because nothing is selected at launch (`setCurrentIndex(-1)` on an editable combo). It now shows a `select experiment…` placeholder.
- New test: the packaged QSS loads non-empty, resolves its asset token, and is applied to the application by window construction. 52 tests pass offscreen.

## Screenshot proof

Rendered offscreen (`window.resize(1400, 860)` + `grab()`), with real Undulator configs and simulated running-scan events:
`/private/tmp/claude-501/-Users-samuelbarber-Desktop-Code-Github-repos-GEECS-Plugins/fce39854-3c63-45df-bd28-53dd41050b98/scratchpad/console-styled.png`

🤖 Generated with [Claude Code](https://claude.com/claude-code)