### PR TITLE
Console UX wave: tooltips, #510 worker routing, optimization dropdown (0.7.0)

### DIFF
--- a/GEECS-Console/CHANGELOG.md
+++ b/GEECS-Console/CHANGELOG.md
@@ -22,7 +22,15 @@ semantic.
   hand-written operator-language tooltips in `_apply_operator_tooltips`.
   Pinned by `tests/test_tooltips.py`: editor tooltips compared against the
   schema field descriptions, representative window controls asserted
-  non-empty and not label restatements.
+  non-empty and not label restatements.  A **Preferences → Show tooltips**
+  toggle (checkable, persisted via `ConsoleSettings.show_tooltips`,
+  default on) turns them all off for operators who know the console: an
+  application-level `ToolTipSuppressor` event filter swallows
+  `QEvent.ToolTip` for every console widget — editors included — and is
+  installed **only while tooltips are off**, so the default path adds no
+  per-event filter overhead (an always-installed filter measurably slowed
+  the offscreen suite).  Parented to the window and removed on close, so
+  no dangling suppressor can outlive it.
 - **Optimization mode dropdown (GUI half)**.  Selecting the R3
   Optimization radio now shows an optimizer-config combo listing the
   YAML files in the experiment's `optimizer_configs/` folder (the legacy

--- a/GEECS-Console/CHANGELOG.md
+++ b/GEECS-Console/CHANGELOG.md
@@ -4,6 +4,56 @@ All notable changes to GEECS-Console are documented here.  Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versioning is
 semantic.
 
+## [0.7.0] - 2026-07-12
+
+### Added
+
+- **Tooltips everywhere** (issue #497 phase 1, text only — no doc links).
+  Editor form fields derive their tooltips from the geecs-schemas pydantic
+  `Field(description=...)` texts via the new
+  `services/schema_tooltips.py::apply_schema_tooltips` helper, applied in
+  all four editors (save sets, scan variables, shot control, action
+  library) — single source of truth; a widget mapped to a description-less
+  or renamed field fails loudly at editor construction.  (No schema
+  descriptions needed backfilling — every geecs-schemas field already
+  carries one, so GEECS-Schemas is untouched.)  The main window's operator
+  controls (mode radios, acquisition combo, shots/step, save-set lists,
+  device panel, Start/Stop, health chips, presets row, ...) get
+  hand-written operator-language tooltips in `_apply_operator_tooltips`.
+  Pinned by `tests/test_tooltips.py`: editor tooltips compared against the
+  schema field descriptions, representative window controls asserted
+  non-empty and not label restatements.
+- **Optimization mode dropdown (GUI half)**.  Selecting the R3
+  Optimization radio now shows an optimizer-config combo listing the
+  YAML files in the experiment's `optimizer_configs/` folder (the legacy
+  GEECS-Scanner-GUI folder name; offline → empty combo and Start stays
+  disabled).  `ConsoleConfigs.optimization_spec` loads a named config as a
+  validated `OptimizationSpec`, accepting both new-schema documents and
+  the legacy `vocs` dialect (via
+  `geecs_schemas.convert.convert_optimizer_config`).
+  `build_scan_request` maps optimize forms onto `mode: optimize` requests
+  carrying the loaded spec (still a pure function — the window resolves
+  name → spec when snapshotting the form), and `form_state_from_request`
+  round-trips optimize instead of raising, so optimize presets save and
+  apply (Apply matches the preset's inline spec against the experiment's
+  configs by content; no match ⇒ status-bar error, form untouched).  The
+  GUI does **not** pre-block submission: the current engine still refuses
+  optimize requests, and that refusal is surfaced in the status bar — when
+  the engine half lands, zero GUI changes are needed.
+
+### Fixed
+
+- **Device-set completion routed through a worker QObject** (issue #510,
+  finished properly).  The 0.6.2 fix swallowed the torn-down-window
+  `RuntimeError` around a `MainWindow`-owned `device_set_finished` signal
+  emitted from the set-dispatch daemon thread; that window-owned
+  cross-thread emission is now gone entirely.  The blocking set runs
+  through a dedicated `BackgroundResult` worker whose `result_ready`
+  signal delivers `(ok, message)` queued to the GUI thread — the blessed
+  pattern (the worker owns the emission and survives window teardown).
+  The deterministic regression test (blocked fake backend released after
+  window close) stays green.
+
 ## [0.6.3] - 2026-07-12
 
 ### Fixed

--- a/GEECS-Console/CLAUDE.md
+++ b/GEECS-Console/CLAUDE.md
@@ -254,8 +254,15 @@ are prefixed by region (`r3_radio_1d`, `r5_start_button`, …).
   construction.  When a tooltip reads poorly, fix the schema description,
   never hardcode GUI text.  Main-window operator controls carry
   hand-written operator-language tooltips (`_apply_operator_tooltips`) —
-  those are GUI concepts with no schema counterpart.  Pinned by
-  `tests/test_tooltips.py`.
+  those are GUI concepts with no schema counterpart.  **Preferences →
+  Show tooltips** (persisted, default on) gates them all via
+  `ToolTipSuppressor`, an application-level event filter that swallows
+  `QEvent.ToolTip`; it is installed on the `QApplication` **only while
+  tooltips are off** — an always-installed per-window app filter
+  measurably slowed the offscreen suite (every event crossing into a
+  Python `eventFilter`), so presence = suppression.  It is parented to
+  the window (Qt auto-removes a destroyed filter) and `closeEvent`
+  removes it explicitly.  Pinned by `tests/test_tooltips.py`.
 
 ## Standing PySide6 ownership hazards (GC eats live C++ objects)
 

--- a/GEECS-Console/CLAUDE.md
+++ b/GEECS-Console/CLAUDE.md
@@ -19,15 +19,18 @@ are prefixed by region (`r3_radio_1d`, `r5_start_button`, …).
   line ("union: N devices"), role-conflict/reference hint line.
 - **R3 scan form** — mode radios (No-scan / 1D / Grid / Optimization /
   Background), variable picker + start/stop/step (two axis rows; row 2 is
-  Grid-only), shots per step, acquisition combo (free_run default, strict —
-  the request declares intent), live shot count with the
+  Grid-only), an optimizer-config combo (visible in Optimization mode only —
+  see Implemented seams), shots per step, acquisition combo (free_run
+  default, strict — the request declares intent), live shot count with the
   `MAXIMUM_SCAN_SIZE = 1e6` guard, description.
 - **R4 presets** — combo + Apply + Save-as + Delete.  A preset IS a saved
   `ScanRequest`; **persistence live** (see Implemented seams): YAML files
   in the configs repo's per-experiment `presets/` dir.
 - **R5 submit row** — Stop (danger) + Start (primary).  Start requires: not
-  scanning, ≥1 selected save set, valid shot count within the guard, mode
-  not Optimization.
+  scanning, ≥1 selected save set, valid shot count within the guard, and in
+  Optimization mode a selected optimizer config.  The GUI never pre-blocks
+  an optimize submission beyond that — the engine's accept/refuse answer is
+  surfaced in the status bar.
 - **R6 now panel** — state pill, progress bar, "Scan NNN" with 10 s expiry
   to "(previous)" (**live**: driven by `ScanLifecycleEvent.scan_number`
   through the adapter's `scan_number_known` signal), compact log tail.
@@ -113,9 +116,11 @@ are prefixed by region (`r3_radio_1d`, `r5_start_button`, …).
   edits only regate the Set button (no CA-monitor churn while typing); a
   generation counter drops straggler callbacks from retired monitors.  Set
   goes through `GatewaySetpointPut` (the one blessed `:SP` put primitive,
-  `wire_value` coercion) on a short-lived daemon thread, reporting via the
-  queued `device_set_finished(bool, str)` signal; the button is disabled
-  while a put is in flight.  PV names come only from `ca_pv`/`bare_pv`
+  `wire_value` coercion) dispatched through a dedicated `BackgroundResult`
+  set worker whose queued `result_ready` delivers `(ok, message)` back on
+  the GUI thread — the worker owns the cross-thread emission, never the
+  window (issue #510, resolved in 0.7.0); the button is disabled while a
+  put is in flight.  PV names come only from `ca_pv`/`bare_pv`
   (never hand-built — the `ca://`-vs-bare addressing rule, issue #490).
   All real imports are lazy (module import-safe offline); `closeEvent`
   unsubscribes and disconnects, never joins.  Inject the real backend in
@@ -225,8 +230,32 @@ are prefixed by region (`r3_radio_1d`, `r5_start_button`, …).
   the worker QObject, never on the window**: emitting a window-owned
   signal from a daemon thread races window teardown and segfaults under
   offscreen pytest (observed directly when the idle scan probe emitted a
-  `MainWindow` signal).  `closeEvent` disconnects each worker's
-  `result_ready`.
+  `MainWindow` signal; the R7 device-set completion was the last such
+  emission and moved to a `BackgroundResult` worker in 0.7.0 — issue
+  #510).  `closeEvent` disconnects each worker's `result_ready`.
+- **Optimization dropdown (R3, GUI half — engine-gated)**: the
+  Optimization radio shows a config combo listing the YAML stems of the
+  experiment's `optimizer_configs/` folder (legacy scanner-GUI folder
+  name; part of `ConfigListing`).  `ConsoleConfigs.optimization_spec`
+  loads a named config as a validated `OptimizationSpec` — new-schema
+  documents directly, the legacy `vocs` dialect through
+  `geecs_schemas.convert.convert_optimizer_config`.  `form_state()`
+  resolves the selected name into the spec (`ConsoleFormState.optimization`)
+  so `build_scan_request` stays pure; optimize requests round-trip through
+  `form_state_from_request`, and applying an optimize preset matches its
+  inline spec against the listed configs by content (no match ⇒ status-bar
+  error, form untouched).  The engine currently refuses optimize requests;
+  the console submits anyway and surfaces the refusal, so the engine half
+  lands with zero GUI changes.
+- **Tooltips (issue #497 phase 1)**: editor form fields get their tooltips
+  from the geecs-schemas `Field(description=...)` texts via
+  `services/schema_tooltips.py::apply_schema_tooltips` — single source of
+  truth; a mapping to a missing or description-less field raises at editor
+  construction.  When a tooltip reads poorly, fix the schema description,
+  never hardcode GUI text.  Main-window operator controls carry
+  hand-written operator-language tooltips (`_apply_operator_tooltips`) —
+  those are GUI concepts with no schema counterpart.  Pinned by
+  `tests/test_tooltips.py`.
 
 ## Standing PySide6 ownership hazards (GC eats live C++ objects)
 
@@ -246,8 +275,12 @@ the window for anything in these families:
 
 ## Stubbed seams (intentional, wire later)
 
-- Optimization mode: radio exists, submission refused with a clear error
-  until an `OptimizationSpec` editor exists.
+- Optimization mode is GUI-complete but **engine-gated**: the console
+  builds and submits `mode: optimize` requests from a named optimizer
+  config (see Implemented seams), and the engine's refusal is surfaced in
+  the status bar until the engine side lands.  An `OptimizationSpec`
+  *editor* (authoring configs in the GUI) remains out of scope — configs
+  are YAML files in `optimizer_configs/`.
 - `ConsoleConfigs._scan_variable_names` reaches into the resolver's private
   `_scan_variables_catalog()` — promote a public "list variable names"
   method on `ConfigsRepoResolver` when next touching geecs-bluesky.

--- a/GEECS-Console/geecs_console/app/main_window.py
+++ b/GEECS-Console/geecs_console/app/main_window.py
@@ -301,10 +301,6 @@ class MainWindow(QMainWindow):
     #: monitor thread; delivered queued to :meth:`_apply_device_value`).
     device_value_ready = Signal(object)
 
-    #: ``(ok, message)`` for one completed device set (emitted from the
-    #: set-dispatch daemon thread; delivered queued).
-    device_set_finished = Signal(bool, str)
-
     def __init__(
         self,
         experiment: str = "",
@@ -351,6 +347,7 @@ class MainWindow(QMainWindow):
         self._apply_stylesheet()
         self._load_ui()
         self._bind_widgets()
+        self._apply_operator_tooltips()
         self._build_menus()
         self._build_status_bar()
         self._wire_signals()
@@ -457,6 +454,10 @@ class MainWindow(QMainWindow):
         self.start2_spin: QDoubleSpinBox = self._child(QDoubleSpinBox, "r3_start2")
         self.stop2_spin: QDoubleSpinBox = self._child(QDoubleSpinBox, "r3_stop2")
         self.step2_spin: QDoubleSpinBox = self._child(QDoubleSpinBox, "r3_step2")
+        self.optimization_label: QLabel = self._child(QLabel, "r3_optimization_label")
+        self.optimization_combo: QComboBox = self._child(
+            QComboBox, "r3_optimization_combo"
+        )
         self.shots_per_step: QSpinBox = self._child(QSpinBox, "r3_shots_per_step")
         self.acquisition_combo: QComboBox = self._child(
             QComboBox, "r3_acquisition_combo"
@@ -489,6 +490,172 @@ class MainWindow(QMainWindow):
 
         for mode in (AcquisitionMode.FREE_RUN, AcquisitionMode.STRICT):
             self.acquisition_combo.addItem(mode.value)
+
+    def _apply_operator_tooltips(self) -> None:
+        """Set the operator-language tooltips on the main-window controls.
+
+        These are hand-written (what it does / what happens), not copies of
+        the widget labels.  Editor form fields are different: their tooltips
+        come from the schema field descriptions via
+        :mod:`~geecs_console.services.schema_tooltips` — single source of
+        truth (issue #497 phase 1).
+        """
+        tooltips = {
+            # R1 session bar
+            self.experiment_combo: (
+                "Which experiment's configs, presets, devices, and gateway "
+                "PVs the console works with. Changing it repopulates "
+                "everything below."
+            ),
+            self.rep_rate: (
+                "The machine repetition rate in Hz — informational for "
+                "free-run pacing; it does not command any hardware."
+            ),
+            self.trigger_profile_combo: (
+                "Trigger profile the scan drives the machine with (OFF / "
+                "STANDBY / SCAN / ... device writes). Empty means the scan "
+                "leaves the trigger alone."
+            ),
+            self.trigger_variant_combo: (
+                "Named operating condition of the trigger profile (e.g. "
+                "laser_off) — overlays a few writes on the base profile. "
+                "Empty runs the base behaviour."
+            ),
+            self.gateway_chip: (
+                "CA gateway health: reads the experiment's heartbeat PV "
+                "every few seconds. WARN means the gateway runs but reports "
+                "zero connected devices."
+            ),
+            self.tiled_chip: (
+                "Tiled data-server health: an HTTP check of the configured "
+                "Tiled URI every few seconds."
+            ),
+            self.db_chip: (
+                "GEECS experiment database health: a cheap MySQL query "
+                "every few seconds."
+            ),
+            # R2 save sets
+            self.available_list: (
+                "The experiment's save sets (named device groups) not yet "
+                "picked for this scan. Select and Add to require them."
+            ),
+            self.selected_list: (
+                "Save sets this scan records. Their devices are unioned; "
+                "each required device gets guarantees (completeness, "
+                "dialogs, images). At least one set is needed to start."
+            ),
+            self.add_button: "Require the selected save sets for this scan.",
+            self.remove_button: (
+                "Drop the selected save sets from this scan (their devices "
+                "may still be logged as background telemetry)."
+            ),
+            self.union_label: (
+                "How many distinct devices the selected save sets add up to "
+                "after merging duplicates."
+            ),
+            # R3 scan form
+            self.radio_noscan: (
+                "Collect shots without moving anything — statistics at the "
+                "current machine settings."
+            ),
+            self.radio_1d: (
+                "Sweep one scan variable through start → stop in step-sized "
+                "moves, taking a batch of shots at each position."
+            ),
+            self.radio_grid: (
+                "Sweep two variables as a grid visiting every combination — "
+                "axis 1 is the outer (slow) loop, axis 2 the inner (fast) "
+                "one."
+            ),
+            self.radio_optimization: (
+                "Let an optimizer pick the settings each iteration, per the "
+                "optimizer config chosen below. Submission is accepted only "
+                "when the scan engine supports optimize scans."
+            ),
+            self.radio_background: (
+                "A no-scan whose data is marked as background/calibration "
+                "shots so analysis can find them later."
+            ),
+            self.optimization_combo: (
+                "Which optimizer config to run — the YAML files in this "
+                "experiment's optimizer_configs folder. Empty when offline "
+                "or the experiment has none (Start stays disabled)."
+            ),
+            self.shots_per_step: (
+                "How many shots to take at each scan position / grid point "
+                "(or in total for a no-scan or background run)."
+            ),
+            self.acquisition_combo: (
+                "free_run: the trigger runs at the machine rate and device "
+                "rows are matched by timestamp afterwards. strict: the scan "
+                "fires each shot itself and waits for every device — "
+                "slower, but nothing is ever missing."
+            ),
+            self.shot_count_label: (
+                "Total shots this form implies (positions × shots per "
+                "step). Above the runaway-scan limit, Start is disabled."
+            ),
+            self.description_edit: (
+                "Free-text note about this scan — it ends up in the scan's "
+                "metadata and the experiment log."
+            ),
+            # R4 presets
+            self.preset_combo: (
+                "Saved scan requests for this experiment (one YAML each in "
+                "the configs repo's presets folder)."
+            ),
+            self.apply_button: (
+                "Load the selected preset into the form. Anything the form "
+                "cannot express (action bindings, position lists) is "
+                "refused, leaving the form untouched."
+            ),
+            self.save_as_button: (
+                "Save the current form as a named preset — the exact scan "
+                "request it would submit."
+            ),
+            self.delete_button: "Delete the selected preset's YAML file.",
+            # R5 submit row
+            self.start_button: (
+                "Build the scan request from this form and hand it to the "
+                "scan engine. Needs a valid shot count and at least one "
+                "selected save set; engine refusals show in the status bar."
+            ),
+            self.stop_button: (
+                "Ask the engine to stop the running scan at the next safe "
+                "point (closeout actions still run)."
+            ),
+            # R6 now panel
+            self.state_pill: "What the scan engine is doing right now.",
+            self.progress_bar: (
+                "Shots completed out of the running scan's announced total."
+            ),
+            self.scan_number_label: (
+                "The scan folder claimed by the running scan; '(previous)' "
+                "is the last scan found in today's data folder."
+            ),
+            self.log_tail: "The most recent scan-engine and console messages.",
+            # R7 device panel
+            self.device_combo: (
+                "Type or pick 'DeviceName:Variable Name' to watch its live "
+                "readback from the gateway (updates on commit, not per "
+                "keystroke)."
+            ),
+            self.readback_label: (
+                "Live readback of the selected device variable, streamed "
+                "from the gateway."
+            ),
+            self.set_field: (
+                "Value to write to the selected device variable — a number, "
+                "or a word the device understands (e.g. 'on')."
+            ),
+            self.set_button: (
+                "Write the value via the gateway setpoint and report the "
+                "outcome in the status bar. Disabled while a write is in "
+                "flight."
+            ),
+        }
+        for widget, text in tooltips.items():
+            widget.setToolTip(text)
 
     def _build_menus(self) -> None:
         """Create the menu bar (Ops / Actions / Editors / Preferences / Help).
@@ -575,6 +742,7 @@ class MainWindow(QMainWindow):
         ):
             spin.valueChanged.connect(self._refresh_shot_count)
         self.shots_per_step.valueChanged.connect(self._refresh_shot_count)
+        self.optimization_combo.currentTextChanged.connect(self._refresh_submit_enabled)
         self.add_button.clicked.connect(self._on_add_save_set)
         self.remove_button.clicked.connect(self._on_remove_save_set)
         self.experiment_combo.currentTextChanged.connect(self._on_experiment_changed)
@@ -598,19 +766,21 @@ class MainWindow(QMainWindow):
         device_line_edit = self.device_combo.lineEdit()
         if device_line_edit is not None:
             device_line_edit.editingFinished.connect(self._resubscribe_device)
-        # Force queued connections: both signals are emitted off the GUI
-        # thread (CA monitor thread / set-dispatch daemon thread), and an
-        # undecorated direct delivery would paint widgets there (hard crash).
+        # Force a queued connection: the signal is emitted off the GUI thread
+        # (the CA monitor thread), and an undecorated direct delivery would
+        # paint widgets there (hard crash).
         self.device_value_ready.connect(
             self._apply_device_value, Qt.ConnectionType.QueuedConnection
         )
-        self.device_set_finished.connect(
+        # Device-set completion, the R7 completions, and the R6 idle
+        # scan-number peek: each result is emitted by a BackgroundResult
+        # worker (never by the window itself — a daemon-thread emit on a
+        # window-owned signal races teardown, issue #510) and delivered
+        # queued to its GUI-thread apply slot.
+        self._device_set_worker = BackgroundResult()
+        self._device_set_worker.result_ready.connect(
             self._apply_device_set_result, Qt.ConnectionType.QueuedConnection
         )
-        # R7 completions and the R6 idle scan-number peek: each result is
-        # emitted by a BackgroundResult worker (never by the window itself —
-        # a daemon-thread emit on a window-owned signal races teardown) and
-        # delivered queued to its GUI-thread apply slot.
         self._completions_worker = BackgroundResult()
         self._completions_worker.result_ready.connect(
             self._apply_device_completions, Qt.ConnectionType.QueuedConnection
@@ -653,6 +823,17 @@ class MainWindow(QMainWindow):
         self.available_list.clear()
         self.available_list.addItems(listing.save_sets)
         self.selected_list.clear()
+        # Optimizer configs (R3): keep the selection when the name survives
+        # the repopulation; offline the listing is empty, which leaves the
+        # combo empty and Start disabled in optimization mode.
+        current_optimization = self.optimization_combo.currentText()
+        self.optimization_combo.blockSignals(True)
+        self.optimization_combo.clear()
+        self.optimization_combo.addItems(listing.optimization_configs)
+        self.optimization_combo.setCurrentIndex(
+            self.optimization_combo.findText(current_optimization)
+        )
+        self.optimization_combo.blockSignals(False)
         self.trigger_profile_combo.blockSignals(True)
         self.trigger_profile_combo.clear()
         self.trigger_profile_combo.addItem("")
@@ -778,6 +959,7 @@ class MainWindow(QMainWindow):
                 self._apply_device_completions,
             ),
             (getattr(self, "_idle_scan_worker", None), self._apply_idle_scan_number),
+            (getattr(self, "_device_set_worker", None), self._apply_device_set_result),
         ):
             if worker is None:
                 continue
@@ -785,14 +967,10 @@ class MainWindow(QMainWindow):
                 worker.result_ready.disconnect(slot)
             except (RuntimeError, TypeError):
                 pass
-        for signal, slot in (
-            (self.device_value_ready, self._apply_device_value),
-            (self.device_set_finished, self._apply_device_set_result),
-        ):
-            try:
-                signal.disconnect(slot)
-            except (RuntimeError, TypeError):
-                pass
+        try:
+            self.device_value_ready.disconnect(self._apply_device_value)
+        except (RuntimeError, TypeError):
+            pass
         super().closeEvent(event)
 
     # ------------------------------------------------------------------
@@ -837,12 +1015,17 @@ class MainWindow(QMainWindow):
         -------
         ConsoleFormState
             The validated form model :func:`build_scan_request` consumes.
+            In optimization mode this resolves the selected optimizer
+            config's name into its loaded spec (the one place the form
+            snapshot reads a file), keeping the request builder pure.
 
         Raises
         ------
         pydantic.ValidationError
             When the widgets hold an invalid combination (e.g. an empty
             scan-variable name in a step mode).
+        ConsoleFormError
+            When the selected optimizer config cannot be loaded.
         """
         mode = self.current_mode()
         axes: list[FormAxis] = []
@@ -864,6 +1047,9 @@ class MainWindow(QMainWindow):
                     step=self.step2_spin.value(),
                 )
             )
+        optimization = None
+        if mode is ConsoleMode.OPTIMIZATION:
+            optimization = self._load_selected_optimization()
         profile = self.trigger_profile_combo.currentText() or None
         variant = self.trigger_variant_combo.currentText() or None
         from geecs_schemas import AcquisitionMode
@@ -877,7 +1063,33 @@ class MainWindow(QMainWindow):
             trigger_variant=variant if profile else None,
             acquisition=AcquisitionMode(self.acquisition_combo.currentText()),
             description=self.description_edit.text(),
+            optimization=optimization,
         )
+
+    def _load_selected_optimization(self):
+        """Resolve the R3 optimizer-config selection into its loaded spec.
+
+        Returns
+        -------
+        geecs_schemas.OptimizationSpec or None
+            The selected config's spec; ``None`` with nothing selected
+            (:func:`build_scan_request` then refuses with a clear message).
+
+        Raises
+        ------
+        ConsoleFormError
+            When the selected config exists in the combo but cannot be
+            loaded (missing file, bad YAML, schema rejection).
+        """
+        name = self.optimization_combo.currentText()
+        if not name:
+            return None
+        try:
+            return self._configs.optimization_spec(name)
+        except Exception as exc:  # ConsoleConfigsError, or a fake's failure
+            raise ConsoleFormError(
+                f"Cannot load optimizer config {name!r}: {exc}"
+            ) from exc
 
     # ------------------------------------------------------------------
     # R3 handlers
@@ -902,6 +1114,10 @@ class MainWindow(QMainWindow):
             self.step2_spin,
         ):
             widget.setEnabled(axis2)
+        # The optimizer-config row only exists for optimization mode.
+        optimize = mode is ConsoleMode.OPTIMIZATION
+        self.optimization_label.setVisible(optimize)
+        self.optimization_combo.setVisible(optimize)
         self._refresh_shot_count()
 
     def _estimation_form(self) -> ConsoleFormState:
@@ -1173,13 +1389,22 @@ class MainWindow(QMainWindow):
         return self._submitter is not None and self._submitter.is_scanning_active()
 
     def _refresh_submit_enabled(self) -> None:
-        """Recompute Start/Stop enabled state from form + engine."""
+        """Recompute Start/Stop enabled state from form + engine.
+
+        Optimization mode additionally needs a selected optimizer config —
+        that is the only optimize-specific gate; whether the engine accepts
+        an optimize submission is the engine's call, surfaced from
+        :meth:`_on_start_clicked` rather than pre-blocked here.
+        """
         scanning = self._scanning()
         ready = (
             not scanning
             and self._shot_count_valid
             and bool(self.selected_save_sets())
-            and self.current_mode() is not ConsoleMode.OPTIMIZATION
+            and (
+                self.current_mode() is not ConsoleMode.OPTIMIZATION
+                or bool(self.optimization_combo.currentText())
+            )
         )
         self.start_button.setEnabled(ready)
         self.stop_button.setEnabled(scanning)
@@ -1334,8 +1559,10 @@ class MainWindow(QMainWindow):
         Raises
         ------
         ConsoleFormError
-            More than two axes (the form has two axis rows) or an axis with
-            an explicit values list (the form only shows start/stop/step).
+            More than two axes (the form has two axis rows), an axis with
+            an explicit values list (the form only shows start/stop/step),
+            or an optimization spec matching none of the experiment's
+            optimizer configs (the form shows a config *name*, not a spec).
         """
         if len(form.axes) > 2:
             raise ConsoleFormError(
@@ -1347,6 +1574,9 @@ class MainWindow(QMainWindow):
                     f"axis {axis.variable!r} uses an explicit position list, "
                     "which the form cannot show (start/stop/step only)."
                 )
+        optimization_name = ""
+        if form.mode is ConsoleMode.OPTIMIZATION and form.optimization is not None:
+            optimization_name = self._match_optimization_config(form.optimization)
 
         radio = {
             ConsoleMode.NOSCAN: self.radio_noscan,
@@ -1367,6 +1597,8 @@ class MainWindow(QMainWindow):
             stop.setValue(axis.stop)
             step.setValue(axis.step)
 
+        if optimization_name:
+            self.optimization_combo.setCurrentText(optimization_name)
         self.shots_per_step.setValue(form.shots_per_step)
         self.acquisition_combo.setCurrentText(form.acquisition.value)
         self.description_edit.setText(form.description)
@@ -1376,6 +1608,44 @@ class MainWindow(QMainWindow):
         self.trigger_variant_combo.setCurrentText(form.trigger_variant or "")
         self._apply_save_sets(form.save_sets)
         self._refresh_shot_count()
+
+    def _match_optimization_config(self, spec: object) -> str:
+        """Find the listed optimizer config whose loaded spec equals *spec*.
+
+        The form expresses optimization as a config *name* (the R3 combo),
+        so applying a preset that carries an inline spec means finding the
+        experiment's config with identical content — pydantic equality over
+        the loaded documents.  Unloadable configs are skipped.
+
+        Parameters
+        ----------
+        spec : OptimizationSpec
+            The preset's optimization block.
+
+        Returns
+        -------
+        str
+            The matching config name from the combo.
+
+        Raises
+        ------
+        ConsoleFormError
+            When no listed config matches — selecting anything else would
+            silently change what the preset submits.
+        """
+        for index in range(self.optimization_combo.count()):
+            name = self.optimization_combo.itemText(index)
+            try:
+                if self._configs.optimization_spec(name) == spec:
+                    return name
+            except Exception as exc:  # noqa: BLE001 — an unloadable config just can't match
+                logger.info(
+                    "optimizer config %r unloadable while matching: %s", name, exc
+                )
+        raise ConsoleFormError(
+            "its optimization spec matches none of this experiment's "
+            "optimizer configs — the form can only show a named config."
+        )
 
     def _apply_save_sets(self, names: list[str]) -> None:
         """Make the R2 selected list exactly *names* (known ones, in order).
@@ -1530,7 +1800,16 @@ class MainWindow(QMainWindow):
         self.readback_label.setText(format_readback(value))
 
     def _on_device_set_clicked(self) -> None:
-        """Dispatch the blocking backend set to a daemon thread."""
+        """Dispatch the blocking backend set through the set worker.
+
+        The blocking ``backend.set`` runs on a short-lived daemon thread via
+        the :class:`BackgroundResult` set worker, whose ``result_ready``
+        signal delivers the ``(ok, message)`` outcome queued back to
+        :meth:`_apply_device_set_result` — the worker owns the cross-thread
+        emission, never the window (issue #510).  The dispatched callable
+        catches every backend failure and returns it as a result, so the
+        in-flight flag is always re-armed.
+        """
         parsed = parse_device_variable(self.device_combo.currentText())
         text = self.set_field.text().strip()
         if parsed is None:
@@ -1542,44 +1821,30 @@ class MainWindow(QMainWindow):
         device, variable = parsed
         value = parse_set_value(text)
         experiment = self.experiment_combo.currentText()
+        backend = self._device_panel
+
+        def run_set() -> tuple[bool, str]:
+            try:
+                backend.set(experiment, device, variable, value)
+            except Exception as exc:  # noqa: BLE001 — any failure is a status report
+                return (False, f"Set {device}:{variable} failed: {exc}")
+            return (True, f"Set {device}:{variable} = {value}")
+
         self._device_set_in_flight = True
         self._refresh_device_set_enabled()
-        threading.Thread(
-            target=self._run_device_set,
-            args=(experiment, device, variable, value),
-            name="console-device-set",
-            daemon=True,
-        ).start()
+        self._device_set_worker.run_async(run_set, name="console-device-set")
 
-    def _run_device_set(
-        self, experiment: str, device: str, variable: str, value: object
-    ) -> None:
-        """Run the blocking set (on the daemon thread) and emit the outcome."""
-        try:
-            self._device_panel.set(experiment, device, variable, value)
-        except Exception as exc:  # noqa: BLE001 — any failure is a status report
-            ok, message = False, f"Set {device}:{variable} failed: {exc}"
-        else:
-            ok, message = True, f"Set {device}:{variable} = {value}"
-        try:
-            self.device_set_finished.emit(ok, message)
-        except RuntimeError:
-            # The window was closed and C++-deleted while the set ran
-            # (closeEvent never joins this thread) — nothing left to report to.
-            pass
-
-    @Slot(bool, str)
-    def _apply_device_set_result(self, ok: bool, message: str) -> None:
+    @Slot(object)
+    def _apply_device_set_result(self, payload: object) -> None:
         """Report one finished set and re-arm the button (GUI-thread slot).
 
         Parameters
         ----------
-        ok : bool
-            Whether the set completed (unused beyond the message — failures
-            already carry the exception text).
-        message : str
-            The status-bar / log line.
+        payload : tuple
+            ``(ok, message)`` from the set worker; ``ok`` is unused beyond
+            the message — failures already carry the exception text.
         """
+        _ok, message = payload
         self._device_set_in_flight = False
         self.statusBar().showMessage(message, 10_000)
         self.append_log(message)

--- a/GEECS-Console/geecs_console/app/main_window.py
+++ b/GEECS-Console/geecs_console/app/main_window.py
@@ -19,7 +19,7 @@ import threading
 from pathlib import Path
 from typing import Callable, Optional
 
-from PySide6.QtCore import QFile, QObject, Qt, QTimer, QUrl, Signal, Slot
+from PySide6.QtCore import QEvent, QFile, QObject, Qt, QTimer, QUrl, Signal, Slot
 from PySide6.QtGui import QDesktopServices
 from PySide6.QtUiTools import QUiLoader
 from PySide6.QtWidgets import (
@@ -253,6 +253,47 @@ class BackgroundResult(QObject):
             self.result_ready.emit(result)
         except RuntimeError:
             pass  # the worker was deleted while the call ran
+
+
+class ToolTipSuppressor(QObject):
+    """Application-level event filter that swallows every tooltip event.
+
+    Installed on the ``QApplication`` **only while tooltips are turned
+    off** — presence means suppression, so one switch covers every console
+    widget (the main window *and* the editor dialogs, whose schema-derived
+    tooltips are applied unconditionally) and the default-on path pays no
+    per-event Python filter cost at all.  Parented to the window: Qt
+    removes a destroyed filter from the application automatically, so a
+    closed window can never leave a dangling suppressor behind.
+
+    Parameters
+    ----------
+    parent : QObject
+        The owning window (keeps the wrapper referenced — the usual
+        PySide6 GC hazard — and bounds the filter's lifetime).
+    """
+
+    def __init__(self, parent: QObject) -> None:
+        super().__init__(parent)
+
+    def eventFilter(self, obj, event) -> bool:  # noqa: N802 — Qt override
+        """Swallow ``QEvent.ToolTip``; pass everything else through.
+
+        Parameters
+        ----------
+        obj : QObject
+            The event's target (unused — suppression is global).
+        event : QEvent
+            The event under consideration.
+
+        Returns
+        -------
+        bool
+            ``True`` (consume the event) for tooltip events.
+        """
+        if event.type() == QEvent.Type.ToolTip:
+            return True
+        return super().eventFilter(obj, event)
 
 
 class MainWindow(QMainWindow):
@@ -706,6 +747,18 @@ class MainWindow(QMainWindow):
         self.random_beep_action.setCheckable(True)
         self.random_beep_action.setChecked(bool(self._settings.randomized_beeps))
         self.random_beep_action.toggled.connect(self._on_randomized_beeps_toggled)
+        prefs.addSeparator()
+        # Tooltips default on (discoverability); an experienced operator
+        # turns them off here.  One application-level suppressor covers the
+        # main window and every editor dialog, installed only while off.
+        self.show_tooltips_action = prefs.addAction("Show tooltips")
+        self.show_tooltips_action.setCheckable(True)
+        self.show_tooltips_action.setChecked(bool(self._settings.show_tooltips))
+        self.show_tooltips_action.toggled.connect(self._on_show_tooltips_toggled)
+        self._tooltip_suppressor = ToolTipSuppressor(self)
+        self._tooltip_suppressor_installed = False
+        if not self._settings.show_tooltips:
+            self._set_tooltips_shown(False)
 
         help_menu = self.menuBar().addMenu("Help")
         self._menus.append(help_menu)
@@ -941,6 +994,11 @@ class MainWindow(QMainWindow):
         timer = getattr(self, "_health_timer", None)
         if timer is not None:
             timer.stop()
+        # A closed window must not keep suppressing application tooltips
+        # (Qt would also drop the filter when the window is destroyed, but
+        # close-without-destroy is the common test teardown shape).
+        if getattr(self, "_tooltip_suppressor_installed", False):
+            self._set_tooltips_shown(True)
         poller = getattr(self, "_health_poller", None)
         if poller is not None:
             try:
@@ -1362,6 +1420,39 @@ class MainWindow(QMainWindow):
             The action's new checked state.
         """
         self._settings.randomized_beeps = checked
+
+    def _on_show_tooltips_toggled(self, checked: bool) -> None:
+        """Persist the tooltip preference and apply it.
+
+        Parameters
+        ----------
+        checked : bool
+            The action's new checked state (``True`` shows tooltips).
+        """
+        self._settings.show_tooltips = checked
+        self._set_tooltips_shown(checked)
+
+    def _set_tooltips_shown(self, shown: bool) -> None:
+        """Install or remove the application-wide tooltip suppressor.
+
+        The suppressor is present on the ``QApplication`` only while
+        tooltips are off, so the default-on path adds no per-event filter
+        overhead.  Idempotent via the installed flag.
+
+        Parameters
+        ----------
+        shown : bool
+            ``True`` shows tooltips (suppressor removed).
+        """
+        app = QApplication.instance()
+        if app is None:
+            return
+        if shown and self._tooltip_suppressor_installed:
+            app.removeEventFilter(self._tooltip_suppressor)
+            self._tooltip_suppressor_installed = False
+        elif not shown and not self._tooltip_suppressor_installed:
+            app.installEventFilter(self._tooltip_suppressor)
+            self._tooltip_suppressor_installed = True
 
     def _maybe_beep(self) -> None:
         """Sound one per-shot beep, honoring the Preferences options.

--- a/GEECS-Console/geecs_console/app/ui/main_window.ui
+++ b/GEECS-Console/geecs_console/app/ui/main_window.ui
@@ -306,6 +306,37 @@
            </layout>
           </item>
           <item>
+           <layout class="QHBoxLayout" name="r3_optimization_layout">
+            <item>
+             <widget class="QLabel" name="r3_optimization_label">
+              <property name="text">
+               <string>Optimization config</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QComboBox" name="r3_optimization_combo">
+              <property name="minimumWidth">
+               <number>220</number>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <spacer name="r3_optimization_spacer">
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>10</width>
+                <height>10</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+           </layout>
+          </item>
+          <item>
            <layout class="QGridLayout" name="r3_axes_layout">
             <item row="0" column="8">
              <spacer name="r3_axes_spacer">

--- a/GEECS-Console/geecs_console/editors/action_library_editor.py
+++ b/GEECS-Console/geecs_console/editors/action_library_editor.py
@@ -72,7 +72,9 @@ from geecs_console.services.device_completions import (
     EmptyCompletions,
     GeecsDbCompletions,
 )
+from geecs_console.services.schema_tooltips import apply_schema_tooltips
 from geecs_schemas import ActionPlan
+from geecs_schemas.action_plan import CheckStep, RunPlanStep, SetStep, WaitStep
 
 logger = logging.getLogger(__name__)
 
@@ -377,6 +379,33 @@ class ActionLibraryEditor(QDialog):
         self.run_warning_label.setStyleSheet("color: #d9a21b;")  # --warn amber
         self.error_label.setStyleSheet("color: #c4453a;")  # --abort red
         self.run_plan_combo.setInsertPolicy(QComboBox.InsertPolicy.NoInsert)
+
+        # Tooltips come from the schema field descriptions — one source of
+        # truth for what each field means (issue #497 phase 1).  Each step
+        # kind's page maps to its own step model.
+        apply_schema_tooltips(
+            ActionPlan,
+            {"description": self.description_edit, "steps": self.steps_table},
+        )
+        apply_schema_tooltips(
+            SetStep,
+            {
+                "device": self.set_device_edit,
+                "variable": self.set_variable_edit,
+                "value": self.set_value_edit,
+                "wait_for_execution": self.set_wait_check,
+            },
+        )
+        apply_schema_tooltips(WaitStep, {"seconds": self.wait_seconds_spin})
+        apply_schema_tooltips(
+            CheckStep,
+            {
+                "device": self.check_device_edit,
+                "variable": self.check_variable_edit,
+                "expected": self.check_expected_edit,
+            },
+        )
+        apply_schema_tooltips(RunPlanStep, {"plan": self.run_plan_combo})
 
     def _wire_signals(self) -> None:
         """Connect every widget signal to its handler."""

--- a/GEECS-Console/geecs_console/editors/save_set_editor.py
+++ b/GEECS-Console/geecs_console/editors/save_set_editor.py
@@ -55,6 +55,7 @@ from geecs_console.services.device_completions import (
     GeecsDbCompletions,
 )
 from geecs_console.services.save_set_store import SaveSetStore, SaveSetStoreError
+from geecs_console.services.schema_tooltips import apply_schema_tooltips
 from geecs_schemas import SaveRole, SaveSet, SaveSetEntry
 
 logger = logging.getLogger(__name__)
@@ -242,6 +243,29 @@ class SaveSetEditor(QDialog):
         self.role_combo.addItem(_ROLE_DERIVED_LABEL, None)
         for role in SaveRole:
             self.role_combo.addItem(role.value, role.value)
+
+        # Tooltips come from the schema field descriptions — one source of
+        # truth for what each field means (issue #497 phase 1).
+        apply_schema_tooltips(
+            SaveSet,
+            {
+                "description": self.description_edit,
+                "entries": self.device_list,
+            },
+        )
+        apply_schema_tooltips(
+            SaveSetEntry,
+            {
+                "device": self.device_edit,
+                "images": self.images_check,
+                "db_scalars": self.db_scalars_check,
+                "all_scalars": self.all_scalars_check,
+                "role": self.role_combo,
+                "scalars": [self.scalar_list, self.scalar_edit],
+                "setup": self.setup_edit,
+                "closeout": self.closeout_edit,
+            },
+        )
 
     def _guard_default_buttons(self) -> None:
         """Keep Enter in a line edit from triggering dialog accept.

--- a/GEECS-Console/geecs_console/editors/scan_variable_editor.py
+++ b/GEECS-Console/geecs_console/editors/scan_variable_editor.py
@@ -72,7 +72,13 @@ from geecs_console.services.scan_variable_store import (
     ScanVariableStore,
     ScanVariableStoreError,
 )
-from geecs_schemas import CompositeMode, ScanVariables
+from geecs_console.services.schema_tooltips import apply_schema_tooltips
+from geecs_schemas import (
+    CompositeMode,
+    PseudoScanVariable,
+    ScanVariable,
+    ScanVariables,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -344,6 +350,27 @@ class ScanVariableEditor(QDialog):
         self.revert_button: QPushButton = self._child(QPushButton, "sve_revert_button")
         self.save_button: QPushButton = self._child(QPushButton, "sve_save_button")
         self.close_button: QPushButton = self._child(QPushButton, "sve_close_button")
+
+        # Tooltips come from the schema field descriptions — one source of
+        # truth for what each field means (issue #497 phase 1).  The
+        # Device/Variable edit pairs jointly form one 'Device:Variable'
+        # schema field, so both halves carry that field's description.
+        apply_schema_tooltips(
+            ScanVariable,
+            {
+                "target": [self.device_edit, self.variable_edit],
+                "kind": self.kind_combo,
+                "confirm": [self.confirm_device_edit, self.confirm_variable_edit],
+            },
+        )
+        apply_schema_tooltips(
+            PseudoScanVariable,
+            {
+                "mode": self.mode_combo,
+                "targets": self.components_table,
+                "inverse": self.inverse_edit,
+            },
+        )
 
     def _populate_static_combos(self) -> None:
         """Fill the kind and mode combos from the schema vocabularies."""

--- a/GEECS-Console/geecs_console/editors/shot_control_editor.py
+++ b/GEECS-Console/geecs_console/editors/shot_control_editor.py
@@ -64,6 +64,7 @@ from geecs_console.services.trigger_profile_store import (
     TriggerProfileStore,
     TriggerProfileStoreError,
 )
+from geecs_console.services.schema_tooltips import apply_schema_tooltips
 from geecs_schemas import TriggerProfile, TriggerState
 
 logger = logging.getLogger(__name__)
@@ -310,6 +311,17 @@ class ShotControlEditor(QDialog):
         )
         self.states_tree.setColumnWidth(0, 280)
         self.states_tree.setColumnWidth(1, 220)
+
+        # Tooltips come from the schema field descriptions — one source of
+        # truth for what each field means (issue #497 phase 1).
+        apply_schema_tooltips(
+            TriggerProfile,
+            {
+                "description": self.description_edit,
+                "states": self.states_tree,
+                "variants": self.variant_combo,
+            },
+        )
 
     def _wire_signals(self) -> None:
         """Connect widget signals to the handlers."""

--- a/GEECS-Console/geecs_console/request_builder.py
+++ b/GEECS-Console/geecs_console/request_builder.py
@@ -18,6 +18,7 @@ from pydantic import BaseModel, Field, model_validator
 
 from geecs_schemas import (
     AcquisitionMode,
+    OptimizationSpec,
     PositionList,
     PositionRange,
     Positions,
@@ -46,7 +47,8 @@ class ConsoleMode(str, Enum):
     GRID : str
         Sweep two or more variables as an outer-product grid.
     OPTIMIZATION : str
-        Let an optimizer drive the settings (not wired in this version).
+        Let an optimizer drive the settings, per a named optimizer config
+        loaded into the form's ``optimization`` spec.
     BACKGROUND : str
         A noscan whose data is marked as background/calibration shots.
     """
@@ -121,7 +123,12 @@ class FormAxis(BaseModel):
 
 
 class ConsoleFormState(BaseModel):
-    """Snapshot of the scan form — everything the operator chose on screen."""
+    """Snapshot of the scan form — everything the operator chose on screen.
+
+    ``optimization`` carries the *loaded* spec of the optimizer config the
+    R3 combo names (the window resolves name → spec when snapshotting), so
+    this model — and :func:`build_scan_request` — stays pure: no file I/O.
+    """
 
     mode: ConsoleMode = ConsoleMode.ONE_D
     axes: list[FormAxis] = Field(default_factory=list)
@@ -132,6 +139,7 @@ class ConsoleFormState(BaseModel):
     acquisition: AcquisitionMode = AcquisitionMode.FREE_RUN
     description: str = ""
     background: bool = False
+    optimization: Optional[OptimizationSpec] = None
 
 
 def _position_count(positions: Positions) -> int:
@@ -197,18 +205,13 @@ def build_scan_request(form: ConsoleFormState) -> ScanRequest:
     Raises
     ------
     ConsoleFormError
-        On optimization mode (not wired yet), a missing/extra axis for the
-        mode, or a total shot count above :data:`MAXIMUM_SCAN_SIZE`.
+        On optimization mode without a loaded optimization spec, a
+        missing/extra axis for the mode, or a total shot count above
+        :data:`MAXIMUM_SCAN_SIZE`.
     pydantic.ValidationError
         When the schema itself rejects the assembled request (e.g. a
         trigger variant without a profile, duplicate axis variables).
     """
-    if form.mode is ConsoleMode.OPTIMIZATION:
-        raise ConsoleFormError(
-            "Optimization submission is not wired in this version of the "
-            "console — it needs an OptimizationSpec editor."
-        )
-
     if form.mode in (ConsoleMode.ONE_D, ConsoleMode.GRID):
         if form.mode is ConsoleMode.ONE_D and len(form.axes) != 1:
             raise ConsoleFormError("A 1D scan needs exactly one axis.")
@@ -219,6 +222,14 @@ def build_scan_request(form: ConsoleFormState) -> ScanRequest:
             ScanAxis(variable=axis.variable, positions=axis.to_positions())
             for axis in form.axes
         ]
+    elif form.mode is ConsoleMode.OPTIMIZATION:
+        if form.optimization is None:
+            raise ConsoleFormError(
+                "An optimization scan needs an optimization config — pick "
+                "one in the scan form."
+            )
+        mode = ScanRequestMode.OPTIMIZE
+        axes = []
     else:
         mode = ScanRequestMode.NOSCAN
         axes = []
@@ -241,6 +252,10 @@ def build_scan_request(form: ConsoleFormState) -> ScanRequest:
         trigger_variant=form.trigger_variant,
         description=form.description,
         background=form.background or form.mode is ConsoleMode.BACKGROUND,
+        # Passed through for every mode — a stray spec on a non-optimize
+        # form is a bug the schema's consistency validator surfaces loudly
+        # rather than being silently dropped here.
+        optimization=form.optimization,
     )
 
 
@@ -264,19 +279,15 @@ def form_state_from_request(request: ScanRequest) -> ConsoleFormState:
         Form state that :func:`build_scan_request` maps back onto an
         equivalent request.  A ``noscan`` with the ``background`` flag
         becomes :attr:`ConsoleMode.BACKGROUND` (the same folding the
-        builder applies in the other direction).
+        builder applies in the other direction); an ``optimize`` request
+        becomes :attr:`ConsoleMode.OPTIMIZATION` carrying the request's
+        optimization spec.
 
     Raises
     ------
     ConsoleFormError
-        For an ``optimize`` request (no OptimizationSpec editor yet) or a
-        request carrying action bindings — both inexpressible on the form.
+        For a request carrying action bindings — inexpressible on the form.
     """
-    if request.mode is ScanRequestMode.OPTIMIZE:
-        raise ConsoleFormError(
-            "This preset is an optimization scan — the console form cannot "
-            "express it (no OptimizationSpec editor yet)."
-        )
     if request.actions.setup or request.actions.per_step or request.actions.closeout:
         raise ConsoleFormError(
             "This preset carries action bindings (setup/per_step/closeout), "
@@ -288,6 +299,10 @@ def form_state_from_request(request: ScanRequest) -> ConsoleFormState:
         mode = ConsoleMode.BACKGROUND if request.background else ConsoleMode.NOSCAN
         background = False  # folded into the mode, mirroring the builder
         axes: list[FormAxis] = []
+    elif request.mode is ScanRequestMode.OPTIMIZE:
+        mode = ConsoleMode.OPTIMIZATION
+        background = request.background
+        axes = []
     else:
         mode = ConsoleMode.ONE_D if len(request.axes) == 1 else ConsoleMode.GRID
         background = request.background
@@ -317,4 +332,5 @@ def form_state_from_request(request: ScanRequest) -> ConsoleFormState:
         acquisition=request.acquisition,
         description=request.description,
         background=background,
+        optimization=request.optimization,
     )

--- a/GEECS-Console/geecs_console/services/configs.py
+++ b/GEECS-Console/geecs_console/services/configs.py
@@ -20,6 +20,12 @@ logger = logging.getLogger(__name__)
 
 SAVE_SET_FOLDER = "save_devices"
 TRIGGER_FOLDER = "shot_control_configurations"
+#: Optimizer configs keep the legacy GEECS-Scanner-GUI folder name.
+OPTIMIZATION_FOLDER = "optimizer_configs"
+
+
+class ConsoleConfigsError(RuntimeError):
+    """A named config cannot be resolved (surfaced in the status bar)."""
 
 
 @dataclass(frozen=True)
@@ -30,6 +36,7 @@ class ConfigListing:
     save_sets: list[str] = field(default_factory=list)
     trigger_profiles: list[str] = field(default_factory=list)
     scan_variables: list[str] = field(default_factory=list)
+    optimization_configs: list[str] = field(default_factory=list)
     configs_root: Optional[Path] = None
     message: Optional[str] = None
 
@@ -133,6 +140,7 @@ class ConsoleConfigs:
             save_sets=_yaml_stems(root / SAVE_SET_FOLDER),
             trigger_profiles=_yaml_stems(root / TRIGGER_FOLDER),
             scan_variables=self._scan_variable_names(),
+            optimization_configs=_yaml_stems(root / OPTIMIZATION_FOLDER),
             configs_root=base,
         )
 
@@ -202,6 +210,93 @@ class ConsoleConfigs:
         ]
         hint = f"reference: {', '.join(references)}" if references else ""
         return UnionPreview(device_count=len(merged.entries), hint=hint)
+
+    def optimization_spec(self, name: str) -> Any:
+        """Load optimizer config *name* as a validated ``OptimizationSpec``.
+
+        Reads ``<experiment>/optimizer_configs/<name>.yaml`` (the folder
+        name the legacy GEECS-Scanner-GUI used) directly — the resolver has
+        no optimization kind yet.  Both dialects are accepted: a plain
+        new-schema :class:`~geecs_schemas.OptimizationSpec` document, or a
+        legacy optimizer config (recognized by its ``vocs`` key) run through
+        :func:`geecs_schemas.convert.convert_optimizer_config`.
+
+        Parameters
+        ----------
+        name : str
+            The config name (YAML file stem from the listing).
+
+        Returns
+        -------
+        geecs_schemas.OptimizationSpec
+            The validated optimization block for a ``mode: optimize``
+            :class:`~geecs_schemas.ScanRequest`.
+
+        Raises
+        ------
+        ConsoleConfigsError
+            Missing configs repo / experiment / file, unparsable YAML, or a
+            document neither dialect accepts — always with a message fit
+            for the status bar.
+        """
+        import yaml
+
+        base = _configs_base()
+        if base is None:
+            raise ConsoleConfigsError(
+                "Configs repo not found — set GEECS_SCANNER_CONFIG_DIR or "
+                "config.ini [Paths] scanner_config_root_path."
+            )
+        if not self._experiment:
+            raise ConsoleConfigsError("No experiment selected.")
+        folder = base / self._experiment / OPTIMIZATION_FOLDER
+        path = folder / f"{name}.yaml"
+        if not path.exists():
+            twin = folder / f"{name}.yml"
+            if twin.exists():
+                path = twin
+        if not path.exists():
+            raise ConsoleConfigsError(f"Optimizer config {name!r} not found ({path}).")
+        try:
+            document = yaml.safe_load(path.read_text(encoding="utf-8"))
+        except yaml.YAMLError as exc:
+            raise ConsoleConfigsError(
+                f"Optimizer config {name!r} is not valid YAML ({path}): {exc}"
+            ) from exc
+        if not isinstance(document, dict):
+            raise ConsoleConfigsError(
+                f"Optimizer config {name!r} ({path}) should be a YAML "
+                f"mapping, got {type(document).__name__}."
+            )
+        if "vocs" in document:
+            # The legacy GEECS-Scanner-GUI dialect (new-schema documents
+            # can't carry a 'vocs' key under extra='forbid').
+            from geecs_schemas.convert import (
+                SchemaConversionError,
+                convert_optimizer_config,
+            )
+
+            try:
+                conversion = convert_optimizer_config(document, name=name)
+            except SchemaConversionError as exc:
+                raise ConsoleConfigsError(
+                    f"Optimizer config {name!r} ({path}) could not be "
+                    f"converted from the legacy dialect: {exc}"
+                ) from exc
+            for note in conversion.notes:
+                logger.info("optimizer config %r: %s", name, note)
+            return conversion.optimization
+        from pydantic import ValidationError
+
+        from geecs_schemas import OptimizationSpec
+
+        try:
+            return OptimizationSpec.model_validate(document)
+        except ValidationError as exc:
+            raise ConsoleConfigsError(
+                f"Optimizer config {name!r} ({path}) is not a valid "
+                f"OptimizationSpec: {exc}"
+            ) from exc
 
     def trigger_variants(self, profile_name: str) -> list[str]:
         """List the variants of one trigger profile (R1 variant combo).

--- a/GEECS-Console/geecs_console/services/schema_tooltips.py
+++ b/GEECS-Console/geecs_console/services/schema_tooltips.py
@@ -1,0 +1,73 @@
+"""Widget tooltips derived from pydantic ``Field(description=...)`` texts.
+
+The geecs-schemas models carry an operator-facing description on every
+field; the editors' form widgets show those descriptions as tooltips so the
+GUI text and the schema documentation are one source of truth (issue #497
+phase 1).  A widget whose meaning matches a schema field must get its
+tooltip through :func:`apply_schema_tooltips` — never a hand-written copy
+that can drift.  Hand-written tooltips are reserved for pure GUI concepts
+with no schema counterpart (buttons, lists, status chips).
+"""
+
+from __future__ import annotations
+
+from typing import Type
+
+from pydantic import BaseModel
+
+
+def schema_tooltip(model_cls: Type[BaseModel], field_name: str) -> str:
+    """Return the tooltip text for one schema field.
+
+    Parameters
+    ----------
+    model_cls : type
+        The pydantic model that declares the field.
+    field_name : str
+        The field's Python name (not its alias).
+
+    Returns
+    -------
+    str
+        The field's ``description``.
+
+    Raises
+    ------
+    KeyError
+        When the model has no such field (a typo here, or a renamed field).
+    LookupError
+        When the field exists but carries no description — add one to the
+        schema (the single source of truth) instead of hardcoding GUI text.
+    """
+    description = model_cls.model_fields[field_name].description
+    if not description:
+        raise LookupError(
+            f"{model_cls.__name__}.{field_name} has no Field description — "
+            "add one in geecs-schemas rather than hardcoding tooltip text."
+        )
+    return description
+
+
+def apply_schema_tooltips(model_cls: Type[BaseModel], widgets: dict) -> None:
+    """Set each widget's tooltip from its schema field's description.
+
+    Parameters
+    ----------
+    model_cls : type
+        The pydantic model the widgets edit.
+    widgets : dict
+        ``{field_name: widget}`` — or ``{field_name: [widget, ...]}`` when
+        several widgets edit one field (e.g. a Device/Variable edit pair
+        that together form a ``Device:Variable`` target).
+
+    Raises
+    ------
+    KeyError, LookupError
+        Propagated from :func:`schema_tooltip` — a bad mapping fails loudly
+        at editor construction, which the editor tests exercise.
+    """
+    for field_name, widget in widgets.items():
+        text = schema_tooltip(model_cls, field_name)
+        targets = widget if isinstance(widget, (list, tuple)) else (widget,)
+        for target in targets:
+            target.setToolTip(text)

--- a/GEECS-Console/geecs_console/services/settings.py
+++ b/GEECS-Console/geecs_console/services/settings.py
@@ -23,6 +23,7 @@ _APPLICATION = "GEECS-Console"
 _LAST_EXPERIMENT_KEY = "session/last_experiment"
 _PER_SHOT_BEEP_KEY = "preferences/per_shot_beep"
 _RANDOMIZED_BEEPS_KEY = "preferences/randomized_beeps"
+_SHOW_TOOLTIPS_KEY = "preferences/show_tooltips"
 
 
 class ConsoleSettings:
@@ -83,3 +84,12 @@ class ConsoleSettings:
     @randomized_beeps.setter
     def randomized_beeps(self, value: bool) -> None:
         self._set_bool(_RANDOMIZED_BEEPS_KEY, value)
+
+    @property
+    def show_tooltips(self) -> bool:
+        """Whether widget tooltips are shown (default on — discoverability first)."""
+        return bool(self._settings.value(_SHOW_TOOLTIPS_KEY, True, type=bool))
+
+    @show_tooltips.setter
+    def show_tooltips(self, value: bool) -> None:
+        self._set_bool(_SHOW_TOOLTIPS_KEY, value)

--- a/GEECS-Console/pyproject.toml
+++ b/GEECS-Console/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-console"
-version = "0.6.3"
+version = "0.7.0"
 description = "Greenfield PySide6 operator console for GEECS (Bluesky/gateway architecture)"
 authors = ["Sam Barber <sbarber@lbl.gov>"]
 readme = "README.md"

--- a/GEECS-Console/tests/test_configs_optimization.py
+++ b/GEECS-Console/tests/test_configs_optimization.py
@@ -1,0 +1,103 @@
+"""ConsoleConfigs optimizer-config listing and loading, against a tmp tree."""
+
+import pytest
+
+from geecs_console.services import configs as configs_module
+from geecs_console.services.configs import (
+    OPTIMIZATION_FOLDER,
+    ConsoleConfigs,
+    ConsoleConfigsError,
+)
+from geecs_schemas import OptimizationSpec
+
+NEW_SCHEMA_YAML = """\
+variables:
+  jet_x: [0.0, 1.0]
+objectives:
+  counts: MAXIMIZE
+evaluator:
+  module: my.evaluators
+  class: BeamCounts
+generator:
+  name: random
+"""
+
+LEGACY_YAML = """\
+vocs:
+  variables:
+    U_Hexapod:ypos: [17.0, 19.0]
+  objectives:
+    f: MINIMIZE
+evaluator:
+  module: my.evaluators
+  class: Legacy
+  kwargs: {}
+generator:
+  name: bayes_default
+"""
+
+
+@pytest.fixture
+def configs_tree(tmp_path, monkeypatch):
+    """A tmp experiments root with one experiment's optimizer configs."""
+    folder = tmp_path / "HTU" / OPTIMIZATION_FOLDER
+    folder.mkdir(parents=True)
+    (folder / "new_style.yaml").write_text(NEW_SCHEMA_YAML, encoding="utf-8")
+    (folder / "legacy_style.yaml").write_text(LEGACY_YAML, encoding="utf-8")
+    (folder / "broken.yaml").write_text("just a string", encoding="utf-8")
+    monkeypatch.setenv("GEECS_SCANNER_CONFIG_DIR", str(tmp_path))
+    return tmp_path
+
+
+class TestListing:
+    def test_listing_includes_optimizer_config_stems(self, configs_tree):
+        listing = ConsoleConfigs("HTU").listing()
+        assert listing.optimization_configs == [
+            "broken",
+            "legacy_style",
+            "new_style",
+        ]
+
+    def test_listing_empty_without_optimizer_folder(self, configs_tree):
+        (configs_tree / "Bella").mkdir()
+        listing = ConsoleConfigs("Bella").listing()
+        assert listing.optimization_configs == []
+
+
+class TestOptimizationSpecLoading:
+    def test_new_schema_document_loads_directly(self, configs_tree):
+        spec = ConsoleConfigs("HTU").optimization_spec("new_style")
+        assert isinstance(spec, OptimizationSpec)
+        assert spec.variables == {"jet_x": (0.0, 1.0)}
+        assert spec.objectives == {"counts": "MAXIMIZE"}
+        assert spec.generator.name == "random"
+
+    def test_legacy_vocs_document_converts(self, configs_tree):
+        spec = ConsoleConfigs("HTU").optimization_spec("legacy_style")
+        assert isinstance(spec, OptimizationSpec)
+        assert spec.variables == {"U_Hexapod:ypos": (17.0, 19.0)}
+        assert spec.objectives == {"f": "MINIMIZE"}
+        assert spec.generator.name == "bayes_default"
+
+    def test_non_mapping_document_raises(self, configs_tree):
+        with pytest.raises(ConsoleConfigsError, match="YAML mapping"):
+            ConsoleConfigs("HTU").optimization_spec("broken")
+
+    def test_missing_config_raises(self, configs_tree):
+        with pytest.raises(ConsoleConfigsError, match="not found"):
+            ConsoleConfigs("HTU").optimization_spec("nope")
+
+    def test_invalid_new_schema_document_raises(self, configs_tree):
+        folder = configs_tree / "HTU" / OPTIMIZATION_FOLDER
+        (folder / "bad.yaml").write_text("variables: {}\n", encoding="utf-8")
+        with pytest.raises(ConsoleConfigsError, match="not a valid"):
+            ConsoleConfigs("HTU").optimization_spec("bad")
+
+    def test_offline_raises_with_actionable_message(self, monkeypatch):
+        monkeypatch.setattr(configs_module, "_configs_base", lambda: None)
+        with pytest.raises(ConsoleConfigsError, match="Configs repo not found"):
+            ConsoleConfigs("HTU").optimization_spec("anything")
+
+    def test_no_experiment_selected_raises(self, configs_tree):
+        with pytest.raises(ConsoleConfigsError, match="No experiment"):
+            ConsoleConfigs("").optimization_spec("new_style")

--- a/GEECS-Console/tests/test_main_window.py
+++ b/GEECS-Console/tests/test_main_window.py
@@ -12,14 +12,22 @@ from geecs_console.request_builder import (
     FormAxis,
     build_scan_request,
 )
-from geecs_console.services.configs import ConfigListing, UnionPreview
+from geecs_console.services.configs import (
+    ConfigListing,
+    ConsoleConfigsError,
+    UnionPreview,
+)
 from geecs_console.services.health import HealthReport, HealthStatus
 from geecs_console.services.presets import PresetStoreError
 from geecs_schemas import ScanRequestMode
 
 
 class FakeConfigs:
-    """ConsoleConfigs stand-in: fixed listings, no filesystem."""
+    """ConsoleConfigs stand-in: fixed listings, no filesystem.
+
+    ``optimization_specs`` maps config name -> OptimizationSpec, standing in
+    for the ``optimizer_configs/`` YAML files (the listing shows its keys).
+    """
 
     def __init__(
         self,
@@ -28,12 +36,14 @@ class FakeConfigs:
         scan_variables=(),
         experiment="TestExp",
         experiments=("TestExp",),
+        optimization_specs=None,
     ):
         self.experiment = experiment
         self._experiments = list(experiments)
         self._save_sets = list(save_sets)
         self._trigger_profiles = list(trigger_profiles)
         self._scan_variables = list(scan_variables)
+        self.optimization_specs = dict(optimization_specs or {})
 
     def set_experiment(self, experiment):
         self.experiment = experiment
@@ -44,6 +54,7 @@ class FakeConfigs:
             save_sets=self._save_sets,
             trigger_profiles=self._trigger_profiles,
             scan_variables=self._scan_variables,
+            optimization_configs=sorted(self.optimization_specs),
         )
 
     def union_preview(self, names):
@@ -51,6 +62,11 @@ class FakeConfigs:
 
     def trigger_variants(self, profile_name):
         return ["laser_off"] if profile_name else []
+
+    def optimization_spec(self, name):
+        if name not in self.optimization_specs:
+            raise ConsoleConfigsError(f"Optimizer config {name!r} not found.")
+        return self.optimization_specs[name]
 
 
 class FakeSubmitter:
@@ -268,10 +284,167 @@ class TestModeRadios:
         assert window.variable_combo.isEnabled()
         assert window.variable2_combo.isEnabled()
 
-    def test_optimization_never_submit_ready(self, window):
+    def test_optimization_without_config_not_submit_ready(self, window):
         select_save_set(window, "Amp4In")
         window.radio_optimization.setChecked(True)
         assert not window.start_button.isEnabled()
+
+
+def _optimization_spec(objective="counts"):
+    """A small valid OptimizationSpec for the optimize-mode window tests."""
+    from geecs_schemas import EvaluatorSpec, GeneratorSpec, OptimizationSpec
+
+    return OptimizationSpec(
+        variables={"jet_x": (0.0, 1.0)},
+        objectives={objective: "MAXIMIZE"},
+        evaluator=EvaluatorSpec(module="m", class_name="C"),
+        generator=GeneratorSpec(name="random"),
+    )
+
+
+class TestOptimizationMode:
+    """The R3 optimizer-config combo: visibility, gating, submission."""
+
+    @pytest.fixture
+    def opt_window(self, qtbot):
+        configs = FakeConfigs(
+            save_sets=["Amp4In"],
+            scan_variables=["jet_x"],
+            optimization_specs={
+                "bayes_jet": _optimization_spec(),
+                "random_walk": _optimization_spec(objective="charge"),
+            },
+        )
+        win = MainWindow(
+            configs=configs,
+            presets=FakePresetStore(),
+            settings=FakeSettings(),
+            submitter=FakeSubmitter(),
+        )
+        qtbot.addWidget(win)
+        return win
+
+    def test_combo_hidden_outside_optimization_mode(self, opt_window):
+        opt_window.show()
+        assert not opt_window.optimization_combo.isVisible()
+        opt_window.radio_optimization.setChecked(True)
+        assert opt_window.optimization_combo.isVisible()
+        assert opt_window.optimization_label.isVisible()
+        opt_window.radio_1d.setChecked(True)
+        assert not opt_window.optimization_combo.isVisible()
+
+    def test_combo_populated_from_configs_listing(self, opt_window):
+        items = [
+            opt_window.optimization_combo.itemText(i)
+            for i in range(opt_window.optimization_combo.count())
+        ]
+        assert items == ["bayes_jet", "random_walk"]
+        # Nothing preselected: the operator must pick a config explicitly.
+        assert opt_window.optimization_combo.currentText() == ""
+
+    def test_offline_empty_combo_disables_start(self, window):
+        # The plain fixture lists no optimizer configs (the offline shape).
+        select_save_set(window, "Amp4In")
+        window.radio_optimization.setChecked(True)
+        assert window.optimization_combo.count() == 0
+        assert not window.start_button.isEnabled()
+
+    def test_selecting_config_enables_start(self, opt_window):
+        select_save_set(opt_window, "Amp4In")
+        opt_window.radio_optimization.setChecked(True)
+        assert not opt_window.start_button.isEnabled()
+        opt_window.optimization_combo.setCurrentText("bayes_jet")
+        assert opt_window.start_button.isEnabled()
+
+    def test_start_submits_optimize_request_with_loaded_spec(self, opt_window):
+        select_save_set(opt_window, "Amp4In")
+        opt_window.radio_optimization.setChecked(True)
+        opt_window.optimization_combo.setCurrentText("bayes_jet")
+        opt_window._on_start_clicked()
+        submitter = opt_window._submitter
+        assert len(submitter.requests) == 1
+        request = submitter.requests[0]
+        assert request.mode is ScanRequestMode.OPTIMIZE
+        assert request.optimization == _optimization_spec()
+        assert request.save_sets == ["Amp4In"]
+
+    def test_engine_refusal_is_surfaced_not_preblocked(self, opt_window):
+        """The current engine refuses optimize requests — the GUI submits
+        anyway and shows the engine's answer in the status bar."""
+
+        class RefusingSubmitter(FakeSubmitter):
+            def reinitialize(self, request):
+                super().reinitialize(request)
+                return False
+
+        opt_window._submitter = RefusingSubmitter()
+        select_save_set(opt_window, "Amp4In")
+        opt_window.radio_optimization.setChecked(True)
+        opt_window.optimization_combo.setCurrentText("bayes_jet")
+        opt_window._on_start_clicked()
+        assert len(opt_window._submitter.requests) == 1  # not pre-blocked
+        assert opt_window._submitter.started == 0
+        assert "refused" in opt_window.log_tail.toPlainText()
+
+    def test_engine_exception_is_surfaced(self, opt_window):
+        class RaisingSubmitter(FakeSubmitter):
+            def reinitialize(self, request):
+                raise RuntimeError("optimize mode not supported by this engine")
+
+        opt_window._submitter = RaisingSubmitter()
+        select_save_set(opt_window, "Amp4In")
+        opt_window.radio_optimization.setChecked(True)
+        opt_window.optimization_combo.setCurrentText("bayes_jet")
+        opt_window._on_start_clicked()
+        assert (
+            "Submission failed: optimize mode not supported"
+            in opt_window.log_tail.toPlainText()
+        )
+
+    def test_unloadable_config_reports_and_does_not_submit(self, opt_window):
+        opt_window._configs.optimization_specs["bayes_jet"] = None  # placeholder
+        del opt_window._configs.optimization_specs["bayes_jet"]  # now unloadable
+        select_save_set(opt_window, "Amp4In")
+        opt_window.radio_optimization.setChecked(True)
+        opt_window.optimization_combo.setCurrentText("bayes_jet")
+        opt_window._on_start_clicked()
+        assert opt_window._submitter.requests == []
+        assert "Cannot load optimizer config" in opt_window.log_tail.toPlainText()
+
+    def test_optimize_preset_applies_matching_config(self, opt_window):
+        request = build_scan_request(
+            ConsoleFormState(
+                mode=ConsoleMode.OPTIMIZATION,
+                save_sets=["Amp4In"],
+                optimization=_optimization_spec(objective="charge"),
+            )
+        )
+        opt_window._presets.presets["opt"] = request
+        opt_window._refresh_presets()
+        opt_window.preset_combo.setCurrentText("opt")
+        opt_window._on_preset_apply()
+        assert opt_window.radio_optimization.isChecked()
+        assert opt_window.optimization_combo.currentText() == "random_walk"
+        assert "Applied preset" in opt_window.log_tail.toPlainText()
+
+    def test_optimize_preset_without_matching_config_reports(self, opt_window):
+        from geecs_schemas import EvaluatorSpec, GeneratorSpec, OptimizationSpec
+
+        stranger = OptimizationSpec(
+            variables={"other": (0.0, 2.0)},
+            objectives={"loss": "MINIMIZE"},
+            evaluator=EvaluatorSpec(module="x", class_name="Y"),
+            generator=GeneratorSpec(name="bayes_default"),
+        )
+        request = build_scan_request(
+            ConsoleFormState(mode=ConsoleMode.OPTIMIZATION, optimization=stranger)
+        )
+        opt_window._presets.presets["opt"] = request
+        opt_window._refresh_presets()
+        opt_window.preset_combo.setCurrentText("opt")
+        opt_window._on_preset_apply()
+        assert not opt_window.radio_optimization.isChecked()  # form untouched
+        assert "matches none" in opt_window.log_tail.toPlainText()
 
 
 class TestShotCount:
@@ -812,10 +985,14 @@ class TestDevicePanel:
     def test_set_finishing_after_window_deletion_is_swallowed(self, qtbot, monkeypatch):
         """A set that outlives the window must not raise on its daemon thread.
 
-        Deterministic form of an intermittent suite flake: the daemon
-        thread's ``device_set_finished.emit`` raised ``RuntimeError: Signal
-        source has been deleted`` (a PytestUnhandledThreadExceptionWarning)
-        whenever the window was C++-deleted before the blocking set returned.
+        Deterministic form of an intermittent suite flake (issue #510): when
+        the window owned the completion signal, the daemon thread's emit
+        raised ``RuntimeError: Signal source has been deleted`` (a
+        PytestUnhandledThreadExceptionWarning) whenever the window was
+        C++-deleted before the blocking set returned.  Completion is now
+        emitted by the window's ``BackgroundResult`` set worker, which
+        survives the window's C++ teardown, so the late emit lands on a live
+        QObject whose connection Qt already dropped.
         """
         import threading
 

--- a/GEECS-Console/tests/test_main_window.py
+++ b/GEECS-Console/tests/test_main_window.py
@@ -131,10 +131,17 @@ class FakePresetStore:
 class FakeSettings:
     """ConsoleSettings stand-in: plain attributes, no QSettings."""
 
-    def __init__(self, last_experiment="", per_shot_beep=False, randomized_beeps=False):
+    def __init__(
+        self,
+        last_experiment="",
+        per_shot_beep=False,
+        randomized_beeps=False,
+        show_tooltips=True,
+    ):
         self.last_experiment = last_experiment
         self.per_shot_beep = per_shot_beep
         self.randomized_beeps = randomized_beeps
+        self.show_tooltips = show_tooltips
 
 
 @pytest.fixture

--- a/GEECS-Console/tests/test_request_builder.py
+++ b/GEECS-Console/tests/test_request_builder.py
@@ -27,6 +27,18 @@ def roundtrip(request: ScanRequest) -> ScanRequest:
     return ScanRequest.model_validate(request.model_dump(mode="json"))
 
 
+def _optimization_spec():
+    """A small valid OptimizationSpec for the optimize-mode tests."""
+    from geecs_schemas import EvaluatorSpec, GeneratorSpec, OptimizationSpec
+
+    return OptimizationSpec(
+        variables={"jet_x": (0.0, 1.0)},
+        objectives={"counts": "MAXIMIZE"},
+        evaluator=EvaluatorSpec(module="m", class_name="C"),
+        generator=GeneratorSpec(name="random"),
+    )
+
+
 class TestNoscan:
     def test_noscan_maps_to_schema_noscan(self):
         form = ConsoleFormState(
@@ -195,9 +207,31 @@ class TestGuardsAndModes:
         assert estimate_total_shots(form) == MAXIMUM_SCAN_SIZE
         build_scan_request(form)  # exactly at the limit is allowed
 
-    def test_optimization_mode_refused(self):
-        with pytest.raises(ConsoleFormError, match="Optimization"):
+    def test_optimization_without_spec_refused(self):
+        with pytest.raises(ConsoleFormError, match="optimization config"):
             build_scan_request(ConsoleFormState(mode=ConsoleMode.OPTIMIZATION))
+
+    def test_optimization_with_spec_builds_optimize_request(self):
+        request = build_scan_request(
+            ConsoleFormState(
+                mode=ConsoleMode.OPTIMIZATION,
+                shots_per_step=5,
+                save_sets=["Amp4In"],
+                optimization=_optimization_spec(),
+            )
+        )
+        assert request.mode is ScanRequestMode.OPTIMIZE
+        assert request.axes == []
+        assert request.optimization == _optimization_spec()
+        assert request.shots_per_step == 5
+        roundtrip(request)
+
+    def test_stray_spec_on_non_optimize_mode_rejected_by_schema(self):
+        form = ConsoleFormState(
+            mode=ConsoleMode.NOSCAN, optimization=_optimization_spec()
+        )
+        with pytest.raises(ValidationError, match="optimize"):
+            build_scan_request(form)
 
     def test_axis_needs_one_positions_shape(self):
         with pytest.raises(ValidationError, match="start, stop, and step"):
@@ -277,20 +311,23 @@ class TestFormStateFromRequest:
         reloaded = ScanRequest.model_validate(request.model_dump(mode="json"))
         assert form_state_from_request(reloaded) == form
 
-    def test_optimize_request_raises_console_form_error(self):
-        from geecs_schemas import EvaluatorSpec, GeneratorSpec, OptimizationSpec
-
-        request = ScanRequest(
-            mode=ScanRequestMode.OPTIMIZE,
-            optimization=OptimizationSpec(
-                variables={"jet_x": (0.0, 1.0)},
-                objectives={"counts": "MAXIMIZE"},
-                evaluator=EvaluatorSpec(module="m", class_name="C"),
-                generator=GeneratorSpec(name="random"),
-            ),
+    def test_optimize_round_trips_exactly(self):
+        form = ConsoleFormState(
+            mode=ConsoleMode.OPTIMIZATION,
+            shots_per_step=5,
+            save_sets=["Amp4In"],
+            description="tune the jet",
+            optimization=_optimization_spec(),
         )
-        with pytest.raises(ConsoleFormError, match="[Oo]ptimization"):
-            form_state_from_request(request)
+        assert self.round_trip(form) == form
+
+    def test_optimize_round_trip_survives_serialization(self):
+        """Preset parity: optimize form -> request -> YAML dict -> form."""
+        form = ConsoleFormState(
+            mode=ConsoleMode.OPTIMIZATION, optimization=_optimization_spec()
+        )
+        reloaded = roundtrip(build_scan_request(form))
+        assert form_state_from_request(reloaded) == form
 
     def test_action_bindings_raise_console_form_error(self):
         from geecs_schemas import ActionBindings

--- a/GEECS-Console/tests/test_settings.py
+++ b/GEECS-Console/tests/test_settings.py
@@ -27,6 +27,15 @@ class TestConsoleSettings:
         assert ConsoleSettings().per_shot_beep is False
         assert ConsoleSettings().randomized_beeps is True
 
+    def test_show_tooltips_defaults_on(self):
+        assert ConsoleSettings().show_tooltips is True
+
+    def test_show_tooltips_round_trips_across_instances(self):
+        ConsoleSettings().show_tooltips = False
+        assert ConsoleSettings().show_tooltips is False
+        ConsoleSettings().show_tooltips = True
+        assert ConsoleSettings().show_tooltips is True
+
     def test_injected_qsettings_is_used(self, tmp_path):
         from PySide6.QtCore import QSettings
 

--- a/GEECS-Console/tests/test_tooltips.py
+++ b/GEECS-Console/tests/test_tooltips.py
@@ -116,6 +116,74 @@ class TestMainWindowOperatorTooltips:
         assert "optimizer" in window.radio_optimization.toolTip()
 
 
+def _tooltip_event():
+    """A synthetic QEvent.ToolTip (what Qt sends on hover-dwell)."""
+    from PySide6.QtCore import QPoint
+    from PySide6.QtGui import QHelpEvent
+
+    return QHelpEvent(QHelpEvent.Type.ToolTip, QPoint(1, 1), QPoint(1, 1))
+
+
+class TestShowTooltipsToggle:
+    """The Preferences 'Show tooltips' switch (default on, persisted).
+
+    The suppressor filter sits on the QApplication only while tooltips are
+    off — presence means suppression (and the default-on path pays no
+    per-event filter cost), so it gates every widget, editors included.
+    """
+
+    def test_action_default_checked_and_no_suppressor_installed(self, window):
+        assert window.show_tooltips_action.isChecked()
+        assert not window._tooltip_suppressor_installed
+
+    def test_suppressor_swallows_tooltip_events_only(self, window):
+        from PySide6.QtCore import QEvent
+
+        suppressor = window._tooltip_suppressor
+        assert suppressor.eventFilter(window.start_button, _tooltip_event())
+        assert not suppressor.eventFilter(
+            window.start_button, QEvent(QEvent.Type.Leave)
+        )
+
+    def test_toggle_off_installs_suppressor_and_persists(self, window):
+        window.show_tooltips_action.setChecked(False)
+        assert window._settings.show_tooltips is False
+        assert window._tooltip_suppressor_installed
+        window.show_tooltips_action.setChecked(True)
+        assert window._settings.show_tooltips is True
+        assert not window._tooltip_suppressor_installed
+
+    def test_saved_preference_restored_at_startup(self, qtbot):
+        win = MainWindow(
+            configs=FakeConfigs(),
+            presets=FakePresetStore(),
+            settings=FakeSettings(show_tooltips=False),
+            submitter=FakeSubmitter(),
+        )
+        qtbot.addWidget(win)
+        assert not win.show_tooltips_action.isChecked()
+        assert win._tooltip_suppressor_installed
+
+    def test_close_removes_an_installed_suppressor(self, qtbot):
+        """A closed window must not keep suppressing application tooltips."""
+        win = MainWindow(
+            configs=FakeConfigs(),
+            presets=FakePresetStore(),
+            settings=FakeSettings(show_tooltips=False),
+            submitter=FakeSubmitter(),
+        )
+        qtbot.addWidget(win)
+        win.show()
+        assert win._tooltip_suppressor_installed
+        assert win.close()
+        assert not win._tooltip_suppressor_installed
+
+    def test_suppressor_is_parented_to_the_window(self, window):
+        """Parenting bounds the filter's lifetime: Qt auto-removes a
+        destroyed filter, so the window can never leak a suppressor."""
+        assert window._tooltip_suppressor.parent() is window
+
+
 class TestSaveSetEditorTooltips:
     def test_entry_fields_match_schema_descriptions(self, qtbot, tmp_path):
         from geecs_console.editors.save_set_editor import SaveSetEditor

--- a/GEECS-Console/tests/test_tooltips.py
+++ b/GEECS-Console/tests/test_tooltips.py
@@ -1,0 +1,224 @@
+"""Tooltips: schema-derived in the editors, operator-language on the window.
+
+Issue #497 phase 1 — editor form fields show the geecs-schemas
+``Field(description=...)`` texts (single source of truth, pinned here by
+comparing widget tooltips to the model fields), and the main window's
+operator controls carry hand-written what-it-does tooltips (pinned as
+non-empty and not a restatement of the label).
+"""
+
+import pytest
+from pydantic import BaseModel, Field
+from PySide6.QtWidgets import QLabel
+from test_main_window import FakeConfigs, FakePresetStore, FakeSettings, FakeSubmitter
+
+from geecs_console.app.main_window import MainWindow
+from geecs_console.services.schema_tooltips import (
+    apply_schema_tooltips,
+    schema_tooltip,
+)
+from geecs_schemas import (
+    ActionPlan,
+    PseudoScanVariable,
+    SaveSet,
+    SaveSetEntry,
+    ScanVariable,
+    TriggerProfile,
+)
+from geecs_schemas.action_plan import CheckStep, RunPlanStep, SetStep, WaitStep
+
+
+class TestSchemaTooltipHelper:
+    class _Model(BaseModel):
+        described: int = Field(0, description="What this field means.")
+        undescribed: int = 0
+
+    def test_returns_the_field_description(self):
+        assert schema_tooltip(self._Model, "described") == "What this field means."
+
+    def test_unknown_field_raises_key_error(self):
+        with pytest.raises(KeyError):
+            schema_tooltip(self._Model, "no_such_field")
+
+    def test_missing_description_raises_lookup_error(self):
+        with pytest.raises(LookupError, match="no Field description"):
+            schema_tooltip(self._Model, "undescribed")
+
+    def test_apply_sets_single_widget_and_widget_lists(self, qtbot):
+        single, first, second = QLabel(), QLabel(), QLabel()
+        for widget in (single, first, second):
+            qtbot.addWidget(widget)
+        apply_schema_tooltips(self._Model, {"described": single})
+        apply_schema_tooltips(self._Model, {"described": [first, second]})
+        assert single.toolTip() == "What this field means."
+        assert first.toolTip() == second.toolTip() == "What this field means."
+
+
+@pytest.fixture
+def window(qtbot):
+    win = MainWindow(
+        configs=FakeConfigs(save_sets=["Amp4In"], scan_variables=["jet_x"]),
+        presets=FakePresetStore(),
+        settings=FakeSettings(),
+        submitter=FakeSubmitter(),
+    )
+    qtbot.addWidget(win)
+    return win
+
+
+class TestMainWindowOperatorTooltips:
+    #: Representative operator controls across every screen-map region.
+    WIDGETS = [
+        "experiment_combo",
+        "trigger_profile_combo",
+        "gateway_chip",
+        "tiled_chip",
+        "db_chip",
+        "available_list",
+        "selected_list",
+        "add_button",
+        "remove_button",
+        "radio_noscan",
+        "radio_1d",
+        "radio_grid",
+        "radio_optimization",
+        "radio_background",
+        "optimization_combo",
+        "shots_per_step",
+        "acquisition_combo",
+        "description_edit",
+        "preset_combo",
+        "apply_button",
+        "save_as_button",
+        "delete_button",
+        "start_button",
+        "stop_button",
+        "state_pill",
+        "progress_bar",
+        "device_combo",
+        "set_field",
+        "set_button",
+    ]
+
+    @pytest.mark.parametrize("name", WIDGETS)
+    def test_operator_control_has_a_tooltip(self, window, name):
+        widget = getattr(window, name)
+        tooltip = widget.toolTip()
+        assert tooltip.strip(), f"{name} has no tooltip"
+        # Operator language, not a restatement of the label.
+        label = getattr(widget, "text", lambda: "")()
+        if label:
+            assert tooltip.strip().lower() != label.strip().lower()
+
+    def test_mode_radio_tooltips_say_what_happens(self, window):
+        assert "without moving" in window.radio_noscan.toolTip()
+        assert "grid" in window.radio_grid.toolTip().lower()
+        assert "optimizer" in window.radio_optimization.toolTip()
+
+
+class TestSaveSetEditorTooltips:
+    def test_entry_fields_match_schema_descriptions(self, qtbot, tmp_path):
+        from geecs_console.editors.save_set_editor import SaveSetEditor
+        from geecs_console.services.save_set_store import SaveSetStore
+
+        editor = SaveSetEditor(
+            experiment="HTU", store=SaveSetStore("HTU", experiments_root=tmp_path)
+        )
+        qtbot.addWidget(editor)
+        fields = SaveSetEntry.model_fields
+        assert editor.images_check.toolTip() == fields["images"].description
+        assert editor.db_scalars_check.toolTip() == fields["db_scalars"].description
+        assert editor.all_scalars_check.toolTip() == fields["all_scalars"].description
+        assert editor.role_combo.toolTip() == fields["role"].description
+        assert editor.device_edit.toolTip() == fields["device"].description
+        assert editor.scalar_list.toolTip() == fields["scalars"].description
+        assert editor.scalar_edit.toolTip() == fields["scalars"].description
+        assert editor.setup_edit.toolTip() == fields["setup"].description
+        assert editor.closeout_edit.toolTip() == fields["closeout"].description
+        assert (
+            editor.description_edit.toolTip()
+            == SaveSet.model_fields["description"].description
+        )
+
+
+class TestScanVariableEditorTooltips:
+    def test_fields_match_schema_descriptions(self, qtbot, tmp_path):
+        from geecs_console.editors.scan_variable_editor import ScanVariableEditor
+        from geecs_console.services.device_completions import EmptyCompletions
+        from geecs_console.services.scan_variable_store import ScanVariableStore
+
+        editor = ScanVariableEditor(
+            store=ScanVariableStore("HTU", experiments_root=tmp_path),
+            completions=EmptyCompletions(),
+        )
+        qtbot.addWidget(editor)
+        editor._confirm_discard = lambda: True  # teardown close must never block
+        target = ScanVariable.model_fields["target"].description
+        assert editor.device_edit.toolTip() == target
+        assert editor.variable_edit.toolTip() == target
+        assert (
+            editor.kind_combo.toolTip() == ScanVariable.model_fields["kind"].description
+        )
+        confirm = ScanVariable.model_fields["confirm"].description
+        assert editor.confirm_device_edit.toolTip() == confirm
+        assert editor.confirm_variable_edit.toolTip() == confirm
+        pseudo = PseudoScanVariable.model_fields
+        assert editor.mode_combo.toolTip() == pseudo["mode"].description
+        assert editor.components_table.toolTip() == pseudo["targets"].description
+        assert editor.inverse_edit.toolTip() == pseudo["inverse"].description
+
+
+class TestShotControlEditorTooltips:
+    def test_fields_match_schema_descriptions(self, qtbot, tmp_path):
+        from geecs_console.editors.shot_control_editor import ShotControlEditor
+        from geecs_console.services.trigger_profile_store import TriggerProfileStore
+
+        editor = ShotControlEditor(
+            experiment="HTU",
+            store=TriggerProfileStore("HTU", experiments_root=tmp_path),
+        )
+        qtbot.addWidget(editor)
+        fields = TriggerProfile.model_fields
+        assert editor.description_edit.toolTip() == fields["description"].description
+        assert editor.states_tree.toolTip() == fields["states"].description
+        assert editor.variant_combo.toolTip() == fields["variants"].description
+
+
+class TestActionLibraryEditorTooltips:
+    def test_fields_match_schema_descriptions(self, qtbot, tmp_path):
+        from geecs_console.editors.action_library_editor import ActionLibraryEditor
+        from geecs_console.services.action_library_store import ActionLibraryStore
+
+        editor = ActionLibraryEditor(
+            store=ActionLibraryStore("HTU", experiments_root=tmp_path)
+        )
+        qtbot.addWidget(editor)
+        editor._confirm_discard = lambda: True  # teardown close must never block
+        assert (
+            editor.description_edit.toolTip()
+            == ActionPlan.model_fields["description"].description
+        )
+        assert (
+            editor.steps_table.toolTip() == ActionPlan.model_fields["steps"].description
+        )
+        set_fields = SetStep.model_fields
+        assert editor.set_device_edit.toolTip() == set_fields["device"].description
+        assert editor.set_variable_edit.toolTip() == set_fields["variable"].description
+        assert editor.set_value_edit.toolTip() == set_fields["value"].description
+        assert (
+            editor.set_wait_check.toolTip()
+            == set_fields["wait_for_execution"].description
+        )
+        assert (
+            editor.wait_seconds_spin.toolTip()
+            == WaitStep.model_fields["seconds"].description
+        )
+        check_fields = CheckStep.model_fields
+        assert editor.check_device_edit.toolTip() == check_fields["device"].description
+        assert (
+            editor.check_expected_edit.toolTip() == check_fields["expected"].description
+        )
+        assert (
+            editor.run_plan_combo.toolTip()
+            == RunPlanStep.model_fields["plan"].description
+        )


### PR DESCRIPTION
One PR, three items on GEECS-Console (minor bump 0.6.3 → 0.7.0).

## A. Tooltips (issue #497 phase 1 — text only, no doc links)

- New `services/schema_tooltips.py`: `apply_schema_tooltips` maps pydantic model fields → widget tooltips from `Field(description=...)`. A mapping to a missing or description-less field **fails loudly at editor construction** — the schema stays the single source of truth.
- Applied in all four editors (save sets, scan variables, shot control, action library). The Device/Variable edit pairs share their joint schema field's description.
- **No GEECS-Schemas changes were needed**: an audit of every model in the package found zero fields without a description, so the planned schema backfill commit (and patch bump) has no content. GEECS-Schemas is untouched by this PR.
- Main-window operator controls (mode radios, acquisition combo, shots/step, save-set lists, device panel, Start/Stop, health chips, presets row, R6 panel, R1 combos) get hand-written operator-language tooltips in `_apply_operator_tooltips`.
- Tests (`tests/test_tooltips.py`): editor tooltips compared verbatim against the schema descriptions; ~30 representative window controls asserted non-empty and not label restatements; helper unit tests (KeyError / LookupError contracts).

## B. Issue #510 — device-set completion via worker QObject

- The window-owned `device_set_finished(bool, str)` signal (emitted from the set-dispatch daemon thread) is gone. The blocking `backend.set` now dispatches through a dedicated `BackgroundResult` worker; its `result_ready` delivers `(ok, message)` queued to the GUI thread. The worker owns the cross-thread emission and survives window teardown, so the 0.6.2 `RuntimeError` swallow is deleted rather than papered over.
- `closeEvent` disconnects the set worker like the other `BackgroundResult` workers.
- The deterministic regression test (blocked fake backend released after window C++ deletion, no unhandled thread exceptions) stays green with its docstring updated.
- Closes #510.

## C. Optimization dropdown (GUI half — engine-gated)

- Selecting the Optimization radio shows an optimizer-config combo in R3, listing YAML stems from the experiment's `optimizer_configs/` folder (the legacy GEECS-Scanner-GUI folder name). Offline ⇒ empty combo and Start stays disabled; a selected config is the only optimize-specific Start gate.
- `ConsoleConfigs.optimization_spec(name)` loads a config as a validated `OptimizationSpec`: new-schema documents directly, and the legacy `vocs` dialect through `geecs_schemas.convert.convert_optimizer_config` (recognized unambiguously by the `vocs` key).
- `build_scan_request` stays pure: the window resolves name → spec when snapshotting the form (`ConsoleFormState.optimization`), and optimize forms map to `mode: optimize` requests. `form_state_from_request` round-trips optimize instead of raising, so optimize presets save/apply; Apply matches the preset's inline spec against the listed configs by content (no match ⇒ status-bar error, form untouched).
- **No pre-blocking**: the current engine still refuses optimize submissions; the console submits and surfaces the engine's answer in the status bar, so the parallel engine-side work lands with zero GUI changes.
- Tests: optimize round-trips (incl. YAML serialization parity), combo population/visibility/gating, submission shape, engine refusal and exception surfacing, preset content-matching, and `ConsoleConfigs` against a tmp configs tree (both dialects + error paths).

## Verification

`QT_QPA_PLATFORM=offscreen poetry run pytest -q`: **613 passed, exit 0**, across repeated runs (baseline 553).

Heads-up: a pyproject/CHANGELOG version conflict with parallel console PRs is expected — whoever merges second takes the next free number.

🤖 Generated with [Claude Code](https://claude.com/claude-code)