### PR TITLE
GEECS-Console 0.8.1: scan browser clears stale run detail on context change

### DIFF
--- a/GEECS-Console/CHANGELOG.md
+++ b/GEECS-Console/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to GEECS-Console are documented here.  Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versioning is
 semantic.
 
+## [0.8.1] - 2026-07-12
+
+### Fixed
+
+- **Scan Browser: stale run detail cleared on context change** (post-merge
+  review finding on #523): reloading the run list (date/experiment change),
+  an emptied selection, and list/load errors now all route through a
+  centralized `_clear_detail()` — B3 actions disabled, plot/table/drift
+  cleared, in-flight loads invalidated. Previously a previously selected
+  scan's detail survived a refresh, and *Open scan folder* could resolve
+  the old run against the newly selected day (wrong-ScanNNN risk). Load
+  failures now carry their request generation so a late error from a
+  superseded load cannot clobber a newer selection.
+
 ## [0.8.0] - 2026-07-12
 
 ### Added

--- a/GEECS-Console/geecs_console/browser/browser_window.py
+++ b/GEECS-Console/geecs_console/browser/browser_window.py
@@ -694,8 +694,29 @@ class ScanBrowserWindow(QMainWindow):
             self._settings.last_experiment = experiment
         self.reload_runs()
 
+    def _clear_detail(self) -> None:
+        """Drop the loaded run from B3-B6 and invalidate in-flight loads.
+
+        Called when the run list is about to change (reload), when the
+        selection empties, and on list/load errors.  A stale detail must
+        never outlive its query context: *Open scan folder* resolves
+        against the currently selected day, so acting on an old
+        ``RunDetail`` under a new date could target the wrong ``ScanNNN``.
+        """
+        self._detail_generation += 1
+        self._detail = None
+        self.b3_title.setText("No scan selected")
+        self.b3_pills.setText("")
+        self.b3_copy_uid_button.setEnabled(False)
+        self.b3_open_folder_button.setEnabled(False)
+        self._clear_series()
+        self.b6_drift_list.clear()
+        self.b6_summary.setText("")
+        self._refresh_table()
+
     def reload_runs(self) -> None:
         """Reload B2 for the current experiment/date (off the GUI thread)."""
+        self._clear_detail()
         self._list_generation += 1
         generation = self._list_generation
         experiment = self.current_experiment()
@@ -714,6 +735,7 @@ class ScanBrowserWindow(QMainWindow):
         """Populate B2 from a finished day query (GUI thread, queued)."""
         result, error = outcome  # type: ignore[misc]
         if error is not None:
+            self._clear_detail()
             self.statusBar().showMessage(f"Run listing failed: {error}")
             return
         generation, summaries = result  # type: ignore[misc]
@@ -766,26 +788,42 @@ class ScanBrowserWindow(QMainWindow):
     ) -> None:
         """Load the newly selected run's detail off the GUI thread."""
         if current is None:
+            # The list emptied (reload/filter) — no run is selected now.
+            self._clear_detail()
             return
         uid = str(current.data(Qt.ItemDataRole.UserRole))
         self._detail_generation += 1
         generation = self._detail_generation
         catalog = self.catalog
         self.statusBar().showMessage(f"Loading {uid[:8]}…")
-        self._detail_worker.run_async(
-            lambda: (generation, catalog.load_run(uid)),
-            "browser-load-run",
-        )
+
+        def _load() -> tuple:
+            # Catch inside the payload so a failure still carries its
+            # generation — a *late* error from a superseded load must not
+            # clear the newer selection's in-flight state.
+            try:
+                return (generation, catalog.load_run(uid), None)
+            except Exception as exc:  # noqa: BLE001 — delivered to the GUI thread
+                return (generation, None, exc)
+
+        self._detail_worker.run_async(_load, "browser-load-run")
 
     @Slot(object)
     def _on_detail_result(self, outcome: object) -> None:
         """Populate B3-B6 from a loaded run (GUI thread, queued)."""
         result, error = outcome  # type: ignore[misc]
         if error is not None:
+            # Worker-level failure (payload never built) — no generation to
+            # check, so clear conservatively: never risk showing stale data.
+            self._clear_detail()
             self.statusBar().showMessage(f"Run load failed: {error}")
             return
-        generation, detail = result  # type: ignore[misc]
+        generation, detail, load_error = result  # type: ignore[misc]
         if generation != self._detail_generation or self._closing:
+            return
+        if load_error is not None:
+            self._clear_detail()
+            self.statusBar().showMessage(f"Run load failed: {load_error}")
             return
         self._detail = detail
         self._clear_series()

--- a/GEECS-Console/pyproject.toml
+++ b/GEECS-Console/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-console"
-version = "0.8.0"
+version = "0.8.1"
 description = "Greenfield PySide6 operator console for GEECS (Bluesky/gateway architecture)"
 authors = ["Sam Barber <sbarber@lbl.gov>"]
 readme = "README.md"

--- a/GEECS-Console/tests/test_scan_browser_window.py
+++ b/GEECS-Console/tests/test_scan_browser_window.py
@@ -368,3 +368,63 @@ def _flush_events(qtbot):
     """Flush posted events after each test before teardown."""
     yield
     qtbot.wait(10)
+
+
+class TestStaleDetail:
+    """A loaded detail must never outlive its query context (review P2).
+
+    Open-scan-folder resolves against the *currently selected* day, so a
+    stale ``RunDetail`` surviving a reload could target the wrong ScanNNN.
+    """
+
+    def _assert_detail_cleared(self, window):
+        assert window._detail is None
+        assert not window.b3_copy_uid_button.isEnabled()
+        assert not window.b3_open_folder_button.isEnabled()
+        assert window.b3_title.text() == "No scan selected"
+        assert window.b6_drift_list.count() == 0
+        assert window.b5_table.rowCount() == 0
+
+    def test_reload_clears_previous_detail(self, qtbot):
+        window = _make_window(qtbot, _two_run_catalog())
+        _wait_runs(qtbot, window, 3)
+        _select_run(qtbot, window, 0)
+        window.catalog = FakeCatalog([])  # the new day has no runs
+        window.reload_runs()
+        self._assert_detail_cleared(window)
+        qtbot.waitUntil(lambda: window.b2_run_list.count() == 0, timeout=3000)
+        self._assert_detail_cleared(window)
+
+    def test_emptied_selection_clears_detail(self, qtbot):
+        window = _make_window(qtbot, _two_run_catalog())
+        _wait_runs(qtbot, window, 3)
+        _select_run(qtbot, window, 0)
+        window.b2_run_list.setCurrentRow(-1)
+        self._assert_detail_cleared(window)
+
+    def test_load_error_clears_previous_detail(self, qtbot):
+        catalog = _two_run_catalog()
+        window = _make_window(qtbot, catalog)
+        _wait_runs(qtbot, window, 3)
+        _select_run(qtbot, window, 0)
+
+        def _boom(uid):
+            raise RuntimeError("share went away")
+
+        catalog.load_run = _boom
+        window.b2_run_list.setCurrentRow(1)
+        qtbot.waitUntil(
+            lambda: "Run load failed" in window.statusBar().currentMessage(),
+            timeout=3000,
+        )
+        self._assert_detail_cleared(window)
+
+    def test_late_error_from_superseded_load_is_ignored(self, qtbot):
+        window = _make_window(qtbot, _two_run_catalog())
+        _wait_runs(qtbot, window, 3)
+        _select_run(qtbot, window, 0)
+        detail_before = window._detail
+        stale = (window._detail_generation - 1, None, RuntimeError("old query"))
+        window._on_detail_result((stale, None))
+        assert window._detail is detail_before
+        assert window.b3_copy_uid_button.isEnabled()


### PR DESCRIPTION
Fixes the P2 from the post-merge adversarial review of #523.

**Problem:** `reload_runs()` didn't clear `_detail`; `_on_run_selected(None)` returned without clearing; list/load errors left the previous run's B3–B6 populated. Worst case: *Open scan folder* passed the old `RunDetail` with the newly selected day — fallback resolution could open the wrong `ScanNNN`.

**Fix:** centralized `_clear_detail()` (drops `_detail`, bumps `_detail_generation`, disables B3 actions, clears plot/table/drift) called at reload start, on emptied selection, and on both error paths. One hardening beyond the review sketch: detail loads catch inside the payload so failures carry their request generation — a late error from a superseded load is ignored instead of clobbering the newer selection's in-flight state.

**Tests:** 4 new regressions (reload-clears, emptied-selection, load-error, late-superseded-error-ignored); full suite 655 passed × 3 consecutive runs, exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)