### PR TITLE
GEECS-Console: ScanVariableEditor (M5)

### DIFF
--- a/GEECS-Console/geecs_console/app/ui/scan_variable_editor.ui
+++ b/GEECS-Console/geecs_console/app/ui/scan_variable_editor.ui
@@ -1,0 +1,405 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>ScanVariableEditorRoot</class>
+ <widget class="QWidget" name="ScanVariableEditorRoot">
+  <property name="windowTitle">
+   <string>Scan Variables</string>
+  </property>
+  <layout class="QVBoxLayout" name="sve_root_layout">
+   <property name="leftMargin">
+    <number>10</number>
+   </property>
+   <property name="topMargin">
+    <number>10</number>
+   </property>
+   <property name="rightMargin">
+    <number>10</number>
+   </property>
+   <property name="bottomMargin">
+    <number>10</number>
+   </property>
+   <property name="spacing">
+    <number>8</number>
+   </property>
+   <item>
+    <layout class="QHBoxLayout" name="sve_columns_layout" stretch="30,70">
+     <property name="spacing">
+      <number>10</number>
+     </property>
+     <!-- Left: the variable list -->
+     <item>
+      <widget class="QGroupBox" name="sve_list_group">
+       <property name="title">
+        <string>VARIABLES</string>
+       </property>
+       <layout class="QVBoxLayout" name="sve_list_layout">
+        <property name="spacing">
+         <number>8</number>
+        </property>
+        <item>
+         <widget class="QListWidget" name="sve_variable_list"/>
+        </item>
+        <item>
+         <layout class="QHBoxLayout" name="sve_new_buttons_layout">
+          <item>
+           <widget class="QPushButton" name="sve_new_simple_button">
+            <property name="text">
+             <string>New</string>
+            </property>
+            <property name="toolTip">
+             <string>Add a simple variable (one device variable)</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QPushButton" name="sve_new_pseudo_button">
+            <property name="text">
+             <string>New composite</string>
+            </property>
+            <property name="toolTip">
+             <string>Add a composite (pseudo) variable moving several devices from one number</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </item>
+        <item>
+         <layout class="QHBoxLayout" name="sve_edit_buttons_layout">
+          <item>
+           <widget class="QPushButton" name="sve_duplicate_button">
+            <property name="text">
+             <string>Duplicate</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QPushButton" name="sve_rename_button">
+            <property name="text">
+             <string>Rename…</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QPushButton" name="sve_delete_button">
+            <property name="text">
+             <string>Delete</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </item>
+       </layout>
+      </widget>
+     </item>
+     <!-- Right: the form pane -->
+     <item>
+      <widget class="QGroupBox" name="sve_form_group">
+       <property name="title">
+        <string>DEFINITION</string>
+       </property>
+       <layout class="QVBoxLayout" name="sve_form_layout">
+        <property name="spacing">
+         <number>8</number>
+        </property>
+        <item>
+         <widget class="QLabel" name="sve_type_label">
+          <property name="text">
+           <string/>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QStackedWidget" name="sve_form_stack">
+          <widget class="QWidget" name="sve_empty_page">
+           <layout class="QVBoxLayout" name="sve_empty_layout">
+            <item>
+             <widget class="QLabel" name="sve_empty_label">
+              <property name="text">
+               <string>No variable selected — add one with New or New composite.</string>
+              </property>
+              <property name="alignment">
+               <set>Qt::AlignCenter</set>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </widget>
+          <widget class="QWidget" name="sve_simple_page">
+           <layout class="QGridLayout" name="sve_simple_grid">
+            <property name="verticalSpacing">
+             <number>8</number>
+            </property>
+            <item row="0" column="0">
+             <widget class="QLabel" name="sve_device_label">
+              <property name="text">
+               <string>Device</string>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="1">
+             <widget class="QLineEdit" name="sve_device_edit">
+              <property name="placeholderText">
+               <string>e.g. U_ESP_JetXYZ</string>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="2">
+             <widget class="QLabel" name="sve_variable_label">
+              <property name="text">
+               <string>Variable</string>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="3">
+             <widget class="QLineEdit" name="sve_variable_edit">
+              <property name="placeholderText">
+               <string>e.g. Position.Axis 3</string>
+              </property>
+             </widget>
+            </item>
+            <item row="1" column="0">
+             <widget class="QLabel" name="sve_kind_label">
+              <property name="text">
+               <string>Kind</string>
+              </property>
+             </widget>
+            </item>
+            <item row="1" column="1">
+             <widget class="QComboBox" name="sve_kind_combo">
+              <property name="toolTip">
+               <string>setpoint = write and wait for the device to accept it; motor = additionally poll the readback until arrival (real positioners)</string>
+              </property>
+             </widget>
+            </item>
+            <item row="2" column="0">
+             <widget class="QLabel" name="sve_confirm_device_label">
+              <property name="text">
+               <string>Confirm device</string>
+              </property>
+             </widget>
+            </item>
+            <item row="2" column="1">
+             <widget class="QLineEdit" name="sve_confirm_device_edit">
+              <property name="placeholderText">
+               <string>optional</string>
+              </property>
+             </widget>
+            </item>
+            <item row="2" column="2">
+             <widget class="QLabel" name="sve_confirm_variable_label">
+              <property name="text">
+               <string>Confirm variable</string>
+              </property>
+             </widget>
+            </item>
+            <item row="2" column="3">
+             <widget class="QLineEdit" name="sve_confirm_variable_edit">
+              <property name="placeholderText">
+               <string>optional</string>
+              </property>
+             </widget>
+            </item>
+            <item row="3" column="0" colspan="4">
+             <widget class="QLabel" name="sve_confirm_hint_label">
+              <property name="text">
+               <string>Confirm: the variable that measures the result when it differs from the one being set (e.g. set Current_Limit.Ch1, confirm Current.Ch1). Leave empty for the common case.</string>
+              </property>
+              <property name="wordWrap">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+            <item row="4" column="0" colspan="4">
+             <spacer name="sve_simple_spacer">
+              <property name="orientation">
+               <enum>Qt::Vertical</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>10</width>
+                <height>10</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+           </layout>
+          </widget>
+          <widget class="QWidget" name="sve_pseudo_page">
+           <layout class="QVBoxLayout" name="sve_pseudo_layout">
+            <property name="spacing">
+             <number>8</number>
+            </property>
+            <item>
+             <layout class="QHBoxLayout" name="sve_mode_layout">
+              <item>
+               <widget class="QLabel" name="sve_mode_label">
+                <property name="text">
+                 <string>Mode</string>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QComboBox" name="sve_mode_combo"/>
+              </item>
+              <item>
+               <widget class="QLabel" name="sve_mode_hint_label">
+                <property name="text">
+                 <string/>
+                </property>
+                <property name="wordWrap">
+                 <bool>true</bool>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </item>
+            <item>
+             <widget class="QTableWidget" name="sve_components_table">
+              <property name="columnCount">
+               <number>3</number>
+              </property>
+              <attribute name="horizontalHeaderStretchLastSection">
+               <bool>true</bool>
+              </attribute>
+              <column>
+               <property name="text">
+                <string>Device</string>
+               </property>
+              </column>
+              <column>
+               <property name="text">
+                <string>Variable</string>
+               </property>
+              </column>
+              <column>
+               <property name="text">
+                <string>Forward (of composite_var)</string>
+               </property>
+              </column>
+             </widget>
+            </item>
+            <item>
+             <layout class="QHBoxLayout" name="sve_component_buttons_layout">
+              <item>
+               <widget class="QPushButton" name="sve_add_component_button">
+                <property name="text">
+                 <string>Add component</string>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QPushButton" name="sve_remove_component_button">
+                <property name="text">
+                 <string>Remove component</string>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <spacer name="sve_component_spacer">
+                <property name="orientation">
+                 <enum>Qt::Horizontal</enum>
+                </property>
+                <property name="sizeHint" stdset="0">
+                 <size>
+                  <width>10</width>
+                  <height>10</height>
+                 </size>
+                </property>
+               </spacer>
+              </item>
+             </layout>
+            </item>
+            <item>
+             <layout class="QHBoxLayout" name="sve_inverse_layout">
+              <item>
+               <widget class="QLabel" name="sve_inverse_label">
+                <property name="text">
+                 <string>Inverse</string>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QLineEdit" name="sve_inverse_edit">
+                <property name="placeholderText">
+                 <string>optional — recover the scanned number from the first target's readback</string>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </item>
+           </layout>
+          </widget>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLabel" name="sve_error_label">
+          <property name="text">
+           <string/>
+          </property>
+          <property name="wordWrap">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <!-- Bottom: dirty indicator + Save / Revert / Close -->
+   <item>
+    <layout class="QHBoxLayout" name="sve_bottom_layout">
+     <property name="spacing">
+      <number>8</number>
+     </property>
+     <item>
+      <widget class="QLabel" name="sve_dirty_label">
+       <property name="text">
+        <string/>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="sve_bottom_spacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QPushButton" name="sve_revert_button">
+       <property name="text">
+        <string>Revert</string>
+       </property>
+       <property name="toolTip">
+        <string>Discard edits and reload the catalog from disk</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="sve_save_button">
+       <property name="text">
+        <string>Save</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="sve_close_button">
+       <property name="text">
+        <string>Close</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/GEECS-Console/geecs_console/editors/__init__.py
+++ b/GEECS-Console/geecs_console/editors/__init__.py
@@ -1,0 +1,1 @@
+"""Editor dialogs for the configs the console submits by name (M5)."""

--- a/GEECS-Console/geecs_console/editors/scan_variable_editor.py
+++ b/GEECS-Console/geecs_console/editors/scan_variable_editor.py
@@ -1,0 +1,1012 @@
+"""The scan-variable editor (M5): edit one experiment's catalog of scan variables.
+
+One modeless :class:`ScanVariableEditor` dialog edits the whole
+:class:`~geecs_schemas.ScanVariables` document —
+``scan_devices/scan_variables.yaml`` — through
+:class:`~geecs_console.services.scan_variable_store.ScanVariableStore`.
+The left pane lists every variable with a *simple* / *composite* type tag;
+the right pane is a form derived from the actual schema models:
+
+- **Simple** (:class:`~geecs_schemas.ScanVariable`): device + variable (the
+  ``target``), the ``kind`` (setpoint / motor), and the optional ``confirm``
+  target for set-one-measure-another devices.
+- **Composite** (:class:`~geecs_schemas.PseudoScanVariable`, ``kind:
+  pseudo``): the ``mode`` (absolute / relative — the forward column header
+  and hint re-label to match), an editable components table (device,
+  variable, ``forward`` expression in terms of ``composite_var``), and the
+  optional ``inverse`` readback formula.
+
+Edits accumulate in an in-memory draft of plain dicts (so *invalid
+intermediate* states are representable while typing); Save validates the
+whole draft through ``ScanVariables.model_validate`` and writes via the
+store — pydantic errors are shown inline in the error label, never a crash.
+Revert reloads from disk; closing with unsaved changes prompts first.
+
+Ergonomics: device and variable fields carry ``QCompleter`` popups fed by an
+injectable :class:`~geecs_console.services.device_completions.
+CompletionsProvider` — fetched once on a short-lived daemon thread (the
+package's no-QThread rule) and marshaled back through a queued signal, so a
+slow DB never blocks the GUI.  Enter never accepts the dialog (no default
+buttons; Return/Enter are swallowed) — it must be safe to hit Enter after
+typing in a field.
+
+The later integration PR wires the Editors menu to
+:func:`open_scan_variable_editor`; nothing here imports the main window.
+"""
+
+from __future__ import annotations
+
+import copy
+import logging
+import threading
+from pathlib import Path
+from typing import Any, Callable, Optional
+
+from pydantic import ValidationError
+from PySide6.QtCore import QFile, QStringListModel, Qt, Signal, Slot
+from PySide6.QtGui import QCloseEvent, QKeyEvent
+from PySide6.QtWidgets import (
+    QComboBox,
+    QCompleter,
+    QDialog,
+    QInputDialog,
+    QLabel,
+    QLineEdit,
+    QListWidget,
+    QListWidgetItem,
+    QMessageBox,
+    QPushButton,
+    QStackedWidget,
+    QTableWidget,
+    QVBoxLayout,
+    QWidget,
+)
+from PySide6.QtUiTools import QUiLoader
+
+from geecs_console.services.device_completions import (
+    CompletionsProvider,
+    EmptyCompletions,
+    GeecsDbCompletions,
+)
+from geecs_console.services.scan_variable_store import (
+    ScanVariableStore,
+    ScanVariableStoreError,
+)
+from geecs_schemas import CompositeMode, ScanVariables
+
+logger = logging.getLogger(__name__)
+
+_UI_PATH = Path(__file__).parent.parent / "app" / "ui" / "scan_variable_editor.ui"
+
+#: The two simple-variable kinds, in combo order (schema Literal values).
+_SIMPLE_KINDS = ("setpoint", "motor")
+
+#: Composite modes in combo order (schema enum values).
+_COMPOSITE_MODES = tuple(mode.value for mode in CompositeMode)
+
+#: Per-mode forward-column header + hint (the abs/rel labeling the schema
+#: semantics make relevant).
+_MODE_LABELS = {
+    "absolute": (
+        "Forward → absolute value",
+        "absolute: each device goes exactly where its formula says.",
+    ),
+    "relative": (
+        "Forward → offset from scan start",
+        "relative: each device is offset from where it was at scan start.",
+    ),
+}
+
+#: Union branch tags in pydantic error locations, per draft shape — used to
+#: drop the *other* branch's noise from smart-union validation errors.
+_BRANCH_TAGS = {"ScanVariable", "PseudoScanVariable"}
+
+
+def _split_target(target: str) -> tuple[str, str]:
+    """Split a ``Device:Variable`` string on its first colon.
+
+    Parameters
+    ----------
+    target : str
+        The stored target string (possibly empty or malformed).
+
+    Returns
+    -------
+    tuple of str
+        ``(device, variable)`` — the variable part keeps any further colons.
+    """
+    device, _, variable = target.partition(":")
+    return device, variable
+
+
+def _join_target(device: str, variable: str) -> str:
+    """Join device/variable form fields back into a ``Device:Variable`` string.
+
+    Parameters
+    ----------
+    device : str
+        The device field text (stripped).
+    variable : str
+        The variable field text (stripped).
+
+    Returns
+    -------
+    str
+        ``"Device:Variable"``, or ``""`` when both fields are empty (so an
+        untouched pair reads as "unset" rather than a bare colon).
+    """
+    if not device and not variable:
+        return ""
+    return f"{device}:{variable}"
+
+
+def _format_validation_error(exc: ValidationError, drafts: dict[str, dict]) -> str:
+    """Render a pydantic error compactly for the inline error label.
+
+    Parameters
+    ----------
+    exc : ValidationError
+        The error ``ScanVariables.model_validate`` raised over the draft.
+    drafts : dict
+        The draft variables (name → field dict) — used to drop the smart
+        union's *other-branch* noise: a composite draft only shows
+        ``PseudoScanVariable`` branch errors and vice versa.
+
+    Returns
+    -------
+    str
+        One ``variables → name → field: message`` line per relevant error,
+        capped at eight lines.
+    """
+    lines: list[str] = []
+    for error in exc.errors():
+        loc = [str(part) for part in error["loc"]]
+        if len(loc) >= 2 and loc[0] == "variables":
+            name = loc[1]
+            is_pseudo = (drafts.get(name) or {}).get("kind") == "pseudo"
+            wanted = "PseudoScanVariable" if is_pseudo else "ScanVariable"
+            other = _BRANCH_TAGS - {wanted}
+            if any(tag in loc for tag in other):
+                continue
+        display = [part for part in loc if part not in _BRANCH_TAGS]
+        line = f"{' → '.join(display)}: {error['msg']}"
+        if line not in lines:
+            lines.append(line)
+    if not lines:  # every branch filtered — fall back to the raw first error
+        first = exc.errors()[0]
+        lines = [f"{' → '.join(str(p) for p in first['loc'])}: {first['msg']}"]
+    shown = lines[:8]
+    if len(lines) > len(shown):
+        shown.append(f"… and {len(lines) - len(shown)} more")
+    return "\n".join(shown)
+
+
+class ScanVariableEditor(QDialog):
+    """Editor dialog for one experiment's scan-variable catalog.
+
+    Parameters
+    ----------
+    store : ScanVariableStore
+        Catalog persistence; tests inject one rooted at a tmp dir.
+    completions : CompletionsProvider, optional
+        Device/variable completion source; default is
+        :class:`~geecs_console.services.device_completions.EmptyCompletions`
+        (no suggestions — offline/test default).  The provider's one blocking
+        call runs on a daemon thread, never the GUI thread.
+    parent : QWidget, optional
+        Parent widget (the main window in production).
+    """
+
+    #: The provider's ``{device: [variable, ...]}`` result (emitted from the
+    #: fetch daemon thread; delivered queued to :meth:`_apply_completions`).
+    completions_ready = Signal(object)
+
+    def __init__(
+        self,
+        store: ScanVariableStore,
+        completions: Optional[CompletionsProvider] = None,
+        parent: Optional[QWidget] = None,
+    ) -> None:
+        super().__init__(parent)
+        self._store = store
+        self._completions = (
+            completions if completions is not None else EmptyCompletions()
+        )
+        #: name → plain field dict (a ScanVariableSpec dump; invalid
+        #: intermediate states are representable while the operator types).
+        self._variables: dict[str, dict] = {}
+        self._snapshot: dict[str, dict] = {}
+        self._schema_version = 1
+        self._current_name: Optional[str] = None
+        self._loading = False
+        self._device_vars: dict[str, list[str]] = {}
+        #: True once the (async) completions fetch has been delivered on the
+        #: GUI thread — tests wait on this so no queued signal can land
+        #: during teardown.
+        self.completions_applied = False
+
+        #: Test seams: ask for a name (rename/duplicate/new) and confirm
+        #: discarding unsaved changes.  Defaults are the modal Qt dialogs.
+        self._ask_name: Callable[[str, str, str], Optional[str]] = self._ask_name_modal
+        self._confirm_discard: Callable[[], bool] = self._confirm_discard_modal
+
+        self._load_ui()
+        self._bind_widgets()
+        self._populate_static_combos()
+        self._build_completers()
+        self._wire_signals()
+        self._disable_enter_accept()
+
+        self.setWindowTitle(
+            f"Scan Variables — {store.experiment}"
+            if store.experiment
+            else "Scan Variables"
+        )
+
+        self._reload_from_store(initial=True)
+
+        self.completions_ready.connect(
+            self._apply_completions, Qt.ConnectionType.QueuedConnection
+        )
+        self._start_completions_fetch()
+
+    # ------------------------------------------------------------------
+    # Construction
+    # ------------------------------------------------------------------
+
+    def _load_ui(self) -> None:
+        """Load the hand-authored .ui as this dialog's only child."""
+        loader = QUiLoader()
+        ui_file = QFile(str(_UI_PATH))
+        ui_file.open(QFile.OpenModeFlag.ReadOnly)
+        try:
+            self._ui: QWidget = loader.load(ui_file, self)
+        finally:
+            ui_file.close()
+        if self._ui is None:
+            raise RuntimeError(f"Failed to load {_UI_PATH}: {loader.errorString()}")
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.addWidget(self._ui)
+        self.resize(900, 560)
+
+    def _child(self, cls: type, name: str) -> Any:
+        """Return the named child widget, failing loudly when missing.
+
+        Parameters
+        ----------
+        cls : type
+            Expected widget class.
+        name : str
+            The ``sve_``-prefixed object name in the .ui.
+
+        Returns
+        -------
+        QWidget
+            The resolved child.
+
+        Raises
+        ------
+        LookupError
+            When the .ui does not contain the widget.
+        """
+        widget = self._ui.findChild(cls, name)
+        if widget is None:
+            raise LookupError(f"{name!r} ({cls.__name__}) not found in {_UI_PATH}")
+        return widget
+
+    def _bind_widgets(self) -> None:
+        """Resolve every wired widget from the loaded .ui once."""
+        self.variable_list: QListWidget = self._child(QListWidget, "sve_variable_list")
+        self.new_simple_button: QPushButton = self._child(
+            QPushButton, "sve_new_simple_button"
+        )
+        self.new_pseudo_button: QPushButton = self._child(
+            QPushButton, "sve_new_pseudo_button"
+        )
+        self.duplicate_button: QPushButton = self._child(
+            QPushButton, "sve_duplicate_button"
+        )
+        self.rename_button: QPushButton = self._child(QPushButton, "sve_rename_button")
+        self.delete_button: QPushButton = self._child(QPushButton, "sve_delete_button")
+
+        self.type_label: QLabel = self._child(QLabel, "sve_type_label")
+        self.form_stack: QStackedWidget = self._child(QStackedWidget, "sve_form_stack")
+        self.empty_page: QWidget = self._child(QWidget, "sve_empty_page")
+        self.simple_page: QWidget = self._child(QWidget, "sve_simple_page")
+        self.pseudo_page: QWidget = self._child(QWidget, "sve_pseudo_page")
+
+        self.device_edit: QLineEdit = self._child(QLineEdit, "sve_device_edit")
+        self.variable_edit: QLineEdit = self._child(QLineEdit, "sve_variable_edit")
+        self.kind_combo: QComboBox = self._child(QComboBox, "sve_kind_combo")
+        self.confirm_device_edit: QLineEdit = self._child(
+            QLineEdit, "sve_confirm_device_edit"
+        )
+        self.confirm_variable_edit: QLineEdit = self._child(
+            QLineEdit, "sve_confirm_variable_edit"
+        )
+
+        self.mode_combo: QComboBox = self._child(QComboBox, "sve_mode_combo")
+        self.mode_hint_label: QLabel = self._child(QLabel, "sve_mode_hint_label")
+        self.components_table: QTableWidget = self._child(
+            QTableWidget, "sve_components_table"
+        )
+        self.add_component_button: QPushButton = self._child(
+            QPushButton, "sve_add_component_button"
+        )
+        self.remove_component_button: QPushButton = self._child(
+            QPushButton, "sve_remove_component_button"
+        )
+        self.inverse_edit: QLineEdit = self._child(QLineEdit, "sve_inverse_edit")
+
+        self.error_label: QLabel = self._child(QLabel, "sve_error_label")
+        self.dirty_label: QLabel = self._child(QLabel, "sve_dirty_label")
+        self.revert_button: QPushButton = self._child(QPushButton, "sve_revert_button")
+        self.save_button: QPushButton = self._child(QPushButton, "sve_save_button")
+        self.close_button: QPushButton = self._child(QPushButton, "sve_close_button")
+
+    def _populate_static_combos(self) -> None:
+        """Fill the kind and mode combos from the schema vocabularies."""
+        self.kind_combo.addItems(list(_SIMPLE_KINDS))
+        self.mode_combo.addItems(list(_COMPOSITE_MODES))
+
+    def _build_completers(self) -> None:
+        """Attach device/variable completers (models filled when the fetch lands)."""
+        #: One shared device-name model; each field gets its own QCompleter
+        #: (a completer binds to a single widget) over this model.
+        self._device_model = QStringListModel(self)
+        for edit in (self.device_edit, self.confirm_device_edit):
+            edit.setCompleter(self._make_completer(self._device_model))
+        #: Variable models are per-field — the word list follows the paired
+        #: device field's text.
+        self._variable_model = QStringListModel(self)
+        self.variable_edit.setCompleter(self._make_completer(self._variable_model))
+        self._confirm_variable_model = QStringListModel(self)
+        self.confirm_variable_edit.setCompleter(
+            self._make_completer(self._confirm_variable_model)
+        )
+
+    def _make_completer(self, model: Any) -> QCompleter:
+        """Build one case-insensitive, contains-matching completer over *model*.
+
+        Parameters
+        ----------
+        model : QStringListModel
+            The word-list model the completer reads.
+
+        Returns
+        -------
+        QCompleter
+            Ready to hand to ``QLineEdit.setCompleter``.
+        """
+        completer = QCompleter(model, self)
+        completer.setCaseSensitivity(Qt.CaseSensitivity.CaseInsensitive)
+        completer.setFilterMode(Qt.MatchFlag.MatchContains)
+        return completer
+
+    def _wire_signals(self) -> None:
+        """Connect widgets to handlers."""
+        self.variable_list.currentItemChanged.connect(self._on_selection_changed)
+        self.new_simple_button.clicked.connect(self._on_new_simple)
+        self.new_pseudo_button.clicked.connect(self._on_new_pseudo)
+        self.duplicate_button.clicked.connect(self._on_duplicate)
+        self.rename_button.clicked.connect(self._on_rename)
+        self.delete_button.clicked.connect(self._on_delete)
+
+        for edit in (
+            self.device_edit,
+            self.variable_edit,
+            self.confirm_device_edit,
+            self.confirm_variable_edit,
+            self.inverse_edit,
+        ):
+            edit.textChanged.connect(self._on_form_edited)
+        self.kind_combo.currentIndexChanged.connect(self._on_form_edited)
+        self.mode_combo.currentIndexChanged.connect(self._on_mode_changed)
+
+        self.add_component_button.clicked.connect(self._on_add_component)
+        self.remove_component_button.clicked.connect(self._on_remove_component)
+
+        self.device_edit.textChanged.connect(
+            lambda text: self._refresh_variable_model(self._variable_model, text)
+        )
+        self.confirm_device_edit.textChanged.connect(
+            lambda text: self._refresh_variable_model(
+                self._confirm_variable_model, text
+            )
+        )
+
+        self.revert_button.clicked.connect(self._on_revert)
+        self.save_button.clicked.connect(self._on_save)
+        self.close_button.clicked.connect(self.close)
+
+    def _disable_enter_accept(self) -> None:
+        """Ensure Enter never accepts the dialog (no default/auto-default buttons)."""
+        for button in self.findChildren(QPushButton):
+            button.setAutoDefault(False)
+            button.setDefault(False)
+
+    # ------------------------------------------------------------------
+    # Modal seams (overridable in tests)
+    # ------------------------------------------------------------------
+
+    def _ask_name_modal(self, title: str, label: str, initial: str) -> Optional[str]:
+        """Ask for a variable name with a modal input dialog.
+
+        Parameters
+        ----------
+        title : str
+            Dialog window title.
+        label : str
+            Prompt text.
+        initial : str
+            Prefilled name.
+
+        Returns
+        -------
+        str or None
+            The entered name, or ``None`` on cancel.
+        """
+        name, accepted = QInputDialog.getText(self, title, label, text=initial)
+        return name if accepted else None
+
+    def _confirm_discard_modal(self) -> bool:
+        """Ask whether to discard unsaved changes (modal).
+
+        Returns
+        -------
+        bool
+            True to discard and proceed, False to stay.
+        """
+        answer = QMessageBox.question(
+            self,
+            "Unsaved changes",
+            "The scan-variable catalog has unsaved changes. Discard them?",
+            QMessageBox.StandardButton.Discard | QMessageBox.StandardButton.Cancel,
+            QMessageBox.StandardButton.Cancel,
+        )
+        return answer == QMessageBox.StandardButton.Discard
+
+    # ------------------------------------------------------------------
+    # Catalog <-> draft
+    # ------------------------------------------------------------------
+
+    def _reload_from_store(self, initial: bool = False) -> None:
+        """Load the catalog from disk into the draft and repopulate.
+
+        Parameters
+        ----------
+        initial : bool, optional
+            True on construction — a load failure then leaves an empty,
+            usable editor with the error shown inline (never a crash).
+        """
+        try:
+            catalog = self._store.load()
+        except ScanVariableStoreError as exc:
+            if not initial:
+                raise
+            logger.warning("scan-variable catalog failed to load: %s", exc)
+            catalog = ScanVariables(variables={})
+            self._show_error(str(exc))
+        else:
+            self._clear_error()
+        self._schema_version = catalog.schema_version
+        self._variables = {
+            name: spec.model_dump(mode="json", exclude_none=True)
+            for name, spec in catalog.variables.items()
+        }
+        self._snapshot = copy.deepcopy(self._variables)
+        self._refresh_list(select=next(iter(self._variables), None))
+        self._update_dirty()
+
+    def _draft_catalog(self) -> ScanVariables:
+        """Validate the current draft as a :class:`ScanVariables` document.
+
+        Returns
+        -------
+        ScanVariables
+            The validated catalog.
+
+        Raises
+        ------
+        pydantic.ValidationError
+            When any draft entry does not satisfy the schema.
+        """
+        return ScanVariables.model_validate(
+            {"schema_version": self._schema_version, "variables": self._variables}
+        )
+
+    @property
+    def dirty(self) -> bool:
+        """Whether the draft differs from what was last loaded/saved."""
+        return self._variables != self._snapshot
+
+    # ------------------------------------------------------------------
+    # List handling
+    # ------------------------------------------------------------------
+
+    def _refresh_list(self, select: Optional[str]) -> None:
+        """Rebuild the variable list from the draft, selecting *select*.
+
+        Parameters
+        ----------
+        select : str or None
+            Variable name to select after the rebuild (None clears the form).
+        """
+        self._loading = True
+        try:
+            self.variable_list.clear()
+            for name, draft in self._variables.items():
+                kind = "composite" if draft.get("kind") == "pseudo" else "simple"
+                item = QListWidgetItem(f"{name}    [{kind}]")
+                item.setData(Qt.ItemDataRole.UserRole, name)
+                self.variable_list.addItem(item)
+        finally:
+            self._loading = False
+        if select is not None:
+            for row in range(self.variable_list.count()):
+                item = self.variable_list.item(row)
+                if item.data(Qt.ItemDataRole.UserRole) == select:
+                    self.variable_list.setCurrentItem(item)
+                    return
+        self.variable_list.setCurrentItem(None)
+        self._populate_form(None)
+
+    def _on_selection_changed(
+        self, current: Optional[QListWidgetItem], _previous: Optional[QListWidgetItem]
+    ) -> None:
+        """Populate the form for the newly selected variable."""
+        if self._loading:
+            return
+        name = current.data(Qt.ItemDataRole.UserRole) if current is not None else None
+        self._populate_form(name)
+
+    def _unique_name(self, base: str) -> str:
+        """Return *base*, suffixed with a counter when the name is taken.
+
+        Parameters
+        ----------
+        base : str
+            The wanted name.
+
+        Returns
+        -------
+        str
+            ``base``, or ``base_2`` / ``base_3`` / … — first free.
+        """
+        if base not in self._variables:
+            return base
+        counter = 2
+        while f"{base}_{counter}" in self._variables:
+            counter += 1
+        return f"{base}_{counter}"
+
+    def _on_new_simple(self) -> None:
+        """Add a fresh simple variable and select it."""
+        name = self._unique_name("new_variable")
+        self._variables[name] = {"target": "", "kind": "setpoint"}
+        self._refresh_list(select=name)
+        self._update_dirty()
+
+    def _on_new_pseudo(self) -> None:
+        """Add a fresh composite (pseudo) variable and select it."""
+        name = self._unique_name("new_composite")
+        self._variables[name] = {
+            "kind": "pseudo",
+            "targets": [{"target": "", "forward": ""}],
+            "mode": "absolute",
+        }
+        self._refresh_list(select=name)
+        self._update_dirty()
+
+    def _on_duplicate(self) -> None:
+        """Duplicate the selected variable under a fresh name."""
+        if self._current_name is None:
+            return
+        name = self._unique_name(f"{self._current_name}_copy")
+        self._variables[name] = copy.deepcopy(self._variables[self._current_name])
+        self._refresh_list(select=name)
+        self._update_dirty()
+
+    def _on_rename(self) -> None:
+        """Rename the selected variable (order-preserving), rejecting collisions."""
+        old = self._current_name
+        if old is None:
+            return
+        new = self._ask_name("Rename scan variable", "New name:", old)
+        if new is None:
+            return
+        new = new.strip()
+        if not new or new == old:
+            return
+        if new in self._variables:
+            self._show_error(f"A variable named {new!r} already exists.")
+            return
+        self._variables = {
+            (new if name == old else name): draft
+            for name, draft in self._variables.items()
+        }
+        self._refresh_list(select=new)
+        self._update_dirty()
+        self._clear_error()
+
+    def _on_delete(self) -> None:
+        """Delete the selected variable from the draft (persisted on Save)."""
+        if self._current_name is None:
+            return
+        names = list(self._variables)
+        index = names.index(self._current_name)
+        del self._variables[self._current_name]
+        remaining = list(self._variables)
+        select = remaining[min(index, len(remaining) - 1)] if remaining else None
+        self._refresh_list(select=select)
+        self._update_dirty()
+
+    # ------------------------------------------------------------------
+    # Form handling
+    # ------------------------------------------------------------------
+
+    def _populate_form(self, name: Optional[str]) -> None:
+        """Fill the form pane from the draft entry *name* (None clears it).
+
+        Parameters
+        ----------
+        name : str or None
+            The variable to show; None shows the empty page.
+        """
+        self._current_name = name
+        has_selection = name is not None
+        for button in (self.duplicate_button, self.rename_button, self.delete_button):
+            button.setEnabled(has_selection)
+        if name is None:
+            self.form_stack.setCurrentWidget(self.empty_page)
+            self.type_label.setText("")
+            return
+        draft = self._variables[name]
+        self._loading = True
+        try:
+            if draft.get("kind") == "pseudo":
+                self.form_stack.setCurrentWidget(self.pseudo_page)
+                self.type_label.setText(
+                    "Composite (pseudo) variable — one number moves several devices"
+                )
+                mode = str(draft.get("mode", "absolute"))
+                index = self.mode_combo.findText(mode)
+                self.mode_combo.setCurrentIndex(index if index >= 0 else 0)
+                self.inverse_edit.setText(str(draft.get("inverse", "") or ""))
+                self._set_component_rows(draft.get("targets", []))
+                self._update_mode_labels()
+            else:
+                self.form_stack.setCurrentWidget(self.simple_page)
+                self.type_label.setText("Simple variable — one device variable")
+                device, variable = _split_target(str(draft.get("target", "")))
+                self.device_edit.setText(device)
+                self.variable_edit.setText(variable)
+                kind = str(draft.get("kind", "setpoint"))
+                index = self.kind_combo.findText(kind)
+                self.kind_combo.setCurrentIndex(index if index >= 0 else 0)
+                confirm_device, confirm_variable = _split_target(
+                    str(draft.get("confirm", "") or "")
+                )
+                self.confirm_device_edit.setText(confirm_device)
+                self.confirm_variable_edit.setText(confirm_variable)
+        finally:
+            self._loading = False
+
+    def _set_component_rows(self, targets: list[dict]) -> None:
+        """Rebuild the components table with one editable row per target.
+
+        Parameters
+        ----------
+        targets : list of dict
+            The draft's ``targets`` entries (``target`` + ``forward``).
+        """
+        self.components_table.setRowCount(0)
+        for entry in targets:
+            device, variable = _split_target(str(entry.get("target", "")))
+            self._append_component_row(device, variable, str(entry.get("forward", "")))
+
+    def _append_component_row(
+        self, device: str = "", variable: str = "", forward: str = ""
+    ) -> None:
+        """Append one component row of line-edit cell widgets.
+
+        Parameters
+        ----------
+        device : str, optional
+            Device cell text.
+        variable : str, optional
+            Variable cell text.
+        forward : str, optional
+            Forward-expression cell text.
+        """
+        row = self.components_table.rowCount()
+        self.components_table.insertRow(row)
+
+        device_edit = QLineEdit(device)
+        device_edit.setCompleter(self._make_completer(self._device_model))
+        variable_edit = QLineEdit(variable)
+        variable_model = QStringListModel(variable_edit)
+        variable_edit.setCompleter(self._make_completer(variable_model))
+        forward_edit = QLineEdit(forward)
+        forward_edit.setPlaceholderText("e.g. composite_var * -2")
+
+        self._refresh_variable_model(variable_model, device)
+        device_edit.textChanged.connect(
+            lambda text, model=variable_model: self._refresh_variable_model(model, text)
+        )
+        for edit in (device_edit, variable_edit, forward_edit):
+            edit.textChanged.connect(self._on_form_edited)
+
+        self.components_table.setCellWidget(row, 0, device_edit)
+        self.components_table.setCellWidget(row, 1, variable_edit)
+        self.components_table.setCellWidget(row, 2, forward_edit)
+
+    def _component_rows(self) -> list[dict]:
+        """Read the components table back into draft ``targets`` entries.
+
+        Returns
+        -------
+        list of dict
+            One ``{"target": ..., "forward": ...}`` per table row.
+        """
+        rows: list[dict] = []
+        for row in range(self.components_table.rowCount()):
+            device_edit = self.components_table.cellWidget(row, 0)
+            variable_edit = self.components_table.cellWidget(row, 1)
+            forward_edit = self.components_table.cellWidget(row, 2)
+            if device_edit is None or variable_edit is None or forward_edit is None:
+                continue
+            rows.append(
+                {
+                    "target": _join_target(
+                        device_edit.text().strip(), variable_edit.text().strip()
+                    ),
+                    "forward": forward_edit.text().strip(),
+                }
+            )
+        return rows
+
+    def _on_add_component(self) -> None:
+        """Append an empty component row and commit."""
+        if self._current_name is None:
+            return
+        self._append_component_row()
+        self._on_form_edited()
+
+    def _on_remove_component(self) -> None:
+        """Remove the selected (else last) component row and commit."""
+        if self._current_name is None:
+            return
+        count = self.components_table.rowCount()
+        if count == 0:
+            return
+        row = self.components_table.currentRow()
+        self.components_table.removeRow(row if 0 <= row < count else count - 1)
+        self._on_form_edited()
+
+    def _on_mode_changed(self) -> None:
+        """Re-label the forward column/hint for the new mode, then commit."""
+        self._update_mode_labels()
+        self._on_form_edited()
+
+    def _update_mode_labels(self) -> None:
+        """Point the forward-column header and hint at the current mode."""
+        header, hint = _MODE_LABELS.get(
+            self.mode_combo.currentText(), _MODE_LABELS["absolute"]
+        )
+        item = self.components_table.horizontalHeaderItem(2)
+        if item is not None:
+            item.setText(header)
+        self.mode_hint_label.setText(hint)
+
+    def _on_form_edited(self, *_args: object) -> None:
+        """Commit the visible form into the draft for the current variable."""
+        if self._loading or self._current_name is None:
+            return
+        draft = self._variables[self._current_name]
+        if draft.get("kind") == "pseudo":
+            draft["mode"] = self.mode_combo.currentText()
+            draft["targets"] = self._component_rows()
+            inverse = self.inverse_edit.text().strip()
+            if inverse:
+                draft["inverse"] = inverse
+            else:
+                draft.pop("inverse", None)
+        else:
+            draft["target"] = _join_target(
+                self.device_edit.text().strip(), self.variable_edit.text().strip()
+            )
+            draft["kind"] = self.kind_combo.currentText()
+            confirm = _join_target(
+                self.confirm_device_edit.text().strip(),
+                self.confirm_variable_edit.text().strip(),
+            )
+            if confirm:
+                draft["confirm"] = confirm
+            else:
+                draft.pop("confirm", None)
+        self._update_dirty()
+
+    # ------------------------------------------------------------------
+    # Save / Revert / dirty
+    # ------------------------------------------------------------------
+
+    def _on_save(self) -> None:
+        """Validate the draft and write it through the store (errors inline)."""
+        try:
+            catalog = self._draft_catalog()
+        except ValidationError as exc:
+            self._show_error(_format_validation_error(exc, self._variables))
+            return
+        try:
+            path = self._store.save(catalog)
+        except ScanVariableStoreError as exc:
+            self._show_error(str(exc))
+            return
+        self._snapshot = copy.deepcopy(self._variables)
+        self._update_dirty()
+        self._clear_error()
+        self.dirty_label.setText(f"saved → {path}")
+
+    def _on_revert(self) -> None:
+        """Discard the draft and reload the catalog from disk (prompted)."""
+        if self.dirty and not self._confirm_discard():
+            return
+        selected = self._current_name
+        self._reload_from_store()
+        if selected in self._variables:
+            self._refresh_list(select=selected)
+
+    def _update_dirty(self) -> None:
+        """Refresh the dirty indicator."""
+        self.dirty_label.setText("● unsaved changes" if self.dirty else "")
+
+    def _show_error(self, message: str) -> None:
+        """Show *message* inline in the error label.
+
+        Parameters
+        ----------
+        message : str
+            Status-bar-fit error text (may be multi-line).
+        """
+        self.error_label.setStyleSheet("color: #d9534f;")
+        self.error_label.setText(message)
+
+    def _clear_error(self) -> None:
+        """Clear the inline error label."""
+        self.error_label.setText("")
+
+    # ------------------------------------------------------------------
+    # Completions
+    # ------------------------------------------------------------------
+
+    def _start_completions_fetch(self) -> None:
+        """Fetch completions on a short-lived daemon thread (queued delivery)."""
+        provider = self._completions
+
+        def fetch() -> None:
+            """Run the provider's one blocking call off the GUI thread."""
+            try:
+                mapping = provider.device_variables()
+            except Exception as exc:  # noqa: BLE001 — providers should not raise
+                logger.info("completions fetch failed: %s", exc)
+                mapping = {}
+            self.completions_ready.emit(mapping)
+
+        threading.Thread(
+            target=fetch, name="sve-completions-fetch", daemon=True
+        ).start()
+
+    @Slot(object)
+    def _apply_completions(self, mapping: object) -> None:
+        """Install the fetched ``{device: [variable, ...]}`` word lists (GUI thread).
+
+        Parameters
+        ----------
+        mapping : dict
+            The provider result delivered by the queued signal.
+        """
+        self.completions_applied = True
+        if not isinstance(mapping, dict):
+            return
+        self._device_vars = {
+            str(device): [str(v) for v in variables]
+            for device, variables in mapping.items()
+        }
+        self._device_model.setStringList(sorted(self._device_vars))
+        self._refresh_variable_model(self._variable_model, self.device_edit.text())
+        self._refresh_variable_model(
+            self._confirm_variable_model, self.confirm_device_edit.text()
+        )
+        for row in range(self.components_table.rowCount()):
+            device_edit = self.components_table.cellWidget(row, 0)
+            variable_edit = self.components_table.cellWidget(row, 1)
+            if device_edit is None or variable_edit is None:
+                continue
+            completer = variable_edit.completer()
+            if completer is not None:
+                self._refresh_variable_model(completer.model(), device_edit.text())
+
+    def _refresh_variable_model(self, model: Any, device_text: str) -> None:
+        """Point one variable word-list *model* at the variables of *device_text*.
+
+        Parameters
+        ----------
+        model : QStringListModel
+            The variable completer's model.
+        device_text : str
+            The paired device field's current text (exact match wins, else a
+            unique case-insensitive match).
+        """
+        device = device_text.strip()
+        variables = self._device_vars.get(device)
+        if variables is None and device:
+            matches = [
+                known for known in self._device_vars if known.lower() == device.lower()
+            ]
+            if len(matches) == 1:
+                variables = self._device_vars[matches[0]]
+        model.setStringList(variables or [])
+
+    # ------------------------------------------------------------------
+    # Close paths (Enter never accepts; unsaved changes prompt)
+    # ------------------------------------------------------------------
+
+    def keyPressEvent(self, event: QKeyEvent) -> None:  # noqa: N802 (Qt override)
+        """Swallow Return/Enter so typing in a field never closes the dialog."""
+        if event.key() in (Qt.Key.Key_Return, Qt.Key.Key_Enter):
+            event.accept()
+            return
+        super().keyPressEvent(event)
+
+    def reject(self) -> None:
+        """Route Esc through the unsaved-changes prompt."""
+        if self.dirty and not self._confirm_discard():
+            return
+        super().reject()
+
+    def closeEvent(self, event: QCloseEvent) -> None:  # noqa: N802 (Qt override)
+        """Prompt before closing with unsaved changes."""
+        if self.dirty and not self._confirm_discard():
+            event.ignore()
+            return
+        event.accept()
+
+
+def open_scan_variable_editor(
+    parent: Optional[QWidget],
+    experiment: str,
+    configs_base: str | Path | None = None,
+    completions: Optional[CompletionsProvider] = None,
+) -> QDialog:
+    """Open the scan-variable editor for *experiment* (the Editors-menu entry).
+
+    Parameters
+    ----------
+    parent : QWidget or None
+        Parent widget (the main window in production).
+    experiment : str
+        Experiment folder under ``scanner_configs/experiments`` ("" opens an
+        empty, offline editor).
+    configs_base : str or Path, optional
+        Override for the experiments root (tests point this at a tmp dir);
+        defaults to the production resolution.
+    completions : CompletionsProvider, optional
+        Device/variable completion source.  Defaults to the DB-backed
+        provider for a named experiment (fetched on a daemon thread; offline
+        it degrades to empty) and to no completions otherwise.
+
+    Returns
+    -------
+    QDialog
+        The shown (modeless) editor dialog.
+    """
+    store = ScanVariableStore(experiment, experiments_root=configs_base)
+    if completions is None:
+        completions = (
+            GeecsDbCompletions(experiment) if experiment else EmptyCompletions()
+        )
+    dialog = ScanVariableEditor(store=store, completions=completions, parent=parent)
+    dialog.show()
+    return dialog

--- a/GEECS-Console/geecs_console/services/device_completions.py
+++ b/GEECS-Console/geecs_console/services/device_completions.py
@@ -1,0 +1,90 @@
+"""Device/variable completion source for editor forms (offline-safe).
+
+The scan-variable editor's device and variable fields carry ``QCompleter``
+popups.  Their word lists come from a :class:`CompletionsProvider` — one
+blocking call returning ``{device: [variable, ...]}`` — which the editor
+dispatches to a short-lived daemon thread (the package's no-QThread rule)
+and marshals back through a queued Qt signal, so a slow or unreachable DB
+never blocks the GUI thread.
+
+- :class:`EmptyCompletions` — the offline/test default: no suggestions,
+  returns instantly.
+- :class:`GeecsDbCompletions` — the real provider: one
+  ``GeecsDb.get_experiment_device_variables`` query (imported lazily inside
+  the call, keeping this module import-safe offline), cached after the first
+  fetch; any failure — no MySQL, no credentials, unreachable host — degrades
+  to empty with a log line, never an exception.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Optional, Protocol, runtime_checkable
+
+logger = logging.getLogger(__name__)
+
+
+@runtime_checkable
+class CompletionsProvider(Protocol):
+    """Anything that can supply device → variable-name completions."""
+
+    def device_variables(self) -> dict[str, list[str]]:
+        """Return ``{device: [variable name, ...]}``; may block, never raises."""
+        ...
+
+
+class EmptyCompletions:
+    """No completions — the offline and hermetic-test default."""
+
+    def device_variables(self) -> dict[str, list[str]]:
+        """Return no completions.
+
+        Returns
+        -------
+        dict
+            Always empty.
+        """
+        return {}
+
+
+class GeecsDbCompletions:
+    """DB-backed completions for one experiment (cached, failure-tolerant).
+
+    Parameters
+    ----------
+    experiment : str
+        GEECS experiment name to enumerate devices/variables for.
+    """
+
+    def __init__(self, experiment: str) -> None:
+        self._experiment = experiment
+        self._cache: Optional[dict[str, list[str]]] = None
+
+    def device_variables(self) -> dict[str, list[str]]:
+        """Fetch (once) ``{device: [variable name, ...]}`` from ``GeecsDb``.
+
+        Returns
+        -------
+        dict
+            Sorted variable names per device; empty when the experiment is
+            unset or the DB is unreachable (logged, never raised).  Cached
+            after the first successful or failed attempt.
+        """
+        if self._cache is not None:
+            return self._cache
+        self._cache = {}
+        if not self._experiment:
+            return self._cache
+        try:
+            from geecs_ca_gateway.db.geecs_db import GeecsDb
+
+            per_device = GeecsDb.get_experiment_device_variables(self._experiment)
+            self._cache = {
+                device: sorted({str(row["name"]) for row in rows if "name" in row})
+                for device, rows in per_device.items()
+            }
+        except Exception as exc:  # noqa: BLE001 — degrade to empty offline
+            logger.info(
+                "device completions unavailable for %r: %s", self._experiment, exc
+            )
+        return self._cache

--- a/GEECS-Console/geecs_console/services/scan_variable_store.py
+++ b/GEECS-Console/geecs_console/services/scan_variable_store.py
@@ -1,0 +1,303 @@
+"""Scan-variable catalog persistence: one :class:`~geecs_schemas.ScanVariables` YAML.
+
+Unlike presets (one file per preset), the scan-variable catalog is **one
+document per experiment** — the same file :class:`geecs_bluesky.config_resolver.
+ConfigsRepoResolver` reads::
+
+    scanner_configs/experiments/<Experiment>/scan_devices/scan_variables.yaml
+
+Loading mirrors the resolver's dialect handling: a file whose top level
+carries ``schema_version`` is the new schema; when it is absent the legacy
+pair (``scan_devices.yaml`` + ``composite_variables.yaml``) is converted
+through :func:`geecs_schemas.convert.convert_scan_variables` — so an
+experiment that has not migrated yet still opens in the editor.  Saving
+always writes the new-schema file (``model_dump(mode="json",
+exclude_none=True)``, which round-trips every set field through
+``ScanVariables.model_validate`` and omits unset optionals exactly the way
+the production catalogs are written).
+
+Offline-safety mirrors :class:`~geecs_console.services.presets.PresetStore`:
+:meth:`ScanVariableStore.load` degrades to an **empty catalog** when the
+configs repo or the experiment folder is missing (the editor still opens);
+save without a resolvable target raises :class:`ScanVariableStoreError` with
+a message fit for the status bar.  Creating the ``scan_devices/`` directory
+with ``mkdir(parents=True, exist_ok=True)`` is deliberate and fine — this is
+a config directory in the configs repo, not a ``scans/ScanNNN/`` data folder,
+so the repo's scan-folder creation invariant does not apply.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Optional
+
+import yaml
+from pydantic import ValidationError
+
+from geecs_console.services.configs import _configs_base
+from geecs_schemas import ScanVariables
+
+logger = logging.getLogger(__name__)
+
+SCAN_VARIABLES_FOLDER = "scan_devices"
+CATALOG_FILE = "scan_variables.yaml"
+LEGACY_SIMPLE_FILE = "scan_devices.yaml"
+LEGACY_COMPOSITE_FILE = "composite_variables.yaml"
+
+
+class ScanVariableStoreError(RuntimeError):
+    """A catalog operation cannot be carried out (surfaced in the status bar)."""
+
+
+def empty_catalog() -> ScanVariables:
+    """Return a fresh empty catalog (what a new experiment starts from).
+
+    Returns
+    -------
+    ScanVariables
+        A validated catalog with no variables.
+    """
+    return ScanVariables(variables={})
+
+
+class ScanVariableStore:
+    """Load/save one experiment's scan-variable catalog.
+
+    Parameters
+    ----------
+    experiment : str, optional
+        Experiment folder under ``scanner_configs/experiments``.  May be
+        empty at construction (before the operator picks one) — loading is
+        then empty and saving raises.
+    experiments_root : str or Path, optional
+        Override for the experiments root (tests point this at a tmp dir);
+        defaults to the production resolution
+        (:func:`geecs_bluesky.scanner_configs.scanner_configs_base`, resolved
+        lazily so the module stays import-safe offline).
+    """
+
+    def __init__(
+        self, experiment: str = "", experiments_root: str | Path | None = None
+    ) -> None:
+        self._experiment = experiment
+        self._experiments_root = (
+            Path(experiments_root) if experiments_root is not None else None
+        )
+
+    @property
+    def experiment(self) -> str:
+        """The experiment this store reads and writes the catalog for."""
+        return self._experiment
+
+    def set_experiment(self, experiment: str) -> None:
+        """Switch the store to *experiment*.
+
+        Parameters
+        ----------
+        experiment : str
+            The new experiment folder name ("" for none selected).
+        """
+        self._experiment = experiment
+
+    # ------------------------------------------------------------------
+    # Folder resolution
+    # ------------------------------------------------------------------
+
+    def _root(self) -> Optional[Path]:
+        """Return the experiments root, or ``None`` when unresolvable."""
+        if self._experiments_root is not None:
+            return self._experiments_root
+        return _configs_base()
+
+    def _check_experiment(self) -> None:
+        """Reject an experiment name that would escape the experiments root.
+
+        Raises
+        ------
+        ScanVariableStoreError
+            When the experiment name contains a path separator or is a
+            relative-path special name.
+        """
+        name = self._experiment
+        if any(sep in name for sep in ("/", "\\")) or name in (".", ".."):
+            raise ScanVariableStoreError(
+                f"Experiment name {name!r} must be a plain folder name "
+                "(no path separators)."
+            )
+
+    def _folder(self) -> Optional[Path]:
+        """Return the ``scan_devices/`` dir, or ``None`` offline/unselected."""
+        root = self._root()
+        if root is None or not self._experiment:
+            return None
+        self._check_experiment()
+        return root / self._experiment / SCAN_VARIABLES_FOLDER
+
+    def _folder_or_raise(self) -> Path:
+        """Return the ``scan_devices/`` dir, raising a clear error otherwise.
+
+        Returns
+        -------
+        Path
+            ``<experiments root>/<experiment>/scan_devices``.
+
+        Raises
+        ------
+        ScanVariableStoreError
+            When the configs repo is not found or no experiment is selected.
+        """
+        root = self._root()
+        if root is None:
+            raise ScanVariableStoreError(
+                "Configs repo not found — set GEECS_SCANNER_CONFIG_DIR or "
+                "config.ini [Paths] scanner_config_root_path."
+            )
+        if not self._experiment:
+            raise ScanVariableStoreError("No experiment selected.")
+        self._check_experiment()
+        return root / self._experiment / SCAN_VARIABLES_FOLDER
+
+    def catalog_path(self) -> Optional[Path]:
+        """Return the new-schema catalog path, or ``None`` offline/unselected.
+
+        Returns
+        -------
+        Path or None
+            ``<scan_devices dir>/scan_variables.yaml`` — the file
+            :meth:`save` writes, whether or not it exists yet.
+        """
+        folder = self._folder()
+        return None if folder is None else folder / CATALOG_FILE
+
+    # ------------------------------------------------------------------
+    # The store surface
+    # ------------------------------------------------------------------
+
+    def load(self) -> ScanVariables:
+        """Load the experiment's catalog (new schema, else converted legacy).
+
+        Returns
+        -------
+        ScanVariables
+            The validated catalog.  An unresolvable configs repo, unselected
+            experiment, or absent catalog file all degrade to an **empty**
+            catalog — the editor still opens offline.
+
+        Raises
+        ------
+        ScanVariableStoreError
+            Unparsable YAML, a document the schema rejects, or a legacy pair
+            the converter rejects — always with a message fit for the status
+            bar.  A *missing* file is not an error.
+        """
+        folder = self._folder()
+        if folder is None:
+            return empty_catalog()
+        new_schema = folder / CATALOG_FILE
+        if new_schema.exists():
+            return self._load_new_schema(new_schema)
+        return self._load_legacy(folder)
+
+    def _load_new_schema(self, path: Path) -> ScanVariables:
+        """Load and validate the new-schema catalog at *path*.
+
+        Raises
+        ------
+        ScanVariableStoreError
+            Unparsable YAML, a non-mapping document, or schema rejection.
+        """
+        try:
+            document = yaml.safe_load(path.read_text(encoding="utf-8"))
+        except yaml.YAMLError as exc:
+            raise ScanVariableStoreError(
+                f"Scan-variable catalog is not valid YAML ({path}): {exc}"
+            ) from exc
+        if not isinstance(document, dict):
+            raise ScanVariableStoreError(
+                f"Scan-variable catalog ({path}) should be a YAML mapping of "
+                f"ScanVariables fields, got {type(document).__name__}."
+            )
+        try:
+            return ScanVariables.model_validate(document)
+        except ValidationError as exc:
+            raise ScanVariableStoreError(
+                f"Scan-variable catalog ({path}) is not a valid ScanVariables "
+                f"document: {exc}"
+            ) from exc
+
+    def _load_legacy(self, folder: Path) -> ScanVariables:
+        """Convert the legacy pair in *folder*; empty catalog when absent.
+
+        Raises
+        ------
+        ScanVariableStoreError
+            When the legacy converter rejects either file.
+        """
+        simple = folder / LEGACY_SIMPLE_FILE
+        composites = folder / LEGACY_COMPOSITE_FILE
+        if not simple.exists() and not composites.exists():
+            return empty_catalog()
+        # Lazy import: the converter is pydantic-only (geecs_schemas), but
+        # keeping it out of module import keeps the cheap path cheap.
+        from geecs_schemas.convert import convert_scan_variables
+
+        try:
+            catalog = convert_scan_variables(
+                simple if simple.exists() else None,
+                composites if composites.exists() else None,
+            )
+        except Exception as exc:
+            raise ScanVariableStoreError(
+                f"Legacy scan-variable files in {folder} could not be converted: {exc}"
+            ) from exc
+        logger.info(
+            "loaded legacy scan-variable pair from %s (%d variables)",
+            folder,
+            len(catalog.variables),
+        )
+        return catalog
+
+    def save(self, catalog: ScanVariables) -> Path:
+        """Write *catalog* as the experiment's new-schema catalog file.
+
+        Parameters
+        ----------
+        catalog : ScanVariables
+            The catalog to persist.
+
+        Returns
+        -------
+        Path
+            The YAML file written (``scan_devices/scan_variables.yaml``).
+
+        Raises
+        ------
+        ScanVariableStoreError
+            Missing configs repo, no experiment selected, or an OS-level
+            write failure.
+        """
+        folder = self._folder_or_raise()
+        path = folder / CATALOG_FILE
+        # A config dir, not a scans/ScanNNN/ data folder — parents=True is
+        # explicitly fine here (the scan-folder invariant does not apply).
+        folder.mkdir(parents=True, exist_ok=True)
+        # exclude_none omits unset optionals (confirm, inverse) the way the
+        # production catalogs are written; every set field round-trips.
+        document = yaml.safe_dump(
+            catalog.model_dump(mode="json", exclude_none=True),
+            sort_keys=False,
+            allow_unicode=True,
+        )
+        try:
+            path.write_text(document, encoding="utf-8")
+        except OSError as exc:
+            raise ScanVariableStoreError(
+                f"Could not write scan-variable catalog: {exc}"
+            ) from exc
+        logger.info(
+            "saved scan-variable catalog (%d variables) to %s",
+            len(catalog.variables),
+            path,
+        )
+        return path

--- a/GEECS-Console/tests/test_scan_variable_editor.py
+++ b/GEECS-Console/tests/test_scan_variable_editor.py
@@ -1,0 +1,521 @@
+"""ScanVariableEditor: hermetic GUI tests against a tmp configs root.
+
+Teardown discipline (segfault class seen on this host: a widget destroyed
+while posted events are still queued): every editor is registered with
+``qtbot.addWidget`` (pytest-qt owns the teardown), the async completions
+fetch is awaited before the test body runs (no queued signal can land on a
+dying dialog), and the unsaved-changes prompt is defaulted to "discard" so
+teardown ``close()`` never blocks on a modal.
+"""
+
+import yaml
+from PySide6.QtCore import Qt
+from PySide6.QtWidgets import QDialog
+
+from geecs_console.editors.scan_variable_editor import (
+    ScanVariableEditor,
+    open_scan_variable_editor,
+)
+from geecs_console.services.device_completions import EmptyCompletions
+from geecs_console.services.scan_variable_store import (
+    CATALOG_FILE,
+    SCAN_VARIABLES_FOLDER,
+    ScanVariableStore,
+)
+from geecs_schemas import (
+    CompositeMode,
+    PseudoComponent,
+    PseudoScanVariable,
+    ScanVariable,
+    ScanVariables,
+)
+
+EXPERIMENT = "HTU"
+
+
+class FakeCompletions:
+    """Canned completions, returned instantly."""
+
+    def __init__(self, mapping):
+        self._mapping = mapping
+
+    def device_variables(self):
+        return self._mapping
+
+
+def seed_catalog(tmp_path) -> ScanVariables:
+    """Write a catalog with a simple, a confirmed, and a composite variable."""
+    catalog = ScanVariables(
+        variables={
+            "jet_z": ScanVariable(target="U_ESP_JetXYZ:Position.Axis 3", kind="motor"),
+            "emq1_current": ScanVariable(
+                target="U_EMQTripletBipolar:Current_Limit.Ch1",
+                kind="setpoint",
+                confirm="U_EMQTripletBipolar:Current.Ch1",
+            ),
+            "angle_offset_x": PseudoScanVariable(
+                kind="pseudo",
+                targets=[
+                    PseudoComponent(
+                        target="U_S3H:Current", forward="composite_var * 1"
+                    ),
+                    PseudoComponent(
+                        target="U_S4H:Current", forward="composite_var * -2"
+                    ),
+                ],
+                mode=CompositeMode.RELATIVE,
+                inverse="composite_var / 1",
+            ),
+        }
+    )
+    ScanVariableStore(EXPERIMENT, experiments_root=tmp_path).save(catalog)
+    return catalog
+
+
+def catalog_document(tmp_path) -> dict:
+    """Read the saved catalog YAML back as a plain dict."""
+    path = tmp_path / EXPERIMENT / SCAN_VARIABLES_FOLDER / CATALOG_FILE
+    return yaml.safe_load(path.read_text())
+
+
+def make_editor(qtbot, tmp_path, experiment=EXPERIMENT, completions=None):
+    """Build an editor with crash-safe test teardown (see module docstring)."""
+    store = ScanVariableStore(experiment, experiments_root=tmp_path)
+    editor = ScanVariableEditor(
+        store=store,
+        completions=completions if completions is not None else EmptyCompletions(),
+    )
+    qtbot.addWidget(editor)
+    editor._confirm_discard = lambda: True  # teardown close must never block
+    qtbot.waitUntil(lambda: editor.completions_applied, timeout=5000)
+    return editor
+
+
+def select_variable(editor, name):
+    """Select the list row whose UserRole is *name*."""
+    for row in range(editor.variable_list.count()):
+        item = editor.variable_list.item(row)
+        if item.data(Qt.ItemDataRole.UserRole) == name:
+            editor.variable_list.setCurrentItem(item)
+            return
+    raise AssertionError(f"{name!r} not in the variable list")
+
+
+def list_names(editor):
+    """The UserRole names in list order."""
+    return [
+        editor.variable_list.item(row).data(Qt.ItemDataRole.UserRole)
+        for row in range(editor.variable_list.count())
+    ]
+
+
+class TestOpenOffline:
+    def test_opens_with_zero_configs(self, qtbot, tmp_path):
+        editor = make_editor(qtbot, tmp_path)
+        assert editor.variable_list.count() == 0
+        assert editor.form_stack.currentWidget() is editor.empty_page
+        assert not editor.dirty
+        assert editor.error_label.text() == ""
+
+    def test_opens_with_no_experiment(self, qtbot, tmp_path):
+        editor = make_editor(qtbot, tmp_path, experiment="")
+        assert editor.variable_list.count() == 0
+
+    def test_entry_point_returns_shown_dialog(self, qtbot, tmp_path):
+        dialog = open_scan_variable_editor(
+            None, EXPERIMENT, configs_base=tmp_path, completions=EmptyCompletions()
+        )
+        qtbot.addWidget(dialog)
+        dialog._confirm_discard = lambda: True
+        qtbot.waitUntil(lambda: dialog.completions_applied, timeout=5000)
+        assert isinstance(dialog, QDialog)
+        assert dialog.isVisible()
+        assert EXPERIMENT in dialog.windowTitle()
+        dialog.close()
+        assert not dialog.isVisible()
+
+    def test_invalid_yaml_opens_with_inline_error(self, qtbot, tmp_path):
+        path = tmp_path / EXPERIMENT / SCAN_VARIABLES_FOLDER / CATALOG_FILE
+        path.parent.mkdir(parents=True)
+        path.write_text("variables: [unclosed")
+        editor = make_editor(qtbot, tmp_path)
+        assert "YAML" in editor.error_label.text()
+        assert editor.variable_list.count() == 0
+
+
+class TestListAndForm:
+    def test_list_shows_names_and_type_tags(self, qtbot, tmp_path):
+        seed_catalog(tmp_path)
+        editor = make_editor(qtbot, tmp_path)
+        assert list_names(editor) == ["jet_z", "emq1_current", "angle_offset_x"]
+        texts = [
+            editor.variable_list.item(row).text()
+            for row in range(editor.variable_list.count())
+        ]
+        assert "[simple]" in texts[0]
+        assert "[composite]" in texts[2]
+
+    def test_simple_form_populates(self, qtbot, tmp_path):
+        seed_catalog(tmp_path)
+        editor = make_editor(qtbot, tmp_path)
+        select_variable(editor, "emq1_current")
+        assert editor.form_stack.currentWidget() is editor.simple_page
+        assert editor.device_edit.text() == "U_EMQTripletBipolar"
+        assert editor.variable_edit.text() == "Current_Limit.Ch1"
+        assert editor.kind_combo.currentText() == "setpoint"
+        assert editor.confirm_device_edit.text() == "U_EMQTripletBipolar"
+        assert editor.confirm_variable_edit.text() == "Current.Ch1"
+        assert not editor.dirty
+
+    def test_pseudo_form_populates(self, qtbot, tmp_path):
+        seed_catalog(tmp_path)
+        editor = make_editor(qtbot, tmp_path)
+        select_variable(editor, "angle_offset_x")
+        assert editor.form_stack.currentWidget() is editor.pseudo_page
+        assert editor.mode_combo.currentText() == "relative"
+        assert editor.inverse_edit.text() == "composite_var / 1"
+        table = editor.components_table
+        assert table.rowCount() == 2
+        assert table.cellWidget(0, 0).text() == "U_S3H"
+        assert table.cellWidget(0, 1).text() == "Current"
+        assert table.cellWidget(1, 2).text() == "composite_var * -2"
+        assert not editor.dirty
+
+    def test_mode_labels_follow_mode(self, qtbot, tmp_path):
+        seed_catalog(tmp_path)
+        editor = make_editor(qtbot, tmp_path)
+        select_variable(editor, "angle_offset_x")
+        header = editor.components_table.horizontalHeaderItem(2)
+        assert "offset from scan start" in header.text()
+        assert "offset" in editor.mode_hint_label.text()
+        editor.mode_combo.setCurrentText("absolute")
+        assert "absolute value" in header.text()
+        assert "exactly" in editor.mode_hint_label.text()
+        assert editor.dirty  # the mode change is a real edit
+
+
+class TestEditingSimple:
+    def test_edit_marks_dirty_and_save_persists(self, qtbot, tmp_path):
+        seed_catalog(tmp_path)
+        editor = make_editor(qtbot, tmp_path)
+        select_variable(editor, "jet_z")
+        editor.device_edit.setText("U_NewStage")
+        assert editor.dirty
+        assert "unsaved" in editor.dirty_label.text()
+        editor.save_button.click()
+        assert not editor.dirty
+        assert "saved" in editor.dirty_label.text()
+        document = catalog_document(tmp_path)
+        assert document["variables"]["jet_z"]["target"] == "U_NewStage:Position.Axis 3"
+
+    def test_kind_change_persists(self, qtbot, tmp_path):
+        seed_catalog(tmp_path)
+        editor = make_editor(qtbot, tmp_path)
+        select_variable(editor, "jet_z")
+        assert editor.kind_combo.currentText() == "motor"
+        editor.kind_combo.setCurrentText("setpoint")
+        editor.save_button.click()
+        assert catalog_document(tmp_path)["variables"]["jet_z"]["kind"] == "setpoint"
+
+    def test_clearing_confirm_removes_the_field(self, qtbot, tmp_path):
+        seed_catalog(tmp_path)
+        editor = make_editor(qtbot, tmp_path)
+        select_variable(editor, "emq1_current")
+        editor.confirm_device_edit.setText("")
+        editor.confirm_variable_edit.setText("")
+        editor.save_button.click()
+        assert "confirm" not in catalog_document(tmp_path)["variables"]["emq1_current"]
+
+    def test_switching_selection_keeps_edits_in_draft(self, qtbot, tmp_path):
+        seed_catalog(tmp_path)
+        editor = make_editor(qtbot, tmp_path)
+        select_variable(editor, "jet_z")
+        editor.device_edit.setText("U_Elsewhere")
+        select_variable(editor, "emq1_current")
+        select_variable(editor, "jet_z")
+        assert editor.device_edit.text() == "U_Elsewhere"
+        assert editor.dirty
+
+
+class TestEditingComposite:
+    def test_forward_edit_persists(self, qtbot, tmp_path):
+        seed_catalog(tmp_path)
+        editor = make_editor(qtbot, tmp_path)
+        select_variable(editor, "angle_offset_x")
+        editor.components_table.cellWidget(0, 2).setText("composite_var * 5")
+        assert editor.dirty
+        editor.save_button.click()
+        document = catalog_document(tmp_path)
+        targets = document["variables"]["angle_offset_x"]["targets"]
+        assert targets[0]["forward"] == "composite_var * 5"
+        assert targets[1]["forward"] == "composite_var * -2"
+
+    def test_add_component_persists(self, qtbot, tmp_path):
+        seed_catalog(tmp_path)
+        editor = make_editor(qtbot, tmp_path)
+        select_variable(editor, "angle_offset_x")
+        editor.add_component_button.click()
+        table = editor.components_table
+        assert table.rowCount() == 3
+        table.cellWidget(2, 0).setText("U_S5H")
+        table.cellWidget(2, 1).setText("Current")
+        table.cellWidget(2, 2).setText("composite_var * 3")
+        editor.save_button.click()
+        targets = catalog_document(tmp_path)["variables"]["angle_offset_x"]["targets"]
+        assert len(targets) == 3
+        assert targets[2] == {"target": "U_S5H:Current", "forward": "composite_var * 3"}
+
+    def test_remove_component_persists(self, qtbot, tmp_path):
+        seed_catalog(tmp_path)
+        editor = make_editor(qtbot, tmp_path)
+        select_variable(editor, "angle_offset_x")
+        editor.remove_component_button.click()  # no current row -> drops the last
+        assert editor.components_table.rowCount() == 1
+        editor.save_button.click()
+        targets = catalog_document(tmp_path)["variables"]["angle_offset_x"]["targets"]
+        assert targets == [{"target": "U_S3H:Current", "forward": "composite_var * 1"}]
+
+    def test_clearing_inverse_removes_the_field(self, qtbot, tmp_path):
+        seed_catalog(tmp_path)
+        editor = make_editor(qtbot, tmp_path)
+        select_variable(editor, "angle_offset_x")
+        editor.inverse_edit.setText("")
+        editor.save_button.click()
+        assert (
+            "inverse" not in catalog_document(tmp_path)["variables"]["angle_offset_x"]
+        )
+
+    def test_mode_change_persists(self, qtbot, tmp_path):
+        seed_catalog(tmp_path)
+        editor = make_editor(qtbot, tmp_path)
+        select_variable(editor, "angle_offset_x")
+        editor.mode_combo.setCurrentText("absolute")
+        editor.save_button.click()
+        assert (
+            catalog_document(tmp_path)["variables"]["angle_offset_x"]["mode"]
+            == "absolute"
+        )
+
+
+class TestValidation:
+    def test_empty_target_shows_inline_error_and_writes_nothing(self, qtbot, tmp_path):
+        editor = make_editor(qtbot, tmp_path)
+        editor.new_simple_button.click()
+        editor.save_button.click()
+        assert "target" in editor.error_label.text()
+        path = tmp_path / EXPERIMENT / SCAN_VARIABLES_FOLDER / CATALOG_FILE
+        assert not path.exists()
+        assert editor.dirty  # the draft is still unsaved
+
+    def test_composite_error_names_the_variable(self, qtbot, tmp_path):
+        seed_catalog(tmp_path)
+        before = catalog_document(tmp_path)
+        editor = make_editor(qtbot, tmp_path)
+        select_variable(editor, "angle_offset_x")
+        editor.components_table.cellWidget(0, 2).setText("")  # forward: min_length 1
+        editor.save_button.click()
+        message = editor.error_label.text()
+        assert "angle_offset_x" in message
+        assert "forward" in message
+        # The simple-branch union noise is filtered out of the display.
+        assert "ScanVariable" not in message
+        assert catalog_document(tmp_path) == before
+
+    def test_error_clears_after_a_good_save(self, qtbot, tmp_path):
+        seed_catalog(tmp_path)
+        editor = make_editor(qtbot, tmp_path)
+        select_variable(editor, "jet_z")
+        editor.variable_edit.setText("")
+        editor.device_edit.setText("")
+        editor.save_button.click()
+        assert editor.error_label.text() != ""
+        editor.device_edit.setText("U_ESP_JetXYZ")
+        editor.variable_edit.setText("Position.Axis 3")
+        editor.save_button.click()
+        assert editor.error_label.text() == ""
+
+    def test_store_error_is_shown_inline(self, qtbot, tmp_path):
+        editor = make_editor(qtbot, tmp_path, experiment="")
+        editor.new_simple_button.click()
+        editor.device_edit.setText("U_Dev")
+        editor.variable_edit.setText("Var")
+        editor.save_button.click()
+        assert "No experiment selected" in editor.error_label.text()
+
+
+class TestRenameDuplicateDelete:
+    def test_rename_preserves_order_and_persists(self, qtbot, tmp_path):
+        seed_catalog(tmp_path)
+        editor = make_editor(qtbot, tmp_path)
+        select_variable(editor, "jet_z")
+        editor._ask_name = lambda *args, **kwargs: "jet_z_new"
+        editor.rename_button.click()
+        assert list_names(editor) == ["jet_z_new", "emq1_current", "angle_offset_x"]
+        assert editor.dirty
+        editor.save_button.click()
+        assert list(catalog_document(tmp_path)["variables"]) == [
+            "jet_z_new",
+            "emq1_current",
+            "angle_offset_x",
+        ]
+
+    def test_rename_collision_is_rejected(self, qtbot, tmp_path):
+        seed_catalog(tmp_path)
+        editor = make_editor(qtbot, tmp_path)
+        select_variable(editor, "jet_z")
+        editor._ask_name = lambda *args, **kwargs: "emq1_current"
+        editor.rename_button.click()
+        assert "already exists" in editor.error_label.text()
+        assert "jet_z" in list_names(editor)
+
+    def test_rename_cancel_is_a_noop(self, qtbot, tmp_path):
+        seed_catalog(tmp_path)
+        editor = make_editor(qtbot, tmp_path)
+        select_variable(editor, "jet_z")
+        editor._ask_name = lambda *args, **kwargs: None
+        editor.rename_button.click()
+        assert not editor.dirty
+
+    def test_duplicate_copies_the_definition(self, qtbot, tmp_path):
+        seed_catalog(tmp_path)
+        editor = make_editor(qtbot, tmp_path)
+        select_variable(editor, "angle_offset_x")
+        editor.duplicate_button.click()
+        assert "angle_offset_x_copy" in list_names(editor)
+        select_variable(editor, "angle_offset_x_copy")
+        assert editor.components_table.rowCount() == 2
+        assert editor.mode_combo.currentText() == "relative"
+
+    def test_delete_persists_on_save(self, qtbot, tmp_path):
+        seed_catalog(tmp_path)
+        editor = make_editor(qtbot, tmp_path)
+        select_variable(editor, "jet_z")
+        editor.delete_button.click()
+        assert "jet_z" not in list_names(editor)
+        editor.save_button.click()
+        assert list(catalog_document(tmp_path)["variables"]) == [
+            "emq1_current",
+            "angle_offset_x",
+        ]
+
+    def test_new_names_do_not_collide(self, qtbot, tmp_path):
+        editor = make_editor(qtbot, tmp_path)
+        editor.new_simple_button.click()
+        editor.new_simple_button.click()
+        editor.new_pseudo_button.click()
+        assert list_names(editor) == [
+            "new_variable",
+            "new_variable_2",
+            "new_composite",
+        ]
+
+
+class TestDirtyRevertClose:
+    def test_revert_restores_from_disk(self, qtbot, tmp_path):
+        seed_catalog(tmp_path)
+        editor = make_editor(qtbot, tmp_path)
+        select_variable(editor, "jet_z")
+        editor.device_edit.setText("U_Elsewhere")
+        editor.revert_button.click()  # default confirm hook discards
+        assert not editor.dirty
+        select_variable(editor, "jet_z")
+        assert editor.device_edit.text() == "U_ESP_JetXYZ"
+
+    def test_revert_can_be_cancelled(self, qtbot, tmp_path):
+        seed_catalog(tmp_path)
+        editor = make_editor(qtbot, tmp_path)
+        select_variable(editor, "jet_z")
+        editor.device_edit.setText("U_Elsewhere")
+        editor._confirm_discard = lambda: False
+        editor.revert_button.click()
+        assert editor.dirty
+        assert editor.device_edit.text() == "U_Elsewhere"
+        editor._confirm_discard = lambda: True  # teardown safety
+
+    def test_close_prompts_when_dirty(self, qtbot, tmp_path):
+        seed_catalog(tmp_path)
+        editor = make_editor(qtbot, tmp_path)
+        editor.show()
+        select_variable(editor, "jet_z")
+        editor.device_edit.setText("U_Elsewhere")
+        editor._confirm_discard = lambda: False
+        editor.close()
+        assert editor.isVisible()  # the ignored close left it open
+        editor._confirm_discard = lambda: True
+        editor.close()
+        assert not editor.isVisible()
+
+    def test_close_without_changes_never_prompts(self, qtbot, tmp_path):
+        seed_catalog(tmp_path)
+        editor = make_editor(qtbot, tmp_path)
+        editor.show()
+        prompts = []
+        editor._confirm_discard = lambda: prompts.append(1) or True
+        editor.close()
+        assert prompts == []
+        assert not editor.isVisible()
+
+
+class TestCompleters:
+    MAPPING = {
+        "U_Hexapod": ["xpos", "ypos", "zpos"],
+        "U_S3H": ["Current"],
+    }
+
+    def test_device_completer_is_populated(self, qtbot, tmp_path):
+        editor = make_editor(qtbot, tmp_path, completions=FakeCompletions(self.MAPPING))
+        assert editor._device_model.stringList() == ["U_Hexapod", "U_S3H"]
+        assert editor.device_edit.completer() is not None
+
+    def test_variable_completer_follows_the_device_field(self, qtbot, tmp_path):
+        seed_catalog(tmp_path)
+        editor = make_editor(qtbot, tmp_path, completions=FakeCompletions(self.MAPPING))
+        select_variable(editor, "jet_z")
+        editor.device_edit.setText("U_Hexapod")
+        assert editor._variable_model.stringList() == ["xpos", "ypos", "zpos"]
+        editor.device_edit.setText("U_Unknown")
+        assert editor._variable_model.stringList() == []
+
+    def test_device_match_is_case_insensitive(self, qtbot, tmp_path):
+        seed_catalog(tmp_path)
+        editor = make_editor(qtbot, tmp_path, completions=FakeCompletions(self.MAPPING))
+        select_variable(editor, "jet_z")
+        editor.device_edit.setText("u_hexapod")
+        assert editor._variable_model.stringList() == ["xpos", "ypos", "zpos"]
+
+    def test_component_row_variable_completer_follows_its_device(self, qtbot, tmp_path):
+        seed_catalog(tmp_path)
+        editor = make_editor(qtbot, tmp_path, completions=FakeCompletions(self.MAPPING))
+        select_variable(editor, "angle_offset_x")
+        table = editor.components_table
+        table.cellWidget(0, 0).setText("U_Hexapod")
+        model = table.cellWidget(0, 1).completer().model()
+        assert model.stringList() == ["xpos", "ypos", "zpos"]
+
+    def test_confirm_pair_gets_completers_too(self, qtbot, tmp_path):
+        seed_catalog(tmp_path)
+        editor = make_editor(qtbot, tmp_path, completions=FakeCompletions(self.MAPPING))
+        select_variable(editor, "emq1_current")
+        editor.confirm_device_edit.setText("U_S3H")
+        assert editor._confirm_variable_model.stringList() == ["Current"]
+
+
+class TestEnterNeverAccepts:
+    def test_return_in_a_field_does_not_close(self, qtbot, tmp_path):
+        seed_catalog(tmp_path)
+        editor = make_editor(qtbot, tmp_path)
+        editor.show()
+        select_variable(editor, "jet_z")
+        editor.device_edit.setFocus()
+        qtbot.keyClick(editor.device_edit, Qt.Key.Key_Return)
+        qtbot.keyClick(editor, Qt.Key.Key_Return)
+        assert editor.isVisible()
+        assert editor.result() == 0
+
+    def test_no_button_is_default(self, qtbot, tmp_path):
+        editor = make_editor(qtbot, tmp_path)
+        from PySide6.QtWidgets import QPushButton
+
+        for button in editor.findChildren(QPushButton):
+            assert not button.isDefault()
+            assert not button.autoDefault()

--- a/GEECS-Console/tests/test_scan_variable_store.py
+++ b/GEECS-Console/tests/test_scan_variable_store.py
@@ -1,0 +1,213 @@
+"""ScanVariableStore: catalog YAML round-trips against a tmp configs root."""
+
+import pytest
+import yaml
+
+from geecs_console.services.scan_variable_store import (
+    CATALOG_FILE,
+    SCAN_VARIABLES_FOLDER,
+    ScanVariableStore,
+    ScanVariableStoreError,
+    empty_catalog,
+)
+from geecs_schemas import (
+    CompositeMode,
+    PseudoComponent,
+    PseudoScanVariable,
+    ScanVariable,
+    ScanVariables,
+)
+
+
+def full_catalog() -> ScanVariables:
+    """A catalog exercising every field the schema defines."""
+    return ScanVariables(
+        variables={
+            "jet_z": ScanVariable(target="U_ESP_JetXYZ:Position.Axis 3", kind="motor"),
+            "emq1_current": ScanVariable(
+                target="U_EMQTripletBipolar:Current_Limit.Ch1",
+                kind="setpoint",
+                confirm="U_EMQTripletBipolar:Current.Ch1",
+            ),
+            "angle_offset_x": PseudoScanVariable(
+                kind="pseudo",
+                targets=[
+                    PseudoComponent(
+                        target="U_S3H:Current", forward="composite_var * 1"
+                    ),
+                    PseudoComponent(
+                        target="U_S4H:Current", forward="composite_var * -2"
+                    ),
+                ],
+                mode=CompositeMode.RELATIVE,
+                inverse="composite_var / 1",
+            ),
+        }
+    )
+
+
+@pytest.fixture
+def store(tmp_path):
+    return ScanVariableStore("HTU", experiments_root=tmp_path)
+
+
+def catalog_path(tmp_path):
+    return tmp_path / "HTU" / SCAN_VARIABLES_FOLDER / CATALOG_FILE
+
+
+class TestRoundTrip:
+    def test_save_load_round_trips_every_field(self, store):
+        catalog = full_catalog()
+        store.save(catalog)
+        loaded = store.load()
+        assert loaded == catalog
+        assert loaded.model_dump() == catalog.model_dump()
+
+    def test_file_lands_at_the_resolver_path(self, store, tmp_path):
+        path = store.save(full_catalog())
+        assert path == catalog_path(tmp_path)
+        assert path.is_file()
+        assert store.catalog_path() == path
+
+    def test_unset_optionals_are_omitted_from_the_yaml(self, store, tmp_path):
+        store.save(full_catalog())
+        document = yaml.safe_load(catalog_path(tmp_path).read_text())
+        assert "confirm" not in document["variables"]["jet_z"]
+        assert "confirm" in document["variables"]["emq1_current"]
+        assert "inverse" in document["variables"]["angle_offset_x"]
+
+    def test_saved_document_carries_schema_version(self, store, tmp_path):
+        store.save(full_catalog())
+        document = yaml.safe_load(catalog_path(tmp_path).read_text())
+        assert document["schema_version"] == 1
+
+    def test_order_is_preserved(self, store):
+        store.save(full_catalog())
+        assert list(store.load().variables) == [
+            "jet_z",
+            "emq1_current",
+            "angle_offset_x",
+        ]
+
+
+class TestOfflineAndMissing:
+    def test_missing_catalog_loads_empty(self, store):
+        assert store.load() == empty_catalog()
+
+    def test_no_experiment_loads_empty(self, tmp_path):
+        assert ScanVariableStore("", experiments_root=tmp_path).load() == (
+            empty_catalog()
+        )
+
+    def test_unresolvable_configs_root_loads_empty(self, monkeypatch):
+        import geecs_console.services.scan_variable_store as module
+
+        monkeypatch.setattr(module, "_configs_base", lambda: None)
+        assert ScanVariableStore("HTU").load() == empty_catalog()
+
+    def test_catalog_path_none_offline(self, monkeypatch):
+        import geecs_console.services.scan_variable_store as module
+
+        monkeypatch.setattr(module, "_configs_base", lambda: None)
+        assert ScanVariableStore("HTU").catalog_path() is None
+
+    def test_save_without_experiment_raises(self, tmp_path):
+        with pytest.raises(ScanVariableStoreError, match="No experiment"):
+            ScanVariableStore("", experiments_root=tmp_path).save(full_catalog())
+
+    def test_save_without_configs_root_raises(self, monkeypatch):
+        import geecs_console.services.scan_variable_store as module
+
+        monkeypatch.setattr(module, "_configs_base", lambda: None)
+        with pytest.raises(ScanVariableStoreError, match="Configs repo not found"):
+            ScanVariableStore("HTU").save(full_catalog())
+
+
+class TestPathEscape:
+    @pytest.mark.parametrize("experiment", ["../evil", "a/b", "a\\b", "..", "."])
+    def test_experiment_with_separators_is_rejected(self, tmp_path, experiment):
+        store = ScanVariableStore(experiment, experiments_root=tmp_path)
+        with pytest.raises(ScanVariableStoreError, match="plain folder name"):
+            store.save(full_catalog())
+
+    def test_escaping_experiment_never_touches_disk(self, tmp_path):
+        store = ScanVariableStore("../evil", experiments_root=tmp_path / "root")
+        with pytest.raises(ScanVariableStoreError):
+            store.save(full_catalog())
+        assert not (tmp_path / "evil").exists()
+
+
+class TestBadDocuments:
+    def test_invalid_yaml_raises_with_path(self, store, tmp_path):
+        path = catalog_path(tmp_path)
+        path.parent.mkdir(parents=True)
+        path.write_text("variables: [unclosed")
+        with pytest.raises(ScanVariableStoreError, match="not valid YAML"):
+            store.load()
+
+    def test_non_mapping_document_raises(self, store, tmp_path):
+        path = catalog_path(tmp_path)
+        path.parent.mkdir(parents=True)
+        path.write_text("- just\n- a\n- list\n")
+        with pytest.raises(ScanVariableStoreError, match="YAML mapping"):
+            store.load()
+
+    def test_schema_rejection_raises(self, store, tmp_path):
+        path = catalog_path(tmp_path)
+        path.parent.mkdir(parents=True)
+        path.write_text(
+            "schema_version: 1\nvariables:\n  broken:\n    target: no_separator\n"
+        )
+        with pytest.raises(ScanVariableStoreError, match="not a valid ScanVariables"):
+            store.load()
+
+
+class TestLegacyPair:
+    def test_legacy_pair_is_converted(self, store, tmp_path):
+        folder = tmp_path / "HTU" / SCAN_VARIABLES_FOLDER
+        folder.mkdir(parents=True)
+        (folder / "scan_devices.yaml").write_text(
+            "single_scan_devices:\n  JetZ (mm): U_ESP_JetXYZ:Position.Axis 3\n"
+        )
+        (folder / "composite_variables.yaml").write_text(
+            "composite_variables:\n"
+            "  offset_x:\n"
+            "    mode: relative\n"
+            "    components:\n"
+            "    - device: U_S3H\n"
+            "      variable: Current\n"
+            "      relation: composite_var * 1\n"
+        )
+        catalog = store.load()
+        assert catalog.variables["JetZ (mm)"].target == "U_ESP_JetXYZ:Position.Axis 3"
+        composite = catalog.variables["offset_x"]
+        assert composite.kind == "pseudo"
+        assert composite.mode == CompositeMode.RELATIVE
+        assert composite.targets[0].target == "U_S3H:Current"
+
+    def test_new_schema_file_wins_over_legacy(self, store, tmp_path):
+        folder = tmp_path / "HTU" / SCAN_VARIABLES_FOLDER
+        folder.mkdir(parents=True)
+        (folder / "scan_devices.yaml").write_text(
+            "single_scan_devices:\n  legacy_only: Dev:Var\n"
+        )
+        store.save(full_catalog())
+        assert "legacy_only" not in store.load().variables
+
+    def test_broken_legacy_pair_raises(self, store, tmp_path):
+        folder = tmp_path / "HTU" / SCAN_VARIABLES_FOLDER
+        folder.mkdir(parents=True)
+        (folder / "scan_devices.yaml").write_text(
+            "single_scan_devices:\n  broken: no_separator_here\n"
+        )
+        with pytest.raises(ScanVariableStoreError, match="could not be converted"):
+            store.load()
+
+
+class TestExperimentSwitch:
+    def test_set_experiment_switches_folders(self, tmp_path):
+        store = ScanVariableStore("HTU", experiments_root=tmp_path)
+        store.save(full_catalog())
+        store.set_experiment("Thomson")
+        assert store.experiment == "Thomson"
+        assert store.load() == empty_catalog()


### PR DESCRIPTION
The M5 editor for the experiment's **scan-variable catalog** — the `scan_devices/scan_variables.yaml` document holding simple (`ScanVariable`) and composite/pseudo (`PseudoScanVariable`) entries. **Files-only** per the parallel-editor isolation rules: no touch to `main_window.py`, the main `.ui`, `pyproject.toml`, or `CHANGELOG.md` — menu wiring and the version bump land in the integration PR.

## What's here

### Store — `services/scan_variable_store.py`
- One `ScanVariables` document per experiment at the exact path `ConfigsRepoResolver` reads: `scanner_configs/experiments/<Exp>/scan_devices/scan_variables.yaml`.
- Dialect handling mirrors the resolver: new-schema file wins; otherwise the legacy pair (`scan_devices.yaml` + `composite_variables.yaml`) is converted on load via `geecs_schemas.convert.convert_scan_variables`, so unmigrated experiments still open.
- Save writes the new schema as `model_dump(mode="json", exclude_none=True)` — **verified read-only against the real Undulator catalog (59 variables, 12 pseudos): load → dump reproduces the on-disk document identically.**
- Offline / missing file → empty catalog (editor still opens); bad YAML / schema rejection / no-experiment save → `ScanVariableStoreError` with a status-bar-fit message; experiment-name path-escape guard.

### Editor — `editors/scan_variable_editor.py` + `app/ui/scan_variable_editor.ui` (`sve_` prefix)
- Variable list with `[simple]` / `[composite]` type tags; New / New composite / Duplicate / Rename / Delete.
- Forms derived from the actual schema models:
  - **simple**: device + variable (the `target`), `kind` (setpoint/motor), optional `confirm` device/variable pair (the topology-C field);
  - **composite**: `mode` combo — the forward column header and hint re-label per mode (*absolute value* vs *offset from scan start*) — an editable components table (device, variable, `forward` in terms of `composite_var`) with add/remove, and the optional `inverse`.
- Edits accumulate in a plain-dict draft (invalid intermediate states are representable while typing); Save validates the whole draft through `ScanVariables.model_validate` and shows pydantic errors inline — smart-union other-branch noise is filtered so a composite error reads `variables → name → targets → 0 → forward: …`, never a crash.
- Dirty tracking + Revert + unsaved-changes prompt on close/Esc (prompt and rename dialogs are injectable seams for tests).
- **Completers**: device/variable fields (simple form, confirm pair, every components-table row) get `QCompleter` popups from an injectable `CompletionsProvider` (`services/device_completions.py`): `EmptyCompletions` offline/test default, `GeecsDbCompletions` = one cached `GeecsDb.get_experiment_device_variables` query, lazily imported, degrading to empty on any failure. The provider's one blocking call runs on a short-lived daemon thread and lands via a queued signal (package no-QThread rule) — a slow DB never blocks the GUI.
- Enter never accepts the dialog (no default/auto-default buttons; Return/Enter swallowed).
- Entry point for the integration PR: `open_scan_variable_editor(parent, experiment, configs_base=None, completions=None) -> QDialog`; opens offline with zero configs.

## Tests

62 new tests (store round-trip incl. multi-component composite, legacy conversion, invalid-YAML/path-escape errors; editor load/edit/save, composite table ops, rename/duplicate/delete incl. collision, dirty/revert/close-prompt paths, completer population and device-following, offline and invalid-YAML opens, Enter handling). Full suite **265 passed, exit 0 across 4 consecutive offscreen runs**. Teardown discipline for the host's segfault class: every dialog registered with `qtbot.addWidget`, the async completions delivery awaited before test bodies run, and the discard prompt defaulted open so teardown `close()` never blocks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)