### PR TITLE
GEECS-Console: Actions menu with execute gating + dry-run preview (G-actions v1)

### DIFF
--- a/GEECS-Console/CHANGELOG.md
+++ b/GEECS-Console/CHANGELOG.md
@@ -4,6 +4,40 @@ All notable changes to GEECS-Console are documented here.  Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versioning is
 semantic.
 
+## [0.10.0] - 2026-07-14
+
+### Added
+
+- **Actions menu (G-actions v1, console half)**: the menu now lists the
+  current experiment's action-plan names (from the same
+  `action_library/actions.yaml` the Action Library editor edits), refreshed
+  on experiment change via a `BackgroundResult` worker; empty/offline shows
+  a disabled "(no actions)" entry.  Clicking a plan opens an
+  `ActionRunDialog` (`app/action_dialog.py`): a dry-run steps table from the
+  engine's `describe_action` (kind / device / variable / value / wait /
+  from-plan per row, execution order) plus Run/Close.  Run dispatches the
+  blocking `run_action` on a daemon worker — in flight the button disables
+  and the status bar shows "running action '<name>'…"; success reports
+  "action '<name>' done"; a failure or refusal (e.g. the engine's
+  "scan in progress — action not started") shows in the status bar AND
+  inline in the dialog.  Preview and run outcomes render on separate lines
+  so a slow preview can never clobber a refusal (pinned by test).
+- **Execute gating**: a checkable "Enable action execution" item tops the
+  menu — the accidental-click guard.  Default OFF at every launch and
+  deliberately NOT persisted (a fresh session never starts armed); while
+  unchecked every action dialog is preview-only.
+- `Submitter` protocol extended with the engine contract's
+  `run_action(name) -> None` (blocking; raises operator-readable messages)
+  and `describe_action(name) -> list[dict]` (dry-run step dicts) — mapped
+  by `make_bluesky_submitter` to the scanner's same-named methods.
+
+### Changed
+
+- `BackgroundResult` extracted from `app/main_window.py` to
+  `services/background.py` (the shared home recorded on issue #510) so the
+  action dialog can own its workers; the browser's `BrowserWorker` twin
+  still awaits its mechanical swap.
+
 ## [0.9.2] - 2026-07-13
 
 ### Changed

--- a/GEECS-Console/CLAUDE.md
+++ b/GEECS-Console/CLAUDE.md
@@ -224,15 +224,43 @@ are prefixed by region (`r3_radio_1d`, `r5_start_button`, …).
   (10 s expiry timer running) is never clobbered.  `tests/conftest.py`
   patches the module-level default lookup (and the completions factory) so
   hermetic tests never touch the real data root or DB.
-- **`BackgroundResult`** (`app/main_window.py`): the one blessed
-  daemon-thread → queued-signal worker for one-shot background calls (the
-  `HealthPoller` shape, generalized).  **The daemon thread must emit on
-  the worker QObject, never on the window**: emitting a window-owned
-  signal from a daemon thread races window teardown and segfaults under
-  offscreen pytest (observed directly when the idle scan probe emitted a
-  `MainWindow` signal; the R7 device-set completion was the last such
-  emission and moved to a `BackgroundResult` worker in 0.7.0 — issue
-  #510).  `closeEvent` disconnects each worker's `result_ready`.
+- **`BackgroundResult`** (`services/background.py`, extracted from
+  `app/main_window.py` in 0.10.0 — the shared home recorded on issue
+  #510): the one blessed daemon-thread → queued-signal worker for one-shot
+  background calls (the `HealthPoller` shape, generalized).  **The daemon
+  thread must emit on the worker QObject, never on the window**: emitting
+  a window-owned signal from a daemon thread races window teardown and
+  segfaults under offscreen pytest (observed directly when the idle scan
+  probe emitted a `MainWindow` signal; the R7 device-set completion was
+  the last such emission and moved to a `BackgroundResult` worker in
+  0.7.0 — issue #510).  `closeEvent` disconnects each worker's
+  `result_ready`.
+- **Actions menu (G-actions v1)**: lists the current experiment's
+  action-plan names — fetched from `ActionLibraryStore.list_names()` (the
+  same `action_library/actions.yaml` the Action Library editor edits;
+  constructor-injectable `action_store` seam) on a `BackgroundResult`
+  worker, refreshed on experiment change, stale results dropped by
+  experiment tag; empty/offline renders one disabled "(no actions)"
+  entry.  On top sits **"Enable action execution"** — the accidental-click
+  guard: checkable, **default OFF at every launch and deliberately NOT
+  persisted** (a fresh session must never start armed; do not "fix" this
+  by adding it to `ConsoleSettings`).  Clicking a plan opens the
+  non-modal `ActionRunDialog` (`app/action_dialog.py`, kept in
+  `self._open_action_dialogs` — the GC hazard): a dry-run steps table
+  from the engine's `describe_action(name) -> list[dict]` (keys `kind` /
+  `device` / `variable` / `value` / `wait_s` / `from_plan`, execution
+  order) plus Run/Close.  Run is enabled only while armed and dispatches
+  the blocking `run_action(name)` on a dialog-owned worker — in flight
+  the button disables and the status bar shows "running action
+  '<name>'…"; success reports "action '<name>' done"; failures/refusals
+  (the engine raises exactly `RuntimeError("scan in progress — action
+  not started")` during a scan) land in the status bar AND inline.  The
+  preview and run outcomes render on **separate labels** — a slow
+  describe arriving late must never clobber a refusal (pinned by test).
+  Both engine methods are `Submitter` protocol members
+  (`submission.py`), mapped to `BlueskyScanner`'s same-named methods.
+  A pause-the-scan flow for actions (#552) is future work.  Pinned by
+  `tests/test_actions_menu.py`.
 - **Optimization (R3) — end to end**: the Optimization radio shows a
   config combo listing the YAML stems of the experiment's
   `optimizer_configs/` folder (legacy scanner-GUI folder name; part of
@@ -355,11 +383,11 @@ than copying):
 Deliberate temporary twins of `app/main_window.py` internals (kept because
 the browser must not import that file — another stream owns it):
 
-- `browser/_background.py::BrowserWorker` ↔ `BackgroundResult`.  **Replace
-  with the shared `services/background.py` once that extraction lands**
-  (the plan recorded on issue #510; #510's own fix landed without it) —
-  the API is kept tiny (one class, one signal, one method) so the swap is
-  mechanical.
+- `browser/_background.py::BrowserWorker` ↔ `BackgroundResult`.  The
+  shared `services/background.py` **exists now** (extracted in 0.10.0 for
+  the Actions menu, per the plan recorded on issue #510); the swap onto it
+  is mechanical (one class, one signal, one method) and simply hasn't been
+  done — take it when next touching the browser.
 - `__main__._load_console_stylesheet` ↔ `load_stylesheet`.
 
 ## Stubbed seams (intentional, wire later)

--- a/GEECS-Console/geecs_console/app/action_dialog.py
+++ b/GEECS-Console/geecs_console/app/action_dialog.py
@@ -1,0 +1,286 @@
+"""The per-action Run/Preview dialog behind the Actions menu (G-actions v1).
+
+Clicking an action-plan name in the Actions menu opens one
+:class:`ActionRunDialog`: the plan's dry-run step table (the engine's
+``describe_action``) plus a Run button gated by the menu's
+"Enable action execution" arming switch.  The dialog is deliberately thin —
+it owns no engine knowledge beyond the two callables it is constructed with,
+so tests drive it with plain fakes and the window wires it to the real
+:class:`~geecs_console.submission.Submitter` methods.
+
+Both engine calls are blocking, so each runs on a short-lived daemon thread
+through a dialog-owned :class:`~geecs_console.services.background.BackgroundResult`
+worker (never a window-owned signal — issue #510), delivered queued back to
+the GUI thread.  ``closeEvent`` disconnects the workers, so closing during a
+slow describe/run returns immediately and the straggler result lands nowhere.
+"""
+
+from __future__ import annotations
+
+from typing import Callable, Optional
+
+from PySide6.QtCore import Qt, Slot
+from PySide6.QtWidgets import (
+    QDialog,
+    QHBoxLayout,
+    QLabel,
+    QPushButton,
+    QTableWidget,
+    QTableWidgetItem,
+    QVBoxLayout,
+    QWidget,
+)
+
+from geecs_console.services.background import BackgroundResult
+
+#: The engine's dry-run step-dict keys, in table-column order (the
+#: ``describe_action`` contract; ``from_plan`` is ``None`` for top-level
+#: steps).  Rows appear in execution order.
+STEP_KEYS = ("kind", "device", "variable", "value", "wait_s", "from_plan")
+
+_STEP_HEADERS = ("#", "kind", "device", "variable", "value", "wait (s)", "from plan")
+
+
+def _cell_text(value: object) -> str:
+    """Render one step-dict value for the table (``None`` as an em-dash)."""
+    return "—" if value is None else str(value)
+
+
+class ActionRunDialog(QDialog):
+    """Preview-and-run dialog for one named action plan.
+
+    Parameters
+    ----------
+    parent : QWidget or None
+        The owning window (the dialog is shown non-modally, so the caller
+        must also keep a Python reference — the PySide6 GC hazard).
+    name : str
+        The action-plan name (dialog title; passed to both callables).
+    describe : callable
+        ``(name) -> list[dict]`` — the engine's blocking dry-run
+        (:meth:`Submitter.describe_action`); called once at construction on
+        a daemon thread.  A raised exception becomes the inline message.
+    run : callable
+        ``(name) -> None`` — the engine's blocking execution
+        (:meth:`Submitter.run_action`); raises with an operator-readable
+        message on refusal/failure (e.g. the scan-in-progress refusal).
+    execution_enabled : bool
+        The Actions menu's arming state at open; the window pushes later
+        toggles through :meth:`set_execution_enabled`.
+    report : callable
+        ``(message) -> None`` — the window's status-bar/log reporter for
+        the running/done/failed lines.
+    """
+
+    def __init__(
+        self,
+        parent: Optional[QWidget],
+        name: str,
+        describe: Callable[[str], list],
+        run: Callable[[str], None],
+        execution_enabled: bool,
+        report: Callable[[str], None],
+    ) -> None:
+        super().__init__(parent)
+        self._name = name
+        self._describe = describe
+        self._run = run
+        self._report = report
+        self._execution_enabled = bool(execution_enabled)
+        self._run_in_flight = False
+
+        self.setWindowTitle(f"Action: {name}")
+        self._build_widgets()
+        self._refresh_run_enabled()
+
+        # Dialog-owned workers: the daemon thread emits on the worker, the
+        # queued delivery paints on the GUI thread, and closeEvent
+        # disconnects both so a slow engine call never blocks closing.
+        self._describe_worker = BackgroundResult()
+        self._describe_worker.result_ready.connect(
+            self._apply_describe_result, Qt.ConnectionType.QueuedConnection
+        )
+        self._run_worker = BackgroundResult()
+        self._run_worker.result_ready.connect(
+            self._apply_run_result, Qt.ConnectionType.QueuedConnection
+        )
+        self._start_describe()
+
+    # ------------------------------------------------------------------
+    # Construction
+    # ------------------------------------------------------------------
+
+    def _build_widgets(self) -> None:
+        """Create the name label, steps table, message line, and buttons."""
+        layout = QVBoxLayout(self)
+
+        title = QLabel(f"Action plan: <b>{self._name}</b>")
+        title.setTextFormat(Qt.TextFormat.RichText)
+        layout.addWidget(title)
+
+        self.steps_table = QTableWidget(0, len(_STEP_HEADERS), self)
+        self.steps_table.setHorizontalHeaderLabels(list(_STEP_HEADERS))
+        self.steps_table.setEditTriggers(QTableWidget.EditTrigger.NoEditTriggers)
+        self.steps_table.setSelectionMode(QTableWidget.SelectionMode.NoSelection)
+        self.steps_table.verticalHeader().setVisible(False)
+        self.steps_table.horizontalHeader().setStretchLastSection(True)
+        layout.addWidget(self.steps_table)
+
+        # Two separate lines, deliberately: the async preview result and the
+        # async run outcome would otherwise race for one label, and a late
+        # preview must never clobber a run failure/refusal (which has to
+        # stay visible).
+        self.preview_label = QLabel("Loading steps…")
+        self.preview_label.setWordWrap(True)
+        layout.addWidget(self.preview_label)
+
+        self.message_label = QLabel("")
+        self.message_label.setWordWrap(True)
+        layout.addWidget(self.message_label)
+
+        buttons = QHBoxLayout()
+        buttons.addStretch(1)
+        self.run_button = QPushButton("Run", self)
+        self.run_button.clicked.connect(self._on_run_clicked)
+        buttons.addWidget(self.run_button)
+        self.close_button = QPushButton("Close", self)
+        self.close_button.clicked.connect(self.close)
+        buttons.addWidget(self.close_button)
+        layout.addLayout(buttons)
+
+        self.resize(640, 360)
+
+    # ------------------------------------------------------------------
+    # Gating
+    # ------------------------------------------------------------------
+
+    def set_execution_enabled(self, enabled: bool) -> None:
+        """Apply the Actions menu's arming state (pushed by the window).
+
+        Parameters
+        ----------
+        enabled : bool
+            The "Enable action execution" checkbox state.
+        """
+        self._execution_enabled = bool(enabled)
+        self._refresh_run_enabled()
+
+    def _refresh_run_enabled(self) -> None:
+        """Gate Run: armed via the menu, and no run already in flight."""
+        self.run_button.setEnabled(self._execution_enabled and not self._run_in_flight)
+        if not self._execution_enabled:
+            self.run_button.setToolTip(
+                "Check 'Enable action execution' in the Actions menu to arm "
+                "Run (preview is always available)."
+            )
+        else:
+            self.run_button.setToolTip(
+                "Execute this action plan through the scan engine now."
+            )
+
+    # ------------------------------------------------------------------
+    # Dry-run preview (describe_action)
+    # ------------------------------------------------------------------
+
+    def _start_describe(self) -> None:
+        """Fetch the dry-run step list on a daemon thread (once, at open)."""
+        describe = self._describe
+        name = self._name
+
+        def fetch() -> tuple[bool, object]:
+            try:
+                return (True, describe(name))
+            except Exception as exc:  # noqa: BLE001 — any failure is an inline message
+                return (False, str(exc))
+
+        self._describe_worker.run_async(fetch, name="console-action-describe")
+
+    @Slot(object)
+    def _apply_describe_result(self, payload: object) -> None:
+        """Render the dry-run steps, or the failure inline (GUI-thread slot).
+
+        Parameters
+        ----------
+        payload : tuple
+            ``(ok, steps | message)`` from the describe worker.
+        """
+        ok, value = payload
+        if not ok:
+            self.preview_label.setText(f"Preview failed: {value}")
+            return
+        steps = list(value)
+        self.steps_table.setRowCount(len(steps))
+        for row, step in enumerate(steps):
+            cells = [str(row + 1)] + [_cell_text(step.get(key)) for key in STEP_KEYS]
+            for column, text in enumerate(cells):
+                self.steps_table.setItem(row, column, QTableWidgetItem(text))
+        self.steps_table.resizeColumnsToContents()
+        count = len(steps)
+        self.preview_label.setText(
+            f"{count} step{'s' if count != 1 else ''} (dry-run preview)."
+        )
+
+    # ------------------------------------------------------------------
+    # Execution (run_action)
+    # ------------------------------------------------------------------
+
+    def _on_run_clicked(self) -> None:
+        """Dispatch the blocking ``run_action`` through the run worker."""
+        if self._run_in_flight or not self._execution_enabled:
+            return
+        self._run_in_flight = True
+        self._refresh_run_enabled()
+        message = f"running action '{self._name}'…"
+        self._report(message)
+        self.message_label.setText(message)
+        run = self._run
+        name = self._name
+
+        def call() -> tuple[bool, str]:
+            try:
+                run(name)
+            except Exception as exc:  # noqa: BLE001 — refusals/failures are messages
+                return (False, str(exc))
+            return (True, f"action '{name}' done")
+
+        self._run_worker.run_async(call, name="console-action-run")
+
+    @Slot(object)
+    def _apply_run_result(self, payload: object) -> None:
+        """Report one finished run and re-arm the button (GUI-thread slot).
+
+        Success shows "action '<name>' done"; a failure or refusal (e.g.
+        the engine's "scan in progress — action not started") shows the
+        raised message — in the status bar *and* inline, so a refusal is
+        never silent.
+
+        Parameters
+        ----------
+        payload : tuple
+            ``(ok, message)`` from the run worker.
+        """
+        _ok, message = payload
+        self._run_in_flight = False
+        self._report(message)
+        self.message_label.setText(message)
+        self._refresh_run_enabled()
+
+    # ------------------------------------------------------------------
+    # Teardown
+    # ------------------------------------------------------------------
+
+    def closeEvent(self, event) -> None:  # noqa: N802 — Qt override
+        """Disconnect the workers so a straggling engine call lands nowhere.
+
+        Never joins the daemon threads — closing during a slow describe or
+        run must return immediately.
+        """
+        for worker, slot in (
+            (self._describe_worker, self._apply_describe_result),
+            (self._run_worker, self._apply_run_result),
+        ):
+            try:
+                worker.result_ready.disconnect(slot)
+            except (RuntimeError, TypeError):
+                pass
+        super().closeEvent(event)

--- a/GEECS-Console/geecs_console/app/main_window.py
+++ b/GEECS-Console/geecs_console/app/main_window.py
@@ -41,12 +41,15 @@ from PySide6.QtWidgets import (
 )
 from pydantic import ValidationError
 
+from geecs_console.app.action_dialog import ActionRunDialog
 from geecs_console.editors.action_library_editor import open_action_library_editor
 from geecs_console.editors.save_set_editor import open_save_set_editor
 from geecs_console.editors.scan_variable_editor import open_scan_variable_editor
 from geecs_console.editors.shot_control_editor import open_shot_control_editor
 from geecs_console.events_adapter import ScanEventsAdapter
 from geecs_console.services import ops_paths
+from geecs_console.services.action_library_store import ActionLibraryStore
+from geecs_console.services.background import BackgroundResult
 from geecs_console.services.device_completions import (
     CompletionsProvider,
     EmptyCompletions,
@@ -213,48 +216,6 @@ class HealthPoller(QObject):
             self.report_ready.emit(report)
 
 
-class BackgroundResult(QObject):
-    """Runs one blocking callable on a daemon thread and reports its result.
-
-    The :class:`HealthPoller` shape, generalized: the worker lives on the
-    GUI thread, each :meth:`run_async` call spawns a short-lived daemon
-    thread, and the result comes back through the queued
-    :attr:`result_ready` signal.  Crucially the daemon thread emits on
-    *this worker*, never on the main window — emitting a window-owned
-    signal from a daemon thread races window teardown and segfaults under
-    offscreen pytest (observed with the idle scan-number probe).
-    """
-
-    result_ready = Signal(object)
-    """Carries the callable's return value, one emission per finished call."""
-
-    def run_async(self, func: Callable[[], object], name: str) -> None:
-        """Run *func* on a fresh daemon thread and emit its result.
-
-        Parameters
-        ----------
-        func : callable
-            Zero-argument blocking callable.  Exceptions are logged and
-            swallowed (no emission), so wrap the call when a failure result
-            should still be delivered.
-        name : str
-            The daemon thread's name (debugging).
-        """
-        threading.Thread(target=self._run, args=(func,), name=name, daemon=True).start()
-
-    def _run(self, func: Callable[[], object]) -> None:
-        """Call *func* (on the daemon thread) and emit the result."""
-        try:
-            result = func()
-        except Exception as exc:  # noqa: BLE001 — background work is best-effort
-            logger.info("background call failed: %s", exc)
-            return
-        try:
-            self.result_ready.emit(result)
-        except RuntimeError:
-            pass  # the worker was deleted while the call ran
-
-
 class ToolTipSuppressor(QObject):
     """Application-level event filter that swallows every tooltip event.
 
@@ -315,6 +276,11 @@ class MainWindow(QMainWindow):
         R4 preset persistence (a preset IS a saved ``ScanRequest``); tests
         inject a fake or a tmp-dir-backed store, default reads/writes the
         experiment's ``presets/`` dir in the configs repo.
+    action_store : ActionLibraryStore, optional
+        The Actions-menu name source (only ``list_names`` /
+        ``set_experiment`` are used — listing runs on a daemon thread);
+        tests inject a fake, default reads the experiment's
+        ``action_library/actions.yaml`` in the configs repo.
     settings : ConsoleSettings, optional
         Persisted GUI state (last selected experiment); tests inject one
         backed by a tmp INI file, default is the user-scope QSettings store.
@@ -349,6 +315,7 @@ class MainWindow(QMainWindow):
         health: Optional[HealthProbe] = None,
         device_panel: Optional[DevicePanelBackend] = None,
         presets: Optional[PresetStore] = None,
+        action_store: Optional[ActionLibraryStore] = None,
         settings: Optional[ConsoleSettings] = None,
         submitter: Optional[Submitter] = None,
         submitter_factory: Optional[Callable[..., Submitter]] = None,
@@ -364,6 +331,11 @@ class MainWindow(QMainWindow):
         )
         self._presets = (
             presets if presets is not None else PresetStore(self._configs.experiment)
+        )
+        self._action_store = (
+            action_store
+            if action_store is not None
+            else ActionLibraryStore(self._configs.experiment)
         )
         self._settings = settings if settings is not None else ConsoleSettings()
         self._device_set_in_flight = False
@@ -384,6 +356,9 @@ class MainWindow(QMainWindow):
         #: garbage-collects an unreferenced dialog wrapper and tears down the
         #: C++ dialog with it, so every opened editor is kept here.
         self._open_editors: list = []
+        #: Non-modal ActionRunDialogs opened from the Actions menu — same
+        #: PySide6 GC hazard, same keep-a-reference cure.
+        self._open_action_dialogs: list = []
 
         self._apply_stylesheet()
         self._load_ui()
@@ -410,13 +385,15 @@ class MainWindow(QMainWindow):
         self._on_mode_changed()
         self._refresh_device_set_enabled()
         # Startup fetches for the selected experiment (no-ops when none):
-        # R7 device:variable completions and the R6 idle scan-number peek.
-        # Restoring the last experiment already fired the experiment-changed
-        # path (which starts both); these cover the explicit-experiment and
-        # no-experiment startups.  Stale results are dropped by experiment
-        # tag, so a duplicate fetch is harmless.
+        # R7 device:variable completions, the R6 idle scan-number peek, and
+        # the Actions-menu plan names.  Restoring the last experiment already
+        # fired the experiment-changed path (which starts all three); these
+        # cover the explicit-experiment and no-experiment startups.  Stale
+        # results are dropped by experiment tag, so a duplicate fetch is
+        # harmless.
         self._start_device_completions_fetch()
         self._start_idle_scan_probe()
+        self._start_actions_fetch()
 
     # ------------------------------------------------------------------
     # Construction
@@ -719,10 +696,21 @@ class MainWindow(QMainWindow):
         github = ops.addAction("GEECS-Plugins on GitHub")
         github.triggered.connect(self._on_open_github)
 
+        # Actions menu: the arming switch on top, then one entry per action
+        # plan in the current experiment's library (filled asynchronously by
+        # _apply_action_names).  The arming state is deliberately NOT
+        # persisted — a fresh session must never start armed, so every
+        # launch begins with execution off and preview-only dialogs.
         actions_menu = self.menuBar().addMenu("Actions")
         self._menus.append(actions_menu)
-        placeholder = actions_menu.addAction("(not wired yet)")
-        placeholder.setEnabled(False)
+        self._actions_menu = actions_menu
+        self.enable_actions_action = actions_menu.addAction("Enable action execution")
+        self.enable_actions_action.setCheckable(True)
+        self.enable_actions_action.setChecked(False)
+        self.enable_actions_action.toggled.connect(self._on_enable_actions_toggled)
+        actions_menu.addSeparator()
+        self._action_plan_actions: list = []
+        self._set_action_names([])
 
         editors = self.menuBar().addMenu("Editors")
         self._menus.append(editors)
@@ -841,6 +829,10 @@ class MainWindow(QMainWindow):
         self._idle_scan_worker = BackgroundResult()
         self._idle_scan_worker.result_ready.connect(
             self._apply_idle_scan_number, Qt.ConnectionType.QueuedConnection
+        )
+        self._actions_worker = BackgroundResult()
+        self._actions_worker.result_ready.connect(
+            self._apply_action_names, Qt.ConnectionType.QueuedConnection
         )
 
         self.events.state_changed.connect(self._on_scan_state)
@@ -1018,6 +1010,7 @@ class MainWindow(QMainWindow):
             ),
             (getattr(self, "_idle_scan_worker", None), self._apply_idle_scan_number),
             (getattr(self, "_device_set_worker", None), self._apply_device_set_result),
+            (getattr(self, "_actions_worker", None), self._apply_action_names),
         ):
             if worker is None:
                 continue
@@ -1260,14 +1253,17 @@ class MainWindow(QMainWindow):
         """Repopulate everything for the newly selected experiment."""
         self._configs.set_experiment(experiment)
         self._presets.set_experiment(experiment)
+        self._action_store.set_experiment(experiment)
         self._settings.last_experiment = experiment
         self._push_experiment_to_probe(experiment)
         self._populate_from_configs()
         # The readback PV is experiment-prefixed — re-point the monitor.
         self._resubscribe_device()
-        # New experiment, new device list and new daily scans folder.
+        # New experiment: new device list, new daily scans folder, and a
+        # new action-plan library.
         self._start_device_completions_fetch()
         self._start_idle_scan_probe()
+        self._start_actions_fetch()
 
     def _restore_last_experiment(self) -> None:
         """Select the remembered experiment at startup (explicit choice wins).
@@ -1396,6 +1392,117 @@ class MainWindow(QMainWindow):
     def _on_edit_action_library(self) -> None:
         """Editors: open the action-library editor for the current experiment."""
         self._open_editor(open_action_library_editor)
+
+    # ------------------------------------------------------------------
+    # Actions menu (G-actions v1: arming switch + per-plan Run/Preview)
+    # ------------------------------------------------------------------
+
+    def _start_actions_fetch(self) -> None:
+        """Fetch the experiment's action-plan names off the GUI thread.
+
+        ``list_names`` parses the library YAML on a possibly slow configs
+        mount, so it runs on a short-lived daemon thread (via the
+        :class:`BackgroundResult` worker), tagged with the experiment and
+        delivered queued to :meth:`_apply_action_names`.  No experiment
+        answers inline with an empty list, spawning no thread.
+        """
+        experiment = self.experiment_combo.currentText()
+        if not experiment:
+            self._apply_action_names((experiment, []))
+            return
+        store = self._action_store
+
+        def fetch() -> tuple[str, list[str]]:
+            return (experiment, store.list_names())
+
+        self._actions_worker.run_async(fetch, name="console-action-names")
+
+    @Slot(object)
+    def _apply_action_names(self, payload: object) -> None:
+        """Rebuild the Actions-menu entries (GUI-thread slot, delivered queued).
+
+        Parameters
+        ----------
+        payload : tuple
+            ``(experiment, [plan_name, ...])``; a result tagged with an
+            experiment that is no longer selected is dropped (a stale fetch
+            racing an experiment change).
+        """
+        experiment, names = payload
+        if experiment != self.experiment_combo.currentText():
+            return
+        self._set_action_names(list(names))
+
+    def _set_action_names(self, names: list[str]) -> None:
+        """Replace the per-plan menu entries below the arming switch.
+
+        Parameters
+        ----------
+        names : list of str
+            The experiment's action-plan names; empty (or offline) renders
+            one disabled ``(no actions)`` entry.
+        """
+        for action in self._action_plan_actions:
+            self._actions_menu.removeAction(action)
+            action.deleteLater()
+        self._action_plan_actions = []
+        if not names:
+            placeholder = self._actions_menu.addAction("(no actions)")
+            placeholder.setEnabled(False)
+            self._action_plan_actions.append(placeholder)
+            return
+        for name in names:
+            action = self._actions_menu.addAction(name)
+            action.triggered.connect(
+                lambda checked=False, plan=name: self._on_action_plan(plan)
+            )
+            self._action_plan_actions.append(action)
+
+    def _on_enable_actions_toggled(self, checked: bool) -> None:
+        """Push the arming state into every open action dialog.
+
+        Deliberately **not** persisted (unlike the Preferences toggles): a
+        fresh console session must never start with action execution armed.
+
+        Parameters
+        ----------
+        checked : bool
+            The "Enable action execution" state.
+        """
+        self._open_action_dialogs = [
+            d for d in self._open_action_dialogs if d.isVisible()
+        ]
+        for dialog in self._open_action_dialogs:
+            dialog.set_execution_enabled(checked)
+
+    def _on_action_plan(self, name: str) -> None:
+        """Open the Run/Preview dialog for action plan *name*.
+
+        The dialog is shown non-modally and kept in
+        ``self._open_action_dialogs`` (the PySide6 GC hazard).  Preview is
+        always available; Run is gated by the arming switch.
+
+        Parameters
+        ----------
+        name : str
+            The action-plan name (a menu entry).
+        """
+        submitter = self._ensure_submitter()
+        if submitter is None:
+            return
+        dialog = ActionRunDialog(
+            self,
+            name,
+            describe=submitter.describe_action,
+            run=submitter.run_action,
+            execution_enabled=self.enable_actions_action.isChecked(),
+            report=self._report,
+        )
+        self._open_action_dialogs = [
+            d for d in self._open_action_dialogs if d.isVisible()
+        ]
+        self._open_action_dialogs.append(dialog)
+        dialog.show()
 
     # ------------------------------------------------------------------
     # Preferences (beeps)

--- a/GEECS-Console/geecs_console/services/background.py
+++ b/GEECS-Console/geecs_console/services/background.py
@@ -1,0 +1,60 @@
+"""The one blessed daemon-thread → queued-signal worker for one-shot calls.
+
+:class:`BackgroundResult` lived in ``app/main_window.py`` until the Actions
+menu needed it from a second window-family module (``app/action_dialog.py``);
+this is the shared extraction recorded on issue #510.  The browser's private
+twin (``browser/_background.py::BrowserWorker``) is still pending its
+mechanical swap onto this class.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+from typing import Callable
+
+from PySide6.QtCore import QObject, Signal
+
+logger = logging.getLogger(__name__)
+
+
+class BackgroundResult(QObject):
+    """Runs one blocking callable on a daemon thread and reports its result.
+
+    The ``HealthPoller`` shape, generalized: the worker lives on the
+    GUI thread, each :meth:`run_async` call spawns a short-lived daemon
+    thread, and the result comes back through the queued
+    :attr:`result_ready` signal.  Crucially the daemon thread emits on
+    *this worker*, never on the main window — emitting a window-owned
+    signal from a daemon thread races window teardown and segfaults under
+    offscreen pytest (observed with the idle scan-number probe).
+    """
+
+    result_ready = Signal(object)
+    """Carries the callable's return value, one emission per finished call."""
+
+    def run_async(self, func: Callable[[], object], name: str) -> None:
+        """Run *func* on a fresh daemon thread and emit its result.
+
+        Parameters
+        ----------
+        func : callable
+            Zero-argument blocking callable.  Exceptions are logged and
+            swallowed (no emission), so wrap the call when a failure result
+            should still be delivered.
+        name : str
+            The daemon thread's name (debugging).
+        """
+        threading.Thread(target=self._run, args=(func,), name=name, daemon=True).start()
+
+    def _run(self, func: Callable[[], object]) -> None:
+        """Call *func* (on the daemon thread) and emit the result."""
+        try:
+            result = func()
+        except Exception as exc:  # noqa: BLE001 — background work is best-effort
+            logger.info("background call failed: %s", exc)
+            return
+        try:
+            self.result_ready.emit(result)
+        except RuntimeError:
+            pass  # the worker was deleted while the call ran

--- a/GEECS-Console/geecs_console/submission.py
+++ b/GEECS-Console/geecs_console/submission.py
@@ -2,9 +2,11 @@
 
 :class:`Submitter` is the protocol the main window depends on — the four
 methods of ``BlueskyScanner``'s ScanManager-compatible surface that the
-console actually calls.  :func:`make_bluesky_submitter` builds the real
-engine; the import is inside the function so the window opens (and the whole
-package imports) without the ``ca`` extra or a reachable gateway.
+console actually calls, plus the two action-plan methods behind the Actions
+menu (``run_action`` / ``describe_action``, same names on the scanner).
+:func:`make_bluesky_submitter` builds the real engine; the import is inside
+the function so the window opens (and the whole package imports) without the
+``ca`` extra or a reachable gateway.
 """
 
 from __future__ import annotations
@@ -32,6 +34,24 @@ class Submitter(Protocol):
 
     def is_scanning_active(self) -> bool:
         """Whether a scan is currently running."""
+        ...
+
+    def run_action(self, name: str) -> None:
+        """Execute action plan *name* now — blocking.
+
+        Raises with an operator-readable message on refusal or failure;
+        during a scan the engine raises exactly
+        ``RuntimeError("scan in progress — action not started")``.
+        """
+        ...
+
+    def describe_action(self, name: str) -> list[dict]:
+        """Dry-run action plan *name* — the resolved steps, never executed.
+
+        Returns one dict per step in execution order, with keys ``kind``,
+        ``device``, ``variable``, ``value``, ``wait_s``, and ``from_plan``
+        (``None`` where not applicable).
+        """
         ...
 
 
@@ -62,6 +82,10 @@ def make_bluesky_submitter(
 
     Notes
     -----
+    The Actions-menu methods (``run_action`` / ``describe_action``) map to
+    the scanner's same-named methods — the returned engine satisfies the
+    protocol structurally, no adapter needed.
+
     The engine's ``optimization_loader`` seam is wired here from
     :func:`geecs_console.services.optimization.make_optimization_loader`:
     with the console's optional ``optimization`` extra installed the loader

--- a/GEECS-Console/pyproject.toml
+++ b/GEECS-Console/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-console"
-version = "0.9.2"
+version = "0.10.0"
 description = "Greenfield PySide6 operator console for GEECS (Bluesky/gateway architecture)"
 authors = ["Sam Barber <sbarber@lbl.gov>"]
 readme = "README.md"

--- a/GEECS-Console/tests/test_actions_menu.py
+++ b/GEECS-Console/tests/test_actions_menu.py
@@ -1,0 +1,326 @@
+"""Actions menu (G-actions v1), hermetic: fake action store + fake submitter.
+
+Covers menu population and experiment-change refresh, the execute-gating
+semantics (default OFF at every launch, deliberately not persisted), the
+per-action Run/Preview dialog (dry-run table from ``describe_action``, Run
+through ``run_action``, refusal surfaced), in-flight disable, and clean
+teardown (close during a slow describe returns fast).
+"""
+
+import threading
+import time
+
+import pytest
+
+from geecs_console.app.main_window import MainWindow
+from geecs_console.services.configs import ConfigListing, UnionPreview
+from geecs_console.services.settings import ConsoleSettings
+
+#: The engine's exact scan-in-progress refusal (the contract this GUI half
+#: is built against).
+SCAN_IN_PROGRESS = "scan in progress — action not started"
+
+
+class FakeConfigs:
+    """Minimal ConsoleConfigs stand-in (no filesystem)."""
+
+    def __init__(self, experiment="TestExp", experiments=("TestExp", "Bella")):
+        self.experiment = experiment
+        self._experiments = list(experiments)
+
+    def set_experiment(self, experiment):
+        self.experiment = experiment
+
+    def listing(self):
+        return ConfigListing(
+            experiments=self._experiments, save_sets=["Diag"], scan_variables=["jet_x"]
+        )
+
+    def union_preview(self, names):
+        return UnionPreview(device_count=len(names), hint="")
+
+    def trigger_variants(self, profile_name):
+        return []
+
+
+class FakeActionStore:
+    """ActionLibraryStore stand-in: names per experiment, no filesystem."""
+
+    def __init__(self, names_by_experiment=None):
+        self.experiment = "TestExp"
+        self.names_by_experiment = dict(names_by_experiment or {})
+
+    def set_experiment(self, experiment):
+        self.experiment = experiment
+
+    def list_names(self):
+        return list(self.names_by_experiment.get(self.experiment, []))
+
+
+class FakeActionSubmitter:
+    """Submitter stand-in with the two action-plan methods under test."""
+
+    def __init__(self, steps=None, run_error=None):
+        self.active = False
+        self.steps = list(
+            steps
+            if steps is not None
+            else [
+                {
+                    "kind": "set",
+                    "device": "Jet",
+                    "variable": "pos",
+                    "value": 3.0,
+                    "wait_s": None,
+                    "from_plan": None,
+                },
+                {
+                    "kind": "wait",
+                    "device": None,
+                    "variable": None,
+                    "value": None,
+                    "wait_s": 1.5,
+                    "from_plan": "warmup",
+                },
+            ]
+        )
+        self.run_error = run_error
+        self.run_calls = []
+        self.describe_calls = []
+        self.describe_started = threading.Event()
+        self.describe_release = threading.Event()
+        self.describe_release.set()  # blocks only when a test clears it
+        self.run_release = threading.Event()
+        self.run_release.set()
+
+    def reinitialize(self, request):
+        return True
+
+    def start_scan_thread(self):
+        self.active = True
+
+    def stop_scanning_thread(self):
+        self.active = False
+
+    def is_scanning_active(self):
+        return self.active
+
+    def describe_action(self, name):
+        self.describe_calls.append(name)
+        self.describe_started.set()
+        self.describe_release.wait(timeout=5)
+        return list(self.steps)
+
+    def run_action(self, name):
+        self.run_calls.append(name)
+        self.run_release.wait(timeout=5)
+        if self.run_error is not None:
+            raise self.run_error
+
+
+def actions_menu(window):
+    for menu in window._menus:
+        if menu.title() == "Actions":
+            return menu
+    raise AssertionError("Actions menu not found")
+
+
+def plan_entries(window):
+    """The menu's per-plan entries (everything below the arming switch)."""
+    return [
+        action.text()
+        for action in actions_menu(window).actions()
+        if action.text() and action.text() != "Enable action execution"
+    ]
+
+
+@pytest.fixture
+def window(qtbot):
+    win = MainWindow(
+        configs=FakeConfigs(),
+        submitter=FakeActionSubmitter(),
+        action_store=FakeActionStore(
+            {"TestExp": ["insert_cal", "vent_line"], "Bella": ["bella_only"]}
+        ),
+    )
+    qtbot.addWidget(win)
+    return win
+
+
+def open_dialog(window, qtbot, name="insert_cal"):
+    """Open the Run/Preview dialog for *name* via its menu entry."""
+    qtbot.waitUntil(lambda: name in plan_entries(window), timeout=3000)
+    (entry,) = [a for a in actions_menu(window).actions() if a.text() == name]
+    entry.trigger()
+    assert window._open_action_dialogs
+    return window._open_action_dialogs[-1]
+
+
+class TestMenuPopulation:
+    def test_menu_lists_the_experiments_action_plans(self, window, qtbot):
+        qtbot.waitUntil(
+            lambda: plan_entries(window) == ["insert_cal", "vent_line"], timeout=3000
+        )
+
+    def test_arming_switch_is_the_first_entry(self, window):
+        first = actions_menu(window).actions()[0]
+        assert first.text() == "Enable action execution"
+        assert first.isCheckable()
+
+    def test_experiment_change_refreshes_the_menu(self, window, qtbot):
+        qtbot.waitUntil(lambda: "insert_cal" in plan_entries(window), timeout=3000)
+        window._on_experiment_changed("Bella")
+        qtbot.waitUntil(lambda: plan_entries(window) == ["bella_only"], timeout=3000)
+
+    def test_empty_library_shows_disabled_placeholder(self, qtbot):
+        win = MainWindow(
+            configs=FakeConfigs(),
+            submitter=FakeActionSubmitter(),
+            action_store=FakeActionStore({}),
+        )
+        qtbot.addWidget(win)
+        qtbot.waitUntil(lambda: plan_entries(win) == ["(no actions)"], timeout=3000)
+        (placeholder,) = [
+            a for a in actions_menu(win).actions() if a.text() == "(no actions)"
+        ]
+        assert not placeholder.isEnabled()
+
+    def test_stale_fetch_for_previous_experiment_is_dropped(self, window):
+        window._apply_action_names(("SomeOtherExp", ["stale_plan"]))
+        assert "stale_plan" not in plan_entries(window)
+
+
+class TestExecuteGating:
+    def test_gating_defaults_off(self, window):
+        assert not window.enable_actions_action.isChecked()
+
+    def test_gating_is_not_persisted_across_sessions(self, qtbot):
+        """A session that armed execution must not leak into the next launch."""
+        first = MainWindow(
+            configs=FakeConfigs(),
+            submitter=FakeActionSubmitter(),
+            action_store=FakeActionStore({}),
+            settings=ConsoleSettings(),
+        )
+        qtbot.addWidget(first)
+        first.enable_actions_action.setChecked(True)
+        assert first.enable_actions_action.isChecked()
+        first.close()
+        fresh = MainWindow(
+            configs=FakeConfigs(),
+            submitter=FakeActionSubmitter(),
+            action_store=FakeActionStore({}),
+            settings=ConsoleSettings(),
+        )
+        qtbot.addWidget(fresh)
+        assert not fresh.enable_actions_action.isChecked()
+
+    def test_run_disabled_until_armed_then_pushed_into_open_dialog(self, window, qtbot):
+        dialog = open_dialog(window, qtbot)
+        assert not dialog.run_button.isEnabled()
+        window.enable_actions_action.setChecked(True)
+        assert dialog.run_button.isEnabled()
+        window.enable_actions_action.setChecked(False)
+        assert not dialog.run_button.isEnabled()
+
+
+class TestActionDialog:
+    def test_preview_table_renders_the_step_dicts(self, window, qtbot):
+        dialog = open_dialog(window, qtbot)
+        qtbot.waitUntil(lambda: dialog.steps_table.rowCount() == 2, timeout=3000)
+        # Row 1: the set step (columns: #, kind, device, variable, value,
+        # wait (s), from plan).
+        texts = [dialog.steps_table.item(0, c).text() for c in range(7)]
+        assert texts == ["1", "set", "Jet", "pos", "3.0", "—", "—"]
+        # Row 2: the wait step, inlined from the 'warmup' sub-plan.
+        texts = [dialog.steps_table.item(1, c).text() for c in range(7)]
+        assert texts == ["2", "wait", "—", "—", "—", "1.5", "warmup"]
+        assert "2 steps" in dialog.preview_label.text()
+
+    def test_describe_failure_shows_inline(self, window, qtbot):
+        class Broken(FakeActionSubmitter):
+            def describe_action(self, name):
+                raise RuntimeError("unknown plan 'insert_cal'")
+
+        window._submitter = Broken()
+        dialog = open_dialog(window, qtbot)
+        qtbot.waitUntil(
+            lambda: "unknown plan" in dialog.preview_label.text(), timeout=3000
+        )
+        assert "Preview failed" in dialog.preview_label.text()
+
+    def test_run_calls_run_action_with_the_plan_name(self, window, qtbot):
+        submitter = window._submitter
+        dialog = open_dialog(window, qtbot, name="vent_line")
+        window.enable_actions_action.setChecked(True)
+        dialog.run_button.click()
+        qtbot.waitUntil(lambda: submitter.run_calls == ["vent_line"], timeout=3000)
+        qtbot.waitUntil(
+            lambda: "action 'vent_line' done" in dialog.message_label.text(),
+            timeout=3000,
+        )
+        assert "action 'vent_line' done" in window.statusBar().currentMessage()
+
+    def test_refusal_message_is_surfaced_not_silent(self, window, qtbot):
+        """The scan-in-progress refusal must show inline AND in the status bar."""
+        submitter = FakeActionSubmitter(run_error=RuntimeError(SCAN_IN_PROGRESS))
+        window._submitter = submitter
+        dialog = open_dialog(window, qtbot)
+        window.enable_actions_action.setChecked(True)
+        dialog.run_button.click()
+        qtbot.waitUntil(
+            lambda: SCAN_IN_PROGRESS in dialog.message_label.text(), timeout=3000
+        )
+        assert SCAN_IN_PROGRESS in window.statusBar().currentMessage()
+        assert SCAN_IN_PROGRESS in window.log_tail.toPlainText()
+        # A failed run re-arms the button (still gated on the arming switch).
+        qtbot.waitUntil(lambda: dialog.run_button.isEnabled(), timeout=3000)
+
+    def test_run_button_disabled_while_in_flight(self, window, qtbot):
+        submitter = window._submitter
+        submitter.run_release.clear()  # hold the engine call open
+        dialog = open_dialog(window, qtbot)
+        window.enable_actions_action.setChecked(True)
+        dialog.run_button.click()
+        qtbot.waitUntil(lambda: submitter.run_calls == ["insert_cal"], timeout=3000)
+        assert not dialog.run_button.isEnabled()
+        assert "running action 'insert_cal'" in window.statusBar().currentMessage()
+        submitter.run_release.set()
+        qtbot.waitUntil(lambda: dialog.run_button.isEnabled(), timeout=3000)
+        qtbot.waitUntil(
+            lambda: "action 'insert_cal' done" in dialog.message_label.text(),
+            timeout=3000,
+        )
+
+    def test_late_preview_never_clobbers_the_run_outcome(self, window, qtbot):
+        """Preview and run land on separate lines — a slow describe arriving
+        after a run must not overwrite the run's message (a refusal that
+        vanished this way would be a silent refusal)."""
+        submitter = window._submitter
+        submitter.describe_release.clear()  # preview stays in flight
+        dialog = open_dialog(window, qtbot)
+        window.enable_actions_action.setChecked(True)
+        dialog.run_button.click()
+        qtbot.waitUntil(
+            lambda: "action 'insert_cal' done" in dialog.message_label.text(),
+            timeout=3000,
+        )
+        submitter.describe_release.set()  # now the preview lands, late
+        qtbot.waitUntil(lambda: "2 steps" in dialog.preview_label.text(), timeout=3000)
+        assert "action 'insert_cal' done" in dialog.message_label.text()
+
+    def test_close_during_slow_describe_returns_fast(self, window, qtbot):
+        submitter = window._submitter
+        submitter.describe_release.clear()  # hold the dry-run open
+        dialog = open_dialog(window, qtbot)
+        assert submitter.describe_started.wait(timeout=3)
+        started = time.monotonic()
+        dialog.close()  # must not join the blocked daemon describe
+        assert time.monotonic() - started < 0.3
+        submitter.describe_release.set()
+
+    def test_dialog_is_kept_referenced_on_the_window(self, window, qtbot):
+        dialog = open_dialog(window, qtbot)
+        assert dialog in window._open_action_dialogs
+        assert dialog.isVisible()
+        assert dialog.windowTitle() == "Action: insert_cal"


### PR DESCRIPTION
The console half of G-actions v1: the Actions menu goes from a disabled "(not wired yet)" placeholder to the full arm-preview-run flow, built against the engine contract with fakes (the engine half lands in its own PR).

## What's in the menu

- **Action-plan entries**: the current experiment's plan names from `ActionLibraryStore.list_names()` (the same `action_library/actions.yaml` the Action Library editor edits), fetched on a `BackgroundResult` daemon worker (never blocking the GUI thread on the configs repo), refreshed on experiment change, stale results dropped by experiment tag. Empty/offline renders one disabled "(no actions)" entry.
- **Execute gating (the accidental-click guard)**: a checkable "Enable action execution" item at the top. **Default OFF at every launch, deliberately NOT persisted** — a fresh session never starts armed. While unchecked, every action dialog is preview-only. Toggles are pushed into already-open dialogs.

## The per-action dialog (`app/action_dialog.py`)

Clicking a plan opens a non-modal `ActionRunDialog` (kept in `self._open_action_dialogs` — the PySide6 GC hazard): the plan name, a read-only steps table from `describe_action` (#, kind, device, variable, value, wait (s), from plan — execution order), and [Run]/[Close]. Run (armed-only) dispatches the blocking `run_action` on a dialog-owned worker: in flight the button disables and the status bar shows "running action '<name>'…"; success → "action '<name>' done"; failure/refusal → the raised message in the status bar **and** inline in the dialog, so the scan-in-progress refusal is never silent. `closeEvent` disconnects the workers — closing during a slow describe returns immediately.

One design fix found by the tests themselves: the async preview and the async run outcome originally shared one label, and a slow `describe_action` landing after a run could clobber the run's failure/refusal message (an intermittent test failure that was a real silent-refusal bug). They now render on **separate labels**, pinned by `test_late_preview_never_clobbers_the_run_outcome`.

## The engine contract (built against fakes — signatures unchanged)

`Submitter` gains exactly the two agreed methods, mapped by `make_bluesky_submitter` to `BlueskyScanner`'s same-named methods (structural — no adapter):

- `run_action(name: str) -> None` — blocking; raises operator-readable messages; during a scan exactly `RuntimeError("scan in progress — action not started")`
- `describe_action(name: str) -> list[dict]` — dry-run step dicts with keys `kind`/`device`/`variable`/`value`/`wait_s`/`from_plan`

No signature deviations to report.

## Per-concern LOC breakdown

| Concern | Files | ~LOC |
|---|---|---:|
| Actions menu wiring (fetch, rebuild, gating, dialog opening, teardown) | `app/main_window.py` | +150 |
| Run/Preview dialog | `app/action_dialog.py` (new) | +280 |
| `Submitter` protocol extension | `submission.py` | +25 |
| `BackgroundResult` extraction (judgment call, see below) | `services/background.py` (new), `main_window.py` (−42) | +62/−42 |
| Tests | `tests/test_actions_menu.py` (new) | +330 |
| Version/CHANGELOG/CLAUDE.md | | +75 |

**Judgment call for cheap veto**: `BackgroundResult` moved from `app/main_window.py` to `services/background.py` — the dialog needs its own workers and importing them from `main_window` would be circular. This is the shared extraction already recorded on issue #510; the browser's `BrowserWorker` twin is *not* swapped here (kept out of scope; CLAUDE.md updated to say the swap is now unblocked).

## Tests

`tests/test_actions_menu.py` (16 new; suite 663 → 679): menu population, experiment-change refresh, empty placeholder, stale-fetch drop, gating default-off, gating not persisted across sessions (real `ConsoleSettings` on tmp INI), arm-toggle pushed into open dialogs, preview table renders the step dicts, describe failure inline, Run calls `run_action` with the right name, refusal surfaced (status bar + inline + log), in-flight disable, late-preview no-clobber, close-during-slow-describe returns fast (<0.3 s), dialog referenced on the window.

Full suite: **679 passed, exit 0** — 8 consecutive clean runs after the label fix (the pre-fix flake was the clobber bug above), no segfaults, `QT_QPA_PLATFORM=offscreen`.

## Left for live verification

- Real `BlueskyScanner.run_action`/`describe_action` through the console against hardware (menu → preview → armed run; the scan-in-progress refusal during a live scan).
- Action-plan names appearing for a real experiment's `actions.yaml` over the network configs mount.
- #552 (pause-the-scan flow for actions) noted as future work in CLAUDE.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)