### PR TITLE
GEECS-Console 0.6.0: Editors menu + M5 integration fixes

### DIFF
--- a/GEECS-Console/CHANGELOG.md
+++ b/GEECS-Console/CHANGELOG.md
@@ -4,6 +4,65 @@ All notable changes to GEECS-Console are documented here.  Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versioning is
 semantic.
 
+## [0.6.0] - 2026-07-12
+
+### Added
+
+- **The four config editors** (built on their own branches, #504–#507, and
+  now wired into the main window): the save-set editor
+  (`editors/save_set_editor.py`), the scan-variable editor
+  (`editors/scan_variable_editor.py`), the trigger-profile / shot-control
+  editor (`editors/shot_control_editor.py`), and the action-library editor
+  (`editors/action_library_editor.py`).  Each exposes an
+  `open_*_editor(parent, experiment, configs_base=None, completions=None)`
+  entry point that shows a non-modal dialog and returns it.
+- **Editors menu wired** (replaces the placeholder): *Save Elements…*,
+  *Scan Variables…*, *Shot Control…*, *Action Library…*, each opening the
+  corresponding editor for the currently selected experiment.  Actions are
+  disabled while no experiment is selected; every opened dialog is
+  referenced on the window (`_open_editors`, pruned when closed) so PySide6
+  garbage collection cannot tear down a live editor.
+- **R7 device-combo autocomplete** (user report: "dropdown shows nothing"):
+  the device panel combo now lists `device:variable` completions from
+  `GeecsDbCompletions` for the current experiment, fetched at startup and
+  on experiment change — one blocking provider call on a short-lived daemon
+  thread, marshaled back through a queued signal (never on the GUI thread;
+  offline degrades to an empty dropdown with free text still working).
+  The combo stays editable; typed text survives repopulation; a stale fetch
+  racing an experiment change is dropped by experiment tag.  The provider
+  factory is constructor-injectable for tests.
+- **R7 parse feedback** (user report: silent nothing): committing device
+  text that doesn't parse as `Device:Variable` now shows
+  "Device format: DeviceName:Variable Name" in the status bar instead of
+  doing nothing (both on selection commit and on a Set attempt).
+- **R6 idle scan-number display** (user report): on startup and experiment
+  change the console peeks — strictly read-only — at today's daily `scans/`
+  folder for the highest existing `ScanNNN` and shows "Scan NNN (previous)"
+  (or keeps "No scans today").  The peek is resolution + listdir only and
+  NEVER creates anything on that path (repo scan-folder invariant, pinned
+  by tree-untouched tests); it runs on a daemon thread because the data
+  root is typically a slow network mount.  New read-only helper
+  `ops_paths.highest_scan_number`.  A live scan number on display is never
+  clobbered by the idle peek.
+- **Version from source** (user report: status bar said 0.1.0 while running
+  0.5.0 code — `importlib.metadata` reflects the last `poetry install`, not
+  the source tree): the status-bar/Help version now prefers the source tree
+  — `geecs_console/version.py::console_version` reads the adjacent
+  `pyproject.toml` (`[tool.poetry] version`) when present (dev checkout),
+  falling back to `importlib.metadata.version`, then to "unknown".
+- `BackgroundResult` (`app/main_window.py`): a small reusable
+  daemon-thread → queued-signal worker (the `HealthPoller` shape,
+  generalized) used by the completions fetch and the idle scan-number
+  probe.  The daemon thread emits on the worker, never on the window —
+  emitting a window-owned signal from a daemon thread races window teardown
+  and segfaults under offscreen pytest.
+
+### Fixed
+
+- `httpx` request logging is capped at WARNING in `configure_logging` — the
+  Tiled health probe's 5 s poll was writing one INFO line per request to
+  the console log, forever.
+
 ## [0.5.0] - 2026-07-11
 
 ### Added

--- a/GEECS-Console/CLAUDE.md
+++ b/GEECS-Console/CLAUDE.md
@@ -31,8 +31,13 @@ are prefixed by region (`r3_radio_1d`, `r5_start_button`, …).
 - **R6 now panel** — state pill, progress bar, "Scan NNN" with 10 s expiry
   to "(previous)" (**live**: driven by `ScanLifecycleEvent.scan_number`
   through the adapter's `scan_number_known` signal), compact log tail.
-- **R7 device panel** — device:variable combo (editable free text),
-  readback label, set field + button.  **Backend live** (see Implemented
+  When idle (startup / experiment change) the label shows
+  "Scan NNN (previous)" from a **strictly read-only** peek at today's
+  daily `scans/` folder (see Implemented seams), or "No scans today".
+- **R7 device panel** — device:variable combo (editable, with
+  `device:variable` dropdown completions from `GeecsDbCompletions` — see
+  Implemented seams), readback label, set field + button.  **Backend
+  live** (see Implemented
   seams): gateway PVs — CA monitor on the readback, put to `:SP` riding
   GEECS's native blocking set — never `geecs_python_api`'s ScanDevice.
   Scalar-only at birth (composites arrive with the pseudo-variable
@@ -177,18 +182,79 @@ are prefixed by region (`r3_radio_1d`, `r5_start_button`, …).
   `RotatingFileHandler` at `~/.config/geecs_console/logs/console.log`
   (2 MB × 3 backups) beside the stderr handler.  Creating that log dir with
   `parents=True` is deliberate — a user config dir, not a scan folder.
+  `configure_logging` caps the `httpx` logger at WARNING — the Tiled
+  health probe otherwise logs one INFO line per 5 s poll, forever.
+- **The four config editors (Editors menu)** — all implemented (built on
+  their own branches, #504–#507; wired in 0.6.0):
+  `editors/save_set_editor.py::open_save_set_editor`,
+  `editors/scan_variable_editor.py::open_scan_variable_editor`,
+  `editors/shot_control_editor.py::open_shot_control_editor` (trigger
+  profiles), `editors/action_library_editor.py::open_action_library_editor`.
+  Each entry point takes `(parent, experiment, configs_base=None,
+  completions=None)`, shows a **non-modal** dialog (`show()`, not
+  `exec()`), and returns it.  The menu handlers call
+  `open_*_editor(self, experiment=<current combo text>)` and append the
+  returned dialog to `self._open_editors` (pruned when closed) — see the
+  PySide6 ownership hazards below.  Actions are disabled while no
+  experiment is selected.  Tests monkeypatch the `open_*` names on
+  `app.main_window`.
+- **R7 device:variable completions**: the device combo's dropdown lists
+  sorted `device:variable` strings from a `CompletionsProvider`
+  (`GeecsDbCompletions` in production, constructor-injectable
+  `completions_factory` in tests), fetched at startup and on experiment
+  change via a `BackgroundResult` worker (below).  The combo stays
+  editable; typed text survives repopulation; results tagged with a
+  no-longer-selected experiment are dropped.  An unparsable committed
+  selection shows "Device format: DeviceName:Variable Name" in the status
+  bar (both on commit and on a Set attempt) instead of a silent no-op.
+- **R6 idle scan number**: at startup and on experiment change a
+  `BackgroundResult` worker runs the injectable `scan_number_lookup`
+  (default: `ops_paths.todays_scan_folder` +
+  `ops_paths.highest_scan_number`) and the label shows
+  "Scan NNN (previous)" or "No scans today".  **Strictly read-only** —
+  resolution + `is_dir()`/`iterdir()` only, never creating anything on the
+  scans path (repo scan-folder invariant; pinned by tree-untouched tests
+  in `tests/test_ops_paths.py` and
+  `tests/test_main_window_editors_integration.py`).  A live scan number
+  (10 s expiry timer running) is never clobbered.  `tests/conftest.py`
+  patches the module-level default lookup (and the completions factory) so
+  hermetic tests never touch the real data root or DB.
+- **`BackgroundResult`** (`app/main_window.py`): the one blessed
+  daemon-thread → queued-signal worker for one-shot background calls (the
+  `HealthPoller` shape, generalized).  **The daemon thread must emit on
+  the worker QObject, never on the window**: emitting a window-owned
+  signal from a daemon thread races window teardown and segfaults under
+  offscreen pytest (observed directly when the idle scan probe emitted a
+  `MainWindow` signal).  `closeEvent` disconnects each worker's
+  `result_ready`.
+
+## Standing PySide6 ownership hazards (GC eats live C++ objects)
+
+Python wrappers PySide6 does not parent-track are garbage-collected, and
+shiboken tears down the underlying C++ object with them.  Two recurrences
+of the same bug class are load-bearing here; hold a Python reference on
+the window for anything in these families:
+
+- **Menus**: the `QMenu` returned by `menuBar().addMenu(...)` must be kept
+  (`self._menus`) or the menu and all its actions vanish.
+- **Non-modal dialogs**: a dialog shown with `show()` (all four editors)
+  must be kept (`self._open_editors`) or it closes/dies at the next GC.
+- **QCompleter** (inside the editors): a completer set on a line edit via
+  `setCompleter` is not owned by the widget — the editors keep their
+  completers (and their model) on `self`.  The same applies to any
+  `QValidator`, proxy model, or event filter created without a parent.
 
 ## Stubbed seams (intentional, wire later)
 
-- R7 device:variable autocomplete: the combo is editable free text (with a
-  placeholder) — `ConsoleConfigs` has no device/variable listing yet.  The
-  natural source is a `GeecsDb` enumeration (device → `get='yes'`
-  variables), populated the way the other combos are.
 - Optimization mode: radio exists, submission refused with a clear error
   until an `OptimizationSpec` editor exists.
 - `ConsoleConfigs._scan_variable_names` reaches into the resolver's private
   `_scan_variables_catalog()` — promote a public "list variable names"
   method on `ConfigsRepoResolver` when next touching geecs-bluesky.
+- **Remaining M5 item — config bootstrap/repair dialog**: deliberately
+  deferred.  When the configs repo (or an experiment's folder inside it)
+  is missing/broken, the console currently reports and degrades to empty
+  listings; a guided create/repair dialog is the outstanding piece of M5.
 
 ## Testing
 

--- a/GEECS-Console/geecs_console/app/main_window.py
+++ b/GEECS-Console/geecs_console/app/main_window.py
@@ -12,7 +12,7 @@ network.
 
 from __future__ import annotations
 
-import importlib.metadata
+import logging
 import os
 import random
 import threading
@@ -41,8 +41,18 @@ from PySide6.QtWidgets import (
 )
 from pydantic import ValidationError
 
+from geecs_console.editors.action_library_editor import open_action_library_editor
+from geecs_console.editors.save_set_editor import open_save_set_editor
+from geecs_console.editors.scan_variable_editor import open_scan_variable_editor
+from geecs_console.editors.shot_control_editor import open_shot_control_editor
 from geecs_console.events_adapter import ScanEventsAdapter
 from geecs_console.services import ops_paths
+from geecs_console.services.device_completions import (
+    CompletionsProvider,
+    EmptyCompletions,
+    GeecsDbCompletions,
+)
+from geecs_console.version import console_version
 from geecs_console.request_builder import (
     MAXIMUM_SCAN_SIZE,
     ConsoleFormError,
@@ -70,6 +80,8 @@ from geecs_console.services.health import (
     StubHealth,
 )
 from geecs_console.submission import Submitter, make_bluesky_submitter
+
+logger = logging.getLogger(__name__)
 
 _UI_PATH = Path(__file__).parent / "ui" / "main_window.ui"
 _QSS_PATH = Path(__file__).parent / "style.qss"
@@ -109,12 +121,31 @@ _STATE_DOT_COLORS = {
 }
 
 
-def _package_version() -> str:
-    """Return the installed geecs-console version, or a dev placeholder."""
-    try:
-        return importlib.metadata.version("geecs-console")
-    except importlib.metadata.PackageNotFoundError:
-        return "dev"
+def _default_completions_factory(experiment: str) -> CompletionsProvider:
+    """Build the production R7 completions provider for *experiment*."""
+    return GeecsDbCompletions(experiment)
+
+
+def _idle_scan_lookup(experiment: str) -> Optional[int]:
+    """Highest existing ``ScanNNN`` in today's daily folder — read-only.
+
+    The production R6 idle-scan lookup: resolves today's ``scans/`` path
+    via :func:`ops_paths.todays_scan_folder` and lists it with
+    :func:`ops_paths.highest_scan_number`.  Strictly read-only (repo
+    scan-folder invariant) and possibly slow (network data root), so the
+    window only ever calls it on a daemon thread.
+
+    Parameters
+    ----------
+    experiment : str
+        The selected experiment ("" falls back to the config default).
+
+    Returns
+    -------
+    int or None
+        The highest scan number, or ``None`` when unresolvable/absent.
+    """
+    return ops_paths.highest_scan_number(ops_paths.todays_scan_folder(experiment))
 
 
 def load_stylesheet() -> str:
@@ -182,6 +213,48 @@ class HealthPoller(QObject):
             self.report_ready.emit(report)
 
 
+class BackgroundResult(QObject):
+    """Runs one blocking callable on a daemon thread and reports its result.
+
+    The :class:`HealthPoller` shape, generalized: the worker lives on the
+    GUI thread, each :meth:`run_async` call spawns a short-lived daemon
+    thread, and the result comes back through the queued
+    :attr:`result_ready` signal.  Crucially the daemon thread emits on
+    *this worker*, never on the main window — emitting a window-owned
+    signal from a daemon thread races window teardown and segfaults under
+    offscreen pytest (observed with the idle scan-number probe).
+    """
+
+    result_ready = Signal(object)
+    """Carries the callable's return value, one emission per finished call."""
+
+    def run_async(self, func: Callable[[], object], name: str) -> None:
+        """Run *func* on a fresh daemon thread and emit its result.
+
+        Parameters
+        ----------
+        func : callable
+            Zero-argument blocking callable.  Exceptions are logged and
+            swallowed (no emission), so wrap the call when a failure result
+            should still be delivered.
+        name : str
+            The daemon thread's name (debugging).
+        """
+        threading.Thread(target=self._run, args=(func,), name=name, daemon=True).start()
+
+    def _run(self, func: Callable[[], object]) -> None:
+        """Call *func* (on the daemon thread) and emit the result."""
+        try:
+            result = func()
+        except Exception as exc:  # noqa: BLE001 — background work is best-effort
+            logger.info("background call failed: %s", exc)
+            return
+        try:
+            self.result_ready.emit(result)
+        except RuntimeError:
+            pass  # the worker was deleted while the call ran
+
+
 class MainWindow(QMainWindow):
     """The operator console main window (screen map regions R1-R7).
 
@@ -213,6 +286,15 @@ class MainWindow(QMainWindow):
     rng : random.Random, optional
         The source of randomness for the "Randomized beeps" option; tests
         inject a seeded instance.  Defaults to a fresh ``random.Random()``.
+    completions_factory : callable, optional
+        ``(experiment) -> CompletionsProvider`` for the R7 device combo's
+        ``device:variable`` items; tests inject a fake.  Defaults to the
+        DB-backed provider (daemon-thread fetch, empty offline).
+    scan_number_lookup : callable, optional
+        ``(experiment) -> int | None`` returning today's highest existing
+        scan number for the R6 idle display; tests inject a fake.  Defaults
+        to the read-only ``ops_paths`` lookup (daemon-thread call — the data
+        root may be a slow network mount).
     """
 
     #: One readback value from the device-panel backend (emitted from the CA
@@ -234,6 +316,8 @@ class MainWindow(QMainWindow):
         submitter: Optional[Submitter] = None,
         submitter_factory: Optional[Callable[..., Submitter]] = None,
         rng: Optional[random.Random] = None,
+        completions_factory: Optional[Callable[[str], CompletionsProvider]] = None,
+        scan_number_lookup: Optional[Callable[[str], Optional[int]]] = None,
     ) -> None:
         super().__init__()
         self._configs = configs if configs is not None else ConsoleConfigs(experiment)
@@ -257,6 +341,12 @@ class MainWindow(QMainWindow):
         self._shot_count_valid = False
         self._beep_rng = rng if rng is not None else random.Random()
         self._last_beep_shots = 0
+        self._completions_factory = completions_factory
+        self._scan_number_lookup = scan_number_lookup
+        #: Non-modal editor dialogs opened from the Editors menu.  PySide6
+        #: garbage-collects an unreferenced dialog wrapper and tears down the
+        #: C++ dialog with it, so every opened editor is kept here.
+        self._open_editors: list = []
 
         self._apply_stylesheet()
         self._load_ui()
@@ -281,6 +371,14 @@ class MainWindow(QMainWindow):
         self._set_state_pill("idle")
         self._on_mode_changed()
         self._refresh_device_set_enabled()
+        # Startup fetches for the selected experiment (no-ops when none):
+        # R7 device:variable completions and the R6 idle scan-number peek.
+        # Restoring the last experiment already fired the experiment-changed
+        # path (which starts both); these cover the explicit-experiment and
+        # no-experiment startups.  Stale results are dropped by experiment
+        # tag, so a duplicate fetch is harmless.
+        self._start_device_completions_fetch()
+        self._start_idle_scan_probe()
 
     # ------------------------------------------------------------------
     # Construction
@@ -413,11 +511,23 @@ class MainWindow(QMainWindow):
         github = ops.addAction("GEECS-Plugins on GitHub")
         github.triggered.connect(self._on_open_github)
 
-        for title in ("Actions", "Editors"):
-            menu = self.menuBar().addMenu(title)
-            self._menus.append(menu)
-            placeholder = menu.addAction("(not wired yet)")
-            placeholder.setEnabled(False)
+        actions_menu = self.menuBar().addMenu("Actions")
+        self._menus.append(actions_menu)
+        placeholder = actions_menu.addAction("(not wired yet)")
+        placeholder.setEnabled(False)
+
+        editors = self.menuBar().addMenu("Editors")
+        self._menus.append(editors)
+        self._editor_actions = []
+        for text, handler in (
+            ("Save Elements…", self._on_edit_save_sets),
+            ("Scan Variables…", self._on_edit_scan_variables),
+            ("Shot Control…", self._on_edit_shot_control),
+            ("Action Library…", self._on_edit_action_library),
+        ):
+            action = editors.addAction(text)
+            action.triggered.connect(handler)
+            self._editor_actions.append(action)
 
         prefs = self.menuBar().addMenu("Preferences")
         self._menus.append(prefs)
@@ -432,7 +542,7 @@ class MainWindow(QMainWindow):
 
         help_menu = self.menuBar().addMenu("Help")
         self._menus.append(help_menu)
-        about = help_menu.addAction(f"GEECS Console {_package_version()}")
+        about = help_menu.addAction(f"GEECS Console {console_version()}")
         about.setEnabled(False)
 
     def _build_status_bar(self) -> None:
@@ -440,7 +550,7 @@ class MainWindow(QMainWindow):
         gateway = os.environ.get("EPICS_CA_ADDR_LIST", "unset")
         self._status_gateway = QLabel(f"gateway: {gateway}")
         self._status_configs = QLabel("configs: —")
-        self._status_version = QLabel(f"v{_package_version()}")
+        self._status_version = QLabel(f"v{console_version()}")
         self.statusBar().addWidget(self._status_gateway)
         self.statusBar().addWidget(self._status_configs)
         self.statusBar().addPermanentWidget(self._status_version)
@@ -497,6 +607,18 @@ class MainWindow(QMainWindow):
         self.device_set_finished.connect(
             self._apply_device_set_result, Qt.ConnectionType.QueuedConnection
         )
+        # R7 completions and the R6 idle scan-number peek: each result is
+        # emitted by a BackgroundResult worker (never by the window itself —
+        # a daemon-thread emit on a window-owned signal races teardown) and
+        # delivered queued to its GUI-thread apply slot.
+        self._completions_worker = BackgroundResult()
+        self._completions_worker.result_ready.connect(
+            self._apply_device_completions, Qt.ConnectionType.QueuedConnection
+        )
+        self._idle_scan_worker = BackgroundResult()
+        self._idle_scan_worker.result_ready.connect(
+            self._apply_idle_scan_number, Qt.ConnectionType.QueuedConnection
+        )
 
         self.events.state_changed.connect(self._on_scan_state)
         self.events.totals_known.connect(self._on_totals_known)
@@ -550,6 +672,7 @@ class MainWindow(QMainWindow):
         self._refresh_presets()
         self._refresh_union_preview()
         self._refresh_shot_count()
+        self._refresh_editor_actions()
 
     @staticmethod
     def _chip_markup(name: str, status: HealthStatus) -> str:
@@ -648,6 +771,19 @@ class MainWindow(QMainWindow):
             try:
                 backend.unsubscribe()
             except Exception:  # noqa: BLE001 — teardown must not raise
+                pass
+        for worker, slot in (
+            (
+                getattr(self, "_completions_worker", None),
+                self._apply_device_completions,
+            ),
+            (getattr(self, "_idle_scan_worker", None), self._apply_idle_scan_number),
+        ):
+            if worker is None:
+                continue
+            try:
+                worker.result_ready.disconnect(slot)
+            except (RuntimeError, TypeError):
                 pass
         for signal, slot in (
             (self.device_value_ready, self._apply_device_value),
@@ -855,6 +991,9 @@ class MainWindow(QMainWindow):
         self._populate_from_configs()
         # The readback PV is experiment-prefixed — re-point the monitor.
         self._resubscribe_device()
+        # New experiment, new device list and new daily scans folder.
+        self._start_device_completions_fetch()
+        self._start_idle_scan_probe()
 
     def _restore_last_experiment(self) -> None:
         """Select the remembered experiment at startup (explicit choice wins).
@@ -934,6 +1073,55 @@ class MainWindow(QMainWindow):
     def _on_open_github(self) -> None:
         """Ops: open the GEECS-Plugins GitHub page in the browser."""
         QDesktopServices.openUrl(QUrl(ops_paths.GITHUB_URL))
+
+    # ------------------------------------------------------------------
+    # Editors menu (each entry point shows a non-modal dialog and returns it)
+    # ------------------------------------------------------------------
+
+    def _refresh_editor_actions(self) -> None:
+        """Enable the Editors-menu actions only when an experiment is selected."""
+        enabled = bool(self.experiment_combo.currentText())
+        for action in self._editor_actions:
+            action.setEnabled(enabled)
+
+    def _open_editor(self, opener: Callable[..., object]) -> None:
+        """Open one editor for the current experiment, holding a reference.
+
+        The ``open_*_editor`` entry points show their dialog non-modally
+        (``show()``, not ``exec()``) and return it; an unreferenced PySide6
+        wrapper would be garbage-collected — taking the C++ dialog down with
+        it — so every opened editor is kept in ``self._open_editors``
+        (closed ones are pruned on the next open).
+
+        Parameters
+        ----------
+        opener : callable
+            One of the four ``open_*_editor`` entry points, called as
+            ``opener(self, experiment=<current>)``.
+        """
+        experiment = self.experiment_combo.currentText()
+        if not experiment:
+            self._report("Select an experiment before opening an editor.")
+            return
+        dialog = opener(self, experiment=experiment)
+        self._open_editors = [d for d in self._open_editors if d.isVisible()]
+        self._open_editors.append(dialog)
+
+    def _on_edit_save_sets(self) -> None:
+        """Editors: open the save-set editor for the current experiment."""
+        self._open_editor(open_save_set_editor)
+
+    def _on_edit_scan_variables(self) -> None:
+        """Editors: open the scan-variable editor for the current experiment."""
+        self._open_editor(open_scan_variable_editor)
+
+    def _on_edit_shot_control(self) -> None:
+        """Editors: open the trigger-profile editor for the current experiment."""
+        self._open_editor(open_shot_control_editor)
+
+    def _on_edit_action_library(self) -> None:
+        """Editors: open the action-library editor for the current experiment."""
+        self._open_editor(open_action_library_editor)
 
     # ------------------------------------------------------------------
     # Preferences (beeps)
@@ -1232,6 +1420,70 @@ class MainWindow(QMainWindow):
         )
         self.set_button.setEnabled(ready)
 
+    def _warn_device_format(self) -> None:
+        """Status-bar hint for an unparsable R7 device selection."""
+        self.statusBar().showMessage("Device format: DeviceName:Variable Name", 10_000)
+
+    def _start_device_completions_fetch(self) -> None:
+        """Fetch R7 ``device:variable`` completions off the GUI thread.
+
+        Mirrors the editors' completions pattern: one blocking provider call
+        on a short-lived daemon thread (via the :class:`BackgroundResult`
+        worker), marshaled back queued to :meth:`_apply_device_completions`
+        — never on the GUI thread.  No experiment (or the
+        :class:`EmptyCompletions` default in tests) answers inline with an
+        empty list, spawning no thread.
+        """
+        experiment = self.experiment_combo.currentText()
+        factory = (
+            self._completions_factory
+            if self._completions_factory is not None
+            else _default_completions_factory
+        )
+        provider = factory(experiment) if experiment else EmptyCompletions()
+        if isinstance(provider, EmptyCompletions):
+            self._apply_device_completions((experiment, []))
+            return
+
+        def fetch() -> tuple[str, list[str]]:
+            try:
+                mapping = provider.device_variables()
+            except Exception as exc:  # noqa: BLE001 — completions are best-effort
+                logger.info("device completions failed: %s", exc)
+                mapping = {}
+            words = sorted(
+                f"{device}:{variable}"
+                for device, variables in (mapping or {}).items()
+                for variable in variables
+            )
+            return (experiment, words)
+
+        self._completions_worker.run_async(fetch, name="console-device-completions")
+
+    @Slot(object)
+    def _apply_device_completions(self, payload: object) -> None:
+        """Populate the R7 combo's dropdown (GUI-thread slot, delivered queued).
+
+        Parameters
+        ----------
+        payload : tuple
+            ``(experiment, ["device:variable", ...])``; a result tagged with
+            an experiment that is no longer selected is dropped (a stale
+            fetch racing an experiment change).
+        """
+        experiment, words = payload
+        if experiment != self.experiment_combo.currentText():
+            return
+        current = self.device_combo.currentText()
+        self.device_combo.blockSignals(True)
+        self.device_combo.clear()
+        self.device_combo.addItems(list(words))
+        self.device_combo.setCurrentIndex(-1)
+        line_edit = self.device_combo.lineEdit()
+        if line_edit is not None:
+            line_edit.setText(current)
+        self.device_combo.blockSignals(False)
+
     def _resubscribe_device(self, *_args: object) -> None:
         """Re-point the readback monitor at the combo's current selection.
 
@@ -1248,6 +1500,10 @@ class MainWindow(QMainWindow):
         self._refresh_device_set_enabled()
         parsed = parse_device_variable(self.device_combo.currentText())
         if parsed is None:
+            # Committed text that doesn't parse gets a visible hint — a
+            # silent no-op looked like a dead panel (user report).
+            if self.device_combo.currentText().strip():
+                self._warn_device_format()
             return
         device, variable = parsed
         try:
@@ -1277,7 +1533,11 @@ class MainWindow(QMainWindow):
         """Dispatch the blocking backend set to a daemon thread."""
         parsed = parse_device_variable(self.device_combo.currentText())
         text = self.set_field.text().strip()
-        if parsed is None or not text or self._device_set_in_flight:
+        if parsed is None:
+            if self.device_combo.currentText().strip():
+                self._warn_device_format()
+            return
+        if not text or self._device_set_in_flight:
             return
         device, variable = parsed
         value = parse_set_value(text)
@@ -1349,8 +1609,59 @@ class MainWindow(QMainWindow):
     def _expire_scan_number(self) -> None:
         """Mark the displayed scan number as previous once the timer fires."""
         text = self.scan_number_label.text()
-        if text.startswith("Scan "):
+        if text.startswith("Scan ") and not text.endswith("(previous)"):
             self.scan_number_label.setText(f"{text} (previous)")
+
+    def _start_idle_scan_probe(self) -> None:
+        """Peek at today's scans dir for the R6 idle display — read-only.
+
+        The lookup resolves today's daily ``scans/`` folder and lists it for
+        the highest existing ``ScanNNN`` — resolution and listdir only,
+        never creating anything on that path (repo scan-folder invariant).
+        The data root is typically a network mount, so the blocking lookup
+        runs on a short-lived daemon thread (via the
+        :class:`BackgroundResult` worker) and reports back queued to
+        :meth:`_apply_idle_scan_number`.
+        """
+        experiment = self.experiment_combo.currentText()
+        lookup = (
+            self._scan_number_lookup
+            if self._scan_number_lookup is not None
+            else _idle_scan_lookup
+        )
+
+        def probe() -> tuple[str, Optional[int]]:
+            try:
+                number = lookup(experiment)
+            except Exception as exc:  # noqa: BLE001 — a flaky mount is not a crash
+                logger.info("idle scan-number lookup failed: %s", exc)
+                number = None
+            return (experiment, number)
+
+        self._idle_scan_worker.run_async(probe, name="console-idle-scan-probe")
+
+    @Slot(object)
+    def _apply_idle_scan_number(self, payload: object) -> None:
+        """Render the idle scan-number peek (GUI-thread slot, delivered queued).
+
+        A live scan number on display (the 10 s expiry timer still running)
+        is never clobbered, and a result tagged with an experiment that is
+        no longer selected is dropped.
+
+        Parameters
+        ----------
+        payload : tuple
+            ``(experiment, int | None)`` from the daemon-thread probe.
+        """
+        experiment, number = payload
+        if experiment != self.experiment_combo.currentText():
+            return
+        if self._scan_number_timer.isActive():
+            return
+        if number is None:
+            self.scan_number_label.setText("No scans today")
+        else:
+            self.scan_number_label.setText(f"Scan {number:03d} (previous)")
 
     def _set_state_pill(self, state: str) -> None:
         """Render the R6 state pill: colored dot + uppercase state word.

--- a/GEECS-Console/geecs_console/services/ops_paths.py
+++ b/GEECS-Console/geecs_console/services/ops_paths.py
@@ -14,11 +14,15 @@ by the caller ("no scans today"), never created here.
 from __future__ import annotations
 
 import logging
+import re
 from datetime import date
 from pathlib import Path
 from typing import Optional
 
 logger = logging.getLogger(__name__)
+
+#: ``ScanNNN`` daily-folder entries (three or more digits, per convention).
+_SCAN_DIR_RE = re.compile(r"^Scan(\d{3,})$")
 
 GITHUB_URL = "https://github.com/GEECS-BELLA/GEECS-Plugins"
 
@@ -138,3 +142,40 @@ def todays_scan_folder(
     except Exception as exc:  # noqa: BLE001 — path building must not crash the GUI
         logger.info("today's scan folder unresolvable: %s", exc)
         return None
+
+
+def highest_scan_number(scans_dir: Optional[Path]) -> Optional[int]:
+    """Return the highest existing ``ScanNNN`` number — strictly read-only.
+
+    Peeks at an existing daily ``scans/`` folder for the R6 idle display
+    ("Scan NNN (previous)").  Resolution and listing only: nothing on this
+    path is ever created or modified (repo scan-folder invariant — the
+    scanner side is the only producer of scan folders).
+
+    Parameters
+    ----------
+    scans_dir : Path or None
+        The daily ``scans/`` folder (usually from
+        :func:`todays_scan_folder`); ``None`` or a missing/unreadable
+        directory yields ``None``.
+
+    Returns
+    -------
+    int or None
+        The largest ``NNN`` among ``ScanNNN`` subdirectories, or ``None``
+        when the folder is absent, unreadable, or holds no scan folders.
+    """
+    if scans_dir is None:
+        return None
+    try:
+        if not scans_dir.is_dir():
+            return None
+        numbers = [
+            int(match.group(1))
+            for entry in scans_dir.iterdir()
+            if entry.is_dir() and (match := _SCAN_DIR_RE.match(entry.name))
+        ]
+    except OSError as exc:  # a flaky network mount must not crash the GUI
+        logger.info("cannot list %s: %s", scans_dir, exc)
+        return None
+    return max(numbers) if numbers else None

--- a/GEECS-Console/geecs_console/version.py
+++ b/GEECS-Console/geecs_console/version.py
@@ -1,0 +1,50 @@
+"""Console version resolution — the source tree wins over installed metadata.
+
+``importlib.metadata`` reflects whatever the last ``poetry install`` recorded,
+not the code actually running — a dev checkout that bumped ``pyproject.toml``
+without reinstalling would show a stale number in the status bar.  So the
+status-bar version prefers the adjacent ``pyproject.toml`` (present in a dev
+checkout, absent in a built wheel), then falls back to the installed
+distribution metadata, then to ``"unknown"``.
+"""
+
+from __future__ import annotations
+
+import importlib.metadata
+import tomllib
+from pathlib import Path
+from typing import Optional
+
+#: The dev-checkout pyproject adjacent to the package directory.
+_PYPROJECT_PATH = Path(__file__).parent.parent / "pyproject.toml"
+
+
+def console_version(pyproject: Optional[Path] = None) -> str:
+    """Return the running console's version string.
+
+    Parameters
+    ----------
+    pyproject : Path, optional
+        The ``pyproject.toml`` to read first; defaults to the one adjacent
+        to the ``geecs_console`` package (a dev checkout).  Tests pass a
+        tmp path.
+
+    Returns
+    -------
+    str
+        The ``[tool.poetry] version`` from *pyproject* when readable, else
+        the installed ``geecs-console`` distribution version, else
+        ``"unknown"``.
+    """
+    path = pyproject if pyproject is not None else _PYPROJECT_PATH
+    try:
+        data = tomllib.loads(path.read_text(encoding="utf-8"))
+        version = data["tool"]["poetry"]["version"]
+        if isinstance(version, str) and version:
+            return version
+    except (OSError, tomllib.TOMLDecodeError, KeyError, TypeError):
+        pass
+    try:
+        return importlib.metadata.version("geecs-console")
+    except importlib.metadata.PackageNotFoundError:
+        return "unknown"

--- a/GEECS-Console/main.py
+++ b/GEECS-Console/main.py
@@ -27,6 +27,9 @@ def configure_logging(level_name: str = "INFO") -> None:
     level = getattr(logging, level_name.upper(), logging.INFO)
     root = logging.getLogger()
     root.setLevel(level)
+    # The Tiled health probe issues an httpx GET every poll; at INFO httpx
+    # logs one line per request (every 5 s, forever).  Quiet it to WARNING.
+    logging.getLogger("httpx").setLevel(logging.WARNING)
     formatter = logging.Formatter("%(asctime)s %(levelname)s %(name)s: %(message)s")
     stderr_handler = logging.StreamHandler()
     stderr_handler.setFormatter(formatter)

--- a/GEECS-Console/pyproject.toml
+++ b/GEECS-Console/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-console"
-version = "0.5.0"
+version = "0.6.0"
 description = "Greenfield PySide6 operator console for GEECS (Bluesky/gateway architecture)"
 authors = ["Sam Barber <sbarber@lbl.gov>"]
 readme = "README.md"

--- a/GEECS-Console/tests/conftest.py
+++ b/GEECS-Console/tests/conftest.py
@@ -23,3 +23,25 @@ def _isolated_qsettings(tmp_path):
         QSettings.Scope.UserScope,
         str(tmp_path / "qsettings"),
     )
+
+
+@pytest.fixture(autouse=True)
+def _offline_window_defaults(monkeypatch):
+    """Neutralize MainWindow's network-touching default seams (hermetic).
+
+    A window built without an injected ``completions_factory`` /
+    ``scan_number_lookup`` would otherwise dispatch daemon threads at the
+    real ``GeecsDb`` and the real data root on every construction.  The
+    module-level defaults are resolved lazily at fetch time, so patching
+    them here keeps every test offline; tests of the features themselves
+    inject fakes through the constructor parameters.
+    """
+    from geecs_console.app import main_window
+    from geecs_console.services.device_completions import EmptyCompletions
+
+    monkeypatch.setattr(
+        main_window,
+        "_default_completions_factory",
+        lambda experiment: EmptyCompletions(),
+    )
+    monkeypatch.setattr(main_window, "_idle_scan_lookup", lambda experiment: None)

--- a/GEECS-Console/tests/test_main_window_editors_integration.py
+++ b/GEECS-Console/tests/test_main_window_editors_integration.py
@@ -1,0 +1,297 @@
+"""M5 integration behavior: Editors menu, R7 completions, parse feedback, R6 idle scan.
+
+Hermetic like the rest of the window suite: fake configs/submitter, the
+``open_*_editor`` entry points monkeypatched at the window module, fake
+completions providers, and tmp-tree scan-number lookups.  The load-bearing
+pin is ``TestIdleScanNumber.test_probe_never_touches_the_tree``: the idle
+peek must never create anything on the scans path (repo scan-folder
+invariant).
+"""
+
+from pathlib import Path
+
+import pytest
+from PySide6.QtWidgets import QDialog
+
+from geecs_console.app import main_window as mw_mod
+from geecs_console.app.main_window import MainWindow
+from geecs_console.services import ops_paths
+from test_main_window import (
+    FakeConfigs,
+    FakePresetStore,
+    FakeSettings,
+    FakeSubmitter,
+)
+
+
+def tree_snapshot(root: Path) -> set:
+    """Every path under *root*, for asserting a tree is untouched."""
+    return set(root.rglob("*"))
+
+
+def make_window(qtbot, **kwargs):
+    kwargs.setdefault(
+        "configs",
+        FakeConfigs(
+            save_sets=["Amp4In"],
+            scan_variables=["jet_x"],
+            experiments=("TestExp", "Bella"),
+        ),
+    )
+    kwargs.setdefault("presets", FakePresetStore())
+    kwargs.setdefault("settings", FakeSettings())
+    kwargs.setdefault("submitter", FakeSubmitter())
+    win = MainWindow(**kwargs)
+    qtbot.addWidget(win)
+    return win
+
+
+class FakeCompletions:
+    """CompletionsProvider stand-in with a fixed mapping."""
+
+    def __init__(self, mapping):
+        self.mapping = mapping
+        self.calls = 0
+
+    def device_variables(self):
+        self.calls += 1
+        return self.mapping
+
+
+class TestEditorsMenu:
+    EXPECTED = [
+        "Save Elements…",
+        "Scan Variables…",
+        "Shot Control…",
+        "Action Library…",
+    ]
+
+    def find_editors_menu(self, window):
+        for menu in window._menus:
+            if menu.title() == "Editors":
+                return menu
+        raise AssertionError("Editors menu not found")
+
+    def test_menu_lists_the_four_editors(self, qtbot):
+        window = make_window(qtbot)
+        menu = self.find_editors_menu(window)
+        texts = [action.text() for action in menu.actions()]
+        assert texts == self.EXPECTED
+
+    @pytest.mark.parametrize(
+        ("index", "entry_point"),
+        [
+            (0, "open_save_set_editor"),
+            (1, "open_scan_variable_editor"),
+            (2, "open_shot_control_editor"),
+            (3, "open_action_library_editor"),
+        ],
+    )
+    def test_action_opens_editor_for_current_experiment(
+        self, qtbot, monkeypatch, index, entry_point
+    ):
+        window = make_window(qtbot)
+        calls = []
+
+        def fake_open(parent, experiment, **kwargs):
+            dialog = QDialog(parent)
+            dialog.show()
+            calls.append((parent, experiment))
+            return dialog
+
+        monkeypatch.setattr(mw_mod, entry_point, fake_open)
+        window._editor_actions[index].trigger()
+        assert calls == [(window, "TestExp")]
+        # The window must hold the dialog reference — PySide6 GC would
+        # otherwise tear the C++ dialog down (the addMenu hazard's cousin).
+        assert window._open_editors[-1].isVisible()
+
+    def test_closed_editors_are_pruned_on_next_open(self, qtbot, monkeypatch):
+        window = make_window(qtbot)
+        opened = []
+
+        def fake_open(parent, experiment, **kwargs):
+            dialog = QDialog(parent)
+            dialog.show()
+            opened.append(dialog)
+            return dialog
+
+        monkeypatch.setattr(mw_mod, "open_save_set_editor", fake_open)
+        window._editor_actions[0].trigger()
+        window._editor_actions[0].trigger()
+        assert len(window._open_editors) == 2
+        opened[0].close()
+        window._editor_actions[0].trigger()
+        assert opened[0] not in window._open_editors
+        assert len(window._open_editors) == 2  # second + third, first pruned
+
+    def test_actions_disabled_without_experiment(self, qtbot):
+        window = make_window(
+            qtbot,
+            configs=FakeConfigs(experiment="", experiments=("TestExp",)),
+        )
+        assert window.experiment_combo.currentText() == ""
+        assert all(not action.isEnabled() for action in window._editor_actions)
+        window.experiment_combo.setCurrentText("TestExp")
+        assert all(action.isEnabled() for action in window._editor_actions)
+
+    def test_open_editor_without_experiment_reports(self, qtbot, monkeypatch):
+        window = make_window(
+            qtbot,
+            configs=FakeConfigs(experiment="", experiments=("TestExp",)),
+        )
+        opened = []
+        monkeypatch.setattr(
+            mw_mod, "open_save_set_editor", lambda *a, **k: opened.append(1)
+        )
+        window._on_edit_save_sets()
+        assert not opened
+        assert "experiment" in window.statusBar().currentMessage().lower()
+
+
+class TestDeviceComboCompletions:
+    def test_combo_populates_from_provider(self, qtbot):
+        provider = FakeCompletions(
+            {"U_ESP_JetXYZ": ["Position.Axis 1", "Position.Axis 2"], "Amp4": ["energy"]}
+        )
+        window = make_window(qtbot, completions_factory=lambda exp: provider)
+        qtbot.waitUntil(lambda: window.device_combo.count() == 3, timeout=3000)
+        items = [window.device_combo.itemText(i) for i in range(3)]
+        assert items == [
+            "Amp4:energy",
+            "U_ESP_JetXYZ:Position.Axis 1",
+            "U_ESP_JetXYZ:Position.Axis 2",
+        ]
+        assert provider.calls == 1
+
+    def test_combo_stays_editable_and_keeps_typed_text(self, qtbot):
+        provider = FakeCompletions({"Dev": ["var"]})
+        window = make_window(qtbot, completions_factory=lambda exp: provider)
+        window.device_combo.setEditText("half-typed")
+        qtbot.waitUntil(lambda: window.device_combo.count() == 1, timeout=3000)
+        assert window.device_combo.isEditable()
+        assert window.device_combo.currentText() == "half-typed"
+
+    def test_stale_experiment_result_is_dropped(self, qtbot):
+        window = make_window(qtbot)
+        window._apply_device_completions(("SomeOtherExp", ["Dev:var"]))
+        assert window.device_combo.count() == 0
+
+    def test_offline_default_is_empty_but_usable(self, qtbot):
+        # No factory injected: the (conftest-patched) default answers empty
+        # inline — free text must still drive the panel.
+        window = make_window(qtbot)
+        assert window.device_combo.count() == 0
+        window.device_combo.setEditText("Dev:var")
+        window.set_field.setText("1.0")
+        assert window.set_button.isEnabled()
+
+    def test_experiment_change_refetches(self, qtbot):
+        by_experiment = {
+            "TestExp": FakeCompletions({"A": ["x"]}),
+            "Bella": FakeCompletions({"B": ["y"], "C": ["z"]}),
+        }
+        window = make_window(qtbot, completions_factory=lambda exp: by_experiment[exp])
+        qtbot.waitUntil(lambda: window.device_combo.count() == 1, timeout=3000)
+        window.experiment_combo.setCurrentText("Bella")
+        qtbot.waitUntil(lambda: window.device_combo.count() == 2, timeout=3000)
+        items = {window.device_combo.itemText(i) for i in range(2)}
+        assert items == {"B:y", "C:z"}
+
+
+class TestDeviceParseFeedback:
+    def test_unparsable_commit_shows_format_hint(self, qtbot):
+        window = make_window(qtbot)
+        window.device_combo.setEditText("no-colon-here")
+        window._resubscribe_device()
+        assert (
+            window.statusBar().currentMessage()
+            == "Device format: DeviceName:Variable Name"
+        )
+
+    def test_empty_commit_stays_silent(self, qtbot):
+        window = make_window(qtbot)
+        window.device_combo.setEditText("")
+        window._resubscribe_device()
+        assert window.statusBar().currentMessage() == ""
+
+    def test_valid_commit_stays_silent(self, qtbot):
+        window = make_window(qtbot)
+        window.device_combo.setEditText("Dev:var")
+        window._resubscribe_device()
+        assert window.statusBar().currentMessage() == ""
+
+    def test_set_click_with_unparsable_device_shows_hint(self, qtbot):
+        window = make_window(qtbot)
+        window.device_combo.setEditText("garbage")
+        window.set_field.setText("1.0")
+        window._on_device_set_clicked()
+        assert (
+            window.statusBar().currentMessage()
+            == "Device format: DeviceName:Variable Name"
+        )
+
+
+class TestIdleScanNumber:
+    def test_shows_previous_scan_on_startup(self, qtbot):
+        window = make_window(qtbot, scan_number_lookup=lambda exp: 17)
+        qtbot.waitUntil(
+            lambda: window.scan_number_label.text() == "Scan 017 (previous)",
+            timeout=3000,
+        )
+
+    def test_no_scans_today_without_folder(self, qtbot):
+        window = make_window(qtbot, scan_number_lookup=lambda exp: None)
+        # The probe result is delivered queued; give it a spin.
+        qtbot.wait(50)
+        assert window.scan_number_label.text() == "No scans today"
+
+    def test_experiment_change_reprobes(self, qtbot):
+        numbers = {"TestExp": 3, "Bella": 12}
+        window = make_window(qtbot, scan_number_lookup=lambda exp: numbers.get(exp))
+        qtbot.waitUntil(
+            lambda: window.scan_number_label.text() == "Scan 003 (previous)",
+            timeout=3000,
+        )
+        window.experiment_combo.setCurrentText("Bella")
+        qtbot.waitUntil(
+            lambda: window.scan_number_label.text() == "Scan 012 (previous)",
+            timeout=3000,
+        )
+
+    def test_live_scan_number_is_never_clobbered(self, qtbot):
+        window = make_window(qtbot, scan_number_lookup=lambda exp: 17)
+        window.set_scan_number(5)  # live scan: starts the 10 s expiry timer
+        window._apply_idle_scan_number(("TestExp", 17))
+        assert window.scan_number_label.text() == "Scan 005"
+
+    def test_stale_experiment_result_is_dropped(self, qtbot):
+        window = make_window(qtbot, scan_number_lookup=lambda exp: None)
+        qtbot.wait(50)
+        window._apply_idle_scan_number(("SomeOtherExp", 42))
+        assert window.scan_number_label.text() == "No scans today"
+
+    def test_probe_never_touches_the_tree(self, qtbot, tmp_path):
+        """The invariant pin: the idle peek is resolution + listdir only."""
+        scans = tmp_path / "present" / "scans"
+        scans.mkdir(parents=True)
+        (scans / "Scan007").mkdir()
+        missing = tmp_path / "missing" / "scans"  # never created
+
+        def lookup(experiment):
+            folder = scans if experiment == "TestExp" else missing
+            return ops_paths.highest_scan_number(folder)
+
+        before = tree_snapshot(tmp_path)
+        window = make_window(qtbot, scan_number_lookup=lookup)
+        qtbot.waitUntil(
+            lambda: window.scan_number_label.text() == "Scan 007 (previous)",
+            timeout=3000,
+        )
+        window.experiment_combo.setCurrentText("Bella")
+        qtbot.waitUntil(
+            lambda: window.scan_number_label.text() == "No scans today",
+            timeout=3000,
+        )
+        assert tree_snapshot(tmp_path) == before
+        assert not missing.exists()

--- a/GEECS-Console/tests/test_ops_paths.py
+++ b/GEECS-Console/tests/test_ops_paths.py
@@ -115,3 +115,47 @@ class TestTodaysScanFolder:
         monkeypatch.setattr(ScanPaths, "paths_config", FakePathsConfig())
         resolved = ops_paths.todays_scan_folder("", today=self.DAY)
         assert resolved == self.expected(tmp_path)
+
+
+class TestHighestScanNumber:
+    def make_scans(self, tmp_path: Path, *names: str) -> Path:
+        scans = tmp_path / "scans"
+        scans.mkdir()
+        for name in names:
+            (scans / name).mkdir()
+        return scans
+
+    def test_highest_of_several(self, tmp_path):
+        scans = self.make_scans(tmp_path, "Scan001", "Scan002", "Scan017")
+        assert ops_paths.highest_scan_number(scans) == 17
+
+    def test_ignores_non_scan_entries(self, tmp_path):
+        scans = self.make_scans(tmp_path, "Scan003", "ScanData", "Scan01", "notes")
+        (scans / "Scan999.txt").write_text("a file, not a scan folder")
+        assert ops_paths.highest_scan_number(scans) == 3
+
+    def test_four_digit_scan_numbers(self, tmp_path):
+        scans = self.make_scans(tmp_path, "Scan0999", "Scan1000")
+        assert ops_paths.highest_scan_number(scans) == 1000
+
+    def test_empty_folder_is_none(self, tmp_path):
+        scans = self.make_scans(tmp_path)
+        assert ops_paths.highest_scan_number(scans) is None
+
+    def test_missing_folder_is_none(self, tmp_path):
+        assert ops_paths.highest_scan_number(tmp_path / "scans") is None
+
+    def test_none_input_is_none(self):
+        assert ops_paths.highest_scan_number(None) is None
+
+    def test_never_creates_or_modifies_anything(self, tmp_path):
+        """The invariant pin: the peek is resolution + listdir only.
+
+        Neither a present nor an absent daily folder may be touched — GUI
+        code is a consumer of scan folders, never a producer.
+        """
+        scans = self.make_scans(tmp_path, "Scan001")
+        before = tree_snapshot(tmp_path)
+        assert ops_paths.highest_scan_number(scans) == 1
+        assert ops_paths.highest_scan_number(tmp_path / "missing" / "scans") is None
+        assert tree_snapshot(tmp_path) == before

--- a/GEECS-Console/tests/test_version.py
+++ b/GEECS-Console/tests/test_version.py
@@ -1,0 +1,78 @@
+"""console_version: source-tree pyproject wins, metadata second, then unknown."""
+
+import importlib.metadata
+
+import geecs_console.version as version_mod
+from geecs_console.version import console_version
+
+
+def test_reads_version_from_pyproject(tmp_path):
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text(
+        '[tool.poetry]\nname = "geecs-console"\nversion = "9.9.9"\n',
+        encoding="utf-8",
+    )
+    assert console_version(pyproject) == "9.9.9"
+
+
+def test_default_reads_the_dev_checkout_pyproject():
+    """In this repo the adjacent pyproject.toml exists and wins."""
+    import tomllib
+    from pathlib import Path
+
+    expected = tomllib.loads(
+        (Path(version_mod.__file__).parent.parent / "pyproject.toml").read_text(
+            encoding="utf-8"
+        )
+    )["tool"]["poetry"]["version"]
+    assert console_version() == expected
+
+
+def test_missing_pyproject_falls_back_to_metadata(tmp_path):
+    got = console_version(tmp_path / "nope" / "pyproject.toml")
+    assert got == importlib.metadata.version("geecs-console")
+
+
+def test_missing_pyproject_and_metadata_is_unknown(tmp_path, monkeypatch):
+    def raise_not_found(name):
+        raise importlib.metadata.PackageNotFoundError(name)
+
+    monkeypatch.setattr(importlib.metadata, "version", raise_not_found)
+    assert console_version(tmp_path / "nope" / "pyproject.toml") == "unknown"
+
+
+def test_malformed_pyproject_falls_back(tmp_path, monkeypatch):
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text("not toml at [ all", encoding="utf-8")
+
+    def raise_not_found(name):
+        raise importlib.metadata.PackageNotFoundError(name)
+
+    monkeypatch.setattr(importlib.metadata, "version", raise_not_found)
+    assert console_version(pyproject) == "unknown"
+
+
+def test_httpx_logger_quieted_by_configure_logging():
+    """The Tiled health probe's httpx INFO chatter is capped at WARNING."""
+    import logging
+    import sys
+    from pathlib import Path
+
+    sys.path.insert(0, str(Path(version_mod.__file__).parent.parent))
+    try:
+        import main as console_main
+    finally:
+        sys.path.pop(0)
+
+    root = logging.getLogger()
+    before = list(root.handlers)
+    level_before = root.level
+    try:
+        console_main.configure_logging("INFO")
+        assert logging.getLogger("httpx").level == logging.WARNING
+    finally:
+        for handler in list(root.handlers):
+            if handler not in before:
+                root.removeHandler(handler)
+                handler.close()
+        root.setLevel(level_before)


### PR DESCRIPTION
Wires the four just-merged editors (#504–#507) into the Editors menu and fixes five user-reported UX issues. Version 0.5.0 → 0.6.0.

## Editors menu wiring

- Four actions in the Editors menu — **Save Elements…**, **Scan Variables…**, **Shot Control…**, **Action Library…** — each calling the corresponding `open_*_editor(self, experiment=<current combo text>)`.
- The entry points show **non-modal** dialogs (`show()`) and return them; every opened dialog is referenced on the window (`_open_editors`, pruned when closed) so PySide6 GC cannot tear down a live editor (the `addMenu` hazard's cousin).
- Actions are disabled while no experiment is selected; a guarded handler reports in the status bar if invoked anyway.

## User-reported fixes

- **R7 device-combo autocomplete** ("dropdown shows nothing"): the combo now lists sorted `device:variable` completions from `GeecsDbCompletions` for the current experiment — fetched at startup and on experiment change on a short-lived daemon thread, delivered via a queued signal (never blocking the GUI). Offline degrades to an empty dropdown; free text still works; typed text survives repopulation; stale fetches racing an experiment change are dropped by experiment tag. Provider factory is constructor-injectable.
- **R7 parse feedback** (silent nothing): device text that doesn't parse as `Device:Variable` on commit (or on a Set attempt) shows "Device format: DeviceName:Variable Name" in the status bar.
- **R6 idle scan-number display**: on startup and experiment change, a **strictly read-only** peek at today's daily `scans/` folder (reusing `ops_paths.todays_scan_folder` + new `ops_paths.highest_scan_number`) shows "Scan NNN (previous)", else keeps "No scans today". Resolution + `is_dir()`/`iterdir()` only — **never creates anything** on the scans path (repo scan-folder invariant, pinned by tree-untouched tests). Runs on a daemon thread (the data root is a NetApp mount over VPN). A live scan number on display is never clobbered.
- **Log hygiene**: `configure_logging` caps the `httpx` logger at WARNING — the Tiled health probe was writing one INFO line per 5 s poll, forever.
- **Version from source** (status bar said 0.1.0 while running 0.5.0 code): new `geecs_console/version.py::console_version` prefers the adjacent `pyproject.toml` (`[tool.poetry] version`, dev checkout), falling back to `importlib.metadata.version`, then `"unknown"`. Used by the status bar and Help menu.

## Threading note (new `BackgroundResult` worker)

The completions fetch and idle scan probe initially emitted window-owned signals from their daemon threads — that **segfaulted deterministically** under offscreen pytest (daemon-thread emit racing window teardown). Both now go through `BackgroundResult`, a small reusable daemon-thread → queued-signal worker (the `HealthPoller` shape, generalized): the daemon thread emits on the worker, never on the window; `closeEvent` disconnects. Documented in `CLAUDE.md` alongside the menu/dialog/QCompleter GC ownership hazards.

**Not in this PR:** the known `_run_device_set` emit-on-deleted-window teardown flake (a daemon set-thread outliving the window in tests) is deliberately left untouched — it's being fixed in a separate session. The intermittent `PytestUnhandledThreadExceptionWarning: Exception in thread console-device-set` seen in some runs is that pre-existing flake.

## Docs

- `CHANGELOG.md`: 0.6.0 entry covering the four editors (#504–#507) and these integration fixes.
- `CLAUDE.md`: editors moved from stubbed seams to implemented (all four entry points listed); new "Standing PySide6 ownership hazards" section (menus, non-modal dialogs, QCompleter); remaining M5 item recorded as the config bootstrap/repair dialog (deliberately deferred).

## Tests

36 new tests (524 total, up from 488): Editors-menu actions (monkeypatched `open_*` entry points, reference-holding, pruning, disabled-without-experiment), combo population via fake provider (incl. experiment-change refetch, stale-result drop, typed-text survival), parse feedback, idle scan-number (incl. the never-creates tree-untouched pin at both the `ops_paths` and window level, live-number no-clobber), `console_version` fallback chain, httpx logger level.

`QT_QPA_PLATFORM=offscreen poetry run pytest -q`: **524 passed, exit 0, 4+ consecutive runs, no segfaults.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)