### PR TITLE
GeecsBluesky 0.36.0: pre-flight dialog for save-set variables the gateway does not serve

### DIFF
--- a/GeecsBluesky/CHANGELOG.md
+++ b/GeecsBluesky/CHANGELOG.md
@@ -4,6 +4,45 @@ All notable changes to `geecs-bluesky` are documented here.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.36.0] - 2026-07-15
+
+### Added
+
+- **Unserved-variables pre-flight check (ScanRequest paths, all modes).**
+  Field incident (2026-07-15, live): a save set naming `UC_TopView`
+  `2ndmomW0x`/`2ndmomW0y` — real DB variables, but not `get='yes'` in
+  `expt_device_variable` and not settable, so the gateway serves no PVs
+  for them — died 20 s into detector connect with an ophyd
+  `NotConnectedError` traceback.  The runner now vets the resolved
+  devices config against the gateway's served set (`get='yes'` ∪ settable
+  variables of enabled devices, per `GeecsCAGateway/DEPLOYMENT.md`)
+  **pre-claim and pre-device-build**, as a new
+  `preflight.UnservedVariablesCheck` pipeline entry:
+  - Unserved variable(s) → ONE operator dialog naming them all
+    (`"<Device>:<var>, … are not set to 'get' in expt_device_variable,
+    so the gateway does not serve them. Continue without these
+    variables?"`).  Continue proceeds with exactly those variables
+    dropped from the devices config (a device whose *every* listed
+    variable is unserved is dropped whole); abort stops the run
+    pre-claim — no scan number burned.
+  - Drops are recorded in run metadata (`dropped_unserved_variables`
+    `{device: [vars]}` + `dropped_unserved_devices`).
+  - Headless (`NullOperator`) default: continue-and-drop with a WARNING
+    — a scan is never aborted headlessly for a soft reason.
+  - Failure-tolerant served-set source
+    (`db_runtime.GeecsDbServedSetProvider`): a DB failure reads as
+    *unknown* (check skipped with one warning), never as *empty* — a DB
+    blip neither blocks nor dialogs a scan.
+- `run_scan_request` / `_run_optimize_request` grew an
+  `operator_channel` hook for runner-asked pre-flight questions; the GUI
+  bridge passes its dialog channel (wrapped so an operator abort answer
+  reports the terminal state as ABORTED).  The check runs on
+  noscan/step/grid **and optimize** (the first operator-dialog pre-flight
+  stage on the optimize path; the detector-level gateway-liveness
+  pipeline still does not run there — unchanged, a later seam).
+- New scan-level exception `GeecsUnservedVariablesError` (carried inside
+  the dialog; `unserved` attribute maps device → variables).
+
 ## [0.35.0] - 2026-07-14
 
 ### Added

--- a/GeecsBluesky/CLAUDE.md
+++ b/GeecsBluesky/CLAUDE.md
@@ -49,8 +49,10 @@ geecs_bluesky/
                             #   "continue"/"abort"/default; EventStreamOperator
                             #   (GUI dialog path) / NullOperator (headless)
   preflight.py              # Pre-flight checks as a pipeline (pass/ask/abort);
-                            #   GatewayLivenessCheck + FreeRunStalenessCheck,
-                            #   run pre-claim, questions via OperatorChannel
+                            #   UnservedVariablesCheck (devices-config level,
+                            #   pre-device-build) + GatewayLivenessCheck +
+                            #   FreeRunStalenessCheck, run pre-claim,
+                            #   questions via OperatorChannel
   config_resolver.py        # ConfigResolver protocol + ConfigsRepoResolver:
                             #   ScanRequest names → schema models (new-schema
                             #   YAML directly, else legacy-convert)
@@ -477,7 +479,24 @@ The scanner's old defensive try/except imports are gone; the remaining
 Operator interaction is one seam: `operator_channel.OperatorChannel`
 (`EventStreamOperator` = today's GUI dialog behavior, `NullOperator` =
 headless default-and-log).  Pre-flight is a pipeline
-(`preflight.run_preflight`); new checks are list entries.
+(`preflight.run_preflight`); new checks are list entries.  Three checks
+exist (0.36.0): the device-level pair (`GatewayLivenessCheck` +
+`FreeRunStalenessCheck`, run by the bridge's `preflight` hook over the
+built detector list) and the config-level `UnservedVariablesCheck`, which
+the **runner itself** runs over the resolved devices config *before any
+detector is built* — a save-set variable outside the gateway's served set
+(`get='yes'` ∪ settable of enabled devices; `GeecsCAGateway/DEPLOYMENT.md`)
+has no PV, so building its detector used to die in a 20 s ophyd
+`NotConnectedError` (live incident 2026-07-15: `UC_TopView`
+`2ndmomW0x`/`2ndmomW0y`).  One dialog names every unserved variable;
+continue (and the headless default, with a WARNING) drops exactly those
+variables — a fully-unserved device is dropped whole — recorded in run
+metadata (`dropped_unserved_variables` / `dropped_unserved_devices`);
+abort is pre-claim.  The served set comes from the failure-tolerant
+`db_runtime.GeecsDbServedSetProvider`, whose DB failure reads as
+*unknown* (check skipped with one warning), never as *empty*.  Questions
+route through the runner's `operator_channel` parameter (the bridge
+passes its dialog channel; headless callers get `NullOperator`).
 
 `ScanRequest` execution (`scan_request_runner` / `GeecsSession.run`) runs
 the full schema surface as of 0.23.0 (M3b): **actions execute**
@@ -528,8 +547,10 @@ pre-claimed number/folder to `session.optimize`, owning the `scan.log`
 attach; the bridge's optional `finish()` (legacy `xopt_dump.yaml`) runs
 after a successful run.  `on_scan_start` fires on the optimize path with
 the `(max_iterations, max_iterations × shots_per_step)` upper bound (the
-suggester may stop early); the operator-dialog `preflight` still does not
-run on optimize (later seam).  Optimizer `device_requirements`
+suggester may stop early); the detector-level operator-dialog `preflight`
+hook still does not run on optimize (later seam), but the config-level
+unserved-variables check does (0.36.0) — it runs pre-claim on every mode,
+inside the runner.  Optimizer `device_requirements`
 auto-provisioning is deliberately **not** wired on this path — the
 request's save sets must name the objective's diagnostics (schema-world
 explicitness; the legacy exec_config path keeps its merge).  The

--- a/GeecsBluesky/geecs_bluesky/db_runtime.py
+++ b/GeecsBluesky/geecs_bluesky/db_runtime.py
@@ -11,12 +11,17 @@ schema describes (the ``SaveSetEntry`` runtime contract in
    :func:`select_telemetry_variables`; the soft read lives in
    :class:`~geecs_bluesky.devices.ca.telemetry.CaTelemetryReadable`.
 
+3. **Served-set resolution** for the unserved-variables pre-flight check —
+   :class:`GeecsDbServedSetProvider` (the gateway serves ``get='yes'`` union
+   settable variables of enabled devices; anything else has no PV).
+
 The **set-side** (DB scan start/end writes) is intentionally disabled: the
 boundary writes would race the shot controller / TriggerProfile on the DG645,
 so the reserved schema fields stay inert.  Everything here is a pure function
-except :class:`GeecsDbScalarPolicy`, the one failure-tolerant place touching
-``GeecsDb`` — a scan must never abort because the DB blipped.  Design
-rationale: ``GeecsBluesky/CLAUDE.md`` (M3c).
+except the two failure-tolerant ``GeecsDb`` touchpoints
+(:class:`GeecsDbScalarPolicy`, :class:`GeecsDbServedSetProvider`) — a scan
+must never abort because the DB blipped.  Design rationale:
+``GeecsBluesky/CLAUDE.md`` (M3c).
 """
 
 from __future__ import annotations
@@ -130,6 +135,90 @@ class GeecsDbScalarPolicy:
     def all_variables(self, device: str) -> list[str]:
         """Return every tracked variable for *device* (empty if uncurated)."""
         return list(self._all_by_device().get(device, []))
+
+
+@dataclass
+class GeecsDbServedSetProvider:
+    """The gateway's served variable set, per device — failure-tolerant.
+
+    The gateway serves each enabled device's ``get='yes'`` variables plus its
+    settable *control surface* (``GeecsCAGateway/DEPLOYMENT.md``,
+    "subscribed_only semantics") — a variable outside that union has no PV
+    at all, so a detector signal on it can never connect.  This provider
+    computes that union from two batched DB queries, cached on first use.
+
+    Failure semantics differ from :class:`GeecsDbScalarPolicy` deliberately:
+    the served set drives a *check*, so a DB failure must read as "unknown"
+    (``None`` — the check is skipped with one warning), never as "empty"
+    (which would condemn every variable as unserved and dialog the operator
+    for a DB blip).  A scan never aborts because the DB was unreachable.
+
+    Parameters
+    ----------
+    experiment : str
+        GEECS experiment name.
+    enabled_only : bool
+        Restrict to devices enabled in the experiment (default true) —
+        matching the gateway's own config builder.
+    db : type, optional
+        The ``GeecsDb`` class (injectable for tests); imported lazily by
+        default so this module has no hard dependency on the ``ca`` DB stack.
+    """
+
+    experiment: str
+    enabled_only: bool = True
+    db: object | None = None
+    _served: Optional[dict[str, set[str]]] = field(default=None, init=False)
+    _attempted: bool = field(default=False, init=False)
+
+    def _geecs_db(self) -> object:
+        if self.db is not None:
+            return self.db
+        from geecs_ca_gateway.db.geecs_db import GeecsDb
+
+        self.db = GeecsDb
+        return GeecsDb
+
+    def served_by_device(self) -> dict[str, set[str]] | None:
+        """Return ``{device: {served variables}}``, or ``None`` on DB failure.
+
+        Returns
+        -------
+        dict or None
+            The gateway's served set (``get='yes'`` union settable) for
+            every enabled device, or ``None`` when the DB could not be read
+            — callers must then skip the unserved-variables check (degrade
+            to pass with a warning, never block a scan on a DB blip).
+        """
+        if not self._attempted:
+            self._attempted = True
+            try:
+                db = self._geecs_db()
+                subscribed = db.get_subscribed_variables(
+                    self.experiment, enabled_only=self.enabled_only
+                )
+                metadata = db.get_experiment_device_variables(
+                    self.experiment, enabled_only=self.enabled_only
+                )
+            except Exception:
+                logger.warning(
+                    "Could not read the gateway served set for experiment %r; "
+                    "the unserved-variables pre-flight check will be skipped",
+                    self.experiment,
+                    exc_info=True,
+                )
+                return None
+            served: dict[str, set[str]] = {
+                device: set(variables) for device, variables in subscribed.items()
+            }
+            for device, rows in metadata.items():
+                settable = {
+                    row["name"] for row in rows if bool(row.get("settable", False))
+                }
+                if settable:
+                    served.setdefault(device, set()).update(settable)
+            self._served = served
+        return self._served
 
 
 def resolve_entry_scalars(

--- a/GeecsBluesky/geecs_bluesky/exceptions.py
+++ b/GeecsBluesky/geecs_bluesky/exceptions.py
@@ -33,6 +33,7 @@ __all__ = [
     "GeecsConfigurationError",
     "GeecsDeviceDownError",
     "GeecsStaleDevicesError",
+    "GeecsUnservedVariablesError",
     "ActionCheckFailedError",
     "ActionPlanNotFoundError",
     "ActionPlanCycleError",
@@ -194,6 +195,31 @@ class GeecsStaleDevicesError(GeecsError):
     Genuinely *dead* devices are :class:`GeecsDeviceDownError` territory.
     The message is operator-facing.
     """
+
+
+class GeecsUnservedVariablesError(GeecsError):
+    """Save-set variable(s) the gateway does not serve as PVs.
+
+    The gateway serves each enabled device's ``get='yes'`` variables plus its
+    settable control surface (``GeecsCAGateway/DEPLOYMENT.md``); a save-set
+    variable outside that set has no PV, so its detector signal can never
+    connect (a 20 s ophyd ``NotConnectedError``, observed live 2026-07-15).
+    Carried inside the pre-claim operator dialog raised by the
+    unserved-variables pre-flight check.  The message is operator-facing.
+
+    Parameters
+    ----------
+    message :
+        The operator-facing dialog body.
+    unserved :
+        ``{device: [variables]}`` — the unserved variables, by device.
+    """
+
+    def __init__(
+        self, message: str, unserved: dict[str, list[str]] | None = None
+    ) -> None:
+        self.unserved = dict(unserved or {})
+        super().__init__(message)
 
 
 # ---------------------------------------------------------------------------

--- a/GeecsBluesky/geecs_bluesky/preflight.py
+++ b/GeecsBluesky/geecs_bluesky/preflight.py
@@ -7,22 +7,32 @@ checks in order, routing questions through the injected
 additions to the list, not new branches in the scanner class.  All checks run
 **before the scan folder is claimed**, so an abort here burns no scan number.
 
-Today's checks: :class:`GatewayLivenessCheck` (both modes) and
+Today's checks: :class:`UnservedVariablesCheck` (ScanRequest paths, all modes
+— it inspects the devices config, so it runs *before* detectors are built),
+:class:`GatewayLivenessCheck` (both acquisition modes) and
 :class:`FreeRunStalenessCheck` (free-run only).  Headless / no answer → the
-check passes unchanged and the scan fails loudly downstream.
+device checks pass unchanged and the scan fails loudly downstream; the
+unserved-variables check instead defaults to continue-and-drop with a
+WARNING (matching the telemetry philosophy: a headless scan is never
+aborted for a soft reason).
 """
 
 from __future__ import annotations
 
 import logging
 import time
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any, Callable, Optional, Protocol, Union
 
-from geecs_bluesky.exceptions import GeecsDeviceDownError, GeecsStaleDevicesError
+from geecs_bluesky.exceptions import (
+    GeecsDeviceDownError,
+    GeecsStaleDevicesError,
+    GeecsUnservedVariablesError,
+)
 from geecs_bluesky.operator_channel import (
     ANSWER_ABORT,
     ANSWER_CONTINUE,
+    NullOperator,
     OperatorChannel,
     OperatorQuestion,
 )
@@ -524,3 +534,209 @@ class FreeRunStalenessCheck:
             on_default=_proceed_unchanged,
             abort_reason="Pre-flight: operator aborted (stale sync devices)",
         )
+
+
+# ---------------------------------------------------------------------------
+# Check 0 — unserved save-set variables (ScanRequest paths, all modes)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class UnservedVariablesCheck:
+    """Catch save-set variables the gateway does not serve, pre-device-build.
+
+    The gateway serves each enabled device's ``get='yes'`` variables plus its
+    settable control surface (``GeecsCAGateway/DEPLOYMENT.md``); a save-set
+    variable outside that union has no PV, so building a detector on it dies
+    in a 20 s ophyd ``NotConnectedError`` (observed live 2026-07-15:
+    ``UC_TopView`` ``2ndmomW0x``/``2ndmomW0y`` — real DB variables, but not
+    ``get='yes'``).  This check therefore runs against the resolved
+    ``devices_config``, **before** any detector is built.
+
+    Outcomes: every listed variable served → pass; the served set unknown
+    (DB unreachable — ``served_by_device()`` returned ``None``) → pass with
+    one warning, never block on a DB blip; unserved variable(s) → ONE
+    operator question naming them all.  Continue (and the headless default,
+    with a WARNING) drops exactly those variables from the devices config —
+    a device whose *every* listed variable is unserved is dropped whole —
+    abort stops the run pre-claim.  Results are exposed on the check
+    instance (``effective_config`` / ``dropped`` / ``dropped_devices``) for
+    the caller to record in run metadata.
+
+    Parameters
+    ----------
+    devices_config :
+        The resolved ``{device: {"variable_list": [...], ...}}`` config.
+    served_by_device :
+        Zero-argument callable returning ``{device: {served variables}}``
+        or ``None`` when the served set could not be determined (see
+        :meth:`~geecs_bluesky.db_runtime.GeecsDbServedSetProvider.served_by_device`).
+    """
+
+    devices_config: dict[str, dict[str, Any]]
+    served_by_device: Callable[[], "dict[str, set[str]] | None"]
+    effective_config: dict[str, dict[str, Any]] = field(init=False)
+    dropped: dict[str, list[str]] = field(default_factory=dict, init=False)
+    dropped_devices: list[str] = field(default_factory=list, init=False)
+
+    def __post_init__(self) -> None:
+        """Start with the unreduced config (a skipped check changes nothing)."""
+        self.effective_config = self.devices_config
+
+    def __call__(self, ctx: PreflightContext) -> CheckResult:
+        """Run the unserved-variables stage against the devices config.
+
+        Parameters
+        ----------
+        ctx :
+            The pre-flight context (used for question assembly only — this
+            check inspects the devices config, not the detector list).
+
+        Returns
+        -------
+        CheckResult
+            ``Passed`` (all served, or served set unknown), or an ``Ask``.
+        """
+        served = self.served_by_device()
+        if served is None:
+            # DB unreachable / no policy: the served set is unknown, which
+            # must never read as "everything unserved" — skip with a warning.
+            logger.warning(
+                "Pre-flight: the gateway served set could not be determined; "
+                "skipping the unserved-variables check (unserved save-set "
+                "variables would fail to connect downstream)"
+            )
+            return Passed()
+
+        unserved: dict[str, list[str]] = {}
+        for device, cfg in self.devices_config.items():
+            served_vars = served.get(device, set())
+            missing = [
+                variable
+                for variable in (cfg.get("variable_list") or [])
+                if variable not in served_vars
+            ]
+            if missing:
+                unserved[device] = missing
+        if not unserved:
+            return Passed()
+
+        whole_devices = [
+            device
+            for device, missing in unserved.items()
+            if len(missing)
+            == len(self.devices_config[device].get("variable_list") or [])
+        ]
+        details = ", ".join(
+            f"{device}:{variable}"
+            for device, missing in unserved.items()
+            for variable in missing
+        )
+        message = (
+            f"{details} are not set to 'get' in expt_device_variable, so the "
+            "gateway does not serve them."
+        )
+        if whole_devices:
+            message += (
+                f" Every listed variable of {', '.join(whole_devices)} is "
+                "unserved, so continuing drops the device(s) entirely."
+            )
+        message += " Continue without these variables?"
+        exc = GeecsUnservedVariablesError(message, unserved)
+
+        def _drop() -> Passed:
+            reduced: dict[str, dict[str, Any]] = {}
+            for device, cfg in self.devices_config.items():
+                missing = set(unserved.get(device, ()))
+                if not missing:
+                    reduced[device] = cfg
+                    continue
+                remaining = [
+                    v for v in (cfg.get("variable_list") or []) if v not in missing
+                ]
+                if not remaining:
+                    # Every listed variable unserved → drop the device whole
+                    # (even an images=True device: with no served scalar it
+                    # has no synchronizable columns to contribute).
+                    self.dropped_devices.append(device)
+                    continue
+                new_cfg = dict(cfg)
+                new_cfg["variable_list"] = remaining
+                reduced[device] = new_cfg
+            self.effective_config = reduced
+            self.dropped = {dev: list(vars_) for dev, vars_ in unserved.items()}
+            return Passed()
+
+        def _drop_by_default() -> Passed:
+            logger.warning(
+                "Pre-flight: unserved save-set variable(s) %s and no operator "
+                "answer — continuing without them (headless default: a scan "
+                "is never aborted for a soft reason)",
+                details,
+            )
+            return _drop()
+
+        return Ask(
+            question=ctx.question(
+                exc,
+                title="Unserved Save-Set Variable(s)",
+                continue_label="Continue Without Them",
+            ),
+            on_continue=_drop,
+            on_default=_drop_by_default,
+            abort_reason="Pre-flight: operator aborted (unserved save-set variables)",
+        )
+
+
+def run_unserved_variables_check(
+    devices_config: dict[str, dict[str, Any]],
+    served_by_device: Callable[[], "dict[str, set[str]] | None"] | None,
+    channel: OperatorChannel | None,
+    *,
+    dialog_timeout: Optional[float] = None,
+) -> tuple[dict[str, dict[str, Any]] | None, dict[str, list[str]], list[str]]:
+    """Run :class:`UnservedVariablesCheck` as a one-check pipeline.
+
+    The scan-request runner's entry point for the config-level pre-flight
+    stage: builds a minimal context (no detectors exist yet), routes the one
+    question through *channel*, and unpacks the check's outputs.
+
+    Parameters
+    ----------
+    devices_config :
+        The resolved devices config to vet.
+    served_by_device :
+        The served-set callable; ``None`` (no experiment / no provider)
+        skips the check entirely.
+    channel :
+        Where the question goes; ``None`` → :class:`NullOperator`
+        (headless: continue-and-drop with a WARNING).
+    dialog_timeout :
+        Per-question wait budget (``None`` → channel default).
+
+    Returns
+    -------
+    tuple
+        ``(effective_config, dropped, dropped_devices)`` —
+        ``effective_config`` is ``None`` when the operator aborted (pre-claim
+        — no scan number burned); ``dropped`` is ``{device: [variables]}``
+        and ``dropped_devices`` the devices removed whole (both empty when
+        nothing was dropped).
+    """
+    if served_by_device is None:
+        return devices_config, {}, []
+    check = UnservedVariablesCheck(
+        devices_config=devices_config, served_by_device=served_by_device
+    )
+    ctx = PreflightContext(
+        detectors=[],
+        strict=False,
+        read_liveness=lambda device: True,
+        drop_devices=lambda detectors, ids: detectors,
+        device_label=str,
+        dialog_timeout=dialog_timeout,
+    )
+    outcome = run_preflight([check], ctx, channel or NullOperator())
+    if outcome is None:
+        return None, {}, []
+    return check.effective_config, check.dropped, check.dropped_devices

--- a/GeecsBluesky/geecs_bluesky/scan_request_runner.py
+++ b/GeecsBluesky/geecs_bluesky/scan_request_runner.py
@@ -45,14 +45,17 @@ from geecs_bluesky.config_resolver import (  # noqa: F401
 )
 from geecs_bluesky.db_runtime import (
     GeecsDbScalarPolicy,
+    GeecsDbServedSetProvider,
     ScalarPolicyProvider,
     resolve_entry_scalars,
     select_telemetry_variables,
 )
 from geecs_bluesky.exceptions import GeecsConfigurationError
 from geecs_bluesky.models.shot_control import ShotControlWrites
+from geecs_bluesky.operator_channel import OperatorChannel
 from geecs_bluesky.plans.action_compiler import compile_action_plan
 from geecs_bluesky.plans.run_wrapper import claim_scan
+from geecs_bluesky.preflight import run_unserved_variables_check
 from geecs_bluesky.scan_log import log_claimed_scan_failure, scan_log
 from geecs_schemas import (
     ActionBindings,
@@ -776,6 +779,52 @@ def make_scalar_policy(session: Any) -> ScalarPolicyProvider | None:
     return GeecsDbScalarPolicy(experiment)
 
 
+def make_served_set_provider(session: Any) -> GeecsDbServedSetProvider | None:
+    """Build the gateway served-set provider for *session*'s experiment.
+
+    The unserved-variables pre-flight check resolves every devices-config
+    variable against this provider's served set (``get='yes'`` union
+    settable variables of enabled devices — the gateway's serving rule).
+    The provider is failure-tolerant: a DB failure makes
+    ``served_by_device()`` return ``None`` and the check is skipped with a
+    warning — a scan never aborts because the DB blipped.
+
+    Parameters
+    ----------
+    session :
+        The :class:`~geecs_bluesky.session.GeecsSession` (duck-typed).
+
+    Returns
+    -------
+    GeecsDbServedSetProvider or None
+        A DB-backed provider, or ``None`` when no experiment is known
+        (the check is then skipped entirely).
+    """
+    experiment = getattr(session, "experiment", None)
+    if not experiment:
+        return None
+    return GeecsDbServedSetProvider(experiment)
+
+
+def _preflight_unserved(
+    session: Any,
+    devices_config: dict[str, dict[str, Any]],
+    operator_channel: "OperatorChannel | None",
+) -> tuple[dict[str, dict[str, Any]] | None, dict[str, list[str]], list[str]]:
+    """Run the unserved-variables check over *devices_config* (pre-claim).
+
+    Thin glue between :func:`make_served_set_provider` and
+    :func:`~geecs_bluesky.preflight.run_unserved_variables_check`; returns
+    as the latter (``None`` config means the operator aborted).
+    """
+    provider = make_served_set_provider(session)
+    return run_unserved_variables_check(
+        devices_config,
+        provider.served_by_device if provider is not None else None,
+        operator_channel,
+    )
+
+
 def warn_if_reserved_boundary_overrides(save_set: SaveSet | None) -> None:
     """Warn once if any entry sets the reserved (not-honored) set-side fields.
 
@@ -874,6 +923,7 @@ def run_scan_request(
     optimization_binder: Callable[..., tuple[Any, Any]] | None = None,
     preflight: Callable[[list, bool], list | None] | None = None,
     on_scan_start: Callable[[int, int], None] | None = None,
+    operator_channel: "OperatorChannel | None" = None,
 ) -> str | None:
     """Execute *request* on *session*; return the run uid.
 
@@ -920,14 +970,23 @@ def run_scan_request(
         a strict flag: ``preflight(detectors, strict) -> list | None``.
         The returned (possibly reduced) list becomes the scan's detectors;
         ``None`` aborts the run (created devices are still disconnected).
-        Not called on the optimize path — an optimize preflight is a later
-        seam.  Headless callers omit it (behavior unchanged when ``None``).
+        Not called on the optimize path — a detector-level optimize
+        preflight is a later seam (the config-level unserved-variables
+        check *does* run there; see *operator_channel*).  Headless callers
+        omit it (behavior unchanged when ``None``).
     on_scan_start :
         Optional progress-totals hook (the GUI bridge's progress seam),
         called with ``(total_steps, total_shots)`` immediately before the
         session scan starts.  On the optimize path the totals are the
         upper bound ``(max_iterations, max_iterations × shots_per_step)``
         — the suggester may stop early.
+    operator_channel :
+        Where the runner's own pre-flight questions go (today: the
+        unserved-variables check, which runs pre-claim over the devices
+        config on **every** mode — noscan/step *and* optimize — before any
+        detector is built).  ``None`` (headless default) answers with each
+        question's default: continue-and-drop with a WARNING.  Distinct
+        from *preflight*, which vets the already-built detector list.
 
     Returns
     -------
@@ -974,6 +1033,7 @@ def run_scan_request(
             on_scan_start=on_scan_start,
             applied_defaults=applied_defaults,
             skipped_actions=skipped_actions,
+            operator_channel=operator_channel,
         )
 
     if not request.save_sets:
@@ -989,6 +1049,20 @@ def run_scan_request(
     # aborts a scan); the DB set-side stays disabled (reserved fields warn).
     scalar_policy = make_scalar_policy(session)
     devices_config = save_set_to_devices_config(save_set, scalar_policy)
+    # Unserved-variables pre-flight (pre-claim, pre-device-build): a variable
+    # the gateway does not serve has no PV, so its detector could never
+    # connect — ask the operator (or headless: drop with a WARNING) now
+    # instead of dying in a 20 s NotConnectedError during connect.
+    checked_config, dropped_unserved, dropped_unserved_devices = _preflight_unserved(
+        session, devices_config, operator_channel
+    )
+    if checked_config is None:
+        logger.warning(
+            "ScanRequest preflight aborted the scan (unserved save-set "
+            "variables; pre-claim — no scan number was burned)"
+        )
+        return None
+    devices_config = checked_config
     slots = assemble_action_slots(request.actions, applied_defaults, rituals)
     warn_if_reserved_boundary_overrides(save_set)
 
@@ -1060,6 +1134,14 @@ def run_scan_request(
         md: dict[str, Any] = {"scan_request_mode": request.mode.value}
         # Provenance: which named save sets were unioned for this scan.
         md["save_sets"] = list(request.save_sets)
+        if dropped_unserved:
+            # Provenance: variables (and whole devices) dropped by the
+            # unserved-variables pre-flight — the run proceeded without them.
+            md["dropped_unserved_variables"] = {
+                dev: list(vars_) for dev, vars_ in dropped_unserved.items()
+            }
+        if dropped_unserved_devices:
+            md["dropped_unserved_devices"] = list(dropped_unserved_devices)
         if applied_defaults:
             # Provenance: the run records exactly which experiment defaults
             # filled in fields the submitter left unset.
@@ -1158,6 +1240,7 @@ def _run_optimize_request(
     on_scan_start: Callable[[int, int], None] | None = None,
     applied_defaults: dict[str, Any] | None = None,
     skipped_actions: dict[str, list[str]] | None = None,
+    operator_channel: "OperatorChannel | None" = None,
 ) -> str | None:
     """Map an optimize-mode request onto :meth:`GeecsSession.optimize`.
 
@@ -1177,9 +1260,11 @@ def _run_optimize_request(
         ``"strict"`` or ``"free_run"``.
     objective, suggester :
         The ready-made optimization callables.
-    optimization_binder, on_scan_start :
-        As in :func:`run_scan_request`.  With a binder (and no ready-made
-        callables) the runner claims the scan itself, pre-bind, so the
+    optimization_binder, on_scan_start, operator_channel :
+        As in :func:`run_scan_request` (the unserved-variables check runs
+        here too, pre-claim, over the save-set devices config).  With a
+        binder (and no ready-made callables) the runner claims the scan
+        itself, pre-bind, so the
         binder's analyzers get the real ``ScanTag`` — mirroring the legacy
         exec_config optimization path; the claim still happens *after*
         every fail-fast resolution and device connect, and the runner then
@@ -1210,6 +1295,8 @@ def _run_optimize_request(
 
     detectors: list = []
     created: list = []
+    dropped_unserved: dict[str, list[str]] = {}
+    dropped_unserved_devices: list[str] = []
     try:
         skipped = {k: list(v) for k, v in (skipped_actions or {}).items() if v}
         # db_scalars applies to optimize too; telemetry does not run here yet
@@ -1227,9 +1314,26 @@ def _run_optimize_request(
                 # Save-set entry rituals can't run in optimize mode yet either;
                 # skip and record rather than refuse (see run_scan_request).
                 skipped["save_set_rituals"] = ritual_names
+            devices_config = save_set_to_devices_config(save_set, scalar_policy)
+            # Unserved-variables pre-flight, exactly as on the scan/noscan
+            # path (pre-claim: the optimize claim happens further down, so
+            # an abort here burns no scan number).  The detector-level
+            # operator preflight hook still does not run on optimize (its
+            # seam is unchanged); this config-level check does.
+            (
+                devices_config,
+                dropped_unserved,
+                dropped_unserved_devices,
+            ) = _preflight_unserved(session, devices_config, operator_channel)
+            if devices_config is None:
+                logger.warning(
+                    "ScanRequest preflight aborted the optimization (unserved "
+                    "save-set variables; pre-claim — no scan number was burned)"
+                )
+                return None
             detectors = _build_request_detectors(
                 session,
-                save_set_to_devices_config(save_set, scalar_policy),
+                devices_config,
                 free_run=mode == "free_run",
             )
             created.extend(detectors)
@@ -1250,6 +1354,14 @@ def _run_optimize_request(
         if request.save_sets:
             # Provenance: which named save sets were unioned for this scan.
             md["save_sets"] = list(request.save_sets)
+        if dropped_unserved:
+            # Provenance: variables (and whole devices) dropped by the
+            # unserved-variables pre-flight — the run proceeded without them.
+            md["dropped_unserved_variables"] = {
+                dev: list(vars_) for dev, vars_ in dropped_unserved.items()
+            }
+        if dropped_unserved_devices:
+            md["dropped_unserved_devices"] = list(dropped_unserved_devices)
         if applied_defaults:
             md["applied_defaults"] = applied_defaults
         if skipped:

--- a/GeecsBluesky/geecs_bluesky/scanner_bridge/bluesky_scanner.py
+++ b/GeecsBluesky/geecs_bluesky/scanner_bridge/bluesky_scanner.py
@@ -60,6 +60,7 @@ from geecs_bluesky.events import (
 )
 from geecs_bluesky.models.shot_control import ShotControlConfig, ShotControlWrites
 from geecs_bluesky.operator_channel import (
+    ANSWER_ABORT,
     EventStreamOperator,
     NullOperator,
     OperatorChannel,
@@ -1082,6 +1083,7 @@ class BlueskyScanner:
             preflight=self._delegated_preflight,
             on_scan_start=self._on_delegated_scan_start,
             optimization_binder=optimization_binder,
+            operator_channel=self._delegated_operator_channel(),
         )
         if opt_bridge is not None:
             # Post-run bookkeeping owned by the bridge (legacy parity with
@@ -1089,6 +1091,29 @@ class BlueskyScanner:
             finish = getattr(opt_bridge, "finish", None)
             if callable(finish):
                 finish()
+
+    def _delegated_operator_channel(self) -> OperatorChannel:
+        """Operator channel for the runner's own pre-flight questions.
+
+        The delegated runner asks its config-level questions itself (today:
+        the unserved-variables check, which runs before detectors exist so
+        it cannot go through :meth:`_delegated_preflight`).  This wraps
+        :meth:`_operator_channel` so an "abort" answer to a runner-asked
+        question also sets the scanner's abort flag — the scan thread's
+        cleanup then reports ABORTED instead of DONE, matching the
+        detector-level pipeline's behavior.
+        """
+        inner = self._operator_channel()
+        scanner = self
+
+        class _AbortNotingChannel:
+            def ask(self, question: OperatorQuestion) -> str:
+                answer = inner.ask(question)
+                if answer == ANSWER_ABORT:
+                    scanner._abort_requested = True
+                return answer
+
+        return _AbortNotingChannel()
 
     def _delegated_preflight(self, detectors: list, strict: bool) -> list | None:
         """Runner preflight hook: the operator-dialog pipeline, sans disconnect.

--- a/GeecsBluesky/pyproject.toml
+++ b/GeecsBluesky/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-bluesky"
-version = "0.35.0"
+version = "0.36.0"
 description = "Bluesky / ophyd-async bridge for the GEECS control system"
 authors = ["Sam Barber <sbarber@lbl.gov>"]
 readme = "README.md"

--- a/GeecsBluesky/tests/test_db_runtime.py
+++ b/GeecsBluesky/tests/test_db_runtime.py
@@ -156,3 +156,76 @@ def test_policy_caches_queries() -> None:
     policy.get_variables("U_Other")
     policy.subscribed_by_device()
     assert _CountingDb.calls == 1  # one batched query, cached
+
+
+# ---------------------------------------------------------------------------
+# GeecsDbServedSetProvider (the unserved-variables pre-flight source)
+# ---------------------------------------------------------------------------
+
+
+class _ServedDb:
+    """Fake DB with a subscribed set and a settable control surface."""
+
+    calls = 0
+
+    @classmethod
+    def get_subscribed_variables(cls, experiment, *, enabled_only=True):
+        cls.calls += 1
+        return {"UC_TopView": ["centroidx", "centroidy"]}
+
+    @classmethod
+    def get_experiment_device_variables(cls, experiment, *, enabled_only=True):
+        return {
+            "UC_TopView": [
+                {"name": "centroidx", "settable": False},
+                {"name": "2ndmomW0x", "settable": False},  # real but unserved
+                {"name": "save", "settable": True},
+                {"name": "localsavingpath", "settable": True},
+            ],
+            "U_SettableOnly": [
+                {"name": "Setpoint", "settable": True},
+            ],
+            "U_NothingServed": [
+                {"name": "ReadOnlyThing", "settable": False},
+            ],
+        }
+
+
+def test_served_set_is_subscribed_union_settable() -> None:
+    from geecs_bluesky.db_runtime import GeecsDbServedSetProvider
+
+    provider = GeecsDbServedSetProvider("Undulator", db=_ServedDb)
+    served = provider.served_by_device()
+    assert served is not None
+    # get='yes' ∪ settable — 2ndmomW0x is a real DB variable but in neither.
+    assert served["UC_TopView"] == {
+        "centroidx",
+        "centroidy",
+        "save",
+        "localsavingpath",
+    }
+    # A device with zero get='yes' variables keeps its control surface.
+    assert served["U_SettableOnly"] == {"Setpoint"}
+    # Nothing subscribed and nothing settable → the gateway skips the device.
+    assert "U_NothingServed" not in served
+
+
+def test_served_set_is_cached() -> None:
+    from geecs_bluesky.db_runtime import GeecsDbServedSetProvider
+
+    _ServedDb.calls = 0
+    provider = GeecsDbServedSetProvider("Undulator", db=_ServedDb)
+    provider.served_by_device()
+    provider.served_by_device()
+    assert _ServedDb.calls == 1
+
+
+def test_served_set_db_failure_returns_none_not_empty(caplog) -> None:
+    from geecs_bluesky.db_runtime import GeecsDbServedSetProvider
+
+    provider = GeecsDbServedSetProvider("Undulator", db=_RaisingDb)
+    with caplog.at_level(logging.WARNING):
+        assert provider.served_by_device() is None  # unknown, NOT empty
+        assert provider.served_by_device() is None  # failure is cached too
+    warnings = [r for r in caplog.records if "served set" in r.getMessage()]
+    assert len(warnings) == 1

--- a/GeecsBluesky/tests/test_preflight_unserved.py
+++ b/GeecsBluesky/tests/test_preflight_unserved.py
@@ -1,0 +1,383 @@
+"""Tests for the unserved-variables pre-flight check (the 2026-07-15 incident).
+
+A save set naming variables the gateway does not serve — real DB variables
+that are neither ``get='yes'`` in ``expt_device_variable`` nor settable
+(live case: ``UC_TopView`` ``2ndmomW0x``/``2ndmomW0y``) — used to die 20 s
+into detector connect with an ophyd ``NotConnectedError`` traceback.  These
+tests pin the replacement behavior on the ScanRequest paths: ONE pre-claim
+operator question naming every unserved variable; continue (and the headless
+default, with a WARNING) drops exactly those variables from the devices
+config — a device whose every listed variable is unserved is dropped whole —
+and records them in run metadata; abort stops the run pre-claim (no scan
+number burned); a DB failure degrades to pass with one warning.  The check
+runs on noscan/step *and* optimize.
+"""
+
+from __future__ import annotations
+
+import logging
+from types import SimpleNamespace
+
+from geecs_bluesky.operator_channel import OperatorQuestion
+from geecs_bluesky.preflight import run_unserved_variables_check
+from geecs_bluesky.scan_request_runner import run_scan_request
+from geecs_schemas import SaveSet, SaveSetEntry, ScanRequest
+
+# ---------------------------------------------------------------------------
+# Fakes: session recording variable lists, one-save-set resolver, channel
+# ---------------------------------------------------------------------------
+
+
+class _RecordingSession:
+    """Fake session recording each device build's variable list (no CA/RE)."""
+
+    def __init__(self) -> None:
+        self.device_calls: list[tuple[str, str, list[str]]] = []
+        self.scan_kwargs: dict | None = None
+        self.optimize_kwargs: dict | None = None
+        self.disconnected: list = []
+
+    def _make(self, kind: str, device: str, variables: list[str]):
+        self.device_calls.append((kind, device, list(variables)))
+        return SimpleNamespace(_geecs_device_name=device, kind=kind)
+
+    def detector(self, device, variables, *, save_images=False, name=None):
+        return self._make("detector", device, variables)
+
+    def contributor(self, device, variables, *, save_images=False, name=None):
+        return self._make("contributor", device, variables)
+
+    def snapshot(self, device, variables, *, name=None):
+        return self._make("snapshot", device, variables)
+
+    def settable(self, device, variable, *, name=None):
+        return SimpleNamespace(_geecs_device_name=f"{device}:{variable}")
+
+    def shot_control(self, config) -> None:
+        pass
+
+    def scan(self, **kwargs):
+        self.scan_kwargs = kwargs
+        return "uid-scan"
+
+    def optimize(self, **kwargs):
+        self.optimize_kwargs = kwargs
+        return "uid-opt", []
+
+    def disconnect(self, *devices) -> None:
+        self.disconnected.extend(devices)
+
+
+class _SaveSetResolver:
+    """Minimal resolver: named save sets only (no defaults, no actions)."""
+
+    def __init__(self, save_sets: dict[str, SaveSet]) -> None:
+        self._save_sets = save_sets
+
+    def resolve_save_set(self, name: str) -> SaveSet:
+        return self._save_sets[name]
+
+
+class _ScriptedChannel:
+    """Answers questions from a scripted list and records them."""
+
+    def __init__(self, answers: list[str]) -> None:
+        self.answers = list(answers)
+        self.questions: list[OperatorQuestion] = []
+
+    def ask(self, question: OperatorQuestion) -> str:
+        self.questions.append(question)
+        return self.answers.pop(0)
+
+
+# The incident shape: UC_TopView's subscribed set is centroidx/y + counts;
+# 2ndmomW0x/2ndmomW0y are real DB variables but not get='yes' → no PVs.
+_SERVED = {
+    "UC_TopView": {
+        "centroidx",
+        "centroidy",
+        "MaxCounts",
+        "MeanCounts",
+        "save",  # settable control surface counts as served
+        "localsavingpath",
+    },
+}
+
+
+def _topview_save_set(extra_entries: list[SaveSetEntry] | None = None) -> SaveSet:
+    entries = [
+        SaveSetEntry(
+            device="UC_TopView",
+            scalars=["centroidx", "2ndmomW0x", "2ndmomW0y"],
+            db_scalars=False,
+        )
+    ]
+    return SaveSet(name="TopView", entries=entries + list(extra_entries or []))
+
+
+def _noscan_request(**overrides) -> ScanRequest:
+    base = dict(
+        mode="noscan",
+        shots_per_step=2,
+        acquisition="strict",
+        save_sets=["TopView"],
+    )
+    base.update(overrides)
+    return ScanRequest.model_validate(base)
+
+
+def _install_served(monkeypatch, served: dict[str, set[str]] | None) -> None:
+    """Route the runner's served-set provider to an in-memory map (or None)."""
+    import geecs_bluesky.scan_request_runner as runner
+
+    provider = SimpleNamespace(served_by_device=lambda: served)
+    monkeypatch.setattr(runner, "make_served_set_provider", lambda session: provider)
+
+
+# ---------------------------------------------------------------------------
+# The check through run_scan_request (noscan/step path)
+# ---------------------------------------------------------------------------
+
+
+def test_all_served_asks_nothing_and_keeps_the_config(monkeypatch) -> None:
+    _install_served(
+        monkeypatch, {"UC_TopView": {"centroidx", "2ndmomW0x", "2ndmomW0y"}}
+    )
+    session = _RecordingSession()
+    channel = _ScriptedChannel([])
+    resolver = _SaveSetResolver({"TopView": _topview_save_set()})
+
+    uid = run_scan_request(
+        session, _noscan_request(), resolver, operator_channel=channel
+    )
+
+    assert uid == "uid-scan"
+    assert channel.questions == []
+    assert session.device_calls == [
+        ("detector", "UC_TopView", ["centroidx", "2ndmomW0x", "2ndmomW0y"])
+    ]
+    assert "dropped_unserved_variables" not in session.scan_kwargs["md"]
+
+
+def test_unserved_variables_ask_one_question_with_the_pinned_text(
+    monkeypatch,
+) -> None:
+    _install_served(monkeypatch, _SERVED)
+    session = _RecordingSession()
+    channel = _ScriptedChannel(["continue"])
+    resolver = _SaveSetResolver({"TopView": _topview_save_set()})
+
+    run_scan_request(session, _noscan_request(), resolver, operator_channel=channel)
+
+    assert len(channel.questions) == 1
+    question = channel.questions[0]
+    assert question.message.startswith(
+        "UC_TopView:2ndmomW0x, UC_TopView:2ndmomW0y are not set to 'get' in "
+        "expt_device_variable, so the gateway does not serve them."
+    )
+    assert question.message.endswith("Continue without these variables?")
+    assert question.title == "Unserved Save-Set Variable(s)"
+    assert question.continue_label == "Continue Without Them"
+
+
+def test_continue_drops_exactly_the_unserved_variables(monkeypatch) -> None:
+    _install_served(monkeypatch, _SERVED)
+    session = _RecordingSession()
+    resolver = _SaveSetResolver({"TopView": _topview_save_set()})
+
+    uid = run_scan_request(
+        session,
+        _noscan_request(),
+        resolver,
+        operator_channel=_ScriptedChannel(["continue"]),
+    )
+
+    assert uid == "uid-scan"
+    # The detector is built from the reduced list — the unserved variables
+    # never reach a device (that is what prevented the connect timeout).
+    assert session.device_calls == [("detector", "UC_TopView", ["centroidx"])]
+    md = session.scan_kwargs["md"]
+    assert md["dropped_unserved_variables"] == {
+        "UC_TopView": ["2ndmomW0x", "2ndmomW0y"]
+    }
+    assert "dropped_unserved_devices" not in md
+
+
+def test_fully_unserved_device_is_dropped_whole(monkeypatch) -> None:
+    _install_served(monkeypatch, _SERVED)
+    session = _RecordingSession()
+    ghost = SaveSetEntry(device="U_Ghost", scalars=["foo"], db_scalars=False)
+    resolver = _SaveSetResolver({"TopView": _topview_save_set([ghost])})
+    channel = _ScriptedChannel(["continue"])
+
+    run_scan_request(session, _noscan_request(), resolver, operator_channel=channel)
+
+    # One dialog covers both the partial and the whole-device drop.
+    assert len(channel.questions) == 1
+    assert (
+        "Every listed variable of U_Ghost is unserved, so continuing drops "
+        "the device(s) entirely." in channel.questions[0].message
+    )
+    built = [device for _kind, device, _vars in session.device_calls]
+    assert built == ["UC_TopView"]  # U_Ghost never built
+    md = session.scan_kwargs["md"]
+    assert md["dropped_unserved_variables"]["U_Ghost"] == ["foo"]
+    assert md["dropped_unserved_devices"] == ["U_Ghost"]
+
+
+def test_abort_answer_aborts_pre_claim_before_any_device_is_built(
+    monkeypatch,
+) -> None:
+    _install_served(monkeypatch, _SERVED)
+    session = _RecordingSession()
+    resolver = _SaveSetResolver({"TopView": _topview_save_set()})
+
+    uid = run_scan_request(
+        session,
+        _noscan_request(),
+        resolver,
+        operator_channel=_ScriptedChannel(["abort"]),
+    )
+
+    assert uid is None
+    # Pre-claim AND pre-device-build: the claim lives inside session.scan,
+    # which never ran, and no detector was created either.
+    assert session.scan_kwargs is None
+    assert session.device_calls == []
+
+
+def test_db_failure_degrades_to_pass_with_one_warning(monkeypatch, caplog) -> None:
+    _install_served(monkeypatch, None)  # served set unknown (DB unreachable)
+    session = _RecordingSession()
+    channel = _ScriptedChannel([])
+    resolver = _SaveSetResolver({"TopView": _topview_save_set()})
+
+    with caplog.at_level(logging.WARNING):
+        uid = run_scan_request(
+            session, _noscan_request(), resolver, operator_channel=channel
+        )
+
+    assert uid == "uid-scan"
+    assert channel.questions == []  # never blocks a scan on a DB blip
+    assert session.device_calls == [
+        ("detector", "UC_TopView", ["centroidx", "2ndmomW0x", "2ndmomW0y"])
+    ]
+    warnings = [
+        r
+        for r in caplog.records
+        if "served set could not be determined" in r.getMessage()
+    ]
+    assert len(warnings) == 1
+
+
+def test_headless_default_continues_and_drops_with_a_warning(
+    monkeypatch, caplog
+) -> None:
+    _install_served(monkeypatch, _SERVED)
+    session = _RecordingSession()
+    resolver = _SaveSetResolver({"TopView": _topview_save_set()})
+
+    with caplog.at_level(logging.WARNING):
+        # No operator_channel at all — the headless NullOperator default.
+        uid = run_scan_request(session, _noscan_request(), resolver)
+
+    assert uid == "uid-scan"
+    assert session.device_calls == [("detector", "UC_TopView", ["centroidx"])]
+    md = session.scan_kwargs["md"]
+    assert md["dropped_unserved_variables"] == {
+        "UC_TopView": ["2ndmomW0x", "2ndmomW0y"]
+    }
+    assert any(
+        "no operator answer — continuing without them" in r.getMessage()
+        for r in caplog.records
+    )
+
+
+# ---------------------------------------------------------------------------
+# The check on the optimize path (runs pre-claim there too)
+# ---------------------------------------------------------------------------
+
+
+def _optimize_request(**overrides) -> ScanRequest:
+    base = dict(
+        mode="optimize",
+        shots_per_step=3,
+        acquisition="free_run",
+        save_sets=["TopView"],
+        optimization={
+            "variables": {"U_S1H:Current": [-2.0, 2.0]},
+            "objectives": {"counts": "MAXIMIZE"},
+            "evaluator": {"module": "m", "class": "C"},
+            "generator": {"name": "bayes_default"},
+            "max_iterations": 4,
+        },
+    )
+    base.update(overrides)
+    return ScanRequest.model_validate(base)
+
+
+def test_optimize_path_runs_the_check_and_drops_on_continue(monkeypatch) -> None:
+    _install_served(monkeypatch, _SERVED)
+    session = _RecordingSession()
+    resolver = _SaveSetResolver({"TopView": _topview_save_set()})
+    channel = _ScriptedChannel(["continue"])
+
+    uid = run_scan_request(
+        session,
+        _optimize_request(),
+        resolver,
+        objective=lambda rows: 0.0,
+        suggester=lambda history: None,
+        operator_channel=channel,
+    )
+
+    assert uid == "uid-opt"
+    assert len(channel.questions) == 1
+    # free_run: the first synchronous device is still the reference detector.
+    assert session.device_calls == [("detector", "UC_TopView", ["centroidx"])]
+    md = session.optimize_kwargs["md"]
+    assert md["dropped_unserved_variables"] == {
+        "UC_TopView": ["2ndmomW0x", "2ndmomW0y"]
+    }
+
+
+def test_optimize_path_abort_is_pre_claim(monkeypatch) -> None:
+    _install_served(monkeypatch, _SERVED)
+    import geecs_bluesky.scan_request_runner as runner
+
+    claims: list = []
+    monkeypatch.setattr(
+        runner,
+        "claim_scan",
+        lambda experiment: claims.append(experiment) or (None, None),
+    )
+    session = _RecordingSession()
+    resolver = _SaveSetResolver({"TopView": _topview_save_set()})
+
+    uid = run_scan_request(
+        session,
+        _optimize_request(),
+        resolver,
+        optimization_binder=lambda **kwargs: (lambda rows: 0.0, lambda history: None),
+        operator_channel=_ScriptedChannel(["abort"]),
+    )
+
+    assert uid is None
+    assert session.optimize_kwargs is None
+    assert claims == []  # the binder path claims pre-bind — never reached
+    assert session.device_calls == []
+
+
+# ---------------------------------------------------------------------------
+# Helper-level edge: no provider at all → the check is skipped entirely
+# ---------------------------------------------------------------------------
+
+
+def test_no_provider_skips_the_check() -> None:
+    config = {"U_Cam": {"variable_list": ["x"], "synchronous": True}}
+    effective, dropped, dropped_devices = run_unserved_variables_check(
+        config, None, None
+    )
+    assert effective is config
+    assert dropped == {}
+    assert dropped_devices == []

--- a/GeecsBluesky/tests/test_scan_request_runner.py
+++ b/GeecsBluesky/tests/test_scan_request_runner.py
@@ -1528,10 +1528,17 @@ class _M3cSession(_FakeSession):
 
 
 def _install_policy(monkeypatch, policy) -> None:
-    """Force run_scan_request to use *policy* instead of a real GeecsDb."""
+    """Force run_scan_request to use *policy* instead of a real GeecsDb.
+
+    Also stubs out the served-set provider (the unserved-variables
+    pre-flight): a session exposing ``experiment`` would otherwise reach for
+    the real DB — these tests must stay hermetic (and never stall on an
+    off-network MySQL timeout).
+    """
     import geecs_bluesky.scan_request_runner as runner
 
     monkeypatch.setattr(runner, "make_scalar_policy", lambda session: policy)
+    monkeypatch.setattr(runner, "make_served_set_provider", lambda session: None)
 
 
 def _db_noscan_request(**overrides):


### PR DESCRIPTION
## The incident (2026-07-15, live)

A save set named `UC_TopView` variables `2ndmomW0x` / `2ndmomW0y` — **real DB variables**, but not `get='yes'` in `expt_device_variable` and not settable (UC_TopView's subscribed set is only centroidx/y, MaxCounts, MeanCounts). The gateway serves only the `get='yes'` ∪ settable subset of each enabled device (`GeecsCAGateway/DEPLOYMENT.md` § subscribed_only semantics), so those PVs don't exist — detector connect died after a 20 s timeout with an ophyd `NotConnectedError` traceback instead of telling the operator what was wrong.

## What this PR does

Adds an **unserved-variables pre-flight check** to the pipeline (`preflight.UnservedVariablesCheck`), run by the ScanRequest runner over the resolved devices config — **pre-claim and pre-device-build**, so the doomed connect never starts and an abort burns no scan number.

The exact dialog text (pinned by test):

> `UC_TopView:2ndmomW0x, UC_TopView:2ndmomW0y are not set to 'get' in expt_device_variable, so the gateway does not serve them. Continue without these variables?`

(title "Unserved Save-Set Variable(s)", buttons "Continue Without Them" / "Abort Scan"; when a device's *every* listed variable is unserved, the same dialog adds "Every listed variable of `<Device>` is unserved, so continuing drops the device(s) entirely.")

Behavior:

- **Continue** → the run proceeds with exactly those variables dropped from the devices config (so each detector's variable list never contains them); a fully-unserved device is dropped whole. Drops are recorded in run metadata: `dropped_unserved_variables` (`{device: [vars]}`) + `dropped_unserved_devices`.
- **Abort** → pre-claim abort; on the GUI bridge the terminal state is ABORTED (the bridge wraps its dialog channel so a runner-asked abort answer sets the abort flag).
- **Headless (NullOperator)** → continue-and-drop with a WARNING — matches the telemetry philosophy: never abort headlessly for a soft reason.
- **DB unreachable** → the served set reads as *unknown*: the check is skipped with one warning, never treated as "everything unserved". A DB blip neither blocks nor dialogs a scan (follows `db_runtime`'s degrade-to-warning pattern; the new `GeecsDbServedSetProvider` deliberately returns `None` on failure where `GeecsDbScalarPolicy` returns `{}` — for a *check*, empty and unknown must not be conflated).

**All modes:** the check runs inside `run_scan_request` / `_run_optimize_request`, so it covers noscan/1D/grid **and optimize** on both the headless and the bridge-delegated paths. It reaches the runner through a new `operator_channel` hook (the bridge passes its existing dialog channel). The existing detector-level gateway-liveness/staleness pipeline (`preflight(detectors, strict)` hook) is untouched, including its not-on-optimize behavior — it vets built detectors and could not be trivially unified with a config-level check that must run *before* detectors exist; this config-level check is therefore the first operator-dialog pre-flight stage that runs on optimize.

## Per-concern LOC breakdown

| Concern | Files | LOC |
|---|---|---|
| The check + pipeline helper | `preflight.py` | +224 |
| Served-set provider (get='yes' ∪ settable, failure-tolerant) | `db_runtime.py` | +95 |
| Runner wiring (check invocation, `operator_channel` hook, metadata, optimize path) | `scan_request_runner.py` | +124/-20 |
| Bridge: pass dialog channel + ABORTED-on-abort wrapper | `scanner_bridge/bluesky_scanner.py` | +25 |
| New exception `GeecsUnservedVariablesError` | `exceptions.py` | +26 |
| Tests | `test_preflight_unserved.py` (new), `test_db_runtime.py`, `test_scan_request_runner.py` | +465 |
| Version/CHANGELOG/CLAUDE.md | | +72 |

Judgment calls, flagged for cheap veto:

- **`dropped_unserved_devices` as a second metadata key** alongside `dropped_unserved_variables` (whole-device drops are also visible as the device's full list in the variables key — the extra key just makes them greppable).
- **The bridge's `_delegated_operator_channel` abort-noting wrapper** — without it, an operator abort on this dialog would end the scan thread in DONE instead of ABORTED. Small, but it is new plumbing.
- **Not modeled:** the gateway also skips `image`/`1darray`-typed variables even when `get='yes'` (`_SKIP_VARTYPES` in the gateway config builder / the `audit.py` SKIP class). A `get='yes'` image-typed variable listed as a save-set *scalar* would still pass this check and fail at connect. Modeling it needs the gateway's `effective_vartype` rules; left out to keep the served-set definition exactly the documented "subscribed ∪ settable". Can follow up if it bites.

## Tests

`./scripts/check.sh` green: lint OK, **GeecsBluesky 503 passed, 3 deselected** (was 490 baseline; +13 new — 10 in `test_preflight_unserved.py` pinning question text / continue-drops / abort-pre-claim / DB-degrade / whole-device drop / headless default / optimize path, 3 in `test_db_runtime.py` for the served-set provider). Existing runner tests' `_install_policy` also stubs the new provider so hermetic tests can never reach for MySQL.

## Hardware verification

**OWED: reproduce the 2026-07-15 incident live** — submit a scan with a save set naming a non-`get` variable (e.g. `UC_TopView` `2ndmomW0x`/`2ndmomW0y`):
- the dialog appears pre-claim with the text above (no 20 s stall, no `NotConnectedError` traceback);
- **Continue Without Them** → the scan runs to completion without those columns, and the run metadata carries `dropped_unserved_variables: {UC_TopView: [2ndmomW0x, 2ndmomW0y]}`;
- **Abort Scan** → no scan folder/number is created and the GUI reports ABORTED;
- off-network sanity: with the DB unreachable the scan submits normally with one "served set could not be determined" warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)