### PR TITLE
Console: validate experiment names before config-store path joins

### DIFF
--- a/GEECS-Console/CHANGELOG.md
+++ b/GEECS-Console/CHANGELOG.md
@@ -4,6 +4,27 @@ All notable changes to GEECS-Console are documented here.  Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versioning is
 semantic.
 
+## [0.6.1] - 2026-07-12
+
+### Fixed
+
+- **Experiment-name path traversal in the config stores** (#513): the
+  experiment selector is editable, and four stores (`PresetStore`,
+  `SaveSetStore`, `TriggerProfileStore`, `ActionLibraryStore`) joined the
+  raw text onto the experiments root — and created parent directories on
+  save — without validating it, so a value like `../OtherExperiment`
+  escaped the intended experiment folder and could corrupt another
+  experiment's real lab configs.  Experiment-name validation is now
+  centralized in `services/_experiment_name.py::check_experiment_name`
+  (mirroring the guard `ScanVariableStore` already had, which now delegates
+  to it) and applied by all five stores **before any path join**: names
+  containing `/` or `\`, or equal to `.` / `..`, make load/save/list/delete
+  raise the store's own error with no directory created.  Pinned by
+  `tests/test_experiment_name_validation.py` (every store × traversal
+  variants, asserting the tmp configs tree stays untouched).  Making the
+  experiment combo non-editable (the other half of the issue) is deliberately
+  deferred as a main-window follow-up.
+
 ## [0.6.0] - 2026-07-12
 
 ### Added

--- a/GEECS-Console/geecs_console/services/_experiment_name.py
+++ b/GEECS-Console/geecs_console/services/_experiment_name.py
@@ -1,0 +1,45 @@
+"""Shared experiment-name validation for the per-experiment config stores.
+
+Every config store joins the experiment name onto the experiments root
+(``scanner_configs/experiments/<Experiment>/...``) and creates parent
+directories before writing.  The main window's experiment selector is
+editable, so the raw text can be a traversal string like
+``../OtherExperiment`` — joined unchecked, it escapes the intended
+experiment folder and can create or corrupt another experiment's real
+configs (issue #513).  :func:`check_experiment_name` is the one guard,
+applied by every store **before** any path join, so load/save/list/delete
+raise the store's own error before any directory is created.
+
+The semantics mirror the original ``ScanVariableStore._check_experiment``
+(the store that already had the guard): the empty string is *allowed* —
+"no experiment selected" is a separate, friendlier error each store raises
+itself — but any path separator or relative-path special name is rejected.
+"""
+
+from __future__ import annotations
+
+
+def check_experiment_name(experiment: str, error_type: type[Exception]) -> None:
+    r"""Reject an experiment name that would escape the experiments root.
+
+    Parameters
+    ----------
+    experiment : str
+        The candidate experiment folder name.  ``""`` passes — the stores
+        handle "no experiment selected" separately.
+    error_type : type of Exception
+        The calling store's error class (each store surfaces its own
+        status-bar-ready error type).
+
+    Raises
+    ------
+    Exception
+        An instance of *error_type* when the name contains a path separator
+        (``/`` or ``\\``) or is a relative-path special name (``.`` or
+        ``..``).
+    """
+    if any(sep in experiment for sep in ("/", "\\")) or experiment in (".", ".."):
+        raise error_type(
+            f"Experiment name {experiment!r} must be a plain folder name "
+            "(no path separators)."
+        )

--- a/GEECS-Console/geecs_console/services/action_library_store.py
+++ b/GEECS-Console/geecs_console/services/action_library_store.py
@@ -36,6 +36,7 @@ from typing import Optional
 import yaml
 from pydantic import ValidationError
 
+from geecs_console.services._experiment_name import check_experiment_name
 from geecs_console.services.configs import _configs_base
 from geecs_schemas import ActionPlan, ActionPlanLibrary
 from geecs_schemas.convert import SchemaConversionError, convert_action_library
@@ -116,12 +117,20 @@ class ActionLibraryStore:
     # ------------------------------------------------------------------
 
     def _library_path(self) -> Optional[Path]:
-        """Return the library file path, or ``None`` offline/unselected."""
+        """Return the library file path, or ``None`` offline/unselected.
+
+        Raises
+        ------
+        ActionLibraryStoreError
+            When the experiment name would escape the experiments root
+            (issue #513) — checked before any path join.
+        """
         root = self._experiments_root
         if root is None:
             root = _configs_base()
         if root is None or not self._experiment:
             return None
+        check_experiment_name(self._experiment, ActionLibraryStoreError)
         return root / self._experiment / ACTION_FOLDER / LIBRARY_FILE
 
     def _library_path_or_raise(self) -> Path:
@@ -135,7 +144,8 @@ class ActionLibraryStore:
         Raises
         ------
         ActionLibraryStoreError
-            When the configs repo is not found or no experiment is selected.
+            When the configs repo is not found, no experiment is selected,
+            or the experiment name would escape the experiments root.
         """
         root = self._experiments_root
         if root is None:
@@ -147,6 +157,7 @@ class ActionLibraryStore:
             )
         if not self._experiment:
             raise ActionLibraryStoreError("No experiment selected.")
+        check_experiment_name(self._experiment, ActionLibraryStoreError)
         return root / self._experiment / ACTION_FOLDER / LIBRARY_FILE
 
     @staticmethod

--- a/GEECS-Console/geecs_console/services/presets.py
+++ b/GEECS-Console/geecs_console/services/presets.py
@@ -26,6 +26,7 @@ from typing import Optional
 import yaml
 from pydantic import ValidationError
 
+from geecs_console.services._experiment_name import check_experiment_name
 from geecs_console.services.configs import _configs_base
 from geecs_schemas import ScanRequest
 
@@ -82,12 +83,20 @@ class PresetStore:
     # ------------------------------------------------------------------
 
     def _folder(self) -> Optional[Path]:
-        """Return the experiment's presets dir, or ``None`` offline/unselected."""
+        """Return the experiment's presets dir, or ``None`` offline/unselected.
+
+        Raises
+        ------
+        PresetStoreError
+            When the experiment name would escape the experiments root
+            (issue #513) — checked before any path join.
+        """
         root = self._experiments_root
         if root is None:
             root = _configs_base()
         if root is None or not self._experiment:
             return None
+        check_experiment_name(self._experiment, PresetStoreError)
         return root / self._experiment / PRESET_FOLDER
 
     def _folder_or_raise(self) -> Path:
@@ -101,7 +110,8 @@ class PresetStore:
         Raises
         ------
         PresetStoreError
-            When the configs repo is not found or no experiment is selected.
+            When the configs repo is not found, no experiment is selected,
+            or the experiment name would escape the experiments root.
         """
         root = self._experiments_root
         if root is None:
@@ -113,6 +123,7 @@ class PresetStore:
             )
         if not self._experiment:
             raise PresetStoreError("No experiment selected.")
+        check_experiment_name(self._experiment, PresetStoreError)
         return root / self._experiment / PRESET_FOLDER
 
     def _path(self, name: str) -> Path:
@@ -154,13 +165,19 @@ class PresetStore:
     # ------------------------------------------------------------------
 
     def list_names(self) -> list[str]:
-        """List the saved preset names, sorted; never raises.
+        """List the saved preset names, sorted.
 
         Returns
         -------
         list of str
             YAML file stems in the presets dir — empty when the configs
             repo, experiment folder, or presets dir is missing.
+
+        Raises
+        ------
+        PresetStoreError
+            When the experiment name would escape the experiments root
+            (issue #513); a merely *missing* folder is not an error.
         """
         folder = self._folder()
         if folder is None or not folder.is_dir():

--- a/GEECS-Console/geecs_console/services/save_set_store.py
+++ b/GEECS-Console/geecs_console/services/save_set_store.py
@@ -35,6 +35,7 @@ from typing import Optional
 import yaml
 from pydantic import ValidationError
 
+from geecs_console.services._experiment_name import check_experiment_name
 from geecs_console.services.configs import SAVE_SET_FOLDER, _configs_base
 from geecs_schemas import SaveSet
 
@@ -95,10 +96,18 @@ class SaveSetStore:
         return _configs_base()
 
     def _folder(self) -> Optional[Path]:
-        """Return the experiment's save-set dir, or ``None`` offline/unselected."""
+        """Return the experiment's save-set dir, or ``None`` offline/unselected.
+
+        Raises
+        ------
+        SaveSetStoreError
+            When the experiment name would escape the experiments root
+            (issue #513) — checked before any path join.
+        """
         root = self._root()
         if root is None or not self._experiment:
             return None
+        check_experiment_name(self._experiment, SaveSetStoreError)
         return root / self._experiment / SAVE_SET_FOLDER
 
     def _folder_or_raise(self) -> Path:
@@ -112,7 +121,8 @@ class SaveSetStore:
         Raises
         ------
         SaveSetStoreError
-            When the configs repo is not found or no experiment is selected.
+            When the configs repo is not found, no experiment is selected,
+            or the experiment name would escape the experiments root.
         """
         root = self._root()
         if root is None:
@@ -122,6 +132,7 @@ class SaveSetStore:
             )
         if not self._experiment:
             raise SaveSetStoreError("No experiment selected.")
+        check_experiment_name(self._experiment, SaveSetStoreError)
         return root / self._experiment / SAVE_SET_FOLDER
 
     def _path(self, name: str) -> Path:
@@ -164,13 +175,19 @@ class SaveSetStore:
     # ------------------------------------------------------------------
 
     def list_names(self) -> list[str]:
-        """List the saved save-set names, sorted; never raises.
+        """List the saved save-set names, sorted.
 
         Returns
         -------
         list of str
             YAML file stems in the ``save_devices`` dir — empty when the
             configs repo, experiment folder, or save-set dir is missing.
+
+        Raises
+        ------
+        SaveSetStoreError
+            When the experiment name would escape the experiments root
+            (issue #513); a merely *missing* folder is not an error.
         """
         folder = self._folder()
         if folder is None or not folder.is_dir():

--- a/GEECS-Console/geecs_console/services/scan_variable_store.py
+++ b/GEECS-Console/geecs_console/services/scan_variable_store.py
@@ -35,6 +35,7 @@ from typing import Optional
 import yaml
 from pydantic import ValidationError
 
+from geecs_console.services._experiment_name import check_experiment_name
 from geecs_console.services.configs import _configs_base
 from geecs_schemas import ScanVariables
 
@@ -113,18 +114,17 @@ class ScanVariableStore:
     def _check_experiment(self) -> None:
         """Reject an experiment name that would escape the experiments root.
 
+        Delegates to the shared
+        :func:`~geecs_console.services._experiment_name.check_experiment_name`
+        guard every config store applies before any path join (issue #513).
+
         Raises
         ------
         ScanVariableStoreError
             When the experiment name contains a path separator or is a
             relative-path special name.
         """
-        name = self._experiment
-        if any(sep in name for sep in ("/", "\\")) or name in (".", ".."):
-            raise ScanVariableStoreError(
-                f"Experiment name {name!r} must be a plain folder name "
-                "(no path separators)."
-            )
+        check_experiment_name(self._experiment, ScanVariableStoreError)
 
     def _folder(self) -> Optional[Path]:
         """Return the ``scan_devices/`` dir, or ``None`` offline/unselected."""

--- a/GEECS-Console/geecs_console/services/trigger_profile_store.py
+++ b/GEECS-Console/geecs_console/services/trigger_profile_store.py
@@ -33,6 +33,7 @@ from typing import Optional
 import yaml
 from pydantic import ValidationError
 
+from geecs_console.services._experiment_name import check_experiment_name
 from geecs_console.services.configs import TRIGGER_FOLDER, _configs_base
 from geecs_schemas import TriggerProfile
 from geecs_schemas.convert import SchemaConversionError, convert_shot_control
@@ -88,12 +89,20 @@ class TriggerProfileStore:
     # ------------------------------------------------------------------
 
     def _folder(self) -> Optional[Path]:
-        """Return the shot-control dir, or ``None`` offline/unselected."""
+        """Return the shot-control dir, or ``None`` offline/unselected.
+
+        Raises
+        ------
+        TriggerProfileStoreError
+            When the experiment name would escape the experiments root
+            (issue #513) — checked before any path join.
+        """
         root = self._experiments_root
         if root is None:
             root = _configs_base()
         if root is None or not self._experiment:
             return None
+        check_experiment_name(self._experiment, TriggerProfileStoreError)
         return root / self._experiment / TRIGGER_FOLDER
 
     def _folder_or_raise(self) -> Path:
@@ -107,7 +116,8 @@ class TriggerProfileStore:
         Raises
         ------
         TriggerProfileStoreError
-            When the configs repo is not found or no experiment is selected.
+            When the configs repo is not found, no experiment is selected,
+            or the experiment name would escape the experiments root.
         """
         root = self._experiments_root
         if root is None:
@@ -119,6 +129,7 @@ class TriggerProfileStore:
             )
         if not self._experiment:
             raise TriggerProfileStoreError("No experiment selected.")
+        check_experiment_name(self._experiment, TriggerProfileStoreError)
         return root / self._experiment / TRIGGER_FOLDER
 
     def _path(self, name: str) -> Path:
@@ -199,13 +210,19 @@ class TriggerProfileStore:
     # ------------------------------------------------------------------
 
     def list_names(self) -> list[str]:
-        """List the saved profile names, sorted; never raises.
+        """List the saved profile names, sorted.
 
         Returns
         -------
         list of str
             YAML file stems in the shot-control dir — empty when the configs
             repo, experiment folder, or shot-control dir is missing.
+
+        Raises
+        ------
+        TriggerProfileStoreError
+            When the experiment name would escape the experiments root
+            (issue #513); a merely *missing* folder is not an error.
         """
         folder = self._folder()
         if folder is None or not folder.is_dir():

--- a/GEECS-Console/pyproject.toml
+++ b/GEECS-Console/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-console"
-version = "0.6.0"
+version = "0.6.1"
 description = "Greenfield PySide6 operator console for GEECS (Bluesky/gateway architecture)"
 authors = ["Sam Barber <sbarber@lbl.gov>"]
 readme = "README.md"

--- a/GEECS-Console/tests/test_experiment_name_validation.py
+++ b/GEECS-Console/tests/test_experiment_name_validation.py
@@ -1,0 +1,174 @@
+"""Experiment-name traversal guard across every config store (issue #513).
+
+The main window's experiment selector is editable, so the raw text a store
+receives can be a traversal string like ``../OtherExperiment``.  Every store
+joins the experiment onto the experiments root and (on save) creates parent
+directories — joined unchecked, a traversal name escapes the intended
+experiment folder and can corrupt another experiment's real lab configs.
+
+These tests pin the shared guard
+(:func:`geecs_console.services._experiment_name.check_experiment_name`,
+mirroring the original ``ScanVariableStore._check_experiment``): for each
+store and each hostile name, every operation raises the store's own error
+type **and leaves the tmp configs root untouched** — no directory is ever
+created on the escape path.
+"""
+
+import pytest
+
+from geecs_console.services.action_library_store import (
+    ActionLibraryStore,
+    ActionLibraryStoreError,
+)
+from geecs_console.services.presets import PresetStore, PresetStoreError
+from geecs_console.services.save_set_store import SaveSetStore, SaveSetStoreError
+from geecs_console.services.scan_variable_store import (
+    ScanVariableStore,
+    ScanVariableStoreError,
+    empty_catalog,
+)
+from geecs_console.services.trigger_profile_store import (
+    TriggerProfileStore,
+    TriggerProfileStoreError,
+)
+from geecs_schemas import (
+    ActionPlan,
+    SaveSet,
+    SaveSetEntry,
+    ScanRequest,
+    ScanRequestMode,
+    TriggerProfile,
+)
+
+# Names that would escape (or alias) the experiments root when joined.
+TRAVERSAL_NAMES = [
+    "../OtherExperiment",
+    "..",
+    ".",
+    "a/b",
+    "a\\b",
+]
+
+GUARD_MESSAGE = "plain folder name"
+
+
+def tree(tmp_path):
+    """Every path under *tmp_path*, relative — the untouched tree is []."""
+    return sorted(p.relative_to(tmp_path) for p in tmp_path.rglob("*"))
+
+
+def minimal_request() -> ScanRequest:
+    return ScanRequest(mode=ScanRequestMode.NOSCAN)
+
+
+def minimal_save_set() -> SaveSet:
+    return SaveSet(name="diag", entries=[SaveSetEntry(device="Dev1", images=True)])
+
+
+@pytest.mark.parametrize("bad", TRAVERSAL_NAMES)
+class TestTraversalNamesRaiseAndCreateNothing:
+    """Each store: every op raises its own error; the tmp tree stays empty."""
+
+    def test_preset_store(self, tmp_path, bad):
+        store = PresetStore(bad, experiments_root=tmp_path)
+        for operation in (
+            store.list_names,
+            lambda: store.load("align"),
+            lambda: store.save("align", minimal_request()),
+            lambda: store.delete("align"),
+        ):
+            with pytest.raises(PresetStoreError, match=GUARD_MESSAGE):
+                operation()
+        assert tree(tmp_path) == []
+
+    def test_save_set_store(self, tmp_path, bad):
+        store = SaveSetStore(bad, experiments_root=tmp_path)
+        for operation in (
+            store.list_names,
+            lambda: store.load("diag"),
+            lambda: store.save("diag", minimal_save_set()),
+            lambda: store.delete("diag"),
+            lambda: store.rename("diag", "diag2"),
+        ):
+            with pytest.raises(SaveSetStoreError, match=GUARD_MESSAGE):
+                operation()
+        assert tree(tmp_path) == []
+
+    def test_trigger_profile_store(self, tmp_path, bad):
+        store = TriggerProfileStore(bad, experiments_root=tmp_path)
+        for operation in (
+            store.list_names,
+            lambda: store.load("normal"),
+            lambda: store.save("normal", TriggerProfile(name="normal")),
+            lambda: store.delete("normal"),
+        ):
+            with pytest.raises(TriggerProfileStoreError, match=GUARD_MESSAGE):
+                operation()
+        assert tree(tmp_path) == []
+
+    def test_action_library_store(self, tmp_path, bad):
+        store = ActionLibraryStore(bad, experiments_root=tmp_path)
+        plan = ActionPlan(steps=[{"do": "wait", "seconds": 1.0}])
+        for operation in (
+            store.load_library,
+            lambda: store.save("plan", plan),
+            lambda: store.delete("plan"),
+        ):
+            with pytest.raises(ActionLibraryStoreError, match=GUARD_MESSAGE):
+                operation()
+        # list_names documents a never-raise contract: it degrades to empty
+        # (the guard fires inside load_library and is caught) — and still
+        # never touches the escape path.
+        assert store.list_names() == []
+        assert tree(tmp_path) == []
+
+    def test_scan_variable_store(self, tmp_path, bad):
+        store = ScanVariableStore(bad, experiments_root=tmp_path)
+        for operation in (
+            store.load,
+            lambda: store.save(empty_catalog()),
+        ):
+            with pytest.raises(ScanVariableStoreError, match=GUARD_MESSAGE):
+                operation()
+        assert tree(tmp_path) == []
+
+
+class TestEmptyExperimentStillMeansUnselected:
+    """ "" is not a traversal name: listing degrades, writing raises, no dirs."""
+
+    def test_listing_degrades_to_empty(self, tmp_path):
+        assert PresetStore("", experiments_root=tmp_path).list_names() == []
+        assert SaveSetStore("", experiments_root=tmp_path).list_names() == []
+        assert TriggerProfileStore("", experiments_root=tmp_path).list_names() == []
+        assert ActionLibraryStore("", experiments_root=tmp_path).list_names() == []
+        catalog = ScanVariableStore("", experiments_root=tmp_path).load()
+        assert catalog == empty_catalog()
+        assert tree(tmp_path) == []
+
+    def test_saving_raises_no_experiment_selected(self, tmp_path):
+        with pytest.raises(PresetStoreError, match="No experiment selected"):
+            PresetStore("", experiments_root=tmp_path).save("align", minimal_request())
+        with pytest.raises(SaveSetStoreError, match="No experiment selected"):
+            SaveSetStore("", experiments_root=tmp_path).save("diag", minimal_save_set())
+        with pytest.raises(TriggerProfileStoreError, match="No experiment selected"):
+            TriggerProfileStore("", experiments_root=tmp_path).save(
+                "normal", TriggerProfile(name="normal")
+            )
+        with pytest.raises(ActionLibraryStoreError, match="No experiment selected"):
+            ActionLibraryStore("", experiments_root=tmp_path).save(
+                "plan", ActionPlan(steps=[{"do": "wait", "seconds": 1.0}])
+            )
+        with pytest.raises(ScanVariableStoreError, match="No experiment selected"):
+            ScanVariableStore("", experiments_root=tmp_path).save(empty_catalog())
+        assert tree(tmp_path) == []
+
+
+class TestPlainNamesStillWork:
+    """The guard does not over-reject: a dotted-but-plain name is fine."""
+
+    def test_dotted_plain_name_saves_inside_its_own_folder(self, tmp_path):
+        store = PresetStore("HTU.v2", experiments_root=tmp_path)
+        path = store.save("align", minimal_request())
+        assert path.is_file()
+        assert path.parent.parent == tmp_path / "HTU.v2"
+        assert store.list_names() == ["align"]


### PR DESCRIPTION
Fixes #513

## What

The experiment selector in the Console main window is editable, and four config stores (`PresetStore`, `SaveSetStore`, `TriggerProfileStore`, `ActionLibraryStore`) used the raw combo text as a path segment — and `mkdir(parents=True)`'d before writing — without validating it. An experiment string like `../OtherExperiment` therefore traversed out of the intended config folder and could create/corrupt another experiment's real lab configs. `ScanVariableStore` already had the right guard (`_check_experiment`); the others did not.

## Fix

- **New shared helper** `geecs_console/services/_experiment_name.py::check_experiment_name(experiment, error_type)` — mirrors the `ScanVariableStore._check_experiment` semantics exactly: rejects names containing `/` or `\`, or equal to `.` / `..`; the empty string still means "no experiment selected" and keeps its separate, friendlier handling.
- **Applied in all five stores before any path join** (`_folder()` / `_folder_or_raise()` / `_library_path*()`), each raising its own store error type, so load/save/list/delete fail cleanly **before any directory is created**. `ScanVariableStore._check_experiment` now delegates to the shared helper.
- `ActionLibraryStore.list_names` keeps its documented never-raise contract (the guard fires inside `load_library` and is caught → empty listing, escape path untouched).

## Tests

New `tests/test_experiment_name_validation.py` (28 tests): every store × traversal variants (`../OtherExperiment`, `..`, `.`, `a/b`, `a\b`) asserts the operation raises the store's error type **and the tmp configs tree is left completely untouched**; `""` still degrades/raises as "no experiment selected"; a dotted-but-plain name (`HTU.v2`) is not over-rejected.

Full suite: 552 passed (524 baseline + 28 new), exit 0, repeated runs, offscreen.

## Deliberately deferred follow-ups

- **Combo editability** (the issue's "also consider making the experiment combo non-editable"): deliberately not touched here — `app/main_window.py` / the `.ui` are being worked on in a parallel session, and whether free-form experiment names are needed is a product question. With this PR the stores are safe regardless of what the combo allows; a window-side guard (or non-editable combo) is a follow-up. Note `main_window.py`'s `_refresh_preset_combo` calls `list_names()` unguarded, so a traversal string typed into the combo now surfaces as a store error instead of silently listing/creating outside the experiment folder.
- `services/configs.py::ConsoleConfigs` also joins the raw experiment name (read-only, no mkdir — listing only), outside the issue's store list; worth folding onto the same helper when next touched.

Version: 0.6.0 → 0.6.1, CHANGELOG entry added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)