### PR TITLE
GEECS-Console 0.2.0: live health chips + operator dialogs

### DIFF
--- a/GEECS-Console/CHANGELOG.md
+++ b/GEECS-Console/CHANGELOG.md
@@ -4,6 +4,31 @@ All notable changes to GEECS-Console are documented here.  Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versioning is
 semantic.
 
+## [0.2.0] - 2026-07-11
+
+### Added
+
+- Live health chips (R1): `GatewayTiledDbHealth` replaces the all-unknown
+  stub — a CA read of `{experiment}:CAGateway:HEARTBEAT` (OK; WARN when
+  `DEVICES_CONNECTED == 0`; DOWN on failure; UNKNOWN with no experiment
+  selected), an HTTP GET of the configured `[tiled] uri` (2xx → OK), and a
+  cheap `GeecsDb` query (OK / DOWN).  Each check is guarded with a short
+  timeout; `poll()` never raises and lazily imports `aioca` / `httpx` /
+  `GeecsDb` so the module stays import-safe offline.  `main.py` injects the
+  real probe; `StubHealth` remains the offline/test default.
+- Background health polling: a GUI-thread `QTimer` dispatches each blocking
+  `poll()` to a short-lived daemon thread (`HealthPoller`); the result is
+  marshaled back to the R1 chips via a queued signal, so a slow probe (e.g.
+  over VPN) never blocks the event loop.  The experiment combo pushes the
+  selected experiment into the probe so the next poll targets the right
+  gateway PV.  `closeEvent` stops the timer for clean teardown.
+- Operator / pre-flight dialogs: `ScanDialogEvent` now renders a modal
+  `QMessageBox` (`ScanEventsAdapter.dialog_requested` → `_on_operator_dialog`)
+  with the request's continue/abort labels.  Abort sets `request.abort[0]`;
+  either choice sets `request.response_event`, unblocking the engine's scan
+  thread (which is waiting on it).  The signal is delivered queued so the
+  modal always runs on the GUI thread while the engine thread stays blocked.
+
 ## [0.1.1] - 2026-07-10
 
 ### Added

--- a/GEECS-Console/CLAUDE.md
+++ b/GEECS-Console/CLAUDE.md
@@ -58,17 +58,42 @@ are prefixed by region (`r3_radio_1d`, `r5_start_button`, …).
 - The `.ui` is hand-authored XML loaded at runtime via `QUiLoader` — no
   generated `*_ui.py` files to keep in sync.
 
+## Implemented seams
+
+- **Health chips (R1)** are live via `GatewayTiledDbHealth` (real probe) or
+  `StubHealth` (all-unknown offline/test default).  The real probe runs three
+  guarded checks — CA read of `{experiment}:CAGateway:HEARTBEAT` (OK; WARN
+  when `DEVICES_CONNECTED == 0`; DOWN on failure; UNKNOWN with no experiment),
+  HTTP GET of the `[tiled] uri`, and a cheap `GeecsDb` query — each with a
+  short timeout; `poll()` **never raises** and lazily imports
+  `aioca`/`httpx`/`GeecsDb` inside itself so the module is import-safe offline.
+  Polling is **background**: a GUI-thread `QTimer` dispatches each blocking
+  `poll()` to a short-lived daemon thread (`HealthPoller`), and the result is
+  marshaled back to the chips via a **queued** `report_ready(object)` signal
+  (`_apply_health_report` is `@Slot(object)` and connected `QueuedConnection`
+  — an undecorated bound method could otherwise wire *direct* and paint
+  QLabels off the GUI thread, a hard crash).  Deliberately **no** worker
+  QThread/event-loop or cross-thread QTimer — that pattern aborted under
+  offscreen pytest ("QThread destroyed while running").  The experiment combo
+  pushes the selection into the probe (guarded `hasattr`/`setattr`, since
+  StubHealth has no `experiment`); `closeEvent` stops the timer.  Inject the
+  real probe in `main.py`; keep `StubHealth` as the window's default.
+- **Operator / pre-flight dialogs**: a `ScanDialogEvent` is rendered as a
+  modal `QMessageBox`.  `ScanEventsAdapter.handle` (on the engine/scan thread)
+  emits `dialog_requested(request)`; the queued signal delivers
+  `_on_operator_dialog` on the GUI thread (where the modal must live) while the
+  engine thread blocks on `request.response_event.wait()`.  Abort sets
+  `request.abort[0] = True`; either choice calls `request.response_event.set()`
+  to unblock the engine.  Duck-typed on the `DialogRequest` attributes — no
+  `geecs_bluesky` import.
+
 ## Stubbed seams (intentional, wire later)
 
-- Health chips: `StubHealth` returns all-unknown.  Real probes: CA read
-  against the gateway, HTTP ping to Tiled, `GeecsDb` connection check.
 - Device panel backend (see R7 above).
 - Presets persistence (save/load ScanRequest YAML; a preset dir in the
   configs repo is the natural home).
 - Optimization mode: radio exists, submission refused with a clear error
   until an `OptimizationSpec` editor exists.
-- `ScanDialogEvent` is logged, not rendered as a modal dialog yet — the
-  engine's operator-question wait falls back to its default.
 - Scan-number source: `set_scan_number` + the 10 s expiry exist, but no
   event carries the claimed number yet (engine-side follow-up).
 - `ConsoleConfigs._scan_variable_names` reaches into the resolver's private

--- a/GEECS-Console/geecs_console/app/main_window.py
+++ b/GEECS-Console/geecs_console/app/main_window.py
@@ -14,10 +14,11 @@ from __future__ import annotations
 
 import importlib.metadata
 import os
+import threading
 from pathlib import Path
 from typing import Callable, Optional
 
-from PySide6.QtCore import QFile, QTimer
+from PySide6.QtCore import QFile, QObject, Qt, QTimer, Signal, Slot
 from PySide6.QtUiTools import QUiLoader
 from PySide6.QtWidgets import (
     QApplication,
@@ -27,6 +28,7 @@ from PySide6.QtWidgets import (
     QLineEdit,
     QListWidget,
     QMainWindow,
+    QMessageBox,
     QPlainTextEdit,
     QProgressBar,
     QPushButton,
@@ -47,13 +49,21 @@ from geecs_console.request_builder import (
     estimate_total_shots,
 )
 from geecs_console.services.configs import ConsoleConfigs
-from geecs_console.services.health import HealthProbe, HealthStatus, StubHealth
+from geecs_console.services.health import (
+    HealthProbe,
+    HealthReport,
+    HealthStatus,
+    StubHealth,
+)
 from geecs_console.submission import Submitter, make_bluesky_submitter
 
 _UI_PATH = Path(__file__).parent / "ui" / "main_window.ui"
 _QSS_PATH = Path(__file__).parent / "style.qss"
 
 _SCAN_NUMBER_EXPIRY_MS = 10_000
+
+#: How often the background poller re-checks the health probe.
+_HEALTH_POLL_INTERVAL_MS = 5_000
 
 #: Screen-map semantic colors (see style.qss header for the full palette).
 _COLOR_DIM = "#6b7681"
@@ -102,6 +112,57 @@ def load_stylesheet() -> str:
     qss = _QSS_PATH.read_text(encoding="utf-8")
     ui_dir = (Path(__file__).parent / "ui").as_posix()
     return qss.replace("@UI_DIR@", ui_dir)
+
+
+class HealthPoller(QObject):
+    """Runs ``probe.poll()`` off the GUI thread and reports the result.
+
+    The poller itself lives on the GUI thread; each :meth:`poll_async` call
+    spawns a short-lived daemon thread that runs the (possibly slow) blocking
+    ``poll()`` and emits :attr:`report_ready` with the result.  Qt marshals the
+    emit back to the GUI-thread slot as a queued delivery, so the chips update
+    without ever blocking the event loop — and there is no worker Qt event loop
+    or cross-thread QTimer to manage.
+
+    Parameters
+    ----------
+    probe : HealthProbe
+        The probe to poll; only its ``poll()`` method is used, so it works
+        with the real probe, the stub, or a test fake.
+    """
+
+    report_ready = Signal(object)
+    """Carries one :class:`HealthReport` per completed poll."""
+
+    def __init__(self, probe: HealthProbe) -> None:
+        super().__init__()
+        self._probe = probe
+        self._busy = False
+
+    @Slot()
+    def poll_async(self) -> None:
+        """Kick off one poll in a daemon thread (skipped if one is in flight).
+
+        Called on the GUI thread from the interval timer; returns immediately.
+        """
+        if self._busy:
+            return
+        self._busy = True
+        threading.Thread(
+            target=self._run, name="console-health-poll", daemon=True
+        ).start()
+
+    def _run(self) -> None:
+        """Poll the probe (on the daemon thread) and emit the report."""
+        report = None
+        try:
+            report = self._probe.poll()
+        except Exception:  # noqa: BLE001 — a probe fault must not kill the poller
+            report = None
+        finally:
+            self._busy = False
+        if report is not None:
+            self.report_ready.emit(report)
 
 
 class MainWindow(QMainWindow):
@@ -158,7 +219,11 @@ class MainWindow(QMainWindow):
         self._scan_number_timer.timeout.connect(self._expire_scan_number)
 
         self._populate_from_configs()
-        self._refresh_health()
+        # Chips read UNKNOWN until the first background poll returns; seed the
+        # markup synchronously (no probe call — never touches the network).
+        self._apply_health_report(HealthReport())
+        self._push_experiment_to_probe(self._configs.experiment)
+        self._start_health_poller()
         self._set_state_pill("idle")
         self._on_mode_changed()
 
@@ -325,6 +390,7 @@ class MainWindow(QMainWindow):
         self.events.progress.connect(self._on_progress)
         self.events.error.connect(self._on_scan_error)
         self.events.log_line.connect(self.append_log)
+        self.events.dialog_requested.connect(self._on_operator_dialog)
 
     # ------------------------------------------------------------------
     # Configs / health population
@@ -389,12 +455,78 @@ class MainWindow(QMainWindow):
         color = _HEALTH_DOT_COLORS.get(status, _COLOR_GREY)
         return f'<span style="color:{color};">●</span> {name}: {status.value}'
 
-    def _refresh_health(self) -> None:
-        """Poll the health probe into the R1 chips."""
-        report = self._health.poll()
+    @Slot(object)
+    def _apply_health_report(self, report: HealthReport) -> None:
+        """Render a health report into the R1 chips (GUI-thread slot).
+
+        Parameters
+        ----------
+        report : HealthReport
+            The polled chip states (delivered queued from the background
+            :class:`HealthPoller`, or passed directly to seed the initial
+            all-unknown markup).
+        """
         self.gateway_chip.setText(self._chip_markup("gateway", report.gateway))
         self.tiled_chip.setText(self._chip_markup("tiled", report.tiled))
         self.db_chip.setText(self._chip_markup("db", report.db))
+
+    def _start_health_poller(self) -> None:
+        """Start the background health poller and its GUI-thread interval timer.
+
+        A GUI-thread :class:`~PySide6.QtCore.QTimer` fires every
+        :data:`_HEALTH_POLL_INTERVAL_MS`; each tick dispatches the blocking
+        ``poll()`` to a daemon thread inside :class:`HealthPoller`, whose
+        ``report_ready`` signal is delivered queued back to
+        :meth:`_apply_health_report` on the GUI thread.  Works with any probe
+        (stub or real).  One immediate poll runs so the chips leave ``UNKNOWN``
+        as soon as the first result lands.
+        """
+        self._health_poller = HealthPoller(self._health)
+        # Force a queued connection so the chip update always runs on the GUI
+        # thread — an undecorated bound method can otherwise be wired direct,
+        # which would paint QLabels from the daemon thread (a hard crash).
+        self._health_poller.report_ready.connect(
+            self._apply_health_report, Qt.ConnectionType.QueuedConnection
+        )
+        self._health_timer = QTimer(self)
+        self._health_timer.setInterval(_HEALTH_POLL_INTERVAL_MS)
+        self._health_timer.timeout.connect(self._health_poller.poll_async)
+        self._health_timer.start()
+        self._health_poller.poll_async()
+
+    def _push_experiment_to_probe(self, experiment: str) -> None:
+        """Point the probe at *experiment*'s gateway PV, if it supports it.
+
+        StubHealth has no ``experiment`` attribute, so this is a guarded no-op
+        for the offline default; the real probe picks up the new prefix on its
+        next poll.
+
+        Parameters
+        ----------
+        experiment : str
+            The selected experiment name ("" for none).
+        """
+        if hasattr(self._health, "experiment"):
+            setattr(self._health, "experiment", experiment or None)
+
+    def closeEvent(self, event) -> None:  # noqa: N802 — Qt override
+        """Stop the background health poller cleanly before closing.
+
+        Stops the GUI-thread interval timer (no further polls) and disconnects
+        the report signal so a still-running daemon poll can't paint a chip on
+        a window being torn down.  In-flight daemon threads are daemonic and
+        finish on their own without blocking shutdown.
+        """
+        timer = getattr(self, "_health_timer", None)
+        if timer is not None:
+            timer.stop()
+        poller = getattr(self, "_health_poller", None)
+        if poller is not None:
+            try:
+                poller.report_ready.disconnect(self._apply_health_report)
+            except (RuntimeError, TypeError):
+                pass
+        super().closeEvent(event)
 
     # ------------------------------------------------------------------
     # Form state (the round-trip surface tests exercise)
@@ -586,6 +718,7 @@ class MainWindow(QMainWindow):
     def _on_experiment_changed(self, experiment: str) -> None:
         """Repopulate everything for the newly selected experiment."""
         self._configs.set_experiment(experiment)
+        self._push_experiment_to_probe(experiment)
         self._populate_from_configs()
 
     def _on_trigger_profile_changed(self, profile: str) -> None:
@@ -750,3 +883,49 @@ class MainWindow(QMainWindow):
     def _on_scan_error(self, message: str) -> None:
         """Show scan errors in the status bar."""
         self.statusBar().showMessage(message, 10_000)
+
+    # ------------------------------------------------------------------
+    # Operator / pre-flight dialogs
+    # ------------------------------------------------------------------
+
+    def _on_operator_dialog(self, request: object) -> None:
+        """Render an operator question modally and unblock the engine thread.
+
+        Delivered queued from :meth:`ScanEventsAdapter.handle` (which runs on
+        the engine/scan thread, blocked on ``request.response_event``), so this
+        slot runs on the GUI thread — where a modal must live.  The engine
+        resumes with the operator's choice: Abort sets ``request.abort[0]``
+        before the response event is set.
+
+        Parameters
+        ----------
+        request : object
+            A ``DialogRequest`` (duck-typed): ``exc``, optional ``title`` /
+            ``continue_label`` / ``abort_label``, a mutable one-element
+            ``abort`` list, and a ``response_event`` (:class:`threading.Event`).
+        """
+        exc = getattr(request, "exc", None)
+        title = getattr(request, "title", None) or "Operator confirmation"
+        continue_label = getattr(request, "continue_label", None) or "Continue"
+        abort_label = getattr(request, "abort_label", None) or "Abort"
+
+        box = QMessageBox(self)
+        box.setIcon(QMessageBox.Icon.Warning)
+        box.setWindowTitle(str(title))
+        box.setText(str(exc) if exc is not None else str(title))
+        continue_button = box.addButton(
+            str(continue_label), QMessageBox.ButtonRole.AcceptRole
+        )
+        box.addButton(str(abort_label), QMessageBox.ButtonRole.RejectRole)
+        box.setDefaultButton(continue_button)
+        box.exec()
+
+        aborted = box.clickedButton() is not continue_button
+        abort_flag = getattr(request, "abort", None)
+        if aborted and isinstance(abort_flag, list) and abort_flag:
+            abort_flag[0] = True
+        self.append_log(f"operator: {'abort' if aborted else 'continue'}")
+
+        response_event = getattr(request, "response_event", None)
+        if response_event is not None and hasattr(response_event, "set"):
+            response_event.set()

--- a/GEECS-Console/geecs_console/events_adapter.py
+++ b/GEECS-Console/geecs_console/events_adapter.py
@@ -33,6 +33,14 @@ class ScanEventsAdapter(QObject):
     log_line = Signal(str)
     """One human-readable line per event, for the compact log tail."""
 
+    dialog_requested = Signal(object)
+    """A ``DialogRequest`` (operator question) to render as a modal dialog.
+
+    Carried as a plain object over a queued connection: :meth:`handle` runs on
+    the engine/scan thread (blocked on the request's ``response_event``), so
+    the GUI slot answers on the main thread and sets that event to unblock it.
+    """
+
     def handle(self, event: Any) -> None:
         """Consume one engine event (the ``on_event`` callback).
 
@@ -69,10 +77,13 @@ class ScanEventsAdapter(QObject):
             message = getattr(event, "message", "")
             self.log_line.emit(f"restore failed: {device}: {message}")
         elif kind == "ScanDialogEvent":
-            # Not yet rendered as a modal dialog (stubbed seam — see
-            # CLAUDE.md); the engine's wait falls back to its default.
+            # The engine's scan thread is blocked on request.response_event;
+            # emit the request so the main-thread slot renders a modal and
+            # answers it (queued delivery keeps the modal off this thread).
             request = getattr(event, "request", None)
             exc = getattr(request, "exc", None)
-            self.log_line.emit(f"operator question (unanswered): {exc}")
+            self.log_line.emit(f"operator question: {exc}")
+            if request is not None:
+                self.dialog_requested.emit(request)
         else:
             self.log_line.emit(kind)

--- a/GEECS-Console/geecs_console/services/health.py
+++ b/GEECS-Console/geecs_console/services/health.py
@@ -1,15 +1,26 @@
 """Health chips seam (R1): gateway / Tiled / DB status for the session bar.
 
-Only the protocol and a stub live here.  Real probes (a CA read against a
-gateway heartbeat PV, an HTTP ping to Tiled, a GeecsDb connection check)
-plug in later behind the same :class:`HealthProbe.poll` shape.
+The protocol and a stub live here alongside the real
+:class:`GatewayTiledDbHealth` probe (a CA read against the gateway heartbeat
+PV, an HTTP ping to Tiled, a GeecsDb connection check).  Every real
+dependency is imported lazily *inside* :meth:`GatewayTiledDbHealth.poll` so
+this module stays import-safe with zero network and without the ``ca`` extra.
+The probe is polled from a background thread (see the main window's
+``HealthPoller``); :meth:`poll` never blocks the GUI thread and never raises.
 """
 
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass
 from enum import Enum
-from typing import Protocol, runtime_checkable
+from typing import Optional, Protocol, runtime_checkable
+
+logger = logging.getLogger(__name__)
+
+#: Per-check timeout budget (seconds).  Kept short so a slow/absent service
+#: degrades a chip instead of stalling the background poll.
+_CHECK_TIMEOUT_S = 2.5
 
 
 class HealthStatus(str, Enum):
@@ -63,3 +74,168 @@ class StubHealth:
             Every chip ``HealthStatus.UNKNOWN``.
         """
         return HealthReport()
+
+
+class GatewayTiledDbHealth:
+    """Real R1 probe: gateway heartbeat PV, Tiled HTTP, and a GeecsDb query.
+
+    Each check runs in its own guarded block with a short timeout, so a slow
+    or absent service degrades a single chip rather than raising or stalling
+    the poll.  All real dependencies (``aioca``, ``httpx``, ``configparser``,
+    ``GeecsDb``) are imported lazily inside :meth:`poll`, keeping this module
+    import-safe offline.  :meth:`poll` is called from a background thread and
+    **never raises**.
+
+    Parameters
+    ----------
+    experiment : str, optional
+        The selected experiment; used to build the prefixed gateway PV
+        (``{experiment}:CAGateway:HEARTBEAT``).  ``None`` (no experiment
+        selected) leaves the gateway chip ``UNKNOWN`` — the prefixed PV
+        cannot be built.  Mutable: set ``self.experiment`` (or call
+        :meth:`set_experiment`) when the operator picks an experiment.
+    """
+
+    def __init__(self, experiment: Optional[str] = None) -> None:
+        self.experiment = experiment
+
+    def set_experiment(self, experiment: Optional[str]) -> None:
+        """Point subsequent polls at *experiment*'s gateway PV.
+
+        Parameters
+        ----------
+        experiment : str or None
+            The newly selected experiment name, or ``None`` for none.
+        """
+        self.experiment = experiment
+
+    def poll(self) -> HealthReport:
+        """Run all three checks and return their combined report.
+
+        Returns
+        -------
+        HealthReport
+            One status per chip.  Never raises: any failure inside a check
+            degrades that chip to ``DOWN`` (or ``UNKNOWN`` when the check is
+            unconfigured).
+        """
+        return HealthReport(
+            gateway=self._check_gateway(),
+            tiled=self._check_tiled(),
+            db=self._check_db(),
+        )
+
+    # ------------------------------------------------------------------
+    # Individual checks (each guarded; never raises)
+    # ------------------------------------------------------------------
+
+    def _check_gateway(self) -> HealthStatus:
+        """CA-read the gateway heartbeat PV for the current experiment.
+
+        Returns
+        -------
+        HealthStatus
+            ``UNKNOWN`` when no experiment is selected (no prefixed PV can be
+            built), ``OK`` when the heartbeat reads, ``WARN`` when it reads
+            but ``DEVICES_CONNECTED`` is 0, ``DOWN`` on any failure/timeout.
+        """
+        experiment = self.experiment
+        if not experiment:
+            return HealthStatus.UNKNOWN
+        try:
+            import asyncio
+
+            import aioca
+            from geecs_bluesky.devices.ca._pv import ca_pv
+            from geecs_bluesky.devices.ca.gateway_put import bare_pv
+
+            heartbeat_pv = bare_pv(ca_pv(experiment, "CAGateway", "HEARTBEAT"))
+            connected_pv = bare_pv(ca_pv(experiment, "CAGateway", "DEVICES_CONNECTED"))
+
+            async def _read() -> tuple[object, object]:
+                heartbeat = await asyncio.wait_for(
+                    aioca.caget(heartbeat_pv), timeout=_CHECK_TIMEOUT_S
+                )
+                try:
+                    connected = await asyncio.wait_for(
+                        aioca.caget(connected_pv), timeout=_CHECK_TIMEOUT_S
+                    )
+                except Exception:
+                    # Heartbeat is the primary liveness signal; a missing
+                    # DEVICES_CONNECTED PV must not flip a live gateway to DOWN.
+                    connected = None
+                return heartbeat, connected
+
+            _heartbeat, connected = asyncio.run(_read())
+            if connected is not None and int(connected) == 0:
+                return HealthStatus.WARN
+            return HealthStatus.OK
+        except Exception as exc:  # noqa: BLE001 — any failure is a DOWN chip
+            logger.debug("gateway health check failed: %s", exc)
+            return HealthStatus.DOWN
+
+    def _tiled_uri(self) -> Optional[str]:
+        """Return the ``[tiled] uri`` from the shared config, or ``None``.
+
+        Delegates to geecs_bluesky's canonical config reader (the same
+        ``[tiled] uri`` the engine subscribes its TiledWriter to), imported
+        lazily so this module stays import-safe offline.
+
+        Returns
+        -------
+        str or None
+            The configured Tiled root URI, or ``None`` when the config file
+            or the ``[tiled] uri`` option is absent.
+        """
+        from geecs_bluesky.tiled_integration import read_tiled_config
+
+        uri, _api_key = read_tiled_config()
+        return uri or None
+
+    def _check_tiled(self) -> HealthStatus:
+        """HTTP-GET the configured Tiled root URI.
+
+        Returns
+        -------
+        HealthStatus
+            ``UNKNOWN`` when no URI is configured, ``OK`` on a 2xx response,
+            ``DOWN`` otherwise (non-2xx or any exception).  The api_key is
+            not sent — a plain GET of the root returns 200.
+        """
+        try:
+            uri = self._tiled_uri()
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("reading tiled uri failed: %s", exc)
+            return HealthStatus.UNKNOWN
+        if not uri:
+            return HealthStatus.UNKNOWN
+        try:
+            import httpx
+
+            response = httpx.get(uri, timeout=_CHECK_TIMEOUT_S)
+            if 200 <= response.status_code < 300:
+                return HealthStatus.OK
+            return HealthStatus.DOWN
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("tiled health check failed: %s", exc)
+            return HealthStatus.DOWN
+
+    def _check_db(self) -> HealthStatus:
+        """Run a cheap GeecsDb query as a MySQL connectivity check.
+
+        Returns
+        -------
+        HealthStatus
+            ``OK`` when the query returns, ``DOWN`` on any exception (no
+            MySQL, no credentials, unreachable host).
+        """
+        try:
+            from geecs_ca_gateway.db.geecs_db import GeecsDb
+
+            # A cheap, indexed get='yes' lookup; the result is irrelevant —
+            # a successful round-trip is the connectivity signal.
+            GeecsDb.get_subscribed_variables(self.experiment or "")
+            return HealthStatus.OK
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("db health check failed: %s", exc)
+            return HealthStatus.DOWN

--- a/GEECS-Console/main.py
+++ b/GEECS-Console/main.py
@@ -14,9 +14,13 @@ def main() -> int:
     from PySide6.QtWidgets import QApplication
 
     from geecs_console.app.main_window import MainWindow
+    from geecs_console.services.health import GatewayTiledDbHealth
 
     app = QApplication(sys.argv)
-    window = MainWindow()
+    # Inject the real health probe in production; tests/offline fall back to the
+    # all-unknown StubHealth default.  The probe is background-polled (never on
+    # the GUI thread) and lazily imports aioca / httpx / GeecsDb inside poll().
+    window = MainWindow(health=GatewayTiledDbHealth())
     window.show()
     return app.exec()
 

--- a/GEECS-Console/pyproject.toml
+++ b/GEECS-Console/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-console"
-version = "0.1.1"
+version = "0.2.0"
 description = "Greenfield PySide6 operator console for GEECS (Bluesky/gateway architecture)"
 authors = ["Sam Barber <sbarber@lbl.gov>"]
 readme = "README.md"

--- a/GEECS-Console/tests/fake_events.py
+++ b/GEECS-Console/tests/fake_events.py
@@ -5,7 +5,8 @@ events_adapter's module docstring), so these hermetic stand-ins exercise the
 exact production dispatch without importing the engine.
 """
 
-from dataclasses import dataclass
+import threading
+from dataclasses import dataclass, field
 from typing import Optional
 
 
@@ -37,7 +38,14 @@ class ScanRestoreFailedEvent:
 
 @dataclass
 class _Request:
+    """Duck-typed stand-in for geecs_bluesky.events.DialogRequest."""
+
     exc: Optional[Exception] = None
+    title: Optional[str] = None
+    continue_label: Optional[str] = None
+    abort_label: Optional[str] = None
+    response_event: threading.Event = field(default_factory=threading.Event)
+    abort: list = field(default_factory=lambda: [False])
 
 
 @dataclass

--- a/GEECS-Console/tests/test_health.py
+++ b/GEECS-Console/tests/test_health.py
@@ -1,0 +1,163 @@
+"""GatewayTiledDbHealth.poll(), hermetic: every dependency monkeypatched.
+
+The real probe reaches CA (aioca), Tiled (httpx), and MySQL (GeecsDb); none
+are reachable in the test environment, so each check's dependency is patched
+to pin the OK / WARN / DOWN / UNKNOWN mapping and the never-raises contract.
+"""
+
+import aioca
+import httpx
+import pytest
+
+from geecs_console.services.health import (
+    GatewayTiledDbHealth,
+    HealthStatus,
+)
+
+
+class _Response:
+    def __init__(self, status_code):
+        self.status_code = status_code
+
+
+@pytest.fixture
+def probe():
+    return GatewayTiledDbHealth(experiment="Undulator")
+
+
+def _caget_returning(mapping, default):
+    async def _caget(pv, *args, **kwargs):
+        for key, value in mapping.items():
+            if key in pv:
+                return value
+        return default
+
+    return _caget
+
+
+def _caget_raising():
+    async def _caget(pv, *args, **kwargs):
+        raise RuntimeError("no CA")
+
+    return _caget
+
+
+class TestGateway:
+    def test_heartbeat_ok(self, probe, monkeypatch):
+        monkeypatch.setattr(aioca, "caget", _caget_returning({}, 232))
+        assert probe._check_gateway() is HealthStatus.OK
+
+    def test_zero_devices_connected_is_warn(self, probe, monkeypatch):
+        monkeypatch.setattr(
+            aioca,
+            "caget",
+            _caget_returning({"DEVICES_CONNECTED": 0, "HEARTBEAT": 232}, 232),
+        )
+        assert probe._check_gateway() is HealthStatus.WARN
+
+    def test_missing_devices_connected_pv_stays_ok(self, probe, monkeypatch):
+        # Heartbeat reads; the DEVICES_CONNECTED read fails -> still OK
+        # (heartbeat is the primary liveness signal).
+        async def _caget(pv, *args, **kwargs):
+            if "DEVICES_CONNECTED" in pv:
+                raise RuntimeError("no such PV")
+            return 232
+
+        monkeypatch.setattr(aioca, "caget", _caget)
+        assert probe._check_gateway() is HealthStatus.OK
+
+    def test_read_failure_is_down(self, probe, monkeypatch):
+        monkeypatch.setattr(aioca, "caget", _caget_raising())
+        assert probe._check_gateway() is HealthStatus.DOWN
+
+    def test_no_experiment_is_unknown(self, monkeypatch):
+        probe = GatewayTiledDbHealth(experiment=None)
+        # caget must never be reached; make it explode if it is.
+        monkeypatch.setattr(aioca, "caget", _caget_raising())
+        assert probe._check_gateway() is HealthStatus.UNKNOWN
+
+
+class TestTiled:
+    def test_2xx_is_ok(self, probe, monkeypatch):
+        monkeypatch.setattr(probe, "_tiled_uri", lambda: "http://tiled.local:8000")
+        monkeypatch.setattr(httpx, "get", lambda *a, **k: _Response(200))
+        assert probe._check_tiled() is HealthStatus.OK
+
+    def test_non_2xx_is_down(self, probe, monkeypatch):
+        monkeypatch.setattr(probe, "_tiled_uri", lambda: "http://tiled.local:8000")
+        monkeypatch.setattr(httpx, "get", lambda *a, **k: _Response(503))
+        assert probe._check_tiled() is HealthStatus.DOWN
+
+    def test_exception_is_down(self, probe, monkeypatch):
+        monkeypatch.setattr(probe, "_tiled_uri", lambda: "http://tiled.local:8000")
+
+        def _boom(*a, **k):
+            raise httpx.ConnectError("refused")
+
+        monkeypatch.setattr(httpx, "get", _boom)
+        assert probe._check_tiled() is HealthStatus.DOWN
+
+    def test_no_uri_is_unknown(self, probe, monkeypatch):
+        monkeypatch.setattr(probe, "_tiled_uri", lambda: None)
+        assert probe._check_tiled() is HealthStatus.UNKNOWN
+
+
+class TestDb:
+    def test_query_ok(self, probe, monkeypatch):
+        from geecs_ca_gateway.db.geecs_db import GeecsDb
+
+        monkeypatch.setattr(
+            GeecsDb, "get_subscribed_variables", classmethod(lambda cls, exp: {})
+        )
+        assert probe._check_db() is HealthStatus.OK
+
+    def test_query_raise_is_down(self, probe, monkeypatch):
+        from geecs_ca_gateway.db.geecs_db import GeecsDb
+
+        def _boom(cls, exp):
+            raise RuntimeError("no MySQL")
+
+        monkeypatch.setattr(GeecsDb, "get_subscribed_variables", classmethod(_boom))
+        assert probe._check_db() is HealthStatus.DOWN
+
+
+class TestPollAggregate:
+    def test_poll_reports_all_three(self, probe, monkeypatch):
+        from geecs_ca_gateway.db.geecs_db import GeecsDb
+
+        monkeypatch.setattr(aioca, "caget", _caget_returning({}, 232))
+        monkeypatch.setattr(probe, "_tiled_uri", lambda: "http://tiled.local:8000")
+        monkeypatch.setattr(httpx, "get", lambda *a, **k: _Response(200))
+        monkeypatch.setattr(
+            GeecsDb, "get_subscribed_variables", classmethod(lambda cls, exp: {})
+        )
+        report = probe.poll()
+        assert report.gateway is HealthStatus.OK
+        assert report.tiled is HealthStatus.OK
+        assert report.db is HealthStatus.OK
+
+    def test_poll_never_raises_when_all_fail(self, probe, monkeypatch):
+        from geecs_ca_gateway.db.geecs_db import GeecsDb
+
+        monkeypatch.setattr(aioca, "caget", _caget_raising())
+        monkeypatch.setattr(probe, "_tiled_uri", lambda: "http://tiled.local:8000")
+
+        def _boom(*a, **k):
+            raise RuntimeError("down")
+
+        monkeypatch.setattr(httpx, "get", _boom)
+        monkeypatch.setattr(
+            GeecsDb,
+            "get_subscribed_variables",
+            classmethod(lambda cls, exp: (_ for _ in ()).throw(RuntimeError("db"))),
+        )
+        report = probe.poll()  # must not raise
+        assert report.gateway is HealthStatus.DOWN
+        assert report.tiled is HealthStatus.DOWN
+        assert report.db is HealthStatus.DOWN
+
+    def test_set_experiment_updates_target(self, probe):
+        probe.set_experiment("Bella")
+        assert probe.experiment == "Bella"
+        probe.experiment = None
+        assert probe.experiment is None

--- a/GEECS-Console/tests/test_main_window.py
+++ b/GEECS-Console/tests/test_main_window.py
@@ -109,8 +109,74 @@ class TestConstruction:
             configs=FakeConfigs(), health=FakeHealth(), submitter=FakeSubmitter()
         )
         qtbot.addWidget(win)
-        # Chips are rich-text pills (colored dot + text) — check the text part.
-        assert "gateway: down" in win.gateway_chip.text()
+        # Chips now update from the background poller (queued to the GUI
+        # thread), so wait for the first report to land.  Chips are rich-text
+        # pills (colored dot + text) — check the text part.
+        qtbot.waitUntil(
+            lambda: "gateway: down" in win.gateway_chip.text(), timeout=3000
+        )
+
+    def test_apply_health_report_updates_chips_and_colors(self, window):
+        """The GUI-thread slot renders each chip's text and dot color."""
+        window._apply_health_report(
+            HealthReport(
+                gateway=HealthStatus.OK,
+                tiled=HealthStatus.WARN,
+                db=HealthStatus.DOWN,
+            )
+        )
+        assert "gateway: ok" in window.gateway_chip.text()
+        assert "tiled: warn" in window.tiled_chip.text()
+        assert "db: down" in window.db_chip.text()
+        # Dot colors come from the semantic palette (green / amber / red).
+        assert "#2f9e63" in window.gateway_chip.text()  # green OK
+        assert "#d9a21b" in window.tiled_chip.text()  # amber WARN
+        assert "#c4453a" in window.db_chip.text()  # red DOWN
+
+    def test_window_closes_cleanly_with_poller(self, qtbot):
+        """Real poller wiring: the interval timer starts, and close stops it.
+
+        Guards against the QThread 'destroyed while running' abort by asserting
+        the poll machinery is deterministically quiet after closeEvent.
+        """
+        win = MainWindow(configs=FakeConfigs(), submitter=FakeSubmitter())
+        qtbot.addWidget(win)
+        win.show()
+        assert win._health_timer.isActive()
+        assert win.close()
+        assert not win._health_timer.isActive()
+
+    def test_close_during_inflight_poll_returns_promptly(self, qtbot):
+        """A slow poll in flight must not block (or crash) window close."""
+        import time
+
+        class SlowHealth:
+            def poll(self):
+                time.sleep(0.4)
+                return HealthReport()
+
+        win = MainWindow(
+            configs=FakeConfigs(), health=SlowHealth(), submitter=FakeSubmitter()
+        )
+        qtbot.addWidget(win)
+        win.show()  # immediate poll dispatched to a daemon thread
+        started = time.monotonic()
+        win.close()  # must not join the 0.4 s daemon poll
+        assert time.monotonic() - started < 0.3
+        assert not win._health_timer.isActive()
+
+    def test_experiment_change_pushes_into_probe(self, qtbot):
+        class ProbeWithExperiment:
+            experiment = None
+
+            def poll(self):
+                return HealthReport()
+
+        probe = ProbeWithExperiment()
+        win = MainWindow(configs=FakeConfigs(), health=probe, submitter=FakeSubmitter())
+        qtbot.addWidget(win)
+        win._on_experiment_changed("Bella")
+        assert probe.experiment == "Bella"
 
     def test_stylesheet_loads_and_applies(self, qtbot, window):
         """The packaged QSS must load non-empty and apply application-wide."""
@@ -278,3 +344,66 @@ class TestNowAndDevicePanel:
         assert window.scan_number_label.text() == "Scan 042"
         window._expire_scan_number()
         assert window.scan_number_label.text() == "Scan 042 (previous)"
+
+
+def _auto_answer(monkeypatch, role):
+    """Make the next QMessageBox return non-blocking, choosing *role*'s button."""
+    from PySide6.QtWidgets import QMessageBox
+
+    monkeypatch.setattr(QMessageBox, "exec", lambda self: 0)
+
+    def _clicked(self):
+        for button in self.buttons():
+            if self.buttonRole(button) == role:
+                return button
+        return None
+
+    monkeypatch.setattr(QMessageBox, "clickedButton", _clicked)
+
+
+class TestOperatorDialog:
+    """ScanDialogEvent -> modal QMessageBox -> unblock the engine thread."""
+
+    def test_continue_sets_response_event_without_aborting(self, window, monkeypatch):
+        from PySide6.QtWidgets import QMessageBox
+
+        from fake_events import ScanDialogEvent, _Request
+
+        _auto_answer(monkeypatch, QMessageBox.ButtonRole.AcceptRole)
+        request = _Request(
+            exc=RuntimeError("gateway down — proceed anyway?"),
+            title="Pre-flight",
+            continue_label="Drop && Continue",
+            abort_label="Abort scan",
+        )
+        # handle() runs on this (GUI) thread here, so the auto-connected signal
+        # delivers the slot synchronously; in production the engine thread's
+        # emit is queued to the GUI thread instead.
+        window.events.handle(ScanDialogEvent(request=request))
+
+        assert request.response_event.is_set()
+        assert request.abort == [False]
+        assert "operator: continue" in window.log_tail.toPlainText()
+
+    def test_abort_sets_flag_and_response_event(self, window, monkeypatch):
+        from PySide6.QtWidgets import QMessageBox
+
+        from fake_events import ScanDialogEvent, _Request
+
+        _auto_answer(monkeypatch, QMessageBox.ButtonRole.RejectRole)
+        request = _Request(exc=RuntimeError("device missing"))
+        window.events.handle(ScanDialogEvent(request=request))
+
+        assert request.response_event.is_set()
+        assert request.abort == [True]
+        assert "operator: abort" in window.log_tail.toPlainText()
+
+    def test_adapter_has_gui_thread_affinity(self, window):
+        """The adapter lives on the GUI thread, so an engine-thread emit queues.
+
+        The dialog connection uses Qt's default AutoConnection (not a forced
+        DirectConnection): because the adapter's thread affinity is the GUI
+        thread, a ``dialog_requested`` emitted from the engine/scan thread is
+        delivered queued onto the GUI thread — the only place the modal may run.
+        """
+        assert window.events.thread() is window.thread()


### PR DESCRIPTION
Wires two previously-stubbed seams in the greenfield PySide6 console (`GEECS-Console`), bumping it to **0.2.0**.

## A. Live health chips (R1)

`GatewayTiledDbHealth` replaces the all-unknown `StubHealth`:

- **gateway** — CA read of `{experiment}:CAGateway:HEARTBEAT` (`aioca.caget`, ~2.5 s). Read OK → `OK`; read OK but `DEVICES_CONNECTED == 0` → `WARN`; failure/timeout → `DOWN`; no experiment selected → `UNKNOWN`. PV built via `ca_pv` + `bare_pv`.
- **tiled** — HTTP GET of the `[tiled] uri` (reuses `geecs_bluesky.tiled_integration.read_tiled_config`); 2xx → `OK`, else/exception → `DOWN`, no uri → `UNKNOWN`.
- **db** — a cheap `GeecsDb.get_subscribed_variables` round-trip; success → `OK`, exception → `DOWN`.

Each check is individually guarded with a short timeout; `poll()` **never raises**, and every real dependency (`aioca`, `httpx`, `configparser`/config, `GeecsDb`) is imported **lazily inside `poll()`** so the module stays import-safe offline. `main.py` injects the real probe; `StubHealth` remains the window's offline/test default.

## B. Operator / pre-flight dialogs

`ScanDialogEvent` now renders a modal `QMessageBox` instead of just logging. `ScanEventsAdapter` gains `dialog_requested(object)`; `_on_operator_dialog` shows the modal with the request's continue/abort labels. On Abort it sets `request.abort[0] = True`; either choice calls `request.response_event.set()` to unblock the engine's scan thread. Duck-typed on the `DialogRequest` attributes — no `geecs_bluesky` import.

## Threading model

- **Health poll — off the GUI thread.** A GUI-thread `QTimer` (5 s) dispatches each blocking `poll()` to a short-lived **daemon thread** (`HealthPoller.poll_async`), whose result is marshaled back to the chips via a **queued** `report_ready(object)` signal (`_apply_health_report` is `@Slot(object)`, connected `QueuedConnection`). This deliberately avoids a worker `QThread`/event-loop + cross-thread `QTimer`: that pattern aborted under offscreen pytest with Qt's fatal *"QThread: Destroyed while thread is still running"*, and an undecorated bound-method connection was silently wired **direct**, painting QLabels off the GUI thread (a segfault). Daemon threads need no join, so a slow probe over VPN can never block window close; `closeEvent` just stops the timer and disconnects the signal. The experiment combo pushes the selection into the probe so the next poll targets the right gateway PV.
- **Dialog — queued to the GUI thread.** `handle()` runs on the engine/scan thread (blocked on `response_event`); because the adapter has GUI-thread affinity, `dialog_requested` is delivered **queued**, so the modal runs on the GUI thread while the engine thread stays blocked until `response_event.set()`.

## Tests

Hermetic, `QT_QPA_PLATFORM=offscreen`, all mock-driven (no lab network):

- `test_health.py` (new) — every dependency monkeypatched: gateway OK/WARN/DOWN/UNKNOWN, tiled OK/DOWN/UNKNOWN, db OK/DOWN, aggregate `poll()`, and `poll()` never raises when all three throw.
- `test_main_window.py` — background poller feeds chips (waitUntil), direct `_apply_health_report` chip text + dot colors, experiment push into probe, dialog continue (abort stays `[False]`, event set) and abort (`[True]`, event set), plus **clean-teardown** tests (timer stops on close; close during an in-flight slow poll returns promptly).

**73 passed, exit 0**, verified stable across repeated runs; the whole prior 52-test suite stays green. The real probes can't be hardware-verified in this env (no lab network) — that is expected and left for live verification against the gateway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)