### PR TITLE
GeecsBluesky 0.40.0 + GEECS-Console 0.15.0: native stop lifecycle — Stop during init is honoured, never blocks the GUI (#571)

### DIFF
--- a/GEECS-Console/CHANGELOG.md
+++ b/GEECS-Console/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to GEECS-Console are documented here.  Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versioning is
 semantic.
 
+## [0.15.0] - 2026-07-16
+
+### Fixed
+
+- **Stop no longer pinwheels the GUI** (#571 — the console half; the
+  stop-is-ignored engine half is GeecsBluesky 0.40.0).
+  `_on_stop_clicked` used to call `stop_scanning_thread()` on the GUI
+  thread, which could block up to 15 s (the engine joined a scan thread
+  sitting in 20 s device connects) — the window froze while the terminal
+  kept logging init steps.  Stop now dispatches through a
+  `BackgroundResult` worker: the click returns immediately, the Stop
+  button disables and shows "Stopping…", and normal gating resumes when
+  the lifecycle event stream reports the terminal state (ABORTED/DONE) —
+  the same stream the window already consumes.  The state pill knows the
+  engine's STOPPING state (amber).
+
 ## [0.14.0] - 2026-07-16
 
 ### Changed

--- a/GEECS-Console/CLAUDE.md
+++ b/GEECS-Console/CLAUDE.md
@@ -32,7 +32,13 @@ are prefixed by region (`r3_radio_1d`, `r5_start_button`, …).
   selected sets is valid there), valid shot count within the guard, and in
   Optimization mode a selected optimizer config.  The GUI never pre-blocks
   an optimize submission beyond that — the engine's accept/refuse answer is
-  surfaced in the status bar.
+  surfaced in the status bar.  **Stop is asynchronous** (#571):
+  `stop_scanning_thread` can block briefly engine-side, so the click
+  dispatches it through a dedicated `BackgroundResult` stop worker (no
+  result slot — completion arrives via the lifecycle stream); the button
+  disables and shows "Stopping…" until a terminal lifecycle state
+  (`_TERMINAL_SCAN_STATES` = aborted/done, exactly the engine's terminal
+  vocabulary) releases the hold and normal gating resumes.
 - **R6 now panel** — state pill, progress bar, "Scan NNN" with 10 s expiry
   to "(previous)" (**live**: driven by `ScanLifecycleEvent.scan_number`
   through the adapter's `scan_number_known` signal), compact log tail.

--- a/GEECS-Console/geecs_console/app/main_window.py
+++ b/GEECS-Console/geecs_console/app/main_window.py
@@ -124,10 +124,12 @@ _STATE_DOT_COLORS = {
     "failed": _COLOR_RED,
 }
 
-# Lifecycle states that settle an in-flight Stop request: the scan is over
-# (or the engine failed), so the Stop button's "Stopping…" hold releases and
-# normal gating resumes.
-_TERMINAL_SCAN_STATES = frozenset({"aborted", "done", "error", "failed", "idle"})
+# Lifecycle states that settle an in-flight Stop request, releasing the Stop
+# button's "Stopping…" hold.  Exactly the engine's terminal vocabulary: the
+# bridge's scan-thread cleanup always ends in ABORTED or DONE
+# (geecs_bluesky.events.ScanState; BlueskyScanner._run_scan).  Deliberately
+# NOT paused_on_error — that state is resumable, the scan is not over.
+_TERMINAL_SCAN_STATES = frozenset({"aborted", "done"})
 
 
 def _default_completions_factory(experiment: str) -> CompletionsProvider:

--- a/GEECS-Console/geecs_console/app/main_window.py
+++ b/GEECS-Console/geecs_console/app/main_window.py
@@ -118,10 +118,16 @@ _STATE_DOT_COLORS = {
     "complete": _COLOR_GREEN,
     "completed": _COLOR_GREEN,
     "initializing": _COLOR_AMBER,
+    "stopping": _COLOR_AMBER,
     "aborted": _COLOR_RED,
     "error": _COLOR_RED,
     "failed": _COLOR_RED,
 }
+
+# Lifecycle states that settle an in-flight Stop request: the scan is over
+# (or the engine failed), so the Stop button's "Stopping…" hold releases and
+# normal gating resumes.
+_TERMINAL_SCAN_STATES = frozenset({"aborted", "done", "error", "failed", "idle"})
 
 
 def _default_completions_factory(experiment: str) -> CompletionsProvider:
@@ -851,6 +857,13 @@ class MainWindow(QMainWindow):
         self._actions_worker.result_ready.connect(
             self._apply_action_names, Qt.ConnectionType.QueuedConnection
         )
+        # Stop dispatch (issue #571): stop_scanning_thread may block briefly
+        # (engine bookkeeping join), so it runs on a worker — never the GUI
+        # thread.  No result slot: completion is announced by the terminal
+        # lifecycle event (_on_scan_state clears the in-flight hold).
+        self._stop_worker = BackgroundResult()
+        self._stop_in_flight = False
+        self._stop_button_label = self.stop_button.text()
 
         self.events.state_changed.connect(self._on_scan_state)
         self.events.totals_known.connect(self._on_totals_known)
@@ -1720,7 +1733,9 @@ class MainWindow(QMainWindow):
             and (not optimize or bool(self.optimization_combo.currentText()))
         )
         self.start_button.setEnabled(ready)
-        self.stop_button.setEnabled(scanning)
+        # While a stop is in flight the button stays disabled ("Stopping…")
+        # until the terminal lifecycle event lands (_on_scan_state).
+        self.stop_button.setEnabled(scanning and not self._stop_in_flight)
 
     def _ensure_submitter(self) -> Optional[Submitter]:
         """Return the injected submitter, or lazily build the real engine."""
@@ -1767,9 +1782,24 @@ class MainWindow(QMainWindow):
         self._refresh_submit_enabled()
 
     def _on_stop_clicked(self) -> None:
-        """Stop the running scan."""
-        if self._submitter is not None and self._submitter.is_scanning_active():
-            self._submitter.stop_scanning_thread()
+        """Request the running scan to stop — never blocking the GUI thread.
+
+        ``stop_scanning_thread`` can block (during initialization the
+        engine's scan thread may sit in a 20 s device connect; calling it
+        here used to pinwheel the window — issue #571), so it is
+        dispatched through the stop worker.  The button disables and shows
+        "Stopping…" until the lifecycle stream reports a terminal state
+        (:meth:`_on_scan_state` releases the hold), then normal gating
+        resumes.
+        """
+        submitter = self._submitter
+        if submitter is None or not submitter.is_scanning_active():
+            self._refresh_submit_enabled()
+            return
+        self._stop_in_flight = True
+        self.stop_button.setText("Stopping…")
+        self._stop_worker.run_async(submitter.stop_scanning_thread, "scan-stop")
+        self.append_log("stop requested")
         self._refresh_submit_enabled()
 
     # ------------------------------------------------------------------
@@ -2272,7 +2302,15 @@ class MainWindow(QMainWindow):
         self.state_pill.setText(f'<span style="color:{color};">●</span> {word.upper()}')
 
     def _on_scan_state(self, state: str) -> None:
-        """Update the state pill and button gating on lifecycle events."""
+        """Update the state pill and button gating on lifecycle events.
+
+        A terminal state (aborted/done/error) also releases an in-flight
+        Stop request: the button label restores and normal gating resumes
+        (:meth:`_on_stop_clicked` set the hold).
+        """
+        if self._stop_in_flight and (state or "").lower() in _TERMINAL_SCAN_STATES:
+            self._stop_in_flight = False
+            self.stop_button.setText(self._stop_button_label)
         self._set_state_pill(state)
         self._refresh_submit_enabled()
 

--- a/GEECS-Console/geecs_console/submission.py
+++ b/GEECS-Console/geecs_console/submission.py
@@ -29,7 +29,13 @@ class Submitter(Protocol):
         ...
 
     def stop_scanning_thread(self) -> None:
-        """Abort the running scan and join its thread."""
+        """Request the running scan to stop; returns promptly.
+
+        May still block briefly (a short bookkeeping join in the engine),
+        so the window dispatches it through a ``BackgroundResult`` worker —
+        never on the GUI thread.  Completion is announced by the terminal
+        ABORTED/DONE lifecycle event, not by this call's return.
+        """
         ...
 
     def is_scanning_active(self) -> bool:

--- a/GEECS-Console/pyproject.toml
+++ b/GEECS-Console/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-console"
-version = "0.14.0"
+version = "0.15.0"
 description = "Greenfield PySide6 operator console for GEECS (Bluesky/gateway architecture)"
 authors = ["Sam Barber <sbarber@lbl.gov>"]
 readme = "README.md"

--- a/GEECS-Console/tests/test_main_window.py
+++ b/GEECS-Console/tests/test_main_window.py
@@ -675,13 +675,69 @@ class TestSubmission:
         assert not window.start_button.isEnabled()
         assert window.stop_button.isEnabled()
 
-    def test_stop_clears_active_and_reenables(self, window):
+    def test_stop_clears_active_and_reenables(self, window, qtbot):
+        """Stop is asynchronous (issue #571): the worker delivers the call,
+        the terminal lifecycle event — not the click — restores gating."""
+        from fake_events import ScanLifecycleEvent
+
         select_save_set(window, "Amp4In")
         window._on_start_clicked()
         assert window._submitter.is_scanning_active()
         window._on_stop_clicked()
-        assert window._submitter.stopped == 1
+        qtbot.waitUntil(lambda: window._submitter.stopped == 1, timeout=2000)
+        window.events.handle(ScanLifecycleEvent(state="aborted"))
         assert window.start_button.isEnabled()
+
+    def test_stop_click_never_blocks_the_gui_thread(self, window, qtbot):
+        """The pinwheel half of issue #571: a stop that takes engine-side
+        time (the old path joined the scan thread for up to 15 s) must
+        return immediately, with the button disabled and 'Stopping…'."""
+        import time
+
+        select_save_set(window, "Amp4In")
+        window._on_start_clicked()
+        submitter = window._submitter
+        finished: list[bool] = []
+
+        def slow_stop():
+            time.sleep(0.5)  # engine-side bookkeeping join stand-in
+            submitter.active = False
+            submitter.stopped += 1
+            finished.append(True)
+
+        submitter.stop_scanning_thread = slow_stop
+        started = time.monotonic()
+        window._on_stop_clicked()
+        assert time.monotonic() - started < 0.3, "stop must not block the GUI"
+        assert not window.stop_button.isEnabled()
+        assert window.stop_button.text() == "Stopping…"
+        qtbot.waitUntil(lambda: bool(finished), timeout=2000)
+
+    def test_stopping_hold_releases_on_terminal_lifecycle_event(self, window, qtbot):
+        from fake_events import ScanLifecycleEvent
+
+        select_save_set(window, "Amp4In")
+        window._on_start_clicked()
+        label = window.stop_button.text()
+        window._on_stop_clicked()
+        assert window._stop_in_flight
+        # The engine's STOPPING event is not terminal: the hold stays.
+        window.events.handle(ScanLifecycleEvent(state="stopping"))
+        assert window._stop_in_flight
+        assert not window.stop_button.isEnabled()
+        assert "STOPPING" in window.state_pill.text()
+        qtbot.waitUntil(lambda: window._submitter.stopped == 1, timeout=2000)
+        # The terminal event releases the hold and normal gating resumes.
+        window.events.handle(ScanLifecycleEvent(state="aborted"))
+        assert not window._stop_in_flight
+        assert window.stop_button.text() == label
+        assert window.start_button.isEnabled()
+        assert not window.stop_button.isEnabled()  # nothing scanning now
+
+    def test_stop_click_with_no_active_scan_is_a_no_op(self, window):
+        window._on_stop_clicked()
+        assert window._submitter.stopped == 0
+        assert not window._stop_in_flight
 
     def test_form_round_trips_into_build_scan_request(self, window):
         select_save_set(window, "Amp4In")

--- a/GeecsBluesky/CHANGELOG.md
+++ b/GeecsBluesky/CHANGELOG.md
@@ -4,6 +4,52 @@ All notable changes to `geecs-bluesky` are documented here.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.40.0] - 2026-07-16
+
+### Fixed
+
+- **Stop during scan initialization is now honoured, RunEngine-native**
+  (#571 — the engine half; the GUI-freeze half is GEECS-Console 0.15.0).
+  A stop clicked while the delegated runner was still resolving configs /
+  connecting devices / running preflight used to be ignored: the bridge
+  set `_abort_requested`, `RE.abort()` no-oped on the idle engine, and
+  nothing re-read the flag once the plan started — the scan ran against
+  the operator's intent.
+  - `run_scan_request` gains a `should_abort` hook (the bridge supplies
+    `lambda: self._abort_requested`), consulted between init stages —
+    after configuration resolution, after device connect, after the
+    preflight hook, and immediately before the scan-number claim (on the
+    optimize path: after device connect and before the runner's own
+    pre-bind claim).  **Every checkpoint is pre-claim, so an init-stage
+    stop burns no scan number**; a trip is the quiet aborted outcome
+    (`session.last_run_aborted` set, one INFO line, created devices
+    disconnected by the runner's `finally`).
+  - `GeecsSession.scan`/`optimize` gain the same `should_abort` and close
+    the residual idle-window race with an in-plan stop gate
+    (`_stop_gated`): the probe is re-read as the plan's very first
+    instruction, which the engine only fetches after reporting `running`
+    (bluesky 1.15.0 `run_engine.py::_run`), so a stop that lands between
+    the runner's last checkpoint and plan start still takes effect — the
+    gate skips the whole plan (zero messages, no run document) and
+    returns the quiet aborted outcome.
+  - `stop_scanning_thread` now returns promptly: the 15 s completion
+    join became a 2 s bookkeeping-only join (`_STOP_JOIN_TIMEOUT`), the
+    still-finishing case logs INFO instead of ERROR, and completion is
+    announced natively by the scan thread's terminal ABORTED/DONE
+    `ScanLifecycleEvent` (a STOPPING event is emitted at request time,
+    as before).  For a running plan the direct `RE.abort()` is kept —
+    verified against bluesky 1.15.0: `abort()` is valid from `running`
+    and `paused` and thread-safe (dispatched onto the engine loop via
+    `__interrupter_helper`'s `call_soon_threadsafe`); no
+    `request_pause()` is needed first.
+
+### Removed
+
+- Bridge dead code (waived finding from #572's review, in scope here):
+  the write-only `_last_run_uid` remnant and the caller-less
+  `_request_operator_decision` one-question seam (its behavior lives on
+  in `operator_channel.EventStreamOperator`).
+
 ## [0.39.0] - 2026-07-16
 
 ### Removed

--- a/GeecsBluesky/CHANGELOG.md
+++ b/GeecsBluesky/CHANGELOG.md
@@ -31,7 +31,12 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
     (bluesky 1.15.0 `run_engine.py::_run`), so a stop that lands between
     the runner's last checkpoint and plan start still takes effect — the
     gate skips the whole plan (zero messages, no run document) and
-    returns the quiet aborted outcome.
+    returns the quiet aborted outcome.  **Gate-path caveat**: on
+    `session.scan` the claim happens before the gate, so a stop landing
+    in the claim→plan-start window (the claim's network I/O + the
+    ScanInfo write) does burn a number — the folder holds ScanInfo and
+    no data, and the INFO line reads "stopped before the plan started".
+    Only the runner checkpoints carry the burns-nothing promise.
   - `stop_scanning_thread` now returns promptly: the 15 s completion
     join became a 2 s bookkeeping-only join (`_STOP_JOIN_TIMEOUT`), the
     still-finishing case logs INFO instead of ERROR, and completion is

--- a/GeecsBluesky/CLAUDE.md
+++ b/GeecsBluesky/CLAUDE.md
@@ -158,7 +158,8 @@ scanner.reinitialize(request)       # ScanRequest ONLY; validates fail-fast
 scanner.start_scan_thread()         # runs it via run_scan_request in a thread
 scanner.is_scanning_active()        # → bool
 scanner.estimate_current_completion()  # → 0.0–1.0
-scanner.stop_scanning_thread()      # RE.abort() + thread join
+scanner.stop_scanning_thread()      # request stop, returns promptly;
+                                    # ABORTED/DONE arrives via events
 scanner.run_action(name)            # on-demand ActionPlan (refused mid-scan)
 scanner.describe_action(name)       # pure dry-run (allowed mid-scan)
 ```

--- a/GeecsBluesky/geecs_bluesky/operator_channel.py
+++ b/GeecsBluesky/geecs_bluesky/operator_channel.py
@@ -119,8 +119,9 @@ class EventStreamOperator:
 
     Wraps the question in a :class:`~geecs_bluesky.events.DialogRequest`,
     emits a :class:`~geecs_bluesky.events.ScanDialogEvent` via the injected
-    callback, and waits on ``response_event``.  Behavior matches the previous
-    ``BlueskyScanner._request_operator_decision`` exactly: an emit failure or
+    callback, and waits on ``response_event``.  Behavior matches the
+    scanner's legacy one-question seam exactly (the since-deleted
+    ``BlueskyScanner._request_operator_decision``): an emit failure or
     an unanswered wait returns the question's default.
 
     Parameters

--- a/GeecsBluesky/geecs_bluesky/scan_request_runner.py
+++ b/GeecsBluesky/geecs_bluesky/scan_request_runner.py
@@ -1044,6 +1044,29 @@ def build_telemetry_readables(
     return [CaTelemetryGroup(members)], recorded
 
 
+def _stopped_during_init(
+    session: Any, should_abort: Callable[[], bool] | None, stage: str
+) -> bool:
+    """Return ``True`` when an operator stop arrived during initialization.
+
+    The init-stage checkpoints of :func:`run_scan_request`: all of them run
+    **pre-claim**, so a stop caught here burns no scan number.  On trip the
+    session's ``last_run_aborted`` is set (the quiet aborted-outcome
+    contract from #563 — callers distinguish "stopped" from "failed"
+    without an exception) and one INFO line is logged; the caller's
+    ``finally`` still owns disconnection of everything it created.
+    """
+    if should_abort is None or not should_abort():
+        return False
+    logger.info(
+        "scan stopped during initialization (%s); nothing claimed — "
+        "no scan number was burned",
+        stage,
+    )
+    session.last_run_aborted = True
+    return True
+
+
 def run_scan_request(
     session: Any,
     request: ScanRequest,
@@ -1056,6 +1079,7 @@ def run_scan_request(
     preflight: Callable[[list, bool], list | None] | None = None,
     on_scan_start: Callable[[int, int], None] | None = None,
     operator_channel: "OperatorChannel | None" = None,
+    should_abort: Callable[[], bool] | None = None,
 ) -> str | None:
     """Execute *request* on *session*; return the run uid.
 
@@ -1131,6 +1155,21 @@ def run_scan_request(
         detector is built).  ``None`` (headless default) answers with each
         question's default: continue-and-drop with a WARNING.  Distinct
         from *preflight*, which vets the already-built detector list.
+    should_abort :
+        Optional operator-stop probe (the GUI bridge passes
+        ``lambda: self._abort_requested``), consulted between the
+        initialization stages — after configuration resolution, after
+        device connect, after the *preflight* hook, and immediately before
+        the scan-number claim — because ``RE.abort()`` cannot stop a scan
+        that has not reached the RunEngine yet.  Every checkpoint is
+        pre-claim, so an init-stage stop burns no scan number; on trip the
+        runner disconnects what it created, logs one INFO line, sets
+        ``session.last_run_aborted`` (the #563 aborted-outcome contract)
+        and returns ``None``.  The callable is also handed to
+        ``session.scan``/``session.optimize``, whose in-plan gate closes
+        the residual window between the last checkpoint here and the
+        engine reporting ``running``.  ``None`` (headless default) checks
+        nothing.
 
     Returns
     -------
@@ -1181,6 +1220,7 @@ def run_scan_request(
             applied_defaults=applied_defaults,
             skipped_actions=skipped_actions,
             operator_channel=operator_channel,
+            should_abort=should_abort,
         )
 
     if not request.save_sets:
@@ -1210,6 +1250,8 @@ def run_scan_request(
         )
         return None
     devices_config = checked_config
+    if _stopped_during_init(session, should_abort, "after configuration resolution"):
+        return None
     slots = assemble_action_slots(request.actions, applied_defaults, rituals)
     warn_if_reserved_boundary_overrides(save_set)
 
@@ -1266,6 +1308,9 @@ def run_scan_request(
             detectors = list(detectors) + telemetry_readables
             created.extend(telemetry_readables)
 
+        if _stopped_during_init(session, should_abort, "after device connect"):
+            return None
+
         if preflight is not None:
             # Scanner-layer seam (operator dialogs): runs pre-claim by
             # construction — the claim happens inside session.scan below.
@@ -1277,6 +1322,8 @@ def run_scan_request(
                 )
                 return None
             detectors = list(checked)
+            if _stopped_during_init(session, should_abort, "after preflight"):
+                return None
 
         md: dict[str, Any] = {"scan_request_mode": request.mode.value}
         # Provenance: which named save sets were unioned for this scan.
@@ -1308,6 +1355,10 @@ def run_scan_request(
 
         if request.mode is ScanRequestMode.NOSCAN:
             scan_info["scan_mode"] = "noscan"
+            # The last pre-claim checkpoint: the claim happens inside
+            # session.scan, immediately below.
+            if _stopped_during_init(session, should_abort, "before scan-number claim"):
+                return None
             if on_scan_start is not None:
                 on_scan_start(1, request.shots_per_step)
             return session.scan(
@@ -1322,6 +1373,7 @@ def run_scan_request(
                 setup=setup,
                 per_step=per_step,
                 closeout=closeout,
+                should_abort=should_abort,
             )
 
         movables: list = []
@@ -1355,6 +1407,10 @@ def run_scan_request(
             scan_info["start"] = outer[0]
             scan_info["end"] = outer[-1]
             scan_info["step"] = (outer[1] - outer[0]) if len(outer) > 1 else 0
+        # The last pre-claim checkpoint: the claim happens inside
+        # session.scan, immediately below.
+        if _stopped_during_init(session, should_abort, "before scan-number claim"):
+            return None
         if on_scan_start is not None:
             on_scan_start(len(positions), len(positions) * request.shots_per_step)
         return session.scan(
@@ -1369,6 +1425,7 @@ def run_scan_request(
             setup=setup,
             per_step=per_step,
             closeout=closeout,
+            should_abort=should_abort,
         )
     finally:
         if created and hasattr(session, "disconnect"):
@@ -1389,6 +1446,7 @@ def _run_optimize_request(
     applied_defaults: dict[str, Any] | None = None,
     skipped_actions: dict[str, list[str]] | None = None,
     operator_channel: "OperatorChannel | None" = None,
+    should_abort: Callable[[], bool] | None = None,
 ) -> str | None:
     """Map an optimize-mode request onto :meth:`GeecsSession.optimize`.
 
@@ -1408,10 +1466,14 @@ def _run_optimize_request(
         ``"strict"`` or ``"free_run"``.
     objective, suggester :
         The ready-made optimization callables.
-    optimization_binder, device_requirements, on_scan_start, operator_channel :
+    optimization_binder, device_requirements, on_scan_start, operator_channel,
+    should_abort :
         As in :func:`run_scan_request` (the unserved-variables check runs
         here too, pre-claim, over the effective devices config — save-set
-        devices *and* optimizer-provisioned ones).  With a
+        devices *and* optimizer-provisioned ones; the *should_abort*
+        init-stage checkpoints run after device connect and immediately
+        before the claim — which on this path is the runner's own,
+        pre-bind).  With a
         binder (and no ready-made callables) the runner claims the scan
         itself, pre-bind, so the
         binder's analyzers get the real ``ScanTag`` — mirroring the legacy
@@ -1521,6 +1583,9 @@ def _run_optimize_request(
             variables[name] = movable
             created.append(movable)
 
+        if _stopped_during_init(session, should_abort, "after device connect"):
+            return None
+
         md: dict[str, Any] = {"scan_request_mode": request.mode.value}
         if request.save_sets:
             # Provenance: which named save sets were unioned for this scan.
@@ -1561,6 +1626,10 @@ def _run_optimize_request(
         scan_folder: str | None = None
         claimed_here = False
         try:
+            # The last pre-claim checkpoint: on this path the runner claims
+            # the scan itself (pre-bind), immediately below.
+            if _stopped_during_init(session, should_abort, "before scan-number claim"):
+                return None
             if objective is None or suggester is None:
                 # Binder path (checked non-None at entry): claim first so the
                 # binder's analyzers get the real ScanTag (docstring above).
@@ -1596,6 +1665,7 @@ def _run_optimize_request(
                     on_finish="best" if spec.move_to_best_on_finish else "hold",
                     scan_number=scan_number,
                     scan_folder=scan_folder,
+                    should_abort=should_abort,
                 )
             if claimed_here and getattr(session, "last_run_aborted", False):
                 # session.optimize returned the aborted outcome quietly

--- a/GeecsBluesky/geecs_bluesky/scanner_bridge/bluesky_scanner.py
+++ b/GeecsBluesky/geecs_bluesky/scanner_bridge/bluesky_scanner.py
@@ -98,7 +98,12 @@ from geecs_schemas import (
 
 logger = logging.getLogger(__name__)
 
-_THREAD_JOIN_TIMEOUT = 15.0
+# Bookkeeping-only join budget for stop_scanning_thread: long enough to
+# reap a thread whose plan cleanup is finishing, short enough that a stop
+# during initialization (the scan thread may sit in a 20 s device connect)
+# never blocks the caller — completion is announced via the lifecycle
+# event stream, not by this join (issue #571).
+_STOP_JOIN_TIMEOUT = 2.0
 
 # LabVIEW→Unix epoch offset; owned by geecs_bluesky.preflight, aliased here
 # because tests and external callers reference it at this path.
@@ -199,8 +204,6 @@ class BlueskyScanner:
         # The claimed day-scoped scan number for the current scan (None until
         # claimed); stamped onto every lifecycle event via _set_state.
         self._scan_number: int | None = None
-        # uid of the most recent run's start document (for the Tiled exporter)
-        self._last_run_uid: str | None = None
         # Ownership tracking for the shared session RunEngine (issue #511):
         # the start-document uid of the run *this scanner* owns, plus the
         # descriptor uids belonging to it.  Foreign runs (e.g. a headless
@@ -362,37 +365,58 @@ class BlueskyScanner:
         logger.info("BlueskyScanner scan thread started")
 
     def stop_scanning_thread(self) -> None:
-        """Abort the running scan and wait for the thread to finish.
+        """Request the running scan to stop; return promptly.
 
-        The abort flag is honoured even before the plan reaches the
-        RunEngine (``RE.abort()`` on an idle engine is a no-op, so a stop
-        clicked during device connect relies on the flag — see
-        :meth:`_abort_before_acquisition`).  If the scan thread does not
-        exit within the join timeout, the thread handle is *kept* so
-        :meth:`is_scanning_active` keeps reporting ``True``: clearing it
-        would let a second ``start_scan_thread`` run the still-busy
-        RunEngine under a live scan.
+        Safe to call from any thread, including a GUI worker: this method
+        never blocks on the scan winding down.  Completion is announced
+        the native way — the scan thread's cleanup emits the terminal
+        ABORTED/DONE :class:`ScanLifecycleEvent` through the event stream
+        the GUI already consumes (a STOPPING event is emitted here first).
+
+        How the stop lands, by phase (issue #571):
+
+        - **Running plan**: ``RE.abort()`` directly — valid from
+          ``running`` *and* ``paused``, and thread-safe (bluesky 1.15.0
+          ``run_engine.py``: ``abort()`` dispatches ``_abort_coro`` onto
+          the engine loop via ``__interrupter_helper``'s
+          ``call_soon_threadsafe``; from ``running`` it cancels the plan
+          task and returns without waiting on the plan's cleanup — no
+          ``request_pause()`` needed first).
+        - **Initialization** (idle engine — ``RE.abort()`` would raise
+          ``TransitionError``): the ``_abort_requested`` flag is read by
+          the delegated runner's init-stage checkpoints
+          (``run_scan_request(should_abort=...)``, all pre-claim) and,
+          for a stop landing between the last checkpoint and plan start,
+          by the session's in-plan stop gate.
+
+        If the scan thread does not exit within the short bookkeeping
+        join, the handle is *kept* so :meth:`is_scanning_active` keeps
+        reporting ``True``: clearing it would let a second
+        ``start_scan_thread`` run the still-busy RunEngine under a live
+        scan.
         """
         logger.info("BlueskyScanner: abort requested")
         self._abort_requested = True
         self._set_state("STOPPING")
         try:
-            # RE.abort() on an idle engine raises a TransitionError; the
-            # pre-RE abort path is covered by the _abort_requested flag.
+            # Idle engine: skip — the init-stage stop is covered by the
+            # should_abort checkpoints + the session's stop gate (above).
             if self._RE.state != "idle":
                 self._RE.abort(reason="stop_scanning_thread called")
         except Exception:
             logger.debug("RE.abort() raised (may not be running)", exc_info=True)
         thread = self._scan_thread
         if thread is not None:
-            thread.join(timeout=_THREAD_JOIN_TIMEOUT)
+            # Bookkeeping-only: never a completion wait (see docstring).
+            thread.join(timeout=_STOP_JOIN_TIMEOUT)
             if thread.is_alive():
-                logger.error(
-                    "BlueskyScanner: scan thread did not stop within %.0f s — "
-                    "keeping the thread handle; the scanner still reports "
-                    "active and must not be restarted or reinitialized until "
-                    "the thread exits",
-                    _THREAD_JOIN_TIMEOUT,
+                logger.info(
+                    "BlueskyScanner: scan thread still finishing after the "
+                    "%.0f s bookkeeping join (normal for a stop during "
+                    "initialization); the scanner keeps reporting active "
+                    "and the terminal lifecycle event will announce "
+                    "completion",
+                    _STOP_JOIN_TIMEOUT,
                 )
             else:
                 self._scan_thread = None
@@ -510,7 +534,6 @@ class BlueskyScanner:
                 return  # foreign run — this scanner has no scan in flight
             self._active_run_uid = doc.get("uid")
             self._active_descriptor_uids = set()
-            self._last_run_uid = doc.get("uid")
             self._note_claimed_scan_number(doc.get("scan_number"))
         elif name == "descriptor":
             uid = doc.get("uid")
@@ -637,9 +660,11 @@ class BlueskyScanner:
         """Return ``True`` (logging loudly) if a stop arrived before the plan ran.
 
         ``RE.abort()`` cannot stop a scan that has not reached the RunEngine
-        yet, so the scan thread checks this flag between thread start and
-        the ``RE(plan)`` invocation (after device connect, before the scan
-        folder is claimed).
+        yet.  This is the scan thread's entry check (a stop that landed
+        before the thread even started); the later initialization stages
+        are covered by the ``should_abort`` hook the delegated runner
+        consults between resolution, device connect, preflight, and the
+        claim (see :meth:`_run_delegated_request`).
         """
         if not self._abort_requested:
             return False
@@ -716,42 +741,6 @@ class BlueskyScanner:
             dialog_event_type=ScanDialogEvent,
             request_type=DialogRequest,
             default_timeout=_PREFLIGHT_DIALOG_TIMEOUT_S,
-        )
-
-    def _request_operator_decision(
-        self,
-        exc: Exception,
-        *,
-        title: str,
-        continue_label: str,
-        abort_label: str = "Abort Scan",
-        context: str | None = None,
-    ) -> str:
-        """Ask the operator one question through the injected channel.
-
-        Kept as the scanner's one-question seam (ad-hoc callers outside the
-        pre-flight pipeline).  Behavior is that of
-        :class:`~geecs_bluesky.operator_channel.EventStreamOperator`:
-
-        Returns
-        -------
-        str
-            ``"continue"`` or ``"abort"`` when the consumer answered;
-            ``"default"`` when there is no consumer (headless), the event
-            types are unavailable, or no answer arrived within
-            :data:`_PREFLIGHT_DIALOG_TIMEOUT_S` — callers must then preserve
-            today's behavior (proceed, fail loudly later).
-        """
-        return self._operator_channel().ask(
-            OperatorQuestion(
-                message=str(exc),
-                exc=exc,
-                context=context,
-                title=title,
-                continue_label=continue_label,
-                abort_label=abort_label,
-                timeout=_PREFLIGHT_DIALOG_TIMEOUT_S,
-            )
         )
 
     def _drop_devices(self, detectors: list, drop_ids: set[int]) -> list:
@@ -888,6 +877,11 @@ class BlueskyScanner:
                 else None
             ),
             operator_channel=self._delegated_operator_channel(),
+            # Stop clicked during initialization: the runner consults this
+            # between init stages (all pre-claim) and the session's stop
+            # gate re-reads it at plan start — RE.abort() alone cannot
+            # reach a scan that has not entered the RunEngine (issue #571).
+            should_abort=lambda: self._abort_requested,
         )
         if opt_bridge is not None and not getattr(
             self._session, "last_run_aborted", False

--- a/GeecsBluesky/geecs_bluesky/scanner_bridge/bluesky_scanner.py
+++ b/GeecsBluesky/geecs_bluesky/scanner_bridge/bluesky_scanner.py
@@ -394,8 +394,23 @@ class BlueskyScanner:
         reporting ``True``: clearing it would let a second
         ``start_scan_thread`` run the still-busy RunEngine under a live
         scan.
+
+        With no active scan (e.g. the click raced the scan's natural
+        completion) this is a logged no-op — no STOPPING event, so the
+        already-emitted terminal state stays the last word.
         """
         logger.info("BlueskyScanner: abort requested")
+        if not self.is_scanning_active():
+            # Nothing to stop — the scan may have just finished naturally
+            # (the click raced the last shot).  Emitting STOPPING here
+            # would repaint the state pill *after* the terminal DONE/
+            # ABORTED event and leave it stuck amber (#573 review); leave
+            # the state stream alone and just reap a dead thread handle.
+            thread = self._scan_thread
+            if thread is not None and not thread.is_alive():
+                self._scan_thread = None
+            logger.info("BlueskyScanner: no active scan; nothing to stop")
+            return
         self._abort_requested = True
         self._set_state("STOPPING")
         try:

--- a/GeecsBluesky/geecs_bluesky/session.py
+++ b/GeecsBluesky/geecs_bluesky/session.py
@@ -75,6 +75,42 @@ def _positions(start: float, end: float, step: float) -> list[float]:
     return list(np.linspace(start, end, n))
 
 
+def _stop_gated(plan: Any, should_abort: Callable[[], bool]) -> tuple[Any, list[bool]]:
+    """Wrap *plan* so a stop that landed in the idle window still takes effect.
+
+    ``RE.abort()`` on an idle engine raises ``TransitionError`` (a no-op to
+    a guarded caller), so a stop request that lands *after* the caller's
+    last pre-run check but *before* the engine reports ``running`` would
+    otherwise be lost — the flag is set, nobody reads it, the scan runs
+    (issue #571).  The gate re-reads *should_abort* as the plan's very
+    first instruction.  That closes the race completely: the engine sets
+    ``self._state = "running"`` before fetching the plan's first message
+    (bluesky 1.15.0, ``run_engine.py::_run``), so a stopper that observed
+    the engine ``idle`` set the flag strictly before this check runs, and
+    a stopper that observed it ``running`` used ``RE.abort()`` directly —
+    which is valid from ``running`` (``_abort_coro`` cancels the plan
+    task; no pause required first).
+
+    On trip the gate yields nothing: the engine processes zero messages,
+    opens no run, and settles back to idle; the second element of the
+    returned pair reads ``True`` so the caller can report the quiet
+    aborted outcome.
+    """
+    tripped = [False]
+
+    def gated():
+        if should_abort():
+            tripped[0] = True
+            # Never started, close for hygiene (generators only).
+            close = getattr(plan, "close", None)
+            if callable(close):
+                close()
+            return
+        return (yield from plan)
+
+    return gated(), tripped
+
+
 def _json_safe(value: Any) -> Any:  # Any: mirrors json.dumps's input surface
     """Recursively replace non-finite floats (NaN/inf) with ``None``.
 
@@ -566,6 +602,7 @@ class GeecsSession:
         setup: Any | None = None,
         per_step: Any | None = None,
         closeout: Any | None = None,
+        should_abort: Callable[[], bool] | None = None,
     ) -> str | None:
         """Run one scan with the full GEECS run discipline; return the run uid.
 
@@ -599,6 +636,15 @@ class GeecsSession:
         :attr:`last_run_aborted` set ``True`` and one INFO line logged.  A
         *pause* still propagates :class:`~bluesky.utils.RunEngineInterrupted`
         (the operator may resume).
+
+        ``should_abort`` (optional) is a stop probe re-read as the plan's
+        first instruction (:func:`_stop_gated`): it closes the window where
+        a stop lands after the caller's last check but before the engine
+        reports ``running`` (``RE.abort()`` is a no-op on an idle engine).
+        A trip is the same quiet aborted outcome — ``None`` returned,
+        :attr:`last_run_aborted` set — but nothing ran: no run document was
+        emitted (the scan number, when this call claimed one, was already
+        burned; the folder holds ScanInfo and no data).
         """
         if mode not in (_FREE_RUN, _STRICT):
             raise ValueError(f"mode={mode!r} invalid; use 'free_run' or 'strict'")
@@ -677,6 +723,10 @@ class GeecsSession:
             closeout=closeout,
         )
 
+        stop_gate = [False]
+        if should_abort is not None:
+            plan, stop_gate = _stop_gated(plan, should_abort)
+
         self._last_run_uid = None
         self.last_run_aborted = False
         # Headless scans get the same per-scan scan.log as bridge scans
@@ -703,6 +753,18 @@ class GeecsSession:
                 )
                 return self._last_run_uid
 
+            if stop_gate[0]:
+                # The stop landed in the idle window (after the caller's
+                # last pre-run check, before the engine reported running):
+                # the gate skipped the whole plan — zero messages, no run.
+                self.last_run_aborted = True
+                logger.info(
+                    "Scan %s stopped before the plan started; nothing ran "
+                    "(no data recorded)",
+                    scan_number if scan_number is not None else "(unsaved)",
+                )
+                return None
+
             if save_data and self._last_run_uid and scan_number is not None:
                 self._export_scalar_files(scan_number)
         return self._last_run_uid
@@ -723,6 +785,7 @@ class GeecsSession:
         on_finish: str = "hold",
         scan_number: int | None = None,
         scan_folder: str | None = None,
+        should_abort: Callable[[], bool] | None = None,
     ) -> tuple[str | None, list[dict]]:
         """Run an optimization **as a scan** (iteration = bin); return (uid, history).
 
@@ -768,6 +831,10 @@ class GeecsSession:
         ``on_finish`` restore-to-initial still runs (abort restores
         *initial*, never best), and one INFO line is logged.  A *pause*
         still propagates :class:`~bluesky.utils.RunEngineInterrupted`.
+        ``should_abort`` is the pre-plan-start stop gate, exactly as on
+        :meth:`scan` (:func:`_stop_gated`); a trip returns ``(None, [])``
+        quietly — nothing ran, so the variables were never moved and no
+        restore is needed.
         """
         if mode not in (_FREE_RUN, _STRICT):
             raise ValueError(f"mode={mode!r} invalid; use 'free_run' or 'strict'")
@@ -909,6 +976,10 @@ class GeecsSession:
 
             run_plan = bpp.finalize_wrapper(run_plan, controller.disarm())
 
+        stop_gate = [False]
+        if should_abort is not None:
+            run_plan, stop_gate = _stop_gated(run_plan, should_abort)
+
         # Headless optimizations get the same per-scan scan.log as bridge
         # runs (see scan()): attach only when this call claimed the number.
         with scan_log(scan_number, scan_folder) if claimed_here else nullcontext():
@@ -932,6 +1003,16 @@ class GeecsSession:
                 raise
             finally:
                 self.RE.unsubscribe(token)
+            if stop_gate[0]:
+                # Stop landed in the idle window: the gate skipped the whole
+                # plan — no iterations, no moves, nothing to restore.
+                self.last_run_aborted = True
+                logger.info(
+                    "Optimization scan %s stopped before the plan started; "
+                    "nothing ran (no data recorded)",
+                    scan_number if scan_number is not None else "(unsaved)",
+                )
+                return None, history
             if aborted:
                 # Operator-requested abort: the engine settled back to idle
                 # and its cleanup (finalize disarm) already ran.  Restore the

--- a/GeecsBluesky/pyproject.toml
+++ b/GeecsBluesky/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-bluesky"
-version = "0.39.0"
+version = "0.40.0"
 description = "Bluesky / ophyd-async bridge for the GEECS control system"
 authors = ["Sam Barber <sbarber@lbl.gov>"]
 readme = "README.md"

--- a/GeecsBluesky/tests/test_bluesky_scanner_progress_and_preflight.py
+++ b/GeecsBluesky/tests/test_bluesky_scanner_progress_and_preflight.py
@@ -167,7 +167,6 @@ def _make_scanner() -> BlueskyScanner:
     scanner._optimization_loader = None
     scanner._scan_request = None
     scanner._request_resolver = None
-    scanner._last_run_uid = None
     scanner._active_run_uid = None
     scanner._active_descriptor_uids = set()
     scanner._RE = SimpleNamespace(
@@ -241,7 +240,6 @@ def test_event_documents_emit_step_progress(monkeypatch) -> None:
             "event", {"descriptor": desc, "data": {"bin_number": bin_number}}
         )
 
-    assert scanner._last_run_uid == "abc"
     step_events = [e for e in events if isinstance(e, _FakeStepEvent)]
     assert [e.shots_completed for e in step_events] == [1, 2, 3, 4]
     assert [e.step_index for e in step_events] == [0, 0, 1, 1]

--- a/GeecsBluesky/tests/test_bluesky_scanner_scan_lifecycle.py
+++ b/GeecsBluesky/tests/test_bluesky_scanner_scan_lifecycle.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 
 import logging
 import threading
+import time
 from types import SimpleNamespace
 
 import pytest
@@ -120,10 +121,15 @@ def test_run_scan_without_stored_request_aborts_loudly(monkeypatch, caplog) -> N
 
 
 def test_timed_out_join_keeps_scanner_active(monkeypatch, caplog) -> None:
-    """A join timeout must not clear the handle while the thread still runs."""
+    """A join timeout must not clear the handle while the thread still runs.
+
+    The still-finishing case is INFO, not ERROR (issue #571): a stop during
+    initialization normally outlives the short bookkeeping join, and the
+    terminal lifecycle event — not this call — announces completion.
+    """
     scanner = _make_scanner()
     monkeypatch.setattr(bluesky_scanner, "ScanState", None)
-    monkeypatch.setattr(bluesky_scanner, "_THREAD_JOIN_TIMEOUT", 0.05)
+    monkeypatch.setattr(bluesky_scanner, "_STOP_JOIN_TIMEOUT", 0.05)
     scanner._RE = SimpleNamespace(state="running", abort=lambda reason=None: None)
 
     release = threading.Event()
@@ -132,12 +138,14 @@ def test_timed_out_join_keeps_scanner_active(monkeypatch, caplog) -> None:
     scanner._scan_thread = thread
     scanner._scan_finished = False
     try:
-        with caplog.at_level(logging.ERROR):
+        with caplog.at_level(logging.INFO):
             scanner.stop_scanning_thread()
 
         assert scanner._scan_thread is thread, "handle kept after timed-out join"
         assert scanner.is_scanning_active() is True
-        assert "did not stop" in caplog.text
+        assert "still finishing" in caplog.text
+        errors = [r for r in caplog.records if r.levelno >= logging.ERROR]
+        assert errors == [], "a slow stop is expected, never an ERROR"
     finally:
         release.set()
         thread.join(timeout=5)
@@ -147,6 +155,54 @@ def test_timed_out_join_keeps_scanner_active(monkeypatch, caplog) -> None:
     scanner.stop_scanning_thread()
     assert scanner._scan_thread is None
     assert scanner.is_scanning_active() is False
+
+
+def test_stop_returns_promptly_while_thread_is_stuck_in_init() -> None:
+    """stop_scanning_thread is bounded by the short bookkeeping join.
+
+    The GUI-freeze half of issue #571: the old 15 s join on the GUI thread
+    pinwheeled the window while the scan thread sat in 20 s device
+    connects.  The join budget is now a short constant, so even a
+    worst-case call returns in ~_STOP_JOIN_TIMEOUT.
+    """
+    scanner = _make_scanner()
+    scanner._RE = SimpleNamespace(state="idle", abort=lambda reason=None: None)
+
+    release = threading.Event()
+    thread = threading.Thread(target=release.wait, daemon=True, name="init-stuck")
+    thread.start()
+    scanner._scan_thread = thread
+    scanner._scan_finished = False
+    try:
+        started = time.monotonic()
+        scanner.stop_scanning_thread()
+        elapsed = time.monotonic() - started
+        assert elapsed < bluesky_scanner._STOP_JOIN_TIMEOUT + 1.0
+        assert scanner._abort_requested is True
+        assert scanner.is_scanning_active() is True
+    finally:
+        release.set()
+        thread.join(timeout=5)
+
+
+def test_delegated_request_supplies_should_abort_probe(monkeypatch) -> None:
+    """The bridge hands the runner a live probe of its abort flag."""
+    scanner = _make_scanner()
+    scanner._scan_request = _noscan_request_sentinel()
+    scanner._request_resolver = object()
+    captured: dict = {}
+
+    def capture(session, request, resolver, **kwargs):
+        captured.update(kwargs)
+        return None
+
+    monkeypatch.setattr(bluesky_scanner, "run_scan_request", capture)
+    scanner._run_delegated_request()
+
+    probe = captured["should_abort"]
+    assert probe() is False
+    scanner._abort_requested = True
+    assert probe() is True, "the probe must read the flag live, not a copy"
 
 
 # ---------------------------------------------------------------------------

--- a/GeecsBluesky/tests/test_bluesky_scanner_scan_lifecycle.py
+++ b/GeecsBluesky/tests/test_bluesky_scanner_scan_lifecycle.py
@@ -185,6 +185,22 @@ def test_stop_returns_promptly_while_thread_is_stuck_in_init() -> None:
         thread.join(timeout=5)
 
 
+def test_stop_with_no_active_scan_is_a_stateless_no_op(monkeypatch) -> None:
+    """A stop racing the scan's natural completion must not repaint the
+    already-emitted terminal state with STOPPING (#573 review finding),
+    nor park an abort flag on the idle scanner."""
+    scanner = _make_scanner()
+    monkeypatch.setattr(bluesky_scanner, "ScanState", None)
+    scanner._scan_finished = True  # the scan thread's cleanup already ran
+    scanner._scan_thread = None
+    scanner._current_state = "done"
+
+    scanner.stop_scanning_thread()
+
+    assert scanner._current_state == "done", "no STOPPING repaint after DONE"
+    assert scanner._abort_requested is False
+
+
 def test_delegated_request_supplies_should_abort_probe(monkeypatch) -> None:
     """The bridge hands the runner a live probe of its abort flag."""
     scanner = _make_scanner()

--- a/GeecsBluesky/tests/test_bluesky_scanner_scan_request_seam.py
+++ b/GeecsBluesky/tests/test_bluesky_scanner_scan_request_seam.py
@@ -236,7 +236,6 @@ def _make_scanner(session: _FakeSession) -> BlueskyScanner:
     scanner._scan_number = None
     scanner._abort_requested = False
     scanner._optimization_loader = None
-    scanner._last_run_uid = None
     scanner._active_run_uid = None
     scanner._active_descriptor_uids = set()
     scanner._scan_request = None
@@ -307,6 +306,10 @@ def _normalize_scan_kwargs(kwargs: dict) -> dict:
     for slot in ("setup", "per_step", "closeout"):
         if slot in normalized:
             normalized[slot] = normalized[slot] is not None
+    # The stop probe is a bridge-vs-headless seam by design: the bridge
+    # supplies its abort-flag lambda, a headless run supplies nothing
+    # (issue #571) — drop it from the parity comparison.
+    normalized.pop("should_abort", None)
     return normalized
 
 

--- a/GeecsBluesky/tests/test_operator_abort.py
+++ b/GeecsBluesky/tests/test_operator_abort.py
@@ -330,3 +330,114 @@ def test_abort_log_filter_attaches_once_across_sessions() -> None:
         f for f in s1.RE.log.logger.filters if isinstance(f, _RequestAbortLogFilter)
     ]
     assert len(ours) == 1
+
+
+# ---------------------------------------------------------------------------
+# The idle-window stop gate (#571): a stop that lands after the caller's
+# last pre-run check but before the engine reports 'running' must still
+# take effect.  RE.abort() on an idle engine raises TransitionError, so the
+# session re-reads should_abort as the plan's first instruction — which the
+# engine only fetches after setting state 'running' (bluesky 1.15.0,
+# run_engine.py::_run), giving a happens-before edge over any stopper that
+# observed the engine idle.
+# ---------------------------------------------------------------------------
+
+
+def test_stop_gate_trips_before_plan_start(caplog) -> None:
+    """should_abort True at plan start → zero messages, no run, quiet abort."""
+    s = _session()
+    det = s.detector("U_Cam", ["Sig"])
+    set_mock_value(det.acq_timestamp, 1000.0)
+    documents: list[str] = []
+    token = s.RE.subscribe(lambda name, doc: documents.append(name))
+    try:
+        with caplog.at_level(logging.INFO, logger="geecs_bluesky"):
+            uid = s.scan(
+                detectors=[det],
+                motor=None,
+                positions=[None],
+                shots_per_step=5,
+                mode="free_run",
+                save_data=False,
+                should_abort=lambda: True,  # the stop landed in the window
+            )
+    finally:
+        s.RE.unsubscribe(token)
+        s.disconnect(det)
+
+    assert uid is None
+    assert s.last_run_aborted is True
+    assert documents == [], "the gate must skip the plan before any run opens"
+    notes = [
+        r
+        for r in caplog.records
+        if "stopped before the plan started" in r.getMessage()
+        and r.name == "geecs_bluesky.session"
+    ]
+    assert len(notes) == 1 and notes[0].levelno == logging.INFO
+    assert _package_errors(caplog) == []
+
+
+def test_stop_gate_quiet_when_no_stop_requested() -> None:
+    """A never-tripping probe leaves the scan completely unchanged."""
+    s = _session()
+    det = s.detector("U_Cam", ["Sig"])
+    set_mock_value(det.acq_timestamp, 1000.0)
+    documents: list[str] = []
+    token = s.RE.subscribe(lambda name, doc: documents.append(name))
+    pacer = start_pacer(s.RE, [(det, 1000.0)], initial_delay=0.4, interval=0.05)
+    try:
+        s.scan(
+            detectors=[det],
+            motor=None,
+            positions=[None],
+            shots_per_step=2,
+            mode="free_run",
+            save_data=False,
+            should_abort=lambda: False,
+        )
+    finally:
+        pacer.cancel()
+        s.RE.unsubscribe(token)
+        s.disconnect(det)
+
+    assert s.last_run_aborted is False
+    assert "start" in documents and "stop" in documents
+
+
+def test_optimize_stop_gate_trips_before_plan_start(caplog) -> None:
+    """The same gate guards optimize: (None, []) returned, nothing moved."""
+    s = _session()
+    cam = s.detector("UC_Cam", ["Sig"], name="cam")
+    knob = s.settable("U_S1H", "Current", name="s1h")
+    set_mock_value(knob.readback, 5.0)
+    set_mock_value(cam.acq_timestamp, 1000.0)
+
+    class _NeverSuggester:
+        def suggest(self):
+            raise AssertionError("the plan must never run")
+
+        def observe(self, inputs, objective, bin_data):
+            raise AssertionError("the plan must never run")
+
+    try:
+        with caplog.at_level(logging.INFO, logger="geecs_bluesky"):
+            uid, history = s.optimize(
+                variables={"s1h": knob},
+                detectors=[cam],
+                objective=lambda bin_data: 1.0,
+                suggester=_NeverSuggester(),
+                shots_per_iteration=2,
+                max_iterations=3,
+                save_data=False,
+                on_finish="initial",
+                should_abort=lambda: True,
+            )
+    finally:
+        s.disconnect(cam, knob)
+
+    assert uid is None
+    assert history == []
+    assert s.last_run_aborted is True
+    assert s._read_movable(knob) == pytest.approx(5.0), "nothing moved, no restore"
+    assert _package_errors(caplog) == []

--- a/GeecsBluesky/tests/test_scan_request_runner.py
+++ b/GeecsBluesky/tests/test_scan_request_runner.py
@@ -2279,3 +2279,187 @@ def test_optimize_binder_operator_abort_notes_folder_calmly(
         and "Optimization scan" in r.getMessage()
     ]
     assert [r.levelno for r in notes] == [logging.WARNING]
+
+
+# ---------------------------------------------------------------------------
+# Operator stop during initialization — the should_abort checkpoints (#571)
+# ---------------------------------------------------------------------------
+#
+# RE.abort() cannot stop a scan that has not reached the RunEngine, so the
+# runner consults the injected probe between init stages: after configuration
+# resolution, after device connect, after the preflight hook, and immediately
+# before the scan-number claim.  Every checkpoint is pre-claim — an
+# init-stage stop must burn NO scan number — and trips into the quiet
+# aborted outcome (session.last_run_aborted set, one INFO line, created
+# devices disconnected, None returned).
+
+
+class _TripAfter:
+    """A should_abort probe that turns True from its Nth consultation on."""
+
+    def __init__(self, calls_before_trip: int) -> None:
+        self.calls_before_trip = calls_before_trip
+        self.calls = 0
+
+    def __call__(self) -> bool:
+        self.calls += 1
+        return self.calls > self.calls_before_trip
+
+
+def _init_stop_notes(caplog) -> list:
+    return [
+        r for r in caplog.records if "stopped during initialization" in r.getMessage()
+    ]
+
+
+def test_stop_after_resolution_builds_nothing_and_burns_nothing(
+    legacy_resolver, caplog
+) -> None:
+    session = _FakeSession()
+    with caplog.at_level(logging.INFO):
+        uid = run_scan_request(
+            session, _noscan_request(), legacy_resolver, should_abort=lambda: True
+        )
+
+    assert uid is None
+    assert session.devices == [], "no detector may be built after the stop"
+    assert session.scan_kwargs is None, "the claim (session.scan) never happens"
+    assert session.last_run_aborted is True
+    (note,) = _init_stop_notes(caplog)
+    assert note.levelno == logging.INFO
+    assert "nothing claimed" in note.getMessage()
+    assert [r for r in caplog.records if r.levelno >= logging.ERROR] == []
+
+
+def test_stop_after_device_connect_disconnects_created(legacy_resolver, caplog) -> None:
+    session = _FakeSession()
+    probe = _TripAfter(1)  # pass "after resolution", trip "after device connect"
+    with caplog.at_level(logging.INFO):
+        uid = run_scan_request(
+            session, _noscan_request(), legacy_resolver, should_abort=probe
+        )
+
+    assert uid is None
+    assert len(session.devices) == 3, "devices were built before the stop landed"
+    assert len(session.disconnected) == 3, "the runner's finally owns disconnect"
+    assert session.scan_kwargs is None
+    assert session.last_run_aborted is True
+    assert len(_init_stop_notes(caplog)) == 1
+
+
+def test_stop_after_preflight_checkpoint(legacy_resolver) -> None:
+    session = _FakeSession()
+    preflight_ran: list = []
+
+    def preflight(detectors, strict):
+        preflight_ran.append(strict)
+        return detectors
+
+    probe = _TripAfter(2)  # trip on the "after preflight" consultation
+    uid = run_scan_request(
+        session,
+        _noscan_request(),
+        legacy_resolver,
+        preflight=preflight,
+        should_abort=probe,
+    )
+
+    assert uid is None
+    assert preflight_ran == [False], "the stop landed after preflight ran"
+    assert session.scan_kwargs is None
+    assert session.last_run_aborted is True
+
+
+def test_stop_immediately_before_claim_burns_no_number(legacy_resolver, caplog) -> None:
+    """The last checkpoint: everything initialized, claim not yet made."""
+    session = _FakeSession()
+    probe = _TripAfter(2)  # no preflight hook → the 3rd consultation is pre-claim
+    with caplog.at_level(logging.INFO):
+        uid = run_scan_request(
+            session, _noscan_request(), legacy_resolver, should_abort=probe
+        )
+
+    assert uid is None
+    assert session.scan_kwargs is None, "session.scan (the claim) never ran"
+    assert session.last_run_aborted is True
+    (note,) = _init_stop_notes(caplog)
+    assert "before scan-number claim" in note.getMessage()
+
+
+def test_stop_pre_claim_on_step_path(legacy_resolver) -> None:
+    """The standard (step) branch has the same final pre-claim checkpoint."""
+    session = _FakeSession()
+    request = _noscan_request(
+        mode="step",
+        axes=[{"variable": "jet_z", "positions": {"start": 0, "end": 1, "step": 0.5}}],
+    )
+    uid = run_scan_request(
+        session, request, legacy_resolver, should_abort=_TripAfter(2)
+    )
+    assert uid is None
+    assert session.scan_kwargs is None
+    assert session.last_run_aborted is True
+
+
+def test_should_abort_probe_is_threaded_into_session_scan(legacy_resolver) -> None:
+    """A never-tripping probe reaches session.scan — the in-plan stop gate
+    that closes the window between the last checkpoint and plan start."""
+    session = _FakeSession()
+    probe = _TripAfter(10_000)
+    uid = run_scan_request(
+        session, _noscan_request(), legacy_resolver, should_abort=probe
+    )
+    assert uid == "uid-scan"
+    assert session.scan_kwargs["should_abort"] is probe
+
+
+def test_optimize_stop_pre_claim_burns_no_number(
+    legacy_resolver, monkeypatch, caplog
+) -> None:
+    """On the binder path the runner itself claims — the checkpoint precedes it."""
+    import geecs_bluesky.scan_request_runner as runner_module
+
+    def _no_claim(experiment):
+        raise AssertionError("claim_scan must not be called after a stop")
+
+    monkeypatch.setattr(runner_module, "claim_scan", _no_claim)
+    session = _FakeSession()
+
+    def binder(**_kwargs):
+        raise AssertionError("the binder must not be called after a stop")
+
+    # Consultations on this path: after device connect, then pre-claim.
+    probe = _TripAfter(1)
+    with caplog.at_level(logging.INFO):
+        uid = run_scan_request(
+            session,
+            _optimize_request(),
+            legacy_resolver,
+            optimization_binder=binder,
+            should_abort=probe,
+        )
+
+    assert uid is None
+    assert session.optimize_kwargs is None
+    assert session.last_run_aborted is True
+    # Movables + detectors were created before the stop; all disconnected.
+    assert len(session.disconnected) == len(session.devices) > 0
+    (note,) = _init_stop_notes(caplog)
+    assert "before scan-number claim" in note.getMessage()
+
+
+def test_optimize_should_abort_probe_reaches_session_optimize(
+    legacy_resolver,
+) -> None:
+    session = _FakeSession()
+    probe = _TripAfter(10_000)
+    uid = run_scan_request(
+        session,
+        _optimize_request(),
+        legacy_resolver,
+        objective=lambda bin_data: 1.0,
+        suggester=object(),
+        should_abort=probe,
+    )
+    assert uid == "uid-opt"
+    assert session.optimize_kwargs["should_abort"] is probe


### PR DESCRIPTION
## What

Fixes #571 the RunEngine-native way, post-G3: pressing Stop during scan
initialization used to (1) pinwheel the console for up to a minute and
(2) be silently ignored — the scan started anyway.

**Engine (GeecsBluesky 0.40.0)**

- `run_scan_request` gains a `should_abort: Callable[[], bool] | None`
  hook (the bridge supplies `lambda: self._abort_requested`), consulted
  between init stages: after configuration resolution, after device
  connect, after the preflight hook, and immediately before the
  scan-number claim (optimize path: after device connect + before the
  runner's own pre-bind claim). **Every runner checkpoint is pre-claim —
  a stop caught there burns no scan number.** (Gate-path caveat, from
  review finding 1: on `session.scan` the claim precedes the in-plan
  gate, so a stop landing in the claim→plan-start window still burns a
  number — folder with ScanInfo, no data, INFO "stopped before the
  plan started". Only the runner checkpoints carry the burns-nothing
  promise; the session docstring and CHANGELOG say so explicitly.) On trip: one INFO line
  ("stopped during initialization … nothing claimed"),
  `session.last_run_aborted = True` (the #563 quiet aborted-outcome
  contract, so the bridge reports ABORTED and optimize `finish()` is
  skipped), created devices disconnected by the runner's existing
  `finally`, `None` returned.
- **Idle-window race closed with an in-plan stop gate** (design choice
  below): `GeecsSession.scan`/`optimize` accept `should_abort` and wrap
  the plan in `_stop_gated`, which re-reads the probe as the plan's very
  first instruction. The engine sets `self._state = "running"` *before*
  fetching the plan's first message (bluesky 1.15.0
  `run_engine.py::_run`, line 1503), so a stopper that observed the
  engine `idle` (and therefore skipped `RE.abort()`) set the flag
  strictly before the gate runs — the gate trips, the engine processes
  zero messages, opens no run, and settles back to idle. A stopper that
  observed `running` used `RE.abort()` directly, which is verified
  correct from another thread while running: `abort()` dispatches
  `_abort_coro` onto the engine loop via `__interrupter_helper`'s
  `call_soon_threadsafe` and, from `running`, cancels the plan task
  without waiting on cleanup (bluesky 1.15.0 `run_engine.py`
  `abort`/`_abort_coro`/`__interrupter_helper`). The alternative — the
  bridge issuing `RE.request_pause()` once the engine reports running —
  was rejected: the `state_hook` fires on the engine loop thread, where
  `request_pause()`'s `run_coroutine_threadsafe(...).result()`
  self-deadlocks, and a pause would additionally strand the engine in
  `paused` needing a second abort step. The gate is pure plan
  composition, no engine internals.
- `stop_scanning_thread` no longer waits for completion: the 15 s join
  became a 2 s bookkeeping-only join (`_STOP_JOIN_TIMEOUT`); a
  still-finishing thread is INFO (normal during init stops), not ERROR;
  the thread handle is still kept so `is_scanning_active()` stays honest.
  Completion is announced natively by the scan thread's terminal
  ABORTED/DONE `ScanLifecycleEvent` (STOPPING is emitted at request
  time, as before).
- Cleanup rider (waived finding from #572's review, explicitly in scope
  here): removed the write-only `_last_run_uid` bridge remnant and the
  caller-less `_request_operator_decision` (its behavior lives on in
  `operator_channel.EventStreamOperator`; docstring cross-ref updated).

**Console (GEECS-Console 0.15.0)**

- `_on_stop_clicked` dispatches `stop_scanning_thread` through a
  `BackgroundResult` worker (the blessed daemon-thread → queued-signal
  shape; no result slot needed — completion arrives via the lifecycle
  stream). The Stop button disables and shows "Stopping…" until
  `_on_scan_state` sees a terminal state (aborted/done — exactly the
  engine's terminal vocabulary; `paused_on_error` deliberately
  excluded — resumable), then the label
  restores and normal gating resumes. The state pill knows the engine's
  STOPPING state (amber).

## Per-concern LOC (production code)

| Concern | Files | ~LOC |
|---|---|---|
| Runner init-stage checkpoints | `scan_request_runner.py` | +74/−5 |
| Session in-plan stop gate | `session.py` | +81 |
| Bridge stop rework + should_abort wiring | `scanner_bridge/bluesky_scanner.py` | +70/−48 |
| Bridge dead-code removal (rider) | `bluesky_scanner.py`, `operator_channel.py` | −40 |
| Console async stop + button state | `app/main_window.py`, `submission.py` | +50/−6 |
| Tests | 6 files | +410 |

## Tests

- **GeecsBluesky: 519 passed, 3 deselected** (was 505; +14 new,
  including the review-fix pin that a stop with no active scan emits no
  STOPPING repaint):
  runner checkpoint tests for each init stage — the pre-claim one
  asserts `session.scan`/`claim_scan` is never called, devices built
  before the trip are disconnected, INFO logged, `last_run_aborted` set;
  probe threaded through to `session.scan`/`optimize` pinned; real-RE
  session-gate tests (gate trips → zero documents emitted, quiet aborted
  outcome; never-tripping probe → normal run untouched; optimize
  gate → `(None, [])`, nothing moved); bridge stop returns promptly
  (timing assertion), still-finishing join is INFO not ERROR, live
  `should_abort` probe wiring. The #563 running-phase quiet-abort pins
  are untouched and green.
- **GEECS-Console: 748 passed** (was 745; +3 new, 1 updated to the async
  contract): stop click returns in <0.3 s with a 0.5 s-blocking
  submitter (the close-during-slow-read pattern), button shows
  "Stopping…" and disables, STOPPING lifecycle event keeps the hold,
  terminal event releases it and restores gating, stop with no active
  scan is a no-op.
- Remaining suites (untouched packages), run the way CI does via
  `scripts/check.sh` after installing the fresh worktree's envs per
  /env-doctor — all green: ImageAnalysis 224 passed / 1 skipped,
  ScanAnalysis 171 passed / 1 skipped, GEECS-Data-Utils 198 passed,
  GEECS-Schemas 211 passed, GeecsCAGateway 181 passed, GEECS-LogTriage
  53 passed; changed-files lint clean.

## Hardware verification

**OWED** (next lab session):
1. Click Stop during scan initialization (within the first seconds after
   Start, while device connects are logging): GUI stays responsive (no
   pinwheel), Stop shows "Stopping…", the scan never starts, terminal
   state ABORTED in the pill. Expected log: INFO "stopped during
   initialization … nothing claimed" and **no `ScanNNN` folder** in the
   common case; a stop landing in the narrow claim→plan-start window
   instead logs INFO "stopped before the plan started" with a claimed
   folder holding ScanInfo and no data — both are correct outcomes, do
   not score the second as a failure.
2. One running-phase stop stays quiet (#563 parity): scan aborts with
   cleanup (disarm, save-off), no ERROR blocks in scan.log, GUI returns
   to normal gating.

Closes #571.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
