### PR TITLE
GEECS-Console: SaveElementEditor (M5)

### DIFF
--- a/GEECS-Console/geecs_console/app/ui/save_set_editor.ui
+++ b/GEECS-Console/geecs_console/app/ui/save_set_editor.ui
@@ -1,0 +1,328 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>SaveSetEditorRoot</class>
+ <widget class="QWidget" name="SaveSetEditorRoot">
+  <property name="windowTitle">
+   <string>Save Set Editor</string>
+  </property>
+  <layout class="QVBoxLayout" name="sse_root_layout">
+   <property name="leftMargin">
+    <number>10</number>
+   </property>
+   <property name="topMargin">
+    <number>10</number>
+   </property>
+   <property name="rightMargin">
+    <number>10</number>
+   </property>
+   <property name="bottomMargin">
+    <number>10</number>
+   </property>
+   <property name="spacing">
+    <number>8</number>
+   </property>
+   <item>
+    <layout class="QHBoxLayout" name="sse_columns_layout" stretch="30,70">
+     <property name="spacing">
+      <number>10</number>
+     </property>
+     <!-- Left: the save-set list -->
+     <item>
+      <widget class="QGroupBox" name="sse_list_group">
+       <property name="title">
+        <string>SAVE SETS</string>
+       </property>
+       <layout class="QVBoxLayout" name="sse_list_layout">
+        <item>
+         <widget class="QListWidget" name="sse_set_list"/>
+        </item>
+        <item>
+         <layout class="QHBoxLayout" name="sse_list_buttons">
+          <item>
+           <widget class="QPushButton" name="sse_new_button">
+            <property name="text">
+             <string>New</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QPushButton" name="sse_duplicate_button">
+            <property name="text">
+             <string>Duplicate</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QPushButton" name="sse_rename_button">
+            <property name="text">
+             <string>Rename</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QPushButton" name="sse_delete_button">
+            <property name="text">
+             <string>Delete</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </item>
+       </layout>
+      </widget>
+     </item>
+     <!-- Right: the selected set's document -->
+     <item>
+      <layout class="QVBoxLayout" name="sse_document_layout">
+       <item>
+        <widget class="QGroupBox" name="sse_set_group">
+         <property name="title">
+          <string>SAVE SET</string>
+         </property>
+         <layout class="QFormLayout" name="sse_set_form">
+          <item row="0" column="0">
+           <widget class="QLabel" name="sse_name_caption">
+            <property name="text">
+             <string>Name</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="QLabel" name="sse_name_label">
+            <property name="text">
+             <string>—</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QLabel" name="sse_description_caption">
+            <property name="text">
+             <string>Description</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1">
+           <widget class="QLineEdit" name="sse_description_edit">
+            <property name="placeholderText">
+             <string>what this save set is for…</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
+        <layout class="QHBoxLayout" name="sse_entries_layout" stretch="40,60">
+         <property name="spacing">
+          <number>10</number>
+         </property>
+         <item>
+          <widget class="QGroupBox" name="sse_devices_group">
+           <property name="title">
+            <string>DEVICES</string>
+           </property>
+           <layout class="QVBoxLayout" name="sse_devices_layout">
+            <item>
+             <widget class="QListWidget" name="sse_device_list"/>
+            </item>
+            <item>
+             <layout class="QHBoxLayout" name="sse_device_add_row">
+              <item>
+               <widget class="QLineEdit" name="sse_device_edit">
+                <property name="placeholderText">
+                 <string>device name…</string>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QPushButton" name="sse_add_device_button">
+                <property name="text">
+                 <string>Add</string>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </item>
+            <item>
+             <widget class="QPushButton" name="sse_remove_device_button">
+              <property name="text">
+               <string>Remove device</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </widget>
+         </item>
+         <item>
+          <widget class="QGroupBox" name="sse_entry_group">
+           <property name="title">
+            <string>SELECTED DEVICE</string>
+           </property>
+           <layout class="QVBoxLayout" name="sse_entry_layout">
+            <item>
+             <widget class="QCheckBox" name="sse_images_check">
+              <property name="text">
+               <string>Save images / non-scalar files</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QCheckBox" name="sse_db_scalars_check">
+              <property name="text">
+               <string>Record DB-marked telemetry (db_scalars)</string>
+              </property>
+              <property name="checked">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QCheckBox" name="sse_all_scalars_check">
+              <property name="text">
+               <string>Record every published scalar (all_scalars)</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <layout class="QHBoxLayout" name="sse_role_row">
+              <item>
+               <widget class="QLabel" name="sse_role_caption">
+                <property name="text">
+                 <string>Role override</string>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QComboBox" name="sse_role_combo"/>
+              </item>
+             </layout>
+            </item>
+            <item>
+             <widget class="QLabel" name="sse_scalars_caption">
+              <property name="text">
+               <string>Extra scalar variables</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QListWidget" name="sse_scalar_list"/>
+            </item>
+            <item>
+             <layout class="QHBoxLayout" name="sse_scalar_add_row">
+              <item>
+               <widget class="QLineEdit" name="sse_scalar_edit">
+                <property name="placeholderText">
+                 <string>variable name…</string>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QPushButton" name="sse_add_scalar_button">
+                <property name="text">
+                 <string>Add</string>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QPushButton" name="sse_remove_scalar_button">
+                <property name="text">
+                 <string>Remove</string>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </item>
+            <item>
+             <layout class="QFormLayout" name="sse_actions_form">
+              <item row="0" column="0">
+               <widget class="QLabel" name="sse_setup_caption">
+                <property name="text">
+                 <string>Setup plans</string>
+                </property>
+               </widget>
+              </item>
+              <item row="0" column="1">
+               <widget class="QLineEdit" name="sse_setup_edit">
+                <property name="placeholderText">
+                 <string>action-plan names, comma-separated</string>
+                </property>
+               </widget>
+              </item>
+              <item row="1" column="0">
+               <widget class="QLabel" name="sse_closeout_caption">
+                <property name="text">
+                 <string>Closeout plans</string>
+                </property>
+               </widget>
+              </item>
+              <item row="1" column="1">
+               <widget class="QLineEdit" name="sse_closeout_edit">
+                <property name="placeholderText">
+                 <string>action-plan names, comma-separated</string>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </item>
+           </layout>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <widget class="QLabel" name="sse_message_label">
+         <property name="text">
+          <string></string>
+         </property>
+         <property name="wordWrap">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <layout class="QHBoxLayout" name="sse_button_row">
+         <item>
+          <widget class="QPushButton" name="sse_revert_button">
+           <property name="text">
+            <string>Revert</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QPushButton" name="sse_save_button">
+           <property name="text">
+            <string>Save</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <spacer name="sse_button_spacer">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+         <item>
+          <widget class="QPushButton" name="sse_close_button">
+           <property name="text">
+            <string>Close</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+      </layout>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/GEECS-Console/geecs_console/editors/__init__.py
+++ b/GEECS-Console/geecs_console/editors/__init__.py
@@ -1,0 +1,1 @@
+"""Editor dialogs for the console's config kinds (Editors menu)."""

--- a/GEECS-Console/geecs_console/editors/__init__.py
+++ b/GEECS-Console/geecs_console/editors/__init__.py
@@ -1,1 +1,1 @@
-"""Editor dialogs for the console's config kinds (Editors menu)."""
+"""Editor dialogs for the configs the console submits by name (M5)."""

--- a/GEECS-Console/geecs_console/editors/save_set_editor.py
+++ b/GEECS-Console/geecs_console/editors/save_set_editor.py
@@ -1,0 +1,1031 @@
+"""The SaveElementEditor: edit an experiment's save sets (M5).
+
+The editor's document IS the :class:`geecs_schemas.SaveSet` pydantic model —
+the form is derived from the model's fields, and every save round-trips
+through ``SaveSet.model_validate`` / ``model_dump(mode="json")`` via
+:class:`~geecs_console.services.save_set_store.SaveSetStore`.  A validation
+error is rendered inline in the message label, never a crash.
+
+Offline-first: the dialog opens with zero network and zero configs (empty
+list, Save disabled until the document validates).  Device and variable name
+completions come from an injectable provider seam —
+``Callable[[str], dict[str, list[str]]]`` mapping experiment → device →
+variable names — fetched once on a daemon thread and delivered back through
+a queued signal (the no-QThread rule; see ``services/health.py``).  The
+production provider, :func:`geecs_db_completions`, imports ``GeecsDb``
+lazily and degrades to empty on any failure, so offline means an empty
+completer, not an exception.
+
+The reserved ``at_scan_start`` / ``at_scan_end`` entry fields (not applied by
+the engine in this version) have no widgets; the editor carries them through
+the round-trip untouched.
+"""
+
+from __future__ import annotations
+
+import copy
+import logging
+import threading
+from pathlib import Path
+from typing import Callable, Optional
+
+from PySide6.QtCore import QFile, QStringListModel, Qt, Signal, Slot
+from PySide6.QtUiTools import QUiLoader
+from PySide6.QtWidgets import (
+    QCheckBox,
+    QComboBox,
+    QCompleter,
+    QDialog,
+    QGroupBox,
+    QInputDialog,
+    QLabel,
+    QLineEdit,
+    QListWidget,
+    QMessageBox,
+    QPushButton,
+    QVBoxLayout,
+    QWidget,
+)
+from pydantic import ValidationError
+
+from geecs_console.services.save_set_store import SaveSetStore, SaveSetStoreError
+from geecs_schemas import SaveRole, SaveSet, SaveSetEntry
+
+logger = logging.getLogger(__name__)
+
+_UI_PATH = Path(__file__).parent.parent / "app" / "ui" / "save_set_editor.ui"
+
+#: Screen-map palette (see app/style.qss header).
+_COLOR_DIM = "#6b7681"
+_COLOR_RED = "#c4453a"
+
+#: The role combo's "let the scanner decide" row (stores ``None``).
+_ROLE_DERIVED_LABEL = "(derived)"
+
+#: The completions seam: experiment name -> {device: [variable, ...]}.
+CompletionsProvider = Callable[[str], dict[str, list[str]]]
+
+
+def geecs_db_completions(experiment: str) -> dict[str, list[str]]:
+    """Fetch device/variable completions from the GEECS experiment database.
+
+    The production :data:`CompletionsProvider` — imports ``GeecsDb`` lazily
+    (keeping this module import-safe offline) and returns empty on any
+    failure, so an unreachable database means an empty completer, never an
+    error.  Blocking; the editor always calls providers on a daemon thread.
+
+    Parameters
+    ----------
+    experiment : str
+        GEECS experiment name ("" returns empty immediately).
+
+    Returns
+    -------
+    dict of str to list of str
+        ``{device: sorted variable names}`` for the experiment's devices.
+    """
+    if not experiment:
+        return {}
+    try:
+        from geecs_ca_gateway.db.geecs_db import GeecsDb
+
+        by_device = GeecsDb.get_experiment_device_variables(experiment)
+        return {
+            device: sorted({meta["name"] for meta in metas})
+            for device, metas in by_device.items()
+        }
+    except Exception as exc:  # noqa: BLE001 — completions are best-effort
+        logger.info("device/variable completions unavailable: %s", exc)
+        return {}
+
+
+def _split_names(text: str) -> list[str]:
+    """Parse a comma-separated line edit into a list of names.
+
+    Parameters
+    ----------
+    text : str
+        The raw line-edit text.
+
+    Returns
+    -------
+    list of str
+        The non-empty, stripped names in order.
+    """
+    return [part.strip() for part in text.split(",") if part.strip()]
+
+
+class SaveSetEditor(QDialog):
+    """Edit the save sets of one experiment (the M5 SaveElementEditor).
+
+    Left: the experiment's save-set list (New / Duplicate / Rename /
+    Delete).  Right: the selected set's document — description, device
+    entries (add/remove), and the selected entry's fields, derived from
+    :class:`geecs_schemas.SaveSetEntry` (images, ``db_scalars`` /
+    ``all_scalars`` flags, role override, extra scalars, setup/closeout
+    plan references).  Save/Revert with dirty tracking and an
+    unsaved-changes prompt on switch/close.
+
+    Parameters
+    ----------
+    parent : QWidget, optional
+        The owning window (the main window, in production).
+    experiment : str, optional
+        Experiment whose save sets to edit; used when *store* is not given.
+    store : SaveSetStore, optional
+        The persistence seam; tests inject one backed by a tmp dir.
+    configs_base : Path, optional
+        Experiments-root override forwarded to the default store.
+    completions : callable, optional
+        :data:`CompletionsProvider` for the device/variable completers.
+        ``None`` (the default) skips fetching entirely — offline/tests get
+        empty completers unless a provider is injected.
+    """
+
+    #: One completions mapping per finished provider call (emitted from the
+    #: fetch daemon thread; delivered queued to :meth:`_apply_completions`).
+    completions_ready = Signal(object)
+
+    def __init__(
+        self,
+        parent: Optional[QWidget] = None,
+        experiment: str = "",
+        store: Optional[SaveSetStore] = None,
+        configs_base: Optional[Path] = None,
+        completions: Optional[CompletionsProvider] = None,
+    ) -> None:
+        super().__init__(parent)
+        self._store = (
+            store
+            if store is not None
+            else SaveSetStore(experiment, experiments_root=configs_base)
+        )
+        self._experiment = experiment or self._store.experiment
+        self._completions_provider = completions
+        self._completions: dict[str, list[str]] = {}
+        #: True once a provider fetch has been applied (tests wait on this
+        #: so the queued delivery cannot outlive the dialog).
+        self._completions_loaded = False
+
+        #: The open document as a JSON-ish dict (``model_dump(mode="json")``
+        #: shape) — ``None`` when nothing is open.
+        self._document: Optional[dict] = None
+        self._dirty = False
+        #: Names present in the list but not yet written to the store.
+        self._unsaved: set[str] = set()
+        #: Row of the set the editor currently shows (-1 for none).
+        self._selected_row = -1
+        #: Reentrancy guards: populating widgets / programmatic selection.
+        self._loading = False
+        self._suppress_selection = False
+
+        self._load_ui()
+        self._bind_widgets()
+        self._guard_default_buttons()
+        self._build_completers()
+        self._wire_signals()
+
+        self.setWindowTitle(self._title())
+        self._refresh_set_list()
+        self._clear_document()
+        self.completions_ready.connect(
+            self._apply_completions, Qt.ConnectionType.QueuedConnection
+        )
+        self._start_completions_fetch()
+
+    # ------------------------------------------------------------------
+    # Construction
+    # ------------------------------------------------------------------
+
+    def _load_ui(self) -> None:
+        """Load the hand-authored .ui as this dialog's content."""
+        loader = QUiLoader()
+        ui_file = QFile(str(_UI_PATH))
+        ui_file.open(QFile.OpenModeFlag.ReadOnly)
+        try:
+            self._ui: QWidget = loader.load(ui_file, self)
+        finally:
+            ui_file.close()
+        if self._ui is None:
+            raise RuntimeError(f"Failed to load {_UI_PATH}: {loader.errorString()}")
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.addWidget(self._ui)
+
+    def _child(self, cls: type, name: str):
+        """Return the named child widget, failing loudly when missing."""
+        widget = self._ui.findChild(cls, name)
+        if widget is None:
+            raise LookupError(f"{name!r} ({cls.__name__}) not found in {_UI_PATH}")
+        return widget
+
+    def _bind_widgets(self) -> None:
+        """Resolve every wired widget from the loaded .ui once."""
+        self.set_list: QListWidget = self._child(QListWidget, "sse_set_list")
+        self.new_button: QPushButton = self._child(QPushButton, "sse_new_button")
+        self.duplicate_button: QPushButton = self._child(
+            QPushButton, "sse_duplicate_button"
+        )
+        self.rename_button: QPushButton = self._child(QPushButton, "sse_rename_button")
+        self.delete_button: QPushButton = self._child(QPushButton, "sse_delete_button")
+
+        self.name_label: QLabel = self._child(QLabel, "sse_name_label")
+        self.description_edit: QLineEdit = self._child(
+            QLineEdit, "sse_description_edit"
+        )
+        self.device_list: QListWidget = self._child(QListWidget, "sse_device_list")
+        self.device_edit: QLineEdit = self._child(QLineEdit, "sse_device_edit")
+        self.add_device_button: QPushButton = self._child(
+            QPushButton, "sse_add_device_button"
+        )
+        self.remove_device_button: QPushButton = self._child(
+            QPushButton, "sse_remove_device_button"
+        )
+
+        self.entry_group: QGroupBox = self._child(QGroupBox, "sse_entry_group")
+        self.images_check: QCheckBox = self._child(QCheckBox, "sse_images_check")
+        self.db_scalars_check: QCheckBox = self._child(
+            QCheckBox, "sse_db_scalars_check"
+        )
+        self.all_scalars_check: QCheckBox = self._child(
+            QCheckBox, "sse_all_scalars_check"
+        )
+        self.role_combo: QComboBox = self._child(QComboBox, "sse_role_combo")
+        self.scalar_list: QListWidget = self._child(QListWidget, "sse_scalar_list")
+        self.scalar_edit: QLineEdit = self._child(QLineEdit, "sse_scalar_edit")
+        self.add_scalar_button: QPushButton = self._child(
+            QPushButton, "sse_add_scalar_button"
+        )
+        self.remove_scalar_button: QPushButton = self._child(
+            QPushButton, "sse_remove_scalar_button"
+        )
+        self.setup_edit: QLineEdit = self._child(QLineEdit, "sse_setup_edit")
+        self.closeout_edit: QLineEdit = self._child(QLineEdit, "sse_closeout_edit")
+
+        self.message_label: QLabel = self._child(QLabel, "sse_message_label")
+        self.revert_button: QPushButton = self._child(QPushButton, "sse_revert_button")
+        self.save_button: QPushButton = self._child(QPushButton, "sse_save_button")
+        self.close_button: QPushButton = self._child(QPushButton, "sse_close_button")
+
+        self.role_combo.addItem(_ROLE_DERIVED_LABEL, None)
+        for role in SaveRole:
+            self.role_combo.addItem(role.value, role.value)
+
+    def _guard_default_buttons(self) -> None:
+        """Keep Enter in a line edit from triggering dialog accept.
+
+        Every ``QPushButton`` in a ``QDialog`` is auto-default by default,
+        so pressing Enter in any line edit would "click" the first button.
+        The line edits have their own Enter behavior (add device / add
+        scalar) wired in :meth:`_wire_signals`.
+        """
+        for button in self.findChildren(QPushButton):
+            button.setAutoDefault(False)
+            button.setDefault(False)
+
+    def _build_completers(self) -> None:
+        """Attach the device/variable completers (empty until a fetch lands).
+
+        Both completers (and their models) are kept as attributes —
+        ``QLineEdit.setCompleter`` does not take ownership, so a
+        local-variable completer would be garbage-collected and the next
+        model update would touch a dangling C++ object (a hard crash).
+        """
+        self._device_model = QStringListModel(self)
+        self._device_completer = QCompleter(self)
+        self._device_completer.setModel(self._device_model)
+        self._device_completer.setCaseSensitivity(Qt.CaseSensitivity.CaseInsensitive)
+        self.device_edit.setCompleter(self._device_completer)
+
+        self._variable_model = QStringListModel(self)
+        self._variable_completer = QCompleter(self)
+        self._variable_completer.setModel(self._variable_model)
+        self._variable_completer.setCaseSensitivity(Qt.CaseSensitivity.CaseInsensitive)
+        self.scalar_edit.setCompleter(self._variable_completer)
+
+    def _wire_signals(self) -> None:
+        """Connect widget signals to the handlers."""
+        self.set_list.currentRowChanged.connect(self._on_set_row_changed)
+        self.new_button.clicked.connect(self._on_new)
+        self.duplicate_button.clicked.connect(self._on_duplicate)
+        self.rename_button.clicked.connect(self._on_rename)
+        self.delete_button.clicked.connect(self._on_delete)
+
+        self.description_edit.textChanged.connect(self._on_description_changed)
+        self.device_list.currentRowChanged.connect(self._on_device_row_changed)
+        self.add_device_button.clicked.connect(self._on_add_device)
+        self.device_edit.returnPressed.connect(self._on_add_device)
+        self.remove_device_button.clicked.connect(self._on_remove_device)
+
+        self.images_check.toggled.connect(self._on_images_toggled)
+        self.db_scalars_check.toggled.connect(self._on_db_scalars_toggled)
+        self.all_scalars_check.toggled.connect(self._on_all_scalars_toggled)
+        self.role_combo.currentIndexChanged.connect(self._on_role_changed)
+        self.add_scalar_button.clicked.connect(self._on_add_scalar)
+        self.scalar_edit.returnPressed.connect(self._on_add_scalar)
+        self.remove_scalar_button.clicked.connect(self._on_remove_scalar)
+        self.setup_edit.textChanged.connect(self._on_setup_changed)
+        self.closeout_edit.textChanged.connect(self._on_closeout_changed)
+
+        self.save_button.clicked.connect(self._on_save)
+        self.revert_button.clicked.connect(self._on_revert)
+        self.close_button.clicked.connect(self.close)
+
+    def _title(self) -> str:
+        """Compose the window title from experiment, open set, and dirt."""
+        parts = ["Save Set Editor"]
+        if self._experiment:
+            parts.append(f"— {self._experiment}")
+        if self._document is not None:
+            star = "*" if self._dirty else ""
+            parts.append(f"— {self._document.get('name', '')}{star}")
+        return " ".join(parts)
+
+    # ------------------------------------------------------------------
+    # Completions (injectable provider, fetched off the GUI thread)
+    # ------------------------------------------------------------------
+
+    def _start_completions_fetch(self) -> None:
+        """Fetch completions once on a daemon thread (skipped with no provider)."""
+        if self._completions_provider is None:
+            return
+        threading.Thread(
+            target=self._fetch_completions,
+            name="sse-completions",
+            daemon=True,
+        ).start()
+
+    def _fetch_completions(self) -> None:
+        """Call the provider (on the daemon thread) and emit the mapping."""
+        try:
+            mapping = self._completions_provider(self._experiment)
+        except Exception as exc:  # noqa: BLE001 — completions are best-effort
+            logger.info("completions provider failed: %s", exc)
+            mapping = {}
+        self.completions_ready.emit(mapping or {})
+
+    @Slot(object)
+    def _apply_completions(self, mapping: dict) -> None:
+        """Feed the completer models (GUI-thread slot, delivered queued).
+
+        Parameters
+        ----------
+        mapping : dict
+            ``{device: [variable, ...]}`` from the provider.
+        """
+        self._completions = dict(mapping)
+        self._completions_loaded = True
+        self._device_model.setStringList(sorted(self._completions))
+        self._refresh_variable_completer()
+
+    def _refresh_variable_completer(self) -> None:
+        """Point the scalar completer at the selected device's variables."""
+        entry = self._current_entry()
+        device = entry["device"] if entry is not None else ""
+        self._variable_model.setStringList(self._completions.get(device, []))
+
+    # ------------------------------------------------------------------
+    # Document plumbing
+    # ------------------------------------------------------------------
+
+    def _show_message(self, text: str, error: bool = False) -> None:
+        """Render *text* in the inline message label.
+
+        Parameters
+        ----------
+        text : str
+            The operator-facing line ("" clears the label).
+        error : bool, optional
+            Render in the danger color instead of the dim one.
+        """
+        self.message_label.setStyleSheet(
+            f"color: {_COLOR_RED if error else _COLOR_DIM};"
+        )
+        self.message_label.setText(text)
+
+    def _validate(self) -> Optional[SaveSet]:
+        """Validate the open document, rendering any error inline.
+
+        Returns
+        -------
+        SaveSet or None
+            The validated model, or ``None`` when nothing is open or the
+            document does not validate (the message label explains why).
+        """
+        if self._document is None:
+            return None
+        try:
+            model = SaveSet.model_validate(self._document)
+        except ValidationError as exc:
+            errors = exc.errors()
+            first = errors[0]
+            location = ".".join(str(part) for part in first["loc"]) or "document"
+            more = f" (+{len(errors) - 1} more)" if len(errors) > 1 else ""
+            self._show_message(
+                f"Invalid save set — {location}: {first['msg']}{more}", error=True
+            )
+            return None
+        self._show_message("")
+        return model
+
+    def _touch(self) -> None:
+        """Mark the document dirty and refresh validation + button gating."""
+        if self._loading:
+            return
+        self._dirty = True
+        self._refresh_gating()
+
+    def _refresh_gating(self) -> None:
+        """Recompute Save/Revert enabled state, title, and validation label."""
+        valid = self._validate() is not None
+        self.save_button.setEnabled(self._dirty and valid)
+        self.revert_button.setEnabled(self._dirty)
+        self.setWindowTitle(self._title())
+
+    def _current_name(self) -> str:
+        """Return the open document's name ("" when nothing is open)."""
+        if self._document is None:
+            return ""
+        return str(self._document.get("name", ""))
+
+    def _current_entry(self) -> Optional[dict]:
+        """Return the selected device's entry dict, or ``None``."""
+        if self._document is None:
+            return None
+        row = self.device_list.currentRow()
+        entries = self._document.get("entries", [])
+        if 0 <= row < len(entries):
+            return entries[row]
+        return None
+
+    # ------------------------------------------------------------------
+    # List / selection management
+    # ------------------------------------------------------------------
+
+    def _refresh_set_list(self, select: str = "") -> None:
+        """Rebuild the save-set list from the store plus unsaved names.
+
+        Parameters
+        ----------
+        select : str, optional
+            Name to select silently after the rebuild ("" selects nothing).
+        """
+        names = sorted(set(self._store.list_names()) | self._unsaved)
+        self._suppress_selection = True
+        try:
+            self.set_list.clear()
+            self.set_list.addItems(names)
+            if select and select in names:
+                row = names.index(select)
+                self.set_list.setCurrentRow(row)
+                self._selected_row = row
+            else:
+                self.set_list.setCurrentRow(-1)
+                self._selected_row = -1
+        finally:
+            self._suppress_selection = False
+
+    def _select_row_silently(self, row: int) -> None:
+        """Move the list selection without triggering the change handler."""
+        self._suppress_selection = True
+        try:
+            self.set_list.setCurrentRow(row)
+        finally:
+            self._suppress_selection = False
+
+    def _on_set_row_changed(self, row: int) -> None:
+        """Open the newly selected save set, honoring unsaved changes."""
+        if self._suppress_selection or row == self._selected_row:
+            return
+        item = self.set_list.item(row)
+        target = item.text() if item is not None else ""
+        if not self._maybe_leave():
+            self._select_row_silently(self._selected_row)
+            return
+        if not target:
+            self._selected_row = row
+            self._clear_document()
+            return
+        # Leaving may have dropped a discarded unsaved item — re-resolve by
+        # name so row indices can't lie.
+        names = [self.set_list.item(i).text() for i in range(self.set_list.count())]
+        if target not in names:
+            self._selected_row = -1
+            self._clear_document()
+            return
+        new_row = names.index(target)
+        self._select_row_silently(new_row)
+        self._selected_row = new_row
+        self._open_set(target)
+
+    def _maybe_leave(self) -> bool:
+        """Resolve unsaved changes before leaving the open document.
+
+        Prompts Save / Discard / Cancel when dirty.  Choosing Save runs the
+        normal save (staying put when it fails); choosing Discard on a
+        never-saved set removes it from the list entirely.
+
+        Returns
+        -------
+        bool
+            ``True`` when it is safe to leave the current document.
+        """
+        if not self._dirty or self._document is None:
+            return True
+        name = self._current_name()
+        choice = QMessageBox.question(
+            self,
+            "Unsaved changes",
+            f"Save set {name!r} has unsaved changes.",
+            QMessageBox.StandardButton.Save
+            | QMessageBox.StandardButton.Discard
+            | QMessageBox.StandardButton.Cancel,
+            QMessageBox.StandardButton.Cancel,
+        )
+        if choice == QMessageBox.StandardButton.Cancel:
+            return False
+        if choice == QMessageBox.StandardButton.Save:
+            return self._save()
+        # Discard: a never-saved set evaporates with its edits.
+        if name in self._unsaved:
+            self._unsaved.discard(name)
+            self._drop_list_item(name)
+        self._dirty = False
+        return True
+
+    def _drop_list_item(self, name: str) -> None:
+        """Remove *name*'s row from the set list without side effects."""
+        self._suppress_selection = True
+        try:
+            for row in range(self.set_list.count()):
+                if self.set_list.item(row).text() == name:
+                    self.set_list.takeItem(row)
+                    break
+        finally:
+            self._suppress_selection = False
+
+    def closeEvent(self, event) -> None:  # noqa: N802 — Qt override
+        """Prompt for unsaved changes before closing."""
+        if not self._maybe_leave():
+            event.ignore()
+            return
+        super().closeEvent(event)
+
+    # ------------------------------------------------------------------
+    # Opening / clearing documents
+    # ------------------------------------------------------------------
+
+    def _set_document_enabled(self, enabled: bool) -> None:
+        """Enable/disable the whole right-hand document panel."""
+        for widget in (
+            self.description_edit,
+            self.device_list,
+            self.device_edit,
+            self.add_device_button,
+            self.remove_device_button,
+            self.entry_group,
+        ):
+            widget.setEnabled(enabled)
+
+    def _clear_document(self) -> None:
+        """Show the no-document state (nothing selected / nothing open)."""
+        self._document = None
+        self._dirty = False
+        self._loading = True
+        try:
+            self.name_label.setText("—")
+            self.description_edit.clear()
+            self.device_list.clear()
+            self.device_edit.clear()
+            self._populate_entry_panel()
+        finally:
+            self._loading = False
+        self._set_document_enabled(False)
+        self.save_button.setEnabled(False)
+        self.revert_button.setEnabled(False)
+        self.setWindowTitle(self._title())
+
+    def _open_set(self, name: str) -> None:
+        """Load save set *name* from the store into the form.
+
+        A load failure (missing file, bad YAML, schema rejection, a lossy
+        legacy element) is rendered inline and leaves the no-document state.
+
+        Parameters
+        ----------
+        name : str
+            The save-set name (list item text / file stem).
+        """
+        try:
+            model = self._store.load(name)
+        except SaveSetStoreError as exc:
+            self._clear_document()
+            self._show_message(str(exc), error=True)
+            return
+        document = model.model_dump(mode="json")
+        if document.get("name") != name:
+            logger.info(
+                "save set %r carries internal name %r — normalizing to the file stem",
+                name,
+                document.get("name"),
+            )
+            document["name"] = name
+        self._adopt_document(document, dirty=False)
+        self._show_message("")
+
+    def _adopt_document(self, document: dict, dirty: bool) -> None:
+        """Render *document* in the form and make it the open document.
+
+        Parameters
+        ----------
+        document : dict
+            A ``SaveSet``-shaped mapping (``model_dump(mode="json")``).
+        dirty : bool
+            Whether the document already differs from the store (new /
+            duplicated sets start dirty).
+        """
+        self._document = document
+        self._dirty = dirty
+        self._loading = True
+        try:
+            self.name_label.setText(document.get("name", "") or "—")
+            self.description_edit.setText(document.get("description", ""))
+            self.device_list.clear()
+            for entry in document.get("entries", []):
+                self.device_list.addItem(entry.get("device", ""))
+            if self.device_list.count():
+                self.device_list.setCurrentRow(0)
+            self.device_edit.clear()
+            self._populate_entry_panel()
+        finally:
+            self._loading = False
+        self._set_document_enabled(True)
+        self._refresh_gating()
+
+    def _adopt_unsaved(self, document: dict) -> None:
+        """Add *document* as a new, unsaved list entry and open it."""
+        name = document["name"]
+        self._unsaved.add(name)
+        self._refresh_set_list(select=name)
+        self._adopt_document(document, dirty=True)
+
+    # ------------------------------------------------------------------
+    # Left-column actions (New / Duplicate / Rename / Delete)
+    # ------------------------------------------------------------------
+
+    def _known_names(self) -> set[str]:
+        """Every name the list shows (stored plus unsaved)."""
+        return set(self._store.list_names()) | self._unsaved
+
+    def _prompt_name(self, title: str, initial: str = "") -> str:
+        """Ask for a save-set name; "" when cancelled, empty, or taken.
+
+        Parameters
+        ----------
+        title : str
+            The input dialog's title.
+        initial : str, optional
+            Prefilled text.
+
+        Returns
+        -------
+        str
+            The accepted, stripped, collision-free name — or "".
+        """
+        name, accepted = QInputDialog.getText(
+            self, title, "Save set name:", text=initial
+        )
+        name = name.strip()
+        if not accepted or not name:
+            return ""
+        if name in self._known_names():
+            self._show_message(f"A save set named {name!r} already exists.", error=True)
+            return ""
+        return name
+
+    def _on_new(self) -> None:
+        """Create a new (empty, not-yet-valid) save set in memory."""
+        if not self._maybe_leave():
+            return
+        name = self._prompt_name("New save set")
+        if not name:
+            return
+        self._adopt_unsaved(
+            {"schema_version": 1, "name": name, "entries": [], "description": ""}
+        )
+
+    def _on_duplicate(self) -> None:
+        """Copy the open save set (as shown, edits included) under a new name."""
+        if self._document is None:
+            self._show_message("No save set selected.")
+            return
+        duplicate = copy.deepcopy(self._document)
+        if not self._maybe_leave():
+            return
+        name = self._prompt_name(
+            "Duplicate save set", initial=f"{duplicate.get('name', '')}-copy"
+        )
+        if not name:
+            return
+        duplicate["name"] = name
+        self._adopt_unsaved(duplicate)
+
+    def _on_rename(self) -> None:
+        """Rename the open save set (file and document name stay in step)."""
+        if self._document is None:
+            self._show_message("No save set selected.")
+            return
+        old = self._current_name()
+        new = self._prompt_name("Rename save set", initial=old)
+        if not new:
+            return
+        if old in self._unsaved:
+            self._unsaved.discard(old)
+            self._unsaved.add(new)
+        else:
+            try:
+                self._store.rename(old, new)
+            except SaveSetStoreError as exc:
+                self._show_message(str(exc), error=True)
+                return
+        self._document["name"] = new
+        self.name_label.setText(new)
+        self._refresh_set_list(select=new)
+        self._refresh_gating()
+        self._show_message(f"Renamed {old!r} to {new!r}.")
+
+    def _on_delete(self) -> None:
+        """Delete the open save set after a confirmation prompt."""
+        if self._document is None:
+            self._show_message("No save set selected.")
+            return
+        name = self._current_name()
+        choice = QMessageBox.question(
+            self,
+            "Delete save set",
+            f"Delete save set {name!r}?",
+            QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
+            QMessageBox.StandardButton.No,
+        )
+        if choice != QMessageBox.StandardButton.Yes:
+            return
+        if name in self._unsaved:
+            self._unsaved.discard(name)
+        else:
+            try:
+                self._store.delete(name)
+            except SaveSetStoreError as exc:
+                self._show_message(str(exc), error=True)
+                return
+        self._dirty = False
+        self._refresh_set_list()
+        self._clear_document()
+        self._show_message(f"Deleted {name!r}.")
+
+    # ------------------------------------------------------------------
+    # Document edits (write-through to the dict, then touch)
+    # ------------------------------------------------------------------
+
+    def _on_description_changed(self, text: str) -> None:
+        """Write the description through to the document."""
+        if self._loading or self._document is None:
+            return
+        self._document["description"] = text
+        self._touch()
+
+    def _on_add_device(self) -> None:
+        """Append a new entry (schema defaults) for the typed device."""
+        if self._document is None:
+            return
+        device = self.device_edit.text().strip()
+        if not device:
+            return
+        existing = [entry.get("device") for entry in self._document.get("entries", [])]
+        if device in existing:
+            self._show_message(
+                f"Device {device!r} is already in this save set.", error=True
+            )
+            return
+        entry = SaveSetEntry(device=device).model_dump(mode="json")
+        self._document.setdefault("entries", []).append(entry)
+        self.device_list.addItem(device)
+        self.device_list.setCurrentRow(self.device_list.count() - 1)
+        self.device_edit.clear()
+        self._touch()
+
+    def _on_remove_device(self) -> None:
+        """Remove the selected device's entry."""
+        if self._document is None:
+            return
+        row = self.device_list.currentRow()
+        entries = self._document.get("entries", [])
+        if not (0 <= row < len(entries)):
+            return
+        del entries[row]
+        self.device_list.takeItem(row)
+        self._populate_entry_panel()
+        self._touch()
+
+    def _on_device_row_changed(self, _row: int) -> None:
+        """Show the newly selected device's entry fields."""
+        if self._loading:
+            return
+        self._populate_entry_panel()
+
+    def _populate_entry_panel(self) -> None:
+        """Render the selected entry into the detail widgets (or blank them)."""
+        entry = self._current_entry()
+        was_loading = self._loading
+        self._loading = True
+        try:
+            if entry is None:
+                self.entry_group.setEnabled(False)
+                self.images_check.setChecked(False)
+                self.db_scalars_check.setChecked(True)
+                self.all_scalars_check.setChecked(False)
+                self.role_combo.setCurrentIndex(0)
+                self.scalar_list.clear()
+                self.scalar_edit.clear()
+                self.setup_edit.clear()
+                self.closeout_edit.clear()
+            else:
+                self.entry_group.setEnabled(self._document is not None)
+                self.images_check.setChecked(bool(entry.get("images", False)))
+                self.db_scalars_check.setChecked(bool(entry.get("db_scalars", True)))
+                self.all_scalars_check.setChecked(bool(entry.get("all_scalars", False)))
+                index = self.role_combo.findData(entry.get("role"))
+                self.role_combo.setCurrentIndex(max(index, 0))
+                self.scalar_list.clear()
+                self.scalar_list.addItems(entry.get("scalars", []))
+                self.scalar_edit.clear()
+                self.setup_edit.setText(", ".join(entry.get("setup", [])))
+                self.closeout_edit.setText(", ".join(entry.get("closeout", [])))
+        finally:
+            self._loading = was_loading
+        self._refresh_variable_completer()
+
+    def _on_images_toggled(self, checked: bool) -> None:
+        """Write the images flag through to the selected entry."""
+        entry = self._current_entry()
+        if self._loading or entry is None:
+            return
+        entry["images"] = checked
+        self._touch()
+
+    def _on_db_scalars_toggled(self, checked: bool) -> None:
+        """Write the db_scalars flag through to the selected entry."""
+        entry = self._current_entry()
+        if self._loading or entry is None:
+            return
+        entry["db_scalars"] = checked
+        self._touch()
+
+    def _on_all_scalars_toggled(self, checked: bool) -> None:
+        """Write the all_scalars flag through to the selected entry."""
+        entry = self._current_entry()
+        if self._loading or entry is None:
+            return
+        entry["all_scalars"] = checked
+        self._touch()
+
+    def _on_role_changed(self, index: int) -> None:
+        """Write the role override through to the selected entry."""
+        entry = self._current_entry()
+        if self._loading or entry is None:
+            return
+        entry["role"] = self.role_combo.itemData(index)
+        self._touch()
+
+    def _on_add_scalar(self) -> None:
+        """Append the typed variable to the selected entry's scalars."""
+        entry = self._current_entry()
+        if entry is None:
+            return
+        variable = self.scalar_edit.text().strip()
+        if not variable:
+            return
+        if variable in entry.get("scalars", []):
+            self._show_message(f"Variable {variable!r} is already listed.", error=True)
+            return
+        entry.setdefault("scalars", []).append(variable)
+        self.scalar_list.addItem(variable)
+        self.scalar_edit.clear()
+        self._touch()
+
+    def _on_remove_scalar(self) -> None:
+        """Remove the selected variable from the entry's scalars."""
+        entry = self._current_entry()
+        if entry is None:
+            return
+        row = self.scalar_list.currentRow()
+        scalars = entry.get("scalars", [])
+        if not (0 <= row < len(scalars)):
+            return
+        del scalars[row]
+        self.scalar_list.takeItem(row)
+        self._touch()
+
+    def _on_setup_changed(self, text: str) -> None:
+        """Write the setup plan references through to the selected entry."""
+        entry = self._current_entry()
+        if self._loading or entry is None:
+            return
+        entry["setup"] = _split_names(text)
+        self._touch()
+
+    def _on_closeout_changed(self, text: str) -> None:
+        """Write the closeout plan references through to the selected entry."""
+        entry = self._current_entry()
+        if self._loading or entry is None:
+            return
+        entry["closeout"] = _split_names(text)
+        self._touch()
+
+    # ------------------------------------------------------------------
+    # Save / Revert
+    # ------------------------------------------------------------------
+
+    def _save(self) -> bool:
+        """Validate and persist the open document.
+
+        Returns
+        -------
+        bool
+            ``True`` when the save landed (validation and write both OK).
+        """
+        model = self._validate()
+        if model is None:
+            self._refresh_gating()
+            return False
+        name = self._current_name()
+        try:
+            self._store.save(name, model)
+        except SaveSetStoreError as exc:
+            self._show_message(str(exc), error=True)
+            return False
+        self._dirty = False
+        self._unsaved.discard(name)
+        self._refresh_set_list(select=name)
+        self._refresh_gating()
+        self._show_message(f"Saved {name!r}.")
+        return True
+
+    def _on_save(self) -> None:
+        """Save button handler."""
+        self._save()
+
+    def _on_revert(self) -> None:
+        """Throw away unsaved edits, restoring the stored document.
+
+        A never-saved set reverts to its empty starting point (there is
+        nothing on disk to restore).
+        """
+        if self._document is None:
+            return
+        name = self._current_name()
+        if name in self._unsaved:
+            self._adopt_document(
+                {"schema_version": 1, "name": name, "entries": [], "description": ""},
+                dirty=True,
+            )
+            self._show_message(f"Reverted {name!r} to an empty new set.")
+            return
+        self._dirty = False
+        self._open_set(name)
+        self._show_message(f"Reverted {name!r}.")
+
+
+def open_save_set_editor(
+    parent: Optional[QWidget],
+    experiment: str,
+    configs_base: Optional[Path] = None,
+    completions: Optional[CompletionsProvider] = None,
+) -> QDialog:
+    """Open the save-set editor for *experiment* (the Editors-menu entry point).
+
+    Parameters
+    ----------
+    parent : QWidget or None
+        The owning window.
+    experiment : str
+        Experiment whose save sets to edit ("" opens empty and offline-safe).
+    configs_base : Path, optional
+        Experiments-root override (tests); defaults to the production
+        configs-repo resolution.
+    completions : callable, optional
+        :data:`CompletionsProvider` override; defaults to
+        :func:`geecs_db_completions` (lazy, daemon-thread, empty offline).
+
+    Returns
+    -------
+    QDialog
+        The shown (non-modal) editor dialog.
+    """
+    editor = SaveSetEditor(
+        parent,
+        experiment=experiment,
+        configs_base=configs_base,
+        completions=completions if completions is not None else geecs_db_completions,
+    )
+    editor.show()
+    return editor

--- a/GEECS-Console/geecs_console/editors/save_set_editor.py
+++ b/GEECS-Console/geecs_console/editors/save_set_editor.py
@@ -8,13 +8,14 @@ error is rendered inline in the message label, never a crash.
 
 Offline-first: the dialog opens with zero network and zero configs (empty
 list, Save disabled until the document validates).  Device and variable name
-completions come from an injectable provider seam —
-``Callable[[str], dict[str, list[str]]]`` mapping experiment → device →
-variable names — fetched once on a daemon thread and delivered back through
-a queued signal (the no-QThread rule; see ``services/health.py``).  The
-production provider, :func:`geecs_db_completions`, imports ``GeecsDb``
-lazily and degrades to empty on any failure, so offline means an empty
-completer, not an exception.
+completions come from the shared
+:class:`~geecs_console.services.device_completions.CompletionsProvider` seam
+— one blocking ``device_variables()`` call returning ``{device: [variable,
+...]}`` — fetched once on a daemon thread and delivered back through a
+queued signal (the no-QThread rule; see ``services/health.py``).  The
+production provider, ``GeecsDbCompletions``, imports ``GeecsDb`` lazily and
+degrades to empty on any failure, so offline means an empty completer, not
+an exception; ``EmptyCompletions`` is the no-fetch default.
 
 The reserved ``at_scan_start`` / ``at_scan_end`` entry fields (not applied by
 the engine in this version) have no widgets; the editor carries them through
@@ -27,7 +28,7 @@ import copy
 import logging
 import threading
 from pathlib import Path
-from typing import Callable, Optional
+from typing import Optional
 
 from PySide6.QtCore import QFile, QStringListModel, Qt, Signal, Slot
 from PySide6.QtUiTools import QUiLoader
@@ -48,6 +49,11 @@ from PySide6.QtWidgets import (
 )
 from pydantic import ValidationError
 
+from geecs_console.services.device_completions import (
+    CompletionsProvider,
+    EmptyCompletions,
+    GeecsDbCompletions,
+)
 from geecs_console.services.save_set_store import SaveSetStore, SaveSetStoreError
 from geecs_schemas import SaveRole, SaveSet, SaveSetEntry
 
@@ -61,42 +67,6 @@ _COLOR_RED = "#c4453a"
 
 #: The role combo's "let the scanner decide" row (stores ``None``).
 _ROLE_DERIVED_LABEL = "(derived)"
-
-#: The completions seam: experiment name -> {device: [variable, ...]}.
-CompletionsProvider = Callable[[str], dict[str, list[str]]]
-
-
-def geecs_db_completions(experiment: str) -> dict[str, list[str]]:
-    """Fetch device/variable completions from the GEECS experiment database.
-
-    The production :data:`CompletionsProvider` — imports ``GeecsDb`` lazily
-    (keeping this module import-safe offline) and returns empty on any
-    failure, so an unreachable database means an empty completer, never an
-    error.  Blocking; the editor always calls providers on a daemon thread.
-
-    Parameters
-    ----------
-    experiment : str
-        GEECS experiment name ("" returns empty immediately).
-
-    Returns
-    -------
-    dict of str to list of str
-        ``{device: sorted variable names}`` for the experiment's devices.
-    """
-    if not experiment:
-        return {}
-    try:
-        from geecs_ca_gateway.db.geecs_db import GeecsDb
-
-        by_device = GeecsDb.get_experiment_device_variables(experiment)
-        return {
-            device: sorted({meta["name"] for meta in metas})
-            for device, metas in by_device.items()
-        }
-    except Exception as exc:  # noqa: BLE001 — completions are best-effort
-        logger.info("device/variable completions unavailable: %s", exc)
-        return {}
 
 
 def _split_names(text: str) -> list[str]:
@@ -136,10 +106,10 @@ class SaveSetEditor(QDialog):
         The persistence seam; tests inject one backed by a tmp dir.
     configs_base : Path, optional
         Experiments-root override forwarded to the default store.
-    completions : callable, optional
-        :data:`CompletionsProvider` for the device/variable completers.
-        ``None`` (the default) skips fetching entirely — offline/tests get
-        empty completers unless a provider is injected.
+    completions : CompletionsProvider, optional
+        Word-list source for the device/variable completers.  ``None`` (the
+        default) means :class:`EmptyCompletions` — no fetch at all, so
+        offline/tests get empty completers unless a provider is injected.
     """
 
     #: One completions mapping per finished provider call (emitted from the
@@ -161,7 +131,9 @@ class SaveSetEditor(QDialog):
             else SaveSetStore(experiment, experiments_root=configs_base)
         )
         self._experiment = experiment or self._store.experiment
-        self._completions_provider = completions
+        self._completions_provider: CompletionsProvider = (
+            completions if completions is not None else EmptyCompletions()
+        )
         self._completions: dict[str, list[str]] = {}
         #: True once a provider fetch has been applied (tests wait on this
         #: so the queued delivery cannot outlive the dialog).
@@ -346,8 +318,13 @@ class SaveSetEditor(QDialog):
     # ------------------------------------------------------------------
 
     def _start_completions_fetch(self) -> None:
-        """Fetch completions once on a daemon thread (skipped with no provider)."""
-        if self._completions_provider is None:
+        """Fetch completions once on a daemon thread.
+
+        The :class:`EmptyCompletions` default is answered inline (no thread
+        to spawn for a constant) — offline construction stays thread-free.
+        """
+        if isinstance(self._completions_provider, EmptyCompletions):
+            self._completions_loaded = True
             return
         threading.Thread(
             target=self._fetch_completions,
@@ -358,7 +335,7 @@ class SaveSetEditor(QDialog):
     def _fetch_completions(self) -> None:
         """Call the provider (on the daemon thread) and emit the mapping."""
         try:
-            mapping = self._completions_provider(self._experiment)
+            mapping = self._completions_provider.device_variables()
         except Exception as exc:  # noqa: BLE001 — completions are best-effort
             logger.info("completions provider failed: %s", exc)
             mapping = {}
@@ -1012,9 +989,10 @@ def open_save_set_editor(
     configs_base : Path, optional
         Experiments-root override (tests); defaults to the production
         configs-repo resolution.
-    completions : callable, optional
-        :data:`CompletionsProvider` override; defaults to
-        :func:`geecs_db_completions` (lazy, daemon-thread, empty offline).
+    completions : CompletionsProvider, optional
+        Completer word-list override; defaults to
+        :class:`~geecs_console.services.device_completions.GeecsDbCompletions`
+        (lazy ``GeecsDb`` import, daemon-thread fetch, empty offline).
 
     Returns
     -------
@@ -1025,7 +1003,9 @@ def open_save_set_editor(
         parent,
         experiment=experiment,
         configs_base=configs_base,
-        completions=completions if completions is not None else geecs_db_completions,
+        completions=(
+            completions if completions is not None else GeecsDbCompletions(experiment)
+        ),
     )
     editor.show()
     return editor

--- a/GEECS-Console/geecs_console/services/device_completions.py
+++ b/GEECS-Console/geecs_console/services/device_completions.py
@@ -1,0 +1,90 @@
+"""Device/variable completion source for editor forms (offline-safe).
+
+The scan-variable editor's device and variable fields carry ``QCompleter``
+popups.  Their word lists come from a :class:`CompletionsProvider` — one
+blocking call returning ``{device: [variable, ...]}`` — which the editor
+dispatches to a short-lived daemon thread (the package's no-QThread rule)
+and marshals back through a queued Qt signal, so a slow or unreachable DB
+never blocks the GUI thread.
+
+- :class:`EmptyCompletions` — the offline/test default: no suggestions,
+  returns instantly.
+- :class:`GeecsDbCompletions` — the real provider: one
+  ``GeecsDb.get_experiment_device_variables`` query (imported lazily inside
+  the call, keeping this module import-safe offline), cached after the first
+  fetch; any failure — no MySQL, no credentials, unreachable host — degrades
+  to empty with a log line, never an exception.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Optional, Protocol, runtime_checkable
+
+logger = logging.getLogger(__name__)
+
+
+@runtime_checkable
+class CompletionsProvider(Protocol):
+    """Anything that can supply device → variable-name completions."""
+
+    def device_variables(self) -> dict[str, list[str]]:
+        """Return ``{device: [variable name, ...]}``; may block, never raises."""
+        ...
+
+
+class EmptyCompletions:
+    """No completions — the offline and hermetic-test default."""
+
+    def device_variables(self) -> dict[str, list[str]]:
+        """Return no completions.
+
+        Returns
+        -------
+        dict
+            Always empty.
+        """
+        return {}
+
+
+class GeecsDbCompletions:
+    """DB-backed completions for one experiment (cached, failure-tolerant).
+
+    Parameters
+    ----------
+    experiment : str
+        GEECS experiment name to enumerate devices/variables for.
+    """
+
+    def __init__(self, experiment: str) -> None:
+        self._experiment = experiment
+        self._cache: Optional[dict[str, list[str]]] = None
+
+    def device_variables(self) -> dict[str, list[str]]:
+        """Fetch (once) ``{device: [variable name, ...]}`` from ``GeecsDb``.
+
+        Returns
+        -------
+        dict
+            Sorted variable names per device; empty when the experiment is
+            unset or the DB is unreachable (logged, never raised).  Cached
+            after the first successful or failed attempt.
+        """
+        if self._cache is not None:
+            return self._cache
+        self._cache = {}
+        if not self._experiment:
+            return self._cache
+        try:
+            from geecs_ca_gateway.db.geecs_db import GeecsDb
+
+            per_device = GeecsDb.get_experiment_device_variables(self._experiment)
+            self._cache = {
+                device: sorted({str(row["name"]) for row in rows if "name" in row})
+                for device, rows in per_device.items()
+            }
+        except Exception as exc:  # noqa: BLE001 — degrade to empty offline
+            logger.info(
+                "device completions unavailable for %r: %s", self._experiment, exc
+            )
+        return self._cache

--- a/GEECS-Console/geecs_console/services/save_set_store.py
+++ b/GEECS-Console/geecs_console/services/save_set_store.py
@@ -1,0 +1,415 @@
+"""Save-set persistence: named :class:`~geecs_schemas.SaveSet` YAML files.
+
+:class:`SaveSetStore` keeps one YAML file per save set (``<name>.yaml``, a
+plain ``model_dump(mode="json")`` document that round-trips through
+``SaveSet.model_validate``) in the per-experiment configs area — the same
+``save_devices/`` folder ``ConfigsRepoResolver`` reads::
+
+    scanner_configs/experiments/<Experiment>/save_devices/<name>.yaml
+
+Loading mirrors the resolver's dispatch: a document carrying
+``schema_version`` is validated directly; a legacy save element
+(``Devices:`` mapping) is converted through
+:func:`geecs_schemas.convert.convert_save_element` — *except* when the
+conversion would extract setup/closeout action plans out of the file.  Those
+plan bodies live only inside the legacy document, so editing-and-saving such
+an element here would silently drop them (the new-schema entries keep only
+name *references*).  The store refuses to load those with a clear message
+instead of losing data.
+
+Offline-safety mirrors :class:`~geecs_console.services.presets.PresetStore`:
+listing degrades to empty with no configs root; ``load``/``save``/``delete``/
+``rename`` raise :class:`SaveSetStoreError` with a status-bar-ready message.
+Creating the ``save_devices/`` directory with ``mkdir(parents=True,
+exist_ok=True)`` is deliberate and fine — this is a config directory in the
+configs repo, not a ``scans/ScanNNN/`` data folder, so the repo's scan-folder
+creation invariant does not apply.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Optional
+
+import yaml
+from pydantic import ValidationError
+
+from geecs_console.services.configs import SAVE_SET_FOLDER, _configs_base
+from geecs_schemas import SaveSet
+
+logger = logging.getLogger(__name__)
+
+
+class SaveSetStoreError(RuntimeError):
+    """A save-set operation cannot be carried out (surfaced in the status bar)."""
+
+
+class SaveSetStore:
+    """Load/save named save sets for one experiment.
+
+    Parameters
+    ----------
+    experiment : str, optional
+        Experiment folder under ``scanner_configs/experiments``.  May be
+        empty at construction (before the operator picks one) — listing is
+        then empty and saving raises.
+    experiments_root : str or Path, optional
+        Override for the experiments root (tests point this at a tmp dir);
+        defaults to the production resolution
+        (:func:`geecs_bluesky.scanner_configs.scanner_configs_base`, resolved
+        lazily so the module stays import-safe offline).
+    """
+
+    def __init__(
+        self, experiment: str = "", experiments_root: str | Path | None = None
+    ) -> None:
+        self._experiment = experiment
+        self._experiments_root = (
+            Path(experiments_root) if experiments_root is not None else None
+        )
+
+    @property
+    def experiment(self) -> str:
+        """The experiment this store reads and writes save sets for."""
+        return self._experiment
+
+    def set_experiment(self, experiment: str) -> None:
+        """Switch the store to *experiment*.
+
+        Parameters
+        ----------
+        experiment : str
+            The new experiment folder name ("" for none selected).
+        """
+        self._experiment = experiment
+
+    # ------------------------------------------------------------------
+    # Folder resolution (mirrors PresetStore)
+    # ------------------------------------------------------------------
+
+    def _root(self) -> Optional[Path]:
+        """Return the experiments root, or ``None`` offline."""
+        if self._experiments_root is not None:
+            return self._experiments_root
+        return _configs_base()
+
+    def _folder(self) -> Optional[Path]:
+        """Return the experiment's save-set dir, or ``None`` offline/unselected."""
+        root = self._root()
+        if root is None or not self._experiment:
+            return None
+        return root / self._experiment / SAVE_SET_FOLDER
+
+    def _folder_or_raise(self) -> Path:
+        """Return the save-set dir, raising a clear error when unresolvable.
+
+        Returns
+        -------
+        Path
+            ``<experiments root>/<experiment>/save_devices``.
+
+        Raises
+        ------
+        SaveSetStoreError
+            When the configs repo is not found or no experiment is selected.
+        """
+        root = self._root()
+        if root is None:
+            raise SaveSetStoreError(
+                "Configs repo not found — set GEECS_SCANNER_CONFIG_DIR or "
+                "config.ini [Paths] scanner_config_root_path."
+            )
+        if not self._experiment:
+            raise SaveSetStoreError("No experiment selected.")
+        return root / self._experiment / SAVE_SET_FOLDER
+
+    def _path(self, name: str) -> Path:
+        """Return the YAML path for save set *name*, validating the name.
+
+        Parameters
+        ----------
+        name : str
+            The save-set name (the file stem — no path separators).
+
+        Returns
+        -------
+        Path
+            ``<save_devices dir>/<name>.yaml`` (an existing ``.yml`` twin is
+            preferred when the ``.yaml`` spelling is absent).
+
+        Raises
+        ------
+        SaveSetStoreError
+            On an empty name or one that would escape the save-set dir.
+        """
+        cleaned = name.strip()
+        if not cleaned:
+            raise SaveSetStoreError("Save set name must not be empty.")
+        if any(sep in cleaned for sep in ("/", "\\")) or cleaned in (".", ".."):
+            raise SaveSetStoreError(
+                f"Save set name {name!r} must be a plain file name "
+                "(no path separators)."
+            )
+        folder = self._folder_or_raise()
+        path = folder / f"{cleaned}.yaml"
+        if not path.exists():
+            twin = folder / f"{cleaned}.yml"
+            if twin.exists():
+                return twin
+        return path
+
+    # ------------------------------------------------------------------
+    # The store surface
+    # ------------------------------------------------------------------
+
+    def list_names(self) -> list[str]:
+        """List the saved save-set names, sorted; never raises.
+
+        Returns
+        -------
+        list of str
+            YAML file stems in the ``save_devices`` dir — empty when the
+            configs repo, experiment folder, or save-set dir is missing.
+        """
+        folder = self._folder()
+        if folder is None or not folder.is_dir():
+            return []
+        return sorted(
+            path.stem for path in folder.iterdir() if path.suffix in (".yaml", ".yml")
+        )
+
+    def _read_document(self, name: str, path: Path) -> dict:
+        """Read one YAML mapping, with status-bar-ready errors.
+
+        Parameters
+        ----------
+        name : str
+            The save-set name (for messages).
+        path : Path
+            The YAML file to read.
+
+        Returns
+        -------
+        dict
+            The parsed top-level mapping.
+
+        Raises
+        ------
+        SaveSetStoreError
+            A missing file, unparsable YAML, or a non-mapping document.
+        """
+        if not path.exists():
+            raise SaveSetStoreError(f"Save set {name!r} not found ({path}).")
+        try:
+            document = yaml.safe_load(path.read_text(encoding="utf-8"))
+        except yaml.YAMLError as exc:
+            raise SaveSetStoreError(
+                f"Save set {name!r} is not valid YAML ({path}): {exc}"
+            ) from exc
+        if not isinstance(document, dict):
+            raise SaveSetStoreError(
+                f"Save set {name!r} ({path}) should be a YAML mapping of "
+                f"SaveSet fields, got {type(document).__name__}."
+            )
+        return document
+
+    def load(self, name: str) -> SaveSet:
+        """Load save set *name* as a validated :class:`SaveSet`.
+
+        New-schema documents (carrying ``schema_version``) validate directly;
+        legacy save elements are converted — unless the conversion would
+        extract inline setup/closeout action plans, which saving back would
+        silently drop (see the module docstring).
+
+        Parameters
+        ----------
+        name : str
+            The save-set name (file stem).
+
+        Returns
+        -------
+        SaveSet
+            The schema-validated save set.
+
+        Raises
+        ------
+        SaveSetStoreError
+            Missing configs repo / experiment / file, unparsable YAML, a
+            document the schema rejects, or a legacy element this editor
+            cannot round-trip without losing its inline actions — always
+            with a message fit for the status bar.
+        """
+        path = self._path(name)
+        document = self._read_document(name, path)
+        if "schema_version" in document:
+            try:
+                return SaveSet.model_validate(document)
+            except ValidationError as exc:
+                raise SaveSetStoreError(
+                    f"Save set {name!r} ({path}) is not a valid SaveSet: {exc}"
+                ) from exc
+        return self._load_legacy(name, path, document)
+
+    def _load_legacy(self, name: str, path: Path, document: dict) -> SaveSet:
+        """Convert a legacy save element, refusing lossy conversions.
+
+        Parameters
+        ----------
+        name : str
+            The save-set name (file stem).
+        path : Path
+            The legacy YAML file (for messages).
+        document : dict
+            The parsed legacy mapping (``Devices:`` dialect).
+
+        Returns
+        -------
+        SaveSet
+            The converted save set.
+
+        Raises
+        ------
+        SaveSetStoreError
+            A document the converter rejects, an action-only element, or an
+            element whose inline setup/closeout actions would be lost by a
+            save from this editor.
+        """
+        from geecs_schemas.convert import SchemaConversionError, convert_save_element
+
+        try:
+            result = convert_save_element(document, name=path.stem)
+        except SchemaConversionError as exc:
+            raise SaveSetStoreError(
+                f"Save set {name!r} ({path}) is not a valid legacy save element: {exc}"
+            ) from exc
+        for note in result.notes:
+            logger.info("save set %s (converted from legacy): %s", path.stem, note)
+        if result.save_set is None:
+            raise SaveSetStoreError(
+                f"Save set {name!r} ({path}) is an action-only legacy "
+                "element — it lists no devices to record."
+            )
+        if result.actions:
+            # The plan bodies exist only inside the legacy file; the
+            # converted entries carry name references.  Saving from this
+            # editor would rewrite the file without the bodies — refuse
+            # rather than lose the operator's rituals.
+            plans = ", ".join(sorted(result.actions))
+            raise SaveSetStoreError(
+                f"Save set {name!r} ({path}) is a legacy element with inline "
+                f"setup/closeout actions ({plans}) — migrate those to the "
+                "experiment's action library before editing it here."
+            )
+        return result.save_set
+
+    def save(self, name: str, save_set: SaveSet) -> Path:
+        """Write *save_set* as *name* (new schema, overwriting an existing file).
+
+        Parameters
+        ----------
+        name : str
+            The save-set name (file stem).
+        save_set : SaveSet
+            The save set to persist.
+
+        Returns
+        -------
+        Path
+            The YAML file written.
+
+        Raises
+        ------
+        SaveSetStoreError
+            Missing configs repo, no experiment selected, a bad name, or an
+            OS-level write failure.
+        """
+        path = self._path(name)
+        # A config dir, not a scans/ScanNNN/ data folder — parents=True is
+        # explicitly fine here (the scan-folder invariant does not apply).
+        path.parent.mkdir(parents=True, exist_ok=True)
+        document = yaml.safe_dump(
+            save_set.model_dump(mode="json"), sort_keys=False, allow_unicode=True
+        )
+        try:
+            path.write_text(document, encoding="utf-8")
+        except OSError as exc:
+            raise SaveSetStoreError(
+                f"Could not write save set {name!r}: {exc}"
+            ) from exc
+        logger.info("saved save set %r to %s", name, path)
+        return path
+
+    def delete(self, name: str) -> None:
+        """Delete save set *name*.
+
+        Parameters
+        ----------
+        name : str
+            The save-set name (file stem).
+
+        Raises
+        ------
+        SaveSetStoreError
+            Missing configs repo / experiment, a bad name, a save set that
+            does not exist, or an OS-level delete failure.
+        """
+        path = self._path(name)
+        if not path.exists():
+            raise SaveSetStoreError(f"Save set {name!r} not found ({path}).")
+        try:
+            path.unlink()
+        except OSError as exc:
+            raise SaveSetStoreError(
+                f"Could not delete save set {name!r}: {exc}"
+            ) from exc
+        logger.info("deleted save set %r (%s)", name, path)
+
+    def rename(self, old: str, new: str) -> Path:
+        """Rename save set *old* to *new*, keeping the document's ``name`` in step.
+
+        A new-schema document's ``name`` field is rewritten to *new* so the
+        file stem and the in-file name never drift apart; a legacy document
+        (no ``name`` field) moves untouched.
+
+        Parameters
+        ----------
+        old : str
+            The current save-set name (file stem).
+        new : str
+            The new name.  Must not collide with an existing save set.
+
+        Returns
+        -------
+        Path
+            The renamed YAML file.
+
+        Raises
+        ------
+        SaveSetStoreError
+            Missing configs repo / experiment, a bad name, a source that
+            does not exist, a target that already exists, or an OS-level
+            failure.
+        """
+        source = self._path(old)
+        if not source.exists():
+            raise SaveSetStoreError(f"Save set {old!r} not found ({source}).")
+        target = self._path(new)
+        if target.exists():
+            raise SaveSetStoreError(
+                f"Cannot rename {old!r} to {new!r}: a save set with that "
+                "name already exists."
+            )
+        document = self._read_document(old, source)
+        if "name" in document:
+            document["name"] = new.strip()
+        text = yaml.safe_dump(document, sort_keys=False, allow_unicode=True)
+        try:
+            target.write_text(text, encoding="utf-8")
+            source.unlink()
+        except OSError as exc:
+            raise SaveSetStoreError(
+                f"Could not rename save set {old!r} to {new!r}: {exc}"
+            ) from exc
+        logger.info("renamed save set %r to %r (%s)", old, new, target)
+        return target

--- a/GEECS-Console/tests/test_save_set_editor.py
+++ b/GEECS-Console/tests/test_save_set_editor.py
@@ -6,15 +6,29 @@ from PySide6.QtCore import Qt
 from PySide6.QtWidgets import QMessageBox, QPushButton
 
 from geecs_console.editors import save_set_editor as sse
-from geecs_console.editors.save_set_editor import (
-    SaveSetEditor,
-    geecs_db_completions,
-    open_save_set_editor,
-)
+from geecs_console.editors.save_set_editor import SaveSetEditor, open_save_set_editor
+from geecs_console.services.device_completions import GeecsDbCompletions
 from geecs_console.services.save_set_store import SaveSetStore
 from geecs_schemas import SaveRole, SaveSet, SaveSetEntry
 
 SAVE_SET_FOLDER = "save_devices"
+
+
+class FakeCompletions:
+    """CompletionsProvider stand-in: a fixed device → variables mapping."""
+
+    def __init__(self, mapping):
+        self._mapping = dict(mapping)
+
+    def device_variables(self):
+        return self._mapping
+
+
+class ExplodingCompletions:
+    """CompletionsProvider stand-in whose fetch always fails."""
+
+    def device_variables(self):
+        raise RuntimeError("no database out here")
 
 
 def diag_set(name="diag", description="alignment diagnostics") -> SaveSet:
@@ -145,7 +159,7 @@ class TestOpening:
 
     def test_entry_point_returns_a_shown_dialog(self, qtbot, track, tmp_path):
         dialog = open_save_set_editor(
-            None, "HTU", configs_base=tmp_path, completions=lambda exp: {}
+            None, "HTU", configs_base=tmp_path, completions=FakeCompletions({})
         )
         track(dialog)
         assert dialog.isVisible()
@@ -156,7 +170,7 @@ class TestOpening:
     def test_db_completions_with_no_experiment_is_empty(self):
         # The production provider's no-experiment early-out — no imports,
         # no network.
-        assert geecs_db_completions("") == {}
+        assert GeecsDbCompletions("").device_variables() == {}
 
 
 class TestDirtySaveRevert:
@@ -323,7 +337,7 @@ class TestCompleters:
             SaveSetEditor(
                 experiment="HTU",
                 store=store,
-                completions=lambda exp: self.COMPLETIONS,
+                completions=FakeCompletions(self.COMPLETIONS),
             )
         )
         qtbot.waitUntil(
@@ -342,11 +356,10 @@ class TestCompleters:
         assert editor._variable_model.stringList() == []
 
     def test_failing_provider_degrades_to_empty(self, qtbot, track, store):
-        def explode(experiment):
-            raise RuntimeError("no database out here")
-
         editor = track(
-            SaveSetEditor(experiment="HTU", store=store, completions=explode)
+            SaveSetEditor(
+                experiment="HTU", store=store, completions=ExplodingCompletions()
+            )
         )
         qtbot.waitUntil(lambda: editor._completions_loaded, timeout=2000)
         assert editor._completions == {}

--- a/GEECS-Console/tests/test_save_set_editor.py
+++ b/GEECS-Console/tests/test_save_set_editor.py
@@ -1,0 +1,378 @@
+"""SaveSetEditor behavior, hermetic: tmp-dir store, fake completions, offscreen Qt."""
+
+import pytest
+import yaml
+from PySide6.QtCore import Qt
+from PySide6.QtWidgets import QMessageBox, QPushButton
+
+from geecs_console.editors import save_set_editor as sse
+from geecs_console.editors.save_set_editor import (
+    SaveSetEditor,
+    geecs_db_completions,
+    open_save_set_editor,
+)
+from geecs_console.services.save_set_store import SaveSetStore
+from geecs_schemas import SaveRole, SaveSet, SaveSetEntry
+
+SAVE_SET_FOLDER = "save_devices"
+
+
+def diag_set(name="diag", description="alignment diagnostics") -> SaveSet:
+    return SaveSet(
+        name=name,
+        description=description,
+        entries=[
+            SaveSetEntry(device="UC_ALineEbeam1", images=True),
+            SaveSetEntry(
+                device="U_HP_Daq",
+                scalars=["PressureTorr"],
+                role=SaveRole.SNAPSHOT,
+                db_scalars=False,
+            ),
+        ],
+    )
+
+
+@pytest.fixture
+def store(tmp_path):
+    store = SaveSetStore("HTU", experiments_root=tmp_path)
+    store.save("diag", diag_set())
+    store.save("beam", diag_set(name="beam", description="beam cams"))
+    return store
+
+
+@pytest.fixture
+def track(qtbot):
+    """Register editors for deterministic teardown.
+
+    Two hazards this fixture defuses:
+
+    - A dirty editor pops a real modal ``QMessageBox.question`` on close
+      (a hang under the offscreen platform) — the dirty flag is cleared
+      before closing.
+    - A shown dialog has posted events (polish, queued signal deliveries)
+      still in Qt's queue; letting the Python reference drop destroys the
+      C++ widget underneath them and the next event flush segfaults.  So
+      teardown flushes posted events *while the editors are alive*, then
+      destroys them deterministically via ``deleteLater`` + another flush.
+    """
+    from PySide6.QtCore import QEvent
+    from PySide6.QtWidgets import QApplication
+
+    editors = []
+
+    def register(editor):
+        editors.append(editor)
+        return editor
+
+    yield register
+
+    for editor in editors:
+        editor._dirty = False
+        editor.close()
+    QApplication.sendPostedEvents()
+    QApplication.processEvents()
+    for editor in editors:
+        editor.deleteLater()
+    QApplication.sendPostedEvents(None, QEvent.Type.DeferredDelete)
+    QApplication.processEvents()
+
+
+@pytest.fixture
+def editor(track, store):
+    return track(SaveSetEditor(experiment="HTU", store=store))
+
+
+def select_set(editor, name):
+    for row in range(editor.set_list.count()):
+        if editor.set_list.item(row).text() == name:
+            editor.set_list.setCurrentRow(row)
+            return
+    raise AssertionError(f"{name!r} not in the set list")
+
+
+def answer(monkeypatch, button):
+    monkeypatch.setattr(sse.QMessageBox, "question", lambda *args, **kwargs: button)
+
+
+def type_name(monkeypatch, name):
+    monkeypatch.setattr(
+        sse.QInputDialog, "getText", lambda *args, **kwargs: (name, True)
+    )
+
+
+class TestOpening:
+    def test_opens_clean_with_no_configs(self, track, tmp_path):
+        editor = track(SaveSetEditor(store=SaveSetStore("", experiments_root=tmp_path)))
+        assert editor.set_list.count() == 0
+        assert not editor.save_button.isEnabled()
+        assert not editor.description_edit.isEnabled()
+
+    def test_lists_the_stores_sets(self, editor):
+        names = [
+            editor.set_list.item(row).text() for row in range(editor.set_list.count())
+        ]
+        assert names == ["beam", "diag"]
+
+    def test_loads_a_set_into_the_form(self, editor):
+        select_set(editor, "diag")
+        assert editor.name_label.text() == "diag"
+        assert editor.description_edit.text() == "alignment diagnostics"
+        devices = [
+            editor.device_list.item(row).text()
+            for row in range(editor.device_list.count())
+        ]
+        assert devices == ["UC_ALineEbeam1", "U_HP_Daq"]
+        # Entry 0: camera with images on, schema defaults elsewhere.
+        assert editor.images_check.isChecked()
+        assert editor.db_scalars_check.isChecked()
+        assert editor.role_combo.currentText() == "(derived)"
+        # Entry 1: snapshot gauge with an extra scalar.
+        editor.device_list.setCurrentRow(1)
+        assert not editor.images_check.isChecked()
+        assert not editor.db_scalars_check.isChecked()
+        assert editor.role_combo.currentText() == "snapshot"
+        assert editor.scalar_list.count() == 1
+        assert editor.scalar_list.item(0).text() == "PressureTorr"
+
+    def test_load_error_is_shown_inline_not_raised(self, editor, tmp_path):
+        folder = tmp_path / "HTU" / SAVE_SET_FOLDER
+        (folder / "broken.yaml").write_text("entries: [unclosed")
+        editor._refresh_set_list()
+        select_set(editor, "broken")
+        assert "not valid YAML" in editor.message_label.text()
+        assert editor.name_label.text() == "—"
+
+    def test_entry_point_returns_a_shown_dialog(self, qtbot, track, tmp_path):
+        dialog = open_save_set_editor(
+            None, "HTU", configs_base=tmp_path, completions=lambda exp: {}
+        )
+        track(dialog)
+        assert dialog.isVisible()
+        # Let the completions fetch land before teardown so its queued
+        # signal delivery cannot outlive the dialog.
+        qtbot.waitUntil(lambda: dialog._completions_loaded, timeout=2000)
+
+    def test_db_completions_with_no_experiment_is_empty(self):
+        # The production provider's no-experiment early-out — no imports,
+        # no network.
+        assert geecs_db_completions("") == {}
+
+
+class TestDirtySaveRevert:
+    def test_edit_marks_dirty_and_enables_save(self, editor):
+        select_set(editor, "diag")
+        assert not editor.save_button.isEnabled()
+        editor.description_edit.setText("retuned")
+        assert editor.windowTitle().endswith("*")
+        assert editor.save_button.isEnabled()
+        assert editor.revert_button.isEnabled()
+
+    def test_save_writes_the_expected_yaml(self, editor, tmp_path):
+        select_set(editor, "diag")
+        editor.description_edit.setText("retuned")
+        editor.images_check.setChecked(False)
+        editor.save_button.click()
+        document = yaml.safe_load(
+            (tmp_path / "HTU" / SAVE_SET_FOLDER / "diag.yaml").read_text()
+        )
+        assert document["description"] == "retuned"
+        assert document["entries"][0]["images"] is False
+        assert not editor.save_button.isEnabled()
+        assert not editor.windowTitle().endswith("*")
+
+    def test_entry_edits_write_through(self, editor, store):
+        select_set(editor, "diag")
+        editor.device_list.setCurrentRow(1)
+        editor.scalar_edit.setText("Temperature")
+        editor.add_scalar_button.click()
+        editor.setup_edit.setText("warm_up, open_shutter")
+        editor.role_combo.setCurrentIndex(editor.role_combo.findData("reference"))
+        editor.save_button.click()
+        loaded = store.load("diag")
+        assert loaded.entries[1].scalars == ["PressureTorr", "Temperature"]
+        assert loaded.entries[1].setup == ["warm_up", "open_shutter"]
+        assert loaded.entries[1].role is SaveRole.REFERENCE
+
+    def test_revert_restores_the_stored_document(self, editor):
+        select_set(editor, "diag")
+        editor.description_edit.setText("scribble")
+        editor.revert_button.click()
+        assert editor.description_edit.text() == "alignment diagnostics"
+        assert not editor.save_button.isEnabled()
+        assert not editor.windowTitle().endswith("*")
+
+    def test_removing_every_device_shows_validation_error(self, editor):
+        select_set(editor, "diag")
+        editor.device_list.setCurrentRow(0)
+        editor.remove_device_button.click()
+        editor.remove_device_button.click()
+        assert not editor.save_button.isEnabled()
+        assert "at least 1 item" in editor.message_label.text()
+
+    def test_duplicate_device_is_refused(self, editor):
+        select_set(editor, "diag")
+        editor.device_edit.setText("U_HP_Daq")
+        editor.add_device_button.click()
+        assert editor.device_list.count() == 2
+        assert "already in this save set" in editor.message_label.text()
+
+
+class TestUnsavedChangesPrompt:
+    def test_cancel_keeps_the_selection_and_edits(self, editor, monkeypatch):
+        select_set(editor, "diag")
+        row = editor.set_list.currentRow()
+        editor.description_edit.setText("scribble")
+        answer(monkeypatch, QMessageBox.StandardButton.Cancel)
+        select_set(editor, "beam")
+        assert editor.set_list.currentRow() == row
+        assert editor.description_edit.text() == "scribble"
+
+    def test_discard_switches_and_drops_the_edits(self, editor, monkeypatch):
+        select_set(editor, "diag")
+        editor.description_edit.setText("scribble")
+        answer(monkeypatch, QMessageBox.StandardButton.Discard)
+        select_set(editor, "beam")
+        assert editor.name_label.text() == "beam"
+        select_set(editor, "diag")
+        assert editor.description_edit.text() == "alignment diagnostics"
+
+    def test_save_choice_persists_before_switching(self, editor, store, monkeypatch):
+        select_set(editor, "diag")
+        editor.description_edit.setText("kept")
+        answer(monkeypatch, QMessageBox.StandardButton.Save)
+        select_set(editor, "beam")
+        assert editor.name_label.text() == "beam"
+        assert store.load("diag").description == "kept"
+
+    def test_close_prompts_and_cancel_keeps_it_open(self, qtbot, editor, monkeypatch):
+        editor.show()
+        select_set(editor, "diag")
+        editor.description_edit.setText("scribble")
+        answer(monkeypatch, QMessageBox.StandardButton.Cancel)
+        editor.close()
+        assert editor.isVisible()
+        answer(monkeypatch, QMessageBox.StandardButton.Discard)
+        editor.close()
+        assert not editor.isVisible()
+
+
+class TestListActions:
+    def test_new_set_is_invalid_until_a_device_is_added(
+        self, editor, store, tmp_path, monkeypatch
+    ):
+        type_name(monkeypatch, "fresh")
+        editor.new_button.click()
+        assert editor.name_label.text() == "fresh"
+        assert not editor.save_button.isEnabled()
+        assert "at least 1 item" in editor.message_label.text()
+        editor.device_edit.setText("UC_NewCam")
+        editor.add_device_button.click()
+        assert editor.save_button.isEnabled()
+        editor.save_button.click()
+        assert (tmp_path / "HTU" / SAVE_SET_FOLDER / "fresh.yaml").is_file()
+        assert store.load("fresh").entries[0].device == "UC_NewCam"
+
+    def test_new_name_collision_is_refused(self, editor, monkeypatch):
+        type_name(monkeypatch, "diag")
+        editor.new_button.click()
+        assert "already exists" in editor.message_label.text()
+        assert editor.set_list.count() == 2
+
+    def test_duplicate_copies_the_open_set(self, editor, store, monkeypatch):
+        select_set(editor, "diag")
+        type_name(monkeypatch, "diag-copy")
+        editor.duplicate_button.click()
+        assert editor.name_label.text() == "diag-copy"
+        assert editor.save_button.isEnabled()  # a duplicate starts dirty & valid
+        editor.save_button.click()
+        assert store.load("diag-copy").entries == diag_set().entries
+
+    def test_rename_updates_file_and_form(self, editor, store, monkeypatch):
+        select_set(editor, "diag")
+        type_name(monkeypatch, "diag2")
+        editor.rename_button.click()
+        assert editor.name_label.text() == "diag2"
+        assert store.list_names() == ["beam", "diag2"]
+        assert store.load("diag2").name == "diag2"
+
+    def test_delete_removes_the_set(self, editor, store, monkeypatch):
+        select_set(editor, "diag")
+        answer(monkeypatch, QMessageBox.StandardButton.Yes)
+        editor.delete_button.click()
+        assert store.list_names() == ["beam"]
+        assert editor.name_label.text() == "—"
+        assert editor.set_list.count() == 1
+
+    def test_delete_no_leaves_everything_alone(self, editor, store, monkeypatch):
+        select_set(editor, "diag")
+        answer(monkeypatch, QMessageBox.StandardButton.No)
+        editor.delete_button.click()
+        assert store.list_names() == ["beam", "diag"]
+        assert editor.name_label.text() == "diag"
+
+
+class TestCompleters:
+    COMPLETIONS = {
+        "UC_ALineEbeam1": ["MaxCounts", "MeanCounts"],
+        "U_HP_Daq": ["PressureTorr"],
+    }
+
+    def test_completers_fed_by_the_injected_provider(self, qtbot, track, store):
+        editor = track(
+            SaveSetEditor(
+                experiment="HTU",
+                store=store,
+                completions=lambda exp: self.COMPLETIONS,
+            )
+        )
+        qtbot.waitUntil(
+            lambda: editor._device_model.stringList() == ["UC_ALineEbeam1", "U_HP_Daq"],
+            timeout=2000,
+        )
+        select_set(editor, "diag")
+        editor.device_list.setCurrentRow(0)
+        assert editor._variable_model.stringList() == ["MaxCounts", "MeanCounts"]
+        editor.device_list.setCurrentRow(1)
+        assert editor._variable_model.stringList() == ["PressureTorr"]
+
+    def test_no_provider_means_empty_completers(self, editor):
+        select_set(editor, "diag")
+        assert editor._device_model.stringList() == []
+        assert editor._variable_model.stringList() == []
+
+    def test_failing_provider_degrades_to_empty(self, qtbot, track, store):
+        def explode(experiment):
+            raise RuntimeError("no database out here")
+
+        editor = track(
+            SaveSetEditor(experiment="HTU", store=store, completions=explode)
+        )
+        qtbot.waitUntil(lambda: editor._completions_loaded, timeout=2000)
+        assert editor._completions == {}
+        assert editor._device_model.stringList() == []
+
+
+class TestEnterGuard:
+    def test_no_button_is_auto_default(self, editor):
+        for button in editor.findChildren(QPushButton):
+            assert not button.autoDefault()
+            assert not button.isDefault()
+
+    def test_enter_in_a_line_edit_does_not_close_the_dialog(self, qtbot, editor):
+        editor.show()
+        select_set(editor, "diag")
+        qtbot.keyClick(editor.description_edit, Qt.Key.Key_Return)
+        assert editor.isVisible()
+
+    def test_enter_in_the_device_edit_adds_the_device(self, qtbot, editor):
+        editor.show()
+        select_set(editor, "diag")
+        editor.device_edit.setText("UC_NewCam")
+        qtbot.keyClick(editor.device_edit, Qt.Key.Key_Return)
+        assert editor.isVisible()
+        devices = [
+            editor.device_list.item(row).text()
+            for row in range(editor.device_list.count())
+        ]
+        assert "UC_NewCam" in devices

--- a/GEECS-Console/tests/test_save_set_store.py
+++ b/GEECS-Console/tests/test_save_set_store.py
@@ -1,0 +1,250 @@
+"""SaveSetStore: YAML round-trips against a tmp configs root, hermetic."""
+
+import pytest
+import yaml
+
+from geecs_console.services.save_set_store import SaveSetStore, SaveSetStoreError
+from geecs_schemas import SaveRole, SaveSet, SaveSetEntry
+
+SAVE_SET_FOLDER = "save_devices"
+
+
+def diag_set(name="diag", description="") -> SaveSet:
+    return SaveSet(
+        name=name,
+        description=description,
+        entries=[
+            SaveSetEntry(device="UC_ALineEbeam1", images=True),
+            SaveSetEntry(
+                device="U_HP_Daq",
+                scalars=["PressureTorr"],
+                role=SaveRole.SNAPSHOT,
+                db_scalars=False,
+            ),
+        ],
+    )
+
+
+LEGACY_PLAIN = """\
+Devices:
+  UC_ALineEbeam1:
+    synchronous: true
+    save_nonscalar_data: true
+    variable_list: [MaxCounts, centroidx]
+"""
+
+LEGACY_WITH_ACTIONS = """\
+Devices:
+  UC_ALineEbeam1:
+    synchronous: true
+    save_nonscalar_data: true
+    variable_list: []
+setup_action:
+  steps:
+    - action: set
+      device: UC_ALineEbeam1
+      variable: Analysis
+      value: 'on'
+"""
+
+LEGACY_ACTION_ONLY = """\
+Devices: {}
+setup_action:
+  steps:
+    - action: set
+      device: UC_ALineEbeam1
+      variable: Analysis
+      value: 'on'
+"""
+
+
+@pytest.fixture
+def store(tmp_path):
+    return SaveSetStore("HTU", experiments_root=tmp_path)
+
+
+@pytest.fixture
+def folder(tmp_path):
+    path = tmp_path / "HTU" / SAVE_SET_FOLDER
+    path.mkdir(parents=True)
+    return path
+
+
+class TestRoundTrip:
+    def test_save_load_round_trips_the_save_set(self, store):
+        save_set = diag_set(description="alignment diagnostics")
+        store.save("diag", save_set)
+        assert store.load("diag") == save_set
+
+    def test_file_lands_in_the_experiment_save_devices_dir(self, store, tmp_path):
+        path = store.save("diag", diag_set())
+        assert path == tmp_path / "HTU" / SAVE_SET_FOLDER / "diag.yaml"
+        assert path.is_file()
+
+    def test_written_yaml_is_the_new_schema(self, store):
+        path = store.save("diag", diag_set())
+        document = yaml.safe_load(path.read_text())
+        assert document["schema_version"] == 1
+        assert document["name"] == "diag"
+        assert [entry["device"] for entry in document["entries"]] == [
+            "UC_ALineEbeam1",
+            "U_HP_Daq",
+        ]
+
+    def test_reserved_fields_survive_the_round_trip(self, store):
+        save_set = SaveSet(
+            name="diag",
+            entries=[
+                SaveSetEntry(
+                    device="UC_ALineEbeam1",
+                    at_scan_start={"Analysis": "on"},
+                    at_scan_end={"Analysis": None},
+                )
+            ],
+        )
+        store.save("diag", save_set)
+        loaded = store.load("diag")
+        assert loaded.entries[0].at_scan_start == {"Analysis": "on"}
+        assert loaded.entries[0].at_scan_end == {"Analysis": None}
+
+    def test_list_names_sorted(self, store):
+        for name in ("zeta", "alpha", "mid"):
+            store.save(name, diag_set(name=name))
+        assert store.list_names() == ["alpha", "mid", "zeta"]
+
+    def test_overwrite_is_allowed(self, store):
+        store.save("diag", diag_set(description="v1"))
+        store.save("diag", diag_set(description="v2"))
+        assert store.load("diag").description == "v2"
+        assert store.list_names() == ["diag"]
+
+    def test_delete_removes_the_save_set(self, store):
+        store.save("diag", diag_set())
+        store.delete("diag")
+        assert store.list_names() == []
+        with pytest.raises(SaveSetStoreError, match="not found"):
+            store.load("diag")
+
+    def test_yml_twin_is_listed_and_loadable(self, store, folder):
+        store.save("seed", diag_set(name="seed"))
+        (folder / "seed.yaml").rename(folder / "twin.yml")
+        assert store.list_names() == ["twin"]
+        assert store.load("twin").entries[0].device == "UC_ALineEbeam1"
+
+    def test_set_experiment_switches_folders(self, store, tmp_path):
+        store.save("diag", diag_set())
+        store.set_experiment("Bella")
+        assert store.list_names() == []
+        store.save("bella-only", diag_set(name="bella-only"))
+        assert (tmp_path / "Bella" / SAVE_SET_FOLDER / "bella-only.yaml").is_file()
+
+
+class TestLegacyConversion:
+    def test_plain_legacy_element_converts(self, store, folder):
+        (folder / "old.yaml").write_text(LEGACY_PLAIN)
+        loaded = store.load("old")
+        assert loaded.name == "old"
+        entry = loaded.entries[0]
+        assert entry.device == "UC_ALineEbeam1"
+        assert entry.images is True
+        assert entry.scalars == ["MaxCounts", "centroidx"]
+        assert entry.db_scalars is False  # converted elements keep legacy behavior
+
+    def test_legacy_with_inline_actions_is_refused(self, store, folder):
+        (folder / "ritual.yaml").write_text(LEGACY_WITH_ACTIONS)
+        with pytest.raises(SaveSetStoreError, match="action library"):
+            store.load("ritual")
+
+    def test_action_only_legacy_element_is_refused(self, store, folder):
+        (folder / "actions.yaml").write_text(LEGACY_ACTION_ONLY)
+        with pytest.raises(SaveSetStoreError, match="action-only"):
+            store.load("actions")
+
+
+class TestRename:
+    def test_rename_moves_file_and_updates_name_field(self, store, tmp_path):
+        store.save("diag", diag_set())
+        path = store.rename("diag", "diag2")
+        assert path == tmp_path / "HTU" / SAVE_SET_FOLDER / "diag2.yaml"
+        assert store.list_names() == ["diag2"]
+        assert store.load("diag2").name == "diag2"
+
+    def test_rename_missing_raises_clearly(self, store):
+        with pytest.raises(SaveSetStoreError, match="'ghost' not found"):
+            store.rename("ghost", "new")
+
+    def test_rename_onto_existing_is_refused(self, store):
+        store.save("a", diag_set(name="a"))
+        store.save("b", diag_set(name="b"))
+        with pytest.raises(SaveSetStoreError, match="already exists"):
+            store.rename("a", "b")
+        assert store.list_names() == ["a", "b"]
+
+    def test_rename_legacy_file_moves_it_untouched(self, store, folder):
+        (folder / "old.yaml").write_text(LEGACY_PLAIN)
+        store.rename("old", "older")
+        assert store.list_names() == ["older"]
+        document = yaml.safe_load((folder / "older.yaml").read_text())
+        assert "Devices" in document and "name" not in document
+
+
+class TestErrors:
+    def test_missing_dir_lists_empty(self, store):
+        assert store.list_names() == []
+
+    def test_load_missing_raises_clearly(self, store):
+        with pytest.raises(SaveSetStoreError, match="'ghost' not found"):
+            store.load("ghost")
+
+    def test_delete_missing_raises_clearly(self, store):
+        with pytest.raises(SaveSetStoreError, match="'ghost' not found"):
+            store.delete("ghost")
+
+    def test_invalid_yaml_raises_clearly(self, store, folder):
+        (folder / "broken.yaml").write_text("entries: [unclosed")
+        with pytest.raises(SaveSetStoreError, match="not valid YAML"):
+            store.load("broken")
+
+    def test_non_mapping_yaml_raises_clearly(self, store, folder):
+        (folder / "list.yaml").write_text("- just\n- a\n- list\n")
+        with pytest.raises(SaveSetStoreError, match="YAML mapping"):
+            store.load("list")
+
+    def test_schema_rejected_document_raises_clearly(self, store, folder):
+        (folder / "bad.yaml").write_text("schema_version: 1\nname: bad\nentries: []\n")
+        with pytest.raises(SaveSetStoreError, match="not a valid SaveSet"):
+            store.load("bad")
+
+    def test_unknown_field_raises_clearly(self, store, folder):
+        (folder / "typo.yaml").write_text(
+            "schema_version: 1\nname: typo\nentires:\n- device: X\n"
+        )
+        with pytest.raises(SaveSetStoreError, match="not a valid SaveSet"):
+            store.load("typo")
+
+    def test_no_experiment_selected_save_raises(self, tmp_path):
+        store = SaveSetStore("", experiments_root=tmp_path)
+        with pytest.raises(SaveSetStoreError, match="No experiment selected"):
+            store.save("diag", diag_set())
+        assert store.list_names() == []
+
+    def test_missing_configs_repo_lists_empty_and_save_raises(self, monkeypatch):
+        # Offline: the lazy configs-root resolution finds nothing.
+        monkeypatch.setattr(
+            "geecs_console.services.save_set_store._configs_base", lambda: None
+        )
+        store = SaveSetStore("HTU")
+        assert store.list_names() == []
+        with pytest.raises(SaveSetStoreError, match="Configs repo not found"):
+            store.save("diag", diag_set())
+
+    @pytest.mark.parametrize("name", ["", "   ", "a/b", "a\\b", "..", "."])
+    def test_bad_names_rejected(self, store, name):
+        with pytest.raises(SaveSetStoreError, match="name"):
+            store.save(name, diag_set())
+
+    @pytest.mark.parametrize("name", ["a/b", ".."])
+    def test_bad_rename_targets_rejected(self, store, name):
+        store.save("diag", diag_set())
+        with pytest.raises(SaveSetStoreError, match="name"):
+            store.rename("diag", name)


### PR DESCRIPTION
The M5 editor for save sets — **new files only** (Editors-menu wiring and the version bump land in the later integration PR, per the four-editors isolation plan).

## What's here

**Store** — `geecs_console/services/save_set_store.py`
- `SaveSetStore`: `list_names` / `load` / `save` / `delete` / `rename` over the per-experiment `scanner_configs/experiments/<Exp>/save_devices/` dir (the same folder `ConfigsRepoResolver` reads).
- YAML ↔ pydantic round-trip: `SaveSet.model_validate` in, `model_dump(mode="json")` out — everything the schema carries (including the reserved `at_scan_start`/`at_scan_end`) survives untouched.
- Mirrors `PresetStore`'s error contract: listing never raises (offline ⇒ empty), everything else raises `SaveSetStoreError` with a status-bar-ready message; empty/path-escaping names rejected.
- Legacy save elements (`Devices:` dialect) load through `convert_save_element`, matching the resolver's `schema_version` dispatch. Elements whose conversion would **extract inline setup/closeout action plans are refused** with a "migrate to the action library first" message — saving them back from this editor would silently drop the plan bodies.
- `rename` keeps the file stem and the document's `name` field in step.

**Editor** — `geecs_console/editors/save_set_editor.py` + `app/ui/save_set_editor.ui`
- Hand-authored `.ui` via `QUiLoader`, `sse_` object-name prefix, styled by the app-level QSS.
- Left: save-set list with New / Duplicate / Rename / Delete. Right: the document — description, device entries (add/remove), and the selected entry's fields **derived from `SaveSetEntry`'s actual model fields**: `images`, `db_scalars`, `all_scalars`, `role` override (`(derived)` / reference / contributor / snapshot), extra `scalars` list, `setup`/`closeout` plan references.
- Save/Revert with dirty tracking; unsaved-changes prompt (Save/Discard/Cancel) on set switch and on close; pydantic validation errors rendered inline in a message label — Save stays disabled until the document validates (a new set is invalid until its first device).
- Device/variable `QCompleter`s fed by the **shared `CompletionsProvider` seam**: fetched once on a **daemon thread + queued signal** (the no-QThread rule); `EmptyCompletions` default is answered inline (offline construction stays thread-free); `open_save_set_editor` defaults to `GeecsDbCompletions(experiment)`. Completers and models are kept as attributes — `setCompleter` does not take ownership, and a GC'd completer segfaults on the next model update.
- Enter in a line edit never triggers dialog accept (all buttons de-auto-defaulted); Enter in the device/variable edits adds the entry instead.
- `open_save_set_editor(parent, experiment, configs_base=None, completions=None) -> QDialog` is the entry point the integration PR will call from the Editors menu. Opens offline with zero configs.

**Shared with PR #504** — `services/device_completions.py` and `editors/__init__.py` are **byte-identical** to `console/editor-scanvars` (verified with `diff`), so whichever PR lands second auto-resolves the identical additions.

**Tests** — 61 new (33 store + 28 editor), full suite **264 passed, exit 0 across 4+ consecutive offscreen runs at final HEAD** (10+ clean runs total during development).
- Store: round-trip/list/delete/rename, legacy conversion + lossy-conversion refusals, invalid YAML / non-mapping / schema-rejected / path-escape / offline paths.
- Editor: load-into-form, edit→dirty→save writes the expected YAML, revert, unsaved-changes prompt (monkeypatched `QMessageBox`), validation-error path, completers from a fake provider (plus failure degradation), Enter-guard, opens clean with no configs.
- Dialog teardown is deterministic (flush posted events while widgets are alive, then `deleteLater` + flush) so no queued polish/signal event can outlive its C++ widget — this addresses the offscreen segfault class seen in parallel editor runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)