### PR TITLE
GEECS-Console 0.18.0: ConfigEditorDialog — shared editor scaffolding base (#533)

### DIFF
--- a/GEECS-Console/CHANGELOG.md
+++ b/GEECS-Console/CHANGELOG.md
@@ -4,6 +4,35 @@ All notable changes to GEECS-Console are documented here.  Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versioning is
 semantic.
 
+## [0.18.0] - 2026-07-20
+
+### Added
+
+- `editors/base.py::ConfigEditorDialog` — the shared scaffolding base for
+  the four config editors (issue #533, extracted **before** editor #5
+  exists): `.ui` loading + fail-loud `_child`, the Enter-guard (both
+  mechanisms, now uniform), the completions scaffold (queued signal,
+  daemon-thread fetch, `EmptyCompletions` inline fast-path, one-shot
+  close-time disconnect — each previously present in only some editors,
+  now in all four), the unified unsaved-changes flow, and the one
+  name-prompt/confirm convention.
+
+### Changed
+
+- **Unsaved-changes prompts are now uniform**: every editor offers
+  Save / Discard / Cancel (the scan-variable and action-library editors
+  previously offered only Discard/Cancel — the user-visible divergence
+  that motivated #533), and **Esc now routes through the prompt in all
+  four editors** (the save-set and trigger-profile editors previously
+  discarded silently on Esc).
+- One name-prompt convention (stripped text, `None` on cancel) and one
+  Yes/No delete confirm across the editors; the action-library delete
+  confirm's second button is now "No" (was "Cancel").
+- The four editors shrink 4,322 → 3,839 lines against a 365-line base
+  (net −479 including test migrations); editor tests drive the prompts
+  through the instance seams (`_prompt_unsaved`, `_prompt_name`,
+  `_confirm`) instead of module-level Qt patches.
+
 ## [0.17.2] - 2026-07-20
 
 ### Changed

--- a/GEECS-Console/geecs_console/editors/action_library_editor.py
+++ b/GEECS-Console/geecs_console/editors/action_library_editor.py
@@ -33,14 +33,11 @@ Design notes
 from __future__ import annotations
 
 import logging
-import threading
 from pathlib import Path
 from typing import Optional
 
 from pydantic import ValidationError
-from PySide6.QtCore import QFile, QStringListModel, Qt, Signal, Slot
-from PySide6.QtGui import QCloseEvent, QKeyEvent
-from PySide6.QtUiTools import QUiLoader
+from PySide6.QtCore import QStringListModel, Qt
 from PySide6.QtWidgets import (
     QAbstractItemView,
     QApplication,
@@ -50,19 +47,17 @@ from PySide6.QtWidgets import (
     QDialog,
     QDoubleSpinBox,
     QHeaderView,
-    QInputDialog,
     QLabel,
     QLineEdit,
     QListWidget,
-    QMessageBox,
     QPushButton,
     QStackedWidget,
     QTableWidget,
     QTableWidgetItem,
-    QVBoxLayout,
     QWidget,
 )
 
+from geecs_console.editors.base import ConfigEditorDialog
 from geecs_console.services.action_library_store import (
     ActionLibraryStore,
     ActionLibraryStoreError,
@@ -219,7 +214,7 @@ def step_summary(step: dict) -> str:
 # ---------------------------------------------------------------------------
 
 
-class ActionLibraryEditor(QDialog):
+class ActionLibraryEditor(ConfigEditorDialog):
     """Edit the named action plans of one experiment (no execution).
 
     Parameters
@@ -236,9 +231,8 @@ class ActionLibraryEditor(QDialog):
         Standard Qt parent.
     """
 
-    #: Provider result (``{device: [variable, ...]}``), emitted from the
-    #: fetch daemon thread; delivered queued to :meth:`_apply_completions`.
-    completions_ready = Signal(object)
+    UI_PATH = _UI_PATH
+    COMPLETIONS_THREAD_NAME = "ale-completions-fetch"
 
     def __init__(
         self,
@@ -248,9 +242,7 @@ class ActionLibraryEditor(QDialog):
     ) -> None:
         super().__init__(parent)
         self._store = store if store is not None else ActionLibraryStore()
-        self._completions: CompletionsProvider = (
-            completions if completions is not None else EmptyCompletions()
-        )
+        self._init_completions(completions)
 
         self._loading = False
         self._dirty = False
@@ -262,16 +254,11 @@ class ActionLibraryEditor(QDialog):
         #: Snapshot for Revert (steps deep-ish copy + description).
         self._baseline_steps: list[dict] = []
         self._baseline_description = ""
-        #: ``{device: [variable, ...]}`` word lists once the fetch lands.
-        self._device_vars: dict[str, list[str]] = {}
-        #: True once the (async) completions fetch has been delivered on the
-        #: GUI thread — tests wait on this so no queued signal can land
-        #: after teardown.
-        self.completions_applied = False
 
         self._apply_stylesheet()
         self._load_ui()
         self._bind_widgets()
+        self._guard_enter_keys()
         self._configure_widgets()
         self._wire_signals()
         self._setup_completers()
@@ -280,10 +267,6 @@ class ActionLibraryEditor(QDialog):
         self._clear_plan_editor()
         self._update_title()
         self._refresh_enabled()
-
-        self.completions_ready.connect(
-            self._apply_completions, Qt.ConnectionType.QueuedConnection
-        )
         self._start_completions_fetch()
 
     # ------------------------------------------------------------------
@@ -297,28 +280,6 @@ class ActionLibraryEditor(QDialog):
             from geecs_console.app.main_window import load_stylesheet
 
             app.setStyleSheet(load_stylesheet())
-
-    def _load_ui(self) -> None:
-        """Load the hand-authored ``.ui`` as this dialog's content."""
-        loader = QUiLoader()
-        ui_file = QFile(str(_UI_PATH))
-        ui_file.open(QFile.OpenModeFlag.ReadOnly)
-        try:
-            self._ui: QWidget = loader.load(ui_file, self)
-        finally:
-            ui_file.close()
-        if self._ui is None:
-            raise RuntimeError(f"Failed to load {_UI_PATH}: {loader.errorString()}")
-        layout = QVBoxLayout(self)
-        layout.setContentsMargins(0, 0, 0, 0)
-        layout.addWidget(self._ui)
-
-    def _child(self, cls: type, name: str):
-        """Return the named child widget, failing loudly when missing."""
-        widget = self._ui.findChild(cls, name)
-        if widget is None:
-            raise LookupError(f"{name!r} ({cls.__name__}) not found in {_UI_PATH}")
-        return widget
 
     def _bind_widgets(self) -> None:
         """Resolve every wired widget from the loaded ``.ui`` once."""
@@ -460,39 +421,8 @@ class ActionLibraryEditor(QDialog):
             completer.setFilterMode(Qt.MatchFlag.MatchContains)
             edit.setCompleter(completer)
 
-    def _start_completions_fetch(self) -> None:
-        """Fetch completions on a short-lived daemon thread (queued delivery)."""
-        provider = self._completions
-
-        def fetch() -> None:
-            """Run the provider's one blocking call off the GUI thread."""
-            try:
-                mapping = provider.device_variables()
-            except Exception as exc:  # noqa: BLE001 — providers should not raise
-                logger.info("completions fetch failed: %s", exc)
-                mapping = {}
-            self.completions_ready.emit(mapping)
-
-        threading.Thread(
-            target=fetch, name="ale-completions-fetch", daemon=True
-        ).start()
-
-    @Slot(object)
-    def _apply_completions(self, mapping: object) -> None:
-        """Install the fetched ``{device: [variable, ...]}`` word lists (GUI thread).
-
-        Parameters
-        ----------
-        mapping : dict
-            The provider result delivered by the queued signal.
-        """
-        self.completions_applied = True
-        if not isinstance(mapping, dict):
-            return
-        self._device_vars = {
-            str(device): [str(v) for v in variables]
-            for device, variables in mapping.items()
-        }
+    def _install_completions(self) -> None:
+        """Point the device/variable completer models at the fresh word lists."""
         self._device_completer_model.setStringList(sorted(self._device_vars))
         self._refresh_variable_completer(
             self._set_variable_completer_model, self.set_device_edit.text()
@@ -506,28 +436,27 @@ class ActionLibraryEditor(QDialog):
         model.setStringList(self._device_vars.get(device, []))
 
     # ------------------------------------------------------------------
-    # Dialog-level behaviour
+    # Dialog-level behaviour (close paths on ConfigEditorDialog — the
+    # unsaved-changes prompt now offers Save alongside Discard/Cancel)
     # ------------------------------------------------------------------
 
-    def keyPressEvent(self, event: QKeyEvent) -> None:  # noqa: N802 (Qt API)
-        """Swallow Return/Enter so they never accept (close) the dialog."""
-        if event.key() in (Qt.Key.Key_Return, Qt.Key.Key_Enter):
-            event.accept()
-            return
-        super().keyPressEvent(event)
+    def _has_unsaved(self) -> bool:
+        """Unsaved-changes hook: the working plan has unsaved edits."""
+        return self._dirty
 
-    def reject(self) -> None:
-        """Prompt for unsaved changes before closing via Escape/close."""
-        if self._dirty and not self._confirm_discard():
-            return
-        super().reject()
+    def _save_unsaved(self) -> bool:
+        """Unsaved-changes hook: persist the working plan."""
+        return self._save_plan()
 
-    def closeEvent(self, event: QCloseEvent) -> None:  # noqa: N802 (Qt API)
-        """Prompt for unsaved changes before the window closes."""
-        if self._dirty and not self._confirm_discard():
-            event.ignore()
-            return
-        super().closeEvent(event)
+    def _discard_unsaved(self) -> None:
+        """Unsaved-changes hook: a never-saved (phantom) plan evaporates."""
+        if self._phantom is not None and self._current == self._phantom:
+            self._phantom = None
+        self._set_dirty(False)
+
+    def _unsaved_prompt_text(self) -> str:
+        """Describe the dirty plan in the unsaved-changes prompt."""
+        return f"Action plan {self._current!r} has unsaved changes."
 
     def _update_title(self) -> None:
         """Render the window title (experiment + unsaved marker)."""
@@ -541,32 +470,11 @@ class ActionLibraryEditor(QDialog):
     # Prompt seams (tests monkeypatch these)
     # ------------------------------------------------------------------
 
-    def _prompt_name(self, title: str, initial: str = "") -> Optional[str]:
-        """Ask the operator for a plan name; ``None`` on cancel."""
-        name, accepted = QInputDialog.getText(self, title, "Plan name:", text=initial)
-        return name if accepted else None
-
-    def _confirm_discard(self) -> bool:
-        """Ask whether unsaved changes may be discarded."""
-        answer = QMessageBox.question(
-            self,
-            "Unsaved changes",
-            "The current plan has unsaved changes. Discard them?",
-            QMessageBox.StandardButton.Discard | QMessageBox.StandardButton.Cancel,
-            QMessageBox.StandardButton.Cancel,
-        )
-        return answer == QMessageBox.StandardButton.Discard
-
     def _confirm_delete(self, name: str) -> bool:
         """Ask whether plan *name* should really be deleted."""
-        answer = QMessageBox.question(
-            self,
-            "Delete plan",
-            f"Delete action plan {name!r}? This cannot be undone.",
-            QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.Cancel,
-            QMessageBox.StandardButton.Cancel,
+        return self._confirm(
+            "Delete plan", f"Delete action plan {name!r}? This cannot be undone."
         )
-        return answer == QMessageBox.StandardButton.Yes
 
     # ------------------------------------------------------------------
     # Inline messages
@@ -626,17 +534,15 @@ class ActionLibraryEditor(QDialog):
         name = current.text() if current is not None else None
         if name == self._current:
             return
-        if self._dirty and not self._confirm_discard():
+        had_phantom = self._phantom
+        if not self._resolve_unsaved():
             self._loading = True
             try:
                 self._select_name(self._current)
             finally:
                 self._loading = False
             return
-        discarded_phantom = self._phantom is not None and self._current == self._phantom
-        self._phantom = None if discarded_phantom else self._phantom
-        self._set_dirty(False)
-        if discarded_phantom:
+        if had_phantom is not None and self._phantom is None:
             # The discarded new plan disappears with its unsaved state.
             self._populate_plan_list(select=name)
         self._load_plan(name)
@@ -730,45 +636,42 @@ class ActionLibraryEditor(QDialog):
 
     def _on_new(self) -> None:
         """Create a new plan (in memory until saved)."""
-        if self._dirty and not self._confirm_discard():
+        if not self._resolve_unsaved():
             return
-        name = self._prompt_name("New action plan")
-        if not name or not name.strip():
+        name = self._prompt_name("New action plan", "Plan name:")
+        if not name:
             return
-        name = name.strip()
         if name in self._store.list_names():
             self._show_error(f"Plan {name!r} already exists.")
             return
-        self._set_dirty(False)
         self._start_phantom(name, [default_step("wait")], "")
 
     def _on_duplicate(self) -> None:
         """Duplicate the selected plan under a new name (in memory)."""
         if self._current is None:
             return
-        if self._dirty and not self._confirm_discard():
+        steps = [dict(step) for step in self._working_steps]
+        description = self.description_edit.text()
+        if not self._resolve_unsaved():
             return
-        name = self._prompt_name("Duplicate plan", initial=f"{self._current}_copy")
-        if not name or not name.strip():
+        name = self._prompt_name(
+            "Duplicate plan", "Plan name:", initial=f"{self._current}_copy"
+        )
+        if not name:
             return
-        name = name.strip()
         if name in self._store.list_names() or name == self._phantom:
             self._show_error(f"Plan {name!r} already exists.")
             return
-        steps = [dict(step) for step in self._working_steps]
-        description = self.description_edit.text()
         self._phantom = None
-        self._set_dirty(False)
         self._start_phantom(name, steps, description)
 
     def _on_rename(self) -> None:
         """Rename the selected plan (updating every ``run`` reference)."""
         if self._current is None:
             return
-        new = self._prompt_name("Rename plan", initial=self._current)
-        if not new or not new.strip() or new.strip() == self._current:
+        new = self._prompt_name("Rename plan", "Plan name:", initial=self._current)
+        if not new or new == self._current:
             return
-        new = new.strip()
         old = self._current
         if self._phantom == old:
             if new in self._store.list_names():
@@ -1031,26 +934,37 @@ class ActionLibraryEditor(QDialog):
             }
         )
 
-    def _on_save(self) -> None:
-        """Validate and persist the current plan through the store."""
+    def _save_plan(self) -> bool:
+        """Validate and persist the current plan through the store.
+
+        Returns
+        -------
+        bool
+            ``True`` when the save landed (validation and write both OK).
+        """
         if self._current is None:
-            return
+            return False
         self._clear_error()
         try:
             plan = self._build_plan()
         except ValidationError as exc:
             self._show_error(f"Invalid plan: {exc}")
-            return
+            return False
         try:
             self._store.save(self._current, plan)
         except ActionLibraryStoreError as exc:
             self._show_error(str(exc))
-            return
+            return False
         self._phantom = None
         self._baseline_steps = [dict(step) for step in self._working_steps]
         self._baseline_description = self.description_edit.text()
         self._set_dirty(False)
         self._populate_plan_list(select=self._current)
+        return True
+
+    def _on_save(self) -> None:
+        """Save button handler."""
+        self._save_plan()
 
     def _on_revert(self) -> None:
         """Restore the plan to its last saved (or freshly created) state."""

--- a/GEECS-Console/geecs_console/editors/action_library_editor.py
+++ b/GEECS-Console/geecs_console/editors/action_library_editor.py
@@ -449,10 +449,23 @@ class ActionLibraryEditor(ConfigEditorDialog):
         return self._save_plan()
 
     def _discard_unsaved(self) -> None:
-        """Unsaved-changes hook: a never-saved (phantom) plan evaporates."""
+        """Unsaved-changes hook: really discard — the widgets follow the flag.
+
+        Callers (New / Duplicate) can still bail out *after* a discard (name
+        prompt canceled, collision), so the editor must be left coherent
+        here, not merely flag-cleared: a never-saved (phantom) plan
+        evaporates from the list and the editor clears; a saved plan
+        reloads clean from the store.
+        """
         if self._phantom is not None and self._current == self._phantom:
             self._phantom = None
+            self._set_dirty(False)
+            self._populate_plan_list()
+            self._load_plan(None)
+            return
         self._set_dirty(False)
+        if self._current is not None:
+            self._load_plan(self._current)
 
     def _unsaved_prompt_text(self) -> str:
         """Describe the dirty plan in the unsaved-changes prompt."""

--- a/GEECS-Console/geecs_console/editors/base.py
+++ b/GEECS-Console/geecs_console/editors/base.py
@@ -173,6 +173,15 @@ class ConfigEditorDialog(QDialog):
         The :class:`EmptyCompletions` default is answered inline (no
         thread to spawn for a constant) — offline construction stays
         thread-free.
+
+        Known debt, consciously carried over from all four pre-base
+        editors rather than introduced here: the daemon thread emits a
+        *dialog-owned* signal instead of routing through the blessed
+        ``services/background.py::BackgroundResult`` worker, and an
+        Esc-closed dialog (``reject`` → ``done()``, no ``QCloseEvent``)
+        never runs the close-time disconnect.  Consolidating onto
+        ``BackgroundResult`` is the follow-up recorded on issue #533 —
+        do it here once, not per editor.
         """
         if isinstance(self._completions, EmptyCompletions):
             self.completions_applied = True
@@ -250,8 +259,11 @@ class ConfigEditorDialog(QDialog):
         box.setText(self._unsaved_prompt_text())
         save = box.addButton("Save", QMessageBox.ButtonRole.AcceptRole)
         discard = box.addButton("Discard", QMessageBox.ButtonRole.DestructiveRole)
-        box.addButton("Cancel", QMessageBox.ButtonRole.RejectRole)
-        box.setDefaultButton(save)
+        cancel = box.addButton("Cancel", QMessageBox.ButtonRole.RejectRole)
+        # The keyboard default is the safe no-op (the convention three of
+        # the four pre-base editors already had) — a reflexive Enter must
+        # never write a config to disk.
+        box.setDefaultButton(cancel)
         box.exec()
         clicked = box.clickedButton()
         if clicked is save:
@@ -332,21 +344,29 @@ class ConfigEditorDialog(QDialog):
     # ------------------------------------------------------------------
 
     def reject(self) -> None:
-        """Route Esc through the unsaved-changes prompt."""
+        """Route Esc through the unsaved-changes prompt.
+
+        Visible closes land here too — see :meth:`closeEvent`.
+        """
         if not self._resolve_unsaved():
             return
         super().reject()
 
     def closeEvent(self, event: QCloseEvent) -> None:  # noqa: N802 (Qt override)
-        """Prompt for unsaved changes, then disconnect the completions signal.
+        """Close via QDialog (one prompt), then disconnect the completions signal.
 
-        Only a *visible* dialog prompts — there is an operator to ask.  A
-        programmatic close of a hidden dialog (test teardown, app
-        shutdown) must never block on a modal nobody can answer.
+        :meth:`reject` is the **only** prompt owner: ``QDialog::closeEvent``
+        routes a *visible* close through the virtual ``reject()`` (ours,
+        above) and ignores the close when the dialog survives it — so
+        prompting here too would ask twice on Discard in the editors whose
+        dirty predicate is computed (draft ≠ snapshot) rather than a flag
+        the discard hook clears.  A hidden dialog (test teardown, app
+        shutdown) closes without ``reject()`` and therefore never blocks
+        on a modal nobody can answer.
         """
-        if self.isVisible() and not self._resolve_unsaved():
-            event.ignore()
-            return
+        super().closeEvent(event)
+        if not event.isAccepted():
+            return  # the operator canceled — the dialog stays open
         # A still-running completions fetch must not queue an event onto a
         # dialog being torn down.  Once only: closeEvent can run twice
         # (explicit close + owner teardown) and a second disconnect warns.
@@ -356,4 +376,3 @@ class ConfigEditorDialog(QDialog):
                 self.completions_ready.disconnect(self._apply_completions)
             except (RuntimeError, TypeError):
                 pass
-        super().closeEvent(event)

--- a/GEECS-Console/geecs_console/editors/base.py
+++ b/GEECS-Console/geecs_console/editors/base.py
@@ -1,0 +1,359 @@
+"""Shared scaffolding for the config-editor dialogs (issue #533).
+
+The four editors (save sets, scan variables, trigger profiles, action
+plans) grew from the same template and had started to diverge in
+user-visible ways — two offered Save/Discard/Cancel on unsaved changes
+while two offered only Discard/Cancel, and Esc silently discarded edits
+in the two editors that never overrode ``reject``.  This base class is
+the one home for that scaffolding; each editor keeps only its store
+binding, its widgets, and its dialect rules.
+
+What lives here:
+
+- ``.ui`` loading (:meth:`_load_ui` from :attr:`UI_PATH`, optional
+  :attr:`INITIAL_SIZE`) and the fail-loud :meth:`_child` lookup.
+- The Enter-key guard, both mechanisms applied uniformly: no
+  default/auto-default buttons (:meth:`_guard_enter_keys`) and a
+  :meth:`keyPressEvent` that swallows Return/Enter.
+- The completions scaffold: one queued ``completions_ready`` signal, a
+  daemon-thread fetch with the ``EmptyCompletions`` inline fast-path (no
+  thread for a constant — offline construction stays thread-free), the
+  normalized ``{device: [variable, ...]}`` word lists in
+  :attr:`_device_vars`, the public ``completions_applied`` flag tests
+  wait on, and the one-shot signal disconnect at close.
+- The unified unsaved-changes flow: :meth:`_prompt_unsaved`
+  (Save/Discard/Cancel, three-way string result) resolved by
+  :meth:`_resolve_unsaved` through the per-editor hooks
+  :meth:`_has_unsaved` / :meth:`_save_unsaved` / :meth:`_discard_unsaved`,
+  wired into both close paths (:meth:`closeEvent` and Esc via
+  :meth:`reject`).
+- One name-prompt convention (:meth:`_prompt_name`: stripped text or
+  ``None`` on cancel) and one Yes/No confirm (:meth:`_confirm`).
+
+The prompt methods are plain bound methods so tests can monkeypatch them
+per instance (``editor._prompt_unsaved = lambda: "discard"``) — the
+pattern the editor test suites already use.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+from pathlib import Path
+from typing import Optional
+
+from PySide6.QtCore import QFile, Qt, Signal, Slot
+from PySide6.QtGui import QCloseEvent, QKeyEvent
+from PySide6.QtUiTools import QUiLoader
+from PySide6.QtWidgets import (
+    QDialog,
+    QInputDialog,
+    QMessageBox,
+    QPushButton,
+    QVBoxLayout,
+    QWidget,
+)
+
+from geecs_console.services.device_completions import (
+    CompletionsProvider,
+    EmptyCompletions,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class ConfigEditorDialog(QDialog):
+    """Base dialog for the per-experiment config editors.
+
+    Subclasses set :attr:`UI_PATH` (and optionally :attr:`INITIAL_SIZE`
+    and :attr:`COMPLETIONS_THREAD_NAME`), call :meth:`_init_completions`
+    early in ``__init__`` and :meth:`_start_completions_fetch` once their
+    widgets exist, and implement the small hooks documented on
+    :meth:`_has_unsaved`, :meth:`_save_unsaved`, :meth:`_discard_unsaved`,
+    :meth:`_unsaved_prompt_text`, and :meth:`_install_completions`.
+    """
+
+    #: The hand-authored ``.ui`` file this dialog loads (subclass-set).
+    UI_PATH: Path
+    #: Optional ``(width, height)`` applied after the ``.ui`` loads.
+    INITIAL_SIZE: Optional[tuple[int, int]] = None
+    #: Name of the completions-fetch daemon thread (subclass-set for
+    #: recognizable thread dumps).
+    COMPLETIONS_THREAD_NAME: str = "editor-completions-fetch"
+
+    #: One ``{device: [variable, ...]}`` mapping per finished provider
+    #: call (emitted from the fetch daemon thread; delivered queued to
+    #: :meth:`_apply_completions`).
+    completions_ready = Signal(object)
+
+    # ------------------------------------------------------------------
+    # UI loading
+    # ------------------------------------------------------------------
+
+    def _load_ui(self) -> None:
+        """Load :attr:`UI_PATH` as this dialog's only child."""
+        loader = QUiLoader()
+        ui_file = QFile(str(self.UI_PATH))
+        ui_file.open(QFile.OpenModeFlag.ReadOnly)
+        try:
+            self._ui: QWidget = loader.load(ui_file, self)
+        finally:
+            ui_file.close()
+        if self._ui is None:
+            raise RuntimeError(f"Failed to load {self.UI_PATH}: {loader.errorString()}")
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.addWidget(self._ui)
+        if self.INITIAL_SIZE is not None:
+            self.resize(*self.INITIAL_SIZE)
+
+    def _child(self, cls: type, name: str):
+        """Return the named child widget, failing loudly when missing."""
+        widget = self._ui.findChild(cls, name)
+        if widget is None:
+            raise LookupError(f"{name!r} ({cls.__name__}) not found in {self.UI_PATH}")
+        return widget
+
+    # ------------------------------------------------------------------
+    # Enter must never accept (close) the dialog
+    # ------------------------------------------------------------------
+
+    def _guard_enter_keys(self) -> None:
+        """Strip default/auto-default from every button (call after binding).
+
+        Every ``QPushButton`` in a ``QDialog`` is auto-default by default,
+        so pressing Enter in any line edit would "click" the first button.
+        :meth:`keyPressEvent` swallows whatever this loop cannot reach.
+        """
+        for button in self.findChildren(QPushButton):
+            button.setAutoDefault(False)
+            button.setDefault(False)
+
+    def keyPressEvent(self, event: QKeyEvent) -> None:  # noqa: N802 (Qt override)
+        """Swallow Return/Enter so typing in a field never closes the dialog."""
+        if event.key() in (Qt.Key.Key_Return, Qt.Key.Key_Enter):
+            event.accept()
+            return
+        super().keyPressEvent(event)
+
+    # ------------------------------------------------------------------
+    # Completions (injectable provider, fetched off the GUI thread)
+    # ------------------------------------------------------------------
+
+    def _init_completions(self, provider: Optional[CompletionsProvider]) -> None:
+        """Install the completions state and the queued signal connection.
+
+        Call early in ``__init__`` (before any fetch).  The connection is
+        forced queued: the fetch emits from a daemon thread, and a direct
+        delivery would touch state on the wrong thread.
+
+        Parameters
+        ----------
+        provider : CompletionsProvider, optional
+            The word-list source; ``None`` means
+            :class:`~geecs_console.services.device_completions.EmptyCompletions`.
+        """
+        self._completions: CompletionsProvider = (
+            provider if provider is not None else EmptyCompletions()
+        )
+        #: The fetched completion word lists (empty until the fetch lands).
+        self._device_vars: dict[str, list[str]] = {}
+        #: True once the (async) completions fetch has been delivered on
+        #: the GUI thread — tests wait on this instead of sleeping.
+        self.completions_applied = False
+        #: Guards the one-shot signal disconnect in :meth:`closeEvent`.
+        self._completions_disconnected = False
+        self.completions_ready.connect(
+            self._apply_completions, Qt.ConnectionType.QueuedConnection
+        )
+
+    def _start_completions_fetch(self) -> None:
+        """Fetch completions on a short-lived daemon thread (queued delivery).
+
+        The :class:`EmptyCompletions` default is answered inline (no
+        thread to spawn for a constant) — offline construction stays
+        thread-free.
+        """
+        if isinstance(self._completions, EmptyCompletions):
+            self.completions_applied = True
+            return
+        provider = self._completions
+
+        def fetch() -> None:
+            """Run the provider's one blocking call off the GUI thread."""
+            try:
+                mapping = provider.device_variables()
+            except Exception as exc:  # noqa: BLE001 — providers should not raise
+                logger.info("completions fetch failed: %s", exc)
+                mapping = {}
+            self.completions_ready.emit(mapping or {})
+
+        threading.Thread(
+            target=fetch, name=self.COMPLETIONS_THREAD_NAME, daemon=True
+        ).start()
+
+    @Slot(object)
+    def _apply_completions(self, mapping: object) -> None:
+        """Store the fetched word lists (GUI-thread slot, delivered queued).
+
+        Parameters
+        ----------
+        mapping : dict
+            The provider result delivered by the queued signal.
+        """
+        self.completions_applied = True
+        if not isinstance(mapping, dict):
+            return
+        self._device_vars = {
+            str(device): [str(variable) for variable in variables]
+            for device, variables in mapping.items()
+        }
+        self._install_completions()
+
+    def _install_completions(self) -> None:
+        """Hook: point completer models at the fresh :attr:`_device_vars`.
+
+        Default is a no-op — an editor whose cell editors read
+        :attr:`_device_vars` lazily at edit-open needs no replumbing.
+        """
+
+    # ------------------------------------------------------------------
+    # Unsaved-changes flow (one prompt, both close paths)
+    # ------------------------------------------------------------------
+
+    def _has_unsaved(self) -> bool:
+        """Hook: whether there are unsaved edits to resolve."""
+        raise NotImplementedError
+
+    def _save_unsaved(self) -> bool:
+        """Hook: run the editor's save; ``True`` when it landed."""
+        raise NotImplementedError
+
+    def _discard_unsaved(self) -> None:
+        """Hook: side effects of discarding (default: none)."""
+
+    def _unsaved_prompt_text(self) -> str:
+        """Hook: the sentence describing what has unsaved changes."""
+        return "This editor has unsaved changes."
+
+    def _prompt_unsaved(self) -> str:
+        """Ask what to do with unsaved changes.
+
+        Returns
+        -------
+        str
+            ``"save"``, ``"discard"``, or ``"cancel"``.
+        """
+        box = QMessageBox(self)
+        box.setIcon(QMessageBox.Icon.Warning)
+        box.setWindowTitle("Unsaved changes")
+        box.setText(self._unsaved_prompt_text())
+        save = box.addButton("Save", QMessageBox.ButtonRole.AcceptRole)
+        discard = box.addButton("Discard", QMessageBox.ButtonRole.DestructiveRole)
+        box.addButton("Cancel", QMessageBox.ButtonRole.RejectRole)
+        box.setDefaultButton(save)
+        box.exec()
+        clicked = box.clickedButton()
+        if clicked is save:
+            return "save"
+        if clicked is discard:
+            return "discard"
+        return "cancel"
+
+    def _resolve_unsaved(self) -> bool:
+        """Settle unsaved edits before leaving the current document.
+
+        Returns
+        -------
+        bool
+            ``True`` when it is safe to proceed (nothing dirty, saved, or
+            discarded); ``False`` on cancel or a failed save.
+        """
+        if not self._has_unsaved():
+            return True
+        choice = self._prompt_unsaved()
+        if choice == "cancel":
+            return False
+        if choice == "save":
+            return self._save_unsaved()
+        self._discard_unsaved()
+        return True
+
+    # ------------------------------------------------------------------
+    # Small modal prompts (instance-monkeypatchable test seams)
+    # ------------------------------------------------------------------
+
+    def _prompt_name(self, title: str, label: str, initial: str = "") -> Optional[str]:
+        """Ask the operator for one name.
+
+        Parameters
+        ----------
+        title : str
+            Dialog window title.
+        label : str
+            Prompt label (e.g. ``"Plan name:"``).
+        initial : str, optional
+            Prefilled text.
+
+        Returns
+        -------
+        str or None
+            The stripped answer (may be ``""``), or ``None`` on cancel.
+        """
+        name, accepted = QInputDialog.getText(self, title, label, text=initial)
+        return name.strip() if accepted else None
+
+    def _confirm(self, title: str, text: str) -> bool:
+        """Ask a yes/no question (used for deletes).
+
+        Parameters
+        ----------
+        title : str
+            Dialog title.
+        text : str
+            The question.
+
+        Returns
+        -------
+        bool
+            ``True`` on Yes.
+        """
+        answer = QMessageBox.question(
+            self,
+            title,
+            text,
+            QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
+            QMessageBox.StandardButton.No,
+        )
+        return answer == QMessageBox.StandardButton.Yes
+
+    # ------------------------------------------------------------------
+    # Close paths
+    # ------------------------------------------------------------------
+
+    def reject(self) -> None:
+        """Route Esc through the unsaved-changes prompt."""
+        if not self._resolve_unsaved():
+            return
+        super().reject()
+
+    def closeEvent(self, event: QCloseEvent) -> None:  # noqa: N802 (Qt override)
+        """Prompt for unsaved changes, then disconnect the completions signal.
+
+        Only a *visible* dialog prompts — there is an operator to ask.  A
+        programmatic close of a hidden dialog (test teardown, app
+        shutdown) must never block on a modal nobody can answer.
+        """
+        if self.isVisible() and not self._resolve_unsaved():
+            event.ignore()
+            return
+        # A still-running completions fetch must not queue an event onto a
+        # dialog being torn down.  Once only: closeEvent can run twice
+        # (explicit close + owner teardown) and a second disconnect warns.
+        if not self._completions_disconnected:
+            self._completions_disconnected = True
+            try:
+                self.completions_ready.disconnect(self._apply_completions)
+            except (RuntimeError, TypeError):
+                pass
+        super().closeEvent(event)

--- a/GEECS-Console/geecs_console/editors/save_set_editor.py
+++ b/GEECS-Console/geecs_console/editors/save_set_editor.py
@@ -26,32 +26,27 @@ from __future__ import annotations
 
 import copy
 import logging
-import threading
 from pathlib import Path
 from typing import Optional
 
-from PySide6.QtCore import QFile, QStringListModel, Qt, Signal, Slot
-from PySide6.QtUiTools import QUiLoader
+from PySide6.QtCore import QStringListModel, Qt
 from PySide6.QtWidgets import (
     QCheckBox,
     QComboBox,
     QCompleter,
     QDialog,
     QGroupBox,
-    QInputDialog,
     QLabel,
     QLineEdit,
     QListWidget,
-    QMessageBox,
     QPushButton,
-    QVBoxLayout,
     QWidget,
 )
 from pydantic import ValidationError
 
+from geecs_console.editors.base import ConfigEditorDialog
 from geecs_console.services.device_completions import (
     CompletionsProvider,
-    EmptyCompletions,
     GeecsDbCompletions,
 )
 from geecs_console.services.save_set_store import SaveSetStore, SaveSetStoreError
@@ -86,7 +81,7 @@ def _split_names(text: str) -> list[str]:
     return [part.strip() for part in text.split(",") if part.strip()]
 
 
-class SaveSetEditor(QDialog):
+class SaveSetEditor(ConfigEditorDialog):
     """Edit the save sets of one experiment (the M5 SaveElementEditor).
 
     Left: the experiment's save-set list (New / Duplicate / Rename /
@@ -113,9 +108,8 @@ class SaveSetEditor(QDialog):
         offline/tests get empty completers unless a provider is injected.
     """
 
-    #: One completions mapping per finished provider call (emitted from the
-    #: fetch daemon thread; delivered queued to :meth:`_apply_completions`).
-    completions_ready = Signal(object)
+    UI_PATH = _UI_PATH
+    COMPLETIONS_THREAD_NAME = "sse-completions"
 
     def __init__(
         self,
@@ -132,13 +126,7 @@ class SaveSetEditor(QDialog):
             else SaveSetStore(experiment, experiments_root=configs_base)
         )
         self._experiment = experiment or self._store.experiment
-        self._completions_provider: CompletionsProvider = (
-            completions if completions is not None else EmptyCompletions()
-        )
-        self._completions: dict[str, list[str]] = {}
-        #: True once a provider fetch has been applied (tests wait on this
-        #: so the queued delivery cannot outlive the dialog).
-        self._completions_loaded = False
+        self._init_completions(completions)
 
         #: The open document as a JSON-ish dict (``model_dump(mode="json")``
         #: shape) — ``None`` when nothing is open.
@@ -154,43 +142,18 @@ class SaveSetEditor(QDialog):
 
         self._load_ui()
         self._bind_widgets()
-        self._guard_default_buttons()
+        self._guard_enter_keys()
         self._build_completers()
         self._wire_signals()
 
         self.setWindowTitle(self._title())
         self._refresh_set_list()
         self._clear_document()
-        self.completions_ready.connect(
-            self._apply_completions, Qt.ConnectionType.QueuedConnection
-        )
         self._start_completions_fetch()
 
     # ------------------------------------------------------------------
     # Construction
     # ------------------------------------------------------------------
-
-    def _load_ui(self) -> None:
-        """Load the hand-authored .ui as this dialog's content."""
-        loader = QUiLoader()
-        ui_file = QFile(str(_UI_PATH))
-        ui_file.open(QFile.OpenModeFlag.ReadOnly)
-        try:
-            self._ui: QWidget = loader.load(ui_file, self)
-        finally:
-            ui_file.close()
-        if self._ui is None:
-            raise RuntimeError(f"Failed to load {_UI_PATH}: {loader.errorString()}")
-        layout = QVBoxLayout(self)
-        layout.setContentsMargins(0, 0, 0, 0)
-        layout.addWidget(self._ui)
-
-    def _child(self, cls: type, name: str):
-        """Return the named child widget, failing loudly when missing."""
-        widget = self._ui.findChild(cls, name)
-        if widget is None:
-            raise LookupError(f"{name!r} ({cls.__name__}) not found in {_UI_PATH}")
-        return widget
 
     def _bind_widgets(self) -> None:
         """Resolve every wired widget from the loaded .ui once."""
@@ -267,18 +230,6 @@ class SaveSetEditor(QDialog):
             },
         )
 
-    def _guard_default_buttons(self) -> None:
-        """Keep Enter in a line edit from triggering dialog accept.
-
-        Every ``QPushButton`` in a ``QDialog`` is auto-default by default,
-        so pressing Enter in any line edit would "click" the first button.
-        The line edits have their own Enter behavior (add device / add
-        scalar) wired in :meth:`_wire_signals`.
-        """
-        for button in self.findChildren(QPushButton):
-            button.setAutoDefault(False)
-            button.setDefault(False)
-
     def _build_completers(self) -> None:
         """Attach the device/variable completers (empty until a fetch lands).
 
@@ -338,52 +289,19 @@ class SaveSetEditor(QDialog):
         return " ".join(parts)
 
     # ------------------------------------------------------------------
-    # Completions (injectable provider, fetched off the GUI thread)
+    # Completions (scaffold on ConfigEditorDialog)
     # ------------------------------------------------------------------
 
-    def _start_completions_fetch(self) -> None:
-        """Fetch completions once on a daemon thread.
-
-        The :class:`EmptyCompletions` default is answered inline (no thread
-        to spawn for a constant) — offline construction stays thread-free.
-        """
-        if isinstance(self._completions_provider, EmptyCompletions):
-            self._completions_loaded = True
-            return
-        threading.Thread(
-            target=self._fetch_completions,
-            name="sse-completions",
-            daemon=True,
-        ).start()
-
-    def _fetch_completions(self) -> None:
-        """Call the provider (on the daemon thread) and emit the mapping."""
-        try:
-            mapping = self._completions_provider.device_variables()
-        except Exception as exc:  # noqa: BLE001 — completions are best-effort
-            logger.info("completions provider failed: %s", exc)
-            mapping = {}
-        self.completions_ready.emit(mapping or {})
-
-    @Slot(object)
-    def _apply_completions(self, mapping: dict) -> None:
-        """Feed the completer models (GUI-thread slot, delivered queued).
-
-        Parameters
-        ----------
-        mapping : dict
-            ``{device: [variable, ...]}`` from the provider.
-        """
-        self._completions = dict(mapping)
-        self._completions_loaded = True
-        self._device_model.setStringList(sorted(self._completions))
+    def _install_completions(self) -> None:
+        """Feed the completer models from the fresh word lists."""
+        self._device_model.setStringList(sorted(self._device_vars))
         self._refresh_variable_completer()
 
     def _refresh_variable_completer(self) -> None:
         """Point the scalar completer at the selected device's variables."""
         entry = self._current_entry()
         device = entry["device"] if entry is not None else ""
-        self._variable_model.setStringList(self._completions.get(device, []))
+        self._variable_model.setStringList(self._device_vars.get(device, []))
 
     # ------------------------------------------------------------------
     # Document plumbing
@@ -500,7 +418,7 @@ class SaveSetEditor(QDialog):
             return
         item = self.set_list.item(row)
         target = item.text() if item is not None else ""
-        if not self._maybe_leave():
+        if not self._resolve_unsaved():
             self._select_row_silently(self._selected_row)
             return
         if not target:
@@ -519,40 +437,25 @@ class SaveSetEditor(QDialog):
         self._selected_row = new_row
         self._open_set(target)
 
-    def _maybe_leave(self) -> bool:
-        """Resolve unsaved changes before leaving the open document.
+    def _has_unsaved(self) -> bool:
+        """Unsaved-changes hook: an open document with unsaved edits."""
+        return self._dirty and self._document is not None
 
-        Prompts Save / Discard / Cancel when dirty.  Choosing Save runs the
-        normal save (staying put when it fails); choosing Discard on a
-        never-saved set removes it from the list entirely.
+    def _save_unsaved(self) -> bool:
+        """Unsaved-changes hook: run the normal save (staying put on failure)."""
+        return self._save()
 
-        Returns
-        -------
-        bool
-            ``True`` when it is safe to leave the current document.
-        """
-        if not self._dirty or self._document is None:
-            return True
+    def _discard_unsaved(self) -> None:
+        """Unsaved-changes hook: a never-saved set evaporates with its edits."""
         name = self._current_name()
-        choice = QMessageBox.question(
-            self,
-            "Unsaved changes",
-            f"Save set {name!r} has unsaved changes.",
-            QMessageBox.StandardButton.Save
-            | QMessageBox.StandardButton.Discard
-            | QMessageBox.StandardButton.Cancel,
-            QMessageBox.StandardButton.Cancel,
-        )
-        if choice == QMessageBox.StandardButton.Cancel:
-            return False
-        if choice == QMessageBox.StandardButton.Save:
-            return self._save()
-        # Discard: a never-saved set evaporates with its edits.
         if name in self._unsaved:
             self._unsaved.discard(name)
             self._drop_list_item(name)
         self._dirty = False
-        return True
+
+    def _unsaved_prompt_text(self) -> str:
+        """Name the dirty save set in the unsaved-changes prompt."""
+        return f"Save set {self._current_name()!r} has unsaved changes."
 
     def _drop_list_item(self, name: str) -> None:
         """Remove *name*'s row from the set list without side effects."""
@@ -565,12 +468,9 @@ class SaveSetEditor(QDialog):
         finally:
             self._suppress_selection = False
 
-    def closeEvent(self, event) -> None:  # noqa: N802 — Qt override
-        """Prompt for unsaved changes before closing."""
-        if not self._maybe_leave():
-            event.ignore()
-            return
-        super().closeEvent(event)
+    # closeEvent / reject / keyPressEvent: ConfigEditorDialog (Esc now
+    # routes through the unsaved-changes prompt instead of silently
+    # hiding a dirty dialog).
 
     # ------------------------------------------------------------------
     # Opening / clearing documents
@@ -678,8 +578,11 @@ class SaveSetEditor(QDialog):
         """Every name the list shows (stored plus unsaved)."""
         return set(self._store.list_names()) | self._unsaved
 
-    def _prompt_name(self, title: str, initial: str = "") -> str:
+    def _prompt_set_name(self, title: str, initial: str = "") -> str:
         """Ask for a save-set name; "" when cancelled, empty, or taken.
+
+        A collision-checking wrapper over the base :meth:`_prompt_name`
+        (the instance-monkeypatchable prompt seam).
 
         Parameters
         ----------
@@ -693,11 +596,8 @@ class SaveSetEditor(QDialog):
         str
             The accepted, stripped, collision-free name — or "".
         """
-        name, accepted = QInputDialog.getText(
-            self, title, "Save set name:", text=initial
-        )
-        name = name.strip()
-        if not accepted or not name:
+        name = self._prompt_name(title, "Save set name:", initial=initial)
+        if not name:
             return ""
         if name in self._known_names():
             self._show_message(f"A save set named {name!r} already exists.", error=True)
@@ -706,9 +606,9 @@ class SaveSetEditor(QDialog):
 
     def _on_new(self) -> None:
         """Create a new (empty, not-yet-valid) save set in memory."""
-        if not self._maybe_leave():
+        if not self._resolve_unsaved():
             return
-        name = self._prompt_name("New save set")
+        name = self._prompt_set_name("New save set")
         if not name:
             return
         self._adopt_unsaved(
@@ -721,9 +621,9 @@ class SaveSetEditor(QDialog):
             self._show_message("No save set selected.")
             return
         duplicate = copy.deepcopy(self._document)
-        if not self._maybe_leave():
+        if not self._resolve_unsaved():
             return
-        name = self._prompt_name(
+        name = self._prompt_set_name(
             "Duplicate save set", initial=f"{duplicate.get('name', '')}-copy"
         )
         if not name:
@@ -737,7 +637,7 @@ class SaveSetEditor(QDialog):
             self._show_message("No save set selected.")
             return
         old = self._current_name()
-        new = self._prompt_name("Rename save set", initial=old)
+        new = self._prompt_set_name("Rename save set", initial=old)
         if not new:
             return
         if old in self._unsaved:
@@ -761,14 +661,7 @@ class SaveSetEditor(QDialog):
             self._show_message("No save set selected.")
             return
         name = self._current_name()
-        choice = QMessageBox.question(
-            self,
-            "Delete save set",
-            f"Delete save set {name!r}?",
-            QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
-            QMessageBox.StandardButton.No,
-        )
-        if choice != QMessageBox.StandardButton.Yes:
+        if not self._confirm("Delete save set", f"Delete save set {name!r}?"):
             return
         if name in self._unsaved:
             self._unsaved.discard(name)

--- a/GEECS-Console/geecs_console/editors/scan_variable_editor.py
+++ b/GEECS-Console/geecs_console/editors/scan_variable_editor.py
@@ -38,18 +38,15 @@ from __future__ import annotations
 
 import copy
 import logging
-import threading
 from pathlib import Path
 from typing import Any, Callable, Optional
 
 from pydantic import ValidationError
-from PySide6.QtCore import QFile, QStringListModel, Qt, Signal, Slot
-from PySide6.QtGui import QCloseEvent, QKeyEvent
+from PySide6.QtCore import QStringListModel, Qt
 from PySide6.QtWidgets import (
     QComboBox,
     QCompleter,
     QDialog,
-    QInputDialog,
     QLabel,
     QLineEdit,
     QListWidget,
@@ -58,11 +55,10 @@ from PySide6.QtWidgets import (
     QPushButton,
     QStackedWidget,
     QTableWidget,
-    QVBoxLayout,
     QWidget,
 )
-from PySide6.QtUiTools import QUiLoader
 
+from geecs_console.editors.base import ConfigEditorDialog
 from geecs_console.services.device_completions import (
     CompletionsProvider,
     EmptyCompletions,
@@ -187,7 +183,7 @@ def _format_validation_error(exc: ValidationError, drafts: dict[str, dict]) -> s
     return "\n".join(shown)
 
 
-class ScanVariableEditor(QDialog):
+class ScanVariableEditor(ConfigEditorDialog):
     """Editor dialog for one experiment's scan-variable catalog.
 
     Parameters
@@ -203,9 +199,9 @@ class ScanVariableEditor(QDialog):
         Parent widget (the main window in production).
     """
 
-    #: The provider's ``{device: [variable, ...]}`` result (emitted from the
-    #: fetch daemon thread; delivered queued to :meth:`_apply_completions`).
-    completions_ready = Signal(object)
+    UI_PATH = _UI_PATH
+    INITIAL_SIZE = (900, 560)
+    COMPLETIONS_THREAD_NAME = "sve-completions-fetch"
 
     def __init__(
         self,
@@ -215,9 +211,7 @@ class ScanVariableEditor(QDialog):
     ) -> None:
         super().__init__(parent)
         self._store = store
-        self._completions = (
-            completions if completions is not None else EmptyCompletions()
-        )
+        self._init_completions(completions)
         #: name → plain field dict (a ScanVariableSpec dump; invalid
         #: intermediate states are representable while the operator types).
         self._variables: dict[str, dict] = {}
@@ -225,15 +219,9 @@ class ScanVariableEditor(QDialog):
         self._schema_version = 1
         self._current_name: Optional[str] = None
         self._loading = False
-        self._device_vars: dict[str, list[str]] = {}
-        #: True once the (async) completions fetch has been delivered on the
-        #: GUI thread — tests wait on this so no queued signal can land
-        #: during teardown.
-        self.completions_applied = False
 
-        #: Test seams: ask for a name (rename/duplicate/new) and confirm
-        #: discarding unsaved changes.  Defaults are the modal Qt dialogs.
-        self._ask_name: Callable[[str, str, str], Optional[str]] = self._ask_name_modal
+        #: Test seam: confirm discarding the draft on Revert (the leave
+        #: prompts go through the base `_prompt_unsaved` seam instead).
         self._confirm_discard: Callable[[], bool] = self._confirm_discard_modal
 
         self._load_ui()
@@ -241,7 +229,7 @@ class ScanVariableEditor(QDialog):
         self._populate_static_combos()
         self._build_completers()
         self._wire_signals()
-        self._disable_enter_accept()
+        self._guard_enter_keys()
 
         self.setWindowTitle(
             f"Scan Variables — {store.experiment}"
@@ -250,56 +238,11 @@ class ScanVariableEditor(QDialog):
         )
 
         self._reload_from_store(initial=True)
-
-        self.completions_ready.connect(
-            self._apply_completions, Qt.ConnectionType.QueuedConnection
-        )
         self._start_completions_fetch()
 
     # ------------------------------------------------------------------
     # Construction
     # ------------------------------------------------------------------
-
-    def _load_ui(self) -> None:
-        """Load the hand-authored .ui as this dialog's only child."""
-        loader = QUiLoader()
-        ui_file = QFile(str(_UI_PATH))
-        ui_file.open(QFile.OpenModeFlag.ReadOnly)
-        try:
-            self._ui: QWidget = loader.load(ui_file, self)
-        finally:
-            ui_file.close()
-        if self._ui is None:
-            raise RuntimeError(f"Failed to load {_UI_PATH}: {loader.errorString()}")
-        layout = QVBoxLayout(self)
-        layout.setContentsMargins(0, 0, 0, 0)
-        layout.addWidget(self._ui)
-        self.resize(900, 560)
-
-    def _child(self, cls: type, name: str) -> Any:
-        """Return the named child widget, failing loudly when missing.
-
-        Parameters
-        ----------
-        cls : type
-            Expected widget class.
-        name : str
-            The ``sve_``-prefixed object name in the .ui.
-
-        Returns
-        -------
-        QWidget
-            The resolved child.
-
-        Raises
-        ------
-        LookupError
-            When the .ui does not contain the widget.
-        """
-        widget = self._ui.findChild(cls, name)
-        if widget is None:
-            raise LookupError(f"{name!r} ({cls.__name__}) not found in {_UI_PATH}")
-        return widget
 
     def _bind_widgets(self) -> None:
         """Resolve every wired widget from the loaded .ui once."""
@@ -447,35 +390,9 @@ class ScanVariableEditor(QDialog):
         self.save_button.clicked.connect(self._on_save)
         self.close_button.clicked.connect(self.close)
 
-    def _disable_enter_accept(self) -> None:
-        """Ensure Enter never accepts the dialog (no default/auto-default buttons)."""
-        for button in self.findChildren(QPushButton):
-            button.setAutoDefault(False)
-            button.setDefault(False)
-
     # ------------------------------------------------------------------
     # Modal seams (overridable in tests)
     # ------------------------------------------------------------------
-
-    def _ask_name_modal(self, title: str, label: str, initial: str) -> Optional[str]:
-        """Ask for a variable name with a modal input dialog.
-
-        Parameters
-        ----------
-        title : str
-            Dialog window title.
-        label : str
-            Prompt text.
-        initial : str
-            Prefilled name.
-
-        Returns
-        -------
-        str or None
-            The entered name, or ``None`` on cancel.
-        """
-        name, accepted = QInputDialog.getText(self, title, label, text=initial)
-        return name if accepted else None
 
     def _confirm_discard_modal(self) -> bool:
         """Ask whether to discard unsaved changes (modal).
@@ -640,7 +557,7 @@ class ScanVariableEditor(QDialog):
         old = self._current_name
         if old is None:
             return
-        new = self._ask_name("Rename scan variable", "New name:", old)
+        new = self._prompt_name("Rename scan variable", "New name:", old)
         if new is None:
             return
         new = new.strip()
@@ -859,22 +776,45 @@ class ScanVariableEditor(QDialog):
     # Save / Revert / dirty
     # ------------------------------------------------------------------
 
-    def _on_save(self) -> None:
-        """Validate the draft and write it through the store (errors inline)."""
+    def _save_draft(self) -> bool:
+        """Validate the draft and write it through the store (errors inline).
+
+        Returns
+        -------
+        bool
+            ``True`` when the save landed (validation and write both OK).
+        """
         try:
             catalog = self._draft_catalog()
         except ValidationError as exc:
             self._show_error(_format_validation_error(exc, self._variables))
-            return
+            return False
         try:
             path = self._store.save(catalog)
         except ScanVariableStoreError as exc:
             self._show_error(str(exc))
-            return
+            return False
         self._snapshot = copy.deepcopy(self._variables)
         self._update_dirty()
         self._clear_error()
         self.dirty_label.setText(f"saved → {path}")
+        return True
+
+    def _on_save(self) -> None:
+        """Save button handler."""
+        self._save_draft()
+
+    def _has_unsaved(self) -> bool:
+        """Unsaved-changes hook: the draft differs from disk."""
+        return self.dirty
+
+    def _save_unsaved(self) -> bool:
+        """Unsaved-changes hook: persist the whole draft catalog."""
+        return self._save_draft()
+
+    def _unsaved_prompt_text(self) -> str:
+        """Describe the dirty draft in the unsaved-changes prompt."""
+        return "The scan-variable catalog has unsaved changes."
 
     def _on_revert(self) -> None:
         """Discard the draft and reload the catalog from disk (prompted)."""
@@ -905,42 +845,11 @@ class ScanVariableEditor(QDialog):
         self.error_label.setText("")
 
     # ------------------------------------------------------------------
-    # Completions
+    # Completions (scaffold on ConfigEditorDialog)
     # ------------------------------------------------------------------
 
-    def _start_completions_fetch(self) -> None:
-        """Fetch completions on a short-lived daemon thread (queued delivery)."""
-        provider = self._completions
-
-        def fetch() -> None:
-            """Run the provider's one blocking call off the GUI thread."""
-            try:
-                mapping = provider.device_variables()
-            except Exception as exc:  # noqa: BLE001 — providers should not raise
-                logger.info("completions fetch failed: %s", exc)
-                mapping = {}
-            self.completions_ready.emit(mapping)
-
-        threading.Thread(
-            target=fetch, name="sve-completions-fetch", daemon=True
-        ).start()
-
-    @Slot(object)
-    def _apply_completions(self, mapping: object) -> None:
-        """Install the fetched ``{device: [variable, ...]}`` word lists (GUI thread).
-
-        Parameters
-        ----------
-        mapping : dict
-            The provider result delivered by the queued signal.
-        """
-        self.completions_applied = True
-        if not isinstance(mapping, dict):
-            return
-        self._device_vars = {
-            str(device): [str(v) for v in variables]
-            for device, variables in mapping.items()
-        }
+    def _install_completions(self) -> None:
+        """Point every device/variable completer model at the fresh word lists."""
         self._device_model.setStringList(sorted(self._device_vars))
         self._refresh_variable_model(self._variable_model, self.device_edit.text())
         self._refresh_variable_model(
@@ -976,29 +885,8 @@ class ScanVariableEditor(QDialog):
                 variables = self._device_vars[matches[0]]
         model.setStringList(variables or [])
 
-    # ------------------------------------------------------------------
-    # Close paths (Enter never accepts; unsaved changes prompt)
-    # ------------------------------------------------------------------
-
-    def keyPressEvent(self, event: QKeyEvent) -> None:  # noqa: N802 (Qt override)
-        """Swallow Return/Enter so typing in a field never closes the dialog."""
-        if event.key() in (Qt.Key.Key_Return, Qt.Key.Key_Enter):
-            event.accept()
-            return
-        super().keyPressEvent(event)
-
-    def reject(self) -> None:
-        """Route Esc through the unsaved-changes prompt."""
-        if self.dirty and not self._confirm_discard():
-            return
-        super().reject()
-
-    def closeEvent(self, event: QCloseEvent) -> None:  # noqa: N802 (Qt override)
-        """Prompt before closing with unsaved changes."""
-        if self.dirty and not self._confirm_discard():
-            event.ignore()
-            return
-        event.accept()
+    # Close paths (keyPressEvent / reject / closeEvent): ConfigEditorDialog
+    # — the unsaved-changes prompt now offers Save alongside Discard/Cancel.
 
 
 def open_scan_variable_editor(

--- a/GEECS-Console/geecs_console/editors/shot_control_editor.py
+++ b/GEECS-Console/geecs_console/editors/shot_control_editor.py
@@ -30,32 +30,27 @@ from __future__ import annotations
 
 import copy
 import logging
-import threading
 from pathlib import Path
 from typing import Optional
 
-from PySide6.QtCore import QFile, Qt, Signal, Slot
-from PySide6.QtGui import QKeyEvent
-from PySide6.QtUiTools import QUiLoader
+from PySide6.QtCore import Qt
 from PySide6.QtWidgets import (
     QAbstractItemView,
     QComboBox,
     QCompleter,
     QDialog,
-    QInputDialog,
     QLabel,
     QLineEdit,
     QListWidget,
-    QMessageBox,
     QPushButton,
     QStyledItemDelegate,
     QTreeWidget,
     QTreeWidgetItem,
-    QVBoxLayout,
     QWidget,
 )
 from pydantic import ValidationError
 
+from geecs_console.editors.base import ConfigEditorDialog
 from geecs_console.services.device_completions import (
     CompletionsProvider,
     EmptyCompletions,
@@ -157,7 +152,7 @@ class _WriteCellDelegate(QStyledItemDelegate):
         return line_edit
 
 
-class ShotControlEditor(QDialog):
+class ShotControlEditor(ConfigEditorDialog):
     """Modeless editor dialog for one experiment's trigger profiles.
 
     Parameters
@@ -177,9 +172,9 @@ class ShotControlEditor(QDialog):
         daemon thread, never the GUI thread.
     """
 
-    #: One ``{device: [variable, ...]}`` mapping (emitted from the fetch
-    #: daemon thread; delivered queued to :meth:`_apply_completions`).
-    completions_ready = Signal(object)
+    UI_PATH = _UI_PATH
+    INITIAL_SIZE = (920, 560)
+    COMPLETIONS_THREAD_NAME = "sce-completions-fetch"
 
     def __init__(
         self,
@@ -191,16 +186,7 @@ class ShotControlEditor(QDialog):
         super().__init__(parent)
         self._experiment = experiment
         self._store = store if store is not None else TriggerProfileStore(experiment)
-        self._completions = (
-            completions if completions is not None else EmptyCompletions()
-        )
-        #: The fetched completion word lists (empty until the fetch lands).
-        self._device_vars: dict[str, list[str]] = {}
-        #: True once the (async) completions fetch has been delivered on the
-        #: GUI thread — tests wait on this instead of sleeping.
-        self.completions_applied = False
-        #: Guards the one-shot signal disconnect in :meth:`closeEvent`.
-        self._completions_disconnected = False
+        self._init_completions(completions)
 
         #: The working document: a TriggerProfile ``model_dump(mode="json")``
         #: dict, kept current on every edit.  ``None`` = no profile loaded.
@@ -216,13 +202,9 @@ class ShotControlEditor(QDialog):
 
         self._load_ui()
         self._bind_widgets()
+        self._guard_enter_keys()
         self._wire_signals()
         self.setWindowTitle(f"Trigger profiles — {experiment or 'no experiment'}")
-        # Force queued: the fetch emits from a daemon thread, and a direct
-        # delivery would touch state on the wrong thread.
-        self.completions_ready.connect(
-            self._apply_completions, Qt.ConnectionType.QueuedConnection
-        )
         self._start_completions_fetch()
         self._refresh_profile_list()
         self._show_document(None)
@@ -230,29 +212,6 @@ class ShotControlEditor(QDialog):
     # ------------------------------------------------------------------
     # Construction
     # ------------------------------------------------------------------
-
-    def _load_ui(self) -> None:
-        """Load the hand-authored .ui into the dialog's layout."""
-        loader = QUiLoader()
-        ui_file = QFile(str(_UI_PATH))
-        ui_file.open(QFile.OpenModeFlag.ReadOnly)
-        try:
-            self._ui: QWidget = loader.load(ui_file, self)
-        finally:
-            ui_file.close()
-        if self._ui is None:
-            raise RuntimeError(f"Failed to load {_UI_PATH}: {loader.errorString()}")
-        layout = QVBoxLayout(self)
-        layout.setContentsMargins(0, 0, 0, 0)
-        layout.addWidget(self._ui)
-        self.resize(920, 560)
-
-    def _child(self, cls: type, name: str):
-        """Return the named child widget, failing loudly when missing."""
-        widget = self._ui.findChild(cls, name)
-        if widget is None:
-            raise LookupError(f"{name!r} ({cls.__name__}) not found in {_UI_PATH}")
-        return widget
 
     def _bind_widgets(self) -> None:
         """Resolve every wired widget from the loaded .ui once."""
@@ -292,12 +251,6 @@ class ShotControlEditor(QDialog):
         self.dirty_label: QLabel = self._child(QLabel, "sce_dirty_label")
         self.revert_button: QPushButton = self._child(QPushButton, "sce_revert_button")
         self.save_button: QPushButton = self._child(QPushButton, "sce_save_button")
-
-        # Enter must never accept the dialog: no default/auto-default
-        # buttons anywhere (keyPressEvent below swallows the rest).
-        for button in self._ui.findChildren(QPushButton):
-            button.setAutoDefault(False)
-            button.setDefault(False)
 
         # Keep a Python reference for the delegate's full lifetime —
         # setItemDelegate does not take ownership, and a GC'd wrapper with
@@ -356,43 +309,10 @@ class ShotControlEditor(QDialog):
         """The fetched ``{device: [variable, ...]}`` completion word lists."""
         return self._device_vars
 
-    def _start_completions_fetch(self) -> None:
-        """Fetch completions on a short-lived daemon thread (queued delivery)."""
-        provider = self._completions
-
-        def fetch() -> None:
-            """Run the provider's one blocking call off the GUI thread."""
-            try:
-                mapping = provider.device_variables()
-            except Exception as exc:  # noqa: BLE001 — providers should not raise
-                logger.info("completions fetch failed: %s", exc)
-                mapping = {}
-            self.completions_ready.emit(mapping)
-
-        threading.Thread(
-            target=fetch, name="sce-completions-fetch", daemon=True
-        ).start()
-
-    @Slot(object)
-    def _apply_completions(self, mapping: object) -> None:
-        """Store the fetched word lists (GUI-thread slot, delivered queued).
-
-        Cell editors read :attr:`device_vars` when they open, so suggestions
-        that land after the dialog is up appear on the next edit — no
-        completer replumbing needed.
-
-        Parameters
-        ----------
-        mapping : dict
-            The provider result delivered by the queued signal.
-        """
-        self.completions_applied = True
-        if not isinstance(mapping, dict):
-            return
-        self._device_vars = {
-            str(device): [str(variable) for variable in variables]
-            for device, variables in mapping.items()
-        }
+    # Completions plumbing lives on ConfigEditorDialog; no
+    # _install_completions override — cell editors read :attr:`device_vars`
+    # when they open, so suggestions that land after the dialog is up
+    # appear on the next edit, with no completer replumbing needed.
 
     def is_dirty(self) -> bool:
         """Whether the working document differs from the loaded snapshot.
@@ -404,91 +324,17 @@ class ShotControlEditor(QDialog):
         """
         return self._doc is not None and self._doc != self._snapshot
 
-    def _prompt_text(self, title: str, label: str, default: str = "") -> str:
-        """Ask the operator for one line of text ("" = cancelled).
+    def _has_unsaved(self) -> bool:
+        """Unsaved-changes hook: the working doc differs from the snapshot."""
+        return self.is_dirty()
 
-        Parameters
-        ----------
-        title : str
-            Dialog title.
-        label : str
-            Prompt label.
-        default : str, optional
-            Pre-filled text.
+    def _save_unsaved(self) -> bool:
+        """Unsaved-changes hook: persist the working document."""
+        return self._save_current()
 
-        Returns
-        -------
-        str
-            The stripped answer, or "" when cancelled/empty.
-        """
-        text, accepted = QInputDialog.getText(self, title, label, text=default)
-        return text.strip() if accepted else ""
-
-    def _confirm(self, title: str, text: str) -> bool:
-        """Ask a yes/no question (used for deletes).
-
-        Parameters
-        ----------
-        title : str
-            Dialog title.
-        text : str
-            The question.
-
-        Returns
-        -------
-        bool
-            ``True`` on Yes.
-        """
-        answer = QMessageBox.question(
-            self,
-            title,
-            text,
-            QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
-            QMessageBox.StandardButton.No,
-        )
-        return answer == QMessageBox.StandardButton.Yes
-
-    def _prompt_unsaved(self) -> str:
-        """Ask what to do with unsaved changes.
-
-        Returns
-        -------
-        str
-            ``"save"``, ``"discard"``, or ``"cancel"``.
-        """
-        box = QMessageBox(self)
-        box.setIcon(QMessageBox.Icon.Warning)
-        box.setWindowTitle("Unsaved changes")
-        box.setText(f"Trigger profile {self._current_name!r} has unsaved changes.")
-        save = box.addButton("Save", QMessageBox.ButtonRole.AcceptRole)
-        discard = box.addButton("Discard", QMessageBox.ButtonRole.DestructiveRole)
-        box.addButton("Cancel", QMessageBox.ButtonRole.RejectRole)
-        box.setDefaultButton(save)
-        box.exec()
-        clicked = box.clickedButton()
-        if clicked is save:
-            return "save"
-        if clicked is discard:
-            return "discard"
-        return "cancel"
-
-    def _resolve_unsaved(self) -> bool:
-        """Settle unsaved edits before leaving the current profile.
-
-        Returns
-        -------
-        bool
-            ``True`` when it is safe to proceed (nothing dirty, saved, or
-            discarded); ``False`` on cancel or a failed save.
-        """
-        if not self.is_dirty():
-            return True
-        choice = self._prompt_unsaved()
-        if choice == "cancel":
-            return False
-        if choice == "save":
-            return self._save_current()
-        return True  # discard
+    def _unsaved_prompt_text(self) -> str:
+        """Name the dirty profile in the unsaved-changes prompt."""
+        return f"Trigger profile {self._current_name!r} has unsaved changes."
 
     # ------------------------------------------------------------------
     # Document handling (the working dict IS model_dump(mode="json"))
@@ -791,7 +637,7 @@ class ShotControlEditor(QDialog):
         """Create (and immediately save) an empty profile."""
         if not self._resolve_unsaved():
             return
-        name = self._prompt_text("New trigger profile", "Profile name:")
+        name = self._prompt_name("New trigger profile", "Profile name:")
         if not name:
             return
         if self._store.exists(name):
@@ -813,8 +659,8 @@ class ShotControlEditor(QDialog):
             return
         if not self._resolve_unsaved():
             return
-        name = self._prompt_text(
-            "Duplicate trigger profile", "New profile name:", default=f"{source}-copy"
+        name = self._prompt_name(
+            "Duplicate trigger profile", "New profile name:", initial=f"{source}-copy"
         )
         if not name:
             return
@@ -838,8 +684,8 @@ class ShotControlEditor(QDialog):
             return
         if not self._resolve_unsaved():
             return
-        name = self._prompt_text(
-            "Rename trigger profile", "New profile name:", default=source
+        name = self._prompt_name(
+            "Rename trigger profile", "New profile name:", initial=source
         )
         if not name or name == source:
             return
@@ -892,7 +738,7 @@ class ShotControlEditor(QDialog):
         """Add an empty variant and switch the tree to it."""
         if self._doc is None:
             return
-        name = self._prompt_text("Add variant", "Variant name:")
+        name = self._prompt_name("Add variant", "Variant name:")
         if not name:
             return
         if name == BASE_LAYER or name in self._doc["variants"]:
@@ -1065,33 +911,8 @@ class ShotControlEditor(QDialog):
         if self._current_name:
             self._load_profile(self._current_name)
 
-    def keyPressEvent(self, event: QKeyEvent) -> None:  # noqa: N802 — Qt override
-        """Swallow Return/Enter so it never accepts (closes) the dialog."""
-        if event.key() in (Qt.Key.Key_Return, Qt.Key.Key_Enter):
-            event.accept()
-            return
-        super().keyPressEvent(event)
-
-    def closeEvent(self, event) -> None:  # noqa: N802 — Qt override
-        """Prompt for unsaved changes before closing.
-
-        Only a *visible* dialog prompts — there is an operator to ask.  A
-        programmatic close of a hidden dialog (test teardown, app shutdown)
-        must never block on a modal nobody can answer.
-        """
-        if self.isVisible() and not self._resolve_unsaved():
-            event.ignore()
-            return
-        # A still-running completions fetch must not queue an event onto a
-        # dialog being torn down.  Once only: closeEvent can run twice
-        # (explicit close + owner teardown) and a second disconnect warns.
-        if not self._completions_disconnected:
-            self._completions_disconnected = True
-            try:
-                self.completions_ready.disconnect(self._apply_completions)
-            except (RuntimeError, TypeError):
-                pass
-        super().closeEvent(event)
+    # keyPressEvent / closeEvent / reject: ConfigEditorDialog (Esc now
+    # routes through the unsaved-changes prompt like every other close).
 
 
 def open_shot_control_editor(

--- a/GEECS-Console/pyproject.toml
+++ b/GEECS-Console/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-console"
-version = "0.17.2"
+version = "0.18.0"
 description = "Greenfield PySide6 operator console for GEECS (Bluesky/gateway architecture)"
 authors = ["Sam Barber <sbarber@lbl.gov>"]
 readme = "README.md"

--- a/GEECS-Console/tests/test_action_library_editor.py
+++ b/GEECS-Console/tests/test_action_library_editor.py
@@ -2,7 +2,7 @@
 
 Every editor is registered with ``qtbot.addWidget`` so pytest-qt owns the
 teardown (close + deletion) — no test ends with a shown widget that only a
-local variable references.  The modal prompt seams (``_confirm_discard``,
+local variable references.  The modal prompt seams (``_prompt_unsaved``,
 ``_confirm_delete``, ``_prompt_name``) are always stubbed, so no test — and
 no teardown ``closeEvent`` — can ever block on a real ``QMessageBox``.
 """
@@ -92,7 +92,7 @@ def make_editor(qtbot, root, experiment=EXPERIMENT, completions=None):
     editor = ActionLibraryEditor(store=store, completions=completions)
     qtbot.addWidget(editor)
     # Never let a teardown closeEvent block on a modal box.
-    editor._confirm_discard = lambda: True
+    editor._prompt_unsaved = lambda: "discard"
     editor._confirm_delete = lambda name: True
     # Let the queued completions delivery land before the test body runs, so
     # no fetch signal can arrive after teardown.
@@ -118,7 +118,7 @@ class TestOffline:
     def test_entry_point_opens_offline(self, qtbot, tmp_path):
         dialog = open_action_library_editor(None, "", configs_base=tmp_path / "nowhere")
         qtbot.addWidget(dialog)
-        dialog._confirm_discard = lambda: True
+        dialog._prompt_unsaved = lambda: "discard"
         qtbot.waitUntil(lambda: dialog.completions_applied, timeout=2000)
         assert dialog.isVisible()
         assert dialog.plan_list.count() == 0
@@ -337,12 +337,12 @@ class TestDirtyRevertPrompt:
         editor = make_editor(qtbot, root)
         select_plan(editor, "close_shutters")
         qtbot.keyClicks(editor.description_edit, "!")
-        editor._confirm_discard = lambda: False
+        editor._prompt_unsaved = lambda: "cancel"
         select_plan(editor, "closeout")
         assert editor._current == "close_shutters"
         assert editor.plan_list.currentItem().text() == "close_shutters"
         assert editor._dirty
-        editor._confirm_discard = lambda: True
+        editor._prompt_unsaved = lambda: "discard"
         select_plan(editor, "closeout")
         assert editor._current == "closeout"
         assert not editor._dirty
@@ -353,11 +353,11 @@ class TestDirtyRevertPrompt:
         qtbot.keyClicks(editor.description_edit, "!")
         editor.show()
         qtbot.waitExposed(editor)
-        editor._confirm_discard = lambda: False
+        editor._prompt_unsaved = lambda: "cancel"
         editor.close()
         qtbot.wait(10)
         assert editor.isVisible()
-        editor._confirm_discard = lambda: True
+        editor._prompt_unsaved = lambda: "discard"
         editor.close()
         qtbot.wait(10)
         assert not editor.isVisible()
@@ -381,7 +381,7 @@ class TestEnterKey:
 class TestPlanLifecycle:
     def test_new_plan_saves_into_store(self, qtbot, root):
         editor = make_editor(qtbot, root)
-        editor._prompt_name = lambda title, initial="": "fresh_plan"
+        editor._prompt_name = lambda *args, **kwargs: "fresh_plan"
         editor.new_button.click()
         assert editor._current == "fresh_plan"
         assert editor._dirty
@@ -394,7 +394,7 @@ class TestPlanLifecycle:
 
     def test_new_plan_discarded_when_switching_away(self, qtbot, root):
         editor = make_editor(qtbot, root)
-        editor._prompt_name = lambda title, initial="": "temp_plan"
+        editor._prompt_name = lambda *args, **kwargs: "temp_plan"
         editor.new_button.click()
         select_plan(editor, "close_shutters")
         names = [
@@ -405,7 +405,7 @@ class TestPlanLifecycle:
 
     def test_new_plan_rejects_existing_name(self, qtbot, root):
         editor = make_editor(qtbot, root)
-        editor._prompt_name = lambda title, initial="": "close_shutters"
+        editor._prompt_name = lambda *args, **kwargs: "close_shutters"
         editor.new_button.click()
         assert "already exists" in editor.error_label.text()
         assert editor._current is None
@@ -413,7 +413,7 @@ class TestPlanLifecycle:
     def test_duplicate_plan(self, qtbot, root):
         editor = make_editor(qtbot, root)
         select_plan(editor, "close_shutters")
-        editor._prompt_name = lambda title, initial="": "shutters_copy"
+        editor._prompt_name = lambda *args, **kwargs: "shutters_copy"
         editor.duplicate_button.click()
         assert editor._current == "shutters_copy"
         assert editor._dirty
@@ -426,7 +426,7 @@ class TestPlanLifecycle:
     def test_rename_updates_references_and_selection(self, qtbot, root):
         editor = make_editor(qtbot, root)
         select_plan(editor, "close_shutters")
-        editor._prompt_name = lambda title, initial="": "shut_all"
+        editor._prompt_name = lambda *args, **kwargs: "shut_all"
         editor.rename_button.click()
         assert editor._current == "shut_all"
         assert editor.plan_list.currentItem().text() == "shut_all"
@@ -484,7 +484,7 @@ class TestCompletions:
         store = ActionLibraryStore(EXPERIMENT, experiments_root=root)
         editor = ActionLibraryEditor(store=store, completions=provider)
         qtbot.addWidget(editor)
-        editor._confirm_discard = lambda: True
+        editor._prompt_unsaved = lambda: "discard"
         qtbot.waitUntil(lambda: editor.completions_applied, timeout=2000)
         assert editor._device_completer_model.stringList() == ["U_A"]
 

--- a/GEECS-Console/tests/test_action_library_editor.py
+++ b/GEECS-Console/tests/test_action_library_editor.py
@@ -127,18 +127,27 @@ class TestOffline:
         assert not dialog.isVisible()
 
     def test_editor_module_source_has_no_ca_or_execution_imports(self):
-        """Editing only: the editor never imports the CA stack (source pin)."""
-        import geecs_console.editors.action_library_editor as module
+        """Editing only: the editor never imports the CA stack (source pin).
+
+        The pin travels with the scaffolding: the shared base and the
+        completions seam it imports are checked too, so a CA import cannot
+        sneak in through the module chain the editor actually loads.
+        """
         from pathlib import Path
 
-        source = Path(module.__file__).read_text(encoding="utf-8")
-        for forbidden in (
-            "import aioca",
-            "import caproto",
-            "from aioca",
-            "from caproto",
-        ):
-            assert forbidden not in source
+        import geecs_console.editors.action_library_editor as module
+        import geecs_console.editors.base as base_module
+        import geecs_console.services.device_completions as completions_module
+
+        for checked in (module, base_module, completions_module):
+            source = Path(checked.__file__).read_text(encoding="utf-8")
+            for forbidden in (
+                "import aioca",
+                "import caproto",
+                "from aioca",
+                "from caproto",
+            ):
+                assert forbidden not in source, checked.__name__
 
 
 class TestNoExecutionSurface:
@@ -409,6 +418,41 @@ class TestPlanLifecycle:
         editor.new_button.click()
         assert "already exists" in editor.error_label.text()
         assert editor._current is None
+
+    def test_discarded_phantom_leaves_no_ghost_on_a_canceled_prompt(self, qtbot, root):
+        """New → Discard → cancel the name prompt must leave a coherent editor.
+
+        Pins the PR-#588 review finding: the discard hook must really
+        discard (list and widgets included), because New/Duplicate can
+        still bail out afterwards — a flag-only discard left a ghost row
+        that Save would happily persist.
+        """
+        editor = make_editor(qtbot, root)
+        editor._prompt_name = lambda *args, **kwargs: "temp_plan"
+        editor.new_button.click()
+        assert editor._dirty and editor._phantom == "temp_plan"
+        editor._prompt_unsaved = lambda: "discard"
+        editor._prompt_name = lambda *args, **kwargs: None  # cancel the name
+        editor.new_button.click()
+        names = [
+            editor.plan_list.item(i).text() for i in range(editor.plan_list.count())
+        ]
+        assert "temp_plan" not in names
+        assert editor._current is None
+        assert not editor._dirty
+        # And Save cannot write the plan the operator just discarded.
+        assert not editor._save_plan()
+        assert "temp_plan" not in store_of(root).list_names()
+
+    def test_save_choice_on_switch_persists_the_plan(self, qtbot, root):
+        """The leave-prompt's Save option (new in the shared base) writes."""
+        editor = make_editor(qtbot, root)
+        select_plan(editor, "close_shutters")
+        qtbot.keyClicks(editor.description_edit, "!")
+        editor._prompt_unsaved = lambda: "save"
+        select_plan(editor, "closeout")
+        assert editor._current == "closeout"
+        assert store_of(root).load("close_shutters").description.endswith("!")
 
     def test_duplicate_plan(self, qtbot, root):
         editor = make_editor(qtbot, root)

--- a/GEECS-Console/tests/test_save_set_editor.py
+++ b/GEECS-Console/tests/test_save_set_editor.py
@@ -3,9 +3,8 @@
 import pytest
 import yaml
 from PySide6.QtCore import Qt
-from PySide6.QtWidgets import QMessageBox, QPushButton
+from PySide6.QtWidgets import QPushButton
 
-from geecs_console.editors import save_set_editor as sse
 from geecs_console.editors.save_set_editor import SaveSetEditor, open_save_set_editor
 from geecs_console.services.device_completions import GeecsDbCompletions
 from geecs_console.services.save_set_store import SaveSetStore
@@ -105,14 +104,18 @@ def select_set(editor, name):
     raise AssertionError(f"{name!r} not in the set list")
 
 
-def answer(monkeypatch, button):
-    monkeypatch.setattr(sse.QMessageBox, "question", lambda *args, **kwargs: button)
+def answer_unsaved(monkeypatch, editor, choice):
+    """Answer the unsaved-changes prompt via its instance seam."""
+    monkeypatch.setattr(editor, "_prompt_unsaved", lambda: choice)
 
 
-def type_name(monkeypatch, name):
-    monkeypatch.setattr(
-        sse.QInputDialog, "getText", lambda *args, **kwargs: (name, True)
-    )
+def answer_confirm(monkeypatch, editor, yes):
+    """Answer the yes/no confirm (deletes) via its instance seam."""
+    monkeypatch.setattr(editor, "_confirm", lambda *args, **kwargs: yes)
+
+
+def type_name(monkeypatch, editor, name):
+    monkeypatch.setattr(editor, "_prompt_name", lambda *args, **kwargs: name)
 
 
 class TestOpening:
@@ -165,7 +168,7 @@ class TestOpening:
         assert dialog.isVisible()
         # Let the completions fetch land before teardown so its queued
         # signal delivery cannot outlive the dialog.
-        qtbot.waitUntil(lambda: dialog._completions_loaded, timeout=2000)
+        qtbot.waitUntil(lambda: dialog.completions_applied, timeout=2000)
 
     def test_db_completions_with_no_experiment_is_empty(self):
         # The production provider's no-experiment early-out — no imports,
@@ -237,7 +240,7 @@ class TestUnsavedChangesPrompt:
         select_set(editor, "diag")
         row = editor.set_list.currentRow()
         editor.description_edit.setText("scribble")
-        answer(monkeypatch, QMessageBox.StandardButton.Cancel)
+        answer_unsaved(monkeypatch, editor, "cancel")
         select_set(editor, "beam")
         assert editor.set_list.currentRow() == row
         assert editor.description_edit.text() == "scribble"
@@ -245,7 +248,7 @@ class TestUnsavedChangesPrompt:
     def test_discard_switches_and_drops_the_edits(self, editor, monkeypatch):
         select_set(editor, "diag")
         editor.description_edit.setText("scribble")
-        answer(monkeypatch, QMessageBox.StandardButton.Discard)
+        answer_unsaved(monkeypatch, editor, "discard")
         select_set(editor, "beam")
         assert editor.name_label.text() == "beam"
         select_set(editor, "diag")
@@ -254,7 +257,7 @@ class TestUnsavedChangesPrompt:
     def test_save_choice_persists_before_switching(self, editor, store, monkeypatch):
         select_set(editor, "diag")
         editor.description_edit.setText("kept")
-        answer(monkeypatch, QMessageBox.StandardButton.Save)
+        answer_unsaved(monkeypatch, editor, "save")
         select_set(editor, "beam")
         assert editor.name_label.text() == "beam"
         assert store.load("diag").description == "kept"
@@ -263,10 +266,10 @@ class TestUnsavedChangesPrompt:
         editor.show()
         select_set(editor, "diag")
         editor.description_edit.setText("scribble")
-        answer(monkeypatch, QMessageBox.StandardButton.Cancel)
+        answer_unsaved(monkeypatch, editor, "cancel")
         editor.close()
         assert editor.isVisible()
-        answer(monkeypatch, QMessageBox.StandardButton.Discard)
+        answer_unsaved(monkeypatch, editor, "discard")
         editor.close()
         assert not editor.isVisible()
 
@@ -275,7 +278,7 @@ class TestListActions:
     def test_new_set_is_invalid_until_a_device_is_added(
         self, editor, store, tmp_path, monkeypatch
     ):
-        type_name(monkeypatch, "fresh")
+        type_name(monkeypatch, editor, "fresh")
         editor.new_button.click()
         assert editor.name_label.text() == "fresh"
         assert not editor.save_button.isEnabled()
@@ -288,14 +291,14 @@ class TestListActions:
         assert store.load("fresh").entries[0].device == "UC_NewCam"
 
     def test_new_name_collision_is_refused(self, editor, monkeypatch):
-        type_name(monkeypatch, "diag")
+        type_name(monkeypatch, editor, "diag")
         editor.new_button.click()
         assert "already exists" in editor.message_label.text()
         assert editor.set_list.count() == 2
 
     def test_duplicate_copies_the_open_set(self, editor, store, monkeypatch):
         select_set(editor, "diag")
-        type_name(monkeypatch, "diag-copy")
+        type_name(monkeypatch, editor, "diag-copy")
         editor.duplicate_button.click()
         assert editor.name_label.text() == "diag-copy"
         assert editor.save_button.isEnabled()  # a duplicate starts dirty & valid
@@ -304,7 +307,7 @@ class TestListActions:
 
     def test_rename_updates_file_and_form(self, editor, store, monkeypatch):
         select_set(editor, "diag")
-        type_name(monkeypatch, "diag2")
+        type_name(monkeypatch, editor, "diag2")
         editor.rename_button.click()
         assert editor.name_label.text() == "diag2"
         assert store.list_names() == ["beam", "diag2"]
@@ -312,7 +315,7 @@ class TestListActions:
 
     def test_delete_removes_the_set(self, editor, store, monkeypatch):
         select_set(editor, "diag")
-        answer(monkeypatch, QMessageBox.StandardButton.Yes)
+        answer_confirm(monkeypatch, editor, True)
         editor.delete_button.click()
         assert store.list_names() == ["beam"]
         assert editor.name_label.text() == "—"
@@ -320,7 +323,7 @@ class TestListActions:
 
     def test_delete_no_leaves_everything_alone(self, editor, store, monkeypatch):
         select_set(editor, "diag")
-        answer(monkeypatch, QMessageBox.StandardButton.No)
+        answer_confirm(monkeypatch, editor, False)
         editor.delete_button.click()
         assert store.list_names() == ["beam", "diag"]
         assert editor.name_label.text() == "diag"
@@ -361,8 +364,8 @@ class TestCompleters:
                 experiment="HTU", store=store, completions=ExplodingCompletions()
             )
         )
-        qtbot.waitUntil(lambda: editor._completions_loaded, timeout=2000)
-        assert editor._completions == {}
+        qtbot.waitUntil(lambda: editor.completions_applied, timeout=2000)
+        assert editor._device_vars == {}
         assert editor._device_model.stringList() == []
 
 

--- a/GEECS-Console/tests/test_scan_variable_editor.py
+++ b/GEECS-Console/tests/test_scan_variable_editor.py
@@ -86,7 +86,8 @@ def make_editor(qtbot, tmp_path, experiment=EXPERIMENT, completions=None):
         completions=completions if completions is not None else EmptyCompletions(),
     )
     qtbot.addWidget(editor)
-    editor._confirm_discard = lambda: True  # teardown close must never block
+    editor._confirm_discard = lambda: True  # revert confirms (teardown safety)
+    editor._prompt_unsaved = lambda: "discard"  # teardown close must never block
     qtbot.waitUntil(lambda: editor.completions_applied, timeout=5000)
     return editor
 
@@ -126,7 +127,7 @@ class TestOpenOffline:
             None, EXPERIMENT, configs_base=tmp_path, completions=EmptyCompletions()
         )
         qtbot.addWidget(dialog)
-        dialog._confirm_discard = lambda: True
+        dialog._prompt_unsaved = lambda: "discard"
         qtbot.waitUntil(lambda: dialog.completions_applied, timeout=5000)
         assert isinstance(dialog, QDialog)
         assert dialog.isVisible()
@@ -348,7 +349,7 @@ class TestRenameDuplicateDelete:
         seed_catalog(tmp_path)
         editor = make_editor(qtbot, tmp_path)
         select_variable(editor, "jet_z")
-        editor._ask_name = lambda *args, **kwargs: "jet_z_new"
+        editor._prompt_name = lambda *args, **kwargs: "jet_z_new"
         editor.rename_button.click()
         assert list_names(editor) == ["jet_z_new", "emq1_current", "angle_offset_x"]
         assert editor.dirty
@@ -363,7 +364,7 @@ class TestRenameDuplicateDelete:
         seed_catalog(tmp_path)
         editor = make_editor(qtbot, tmp_path)
         select_variable(editor, "jet_z")
-        editor._ask_name = lambda *args, **kwargs: "emq1_current"
+        editor._prompt_name = lambda *args, **kwargs: "emq1_current"
         editor.rename_button.click()
         assert "already exists" in editor.error_label.text()
         assert "jet_z" in list_names(editor)
@@ -372,7 +373,7 @@ class TestRenameDuplicateDelete:
         seed_catalog(tmp_path)
         editor = make_editor(qtbot, tmp_path)
         select_variable(editor, "jet_z")
-        editor._ask_name = lambda *args, **kwargs: None
+        editor._prompt_name = lambda *args, **kwargs: None
         editor.rename_button.click()
         assert not editor.dirty
 
@@ -438,10 +439,10 @@ class TestDirtyRevertClose:
         editor.show()
         select_variable(editor, "jet_z")
         editor.device_edit.setText("U_Elsewhere")
-        editor._confirm_discard = lambda: False
+        editor._prompt_unsaved = lambda: "cancel"
         editor.close()
         assert editor.isVisible()  # the ignored close left it open
-        editor._confirm_discard = lambda: True
+        editor._prompt_unsaved = lambda: "discard"
         editor.close()
         assert not editor.isVisible()
 
@@ -450,7 +451,7 @@ class TestDirtyRevertClose:
         editor = make_editor(qtbot, tmp_path)
         editor.show()
         prompts = []
-        editor._confirm_discard = lambda: prompts.append(1) or True
+        editor._prompt_unsaved = lambda: prompts.append(1) or "discard"
         editor.close()
         assert prompts == []
         assert not editor.isVisible()

--- a/GEECS-Console/tests/test_scan_variable_editor.py
+++ b/GEECS-Console/tests/test_scan_variable_editor.py
@@ -456,6 +456,37 @@ class TestDirtyRevertClose:
         assert prompts == []
         assert not editor.isVisible()
 
+    def test_close_discard_prompts_exactly_once(self, qtbot, tmp_path):
+        """QDialog routes a visible close through reject(); only reject prompts.
+
+        Pins the PR-#588 review finding: with both closeEvent and reject
+        prompting, a computed-dirty editor (draft ≠ snapshot survives the
+        discard) asked twice on Discard.
+        """
+        seed_catalog(tmp_path)
+        editor = make_editor(qtbot, tmp_path)
+        editor.show()
+        select_variable(editor, "jet_z")
+        editor.device_edit.setText("U_Elsewhere")
+        prompts = []
+        editor._prompt_unsaved = lambda: prompts.append(1) or "discard"
+        editor.close()
+        assert not editor.isVisible()
+        assert prompts == [1]
+
+    def test_close_save_choice_persists_the_draft(self, qtbot, tmp_path):
+        """The leave-prompt's Save option (new in the shared base) writes."""
+        seed_catalog(tmp_path)
+        editor = make_editor(qtbot, tmp_path)
+        editor.show()
+        select_variable(editor, "jet_z")
+        editor.device_edit.setText("U_Elsewhere")
+        editor._prompt_unsaved = lambda: "save"
+        editor.close()
+        assert not editor.isVisible()
+        document = catalog_document(tmp_path)
+        assert document["variables"]["jet_z"]["target"].startswith("U_Elsewhere:")
+
 
 class TestCompleters:
     MAPPING = {

--- a/GEECS-Console/tests/test_shot_control_editor.py
+++ b/GEECS-Console/tests/test_shot_control_editor.py
@@ -264,7 +264,7 @@ class TestVariants:
 
     def test_add_variant(self, editor, store, monkeypatch):
         select_profile(editor, "HTU-Normal")
-        monkeypatch.setattr(editor, "_prompt_text", lambda *a, **k: "no_gas")
+        monkeypatch.setattr(editor, "_prompt_name", lambda *a, **k: "no_gas")
         editor.add_variant_button.click()
         assert editor.variant_combo.currentText() == "no_gas"
         assert editor.is_dirty()
@@ -273,7 +273,7 @@ class TestVariants:
 
     def test_add_variant_rejects_taken_names(self, editor, monkeypatch):
         select_profile(editor, "HTU-Normal")
-        monkeypatch.setattr(editor, "_prompt_text", lambda *a, **k: "laser_off")
+        monkeypatch.setattr(editor, "_prompt_name", lambda *a, **k: "laser_off")
         editor.add_variant_button.click()
         assert "taken" in editor.validation_label.text()
 
@@ -289,20 +289,20 @@ class TestVariants:
 
 class TestProfileOperations:
     def test_new_profile_is_saved_and_selected(self, editor, store, monkeypatch):
-        monkeypatch.setattr(editor, "_prompt_text", lambda *a, **k: "Fresh")
+        monkeypatch.setattr(editor, "_prompt_name", lambda *a, **k: "Fresh")
         editor.new_button.click()
         assert store.load("Fresh") == TriggerProfile(name="Fresh")
         assert editor.profile_list.currentItem().text() == "Fresh"
         assert "Fresh" in editor.profile_name_label.text()
 
     def test_new_profile_refuses_existing_names(self, editor, store, monkeypatch):
-        monkeypatch.setattr(editor, "_prompt_text", lambda *a, **k: "Minimal")
+        monkeypatch.setattr(editor, "_prompt_name", lambda *a, **k: "Minimal")
         editor.new_button.click()
         assert "already exists" in editor.validation_label.text()
 
     def test_duplicate_profile(self, editor, store, monkeypatch):
         select_profile(editor, "HTU-Normal")
-        monkeypatch.setattr(editor, "_prompt_text", lambda *a, **k: "HTU-Copy")
+        monkeypatch.setattr(editor, "_prompt_name", lambda *a, **k: "HTU-Copy")
         editor.duplicate_button.click()
         copied = store.load("HTU-Copy")
         assert copied.name == "HTU-Copy"
@@ -311,7 +311,7 @@ class TestProfileOperations:
 
     def test_rename_profile(self, editor, store, monkeypatch):
         select_profile(editor, "Minimal")
-        monkeypatch.setattr(editor, "_prompt_text", lambda *a, **k: "Renamed")
+        monkeypatch.setattr(editor, "_prompt_name", lambda *a, **k: "Renamed")
         editor.rename_button.click()
         assert store.list_names() == ["HTU-Normal", "Renamed"]
         assert store.load("Renamed").name == "Renamed"

--- a/GEECS-Console/tests/test_shot_control_editor.py
+++ b/GEECS-Console/tests/test_shot_control_editor.py
@@ -378,6 +378,24 @@ class TestUnsavedChanges:
         monkeypatch.setattr(editor, "_prompt_unsaved", boom)
         assert editor.close()
 
+    def test_close_discard_prompts_exactly_once(self, qtbot, editor, monkeypatch):
+        """QDialog routes a visible close through reject(); only reject prompts.
+
+        Pins the PR-#588 review finding: with both closeEvent and reject
+        prompting, a computed-dirty editor (doc ≠ snapshot survives the
+        discard) asked twice on Discard.
+        """
+        self.make_dirty(editor)
+        editor.show()
+        qtbot.waitExposed(editor)
+        prompts = []
+        monkeypatch.setattr(
+            editor, "_prompt_unsaved", lambda: prompts.append(1) or "discard"
+        )
+        assert editor.close()
+        assert not editor.isVisible()
+        assert prompts == [1]
+
 
 class TestErgonomics:
     def test_enter_does_not_accept_the_dialog(self, qtbot, editor):


### PR DESCRIPTION
Closes #533. Extracts the duplicated dialog scaffolding of the four config editors into `editors/base.py::ConfigEditorDialog` — deliberately **before** editor #5 (the OptimizationSpec editor) exists, per the issue's thesis and the root CLAUDE.md's documented `geecs_scanner.py` failure mode.

## What moved into the base (and what it fixed on the way)

| Cluster | Before | Now |
|---|---|---|
| `.ui` loading + `_child` | 4 near-identical copies (only a trailing `resize` differed) | `UI_PATH` / `INITIAL_SIZE` class attrs |
| Enter-guard | 2×2 mess: button-loop only (save_set), keyPressEvent only (action_library), both (other two) | **both mechanisms in all four** |
| Completions | 4 hand-rolled daemon-thread fetches; `EmptyCompletions` fast-path in save_set only; close-time signal disconnect in shot_control only; save_set's attribute names inverted vs the other three | one scaffold: queued signal, fast-path, one-shot disconnect, unified names (`_device_vars`, public `completions_applied`), `_install_completions()` hook |
| Unsaved-changes prompt | **user-visible divergence**: Save/Discard/Cancel in two editors, Discard/Cancel in the other two; Esc silently discarded in save_set + shot_control | one three-way prompt via `_resolve_unsaved()` + hooks (`_has_unsaved`/`_save_unsaved`/`_discard_unsaved`); **Esc prompts everywhere**; hidden-dialog closes never block (QDialog's own hidden-close routing, uniform) |
| Name prompt / confirm | `None`-vs-`""` cancel split, label hardcoded-vs-parameter, collision handling in one prompt | one `_prompt_name` (stripped, `None` on cancel) + one Yes/No `_confirm`; save_set keeps a collision-checking wrapper |

## Deliberate behavior changes (flagged for veto)

- scan-variable + action-library editors **gain the Save button** in the leave-prompt (close/Esc/new/duplicate/plan-switch) — the #533 motivating symptom.
- save-set + trigger-profile editors: **Esc now prompts** instead of silently hiding a dirty dialog (arguably a live bug fixed).
- action-library delete confirm's second button: "No" (was "Cancel").
- `EmptyCompletions` fast-path (no thread offline) now applies to all four (was save_set-only).
- The unsaved prompt's **keyboard default is now Cancel** (the safe no-op) in all four editors — the trigger-profile editor previously defaulted to Save; the other three already defaulted to the safe choice (review finding 3).
- ~~Name prompts now strip whitespace uniformly (scan-variable rename previously didn't)~~ — correction from review: the old rename *did* strip; this flag was a no-op.

## Deliberately NOT in this PR (noted on #532/#533)

List-CRUD lifting (only ~40–50% common — persistence timing differs fundamentally per editor), dirty-idiom normalization (bool-flag vs computed-diff; bridged via `_has_unsaved()` hook instead), the `_loading` context manager (+20 churn sites), palette constants, completer construction.

## LOC breakdown

Editors 4,322 → 3,839 lines; base +365; net **−479** overall (11 files, +614/−706 with test migrations). Per editor: action_library 1109→1023, save_set 1035→929, scan_variable 1039→927, shot_control 1139→960.

## Tests

Full console suite: **764 passed** (offscreen). Test migrations in the same PR (never split from the behavior change): prompt monkeypatches moved from module-level Qt patches (save_set) and retired seams (`_ask_name`, close-path `_confirm_discard`) to the base's instance seams (`_prompt_unsaved`, `_prompt_name`, `_confirm`); `_completions_loaded`/`_completions` → `completions_applied`/`_device_vars`. `_confirm_discard` survives in scan_variable **only** as the Revert confirm (Save makes no sense there).

## Hardware verification

None owed — editor dialogs only; nothing touches scan execution or devices. A 30-second GUI sanity pass (open each editor, dirty it, Esc) next console session is welcome but not gating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

