### PR TITLE
GeecsBluesky 0.35.0: telemetry shot context (read-path phase 4, owner-decided)

### DIFF
--- a/GeecsBluesky/CHANGELOG.md
+++ b/GeecsBluesky/CHANGELOG.md
@@ -4,6 +4,26 @@ All notable changes to `geecs-bluesky` are documented here.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.35.0] - 2026-07-13
+
+### Added
+
+- **Telemetry shot context (read-path phase 4, per the owner decisions in
+  `Planning/device_read_path/01_telemetry_attribution.md`).**  Every
+  telemetry device now records its own
+  `telemetry_<device>-acq_timestamp` column (the gateway serves the PV
+  for every device; async devices honestly show the `0.0` never-acquired
+  placeholder — no derived labels are manufactured for them).  On
+  free-run scans, telemetry devices **observed to have fired** (positive
+  cached `acq_timestamp` at the quiesced t0 snapshot — no classification
+  stage, no config flag, no DB toggle) are seeded like contributors and
+  additionally emit the standard `shot_id`/`shot_offset`/`valid`
+  companions, computed without any grace wait (telemetry never gates a
+  shot).  The start doc records the seeded device names under
+  `telemetry_shot_seeded`.  Additive column convention — no event-schema
+  version bump (EVENT_SCHEMA.md updated).  Strict-mode scans record the
+  raw acq column only (no t0 stage).
+
 ## [0.34.0] - 2026-07-13
 
 ### Changed

--- a/GeecsBluesky/EVENT_SCHEMA.md
+++ b/GeecsBluesky/EVENT_SCHEMA.md
@@ -125,6 +125,25 @@ start-doc `background_telemetry` key (present only when telemetry ran) records
 the `{device: [variables]}` actually selected. This is an additive
 device-name convention, not a new schema field — it does not bump the version.
 
+**Telemetry shot context** (optional, additive — does not bump the version):
+every telemetry device additionally records its own
+`telemetry_<device>-acq_timestamp` (the gateway serves this PV for every
+device; `0.0` is the never-acquired placeholder, recorded as-is — an async
+device honestly shows `0.0`). On free-run scans, a telemetry device whose
+cached `acq_timestamp` was **positive at the quiesced t0 snapshot** (i.e. it
+was observed to have actually fired — there is no classification flag) is
+seeded like a contributor and additionally carries the standard sync
+companions `telemetry_<device>-t0_acq_timestamp` / `-shot_id` /
+`-shot_offset` / `-valid`, computed without any grace wait (telemetry never
+gates a shot). Devices not seeded — async, never-fired, or any strict-mode
+scan (no t0 stage) — carry **no derived labels**: attribution for them is a
+downstream decision made from the raw timestamps (owner decision; design:
+`Planning/device_read_path/01_telemetry_attribution.md`). The start-doc
+`telemetry_shot_seeded` key (free-run, telemetry present) lists the device
+names that were seeded. Consumers must key any shot attribution on the
+`acq_timestamp` column, never on a data column's reading timestamp
+(deadband suppression makes those last-*change* times).
+
 **Free-run tail flush:** after the last shot, free-run runs emit one final
 event on a separate `flush` stream (one extra read of all devices) so a
 contributor lagging at `shot_offset = -1` still records its final shot.

--- a/GeecsBluesky/geecs_bluesky/devices/ca/telemetry.py
+++ b/GeecsBluesky/geecs_bluesky/devices/ca/telemetry.py
@@ -24,6 +24,7 @@ from ophyd_async.core import AsyncStatus, StandardReadable
 from ophyd_async.epics.core import epics_signal_r
 
 from geecs_bluesky.devices.ca._pv import ca_pv
+from geecs_bluesky.devices.shot_id import ShotIdSupport
 from geecs_bluesky.utils import safe_name
 
 logger = logging.getLogger(__name__)
@@ -33,7 +34,7 @@ logger = logging.getLogger(__name__)
 TELEMETRY_NAME_PREFIX = "telemetry_"
 
 
-class CaTelemetryReadable(StandardReadable):
+class CaTelemetryReadable(ShotIdSupport, StandardReadable):
     """Soft, read-only GEECS readable for background telemetry over gateway PVs.
 
     A fault-tolerant :meth:`read` never propagates an exception: a signal
@@ -42,6 +43,18 @@ class CaTelemetryReadable(StandardReadable):
     per-variable from the PV's native CA type: numeric PVs stay ``float``,
     enum/string PVs are captured as their label string.  Type tolerance is
     per-variable, never whole-device.
+
+    **Shot context (phase 4)**: with ``shot_rep_rate_hz`` set, the device
+    additionally reads its own ``acq_timestamp`` PV (the gateway serves one
+    for every device; it stays at the ``0.0`` placeholder unless the device
+    is actually triggered) as a ``<name>-acq_timestamp`` column, and — when
+    the free-run plan managed to **seed** its tracker at t0-sync (i.e. the
+    device has genuinely fired) — emits the standard sync-companion columns
+    (``shot_id`` / ``shot_offset`` / ``valid``) exactly like a contributor,
+    minus any grace wait (telemetry must never gate a shot).  There is no
+    classification stage or config flag: seeded ⇔ observed-to-have-fired,
+    decided per scan from the quiesced t0 snapshot (design:
+    ``Planning/device_read_path/01_telemetry_attribution.md``).
 
     Parameters
     ----------
@@ -59,6 +72,10 @@ class CaTelemetryReadable(StandardReadable):
         Scalar CA datatype.  Default ``None`` — infer each PV's native type.
         Do not force ``float`` here: that reintroduces the connect-time drop
         for non-numeric variables.
+    shot_rep_rate_hz : float, optional
+        Enable shot context: read the device's ``acq_timestamp`` and derive
+        shot IDs at this trigger rep rate.  ``None`` (default) is the
+        pre-phase-4 value-columns-only behavior.
     """
 
     def __init__(
@@ -69,22 +86,58 @@ class CaTelemetryReadable(StandardReadable):
         experiment: str | None = None,
         name: str | None = None,
         datatype: type | None = None,
+        shot_rep_rate_hz: float | None = None,
     ) -> None:
         if isinstance(variable_list, str):
             variable_list = [variable_list]
         self._geecs_device_name = device
         name = name or f"{TELEMETRY_NAME_PREFIX}{safe_name(device)}"
         self._telemetry_signals: list = []
+        self._row_reference: Any | None = None
         with self.add_children_as_readables():
             for var in variable_list:
+                if shot_rep_rate_hz is not None and var == "acq_timestamp":
+                    continue  # created below as the dedicated child
                 signal = epics_signal_r(datatype, ca_pv(experiment, device, var))
                 setattr(self, safe_name(var), signal)
                 self._telemetry_signals.append(signal)
+            if shot_rep_rate_hz is not None:
+                # Every gateway device serves this PV (0.0 unless triggered);
+                # as a readable child it lands as <name>-acq_timestamp.
+                self.acq_timestamp = epics_signal_r(
+                    float, ca_pv(experiment, device, "acq_timestamp")
+                )
+                self._telemetry_signals.append(self.acq_timestamp)
         super().__init__(name=name)
+        if shot_rep_rate_hz is not None:
+            self.configure_shot_id(shot_rep_rate_hz)
         # Telemetry columns are marked by the device-name prefix, not folded
         # into geecs_scalar_headers: they are Tier 2, not legacy s-file scalars,
         # so the Tiled→s-file exporter must not rename them as save-set data.
         self._column_headers: dict[str, str] = {}
+
+    def set_row_reference(self, reference: Any) -> None:
+        """Anchor companion columns to the free-run pacemaker.
+
+        Stored as a :class:`~ophyd_async.core.Reference` — assigning a bare
+        Device attribute would re-parent and rename the pacemaker (the same
+        hazard :class:`~geecs_bluesky.devices.contributor.FreeRunContributorSupport`
+        documents).
+        """
+        from ophyd_async.core import Reference
+
+        self._row_reference = Reference(reference)
+
+    def _row_shot_id(self) -> int | None:
+        """The row's shot ID, from the reference's cached timestamp (or None)."""
+        ref = self._row_reference() if self._row_reference is not None else None
+        if ref is None:
+            return None
+        tracker = ref.shot_id_tracker
+        ts = ref.last_acq_timestamp
+        if tracker is None or ts is None:
+            return None
+        return tracker.peek(ts)
 
     #: Per-signal read budget (seconds).  Bounds the soft tier's *latency*
     #: as well as its failures: without it a hung PV holds the event row for
@@ -137,7 +190,41 @@ class CaTelemetryReadable(StandardReadable):
                     }
             else:
                 reading.update(result)
+        tracker = self._shot_id_tracker
+        if tracker is not None and tracker.is_seeded:
+            # Companion columns for observed-to-have-fired devices only:
+            # seeded at the free-run plan's t0 snapshot, never a config flag.
+            ts_key = f"{self.name}-acq_timestamp"
+            entry = reading.get(ts_key)
+            ts = entry["value"] if entry is not None else None
+            event_timestamp = entry["timestamp"] if entry is not None else time.time()
+            shot_id = (
+                tracker.update(float(ts))
+                if isinstance(ts, (int, float)) and ts > 0
+                else None
+            )
+            row_shot_id = self._row_shot_id()
+            shot_offset = (
+                shot_id - row_shot_id
+                if shot_id is not None and row_shot_id is not None
+                else None
+            )
+            self._emit_shot_id_readings(reading, event_timestamp, shot_id, shot_offset)
         return reading
+
+    async def describe(self) -> dict[str, Any]:
+        """Data keys, plus the sync-companion keys when the tracker is seeded.
+
+        Seeding happens before the run opens (free-run t0 stage), so the
+        descriptor is stable for the whole scan: an unseeded (async or
+        never-fired) device describes exactly its value columns — per the
+        owner decision, async devices carry **no** derived labels.
+        """
+        desc = await super().describe()
+        tracker = self._shot_id_tracker
+        if tracker is not None and tracker.is_seeded:
+            desc.update(self._shot_id_datakeys())
+        return desc
 
 
 async def _null_value_for(signal: Any) -> Any:

--- a/GeecsBluesky/geecs_bluesky/plans/free_run_step_scan.py
+++ b/GeecsBluesky/geecs_bluesky/plans/free_run_step_scan.py
@@ -221,6 +221,21 @@ def geecs_free_run_step_scan(
     for det in detectors:
         if hasattr(det, "set_reference"):
             det.set_reference(reference)
+    # Soft shot-context candidates: telemetry members (inside a group) with
+    # a configured tracker.  They are anchored to the reference like
+    # contributors, and SEEDED best-effort below — only devices whose
+    # acq_timestamp is positive at the quiesced t0 snapshot (i.e. observed
+    # to have actually fired) get companion columns; the rest stay
+    # value-columns-only.  Soft: never gates, never fails the scan.
+    soft_shot_members = [
+        m
+        for d in detectors
+        for m in getattr(d, "members", [])
+        if isinstance(m, ShotIdSupport) and m.shot_id_tracker is not None
+    ]
+    for member in soft_shot_members:
+        if hasattr(member, "set_row_reference"):
+            member.set_row_reference(reference)
 
     _md: dict[str, Any] = {
         "plan_name": "geecs_free_run_step_scan",
@@ -250,6 +265,24 @@ def geecs_free_run_step_scan(
         yield from enable_saving()
     t0s = yield from geecs_t0_sync(sync_devices, window_s=effective_window_s)
     _md["device_t0s"] = t0s
+    if soft_shot_members:
+        # Soft seeding from the same quiesced snapshot: a positive cached
+        # acq_timestamp means the device has genuinely fired; 0.0 is the
+        # gateway's never-acquired placeholder (PV_CONTRACT.md §3) — those
+        # devices stay unseeded and emit no companion columns this scan.
+        seeded: list[str] = []
+        for member in soft_shot_members:
+            ts = yield from bps.rd(member.acq_timestamp)
+            if ts is not None and float(ts) > 0:
+                member.seed_shot_id(float(ts))
+                seeded.append(getattr(member, "name", str(member)))
+        logger.info(
+            "telemetry shot context: %d of %d devices seeded (fired before "
+            "t0); the rest record value columns only",
+            len(seeded),
+            len(soft_shot_members),
+        )
+        _md["telemetry_shot_seeded"] = seeded
 
     @bpp.run_decorator(md=_md)
     def _inner():

--- a/GeecsBluesky/geecs_bluesky/session.py
+++ b/GeecsBluesky/geecs_bluesky/session.py
@@ -280,6 +280,7 @@ class GeecsSession:
             variables,
             experiment=self.experiment,
             name=name,
+            shot_rep_rate_hz=self.rep_rate_hz,
         )
         try:
             return self._connect(det)
@@ -325,7 +326,12 @@ class GeecsSession:
         import asyncio
 
         devices = [
-            CaTelemetryReadable(device, variables, experiment=self.experiment)
+            CaTelemetryReadable(
+                device,
+                variables,
+                experiment=self.experiment,
+                shot_rep_rate_hz=self.rep_rate_hz,
+            )
             for device, variables in selected.items()
         ]
 

--- a/GeecsBluesky/pyproject.toml
+++ b/GeecsBluesky/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-bluesky"
-version = "0.34.0"
+version = "0.35.0"
 description = "Bluesky / ophyd-async bridge for the GEECS control system"
 authors = ["Sam Barber <sbarber@lbl.gov>"]
 readme = "README.md"

--- a/GeecsBluesky/tests/test_telemetry_shot_context.py
+++ b/GeecsBluesky/tests/test_telemetry_shot_context.py
@@ -1,0 +1,117 @@
+"""Pins for phase 4 — timestamp-only telemetry shot context (0.35.0).
+
+Owner decisions (Planning/device_read_path/01_telemetry_attribution.md):
+async devices carry NO derived labels (D1a); there is no classification
+stage — strict synchronization stays a save-set concept, and telemetry
+devices simply log their own ``acq_timestamp`` (D2, tabled); devices
+observed to have fired (positive ``acq_timestamp`` at the quiesced t0
+snapshot) get the full contributor companion set (D3).
+"""
+
+from __future__ import annotations
+
+import pytest
+from bluesky import RunEngine
+
+pytest.importorskip("aioca")
+
+from ophyd_async.core import set_mock_value  # noqa: E402
+
+from geecs_bluesky.devices.ca import CaGenericDetector  # noqa: E402
+from geecs_bluesky.devices.ca.telemetry import (  # noqa: E402
+    CaTelemetryGroup,
+    CaTelemetryReadable,
+)
+from geecs_bluesky.plans.orchestration import build_step_scan_plan  # noqa: E402
+from geecs_bluesky.session import GeecsSession  # noqa: E402
+from tests.ca_mock_helpers import connect_mock, start_pacer  # noqa: E402
+
+REF_T0 = 1000.0
+TEL_T0 = 1000.03
+
+
+def _run_scan(fire_telemetry: bool) -> tuple[list[dict], dict]:
+    """Mock free-run NOSCAN with one shot-context telemetry member."""
+    RE = RunEngine()
+    start_docs: list[dict] = []
+    events: list[dict] = []
+
+    def collect(name: str, doc: dict) -> None:
+        if name == "start":
+            start_docs.append(doc)
+        elif name == "event":
+            events.append(doc)
+
+    RE.subscribe(collect)
+
+    ref = CaGenericDetector("U_Ref", ["Sig"], name="ref")
+    ref.configure_shot_id(rep_rate_hz=1.0)
+    tel = CaTelemetryReadable(
+        "U_Tel", ["Val"], name="telemetry_u_tel", shot_rep_rate_hz=1.0
+    )
+    connect_mock(RE, ref, tel)
+    set_mock_value(ref.acq_timestamp, REF_T0)
+    if fire_telemetry:
+        set_mock_value(tel.acq_timestamp, TEL_T0)
+    # else: the acq_timestamp mock stays at its 0.0 default — the gateway's
+    # never-acquired placeholder.
+
+    group = CaTelemetryGroup([tel])
+    targets = [(ref, REF_T0)] + ([(tel, TEL_T0)] if fire_telemetry else [])
+    pacer = start_pacer(RE, targets, initial_delay=1.0, interval=0.3)
+    try:
+        RE(
+            build_step_scan_plan(
+                strict=False,
+                motor=None,
+                positions=[None],
+                reference=ref,
+                detectors=[ref, group],
+                shots_per_step=2,
+                controller=None,
+                experiment="",
+                scan_number=None,
+                scan_folder=None,
+                saving_detectors=[],
+            )
+        )
+    finally:
+        pacer.cancel()
+    return events, start_docs[0]
+
+
+class TestFiredTelemetryGetsCompanions:
+    def test_companions_present_and_valid(self) -> None:
+        events, start = _run_scan(fire_telemetry=True)
+        assert start["telemetry_shot_seeded"] == ["telemetry_u_tel"]
+        primary = [e for e in events if "telemetry_u_tel-acq_timestamp" in e["data"]]
+        assert primary
+        row = primary[-1]["data"]
+        assert row["telemetry_u_tel-acq_timestamp"] > 0
+        assert row["telemetry_u_tel-shot_id"] == row["ref-shot_id"]
+        assert row["telemetry_u_tel-shot_offset"] == 0
+        assert row["telemetry_u_tel-valid"] is True
+
+
+class TestNeverFiredTelemetryStaysPlain:
+    def test_no_companions_no_labels(self) -> None:
+        events, start = _run_scan(fire_telemetry=False)
+        assert start["telemetry_shot_seeded"] == []
+        row = events[0]["data"]
+        # The raw acq_timestamp column exists and shows the honest 0.0
+        # placeholder; NO derived labels are manufactured (owner call D1a).
+        assert row["telemetry_u_tel-acq_timestamp"] == 0.0
+        assert "telemetry_u_tel-shot_id" not in row
+        assert "telemetry_u_tel-shot_offset" not in row
+        assert "telemetry_u_tel-valid" not in row
+        # Value columns unaffected either way.
+        assert "telemetry_u_tel-val" in row
+
+
+class TestSessionWiresShotContext:
+    def test_telemetry_batch_configures_trackers(self) -> None:
+        session = GeecsSession("Test", tiled=False, mock=True, rep_rate_hz=1.0)
+        members = session.telemetry_batch({"U_A": ["X"]})
+        assert len(members) == 1
+        assert members[0].shot_id_tracker is not None
+        assert hasattr(members[0], "acq_timestamp")

--- a/Planning/device_read_path/01_telemetry_attribution.md
+++ b/Planning/device_read_path/01_telemetry_attribution.md
@@ -1,7 +1,28 @@
 # Phase 4 design note — timestamp-only telemetry shot attribution
 
-**Status: DRAFT for review (Sam).**  Three decisions below (D1–D3) need an
-owner call before any code.  2026-07-13.
+**Status: DECIDED (Sam, 2026-07-13) and implemented in 0.35.0.**
+
+- **D1 → (a)**: async devices carry **no** derived labels and no
+  `systimestamp` column either — Sam's refinement: `systimestamp` advances
+  with the device loop even when nothing is acquiring, so it can be
+  meaningless as an alignment signal.  The raw
+  `telemetry_<device>-acq_timestamp` column (0.0 placeholder for async)
+  is recorded for every telemetry device; attribution beyond that is a
+  downstream decision.
+- **D2 → tabled**: no classification stage.  The standing design decision
+  holds — anything needing strict synchronization belongs in a save set.
+  Telemetry just logs `acq_timestamp`; sync context is recoverable post
+  facto.
+- **D3 → full companion set, under the D2 constraint**: devices whose
+  cached `acq_timestamp` is positive at the quiesced t0 snapshot (i.e.
+  observed to have actually fired) are seeded like contributors and emit
+  `shot_id`/`shot_offset`/`valid`; everything else stays value-columns
+  (+ raw acq) only.  Seeding is free — no observation window, no trigger
+  authority, no flag: seeded ⇔ has-ever-fired at t0.
+
+The original option analysis is kept below for the record.
+
+---
 
 ## Why this matters (the cutover framing)
 


### PR DESCRIPTION
Implements phase 4 exactly per the owner decisions (design note updated to DECIDED in this PR):

- **D1 → (a):** async devices carry no derived labels — and no `systimestamp` column either (Sam's refinement: it advances with the device loop even when nothing is acquiring, so it can be meaningless as an alignment signal). Every telemetry device does record its own raw `telemetry_<device>-acq_timestamp` (the gateway serves the PV for every device; async devices honestly show the `0.0` placeholder).
- **D2 → tabled:** no classification stage, no observation window, no cache, no DB toggle. Strict synchronization remains a save-set concept.
- **D3 → full companion set under the D2 constraint:** on free-run scans, a telemetry device whose cached `acq_timestamp` is **positive at the quiesced t0 snapshot** (observed to have actually fired — classification collapses into the seed itself, for free) is seeded like a contributor and emits `shot_id`/`shot_offset`/`valid`, computed with no grace wait (telemetry never gates a shot). Everything else — async, never-fired, strict-mode scans — stays value-columns + raw acq only. The start doc lists seeded devices under `telemetry_shot_seeded`.

Mechanics: `CaTelemetryReadable` gains `ShotIdSupport` + an optional `shot_rep_rate_hz` (session factories pass the session rep rate); the free-run plan anchors group members to the reference and soft-seeds them via `bps.rd` right after t0-sync (staged cache reads — zero added latency, no trigger authority). `EVENT_SCHEMA.md` gets the additive telemetry-shot-context section (explicitly *not* a schema version bump), including the consumer rule: key attribution on the `acq_timestamp` column, never a data column's reading timestamp (deadband makes those last-change times).

+308/−5; 3 new tests (fired member gets companions matching the reference; never-fired member gets the honest 0.0 and no labels; session wiring); full suite **480 passed**.

Live verification on the 2-camera rig to follow as a comment (save set with one camera → the other becomes triggered telemetry, per the design note's verification plan).

🤖 Generated with [Claude Code](https://claude.com/claude-code)