### PR TITLE
GeecsBluesky 0.38.2: silence upstream RequestAbort traceback on operator abort

### DIFF
--- a/GeecsBluesky/CHANGELOG.md
+++ b/GeecsBluesky/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to `geecs-bluesky` are documented here.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.38.2] - 2026-07-16
+
+### Fixed
+
+- **Upstream bluesky's `Run aborted` traceback silenced for operator
+  aborts** (the #563 follow-up, observed live 2026-07-16): the session
+  attaches a log filter to its RunEngine's logger that drops records
+  whose exception is `RequestAbort` — the abort *mechanism*, not an
+  error. The filter keys on the exception type, never the message, so
+  the genuine-exception path's identically-worded "Run aborted" record
+  (real failures) still logs with its full traceback. Pinned by a
+  type-discrimination test and an end-to-end live-abort test.
+
 ## [0.38.1] - 2026-07-16
 
 ### Fixed

--- a/GeecsBluesky/CHANGELOG.md
+++ b/GeecsBluesky/CHANGELOG.md
@@ -10,7 +10,8 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - **Upstream bluesky's `Run aborted` traceback silenced for operator
   aborts** (the #563 follow-up, observed live 2026-07-16): the session
-  attaches a log filter to its RunEngine's logger that drops records
+  attaches a log filter (once — idempotent) to the process-wide
+  ``bluesky`` logger every RunEngine shares that drops records
   whose exception is `RequestAbort` — the abort *mechanism*, not an
   error. The filter keys on the exception type, never the message, so
   the genuine-exception path's identically-worded "Run aborted" record

--- a/GeecsBluesky/geecs_bluesky/session.py
+++ b/GeecsBluesky/geecs_bluesky/session.py
@@ -35,7 +35,7 @@ from typing import Any, Callable, Sequence
 
 import numpy as np
 from bluesky import RunEngine
-from bluesky.utils import RunEngineInterrupted
+from bluesky.utils import RequestAbort, RunEngineInterrupted
 
 from geecs_bluesky.data_paths import asset_resource_root_paths, device_server_save_path
 from geecs_bluesky.exceptions import GeecsConfigurationError
@@ -92,6 +92,24 @@ def _json_safe(value: Any) -> Any:  # Any: mirrors json.dumps's input surface
     return value
 
 
+class _RequestAbortLogFilter(logging.Filter):
+    """Drop upstream bluesky's ``RequestAbort`` traceback record.
+
+    The RunEngine logs ``"Run aborted"`` with a full traceback from two
+    sites: the ``RequestAbort`` path (an operator-requested abort — the
+    *mechanism* of aborting, not an error; the session logs its own single
+    INFO line) and a genuine-exception path.  Filtering on the exception
+    *type* silences only the former — a real failure's "Run aborted"
+    traceback still gets through.
+    """
+
+    def filter(self, record: logging.LogRecord) -> bool:  # noqa: D102 — base doc
+        exc = record.exc_info
+        if exc and exc[0] is not None and issubclass(exc[0], RequestAbort):
+            return False
+        return True
+
+
 class GeecsSession:
     """Headless scan session for one experiment, over the CA gateway.
 
@@ -127,6 +145,12 @@ class GeecsSession:
         self._mock = mock
         # context_managers=[] so sessions also work off the main thread.
         self.RE = RunEngine(context_managers=[])
+        # Silence upstream's RequestAbort traceback on THIS engine's logger
+        # (operator aborts are quiet, intentional outcomes — #563 follow-up);
+        # RE.log is a LoggerAdapter, so the filter goes on its real logger.
+        _re_logger = getattr(self.RE.log, "logger", None)
+        if _re_logger is not None:
+            _re_logger.addFilter(_RequestAbortLogFilter())
         self._last_run_uid: str | None = None
         #: ``True`` when the most recent :meth:`scan`/:meth:`optimize` ended
         #: in an operator-requested abort (``RE.abort()``/``RE.stop()``) —

--- a/GeecsBluesky/geecs_bluesky/session.py
+++ b/GeecsBluesky/geecs_bluesky/session.py
@@ -145,11 +145,17 @@ class GeecsSession:
         self._mock = mock
         # context_managers=[] so sessions also work off the main thread.
         self.RE = RunEngine(context_managers=[])
-        # Silence upstream's RequestAbort traceback on THIS engine's logger
-        # (operator aborts are quiet, intentional outcomes — #563 follow-up);
-        # RE.log is a LoggerAdapter, so the filter goes on its real logger.
+        # Silence upstream's RequestAbort traceback (operator aborts are
+        # quiet, intentional outcomes — #563 follow-up).  RE.log is a
+        # LoggerAdapter over the PROCESS-WIDE ``bluesky`` logger shared by
+        # every RunEngine, so this covers all engines in the process (a
+        # RequestAbort is the abort mechanism whoever raised it) — and the
+        # guard keeps repeated session construction from stacking
+        # duplicate filters on that global logger.
         _re_logger = getattr(self.RE.log, "logger", None)
-        if _re_logger is not None:
+        if _re_logger is not None and not any(
+            isinstance(f, _RequestAbortLogFilter) for f in _re_logger.filters
+        ):
             _re_logger.addFilter(_RequestAbortLogFilter())
         self._last_run_uid: str | None = None
         #: ``True`` when the most recent :meth:`scan`/:meth:`optimize` ended

--- a/GeecsBluesky/pyproject.toml
+++ b/GeecsBluesky/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-bluesky"
-version = "0.38.1"
+version = "0.38.2"
 description = "Bluesky / ophyd-async bridge for the GEECS control system"
 authors = ["Sam Barber <sbarber@lbl.gov>"]
 readme = "README.md"

--- a/GeecsBluesky/tests/test_operator_abort.py
+++ b/GeecsBluesky/tests/test_operator_abort.py
@@ -257,3 +257,62 @@ def test_claimed_scan_failure_note_stays_error(caplog) -> None:
     [record] = caplog.records
     assert record.levelno == logging.ERROR
     assert "failed or aborted" in record.getMessage()
+
+
+def test_upstream_request_abort_traceback_is_filtered(caplog) -> None:
+    """Upstream bluesky's 'Run aborted' RequestAbort traceback is dropped by
+    the session's log filter; a genuine exception's record passes through
+    (the filter keys on the exception TYPE, never the message)."""
+    from bluesky.utils import RequestAbort
+
+    s = _session()
+    re_logger = s.RE.log.logger
+
+    with caplog.at_level(logging.DEBUG, logger=re_logger.name):
+        try:
+            raise RequestAbort()
+        except RequestAbort:
+            re_logger.exception("Run aborted")  # upstream's abort-path record
+        try:
+            raise RuntimeError("real failure")
+        except RuntimeError:
+            re_logger.exception("Run aborted")  # upstream's genuine-error record
+
+    aborted = [r for r in caplog.records if r.getMessage() == "Run aborted"]
+    assert len(aborted) == 1, "only the genuine-exception record may survive"
+    assert aborted[0].exc_info[0] is RuntimeError
+
+
+def test_live_abort_produces_no_upstream_traceback(caplog) -> None:
+    """End-to-end: a real RE.abort() leaves zero RequestAbort tracebacks in
+    the log stream (the field complaint), while the quiet INFO remains."""
+    s = _session()
+    det = s.detector("U_Cam", ["Sig"])
+    set_mock_value(det.acq_timestamp, 1000.0)
+    pacer = start_pacer(s.RE, [(det, 1000.0)], initial_delay=0.4, interval=0.05)
+    aborter = _abort_when_running(s.RE)
+    try:
+        with caplog.at_level(logging.DEBUG):
+            s.scan(
+                detectors=[det],
+                motor=None,
+                positions=[None],
+                shots_per_step=200,
+                mode="free_run",
+                save_data=False,
+            )
+    finally:
+        pacer.cancel()
+        aborter.join(timeout=15.0)
+        s.disconnect(det)
+
+    from bluesky.utils import RequestAbort
+
+    leaked = [
+        r
+        for r in caplog.records
+        if r.exc_info
+        and r.exc_info[0] is not None
+        and issubclass(r.exc_info[0], RequestAbort)
+    ]
+    assert leaked == [], "RequestAbort tracebacks must not reach the log"

--- a/GeecsBluesky/tests/test_operator_abort.py
+++ b/GeecsBluesky/tests/test_operator_abort.py
@@ -316,3 +316,17 @@ def test_live_abort_produces_no_upstream_traceback(caplog) -> None:
         and issubclass(r.exc_info[0], RequestAbort)
     ]
     assert leaked == [], "RequestAbort tracebacks must not reach the log"
+
+
+def test_abort_log_filter_attaches_once_across_sessions() -> None:
+    """The filter lands on the process-global bluesky logger — repeated
+    session construction must not stack duplicates (review finding, #570)."""
+    from geecs_bluesky.session import _RequestAbortLogFilter
+
+    s1 = _session()
+    s2 = _session()
+    assert s1.RE.log.logger is s2.RE.log.logger  # global, by upstream design
+    ours = [
+        f for f in s1.RE.log.logger.filters if isinstance(f, _RequestAbortLogFilter)
+    ]
+    assert len(ours) == 1


### PR DESCRIPTION
The #563 follow-up its PR body promised, now field-driven: after #563, an operator abort still shows upstream bluesky's `ERROR bluesky: Run aborted` + full `RequestAbort` traceback (observed live this morning). Upstream logs that message from **two** sites — the RequestAbort path and a genuine-exception path — so the fix filters by **exception type, never message**: a `logging.Filter` on the session RE's underlying logger drops RequestAbort-typed records only. Real failures' identically-worded records pass through with tracebacks intact (pinned by a type-discrimination test); an end-to-end live-abort test asserts zero RequestAbort tracebacks reach the stream.

## Tests
`./scripts/check.sh`: lint green, GeecsBluesky **533 passed** (2 new).

## Hardware verification
OWED: one live abort — expect exactly one geecs INFO + one calm WARNING and no traceback blocks at all (rides today's optimize-repro session).

🤖 Generated with [Claude Code](https://claude.com/claude-code)