### PR TITLE
GeecsCAGateway: align audit classifier with gateway dtype resolution

### DIFF
--- a/GeecsCAGateway/CHANGELOG.md
+++ b/GeecsCAGateway/CHANGELOG.md
@@ -3,6 +3,23 @@
 All notable changes to `geecs-ca-gateway` are documented here, following
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and semantic versioning.
 
+## [0.13.1] - 2026-07-12
+
+### Fixed
+
+- **Audit classifier now matches the gateway's effective-type resolution**
+  (`#512`). The DB-hygiene audit flagged SKIP variables by `variabletype`
+  alone, but the gateway's config builder treats a bare type-descriptor word
+  in `choices` (`image`, `1darray`, `numeric`, `string`, `path`) as the
+  authoritative type — so a `variabletype='choice'`, `choices='image'` row
+  (a real camera/array variable) was skipped by the gateway yet reported
+  clean by the audit. The resolution logic is now a single shared pure
+  helper, `geecs_ca_gateway.config.effective_vartype()`, extracted from
+  `DeviceSpec.from_db_metadata()` and used by both the config builder and
+  `audit_subscribed_variables()`; such rows are now reported as
+  `SKIP:image` / `SKIP:1darray`. Gateway serving behavior is unchanged
+  (pinned by the existing `test_config_from_db.py` tests).
+
 ## [0.13.0] - 2026-07-11
 
 ### Added

--- a/GeecsCAGateway/CLAUDE.md
+++ b/GeecsCAGateway/CLAUDE.md
@@ -202,8 +202,12 @@ gateway/scanner try to connect a PV that never exists → per-device stalls. The
 audit reports them; run it on-network with `python -m geecs_ca_gateway.audit
 --experiment Undulator` (add `--full` for the per-device listing, `--sql` to
 *print* review-only DELETEs). It flags: **GHOST** (`get='yes'` name isn't a real
-device variable), **SKIP:<type>** (`get='yes'` var typed `image`/`1darray`, in
-`_SKIP_VARTYPES`, so no scalar PV), and **FK-orphan** (`expt_device_id` with no
-`expt_device`). The classifier `audit_subscribed_variables()` is a pure function
-over plain dicts (no DB — unit-tested in `test_audit.py`); DB access is lazy.
+device variable), **SKIP:<type>** (`get='yes'` var whose *effective* type is
+`image`/`1darray`, in `_SKIP_VARTYPES`, so no scalar PV), and **FK-orphan**
+(`expt_device_id` with no `expt_device`). Effective types come from the shared
+pure helper `config.effective_vartype()` — the same choice-descriptor rules the
+config builder applies (`variabletype='choice'` + `choices='image'` is an image;
+#512) — so the audit flags exactly what the gateway skips. The classifier
+`audit_subscribed_variables()` is a pure function over plain dicts (no DB —
+unit-tested in `test_audit.py`); DB access is lazy.
 **Read-only: it never DELETEs or modifies** — `--sql` only prints.

--- a/GeecsCAGateway/geecs_ca_gateway/audit.py
+++ b/GeecsCAGateway/geecs_ca_gateway/audit.py
@@ -13,9 +13,13 @@ GHOST
     device (a deleted variable, or an alias-derived name).  The gateway serves
     PVs by *real* variablename, so a ghost names a PV that is never created.
 SKIP:<type>
-    A ``get='yes'`` variable whose ``variabletype`` is in the gateway's
+    A ``get='yes'`` variable whose *effective* type is in the gateway's
     ``_SKIP_VARTYPES`` (``image`` / ``1darray``).  These are not scalar CA data,
-    so no PV is served for them.
+    so no PV is served for them.  The effective type is resolved with the same
+    shared helper the gateway's config builder uses
+    (:func:`geecs_ca_gateway.config.effective_vartype`), so choice-descriptor
+    rows (``variabletype='choice'`` with ``choices='image'``/``'1darray'``) are
+    flagged exactly as the gateway skips them (#512).
 FK-orphan
     An ``expt_device_variable`` row whose ``expt_device_id`` points at an
     ``expt_device.id`` that no longer exists (a whole experiment removed).
@@ -35,6 +39,8 @@ from __future__ import annotations
 import argparse
 import logging
 from dataclasses import dataclass, field
+
+from .config import effective_vartype
 
 logger = logging.getLogger("geecs_ca_gateway.audit")
 
@@ -127,14 +133,18 @@ def audit_subscribed_variables(
         e.g. from :meth:`GeecsDb.get_subscribed_variables`.
     device_variables:
         ``{device: [metadata, ...]}`` where each metadata dict has at least a
-        ``name`` and a ``variabletype`` key (the shape of
-        :meth:`GeecsDb.get_device_variables` /
+        ``name`` and a ``variabletype`` key, plus ``choices`` when present (the
+        shape of :meth:`GeecsDb.get_device_variables` /
         :meth:`GeecsDb.get_experiment_device_variables`).  A device absent from
         this mapping has no known real variables, so every subscribed variable
         for it is reported as a GHOST rather than crashing.
     skip_types:
         Variable types the gateway does not serve (the gateway's
-        ``_SKIP_VARTYPES``, e.g. ``{"image", "1darray"}``).
+        ``_SKIP_VARTYPES``, e.g. ``{"image", "1darray"}``).  Matched against
+        the *effective* type resolved by
+        :func:`geecs_ca_gateway.config.effective_vartype` — the same rules the
+        gateway's config builder applies, so choice-descriptor rows
+        (``variabletype='choice'``, ``choices='image'``) are flagged too.
 
     Returns
     -------
@@ -152,7 +162,9 @@ def audit_subscribed_variables(
             for meta in real:
                 name = meta.get("name")
                 if name is not None:
-                    by_name[name] = (meta.get("variabletype") or "").strip().lower()
+                    by_name[name] = effective_vartype(
+                        meta.get("variabletype"), meta.get("choices")
+                    )
         for variable in subscribed[device]:
             if variable not in by_name:
                 findings.append(Finding(device, variable, GHOST))

--- a/GeecsCAGateway/geecs_ca_gateway/config.py
+++ b/GeecsCAGateway/geecs_ca_gateway/config.py
@@ -46,6 +46,53 @@ _SKIP_VARTYPES = {"image", "1darray"}
 _MAX_ENUM_STATES = 16
 _MAX_ENUM_STRING_LEN = 26
 
+# `choices` values that are bare type descriptors rather than option lists (the
+# `choice` table's low IDs double as type descriptors in the GEECS DB).
+_CHOICE_TYPE_DESCRIPTORS = _SKIP_VARTYPES | {"numeric", "string", "path"}
+
+
+def effective_vartype(variabletype: str | None, choices: str | None) -> str:
+    """Resolve the effective GEECS variable type from DB metadata.
+
+    The single source of truth for how the gateway interprets a DB variable
+    row's type — used by :meth:`DeviceSpec.from_db_metadata` when building
+    served specs *and* by the DB-hygiene audit
+    (:func:`geecs_ca_gateway.audit.audit_subscribed_variables`), so the audit
+    flags exactly what the gateway skips (#512).
+
+    The ``choice`` table's low IDs double as type descriptors, so when
+    ``choices`` is a bare descriptor word (``image``, ``1darray``, ``numeric``,
+    ``string``, ``path``) it is the AUTHORITATIVE type — even when
+    ``variabletype`` says otherwise (e.g. ``variabletype='choice'`` with
+    ``choices='image'`` is an image variable streaming raw bytes, not a
+    one-option enum).  Otherwise trust ``variabletype``; if it is blank, a real
+    option list is a ``choice``, else fall back to ``numeric``.
+
+    Parameters
+    ----------
+    variabletype : str or None
+        The DB ``variabletype`` column (may be blank/None).
+    choices : str or None
+        The DB ``choices`` column (an option list, a bare type descriptor,
+        or blank/None).
+
+    Returns
+    -------
+    str
+        The effective type, lower-cased: one of the descriptor words above,
+        a ``variabletype`` value, or ``"choice"`` / ``"numeric"`` fallbacks.
+    """
+    vartype = (variabletype or "").strip().lower()
+    raw_choices = (choices or "").strip()
+    descriptor = raw_choices.lower()
+    if descriptor in _CHOICE_TYPE_DESCRIPTORS:
+        return descriptor
+    if vartype:
+        return vartype
+    if "," in raw_choices:
+        return "choice"
+    return "numeric"
+
 
 class VariableSpec(BaseModel):
     """One GEECS variable exposed as EPICS PV(s).
@@ -189,28 +236,12 @@ class DeviceSpec(BaseModel):
             seen.add(var_name)
 
             override = dtypes.get(var_name)
-            vartype = (meta.get("variabletype") or "").strip().lower()
             raw_choices = (meta.get("choices") or "").strip()
-            descriptor = raw_choices.lower()
 
-            # The `choice` table's low IDs double as type descriptors, so when
-            # `choices` is a bare descriptor word it is the AUTHORITATIVE type —
-            # even when variabletype says otherwise (e.g. variabletype='choice'
-            # with choices='image' is an image variable streaming raw bytes, not a
-            # one-option enum). Otherwise trust variabletype; if it's blank, a real
-            # option list is a choice, else fall back to numeric.
-            if descriptor in _SKIP_VARTYPES or descriptor in (
-                "numeric",
-                "string",
-                "path",
-            ):
-                effective = descriptor
-            elif vartype:
-                effective = vartype
-            elif "," in raw_choices:
-                effective = "choice"
-            else:
-                effective = "numeric"
+            # Effective-type resolution (choice-descriptor quirks included)
+            # lives in the shared pure helper so the DB-hygiene audit applies
+            # the identical rules (see `effective_vartype`, #512).
+            effective = effective_vartype(meta.get("variabletype"), raw_choices)
 
             if override is None and effective in _SKIP_VARTYPES:
                 logger.debug(

--- a/GeecsCAGateway/pyproject.toml
+++ b/GeecsCAGateway/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-ca-gateway"
-version = "0.13.0"
+version = "0.13.1"
 description = "EPICS Channel Access soft-IOC gateway exposing GEECS devices as PVs"
 authors = ["Sam Barber <sbarber@lbl.gov>"]
 readme = "README.md"

--- a/GeecsCAGateway/tests/test_audit.py
+++ b/GeecsCAGateway/tests/test_audit.py
@@ -94,6 +94,41 @@ def test_mixed_devices_ordered_by_device_then_input_order() -> None:
     ]
 
 
+def test_choice_descriptor_rows_are_flagged_like_the_gateway_skips_them() -> None:
+    """variabletype='choice' with a bare image/1darray descriptor is SKIP:<type>.
+
+    The gateway's config builder resolves the effective type from ``choices``
+    first (a bare descriptor word is authoritative), so these rows are skipped
+    by the gateway and must be flagged by the audit too (#512).
+    """
+    subscribed = {"UC_Cam": ["frame", "trace", "mode"]}
+    device_variables = {
+        "UC_Cam": [
+            {"name": "frame", "variabletype": "choice", "choices": "image"},
+            {"name": "trace", "variabletype": "choice", "choices": "1darray"},
+            {"name": "mode", "variabletype": "choice", "choices": "on,off"},
+        ]
+    }
+    findings = audit_subscribed_variables(subscribed, device_variables, SKIP_TYPES)
+    assert findings == [
+        Finding("UC_Cam", "frame", "SKIP:image"),
+        Finding("UC_Cam", "trace", "SKIP:1darray"),
+    ]
+
+
+def test_scalar_choice_descriptors_are_not_flagged() -> None:
+    """Bare numeric/string/path descriptors resolve to served scalar types."""
+    subscribed = {"U_Dev": ["gain", "label", "savedir"]}
+    device_variables = {
+        "U_Dev": [
+            {"name": "gain", "variabletype": "choice", "choices": "numeric"},
+            {"name": "label", "variabletype": "choice", "choices": "string"},
+            {"name": "savedir", "variabletype": "choice", "choices": "path"},
+        ]
+    }
+    assert audit_subscribed_variables(subscribed, device_variables, SKIP_TYPES) == []
+
+
 def test_variabletype_case_is_normalized() -> None:
     """Skip matching is case-insensitive on the variabletype."""
     subscribed = {"U_Dev": ["frame"]}


### PR DESCRIPTION
## Summary

- Extracts the gateway's effective-type resolution (the choice-descriptor quirk: a bare `choices` word — `image`, `1darray`, `numeric`, `string`, `path` — is the authoritative type, even when `variabletype` says `choice`) from `DeviceSpec.from_db_metadata()` into a shared pure helper, `geecs_ca_gateway.config.effective_vartype()`.
- Uses the helper in **both** the config builder and the audit classifier `audit_subscribed_variables()`, so the audit flags exactly what the gateway skips. Previously a `variabletype='choice'`, `choices='image'` row (a real camera/array variable) was skipped by the gateway but reported clean by the audit — defeating the tool's purpose.
- The audit's data path already carries `choices` (`GeecsDb._variable_row_to_meta` includes it), so no DB-layer changes were needed.
- Gateway serving behavior is unchanged — the existing `test_config_from_db.py` pins (including `test_choice_pointing_at_type_descriptor_is_skipped`) stay green.

## Tests

- New: `test_choice_descriptor_rows_are_flagged_like_the_gateway_skips_them` — `{"name": "frame", "variabletype": "choice", "choices": "image"}` → `SKIP:image`, `{"name": "trace", ..., "choices": "1darray"}` → `SKIP:1darray`; a real option list (`on,off`) stays clean.
- New: `test_scalar_choice_descriptors_are_not_flagged` — bare `numeric`/`string`/`path` descriptors resolve to served scalar types, no finding.
- Full suite: 181 passed (`poetry run pytest tests -q`, offline).

Patch bump 0.13.0 → 0.13.1 + CHANGELOG entry; CLAUDE.md audit section updated.

Fixes #512

🤖 Generated with [Claude Code](https://claude.com/claude-code)