### PR TITLE
docs: TILED_SETUP.md — server upgraded to 0.2.14 (migration runbook, no-web-UI finding)

### DIFF
--- a/GeecsBluesky/TILED_SETUP.md
+++ b/GeecsBluesky/TILED_SETUP.md
@@ -9,19 +9,55 @@ from any Python session on the network without touching the raw data files.
 
 ---
 
-## Infrastructure State (last hardware-verified 2026-05-08)
+## Infrastructure State (last hardware-verified 2026-07-12)
 
 ### DB Server — `192.168.6.14`
 
 - OS: Ubuntu 22.04.5 LTS
 - Python: 3.10.12
-- Tiled: 0.2.9 installed via `pip install 'tiled[server]'` into `~/.local`
+- Tiled: **0.2.14** (upgraded from 0.2.9 on 2026-07-12) installed via
+  `pip install --user 'tiled[server]'` into `~/.local`
 - Running as systemd service: `sudo systemctl status tiled`
+  (`tiled serve config ~/tiled/config.yml`; auth + host/port + trees all
+  live in that config file, not in the unit)
 - Catalog DB: `~/tiled/catalog.db` (SQLite, metadata index)
 - Tabular storage: `~/tiled/tabular.db` (SQLite, event tables)
 - File storage: `~/tiled/storage/`
-- API key: stable — set via `TILED_SINGLE_USER_API_KEY` env var, stored in
-  `~/.config/geecs_python_api/config.ini` on all client machines
+- API key: stable — `single_user_api_key` in `~/tiled/config.yml` on the
+  server; stored in `~/.config/geecs_python_api/config.ini` on all client
+  machines
+
+### Upgrading the server (verified 2026-07-12, 0.2.9 → 0.2.14)
+
+```bash
+sudo systemctl stop tiled
+cp ~/tiled/catalog.db ~/tiled/catalog.db.bak-YYYYMMDD
+cp ~/tiled/tabular.db ~/tiled/tabular.db.bak-YYYYMMDD
+python3 -m pip install --user -U 'tiled[server]'
+sudo systemctl start tiled
+```
+
+**Expect a catalog-schema migration**: with `init_if_not_exists: true` in
+the serve config, the service crash-loops after a version jump until the
+alembic migration is applied (journal shows `DatabaseUpgradeNeeded` /
+`CalledProcessError` from `tiled catalog init`). Fix:
+
+```bash
+python3 -m tiled catalog upgrade-database 'sqlite+aiosqlite:////home/<user>/tiled/catalog.db'
+sudo systemctl start tiled
+```
+
+Post-upgrade verification from any client: `/api/v1/` reports the new
+`library_version`; existing runs read back (`run["primary"].read()` — the
+pattern `tiled_export.py` / `tiled_readback.py` use — survived 0.2.14's
+composite-container change; ad-hoc `run["primary"]["data"]` does **not**,
+use `.base` for raw node access).
+
+**There is no web UI in the pip wheel** (verified 0.2.14: no built
+frontend assets ship in the package). The root page is a minimal fallback;
+Tiled's React catalog browser comes only with their Docker distribution or
+a separately built frontend. The GEECS quick-look path is the scan browser
+(GEECS-Console), not Tiled's UI.
 
 ### Client machines
 


### PR DESCRIPTION
Documentation-only. Records tonight's live server upgrade on 192.168.6.14:

- Tiled 0.2.9 → 0.2.14 (pip --user, systemd service)
- The catalog-schema migration gotcha (`DatabaseUpgradeNeeded` crash-loop with `init_if_not_exists: true`) and its fix (`tiled catalog upgrade-database`)
- Post-upgrade verification: 149 runs intact, repo read pattern (`run["primary"].read()`) unaffected by the composite-container change, console health chips green
- Finding: the pip wheel ships no web UI on any version — Tiled's React browser is Docker-distribution only; the GEECS quick-look path is the planned scan browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)