### PR TITLE
GeecsCAGateway 0.13.3: DEPLOYMENT.md post-reboot recovery runbook

### DIFF
--- a/GeecsCAGateway/CHANGELOG.md
+++ b/GeecsCAGateway/CHANGELOG.md
@@ -3,6 +3,19 @@
 All notable changes to `geecs-ca-gateway` are documented here, following
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and semantic versioning.
 
+## [0.13.3] - 2026-07-15
+
+### Changed
+
+- `DEPLOYMENT.md`: new "Host reboots and network mounts" runbook — the
+  NAS-mount boot-order dependency whose failure mode is a healthy gateway
+  with silently absent derived channels (hand mounts / fstab racing a
+  down NAS). Documents the self-healing pattern (credentials file +
+  `_netdev,nofail,x-systemd.automount` + `RequiresMountsFor` on the
+  unit), the no-reboot verification cycle, and the off-subnet CA-client
+  footnote (beacons don't cross routed paths — restart long-lived
+  displays after a gateway restart). Verified live 2026-07-15.
+
 ## [0.13.2] - 2026-07-13
 
 ### Fixed

--- a/GeecsCAGateway/DEPLOYMENT.md
+++ b/GeecsCAGateway/DEPLOYMENT.md
@@ -350,6 +350,51 @@ sudo systemctl enable --now geecs-ca-gateway
   `--experiment`/subsystem configs; CA name resolution makes this invisible to
   clients (DESIGN.md).
 
+### Host reboots and network mounts (verified live 2026-07-15)
+
+The gateway host typically holds the configs repo on a NAS mount (the
+derived-channels overlay resolves through it — §1). That makes the mount a
+**boot-order dependency with a silent failure mode**: a hand-mounted share
+(no fstab entry), or an fstab mount attempted while the NAS is down,
+simply isn't there when the service starts — and the gateway then starts
+*normally with no derived PVs* (by design). The only symptom is the
+derived channels missing; every other PV is healthy. This exact chain
+happened after a 2026-07-15 site power cycle where the NAS came up after
+the gateway host.
+
+Make the whole chain self-healing once:
+
+```bash
+# root-only credentials file (never put the password in fstab):
+#   /root/.smb-credentials   (chmod 600)  containing username=/password=/domain=
+# fstab entry — the three options are the point:
+//<nas-host>/<share>  /mnt/<share>  cifs  credentials=/root/.smb-credentials,_netdev,nofail,x-systemd.automount  0  0
+sudo systemctl daemon-reload
+```
+
+- `x-systemd.automount` mounts **on first access** instead of once at
+  boot — a NAS that comes up hours after the host is a non-event.
+- `nofail` keeps a dead NAS from wedging boot; `_netdev` orders after
+  networking.
+- Teach the unit the dependency so a missing mount *delays* the gateway
+  instead of silently starting it configless:
+  `sudo systemctl edit geecs-ca-gateway` →
+  `[Unit]` / `RequiresMountsFor=/mnt/<share>`.
+
+Verify the cycle without rebooting: `umount` the share, `systemctl start
+mnt-<share>.automount` (at boot it arms itself; mid-session you start it
+once), then `ls` the mountpoint — the listing should trigger the mount.
+After fixing, `systemctl restart geecs-ca-gateway` and confirm a derived
+PV answers.
+
+One client-side footnote for off-subnet operators (VPN/routed): CA's
+beacon mechanism — which tells clients to re-search PVs after a server
+restart — rides UDP broadcast and does not cross routed paths. Long-lived
+displays (Phoebus) that were searching while the gateway was down back
+off to very slow retries and can look stuck for minutes after the
+gateway returns; restart the display. On-subnet clients and the Python
+stack (fresh searches per polling cycle) recover on their own.
+
 ### Log expectations
 
 journald captures stdout (`%(asctime)s %(levelname)s %(name)s: %(message)s`).

--- a/GeecsCAGateway/pyproject.toml
+++ b/GeecsCAGateway/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-ca-gateway"
-version = "0.13.2"
+version = "0.13.3"
 description = "EPICS Channel Access soft-IOC gateway exposing GEECS devices as PVs"
 authors = ["Sam Barber <sbarber@lbl.gov>"]
 readme = "README.md"


### PR DESCRIPTION
## What + why

Today's site power cycle produced the exact silent failure DEPLOYMENT.md's "one box" section worried about: the NAS came up after the gateway host, the hand-mounted share never returned, and the gateway started **normally with no derived PVs** — the only symptom was one disconnected Phoebus widget. This adds the "Host reboots and network mounts" runbook: the failure chain, the self-healing mount pattern (root-only credentials file + `_netdev,nofail,x-systemd.automount` + `RequiresMountsFor` on the unit), the no-reboot verification cycle, and the off-subnet CA-beacon footnote (restart long-lived displays after a gateway restart; Python clients recover alone).

Docs-only; patch bump per repo convention. Public-repo hygiene: pattern-only (placeholders for share/user; no account names, hostnames, or credentials).

## Tests

`./scripts/check.sh`: GeecsCAGateway **181 passed** (docs-only change; suite green as regression guard).

## Hardware verification

The content *is* the verification: every step was executed live on the gateway host today — automount armed and spring-tested (`active (waiting)` → first-access CIFS mount), gateway restarted with the mount present, derived PV `TargetChamberPressure:Pressure` confirmed serving from a remote client.

🤖 Generated with [Claude Code](https://claude.com/claude-code)