### PR TITLE
tooling: collapse branch topology to dev + master

### DIFF
--- a/.claude/skills/land/SKILL.md
+++ b/.claude/skills/land/SKILL.md
@@ -26,14 +26,14 @@ and the topology in `CONTRIBUTING.md`.
 The branch topology (which work targets which base, until the M6 cutover)
 lives in **CONTRIBUTING.md § "Branch topology"** — that is the single
 canonical copy; read it now and pick the base matching the content of the
-change. Never target `master` directly — it lags the active branches
-until M6.
+change (`dev` for vision-world work; `master` only for analysis/legacy
+work with no dev-only imports).
 
-**Roll-forward rule (until M6):** the greenfield GUI branch is stacked on
-the engine branch. After merging a PR into the engine branch, merge it
-forward into greenfield (`git merge origin/<engine-branch> --no-edit
---no-verify` — `--no-verify` because pre-commit's auto-fixers abort merge
-commits) and push.
+**Roll-forward rule (until M6):** after merging an analysis/legacy PR
+into `master`, merge `master` forward into `dev` (`git merge
+origin/master --no-edit --no-verify` — `--no-verify` because pre-commit's
+auto-fixers abort merge commits) and push. Nothing merges `dev` →
+`master` until the M6 cutover.
 
 ## Steps
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,21 +26,28 @@ encode the recurring workflows.
 This section is the **single canonical copy** of the branch layout — the
 PR template and the `/land` skill point here rather than repeating it, so
 at M6 only this section (and the pointers' one-line reminders) needs
-editing. Active development does **not** target `master`:
+editing. Two lines (collapsed from three on 2026-07-13 — `feat/vision-v1`
+was retired into `dev`, and `feat/greenfield-epics-bluesky-gui` was
+renamed `dev`):
 
-- `feat/vision-v1` — the engine line: GeecsBluesky, GeecsCAGateway,
-  GEECS-Schemas, GEECS-Data-Utils, Planning docs, repo tooling.
-- `feat/greenfield-epics-bluesky-gui` — stacked on vision-v1: the
-  GEECS-Console operator GUI, GEECS-Scanner-GUI changes, the docs site.
+- `dev` — the vision world, and the default target for development:
+  GeecsBluesky, GeecsCAGateway, GEECS-Schemas, GEECS-Console, the scan
+  browser, Planning docs, repo tooling, the docs site.
+- `master` — the legacy-scanner line, kept deployable through the M6 gap:
+  the pure-legacy GEECS-Scanner-GUI plus **living analysis development**
+  (ImageAnalysis, ScanAnalysis, and their data-utils needs). Target
+  `master` for analysis work *unless it imports something that only
+  exists on `dev`* (e.g. `geecs_data_utils.tiled_catalog`) — then target
+  `dev`.
 
-PRs target the branch matching their content. After a vision-v1 merge,
-vision-v1 is merged forward into greenfield. `master` catches up at
-milestone cutovers. (This section will be deleted when the branches
-collapse at M6 — also prune the branch names from `pick_base()` in
-`scripts/check.sh` then; harmless if forgotten, it skips deleted
-branches and falls back to the default branch. Any other grep hits for
-the branch names — Planning/ notes, CHANGELOGs — are historical record,
-not instruction: leave them.)
+`master` is merged forward into `dev` periodically, so analysis work
+flows into the vision world automatically; nothing merges the other way
+until the M6 cutover (tag `master` first, then merge `dev` in). (At M6
+this section collapses to "everything targets `master`" — also prune the
+branch names from `pick_base()` in `scripts/check.sh` then; harmless if
+forgotten, it skips deleted branches and falls back to the default
+branch. Grep hits for the *old* branch names — Planning/ notes,
+CHANGELOGs — are historical record, not instruction: leave them.)
 
 ## Every PR that changes a package
 

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -70,7 +70,7 @@ pick_base() {
     # not a correctness fix.
     best=""
     best_n=999999
-    for c in origin/feat/vision-v1 origin/feat/greenfield-epics-bluesky-gui origin/HEAD origin/master; do
+    for c in origin/dev origin/HEAD origin/master; do
         git rev-parse --verify -q "$c" >/dev/null || continue
         mb="$(git merge-base HEAD "$c" 2>/dev/null)" || continue
         n="$(git rev-list --count "$mb..HEAD")"


### PR DESCRIPTION
Executes the branch collapse Sam approved: `feat/vision-v1` retired (verified 0 unique commits — fully contained), `feat/greenfield-epics-bluesky-gui` renamed `dev` (GitHub rename; old-name redirects and PR retargeting are automatic).

- CONTRIBUTING § Branch topology (the canonical copy) rewritten: `dev` = vision-world development target; `master` = legacy scanner + living analysis line (analysis PRs target master unless they import dev-only foundations); master → dev sync periodic; dev → master only at M6, tag first.
- `check.sh pick_base()` candidates pruned to `origin/dev origin/HEAD origin/master`.
- `/land` roll-forward rule updated to the new single sync direction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)