### PR TITLE
GeecsBluesky 0.41.0: validate_scan_request — one fail-fast definition for bridge + runner

### DIFF
--- a/GeecsBluesky/CHANGELOG.md
+++ b/GeecsBluesky/CHANGELOG.md
@@ -4,6 +4,33 @@ All notable changes to `geecs-bluesky` are documented here.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.41.0] - 2026-07-16
+
+### Added
+
+- **`validate_scan_request(request, resolver)`** (issue #529) — THE one
+  fail-fast definition of "what must resolve" for a ScanRequest, in
+  `scan_request_runner`: experiment defaults, action names (nested `run`
+  references included), trigger profile + variant, the save-set rule
+  (non-optimize needs ≥1; optimize may run save-set-less), save sets +
+  entry rituals, step-axis movable targets (pseudo refused), and optimize
+  VOCS catalog names.  Pure resolution — no session, no hardware.
+
+### Changed
+
+- `BlueskyScanner.reinitialize` and `run_scan_request` both route through
+  `validate_scan_request` (the bridge for submission-time errors, the
+  runner as its own first phase), replacing the bridge's hand-maintained
+  "resolve and discard" mirror of the runner's resolution sequence — the
+  drift class where a new resolvable field surfaced its error in the scan
+  thread instead of at Start (it had already bitten once: the optimize
+  save-set-less rule of 0.38.0 was encoded twice).  New resolvable fields
+  are added to `validate_scan_request`, never to a caller.  The runner now
+  refuses a bad request **before** touching any session state (previously
+  the trigger profile was attached before some name resolutions); pinned
+  by `tests/test_validate_scan_request.py`, including a structural
+  no-drift spy on the bridge and a session-untouched fail-fast pin.
+
 ## [0.40.0] - 2026-07-16
 
 ### Fixed

--- a/GeecsBluesky/geecs_bluesky/scan_request_runner.py
+++ b/GeecsBluesky/geecs_bluesky/scan_request_runner.py
@@ -826,9 +826,14 @@ def validate_scan_request(
 
     Returns
     -------
-    tuple[ScanRequest, dict]
-        The **post-defaults** validated copy of *request*, and the applied-
-        defaults provenance record (as :func:`apply_experiment_defaults`).
+    tuple[ScanRequest, dict, Any]
+        The **post-defaults** validated copy of *request*, the applied-
+        defaults provenance record (as :func:`apply_experiment_defaults`),
+        and the raw defaults object itself — returned so execution reads
+        the defaults file exactly once per run (flags that are not request
+        fields, e.g. ``background_telemetry``, must come from the same
+        snapshot the validation applied, not a second read that could see
+        a concurrent edit).
 
     Raises
     ------
@@ -838,7 +843,8 @@ def validate_scan_request(
     NotImplementedError
         Pseudo (composite) scan variables — validated first, refused loudly.
     """
-    validated, applied = resolve_defaults_for(resolver, request)
+    defaults = resolve_experiment_defaults(resolver)
+    validated, applied = apply_experiment_defaults(request, defaults)
     resolve_and_validate_actions(validated.actions, resolver)
 
     if validated.trigger_profile:
@@ -867,7 +873,7 @@ def validate_scan_request(
                 spec = resolver.resolve_scan_variable(name)
                 resolve_movable_target(spec, name)
 
-    return validated, applied
+    return validated, applied, defaults
 
 
 def resolve_movable_target(
@@ -1269,10 +1275,10 @@ def run_scan_request(
     # must resolve does so here, before any session state is touched.  The
     # GUI bridge's reinitialize calls the same function, so submission-time
     # and execution-time validation cannot drift.
-    request, applied_defaults = validate_scan_request(request, resolver)
-    # The raw defaults object is still needed for execution-time flags that
-    # are not request fields (the background_telemetry experiment default).
-    defaults = resolve_experiment_defaults(resolver)
+    # The returned raw defaults object serves execution-time flags that are
+    # not request fields (background_telemetry) from the SAME file snapshot
+    # the validation applied — one read per run, no torn-edit window.
+    request, applied_defaults, defaults = validate_scan_request(request, resolver)
     resolved_actions = resolve_and_validate_actions(request.actions, resolver)
 
     if request.trigger_profile:

--- a/GeecsBluesky/geecs_bluesky/scan_request_runner.py
+++ b/GeecsBluesky/geecs_bluesky/scan_request_runner.py
@@ -792,6 +792,84 @@ def _defaults_flag(defaults: Any | None, name: str, fallback: bool) -> bool:
 # ---------------------------------------------------------------------------
 
 
+def validate_scan_request(
+    request: ScanRequest, resolver: ConfigResolver
+) -> tuple[ScanRequest, dict[str, Any]]:
+    """Fail-fast dry-run of everything :func:`run_scan_request` must resolve.
+
+    THE one definition of "what must resolve" (issue #529): the GUI
+    bridge's ``reinitialize`` calls this for submission-time errors, and
+    :func:`run_scan_request` runs it as its own first phase — so the
+    bridge's fail-fast can never drift from execution.  **When a new
+    resolvable field is added to the runner, its resolution is added
+    here**, never re-implemented in a caller.
+
+    Pure resolution: no session, no hardware, no side effects.  Resolved
+    products beyond the returned pair are discarded — execution re-resolves
+    what it needs.  Checks, in order: experiment defaults apply, every
+    action name (request-level; unknown nested ``run`` references included),
+    the trigger profile + variant, the save-set rule (a non-optimize
+    request needs at least one — optimize may run save-set-less because the
+    optimizer's ``device_requirements`` are auto-provisioned at execution
+    time, where an empty *effective* set still refuses pre-claim), every
+    named save set + entry rituals, every step-axis movable target (pseudo
+    variables refused), and every optimize VOCS catalog name (bare names
+    only — ``Device:Variable`` strings pass through, matching the runner's
+    dispatch).
+
+    Parameters
+    ----------
+    request :
+        The scan request to validate.
+    resolver :
+        Resolves the request's names to schema models.
+
+    Returns
+    -------
+    tuple[ScanRequest, dict]
+        The **post-defaults** validated copy of *request*, and the applied-
+        defaults provenance record (as :func:`apply_experiment_defaults`).
+
+    Raises
+    ------
+    GeecsConfigurationError
+        Unresolvable names, an unknown trigger variant, or a step/noscan
+        request without a save set.
+    NotImplementedError
+        Pseudo (composite) scan variables — validated first, refused loudly.
+    """
+    validated, applied = resolve_defaults_for(resolver, request)
+    resolve_and_validate_actions(validated.actions, resolver)
+
+    if validated.trigger_profile:
+        # Adapt (and discard) the writes so an unknown trigger_variant
+        # fails here, not at execution time.
+        profile = resolver.resolve_trigger_profile(validated.trigger_profile)
+        trigger_writes_from_profile(profile, validated.trigger_variant)
+
+    if not validated.save_sets:
+        if validated.mode is not ScanRequestMode.OPTIMIZE:
+            raise GeecsConfigurationError(
+                f"a {validated.mode.value!r} ScanRequest needs at least "
+                "one save set in save_sets — without one the scan would "
+                "record nothing"
+            )
+    else:
+        resolve_save_sets_and_rituals(resolver, validated.save_sets)
+
+    if validated.mode is ScanRequestMode.STEP:
+        for axis in validated.axes:
+            spec = resolver.resolve_scan_variable(axis.variable)
+            resolve_movable_target(spec, axis.variable)
+    if validated.mode is ScanRequestMode.OPTIMIZE and validated.optimization:
+        for name in validated.optimization.variables:
+            if ":" not in name:
+                spec = resolver.resolve_scan_variable(name)
+                resolve_movable_target(spec, name)
+
+    return validated, applied
+
+
 def resolve_movable_target(
     spec: ScanVariableSpec, name: str
 ) -> tuple[str, str, str, str | None]:
@@ -1187,8 +1265,14 @@ def run_scan_request(
         an optimize request with an empty effective device set (no save
         sets and no optimizer device requirements to provision).
     """
+    # Phase 1 — the one fail-fast definition (issue #529): everything that
+    # must resolve does so here, before any session state is touched.  The
+    # GUI bridge's reinitialize calls the same function, so submission-time
+    # and execution-time validation cannot drift.
+    request, applied_defaults = validate_scan_request(request, resolver)
+    # The raw defaults object is still needed for execution-time flags that
+    # are not request fields (the background_telemetry experiment default).
     defaults = resolve_experiment_defaults(resolver)
-    request, applied_defaults = apply_experiment_defaults(request, defaults)
     resolved_actions = resolve_and_validate_actions(request.actions, resolver)
 
     if request.trigger_profile:
@@ -1223,11 +1307,8 @@ def run_scan_request(
             should_abort=should_abort,
         )
 
-    if not request.save_sets:
-        raise GeecsConfigurationError(
-            f"a {request.mode.value!r} ScanRequest needs at least one save "
-            "set in save_sets — without one the scan would record nothing"
-        )
+    # A step/noscan request without a save set was already refused by
+    # validate_scan_request (phase 1) — no second copy of that rule here.
     # Multiple named save sets union into one effective save set (devices
     # deduped/merged; rituals collected across all sets, deduped by name).
     save_set, rituals = resolve_save_sets_and_rituals(resolver, request.save_sets)

--- a/GeecsBluesky/geecs_bluesky/scanner_bridge/bluesky_scanner.py
+++ b/GeecsBluesky/geecs_bluesky/scanner_bridge/bluesky_scanner.py
@@ -82,12 +82,8 @@ from geecs_bluesky.preflight import (
 from geecs_bluesky.scan_request_runner import (
     ConfigResolver,
     ConfigsRepoResolver,
-    resolve_and_validate_actions,
-    resolve_defaults_for,
-    resolve_movable_target,
-    resolve_save_sets_and_rituals,
     run_scan_request,
-    trigger_writes_from_profile,
+    validate_scan_request,
 )
 from geecs_bluesky.session import GeecsSession
 from geecs_schemas import (
@@ -283,43 +279,12 @@ class BlueskyScanner:
                 "suggester=...)"
             )
 
-        # Fail-fast validation on a LOCAL post-defaults copy; every result
-        # is discarded — run_scan_request re-resolves at execution time.
-        validated, _applied = resolve_defaults_for(resolver, request)
-        resolve_and_validate_actions(validated.actions, resolver)
-        if not validated.save_sets:
-            # Optimize may run save-set-less: the optimizer's
-            # device_requirements are auto-provisioned into the effective
-            # device set at execution time (the runner still refuses an
-            # empty *effective* set pre-claim).  Every other mode records
-            # nothing without a save set.
-            if validated.mode is not ScanRequestMode.OPTIMIZE:
-                raise GeecsConfigurationError(
-                    f"a {request.mode.value!r} ScanRequest needs at least "
-                    "one save set in save_sets — without one the scan "
-                    "would record nothing"
-                )
-        else:
-            resolve_save_sets_and_rituals(resolver, validated.save_sets)
-        if validated.trigger_profile:
-            # Adapt (and discard) the writes so an unknown trigger_variant
-            # fails here, not in the scan thread.
-            profile = resolver.resolve_trigger_profile(validated.trigger_profile)
-            trigger_writes_from_profile(profile, validated.trigger_variant)
-        if validated.mode is ScanRequestMode.STEP:
-            for axis in validated.axes:
-                # Resolve to an executable target so pseudo (composite)
-                # variables are refused here, not in the scan thread.
-                spec = resolver.resolve_scan_variable(axis.variable)
-                resolve_movable_target(spec, axis.variable)
-        if validated.mode is ScanRequestMode.OPTIMIZE and validated.optimization:
-            for name in validated.optimization.variables:
-                # Catalog names must resolve (and pseudo variables are
-                # refused) here, not in the scan thread; 'Device:Variable'
-                # strings pass through, matching the runner's dispatch.
-                if ":" not in name:
-                    spec = resolver.resolve_scan_variable(name)
-                    resolve_movable_target(spec, name)
+        # Fail-fast validation through THE one definition of "what must
+        # resolve" (scan_request_runner.validate_scan_request, issue #529);
+        # results are discarded — run_scan_request re-resolves at execution
+        # time (it runs the same function as its own first phase, so this
+        # submission-time check can never drift from execution).
+        validate_scan_request(request, resolver)
 
         # Store the ORIGINAL pre-defaults request (see docstring).
         self._scan_request = request

--- a/GeecsBluesky/pyproject.toml
+++ b/GeecsBluesky/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-bluesky"
-version = "0.40.0"
+version = "0.41.0"
 description = "Bluesky / ophyd-async bridge for the GEECS control system"
 authors = ["Sam Barber <sbarber@lbl.gov>"]
 readme = "README.md"

--- a/GeecsBluesky/tests/test_validate_scan_request.py
+++ b/GeecsBluesky/tests/test_validate_scan_request.py
@@ -149,7 +149,7 @@ def test_no_save_sets_allowed_for_optimize() -> None:
             "generator": {"name": "bayes_default"},
         },
     )
-    validated, applied = validate_scan_request(request, _resolver())
+    validated, applied, _defaults = validate_scan_request(request, _resolver())
     assert validated.mode.value == "optimize"
     assert applied == {}
 
@@ -222,7 +222,7 @@ def test_optimize_vocs_device_variable_passes_through() -> None:
             "generator": {"name": "bayes_default"},
         },
     )
-    validated, _applied = validate_scan_request(request, _resolver())
+    validated, _applied, _defaults = validate_scan_request(request, _resolver())
     assert validated.optimization is not None
 
 
@@ -238,7 +238,7 @@ def test_returns_post_defaults_copy_with_provenance() -> None:
         defaults={"trigger_profile": "HTU"},
     )
     request = _request()  # no trigger_profile of its own
-    validated, applied = validate_scan_request(request, resolver)
+    validated, applied, _defaults = validate_scan_request(request, resolver)
     assert validated.trigger_profile == "HTU"
     assert applied == {"trigger_profile": "HTU"}
     # The input request is untouched (post-defaults COPY, never in place).
@@ -248,7 +248,9 @@ def test_returns_post_defaults_copy_with_provenance() -> None:
 def test_valid_plan_names_resolve_clean() -> None:
     plan = ActionPlan.model_validate({"steps": [{"do": "wait", "seconds": 0.01}]})
     request = _request(actions={"setup": ["prep"]})
-    validated, applied = validate_scan_request(request, _resolver(plans={"prep": plan}))
+    validated, applied, _defaults = validate_scan_request(
+        request, _resolver(plans={"prep": plan})
+    )
     assert validated.actions.setup == ["prep"]
     assert applied == {}
 
@@ -270,7 +272,7 @@ def test_bridge_reinitialize_calls_the_shared_validator(monkeypatch) -> None:
 
     def _spy(request, resolver):
         calls.append((request, resolver))
-        return request, {}
+        return request, {}, None
 
     monkeypatch.setattr(bluesky_scanner, "validate_scan_request", _spy)
     scanner = bluesky_scanner.BlueskyScanner.__new__(bluesky_scanner.BlueskyScanner)

--- a/GeecsBluesky/tests/test_validate_scan_request.py
+++ b/GeecsBluesky/tests/test_validate_scan_request.py
@@ -1,0 +1,289 @@
+"""validate_scan_request — THE one fail-fast definition (issue #529).
+
+Pins the contract that submission-time validation (the GUI bridge's
+``reinitialize``) and execution-time validation (``run_scan_request``'s
+first phase) are the same function, so they cannot drift:
+
+* every resolvable category refuses loudly through the one function;
+* ``run_scan_request`` fails a bad request *before* touching any session
+  state (no ``shot_control`` attach on a doomed request);
+* the bridge routes ``reinitialize`` through the same function object.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from geecs_bluesky.exceptions import GeecsConfigurationError
+from geecs_bluesky.scan_request_runner import (
+    run_scan_request,
+    validate_scan_request,
+)
+from geecs_bluesky.scanner_bridge import bluesky_scanner
+from geecs_schemas import (
+    ActionPlan,
+    PseudoScanVariable,
+    SaveSet,
+    SaveSetEntry,
+    ScanRequest,
+    TriggerProfile,
+)
+
+# ---------------------------------------------------------------------------
+# Fakes
+# ---------------------------------------------------------------------------
+
+
+class _StubResolver:
+    """Name → schema-model dict resolver (unknown names refuse loudly)."""
+
+    def __init__(
+        self,
+        *,
+        save_sets=None,
+        trigger_profiles=None,
+        variables=None,
+        plans=None,
+        defaults=None,
+    ) -> None:
+        self.save_sets = save_sets or {}
+        self.trigger_profiles = trigger_profiles or {}
+        self.variables = variables or {}
+        self.plans = plans or {}
+        self.defaults = defaults
+
+    def resolve_save_set(self, name):
+        try:
+            return self.save_sets[name]
+        except KeyError:
+            raise GeecsConfigurationError(f"save set {name!r} not found") from None
+
+    def resolve_trigger_profile(self, name):
+        try:
+            return self.trigger_profiles[name]
+        except KeyError:
+            raise GeecsConfigurationError(
+                f"trigger profile {name!r} not found"
+            ) from None
+
+    def resolve_scan_variable(self, name):
+        try:
+            return self.variables[name]
+        except KeyError:
+            raise GeecsConfigurationError(f"scan variable {name!r} not found") from None
+
+    def resolve_action_plan(self, name):
+        try:
+            return self.plans[name]
+        except KeyError:
+            raise GeecsConfigurationError(f"action plan {name!r} not found") from None
+
+    def resolve_experiment_defaults(self):
+        return self.defaults
+
+
+class _RefusingSession:
+    """A session on which ANY touch is a test failure (fail-fast pin)."""
+
+    def __getattr__(self, name):
+        raise AssertionError(
+            f"run_scan_request touched session.{name} before validation "
+            "passed — phase 1 must fail first (issue #529)"
+        )
+
+
+_SAVE_SET = SaveSet(
+    name="baseline",
+    entries=[SaveSetEntry(device="U_Ref", scalars=["Sig"])],
+)
+
+
+def _resolver(**overrides) -> _StubResolver:
+    base = dict(save_sets={"baseline": _SAVE_SET})
+    base.update(overrides)
+    return _StubResolver(**base)
+
+
+def _request(**overrides) -> ScanRequest:
+    base = dict(
+        mode="noscan",
+        shots_per_step=1,
+        acquisition="free_run",
+        save_sets=["baseline"],
+    )
+    base.update(overrides)
+    return ScanRequest.model_validate(base)
+
+
+# ---------------------------------------------------------------------------
+# Each resolvable category refuses through the one function
+# ---------------------------------------------------------------------------
+
+
+def test_unknown_action_plan_refused() -> None:
+    request = _request(actions={"setup": ["nope"]})
+    with pytest.raises(GeecsConfigurationError, match="nope"):
+        validate_scan_request(request, _resolver())
+
+
+def test_unknown_save_set_refused() -> None:
+    with pytest.raises(GeecsConfigurationError, match="ghost"):
+        validate_scan_request(_request(save_sets=["ghost"]), _resolver())
+
+
+def test_no_save_sets_refused_for_non_optimize() -> None:
+    with pytest.raises(GeecsConfigurationError, match="at least one save"):
+        validate_scan_request(_request(save_sets=[]), _resolver())
+
+
+def test_no_save_sets_allowed_for_optimize() -> None:
+    # The optimizer's device_requirements are auto-provisioned at execution
+    # time; an empty *effective* set still refuses pre-claim there.
+    request = _request(
+        mode="optimize",
+        save_sets=[],
+        optimization={
+            "variables": {"U_S1H:Current": [-2.0, 2.0]},
+            "objectives": {"counts": "MAXIMIZE"},
+            "evaluator": {"module": "m", "class": "C"},
+            "generator": {"name": "bayes_default"},
+        },
+    )
+    validated, applied = validate_scan_request(request, _resolver())
+    assert validated.mode.value == "optimize"
+    assert applied == {}
+
+
+def test_unknown_trigger_profile_refused() -> None:
+    with pytest.raises(GeecsConfigurationError, match="trigger profile"):
+        validate_scan_request(_request(trigger_profile="HTU"), _resolver())
+
+
+def test_unknown_trigger_variant_refused() -> None:
+    profile = TriggerProfile(
+        name="HTU",
+        states={
+            "SCAN": [{"device": "U_DG", "variable": "Trigger.Source", "value": "Ext"}]
+        },
+    )
+    request = _request(trigger_profile="HTU", trigger_variant="no-such-variant")
+    with pytest.raises(GeecsConfigurationError, match="variant"):
+        validate_scan_request(request, _resolver(trigger_profiles={"HTU": profile}))
+
+
+def test_unresolvable_step_axis_refused() -> None:
+    request = _request(
+        mode="step",
+        axes=[{"variable": "ghost_axis", "positions": {"values": [0.0, 1.0]}}],
+    )
+    with pytest.raises(GeecsConfigurationError, match="ghost_axis"):
+        validate_scan_request(request, _resolver())
+
+
+def test_pseudo_step_axis_refused() -> None:
+    pseudo = PseudoScanVariable(
+        kind="pseudo",
+        targets=[{"target": "U_X:Pos", "forward": "combo"}],
+        mode="absolute",
+    )
+    request = _request(
+        mode="step",
+        axes=[{"variable": "combo", "positions": {"values": [0.0, 1.0]}}],
+    )
+    with pytest.raises(NotImplementedError, match="pseudo"):
+        validate_scan_request(request, _resolver(variables={"combo": pseudo}))
+
+
+def test_optimize_vocs_bare_name_must_resolve() -> None:
+    request = _request(
+        mode="optimize",
+        save_sets=[],
+        optimization={
+            "variables": {"ghost_var": [0.0, 1.0]},
+            "objectives": {"counts": "MAXIMIZE"},
+            "evaluator": {"module": "m", "class": "C"},
+            "generator": {"name": "bayes_default"},
+        },
+    )
+    with pytest.raises(GeecsConfigurationError, match="ghost_var"):
+        validate_scan_request(request, _resolver())
+
+
+def test_optimize_vocs_device_variable_passes_through() -> None:
+    # 'Device:Variable' strings bypass the catalog, matching the runner's
+    # execution-time dispatch.
+    request = _request(
+        mode="optimize",
+        save_sets=[],
+        optimization={
+            "variables": {"U_S1H:Current": [-2.0, 2.0]},
+            "objectives": {"counts": "MAXIMIZE"},
+            "evaluator": {"module": "m", "class": "C"},
+            "generator": {"name": "bayes_default"},
+        },
+    )
+    validated, _applied = validate_scan_request(request, _resolver())
+    assert validated.optimization is not None
+
+
+def test_returns_post_defaults_copy_with_provenance() -> None:
+    profile = TriggerProfile(
+        name="HTU",
+        states={
+            "SCAN": [{"device": "U_DG", "variable": "Trigger.Source", "value": "Ext"}]
+        },
+    )
+    resolver = _resolver(
+        trigger_profiles={"HTU": profile},
+        defaults={"trigger_profile": "HTU"},
+    )
+    request = _request()  # no trigger_profile of its own
+    validated, applied = validate_scan_request(request, resolver)
+    assert validated.trigger_profile == "HTU"
+    assert applied == {"trigger_profile": "HTU"}
+    # The input request is untouched (post-defaults COPY, never in place).
+    assert request.trigger_profile is None
+
+
+def test_valid_plan_names_resolve_clean() -> None:
+    plan = ActionPlan.model_validate({"steps": [{"do": "wait", "seconds": 0.01}]})
+    request = _request(actions={"setup": ["prep"]})
+    validated, applied = validate_scan_request(request, _resolver(plans={"prep": plan}))
+    assert validated.actions.setup == ["prep"]
+    assert applied == {}
+
+
+# ---------------------------------------------------------------------------
+# The two callers route through the one definition
+# ---------------------------------------------------------------------------
+
+
+def test_runner_fails_fast_before_touching_the_session() -> None:
+    """Phase 1 refuses a bad request before ANY session attribute is used."""
+    with pytest.raises(GeecsConfigurationError, match="ghost"):
+        run_scan_request(_RefusingSession(), _request(save_sets=["ghost"]), _resolver())
+
+
+def test_bridge_reinitialize_calls_the_shared_validator(monkeypatch) -> None:
+    """reinitialize IS validate_scan_request (structural no-drift pin)."""
+    calls: list[tuple] = []
+
+    def _spy(request, resolver):
+        calls.append((request, resolver))
+        return request, {}
+
+    monkeypatch.setattr(bluesky_scanner, "validate_scan_request", _spy)
+    scanner = bluesky_scanner.BlueskyScanner.__new__(bluesky_scanner.BlueskyScanner)
+    scanner._optimization_loader = None
+    scanner._experiment_dir = "TestExp"
+    scanner._scan_request = None
+    scanner._request_resolver = None
+    scanner._completed_shots = 0
+    scanner._total_shots = 0
+    scanner._total_steps = 0
+    scanner._scan_number = None
+
+    resolver = _resolver()
+    request = _request()
+    assert scanner.reinitialize(request, resolver=resolver) is True
+    assert calls == [(request, resolver)]


### PR DESCRIPTION
Closes #529.

## What + why

`BlueskyScanner.reinitialize` re-implemented `run_scan_request`'s resolution sequence in hand-maintained "resolve and discard" form — defaults, action names, trigger profile/variant, save sets + rituals, step-axis movable targets, optimize VOCS names. Any new resolvable field added to the runner had to be manually mirrored in the bridge, or GUI submitters got their error in the scan thread instead of at Start. The drift had already happened once: the optimize save-set-less rule (0.38.0) is encoded in both places today.

This extracts **`validate_scan_request(request, resolver)`** in `scan_request_runner` — pure resolution, no session, no hardware — and makes it THE one definition: the bridge calls it for submission-time errors (its whole 37-line mirror collapses to one call), and `run_scan_request` runs it as its own first phase. New resolvable fields get added there, never to a caller.

**One deliberate behavior improvement** (flagged for veto): the runner now refuses a bad request *before* touching any session state — previously it attached the trigger profile (`session.shot_control`) before resolving save sets and axis targets, so a doomed request could still mutate session shot-control state. Pinned by a test that runs `run_scan_request` against a session object where *any* attribute access is a failure.

## Per-concern LOC breakdown

- `validate_scan_request` + docstring (`scan_request_runner.py`): +80
- Runner phase-1 rewiring (head of `run_scan_request`; duplicate save-set raise removed — one definition): +10 / −9
- Bridge mirror deletion (`bluesky_scanner.py`: 37-line block → 1 call; 5 now-unused imports dropped): +7 / −40
- Tests (`tests/test_validate_scan_request.py`: 14 tests — every resolvable category refused through the one function, the optimize exemptions, defaults provenance + copy-not-in-place, the session-untouched fail-fast pin, and a structural spy pinning that `reinitialize` calls the shared function): +290
- Version bump + CHANGELOG (0.41.0 minor): +30

## Tests

- `./scripts/check.sh` (scoped): lint clean; **GeecsBluesky 533 passed, 3 deselected** (519 existing + 14 new). The existing bridge seam suite — which pins every fail-fast behavior through `reinitialize` (unknown names, pseudo refusal, defaults-not-applied-twice, store-original semantics) — passes unchanged through the shared function, pinning behavior preservation.

## Hardware verification

N/A — pure pre-claim name resolution; no scan execution, device I/O, or claim path touched. The only ordering change moves failures *earlier* (before `session.shot_control`), which has no hardware-observable surface on a request that was going to be refused anyway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)