### PR TITLE
tooling: adversarial-review step in the /land ritual

### DIFF
--- a/.claude/skills/land/SKILL.md
+++ b/.claude/skills/land/SKILL.md
@@ -65,7 +65,9 @@ auto-fixers abort merge commits) and push. Nothing merges `dev` →
    hardware-verified distinction is never implicit.
 7. **Adversarial review** (runs during the CI wait; see the section
    below): spawn a fresh-context reviewer subagent on the PR's diff,
-   post its surviving findings as a PR comment, and disposition every
+   post its report as a PR comment **either way** — a "no surviving
+   findings" report is itself the audit record distinguishing
+   "reviewed, clean" from "review skipped" — and disposition every
    finding — fix it, or waive it with a stated reason — before merging.
    No PR merges with an undispositioned finding.
 8. **Merge**: wait for CI (`gh pr checks <n> --watch`), merge with
@@ -97,7 +99,11 @@ The reviewer brief (pass verbatim, plus the PR/diff reference):
 >    (inputs/state → wrong behavior). Check edge cases the tests skip,
 >    invariant violations (scan-folder creation, public-repo hygiene,
 >    contract files traveling with behavior), and whether new tests
->    would actually fail if the code were wrong.
+>    would actually fail if the code were wrong. For a diff with no
+>    runtime surface (docs, process, tooling), correctness means:
+>    internal contradictions, conflicts with other repo policy
+>    documents, broken cross-references, and instructions that are
+>    ambiguous or unexecutable as written.
 > 2. **Redundancy** — does some or all of this already exist? Search
 >    the repo for existing implementations, helpers, or patterns that
 >    overlap what the diff adds (the repo has grown duplicate config
@@ -117,9 +123,11 @@ The reviewer brief (pass verbatim, plus the PR/diff reference):
 
 Disposition, in a PR comment before merge: each finding is either
 **fixed** (commit referenced) or **waived** with a one-line reason.
-Waivers are cheap-to-veto flags for the owner, same as judgment-call
-additions. If a finding invalidates the approach, stop and surface it
-instead of merging.
+A fix must go back to the **same reviewer** (continue the subagent)
+for a confirm/deny before it is dispositioned as fixed — otherwise the
+author is back to assessing their own work. Waivers are cheap-to-veto
+flags for the owner, same as judgment-call additions. If a finding
+invalidates the approach, stop and surface it instead of merging.
 
 ## Hard rules (violations have shipped incidents)
 

--- a/.claude/skills/land/SKILL.md
+++ b/.claude/skills/land/SKILL.md
@@ -3,8 +3,10 @@ name: land
 description: >
   Land a change as a PR the GEECS-Plugins way: branch off the right base,
   scope check, version bump + CHANGELOG, tests run the way CI runs them,
-  commit.sh, PR body with the hardware-verification section, CI watch,
-  merge, roll-forward. Use when the user says "land this", "open a PR",
+  commit.sh, PR body with the hardware-verification section, adversarial
+  review by a fresh-context subagent (correctness + redundancy +
+  placement) with dispositioned findings, CI watch, merge, roll-forward.
+  Use when the user says "land this", "open a PR",
   "commit and push this", "prep this branch for review", or when a change
   in the working tree is finished and needs to become a merged PR.
 ---
@@ -61,15 +63,63 @@ auto-fixers abort merge commits) and push. Nothing merges `dev` →
    verification** section: either the live results or an explicit
    "OWED: <what to verify, expected numbers>" so the code-complete vs
    hardware-verified distinction is never implicit.
-7. **Merge**: wait for CI (`gh pr checks <n> --watch`), merge with
+7. **Adversarial review** (runs during the CI wait; see the section
+   below): spawn a fresh-context reviewer subagent on the PR's diff,
+   post its surviving findings as a PR comment, and disposition every
+   finding — fix it, or waive it with a stated reason — before merging.
+   No PR merges with an undispositioned finding.
+8. **Merge**: wait for CI (`gh pr checks <n> --watch`), merge with
    `--merge --delete-branch`. Then do the roll-forward merge if the base
    was the engine branch (rule above). Remove the worktree after merge
    unless it hosts an open stacked branch — and always confirm with the
    user before removing any worktree.
-8. **Stacked PRs**: base on the parent PR's branch and say "merge #N
+9. **Stacked PRs**: base on the parent PR's branch and say "merge #N
    first" in the body — but beware: GitHub auto-closes (unreopenable) a
    PR whose base branch is deleted. Prefer merging the parent first and
    retargeting before it merges, or re-file (precedent: #538 → #539).
+
+## The adversarial review step
+
+The author must not be the only reader of a diff before it lands. The
+reviewer is a **separate subagent with fresh context**: give it the PR
+number (or the diff), the branch, and the brief below — never your own
+rationale, summaries, or the PR body's framing beyond what any outside
+reviewer would see. Its job is to refute the change, not to appreciate
+it.
+
+The reviewer brief (pass verbatim, plus the PR/diff reference):
+
+> Review this diff adversarially through three lenses, using the whole
+> repository as context (root and package `CLAUDE.md` files, the
+> dependency graph, existing modules and tests):
+>
+> 1. **Correctness** — try to construct concrete failure scenarios
+>    (inputs/state → wrong behavior). Check edge cases the tests skip,
+>    invariant violations (scan-folder creation, public-repo hygiene,
+>    contract files traveling with behavior), and whether new tests
+>    would actually fail if the code were wrong.
+> 2. **Redundancy** — does some or all of this already exist? Search
+>    the repo for existing implementations, helpers, or patterns that
+>    overlap what the diff adds (the repo has grown duplicate config
+>    readers, worker classes, and prompt dialogs before — assume
+>    duplication until a search says otherwise, and cite the files you
+>    checked).
+> 3. **Placement** — is there a more natural home for each new piece,
+>    given the package dependency graph and each package's stated
+>    boundaries (e.g. pure logic belongs below GUI packages; schema
+>    knowledge in its one module; browser/console kit boundaries)?
+>    Flag code that a future feature would have to move.
+>
+> Report only findings that survive your own attempt to refute them,
+> ranked by severity, each with the concrete scenario or the existing
+> file it duplicates / the better home. Say "no surviving findings"
+> if that is the honest result — do not pad.
+
+Disposition, in a PR comment before merge: each finding is either
+**fixed** (commit referenced) or **waived** with a one-line reason.
+Waivers are cheap-to-veto flags for the owner, same as judgment-call
+additions. If a finding invalidates the approach, stop and surface it
+instead of merging.
 
 ## Hard rules (violations have shipped incidents)
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,6 +11,8 @@
 - [ ] Base branch matches the content — see CONTRIBUTING.md
       § "Branch topology" (delete this line at M6)
 - [ ] Public-repo hygiene: no lab accounts/hostnames/home paths
+- [ ] Adversarial review posted and every finding dispositioned
+      (brief in `.claude/skills/land/SKILL.md`)
 
 ## Tests
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,6 +76,14 @@ deferred-work or strategy content.)
    the PR template — either live results or an explicit "owed:" note.
    Code-complete and hardware-verified are different states here, and PRs
    are expected to say which they are.
+5. **Adversarial review before merge.** Every PR gets a review by someone
+   (or, for AI-assisted work, a fresh-context agent) who did not write
+   it, covering three lenses: correctness (concrete failure scenarios),
+   redundancy (does this already exist somewhere in the repo?), and
+   placement (is there a more natural home, given the dependency graph
+   and package boundaries?). Findings are posted on the PR and each one
+   is dispositioned — fixed, or waived with a stated reason — before
+   merge. The reviewer brief lives in `.claude/skills/land/SKILL.md`.
 
 ## Committing
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,14 +76,17 @@ deferred-work or strategy content.)
    the PR template — either live results or an explicit "owed:" note.
    Code-complete and hardware-verified are different states here, and PRs
    are expected to say which they are.
-5. **Adversarial review before merge.** Every PR gets a review by someone
-   (or, for AI-assisted work, a fresh-context agent) who did not write
-   it, covering three lenses: correctness (concrete failure scenarios),
-   redundancy (does this already exist somewhere in the repo?), and
-   placement (is there a more natural home, given the dependency graph
-   and package boundaries?). Findings are posted on the PR and each one
-   is dispositioned — fixed, or waived with a stated reason — before
-   merge. The reviewer brief lives in `.claude/skills/land/SKILL.md`.
+5. **Adversarial review before merge** — this one applies to *all* PRs,
+   including tooling/docs-only ones that change no package. A review by
+   someone (or, for AI-assisted work, a fresh-context agent) who did not
+   write the diff, covering three lenses: correctness (concrete failure
+   scenarios), redundancy (does this already exist somewhere in the
+   repo?), and placement (is there a more natural home, given the
+   dependency graph and package boundaries?). The review report is
+   posted on the PR either way — "no surviving findings" is itself the
+   record — and each finding is dispositioned — fixed (and confirmed by
+   the reviewer), or waived with a stated reason — before merge. The
+   reviewer brief lives in `.claude/skills/land/SKILL.md`.
 
 ## Committing
 


### PR DESCRIPTION
## What + why

Owner-requested process change (2026-07-16): until now the landing flow had one agent find, fix, self-assess, and merge — nobody adversarial ever read a diff before it reached `dev` (post-merge audits caught things like #517 only after the fact). This adds a mandatory **adversarial review step** to `/land`, run during the CI wait by a **fresh-context subagent** that gets the diff but never the author's rationale.

The reviewer brief (verbatim in the skill) covers three lenses, per Sam's spec:

1. **Correctness** — construct concrete failure scenarios; check what the tests would actually catch.
2. **Redundancy** — does some or all of this already exist in the repo? (We've grown duplicate config readers, worker twins, and prompt dialogs before — the brief says assume duplication until a search proves otherwise.)
3. **Placement** — is there a more natural home, given the dependency graph and package boundaries?

Every finding must be **dispositioned before merge** — fixed with a commit reference, or waived with a one-line reason (waivers double as cheap-to-veto flags for the owner). No undispositioned finding merges.

## Changes

- `.claude/skills/land/SKILL.md`: new step 7 + "The adversarial review step" section with the verbatim reviewer brief; frontmatter description updated (repo policy: skill descriptions stay current).
- `CONTRIBUTING.md`: matching step 5 in "Every PR that changes a package" (human-facing distillation, pointing at the skill for the full brief).

No package code — no version bump (tooling precedent: #546/#548).

## Tests

Docs/process only; `./scripts/check.sh --lint` clean via commit.sh hooks. The real test is dogfooding: this PR itself gets the new review step before merging.

## Hardware verification

None — process documentation only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)