### PR TITLE
Lowercase PV naming contract, one :SP owner, safe_name unification

### DIFF
--- a/GEECS-Console/CHANGELOG.md
+++ b/GEECS-Console/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to GEECS-Console are documented here.  Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versioning is
 semantic.
 
+## [0.17.2] - 2026-07-20
+
+### Changed
+
+- R7 device panel assembles `:SP` setpoint names via the naming contract's
+  `setpoint_pv` helper instead of hand-built `f"...:SP"` strings; no behavior
+  change beyond following the geecs-ca-gateway 0.14.0 lowercase PV contract
+  (every PV the console addresses is now lowercase, matching the deployed
+  gateway — operator-typed case in the R7 combo no longer matters).
+
 ## [0.17.1] - 2026-07-16
 
 ### Fixed

--- a/GEECS-Console/CLAUDE.md
+++ b/GEECS-Console/CLAUDE.md
@@ -96,7 +96,7 @@ are prefixed by region (`r3_radio_1d`, `r5_start_button`, …).
 
 - **Health chips (R1)** are live via `GatewayTiledDbHealth` (real probe) or
   `StubHealth` (all-unknown offline/test default).  The real probe runs three
-  guarded checks — CA read of `{experiment}:CAGateway:HEARTBEAT` (OK; WARN
+  guarded checks — CA read of `{experiment}:cagateway:heartbeat` (OK; WARN
   when `DEVICES_CONNECTED == 0`; DOWN on failure; UNKNOWN with no experiment),
   HTTP GET of the `[tiled] uri`, and a cheap `GeecsDb` query — each with a
   short timeout; `poll()` **never raises** and lazily imports

--- a/GEECS-Console/geecs_console/services/device_panel.py
+++ b/GEECS-Console/geecs_console/services/device_panel.py
@@ -212,7 +212,7 @@ def setpoint_pv(experiment: str, device: str, variable: str) -> str:
     str
         The bare ``…:SP`` EPICS name.
     """
-    from geecs_ca_gateway.pv_naming import setpoint_pv as sp
+    from geecs_bluesky.devices.ca._pv import setpoint_pv as sp
 
     return sp(readback_pv(experiment, device, variable))
 

--- a/GEECS-Console/geecs_console/services/device_panel.py
+++ b/GEECS-Console/geecs_console/services/device_panel.py
@@ -187,7 +187,9 @@ def readback_pv(experiment: str, device: str, variable: str) -> str:
     Returns
     -------
     str
-        The bare EPICS name, e.g. ``"HTU:U_Hexapod:ypos"``.
+        The bare EPICS name, e.g. ``"htu:u_hexapod:ypos"`` (PV components
+        are lowercase — the naming contract case-folds, so operator-typed
+        case never matters).
     """
     from geecs_bluesky.devices.ca._pv import ca_pv
     from geecs_bluesky.devices.ca.gateway_put import bare_pv
@@ -210,7 +212,9 @@ def setpoint_pv(experiment: str, device: str, variable: str) -> str:
     str
         The bare ``…:SP`` EPICS name.
     """
-    return f"{readback_pv(experiment, device, variable)}:SP"
+    from geecs_ca_gateway.pv_naming import setpoint_pv as sp
+
+    return sp(readback_pv(experiment, device, variable))
 
 
 # ----------------------------------------------------------------------
@@ -335,10 +339,11 @@ class GatewayDevicePanel:
             window renders it in the status bar.
         """
         from geecs_bluesky.devices.ca._pv import ca_pv
+        from geecs_bluesky.devices.ca._pv import setpoint_pv as sp
         from geecs_bluesky.devices.ca.gateway_put import GatewaySetpointPut, wire_value
 
         put = GatewaySetpointPut(
-            setpoint_pv=f"{ca_pv(experiment or None, device, variable)}:SP",
+            setpoint_pv=sp(ca_pv(experiment or None, device, variable)),
             coerce=wire_value,
             timeout=self._put_timeout,
             name=f"{device}:{variable}",

--- a/GEECS-Console/geecs_console/services/health.py
+++ b/GEECS-Console/geecs_console/services/health.py
@@ -91,7 +91,7 @@ class GatewayTiledDbHealth:
     ----------
     experiment : str, optional
         The selected experiment; used to build the prefixed gateway PV
-        (``{experiment}:CAGateway:HEARTBEAT``).  ``None`` (no experiment
+        (``{experiment}:cagateway:heartbeat``).  ``None`` (no experiment
         selected) leaves the gateway chip ``UNKNOWN`` — the prefixed PV
         cannot be built.  Mutable: set ``self.experiment`` (or call
         :meth:`set_experiment`) when the operator picks an experiment.
@@ -138,7 +138,7 @@ class GatewayTiledDbHealth:
         HealthStatus
             ``UNKNOWN`` when no experiment is selected (no prefixed PV can be
             built), ``OK`` when the heartbeat reads, ``WARN`` when it reads
-            but ``DEVICES_CONNECTED`` is 0, ``DOWN`` on any failure/timeout.
+            but ``devices_connected`` is 0, ``DOWN`` on any failure/timeout.
         """
         experiment = self.experiment
         if not experiment:

--- a/GEECS-Console/pyproject.toml
+++ b/GEECS-Console/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-console"
-version = "0.17.1"
+version = "0.17.2"
 description = "Greenfield PySide6 operator console for GEECS (Bluesky/gateway architecture)"
 authors = ["Sam Barber <sbarber@lbl.gov>"]
 readme = "README.md"

--- a/GEECS-Console/tests/test_device_panel.py
+++ b/GEECS-Console/tests/test_device_panel.py
@@ -88,14 +88,14 @@ class TestPvNames:
         # bare_pv strips the ca:// scheme raw aioca must never see.
         assert (
             readback_pv("HTU", "U_Hexapod", "Position.Axis 1")
-            == "HTU:U_Hexapod:Position_Axis_1"
+            == "htu:u_hexapod:position_axis_1"
         )
 
     def test_empty_experiment_drops_out(self):
-        assert readback_pv("", "Dev", "Var") == "Dev:Var"
+        assert readback_pv("", "Dev", "Var") == "dev:var"
 
     def test_setpoint_pv_appends_sp(self):
-        assert setpoint_pv("HTU", "Dev", "Var") == "HTU:Dev:Var:SP"
+        assert setpoint_pv("HTU", "Dev", "Var") == "htu:dev:var:SP"
 
 
 # ----------------------------------------------------------------------
@@ -172,7 +172,7 @@ class TestGatewayDevicePanel:
         panel = GatewayDevicePanel()
         panel.subscribe("HTU", "U_Hexapod", "ypos", lambda value: None)
         assert wait_for(lambda: len(fake_aioca.subscriptions) == 1)
-        assert fake_aioca.subscriptions[0].pv == "HTU:U_Hexapod:ypos"
+        assert fake_aioca.subscriptions[0].pv == "htu:u_hexapod:ypos"
         panel.unsubscribe()
 
     def test_monitor_values_reach_on_value(self, fake_aioca):
@@ -191,7 +191,7 @@ class TestGatewayDevicePanel:
         panel.subscribe("HTU", "Dev2", "Var2", lambda value: None)
         assert wait_for(lambda: len(fake_aioca.subscriptions) == 2)
         assert wait_for(lambda: fake_aioca.subscriptions[0].closed)
-        assert fake_aioca.subscriptions[1].pv == "HTU:Dev2:Var2"
+        assert fake_aioca.subscriptions[1].pv == "htu:dev2:var2"
         panel.unsubscribe()
         assert wait_for(lambda: fake_aioca.subscriptions[1].closed)
 
@@ -221,13 +221,13 @@ class TestGatewayDevicePanel:
     def test_set_puts_wire_value_to_bare_sp_pv(self, fake_aioca):
         panel = GatewayDevicePanel()
         panel.set("HTU", "Dev", "Position.Axis 1", 2.5)
-        assert fake_aioca.puts == [("HTU:Dev:Position_Axis_1:SP", 2.5, True, 10.0)]
+        assert fake_aioca.puts == [("htu:dev:position_axis_1:SP", 2.5, True, 10.0)]
 
     def test_set_string_value_goes_as_wire_string(self, fake_aioca):
         panel = GatewayDevicePanel()
         panel.set("", "Dev", "Trigger.Source", "Single shot")
         (pv, value, wait, _timeout) = fake_aioca.puts[0]
-        assert pv == "Dev:Trigger_Source:SP"
+        assert pv == "dev:trigger_source:SP"
         assert value == "Single shot"
         assert wait is True
 

--- a/GEECS-Console/tests/test_health.py
+++ b/GEECS-Console/tests/test_health.py
@@ -51,7 +51,7 @@ class TestGateway:
         monkeypatch.setattr(
             aioca,
             "caget",
-            _caget_returning({"DEVICES_CONNECTED": 0, "HEARTBEAT": 232}, 232),
+            _caget_returning({"devices_connected": 0, "heartbeat": 232}, 232),
         )
         assert probe._check_gateway() is HealthStatus.WARN
 

--- a/GEECS-Schemas/CHANGELOG.md
+++ b/GEECS-Schemas/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to GEECS-Schemas are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.1] - 2026-07-20
+
+### Changed
+
+- `derived_channels.py`: the output-PV example in the `device` field
+  description follows the geecs-ca-gateway 0.14.0 lowercase PV contract
+  (`undulator:u_chambervac:pressure`); `docs/geecs_schemas/schema_reference.md`
+  regenerated.
+
 ## [0.8.0] - 2026-07-10
 
 ### Changed

--- a/GEECS-Schemas/geecs_schemas/derived_channels.py
+++ b/GEECS-Schemas/geecs_schemas/derived_channels.py
@@ -73,7 +73,7 @@ class DerivedChannel(SchemaModel):
     device: str = Field(
         description=(
             "Device component of the output PV, e.g. 'U_ChamberVac' for "
-            "'Undulator:U_ChamberVac:Pressure'. This may be semantic and does "
+            "'undulator:u_chambervac:pressure'. This may be semantic and does "
             "not need to be a real GEECS hardware device."
         )
     )

--- a/GEECS-Schemas/pyproject.toml
+++ b/GEECS-Schemas/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-schemas"
-version = "0.8.0"
+version = "0.8.1"
 description = "Versioned Pydantic schemas for GEECS scanner configs (scan requests, save sets, scan variables, trigger profiles, action plans) plus legacy-YAML converters."
 authors = ["Sam Barber <sbarber@lbl.gov>"]
 readme = "README.md"

--- a/GeecsBluesky/CHANGELOG.md
+++ b/GeecsBluesky/CHANGELOG.md
@@ -4,6 +4,31 @@ All notable changes to `geecs-bluesky` are documented here.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.46.0] - 2026-07-20
+
+### Changed
+
+- **`safe_name` delegates to the shared naming contract**
+  (`geecs_ca_gateway.pv_naming.normalize_component` + the non-empty `"var"`
+  fallback), so a GEECS name mangles identically into an event-document
+  column component and a gateway PV component — one lossy encoding instead of
+  two (pinned by `test_safe_name_agrees_with_the_pv_naming_contract`).
+  Column-name change: runs of specials now collapse to one underscore
+  (`Wavelength (nm)` → `wavelength_nm`, was `wavelength__nm`). Event-schema
+  version stays 1 (column-name convention, not field/semantics); pre-0.46.0
+  runs keep their old column names and remain readable via
+  `geecs_scalar_headers` — see the EVENT_SCHEMA.md note.
+- All PV names consumed by the CA devices are lowercase (geecs-ca-gateway
+  0.14.0 naming contract); `:SP` setpoint names are now assembled via
+  `pv_naming.setpoint_pv` (re-exported through `devices/ca/_pv.py`) instead
+  of hand-built `f"...:SP"` strings (`shot_controller`, `settable`,
+  `timestamped_readable`, `generic_detector`, `action_signals`).
+
+### Requires
+
+- geecs-ca-gateway ≥ 0.14.0 (lowercase PV contract) — gateway and clients
+  must be deployed together across this boundary.
+
 ## [0.45.1] - 2026-07-16
 
 ### Fixed

--- a/GeecsBluesky/CLAUDE.md
+++ b/GeecsBluesky/CLAUDE.md
@@ -313,7 +313,7 @@ Device connect/disconnect uses `asyncio.run_coroutine_threadsafe(...).result(tim
 
 **Devices are CA-backed only** (`devices/ca/*`): stock ophyd-async
 `epics_signal_r/rw` against the GeecsCAGateway PVs
-(`[Experiment:]Device:Variable`, setpoints at `…:SP`). Requires the `ca` extra
+(`[experiment:]device:variable` — all-lowercase components, setpoints at `…:SP`). Requires the `ca` extra
 (`aioca`) and a running gateway (≥0.3.0 for control-surface and long-string
 path PVs). The gateway is consumed as a **CA service, never as a Python
 import** (the gateway imports our transport core, so an import the other way

--- a/GeecsBluesky/EVENT_SCHEMA.md
+++ b/GeecsBluesky/EVENT_SCHEMA.md
@@ -71,6 +71,18 @@ Never look a run up by `scan_id` alone; qualify with the day, or use
 
 ## Event-stream columns
 
+Column-name components come from `safe_name()` (`geecs_bluesky/utils.py`),
+which delegates to the shared naming contract
+(`geecs_ca_gateway.pv_naming.normalize_component`): runs of non-alphanumeric
+characters collapse to one underscore, lowercase. A GEECS name therefore
+mangles identically into an event column and a gateway PV component.
+(Before GeecsBluesky 0.46.0, `safe_name` replaced specials per-character, so
+`Wavelength (nm)` produced `wavelength__nm` — a double underscore; it now
+produces `wavelength_nm`. A column-name convention change, not a field or
+semantics change, so the schema version stays 1 — runs are self-describing
+and pre-0.46.0 runs keep their old column names, recoverable as ever via
+`geecs_scalar_headers`.)
+
 Row identity (every mode, every row — set by the plan via `ScanContext`):
 
 - `bin_number` — 1-based step index (always `1` for statistics collection)

--- a/GeecsBluesky/EVENT_SCHEMA.md
+++ b/GeecsBluesky/EVENT_SCHEMA.md
@@ -81,7 +81,13 @@ mangles identically into an event column and a gateway PV component.
 produces `wavelength_nm`. A column-name convention change, not a field or
 semantics change, so the schema version stays 1 — runs are self-describing
 and pre-0.46.0 runs keep their old column names, recoverable as ever via
-`geecs_scalar_headers`.)
+`geecs_scalar_headers`. One caveat: asset readback
+(`assets/tiled_readback.py`) recomputes `safe_name(device)` at read time
+rather than consulting stored headers, so a pre-0.46.0 run whose *device
+name* contains adjacent special characters would not resolve its asset
+columns under the new policy — no real GEECS device name does, they are
+identifier-clean `U_*` strings, but if one ever did, route the lookup
+through the run's own column names.)
 
 Row identity (every mode, every row — set by the plan via `ScanContext`):
 

--- a/GeecsBluesky/geecs_bluesky/devices/ca/_pv.py
+++ b/GeecsBluesky/geecs_bluesky/devices/ca/_pv.py
@@ -21,6 +21,9 @@ the ``ca://…`` source string either way.
 from __future__ import annotations
 
 from geecs_ca_gateway.pv_naming import pv_name
+from geecs_ca_gateway.pv_naming import (
+    setpoint_pv as setpoint_pv,
+)  # re-export: the CA modules' naming home
 
 #: Explicit Channel Access scheme understood by
 #: ``ophyd_async.epics.core._signal.split_protocol_from_pv``.

--- a/GeecsBluesky/geecs_bluesky/devices/ca/action_signals.py
+++ b/GeecsBluesky/geecs_bluesky/devices/ca/action_signals.py
@@ -43,7 +43,7 @@ from typing import Any, Callable
 
 from ophyd_async.epics.core import epics_signal_r
 
-from geecs_bluesky.devices.ca._pv import ca_pv
+from geecs_bluesky.devices.ca._pv import ca_pv, setpoint_pv
 from geecs_bluesky.devices.ca.gateway_put import GatewaySetpointPut, wire_value
 from geecs_bluesky.utils import safe_name
 
@@ -102,7 +102,7 @@ class CaActionSignalFactory:
         key = (device, variable)
         settable = self._settables.get(key)
         if settable is None:
-            pv = f"{ca_pv(self._experiment, device, variable)}:SP"
+            pv = setpoint_pv(ca_pv(self._experiment, device, variable))
             name = safe_name(f"{device}_{variable}_sp")
             # dtype-inferred probe: proves the PV exists/connects (pre-claim
             # fail-fast) without imposing a type the PV may not have.

--- a/GeecsBluesky/geecs_bluesky/devices/ca/gateway_put.py
+++ b/GeecsBluesky/geecs_bluesky/devices/ca/gateway_put.py
@@ -57,8 +57,8 @@ def bare_pv(pv: str) -> str:
     Parameters
     ----------
     pv : str
-        A gateway PV name, bare (``Expt:Dev:Var:SP``) or in the ophyd
-        signal-URI form (``ca://Expt:Dev:Var:SP``).
+        A gateway PV name, bare (``expt:dev:var:SP``) or in the ophyd
+        signal-URI form (``ca://expt:dev:var:SP``).
 
     Returns
     -------

--- a/GeecsBluesky/geecs_bluesky/devices/ca/generic_detector.py
+++ b/GeecsBluesky/geecs_bluesky/devices/ca/generic_detector.py
@@ -19,7 +19,7 @@ from bluesky.protocols import Reading
 from event_model import DataKey
 from ophyd_async.epics.core import epics_signal_rw
 
-from geecs_bluesky.devices.ca._pv import ca_pv
+from geecs_bluesky.devices.ca._pv import ca_pv, setpoint_pv
 from geecs_bluesky.devices.ca.triggerable import CaTriggerable
 from geecs_bluesky.devices.nonscalar_save import NonScalarSaveSupport
 from geecs_bluesky.devices.shot_id import ShotIdSupport
@@ -92,7 +92,7 @@ class CaGenericDetector(ShotIdSupport, NonScalarSaveSupport, CaTriggerable):
                 setattr(
                     self,
                     attr,
-                    epics_signal_rw(str, readback, f"{readback}:SP"),
+                    epics_signal_rw(str, readback, setpoint_pv(readback)),
                 )
 
     @property

--- a/GeecsBluesky/geecs_bluesky/devices/ca/settable.py
+++ b/GeecsBluesky/geecs_bluesky/devices/ca/settable.py
@@ -1,7 +1,7 @@
 """CaSettable — a writable GEECS variable driven through the CA gateway.
 
 The gateway exposes a settable GEECS variable as two PVs: a readback
-(``[Experiment:]Device:Variable``, fed by the device stream) and a setpoint
+(``[experiment:]device:variable``, fed by the device stream) and a setpoint
 (``…:SP``, forwarded to the device over UDP).  This device writes the
 setpoint and reads back the real value.
 
@@ -21,7 +21,7 @@ import logging
 from ophyd_async.core import AsyncStatus, StandardReadable
 from ophyd_async.epics.core import epics_signal_r, epics_signal_rw
 
-from geecs_bluesky.devices.ca._pv import ca_pv
+from geecs_bluesky.devices.ca._pv import ca_pv, setpoint_pv
 from geecs_bluesky.devices.ca.gateway_put import GatewaySetpointPut
 
 logger = logging.getLogger(__name__)
@@ -66,7 +66,7 @@ class CaSettable(StandardReadable):
         readback_pv = ca_pv(experiment, device, variable)
         # Setpoint is not a child readable (no feedback loop): set() writes it,
         # read() reflects the streamed readback instead.
-        self._setpoint = epics_signal_rw(datatype, f"{readback_pv}:SP")
+        self._setpoint = epics_signal_rw(datatype, setpoint_pv(readback_pv))
         # Layer-1 puts ride the shared gateway-put primitive (the one owner
         # of addressing/coercion/timeout policy); the typed signal stays the
         # transport — connect-time dtype check and the mock-backend seam.

--- a/GeecsBluesky/geecs_bluesky/devices/ca/timestamped_readable.py
+++ b/GeecsBluesky/geecs_bluesky/devices/ca/timestamped_readable.py
@@ -17,7 +17,7 @@ import logging
 
 from ophyd_async.epics.core import epics_signal_rw
 
-from geecs_bluesky.devices.ca._pv import ca_pv
+from geecs_bluesky.devices.ca._pv import ca_pv, setpoint_pv
 from geecs_bluesky.devices.ca.triggerable import CaAcqTimestampReadable
 from geecs_bluesky.devices.contributor import FreeRunContributorSupport
 from geecs_bluesky.devices.nonscalar_save import NonScalarSaveSupport
@@ -84,7 +84,7 @@ class CaTimestampedReadable(
                 setattr(
                     self,
                     attr,
-                    epics_signal_rw(str, readback, f"{readback}:SP"),
+                    epics_signal_rw(str, readback, setpoint_pv(readback)),
                 )
 
     @property

--- a/GeecsBluesky/geecs_bluesky/shot_controller.py
+++ b/GeecsBluesky/geecs_bluesky/shot_controller.py
@@ -24,7 +24,7 @@ from geecs_bluesky.models.shot_control import (
     ShotControlWrites,
 )
 from geecs_bluesky.plans.single_shot import geecs_confirm_quiescent
-from geecs_ca_gateway.pv_naming import pv_name
+from geecs_ca_gateway.pv_naming import pv_name, setpoint_pv
 
 logger = logging.getLogger(__name__)
 
@@ -106,7 +106,8 @@ class ShotController:
         # gateway_put.bare_pv (issue #490).
         setters = {
             var: CaPutSetter(
-                f"{pv_name(experiment, config.device, var)}:SP", timeout=put_timeout
+                setpoint_pv(pv_name(experiment, config.device, var)),
+                timeout=put_timeout,
             )
             for var in config.variables
         }
@@ -148,7 +149,7 @@ class ShotController:
         """
         factory = setter_factory or (
             lambda device, variable: CaPutSetter(
-                f"{pv_name(experiment, device, variable)}:SP", timeout=put_timeout
+                setpoint_pv(pv_name(experiment, device, variable)), timeout=put_timeout
             )
         )
         setters: dict[tuple[str, str], Any] = {}

--- a/GeecsBluesky/geecs_bluesky/utils.py
+++ b/GeecsBluesky/geecs_bluesky/utils.py
@@ -2,15 +2,17 @@
 
 from __future__ import annotations
 
-import re
+from geecs_ca_gateway.pv_naming import normalize_component
 
 
 def safe_name(s: str) -> str:
     """Convert an arbitrary string to a valid Python/ophyd-async identifier.
 
-    Strips or replaces any character that is not alphanumeric or underscore,
-    collapses leading/trailing underscores, and lower-cases the result.
-    Returns ``"var"`` for strings that reduce to empty.
+    Delegates to the shared naming contract
+    (:func:`geecs_ca_gateway.pv_naming.normalize_component` — runs of
+    non-alphanumeric characters collapse to one underscore, lowercase), so a
+    GEECS name mangles identically whether it becomes a PV component or an
+    event-column component.  Returns ``"var"`` for strings that reduce to
+    empty (an identifier, unlike a PV component, must be non-empty).
     """
-    cleaned = re.sub(r"[^a-zA-Z0-9_]", "_", s).strip("_").lower()
-    return cleaned or "var"
+    return normalize_component(s) or "var"

--- a/GeecsBluesky/pyproject.toml
+++ b/GeecsBluesky/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-bluesky"
-version = "0.45.1"
+version = "0.46.0"
 description = "Bluesky / ophyd-async bridge for the GEECS control system"
 authors = ["Sam Barber <sbarber@lbl.gov>"]
 readme = "README.md"

--- a/GeecsBluesky/tests/test_action_signals.py
+++ b/GeecsBluesky/tests/test_action_signals.py
@@ -36,7 +36,7 @@ def test_settable_pv_has_no_transport_scheme() -> None:
     factory = CaActionSignalFactory("Undulator", _Recorder(), mock=True)
     settable = factory.get_settable("U_ESP_JetXYZ", "Position.Axis 1")
     assert not settable._pv.startswith("ca://")
-    assert settable._pv == "Undulator:U_ESP_JetXYZ:Position_Axis_1:SP"
+    assert settable._pv == "undulator:u_esp_jetxyz:position_axis_1:SP"
     # the probe keeps the ophyd signal-URI form (ophyd handles the scheme)
 
 

--- a/GeecsBluesky/tests/test_ca_devices.py
+++ b/GeecsBluesky/tests/test_ca_devices.py
@@ -42,15 +42,15 @@ from geecs_ca_gateway.pv_naming import normalize_component, pv_name  # noqa: E40
 
 def test_pv_name_policy() -> None:
     """Experiment prefix, dot-escaping, and space collapsing match the gateway."""
-    assert pv_name("Undulator", "U_S1H", "Current") == "Undulator:U_S1H:Current"
-    assert pv_name(None, "U_DG645", "Trigger.Source") == "U_DG645:Trigger_Source"
-    assert normalize_component("Beam Current (A)") == "Beam_Current_A"
+    assert pv_name("Undulator", "U_S1H", "Current") == "undulator:u_s1h:current"
+    assert pv_name(None, "U_DG645", "Trigger.Source") == "u_dg645:trigger_source"
+    assert normalize_component("Beam Current (A)") == "beam_current_a"
 
 
 def test_ca_pv_pins_the_transport_on_gateway_names() -> None:
     """ca_pv is pv_name with the explicit CA transport scheme prepended."""
-    assert ca_pv("Undulator", "U_S1H", "Current") == "ca://Undulator:U_S1H:Current"
-    assert ca_pv(None, "U_DG645", "Trigger.Source") == "ca://U_DG645:Trigger_Source"
+    assert ca_pv("Undulator", "U_S1H", "Current") == "ca://undulator:u_s1h:current"
+    assert ca_pv(None, "U_DG645", "Trigger.Source") == "ca://u_dg645:trigger_source"
 
 
 # --------------------------------------------------------------------------
@@ -108,7 +108,7 @@ async def test_every_ca_device_signal_pins_the_ca_transport() -> None:
         assert "ca://" in signal.source, signal.source
         assert signal.source.count("ca://") == 1, signal.source
     # Write PVs (":SP") pin the transport too, not just readbacks.
-    assert settable._setpoint.source.endswith("ca://Undulator:U_S1H:Current:SP")
+    assert settable._setpoint.source.endswith("ca://undulator:u_s1h:current:SP")
 
 
 async def test_ca_prefix_does_not_leak_into_event_keys_or_describe() -> None:
@@ -122,7 +122,7 @@ async def test_ca_prefix_does_not_leak_into_event_keys_or_describe() -> None:
     assert set(desc) == {"amp-centroidx", "amp-acq_timestamp"}
     assert set(reading) == {"amp-centroidx", "amp-acq_timestamp"}
     assert desc["amp-centroidx"]["source"] == (
-        "mock+ca://Undulator:UC_Amp2_IR_input:centroidx"
+        "mock+ca://undulator:uc_amp2_ir_input:centroidx"
     )
     # Exporter column headers keep the legacy "Device Variable" form.
     assert det._column_headers == {"amp-centroidx": "UC_Amp2_IR_input centroidx"}
@@ -142,7 +142,7 @@ async def test_readable_reads_value() -> None:
     set_mock_value(dev.centroidx, 42.0)
     reading = await dev.read()
     assert reading["amp-centroidx"]["value"] == 42.0
-    assert dev.centroidx.source.endswith("Undulator:UC_Amp2_IR_input:centroidx")
+    assert dev.centroidx.source.endswith("undulator:uc_amp2_ir_input:centroidx")
 
 
 async def test_readable_multiple_variables() -> None:
@@ -169,8 +169,8 @@ async def test_settable_forwards_put_to_setpoint() -> None:
     put = get_mock_put(dev._setpoint)
     put.assert_called_once()
     assert put.call_args.args[0] == 0.5
-    assert dev._setpoint.source.endswith("Undulator:U_S1H:Current:SP")
-    assert dev.readback.source.endswith("Undulator:U_S1H:Current")
+    assert dev._setpoint.source.endswith("undulator:u_s1h:current:SP")
+    assert dev.readback.source.endswith("undulator:u_s1h:current")
 
 
 async def test_settable_readback_is_the_reading() -> None:
@@ -198,7 +198,7 @@ async def test_motor_set_completes_on_arrival() -> None:
     put = get_mock_put(motor._setpoint)
     put.assert_called_once()
     assert put.call_args.args[0] == 4.5
-    assert motor._setpoint.source.endswith("Undulator:U_ESP_JetXYZ:Position_Axis_1:SP")
+    assert motor._setpoint.source.endswith("undulator:u_esp_jetxyz:position_axis_1:SP")
     reading = await motor.read()
     assert reading["jet-position"]["value"] == 4.5
 
@@ -242,10 +242,10 @@ async def test_confirm_writes_target_variable_reads_confirm_variable() -> None:
     device = _emq_confirm_device()
     await device.connect(mock=True)
     assert device._setpoint.source.endswith(
-        "Undulator:U_EMQTripletBipolar:Current_Limit_Ch1:SP"
+        "undulator:u_emqtripletbipolar:current_limit_ch1:SP"
     )
     assert device._confirm_readback.source.endswith(
-        "Undulator:U_EMQTripletBipolar:Current_Ch1"
+        "undulator:u_emqtripletbipolar:current_ch1"
     )
 
 
@@ -522,9 +522,9 @@ async def test_generic_detector_save_controls_over_ca() -> None:
     await det.connect(mock=True)
 
     assert det.localsavingpath.source.endswith(
-        "Undulator:UC_Amp2_IR_input:localsavingpath"
+        "undulator:uc_amp2_ir_input:localsavingpath"
     )
-    assert det.save.source.endswith("Undulator:UC_Amp2_IR_input:save")
+    assert det.save.source.endswith("undulator:uc_amp2_ir_input:save")
     await det.save.set("on")
     put = get_mock_put(det.save)
     put.assert_called_once()
@@ -656,7 +656,7 @@ async def test_snapshot_reads_latest_values() -> None:
     reading = await snap.read()
     assert reading["s1h-current"]["value"] == 0.5
     assert set(reading) == {"s1h-current", "s1h-voltage"}
-    assert snap.current.source.endswith("Undulator:U_S1H:Current")
+    assert snap.current.source.endswith("undulator:u_s1h:current")
 
 
 # --------------------------------------------------------------------------

--- a/GeecsBluesky/tests/test_free_run_plan.py
+++ b/GeecsBluesky/tests/test_free_run_plan.py
@@ -121,7 +121,7 @@ def test_free_run_scan_with_live_contributor() -> None:
         assert data["cam-shot_offset"] == 0
         assert data["cam-shot_id"] == data["ref-shot_id"]
         assert data["cam-val"] == 2.0
-        assert "async_snapshot-position__mm" in data
+        assert "async_snapshot-position_mm" in data
         assert "scan_motor-position" in data
     assert [ev["data"]["bin_number"] for ev in events] == [1, 1, 2, 2]
     assert [ev["data"]["shot_index_in_bin"] for ev in events] == [1, 2, 1, 2]

--- a/GeecsBluesky/tests/test_session.py
+++ b/GeecsBluesky/tests/test_session.py
@@ -57,10 +57,10 @@ def test_factories_build_connected_named_devices() -> None:
     jet = s.motor("U_ESP_JetXYZ", "Position.Axis 1")
 
     assert det.name == "uc_amp2_ir_input"
-    assert det.centroidx.source.endswith("Undulator:UC_Amp2_IR_input:centroidx")
-    assert con.acq_timestamp.source.endswith("Undulator:UC_TopView:acq_timestamp")
-    assert snap.current.source.endswith("Undulator:U_S1H:Current")
-    assert jet._setpoint.source.endswith("Undulator:U_ESP_JetXYZ:Position_Axis_1:SP")
+    assert det.centroidx.source.endswith("undulator:uc_amp2_ir_input:centroidx")
+    assert con.acq_timestamp.source.endswith("undulator:uc_topview:acq_timestamp")
+    assert snap.current.source.endswith("undulator:u_s1h:current")
+    assert jet._setpoint.source.endswith("undulator:u_esp_jetxyz:position_axis_1:SP")
 
 
 def test_construction_with_unreachable_tiled_server_is_prompt(
@@ -100,7 +100,7 @@ def test_shot_control_attaches_ca_controller() -> None:
     assert isinstance(controller, ShotController)
     setter = controller._setters["Trigger.Source"]
     assert isinstance(setter, CaPutSetter)
-    assert setter._pv == "Undulator:U_DG645_ShotControl:Trigger_Source:SP"
+    assert setter._pv == "undulator:u_dg645_shotcontrol:trigger_source:SP"
     assert s.shot_control(None) is None  # detaches
 
 
@@ -127,8 +127,8 @@ def test_shot_control_accepts_generalized_writes() -> None:
         setters[("U_DG645_ShotControl", "Amplitude.Ch AB")]._pv,
         setters[("U_PLC", "DO.Ch9")]._pv,
     } == {
-        "Undulator:U_DG645_ShotControl:Amplitude_Ch_AB:SP",
-        "Undulator:U_PLC:DO_Ch9:SP",
+        "undulator:u_dg645_shotcontrol:amplitude_ch_ab:SP",
+        "undulator:u_plc:do_ch9:SP",
     }
     # Empty writes detach, like an empty legacy config.
     assert s.shot_control(ShotControlWrites(name="empty", states={})) is None
@@ -141,11 +141,11 @@ def test_action_signal_factory_builds_cached_connected_signals() -> None:
     s = _session()
     factory = s.action_signal_factory()
     settable = factory.get_settable("U_PLC", "DO.Ch9")
-    assert settable._pv.endswith("Undulator:U_PLC:DO_Ch9:SP")
+    assert settable._pv.endswith("undulator:u_plc:do_ch9:SP")
     # Cached per (device, variable): the same wrapper comes back.
     assert factory.get_settable("U_PLC", "DO.Ch9") is settable
     readable = factory.get_readable("U_PLC", "DI.Ch17")
-    assert readable.source.endswith("Undulator:U_PLC:DI_Ch17")
+    assert readable.source.endswith("undulator:u_plc:di_ch17")
     assert factory.get_readable("U_PLC", "DI.Ch17") is readable
 
     # Values are coerced to wire strings on set (mock session records the
@@ -285,8 +285,8 @@ def test_shot_control_reachability_check_passes(
     assert isinstance(controller, ShotController)
     assert seen == [
         [
-            "Undulator:U_DG645_ShotControl:Trigger_ExecuteSingleShot:SP",
-            "Undulator:U_DG645_ShotControl:Trigger_Source:SP",
+            "undulator:u_dg645_shotcontrol:trigger_executesingleshot:SP",
+            "undulator:u_dg645_shotcontrol:trigger_source:SP",
         ]
     ]
 

--- a/GeecsBluesky/tests/test_telemetry_device.py
+++ b/GeecsBluesky/tests/test_telemetry_device.py
@@ -120,7 +120,7 @@ async def test_mixed_numeric_and_string_vars_both_logged(monkeypatch) -> None:
         monkeypatch,
         "U_VisaPlungers",
         ["Pressure", "DigitalOutput.Channel 3"],
-        {"Pressure": float, "Channel_3": str},
+        {"pressure": float, "channel_3": str},
         name="telemetry_visaplungers",
     )
     await dev.connect(mock=True)  # must NOT raise a type-coercion error
@@ -155,7 +155,7 @@ async def test_failed_read_of_string_signal_degrades_to_empty_string(
         monkeypatch,
         "U_VisaPlungers",
         ["Pressure", "DigitalOutput.Channel 3"],
-        {"Pressure": float, "Channel_3": str},
+        {"pressure": float, "channel_3": str},
         name="telemetry_visaplungers",
     )
     await dev.connect(mock=True)

--- a/GeecsBluesky/tests/test_timestamped_readable.py
+++ b/GeecsBluesky/tests/test_timestamped_readable.py
@@ -144,8 +144,8 @@ async def test_save_nonscalar_emits_save_path_column() -> None:
     cam.configure_shot_id(rep_rate_hz=1.0)
     # The writable save-control signals exist (used by the run wrapper to turn
     # native saving on/off through the gateway :SP PVs)
-    assert cam.localsavingpath.source.endswith("Test:U_Cam:localsavingpath")
-    assert cam.save.source.endswith("Test:U_Cam:save")
+    assert cam.localsavingpath.source.endswith("test:u_cam:localsavingpath")
+    assert cam.save.source.endswith("test:u_cam:save")
     cam.configure_nonscalar_file_logging("/data/Scan001/U_Cam")
 
     desc = await asyncio.wait_for(cam.describe(), timeout=3.0)

--- a/GeecsBluesky/tests/test_utils.py
+++ b/GeecsBluesky/tests/test_utils.py
@@ -16,11 +16,24 @@ from geecs_bluesky.devices.ca import (  # noqa: E402
 
 
 def test_safe_name_mangles_and_lowercases() -> None:
-    # Each non-alphanumeric char becomes "_"; adjacent specials (space + "(")
-    # collapse only via strip, so "Wavelength (nm)" keeps a double underscore.
-    assert safe_name("Wavelength (nm)") == "wavelength__nm"
+    # Runs of non-alphanumeric chars collapse to one "_" (the shared
+    # pv_naming.normalize_component policy), lowercase.
+    assert safe_name("Wavelength (nm)") == "wavelength_nm"
     assert safe_name("Position.Axis 1") == "position_axis_1"
     assert safe_name("") == "var"
+
+
+def test_safe_name_agrees_with_the_pv_naming_contract() -> None:
+    """One lossy encoding, not two: column components == PV components.
+
+    ``safe_name`` must stay a delegation to the gateway's
+    ``normalize_component`` (plus the non-empty fallback) so a GEECS name
+    mangles identically into an event column and a PV.
+    """
+    from geecs_ca_gateway.pv_naming import normalize_component
+
+    for raw in ("Position.Axis 1", "Amplitude.Ch AB", "Beam Current (A)", "ypos"):
+        assert safe_name(raw) == normalize_component(raw)
 
 
 def test_generic_detector_column_headers() -> None:
@@ -30,8 +43,8 @@ def test_generic_detector_column_headers() -> None:
         name="wavemeter",
     )
     assert det._column_headers == {
-        "wavemeter-wavelength__nm": "UC_Wavemeter Wavelength (nm)",
-        "wavemeter-power__mw": "UC_Wavemeter Power (mW)",
+        "wavemeter-wavelength_nm": "UC_Wavemeter Wavelength (nm)",
+        "wavemeter-power_mw": "UC_Wavemeter Power (mW)",
     }
 
 

--- a/GeecsCAGateway/CHANGELOG.md
+++ b/GeecsCAGateway/CHANGELOG.md
@@ -3,6 +3,28 @@
 All notable changes to `geecs-ca-gateway` are documented here, following
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and semantic versioning.
 
+## [0.14.0] - 2026-07-20
+
+### Changed
+
+- **PV name components are now lowercase** (`pv_naming.normalize_component`
+  case-folds): case carries no meaning anywhere in GEECS, and folding makes
+  every derived PV case-insensitive to operator input — any casing of a GEECS
+  name resolves to the same PV. Deployed PVs change on the wire
+  (`Undulator:U_S1H:Current` → `undulator:u_s1h:current`); the gateway and its
+  CA clients must be updated together. `PV_CONTRACT.md` §1 updated with the
+  case-folding step, lowercase examples, and the canonical-vocabulary
+  statement (GEECS-native names are canonical; PV names are a derived one-way
+  encoding).
+
+### Added
+
+- `pv_naming.setpoint_pv` (+ `SETPOINT_SUFFIX`): the one place the `:SP`
+  setpoint suffix is applied. The suffix itself stays uppercase — a fixed
+  structural literal, not a name component. Gateway pvdb construction and all
+  known consumers (GeecsBluesky, GEECS-Console) now use it instead of
+  hand-assembled `f"...:SP"` strings.
+
 ## [0.13.4] - 2026-07-15
 
 ### Changed

--- a/GeecsCAGateway/DEPLOYMENT.md
+++ b/GeecsCAGateway/DEPLOYMENT.md
@@ -279,22 +279,22 @@ EPICS base work identically). Substitute your experiment/device.
 ```bash
 # 1. Gateway process up and serving? (heartbeat ticks every 5 s)
 poetry run caproto-get Undulator:CAGateway:VERSION Undulator:CAGateway:UPTIME
-poetry run caproto-monitor Undulator:CAGateway:HEARTBEAT   # Ctrl-C after a couple of ticks
+poetry run caproto-monitor undulator:cagateway:heartbeat   # Ctrl-C after a couple of ticks
 
 # 2. Is a given device live behind it?
 poetry run caproto-get Undulator:U_S1H:CONNECTED           # → Connected
 poetry run caproto-get Undulator:CAGateway:DEVICES_CONNECTED
 
 # 3. Readback streaming? (should tick with the device's ~1–5 Hz stream)
-poetry run caproto-monitor Undulator:U_S1H:Current
+poetry run caproto-monitor undulator:u_s1h:current
 
 # 3b. Derived readback loaded from the configs repo? (example: target chamber)
 poetry run caproto-get -a Undulator:TargetChamberPressure:Pressure
 
 # 4. Write path (pick a harmless settable variable; put-completion = GEECS
 #    convergence, so this blocks until the device converges)
-poetry run caproto-get Undulator:U_S1H:Current             # note the value
-poetry run caproto-put Undulator:U_S1H:Current:SP <same value>
+poetry run caproto-get undulator:u_s1h:current             # note the value
+poetry run caproto-put undulator:u_s1h:current:SP <same value>
 ```
 
 Interpretation:

--- a/GeecsCAGateway/DEPLOYMENT.md
+++ b/GeecsCAGateway/DEPLOYMENT.md
@@ -278,18 +278,18 @@ EPICS base work identically). Substitute your experiment/device.
 
 ```bash
 # 1. Gateway process up and serving? (heartbeat ticks every 5 s)
-poetry run caproto-get Undulator:CAGateway:VERSION Undulator:CAGateway:UPTIME
+poetry run caproto-get undulator:cagateway:version undulator:cagateway:uptime
 poetry run caproto-monitor undulator:cagateway:heartbeat   # Ctrl-C after a couple of ticks
 
 # 2. Is a given device live behind it?
-poetry run caproto-get Undulator:U_S1H:CONNECTED           # → Connected
-poetry run caproto-get Undulator:CAGateway:DEVICES_CONNECTED
+poetry run caproto-get undulator:u_s1h:connected           # → Connected
+poetry run caproto-get undulator:cagateway:devices_connected
 
 # 3. Readback streaming? (should tick with the device's ~1–5 Hz stream)
 poetry run caproto-monitor undulator:u_s1h:current
 
 # 3b. Derived readback loaded from the configs repo? (example: target chamber)
-poetry run caproto-get -a Undulator:TargetChamberPressure:Pressure
+poetry run caproto-get -a undulator:targetchamberpressure:pressure
 
 # 4. Write path (pick a harmless settable variable; put-completion = GEECS
 #    convergence, so this blocks until the device converges)
@@ -338,13 +338,13 @@ sudo systemctl enable --now geecs-ca-gateway
   poetry install && systemctl restart geecs-ca-gateway` — matching the
   existing GEECS master-GUI reboot pattern for device-set changes.
 - **DB edits don't need shell access**: any CA client can write the
-  `[Experiment:]CAGateway:RESTART` PV (devIocStats `SYSRESET` pattern) and
+  `[experiment:]cagateway:restart` PV (devIocStats `SYSRESET` pattern) and
   the gateway exits with code 86, which the unit's `RestartForceExitStatus`
   turns into a relaunch — serving the freshly edited device/get-list set a
   few seconds later. A Phoebus button, a GUI menu action, or a one-liner:
 
   ```bash
-  caproto-put Undulator:CAGateway:RESTART Restart
+  caproto-put undulator:cagateway:restart Restart
   ```
 - Later sharding for fault isolation = more units with different
   `--experiment`/subsystem configs; CA name resolution makes this invisible to

--- a/GeecsCAGateway/DESIGN.md
+++ b/GeecsCAGateway/DESIGN.md
@@ -155,7 +155,7 @@ Recorded so the next build phase doesn't relitigate them.
   per-camera IOCs coexist transparently.
 
 - **Naming policy (retrofit-expensive — locked first):**
-  - Namespace `[Experiment:]Device:Variable`, e.g. `Undulator:U_S1H:Current`.
+  - Namespace `[experiment:]device:variable` (lowercase components), e.g. `undulator:u_s1h:current`.
     The experiment prefix future-proofs against cross-experiment collisions
     (experiments are already separated in the DB).
   - Character mapping: within a component allow only `[A-Za-z0-9_]`; `:` is the

--- a/GeecsCAGateway/PV_CONTRACT.md
+++ b/GeecsCAGateway/PV_CONTRACT.md
@@ -33,7 +33,8 @@ in `DEPLOYMENT.md`.
 Example: `undulator:u_s1h:current` and `undulator:u_s1h:current:SP`.
 
 Every name **component** is lowercase (see normalization below); the only
-uppercase in the PV namespace is the literal `:SP` setpoint suffix.
+uppercase in the PV namespace are the fixed structural literals — the `:SP`
+setpoint suffix and the `.DESC` description-field suffix.
 
 - `:` is the **reserved namespace separator**, applied only between components
   (`pv_naming.pv_name`). It never appears inside a component.

--- a/GeecsCAGateway/PV_CONTRACT.md
+++ b/GeecsCAGateway/PV_CONTRACT.md
@@ -23,14 +23,17 @@ in `DEPLOYMENT.md`.
 ### Namespace
 
 ```
-[Experiment:]Device:Variable          readback
-[Experiment:]Device:Variable:SP       setpoint (only when the variable is settable)
-[Experiment:]Device:Variable          derived readback (when declared)
-[Experiment:]Device:CONNECTED         per-device status
-[Experiment:]CAGateway:<SUFFIX>       gateway self-diagnostics
+[experiment:]device:variable          readback
+[experiment:]device:variable:SP       setpoint (only when the variable is settable)
+[experiment:]device:variable          derived readback (when declared)
+[experiment:]device:connected         per-device status
+[experiment:]cagateway:<suffix>       gateway self-diagnostics
 ```
 
-Example: `Undulator:U_S1H:Current` and `Undulator:U_S1H:Current:SP`.
+Example: `undulator:u_s1h:current` and `undulator:u_s1h:current:SP`.
+
+Every name **component** is lowercase (see normalization below); the only
+uppercase in the PV namespace is the literal `:SP` setpoint suffix.
 
 - `:` is the **reserved namespace separator**, applied only between components
   (`pv_naming.pv_name`). It never appears inside a component.
@@ -45,7 +48,7 @@ Example: `Undulator:U_S1H:Current` and `Undulator:U_S1H:Current:SP`.
 
 ### Component normalization (`pv_naming.normalize_component`)
 
-Within a single component, only `[A-Za-z0-9_]` survives. The exact
+Within a single component, only `[a-z0-9_]` survives. The exact
 transformation is:
 
 1. Leading/trailing whitespace is stripped.
@@ -53,23 +56,37 @@ transformation is:
    parentheses, slashes, anything — collapses to a **single** underscore
    (regex `[^A-Za-z0-9_]+` → `_`).
 3. Leading and trailing underscores produced by step 2 are stripped.
+4. The result is **lowercased**. Case carries no meaning anywhere in GEECS,
+   and folding it here makes every derived name case-insensitive to operator
+   input: any casing of a GEECS name resolves to the same PV.
 
 Examples (each pinned by a test):
 
 | GEECS name           | PV component     | Why it matters |
 |----------------------|------------------|----------------|
-| `Trigger.Source`     | `Trigger_Source` | **The dot is critical**: EPICS parses `.` as the record/field separator, so `Dev:Trigger.Source` would read as field `.Source` of record `Dev:Trigger` |
-| `Jet X pos`          | `Jet_X_pos`      | spaces |
-| `Beam-Current (A)`   | `Beam_Current_A` | run of ` (` collapses to one `_`; trailing `)` stripped |
+| `Trigger.Source`     | `trigger_source` | **The dot is critical**: EPICS parses `.` as the record/field separator, so `Dev:Trigger.Source` would read as field `.Source` of record `Dev:Trigger` |
+| `Jet X pos`          | `jet_x_pos`      | spaces |
+| `Beam-Current (A)`   | `beam_current_a` | run of ` (` collapses to one `_`; trailing `)` stripped |
 | `  padded  name  `   | `padded_name`    | whitespace + run collapsing |
+| `MiXeD Case`         | `mixed_case`     | case-folded — PVs are case-insensitive to operator input |
 
 This policy lives in **`geecs_ca_gateway.pv_naming`** — the one module both the
 gateway (producer) and GeecsBluesky's CA devices (consumer) import — so the two
 sides can never drift. `geecs_ca_gateway.naming` is a thin re-export.
+GeecsBluesky's event-column mangling (`safe_name`) delegates to the same
+function, so a GEECS name mangles identically into a PV component and an
+event-document column component (pinned by
+`GeecsBluesky/tests/test_utils.py::test_safe_name_agrees_with_the_pv_naming_contract`).
+
+**GEECS-native names are the canonical vocabulary.** Configs, schemas, the
+DB, and every user-facing surface speak raw GEECS names; PV names (and event
+columns) are derived one-way encodings produced only by this module. Tools
+needing the reverse direction use the manifest (below), never string surgery.
 
 ### The mapping is lossy — use the manifest
 
-`Trigger.Source` and `Trigger Source` normalize to the same PV component.
+`Trigger.Source`, `Trigger Source`, and `trigger source` normalize to the
+same PV component.
 **Never reverse-engineer a GEECS name from a PV string.** The gateway holds the
 authoritative bidirectional map in `GeecsCaGateway.manifest`
 (`PV → (device, geecs_var, kind)` where kind is `"readback"`, `"setpoint"`,
@@ -79,7 +96,9 @@ source GEECS device whose frame drives the calculation.
 ### Setpoint PVs — `:SP`
 
 A variable whose **`devicetype_variable.set`** flag is `yes` gets a companion
-setpoint PV at the literal suffix `:SP` appended to the full readback name.
+setpoint PV at the literal suffix `:SP` appended to the full readback name
+(`pv_naming.setpoint_pv`, the one place the suffix is applied; the suffix is
+deliberately uppercase — a fixed structural literal, not a name component).
 Non-settable variables (including the intrinsic timestamp variables) have
 **no** `:SP` PV.
 
@@ -104,7 +123,7 @@ too. Pinned by the inheritance-chain tests in `tests/test_geecs_db.py`.
 
 ### Per-device status PV — `CONNECTED`
 
-Every device gets exactly one status PV: `[Experiment:]Device:CONNECTED`.
+Every device gets exactly one status PV: `[experiment:]device:connected`.
 
 - Type: enum with `enum_strings = ["Disconnected", "Connected"]`
   (index 0 = Disconnected, 1 = Connected).
@@ -114,13 +133,13 @@ Every device gets exactly one status PV: `[Experiment:]Device:CONNECTED`.
 
 ### Gateway self-diagnostics — the reserved `CAGateway` namespace
 
-`[Experiment:]CAGateway:{UPTIME, HEARTBEAT, DEVICES_CONNECTED, VERSION}`
+`[experiment:]cagateway:{uptime, heartbeat, devices_connected, version}`
 (devIocStats-style; updated by a 5 s status loop; `UPTIME` in seconds,
 `VERSION` is the installed package version). The `CAGateway` device component
 is **reserved**: a real GEECS device whose PVs would land there trips the
 collision guard at startup rather than silently clobbering the status PVs.
 
-**`[Experiment:]CAGateway:RESTART`** is the one *client-writable* PV in the
+**`[experiment:]cagateway:restart`** is the one *client-writable* PV in the
 namespace (the devIocStats `SYSRESET` pattern): an enum with states
 `["Idle", "Restart"]`. Writing `Restart` (label or index 1) makes the gateway
 shut down cleanly and exit with the restart code (86); under the shipped
@@ -346,7 +365,7 @@ Resolution quirks (all DB-driven, all pinned by tests):
 A variable's DB `description` (from the per-instance `variable` table,
 resolved through the capability inheritance chain like every other field) is
 served as the standard EPICS `.DESC` field: a read-only `<pv>.DESC` string
-channel, so `caget Undulator:U_S1H:Current.DESC` returns the text and Phoebus
+channel, so `caget undulator:u_s1h:current.DESC` returns the text and Phoebus
 / the archiver pick it up automatically. Only variables with a non-empty
 description get a `.DESC` entry (no empty descriptions are served). The text
 is clipped to the EPICS **DBR_STRING 40-character** limit at both the DB
@@ -461,10 +480,10 @@ At `pvdb` build time (startup), every PV registers in the manifest:
   `from_db_metadata` also dedupes rows defensively.
 - **Genuine collisions raise**: a *different* source mapping to an existing PV
   name (e.g. `Trigger.Source` and `Trigger Source` on one device, both
-  normalizing to `Trigger_Source`) raises `ValueError` at startup. Never a
+  normalizing to `trigger_source`) raises `ValueError` at startup. Never a
   silent clobber; the gateway refuses to start until the overlay renames one.
-- **The status namespace is reserved**: per-device `…:CONNECTED` and the
-  `[Experiment:]CAGateway:*` diagnostics go through the same guard, so a GEECS
+- **The status namespace is reserved**: per-device `…:connected` and the
+  `[experiment:]cagateway:*` diagnostics go through the same guard, so a GEECS
   variable named `CONNECTED` or a device named `CAGateway` is a startup error,
   not a shadowed status PV.
 
@@ -538,12 +557,13 @@ that branch and are part of this contract's target behavior.
 
 | Contract claim | Pinned by |
 |---|---|
-| Component normalization (dot, spaces, runs, strip) | `test_naming.py::test_dot_becomes_underscore`, `::test_spaces_collapse_to_underscores`, `::test_mixed_bad_chars_collapse` |
-| `[Experiment:]Device:Variable` assembly, prefix optional, overrides | `test_naming.py::test_pv_name_for_with_experiment_prefix`, `::test_pv_name_for_without_experiment`, `::test_variable_spec_explicit_pv_wins`, `::test_device_prefix_defaults_to_name`; `test_pv_contract.py::test_pv_name_drops_falsy_parts_and_normalizes` |
+| Component normalization (dot, spaces, runs, strip, lowercase) | `test_naming.py::test_dot_becomes_underscore`, `::test_spaces_collapse_to_underscores`, `::test_mixed_bad_chars_collapse`, `::test_components_are_lowercased` |
+| Event-column mangling delegates to the same policy | `GeecsBluesky/tests/test_utils.py::test_safe_name_agrees_with_the_pv_naming_contract` |
+| `[experiment:]device:variable` assembly (lowercase), prefix optional, overrides | `test_naming.py::test_pv_name_for_with_experiment_prefix`, `::test_pv_name_for_without_experiment`, `::test_variable_spec_explicit_pv_wins`, `::test_device_prefix_defaults_to_name`; `test_pv_contract.py::test_pv_name_drops_falsy_parts_and_normalizes` |
 | Manifest as authoritative map; `:SP` only when settable | `test_gateway.py::test_experiment_prefix_and_manifest`, `::test_pvdb_contains_readback_and_setpoint` |
 | Genuine collision raises; exact duplicates tolerated | `test_gateway.py::test_pv_name_collision_raises`; `test_config_from_db.py::test_from_db_metadata_dedupes_duplicate_variables` |
 | Reserved `CAGateway`/status namespace guarded | `test_gateway.py::test_pvdb_has_connected_and_gateway_status_pvs`; `test_pv_contract.py::test_status_pv_namespace_is_collision_guarded` |
-| `CAGateway:RESTART` triggers clean shutdown; `Idle` is a no-op; exit code 86 | `test_pv_contract.py::test_restart_pv_requests_clean_shutdown`; `test_gateway.py::test_run_returns_true_on_restart_request`; `test_entrypoint.py::test_main_exits_with_restart_code` |
+| `cagateway:restart` triggers clean shutdown; `Idle` is a no-op; exit code 86 | `test_pv_contract.py::test_restart_pv_requests_clean_shutdown`; `test_gateway.py::test_run_returns_true_on_restart_request`; `test_entrypoint.py::test_main_exits_with_restart_code` |
 | Readbacks client-read-only; setpoints writable | `test_gateway.py::test_readback_channels_deny_client_writes` |
 | Stream → readback; caput `:SP` → GEECS → readback | `test_gateway.py::test_stream_updates_readback`, `::test_setpoint_write_reaches_geecs` |
 | Failed GEECS set ⇒ CA put fails, value not stored | `test_pv_contract.py::test_setpoint_put_failure_leaves_value_unstored` |

--- a/GeecsCAGateway/deploy/README.md
+++ b/GeecsCAGateway/deploy/README.md
@@ -52,8 +52,8 @@ Then the smoke tests from `DEPLOYMENT.md` §4 — from a *different* machine, so
 subnet scoping and firewalls are exercised:
 
 ```bash
-caproto-get Undulator:CAGateway:VERSION Undulator:CAGateway:DEVICES_CONNECTED
-caproto-monitor Undulator:CAGateway:HEARTBEAT    # ticks every 5 s
+caproto-get undulator:cagateway:version undulator:cagateway:devices_connected
+caproto-monitor undulator:cagateway:heartbeat    # ticks every 5 s
 ```
 
 ## Upgrade / resync with the GEECS DB
@@ -72,7 +72,7 @@ on the lab subnet (the unit's `RestartForceExitStatus=86` relaunches the
 service, which rebuilds its config from the DB):
 
 ```bash
-caproto-put Undulator:CAGateway:RESTART Restart
+caproto-put undulator:cagateway:restart Restart
 ```
 
 ## CA alarm limits table
@@ -89,14 +89,14 @@ mysql --host=<db-host> --user=<db-user> --password <db-name> \
 
 The table is optional from the gateway's perspective: if it is absent, startup
 continues with no curated value alarms. After editing rows in `ca_alarm_limits`,
-restart through the service or `Undulator:CAGateway:RESTART` so the gateway
+restart through the service or `undulator:cagateway:restart` so the gateway
 reloads the DB-backed config.
 
 To smoke-test one configured row, drive the readback into one of its alarm
 bands and read the PV with status metadata:
 
 ```bash
-caproto-get -a Undulator:U_S1H:Current
+caproto-get -a undulator:u_s1h:current
 ```
 
 For example, with `high=2.5`, `hihi=4.5`, and the default high severity of

--- a/GeecsCAGateway/geecs_ca_gateway/demo.py
+++ b/GeecsCAGateway/geecs_ca_gateway/demo.py
@@ -8,9 +8,9 @@ It spins up an in-process ``FakeGeecsServer``, builds a gateway over it, perform
 an in-process self-check (stream → readback, and caput → GEECS → readback), then
 serves the PVs so you can poke them with real CA tools::
 
-    caget  U_ESP_JetXYZ:Position
-    camonitor U_ESP_JetXYZ:Position
-    caput  U_ESP_JetXYZ:Position:SP 4.2
+    caget  u_esp_jetxyz:position
+    camonitor u_esp_jetxyz:position
+    caput  u_esp_jetxyz:position:SP 4.2
 """
 
 from __future__ import annotations
@@ -22,6 +22,7 @@ from geecs_ca_gateway.testing.fake_device_server import FakeGeecsDevice, FakeGee
 
 from .config import DeviceSpec, GatewayConfig, VariableSpec
 from .gateway import GeecsCaGateway
+from .pv_naming import pv_name, setpoint_pv
 
 DEVICE_NAME = "U_ESP_JetXYZ"
 
@@ -61,10 +62,10 @@ async def main() -> None:
 
         # ---- in-process self-check (proves the two data paths) --------------
         await asyncio.sleep(0.5)  # let a couple of 5 Hz stream frames land
-        rb = gateway.pvdb[f"{DEVICE_NAME}:Position"]
+        rb = gateway.pvdb[pv_name(DEVICE_NAME, "Position")]
         print(f"\n[self-check] stream → readback: {DEVICE_NAME}:Position = {rb.value}")
 
-        sp = gateway.pvdb[f"{DEVICE_NAME}:Position:SP"]
+        sp = gateway.pvdb[setpoint_pv(pv_name(DEVICE_NAME, "Position"))]
         await sp.write(4.2)  # simulate a CA caput on the setpoint
         await asyncio.sleep(0.5)  # let the change stream back as a readback
         print(

--- a/GeecsCAGateway/geecs_ca_gateway/gateway.py
+++ b/GeecsCAGateway/geecs_ca_gateway/gateway.py
@@ -46,7 +46,7 @@ from .channels import (
 )
 from .config import GatewayConfig, VariableSpec
 from .derived import DerivedChannelSpec, ExpressionEvaluator, derived_pv_name
-from .pv_naming import pv_name
+from .pv_naming import pv_name, setpoint_pv
 
 logger = logging.getLogger(__name__)
 
@@ -224,7 +224,7 @@ class GeecsCaGateway:
                     )
 
                 if var.settable:
-                    sp_name = f"{full}:SP"
+                    sp_name = setpoint_pv(full)
                     if self._register(sp_name, dev.name, var.geecs_var, "setpoint"):
                         setter = self._make_setter(dev.name, var.geecs_var)
                         self.pvdb[sp_name] = make_setpoint_channel(var, setter)

--- a/GeecsCAGateway/geecs_ca_gateway/naming.py
+++ b/GeecsCAGateway/geecs_ca_gateway/naming.py
@@ -7,5 +7,6 @@ The normalization policy itself lives in :mod:`geecs_ca_gateway.pv_naming`
 from __future__ import annotations
 
 from geecs_ca_gateway.pv_naming import normalize_component as normalize_pv_component
+from geecs_ca_gateway.pv_naming import setpoint_pv
 
-__all__ = ["normalize_pv_component"]
+__all__ = ["normalize_pv_component", "setpoint_pv"]

--- a/GeecsCAGateway/geecs_ca_gateway/pv_naming.py
+++ b/GeecsCAGateway/geecs_ca_gateway/pv_naming.py
@@ -8,13 +8,19 @@ module both import — rather than being duplicated where it could drift.
 GEECS raw names are close to EPICS PV naming, which uses ``:`` as its hierarchy
 separator, but LabVIEW tolerates characters CA does not.  Within a single name
 *component* only ``[A-Za-z0-9_]`` is kept; every other run of characters maps to
-one ``_``.  The most important case is the **dot**: EPICS reads ``.`` as the
-record/field separator, so ``Trigger.Source`` must become ``Trigger_Source`` or
-clients would parse ``.Source`` as a field.
+one ``_``, and the result is lowercased.  The most important case is the
+**dot**: EPICS reads ``.`` as the record/field separator, so ``Trigger.Source``
+must become ``trigger_source`` or clients would parse ``.Source`` as a field.
 
-The mapping is deliberately **lossy** (``Trigger.Source`` and ``Trigger Source``
-both collapse to ``Trigger_Source``); the gateway keeps the authoritative
-``geecs_var ↔ PV`` manifest, so never reverse-engineer a GEECS name from a PV.
+The mapping is deliberately **lossy** (``Trigger.Source``, ``Trigger Source``,
+and ``trigger source`` all collapse to ``trigger_source``); the gateway keeps
+the authoritative ``geecs_var ↔ PV`` manifest, so never reverse-engineer a
+GEECS name from a PV.
+
+**GEECS-native names are the canonical vocabulary** (configs, schemas, the DB,
+every user-facing surface); PV names are a derived wire encoding produced only
+here, one-way.  The ``:SP`` setpoint suffix is part of the same contract and is
+applied only by :func:`setpoint_pv` — never hand-assemble it.
 """
 
 from __future__ import annotations
@@ -29,9 +35,12 @@ def normalize_component(name: str) -> str:
     """Return a Channel-Access-safe version of a single name component.
 
     Maps every run of characters outside ``[A-Za-z0-9_]`` (spaces, dots, dashes,
-    parentheses, …) to a single underscore and strips leading/trailing
-    underscores.  Does not touch ``:`` — that is the reserved namespace separator
-    applied by :func:`pv_name`, never inside a component.
+    parentheses, …) to a single underscore, strips leading/trailing
+    underscores, and **lowercases** the result — case carries no meaning
+    anywhere in GEECS, and case-folding here makes every derived name (PVs,
+    event columns) case-insensitive to operator input for free.  Does not
+    touch ``:`` — that is the reserved namespace separator applied by
+    :func:`pv_name`, never inside a component.
 
     Parameters
     ----------
@@ -41,9 +50,9 @@ def normalize_component(name: str) -> str:
     Returns
     -------
     str
-        A CA-safe name component.
+        A CA-safe, lowercase name component.
     """
-    return _INVALID.sub("_", name.strip()).strip("_")
+    return _INVALID.sub("_", name.strip()).strip("_").lower()
 
 
 def pv_name(*parts: str) -> str:
@@ -63,3 +72,28 @@ def pv_name(*parts: str) -> str:
         The full ``a:b:c`` PV name.
     """
     return ":".join(normalize_component(part) for part in parts if part)
+
+
+#: The setpoint-PV suffix — part of the naming contract (readback at
+#: ``[expt:]dev:var``, setpoint at ``[expt:]dev:var:SP``).
+SETPOINT_SUFFIX = ":SP"
+
+
+def setpoint_pv(readback_pv: str) -> str:
+    """Return the setpoint PV name for a readback PV name.
+
+    The one place the ``:SP`` suffix is applied.  Works on bare EPICS names
+    and on ``ca://``-schemed signal URIs alike (the suffix parses identically
+    either way).
+
+    Parameters
+    ----------
+    readback_pv : str
+        A full readback PV name, e.g. from :func:`pv_name`.
+
+    Returns
+    -------
+    str
+        The corresponding ``…:SP`` setpoint PV name.
+    """
+    return f"{readback_pv}{SETPOINT_SUFFIX}"

--- a/GeecsCAGateway/pyproject.toml
+++ b/GeecsCAGateway/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-ca-gateway"
-version = "0.13.4"
+version = "0.14.0"
 description = "EPICS Channel Access soft-IOC gateway exposing GEECS devices as PVs"
 authors = ["Sam Barber <sbarber@lbl.gov>"]
 readme = "README.md"

--- a/GeecsCAGateway/tests/test_config_from_db.py
+++ b/GeecsCAGateway/tests/test_config_from_db.py
@@ -179,12 +179,12 @@ def test_pvdb_built_from_db_spec_has_limits() -> None:
     # __init__ only builds the pvdb — no network until connect() is called.
     gw = GeecsCaGateway(GatewayConfig(devices=[spec]))
 
-    current = gw.pvdb["U_S1H:Current"]
+    current = gw.pvdb["u_s1h:current"]
     # display (informational) limits, not enforced control limits
     assert current.upper_disp_limit == 5.0
     assert current.lower_disp_limit == -5.0
     assert current.units == "A"
-    assert "U_S1H:Current:SP" in gw.pvdb  # settable -> setpoint exists
+    assert "u_s1h:current:SP" in gw.pvdb  # settable -> setpoint exists
 
 
 def test_from_db_metadata_dedupes_duplicate_variables() -> None:
@@ -211,7 +211,7 @@ def test_from_db_metadata_dedupes_duplicate_variables() -> None:
     assert len(spec.variables) == 1  # deduped
     # and building the gateway does not raise a spurious collision
     gw = GeecsCaGateway(GatewayConfig(devices=[spec]))
-    assert "Undulator:U_GhostFilters:Transmission_Channel11_Pos1" in gw.pvdb
+    assert "undulator:u_ghostfilters:transmission_channel11_pos1" in gw.pvdb
 
 
 def test_from_db_metadata_maps_variable_types() -> None:
@@ -422,7 +422,7 @@ def test_from_geecs_experiment_subscribed_only(monkeypatch) -> None:
     assert {v.geecs_var for v in by_name["U_A"].variables} == {"Current"}
     assert {v.geecs_var for v in by_name["U_B"].variables} == {"Current", "Voltage"}
     gw = GeecsCaGateway(cfg)
-    assert "Undulator:U_B:Voltage" in gw.pvdb
+    assert "undulator:u_b:voltage" in gw.pvdb
 
 
 def test_from_geecs_experiment_keeps_settable_only_devices(monkeypatch) -> None:
@@ -448,7 +448,7 @@ def test_from_geecs_experiment_keeps_settable_only_devices(monkeypatch) -> None:
     # control surface survives: only the settable variable, not the readback set
     assert {v.geecs_var for v in by_name["U_CTRL"].variables} == {"save"}
     gw = GeecsCaGateway(cfg)
-    assert "Undulator:U_CTRL:save:SP" in gw.pvdb
+    assert "undulator:u_ctrl:save:SP" in gw.pvdb
     # a device exposing nothing at all is dropped (no pointless connections)
     assert "U_IDLE" not in by_name
     # --no-settable restores the strict get-list behavior

--- a/GeecsCAGateway/tests/test_derived_channels.py
+++ b/GeecsCAGateway/tests/test_derived_channels.py
@@ -197,7 +197,7 @@ def test_derived_pvdb_has_numeric_readback_and_manifest() -> None:
     )
     gw = GeecsCaGateway(cfg)
 
-    pv = "Undulator:U_ChamberVac:Pressure"
+    pv = "undulator:u_chambervac:pressure"
     assert pv in gw.pvdb
     assert gw.pvdb[pv].units == "Torr"
     assert gw.pvdb[pv].precision == 4
@@ -244,8 +244,8 @@ async def test_derived_channel_updates_from_same_source_frame() -> None:
         gw = GeecsCaGateway(cfg)
         await gw.connect()
         await gw.subscribe()
-        raw = gw.pvdb["Undulator:U_DaqPad1:Analog_Input_10"]
-        pressure = gw.pvdb["Undulator:U_ChamberVac:Pressure"]
+        raw = gw.pvdb["undulator:u_daqpad1:analog_input_10"]
+        pressure = gw.pvdb["undulator:u_chambervac:pressure"]
         try:
             assert await _wait_until(lambda: pressure.value == pytest.approx(10.0))
             assert raw.value == pytest.approx(6.0)
@@ -284,10 +284,10 @@ async def test_derived_only_input_is_subscribed_without_raw_pv() -> None:
             ],
         )
         gw = GeecsCaGateway(cfg)
-        assert "Undulator:U_DaqPad1:Analog_Input_10" not in gw.pvdb
+        assert "undulator:u_daqpad1:analog_input_10" not in gw.pvdb
         await gw.connect()
         await gw.subscribe()
-        pressure = gw.pvdb["Undulator:U_ChamberVac:Pressure"]
+        pressure = gw.pvdb["undulator:u_chambervac:pressure"]
         try:
             assert await _wait_until(lambda: pressure.value == pytest.approx(1.0))
         finally:
@@ -335,7 +335,7 @@ async def test_cross_device_derived_channel_uses_latest_values() -> None:
         ],
     )
     gw = GeecsCaGateway(cfg)
-    permit = gw.pvdb["Undulator:LaserPermit:OK"]
+    permit = gw.pvdb["undulator:laserpermit:ok"]
     pressure_callback = gw._make_callback(cfg.devices[0])
     shutter_callback = gw._make_callback(cfg.devices[1])
 
@@ -393,7 +393,7 @@ async def test_cross_device_derived_channel_marks_stale_input_invalid() -> None:
         ],
     )
     gw = GeecsCaGateway(cfg)
-    permit = gw.pvdb["Undulator:LaserPermit:OK"]
+    permit = gw.pvdb["undulator:laserpermit:ok"]
     pressure_callback = gw._make_callback(cfg.devices[0])
     shutter_callback = gw._make_callback(cfg.devices[1])
 
@@ -446,7 +446,7 @@ async def test_cross_device_quiet_sources_mark_stale_invalid() -> None:
         ],
     )
     gw = GeecsCaGateway(cfg)
-    permit = gw.pvdb["Undulator:LaserPermit:OK"]
+    permit = gw.pvdb["undulator:laserpermit:ok"]
 
     await gw._make_callback(cfg.devices[0])({"Pressure": 1e-6})
     await gw._make_callback(cfg.devices[1])({"Ready": 1.0})
@@ -500,7 +500,7 @@ async def test_cross_device_source_disconnect_marks_dependent_derived_invalid() 
         ],
     )
     gw = GeecsCaGateway(cfg)
-    permit = gw.pvdb["Undulator:LaserPermit:OK"]
+    permit = gw.pvdb["undulator:laserpermit:ok"]
 
     await gw._make_callback(cfg.devices[0])({"Pressure": 1e-6})
     await gw._make_callback(cfg.devices[1])({"Ready": 1.0})
@@ -540,7 +540,7 @@ async def test_derived_expression_failure_marks_invalid_calc() -> None:
         ],
     )
     gw = GeecsCaGateway(cfg)
-    pressure = gw.pvdb["Undulator:U_ChamberVac:Pressure"]
+    pressure = gw.pvdb["undulator:u_chambervac:pressure"]
     callback = gw._make_callback(cfg.devices[0])
 
     await callback({"Analog Input 10": 2.0})
@@ -586,7 +586,7 @@ async def test_missing_derived_input_marks_invalid_udf() -> None:
         ],
     )
     gw = GeecsCaGateway(cfg)
-    pressure = gw.pvdb["Undulator:U_ChamberVac:Pressure"]
+    pressure = gw.pvdb["undulator:u_chambervac:pressure"]
     callback = gw._make_callback(cfg.devices[0])
 
     await callback({"Other Input": 5.0})
@@ -624,7 +624,7 @@ async def test_repeated_derived_failure_does_not_republish_invalid(monkeypatch) 
         ],
     )
     gw = GeecsCaGateway(cfg)
-    pressure = gw.pvdb["Undulator:U_ChamberVac:Pressure"]
+    pressure = gw.pvdb["undulator:u_chambervac:pressure"]
     callback = gw._make_callback(cfg.devices[0])
     writes = 0
     original_write = pressure.write
@@ -677,7 +677,7 @@ async def test_derived_reconnect_clears_invalid_even_when_value_unchanged() -> N
     gw = GeecsCaGateway(cfg, reconnect_min_s=0.2, reconnect_max_s=0.4)
     await gw.connect()
     await gw.subscribe()
-    pressure = gw.pvdb["Undulator:U_ChamberVac:Pressure"]
+    pressure = gw.pvdb["undulator:u_chambervac:pressure"]
     try:
         assert await _wait_until(lambda: pressure.value == pytest.approx(1.0))
         assert int(pressure.severity) == int(AlarmSeverity.NO_ALARM)

--- a/GeecsCAGateway/tests/test_gateway.py
+++ b/GeecsCAGateway/tests/test_gateway.py
@@ -26,6 +26,7 @@ from geecs_ca_gateway.gateway import GeecsCaGateway, _extract_timestamp
 pytestmark = pytest.mark.fake_server
 
 DEVICE = "U_ESP_JetXYZ"
+DEVICE_PV = "u_esp_jetxyz"  # pv_name(DEVICE) — PVs are lowercase
 LABVIEW_OFFSET = 2_082_844_800  # LabVIEW epoch (1904) → Unix epoch (1970)
 
 
@@ -142,10 +143,10 @@ def test_experiment_prefix_and_manifest() -> None:
         ]
     )
     gw = GeecsCaGateway(cfg)
-    assert "Undulator:U_S1H:Current" in gw.pvdb
-    assert "Undulator:U_S1H:Current:SP" in gw.pvdb
-    assert gw.manifest["Undulator:U_S1H:Current"] == ("U_S1H", "Current", "readback")
-    assert gw.manifest["Undulator:U_S1H:Current:SP"] == ("U_S1H", "Current", "setpoint")
+    assert "undulator:u_s1h:current" in gw.pvdb
+    assert "undulator:u_s1h:current:SP" in gw.pvdb
+    assert gw.manifest["undulator:u_s1h:current"] == ("U_S1H", "Current", "readback")
+    assert gw.manifest["undulator:u_s1h:current:SP"] == ("U_S1H", "Current", "setpoint")
 
 
 def test_description_served_as_desc_field() -> None:
@@ -168,11 +169,11 @@ def test_description_served_as_desc_field() -> None:
         ]
     )
     gw = GeecsCaGateway(cfg)
-    desc_pv = "Undulator:U_S1H:Current.DESC"
+    desc_pv = "undulator:u_s1h:current.DESC"
     assert desc_pv in gw.pvdb
     assert gw.pvdb[desc_pv].value == "S1H steering magnet current"
     # A variable with no description gets no .DESC entry.
-    assert "Undulator:U_S1H:Voltage.DESC" not in gw.pvdb
+    assert "undulator:u_s1h:voltage.DESC" not in gw.pvdb
 
 
 def test_pv_name_collision_raises() -> None:
@@ -198,11 +199,11 @@ def test_pv_name_collision_raises() -> None:
 async def test_pvdb_contains_readback_and_setpoint() -> None:
     """Settable variable yields both a readback and a ``:SP`` setpoint PV."""
     gw = GeecsCaGateway(_config("127.0.0.1", 1))
-    assert f"{DEVICE}:Position" in gw.pvdb
-    assert f"{DEVICE}:Position:SP" in gw.pvdb
+    assert f"{DEVICE_PV}:position" in gw.pvdb
+    assert f"{DEVICE_PV}:position:SP" in gw.pvdb
     # non-settable variable has no setpoint
-    assert f"{DEVICE}:acq_timestamp" in gw.pvdb
-    assert f"{DEVICE}:acq_timestamp:SP" not in gw.pvdb
+    assert f"{DEVICE_PV}:acq_timestamp" in gw.pvdb
+    assert f"{DEVICE_PV}:acq_timestamp:SP" not in gw.pvdb
 
 
 async def test_stream_updates_readback() -> None:
@@ -216,7 +217,7 @@ async def test_stream_updates_readback() -> None:
         await gw.subscribe()
         try:
             await asyncio.sleep(0.4)  # a couple of 5 Hz frames
-            assert gw.pvdb[f"{DEVICE}:Position"].value == pytest.approx(7.5)
+            assert gw.pvdb[f"{DEVICE_PV}:position"].value == pytest.approx(7.5)
         finally:
             await gw.close()
 
@@ -233,7 +234,7 @@ async def test_reconnect_and_validity() -> None:
     )
     await gw.connect()
     await gw.subscribe()
-    rb = gw.pvdb[f"{DEVICE}:Position"]
+    rb = gw.pvdb[f"{DEVICE_PV}:position"]
     try:
         # live: value flows and severity is clear
         assert await _wait_until(lambda: rb.value == pytest.approx(7.5))
@@ -265,7 +266,7 @@ async def test_value_alarm_limits_set_live_readback_severity() -> None:
     """Curated scalar limits set MINOR/MAJOR severity on live values."""
     cfg = _alarm_config()
     gw = GeecsCaGateway(cfg)
-    rb = gw.pvdb[f"{DEVICE}:Position"]
+    rb = gw.pvdb[f"{DEVICE_PV}:position"]
     callback = gw._make_callback(cfg.devices[0])
 
     await callback({"Position": 7.0})
@@ -303,7 +304,7 @@ async def test_high_only_alarm_row_does_not_trigger_native_low_alarm() -> None:
         ]
     )
     gw = GeecsCaGateway(cfg)
-    rb = gw.pvdb[f"{DEVICE}:Position"]
+    rb = gw.pvdb[f"{DEVICE_PV}:position"]
     callback = gw._make_callback(cfg.devices[0])
 
     await callback({"Position": -1.0})
@@ -332,7 +333,7 @@ async def test_alarm_hysteresis_holds_hihi_before_stepping_down() -> None:
         ]
     )
     gw = GeecsCaGateway(cfg)
-    rb = gw.pvdb[f"{DEVICE}:Position"]
+    rb = gw.pvdb[f"{DEVICE_PV}:position"]
     callback = gw._make_callback(cfg.devices[0])
 
     await callback({"Position": 5.1})
@@ -351,7 +352,7 @@ async def test_invalid_liveness_overrides_value_alarm_until_live_frame() -> None
     """A disconnect still reports INVALID/COMM; the next live value recomputes."""
     cfg = _alarm_config()
     gw = GeecsCaGateway(cfg)
-    rb = gw.pvdb[f"{DEVICE}:Position"]
+    rb = gw.pvdb[f"{DEVICE_PV}:position"]
     callback = gw._make_callback(cfg.devices[0])
 
     await callback({"Position": 7.0})
@@ -386,12 +387,12 @@ async def test_timestamp_vars_exposed_as_pvs_with_raw_value() -> None:
         )
         gw = GeecsCaGateway(cfg)
         # both intrinsic timestamp vars get PVs (acq even if this device won't push it)
-        assert f"{DEVICE}:systimestamp" in gw.pvdb
-        assert f"{DEVICE}:acq_timestamp" in gw.pvdb
+        assert f"{DEVICE_PV}:systimestamp" in gw.pvdb
+        assert f"{DEVICE_PV}:acq_timestamp" in gw.pvdb
         await gw.connect()
         await gw.subscribe()
         try:
-            rb = gw.pvdb[f"{DEVICE}:systimestamp"]
+            rb = gw.pvdb[f"{DEVICE_PV}:systimestamp"]
             # RAW LabVIEW value, not unix-converted
             assert await _wait_until(lambda: rb.value == pytest.approx(labview))
         finally:
@@ -418,7 +419,7 @@ async def test_pv_timestamp_from_systimestamp() -> None:
         gw = GeecsCaGateway(cfg)
         await gw.connect()
         await gw.subscribe()
-        rb = gw.pvdb[f"{DEVICE}:Position"]
+        rb = gw.pvdb[f"{DEVICE_PV}:position"]
         try:
             assert await _wait_until(lambda: rb.value == pytest.approx(3.3))
             assert rb.timestamp == pytest.approx(1782949690.5, abs=1e-3)
@@ -456,8 +457,8 @@ async def test_enum_readback_and_setpoint() -> None:
         gw = GeecsCaGateway(cfg)
         await gw.connect()
         await gw.subscribe()
-        rb = gw.pvdb[f"{DEVICE}:Enable_Output"]
-        sp = gw.pvdb[f"{DEVICE}:Enable_Output:SP"]
+        rb = gw.pvdb[f"{DEVICE_PV}:enable_output"]
+        sp = gw.pvdb[f"{DEVICE_PV}:enable_output:SP"]
         try:
             # readback: GEECS "off" string -> enum label "off"
             assert await _wait_until(lambda: _enum_label(rb) == "off")
@@ -489,7 +490,7 @@ async def test_deadband_suppresses_small_changes() -> None:
         gw = GeecsCaGateway(cfg)
         await gw.connect()
         await gw.subscribe()
-        rb = gw.pvdb[f"{DEVICE}:Pos"]
+        rb = gw.pvdb[f"{DEVICE_PV}:pos"]
         try:
             assert await _wait_until(lambda: rb.value == pytest.approx(5.0))
             # within deadband (0.05 <= 0.1): suppressed, value stays 5.0
@@ -522,7 +523,7 @@ async def test_nan_readback_accepted_despite_limits() -> None:
         gw = GeecsCaGateway(cfg)
         await gw.connect()
         await gw.subscribe()
-        rb = gw.pvdb[f"{DEVICE}:Pos"]
+        rb = gw.pvdb[f"{DEVICE_PV}:pos"]
         try:
             await asyncio.sleep(0.4)
             value = rb.value
@@ -555,7 +556,7 @@ async def test_uncoercible_value_warns_once_and_skips() -> None:
         try:
             await asyncio.sleep(0.5)  # several 5 Hz frames of the bad value
             # value skipped (PV stays at initial), no crash, warned exactly once
-            assert gw.pvdb[f"{DEVICE}:Pos"].value == pytest.approx(0.0)
+            assert gw.pvdb[f"{DEVICE_PV}:pos"].value == pytest.approx(0.0)
             assert (DEVICE, "Pos") in gw._coerce_warned
         finally:
             await gw.close()
@@ -571,11 +572,11 @@ async def test_setpoint_write_reaches_geecs() -> None:
         await gw.connect()
         await gw.subscribe()
         try:
-            await gw.pvdb[f"{DEVICE}:Position:SP"].write(4.2)
+            await gw.pvdb[f"{DEVICE_PV}:position:SP"].write(4.2)
             assert device.get("Position") == pytest.approx(4.2)
             # and the change streams back into the readback
             await asyncio.sleep(0.4)
-            assert gw.pvdb[f"{DEVICE}:Position"].value == pytest.approx(4.2)
+            assert gw.pvdb[f"{DEVICE_PV}:position"].value == pytest.approx(4.2)
         finally:
             await gw.close()
 
@@ -685,11 +686,11 @@ def test_pvdb_has_connected_and_gateway_status_pvs() -> None:
     )
     gw = GeecsCaGateway(GatewayConfig(devices=[spec]))
 
-    assert "Test:U_Dev:CONNECTED" in gw.pvdb
-    assert str(gw.pvdb["Test:U_Dev:CONNECTED"].value) == "Disconnected"
-    for suffix in ("UPTIME", "HEARTBEAT", "DEVICES_CONNECTED", "VERSION"):
-        assert f"Test:CAGateway:{suffix}" in gw.pvdb
-    assert gw.manifest["Test:U_Dev:CONNECTED"] == ("U_Dev", "CONNECTED", "status")
+    assert "test:u_dev:connected" in gw.pvdb
+    assert str(gw.pvdb["test:u_dev:connected"].value) == "Disconnected"
+    for suffix in ("uptime", "heartbeat", "devices_connected", "version"):
+        assert f"test:cagateway:{suffix}" in gw.pvdb
+    assert gw.manifest["test:u_dev:connected"] == ("U_Dev", "CONNECTED", "status")
 
 
 async def test_set_connected_updates_pv_severity_and_count() -> None:
@@ -706,15 +707,15 @@ async def test_set_connected_updates_pv_severity_and_count() -> None:
     gw = GeecsCaGateway(GatewayConfig(devices=[spec]))
 
     await gw._set_connected("U_Dev", True)
-    conn = gw.pvdb["Test:U_Dev:CONNECTED"]
+    conn = gw.pvdb["test:u_dev:connected"]
     assert str(conn.value) == "Connected"
     assert conn.alarm.severity == AlarmSeverity.NO_ALARM
-    assert gw.pvdb["Test:CAGateway:DEVICES_CONNECTED"].value in (1, [1])
+    assert gw.pvdb["test:cagateway:devices_connected"].value in (1, [1])
 
     await gw._set_connected("U_Dev", False)
     assert str(conn.value) == "Disconnected"
     assert conn.alarm.severity == AlarmSeverity.MAJOR_ALARM
-    assert gw.pvdb["Test:CAGateway:DEVICES_CONNECTED"].value in (0, [0])
+    assert gw.pvdb["test:cagateway:devices_connected"].value in (0, [0])
 
 
 # ---------------------------------------------------------------------------
@@ -756,7 +757,7 @@ async def test_setpoint_write_uses_move_budget_timeout() -> None:
     udp = _RecordingUdp(device_name=DEVICE)
     gw._udp[DEVICE] = udp
 
-    await gw.pvdb[f"{DEVICE}:Position:SP"].write(4.2)
+    await gw.pvdb[f"{DEVICE_PV}:position:SP"].write(4.2)
 
     assert len(udp.set_calls) == 1
     variable, value, timeout = udp.set_calls[0]
@@ -772,7 +773,7 @@ async def test_set_timeout_is_configurable() -> None:
     udp = _RecordingUdp(device_name=DEVICE)
     gw._udp[DEVICE] = udp
 
-    await gw.pvdb[f"{DEVICE}:Position:SP"].write(1.0)
+    await gw.pvdb[f"{DEVICE_PV}:position:SP"].write(1.0)
 
     assert udp.set_calls[0][2] == pytest.approx(45.0)
 
@@ -850,7 +851,7 @@ async def test_setpoint_write_without_udp_client_raises_cleanly() -> None:
 
     gw = GeecsCaGateway(_config("127.0.0.1", 1))  # connect() never called
     with pytest.raises(GeecsConnectionError, match="bind failed at startup"):
-        await gw.pvdb[f"{DEVICE}:Position:SP"].write(1.0)
+        await gw.pvdb[f"{DEVICE_PV}:position:SP"].write(1.0)
 
 
 class _ValueRecordingChannel:
@@ -937,5 +938,5 @@ async def test_run_returns_true_on_restart_request(monkeypatch) -> None:
     await asyncio.sleep(0.05)
     assert not run_task.done()  # serving; no restart requested yet
 
-    await gw.pvdb["CAGateway:RESTART"].write("Restart")
+    await gw.pvdb["cagateway:restart"].write("Restart")
     assert await asyncio.wait_for(run_task, timeout=5) is True

--- a/GeecsCAGateway/tests/test_naming.py
+++ b/GeecsCAGateway/tests/test_naming.py
@@ -8,32 +8,32 @@ from geecs_ca_gateway.naming import normalize_pv_component
 
 def test_spaces_collapse_to_underscores() -> None:
     """GEECS variable names with spaces become CA-safe underscores."""
-    assert normalize_pv_component("Jet X pos") == "Jet_X_pos"
+    assert normalize_pv_component("Jet X pos") == "jet_x_pos"
     assert normalize_pv_component("  padded  name  ") == "padded_name"
 
 
 def test_dot_becomes_underscore() -> None:
     """The dot is critical: EPICS reads it as the record/field separator."""
-    assert normalize_pv_component("Trigger.Source") == "Trigger_Source"
+    assert normalize_pv_component("Trigger.Source") == "trigger_source"
 
 
 def test_mixed_bad_chars_collapse() -> None:
     """Dashes, parens, and other non-[A-Za-z0-9_] chars map to single ``_``."""
-    assert normalize_pv_component("Beam-Current (A)") == "Beam_Current_A"
+    assert normalize_pv_component("Beam-Current (A)") == "beam_current_a"
 
 
 def test_pv_name_for_with_experiment_prefix() -> None:
     """Experiment prefix yields ``Experiment:Device:Variable``."""
     dev = DeviceSpec(name="U_S1H", host="h", port=1, experiment="Undulator")
     assert (
-        dev.pv_name_for(VariableSpec(geecs_var="Current")) == "Undulator:U_S1H:Current"
+        dev.pv_name_for(VariableSpec(geecs_var="Current")) == "undulator:u_s1h:current"
     )
 
 
 def test_pv_name_for_without_experiment() -> None:
     """No experiment prefix yields ``Device:Variable``."""
     dev = DeviceSpec(name="U_S1H", host="h", port=1)
-    assert dev.pv_name_for(VariableSpec(geecs_var="Current")) == "U_S1H:Current"
+    assert dev.pv_name_for(VariableSpec(geecs_var="Current")) == "u_s1h:current"
 
 
 def test_pv_name_for_normalizes_variable_dot() -> None:
@@ -41,23 +41,31 @@ def test_pv_name_for_normalizes_variable_dot() -> None:
     dev = DeviceSpec(name="U_DG645", host="h", port=1)
     assert (
         dev.pv_name_for(VariableSpec(geecs_var="Trigger.Source"))
-        == "U_DG645:Trigger_Source"
+        == "u_dg645:trigger_source"
     )
 
 
 def test_variable_spec_default_suffix_normalizes() -> None:
     """A VariableSpec with no explicit ``pv`` normalizes the GEECS var name."""
     spec = VariableSpec(geecs_var="Beam Current")
-    assert spec.pv_suffix == "Beam_Current"
+    assert spec.pv_suffix == "beam_current"
 
 
 def test_variable_spec_explicit_pv_wins() -> None:
     """An explicit ``pv`` overrides the derived suffix."""
     spec = VariableSpec(geecs_var="acq_timestamp", pv="AcqTime")
-    assert spec.pv_suffix == "AcqTime"
+    assert spec.pv_suffix == "acqtime"
 
 
 def test_device_prefix_defaults_to_name() -> None:
     """``pv_prefix`` falls back to the device name when unset."""
     dev = DeviceSpec(name="U_HexapodXYZ", host="127.0.0.1", port=1)
     assert dev.pv_prefix == "U_HexapodXYZ"
+
+
+def test_components_are_lowercased() -> None:
+    """Case carries no meaning: all derived PV components are lowercase."""
+    assert normalize_pv_component("MiXeD Case") == "mixed_case"
+    dev = DeviceSpec(name="U_S1H", host="h", port=1, experiment="Undulator")
+    pv = dev.pv_name_for(VariableSpec(geecs_var="Trigger.Source"))
+    assert pv == pv.lower()

--- a/GeecsCAGateway/tests/test_pv_contract.py
+++ b/GeecsCAGateway/tests/test_pv_contract.py
@@ -36,11 +36,11 @@ def test_pv_name_drops_falsy_parts_and_normalizes() -> None:
     part simply drops out of the ``:``-join — and ``:`` is applied only between
     components, never inside one.
     """
-    assert pv_name("", "U_S1H", "Current") == "U_S1H:Current"
-    assert pv_name(None, "U_S1H", "Current") == "U_S1H:Current"
+    assert pv_name("", "U_S1H", "Current") == "u_s1h:current"
+    assert pv_name(None, "U_S1H", "Current") == "u_s1h:current"
     assert (
         pv_name("Undulator", "U DG645", "Trigger.Source")
-        == "Undulator:U_DG645:Trigger_Source"
+        == "undulator:u_dg645:trigger_source"
     )
 
 
@@ -226,7 +226,7 @@ async def test_restart_pv_requests_clean_shutdown() -> None:
         ]
     )
     gw = GeecsCaGateway(cfg)
-    restart = gw.pvdb["Undulator:CAGateway:RESTART"]
+    restart = gw.pvdb["undulator:cagateway:restart"]
 
     await restart.write("Idle")
     await restart.write(0)
@@ -237,5 +237,5 @@ async def test_restart_pv_requests_clean_shutdown() -> None:
 
     # index form works too (fresh gateway — the event latches)
     gw2 = GeecsCaGateway(cfg)
-    await gw2.pvdb["Undulator:CAGateway:RESTART"].write(1)
+    await gw2.pvdb["undulator:cagateway:restart"].write(1)
     assert gw2._restart_requested.is_set()

--- a/docs/geecs_console/troubleshooting.md
+++ b/docs/geecs_console/troubleshooting.md
@@ -7,7 +7,7 @@ the triage tools.
 
 | Chip | Down means | First checks |
 |---|---|---|
-| **Gateway** | The CA gateway isn't serving PVs — no readbacks, no scans | Is the gateway service running on the lab server? `caget <Expt>:CAGateway:HEARTBEAT` |
+| **Gateway** | The CA gateway isn't serving PVs — no readbacks, no scans | Is the gateway service running on the lab server? `caget <expt>:cagateway:heartbeat` |
 | **Tiled** | Runs won't be archived / browser has nothing to read | Tiled service on the lab server; the `[tiled] uri` in `config.ini` |
 | **DB** | Name completion and DB-driven variable lists unavailable | MySQL on the lab server; credentials chain in `config.ini` |
 

--- a/docs/geecs_gateway/client_overview.md
+++ b/docs/geecs_gateway/client_overview.md
@@ -29,20 +29,22 @@ as the source of truth if anything here and there ever disagree.
 A PV name is the GEECS names joined by `:`, one component per level:
 
 ```
-[Experiment:]Device:Variable          readback
-[Experiment:]Device:Variable:SP       setpoint (only when the variable is settable)
+[experiment:]device:variable          readback
+[experiment:]device:variable:SP       setpoint (only when the variable is settable)
 [Experiment:]Device:CONNECTED         per-device liveness
 ```
 
-Example: `Undulator:U_S1H:Current` and its setpoint `Undulator:U_S1H:Current:SP`.
+Example: `undulator:u_s1h:current` and its setpoint `undulator:u_s1h:current:SP`.
+Every name component is lowercase — any casing of a GEECS name resolves to
+the same PV; the only uppercase in the namespace is the literal `:SP` suffix.
 
 **Within a component**, only `[A-Za-z0-9_]` survive: dots, spaces, dashes,
 parentheses — any run of other characters — collapse to a single underscore
-(`Trigger.Source` → `Trigger_Source`, `Jet X pos` → `Jet_X_pos`). The dot
+(`Trigger.Source` → `trigger_source`, `Jet X pos` → `jet_x_pos`). The dot
 collapse matters because EPICS reads `.` as the record/field separator.
 
 The mapping is **lossy** — `Trigger.Source` and `Trigger Source` both normalize
-to `Trigger_Source` — so never reverse-engineer a GEECS name from a PV string.
+to `trigger_source` — so never reverse-engineer a GEECS name from a PV string.
 The gateway holds the authoritative reverse map (`PV → (device, variable,
 kind)`) in its manifest, and a genuine collision is a startup error, never a
 silent clobber.

--- a/docs/geecs_gateway/client_overview.md
+++ b/docs/geecs_gateway/client_overview.md
@@ -31,12 +31,13 @@ A PV name is the GEECS names joined by `:`, one component per level:
 ```
 [experiment:]device:variable          readback
 [experiment:]device:variable:SP       setpoint (only when the variable is settable)
-[Experiment:]Device:CONNECTED         per-device liveness
+[experiment:]device:connected         per-device liveness
 ```
 
 Example: `undulator:u_s1h:current` and its setpoint `undulator:u_s1h:current:SP`.
 Every name component is lowercase — any casing of a GEECS name resolves to
-the same PV; the only uppercase in the namespace is the literal `:SP` suffix.
+the same PV; the only uppercase in the namespace are the fixed structural
+literals `:SP` and `.DESC`.
 
 **Within a component**, only `[A-Za-z0-9_]` survive: dots, spaces, dashes,
 parentheses — any run of other characters — collapse to a single underscore
@@ -67,7 +68,7 @@ variables are served as char-array (long-string) PVs — read/write them with
 
 ## Liveness — the `CONNECTED` PV
 
-Every device has one `[Experiment:]Device:CONNECTED` PV: an enum
+Every device has one `[experiment:]device:connected` PV: an enum
 (`Disconnected` / `Connected`), `MAJOR_ALARM` while the device's TCP
 subscription is down. **Prefer it as the liveness signal** over inferring
 liveness from data — the gateway serves a device's data PVs whether or not the

--- a/docs/geecs_schemas/schema_reference.md
+++ b/docs/geecs_schemas/schema_reference.md
@@ -489,7 +489,7 @@ One read-only float PV computed from a numeric expression.
 
 | Field | Type | Required | Default | What it does |
 |---|---|---|---|---|
-| `device` | `str` | yes | — | Device component of the output PV, e.g. 'U_ChamberVac' for 'Undulator:U_ChamberVac:Pressure'. This may be semantic and does not need to be a real GEECS hardware device. |
+| `device` | `str` | yes | — | Device component of the output PV, e.g. 'U_ChamberVac' for 'undulator:u_chambervac:pressure'. This may be semantic and does not need to be a real GEECS hardware device. |
 | `variable` | `str` | yes | — | Variable component of the output PV, e.g. 'Pressure'. The gateway normalizes it using the same rules as raw GEECS variables. |
 | `expression` | `str` | yes | — | Numeric formula for the output value, using input symbols and the gateway's restricted arithmetic subset. Example: '10**(v - 5)'. |
 | `inputs` | `list[DerivedInput]` | yes | — | Input variables available to the expression. Inputs from one source device are frame-coherent; inputs spanning devices use latest-value semantics and require stale_after. |


### PR DESCRIPTION
## What

Standardizes the naming boundary decided in today's design discussion: **GEECS-native names are the canonical vocabulary; PV names and event-column names are ONE derived lowercase encoding**, produced only by `pv_naming`.

- **`normalize_component` case-folds** — every PV component is lowercase (`Undulator:U_S1H:Current` → `undulator:u_s1h:current`). Case carries no meaning anywhere in GEECS; folding makes every derived name case-insensitive to operator input for free (any casing typed into the console R7 combo resolves to the same PV).
- **`pv_naming.setpoint_pv` + `SETPOINT_SUFFIX`** — the one place the `:SP` suffix is applied. Gateway pvdb build, GeecsBluesky (`shot_controller`, `settable`, `timestamped_readable`, `generic_detector`, `action_signals`, re-export via `devices/ca/_pv.py`), and the console R7 backend all use it; zero hand-built `f"...:SP"` strings remain.
- **`safe_name` delegates to `normalize_component`** (+ the non-empty `"var"` fallback) — event-document columns and PV components now mangle identically; the agreement is pinned by a new cross-check test. Column-name change: runs of specials collapse to one underscore (`Wavelength (nm)` → `wavelength_nm`, was `wavelength__nm`).
- **Contracts updated in the same PR** (per the gateway's contract rule): `PV_CONTRACT.md` §1 (case-fold step, lowercase examples/status namespace, canonical-vocabulary statement, `setpoint_pv`, test map), `EVENT_SCHEMA.md` (column-convention note; schema version stays 1 — runs are self-describing, pre-0.46.0 runs remain readable via `geecs_scalar_headers`), `DEPLOYMENT.md` smoke-test PVs, `docs/geecs_gateway/client_overview.md`, CLAUDE.md placeholders.

## Why

The console R7 investigation surfaced the naming conflation: three vocabularies (GEECS raw, gateway PV, event columns) with two independent lossy normalizers and case-sensitivity nobody wants. Owner decision (2026-07-20): lowercase everything, unify the normalizers, do it now while pre-production (Phoebus screens are play-only; Tiled may be purged, though it doesn't need to be).

## Per-concern LOC (production code)

| Concern | Files | ~LOC |
|---|---|---|
| Case-fold + `setpoint_pv` helper (`pv_naming.py`) | 1 | +40/−10 |
| Gateway internal use (`gateway.py`, `naming.py`, `demo.py`) | 3 | ~12 |
| GeecsBluesky `:SP` sites + `safe_name` + `_pv.py` re-export | 8 | ~25 |
| Console `:SP` sites + docstring | 1 | ~8 |
| Contract/docs | 6 | ~90 |
| Test updates (mechanical case/underscore folds + 2 new pins) | 16 | ~160 |

## Judgment calls (cheap to veto)

- **`:SP` stays uppercase** — it's a fixed structural literal, not a name component; visually separates setpoints from name components. Flipping it to `:sp` for total lowercase is a 5-minute follow-up if preferred.
- **Console bump is patch** (0.17.2): its only code change is routing through the helper; the wire-name change is the gateway contract's, not the console's.
- Two test-only collaterals were deliberately *not* folded: `parse_device_variable` inputs and the `confirm_variable` exception attribute — both are GEECS-name (Domain A) strings, not PVs.

## Tests

- GeecsCAGateway: **182 passed** (was 181 + 1 new lowercase pin)
- GeecsBluesky: **581 passed, 3 deselected** (incl. new `test_safe_name_agrees_with_the_pv_naming_contract`)
- GEECS-Console: **764 passed**
- Full `./scripts/check.sh --all`: root 2, ImageAnalysis 224, ScanAnalysis 171, GEECS-Data-Utils 198, GEECS-Schemas 211, GEECS-LogTriage 53 — all green. (`--all` lint via the *global* pre-commit fails on the jupyter-clear hook — `jupyter` not on PATH, unrelated to this diff; `poetry run pre-commit run --all-files` is fully green.)

## Hardware verification

**OWED (next lab-network session — gateway and clients must deploy together):**
1. Restart the gateway on 192.168.6.14 with this version; `caproto-get undulator:cagateway:heartbeat` ticks.
2. `caproto-get undulator:u_s1h:current` (or any live readback) returns; the old mixed-case name no longer resolves.
3. `caput` one `:SP` (e.g. jet position) → hardware moves; console R7 dropdown set → hardware moves.
4. One free-run scan end-to-end: rows land in Tiled with single-underscore lowercase columns; s-file export recovers legacy `Device Variable` headers via `geecs_scalar_headers`.
5. Phoebus screens: re-point the play screens at the lowercase names (sed sweep, no deployed screens).

🤖 Generated with [Claude Code](https://claude.com/claude-code)