### PR TITLE
GeecsBluesky 0.34.0: read-path phases 2+3 — telemetry group, t0 seed check (+ phase 4 design note)

### DIFF
--- a/GeecsBluesky/CHANGELOG.md
+++ b/GeecsBluesky/CHANGELOG.md
@@ -4,6 +4,28 @@ All notable changes to `geecs-bluesky` are documented here.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.34.0] - 2026-07-13
+
+### Changed
+
+- **Read-path hardening phase 2 — the soft tier is one device.**
+  `build_telemetry_readables` wraps the connected telemetry readables in a
+  single `CaTelemetryGroup` whose `read()`/`describe()` gather across
+  members concurrently — one RunEngine `read` message per row instead of
+  one per device (~0.30 ms/message; ~25 ms/row at the ~87-device Undulator
+  selection).  Deliberately not an ophyd parent: members keep their own
+  names, so every `telemetry_<device>-<var>` event column is byte-identical
+  to the ungrouped layout (EVENT_SCHEMA.md contract).
+  `stage`/`unstage`/`disconnect` forward to members.
+- **Read-path hardening phase 3 — t0 seed check.**  After the first
+  free-run row, the plan logs a WARNING naming any contributor whose
+  `shot_offset != 0` — the signature of a t0 seeding off by a trigger
+  period (or a first-shot lag).  A loud hint, not an abort: offsets stay
+  truthfully labeled and realignable either way.
+- Phase 4 (timestamp-only telemetry shot attribution) is written up as a
+  design note with the open owner decisions:
+  `Planning/device_read_path/01_telemetry_attribution.md`.
+
 ## [0.33.0] - 2026-07-13
 
 ### Fixed

--- a/GeecsBluesky/geecs_bluesky/devices/ca/telemetry.py
+++ b/GeecsBluesky/geecs_bluesky/devices/ca/telemetry.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-from ophyd_async.core import StandardReadable
+from ophyd_async.core import AsyncStatus, StandardReadable
 from ophyd_async.epics.core import epics_signal_r
 
 from geecs_bluesky.devices.ca._pv import ca_pv
@@ -166,3 +166,93 @@ def _reading_keys(signal: Any) -> list[str]:
     """
     name = getattr(signal, "name", None)
     return [name] if name else []
+
+
+class CaTelemetryGroup:
+    """One Bluesky Readable bundling every Tier-2 telemetry device of a scan.
+
+    The RunEngine processes one ``read`` message at a time, so N separate
+    telemetry devices cost N sequential dispatches per event row (~0.3 ms
+    each — ~25 ms/row at the ~87-device Undulator selection, measured by
+    the 2026-07-13 plan-layer benchmark).  The group collapses the whole
+    soft tier into **one** read message whose ``read()``/``describe()``
+    gather across members concurrently.
+
+    Deliberately **not** an ophyd-async parent device: adopting the members
+    as children would re-parent and rename them, changing every
+    ``telemetry_<device>-<var>`` event column (the EVENT_SCHEMA.md
+    contract).  Members keep their own names and their own per-signal
+    fault tolerance; the merged event columns are byte-identical to the
+    ungrouped layout.
+
+    ``stage``/``unstage``/``disconnect`` forward to the members so the
+    read-path staging contract and the runner's cleanup see one device.
+
+    Parameters
+    ----------
+    members : list of CaTelemetryReadable
+        Connected telemetry readables (the group does not connect them).
+    name : str
+        Bluesky object name; never appears in event columns.
+    """
+
+    parent = None
+
+    def __init__(
+        self,
+        members: list[CaTelemetryReadable],
+        name: str = "telemetry_group",
+    ) -> None:
+        self.name = name
+        self._members = list(members)
+
+    @property
+    def members(self) -> list[CaTelemetryReadable]:
+        """The wrapped telemetry readables (read-only view)."""
+        return list(self._members)
+
+    async def describe(self) -> dict[str, Any]:
+        """Merged data keys of every member (concurrent)."""
+        import asyncio
+
+        merged: dict[str, Any] = {}
+        for desc in await asyncio.gather(*(m.describe() for m in self._members)):
+            merged.update(desc)
+        return merged
+
+    async def read(self) -> dict[str, Any]:
+        """Merged readings of every member (concurrent, member-fault-tolerant)."""
+        import asyncio
+
+        merged: dict[str, Any] = {}
+        for reading in await asyncio.gather(*(m.read() for m in self._members)):
+            merged.update(reading)
+        return merged
+
+    @AsyncStatus.wrap
+    async def stage(self) -> None:
+        """Stage every member (starts their caching monitors)."""
+        import asyncio
+
+        await asyncio.gather(*(m.stage() for m in self._members))
+
+    @AsyncStatus.wrap
+    async def unstage(self) -> None:
+        """Unstage every member (drops their caches)."""
+        import asyncio
+
+        await asyncio.gather(*(m.unstage() for m in self._members))
+
+    async def disconnect(self) -> None:
+        """Disconnect members that support it (the runner's cleanup seam).
+
+        ``CaTelemetryReadable`` itself defines no ``disconnect`` — its only
+        per-scan resources are the staged caches, dropped at ``unstage`` —
+        so this is a tolerant forward for members that do (parity with the
+        session's best-effort cleanup loop).
+        """
+        import asyncio
+
+        closers = [m.disconnect() for m in self._members if hasattr(m, "disconnect")]
+        if closers:
+            await asyncio.gather(*closers)

--- a/GeecsBluesky/geecs_bluesky/devices/contributor.py
+++ b/GeecsBluesky/geecs_bluesky/devices/contributor.py
@@ -49,6 +49,10 @@ class FreeRunContributorSupport:
 
     _reference: "Reference[ShotIdSupport] | None" = None
     _grace_wait_s: float = 0.3
+    #: The most recent read's reference-relative shot offset (``None`` before
+    #: the first read or when underivable) — consumed by the free-run plan's
+    #: t0 seed check after the first row.
+    last_shot_offset: int | None = None
 
     def set_reference(
         self,
@@ -177,5 +181,6 @@ class FreeRunContributorSupport:
             if shot_id is not None and row_shot_id is not None
             else None
         )
+        self.last_shot_offset = shot_offset
         self._emit_shot_id_readings(reading, event_timestamp, shot_id, shot_offset)
         return reading

--- a/GeecsBluesky/geecs_bluesky/plans/free_run_step_scan.py
+++ b/GeecsBluesky/geecs_bluesky/plans/free_run_step_scan.py
@@ -59,6 +59,32 @@ from geecs_bluesky.plans.t0_sync import geecs_t0_sync
 logger = logging.getLogger(__name__)
 
 
+def _t0_seed_check(contributors: list) -> None:
+    """Warn when the scan's first row shows a contributor off its t0 seed.
+
+    The t0-sync stage seeds every sync device from what should be one common
+    physical shot; a seeding error (window wider than the caches' spread —
+    possible near the ~50 ms clock-skew floor at fast rep rates) shows up as
+    a **constant nonzero ``shot_offset`` from the very first row**.  A
+    transiently lagging contributor also lands nonzero here, so this is a
+    loud hint, not an abort: offsets stay truthfully labeled and rows remain
+    realignable downstream either way (the event-schema contract).
+    """
+    suspects = [
+        getattr(dev, "name", str(dev))
+        for dev in contributors
+        if getattr(dev, "last_shot_offset", None) not in (None, 0)
+    ]
+    if suspects:
+        logger.warning(
+            "t0 seed check: first-row shot_offset != 0 for %s — either the "
+            "t0 seeding is off by a trigger period (check t0_sync_window_s "
+            "vs the rep rate) or the device lagged the first shot; "
+            "shot_offset labels remain truthful and realignable",
+            suspects,
+        )
+
+
 def geecs_free_run_step_scan(
     motor: Any | Sequence[Any] | None,
     positions: Iterable[Any],
@@ -254,6 +280,8 @@ def geecs_free_run_step_scan(
                         (time.monotonic() - row_t0) * 1e3,
                         len(_read_devices),
                     )
+                if scan_event_index == 1:
+                    _t0_seed_check(detectors)
             if disarm_trigger is not None:
                 yield from disarm_trigger()
         # End of scan: stop the trigger BEFORE the tail machinery — STANDBY

--- a/GeecsBluesky/geecs_bluesky/scan_request_runner.py
+++ b/GeecsBluesky/geecs_bluesky/scan_request_runner.py
@@ -819,24 +819,29 @@ def build_telemetry_readables(
     Returns
     -------
     tuple
-        ``(readables, recorded)`` — connected devices and the
+        ``(readables, recorded)`` — a single-element list holding the
+        :class:`~geecs_bluesky.devices.ca.telemetry.CaTelemetryGroup` of
+        connected devices (empty list when none connected), and the
         ``{device: [variables]}`` map of **only those that connected**
         (run-metadata key must match the columns that actually exist).
+        The group costs one RunEngine ``read`` message per row instead of
+        one per device; event columns are identical to the ungrouped
+        layout (members keep their own names).
     """
     if scalar_policy is None:
         return [], {}
     selected = select_telemetry_variables(
         save_set, scalar_policy.subscribed_by_device()
     )
-    readables: list = []
+    members: list = []
     recorded: dict[str, list[str]] = {}
     if hasattr(session, "telemetry_batch"):
         # Concurrent connects: wall time = slowest device, not the sum
         # (~87 sequential connects cost ~9 s of start latency; measured
         # live 2026-07-13).  Fake sessions without the batch method fall
         # through to the sequential per-device factory below.
-        readables = list(session.telemetry_batch(selected))
-        for readable in readables:
+        members = list(session.telemetry_batch(selected))
+        for readable in members:
             device = getattr(readable, "_geecs_device_name", None)
             if device in selected:
                 recorded[device] = list(selected[device])
@@ -844,13 +849,19 @@ def build_telemetry_readables(
         for device, variables in selected.items():
             readable = session.telemetry(device, variables)
             if readable is not None:
-                readables.append(readable)
+                members.append(readable)
                 recorded[device] = list(variables)
     # Record only the devices that actually connected: a device dropped as
     # unreachable at scan start contributes no columns, so the start-doc
     # metadata must not advertise them (EVENT_SCHEMA.md contract — the key
     # reflects what was recorded, not what was selected).
-    return readables, recorded
+    if not members:
+        return [], recorded
+    # Lazy import: the runner stays free of device-layer (aioca) imports so
+    # it remains importable without the `ca` extra.
+    from geecs_bluesky.devices.ca.telemetry import CaTelemetryGroup
+
+    return [CaTelemetryGroup(members)], recorded
 
 
 def run_scan_request(

--- a/GeecsBluesky/pyproject.toml
+++ b/GeecsBluesky/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-bluesky"
-version = "0.33.0"
+version = "0.34.0"
 description = "Bluesky / ophyd-async bridge for the GEECS control system"
 authors = ["Sam Barber <sbarber@lbl.gov>"]
 readme = "README.md"

--- a/GeecsBluesky/tests/test_start_latency_and_done_state.py
+++ b/GeecsBluesky/tests/test_start_latency_and_done_state.py
@@ -145,7 +145,9 @@ class TestTelemetryBatchConnect:
         session = BatchSession()
         readables, recorded = build_telemetry_readables(session, None, policy)
         assert session.batch_calls  # the batch path was taken
-        assert [r._geecs_device_name for r in readables] == ["d1", "d3"]
+        # Members arrive wrapped in one CaTelemetryGroup (one read Msg/row).
+        assert len(readables) == 1
+        assert [m._geecs_device_name for m in readables[0].members] == ["d1", "d3"]
         assert recorded == {"d1": ["v1"], "d3": ["v3"]}
 
     def test_runner_falls_back_without_batch(self) -> None:
@@ -159,5 +161,6 @@ class TestTelemetryBatchConnect:
             subscribed_by_device=lambda: {"d1": ["v1"], "dead": ["v2"]}
         )
         readables, recorded = build_telemetry_readables(LegacySession(), None, policy)
-        assert [r._geecs_device_name for r in readables] == ["d1"]
+        assert len(readables) == 1
+        assert [m._geecs_device_name for m in readables[0].members] == ["d1"]
         assert recorded == {"d1": ["v1"]}

--- a/GeecsBluesky/tests/test_telemetry_group_and_t0check.py
+++ b/GeecsBluesky/tests/test_telemetry_group_and_t0check.py
@@ -1,0 +1,184 @@
+"""Pins for read-path hardening phases 2 & 3 (0.34.0).
+
+Phase 2 — ``CaTelemetryGroup``: the whole soft tier costs one RunEngine
+``read`` message per row; merged event columns are identical to the
+ungrouped layout (members keep their own names — the EVENT_SCHEMA.md
+contract).
+
+Phase 3 — t0 seed check: the free-run plan warns when the scan's first row
+shows a contributor at ``shot_offset != 0`` (a seeding error is constant
+from row one; a healthy scan is silent).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+
+import pytest
+from bluesky import RunEngine
+
+pytest.importorskip("aioca")
+
+from ophyd_async.core import set_mock_value  # noqa: E402
+
+from geecs_bluesky.devices.ca import (  # noqa: E402
+    CaGenericDetector,
+    CaTimestampedReadable,
+)
+from geecs_bluesky.devices.ca.telemetry import (  # noqa: E402
+    CaTelemetryGroup,
+    CaTelemetryReadable,
+)
+from geecs_bluesky.plans.orchestration import build_step_scan_plan  # noqa: E402
+from tests.ca_mock_helpers import connect_mock, start_pacer  # noqa: E402
+
+REF_T0 = 1000.0
+CAM_T0 = 1000.05
+
+
+def _run_on(loop_owner: RunEngine, coro):
+    return asyncio.run_coroutine_threadsafe(coro, loop_owner._loop).result(timeout=10.0)
+
+
+class TestTelemetryGroup:
+    """One read Msg for the soft tier; columns identical to ungrouped."""
+
+    def _members(self, RE: RunEngine) -> list[CaTelemetryReadable]:
+        members = [
+            CaTelemetryReadable("U_Dev1", ["A", "B"], name="telemetry_u_dev1"),
+            CaTelemetryReadable("U_Dev2", ["C"], name="telemetry_u_dev2"),
+        ]
+        connect_mock(RE, *members)
+        return members
+
+    def test_group_merges_readings_and_datakeys_unrenamed(self) -> None:
+        RE = RunEngine()
+        members = self._members(RE)
+        group = CaTelemetryGroup(members)
+
+        member_desc: dict = {}
+        member_read: dict = {}
+        for m in members:
+            member_desc.update(_run_on(RE, m.describe()))
+            member_read.update(_run_on(RE, m.read()))
+        group_desc = _run_on(RE, group.describe())
+        group_read = _run_on(RE, group.read())
+
+        # Byte-identical column layout: same keys, member names untouched.
+        assert set(group_desc) == set(member_desc)
+        assert set(group_read) == set(member_read)
+        assert all(k.startswith("telemetry_u_dev") for k in group_desc)
+
+    def test_group_stage_serves_member_reads_from_cache(self) -> None:
+        RE = RunEngine()
+        members = self._members(RE)
+        group = CaTelemetryGroup(members)
+
+        async def stage_and_probe() -> tuple:
+            await group.stage()
+            set_mock_value(members[0]._telemetry_signals[0], 42.0)
+            reading = await group.read()
+            await group.unstage()
+            return reading
+
+        reading = _run_on(RE, stage_and_probe())
+        key = members[0]._telemetry_signals[0].name
+        # The staged cache tracked the monitor update.
+        assert reading[key]["value"] == 42.0
+
+    def test_group_costs_one_read_msg_per_row(self) -> None:
+        RE = RunEngine()
+        commands: list[str] = []
+        RE.msg_hook = lambda msg: commands.append(msg.command)
+
+        ref = CaGenericDetector("U_Ref", ["Sig"], name="ref")
+        cam = CaTimestampedReadable("U_Cam", ["Val"], name="cam")
+        ref.configure_shot_id(rep_rate_hz=1.0)
+        cam.configure_shot_id(rep_rate_hz=1.0)
+        cam.set_reference(ref, grace_wait_s=0.05)
+        connect_mock(RE, ref, cam)
+        members = self._members(RE)
+        group = CaTelemetryGroup(members)
+        set_mock_value(ref.acq_timestamp, REF_T0)
+        set_mock_value(cam.acq_timestamp, CAM_T0)
+
+        pacer = start_pacer(
+            RE, [(ref, REF_T0), (cam, CAM_T0)], initial_delay=1.0, interval=0.3
+        )
+        try:
+            RE(
+                build_step_scan_plan(
+                    strict=False,
+                    motor=None,
+                    positions=[None],
+                    reference=ref,
+                    detectors=[ref, cam, group],
+                    shots_per_step=1,
+                    controller=None,
+                    experiment="",
+                    scan_number=None,
+                    scan_folder=None,
+                    saving_detectors=[],
+                )
+            )
+        finally:
+            pacer.cancel()
+
+        # Primary row + tail flush each read: ref, cam, group, scan_context
+        # — 4 reads/row regardless of how many devices the group holds.
+        assert commands.count("read") == 8
+
+    def test_group_disconnect_forwards_to_members(self) -> None:
+        RE = RunEngine()
+        members = self._members(RE)
+        group = CaTelemetryGroup(members)
+        _run_on(RE, group.disconnect())  # must not raise; forwards to members
+
+
+class TestT0SeedCheck:
+    """First-row shot_offset != 0 warns; a healthy first row is silent."""
+
+    def _scan(self, fire_cam: bool, caplog) -> None:
+        RE = RunEngine()
+        ref = CaGenericDetector("U_Ref", ["Sig"], name="ref")
+        cam = CaTimestampedReadable("U_Cam", ["Val"], name="cam")
+        ref.configure_shot_id(rep_rate_hz=1.0)
+        cam.configure_shot_id(rep_rate_hz=1.0)
+        cam.set_reference(ref, grace_wait_s=0.05)
+        connect_mock(RE, ref, cam)
+        set_mock_value(ref.acq_timestamp, REF_T0)
+        set_mock_value(cam.acq_timestamp, CAM_T0)
+
+        targets = [(ref, REF_T0)] + ([(cam, CAM_T0)] if fire_cam else [])
+        pacer = start_pacer(RE, targets, initial_delay=1.0, interval=0.3)
+        try:
+            with caplog.at_level(
+                logging.WARNING, logger="geecs_bluesky.plans.free_run_step_scan"
+            ):
+                RE(
+                    build_step_scan_plan(
+                        strict=False,
+                        motor=None,
+                        positions=[None],
+                        reference=ref,
+                        detectors=[ref, cam],
+                        shots_per_step=2,
+                        controller=None,
+                        experiment="",
+                        scan_number=None,
+                        scan_folder=None,
+                        saving_detectors=[],
+                    )
+                )
+        finally:
+            pacer.cancel()
+
+    def test_lagging_contributor_warns_on_first_row(self, caplog) -> None:
+        self._scan(fire_cam=False, caplog=caplog)
+        warnings = [r for r in caplog.records if "t0 seed check" in r.getMessage()]
+        assert warnings and "cam" in warnings[0].getMessage()
+
+    def test_healthy_first_row_is_silent(self, caplog) -> None:
+        self._scan(fire_cam=True, caplog=caplog)
+        assert not [r for r in caplog.records if "t0 seed check" in r.getMessage()]

--- a/Planning/device_read_path/01_telemetry_attribution.md
+++ b/Planning/device_read_path/01_telemetry_attribution.md
@@ -1,0 +1,106 @@
+# Phase 4 design note — timestamp-only telemetry shot attribution
+
+**Status: DRAFT for review (Sam).**  Three decisions below (D1–D3) need an
+owner call before any code.  2026-07-13.
+
+## Why this matters (the cutover framing)
+
+Background telemetry is a **parity gate for the M6 cutover**: the Bluesky
+path must record at least as much context as the current best
+implementations (Master Control's save-everything; the legacy scanner's
+device logging) before either is retired.  Tier 2 already records every
+`get='yes'` variable of every live device.  What it lacks vs "best" is
+*shot attribution*: today a telemetry cell is "latest cached value at row
+time" with no statement about which physical shot it belongs to.  For
+triggered devices that statement is derivable — and the machinery already
+exists.
+
+## Mechanism (verified in the read-path audit, link 5)
+
+- Every gateway-served device gets `acq_timestamp` and `systimestamp` PVs
+  regardless of DB content.  A triggered device pushes `acq_timestamp` per
+  shot; a non-triggered device leaves it at the `0.0` placeholder forever
+  while `systimestamp` advances.  **Triggered-ness is therefore observable
+  — no config flag, no DB toggle**:
+  - `acq_timestamp > 0` and advancing in lockstep with the trigger
+    (advance rate ≈ rep rate) ⇒ triggered;
+  - pinned at `0.0` with a live `systimestamp` ⇒ async;
+  - advancing but *not* in lockstep ⇒ independently-clocked (treat as
+    async — the quiesced-window check below catches these).
+- Per-sample attribution for triggered telemetry = the existing
+  contributor recipe minus the grace wait (telemetry must never gate a
+  shot): include the device's own `acq_timestamp` in its signal set, seed
+  a `ShotIdTracker` at the t0-sync stage (cache reads only — cheap even at
+  ~87 devices), and emit `shot_id`/`shot_offset`/`valid` companions from
+  `read()` exactly as `FreeRunContributorSupport` does.
+- **The one trap**: deadband/exact-repeat suppression means a *data*
+  column's CA timestamp is "time of last change", not "time of this
+  sample".  Attribution must key on the `acq_timestamp` PV (which reposts
+  every frame), never on data-column reading metadata.
+
+## Decisions needed (owner)
+
+**D1 — what do async devices' telemetry rows say?**
+  a. Nothing new (today's behavior): value columns only; offline analysis
+     joins by the run's wall clock if it cares.
+  b. Add a `systimestamp` column per async telemetry device: the device's
+     own last-update time rides into every row, enabling offline
+     nearest-shot joins *with the clock-skew caveat made explicit*.
+  c. Nearest-shot `shot_id` labeling from `systimestamp` at read time:
+     maximum convenience, but manufactures precision from skewed clocks.
+  **Recommendation: (b)** — record the honest raw material, never a
+  derived label the data can't support.  (a) loses information we get for
+  free; (c) violates the "truthfully labeled" schema philosophy.
+
+**D2 — when does classification happen?**
+  a. Passively within each scan: classify from what `acq_timestamp` did
+     during the scan itself; per-sample labels only become trustworthy
+     after the first few rows.
+  b. An explicit pre-claim observation window: watch all candidates'
+     `acq_timestamp` during one armed window and one quiesced window
+     (both primitives exist: the staleness probe and
+     `geecs_confirm_quiescent`).  Deterministic, but costs seconds per
+     scan and needs trigger authority before the run.
+  c. (b) once per session/experiment, cached, with re-observation on
+     demand — devices do not change triggered-ness scan to scan.
+  **Recommendation: (c)** — first scan of a session pays the observation
+  window; subsequent scans reuse the classification; an operator action
+  (or an experiment change) invalidates the cache.
+
+**D3 — which companions do triggered telemetry devices get?**
+  The full contributor set (`-acq_timestamp`, `-shot_id`, `-shot_offset`,
+  `-valid`) or a minimal `-acq_timestamp` only (offline derivation of the
+  rest)?  **Recommendation: the full set** — the tracker arithmetic is
+  cheap, in-row `valid` is what makes the columns immediately usable, and
+  it is exactly the schema shape consumers already understand for
+  contributors.  Adds ~4 columns per *triggered* telemetry device (the
+  Undulator selection is mostly async, so the growth is modest).
+
+## What this is NOT
+
+- Not a schema version bump: new columns follow the existing contributor
+  companion pattern and the `telemetry_` prefix rule; consumers that
+  ignore them keep working.  (Telemetry as Bluesky monitor streams remains
+  the fully conventional endgame and IS a schema change — deferred, pairs
+  with #528.)
+- Not dependent on the MySQL `synchronous`-ish context: the DB can serve
+  as an optional *prior* to seed D2's first classification, never as the
+  source of truth.
+
+## Verification plan (the 2-camera + DG645 rig suffices)
+
+1. Save set = `Amp4In` only; the output camera then lands in telemetry.
+2. Run a free-run NOSCAN: the output camera's telemetry columns must
+   classify triggered, seed at t0, and label `shot_offset == 0` rows in
+   lockstep with the reference.
+3. Quiesce the trigger mid-observation-window (D2b path): the camera must
+   classify async-for-this-scan and fall back to D1 behavior.
+4. Any genuinely async device that is still up (gateway status PVs at
+   minimum) pins the D1 column shape.
+
+## Estimated shape
+
+`CaTelemetryReadable` grows an optional shot-id mode (constructor flag +
+the two mixins it currently omits); `build_telemetry_readables` splits the
+selection by classification; the observation stage is a new pre-claim step
+beside preflight.  Roughly a #541-sized PR, dominated by tests.


### PR DESCRIPTION
Phases 2 and 3 of the read-path hardening plan, plus the phase 4 design note for review.

**Phase 2 — `CaTelemetryGroup` (~90 LOC + tests).** The whole soft tier becomes one Bluesky Readable: `read()`/`describe()` gather across members concurrently, so a row costs one RunEngine `read` message instead of one per telemetry device (~0.30 ms/message → ~25 ms/row back at the 87-device selection, per the plan-layer benchmark). Deliberately **not** an ophyd parent — adoption would rename members and change every `telemetry_<device>-<var>` column; members keep their names and the merged layout is byte-identical to ungrouped (pinned by test). `stage`/`unstage`/`disconnect` forward to members; the runner wraps both the batch and fallback paths.

**Phase 3 — t0 seed check (~30 LOC + tests).** After the first free-run row, a WARNING names any contributor whose `shot_offset != 0` — the constant-from-row-one signature of t0 seeding off by a trigger period (thin window/skew margin at 5 Hz). Loud hint, never an abort: offsets remain truthfully labeled and realignable (schema contract).

**Phase 4 — design note only** (`Planning/device_read_path/01_telemetry_attribution.md`): timestamp-only telemetry shot attribution, framed as the M6 parity gate. Three owner decisions flagged (D1 async-row labeling, D2 classification-window policy, D3 companion-column set), each with a recommendation. No code until those are called.

Tests: 6 new in `tests/test_telemetry_group_and_t0check.py` (column-layout identity, cache-serving stage, one-read-Msg pin via msg_hook, disconnect forward, warn/silent t0 cases); the two 0.33.0 runner tests updated for the group shape. Full suite: **477 passed**.

Live verification (free-run + strict scans through the delegated ScanRequest path on the DG645 + 2-camera rig) to follow as a PR comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)