### PR TITLE
lab_status.sh: tier-2 probe speaks both PV naming contracts

### DIFF
--- a/scripts/lab_status.sh
+++ b/scripts/lab_status.sh
@@ -165,9 +165,14 @@ async def main():
     # geecs-ca-gateway >= 0.14.0 serves lowercase PV components (PV_CONTRACT.md
     # §1); older deployments serve mixed case. Probe new-contract names first,
     # fall back to the legacy ones — which contract answers doubles as a
-    # deployed-generation indicator during the transition.
+    # deployed-generation indicator during the transition. New-contract names
+    # come from the naming contract itself; only the legacy fallback needs
+    # literals (pre-0.14.0 normalize_component preserved case, so today's
+    # pv_name can no longer produce those names).
+    from geecs_ca_gateway.pv_naming import pv_name
+
     contracts = [
-        ("lowercase (>=0.14.0)", f"{experiment.lower()}:cagateway",
+        ("lowercase (>=0.14.0)", pv_name(experiment, "CAGateway"),
          {"heartbeat": "heartbeat", "connected": "devices_connected", "version": "version"}),
         ("legacy mixed-case (<0.14.0)", f"{experiment}:CAGateway",
          {"heartbeat": "HEARTBEAT", "connected": "DEVICES_CONNECTED", "version": "VERSION"}),

--- a/scripts/lab_status.sh
+++ b/scripts/lab_status.sh
@@ -154,20 +154,42 @@ async def read(pv):
     return await asyncio.wait_for(aioca.caget(pv), timeout=timeout)
 
 
+async def probe(prefix, names):
+    heartbeat = await read(f"{prefix}:{names['heartbeat']}")
+    connected = await read(f"{prefix}:{names['connected']}")
+    version = await read(f"{prefix}:{names['version']}")
+    return heartbeat, connected, version
+
+
 async def main():
-    prefix = f"{experiment}:CAGateway"
-    try:
-        heartbeat = await read(f"{prefix}:HEARTBEAT")
-        connected = await read(f"{prefix}:DEVICES_CONNECTED")
-        version = await read(f"{prefix}:VERSION")
+    # geecs-ca-gateway >= 0.14.0 serves lowercase PV components (PV_CONTRACT.md
+    # §1); older deployments serve mixed case. Probe new-contract names first,
+    # fall back to the legacy ones — which contract answers doubles as a
+    # deployed-generation indicator during the transition.
+    contracts = [
+        ("lowercase (>=0.14.0)", f"{experiment.lower()}:cagateway",
+         {"heartbeat": "heartbeat", "connected": "devices_connected", "version": "version"}),
+        ("legacy mixed-case (<0.14.0)", f"{experiment}:CAGateway",
+         {"heartbeat": "HEARTBEAT", "connected": "DEVICES_CONNECTED", "version": "VERSION"}),
+    ]
+    last_exc = None
+    for label, prefix, names in contracts:
+        try:
+            heartbeat, connected, version = await probe(prefix, names)
+        except Exception as exc:  # noqa: BLE001 — try the other contract
+            last_exc = exc
+            continue
         print(f"  [ OK ] gateway alive: heartbeat={int(heartbeat)}, "
-              f"devices_connected={int(connected)}, version={version}")
+              f"devices_connected={int(connected)}, version={version} "
+              f"[{label} naming]")
         if int(connected) == 0:
             print("  [WARN] zero devices connected — GEECS side likely down")
-    except Exception as exc:  # noqa: BLE001 — a failed probe is a finding
-        print(f"  [DOWN] gateway PVs unreadable ({type(exc).__name__}: {exc})")
-        print("         network may be up while the gateway service is not")
-        raise SystemExit(1)
+        return
+    exc = last_exc
+    print(f"  [DOWN] gateway PVs unreadable under either naming contract "
+          f"({type(exc).__name__}: {exc})")
+    print("         network may be up while the gateway service is not")
+    raise SystemExit(1)
 
 
 asyncio.run(main())


### PR DESCRIPTION
## What

Follow-up to #585 closing a gap both that PR's sweep and its review missed: `scripts/lab_status.sh --hardware` hardcoded the legacy mixed-case gateway status PVs (`{Experiment}:CAGateway:HEARTBEAT` …), so the moment a geecs-ca-gateway ≥ 0.14.0 deploys, the probe would report a healthy gateway as DOWN — exactly the tool you'd trust while smoke-testing that deploy.

The tier-2 probe now tries the lowercase contract first and falls back to legacy, labeling which one answered — doubling as a deployed-generation indicator during the transition. The dual-contract probe is transition tooling; once the 0.14.0 deploy is verified, the legacy branch can be deleted at leisure.

One script, +32/−10; no package code changed, so no version bumps.

## Tests / verification

- `bash -n` clean; tier-1 behavior untouched.
- **Live-verified over VPN against the running 0.10.0 gateway**: lowercase attempt times out, probe falls back and reports `version=0.10.0 [legacy mixed-case (<0.14.0) naming]`.

## Hardware verification

OWED (bundled with the #585 deploy session): after the gateway restarts on 0.14.0+, the same command should report `[lowercase (>=0.14.0) naming]` with no fallback delay.

🤖 Generated with [Claude Code](https://claude.com/claude-code)