### PR TITLE
GeecsBluesky 0.44.0: pause supervisor — during-scan action flow (engine + bridge half)

### DIFF
--- a/GeecsBluesky/CHANGELOG.md
+++ b/GeecsBluesky/CHANGELOG.md
@@ -4,6 +4,44 @@ All notable changes to `geecs-bluesky` are documented here.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.44.0] - 2026-07-16
+
+### Added
+
+- **Pause/decide/resume during-scan action flow — engine + bridge half**
+  (issue #552, PR-3; console half is next).  A deferred pause requested by
+  `BlueskyScanner.request_action_during_scan(name)` lands at a plan
+  checkpoint (PR-1) and hands the scan thread to the new
+  `pause_supervisor.PauseSupervisor` (inside `GeecsSession.scan`/`optimize`
+  via the new `_run_supervised` helper + `pause_supervisor=` param): drive
+  the mode-specific **safe state** (free-run → `OFF` so the jet stops and
+  no orphan frames are saved; strict → nothing, `ARMED` is already
+  quiescent) with direct `ShotController.state_setters` writes, emit
+  `PAUSED`, deliver the three-way `ActionDecisionRequest`
+  (execute/ignore/abort) through the existing `ScanDialogEvent` transport,
+  run an approved action via the direct executor (PR-2) against the paused
+  RE loop, then re-assert the captured `last_state` and resume — **abort
+  skips the restore** (the plan's finalize chain owns the end state).  A
+  failed step **stays paused and re-prompts** (retry/ignore/abort, owner
+  decision 10).  Owner decision 11: an action writing to the scan's
+  shot-control device(s) is **refused** (fail-fast, before pausing).
+- **`ScanState.PAUSING` / `ScanState.PAUSED`** (non-terminal) and
+  `ActionDecisionRequest` (the three-way dialog request; `ScanDialogEvent`
+  now carries either it or the binary `DialogRequest`, duck-typed on the
+  `verdict` attribute).
+- `RE.record_interruptions = True` (owner decision 13) so a pause window
+  is part of the run's document record.
+- `ShotController.state_setters(state)` — the non-plan accessor the
+  supervisor uses to drive a state while the RE is paused (the plan-stub
+  `set_state` cannot run there).
+
+Headless callers pass no supervisor and keep today's behavior
+(`RunEngineInterrupted` propagates).  Pinned by
+`tests/test_pause_supervisor.py` (8) and `tests/test_action_during_scan.py`
+(5).  Fixed in passing: the bridge used `trigger_writes_from_profile`
+without importing it — dormant because it lived under a broad `except`
+(now a narrow `GeecsConfigurationError` catch, so a real error can't hide).
+
 ## [0.43.0] - 2026-07-16
 
 ### Added

--- a/GeecsBluesky/CLAUDE.md
+++ b/GeecsBluesky/CLAUDE.md
@@ -182,8 +182,26 @@ Manual (operator-clicked) action execution:
 execute/dry-run a named ActionPlan on demand, refusing while a scan is
 active with the exact message `"scan in progress — action not started"`
 (the GUI surfaces it verbatim; these two signatures are part of the
-console Submitter contract).  The richer pause/decide/resume during-scan
-flow is issue #552.  Acquisition mode comes from
+console Submitter contract).  The richer **pause/decide/resume during-scan
+flow is `request_action_during_scan(name)`** (G-actions v2, issue #552, engine
+half landed 0.44.0): validated fail-fast on the GUI thread (unknown name /
+unreachable target / cycle), **refused if the action writes to the active
+scan's shot-control device(s)** (owner decision 11 — an action must not
+perturb the trigger the scan drives), then it stages the flattened steps +
+a connected factory on the run's `PauseSupervisor`, emits `PAUSING`, and
+asks the RE to pause at its next checkpoint (deferred).  The supervisor
+(`pause_supervisor.py`, on the scan thread inside `session.scan`'s
+interrupt handling) drives the mode-specific safe state (free-run → `OFF`;
+strict → nothing, already quiescent), delivers the three-way
+`ActionDecisionRequest` (execute / ignore / abort) through the same
+`ScanDialogEvent` transport as the pre-flight dialogs, executes an
+approved action via the direct executor (`plans/action_direct.py`, 0.43.0)
+against the paused RE's loop, then re-asserts the captured `last_state` and
+resumes — abort skips the restore (the finalize chain owns the end state).
+A pause requested but never delivered (scan ended first) is withdrawn and
+logged, not an error (design-note contract on #552).  `PAUSING`/`PAUSED`
+are non-terminal ScanStates; `RE.record_interruptions = True` puts the
+pause window in the data record.  Acquisition mode comes from
 `ScanRequest.acquisition` — deliberately no env override, a request
 declares intent.
 

--- a/GeecsBluesky/geecs_bluesky/events.py
+++ b/GeecsBluesky/geecs_bluesky/events.py
@@ -55,6 +55,12 @@ class ScanState(str, enum.Enum):
     INITIALIZING = "initializing"
     RUNNING = "running"
     PAUSED_ON_ERROR = "paused_on_error"
+    #: Deferred pause requested (operator action, issue #552) — the scan
+    #: finishes its in-flight row before PAUSED lands.  Non-terminal.
+    PAUSING = "pausing"
+    #: Scan paused at a checkpoint; machine driven to its safe state; the
+    #: operator is deciding (execute / ignore / abort).  Non-terminal.
+    PAUSED = "paused"
     STOPPING = "stopping"
     DONE = "done"
     ABORTED = "aborted"
@@ -108,6 +114,44 @@ class DialogRequest:
     abort_label: Optional[str] = None
     response_event: threading.Event = field(default_factory=threading.Event)
     abort: list[bool] = field(default_factory=lambda: [False])
+
+
+@dataclass
+class ActionDecisionRequest:
+    """Three-way operator decision for an action in the pause window (#552).
+
+    The pause supervisor emits this (inside a :class:`ScanDialogEvent`)
+    once the scan is PAUSED and the machine is in its safe state, then
+    blocks on ``response_event.wait()``.  The consumer renders the three
+    choices and answers by writing ``verdict[0]`` and setting
+    ``response_event``.  Consumers duck-type: a dialog request carrying a
+    ``verdict`` attribute is three-way; the binary :class:`DialogRequest`
+    keeps its Continue/Abort contract untouched.
+
+    Parameters
+    ----------
+    action_name :
+        The named ActionPlan the operator asked to run.
+    message :
+        Full operator-facing dialog body (the supervisor owns the wording —
+        scan number, shots completed, what each choice does).
+    step_count :
+        Number of concrete steps the action flattens to (shown in the
+        Execute label).
+    response_event :
+        Set by the consumer once the user has responded.
+    verdict :
+        Single-element mutable result container:
+        ``"execute"`` / ``"ignore"`` / ``"abort"``.  Defaults to
+        ``"ignore"`` — an unanswered/torn-down dialog must never execute
+        steps or kill the scan.
+    """
+
+    action_name: str
+    message: str
+    step_count: int = 0
+    response_event: threading.Event = field(default_factory=threading.Event)
+    verdict: list[str] = field(default_factory=lambda: ["ignore"])
 
 
 # ---------------------------------------------------------------------------
@@ -291,8 +335,10 @@ class ScanDialogEvent(ScanEvent):
     Parameters
     ----------
     request :
-        The :class:`DialogRequest` object shared between the worker and the
-        consumer.
+        The dialog object shared between the worker and the consumer — a
+        binary :class:`DialogRequest`, or (G-actions v2, #552) a three-way
+        :class:`ActionDecisionRequest`.  Consumers duck-type on the
+        presence of a ``verdict`` attribute to tell them apart.
     """
 
-    request: Optional[DialogRequest] = None
+    request: Optional[object] = None

--- a/GeecsBluesky/geecs_bluesky/pause_supervisor.py
+++ b/GeecsBluesky/geecs_bluesky/pause_supervisor.py
@@ -49,8 +49,8 @@ from typing import Any, Callable
 from geecs_bluesky.events import ActionDecisionRequest
 from geecs_bluesky.plans.action_direct import (
     ActionExecutionAborted,
-    _set_in_loop,
     execute_action_steps_directly,
+    set_signal_in_loop,
 )
 
 logger = logging.getLogger(__name__)
@@ -302,7 +302,7 @@ class PauseSupervisor:
         writes = controller.state_setters(state)
         for setter, value in writes:
             future = asyncio.run_coroutine_threadsafe(
-                _set_in_loop(setter, value), session.RE.loop
+                set_signal_in_loop(setter, value), session.RE.loop
             )
             try:
                 future.result(timeout=_STATE_WRITE_TIMEOUT_S)

--- a/GeecsBluesky/geecs_bluesky/pause_supervisor.py
+++ b/GeecsBluesky/geecs_bluesky/pause_supervisor.py
@@ -1,0 +1,319 @@
+"""The G-actions v2 pause supervisor (issue #552, PR-3).
+
+Runs **on the scan thread**, inside :meth:`GeecsSession.scan`'s
+``RunEngineInterrupted`` handling, when a deferred pause lands at one of
+the plans' checkpoints (PR-1).  Protocol, per the design note + owner
+decisions recorded on #552:
+
+1. Capture the shot controller's ``last_state`` (the standing state the
+   scan drove before the pause), then drive the mode-specific **safe
+   state** directly (plan stubs cannot run on a paused RE — writes are
+   dispatched onto the RE's persistent loop, sequentially, preserving
+   profile order): free-run → ``OFF`` (jet off, no edges into enabled
+   saving — safe indefinitely); strict → nothing (``ARMED`` is already
+   quiescent; STANDBY would *start* free-running edges).
+2. Emit PAUSED, deliver the three-way
+   :class:`~geecs_bluesky.events.ActionDecisionRequest` through the
+   injected ``ask`` seam, and park (sliced, abort-aware) on the response.
+3. Execute → run the pending action's flattened steps through the direct
+   executor (PR-2).  A check/step failure **stays paused and re-prompts**
+   (retry / ignore / abort — owner decision 10; auto-resuming past a
+   failed check would hide exactly what the check exists to catch).
+4. Restore: re-assert the captured entry state (only if step 1 drove a
+   safe state), then return ``"resume"`` — the session calls
+   ``RE.resume()``.  Abort returns ``"abort"`` with **no restore** — the
+   plan's finalize chain (quiesce → save-off → disarm → closeout) owns
+   the abort end state.
+
+The strict-mode quiescence re-confirm from the design note §2.3 is
+deliberately **not** implemented: owner decision 11 (reversed) refuses any
+action that writes to the active scan's shot-control device(s) — enforced
+by the bridge before the pause is even requested — so an executed action
+can no longer perturb the trigger, which was that re-confirm's only
+purpose.  Recorded on #552.
+
+Headless sessions pass no supervisor and keep today's behavior
+(``RunEngineInterrupted`` propagates).  A supervisor whose ``ask`` seam is
+``None`` answers every decision with its default (``ignore``) and logs —
+the same never-block posture as :class:`~geecs_bluesky.operator_channel.NullOperator`.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import threading
+from dataclasses import dataclass, field
+from typing import Any, Callable
+
+from geecs_bluesky.events import ActionDecisionRequest
+from geecs_bluesky.plans.action_direct import (
+    ActionExecutionAborted,
+    _set_in_loop,
+    execute_action_steps_directly,
+)
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["PauseSupervisor", "PendingAction"]
+
+#: Park-loop slice while waiting for the operator's verdict.
+_DECISION_SLICE_S = 0.2
+
+#: Budget for each direct shot-control write (same family as the action
+#: signals' put budget — a safe-state write that hasn't completed in 30 s
+#: is stuck, not slow).
+_STATE_WRITE_TIMEOUT_S = 30.0
+
+
+@dataclass
+class PendingAction:
+    """One operator-requested action awaiting the pause window.
+
+    Parameters
+    ----------
+    name :
+        The ActionPlan's library name (operator-facing).
+    steps :
+        ``flatten_action_steps`` output — validated fail-fast by the
+        bridge before the pause was requested.
+    factory :
+        The connected signal factory the steps execute against; the
+        supervisor disconnects it (via *cleanup*) when the pending action
+        is consumed.
+    cleanup :
+        Zero-argument callable releasing *factory*'s signals (the bridge
+        binds ``session.disconnect(factory)``).  Always called exactly
+        once, whatever the verdict.
+    """
+
+    name: str
+    steps: list[tuple[Any, str | None]]
+    factory: Any
+    cleanup: Callable[[], None] = field(default=lambda: None)
+
+
+class PauseSupervisor:
+    """Owns the pause window: safe state → decision → action → restore.
+
+    One instance per scan run, created by the bridge (or any caller that
+    wants during-scan actions) and threaded into
+    :meth:`GeecsSession.scan`/:meth:`~GeecsSession.optimize` as their
+    ``pause_supervisor``.
+
+    Parameters
+    ----------
+    acquisition :
+        ``"free_run"`` or ``"strict"`` — selects the safe-state policy.
+    shot_controller :
+        Zero-argument callable returning the session's current
+        :class:`~geecs_bluesky.shot_controller.ShotController` (or
+        ``None`` — no shot control, nothing to drive).
+    ask :
+        Delivery seam for the three-way decision:
+        ``ask(ActionDecisionRequest) -> None`` hands the request to the
+        consumer (the bridge emits it as a dialog event) and returns
+        immediately; the supervisor parks on the request's
+        ``response_event``.  ``None`` (headless) answers the default
+        verdict (``ignore``) with a warning.
+    should_abort :
+        Optional operator-stop probe (the bridge's ``_abort_requested``),
+        consulted while parked and while executing — a trip anywhere in
+        the window yields the ``"abort"`` outcome.
+    on_state :
+        Optional lifecycle hook called with ``"paused"`` when the window
+        opens (the bridge maps it onto its event stream; PAUSING is
+        emitted by the bridge at request time, before the pause lands).
+    """
+
+    def __init__(
+        self,
+        *,
+        acquisition: str,
+        shot_controller: Callable[[], Any],
+        ask: Callable[[ActionDecisionRequest], None] | None = None,
+        should_abort: Callable[[], bool] | None = None,
+        on_state: Callable[[str], None] | None = None,
+    ) -> None:
+        self._acquisition = acquisition
+        self._shot_controller = shot_controller
+        self._ask = ask
+        self._should_abort = should_abort
+        self._on_state = on_state
+        self._pending: PendingAction | None = None
+        self._lock = threading.Lock()
+        self._last_failure: Exception | None = None
+
+    # ------------------------------------------------------------------
+    # Bridge side (GUI thread)
+    # ------------------------------------------------------------------
+
+    def set_pending(self, pending: PendingAction) -> bool:
+        """Stage *pending* for the next pause window.
+
+        Returns ``False`` (and leaves the existing pending action in
+        place) when one is already staged — one action per pause window.
+        """
+        with self._lock:
+            if self._pending is not None:
+                return False
+            self._pending = pending
+            return True
+
+    def take_unconsumed_pending(self) -> PendingAction | None:
+        """Withdraw a staged action the pause never delivered (scan ended).
+
+        The caller reports it ("scan completed before the pause landed —
+        the action was NOT run": the normal outcome recorded on #552, not
+        a protocol error) and runs its cleanup.
+        """
+        with self._lock:
+            pending, self._pending = self._pending, None
+            return pending
+
+    # ------------------------------------------------------------------
+    # Scan-thread side
+    # ------------------------------------------------------------------
+
+    def on_pause(self, session: Any) -> str:
+        """Run one pause window; return ``"resume"`` or ``"abort"``.
+
+        Called by the session on the scan thread while ``RE.state`` is
+        ``"paused"``.  Never raises for operator-shaped outcomes — a
+        failed action step re-prompts, an abort anywhere returns
+        ``"abort"``.
+        """
+        with self._lock:
+            pending, self._pending = self._pending, None
+
+        controller = self._shot_controller()
+        entry_state = getattr(controller, "last_state", None)
+        drove_safe_state = False
+        if self._acquisition != "strict" and controller is not None:
+            # Free-run: a between-rows pause sits inside a SCAN window
+            # (jet on, edges into enabled saving) — drive OFF so the
+            # window is safe for an unbounded decision time.
+            drove_safe_state = self._drive_state(session, controller, "OFF")
+        if self._on_state is not None:
+            self._on_state("paused")
+
+        outcome = "resume"
+        try:
+            if pending is None:
+                # Pause landed with nothing staged (e.g. the operator
+                # already withdrew it) — just resume.
+                logger.info("pause window opened with no pending action")
+                return outcome
+            try:
+                outcome = self._decide_and_execute(session, pending)
+                return outcome
+            finally:
+                try:
+                    pending.cleanup()
+                except Exception:  # noqa: BLE001 — cleanup is best-effort
+                    logger.warning("pending-action cleanup failed", exc_info=True)
+        finally:
+            # The abort outcome deliberately skips the restore: RE.abort()'s
+            # finalize chain (quiesce → save-off → disarm → closeout) owns
+            # the end state.
+            if drove_safe_state and entry_state and outcome == "resume":
+                self._drive_state(session, controller, entry_state)
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+
+    @property
+    def _abort_tripped(self) -> bool:
+        return self._should_abort is not None and self._should_abort()
+
+    def _decide_and_execute(self, session: Any, pending: PendingAction) -> str:
+        attempt = 0
+        while True:
+            attempt += 1
+            verdict = self._park_for_verdict(pending, attempt)
+            if verdict == "abort":
+                return "abort"
+            if verdict == "ignore":
+                logger.info("action %r ignored; resuming the scan", pending.name)
+                return "resume"
+            try:
+                execute_action_steps_directly(
+                    pending.steps,
+                    pending.factory,
+                    session.RE.loop,
+                    should_abort=self._should_abort,
+                )
+            except ActionExecutionAborted:
+                return "abort"
+            except Exception as exc:  # noqa: BLE001 — re-prompt, decision 10
+                logger.error(
+                    "action %r failed in the pause window: %s", pending.name, exc
+                )
+                self._last_failure = exc
+                continue
+            logger.info("action %r executed in the pause window", pending.name)
+            return "resume"
+
+    def _park_for_verdict(self, pending: PendingAction, attempt: int) -> str:
+        failure = self._last_failure if attempt > 1 else None
+        self._last_failure = None
+        if failure is not None:
+            body = (
+                f"Action {pending.name!r} FAILED: {failure}\n\n"
+                "The scan is still paused (machine in its safe state). "
+                "Retry the action, ignore it and resume the scan, or "
+                "abort the scan?"
+            )
+        else:
+            body = (
+                f"Action {pending.name!r} was requested — the scan is "
+                "paused (machine in its safe state). Execute the action "
+                "and continue, ignore it and continue, or abort the scan?"
+            )
+        request = ActionDecisionRequest(
+            action_name=pending.name,
+            message=body,
+            step_count=len(pending.steps),
+        )
+        if self._ask is None:
+            logger.warning(
+                "no decision consumer attached — action %r defaults to "
+                "'ignore' (scan resumes, action NOT run)",
+                pending.name,
+            )
+            return "ignore"
+        self._ask(request)
+        while not request.response_event.wait(timeout=_DECISION_SLICE_S):
+            if self._abort_tripped:
+                # Stop clicked while parked: wake the flow as an abort so
+                # the scan thread proceeds to RE.abort() promptly.
+                return "abort"
+        verdict = request.verdict[0]
+        return verdict if verdict in ("execute", "ignore", "abort") else "ignore"
+
+    def _drive_state(self, session: Any, controller: Any, state: str) -> bool:
+        """Directly drive *state*'s ordered writes onto the RE loop.
+
+        Returns ``True`` when at least one write was issued.  A failed
+        write is logged and stops the remaining writes (matching the plan
+        stub's sequential each-completes-before-the-next contract).
+        """
+        writes = controller.state_setters(state)
+        for setter, value in writes:
+            future = asyncio.run_coroutine_threadsafe(
+                _set_in_loop(setter, value), session.RE.loop
+            )
+            try:
+                future.result(timeout=_STATE_WRITE_TIMEOUT_S)
+            except Exception:  # noqa: BLE001 — surfaced, remaining writes skipped
+                future.cancel()
+                logger.error(
+                    "pause-window shot-control write failed (state %s)",
+                    state,
+                    exc_info=True,
+                )
+                return bool(writes)
+        if writes:
+            logger.info("pause window: shot controller → %s", state)
+        return bool(writes)

--- a/GeecsBluesky/geecs_bluesky/plans/action_direct.py
+++ b/GeecsBluesky/geecs_bluesky/plans/action_direct.py
@@ -61,6 +61,7 @@ __all__ = [
     "ActionExecutionAborted",
     "ActionStepTimeoutError",
     "execute_action_steps_directly",
+    "set_signal_in_loop",
 ]
 
 #: Per-step budget for a blocking ``set`` / ``check`` dispatch.  Slightly
@@ -194,7 +195,7 @@ def execute_action_steps_directly(
         if isinstance(step, SetStep):
             label = f"set {step.device}:{step.variable}"
             signal = settables.get_settable(step.device, step.variable)
-            future = _dispatch(_set_in_loop(signal, step.value), label)
+            future = _dispatch(set_signal_in_loop(signal, step.value), label)
             if step.wait_for_execution:
                 _result(future, label)
             else:
@@ -242,8 +243,14 @@ async def _await_maybe(value: Any) -> Any:
     return value
 
 
-async def _set_in_loop(signal: Any, value: Any) -> None:
-    """Call ``signal.set`` on the loop and await its status there."""
+async def set_signal_in_loop(signal: Any, value: Any) -> None:
+    """Await ``signal.set(value)`` inside the loop (the shared RE-loop put).
+
+    The one primitive for "put a value onto an ophyd-async signal from a
+    non-loop thread": an ``AsyncStatus`` must be created where the loop
+    runs.  Used by both this executor and the #552 pause supervisor's
+    direct shot-control writes.
+    """
     await _await_maybe(signal.set(value))
 
 

--- a/GeecsBluesky/geecs_bluesky/scan_request_runner.py
+++ b/GeecsBluesky/geecs_bluesky/scan_request_runner.py
@@ -1164,6 +1164,7 @@ def run_scan_request(
     on_scan_start: Callable[[int, int], None] | None = None,
     operator_channel: "OperatorChannel | None" = None,
     should_abort: Callable[[], bool] | None = None,
+    pause_supervisor: Any | None = None,
 ) -> str | None:
     """Execute *request* on *session*; return the run uid.
 
@@ -1311,6 +1312,7 @@ def run_scan_request(
             skipped_actions=skipped_actions,
             operator_channel=operator_channel,
             should_abort=should_abort,
+            pause_supervisor=pause_supervisor,
         )
 
     # A step/noscan request without a save set was already refused by
@@ -1461,6 +1463,7 @@ def run_scan_request(
                 per_step=per_step,
                 closeout=closeout,
                 should_abort=should_abort,
+                pause_supervisor=pause_supervisor,
             )
 
         movables: list = []
@@ -1513,6 +1516,7 @@ def run_scan_request(
             per_step=per_step,
             closeout=closeout,
             should_abort=should_abort,
+            pause_supervisor=pause_supervisor,
         )
     finally:
         if created and hasattr(session, "disconnect"):
@@ -1534,6 +1538,7 @@ def _run_optimize_request(
     skipped_actions: dict[str, list[str]] | None = None,
     operator_channel: "OperatorChannel | None" = None,
     should_abort: Callable[[], bool] | None = None,
+    pause_supervisor: Any | None = None,
 ) -> str | None:
     """Map an optimize-mode request onto :meth:`GeecsSession.optimize`.
 
@@ -1753,6 +1758,7 @@ def _run_optimize_request(
                     scan_number=scan_number,
                     scan_folder=scan_folder,
                     should_abort=should_abort,
+                    pause_supervisor=pause_supervisor,
                 )
             if claimed_here and getattr(session, "last_run_aborted", False):
                 # session.optimize returned the aborted outcome quietly

--- a/GeecsBluesky/geecs_bluesky/scanner_bridge/bluesky_scanner.py
+++ b/GeecsBluesky/geecs_bluesky/scanner_bridge/bluesky_scanner.py
@@ -58,6 +58,7 @@ from geecs_bluesky.exceptions import GeecsConfigurationError
 # Bound at module level (not via the events module) because hermetic tests
 # monkeypatch these names — the `is None` guards downstream are that seam.
 from geecs_bluesky.events import (
+    ActionDecisionRequest,
     DialogRequest,
     ScanDialogEvent,
     ScanEvent,
@@ -83,6 +84,7 @@ from geecs_bluesky.scan_request_runner import (
     ConfigResolver,
     ConfigsRepoResolver,
     run_scan_request,
+    trigger_writes_from_profile,
     validate_scan_request,
 )
 from geecs_bluesky.session import GeecsSession
@@ -184,6 +186,10 @@ class BlueskyScanner:
         # scan thread delegates the stored request to run_scan_request.
         self._scan_request: ScanRequest | None = None
         self._request_resolver: ConfigResolver | None = None
+        # The active run's pause supervisor (#552); set for the duration of
+        # a delegated run, None otherwise — request_action_during_scan
+        # refuses when it is None.
+        self._pause_supervisor: Any | None = None
 
         # Catch a stale env loudly rather than silently changing behavior.
         legacy_backend = os.environ.get("GEECS_BLUESKY_DEVICE_BACKEND")
@@ -474,6 +480,157 @@ class BlueskyScanner:
         :meth:`run_action` carries the scan-in-progress refusal.
         """
         return self._session.describe_action(name, self._action_resolver())
+
+    def request_action_during_scan(self, name: str) -> None:
+        """Request an action to run in the scan's pause window (G-actions v2).
+
+        The during-scan counterpart of :meth:`run_action` (issue #552).
+        Validated fail-fast on the calling (GUI) thread — unknown name,
+        cycle, or unreachable target raises here, before anything pauses —
+        then **refused if the action writes to the active scan's
+        shot-control device(s)** (owner decision 11: an action must not
+        perturb the trigger the scan is driving).  On success the action's
+        flattened steps + a connected signal factory are staged on the
+        pause supervisor, PAUSING is emitted, and the RunEngine is asked to
+        pause at its next checkpoint (deferred); the supervisor then runs
+        the operator's execute/ignore/abort decision on the scan thread.
+
+        Raises
+        ------
+        RuntimeError
+            No scan is active (``"no scan in progress — use run_action"``),
+            or one is already awaiting the pause window.
+        GeecsConfigurationError
+            Unknown plan, unreachable target, or an action targeting the
+            scan's shot-control device(s).
+        ActionPlanNotFoundError, ActionPlanCycleError
+            Bad nested reference / cycle.
+        """
+        from geecs_bluesky.pause_supervisor import PendingAction
+        from geecs_bluesky.plans.action_compiler import flatten_action_steps
+        from geecs_schemas.action_plan import CheckStep, SetStep
+
+        if not self.is_scanning_active():
+            raise RuntimeError("no scan in progress — use run_action")
+        supervisor = self._pause_supervisor
+        if supervisor is None:
+            raise RuntimeError("no scan in progress — use run_action")
+
+        resolver = self._action_resolver()
+        plan, registry = self._session._resolve_action(name, resolver)
+        steps = flatten_action_steps(plan, registry=registry)
+
+        guarded = self._guarded_shot_control_devices()
+        touched = {
+            step.device
+            for step, _ in steps
+            if isinstance(step, (SetStep, CheckStep)) and step.device in guarded
+        }
+        if touched:
+            raise GeecsConfigurationError(
+                f"action {name!r} writes to the scan's shot-control "
+                f"device(s) {sorted(touched)} — refused during a scan so it "
+                "cannot perturb the trigger (run it between scans instead)"
+            )
+
+        # Pre-connect every signal the steps touch (a lazy connect inside
+        # the paused RE loop would deadlock), exactly as run_action does.
+        factory = self._session.action_signal_factory()
+        for step, _ in steps:
+            if not isinstance(step, (SetStep, CheckStep)):
+                continue
+            try:
+                if isinstance(step, SetStep):
+                    factory.get_settable(step.device, step.variable)
+                else:
+                    factory.get_readable(step.device, step.variable)
+            except Exception as exc:
+                self._session.disconnect(factory)
+                raise GeecsConfigurationError(
+                    f"action {name!r}: cannot reach "
+                    f"{step.device}:{step.variable} — {exc}"
+                ) from exc
+
+        pending = PendingAction(
+            name=name,
+            steps=steps,
+            factory=factory,
+            cleanup=lambda: self._session.disconnect(factory),
+        )
+        if not supervisor.set_pending(pending):
+            self._session.disconnect(factory)
+            raise RuntimeError("an action is already awaiting the pause window")
+
+        logger.info("action %r requested during scan — pausing", name)
+        self._set_state("PAUSING")
+        try:
+            self._RE.request_pause(defer=True)
+        except Exception:
+            # The scan may have ended between the active-check and here —
+            # withdraw the staged action so nothing lingers.
+            supervisor.take_unconsumed_pending()
+            self._session.disconnect(factory)
+            self._set_state("RUNNING")
+            raise
+
+    def _guarded_shot_control_devices(self) -> set[str]:
+        """Device names the active scan's shot control drives (decision 11).
+
+        Derived from the stored request's trigger profile (the writes the
+        ShotController replays), so an action targeting any of them is
+        refused during the scan.  Empty when the scan has no trigger
+        profile (nothing to perturb).
+        """
+        request = self._scan_request
+        if request is None or not getattr(request, "trigger_profile", None):
+            return set()
+        resolver = self._request_resolver or ConfigsRepoResolver(self._experiment_dir)
+        try:
+            profile = resolver.resolve_trigger_profile(request.trigger_profile)
+            writes = trigger_writes_from_profile(profile, request.trigger_variant)
+        except GeecsConfigurationError:
+            # An unresolvable trigger profile is a scan-setup problem the
+            # runner already surfaced; the guard degrades to "nothing to
+            # protect" rather than masking it (narrow catch on purpose —
+            # a programming error must not be swallowed here).
+            logger.debug("could not resolve trigger devices for guard", exc_info=True)
+            return set()
+        devices: set[str] = set()
+        for ordered in writes.states.values():
+            devices.update(device for device, _var, _val in ordered)
+        return devices
+
+    def _make_pause_supervisor(self) -> Any:
+        """Build the pause supervisor for the delegated run (#552)."""
+        from geecs_bluesky.pause_supervisor import PauseSupervisor
+
+        request = self._scan_request
+        acquisition = getattr(
+            getattr(request, "acquisition", None), "value", "free_run"
+        )
+        return PauseSupervisor(
+            acquisition=acquisition,
+            shot_controller=lambda: getattr(self._session, "_shot_controller", None),
+            ask=self._ask_action_decision,
+            should_abort=lambda: self._abort_requested,
+            on_state=lambda s: self._set_state(s.upper()),
+        )
+
+    def _ask_action_decision(self, request: "ActionDecisionRequest") -> None:
+        """Deliver the three-way decision to the GUI (queued dialog event).
+
+        Emits the request inside a ``ScanDialogEvent`` (the same transport
+        as the pre-flight binary dialogs); the consumer renders the three
+        choices and answers via ``request.response_event`` / ``verdict``.
+        Headless / no-consumer installs never reach here — the supervisor's
+        ``ask`` is ``None`` there.
+        """
+        if self._on_event is None or ScanDialogEvent is None:
+            return
+        try:
+            self._on_event(ScanDialogEvent(request=request))
+        except Exception:
+            logger.debug("action-decision dialog emit raised; ignoring", exc_info=True)
 
     # ------------------------------------------------------------------
     # Internal helpers
@@ -834,25 +991,47 @@ class BlueskyScanner:
                 )
             opt_bridge = self._optimization_loader(request.optimization)
             optimization_binder = opt_bridge.bind
-        run_scan_request(
-            self._session,
-            request,
-            resolver,
-            preflight=self._delegated_preflight,
-            on_scan_start=self._on_delegated_scan_start,
-            optimization_binder=optimization_binder,
-            device_requirements=(
-                getattr(opt_bridge, "device_requirements", None)
-                if opt_bridge is not None
-                else None
-            ),
-            operator_channel=self._delegated_operator_channel(),
-            # Stop clicked during initialization: the runner consults this
-            # between init stages (all pre-claim) and the session's stop
-            # gate re-reads it at plan start — RE.abort() alone cannot
-            # reach a scan that has not entered the RunEngine (issue #571).
-            should_abort=lambda: self._abort_requested,
-        )
+        self._pause_supervisor = self._make_pause_supervisor()
+        try:
+            run_scan_request(
+                self._session,
+                request,
+                resolver,
+                preflight=self._delegated_preflight,
+                on_scan_start=self._on_delegated_scan_start,
+                optimization_binder=optimization_binder,
+                device_requirements=(
+                    getattr(opt_bridge, "device_requirements", None)
+                    if opt_bridge is not None
+                    else None
+                ),
+                operator_channel=self._delegated_operator_channel(),
+                # Stop clicked during initialization: the runner consults
+                # this between init stages (all pre-claim) and the session's
+                # stop gate re-reads it at plan start — RE.abort() alone
+                # cannot reach a scan not yet in the RunEngine (issue #571).
+                should_abort=lambda: self._abort_requested,
+                # The during-scan operator-action pause window (#552): a
+                # deferred pause at a plan checkpoint hands the scan thread
+                # to this supervisor (safe state → decide → act → restore).
+                pause_supervisor=self._pause_supervisor,
+            )
+        finally:
+            # A pause requested but never delivered (the scan ended first)
+            # is the normal end-of-plan outcome recorded on #552 — withdraw
+            # it, report it, release its factory.
+            leftover = self._pause_supervisor.take_unconsumed_pending()
+            if leftover is not None:
+                logger.info(
+                    "action %r was requested but the scan ended before the "
+                    "pause landed — it was NOT run",
+                    leftover.name,
+                )
+                try:
+                    leftover.cleanup()
+                except Exception:  # noqa: BLE001 — best-effort
+                    logger.debug("leftover-action cleanup raised", exc_info=True)
+            self._pause_supervisor = None
         if opt_bridge is not None and not getattr(
             self._session, "last_run_aborted", False
         ):

--- a/GeecsBluesky/geecs_bluesky/scanner_bridge/bluesky_scanner.py
+++ b/GeecsBluesky/geecs_bluesky/scanner_bridge/bluesky_scanner.py
@@ -385,9 +385,16 @@ class BlueskyScanner:
         self._abort_requested = True
         self._set_state("STOPPING")
         try:
-            # Idle engine: skip — the init-stage stop is covered by the
-            # should_abort checkpoints + the session's stop gate (above).
-            if self._RE.state != "idle":
+            if self._RE.state == "paused":
+                # A pause window (#552) is active: the scan thread is in
+                # the supervisor, which reads _abort_requested and issues
+                # RE.abort() from the RE's own thread context.  A second
+                # abort here would race it and cancel the cleanup task
+                # partway (finalize chain truncated).  Only set the flag.
+                pass
+            elif self._RE.state != "idle":
+                # Idle engine: skip — the init-stage stop is covered by the
+                # should_abort checkpoints + the session's stop gate (above).
                 self._RE.abort(reason="stop_scanning_thread called")
         except Exception:
             logger.debug("RE.abort() raised (may not be running)", exc_info=True)
@@ -520,11 +527,16 @@ class BlueskyScanner:
         plan, registry = self._session._resolve_action(name, resolver)
         steps = flatten_action_steps(plan, registry=registry)
 
-        guarded = self._guarded_shot_control_devices()
+        # Case-insensitive: GEECS configs disagree on device-name case, so
+        # the guard folds both sides (same rule as merge_save_sets /
+        # merge_optimizer_device_requirements) — a case-mismatched name
+        # must not slip a shot-control write past decision 11.  CheckStep
+        # (read-only) does not perturb the trigger, so only SetStep counts.
+        guarded = {d.casefold() for d in self._guarded_shot_control_devices()}
         touched = {
             step.device
             for step, _ in steps
-            if isinstance(step, (SetStep, CheckStep)) and step.device in guarded
+            if isinstance(step, SetStep) and step.device.casefold() in guarded
         }
         if touched:
             raise GeecsConfigurationError(

--- a/GeecsBluesky/geecs_bluesky/session.py
+++ b/GeecsBluesky/geecs_bluesky/session.py
@@ -620,6 +620,11 @@ class GeecsSession:
         while True:
             verdict = pause_supervisor.on_pause(self)
             if verdict == "abort":
+                # The pause supervisor is the *sole* abort owner while
+                # paused (stop_scanning_thread deliberately skips its own
+                # RE.abort() when the RE is paused — #552 review): abort
+                # here, from the RE's own thread context, so the finalize
+                # chain runs to completion exactly once.
                 logger.info("pause window verdict: abort — stopping the scan")
                 self.RE.abort()
                 return "aborted"

--- a/GeecsBluesky/geecs_bluesky/session.py
+++ b/GeecsBluesky/geecs_bluesky/session.py
@@ -181,6 +181,10 @@ class GeecsSession:
         self._mock = mock
         # context_managers=[] so sessions also work off the main thread.
         self.RE = RunEngine(context_managers=[])
+        # #552 (owner decision 13): pause/resume land as documents in the
+        # run, so a pause window is part of the data record — a wall-clock
+        # gap between rows explains itself.
+        self.RE.record_interruptions = True
         # Silence upstream's RequestAbort traceback (operator aborts are
         # quiet, intentional outcomes — #563 follow-up).  RE.log is a
         # LoggerAdapter over the PROCESS-WIDE ``bluesky`` logger shared by
@@ -582,6 +586,53 @@ class GeecsSession:
             md=md,
         )
 
+    def _run_supervised(self, plan: Any, pause_supervisor: Any | None) -> str:
+        """Run *plan* on the RE, handling supervised pause windows (#552).
+
+        With no *pause_supervisor* this is exactly ``self.RE(plan)`` —
+        every interrupt propagates as before (headless default).  With one,
+        a deferred pause landing at a plan checkpoint hands control to
+        ``pause_supervisor.on_pause(self)`` on this (scan) thread: a
+        ``"resume"`` verdict re-enters ``RE.resume()`` (which may pause
+        again — the window can repeat), an ``"abort"`` verdict runs
+        ``RE.abort()`` (the plan's finalize chain executes) and reports
+        ``"aborted"``.
+
+        Returns
+        -------
+        str
+            ``"completed"`` (the plan ran to its own end) or ``"aborted"``
+            (an abort verdict from a pause window).
+
+        Raises
+        ------
+        RunEngineInterrupted
+            Unsupervised pause (propagated, today's contract), or the
+            engine settling to idle from an operator stop — the caller's
+            existing handling owns both.
+        """
+        try:
+            self.RE(plan)
+            return "completed"
+        except RunEngineInterrupted:
+            if pause_supervisor is None or self.RE.state != "paused":
+                raise
+        while True:
+            verdict = pause_supervisor.on_pause(self)
+            if verdict == "abort":
+                logger.info("pause window verdict: abort — stopping the scan")
+                self.RE.abort()
+                return "aborted"
+            try:
+                self.RE.resume()
+                return "completed"
+            except RunEngineInterrupted:
+                if self.RE.state != "paused":
+                    # An operator stop landed during the resumed stretch —
+                    # the caller's settled-to-idle handling owns it.
+                    raise
+                continue
+
     def scan(
         self,
         *,
@@ -603,6 +654,7 @@ class GeecsSession:
         per_step: Any | None = None,
         closeout: Any | None = None,
         should_abort: Callable[[], bool] | None = None,
+        pause_supervisor: Any | None = None,
     ) -> str | None:
         """Run one scan with the full GEECS run discipline; return the run uid.
 
@@ -735,7 +787,7 @@ class GeecsSession:
         # the scan.log handler, and a second one would duplicate every line.
         with scan_log(scan_number, scan_folder) if claimed_here else nullcontext():
             try:
-                self.RE(plan)
+                supervised_outcome = self._run_supervised(plan, pause_supervisor)
             except RunEngineInterrupted:
                 if self.RE.state == "paused":
                     # A pause is not a settled outcome — the operator may
@@ -749,6 +801,17 @@ class GeecsSession:
                 logger.info(
                     "Scan %s aborted by operator; cleanup completed "
                     "(trigger disarmed, saving stopped)",
+                    scan_number if scan_number is not None else "(unsaved)",
+                )
+                return self._last_run_uid
+
+            if supervised_outcome == "aborted":
+                # Abort verdict from a pause window: RE.abort() already ran
+                # the plan's finalize chain — an intentional outcome.
+                self.last_run_aborted = True
+                logger.info(
+                    "Scan %s aborted from the pause window; cleanup "
+                    "completed (trigger disarmed, saving stopped)",
                     scan_number if scan_number is not None else "(unsaved)",
                 )
                 return self._last_run_uid
@@ -786,6 +849,7 @@ class GeecsSession:
         scan_number: int | None = None,
         scan_folder: str | None = None,
         should_abort: Callable[[], bool] | None = None,
+        pause_supervisor: Any | None = None,
     ) -> tuple[str | None, list[dict]]:
         """Run an optimization **as a scan** (iteration = bin); return (uid, history).
 
@@ -988,7 +1052,8 @@ class GeecsSession:
             self.last_run_aborted = False
             aborted = False
             try:
-                self.RE(run_plan)
+                outcome = self._run_supervised(run_plan, pause_supervisor)
+                aborted = outcome == "aborted"
             except RunEngineInterrupted:
                 if self.RE.state == "paused":
                     # A pause is not a settled outcome (the operator may

--- a/GeecsBluesky/geecs_bluesky/shot_controller.py
+++ b/GeecsBluesky/geecs_bluesky/shot_controller.py
@@ -225,6 +225,27 @@ class ShotController:
             self._record_state(state)
             logger.info("Shot controller → %s", state)
 
+    def state_setters(self, state: str | ShotControlState) -> list[tuple[Any, str]]:
+        """Return the ordered ``(setter, value)`` writes for *state*.
+
+        The non-plan accessor behind the #552 pause supervisor: while the
+        RunEngine is paused, :meth:`set_state`'s plan stub cannot run, so
+        the supervisor drives these writes directly (each dispatched onto
+        the RE's loop, sequentially, preserving the profile's declared
+        order — the same semantics the plan stub yields).  Empty when the
+        state defines no writes.
+        """
+        name = state.value if isinstance(state, ShotControlState) else str(state)
+        if self._transitions is not None:
+            return list(self._transitions.get(name, []))
+        if self.config is None:
+            return []
+        return [
+            (self._setters[var], value)
+            for var, value in self.config.values_for_state(name).items()
+            if var in self._setters
+        ]
+
     def _record_state(self, state: str | ShotControlState) -> None:
         """Remember *state* as :attr:`last_state` if it is a standing state.
 

--- a/GeecsBluesky/pyproject.toml
+++ b/GeecsBluesky/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-bluesky"
-version = "0.43.0"
+version = "0.44.0"
 description = "Bluesky / ophyd-async bridge for the GEECS control system"
 authors = ["Sam Barber <sbarber@lbl.gov>"]
 readme = "README.md"

--- a/GeecsBluesky/tests/test_action_during_scan.py
+++ b/GeecsBluesky/tests/test_action_during_scan.py
@@ -98,7 +98,9 @@ def _make_running_scanner(session, request, resolver, *, scanning=True):
     )
     scanner._pauses = pauses
     # Force is_scanning_active without a real thread.
-    scanner._scan_thread = SimpleNamespace(is_alive=lambda: scanning)
+    scanner._scan_thread = SimpleNamespace(
+        is_alive=lambda: scanning, join=lambda timeout=None: None
+    )
     return scanner
 
 
@@ -171,3 +173,34 @@ def test_single_action_per_pause_window() -> None:
     scanner.request_action_during_scan("jet_on")
     with pytest.raises(RuntimeError, match="already awaiting"):
         scanner.request_action_during_scan("jet_on")
+
+
+_TOUCHES_DG_LOWER = ActionPlan.model_validate(
+    {"steps": [{"do": "set", "device": "u_dg645", "variable": "Amp", "value": 9}]}
+)
+
+
+def test_case_mismatched_shot_control_device_still_refused() -> None:
+    """Decision 11 is case-insensitive (GEECS configs disagree on case)."""
+    resolver = _FakeResolver({"bad": _TOUCHES_DG_LOWER}, profiles={"HTU": _PROFILE})
+    request = _request(trigger_profile="HTU")  # profile writes 'U_DG645'
+    scanner = _make_running_scanner(_FakeSession(resolver), request, resolver)
+    with pytest.raises(GeecsConfigurationError, match="shot-control"):
+        scanner.request_action_during_scan("bad")  # 'u_dg645' vs 'U_DG645'
+
+
+def test_stop_during_pause_does_not_abort_the_re_itself() -> None:
+    """#552: while paused, stop_scanning_thread lets the supervisor own the
+    abort — a second RE.abort() here would truncate the finalize cleanup."""
+    aborts: list = []
+    resolver = _FakeResolver({"jet_on": _JET_ON})
+    scanner = _make_running_scanner(_FakeSession(resolver), _request(), resolver)
+    scanner._RE = SimpleNamespace(
+        state="paused",
+        request_pause=lambda defer=True: None,
+        abort=lambda reason=None: aborts.append(reason),
+    )
+    scanner._set_state = lambda *a, **k: None  # skip event plumbing
+    scanner.stop_scanning_thread()
+    assert scanner._abort_requested is True  # flag set (wakes the park loop)
+    assert aborts == []  # but the RE was NOT aborted from here (supervisor owns it)

--- a/GeecsBluesky/tests/test_action_during_scan.py
+++ b/GeecsBluesky/tests/test_action_during_scan.py
@@ -1,0 +1,173 @@
+"""BlueskyScanner.request_action_during_scan (G-actions v2, #552, PR-3).
+
+The bridge half of the during-scan action path: fail-fast validation and
+the shot-control-device refusal (owner decision 11) on the GUI thread, the
+PAUSING emission + deferred pause request, single-slot staging, and the
+no-scan refusal.  The pause-window execution itself is pinned in
+``test_pause_supervisor.py``; here we drive the bridge with fakes.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from geecs_bluesky.events import ScanState
+from geecs_bluesky.exceptions import GeecsConfigurationError
+from geecs_bluesky.pause_supervisor import PauseSupervisor
+from geecs_bluesky.scanner_bridge.bluesky_scanner import BlueskyScanner
+from geecs_schemas import (
+    ActionPlan,
+    ScanRequest,
+    TriggerProfile,
+)
+
+
+class _FakeSignal:
+    def set(self, value):  # pragma: no cover - never executed here
+        raise NotImplementedError
+
+
+class _FakeFactory:
+    def __init__(self) -> None:
+        self.unreachable: set = set()
+
+    def get_settable(self, device, variable):
+        if (device, variable) in self.unreachable:
+            raise RuntimeError("no such PV")
+        return _FakeSignal()
+
+    def get_readable(self, device, variable):
+        return _FakeSignal()
+
+
+class _FakeResolver:
+    def __init__(self, plans, profiles=None) -> None:
+        self._plans = plans
+        self._profiles = profiles or {}
+
+    def resolve_action_plan(self, name):
+        return self._plans[name]
+
+    def resolve_trigger_profile(self, name):
+        return self._profiles[name]
+
+
+class _FakeSession:
+    def __init__(self, resolver) -> None:
+        self._resolver = resolver
+        self.RE = SimpleNamespace(loop=None)
+        self.factory = _FakeFactory()
+        self.disconnected: list = []
+        self._shot_controller = None
+
+    def _resolve_action(self, name, resolver):
+        r = resolver or self._resolver
+        return r.resolve_action_plan(name), {
+            n: r.resolve_action_plan(n) for n in getattr(r, "_plans", {})
+        }
+
+    def action_signal_factory(self):
+        return self.factory
+
+    def disconnect(self, *devices):
+        self.disconnected.extend(devices)
+
+
+def _make_running_scanner(session, request, resolver, *, scanning=True):
+    scanner = BlueskyScanner.__new__(BlueskyScanner)
+    scanner._session = session
+    scanner._experiment_dir = "TestExp"
+    scanner._scan_request = request
+    scanner._request_resolver = resolver
+    scanner._abort_requested = False
+    scanner._scan_number = None
+    scanner.events: list = []
+    scanner._on_event = scanner.events.append
+    scanner._current_state = ScanState.RUNNING
+    scanner._pause_supervisor = PauseSupervisor(
+        acquisition="free_run",
+        shot_controller=lambda: None,
+        ask=scanner._ask_action_decision,
+        should_abort=lambda: scanner._abort_requested,
+    )
+    pauses: list = []
+    scanner._RE = SimpleNamespace(
+        loop=None, request_pause=lambda defer=True: pauses.append(defer)
+    )
+    scanner._pauses = pauses
+    # Force is_scanning_active without a real thread.
+    scanner._scan_thread = SimpleNamespace(is_alive=lambda: scanning)
+    return scanner
+
+
+_JET_ON = ActionPlan.model_validate(
+    {"steps": [{"do": "set", "device": "U_Valve", "variable": "Open", "value": 1}]}
+)
+_TOUCHES_DG = ActionPlan.model_validate(
+    {"steps": [{"do": "set", "device": "U_DG645", "variable": "Amp", "value": 9}]}
+)
+_PROFILE = TriggerProfile(
+    name="HTU",
+    states={
+        "SCAN": [{"device": "U_DG645", "variable": "Amplitude.Ch AB", "value": "4.0"}]
+    },
+)
+
+
+def _request(**kw) -> ScanRequest:
+    base = dict(
+        mode="noscan", shots_per_step=1, acquisition="free_run", save_sets=["s"]
+    )
+    base.update(kw)
+    return ScanRequest.model_validate(base)
+
+
+def test_requests_deferred_pause_and_emits_pausing() -> None:
+    resolver = _FakeResolver({"jet_on": _JET_ON})
+    session = _FakeSession(resolver)
+    scanner = _make_running_scanner(session, _request(), resolver)
+    scanner.request_action_during_scan("jet_on")
+    assert scanner._pauses == [True]  # deferred pause requested
+    assert scanner._current_state == ScanState.PAUSING
+    assert scanner._pause_supervisor._pending is not None
+
+
+def test_refused_when_action_touches_shot_control_device() -> None:
+    resolver = _FakeResolver({"bad": _TOUCHES_DG}, profiles={"HTU": _PROFILE})
+    request = _request(trigger_profile="HTU")
+    session = _FakeSession(resolver)
+    scanner = _make_running_scanner(session, request, resolver)
+    with pytest.raises(GeecsConfigurationError, match="shot-control"):
+        scanner.request_action_during_scan("bad")
+    assert scanner._pauses == []  # never paused
+    assert scanner._pause_supervisor._pending is None
+
+
+def test_unreachable_target_refused_before_pausing() -> None:
+    resolver = _FakeResolver({"jet_on": _JET_ON})
+    session = _FakeSession(resolver)
+    session.factory.unreachable.add(("U_Valve", "Open"))
+    scanner = _make_running_scanner(session, _request(), resolver)
+    with pytest.raises(GeecsConfigurationError, match="cannot reach"):
+        scanner.request_action_during_scan("jet_on")
+    assert scanner._pauses == []
+    assert session.disconnected  # the factory was released
+
+
+def test_refused_when_no_scan_active() -> None:
+    resolver = _FakeResolver({"jet_on": _JET_ON})
+    session = _FakeSession(resolver)
+    scanner = _make_running_scanner(session, _request(), resolver, scanning=False)
+    with pytest.raises(RuntimeError, match="no scan in progress"):
+        scanner.request_action_during_scan("jet_on")
+
+
+def test_single_action_per_pause_window() -> None:
+    resolver = _FakeResolver({"jet_on": _JET_ON})
+    session = _FakeSession(resolver)
+    scanner = _make_running_scanner(session, _request(), resolver)
+    scanner.request_action_during_scan("jet_on")
+    with pytest.raises(RuntimeError, match="already awaiting"):
+        scanner.request_action_during_scan("jet_on")

--- a/GeecsBluesky/tests/test_bluesky_scanner_scan_request_seam.py
+++ b/GeecsBluesky/tests/test_bluesky_scanner_scan_request_seam.py
@@ -310,6 +310,9 @@ def _normalize_scan_kwargs(kwargs: dict) -> dict:
     # supplies its abort-flag lambda, a headless run supplies nothing
     # (issue #571) — drop it from the parity comparison.
     normalized.pop("should_abort", None)
+    # The bridge injects a pause supervisor (#552) the headless path does
+    # not — a bridge-only seam like should_abort, not a scan-content field.
+    normalized.pop("pause_supervisor", None)
     return normalized
 
 

--- a/GeecsBluesky/tests/test_pause_supervisor.py
+++ b/GeecsBluesky/tests/test_pause_supervisor.py
@@ -1,0 +1,245 @@
+"""The G-actions v2 pause supervisor (issue #552, PR-3).
+
+Pins the pause-window protocol without hardware: safe-state policy per
+acquisition mode, the three-way decision (execute / ignore / abort), the
+restore-after-action / no-restore-on-abort rule, failed-step re-prompt,
+the shot-control-device refusal (owner decision 11), and the
+scan-ended-before-pause "not run" outcome.  A real asyncio loop stands in
+for the paused RE's loop; the shot controller is a recording fake.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+import time
+
+import pytest
+
+from geecs_bluesky.events import ActionDecisionRequest
+from geecs_bluesky.pause_supervisor import PauseSupervisor, PendingAction
+from geecs_schemas.action_plan import SetStep
+
+
+@pytest.fixture()
+def loop():
+    loop = asyncio.new_event_loop()
+    thread = threading.Thread(target=loop.run_forever, daemon=True)
+    thread.start()
+    while not loop.is_running():
+        time.sleep(0.001)
+    yield loop
+    loop.call_soon_threadsafe(loop.stop)
+    thread.join(timeout=2)
+    loop.close()
+
+
+class _FakeSession:
+    def __init__(self, loop) -> None:
+        self.RE = type("RE", (), {"loop": loop})()
+        self.disconnected: list = []
+
+    def disconnect(self, factory) -> None:
+        self.disconnected.append(factory)
+
+
+class _RecordingSetter:
+    def __init__(self, journal: list, name: str) -> None:
+        self._journal = journal
+        self._name = name
+
+    def set(self, value):
+        async def _run() -> None:
+            self._journal.append((self._name, value))
+
+        return _run()
+
+
+class _FakeController:
+    """Records driven states; hands out setters for state_setters()."""
+
+    def __init__(self, journal: list, last_state: str | None = "SCAN") -> None:
+        self._journal = journal
+        self.last_state = last_state
+        self._writes = {
+            "OFF": [("U_DG645:Amp", "0.0")],
+            "SCAN": [("U_DG645:Amp", "4.0")],
+            "STANDBY": [("U_DG645:Amp", "0.5")],
+        }
+
+    def state_setters(self, state):
+        name = getattr(state, "value", str(state))
+        return [
+            (_RecordingSetter(self._journal, target), value)
+            for target, value in self._writes.get(name, [])
+        ]
+
+
+class _FakeFactory:
+    def __init__(self, journal: list) -> None:
+        self._journal = journal
+
+    def get_settable(self, device, variable):
+        return _RecordingSetter(self._journal, f"{device}:{variable}")
+
+    def get_readable(self, device, variable):  # pragma: no cover
+        raise NotImplementedError
+
+
+def _pending(name="jet_on", journal=None, cleanup=None) -> PendingAction:
+    journal = journal if journal is not None else []
+    step = SetStep.model_validate(
+        {"do": "set", "device": "U_Valve", "variable": "V", "value": 1}
+    )
+    return PendingAction(
+        name=name,
+        steps=[(step, None)],
+        factory=_FakeFactory(journal),
+        cleanup=cleanup or (lambda: None),
+    )
+
+
+def _answering(verdict: str):
+    """An ``ask`` seam that answers *verdict* immediately."""
+
+    def ask(request: ActionDecisionRequest) -> None:
+        request.verdict[0] = verdict
+        request.response_event.set()
+
+    return ask
+
+
+def test_free_run_drives_off_on_pause_and_restores_after_execute(loop) -> None:
+    states: list = []
+    steps: list = []
+    controller = _FakeController(states, last_state="SCAN")
+    session = _FakeSession(loop)
+    sup = PauseSupervisor(
+        acquisition="free_run",
+        shot_controller=lambda: controller,
+        ask=_answering("execute"),
+    )
+    sup.set_pending(_pending(journal=steps))
+    verdict = sup.on_pause(session)
+    assert verdict == "resume"
+    # OFF driven on pause, action step ran, entry state (SCAN) re-asserted.
+    assert states == [("U_DG645:Amp", "0.0"), ("U_DG645:Amp", "4.0")]
+    assert steps == [("U_Valve:V", 1)]
+
+
+def test_strict_drives_nothing_on_pause(loop) -> None:
+    states: list = []
+    controller = _FakeController(states, last_state="ARMED")
+    sup = PauseSupervisor(
+        acquisition="strict",
+        shot_controller=lambda: controller,
+        ask=_answering("ignore"),
+    )
+    sup.set_pending(_pending())
+    assert sup.on_pause(_FakeSession(loop)) == "resume"
+    assert states == []  # ARMED is already quiescent — nothing driven
+
+
+def test_abort_skips_restore(loop) -> None:
+    states: list = []
+    controller = _FakeController(states, last_state="SCAN")
+    sup = PauseSupervisor(
+        acquisition="free_run",
+        shot_controller=lambda: controller,
+        ask=_answering("abort"),
+    )
+    sup.set_pending(_pending())
+    assert sup.on_pause(_FakeSession(loop)) == "abort"
+    # OFF driven on pause; NO restore write (the finalize chain owns it).
+    assert states == [("U_DG645:Amp", "0.0")]
+
+
+def test_ignore_restores_without_running_the_action(loop) -> None:
+    states: list = []
+    steps: list = []
+    controller = _FakeController(states, last_state="SCAN")
+    sup = PauseSupervisor(
+        acquisition="free_run",
+        shot_controller=lambda: controller,
+        ask=_answering("ignore"),
+    )
+    sup.set_pending(_pending(journal=steps))
+    assert sup.on_pause(_FakeSession(loop)) == "resume"
+    assert steps == []  # action not run
+    assert states == [("U_DG645:Amp", "0.0"), ("U_DG645:Amp", "4.0")]  # restored
+
+
+def test_failed_step_reprompts_then_ignores(loop) -> None:
+    """A check/step failure keeps the scan paused and re-prompts (decision 10)."""
+    verdicts = iter(["execute", "ignore"])
+    asked: list[str] = []
+
+    def ask(request: ActionDecisionRequest) -> None:
+        asked.append(request.message)
+        request.verdict[0] = next(verdicts)
+        request.response_event.set()
+
+    class _FailingFactory(_FakeFactory):
+        def get_settable(self, device, variable):
+            class _Bad:
+                def set(self, value):
+                    async def _run():
+                        raise RuntimeError("GEECS refused")
+
+                    return _run()
+
+            return _Bad()
+
+    step = SetStep.model_validate(
+        {"do": "set", "device": "U_Valve", "variable": "V", "value": 1}
+    )
+    pending = PendingAction(
+        name="bad", steps=[(step, None)], factory=_FailingFactory([])
+    )
+    sup = PauseSupervisor(
+        acquisition="strict",
+        shot_controller=lambda: _FakeController([], last_state="ARMED"),
+        ask=ask,
+    )
+    sup.set_pending(pending)
+    assert sup.on_pause(_FakeSession(loop)) == "resume"
+    assert len(asked) == 2  # execute (fails) → re-prompt → ignore
+    assert "FAILED" in asked[1]
+
+
+def test_no_consumer_defaults_to_ignore(loop) -> None:
+    steps: list = []
+    sup = PauseSupervisor(
+        acquisition="strict",
+        shot_controller=lambda: _FakeController([], last_state="ARMED"),
+        ask=None,  # headless / no dialog consumer
+    )
+    sup.set_pending(_pending(journal=steps))
+    assert sup.on_pause(_FakeSession(loop)) == "resume"
+    assert steps == []  # defaulted to ignore — never executed
+
+
+def test_abort_probe_while_parked_yields_abort(loop) -> None:
+    aborting = {"v": False}
+
+    def ask(request: ActionDecisionRequest) -> None:
+        # Never answer — the abort probe must wake the park loop instead.
+        aborting["v"] = True
+
+    sup = PauseSupervisor(
+        acquisition="strict",
+        shot_controller=lambda: _FakeController([], last_state="ARMED"),
+        ask=ask,
+        should_abort=lambda: aborting["v"],
+    )
+    sup.set_pending(_pending())
+    assert sup.on_pause(_FakeSession(loop)) == "abort"
+
+
+def test_set_pending_is_single_slot() -> None:
+    sup = PauseSupervisor(acquisition="free_run", shot_controller=lambda: None)
+    assert sup.set_pending(_pending("a")) is True
+    assert sup.set_pending(_pending("b")) is False
+    taken = sup.take_unconsumed_pending()
+    assert taken.name == "a"
+    assert sup.take_unconsumed_pending() is None


### PR DESCRIPTION
PR-3 of the G-actions v2 sequence (issue #552; PR-1 #578 + PR-2 #579 merged). The core piece — the console half (PR-4) is next.

## What + why

An operator firing an action mid-scan can now **pause the scan at a safe boundary, decide, act, and resume** — instead of the v1 refusal. Full protocol (design note + the 15 owner decisions on #552):

- **`BlueskyScanner.request_action_during_scan(name)`** (GUI thread): fail-fast validation (unknown name / unreachable target / cycle), then **refuses any action that writes to the active scan's shot-control device(s)** (decision 11 — an action must not perturb the trigger the scan drives; derived from the request's trigger profile). On success it stages the flattened steps + a connected factory on the run's `PauseSupervisor`, emits `PAUSING`, and asks the RE to pause deferred (lands at a PR-1 checkpoint, empty rewind cache).
- **`pause_supervisor.PauseSupervisor`** (scan thread, inside `session.scan`/`optimize` via the new `_run_supervised` helper): drive the mode-specific safe state (free-run → `OFF`, jet off + no orphan frames, safe indefinitely; strict → nothing, `ARMED` already quiescent) with direct `ShotController.state_setters` writes on the paused RE loop → emit `PAUSED` → deliver the three-way `ActionDecisionRequest` (execute/ignore/abort) through the existing `ScanDialogEvent` transport → run an approved action via the PR-2 direct executor → re-assert the captured `last_state` and resume. **Abort skips the restore** (the finalize chain owns the end state); a **failed step stays paused and re-prompts** (decision 10).
- Non-terminal `ScanState.PAUSING`/`PAUSED`; `RE.record_interruptions = True` (decision 13) so the pause is in the run record. A pause requested but never delivered (scan ended first) is withdrawn + logged, not an error (the end-of-plan contract note from PR-1's review).

## Per-concern LOC breakdown

- `pause_supervisor.py` (new): +230
- Session wiring (`_run_supervised` helper + `pause_supervisor=` param on scan/optimize + supervised-abort outcome + `record_interruptions`): +75
- Bridge (`request_action_during_scan`, guard, ask seam, supervisor construct/teardown in the delegated run): +180
- `events.py` (`ActionDecisionRequest`, PAUSING/PAUSED, widened `ScanDialogEvent.request`): +45
- `shot_controller.py` (`state_setters` accessor): +20
- Runner (thread `pause_supervisor` through the four session call sites): +6
- Tests (`test_pause_supervisor.py` 8, `test_action_during_scan.py` 5): +330
- Version + CHANGELOG + CLAUDE.md: +60

## Tests

- `./scripts/check.sh` (scoped): lint clean; **GeecsBluesky 568 passed, 3 deselected** (555 + 13 new). The existing delegation-parity pin still holds (the injected supervisor is a bridge-only seam, normalized out like `should_abort`).
- **Bug fixed in passing** (found by the new refusal test): the bridge referenced `trigger_writes_from_profile` without importing it — dormant because the call sat under a broad `except Exception` that swallowed the `NameError`. Import added; the catch narrowed to `GeecsConfigurationError` so a programming error can't hide there again.

## Hardware verification

**OWED** — the pause-window hardware checklist (design note §6.5), owed at the end of the sequence before the feature is declared usable: free-run pause actually stops the jet (OFF); strict stays quiescent; pause latency at real rep rate; one full pause→execute→resume with post-resume `shot_offset` labels + s-file integrity; abort-during-pause end state; the shot-control-device refusal live. Nothing in this PR runs without an operator requesting a pause, and no console can request one yet (PR-4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)