### PR TITLE
GEECS-Console: ShotControlEditor (M5)

### DIFF
--- a/GEECS-Console/geecs_console/app/ui/shot_control_editor.ui
+++ b/GEECS-Console/geecs_console/app/ui/shot_control_editor.ui
@@ -1,0 +1,307 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>ShotControlEditorRoot</class>
+ <widget class="QWidget" name="ShotControlEditorRoot">
+  <property name="windowTitle">
+   <string>Trigger profiles (shot control)</string>
+  </property>
+  <layout class="QHBoxLayout" name="sce_root_layout">
+   <property name="leftMargin">
+    <number>10</number>
+   </property>
+   <property name="topMargin">
+    <number>10</number>
+   </property>
+   <property name="rightMargin">
+    <number>10</number>
+   </property>
+   <property name="bottomMargin">
+    <number>10</number>
+   </property>
+   <property name="spacing">
+    <number>10</number>
+   </property>
+   <!-- Left column: the profile list + file operations -->
+   <item>
+    <widget class="QGroupBox" name="sce_profiles_group">
+     <property name="title">
+      <string>PROFILES</string>
+     </property>
+     <layout class="QVBoxLayout" name="sce_profiles_layout">
+      <property name="spacing">
+       <number>8</number>
+      </property>
+      <item>
+       <widget class="QListWidget" name="sce_profile_list"/>
+      </item>
+      <item>
+       <layout class="QGridLayout" name="sce_profile_buttons_layout">
+        <item row="0" column="0">
+         <widget class="QPushButton" name="sce_new_button">
+          <property name="text">
+           <string>New…</string>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="1">
+         <widget class="QPushButton" name="sce_duplicate_button">
+          <property name="text">
+           <string>Duplicate…</string>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="0">
+         <widget class="QPushButton" name="sce_rename_button">
+          <property name="text">
+           <string>Rename…</string>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="1">
+         <widget class="QPushButton" name="sce_delete_button">
+          <property name="text">
+           <string>Delete</string>
+          </property>
+          <property name="toolTip">
+           <string>Delete the selected trigger profile file</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <!-- Right column: the profile document -->
+   <item>
+    <widget class="QGroupBox" name="sce_document_group">
+     <property name="title">
+      <string>PROFILE</string>
+     </property>
+     <layout class="QVBoxLayout" name="sce_document_layout">
+      <property name="spacing">
+       <number>8</number>
+      </property>
+      <item>
+       <layout class="QHBoxLayout" name="sce_header_layout">
+        <item>
+         <widget class="QLabel" name="sce_profile_name_label">
+          <property name="text">
+           <string>(no profile selected)</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <spacer name="sce_header_spacer">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>20</width>
+            <height>10</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+        <item>
+         <widget class="QLabel" name="sce_legacy_label">
+          <property name="text">
+           <string/>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item>
+       <layout class="QHBoxLayout" name="sce_variant_layout">
+        <item>
+         <widget class="QLabel" name="sce_variant_label">
+          <property name="text">
+           <string>Variant</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QComboBox" name="sce_variant_combo">
+          <property name="minimumWidth">
+           <number>160</number>
+          </property>
+          <property name="toolTip">
+           <string>Which layer the table edits: the base profile, or one variant's overlay writes</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QPushButton" name="sce_add_variant_button">
+          <property name="text">
+           <string>Add variant…</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QPushButton" name="sce_remove_variant_button">
+          <property name="text">
+           <string>Remove variant</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <spacer name="sce_variant_spacer">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>10</width>
+            <height>10</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+       </layout>
+      </item>
+      <item>
+       <layout class="QHBoxLayout" name="sce_description_layout">
+        <item>
+         <widget class="QLabel" name="sce_description_label">
+          <property name="text">
+           <string>Description</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLineEdit" name="sce_description_edit">
+          <property name="toolTip">
+           <string>Note on the selected layer: the profile when (base) is shown, otherwise the variant</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item>
+       <widget class="QTreeWidget" name="sce_states_tree">
+        <property name="toolTip">
+         <string>Per-state device writes, sent top to bottom — order matters within a state</string>
+        </property>
+        <property name="rootIsDecorated">
+         <bool>true</bool>
+        </property>
+        <column>
+         <property name="text">
+          <string>State / device</string>
+         </property>
+        </column>
+        <column>
+         <property name="text">
+          <string>Variable</string>
+         </property>
+        </column>
+        <column>
+         <property name="text">
+          <string>Value</string>
+         </property>
+        </column>
+       </widget>
+      </item>
+      <item>
+       <layout class="QHBoxLayout" name="sce_write_buttons_layout">
+        <item>
+         <widget class="QPushButton" name="sce_add_write_button">
+          <property name="text">
+           <string>Add write</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QPushButton" name="sce_remove_write_button">
+          <property name="text">
+           <string>Remove write</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QPushButton" name="sce_move_up_button">
+          <property name="text">
+           <string>Move up</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QPushButton" name="sce_move_down_button">
+          <property name="text">
+           <string>Move down</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <spacer name="sce_write_buttons_spacer">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>10</width>
+            <height>10</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+       </layout>
+      </item>
+      <item>
+       <widget class="QLabel" name="sce_validation_label">
+        <property name="text">
+         <string/>
+        </property>
+        <property name="wordWrap">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <layout class="QHBoxLayout" name="sce_footer_layout">
+        <item>
+         <widget class="QLabel" name="sce_dirty_label">
+          <property name="text">
+           <string/>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <spacer name="sce_footer_spacer">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>10</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+        <item>
+         <widget class="QPushButton" name="sce_revert_button">
+          <property name="text">
+           <string>Revert</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QPushButton" name="sce_save_button">
+          <property name="text">
+           <string>Save</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+     </layout>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/GEECS-Console/geecs_console/editors/shot_control_editor.py
+++ b/GEECS-Console/geecs_console/editors/shot_control_editor.py
@@ -1,0 +1,1127 @@
+"""The trigger-profile (shot control) editor — the M5 editor dialog.
+
+Edits the versioned :class:`geecs_schemas.TriggerProfile` documents in the
+per-experiment ``shot_control_configurations/`` folder through
+:class:`~geecs_console.services.trigger_profile_store.TriggerProfileStore`.
+Trigger profiles gate real hardware at scan time, so correctness of the
+saved YAML outranks features here: the working document is a plain
+``model_dump(mode="json")`` dict, every edit re-validates it against the
+real schema, and Save refuses anything pydantic rejects — the error is
+shown inline, never raised at the operator.
+
+Layout: a profile list (New / Duplicate / Rename / Delete) on the left; the
+document on the right — a variant selector (the table edits the base
+profile or one variant's overlay), a per-layer description, and the
+state × (device, variable, value) write tree with Add/Remove/Move up/Move
+down (order matters within a transition: writes are sent top to bottom).
+Dirty tracking with Save/Revert and an unsaved-changes prompt on profile
+switch and close.
+
+Offline-first: with no configs repo the list is empty and the dialog still
+opens.  Device/variable cells get QCompleter suggestions from an injectable
+:class:`~geecs_console.services.device_completions.CompletionsProvider` —
+its one blocking ``device_variables()`` call runs on a short-lived daemon
+thread (the package's no-QThread rule) with the result marshaled back
+through a queued signal, so a slow or unreachable DB never blocks the GUI.
+Enter never accepts the dialog — it commits the active cell edit at most.
+"""
+
+from __future__ import annotations
+
+import copy
+import logging
+import threading
+from pathlib import Path
+from typing import Optional
+
+from PySide6.QtCore import QFile, Qt, Signal, Slot
+from PySide6.QtGui import QKeyEvent
+from PySide6.QtUiTools import QUiLoader
+from PySide6.QtWidgets import (
+    QAbstractItemView,
+    QComboBox,
+    QCompleter,
+    QDialog,
+    QInputDialog,
+    QLabel,
+    QLineEdit,
+    QListWidget,
+    QMessageBox,
+    QPushButton,
+    QStyledItemDelegate,
+    QTreeWidget,
+    QTreeWidgetItem,
+    QVBoxLayout,
+    QWidget,
+)
+from pydantic import ValidationError
+
+from geecs_console.services.device_completions import (
+    CompletionsProvider,
+    EmptyCompletions,
+)
+from geecs_console.services.trigger_profile_store import (
+    TriggerProfileStore,
+    TriggerProfileStoreError,
+)
+from geecs_schemas import TriggerProfile, TriggerState
+
+logger = logging.getLogger(__name__)
+
+_UI_PATH = Path(__file__).parent.parent / "app" / "ui" / "shot_control_editor.ui"
+
+#: The variant combo's entry for editing the profile's base states.
+BASE_LAYER = "(base)"
+
+#: Semantic colors matching the main window's palette (style.qss header).
+_COLOR_RED = "#c4453a"
+_COLOR_AMBER = "#d9a21b"
+
+#: Tree roles: which state a top-level item represents.
+_STATE_ROLE = Qt.ItemDataRole.UserRole
+
+
+def _format_validation_error(exc: ValidationError) -> str:
+    """Render a pydantic error compactly for the inline validation label.
+
+    Parameters
+    ----------
+    exc : ValidationError
+        The schema rejection to summarize.
+
+    Returns
+    -------
+    str
+        Up to three ``location: message`` lines plus an overflow count.
+    """
+    errors = exc.errors()
+    lines = [
+        f"{'.'.join(str(part) for part in error['loc']) or 'profile'}: {error['msg']}"
+        for error in errors[:3]
+    ]
+    if len(errors) > 3:
+        lines.append(f"… and {len(errors) - 3} more")
+    return "; ".join(lines)
+
+
+class _WriteCellDelegate(QStyledItemDelegate):
+    """Line-edit cells for write rows, with device/variable completion.
+
+    The completer is rebuilt each time a cell editor opens, so suggestions
+    that arrive asynchronously (the real provider fetches on a daemon
+    thread) appear on the next edit without any signal plumbing.
+
+    Parameters
+    ----------
+    editor : ShotControlEditor
+        The owning dialog — source of the experiment name and the
+        completions provider.
+    """
+
+    def __init__(self, editor: "ShotControlEditor") -> None:
+        super().__init__(editor)
+        self._editor = editor
+
+    def createEditor(self, parent, option, index):  # noqa: N802 — Qt override
+        """Create the cell's line edit, wiring a completer for columns 0/1.
+
+        Parameters
+        ----------
+        parent : QWidget
+            The editor's parent (the tree viewport).
+        option : QStyleOptionViewItem
+            Qt's style options (unused beyond the base call).
+        index : QModelIndex
+            The cell being edited; column selects the completion source.
+
+        Returns
+        -------
+        QWidget
+            A ``QLineEdit`` (completer-armed for device/variable columns).
+        """
+        line_edit = QLineEdit(parent)
+        words: list[str] = []
+        device_vars = self._editor.device_vars
+        if index.column() == 0:
+            words = sorted(device_vars)
+        elif index.column() == 1:
+            device = str(index.siblingAtColumn(0).data() or "").strip()
+            if device:
+                words = list(device_vars.get(device, []))
+        if words:
+            completer = QCompleter(words, line_edit)
+            completer.setCaseSensitivity(Qt.CaseSensitivity.CaseInsensitive)
+            completer.setFilterMode(Qt.MatchFlag.MatchContains)
+            line_edit.setCompleter(completer)
+        return line_edit
+
+
+class ShotControlEditor(QDialog):
+    """Modeless editor dialog for one experiment's trigger profiles.
+
+    Parameters
+    ----------
+    parent : QWidget, optional
+        The owning window (the console main window in production).
+    experiment : str, optional
+        Experiment whose ``shot_control_configurations/`` folder to edit;
+        empty opens the dialog with no profiles (offline default).
+    store : TriggerProfileStore, optional
+        Persistence seam; tests inject one rooted at a tmp dir, default
+        reads/writes the configs repo.
+    completions : CompletionsProvider, optional
+        Device/variable cell suggestions; defaults to
+        :class:`~geecs_console.services.device_completions.EmptyCompletions`.
+        The provider's one blocking ``device_variables()`` call runs on a
+        daemon thread, never the GUI thread.
+    """
+
+    #: One ``{device: [variable, ...]}`` mapping (emitted from the fetch
+    #: daemon thread; delivered queued to :meth:`_apply_completions`).
+    completions_ready = Signal(object)
+
+    def __init__(
+        self,
+        parent: Optional[QWidget] = None,
+        experiment: str = "",
+        store: Optional[TriggerProfileStore] = None,
+        completions: Optional[CompletionsProvider] = None,
+    ) -> None:
+        super().__init__(parent)
+        self._experiment = experiment
+        self._store = store if store is not None else TriggerProfileStore(experiment)
+        self._completions = (
+            completions if completions is not None else EmptyCompletions()
+        )
+        #: The fetched completion word lists (empty until the fetch lands).
+        self._device_vars: dict[str, list[str]] = {}
+        #: True once the (async) completions fetch has been delivered on the
+        #: GUI thread — tests wait on this instead of sleeping.
+        self.completions_applied = False
+        #: Guards the one-shot signal disconnect in :meth:`closeEvent`.
+        self._completions_disconnected = False
+
+        #: The working document: a TriggerProfile ``model_dump(mode="json")``
+        #: dict, kept current on every edit.  ``None`` = no profile loaded.
+        self._doc: Optional[dict] = None
+        #: The last loaded/saved document — dirty means ``_doc != _snapshot``.
+        self._snapshot: Optional[dict] = None
+        #: The profile (file stem) the document belongs to.
+        self._current_name: str = ""
+        #: The layer the tree edits: ``BASE_LAYER`` or a variant name.
+        self._current_layer: str = BASE_LAYER
+        #: True while code (not the operator) is populating widgets.
+        self._loading = False
+
+        self._load_ui()
+        self._bind_widgets()
+        self._wire_signals()
+        self.setWindowTitle(f"Trigger profiles — {experiment or 'no experiment'}")
+        # Force queued: the fetch emits from a daemon thread, and a direct
+        # delivery would touch state on the wrong thread.
+        self.completions_ready.connect(
+            self._apply_completions, Qt.ConnectionType.QueuedConnection
+        )
+        self._start_completions_fetch()
+        self._refresh_profile_list()
+        self._show_document(None)
+
+    # ------------------------------------------------------------------
+    # Construction
+    # ------------------------------------------------------------------
+
+    def _load_ui(self) -> None:
+        """Load the hand-authored .ui into the dialog's layout."""
+        loader = QUiLoader()
+        ui_file = QFile(str(_UI_PATH))
+        ui_file.open(QFile.OpenModeFlag.ReadOnly)
+        try:
+            self._ui: QWidget = loader.load(ui_file, self)
+        finally:
+            ui_file.close()
+        if self._ui is None:
+            raise RuntimeError(f"Failed to load {_UI_PATH}: {loader.errorString()}")
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.addWidget(self._ui)
+        self.resize(920, 560)
+
+    def _child(self, cls: type, name: str):
+        """Return the named child widget, failing loudly when missing."""
+        widget = self._ui.findChild(cls, name)
+        if widget is None:
+            raise LookupError(f"{name!r} ({cls.__name__}) not found in {_UI_PATH}")
+        return widget
+
+    def _bind_widgets(self) -> None:
+        """Resolve every wired widget from the loaded .ui once."""
+        self.profile_list: QListWidget = self._child(QListWidget, "sce_profile_list")
+        self.new_button: QPushButton = self._child(QPushButton, "sce_new_button")
+        self.duplicate_button: QPushButton = self._child(
+            QPushButton, "sce_duplicate_button"
+        )
+        self.rename_button: QPushButton = self._child(QPushButton, "sce_rename_button")
+        self.delete_button: QPushButton = self._child(QPushButton, "sce_delete_button")
+        self.profile_name_label: QLabel = self._child(QLabel, "sce_profile_name_label")
+        self.legacy_label: QLabel = self._child(QLabel, "sce_legacy_label")
+        self.variant_combo: QComboBox = self._child(QComboBox, "sce_variant_combo")
+        self.add_variant_button: QPushButton = self._child(
+            QPushButton, "sce_add_variant_button"
+        )
+        self.remove_variant_button: QPushButton = self._child(
+            QPushButton, "sce_remove_variant_button"
+        )
+        self.description_edit: QLineEdit = self._child(
+            QLineEdit, "sce_description_edit"
+        )
+        self.states_tree: QTreeWidget = self._child(QTreeWidget, "sce_states_tree")
+        self.add_write_button: QPushButton = self._child(
+            QPushButton, "sce_add_write_button"
+        )
+        self.remove_write_button: QPushButton = self._child(
+            QPushButton, "sce_remove_write_button"
+        )
+        self.move_up_button: QPushButton = self._child(
+            QPushButton, "sce_move_up_button"
+        )
+        self.move_down_button: QPushButton = self._child(
+            QPushButton, "sce_move_down_button"
+        )
+        self.validation_label: QLabel = self._child(QLabel, "sce_validation_label")
+        self.dirty_label: QLabel = self._child(QLabel, "sce_dirty_label")
+        self.revert_button: QPushButton = self._child(QPushButton, "sce_revert_button")
+        self.save_button: QPushButton = self._child(QPushButton, "sce_save_button")
+
+        # Enter must never accept the dialog: no default/auto-default
+        # buttons anywhere (keyPressEvent below swallows the rest).
+        for button in self._ui.findChildren(QPushButton):
+            button.setAutoDefault(False)
+            button.setDefault(False)
+
+        # Keep a Python reference for the delegate's full lifetime —
+        # setItemDelegate does not take ownership, and a GC'd wrapper with
+        # queued events is a segfault.
+        self._delegate = _WriteCellDelegate(self)
+        self.states_tree.setItemDelegate(self._delegate)
+        self.states_tree.setEditTriggers(
+            QAbstractItemView.EditTrigger.DoubleClicked
+            | QAbstractItemView.EditTrigger.SelectedClicked
+            | QAbstractItemView.EditTrigger.EditKeyPressed
+        )
+        self.states_tree.setColumnWidth(0, 280)
+        self.states_tree.setColumnWidth(1, 220)
+
+    def _wire_signals(self) -> None:
+        """Connect widget signals to the handlers."""
+        self.profile_list.currentItemChanged.connect(self._on_profile_selected)
+        self.new_button.clicked.connect(self._on_new)
+        self.duplicate_button.clicked.connect(self._on_duplicate)
+        self.rename_button.clicked.connect(self._on_rename)
+        self.delete_button.clicked.connect(self._on_delete)
+        self.variant_combo.currentTextChanged.connect(self._on_layer_changed)
+        self.add_variant_button.clicked.connect(self._on_add_variant)
+        self.remove_variant_button.clicked.connect(self._on_remove_variant)
+        self.description_edit.textChanged.connect(self._on_description_edited)
+        self.states_tree.itemChanged.connect(self._on_tree_edited)
+        self.add_write_button.clicked.connect(self._on_add_write)
+        self.remove_write_button.clicked.connect(self._on_remove_write)
+        self.move_up_button.clicked.connect(lambda: self._on_move_write(-1))
+        self.move_down_button.clicked.connect(lambda: self._on_move_write(+1))
+        self.revert_button.clicked.connect(self._on_revert)
+        self.save_button.clicked.connect(self._on_save)
+
+    # ------------------------------------------------------------------
+    # Small injectable surfaces (tests monkeypatch these)
+    # ------------------------------------------------------------------
+
+    @property
+    def experiment(self) -> str:
+        """The experiment whose profiles this dialog edits."""
+        return self._experiment
+
+    @property
+    def device_vars(self) -> dict[str, list[str]]:
+        """The fetched ``{device: [variable, ...]}`` completion word lists."""
+        return self._device_vars
+
+    def _start_completions_fetch(self) -> None:
+        """Fetch completions on a short-lived daemon thread (queued delivery)."""
+        provider = self._completions
+
+        def fetch() -> None:
+            """Run the provider's one blocking call off the GUI thread."""
+            try:
+                mapping = provider.device_variables()
+            except Exception as exc:  # noqa: BLE001 — providers should not raise
+                logger.info("completions fetch failed: %s", exc)
+                mapping = {}
+            self.completions_ready.emit(mapping)
+
+        threading.Thread(
+            target=fetch, name="sce-completions-fetch", daemon=True
+        ).start()
+
+    @Slot(object)
+    def _apply_completions(self, mapping: object) -> None:
+        """Store the fetched word lists (GUI-thread slot, delivered queued).
+
+        Cell editors read :attr:`device_vars` when they open, so suggestions
+        that land after the dialog is up appear on the next edit — no
+        completer replumbing needed.
+
+        Parameters
+        ----------
+        mapping : dict
+            The provider result delivered by the queued signal.
+        """
+        self.completions_applied = True
+        if not isinstance(mapping, dict):
+            return
+        self._device_vars = {
+            str(device): [str(variable) for variable in variables]
+            for device, variables in mapping.items()
+        }
+
+    def is_dirty(self) -> bool:
+        """Whether the working document differs from the loaded snapshot.
+
+        Returns
+        -------
+        bool
+            ``True`` when there are unsaved edits.
+        """
+        return self._doc is not None and self._doc != self._snapshot
+
+    def _prompt_text(self, title: str, label: str, default: str = "") -> str:
+        """Ask the operator for one line of text ("" = cancelled).
+
+        Parameters
+        ----------
+        title : str
+            Dialog title.
+        label : str
+            Prompt label.
+        default : str, optional
+            Pre-filled text.
+
+        Returns
+        -------
+        str
+            The stripped answer, or "" when cancelled/empty.
+        """
+        text, accepted = QInputDialog.getText(self, title, label, text=default)
+        return text.strip() if accepted else ""
+
+    def _confirm(self, title: str, text: str) -> bool:
+        """Ask a yes/no question (used for deletes).
+
+        Parameters
+        ----------
+        title : str
+            Dialog title.
+        text : str
+            The question.
+
+        Returns
+        -------
+        bool
+            ``True`` on Yes.
+        """
+        answer = QMessageBox.question(
+            self,
+            title,
+            text,
+            QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
+            QMessageBox.StandardButton.No,
+        )
+        return answer == QMessageBox.StandardButton.Yes
+
+    def _prompt_unsaved(self) -> str:
+        """Ask what to do with unsaved changes.
+
+        Returns
+        -------
+        str
+            ``"save"``, ``"discard"``, or ``"cancel"``.
+        """
+        box = QMessageBox(self)
+        box.setIcon(QMessageBox.Icon.Warning)
+        box.setWindowTitle("Unsaved changes")
+        box.setText(f"Trigger profile {self._current_name!r} has unsaved changes.")
+        save = box.addButton("Save", QMessageBox.ButtonRole.AcceptRole)
+        discard = box.addButton("Discard", QMessageBox.ButtonRole.DestructiveRole)
+        box.addButton("Cancel", QMessageBox.ButtonRole.RejectRole)
+        box.setDefaultButton(save)
+        box.exec()
+        clicked = box.clickedButton()
+        if clicked is save:
+            return "save"
+        if clicked is discard:
+            return "discard"
+        return "cancel"
+
+    def _resolve_unsaved(self) -> bool:
+        """Settle unsaved edits before leaving the current profile.
+
+        Returns
+        -------
+        bool
+            ``True`` when it is safe to proceed (nothing dirty, saved, or
+            discarded); ``False`` on cancel or a failed save.
+        """
+        if not self.is_dirty():
+            return True
+        choice = self._prompt_unsaved()
+        if choice == "cancel":
+            return False
+        if choice == "save":
+            return self._save_current()
+        return True  # discard
+
+    # ------------------------------------------------------------------
+    # Document handling (the working dict IS model_dump(mode="json"))
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _normalize(doc: dict) -> dict:
+        """Drop empty state lists (a state with no writes is "not defined").
+
+        Keeps dirty tracking honest: the tree omits empty states when it
+        rebuilds its layer, so the loaded document must not carry them
+        either.  Semantically identical per the schema's ``defines_state``.
+
+        Parameters
+        ----------
+        doc : dict
+            A ``model_dump(mode="json")`` document (modified in place).
+
+        Returns
+        -------
+        dict
+            The same document, with empty state lists removed from the base
+            profile and every variant.
+        """
+        doc["states"] = {
+            state: writes for state, writes in doc.get("states", {}).items() if writes
+        }
+        for variant in doc.get("variants", {}).values():
+            variant["states"] = {
+                state: writes
+                for state, writes in variant.get("states", {}).items()
+                if writes
+            }
+        return doc
+
+    def _layer_states(self) -> Optional[dict]:
+        """Return the states dict of the layer the tree currently edits."""
+        if self._doc is None:
+            return None
+        if self._current_layer == BASE_LAYER:
+            return self._doc["states"]
+        variant = self._doc["variants"].get(self._current_layer)
+        return None if variant is None else variant["states"]
+
+    def _set_layer_states(self, states: dict) -> None:
+        """Replace the current layer's states dict with *states*."""
+        if self._doc is None:
+            return
+        if self._current_layer == BASE_LAYER:
+            self._doc["states"] = states
+        elif self._current_layer in self._doc["variants"]:
+            self._doc["variants"][self._current_layer]["states"] = states
+
+    def _show_document(self, doc: Optional[dict]) -> None:
+        """Render *doc* (or the empty no-selection state) into the widgets.
+
+        Parameters
+        ----------
+        doc : dict or None
+            The working document; ``None`` clears and disables the editor.
+        """
+        self._doc = doc
+        self._current_layer = BASE_LAYER
+        self._loading = True
+        try:
+            enabled = doc is not None
+            for widget in (
+                self.variant_combo,
+                self.add_variant_button,
+                self.remove_variant_button,
+                self.description_edit,
+                self.states_tree,
+                self.add_write_button,
+                self.remove_write_button,
+                self.move_up_button,
+                self.move_down_button,
+            ):
+                widget.setEnabled(enabled)
+            self._populate_variant_combo()
+            self._populate_tree()
+            self._refresh_description()
+            if doc is None:
+                self.profile_name_label.setText("(no profile selected)")
+                self.legacy_label.setText("")
+                self.validation_label.setText("")
+            else:
+                self.profile_name_label.setText(
+                    f"<b>{doc.get('name', self._current_name)}</b>"
+                )
+        finally:
+            self._loading = False
+        self._refresh_validation()
+
+    def _populate_variant_combo(self) -> None:
+        """Fill the layer selector: (base) plus the document's variants."""
+        self.variant_combo.blockSignals(True)
+        self.variant_combo.clear()
+        if self._doc is not None:
+            self.variant_combo.addItem(BASE_LAYER)
+            self.variant_combo.addItems(sorted(self._doc.get("variants", {})))
+            self.variant_combo.setCurrentText(self._current_layer)
+        self.variant_combo.blockSignals(False)
+        self.remove_variant_button.setEnabled(
+            self._doc is not None and self._current_layer != BASE_LAYER
+        )
+
+    def _populate_tree(self) -> None:
+        """Rebuild the state tree from the current layer's states dict."""
+        self.states_tree.blockSignals(True)
+        self.states_tree.clear()
+        states = self._layer_states()
+        if states is not None:
+            for state in TriggerState:
+                state_item = QTreeWidgetItem(self.states_tree)
+                state_item.setText(0, state.value)
+                state_item.setData(0, _STATE_ROLE, state.value)
+                state_item.setFlags(
+                    Qt.ItemFlag.ItemIsEnabled | Qt.ItemFlag.ItemIsSelectable
+                )
+                state_item.setFirstColumnSpanned(True)
+                for write in states.get(state.value, []):
+                    self._make_write_item(state_item, write)
+                state_item.setExpanded(True)
+        self.states_tree.blockSignals(False)
+
+    @staticmethod
+    def _make_write_item(parent: QTreeWidgetItem, write: dict) -> QTreeWidgetItem:
+        """Append one editable write row under *parent*.
+
+        Parameters
+        ----------
+        parent : QTreeWidgetItem
+            The state item to append to.
+        write : dict
+            ``{"device": ..., "variable": ..., "value": ...}``.
+
+        Returns
+        -------
+        QTreeWidgetItem
+            The created row.
+        """
+        item = QTreeWidgetItem(parent)
+        item.setText(0, str(write.get("device", "")))
+        item.setText(1, str(write.get("variable", "")))
+        item.setText(2, str(write.get("value", "")))
+        item.setFlags(
+            Qt.ItemFlag.ItemIsEnabled
+            | Qt.ItemFlag.ItemIsSelectable
+            | Qt.ItemFlag.ItemIsEditable
+        )
+        return item
+
+    def _rebuild_layer_from_tree(self) -> None:
+        """Read the tree back into the current layer's states dict."""
+        states: dict[str, list[dict]] = {}
+        for row in range(self.states_tree.topLevelItemCount()):
+            state_item = self.states_tree.topLevelItem(row)
+            state = str(state_item.data(0, _STATE_ROLE))
+            writes = [
+                {
+                    "device": state_item.child(child).text(0).strip(),
+                    "variable": state_item.child(child).text(1).strip(),
+                    "value": state_item.child(child).text(2),
+                }
+                for child in range(state_item.childCount())
+            ]
+            if writes:
+                states[state] = writes
+        self._set_layer_states(states)
+
+    def _refresh_description(self) -> None:
+        """Bind the description edit to the current layer's description."""
+        self.description_edit.blockSignals(True)
+        if self._doc is None:
+            self.description_edit.setText("")
+        elif self._current_layer == BASE_LAYER:
+            self.description_edit.setText(self._doc.get("description", ""))
+        else:
+            variant = self._doc["variants"].get(self._current_layer, {})
+            self.description_edit.setText(variant.get("description", ""))
+        self.description_edit.blockSignals(False)
+
+    def _validated_profile(self) -> Optional[TriggerProfile]:
+        """Validate the working document, rendering any rejection inline.
+
+        Returns
+        -------
+        TriggerProfile or None
+            The validated model, or ``None`` (with the validation label set)
+            when the document is empty or the schema rejects it.
+        """
+        if self._doc is None:
+            return None
+        try:
+            profile = TriggerProfile.model_validate(self._doc)
+        except ValidationError as exc:
+            self.validation_label.setText(
+                f'<span style="color:{_COLOR_RED};">'
+                f"{_format_validation_error(exc)}</span>"
+            )
+            return None
+        self.validation_label.setText("")
+        return profile
+
+    def _refresh_validation(self) -> None:
+        """Re-validate the document; gate Save/Revert and the dirty marker."""
+        profile = self._validated_profile()
+        dirty = self.is_dirty()
+        self.dirty_label.setText("● unsaved changes" if dirty else "")
+        self.save_button.setEnabled(dirty and profile is not None)
+        self.revert_button.setEnabled(dirty)
+
+    def _report_store_error(self, exc: TriggerProfileStoreError) -> None:
+        """Show a store failure inline (never a crash).
+
+        Parameters
+        ----------
+        exc : TriggerProfileStoreError
+            The failed operation's message.
+        """
+        self.validation_label.setText(f'<span style="color:{_COLOR_RED};">{exc}</span>')
+        logger.warning("trigger-profile store: %s", exc)
+
+    # ------------------------------------------------------------------
+    # Profile list handling
+    # ------------------------------------------------------------------
+
+    def _refresh_profile_list(self, select: str = "") -> None:
+        """Repopulate the profile list from the store (offline ⇒ empty).
+
+        Parameters
+        ----------
+        select : str, optional
+            Name to select after repopulating (no selection when absent).
+        """
+        self.profile_list.blockSignals(True)
+        self.profile_list.clear()
+        self.profile_list.addItems(self._store.list_names())
+        if select:
+            matches = self.profile_list.findItems(select, Qt.MatchFlag.MatchExactly)
+            if matches:
+                self.profile_list.setCurrentItem(matches[0])
+        self.profile_list.blockSignals(False)
+        if select:
+            self._load_profile(select)
+
+    def _on_profile_selected(self, current, previous) -> None:
+        """Load the newly selected profile, honoring unsaved changes."""
+        if self._loading:
+            return
+        name = current.text() if current is not None else ""
+        if name == self._current_name:
+            return
+        if not self._resolve_unsaved():
+            # Cancelled: put the selection back without re-firing.
+            self.profile_list.blockSignals(True)
+            self.profile_list.setCurrentItem(previous)
+            self.profile_list.blockSignals(False)
+            return
+        self._load_profile(name)
+
+    def _load_profile(self, name: str) -> None:
+        """Load *name* from disk into the editor (inline error on failure).
+
+        Parameters
+        ----------
+        name : str
+            The profile (file stem) to load; "" clears the editor.
+        """
+        self._current_name = name
+        if not name:
+            self._snapshot = None
+            self._show_document(None)
+            return
+        try:
+            profile = self._store.load(name)
+            legacy = self._store.is_legacy(name)
+        except TriggerProfileStoreError as exc:
+            self._snapshot = None
+            self._show_document(None)
+            self.profile_name_label.setText(f"<b>{name}</b>")
+            self._report_store_error(exc)
+            return
+        doc = self._normalize(profile.model_dump(mode="json"))
+        self._snapshot = copy.deepcopy(doc)
+        self._show_document(doc)
+        self.legacy_label.setText(
+            f'<span style="color:{_COLOR_AMBER};">legacy file — '
+            "Save migrates it to the versioned schema</span>"
+            if legacy
+            else ""
+        )
+
+    def _selected_name(self) -> str:
+        """Return the profile list's current name ("" when none)."""
+        item = self.profile_list.currentItem()
+        return item.text() if item is not None else ""
+
+    def _on_new(self) -> None:
+        """Create (and immediately save) an empty profile."""
+        if not self._resolve_unsaved():
+            return
+        name = self._prompt_text("New trigger profile", "Profile name:")
+        if not name:
+            return
+        if self._store.exists(name):
+            self._report_store_error(
+                TriggerProfileStoreError(f"Trigger profile {name!r} already exists.")
+            )
+            return
+        try:
+            self._store.save(name, TriggerProfile(name=name))
+        except TriggerProfileStoreError as exc:
+            self._report_store_error(exc)
+            return
+        self._refresh_profile_list(select=name)
+
+    def _on_duplicate(self) -> None:
+        """Copy the selected profile's file under a new name."""
+        source = self._selected_name()
+        if not source:
+            return
+        if not self._resolve_unsaved():
+            return
+        name = self._prompt_text(
+            "Duplicate trigger profile", "New profile name:", default=f"{source}-copy"
+        )
+        if not name:
+            return
+        if self._store.exists(name):
+            self._report_store_error(
+                TriggerProfileStoreError(f"Trigger profile {name!r} already exists.")
+            )
+            return
+        try:
+            profile = self._store.load(source)
+            self._store.save(name, profile.model_copy(update={"name": name}))
+        except TriggerProfileStoreError as exc:
+            self._report_store_error(exc)
+            return
+        self._refresh_profile_list(select=name)
+
+    def _on_rename(self) -> None:
+        """Rename the selected profile (file stem + stored name field)."""
+        source = self._selected_name()
+        if not source:
+            return
+        if not self._resolve_unsaved():
+            return
+        name = self._prompt_text(
+            "Rename trigger profile", "New profile name:", default=source
+        )
+        if not name or name == source:
+            return
+        try:
+            self._store.rename(source, name)
+        except TriggerProfileStoreError as exc:
+            self._report_store_error(exc)
+            return
+        self._refresh_profile_list(select=name)
+
+    def _on_delete(self) -> None:
+        """Delete the selected profile file after confirmation."""
+        name = self._selected_name()
+        if not name:
+            return
+        if not self._confirm(
+            "Delete trigger profile",
+            f"Delete trigger profile {name!r}? The YAML file is removed "
+            "from the configs repo.",
+        ):
+            return
+        try:
+            self._store.delete(name)
+        except TriggerProfileStoreError as exc:
+            self._report_store_error(exc)
+            return
+        self._current_name = ""
+        self._snapshot = None
+        self._show_document(None)
+        self._refresh_profile_list()
+
+    # ------------------------------------------------------------------
+    # Layer (base/variant) handling
+    # ------------------------------------------------------------------
+
+    def _on_layer_changed(self, layer: str) -> None:
+        """Point the tree and description at the newly selected layer."""
+        if self._loading or self._doc is None or not layer:
+            return
+        self._current_layer = layer
+        self._loading = True
+        try:
+            self._populate_tree()
+            self._refresh_description()
+        finally:
+            self._loading = False
+        self.remove_variant_button.setEnabled(layer != BASE_LAYER)
+
+    def _on_add_variant(self) -> None:
+        """Add an empty variant and switch the tree to it."""
+        if self._doc is None:
+            return
+        name = self._prompt_text("Add variant", "Variant name:")
+        if not name:
+            return
+        if name == BASE_LAYER or name in self._doc["variants"]:
+            self._report_store_error(
+                TriggerProfileStoreError(f"Variant {name!r} is taken.")
+            )
+            return
+        self._doc["variants"][name] = {"states": {}, "description": ""}
+        self._current_layer = name
+        self._loading = True
+        try:
+            self._populate_variant_combo()
+            self._populate_tree()
+            self._refresh_description()
+        finally:
+            self._loading = False
+        self._refresh_validation()
+
+    def _on_remove_variant(self) -> None:
+        """Remove the selected variant (with confirmation) — Save persists."""
+        if self._doc is None or self._current_layer == BASE_LAYER:
+            return
+        name = self._current_layer
+        if not self._confirm(
+            "Remove variant", f"Remove variant {name!r} from this profile?"
+        ):
+            return
+        self._doc["variants"].pop(name, None)
+        self._current_layer = BASE_LAYER
+        self._loading = True
+        try:
+            self._populate_variant_combo()
+            self._populate_tree()
+            self._refresh_description()
+        finally:
+            self._loading = False
+        self._refresh_validation()
+
+    def _on_description_edited(self, text: str) -> None:
+        """Write the description edit into the current layer."""
+        if self._loading or self._doc is None:
+            return
+        if self._current_layer == BASE_LAYER:
+            self._doc["description"] = text
+        elif self._current_layer in self._doc["variants"]:
+            self._doc["variants"][self._current_layer]["description"] = text
+        self._refresh_validation()
+
+    # ------------------------------------------------------------------
+    # Write-row handling
+    # ------------------------------------------------------------------
+
+    def _on_tree_edited(self, item: QTreeWidgetItem, column: int) -> None:
+        """Fold a cell edit back into the document and re-validate."""
+        if self._loading or self._doc is None:
+            return
+        self._rebuild_layer_from_tree()
+        self._refresh_validation()
+
+    def _target_state_item(self) -> Optional[QTreeWidgetItem]:
+        """The state item Add-write appends to (selection or its parent)."""
+        item = self.states_tree.currentItem()
+        if item is None:
+            return None
+        parent = item.parent()
+        return item if parent is None else parent
+
+    def _on_add_write(self) -> None:
+        """Append an empty write row to the selected state and edit it."""
+        if self._doc is None:
+            return
+        state_item = self._target_state_item()
+        if state_item is None:
+            self.validation_label.setText(
+                f'<span style="color:{_COLOR_AMBER};">Select a state '
+                "(or one of its writes) to add a write to.</span>"
+            )
+            return
+        self.states_tree.blockSignals(True)
+        row = self._make_write_item(
+            state_item, {"device": "", "variable": "", "value": ""}
+        )
+        state_item.setExpanded(True)
+        self.states_tree.blockSignals(False)
+        self._rebuild_layer_from_tree()
+        self._refresh_validation()
+        self.states_tree.setCurrentItem(row)
+        if self.states_tree.isVisible():
+            # Drop the operator straight into the device cell.  Never on a
+            # hidden tree: an open cell editor on an unshown dialog leaves
+            # queued events that break programmatic teardown.
+            self.states_tree.editItem(row, 0)
+
+    def _on_remove_write(self) -> None:
+        """Remove the selected write row."""
+        if self._doc is None:
+            return
+        item = self.states_tree.currentItem()
+        if item is None or item.parent() is None:
+            return
+        item.parent().removeChild(item)
+        self._rebuild_layer_from_tree()
+        self._refresh_validation()
+
+    def _on_move_write(self, delta: int) -> None:
+        """Move the selected write up or down within its state.
+
+        Order matters: a state's writes are sent top to bottom at scan time.
+
+        Parameters
+        ----------
+        delta : int
+            ``-1`` for up, ``+1`` for down.
+        """
+        if self._doc is None:
+            return
+        item = self.states_tree.currentItem()
+        if item is None:
+            return
+        parent = item.parent()
+        if parent is None:
+            return
+        row = parent.indexOfChild(item)
+        target = row + delta
+        if target < 0 or target >= parent.childCount():
+            return
+        self.states_tree.blockSignals(True)
+        parent.takeChild(row)
+        parent.insertChild(target, item)
+        self.states_tree.blockSignals(False)
+        self.states_tree.setCurrentItem(item)
+        self._rebuild_layer_from_tree()
+        self._refresh_validation()
+
+    # ------------------------------------------------------------------
+    # Save / Revert / close
+    # ------------------------------------------------------------------
+
+    def _save_current(self) -> bool:
+        """Validate and persist the working document.
+
+        Returns
+        -------
+        bool
+            ``True`` on success; ``False`` with the error shown inline when
+            the schema rejects the document or the store cannot write.
+        """
+        profile = self._validated_profile()
+        if profile is None or not self._current_name:
+            return False
+        try:
+            self._store.save(self._current_name, profile)
+        except TriggerProfileStoreError as exc:
+            self._report_store_error(exc)
+            return False
+        # Snapshot the normalized dump so dirty tracking restarts clean.
+        doc = self._normalize(profile.model_dump(mode="json"))
+        self._doc = doc
+        self._snapshot = copy.deepcopy(doc)
+        self.legacy_label.setText("")
+        self._refresh_validation()
+        return True
+
+    def _on_save(self) -> None:
+        """Save button: persist the working document."""
+        self._save_current()
+
+    def _on_revert(self) -> None:
+        """Throw away unsaved edits and reload the profile from disk."""
+        if self._current_name:
+            self._load_profile(self._current_name)
+
+    def keyPressEvent(self, event: QKeyEvent) -> None:  # noqa: N802 — Qt override
+        """Swallow Return/Enter so it never accepts (closes) the dialog."""
+        if event.key() in (Qt.Key.Key_Return, Qt.Key.Key_Enter):
+            event.accept()
+            return
+        super().keyPressEvent(event)
+
+    def closeEvent(self, event) -> None:  # noqa: N802 — Qt override
+        """Prompt for unsaved changes before closing.
+
+        Only a *visible* dialog prompts — there is an operator to ask.  A
+        programmatic close of a hidden dialog (test teardown, app shutdown)
+        must never block on a modal nobody can answer.
+        """
+        if self.isVisible() and not self._resolve_unsaved():
+            event.ignore()
+            return
+        # A still-running completions fetch must not queue an event onto a
+        # dialog being torn down.  Once only: closeEvent can run twice
+        # (explicit close + owner teardown) and a second disconnect warns.
+        if not self._completions_disconnected:
+            self._completions_disconnected = True
+            try:
+                self.completions_ready.disconnect(self._apply_completions)
+            except (RuntimeError, TypeError):
+                pass
+        super().closeEvent(event)
+
+
+def open_shot_control_editor(
+    parent: Optional[QWidget],
+    experiment: str,
+    configs_base: str | Path | None = None,
+    completions: Optional[CompletionsProvider] = None,
+) -> QDialog:
+    """Open the trigger-profile editor (the Editors-menu entry point).
+
+    Opens offline with zero configs: a missing configs repo just lists no
+    profiles.  The default completions provider fetches device/variable
+    names from ``GeecsDb`` (one query, on a daemon thread — never blocking
+    the GUI, degrading to no suggestions offline).
+
+    Parameters
+    ----------
+    parent : QWidget or None
+        The owning window.
+    experiment : str
+        Experiment whose ``shot_control_configurations/`` folder to edit.
+    configs_base : str or Path, optional
+        Override for the experiments root (defaults to the configs repo
+        resolved lazily, exactly like the preset store).
+    completions : CompletionsProvider, optional
+        Device/variable cell suggestions; defaults to the DB-backed
+        provider for a named experiment and to no completions otherwise.
+
+    Returns
+    -------
+    QDialog
+        The shown (modeless) editor dialog.
+    """
+    if completions is None:
+        from geecs_console.services.device_completions import GeecsDbCompletions
+
+        completions = (
+            GeecsDbCompletions(experiment) if experiment else EmptyCompletions()
+        )
+    store = TriggerProfileStore(experiment, experiments_root=configs_base)
+    dialog = ShotControlEditor(
+        parent, experiment=experiment, store=store, completions=completions
+    )
+    dialog.show()
+    return dialog

--- a/GEECS-Console/geecs_console/services/trigger_profile_store.py
+++ b/GEECS-Console/geecs_console/services/trigger_profile_store.py
@@ -1,0 +1,430 @@
+"""Trigger-profile persistence over the per-experiment shot-control dir.
+
+A trigger profile GATES real hardware (the DG645 that fires the machine
+trigger, the gas jet it drives) at scan time, so the load/save round-trip
+must be lossless: :class:`TriggerProfileStore` keeps one YAML file per
+profile (``<name>.yaml``, a plain ``model_dump(mode="json")`` document that
+round-trips through ``TriggerProfile.model_validate``) in the same folder
+``ConfigsRepoResolver`` reads::
+
+    scanner_configs/experiments/<Experiment>/shot_control_configurations/<name>.yaml
+
+Legacy files (the pre-schema single-device dialect, no ``schema_version``
+key) are loaded through :func:`geecs_schemas.convert.convert_shot_control` —
+exactly what the resolver does — so the existing corpus opens in the editor;
+saving such a profile migrates the file to the versioned schema.
+
+Offline-safety mirrors :class:`~geecs_console.services.presets.PresetStore`
+(the store pattern this module copies): listing degrades to empty with no
+configs root; ``load``/``save``/``delete``/``rename`` raise
+:class:`TriggerProfileStoreError` with a message fit for inline display.
+Creating the ``shot_control_configurations/`` directory with
+``mkdir(parents=True, exist_ok=True)`` is deliberate and fine — this is a
+config directory in the configs repo, not a ``scans/ScanNNN/`` data folder,
+so the repo's scan-folder creation invariant does not apply.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Optional
+
+import yaml
+from pydantic import ValidationError
+
+from geecs_console.services.configs import TRIGGER_FOLDER, _configs_base
+from geecs_schemas import TriggerProfile
+from geecs_schemas.convert import SchemaConversionError, convert_shot_control
+
+logger = logging.getLogger(__name__)
+
+
+class TriggerProfileStoreError(RuntimeError):
+    """A trigger-profile operation cannot be carried out (shown inline)."""
+
+
+class TriggerProfileStore:
+    """Load/save named trigger profiles for one experiment.
+
+    Parameters
+    ----------
+    experiment : str, optional
+        Experiment folder under ``scanner_configs/experiments``.  May be
+        empty at construction (before the operator picks one) — listing is
+        then empty and saving raises.
+    experiments_root : str or Path, optional
+        Override for the experiments root (tests point this at a tmp dir);
+        defaults to the production resolution
+        (:func:`geecs_bluesky.scanner_configs.scanner_configs_base`, resolved
+        lazily so the module stays import-safe offline).
+    """
+
+    def __init__(
+        self, experiment: str = "", experiments_root: str | Path | None = None
+    ) -> None:
+        self._experiment = experiment
+        self._experiments_root = (
+            Path(experiments_root) if experiments_root is not None else None
+        )
+
+    @property
+    def experiment(self) -> str:
+        """The experiment this store reads and writes trigger profiles for."""
+        return self._experiment
+
+    def set_experiment(self, experiment: str) -> None:
+        """Switch the store to *experiment*.
+
+        Parameters
+        ----------
+        experiment : str
+            The new experiment folder name ("" for none selected).
+        """
+        self._experiment = experiment
+
+    # ------------------------------------------------------------------
+    # Folder resolution
+    # ------------------------------------------------------------------
+
+    def _folder(self) -> Optional[Path]:
+        """Return the shot-control dir, or ``None`` offline/unselected."""
+        root = self._experiments_root
+        if root is None:
+            root = _configs_base()
+        if root is None or not self._experiment:
+            return None
+        return root / self._experiment / TRIGGER_FOLDER
+
+    def _folder_or_raise(self) -> Path:
+        """Return the shot-control dir, raising a clear error when unresolvable.
+
+        Returns
+        -------
+        Path
+            ``<experiments root>/<experiment>/shot_control_configurations``.
+
+        Raises
+        ------
+        TriggerProfileStoreError
+            When the configs repo is not found or no experiment is selected.
+        """
+        root = self._experiments_root
+        if root is None:
+            root = _configs_base()
+        if root is None:
+            raise TriggerProfileStoreError(
+                "Configs repo not found — set GEECS_SCANNER_CONFIG_DIR or "
+                "config.ini [Paths] scanner_config_root_path."
+            )
+        if not self._experiment:
+            raise TriggerProfileStoreError("No experiment selected.")
+        return root / self._experiment / TRIGGER_FOLDER
+
+    def _path(self, name: str) -> Path:
+        """Return the YAML path for profile *name*, validating the name.
+
+        Parameters
+        ----------
+        name : str
+            The profile name (the file stem — no path separators).
+
+        Returns
+        -------
+        Path
+            ``<shot-control dir>/<name>.yaml`` (an existing ``.yml`` twin is
+            preferred when the ``.yaml`` spelling is absent).
+
+        Raises
+        ------
+        TriggerProfileStoreError
+            On an empty name or one that would escape the shot-control dir.
+        """
+        cleaned = name.strip()
+        if not cleaned:
+            raise TriggerProfileStoreError("Profile name must not be empty.")
+        if any(sep in cleaned for sep in ("/", "\\")) or cleaned in (".", ".."):
+            raise TriggerProfileStoreError(
+                f"Profile name {name!r} must be a plain file name (no path separators)."
+            )
+        folder = self._folder_or_raise()
+        path = folder / f"{cleaned}.yaml"
+        if not path.exists():
+            twin = folder / f"{cleaned}.yml"
+            if twin.exists():
+                return twin
+        return path
+
+    def _read_document(self, name: str) -> tuple[dict, Path]:
+        """Read profile *name*'s raw YAML mapping (shared by load/is_legacy).
+
+        Parameters
+        ----------
+        name : str
+            The profile name (file stem).
+
+        Returns
+        -------
+        tuple of (dict, Path)
+            The parsed top-level mapping and the file it came from.
+
+        Raises
+        ------
+        TriggerProfileStoreError
+            Missing configs repo / experiment / file, unparsable YAML, or a
+            document that is not a mapping.
+        """
+        path = self._path(name)
+        if not path.exists():
+            raise TriggerProfileStoreError(
+                f"Trigger profile {name!r} not found ({path})."
+            )
+        try:
+            document = yaml.safe_load(path.read_text(encoding="utf-8"))
+        except yaml.YAMLError as exc:
+            raise TriggerProfileStoreError(
+                f"Trigger profile {name!r} is not valid YAML ({path}): {exc}"
+            ) from exc
+        if document is None:
+            document = {}
+        if not isinstance(document, dict):
+            raise TriggerProfileStoreError(
+                f"Trigger profile {name!r} ({path}) should be a YAML mapping, "
+                f"got {type(document).__name__}."
+            )
+        return document, path
+
+    # ------------------------------------------------------------------
+    # The store surface
+    # ------------------------------------------------------------------
+
+    def list_names(self) -> list[str]:
+        """List the saved profile names, sorted; never raises.
+
+        Returns
+        -------
+        list of str
+            YAML file stems in the shot-control dir — empty when the configs
+            repo, experiment folder, or shot-control dir is missing.
+        """
+        folder = self._folder()
+        if folder is None or not folder.is_dir():
+            return []
+        return sorted(
+            path.stem for path in folder.iterdir() if path.suffix in (".yaml", ".yml")
+        )
+
+    def exists(self, name: str) -> bool:
+        """Whether a profile file called *name* is on disk.
+
+        Parameters
+        ----------
+        name : str
+            The profile name (file stem).
+
+        Returns
+        -------
+        bool
+            ``True`` when either YAML spelling exists (``False`` offline).
+        """
+        try:
+            return self._path(name).exists()
+        except TriggerProfileStoreError:
+            return False
+
+    def is_legacy(self, name: str) -> bool:
+        """Whether profile *name* is a legacy (pre-schema) file on disk.
+
+        Parameters
+        ----------
+        name : str
+            The profile name (file stem).
+
+        Returns
+        -------
+        bool
+            ``True`` when the file carries no top-level ``schema_version`` —
+            saving it from the editor migrates it to the versioned schema.
+
+        Raises
+        ------
+        TriggerProfileStoreError
+            Missing configs repo / experiment / file, or unparsable YAML.
+        """
+        document, _ = self._read_document(name)
+        return "schema_version" not in document
+
+    def load(self, name: str) -> TriggerProfile:
+        """Load profile *name* as a validated :class:`TriggerProfile`.
+
+        New-schema files (top-level ``schema_version``) validate directly;
+        legacy shot-control files go through the same converter the resolver
+        uses, so the editor opens the existing corpus unchanged.
+
+        Parameters
+        ----------
+        name : str
+            The profile name (file stem).
+
+        Returns
+        -------
+        TriggerProfile
+            The schema-validated profile the file stores.
+
+        Raises
+        ------
+        TriggerProfileStoreError
+            Missing configs repo / experiment / file, unparsable YAML, a
+            document the schema rejects, or an empty/deviceless legacy file
+            — always with a message fit for inline display.
+        """
+        document, path = self._read_document(name)
+        if "schema_version" in document:
+            try:
+                return TriggerProfile.model_validate(document)
+            except ValidationError as exc:
+                raise TriggerProfileStoreError(
+                    f"Trigger profile {name!r} ({path}) is not a valid "
+                    f"TriggerProfile: {exc}"
+                ) from exc
+        try:
+            profile = convert_shot_control(document, name=name)
+        except (SchemaConversionError, ValidationError) as exc:
+            raise TriggerProfileStoreError(
+                f"Trigger profile {name!r} ({path}) could not be converted "
+                f"from the legacy shot-control format: {exc}"
+            ) from exc
+        if profile is None:
+            raise TriggerProfileStoreError(
+                f"Trigger profile {name!r} ({path}) is empty / names no "
+                "device — there is nothing to edit."
+            )
+        return profile
+
+    def save(self, name: str, profile: TriggerProfile) -> Path:
+        """Write *profile* as profile *name* (overwriting an existing one).
+
+        The document is a plain ``model_dump(mode="json")`` in declared field
+        order — every schema field (``schema_version``, ``name``, ``states``,
+        ``variants``, ``description``) is preserved, and loading it back
+        yields a model equal to *profile*.
+
+        Parameters
+        ----------
+        name : str
+            The profile name (file stem).
+        profile : TriggerProfile
+            The profile to persist.
+
+        Returns
+        -------
+        Path
+            The YAML file written.
+
+        Raises
+        ------
+        TriggerProfileStoreError
+            Missing configs repo, no experiment selected, a bad name, or an
+            OS-level write failure.
+        """
+        path = self._path(name)
+        # A config dir, not a scans/ScanNNN/ data folder — parents=True is
+        # explicitly fine here (the scan-folder invariant does not apply).
+        path.parent.mkdir(parents=True, exist_ok=True)
+        document = yaml.safe_dump(
+            profile.model_dump(mode="json"), sort_keys=False, allow_unicode=True
+        )
+        try:
+            path.write_text(document, encoding="utf-8")
+        except OSError as exc:
+            raise TriggerProfileStoreError(
+                f"Could not write trigger profile {name!r}: {exc}"
+            ) from exc
+        logger.info("saved trigger profile %r to %s", name, path)
+        return path
+
+    def delete(self, name: str) -> None:
+        """Delete profile *name*.
+
+        Parameters
+        ----------
+        name : str
+            The profile name (file stem).
+
+        Raises
+        ------
+        TriggerProfileStoreError
+            Missing configs repo / experiment, a bad name, a profile that
+            does not exist, or an OS-level delete failure.
+        """
+        path = self._path(name)
+        if not path.exists():
+            raise TriggerProfileStoreError(
+                f"Trigger profile {name!r} not found ({path})."
+            )
+        try:
+            path.unlink()
+        except OSError as exc:
+            raise TriggerProfileStoreError(
+                f"Could not delete trigger profile {name!r}: {exc}"
+            ) from exc
+        logger.info("deleted trigger profile %r (%s)", name, path)
+
+    def rename(self, old: str, new: str) -> Path:
+        """Rename profile *old* to *new*, refusing to overwrite.
+
+        A new-schema file also gets its stored ``name`` field updated (the
+        rest of the document is carried over verbatim — no model round-trip,
+        so nothing else in the file changes).  A legacy file has no name
+        field and is renamed as-is.
+
+        Parameters
+        ----------
+        old : str
+            The current profile name (file stem).
+        new : str
+            The new profile name (file stem).
+
+        Returns
+        -------
+        Path
+            The renamed YAML file.
+
+        Raises
+        ------
+        TriggerProfileStoreError
+            Missing configs repo / experiment, a bad name, a source that
+            does not exist, a target that already exists, or an OS-level
+            failure.
+        """
+        source = self._path(old)
+        if not source.exists():
+            raise TriggerProfileStoreError(
+                f"Trigger profile {old!r} not found ({source})."
+            )
+        target = self._folder_or_raise() / f"{new.strip()}.yaml"
+        # Validate the new name (empty / path separators) with _path, but
+        # target the .yaml spelling regardless of any .yml twin.
+        self._path(new)
+        if target.exists() or target.with_suffix(".yml").exists():
+            raise TriggerProfileStoreError(
+                f"Trigger profile {new!r} already exists — delete it first "
+                "or pick another name."
+            )
+        document, _ = self._read_document(old)
+        try:
+            if "schema_version" in document and "name" in document:
+                document["name"] = new.strip()
+                target.write_text(
+                    yaml.safe_dump(document, sort_keys=False, allow_unicode=True),
+                    encoding="utf-8",
+                )
+                source.unlink()
+            else:
+                source.rename(target)
+        except OSError as exc:
+            raise TriggerProfileStoreError(
+                f"Could not rename trigger profile {old!r} to {new!r}: {exc}"
+            ) from exc
+        logger.info("renamed trigger profile %r to %r (%s)", old, new, target)
+        return target

--- a/GEECS-Console/tests/test_shot_control_editor.py
+++ b/GEECS-Console/tests/test_shot_control_editor.py
@@ -1,0 +1,478 @@
+"""ShotControlEditor: hermetic GUI tests over a tmp-dir store and fakes.
+
+Every dialog is registered with ``qtbot.addWidget`` so pytest-qt owns the
+teardown — no test ends with a shown widget that Qt still has queued
+events for.
+"""
+
+import pytest
+from PySide6.QtCore import Qt
+from PySide6.QtWidgets import QLineEdit
+
+from geecs_console.editors.shot_control_editor import (
+    BASE_LAYER,
+    ShotControlEditor,
+    open_shot_control_editor,
+)
+from geecs_console.services.trigger_profile_store import TriggerProfileStore
+from geecs_schemas import TriggerProfile
+
+from test_trigger_profile_store import (
+    DG,
+    LEGACY_YAML,
+    TRIGGER_FOLDER,
+    representative_profile,
+)
+
+
+class FakeCompletions:
+    """Deterministic suggestions; records that the fetch ran."""
+
+    def __init__(self):
+        self.calls = 0
+
+    def device_variables(self):
+        self.calls += 1
+        return {
+            DG: ["Amplitude.Ch AB", "Trigger.Source"],
+            "U_GasJet": ["Pressure"],
+        }
+
+
+@pytest.fixture
+def store(tmp_path):
+    store = TriggerProfileStore("HTU", experiments_root=tmp_path)
+    store.save("HTU-Normal", representative_profile())
+    store.save(
+        "Minimal",
+        TriggerProfile(
+            name="Minimal",
+            states={"SCAN": [{"device": DG, "variable": "V", "value": "1"}]},
+        ),
+    )
+    return store
+
+
+@pytest.fixture
+def completions():
+    return FakeCompletions()
+
+
+@pytest.fixture
+def editor(qtbot, store, completions):
+    dialog = ShotControlEditor(experiment="HTU", store=store, completions=completions)
+    qtbot.addWidget(dialog)
+    return dialog
+
+
+def select_profile(editor, name):
+    matches = editor.profile_list.findItems(name, Qt.MatchFlag.MatchExactly)
+    assert matches, f"profile {name!r} not in the list"
+    editor.profile_list.setCurrentItem(matches[0])
+
+
+def state_item(editor, state):
+    for row in range(editor.states_tree.topLevelItemCount()):
+        item = editor.states_tree.topLevelItem(row)
+        if item.text(0) == state:
+            return item
+    raise AssertionError(f"no state row {state!r}")
+
+
+def write_rows(editor, state):
+    item = state_item(editor, state)
+    return [
+        (item.child(i).text(0), item.child(i).text(1), item.child(i).text(2))
+        for i in range(item.childCount())
+    ]
+
+
+class TestLoading:
+    def test_profile_list_is_populated_sorted(self, editor):
+        names = [
+            editor.profile_list.item(i).text()
+            for i in range(editor.profile_list.count())
+        ]
+        assert names == ["HTU-Normal", "Minimal"]
+
+    def test_completions_fetch_runs_once_and_is_applied(
+        self, qtbot, editor, completions
+    ):
+        qtbot.waitUntil(lambda: editor.completions_applied)
+        assert completions.calls == 1
+        assert sorted(editor.device_vars) == [DG, "U_GasJet"]
+
+    def test_selecting_a_profile_renders_its_writes_in_order(self, editor):
+        select_profile(editor, "HTU-Normal")
+        assert write_rows(editor, "SCAN") == [
+            (DG, "Amplitude.Ch AB", "4.0"),
+            (DG, "Trigger.Source", "External rising edges"),
+        ]
+        assert write_rows(editor, "SINGLESHOT") == [
+            (DG, "Trigger.ExecuteSingleShot", "on"),
+        ]
+
+    def test_all_five_states_are_shown(self, editor):
+        select_profile(editor, "Minimal")
+        states = [
+            editor.states_tree.topLevelItem(i).text(0)
+            for i in range(editor.states_tree.topLevelItemCount())
+        ]
+        assert states == ["OFF", "STANDBY", "SCAN", "SINGLESHOT", "ARMED"]
+
+    def test_variant_combo_lists_base_plus_variants(self, editor):
+        select_profile(editor, "HTU-Normal")
+        entries = [
+            editor.variant_combo.itemText(i)
+            for i in range(editor.variant_combo.count())
+        ]
+        assert entries == [BASE_LAYER, "laser_off"]
+
+    def test_loading_is_not_dirty(self, editor):
+        select_profile(editor, "HTU-Normal")
+        assert not editor.is_dirty()
+        assert not editor.save_button.isEnabled()
+
+    def test_invalid_file_shows_inline_error_not_a_crash(
+        self, qtbot, store, tmp_path, completions
+    ):
+        folder = tmp_path / "HTU" / TRIGGER_FOLDER
+        (folder / "broken.yaml").write_text("states: [unclosed")
+        dialog = ShotControlEditor(
+            experiment="HTU", store=store, completions=completions
+        )
+        qtbot.addWidget(dialog)
+        select_profile(dialog, "broken")
+        assert "not valid YAML" in dialog.validation_label.text()
+        assert not dialog.states_tree.isEnabled()
+
+    def test_offline_open_with_zero_configs(self, qtbot, tmp_path):
+        store = TriggerProfileStore("", experiments_root=tmp_path / "missing")
+        dialog = ShotControlEditor(experiment="", store=store)
+        qtbot.addWidget(dialog)
+        assert dialog.profile_list.count() == 0
+        assert not dialog.states_tree.isEnabled()
+
+
+class TestEditing:
+    def test_editing_a_value_marks_dirty_and_saves_the_model(self, editor, store):
+        select_profile(editor, "HTU-Normal")
+        state_item(editor, "SCAN").child(0).setText(2, "3.5")
+        assert editor.is_dirty()
+        assert editor.save_button.isEnabled()
+        editor.save_button.click()
+        assert not editor.is_dirty()
+        loaded = store.load("HTU-Normal")
+        assert loaded.writes_for("SCAN")[0].value == "3.5"
+        # Everything else survives the edit untouched.
+        expected = representative_profile()
+        assert loaded.variants == expected.variants
+        assert loaded.writes_for("ARMED") == expected.writes_for("ARMED")
+
+    def test_revert_restores_the_disk_state(self, editor, store):
+        select_profile(editor, "HTU-Normal")
+        state_item(editor, "SCAN").child(0).setText(2, "9.9")
+        assert editor.is_dirty()
+        editor.revert_button.click()
+        assert not editor.is_dirty()
+        assert write_rows(editor, "SCAN")[0][2] == "4.0"
+        assert store.load("HTU-Normal") == representative_profile()
+
+    def test_add_write_is_invalid_until_filled_then_saves(self, editor, store):
+        select_profile(editor, "Minimal")
+        editor.states_tree.setCurrentItem(state_item(editor, "STANDBY"))
+        editor.add_write_button.click()
+        assert editor.validation_label.text() != ""
+        assert not editor.save_button.isEnabled()
+        row = state_item(editor, "STANDBY").child(0)
+        row.setText(0, DG)
+        row.setText(1, "Amplitude.Ch AB")
+        row.setText(2, "0.5")
+        assert editor.validation_label.text() == ""
+        editor.save_button.click()
+        assert store.load("Minimal").writes_for("STANDBY")[0].value == "0.5"
+
+    def test_add_write_with_a_write_selected_targets_its_state(self, editor):
+        select_profile(editor, "HTU-Normal")
+        editor.states_tree.setCurrentItem(state_item(editor, "SCAN").child(1))
+        editor.add_write_button.click()
+        assert len(write_rows(editor, "SCAN")) == 3
+
+    def test_remove_write(self, editor, store):
+        select_profile(editor, "HTU-Normal")
+        editor.states_tree.setCurrentItem(state_item(editor, "SINGLESHOT").child(0))
+        editor.remove_write_button.click()
+        editor.save_button.click()
+        assert not store.load("HTU-Normal").defines_state("SINGLESHOT")
+
+    def test_move_write_down_changes_the_send_order(self, editor, store):
+        select_profile(editor, "HTU-Normal")
+        editor.states_tree.setCurrentItem(state_item(editor, "SCAN").child(0))
+        editor.move_down_button.click()
+        assert [row[1] for row in write_rows(editor, "SCAN")] == [
+            "Trigger.Source",
+            "Amplitude.Ch AB",
+        ]
+        editor.save_button.click()
+        assert [w.variable for w in store.load("HTU-Normal").writes_for("SCAN")] == [
+            "Trigger.Source",
+            "Amplitude.Ch AB",
+        ]
+
+    def test_move_write_up_at_the_top_is_a_no_op(self, editor):
+        select_profile(editor, "HTU-Normal")
+        editor.states_tree.setCurrentItem(state_item(editor, "SCAN").child(0))
+        editor.move_up_button.click()
+        assert write_rows(editor, "SCAN")[0][1] == "Amplitude.Ch AB"
+        assert not editor.is_dirty()
+
+    def test_duplicate_target_is_rejected_inline(self, editor):
+        select_profile(editor, "HTU-Normal")
+        row = state_item(editor, "SCAN").child(1)
+        row.setText(1, "Amplitude.Ch AB")  # same target as row 0
+        assert "more than once" in editor.validation_label.text()
+        assert not editor.save_button.isEnabled()
+
+    def test_base_description_edit_round_trips(self, editor, store):
+        select_profile(editor, "HTU-Normal")
+        editor.description_edit.setText("retimed 2026-07")
+        editor.save_button.click()
+        assert store.load("HTU-Normal").description == "retimed 2026-07"
+
+
+class TestVariants:
+    def test_variant_layer_shows_only_overlay_writes(self, editor):
+        select_profile(editor, "HTU-Normal")
+        editor.variant_combo.setCurrentText("laser_off")
+        assert write_rows(editor, "SCAN") == [
+            (DG, "Trigger.Source", "Single shot external rising edges"),
+        ]
+        assert write_rows(editor, "OFF") == []
+        assert editor.description_edit.text() == (
+            "Trigger internally while the laser is off."
+        )
+
+    def test_editing_a_variant_write_saves_into_the_variant(self, editor, store):
+        select_profile(editor, "HTU-Normal")
+        editor.variant_combo.setCurrentText("laser_off")
+        state_item(editor, "SCAN").child(0).setText(2, "Internal")
+        editor.save_button.click()
+        loaded = store.load("HTU-Normal")
+        assert loaded.variants["laser_off"].states["SCAN"][0].value == "Internal"
+        # The base states are untouched.
+        assert loaded.states == representative_profile().states
+
+    def test_add_variant(self, editor, store, monkeypatch):
+        select_profile(editor, "HTU-Normal")
+        monkeypatch.setattr(editor, "_prompt_text", lambda *a, **k: "no_gas")
+        editor.add_variant_button.click()
+        assert editor.variant_combo.currentText() == "no_gas"
+        assert editor.is_dirty()
+        editor.save_button.click()
+        assert "no_gas" in store.load("HTU-Normal").variants
+
+    def test_add_variant_rejects_taken_names(self, editor, monkeypatch):
+        select_profile(editor, "HTU-Normal")
+        monkeypatch.setattr(editor, "_prompt_text", lambda *a, **k: "laser_off")
+        editor.add_variant_button.click()
+        assert "taken" in editor.validation_label.text()
+
+    def test_remove_variant(self, editor, store, monkeypatch):
+        select_profile(editor, "HTU-Normal")
+        editor.variant_combo.setCurrentText("laser_off")
+        monkeypatch.setattr(editor, "_confirm", lambda *a, **k: True)
+        editor.remove_variant_button.click()
+        assert editor.variant_combo.currentText() == BASE_LAYER
+        editor.save_button.click()
+        assert store.load("HTU-Normal").variants == {}
+
+
+class TestProfileOperations:
+    def test_new_profile_is_saved_and_selected(self, editor, store, monkeypatch):
+        monkeypatch.setattr(editor, "_prompt_text", lambda *a, **k: "Fresh")
+        editor.new_button.click()
+        assert store.load("Fresh") == TriggerProfile(name="Fresh")
+        assert editor.profile_list.currentItem().text() == "Fresh"
+        assert "Fresh" in editor.profile_name_label.text()
+
+    def test_new_profile_refuses_existing_names(self, editor, store, monkeypatch):
+        monkeypatch.setattr(editor, "_prompt_text", lambda *a, **k: "Minimal")
+        editor.new_button.click()
+        assert "already exists" in editor.validation_label.text()
+
+    def test_duplicate_profile(self, editor, store, monkeypatch):
+        select_profile(editor, "HTU-Normal")
+        monkeypatch.setattr(editor, "_prompt_text", lambda *a, **k: "HTU-Copy")
+        editor.duplicate_button.click()
+        copied = store.load("HTU-Copy")
+        assert copied.name == "HTU-Copy"
+        assert copied.states == representative_profile().states
+        assert editor.profile_list.currentItem().text() == "HTU-Copy"
+
+    def test_rename_profile(self, editor, store, monkeypatch):
+        select_profile(editor, "Minimal")
+        monkeypatch.setattr(editor, "_prompt_text", lambda *a, **k: "Renamed")
+        editor.rename_button.click()
+        assert store.list_names() == ["HTU-Normal", "Renamed"]
+        assert store.load("Renamed").name == "Renamed"
+        assert editor.profile_list.currentItem().text() == "Renamed"
+
+    def test_delete_profile_after_confirmation(self, editor, store, monkeypatch):
+        select_profile(editor, "Minimal")
+        monkeypatch.setattr(editor, "_confirm", lambda *a, **k: True)
+        editor.delete_button.click()
+        assert store.list_names() == ["HTU-Normal"]
+        assert not editor.states_tree.isEnabled()
+
+    def test_delete_declined_changes_nothing(self, editor, store, monkeypatch):
+        select_profile(editor, "Minimal")
+        monkeypatch.setattr(editor, "_confirm", lambda *a, **k: False)
+        editor.delete_button.click()
+        assert store.list_names() == ["HTU-Normal", "Minimal"]
+
+
+class TestUnsavedChanges:
+    def make_dirty(self, editor):
+        select_profile(editor, "HTU-Normal")
+        state_item(editor, "SCAN").child(0).setText(2, "7.7")
+        assert editor.is_dirty()
+
+    def test_cancel_keeps_the_selection_and_the_edits(self, editor, store, monkeypatch):
+        self.make_dirty(editor)
+        monkeypatch.setattr(editor, "_prompt_unsaved", lambda: "cancel")
+        select_profile(editor, "Minimal")
+        assert editor.profile_list.currentItem().text() == "HTU-Normal"
+        assert editor.is_dirty()
+        assert store.load("HTU-Normal") == representative_profile()
+
+    def test_discard_switches_without_writing(self, editor, store, monkeypatch):
+        self.make_dirty(editor)
+        monkeypatch.setattr(editor, "_prompt_unsaved", lambda: "discard")
+        select_profile(editor, "Minimal")
+        assert editor.profile_list.currentItem().text() == "Minimal"
+        assert store.load("HTU-Normal") == representative_profile()
+
+    def test_save_choice_writes_then_switches(self, editor, store, monkeypatch):
+        self.make_dirty(editor)
+        monkeypatch.setattr(editor, "_prompt_unsaved", lambda: "save")
+        select_profile(editor, "Minimal")
+        assert editor.profile_list.currentItem().text() == "Minimal"
+        assert store.load("HTU-Normal").writes_for("SCAN")[0].value == "7.7"
+
+    def test_close_with_dirty_can_be_cancelled(self, qtbot, editor, monkeypatch):
+        self.make_dirty(editor)
+        monkeypatch.setattr(editor, "_prompt_unsaved", lambda: "cancel")
+        editor.show()
+        qtbot.waitExposed(editor)
+        assert not editor.close()
+        assert editor.isVisible()
+        monkeypatch.setattr(editor, "_prompt_unsaved", lambda: "discard")
+        assert editor.close()
+
+    def test_clean_close_never_prompts(self, qtbot, editor, monkeypatch):
+        select_profile(editor, "HTU-Normal")
+
+        def boom():
+            raise AssertionError("prompted with no unsaved changes")
+
+        monkeypatch.setattr(editor, "_prompt_unsaved", boom)
+        assert editor.close()
+
+
+class TestErgonomics:
+    def test_enter_does_not_accept_the_dialog(self, qtbot, editor):
+        editor.show()
+        qtbot.waitExposed(editor)
+        qtbot.keyClick(editor, Qt.Key.Key_Return)
+        qtbot.keyClick(editor, Qt.Key.Key_Enter)
+        assert editor.isVisible()
+        editor.close()
+
+    def test_no_button_is_a_default_button(self, editor):
+        from PySide6.QtWidgets import QPushButton
+
+        for button in editor.findChildren(QPushButton):
+            assert not button.isDefault()
+            assert not button.autoDefault()
+
+    def test_device_cell_editor_gets_device_completions(self, qtbot, editor):
+        qtbot.waitUntil(lambda: editor.completions_applied)
+        select_profile(editor, "HTU-Normal")
+        tree = editor.states_tree
+        row = state_item(editor, "SCAN").child(0)
+        index = tree.indexFromItem(row, 0)
+        cell = editor._delegate.createEditor(tree.viewport(), None, index)
+        assert isinstance(cell, QLineEdit)
+        model = cell.completer().model()
+        words = [model.index(i, 0).data() for i in range(model.rowCount())]
+        assert words == [DG, "U_GasJet"]
+
+    def test_variable_cell_editor_completes_for_the_rows_device(self, qtbot, editor):
+        qtbot.waitUntil(lambda: editor.completions_applied)
+        select_profile(editor, "HTU-Normal")
+        tree = editor.states_tree
+        row = state_item(editor, "SCAN").child(0)
+        index = tree.indexFromItem(row, 1)
+        cell = editor._delegate.createEditor(tree.viewport(), None, index)
+        model = cell.completer().model()
+        words = [model.index(i, 0).data() for i in range(model.rowCount())]
+        assert words == ["Amplitude.Ch AB", "Trigger.Source"]
+
+    def test_offline_default_provider_means_no_completer(self, qtbot, store):
+        dialog = ShotControlEditor(experiment="HTU", store=store)
+        qtbot.addWidget(dialog)
+        qtbot.waitUntil(lambda: dialog.completions_applied)
+        select_profile(dialog, "HTU-Normal")
+        tree = dialog.states_tree
+        row = state_item(dialog, "SCAN").child(0)
+        index = tree.indexFromItem(row, 0)
+        cell = dialog._delegate.createEditor(tree.viewport(), None, index)
+        assert cell.completer() is None
+
+
+class TestLegacyInEditor:
+    def test_legacy_profile_shows_the_migration_note(
+        self, qtbot, store, tmp_path, completions
+    ):
+        folder = tmp_path / "HTU" / TRIGGER_FOLDER
+        (folder / "OldStyle.yaml").write_text(LEGACY_YAML)
+        dialog = ShotControlEditor(
+            experiment="HTU", store=store, completions=completions
+        )
+        qtbot.addWidget(dialog)
+        select_profile(dialog, "OldStyle")
+        assert "legacy" in dialog.legacy_label.text()
+        assert write_rows(dialog, "SINGLESHOT") == [
+            (DG, "Trigger.ExecuteSingleShot", "on"),
+        ]
+        # Save migrates the file and drops the note.
+        state_item(dialog, "SCAN").child(0).setText(2, "4.5")
+        dialog.save_button.click()
+        assert dialog.legacy_label.text() == ""
+        assert not store.is_legacy("OldStyle")
+        assert store.load("OldStyle").writes_for("SCAN")[0].value == "4.5"
+
+
+class TestEntryPoint:
+    def test_open_shot_control_editor_offline(self, qtbot, tmp_path):
+        dialog = open_shot_control_editor(
+            None, "HTU", configs_base=tmp_path, completions=FakeCompletions()
+        )
+        qtbot.addWidget(dialog)
+        assert dialog.isVisible()
+        assert dialog.profile_list.count() == 0
+        dialog.close()
+
+    def test_open_shot_control_editor_lists_existing_profiles(
+        self, qtbot, store, tmp_path
+    ):
+        dialog = open_shot_control_editor(
+            None, "HTU", configs_base=tmp_path, completions=FakeCompletions()
+        )
+        qtbot.addWidget(dialog)
+        names = [
+            dialog.profile_list.item(i).text()
+            for i in range(dialog.profile_list.count())
+        ]
+        assert names == ["HTU-Normal", "Minimal"]
+        dialog.close()

--- a/GEECS-Console/tests/test_trigger_profile_store.py
+++ b/GEECS-Console/tests/test_trigger_profile_store.py
@@ -1,0 +1,329 @@
+"""TriggerProfileStore: lossless YAML round-trips against a tmp configs root.
+
+Trigger profiles gate real hardware at scan time, so the round-trip tests
+here are the important ones: save→load must reproduce the model exactly
+(pinned via pydantic model equality) and load→save with no edits must be
+byte-stable.
+"""
+
+import yaml
+import pytest
+
+from geecs_console.services.trigger_profile_store import (
+    TriggerProfileStore,
+    TriggerProfileStoreError,
+)
+from geecs_schemas import TriggerProfile, TriggerState
+
+TRIGGER_FOLDER = "shot_control_configurations"
+
+DG = "U_DG645_ShotControl"
+
+
+def representative_profile() -> TriggerProfile:
+    """The HTU shape: DG645 drives trigger + gas jet, one laser-off variant."""
+    return TriggerProfile(
+        name="HTU-Normal",
+        description="DG645 drives the machine trigger and gas jet",
+        states={
+            "OFF": [
+                {"device": DG, "variable": "Amplitude.Ch AB", "value": "0.5"},
+                {
+                    "device": DG,
+                    "variable": "Trigger.Source",
+                    "value": "Single shot external rising edges",
+                },
+            ],
+            "STANDBY": [
+                {"device": DG, "variable": "Amplitude.Ch AB", "value": "0.5"},
+                {
+                    "device": DG,
+                    "variable": "Trigger.Source",
+                    "value": "External rising edges",
+                },
+            ],
+            "SCAN": [
+                {"device": DG, "variable": "Amplitude.Ch AB", "value": "4.0"},
+                {
+                    "device": DG,
+                    "variable": "Trigger.Source",
+                    "value": "External rising edges",
+                },
+            ],
+            "SINGLESHOT": [
+                {"device": DG, "variable": "Trigger.ExecuteSingleShot", "value": "on"},
+            ],
+            "ARMED": [
+                {"device": DG, "variable": "Amplitude.Ch AB", "value": "4.0"},
+                {
+                    "device": DG,
+                    "variable": "Trigger.Source",
+                    "value": "Single shot external rising edges",
+                },
+            ],
+        },
+        variants={
+            "laser_off": {
+                "states": {
+                    "SCAN": [
+                        {
+                            "device": DG,
+                            "variable": "Trigger.Source",
+                            "value": "Single shot external rising edges",
+                        }
+                    ]
+                },
+                "description": "Trigger internally while the laser is off.",
+            }
+        },
+    )
+
+
+LEGACY_YAML = """\
+device: U_DG645_ShotControl
+variables:
+  Amplitude.Ch AB:
+    'OFF': '0.5'
+    SCAN: '4.0'
+    STANDBY: '0.5'
+  Trigger.ExecuteSingleShot:
+    SCAN: ''
+    SINGLESHOT: 'on'
+  Trigger.Source:
+    'OFF': Single shot external rising edges
+    SCAN: External rising edges
+    STANDBY: External rising edges
+"""
+
+
+@pytest.fixture
+def store(tmp_path):
+    return TriggerProfileStore("HTU", experiments_root=tmp_path)
+
+
+@pytest.fixture
+def folder(tmp_path):
+    path = tmp_path / "HTU" / TRIGGER_FOLDER
+    path.mkdir(parents=True)
+    return path
+
+
+class TestRoundTrip:
+    def test_save_load_round_trips_the_profile(self, store):
+        profile = representative_profile()
+        store.save("HTU-Normal", profile)
+        assert store.load("HTU-Normal") == profile
+
+    def test_round_trip_is_byte_stable(self, store):
+        path = store.save("HTU-Normal", representative_profile())
+        first = path.read_bytes()
+        store.save("HTU-Normal", store.load("HTU-Normal"))
+        assert path.read_bytes() == first
+
+    def test_every_schema_field_survives(self, store):
+        profile = representative_profile()
+        store.save("HTU-Normal", profile)
+        loaded = store.load("HTU-Normal")
+        assert loaded.schema_version == profile.schema_version
+        assert loaded.name == profile.name
+        assert loaded.description == profile.description
+        assert loaded.states == profile.states
+        assert loaded.variants == profile.variants
+
+    def test_off_state_survives_yaml_11_boolean_parsing(self, store):
+        # A bare OFF: key parses as boolean False in YAML 1.1 — the schema
+        # (and the dump's quoting) must keep it a state either way.
+        path = store.save("HTU-Normal", representative_profile())
+        raw = yaml.safe_load(path.read_text())
+        assert False not in raw["states"], "OFF key must be quoted in the dump"
+        assert TriggerState.OFF in store.load("HTU-Normal").states
+
+    def test_write_order_within_a_state_is_preserved(self, store):
+        profile = representative_profile()
+        store.save("HTU-Normal", profile)
+        loaded = store.load("HTU-Normal")
+        assert [w.variable for w in loaded.writes_for("SCAN")] == [
+            "Amplitude.Ch AB",
+            "Trigger.Source",
+        ]
+
+    def test_file_lands_in_the_shot_control_dir(self, store, tmp_path):
+        path = store.save("HTU-Normal", representative_profile())
+        assert path == tmp_path / "HTU" / TRIGGER_FOLDER / "HTU-Normal.yaml"
+        assert path.is_file()
+
+    def test_list_names_sorted(self, store):
+        for name in ("zeta", "alpha", "mid"):
+            store.save(name, representative_profile())
+        assert store.list_names() == ["alpha", "mid", "zeta"]
+
+    def test_overwrite_is_allowed(self, store):
+        profile = representative_profile()
+        store.save("p", profile)
+        store.save("p", profile.model_copy(update={"description": "v2"}))
+        assert store.load("p").description == "v2"
+        assert store.list_names() == ["p"]
+
+    def test_yml_twin_is_listed_and_loadable(self, store, tmp_path):
+        folder = tmp_path / "HTU" / TRIGGER_FOLDER
+        store.save("seed", representative_profile())
+        (folder / "seed.yaml").rename(folder / "twin.yml")
+        assert store.list_names() == ["twin"]
+        assert store.load("twin").name == "HTU-Normal"
+
+    def test_exists(self, store):
+        assert not store.exists("p")
+        store.save("p", representative_profile())
+        assert store.exists("p")
+
+    def test_set_experiment_switches_folders(self, store, tmp_path):
+        store.save("p", representative_profile())
+        store.set_experiment("Bella")
+        assert store.list_names() == []
+        store.save("bella-only", representative_profile())
+        assert (tmp_path / "Bella" / TRIGGER_FOLDER / "bella-only.yaml").is_file()
+
+
+class TestLegacyFiles:
+    def test_legacy_file_loads_via_the_converter(self, store, folder):
+        (folder / "HTU-Normal.yaml").write_text(LEGACY_YAML)
+        profile = store.load("HTU-Normal")
+        assert profile.name == "HTU-Normal"
+        assert profile.devices == [DG]
+        # The legacy empty-string no-op (SCAN on ExecuteSingleShot) is omitted.
+        assert [w.variable for w in profile.writes_for("SCAN")] == [
+            "Amplitude.Ch AB",
+            "Trigger.Source",
+        ]
+        assert [w.value for w in profile.writes_for("SINGLESHOT")] == ["on"]
+
+    def test_is_legacy(self, store, folder):
+        (folder / "old.yaml").write_text(LEGACY_YAML)
+        store.save("new", representative_profile())
+        assert store.is_legacy("old")
+        assert not store.is_legacy("new")
+
+    def test_saving_a_legacy_profile_migrates_it(self, store, folder):
+        (folder / "old.yaml").write_text(LEGACY_YAML)
+        loaded = store.load("old")
+        store.save("old", loaded)
+        assert not store.is_legacy("old")
+        assert store.load("old") == loaded
+
+    def test_empty_legacy_file_raises_clearly(self, store, folder):
+        (folder / "No Device.yaml").write_text("{}\n")
+        with pytest.raises(TriggerProfileStoreError, match="nothing to edit"):
+            store.load("No Device")
+
+    def test_unconvertible_legacy_file_raises_clearly(self, store, folder):
+        (folder / "odd.yaml").write_text(
+            "device: D\nvariables:\n  V:\n    NOT_A_STATE: '1'\n"
+        )
+        with pytest.raises(TriggerProfileStoreError, match="legacy"):
+            store.load("odd")
+
+
+class TestRename:
+    def test_rename_updates_file_and_stored_name(self, store, tmp_path):
+        store.save("old", representative_profile())
+        target = store.rename("old", "new")
+        assert target == tmp_path / "HTU" / TRIGGER_FOLDER / "new.yaml"
+        assert store.list_names() == ["new"]
+        assert store.load("new").name == "new"
+
+    def test_rename_carries_the_rest_of_the_document_verbatim(self, store):
+        profile = representative_profile()
+        store.save("old", profile)
+        store.rename("old", "new")
+        assert store.load("new") == profile.model_copy(update={"name": "new"})
+
+    def test_rename_legacy_file_moves_it_as_is(self, store, folder):
+        (folder / "old.yaml").write_text(LEGACY_YAML)
+        store.rename("old", "new")
+        assert store.is_legacy("new")
+        assert (folder / "new.yaml").read_text() == LEGACY_YAML
+
+    def test_rename_missing_source_raises(self, store):
+        with pytest.raises(TriggerProfileStoreError, match="'ghost' not found"):
+            store.rename("ghost", "new")
+
+    def test_rename_refuses_to_overwrite(self, store):
+        store.save("a", representative_profile())
+        store.save("b", representative_profile())
+        with pytest.raises(TriggerProfileStoreError, match="already exists"):
+            store.rename("a", "b")
+
+    @pytest.mark.parametrize("name", ["", "   ", "a/b", "a\\b", "..", "."])
+    def test_rename_bad_target_names_rejected(self, store, name):
+        store.save("a", representative_profile())
+        with pytest.raises(TriggerProfileStoreError, match="name"):
+            store.rename("a", name)
+
+
+class TestErrors:
+    def test_missing_dir_lists_empty(self, store):
+        assert store.list_names() == []
+
+    def test_load_missing_profile_raises_clearly(self, store):
+        with pytest.raises(TriggerProfileStoreError, match="'ghost' not found"):
+            store.load("ghost")
+
+    def test_delete_removes_the_profile(self, store):
+        store.save("p", representative_profile())
+        store.delete("p")
+        assert store.list_names() == []
+        with pytest.raises(TriggerProfileStoreError, match="not found"):
+            store.load("p")
+
+    def test_delete_missing_profile_raises_clearly(self, store):
+        with pytest.raises(TriggerProfileStoreError, match="'ghost' not found"):
+            store.delete("ghost")
+
+    def test_invalid_yaml_raises_clearly(self, store, folder):
+        (folder / "broken.yaml").write_text("states: [unclosed")
+        with pytest.raises(TriggerProfileStoreError, match="not valid YAML"):
+            store.load("broken")
+
+    def test_non_mapping_yaml_raises_clearly(self, store, folder):
+        (folder / "list.yaml").write_text("- just\n- a\n- list\n")
+        with pytest.raises(TriggerProfileStoreError, match="YAML mapping"):
+            store.load("list")
+
+    def test_schema_rejected_document_raises_clearly(self, store, folder):
+        (folder / "bad.yaml").write_text(
+            "schema_version: 1\nname: bad\nstates:\n  SCAN:\n"
+            "    - device: D\n      variable: V\n      value: ''\n"
+        )
+        with pytest.raises(TriggerProfileStoreError, match="not a valid"):
+            store.load("bad")
+
+    def test_duplicate_target_document_raises_clearly(self, store, folder):
+        (folder / "dup.yaml").write_text(
+            "schema_version: 1\nname: dup\nstates:\n  SCAN:\n"
+            "    - device: D\n      variable: V\n      value: '1'\n"
+            "    - device: D\n      variable: V\n      value: '2'\n"
+        )
+        with pytest.raises(TriggerProfileStoreError, match="more than once"):
+            store.load("dup")
+
+    def test_no_experiment_selected_save_raises(self, tmp_path):
+        store = TriggerProfileStore("", experiments_root=tmp_path)
+        with pytest.raises(TriggerProfileStoreError, match="No experiment selected"):
+            store.save("p", representative_profile())
+        assert store.list_names() == []
+
+    def test_missing_configs_repo_lists_empty_and_save_raises(self, monkeypatch):
+        # Offline: the lazy configs-root resolution finds nothing.
+        monkeypatch.setattr(
+            "geecs_console.services.trigger_profile_store._configs_base",
+            lambda: None,
+        )
+        store = TriggerProfileStore("HTU")
+        assert store.list_names() == []
+        with pytest.raises(TriggerProfileStoreError, match="Configs repo not found"):
+            store.save("p", representative_profile())
+
+    @pytest.mark.parametrize("name", ["", "   ", "a/b", "a\\b", "..", "."])
+    def test_bad_names_rejected(self, store, name):
+        with pytest.raises(TriggerProfileStoreError, match="name"):
+            store.save(name, representative_profile())


### PR DESCRIPTION
The M5 editor for trigger profiles (shot control): a modeless dialog editing the versioned `geecs_schemas.TriggerProfile` documents in the per-experiment `shot_control_configurations/` folder. Trigger profiles gate real hardware (DG645, gas jet) at scan time, so correctness of the saved YAML outranks features: everything rides the real schema, and the round-trip is lossless.

## Store — `services/trigger_profile_store.py`

- `TriggerProfileStore`: list/load/save/delete/rename over `scanner_configs/experiments/<Experiment>/shot_control_configurations/` (the same folder `ConfigsRepoResolver` reads), mirroring `PresetStore`'s pattern and error contract (`TriggerProfileStoreError`, offline → empty listings, path-escape-safe names, `.yml` twins).
- **Lossless round-trip**: `save` writes a plain `model_dump(mode="json")` document; save→load pins pydantic model equality and load→save with no edits is byte-stable (both pinned by tests). The `'OFF'` state key is quoted on dump and the schema's YAML-1.1 normalizer covers hand-edited files.
- **Legacy corpus**: files without `schema_version` load through `geecs_schemas.convert.convert_shot_control` — exactly what the resolver does — and migrate to the versioned schema on save. `is_legacy()` lets the editor surface the migration note.
- `rename` refuses to overwrite and also updates the stored `name` field of a new-schema file, carrying the rest of the document over verbatim (no model round-trip).

## Editor — `editors/shot_control_editor.py` + `app/ui/shot_control_editor.ui` (`sce_` prefix)

- Profile list with New / Duplicate / Rename / Delete.
- The document as a **state × (device, variable, value) write tree**: all five `TriggerState`s in enum order, editable write rows, Add/Remove/**Move up/Move down** (order matters — a state's writes are sent top to bottom).
- **Variants**: a layer selector edits the base states or one variant's overlay writes, with Add/Remove variant and a per-layer description edit.
- **Inline pydantic validation** on every edit (empty devices/values, duplicate `(device, variable)` targets per state, …): Save is gated on validity, errors render in the dialog, nothing crashes.
- Dirty tracking, Save/Revert, unsaved-changes prompt (Save/Discard/Cancel) on profile switch and close — visible dialogs only, so programmatic teardown never blocks on a modal nobody can answer.
- Device/variable cells get `QCompleter` suggestions from the shared `services/device_completions.py` provider (from #504): one blocking `device_variables()` call on a short-lived daemon thread, queued delivery, offline → no suggestions. Completers are rebuilt per cell-edit so late-arriving suggestions appear without replumbing.
- Enter never accepts the dialog (no default buttons + swallowed at the dialog); it commits the active cell edit at most.
- `open_shot_control_editor(parent, experiment, configs_base=None, completions=None) -> QDialog` is the entry point for the later Editors-menu integration PR; opens offline with zero configs.

## Tests

84 new (43 store + 41 editor), hermetic over `tmp_path` stores and fake completions — round-trip/byte-stability, legacy conversion + migration, rename/delete/invalid-YAML, editor load/edit/save/revert/dirty/prompt paths, write ordering, variant editing, completer wiring, offline open, Enter behavior. Full suite **349 passed, exit 0, across 5 consecutive runs** (includes the 265 preexisting tests after #504).

Adds files only — no changes to `main_window.py`, the main `.ui`, `pyproject.toml`, or `CHANGELOG.md` (version bump + menu wiring land in the integration PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)