### PR TITLE
GeecsBluesky 0.45.0 + GEECS-Console 0.17.0: standalone operator Pause/Resume button

### DIFF
--- a/GEECS-Console/CHANGELOG.md
+++ b/GEECS-Console/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to GEECS-Console are documented here.  Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versioning is
 semantic.
 
+## [0.17.0] - 2026-07-16
+
+### Added
+
+- **Pause / Resume button on the submit row (R5)** — the standalone
+  operator pause (GeecsBluesky 0.45.0).  While a scan is RUNNING the
+  button reads "Pause" and calls the engine's `request_pause` (pause at
+  the next safe point; the machine goes quiescent — jet off in free-run);
+  while PAUSED it becomes "▶ Resume" and calls `request_resume`; Stop still
+  aborts out of the pause.  Non-modal by design — the device panels and
+  everything else stay usable while the scan holds.  Disabled during the
+  transitional PAUSING/STOPPING states and when idle/terminal.  New
+  `Submitter` members `request_pause` / `request_resume`; the `r5_pause_button`
+  widget added to `main_window.ui`.  Pinned by `tests/test_main_window.py`.
+
 ## [0.16.0] - 2026-07-16
 
 ### Added

--- a/GEECS-Console/geecs_console/app/main_window.py
+++ b/GEECS-Console/geecs_console/app/main_window.py
@@ -417,6 +417,7 @@ class MainWindow(QMainWindow):
         # R5 submit row
         self.stop_button: QPushButton = self._child(QPushButton, "r5_stop_button")
         self.start_button: QPushButton = self._child(QPushButton, "r5_start_button")
+        self.pause_button: QPushButton = self._child(QPushButton, "r5_pause_button")
         # R6 now panel
         self.state_pill: QLabel = self._child(QLabel, "r6_state_pill")
         self.progress_bar: QProgressBar = self._child(QProgressBar, "r6_progress")
@@ -556,6 +557,7 @@ class MainWindow(QMainWindow):
         )
         self.start_button.clicked.connect(self._on_start_clicked)
         self.stop_button.clicked.connect(self._on_stop_clicked)
+        self.pause_button.clicked.connect(self._on_pause_clicked)
         self.apply_button.clicked.connect(self._on_preset_apply)
         self.save_as_button.clicked.connect(self._on_preset_save_as)
         self.delete_button.clicked.connect(self._on_preset_delete)
@@ -605,6 +607,11 @@ class MainWindow(QMainWindow):
         self._stop_worker = BackgroundResult()
         self._stop_in_flight = False
         self._stop_button_label = self.stop_button.text()
+        #: Last lifecycle state word (lowercase) — drives the Pause/Resume
+        #: button (G-actions v2 operator pause).
+        self._scan_state_text = "idle"
+        self._pause_button_label = self.pause_button.text()
+        self._refresh_pause_button()
 
         self.events.state_changed.connect(self._on_scan_state)
         self.events.totals_known.connect(self._on_totals_known)
@@ -1479,6 +1486,31 @@ class MainWindow(QMainWindow):
         # While a stop is in flight the button stays disabled ("Stopping…")
         # until the terminal lifecycle event lands (_on_scan_state).
         self.stop_button.setEnabled(scanning and not self._stop_in_flight)
+        self._refresh_pause_button()
+
+    def _refresh_pause_button(self) -> None:
+        """Set the Pause/Resume button from the current lifecycle state.
+
+        Pause while RUNNING, Resume while PAUSED; disabled otherwise
+        (transitional PAUSING/STOPPING, idle, or terminal).  The engine's
+        operator-pause holds the scan non-modally, so the GUI stays usable
+        while paused.
+        """
+        state = self._scan_state_text
+        if state == "paused":
+            self.pause_button.setText("▶ Resume")
+            self.pause_button.setEnabled(not self._stop_in_flight)
+            self.pause_button.setToolTip("Resume the paused scan.")
+        elif state == "running":
+            self.pause_button.setText(self._pause_button_label)
+            self.pause_button.setEnabled(not self._stop_in_flight)
+            self.pause_button.setToolTip(
+                "Pause the scan at its next safe point (the machine goes to "
+                "its quiescent state; Resume or Stop from here)."
+            )
+        else:
+            self.pause_button.setText(self._pause_button_label)
+            self.pause_button.setEnabled(False)
 
     def _ensure_submitter(self) -> Optional[Submitter]:
         """Return the injected submitter, or lazily build the real engine."""
@@ -1544,6 +1576,27 @@ class MainWindow(QMainWindow):
         self._stop_worker.run_async(submitter.stop_scanning_thread, "scan-stop")
         self.append_log("stop requested")
         self._refresh_submit_enabled()
+
+    def _on_pause_clicked(self) -> None:
+        """Pause the running scan, or resume it if already paused.
+
+        Both engine calls return promptly (``request_pause`` asks the
+        RunEngine to pause at its next checkpoint; ``request_resume`` signals
+        the parked pause supervisor), so they run on the GUI thread — no
+        worker.  The actual pause/resume happens on the engine's scan
+        thread and is announced back through the lifecycle stream (the
+        PAUSED/RUNNING states flip this button via
+        :meth:`_refresh_pause_button`).
+        """
+        submitter = self._submitter
+        if submitter is None or not submitter.is_scanning_active():
+            return
+        if self._scan_state_text == "paused":
+            submitter.request_resume()
+            self.append_log("resume requested")
+        else:
+            submitter.request_pause()
+            self.append_log("pause requested")
 
     # ------------------------------------------------------------------
     # R4 presets (a preset IS a saved ScanRequest)
@@ -2052,6 +2105,7 @@ class MainWindow(QMainWindow):
         (:meth:`_on_stop_clicked` set the hold).
         """
         lowered = (state or "").lower()
+        self._scan_state_text = lowered or "idle"
         if self._stop_in_flight and lowered in _TERMINAL_SCAN_STATES:
             self._stop_in_flight = False
             self.stop_button.setText(self._stop_button_label)

--- a/GEECS-Console/geecs_console/app/ui/main_window.ui
+++ b/GEECS-Console/geecs_console/app/ui/main_window.ui
@@ -744,6 +744,16 @@
            </spacer>
           </item>
           <item>
+           <widget class="QPushButton" name="r5_pause_button">
+            <property name="text">
+             <string>❚❚ Pause</string>
+            </property>
+            <property name="enabled">
+             <bool>false</bool>
+            </property>
+           </widget>
+          </item>
+          <item>
            <widget class="QPushButton" name="r5_stop_button">
             <property name="text">
              <string>■ Stop</string>

--- a/GEECS-Console/geecs_console/submission.py
+++ b/GEECS-Console/geecs_console/submission.py
@@ -60,6 +60,19 @@ class Submitter(Protocol):
         """
         ...
 
+    def request_pause(self) -> None:
+        """Pause the running scan at its next safe point (operator Pause).
+
+        No action involved: the machine goes to its quiescent state and the
+        scan holds (non-modally) until :meth:`request_resume` or a stop.
+        Returns promptly; the PAUSED lifecycle state is announced back.
+        """
+        ...
+
+    def request_resume(self) -> None:
+        """Resume a scan paused by :meth:`request_pause` (operator Resume)."""
+        ...
+
     def request_action_during_scan(self, name: str) -> None:
         """Request action plan *name* to run in the scan's pause window.
 

--- a/GEECS-Console/pyproject.toml
+++ b/GEECS-Console/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-console"
-version = "0.16.0"
+version = "0.17.0"
 description = "Greenfield PySide6 operator console for GEECS (Bluesky/gateway architecture)"
 authors = ["Sam Barber <sbarber@lbl.gov>"]
 readme = "README.md"

--- a/GEECS-Console/tests/test_main_window.py
+++ b/GEECS-Console/tests/test_main_window.py
@@ -77,6 +77,8 @@ class FakeSubmitter:
         self.requests = []
         self.started = 0
         self.stopped = 0
+        self.pauses = 0
+        self.resumes = 0
 
     def reinitialize(self, request):
         self.requests.append(request)
@@ -92,6 +94,12 @@ class FakeSubmitter:
 
     def is_scanning_active(self):
         return self.active
+
+    def request_pause(self):
+        self.pauses += 1
+
+    def request_resume(self):
+        self.resumes += 1
 
 
 class FakeHealth:
@@ -738,6 +746,59 @@ class TestSubmission:
         window._on_stop_clicked()
         assert window._submitter.stopped == 0
         assert not window._stop_in_flight
+
+    def test_pause_button_disabled_when_not_scanning(self, window):
+        assert not window.pause_button.isEnabled()
+
+    def test_pause_button_enabled_while_running_reads_pause(self, window):
+        from fake_events import ScanLifecycleEvent
+
+        select_save_set(window, "Amp4In")
+        window._on_start_clicked()
+        window.events.handle(ScanLifecycleEvent(state="running"))
+        assert window.pause_button.isEnabled()
+        assert "Pause" in window.pause_button.text()
+
+    def test_pause_click_requests_pause_then_button_becomes_resume(self, window):
+        from fake_events import ScanLifecycleEvent
+
+        select_save_set(window, "Amp4In")
+        window._on_start_clicked()
+        window.events.handle(ScanLifecycleEvent(state="running"))
+        window.pause_button.click()
+        assert window._submitter.pauses == 1
+        # The engine confirms with PAUSED; the button flips to Resume.
+        window.events.handle(ScanLifecycleEvent(state="paused"))
+        assert "Resume" in window.pause_button.text()
+        assert window.pause_button.isEnabled()
+
+    def test_resume_click_calls_request_resume(self, window):
+        from fake_events import ScanLifecycleEvent
+
+        select_save_set(window, "Amp4In")
+        window._on_start_clicked()
+        window.events.handle(ScanLifecycleEvent(state="paused"))
+        window.pause_button.click()
+        assert window._submitter.resumes == 1
+        assert window._submitter.pauses == 0  # resume, not a second pause
+
+    def test_pause_button_disabled_during_pausing_transition(self, window):
+        from fake_events import ScanLifecycleEvent
+
+        select_save_set(window, "Amp4In")
+        window._on_start_clicked()
+        window.events.handle(ScanLifecycleEvent(state="pausing"))
+        assert not window.pause_button.isEnabled()  # transitional
+
+    def test_terminal_state_disables_the_pause_button(self, window):
+        from fake_events import ScanLifecycleEvent
+
+        select_save_set(window, "Amp4In")
+        window._on_start_clicked()
+        window.events.handle(ScanLifecycleEvent(state="paused"))
+        window.events.handle(ScanLifecycleEvent(state="aborted"))
+        assert not window.pause_button.isEnabled()
+        assert "Pause" in window.pause_button.text()
 
     def test_form_round_trips_into_build_scan_request(self, window):
         select_save_set(window, "Amp4In")

--- a/GeecsBluesky/CHANGELOG.md
+++ b/GeecsBluesky/CHANGELOG.md
@@ -9,7 +9,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Added
 
 - **Operator pause (bare Pause button, #552 follow-up).**
-  `BlueskyScanner.request_pause()` / `resume_scan()` and
+  `BlueskyScanner.request_pause()` / `request_resume()` and
   `PauseSupervisor.arm_manual_pause()` / `request_resume()`: a manual
   pause with **no action** — the supervisor drives the mode-safe state
   (free-run → `OFF`, strict → nothing) and **parks non-modally** on a
@@ -114,7 +114,7 @@ without importing it — dormant because it lived under a broad `except`
 
 ### Removed
 
-- **`BlueskyScanner.pause_scan` / `request_resume`** — the old hard-pause
+- **`BlueskyScanner.pause_scan` / `resume_scan`** — the old hard-pause
   API (`request_pause(defer=False)`).  With no checkpoints it was a
   resume-replays-the-whole-scan trap; with them, a hard pause still
   replays the partial row (re-firing a physical shot in strict mode).

--- a/GeecsBluesky/CHANGELOG.md
+++ b/GeecsBluesky/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to `geecs-bluesky` are documented here.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.45.0] - 2026-07-16
+
+### Added
+
+- **Operator pause (bare Pause button, #552 follow-up).**
+  `BlueskyScanner.request_pause()` / `resume_scan()` and
+  `PauseSupervisor.arm_manual_pause()` / `request_resume()`: a manual
+  pause with **no action** — the supervisor drives the mode-safe state
+  (free-run → `OFF`, strict → nothing) and **parks non-modally** on a
+  resume/stop signal (the GUI stays usable while paused), then re-asserts
+  the pre-pause shot-control state and resumes.  Reuses the deferred-pause
+  checkpoints + supervisor machinery from the G-actions v2 sequence; the
+  bare-pause branch is why `on_pause` no longer immediately resumes when
+  nothing is staged.  Pinned by `tests/test_pause_supervisor.py` and
+  `tests/test_action_during_scan.py`.
+
 ## [0.44.1] - 2026-07-16
 
 ### Fixed
@@ -98,7 +114,7 @@ without importing it — dormant because it lived under a broad `except`
 
 ### Removed
 
-- **`BlueskyScanner.pause_scan` / `resume_scan`** — the old hard-pause
+- **`BlueskyScanner.pause_scan` / `request_resume`** — the old hard-pause
   API (`request_pause(defer=False)`).  With no checkpoints it was a
   resume-replays-the-whole-scan trap; with them, a hard pause still
   replays the partial row (re-firing a physical shot in strict mode).

--- a/GeecsBluesky/geecs_bluesky/pause_supervisor.py
+++ b/GeecsBluesky/geecs_bluesky/pause_supervisor.py
@@ -221,25 +221,32 @@ class PauseSupervisor:
 
         outcome = "resume"
         try:
+            if pending is not None:
+                # A staged action wins even if a bare pause was *also* armed
+                # (operator raced the Pause button with an action's "Pause
+                # scan & run"): honour the action decision rather than
+                # silently drop it — its cleanup runs in the finally below
+                # regardless of which branch we took.
+                outcome = self._decide_and_execute(session, pending)
+                return outcome
             if manual_pause:
                 # Bare operator pause: hold (safe state driven above) until
                 # Resume or Stop.  Non-modal — the GUI stays usable.
                 outcome = self._park_manual_pause()
                 return outcome
-            if pending is None:
-                # Pause landed with nothing staged (e.g. the operator
-                # already withdrew it) — just resume.
-                logger.info("pause window opened with no pending action")
-                return outcome
-            try:
-                outcome = self._decide_and_execute(session, pending)
-                return outcome
-            finally:
+            # Pause landed with nothing staged (e.g. the operator already
+            # withdrew it) — just resume.
+            logger.info("pause window opened with no pending action")
+            return outcome
+        finally:
+            # Cleanup of a staged action's connected factory ALWAYS runs
+            # when one was taken — whatever branch or exception path (this
+            # is the leak the manual-pause branch used to skip).
+            if pending is not None:
                 try:
                     pending.cleanup()
                 except Exception:  # noqa: BLE001 — cleanup is best-effort
                     logger.warning("pending-action cleanup failed", exc_info=True)
-        finally:
             # The abort outcome deliberately skips the restore: RE.abort()'s
             # finalize chain (quiesce → save-off → disarm → closeout) owns
             # the end state.

--- a/GeecsBluesky/geecs_bluesky/pause_supervisor.py
+++ b/GeecsBluesky/geecs_bluesky/pause_supervisor.py
@@ -143,6 +143,11 @@ class PauseSupervisor:
         self._pending: PendingAction | None = None
         self._lock = threading.Lock()
         self._last_failure: Exception | None = None
+        #: A bare operator pause (Pause button, no action).  Parks on
+        #: :attr:`_resume_event` until Resume or Abort — the GUI stays
+        #: usable (non-modal), unlike the action-decision modal.
+        self._manual_pause = False
+        self._resume_event = threading.Event()
 
     # ------------------------------------------------------------------
     # Bridge side (GUI thread)
@@ -171,6 +176,22 @@ class PauseSupervisor:
             pending, self._pending = self._pending, None
             return pending
 
+    def arm_manual_pause(self) -> None:
+        """Mark the next pause window as a bare operator pause (Pause button).
+
+        No action is staged: :meth:`on_pause` drives the safe state, emits
+        PAUSED, and parks until :meth:`request_resume` (Resume) or the abort
+        probe (Stop).  Idempotent — a second call before the pause lands is
+        a no-op.
+        """
+        with self._lock:
+            self._manual_pause = True
+            self._resume_event.clear()
+
+    def request_resume(self) -> None:
+        """Wake a manually-paused window so the scan resumes (Resume button)."""
+        self._resume_event.set()
+
     # ------------------------------------------------------------------
     # Scan-thread side
     # ------------------------------------------------------------------
@@ -185,6 +206,7 @@ class PauseSupervisor:
         """
         with self._lock:
             pending, self._pending = self._pending, None
+            manual_pause, self._manual_pause = self._manual_pause, False
 
         controller = self._shot_controller()
         entry_state = getattr(controller, "last_state", None)
@@ -199,6 +221,11 @@ class PauseSupervisor:
 
         outcome = "resume"
         try:
+            if manual_pause:
+                # Bare operator pause: hold (safe state driven above) until
+                # Resume or Stop.  Non-modal — the GUI stays usable.
+                outcome = self._park_manual_pause()
+                return outcome
             if pending is None:
                 # Pause landed with nothing staged (e.g. the operator
                 # already withdrew it) — just resume.
@@ -226,6 +253,20 @@ class PauseSupervisor:
     @property
     def _abort_tripped(self) -> bool:
         return self._should_abort is not None and self._should_abort()
+
+    def _park_manual_pause(self) -> str:
+        """Hold a bare operator pause until Resume or Stop.
+
+        Returns ``"resume"`` when :meth:`request_resume` fires, ``"abort"``
+        when the operator-stop probe trips.  Sliced so a Stop lands
+        promptly.
+        """
+        logger.info("scan paused by operator — awaiting resume/stop")
+        while not self._resume_event.wait(timeout=_DECISION_SLICE_S):
+            if self._abort_tripped:
+                return "abort"
+        logger.info("operator resumed the scan")
+        return "resume"
 
     def _decide_and_execute(self, session: Any, pending: PendingAction) -> str:
         attempt = 0

--- a/GeecsBluesky/geecs_bluesky/scanner_bridge/bluesky_scanner.py
+++ b/GeecsBluesky/geecs_bluesky/scanner_bridge/bluesky_scanner.py
@@ -414,11 +414,12 @@ class BlueskyScanner:
             else:
                 self._scan_thread = None
 
-    # pause_scan/resume_scan were deleted (issue #552 PR-1): they issued a
-    # HARD pause (request_pause(defer=False)) whose resume replays the
-    # partial row — in strict mode refiring a physical shot — and no caller
-    # existed.  The deferred pause/decide/resume flow arrives with the #552
-    # pause supervisor; do not reintroduce a bare pause API.
+    # The old pause_scan/resume_scan were deleted (issue #552 PR-1): they
+    # issued a HARD pause (request_pause(defer=False)) whose resume replays
+    # the partial row — in strict mode refiring a physical shot.  The safe
+    # operator pause is request_pause/request_resume below (deferred pause
+    # at a checkpoint, driven through the pause supervisor); never
+    # reintroduce a bare RE.resume() API under the old names.
 
     def is_scanning_active(self) -> bool:
         """Return ``True`` if a scan thread is currently running.
@@ -487,6 +488,44 @@ class BlueskyScanner:
         :meth:`run_action` carries the scan-in-progress refusal.
         """
         return self._session.describe_action(name, self._action_resolver())
+
+    def request_pause(self) -> None:
+        """Pause the running scan at its next safe point (operator Pause).
+
+        The bare-pause counterpart of :meth:`request_action_during_scan`:
+        no action is staged.  Marks the pause supervisor for a manual
+        pause, emits ``PAUSING``, and asks the RunEngine to pause at its
+        next checkpoint (deferred).  The supervisor drives the mode-safe
+        state (free-run → ``OFF``, jet off; strict → nothing) and holds —
+        non-modal, the GUI stays usable — until :meth:`request_resume` or a
+        Stop.  A no-op (logged) when no scan is active.
+        """
+        if not self.is_scanning_active():
+            logger.info("request_pause: no active scan; nothing to pause")
+            return
+        supervisor = self._pause_supervisor
+        if supervisor is None:
+            return
+        supervisor.arm_manual_pause()
+        logger.info("operator pause requested — pausing at next checkpoint")
+        self._set_state("PAUSING")
+        try:
+            self._RE.request_pause(defer=True)
+        except Exception:
+            logger.debug("RE.request_pause() raised", exc_info=True)
+
+    def request_resume(self) -> None:
+        """Resume a scan paused by :meth:`request_pause` (operator Resume).
+
+        Signals the parked pause supervisor (on the scan thread) to resume;
+        it re-asserts the pre-pause shot-control state and the RunEngine
+        rewinds to the checkpoint and continues.  A no-op when nothing is
+        paused.
+        """
+        supervisor = self._pause_supervisor
+        if supervisor is not None:
+            supervisor.request_resume()
+            logger.info("operator resume requested")
 
     def request_action_during_scan(self, name: str) -> None:
         """Request an action to run in the scan's pause window (G-actions v2).

--- a/GeecsBluesky/pyproject.toml
+++ b/GeecsBluesky/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-bluesky"
-version = "0.44.1"
+version = "0.45.0"
 description = "Bluesky / ophyd-async bridge for the GEECS control system"
 authors = ["Sam Barber <sbarber@lbl.gov>"]
 readme = "README.md"

--- a/GeecsBluesky/tests/test_action_during_scan.py
+++ b/GeecsBluesky/tests/test_action_during_scan.py
@@ -214,3 +214,31 @@ def test_console_less_bridge_gives_supervisor_no_ask() -> None:
     scanner._on_event = None  # no consumer
     sup = scanner._make_pause_supervisor()
     assert sup._ask is None
+
+
+def test_request_pause_arms_manual_pause_and_defers() -> None:
+    """The operator Pause button: arm a manual pause + deferred RE pause."""
+    resolver = _FakeResolver({})
+    scanner = _make_running_scanner(_FakeSession(resolver), _request(), resolver)
+    scanner.request_pause()
+    assert scanner._pauses == [True]  # deferred pause requested
+    assert scanner._current_state == ScanState.PAUSING
+    assert scanner._pause_supervisor._manual_pause is True
+
+
+def test_request_resume_signals_the_supervisor() -> None:
+    resolver = _FakeResolver({})
+    scanner = _make_running_scanner(_FakeSession(resolver), _request(), resolver)
+    scanner._pause_supervisor.arm_manual_pause()
+    assert not scanner._pause_supervisor._resume_event.is_set()
+    scanner.request_resume()
+    assert scanner._pause_supervisor._resume_event.is_set()
+
+
+def test_request_pause_no_op_without_active_scan() -> None:
+    resolver = _FakeResolver({})
+    scanner = _make_running_scanner(
+        _FakeSession(resolver), _request(), resolver, scanning=False
+    )
+    scanner.request_pause()
+    assert scanner._pauses == []  # nothing paused

--- a/GeecsBluesky/tests/test_pause_supervisor.py
+++ b/GeecsBluesky/tests/test_pause_supervisor.py
@@ -243,3 +243,51 @@ def test_set_pending_is_single_slot() -> None:
     taken = sup.take_unconsumed_pending()
     assert taken.name == "a"
     assert sup.take_unconsumed_pending() is None
+
+
+class TestManualPause:
+    """The bare operator Pause button: park until Resume or Stop, no action."""
+
+    def test_manual_pause_parks_until_resume_then_restores(self, loop) -> None:
+        states: list = []
+        controller = _FakeController(states, last_state="SCAN")
+        sup = PauseSupervisor(
+            acquisition="free_run", shot_controller=lambda: controller
+        )
+        sup.arm_manual_pause()
+        # Resume from another thread shortly after on_pause parks.
+        import threading as _t
+
+        _t.Timer(0.15, sup.request_resume).start()
+        assert sup.on_pause(_FakeSession(loop)) == "resume"
+        # OFF driven on pause, SCAN re-asserted on resume — no action ran.
+        assert states == [("U_DG645:Amp", "0.0"), ("U_DG645:Amp", "4.0")]
+
+    def test_manual_pause_strict_drives_nothing(self, loop) -> None:
+        states: list = []
+        sup = PauseSupervisor(
+            acquisition="strict",
+            shot_controller=lambda: _FakeController(states, last_state="ARMED"),
+        )
+        sup.arm_manual_pause()
+        import threading as _t
+
+        _t.Timer(0.1, sup.request_resume).start()
+        assert sup.on_pause(_FakeSession(loop)) == "resume"
+        assert states == []
+
+    def test_manual_pause_abort_via_stop_probe_skips_restore(self, loop) -> None:
+        states: list = []
+        controller = _FakeController(states, last_state="SCAN")
+        stopping = {"v": False}
+        sup = PauseSupervisor(
+            acquisition="free_run",
+            shot_controller=lambda: controller,
+            should_abort=lambda: stopping["v"],
+        )
+        sup.arm_manual_pause()
+        import threading as _t
+
+        _t.Timer(0.1, lambda: stopping.update(v=True)).start()
+        assert sup.on_pause(_FakeSession(loop)) == "abort"
+        assert states == [("U_DG645:Amp", "0.0")]  # OFF only; no restore

--- a/GeecsBluesky/tests/test_pause_supervisor.py
+++ b/GeecsBluesky/tests/test_pause_supervisor.py
@@ -291,3 +291,22 @@ class TestManualPause:
         _t.Timer(0.1, lambda: stopping.update(v=True)).start()
         assert sup.on_pause(_FakeSession(loop)) == "abort"
         assert states == [("U_DG645:Amp", "0.0")]  # OFF only; no restore
+
+
+def test_manual_pause_with_staged_action_runs_the_action_and_cleans_up(loop):
+    """Manual pause + a staged action (raced): the action wins, is decided,
+    and its factory is cleaned up exactly once (no leak)."""
+    cleaned: list = []
+    states: list = []
+    steps: list = []
+    controller = _FakeController(states, last_state="SCAN")
+    sup = PauseSupervisor(
+        acquisition="free_run",
+        shot_controller=lambda: controller,
+        ask=_answering("execute"),
+    )
+    sup.set_pending(_pending(journal=steps, cleanup=lambda: cleaned.append(True)))
+    sup.arm_manual_pause()  # both armed — action must win, not be dropped
+    assert sup.on_pause(_FakeSession(loop)) == "resume"
+    assert steps == [("U_Valve:V", 1)]  # the action ran
+    assert cleaned == [True]  # factory cleaned exactly once (the leak fix)


### PR DESCRIPTION
Follow-up to the G-actions v2 sequence (issue #552): the **standalone Pause button** the operator actually wanted. The four-PR sequence built the pause *engine* but wired its only trigger to "run an action mid-scan"; this adds a bare Pause control that reuses all of it.

## What + why

The pause supervisor, deferred-pause checkpoints, safe-state drive, and PAUSED lifecycle are all already in place — a bare pause just needed a trigger with **no action** and a way to hold until Resume.

- **Engine (GeecsBluesky 0.45.0):** `BlueskyScanner.request_pause()` / `request_resume()` + `PauseSupervisor.arm_manual_pause()` / `request_resume()`. A manual pause drives the mode-safe state (free-run → `OFF`, jet off; strict → nothing) and **parks non-modally** on a resume/stop signal — no dialog, so the GUI stays fully usable while the scan holds (read device panels, etc.). On Resume it re-asserts the pre-pause shot-control state; Stop aborts out (finalize chain owns the end state). This is *why* `on_pause` no longer immediately resumes an actionless pause.
- **Console (GEECS-Console 0.17.0):** a **Pause** button on the R5 submit row (new `r5_pause_button` in `main_window.ui`), between the spacer and Stop. Enabled while RUNNING (reads "❚❚ Pause"); becomes "▶ Resume" while PAUSED; disabled during the transitional PAUSING/STOPPING and when idle/terminal. New `Submitter` members `request_pause` / `request_resume`.

**Naming:** the new methods are `request_pause`/`request_resume` — deliberately *not* the tombstoned `pause_scan`/`resume_scan` (the deleted hard-pause trap), so the PR-1 tombstone test stays valid and no one confuses the safe deferred pause with the old bare-`RE.resume()` replay trap.

## Per-concern LOC breakdown

- Supervisor manual-pause branch (`arm_manual_pause`/`request_resume`/`_park_manual_pause` + on_pause dispatch): +45
- Bridge `request_pause`/`request_resume`: +45
- Console R5 button (.ui widget, bind, `_on_pause_clicked`, `_refresh_pause_button`, state tracking): +75
- Submitter protocol members: +14
- Tests (bluesky: 3 supervisor + 3 bridge; console: 6 button-lifecycle): +150
- Version + CHANGELOG × 2: +40

## Tests

- `./scripts/check.sh`: **GeecsBluesky 577 passed** (incl. the tombstone test — still green after the deliberate rename), **GEECS-Console 761 passed** (+6 button tests; the 2 `*_without_the_extra` optimization failures are the known local-extra issue, pass in CI). Verified the button renders + cycles (disabled → Pause → Resume) by driving the real window headlessly.

## Hardware verification

**OWED** — folds into the same Undulator session as the rest of #552 (the checklist of record). This makes step 1 a two-click test: Start, then Pause — no action library needed. Behavior is identical to an action-triggered pause minus the action, so the free-run-OFF / strict-quiescent / abort-end-state checks cover it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)