### PR TITLE
GEECS-Console 0.12.0: warm optimization-stack import at startup

### DIFF
--- a/GEECS-Console/CHANGELOG.md
+++ b/GEECS-Console/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to GEECS-Console are documented here.  Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versioning is
 semantic.
 
+## [0.11.0] - 2026-07-15
+
+### Added
+
+- **Optimization stack warm-up at startup**
+  (`services/optimization.py::warm_up_optimization_stack`, called once by
+  `main.py` after the window shows): with the `optimization` extra
+  installed, a daemon thread pre-imports the loader's heavy modules
+  (`geecs_scanner.optimization` → xopt → botorch → torch) so their
+  tens-of-seconds cold import is paid in the background at launch instead
+  of freezing the first optimize submission (field incident 2026-07-15).
+  Logs "optimization stack preloaded in N.n s" on completion; failures are
+  logged and swallowed (the lazy loader path then pays the cost as
+  before).  No-op without the extra (same `find_spec` probe as the
+  loader).  A submission arriving mid-warm-up needs no guard — Python's
+  per-module import locks serialize the concurrent import.
+
 ## [0.10.1] - 2026-07-15
 
 ### Changed

--- a/GEECS-Console/CLAUDE.md
+++ b/GEECS-Console/CLAUDE.md
@@ -284,7 +284,13 @@ are prefixed by region (`r3_radio_1d`, `r5_start_button`, …).
   import confined to `services/optimization.py`, lazy, gated by a light
   `find_spec` probe); without it the loader is `None` and the engine's
   needs-a-loader refusal shows in the status bar, all other modes
-  unaffected.  The save sets must name the objective's diagnostics —
+  unaffected.  With the extra installed, `main.py` calls
+  `warm_up_optimization_stack()` once after `window.show()` — a daemon
+  thread pre-imports the loader's heavy modules (torch/botorch/xopt cost
+  tens of seconds cold) so the first optimize submission doesn't freeze;
+  failures are logged and swallowed (the lazy path then pays the cost),
+  and a submission mid-warm-up simply blocks on Python's per-module
+  import lock — no extra machinery.  The save sets must name the objective's diagnostics —
   optimizer `device_requirements` auto-provisioning is deliberately not
   wired on the delegated path (engine decision, PR #520).
 - **Tooltips (issue #497 phase 1)**: editor form fields get their tooltips

--- a/GEECS-Console/geecs_console/services/optimization.py
+++ b/GEECS-Console/geecs_console/services/optimization.py
@@ -26,6 +26,11 @@ console's implementation of that seam:
   bar.  The check is a light ``find_spec`` so submitter construction never
   pays the Xopt import; the heavy imports happen inside the loader call,
   on the scan thread, once per process.
+- :func:`warm_up_optimization_stack` — the startup warm-up ``main.py``
+  calls once: when the extra is present, a daemon thread pre-imports the
+  loader's heavy modules so the torch/botorch/xopt cold-import cost
+  (tens of seconds) is paid in the background at launch instead of
+  freezing the first optimize submission.
 
 The stack behind the loader (evaluators → ScanAnalysis/ImageAnalysis
 analyzers) is the legacy machinery kept for old-GUI parity; a redesigned
@@ -36,11 +41,23 @@ written to be deletable — nothing else in the console imports
 
 from __future__ import annotations
 
+import importlib
 import importlib.util
 import logging
+import threading
+import time
 from typing import Any, Callable, Optional
 
 logger = logging.getLogger(__name__)
+
+#: The heavy modules :func:`load_console_optimization` imports at call time —
+#: pulling in the whole Xopt/botorch/torch stack transitively.  The warm-up
+#: thread imports exactly these so a later loader call is a pure
+#: ``sys.modules`` cache hit.
+_HEAVY_MODULES = (
+    "geecs_scanner.optimization.base_optimizer",
+    "geecs_scanner.optimization.session_bridge",
+)
 
 
 def optimizer_config_from_spec(spec: Any) -> dict:
@@ -151,3 +168,58 @@ def make_optimization_loader() -> Optional[Callable[[Any], Any]]:
         )
         return None
     return load_console_optimization
+
+
+def warm_up_optimization_stack() -> Optional[threading.Thread]:
+    """Pre-import the optimization stack on a daemon thread.
+
+    The loader's first call pays the torch/botorch/xopt cold import — tens
+    of seconds — which froze the first optimize submission in the field.
+    ``main.py`` calls this once at startup: when the ``optimization`` extra
+    is present (the same light ``find_spec`` probe as
+    :func:`make_optimization_loader`), a daemon thread imports
+    ``_HEAVY_MODULES`` in the background so the stack is warm before the
+    operator ever clicks Start.  Without the extra this is a no-op.
+
+    Warm-up failures are logged and swallowed — they never affect startup;
+    the loader's own lazy import simply pays the cost (and raises its own
+    error) later.
+
+    No double-import guard is needed for a submission arriving mid-warm-up:
+    Python's per-module import locks already serialize concurrent imports,
+    so :func:`load_console_optimization`'s import statements block until
+    the warm-up thread finishes that module, then reuse it from
+    ``sys.modules``.  The work happens exactly once per process either way.
+
+    Returns
+    -------
+    threading.Thread or None
+        The started daemon thread, or ``None`` when the ``optimization``
+        extra is absent (nothing to warm).  Callers need not join it.
+    """
+    if not optimization_available():
+        logger.debug(
+            "optimization stack warm-up skipped — geecs-scanner-gui is not "
+            "installed (console 'optimization' extra)"
+        )
+        return None
+
+    def _warm_up() -> None:
+        start = time.perf_counter()
+        try:
+            for name in _HEAVY_MODULES:
+                importlib.import_module(name)
+        except Exception:
+            logger.warning(
+                "optimization stack warm-up failed — the first optimize "
+                "submission will pay the import cost instead",
+                exc_info=True,
+            )
+            return
+        logger.info(
+            "optimization stack preloaded in %.1f s", time.perf_counter() - start
+        )
+
+    thread = threading.Thread(target=_warm_up, name="optimization-warmup", daemon=True)
+    thread.start()
+    return thread

--- a/GEECS-Console/main.py
+++ b/GEECS-Console/main.py
@@ -77,6 +77,7 @@ def main(argv: Optional[list[str]] = None) -> int:
     from geecs_console.app.main_window import MainWindow
     from geecs_console.services.device_panel import GatewayDevicePanel
     from geecs_console.services.health import GatewayTiledDbHealth
+    from geecs_console.services.optimization import warm_up_optimization_stack
 
     app = QApplication([sys.argv[0], *qt_args])
     # Inject the real seams in production; tests/offline fall back to the
@@ -89,6 +90,11 @@ def main(argv: Optional[list[str]] = None) -> int:
         device_panel=GatewayDevicePanel(),
     )
     window.show()
+    # With the `optimization` extra installed, pre-import the torch/botorch/
+    # xopt stack on a daemon thread so the first optimize submission doesn't
+    # freeze for its tens-of-seconds cold import (no-op without the extra;
+    # started after the window is up so nothing races Qt initialization).
+    warm_up_optimization_stack()
     return app.exec()
 
 

--- a/GEECS-Console/pyproject.toml
+++ b/GEECS-Console/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-console"
-version = "0.10.1"
+version = "0.11.0"
 description = "Greenfield PySide6 operator console for GEECS (Bluesky/gateway architecture)"
 authors = ["Sam Barber <sbarber@lbl.gov>"]
 readme = "README.md"

--- a/GEECS-Console/tests/test_optimization_warmup.py
+++ b/GEECS-Console/tests/test_optimization_warmup.py
@@ -1,0 +1,169 @@
+"""The startup warm-up: pre-importing the optimization stack off-thread.
+
+Hermetic — ``geecs-scanner-gui`` (the ``optimization`` extra) is NOT
+installed in the test environment: the no-op path is exercised against the
+real ``find_spec`` probe, the warm path against fake ``geecs_scanner``
+modules planted in ``sys.modules``, and the never-blocks pin against an
+import stub gated on an event.  The double-work guard (a submission
+arriving mid-warm-up) is deliberately not machinery — Python's per-module
+import locks already serialize concurrent imports — so there is nothing to
+test beyond the loader tests in ``test_optimization_loader.py``.
+"""
+
+from __future__ import annotations
+
+import importlib
+import logging
+import sys
+import threading
+import types
+
+from geecs_console.services import optimization as optimization_module
+from geecs_console.services.optimization import warm_up_optimization_stack
+
+_JOIN_TIMEOUT_S = 5.0
+
+
+def _plant_fake_stack(monkeypatch) -> None:
+    """Put importable fakes at the heavy-module paths in ``sys.modules``."""
+    for name in (
+        "geecs_scanner",
+        "geecs_scanner.optimization",
+        *optimization_module._HEAVY_MODULES,
+    ):
+        monkeypatch.setitem(sys.modules, name, types.ModuleType(name))
+
+
+def test_warm_up_no_ops_without_the_extra(caplog) -> None:
+    """Extra absent (real find_spec probe): no thread, nothing logged loudly."""
+    with caplog.at_level(logging.INFO, logger=optimization_module.__name__):
+        assert warm_up_optimization_stack() is None
+    assert "preloaded" not in caplog.text
+
+
+def test_warm_up_imports_the_heavy_modules_and_logs(monkeypatch, caplog) -> None:
+    monkeypatch.setattr(optimization_module, "optimization_available", lambda: True)
+    _plant_fake_stack(monkeypatch)
+    imported: list[str] = []
+    real_import = importlib.import_module
+
+    def recording_import(name, package=None):
+        imported.append(name)
+        return real_import(name, package)
+
+    monkeypatch.setattr(importlib, "import_module", recording_import)
+
+    with caplog.at_level(logging.INFO, logger=optimization_module.__name__):
+        thread = warm_up_optimization_stack()
+        assert thread is not None
+        assert thread.daemon is True
+        thread.join(timeout=_JOIN_TIMEOUT_S)
+        assert not thread.is_alive()
+
+    assert imported == list(optimization_module._HEAVY_MODULES)
+    assert "optimization stack preloaded in" in caplog.text
+
+
+def test_warm_up_returns_immediately_while_the_import_runs(monkeypatch) -> None:
+    """The startup path never blocks: the call returns mid-import."""
+    monkeypatch.setattr(optimization_module, "optimization_available", lambda: True)
+    release = threading.Event()
+
+    def blocking_import(name, package=None):
+        release.wait(timeout=_JOIN_TIMEOUT_S)
+        return types.ModuleType(name)
+
+    monkeypatch.setattr(importlib, "import_module", blocking_import)
+
+    thread = warm_up_optimization_stack()
+    try:
+        # Back on the caller immediately — the import is still parked on
+        # the event, so a blocking implementation would never get here.
+        assert thread is not None
+        assert thread.is_alive()
+    finally:
+        release.set()
+        thread.join(timeout=_JOIN_TIMEOUT_S)
+    assert not thread.is_alive()
+
+
+def test_warm_up_failure_is_logged_and_swallowed(monkeypatch, caplog) -> None:
+    monkeypatch.setattr(optimization_module, "optimization_available", lambda: True)
+
+    def failing_import(name, package=None):
+        raise ImportError(f"boom: {name}")
+
+    monkeypatch.setattr(importlib, "import_module", failing_import)
+
+    with caplog.at_level(logging.WARNING, logger=optimization_module.__name__):
+        thread = warm_up_optimization_stack()
+        assert thread is not None
+        thread.join(timeout=_JOIN_TIMEOUT_S)
+        assert not thread.is_alive()
+
+    assert "optimization stack warm-up failed" in caplog.text
+    assert "preloaded" not in caplog.text
+
+
+def test_main_kicks_the_warm_up_once_at_startup(monkeypatch) -> None:
+    """main() calls warm_up_optimization_stack after the window is shown."""
+    from pathlib import Path
+
+    import PySide6.QtWidgets as qtwidgets
+
+    import geecs_console.app.main_window as mw_mod
+    import geecs_console.services.device_panel as dp_mod
+    import geecs_console.services.health as health_mod
+    import geecs_console.version as version_mod
+
+    sys.path.insert(0, str(Path(version_mod.__file__).parent.parent))
+    try:
+        import main as console_main
+    finally:
+        sys.path.pop(0)
+
+    order: list[str] = []
+
+    class _FakeApp:
+        # pytest-qt's per-test teardown calls QApplication.instance() on the
+        # (patched) module attribute — delegate to the real class so the
+        # plugin keeps working while the patch is live.
+        instance = staticmethod(qtwidgets.QApplication.instance)
+
+        def __init__(self, argv) -> None:
+            pass
+
+        def exec(self) -> int:
+            order.append("exec")
+            return 0
+
+    class _FakeWindow:
+        def __init__(self, **kwargs) -> None:
+            pass
+
+        def show(self) -> None:
+            order.append("show")
+
+    monkeypatch.setattr(qtwidgets, "QApplication", _FakeApp)
+    monkeypatch.setattr(mw_mod, "MainWindow", _FakeWindow)
+    monkeypatch.setattr(health_mod, "GatewayTiledDbHealth", lambda: object())
+    monkeypatch.setattr(dp_mod, "GatewayDevicePanel", lambda: object())
+    monkeypatch.setattr(
+        optimization_module,
+        "warm_up_optimization_stack",
+        lambda: order.append("warm_up"),
+    )
+
+    root = logging.getLogger()
+    handlers_before = list(root.handlers)
+    level_before = root.level
+    try:
+        assert console_main.main([]) == 0
+    finally:
+        for handler in list(root.handlers):
+            if handler not in handlers_before:
+                root.removeHandler(handler)
+                handler.close()
+        root.setLevel(level_before)
+
+    assert order == ["show", "warm_up", "exec"]


### PR DESCRIPTION
## What & why

Eliminates the first-optimization freeze seen live today (2026-07-15): the optimization loader (`services/optimization.py`) imports the geecs_scanner → xopt → botorch → torch stack lazily at first use, and torch alone costs tens of seconds cold — so the operator's first optimize submission appeared hung. Subsequent submissions were fine (modules cached in `sys.modules`).

Fix: `main.py` calls the new `warm_up_optimization_stack()` once, right after `window.show()`. With the `optimization` extra installed (the same light `find_spec` probe as `make_optimization_loader` — nothing heavy at probe time), a **daemon thread** pre-imports the loader's two heavy modules (`geecs_scanner.optimization.base_optimizer` / `.session_bridge`, which pull the whole torch stack transitively), then logs one INFO: `optimization stack preloaded in N.n s`.

- **Offline-first preserved**: without the extra the hook is a no-op (DEBUG log only); nothing new imports at module level.
- **Startup never blocks**: thread creation only on the GUI thread; warm-up failures are logged (WARNING, with traceback) and swallowed — a failed warm-up just means the old lazy path pays the cost later, exactly as before.
- **No double-work machinery**: a submission arriving mid-warm-up blocks on Python's per-module import lock and then reuses the module from `sys.modules` — documented in the docstring rather than built (verified: per-module import locks since 3.3).
- **No QThread** (repo rule): plain daemon `threading.Thread`, started after the window is up so nothing races Qt initialization.
- Stays out of `app/main_window.py` / `request_builder.py` (owned by the parallel iterations PR #560): changes are confined to `services/optimization.py`, `main.py`, docs, and tests.

**Version race note**: #560 merged first and took 0.11.0 while this branch was in flight; per the second-to-finish rule this PR merged `origin/dev` back in (CHANGELOG conflict resolved, iterations entry kept at 0.11.0) and takes **0.12.0** (minor: new public function + new startup behavior, backwards-compatible). The pre-merge commit subject still says 0.11.0; the merge commit records the renumber.

Judgment calls, flagged for cheap veto:
- One added sentence to the `Optimization (R3)` bullet in `GEECS-Console/CLAUDE.md` documenting the warm-up (keeps the seam docs accurate).
- The warm-up runs after `window.show()` rather than earliest-possible — deliberately, so the background import can never interleave with Qt/QApplication initialization; the operator still gets tens of seconds of headroom before any realistic first click.

LOC (excluding the merge of dev): `services/optimization.py` +72, `main.py` +6, `tests/test_optimization_warmup.py` +169 (new), CHANGELOG +17, CLAUDE.md +9.

## Checklist

- [x] `poetry version` run for every package whose code changed (GEECS-Console 0.10.1 → 0.12.0; 0.11.0 taken by #560)
- [x] `CHANGELOG.md` entry added under the new version (Keep a Changelog)
- [x] Tests: exact counts reported below (not "tests pass")
- [x] Base branch matches the content — see CONTRIBUTING.md § "Branch topology" (console/vision work → `dev`)
- [x] Public-repo hygiene: no lab accounts/hostnames/home paths

## Tests

GEECS-Console: **706 passed** (5 new in `tests/test_optimization_warmup.py`), exit 0, run twice (`QT_QPA_PLATFORM=offscreen poetry run pytest -q`; 706 both runs) + `./scripts/check.sh` green (lint + GEECS-Console suite). Post-merge baseline 701 + 5 new. New tests pin: no-op without the extra (real `find_spec` probe), the thread imports exactly `_HEAVY_MODULES` and logs the preloaded line, the call returns immediately while the import is still running (never-blocks), failure is logged-and-swallowed, and `main()` kicks the warm-up after `show()` and before `exec()`.

## Hardware verification

- OWED: first optimize submission after console launch (with the `optimization` extra installed) starts promptly instead of freezing for tens of seconds; console log shows one "optimization stack preloaded in N.n s" INFO shortly after launch. User verifies live today (2026-07-15).

🤖 Generated with [Claude Code](https://claude.com/claude-code)