### PR TITLE
GeecsCAGateway 0.13.4: deploy checklist Step 0 — persistent NAS mount

### DIFF
--- a/GeecsCAGateway/CHANGELOG.md
+++ b/GeecsCAGateway/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to `geecs-ca-gateway` are documented here, following
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and semantic versioning.
 
+## [0.13.4] - 2026-07-15
+
+### Changed
+
+- `deploy/README.md`: install checklist gains **Step 0 — persistent NAS
+  mount** (pointer to the DEPLOYMENT.md host-reboots runbook, with the
+  spring-test), so a new gateway host is never stood up with a hand
+  mount that dies at the first reboot.
+
 ## [0.13.3] - 2026-07-15
 
 ### Changed

--- a/GeecsCAGateway/deploy/README.md
+++ b/GeecsCAGateway/deploy/README.md
@@ -11,6 +11,19 @@ recipe, smoke tests, log expectations — is in
 
 ## Install
 
+**Step 0 — persistent NAS mount, before anything else.** The gateway reads
+the configs repo (derived channels, and any config kind that lives there)
+from the data share. A hand mount will not survive a reboot, and an
+ordinary fstab mount fails permanently if the NAS is down at boot — and
+the gateway then starts *silently without derived PVs*. Set up the
+self-healing mount first, exactly as in
+[`DEPLOYMENT.md` § "Host reboots and network mounts"](../DEPLOYMENT.md):
+root-only credentials file, an fstab entry with
+`_netdev,nofail,x-systemd.automount`, and `RequiresMountsFor=` on the
+unit once it is installed below. Spring-test the automount (umount →
+`systemctl start <mountpoint>.automount` → `ls` the path) before
+proceeding.
+
 From the repo checkout on the target box:
 
 ```bash

--- a/GeecsCAGateway/pyproject.toml
+++ b/GeecsCAGateway/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-ca-gateway"
-version = "0.13.3"
+version = "0.13.4"
 description = "EPICS Channel Access soft-IOC gateway exposing GEECS devices as PVs"
 authors = ["Sam Barber <sbarber@lbl.gov>"]
 readme = "README.md"


### PR DESCRIPTION
Per Sam: the transition/setup docs need an explicit "make sure the NetApp is persistently mapped on the gateway machine" step, not just the incident runbook. `deploy/README.md`'s Install section gains **Step 0** — set up the self-healing mount (credentials file + `_netdev,nofail,x-systemd.automount` + `RequiresMountsFor`) and spring-test it **before** installing the service. Pointer-only per the one-canonical-copy rule; the full steps live in DEPLOYMENT.md § Host reboots (merged in #556). This is the doc the M6 facility-2 stand-up follows.

## Tests
`./scripts/check.sh`: GeecsCAGateway **181 passed** (docs-only; regression guard).

## Hardware verification
N/A — docs pointer; the underlying steps were live-verified today (#556).

🤖 Generated with [Claude Code](https://claude.com/claude-code)