### PR TITLE
GeecsCAGateway: DB-hygiene audit tool (get='yes' ghosts/skips + FK-orphans, #496)

### DIFF
--- a/GeecsCAGateway/CHANGELOG.md
+++ b/GeecsCAGateway/CHANGELOG.md
@@ -3,6 +3,33 @@
 All notable changes to `geecs-ca-gateway` are documented here, following
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and semantic versioning.
 
+## [0.13.0] - 2026-07-11
+
+### Added
+
+- **DB-hygiene audit tool** (`geecs_ca_gateway/audit.py`; `#496`) — a read-only
+  report of every `get='yes'` variable the gateway will NOT serve, plus
+  FK-orphans. Ships as both a reusable pure function and a CLI
+  (`python -m geecs_ca_gateway.audit --experiment NAME`, console script
+  `geecs-ca-gateway-audit`). Flags three flavours of `expt_device_variable`
+  rot that the LabVIEW DB-editing GUIs leave behind (no cascade deletes):
+  - **GHOST** — a `get='yes'` row whose `variablename` is not a real variable
+    of the device (deleted / alias-derived name); names a PV never created.
+  - **SKIP:<type>** — a `get='yes'` variable whose `variabletype` is in the
+    gateway's `_SKIP_VARTYPES` (`image` / `1darray`); no scalar PV served.
+  - **FK-orphan** — an `expt_device_variable` row whose `expt_device_id` points
+    at an `expt_device.id` that no longer exists (whole experiment removed).
+
+  The classifier `audit_subscribed_variables(subscribed, device_variables,
+  skip_types)` is a **pure function over plain dicts** with zero DB imports
+  (fully unit-tested). The DB-facing wrapper and CLI import `GeecsDb` / `mysql`
+  lazily, so the module imports offline. **Strictly read-only** — it never
+  DELETEs or modifies; the optional `--sql` flag only *prints* (never executes)
+  the DELETE statements a human could review. `--full` prints the complete
+  per-device listing.
+- `GeecsDb.get_fk_orphan_variables()` — read-only LEFT-JOIN query returning the
+  count + a capped sample of FK-orphan `expt_device_variable` rows.
+
 ## [0.12.2] - 2026-07-10
 
 ### Fixed

--- a/GeecsCAGateway/CLAUDE.md
+++ b/GeecsCAGateway/CLAUDE.md
@@ -47,6 +47,10 @@ geecs_ca_gateway/
                      #   from_db_metadata (pure) / from_geecs_db / from_geecs_experiment
   pv_naming.py       # THE shared naming policy (producer + consumers import it)
   naming.py          # thin re-export of pv_naming for gateway-local use
+  audit.py           # read-only DB-hygiene audit (#496): reports every get='yes'
+                     #   variable the gateway won't serve + FK-orphans. Pure
+                     #   classifier audit_subscribed_variables() (no DB) + CLI
+                     #   (python -m geecs_ca_gateway.audit / geecs-ca-gateway-audit)
   transport/
     udp_client.py    # GeecsUdpClient — cmd/ACK/exe protocol, exchange lock,
                      #   exe-reply correlation, local-IP detection (VPN/PPP)
@@ -189,3 +193,17 @@ ca_addr_list`, applied by geecs_bluesky at import) is documented in
 - Follow the repo-wide conventions (root `CLAUDE.md`): Pydantic v2, NumPy
   docstrings, type hints, `poetry version` + `CHANGELOG.md` on every
   code-changing PR.
+
+## DB-hygiene audit (`audit.py`, #496)
+
+`expt_device_variable` accumulates `get='yes'` rows that map to nothing real
+(the LabVIEW DB-editing GUIs don't cascade deletes), and each one makes the
+gateway/scanner try to connect a PV that never exists → per-device stalls. The
+audit reports them; run it on-network with `python -m geecs_ca_gateway.audit
+--experiment Undulator` (add `--full` for the per-device listing, `--sql` to
+*print* review-only DELETEs). It flags: **GHOST** (`get='yes'` name isn't a real
+device variable), **SKIP:<type>** (`get='yes'` var typed `image`/`1darray`, in
+`_SKIP_VARTYPES`, so no scalar PV), and **FK-orphan** (`expt_device_id` with no
+`expt_device`). The classifier `audit_subscribed_variables()` is a pure function
+over plain dicts (no DB — unit-tested in `test_audit.py`); DB access is lazy.
+**Read-only: it never DELETEs or modifies** — `--sql` only prints.

--- a/GeecsCAGateway/geecs_ca_gateway/audit.py
+++ b/GeecsCAGateway/geecs_ca_gateway/audit.py
@@ -1,0 +1,393 @@
+"""Read-only DB-hygiene audit for the GEECS experiment database.
+
+The LabVIEW DB-editing GUIs do not cascade deletions (there are no foreign-key
+constraints on ``expt_device_variable``), so the table accumulates ``get='yes'``
+rows that no longer map to anything the gateway can serve.  Each such row makes
+the CA gateway / scanner try to connect a PV that will never exist, which shows
+up as a per-device stall.  This module reports them so a human can clean the DB.
+
+Three flavours are flagged:
+
+GHOST
+    A ``get='yes'`` row whose ``variablename`` is not a real variable of the
+    device (a deleted variable, or an alias-derived name).  The gateway serves
+    PVs by *real* variablename, so a ghost names a PV that is never created.
+SKIP:<type>
+    A ``get='yes'`` variable whose ``variabletype`` is in the gateway's
+    ``_SKIP_VARTYPES`` (``image`` / ``1darray``).  These are not scalar CA data,
+    so no PV is served for them.
+FK-orphan
+    An ``expt_device_variable`` row whose ``expt_device_id`` points at an
+    ``expt_device.id`` that no longer exists (a whole experiment removed).
+
+The pure classification logic (:func:`audit_subscribed_variables`) has **zero**
+database imports and is fully unit-testable over plain dicts.  The DB-facing
+:func:`run_audit` and the CLI import :class:`GeecsDb` / ``mysql`` lazily so this
+module imports with no database on the machine.
+
+**This tool is strictly read-only.**  It never DELETEs or modifies a row.  The
+optional ``--sql`` mode only *prints* the DELETE statements a human could
+review and run themselves; it never executes them.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+from dataclasses import dataclass, field
+
+logger = logging.getLogger("geecs_ca_gateway.audit")
+
+#: Reason tag for a subscribed variable that is not a real device variable.
+GHOST = "GHOST"
+
+
+def _skip_reason(vartype: str) -> str:
+    """Return the ``SKIP:<type>`` reason tag for a skipped variable type."""
+    return f"SKIP:{vartype}"
+
+
+@dataclass(frozen=True)
+class Finding:
+    """One ``get='yes'`` variable the gateway will not serve.
+
+    Attributes
+    ----------
+    device:
+        GEECS device name.
+    variable:
+        The subscribed ``variablename`` that is a problem.
+    reason:
+        Why it will not be served — ``"GHOST"`` (name is not a real variable of
+        the device) or ``"SKIP:<type>"`` (variabletype is a non-scalar type the
+        gateway skips, e.g. ``"SKIP:image"`` / ``"SKIP:1darray"``).
+    """
+
+    device: str
+    variable: str
+    reason: str
+
+
+@dataclass
+class FkOrphanReport:
+    """FK-orphan summary: rows whose ``expt_device_id`` has no ``expt_device``.
+
+    Attributes
+    ----------
+    count:
+        Total number of orphaned ``expt_device_variable`` rows.
+    sample:
+        A capped sample of orphan rows, each a dict with ``id``,
+        ``expt_device_id`` and ``variablename`` keys, for eyeballing.
+    """
+
+    count: int = 0
+    sample: list[dict] = field(default_factory=list)
+
+
+@dataclass
+class AuditResult:
+    """The full audit outcome for one experiment.
+
+    Attributes
+    ----------
+    experiment:
+        GEECS experiment name audited.
+    findings:
+        GHOST / SKIP findings from :func:`audit_subscribed_variables`.
+    orphans:
+        FK-orphan summary (global — orphans are not experiment-scoped because
+        their owning ``expt_device`` is gone).
+    subscribed:
+        The ``{device: [variablename, ...]}`` monitoring set that was audited,
+        kept for the ``--full`` per-device listing.
+    """
+
+    experiment: str
+    findings: list[Finding] = field(default_factory=list)
+    orphans: FkOrphanReport = field(default_factory=FkOrphanReport)
+    subscribed: dict[str, list[str]] = field(default_factory=dict)
+
+
+def audit_subscribed_variables(
+    subscribed: dict[str, list[str]],
+    device_variables: dict[str, list[dict]],
+    skip_types: set[str],
+) -> list[Finding]:
+    """Classify every subscribed variable the gateway will not serve.
+
+    Pure function — no database, no network.  Cross-checks each subscribed
+    (``get='yes'``) variablename against the device's real variable list and
+    returns a :class:`Finding` for each one that is a ghost or a skipped type.
+
+    Parameters
+    ----------
+    subscribed:
+        ``{device: [variablename, ...]}`` — the ``get='yes'`` monitoring set,
+        e.g. from :meth:`GeecsDb.get_subscribed_variables`.
+    device_variables:
+        ``{device: [metadata, ...]}`` where each metadata dict has at least a
+        ``name`` and a ``variabletype`` key (the shape of
+        :meth:`GeecsDb.get_device_variables` /
+        :meth:`GeecsDb.get_experiment_device_variables`).  A device absent from
+        this mapping has no known real variables, so every subscribed variable
+        for it is reported as a GHOST rather than crashing.
+    skip_types:
+        Variable types the gateway does not serve (the gateway's
+        ``_SKIP_VARTYPES``, e.g. ``{"image", "1darray"}``).
+
+    Returns
+    -------
+    list[Finding]
+        One finding per problem variable, ordered by device (sorted) then by
+        the input order of that device's subscribed variables.  A clean
+        variable produces no finding.
+    """
+    skip = {str(t).strip().lower() for t in skip_types}
+    findings: list[Finding] = []
+    for device in sorted(subscribed):
+        real = device_variables.get(device)
+        by_name: dict[str, str] = {}
+        if real:
+            for meta in real:
+                name = meta.get("name")
+                if name is not None:
+                    by_name[name] = (meta.get("variabletype") or "").strip().lower()
+        for variable in subscribed[device]:
+            if variable not in by_name:
+                findings.append(Finding(device, variable, GHOST))
+                continue
+            vartype = by_name[variable]
+            if vartype in skip:
+                findings.append(Finding(device, variable, _skip_reason(vartype)))
+    return findings
+
+
+def build_delete_sql(experiment: str, result: AuditResult) -> list[str]:
+    """Return DELETE statements a human could review to remove the flagged rows.
+
+    Pure string builder — this **prints** SQL for human review; it never
+    executes anything.  Ghost/skip deletes are scoped by experiment + device +
+    variablename + ``get='yes'``; the FK-orphan delete removes rows whose
+    ``expt_device`` is gone (global, since they are not experiment-scoped).
+
+    Parameters
+    ----------
+    experiment:
+        GEECS experiment name (used to scope the ghost/skip deletes).
+    result:
+        The audit result whose findings/orphans to emit deletes for.
+
+    Returns
+    -------
+    list[str]
+        One SQL statement per line, safe to hand to a DBA — nothing is run here.
+    """
+
+    def esc(value: str) -> str:
+        return value.replace("'", "''")
+
+    statements: list[str] = []
+    for finding in result.findings:
+        statements.append(
+            "DELETE edv FROM expt_device_variable edv "
+            "JOIN expt_device ed ON ed.id = edv.expt_device_id "
+            f"WHERE ed.expt = '{esc(experiment)}' "
+            f"AND ed.device = '{esc(finding.device)}' "
+            f"AND edv.variablename = '{esc(finding.variable)}' "
+            f"AND edv.get = 'yes';  -- {finding.reason}"
+        )
+    if result.orphans.count:
+        statements.append(
+            "DELETE edv FROM expt_device_variable edv "
+            "LEFT JOIN expt_device ed ON ed.id = edv.expt_device_id "
+            f"WHERE ed.id IS NULL;  -- {result.orphans.count} FK-orphan row(s)"
+        )
+    return statements
+
+
+def format_report(result: AuditResult, *, full: bool = False) -> str:
+    """Render *result* as a clean text report (a PROBLEMS summary, then detail).
+
+    Parameters
+    ----------
+    result:
+        The audit outcome to render.
+    full:
+        When true, append the complete per-device subscribed-variable listing
+        (each variable marked OK / GHOST / SKIP:<type>).
+
+    Returns
+    -------
+    str
+        The formatted, printable report.
+    """
+    lines: list[str] = []
+    lines.append(f"DB-hygiene audit for experiment {result.experiment!r}")
+    lines.append("=" * 60)
+
+    ghosts = [f for f in result.findings if f.reason == GHOST]
+    skips = [f for f in result.findings if f.reason != GHOST]
+
+    lines.append("")
+    lines.append("PROBLEMS")
+    lines.append("-" * 60)
+    lines.append(f"  GHOST vars (get='yes', not a real device variable): {len(ghosts)}")
+    lines.append(f"  SKIP vars  (get='yes', non-scalar type not served): {len(skips)}")
+    lines.append(
+        f"  FK-orphan rows (expt_device_id with no expt_device): {result.orphans.count}"
+    )
+
+    if result.findings:
+        lines.append("")
+        lines.append("  Flagged variables:")
+        for finding in result.findings:
+            lines.append(
+                f"    [{finding.reason:<12}] {finding.device} :: {finding.variable}"
+            )
+
+    if result.orphans.sample:
+        lines.append("")
+        lines.append(
+            f"  FK-orphan sample (first {len(result.orphans.sample)} of "
+            f"{result.orphans.count}):"
+        )
+        for row in result.orphans.sample:
+            lines.append(
+                f"    id={row.get('id')} "
+                f"expt_device_id={row.get('expt_device_id')} "
+                f"variablename={row.get('variablename')!r}"
+            )
+
+    if not result.findings and not result.orphans.count:
+        lines.append("")
+        lines.append("  No problems found.")
+
+    if full:
+        lines.append("")
+        lines.append("FULL PER-DEVICE LISTING")
+        lines.append("-" * 60)
+        flagged = {(f.device, f.variable): f.reason for f in result.findings}
+        for device in sorted(result.subscribed):
+            lines.append(f"  {device}")
+            for variable in result.subscribed[device]:
+                reason = flagged.get((device, variable), "OK")
+                lines.append(f"    [{reason:<12}] {variable}")
+
+    return "\n".join(lines)
+
+
+def run_audit(
+    experiment: str,
+    *,
+    enabled_only: bool = True,
+    skip_types: set[str] | None = None,
+) -> AuditResult:
+    """Run the full read-only audit against the live GEECS database.
+
+    Pulls the ``get='yes'`` monitoring set and per-device variable metadata,
+    runs the pure :func:`audit_subscribed_variables`, and adds the FK-orphan
+    count + sample.  ``GeecsDb`` (and thereby ``mysql``) is imported lazily so
+    this module imports on machines with no database.
+
+    Parameters
+    ----------
+    experiment:
+        GEECS experiment name.
+    enabled_only:
+        Restrict the subscribed set + device metadata to enabled devices
+        (default true, matching the gateway's default served set).
+    skip_types:
+        Variable types treated as non-servable; defaults to the gateway's
+        ``_SKIP_VARTYPES`` from :mod:`geecs_ca_gateway.config`.
+
+    Returns
+    -------
+    AuditResult
+        Findings, FK-orphan summary, and the audited subscribed set.
+    """
+    from .config import _SKIP_VARTYPES
+    from .db.geecs_db import GeecsDb
+
+    skip = set(_SKIP_VARTYPES if skip_types is None else skip_types)
+
+    subscribed = GeecsDb.get_subscribed_variables(experiment, enabled_only=enabled_only)
+    device_variables = GeecsDb.get_experiment_device_variables(
+        experiment, enabled_only=enabled_only
+    )
+    findings = audit_subscribed_variables(subscribed, device_variables, skip)
+    orphan_dict = GeecsDb.get_fk_orphan_variables()
+    orphans = FkOrphanReport(
+        count=int(orphan_dict.get("count", 0)),
+        sample=list(orphan_dict.get("sample", [])),
+    )
+    return AuditResult(
+        experiment=experiment,
+        findings=findings,
+        orphans=orphans,
+        subscribed=subscribed,
+    )
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        prog="geecs-ca-gateway-audit",
+        description=(
+            "Read-only DB-hygiene audit: report every get='yes' variable the "
+            "gateway will NOT serve (ghosts / skipped types) plus FK-orphans. "
+            "Never modifies the database."
+        ),
+    )
+    parser.add_argument(
+        "--experiment",
+        required=True,
+        help="GEECS experiment name, e.g. Undulator.",
+    )
+    parser.add_argument(
+        "--include-disabled",
+        action="store_true",
+        help="Include devices not enabled in the experiment.",
+    )
+    parser.add_argument(
+        "--full",
+        action="store_true",
+        help="Also print the complete per-device subscribed-variable listing.",
+    )
+    parser.add_argument(
+        "--sql",
+        action="store_true",
+        help=(
+            "Print (do NOT execute) the DELETE statements a human could review "
+            "to remove the flagged rows. The audit never modifies the DB."
+        ),
+    )
+    parser.add_argument(
+        "--log-level",
+        default="WARNING",
+        help="Logging level (default WARNING — keep the report clean).",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> None:
+    """CLI entry point: ``python -m geecs_ca_gateway.audit --experiment NAME``."""
+    args = _parse_args(argv)
+    logging.basicConfig(
+        level=args.log_level.upper(),
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    )
+    result = run_audit(args.experiment, enabled_only=not args.include_disabled)
+    print(format_report(result, full=args.full))
+    if args.sql:
+        statements = build_delete_sql(args.experiment, result)
+        print("")
+        print("-- REVIEW-ONLY SQL (not executed) " + "-" * 26)
+        if statements:
+            for statement in statements:
+                print(statement)
+        else:
+            print("-- nothing to delete")
+
+
+if __name__ == "__main__":
+    main()

--- a/GeecsCAGateway/geecs_ca_gateway/db/geecs_db.py
+++ b/GeecsCAGateway/geecs_ca_gateway/db/geecs_db.py
@@ -656,6 +656,67 @@ class GeecsDb:
         }
 
     @classmethod
+    def get_fk_orphan_variables(cls, *, sample_limit: int = 20) -> dict:
+        """Return ``expt_device_variable`` rows whose ``expt_device`` is gone.
+
+        The LabVIEW DB-editing GUIs do not cascade deletions (there are no
+        foreign-key constraints), so removing a whole experiment can leave
+        ``expt_device_variable`` rows whose ``expt_device_id`` points at an
+        ``expt_device.id`` that no longer exists.  A LEFT JOIN with
+        ``ed.id IS NULL`` finds them.  Read-only — this only reports.
+
+        These orphans are **not experiment-scoped** (their owning
+        ``expt_device`` row, which carried the experiment name, is gone), so the
+        query is global.
+
+        Parameters
+        ----------
+        sample_limit:
+            Maximum number of orphan rows to return in the ``sample`` list for
+            eyeballing (the ``count`` is always the full total).
+
+        Returns
+        -------
+        dict
+            ``{"count": int, "sample": [{"id", "expt_device_id",
+            "variablename"}, ...]}``.
+        """
+        try:
+            import mysql.connector
+        except ImportError as exc:
+            raise ImportError(
+                "mysql-connector-python is required for DB lookups."
+            ) from exc
+
+        conn = _connect_mysql(mysql.connector)
+        try:
+            cur = conn.cursor()
+            cur.execute(
+                "SELECT COUNT(*) FROM expt_device_variable edv "
+                "LEFT JOIN expt_device ed ON ed.id = edv.expt_device_id "
+                "WHERE ed.id IS NULL"
+            )
+            count_row = cur.fetchone()
+            count = int(count_row[0]) if count_row else 0
+            cur.execute(
+                "SELECT edv.id, edv.expt_device_id, edv.variablename "
+                "FROM expt_device_variable edv "
+                "LEFT JOIN expt_device ed ON ed.id = edv.expt_device_id "
+                "WHERE ed.id IS NULL "
+                "ORDER BY edv.id LIMIT %s",
+                (int(sample_limit),),
+            )
+            sample_rows = cur.fetchall()
+        finally:
+            conn.close()
+
+        sample = [
+            {"id": row[0], "expt_device_id": row[1], "variablename": row[2]}
+            for row in sample_rows
+        ]
+        return {"count": count, "sample": sample}
+
+    @classmethod
     def get_ca_alarm_limits(cls, experiment: str) -> dict[tuple[str, str], AlarmLimits]:
         """Return enabled curated CA alarm limits for *experiment*.
 

--- a/GeecsCAGateway/pyproject.toml
+++ b/GeecsCAGateway/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-ca-gateway"
-version = "0.12.2"
+version = "0.13.0"
 description = "EPICS Channel Access soft-IOC gateway exposing GEECS devices as PVs"
 authors = ["Sam Barber <sbarber@lbl.gov>"]
 readme = "README.md"
@@ -8,6 +8,7 @@ packages = [{ include = "geecs_ca_gateway" }]
 
 [tool.poetry.scripts]
 geecs-ca-gateway = "geecs_ca_gateway.__main__:main"
+geecs-ca-gateway-audit = "geecs_ca_gateway.audit:main"
 
 [tool.poetry.dependencies]
 python = ">=3.11,<3.12"

--- a/GeecsCAGateway/tests/test_audit.py
+++ b/GeecsCAGateway/tests/test_audit.py
@@ -1,0 +1,144 @@
+"""Tests for the read-only DB-hygiene audit (pure logic, no database).
+
+The DB-facing wrapper (:func:`run_audit`) and CLI import ``GeecsDb`` / ``mysql``
+lazily; these tests exercise only the pure classifier and the report/SQL
+formatters, so nothing here touches the database or the network.
+"""
+
+from __future__ import annotations
+
+from geecs_ca_gateway.audit import (
+    GHOST,
+    AuditResult,
+    Finding,
+    FkOrphanReport,
+    audit_subscribed_variables,
+    build_delete_sql,
+    format_report,
+)
+
+# The gateway's real skip set (image / 1darray are non-scalar, not served).
+SKIP_TYPES = {"image", "1darray"}
+
+
+def _var(name: str, vartype: str) -> dict:
+    """Build a minimal device-variable metadata dict (name + variabletype)."""
+    return {"name": name, "variabletype": vartype}
+
+
+def test_clean_device_has_no_findings() -> None:
+    """A device whose subscribed vars are all real scalars yields nothing."""
+    subscribed = {"U_Dev": ["current", "voltage"]}
+    device_variables = {
+        "U_Dev": [_var("current", "numeric"), _var("voltage", "numeric")]
+    }
+    assert audit_subscribed_variables(subscribed, device_variables, SKIP_TYPES) == []
+
+
+def test_ghost_variable_is_flagged() -> None:
+    """A get='yes' name absent from the device's real variables is a GHOST."""
+    subscribed = {"PicoscopeV2": ["charge_pC", "voltage"]}
+    device_variables = {"PicoscopeV2": [_var("voltage", "numeric")]}
+    findings = audit_subscribed_variables(subscribed, device_variables, SKIP_TYPES)
+    assert findings == [Finding("PicoscopeV2", "charge_pC", GHOST)]
+
+
+def test_skip_variable_is_flagged_with_its_type() -> None:
+    """A get='yes' variable typed image/1darray is a SKIP:<type> finding."""
+    subscribed = {"UC_Cam": ["frame", "lineout", "exposure"]}
+    device_variables = {
+        "UC_Cam": [
+            _var("frame", "image"),
+            _var("lineout", "1darray"),
+            _var("exposure", "numeric"),
+        ]
+    }
+    findings = audit_subscribed_variables(subscribed, device_variables, SKIP_TYPES)
+    assert findings == [
+        Finding("UC_Cam", "frame", "SKIP:image"),
+        Finding("UC_Cam", "lineout", "SKIP:1darray"),
+    ]
+
+
+def test_device_missing_from_metadata_is_all_ghosts_not_a_crash() -> None:
+    """A device absent from device_variables reports gracefully (all GHOST)."""
+    subscribed = {"U_Gone": ["a", "b"]}
+    device_variables: dict[str, list[dict]] = {}
+    findings = audit_subscribed_variables(subscribed, device_variables, SKIP_TYPES)
+    assert findings == [
+        Finding("U_Gone", "a", GHOST),
+        Finding("U_Gone", "b", GHOST),
+    ]
+
+
+def test_empty_inputs_yield_no_findings() -> None:
+    """Empty subscribed / device_variables produce an empty finding list."""
+    assert audit_subscribed_variables({}, {}, SKIP_TYPES) == []
+
+
+def test_mixed_devices_ordered_by_device_then_input_order() -> None:
+    """Findings sort by device (sorted) then the input order of variables."""
+    subscribed = {
+        "B_Dev": ["ghost_b", "img_b"],
+        "A_Dev": ["real_a", "ghost_a"],
+    }
+    device_variables = {
+        "A_Dev": [_var("real_a", "numeric")],
+        "B_Dev": [_var("img_b", "image")],
+    }
+    findings = audit_subscribed_variables(subscribed, device_variables, SKIP_TYPES)
+    assert findings == [
+        Finding("A_Dev", "ghost_a", GHOST),
+        Finding("B_Dev", "ghost_b", GHOST),
+        Finding("B_Dev", "img_b", "SKIP:image"),
+    ]
+
+
+def test_variabletype_case_is_normalized() -> None:
+    """Skip matching is case-insensitive on the variabletype."""
+    subscribed = {"U_Dev": ["frame"]}
+    device_variables = {"U_Dev": [_var("frame", "IMAGE")]}
+    findings = audit_subscribed_variables(subscribed, device_variables, SKIP_TYPES)
+    assert findings == [Finding("U_Dev", "frame", "SKIP:image")]
+
+
+def test_format_report_clean_says_no_problems() -> None:
+    """A clean audit result renders a 'No problems found.' report."""
+    result = AuditResult(experiment="Undulator")
+    report = format_report(result)
+    assert "No problems found." in report
+    assert "Undulator" in report
+
+
+def test_format_report_summarizes_counts_and_orphans() -> None:
+    """The PROBLEMS summary counts ghosts, skips and FK-orphans separately."""
+    result = AuditResult(
+        experiment="Undulator",
+        findings=[
+            Finding("D", "ghost", GHOST),
+            Finding("D", "img", "SKIP:image"),
+        ],
+        orphans=FkOrphanReport(count=1557, sample=[{"id": 1}]),
+        subscribed={"D": ["ghost", "img", "ok"]},
+    )
+    report = format_report(result, full=True)
+    assert "GHOST vars" in report
+    assert "1557" in report
+    # --full listing marks the clean variable OK and echoes the reasons.
+    assert "[OK" in report
+    assert "GHOST" in report
+
+
+def test_build_delete_sql_is_review_only_and_scoped() -> None:
+    """DELETE builder emits scoped ghost/skip deletes plus the orphan delete."""
+    result = AuditResult(
+        experiment="Undulator",
+        findings=[Finding("PicoscopeV2", "charge_pC", GHOST)],
+        orphans=FkOrphanReport(count=3),
+    )
+    statements = build_delete_sql("Undulator", result)
+    assert len(statements) == 2
+    assert "ed.expt = 'Undulator'" in statements[0]
+    assert "ed.device = 'PicoscopeV2'" in statements[0]
+    assert "edv.variablename = 'charge_pC'" in statements[0]
+    assert "ed.id IS NULL" in statements[1]


### PR DESCRIPTION
## What

A **read-only** DB-hygiene audit for the GEECS experiment database (tracks #496).

`expt_device_variable` accumulates `get='yes'` rows that no longer map to
anything real, because the LabVIEW DB-editing GUIs don't cascade deletions (no
FK constraints). Each stale row makes the CA gateway / scanner try to connect a
PV that will never exist → per-device stalls. This tool reports them so a human
can clean the DB.

### What it flags
- **GHOST** — a `get='yes'` row whose `variablename` isn't a real variable of
  the device (deleted variable, or an alias-derived name). The gateway serves
  PVs by *real* variablename, so a ghost names a PV that is never created.
- **SKIP:&lt;type&gt;** — a `get='yes'` variable whose `variabletype` is in the
  gateway's `_SKIP_VARTYPES` (`image` / `1darray`), so no scalar PV is served.
- **FK-orphan** — an `expt_device_variable` row whose `expt_device_id` points at
  an `expt_device.id` that no longer exists (whole experiment removed). ~1557 of
  these were found on the live DB during the 2026-07-10 investigation.

## Shape
- **Pure classifier** `audit_subscribed_variables(subscribed, device_variables,
  skip_types) -> list[Finding]` — zero DB imports, fully unit-tested over plain
  dicts.
- **DB-facing** `run_audit()` + `GeecsDb.get_fk_orphan_variables()` (LEFT JOIN
  `WHERE ed.id IS NULL`) import `GeecsDb` / `mysql` **lazily**, so the module
  imports offline.
- **CLI** — integrated alongside the existing `python -m geecs_ca_gateway` serve
  CLI as a sibling module `python -m geecs_ca_gateway.audit`, mirroring
  `__main__.py`'s argparse style, plus a new console script
  `geecs-ca-gateway-audit` next to `geecs-ca-gateway` in `pyproject.toml`.

## Read-only guarantee
It **never DELETEs or modifies** anything. `--sql` only *prints* (never
executes) the DELETE statements a human could review and run themselves;
`--full` prints the complete per-device listing.

## Example invocation
```
python -m geecs_ca_gateway.audit --experiment Undulator
python -m geecs_ca_gateway.audit --experiment Undulator --full --sql
```

## Tests
`tests/test_audit.py` (10 new, hermetic — no DB): clean device, GHOST,
SKIP:image/1darray, device missing from metadata (graceful all-GHOST, no crash),
empty inputs, ordering, case-normalization, report formatting, and the
review-only SQL builder.

`poetry run pytest tests -q` → **179 passed** (prior suite + 10 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)