### PR TITLE
GEECS-Console 0.15.1: main_window slimming step 1 — HealthPoller + tooltips out

### DIFF
--- a/GEECS-Console/CHANGELOG.md
+++ b/GEECS-Console/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to GEECS-Console are documented here.  Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versioning is
 semantic.
 
+## [0.15.1] - 2026-07-16
+
+### Changed
+
+- **main_window slimming, step 1** (issue #534 plan; no behavior change):
+  `HealthPoller` moved to `services/background.py` beside
+  `BackgroundResult` (the module now holds both blessed worker shapes,
+  one-shot + interval), and `ToolTipSuppressor` + the operator-tooltip
+  catalog moved to the new `app/tooltips.py` — the catalog is now pure
+  attribute-name → text data (`OPERATOR_TOOLTIPS`), applied by
+  `apply_operator_tooltips(window)`, raising loudly on a missing widget.
+  `main_window.py`: 2,390 → 2,125 lines.
+
 ## [0.15.0] - 2026-07-16
 
 ### Fixed

--- a/GEECS-Console/CHANGELOG.md
+++ b/GEECS-Console/CHANGELOG.md
@@ -15,7 +15,7 @@ semantic.
   catalog moved to the new `app/tooltips.py` — the catalog is now pure
   attribute-name → text data (`OPERATOR_TOOLTIPS`), applied by
   `apply_operator_tooltips(window)`, raising loudly on a missing widget.
-  `main_window.py`: 2,390 → 2,125 lines.
+  `main_window.py`: 2,390 → 2,124 lines.
 
 ## [0.15.0] - 2026-07-16
 

--- a/GEECS-Console/CLAUDE.md
+++ b/GEECS-Console/CLAUDE.md
@@ -235,7 +235,9 @@ are prefixed by region (`r3_radio_1d`, `r5_start_button`, …).
 - **`BackgroundResult`** (`services/background.py`, extracted from
   `app/main_window.py` in 0.10.0 — the shared home recorded on issue
   #510): the one blessed daemon-thread → queued-signal worker for one-shot
-  background calls (the `HealthPoller` shape, generalized).  **The daemon
+  background calls (the `HealthPoller` shape, generalized —
+  `HealthPoller` itself, the interval variant with in-flight skip, lives
+  beside it in the same module since 0.15.1 / issue #534 step 1).  **The daemon
   thread must emit on the worker QObject, never on the window**: emitting
   a window-owned signal from a daemon thread races window teardown and
   segfaults under offscreen pytest (observed directly when the idle scan
@@ -323,8 +325,11 @@ are prefixed by region (`r3_radio_1d`, `r5_start_button`, …).
   truth; a mapping to a missing or description-less field raises at editor
   construction.  When a tooltip reads poorly, fix the schema description,
   never hardcode GUI text.  Main-window operator controls carry
-  hand-written operator-language tooltips (`_apply_operator_tooltips`) —
-  those are GUI concepts with no schema counterpart.  **Preferences →
+  hand-written operator-language tooltips
+  (`app/tooltips.py::apply_operator_tooltips`, an attribute-name → text
+  catalog that raises loudly on a missing widget; `ToolTipSuppressor`
+  lives in the same module) — those are GUI concepts with no schema
+  counterpart.  **Preferences →
   Show tooltips** (persisted, default on) gates them all via
   `ToolTipSuppressor`, an application-level event filter that swallows
   `QEvent.ToolTip`; it is installed on the `QApplication` **only while

--- a/GEECS-Console/geecs_console/app/main_window.py
+++ b/GEECS-Console/geecs_console/app/main_window.py
@@ -15,11 +15,10 @@ from __future__ import annotations
 import logging
 import os
 import random
-import threading
 from pathlib import Path
 from typing import Callable, Optional
 
-from PySide6.QtCore import QEvent, QFile, QObject, Qt, QTimer, QUrl, Signal, Slot
+from PySide6.QtCore import QFile, Qt, QTimer, QUrl, Signal, Slot
 from PySide6.QtGui import QDesktopServices
 from PySide6.QtUiTools import QUiLoader
 from PySide6.QtWidgets import (
@@ -49,7 +48,8 @@ from geecs_console.editors.shot_control_editor import open_shot_control_editor
 from geecs_console.events_adapter import ScanEventsAdapter
 from geecs_console.services import ops_paths
 from geecs_console.services.action_library_store import ActionLibraryStore
-from geecs_console.services.background import BackgroundResult
+from geecs_console.app.tooltips import ToolTipSuppressor, apply_operator_tooltips
+from geecs_console.services.background import BackgroundResult, HealthPoller
 from geecs_console.services.device_completions import (
     CompletionsProvider,
     EmptyCompletions,
@@ -173,98 +173,6 @@ def load_stylesheet() -> str:
     return qss.replace("@UI_DIR@", ui_dir)
 
 
-class HealthPoller(QObject):
-    """Runs ``probe.poll()`` off the GUI thread and reports the result.
-
-    The poller itself lives on the GUI thread; each :meth:`poll_async` call
-    spawns a short-lived daemon thread that runs the (possibly slow) blocking
-    ``poll()`` and emits :attr:`report_ready` with the result.  Qt marshals the
-    emit back to the GUI-thread slot as a queued delivery, so the chips update
-    without ever blocking the event loop — and there is no worker Qt event loop
-    or cross-thread QTimer to manage.
-
-    Parameters
-    ----------
-    probe : HealthProbe
-        The probe to poll; only its ``poll()`` method is used, so it works
-        with the real probe, the stub, or a test fake.
-    """
-
-    report_ready = Signal(object)
-    """Carries one :class:`HealthReport` per completed poll."""
-
-    def __init__(self, probe: HealthProbe) -> None:
-        super().__init__()
-        self._probe = probe
-        self._busy = False
-
-    @Slot()
-    def poll_async(self) -> None:
-        """Kick off one poll in a daemon thread (skipped if one is in flight).
-
-        Called on the GUI thread from the interval timer; returns immediately.
-        """
-        if self._busy:
-            return
-        self._busy = True
-        threading.Thread(
-            target=self._run, name="console-health-poll", daemon=True
-        ).start()
-
-    def _run(self) -> None:
-        """Poll the probe (on the daemon thread) and emit the report."""
-        report = None
-        try:
-            report = self._probe.poll()
-        except Exception:  # noqa: BLE001 — a probe fault must not kill the poller
-            report = None
-        finally:
-            self._busy = False
-        if report is not None:
-            self.report_ready.emit(report)
-
-
-class ToolTipSuppressor(QObject):
-    """Application-level event filter that swallows every tooltip event.
-
-    Installed on the ``QApplication`` **only while tooltips are turned
-    off** — presence means suppression, so one switch covers every console
-    widget (the main window *and* the editor dialogs, whose schema-derived
-    tooltips are applied unconditionally) and the default-on path pays no
-    per-event Python filter cost at all.  Parented to the window: Qt
-    removes a destroyed filter from the application automatically, so a
-    closed window can never leave a dangling suppressor behind.
-
-    Parameters
-    ----------
-    parent : QObject
-        The owning window (keeps the wrapper referenced — the usual
-        PySide6 GC hazard — and bounds the filter's lifetime).
-    """
-
-    def __init__(self, parent: QObject) -> None:
-        super().__init__(parent)
-
-    def eventFilter(self, obj, event) -> bool:  # noqa: N802 — Qt override
-        """Swallow ``QEvent.ToolTip``; pass everything else through.
-
-        Parameters
-        ----------
-        obj : QObject
-            The event's target (unused — suppression is global).
-        event : QEvent
-            The event under consideration.
-
-        Returns
-        -------
-        bool
-            ``True`` (consume the event) for tooltip events.
-        """
-        if event.type() == QEvent.Type.ToolTip:
-            return True
-        return super().eventFilter(obj, event)
-
-
 class MainWindow(QMainWindow):
     """The operator console main window (screen map regions R1-R7).
 
@@ -371,7 +279,7 @@ class MainWindow(QMainWindow):
         self._apply_stylesheet()
         self._load_ui()
         self._bind_widgets()
-        self._apply_operator_tooltips()
+        apply_operator_tooltips(self)
         self._build_menus()
         self._build_status_bar()
         self._wire_signals()
@@ -522,180 +430,6 @@ class MainWindow(QMainWindow):
 
         for mode in (AcquisitionMode.FREE_RUN, AcquisitionMode.STRICT):
             self.acquisition_combo.addItem(mode.value)
-
-    def _apply_operator_tooltips(self) -> None:
-        """Set the operator-language tooltips on the main-window controls.
-
-        These are hand-written (what it does / what happens), not copies of
-        the widget labels.  Editor form fields are different: their tooltips
-        come from the schema field descriptions via
-        :mod:`~geecs_console.services.schema_tooltips` — single source of
-        truth (issue #497 phase 1).
-        """
-        tooltips = {
-            # R1 session bar
-            self.experiment_combo: (
-                "Which experiment's configs, presets, devices, and gateway "
-                "PVs the console works with. Changing it repopulates "
-                "everything below."
-            ),
-            self.rep_rate: (
-                "The machine repetition rate in Hz — informational for "
-                "free-run pacing; it does not command any hardware."
-            ),
-            self.trigger_profile_combo: (
-                "Trigger profile the scan drives the machine with (OFF / "
-                "STANDBY / SCAN / ... device writes). Empty means the scan "
-                "leaves the trigger alone."
-            ),
-            self.trigger_variant_combo: (
-                "Named operating condition of the trigger profile (e.g. "
-                "laser_off) — overlays a few writes on the base profile. "
-                "Empty runs the base behaviour."
-            ),
-            self.gateway_chip: (
-                "CA gateway health: reads the experiment's heartbeat PV "
-                "every few seconds. WARN means the gateway runs but reports "
-                "zero connected devices."
-            ),
-            self.tiled_chip: (
-                "Tiled data-server health: an HTTP check of the configured "
-                "Tiled URI every few seconds."
-            ),
-            self.db_chip: (
-                "GEECS experiment database health: a cheap MySQL query "
-                "every few seconds."
-            ),
-            # R2 save sets
-            self.available_list: (
-                "The experiment's save sets (named device groups) not yet "
-                "picked for this scan. Select and Add to require them."
-            ),
-            self.selected_list: (
-                "Save sets this scan records. Their devices are unioned; "
-                "each required device gets guarantees (completeness, "
-                "dialogs, images). At least one set is needed to start — "
-                "except in Optimization mode, where the optimizer config "
-                "provisions its own diagnostics."
-            ),
-            self.add_button: "Require the selected save sets for this scan.",
-            self.remove_button: (
-                "Drop the selected save sets from this scan (their devices "
-                "may still be logged as background telemetry)."
-            ),
-            self.union_label: (
-                "How many distinct devices the selected save sets add up to "
-                "after merging duplicates."
-            ),
-            # R3 scan form
-            self.radio_noscan: (
-                "Collect shots without moving anything — statistics at the "
-                "current machine settings."
-            ),
-            self.radio_1d: (
-                "Sweep one scan variable through start → stop in step-sized "
-                "moves, taking a batch of shots at each position."
-            ),
-            self.radio_grid: (
-                "Sweep two variables as a grid visiting every combination — "
-                "axis 1 is the outer (slow) loop, axis 2 the inner (fast) "
-                "one."
-            ),
-            self.radio_optimization: (
-                "Let an optimizer pick the settings each iteration, per the "
-                "optimizer config chosen below. Submission is accepted only "
-                "when the scan engine supports optimize scans."
-            ),
-            self.radio_background: (
-                "A no-scan whose data is marked as background/calibration "
-                "shots so analysis can find them later."
-            ),
-            self.optimization_combo: (
-                "Which optimizer config to run — the YAML files in this "
-                "experiment's optimizer_configs folder. Empty when offline "
-                "or the experiment has none (Start stays disabled)."
-            ),
-            self.iterations_spin: (
-                "How many optimizer iterations to run — total shots = "
-                "iterations × shots per step. Picking a config seeds this "
-                "from the config's own limit; 'auto' (0) submits no limit "
-                "and the engine's default budget applies."
-            ),
-            self.shots_per_step: (
-                "How many shots to take at each scan position / grid point "
-                "(or in total for a no-scan or background run)."
-            ),
-            self.acquisition_combo: (
-                "free_run: the trigger runs at the machine rate and device "
-                "rows are matched by timestamp afterwards. strict: the scan "
-                "fires each shot itself and waits for every device — "
-                "slower, but nothing is ever missing."
-            ),
-            self.shot_count_label: (
-                "Total shots this form implies (positions × shots per "
-                "step). Above the runaway-scan limit, Start is disabled."
-            ),
-            self.description_edit: (
-                "Free-text note about this scan — it ends up in the scan's "
-                "metadata and the experiment log."
-            ),
-            # R4 presets
-            self.preset_combo: (
-                "Saved scan requests for this experiment (one YAML each in "
-                "the configs repo's presets folder)."
-            ),
-            self.apply_button: (
-                "Load the selected preset into the form. Anything the form "
-                "cannot express (action bindings, position lists) is "
-                "refused, leaving the form untouched."
-            ),
-            self.save_as_button: (
-                "Save the current form as a named preset — the exact scan "
-                "request it would submit."
-            ),
-            self.delete_button: "Delete the selected preset's YAML file.",
-            # R5 submit row
-            self.start_button: (
-                "Build the scan request from this form and hand it to the "
-                "scan engine. Needs a valid shot count and at least one "
-                "selected save set; engine refusals show in the status bar."
-            ),
-            self.stop_button: (
-                "Ask the engine to stop the running scan at the next safe "
-                "point (closeout actions still run)."
-            ),
-            # R6 now panel
-            self.state_pill: "What the scan engine is doing right now.",
-            self.progress_bar: (
-                "Shots completed out of the running scan's announced total."
-            ),
-            self.scan_number_label: (
-                "The scan folder claimed by the running scan; '(previous)' "
-                "is the last scan found in today's data folder."
-            ),
-            self.log_tail: "The most recent scan-engine and console messages.",
-            # R7 device panel
-            self.device_combo: (
-                "Type or pick 'DeviceName:Variable Name' to watch its live "
-                "readback from the gateway (updates on commit, not per "
-                "keystroke)."
-            ),
-            self.readback_label: (
-                "Live readback of the selected device variable, streamed "
-                "from the gateway."
-            ),
-            self.set_field: (
-                "Value to write to the selected device variable — a number, "
-                "or a word the device understands (e.g. 'on')."
-            ),
-            self.set_button: (
-                "Write the value via the gateway setpoint and report the "
-                "outcome in the status bar. Disabled while a write is in "
-                "flight."
-            ),
-        }
-        for widget, text in tooltips.items():
-            widget.setToolTip(text)
 
     def _build_menus(self) -> None:
         """Create the menu bar (Ops / Actions / Editors / Preferences / Help).

--- a/GEECS-Console/geecs_console/app/tooltips.py
+++ b/GEECS-Console/geecs_console/app/tooltips.py
@@ -1,0 +1,246 @@
+"""Operator-language tooltips for the main window, and their kill switch.
+
+Main-window operator controls carry hand-written what-it-does tooltips
+(:data:`OPERATOR_TOOLTIPS`, applied by :func:`apply_operator_tooltips`) —
+GUI concepts with no schema counterpart.  Editor form fields are different:
+their tooltips come from the geecs-schemas field descriptions via
+:mod:`~geecs_console.services.schema_tooltips` — single source of truth
+(issue #497 phase 1); when a tooltip reads poorly there, fix the schema
+description, never hardcode GUI text.
+
+**Preferences → Show tooltips** gates them all via
+:class:`ToolTipSuppressor`, an application-level event filter installed
+**only while tooltips are off** — an always-installed per-window app filter
+measurably slowed the offscreen suite (every event crossing into a Python
+``eventFilter``), so presence = suppression.
+
+Both pieces moved here from ``app/main_window.py`` in the issue #534
+slimming (step 1).
+"""
+
+from __future__ import annotations
+
+from PySide6.QtCore import QEvent, QObject
+
+
+class ToolTipSuppressor(QObject):
+    """Application-level event filter that swallows every tooltip event.
+
+    Installed on the ``QApplication`` **only while tooltips are turned
+    off** — presence means suppression, so one switch covers every console
+    widget (the main window *and* the editor dialogs, whose schema-derived
+    tooltips are applied unconditionally) and the default-on path pays no
+    per-event Python filter cost at all.  Parented to the window: Qt
+    removes a destroyed filter from the application automatically, so a
+    closed window can never leave a dangling suppressor behind.
+
+    Parameters
+    ----------
+    parent : QObject
+        The owning window (keeps the wrapper referenced — the usual
+        PySide6 GC hazard — and bounds the filter's lifetime).
+    """
+
+    def __init__(self, parent: QObject) -> None:
+        super().__init__(parent)
+
+    def eventFilter(self, obj, event) -> bool:  # noqa: N802 — Qt override
+        """Swallow ``QEvent.ToolTip``; pass everything else through.
+
+        Parameters
+        ----------
+        obj : QObject
+            The event's target (unused — suppression is global).
+        event : QEvent
+            The event under consideration.
+
+        Returns
+        -------
+        bool
+            ``True`` (consume the event) for tooltip events.
+        """
+        if event.type() == QEvent.Type.ToolTip:
+            return True
+        return super().eventFilter(obj, event)
+
+
+#: Main-window widget attribute name → its operator tooltip.  Pure data —
+#: :func:`apply_operator_tooltips` resolves each name on the window and a
+#: missing widget raises loudly at construction (same fail-loud convention
+#: as the editors' schema tooltips).
+OPERATOR_TOOLTIPS: dict[str, str] = {
+    # R1 session bar
+    "experiment_combo": (
+        "Which experiment's configs, presets, devices, and gateway "
+        "PVs the console works with. Changing it repopulates "
+        "everything below."
+    ),
+    "rep_rate": (
+        "The machine repetition rate in Hz — informational for "
+        "free-run pacing; it does not command any hardware."
+    ),
+    "trigger_profile_combo": (
+        "Trigger profile the scan drives the machine with (OFF / "
+        "STANDBY / SCAN / ... device writes). Empty means the scan "
+        "leaves the trigger alone."
+    ),
+    "trigger_variant_combo": (
+        "Named operating condition of the trigger profile (e.g. "
+        "laser_off) — overlays a few writes on the base profile. "
+        "Empty runs the base behaviour."
+    ),
+    "gateway_chip": (
+        "CA gateway health: reads the experiment's heartbeat PV "
+        "every few seconds. WARN means the gateway runs but reports "
+        "zero connected devices."
+    ),
+    "tiled_chip": (
+        "Tiled data-server health: an HTTP check of the configured "
+        "Tiled URI every few seconds."
+    ),
+    "db_chip": (
+        "GEECS experiment database health: a cheap MySQL query every few seconds."
+    ),
+    # R2 save sets
+    "available_list": (
+        "The experiment's save sets (named device groups) not yet "
+        "picked for this scan. Select and Add to require them."
+    ),
+    "selected_list": (
+        "Save sets this scan records. Their devices are unioned; "
+        "each required device gets guarantees (completeness, "
+        "dialogs, images). At least one set is needed to start — "
+        "except in Optimization mode, where the optimizer config "
+        "provisions its own diagnostics."
+    ),
+    "add_button": "Require the selected save sets for this scan.",
+    "remove_button": (
+        "Drop the selected save sets from this scan (their devices "
+        "may still be logged as background telemetry)."
+    ),
+    "union_label": (
+        "How many distinct devices the selected save sets add up to "
+        "after merging duplicates."
+    ),
+    # R3 scan form
+    "radio_noscan": (
+        "Collect shots without moving anything — statistics at the "
+        "current machine settings."
+    ),
+    "radio_1d": (
+        "Sweep one scan variable through start → stop in step-sized "
+        "moves, taking a batch of shots at each position."
+    ),
+    "radio_grid": (
+        "Sweep two variables as a grid visiting every combination — "
+        "axis 1 is the outer (slow) loop, axis 2 the inner (fast) "
+        "one."
+    ),
+    "radio_optimization": (
+        "Let an optimizer pick the settings each iteration, per the "
+        "optimizer config chosen below. Submission is accepted only "
+        "when the scan engine supports optimize scans."
+    ),
+    "radio_background": (
+        "A no-scan whose data is marked as background/calibration "
+        "shots so analysis can find them later."
+    ),
+    "optimization_combo": (
+        "Which optimizer config to run — the YAML files in this "
+        "experiment's optimizer_configs folder. Empty when offline "
+        "or the experiment has none (Start stays disabled)."
+    ),
+    "iterations_spin": (
+        "How many optimizer iterations to run — total shots = "
+        "iterations × shots per step. Picking a config seeds this "
+        "from the config's own limit; 'auto' (0) submits no limit "
+        "and the engine's default budget applies."
+    ),
+    "shots_per_step": (
+        "How many shots to take at each scan position / grid point "
+        "(or in total for a no-scan or background run)."
+    ),
+    "acquisition_combo": (
+        "free_run: the trigger runs at the machine rate and device "
+        "rows are matched by timestamp afterwards. strict: the scan "
+        "fires each shot itself and waits for every device — "
+        "slower, but nothing is ever missing."
+    ),
+    "shot_count_label": (
+        "Total shots this form implies (positions × shots per "
+        "step). Above the runaway-scan limit, Start is disabled."
+    ),
+    "description_edit": (
+        "Free-text note about this scan — it ends up in the scan's "
+        "metadata and the experiment log."
+    ),
+    # R4 presets
+    "preset_combo": (
+        "Saved scan requests for this experiment (one YAML each in "
+        "the configs repo's presets folder)."
+    ),
+    "apply_button": (
+        "Load the selected preset into the form. Anything the form "
+        "cannot express (action bindings, position lists) is "
+        "refused, leaving the form untouched."
+    ),
+    "save_as_button": (
+        "Save the current form as a named preset — the exact scan "
+        "request it would submit."
+    ),
+    "delete_button": "Delete the selected preset's YAML file.",
+    # R5 submit row
+    "start_button": (
+        "Build the scan request from this form and hand it to the "
+        "scan engine. Needs a valid shot count and at least one "
+        "selected save set; engine refusals show in the status bar."
+    ),
+    "stop_button": (
+        "Ask the engine to stop the running scan at the next safe "
+        "point (closeout actions still run)."
+    ),
+    # R6 now panel
+    "state_pill": "What the scan engine is doing right now.",
+    "progress_bar": ("Shots completed out of the running scan's announced total."),
+    "scan_number_label": (
+        "The scan folder claimed by the running scan; '(previous)' "
+        "is the last scan found in today's data folder."
+    ),
+    "log_tail": "The most recent scan-engine and console messages.",
+    # R7 device panel
+    "device_combo": (
+        "Type or pick 'DeviceName:Variable Name' to watch its live "
+        "readback from the gateway (updates on commit, not per "
+        "keystroke)."
+    ),
+    "readback_label": (
+        "Live readback of the selected device variable, streamed from the gateway."
+    ),
+    "set_field": (
+        "Value to write to the selected device variable — a number, "
+        "or a word the device understands (e.g. 'on')."
+    ),
+    "set_button": (
+        "Write the value via the gateway setpoint and report the "
+        "outcome in the status bar. Disabled while a write is in "
+        "flight."
+    ),
+}
+
+
+def apply_operator_tooltips(window: QObject) -> None:
+    """Set the operator-language tooltips on the main-window controls.
+
+    These are hand-written (what it does / what happens), not copies of
+    the widget labels.  A name in :data:`OPERATOR_TOOLTIPS` that no longer
+    matches a window attribute raises ``AttributeError`` at construction —
+    the mapping and the widgets must move together.
+
+    Parameters
+    ----------
+    window : QObject
+        The main window carrying the widgets named in
+        :data:`OPERATOR_TOOLTIPS` as attributes.
+    """
+    for attr, text in OPERATOR_TOOLTIPS.items():
+        getattr(window, attr).setToolTip(text)

--- a/GEECS-Console/geecs_console/services/background.py
+++ b/GEECS-Console/geecs_console/services/background.py
@@ -1,19 +1,25 @@
-"""The one blessed daemon-thread → queued-signal worker for one-shot calls.
+"""The blessed daemon-thread → queued-signal workers (one-shot + interval).
 
-:class:`BackgroundResult` lived in ``app/main_window.py`` until the Actions
-menu needed it from a second window-family module (``app/action_dialog.py``);
-this is the shared extraction recorded on issue #510.  The scan browser uses
-it too (its former private twin, ``browser/_background.py::BrowserWorker``,
-was deleted once this module landed).
+:class:`BackgroundResult` (one-shot) lived in ``app/main_window.py`` until
+the Actions menu needed it from a second window-family module
+(``app/action_dialog.py``); this is the shared extraction recorded on issue
+#510.  The scan browser uses it too (its former private twin,
+``browser/_background.py::BrowserWorker``, was deleted once this module
+landed).  :class:`HealthPoller` — the interval-polling shape
+``BackgroundResult`` generalized — moved here from ``app/main_window.py``
+in the issue #534 slimming (step 1).
 """
 
 from __future__ import annotations
 
 import logging
 import threading
-from typing import Callable
+from typing import TYPE_CHECKING, Callable
 
-from PySide6.QtCore import QObject, Signal
+from PySide6.QtCore import QObject, Signal, Slot
+
+if TYPE_CHECKING:
+    from geecs_console.services.health import HealthProbe
 
 logger = logging.getLogger(__name__)
 
@@ -58,3 +64,58 @@ class BackgroundResult(QObject):
             self.result_ready.emit(result)
         except RuntimeError:
             pass  # the worker was deleted while the call ran
+
+
+class HealthPoller(QObject):
+    """Runs ``probe.poll()`` off the GUI thread and reports the result.
+
+    The interval-polling variant of the same daemon-thread → queued-signal
+    pattern as :class:`BackgroundResult` (which generalized this shape):
+    the poller itself lives on the GUI thread; each :meth:`poll_async` call
+    spawns a short-lived daemon thread that runs the (possibly slow)
+    blocking ``poll()`` and emits :attr:`report_ready` with the result.  Qt
+    marshals the emit back to the GUI-thread slot as a queued delivery, so
+    the chips update without ever blocking the event loop — and there is no
+    worker Qt event loop or cross-thread QTimer to manage.  Unlike the
+    one-shot worker it skips a poll while one is already in flight.
+
+    Parameters
+    ----------
+    probe :
+        The probe to poll; only its ``poll()`` method is used, so it works
+        with the real probe (:class:`~geecs_console.services.health.HealthProbe`),
+        the stub, or a test fake.
+    """
+
+    report_ready = Signal(object)
+    """Carries one :class:`~geecs_console.services.health.HealthReport` per poll."""
+
+    def __init__(self, probe: "HealthProbe") -> None:
+        super().__init__()
+        self._probe = probe
+        self._busy = False
+
+    @Slot()
+    def poll_async(self) -> None:
+        """Kick off one poll in a daemon thread (skipped if one is in flight).
+
+        Called on the GUI thread from the interval timer; returns immediately.
+        """
+        if self._busy:
+            return
+        self._busy = True
+        threading.Thread(
+            target=self._run, name="console-health-poll", daemon=True
+        ).start()
+
+    def _run(self) -> None:
+        """Poll the probe (on the daemon thread) and emit the report."""
+        report = None
+        try:
+            report = self._probe.poll()
+        except Exception:  # noqa: BLE001 — a probe fault must not kill the poller
+            report = None
+        finally:
+            self._busy = False
+        if report is not None:
+            self.report_ready.emit(report)

--- a/GEECS-Console/geecs_console/services/health.py
+++ b/GEECS-Console/geecs_console/services/health.py
@@ -5,8 +5,9 @@ The protocol and a stub live here alongside the real
 PV, an HTTP ping to Tiled, a GeecsDb connection check).  Every real
 dependency is imported lazily *inside* :meth:`GatewayTiledDbHealth.poll` so
 this module stays import-safe with zero network and without the ``ca`` extra.
-The probe is polled from a background thread (see the main window's
-``HealthPoller``); :meth:`poll` never blocks the GUI thread and never raises.
+The probe is polled from a background thread (see
+:class:`~geecs_console.services.background.HealthPoller`); :meth:`poll`
+never blocks the GUI thread and never raises.
 """
 
 from __future__ import annotations

--- a/GEECS-Console/pyproject.toml
+++ b/GEECS-Console/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-console"
-version = "0.15.0"
+version = "0.15.1"
 description = "Greenfield PySide6 operator console for GEECS (Bluesky/gateway architecture)"
 authors = ["Sam Barber <sbarber@lbl.gov>"]
 readme = "README.md"


### PR DESCRIPTION
First PR of the issue #534 extraction plan (step 1 of 5 — the only step with no forcing-function pairing needed: pure relocation, zero behavior change). `main_window.py`: **2,390 → 2,125 lines**.

## What + why

`main_window.py` crossed the documented danger size (the Scanner-GUI postmortem threshold) after the optimization and stop-lifecycle work. This moves the two module-level classes and the largest static block out:

- **`HealthPoller` → `services/background.py`**, beside `BackgroundResult` — whose docstring already described itself as "the HealthPoller shape, generalized". The module now holds both blessed daemon-thread → queued-signal worker shapes (one-shot + interval); the probe type hint is a `TYPE_CHECKING` import so no runtime coupling to `services/health` is added.
- **`ToolTipSuppressor` + the operator-tooltip catalog → new `app/tooltips.py`.** The ~160-line tooltip dict was keyed by widget *references* inside a method; it is now pure attribute-name → text data (`OPERATOR_TOOLTIPS`) applied by `apply_operator_tooltips(window)` — a missing widget raises `AttributeError` loudly at construction, the same fail-loud convention as the editors' schema tooltips.

Judgment-call detail (cheap to veto): converting the tooltip dict keys from widget references to attribute-name strings. It makes the catalog data instead of code and keeps widget refs out of the module, at the cost of one `getattr` indirection.

## Per-concern LOC breakdown

- `app/tooltips.py` (new): +246 (mostly the relocated tooltip text)
- `services/background.py`: +64 (HealthPoller + module-docstring update)
- `main_window.py`: −265 (both classes + the tooltip method), +2 (imports/call site)
- CLAUDE.md pointer updates: ~10 lines
- Version bump + CHANGELOG (0.15.1 patch): +16

## Tests

- `./scripts/check.sh` (scoped): lint clean; GEECS-Console **746 passed** (plus the 2 known env-shaped `*_without_the_extra` optimization failures — this local venv has the extra installed; they fail identically on `dev` and pass in CI). No test changes needed: nothing imported the moved classes directly (verified by grep), and the existing health-chip, tooltip-preference, and worker-behavior tests exercise both relocated pieces through the window.

## Hardware verification

None needed — GUI code relocation only; no scan execution or device path touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)