### PR TITLE
GEECS-Console 0.18.2: NowPanelController extraction — #534 step 5

### DIFF
--- a/GEECS-Console/CHANGELOG.md
+++ b/GEECS-Console/CHANGELOG.md
@@ -4,6 +4,25 @@ All notable changes to GEECS-Console are documented here.  Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versioning is
 semantic.
 
+## [0.18.2] - 2026-07-20
+
+### Changed
+
+- Main-window slimming step 5 (issue #534): the R6 now-panel rendering —
+  state pill, progress bar, scan number + 10 s expiry, log tail, and the
+  idle scan-number probe — moves to
+  `app/now_panel.py::NowPanelController` (2,181 → 2,103 window lines
+  against a 262-line module).  The window keeps the widget attributes,
+  thin `append_log`/`set_scan_number` delegates, the beep logic
+  (Preferences), and the scan-lifecycle hub.
+
+### Fixed
+
+- The idle scan-number probe gets the same one-in-flight-per-experiment
+  dedupe as the actions fetch (0.18.1) — startup double-spawned it, the
+  same native-first-import race shape; of the three startup fetch pairs
+  only the completions pair now remains undeduped.
+
 ## [0.18.1] - 2026-07-20
 
 ### Changed

--- a/GEECS-Console/CLAUDE.md
+++ b/GEECS-Console/CLAUDE.md
@@ -179,8 +179,8 @@ are prefixed by region (`r3_radio_1d`, `r5_start_button`, …).
 - **Scan number (R6)**: the engine's `ScanLifecycleEvent.scan_number`
   (`None` until the scan folder is claimed, then present on every lifecycle
   emission) is read duck-typed by `ScanEventsAdapter` and emitted as
-  `scan_number_known(int)`; the window connects it to `set_scan_number`
-  (10 s expiry to "(previous)").
+  `scan_number_known(int)`; the window connects it to `set_scan_number`,
+  which delegates to `NowPanelController` (10 s expiry to "(previous)").
 - **Ops menu**: four items, handlers in `main_window.py`, path resolution
   factored into `services/ops_paths.py` as small pure `-> Path | None`
   functions (unit-tested against tmp trees, no Finder).  *Open experiment
@@ -232,11 +232,19 @@ are prefixed by region (`r3_radio_1d`, `r5_start_button`, …).
   no-longer-selected experiment are dropped.  An unparsable committed
   selection shows "Device format: DeviceName:Variable Name" in the status
   bar (both on commit and on a Set attempt) instead of a silent no-op.
-- **R6 idle scan number**: at startup and on experiment change a
-  `BackgroundResult` worker runs the injectable `scan_number_lookup`
-  (default: `ops_paths.todays_scan_folder` +
-  `ops_paths.highest_scan_number`) and the label shows
-  "Scan NNN (previous)" or "No scans today".  **Strictly read-only** —
+- **R6 idle scan number** — owned by
+  `app/now_panel.py::NowPanelController` since 0.18.2 (issue #534 step 5,
+  with the pill/progress/log-tail rendering and the expiry timer; the
+  window keeps the widget attributes, thin `append_log` /
+  `set_scan_number` delegates, and the scan-lifecycle hub, and its
+  `closeEvent` calls the controller's `dispose()` — same lifetime rule
+  as the actions-menu controller): at startup and on experiment change
+  the controller's `BackgroundResult` worker runs the injectable
+  `scan_number_lookup` (default: `ops_paths.todays_scan_folder` +
+  `ops_paths.highest_scan_number`, resolved at probe time so test
+  patching works), **one probe in flight per experiment** (the same
+  native-first-import race dedupe as the actions fetch), and the label
+  shows "Scan NNN (previous)" or "No scans today".  **Strictly read-only** —
   resolution + `is_dir()`/`iterdir()` only, never creating anything on the
   scans path (repo scan-folder invariant; pinned by tree-untouched tests
   in `tests/test_ops_paths.py` and
@@ -256,8 +264,8 @@ are prefixed by region (`r3_radio_1d`, `r5_start_button`, …).
   probe emitted a `MainWindow` signal; the R7 device-set completion was
   the last such emission and moved to a `BackgroundResult` worker in
   0.7.0 — issue #510).  `closeEvent` disconnects each window-owned
-  worker's `result_ready`; the actions-menu controller's worker is
-  detached inside its `dispose()` instead.
+  worker's `result_ready`; the actions-menu and now-panel controllers'
+  workers are detached inside their `dispose()` instead.
 - **Actions menu (G-actions v1)** — owned by
   `app/actions_menu.py::ActionsMenuController` since 0.18.1 (issue #534
   step 3): the window creates the QMenu (kept in `self._menus`) and the
@@ -275,9 +283,9 @@ are prefixed by region (`r3_radio_1d`, `r5_start_button`, …).
   flight per experiment** — startup requests twice back-to-back, and
   two concurrent fetch threads race the lazy `geecs_bluesky` import
   inside the store's configs-root resolution, a native init that
-  aborts the process when raced (found 2026-07-20; the sibling
-  completions/idle-scan double-fetches share the hazard shape and are
-  not yet deduped); empty/offline/failed renders one disabled
+  aborts the process when raced (found 2026-07-20; the now-panel idle
+  probe is deduped the same way since 0.18.2, the completions
+  double-fetch is not yet); empty/offline/failed renders one disabled
   "(no actions)" entry.  On top sits **"Enable action execution"** — the
   accidental-click guard: checkable, **default OFF at every launch and
   deliberately NOT persisted** (a fresh session must never start armed;

--- a/GEECS-Console/geecs_console/app/main_window.py
+++ b/GEECS-Console/geecs_console/app/main_window.py
@@ -41,6 +41,7 @@ from PySide6.QtWidgets import (
 from pydantic import ValidationError
 
 from geecs_console.app.actions_menu import ActionsMenuController
+from geecs_console.app.now_panel import NowPanelController
 from geecs_console.editors.action_library_editor import open_action_library_editor
 from geecs_console.editors.save_set_editor import open_save_set_editor
 from geecs_console.editors.scan_variable_editor import open_scan_variable_editor
@@ -89,8 +90,6 @@ logger = logging.getLogger(__name__)
 _UI_PATH = Path(__file__).parent / "ui" / "main_window.ui"
 _QSS_PATH = Path(__file__).parent / "style.qss"
 
-_SCAN_NUMBER_EXPIRY_MS = 10_000
-
 #: With "Randomized beeps" on, the fraction of shots that actually beep.
 _RANDOM_BEEP_PROBABILITY = 0.25
 
@@ -109,21 +108,6 @@ _HEALTH_DOT_COLORS = {
     HealthStatus.WARN: _COLOR_AMBER,
     HealthStatus.DOWN: _COLOR_RED,
     HealthStatus.UNKNOWN: _COLOR_GREY,
-}
-
-#: ScanState value → state-pill dot color (grey covers idle/unknown).
-_STATE_DOT_COLORS = {
-    "running": _COLOR_GREEN,
-    "done": _COLOR_GREEN,
-    "complete": _COLOR_GREEN,
-    "completed": _COLOR_GREEN,
-    "initializing": _COLOR_AMBER,
-    "stopping": _COLOR_AMBER,
-    "pausing": _COLOR_AMBER,
-    "paused": _COLOR_AMBER,
-    "aborted": _COLOR_RED,
-    "error": _COLOR_RED,
-    "failed": _COLOR_RED,
 }
 
 # Lifecycle states that settle an in-flight Stop request, releasing the Stop
@@ -264,7 +248,6 @@ class MainWindow(QMainWindow):
             else make_bluesky_submitter
         )
         self.events = ScanEventsAdapter(self)
-        self._total_shots = 0
         self._shot_count_valid = False
         self._beep_rng = rng if rng is not None else random.Random()
         self._last_beep_shots = 0
@@ -287,10 +270,22 @@ class MainWindow(QMainWindow):
         self._wire_signals()
 
         self.setWindowTitle("GEECS Console")
-        self._scan_number_timer = QTimer(self)
-        self._scan_number_timer.setSingleShot(True)
-        self._scan_number_timer.setInterval(_SCAN_NUMBER_EXPIRY_MS)
-        self._scan_number_timer.timeout.connect(self._expire_scan_number)
+        # R6 rendering lives on NowPanelController (app/now_panel.py); the
+        # widgets stay window attributes (tests, tooltips), the lookup is
+        # resolved at probe time so the module-level default stays
+        # test-patchable.
+        self._now = NowPanelController(
+            state_pill=self.state_pill,
+            progress_bar=self.progress_bar,
+            scan_number_label=self.scan_number_label,
+            log_tail=self.log_tail,
+            current_experiment=lambda: self.experiment_combo.currentText(),
+            resolve_lookup=lambda: (
+                self._scan_number_lookup
+                if self._scan_number_lookup is not None
+                else _idle_scan_lookup
+            ),
+        )
 
         # First populate quietly: a remembered experiment restored on the
         # next line makes its "No experiment selected." a lie (it used to
@@ -303,7 +298,7 @@ class MainWindow(QMainWindow):
         self._apply_health_report(HealthReport())
         self._push_experiment_to_probe(self._configs.experiment)
         self._start_health_poller()
-        self._set_state_pill("idle")
+        self._now.set_state_pill("idle")
         self._on_mode_changed()
         self._refresh_device_set_enabled()
         # Startup fetches for the selected experiment (no-ops when none):
@@ -314,13 +309,13 @@ class MainWindow(QMainWindow):
         # duplicate fetch is *result*-safe (stale results are dropped by
         # experiment tag) but NOT thread-safe in general: two concurrent
         # fetch threads can race the lazy first import of a native chain
-        # (geecs_bluesky's EPICS init aborts the process when raced — hence
-        # the actions controller's one-in-flight dedupe).  The completions
-        # and idle-scan pairs still double-spawn and share the hazard shape
-        # (mysql-connector / pandas chains); dedupe them the same way if
-        # this ever bites.
+        # (a native init in the geecs_bluesky chain aborts the process when
+        # raced — hence the one-in-flight dedupe in the actions and
+        # now-panel controllers).  The completions pair still double-spawns
+        # and shares the hazard shape (mysql-connector chain); dedupe it
+        # the same way if this ever bites.
         self._start_device_completions_fetch()
-        self._start_idle_scan_probe()
+        self._now.start_idle_probe()
         self._actions.start_fetch()
 
     # ------------------------------------------------------------------
@@ -593,11 +588,8 @@ class MainWindow(QMainWindow):
         self._completions_worker.result_ready.connect(
             self._apply_device_completions, Qt.ConnectionType.QueuedConnection
         )
-        self._idle_scan_worker = BackgroundResult()
-        self._idle_scan_worker.result_ready.connect(
-            self._apply_idle_scan_number, Qt.ConnectionType.QueuedConnection
-        )
-        # (The actions-menu fetch worker lives on ActionsMenuController.)
+        # (The actions-menu fetch worker lives on ActionsMenuController;
+        # the idle scan-number probe worker on NowPanelController.)
         # Stop dispatch (issue #571): stop_scanning_thread may block briefly
         # (engine bookkeeping join), so it runs on a worker — never the GUI
         # thread.  No result slot: completion is announced by the terminal
@@ -802,7 +794,6 @@ class MainWindow(QMainWindow):
                 getattr(self, "_completions_worker", None),
                 self._apply_device_completions,
             ),
-            (getattr(self, "_idle_scan_worker", None), self._apply_idle_scan_number),
             (getattr(self, "_device_set_worker", None), self._apply_device_set_result),
         ):
             if worker is None:
@@ -818,6 +809,9 @@ class MainWindow(QMainWindow):
         actions = getattr(self, "_actions", None)
         if actions is not None:
             actions.dispose()
+        now = getattr(self, "_now", None)
+        if now is not None:
+            now.dispose()
         super().closeEvent(event)
 
     # ------------------------------------------------------------------
@@ -1128,7 +1122,7 @@ class MainWindow(QMainWindow):
         # New experiment: new device list, new daily scans folder, and a
         # new action-plan library.
         self._start_device_completions_fetch()
-        self._start_idle_scan_probe()
+        self._now.start_idle_probe()
         self._actions.start_fetch()
 
     def _restore_last_experiment(self) -> bool:
@@ -1907,96 +1901,24 @@ class MainWindow(QMainWindow):
     # ------------------------------------------------------------------
 
     def append_log(self, line: str) -> None:
-        """Append one line to the compact log tail.
+        """Append one line to the compact log tail (delegates to the panel).
 
         Parameters
         ----------
         line : str
             The text to append (one log-tail row).
         """
-        self.log_tail.appendPlainText(line)
+        self._now.append_log(line)
 
     def set_scan_number(self, number: int) -> None:
-        """Show the current scan number, expiring to 'previous' after 10 s.
+        """Show the current scan number (delegates to the panel).
 
         Parameters
         ----------
         number : int
             The claimed scan number.
         """
-        self.scan_number_label.setText(f"Scan {number:03d}")
-        self._scan_number_timer.start()
-
-    def _expire_scan_number(self) -> None:
-        """Mark the displayed scan number as previous once the timer fires."""
-        text = self.scan_number_label.text()
-        if text.startswith("Scan ") and not text.endswith("(previous)"):
-            self.scan_number_label.setText(f"{text} (previous)")
-
-    def _start_idle_scan_probe(self) -> None:
-        """Peek at today's scans dir for the R6 idle display — read-only.
-
-        The lookup resolves today's daily ``scans/`` folder and lists it for
-        the highest existing ``ScanNNN`` — resolution and listdir only,
-        never creating anything on that path (repo scan-folder invariant).
-        The data root is typically a network mount, so the blocking lookup
-        runs on a short-lived daemon thread (via the
-        :class:`BackgroundResult` worker) and reports back queued to
-        :meth:`_apply_idle_scan_number`.
-        """
-        experiment = self.experiment_combo.currentText()
-        lookup = (
-            self._scan_number_lookup
-            if self._scan_number_lookup is not None
-            else _idle_scan_lookup
-        )
-
-        def probe() -> tuple[str, Optional[int]]:
-            try:
-                number = lookup(experiment)
-            except Exception as exc:  # noqa: BLE001 — a flaky mount is not a crash
-                logger.info("idle scan-number lookup failed: %s", exc)
-                number = None
-            return (experiment, number)
-
-        self._idle_scan_worker.run_async(probe, name="console-idle-scan-probe")
-
-    @Slot(object)
-    def _apply_idle_scan_number(self, payload: object) -> None:
-        """Render the idle scan-number peek (GUI-thread slot, delivered queued).
-
-        A live scan number on display (the 10 s expiry timer still running)
-        is never clobbered, and a result tagged with an experiment that is
-        no longer selected is dropped.
-
-        Parameters
-        ----------
-        payload : tuple
-            ``(experiment, int | None)`` from the daemon-thread probe.
-        """
-        experiment, number = payload
-        if experiment != self.experiment_combo.currentText():
-            return
-        if self._scan_number_timer.isActive():
-            return
-        if number is None:
-            self.scan_number_label.setText("No scans today")
-        else:
-            self.scan_number_label.setText(f"Scan {number:03d} (previous)")
-
-    def _set_state_pill(self, state: str) -> None:
-        """Render the R6 state pill: colored dot + uppercase state word.
-
-        Parameters
-        ----------
-        state : str
-            A ``ScanState`` value (e.g. ``"running"``); dot color is green
-            for running/done, amber for initializing, red for aborted or
-            error, grey otherwise (idle).
-        """
-        word = (state or "idle").strip()
-        color = _STATE_DOT_COLORS.get(word.lower(), _COLOR_GREY)
-        self.state_pill.setText(f'<span style="color:{color};">●</span> {word.upper()}')
+        self._now.set_scan_number(number)
 
     def _on_scan_state(self, state: str) -> None:
         """Update the state pill and button gating on lifecycle events.
@@ -2010,7 +1932,7 @@ class MainWindow(QMainWindow):
         if self._stop_in_flight and lowered in _TERMINAL_SCAN_STATES:
             self._stop_in_flight = False
             self.stop_button.setText(self._stop_button_label)
-        self._set_state_pill(state)
+        self._now.set_state_pill(state)
         self._refresh_submit_enabled()
 
         # Push the live scan state into open action dialogs so their Run
@@ -2028,20 +1950,14 @@ class MainWindow(QMainWindow):
 
     def _on_totals_known(self, total_shots: int) -> None:
         """Size the progress bar once the scan announces its totals."""
-        self._total_shots = total_shots
-        self.progress_bar.setMaximum(max(1, total_shots))
-        self.progress_bar.setValue(0)
+        self._now.set_totals(total_shots)
         self._last_beep_shots = 0  # new scan: re-arm the per-shot beep
 
     def _on_progress(
         self, step_index: int, total_steps: int, shots_completed: int
     ) -> None:
         """Advance the progress bar from step events; beep on shot increments."""
-        if self._total_shots:
-            self.progress_bar.setValue(min(shots_completed, self._total_shots))
-        elif total_steps:
-            self.progress_bar.setMaximum(total_steps)
-            self.progress_bar.setValue(min(step_index + 1, total_steps))
+        self._now.update_progress(step_index, total_steps, shots_completed)
         if shots_completed > self._last_beep_shots:
             self._last_beep_shots = shots_completed
             self._maybe_beep()

--- a/GEECS-Console/geecs_console/app/main_window.py
+++ b/GEECS-Console/geecs_console/app/main_window.py
@@ -309,11 +309,12 @@ class MainWindow(QMainWindow):
         # duplicate fetch is *result*-safe (stale results are dropped by
         # experiment tag) but NOT thread-safe in general: two concurrent
         # fetch threads can race the lazy first import of a native chain
-        # (a native init in the geecs_bluesky chain aborts the process when
-        # raced — hence the one-in-flight dedupe in the actions and
-        # now-panel controllers).  The completions pair still double-spawns
-        # and shares the hazard shape (mysql-connector chain); dedupe it
-        # the same way if this ever bites.
+        # (demonstrated in the actions fetch's geecs_bluesky chain, which
+        # aborted the process — hence the one-in-flight dedupe in the
+        # actions and now-panel controllers; the idle probe's own lazy
+        # chain is geecs_data_utils/pandas).  The completions pair still
+        # double-spawns and shares the hazard shape (mysql-connector
+        # chain); dedupe it the same way if this ever bites.
         self._start_device_completions_fetch()
         self._now.start_idle_probe()
         self._actions.start_fetch()

--- a/GEECS-Console/geecs_console/app/now_panel.py
+++ b/GEECS-Console/geecs_console/app/now_panel.py
@@ -150,6 +150,12 @@ class NowPanelController(QObject):
         experiment.
         """
         experiment = self._current_experiment()
+        if not experiment:
+            # No experiment: answer inline (no thread for a constant) —
+            # and never leave a ""-tagged probe that the disposed state's
+            # ""-returning sentinel would fail to stale-drop.
+            self._apply_idle_scan_number((experiment, None))
+            return
         if self._probe_inflight == experiment:
             return
         self._probe_inflight = experiment
@@ -250,8 +256,10 @@ class NowPanelController(QObject):
 
         Called from the window's ``closeEvent``.  Stops the expiry timer,
         detaches the probe worker so a straggling result lands nowhere,
-        and drops the widget/closure references so the dead window is
-        freed by refcount rather than the cyclic GC.
+        and replaces the two closures — the only Python edges back to the
+        window (child-widget wrappers hold no reference to the window
+        wrapper) — so the dead window is freed by refcount rather than
+        the cyclic GC.
         """
         self._scan_number_timer.stop()
         try:

--- a/GEECS-Console/geecs_console/app/now_panel.py
+++ b/GEECS-Console/geecs_console/app/now_panel.py
@@ -1,0 +1,262 @@
+"""The R6 now panel: state pill, progress bar, scan number, log tail.
+
+Owns the rendering of the console's "what is happening right now" region
+so the main window stays a composition root.  The window's scan-lifecycle
+hub (``_on_scan_state``) remains in the window — it fans out to R5 button
+gating and dialog teardown as well — and delegates the R6 rendering here.
+
+The log tail this panel appends to is NOT the Python log; see the R6
+bullet in this package's CLAUDE.md for the canonical description of the
+two streams and why their shot counts must never be reconciled.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Callable, Optional
+
+from PySide6.QtCore import QObject, Qt, QTimer, Slot
+from PySide6.QtWidgets import QLabel, QPlainTextEdit, QProgressBar
+
+from geecs_console.services.background import BackgroundResult
+
+logger = logging.getLogger(__name__)
+
+#: A displayed live scan number expires to "(previous)" after this long.
+_SCAN_NUMBER_EXPIRY_MS = 10_000
+
+#: Screen-map palette (see app/style.qss header; a shared palette module
+#: is a recorded deferral).
+_COLOR_GREY = "#b9c0c7"
+_COLOR_GREEN = "#2f9e63"
+_COLOR_AMBER = "#d9a21b"
+_COLOR_RED = "#c4453a"
+
+#: ScanState value → state-pill dot color (grey covers idle/unknown).
+_STATE_DOT_COLORS = {
+    "running": _COLOR_GREEN,
+    "done": _COLOR_GREEN,
+    "complete": _COLOR_GREEN,
+    "completed": _COLOR_GREEN,
+    "initializing": _COLOR_AMBER,
+    "stopping": _COLOR_AMBER,
+    "pausing": _COLOR_AMBER,
+    "paused": _COLOR_AMBER,
+    "aborted": _COLOR_RED,
+    "error": _COLOR_RED,
+    "failed": _COLOR_RED,
+}
+
+
+class NowPanelController(QObject):
+    """Render the R6 region on behalf of the main window.
+
+    A ``QObject`` with **no Qt parent**, kept alive only by the window's
+    Python reference (``self._now``); the window's ``closeEvent`` calls
+    :meth:`dispose` to sever every controller → window edge so the dead
+    window is freed by refcount, not the cyclic GC (the actions-menu
+    controller's documented lifetime rule).
+
+    Parameters
+    ----------
+    state_pill, progress_bar, scan_number_label, log_tail : QWidget
+        The R6 widgets (bound from the ``.ui`` by the window, which
+        remains their attribute home for tests and tooltips).
+    current_experiment : callable
+        Returns the currently selected experiment name ("" for none).
+    resolve_lookup : callable
+        Returns the idle scan-number lookup to use for one probe —
+        resolved at call time so test patching of the module-level
+        default keeps working.
+    """
+
+    def __init__(
+        self,
+        *,
+        state_pill: QLabel,
+        progress_bar: QProgressBar,
+        scan_number_label: QLabel,
+        log_tail: QPlainTextEdit,
+        current_experiment: Callable[[], str],
+        resolve_lookup: Callable[[], Callable[[str], Optional[int]]],
+    ) -> None:
+        super().__init__()
+        self._state_pill = state_pill
+        self._progress_bar = progress_bar
+        self._scan_number_label = scan_number_label
+        self._log_tail = log_tail
+        self._current_experiment = current_experiment
+        self._resolve_lookup = resolve_lookup
+
+        #: Total shots announced by the running scan (0 = not announced).
+        self._total_shots = 0
+
+        self._scan_number_timer = QTimer(self)
+        self._scan_number_timer.setSingleShot(True)
+        self._scan_number_timer.setInterval(_SCAN_NUMBER_EXPIRY_MS)
+        self._scan_number_timer.timeout.connect(self._expire_scan_number)
+
+        self._worker = BackgroundResult()
+        self._worker.result_ready.connect(
+            self._apply_idle_scan_number, Qt.ConnectionType.QueuedConnection
+        )
+        #: Experiment tag of an in-flight idle probe, or None — same
+        #: one-per-experiment dedupe as the actions-menu fetch (startup
+        #: requests twice back-to-back; concurrent daemon threads racing
+        #: a lazy native first import can abort the process).
+        self._probe_inflight: Optional[str] = None
+
+    # ------------------------------------------------------------------
+    # Log tail + scan number
+    # ------------------------------------------------------------------
+
+    def append_log(self, line: str) -> None:
+        """Append one line to the compact log tail.
+
+        Parameters
+        ----------
+        line : str
+            The text to append (one log-tail row).
+        """
+        self._log_tail.appendPlainText(line)
+
+    def set_scan_number(self, number: int) -> None:
+        """Show the current scan number, expiring to 'previous' after 10 s.
+
+        Parameters
+        ----------
+        number : int
+            The claimed scan number.
+        """
+        self._scan_number_label.setText(f"Scan {number:03d}")
+        self._scan_number_timer.start()
+
+    def _expire_scan_number(self) -> None:
+        """Mark the displayed scan number as previous once the timer fires."""
+        text = self._scan_number_label.text()
+        if text.startswith("Scan ") and not text.endswith("(previous)"):
+            self._scan_number_label.setText(f"{text} (previous)")
+
+    def start_idle_probe(self) -> None:
+        """Peek at today's scans dir for the idle display — read-only.
+
+        The lookup resolves today's daily ``scans/`` folder and lists it
+        for the highest existing ``ScanNNN`` — resolution and listdir
+        only, never creating anything on that path (repo scan-folder
+        invariant).  The data root is typically a network mount, so the
+        blocking lookup runs on a short-lived daemon thread (via the
+        :class:`BackgroundResult` worker) and reports back queued to
+        :meth:`_apply_idle_scan_number`; one probe in flight per
+        experiment.
+        """
+        experiment = self._current_experiment()
+        if self._probe_inflight == experiment:
+            return
+        self._probe_inflight = experiment
+        lookup = self._resolve_lookup()
+
+        def probe() -> tuple[str, Optional[int]]:
+            try:
+                number = lookup(experiment)
+            except Exception as exc:  # noqa: BLE001 — a flaky mount is not a crash
+                logger.info("idle scan-number lookup failed: %s", exc)
+                number = None
+            return (experiment, number)
+
+        self._worker.run_async(probe, name="console-idle-scan-probe")
+
+    @Slot(object)
+    def _apply_idle_scan_number(self, payload: object) -> None:
+        """Render the idle scan-number peek (GUI-thread slot, delivered queued).
+
+        A live scan number on display (the 10 s expiry timer still
+        running) is never clobbered, and a result tagged with an
+        experiment that is no longer selected is dropped.
+
+        Parameters
+        ----------
+        payload : tuple
+            ``(experiment, int | None)`` from the daemon-thread probe.
+        """
+        experiment, number = payload
+        if self._probe_inflight == experiment:
+            self._probe_inflight = None
+        if experiment != self._current_experiment():
+            return
+        if self._scan_number_timer.isActive():
+            return
+        if number is None:
+            self._scan_number_label.setText("No scans today")
+        else:
+            self._scan_number_label.setText(f"Scan {number:03d} (previous)")
+
+    # ------------------------------------------------------------------
+    # State pill + progress
+    # ------------------------------------------------------------------
+
+    def set_state_pill(self, state: str) -> None:
+        """Render the state pill: colored dot + uppercase state word.
+
+        Parameters
+        ----------
+        state : str
+            A ``ScanState`` value (e.g. ``"running"``); the dot color
+            comes from ``_STATE_DOT_COLORS`` (grey covers idle/unknown).
+        """
+        word = (state or "idle").strip()
+        color = _STATE_DOT_COLORS.get(word.lower(), _COLOR_GREY)
+        self._state_pill.setText(
+            f'<span style="color:{color};">●</span> {word.upper()}'
+        )
+
+    def set_totals(self, total_shots: int) -> None:
+        """Size the progress bar once the scan announces its totals.
+
+        Parameters
+        ----------
+        total_shots : int
+            The scan's announced shot total.
+        """
+        self._total_shots = total_shots
+        self._progress_bar.setMaximum(max(1, total_shots))
+        self._progress_bar.setValue(0)
+
+    def update_progress(
+        self, step_index: int, total_steps: int, shots_completed: int
+    ) -> None:
+        """Advance the progress bar from one step event.
+
+        Parameters
+        ----------
+        step_index : int
+            Zero-based index of the current step.
+        total_steps : int
+            The step total ("0" when unannounced).
+        shots_completed : int
+            Shots completed so far.
+        """
+        if self._total_shots:
+            self._progress_bar.setValue(min(shots_completed, self._total_shots))
+        elif total_steps:
+            self._progress_bar.setMaximum(total_steps)
+            self._progress_bar.setValue(min(step_index + 1, total_steps))
+
+    # ------------------------------------------------------------------
+    # Teardown
+    # ------------------------------------------------------------------
+
+    def dispose(self) -> None:
+        """Sever every controller → window reference; idempotent.
+
+        Called from the window's ``closeEvent``.  Stops the expiry timer,
+        detaches the probe worker so a straggling result lands nowhere,
+        and drops the widget/closure references so the dead window is
+        freed by refcount rather than the cyclic GC.
+        """
+        self._scan_number_timer.stop()
+        try:
+            self._worker.result_ready.disconnect(self._apply_idle_scan_number)
+        except (RuntimeError, TypeError):
+            pass
+        self._current_experiment = lambda: ""
+        self._resolve_lookup = lambda: (lambda experiment: None)

--- a/GEECS-Console/pyproject.toml
+++ b/GEECS-Console/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-console"
-version = "0.18.1"
+version = "0.18.2"
 description = "Greenfield PySide6 operator console for GEECS (Bluesky/gateway architecture)"
 authors = ["Sam Barber <sbarber@lbl.gov>"]
 readme = "README.md"

--- a/GEECS-Console/tests/test_main_window.py
+++ b/GEECS-Console/tests/test_main_window.py
@@ -859,7 +859,7 @@ class TestNowAndDevicePanel:
     def test_scan_number_expiry(self, window):
         window.set_scan_number(42)
         assert window.scan_number_label.text() == "Scan 042"
-        window._expire_scan_number()
+        window._now._expire_scan_number()
         assert window.scan_number_label.text() == "Scan 042 (previous)"
 
     def test_lifecycle_scan_number_drives_the_label(self, window):
@@ -870,7 +870,7 @@ class TestNowAndDevicePanel:
         assert window.scan_number_label.text() == before  # None -> untouched
         window.events.handle(ScanLifecycleEvent(state="running", scan_number=7))
         assert window.scan_number_label.text() == "Scan 007"
-        assert window._scan_number_timer.isActive()  # 10 s expiry armed
+        assert window._now._scan_number_timer.isActive()  # 10 s expiry armed
 
 
 class TestOpsMenu:

--- a/GEECS-Console/tests/test_main_window.py
+++ b/GEECS-Console/tests/test_main_window.py
@@ -856,6 +856,52 @@ class TestNowAndDevicePanel:
         assert window.progress_bar.value() == 10
         assert "running" in window.log_tail.toPlainText()
 
+    def test_concurrent_idle_probes_for_one_experiment_are_deduplicated(
+        self, window, monkeypatch
+    ):
+        """One in-flight idle probe per experiment — never two racing threads.
+
+        Startup requests twice back-to-back (restore-fired experiment
+        change + explicit construction-time call); concurrent daemon
+        threads racing a lazy native first import can abort the process.
+        """
+        controller = window._now
+        spawned = []
+        monkeypatch.setattr(
+            controller._worker,
+            "run_async",
+            lambda func, name: spawned.append(name),
+        )
+        controller.start_idle_probe()
+        controller.start_idle_probe()  # same experiment, first still in flight
+        assert len(spawned) == 1
+        # Delivery clears the tag, so a later refresh probes again.
+        controller._apply_idle_scan_number(("TestExp", None))
+        controller.start_idle_probe()
+        assert len(spawned) == 2
+
+    def test_no_experiment_probe_answers_inline_without_a_thread(
+        self, qtbot, monkeypatch
+    ):
+        """No experiment: no daemon thread, and the label reports directly."""
+        win = MainWindow(
+            configs=FakeConfigs(experiment=""),
+            presets=FakePresetStore(),
+            settings=FakeSettings(),
+            submitter=FakeSubmitter(),
+        )
+        qtbot.addWidget(win)
+        controller = win._now
+        spawned = []
+        monkeypatch.setattr(
+            controller._worker,
+            "run_async",
+            lambda func, name: spawned.append(name),
+        )
+        controller.start_idle_probe()
+        assert spawned == []
+        assert win.scan_number_label.text() == "No scans today"
+
     def test_scan_number_expiry(self, window):
         window.set_scan_number(42)
         assert window.scan_number_label.text() == "Scan 042"

--- a/GEECS-Console/tests/test_main_window_editors_integration.py
+++ b/GEECS-Console/tests/test_main_window_editors_integration.py
@@ -262,13 +262,13 @@ class TestIdleScanNumber:
     def test_live_scan_number_is_never_clobbered(self, qtbot):
         window = make_window(qtbot, scan_number_lookup=lambda exp: 17)
         window.set_scan_number(5)  # live scan: starts the 10 s expiry timer
-        window._apply_idle_scan_number(("TestExp", 17))
+        window._now._apply_idle_scan_number(("TestExp", 17))
         assert window.scan_number_label.text() == "Scan 005"
 
     def test_stale_experiment_result_is_dropped(self, qtbot):
         window = make_window(qtbot, scan_number_lookup=lambda exp: None)
         qtbot.wait(50)
-        window._apply_idle_scan_number(("SomeOtherExp", 42))
+        window._now._apply_idle_scan_number(("SomeOtherExp", 42))
         assert window.scan_number_label.text() == "No scans today"
 
     def test_probe_never_touches_the_tree(self, qtbot, tmp_path):


### PR DESCRIPTION
Step 5 of the #534 plan of record (per the 2026-07-20 refresh comment): the R6 now-panel rendering moves out of `main_window.py` into `app/now_panel.py::NowPanelController`.

## Per-concern breakdown

| Concern | LOC | What |
|---|---|---|
| **Extraction (the step itself)** | +262 module, −78 window (2,181 → 2,103) | State pill (+ the exact `_STATE_DOT_COLORS` dict, transplanted verbatim), progress-bar math (`_total_shots`), scan number + 10 s expiry timer, log tail, idle scan-number probe (worker owned by the controller; lookup resolved at probe time so conftest's module-level patch keeps working). Per the plan refresh: the **scan-lifecycle hub stays in the window** (it fans out to R5 gating and dialog teardown), as do the widget attributes (tests, tooltips), thin `append_log`/`set_scan_number` delegates, and the beep logic (Preferences cluster). #589's lifetime lessons applied up front: no Qt parent, `dispose()` in `closeEvent`. |
| **Idle-probe dedupe** | ~10 | The idle probe gets the same one-in-flight-per-experiment dedupe as the actions fetch (0.18.1) — startup double-spawns it identically, same native-first-import race shape. Of the three startup fetch pairs flagged in #589, **only the completions pair now remains** (R7 territory — #534 step 4's natural scope). |
| **Contract + comment hygiene** | docs | Console CLAUDE.md updated **in this PR** (the #589 finding-1 lesson): R6 seam bullets describe the controller shape, the worker-disconnect split names both controllers, the sibling-hazard note reflects the narrowed state. The startup hazard comment softened to "native init in the geecs_bluesky chain" per the #589 reviewer's terminology nit (EPICS specifically was never demonstrated). |

## Deliberately unchanged
Zero user-visible behavior intended. Test migrations: four private grips (`_apply_idle_scan_number` ×2, `_scan_number_timer`, `_expire_scan_number`) move to `window._now.…`; the widget attributes and public methods are untouched surfaces.

## Tests
Full console suite **770 passed**, verified **3× consecutively** (same flaky-crash caution as #589).

## Hardware verification
None owed — rendering/window plumbing only; nothing touches scan execution or devices.

🤖 Generated with [Claude Code](https://claude.com/claude-code)