### PR TITLE
GEECS-Console 0.3.0: live device panel (CA readback monitor + gateway :SP set)

### DIFF
--- a/GEECS-Console/CHANGELOG.md
+++ b/GEECS-Console/CHANGELOG.md
@@ -4,6 +4,38 @@ All notable changes to GEECS-Console are documented here.  Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versioning is
 semantic.
 
+## [0.3.0] - 2026-07-11
+
+### Added
+
+- Live device panel (R7): the stubbed backend is replaced by a
+  `DevicePanelBackend` seam (`services/device_panel.py`) with two
+  implementations — `StubDevicePanel` (the offline/test default: readback
+  never updates, sets report unwired) and `GatewayDevicePanel` (the real
+  one, injected by `main.py`).
+- Readback: a persistent `aioca.camonitor` on the gateway readback PV
+  (`{experiment}:{device}:{variable}`, names via the blessed
+  `ca_pv`/`bare_pv` helpers).  The backend owns ONE persistent asyncio
+  event loop in a single daemon thread (no QThread — the health-probe
+  teardown rule); monitor open/close are submitted via
+  `run_coroutine_threadsafe` and values are marshaled to the GUI through a
+  queued `device_value_ready(object)` signal.  Committing a new
+  `device:variable` selection (dropdown pick / Enter / focus leave) closes
+  the previous monitor first, and a generation guard drops straggler
+  callbacks from retired monitors.  Floats render with 6 significant
+  digits, strings as-is (scalar-only, per the package charter).
+- Set: `GatewaySetpointPut` (the one blessed gateway `:SP` put primitive,
+  `wire_value` coercion) on the `{...}:SP` PV — put-completion rides
+  GEECS's native blocking set.  The blocking put is dispatched to a
+  short-lived daemon thread (never the GUI thread); success/failure lands
+  in the status bar + log via a queued `device_set_finished(bool, str)`
+  signal, and the Set button is disabled while a put is in flight, when
+  the selection is not a valid `device:variable`, or when the field is
+  empty.
+- The experiment combo re-points the readback monitor (the PV is
+  experiment-prefixed); `closeEvent` unsubscribes the monitor and
+  disconnects both queued signals without joining any thread.
+
 ## [0.2.0] - 2026-07-11
 
 ### Added

--- a/GEECS-Console/CLAUDE.md
+++ b/GEECS-Console/CLAUDE.md
@@ -29,11 +29,12 @@ are prefixed by region (`r3_radio_1d`, `r5_start_button`, …).
   not Optimization.
 - **R6 now panel** — state pill, progress bar, "Scan NNN" with 10 s expiry
   to "(previous)", compact log tail.
-- **R7 device panel** — device:variable combo, readback label, set field +
-  button.  **Backend stubbed** — the real one is gateway PVs (CA monitor on
-  the readback, put to `:SP` riding GEECS's native blocking set), never
-  `geecs_python_api`'s ScanDevice.  Scalar-only at birth (composites arrive
-  with the pseudo-variable runtime, if ever).
+- **R7 device panel** — device:variable combo (editable free text),
+  readback label, set field + button.  **Backend live** (see Implemented
+  seams): gateway PVs — CA monitor on the readback, put to `:SP` riding
+  GEECS's native blocking set — never `geecs_python_api`'s ScanDevice.
+  Scalar-only at birth (composites arrive with the pseudo-variable
+  runtime, if ever).
 
 ## Architecture rules
 
@@ -86,10 +87,36 @@ are prefixed by region (`r3_radio_1d`, `r5_start_button`, …).
   `request.abort[0] = True`; either choice calls `request.response_event.set()`
   to unblock the engine.  Duck-typed on the `DialogRequest` attributes — no
   `geecs_bluesky` import.
+- **Device panel (R7)** is live via `GatewayDevicePanel` (real backend) or
+  `StubDevicePanel` (no-op offline/test default), behind the
+  `DevicePanelBackend` protocol in `services/device_panel.py`.  Readback is
+  a persistent `aioca.camonitor` on the gateway readback PV; because aioca
+  is asyncio-based and the monitor is long-lived, the backend owns **one
+  persistent asyncio event loop in one daemon `threading.Thread`**
+  (`run_forever`; camonitor open/close submitted via
+  `run_coroutine_threadsafe`) — the same **no-QThread** rule as the health
+  poller (a worker QThread aborted under offscreen pytest: "QThread
+  destroyed while running").  Values reach the GUI through the window's
+  `device_value_ready(object)` signal, connected **queued** to a
+  `@Slot(object)` — never paint widgets off the GUI thread.  Selection
+  commits (dropdown pick / Enter / focus leave) resubscribe; per-keystroke
+  edits only regate the Set button (no CA-monitor churn while typing); a
+  generation counter drops straggler callbacks from retired monitors.  Set
+  goes through `GatewaySetpointPut` (the one blessed `:SP` put primitive,
+  `wire_value` coercion) on a short-lived daemon thread, reporting via the
+  queued `device_set_finished(bool, str)` signal; the button is disabled
+  while a put is in flight.  PV names come only from `ca_pv`/`bare_pv`
+  (never hand-built — the `ca://`-vs-bare addressing rule, issue #490).
+  All real imports are lazy (module import-safe offline); `closeEvent`
+  unsubscribes and disconnects, never joins.  Inject the real backend in
+  `main.py`; keep `StubDevicePanel` as the window's default.
 
 ## Stubbed seams (intentional, wire later)
 
-- Device panel backend (see R7 above).
+- R7 device:variable autocomplete: the combo is editable free text (with a
+  placeholder) — `ConsoleConfigs` has no device/variable listing yet.  The
+  natural source is a `GeecsDb` enumeration (device → `get='yes'`
+  variables), populated the way the other combos are.
 - Presets persistence (save/load ScanRequest YAML; a preset dir in the
   configs repo is the natural home).
 - Optimization mode: radio exists, submission refused with a clear error

--- a/GEECS-Console/geecs_console/app/main_window.py
+++ b/GEECS-Console/geecs_console/app/main_window.py
@@ -49,6 +49,13 @@ from geecs_console.request_builder import (
     estimate_total_shots,
 )
 from geecs_console.services.configs import ConsoleConfigs
+from geecs_console.services.device_panel import (
+    DevicePanelBackend,
+    StubDevicePanel,
+    format_readback,
+    parse_device_variable,
+    parse_set_value,
+)
 from geecs_console.services.health import (
     HealthProbe,
     HealthReport,
@@ -176,6 +183,10 @@ class MainWindow(QMainWindow):
         Configs-repo service; tests inject a fake, default reads the repo.
     health : HealthProbe, optional
         Session-bar chip source; default is the all-unknown stub.
+    device_panel : DevicePanelBackend, optional
+        R7 readback/set backend; default is the no-op stub (readback never
+        updates, sets report unwired).  ``main.py`` injects the real
+        :class:`~geecs_console.services.device_panel.GatewayDevicePanel`.
     submitter : Submitter, optional
         Scan engine; tests inject a fake.  When ``None`` one is built
         lazily by *submitter_factory* on the first Start click.
@@ -184,17 +195,30 @@ class MainWindow(QMainWindow):
         :func:`~geecs_console.submission.make_bluesky_submitter`.
     """
 
+    #: One readback value from the device-panel backend (emitted from the CA
+    #: monitor thread; delivered queued to :meth:`_apply_device_value`).
+    device_value_ready = Signal(object)
+
+    #: ``(ok, message)`` for one completed device set (emitted from the
+    #: set-dispatch daemon thread; delivered queued).
+    device_set_finished = Signal(bool, str)
+
     def __init__(
         self,
         experiment: str = "",
         configs: Optional[ConsoleConfigs] = None,
         health: Optional[HealthProbe] = None,
+        device_panel: Optional[DevicePanelBackend] = None,
         submitter: Optional[Submitter] = None,
         submitter_factory: Optional[Callable[..., Submitter]] = None,
     ) -> None:
         super().__init__()
         self._configs = configs if configs is not None else ConsoleConfigs(experiment)
         self._health = health if health is not None else StubHealth()
+        self._device_panel = (
+            device_panel if device_panel is not None else StubDevicePanel()
+        )
+        self._device_set_in_flight = False
         self._submitter = submitter
         self._submitter_factory = (
             submitter_factory
@@ -226,6 +250,7 @@ class MainWindow(QMainWindow):
         self._start_health_poller()
         self._set_state_pill("idle")
         self._on_mode_changed()
+        self._refresh_device_set_enabled()
 
     # ------------------------------------------------------------------
     # Construction
@@ -327,6 +352,9 @@ class MainWindow(QMainWindow):
         self.readback_label: QLabel = self._child(QLabel, "r7_readback_label")
         self.set_field: QLineEdit = self._child(QLineEdit, "r7_set_field")
         self.set_button: QPushButton = self._child(QPushButton, "r7_set_button")
+        device_line_edit = self.device_combo.lineEdit()
+        if device_line_edit is not None:
+            device_line_edit.setPlaceholderText("device:variable")
 
         from geecs_schemas import AcquisitionMode
 
@@ -383,7 +411,27 @@ class MainWindow(QMainWindow):
         self.stop_button.clicked.connect(self._on_stop_clicked)
         self.apply_button.clicked.connect(self._on_preset_stub)
         self.save_as_button.clicked.connect(self._on_preset_stub)
-        self.set_button.clicked.connect(self._on_device_set_stub)
+
+        # R7 device panel.  Selection commits (dropdown pick / Enter / focus
+        # leave) resubscribe the readback; per-keystroke edits only regate the
+        # Set button — never churn CA monitors while the operator types.
+        self.set_button.clicked.connect(self._on_device_set_clicked)
+        self.set_field.textChanged.connect(self._refresh_device_set_enabled)
+        self.set_field.returnPressed.connect(self._on_device_set_clicked)
+        self.device_combo.editTextChanged.connect(self._refresh_device_set_enabled)
+        self.device_combo.activated.connect(self._resubscribe_device)
+        device_line_edit = self.device_combo.lineEdit()
+        if device_line_edit is not None:
+            device_line_edit.editingFinished.connect(self._resubscribe_device)
+        # Force queued connections: both signals are emitted off the GUI
+        # thread (CA monitor thread / set-dispatch daemon thread), and an
+        # undecorated direct delivery would paint widgets there (hard crash).
+        self.device_value_ready.connect(
+            self._apply_device_value, Qt.ConnectionType.QueuedConnection
+        )
+        self.device_set_finished.connect(
+            self._apply_device_set_result, Qt.ConnectionType.QueuedConnection
+        )
 
         self.events.state_changed.connect(self._on_scan_state)
         self.events.totals_known.connect(self._on_totals_known)
@@ -510,12 +558,14 @@ class MainWindow(QMainWindow):
             setattr(self._health, "experiment", experiment or None)
 
     def closeEvent(self, event) -> None:  # noqa: N802 — Qt override
-        """Stop the background health poller cleanly before closing.
+        """Stop background I/O cleanly before closing — never joins a thread.
 
-        Stops the GUI-thread interval timer (no further polls) and disconnects
-        the report signal so a still-running daemon poll can't paint a chip on
-        a window being torn down.  In-flight daemon threads are daemonic and
-        finish on their own without blocking shutdown.
+        Stops the GUI-thread health interval timer (no further polls),
+        unsubscribes the device-panel readback monitor (non-blocking), and
+        disconnects every cross-thread signal so a still-running daemon
+        poll/put/monitor can't paint a widget on a window being torn down.
+        In-flight daemon threads finish on their own without blocking
+        shutdown.
         """
         timer = getattr(self, "_health_timer", None)
         if timer is not None:
@@ -524,6 +574,20 @@ class MainWindow(QMainWindow):
         if poller is not None:
             try:
                 poller.report_ready.disconnect(self._apply_health_report)
+            except (RuntimeError, TypeError):
+                pass
+        backend = getattr(self, "_device_panel", None)
+        if backend is not None:
+            try:
+                backend.unsubscribe()
+            except Exception:  # noqa: BLE001 — teardown must not raise
+                pass
+        for signal, slot in (
+            (self.device_value_ready, self._apply_device_value),
+            (self.device_set_finished, self._apply_device_set_result),
+        ):
+            try:
+                signal.disconnect(slot)
             except (RuntimeError, TypeError):
                 pass
         super().closeEvent(event)
@@ -720,6 +784,8 @@ class MainWindow(QMainWindow):
         self._configs.set_experiment(experiment)
         self._push_experiment_to_probe(experiment)
         self._populate_from_configs()
+        # The readback PV is experiment-prefixed — re-point the monitor.
+        self._resubscribe_device()
 
     def _on_trigger_profile_changed(self, profile: str) -> None:
         """Repopulate the variant combo for the selected trigger profile."""
@@ -799,7 +865,7 @@ class MainWindow(QMainWindow):
         self._refresh_submit_enabled()
 
     # ------------------------------------------------------------------
-    # R4 / R7 stubs
+    # R4 stub
     # ------------------------------------------------------------------
 
     def _on_preset_stub(self) -> None:
@@ -808,11 +874,107 @@ class MainWindow(QMainWindow):
             "Presets are not wired yet (a preset is a saved ScanRequest).", 10_000
         )
 
-    def _on_device_set_stub(self) -> None:
-        """R7 placeholder: gateway-PV set/readback backend arrives later."""
-        message = "Device panel backend not wired yet (gateway PV set/readback)."
+    # ------------------------------------------------------------------
+    # R7 device panel
+    # ------------------------------------------------------------------
+
+    def _refresh_device_set_enabled(self) -> None:
+        """Gate the Set button: valid ``device:variable``, a value, no put in flight."""
+        ready = (
+            not self._device_set_in_flight
+            and parse_device_variable(self.device_combo.currentText()) is not None
+            and bool(self.set_field.text().strip())
+        )
+        self.set_button.setEnabled(ready)
+
+    def _resubscribe_device(self, *_args: object) -> None:
+        """Re-point the readback monitor at the combo's current selection.
+
+        Closes the previous monitor first (the backend guarantees straggler
+        callbacks from it are dropped) and resets the label to the em-dash
+        until the new monitor's first value lands.  An unparsable selection
+        leaves the panel unsubscribed.
+        """
+        try:
+            self._device_panel.unsubscribe()
+        except Exception as exc:  # noqa: BLE001 — teardown must not break the GUI
+            self.append_log(f"Readback unsubscribe failed: {exc}")
+        self.readback_label.setText("—")
+        self._refresh_device_set_enabled()
+        parsed = parse_device_variable(self.device_combo.currentText())
+        if parsed is None:
+            return
+        device, variable = parsed
+        try:
+            self._device_panel.subscribe(
+                self.experiment_combo.currentText(),
+                device,
+                variable,
+                self.device_value_ready.emit,
+            )
+        except Exception as exc:  # noqa: BLE001 — surface, don't crash
+            message = f"Readback subscribe failed for {device}:{variable}: {exc}"
+            self.statusBar().showMessage(message, 10_000)
+            self.append_log(message)
+
+    @Slot(object)
+    def _apply_device_value(self, value: object) -> None:
+        """Render one readback value (GUI-thread slot, delivered queued).
+
+        Parameters
+        ----------
+        value : object
+            The monitor value (float / int / string) from the backend.
+        """
+        self.readback_label.setText(format_readback(value))
+
+    def _on_device_set_clicked(self) -> None:
+        """Dispatch the blocking backend set to a daemon thread."""
+        parsed = parse_device_variable(self.device_combo.currentText())
+        text = self.set_field.text().strip()
+        if parsed is None or not text or self._device_set_in_flight:
+            return
+        device, variable = parsed
+        value = parse_set_value(text)
+        experiment = self.experiment_combo.currentText()
+        self._device_set_in_flight = True
+        self._refresh_device_set_enabled()
+        threading.Thread(
+            target=self._run_device_set,
+            args=(experiment, device, variable, value),
+            name="console-device-set",
+            daemon=True,
+        ).start()
+
+    def _run_device_set(
+        self, experiment: str, device: str, variable: str, value: object
+    ) -> None:
+        """Run the blocking set (on the daemon thread) and emit the outcome."""
+        try:
+            self._device_panel.set(experiment, device, variable, value)
+        except Exception as exc:  # noqa: BLE001 — any failure is a status report
+            self.device_set_finished.emit(
+                False, f"Set {device}:{variable} failed: {exc}"
+            )
+        else:
+            self.device_set_finished.emit(True, f"Set {device}:{variable} = {value}")
+
+    @Slot(bool, str)
+    def _apply_device_set_result(self, ok: bool, message: str) -> None:
+        """Report one finished set and re-arm the button (GUI-thread slot).
+
+        Parameters
+        ----------
+        ok : bool
+            Whether the set completed (unused beyond the message — failures
+            already carry the exception text).
+        message : str
+            The status-bar / log line.
+        """
+        self._device_set_in_flight = False
         self.statusBar().showMessage(message, 10_000)
         self.append_log(message)
+        self._refresh_device_set_enabled()
 
     # ------------------------------------------------------------------
     # R6 now panel

--- a/GEECS-Console/geecs_console/services/device_panel.py
+++ b/GEECS-Console/geecs_console/services/device_panel.py
@@ -1,0 +1,348 @@
+"""Device panel seam (R7): live gateway readback + ``:SP`` setpoint puts.
+
+The protocol and a no-op stub live here alongside the real
+:class:`GatewayDevicePanel`: a persistent ``aioca.camonitor`` on the readback
+PV (values flow to the GUI through a queued Qt signal owned by the window)
+and setpoint puts through :class:`~geecs_bluesky.devices.ca.gateway_put.
+GatewaySetpointPut` — the one blessed gateway ``:SP`` put primitive, riding
+GEECS's native blocking set.
+
+Threading model (mirrors the health-probe precedent — **no QThread**, ever):
+``aioca`` is asyncio-based, so the real backend owns ONE persistent asyncio
+event loop running ``run_forever`` in a single daemon ``threading.Thread``,
+created lazily on first use.  ``camonitor`` / subscription close / ``caput``
+are submitted onto that loop via ``asyncio.run_coroutine_threadsafe``.
+Nothing here ever blocks the GUI thread: ``subscribe`` / ``unsubscribe``
+return immediately, and the blocking ``set`` is dispatched by the window to
+a short-lived daemon thread.  Teardown never joins — the loop thread is
+daemonic and dies with the process.
+
+Every real dependency (``aioca``, the geecs-bluesky PV helpers) is imported
+lazily inside methods, keeping this module import-safe with zero network and
+without the ``ca`` extra.  Scalar-only, per the package charter.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import threading
+from typing import Any, Callable, Optional, Protocol, runtime_checkable
+
+logger = logging.getLogger(__name__)
+
+#: Default per-put budget (seconds) — the gateway completes the CA put only
+#: when GEECS accepts the set, so this is the whole blocking-set budget.
+_PUT_TIMEOUT_S = 10.0
+
+#: Extra slack on top of the put budget for the cross-thread future wait.
+_DISPATCH_SLACK_S = 5.0
+
+
+@runtime_checkable
+class DevicePanelBackend(Protocol):
+    """Anything that can drive the R7 device panel (readback + set)."""
+
+    def subscribe(
+        self,
+        experiment: str,
+        device: str,
+        variable: str,
+        on_value: Callable[[Any], None],
+    ) -> None:
+        """Start a readback stream; *on_value* may fire on any thread."""
+        ...
+
+    def unsubscribe(self) -> None:
+        """Stop the current readback stream (no-op when none is active)."""
+        ...
+
+    def set(self, experiment: str, device: str, variable: str, value: Any) -> None:
+        """Write *value* to the setpoint, blocking until done; raise on failure."""
+        ...
+
+
+class StubDevicePanel:
+    """The no-network default: readback never updates, sets report unwired."""
+
+    def subscribe(
+        self,
+        experiment: str,
+        device: str,
+        variable: str,
+        on_value: Callable[[Any], None],
+    ) -> None:
+        """No-op: the stub has no readback source.
+
+        Parameters
+        ----------
+        experiment, device, variable : str
+            Ignored.
+        on_value : callable
+            Never called.
+        """
+        return None
+
+    def unsubscribe(self) -> None:
+        """No-op: nothing was subscribed."""
+        return None
+
+    def set(self, experiment: str, device: str, variable: str, value: Any) -> None:
+        """Refuse the set so the window surfaces a clear offline message.
+
+        Raises
+        ------
+        RuntimeError
+            Always — the stub has no gateway to write to.
+        """
+        raise RuntimeError("device panel backend not wired (offline stub)")
+
+
+# ----------------------------------------------------------------------
+# Pure helpers (unit-testable without Qt or CA)
+# ----------------------------------------------------------------------
+
+
+def parse_device_variable(text: str) -> Optional[tuple[str, str]]:
+    """Split a ``device:variable`` combo entry into its two GEECS names.
+
+    Parameters
+    ----------
+    text : str
+        The R7 combo text, e.g. ``"U_ESP_JetXYZ:Position.Axis 1"``.  The
+        split is on the *first* colon — GEECS variable names may contain
+        dots and spaces but device names never contain colons.
+
+    Returns
+    -------
+    tuple of (str, str) or None
+        ``(device, variable)`` with surrounding whitespace stripped, or
+        ``None`` when the text is not a valid ``device:variable`` pair.
+    """
+    device, sep, variable = text.partition(":")
+    device, variable = device.strip(), variable.strip()
+    if not sep or not device or not variable:
+        return None
+    return device, variable
+
+
+def parse_set_value(text: str) -> float | str:
+    """Interpret the R7 set-field text as a scalar wire value.
+
+    Parameters
+    ----------
+    text : str
+        The raw field text.
+
+    Returns
+    -------
+    float or str
+        A float when the text parses as one (numeric setpoints go natively
+        — the :func:`~geecs_bluesky.devices.ca.gateway_put.wire_value`
+        convention), otherwise the stripped string (enum labels,
+        ``'on'``/``'off'``).
+    """
+    raw = text.strip()
+    try:
+        return float(raw)
+    except ValueError:
+        return raw
+
+
+def format_readback(value: Any) -> str:
+    """Render one readback value for the R7 label.
+
+    Parameters
+    ----------
+    value : Any
+        A monitor callback value (aioca augmented values subclass their
+        native python type, so plain ``isinstance`` checks apply).
+
+    Returns
+    -------
+    str
+        Floats with 6 significant digits, everything else stringified.
+    """
+    if isinstance(value, bool):
+        return str(value)
+    if isinstance(value, float):
+        return f"{value:.6g}"
+    return str(value)
+
+
+def readback_pv(experiment: str, device: str, variable: str) -> str:
+    """Bare readback PV name for ``(experiment, device, variable)``.
+
+    Built through the blessed geecs-bluesky helpers (lazy import): ``ca_pv``
+    applies the gateway naming contract, ``bare_pv`` strips the ``ca://``
+    transport scheme raw aioca must never see (issue #490).
+
+    Parameters
+    ----------
+    experiment : str
+        Experiment prefix ("" drops out of the name).
+    device, variable : str
+        Raw GEECS names; CA-normalized by the naming contract.
+
+    Returns
+    -------
+    str
+        The bare EPICS name, e.g. ``"HTU:U_Hexapod:ypos"``.
+    """
+    from geecs_bluesky.devices.ca._pv import ca_pv
+    from geecs_bluesky.devices.ca.gateway_put import bare_pv
+
+    return bare_pv(ca_pv(experiment or None, device, variable))
+
+
+def setpoint_pv(experiment: str, device: str, variable: str) -> str:
+    """Bare setpoint (``:SP``) PV name for ``(experiment, device, variable)``.
+
+    Parameters
+    ----------
+    experiment : str
+        Experiment prefix ("" drops out of the name).
+    device, variable : str
+        Raw GEECS names.
+
+    Returns
+    -------
+    str
+        The bare ``…:SP`` EPICS name.
+    """
+    return f"{readback_pv(experiment, device, variable)}:SP"
+
+
+# ----------------------------------------------------------------------
+# The real backend
+# ----------------------------------------------------------------------
+
+
+class GatewayDevicePanel:
+    """Live R7 backend: CA monitor readback + gateway ``:SP`` blocking set.
+
+    One persistent asyncio event loop in one daemon thread hosts the aioca
+    machinery (see the module docstring).  At most one readback monitor is
+    active at a time — subscribing closes the previous monitor first, and a
+    monotonically increasing generation counter drops any straggler callback
+    from a closed monitor.
+
+    Parameters
+    ----------
+    put_timeout : float, optional
+        Per-put budget in seconds (the gateway completes the CA put when
+        GEECS accepts the set, so this bounds the whole blocking set).
+    """
+
+    def __init__(self, put_timeout: float = _PUT_TIMEOUT_S) -> None:
+        self._put_timeout = put_timeout
+        self._loop: Optional[asyncio.AbstractEventLoop] = None
+        self._loop_lock = threading.Lock()
+        self._generation = 0
+        self._pending_subscription: Any = None  # Future -> aioca Subscription
+
+    def _ensure_loop(self) -> asyncio.AbstractEventLoop:
+        """Return the persistent CA event loop, starting it on first use.
+
+        Returns
+        -------
+        asyncio.AbstractEventLoop
+            A loop running ``run_forever`` in one daemon thread — never
+            joined; it dies with the process.
+        """
+        with self._loop_lock:
+            if self._loop is None:
+                loop = asyncio.new_event_loop()
+                threading.Thread(
+                    target=loop.run_forever,
+                    name="console-device-panel-ca",
+                    daemon=True,
+                ).start()
+                self._loop = loop
+        return self._loop
+
+    def subscribe(
+        self,
+        experiment: str,
+        device: str,
+        variable: str,
+        on_value: Callable[[Any], None],
+    ) -> None:
+        """Open a CA monitor on the readback PV; returns immediately.
+
+        Parameters
+        ----------
+        experiment, device, variable : str
+            Raw GEECS names; the PV comes from :func:`readback_pv`.
+        on_value : callable
+            Called with each monitor value **on the CA loop thread** — the
+            window passes a queued Qt signal's ``emit``, so values land on
+            the GUI thread.
+        """
+        self.unsubscribe()
+        pv = readback_pv(experiment, device, variable)
+        generation = self._generation
+
+        def _dispatch(value: Any) -> None:
+            # Drop stragglers from a monitor unsubscribe() already retired.
+            if generation == self._generation:
+                on_value(value)
+
+        async def _start() -> Any:
+            import aioca  # deferred: needs the `ca` extra
+
+            return aioca.camonitor(pv, _dispatch)
+
+        loop = self._ensure_loop()
+        self._pending_subscription = asyncio.run_coroutine_threadsafe(_start(), loop)
+
+    def unsubscribe(self) -> None:
+        """Close the active monitor (if any); returns immediately, never joins."""
+        self._generation += 1
+        pending, self._pending_subscription = self._pending_subscription, None
+        if pending is None or self._loop is None:
+            return
+
+        async def _close() -> None:
+            try:
+                subscription = await asyncio.wrap_future(pending)
+                subscription.close()
+            except Exception as exc:  # noqa: BLE001 — teardown must not raise
+                logger.debug("closing readback monitor failed: %s", exc)
+
+        asyncio.run_coroutine_threadsafe(_close(), self._loop)
+
+    def set(self, experiment: str, device: str, variable: str, value: Any) -> None:
+        """Blocking setpoint put through :class:`GatewaySetpointPut`.
+
+        Called from a short-lived daemon thread (never the GUI thread — the
+        window dispatches).  Completion means GEECS accepted the set (the
+        gateway forwards ``:SP`` puts to GEECS's native blocking set).
+
+        Parameters
+        ----------
+        experiment, device, variable : str
+            Raw GEECS names; the ``:SP`` PV comes from the naming contract.
+        value : Any
+            The scalar to write; wire-coerced by
+            :func:`~geecs_bluesky.devices.ca.gateway_put.wire_value`
+            (native numerics, wire string otherwise).
+
+        Raises
+        ------
+        Exception
+            Whatever the put raises (timeout, GEECS rejection, no CA) — the
+            window renders it in the status bar.
+        """
+        from geecs_bluesky.devices.ca._pv import ca_pv
+        from geecs_bluesky.devices.ca.gateway_put import GatewaySetpointPut, wire_value
+
+        put = GatewaySetpointPut(
+            setpoint_pv=f"{ca_pv(experiment or None, device, variable)}:SP",
+            coerce=wire_value,
+            timeout=self._put_timeout,
+            name=f"{device}:{variable}",
+        )
+        loop = self._ensure_loop()
+        future = asyncio.run_coroutine_threadsafe(put.put(value), loop)
+        future.result(timeout=self._put_timeout + _DISPATCH_SLACK_S)

--- a/GEECS-Console/main.py
+++ b/GEECS-Console/main.py
@@ -14,13 +14,19 @@ def main() -> int:
     from PySide6.QtWidgets import QApplication
 
     from geecs_console.app.main_window import MainWindow
+    from geecs_console.services.device_panel import GatewayDevicePanel
     from geecs_console.services.health import GatewayTiledDbHealth
 
     app = QApplication(sys.argv)
-    # Inject the real health probe in production; tests/offline fall back to the
-    # all-unknown StubHealth default.  The probe is background-polled (never on
-    # the GUI thread) and lazily imports aioca / httpx / GeecsDb inside poll().
-    window = MainWindow(health=GatewayTiledDbHealth())
+    # Inject the real seams in production; tests/offline fall back to the
+    # stub defaults.  The health probe is background-polled (never on the GUI
+    # thread) and lazily imports aioca / httpx / GeecsDb inside poll().  The
+    # device panel hosts its CA monitor on one persistent daemon-thread event
+    # loop and dispatches blocking :SP puts off the GUI thread.
+    window = MainWindow(
+        health=GatewayTiledDbHealth(),
+        device_panel=GatewayDevicePanel(),
+    )
     window.show()
     return app.exec()
 

--- a/GEECS-Console/pyproject.toml
+++ b/GEECS-Console/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-console"
-version = "0.2.0"
+version = "0.3.0"
 description = "Greenfield PySide6 operator console for GEECS (Bluesky/gateway architecture)"
 authors = ["Sam Barber <sbarber@lbl.gov>"]
 readme = "README.md"

--- a/GEECS-Console/tests/test_device_panel.py
+++ b/GEECS-Console/tests/test_device_panel.py
@@ -1,0 +1,245 @@
+"""Device-panel seam tests: pure helpers + GatewayDevicePanel with a fake aioca.
+
+No live CA anywhere: the real backend's lazy ``import aioca`` (inside the
+coroutines it submits to its persistent loop) is intercepted by planting a
+fake module in ``sys.modules``, so subscribe/unsubscribe/set exercise the
+real threading + event-loop machinery against recorded fakes.
+"""
+
+import sys
+import time
+import types
+
+import pytest
+
+from geecs_console.services.device_panel import (
+    DevicePanelBackend,
+    GatewayDevicePanel,
+    StubDevicePanel,
+    format_readback,
+    parse_device_variable,
+    parse_set_value,
+    readback_pv,
+    setpoint_pv,
+)
+
+
+def wait_for(predicate, timeout=3.0):
+    """Poll *predicate* until true or *timeout* seconds elapse."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        time.sleep(0.01)
+    return predicate()
+
+
+# ----------------------------------------------------------------------
+# Pure helpers
+# ----------------------------------------------------------------------
+
+
+class TestParseDeviceVariable:
+    def test_simple_pair(self):
+        assert parse_device_variable("U_Hexapod:ypos") == ("U_Hexapod", "ypos")
+
+    def test_splits_on_first_colon_only(self):
+        # GEECS variable names may contain dots/spaces but never lead with
+        # another device name; the split is on the first colon.
+        assert parse_device_variable("Dev:Var:extra") == ("Dev", "Var:extra")
+
+    def test_strips_whitespace(self):
+        assert parse_device_variable(" Dev : Position.Axis 1 ") == (
+            "Dev",
+            "Position.Axis 1",
+        )
+
+    @pytest.mark.parametrize("text", ["", "nodots", ":var", "dev:", " : "])
+    def test_invalid_forms_return_none(self, text):
+        assert parse_device_variable(text) is None
+
+
+class TestParseSetValue:
+    def test_numeric_text_becomes_float(self):
+        assert parse_set_value("2.5") == 2.5
+        assert isinstance(parse_set_value("3"), float)
+
+    def test_non_numeric_text_stays_string(self):
+        assert parse_set_value("on") == "on"
+        assert parse_set_value(" Single shot ") == "Single shot"
+
+
+class TestFormatReadback:
+    def test_float_six_significant_digits(self):
+        assert format_readback(3.141592653589793) == "3.14159"
+        assert format_readback(0.5) == "0.5"
+
+    def test_int_and_string_pass_through(self):
+        assert format_readback(42) == "42"
+        assert format_readback("Connected") == "Connected"
+
+    def test_bool_renders_as_bool(self):
+        assert format_readback(True) == "True"
+
+
+class TestPvNames:
+    def test_readback_pv_is_bare_and_normalized(self):
+        # ca_pv applies the gateway naming contract (dots/spaces -> _),
+        # bare_pv strips the ca:// scheme raw aioca must never see.
+        assert (
+            readback_pv("HTU", "U_Hexapod", "Position.Axis 1")
+            == "HTU:U_Hexapod:Position_Axis_1"
+        )
+
+    def test_empty_experiment_drops_out(self):
+        assert readback_pv("", "Dev", "Var") == "Dev:Var"
+
+    def test_setpoint_pv_appends_sp(self):
+        assert setpoint_pv("HTU", "Dev", "Var") == "HTU:Dev:Var:SP"
+
+
+# ----------------------------------------------------------------------
+# Protocol / stub
+# ----------------------------------------------------------------------
+
+
+class TestProtocolAndStub:
+    def test_stub_satisfies_protocol(self):
+        assert isinstance(StubDevicePanel(), DevicePanelBackend)
+
+    def test_gateway_backend_satisfies_protocol(self):
+        assert isinstance(GatewayDevicePanel(), DevicePanelBackend)
+
+    def test_stub_subscribe_and_unsubscribe_are_noops(self):
+        stub = StubDevicePanel()
+        values = []
+        stub.subscribe("Exp", "Dev", "Var", values.append)
+        stub.unsubscribe()
+        assert values == []
+
+    def test_stub_set_raises(self):
+        with pytest.raises(RuntimeError, match="not wired"):
+            StubDevicePanel().set("Exp", "Dev", "Var", 1.0)
+
+
+# ----------------------------------------------------------------------
+# GatewayDevicePanel against a fake aioca (no live CA)
+# ----------------------------------------------------------------------
+
+
+class FakeSubscription:
+    def __init__(self, pv, callback):
+        self.pv = pv
+        self.callback = callback
+        self.closed = False
+
+    def close(self):
+        self.closed = True
+
+
+class FakeAioca:
+    """Records camonitor/caput calls; stands in for the aioca module."""
+
+    def __init__(self):
+        self.subscriptions = []
+        self.puts = []
+
+    def make_module(self):
+        module = types.ModuleType("aioca")
+
+        def camonitor(pv, callback, **kwargs):
+            subscription = FakeSubscription(pv, callback)
+            self.subscriptions.append(subscription)
+            return subscription
+
+        async def caput(pv, value, wait=False, timeout=None):
+            self.puts.append((pv, value, wait, timeout))
+
+        module.camonitor = camonitor
+        module.caput = caput
+        return module
+
+
+@pytest.fixture
+def fake_aioca(monkeypatch):
+    fake = FakeAioca()
+    monkeypatch.setitem(sys.modules, "aioca", fake.make_module())
+    return fake
+
+
+class TestGatewayDevicePanel:
+    def test_subscribe_opens_monitor_on_bare_readback_pv(self, fake_aioca):
+        panel = GatewayDevicePanel()
+        panel.subscribe("HTU", "U_Hexapod", "ypos", lambda value: None)
+        assert wait_for(lambda: len(fake_aioca.subscriptions) == 1)
+        assert fake_aioca.subscriptions[0].pv == "HTU:U_Hexapod:ypos"
+        panel.unsubscribe()
+
+    def test_monitor_values_reach_on_value(self, fake_aioca):
+        panel = GatewayDevicePanel()
+        values = []
+        panel.subscribe("HTU", "Dev", "Var", values.append)
+        assert wait_for(lambda: fake_aioca.subscriptions)
+        fake_aioca.subscriptions[0].callback(3.25)
+        assert values == [3.25]
+        panel.unsubscribe()
+
+    def test_resubscribe_closes_previous_monitor(self, fake_aioca):
+        panel = GatewayDevicePanel()
+        panel.subscribe("HTU", "Dev", "Var", lambda value: None)
+        assert wait_for(lambda: len(fake_aioca.subscriptions) == 1)
+        panel.subscribe("HTU", "Dev2", "Var2", lambda value: None)
+        assert wait_for(lambda: len(fake_aioca.subscriptions) == 2)
+        assert wait_for(lambda: fake_aioca.subscriptions[0].closed)
+        assert fake_aioca.subscriptions[1].pv == "HTU:Dev2:Var2"
+        panel.unsubscribe()
+        assert wait_for(lambda: fake_aioca.subscriptions[1].closed)
+
+    def test_straggler_callback_after_unsubscribe_is_dropped(self, fake_aioca):
+        panel = GatewayDevicePanel()
+        values = []
+        panel.subscribe("HTU", "Dev", "Var", values.append)
+        assert wait_for(lambda: fake_aioca.subscriptions)
+        subscription = fake_aioca.subscriptions[0]
+        panel.unsubscribe()
+        # A CA callback already in flight when the monitor was retired must
+        # not repaint the panel with a stale device's value.
+        subscription.callback(9.9)
+        assert values == []
+
+    def test_unsubscribe_without_subscribe_is_noop(self):
+        GatewayDevicePanel().unsubscribe()  # must not raise, must not spin a loop
+
+    def test_unsubscribe_returns_immediately(self, fake_aioca):
+        panel = GatewayDevicePanel()
+        panel.subscribe("HTU", "Dev", "Var", lambda value: None)
+        assert wait_for(lambda: fake_aioca.subscriptions)
+        started = time.monotonic()
+        panel.unsubscribe()
+        assert time.monotonic() - started < 0.2  # scheduled, never joined
+
+    def test_set_puts_wire_value_to_bare_sp_pv(self, fake_aioca):
+        panel = GatewayDevicePanel()
+        panel.set("HTU", "Dev", "Position.Axis 1", 2.5)
+        assert fake_aioca.puts == [("HTU:Dev:Position_Axis_1:SP", 2.5, True, 10.0)]
+
+    def test_set_string_value_goes_as_wire_string(self, fake_aioca):
+        panel = GatewayDevicePanel()
+        panel.set("", "Dev", "Trigger.Source", "Single shot")
+        (pv, value, wait, _timeout) = fake_aioca.puts[0]
+        assert pv == "Dev:Trigger_Source:SP"
+        assert value == "Single shot"
+        assert wait is True
+
+    def test_set_failure_propagates(self, monkeypatch):
+        fake = FakeAioca()
+        module = fake.make_module()
+
+        async def failing_caput(pv, value, wait=False, timeout=None):
+            raise TimeoutError("GEECS did not accept the set")
+
+        module.caput = failing_caput
+        monkeypatch.setitem(sys.modules, "aioca", module)
+        panel = GatewayDevicePanel()
+        with pytest.raises(TimeoutError, match="did not accept"):
+            panel.set("HTU", "Dev", "Var", 1.0)

--- a/GEECS-Console/tests/test_main_window.py
+++ b/GEECS-Console/tests/test_main_window.py
@@ -335,15 +335,196 @@ class TestNowAndDevicePanel:
         assert window.progress_bar.value() == 10
         assert "running" in window.log_tail.toPlainText()
 
-    def test_device_set_button_is_a_stub(self, window):
-        window._on_device_set_stub()
-        assert "not wired" in window.log_tail.toPlainText()
-
     def test_scan_number_expiry(self, window):
         window.set_scan_number(42)
         assert window.scan_number_label.text() == "Scan 042"
         window._expire_scan_number()
         assert window.scan_number_label.text() == "Scan 042 (previous)"
+
+
+class FakeDevicePanel:
+    """DevicePanelBackend stand-in recording every call; fires values on demand."""
+
+    def __init__(self):
+        self.subscriptions = []
+        self.unsubscribes = 0
+        self.set_calls = []
+        self.on_value = None
+
+    def subscribe(self, experiment, device, variable, on_value):
+        self.subscriptions.append((experiment, device, variable))
+        self.on_value = on_value
+
+    def unsubscribe(self):
+        self.unsubscribes += 1
+        self.on_value = None
+
+    def set(self, experiment, device, variable, value):
+        self.set_calls.append((experiment, device, variable, value))
+
+
+@pytest.fixture
+def device_window(qtbot):
+    backend = FakeDevicePanel()
+    win = MainWindow(
+        configs=FakeConfigs(), device_panel=backend, submitter=FakeSubmitter()
+    )
+    qtbot.addWidget(win)
+    return win, backend
+
+
+class TestDevicePanel:
+    def test_default_backend_is_the_stub(self, window):
+        from geecs_console.services.device_panel import StubDevicePanel
+
+        assert isinstance(window._device_panel, StubDevicePanel)
+
+    def test_set_button_disabled_until_selection_and_value(self, device_window):
+        win, _backend = device_window
+        assert not win.set_button.isEnabled()
+        win.device_combo.setCurrentText("U_Hexapod:ypos")
+        assert not win.set_button.isEnabled()  # no value yet
+        win.set_field.setText("2.5")
+        assert win.set_button.isEnabled()
+        win.set_field.setText("   ")
+        assert not win.set_button.isEnabled()
+        win.set_field.setText("2.5")
+        win.device_combo.setCurrentText("no-colon")
+        assert not win.set_button.isEnabled()
+
+    def test_selection_commit_subscribes_with_parsed_names(self, device_window):
+        win, backend = device_window
+        win.device_combo.setCurrentText("U_Hexapod:ypos")
+        win._resubscribe_device()  # editingFinished path
+        assert backend.subscriptions == [("TestExp", "U_Hexapod", "ypos")]
+        assert win.readback_label.text() == "—"
+
+    def test_readback_value_updates_label_via_queued_path(self, device_window, qtbot):
+        import threading
+
+        win, backend = device_window
+        win.device_combo.setCurrentText("Dev:Var")
+        win._resubscribe_device()
+        # Fire the value from a non-GUI thread, as the CA monitor loop would;
+        # the queued signal must marshal it onto the GUI-thread slot.
+        threading.Thread(
+            target=lambda: backend.on_value(3.141592653589793), daemon=True
+        ).start()
+        qtbot.waitUntil(lambda: win.readback_label.text() == "3.14159", timeout=3000)
+
+    def test_string_readback_renders_as_is(self, device_window, qtbot):
+        win, backend = device_window
+        win.device_combo.setCurrentText("Dev:Var")
+        win._resubscribe_device()
+        backend.on_value("Connected")
+        qtbot.waitUntil(lambda: win.readback_label.text() == "Connected", timeout=3000)
+
+    def test_switching_selection_unsubscribes_then_resubscribes(self, device_window):
+        win, backend = device_window
+        win.device_combo.setCurrentText("Dev:Var")
+        win._resubscribe_device()
+        unsubscribes_after_first = backend.unsubscribes
+        win.device_combo.setCurrentText("Dev2:Var2")
+        win._resubscribe_device()
+        assert backend.unsubscribes == unsubscribes_after_first + 1
+        assert backend.subscriptions[-1] == ("TestExp", "Dev2", "Var2")
+        assert win.readback_label.text() == "—"  # reset until the new value lands
+
+    def test_invalid_selection_leaves_panel_unsubscribed(self, device_window):
+        win, backend = device_window
+        win.device_combo.setCurrentText("not-a-pair")
+        win._resubscribe_device()
+        assert backend.subscriptions == []
+        assert win.readback_label.text() == "—"
+
+    def test_set_click_dispatches_parsed_value_to_backend(self, device_window, qtbot):
+        win, backend = device_window
+        win.device_combo.setCurrentText("U_Hexapod:ypos")
+        win.set_field.setText("2.5")
+        qtbot.mouseClick(win.set_button, Qt.MouseButton.LeftButton)
+        qtbot.waitUntil(
+            lambda: backend.set_calls == [("TestExp", "U_Hexapod", "ypos", 2.5)],
+            timeout=3000,
+        )
+        qtbot.waitUntil(
+            lambda: "Set U_Hexapod:ypos = 2.5" in win.log_tail.toPlainText(),
+            timeout=3000,
+        )
+        assert win.set_button.isEnabled()  # re-armed after completion
+
+    def test_set_with_string_value_passes_the_string(self, device_window, qtbot):
+        win, backend = device_window
+        win.device_combo.setCurrentText("Dev:Trigger.Source")
+        win.set_field.setText("Single shot")
+        win._on_device_set_clicked()
+        qtbot.waitUntil(
+            lambda: backend.set_calls
+            == [("TestExp", "Dev", "Trigger.Source", "Single shot")],
+            timeout=3000,
+        )
+
+    def test_backend_set_failure_reports_to_status_and_log(self, device_window, qtbot):
+        win, backend = device_window
+        backend.set = lambda *args: (_ for _ in ()).throw(
+            RuntimeError("gateway rejected")
+        )
+        win.device_combo.setCurrentText("Dev:Var")
+        win.set_field.setText("1.0")
+        win._on_device_set_clicked()
+        qtbot.waitUntil(
+            lambda: "Set Dev:Var failed: gateway rejected"
+            in win.log_tail.toPlainText(),
+            timeout=3000,
+        )
+        assert win.set_button.isEnabled()  # failure also re-arms
+
+    def test_stub_set_reports_unwired(self, window, qtbot):
+        window.device_combo.setCurrentText("Dev:Var")
+        window.set_field.setText("1.0")
+        window._on_device_set_clicked()
+        qtbot.waitUntil(
+            lambda: "not wired" in window.log_tail.toPlainText(), timeout=3000
+        )
+
+    def test_experiment_change_resubscribes_readback(self, device_window):
+        win, backend = device_window
+        win.device_combo.setCurrentText("Dev:Var")
+        win._resubscribe_device()
+        win._on_experiment_changed("Bella")
+        assert backend.subscriptions[-1] == ("Bella", "Dev", "Var")
+
+    def test_close_unsubscribes_backend(self, qtbot):
+        backend = FakeDevicePanel()
+        win = MainWindow(
+            configs=FakeConfigs(), device_panel=backend, submitter=FakeSubmitter()
+        )
+        qtbot.addWidget(win)
+        win.show()
+        assert win.close()
+        assert backend.unsubscribes >= 1
+
+    def test_close_during_inflight_set_returns_promptly(self, qtbot):
+        """A slow backend set on its daemon thread must not block window close."""
+        import time
+
+        class SlowSetPanel(FakeDevicePanel):
+            def set(self, experiment, device, variable, value):
+                time.sleep(0.4)
+                super().set(experiment, device, variable, value)
+
+        win = MainWindow(
+            configs=FakeConfigs(),
+            device_panel=SlowSetPanel(),
+            submitter=FakeSubmitter(),
+        )
+        qtbot.addWidget(win)
+        win.show()
+        win.device_combo.setCurrentText("Dev:Var")
+        win.set_field.setText("1.0")
+        win._on_device_set_clicked()  # daemon thread now sleeping in set()
+        started = time.monotonic()
+        assert win.close()  # must not join the 0.4 s daemon set
+        assert time.monotonic() - started < 0.3
 
 
 def _auto_answer(monkeypatch, role):


### PR DESCRIPTION
## Summary

Wires the R7 device panel to real gateway PVs behind an injectable `DevicePanelBackend` seam (`geecs_console/services/device_panel.py`), replacing the stubbed Set-button handler. Offline behavior is unchanged: `StubDevicePanel` stays the window default (readback never updates, sets report unwired), and `main.py` injects the real `GatewayDevicePanel`.

### Readback (CA monitor)

- Persistent `aioca.camonitor` on the readback PV; names built only through the blessed `ca_pv` / `bare_pv` helpers (the `ca://`-vs-bare addressing rule, issue #490).
- aioca is asyncio-based, so the backend owns **one persistent asyncio event loop in one daemon `threading.Thread`** (`run_forever`; monitor open/close submitted via `run_coroutine_threadsafe`). **No QThread anywhere** — same teardown rule as the health poller.
- Values reach the GUI through the window's `device_value_ready(object)` signal, connected with an explicit `QueuedConnection` to a `@Slot(object)` (never paint widgets off the GUI thread).
- Committing a new `device:variable` selection (dropdown pick / Enter / focus leave) closes the previous monitor; per-keystroke edits only regate the Set button, so typing never churns CA monitors. A generation counter drops straggler callbacks from retired monitors. Experiment changes re-point the monitor (the PV is experiment-prefixed).
- Floats render with 6 significant digits, strings as-is. Scalar-only per the package charter.

### Set (gateway :SP)

- `GatewaySetpointPut` — the one blessed `:SP` put primitive — with `wire_value` coercion; put-completion rides GEECS's native blocking set.
- The blocking put is dispatched to a short-lived daemon thread (never the GUI thread); success/failure lands in the status bar + log via the queued `device_set_finished(bool, str)` signal.
- Set button disabled when the selection is not a valid `device:variable`, the field is empty, or a put is in flight.
- `closeEvent` unsubscribes the monitor and disconnects both queued signals — never joins a thread.

### Tests

- `tests/test_device_panel.py`: pure helpers (parsing, formatting, PV-name construction through the real naming contract) + `GatewayDevicePanel` exercised against a fake `aioca` planted in `sys.modules` — the real loop/thread machinery runs, no live CA.
- `tests/test_main_window.py`: window wiring with fake backends — queued-path readback from a non-GUI thread (`qtbot.waitUntil`), Set dispatch with parsed values, unsubscribe/resubscribe on selection and experiment change, stub failure reporting, and prompt close during a slow in-flight set (mirroring the health-poller teardown tests).
- `QT_QPA_PLATFORM=offscreen poetry run pytest -q`: **115 passed, exit 0**, stable across 4+ repeated runs (exit code checked each time).

### Housekeeping

- `poetry version minor` → 0.3.0, CHANGELOG entry, CLAUDE.md updated (device panel moved from stubbed to implemented seams; R7 `device:variable` autocomplete recorded as the remaining stub — `ConsoleConfigs` has no device/variable listing yet).

### Left for live verification

- Real camonitor updates against a running gateway (value stream + reconnect behavior).
- A real `:SP` put end-to-end (GEECS blocking-set completion, timeout behavior on a rejected set).
- Readback formatting against real gateway value types (enum labels, long strings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)