### PR TITLE
GeecsBluesky 0.42.0: deferred-pause checkpoints + last_state, delete hard-pause API

### DIFF
--- a/GeecsBluesky/CHANGELOG.md
+++ b/GeecsBluesky/CHANGELOG.md
@@ -8,10 +8,12 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
-- **Deferred-pause checkpoints in both step plans** (issue #552, PR-1 of
-  the G-actions v2 sequence): one `bps.checkpoint()` before each step's
-  move and one before every row, in `geecs_step_scan` and
-  `geecs_free_run_step_scan`.  `request_pause(defer=True)` now lands at a
+- **Deferred-pause checkpoints in all three scan plans** (issue #552,
+  PR-1 of the G-actions v2 sequence): one `bps.checkpoint()` before each
+  step's move / iteration and one before every row, in `geecs_step_scan`,
+  `geecs_free_run_step_scan`, and `geecs_adaptive_scan` (optimize — added
+  after review: without them a pause requested during an optimize scan
+  would never land and the console would sit in PAUSING).  `request_pause(defer=True)` now lands at a
   row/step boundary with an empty rewind cache — resume replays nothing
   (no re-move, no re-fire).  Zero behavior change for an unpaused scan.
   Pinned by `tests/test_pause_checkpoints.py` (checkpoint placement,

--- a/GeecsBluesky/CHANGELOG.md
+++ b/GeecsBluesky/CHANGELOG.md
@@ -4,6 +4,33 @@ All notable changes to `geecs-bluesky` are documented here.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.42.0] - 2026-07-16
+
+### Added
+
+- **Deferred-pause checkpoints in both step plans** (issue #552, PR-1 of
+  the G-actions v2 sequence): one `bps.checkpoint()` before each step's
+  move and one before every row, in `geecs_step_scan` and
+  `geecs_free_run_step_scan`.  `request_pause(defer=True)` now lands at a
+  row/step boundary with an empty rewind cache — resume replays nothing
+  (no re-move, no re-fire).  Zero behavior change for an unpaused scan.
+  Pinned by `tests/test_pause_checkpoints.py` (checkpoint placement,
+  never inside an open event bundle, and an RE-level deferred
+  pause + resume yielding every row exactly once).
+- **`ShotController.last_state`** — records the last *standing* state
+  actually driven (OFF/SCAN/STANDBY/ARMED; never the momentary
+  SINGLESHOT fire, so a later re-assert can never refire a shot).  Read
+  by the upcoming #552 pause supervisor to restore the trigger state
+  after an operator action runs in the pause window.
+
+### Removed
+
+- **`BlueskyScanner.pause_scan` / `resume_scan`** — the old hard-pause
+  API (`request_pause(defer=False)`).  With no checkpoints it was a
+  resume-replays-the-whole-scan trap; with them, a hard pause still
+  replays the partial row (re-firing a physical shot in strict mode).
+  No caller existed; absence pinned by test.
+
 ## [0.41.0] - 2026-07-16
 
 ### Added

--- a/GeecsBluesky/geecs_bluesky/plans/free_run_step_scan.py
+++ b/GeecsBluesky/geecs_bluesky/plans/free_run_step_scan.py
@@ -256,6 +256,12 @@ def geecs_free_run_step_scan(
         scan_event_index = 0
         previous: tuple | None = None
         for bin_number, pos in enumerate(_positions, start=1):
+            # Deferred-pause boundary (issue #552): a checkpoint before the
+            # move and before every row means request_pause(defer=True)
+            # lands with an empty rewind cache — resume replays nothing.
+            # A between-rows pause sits inside a SCAN window; the pause
+            # supervisor owns driving the trigger to a safe state there.
+            yield from bps.checkpoint()
             if _motors and pos is not None:
                 previous = yield from move_changed_axes(_motors, pos, previous)
             if per_step is not None:
@@ -265,6 +271,7 @@ def geecs_free_run_step_scan(
             if arm_trigger is not None:
                 yield from arm_trigger()
             for shot_index_in_bin in range(1, shots_per_step + 1):
+                yield from bps.checkpoint()
                 scan_event_index += 1
                 scan_context.set_context(
                     bin_number=bin_number,

--- a/GeecsBluesky/geecs_bluesky/plans/optimize.py
+++ b/GeecsBluesky/geecs_bluesky/plans/optimize.py
@@ -141,6 +141,12 @@ def geecs_adaptive_scan(
         try:
             scan_event_index = 0
             for iteration in range(1, max_iterations + 1):
+                # Deferred-pause boundary (issue #552): same per-iteration +
+                # per-row checkpoints as the step plans, so an operator
+                # action during an optimize scan can pause it — without
+                # these, request_pause(defer=True) never fires and the
+                # console would sit in PAUSING while the scan ran on.
+                yield from bps.checkpoint()
                 proposal = propose_pool.submit(propose, iteration)
                 while not proposal.done():
                     yield from bps.sleep(_PROPOSE_POLL_S)
@@ -155,6 +161,7 @@ def geecs_adaptive_scan(
                 if arm_trigger is not None:
                     yield from arm_trigger()
                 for shot_index_in_bin in range(1, shots_per_iteration + 1):
+                    yield from bps.checkpoint()
                     scan_event_index += 1
                     scan_context.set_context(
                         bin_number=iteration,

--- a/GeecsBluesky/geecs_bluesky/plans/step_scan.py
+++ b/GeecsBluesky/geecs_bluesky/plans/step_scan.py
@@ -229,6 +229,12 @@ def geecs_step_scan(
         scan_event_index = 0
         previous: tuple | None = None
         for bin_number, pos in enumerate(_positions, start=1):
+            # Deferred-pause boundary (issue #552): a checkpoint before the
+            # move and before every row means request_pause(defer=True)
+            # lands with an empty rewind cache — resume replays nothing
+            # (no re-move, no re-fire).  Never place a checkpoint between
+            # create and save (IllegalMessageSequence).
+            yield from bps.checkpoint()
             if _motors and pos is not None:
                 previous = yield from move_changed_axes(_motors, pos, previous)
             if per_step is not None:
@@ -238,6 +244,7 @@ def geecs_step_scan(
             if arm_trigger is not None:
                 yield from arm_trigger()
             for shot_index_in_bin in range(1, shots_per_step + 1):
+                yield from bps.checkpoint()
                 scan_event_index += 1
                 scan_context.set_context(
                     bin_number=bin_number,

--- a/GeecsBluesky/geecs_bluesky/scanner_bridge/bluesky_scanner.py
+++ b/GeecsBluesky/geecs_bluesky/scanner_bridge/bluesky_scanner.py
@@ -401,21 +401,11 @@ class BlueskyScanner:
             else:
                 self._scan_thread = None
 
-    def pause_scan(self) -> None:
-        """Request the RunEngine to pause between plans steps."""
-        logger.info("BlueskyScanner: pause requested")
-        try:
-            self._RE.request_pause()
-        except Exception:
-            logger.debug("RE.request_pause() raised", exc_info=True)
-
-    def resume_scan(self) -> None:
-        """Resume a paused RunEngine."""
-        logger.info("BlueskyScanner: resume requested")
-        try:
-            self._RE.resume()
-        except Exception:
-            logger.debug("RE.resume() raised", exc_info=True)
+    # pause_scan/resume_scan were deleted (issue #552 PR-1): they issued a
+    # HARD pause (request_pause(defer=False)) whose resume replays the
+    # partial row — in strict mode refiring a physical shot — and no caller
+    # existed.  The deferred pause/decide/resume flow arrives with the #552
+    # pause supervisor; do not reintroduce a bare pause API.
 
     def is_scanning_active(self) -> bool:
         """Return ``True`` if a scan thread is currently running.

--- a/GeecsBluesky/geecs_bluesky/shot_controller.py
+++ b/GeecsBluesky/geecs_bluesky/shot_controller.py
@@ -81,6 +81,11 @@ class ShotController:
         # {state_name: [(setter, value), ...]} — set by from_writes.
         self._transitions: dict[str, list[tuple[Any, str]]] | None = None
         self._writes: ShotControlWrites | None = None
+        #: The last *standing* state actually driven (writes issued) —
+        #: OFF/SCAN/STANDBY/ARMED, never the momentary SINGLESHOT fire.
+        #: The #552 pause supervisor reads this to know what to re-assert
+        #: after an operator action runs in the pause window.
+        self.last_state: str | None = None
 
     # ------------------------------------------------------------------
     # Factories
@@ -206,6 +211,7 @@ class ShotController:
                 yield from bps.abs_set(setter, value, group=group)
                 yield from bps.wait(group)
             if ordered:
+                self._record_state(name)
                 logger.info("Shot controller → %s", name)
             return
         group = f"shot_ctrl_{state}"
@@ -216,7 +222,18 @@ class ShotController:
                 yield from bps.abs_set(setter, val, group=group)
         if writes:
             yield from bps.wait(group)
+            self._record_state(state)
             logger.info("Shot controller → %s", state)
+
+    def _record_state(self, state: str | ShotControlState) -> None:
+        """Remember *state* as :attr:`last_state` if it is a standing state.
+
+        ``SINGLESHOT`` is a momentary fire, not a standing state — recording
+        it would make a later re-assert refire a physical shot.
+        """
+        name = state.value if isinstance(state, ShotControlState) else str(state)
+        if name != ShotControlState.SINGLESHOT.value:
+            self.last_state = name
 
     def arm(self):
         """Plan stub: SCAN state (data-taking, trigger running)."""

--- a/GeecsBluesky/pyproject.toml
+++ b/GeecsBluesky/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-bluesky"
-version = "0.41.0"
+version = "0.42.0"
 description = "Bluesky / ophyd-async bridge for the GEECS control system"
 authors = ["Sam Barber <sbarber@lbl.gov>"]
 readme = "README.md"

--- a/GeecsBluesky/tests/test_grid_plans_message_level.py
+++ b/GeecsBluesky/tests/test_grid_plans_message_level.py
@@ -108,9 +108,10 @@ def test_per_step_runs_after_move_before_shots_at_every_grid_point() -> None:
             continue
         # No trigger/create between this step's moves and the marker.  The
         # row's deferred-pause checkpoint (issue #552) sits between the
-        # marker and the first shot — part of the row boundary, not a shot.
-        after = commands[index + 1]
-        assert after in ("checkpoint", "trigger", "create"), after
+        # marker and the first shot — skip it so the original "nothing
+        # hides between per_step and the first shot" pin keeps its teeth.
+        after = next(c for c in commands[index + 1 :] if c != "checkpoint")
+        assert after in ("trigger", "create"), after
         before = commands[index - 1]
         assert before in ("wait", "open_run"), before
 

--- a/GeecsBluesky/tests/test_grid_plans_message_level.py
+++ b/GeecsBluesky/tests/test_grid_plans_message_level.py
@@ -106,9 +106,11 @@ def test_per_step_runs_after_move_before_shots_at_every_grid_point() -> None:
     for index, command in enumerate(commands):
         if command != "per_step_marker":
             continue
-        # No trigger/create between this step's moves and the marker.
+        # No trigger/create between this step's moves and the marker.  The
+        # row's deferred-pause checkpoint (issue #552) sits between the
+        # marker and the first shot — part of the row boundary, not a shot.
         after = commands[index + 1]
-        assert after in ("trigger", "create"), after
+        assert after in ("checkpoint", "trigger", "create"), after
         before = commands[index - 1]
         assert before in ("wait", "open_run"), before
 

--- a/GeecsBluesky/tests/test_optimize.py
+++ b/GeecsBluesky/tests/test_optimize.py
@@ -239,3 +239,47 @@ def test_move_movables_uses_movable_set_not_raw_setpoint(caplog) -> None:
     warnings = [r for r in caplog.records if "could not move" in r.getMessage()]
     assert len(warnings) == 1
     assert warnings[0].exc_info is not None
+
+
+def test_adaptive_scan_checkpoints_per_iteration_and_row() -> None:
+    """Optimize scans carry the same deferred-pause checkpoints (issue #552).
+
+    Without them, request_pause(defer=True) during an optimize scan would
+    never fire — the console would sit in PAUSING while the scan ran on.
+    2 iterations × (1 pre-iteration + 2 pre-row) = 6 checkpoints, never
+    inside an open event bundle.
+    """
+    s = GeecsSession("Test", tiled=False, mock=True)
+    cam = s.detector("UC_Cam", ["Sig"], name="cam")
+    knob = s.settable("U_S1H", "Current", name="s1h")
+    callback_on_mock_put(
+        knob._setpoint, lambda v, **kw: set_mock_value(knob.readback, v)
+    )
+    set_mock_value(cam.acq_timestamp, 1000.0)
+    commands: list[str] = []
+    s.RE.msg_hook = lambda msg: commands.append(msg.command)
+    pacer = start_pacer(s.RE, [(cam, 1000.0)], initial_delay=0.8, interval=0.15)
+    try:
+        s.optimize(
+            variables={"s1h": knob},
+            detectors=[cam],
+            objective=lambda bin_data: 0.0,
+            suggester=ScriptedSuggester([{"s1h": 0.1}, {"s1h": 0.4}]),
+            shots_per_iteration=2,
+            max_iterations=5,
+            save_data=False,
+        )
+    finally:
+        pacer.cancel()
+
+    # 2 scripted iterations + the stopping call's own pre-iteration
+    # checkpoint (the suggester answers None on the 3rd propose).
+    assert commands.count("checkpoint") == 2 * (1 + 2) + 1
+    open_bundle = False
+    for command in commands:
+        if command == "create":
+            open_bundle = True
+        elif command == "save":
+            open_bundle = False
+        elif command == "checkpoint":
+            assert not open_bundle

--- a/GeecsBluesky/tests/test_pause_checkpoints.py
+++ b/GeecsBluesky/tests/test_pause_checkpoints.py
@@ -252,3 +252,49 @@ def test_hard_pause_bridge_api_deleted() -> None:
     """pause_scan/resume_scan (hard pause, replay trap) must not return."""
     assert not hasattr(BlueskyScanner, "pause_scan")
     assert not hasattr(BlueskyScanner, "resume_scan")
+
+
+def test_free_run_plan_checkpoints_per_step_and_row_never_in_bundle() -> None:
+    """Free-run (production mode): same checkpoint contract, incl. tail flush.
+
+    Motorless statistics run, 1 bin × 2 shots → 1 pre-move + 2 pre-row
+    checkpoints; the tail-flush create/read/save bundle must contain none.
+    """
+    pytest.importorskip("aioca")
+    from ophyd_async.core import set_mock_value
+
+    from geecs_bluesky.devices.ca import CaGenericDetector
+    from geecs_bluesky.plans.free_run_step_scan import geecs_free_run_step_scan
+    from tests.ca_mock_helpers import connect_mock, start_pacer
+
+    ref = CaGenericDetector("U_Ref", ["Sig"], name="ref")
+    ref.configure_shot_id(rep_rate_hz=1.0)
+
+    RE = RunEngine()
+    commands: list[str] = []
+    RE.msg_hook = lambda msg: commands.append(msg.command)
+    connect_mock(RE, ref)
+    set_mock_value(ref.acq_timestamp, 1000.0)
+    pacer = start_pacer(RE, [(ref, 1000.0)], initial_delay=0.2, interval=0.1)
+    try:
+        RE(
+            geecs_free_run_step_scan(
+                motor=None,
+                positions=[None],
+                reference=ref,
+                detectors=[],
+                shots_per_step=2,
+            )
+        )
+    finally:
+        pacer.cancel()
+
+    assert commands.count("checkpoint") == 1 + 2
+    open_bundle = False
+    for command in commands:
+        if command == "create":
+            open_bundle = True
+        elif command == "save":
+            open_bundle = False
+        elif command == "checkpoint":
+            assert not open_bundle, "checkpoint inside an open event bundle"

--- a/GeecsBluesky/tests/test_pause_checkpoints.py
+++ b/GeecsBluesky/tests/test_pause_checkpoints.py
@@ -1,0 +1,254 @@
+"""Deferred-pause groundwork for G-actions v2 (issue #552, PR-1).
+
+Pins three things:
+
+* **Checkpoint placement** in both step plans — one before each step's
+  move and one before every row, never between ``create`` and ``save`` —
+  so ``request_pause(defer=True)`` always lands with an empty rewind
+  cache and resume replays nothing (no re-move, no re-fire).
+* **Resume replays nothing** at the RunEngine level: a deferred pause
+  raised mid-scan and resumed yields exactly the expected event rows,
+  each ``scan_event_index`` exactly once.
+* **``ShotController.last_state``** records the last *standing* state
+  actually driven (never the momentary ``SINGLESHOT`` fire) — what the
+  #552 pause supervisor re-asserts after an operator action.
+
+Also pins that the old hard-pause bridge API (``pause_scan`` /
+``resume_scan``) is gone: with no checkpoints it was a
+resume-replays-the-scan trap, and with checkpoints a bare hard pause
+still replays a partial row (re-firing a shot in strict mode).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import bluesky.plan_stubs as bps
+import pytest
+from bluesky import RunEngine
+from bluesky.utils import Msg, RunEngineInterrupted
+from ophyd_async.core import AsyncStatus
+
+from geecs_bluesky.models.shot_control import ShotControlWrites
+from geecs_bluesky.plans.step_scan import geecs_step_scan
+from geecs_bluesky.scanner_bridge.bluesky_scanner import BlueskyScanner
+from geecs_bluesky.shot_controller import ShotController
+
+# ---------------------------------------------------------------------------
+# Message-level checkpoint placement (no RunEngine, no CA — CI-safe)
+# ---------------------------------------------------------------------------
+
+
+class _NamedFake:
+    """Minimal named object for message-level plans (never actually set)."""
+
+    parent = None  # bps.mv inspects .parent for coupled-device handling
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+    def read(self):  # pragma: no cover - message-level only
+        return {}
+
+    def describe(self):  # pragma: no cover - message-level only
+        return {}
+
+
+def _collect(plan) -> list[Msg]:
+    messages: list[Msg] = []
+    try:
+        msg = plan.send(None)
+        while True:
+            messages.append(msg)
+            msg = plan.send(None)
+    except StopIteration:
+        pass
+    return messages
+
+
+def _step_plan_messages(num_points: int = 3, shots_per_step: int = 2) -> list[Msg]:
+    motor = _NamedFake("jet_z")
+    det = _NamedFake("cam")
+    return _collect(
+        geecs_step_scan(
+            motor=motor,
+            positions=[float(i) for i in range(num_points)],
+            detectors=[det],
+            shots_per_step=shots_per_step,
+        )
+    )
+
+
+def test_one_checkpoint_per_step_and_per_row() -> None:
+    """3 steps × 2 shots → 3 pre-move + 6 pre-row = 9 checkpoints."""
+    commands = [m.command for m in _step_plan_messages(3, 2)]
+    assert commands.count("checkpoint") == 3 + 3 * 2
+
+
+def test_checkpoint_precedes_the_move_and_every_row() -> None:
+    """The first message of each step is a checkpoint, before any set."""
+    messages = _step_plan_messages(2, 1)
+    commands = [m.command for m in messages]
+    first_checkpoint = commands.index("checkpoint")
+    first_set = commands.index("set")
+    assert first_checkpoint < first_set
+    # Every create (row open) is preceded by a checkpoint later than the
+    # previous save — i.e. one checkpoint per row, at the row boundary.
+    last_boundary = -1
+    for index, command in enumerate(commands):
+        if command == "create":
+            boundary = max(i for i in range(index) if commands[i] == "checkpoint")
+            assert boundary > last_boundary
+        elif command == "save":
+            last_boundary = index
+
+
+def test_no_checkpoint_between_create_and_save() -> None:
+    """A checkpoint inside an open event bundle is IllegalMessageSequence."""
+    commands = [m.command for m in _step_plan_messages(3, 2)]
+    open_bundle = False
+    for command in commands:
+        if command == "create":
+            open_bundle = True
+        elif command == "save":
+            open_bundle = False
+        elif command == "checkpoint":
+            assert not open_bundle, "checkpoint inside an open event bundle"
+
+
+# ---------------------------------------------------------------------------
+# RunEngine level: deferred pause + resume replays nothing (CA mocks)
+# ---------------------------------------------------------------------------
+
+
+def test_deferred_pause_and_resume_replays_no_row() -> None:
+    """Pause mid-scan (deferred) + resume → every row exactly once."""
+    pytest.importorskip("aioca")
+    from ophyd_async.core import set_mock_value
+
+    from geecs_bluesky.devices.ca import CaGenericDetector, CaMotor
+    from tests.ca_mock_helpers import connect_mock, follow_setpoint, start_pacer
+
+    events: list[dict] = []
+
+    def collect(name: str, doc: dict) -> None:
+        if name == "event":
+            events.append(doc)
+
+    motor = CaMotor("U_Ref", "Position (mm)", name="scan_motor")
+    ref = CaGenericDetector("U_Ref", ["Sig"], name="ref")
+    ref.configure_shot_id(rep_rate_hz=1.0)
+
+    RE = RunEngine()
+    RE.subscribe(collect)
+    connect_mock(RE, motor, ref)
+    follow_setpoint(motor)
+    set_mock_value(ref.acq_timestamp, 1000.0)
+    pacer = start_pacer(RE, [(ref, 1000.0)], initial_delay=0.2, interval=0.1)
+
+    paused_once = {"done": False}
+
+    def pausing_per_step():
+        # Deterministic mid-scan deferred pause: the plan itself requests
+        # it once; the RE then pauses at the NEXT checkpoint (the first
+        # row of this step), where the rewind cache is empty.
+        if not paused_once["done"]:
+            paused_once["done"] = True
+            yield from bps.deferred_pause()
+        else:
+            yield from bps.null()
+
+    plan = geecs_step_scan(
+        motor=motor,
+        positions=[0.0, 1.0],
+        detectors=[ref],
+        shots_per_step=2,
+        per_step=pausing_per_step,
+    )
+    try:
+        with pytest.raises(RunEngineInterrupted):
+            RE(plan)
+        assert RE.state == "paused"
+        RE.resume()
+    finally:
+        pacer.cancel()
+
+    assert len(events) == 4  # 2 positions × 2 shots — nothing replayed
+    indices = [e["data"]["scan_event_index"] for e in events]
+    assert indices == [1, 2, 3, 4]
+
+
+# ---------------------------------------------------------------------------
+# ShotController.last_state
+# ---------------------------------------------------------------------------
+
+
+class _RecordingSetter:
+    def __init__(self, name: str, journal: list) -> None:
+        self.name = name
+        self._journal = journal
+
+    def set(self, value: Any) -> AsyncStatus:
+        self._journal.append((self.name, value))
+
+        async def _noop() -> None:
+            pass
+
+        return AsyncStatus(_noop())
+
+
+_WRITES = ShotControlWrites(
+    name="pause-test",
+    states={
+        "SCAN": [("U_DG645", "Amplitude.Ch AB", "4.0")],
+        "STANDBY": [("U_DG645", "Amplitude.Ch AB", "0.5")],
+        "ARMED": [("U_DG645", "Trigger.Source", "Single shot")],
+        "SINGLESHOT": [("U_DG645", "Trigger.ExecuteSingleShot", "on")],
+    },
+)
+
+
+def _controller() -> tuple[RunEngine, ShotController]:
+    journal: list = []
+    controller = ShotController.from_writes(
+        _WRITES,
+        setter_factory=lambda d, v: _RecordingSetter(f"{d}:{v}", journal),
+    )
+    return RunEngine(), controller
+
+
+def test_last_state_tracks_standing_states() -> None:
+    re, controller = _controller()
+    assert controller.last_state is None
+    re(controller.arm())
+    assert controller.last_state == "SCAN"
+    re(controller.disarm())
+    assert controller.last_state == "STANDBY"
+
+
+def test_singleshot_fire_never_recorded_as_last_state() -> None:
+    """Re-asserting last_state must never refire a shot."""
+    re, controller = _controller()
+    re(controller.set_state("ARMED"))
+    assert controller.last_state == "ARMED"
+    re(controller.fire_shot())  # SINGLESHOT — momentary, not standing
+    assert controller.last_state == "ARMED"
+
+
+def test_stateless_transition_leaves_last_state_alone() -> None:
+    """A state with no writes drives nothing, so nothing is recorded."""
+    re, controller = _controller()
+    re(controller.arm())
+    re(controller.quiesce())  # OFF not declared in this profile → no-op
+    assert controller.last_state == "SCAN"
+
+
+# ---------------------------------------------------------------------------
+# The hard-pause bridge API is gone
+# ---------------------------------------------------------------------------
+
+
+def test_hard_pause_bridge_api_deleted() -> None:
+    """pause_scan/resume_scan (hard pause, replay trap) must not return."""
+    assert not hasattr(BlueskyScanner, "pause_scan")
+    assert not hasattr(BlueskyScanner, "resume_scan")


### PR DESCRIPTION
PR-1 of the G-actions v2 sequence (issue #552; design note + owner decisions recorded on the issue — all defaults accepted, decision 11 reversed to refuse shot-control-device actions, which lands in PR-3).

## What + why

The design note's key verified finding: **our step plans emitted zero checkpoint messages**, so any pause + resume would rewind to plan start and replay the entire scan — re-opening the run, re-driving every trigger transition, re-firing every shot. The existing `pause_scan`/`resume_scan` bridge methods (hard pause) were exactly that trap, with no callers.

This PR lays the groundwork all later PRs build on:

- **Checkpoints in both step plans** — one before each step's move, one before every row. `request_pause(defer=True)` now lands at a row/step boundary with an empty rewind cache: resume replays nothing. Zero behavior change for an unpaused scan (a checkpoint is a no-op outside pause/suspend handling).
- **`ShotController.last_state`** — records the last *standing* state actually driven (never the momentary SINGLESHOT fire, so a later re-assert can never refire a shot). The PR-3 pause supervisor reads this to restore the trigger state after an operator action.
- **`pause_scan`/`resume_scan` deleted** with a tombstone comment; absence pinned by test (design decision 2).

## Per-concern LOC breakdown

- Checkpoints (`step_scan.py` +9, `free_run_step_scan.py` +9, comments included)
- `last_state` (`shot_controller.py`: attribute + `_record_state` + two call sites): +22
- Hard-pause API deletion (`bluesky_scanner.py`): −16 / +6 tombstone
- Tests (`tests/test_pause_checkpoints.py`, 8 tests): +250 — checkpoint count/placement, never-inside-an-open-event-bundle, an RE-level deferred pause + resume yielding every row exactly once (deterministic: the plan itself yields `deferred_pause` via the per_step hook), `last_state` standing-states-only semantics, and the deleted-API pin
- One existing pin updated: `test_grid_plans_message_level.py` per-step placement now accepts the row checkpoint as part of the row boundary (+3/−1)
- Version bump + CHANGELOG (0.42.0 minor): +30

## Tests

`./scripts/check.sh` (scoped): lint clean; **GeecsBluesky 541 passed, 3 deselected** (533 + 8 new). The RE-level test exercises real deferred-pause semantics against bluesky 1.15 (RunEngineInterrupted → paused → resume → exact event count, monotone scan_event_index).

## Hardware verification

**N/A for this PR alone** — checkpoints are inert without a pause request, and nothing requests one yet (the supervisor arrives in PR-3). The full pause-window hardware checklist (jet stops in free-run OFF, strict stays quiescent, pause latency at real rep rate, abort-during-pause end state) is enumerated in the design note §6.5 and owed at the end of the sequence, before the feature is declared usable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)