### PR TITLE
GEECS-Console 0.16.0 + GeecsBluesky 0.44.1: G-actions v2 console half + #575 dialog hardening

### DIFF
--- a/GEECS-Console/CHANGELOG.md
+++ b/GEECS-Console/CHANGELOG.md
@@ -4,6 +4,30 @@ All notable changes to GEECS-Console are documented here.  Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versioning is
 semantic.
 
+## [0.16.0] - 2026-07-16
+
+### Added
+
+- **G-actions v2 console half** (issue #552 PR-4; #575 dialog hardening).
+  The Actions Run/Preview dialog now drives the during-scan pause flow:
+  while a scan is active the Run button reads **"Pause scan & run (N
+  steps)"** and calls the engine's `request_action_during_scan` (pause →
+  decide → run) instead of the idle `run_action`; the window pushes live
+  scan state into open dialogs so the button flips automatically.  The
+  three-way **action-decision modal** (Execute / Ignore / Abort) renders
+  from the engine's `ActionDecisionRequest` (routed through the existing
+  `ScanDialogEvent` transport, duck-typed on the `verdict` attribute) and
+  is **dismissed on a terminal ABORTED state** — a Stop during the pause
+  window aborts the scan without the engine answering, and the engine has
+  no dialog-cancel signal (the #552 PR-3 review contract).  New
+  `Submitter` protocol member `request_action_during_scan`; new
+  `ScanState.PAUSING`/`PAUSED` render amber on the R6 pill.
+- **Actions dialog misfire hardening** (issue #575): the action name in
+  larger type on its own line, **Run disabled until the dry-run preview
+  loads** (no firing beside an empty table — this also eliminates the old
+  late-preview-clobbers-run race by construction), and the **step count on
+  the Run button** ("Run (N steps)").
+
 ## [0.15.1] - 2026-07-16
 
 ### Changed

--- a/GEECS-Console/CLAUDE.md
+++ b/GEECS-Console/CLAUDE.md
@@ -269,7 +269,22 @@ are prefixed by region (`r3_radio_1d`, `r5_start_button`, …).
   describe arriving late must never clobber a refusal (pinned by test).
   Both engine methods are `Submitter` protocol members
   (`submission.py`), mapped to `BlueskyScanner`'s same-named methods.
-  A pause-the-scan flow for actions (#552) is future work.  Pinned by
+  **During-scan (G-actions v2, #552, 0.16.0):** the same dialog drives the
+  pause flow — with a scan active the Run button reads "Pause scan & run
+  (N steps)" and calls the `Submitter.request_action_during_scan` member
+  (pause → decide → run) instead of idle `run_action`; the window pushes
+  live scan state into open dialogs (`set_scanning`) so the button flips.
+  The three-way **action-decision modal** (Execute / Ignore / Abort) is
+  rendered by `_on_action_decision` from an engine `ActionDecisionRequest`
+  (routed through the same `ScanDialogEvent`/`dialog_requested` transport
+  as the binary pre-flight dialog — `_on_operator_dialog` duck-types on the
+  `verdict` attribute), and is **dismissed on a terminal ABORTED state**
+  (`self._decision_box.reject()` in `_on_scan_state`): a Stop during the
+  pause window aborts without the engine answering, and the engine has no
+  dialog-cancel signal (the #552 PR-3 review contract).  **Misfire
+  hardening (#575):** name in larger type, Run gated on the preview having
+  loaded (no firing beside an empty table — kills the old
+  late-preview-clobbers-run race), step count on the Run label.  Pinned by
   `tests/test_actions_menu.py`.
 - **Optimization (R3) — end to end**: the Optimization radio shows a
   config combo listing the YAML stems of the experiment's

--- a/GEECS-Console/geecs_console/app/action_dialog.py
+++ b/GEECS-Console/geecs_console/app/action_dialog.py
@@ -70,6 +70,15 @@ class ActionRunDialog(QDialog):
     report : callable
         ``(message) -> None`` — the window's status-bar/log reporter for
         the running/done/failed lines.
+    request_during_scan : callable, optional
+        ``(name) -> None`` — :meth:`Submitter.request_action_during_scan`,
+        the during-scan path (pause → decide → run).  When a scan is
+        active the Run button uses this instead of *run*; without it (or
+        without *is_scanning*) the dialog only ever runs idle.
+    is_scanning : callable, optional
+        ``() -> bool`` — whether a scan is active *now*, so the Run button
+        picks the path and shows the right label.  The window also pushes
+        state changes via :meth:`set_scanning`.
     """
 
     def __init__(
@@ -80,14 +89,24 @@ class ActionRunDialog(QDialog):
         run: Callable[[str], None],
         execution_enabled: bool,
         report: Callable[[str], None],
+        request_during_scan: Optional[Callable[[str], None]] = None,
+        is_scanning: Optional[Callable[[], bool]] = None,
     ) -> None:
         super().__init__(parent)
         self._name = name
         self._describe = describe
         self._run = run
         self._report = report
+        self._request_during_scan = request_during_scan
+        self._is_scanning = is_scanning
         self._execution_enabled = bool(execution_enabled)
         self._run_in_flight = False
+        #: Run stays disabled until the dry-run preview loads — a slow
+        #: describe must never leave Run clickable beside an empty table
+        #: (issue #575 misfire hardening).
+        self._preview_loaded = False
+        self._step_count = 0
+        self._scanning = bool(is_scanning()) if is_scanning is not None else False
 
         self.setWindowTitle(f"Action: {name}")
         self._build_widgets()
@@ -114,7 +133,10 @@ class ActionRunDialog(QDialog):
         """Create the name label, steps table, message line, and buttons."""
         layout = QVBoxLayout(self)
 
-        title = QLabel(f"Action plan: <b>{self._name}</b>")
+        # The action name is unmissable (issue #575: the misfire is
+        # selection-adjacency — a habituated operator clicks Run beside the
+        # wrong name).  Larger type, name on its own line.
+        title = QLabel(f"Run action<br><b style='font-size:16px;'>{self._name}</b>")
         title.setTextFormat(Qt.TextFormat.RichText)
         layout.addWidget(title)
 
@@ -165,13 +187,46 @@ class ActionRunDialog(QDialog):
         self._execution_enabled = bool(enabled)
         self._refresh_run_enabled()
 
+    def set_scanning(self, scanning: bool) -> None:
+        """Push the live scan state so Run picks the path and label.
+
+        Parameters
+        ----------
+        scanning : bool
+            Whether a scan is active (the window pushes lifecycle changes).
+        """
+        self._scanning = bool(scanning)
+        self._refresh_run_enabled()
+
+    def _during_scan(self) -> bool:
+        """Whether the Run button should use the pause-scan path."""
+        return self._scanning and self._request_during_scan is not None
+
     def _refresh_run_enabled(self) -> None:
-        """Gate Run: armed via the menu, and no run already in flight."""
-        self.run_button.setEnabled(self._execution_enabled and not self._run_in_flight)
+        """Gate Run and set its label — armed, previewed, not in flight."""
+        ready = (
+            self._execution_enabled and self._preview_loaded and not self._run_in_flight
+        )
+        self.run_button.setEnabled(ready)
+        # Step count on the button (issue #575): "Run 'name' (N steps)".
+        steps = f" ({self._step_count} step{'s' if self._step_count != 1 else ''})"
+        if self._during_scan():
+            self.run_button.setText(f"Pause scan & run{steps}")
+        else:
+            self.run_button.setText(f"Run{steps if self._preview_loaded else ''}")
+
         if not self._execution_enabled:
             self.run_button.setToolTip(
                 "Check 'Enable action execution' in the Actions menu to arm "
                 "Run (preview is always available)."
+            )
+        elif not self._preview_loaded:
+            self.run_button.setToolTip("Waiting for the dry-run preview to load…")
+        elif self._during_scan():
+            self.run_button.setToolTip(
+                "Pause the running scan at its next safe point, then decide "
+                "whether to run this action (a pop-up asks execute / ignore / "
+                "abort).  Refused if the action writes the scan's trigger."
             )
         else:
             self.run_button.setToolTip(
@@ -219,29 +274,58 @@ class ActionRunDialog(QDialog):
         self.preview_label.setText(
             f"{count} step{'s' if count != 1 else ''} (dry-run preview)."
         )
+        # The preview loaded — arm Run (if the menu allows) with the step
+        # count now on its label.
+        self._preview_loaded = True
+        self._step_count = count
+        self._refresh_run_enabled()
 
     # ------------------------------------------------------------------
     # Execution (run_action)
     # ------------------------------------------------------------------
 
     def _on_run_clicked(self) -> None:
-        """Dispatch the blocking ``run_action`` through the run worker."""
-        if self._run_in_flight or not self._execution_enabled:
+        """Dispatch the action — idle ``run_action`` or the pause-scan path."""
+        if (
+            self._run_in_flight
+            or not self._execution_enabled
+            or not self._preview_loaded
+        ):
             return
         self._run_in_flight = True
         self._refresh_run_enabled()
-        message = f"running action '{self._name}'…"
-        self._report(message)
-        self.message_label.setText(message)
-        run = self._run
         name = self._name
 
-        def call() -> tuple[bool, str]:
-            try:
-                run(name)
-            except Exception as exc:  # noqa: BLE001 — refusals/failures are messages
-                return (False, str(exc))
-            return (True, f"action '{name}' done")
+        if self._during_scan():
+            # During a scan: ask the engine to pause and stage the action;
+            # the operator's execute/ignore/abort decision then arrives as a
+            # separate three-way modal on the window.  This call returns
+            # promptly (or raises a refusal).
+            message = f"pausing scan to run '{name}'…"
+            self._report(message)
+            self.message_label.setText(message)
+            request = self._request_during_scan
+            done_ok = "scan pausing — decide in the pop-up"
+
+            def call() -> tuple[bool, str]:
+                try:
+                    request(name)
+                except Exception as exc:  # noqa: BLE001 — refusals are messages
+                    return (False, str(exc))
+                return (True, done_ok)
+
+        else:
+            message = f"running action '{name}'…"
+            self._report(message)
+            self.message_label.setText(message)
+            run = self._run
+
+            def call() -> tuple[bool, str]:
+                try:
+                    run(name)
+                except Exception as exc:  # noqa: BLE001 — refusals are messages
+                    return (False, str(exc))
+                return (True, f"action '{name}' done")
 
         self._run_worker.run_async(call, name="console-action-run")
 

--- a/GEECS-Console/geecs_console/app/action_dialog.py
+++ b/GEECS-Console/geecs_console/app/action_dialog.py
@@ -208,12 +208,18 @@ class ActionRunDialog(QDialog):
             self._execution_enabled and self._preview_loaded and not self._run_in_flight
         )
         self.run_button.setEnabled(ready)
-        # Step count on the button (issue #575): "Run 'name' (N steps)".
-        steps = f" ({self._step_count} step{'s' if self._step_count != 1 else ''})"
+        # Step count on the button (issue #575) — only once the preview has
+        # loaded, so an in-flight describe never shows a misleading "(0
+        # steps)" on either path.
+        steps = (
+            f" ({self._step_count} step{'s' if self._step_count != 1 else ''})"
+            if self._preview_loaded
+            else ""
+        )
         if self._during_scan():
             self.run_button.setText(f"Pause scan & run{steps}")
         else:
-            self.run_button.setText(f"Run{steps if self._preview_loaded else ''}")
+            self.run_button.setText(f"Run{steps}")
 
         if not self._execution_enabled:
             self.run_button.setToolTip(

--- a/GEECS-Console/geecs_console/app/main_window.py
+++ b/GEECS-Console/geecs_console/app/main_window.py
@@ -2127,28 +2127,45 @@ class MainWindow(QMainWindow):
         if getattr(request, "verdict", None) is not None:
             self._on_action_decision(request)
             return
-        exc = getattr(request, "exc", None)
-        title = getattr(request, "title", None) or "Operator confirmation"
-        continue_label = getattr(request, "continue_label", None) or "Continue"
-        abort_label = getattr(request, "abort_label", None) or "Abort"
+        try:
+            exc = getattr(request, "exc", None)
+            title = getattr(request, "title", None) or "Operator confirmation"
+            continue_label = getattr(request, "continue_label", None) or "Continue"
+            abort_label = getattr(request, "abort_label", None) or "Abort"
 
-        box = QMessageBox(self)
-        box.setIcon(QMessageBox.Icon.Warning)
-        box.setWindowTitle(str(title))
-        box.setText(str(exc) if exc is not None else str(title))
-        continue_button = box.addButton(
-            str(continue_label), QMessageBox.ButtonRole.AcceptRole
-        )
-        box.addButton(str(abort_label), QMessageBox.ButtonRole.RejectRole)
-        box.setDefaultButton(continue_button)
-        box.exec()
+            box = QMessageBox(self)
+            box.setIcon(QMessageBox.Icon.Warning)
+            box.setWindowTitle(str(title))
+            box.setText(str(exc) if exc is not None else str(title))
+            continue_button = box.addButton(
+                str(continue_label), QMessageBox.ButtonRole.AcceptRole
+            )
+            box.addButton(str(abort_label), QMessageBox.ButtonRole.RejectRole)
+            box.setDefaultButton(continue_button)
+            box.exec()
 
-        aborted = box.clickedButton() is not continue_button
-        abort_flag = getattr(request, "abort", None)
-        if aborted and isinstance(abort_flag, list) and abort_flag:
-            abort_flag[0] = True
-        self.append_log(f"operator: {'abort' if aborted else 'continue'}")
+            aborted = box.clickedButton() is not continue_button
+            abort_flag = getattr(request, "abort", None)
+            if aborted and isinstance(abort_flag, list) and abort_flag:
+                abort_flag[0] = True
+            self.append_log(f"operator: {'abort' if aborted else 'continue'}")
+        except Exception:  # noqa: BLE001 — must never leave the engine parked
+            logger.exception("operator dialog render failed; aborting to be safe")
+            abort_flag = getattr(request, "abort", None)
+            if isinstance(abort_flag, list) and abort_flag:
+                abort_flag[0] = True  # a warning we cannot show → do not proceed
+        finally:
+            self._unblock_engine(request)
 
+    @staticmethod
+    def _unblock_engine(request: object) -> None:
+        """Set the request's response event so the parked engine thread runs.
+
+        Called from a ``finally`` in both dialog handlers: an exception in
+        the render path must never leave the engine's scan thread blocked
+        on ``response_event`` forever (the engine has no dialog-cancel
+        signal; #552 PR-3/PR-4 contract).
+        """
         response_event = getattr(request, "response_event", None)
         if response_event is not None and hasattr(response_event, "set"):
             response_event.set()
@@ -2171,46 +2188,49 @@ class MainWindow(QMainWindow):
             ``message``, ``step_count``, a mutable one-element ``verdict``
             list, and a ``response_event``.
         """
-        name = str(getattr(request, "action_name", "action"))
-        message = str(getattr(request, "message", "")) or f"Action '{name}'"
-        steps = int(getattr(request, "step_count", 0) or 0)
-
-        box = QMessageBox(self)
-        box.setIcon(QMessageBox.Icon.Question)
-        box.setWindowTitle(f"Scan paused — action '{name}'")
-        box.setText(message)
-        execute_button = box.addButton(
-            f"Execute ({steps} step{'s' if steps != 1 else ''})",
-            QMessageBox.ButtonRole.AcceptRole,
-        )
-        ignore_button = box.addButton(
-            "Ignore & resume", QMessageBox.ButtonRole.RejectRole
-        )
-        box.addButton("Abort scan", QMessageBox.ButtonRole.DestructiveRole)
-        box.setDefaultButton(ignore_button)
-
-        self._decision_box = box
         try:
-            box.exec()
+            name = str(getattr(request, "action_name", "action"))
+            message = str(getattr(request, "message", "")) or f"Action '{name}'"
+            steps = int(getattr(request, "step_count", 0) or 0)
+
+            box = QMessageBox(self)
+            box.setIcon(QMessageBox.Icon.Question)
+            box.setWindowTitle(f"Scan paused — action '{name}'")
+            box.setText(message)
+            execute_button = box.addButton(
+                f"Execute ({steps} step{'s' if steps != 1 else ''})",
+                QMessageBox.ButtonRole.AcceptRole,
+            )
+            ignore_button = box.addButton(
+                "Ignore & resume", QMessageBox.ButtonRole.RejectRole
+            )
+            box.addButton("Abort scan", QMessageBox.ButtonRole.DestructiveRole)
+            box.setDefaultButton(ignore_button)
+
+            self._decision_box = box
+            try:
+                box.exec()
+            finally:
+                self._decision_box = None
+
+            clicked = box.clickedButton()
+            if clicked is execute_button:
+                verdict = "execute"
+            elif clicked is ignore_button:
+                verdict = "ignore"
+            else:
+                # Abort, or a programmatic dismiss (terminal-state reject()):
+                # a dismiss already means the scan is ending, so "abort" is
+                # the safe read either way.
+                verdict = "abort"
+
+            verdict_list = getattr(request, "verdict", None)
+            if isinstance(verdict_list, list) and verdict_list:
+                verdict_list[0] = verdict
+            self.append_log(f"action decision: {verdict}")
+        except Exception:  # noqa: BLE001 — must never leave the engine parked
+            # The request's verdict default is "ignore" (resume, run
+            # nothing) — the safe outcome when the pop-up could not render.
+            logger.exception("action-decision dialog render failed; resuming")
         finally:
-            self._decision_box = None
-
-        clicked = box.clickedButton()
-        if clicked is execute_button:
-            verdict = "execute"
-        elif clicked is ignore_button:
-            verdict = "ignore"
-        else:
-            # Abort, or a programmatic dismiss (terminal-state reject()):
-            # a dismiss already means the scan is ending, so "abort" is the
-            # safe read either way.
-            verdict = "abort"
-
-        verdict_list = getattr(request, "verdict", None)
-        if isinstance(verdict_list, list) and verdict_list:
-            verdict_list[0] = verdict
-        self.append_log(f"action decision: {verdict}")
-
-        response_event = getattr(request, "response_event", None)
-        if response_event is not None and hasattr(response_event, "set"):
-            response_event.set()
+            self._unblock_engine(request)

--- a/GEECS-Console/geecs_console/app/main_window.py
+++ b/GEECS-Console/geecs_console/app/main_window.py
@@ -119,6 +119,8 @@ _STATE_DOT_COLORS = {
     "completed": _COLOR_GREEN,
     "initializing": _COLOR_AMBER,
     "stopping": _COLOR_AMBER,
+    "pausing": _COLOR_AMBER,
+    "paused": _COLOR_AMBER,
     "aborted": _COLOR_RED,
     "error": _COLOR_RED,
     "failed": _COLOR_RED,
@@ -275,6 +277,9 @@ class MainWindow(QMainWindow):
         #: Non-modal ActionRunDialogs opened from the Actions menu — same
         #: PySide6 GC hazard, same keep-a-reference cure.
         self._open_action_dialogs: list = []
+        #: The open three-way action-decision modal (G-actions v2), or None
+        #: — kept so a terminal lifecycle state can dismiss a dangling one.
+        self._decision_box: Optional[object] = None
 
         self._apply_stylesheet()
         self._load_ui()
@@ -1359,6 +1364,8 @@ class MainWindow(QMainWindow):
             run=submitter.run_action,
             execution_enabled=self.enable_actions_action.isChecked(),
             report=self._report,
+            request_during_scan=submitter.request_action_during_scan,
+            is_scanning=submitter.is_scanning_active,
         )
         self._open_action_dialogs = [
             d for d in self._open_action_dialogs if d.isVisible()
@@ -2044,11 +2051,29 @@ class MainWindow(QMainWindow):
         Stop request: the button label restores and normal gating resumes
         (:meth:`_on_stop_clicked` set the hold).
         """
-        if self._stop_in_flight and (state or "").lower() in _TERMINAL_SCAN_STATES:
+        lowered = (state or "").lower()
+        if self._stop_in_flight and lowered in _TERMINAL_SCAN_STATES:
             self._stop_in_flight = False
             self.stop_button.setText(self._stop_button_label)
         self._set_state_pill(state)
         self._refresh_submit_enabled()
+
+        # Push the live scan state into open action dialogs so their Run
+        # button flips between "Run" and "Pause scan & run" (G-actions v2).
+        scanning = lowered not in _TERMINAL_SCAN_STATES and lowered != "idle"
+        self._open_action_dialogs = [
+            d for d in self._open_action_dialogs if d.isVisible()
+        ]
+        for dialog in self._open_action_dialogs:
+            dialog.set_scanning(scanning)
+
+        # A terminal state dismisses a dangling action-decision modal: an
+        # operator Stop during the pause window aborts the scan without the
+        # engine answering the three-way dialog, so the console must tear it
+        # down itself (the #552 PR-3 review contract — the engine has no
+        # dialog-cancel signal).
+        if lowered in _TERMINAL_SCAN_STATES and self._decision_box is not None:
+            self._decision_box.reject()
 
     def _on_totals_known(self, total_shots: int) -> None:
         """Size the progress bar once the scan announces its totals."""
@@ -2096,7 +2121,12 @@ class MainWindow(QMainWindow):
             A ``DialogRequest`` (duck-typed): ``exc``, optional ``title`` /
             ``continue_label`` / ``abort_label``, a mutable one-element
             ``abort`` list, and a ``response_event`` (:class:`threading.Event`).
+            An ``ActionDecisionRequest`` (carrying a ``verdict`` list) is
+            rendered as the three-way action pop-up instead (G-actions v2).
         """
+        if getattr(request, "verdict", None) is not None:
+            self._on_action_decision(request)
+            return
         exc = getattr(request, "exc", None)
         title = getattr(request, "title", None) or "Operator confirmation"
         continue_label = getattr(request, "continue_label", None) or "Continue"
@@ -2118,6 +2148,68 @@ class MainWindow(QMainWindow):
         if aborted and isinstance(abort_flag, list) and abort_flag:
             abort_flag[0] = True
         self.append_log(f"operator: {'abort' if aborted else 'continue'}")
+
+        response_event = getattr(request, "response_event", None)
+        if response_event is not None and hasattr(response_event, "set"):
+            response_event.set()
+
+    def _on_action_decision(self, request: object) -> None:
+        """Render the three-way action-decision pop-up (G-actions v2).
+
+        The scan is paused (machine in its safe state) and the engine's
+        scan thread is parked on ``request.response_event``.  This modal
+        offers Execute / Ignore / Abort; the choice goes into
+        ``request.verdict[0]`` before the event is set.  The box is tracked
+        on ``self._decision_box`` so a terminal lifecycle state (an operator
+        Stop that aborted the scan out of band) can dismiss it — the engine
+        provides no dialog-cancel signal (#552 PR-3 contract).
+
+        Parameters
+        ----------
+        request : object
+            An ``ActionDecisionRequest`` (duck-typed): ``action_name``,
+            ``message``, ``step_count``, a mutable one-element ``verdict``
+            list, and a ``response_event``.
+        """
+        name = str(getattr(request, "action_name", "action"))
+        message = str(getattr(request, "message", "")) or f"Action '{name}'"
+        steps = int(getattr(request, "step_count", 0) or 0)
+
+        box = QMessageBox(self)
+        box.setIcon(QMessageBox.Icon.Question)
+        box.setWindowTitle(f"Scan paused — action '{name}'")
+        box.setText(message)
+        execute_button = box.addButton(
+            f"Execute ({steps} step{'s' if steps != 1 else ''})",
+            QMessageBox.ButtonRole.AcceptRole,
+        )
+        ignore_button = box.addButton(
+            "Ignore & resume", QMessageBox.ButtonRole.RejectRole
+        )
+        box.addButton("Abort scan", QMessageBox.ButtonRole.DestructiveRole)
+        box.setDefaultButton(ignore_button)
+
+        self._decision_box = box
+        try:
+            box.exec()
+        finally:
+            self._decision_box = None
+
+        clicked = box.clickedButton()
+        if clicked is execute_button:
+            verdict = "execute"
+        elif clicked is ignore_button:
+            verdict = "ignore"
+        else:
+            # Abort, or a programmatic dismiss (terminal-state reject()):
+            # a dismiss already means the scan is ending, so "abort" is the
+            # safe read either way.
+            verdict = "abort"
+
+        verdict_list = getattr(request, "verdict", None)
+        if isinstance(verdict_list, list) and verdict_list:
+            verdict_list[0] = verdict
+        self.append_log(f"action decision: {verdict}")
 
         response_event = getattr(request, "response_event", None)
         if response_event is not None and hasattr(response_event, "set"):

--- a/GEECS-Console/geecs_console/events_adapter.py
+++ b/GEECS-Console/geecs_console/events_adapter.py
@@ -91,9 +91,17 @@ class ScanEventsAdapter(QObject):
             # The engine's scan thread is blocked on request.response_event;
             # emit the request so the main-thread slot renders a modal and
             # answers it (queued delivery keeps the modal off this thread).
+            # Two request shapes: the binary DialogRequest (an ``exc``) and
+            # the three-way ActionDecisionRequest (a ``verdict`` list).
             request = getattr(event, "request", None)
-            exc = getattr(request, "exc", None)
-            self.log_line.emit(f"operator question: {exc}")
+            if getattr(request, "verdict", None) is not None:
+                self.log_line.emit(
+                    f"action decision: {getattr(request, 'action_name', '')}"
+                )
+            else:
+                self.log_line.emit(
+                    f"operator question: {getattr(request, 'exc', None)}"
+                )
             if request is not None:
                 self.dialog_requested.emit(request)
         else:

--- a/GEECS-Console/geecs_console/submission.py
+++ b/GEECS-Console/geecs_console/submission.py
@@ -60,6 +60,19 @@ class Submitter(Protocol):
         """
         ...
 
+    def request_action_during_scan(self, name: str) -> None:
+        """Request action plan *name* to run in the scan's pause window.
+
+        The during-scan counterpart of :meth:`run_action` (G-actions v2):
+        validates fail-fast, refuses an action that writes the scan's
+        shot-control device(s), then asks the engine to pause at its next
+        checkpoint and stage the action.  Returns promptly — the operator's
+        execute/ignore/abort decision arrives as a separate dialog event.
+        Raises with an operator-readable message on refusal (no active
+        scan, unreachable target, or a shot-control-device write).
+        """
+        ...
+
 
 def make_bluesky_submitter(
     experiment: str,

--- a/GEECS-Console/pyproject.toml
+++ b/GEECS-Console/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-console"
-version = "0.15.1"
+version = "0.16.0"
 description = "Greenfield PySide6 operator console for GEECS (Bluesky/gateway architecture)"
 authors = ["Sam Barber <sbarber@lbl.gov>"]
 readme = "README.md"

--- a/GEECS-Console/tests/test_actions_menu.py
+++ b/GEECS-Console/tests/test_actions_menu.py
@@ -452,3 +452,43 @@ class TestActionDecisionModal:
         window._on_action_decision(req)
         assert req.verdict[0] == "abort"
         assert req.response_event.is_set()
+
+
+class TestDialogUnblockOnFailure:
+    """A render failure must never leave the engine's scan thread parked."""
+
+    def test_action_decision_render_failure_still_unblocks_engine(
+        self, window, monkeypatch
+    ):
+        from PySide6.QtWidgets import QMessageBox
+
+        def boom(self):
+            raise RuntimeError("Qt exploded mid-render")
+
+        monkeypatch.setattr(QMessageBox, "exec", boom)
+        req = _decision_request()
+        window._on_action_decision(req)  # must not raise out
+        assert req.response_event.is_set()  # engine unblocked
+        assert req.verdict[0] == "ignore"  # safe default (resume, run nothing)
+
+    def test_operator_dialog_render_failure_aborts_and_unblocks(
+        self, window, monkeypatch
+    ):
+        from PySide6.QtWidgets import QMessageBox
+
+        def boom(self):
+            raise RuntimeError("Qt exploded mid-render")
+
+        monkeypatch.setattr(QMessageBox, "exec", boom)
+
+        class _Req:
+            exc = RuntimeError("some pre-flight warning")
+
+            def __init__(self):
+                self.abort = [False]
+                self.response_event = threading.Event()
+
+        req = _Req()
+        window._on_operator_dialog(req)
+        assert req.response_event.is_set()
+        assert req.abort[0] is True  # unshowable warning → do not proceed

--- a/GEECS-Console/tests/test_actions_menu.py
+++ b/GEECS-Console/tests/test_actions_menu.py
@@ -86,6 +86,8 @@ class FakeActionSubmitter:
         )
         self.run_error = run_error
         self.run_calls = []
+        self.request_calls = []
+        self.request_error = None
         self.describe_calls = []
         self.describe_started = threading.Event()
         self.describe_release = threading.Event()
@@ -116,6 +118,16 @@ class FakeActionSubmitter:
         self.run_release.wait(timeout=5)
         if self.run_error is not None:
             raise self.run_error
+
+    def request_action_during_scan(self, name):
+        self.request_calls.append(name)
+        if self.request_error is not None:
+            raise self.request_error
+
+
+def wait_previewed(dialog, qtbot):
+    """Arm the run gate: wait for the dry-run preview to load."""
+    qtbot.waitUntil(lambda: dialog._preview_loaded, timeout=3000)
 
 
 def actions_menu(window):
@@ -217,6 +229,7 @@ class TestExecuteGating:
 
     def test_run_disabled_until_armed_then_pushed_into_open_dialog(self, window, qtbot):
         dialog = open_dialog(window, qtbot)
+        wait_previewed(dialog, qtbot)
         assert not dialog.run_button.isEnabled()
         window.enable_actions_action.setChecked(True)
         assert dialog.run_button.isEnabled()
@@ -252,6 +265,7 @@ class TestActionDialog:
     def test_run_calls_run_action_with_the_plan_name(self, window, qtbot):
         submitter = window._submitter
         dialog = open_dialog(window, qtbot, name="vent_line")
+        wait_previewed(dialog, qtbot)
         window.enable_actions_action.setChecked(True)
         dialog.run_button.click()
         qtbot.waitUntil(lambda: submitter.run_calls == ["vent_line"], timeout=3000)
@@ -266,6 +280,7 @@ class TestActionDialog:
         submitter = FakeActionSubmitter(run_error=RuntimeError(SCAN_IN_PROGRESS))
         window._submitter = submitter
         dialog = open_dialog(window, qtbot)
+        wait_previewed(dialog, qtbot)
         window.enable_actions_action.setChecked(True)
         dialog.run_button.click()
         qtbot.waitUntil(
@@ -280,6 +295,7 @@ class TestActionDialog:
         submitter = window._submitter
         submitter.run_release.clear()  # hold the engine call open
         dialog = open_dialog(window, qtbot)
+        wait_previewed(dialog, qtbot)
         window.enable_actions_action.setChecked(True)
         dialog.run_button.click()
         qtbot.waitUntil(lambda: submitter.run_calls == ["insert_cal"], timeout=3000)
@@ -292,22 +308,19 @@ class TestActionDialog:
             timeout=3000,
         )
 
-    def test_late_preview_never_clobbers_the_run_outcome(self, window, qtbot):
-        """Preview and run land on separate lines — a slow describe arriving
-        after a run must not overwrite the run's message (a refusal that
-        vanished this way would be a silent refusal)."""
+    def test_run_stays_disabled_until_the_preview_loads(self, window, qtbot):
+        """#575 hardening: Run cannot fire beside an empty table — even armed,
+        it waits for the dry-run preview.  This also eliminates by
+        construction the old late-preview-clobbers-run race: a run can no
+        longer start before the preview has landed."""
         submitter = window._submitter
-        submitter.describe_release.clear()  # preview stays in flight
+        submitter.describe_release.clear()  # hold the preview in flight
         dialog = open_dialog(window, qtbot)
         window.enable_actions_action.setChecked(True)
-        dialog.run_button.click()
-        qtbot.waitUntil(
-            lambda: "action 'insert_cal' done" in dialog.message_label.text(),
-            timeout=3000,
-        )
-        submitter.describe_release.set()  # now the preview lands, late
-        qtbot.waitUntil(lambda: "2 steps" in dialog.preview_label.text(), timeout=3000)
-        assert "action 'insert_cal' done" in dialog.message_label.text()
+        assert not dialog.run_button.isEnabled()  # armed, but no preview yet
+        submitter.describe_release.set()  # preview lands
+        qtbot.waitUntil(lambda: dialog.run_button.isEnabled(), timeout=3000)
+        assert "2 steps" in dialog.run_button.text()  # step count on the label
 
     def test_close_during_slow_describe_returns_fast(self, window, qtbot):
         submitter = window._submitter
@@ -324,3 +337,118 @@ class TestActionDialog:
         assert dialog in window._open_action_dialogs
         assert dialog.isVisible()
         assert dialog.windowTitle() == "Action: insert_cal"
+
+
+class TestDuringScanActions:
+    """G-actions v2 console half: the pause-scan path + three-way modal."""
+
+    def test_run_button_flips_to_pause_when_scanning(self, window, qtbot):
+        dialog = open_dialog(window, qtbot)
+        wait_previewed(dialog, qtbot)
+        window.enable_actions_action.setChecked(True)
+        assert dialog.run_button.text().startswith("Run")
+        window._submitter.active = True
+        window._on_scan_state("running")  # window pushes state into dialogs
+        assert dialog.run_button.text().startswith("Pause scan & run")
+
+    def test_run_during_scan_uses_request_action_during_scan(self, window, qtbot):
+        submitter = window._submitter
+        submitter.active = True
+        dialog = open_dialog(window, qtbot)
+        wait_previewed(dialog, qtbot)
+        window._on_scan_state("running")
+        window.enable_actions_action.setChecked(True)
+        dialog.run_button.click()
+        qtbot.waitUntil(lambda: submitter.request_calls == ["insert_cal"], timeout=3000)
+        assert submitter.run_calls == []  # NOT the idle path
+        qtbot.waitUntil(
+            lambda: "decide in the pop-up" in dialog.message_label.text(), timeout=3000
+        )
+
+    def test_shot_control_refusal_during_scan_is_surfaced(self, window, qtbot):
+        submitter = window._submitter
+        submitter.active = True
+        submitter.request_error = RuntimeError("action writes the scan's shot-control")
+        dialog = open_dialog(window, qtbot)
+        wait_previewed(dialog, qtbot)
+        window._on_scan_state("running")
+        window.enable_actions_action.setChecked(True)
+        dialog.run_button.click()
+        qtbot.waitUntil(
+            lambda: "shot-control" in dialog.message_label.text(), timeout=3000
+        )
+
+
+def _decision_request():
+    class _Req:
+        action_name = "jet_on"
+        message = "Scan paused — run jet_on?"
+        step_count = 3
+
+        def __init__(self):
+            self.verdict = ["ignore"]
+            self.response_event = threading.Event()
+
+    return _Req()
+
+
+def _click_role(monkeypatch, role):
+    """Make QMessageBox.exec click the button with *role* (offscreen)."""
+    from PySide6.QtWidgets import QMessageBox
+
+    holder = {}
+
+    def fake_exec(box):
+        for b in box.buttons():
+            if role is not None and box.buttonRole(b) == role:
+                holder["clicked"] = b
+        box.done(0)
+
+    monkeypatch.setattr(QMessageBox, "exec", fake_exec)
+    monkeypatch.setattr(
+        QMessageBox, "clickedButton", lambda self: holder.get("clicked")
+    )
+
+
+class TestActionDecisionModal:
+    def test_execute_verdict(self, window, monkeypatch):
+        from PySide6.QtWidgets import QMessageBox
+
+        _click_role(monkeypatch, QMessageBox.ButtonRole.AcceptRole)
+        req = _decision_request()
+        window._on_action_decision(req)
+        assert req.verdict[0] == "execute"
+        assert req.response_event.is_set()
+
+    def test_ignore_verdict(self, window, monkeypatch):
+        from PySide6.QtWidgets import QMessageBox
+
+        _click_role(monkeypatch, QMessageBox.ButtonRole.RejectRole)
+        req = _decision_request()
+        window._on_action_decision(req)
+        assert req.verdict[0] == "ignore"
+        assert req.response_event.is_set()
+
+    def test_abort_verdict(self, window, monkeypatch):
+        from PySide6.QtWidgets import QMessageBox
+
+        _click_role(monkeypatch, QMessageBox.ButtonRole.DestructiveRole)
+        req = _decision_request()
+        window._on_action_decision(req)
+        assert req.verdict[0] == "abort"
+        assert req.response_event.is_set()
+
+    def test_terminal_state_dismisses_dangling_modal(self, window, monkeypatch):
+        """A Stop that aborts the scan out of band tears the modal down; the
+        programmatic dismiss reads as 'abort' (#552 PR-3 contract)."""
+        from PySide6.QtWidgets import QMessageBox
+
+        def fake_exec(box):
+            window._on_scan_state("aborted")  # terminal → reject the stored box
+
+        monkeypatch.setattr(QMessageBox, "exec", fake_exec)
+        monkeypatch.setattr(QMessageBox, "clickedButton", lambda self: None)
+        req = _decision_request()
+        window._on_action_decision(req)
+        assert req.verdict[0] == "abort"
+        assert req.response_event.is_set()

--- a/GeecsBluesky/CHANGELOG.md
+++ b/GeecsBluesky/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to `geecs-bluesky` are documented here.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.44.1] - 2026-07-16
+
+### Fixed
+
+- **Console-less bridge no longer parks a pause window forever** (#552):
+  `_make_pause_supervisor` passes `ask=None` when the bridge has no
+  `on_event` consumer, so the supervisor defaults to `ignore` instead of
+  waiting on a decision that can never be delivered.  Pinned by
+  `tests/test_action_during_scan.py`.
+
 ## [0.44.0] - 2026-07-16
 
 ### Added

--- a/GeecsBluesky/geecs_bluesky/scanner_bridge/bluesky_scanner.py
+++ b/GeecsBluesky/geecs_bluesky/scanner_bridge/bluesky_scanner.py
@@ -623,7 +623,12 @@ class BlueskyScanner:
         return PauseSupervisor(
             acquisition=acquisition,
             shot_controller=lambda: getattr(self._session, "_shot_controller", None),
-            ask=self._ask_action_decision,
+            # With no event consumer, _ask_action_decision emits nowhere —
+            # so hand the supervisor a None ask, which makes it default to
+            # 'ignore' rather than park forever waiting for an answer that
+            # can never arrive (a console-less bridge that still somehow
+            # reaches a pause window).
+            ask=self._ask_action_decision if self._on_event is not None else None,
             should_abort=lambda: self._abort_requested,
             on_state=lambda s: self._set_state(s.upper()),
         )

--- a/GeecsBluesky/pyproject.toml
+++ b/GeecsBluesky/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-bluesky"
-version = "0.44.0"
+version = "0.44.1"
 description = "Bluesky / ophyd-async bridge for the GEECS control system"
 authors = ["Sam Barber <sbarber@lbl.gov>"]
 readme = "README.md"

--- a/GeecsBluesky/tests/test_action_during_scan.py
+++ b/GeecsBluesky/tests/test_action_during_scan.py
@@ -204,3 +204,13 @@ def test_stop_during_pause_does_not_abort_the_re_itself() -> None:
     scanner.stop_scanning_thread()
     assert scanner._abort_requested is True  # flag set (wakes the park loop)
     assert aborts == []  # but the RE was NOT aborted from here (supervisor owns it)
+
+
+def test_console_less_bridge_gives_supervisor_no_ask() -> None:
+    """A bridge with no on_event consumer hands the supervisor ask=None, so
+    a pause window defaults to 'ignore' rather than parking forever."""
+    resolver = _FakeResolver({"jet_on": _JET_ON})
+    scanner = _make_running_scanner(_FakeSession(resolver), _request(), resolver)
+    scanner._on_event = None  # no consumer
+    sup = scanner._make_pause_supervisor()
+    assert sup._ask is None


### PR DESCRIPTION
PR-4 (final) of the G-actions v2 sequence (issue #552; engine half #578/#579/#580 merged). This makes the pause/decide/resume flow reachable from the UI and closes #575's misfire complaint.

## What + why

**During-scan action flow (console half):** the Actions Run/Preview dialog now drives the pause path. While a scan is active the Run button reads **"Pause scan & run (N steps)"** and calls the new `Submitter.request_action_during_scan` member (pause → decide → run) instead of idle `run_action`; the window pushes live scan state into open dialogs (`set_scanning`) so the label flips automatically. The three-way **action-decision modal** (Execute / Ignore / Abort) is rendered by `_on_action_decision` from the engine's `ActionDecisionRequest`, routed through the *existing* `ScanDialogEvent`/`dialog_requested` transport — `_on_operator_dialog` duck-types on the `verdict` attribute, so the binary pre-flight dialog is untouched. New `PAUSING`/`PAUSED` states render amber on the R6 pill.

**The #552 PR-3 contract, honoured:** the modal is **dismissed on a terminal ABORTED state** (`self._decision_box.reject()` in `_on_scan_state`). A Stop during the pause window aborts the scan without the engine answering, and the engine has no dialog-cancel signal — so the console tears the dangling modal down itself; the programmatic dismiss reads as `abort`.

**#575 misfire hardening (Option A from the design note):** action name in larger type on its own line; **Run disabled until the dry-run preview loads** (no firing beside an empty table — this also *eliminates by construction* the old late-preview-clobbers-run race, so that test became a positive pin for the gate); step count on the Run button.

## Per-concern LOC breakdown

- `submission.py` (Submitter member): +14
- `action_dialog.py` (during-scan path + preview gate + step-count label + name hardening): +85 / −20
- `main_window.py` (dialog wiring, scan-state push to dialogs, three-way modal, terminal dismiss, pill colors): +90
- `events_adapter.py` (log-line duck-type for the two request shapes): +8 / −3
- Tests (`test_actions_menu.py`: existing 16 updated for the preview gate + 7 new — during-scan path, refusal surfaced, the three verdicts, terminal dismiss): +130
- CLAUDE.md + CHANGELOG + version: +55

**Judgment-call cross-package addition (cheap to veto):** a one-line GeecsBluesky fix (`0.44.1`) — `_make_pause_supervisor` passes `ask=None` when the bridge has no `on_event` consumer, so a console-less bridge that somehow reached a pause window defaults to `ignore` instead of parking forever (the supervisor's safe posture). Reachable only by misuse (`request_action_during_scan` is console-only), but it closes a real park-forever hole in the just-merged engine. Pinned by a bridge test. Split it out if you'd rather keep this PR console-only.

## Tests

- `./scripts/check.sh`: **GEECS-Console 753 passed** (23 in the actions suite: 16 existing + 7 new), **GeecsBluesky 571 passed** (+1 park-gap pin). The 2 `*_without_the_extra` optimization failures are the known local-venv-has-the-extra issue (pass in CI).

## Hardware verification

**OWED** — the whole feature is now code-complete, so the checklist of record (issue #552 comment) is runnable: free-run pause = jet off, strict quiescent, pause latency, full pause→execute→resume integrity, abort-from-dialog, Stop-during-pause single-abort, decision-11 refusal live. One Undulator session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)