### PR TITLE
GeecsBluesky 0.45.1: emit RUNNING on resume — multiple pauses per scan

### DIFF
--- a/GEECS-Console/tests/test_main_window.py
+++ b/GEECS-Console/tests/test_main_window.py
@@ -782,6 +782,25 @@ class TestSubmission:
         assert window._submitter.resumes == 1
         assert window._submitter.pauses == 0  # resume, not a second pause
 
+    def test_button_returns_to_pause_after_resume_running_event(self, window):
+        """Multiple pauses per scan: the engine emits RUNNING on resume, so
+        the button flips back to Pause and a second Pause click works."""
+        from fake_events import ScanLifecycleEvent
+
+        select_save_set(window, "Amp4In")
+        window._on_start_clicked()
+        window.events.handle(ScanLifecycleEvent(state="running"))
+        window.pause_button.click()  # pause
+        window.events.handle(ScanLifecycleEvent(state="paused"))
+        assert "Resume" in window.pause_button.text()
+        window.pause_button.click()  # resume
+        # The engine's resume emits RUNNING; the button must flip back.
+        window.events.handle(ScanLifecycleEvent(state="running"))
+        assert "Pause" in window.pause_button.text()
+        assert window.pause_button.isEnabled()
+        window.pause_button.click()  # a SECOND pause must work
+        assert window._submitter.pauses == 2
+
     def test_pause_button_disabled_during_pausing_transition(self, window):
         from fake_events import ScanLifecycleEvent
 

--- a/GeecsBluesky/CHANGELOG.md
+++ b/GeecsBluesky/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to `geecs-bluesky` are documented here.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.45.1] - 2026-07-16
+
+### Fixed
+
+- **Multiple pauses per scan** (operator-pause follow-up): the pause
+  supervisor now emits `on_state("running")` when a pause window ends in a
+  resume — the symmetric close of the `on_state("paused")` it emits at
+  window open.  Without it the console's state pill and Pause/Resume button
+  stayed stuck on PAUSED/"Resume" after resuming, so a second Pause click
+  hit the no-op resume path — one pause per scan.  The engine already
+  supported repeated pauses (the supervised-run loop re-enters `on_pause`
+  per deferred pause); this just lets the GUI keep up.  Covers both the
+  bare operator pause and the action-triggered pause.  Pinned by
+  `tests/test_pause_supervisor.py`.
+
 ## [0.45.0] - 2026-07-16
 
 ### Added

--- a/GeecsBluesky/geecs_bluesky/pause_supervisor.py
+++ b/GeecsBluesky/geecs_bluesky/pause_supervisor.py
@@ -250,8 +250,18 @@ class PauseSupervisor:
             # The abort outcome deliberately skips the restore: RE.abort()'s
             # finalize chain (quiesce → save-off → disarm → closeout) owns
             # the end state.
-            if drove_safe_state and entry_state and outcome == "resume":
-                self._drive_state(session, controller, entry_state)
+            if outcome == "resume":
+                if drove_safe_state and entry_state:
+                    self._drive_state(session, controller, entry_state)
+                # The scan is about to resume — flip the consumer back from
+                # PAUSED to RUNNING (state pill + the console Pause button,
+                # which otherwise stays stuck on "Resume" — only one pause
+                # per scan).  ``on_state("paused")`` was emitted at window
+                # open; this is its symmetric close.  The engine already
+                # supports repeated pauses (the supervised-run loop re-enters
+                # on_pause per deferred pause); this makes the GUI keep up.
+                if self._on_state is not None:
+                    self._on_state("running")
 
     # ------------------------------------------------------------------
     # Internals

--- a/GeecsBluesky/pyproject.toml
+++ b/GeecsBluesky/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-bluesky"
-version = "0.45.0"
+version = "0.45.1"
 description = "Bluesky / ophyd-async bridge for the GEECS control system"
 authors = ["Sam Barber <sbarber@lbl.gov>"]
 readme = "README.md"

--- a/GeecsBluesky/tests/test_pause_supervisor.py
+++ b/GeecsBluesky/tests/test_pause_supervisor.py
@@ -310,3 +310,33 @@ def test_manual_pause_with_staged_action_runs_the_action_and_cleans_up(loop):
     assert sup.on_pause(_FakeSession(loop)) == "resume"
     assert steps == [("U_Valve:V", 1)]  # the action ran
     assert cleaned == [True]  # factory cleaned exactly once (the leak fix)
+
+
+def test_resume_emits_running_state_so_the_gui_can_relabel(loop) -> None:
+    """On resume the supervisor emits on_state('running') — the console flips
+    the pause button back to 'Pause' (else only one pause per scan)."""
+    emitted: list = []
+    sup = PauseSupervisor(
+        acquisition="strict",
+        shot_controller=lambda: _FakeController([], last_state="ARMED"),
+        on_state=emitted.append,
+    )
+    sup.arm_manual_pause()
+    import threading as _t
+
+    _t.Timer(0.1, sup.request_resume).start()
+    assert sup.on_pause(_FakeSession(loop)) == "resume"
+    assert emitted == ["paused", "running"]  # symmetric open/close
+
+
+def test_abort_does_not_emit_running(loop) -> None:
+    emitted: list = []
+    sup = PauseSupervisor(
+        acquisition="strict",
+        shot_controller=lambda: _FakeController([], last_state="ARMED"),
+        should_abort=lambda: True,
+        on_state=emitted.append,
+    )
+    sup.arm_manual_pause()
+    assert sup.on_pause(_FakeSession(loop)) == "abort"
+    assert "running" not in emitted  # abort → ABORTED comes from the bridge


### PR DESCRIPTION
Operator-pause follow-up (issue #552). **Bug found in live testing:** after Resume, the console's Pause button stays on "Resume" and the pill on PAUSED, so you only get **one pause per scan** — a second click hits the no-op resume path.

## What + why

The **engine already supports repeated pauses** — `_run_supervised`'s loop re-enters `on_pause` on every deferred pause. The bug is purely that the GUI never learns the scan resumed: the pause supervisor emits `on_state("paused")` when a window opens but had **no symmetric close**, so nothing flipped the console back to RUNNING. The state pill and the Pause/Resume button both key off the lifecycle state word, so both stuck on PAUSED.

Fix: the supervisor emits `on_state("running")` when a pause window ends in a **resume** (not on abort — ABORTED comes from the bridge's abort path). One symmetric line in the `finally`. Covers both the bare operator pause (#582) and the action-triggered pause (#581) — both stuck identically.

Why the hardware checklist missed it: item 4 verified *data* integrity through a pause→execute→resume (shot_offset labels, s-file) — all unaffected by a stale pill. The stuck UI state corrupts nothing; it just caps you at one pause.

## Per-concern LOC breakdown

- Supervisor `on_state("running")` on resume (`pause_supervisor.py`): +12 (mostly the why-comment)
- Tests: bluesky +2 (resume-emits-running, abort-does-not); console +1 (full running→paused→running cycle + a second pause click works)
- Version bump + CHANGELOG (0.45.1 patch): +16

Console is test-only (a new pin against the engine's emit) — no console code changed, so unbumped.

## Tests

- `./scripts/check.sh`: **GeecsBluesky 580 passed** (+2), **GEECS-Console 762 passed** (+1; the 2 `*_without_the_extra` optimization failures are the known local-extra issue). The console test drives the full cycle and asserts a *second* Pause click reaches `request_pause`.

## Hardware verification

**N/A for correctness** — pure lifecycle-event emission; no scan execution, device, or timing path changed. Worth an eyeball at the beamline next session (pause → resume → pause again → the button cycles), but nothing data-affecting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)