### PR TITLE
GeecsBluesky 0.36.0: quiet operator-requested aborts

### DIFF
--- a/GeecsBluesky/CHANGELOG.md
+++ b/GeecsBluesky/CHANGELOG.md
@@ -4,6 +4,37 @@ All notable changes to `geecs-bluesky` are documented here.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.36.0] - 2026-07-15
+
+### Changed
+
+- **Operator-requested aborts are quiet, intentional outcomes** (field
+  incident 2026-07-15: a Stop during a delegated optimization run cleaned
+  up perfectly yet produced three ERROR blocks).
+  - `GeecsSession.scan` / `GeecsSession.optimize` catch
+    `bluesky.utils.RunEngineInterrupted` at their `RE(...)` call sites.
+    When the engine settled back to `idle` (an `RE.abort()`/`RE.stop()`
+    — bluesky raises the same type for a pause, which leaves the engine
+    `paused`), they log one INFO line and **return the aborted outcome
+    instead of raising**, with the new session attribute
+    `last_run_aborted` set so callers distinguish completed vs aborted
+    without exceptions.  A pause still propagates.  Optimize's
+    `on_finish` restore-to-initial runs on the quiet abort branch (no
+    longer rides the propagating exception); abort still restores
+    *initial*, never best, and `finish()`-style post-run bookkeeping is
+    still skipped.
+  - `BlueskyScanner._run_scan` no longer logs the generic ERROR
+    "scan thread raised an exception" traceback when `_abort_requested`
+    is set — one INFO line, same ABORTED state.  Genuine exceptions
+    (no abort requested) keep the full ERROR traceback.
+  - `log_claimed_scan_failure` grew an `aborted` flag: an
+    operator-requested abort draws one calm WARNING ("aborted by
+    operator; folder … kept (never deleted) — partial data may be
+    present") instead of the failure ERROR, which is unchanged for
+    genuine failures.  The bridge (`_execute_scan`,
+    `_run_optimization`) and the delegated optimize runner thread the
+    distinction through.
+
 ## [0.35.0] - 2026-07-14
 
 ### Added

--- a/GeecsBluesky/geecs_bluesky/scan_log.py
+++ b/GeecsBluesky/geecs_bluesky/scan_log.py
@@ -55,14 +55,20 @@ class ScanLogContextFilter(logging.Filter):
 
 
 def log_claimed_scan_failure(
-    scan_number: int | None, scan_folder: str | None, *, label: str = "Scan"
+    scan_number: int | None,
+    scan_folder: str | None,
+    *,
+    label: str = "Scan",
+    aborted: bool = False,
 ) -> None:
-    """Log loudly that a claimed scan folder was left behind by a failure.
+    """Log that a claimed scan folder was left behind by a failure or abort.
 
     The folder is never deleted (scan-folder lifecycle invariant: once a
     ``scans/ScanNNN/`` folder exists it must not be removed or recreated),
-    so the claimed-but-failed state is surfaced instead of being silent.
-    A no-op when nothing was claimed.
+    so the claimed-but-not-completed state is surfaced instead of being
+    silent.  A genuine failure is an ERROR; an operator-requested abort
+    (``aborted=True``) is an intentional outcome and gets one calm WARNING
+    instead.  A no-op when nothing was claimed.
 
     Parameters
     ----------
@@ -72,8 +78,20 @@ def log_claimed_scan_failure(
         The claimed ``scans/ScanNNN`` folder path.
     label : str
         Message prefix naming the scan kind (e.g. ``"Optimization scan"``).
+    aborted : bool
+        ``True`` when the scan ended because the operator requested an
+        abort (WARNING, calm wording) rather than failing (ERROR).
     """
     if scan_number is None and scan_folder is None:
+        return
+    if aborted:
+        logger.warning(
+            "%s %s aborted by operator; folder %s kept (never deleted) — "
+            "partial data may be present",
+            label,
+            scan_number,
+            scan_folder,
+        )
         return
     logger.error(
         "%s %s failed or aborted after its folder was claimed at %s; "

--- a/GeecsBluesky/geecs_bluesky/scan_request_runner.py
+++ b/GeecsBluesky/geecs_bluesky/scan_request_runner.py
@@ -1308,6 +1308,16 @@ def _run_optimize_request(
                     scan_number=scan_number,
                     scan_folder=scan_folder,
                 )
+            if claimed_here and getattr(session, "last_run_aborted", False):
+                # session.optimize returned the aborted outcome quietly
+                # (operator-requested); note the claimed-but-partial folder
+                # calmly (WARNING) instead of the failure ERROR.
+                log_claimed_scan_failure(
+                    scan_number,
+                    scan_folder,
+                    label="Optimization scan",
+                    aborted=True,
+                )
             return uid
         except BaseException:
             if claimed_here:

--- a/GeecsBluesky/geecs_bluesky/scanner_bridge/bluesky_scanner.py
+++ b/GeecsBluesky/geecs_bluesky/scanner_bridge/bluesky_scanner.py
@@ -1014,9 +1014,18 @@ class BlueskyScanner:
                 logger.warning(
                     "BlueskyScanner: scan mode %r not yet supported; skipping", mode_val
                 )
-        except Exception:
-            failed = True
-            logger.exception("BlueskyScanner scan thread raised an exception")
+        except Exception as exc:
+            if self._abort_requested:
+                # Operator-requested abort: anything unwinding out of the
+                # scan here is part of the stop, not a failure — one INFO
+                # line, no traceback (ABORTED state is set below either way).
+                logger.info(
+                    "BlueskyScanner: scan thread exiting after operator abort (%s)",
+                    exc,
+                )
+            else:
+                failed = True
+                logger.exception("BlueskyScanner scan thread raised an exception")
         finally:
             self._disconnect_devices_sync()
             # Cleanup is complete: mark inactive BEFORE emitting the terminal
@@ -1083,9 +1092,12 @@ class BlueskyScanner:
             on_scan_start=self._on_delegated_scan_start,
             optimization_binder=optimization_binder,
         )
-        if opt_bridge is not None:
+        if opt_bridge is not None and not getattr(
+            self._session, "last_run_aborted", False
+        ):
             # Post-run bookkeeping owned by the bridge (legacy parity with
-            # _run_optimization); skipped on failure — exceptions propagate.
+            # _run_optimization); skipped on failure (exceptions propagate)
+            # and on an operator abort (the quiet aborted-outcome return).
             finish = getattr(opt_bridge, "finish", None)
             if callable(finish):
                 finish()
@@ -1359,13 +1371,21 @@ class BlueskyScanner:
                     # legacy move_to_best_on_finish flag) onto the session's.
                     on_finish=getattr(bridge, "on_finish", "hold"),
                 )
-                # Post-run bookkeeping owned by the bridge (e.g. the legacy
-                # xopt_dump.yaml written into the scan folder).
-                finish = getattr(bridge, "finish", None)
-                if callable(finish):
-                    finish()
+                if getattr(self._session, "last_run_aborted", False):
+                    # Aborted outcome returned quietly: note the folder
+                    # calmly and skip finish() (legacy parity — the
+                    # exception path never ran it on abort either).
+                    log_claimed_scan_failure(scan_number, scan_folder, aborted=True)
+                else:
+                    # Post-run bookkeeping owned by the bridge (e.g. the
+                    # legacy xopt_dump.yaml written into the scan folder).
+                    finish = getattr(bridge, "finish", None)
+                    if callable(finish):
+                        finish()
         except BaseException:
-            log_claimed_scan_failure(scan_number, scan_folder)
+            log_claimed_scan_failure(
+                scan_number, scan_folder, aborted=self._abort_requested
+            )
             raise
 
     def _execute_scan(
@@ -1464,8 +1484,14 @@ class BlueskyScanner:
                     scan_info=scan_info,
                 )
         except BaseException:
-            log_claimed_scan_failure(scan_number, scan_folder)
+            log_claimed_scan_failure(
+                scan_number, scan_folder, aborted=self._abort_requested
+            )
             raise
+        if getattr(self._session, "last_run_aborted", False):
+            # session.scan returned the aborted outcome quietly; note the
+            # claimed-but-partial folder calmly (WARNING, not ERROR).
+            log_claimed_scan_failure(scan_number, scan_folder, aborted=True)
 
     def _build_session_devices(self) -> list:
         """Create CA devices from the GUI device table via the session factories.

--- a/GeecsBluesky/geecs_bluesky/session.py
+++ b/GeecsBluesky/geecs_bluesky/session.py
@@ -35,6 +35,7 @@ from typing import Any, Callable, Sequence
 
 import numpy as np
 from bluesky import RunEngine
+from bluesky.utils import RunEngineInterrupted
 
 from geecs_bluesky.data_paths import asset_resource_root_paths, device_server_save_path
 from geecs_bluesky.exceptions import GeecsConfigurationError
@@ -127,6 +128,11 @@ class GeecsSession:
         # context_managers=[] so sessions also work off the main thread.
         self.RE = RunEngine(context_managers=[])
         self._last_run_uid: str | None = None
+        #: ``True`` when the most recent :meth:`scan`/:meth:`optimize` ended
+        #: in an operator-requested abort (``RE.abort()``/``RE.stop()``) —
+        #: those calls return the aborted outcome instead of raising, and
+        #: callers distinguish completed vs aborted through this flag.
+        self.last_run_aborted: bool = False
         self.RE.subscribe(self._remember_uid, name="start")
         if tiled:
             subscribe_tiled(self.RE, tiled_uri, tiled_api_key)
@@ -556,6 +562,13 @@ class GeecsSession:
         (after the move, before the shots), closeout in a finalize wrapper
         that runs even on abort, after the trigger disarm.  See
         :func:`~geecs_bluesky.plans.orchestration.build_step_scan_plan`.
+
+        An operator-requested abort (``RE.abort()``/``RE.stop()`` while the
+        plan runs) is an intentional outcome, not a failure: the run uid (of
+        the partial run, when one started) is returned normally with
+        :attr:`last_run_aborted` set ``True`` and one INFO line logged.  A
+        *pause* still propagates :class:`~bluesky.utils.RunEngineInterrupted`
+        (the operator may resume).
         """
         if mode not in (_FREE_RUN, _STRICT):
             raise ValueError(f"mode={mode!r} invalid; use 'free_run' or 'strict'")
@@ -635,12 +648,30 @@ class GeecsSession:
         )
 
         self._last_run_uid = None
+        self.last_run_aborted = False
         # Headless scans get the same per-scan scan.log as bridge scans
         # (Gate-2 finding).  Attach only when this call claimed the number:
         # a pre-claimed number means the caller (e.g. the GUI bridge) owns
         # the scan.log handler, and a second one would duplicate every line.
         with scan_log(scan_number, scan_folder) if claimed_here else nullcontext():
-            self.RE(plan)
+            try:
+                self.RE(plan)
+            except RunEngineInterrupted:
+                if self.RE.state == "paused":
+                    # A pause is not a settled outcome — the operator may
+                    # still resume; keep today's propagation behavior.
+                    raise
+                # The engine settled back to idle: an operator-requested
+                # abort/stop.  The plan's finalize chain (save-off, disarm)
+                # already ran inside the engine's cleanup, so this is an
+                # intentional outcome, not a failure — report it quietly.
+                self.last_run_aborted = True
+                logger.info(
+                    "Scan %s aborted by operator; cleanup completed "
+                    "(trigger disarmed, saving stopped)",
+                    scan_number if scan_number is not None else "(unsaved)",
+                )
+                return self._last_run_uid
 
             if save_data and self._last_run_uid and scan_number is not None:
                 self._export_scalar_files(scan_number)
@@ -698,6 +729,15 @@ class GeecsSession:
         scan_number, scan_folder:
             Pre-claimed scan number/folder (as in :meth:`scan`).  When omitted
             and *save_data* is true, they are claimed here.
+
+        Notes
+        -----
+        An operator-requested abort is an intentional outcome, not a
+        failure: ``(uid, history)`` for the completed iterations is
+        returned normally with :attr:`last_run_aborted` set ``True``, the
+        ``on_finish`` restore-to-initial still runs (abort restores
+        *initial*, never best), and one INFO line is logged.  A *pause*
+        still propagates :class:`~bluesky.utils.RunEngineInterrupted`.
         """
         if mode not in (_FREE_RUN, _STRICT):
             raise ValueError(f"mode={mode!r} invalid; use 'free_run' or 'strict'")
@@ -844,14 +884,45 @@ class GeecsSession:
         with scan_log(scan_number, scan_folder) if claimed_here else nullcontext():
             token = self.RE.subscribe(_collect)
             self._last_run_uid = None
+            self.last_run_aborted = False
+            aborted = False
             try:
                 self.RE(run_plan)
+            except RunEngineInterrupted:
+                if self.RE.state == "paused":
+                    # A pause is not a settled outcome (the operator may
+                    # resume) — keep today's restore-and-propagate behavior.
+                    if on_finish in ("initial", "best"):
+                        self._move_movables(variables, initial_values)
+                    raise
+                aborted = True
             except BaseException:
                 if on_finish in ("initial", "best"):
                     self._move_movables(variables, initial_values)
                 raise
             finally:
                 self.RE.unsubscribe(token)
+            if aborted:
+                # Operator-requested abort: the engine settled back to idle
+                # and its cleanup (finalize disarm) already ran.  Restore the
+                # variables exactly as the exception path always has (abort
+                # restores *initial*, never best — docstring contract), then
+                # return the aborted outcome quietly instead of raising.
+                self.last_run_aborted = True
+                if on_finish in ("initial", "best"):
+                    self._move_movables(variables, initial_values)
+                logger.info(
+                    "Optimization scan %s aborted by operator; cleanup "
+                    "completed (%d iteration(s) recorded%s)",
+                    scan_number if scan_number is not None else "(unsaved)",
+                    len(history),
+                    (
+                        "; variables restored to initial values"
+                        if on_finish in ("initial", "best")
+                        else ""
+                    ),
+                )
+                return self._last_run_uid, history
             _observe_previous(len(history) + 1)  # final bin
 
             if on_finish in ("initial", "best"):

--- a/GeecsBluesky/pyproject.toml
+++ b/GeecsBluesky/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-bluesky"
-version = "0.35.0"
+version = "0.36.0"
 description = "Bluesky / ophyd-async bridge for the GEECS control system"
 authors = ["Sam Barber <sbarber@lbl.gov>"]
 readme = "README.md"

--- a/GeecsBluesky/tests/test_bluesky_scanner_scan_lifecycle.py
+++ b/GeecsBluesky/tests/test_bluesky_scanner_scan_lifecycle.py
@@ -737,3 +737,192 @@ def test_reference_abort_message_names_the_failing_devices() -> None:
 
     assert "U_RefCam" in str(excinfo.value)
     assert "connect failed" in str(excinfo.value)
+
+
+# ---------------------------------------------------------------------------
+# Operator-requested aborts are quiet (0.36.0) — no ERROR tracebacks
+# ---------------------------------------------------------------------------
+
+
+def test_scan_thread_operator_abort_logs_info_not_error(monkeypatch, caplog) -> None:
+    """An exception unwinding after Stop is one INFO line, not a traceback."""
+    session = _FakeSession()
+    scanner = _make_scanner(
+        session, {"U_Cam": {"synchronous": True, "variable_list": ["Sig"]}}
+    )
+    monkeypatch.setattr(bluesky_scanner, "ScanState", None)
+    _patch_claim(monkeypatch, [], result=(7, "/nonexistent/scans/Scan007"))
+    monkeypatch.setattr(
+        scanner,
+        "_preflight_check_sync_liveness",
+        lambda detectors, strict, **kw: detectors,
+    )
+
+    def scan_stopped_mid_run(**kwargs):
+        # The operator's Stop: the flag is set and something unwinds out of
+        # the interrupted run (the shape of the 2026-07-15 field incident).
+        scanner._abort_requested = True
+        raise RuntimeError("unwinding after RE.abort()")
+
+    session.scan = scan_stopped_mid_run
+
+    with caplog.at_level(logging.INFO):
+        scanner._run_scan(_noscan_config())
+
+    assert scanner.current_state == "aborted"
+    errors = [r for r in caplog.records if r.levelno >= logging.ERROR]
+    assert errors == [], "operator abort must not produce ERROR records"
+    assert any(
+        "exiting after operator abort" in r.getMessage() and r.levelno == logging.INFO
+        for r in caplog.records
+    )
+    # The claimed-folder note is the calm WARNING variant.
+    assert any(
+        "aborted by operator" in r.getMessage() and r.levelno == logging.WARNING
+        for r in caplog.records
+    )
+
+
+def test_scan_thread_genuine_failure_keeps_error_traceback(monkeypatch, caplog) -> None:
+    """Without an abort request, a raising scan thread still ERRORs loudly."""
+    session = _FakeSession()
+    scanner = _make_scanner(
+        session, {"U_Cam": {"synchronous": True, "variable_list": ["Sig"]}}
+    )
+    monkeypatch.setattr(bluesky_scanner, "ScanState", None)
+    _patch_claim(monkeypatch, [], result=(7, "/nonexistent/scans/Scan007"))
+    monkeypatch.setattr(
+        scanner,
+        "_preflight_check_sync_liveness",
+        lambda detectors, strict, **kw: detectors,
+    )
+
+    def scan_blows_up(**kwargs):
+        raise RuntimeError("genuine failure")
+
+    session.scan = scan_blows_up
+
+    with caplog.at_level(logging.INFO):
+        scanner._run_scan(_noscan_config())
+
+    assert scanner.current_state == "aborted"
+    tracebacks = [
+        r
+        for r in caplog.records
+        if r.levelno == logging.ERROR
+        and "scan thread raised an exception" in r.getMessage()
+    ]
+    assert len(tracebacks) == 1 and tracebacks[0].exc_info is not None
+    assert any(
+        "failed or aborted" in r.getMessage() and r.levelno == logging.ERROR
+        for r in caplog.records
+    ), "the genuine-failure claimed-folder note must stay ERROR"
+
+
+def test_operator_abort_quiet_return_notes_folder_calmly(monkeypatch, caplog) -> None:
+    """session.scan's quiet aborted return → calm folder WARNING, no ERROR."""
+    session = _FakeSession()
+    scanner = _make_scanner(
+        session, {"U_Cam": {"synchronous": True, "variable_list": ["Sig"]}}
+    )
+    monkeypatch.setattr(bluesky_scanner, "ScanState", None)
+    _patch_claim(monkeypatch, [], result=(7, "/nonexistent/scans/Scan007"))
+    monkeypatch.setattr(
+        scanner,
+        "_preflight_check_sync_liveness",
+        lambda detectors, strict, **kw: detectors,
+    )
+
+    def scan_aborted_quietly(**kwargs):
+        scanner._abort_requested = True  # Stop arrived while the RE ran
+        session.last_run_aborted = True  # session translated it quietly
+        return "uid"
+
+    session.scan = scan_aborted_quietly
+
+    with caplog.at_level(logging.INFO):
+        scanner._run_scan(_noscan_config())
+
+    assert scanner.current_state == "aborted"
+    assert [r for r in caplog.records if r.levelno >= logging.ERROR] == []
+    notes = [
+        r
+        for r in caplog.records
+        if "aborted by operator" in r.getMessage() and "kept" in r.getMessage()
+    ]
+    assert [r.levelno for r in notes] == [logging.WARNING]
+
+
+def test_optimization_operator_abort_skips_finish_and_stays_calm(
+    monkeypatch, caplog
+) -> None:
+    """An aborted optimization skips bridge.finish() (legacy parity) quietly."""
+
+    class _FinishTrackingBridge(_FakeBridge):
+        def __init__(self) -> None:
+            super().__init__()
+            self.finished = False
+
+        def finish(self) -> None:
+            self.finished = True
+
+    session = _FakeSession()
+    scanner = _make_scanner(
+        session, {"U_Cam": {"synchronous": True, "variable_list": ["Sig"]}}
+    )
+    bridge = _FinishTrackingBridge()
+    scanner._optimization_loader = lambda path: bridge
+    monkeypatch.setattr(bluesky_scanner, "ScanState", None)
+    _patch_claim(
+        monkeypatch, [], result=(SimpleNamespace(number=7), "/nonexistent/Scan007")
+    )
+
+    def optimize_aborted(**kwargs):
+        session.optimize_kwargs = kwargs
+        scanner._abort_requested = True
+        session.last_run_aborted = True
+        return "uid", []
+
+    session.optimize = optimize_aborted
+
+    with caplog.at_level(logging.INFO):
+        scanner._run_scan(
+            SimpleNamespace(
+                scan_mode="optimization",
+                optimizer_config_path="/cfg/opt.yaml",
+                start=0.0,
+                end=1.0,
+                step=1.0,
+                wait_time=1.0,
+                additional_description="",
+            )
+        )
+
+    assert scanner.current_state == "aborted"
+    assert bridge.finished is False, "finish() must not run after an abort"
+    assert [r for r in caplog.records if r.levelno >= logging.ERROR] == []
+    assert any(
+        "aborted by operator" in r.getMessage() and r.levelno == logging.WARNING
+        for r in caplog.records
+    )
+
+
+def test_optimization_normal_completion_still_runs_finish(monkeypatch) -> None:
+    """The abort guard must not eat the successful-run finish() bookkeeping."""
+
+    class _FinishTrackingBridge(_FakeBridge):
+        def __init__(self) -> None:
+            super().__init__()
+            self.finished = False
+
+        def finish(self) -> None:
+            self.finished = True
+
+    session = _FakeSession()
+    scanner = _make_scanner(
+        session, {"U_Cam": {"synchronous": True, "variable_list": ["Sig"]}}
+    )
+    bridge = _FinishTrackingBridge()
+    _run_optimization_with_bridge(monkeypatch, scanner, bridge)
+
+    assert bridge.finished is True

--- a/GeecsBluesky/tests/test_operator_abort.py
+++ b/GeecsBluesky/tests/test_operator_abort.py
@@ -1,0 +1,259 @@
+"""Operator-requested aborts are quiet, intentional outcomes (0.36.0).
+
+Field incident (2026-07-15): an operator's Stop during a delegated
+optimization run cleaned up perfectly (finalize disarm, ``exit_status
+'abort'``, on_finish restore) yet the logs showed three ERROR blocks —
+``RunEngineInterrupted`` escaping ``session.scan``/``session.optimize``,
+the bridge's generic "scan thread raised an exception" traceback, and the
+claimed-folder ERROR.  These tests pin the translation:
+
+- the session catches ``RunEngineInterrupted`` at both ``RE(...)`` call
+  sites and, when the engine settled back to ``idle`` (an abort/stop —
+  bluesky raises the same type for a pause, which leaves the engine
+  ``paused``), returns the aborted outcome with ``last_run_aborted`` set
+  and one INFO line instead of raising;
+- a *pause* still propagates (the operator may resume);
+- optimize's on_finish restore-to-initial runs on the quiet abort path
+  without depending on the exception propagating;
+- ``log_claimed_scan_failure(aborted=True)`` is a calm WARNING, and the
+  genuine-failure ERROR is unchanged.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+import time
+
+import pytest
+
+pytest.importorskip("aioca")
+
+from bluesky.utils import RunEngineInterrupted  # noqa: E402
+from ophyd_async.core import callback_on_mock_put, set_mock_value  # noqa: E402
+
+from geecs_bluesky.scan_log import log_claimed_scan_failure  # noqa: E402
+from geecs_bluesky.session import GeecsSession  # noqa: E402
+from tests.ca_mock_helpers import start_pacer  # noqa: E402
+
+
+def _session() -> GeecsSession:
+    return GeecsSession("TestExp", tiled=False, mock=True)
+
+
+def _abort_when_running(run_engine, *, settle_s: float = 0.5) -> threading.Thread:
+    """Fire ``RE.abort()`` from another thread once the plan is running.
+
+    The operator's Stop button: ``stop_scanning_thread`` calls
+    ``RE.abort(reason=...)`` from the GUI thread while ``RE(plan)`` blocks
+    the scan thread.
+    """
+
+    def aborter() -> None:
+        deadline = time.monotonic() + 15.0
+        while time.monotonic() < deadline:
+            if run_engine.state == "running":
+                time.sleep(settle_s)  # let the plan get properly underway
+                try:
+                    run_engine.abort(reason="operator clicked stop")
+                except Exception:
+                    pass  # the plan may have finished inside the window
+                return
+            time.sleep(0.01)
+
+    thread = threading.Thread(target=aborter, daemon=True, name="operator-stop")
+    thread.start()
+    return thread
+
+
+def _package_errors(caplog) -> list[logging.LogRecord]:
+    """ERROR-or-worse records from this package's loggers."""
+    return [
+        r
+        for r in caplog.records
+        if r.levelno >= logging.ERROR and r.name.startswith("geecs_bluesky")
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Session: real RunEngine, real abort from another thread (mock CA devices)
+# ---------------------------------------------------------------------------
+
+
+def test_scan_abort_mid_plan_returns_quietly(caplog) -> None:
+    """RE.abort() mid-scan: scan() returns (no raise), one INFO, no ERROR."""
+    s = _session()
+    det = s.detector("U_Cam", ["Sig"])
+    set_mock_value(det.acq_timestamp, 1000.0)
+    pacer = start_pacer(s.RE, [(det, 1000.0)], initial_delay=0.4, interval=0.05)
+    aborter = _abort_when_running(s.RE)
+    try:
+        with caplog.at_level(logging.INFO, logger="geecs_bluesky"):
+            s.scan(
+                detectors=[det],
+                motor=None,
+                positions=[None],
+                shots_per_step=200,
+                mode="free_run",
+                save_data=False,
+            )
+    finally:
+        pacer.cancel()
+        aborter.join(timeout=15.0)
+        s.disconnect(det)
+
+    assert s.last_run_aborted is True
+    quiet = [
+        r
+        for r in caplog.records
+        if "aborted by operator" in r.getMessage() and r.name == "geecs_bluesky.session"
+    ]
+    assert len(quiet) == 1 and quiet[0].levelno == logging.INFO
+    assert _package_errors(caplog) == [], (
+        "an operator abort must not produce ERROR records from this package"
+    )
+
+
+def test_optimize_abort_restores_initial_and_returns_history(caplog) -> None:
+    """RE.abort() mid-optimize: quiet return and on_finish restore still runs."""
+    s = _session()
+    cam = s.detector("UC_Cam", ["Sig"], name="cam")
+    knob = s.settable("U_S1H", "Current", name="s1h")
+    callback_on_mock_put(
+        knob._setpoint, lambda v, **kw: set_mock_value(knob.readback, v)
+    )
+    set_mock_value(knob.readback, 5.0)  # pre-optimization value to restore
+    set_mock_value(cam.acq_timestamp, 1000.0)
+
+    class _EndlessSuggester:
+        def suggest(self):
+            return {"s1h": 0.25}  # never stops — only the abort ends the run
+
+        def observe(self, inputs, objective, bin_data):
+            pass
+
+    pacer = start_pacer(s.RE, [(cam, 1000.0)], initial_delay=0.4, interval=0.05)
+    aborter = _abort_when_running(s.RE, settle_s=0.8)
+    try:
+        with caplog.at_level(logging.INFO, logger="geecs_bluesky"):
+            _uid, history = s.optimize(
+                variables={"s1h": knob},
+                detectors=[cam],
+                objective=lambda bin_data: 1.0,
+                suggester=_EndlessSuggester(),
+                shots_per_iteration=2,
+                max_iterations=1000,
+                save_data=False,
+                on_finish="initial",
+            )
+    finally:
+        pacer.cancel()
+        aborter.join(timeout=15.0)
+        s.disconnect(cam, knob)
+
+    assert s.last_run_aborted is True
+    assert isinstance(history, list)  # completed iterations, returned not raised
+    # The restore no longer rides the exception path: it ran on the quiet
+    # abort branch, driving the knob back to its pre-optimization value.
+    assert s._read_movable(knob) == pytest.approx(5.0)
+    assert _package_errors(caplog) == []
+    assert any(
+        "aborted by operator" in r.getMessage()
+        for r in caplog.records
+        if r.name == "geecs_bluesky.session" and r.levelno == logging.INFO
+    )
+
+
+# ---------------------------------------------------------------------------
+# Session: the abort-vs-pause distinction (deterministic fake-RE pins)
+# ---------------------------------------------------------------------------
+
+
+class _InterruptingRE:
+    """Stands in for a RunEngine whose ``__call__`` was interrupted.
+
+    Bluesky raises the same ``RunEngineInterrupted`` for a pause and for an
+    abort/stop; the difference is the settled engine state — ``paused``
+    (resumable) vs ``idle`` (the ``_run`` coroutine's cleanup finished and
+    reset the state before the blocked ``RE(...)`` call raises).
+    """
+
+    def __init__(self, state: str) -> None:
+        self.state = state
+
+    def __call__(self, plan) -> None:
+        plan.close()
+        raise RunEngineInterrupted("boilerplate pause message")
+
+
+def test_settled_interruption_returns_aborted_outcome(caplog) -> None:
+    """Interrupted with the engine idle (abort/stop) → quiet aborted return."""
+    s = _session()
+    det = s.detector("U_Cam", ["Sig"])
+    real_re = s.RE
+    s.RE = _InterruptingRE("idle")  # type: ignore[assignment]
+    try:
+        with caplog.at_level(logging.INFO, logger="geecs_bluesky"):
+            uid = s.scan(
+                detectors=[det],
+                motor=None,
+                positions=[None],
+                shots_per_step=1,
+                save_data=False,
+            )
+    finally:
+        s.RE = real_re
+        s.disconnect(det)
+
+    assert uid is None
+    assert s.last_run_aborted is True
+    assert any("aborted by operator" in r.getMessage() for r in caplog.records)
+    assert _package_errors(caplog) == []
+
+
+def test_paused_interruption_still_raises() -> None:
+    """Interrupted with the engine paused → propagate (the operator may resume)."""
+    s = _session()
+    det = s.detector("U_Cam", ["Sig"])
+    real_re = s.RE
+    s.RE = _InterruptingRE("paused")  # type: ignore[assignment]
+    try:
+        with pytest.raises(RunEngineInterrupted):
+            s.scan(
+                detectors=[det],
+                motor=None,
+                positions=[None],
+                shots_per_step=1,
+                save_data=False,
+            )
+    finally:
+        s.RE = real_re
+        s.disconnect(det)
+
+    assert s.last_run_aborted is False
+
+
+# ---------------------------------------------------------------------------
+# scan_log: the claimed-folder note is calm on abort, loud on failure
+# ---------------------------------------------------------------------------
+
+
+def test_claimed_scan_abort_note_is_calm_warning(caplog) -> None:
+    with caplog.at_level(logging.INFO, logger="geecs_bluesky.scan_log"):
+        log_claimed_scan_failure(
+            7, "/data/scans/Scan007", label="Optimization scan", aborted=True
+        )
+    [record] = caplog.records
+    assert record.levelno == logging.WARNING
+    message = record.getMessage()
+    assert "aborted by operator" in message
+    assert "never deleted" in message
+    assert "partial data may be present" in message
+
+
+def test_claimed_scan_failure_note_stays_error(caplog) -> None:
+    with caplog.at_level(logging.INFO, logger="geecs_bluesky.scan_log"):
+        log_claimed_scan_failure(7, "/data/scans/Scan007")
+    [record] = caplog.records
+    assert record.levelno == logging.ERROR
+    assert "failed or aborted" in record.getMessage()

--- a/GeecsBluesky/tests/test_scan_request_runner.py
+++ b/GeecsBluesky/tests/test_scan_request_runner.py
@@ -1970,3 +1970,45 @@ def test_on_scan_start_totals_for_grid(legacy_resolver) -> None:
         on_scan_start=lambda steps, shots: calls.append((steps, shots)),
     )
     assert calls == [(6, 18)]  # shots_per_step=3
+
+
+def test_optimize_binder_operator_abort_notes_folder_calmly(
+    legacy_resolver, monkeypatch, caplog
+) -> None:
+    """A quiet aborted optimize return draws the calm WARNING, never the ERROR."""
+    import geecs_bluesky.scan_request_runner as runner_module
+
+    tag = SimpleNamespace(number=7)
+    monkeypatch.setattr(
+        runner_module,
+        "claim_scan",
+        lambda experiment: (tag, "/nonexistent/scans/Scan007"),
+    )
+    session = _FakeSession()
+
+    def optimize_aborted_by_operator(**kwargs):
+        session.optimize_kwargs = kwargs
+        session.last_run_aborted = True  # session.optimize's quiet abort return
+        return "uid-opt", []
+
+    session.optimize = optimize_aborted_by_operator
+
+    with caplog.at_level(logging.INFO):
+        uid = run_scan_request(
+            session,
+            _optimize_request(),
+            legacy_resolver,
+            optimization_binder=lambda **_kw: (object(), object()),
+        )
+
+    assert uid == "uid-opt"
+    assert [r for r in caplog.records if r.levelno >= logging.ERROR] == [], (
+        "an operator-requested abort must not log ERROR records"
+    )
+    notes = [
+        r
+        for r in caplog.records
+        if "aborted by operator" in r.getMessage()
+        and "Optimization scan" in r.getMessage()
+    ]
+    assert [r.levelno for r in notes] == [logging.WARNING]


### PR DESCRIPTION
## What & why

Field incident (2026-07-15, live): the operator clicked Stop during a delegated optimization run. Cleanup worked perfectly — finalize ran, shot controller went to STANDBY, `exit_status='abort'`, the on_finish restore-to-initial executed — but the logs showed three scary blocks: (1) bluesky's own `ERROR bluesky: Run aborted` + RequestAbort traceback, (2) our scan_log ERROR "Optimization scan N failed or aborted after its folder was claimed…", and (3) a `RunEngineInterrupted` traceback (with bluesky's misleading "RE.resume()…" pause boilerplate) escaping `session.optimize` up through the bridge's generic "scan thread raised an exception" ERROR handler. Nothing translated "the operator asked for this" into a normal outcome.

This PR makes an operator-requested abort a quiet, intentional outcome while keeping genuine failures exactly as loud as before.

### Distinguishing abort from pause (the design question)

Bluesky raises the **same** `RunEngineInterrupted` for a pause and for an abort/stop/halt. The reliable discriminator is the settled engine state at raise time, verified against the installed bluesky source (`run_engine.py`):

- On abort/stop/halt from another thread, the `_run` coroutine's `finally` sets `self._state = "idle"` *inside the coroutine*, i.e. strictly before the task future resolves — and the blocked `RE(plan)` call only raises after that future completes. So `RE.state == "idle"` at catch time deterministically means the interruption **settled** (cleanup done, stop doc emitted).
- On a pause, `RE(plan)` raises while `RE.state == "paused"` — a resumable, not-settled situation.

`GeecsSession.scan`/`optimize` therefore catch `RunEngineInterrupted`; `paused` → re-raise (today's behavior, the operator may resume); otherwise → the quiet aborted outcome. Since the session's RE has SIGINT handling disabled (`context_managers=[]`) and plans can't raise this type themselves, a settled interruption can only come from an explicit external `abort()`/`stop()` — i.e. an operator request.

### The return contract (completed vs aborted without exceptions)

A session attribute — `GeecsSession.last_run_aborted: bool`, reset at the start of every `scan()`/`optimize()` — rather than a new return type. Rationale: `scan()` keeps returning `str | None` (uid) and `optimize()` keeps `(uid, history)`, so the runner (`run_scan_request` returns the uid through three layers) and every existing caller signature stay untouched; the two callers that care (bridge, delegated optimize runner) read the flag right after the call. A result object would have rippled through the runner/bridge shapes for one bit of information.

### What each layer now does on an operator abort

- **Session**: one INFO line ("aborted by operator; cleanup completed…"), returns the aborted outcome. Optimize's on_finish restore-to-initial runs on the quiet branch (no longer rides the propagating exception); abort still restores *initial*, never best (docstring contract), and the post-run extras (final-bin observe, `optimization.json`, s-file export) are skipped exactly as the old exception path skipped them.
- **Bridge** (`_run_scan`): with `_abort_requested` set, an exception unwinding out of the scan thread is one INFO line, no traceback; ABORTED state exactly as today. Genuine exceptions (no abort requested) keep the full `logger.exception` traceback. `finish()` bookkeeping (legacy `xopt_dump.yaml`) is skipped on abort on both optimize paths — legacy parity, the exception path never ran it.
- **scan_log** (`log_claimed_scan_failure`): new `aborted` flag → one calm WARNING ("aborted by operator; folder … kept (never deleted) — partial data may be present"); the genuine-failure ERROR is byte-identical to before. The bridge's `_execute_scan`/`_run_optimization` and the delegated optimize runner thread the distinction through (including `aborted=self._abort_requested` on their exception paths, so something raising *during* a stop is also calm).

### Bluesky's own "Run aborted" ERROR (deliberately untouched)

Block (1) of the incident comes from the RunEngine's own logger inside its `_run` coroutine (`self.log.exception("Run aborted")` on RequestAbort/CancelledError) — upstream's logger, not ours. Sanctioned follow-up rather than a hack: bluesky documents per-logger configuration on the `bluesky` logger namespace, so the console/GUI entry point could raise that logger's level or attach a record filter for RequestAbort tracebacks if the one remaining upstream block is still too loud in practice. Left out of this PR.

## Per-concern LOC breakdown

- Session quiet-abort handling + `last_run_aborted` + docstrings (`session.py`): +72 / −1
- Bridge INFO-not-ERROR, finish-skip, calm folder notes (`scanner_bridge/bluesky_scanner.py`): +38 / −12
- `log_claimed_scan_failure(aborted=...)` (`scan_log.py`): +22 / −4
- Delegated optimize runner calm note (`scan_request_runner.py`): +10 / −0
- Tests: new `tests/test_operator_abort.py` +260; `tests/test_bluesky_scanner_scan_lifecycle.py` +189; `tests/test_scan_request_runner.py` +42
- Version bump + CHANGELOG: +32 / −1

Judgment calls flagged for cheap veto:
- Aborted optimize does **not** write `optimization.json` / run the final-bin observe (parity with the old exception path). Writing the partial history on abort would be genuinely useful — happy to do as a follow-up, kept out of scope here.
- The bridge exception paths now pass `aborted=self._abort_requested` into the claimed-folder note, so a *raising* stop is calm too (not just the clean quiet return).

## Checklist

- [x] `poetry version minor` (GeecsBluesky 0.35.0 → 0.36.0; origin/dev still at 0.35.0 — no version race at time of writing, no open PR bumps GeecsBluesky)
- [x] `CHANGELOG.md` entry added under 0.36.0
- [x] Tests: exact counts below
- [x] Base branch: `dev` (vision-world work, GeecsBluesky)
- [x] Public-repo hygiene: no lab accounts/hostnames/home paths

## Tests

- `./scripts/check.sh` (scoped): lint passed; **GeecsBluesky 502 passed, 3 deselected** (~490 baseline + 12 new: 6 in `tests/test_operator_abort.py` — two real `RE.abort()`-from-another-thread integration tests for scan and optimize (restore-to-initial pinned), two deterministic fake-RE pins of the idle-vs-paused distinction, two `log_claimed_scan_failure` level/wording pins; 5 in `test_bluesky_scanner_scan_lifecycle.py` — abort → INFO + no ERROR records, genuine failure → ERROR traceback kept, quiet-return folder note is the WARNING variant, aborted optimization skips `finish()`, normal completion still runs `finish()`; 1 in `test_scan_request_runner.py` — delegated optimize abort notes the folder as WARNING with zero ERROR records).
- Full local sweep (`--all` equivalent; the fresh worktree's missing envs were installed per /env-doctor, then every locally runnable suite ran the CI way): ImageAnalysis **224 passed, 1 skipped, 10 deselected**; ScanAnalysis **171 passed, 1 skipped, 11 deselected**; GEECS-Data-Utils **197 passed**; GEECS-Schemas **211 passed, 7 deselected**; GeecsCAGateway **181 passed**; GEECS-Console **679 passed**; GEECS-LogTriage **53 passed**. (No other package references the changed surfaces — verified by grep for `log_claimed_scan_failure` / `last_run_aborted` / `RunEngineInterrupted` / the old ERROR wording across GEECS-Console, GEECS-Scanner-GUI, GEECS-LogTriage.)

## Hardware verification

**OWED**: one live abort of an optimize run (Stop mid-optimization, delegated ScanRequest path). Expected: scan.log/console show exactly one INFO `Optimization scan N aborted by operator; cleanup completed (...)`, one WARNING `Optimization scan N aborted by operator; folder ... kept (never deleted) — partial data may be present`, the ABORTED lifecycle state, shot controller in STANDBY, variables restored to initial — and **zero ERROR records from geecs_bluesky** (bluesky's own single "Run aborted" ERROR remains; upstream, see follow-up note above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
