### PR TITLE
GEECS-Console 0.11.0: Iterations spinner for optimization mode (max_iterations)

### DIFF
--- a/GEECS-Console/CHANGELOG.md
+++ b/GEECS-Console/CHANGELOG.md
@@ -4,6 +4,35 @@ All notable changes to GEECS-Console are documented here.  Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versioning is
 semantic.
 
+## [0.11.0] - 2026-07-15
+
+### Added
+
+- **Iterations spinner (R3, optimization mode)**: exposes the scan
+  request's `optimization.max_iterations`.  Visible only in Optimization
+  mode next to the optimizer-config combo; range 0–100000 with 0 rendered
+  as "auto" (submits no limit — the engine's default budget applies).
+  The spinner owns the submitted value: `ConsoleFormState.max_iterations`
+  is written onto the spec by `build_scan_request`, restored by
+  `form_state_from_request` (presets round-trip it; spec matching treats
+  `max_iterations` as neutral), and picking a config seeds the spinner
+  from the config's own limit so nothing is overridden silently.  This
+  deliberately does NOT revive the old GUI's derive-iterations-from-the-
+  1D-start/stop/step hack.
+- The R3 live shot count is now honest in Optimization mode: it shows
+  `iterations × shots per step` (the engine's announced upper bound; the
+  runaway-scan guard applies to the product) or "total shots: auto" when
+  no limit is set — it previously showed a bare `shots per step`.
+
+### Fixed
+
+- The stray "No experiment selected." status message no longer flashes at
+  startup (and no longer sits in the R6 log tail right above the next
+  submission report) when the last-used experiment is restored: the
+  constructor's first configs populate runs quietly and the message is
+  announced only if the restore selects nothing.  Selecting an experiment
+  now also clears a stale listing message from the status bar.
+
 ## [0.10.1] - 2026-07-15
 
 ### Changed

--- a/GEECS-Console/CLAUDE.md
+++ b/GEECS-Console/CLAUDE.md
@@ -272,7 +272,15 @@ are prefixed by region (`r3_radio_1d`, `r5_start_button`, …).
   so `build_scan_request` stays pure; optimize requests round-trip through
   `form_state_from_request`, and applying an optimize preset matches its
   inline spec against the listed configs by content (no match ⇒ status-bar
-  error, form untouched).  **The engine-side loader is wired** (0.9.0):
+  error, form untouched; `max_iterations` is neutral in the match — it
+  belongs to the spinner below).  The **Iterations spinner** (`r3_iterations_spin`,
+  visible with the mode) owns the submitted spec's `max_iterations`
+  (`ConsoleFormState.max_iterations`; 0 renders as "auto" ⇒ `None`, the
+  engine's default budget — deliberately NOT the old GUI's derive-from-1D-
+  limits hack): the builder writes it onto the spec, picking a config seeds
+  the spinner from the config's own limit, presets restore it, and the R3
+  shot count shows `iterations × shots/step` (the runaway guard applies) or
+  "auto".  **The engine-side loader is wired** (0.9.0):
   `make_bluesky_submitter` injects `optimization_loader` from
   `services/optimization.py` — `optimizer_config_from_spec` maps the spec
   onto the `BaseOptimizerConfig` dict shape (pinned as the exact inverse

--- a/GEECS-Console/geecs_console/app/main_window.py
+++ b/GEECS-Console/geecs_console/app/main_window.py
@@ -374,8 +374,12 @@ class MainWindow(QMainWindow):
         self._scan_number_timer.setInterval(_SCAN_NUMBER_EXPIRY_MS)
         self._scan_number_timer.timeout.connect(self._expire_scan_number)
 
-        self._populate_from_configs()
-        self._restore_last_experiment()
+        # First populate quietly: a remembered experiment restored on the
+        # next line makes its "No experiment selected." a lie (it used to
+        # flash for 10 s and stick in the log tail — user report).
+        self._populate_from_configs(announce=False)
+        if not self._restore_last_experiment() and self._listing_message:
+            self._report(self._listing_message)
         # Chips read UNKNOWN until the first background poll returns; seed the
         # markup synchronously (no probe call — never touches the network).
         self._apply_health_report(HealthReport())
@@ -476,6 +480,8 @@ class MainWindow(QMainWindow):
         self.optimization_combo: QComboBox = self._child(
             QComboBox, "r3_optimization_combo"
         )
+        self.iterations_label: QLabel = self._child(QLabel, "r3_iterations_label")
+        self.iterations_spin: QSpinBox = self._child(QSpinBox, "r3_iterations_spin")
         self.shots_per_step: QSpinBox = self._child(QSpinBox, "r3_shots_per_step")
         self.acquisition_combo: QComboBox = self._child(
             QComboBox, "r3_acquisition_combo"
@@ -598,6 +604,12 @@ class MainWindow(QMainWindow):
                 "Which optimizer config to run — the YAML files in this "
                 "experiment's optimizer_configs folder. Empty when offline "
                 "or the experiment has none (Start stays disabled)."
+            ),
+            self.iterations_spin: (
+                "How many optimizer iterations to run — total shots = "
+                "iterations × shots per step. Picking a config seeds this "
+                "from the config's own limit; 'auto' (0) submits no limit "
+                "and the engine's default budget applies."
             ),
             self.shots_per_step: (
                 "How many shots to take at each scan position / grid point "
@@ -783,7 +795,10 @@ class MainWindow(QMainWindow):
         ):
             spin.valueChanged.connect(self._refresh_shot_count)
         self.shots_per_step.valueChanged.connect(self._refresh_shot_count)
-        self.optimization_combo.currentTextChanged.connect(self._refresh_submit_enabled)
+        self.iterations_spin.valueChanged.connect(self._refresh_shot_count)
+        self.optimization_combo.currentTextChanged.connect(
+            self._on_optimization_config_changed
+        )
         self.add_button.clicked.connect(self._on_add_save_set)
         self.remove_button.clicked.connect(self._on_remove_save_set)
         self.experiment_combo.currentTextChanged.connect(self._on_experiment_changed)
@@ -847,8 +862,20 @@ class MainWindow(QMainWindow):
     # Configs / health population
     # ------------------------------------------------------------------
 
-    def _populate_from_configs(self) -> None:
-        """Fill the combos and lists from the configs service (offline-safe)."""
+    def _populate_from_configs(self, announce: bool = True) -> None:
+        """Fill the combos and lists from the configs service (offline-safe).
+
+        Parameters
+        ----------
+        announce : bool, optional
+            Show the listing's message (or clear a stale one) in the status
+            bar.  The constructor's *first* populate passes ``False``: it
+            runs before the last-experiment restore, so its transient
+            "No experiment selected." would flash — and sit in the log tail
+            right above whatever the operator does next — even though an
+            experiment is selected one line later (the constructor
+            re-announces afterwards only if the restore selected nothing).
+        """
         listing = self._configs.listing()
         self.experiment_combo.blockSignals(True)
         self.experiment_combo.clear()
@@ -892,9 +919,15 @@ class MainWindow(QMainWindow):
 
         root = str(listing.configs_root) if listing.configs_root else "not found"
         self._status_configs.setText(f"configs: {root}")
-        if listing.message:
-            self.statusBar().showMessage(listing.message, 10_000)
-            self.append_log(listing.message)
+        self._listing_message = listing.message
+        if announce:
+            if listing.message:
+                self._report(listing.message)
+            else:
+                # A clean listing supersedes any earlier listing complaint
+                # still sitting in the status bar (e.g. the no-experiment
+                # message after the operator picks one).
+                self.statusBar().clearMessage()
         self._refresh_presets()
         self._refresh_union_preview()
         self._refresh_shot_count()
@@ -1099,8 +1132,11 @@ class MainWindow(QMainWindow):
                 )
             )
         optimization = None
+        max_iterations = None
         if mode is ConsoleMode.OPTIMIZATION:
             optimization = self._load_selected_optimization()
+            # The spinner's special value 0 renders as "auto" = no limit.
+            max_iterations = self.iterations_spin.value() or None
         profile = self.trigger_profile_combo.currentText() or None
         variant = self.trigger_variant_combo.currentText() or None
         from geecs_schemas import AcquisitionMode
@@ -1115,6 +1151,7 @@ class MainWindow(QMainWindow):
             acquisition=AcquisitionMode(self.acquisition_combo.currentText()),
             description=self.description_edit.text(),
             optimization=optimization,
+            max_iterations=max_iterations,
         )
 
     def _load_selected_optimization(self):
@@ -1169,7 +1206,37 @@ class MainWindow(QMainWindow):
         optimize = mode is ConsoleMode.OPTIMIZATION
         self.optimization_label.setVisible(optimize)
         self.optimization_combo.setVisible(optimize)
+        self.iterations_label.setVisible(optimize)
+        self.iterations_spin.setVisible(optimize)
         self._refresh_shot_count()
+
+    def _on_optimization_config_changed(self, name: str) -> None:
+        """Seed the Iterations spinner from the newly selected config.
+
+        The spinner owns the submitted iteration count (see
+        :class:`~geecs_console.request_builder.ConsoleFormState`), so a
+        config's own ``max_iterations`` must surface *here* — otherwise it
+        would be silently overridden at submission.  Best-effort: an
+        unloadable config leaves the spinner alone (submission reports the
+        load failure properly).
+
+        Parameters
+        ----------
+        name : str
+            The R3 optimizer-config combo's new text ("" for none).
+        """
+        if name:
+            try:
+                spec = self._configs.optimization_spec(name)
+            except Exception as exc:  # noqa: BLE001 — seeding is best-effort
+                logger.info(
+                    "optimizer config %r unloadable while seeding: %s", name, exc
+                )
+            else:
+                self.iterations_spin.setValue(
+                    getattr(spec, "max_iterations", None) or 0
+                )
+        self._refresh_submit_enabled()
 
     def _estimation_form(self) -> ConsoleFormState:
         """Form state for shot counting only (placeholder variable names)."""
@@ -1194,13 +1261,32 @@ class MainWindow(QMainWindow):
                 )
             )
         return ConsoleFormState(
-            mode=mode, axes=axes, shots_per_step=self.shots_per_step.value()
+            mode=mode,
+            axes=axes,
+            shots_per_step=self.shots_per_step.value(),
+            max_iterations=(
+                self.iterations_spin.value() or None
+                if mode is ConsoleMode.OPTIMIZATION
+                else None
+            ),
         )
 
     def _refresh_shot_count(self) -> None:
-        """Recompute the live shot-count label and the runaway guard."""
+        """Recompute the live shot-count label and the runaway guard.
+
+        Optimization mode shows ``iterations × shots per step`` when the
+        Iterations spinner is set (the engine's announced upper bound —
+        the suggester may stop early), or ``auto`` when it isn't; the
+        runaway guard applies to the product like any other mode.
+        """
+        form = self._estimation_form()
+        if form.mode is ConsoleMode.OPTIMIZATION and form.max_iterations is None:
+            self._shot_count_valid = True
+            self.shot_count_label.setText("total shots: auto")
+            self._refresh_submit_enabled()
+            return
         try:
-            total = estimate_total_shots(self._estimation_form())
+            total = estimate_total_shots(form)
         except (ConsoleFormError, ValidationError):
             self._shot_count_valid = False
             self.shot_count_label.setText("total shots: —")
@@ -1265,7 +1351,7 @@ class MainWindow(QMainWindow):
         self._start_idle_scan_probe()
         self._start_actions_fetch()
 
-    def _restore_last_experiment(self) -> None:
+    def _restore_last_experiment(self) -> bool:
         """Select the remembered experiment at startup (explicit choice wins).
 
         Runs once from the constructor, after the combo is populated.  A
@@ -1273,13 +1359,21 @@ class MainWindow(QMainWindow):
         explicitly and the name is still in the combo's list; selecting it
         fires :meth:`_on_experiment_changed`, so configs, presets, the
         health probe, and the device panel all follow.
+
+        Returns
+        -------
+        bool
+            Whether the restore selected an experiment (and so repopulated
+            with a fresh listing message) — ``False`` tells the constructor
+            the quiet first populate's message still stands.
         """
         if self._configs.experiment:
-            return
+            return False
         remembered = self._settings.last_experiment
         if not remembered or self.experiment_combo.findText(remembered) < 0:
-            return
+            return False
         self.experiment_combo.setCurrentText(remembered)
+        return True
 
     def _on_trigger_profile_changed(self, profile: str) -> None:
         """Repopulate the variant combo for the selected trigger profile."""
@@ -1797,6 +1891,9 @@ class MainWindow(QMainWindow):
 
         if optimization_name:
             self.optimization_combo.setCurrentText(optimization_name)
+        # After the combo (whose change handler seeds the spinner from the
+        # config): the preset's own iteration count wins.
+        self.iterations_spin.setValue(form.max_iterations or 0)
         self.shots_per_step.setValue(form.shots_per_step)
         self.acquisition_combo.setCurrentText(form.acquisition.value)
         self.description_edit.setText(form.description)
@@ -1813,7 +1910,11 @@ class MainWindow(QMainWindow):
         The form expresses optimization as a config *name* (the R3 combo),
         so applying a preset that carries an inline spec means finding the
         experiment's config with identical content — pydantic equality over
-        the loaded documents.  Unloadable configs are skipped.
+        the loaded documents, with ``max_iterations`` neutralized on both
+        sides: that field belongs to the Iterations spinner (restored
+        separately from the preset), so a preset saved with an overridden
+        count must still match its source config.  Unloadable configs are
+        skipped.
 
         Parameters
         ----------
@@ -1831,10 +1932,15 @@ class MainWindow(QMainWindow):
             When no listed config matches — selecting anything else would
             silently change what the preset submits.
         """
+        neutral = {"max_iterations": None}
+        wanted = spec.model_copy(update=neutral)
         for index in range(self.optimization_combo.count()):
             name = self.optimization_combo.itemText(index)
             try:
-                if self._configs.optimization_spec(name) == spec:
+                if (
+                    self._configs.optimization_spec(name).model_copy(update=neutral)
+                    == wanted
+                ):
                     return name
             except Exception as exc:  # noqa: BLE001 — an unloadable config just can't match
                 logger.info(

--- a/GEECS-Console/geecs_console/app/ui/main_window.ui
+++ b/GEECS-Console/geecs_console/app/ui/main_window.ui
@@ -322,6 +322,35 @@
              </widget>
             </item>
             <item>
+             <widget class="QLabel" name="r3_iterations_label">
+              <property name="text">
+               <string>Iterations</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QSpinBox" name="r3_iterations_spin">
+              <property name="buttonSymbols">
+               <enum>QAbstractSpinBox::NoButtons</enum>
+              </property>
+              <property name="maximumWidth">
+               <number>90</number>
+              </property>
+              <property name="minimum">
+               <number>0</number>
+              </property>
+              <property name="maximum">
+               <number>100000</number>
+              </property>
+              <property name="value">
+               <number>0</number>
+              </property>
+              <property name="specialValueText">
+               <string>auto</string>
+              </property>
+             </widget>
+            </item>
+            <item>
              <spacer name="r3_optimization_spacer">
               <property name="orientation">
                <enum>Qt::Horizontal</enum>

--- a/GEECS-Console/geecs_console/request_builder.py
+++ b/GEECS-Console/geecs_console/request_builder.py
@@ -128,6 +128,13 @@ class ConsoleFormState(BaseModel):
     ``optimization`` carries the *loaded* spec of the optimizer config the
     R3 combo names (the window resolves name → spec when snapshotting), so
     this model — and :func:`build_scan_request` — stays pure: no file I/O.
+
+    ``max_iterations`` mirrors the R3 Iterations spinner (optimization mode
+    only) and **owns** the submitted spec's ``max_iterations``: the builder
+    writes it onto the spec, so ``0``/``None`` (the spinner's "auto")
+    submits no limit even when the loaded config carries one — the window
+    seeds the spinner from the config on selection, so a config's own limit
+    is surfaced there rather than applied silently.
     """
 
     mode: ConsoleMode = ConsoleMode.ONE_D
@@ -140,6 +147,7 @@ class ConsoleFormState(BaseModel):
     description: str = ""
     background: bool = False
     optimization: Optional[OptimizationSpec] = None
+    max_iterations: Optional[int] = Field(None, ge=0)
 
 
 def _position_count(positions: Positions) -> int:
@@ -174,13 +182,18 @@ def estimate_total_shots(form: ConsoleFormState) -> int:
     -------
     int
         ``shots_per_step`` times the product of the axis position counts
-        (1 for noscan/background/optimization).
+        (1 for noscan/background).  Optimization mode multiplies by
+        ``max_iterations`` when set — the engine's announced upper bound —
+        and falls back to one iteration's worth when unset ("auto": the
+        window renders that case as such rather than as a count).
 
     Raises
     ------
     ConsoleFormError
         If an axis's positions are invalid (e.g. zero step).
     """
+    if form.mode is ConsoleMode.OPTIMIZATION and form.max_iterations:
+        return form.shots_per_step * form.max_iterations
     if form.mode not in (ConsoleMode.ONE_D, ConsoleMode.GRID):
         return form.shots_per_step
     total = form.shots_per_step
@@ -212,6 +225,9 @@ def build_scan_request(form: ConsoleFormState) -> ScanRequest:
         When the schema itself rejects the assembled request (e.g. a
         trigger variant without a profile, duplicate axis variables).
     """
+    # A stray spec on a non-optimize form is a bug the schema's consistency
+    # validator surfaces loudly rather than being silently dropped here.
+    optimization = form.optimization
     if form.mode in (ConsoleMode.ONE_D, ConsoleMode.GRID):
         if form.mode is ConsoleMode.ONE_D and len(form.axes) != 1:
             raise ConsoleFormError("A 1D scan needs exactly one axis.")
@@ -230,6 +246,13 @@ def build_scan_request(form: ConsoleFormState) -> ScanRequest:
             )
         mode = ScanRequestMode.OPTIMIZE
         axes = []
+        # The form's iteration count owns the submitted spec's limit (see
+        # ConsoleFormState): the spinner was seeded from the config, so
+        # whatever it now says — a number or "auto" (None) — is the
+        # operator's answer, not a value to merge with the config's.
+        optimization = form.optimization.model_copy(
+            update={"max_iterations": form.max_iterations or None}
+        )
     else:
         mode = ScanRequestMode.NOSCAN
         axes = []
@@ -252,10 +275,7 @@ def build_scan_request(form: ConsoleFormState) -> ScanRequest:
         trigger_variant=form.trigger_variant,
         description=form.description,
         background=form.background or form.mode is ConsoleMode.BACKGROUND,
-        # Passed through for every mode — a stray spec on a non-optimize
-        # form is a bug the schema's consistency validator surfaces loudly
-        # rather than being silently dropped here.
-        optimization=form.optimization,
+        optimization=optimization,
     )
 
 
@@ -281,7 +301,8 @@ def form_state_from_request(request: ScanRequest) -> ConsoleFormState:
         becomes :attr:`ConsoleMode.BACKGROUND` (the same folding the
         builder applies in the other direction); an ``optimize`` request
         becomes :attr:`ConsoleMode.OPTIMIZATION` carrying the request's
-        optimization spec.
+        optimization spec and its ``max_iterations`` (the Iterations
+        spinner).
 
     Raises
     ------
@@ -333,4 +354,11 @@ def form_state_from_request(request: ScanRequest) -> ConsoleFormState:
         description=request.description,
         background=background,
         optimization=request.optimization,
+        # The spec's limit is the Iterations spinner's value (None = "auto"
+        # = 0 on the widget) — the exact inverse of the builder's override.
+        max_iterations=(
+            request.optimization.max_iterations
+            if request.optimization is not None
+            else None
+        ),
     )

--- a/GEECS-Console/pyproject.toml
+++ b/GEECS-Console/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-console"
-version = "0.10.1"
+version = "0.11.0"
 description = "Greenfield PySide6 operator console for GEECS (Bluesky/gateway architecture)"
 authors = ["Sam Barber <sbarber@lbl.gov>"]
 readme = "README.md"

--- a/GEECS-Console/tests/test_main_window.py
+++ b/GEECS-Console/tests/test_main_window.py
@@ -434,6 +434,110 @@ class TestOptimizationMode:
         assert opt_window.optimization_combo.currentText() == "random_walk"
         assert "Applied preset" in opt_window.log_tail.toPlainText()
 
+    def test_iterations_spinner_hidden_outside_optimization_mode(self, opt_window):
+        opt_window.show()
+        assert not opt_window.iterations_spin.isVisible()
+        opt_window.radio_optimization.setChecked(True)
+        assert opt_window.iterations_spin.isVisible()
+        assert opt_window.iterations_label.isVisible()
+        opt_window.radio_1d.setChecked(True)
+        assert not opt_window.iterations_spin.isVisible()
+
+    def test_iterations_spinner_defaults_to_auto(self, opt_window):
+        assert opt_window.iterations_spin.value() == 0
+        assert opt_window.iterations_spin.specialValueText() == "auto"
+
+    def test_start_submits_the_iteration_count(self, opt_window):
+        select_save_set(opt_window, "Amp4In")
+        opt_window.radio_optimization.setChecked(True)
+        opt_window.optimization_combo.setCurrentText("bayes_jet")
+        opt_window.iterations_spin.setValue(25)
+        opt_window._on_start_clicked()
+        request = opt_window._submitter.requests[0]
+        assert request.optimization.max_iterations == 25
+
+    def test_start_with_auto_submits_no_limit(self, opt_window):
+        select_save_set(opt_window, "Amp4In")
+        opt_window.radio_optimization.setChecked(True)
+        opt_window.optimization_combo.setCurrentText("bayes_jet")
+        assert opt_window.iterations_spin.value() == 0  # "auto"
+        opt_window._on_start_clicked()
+        request = opt_window._submitter.requests[0]
+        assert request.optimization.max_iterations is None
+
+    def test_selecting_config_seeds_spinner_from_its_limit(self, opt_window):
+        """A config's own max_iterations surfaces on the spinner (the
+        spinner owns the submitted value, so it must show the config's)."""
+        opt_window._configs.optimization_specs["capped"] = (
+            _optimization_spec().model_copy(update={"max_iterations": 15})
+        )
+        opt_window._populate_from_configs()
+        opt_window.radio_optimization.setChecked(True)
+        opt_window.iterations_spin.setValue(3)
+        opt_window.optimization_combo.setCurrentText("capped")
+        assert opt_window.iterations_spin.value() == 15
+        # A config without a limit reseeds back to "auto".
+        opt_window.optimization_combo.setCurrentText("bayes_jet")
+        assert opt_window.iterations_spin.value() == 0
+
+    def test_optimize_preset_restores_the_iteration_count(self, opt_window):
+        """A preset saved with an overridden count still matches its source
+        config (max_iterations is neutral in matching) and restores it."""
+        request = build_scan_request(
+            ConsoleFormState(
+                mode=ConsoleMode.OPTIMIZATION,
+                save_sets=["Amp4In"],
+                optimization=_optimization_spec(objective="charge"),
+                max_iterations=7,
+            )
+        )
+        opt_window._presets.presets["opt"] = request
+        opt_window._refresh_presets()
+        opt_window.preset_combo.setCurrentText("opt")
+        opt_window._on_preset_apply()
+        assert opt_window.optimization_combo.currentText() == "random_walk"
+        assert opt_window.iterations_spin.value() == 7
+
+    def test_optimize_preset_with_auto_restores_auto(self, opt_window):
+        request = build_scan_request(
+            ConsoleFormState(
+                mode=ConsoleMode.OPTIMIZATION,
+                save_sets=["Amp4In"],
+                optimization=_optimization_spec(),
+            )
+        )
+        opt_window._presets.presets["opt"] = request
+        opt_window._refresh_presets()
+        opt_window.iterations_spin.setValue(9)  # stale operator value
+        opt_window.preset_combo.setCurrentText("opt")
+        opt_window._on_preset_apply()
+        assert opt_window.iterations_spin.value() == 0
+
+    def test_optimize_shot_count_shows_auto_without_iterations(self, opt_window):
+        opt_window.radio_optimization.setChecked(True)
+        assert opt_window.shot_count_label.text() == "total shots: auto"
+
+    def test_optimize_shot_count_multiplies_iterations(self, opt_window):
+        opt_window.radio_optimization.setChecked(True)
+        opt_window.shots_per_step.setValue(10)
+        opt_window.iterations_spin.setValue(25)
+        assert opt_window.shot_count_label.text() == "total shots: 250"
+        # Leaving optimization mode goes back to step counting
+        # (start 0 / stop 1 / step 1 -> 2 positions x 10 shots).
+        opt_window.radio_1d.setChecked(True)
+        assert opt_window.shot_count_label.text() == "total shots: 20"
+
+    def test_optimize_runaway_guard_gates_start(self, opt_window):
+        select_save_set(opt_window, "Amp4In")
+        opt_window.radio_optimization.setChecked(True)
+        opt_window.optimization_combo.setCurrentText("bayes_jet")
+        opt_window.shots_per_step.setValue(100)
+        opt_window.iterations_spin.setValue(100_000)  # 10,000,000 shots
+        assert "exceeds" in opt_window.shot_count_label.text()
+        assert not opt_window.start_button.isEnabled()
+        opt_window.iterations_spin.setValue(10)
+        assert opt_window.start_button.isEnabled()
+
     def test_optimize_preset_without_matching_config_reports(self, opt_window):
         from geecs_schemas import EvaluatorSpec, GeneratorSpec, OptimizationSpec
 
@@ -1368,3 +1472,52 @@ class TestLastExperiment:
         )
         qtbot.addWidget(win2)
         assert win2.experiment_combo.currentText() == "Bella"
+
+
+class MessagingConfigs(FakeConfigs):
+    """FakeConfigs honoring the real listing's message contract."""
+
+    def listing(self):
+        if not self.experiment:
+            return ConfigListing(
+                experiments=self._experiments,
+                message="No experiment selected.",
+            )
+        return super().listing()
+
+
+class TestStartupListingMessage:
+    """The stray 'No experiment selected.' flash (live-test report).
+
+    The constructor's first populate runs before the last-experiment
+    restore; its no-experiment message must not reach the operator when a
+    restore is about to select one, and a stale status-bar message must not
+    outlive an experiment change.
+    """
+
+    def _window(self, qtbot, last_experiment):
+        win = MainWindow(
+            configs=MessagingConfigs(experiment=""),
+            presets=FakePresetStore(),
+            settings=FakeSettings(last_experiment=last_experiment),
+            submitter=FakeSubmitter(),
+        )
+        qtbot.addWidget(win)
+        return win
+
+    def test_restored_experiment_suppresses_the_flash(self, qtbot):
+        win = self._window(qtbot, last_experiment="TestExp")
+        assert win.experiment_combo.currentText() == "TestExp"
+        assert "No experiment selected." not in win.log_tail.toPlainText()
+        assert win.statusBar().currentMessage() == ""
+
+    def test_no_restore_still_reports_the_message(self, qtbot):
+        win = self._window(qtbot, last_experiment="")
+        assert "No experiment selected." in win.log_tail.toPlainText()
+        assert win.statusBar().currentMessage() == "No experiment selected."
+
+    def test_selecting_an_experiment_clears_the_stale_message(self, qtbot):
+        win = self._window(qtbot, last_experiment="")
+        assert win.statusBar().currentMessage() == "No experiment selected."
+        win.experiment_combo.setCurrentText("TestExp")
+        assert win.statusBar().currentMessage() == ""

--- a/GEECS-Console/tests/test_request_builder.py
+++ b/GEECS-Console/tests/test_request_builder.py
@@ -338,3 +338,82 @@ class TestFormStateFromRequest:
         )
         with pytest.raises(ConsoleFormError, match="action bindings"):
             form_state_from_request(request)
+
+
+class TestMaxIterations:
+    """The Iterations spinner's field: owns the submitted spec's limit."""
+
+    def _form(self, **overrides):
+        base = dict(
+            mode=ConsoleMode.OPTIMIZATION,
+            shots_per_step=5,
+            save_sets=["Amp4In"],
+            optimization=_optimization_spec(),
+        )
+        base.update(overrides)
+        return ConsoleFormState(**base)
+
+    def test_positive_count_lands_on_the_spec(self):
+        request = build_scan_request(self._form(max_iterations=50))
+        assert request.optimization.max_iterations == 50
+        assert roundtrip(request).optimization.max_iterations == 50
+
+    def test_zero_is_auto_and_maps_to_none(self):
+        # The spinner's special value 0 ("auto") submits no limit.
+        request = build_scan_request(self._form(max_iterations=0))
+        assert request.optimization.max_iterations is None
+
+    def test_unset_maps_to_none(self):
+        request = build_scan_request(self._form(max_iterations=None))
+        assert request.optimization.max_iterations is None
+
+    def test_form_count_owns_the_specs_own_limit(self):
+        """The spinner is authoritative — a config's inline limit is
+        surfaced by seeding the spinner, never merged at build time."""
+        spec = _optimization_spec().model_copy(update={"max_iterations": 20})
+        assert (
+            build_scan_request(
+                self._form(optimization=spec, max_iterations=50)
+            ).optimization.max_iterations
+            == 50
+        )
+        assert (
+            build_scan_request(
+                self._form(optimization=spec, max_iterations=None)
+            ).optimization.max_iterations
+            is None
+        )
+
+    def test_estimate_multiplies_iterations_by_shots(self):
+        assert estimate_total_shots(self._form(max_iterations=50)) == 250
+        # Unset ("auto"): one iteration's worth, as before.
+        assert estimate_total_shots(self._form(max_iterations=None)) == 5
+
+    def test_runaway_guard_applies_to_optimize_iterations(self):
+        form = self._form(max_iterations=100_000, shots_per_step=11)
+        assert estimate_total_shots(form) == 1_100_000 > MAXIMUM_SCAN_SIZE
+        with pytest.raises(ConsoleFormError, match="runaway"):
+            build_scan_request(form)
+
+    def test_negative_count_rejected(self):
+        with pytest.raises(ValidationError):
+            self._form(max_iterations=-1)
+
+    def test_iterations_round_trip_is_request_exact(self):
+        """Apply-then-resubmit fidelity: the restored form rebuilds the
+        identical request (the spinner field is folded into the spec, so
+        form equality is not the invariant — request equality is)."""
+        form = self._form(max_iterations=50)
+        request = roundtrip(build_scan_request(form))
+        restored = form_state_from_request(request)
+        assert restored.max_iterations == 50
+        assert build_scan_request(restored) == request
+
+    def test_auto_round_trips_to_none(self):
+        # 0 (widget) -> None (request) -> None (form): resubmitting an
+        # applied "auto" preset submits "auto" again.
+        request = build_scan_request(self._form(max_iterations=0))
+        restored = form_state_from_request(request)
+        assert restored.max_iterations is None
+        rebuilt = build_scan_request(restored)
+        assert rebuilt.optimization.max_iterations is None


### PR DESCRIPTION
## What / why

Live testing of optimization mode found no way to set the iteration count. The schema field exists (`OptimizationSpec.max_iterations` — note: it lives on the spec, not on `ScanRequest` directly) and the engine already consumes it (`scan_request_runner` announces `(max_iterations, max_iterations × shots_per_step)` and defaults to 20 when unset). This PR exposes it as an **Iterations spinner** in R3, visible only in Optimization mode next to the optimizer-config combo.

Semantics (the spinner owns the submitted value):

- Range 0–100000; **0 renders as "auto"** and submits `max_iterations=None`; any positive count lands on `request.optimization.max_iterations`.
- `ConsoleFormState.max_iterations` is the new pure-form field; `build_scan_request` folds it onto the spec (`0`/`None` → `None`), `form_state_from_request` inverts it. Both functions stay pure; round-trip is request-exact (pinned).
- **Picking a config seeds the spinner from the config's own `max_iterations`** — since the spinner overrides the spec at build time, a config's inline limit must surface on the widget rather than be silently clobbered. (Legacy-dialect conversion never produces the field, so this is mostly future-proofing for hand-authored new-schema configs.)
- Presets restore the spinner; `_match_optimization_config` now compares specs with `max_iterations` neutralized on both sides, so a preset saved with an overridden count still matches its source config (pinned).
- The R3 live shot count stops lying in Optimization mode: it previously showed a bare `shots per step`; now it shows `iterations × shots/step` (the engine's announced upper bound; the 1e6 runaway guard applies to the product and gates Start) or `total shots: auto` when unset.
- **The old GUI's derive-iterations-from-the-1D-start/stop/step hack is deliberately not replicated.**

Judgment calls (cheap to veto):

- Special value text is **"auto"**, not "auto (suggester decides)": with `max_iterations=None` the engine runs `spec.max_iterations or 20` — the suggester does *not* solely decide, so the longer text would mislead. The engine-default nuance lives in the operator tooltip instead. (Side note for a possible schema follow-up: the `Field` description says "run until stopped by hand", which contradicts the engine's `or 20` default.)
- The config-seeding behavior above (one synchronous small-YAML load per combo selection — same class of load preset-apply already does).
- Operator tooltip is hand-written (`_apply_operator_tooltips`), not schema-derived: the schema description is editor-oriented ("Leave unset…") and inaccurate about engine behavior.

## Item-4 finding: the stray "No experiment selected." flash — diagnosed and fixed

`grep` finds two console-side emitters: `services/configs.py:129` (`listing()` message when no experiment is set) and `configs.py:251` (`optimization_spec` raise). The submission path itself never emits it — the flash comes from **constructor ordering**: `__init__` runs `_populate_from_configs()` (no experiment yet → shows "No experiment selected." for 10 s **and** appends it to the R6 log tail) *before* `_restore_last_experiment()` selects the remembered experiment, and the post-restore repopulate never cleared the stale message. The startup line then sits in the log tail immediately above whatever happens next — in the live session, the optimize submission refusal — making it look submission-adjacent (and within 10 s of a relaunch it's still in the status bar too).

Fix (small, separate concern): the constructor's first populate runs with `announce=False`; the pending message is announced only if the restore selects nothing; and a message-less repopulate now clears a stale status-bar message on experiment change. Pinned by `TestStartupListingMessage` (3 tests).

## Per-concern LOC (456+/24− total, all GEECS-Console)

| Concern | Files | ~LOC |
|---|---|---|
| Iterations spinner (form field, builder/inverse, .ui, wiring, seeding, shot count, tooltip) | `request_builder.py`, `main_window.py`, `main_window.ui` | ~150 |
| Startup-message fix (item 4) | `main_window.py` (`_populate_from_configs` announce param, `_restore_last_experiment` return) | ~35 |
| Tests | `test_request_builder.py` (+10), `test_main_window.py` (+12) | ~230 |
| Version/CHANGELOG/CLAUDE.md | | ~40 |

## Tests

`QT_QPA_PLATFORM=offscreen poetry run pytest -q`: **701 passed** (baseline on `dev`: 679; +22 new), exit 0, stable across 3 consecutive runs. `./scripts/check.sh` (lint + GEECS-Console suite, the CI mapping): OK. New coverage: spinner visibility per mode, 0→None / N→N mapping through the build/form_state pair, spinner-authoritative override of a spec's inline limit, config-selection seeding, preset restore (incl. neutralized matching), optimize shot-count display + runaway gating, startup-message suppression/announce/clear.

## Hardware verification

**OWED**: one live optimization run submitted through the console with the Iterations spinner set to N, observed to announce totals `N × shots/step` in R6 and stop after N iterations; plus one "auto" submission observed to run the engine-default budget (currently 20). Also re-check live that the "No experiment selected." flash is gone after a relaunch-and-submit. (User is live-testing today.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)