### PR TITLE
GeecsBluesky 0.32.0: read-path hardening phase 1 — stage per-row devices (#540)

### DIFF
--- a/GeecsBluesky/CHANGELOG.md
+++ b/GeecsBluesky/CHANGELOG.md
@@ -4,6 +4,48 @@ All notable changes to `geecs-bluesky` are documented here.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.32.0] - 2026-07-13
+
+### Fixed
+
+- **Per-shot reads no longer issue one network CA get per signal per row**
+  (issue #540 — scans at a 1 Hz trigger ran at 0.5 Hz once background
+  telemetry's ~87 devices joined every event row).
+  `build_step_scan_plan` now stages every per-row read device
+  (`bpp.stage_wrapper`, unstaged on every exit path), so each signal gets a
+  caching CA monitor for the scan's duration and per-shot reads are served
+  locally.  Cached reads are shot-coherent by the gateway's frame-ordering
+  contract (data variables post before the timestamp ladder,
+  PV_CONTRACT.md §3) — chain verified against installed caproto/aioca/
+  ophyd-async sources; conditions documented in CLAUDE.md "Read path:
+  staging & shot coherence".  Pinned by `tests/test_read_path_staging.py`
+  (zero backend gets per row; stage/unstage bracket the run, abort path
+  included).
+- **One hung telemetry PV can no longer hold an event row for 10 s**:
+  `CaTelemetryReadable` bounds each signal read at 2 s
+  (`_read_timeout_s`); a timeout degrades to the existing null cell.
+
+### Changed
+
+- **1 Hz-era constants now scale with the configured rep rate** (5 Hz
+  system-limit readiness; behavior at 1 Hz unchanged):
+  - the free-run contributor grace wait is capped at half a trigger period
+    (`FreeRunContributorSupport._effective_grace_wait_s`; was a fixed
+    0.3 s — 1.5 shot periods at 5 Hz, serialized per lagging contributor);
+  - the t0-sync acceptance window is capped at `0.4 / rep_rate_hz`
+    (a window wider than one period silently accepts caches seeded one
+    shot apart); the effective value is recorded in the start document;
+  - `CaAcqTimestampReadable._shot_queue_maxsize` 32 → 128 (worst case is
+    rep-rate × trigger-timeout = 15 at 5 Hz; the old bound left margin 2
+    at 10 Hz).
+- Per-phase DEBUG timing in the shot loop: strict fire / frame-wait
+  durations (`geecs_single_shot`), free-run row duration
+  (`geecs_free_run_step_scan`) — the next timing question is answerable
+  from one log at DEBUG level.
+- Audit findings and the phased hardening plan (telemetry aggregation,
+  t0-sync seed verification, timestamp-only telemetry attribution) are
+  recorded in `Planning/device_read_path/00_overview.md`.
+
 ## [0.31.1] - 2026-07-13
 
 ### Changed

--- a/GeecsBluesky/CLAUDE.md
+++ b/GeecsBluesky/CLAUDE.md
@@ -344,6 +344,68 @@ Hermetic testing uses ophyd-async mock backends (`tests/ca_mock_helpers.py`):
 `set_mock_value` on `acq_timestamp` is a shot, `start_pacer` on the RE loop is
 the free-running trigger, `follow_setpoint` stands in for GEECS convergence.
 
+## Read path: staging & shot coherence (0.32.0)
+
+**The read-path contract: every per-row read device is staged.**
+`build_step_scan_plan` wraps the composed plan in `bpp.stage_wrapper` over
+detectors + telemetry + motors, so every readable child signal gets a caching
+CA monitor for the scan's duration and per-shot `read()`s are served from
+memory — zero network round trips per row.  Before this, every signal of
+every device was one uncached CA get per row, serialized across devices by
+the RunEngine (measured live 2026-07-13: 87 telemetry devices × ~7 ms VPN
+RTT ≈ 0.7 s/row — scans at a 1 Hz trigger ran at exactly 0.5 Hz).  Pinned by
+`tests/test_read_path_staging.py` (zero backend gets per row; stage/unstage
+bracket the run, including the abort path).
+
+Why cached reads are *correct*, not just fast — the coherence chain, each
+link verified against installed sources (caproto 1.3.0, aioca 2.1,
+ophyd-async 0.19.3):
+
+1. The gateway posts a frame's data variables before its timestamp-ladder
+   variables (PV_CONTRACT.md §3, pinned by
+   `test_callback_posts_timestamp_variables_last`), sequentially awaited —
+   never gathered.
+2. caproto serializes all subscription updates FIFO through one context
+   queue → one per-circuit queue → one TCP socket; aioca delivers via a
+   single FIFO `call_soon_threadsafe` hop; the ophyd-async cache updates
+   synchronously in that callback.
+3. Therefore when `trigger()` completes (the `acq_timestamp` advance
+   arrived), every staged data cache already holds that frame's values —
+   or newer, never older.  This is strictly stronger than an uncached
+   post-trigger get (which samples the same gateway cache, with the same
+   next-frame race, plus a round trip).
+
+Conditions the guarantee stands on (do not silently violate):
+
+- One CA context per process (ordering is per-circuit; aioca's module-level
+  context — the default — satisfies this).
+- `OPHYD_ASYNC_EPICS_CA_KEEP_ALL_UPDATES` stays at its `True` default —
+  client-side coalescing would break "data before timestamp" delivery.
+- The client must not backlog past caproto's per-subscription drop-oldest
+  quota (~1000 updates) — the stated boundary where coherence can break.
+- Connection loss surfaces as `alarm_severity`/`CONNECTED`, never assumed
+  away — a dead monitor serves its last reading silently.
+
+Sharp edges: ophyd-async staging is a **bool, not a refcount** — the
+orchestration layer stages exactly once; nested plans must never re-stage
+these devices.  A staged reading's `timestamp` is the CA server (device
+ladder) time of the last delivery, not read time.  The first post-stage
+read blocks until each monitor's initial update (stage early, not
+mid-step).  `CaAcqTimestampReadable`'s persistent `subscribe_reading`
+shares the same refcounted-by-listeners cache and survives unstage —
+deliberate and safe.
+
+Rate-derived bounds (1 Hz-era constants scaled for the 5 Hz system limit):
+the contributor grace wait is capped at half a trigger period
+(`_effective_grace_wait_s`), the t0-sync window is capped at
+`0.4 / rep_rate_hz` (recorded value lands in the start doc), the telemetry
+per-signal read budget is 2 s (`CaTelemetryReadable._read_timeout_s` — one
+hung PV costs at most that, not ophyd's 10 s default), and the shot queue
+holds 128 updates.  **The t0-sync design floor**: the window must exceed
+inter-machine clock skew (~50 ms); at 5 Hz that leaves 50–80 ms of margin,
+and rates meaningfully beyond 5 Hz need a redesigned seeding stage — see
+`Planning/device_read_path/00_overview.md`.
+
 ## Transport Layer — moved to GeecsCAGateway
 
 The GEECS wire-protocol transport (`GeecsUdpClient`, `GeecsTcpSubscriber`)

--- a/GeecsBluesky/geecs_bluesky/devices/ca/telemetry.py
+++ b/GeecsBluesky/geecs_bluesky/devices/ca/telemetry.py
@@ -86,13 +86,21 @@ class CaTelemetryReadable(StandardReadable):
         # so the Tiled→s-file exporter must not rename them as save-set data.
         self._column_headers: dict[str, str] = {}
 
+    #: Per-signal read budget (seconds).  Bounds the soft tier's *latency*
+    #: as well as its failures: without it a hung PV holds the event row for
+    #: ophyd's 10 s default signal timeout (rows are serialized), and a
+    #: staged-but-never-delivered monitor would hold it forever.  Staged
+    #: reads are cache hits (~µs), so this only ever fires on real trouble.
+    _read_timeout_s: float = 2.0
+
     async def read(self) -> dict[str, Any]:
         """Read all telemetry signals, substituting a null cell for any that fail.
 
         The soft-tier guarantee: one unreadable signal degrades to a
         dtype-appropriate null (``NaN`` for numeric, ``""`` for string/enum)
         rather than raising into ``trigger_and_read``.  Reads are issued
-        concurrently; the row's timestamp is best effort.
+        concurrently and individually bounded by :attr:`_read_timeout_s`;
+        the row's timestamp is best effort.
 
         Returns
         -------
@@ -104,7 +112,11 @@ class CaTelemetryReadable(StandardReadable):
 
         signals = list(self._telemetry_signals)
         results = await asyncio.gather(
-            *(sig.read() for sig in signals), return_exceptions=True
+            *(
+                asyncio.wait_for(sig.read(), timeout=self._read_timeout_s)
+                for sig in signals
+            ),
+            return_exceptions=True,
         )
         reading: dict[str, Any] = {}
         for sig, result in zip(signals, results):

--- a/GeecsBluesky/geecs_bluesky/devices/ca/triggerable.py
+++ b/GeecsBluesky/geecs_bluesky/devices/ca/triggerable.py
@@ -68,14 +68,18 @@ class CaAcqTimestampReadable(StandardReadable):
     _acq_timestamp_variable : str
         GEECS variable that advances per shot.  Default ``"acq_timestamp"``.
     _shot_queue_maxsize : int
-        Bound on the shot-update queue (default 32 — comfortably above the
-        worst case of rep-rate × trigger-timeout updates between baseline
-        and the awaited get).  Only ``trigger()`` drains the queue, so an
-        unbounded queue would grow one float per machine shot on idle devices.
+        Bound on the shot-update queue (default 128 — the worst case is
+        rep-rate × trigger-timeout updates between baseline and the awaited
+        get, i.e. 15 at the 5 Hz system limit, with a wide margin so the
+        bound never needs revisiting below ~40 Hz).  Only ``trigger()``
+        drains the queue, so an unbounded queue would grow one float per
+        machine shot on idle devices; overflow is drop-oldest and
+        correctness-preserving (any surviving post-baseline update passes
+        the ``!= t0`` shot test).
     """
 
     _acq_timestamp_variable: str = "acq_timestamp"
-    _shot_queue_maxsize: int = 32
+    _shot_queue_maxsize: int = 128
 
     def __init__(
         self,

--- a/GeecsBluesky/geecs_bluesky/devices/contributor.py
+++ b/GeecsBluesky/geecs_bluesky/devices/contributor.py
@@ -64,8 +64,12 @@ class FreeRunContributorSupport:
             ``ShotIdSupport`` device, normally the triggered reference detector.
         grace_wait_s:
             Bounded wait at read time for this device's own frame for the
-            row's shot to arrive (~one push period).  ``0`` disables;
-            ``None`` keeps the current setting (default ``0.3``).
+            row's shot to arrive.  ``0`` disables; ``None`` keeps the
+            current setting (default ``0.3``).  The *effective* wait is
+            additionally capped at half a trigger period
+            (``0.5 / rep_rate_hz`` from the shot-ID tracker), so a fixed
+            default can never burn multiple shot periods at fast rep rates
+            — see :meth:`_effective_grace_wait_s`.
         """
         # Reference opts out of ophyd-async's child adoption: assigning a
         # bare Device attribute would re-parent and rename the pacemaker,
@@ -91,13 +95,27 @@ class FreeRunContributorSupport:
             return None
         return tracker.peek(ts)
 
+    def _effective_grace_wait_s(self) -> float:
+        """Grace wait bounded to half a trigger period.
+
+        Contributors are read sequentially by the RunEngine, so an
+        over-long grace wait serializes across every lagging contributor.
+        Capping at ``0.5 / rep_rate_hz`` keeps the worst case under one
+        shot period per row regardless of the configured default (at the
+        1 Hz default nothing changes: ``min(0.3, 0.5) == 0.3``).
+        """
+        tracker = self._shot_id_tracker
+        if tracker is None:
+            return self._grace_wait_s
+        return min(self._grace_wait_s, 0.5 / tracker.rep_rate_hz)
+
     async def _grace_wait(self, row_shot_id: int) -> None:
         """Wait (bounded) for this device's frame for *row_shot_id*."""
         tracker = self._shot_id_tracker
         if tracker is None or not tracker.is_seeded:
             return
         loop = asyncio.get_running_loop()
-        deadline = loop.time() + self._grace_wait_s
+        deadline = loop.time() + self._effective_grace_wait_s()
         while True:
             ts = self.last_acq_timestamp
             if ts is not None:

--- a/GeecsBluesky/geecs_bluesky/plans/free_run_step_scan.py
+++ b/GeecsBluesky/geecs_bluesky/plans/free_run_step_scan.py
@@ -39,6 +39,8 @@ do not "fix" into per-step save toggling.  Design rationale:
 
 from __future__ import annotations
 
+import logging
+import time
 from typing import Any, Callable, Iterable, Sequence
 
 import bluesky.plan_stubs as bps
@@ -53,6 +55,8 @@ from geecs_bluesky.plans.step_scan import (
     normalize_motors,
 )
 from geecs_bluesky.plans.t0_sync import geecs_t0_sync
+
+logger = logging.getLogger(__name__)
 
 
 def geecs_free_run_step_scan(
@@ -125,7 +129,14 @@ def geecs_free_run_step_scan(
         same point, unwindowed.  Save-*off* stays the run wrapper's
         innermost finalize, before the caller's disarm.
     t0_sync_window_s:
-        Acceptance window for the t0-sync stage.
+        Acceptance window for the t0-sync stage.  Capped at
+        ``0.4 / rep_rate_hz`` (from the reference's shot-ID tracker) so the
+        window can never span more than one trigger period — a window wider
+        than a period silently accepts caches seeded one shot apart.  The
+        effective value is recorded in the start document.  Note the design
+        floor: the window must stay above inter-machine clock skew
+        (~50 ms), which at 5 Hz leaves 50–80 ms of real margin; rates much
+        beyond 5 Hz need a redesigned seeding stage, not a smaller window.
     tail_flush:
         Emit one final ``flush``-stream event after the last disarm so
         lagging contributors' final shot is captured.
@@ -162,6 +173,16 @@ def geecs_free_run_step_scan(
 
     _positions = list(positions)
     _motors = normalize_motors(motor)
+    rep_rate_hz = reference.shot_id_tracker.rep_rate_hz
+    effective_window_s = min(t0_sync_window_s, 0.4 / rep_rate_hz)
+    if effective_window_s < t0_sync_window_s:
+        logger.info(
+            "t0-sync window capped to %.3fs (%.3fs requested) for rep rate "
+            "%.1f Hz — the window must stay under one trigger period",
+            effective_window_s,
+            t0_sync_window_s,
+            rep_rate_hz,
+        )
     scan_context = ScanContext()
     _read_devices = [reference, *detectors]
     _read_devices.extend(_motors)
@@ -182,7 +203,7 @@ def geecs_free_run_step_scan(
         "reference_device": getattr(
             reference, "_geecs_device_name", getattr(reference, "name", "")
         ),
-        "t0_sync_window_s": t0_sync_window_s,
+        "t0_sync_window_s": effective_window_s,
         "motor": motor_md(_motors),
         "detectors": [getattr(d, "name", str(d)) for d in (reference, *detectors)],
         "positions": _positions,
@@ -201,7 +222,7 @@ def geecs_free_run_step_scan(
         # Trigger stopped through t0 sync until the first arm[SCAN] — the
         # earliest orphan-free moment to start native saving (Gate-2).
         yield from enable_saving()
-    t0s = yield from geecs_t0_sync(sync_devices, window_s=t0_sync_window_s)
+    t0s = yield from geecs_t0_sync(sync_devices, window_s=effective_window_s)
     _md["device_t0s"] = t0s
 
     @bpp.run_decorator(md=_md)
@@ -224,7 +245,15 @@ def geecs_free_run_step_scan(
                     shot_index_in_bin=shot_index_in_bin,
                     scan_event_index=scan_event_index,
                 )
+                row_t0 = time.monotonic()
                 yield from bps.trigger_and_read(_read_devices)
+                if logger.isEnabledFor(logging.DEBUG):
+                    logger.debug(
+                        "row %d: %.1f ms (trigger wait + %d device reads)",
+                        scan_event_index,
+                        (time.monotonic() - row_t0) * 1e3,
+                        len(_read_devices),
+                    )
             if disarm_trigger is not None:
                 yield from disarm_trigger()
         # End of scan: stop the trigger BEFORE the tail machinery — STANDBY

--- a/GeecsBluesky/geecs_bluesky/plans/orchestration.py
+++ b/GeecsBluesky/geecs_bluesky/plans/orchestration.py
@@ -178,4 +178,14 @@ def build_step_scan_plan(
         plan = bpp.finalize_wrapper(plan, controller.disarm())
     if closeout is not None:
         plan = bpp.finalize_wrapper(plan, closeout)
+    # Outermost: stage every per-row read device so each signal gets a caching
+    # CA monitor and per-shot reads are served locally instead of issuing one
+    # network get per signal per row (the read-path contract —
+    # GeecsBluesky/CLAUDE.md "Read path: staging & shot coherence").  Staged
+    # reads are shot-coherent because the gateway posts a frame's data
+    # variables before its timestamp-ladder variables (PV_CONTRACT.md §3).
+    # stage_wrapper stages exactly once on entry and unstages via finalize on
+    # every exit path (ophyd-async staging is a bool, not a refcount — nested
+    # plans must not re-stage these devices).
+    plan = bpp.stage_wrapper(plan, scalar_devices)
     return plan

--- a/GeecsBluesky/geecs_bluesky/plans/single_shot.py
+++ b/GeecsBluesky/geecs_bluesky/plans/single_shot.py
@@ -22,6 +22,7 @@ longer cannot help, but firing again can.
 from __future__ import annotations
 
 import logging
+import time
 from typing import Any, Callable, Sequence
 
 import bluesky.plan_stubs as bps
@@ -144,9 +145,18 @@ def geecs_single_shot(
         try:
             for obj in triggerables:
                 yield from bps.trigger(obj, group=grp, wait=False)
+            fire_t0 = time.monotonic()
             yield from fire()
+            fire_done = time.monotonic()
             if triggerables:
                 yield from bps.wait(group=grp)
+            if logger.isEnabledFor(logging.DEBUG):
+                logger.debug(
+                    "shot phases: fire %.1f ms, frame wait %.1f ms (%d triggerables)",
+                    (fire_done - fire_t0) * 1e3,
+                    (time.monotonic() - fire_done) * 1e3,
+                    len(triggerables),
+                )
         except FailedStatus as exc:
             # No cancellation of abandoned statuses is needed: the RunEngine
             # stashes a late FailedStatus and throws it into the plan at the

--- a/GeecsBluesky/pyproject.toml
+++ b/GeecsBluesky/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-bluesky"
-version = "0.31.1"
+version = "0.32.0"
 description = "Bluesky / ophyd-async bridge for the GEECS control system"
 authors = ["Sam Barber <sbarber@lbl.gov>"]
 readme = "README.md"

--- a/GeecsBluesky/tests/test_read_path_staging.py
+++ b/GeecsBluesky/tests/test_read_path_staging.py
@@ -1,0 +1,255 @@
+"""Read-path hardening pins: staging, grace-wait cap, t0 window cap, telemetry bound.
+
+The read-path contract (GeecsBluesky/CLAUDE.md "Read path: staging & shot
+coherence"): every per-row read device is staged by the orchestration layer,
+so per-shot reads are served from caching monitors instead of issuing one
+network get per signal per row.  These tests pin the contract hermetically by
+counting mock-backend ``get_reading`` calls — the mock analogue of a CA get.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from typing import Any
+
+import pytest
+from bluesky import RunEngine
+
+pytest.importorskip("aioca")
+
+from geecs_bluesky.devices.ca import (  # noqa: E402
+    CaGenericDetector,
+    CaSnapshotReadable,
+    CaTelemetryReadable,
+    CaTimestampedReadable,
+)
+from geecs_bluesky.plans.orchestration import build_step_scan_plan  # noqa: E402
+from tests.ca_mock_helpers import connect_mock, start_pacer  # noqa: E402
+
+REF_T0 = 1000.0
+CAM_T0 = 1000.05
+
+
+def _count_backend_gets(device: Any, counters: dict[str, int]) -> None:
+    """Wrap every child signal backend's ``get_reading`` with a counter.
+
+    A ``get_reading`` call is the mock analogue of an uncached CA get — the
+    thing staging is supposed to eliminate from the per-row path.
+    """
+    for _, child in device.children():
+        backend = getattr(child, "_connector", None)
+        backend = getattr(backend, "backend", None)
+        if backend is None or not hasattr(backend, "get_reading"):
+            continue
+        original = backend.get_reading
+        key = child.name
+
+        async def counted(_original=original, _key=key):
+            counters[_key] = counters.get(_key, 0) + 1
+            return await _original()
+
+        backend.get_reading = counted
+
+
+def _make_devices() -> tuple[Any, Any, Any]:
+    ref = CaGenericDetector("U_Ref", ["Sig"], name="ref")
+    cam = CaTimestampedReadable("U_Cam", ["Val"], name="cam")
+    snapshot = CaSnapshotReadable("U_Ref", ["Sig"], name="async_snapshot")
+    ref.configure_shot_id(rep_rate_hz=1.0)
+    cam.configure_shot_id(rep_rate_hz=1.0)
+    cam.set_reference(ref, grace_wait_s=0.05)
+    return ref, cam, snapshot
+
+
+def _noscan_plan(ref: Any, detectors: list[Any], shots: int = 3):
+    return build_step_scan_plan(
+        strict=False,
+        motor=None,
+        positions=[None],
+        reference=ref,
+        detectors=detectors,
+        shots_per_step=shots,
+        controller=None,
+        experiment="",
+        scan_number=None,
+        scan_folder=None,
+        saving_detectors=[],
+    )
+
+
+class TestStagingContract:
+    """Per-row reads must be cache hits; stage/unstage must bracket the run."""
+
+    def test_staged_scan_issues_zero_backend_gets(self) -> None:
+        ref, cam, snapshot = _make_devices()
+        RE = RunEngine()
+        connect_mock(RE, ref, cam, snapshot)
+        from ophyd_async.core import set_mock_value
+
+        set_mock_value(ref.acq_timestamp, REF_T0)
+        set_mock_value(cam.acq_timestamp, CAM_T0)
+
+        counters: dict[str, int] = {}
+        for dev in (ref, cam, snapshot):
+            _count_backend_gets(dev, counters)
+
+        pacer = start_pacer(
+            RE, [(ref, REF_T0), (cam, CAM_T0)], initial_delay=1.0, interval=0.3
+        )
+        try:
+            RE(_noscan_plan(ref, [ref, cam, snapshot]))
+        finally:
+            pacer.cancel()
+
+        assert counters == {}, (
+            "per-row reads issued uncached backend gets — the staging "
+            f"contract is broken: {counters}"
+        )
+
+    def test_stage_and_unstage_bracket_the_run(self) -> None:
+        ref, cam, snapshot = _make_devices()
+        RE = RunEngine()
+        commands: list[str] = []
+        RE.msg_hook = lambda msg: commands.append(msg.command)
+        connect_mock(RE, ref, cam, snapshot)
+        from ophyd_async.core import set_mock_value
+
+        set_mock_value(ref.acq_timestamp, REF_T0)
+        set_mock_value(cam.acq_timestamp, CAM_T0)
+
+        pacer = start_pacer(
+            RE, [(ref, REF_T0), (cam, CAM_T0)], initial_delay=1.0, interval=0.3
+        )
+        try:
+            RE(_noscan_plan(ref, [ref, cam, snapshot], shots=1))
+        finally:
+            pacer.cancel()
+
+        # Staged exactly once per device (ophyd-async staging is a bool, not
+        # a refcount — double-staging would break unstage).
+        assert commands.count("stage") == 3
+        assert commands.count("unstage") == 3
+        assert commands.index("stage") < commands.index("open_run")
+        assert commands[::-1].index("unstage") < commands[::-1].index("close_run")
+
+    def test_devices_unstaged_after_mid_scan_failure(self) -> None:
+        ref, cam, snapshot = _make_devices()
+        RE = RunEngine()
+        connect_mock(RE, ref, cam, snapshot)
+        from ophyd_async.core import set_mock_value
+
+        set_mock_value(ref.acq_timestamp, REF_T0)
+        set_mock_value(cam.acq_timestamp, CAM_T0)
+
+        def failing_per_step():
+            raise RuntimeError("boom")
+            yield  # pragma: no cover - marks this as a generator
+
+        plan = build_step_scan_plan(
+            strict=False,
+            motor=None,
+            positions=[None],
+            reference=ref,
+            detectors=[ref, cam, snapshot],
+            shots_per_step=1,
+            controller=None,
+            experiment="",
+            scan_number=None,
+            scan_folder=None,
+            saving_detectors=[],
+            per_step=failing_per_step,
+        )
+        with pytest.raises(RuntimeError, match="boom"):
+            RE(plan)
+
+        # After the failed run the caches must be gone again: a fresh read of
+        # a data signal (NOT acq_timestamp, whose persistent subscription
+        # legitimately keeps its cache) goes back to the backend.
+        counters: dict[str, int] = {}
+        _count_backend_gets(snapshot, counters)
+        asyncio.run_coroutine_threadsafe(snapshot.read(), RE._loop).result(timeout=5.0)
+        assert sum(counters.values()) > 0, (
+            "data-signal cache survived unstage — devices were not unstaged "
+            "on the failure path"
+        )
+
+
+class TestRateDerivedBounds:
+    """1 Hz-era constants must scale with the configured rep rate."""
+
+    def test_grace_wait_capped_at_half_period(self) -> None:
+        cam = CaTimestampedReadable("U_Cam", ["Val"], name="cam")
+        cam.configure_shot_id(rep_rate_hz=5.0)
+        assert cam._effective_grace_wait_s() == pytest.approx(0.1)
+
+    def test_grace_wait_unchanged_at_one_hz(self) -> None:
+        cam = CaTimestampedReadable("U_Cam", ["Val"], name="cam")
+        cam.configure_shot_id(rep_rate_hz=1.0)
+        assert cam._effective_grace_wait_s() == pytest.approx(0.3)
+
+    def test_explicit_grace_below_cap_wins(self) -> None:
+        ref = CaGenericDetector("U_Ref", ["Sig"], name="ref")
+        ref.configure_shot_id(rep_rate_hz=5.0)
+        cam = CaTimestampedReadable("U_Cam", ["Val"], name="cam")
+        cam.configure_shot_id(rep_rate_hz=5.0)
+        cam.set_reference(ref, grace_wait_s=0.05)
+        assert cam._effective_grace_wait_s() == pytest.approx(0.05)
+
+    def test_t0_sync_window_capped_in_start_doc(self) -> None:
+        ref, cam, snapshot = _make_devices()
+        ref.configure_shot_id(rep_rate_hz=5.0)
+        cam.configure_shot_id(rep_rate_hz=5.0)
+        start_docs: list[dict] = []
+        RE = RunEngine()
+        RE.subscribe(
+            lambda name, doc: start_docs.append(doc) if name == "start" else None
+        )
+        connect_mock(RE, ref, cam, snapshot)
+        from ophyd_async.core import set_mock_value
+
+        set_mock_value(ref.acq_timestamp, REF_T0)
+        set_mock_value(cam.acq_timestamp, CAM_T0)
+
+        pacer = start_pacer(
+            RE, [(ref, REF_T0), (cam, CAM_T0)], initial_delay=1.0, interval=0.3
+        )
+        try:
+            RE(_noscan_plan(ref, [ref, cam, snapshot], shots=1))
+        finally:
+            pacer.cancel()
+
+        assert start_docs[0]["t0_sync_window_s"] == pytest.approx(0.4 / 5.0)
+
+
+class TestTelemetryReadBound:
+    """One hung telemetry PV must cost at most the read budget, not 10 s."""
+
+    def test_hung_signal_degrades_to_null_within_budget(self) -> None:
+        telemetry = CaTelemetryReadable(
+            "U_Slow", ["Fast", "Hung"], experiment="Test", name="telemetry_u_slow"
+        )
+        RE = RunEngine()
+        connect_mock(RE, telemetry)
+        telemetry._read_timeout_s = 0.2
+
+        fast, hung = telemetry._telemetry_signals
+
+        async def never_returns():
+            await asyncio.sleep(30)
+
+        hung.read = never_returns  # type: ignore[method-assign]
+
+        t0 = time.monotonic()
+        reading = asyncio.run_coroutine_threadsafe(telemetry.read(), RE._loop).result(
+            timeout=5.0
+        )
+        elapsed = time.monotonic() - t0
+
+        assert elapsed < 2.0, f"hung signal held the row for {elapsed:.1f}s"
+        hung_cells = [k for k in reading if "hung" in k.lower()]
+        assert hung_cells, f"no null cell emitted for the hung signal: {reading}"
+        for key in hung_cells:
+            assert reading[key]["alarm_severity"] == 3
+        fast_cells = [k for k in reading if "fast" in k.lower()]
+        assert fast_cells and all(reading[k]["alarm_severity"] == 0 for k in fast_cells)

--- a/Planning/device_read_path/00_overview.md
+++ b/Planning/device_read_path/00_overview.md
@@ -1,0 +1,123 @@
+# Device read-path hardening — audit findings & phased plan
+
+**Date:** 2026-07-13.  **Trigger:** live scans (Undulator Scans 1–3) at a
+1 Hz trigger ran at exactly 0.5 Hz — camera `acq_timestamp` deltas were
+exactly 2.000 s (free-run rows landing on every second trigger tick), and
+strict single-shot cadence measured 1.6–2.0 s/shot.
+
+**Target envelope:** 5 Hz (the system limit — laser rep rate; the LV GEECS
+device acquisition loop can be raised via a DB setting but ~5 Hz is the
+practical ceiling) with ~50 save-set devices plus background telemetry.
+Verification happens at 1 Hz (the available trigger rate); the design must
+make 5 Hz follow trivially.  Rates of 100 Hz+ are explicitly out of scope —
+that is a different framework, not a tuning exercise.
+
+## Root cause (measured, 2026-07-13)
+
+`background_telemetry` defaults on for ScanRequest submissions (the console
+path; the legacy exec_config path never ran telemetry), adding ~87 soft
+devices / 376 columns to every event row.  The RunEngine reads devices
+**sequentially** (one `read` Msg at a time), no plan ever **staged** a
+device, and an unstaged ophyd-async `read()` is one network CA get per
+signal — so each row paid ~87 serialized round trips (~7 ms each over VPN
+≈ 0.7 s), plus the blocking SINGLESHOT fire in strict mode.  Tracked as
+issue #540.
+
+## Audit verdicts (four deep-dives, 2026-07-13)
+
+1. **Foundation is sound.** `CaAcqTimestampReadable` is not a hack: it uses
+   ophyd-async's own subscription API, and its queue-plus-synchronous-baseline
+   `trigger()` solves a real shipped race (`wait_for_value`-style
+   subscribe-after-fire windows would reintroduce it).  The systemic gap was
+   only that plans never staged.
+2. **Staging semantics verified from installed source** (ophyd-async
+   0.19.3): `stage()` starts one caching CA monitor per signal; reads then
+   serve from memory (0 backend calls, proven with a counting-proxy
+   experiment); coexists with the persistent `acq_timestamp` subscription
+   (shared, listener-refcounted cache); works identically under mock
+   backends; **not refcounted** (stage exactly once); reads stay serialized
+   across devices (parallelism exists only within one device's read).
+3. **Framework ceiling measured** (mock-backend benchmark through the real
+   plans): `ms/event ≈ 0.5 + 0.30·devices + 0.013·columns`.  At the
+   50-device target ≈ 16 ms/event including TiledWriter's synchronous work —
+   ~8 % of the 5 Hz budget (200 ms/row).  Today's 87-device/785-column
+   telemetry shape ≈ 42 ms/event — fine at 5 Hz.  TiledWriter batches
+   (10 000-event buffer): HTTP at run open/close, never between shots.
+   Device *count* is the dominant framework lever (0.30 ms per read Msg).
+4. **Shot coherence of cached reads verified link-by-link** (gateway posting
+   order → caproto FIFO circuit → aioca FIFO hop → synchronous cache
+   update): at `trigger()` completion, staged data caches hold the
+   triggering frame or newer — never the previous frame.  Conditions and
+   sharp edges: `GeecsBluesky/CLAUDE.md` "Read path: staging & shot
+   coherence".
+5. **Strict mode is structurally ≲1–2 Hz** (the SINGLESHOT fire is a
+   blocking GEECS set awaited per shot, plus bounded refire budget).
+   5 Hz is free-run territory; free-run does zero puts per shot.
+
+## Phased plan
+
+### Phase 1 — staging + rate-derived bounds (LANDED, 0.32.0)
+
+- `build_step_scan_plan` stages every per-row read device (outermost
+  `bpp.stage_wrapper`; unstage runs on every exit path including abort).
+- Contributor grace wait capped at half a trigger period
+  (`FreeRunContributorSupport._effective_grace_wait_s`) — was a fixed 0.3 s
+  (3 periods at 10 Hz, 1.5 at 5 Hz, serialized per lagging contributor).
+- t0-sync window capped at `0.4 / rep_rate_hz`; effective value recorded in
+  the start doc.
+- Telemetry per-signal read budget 2 s (was ophyd's 10 s default; also
+  covers the staged first-read-never-delivers hazard).
+- Shot queue bound 32 → 128 (worst case 15 at 5 Hz).
+- Per-phase DEBUG timing: strict fire/frame-wait durations, free-run row
+  duration.
+- Pinned by `tests/test_read_path_staging.py`; full suite green.
+
+**Hardware verification (1 Hz):** free-run NOSCAN row cadence must be
+1.00 s (was exactly 2.00 s); strict cadence drops by the former read cost.
+5 Hz is *designed for, untested* — the plan's obligations at 5 Hz are all
+rate-derived, none hardcoded.
+
+### Phase 2 — telemetry aggregation (margin, not critical path at 5 Hz)
+
+Fold the ~87 per-device `CaTelemetryReadable`s into a handful of composite
+readables whose `read()` gathers across devices (each device already
+gathers internally — one more level of the same pattern).  Saves
+~25 ms/row of Msg dispatch, gives one stage point and one place to bound
+total telemetry wall time.  No schema impact (same columns).
+
+### Phase 3 — t0-sync seed verification
+
+The Phase 1 window cap makes 5 Hz *arithmetically* sound (window ∈
+(50, 100) ms between the clock-skew floor and half a period), but with
+little margin.  Add a cheap post-seed cross-check: verify the first armed
+rows land at `shot_offset == 0` across sync devices before trusting the
+scan (or re-seed from a plan-owned single shot).  Beyond 5 Hz the design's
+two requirements (window > skew, window < period/2) collide — redesign
+territory, out of scope.
+
+### Phase 4 — timestamp-only telemetry shot-attribution (design note first)
+
+Confirmed feasible with no MySQL flag: every gateway device serves
+`acq_timestamp` (pinned at 0.0 forever unless triggered) + `systimestamp`,
+so triggered-ness is *observable* (advancing in lockstep with the trigger
+vs static).  Per-sample attribution = include each telemetry device's own
+`acq_timestamp` in its variable set + seed a `ShotIdTracker` per device +
+label rows like `FreeRunContributorSupport` minus the grace wait
+(telemetry must never gate a shot).  One trap: deadband-suppressed data
+columns carry last-*change* timestamps — attribution must key on the
+timestamp PV, never data-column metadata.  Open semantic decisions for the
+design note: labeling of async devices' rows, when the observation window
+runs (needs trigger authority → pre-claim stage), which columns are added.
+
+## Deferred / out of scope
+
+- Telemetry as Bluesky monitor streams (`sd.monitors`) — the fully
+  conventional shape (zero shot-path cost, device-native cadence), deferred
+  because it is an event-schema change; revisit whenever the schema
+  iterates anyway (also the natural moment to wire the schema-version check,
+  issue #528).
+- `TiledWriter` per-event normalizer cost (~9 ms at 800 columns) — only
+  matters past 5 Hz.
+- Strict-mode rate: bounded by the blocking DG645 fire; not a software
+  problem.
+- 100 Hz+ — ground-up framework reconsideration, per the owner.


### PR DESCRIPTION
Phase 1 of the read-path hardening plan (full audit + phases 2–4 in `Planning/device_read_path/00_overview.md`, added here). Fixes the root cause behind #540: no plan ever staged a device, so every per-shot read was one uncached network CA get per signal, serialized across ~87 telemetry devices by the RunEngine — a 1 Hz scan ran at exactly 0.5 Hz.

Per-concern breakdown (+579/−14, of which ~230 is the Planning doc and ~250 is tests):

**The fix (~12 LOC)** — `build_step_scan_plan` wraps the composed plan in `bpp.stage_wrapper` over every per-row read device. Staged signals get one caching CA monitor for the scan's duration; per-shot reads become local cache hits. Correctness rests on the gateway's frame-ordering contract (data variables post before the timestamp ladder, PV_CONTRACT §3) — the full coherence chain was verified against installed caproto 1.3.0 / aioca 2.1 / ophyd-async 0.19.3 sources, and the conditions it stands on are written down in CLAUDE.md "Read path: staging & shot coherence".

**Rate-derived bounds (1 Hz behavior unchanged; 5 Hz is the design target, verified at 1 Hz per operator constraints):**
- contributor grace wait capped at half a trigger period (was fixed 0.3 s — 1.5 periods at 5 Hz, serialized per lagging contributor)
- t0-sync window capped at `0.4 / rep_rate_hz`; effective value recorded in the start doc (a window wider than a period silently seeds devices one shot apart)
- telemetry per-signal read budget 2 s (was ophyd's 10 s default — one hung PV held the row; also covers the staged first-read-never-delivers hazard)
- shot queue 32 → 128

**Observability** — DEBUG-level phase timing: strict fire/frame-wait durations, free-run row duration.

**Tests** — `tests/test_read_path_staging.py` (8 new): zero backend gets per row (counting-proxy pin), stage/unstage bracket the run including the abort path, grace/t0 caps, hung-telemetry bound. Full suite: **465 passed**.

**Hardware verification at 1 Hz** (next step, at the lab): free-run NOSCAN row cadence must return to 1.00 s from today's exactly-2.00 s. Framework headroom at the 5 Hz / 50-device target was benchmarked at ~16 ms per 200 ms row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)