### PR TITLE
GeecsBluesky: carry claimed scan number on lifecycle events

### DIFF
--- a/GeecsBluesky/CHANGELOG.md
+++ b/GeecsBluesky/CHANGELOG.md
@@ -4,6 +4,26 @@ All notable changes to `geecs-bluesky` are documented here.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.30.0] - 2026-07-11
+
+### Added
+
+- **Lifecycle events carry the claimed scan number.** `ScanLifecycleEvent`
+  (`geecs_bluesky/events.py`) gains an optional `scan_number: int | None`
+  field (default `None` — additive, consumers dispatching on event class
+  names are unaffected) so GUIs can display "Scan NNN" from the event
+  stream alone. `BlueskyScanner` stamps it onto every lifecycle emission:
+  the exec_config paths (`_execute_scan`, `_run_optimization`) set it at
+  their claim sites, so INITIALIZING/RUNNING/DONE/ABORTED all carry the
+  number; the delegated ScanRequest path (where `session.scan` claims
+  inside the engine, after INITIALIZING/RUNNING were emitted) picks the
+  number up from the run start document (`geecs_run_wrapper` metadata) and
+  re-emits RUNNING carrying it, so consumers get the number mid-scan, not
+  only on DONE. Emissions before the claim — and every emission of a scan
+  whose claim failed (NetApp unreachable) — carry `None`. A guard ignores
+  start documents while the scanner is not RUNNING, so a headless run on
+  the shared RunEngine cannot flip an idle GUI or plant a stale number.
+
 ## [0.29.0] - 2026-07-10
 
 ### Changed

--- a/GeecsBluesky/CLAUDE.md
+++ b/GeecsBluesky/CLAUDE.md
@@ -146,8 +146,13 @@ session, the `GEECS_USE_BLUESKY` env var (resolved by
 `geecs_scanner.engine.backend_selection`; explicit argument wins, default
 legacy).  That path loads the selected shot-control YAML and passes it as
 `shot_control_information`, and passes the `on_event` callback:
-BlueskyScanner emits `ScanLifecycleEvent`s through it via `_set_state`,
-shot-level `ScanStepEvent`s per event document via `_on_document` (so the
+BlueskyScanner emits `ScanLifecycleEvent`s through it via `_set_state` —
+each carrying the claimed scan number (`scan_number=None` until the
+`ScanNNN` folder is claimed; the delegated ScanRequest path, where
+`session.scan` claims inside the engine, picks the number up from the run
+start document and re-emits RUNNING with it, so a "Scan NNN" GUI label
+works on every path) — shot-level `ScanStepEvent`s per event document via
+`_on_document` (so the
 GUI progress bar works in Bluesky mode), and pre-flight `ScanDialogEvent`s
 from the gateway-liveness check (both modes: each sync device's
 `connected_status` — the gateway `CONNECTED` PV — is read pre-claim; free-run

--- a/GeecsBluesky/geecs_bluesky/events.py
+++ b/GeecsBluesky/geecs_bluesky/events.py
@@ -147,10 +147,19 @@ class ScanLifecycleEvent(ScanEvent):
         Non-zero only on the ``INITIALIZING`` event; zero on all others.
         Consumers should cache this value on the ``INITIALIZING`` event and
         use it to compute progress from subsequent :class:`ScanStepEvent` s.
+    scan_number :
+        The claimed day-scoped GEECS scan number (``ScanNNN``), or ``None``
+        when it is not (yet) known.  Emissions before the scan folder is
+        claimed carry ``None``; every lifecycle emission after the claim
+        carries the number, so consumers (e.g. a "Scan NNN" GUI label) can
+        latch the first non-``None`` value.  A scan whose claim failed
+        (``geecs_data_utils`` unavailable, NetApp unreachable) keeps
+        emitting ``None``.
     """
 
     state: ScanState = ScanState.IDLE
     total_shots: int = 0
+    scan_number: Optional[int] = None
 
 
 # ---------------------------------------------------------------------------

--- a/GeecsBluesky/geecs_bluesky/scanner_bridge/bluesky_scanner.py
+++ b/GeecsBluesky/geecs_bluesky/scanner_bridge/bluesky_scanner.py
@@ -225,6 +225,9 @@ class BlueskyScanner:
         self._total_shots: int = 0
         self._total_steps: int = 0
         self._completed_shots: int = 0
+        # The claimed day-scoped scan number for the current scan (None until
+        # claimed); stamped onto every lifecycle event via _set_state.
+        self._scan_number: int | None = None
         # uid of the most recent run's start document (for the Tiled exporter)
         self._last_run_uid: str | None = None
 
@@ -298,6 +301,7 @@ class BlueskyScanner:
         self._completed_shots = 0
         self._total_shots = 0
         self._total_steps = 0
+        self._scan_number = None
         self._session.rep_rate_hz = self._rep_rate_hz
 
         # Disconnect any leftover devices from a previous scan
@@ -381,6 +385,7 @@ class BlueskyScanner:
         self._completed_shots = 0
         self._total_shots = 0
         self._total_steps = 0
+        self._scan_number = None
         self._session.rep_rate_hz = self._rep_rate_hz
 
         # Disconnect any leftover devices from a previous scan
@@ -461,6 +466,7 @@ class BlueskyScanner:
             return
 
         self._completed_shots = 0
+        self._scan_number = None
         self._abort_requested = False
         self._scan_thread = threading.Thread(
             target=self._run_scan,
@@ -541,9 +547,41 @@ class BlueskyScanner:
     def _on_document(self, name: str, doc: dict) -> None:
         if name == "start":
             self._last_run_uid = doc.get("uid")
+            self._note_claimed_scan_number(doc.get("scan_number"))
         elif name == "event":
             self._completed_shots += 1
             self._emit_step_progress(doc)
+
+    def _note_claimed_scan_number(self, scan_number: Any) -> None:
+        """Carry an engine-claimed scan number into the lifecycle stream.
+
+        On the delegated ScanRequest path the bridge never pre-claims —
+        ``session.scan`` claims the number inside the engine and stamps it
+        into the run start document (``geecs_run_wrapper`` metadata,
+        ``EVENT_SCHEMA.md``).  The INITIALIZING/RUNNING lifecycle events
+        were already emitted (pre-claim, ``scan_number=None``) by then, so
+        pick the number up here and re-emit RUNNING carrying it — consumers
+        get the number while the scan runs, not only on DONE/ABORTED.
+
+        The exec_config paths set ``_scan_number`` at their own claim sites
+        before any lifecycle emission, so this is a no-op there (the start
+        document repeats the same number).  The RUNNING guard keeps a
+        headless run on the shared RunEngine (not this scanner's scan) from
+        flipping the GUI state.
+        """
+        if scan_number is None or self._scan_number is not None:
+            return
+        if self._current_state != self._scan_state("RUNNING"):
+            return
+        try:
+            self._scan_number = int(scan_number)
+        except (TypeError, ValueError):
+            logger.debug(
+                "start document carried a non-integer scan_number %r; ignoring",
+                scan_number,
+            )
+            return
+        self._set_state("RUNNING")
 
     def _emit_step_progress(self, doc: dict) -> None:
         """Emit a :class:`ScanStepEvent` for one Bluesky event document.
@@ -597,13 +635,24 @@ class BlueskyScanner:
         return getattr(ScanState, state_name)
 
     def _set_state(self, state_name: str, total_shots: int = 0) -> None:
-        """Update lifecycle state and emit a GUI scan lifecycle event if possible."""
+        """Update lifecycle state and emit a GUI scan lifecycle event if possible.
+
+        Every emission carries the claimed scan number (``None`` until the
+        scan folder is claimed), so consumers can display "Scan NNN" from
+        the lifecycle stream alone.
+        """
         state = self._scan_state(state_name)
         self._current_state = state
         if self._on_event is None or ScanLifecycleEvent is None:
             return
         try:
-            self._on_event(ScanLifecycleEvent(state=state, total_shots=total_shots))
+            self._on_event(
+                ScanLifecycleEvent(
+                    state=state,
+                    total_shots=total_shots,
+                    scan_number=self._scan_number,
+                )
+            )
         except Exception:
             logger.debug("on_event callback raised; ignoring", exc_info=True)
 
@@ -1124,6 +1173,8 @@ class BlueskyScanner:
         # the whole run).
         scan_tag, scan_folder = claim_scan(self._experiment_dir)
         scan_number = scan_tag.number if scan_tag is not None else None
+        # Lifecycle events emitted from here on carry the claimed number.
+        self._scan_number = scan_number
 
         try:
             objective, suggester = bridge.bind(
@@ -1226,6 +1277,8 @@ class BlueskyScanner:
             return
 
         scan_number, scan_folder = claim_scan_number(self._experiment_dir)
+        # Lifecycle events emitted from here on carry the claimed number.
+        self._scan_number = scan_number
 
         n_shots = len(positions) * self._shots_per_step
         self._total_shots = n_shots

--- a/GeecsBluesky/pyproject.toml
+++ b/GeecsBluesky/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-bluesky"
-version = "0.29.0"
+version = "0.30.0"
 description = "Bluesky / ophyd-async bridge for the GEECS control system"
 authors = ["Sam Barber <sbarber@lbl.gov>"]
 readme = "README.md"

--- a/GeecsBluesky/tests/test_bluesky_scanner_gui_bridge.py
+++ b/GeecsBluesky/tests/test_bluesky_scanner_gui_bridge.py
@@ -31,6 +31,7 @@ class _FakeLifecycleEvent:
 
     state: str
     total_shots: int = 0
+    scan_number: int | None = None
 
 
 def test_set_state_emits_gui_lifecycle_event(monkeypatch) -> None:
@@ -39,6 +40,7 @@ def test_set_state_emits_gui_lifecycle_event(monkeypatch) -> None:
     scanner = BlueskyScanner.__new__(BlueskyScanner)
     scanner._on_event = events.append
     scanner._current_state = None
+    scanner._scan_number = None
 
     monkeypatch.setattr(
         bluesky_scanner,
@@ -54,7 +56,30 @@ def test_set_state_emits_gui_lifecycle_event(monkeypatch) -> None:
     scanner._set_state("DONE", total_shots=12)
 
     assert scanner.current_state == "done"
-    assert events == [_FakeLifecycleEvent(state="done", total_shots=12)]
+    assert events == [
+        _FakeLifecycleEvent(state="done", total_shots=12, scan_number=None)
+    ]
+
+
+def test_set_state_carries_claimed_scan_number(monkeypatch) -> None:
+    """Once a scan number is claimed, every lifecycle emission carries it."""
+    events: list[_FakeLifecycleEvent] = []
+    scanner = BlueskyScanner.__new__(BlueskyScanner)
+    scanner._on_event = events.append
+    scanner._current_state = None
+    scanner._scan_number = 41
+
+    monkeypatch.setattr(
+        bluesky_scanner,
+        "ScanState",
+        SimpleNamespace(RUNNING="running", DONE="done"),
+    )
+    monkeypatch.setattr(bluesky_scanner, "ScanLifecycleEvent", _FakeLifecycleEvent)
+
+    scanner._set_state("RUNNING")
+    scanner._set_state("DONE")
+
+    assert [e.scan_number for e in events] == [41, 41]
 
 
 def test_prepare_descriptor_for_tiled_internalizes_geecs_assets() -> None:
@@ -324,6 +349,7 @@ def _make_optimization_scanner(session, bridge, monkeypatch, *, loader=True):
     scanner._on_event = None
     scanner._current_state = None
     scanner._total_shots = 0
+    scanner._scan_number = None
     scanner._abort_requested = False
     scanner._optimization_loader = (lambda path: bridge) if loader else None
     monkeypatch.setattr(

--- a/GeecsBluesky/tests/test_bluesky_scanner_progress_and_preflight.py
+++ b/GeecsBluesky/tests/test_bluesky_scanner_progress_and_preflight.py
@@ -201,6 +201,7 @@ def _make_scanner(
     scanner._total_shots = 0
     scanner._total_steps = 0
     scanner._completed_shots = 0
+    scanner._scan_number = None
     scanner._abort_requested = False
     scanner._optimization_loader = None
     scanner._RE = SimpleNamespace(
@@ -950,3 +951,62 @@ def test_recheck_clears_transiently_stale_device(monkeypatch) -> None:
     assert not any(isinstance(e, _FakeDialogEvent) for e in events)
     assert session.scan_kwargs is not None
     assert len(session.scan_kwargs["detectors"]) == 2
+
+
+# ---------------------------------------------------------------------------
+# Lifecycle events carry the claimed scan number (GUI "Scan NNN" label)
+# ---------------------------------------------------------------------------
+
+
+def test_lifecycle_events_carry_claimed_scan_number(monkeypatch) -> None:
+    """Every post-claim lifecycle emission carries the claimed number.
+
+    On the exec_config path the bridge claims before emitting INITIALIZING,
+    so INITIALIZING/RUNNING/DONE all carry the number — GUI consumers can
+    latch the first non-None value for a "Scan NNN" label.
+    """
+    from geecs_bluesky.events import ScanLifecycleEvent, ScanState
+
+    _patch_dialog_channel(monkeypatch)
+    claims: list = []
+    _patch_claim(monkeypatch, claims, result=(12, "/nonexistent/Scan012"))
+    session = _FakeSession()
+    scanner = _make_scanner(
+        session, {"U_Ref": {"synchronous": True, "variable_list": ["Sig"]}}
+    )
+    events: list = []
+    scanner._on_event = events.append
+
+    scanner._run_scan(_noscan_config())
+
+    assert session.scan_kwargs is not None
+    assert session.scan_kwargs["scan_number"] == 12
+    lifecycle = [
+        (e.state, e.scan_number) for e in events if isinstance(e, ScanLifecycleEvent)
+    ]
+    assert lifecycle == [
+        (ScanState.INITIALIZING, 12),
+        (ScanState.RUNNING, 12),
+        (ScanState.DONE, 12),
+    ]
+
+
+def test_lifecycle_events_carry_none_when_claim_fails(monkeypatch) -> None:
+    """An unclaimed scan (NetApp down / claim failed) keeps emitting None."""
+    from geecs_bluesky.events import ScanLifecycleEvent
+
+    _patch_dialog_channel(monkeypatch)
+    claims: list = []
+    _patch_claim(monkeypatch, claims, result=(None, None))
+    session = _FakeSession()
+    scanner = _make_scanner(
+        session, {"U_Ref": {"synchronous": True, "variable_list": ["Sig"]}}
+    )
+    events: list = []
+    scanner._on_event = events.append
+
+    scanner._run_scan(_noscan_config())
+
+    lifecycle = [e for e in events if isinstance(e, ScanLifecycleEvent)]
+    assert lifecycle, "the scan must still emit lifecycle events"
+    assert all(e.scan_number is None for e in lifecycle)

--- a/GeecsBluesky/tests/test_bluesky_scanner_scan_lifecycle.py
+++ b/GeecsBluesky/tests/test_bluesky_scanner_scan_lifecycle.py
@@ -117,6 +117,7 @@ def _make_scanner(
     scanner._current_state = None
     scanner._total_shots = 0
     scanner._completed_shots = 0
+    scanner._scan_number = None
     scanner._abort_requested = False
     scanner._optimization_loader = None
     scanner._RE = SimpleNamespace(

--- a/GeecsBluesky/tests/test_bluesky_scanner_scan_request_seam.py
+++ b/GeecsBluesky/tests/test_bluesky_scanner_scan_request_seam.py
@@ -199,6 +199,7 @@ def _make_scanner(session: _FakeSession) -> BlueskyScanner:
     scanner._total_shots = 0
     scanner._total_steps = 0
     scanner._completed_shots = 0
+    scanner._scan_number = None
     scanner._abort_requested = False
     scanner._optimization_loader = None
     scanner._scan_request = None
@@ -558,6 +559,72 @@ def test_delegated_preflight_receives_assembled_detectors(monkeypatch) -> None:
     assert seen["strict"] is True
     assert seen["disconnect_on_drop"] is False
     assert session.scan_kwargs is not None
+
+
+def test_delegated_lifecycle_carries_engine_claimed_scan_number(monkeypatch) -> None:
+    """The delegated path picks the scan number up from the start document.
+
+    The bridge never pre-claims here — ``session.scan`` claims inside the
+    engine, after INITIALIZING/RUNNING were emitted — so those first
+    emissions carry ``None`` and the bridge re-emits RUNNING with the
+    number once the start document (which ``geecs_run_wrapper`` stamps
+    with ``scan_number``) flows through ``_on_document``.  DONE then
+    carries it too.
+    """
+    from geecs_bluesky.events import ScanLifecycleEvent, ScanState
+
+    _patch_claim(monkeypatch, [])
+    session = _FakeSession()
+    scanner = _make_scanner(session)
+    events: list = []
+    scanner._on_event = events.append
+    scanner.reinitialize(_noscan_request(), resolver=_resolver())
+    # Pass-through preflight: the operator-dialog pipeline is pinned
+    # elsewhere and would otherwise dialog on the frameless fakes.
+    scanner._preflight_check_sync_liveness = (
+        lambda detectors, strict=False, disconnect_on_drop=True: detectors
+    )
+
+    original_scan = session.scan
+
+    def scan_with_engine_claim(**kwargs):
+        # The engine claims inside session.scan and stamps the number into
+        # the run start document; the bridge sees it via _on_document.
+        scanner._on_document("start", {"uid": "u1", "scan_number": 33})
+        # A duplicate start-doc pickup must not re-emit.
+        scanner._on_document("start", {"uid": "u1", "scan_number": 33})
+        return original_scan(**kwargs)
+
+    session.scan = scan_with_engine_claim
+    scanner._run_scan(scanner._scan_config)
+
+    lifecycle = [
+        (e.state, e.scan_number) for e in events if isinstance(e, ScanLifecycleEvent)
+    ]
+    assert lifecycle == [
+        (ScanState.INITIALIZING, None),  # pre-claim: number not known yet
+        (ScanState.RUNNING, None),
+        (ScanState.RUNNING, 33),  # re-emitted once the engine claimed
+        (ScanState.DONE, 33),
+    ]
+
+
+def test_start_document_from_foreign_run_is_ignored(monkeypatch) -> None:
+    """A start document while this scanner is not RUNNING changes nothing.
+
+    The session's RunEngine is shared: a headless run driven directly on
+    ``scanner._session`` must not flip the idle GUI to RUNNING or plant a
+    stale scan number.
+    """
+    session = _FakeSession()
+    scanner = _make_scanner(session)
+    events: list = []
+    scanner._on_event = events.append
+
+    scanner._on_document("start", {"uid": "u1", "scan_number": 99})
+
+    assert scanner._scan_number is None
+    assert events == []
 
 
 def test_delegated_totals_hook(monkeypatch) -> None:


### PR DESCRIPTION
## What

Adds the claimed day-scoped scan number to the engine's scan event stream so GUI consumers (e.g. the GEECS-Console "Scan NNN" label) can display it without polling.

## Design

- **`ScanLifecycleEvent` gains `scan_number: int | None = None`** (`geecs_bluesky/events.py`). Additive field on the existing lifecycle event — consumers dispatch on event class names, so no new event class and no compatibility break (the `geecs_scanner` shims re-export the same class object).
- **`BlueskyScanner` stamps it on every lifecycle emission** via `_set_state`, tracked in a per-scan `_scan_number` (reset at `reinitialize` / `start_scan_thread`):
  - **exec_config paths** (`_execute_scan`, `_run_optimization`): set at the claim site, so INITIALIZING / RUNNING / DONE / ABORTED all carry the number.
  - **delegated ScanRequest path**: the bridge never pre-claims there — `session.scan` claims inside the engine *after* INITIALIZING/RUNNING were emitted. The bridge picks the number up from the run start document (`geecs_run_wrapper` already stamps `scan_number` into run metadata, see `EVENT_SCHEMA.md`) and re-emits RUNNING carrying it, so consumers get the number mid-scan, not only on DONE.
  - Pre-claim emissions and every emission of a failed-claim scan (NetApp unreachable) carry `None`.
  - A RUNNING guard in the start-document pickup keeps a headless run on the shared RunEngine from flipping an idle GUI or planting a stale number.

## Tests

- `test_set_state_carries_claimed_scan_number` + updated `_FakeLifecycleEvent` pin the `_set_state` emission (gui_bridge).
- `test_lifecycle_events_carry_claimed_scan_number` / `test_lifecycle_events_carry_none_when_claim_fails` pin the exec_config path end-to-end with the claim mocked (progress_and_preflight fakes).
- `test_delegated_lifecycle_carries_engine_claimed_scan_number` pins the delegated-path sequence `(INITIALIZING, None) → (RUNNING, None) → (RUNNING, 33) → (DONE, 33)` including duplicate-start-doc suppression; `test_start_document_from_foreign_run_is_ignored` pins the shared-RE guard (scan_request_seam).
- Full suite: **302 passed, 16 skipped, 2 deselected** (hardware/extras skips per existing conventions), hermetic — no gateway/DB/device contact.

GeecsBluesky `0.29.0 → 0.30.0` (minor), CHANGELOG + CLAUDE.md event-vocabulary note updated.

Note: this branch replaces an interrupted earlier push of the same name (force-pushed; no PR existed for it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)