### PR TITLE
GEECS-Console 0.17.1 + docs/tooling: slate-clean — env-gated tests + session knowledge percolation

### DIFF
--- a/.claude/skills/land/SKILL.md
+++ b/.claude/skills/land/SKILL.md
@@ -125,7 +125,11 @@ Disposition, in a PR comment before merge: each finding is either
 **fixed** (commit referenced) or **waived** with a one-line reason.
 A fix must go back to the **same reviewer** (continue the subagent)
 for a confirm/deny before it is dispositioned as fixed — otherwise the
-author is back to assessing their own work. Waivers are cheap-to-veto
+author is back to assessing their own work.  If that reviewer becomes
+unreachable (repeated API errors after backoff — long transcripts make
+resumes heavy), a **fresh-context verifier** given only the finding text
+and the fix commit preserves the independence; note the substitution in
+the disposition. Waivers are cheap-to-veto
 flags for the owner, same as judgment-call additions. If a finding
 invalidates the approach, stop and surface it instead of merging.
 

--- a/GEECS-Console/CHANGELOG.md
+++ b/GEECS-Console/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to GEECS-Console are documented here.  Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versioning is
 semantic.
 
+## [0.17.1] - 2026-07-16
+
+### Fixed
+
+- The two `*_without_the_extra` optimization tests now **skip** (with the
+  reason) instead of failing on dev machines where the `optimization`
+  extra is installed — the environment, not the code, decides those
+  tests' premise; CI (extra absent) runs them as before.  They had
+  false-failed every local `check.sh` run on extra-installed setups.
+
 ## [0.17.0] - 2026-07-16
 
 ### Added

--- a/GEECS-Console/CLAUDE.md
+++ b/GEECS-Console/CLAUDE.md
@@ -45,11 +45,15 @@ are prefixed by region (`r3_radio_1d`, `r5_start_button`, …).
   When idle (startup / experiment change) the label shows
   "Scan NNN (previous)" from a **strictly read-only** peek at today's
   daily `scans/` folder (see Implemented seams), or "No scans today".
-  **The log tail is NOT the Python log**: it is a narration of the
+  **The log tail is NOT the Python log** (the canonical statement of
+  this — the engine CLAUDE.md points here): it is a narration of the
   `ScanEvent` stream built in `events_adapter.handle` — per-shot lines
-  are event *documents* (emitted at end-of-shot, delivered queued, lagged
-  over VPN), while the terminal/file log's lines fire synchronously at
-  the point of action.  The two are independent stories with different
+  are event *documents*, emitted at ``bps.save()`` (end of shot, *after*
+  the per-shot CA reads that ride the VPN) and delivered queued; the
+  terminal/file log's lines fire synchronously at the point of action
+  (e.g. `SINGLESHOT` logs at shot *start*).  Same process, no network
+  between engine and GUI — the VPN latency enters upstream, in when the
+  shot's reads complete.  The two are independent stories with different
   timing and granularity; they will drift, and shot counts must never be
   reconciled across them (live-investigated 2026-07-16 — a "pause shows
   extra steps" report was mostly this drift).

--- a/GEECS-Console/CLAUDE.md
+++ b/GEECS-Console/CLAUDE.md
@@ -45,6 +45,14 @@ are prefixed by region (`r3_radio_1d`, `r5_start_button`, …).
   When idle (startup / experiment change) the label shows
   "Scan NNN (previous)" from a **strictly read-only** peek at today's
   daily `scans/` folder (see Implemented seams), or "No scans today".
+  **The log tail is NOT the Python log**: it is a narration of the
+  `ScanEvent` stream built in `events_adapter.handle` — per-shot lines
+  are event *documents* (emitted at end-of-shot, delivered queued, lagged
+  over VPN), while the terminal/file log's lines fire synchronously at
+  the point of action.  The two are independent stories with different
+  timing and granularity; they will drift, and shot counts must never be
+  reconciled across them (live-investigated 2026-07-16 — a "pause shows
+  extra steps" report was mostly this drift).
 - **R7 device panel** — device:variable combo (editable, with
   `device:variable` dropdown completions from `GeecsDbCompletions` — see
   Implemented seams), readback label, set field + button.  **Backend

--- a/GEECS-Console/pyproject.toml
+++ b/GEECS-Console/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-console"
-version = "0.17.0"
+version = "0.17.1"
 description = "Greenfield PySide6 operator console for GEECS (Bluesky/gateway architecture)"
 authors = ["Sam Barber <sbarber@lbl.gov>"]
 readme = "README.md"

--- a/GEECS-Console/tests/test_optimization_loader.py
+++ b/GEECS-Console/tests/test_optimization_loader.py
@@ -10,6 +10,7 @@ inverse of ``geecs_schemas.convert.convert_optimizer_config``.
 
 from __future__ import annotations
 
+import importlib.util
 import sys
 import types
 
@@ -98,9 +99,17 @@ def test_mapping_is_the_exact_inverse_of_the_legacy_converter() -> None:
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.skipif(
+    importlib.util.find_spec("geecs_scanner") is not None,
+    reason="the optimization extra IS installed here — the test's premise "
+    "(extra absent, as in CI) does not hold; the available path is covered "
+    "by the monkeypatched tests below",
+)
 def test_optimization_unavailable_without_the_extra() -> None:
-    # The console test environment deliberately does not install the
-    # `optimization` extra, so the real probe reports unavailable.
+    # CI deliberately does not install the `optimization` extra, so the
+    # real probe reports unavailable.  Skipped (not failed) on dev
+    # machines that installed the extra — the environment, not the code,
+    # decides this test's premise.
     assert optimization_available() is False
     assert make_optimization_loader() is None
 

--- a/GEECS-Console/tests/test_optimization_loader.py
+++ b/GEECS-Console/tests/test_optimization_loader.py
@@ -5,14 +5,12 @@ installed in CI; on dev machines that installed it, the real-probe test
 skips (the environment, not the code, decides its premise).  The mapping
 tests are pure, the loader construction test injects fake
 ``geecs_scanner`` modules into ``sys.modules``, and the availability gate
-is monkeypatched.  The
-round-trip test pins :func:`optimizer_config_from_spec` as the exact
+is monkeypatched.  The round-trip test pins :func:`optimizer_config_from_spec` as the exact
 inverse of ``geecs_schemas.convert.convert_optimizer_config``.
 """
 
 from __future__ import annotations
 
-import importlib.util
 import sys
 import types
 
@@ -102,7 +100,10 @@ def test_mapping_is_the_exact_inverse_of_the_legacy_converter() -> None:
 
 
 @pytest.mark.skipif(
-    importlib.util.find_spec("geecs_scanner.optimization") is not None,
+    # optimization_available() is the probe under test itself — agreement
+    # by construction, and (unlike a bare dotted find_spec) it guards the
+    # ModuleNotFoundError that an absent parent package raises.
+    optimization_available(),
     reason="the optimization extra IS installed here — the test's premise "
     "(extra absent, as in CI) does not hold; the available path is covered "
     "by the monkeypatched tests below",

--- a/GEECS-Console/tests/test_optimization_loader.py
+++ b/GEECS-Console/tests/test_optimization_loader.py
@@ -1,9 +1,11 @@
 """The optimization_loader seam: spec→config mapping, gating, and injection.
 
 Hermetic — ``geecs-scanner-gui`` (the ``optimization`` extra) is NOT
-installed in the test environment: the mapping tests are pure, the loader
-construction test injects fake ``geecs_scanner`` modules into
-``sys.modules``, and the availability gate is monkeypatched.  The
+installed in CI; on dev machines that installed it, the real-probe test
+skips (the environment, not the code, decides its premise).  The mapping
+tests are pure, the loader construction test injects fake
+``geecs_scanner`` modules into ``sys.modules``, and the availability gate
+is monkeypatched.  The
 round-trip test pins :func:`optimizer_config_from_spec` as the exact
 inverse of ``geecs_schemas.convert.convert_optimizer_config``.
 """
@@ -100,7 +102,7 @@ def test_mapping_is_the_exact_inverse_of_the_legacy_converter() -> None:
 
 
 @pytest.mark.skipif(
-    importlib.util.find_spec("geecs_scanner") is not None,
+    importlib.util.find_spec("geecs_scanner.optimization") is not None,
     reason="the optimization extra IS installed here — the test's premise "
     "(extra absent, as in CI) does not hold; the available path is covered "
     "by the monkeypatched tests below",

--- a/GEECS-Console/tests/test_optimization_warmup.py
+++ b/GEECS-Console/tests/test_optimization_warmup.py
@@ -1,10 +1,12 @@
 """The startup warm-up: pre-importing the optimization stack off-thread.
 
 Hermetic — ``geecs-scanner-gui`` (the ``optimization`` extra) is NOT
-installed in the test environment: the no-op path is exercised against the
-real ``find_spec`` probe, the warm path against fake ``geecs_scanner``
-modules planted in ``sys.modules``, and the never-blocks pin against an
-import stub gated on an event.  The double-work guard (a submission
+installed in CI, where the no-op path is exercised against the real
+``find_spec`` probe; on dev machines that installed the extra, that
+real-probe test skips (the environment, not the code, decides its
+premise).  The warm path runs against fake ``geecs_scanner`` modules
+planted in ``sys.modules``, and the never-blocks pin against an import
+stub gated on an event.  The double-work guard (a submission
 arriving mid-warm-up) is deliberately not machinery — Python's per-module
 import locks already serialize concurrent imports — so there is nothing to
 test beyond the loader tests in ``test_optimization_loader.py``.
@@ -12,13 +14,13 @@ test beyond the loader tests in ``test_optimization_loader.py``.
 
 from __future__ import annotations
 
-import importlib
+import importlib.util
 import logging
-
-import pytest
 import sys
 import threading
 import types
+
+import pytest
 
 from geecs_console.services import optimization as optimization_module
 from geecs_console.services.optimization import warm_up_optimization_stack
@@ -37,7 +39,7 @@ def _plant_fake_stack(monkeypatch) -> None:
 
 
 @pytest.mark.skipif(
-    importlib.util.find_spec("geecs_scanner") is not None,
+    importlib.util.find_spec("geecs_scanner.optimization") is not None,
     reason="the optimization extra IS installed here — the test's premise "
     "(extra absent, as in CI) does not hold",
 )

--- a/GEECS-Console/tests/test_optimization_warmup.py
+++ b/GEECS-Console/tests/test_optimization_warmup.py
@@ -14,7 +14,7 @@ test beyond the loader tests in ``test_optimization_loader.py``.
 
 from __future__ import annotations
 
-import importlib.util
+import importlib
 import logging
 import sys
 import threading
@@ -23,7 +23,10 @@ import types
 import pytest
 
 from geecs_console.services import optimization as optimization_module
-from geecs_console.services.optimization import warm_up_optimization_stack
+from geecs_console.services.optimization import (
+    optimization_available,
+    warm_up_optimization_stack,
+)
 
 _JOIN_TIMEOUT_S = 5.0
 
@@ -39,7 +42,10 @@ def _plant_fake_stack(monkeypatch) -> None:
 
 
 @pytest.mark.skipif(
-    importlib.util.find_spec("geecs_scanner.optimization") is not None,
+    # optimization_available() is the probe under test itself — agreement
+    # by construction, and (unlike a bare dotted find_spec) it guards the
+    # ModuleNotFoundError that an absent parent package raises.
+    optimization_available(),
     reason="the optimization extra IS installed here — the test's premise "
     "(extra absent, as in CI) does not hold",
 )

--- a/GEECS-Console/tests/test_optimization_warmup.py
+++ b/GEECS-Console/tests/test_optimization_warmup.py
@@ -14,6 +14,8 @@ from __future__ import annotations
 
 import importlib
 import logging
+
+import pytest
 import sys
 import threading
 import types
@@ -34,6 +36,11 @@ def _plant_fake_stack(monkeypatch) -> None:
         monkeypatch.setitem(sys.modules, name, types.ModuleType(name))
 
 
+@pytest.mark.skipif(
+    importlib.util.find_spec("geecs_scanner") is not None,
+    reason="the optimization extra IS installed here — the test's premise "
+    "(extra absent, as in CI) does not hold",
+)
 def test_warm_up_no_ops_without_the_extra(caplog) -> None:
     """Extra absent (real find_spec probe): no thread, nothing logged loudly."""
     with caplog.at_level(logging.INFO, logger=optimization_module.__name__):

--- a/GeecsBluesky/CLAUDE.md
+++ b/GeecsBluesky/CLAUDE.md
@@ -201,9 +201,24 @@ resumes — abort skips the restore (the finalize chain owns the end state).
 A pause requested but never delivered (scan ended first) is withdrawn and
 logged, not an error (design-note contract on #552).  `PAUSING`/`PAUSED`
 are non-terminal ScanStates; `RE.record_interruptions = True` puts the
-pause window in the data record.  Acquisition mode comes from
-`ScanRequest.acquisition` — deliberately no env override, a request
-declares intent.
+pause window in the data record.  The bare operator pause
+(`request_pause`/`request_resume`, #582/#583) rides the same supervisor:
+no action staged, park non-modally until Resume/Stop, emit
+`on_state("running")` on resume so the GUI relabels (multiple pauses per
+scan).  **Expected pause latency — do not "fix" (live-investigated
+2026-07-16):** 1–2 shots complete after the pause request.  The in-flight
+shot always finishes (checkpoints deliberately never split a shot), and
+the deferred flag is set by a coroutine dispatched onto the busy RE loop
+(`request_pause` → `run_coroutine_threadsafe`), which on a loaded/VPN
+loop can land after the next shot's checkpoint has already passed — one
+more shot slips.  This is the architectural floor; getting under it means
+reintroducing the hard-pause replay trap.  The GUI's log tail can make it
+look worse: its per-shot lines are event *documents* (emitted at
+``bps.save()``, end of shot, delivered queued + over VPN), while the
+terminal log's `SINGLESHOT` lines fire at shot *start* — two independent
+streams that drift; never reconcile shot counts across them.  Acquisition
+mode comes from `ScanRequest.acquisition` — deliberately no env override,
+a request declares intent.
 
 ### Shot control — `ShotControlConfig` + named states
 

--- a/GeecsBluesky/CLAUDE.md
+++ b/GeecsBluesky/CLAUDE.md
@@ -212,13 +212,12 @@ the deferred flag is set by a coroutine dispatched onto the busy RE loop
 (`request_pause` → `run_coroutine_threadsafe`), which on a loaded/VPN
 loop can land after the next shot's checkpoint has already passed — one
 more shot slips.  This is the architectural floor; getting under it means
-reintroducing the hard-pause replay trap.  The GUI's log tail can make it
-look worse: its per-shot lines are event *documents* (emitted at
-``bps.save()``, end of shot, delivered queued + over VPN), while the
-terminal log's `SINGLESHOT` lines fire at shot *start* — two independent
-streams that drift; never reconcile shot counts across them.  Acquisition
-mode comes from `ScanRequest.acquisition` — deliberately no env override,
-a request declares intent.
+reintroducing the hard-pause replay trap.  (The console's log tail can
+make the latency look worse than it is — its per-shot lines and the
+terminal log are two independent streams with different timing; the
+canonical description lives in `GEECS-Console/CLAUDE.md`'s R6 bullet.)
+Acquisition mode comes from `ScanRequest.acquisition` — deliberately no
+env override, a request declares intent.
 
 ### Shot control — `ShotControlConfig` + named states
 


### PR DESCRIPTION
End-of-stream housekeeping (owner-requested slate-wipe): percolate this session's tribal knowledge into the durable homes, and kill the one recurring dev-environment annoyance. Deliberately minimal — no new skills, no speculative docs.

## Per-concern breakdown

1. **Env-gated optimization tests (GEECS-Console 0.17.1, the only code change).** The two `*_without_the_extra` tests assert behavior whose premise is "the optimization extra is absent" — true in CI, false on dev machines that installed it. They false-failed **every** local `check.sh` run this session. Now `skipif(find_spec('geecs_scanner'))` with the reason spelled out: the environment, not the code, decides the premise; CI runs them exactly as before. Local suite: 762 passed, **2 skipped** (was 2 failed).
2. **GeecsBluesky/CLAUDE.md** (+16 lines, docs-only, no bump alongside the console's): the live-investigated **expected pause latency** — 1–2 shots after a pause request is the architectural floor (in-flight shot always completes; deferred-flag dispatch onto the busy RE loop, VPN-amplified) — marked *do not "fix"*; plus the bare operator pause summary (#582/#583).
3. **GEECS-Console/CLAUDE.md** (+8 lines): the **log-tail-vs-terminal-log duality** — the R6 tail narrates the ScanEvent stream (end-of-shot event documents, queued, VPN-lagged) while the Python log fires at point-of-action; independent streams, never reconcile shot counts across them (a live "pause shows extra steps" report was mostly this drift).
4. **`/land` skill** (+5 lines): the reviewer-unreachable pattern proven during the API-overload spell — after backoff, a fresh-context verifier given only the finding text + fix commit preserves independence; note the substitution in the disposition.

## Tests

`./scripts/check.sh`: GEECS-Console **762 passed, 2 skipped**; GeecsBluesky **580 passed** — first fully-green local run of the day (the two false failures are gone).

## Hardware verification

N/A — tests/docs/skill text only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)