### PR TITLE
GeecsBluesky: ignore foreign RunEngine event docs in scanner progress

### DIFF
--- a/GeecsBluesky/CHANGELOG.md
+++ b/GeecsBluesky/CHANGELOG.md
@@ -4,6 +4,29 @@ All notable changes to `geecs-bluesky` are documented here.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.30.1] - 2026-07-12
+
+### Fixed
+
+- **Foreign RunEngine event documents no longer mutate GUI scan progress**
+  ([#511](https://github.com/GEECS-BELLA/GEECS-Plugins/issues/511)).
+  `BlueskyScanner._on_document` guarded foreign start documents (the
+  RUNNING-state guard on scan-number pickup, 0.30.0) but still counted
+  *every* event document into `_completed_shots` and emitted a
+  `ScanStepEvent` for it — a headless/foreign run driven directly on the
+  shared session RunEngine could advance an idle or completed scanner's
+  progress and contaminate `estimate_current_completion()`. The scanner
+  now tracks ownership: a start document is claimed only while this
+  scanner is RUNNING (every scan path sets RUNNING before its plan
+  reaches the serial RunEngine), the claimed run's descriptor uids are
+  collected from descriptor documents, and event documents are matched
+  back through their `descriptor` uid — unmatched events are ignored,
+  and the claim is cleared on the run's stop document. Residual
+  limitation (documented in `_on_document`): a foreign run squeezed in
+  after RUNNING is set but before this scanner's plan opens its run
+  would still be mis-claimed; the RunEngine executes plans serially, so
+  that window is only the bridge's pre-plan setup.
+
 ## [0.30.0] - 2026-07-11
 
 ### Added

--- a/GeecsBluesky/geecs_bluesky/scanner_bridge/bluesky_scanner.py
+++ b/GeecsBluesky/geecs_bluesky/scanner_bridge/bluesky_scanner.py
@@ -230,6 +230,14 @@ class BlueskyScanner:
         self._scan_number: int | None = None
         # uid of the most recent run's start document (for the Tiled exporter)
         self._last_run_uid: str | None = None
+        # Ownership tracking for the shared session RunEngine (issue #511):
+        # the start-document uid of the run *this scanner* owns, plus the
+        # descriptor uids belonging to it.  Foreign runs (e.g. a headless
+        # GeecsSession scan driven directly on self._session) flow through
+        # the same _on_document subscription and must not mutate GUI
+        # progress; see _on_document for the claiming/matching rules.
+        self._active_run_uid: str | None = None
+        self._active_descriptor_uids: set[str] = set()
 
         # Devices held open between reinitialize() and scan completion
         self._motor: Any | None = None
@@ -545,12 +553,52 @@ class BlueskyScanner:
     # ------------------------------------------------------------------
 
     def _on_document(self, name: str, doc: dict) -> None:
+        """Route RunEngine documents into GUI progress — owned runs only.
+
+        The session RunEngine is shared: a foreign run (e.g. a headless
+        ``GeecsSession`` scan driven directly on ``self._session``) flows
+        through this same subscription.  A start document is claimed as
+        *ours* only while this scanner is RUNNING — every scan path sets
+        RUNNING before handing its plan to the (serial) RunEngine, so a
+        start document arriving while the scanner is idle/done is foreign.
+        Event documents carry a ``descriptor`` uid rather than the run
+        start uid, so descriptors of the claimed run are collected and
+        events are matched through them; foreign events never touch
+        ``_completed_shots`` or emit ``ScanStepEvent`` s (issue #511).
+
+        Residual limitation: a foreign run squeezed onto the RunEngine
+        after this scanner enters RUNNING but before its own plan opens
+        its run would still be mis-claimed.  The RunEngine executes plans
+        serially, so that window is only the bridge's pre-plan setup; a
+        full fix would need the plan to hand its run uid out-of-band.
+        """
         if name == "start":
+            if self._current_state != self._scan_state("RUNNING"):
+                return  # foreign run — this scanner has no scan in flight
+            self._active_run_uid = doc.get("uid")
+            self._active_descriptor_uids = set()
             self._last_run_uid = doc.get("uid")
             self._note_claimed_scan_number(doc.get("scan_number"))
+        elif name == "descriptor":
+            uid = doc.get("uid")
+            if (
+                uid is not None
+                and self._active_run_uid is not None
+                and doc.get("run_start") == self._active_run_uid
+            ):
+                self._active_descriptor_uids.add(uid)
         elif name == "event":
+            if doc.get("descriptor") not in self._active_descriptor_uids:
+                return  # event from a run this scanner does not own
             self._completed_shots += 1
             self._emit_step_progress(doc)
+        elif name == "stop":
+            if (
+                self._active_run_uid is not None
+                and doc.get("run_start") == self._active_run_uid
+            ):
+                self._active_run_uid = None
+                self._active_descriptor_uids = set()
 
     def _note_claimed_scan_number(self, scan_number: Any) -> None:
         """Carry an engine-claimed scan number into the lifecycle stream.

--- a/GeecsBluesky/pyproject.toml
+++ b/GeecsBluesky/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-bluesky"
-version = "0.30.0"
+version = "0.30.1"
 description = "Bluesky / ophyd-async bridge for the GEECS control system"
 authors = ["Sam Barber <sbarber@lbl.gov>"]
 readme = "README.md"

--- a/GeecsBluesky/tests/test_bluesky_scanner_progress_and_preflight.py
+++ b/GeecsBluesky/tests/test_bluesky_scanner_progress_and_preflight.py
@@ -204,10 +204,28 @@ def _make_scanner(
     scanner._scan_number = None
     scanner._abort_requested = False
     scanner._optimization_loader = None
+    scanner._last_run_uid = None
+    scanner._active_run_uid = None
+    scanner._active_descriptor_uids = set()
     scanner._RE = SimpleNamespace(
         state="idle", abort=lambda reason=None: None, _loop=_bg_loop()
     )
     return scanner
+
+
+def _begin_owned_run(
+    scanner: BlueskyScanner, uid: str = "run-1", descriptor: str = "desc-1"
+) -> str:
+    """Claim a run as this scanner's own (state RUNNING + start/descriptor).
+
+    Mirrors a real scan: the bridge sets RUNNING before the plan reaches the
+    RunEngine, then the run's start and descriptor documents flow through
+    ``_on_document``.  Returns the descriptor uid for the event documents.
+    """
+    scanner._current_state = scanner._scan_state("RUNNING")
+    scanner._on_document("start", {"uid": uid})
+    scanner._on_document("descriptor", {"uid": descriptor, "run_start": uid})
+    return descriptor
 
 
 def _noscan_config() -> SimpleNamespace:
@@ -272,9 +290,11 @@ def test_event_documents_emit_step_progress(monkeypatch) -> None:
     scanner._total_shots = 4
     scanner._total_steps = 2
 
-    scanner._on_document("start", {"uid": "abc"})
+    desc = _begin_owned_run(scanner, uid="abc")
     for bin_number in (1, 1, 2, 2):
-        scanner._on_document("event", {"data": {"bin_number": bin_number}})
+        scanner._on_document(
+            "event", {"descriptor": desc, "data": {"bin_number": bin_number}}
+        )
 
     assert scanner._last_run_uid == "abc"
     step_events = [e for e in events if isinstance(e, _FakeStepEvent)]
@@ -293,10 +313,11 @@ def test_progress_clamps_at_total_shots_for_tail_flush(monkeypatch) -> None:
     scanner._total_shots = 2
     scanner._total_steps = 1
 
-    scanner._on_document("event", {"data": {"bin_number": 1}})
-    scanner._on_document("event", {"data": {"bin_number": 1}})
+    desc = _begin_owned_run(scanner)
+    scanner._on_document("event", {"descriptor": desc, "data": {"bin_number": 1}})
+    scanner._on_document("event", {"descriptor": desc, "data": {"bin_number": 1}})
     # Tail flush: one extra event on the flush stream (no bin_number here).
-    scanner._on_document("event", {"data": {}})
+    scanner._on_document("event", {"descriptor": desc, "data": {}})
 
     assert [e.shots_completed for e in events] == [1, 2, 2]
     assert events[-1].step_index == 0  # clamped inside [0, total_steps)
@@ -310,12 +331,15 @@ def test_progress_without_callback_or_event_type_is_silent(monkeypatch) -> None:
     """No consumer or no geecs_scanner installed → counting still works."""
     scanner = _make_scanner(_FakeSession())
     scanner._total_shots = 2
-    scanner._on_document("event", {"data": {"bin_number": 1}})  # _on_event None
+    desc = _begin_owned_run(scanner)
+    scanner._on_document(
+        "event", {"descriptor": desc, "data": {"bin_number": 1}}
+    )  # _on_event None
 
     events: list = []
     scanner._on_event = events.append
     monkeypatch.setattr(bluesky_scanner, "ScanStepEvent", None)
-    scanner._on_document("event", {"data": {"bin_number": 1}})
+    scanner._on_document("event", {"descriptor": desc, "data": {"bin_number": 1}})
 
     assert events == []
     assert scanner._completed_shots == 2
@@ -331,7 +355,8 @@ def test_progress_survives_raising_callback(monkeypatch) -> None:
     scanner = _make_scanner(_FakeSession())
     scanner._on_event = bad_callback
     scanner._total_shots = 2
-    scanner._on_document("event", {"data": {"bin_number": 1}})
+    desc = _begin_owned_run(scanner)
+    scanner._on_document("event", {"descriptor": desc, "data": {"bin_number": 1}})
     assert scanner._completed_shots == 1
 
 

--- a/GeecsBluesky/tests/test_bluesky_scanner_scan_request_seam.py
+++ b/GeecsBluesky/tests/test_bluesky_scanner_scan_request_seam.py
@@ -202,6 +202,9 @@ def _make_scanner(session: _FakeSession) -> BlueskyScanner:
     scanner._scan_number = None
     scanner._abort_requested = False
     scanner._optimization_loader = None
+    scanner._last_run_uid = None
+    scanner._active_run_uid = None
+    scanner._active_descriptor_uids = set()
     scanner._scan_request = None
     scanner._request_resolver = None
     scanner._scan_config = None
@@ -625,6 +628,72 @@ def test_start_document_from_foreign_run_is_ignored(monkeypatch) -> None:
 
     assert scanner._scan_number is None
     assert events == []
+
+
+def test_foreign_run_events_while_idle_do_not_mutate_progress() -> None:
+    """A whole foreign run while idle leaves GUI progress untouched (#511).
+
+    The session's RunEngine is shared: a headless run driven directly on
+    ``scanner._session`` emits start, descriptor, and event documents
+    through the same ``_on_document`` subscription.  None of them may
+    mutate ``_completed_shots`` or emit a ``ScanStepEvent``.
+    """
+    from geecs_bluesky.events import ScanStepEvent
+
+    session = _FakeSession()
+    scanner = _make_scanner(session)
+    events: list = []
+    scanner._on_event = events.append
+
+    scanner._on_document("start", {"uid": "f1", "scan_number": 99})
+    scanner._on_document("descriptor", {"uid": "fd1", "run_start": "f1"})
+    scanner._on_document("event", {"descriptor": "fd1", "data": {"bin_number": 1}})
+    scanner._on_document("event", {"descriptor": "fd1", "data": {"bin_number": 2}})
+    scanner._on_document("stop", {"run_start": "f1"})
+
+    assert scanner._completed_shots == 0
+    assert scanner._scan_number is None
+    assert not any(isinstance(e, ScanStepEvent) for e in events)
+    assert events == []
+
+
+def test_foreign_run_events_after_completion_do_not_mutate_progress() -> None:
+    """Foreign events after this scanner's run completed are ignored (#511).
+
+    Simulates a full owned run (RUNNING → start/descriptor/event/stop →
+    DONE, as the scan thread does), then a foreign run on the shared
+    RunEngine: the completed counters must stay frozen and no further
+    ``ScanStepEvent`` may reach the GUI.
+    """
+    from geecs_bluesky.events import ScanStepEvent
+
+    session = _FakeSession()
+    scanner = _make_scanner(session)
+    events: list = []
+    scanner._on_event = events.append
+    scanner._total_shots = 1
+    scanner._total_steps = 1
+
+    # This scanner's own run: RUNNING is set before the plan reaches the RE.
+    scanner._current_state = scanner._scan_state("RUNNING")
+    scanner._on_document("start", {"uid": "own1", "scan_number": 12})
+    scanner._on_document("descriptor", {"uid": "own-d1", "run_start": "own1"})
+    scanner._on_document("event", {"descriptor": "own-d1", "data": {"bin_number": 1}})
+    scanner._on_document("stop", {"run_start": "own1"})
+    scanner._current_state = scanner._scan_state("DONE")
+    assert scanner._completed_shots == 1
+    own_step_events = [e for e in events if isinstance(e, ScanStepEvent)]
+    assert len(own_step_events) == 1
+
+    # Foreign run after completion: nothing may move.
+    scanner._on_document("start", {"uid": "f2", "scan_number": 99})
+    scanner._on_document("descriptor", {"uid": "fd2", "run_start": "f2"})
+    scanner._on_document("event", {"descriptor": "fd2", "data": {"bin_number": 1}})
+    scanner._on_document("stop", {"run_start": "f2"})
+
+    assert scanner._completed_shots == 1
+    assert scanner._scan_number == 12
+    assert [e for e in events if isinstance(e, ScanStepEvent)] == own_step_events
 
 
 def test_delegated_totals_hook(monkeypatch) -> None:


### PR DESCRIPTION
Fixes #511

## Problem

`BlueskyScanner._on_document` guarded foreign **start** documents (the RUNNING-state guard on scan-number pickup) but accepted **every event document**: each one incremented `_completed_shots` and emitted a `ScanStepEvent`. The session RunEngine is shared, so a headless/foreign run driven directly on `scanner._session` could advance an idle or completed scanner's GUI progress and contaminate `estimate_current_completion()`.

## Fix — track the active run's ownership

- **start**: claimed as this scanner's run only while `_current_state == RUNNING` (every scan path — delegated and legacy — sets RUNNING before its plan reaches the serial RunEngine). Claiming records `_active_run_uid`, resets the descriptor set, sets `_last_run_uid`, and picks up the engine-claimed scan number. Foreign starts are ignored entirely (previously they still clobbered `_last_run_uid`).
- **descriptor**: descriptors whose `run_start` matches the active uid are collected — event documents carry a `descriptor` uid, not the run start uid, so this is the descriptor→run mapping.
- **event**: counted into `_completed_shots` / emitted as `ScanStepEvent` only when its `descriptor` uid belongs to the claimed run.
- **stop**: clears the claim when it belongs to the active run.

Residual limitation (documented in the `_on_document` docstring): a foreign run squeezed onto the RunEngine after this scanner enters RUNNING but before its own plan opens its run would still be mis-claimed. The RunEngine executes plans serially, so that window is only the bridge's pre-plan setup.

## Tests

- `tests/test_bluesky_scanner_scan_request_seam.py`: two new regression tests per the issue — a full foreign run (start/descriptor/events/stop) while idle, and a foreign run after this scanner's run completed; both assert `_completed_shots` is unchanged and no `ScanStepEvent` is emitted.
- Existing progress tests updated to simulate an owned run (RUNNING state + start/descriptor claiming) via a shared `_begin_owned_run` helper.
- Full suite: **304 passed, 16 skipped** (302 baseline + 2 new), hermetic only.

geecs-bluesky 0.30.0 → 0.30.1 + CHANGELOG entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)