### PR TITLE
GeecsBluesky 0.38.1: gateway-synthesized variables are always-served (unserved-check false positive)

### DIFF
--- a/GeecsBluesky/CHANGELOG.md
+++ b/GeecsBluesky/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to `geecs-bluesky` are documented here.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.38.1] - 2026-07-16
+
+### Fixed
+
+- **Gateway-synthesized variables no longer draw the unserved-variables
+  dialog** (field regression, same day): `acq_timestamp`, `systimestamp`,
+  and `CONNECTED` are synthesized by the gateway for every device — no
+  `expt_device_variable` row exists, so the served-set model
+  (`get='yes'` ∪ settable) wrongly flagged them. First seen when the
+  optimizer's auto-provisioned `acq_timestamp` request produced a false
+  "Every listed variable of UC_TopView is unserved" whole-device-drop
+  question. `GATEWAY_SYNTHESIZED_VARIABLES` (db_runtime) is now the
+  canonical always-served set, honored by the pre-flight check; pinned by
+  a regression test.
+
 ## [0.38.0] - 2026-07-16
 
 ### Added

--- a/GeecsBluesky/geecs_bluesky/db_runtime.py
+++ b/GeecsBluesky/geecs_bluesky/db_runtime.py
@@ -137,6 +137,20 @@ class GeecsDbScalarPolicy:
         return list(self._all_by_device().get(device, []))
 
 
+#: Variables the gateway synthesizes for EVERY device, independent of the
+#: DB ``get`` flags: the timestamp ladder (``DeviceSpec.timestamp_vars`` in
+#: GeecsCAGateway's ``config.py`` — ``acq_timestamp`` preferred,
+#: ``systimestamp`` fallback, both always subscribed) and the per-device
+#: ``CONNECTED`` status PV (``gateway.py``). These are served even though no
+#: ``expt_device_variable`` row exists, so the unserved-variables check must
+#: treat them as always-served (field regression 2026-07-16: the optimizer's
+#: auto-provisioned ``acq_timestamp`` request drew a false "not served"
+#: dialog threatening to drop the whole device).
+GATEWAY_SYNTHESIZED_VARIABLES = frozenset(
+    {"acq_timestamp", "systimestamp", "CONNECTED"}
+)
+
+
 @dataclass
 class GeecsDbServedSetProvider:
     """The gateway's served variable set, per device — failure-tolerant.

--- a/GeecsBluesky/geecs_bluesky/preflight.py
+++ b/GeecsBluesky/geecs_bluesky/preflight.py
@@ -29,6 +29,7 @@ from geecs_bluesky.exceptions import (
     GeecsStaleDevicesError,
     GeecsUnservedVariablesError,
 )
+from geecs_bluesky.db_runtime import GATEWAY_SYNTHESIZED_VARIABLES
 from geecs_bluesky.operator_channel import (
     ANSWER_ABORT,
     ANSWER_CONTINUE,
@@ -615,6 +616,7 @@ class UnservedVariablesCheck:
                 variable
                 for variable in (cfg.get("variable_list") or [])
                 if variable not in served_vars
+                and variable not in GATEWAY_SYNTHESIZED_VARIABLES
             ]
             if missing:
                 unserved[device] = missing

--- a/GeecsBluesky/pyproject.toml
+++ b/GeecsBluesky/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-bluesky"
-version = "0.38.0"
+version = "0.38.1"
 description = "Bluesky / ophyd-async bridge for the GEECS control system"
 authors = ["Sam Barber <sbarber@lbl.gov>"]
 readme = "README.md"

--- a/GeecsBluesky/tests/test_preflight_unserved.py
+++ b/GeecsBluesky/tests/test_preflight_unserved.py
@@ -381,3 +381,37 @@ def test_no_provider_skips_the_check() -> None:
     assert effective is config
     assert dropped == {}
     assert dropped_devices == []
+
+
+def test_gateway_synthesized_variables_are_always_served(monkeypatch) -> None:
+    """acq_timestamp/systimestamp/CONNECTED are gateway-synthesized for every
+    device (no expt_device_variable row exists) — they must never draw the
+    unserved dialog. Field regression 2026-07-16: the optimizer's
+    auto-provisioned ``acq_timestamp`` request produced a false
+    whole-device-drop question for UC_TopView.
+    """
+    _install_served(monkeypatch, _SERVED)
+    session = _RecordingSession()
+    channel = _ScriptedChannel([])  # any question would exhaust the script
+    save_set = SaveSet(
+        name="TopView",
+        entries=[
+            SaveSetEntry(
+                device="UC_TopView",
+                scalars=["acq_timestamp", "systimestamp", "CONNECTED"],
+                db_scalars=False,
+            )
+        ],
+    )
+    resolver = _SaveSetResolver({"TopView": save_set})
+
+    uid = run_scan_request(
+        session, _noscan_request(), resolver, operator_channel=channel
+    )
+
+    assert uid == "uid-scan"
+    assert channel.questions == []  # no dialog: synthesized vars are served
+    assert session.device_calls == [
+        ("detector", "UC_TopView", ["acq_timestamp", "systimestamp", "CONNECTED"])
+    ]
+    assert "dropped_unserved_variables" not in session.scan_kwargs["md"]


### PR DESCRIPTION
Field regression from today's live testing, reported by Sam with the diagnosis already correct: the #562 unserved-variables check models served = `get='yes'` ∪ settable, but the gateway synthesizes `acq_timestamp`/`systimestamp` (the timestamp ladder, `DeviceSpec.timestamp_vars`) and `CONNECTED` for **every** device with no DB row — so #567's auto-provisioned `acq_timestamp` request drew *"Every listed variable of UC_TopView is unserved… continuing drops the device(s) entirely"*. Verified live before fixing: `caget Undulator:UC_TopView:acq_timestamp` answers.

Fix: `GATEWAY_SYNTHESIZED_VARIABLES` in `db_runtime.py` (canonical, documented against the gateway source) honored by the pre-flight membership test. One regression test.

## Tests
`./scripts/check.sh`: lint green, GeecsBluesky **531 passed** (11 in the unserved suite incl. the new pin).

## Hardware verification
The trigger condition was observed live today (the false dialog); post-merge the same TopViewMax zero-save-set run must proceed past pre-flight without the dialog — rides the already-OWED #567 repro.

🤖 Generated with [Claude Code](https://claude.com/claude-code)