### PR TITLE
GeecsBluesky 0.33.0: scan QoL — DONE implies inactive; concurrent telemetry connects

### DIFF
--- a/GeecsBluesky/CHANGELOG.md
+++ b/GeecsBluesky/CHANGELOG.md
@@ -4,6 +4,32 @@ All notable changes to `geecs-bluesky` are documented here.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.33.0] - 2026-07-13
+
+### Fixed
+
+- **The console's Start button no longer sticks after a scan** (operator
+  finding, 2026-07-13): the terminal DONE/ABORTED lifecycle event was
+  emitted from the scan thread milliseconds before it exited, so an
+  event-driven GUI re-checking `is_scanning_active()` from its
+  terminal-state handler raced the thread's last instructions and saw
+  `is_alive() == True` — leaving Start disabled until the operator
+  clicked Stop.  `is_scanning_active()` now reports `False` as soon as
+  the scan's `finally` cleanup completes, *before* the terminal event is
+  emitted; a thread genuinely stuck mid-plan still reports active (the
+  timed-out-join semantics are unchanged).
+
+### Changed
+
+- **Start-to-execution latency: telemetry devices connect concurrently.**
+  New `GeecsSession.telemetry_batch` constructs all Tier-2 readables and
+  awaits their connects in one gather, so wall time is the slowest device
+  rather than the sum — sequential connects cost ~9 s at ~87 devices
+  (measured live 2026-07-13, Scan006 timeline).
+  `build_telemetry_readables` uses the batch when the session provides it
+  (per-device fallback kept for duck-typed sessions); drop-on-failure
+  semantics per device are unchanged.
+
 ## [0.32.0] - 2026-07-13
 
 ### Fixed

--- a/GeecsBluesky/geecs_bluesky/scan_request_runner.py
+++ b/GeecsBluesky/geecs_bluesky/scan_request_runner.py
@@ -830,11 +830,22 @@ def build_telemetry_readables(
     )
     readables: list = []
     recorded: dict[str, list[str]] = {}
-    for device, variables in selected.items():
-        readable = session.telemetry(device, variables)
-        if readable is not None:
-            readables.append(readable)
-            recorded[device] = list(variables)
+    if hasattr(session, "telemetry_batch"):
+        # Concurrent connects: wall time = slowest device, not the sum
+        # (~87 sequential connects cost ~9 s of start latency; measured
+        # live 2026-07-13).  Fake sessions without the batch method fall
+        # through to the sequential per-device factory below.
+        readables = list(session.telemetry_batch(selected))
+        for readable in readables:
+            device = getattr(readable, "_geecs_device_name", None)
+            if device in selected:
+                recorded[device] = list(selected[device])
+    else:
+        for device, variables in selected.items():
+            readable = session.telemetry(device, variables)
+            if readable is not None:
+                readables.append(readable)
+                recorded[device] = list(variables)
     # Record only the devices that actually connected: a device dropped as
     # unreachable at scan start contributes no columns, so the start-doc
     # metadata must not advertise them (EVENT_SCHEMA.md contract — the key

--- a/GeecsBluesky/geecs_bluesky/scanner_bridge/bluesky_scanner.py
+++ b/GeecsBluesky/geecs_bluesky/scanner_bridge/bluesky_scanner.py
@@ -209,6 +209,7 @@ class BlueskyScanner:
         self._on_event = on_event
         self._current_state = self._scan_state("IDLE")
         self._abort_requested = False
+        self._scan_finished = False
 
         self._scan_thread: threading.Thread | None = None
         self._scan_config: Any = None
@@ -501,6 +502,7 @@ class BlueskyScanner:
         self._completed_shots = 0
         self._scan_number = None
         self._abort_requested = False
+        self._scan_finished = False
         self._scan_thread = threading.Thread(
             target=self._run_scan,
             args=(self._scan_config,),
@@ -564,8 +566,23 @@ class BlueskyScanner:
             logger.debug("RE.resume() raised", exc_info=True)
 
     def is_scanning_active(self) -> bool:
-        """Return ``True`` if a scan thread is currently running."""
-        return bool(self._scan_thread and self._scan_thread.is_alive())
+        """Return ``True`` if a scan thread is currently running.
+
+        ``False`` as soon as the scan's cleanup has completed — *before* the
+        terminal DONE/ABORTED lifecycle event is emitted — so an event-driven
+        GUI that re-checks this from its terminal-state handler never races
+        the scan thread's last few instructions (the thread emits the event
+        and exits milliseconds later; ``is_alive()`` alone reported ``True``
+        in that window, leaving Start disabled until an operator clicked
+        Stop).  A thread that is genuinely stuck mid-plan still reports
+        active: the flag is only set once the ``finally`` cleanup ran.
+        """
+        return bool(
+            self._scan_thread
+            and self._scan_thread.is_alive()
+            # getattr: hermetic tests build bare scanners via __new__.
+            and not getattr(self, "_scan_finished", False)
+        )
 
     def estimate_current_completion(self) -> float:
         """Return fraction complete (0.0–1.0) based on shots emitted."""
@@ -959,6 +976,10 @@ class BlueskyScanner:
             logger.exception("BlueskyScanner scan thread raised an exception")
         finally:
             self._disconnect_devices_sync()
+            # Cleanup is complete: mark inactive BEFORE emitting the terminal
+            # state, so a consumer reacting to DONE/ABORTED observes
+            # is_scanning_active() == False (see its docstring).
+            self._scan_finished = True
             if self._abort_requested or failed:
                 self._set_state("ABORTED")
             else:

--- a/GeecsBluesky/geecs_bluesky/session.py
+++ b/GeecsBluesky/geecs_bluesky/session.py
@@ -292,6 +292,65 @@ class GeecsSession:
             )
             return None
 
+    def telemetry_batch(
+        self,
+        selected: dict[str, list[str]],
+    ) -> list[CaTelemetryReadable]:
+        """Build and connect all Tier-2 telemetry readables **concurrently**.
+
+        The per-device :meth:`telemetry` factory connects sequentially — at
+        ~87 telemetry devices that alone cost ~9 s of the operator's
+        start-to-execution latency (each connect is a network round trip;
+        measured live 2026-07-13).  This batch variant constructs every
+        readable first, then awaits all connects in one ``asyncio.gather``
+        on the RunEngine loop, so wall time is the slowest single device
+        rather than the sum.
+
+        Per-device semantics are identical to :meth:`telemetry`: a device
+        unreachable at scan start is dropped with a warning, never an error
+        (the soft-tier contract).
+
+        Parameters
+        ----------
+        selected:
+            ``{device: [variables]}`` — the telemetry selection
+            (:func:`~geecs_bluesky.db_runtime.select_telemetry_variables`).
+
+        Returns
+        -------
+        list of CaTelemetryReadable
+            The connected readables, in *selected* order (dropped devices
+            omitted).
+        """
+        import asyncio
+
+        devices = [
+            CaTelemetryReadable(device, variables, experiment=self.experiment)
+            for device, variables in selected.items()
+        ]
+
+        async def _connect_all() -> list:
+            return await asyncio.gather(
+                *(d.connect(mock=self._mock) for d in devices),
+                return_exceptions=True,
+            )
+
+        results = asyncio.run_coroutine_threadsafe(
+            _connect_all(), self.RE._loop
+        ).result(timeout=30.0)
+        connected: list[CaTelemetryReadable] = []
+        for device_obj, result in zip(devices, results):
+            if isinstance(result, BaseException):
+                logger.warning(
+                    "Dropping background-telemetry device %s: unreachable at "
+                    "scan start (soft tier — never aborts the scan)",
+                    device_obj._geecs_device_name,
+                    exc_info=result,
+                )
+            else:
+                connected.append(device_obj)
+        return connected
+
     def motor(
         self,
         device: str,

--- a/GeecsBluesky/pyproject.toml
+++ b/GeecsBluesky/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-bluesky"
-version = "0.32.0"
+version = "0.33.0"
 description = "Bluesky / ophyd-async bridge for the GEECS control system"
 authors = ["Sam Barber <sbarber@lbl.gov>"]
 readme = "README.md"

--- a/GeecsBluesky/tests/test_start_latency_and_done_state.py
+++ b/GeecsBluesky/tests/test_start_latency_and_done_state.py
@@ -1,0 +1,163 @@
+"""Pins for the two scan QoL fixes (0.33.0).
+
+1. ``is_scanning_active()`` must already be ``False`` when the terminal
+   DONE/ABORTED lifecycle event is delivered — an event-driven GUI that
+   re-checks it from its terminal-state handler must never race the scan
+   thread's last instructions (observed live: the console's Start button
+   stayed disabled after every scan until the operator clicked Stop).
+2. Telemetry devices connect **concurrently** (``telemetry_batch``) — the
+   sequential per-device connects cost ~9 s of start-to-execution latency
+   at ~87 devices (measured live 2026-07-13).
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+import geecs_bluesky.session as session_module
+from geecs_bluesky.scan_request_runner import build_telemetry_readables
+from geecs_bluesky.scanner_bridge.bluesky_scanner import BlueskyScanner
+
+
+class TestDoneImpliesInactive:
+    """Terminal lifecycle events must observe an inactive scanner."""
+
+    def _bare_scanner(self, events: list) -> BlueskyScanner:
+        scanner = BlueskyScanner.__new__(BlueskyScanner)
+        scanner._on_event = lambda ev: events.append(
+            (getattr(ev, "state", None), scanner.is_scanning_active())
+        )
+        scanner._current_state = None
+        scanner._scan_number = None
+        scanner._scan_thread = None
+        scanner._scan_request = None
+        scanner._total_shots = 0
+        scanner._disconnect_devices_sync = lambda: None  # type: ignore[method-assign]
+        return scanner
+
+    def test_done_event_observes_inactive_scanner(self) -> None:
+        events: list[tuple] = []
+        scanner = self._bare_scanner(events)
+        # An unsupported mode runs the thread body straight to the finally
+        # block — the shortest real path through _run_scan's cleanup.
+        scanner._scan_config = SimpleNamespace(scan_mode="unsupported-mode")
+
+        scanner.start_scan_thread()
+        scanner._scan_thread.join(timeout=5.0)
+        assert not scanner._scan_thread.is_alive()
+
+        done = [
+            active
+            for state, active in events
+            if str(getattr(state, "value", state)).lower() == "done"
+        ]
+        assert done == [False], (
+            "the DONE lifecycle event was emitted while is_scanning_active() "
+            "still reported True — the GUI Start/Stop race is back"
+        )
+
+    def test_aborted_event_observes_inactive_scanner(self) -> None:
+        events: list[tuple] = []
+        scanner = self._bare_scanner(events)
+        scanner._scan_config = SimpleNamespace(scan_mode="unsupported-mode")
+
+        scanner.start_scan_thread()
+        scanner._abort_requested = True  # simulate a stop arriving mid-run
+        scanner._scan_thread.join(timeout=5.0)
+
+        terminal = [
+            (str(getattr(state, "value", state)).lower(), active)
+            for state, active in events
+            if str(getattr(state, "value", state)).lower() in ("done", "aborted")
+        ]
+        assert terminal and all(active is False for _, active in terminal)
+
+    def test_restart_resets_the_finished_flag(self) -> None:
+        events: list[tuple] = []
+        scanner = self._bare_scanner(events)
+        scanner._scan_config = SimpleNamespace(scan_mode="unsupported-mode")
+        scanner.start_scan_thread()
+        scanner._scan_thread.join(timeout=5.0)
+        assert scanner.is_scanning_active() is False
+
+        # A second scan must report active again while its thread runs.
+        import threading
+
+        release = threading.Event()
+
+        def blocking_run(_config):
+            release.wait(timeout=5.0)
+
+        scanner._run_scan = blocking_run  # type: ignore[method-assign]
+        scanner.start_scan_thread()
+        try:
+            assert scanner.is_scanning_active() is True
+        finally:
+            release.set()
+            scanner._scan_thread.join(timeout=5.0)
+
+
+class TestTelemetryBatchConnect:
+    """Telemetry connects run concurrently, drop-on-failure per device."""
+
+    def test_batch_connects_all_and_drops_failures(self, monkeypatch) -> None:
+        pytest.importorskip("aioca")
+        real = session_module.CaTelemetryReadable
+
+        class Flaky(real):  # type: ignore[misc,valid-type]
+            async def connect(self, **kwargs):
+                if self._geecs_device_name == "bad":
+                    raise RuntimeError("dead at scan start")
+                return await super().connect(**kwargs)
+
+        monkeypatch.setattr(session_module, "CaTelemetryReadable", Flaky)
+        session = session_module.GeecsSession("Test", tiled=False, mock=True)
+        connected = session.telemetry_batch({"a": ["X"], "bad": ["Y"], "c": ["Z"]})
+        assert [d._geecs_device_name for d in connected] == ["a", "c"]
+
+    def test_runner_uses_batch_and_records_only_connected(self) -> None:
+        class BatchSession:
+            def __init__(self) -> None:
+                self.batch_calls: list[dict] = []
+
+            def telemetry_batch(self, selected):
+                self.batch_calls.append(dict(selected))
+                return [
+                    SimpleNamespace(_geecs_device_name=device)
+                    for device in selected
+                    if device != "dropped"
+                ]
+
+            def telemetry(self, *args, **kwargs):  # pragma: no cover
+                raise AssertionError(
+                    "sequential telemetry factory used despite batch support"
+                )
+
+        policy = SimpleNamespace(
+            subscribed_by_device=lambda: {
+                "d1": ["v1"],
+                "dropped": ["v2"],
+                "d3": ["v3"],
+            }
+        )
+        session = BatchSession()
+        readables, recorded = build_telemetry_readables(session, None, policy)
+        assert session.batch_calls  # the batch path was taken
+        assert [r._geecs_device_name for r in readables] == ["d1", "d3"]
+        assert recorded == {"d1": ["v1"], "d3": ["v3"]}
+
+    def test_runner_falls_back_without_batch(self) -> None:
+        class LegacySession:
+            def telemetry(self, device, variables, **kwargs):
+                if device == "dead":
+                    return None
+                return SimpleNamespace(_geecs_device_name=device)
+
+        policy = SimpleNamespace(
+            subscribed_by_device=lambda: {"d1": ["v1"], "dead": ["v2"]}
+        )
+        readables, recorded = build_telemetry_readables(LegacySession(), None, policy)
+        assert [r._geecs_device_name for r in readables] == ["d1"]
+        assert recorded == {"d1": ["v1"]}


### PR DESCRIPTION
The two operator findings from today's verification session, both engine-side (+288/−8, ~180 of it tests):

**1. Start button stuck after every scan (the Stop-before-restart annoyance).**
Root cause: the console *does* refresh its buttons on the DONE lifecycle event — but that event is emitted from the scan thread milliseconds before the thread exits, and `is_scanning_active()` checked only `thread.is_alive()`. The queued GUI handler reliably won that race, saw "still scanning", and — the console being purely event-driven — nothing ever re-checked. Fix: `is_scanning_active()` returns `False` once the scan's `finally` cleanup completes, *before* the terminal event is emitted, so any consumer reacting to DONE/ABORTED observes an inactive scanner by construction. A thread genuinely stuck mid-plan still reports active (the flag is only set when cleanup ran), and `stop_scanning_thread`'s timed-out-join semantics are untouched — its existing pinning test passes unchanged.

**2. ~9 s between pressing Start and the scan executing.**
The Scan006 console-log timeline shows 12:04:51 (shot control attached) → 12:05:00 (preflight) — almost all of it the ~87 telemetry devices connecting **sequentially**, one network round trip each (the connect-time cousin of the read bug #541 fixed). New `GeecsSession.telemetry_batch` constructs all readables and awaits their connects in one `asyncio.gather` — wall time becomes the slowest device, not the sum. `build_telemetry_readables` prefers the batch when the session provides it (duck-typed fallback kept); per-device drop-on-failure semantics unchanged, recorded-metadata contract unchanged (only connected devices advertised). Expected start latency: ~9.5 s → ~2–3 s (the remaining chunk is config resolution + DB queries + detector connects + preflight).

Pinned by `tests/test_start_latency_and_done_state.py` (6 new: DONE/ABORTED observe inactive, restart re-arms, batch drop-on-failure, runner batch path + fallback). Full suite: **471 passed**.

Operator acceptance: after merge + console restart — Start re-enables itself when the scan finishes (no Stop click), and the gap between Start and the shot-controller's first state change shrinks to a few seconds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)