### PR TITLE
GEECS-Console 0.12.1: experiment-name guard covers Windows drive names + reserved devices

### DIFF
--- a/GEECS-Console/CHANGELOG.md
+++ b/GEECS-Console/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to GEECS-Console are documented here.  Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versioning is
 semantic.
 
+## [0.12.1] - 2026-07-16
+
+### Fixed
+
+- **Experiment-name guard covers Windows path grammar** (issue #517).
+  `check_experiment_name` now also rejects `:` — on Windows,
+  `PureWindowsPath(root) / "D:Other"` silently discards the experiments
+  root, so a drive-qualified name escaped the guard without containing a
+  path separator — and reserved Windows device names (`CON`, `NUL`,
+  `COM1`, …, bare or with an extension), which would create unusable or
+  aliased config directories on the control-room machines.  Regression
+  names added to the per-store traversal matrix in
+  `tests/test_experiment_name_validation.py`.
+
 ## [0.12.0] - 2026-07-15
 
 ### Added

--- a/GEECS-Console/geecs_console/services/_experiment_name.py
+++ b/GEECS-Console/geecs_console/services/_experiment_name.py
@@ -14,9 +14,25 @@ The semantics mirror the original ``ScanVariableStore._check_experiment``
 (the store that already had the guard): the empty string is *allowed* —
 "no experiment selected" is a separate, friendlier error each store raises
 itself — but any path separator or relative-path special name is rejected.
+
+The guard must hold under **Windows path grammar too** (issue #517): the
+console runs on Windows control-room machines, and
+``PureWindowsPath("root") / "D:Other"`` silently discards ``root`` —
+a drive-qualified name escapes without containing a separator.  Reserved
+device names (``CON``, ``NUL``, ``COM1``, …) don't escape, but a store
+would create an unusable/aliased directory from them, so they are
+rejected on every platform for config portability.
 """
 
 from __future__ import annotations
+
+# Windows reserves these as device names — bare or with any extension
+# ("CON", "con.yaml") — on every drive and in every directory.
+_WINDOWS_RESERVED_DEVICE_NAMES = frozenset(
+    {"con", "prn", "aux", "nul"}
+    | {f"com{i}" for i in range(1, 10)}
+    | {f"lpt{i}" for i in range(1, 10)}
+)
 
 
 def check_experiment_name(experiment: str, error_type: type[Exception]) -> None:
@@ -35,11 +51,17 @@ def check_experiment_name(experiment: str, error_type: type[Exception]) -> None:
     ------
     Exception
         An instance of *error_type* when the name contains a path separator
-        (``/`` or ``\\``) or is a relative-path special name (``.`` or
-        ``..``).
+        (``/`` or ``\\``) or a drive/stream separator (``:``), is a
+        relative-path special name (``.`` or ``..``), or is a reserved
+        Windows device name (bare or with an extension).
     """
-    if any(sep in experiment for sep in ("/", "\\")) or experiment in (".", ".."):
+    if any(sep in experiment for sep in ("/", "\\", ":")) or experiment in (".", ".."):
         raise error_type(
             f"Experiment name {experiment!r} must be a plain folder name "
-            "(no path separators)."
+            "(no path separators or drive letters)."
+        )
+    if experiment.split(".", 1)[0].lower() in _WINDOWS_RESERVED_DEVICE_NAMES:
+        raise error_type(
+            f"Experiment name {experiment!r} must be a plain folder name "
+            "(reserved Windows device name)."
         )

--- a/GEECS-Console/pyproject.toml
+++ b/GEECS-Console/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-console"
-version = "0.12.0"
+version = "0.12.1"
 description = "Greenfield PySide6 operator console for GEECS (Bluesky/gateway architecture)"
 authors = ["Sam Barber <sbarber@lbl.gov>"]
 readme = "README.md"

--- a/GEECS-Console/tests/test_experiment_name_validation.py
+++ b/GEECS-Console/tests/test_experiment_name_validation.py
@@ -40,13 +40,22 @@ from geecs_schemas import (
     TriggerProfile,
 )
 
-# Names that would escape (or alias) the experiments root when joined.
+# Names that would escape (or alias) the experiments root when joined —
+# under POSIX *or* Windows path grammar (issue #517: PureWindowsPath("root")
+# / "D:Other" discards root entirely), plus reserved Windows device names
+# (rejected everywhere so configs stay portable to the control-room boxes).
 TRAVERSAL_NAMES = [
     "../OtherExperiment",
     "..",
     ".",
     "a/b",
     "a\\b",
+    "D:Other",
+    "C:Other",
+    "C:",
+    "CON",
+    "nul.yaml",
+    "com1",
 ]
 
 GUARD_MESSAGE = "plain folder name"
@@ -172,3 +181,11 @@ class TestPlainNamesStillWork:
         assert path.is_file()
         assert path.parent.parent == tmp_path / "HTU.v2"
         assert store.list_names() == ["align"]
+
+    def test_reserved_prefix_is_not_reserved(self, tmp_path):
+        # "CONSOLE" starts with "CON" but is a legal folder name everywhere;
+        # only the exact device names (bare or with an extension) are blocked.
+        store = PresetStore("CONSOLE", experiments_root=tmp_path)
+        path = store.save("align", minimal_request())
+        assert path.is_file()
+        assert path.parent.parent == tmp_path / "CONSOLE"


### PR DESCRIPTION
Closes #517.

## What + why

The shared experiment-name guard (`services/_experiment_name.py`, issue #513) blocked `/`, `\`, `.`, `..` — POSIX escape grammar — but not Windows drive-qualified segments: `PureWindowsPath(root) / "D:Other"` silently discards the experiments root, so an editable experiment value like `D:Other` bypassed the plain-folder-name invariant on the Windows control-room machines the console targets. The guard now rejects `:` alongside the separators.

Judgment-call addition (cheap to veto): the issue's "also consider" item — reserved Windows device names (`CON`, `NUL`, `AUX`, `PRN`, `COM1`–`COM9`, `LPT1`–`LPT9`, bare or with an extension) are rejected too, on every platform, since the stores create directories from this text and a reserved name yields an unusable/aliased config dir. It's ~10 lines in the same guard; drop it if you'd rather keep this strictly to the escape fix.

## Per-concern LOC breakdown

- Guard fix (`_experiment_name.py`: `:` rejection + reserved-name set + docstrings): +32 / −5
- Regression tests (`test_experiment_name_validation.py`: 6 new hostile names through the per-store matrix + a `CONSOLE`-is-not-`CON` over-rejection check): +23 / −1
- Version bump + CHANGELOG (0.12.1 patch): +16

## Tests

- `tests/test_experiment_name_validation.py`: **59 passed** (matrix grew 27 → 59 with the new names; every store still raises before any directory is created, tmp tree stays untouched).
- `./scripts/check.sh --all`: all suites green — GEECS-Console **735 passed** (plus the 2 known env-shaped `*_without_the_extra` optimization failures: this local venv has the `optimization` extra installed, which those tests assume absent — they fail identically on `dev` locally and pass in CI), GeecsBluesky 490, ImageAnalysis 224+1skip, GEECS-Schemas 211, GEECS-Data-Utils 197, GeecsCAGateway 181, ScanAnalysis 171, GEECS-LogTriage 53. Repo-wide lint fails only on the pre-existing GEECS-PythonAPI notebook files (identical on `dev`); scoped lint on this diff is clean.

## Hardware verification

None needed — pure input validation in the config-store layer; no scan execution or device path touched. The Windows behavior itself is exercised by the existing `console-windows` CI job running this suite on `windows-latest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)