### PR TITLE
GEECS-Console 0.4.0: presets persistence + last-experiment memory

### DIFF
--- a/GEECS-Console/CHANGELOG.md
+++ b/GEECS-Console/CHANGELOG.md
@@ -4,6 +4,38 @@ All notable changes to GEECS-Console are documented here.  Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versioning is
 semantic.
 
+## [0.4.0] - 2026-07-11
+
+### Added
+
+- Presets persistence (R4): the stub handlers are replaced by a
+  `PresetStore` seam (`services/presets.py`).  A preset IS a saved
+  `ScanRequest` — one YAML file per preset
+  (`scanner_configs/experiments/<Experiment>/presets/<name>.yaml`, a plain
+  `model_dump(mode="json")` document round-tripped through
+  `ScanRequest.model_validate`), living beside the other per-experiment
+  config kinds `ConfigsRepoResolver` reads.  Listing degrades to empty with
+  no configs repo; load/save/delete raise `PresetStoreError` with a message
+  the window surfaces in the status bar.  Constructor-injectable into
+  `MainWindow` (tests drive a fake or a tmp-dir-backed store).
+- Save-as: current form → `build_scan_request` → store, named via a
+  `QInputDialog` (overwrite allowed); the combo repopulates and selects the
+  new preset.  Apply: selected preset → `form_state_from_request` (the new
+  pure inverse of `build_scan_request`, beside it in `request_builder.py`)
+  → form widgets.  Content the form cannot express — an optimize preset,
+  action bindings, explicit position lists, more than two axes — reports a
+  clear status-bar error and leaves the form untouched; preset save-set
+  names missing from the experiment's configs are skipped with a warning.
+  Delete: a Delete button beside Save-as removes the selected preset.  The
+  combo repopulates on experiment change and after save/delete.
+- Last-experiment memory: the last selected experiment persists across
+  sessions via `ConsoleSettings` (`services/settings.py`, a tiny
+  QSettings-backed helper — `GEECS` / `GEECS-Console`, INI format) and is
+  restored at startup when nothing was selected explicitly and the name is
+  still in the combo's list — so the health probe, configs, presets, and
+  device panel all reopen pointed at it.  Constructor-injectable; tests
+  redirect QSettings to a per-test tmp path.
+
 ## [0.3.0] - 2026-07-11
 
 ### Added

--- a/GEECS-Console/CLAUDE.md
+++ b/GEECS-Console/CLAUDE.md
@@ -22,8 +22,9 @@ are prefixed by region (`r3_radio_1d`, `r5_start_button`, …).
   Grid-only), shots per step, acquisition combo (free_run default, strict —
   the request declares intent), live shot count with the
   `MAXIMUM_SCAN_SIZE = 1e6` guard, description.
-- **R4 presets** — combo + Apply + Save-as.  A preset IS a saved
-  `ScanRequest`; persistence not wired yet.
+- **R4 presets** — combo + Apply + Save-as + Delete.  A preset IS a saved
+  `ScanRequest`; **persistence live** (see Implemented seams): YAML files
+  in the configs repo's per-experiment `presets/` dir.
 - **R5 submit row** — Stop (danger) + Start (primary).  Start requires: not
   scanning, ≥1 selected save set, valid shot count within the guard, mode
   not Optimization.
@@ -47,8 +48,9 @@ are prefixed by region (`r3_radio_1d`, `r5_start_button`, …).
   a request; keep it a pure function, keep widgets out of it.
 - **The window depends on seams, not implementations**: `Submitter`
   (protocol over `BlueskyScanner`'s four ScanManager-compatible methods),
-  `ConsoleConfigs`, `HealthProbe`, `ScanEventsAdapter`.  All constructor-
-  injectable; every test drives the window with fakes.
+  `ConsoleConfigs`, `HealthProbe`, `ScanEventsAdapter`, `PresetStore`,
+  `ConsoleSettings`.  All constructor-injectable; every test drives the
+  window with fakes.
 - **Offline-first**: the window must open and run with zero network and
   zero configs.  `geecs_bluesky` is imported lazily (function-level) in
   `submission.py` and `services/configs.py` — it pulls `aioca` at package
@@ -110,6 +112,36 @@ are prefixed by region (`r3_radio_1d`, `r5_start_button`, …).
   All real imports are lazy (module import-safe offline); `closeEvent`
   unsubscribes and disconnects, never joins.  Inject the real backend in
   `main.py`; keep `StubDevicePanel` as the window's default.
+- **Presets (R4)** are live via `PresetStore` (`services/presets.py`), the
+  constructor-injectable persistence seam.  A preset IS a saved
+  `ScanRequest`: one YAML file per preset at
+  `scanner_configs/experiments/<Experiment>/presets/<name>.yaml` (beside
+  the config kinds `ConfigsRepoResolver` reads), written as
+  `model_dump(mode="json")` and loaded through
+  `ScanRequest.model_validate`.  Save-as goes current form →
+  `build_scan_request` → store (name from a `QInputDialog`, overwrite
+  allowed); Apply goes store → `form_state_from_request` — the **pure
+  inverse** of `build_scan_request`, next to it in `request_builder.py`,
+  widgets kept out — → `_apply_form_state`, which validates everything the
+  widgets cannot express *before* touching any of them (optimize presets,
+  action bindings, explicit position lists, >2 axes ⇒ status-bar error,
+  form untouched; unknown save-set names are skipped with a warning).
+  Listing never raises (missing configs repo ⇒ empty); save/load/delete
+  raise `PresetStoreError` surfaced in the status bar.  Creating the
+  `presets/` dir with `mkdir(parents=True, exist_ok=True)` is deliberate —
+  it is a config dir, not a `scans/ScanNNN/` folder, so the repo's
+  scan-folder invariant does not apply.  The combo repopulates on
+  experiment change and after save/delete.
+- **Last-experiment memory**: `ConsoleSettings` (`services/settings.py`) is
+  a tiny QSettings-backed helper (`GEECS`/`GEECS-Console`, **INI format**
+  so `QSettings.setPath` redirection works in tests) — deliberately not a
+  framework; future GUI state becomes more properties on it.  The window
+  writes `last_experiment` on every experiment change and restores it at
+  startup only when no experiment was passed explicitly and the name is
+  still in the combo (restoring fires the normal experiment-changed path,
+  so configs, presets, health probe, and device panel all follow).
+  Constructor-injectable; `tests/conftest.py` isolates the user scope to a
+  per-test tmp path so no test touches real settings.
 
 ## Stubbed seams (intentional, wire later)
 
@@ -117,8 +149,6 @@ are prefixed by region (`r3_radio_1d`, `r5_start_button`, …).
   placeholder) — `ConsoleConfigs` has no device/variable listing yet.  The
   natural source is a `GeecsDb` enumeration (device → `get='yes'`
   variables), populated the way the other combos are.
-- Presets persistence (save/load ScanRequest YAML; a preset dir in the
-  configs repo is the natural home).
 - Optimization mode: radio exists, submission refused with a clear error
   until an `OptimizationSpec` editor exists.
 - Scan-number source: `set_scan_number` + the 10 s expiry exist, but no

--- a/GEECS-Console/geecs_console/app/main_window.py
+++ b/GEECS-Console/geecs_console/app/main_window.py
@@ -24,6 +24,7 @@ from PySide6.QtWidgets import (
     QApplication,
     QComboBox,
     QDoubleSpinBox,
+    QInputDialog,
     QLabel,
     QLineEdit,
     QListWidget,
@@ -47,8 +48,11 @@ from geecs_console.request_builder import (
     FormAxis,
     build_scan_request,
     estimate_total_shots,
+    form_state_from_request,
 )
 from geecs_console.services.configs import ConsoleConfigs
+from geecs_console.services.presets import PresetStore, PresetStoreError
+from geecs_console.services.settings import ConsoleSettings
 from geecs_console.services.device_panel import (
     DevicePanelBackend,
     StubDevicePanel,
@@ -187,6 +191,13 @@ class MainWindow(QMainWindow):
         R7 readback/set backend; default is the no-op stub (readback never
         updates, sets report unwired).  ``main.py`` injects the real
         :class:`~geecs_console.services.device_panel.GatewayDevicePanel`.
+    presets : PresetStore, optional
+        R4 preset persistence (a preset IS a saved ``ScanRequest``); tests
+        inject a fake or a tmp-dir-backed store, default reads/writes the
+        experiment's ``presets/`` dir in the configs repo.
+    settings : ConsoleSettings, optional
+        Persisted GUI state (last selected experiment); tests inject one
+        backed by a tmp INI file, default is the user-scope QSettings store.
     submitter : Submitter, optional
         Scan engine; tests inject a fake.  When ``None`` one is built
         lazily by *submitter_factory* on the first Start click.
@@ -209,6 +220,8 @@ class MainWindow(QMainWindow):
         configs: Optional[ConsoleConfigs] = None,
         health: Optional[HealthProbe] = None,
         device_panel: Optional[DevicePanelBackend] = None,
+        presets: Optional[PresetStore] = None,
+        settings: Optional[ConsoleSettings] = None,
         submitter: Optional[Submitter] = None,
         submitter_factory: Optional[Callable[..., Submitter]] = None,
     ) -> None:
@@ -218,6 +231,10 @@ class MainWindow(QMainWindow):
         self._device_panel = (
             device_panel if device_panel is not None else StubDevicePanel()
         )
+        self._presets = (
+            presets if presets is not None else PresetStore(self._configs.experiment)
+        )
+        self._settings = settings if settings is not None else ConsoleSettings()
         self._device_set_in_flight = False
         self._submitter = submitter
         self._submitter_factory = (
@@ -243,6 +260,7 @@ class MainWindow(QMainWindow):
         self._scan_number_timer.timeout.connect(self._expire_scan_number)
 
         self._populate_from_configs()
+        self._restore_last_experiment()
         # Chips read UNKNOWN until the first background poll returns; seed the
         # markup synchronously (no probe call — never touches the network).
         self._apply_health_report(HealthReport())
@@ -339,6 +357,7 @@ class MainWindow(QMainWindow):
         self.preset_combo: QComboBox = self._child(QComboBox, "r4_preset_combo")
         self.apply_button: QPushButton = self._child(QPushButton, "r4_apply_button")
         self.save_as_button: QPushButton = self._child(QPushButton, "r4_save_as_button")
+        self.delete_button: QPushButton = self._child(QPushButton, "r4_delete_button")
         # R5 submit row
         self.stop_button: QPushButton = self._child(QPushButton, "r5_stop_button")
         self.start_button: QPushButton = self._child(QPushButton, "r5_start_button")
@@ -409,8 +428,9 @@ class MainWindow(QMainWindow):
         )
         self.start_button.clicked.connect(self._on_start_clicked)
         self.stop_button.clicked.connect(self._on_stop_clicked)
-        self.apply_button.clicked.connect(self._on_preset_stub)
-        self.save_as_button.clicked.connect(self._on_preset_stub)
+        self.apply_button.clicked.connect(self._on_preset_apply)
+        self.save_as_button.clicked.connect(self._on_preset_save_as)
+        self.delete_button.clicked.connect(self._on_preset_delete)
 
         # R7 device panel.  Selection commits (dropdown pick / Enter / focus
         # leave) resubscribe the readback; per-keystroke edits only regate the
@@ -481,6 +501,7 @@ class MainWindow(QMainWindow):
         if listing.message:
             self.statusBar().showMessage(listing.message, 10_000)
             self.append_log(listing.message)
+        self._refresh_presets()
         self._refresh_union_preview()
         self._refresh_shot_count()
 
@@ -782,10 +803,28 @@ class MainWindow(QMainWindow):
     def _on_experiment_changed(self, experiment: str) -> None:
         """Repopulate everything for the newly selected experiment."""
         self._configs.set_experiment(experiment)
+        self._presets.set_experiment(experiment)
+        self._settings.last_experiment = experiment
         self._push_experiment_to_probe(experiment)
         self._populate_from_configs()
         # The readback PV is experiment-prefixed — re-point the monitor.
         self._resubscribe_device()
+
+    def _restore_last_experiment(self) -> None:
+        """Select the remembered experiment at startup (explicit choice wins).
+
+        Runs once from the constructor, after the combo is populated.  A
+        remembered experiment is restored only when nothing was selected
+        explicitly and the name is still in the combo's list; selecting it
+        fires :meth:`_on_experiment_changed`, so configs, presets, the
+        health probe, and the device panel all follow.
+        """
+        if self._configs.experiment:
+            return
+        remembered = self._settings.last_experiment
+        if not remembered or self.experiment_combo.findText(remembered) < 0:
+            return
+        self.experiment_combo.setCurrentText(remembered)
 
     def _on_trigger_profile_changed(self, profile: str) -> None:
         """Repopulate the variant combo for the selected trigger profile."""
@@ -865,14 +904,177 @@ class MainWindow(QMainWindow):
         self._refresh_submit_enabled()
 
     # ------------------------------------------------------------------
-    # R4 stub
+    # R4 presets (a preset IS a saved ScanRequest)
     # ------------------------------------------------------------------
 
-    def _on_preset_stub(self) -> None:
-        """R4 placeholder: presets are scan requests, not wired yet."""
-        self.statusBar().showMessage(
-            "Presets are not wired yet (a preset is a saved ScanRequest).", 10_000
+    def _report(self, message: str) -> None:
+        """Show *message* in the status bar and append it to the log tail.
+
+        Parameters
+        ----------
+        message : str
+            The operator-facing line.
+        """
+        self.statusBar().showMessage(message, 10_000)
+        self.append_log(message)
+
+    def _refresh_presets(self) -> None:
+        """Repopulate the R4 combo from the store, keeping the selection."""
+        current = self.preset_combo.currentText()
+        self.preset_combo.blockSignals(True)
+        self.preset_combo.clear()
+        self.preset_combo.addItems(self._presets.list_names())
+        # findText returns -1 when the previous selection is gone, which
+        # setCurrentIndex(-1) renders as "nothing selected" — exactly right.
+        self.preset_combo.setCurrentIndex(self.preset_combo.findText(current))
+        self.preset_combo.blockSignals(False)
+
+    def _on_preset_save_as(self) -> None:
+        """R4 Save-as: current form → ScanRequest → named YAML in the store."""
+        try:
+            request = build_scan_request(self.form_state())
+        except (ConsoleFormError, ValidationError) as exc:
+            self._report(f"Cannot save preset: {exc}")
+            return
+        name, accepted = QInputDialog.getText(
+            self,
+            "Save preset",
+            "Preset name:",
+            text=self.preset_combo.currentText(),
         )
+        name = name.strip()
+        if not accepted or not name:
+            return
+        try:
+            self._presets.save(name, request)
+        except PresetStoreError as exc:
+            self._report(f"Cannot save preset: {exc}")
+            return
+        self._refresh_presets()
+        self.preset_combo.setCurrentText(name)
+        self._report(f"Saved preset {name!r}.")
+
+    def _on_preset_apply(self) -> None:
+        """R4 Apply: load the selected preset and populate the form from it.
+
+        Anything unloadable or inexpressible on the form (a missing or
+        invalid file, an optimize preset, action bindings, explicit position
+        lists, more than two axes) reports a status-bar error and leaves the
+        form untouched.
+        """
+        name = self.preset_combo.currentText()
+        if not name:
+            self._report("No preset selected.")
+            return
+        try:
+            form = form_state_from_request(self._presets.load(name))
+            self._apply_form_state(form)
+        except (PresetStoreError, ConsoleFormError) as exc:
+            self._report(f"Cannot apply preset {name!r}: {exc}")
+            return
+        self._report(f"Applied preset {name!r}.")
+
+    def _on_preset_delete(self) -> None:
+        """R4 Delete: remove the selected preset and refresh the combo."""
+        name = self.preset_combo.currentText()
+        if not name:
+            self._report("No preset selected.")
+            return
+        try:
+            self._presets.delete(name)
+        except PresetStoreError as exc:
+            self._report(f"Cannot delete preset {name!r}: {exc}")
+            return
+        self._refresh_presets()
+        self._report(f"Deleted preset {name!r}.")
+
+    def _apply_form_state(self, form: ConsoleFormState) -> None:
+        """Populate the R1–R3 form widgets from *form* (the Apply inverse).
+
+        Validates everything the widgets cannot express **before** touching
+        any of them, so a failed apply leaves the form exactly as it was.
+
+        Parameters
+        ----------
+        form : ConsoleFormState
+            The form snapshot to render (usually from
+            :func:`form_state_from_request`).
+
+        Raises
+        ------
+        ConsoleFormError
+            More than two axes (the form has two axis rows) or an axis with
+            an explicit values list (the form only shows start/stop/step).
+        """
+        if len(form.axes) > 2:
+            raise ConsoleFormError(
+                f"it sweeps {len(form.axes)} axes — the form has two axis rows."
+            )
+        for axis in form.axes:
+            if axis.values is not None:
+                raise ConsoleFormError(
+                    f"axis {axis.variable!r} uses an explicit position list, "
+                    "which the form cannot show (start/stop/step only)."
+                )
+
+        radio = {
+            ConsoleMode.NOSCAN: self.radio_noscan,
+            ConsoleMode.ONE_D: self.radio_1d,
+            ConsoleMode.GRID: self.radio_grid,
+            ConsoleMode.OPTIMIZATION: self.radio_optimization,
+            ConsoleMode.BACKGROUND: self.radio_background,
+        }[form.mode]
+        radio.setChecked(True)
+
+        axis_rows = (
+            (self.variable_combo, self.start_spin, self.stop_spin, self.step_spin),
+            (self.variable2_combo, self.start2_spin, self.stop2_spin, self.step2_spin),
+        )
+        for axis, (combo, start, stop, step) in zip(form.axes, axis_rows):
+            combo.setCurrentText(axis.variable)
+            start.setValue(axis.start)
+            stop.setValue(axis.stop)
+            step.setValue(axis.step)
+
+        self.shots_per_step.setValue(form.shots_per_step)
+        self.acquisition_combo.setCurrentText(form.acquisition.value)
+        self.description_edit.setText(form.description)
+        self.trigger_profile_combo.setCurrentText(form.trigger_profile or "")
+        # Changing the profile text repopulated the variant combo (the
+        # currentTextChanged handler); now pick the preset's variant.
+        self.trigger_variant_combo.setCurrentText(form.trigger_variant or "")
+        self._apply_save_sets(form.save_sets)
+        self._refresh_shot_count()
+
+    def _apply_save_sets(self, names: list[str]) -> None:
+        """Make the R2 selected list exactly *names* (known ones, in order).
+
+        Save-set names the current experiment's configs don't list are
+        skipped with a status-bar warning — putting an unresolvable name in
+        the selected list would only fail later, at submission.
+
+        Parameters
+        ----------
+        names : list of str
+            The preset's save-set names, in list order.
+        """
+        known = set(self.selected_save_sets()) | {
+            self.available_list.item(row).text()
+            for row in range(self.available_list.count())
+        }
+        selected = [name for name in names if name in known]
+        missing = [name for name in names if name not in known]
+        self.selected_list.clear()
+        self.selected_list.addItems(selected)
+        self.available_list.clear()
+        self.available_list.addItems(sorted(known - set(selected)))
+        if missing:
+            self._report(
+                "Preset save sets not in this experiment's configs "
+                f"(skipped): {', '.join(missing)}"
+            )
+        self._refresh_union_preview()
+        self._refresh_submit_enabled()
 
     # ------------------------------------------------------------------
     # R7 device panel

--- a/GEECS-Console/geecs_console/app/ui/main_window.ui
+++ b/GEECS-Console/geecs_console/app/ui/main_window.ui
@@ -632,6 +632,16 @@
            </widget>
           </item>
           <item>
+           <widget class="QPushButton" name="r4_delete_button">
+            <property name="text">
+             <string>Delete</string>
+            </property>
+            <property name="toolTip">
+             <string>Delete the selected preset</string>
+            </property>
+           </widget>
+          </item>
+          <item>
            <spacer name="r4_spacer">
             <property name="orientation">
              <enum>Qt::Horizontal</enum>

--- a/GEECS-Console/geecs_console/request_builder.py
+++ b/GEECS-Console/geecs_console/request_builder.py
@@ -242,3 +242,79 @@ def build_scan_request(form: ConsoleFormState) -> ScanRequest:
         description=form.description,
         background=form.background or form.mode is ConsoleMode.BACKGROUND,
     )
+
+
+def form_state_from_request(request: ScanRequest) -> ConsoleFormState:
+    """Invert :func:`build_scan_request`: a saved request back into form state.
+
+    This is the Apply half of presets (a preset IS a saved
+    :class:`~geecs_schemas.ScanRequest`).  It is pure — no widgets — and
+    strict: content the scan form cannot express raises instead of being
+    silently dropped, so applying then re-saving a preset never loses part
+    of it.
+
+    Parameters
+    ----------
+    request : ScanRequest
+        The saved request to translate.
+
+    Returns
+    -------
+    ConsoleFormState
+        Form state that :func:`build_scan_request` maps back onto an
+        equivalent request.  A ``noscan`` with the ``background`` flag
+        becomes :attr:`ConsoleMode.BACKGROUND` (the same folding the
+        builder applies in the other direction).
+
+    Raises
+    ------
+    ConsoleFormError
+        For an ``optimize`` request (no OptimizationSpec editor yet) or a
+        request carrying action bindings — both inexpressible on the form.
+    """
+    if request.mode is ScanRequestMode.OPTIMIZE:
+        raise ConsoleFormError(
+            "This preset is an optimization scan — the console form cannot "
+            "express it (no OptimizationSpec editor yet)."
+        )
+    if request.actions.setup or request.actions.per_step or request.actions.closeout:
+        raise ConsoleFormError(
+            "This preset carries action bindings (setup/per_step/closeout), "
+            "which the console form cannot express — applying it would drop "
+            "them on the next save or submit."
+        )
+
+    if request.mode is ScanRequestMode.NOSCAN:
+        mode = ConsoleMode.BACKGROUND if request.background else ConsoleMode.NOSCAN
+        background = False  # folded into the mode, mirroring the builder
+        axes: list[FormAxis] = []
+    else:
+        mode = ConsoleMode.ONE_D if len(request.axes) == 1 else ConsoleMode.GRID
+        background = request.background
+        axes = []
+        for axis in request.axes:
+            if isinstance(axis.positions, PositionList):
+                axes.append(
+                    FormAxis(variable=axis.variable, values=axis.positions.to_values())
+                )
+            else:
+                axes.append(
+                    FormAxis(
+                        variable=axis.variable,
+                        start=axis.positions.start,
+                        stop=axis.positions.end,
+                        step=axis.positions.step,
+                    )
+                )
+
+    return ConsoleFormState(
+        mode=mode,
+        axes=axes,
+        shots_per_step=request.shots_per_step,
+        save_sets=list(request.save_sets),
+        trigger_profile=request.trigger_profile,
+        trigger_variant=request.trigger_variant,
+        acquisition=request.acquisition,
+        description=request.description,
+        background=background,
+    )

--- a/GEECS-Console/geecs_console/services/presets.py
+++ b/GEECS-Console/geecs_console/services/presets.py
@@ -1,0 +1,269 @@
+"""Preset persistence: named :class:`~geecs_schemas.ScanRequest` YAML files.
+
+A preset IS a saved ``ScanRequest`` — nothing more.  :class:`PresetStore`
+keeps one YAML file per preset (``<name>.yaml``, a plain
+``model_dump(mode="json")`` document that round-trips through
+``ScanRequest.model_validate``) in the per-experiment configs area, beside
+the other config kinds ``ConfigsRepoResolver`` reads::
+
+    scanner_configs/experiments/<Experiment>/presets/<name>.yaml
+
+Offline-safety mirrors :class:`~geecs_console.services.configs.ConsoleConfigs`:
+listing degrades to empty with no configs root; ``load``/``save``/``delete``
+raise :class:`PresetStoreError` with a clear message the window surfaces in
+the status bar.  Creating the ``presets/`` directory with
+``mkdir(parents=True, exist_ok=True)`` is deliberate and fine — this is a
+config directory in the configs repo, not a ``scans/ScanNNN/`` data folder,
+so the repo's scan-folder creation invariant does not apply.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Optional
+
+import yaml
+from pydantic import ValidationError
+
+from geecs_console.services.configs import _configs_base
+from geecs_schemas import ScanRequest
+
+logger = logging.getLogger(__name__)
+
+PRESET_FOLDER = "presets"
+
+
+class PresetStoreError(RuntimeError):
+    """A preset operation cannot be carried out (surfaced in the status bar)."""
+
+
+class PresetStore:
+    """Load/save named scan-request presets for one experiment.
+
+    Parameters
+    ----------
+    experiment : str, optional
+        Experiment folder under ``scanner_configs/experiments``.  May be
+        empty at construction (before the operator picks one) — listing is
+        then empty and saving raises.
+    experiments_root : str or Path, optional
+        Override for the experiments root (tests point this at a tmp dir);
+        defaults to the production resolution
+        (:func:`geecs_bluesky.scanner_configs.scanner_configs_base`, resolved
+        lazily so the module stays import-safe offline).
+    """
+
+    def __init__(
+        self, experiment: str = "", experiments_root: str | Path | None = None
+    ) -> None:
+        self._experiment = experiment
+        self._experiments_root = (
+            Path(experiments_root) if experiments_root is not None else None
+        )
+
+    @property
+    def experiment(self) -> str:
+        """The experiment this store reads and writes presets for."""
+        return self._experiment
+
+    def set_experiment(self, experiment: str) -> None:
+        """Switch the store to *experiment*.
+
+        Parameters
+        ----------
+        experiment : str
+            The new experiment folder name ("" for none selected).
+        """
+        self._experiment = experiment
+
+    # ------------------------------------------------------------------
+    # Folder resolution
+    # ------------------------------------------------------------------
+
+    def _folder(self) -> Optional[Path]:
+        """Return the experiment's presets dir, or ``None`` offline/unselected."""
+        root = self._experiments_root
+        if root is None:
+            root = _configs_base()
+        if root is None or not self._experiment:
+            return None
+        return root / self._experiment / PRESET_FOLDER
+
+    def _folder_or_raise(self) -> Path:
+        """Return the presets dir, raising a clear error when unresolvable.
+
+        Returns
+        -------
+        Path
+            ``<experiments root>/<experiment>/presets``.
+
+        Raises
+        ------
+        PresetStoreError
+            When the configs repo is not found or no experiment is selected.
+        """
+        root = self._experiments_root
+        if root is None:
+            root = _configs_base()
+        if root is None:
+            raise PresetStoreError(
+                "Configs repo not found — set GEECS_SCANNER_CONFIG_DIR or "
+                "config.ini [Paths] scanner_config_root_path."
+            )
+        if not self._experiment:
+            raise PresetStoreError("No experiment selected.")
+        return root / self._experiment / PRESET_FOLDER
+
+    def _path(self, name: str) -> Path:
+        """Return the YAML path for preset *name*, validating the name.
+
+        Parameters
+        ----------
+        name : str
+            The preset name (the file stem — no path separators).
+
+        Returns
+        -------
+        Path
+            ``<presets dir>/<name>.yaml`` (an existing ``.yml`` twin is
+            preferred when the ``.yaml`` spelling is absent).
+
+        Raises
+        ------
+        PresetStoreError
+            On an empty name or one that would escape the presets dir.
+        """
+        cleaned = name.strip()
+        if not cleaned:
+            raise PresetStoreError("Preset name must not be empty.")
+        if any(sep in cleaned for sep in ("/", "\\")) or cleaned in (".", ".."):
+            raise PresetStoreError(
+                f"Preset name {name!r} must be a plain file name (no path separators)."
+            )
+        folder = self._folder_or_raise()
+        path = folder / f"{cleaned}.yaml"
+        if not path.exists():
+            twin = folder / f"{cleaned}.yml"
+            if twin.exists():
+                return twin
+        return path
+
+    # ------------------------------------------------------------------
+    # The store surface
+    # ------------------------------------------------------------------
+
+    def list_names(self) -> list[str]:
+        """List the saved preset names, sorted; never raises.
+
+        Returns
+        -------
+        list of str
+            YAML file stems in the presets dir — empty when the configs
+            repo, experiment folder, or presets dir is missing.
+        """
+        folder = self._folder()
+        if folder is None or not folder.is_dir():
+            return []
+        return sorted(
+            path.stem for path in folder.iterdir() if path.suffix in (".yaml", ".yml")
+        )
+
+    def load(self, name: str) -> ScanRequest:
+        """Load preset *name* as a validated :class:`ScanRequest`.
+
+        Parameters
+        ----------
+        name : str
+            The preset name (file stem).
+
+        Returns
+        -------
+        ScanRequest
+            The schema-validated request the preset stores.
+
+        Raises
+        ------
+        PresetStoreError
+            Missing configs repo / experiment / file, unparsable YAML, or a
+            document the schema rejects — always with a message fit for the
+            status bar.
+        """
+        path = self._path(name)
+        if not path.exists():
+            raise PresetStoreError(f"Preset {name!r} not found ({path}).")
+        try:
+            document = yaml.safe_load(path.read_text(encoding="utf-8"))
+        except yaml.YAMLError as exc:
+            raise PresetStoreError(
+                f"Preset {name!r} is not valid YAML ({path}): {exc}"
+            ) from exc
+        if not isinstance(document, dict):
+            raise PresetStoreError(
+                f"Preset {name!r} ({path}) should be a YAML mapping of "
+                f"ScanRequest fields, got {type(document).__name__}."
+            )
+        try:
+            return ScanRequest.model_validate(document)
+        except ValidationError as exc:
+            raise PresetStoreError(
+                f"Preset {name!r} ({path}) is not a valid ScanRequest: {exc}"
+            ) from exc
+
+    def save(self, name: str, request: ScanRequest) -> Path:
+        """Write *request* as preset *name* (overwriting an existing one).
+
+        Parameters
+        ----------
+        name : str
+            The preset name (file stem).
+        request : ScanRequest
+            The request to persist.
+
+        Returns
+        -------
+        Path
+            The YAML file written.
+
+        Raises
+        ------
+        PresetStoreError
+            Missing configs repo, no experiment selected, a bad name, or an
+            OS-level write failure.
+        """
+        path = self._path(name)
+        # A config dir, not a scans/ScanNNN/ data folder — parents=True is
+        # explicitly fine here (the scan-folder invariant does not apply).
+        path.parent.mkdir(parents=True, exist_ok=True)
+        document = yaml.safe_dump(
+            request.model_dump(mode="json"), sort_keys=False, allow_unicode=True
+        )
+        try:
+            path.write_text(document, encoding="utf-8")
+        except OSError as exc:
+            raise PresetStoreError(f"Could not write preset {name!r}: {exc}") from exc
+        logger.info("saved preset %r to %s", name, path)
+        return path
+
+    def delete(self, name: str) -> None:
+        """Delete preset *name*.
+
+        Parameters
+        ----------
+        name : str
+            The preset name (file stem).
+
+        Raises
+        ------
+        PresetStoreError
+            Missing configs repo / experiment, a bad name, a preset that
+            does not exist, or an OS-level delete failure.
+        """
+        path = self._path(name)
+        if not path.exists():
+            raise PresetStoreError(f"Preset {name!r} not found ({path}).")
+        try:
+            path.unlink()
+        except OSError as exc:
+            raise PresetStoreError(f"Could not delete preset {name!r}: {exc}") from exc
+        logger.info("deleted preset %r (%s)", name, path)

--- a/GEECS-Console/geecs_console/services/settings.py
+++ b/GEECS-Console/geecs_console/services/settings.py
@@ -1,0 +1,55 @@
+"""Tiny persistent GUI-state helper (QSettings-backed) — not a framework.
+
+One class, one key so far: the last selected experiment, remembered across
+sessions so the console reopens pointed where the operator left it (health
+probe and configs included).  Future GUI state (window geometry, last
+preset, …) belongs here as more properties — resist anything grander.
+
+The backing store is ``QSettings("GEECS", "GEECS-Console")`` in INI format
+(INI honors ``QSettings.setPath``, so tests can redirect the user scope to a
+tmp dir; the platform-native macOS plist store ignores it).  Tests can also
+inject their own ``QSettings`` instance directly.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from PySide6.QtCore import QSettings
+
+_ORGANIZATION = "GEECS"
+_APPLICATION = "GEECS-Console"
+_LAST_EXPERIMENT_KEY = "session/last_experiment"
+
+
+class ConsoleSettings:
+    """Persisted console GUI state.
+
+    Parameters
+    ----------
+    qsettings : QSettings, optional
+        The backing store; tests inject one pointed at a tmp INI file.
+        Defaults to the user-scope ``GEECS / GEECS-Console`` INI store.
+    """
+
+    def __init__(self, qsettings: Optional[QSettings] = None) -> None:
+        self._settings = (
+            qsettings
+            if qsettings is not None
+            else QSettings(
+                QSettings.Format.IniFormat,
+                QSettings.Scope.UserScope,
+                _ORGANIZATION,
+                _APPLICATION,
+            )
+        )
+
+    @property
+    def last_experiment(self) -> str:
+        """The experiment selected when the console last changed it ("" if never)."""
+        return str(self._settings.value(_LAST_EXPERIMENT_KEY, "") or "")
+
+    @last_experiment.setter
+    def last_experiment(self, experiment: str) -> None:
+        self._settings.setValue(_LAST_EXPERIMENT_KEY, experiment)
+        self._settings.sync()

--- a/GEECS-Console/pyproject.toml
+++ b/GEECS-Console/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-console"
-version = "0.3.0"
+version = "0.4.0"
 description = "Greenfield PySide6 operator console for GEECS (Bluesky/gateway architecture)"
 authors = ["Sam Barber <sbarber@lbl.gov>"]
 readme = "README.md"

--- a/GEECS-Console/tests/conftest.py
+++ b/GEECS-Console/tests/conftest.py
@@ -2,4 +2,24 @@
 
 import os
 
+import pytest
+
 os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+
+@pytest.fixture(autouse=True)
+def _isolated_qsettings(tmp_path):
+    """Point QSettings' user scope at a per-test tmp dir (hermetic settings).
+
+    ``ConsoleSettings`` uses the INI format precisely because INI honors
+    ``QSettings.setPath`` — so no test can read or write the developer's
+    real ``GEECS/GEECS-Console`` settings, even when a window is built
+    without an injected settings object.
+    """
+    from PySide6.QtCore import QSettings
+
+    QSettings.setPath(
+        QSettings.Format.IniFormat,
+        QSettings.Scope.UserScope,
+        str(tmp_path / "qsettings"),
+    )

--- a/GEECS-Console/tests/test_main_window.py
+++ b/GEECS-Console/tests/test_main_window.py
@@ -4,17 +4,31 @@ import pytest
 from PySide6.QtCore import Qt
 
 from geecs_console.app.main_window import MainWindow
-from geecs_console.request_builder import ConsoleMode, build_scan_request
+from geecs_console.request_builder import (
+    ConsoleFormState,
+    ConsoleMode,
+    FormAxis,
+    build_scan_request,
+)
 from geecs_console.services.configs import ConfigListing, UnionPreview
 from geecs_console.services.health import HealthReport, HealthStatus
+from geecs_console.services.presets import PresetStoreError
 from geecs_schemas import ScanRequestMode
 
 
 class FakeConfigs:
     """ConsoleConfigs stand-in: fixed listings, no filesystem."""
 
-    def __init__(self, save_sets=(), trigger_profiles=(), scan_variables=()):
-        self.experiment = "TestExp"
+    def __init__(
+        self,
+        save_sets=(),
+        trigger_profiles=(),
+        scan_variables=(),
+        experiment="TestExp",
+        experiments=("TestExp",),
+    ):
+        self.experiment = experiment
+        self._experiments = list(experiments)
         self._save_sets = list(save_sets)
         self._trigger_profiles = list(trigger_profiles)
         self._scan_variables = list(scan_variables)
@@ -24,7 +38,7 @@ class FakeConfigs:
 
     def listing(self):
         return ConfigListing(
-            experiments=["TestExp"],
+            experiments=self._experiments,
             save_sets=self._save_sets,
             trigger_profiles=self._trigger_profiles,
             scan_variables=self._scan_variables,
@@ -67,6 +81,42 @@ class FakeHealth:
         return HealthReport(gateway=HealthStatus.DOWN)
 
 
+class FakePresetStore:
+    """PresetStore stand-in: an in-memory name -> ScanRequest dict."""
+
+    def __init__(self, presets=None):
+        self.presets = dict(presets or {})
+        self.experiment = "TestExp"
+        self.saved = []
+
+    def set_experiment(self, experiment):
+        self.experiment = experiment
+
+    def list_names(self):
+        return sorted(self.presets)
+
+    def load(self, name):
+        if name not in self.presets:
+            raise PresetStoreError(f"Preset {name!r} not found.")
+        return self.presets[name]
+
+    def save(self, name, request):
+        self.presets[name] = request
+        self.saved.append((name, request))
+
+    def delete(self, name):
+        if name not in self.presets:
+            raise PresetStoreError(f"Preset {name!r} not found.")
+        del self.presets[name]
+
+
+class FakeSettings:
+    """ConsoleSettings stand-in: a plain attribute, no QSettings."""
+
+    def __init__(self, last_experiment=""):
+        self.last_experiment = last_experiment
+
+
 @pytest.fixture
 def window(qtbot):
     configs = FakeConfigs(
@@ -74,7 +124,12 @@ def window(qtbot):
         trigger_profiles=["HTU-Standard"],
         scan_variables=["jet_x", "jet_z"],
     )
-    win = MainWindow(configs=configs, submitter=FakeSubmitter())
+    win = MainWindow(
+        configs=configs,
+        presets=FakePresetStore(),
+        settings=FakeSettings(),
+        submitter=FakeSubmitter(),
+    )
     qtbot.addWidget(win)
     return win
 
@@ -588,3 +643,268 @@ class TestOperatorDialog:
         delivered queued onto the GUI thread — the only place the modal may run.
         """
         assert window.events.thread() is window.thread()
+
+
+def preset_request(**overrides):
+    """A representative 1D ScanRequest the FakeConfigs listings can render."""
+    form = dict(
+        mode=ConsoleMode.ONE_D,
+        axes=[FormAxis(variable="jet_z", start=-1.0, stop=2.0, step=0.5)],
+        shots_per_step=7,
+        save_sets=["EBeamDiags"],
+        trigger_profile="HTU-Standard",
+        trigger_variant="laser_off",
+        description="preset check",
+    )
+    form.update(overrides)
+    return build_scan_request(ConsoleFormState(**form))
+
+
+class TestPresets:
+    def _select_preset(self, window, name):
+        window._refresh_presets()
+        window.preset_combo.setCurrentIndex(window.preset_combo.findText(name))
+
+    def test_save_as_invokes_store_with_built_request(self, window, monkeypatch):
+        from PySide6.QtWidgets import QInputDialog
+
+        monkeypatch.setattr(
+            QInputDialog, "getText", staticmethod(lambda *a, **k: ("MyPreset", True))
+        )
+        select_save_set(window, "Amp4In")
+        window.variable_combo.setCurrentText("jet_x")
+        window._on_preset_save_as()
+        ((name, request),) = window._presets.saved
+        assert name == "MyPreset"
+        assert request.mode is ScanRequestMode.STEP
+        assert request.save_sets == ["Amp4In"]
+        assert request.axes[0].variable == "jet_x"
+        # The combo repopulated and now shows the new preset.
+        assert window.preset_combo.currentText() == "MyPreset"
+
+    def test_save_as_cancelled_dialog_saves_nothing(self, window, monkeypatch):
+        from PySide6.QtWidgets import QInputDialog
+
+        monkeypatch.setattr(
+            QInputDialog, "getText", staticmethod(lambda *a, **k: ("ignored", False))
+        )
+        select_save_set(window, "Amp4In")
+        window.variable_combo.setCurrentText("jet_x")
+        window._on_preset_save_as()
+        assert window._presets.saved == []
+
+    def test_save_as_invalid_form_reports_without_dialog(self, window, monkeypatch):
+        from PySide6.QtWidgets import QInputDialog
+
+        def _fail(*a, **k):
+            raise AssertionError("dialog must not open for an invalid form")
+
+        monkeypatch.setattr(QInputDialog, "getText", staticmethod(_fail))
+        window.variable_combo.setCurrentText("jet_x")
+        window.step_spin.setValue(0.0)  # zero step -> unbuildable request
+        window._on_preset_save_as()
+        assert window._presets.saved == []
+        assert "Cannot save preset" in window.statusBar().currentMessage()
+
+    def test_save_error_surfaces_in_status_bar(self, window, monkeypatch):
+        from PySide6.QtWidgets import QInputDialog
+
+        monkeypatch.setattr(
+            QInputDialog, "getText", staticmethod(lambda *a, **k: ("MyPreset", True))
+        )
+
+        def _refuse(name, request):
+            raise PresetStoreError("Configs repo not found.")
+
+        window._presets.save = _refuse
+        select_save_set(window, "Amp4In")
+        window.variable_combo.setCurrentText("jet_x")
+        window._on_preset_save_as()
+        assert "Configs repo not found" in window.statusBar().currentMessage()
+
+    def test_apply_populates_form(self, window):
+        window._presets.presets["align"] = preset_request()
+        self._select_preset(window, "align")
+        window._on_preset_apply()
+        assert window.radio_1d.isChecked()
+        assert window.variable_combo.currentText() == "jet_z"
+        assert window.start_spin.value() == -1.0
+        assert window.stop_spin.value() == 2.0
+        assert window.step_spin.value() == 0.5
+        assert window.shots_per_step.value() == 7
+        assert window.description_edit.text() == "preset check"
+        assert window.trigger_profile_combo.currentText() == "HTU-Standard"
+        assert window.trigger_variant_combo.currentText() == "laser_off"
+        assert window.selected_save_sets() == ["EBeamDiags"]
+        assert "total shots: 49" in window.shot_count_label.text()
+        # The applied form is submit-ready and rebuilds an equal request.
+        assert build_scan_request(window.form_state()) == preset_request()
+
+    def test_apply_noscan_preset_switches_mode(self, window):
+        window._presets.presets["stats"] = preset_request(
+            mode=ConsoleMode.NOSCAN,
+            axes=[],
+            shots_per_step=100,
+            trigger_profile=None,
+            trigger_variant=None,
+        )
+        self._select_preset(window, "stats")
+        window._on_preset_apply()
+        assert window.radio_noscan.isChecked()
+        assert window.shots_per_step.value() == 100
+        assert not window.variable_combo.isEnabled()
+
+    def test_apply_unmappable_preset_leaves_form_untouched(self, window):
+        from geecs_schemas import ScanRequest
+
+        window._presets.presets["3axis"] = ScanRequest.model_validate(
+            {
+                "mode": "step",
+                "axes": [
+                    {"variable": f"v{i}", "positions": {"values": [0.0, 1.0]}}
+                    for i in range(3)
+                ],
+            }
+        )
+        before = window.form_state()
+        self._select_preset(window, "3axis")
+        window._on_preset_apply()
+        assert "Cannot apply preset '3axis'" in window.statusBar().currentMessage()
+        assert window.form_state() == before
+
+    def test_apply_position_list_preset_reports_and_leaves_form(self, window):
+        window._presets.presets["list"] = preset_request(
+            axes=[FormAxis(variable="jet_z", values=[0.0, 0.5, 2.0])],
+            trigger_profile=None,
+            trigger_variant=None,
+        )
+        before = window.form_state()
+        self._select_preset(window, "list")
+        window._on_preset_apply()
+        assert "position list" in window.statusBar().currentMessage()
+        assert window.form_state() == before
+
+    def test_apply_skips_unknown_save_sets_with_warning(self, window):
+        window._presets.presets["mixed"] = preset_request(
+            save_sets=["EBeamDiags", "GhostSet"],
+            trigger_profile=None,
+            trigger_variant=None,
+        )
+        self._select_preset(window, "mixed")
+        window._on_preset_apply()
+        assert window.selected_save_sets() == ["EBeamDiags"]
+        assert "GhostSet" in window.log_tail.toPlainText()
+
+    def test_apply_with_nothing_selected_reports(self, window):
+        window._on_preset_apply()
+        assert "No preset selected" in window.statusBar().currentMessage()
+
+    def test_delete_updates_combo(self, window):
+        window._presets.presets["a"] = preset_request()
+        window._presets.presets["b"] = preset_request()
+        self._select_preset(window, "a")
+        window._on_preset_delete()
+        assert "a" not in window._presets.presets
+        assert [
+            window.preset_combo.itemText(i) for i in range(window.preset_combo.count())
+        ] == ["b"]
+
+    def test_delete_error_surfaces_in_status_bar(self, window):
+        window._presets.presets["a"] = preset_request()
+        self._select_preset(window, "a")
+        del window._presets.presets["a"]  # gone underneath us
+        window._on_preset_delete()
+        assert "Cannot delete preset 'a'" in window.statusBar().currentMessage()
+
+    def test_experiment_change_repoints_store_and_repopulates(self, qtbot):
+        class PerExperimentStore(FakePresetStore):
+            def __init__(self, by_experiment):
+                self.by_experiment = by_experiment
+                super().__init__()
+                self.set_experiment("TestExp")
+
+            def set_experiment(self, experiment):
+                super().set_experiment(experiment)
+                self.presets = dict(self.by_experiment.get(experiment, {}))
+
+        store = PerExperimentStore(
+            {
+                "TestExp": {"htu-align": preset_request()},
+                "Bella": {"bella-stats": preset_request()},
+            }
+        )
+        configs = FakeConfigs(experiments=["Bella", "TestExp"])
+        win = MainWindow(
+            configs=configs,
+            presets=store,
+            settings=FakeSettings(),
+            submitter=FakeSubmitter(),
+        )
+        qtbot.addWidget(win)
+        assert win.preset_combo.count() == 1
+        assert win.preset_combo.itemText(0) == "htu-align"
+        win.experiment_combo.setCurrentText("Bella")
+        assert store.experiment == "Bella"
+        assert win.preset_combo.itemText(0) == "bella-stats"
+
+
+class TestLastExperiment:
+    def test_remembered_experiment_restored_at_startup(self, qtbot):
+        configs = FakeConfigs(experiment="", experiments=["Bella", "TestExp"])
+        settings = FakeSettings(last_experiment="Bella")
+        win = MainWindow(
+            configs=configs,
+            presets=FakePresetStore(),
+            settings=settings,
+            submitter=FakeSubmitter(),
+        )
+        qtbot.addWidget(win)
+        assert win.experiment_combo.currentText() == "Bella"
+        assert configs.experiment == "Bella"
+
+    def test_remembered_experiment_not_in_list_is_ignored(self, qtbot):
+        configs = FakeConfigs(experiment="", experiments=["TestExp"])
+        settings = FakeSettings(last_experiment="Ghost")
+        win = MainWindow(
+            configs=configs,
+            presets=FakePresetStore(),
+            settings=settings,
+            submitter=FakeSubmitter(),
+        )
+        qtbot.addWidget(win)
+        assert win.experiment_combo.currentIndex() == -1
+        assert configs.experiment == ""
+
+    def test_explicit_experiment_wins_over_memory(self, qtbot):
+        configs = FakeConfigs(experiment="TestExp", experiments=["Bella", "TestExp"])
+        settings = FakeSettings(last_experiment="Bella")
+        win = MainWindow(
+            configs=configs,
+            presets=FakePresetStore(),
+            settings=settings,
+            submitter=FakeSubmitter(),
+        )
+        qtbot.addWidget(win)
+        assert win.experiment_combo.currentText() == "TestExp"
+        assert configs.experiment == "TestExp"
+
+    def test_experiment_change_is_remembered(self, window):
+        window._on_experiment_changed("Bella")
+        assert window._settings.last_experiment == "Bella"
+
+    def test_qsettings_default_persists_across_windows(self, qtbot):
+        """No injected settings: the real ConsoleSettings (isolated to the
+        test's tmp QSettings path by conftest) carries the selection from
+        one window to the next."""
+        configs1 = FakeConfigs(experiment="", experiments=["Bella", "TestExp"])
+        win1 = MainWindow(
+            configs=configs1, presets=FakePresetStore(), submitter=FakeSubmitter()
+        )
+        qtbot.addWidget(win1)
+        win1.experiment_combo.setCurrentText("Bella")
+        configs2 = FakeConfigs(experiment="", experiments=["Bella", "TestExp"])
+        win2 = MainWindow(
+            configs=configs2, presets=FakePresetStore(), submitter=FakeSubmitter()
+        )
+        qtbot.addWidget(win2)
+        assert win2.experiment_combo.currentText() == "Bella"

--- a/GEECS-Console/tests/test_presets.py
+++ b/GEECS-Console/tests/test_presets.py
@@ -1,0 +1,128 @@
+"""PresetStore: YAML round-trips against a tmp configs root, hermetic."""
+
+import pytest
+
+from geecs_console.request_builder import (
+    ConsoleFormState,
+    ConsoleMode,
+    FormAxis,
+    build_scan_request,
+)
+from geecs_console.services.presets import PRESET_FOLDER, PresetStore, PresetStoreError
+from geecs_schemas import ScanRequest, ScanRequestMode
+
+
+def one_d_request(variable="jet_x", description="") -> ScanRequest:
+    return build_scan_request(
+        ConsoleFormState(
+            mode=ConsoleMode.ONE_D,
+            axes=[FormAxis(variable=variable, start=0.0, stop=1.0, step=0.25)],
+            shots_per_step=10,
+            save_sets=["Amp4In"],
+            description=description,
+        )
+    )
+
+
+@pytest.fixture
+def store(tmp_path):
+    return PresetStore("HTU", experiments_root=tmp_path)
+
+
+class TestRoundTrip:
+    def test_save_load_round_trips_the_request(self, store):
+        request = one_d_request(description="align the jet")
+        store.save("align", request)
+        assert store.load("align") == request
+
+    def test_file_lands_in_the_experiment_presets_dir(self, store, tmp_path):
+        path = store.save("align", one_d_request())
+        assert path == tmp_path / "HTU" / PRESET_FOLDER / "align.yaml"
+        assert path.is_file()
+
+    def test_list_names_sorted(self, store):
+        for name in ("zeta", "alpha", "mid"):
+            store.save(name, one_d_request())
+        assert store.list_names() == ["alpha", "mid", "zeta"]
+
+    def test_overwrite_is_allowed(self, store):
+        store.save("align", one_d_request(description="v1"))
+        store.save("align", one_d_request(description="v2"))
+        assert store.load("align").description == "v2"
+        assert store.list_names() == ["align"]
+
+    def test_delete_removes_the_preset(self, store):
+        store.save("align", one_d_request())
+        store.delete("align")
+        assert store.list_names() == []
+        with pytest.raises(PresetStoreError, match="not found"):
+            store.load("align")
+
+    def test_yml_twin_is_listed_and_loadable(self, store, tmp_path):
+        folder = tmp_path / "HTU" / PRESET_FOLDER
+        store.save("seed", one_d_request())
+        (folder / "seed.yaml").rename(folder / "twin.yml")
+        assert store.list_names() == ["twin"]
+        assert store.load("twin").mode is ScanRequestMode.STEP
+
+    def test_set_experiment_switches_folders(self, store, tmp_path):
+        store.save("align", one_d_request())
+        store.set_experiment("Bella")
+        assert store.list_names() == []
+        store.save("bella-only", one_d_request())
+        assert (tmp_path / "Bella" / PRESET_FOLDER / "bella-only.yaml").is_file()
+
+
+class TestErrors:
+    def test_missing_dir_lists_empty(self, store):
+        assert store.list_names() == []
+
+    def test_load_missing_preset_raises_clearly(self, store):
+        with pytest.raises(PresetStoreError, match="'ghost' not found"):
+            store.load("ghost")
+
+    def test_delete_missing_preset_raises_clearly(self, store):
+        with pytest.raises(PresetStoreError, match="'ghost' not found"):
+            store.delete("ghost")
+
+    def test_invalid_yaml_raises_clearly(self, store, tmp_path):
+        folder = tmp_path / "HTU" / PRESET_FOLDER
+        folder.mkdir(parents=True)
+        (folder / "broken.yaml").write_text("mode: [unclosed")
+        with pytest.raises(PresetStoreError, match="not valid YAML"):
+            store.load("broken")
+
+    def test_non_mapping_yaml_raises_clearly(self, store, tmp_path):
+        folder = tmp_path / "HTU" / PRESET_FOLDER
+        folder.mkdir(parents=True)
+        (folder / "list.yaml").write_text("- just\n- a\n- list\n")
+        with pytest.raises(PresetStoreError, match="YAML mapping"):
+            store.load("list")
+
+    def test_schema_rejected_document_raises_clearly(self, store, tmp_path):
+        folder = tmp_path / "HTU" / PRESET_FOLDER
+        folder.mkdir(parents=True)
+        (folder / "bad.yaml").write_text("mode: step\naxes: []\n")
+        with pytest.raises(PresetStoreError, match="not a valid ScanRequest"):
+            store.load("bad")
+
+    def test_no_experiment_selected_save_raises(self, tmp_path):
+        store = PresetStore("", experiments_root=tmp_path)
+        with pytest.raises(PresetStoreError, match="No experiment selected"):
+            store.save("align", one_d_request())
+        assert store.list_names() == []
+
+    def test_missing_configs_repo_lists_empty_and_save_raises(self, monkeypatch):
+        # Offline: the lazy configs-root resolution finds nothing.
+        monkeypatch.setattr(
+            "geecs_console.services.presets._configs_base", lambda: None
+        )
+        store = PresetStore("HTU")
+        assert store.list_names() == []
+        with pytest.raises(PresetStoreError, match="Configs repo not found"):
+            store.save("align", one_d_request())
+
+    @pytest.mark.parametrize("name", ["", "   ", "a/b", "a\\b", "..", "."])
+    def test_bad_names_rejected(self, store, name):
+        with pytest.raises(PresetStoreError, match="name"):
+            store.save(name, one_d_request())

--- a/GEECS-Console/tests/test_request_builder.py
+++ b/GEECS-Console/tests/test_request_builder.py
@@ -11,6 +11,7 @@ from geecs_console.request_builder import (
     FormAxis,
     build_scan_request,
     estimate_total_shots,
+    form_state_from_request,
 )
 from geecs_schemas import (
     AcquisitionMode,
@@ -203,3 +204,100 @@ class TestGuardsAndModes:
             FormAxis(variable="jet_x", start=0.0)
         with pytest.raises(ValidationError, match="not both"):
             FormAxis(variable="jet_x", start=0.0, stop=1.0, step=0.5, values=[1.0])
+
+
+class TestFormStateFromRequest:
+    """The Apply inverse: request -> form state, round-trip exact."""
+
+    def round_trip(self, form: ConsoleFormState) -> ConsoleFormState:
+        return form_state_from_request(build_scan_request(form))
+
+    def test_noscan_round_trips_exactly(self):
+        form = ConsoleFormState(
+            mode=ConsoleMode.NOSCAN,
+            shots_per_step=100,
+            save_sets=["Amp4In"],
+            description="stats run",
+        )
+        assert self.round_trip(form) == form
+
+    def test_background_round_trips_to_background_mode(self):
+        form = ConsoleFormState(mode=ConsoleMode.BACKGROUND, shots_per_step=50)
+        assert self.round_trip(form) == form
+
+    def test_one_d_round_trips_exactly(self):
+        form = ConsoleFormState(
+            mode=ConsoleMode.ONE_D,
+            axes=[FormAxis(variable="jet_x", start=0.0, stop=1.0, step=0.25)],
+            shots_per_step=10,
+            save_sets=["Amp4In", "EBeamDiags"],
+            trigger_profile="HTU-Standard",
+            trigger_variant="laser_off",
+            acquisition=AcquisitionMode.STRICT,
+            description="align the jet",
+        )
+        assert self.round_trip(form) == form
+
+    def test_grid_round_trips_exactly(self):
+        form = ConsoleFormState(
+            mode=ConsoleMode.GRID,
+            axes=[
+                FormAxis(variable="jet_x", start=0.0, stop=1.0, step=0.5),
+                FormAxis(variable="jet_z", start=-1.0, stop=1.0, step=1.0),
+            ],
+            shots_per_step=3,
+        )
+        assert self.round_trip(form) == form
+
+    def test_position_list_round_trips_exactly(self):
+        form = ConsoleFormState(
+            mode=ConsoleMode.ONE_D,
+            axes=[FormAxis(variable="jet_x", values=[0.0, 0.5, 2.0, 8.0])],
+        )
+        assert self.round_trip(form) == form
+
+    def test_step_scan_keeps_the_background_flag(self):
+        form = ConsoleFormState(
+            mode=ConsoleMode.ONE_D,
+            axes=[FormAxis(variable="jet_x", start=0.0, stop=1.0, step=0.5)],
+            background=True,
+        )
+        assert self.round_trip(form) == form
+
+    def test_yaml_round_trip_survives_serialization(self):
+        """Preset parity: form -> request -> YAML dict -> request -> form."""
+        form = ConsoleFormState(
+            mode=ConsoleMode.ONE_D,
+            axes=[FormAxis(variable="jet_x", start=0.0, stop=1.0, step=0.25)],
+            shots_per_step=10,
+            save_sets=["Amp4In"],
+            trigger_profile="HTU-Standard",
+        )
+        request = build_scan_request(form)
+        reloaded = ScanRequest.model_validate(request.model_dump(mode="json"))
+        assert form_state_from_request(reloaded) == form
+
+    def test_optimize_request_raises_console_form_error(self):
+        from geecs_schemas import EvaluatorSpec, GeneratorSpec, OptimizationSpec
+
+        request = ScanRequest(
+            mode=ScanRequestMode.OPTIMIZE,
+            optimization=OptimizationSpec(
+                variables={"jet_x": (0.0, 1.0)},
+                objectives={"counts": "MAXIMIZE"},
+                evaluator=EvaluatorSpec(module="m", class_name="C"),
+                generator=GeneratorSpec(name="random"),
+            ),
+        )
+        with pytest.raises(ConsoleFormError, match="[Oo]ptimization"):
+            form_state_from_request(request)
+
+    def test_action_bindings_raise_console_form_error(self):
+        from geecs_schemas import ActionBindings
+
+        request = ScanRequest(
+            mode=ScanRequestMode.NOSCAN,
+            actions=ActionBindings(setup=["warmup"]),
+        )
+        with pytest.raises(ConsoleFormError, match="action bindings"):
+            form_state_from_request(request)

--- a/GEECS-Console/tests/test_settings.py
+++ b/GEECS-Console/tests/test_settings.py
@@ -1,0 +1,24 @@
+"""ConsoleSettings: QSettings-backed, isolated to a tmp path by conftest."""
+
+from geecs_console.services.settings import ConsoleSettings
+
+
+class TestConsoleSettings:
+    def test_defaults_to_empty(self):
+        assert ConsoleSettings().last_experiment == ""
+
+    def test_last_experiment_round_trips_across_instances(self):
+        ConsoleSettings().last_experiment = "HTU"
+        assert ConsoleSettings().last_experiment == "HTU"
+
+    def test_injected_qsettings_is_used(self, tmp_path):
+        from PySide6.QtCore import QSettings
+
+        backing = QSettings(str(tmp_path / "own.ini"), QSettings.Format.IniFormat)
+        settings = ConsoleSettings(backing)
+        settings.last_experiment = "Bella"
+        assert (tmp_path / "own.ini").is_file()
+        reread = ConsoleSettings(
+            QSettings(str(tmp_path / "own.ini"), QSettings.Format.IniFormat)
+        )
+        assert reread.last_experiment == "Bella"


### PR DESCRIPTION
## What

Wires the two remaining pieces of console session ergonomics: R4 presets stop being stubs, and the console remembers which experiment it was pointed at.

### A. Presets (R4) — a preset IS a saved `ScanRequest`

- **`PresetStore`** (`geecs_console/services/presets.py`), a new constructor-injectable seam: `list_names` / `load` / `save` / `delete` over one YAML file per preset at `scanner_configs/experiments/<Experiment>/presets/<name>.yaml` — beside the other per-experiment config kinds `ConfigsRepoResolver` reads. The document is a plain `model_dump(mode="json")` and loads back through `ScanRequest.model_validate`, so a preset file is just a scan request. Listing never raises (missing configs repo/dir → empty); load/save/delete raise `PresetStoreError` with a status-bar-ready message. Creating `presets/` with `mkdir(parents=True, exist_ok=True)` is deliberate — a config dir, not a `scans/ScanNNN/` folder, so the scan-folder invariant does not apply.
- **Save-as**: current form → `build_scan_request` → store, name via `QInputDialog` (overwrite allowed); combo repopulates and selects the new preset. Invalid forms and store errors surface in the status bar, and the name dialog never opens for an unbuildable form.
- **Apply**: selected preset → **`form_state_from_request`** — the new pure inverse of `build_scan_request`, next to it in `request_builder.py`, widgets kept out — then `_apply_form_state`, which validates everything the widgets cannot express *before* touching any of them. Optimize presets, action bindings, explicit position lists, and >2 axes give a clear status-bar error with the form untouched; preset save-set names missing from the experiment's configs are skipped with a warning.
- **Delete**: a new `r4_delete_button` beside Save-as removes the selected preset.
- The combo repopulates on experiment change (the store follows the experiment) and after save/delete.

### B. Last-experiment memory

- **`ConsoleSettings`** (`geecs_console/services/settings.py`): a tiny QSettings-backed helper (`GEECS` / `GEECS-Console`, INI format so tests can redirect the user scope) — one property so far, deliberately not a framework. The window records every experiment change and restores the remembered experiment at startup only when nothing was selected explicitly and the name is still in the combo; restoring fires the normal experiment-changed path, so configs, presets, the health probe, and the device panel all reopen pointed at it.

### Tests

166 pass offscreen (was 122), exit 0 across repeated runs. New coverage: `PresetStore` round-trips against `tmp_path` (save/load/list/delete, `.yml` twins, overwrite, missing dir/repo/experiment, invalid YAML, non-mapping docs, schema-rejected docs, bad names); form→request→form round-trip equality for noscan/background/1D/grid/position-list/step-with-background plus YAML-serialization parity, and `ConsoleFormError` for optimize/action-bindings; window-level save-as (monkeypatched `QInputDialog`), apply (populates the form and rebuilds an equal request), untouched-form error paths, delete, per-experiment combo repopulation, and last-experiment restore (injected fake settings + real QSettings isolated to a per-test tmp path via a new autouse conftest fixture).

### Ship

`geecs-console` 0.3.0 → 0.4.0, CHANGELOG entry, CLAUDE.md moved presets out of "Stubbed seams" into "Implemented seams" and documented both new seams.

🤖 Generated with [Claude Code](https://claude.com/claude-code)