### PR TITLE
GEECS-Console: ActionLibrary editor (M5, editing only)

### DIFF
--- a/GEECS-Console/geecs_console/app/ui/action_library_editor.ui
+++ b/GEECS-Console/geecs_console/app/ui/action_library_editor.ui
@@ -1,0 +1,507 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>ActionLibraryEditorRoot</class>
+ <widget class="QWidget" name="ActionLibraryEditorRoot">
+  <property name="windowTitle">
+   <string>Action Library</string>
+  </property>
+  <layout class="QVBoxLayout" name="ale_root_layout">
+   <property name="leftMargin">
+    <number>10</number>
+   </property>
+   <property name="topMargin">
+    <number>10</number>
+   </property>
+   <property name="rightMargin">
+    <number>10</number>
+   </property>
+   <property name="bottomMargin">
+    <number>10</number>
+   </property>
+   <property name="spacing">
+    <number>8</number>
+   </property>
+   <item>
+    <layout class="QHBoxLayout" name="ale_columns_layout">
+     <property name="spacing">
+      <number>8</number>
+     </property>
+     <!-- Left column: the plan list -->
+     <item>
+      <widget class="QGroupBox" name="ale_plans_group">
+       <property name="title">
+        <string>ACTION PLANS</string>
+       </property>
+       <layout class="QVBoxLayout" name="ale_plans_layout">
+        <property name="spacing">
+         <number>6</number>
+        </property>
+        <item>
+         <widget class="QListWidget" name="ale_plan_list">
+          <property name="minimumWidth">
+           <number>200</number>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <layout class="QHBoxLayout" name="ale_plan_buttons_layout">
+          <property name="spacing">
+           <number>6</number>
+          </property>
+          <item>
+           <widget class="QPushButton" name="ale_new_button">
+            <property name="text">
+             <string>New</string>
+            </property>
+            <property name="autoDefault">
+             <bool>false</bool>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QPushButton" name="ale_duplicate_button">
+            <property name="text">
+             <string>Duplicate</string>
+            </property>
+            <property name="autoDefault">
+             <bool>false</bool>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QPushButton" name="ale_rename_button">
+            <property name="text">
+             <string>Rename</string>
+            </property>
+            <property name="autoDefault">
+             <bool>false</bool>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QPushButton" name="ale_delete_button">
+            <property name="text">
+             <string>Delete</string>
+            </property>
+            <property name="autoDefault">
+             <bool>false</bool>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </item>
+       </layout>
+      </widget>
+     </item>
+     <!-- Right column: the selected plan -->
+     <item>
+      <widget class="QGroupBox" name="ale_plan_group">
+       <property name="title">
+        <string>SELECTED PLAN</string>
+       </property>
+       <layout class="QVBoxLayout" name="ale_plan_layout">
+        <property name="spacing">
+         <number>6</number>
+        </property>
+        <item>
+         <layout class="QHBoxLayout" name="ale_description_layout">
+          <property name="spacing">
+           <number>6</number>
+          </property>
+          <item>
+           <widget class="QLabel" name="ale_description_label">
+            <property name="text">
+             <string>Description</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QLineEdit" name="ale_description_edit">
+            <property name="placeholderText">
+             <string>What this plan does and when to use it</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </item>
+        <item>
+         <widget class="QTableWidget" name="ale_steps_table">
+          <property name="minimumWidth">
+           <number>380</number>
+          </property>
+          <property name="minimumHeight">
+           <number>180</number>
+          </property>
+          <column>
+           <property name="text">
+            <string>Do</string>
+           </property>
+          </column>
+          <column>
+           <property name="text">
+            <string>Summary</string>
+           </property>
+          </column>
+         </widget>
+        </item>
+        <item>
+         <layout class="QHBoxLayout" name="ale_step_buttons_layout">
+          <property name="spacing">
+           <number>6</number>
+          </property>
+          <item>
+           <widget class="QPushButton" name="ale_add_step_button">
+            <property name="text">
+             <string>Add step</string>
+            </property>
+            <property name="autoDefault">
+             <bool>false</bool>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QPushButton" name="ale_remove_step_button">
+            <property name="text">
+             <string>Remove</string>
+            </property>
+            <property name="autoDefault">
+             <bool>false</bool>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QPushButton" name="ale_up_button">
+            <property name="text">
+             <string>Up</string>
+            </property>
+            <property name="autoDefault">
+             <bool>false</bool>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QPushButton" name="ale_down_button">
+            <property name="text">
+             <string>Down</string>
+            </property>
+            <property name="autoDefault">
+             <bool>false</bool>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <spacer name="ale_step_buttons_spacer">
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>40</width>
+              <height>20</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+         </layout>
+        </item>
+        <!-- Per-step editor: kind selector drives the visible fields -->
+        <item>
+         <widget class="QGroupBox" name="ale_step_group">
+          <property name="title">
+           <string>STEP</string>
+          </property>
+          <layout class="QVBoxLayout" name="ale_step_layout">
+           <property name="spacing">
+            <number>6</number>
+           </property>
+           <item>
+            <layout class="QHBoxLayout" name="ale_kind_layout">
+             <property name="spacing">
+              <number>6</number>
+             </property>
+             <item>
+              <widget class="QLabel" name="ale_kind_label">
+               <property name="text">
+                <string>Do</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QComboBox" name="ale_kind_combo">
+               <property name="minimumWidth">
+                <number>110</number>
+               </property>
+               <item>
+                <property name="text">
+                 <string>set</string>
+                </property>
+               </item>
+               <item>
+                <property name="text">
+                 <string>wait</string>
+                </property>
+               </item>
+               <item>
+                <property name="text">
+                 <string>check</string>
+                </property>
+               </item>
+               <item>
+                <property name="text">
+                 <string>run</string>
+                </property>
+               </item>
+              </widget>
+             </item>
+             <item>
+              <spacer name="ale_kind_spacer">
+               <property name="orientation">
+                <enum>Qt::Horizontal</enum>
+               </property>
+               <property name="sizeHint" stdset="0">
+                <size>
+                 <width>40</width>
+                 <height>20</height>
+                </size>
+               </property>
+              </spacer>
+             </item>
+            </layout>
+           </item>
+           <item>
+            <widget class="QStackedWidget" name="ale_step_stack">
+             <!-- page 0: set -->
+             <widget class="QWidget" name="ale_page_set">
+              <layout class="QFormLayout" name="ale_set_form">
+               <item row="0" column="0">
+                <widget class="QLabel" name="ale_set_device_label">
+                 <property name="text">
+                  <string>Device</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="0" column="1">
+                <widget class="QLineEdit" name="ale_set_device_edit">
+                 <property name="placeholderText">
+                  <string>e.g. U_148_PLC</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="1" column="0">
+                <widget class="QLabel" name="ale_set_variable_label">
+                 <property name="text">
+                  <string>Variable</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="1" column="1">
+                <widget class="QLineEdit" name="ale_set_variable_edit">
+                 <property name="placeholderText">
+                  <string>e.g. DO.Ch9</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="2" column="0">
+                <widget class="QLabel" name="ale_set_value_label">
+                 <property name="text">
+                  <string>Value</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="2" column="1">
+                <widget class="QLineEdit" name="ale_set_value_edit">
+                 <property name="placeholderText">
+                  <string>number or word, e.g. 0 or on</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="3" column="1">
+                <widget class="QCheckBox" name="ale_set_wait_check">
+                 <property name="text">
+                  <string>Wait for execution</string>
+                 </property>
+                 <property name="checked">
+                  <bool>true</bool>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </widget>
+             <!-- page 1: wait -->
+             <widget class="QWidget" name="ale_page_wait">
+              <layout class="QFormLayout" name="ale_wait_form">
+               <item row="0" column="0">
+                <widget class="QLabel" name="ale_wait_seconds_label">
+                 <property name="text">
+                  <string>Seconds</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="0" column="1">
+                <widget class="QDoubleSpinBox" name="ale_wait_seconds_spin">
+                 <property name="buttonSymbols">
+                  <enum>QAbstractSpinBox::NoButtons</enum>
+                 </property>
+                 <property name="maximumWidth">
+                  <number>110</number>
+                 </property>
+                 <property name="decimals">
+                  <number>3</number>
+                 </property>
+                 <property name="minimum">
+                  <double>0.000000000000000</double>
+                 </property>
+                 <property name="maximum">
+                  <double>86400.000000000000000</double>
+                 </property>
+                 <property name="value">
+                  <double>1.000000000000000</double>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </widget>
+             <!-- page 2: check -->
+             <widget class="QWidget" name="ale_page_check">
+              <layout class="QFormLayout" name="ale_check_form">
+               <item row="0" column="0">
+                <widget class="QLabel" name="ale_check_device_label">
+                 <property name="text">
+                  <string>Device</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="0" column="1">
+                <widget class="QLineEdit" name="ale_check_device_edit">
+                 <property name="placeholderText">
+                  <string>e.g. U_GaiaSVEReader</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="1" column="0">
+                <widget class="QLabel" name="ale_check_variable_label">
+                 <property name="text">
+                  <string>Variable</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="1" column="1">
+                <widget class="QLineEdit" name="ale_check_variable_edit">
+                 <property name="placeholderText">
+                  <string>e.g. InternalShutterA</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="2" column="0">
+                <widget class="QLabel" name="ale_check_expected_label">
+                 <property name="text">
+                  <string>Expected</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="2" column="1">
+                <widget class="QLineEdit" name="ale_check_expected_edit">
+                 <property name="placeholderText">
+                  <string>number or word the reading must match</string>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </widget>
+             <!-- page 3: run -->
+             <widget class="QWidget" name="ale_page_run">
+              <layout class="QFormLayout" name="ale_run_form">
+               <item row="0" column="0">
+                <widget class="QLabel" name="ale_run_plan_label">
+                 <property name="text">
+                  <string>Plan</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="0" column="1">
+                <widget class="QComboBox" name="ale_run_plan_combo">
+                 <property name="editable">
+                  <bool>true</bool>
+                 </property>
+                 <property name="minimumWidth">
+                  <number>220</number>
+                 </property>
+                </widget>
+               </item>
+               <item row="1" column="1">
+                <widget class="QLabel" name="ale_run_warning_label">
+                 <property name="text">
+                  <string/>
+                 </property>
+                 <property name="wordWrap">
+                  <bool>true</bool>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </widget>
+            </widget>
+           </item>
+          </layout>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLabel" name="ale_error_label">
+          <property name="text">
+           <string/>
+          </property>
+          <property name="wordWrap">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <layout class="QHBoxLayout" name="ale_save_row_layout">
+          <property name="spacing">
+           <number>6</number>
+          </property>
+          <item>
+           <spacer name="ale_save_spacer">
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>40</width>
+              <height>20</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+          <item>
+           <widget class="QPushButton" name="ale_revert_button">
+            <property name="text">
+             <string>Revert</string>
+            </property>
+            <property name="autoDefault">
+             <bool>false</bool>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QPushButton" name="ale_save_button">
+            <property name="text">
+             <string>Save</string>
+            </property>
+            <property name="autoDefault">
+             <bool>false</bool>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </item>
+       </layout>
+      </widget>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/GEECS-Console/geecs_console/editors/__init__.py
+++ b/GEECS-Console/geecs_console/editors/__init__.py
@@ -1,0 +1,1 @@
+"""Editor dialogs for the configs-repo config kinds (editing only)."""

--- a/GEECS-Console/geecs_console/editors/__init__.py
+++ b/GEECS-Console/geecs_console/editors/__init__.py
@@ -1,1 +1,1 @@
-"""Editor dialogs for the configs-repo config kinds (editing only)."""
+"""Editor dialogs for the configs the console submits by name (M5)."""

--- a/GEECS-Console/geecs_console/editors/action_library_editor.py
+++ b/GEECS-Console/geecs_console/editors/action_library_editor.py
@@ -1,0 +1,1102 @@
+"""The ActionLibrary editor dialog — **editing only, never execution**.
+
+Edits the named :class:`~geecs_schemas.ActionPlan`s of one experiment's
+``action_library/actions.yaml`` through
+:class:`~geecs_console.services.action_library_store.ActionLibraryStore`.
+A plan is an ordered list of steps; the step kinds and their fields come
+straight from the schema's discriminated union (``geecs_schemas.action_plan``):
+``set`` (device / variable / value / wait_for_execution), ``wait``
+(seconds), ``check`` (device / variable / expected), and ``run`` (the name
+of another plan in the same library).
+
+Design notes
+------------
+- **No execution surface.**  This dialog cannot run a plan: there is no run
+  button, no Channel Access import, and nothing that reaches a device.
+  Executing plans from the console is separate future work (G-actions).
+- **Offline-first**: opens with zero network and zero configs (empty plan
+  list, saving reports the missing configs repo inline).
+- The ``.ui`` is hand-authored XML (``app/ui/action_library_editor.ui``,
+  object names prefixed ``ale_``) loaded at runtime via ``QUiLoader``.
+- Device/variable fields carry a ``QCompleter`` fed by an injectable
+  :class:`CompletionsProvider`; the production
+  :class:`GeecsDbCompletions` queries ``GeecsDb`` lazily and degrades to
+  empty on any failure, tests inject fakes, and the default is
+  :class:`EmptyCompletions` (offline).
+- Enter never accepts the dialog (every button is non-default and the
+  key is swallowed) — pressing Return in a field must not close the editor.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Optional, Protocol
+
+from pydantic import ValidationError
+from PySide6.QtCore import QFile, QStringListModel, Qt
+from PySide6.QtGui import QCloseEvent, QKeyEvent
+from PySide6.QtUiTools import QUiLoader
+from PySide6.QtWidgets import (
+    QAbstractItemView,
+    QApplication,
+    QCheckBox,
+    QComboBox,
+    QCompleter,
+    QDialog,
+    QDoubleSpinBox,
+    QHeaderView,
+    QInputDialog,
+    QLabel,
+    QLineEdit,
+    QListWidget,
+    QMessageBox,
+    QPushButton,
+    QStackedWidget,
+    QTableWidget,
+    QTableWidgetItem,
+    QVBoxLayout,
+    QWidget,
+)
+
+from geecs_console.services.action_library_store import (
+    ActionLibraryStore,
+    ActionLibraryStoreError,
+)
+from geecs_schemas import ActionPlan
+
+logger = logging.getLogger(__name__)
+
+_UI_PATH = Path(__file__).parent.parent / "app" / "ui" / "action_library_editor.ui"
+
+#: Step kinds in kind-combo / stacked-page order — mirrors the schema's
+#: discriminated union (``geecs_schemas.action_plan.ActionStep``).
+STEP_KINDS = ("set", "wait", "check", "run")
+
+
+# ---------------------------------------------------------------------------
+# Completions seam
+# ---------------------------------------------------------------------------
+
+
+class CompletionsProvider(Protocol):
+    """Device/variable name completions for the step editor fields."""
+
+    def devices(self) -> list[str]:
+        """Return the known device names (may be empty)."""
+        ...
+
+    def variables(self, device: str) -> list[str]:
+        """Return the known variable names of *device* (may be empty)."""
+        ...
+
+
+class EmptyCompletions:
+    """The offline/test default: no completions at all."""
+
+    def devices(self) -> list[str]:
+        """Return no device names."""
+        return []
+
+    def variables(self, device: str) -> list[str]:
+        """Return no variable names.
+
+        Parameters
+        ----------
+        device : str
+            Ignored.
+        """
+        return []
+
+
+class GeecsDbCompletions:
+    """DB-backed completions: devices and variables of one experiment.
+
+    Queries ``GeecsDb.get_experiment_device_variables`` **lazily on first
+    use** and caches the result; any failure (no lab network, missing
+    ``mysql-connector``, missing config) degrades to empty completions with
+    a log line — never an exception, never a retry loop.
+
+    Parameters
+    ----------
+    experiment : str
+        GEECS experiment name to enumerate.
+    """
+
+    def __init__(self, experiment: str) -> None:
+        self._experiment = experiment
+        self._cache: Optional[dict[str, list[str]]] = None
+
+    def _catalog(self) -> dict[str, list[str]]:
+        """Fetch (once) the ``{device: [variable, ...]}`` catalog."""
+        if self._cache is not None:
+            return self._cache
+        try:
+            from geecs_ca_gateway.db.geecs_db import GeecsDb
+
+            raw = GeecsDb.get_experiment_device_variables(self._experiment)
+            self._cache = {
+                device: sorted({meta["name"] for meta in metas})
+                for device, metas in raw.items()
+            }
+        except Exception as exc:  # no DB / no network / no driver — degrade
+            logger.info("device/variable completions unavailable: %s", exc)
+            self._cache = {}
+        return self._cache
+
+    def devices(self) -> list[str]:
+        """Return the experiment's device names (empty offline)."""
+        return sorted(self._catalog())
+
+    def variables(self, device: str) -> list[str]:
+        """Return *device*'s variable names (empty offline/unknown).
+
+        Parameters
+        ----------
+        device : str
+            The device to enumerate variables for.
+        """
+        return self._catalog().get(device, [])
+
+
+# ---------------------------------------------------------------------------
+# Step-dict helpers (the editor's working representation)
+# ---------------------------------------------------------------------------
+
+
+def default_step(kind: str) -> dict:
+    """Return a fresh working step dict of *kind* with schema-default fields.
+
+    Parameters
+    ----------
+    kind : str
+        One of :data:`STEP_KINDS`.
+
+    Returns
+    -------
+    dict
+        The working step (plain dict — validated into the schema on save).
+    """
+    if kind == "set":
+        return {
+            "do": "set",
+            "device": "",
+            "variable": "",
+            "value": "",
+            "wait_for_execution": True,
+        }
+    if kind == "wait":
+        return {"do": "wait", "seconds": 1.0}
+    if kind == "check":
+        return {"do": "check", "device": "", "variable": "", "expected": ""}
+    if kind == "run":
+        return {"do": "run", "plan": ""}
+    raise ValueError(f"Unknown step kind {kind!r}. Expected one of {STEP_KINDS}.")
+
+
+def convert_step_kind(step: dict, new_kind: str) -> dict:
+    """Convert a working step to *new_kind*, carrying shared fields over.
+
+    ``device``/``variable`` survive a ``set`` ↔ ``check`` switch, and the
+    written ``value`` maps onto the expected reading (and back).
+
+    Parameters
+    ----------
+    step : dict
+        The current working step.
+    new_kind : str
+        The target kind (one of :data:`STEP_KINDS`).
+
+    Returns
+    -------
+    dict
+        A new working step of *new_kind*.
+    """
+    converted = default_step(new_kind)
+    for key in ("device", "variable"):
+        if key in converted and step.get(key):
+            converted[key] = step[key]
+    if new_kind == "check" and step.get("do") == "set":
+        converted["expected"] = step.get("value", "")
+    if new_kind == "set" and step.get("do") == "check":
+        converted["value"] = step.get("expected", "")
+    return converted
+
+
+def parse_action_value(text: str, original: object = None) -> object:
+    """Parse a value field's text into the schema's ``str | float | int``.
+
+    When the text still renders the *original* value unchanged, the original
+    object is returned as-is so an untouched field never changes type (a
+    string ``"0"`` loaded from YAML stays a string through a save).
+
+    Parameters
+    ----------
+    text : str
+        The field text.
+    original : str or float or int, optional
+        The value the field was populated from.
+
+    Returns
+    -------
+    str or float or int
+        ``int`` when the text parses as one, else ``float``, else the text.
+    """
+    if original is not None and str(original) == text:
+        return original
+    stripped = text.strip()
+    try:
+        return int(stripped)
+    except ValueError:
+        pass
+    try:
+        return float(stripped)
+    except ValueError:
+        pass
+    return text
+
+
+def step_summary(step: dict) -> str:
+    """One-line summary of a working step for the steps table.
+
+    Parameters
+    ----------
+    step : dict
+        The working step.
+
+    Returns
+    -------
+    str
+        A compact human-readable description.
+    """
+    kind = step.get("do", "?")
+    if kind == "set":
+        suffix = "" if step.get("wait_for_execution", True) else "  (no wait)"
+        return (
+            f"{step.get('device', '')}:{step.get('variable', '')} "
+            f"← {step.get('value', '')}{suffix}"
+        )
+    if kind == "wait":
+        return f"{step.get('seconds', '')} s"
+    if kind == "check":
+        return (
+            f"{step.get('device', '')}:{step.get('variable', '')} "
+            f"== {step.get('expected', '')}"
+        )
+    if kind == "run":
+        return f"→ {step.get('plan', '')}"
+    return ""
+
+
+# ---------------------------------------------------------------------------
+# The dialog
+# ---------------------------------------------------------------------------
+
+
+class ActionLibraryEditor(QDialog):
+    """Edit the named action plans of one experiment (no execution).
+
+    Parameters
+    ----------
+    store : ActionLibraryStore, optional
+        The persistence seam; defaults to an :class:`ActionLibraryStore`
+        with no experiment (offline: empty list, saving reports why).
+    completions : CompletionsProvider, optional
+        Device/variable completions for the step fields; defaults to
+        :class:`EmptyCompletions`.
+    parent : QWidget, optional
+        Standard Qt parent.
+    """
+
+    def __init__(
+        self,
+        store: ActionLibraryStore | None = None,
+        completions: CompletionsProvider | None = None,
+        parent: QWidget | None = None,
+    ) -> None:
+        super().__init__(parent)
+        self._store = store if store is not None else ActionLibraryStore()
+        self._completions: CompletionsProvider = (
+            completions if completions is not None else EmptyCompletions()
+        )
+
+        self._loading = False
+        self._dirty = False
+        self._current: Optional[str] = None
+        #: Name of a new/duplicated plan that exists only in memory until saved.
+        self._phantom: Optional[str] = None
+        self._working_steps: list[dict] = []
+        self._working_version = 1
+        #: Snapshot for Revert (steps deep-ish copy + description).
+        self._baseline_steps: list[dict] = []
+        self._baseline_description = ""
+
+        self._apply_stylesheet()
+        self._load_ui()
+        self._bind_widgets()
+        self._configure_widgets()
+        self._wire_signals()
+        self._setup_completers()
+
+        self._populate_plan_list()
+        self._clear_plan_editor()
+        self._update_title()
+        self._refresh_enabled()
+
+    # ------------------------------------------------------------------
+    # Construction
+    # ------------------------------------------------------------------
+
+    def _apply_stylesheet(self) -> None:
+        """Apply the console QSS application-wide when not already set."""
+        app = QApplication.instance()
+        if app is not None and not app.styleSheet():
+            from geecs_console.app.main_window import load_stylesheet
+
+            app.setStyleSheet(load_stylesheet())
+
+    def _load_ui(self) -> None:
+        """Load the hand-authored ``.ui`` as this dialog's content."""
+        loader = QUiLoader()
+        ui_file = QFile(str(_UI_PATH))
+        ui_file.open(QFile.OpenModeFlag.ReadOnly)
+        try:
+            self._ui: QWidget = loader.load(ui_file, self)
+        finally:
+            ui_file.close()
+        if self._ui is None:
+            raise RuntimeError(f"Failed to load {_UI_PATH}: {loader.errorString()}")
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.addWidget(self._ui)
+
+    def _child(self, cls: type, name: str):
+        """Return the named child widget, failing loudly when missing."""
+        widget = self._ui.findChild(cls, name)
+        if widget is None:
+            raise LookupError(f"{name!r} ({cls.__name__}) not found in {_UI_PATH}")
+        return widget
+
+    def _bind_widgets(self) -> None:
+        """Resolve every wired widget from the loaded ``.ui`` once."""
+        self.plan_list: QListWidget = self._child(QListWidget, "ale_plan_list")
+        self.new_button: QPushButton = self._child(QPushButton, "ale_new_button")
+        self.duplicate_button: QPushButton = self._child(
+            QPushButton, "ale_duplicate_button"
+        )
+        self.rename_button: QPushButton = self._child(QPushButton, "ale_rename_button")
+        self.delete_button: QPushButton = self._child(QPushButton, "ale_delete_button")
+        self.description_edit: QLineEdit = self._child(
+            QLineEdit, "ale_description_edit"
+        )
+        self.steps_table: QTableWidget = self._child(QTableWidget, "ale_steps_table")
+        self.add_step_button: QPushButton = self._child(
+            QPushButton, "ale_add_step_button"
+        )
+        self.remove_step_button: QPushButton = self._child(
+            QPushButton, "ale_remove_step_button"
+        )
+        self.up_button: QPushButton = self._child(QPushButton, "ale_up_button")
+        self.down_button: QPushButton = self._child(QPushButton, "ale_down_button")
+        self.kind_combo: QComboBox = self._child(QComboBox, "ale_kind_combo")
+        self.step_stack: QStackedWidget = self._child(QStackedWidget, "ale_step_stack")
+        self.set_device_edit: QLineEdit = self._child(QLineEdit, "ale_set_device_edit")
+        self.set_variable_edit: QLineEdit = self._child(
+            QLineEdit, "ale_set_variable_edit"
+        )
+        self.set_value_edit: QLineEdit = self._child(QLineEdit, "ale_set_value_edit")
+        self.set_wait_check: QCheckBox = self._child(QCheckBox, "ale_set_wait_check")
+        self.wait_seconds_spin: QDoubleSpinBox = self._child(
+            QDoubleSpinBox, "ale_wait_seconds_spin"
+        )
+        self.check_device_edit: QLineEdit = self._child(
+            QLineEdit, "ale_check_device_edit"
+        )
+        self.check_variable_edit: QLineEdit = self._child(
+            QLineEdit, "ale_check_variable_edit"
+        )
+        self.check_expected_edit: QLineEdit = self._child(
+            QLineEdit, "ale_check_expected_edit"
+        )
+        self.run_plan_combo: QComboBox = self._child(QComboBox, "ale_run_plan_combo")
+        self.run_warning_label: QLabel = self._child(QLabel, "ale_run_warning_label")
+        self.error_label: QLabel = self._child(QLabel, "ale_error_label")
+        self.revert_button: QPushButton = self._child(QPushButton, "ale_revert_button")
+        self.save_button: QPushButton = self._child(QPushButton, "ale_save_button")
+
+    def _configure_widgets(self) -> None:
+        """Post-load widget configuration ``.ui`` XML cannot express well."""
+        table = self.steps_table
+        table.setEditTriggers(QAbstractItemView.EditTrigger.NoEditTriggers)
+        table.setSelectionBehavior(QAbstractItemView.SelectionBehavior.SelectRows)
+        table.setSelectionMode(QAbstractItemView.SelectionMode.SingleSelection)
+        header = table.horizontalHeader()
+        header.setSectionResizeMode(0, QHeaderView.ResizeMode.ResizeToContents)
+        header.setSectionResizeMode(1, QHeaderView.ResizeMode.Stretch)
+        self.run_warning_label.setStyleSheet("color: #d9a21b;")  # --warn amber
+        self.error_label.setStyleSheet("color: #c4453a;")  # --abort red
+        self.run_plan_combo.setInsertPolicy(QComboBox.InsertPolicy.NoInsert)
+
+    def _wire_signals(self) -> None:
+        """Connect every widget signal to its handler."""
+        self.plan_list.currentItemChanged.connect(self._on_plan_selected)
+        self.new_button.clicked.connect(self._on_new)
+        self.duplicate_button.clicked.connect(self._on_duplicate)
+        self.rename_button.clicked.connect(self._on_rename)
+        self.delete_button.clicked.connect(self._on_delete)
+        self.description_edit.textEdited.connect(self._on_description_edited)
+        self.steps_table.currentCellChanged.connect(self._on_step_row_changed)
+        self.add_step_button.clicked.connect(self._on_add_step)
+        self.remove_step_button.clicked.connect(self._on_remove_step)
+        self.up_button.clicked.connect(lambda: self._on_move_step(-1))
+        self.down_button.clicked.connect(lambda: self._on_move_step(+1))
+        self.kind_combo.currentIndexChanged.connect(self._on_kind_changed)
+        self.set_device_edit.textEdited.connect(self._on_step_field_edited)
+        self.set_variable_edit.textEdited.connect(self._on_step_field_edited)
+        self.set_value_edit.textEdited.connect(self._on_step_field_edited)
+        self.set_wait_check.toggled.connect(self._on_step_field_edited)
+        self.wait_seconds_spin.valueChanged.connect(self._on_step_field_edited)
+        self.check_device_edit.textEdited.connect(self._on_step_field_edited)
+        self.check_variable_edit.textEdited.connect(self._on_step_field_edited)
+        self.check_expected_edit.textEdited.connect(self._on_step_field_edited)
+        self.run_plan_combo.editTextChanged.connect(self._on_run_plan_changed)
+        self.revert_button.clicked.connect(self._on_revert)
+        self.save_button.clicked.connect(self._on_save)
+        # Variable completions follow the device the operator typed.
+        self.set_device_edit.textChanged.connect(
+            lambda text: self._refresh_variable_completer(
+                self._set_variable_completer_model, text
+            )
+        )
+        self.check_device_edit.textChanged.connect(
+            lambda text: self._refresh_variable_completer(
+                self._check_variable_completer_model, text
+            )
+        )
+
+    def _setup_completers(self) -> None:
+        """Attach device/variable ``QCompleter``s fed by the provider."""
+        try:
+            devices = list(self._completions.devices())
+        except Exception as exc:  # a provider must never break the editor
+            logger.info("completions provider failed: %s", exc)
+            devices = []
+        self._device_completer_model = QStringListModel(devices, self)
+        self._set_variable_completer_model = QStringListModel([], self)
+        self._check_variable_completer_model = QStringListModel([], self)
+        for edit, model in (
+            (self.set_device_edit, self._device_completer_model),
+            (self.check_device_edit, self._device_completer_model),
+            (self.set_variable_edit, self._set_variable_completer_model),
+            (self.check_variable_edit, self._check_variable_completer_model),
+        ):
+            completer = QCompleter(model, edit)
+            completer.setCaseSensitivity(Qt.CaseSensitivity.CaseInsensitive)
+            completer.setFilterMode(Qt.MatchFlag.MatchContains)
+            edit.setCompleter(completer)
+
+    def _refresh_variable_completer(self, model: QStringListModel, device: str) -> None:
+        """Repopulate a variable completer for the typed *device*."""
+        try:
+            model.setStringList(list(self._completions.variables(device)))
+        except Exception as exc:  # a provider must never break the editor
+            logger.info("completions provider failed: %s", exc)
+            model.setStringList([])
+
+    # ------------------------------------------------------------------
+    # Dialog-level behaviour
+    # ------------------------------------------------------------------
+
+    def keyPressEvent(self, event: QKeyEvent) -> None:  # noqa: N802 (Qt API)
+        """Swallow Return/Enter so they never accept (close) the dialog."""
+        if event.key() in (Qt.Key.Key_Return, Qt.Key.Key_Enter):
+            event.accept()
+            return
+        super().keyPressEvent(event)
+
+    def reject(self) -> None:
+        """Prompt for unsaved changes before closing via Escape/close."""
+        if self._dirty and not self._confirm_discard():
+            return
+        super().reject()
+
+    def closeEvent(self, event: QCloseEvent) -> None:  # noqa: N802 (Qt API)
+        """Prompt for unsaved changes before the window closes."""
+        if self._dirty and not self._confirm_discard():
+            event.ignore()
+            return
+        super().closeEvent(event)
+
+    def _update_title(self) -> None:
+        """Render the window title (experiment + unsaved marker)."""
+        experiment = self._store.experiment
+        title = "Action Library" + (f" — {experiment}" if experiment else "")
+        if self._dirty:
+            title += " *"
+        self.setWindowTitle(title)
+
+    # ------------------------------------------------------------------
+    # Prompt seams (tests monkeypatch these)
+    # ------------------------------------------------------------------
+
+    def _prompt_name(self, title: str, initial: str = "") -> Optional[str]:
+        """Ask the operator for a plan name; ``None`` on cancel."""
+        name, accepted = QInputDialog.getText(self, title, "Plan name:", text=initial)
+        return name if accepted else None
+
+    def _confirm_discard(self) -> bool:
+        """Ask whether unsaved changes may be discarded."""
+        answer = QMessageBox.question(
+            self,
+            "Unsaved changes",
+            "The current plan has unsaved changes. Discard them?",
+            QMessageBox.StandardButton.Discard | QMessageBox.StandardButton.Cancel,
+            QMessageBox.StandardButton.Cancel,
+        )
+        return answer == QMessageBox.StandardButton.Discard
+
+    def _confirm_delete(self, name: str) -> bool:
+        """Ask whether plan *name* should really be deleted."""
+        answer = QMessageBox.question(
+            self,
+            "Delete plan",
+            f"Delete action plan {name!r}? This cannot be undone.",
+            QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.Cancel,
+            QMessageBox.StandardButton.Cancel,
+        )
+        return answer == QMessageBox.StandardButton.Yes
+
+    # ------------------------------------------------------------------
+    # Inline messages
+    # ------------------------------------------------------------------
+
+    def _show_error(self, message: str) -> None:
+        """Show *message* in the inline error label."""
+        self.error_label.setText(message)
+
+    def _clear_error(self) -> None:
+        """Clear the inline error label."""
+        self.error_label.setText("")
+
+    def _set_dirty(self, dirty: bool) -> None:
+        """Set the dirty flag and re-render the title."""
+        if self._dirty != dirty:
+            self._dirty = dirty
+            self._update_title()
+
+    # ------------------------------------------------------------------
+    # Plan list
+    # ------------------------------------------------------------------
+
+    def _known_names(self) -> list[str]:
+        """All referenceable plan names: the library plus the unsaved one."""
+        names = self._store.list_names()
+        if self._phantom is not None and self._phantom not in names:
+            names.append(self._phantom)
+        return sorted(names)
+
+    def _populate_plan_list(self, select: Optional[str] = None) -> None:
+        """Repopulate the plan list from the store (plus the phantom)."""
+        self._loading = True
+        try:
+            self.plan_list.clear()
+            for name in self._known_names():
+                self.plan_list.addItem(name)
+            if select is not None:
+                self._select_name(select)
+        finally:
+            self._loading = False
+
+    def _select_name(self, name: Optional[str]) -> None:
+        """Move the list selection to *name* (no-op when absent)."""
+        if name is None:
+            self.plan_list.setCurrentItem(None)
+            return
+        for row in range(self.plan_list.count()):
+            if self.plan_list.item(row).text() == name:
+                self.plan_list.setCurrentRow(row)
+                return
+
+    def _on_plan_selected(self, current, _previous) -> None:
+        """Load the newly selected plan (prompting on unsaved changes)."""
+        if self._loading:
+            return
+        name = current.text() if current is not None else None
+        if name == self._current:
+            return
+        if self._dirty and not self._confirm_discard():
+            self._loading = True
+            try:
+                self._select_name(self._current)
+            finally:
+                self._loading = False
+            return
+        discarded_phantom = self._phantom is not None and self._current == self._phantom
+        self._phantom = None if discarded_phantom else self._phantom
+        self._set_dirty(False)
+        if discarded_phantom:
+            # The discarded new plan disappears with its unsaved state.
+            self._populate_plan_list(select=name)
+        self._load_plan(name)
+
+    def _load_plan(self, name: Optional[str]) -> None:
+        """Populate the editor from plan *name* (or clear it for ``None``)."""
+        self._clear_error()
+        if name is None:
+            self._current = None
+            self._clear_plan_editor()
+            self._refresh_enabled()
+            return
+        try:
+            plan = self._store.load(name)
+        except ActionLibraryStoreError as exc:
+            self._current = None
+            self._clear_plan_editor()
+            self._show_error(str(exc))
+            self._refresh_enabled()
+            return
+        dumped = plan.model_dump(mode="python")
+        self._current = name
+        self._working_version = dumped.get("schema_version", 1)
+        self._working_steps = [dict(step) for step in dumped["steps"]]
+        self._baseline_steps = [dict(step) for step in self._working_steps]
+        self._baseline_description = dumped.get("description", "")
+        self._loading = True
+        try:
+            self.description_edit.setText(self._baseline_description)
+        finally:
+            self._loading = False
+        self._refresh_table(select_row=0 if self._working_steps else None)
+        self._set_dirty(False)
+        self._refresh_enabled()
+
+    def _clear_plan_editor(self) -> None:
+        """Blank the right-hand plan editor (no plan selected)."""
+        self._working_steps = []
+        self._baseline_steps = []
+        self._baseline_description = ""
+        self._loading = True
+        try:
+            self.description_edit.setText("")
+            self.steps_table.setRowCount(0)
+        finally:
+            self._loading = False
+
+    def _refresh_enabled(self) -> None:
+        """Enable/disable buttons and fields for the current selection."""
+        has_plan = self._current is not None
+        row = self.steps_table.currentRow()
+        has_step = has_plan and 0 <= row < len(self._working_steps)
+        for widget in (
+            self.duplicate_button,
+            self.rename_button,
+            self.delete_button,
+            self.description_edit,
+            self.add_step_button,
+            self.save_button,
+            self.revert_button,
+        ):
+            widget.setEnabled(has_plan)
+        self.remove_step_button.setEnabled(has_step and len(self._working_steps) > 1)
+        self.up_button.setEnabled(has_step and row > 0)
+        self.down_button.setEnabled(has_step and row < len(self._working_steps) - 1)
+        self.kind_combo.setEnabled(has_step)
+        self.step_stack.setEnabled(has_step)
+
+    # ------------------------------------------------------------------
+    # Plan-level actions
+    # ------------------------------------------------------------------
+
+    def _start_phantom(self, name: str, steps: list[dict], description: str) -> None:
+        """Begin editing a new in-memory plan *name* (unsaved until Save)."""
+        self._phantom = name
+        self._current = name
+        self._working_version = 1
+        self._working_steps = [dict(step) for step in steps]
+        self._baseline_steps = [dict(step) for step in steps]
+        self._baseline_description = description
+        self._populate_plan_list(select=name)
+        self._loading = True
+        try:
+            self.description_edit.setText(description)
+        finally:
+            self._loading = False
+        self._refresh_table(select_row=0 if self._working_steps else None)
+        self._set_dirty(True)
+        self._clear_error()
+        self._refresh_enabled()
+
+    def _on_new(self) -> None:
+        """Create a new plan (in memory until saved)."""
+        if self._dirty and not self._confirm_discard():
+            return
+        name = self._prompt_name("New action plan")
+        if not name or not name.strip():
+            return
+        name = name.strip()
+        if name in self._store.list_names():
+            self._show_error(f"Plan {name!r} already exists.")
+            return
+        self._set_dirty(False)
+        self._start_phantom(name, [default_step("wait")], "")
+
+    def _on_duplicate(self) -> None:
+        """Duplicate the selected plan under a new name (in memory)."""
+        if self._current is None:
+            return
+        if self._dirty and not self._confirm_discard():
+            return
+        name = self._prompt_name("Duplicate plan", initial=f"{self._current}_copy")
+        if not name or not name.strip():
+            return
+        name = name.strip()
+        if name in self._store.list_names() or name == self._phantom:
+            self._show_error(f"Plan {name!r} already exists.")
+            return
+        steps = [dict(step) for step in self._working_steps]
+        description = self.description_edit.text()
+        self._phantom = None
+        self._set_dirty(False)
+        self._start_phantom(name, steps, description)
+
+    def _on_rename(self) -> None:
+        """Rename the selected plan (updating every ``run`` reference)."""
+        if self._current is None:
+            return
+        new = self._prompt_name("Rename plan", initial=self._current)
+        if not new or not new.strip() or new.strip() == self._current:
+            return
+        new = new.strip()
+        old = self._current
+        if self._phantom == old:
+            if new in self._store.list_names():
+                self._show_error(f"Plan {new!r} already exists.")
+                return
+            self._phantom = new
+            self._current = new
+            self._populate_plan_list(select=new)
+            self._update_title()
+            return
+        try:
+            self._store.rename(old, new)
+        except ActionLibraryStoreError as exc:
+            self._show_error(str(exc))
+            return
+        # Working run-references to the old name follow the rename too.
+        for step in self._working_steps:
+            if step.get("do") == "run" and step.get("plan") == old:
+                step["plan"] = new
+        self._current = new
+        self._populate_plan_list(select=new)
+        self._refresh_table(select_row=self.steps_table.currentRow())
+        self._clear_error()
+
+    def _on_delete(self) -> None:
+        """Delete the selected plan (store-checked for ``run`` referrers)."""
+        if self._current is None:
+            return
+        name = self._current
+        if not self._confirm_delete(name):
+            return
+        if self._phantom == name:
+            self._phantom = None
+            self._current = None
+            self._set_dirty(False)
+            self._populate_plan_list()
+            self._clear_plan_editor()
+            self._clear_error()
+            self._refresh_enabled()
+            return
+        try:
+            self._store.delete(name)
+        except ActionLibraryStoreError as exc:
+            self._show_error(str(exc))
+            return
+        self._current = None
+        self._set_dirty(False)
+        self._populate_plan_list()
+        self._clear_plan_editor()
+        self._clear_error()
+        self._refresh_enabled()
+
+    def _on_description_edited(self, _text: str) -> None:
+        """Mark the plan dirty when its description is edited."""
+        if self._loading:
+            return
+        self._set_dirty(True)
+
+    # ------------------------------------------------------------------
+    # Steps table
+    # ------------------------------------------------------------------
+
+    def _refresh_table(self, select_row: Optional[int] = None) -> None:
+        """Rebuild the steps table from the working steps."""
+        self._loading = True
+        try:
+            table = self.steps_table
+            table.setRowCount(len(self._working_steps))
+            for row, step in enumerate(self._working_steps):
+                table.setItem(row, 0, QTableWidgetItem(step.get("do", "?")))
+                table.setItem(row, 1, QTableWidgetItem(step_summary(step)))
+            if select_row is not None and 0 <= select_row < len(self._working_steps):
+                table.setCurrentCell(select_row, 0)
+        finally:
+            self._loading = False
+        self._load_step_detail(self.steps_table.currentRow())
+        self._refresh_enabled()
+
+    def _update_summary_cell(self, row: int) -> None:
+        """Refresh one row's kind + summary cells in place."""
+        if not (0 <= row < len(self._working_steps)):
+            return
+        step = self._working_steps[row]
+        self._loading = True
+        try:
+            self.steps_table.setItem(row, 0, QTableWidgetItem(step.get("do", "?")))
+            self.steps_table.setItem(row, 1, QTableWidgetItem(step_summary(step)))
+        finally:
+            self._loading = False
+
+    def _on_step_row_changed(
+        self, row: int, _col: int, _prev_row: int, _prev_col: int
+    ) -> None:
+        """Load the newly selected step into the detail editor."""
+        if self._loading:
+            return
+        self._load_step_detail(row)
+        self._refresh_enabled()
+
+    def _load_step_detail(self, row: int) -> None:
+        """Populate the kind combo + stacked fields from step *row*."""
+        if not (0 <= row < len(self._working_steps)):
+            return
+        step = self._working_steps[row]
+        kind = step.get("do", "set")
+        index = STEP_KINDS.index(kind) if kind in STEP_KINDS else 0
+        self._loading = True
+        try:
+            self.kind_combo.setCurrentIndex(index)
+            self.step_stack.setCurrentIndex(index)
+            if kind == "set":
+                self.set_device_edit.setText(str(step.get("device", "")))
+                self.set_variable_edit.setText(str(step.get("variable", "")))
+                self.set_value_edit.setText(str(step.get("value", "")))
+                self.set_wait_check.setChecked(
+                    bool(step.get("wait_for_execution", True))
+                )
+            elif kind == "wait":
+                try:
+                    self.wait_seconds_spin.setValue(float(step.get("seconds", 1.0)))
+                except (TypeError, ValueError):
+                    self.wait_seconds_spin.setValue(0.0)
+            elif kind == "check":
+                self.check_device_edit.setText(str(step.get("device", "")))
+                self.check_variable_edit.setText(str(step.get("variable", "")))
+                self.check_expected_edit.setText(str(step.get("expected", "")))
+            elif kind == "run":
+                self.run_plan_combo.clear()
+                self.run_plan_combo.addItems(self._known_names())
+                self.run_plan_combo.setEditText(str(step.get("plan", "")))
+        finally:
+            self._loading = False
+        if kind == "run":
+            self._update_run_warning(str(step.get("plan", "")))
+
+    def _on_add_step(self) -> None:
+        """Append a fresh step and select it."""
+        if self._current is None:
+            return
+        self._working_steps.append(default_step("set"))
+        self._refresh_table(select_row=len(self._working_steps) - 1)
+        self._set_dirty(True)
+
+    def _on_remove_step(self) -> None:
+        """Remove the selected step (a plan keeps at least one step)."""
+        row = self.steps_table.currentRow()
+        if not (0 <= row < len(self._working_steps)) or len(self._working_steps) <= 1:
+            return
+        del self._working_steps[row]
+        self._refresh_table(select_row=min(row, len(self._working_steps) - 1))
+        self._set_dirty(True)
+
+    def _on_move_step(self, delta: int) -> None:
+        """Move the selected step up (``-1``) or down (``+1``)."""
+        row = self.steps_table.currentRow()
+        target = row + delta
+        if not (0 <= row < len(self._working_steps)):
+            return
+        if not (0 <= target < len(self._working_steps)):
+            return
+        steps = self._working_steps
+        steps[row], steps[target] = steps[target], steps[row]
+        self._refresh_table(select_row=target)
+        self._set_dirty(True)
+
+    # ------------------------------------------------------------------
+    # Step detail editing
+    # ------------------------------------------------------------------
+
+    def _current_step(self) -> Optional[dict]:
+        """Return the working step of the selected row, or ``None``."""
+        row = self.steps_table.currentRow()
+        if 0 <= row < len(self._working_steps):
+            return self._working_steps[row]
+        return None
+
+    def _on_kind_changed(self, index: int) -> None:
+        """Switch the selected step to the newly picked kind."""
+        if self._loading:
+            return
+        row = self.steps_table.currentRow()
+        step = self._current_step()
+        if step is None or not (0 <= index < len(STEP_KINDS)):
+            return
+        new_kind = STEP_KINDS[index]
+        if step.get("do") == new_kind:
+            return
+        self._working_steps[row] = convert_step_kind(step, new_kind)
+        self.step_stack.setCurrentIndex(index)
+        self._update_summary_cell(row)
+        self._load_step_detail(row)
+        self._set_dirty(True)
+
+    def _on_step_field_edited(self, *_args) -> None:
+        """Fold the visible per-kind fields back into the working step."""
+        if self._loading:
+            return
+        row = self.steps_table.currentRow()
+        step = self._current_step()
+        if step is None:
+            return
+        kind = step.get("do")
+        if kind == "set":
+            step["device"] = self.set_device_edit.text()
+            step["variable"] = self.set_variable_edit.text()
+            step["value"] = parse_action_value(
+                self.set_value_edit.text(), step.get("value")
+            )
+            step["wait_for_execution"] = self.set_wait_check.isChecked()
+        elif kind == "wait":
+            step["seconds"] = self.wait_seconds_spin.value()
+        elif kind == "check":
+            step["device"] = self.check_device_edit.text()
+            step["variable"] = self.check_variable_edit.text()
+            step["expected"] = parse_action_value(
+                self.check_expected_edit.text(), step.get("expected")
+            )
+        self._update_summary_cell(row)
+        self._set_dirty(True)
+
+    def _on_run_plan_changed(self, text: str) -> None:
+        """Track the ``run`` step's target plan and warn on dangling names."""
+        if self._loading:
+            return
+        row = self.steps_table.currentRow()
+        step = self._current_step()
+        if step is None or step.get("do") != "run":
+            return
+        step["plan"] = text
+        self._update_summary_cell(row)
+        self._update_run_warning(text)
+        self._set_dirty(True)
+
+    def _update_run_warning(self, plan_name: str) -> None:
+        """Show the inline dangling-reference warning when needed."""
+        if plan_name and plan_name not in self._known_names():
+            self.run_warning_label.setText(
+                f"⚠ plan {plan_name!r} is not in the library"
+            )
+        else:
+            self.run_warning_label.setText("")
+
+    # ------------------------------------------------------------------
+    # Save / Revert
+    # ------------------------------------------------------------------
+
+    def _build_plan(self) -> ActionPlan:
+        """Validate the working state into an :class:`ActionPlan`.
+
+        Raises
+        ------
+        pydantic.ValidationError
+            When the working steps violate the schema (surfaced inline).
+        """
+        return ActionPlan.model_validate(
+            {
+                "schema_version": self._working_version,
+                "steps": self._working_steps,
+                "description": self.description_edit.text(),
+            }
+        )
+
+    def _on_save(self) -> None:
+        """Validate and persist the current plan through the store."""
+        if self._current is None:
+            return
+        self._clear_error()
+        try:
+            plan = self._build_plan()
+        except ValidationError as exc:
+            self._show_error(f"Invalid plan: {exc}")
+            return
+        try:
+            self._store.save(self._current, plan)
+        except ActionLibraryStoreError as exc:
+            self._show_error(str(exc))
+            return
+        self._phantom = None
+        self._baseline_steps = [dict(step) for step in self._working_steps]
+        self._baseline_description = self.description_edit.text()
+        self._set_dirty(False)
+        self._populate_plan_list(select=self._current)
+
+    def _on_revert(self) -> None:
+        """Restore the plan to its last saved (or freshly created) state."""
+        if self._current is None:
+            return
+        self._working_steps = [dict(step) for step in self._baseline_steps]
+        self._loading = True
+        try:
+            self.description_edit.setText(self._baseline_description)
+        finally:
+            self._loading = False
+        self._refresh_table(select_row=0 if self._working_steps else None)
+        # A brand-new unsaved plan stays unsaved (and therefore dirty).
+        self._set_dirty(self._phantom == self._current)
+        self._clear_error()
+
+
+def open_action_library_editor(
+    parent: QWidget | None,
+    experiment: str,
+    configs_base: str | Path | None = None,
+    completions: CompletionsProvider | None = None,
+) -> QDialog:
+    """Open the ActionLibrary editor for *experiment* (editing only).
+
+    The integration entry point the main window's Editors menu will call.
+    Opens offline with zero configs: the plan list is simply empty and
+    saving reports the missing configs repo inline.
+
+    Parameters
+    ----------
+    parent : QWidget or None
+        Parent widget for the dialog.
+    experiment : str
+        Experiment folder under ``scanner_configs/experiments``.
+    configs_base : str or Path, optional
+        Override for the experiments root (defaults to the production
+        resolution, lazily — offline stays fine).
+    completions : CompletionsProvider, optional
+        Device/variable completions; e.g. ``GeecsDbCompletions(experiment)``
+        on the lab network. Defaults to none.
+
+    Returns
+    -------
+    QDialog
+        The shown (non-modal) editor dialog.
+    """
+    store = ActionLibraryStore(experiment, experiments_root=configs_base)
+    dialog = ActionLibraryEditor(store=store, completions=completions, parent=parent)
+    dialog.show()
+    return dialog

--- a/GEECS-Console/geecs_console/editors/action_library_editor.py
+++ b/GEECS-Console/geecs_console/editors/action_library_editor.py
@@ -19,10 +19,13 @@ Design notes
 - The ``.ui`` is hand-authored XML (``app/ui/action_library_editor.ui``,
   object names prefixed ``ale_``) loaded at runtime via ``QUiLoader``.
 - Device/variable fields carry a ``QCompleter`` fed by an injectable
-  :class:`CompletionsProvider`; the production
-  :class:`GeecsDbCompletions` queries ``GeecsDb`` lazily and degrades to
-  empty on any failure, tests inject fakes, and the default is
-  :class:`EmptyCompletions` (offline).
+  :class:`~geecs_console.services.device_completions.CompletionsProvider`
+  (the shared editor seam) — fetched **once on a short-lived daemon thread**
+  (the package's no-QThread rule) and marshaled back through the queued
+  ``completions_ready`` signal, so a slow or unreachable DB never blocks
+  the GUI thread.  The production ``GeecsDbCompletions`` degrades to empty
+  on any failure; tests inject fakes; the constructor default is
+  ``EmptyCompletions`` (offline).
 - Enter never accepts the dialog (every button is non-default and the
   key is swallowed) — pressing Return in a field must not close the editor.
 """
@@ -30,11 +33,12 @@ Design notes
 from __future__ import annotations
 
 import logging
+import threading
 from pathlib import Path
-from typing import Optional, Protocol
+from typing import Optional
 
 from pydantic import ValidationError
-from PySide6.QtCore import QFile, QStringListModel, Qt
+from PySide6.QtCore import QFile, QStringListModel, Qt, Signal, Slot
 from PySide6.QtGui import QCloseEvent, QKeyEvent
 from PySide6.QtUiTools import QUiLoader
 from PySide6.QtWidgets import (
@@ -63,6 +67,11 @@ from geecs_console.services.action_library_store import (
     ActionLibraryStore,
     ActionLibraryStoreError,
 )
+from geecs_console.services.device_completions import (
+    CompletionsProvider,
+    EmptyCompletions,
+    GeecsDbCompletions,
+)
 from geecs_schemas import ActionPlan
 
 logger = logging.getLogger(__name__)
@@ -72,91 +81,6 @@ _UI_PATH = Path(__file__).parent.parent / "app" / "ui" / "action_library_editor.
 #: Step kinds in kind-combo / stacked-page order — mirrors the schema's
 #: discriminated union (``geecs_schemas.action_plan.ActionStep``).
 STEP_KINDS = ("set", "wait", "check", "run")
-
-
-# ---------------------------------------------------------------------------
-# Completions seam
-# ---------------------------------------------------------------------------
-
-
-class CompletionsProvider(Protocol):
-    """Device/variable name completions for the step editor fields."""
-
-    def devices(self) -> list[str]:
-        """Return the known device names (may be empty)."""
-        ...
-
-    def variables(self, device: str) -> list[str]:
-        """Return the known variable names of *device* (may be empty)."""
-        ...
-
-
-class EmptyCompletions:
-    """The offline/test default: no completions at all."""
-
-    def devices(self) -> list[str]:
-        """Return no device names."""
-        return []
-
-    def variables(self, device: str) -> list[str]:
-        """Return no variable names.
-
-        Parameters
-        ----------
-        device : str
-            Ignored.
-        """
-        return []
-
-
-class GeecsDbCompletions:
-    """DB-backed completions: devices and variables of one experiment.
-
-    Queries ``GeecsDb.get_experiment_device_variables`` **lazily on first
-    use** and caches the result; any failure (no lab network, missing
-    ``mysql-connector``, missing config) degrades to empty completions with
-    a log line — never an exception, never a retry loop.
-
-    Parameters
-    ----------
-    experiment : str
-        GEECS experiment name to enumerate.
-    """
-
-    def __init__(self, experiment: str) -> None:
-        self._experiment = experiment
-        self._cache: Optional[dict[str, list[str]]] = None
-
-    def _catalog(self) -> dict[str, list[str]]:
-        """Fetch (once) the ``{device: [variable, ...]}`` catalog."""
-        if self._cache is not None:
-            return self._cache
-        try:
-            from geecs_ca_gateway.db.geecs_db import GeecsDb
-
-            raw = GeecsDb.get_experiment_device_variables(self._experiment)
-            self._cache = {
-                device: sorted({meta["name"] for meta in metas})
-                for device, metas in raw.items()
-            }
-        except Exception as exc:  # no DB / no network / no driver — degrade
-            logger.info("device/variable completions unavailable: %s", exc)
-            self._cache = {}
-        return self._cache
-
-    def devices(self) -> list[str]:
-        """Return the experiment's device names (empty offline)."""
-        return sorted(self._catalog())
-
-    def variables(self, device: str) -> list[str]:
-        """Return *device*'s variable names (empty offline/unknown).
-
-        Parameters
-        ----------
-        device : str
-            The device to enumerate variables for.
-        """
-        return self._catalog().get(device, [])
 
 
 # ---------------------------------------------------------------------------
@@ -303,10 +227,16 @@ class ActionLibraryEditor(QDialog):
         with no experiment (offline: empty list, saving reports why).
     completions : CompletionsProvider, optional
         Device/variable completions for the step fields; defaults to
-        :class:`EmptyCompletions`.
+        :class:`~geecs_console.services.device_completions.EmptyCompletions`.
+        The provider's one blocking call runs on a daemon thread, never the
+        GUI thread.
     parent : QWidget, optional
         Standard Qt parent.
     """
+
+    #: Provider result (``{device: [variable, ...]}``), emitted from the
+    #: fetch daemon thread; delivered queued to :meth:`_apply_completions`.
+    completions_ready = Signal(object)
 
     def __init__(
         self,
@@ -330,6 +260,12 @@ class ActionLibraryEditor(QDialog):
         #: Snapshot for Revert (steps deep-ish copy + description).
         self._baseline_steps: list[dict] = []
         self._baseline_description = ""
+        #: ``{device: [variable, ...]}`` word lists once the fetch lands.
+        self._device_vars: dict[str, list[str]] = {}
+        #: True once the (async) completions fetch has been delivered on the
+        #: GUI thread — tests wait on this so no queued signal can land
+        #: after teardown.
+        self.completions_applied = False
 
         self._apply_stylesheet()
         self._load_ui()
@@ -342,6 +278,11 @@ class ActionLibraryEditor(QDialog):
         self._clear_plan_editor()
         self._update_title()
         self._refresh_enabled()
+
+        self.completions_ready.connect(
+            self._apply_completions, Qt.ConnectionType.QueuedConnection
+        )
+        self._start_completions_fetch()
 
     # ------------------------------------------------------------------
     # Construction
@@ -475,13 +416,8 @@ class ActionLibraryEditor(QDialog):
         )
 
     def _setup_completers(self) -> None:
-        """Attach device/variable ``QCompleter``s fed by the provider."""
-        try:
-            devices = list(self._completions.devices())
-        except Exception as exc:  # a provider must never break the editor
-            logger.info("completions provider failed: %s", exc)
-            devices = []
-        self._device_completer_model = QStringListModel(devices, self)
+        """Attach device/variable ``QCompleter``s (word lists arrive queued)."""
+        self._device_completer_model = QStringListModel([], self)
         self._set_variable_completer_model = QStringListModel([], self)
         self._check_variable_completer_model = QStringListModel([], self)
         for edit, model in (
@@ -495,13 +431,50 @@ class ActionLibraryEditor(QDialog):
             completer.setFilterMode(Qt.MatchFlag.MatchContains)
             edit.setCompleter(completer)
 
+    def _start_completions_fetch(self) -> None:
+        """Fetch completions on a short-lived daemon thread (queued delivery)."""
+        provider = self._completions
+
+        def fetch() -> None:
+            """Run the provider's one blocking call off the GUI thread."""
+            try:
+                mapping = provider.device_variables()
+            except Exception as exc:  # noqa: BLE001 — providers should not raise
+                logger.info("completions fetch failed: %s", exc)
+                mapping = {}
+            self.completions_ready.emit(mapping)
+
+        threading.Thread(
+            target=fetch, name="ale-completions-fetch", daemon=True
+        ).start()
+
+    @Slot(object)
+    def _apply_completions(self, mapping: object) -> None:
+        """Install the fetched ``{device: [variable, ...]}`` word lists (GUI thread).
+
+        Parameters
+        ----------
+        mapping : dict
+            The provider result delivered by the queued signal.
+        """
+        self.completions_applied = True
+        if not isinstance(mapping, dict):
+            return
+        self._device_vars = {
+            str(device): [str(v) for v in variables]
+            for device, variables in mapping.items()
+        }
+        self._device_completer_model.setStringList(sorted(self._device_vars))
+        self._refresh_variable_completer(
+            self._set_variable_completer_model, self.set_device_edit.text()
+        )
+        self._refresh_variable_completer(
+            self._check_variable_completer_model, self.check_device_edit.text()
+        )
+
     def _refresh_variable_completer(self, model: QStringListModel, device: str) -> None:
-        """Repopulate a variable completer for the typed *device*."""
-        try:
-            model.setStringList(list(self._completions.variables(device)))
-        except Exception as exc:  # a provider must never break the editor
-            logger.info("completions provider failed: %s", exc)
-            model.setStringList([])
+        """Point one variable word-list *model* at the variables of *device*."""
+        model.setStringList(self._device_vars.get(device, []))
 
     # ------------------------------------------------------------------
     # Dialog-level behaviour
@@ -1088,15 +1061,20 @@ def open_action_library_editor(
         Override for the experiments root (defaults to the production
         resolution, lazily — offline stays fine).
     completions : CompletionsProvider, optional
-        Device/variable completions; e.g. ``GeecsDbCompletions(experiment)``
-        on the lab network. Defaults to none.
+        Device/variable completion source.  Defaults to the DB-backed
+        provider for a named experiment (fetched on a daemon thread; offline
+        it degrades to empty) and to no completions otherwise.
 
     Returns
     -------
     QDialog
-        The shown (non-modal) editor dialog.
+        The shown (modeless) editor dialog.
     """
     store = ActionLibraryStore(experiment, experiments_root=configs_base)
+    if completions is None:
+        completions = (
+            GeecsDbCompletions(experiment) if experiment else EmptyCompletions()
+        )
     dialog = ActionLibraryEditor(store=store, completions=completions, parent=parent)
     dialog.show()
     return dialog

--- a/GEECS-Console/geecs_console/services/action_library_store.py
+++ b/GEECS-Console/geecs_console/services/action_library_store.py
@@ -1,0 +1,460 @@
+"""Action-library persistence: named :class:`~geecs_schemas.ActionPlan` YAMLs.
+
+The experiment's action plans all live in **one** library file — the same
+one ``geecs_bluesky.config_resolver.ConfigsRepoResolver`` reads::
+
+    scanner_configs/experiments/<Experiment>/action_library/actions.yaml
+
+A file whose top level carries ``schema_version`` loads directly as a
+:class:`~geecs_schemas.ActionPlanLibrary`; anything else is treated as the
+legacy ``actions:`` dialect and goes through
+:func:`geecs_schemas.convert.convert_action_library` — mirroring the
+resolver, so the existing corpus opens unchanged.  Saving always writes the
+new schema (``model_dump(mode="json")``), which round-trips losslessly
+through ``ActionPlanLibrary.model_validate``.
+
+Offline-safety mirrors :class:`~geecs_console.services.presets.PresetStore`:
+listing degrades to empty with no configs root; ``load``/``save``/``delete``/
+``rename`` raise :class:`ActionLibraryStoreError` with a message fit for
+inline display.  The schema's library validator rejects dangling ``run``
+references, so this store pre-checks deletes and saves and raises the
+clearer message itself.  Creating the ``action_library/`` directory with
+``mkdir(parents=True, exist_ok=True)`` is deliberate and fine — this is a
+config directory in the configs repo, not a ``scans/ScanNNN/`` data folder,
+so the repo's scan-folder creation invariant does not apply.
+
+This module is **editing only** — it never executes a plan and never touches
+Channel Access or hardware.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Optional
+
+import yaml
+from pydantic import ValidationError
+
+from geecs_console.services.configs import _configs_base
+from geecs_schemas import ActionPlan, ActionPlanLibrary
+from geecs_schemas.convert import SchemaConversionError, convert_action_library
+
+logger = logging.getLogger(__name__)
+
+ACTION_FOLDER = "action_library"
+LIBRARY_FILE = "actions.yaml"
+
+
+class ActionLibraryStoreError(RuntimeError):
+    """An action-library operation cannot be carried out (shown inline)."""
+
+
+def referencing_plans(library: ActionPlanLibrary, name: str) -> list[str]:
+    """List the plans whose ``run`` steps reference plan *name*.
+
+    Parameters
+    ----------
+    library : ActionPlanLibrary
+        The library to search.
+    name : str
+        The referenced plan name.
+
+    Returns
+    -------
+    list of str
+        Names of plans containing a ``run`` step targeting *name*, sorted.
+    """
+    return sorted(
+        plan_name
+        for plan_name, plan in library.plans.items()
+        if any(getattr(step, "plan", None) == name for step in plan.steps)
+    )
+
+
+class ActionLibraryStore:
+    """Load/save named action plans for one experiment's library file.
+
+    Parameters
+    ----------
+    experiment : str, optional
+        Experiment folder under ``scanner_configs/experiments``.  May be
+        empty at construction (before the operator picks one) — listing is
+        then empty and saving raises.
+    experiments_root : str or Path, optional
+        Override for the experiments root (tests point this at a tmp dir);
+        defaults to the production resolution
+        (:func:`geecs_bluesky.scanner_configs.scanner_configs_base`,
+        resolved lazily so the module stays import-safe offline).
+    """
+
+    def __init__(
+        self, experiment: str = "", experiments_root: str | Path | None = None
+    ) -> None:
+        self._experiment = experiment
+        self._experiments_root = (
+            Path(experiments_root) if experiments_root is not None else None
+        )
+
+    @property
+    def experiment(self) -> str:
+        """The experiment this store reads and writes action plans for."""
+        return self._experiment
+
+    def set_experiment(self, experiment: str) -> None:
+        """Switch the store to *experiment*.
+
+        Parameters
+        ----------
+        experiment : str
+            The new experiment folder name ("" for none selected).
+        """
+        self._experiment = experiment
+
+    # ------------------------------------------------------------------
+    # Path resolution
+    # ------------------------------------------------------------------
+
+    def _library_path(self) -> Optional[Path]:
+        """Return the library file path, or ``None`` offline/unselected."""
+        root = self._experiments_root
+        if root is None:
+            root = _configs_base()
+        if root is None or not self._experiment:
+            return None
+        return root / self._experiment / ACTION_FOLDER / LIBRARY_FILE
+
+    def _library_path_or_raise(self) -> Path:
+        """Return the library file path, raising a clear error when unresolvable.
+
+        Returns
+        -------
+        Path
+            ``<experiments root>/<experiment>/action_library/actions.yaml``.
+
+        Raises
+        ------
+        ActionLibraryStoreError
+            When the configs repo is not found or no experiment is selected.
+        """
+        root = self._experiments_root
+        if root is None:
+            root = _configs_base()
+        if root is None:
+            raise ActionLibraryStoreError(
+                "Configs repo not found — set GEECS_SCANNER_CONFIG_DIR or "
+                "config.ini [Paths] scanner_config_root_path."
+            )
+        if not self._experiment:
+            raise ActionLibraryStoreError("No experiment selected.")
+        return root / self._experiment / ACTION_FOLDER / LIBRARY_FILE
+
+    @staticmethod
+    def _validate_name(name: str) -> str:
+        """Validate and normalise a plan name.
+
+        Plan names are dict keys inside one file — no path is built from
+        them — but a name with separators or traversal parts is always a
+        mistake and would confuse every downstream name reference, so it is
+        rejected here.
+
+        Parameters
+        ----------
+        name : str
+            The candidate plan name.
+
+        Returns
+        -------
+        str
+            The stripped name.
+
+        Raises
+        ------
+        ActionLibraryStoreError
+            On an empty name or one containing path separators / traversal.
+        """
+        cleaned = name.strip()
+        if not cleaned:
+            raise ActionLibraryStoreError("Plan name must not be empty.")
+        if any(sep in cleaned for sep in ("/", "\\")) or cleaned in (".", ".."):
+            raise ActionLibraryStoreError(
+                f"Plan name {name!r} must be a plain name (no path separators)."
+            )
+        return cleaned
+
+    # ------------------------------------------------------------------
+    # Whole-library I/O
+    # ------------------------------------------------------------------
+
+    def load_library(self) -> ActionPlanLibrary:
+        """Load the experiment's action-plan library.
+
+        Returns
+        -------
+        ActionPlanLibrary
+            The validated library; **empty** when the library file does not
+            exist yet (a new experiment simply has no plans).
+
+        Raises
+        ------
+        ActionLibraryStoreError
+            Missing configs repo / experiment, unparsable YAML, an
+            unconvertible legacy document, or a document the schema rejects
+            — always with a message fit for inline display.
+        """
+        path = self._library_path_or_raise()
+        if not path.exists():
+            return ActionPlanLibrary(plans={})
+        try:
+            document = yaml.safe_load(path.read_text(encoding="utf-8"))
+        except yaml.YAMLError as exc:
+            raise ActionLibraryStoreError(
+                f"Action library is not valid YAML ({path}): {exc}"
+            ) from exc
+        if document is None:
+            return ActionPlanLibrary(plans={})
+        if not isinstance(document, dict):
+            raise ActionLibraryStoreError(
+                f"Action library ({path}) should be a YAML mapping, got "
+                f"{type(document).__name__}."
+            )
+        if "schema_version" in document:
+            try:
+                return ActionPlanLibrary.model_validate(document)
+            except (ValidationError, ValueError) as exc:
+                raise ActionLibraryStoreError(
+                    f"Action library ({path}) is not a valid ActionPlanLibrary: {exc}"
+                ) from exc
+        try:
+            return convert_action_library(document)
+        except (SchemaConversionError, ValidationError, ValueError) as exc:
+            raise ActionLibraryStoreError(
+                f"Action library ({path}) could not be converted from the "
+                f"legacy dialect: {exc}"
+            ) from exc
+
+    def save_library(self, library: ActionPlanLibrary) -> Path:
+        """Write *library* as the experiment's ``actions.yaml`` (new schema).
+
+        Parameters
+        ----------
+        library : ActionPlanLibrary
+            The validated library to persist.
+
+        Returns
+        -------
+        Path
+            The YAML file written.
+
+        Raises
+        ------
+        ActionLibraryStoreError
+            Missing configs repo / experiment, or an OS-level write failure.
+        """
+        path = self._library_path_or_raise()
+        # A config dir, not a scans/ScanNNN/ data folder — parents=True is
+        # explicitly fine here (the scan-folder invariant does not apply).
+        path.parent.mkdir(parents=True, exist_ok=True)
+        document = yaml.safe_dump(
+            library.model_dump(mode="json"), sort_keys=False, allow_unicode=True
+        )
+        try:
+            path.write_text(document, encoding="utf-8")
+        except OSError as exc:
+            raise ActionLibraryStoreError(
+                f"Could not write the action library: {exc}"
+            ) from exc
+        logger.info("saved action library (%d plans) to %s", len(library.plans), path)
+        return path
+
+    # ------------------------------------------------------------------
+    # Named-plan surface
+    # ------------------------------------------------------------------
+
+    def list_names(self) -> list[str]:
+        """List the saved plan names, sorted; never raises.
+
+        Returns
+        -------
+        list of str
+            Plan names in the library — empty when the configs repo,
+            experiment, or library file is missing or unreadable.
+        """
+        try:
+            return sorted(self.load_library().plans)
+        except ActionLibraryStoreError as exc:
+            logger.info("action library unavailable: %s", exc)
+            return []
+
+    def load(self, name: str) -> ActionPlan:
+        """Load plan *name* as a validated :class:`ActionPlan`.
+
+        Parameters
+        ----------
+        name : str
+            The plan name.
+
+        Returns
+        -------
+        ActionPlan
+            The schema-validated plan.
+
+        Raises
+        ------
+        ActionLibraryStoreError
+            Missing configs repo / experiment / library / plan, or an
+            invalid library file.
+        """
+        cleaned = self._validate_name(name)
+        library = self.load_library()
+        plan = library.plans.get(cleaned)
+        if plan is None:
+            raise ActionLibraryStoreError(
+                f"Action plan {name!r} not found. Known plans: {sorted(library.plans)}"
+            )
+        return plan
+
+    def save(self, name: str, plan: ActionPlan) -> Path:
+        """Write *plan* as *name* into the library (overwriting an existing one).
+
+        Parameters
+        ----------
+        name : str
+            The plan name.
+        plan : ActionPlan
+            The plan to persist.
+
+        Returns
+        -------
+        Path
+            The YAML file written.
+
+        Raises
+        ------
+        ActionLibraryStoreError
+            Missing configs repo / experiment, a bad name, a ``run`` step
+            referencing a plan that would not exist in the saved library, or
+            an OS-level write failure.
+        """
+        cleaned = self._validate_name(name)
+        library = self.load_library()
+        plans = dict(library.plans)
+        plans[cleaned] = plan
+        dangling = sorted(
+            {
+                step.plan
+                for candidate in plans.values()
+                for step in candidate.steps
+                if getattr(step, "plan", None) is not None and step.plan not in plans
+            }
+        )
+        if dangling:
+            raise ActionLibraryStoreError(
+                f"Cannot save {name!r}: 'run' steps reference plans not in "
+                f"the library: {dangling}."
+            )
+        try:
+            updated = ActionPlanLibrary(
+                schema_version=library.schema_version, plans=plans
+            )
+        except (ValidationError, ValueError) as exc:
+            raise ActionLibraryStoreError(f"Cannot save {name!r}: {exc}") from exc
+        return self.save_library(updated)
+
+    def delete(self, name: str) -> None:
+        """Delete plan *name* from the library.
+
+        Parameters
+        ----------
+        name : str
+            The plan name.
+
+        Raises
+        ------
+        ActionLibraryStoreError
+            Missing configs repo / experiment / plan, a plan still
+            referenced by another plan's ``run`` step, or an OS-level write
+            failure.
+        """
+        cleaned = self._validate_name(name)
+        library = self.load_library()
+        if cleaned not in library.plans:
+            raise ActionLibraryStoreError(f"Action plan {name!r} not found.")
+        referrers = referencing_plans(library, cleaned)
+        referrers = [ref for ref in referrers if ref != cleaned]
+        if referrers:
+            raise ActionLibraryStoreError(
+                f"Cannot delete {name!r}: still referenced by 'run' steps in "
+                f"{referrers}."
+            )
+        plans = {k: v for k, v in library.plans.items() if k != cleaned}
+        updated = ActionPlanLibrary(schema_version=library.schema_version, plans=plans)
+        self.save_library(updated)
+        logger.info("deleted action plan %r", name)
+
+    def rename(self, old: str, new: str) -> None:
+        """Rename plan *old* to *new*, updating every ``run`` reference to it.
+
+        The plan keeps its position in the library file, and every other
+        plan's ``run`` step targeting *old* is rewritten to *new* — a rename
+        can therefore never leave a dangling reference behind.
+
+        Parameters
+        ----------
+        old : str
+            The current plan name.
+        new : str
+            The new plan name.
+
+        Raises
+        ------
+        ActionLibraryStoreError
+            Missing configs repo / experiment / plan, a bad new name, a
+            *new* name already in the library, or an OS-level write failure.
+        """
+        cleaned_old = self._validate_name(old)
+        cleaned_new = self._validate_name(new)
+        if cleaned_new == cleaned_old:
+            return
+        library = self.load_library()
+        if cleaned_old not in library.plans:
+            raise ActionLibraryStoreError(f"Action plan {old!r} not found.")
+        if cleaned_new in library.plans:
+            raise ActionLibraryStoreError(
+                f"Cannot rename {old!r}: plan {new!r} already exists."
+            )
+        plans: dict[str, ActionPlan] = {}
+        for plan_name, plan in library.plans.items():
+            retargeted = _retarget_run_steps(plan, cleaned_old, cleaned_new)
+            plans[cleaned_new if plan_name == cleaned_old else plan_name] = retargeted
+        updated = ActionPlanLibrary(schema_version=library.schema_version, plans=plans)
+        self.save_library(updated)
+        logger.info("renamed action plan %r to %r", old, new)
+
+
+def _retarget_run_steps(plan: ActionPlan, old: str, new: str) -> ActionPlan:
+    """Return *plan* with every ``run`` step targeting *old* rewritten to *new*.
+
+    Parameters
+    ----------
+    plan : ActionPlan
+        The plan to rewrite.
+    old : str
+        The referenced plan name to replace.
+    new : str
+        The replacement plan name.
+
+    Returns
+    -------
+    ActionPlan
+        The rewritten plan (the original object when nothing referenced *old*).
+    """
+    if not any(getattr(step, "plan", None) == old for step in plan.steps):
+        return plan
+    steps = [
+        step.model_copy(update={"plan": new})
+        if getattr(step, "plan", None) == old
+        else step
+        for step in plan.steps
+    ]
+    return plan.model_copy(update={"steps": steps})

--- a/GEECS-Console/geecs_console/services/device_completions.py
+++ b/GEECS-Console/geecs_console/services/device_completions.py
@@ -1,0 +1,90 @@
+"""Device/variable completion source for editor forms (offline-safe).
+
+The scan-variable editor's device and variable fields carry ``QCompleter``
+popups.  Their word lists come from a :class:`CompletionsProvider` — one
+blocking call returning ``{device: [variable, ...]}`` — which the editor
+dispatches to a short-lived daemon thread (the package's no-QThread rule)
+and marshals back through a queued Qt signal, so a slow or unreachable DB
+never blocks the GUI thread.
+
+- :class:`EmptyCompletions` — the offline/test default: no suggestions,
+  returns instantly.
+- :class:`GeecsDbCompletions` — the real provider: one
+  ``GeecsDb.get_experiment_device_variables`` query (imported lazily inside
+  the call, keeping this module import-safe offline), cached after the first
+  fetch; any failure — no MySQL, no credentials, unreachable host — degrades
+  to empty with a log line, never an exception.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Optional, Protocol, runtime_checkable
+
+logger = logging.getLogger(__name__)
+
+
+@runtime_checkable
+class CompletionsProvider(Protocol):
+    """Anything that can supply device → variable-name completions."""
+
+    def device_variables(self) -> dict[str, list[str]]:
+        """Return ``{device: [variable name, ...]}``; may block, never raises."""
+        ...
+
+
+class EmptyCompletions:
+    """No completions — the offline and hermetic-test default."""
+
+    def device_variables(self) -> dict[str, list[str]]:
+        """Return no completions.
+
+        Returns
+        -------
+        dict
+            Always empty.
+        """
+        return {}
+
+
+class GeecsDbCompletions:
+    """DB-backed completions for one experiment (cached, failure-tolerant).
+
+    Parameters
+    ----------
+    experiment : str
+        GEECS experiment name to enumerate devices/variables for.
+    """
+
+    def __init__(self, experiment: str) -> None:
+        self._experiment = experiment
+        self._cache: Optional[dict[str, list[str]]] = None
+
+    def device_variables(self) -> dict[str, list[str]]:
+        """Fetch (once) ``{device: [variable name, ...]}`` from ``GeecsDb``.
+
+        Returns
+        -------
+        dict
+            Sorted variable names per device; empty when the experiment is
+            unset or the DB is unreachable (logged, never raised).  Cached
+            after the first successful or failed attempt.
+        """
+        if self._cache is not None:
+            return self._cache
+        self._cache = {}
+        if not self._experiment:
+            return self._cache
+        try:
+            from geecs_ca_gateway.db.geecs_db import GeecsDb
+
+            per_device = GeecsDb.get_experiment_device_variables(self._experiment)
+            self._cache = {
+                device: sorted({str(row["name"]) for row in rows if "name" in row})
+                for device, rows in per_device.items()
+            }
+        except Exception as exc:  # noqa: BLE001 — degrade to empty offline
+            logger.info(
+                "device completions unavailable for %r: %s", self._experiment, exc
+            )
+        return self._cache

--- a/GEECS-Console/tests/test_action_library_editor.py
+++ b/GEECS-Console/tests/test_action_library_editor.py
@@ -1,0 +1,522 @@
+"""ActionLibraryEditor behavior, hermetic: tmp configs roots, offscreen Qt.
+
+Every editor is registered with ``qtbot.addWidget`` so pytest-qt owns the
+teardown (close + deletion) — no test ends with a shown widget that only a
+local variable references.  The modal prompt seams (``_confirm_discard``,
+``_confirm_delete``, ``_prompt_name``) are always stubbed, so no test — and
+no teardown ``closeEvent`` — can ever block on a real ``QMessageBox``.
+"""
+
+import pytest
+import yaml
+from PySide6.QtCore import Qt
+
+from geecs_console.editors.action_library_editor import (
+    ActionLibraryEditor,
+    EmptyCompletions,
+    STEP_KINDS,
+    convert_step_kind,
+    default_step,
+    open_action_library_editor,
+    parse_action_value,
+    step_summary,
+)
+from geecs_console.services.action_library_store import ActionLibraryStore
+
+EXPERIMENT = "TestExp"
+
+LIBRARY = {
+    "schema_version": 1,
+    "plans": {
+        "close_shutters": {
+            "steps": [
+                {
+                    "do": "set",
+                    "device": "U_PLC",
+                    "variable": "DO.Ch9",
+                    "value": "off",
+                    "wait_for_execution": True,
+                },
+                {"do": "wait", "seconds": 3.0},
+                {
+                    "do": "check",
+                    "device": "U_PLC",
+                    "variable": "DI.Ch17",
+                    "expected": "off",
+                },
+            ],
+            "description": "shut it all",
+        },
+        "closeout": {
+            "steps": [
+                {"do": "run", "plan": "close_shutters"},
+                {
+                    "do": "set",
+                    "device": "U_HP_Daq",
+                    "variable": "AnalogOutput.Channel 1",
+                    "value": 0,
+                    "wait_for_execution": False,
+                },
+            ],
+            "description": "",
+        },
+    },
+}
+
+
+class FakeCompletions:
+    """CompletionsProvider stand-in with a fixed catalog."""
+
+    def __init__(self, catalog=None):
+        self._catalog = catalog or {}
+
+    def devices(self):
+        return sorted(self._catalog)
+
+    def variables(self, device):
+        return self._catalog.get(device, [])
+
+
+@pytest.fixture
+def root(tmp_path):
+    """A tmp experiments root with the seeded TestExp action library."""
+    experiments = tmp_path / "experiments"
+    folder = experiments / EXPERIMENT / "action_library"
+    folder.mkdir(parents=True)
+    (folder / "actions.yaml").write_text(
+        yaml.safe_dump(LIBRARY, sort_keys=False), encoding="utf-8"
+    )
+    return experiments
+
+
+def make_editor(qtbot, root, experiment=EXPERIMENT, completions=None):
+    """Build an editor over *root*, teardown-safe and prompt-stubbed."""
+    store = ActionLibraryStore(experiment, experiments_root=root)
+    editor = ActionLibraryEditor(store=store, completions=completions)
+    qtbot.addWidget(editor)
+    # Never let a teardown closeEvent block on a modal box.
+    editor._confirm_discard = lambda: True
+    editor._confirm_delete = lambda name: True
+    return editor
+
+
+def select_plan(editor, name):
+    editor._select_name(name)
+
+
+def store_of(root):
+    return ActionLibraryStore(EXPERIMENT, experiments_root=root)
+
+
+class TestOffline:
+    def test_opens_with_zero_configs(self, qtbot, tmp_path):
+        editor = make_editor(qtbot, tmp_path / "nowhere", experiment="")
+        assert editor.plan_list.count() == 0
+        assert not editor.save_button.isEnabled()
+        assert editor.error_label.text() == ""
+
+    def test_entry_point_opens_offline(self, qtbot, tmp_path):
+        dialog = open_action_library_editor(None, "", configs_base=tmp_path / "nowhere")
+        qtbot.addWidget(dialog)
+        dialog._confirm_discard = lambda: True
+        assert dialog.isVisible()
+        assert dialog.plan_list.count() == 0
+        dialog.close()
+        qtbot.wait(10)
+        assert not dialog.isVisible()
+
+    def test_editor_module_source_has_no_ca_or_execution_imports(self):
+        """Editing only: the editor never imports the CA stack (source pin)."""
+        import geecs_console.editors.action_library_editor as module
+        from pathlib import Path
+
+        source = Path(module.__file__).read_text(encoding="utf-8")
+        for forbidden in (
+            "import aioca",
+            "import caproto",
+            "from aioca",
+            "from caproto",
+        ):
+            assert forbidden not in source
+
+
+class TestNoExecutionSurface:
+    def test_no_run_or_execute_button(self, qtbot, root):
+        from PySide6.QtWidgets import QPushButton
+
+        editor = make_editor(qtbot, root)
+        texts = [b.text().lower() for b in editor.findChildren(QPushButton)]
+        assert texts  # sanity: the buttons were found
+        for text in texts:
+            assert "run" not in text
+            assert "execute" not in text
+
+
+class TestPlanListAndDetail:
+    def test_lists_plans_sorted(self, qtbot, root):
+        editor = make_editor(qtbot, root)
+        names = [
+            editor.plan_list.item(i).text() for i in range(editor.plan_list.count())
+        ]
+        assert names == ["close_shutters", "closeout"]
+
+    def test_selecting_plan_fills_table_and_description(self, qtbot, root):
+        editor = make_editor(qtbot, root)
+        select_plan(editor, "close_shutters")
+        assert editor.steps_table.rowCount() == 3
+        kinds = [editor.steps_table.item(r, 0).text() for r in range(3)]
+        assert kinds == ["set", "wait", "check"]
+        assert editor.description_edit.text() == "shut it all"
+        assert not editor._dirty
+
+    def test_step_selection_drives_kind_and_stack(self, qtbot, root):
+        editor = make_editor(qtbot, root)
+        select_plan(editor, "close_shutters")
+        editor.steps_table.setCurrentCell(0, 0)
+        assert editor.kind_combo.currentText() == "set"
+        assert editor.step_stack.currentIndex() == STEP_KINDS.index("set")
+        assert editor.set_device_edit.text() == "U_PLC"
+        assert editor.set_value_edit.text() == "off"
+        assert editor.set_wait_check.isChecked()
+        editor.steps_table.setCurrentCell(1, 0)
+        assert editor.step_stack.currentIndex() == STEP_KINDS.index("wait")
+        assert editor.wait_seconds_spin.value() == 3.0
+        editor.steps_table.setCurrentCell(2, 0)
+        assert editor.step_stack.currentIndex() == STEP_KINDS.index("check")
+        assert editor.check_expected_edit.text() == "off"
+
+    def test_run_step_page_lists_library_plans(self, qtbot, root):
+        editor = make_editor(qtbot, root)
+        select_plan(editor, "closeout")
+        editor.steps_table.setCurrentCell(0, 0)
+        assert editor.step_stack.currentIndex() == STEP_KINDS.index("run")
+        items = [
+            editor.run_plan_combo.itemText(i)
+            for i in range(editor.run_plan_combo.count())
+        ]
+        assert items == ["close_shutters", "closeout"]
+        assert editor.run_plan_combo.currentText() == "close_shutters"
+        assert editor.run_warning_label.text() == ""
+
+
+class TestKindSwitch:
+    def test_switch_changes_stack_step_and_dirty(self, qtbot, root):
+        editor = make_editor(qtbot, root)
+        select_plan(editor, "close_shutters")
+        editor.steps_table.setCurrentCell(1, 0)  # the wait step
+        editor.kind_combo.setCurrentIndex(STEP_KINDS.index("set"))
+        assert editor.step_stack.currentIndex() == STEP_KINDS.index("set")
+        assert editor._working_steps[1]["do"] == "set"
+        assert editor._dirty
+        assert editor.windowTitle().endswith("*")
+
+    def test_switch_preserves_shared_fields(self):
+        step = {
+            "do": "set",
+            "device": "U_PLC",
+            "variable": "DO.Ch9",
+            "value": "on",
+            "wait_for_execution": True,
+        }
+        converted = convert_step_kind(step, "check")
+        assert converted == {
+            "do": "check",
+            "device": "U_PLC",
+            "variable": "DO.Ch9",
+            "expected": "on",
+        }
+        back = convert_step_kind(converted, "set")
+        assert back["value"] == "on"
+        assert back["device"] == "U_PLC"
+
+
+class TestEditingAndSave:
+    def test_typed_edit_saves_expected_model(self, qtbot, root):
+        editor = make_editor(qtbot, root)
+        select_plan(editor, "close_shutters")
+        editor.steps_table.setCurrentCell(0, 0)
+        editor.set_device_edit.clear()
+        qtbot.keyClicks(editor.set_device_edit, "U_NEW_PLC")
+        assert editor._dirty
+        editor.save_button.click()
+        assert editor.error_label.text() == ""
+        assert not editor._dirty
+        loaded = store_of(root).load("close_shutters")
+        assert loaded.steps[0].device == "U_NEW_PLC"
+        assert loaded.steps[0].value == "off"
+        assert loaded.description == "shut it all"
+
+    def test_add_remove_reorder_persist(self, qtbot, root):
+        editor = make_editor(qtbot, root)
+        select_plan(editor, "close_shutters")
+        editor.add_step_button.click()  # appended 'set' step, selected
+        assert editor.steps_table.rowCount() == 4
+        assert editor.steps_table.currentRow() == 3
+        editor.up_button.click()  # rows: set, wait, NEW, check
+        assert editor.steps_table.currentRow() == 2
+        editor.save_button.click()
+        assert editor.error_label.text() == ""
+        loaded = store_of(root).load("close_shutters")
+        assert [step.do for step in loaded.steps] == ["set", "wait", "set", "check"]
+        # remove it again and confirm the removal persists too
+        editor.steps_table.setCurrentCell(2, 0)
+        editor.remove_step_button.click()
+        editor.save_button.click()
+        loaded = store_of(root).load("close_shutters")
+        assert [step.do for step in loaded.steps] == ["set", "wait", "check"]
+
+    def test_untouched_value_types_survive_save(self, qtbot, root):
+        editor = make_editor(qtbot, root)
+        select_plan(editor, "closeout")
+        editor.steps_table.setCurrentCell(1, 0)
+        # Touch an unrelated field so the plan is dirty but the value is not.
+        editor.set_wait_check.setChecked(True)
+        editor.save_button.click()
+        assert editor.error_label.text() == ""
+        loaded = store_of(root).load("closeout")
+        assert loaded.steps[1].value == 0
+        assert isinstance(loaded.steps[1].value, int)
+        assert loaded.steps[1].wait_for_execution is True
+
+    def test_validation_error_shows_inline_and_blocks_save(self, qtbot, root):
+        editor = make_editor(qtbot, root)
+        select_plan(editor, "close_shutters")
+        editor.steps_table.setCurrentCell(1, 0)
+        editor.wait_seconds_spin.setValue(0.0)  # schema requires gt=0
+        assert editor._dirty
+        editor.save_button.click()
+        assert "Invalid plan" in editor.error_label.text()
+        assert editor._dirty  # nothing was saved
+        assert store_of(root).load("close_shutters").steps[1].seconds == 3.0
+
+
+class TestRunReferences:
+    def test_dangling_reference_warns_inline(self, qtbot, root):
+        editor = make_editor(qtbot, root)
+        select_plan(editor, "closeout")
+        editor.steps_table.setCurrentCell(0, 0)
+        editor.run_plan_combo.setEditText("does_not_exist")
+        assert "does_not_exist" in editor.run_warning_label.text()
+        assert editor._working_steps[0]["plan"] == "does_not_exist"
+        editor.run_plan_combo.setEditText("close_shutters")
+        assert editor.run_warning_label.text() == ""
+
+    def test_saving_dangling_reference_shows_store_error(self, qtbot, root):
+        editor = make_editor(qtbot, root)
+        select_plan(editor, "closeout")
+        editor.steps_table.setCurrentCell(0, 0)
+        editor.run_plan_combo.setEditText("does_not_exist")
+        editor.save_button.click()
+        assert "does_not_exist" in editor.error_label.text()
+        # The library on disk still points at the original plan.
+        assert store_of(root).load("closeout").steps[0].plan == "close_shutters"
+
+
+class TestDirtyRevertPrompt:
+    def test_description_edit_marks_dirty_and_revert_restores(self, qtbot, root):
+        editor = make_editor(qtbot, root)
+        select_plan(editor, "close_shutters")
+        qtbot.keyClicks(editor.description_edit, "!!")
+        assert editor._dirty
+        assert editor.windowTitle().endswith("*")
+        editor.revert_button.click()
+        assert editor.description_edit.text() == "shut it all"
+        assert not editor._dirty
+
+    def test_revert_restores_steps(self, qtbot, root):
+        editor = make_editor(qtbot, root)
+        select_plan(editor, "close_shutters")
+        editor.add_step_button.click()
+        assert editor.steps_table.rowCount() == 4
+        editor.revert_button.click()
+        assert editor.steps_table.rowCount() == 3
+        assert not editor._dirty
+
+    def test_unsaved_changes_block_plan_switch_when_not_discarded(self, qtbot, root):
+        editor = make_editor(qtbot, root)
+        select_plan(editor, "close_shutters")
+        qtbot.keyClicks(editor.description_edit, "!")
+        editor._confirm_discard = lambda: False
+        select_plan(editor, "closeout")
+        assert editor._current == "close_shutters"
+        assert editor.plan_list.currentItem().text() == "close_shutters"
+        assert editor._dirty
+        editor._confirm_discard = lambda: True
+        select_plan(editor, "closeout")
+        assert editor._current == "closeout"
+        assert not editor._dirty
+
+    def test_close_prompts_on_dirty(self, qtbot, root):
+        editor = make_editor(qtbot, root)
+        select_plan(editor, "close_shutters")
+        qtbot.keyClicks(editor.description_edit, "!")
+        editor.show()
+        qtbot.waitExposed(editor)
+        editor._confirm_discard = lambda: False
+        editor.close()
+        qtbot.wait(10)
+        assert editor.isVisible()
+        editor._confirm_discard = lambda: True
+        editor.close()
+        qtbot.wait(10)
+        assert not editor.isVisible()
+
+
+class TestEnterKey:
+    def test_enter_does_not_close_the_dialog(self, qtbot, root):
+        editor = make_editor(qtbot, root)
+        select_plan(editor, "close_shutters")
+        editor.show()
+        qtbot.waitExposed(editor)
+        qtbot.keyClick(editor, Qt.Key.Key_Return)
+        qtbot.keyClick(editor.description_edit, Qt.Key.Key_Return)
+        qtbot.keyClick(editor.set_device_edit, Qt.Key.Key_Enter)
+        qtbot.wait(10)
+        assert editor.isVisible()
+        editor.close()
+        qtbot.wait(10)
+
+
+class TestPlanLifecycle:
+    def test_new_plan_saves_into_store(self, qtbot, root):
+        editor = make_editor(qtbot, root)
+        editor._prompt_name = lambda title, initial="": "fresh_plan"
+        editor.new_button.click()
+        assert editor._current == "fresh_plan"
+        assert editor._dirty
+        assert editor.steps_table.rowCount() == 1  # the default wait step
+        editor.save_button.click()
+        assert editor.error_label.text() == ""
+        assert "fresh_plan" in store_of(root).list_names()
+        loaded = store_of(root).load("fresh_plan")
+        assert loaded.steps[0].do == "wait"
+
+    def test_new_plan_discarded_when_switching_away(self, qtbot, root):
+        editor = make_editor(qtbot, root)
+        editor._prompt_name = lambda title, initial="": "temp_plan"
+        editor.new_button.click()
+        select_plan(editor, "close_shutters")
+        names = [
+            editor.plan_list.item(i).text() for i in range(editor.plan_list.count())
+        ]
+        assert "temp_plan" not in names
+        assert "temp_plan" not in store_of(root).list_names()
+
+    def test_new_plan_rejects_existing_name(self, qtbot, root):
+        editor = make_editor(qtbot, root)
+        editor._prompt_name = lambda title, initial="": "close_shutters"
+        editor.new_button.click()
+        assert "already exists" in editor.error_label.text()
+        assert editor._current is None
+
+    def test_duplicate_plan(self, qtbot, root):
+        editor = make_editor(qtbot, root)
+        select_plan(editor, "close_shutters")
+        editor._prompt_name = lambda title, initial="": "shutters_copy"
+        editor.duplicate_button.click()
+        assert editor._current == "shutters_copy"
+        assert editor._dirty
+        editor.save_button.click()
+        original = store_of(root).load("close_shutters")
+        copy = store_of(root).load("shutters_copy")
+        assert copy.steps == original.steps
+        assert copy.description == original.description
+
+    def test_rename_updates_references_and_selection(self, qtbot, root):
+        editor = make_editor(qtbot, root)
+        select_plan(editor, "close_shutters")
+        editor._prompt_name = lambda title, initial="": "shut_all"
+        editor.rename_button.click()
+        assert editor._current == "shut_all"
+        assert editor.plan_list.currentItem().text() == "shut_all"
+        library_names = store_of(root).list_names()
+        assert "shut_all" in library_names and "close_shutters" not in library_names
+        assert store_of(root).load("closeout").steps[0].plan == "shut_all"
+
+    def test_delete_referenced_plan_reports_inline(self, qtbot, root):
+        editor = make_editor(qtbot, root)
+        select_plan(editor, "close_shutters")
+        editor.delete_button.click()
+        assert "closeout" in editor.error_label.text()
+        assert "close_shutters" in store_of(root).list_names()
+
+    def test_delete_unreferenced_plan(self, qtbot, root):
+        editor = make_editor(qtbot, root)
+        select_plan(editor, "closeout")
+        editor.delete_button.click()
+        assert editor.error_label.text() == ""
+        assert store_of(root).list_names() == ["close_shutters"]
+        assert editor._current is None
+
+
+class TestCompletions:
+    def test_device_completer_uses_provider(self, qtbot, root):
+        provider = FakeCompletions({"U_A": ["Alpha", "Beta"], "U_B": ["Gamma"]})
+        editor = make_editor(qtbot, root, completions=provider)
+        assert editor._device_completer_model.stringList() == ["U_A", "U_B"]
+        assert editor.set_device_edit.completer() is not None
+        assert editor.check_device_edit.completer() is not None
+
+    def test_variable_completer_follows_typed_device(self, qtbot, root):
+        provider = FakeCompletions({"U_A": ["Alpha", "Beta"], "U_B": ["Gamma"]})
+        editor = make_editor(qtbot, root, completions=provider)
+        editor.set_device_edit.setText("U_A")
+        assert editor._set_variable_completer_model.stringList() == ["Alpha", "Beta"]
+        editor.check_device_edit.setText("U_B")
+        assert editor._check_variable_completer_model.stringList() == ["Gamma"]
+        editor.set_device_edit.setText("nope")
+        assert editor._set_variable_completer_model.stringList() == []
+
+    def test_broken_provider_never_breaks_the_editor(self, qtbot, root):
+        class Broken:
+            def devices(self):
+                raise RuntimeError("db exploded")
+
+            def variables(self, device):
+                raise RuntimeError("db exploded")
+
+        editor = make_editor(qtbot, root, completions=Broken())
+        assert editor._device_completer_model.stringList() == []
+        editor.set_device_edit.setText("U_A")
+        assert editor._set_variable_completer_model.stringList() == []
+
+    def test_default_provider_is_empty(self):
+        provider = EmptyCompletions()
+        assert provider.devices() == []
+        assert provider.variables("anything") == []
+
+
+class TestHelpers:
+    @pytest.mark.parametrize(
+        ("text", "original", "expected"),
+        [
+            ("0", None, 0),
+            ("3.5", None, 3.5),
+            ("off", None, "off"),
+            ("off", "off", "off"),
+            ("0", "0", "0"),  # untouched string stays a string
+            ("0", 0, 0),
+            ("7", 3, 7),
+        ],
+    )
+    def test_parse_action_value(self, text, original, expected):
+        result = parse_action_value(text, original)
+        assert result == expected
+        assert type(result) is type(expected)
+
+    def test_step_summaries(self):
+        assert "U_PLC:DO.Ch9 ← off" in step_summary(
+            {"do": "set", "device": "U_PLC", "variable": "DO.Ch9", "value": "off"}
+        )
+        assert step_summary({"do": "wait", "seconds": 3.0}) == "3.0 s"
+        assert "== off" in step_summary(
+            {"do": "check", "device": "d", "variable": "v", "expected": "off"}
+        )
+        assert step_summary({"do": "run", "plan": "p"}) == "→ p"
+
+    def test_default_steps_cover_every_kind(self):
+        for kind in STEP_KINDS:
+            step = default_step(kind)
+            assert step["do"] == kind
+        with pytest.raises(ValueError):
+            default_step("bogus")

--- a/GEECS-Console/tests/test_action_library_editor.py
+++ b/GEECS-Console/tests/test_action_library_editor.py
@@ -12,9 +12,8 @@ import yaml
 from PySide6.QtCore import Qt
 
 from geecs_console.editors.action_library_editor import (
-    ActionLibraryEditor,
-    EmptyCompletions,
     STEP_KINDS,
+    ActionLibraryEditor,
     convert_step_kind,
     default_step,
     open_action_library_editor,
@@ -22,6 +21,7 @@ from geecs_console.editors.action_library_editor import (
     step_summary,
 )
 from geecs_console.services.action_library_store import ActionLibraryStore
+from geecs_console.services.device_completions import EmptyCompletions
 
 EXPERIMENT = "TestExp"
 
@@ -70,11 +70,8 @@ class FakeCompletions:
     def __init__(self, catalog=None):
         self._catalog = catalog or {}
 
-    def devices(self):
-        return sorted(self._catalog)
-
-    def variables(self, device):
-        return self._catalog.get(device, [])
+    def device_variables(self):
+        return dict(self._catalog)
 
 
 @pytest.fixture
@@ -97,6 +94,9 @@ def make_editor(qtbot, root, experiment=EXPERIMENT, completions=None):
     # Never let a teardown closeEvent block on a modal box.
     editor._confirm_discard = lambda: True
     editor._confirm_delete = lambda name: True
+    # Let the queued completions delivery land before the test body runs, so
+    # no fetch signal can arrive after teardown.
+    qtbot.waitUntil(lambda: editor.completions_applied, timeout=2000)
     return editor
 
 
@@ -119,6 +119,7 @@ class TestOffline:
         dialog = open_action_library_editor(None, "", configs_base=tmp_path / "nowhere")
         qtbot.addWidget(dialog)
         dialog._confirm_discard = lambda: True
+        qtbot.waitUntil(lambda: dialog.completions_applied, timeout=2000)
         assert dialog.isVisible()
         assert dialog.plan_list.count() == 0
         dialog.close()
@@ -469,10 +470,7 @@ class TestCompletions:
 
     def test_broken_provider_never_breaks_the_editor(self, qtbot, root):
         class Broken:
-            def devices(self):
-                raise RuntimeError("db exploded")
-
-            def variables(self, device):
+            def device_variables(self):
                 raise RuntimeError("db exploded")
 
         editor = make_editor(qtbot, root, completions=Broken())
@@ -480,10 +478,18 @@ class TestCompletions:
         editor.set_device_edit.setText("U_A")
         assert editor._set_variable_completer_model.stringList() == []
 
+    def test_completer_lists_fill_after_queued_delivery(self, qtbot, root):
+        """The word lists arrive via the queued signal, not at construction."""
+        provider = FakeCompletions({"U_A": ["Alpha"]})
+        store = ActionLibraryStore(EXPERIMENT, experiments_root=root)
+        editor = ActionLibraryEditor(store=store, completions=provider)
+        qtbot.addWidget(editor)
+        editor._confirm_discard = lambda: True
+        qtbot.waitUntil(lambda: editor.completions_applied, timeout=2000)
+        assert editor._device_completer_model.stringList() == ["U_A"]
+
     def test_default_provider_is_empty(self):
-        provider = EmptyCompletions()
-        assert provider.devices() == []
-        assert provider.variables("anything") == []
+        assert EmptyCompletions().device_variables() == {}
 
 
 class TestHelpers:

--- a/GEECS-Console/tests/test_action_library_store.py
+++ b/GEECS-Console/tests/test_action_library_store.py
@@ -1,0 +1,317 @@
+"""ActionLibraryStore behavior, hermetic: tmp configs roots, no network."""
+
+import pytest
+import yaml
+
+import geecs_console.services.action_library_store as store_module
+from geecs_console.services.action_library_store import (
+    ActionLibraryStore,
+    ActionLibraryStoreError,
+    referencing_plans,
+)
+from geecs_schemas import ActionPlan, ActionPlanLibrary
+
+EXPERIMENT = "TestExp"
+
+#: A library exercising every step kind the schema defines.
+ALL_KINDS_LIBRARY = {
+    "schema_version": 1,
+    "plans": {
+        "close_shutters": {
+            "steps": [
+                {
+                    "do": "set",
+                    "device": "U_PLC",
+                    "variable": "DO.Ch9",
+                    "value": "off",
+                    "wait_for_execution": True,
+                },
+                {"do": "wait", "seconds": 3.0},
+                {
+                    "do": "check",
+                    "device": "U_PLC",
+                    "variable": "DI.Ch17",
+                    "expected": "off",
+                },
+            ],
+            "description": "shut it all",
+        },
+        "closeout": {
+            "steps": [
+                {"do": "run", "plan": "close_shutters"},
+                {
+                    "do": "set",
+                    "device": "U_HP_Daq",
+                    "variable": "AnalogOutput.Channel 1",
+                    "value": 0,
+                    "wait_for_execution": False,
+                },
+            ],
+            "description": "",
+        },
+    },
+}
+
+LEGACY_LIBRARY = {
+    "actions": {
+        "zero_pressure": {
+            "steps": [
+                {
+                    "action": "set",
+                    "device": "U_HP_Daq",
+                    "variable": "AnalogOutput.Channel 1",
+                    "value": 0,
+                    "wait_for_execution": True,
+                },
+                {"action": "wait", "wait": 3},
+                {
+                    "action": "get",
+                    "device": "U_148_PLC",
+                    "variable": "DI.Ch17",
+                    "expected_value": "off",
+                },
+                {"action": "execute", "action_name": "nested"},
+            ]
+        },
+        "nested": {"steps": [{"action": "wait", "wait": 1}]},
+    }
+}
+
+
+@pytest.fixture
+def root(tmp_path):
+    """A tmp experiments root with an empty TestExp folder."""
+    experiments = tmp_path / "experiments"
+    (experiments / EXPERIMENT).mkdir(parents=True)
+    return experiments
+
+
+def write_library(root, document):
+    """Write *document* as the TestExp actions.yaml and return the path."""
+    folder = root / EXPERIMENT / "action_library"
+    folder.mkdir(parents=True, exist_ok=True)
+    path = folder / "actions.yaml"
+    path.write_text(yaml.safe_dump(document, sort_keys=False), encoding="utf-8")
+    return path
+
+
+def make_store(root, experiment=EXPERIMENT):
+    return ActionLibraryStore(experiment, experiments_root=root)
+
+
+class TestListing:
+    def test_offline_configs_root_lists_empty(self, monkeypatch):
+        monkeypatch.setattr(store_module, "_configs_base", lambda: None)
+        assert ActionLibraryStore(EXPERIMENT).list_names() == []
+
+    def test_no_experiment_lists_empty(self, root):
+        assert make_store(root, experiment="").list_names() == []
+
+    def test_missing_library_file_lists_empty(self, root):
+        assert make_store(root).list_names() == []
+
+    def test_lists_plan_names_sorted(self, root):
+        write_library(root, ALL_KINDS_LIBRARY)
+        assert make_store(root).list_names() == ["close_shutters", "closeout"]
+
+    def test_unreadable_library_lists_empty(self, root):
+        write_library(root, ALL_KINDS_LIBRARY)
+        path = root / EXPERIMENT / "action_library" / "actions.yaml"
+        path.write_text("plans: {broken: [", encoding="utf-8")
+        assert make_store(root).list_names() == []
+
+
+class TestRoundTrip:
+    def test_every_step_kind_round_trips_losslessly(self, root):
+        write_library(root, ALL_KINDS_LIBRARY)
+        store = make_store(root)
+        first = store.load_library()
+        store.save_library(first)
+        second = store.load_library()
+        assert second == first
+        assert second.plans["close_shutters"].steps[0].do == "set"
+        assert second.plans["close_shutters"].steps[1].do == "wait"
+        assert second.plans["close_shutters"].steps[2].do == "check"
+        assert second.plans["closeout"].steps[0].do == "run"
+
+    def test_value_types_survive_round_trip(self, root):
+        write_library(root, ALL_KINDS_LIBRARY)
+        store = make_store(root)
+        store.save_library(store.load_library())
+        library = store.load_library()
+        assert library.plans["close_shutters"].steps[0].value == "off"
+        assert library.plans["closeout"].steps[1].value == 0
+        assert isinstance(library.plans["closeout"].steps[1].value, int)
+
+    def test_saved_file_is_new_schema(self, root):
+        write_library(root, ALL_KINDS_LIBRARY)
+        store = make_store(root)
+        path = store.save_library(store.load_library())
+        document = yaml.safe_load(path.read_text(encoding="utf-8"))
+        assert document["schema_version"] == 1
+        assert set(document["plans"]) == {"close_shutters", "closeout"}
+
+    def test_reorder_persists(self, root):
+        write_library(root, ALL_KINDS_LIBRARY)
+        store = make_store(root)
+        plan = store.load(name="close_shutters")
+        reordered = plan.model_copy(update={"steps": list(reversed(plan.steps))})
+        store.save("close_shutters", reordered)
+        loaded = store.load("close_shutters")
+        assert [step.do for step in loaded.steps] == ["check", "wait", "set"]
+        assert loaded == reordered
+
+    def test_missing_file_loads_empty_library(self, root):
+        library = make_store(root).load_library()
+        assert library.plans == {}
+
+    def test_empty_file_loads_empty_library(self, root):
+        folder = root / EXPERIMENT / "action_library"
+        folder.mkdir(parents=True)
+        (folder / "actions.yaml").write_text("", encoding="utf-8")
+        assert make_store(root).load_library().plans == {}
+
+
+class TestLegacyConversion:
+    def test_legacy_dialect_loads_via_converter(self, root):
+        write_library(root, LEGACY_LIBRARY)
+        library = make_store(root).load_library()
+        steps = library.plans["zero_pressure"].steps
+        assert [step.do for step in steps] == ["set", "wait", "check", "run"]
+        assert steps[1].seconds == 3
+        assert steps[2].expected == "off"
+        assert steps[3].plan == "nested"
+
+    def test_legacy_migrates_to_new_schema_on_save(self, root):
+        write_library(root, LEGACY_LIBRARY)
+        store = make_store(root)
+        store.save_library(store.load_library())
+        document = yaml.safe_load(
+            (root / EXPERIMENT / "action_library" / "actions.yaml").read_text()
+        )
+        assert "actions" not in document
+        assert document["schema_version"] == 1
+        assert store.list_names() == ["nested", "zero_pressure"]
+
+    def test_unconvertible_legacy_raises(self, root):
+        write_library(root, {"actions": {"bad": {"steps": [{"action": "frobnicate"}]}}})
+        with pytest.raises(ActionLibraryStoreError, match="legacy"):
+            make_store(root).load_library()
+
+
+class TestErrors:
+    def test_load_missing_plan_raises(self, root):
+        write_library(root, ALL_KINDS_LIBRARY)
+        with pytest.raises(ActionLibraryStoreError, match="not found"):
+            make_store(root).load("nope")
+
+    def test_invalid_yaml_raises(self, root):
+        folder = root / EXPERIMENT / "action_library"
+        folder.mkdir(parents=True)
+        (folder / "actions.yaml").write_text("plans: {broken: [", encoding="utf-8")
+        with pytest.raises(ActionLibraryStoreError, match="not valid YAML"):
+            make_store(root).load_library()
+
+    def test_non_mapping_document_raises(self, root):
+        folder = root / EXPERIMENT / "action_library"
+        folder.mkdir(parents=True)
+        (folder / "actions.yaml").write_text("- a\n- b\n", encoding="utf-8")
+        with pytest.raises(ActionLibraryStoreError, match="mapping"):
+            make_store(root).load_library()
+
+    def test_invalid_new_schema_document_raises(self, root):
+        write_library(
+            root,
+            {"schema_version": 1, "plans": {"p": {"steps": [{"do": "bogus"}]}}},
+        )
+        with pytest.raises(ActionLibraryStoreError, match="not a valid"):
+            make_store(root).load_library()
+
+    def test_save_without_experiment_raises(self, root):
+        plan = ActionPlan(steps=[{"do": "wait", "seconds": 1.0}])
+        with pytest.raises(ActionLibraryStoreError, match="No experiment"):
+            make_store(root, experiment="").save("p", plan)
+
+    def test_save_offline_raises(self, monkeypatch):
+        monkeypatch.setattr(store_module, "_configs_base", lambda: None)
+        plan = ActionPlan(steps=[{"do": "wait", "seconds": 1.0}])
+        with pytest.raises(ActionLibraryStoreError, match="Configs repo not found"):
+            ActionLibraryStore(EXPERIMENT).save("p", plan)
+
+    @pytest.mark.parametrize("bad", ["", "  ", "a/b", "a\\b", ".", ".."])
+    def test_bad_plan_names_raise(self, root, bad):
+        store = make_store(root)
+        plan = ActionPlan(steps=[{"do": "wait", "seconds": 1.0}])
+        with pytest.raises(ActionLibraryStoreError):
+            store.save(bad, plan)
+        with pytest.raises(ActionLibraryStoreError):
+            store.load(bad)
+
+    def test_save_with_dangling_run_reference_raises(self, root):
+        write_library(root, ALL_KINDS_LIBRARY)
+        plan = ActionPlan(steps=[{"do": "run", "plan": "does_not_exist"}])
+        with pytest.raises(ActionLibraryStoreError, match="does_not_exist"):
+            make_store(root).save("broken", plan)
+        # Nothing was written.
+        assert make_store(root).list_names() == ["close_shutters", "closeout"]
+
+
+class TestDelete:
+    def test_delete_removes_plan(self, root):
+        write_library(root, ALL_KINDS_LIBRARY)
+        store = make_store(root)
+        store.delete("closeout")
+        assert store.list_names() == ["close_shutters"]
+
+    def test_delete_missing_raises(self, root):
+        write_library(root, ALL_KINDS_LIBRARY)
+        with pytest.raises(ActionLibraryStoreError, match="not found"):
+            make_store(root).delete("nope")
+
+    def test_delete_referenced_plan_raises_naming_referrer(self, root):
+        write_library(root, ALL_KINDS_LIBRARY)
+        with pytest.raises(ActionLibraryStoreError, match="closeout"):
+            make_store(root).delete("close_shutters")
+        assert "close_shutters" in make_store(root).list_names()
+
+
+class TestRename:
+    def test_rename_updates_run_references(self, root):
+        write_library(root, ALL_KINDS_LIBRARY)
+        store = make_store(root)
+        store.rename("close_shutters", "shut_everything")
+        library = store.load_library()
+        assert "close_shutters" not in library.plans
+        assert library.plans["closeout"].steps[0].plan == "shut_everything"
+
+    def test_rename_preserves_file_order(self, root):
+        write_library(root, ALL_KINDS_LIBRARY)
+        make_store(root).rename("close_shutters", "aaa_shut")
+        document = yaml.safe_load(
+            (root / EXPERIMENT / "action_library" / "actions.yaml").read_text()
+        )
+        assert list(document["plans"]) == ["aaa_shut", "closeout"]
+
+    def test_rename_to_existing_raises(self, root):
+        write_library(root, ALL_KINDS_LIBRARY)
+        with pytest.raises(ActionLibraryStoreError, match="already exists"):
+            make_store(root).rename("close_shutters", "closeout")
+
+    def test_rename_missing_raises(self, root):
+        write_library(root, ALL_KINDS_LIBRARY)
+        with pytest.raises(ActionLibraryStoreError, match="not found"):
+            make_store(root).rename("nope", "other")
+
+    def test_rename_to_same_name_is_a_noop(self, root):
+        write_library(root, ALL_KINDS_LIBRARY)
+        store = make_store(root)
+        before = store.load_library()
+        store.rename("close_shutters", "close_shutters")
+        assert store.load_library() == before
+
+
+class TestReferencingPlans:
+    def test_names_referrers(self):
+        library = ActionPlanLibrary.model_validate(ALL_KINDS_LIBRARY)
+        assert referencing_plans(library, "close_shutters") == ["closeout"]
+        assert referencing_plans(library, "closeout") == []


### PR DESCRIPTION
## What

The M5 **ActionLibrary editor** for GEECS-Console — create, edit, reorder, rename, and delete the named action plans of an experiment's `action_library/actions.yaml`. **Editing only**: executing actions is a separate future work item (G-actions); this dialog has no execution capability at all (no run button, no CA imports — pinned by a source test).

Adds files only (no existing module touched); menu wiring + version bump land in the later integration PR, via:

```python
open_action_library_editor(parent, experiment, configs_base=None, completions=None) -> QDialog
```

## Schema + on-disk binding

- **Models**: `geecs_schemas.ActionPlan` / `ActionPlanLibrary` and the `ActionStep` discriminated union — `set` (device/variable/value/wait_for_execution), `wait` (seconds), `check` (device/variable/expected), `run` (nested plan name).
- **Layout**: the single per-experiment library file `ConfigsRepoResolver` reads — `scanner_configs/experiments/<Experiment>/action_library/actions.yaml`. A `schema_version` document loads as the new schema; anything else goes through `geecs_schemas.convert.convert_action_library` (the real Undulator/Thomson legacy corpora load cleanly, verified read-only). Saves always write the new schema.

## Pieces

- **`services/action_library_store.py`** — `ActionLibraryStore` (mirrors the `PresetStore` pattern + error contract): list/load/save/delete/rename named plans, lossless round-trip, offline → empty listing, `ActionLibraryStoreError` for everything else. Rename retargets every `run` reference so it can never leave a dangling pointer; deleting a still-referenced plan refuses, naming the referrers; saving a plan with a dangling `run` reference refuses (the schema's library validator would reject it anyway).
- **`editors/action_library_editor.py` + `app/ui/action_library_editor.ui`** (`ale_` prefix, hand-authored XML via `QUiLoader`) — plan list with New/Duplicate/Rename/Delete; ordered steps table with Add/Remove/Up/Down; per-step kind selector driving stacked per-kind fields; Save/Revert with dirty tracking and unsaved-changes prompts; inline pydantic + store errors; inline warning when a `run` step references a plan not in the library; Enter never accepts the dialog.
- **Completions** — device/variable fields get `QCompleter`s from the **shared `services/device_completions.py` seam introduced by #504** (`CompletionsProvider` / `EmptyCompletions` / `GeecsDbCompletions`): one blocking `device_variables()` call, fetched on a short-lived daemon thread and delivered through the queued `completions_ready` signal (the package's no-QThread rule), mirroring the ScanVariableEditor. A broken provider can never break the editor.

## Overlap with #504 (pre-resolved)

`services/device_completions.py` and `editors/__init__.py` are **byte-identical** to #504's versions, so whichever PR merges second sees identical additions — no conflict, no divergence. This editor consumes the shared provider rather than defining its own.

## Tests

78 new hermetic tests (36 store + 42 editor) over tmp roots — store round-trip exercising every step kind, legacy conversion + migration, reorder persistence, rename/delete/invalid-YAML/path-escape; editor load/edit/save expected models, kind-switch field visibility, dangling-reference warning, dirty/revert/prompt flows, offline open, Enter handling, queued completions delivery. Full suite **281 passed, exit 0, across repeated consecutive runs**; every widget is `qtbot.addWidget`-registered, all modal prompt seams are stubbed, and tests wait on `completions_applied` so no queued signal can land after teardown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)