### PR TITLE
GEECS-Console 0.18.1: ActionsMenuController extraction — #534 step 3

### DIFF
--- a/GEECS-Console/CHANGELOG.md
+++ b/GEECS-Console/CHANGELOG.md
@@ -4,6 +4,33 @@ All notable changes to GEECS-Console are documented here.  Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versioning is
 semantic.
 
+## [0.18.1] - 2026-07-20
+
+### Changed
+
+- Main-window slimming step 3 (issue #534): the Actions menu's contents,
+  plan-name fetch, arming switch, and dialog bookkeeping move to
+  `app/actions_menu.py::ActionsMenuController` (2,290 → 2,181 window
+  lines against a 273-line module).  The window keeps the composition,
+  the scan-lifecycle fan-out, and a thin test surface
+  (`enable_actions_action`, `_open_action_dialogs`).
+
+### Fixed
+
+- Plan-name fetches are deduplicated (one in flight per experiment):
+  startup fires the fetch twice back-to-back, and the two daemon
+  threads raced the lazy `geecs_bluesky` import inside the configs-root
+  resolution — a native-extension init that aborts the process when
+  raced (surfaced deterministically by the extraction's timing change;
+  latent before).  A failed fetch now also delivers an empty answer
+  instead of silently never clearing the in-flight tag.
+- Test hermeticity: windows built without an injected `action_store`
+  no longer reach the real configs repo (and the real user config) from
+  fetch threads — conftest neutralizes the default action store exactly
+  like the completions and idle-scan default seams.
+- Docstrings from 0.18.0 trimmed to present-tense constraints
+  (provenance lives in commits/PRs, not code).
+
 ## [0.18.0] - 2026-07-20
 
 ### Added

--- a/GEECS-Console/CHANGELOG.md
+++ b/GEECS-Console/CHANGELOG.md
@@ -23,7 +23,11 @@ semantic.
   resolution — a native-extension init that aborts the process when
   raced (surfaced deterministically by the extraction's timing change;
   latent before).  A failed fetch now also delivers an empty answer
-  instead of silently never clearing the in-flight tag.
+  instead of silently never clearing the in-flight tag — which also
+  changes one visible failure mode for the better: a fetch that raises
+  past the store's own error handling (e.g. an SMB read error) now
+  renders "(no actions)" instead of silently keeping the *previous*
+  experiment's plan names in the menu.
 - Test hermeticity: windows built without an injected `action_store`
   no longer reach the real configs repo (and the real user config) from
   fetch threads — conftest neutralizes the default action store exactly

--- a/GEECS-Console/CLAUDE.md
+++ b/GEECS-Console/CLAUDE.md
@@ -255,20 +255,35 @@ are prefixed by region (`r3_radio_1d`, `r5_start_button`, …).
   segfaults under offscreen pytest (observed directly when the idle scan
   probe emitted a `MainWindow` signal; the R7 device-set completion was
   the last such emission and moved to a `BackgroundResult` worker in
-  0.7.0 — issue #510).  `closeEvent` disconnects each worker's
-  `result_ready`.
-- **Actions menu (G-actions v1)**: lists the current experiment's
+  0.7.0 — issue #510).  `closeEvent` disconnects each window-owned
+  worker's `result_ready`; the actions-menu controller's worker is
+  detached inside its `dispose()` instead.
+- **Actions menu (G-actions v1)** — owned by
+  `app/actions_menu.py::ActionsMenuController` since 0.18.1 (issue #534
+  step 3): the window creates the QMenu (kept in `self._menus`) and the
+  controller owns its contents, its `BackgroundResult` fetch worker, and
+  the open dialogs; the window keeps thin `enable_actions_action` /
+  `_open_action_dialogs` properties as the test surface, and its
+  `closeEvent` calls the controller's `dispose()` (severing every
+  controller → window reference — the cycle would otherwise defer
+  dead-window teardown to the cyclic GC mid-event-processing, a
+  segfault under offscreen pytest).  Lists the current experiment's
   action-plan names — fetched from `ActionLibraryStore.list_names()` (the
   same `action_library/actions.yaml` the Action Library editor edits;
-  constructor-injectable `action_store` seam) on a `BackgroundResult`
-  worker, refreshed on experiment change, stale results dropped by
-  experiment tag; empty/offline renders one disabled "(no actions)"
-  entry.  On top sits **"Enable action execution"** — the accidental-click
-  guard: checkable, **default OFF at every launch and deliberately NOT
-  persisted** (a fresh session must never start armed; do not "fix" this
-  by adding it to `ConsoleSettings`).  Clicking a plan opens the
-  non-modal `ActionRunDialog` (`app/action_dialog.py`, kept in
-  `self._open_action_dialogs` — the GC hazard): a dry-run steps table
+  constructor-injectable `action_store` seam), refreshed on experiment
+  change, stale results dropped by experiment tag, **one fetch in
+  flight per experiment** — startup requests twice back-to-back, and
+  two concurrent fetch threads race the lazy `geecs_bluesky` import
+  inside the store's configs-root resolution, a native init that
+  aborts the process when raced (found 2026-07-20; the sibling
+  completions/idle-scan double-fetches share the hazard shape and are
+  not yet deduped); empty/offline/failed renders one disabled
+  "(no actions)" entry.  On top sits **"Enable action execution"** — the
+  accidental-click guard: checkable, **default OFF at every launch and
+  deliberately NOT persisted** (a fresh session must never start armed;
+  do not "fix" this by adding it to `ConsoleSettings`).  Clicking a plan
+  opens the non-modal `ActionRunDialog` (`app/action_dialog.py`, kept on
+  the controller — the GC hazard): a dry-run steps table
   from the engine's `describe_action(name) -> list[dict]` (keys `kind` /
   `device` / `variable` / `value` / `wait_s` / `from_plan`, execution
   order) plus Run/Close.  Run is enabled only while armed and dispatches
@@ -284,8 +299,10 @@ are prefixed by region (`r3_radio_1d`, `r5_start_button`, …).
   **During-scan (G-actions v2, #552, 0.16.0):** the same dialog drives the
   pause flow — with a scan active the Run button reads "Pause scan & run
   (N steps)" and calls the `Submitter.request_action_during_scan` member
-  (pause → decide → run) instead of idle `run_action`; the window pushes
-  live scan state into open dialogs (`set_scanning`) so the button flips.
+  (pause → decide → run) instead of idle `run_action`; the window's
+  scan-lifecycle hub pushes live scan state into the controller
+  (`set_scanning`), which forwards it to the open dialogs so the button
+  flips.
   The three-way **action-decision modal** (Execute / Ignore / Abort) is
   rendered by `_on_action_decision` from an engine `ActionDecisionRequest`
   (routed through the same `ScanDialogEvent`/`dialog_requested` transport

--- a/GEECS-Console/geecs_console/app/actions_menu.py
+++ b/GEECS-Console/geecs_console/app/actions_menu.py
@@ -1,0 +1,273 @@
+"""The Actions menu: arming switch, per-plan entries, and their dialogs.
+
+Owns everything behind the menu-bar "Actions" entry so the main window
+stays a composition root: the "Enable action execution" arming switch,
+the per-plan menu entries (fetched off the GUI thread, stale results
+dropped by experiment tag), and the non-modal :class:`ActionRunDialog`
+windows those entries open.
+
+The arming switch is deliberately **not** persisted (unlike the
+Preferences toggles): a fresh console session must never start with
+action execution armed.  Do not "fix" this by adding it to
+``ConsoleSettings``.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Callable, Optional
+
+from PySide6.QtCore import QObject, Qt, Slot
+from PySide6.QtWidgets import QMenu, QWidget
+
+from geecs_console.app.action_dialog import ActionRunDialog
+from geecs_console.services.action_library_store import ActionLibraryStore
+from geecs_console.services.background import BackgroundResult
+from geecs_console.submission import Submitter
+
+logger = logging.getLogger(__name__)
+
+
+class ActionsMenuController(QObject):
+    """Populate and run one Actions menu on behalf of the main window.
+
+    A ``QObject`` with **no Qt parent**, kept alive only by the window's
+    Python reference (``self._actions``) — the same lifetime rule as the
+    ``BackgroundResult`` workers.
+
+    Lifetime constraint: holding the window and its bound methods here
+    creates a Python reference cycle (window → controller → window) that
+    refcounting cannot free — the dead window's whole C++ tree would
+    then be torn down whenever the *cyclic* GC happens to run, including
+    mid-event-processing of a later window (a segfault under offscreen
+    pytest).  The window's ``closeEvent`` therefore calls
+    :meth:`dispose`, which severs every controller → window edge and
+    restores deterministic refcount destruction.
+
+    Parameters
+    ----------
+    menu : QMenu
+        The already-created menu-bar entry (the window keeps it in
+        ``self._menus``); this controller owns its contents.
+    window : QWidget
+        The main window — Qt parent and the dialogs' parent.
+    store : ActionLibraryStore
+        The plan-name source; the window re-points it on experiment
+        change (``set_experiment``), so the reference stays valid.
+    current_experiment : callable
+        Returns the currently selected experiment name ("" for none).
+    ensure_submitter : callable
+        Returns the engine :class:`Submitter` (or ``None`` when the
+        engine is unavailable — reported to the operator by the window).
+    report : callable
+        One operator-facing status line (status bar + log tail).
+    """
+
+    def __init__(
+        self,
+        menu: QMenu,
+        *,
+        window: QWidget,
+        store: ActionLibraryStore,
+        current_experiment: Callable[[], str],
+        ensure_submitter: Callable[[], Optional[Submitter]],
+        report: Callable[[str], None],
+    ) -> None:
+        super().__init__()
+        self._menu = menu
+        self._window = window
+        self._store = store
+        self._current_experiment = current_experiment
+        self._ensure_submitter = ensure_submitter
+        self._report = report
+
+        self.enable_action = menu.addAction("Enable action execution")
+        self.enable_action.setCheckable(True)
+        self.enable_action.setChecked(False)
+        self.enable_action.toggled.connect(self._on_enable_actions_toggled)
+        menu.addSeparator()
+        #: The per-plan entries below the arming switch (rebuilt per fetch).
+        self._plan_actions: list = []
+        #: Open ActionRunDialogs — referenced here so GC cannot take them.
+        self.open_dialogs: list = []
+
+        self._worker = BackgroundResult()
+        self._worker.result_ready.connect(
+            self._apply_action_names, Qt.ConnectionType.QueuedConnection
+        )
+        #: Experiment tag of an in-flight fetch, or None.  One fetch at a
+        #: time: startup can request twice back-to-back (the restored
+        #: experiment fires the experiment-changed path just before the
+        #: explicit construction-time call), and two concurrent fetch
+        #: threads race the lazy ``geecs_bluesky`` import inside the
+        #: store's configs-root resolution — a native-extension init that
+        #: aborts the process when raced.  Dedup also spares the configs
+        #: mount a redundant YAML parse.
+        self._fetch_inflight: Optional[str] = None
+        self._set_action_names([])
+
+    # ------------------------------------------------------------------
+    # Plan-name fetch (off the GUI thread, stale-dropped by experiment)
+    # ------------------------------------------------------------------
+
+    def start_fetch(self) -> None:
+        """Fetch the experiment's action-plan names off the GUI thread.
+
+        ``list_names`` parses the library YAML on a possibly slow configs
+        mount, so it runs on a short-lived daemon thread (via the
+        :class:`BackgroundResult` worker), tagged with the experiment and
+        delivered queued to :meth:`_apply_action_names`.  No experiment
+        answers inline with an empty list, spawning no thread.
+        """
+        experiment = self._current_experiment()
+        if not experiment:
+            self._apply_action_names((experiment, []))
+            return
+        if self._fetch_inflight == experiment:
+            return
+        self._fetch_inflight = experiment
+        store = self._store
+
+        def fetch() -> tuple[str, list[str]]:
+            # Never raise: BackgroundResult swallows exceptions without
+            # emitting, which would leave the in-flight tag stuck.
+            try:
+                return (experiment, store.list_names())
+            except Exception as exc:  # noqa: BLE001 — deliver the empty answer
+                logger.info("action-name fetch failed: %s", exc)
+                return (experiment, [])
+
+        self._worker.run_async(fetch, name="console-action-names")
+
+    @Slot(object)
+    def _apply_action_names(self, payload: object) -> None:
+        """Rebuild the menu entries (GUI-thread slot, delivered queued).
+
+        Parameters
+        ----------
+        payload : tuple
+            ``(experiment, [plan_name, ...])``; a result tagged with an
+            experiment that is no longer selected is dropped (a stale
+            fetch racing an experiment change).
+        """
+        experiment, names = payload
+        if self._fetch_inflight == experiment:
+            self._fetch_inflight = None
+        if experiment != self._current_experiment():
+            return
+        self._set_action_names(list(names))
+
+    def _set_action_names(self, names: list[str]) -> None:
+        """Replace the per-plan menu entries below the arming switch.
+
+        Parameters
+        ----------
+        names : list of str
+            The experiment's action-plan names; empty (or offline)
+            renders one disabled ``(no actions)`` entry.
+        """
+        for action in self._plan_actions:
+            self._menu.removeAction(action)
+            action.deleteLater()
+        self._plan_actions = []
+        if not names:
+            placeholder = self._menu.addAction("(no actions)")
+            placeholder.setEnabled(False)
+            self._plan_actions.append(placeholder)
+            return
+        for name in names:
+            action = self._menu.addAction(name)
+            action.triggered.connect(
+                lambda checked=False, plan=name: self._on_action_plan(plan)
+            )
+            self._plan_actions.append(action)
+
+    # ------------------------------------------------------------------
+    # Arming + dialogs
+    # ------------------------------------------------------------------
+
+    def _on_enable_actions_toggled(self, checked: bool) -> None:
+        """Push the arming state into every open action dialog.
+
+        Parameters
+        ----------
+        checked : bool
+            The "Enable action execution" state.
+        """
+        self.open_dialogs = [d for d in self.open_dialogs if d.isVisible()]
+        for dialog in self.open_dialogs:
+            dialog.set_execution_enabled(checked)
+
+    def _on_action_plan(self, name: str) -> None:
+        """Open the Run/Preview dialog for action plan *name*.
+
+        The dialog is shown non-modally and kept in :attr:`open_dialogs`
+        (the PySide6 GC hazard).  Preview is always available; Run is
+        gated by the arming switch.
+
+        Parameters
+        ----------
+        name : str
+            The action-plan name (a menu entry).
+        """
+        submitter = self._ensure_submitter()
+        if submitter is None:
+            return
+        dialog = ActionRunDialog(
+            self._window,
+            name,
+            describe=submitter.describe_action,
+            run=submitter.run_action,
+            execution_enabled=self.enable_action.isChecked(),
+            report=self._report,
+            request_during_scan=submitter.request_action_during_scan,
+            is_scanning=submitter.is_scanning_active,
+        )
+        self.open_dialogs = [d for d in self.open_dialogs if d.isVisible()]
+        self.open_dialogs.append(dialog)
+        dialog.show()
+
+    def set_scanning(self, scanning: bool) -> None:
+        """Push live scan state into every open dialog.
+
+        The window's scan-lifecycle hub calls this so each dialog's Run
+        button flips between "Run" and "Pause scan & run".
+
+        Parameters
+        ----------
+        scanning : bool
+            Whether a scan is currently active (non-terminal, non-idle).
+        """
+        self.open_dialogs = [d for d in self.open_dialogs if d.isVisible()]
+        for dialog in self.open_dialogs:
+            dialog.set_scanning(scanning)
+
+    # ------------------------------------------------------------------
+    # Teardown
+    # ------------------------------------------------------------------
+
+    def disconnect_worker(self) -> None:
+        """Detach the fetch worker so a straggling result lands nowhere.
+
+        Safe to call more than once.
+        """
+        try:
+            self._worker.result_ready.disconnect(self._apply_action_names)
+        except (RuntimeError, TypeError):
+            pass
+
+    def dispose(self) -> None:
+        """Sever every controller → window reference (see the class docstring).
+
+        Called from the window's ``closeEvent``; idempotent.  After this
+        the controller renders nothing and answers no fetches — it only
+        awaits collection alongside the window that owns it.
+        """
+        self.disconnect_worker()
+        self._window = None
+        self._store = None
+        self._current_experiment = lambda: ""
+        self._ensure_submitter = lambda: None
+        self._report = lambda message: None
+        self.open_dialogs = []
+        self._plan_actions = []

--- a/GEECS-Console/geecs_console/app/actions_menu.py
+++ b/GEECS-Console/geecs_console/app/actions_menu.py
@@ -95,14 +95,16 @@ class ActionsMenuController(QObject):
         self._worker.result_ready.connect(
             self._apply_action_names, Qt.ConnectionType.QueuedConnection
         )
-        #: Experiment tag of an in-flight fetch, or None.  One fetch at a
-        #: time: startup can request twice back-to-back (the restored
+        #: Experiment tag of an in-flight fetch, or None.  One fetch per
+        #: *experiment*: startup requests twice back-to-back (the restored
         #: experiment fires the experiment-changed path just before the
         #: explicit construction-time call), and two concurrent fetch
         #: threads race the lazy ``geecs_bluesky`` import inside the
         #: store's configs-root resolution — a native-extension init that
-        #: aborts the process when raced.  Dedup also spares the configs
-        #: mount a redundant YAML parse.
+        #: aborts the process when raced.  An experiment *switch* while a
+        #: fetch is in flight still spawns a second thread (human-timescale
+        #: rare, and only the very first import is race-prone); dedup also
+        #: spares the configs mount a redundant YAML parse.
         self._fetch_inflight: Optional[str] = None
         self._set_action_names([])
 

--- a/GEECS-Console/geecs_console/app/main_window.py
+++ b/GEECS-Console/geecs_console/app/main_window.py
@@ -40,7 +40,7 @@ from PySide6.QtWidgets import (
 )
 from pydantic import ValidationError
 
-from geecs_console.app.action_dialog import ActionRunDialog
+from geecs_console.app.actions_menu import ActionsMenuController
 from geecs_console.editors.action_library_editor import open_action_library_editor
 from geecs_console.editors.save_set_editor import open_save_set_editor
 from geecs_console.editors.scan_variable_editor import open_scan_variable_editor
@@ -274,9 +274,6 @@ class MainWindow(QMainWindow):
         #: garbage-collects an unreferenced dialog wrapper and tears down the
         #: C++ dialog with it, so every opened editor is kept here.
         self._open_editors: list = []
-        #: Non-modal ActionRunDialogs opened from the Actions menu — same
-        #: PySide6 GC hazard, same keep-a-reference cure.
-        self._open_action_dialogs: list = []
         #: The open three-way action-decision modal (G-actions v2), or None
         #: — kept so a terminal lifecycle state can dismiss a dangling one.
         self._decision_box: Optional[object] = None
@@ -318,7 +315,7 @@ class MainWindow(QMainWindow):
         # harmless.
         self._start_device_completions_fetch()
         self._start_idle_scan_probe()
-        self._start_actions_fetch()
+        self._actions.start_fetch()
 
     # ------------------------------------------------------------------
     # Construction
@@ -458,21 +455,19 @@ class MainWindow(QMainWindow):
         github = ops.addAction("GEECS-Plugins on GitHub")
         github.triggered.connect(self._on_open_github)
 
-        # Actions menu: the arming switch on top, then one entry per action
-        # plan in the current experiment's library (filled asynchronously by
-        # _apply_action_names).  The arming state is deliberately NOT
-        # persisted — a fresh session must never start armed, so every
-        # launch begins with execution off and preview-only dialogs.
+        # Actions menu: contents and dialogs live on ActionsMenuController
+        # (app/actions_menu.py); the window keeps the QMenu reference and
+        # the controller composition.
         actions_menu = self.menuBar().addMenu("Actions")
         self._menus.append(actions_menu)
-        self._actions_menu = actions_menu
-        self.enable_actions_action = actions_menu.addAction("Enable action execution")
-        self.enable_actions_action.setCheckable(True)
-        self.enable_actions_action.setChecked(False)
-        self.enable_actions_action.toggled.connect(self._on_enable_actions_toggled)
-        actions_menu.addSeparator()
-        self._action_plan_actions: list = []
-        self._set_action_names([])
+        self._actions = ActionsMenuController(
+            actions_menu,
+            window=self,
+            store=self._action_store,
+            current_experiment=lambda: self.experiment_combo.currentText(),
+            ensure_submitter=self._ensure_submitter,
+            report=self._report,
+        )
 
         editors = self.menuBar().addMenu("Editors")
         self._menus.append(editors)
@@ -596,10 +591,7 @@ class MainWindow(QMainWindow):
         self._idle_scan_worker.result_ready.connect(
             self._apply_idle_scan_number, Qt.ConnectionType.QueuedConnection
         )
-        self._actions_worker = BackgroundResult()
-        self._actions_worker.result_ready.connect(
-            self._apply_action_names, Qt.ConnectionType.QueuedConnection
-        )
+        # (The actions-menu fetch worker lives on ActionsMenuController.)
         # Stop dispatch (issue #571): stop_scanning_thread may block briefly
         # (engine bookkeeping join), so it runs on a worker — never the GUI
         # thread.  No result slot: completion is announced by the terminal
@@ -806,7 +798,6 @@ class MainWindow(QMainWindow):
             ),
             (getattr(self, "_idle_scan_worker", None), self._apply_idle_scan_number),
             (getattr(self, "_device_set_worker", None), self._apply_device_set_result),
-            (getattr(self, "_actions_worker", None), self._apply_action_names),
         ):
             if worker is None:
                 continue
@@ -818,6 +809,9 @@ class MainWindow(QMainWindow):
             self.device_value_ready.disconnect(self._apply_device_value)
         except (RuntimeError, TypeError):
             pass
+        actions = getattr(self, "_actions", None)
+        if actions is not None:
+            actions.dispose()
         super().closeEvent(event)
 
     # ------------------------------------------------------------------
@@ -1129,7 +1123,7 @@ class MainWindow(QMainWindow):
         # new action-plan library.
         self._start_device_completions_fetch()
         self._start_idle_scan_probe()
-        self._start_actions_fetch()
+        self._actions.start_fetch()
 
     def _restore_last_experiment(self) -> bool:
         """Select the remembered experiment at startup (explicit choice wins).
@@ -1268,117 +1262,18 @@ class MainWindow(QMainWindow):
         self._open_editor(open_action_library_editor)
 
     # ------------------------------------------------------------------
-    # Actions menu (G-actions v1: arming switch + per-plan Run/Preview)
+    # Actions menu (contents on ActionsMenuController; thin test surface)
     # ------------------------------------------------------------------
 
-    def _start_actions_fetch(self) -> None:
-        """Fetch the experiment's action-plan names off the GUI thread.
+    @property
+    def enable_actions_action(self):
+        """The arming switch QAction (owned by the actions-menu controller)."""
+        return self._actions.enable_action
 
-        ``list_names`` parses the library YAML on a possibly slow configs
-        mount, so it runs on a short-lived daemon thread (via the
-        :class:`BackgroundResult` worker), tagged with the experiment and
-        delivered queued to :meth:`_apply_action_names`.  No experiment
-        answers inline with an empty list, spawning no thread.
-        """
-        experiment = self.experiment_combo.currentText()
-        if not experiment:
-            self._apply_action_names((experiment, []))
-            return
-        store = self._action_store
-
-        def fetch() -> tuple[str, list[str]]:
-            return (experiment, store.list_names())
-
-        self._actions_worker.run_async(fetch, name="console-action-names")
-
-    @Slot(object)
-    def _apply_action_names(self, payload: object) -> None:
-        """Rebuild the Actions-menu entries (GUI-thread slot, delivered queued).
-
-        Parameters
-        ----------
-        payload : tuple
-            ``(experiment, [plan_name, ...])``; a result tagged with an
-            experiment that is no longer selected is dropped (a stale fetch
-            racing an experiment change).
-        """
-        experiment, names = payload
-        if experiment != self.experiment_combo.currentText():
-            return
-        self._set_action_names(list(names))
-
-    def _set_action_names(self, names: list[str]) -> None:
-        """Replace the per-plan menu entries below the arming switch.
-
-        Parameters
-        ----------
-        names : list of str
-            The experiment's action-plan names; empty (or offline) renders
-            one disabled ``(no actions)`` entry.
-        """
-        for action in self._action_plan_actions:
-            self._actions_menu.removeAction(action)
-            action.deleteLater()
-        self._action_plan_actions = []
-        if not names:
-            placeholder = self._actions_menu.addAction("(no actions)")
-            placeholder.setEnabled(False)
-            self._action_plan_actions.append(placeholder)
-            return
-        for name in names:
-            action = self._actions_menu.addAction(name)
-            action.triggered.connect(
-                lambda checked=False, plan=name: self._on_action_plan(plan)
-            )
-            self._action_plan_actions.append(action)
-
-    def _on_enable_actions_toggled(self, checked: bool) -> None:
-        """Push the arming state into every open action dialog.
-
-        Deliberately **not** persisted (unlike the Preferences toggles): a
-        fresh console session must never start with action execution armed.
-
-        Parameters
-        ----------
-        checked : bool
-            The "Enable action execution" state.
-        """
-        self._open_action_dialogs = [
-            d for d in self._open_action_dialogs if d.isVisible()
-        ]
-        for dialog in self._open_action_dialogs:
-            dialog.set_execution_enabled(checked)
-
-    def _on_action_plan(self, name: str) -> None:
-        """Open the Run/Preview dialog for action plan *name*.
-
-        The dialog is shown non-modally and kept in
-        ``self._open_action_dialogs`` (the PySide6 GC hazard).  Preview is
-        always available; Run is gated by the arming switch.
-
-        Parameters
-        ----------
-        name : str
-            The action-plan name (a menu entry).
-        """
-        submitter = self._ensure_submitter()
-        if submitter is None:
-            return
-        dialog = ActionRunDialog(
-            self,
-            name,
-            describe=submitter.describe_action,
-            run=submitter.run_action,
-            execution_enabled=self.enable_actions_action.isChecked(),
-            report=self._report,
-            request_during_scan=submitter.request_action_during_scan,
-            is_scanning=submitter.is_scanning_active,
-        )
-        self._open_action_dialogs = [
-            d for d in self._open_action_dialogs if d.isVisible()
-        ]
-        self._open_action_dialogs.append(dialog)
-        dialog.show()
+    @property
+    def _open_action_dialogs(self) -> list:
+        """The controller's open ActionRunDialogs (read-only view)."""
+        return self._actions.open_dialogs
 
     # ------------------------------------------------------------------
     # Preferences (beeps)
@@ -2115,11 +2010,7 @@ class MainWindow(QMainWindow):
         # Push the live scan state into open action dialogs so their Run
         # button flips between "Run" and "Pause scan & run" (G-actions v2).
         scanning = lowered not in _TERMINAL_SCAN_STATES and lowered != "idle"
-        self._open_action_dialogs = [
-            d for d in self._open_action_dialogs if d.isVisible()
-        ]
-        for dialog in self._open_action_dialogs:
-            dialog.set_scanning(scanning)
+        self._actions.set_scanning(scanning)
 
         # A terminal state dismisses a dangling action-decision modal: an
         # operator Stop during the pause window aborts the scan without the

--- a/GEECS-Console/geecs_console/app/main_window.py
+++ b/GEECS-Console/geecs_console/app/main_window.py
@@ -310,9 +310,15 @@ class MainWindow(QMainWindow):
         # R7 device:variable completions, the R6 idle scan-number peek, and
         # the Actions-menu plan names.  Restoring the last experiment already
         # fired the experiment-changed path (which starts all three); these
-        # cover the explicit-experiment and no-experiment startups.  Stale
-        # results are dropped by experiment tag, so a duplicate fetch is
-        # harmless.
+        # cover the explicit-experiment and no-experiment startups.  A
+        # duplicate fetch is *result*-safe (stale results are dropped by
+        # experiment tag) but NOT thread-safe in general: two concurrent
+        # fetch threads can race the lazy first import of a native chain
+        # (geecs_bluesky's EPICS init aborts the process when raced — hence
+        # the actions controller's one-in-flight dedupe).  The completions
+        # and idle-scan pairs still double-spawn and share the hazard shape
+        # (mysql-connector / pandas chains); dedupe them the same way if
+        # this ever bites.
         self._start_device_completions_fetch()
         self._start_idle_scan_probe()
         self._actions.start_fetch()

--- a/GEECS-Console/geecs_console/editors/base.py
+++ b/GEECS-Console/geecs_console/editors/base.py
@@ -1,12 +1,10 @@
-"""Shared scaffolding for the config-editor dialogs (issue #533).
+"""Shared scaffolding for the config-editor dialogs.
 
-The four editors (save sets, scan variables, trigger profiles, action
-plans) grew from the same template and had started to diverge in
-user-visible ways — two offered Save/Discard/Cancel on unsaved changes
-while two offered only Discard/Cancel, and Esc silently discarded edits
-in the two editors that never overrode ``reject``.  This base class is
-the one home for that scaffolding; each editor keeps only its store
-binding, its widgets, and its dialect rules.
+The one home for the dialog machinery all four editors (save sets, scan
+variables, trigger profiles, action plans) share; each editor keeps only
+its store binding, its widgets, and its dialect rules.  A new editor
+should subclass :class:`ConfigEditorDialog` rather than re-growing any
+of this.
 
 What lives here:
 
@@ -174,14 +172,12 @@ class ConfigEditorDialog(QDialog):
         thread to spawn for a constant) — offline construction stays
         thread-free.
 
-        Known debt, consciously carried over from all four pre-base
-        editors rather than introduced here: the daemon thread emits a
-        *dialog-owned* signal instead of routing through the blessed
+        Known debt: the daemon thread emits a *dialog-owned* signal
+        instead of routing through the blessed
         ``services/background.py::BackgroundResult`` worker, and an
         Esc-closed dialog (``reject`` → ``done()``, no ``QCloseEvent``)
-        never runs the close-time disconnect.  Consolidating onto
-        ``BackgroundResult`` is the follow-up recorded on issue #533 —
-        do it here once, not per editor.
+        never runs the close-time disconnect.  Consolidate onto
+        ``BackgroundResult`` here, once — not per editor.
         """
         if isinstance(self._completions, EmptyCompletions):
             self.completions_applied = True

--- a/GEECS-Console/pyproject.toml
+++ b/GEECS-Console/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-console"
-version = "0.18.0"
+version = "0.18.1"
 description = "Greenfield PySide6 operator console for GEECS (Bluesky/gateway architecture)"
 authors = ["Sam Barber <sbarber@lbl.gov>"]
 readme = "README.md"

--- a/GEECS-Console/tests/conftest.py
+++ b/GEECS-Console/tests/conftest.py
@@ -45,3 +45,24 @@ def _offline_window_defaults(monkeypatch):
         lambda experiment: EmptyCompletions(),
     )
     monkeypatch.setattr(main_window, "_idle_scan_lookup", lambda experiment: None)
+
+    class _OfflineActionStore:
+        """No-op stand-in for the default ``ActionLibraryStore``.
+
+        The real default's ``list_names`` resolves the configs repo —
+        reading the developer's actual user config and lazily importing
+        ``geecs_bluesky`` on a daemon thread per window construction.
+        Tests of the Actions menu inject their own store; every other
+        window must stay offline.
+        """
+
+        def __init__(self, experiment: str = "", experiments_root=None) -> None:
+            self.experiment = experiment
+
+        def set_experiment(self, experiment: str) -> None:
+            self.experiment = experiment
+
+        def list_names(self) -> list:
+            return []
+
+    monkeypatch.setattr(main_window, "ActionLibraryStore", _OfflineActionStore)

--- a/GEECS-Console/tests/test_action_library_editor.py
+++ b/GEECS-Console/tests/test_action_library_editor.py
@@ -422,10 +422,9 @@ class TestPlanLifecycle:
     def test_discarded_phantom_leaves_no_ghost_on_a_canceled_prompt(self, qtbot, root):
         """New → Discard → cancel the name prompt must leave a coherent editor.
 
-        Pins the PR-#588 review finding: the discard hook must really
-        discard (list and widgets included), because New/Duplicate can
-        still bail out afterwards — a flag-only discard left a ghost row
-        that Save would happily persist.
+        The discard hook must really discard (list and widgets included),
+        because New/Duplicate can still bail out afterwards — a flag-only
+        discard leaves a ghost row that Save would happily persist.
         """
         editor = make_editor(qtbot, root)
         editor._prompt_name = lambda *args, **kwargs: "temp_plan"

--- a/GEECS-Console/tests/test_actions_menu.py
+++ b/GEECS-Console/tests/test_actions_menu.py
@@ -197,8 +197,35 @@ class TestMenuPopulation:
         ]
         assert not placeholder.isEnabled()
 
+    def test_concurrent_fetches_for_one_experiment_are_deduplicated(
+        self, window, qtbot, monkeypatch
+    ):
+        """One in-flight fetch per experiment — never two racing threads.
+
+        Startup requests twice back-to-back (the restored experiment
+        fires the experiment-changed path just before the explicit
+        construction-time call); two concurrent fetch threads would race
+        the lazy ``geecs_bluesky`` import inside the store's configs-root
+        resolution, a native-extension init that aborts when raced.
+        """
+        qtbot.waitUntil(lambda: "insert_cal" in plan_entries(window), timeout=3000)
+        controller = window._actions
+        spawned = []
+        monkeypatch.setattr(
+            controller._worker,
+            "run_async",
+            lambda func, name: spawned.append(name),
+        )
+        controller.start_fetch()
+        controller.start_fetch()  # same experiment, first still in flight
+        assert len(spawned) == 1
+        # Delivery clears the tag, so a later refresh fetches again.
+        controller._apply_action_names(("TestExp", ["insert_cal", "vent_line"]))
+        controller.start_fetch()
+        assert len(spawned) == 2
+
     def test_stale_fetch_for_previous_experiment_is_dropped(self, window):
-        window._apply_action_names(("SomeOtherExp", ["stale_plan"]))
+        window._actions._apply_action_names(("SomeOtherExp", ["stale_plan"]))
         assert "stale_plan" not in plan_entries(window)
 
 

--- a/GEECS-Console/tests/test_scan_variable_editor.py
+++ b/GEECS-Console/tests/test_scan_variable_editor.py
@@ -459,9 +459,9 @@ class TestDirtyRevertClose:
     def test_close_discard_prompts_exactly_once(self, qtbot, tmp_path):
         """QDialog routes a visible close through reject(); only reject prompts.
 
-        Pins the PR-#588 review finding: with both closeEvent and reject
-        prompting, a computed-dirty editor (draft ≠ snapshot survives the
-        discard) asked twice on Discard.
+        A closeEvent that prompted too would ask twice on Discard here:
+        this editor's dirty predicate is computed (draft ≠ snapshot), so
+        it survives the discard choice.
         """
         seed_catalog(tmp_path)
         editor = make_editor(qtbot, tmp_path)

--- a/GEECS-Console/tests/test_shot_control_editor.py
+++ b/GEECS-Console/tests/test_shot_control_editor.py
@@ -381,9 +381,9 @@ class TestUnsavedChanges:
     def test_close_discard_prompts_exactly_once(self, qtbot, editor, monkeypatch):
         """QDialog routes a visible close through reject(); only reject prompts.
 
-        Pins the PR-#588 review finding: with both closeEvent and reject
-        prompting, a computed-dirty editor (doc ≠ snapshot survives the
-        discard) asked twice on Discard.
+        A closeEvent that prompted too would ask twice on Discard here:
+        this editor's dirty predicate is computed (doc ≠ snapshot), so
+        it survives the discard choice.
         """
         self.make_dirty(editor)
         editor.show()


### PR DESCRIPTION
Step 3 of the #534 plan of record (per the 2026-07-20 refresh comment there): the Actions menu moves out of `main_window.py` into `app/actions_menu.py::ActionsMenuController`.

## Per-concern breakdown

| Concern | LOC | What |
|---|---|---|
| **Extraction (the step itself)** | +273 module, −109 window (2,290 → 2,181) | Menu contents, arming switch, plan-name fetch (worker owned by the controller), `ActionRunDialog` bookkeeping, `set_scanning` push. Boundary rulings per the plan refresh: the action-decision modal and the scan-lifecycle fan-out **stay in the window**. Thin test surface kept: `enable_actions_action` / `_open_action_dialogs` properties; one test call site migrated to the controller. The controller severs its window references in `closeEvent` (`dispose()`) — a window↔controller reference cycle would otherwise defer dead-window teardown to the cyclic GC mid-event-processing. |
| **Bug fix surfaced by the extraction** | ~20 | **Startup double-fetch races the lazy `geecs_bluesky` import** — construction fires the plan-name fetch twice back-to-back (restore-fired experiment change + explicit call); two daemon threads first-importing the native extension chain **abort the process**. Latent on `dev` (timing luck); the extraction's tighter spawn timing made it a deterministic segfault under offscreen pytest. Fix: one in-flight fetch per experiment, failure delivers an empty answer (never a stuck tag). Pinned by `test_concurrent_fetches_for_one_experiment_are_deduplicated`. |
| **Test hermeticity fix** | ~25 (conftest) | Windows built without an injected `action_store` were reaching the **real** configs repo + real user config from fetch threads on every construction — the exact gap conftest's `_offline_window_defaults` already closes for the completions and idle-scan seams; the action store was missed when G-actions landed. Now neutralized identically. (An earlier ~3× suite-speed claim did not reproduce under review — locally ~8%; the win is determinism and hermeticity, with any speedup environment-dependent.) |
| **Flagged secondary concern: docstring trim** | docs-only, ~40 lines | 0.18.0-era docstrings in `editors/base.py` + editor tests trimmed to present-tense constraints; provenance (issue/PR numbers, review-finding citations) removed per owner feedback — history lives in commits/PRs. |

## Deliberately unchanged
Zero user-visible behavior, with one review-identified beneficial exception: a plan-name fetch that raises past the store's own error handling (e.g. an SMB read error) now renders "(no actions)" instead of silently keeping the previous experiment's plan names in the menu. The lifecycle hub (`_on_scan_state`), decision-modal transport, and queued-signal/worker discipline move nothing.

## Tests
Full console suite **770 passed** (769 + 1 new pin), verified **3× consecutively** (the failure mode here was a flaky segfault — single green runs prove nothing).

## Hardware verification
None owed — menu/window plumbing only; nothing touches scan execution or devices.

## Remaining production note (for the reviewer to weigh)
The concurrent-lazy-import hazard is narrowed, not eliminated: two *different* console daemon threads could still first-import `geecs_bluesky` simultaneously (e.g. actions fetch + a preset resolution on experiment change). Pre-existing, now documented; a process-wide import lock is the follow-up candidate if it ever bites live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
