### PR TITLE
feat(bluesky): wire optimization into the delegated ScanRequest path (M4 step iii)

### DIFF
--- a/GeecsBluesky/CHANGELOG.md
+++ b/GeecsBluesky/CHANGELOG.md
@@ -4,6 +4,35 @@ All notable changes to `geecs-bluesky` are documented here.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.31.0] - 2026-07-12
+
+### Added
+
+- **Optimize-mode ScanRequests run through the delegated GUI-bridge path**
+  (M4 GUI-submission step iii). `BlueskyScanner.reinitialize(ScanRequest)`
+  no longer refuses `mode: optimize`: the scan thread hands the request's
+  `OptimizationSpec` to the GUI-injected `optimization_loader` (the same
+  seam as legacy exec_config optimization — the Xopt/evaluator stack stays
+  in `geecs_scanner.optimization`; this package still never imports it,
+  now pinned by an AST-level test) and threads the returned bridge's
+  `bind` into `run_scan_request` as the new `optimization_binder` hook.
+  The runner claims the scan itself just before binding — after every
+  fail-fast resolution and device connect — because the binder's
+  analyzers need the real `ScanTag`; it then passes the pre-claimed
+  number/folder to `session.optimize` and owns the `scan.log` attach
+  (the session only self-attaches when *it* claimed). The bridge's
+  optional `finish()` bookkeeping (legacy `xopt_dump.yaml`) runs after a
+  successful run. Preserved behaviors: fail-fast pre-claim name
+  resolution (VOCS catalog names now validate at reinitialize, pseudo
+  variables refused there), actions-skipped-with-warning on optimize
+  (recorded under `skipped_action_plans`), and the `db_scan_runtime`
+  metadata. The GUI progress-totals hook now fires on the optimize path
+  too, with the `(max_iterations, max_iterations × shots_per_step)`
+  upper bound — the suggester may stop early. Reinitializing an optimize
+  request on a scanner constructed *without* an `optimization_loader` is
+  still refused with an explicit error (headless callers keep using
+  `GeecsSession.run(request, resolver, objective=..., suggester=...)`).
+
 ## [0.30.1] - 2026-07-12
 
 ### Fixed

--- a/GeecsBluesky/CLAUDE.md
+++ b/GeecsBluesky/CLAUDE.md
@@ -437,9 +437,32 @@ too.  The bridge contributes its two seams via runner hooks:
 `None` aborts; dropped devices are left connected — the runner's `finally`
 owns disconnection) and `on_scan_start(total_steps, total_shots)` (GUI
 progress totals).  The bridge never pre-claims on this path —
-`session.scan` claims and self-attaches `scan.log`.  Optimize-mode
-requests are still refused at reinitialize until GUI-submission step (iii)
-wires the `optimization_loader` into the delegated path.  Experiment defaults
+`session.scan` claims and self-attaches `scan.log`.  **As of 0.31.0 (M4
+step iii) optimize-mode requests run through the delegated path too**:
+`reinitialize` requires the GUI-injected `optimization_loader` for
+`mode: optimize` (refused with an explicit error otherwise — headless
+callers use `GeecsSession.run(request, resolver, objective=...,
+suggester=...)`) and fail-fast validates the VOCS catalog names; the scan
+thread calls `optimization_loader(request.optimization)` — the loader's
+one argument is the resolved `OptimizationSpec` on this path, vs the
+optimizer-YAML path string on the legacy exec_config path — and threads
+the returned bridge's `bind` into `run_scan_request` as its
+`optimization_binder` hook.  Because the binder's analyzers need the real
+`ScanTag`, the **runner claims the scan itself just before binding**
+(after every fail-fast resolution and device connect — the one delegated
+path where the claim is not inside the session call) and passes the
+pre-claimed number/folder to `session.optimize`, owning the `scan.log`
+attach; the bridge's optional `finish()` (legacy `xopt_dump.yaml`) runs
+after a successful run.  `on_scan_start` fires on the optimize path with
+the `(max_iterations, max_iterations × shots_per_step)` upper bound (the
+suggester may stop early); the operator-dialog `preflight` still does not
+run on optimize (later seam).  Optimizer `device_requirements`
+auto-provisioning is deliberately **not** wired on this path — the
+request's save sets must name the objective's diagnostics (schema-world
+explicitness; the legacy exec_config path keeps its merge).  The
+dependency direction (no `geecs_scanner` import anywhere in this package)
+is pinned by an AST-level test in the scan-request seam suite.
+Experiment defaults
 (`experiment_defaults.yaml`) fill request fields left unset — never
 overriding explicit values — and every applied default is recorded into
 the run metadata for provenance (closeout defaults append *after* the
@@ -551,13 +574,16 @@ Remaining items are features/tuning, not architecture — see
 - **Background scan mode not implemented.**  Optimization runs as a scan via
   `GeecsSession.optimize` (adaptive scan: iteration = bin, same schema/data
   tree as any scan — see `plans/optimize.py`), both headless (suggester +
-  objective in hand) and from the GUI: `BlueskyScanner` handles OPTIMIZATION
-  scan mode through a GUI-injected `optimization_loader`
+  objective in hand) and from the GUI: `BlueskyScanner` handles optimization
+  through a GUI-injected `optimization_loader`
   (`geecs_scanner.optimization.session_bridge`), which runs the config-driven
-  Xopt 3.1 / evaluator / ScanAnalysis stack against the session's bin rows.
-  The evaluator seam is `EvaluatorDataSource` in
+  Xopt 3.1 / evaluator / ScanAnalysis stack against the session's bin rows —
+  on the legacy exec_config path (loader argument: the optimizer-YAML path)
+  and, since 0.31.0, on the delegated ScanRequest path (loader argument: the
+  request's resolved `OptimizationSpec`; see the engine-consolidation
+  section).  The evaluator seam is `EvaluatorDataSource` in
   `geecs_scanner.optimization.base_evaluator`; this package stays free of any
-  geecs_scanner import (dependency direction).
+  geecs_scanner import (dependency direction, pinned by an AST-level test).
 - **Pre/post-scan action sequences run on the ScanRequest path only.**
   `GeecsSession.run(request)` executes setup/per_step/closeout ActionPlans
   (0.23.0), and since 0.28.0 the GUI bridge's delegated ScanRequest path

--- a/GeecsBluesky/geecs_bluesky/scan_request_runner.py
+++ b/GeecsBluesky/geecs_bluesky/scan_request_runner.py
@@ -20,9 +20,10 @@
   :class:`~geecs_bluesky.session.GeecsSession`.
 
 Deliberate v1 gaps (validated, then refused loudly — never silently wrong):
-pseudo scan variables, ``all_scalars``, and optimize without an injected
-``objective``/``suggester`` (the Xopt stack lives in
-``geecs_scanner.optimization``, which this package must not import).
+pseudo scan variables, ``all_scalars``, and optimize without either an
+injected ``objective``/``suggester`` pair or an ``optimization_binder``
+(the Xopt stack lives in ``geecs_scanner.optimization``, which this package
+must not import — the binder is the GUI bridge's injected seam for it).
 
 Configs speak GEECS device/variable names, never PVs (ratified convention);
 PV derivation stays inside the device factories.
@@ -33,6 +34,7 @@ from __future__ import annotations
 import itertools
 import logging
 from collections.abc import Mapping
+from contextlib import nullcontext
 from typing import Any, Callable
 
 # ConfigsRepoResolver is re-exported: the existing import surface
@@ -50,6 +52,8 @@ from geecs_bluesky.db_runtime import (
 from geecs_bluesky.exceptions import GeecsConfigurationError
 from geecs_bluesky.models.shot_control import ShotControlWrites
 from geecs_bluesky.plans.action_compiler import compile_action_plan
+from geecs_bluesky.plans.run_wrapper import claim_scan
+from geecs_bluesky.scan_log import scan_log
 from geecs_schemas import (
     ActionBindings,
     ActionPlan,
@@ -845,6 +849,7 @@ def run_scan_request(
     *,
     objective: Any | None = None,
     suggester: Any | None = None,
+    optimization_binder: Callable[..., tuple[Any, Any]] | None = None,
     preflight: Callable[[list, bool], list | None] | None = None,
     on_scan_start: Callable[[int, int], None] | None = None,
 ) -> str | None:
@@ -875,9 +880,22 @@ def run_scan_request(
     resolver :
         Resolves the request's names to schema models.
     objective, suggester :
-        Required for ``optimize`` mode (see the module docstring's gap
-        list): the evaluator/generator specs cannot be instantiated in this
-        package.
+        Ready-made optimization callables for ``optimize`` mode (see the
+        module docstring's gap list): the evaluator/generator specs cannot
+        be instantiated in this package.
+    optimization_binder :
+        Alternative to *objective*/*suggester* for ``optimize`` mode: a
+        scanner-layer hook (the GUI bridge's injected
+        ``optimization_loader`` seam) called as
+        ``binder(devices=..., scan_tag=..., scan_folder=...) ->
+        (objective, suggester)`` with the connected movables + detectors
+        and the freshly claimed scan.  Because the binder's stack needs
+        the real ``ScanTag`` (its analyzers load natively saved files by
+        tag), the runner claims the scan itself just before binding —
+        after every fail-fast resolution and device connect — and passes
+        the pre-claimed number/folder to ``session.optimize`` (attaching
+        ``scan.log`` here, since the session only self-attaches when *it*
+        claimed).  Ignored when *objective* and *suggester* are given.
     preflight :
         Optional scanner-layer hook (the GUI bridge's operator-dialog
         seam), called pre-claim with the fully assembled detector list and
@@ -889,7 +907,9 @@ def run_scan_request(
     on_scan_start :
         Optional progress-totals hook (the GUI bridge's progress seam),
         called with ``(total_steps, total_shots)`` immediately before the
-        session scan starts.  Not called on the optimize path.
+        session scan starts.  On the optimize path the totals are the
+        upper bound ``(max_iterations, max_iterations × shots_per_step)``
+        — the suggester may stop early.
 
     Returns
     -------
@@ -900,7 +920,7 @@ def run_scan_request(
     ------
     NotImplementedError
         Pseudo scan variables, and optimize mode without an injected
-        objective/suggester or with action bindings (the documented v1
+        objective/suggester or optimization_binder (the documented v1
         gaps — validated first, refused loudly).
     GeecsConfigurationError
         Unresolvable names, or a step/noscan request without a save set.
@@ -932,6 +952,8 @@ def run_scan_request(
             mode,
             objective=objective,
             suggester=suggester,
+            optimization_binder=optimization_binder,
+            on_scan_start=on_scan_start,
             applied_defaults=applied_defaults,
             skipped_actions=skipped_actions,
         )
@@ -1114,6 +1136,8 @@ def _run_optimize_request(
     *,
     objective: Any | None,
     suggester: Any | None,
+    optimization_binder: Callable[..., tuple[Any, Any]] | None = None,
+    on_scan_start: Callable[[int, int], None] | None = None,
     applied_defaults: dict[str, Any] | None = None,
     skipped_actions: dict[str, list[str]] | None = None,
 ) -> str | None:
@@ -1124,8 +1148,8 @@ def _run_optimize_request(
     ``max_iterations``, and ``move_to_best_on_finish`` (→ ``on_finish``).
     The variable *bounds*, ``objectives``/``observables``/``constraints``,
     and the evaluator/generator specs are the suggester's business — they
-    are **not** consumed here (documented gap; the injected suggester is
-    expected to have been built from them by the caller's stack).
+    are **not** consumed here (the injected objective/suggester — or the
+    binder's stack — is expected to have been built from them).
 
     Parameters
     ----------
@@ -1134,7 +1158,14 @@ def _run_optimize_request(
     mode :
         ``"strict"`` or ``"free_run"``.
     objective, suggester :
-        The ready-made optimization callables (required).
+        The ready-made optimization callables.
+    optimization_binder, on_scan_start :
+        As in :func:`run_scan_request`.  With a binder (and no ready-made
+        callables) the runner claims the scan itself, pre-bind, so the
+        binder's analyzers get the real ``ScanTag`` — mirroring the legacy
+        exec_config optimization path; the claim still happens *after*
+        every fail-fast resolution and device connect, and the runner then
+        owns the ``scan.log`` attach for the run.
 
     Returns
     -------
@@ -1144,17 +1175,19 @@ def _run_optimize_request(
     Raises
     ------
     NotImplementedError
-        When *objective* or *suggester* is missing.
+        When *objective* or *suggester* is missing and no
+        *optimization_binder* was given.
     """
     spec = request.optimization
     assert spec is not None  # guaranteed by ScanRequest validation
-    if objective is None or suggester is None:
+    if (objective is None or suggester is None) and optimization_binder is None:
         raise NotImplementedError(
             "optimize-mode ScanRequest execution needs a ready-made "
             "objective and suggester (run(request, resolver, objective=..., "
-            "suggester=...)): instantiating them from the request's "
-            "evaluator/generator specs lives in the GUI optimization stack "
-            "(geecs_scanner.optimization), which geecs_bluesky cannot import"
+            "suggester=...)) or an optimization_binder: instantiating them "
+            "from the request's evaluator/generator specs lives in the GUI "
+            "optimization stack (geecs_scanner.optimization), which "
+            "geecs_bluesky cannot import"
         )
 
     detectors: list = []
@@ -1216,19 +1249,63 @@ def _run_optimize_request(
             "db_scalars": "applied",
             "background_telemetry": "not_run_in_optimize",
         }
-        uid, _history = session.optimize(
-            variables=variables,
-            detectors=detectors,
-            objective=objective,
-            suggester=suggester,
-            shots_per_iteration=request.shots_per_step,
-            max_iterations=spec.max_iterations or 20,
-            mode=mode,
-            description=request.description,
-            md=md,
-            on_finish="best" if spec.move_to_best_on_finish else "hold",
-        )
-        return uid
+
+        scan_number: int | None = None
+        scan_folder: str | None = None
+        claimed_here = False
+        try:
+            if objective is None or suggester is None:
+                # Binder path (checked non-None at entry): claim first —
+                # the binder's stack needs the real ScanTag (analyzers load
+                # natively saved files by tag) — then bind against the
+                # connected movables + detectors.  Everything that can
+                # fail-fast already ran above, legacy exec_config parity.
+                scan_tag, scan_folder = claim_scan(
+                    getattr(session, "experiment", "") or ""
+                )
+                scan_number = scan_tag.number if scan_tag is not None else None
+                claimed_here = scan_number is not None
+                objective, suggester = optimization_binder(
+                    devices=list(variables.values()) + detectors,
+                    scan_tag=scan_tag,
+                    scan_folder=scan_folder,
+                )
+
+            max_iterations = spec.max_iterations or 20
+            if on_scan_start is not None:
+                # Upper-bound totals: the suggester may stop early.
+                on_scan_start(max_iterations, max_iterations * request.shots_per_step)
+
+            # The runner claimed → the runner attaches scan.log (the session
+            # only self-attaches when *it* claimed the number).
+            with scan_log(scan_number, scan_folder) if claimed_here else nullcontext():
+                uid, _history = session.optimize(
+                    variables=variables,
+                    detectors=detectors,
+                    objective=objective,
+                    suggester=suggester,
+                    shots_per_iteration=request.shots_per_step,
+                    max_iterations=max_iterations,
+                    mode=mode,
+                    description=request.description,
+                    md=md,
+                    on_finish="best" if spec.move_to_best_on_finish else "hold",
+                    scan_number=scan_number,
+                    scan_folder=scan_folder,
+                )
+            return uid
+        except BaseException:
+            if claimed_here:
+                # Scan-folder lifecycle invariant: a claimed ScanNNN/ folder
+                # is never deleted, so surface the claimed-but-failed state.
+                logger.error(
+                    "Optimization scan %s failed or aborted after its folder "
+                    "was claimed at %s; the folder is left in place (never "
+                    "deleted) and may be missing ScanInfo or data",
+                    scan_number,
+                    scan_folder,
+                )
+            raise
     finally:
         if created and hasattr(session, "disconnect"):
             session.disconnect(*created)

--- a/GeecsBluesky/geecs_bluesky/scanner_bridge/bluesky_scanner.py
+++ b/GeecsBluesky/geecs_bluesky/scanner_bridge/bluesky_scanner.py
@@ -160,16 +160,21 @@ class BlueskyScanner:
     tiled_api_key:
         API key for the Tiled server, if authentication is enabled.
     optimization_loader:
-        Callable injected by the GUI layer for OPTIMIZATION scans:
-        ``optimization_loader(optimizer_config_path)`` returns a bridge object
-        exposing ``variable_names`` (``"Device:Variable"`` VOCS keys) and
-        ``bind(devices=..., scan_tag=..., scan_folder=...) -> (objective,
-        suggester)`` for
-        :meth:`GeecsSession.optimize`.  Lives on the GUI side because the
-        config-driven optimizer stack (Xopt, evaluators, ScanAnalysis
-        analyzers) belongs to ``geecs_scanner.optimization`` — this package
-        cannot import it (dependency direction).  Without a loader,
-        optimization-mode requests are logged and skipped.
+        Callable injected by the GUI layer for OPTIMIZATION scans; returns
+        a bridge object exposing ``variable_names`` (``"Device:Variable"``
+        VOCS keys) and ``bind(devices=..., scan_tag=..., scan_folder=...)
+        -> (objective, suggester)`` for :meth:`GeecsSession.optimize`.
+        Called with one argument whose type depends on the submission
+        path: the legacy exec_config path passes the optimizer-config YAML
+        path (``str``); the delegated ScanRequest path passes the
+        request's resolved :class:`~geecs_schemas.OptimizationSpec` — a
+        loader serving both paths dispatches on the argument type.  Lives
+        on the GUI side because the config-driven optimizer stack (Xopt,
+        evaluators, ScanAnalysis analyzers) belongs to
+        ``geecs_scanner.optimization`` — this package cannot import it
+        (dependency direction).  Without a loader, exec_config
+        optimization scans are logged and skipped, and optimize-mode
+        ScanRequests are refused at :meth:`reinitialize`.
     """
 
     def __init__(
@@ -339,21 +344,28 @@ class BlueskyScanner:
         experiment defaults itself, so storing a post-defaults copy would
         apply them twice.  ``acquisition`` comes from the request —
         deliberately no env override, a request declares intent.  Optimize
-        mode is still refused: wiring the GUI's ``optimization_loader`` into
-        the delegated path is GUI-submission step (iii).
+        mode requires the GUI-injected ``optimization_loader`` (refused
+        here otherwise — the loader cannot appear later); the scan thread
+        hands the request's resolved ``OptimizationSpec`` to the loader and
+        threads the returned bridge's ``bind`` into the delegated runner
+        (see :meth:`_run_delegated_request`).
 
         Returns ``True`` (matching :meth:`reinitialize`).
         """
         if resolver is None:
             resolver = ConfigsRepoResolver(self._experiment_dir)
 
-        if request.mode is ScanRequestMode.OPTIMIZE:
+        if request.mode is ScanRequestMode.OPTIMIZE and (
+            self._optimization_loader is None
+        ):
             raise NotImplementedError(
                 "optimize-mode ScanRequest execution through BlueskyScanner "
-                "lands with GUI-submission step (iii), which wires the "
-                "GUI-injected optimization_loader into the delegated path; "
-                "use GeecsSession.run(request, resolver, objective=..., "
-                "suggester=...) headless"
+                "needs the GUI-injected optimization_loader (the config-"
+                "driven Xopt/evaluator stack lives in geecs_scanner."
+                "optimization, which this package cannot import); construct "
+                "the scanner with optimization_loader=..., or run headless "
+                "via GeecsSession.run(request, resolver, objective=..., "
+                "suggester=...)"
             )
 
         # Fail-fast validation on a LOCAL post-defaults copy; every result
@@ -378,6 +390,14 @@ class BlueskyScanner:
                 # variables are refused here, not in the scan thread.
                 spec = resolver.resolve_scan_variable(axis.variable)
                 resolve_movable_target(spec, axis.variable)
+        if validated.mode is ScanRequestMode.OPTIMIZE and validated.optimization:
+            for name in validated.optimization.variables:
+                # Catalog names must resolve (and pseudo variables are
+                # refused) here, not in the scan thread; 'Device:Variable'
+                # strings pass through, matching the runner's dispatch.
+                if ":" not in name:
+                    spec = resolver.resolve_scan_variable(name)
+                    resolve_movable_target(spec, name)
 
         # Store the ORIGINAL pre-defaults request (see docstring).
         self._scan_request = request
@@ -990,16 +1010,43 @@ class BlueskyScanner:
         ``scan.log`` when *it* claimed — so the bridge must NOT pre-claim
         here.  Exceptions propagate to :meth:`_run_scan`'s cleanup
         (ABORTED state + disconnect).
+
+        Optimize-mode requests hand the request's ``OptimizationSpec`` to
+        the GUI-injected ``optimization_loader`` (presence enforced at
+        :meth:`_reinitialize_from_scan_request`); the returned bridge's
+        ``bind`` becomes the runner's ``optimization_binder`` — the runner
+        claims the scan, binds, and maps onto ``session.optimize``.  The
+        bridge's optional ``finish()`` bookkeeping (e.g. the legacy
+        ``xopt_dump.yaml``) runs after a successful run, as on the legacy
+        exec_config optimization path.
         """
         request = self._scan_request
         resolver = self._request_resolver or ConfigsRepoResolver(self._experiment_dir)
+        optimization_binder = None
+        opt_bridge: Any | None = None
+        if request.mode is ScanRequestMode.OPTIMIZE:
+            if self._optimization_loader is None:
+                # reinitialize refused already; guard direct/stale callers.
+                raise GeecsConfigurationError(
+                    "optimize-mode ScanRequest reached the scan thread "
+                    "without an optimization_loader"
+                )
+            opt_bridge = self._optimization_loader(request.optimization)
+            optimization_binder = opt_bridge.bind
         run_scan_request(
             self._session,
             request,
             resolver,
             preflight=self._delegated_preflight,
             on_scan_start=self._on_delegated_scan_start,
+            optimization_binder=optimization_binder,
         )
+        if opt_bridge is not None:
+            # Post-run bookkeeping owned by the bridge (legacy parity with
+            # _run_optimization); skipped on failure — exceptions propagate.
+            finish = getattr(opt_bridge, "finish", None)
+            if callable(finish):
+                finish()
 
     def _delegated_preflight(self, detectors: list, strict: bool) -> list | None:
         """Runner preflight hook: the operator-dialog pipeline, sans disconnect.

--- a/GeecsBluesky/pyproject.toml
+++ b/GeecsBluesky/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-bluesky"
-version = "0.30.1"
+version = "0.31.0"
 description = "Bluesky / ophyd-async bridge for the GEECS control system"
 authors = ["Sam Barber <sbarber@lbl.gov>"]
 readme = "README.md"

--- a/GeecsBluesky/tests/test_bluesky_scanner_scan_request_seam.py
+++ b/GeecsBluesky/tests/test_bluesky_scanner_scan_request_seam.py
@@ -13,10 +13,12 @@ must not pre-claim a scan number on this path (``session.scan`` claims).
 from __future__ import annotations
 
 import threading
+from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
 
+from geecs_bluesky import scan_request_runner
 from geecs_bluesky.exceptions import GeecsConfigurationError
 from geecs_bluesky.models.shot_control import ShotControlWrites
 from geecs_bluesky.scan_request_runner import run_scan_request
@@ -93,6 +95,7 @@ class _FakeSession:
     def __init__(self) -> None:
         self.rep_rate_hz = 1.0
         self.scan_kwargs: dict | None = None
+        self.optimize_kwargs: dict | None = None
         self.shot_control_config = "unset"
         self.movables: list[_FakeMovable] = []
         self.disconnected: list = []
@@ -129,8 +132,48 @@ class _FakeSession:
         self.scan_kwargs = kwargs
         return "uid"
 
+    def optimize(self, **kwargs):
+        self.optimize_kwargs = kwargs
+        return "uid-opt", []
+
     def disconnect(self, *devices):
         self.disconnected.extend(devices)
+
+
+class _FakeOptimizationBridge:
+    """Loader-returned bridge fake: records bind()/finish() interactions."""
+
+    def __init__(self, spec) -> None:
+        self.spec = spec
+        self.bind_kwargs: dict | None = None
+        self.finished = False
+        self.objective = object()
+        self.suggester = object()
+
+    def bind(self, *, devices, scan_tag, scan_folder=None):
+        self.bind_kwargs = {
+            "devices": list(devices),
+            "scan_tag": scan_tag,
+            "scan_folder": scan_folder,
+        }
+        return self.objective, self.suggester
+
+    def finish(self) -> None:
+        self.finished = True
+
+
+class _FakeOptimizationLoader:
+    """optimization_loader fake: records what it was called with."""
+
+    def __init__(self) -> None:
+        self.calls: list = []
+        self.bridges: list[_FakeOptimizationBridge] = []
+
+    def __call__(self, spec) -> _FakeOptimizationBridge:
+        self.calls.append(spec)
+        bridge = _FakeOptimizationBridge(spec)
+        self.bridges.append(bridge)
+        return bridge
 
 
 class _StubResolver:
@@ -719,25 +762,221 @@ def test_delegated_totals_hook(monkeypatch) -> None:
 
 
 # ---------------------------------------------------------------------------
-# Retained refusal (optimize awaits GUI-submission step (iii)) + state reset
+# Optimize through the seam (delegated via the injected optimization_loader)
 # ---------------------------------------------------------------------------
 
 
-def test_optimize_request_refused_at_reinitialize() -> None:
-    scanner = _make_scanner(_FakeSession())
-    request = ScanRequest.model_validate(
-        {
-            "mode": "optimize",
-            "save_sets": ["baseline"],
-            "optimization": {
-                "variables": {"jet_z": [0.0, 1.0]},
-                "evaluator": {"module": "m", "class": "C"},
-                "generator": {"name": "random"},
-            },
-        }
+def _optimize_request(**overrides) -> ScanRequest:
+    base = dict(
+        mode="optimize",
+        shots_per_step=4,
+        acquisition="free_run",
+        save_sets=["baseline"],
+        optimization={
+            "variables": {"jet_z": [0.0, 1.0], "U_S1H:Current": [-2.0, 2.0]},
+            "objectives": {"counts": "MAXIMIZE"},
+            "evaluator": {"module": "m", "class": "C"},
+            "generator": {"name": "bayes_default"},
+            "max_iterations": 5,
+            "move_to_best_on_finish": True,
+        },
     )
-    with pytest.raises(NotImplementedError, match="GeecsSession.run"):
-        scanner.reinitialize(request, resolver=_resolver())
+    base.update(overrides)
+    return ScanRequest.model_validate(base)
+
+
+def _optimize_resolver(**overrides) -> _StubResolver:
+    base = dict(
+        variables={"jet_z": ScanVariable(target="U_ESP_JetXYZ:Position.Axis 3")}
+    )
+    base.update(overrides)
+    return _resolver(**base)
+
+
+def _patch_runner_claim(monkeypatch, tag) -> list:
+    """Patch the runner's claim_scan; return the recorded experiment names."""
+    claims: list = []
+    folder = None if tag is None else f"/nonexistent/scans/Scan{tag.number:03d}"
+    monkeypatch.setattr(
+        scan_request_runner,
+        "claim_scan",
+        lambda experiment: claims.append(experiment) or (tag, folder),
+    )
+    return claims
+
+
+def test_optimize_request_runs_end_to_end_through_bridge(monkeypatch) -> None:
+    """The refusal is gone: an optimize request delegates through the runner.
+
+    The loader receives the request's resolved ``OptimizationSpec``, the
+    bridge's ``bind`` gets the connected movables + detectors and the
+    runner-claimed scan tag/folder, and its (objective, suggester) pair
+    reaches ``session.optimize`` along with the pre-claimed number/folder.
+    ``finish()`` bookkeeping runs after the successful run.
+    """
+    tag = SimpleNamespace(number=41)
+    _patch_runner_claim(monkeypatch, tag)
+    session = _FakeSession()
+    scanner = _make_scanner(session)
+    loader = _FakeOptimizationLoader()
+    scanner._optimization_loader = loader
+    request = _optimize_request()
+
+    assert scanner.reinitialize(request, resolver=_optimize_resolver()) is True
+    scanner._run_scan(scanner._scan_config)
+
+    # The loader received the request's optimization field group, verbatim.
+    assert loader.calls == [request.optimization]
+    (bridge,) = loader.bridges
+    assert bridge.bind_kwargs is not None
+    assert bridge.bind_kwargs["scan_tag"] is tag
+    assert bridge.bind_kwargs["scan_folder"] == "/nonexistent/scans/Scan041"
+    bound_names = {
+        getattr(d, "_geecs_device_name", None) for d in bridge.bind_kwargs["devices"]
+    }
+    # Movables (both VOCS variables) + the save set's detectors.
+    assert {"U_ESP_JetXYZ", "U_S1H", "U_Ref", "U_Cam2", "U_Stage"} <= bound_names
+    assert bridge.finished is True
+
+    kwargs = session.optimize_kwargs
+    assert kwargs is not None
+    assert kwargs["objective"] is bridge.objective
+    assert kwargs["suggester"] is bridge.suggester
+    assert kwargs["scan_number"] == 41
+    assert kwargs["scan_folder"] == "/nonexistent/scans/Scan041"
+    assert kwargs["max_iterations"] == 5
+    assert kwargs["shots_per_iteration"] == 4
+    assert kwargs["on_finish"] == "best"
+    assert kwargs["mode"] == "free_run"
+    # Catalog name resolved to its target; Device:Variable passes through.
+    assert set(kwargs["variables"]) == {"jet_z", "U_S1H:Current"}
+    assert kwargs["md"]["scan_request_mode"] == "optimize"
+    assert kwargs["md"]["db_scan_runtime"] == {
+        "db_scalars": "applied",
+        "background_telemetry": "not_run_in_optimize",
+    }
+    # The runner's finally still disconnects everything it created.
+    assert len(session.disconnected) == 5
+
+
+def test_optimize_totals_hook_primes_gui_progress(monkeypatch) -> None:
+    """Optimize primes the GUI totals with the max_iterations upper bound."""
+    _patch_runner_claim(monkeypatch, None)
+    session = _FakeSession()
+    scanner = _make_scanner(session)
+    scanner._optimization_loader = _FakeOptimizationLoader()
+    scanner.reinitialize(_optimize_request(), resolver=_optimize_resolver())
+    scanner._run_scan(scanner._scan_config)
+
+    assert scanner._total_steps == 5
+    assert scanner._total_shots == 20  # 5 iterations × 4 shots
+
+
+def test_optimize_unclaimed_scan_still_runs(monkeypatch) -> None:
+    """claim failure (off-network) binds with scan_tag=None and still runs."""
+    _patch_runner_claim(monkeypatch, None)
+    session = _FakeSession()
+    scanner = _make_scanner(session)
+    loader = _FakeOptimizationLoader()
+    scanner._optimization_loader = loader
+    scanner.reinitialize(_optimize_request(), resolver=_optimize_resolver())
+    scanner._run_scan(scanner._scan_config)
+
+    (bridge,) = loader.bridges
+    assert bridge.bind_kwargs["scan_tag"] is None
+    kwargs = session.optimize_kwargs
+    assert kwargs is not None
+    assert kwargs["scan_number"] is None
+    assert kwargs["scan_folder"] is None
+
+
+def test_optimize_actions_skipped_and_recorded_through_bridge(monkeypatch) -> None:
+    """Actions on optimize keep the skip-with-warning behavior via the bridge:
+    names still validate fail-fast at reinitialize, nothing compiles/executes,
+    and the skip is recorded in the run metadata."""
+    _patch_runner_claim(monkeypatch, None)
+    session = _FakeSession()
+    scanner = _make_scanner(session)
+    scanner._optimization_loader = _FakeOptimizationLoader()
+    resolver = _optimize_resolver(plans={"prep": _WAIT_PLAN})
+    request = _optimize_request(actions={"setup": ["prep"]})
+    assert scanner.reinitialize(request, resolver=resolver) is True
+    scanner._run_scan(scanner._scan_config)
+
+    kwargs = session.optimize_kwargs
+    assert kwargs is not None
+    assert kwargs["md"]["skipped_action_plans"] == {"setup": ["prep"]}
+    assert session.action_factories == []  # nothing compiled
+
+
+def test_optimize_unknown_action_still_fails_at_reinitialize() -> None:
+    scanner = _make_scanner(_FakeSession())
+    scanner._optimization_loader = _FakeOptimizationLoader()
+    request = _optimize_request(actions={"setup": ["prep"]})
+    with pytest.raises(GeecsConfigurationError, match="prep"):
+        scanner.reinitialize(request, resolver=_optimize_resolver())
+
+
+def test_optimize_unknown_variable_fails_at_reinitialize() -> None:
+    """A catalog VOCS name that does not resolve fails at reinitialize."""
+    scanner = _make_scanner(_FakeSession())
+    scanner._optimization_loader = _FakeOptimizationLoader()
+    with pytest.raises(GeecsConfigurationError, match="jet_z"):
+        scanner.reinitialize(_optimize_request(), resolver=_resolver())
+
+
+def test_optimize_pseudo_variable_fails_at_reinitialize() -> None:
+    pseudo = PseudoScanVariable(
+        kind="pseudo",
+        targets=[{"target": "U_X:Pos", "forward": "composite_var"}],
+        mode="absolute",
+    )
+    scanner = _make_scanner(_FakeSession())
+    scanner._optimization_loader = _FakeOptimizationLoader()
+    with pytest.raises(NotImplementedError, match="pseudo"):
+        scanner.reinitialize(
+            _optimize_request(), resolver=_resolver(variables={"jet_z": pseudo})
+        )
+
+
+def test_optimize_request_without_loader_refused_at_reinitialize() -> None:
+    """No injected optimization_loader → clear refusal (the GUI half being
+    built in parallel relies on this message staying explicit)."""
+    scanner = _make_scanner(_FakeSession())  # _optimization_loader is None
+    with pytest.raises(NotImplementedError, match="optimization_loader"):
+        scanner.reinitialize(_optimize_request(), resolver=_optimize_resolver())
+
+
+def test_dependency_direction_no_geecs_scanner_import() -> None:
+    """geecs_bluesky must never import geecs_scanner (the loader stays
+    injected; the Xopt/evaluator stack lives GUI-side).  AST-level check so
+    docstring usage examples don't count — only real import statements."""
+    import ast
+
+    import geecs_bluesky
+
+    def _imports_geecs_scanner(tree: ast.AST) -> bool:
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                if any(a.name.split(".")[0] == "geecs_scanner" for a in node.names):
+                    return True
+            elif isinstance(node, ast.ImportFrom):
+                if (node.module or "").split(".")[0] == "geecs_scanner":
+                    return True
+        return False
+
+    package_root = Path(geecs_bluesky.__file__).parent
+    offenders = [
+        str(path.relative_to(package_root))
+        for path in sorted(package_root.rglob("*.py"))
+        if _imports_geecs_scanner(ast.parse(path.read_text()))
+    ]
+    assert offenders == []
+
+
+# ---------------------------------------------------------------------------
+# State reset when switching submission shapes
+# ---------------------------------------------------------------------------
 
 
 def test_exec_config_path_clears_request_state(monkeypatch) -> None:

--- a/GeecsBluesky/tests/test_scan_request_runner.py
+++ b/GeecsBluesky/tests/test_scan_request_runner.py
@@ -14,6 +14,7 @@ since optimize has no action hooks yet.
 from __future__ import annotations
 
 import logging
+from types import SimpleNamespace
 
 import pytest
 from bluesky.utils import Msg
@@ -842,6 +843,78 @@ def test_optimize_without_injected_callables_is_a_documented_gap(
 ) -> None:
     with pytest.raises(NotImplementedError, match="objective"):
         run_scan_request(_FakeSession(), _optimize_request(), legacy_resolver)
+
+
+def test_optimize_binder_claims_binds_and_supplies_callables(
+    legacy_resolver, monkeypatch
+) -> None:
+    """The optimization_binder path: the runner claims the scan first (the
+    binder's stack needs the real ScanTag), calls the binder with the
+    connected movables + detectors, and threads the returned callables and
+    the pre-claimed number/folder into session.optimize."""
+    import geecs_bluesky.scan_request_runner as runner_module
+
+    tag = SimpleNamespace(number=7)
+    claims: list = []
+    monkeypatch.setattr(
+        runner_module,
+        "claim_scan",
+        lambda experiment: claims.append(experiment)
+        or (tag, "/nonexistent/scans/Scan007"),
+    )
+    session = _FakeSession()
+    objective, suggester = object(), object()
+    bind_kwargs: dict = {}
+
+    def binder(*, devices, scan_tag, scan_folder=None):
+        bind_kwargs.update(
+            devices=list(devices), scan_tag=scan_tag, scan_folder=scan_folder
+        )
+        return objective, suggester
+
+    uid = run_scan_request(
+        session, _optimize_request(), legacy_resolver, optimization_binder=binder
+    )
+    assert uid == "uid-opt"
+    assert claims == [""]  # fake session exposes no experiment name
+    assert bind_kwargs["scan_tag"] is tag
+    assert bind_kwargs["scan_folder"] == "/nonexistent/scans/Scan007"
+    # Movables (2 VOCS variables) + the save set's detectors (3 devices).
+    assert len(bind_kwargs["devices"]) == 5
+    kwargs = session.optimize_kwargs
+    assert kwargs["objective"] is objective
+    assert kwargs["suggester"] is suggester
+    assert kwargs["scan_number"] == 7
+    assert kwargs["scan_folder"] == "/nonexistent/scans/Scan007"
+
+
+def test_optimize_binder_ignored_when_callables_given(
+    legacy_resolver, monkeypatch
+) -> None:
+    """Ready-made objective/suggester win: no claim, binder never called."""
+    import geecs_bluesky.scan_request_runner as runner_module
+
+    def _no_claim(experiment):
+        raise AssertionError("claim_scan must not be called")
+
+    monkeypatch.setattr(runner_module, "claim_scan", _no_claim)
+    session = _FakeSession()
+    objective, suggester = object(), object()
+
+    def binder(**_kwargs):
+        raise AssertionError("binder must not be called")
+
+    run_scan_request(
+        session,
+        _optimize_request(),
+        legacy_resolver,
+        objective=objective,
+        suggester=suggester,
+        optimization_binder=binder,
+    )
+    kwargs = session.optimize_kwargs
+    assert kwargs["objective"] is objective
+    assert kwargs["scan_number"] is None
 
 
 def test_optimize_maps_onto_session_optimize(legacy_resolver) -> None:


### PR DESCRIPTION
## Summary

M4 GUI-submission step (iii): an optimize-mode `ScanRequest` submitted through the GUI bridge now runs end-to-end through the one engine definition, closing the gap documented in `GeecsBluesky/CLAUDE.md` ("Optimize-mode requests are still refused at reinitialize until GUI-submission step (iii) wires the `optimization_loader` into the delegated path").

- **`reinitialize(ScanRequest)` no longer refuses `mode: optimize`.** It now requires the GUI-injected `optimization_loader` (refused with an explicit error otherwise — see the parallel-work note below) and extends the fail-fast pre-claim validation to the `optimization` field group: VOCS catalog names must resolve, pseudo variables are refused at reinitialize.
- **The loader seam stays injected (dependency direction is hard).** The scan thread calls `optimization_loader(request.optimization)` — the loader's one argument is the resolved `geecs_schemas.OptimizationSpec` on this path, vs the optimizer-YAML path string on the legacy exec_config path; a loader serving both dispatches on argument type. The returned bridge's `bind` becomes `run_scan_request`'s new `optimization_binder` hook. `geecs_bluesky` still never imports `geecs_scanner`, now pinned by an AST-level test.
- **The runner claims the scan pre-bind.** The binder's stack (evaluator analyzers) needs the real `ScanTag`, so — uniquely on the delegated paths — `run_scan_request` claims just before binding, after every fail-fast resolution and device connect (legacy exec_config parity). It passes the pre-claimed number/folder to `session.optimize` and owns the `scan.log` attach (the session only self-attaches when *it* claimed). The bridge's optional `finish()` bookkeeping (legacy `xopt_dump.yaml`) runs after a successful run.
- **Preserved:** fail-fast pre-claim name resolution, actions-skipped-with-warning on optimize (`skipped_action_plans` metadata), `db_scan_runtime` metadata. The GUI progress-totals hook (`on_scan_start`) now also fires on optimize with the `(max_iterations, max_iterations × shots_per_step)` upper bound; the operator-dialog preflight still does not run on optimize (later seam).
- **Deliberately not wired:** optimizer `device_requirements` auto-provisioning on the delegated path — the request's save sets must name the objective's diagnostics (schema-world explicitness; the legacy exec_config path keeps its merge). Documented in CLAUDE.md.

## Coordination note (parallel GUI work)

The GUI half (the optimization dropdown / request composition) is being built in parallel against the **current refusal behavior**. Until this PR merges, `reinitialize` keeps refusing optimize requests when no `optimization_loader` is injected, with an explicit `NotImplementedError` naming `optimization_loader` — that refusal (and its message) is pinned by `test_optimize_request_without_loader_refused_at_reinitialize`. After the merge, the GUI-side loader must accept an `OptimizationSpec` argument on the delegated path (type-dispatch alongside the legacy YAML-path string).

## Testing

Hermetic only (no hardware/DB/network). `GeecsBluesky: poetry run pytest tests -q` → **314 passed, 16 skipped** (baseline ~304 + 10 new):

- `tests/test_bluesky_scanner_scan_request_seam.py`: fake loader/bridge — optimize request runs end-to-end through the bridge (loader receives the resolved `OptimizationSpec`, bind gets movables+detectors and the claimed tag/folder, objective/suggester reach `session.optimize`, `finish()` runs); totals hook; claim-failure (off-network) still runs; actions skipped-and-recorded; unknown action/variable and pseudo-variable fail at reinitialize; no-loader refusal retained; AST-level no-`geecs_scanner`-import pin.
- `tests/test_scan_request_runner.py`: headless binder path (claims pre-bind, threads callables + pre-claimed number/folder); ready-made objective/suggester win over the binder (no claim, binder never called).

Version `0.30.1 → 0.31.0` (minor), CHANGELOG + CLAUDE.md updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)