### PR TITLE
feat(telemetry): gate background telemetry on the gateway CONNECTED PV (#494)

### DIFF
--- a/GeecsBluesky/CHANGELOG.md
+++ b/GeecsBluesky/CHANGELOG.md
@@ -4,6 +4,29 @@ All notable changes to `geecs-bluesky` are documented here.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.30.0] - 2026-07-10
+
+### Changed
+
+- **Background telemetry now gates on the gateway `CONNECTED` PV before
+  full-connect (issue #494).** `build_telemetry_readables` first reads each
+  candidate device's `[Experiment:]Device:CONNECTED` status (one fast
+  concurrent read via the new `GeecsSession.live_devices` — the same
+  authoritative liveness source pre-flight uses) and skips the
+  `Disconnected` ones immediately, instead of paying a full ~20 s device
+  connect timeout per dead device (serially). A scan with several dead
+  telemetry devices — common when driving remotely over VPN — now reaches
+  pre-flight in ~one round-trip instead of 20 s × N-dead. Fail-open: an
+  unreadable status keeps the device (the soft tier still drops it if the
+  real connect then fails), so a gateway without status PVs never silently
+  drops telemetry.
+
+### Added
+
+- `GeecsSession.live_devices(devices, *, timeout=3.0)` — concurrent gateway
+  `CONNECTED` liveness probe returning the live/indeterminate subset
+  (fail-open; mock-mode returns all).
+
 ## [0.29.0] - 2026-07-10
 
 ### Changed

--- a/GeecsBluesky/geecs_bluesky/scan_request_runner.py
+++ b/GeecsBluesky/geecs_bluesky/scan_request_runner.py
@@ -824,9 +824,22 @@ def build_telemetry_readables(
     selected = select_telemetry_variables(
         save_set, scalar_policy.subscribed_by_device()
     )
+    # Gate on the gateway CONNECTED PV first (one fast concurrent read per
+    # device — the same liveness source pre-flight uses) so a dead telemetry
+    # device is skipped immediately instead of burning a full connect
+    # timeout. Fail-open: an unreadable status keeps the device (session.
+    # telemetry still drops it softly if the real connect then fails).
+    live = session.live_devices(list(selected))
     readables: list = []
     recorded: dict[str, list[str]] = {}
     for device, variables in selected.items():
+        if device not in live:
+            logger.info(
+                "Skipping background-telemetry device %s: gateway reports it "
+                "Disconnected (soft tier — never aborts the scan)",
+                device,
+            )
+            continue
         readable = session.telemetry(device, variables)
         if readable is not None:
             readables.append(readable)

--- a/GeecsBluesky/geecs_bluesky/session.py
+++ b/GeecsBluesky/geecs_bluesky/session.py
@@ -139,15 +139,67 @@ class GeecsSession:
     # Device factories (constructed connected; explicit names)
     # ------------------------------------------------------------------
 
-    def _connect(self, device: Any) -> Any:
+    def _connect(self, device: Any, *, timeout: float = 20.0) -> Any:
         """Connect a device in the RunEngine's persistent event loop."""
         import asyncio
 
         future = asyncio.run_coroutine_threadsafe(
             device.connect(mock=self._mock), self.RE._loop
         )
-        future.result(timeout=20.0)
+        future.result(timeout=timeout)
         return device
+
+    def live_devices(self, devices: list[str], *, timeout: float = 3.0) -> set[str]:
+        """Return the subset of *devices* the gateway reports as connected.
+
+        Reads each device's gateway ``CONNECTED`` PV
+        (``[Experiment:]Device:CONNECTED``) **concurrently** on the RE loop —
+        the same authoritative liveness source the pre-flight uses — so a
+        dead device is identified by one fast read instead of a full device
+        connect timeout.  **Fail-open**: only the exact ``"Disconnected"``
+        reading excludes a device; an unreadable PV, a mock backend, or a
+        gateway without status PVs keeps the device in the live set (a
+        missing status surface must never silently drop everything).  In
+        mock mode every device is returned live.
+
+        Parameters
+        ----------
+        devices :
+            GEECS device names to probe.
+        timeout :
+            Per-read CA budget (seconds); the reads run in parallel, so the
+            whole gate costs roughly one round-trip even for many devices.
+
+        Returns
+        -------
+        set of str
+            The device names to keep (live or indeterminate).
+        """
+        if self._mock or not devices:
+            return set(devices)
+
+        import asyncio
+
+        from geecs_bluesky.devices.ca._pv import GATEWAY_DISCONNECTED, ca_pv
+        from geecs_bluesky.devices.ca.gateway_put import bare_pv
+
+        async def _probe(device: str) -> tuple[str, bool]:
+            from aioca import caget
+
+            pv = bare_pv(ca_pv(self.experiment, device, "CONNECTED"))
+            try:
+                value = await asyncio.wait_for(caget(pv), timeout=timeout)
+            except Exception:
+                return device, True  # fail-open: unreadable → keep
+            return device, str(value) != GATEWAY_DISCONNECTED
+
+        async def _gather() -> list[tuple[str, bool]]:
+            return await asyncio.gather(*(_probe(d) for d in devices))
+
+        results = asyncio.run_coroutine_threadsafe(_gather(), self.RE._loop).result(
+            timeout=timeout + 5.0
+        )
+        return {device for device, live in results if live}
 
     def _read_movable(self, movable: Any) -> float:
         """Current readback value of a session settable/motor."""

--- a/GeecsBluesky/pyproject.toml
+++ b/GeecsBluesky/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-bluesky"
-version = "0.29.0"
+version = "0.30.0"
 description = "Bluesky / ophyd-async bridge for the GEECS control system"
 authors = ["Sam Barber <sbarber@lbl.gov>"]
 readme = "README.md"

--- a/GeecsBluesky/tests/test_scan_request_runner.py
+++ b/GeecsBluesky/tests/test_scan_request_runner.py
@@ -1447,6 +1447,11 @@ class _M3cSession(_FakeSession):
         self.telemetry_calls: list = []
         self.dead_devices: set = set()
 
+    def live_devices(self, devices, *, timeout=3.0):
+        # Gateway CONNECTED gate: dead devices are excluded before any
+        # full-connect (fail-open otherwise).
+        return {d for d in devices if d not in self.dead_devices}
+
     def telemetry(self, device, variables, *, name=None):
         self.telemetry_calls.append((device, list(variables)))
         if device in self.dead_devices:
@@ -1560,16 +1565,37 @@ def test_telemetry_selects_non_saveset_devices(monkeypatch, legacy_resolver) -> 
     }
 
 
-def test_telemetry_dead_device_dropped_not_raised(
-    monkeypatch, legacy_resolver, caplog
+def test_telemetry_dead_device_gated_out_before_connect(
+    monkeypatch, legacy_resolver
 ) -> None:
+    """A gateway-Disconnected telemetry device is skipped by the CONNECTED
+    gate *before* the expensive full-connect — no telemetry() call, no
+    read-set column, no raise (issue #494)."""
     policy = _M3cPolicy(subscribed={"U_Press": ["Pressure"]})
     _install_policy(monkeypatch, policy)
     session = _M3cSession()
-    session.dead_devices = {"U_Press"}
-    # Must not raise even though the telemetry device is unreachable.
+    session.dead_devices = {"U_Press"}  # live_devices excludes it
     run_scan_request(session, _db_noscan_request(), legacy_resolver)
-    # Attempted, returned None → not in the read set.
+    # Gated out up front — telemetry() never even attempted.
+    assert session.telemetry_calls == []
+    assert not any(d[0].startswith("telemetry:") for d in session.devices)
+
+
+def test_telemetry_indeterminate_device_still_attempted(
+    monkeypatch, legacy_resolver
+) -> None:
+    """Fail-open: a device the gate keeps (live/indeterminate) is still
+    handed to telemetry(), which drops it softly if the real connect fails."""
+
+    class _FailOpenSession(_M3cSession):
+        def live_devices(self, devices, *, timeout=3.0):
+            return set(devices)  # gate can't tell — keep everything
+
+    policy = _M3cPolicy(subscribed={"U_Press": ["Pressure"]})
+    _install_policy(monkeypatch, policy)
+    session = _FailOpenSession()
+    session.dead_devices = {"U_Press"}  # gate keeps it; telemetry() drops it
+    run_scan_request(session, _db_noscan_request(), legacy_resolver)
     assert session.telemetry_calls == [("U_Press", ["Pressure"])]
     assert not any(d[0].startswith("telemetry:") for d in session.devices)
 

--- a/GeecsBluesky/tests/test_session.py
+++ b/GeecsBluesky/tests/test_session.py
@@ -407,3 +407,31 @@ def test_scan_info_stamps_bluesky_scanner(tmp_path: Path) -> None:
     content = (tmp_path / f"ScanInfo{tmp_path.name}.ini").read_text()
     assert 'Scanner = "bluesky"' in content
     assert "[Scan Info]" in content  # legacy section intact
+
+
+def test_live_devices_mock_returns_all() -> None:
+    """In mock mode the CONNECTED gate is a no-op (all devices live)."""
+    s = _session()  # mock=True
+    assert s.live_devices(["U_A", "U_B"]) == {"U_A", "U_B"}
+    assert s.live_devices([]) == set()
+
+
+def test_live_devices_gates_on_connected_pv(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Real path: 'Disconnected' excludes; 'Connected' keeps; an unreadable
+    PV is fail-open (kept). Verified against a patched aioca.caget."""
+    import aioca
+
+    async def fake_caget(pv: str):
+        if "U_Dead" in pv:
+            return "Disconnected"
+        if "U_Slow" in pv:
+            raise TimeoutError("no reply")  # unreadable → fail-open
+        return "Connected"
+
+    monkeypatch.setattr(aioca, "caget", fake_caget)
+    s = GeecsSession("Undulator", tiled=False, mock=False)
+    try:
+        live = s.live_devices(["U_Live", "U_Dead", "U_Slow"], timeout=1.0)
+    finally:
+        s.RE.halt() if s.RE.state != "idle" else None
+    assert live == {"U_Live", "U_Slow"}  # dead excluded, slow kept (fail-open)


### PR DESCRIPTION
Closes #494. Found driving GEECS-Console live over VPN: a scan with unreachable background-telemetry devices stalled ~20 s **per dead device, serially**, before reaching pre-flight (~40 s of dead air with two dead ICTs). Root cause: `build_telemetry_readables` did a full ophyd `connect()` (20 s budget) on every candidate, then dropped the failures.

**Fix** (the maintainer's insight): the gateway already serves a per-device `CONNECTED` PV, and the save-device pre-flight already trusts it. Background telemetry now does the same — read `[Experiment:]Device:CONNECTED` **first**, skip the `Disconnected` ones before any full-connect.

- New `GeecsSession.live_devices(devices, *, timeout=3.0)` — reads every candidate's `CONNECTED` PV **concurrently** on the RE loop (one round-trip for the whole set), returns the live/indeterminate subset. **Fail-open**: only the exact `"Disconnected"` string excludes a device; unreadable PV / mock backend / gateway-without-status-PVs all keep it, so a missing status surface never silently drops telemetry.
- `build_telemetry_readables` gates `selected` through `live_devices` before calling `session.telemetry` — dead devices are skipped with a log line; survivors take the normal (still soft, still drop-if-connect-fails) path.

Result: a scan with N dead telemetry devices reaches pre-flight in ~one round-trip instead of 20 s × N. Directly fixes the "slow and unresponsive" GEECS-Console experience for remote/VPN operators.

**Tests**: full suite **443 passed**. New: `live_devices` mock no-op + real-path CONNECTED gating (patched aioca.caget: Disconnected excluded, Connected kept, timeout fail-open kept); telemetry-builder gating (dead device skipped *before* `telemetry()`) + fail-open (indeterminate device still attempted then dropped softly). The old `test_telemetry_dead_device_dropped_not_raised` was updated to the new fast path.

GeecsBluesky 0.30.0. Engine fix → `feat/vision-v1`; syncs up to greenfield so GEECS-Console inherits it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)