### PR TITLE
GEECS-Console: Windows CI job + font fallback

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -42,3 +42,42 @@ jobs:
       - name: Run GeecsBluesky pure unit tests
         working-directory: GeecsBluesky
         run: poetry run pytest tests -m "not integration and not fake_server" --tb=short -q
+
+  console-windows:
+    # GEECS-Console is the operator-facing PySide6 GUI and control-room
+    # machines run Windows — this job pins that the console suite passes
+    # on windows-latest.  Console only; the rest of the monorepo is
+    # covered by the ubuntu job above.
+    runs-on: windows-latest
+
+    defaults:
+      run:
+        working-directory: GEECS-Console
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install Poetry
+        run: pip install poetry
+
+      - name: Cache Poetry package cache
+        uses: actions/cache@v4
+        with:
+          path: ~\AppData\Local\pypoetry\Cache
+          key: poetry-console-windows-py311-${{ hashFiles('GEECS-Console/poetry.lock') }}
+          restore-keys: poetry-console-windows-py311-
+
+      - name: Install GEECS-Console dependencies
+        # Path deps (geecs-bluesky -> geecs-ca-gateway/geecs-schemas/
+        # geecs-data-utils) resolve relative to GEECS-Console/ inside the
+        # checkout, same as on the ubuntu job.
+        run: poetry install --with dev
+
+      - name: Run GEECS-Console tests
+        env:
+          QT_QPA_PLATFORM: offscreen
+        run: poetry run pytest -q --tb=short

--- a/GEECS-Console/CHANGELOG.md
+++ b/GEECS-Console/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to GEECS-Console are documented here.  Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versioning is
 semantic.
 
+## [0.6.1] - 2026-07-12
+
+### Added
+
+- **Windows CI job** (`console-windows` in `.github/workflows/unit-tests.yml`):
+  the full GEECS-Console suite now runs on `windows-latest` (Python 3.11,
+  Poetry, `QT_QPA_PLATFORM=offscreen`) on every push/PR — the console is the
+  operator-facing GUI and control-room machines run Windows.  Console only;
+  the ubuntu job continues to cover the rest of the monorepo.
+
+### Notes
+
+- The monospace font stack in `app/style.qss` was audited for Windows: every
+  `font-family` already carries the cross-platform fallback chain
+  `"SF Mono", "Menlo", "Consolas", "DejaVu Sans Mono", monospace`, so no
+  style change was needed.
+
 ## [0.6.0] - 2026-07-12
 
 ### Added

--- a/GEECS-Console/CHANGELOG.md
+++ b/GEECS-Console/CHANGELOG.md
@@ -14,6 +14,15 @@ semantic.
   operator-facing GUI and control-room machines run Windows.  Console only;
   the ubuntu job continues to cover the rest of the monorepo.
 
+### Fixed
+
+- **Windows test portability** (surfaced by the new CI job's first run):
+  the four `TestOpsMenu` open-URL assertions now compare as `Path` —
+  `QUrl.toLocalFile()` always returns forward slashes while `str(tmp_path)`
+  is backslashed on Windows — and the no-geecs-python-api source grep reads
+  files as UTF-8 explicitly (`read_text()` defaults to cp1252 on Windows,
+  which cannot decode the sources).
+
 ### Notes
 
 - The monospace font stack in `app/style.qss` was audited for Windows: every

--- a/GEECS-Console/CLAUDE.md
+++ b/GEECS-Console/CLAUDE.md
@@ -261,4 +261,6 @@ the window for anything in these families:
 `QT_QPA_PLATFORM=offscreen poetry run pytest -q` — hermetic, pytest-qt,
 `qt_api = "pyside6"` pinned in pyproject.  The request-builder tests are the
 important ones: they validate the exact `ScanRequest` shapes against the
-real schema.
+real schema.  CI also runs this suite on `windows-latest` (the
+`console-windows` job in `.github/workflows/unit-tests.yml`) — the console
+deploys to Windows control-room machines, so keep the suite green there too.

--- a/GEECS-Console/pyproject.toml
+++ b/GEECS-Console/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-console"
-version = "0.6.0"
+version = "0.6.1"
 description = "Greenfield PySide6 operator console for GEECS (Bluesky/gateway architecture)"
 authors = ["Sam Barber <sbarber@lbl.gov>"]
 readme = "README.md"

--- a/GEECS-Console/tests/test_main_window.py
+++ b/GEECS-Console/tests/test_main_window.py
@@ -1,5 +1,7 @@
 """MainWindow behavior, hermetic: fake configs, fake submitter, offscreen Qt."""
 
+from pathlib import Path
+
 import pytest
 from PySide6.QtCore import Qt
 
@@ -412,7 +414,12 @@ class TestNowAndDevicePanel:
 class TestOpsMenu:
     @pytest.fixture
     def opened(self, monkeypatch):
-        """Record every QDesktopServices.openUrl target as a string."""
+        """Record every QDesktopServices.openUrl target.
+
+        Assertions compare as ``Path``: ``QUrl.toLocalFile()`` always
+        returns forward slashes, while ``str(tmp_path)`` is backslashed
+        on Windows.
+        """
         from PySide6.QtGui import QDesktopServices
 
         urls = []
@@ -430,7 +437,7 @@ class TestOpsMenu:
             ops_paths, "experiment_configs_folder", lambda experiment: tmp_path
         )
         window._on_open_experiment_configs()
-        assert [url.toLocalFile() for url in opened] == [str(tmp_path)]
+        assert [Path(url.toLocalFile()) for url in opened] == [tmp_path]
 
     def test_open_experiment_configs_unresolvable_reports(
         self, window, opened, monkeypatch
@@ -451,7 +458,7 @@ class TestOpsMenu:
         config.write_text("[Paths]\n")
         monkeypatch.setattr(ops_paths, "user_config_target", lambda: config)
         window._on_open_user_config()
-        assert [url.toLocalFile() for url in opened] == [str(config)]
+        assert [Path(url.toLocalFile()) for url in opened] == [config]
 
     def test_open_user_config_missing_file_opens_folder_with_note(
         self, window, opened, monkeypatch, tmp_path
@@ -460,7 +467,7 @@ class TestOpsMenu:
 
         monkeypatch.setattr(ops_paths, "user_config_target", lambda: tmp_path)
         window._on_open_user_config()
-        assert [url.toLocalFile() for url in opened] == [str(tmp_path)]
+        assert [Path(url.toLocalFile()) for url in opened] == [tmp_path]
         assert "config.ini not found" in window.statusBar().currentMessage()
 
     def test_open_user_config_unresolvable_reports(self, window, opened, monkeypatch):
@@ -480,7 +487,7 @@ class TestOpsMenu:
         scans.mkdir()
         monkeypatch.setattr(ops_paths, "todays_scan_folder", lambda experiment: scans)
         window._on_open_todays_scans()
-        assert [url.toLocalFile() for url in opened] == [str(scans)]
+        assert [Path(url.toLocalFile()) for url in opened] == [scans]
 
     def test_open_todays_scans_missing_reports_and_never_creates(
         self, window, opened, monkeypatch, tmp_path

--- a/GEECS-Console/tests/test_no_geecs_python_api.py
+++ b/GEECS-Console/tests/test_no_geecs_python_api.py
@@ -26,7 +26,9 @@ def test_source_never_mentions_geecs_python_api():
     for path in PACKAGE_DIR.rglob("*"):
         if path.suffix not in (".py", ".ui"):
             continue
-        text = path.read_text().replace(ALLOWED_LITERAL, "")
+        # Explicit encoding: sources are UTF-8, but read_text() defaults to
+        # the locale codec, which is cp1252 on Windows and cannot decode them.
+        text = path.read_text(encoding="utf-8").replace(ALLOWED_LITERAL, "")
         if FORBIDDEN in text:
             offenders.append(str(path))
     assert not offenders, f"{FORBIDDEN} referenced in: {offenders}"


### PR DESCRIPTION
## What

- **`console-windows` job** added to `.github/workflows/unit-tests.yml`: runs the full GEECS-Console suite on `windows-latest` — Python 3.11, `pip install poetry`, `poetry install --with dev` in `GEECS-Console/`, `pytest` with `QT_QPA_PLATFORM: offscreen`. No `continue-on-error`; this is a required-quality gate. Poetry's package cache is keyed on `GEECS-Console/poetry.lock`.
- **Font fallback audit**: every monospace `font-family` in `geecs_console/app/style.qss` already carries the cross-platform stack `"SF Mono", "Menlo", "Consolas", "DejaVu Sans Mono", monospace` (and no other font references exist in `.py`/`.ui`), so no style change was needed — the audit result is recorded in the CHANGELOG instead.
- GEECS-Console `0.6.0 → 0.6.1`, CHANGELOG entry, one CLAUDE.md line noting the Windows CI job.

## Why it lives in unit-tests.yml

The repo convention is one workflow per concern (`pre-commit.yml`, `unit-tests.yml`); this is a unit-test job, so it joins `unit-tests.yml` as a second job rather than a new file.

## Windows-wheel risk check

Verified against `GEECS-Console/poetry.lock` before pushing: `epicscorelibs` ships a `cp311 win_amd64` wheel (pulled via geecs-bluesky's `ca` extra → aioca, which is pure Python), and PySide6/numpy have Windows wheels. The path-dep chain (geecs-bluesky → geecs-ca-gateway / geecs-schemas / geecs-data-utils) is all relative paths, which resolve identically from a Windows checkout.

## Verification

- Local (macOS): `QT_QPA_PLATFORM=offscreen poetry run pytest -q` in `GEECS-Console/` → **524 passed** (baseline).
- Windows: this PR's own `console-windows` check is the verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)