### PR TITLE
GEECS-Console 0.18.3: config-store base — ExperimentConfigStore/NamedConfigStore (#532)

### DIFF
--- a/GEECS-Console/CHANGELOG.md
+++ b/GEECS-Console/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to GEECS-Console are documented here.  Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versioning is
 semantic.
 
+## [0.18.3] - 2026-07-20
+
+### Changed
+
+- Shared persistence base for the five per-experiment config stores
+  (issue #532): `services/config_store.py` — `ExperimentConfigStore`
+  (experiment selection, configs-root/folder resolution, the
+  experiment-name guard, YAML read/write with status-bar-ready errors;
+  all five stores) and `NamedConfigStore` (name validation, `.yml` twin
+  fallback, sorted listing, delete; the preset/save-set/trigger-profile
+  file-per-name trio).  Net −354 lines (842 duplicated removed against a
+  376-line base); every class name, error class, constant, signature,
+  and rendered message is unchanged, and the store test suites pass
+  unmodified.  The scan-folder-invariant rationale for config-dir
+  creation now lives in exactly one place (was restated ~10× across the
+  five modules); `configs._yaml_stems` delegates to the shared
+  `yaml_stems` (it was a fourth copy of the listing body).
+
 ## [0.18.2] - 2026-07-20
 
 ### Changed

--- a/GEECS-Console/geecs_console/services/action_library_store.py
+++ b/GEECS-Console/geecs_console/services/action_library_store.py
@@ -18,10 +18,8 @@ listing degrades to empty with no configs root; ``load``/``save``/``delete``/
 ``rename`` raise :class:`ActionLibraryStoreError` with a message fit for
 inline display.  The schema's library validator rejects dangling ``run``
 references, so this store pre-checks deletes and saves and raises the
-clearer message itself.  Creating the ``action_library/`` directory with
-``mkdir(parents=True, exist_ok=True)`` is deliberate and fine — this is a
-config directory in the configs repo, not a ``scans/ScanNNN/`` data folder,
-so the repo's scan-folder creation invariant does not apply.
+clearer message itself.  Directory creation and the scan-folder-invariant
+rationale live in :mod:`geecs_console.services.config_store`.
 
 This module is **editing only** — it never executes a plan and never touches
 Channel Access or hardware.
@@ -33,11 +31,13 @@ import logging
 from pathlib import Path
 from typing import Optional
 
-import yaml
 from pydantic import ValidationError
 
-from geecs_console.services._experiment_name import check_experiment_name
-from geecs_console.services.configs import _configs_base
+from geecs_console.services.config_store import ExperimentConfigStore
+
+# The base resolves the configs root through this module's namespace, so
+# tests can monkeypatch ``action_library_store._configs_base``.
+from geecs_console.services.configs import _configs_base  # noqa: F401
 from geecs_schemas import ActionPlan, ActionPlanLibrary
 from geecs_schemas.convert import SchemaConversionError, convert_action_library
 
@@ -45,6 +45,11 @@ logger = logging.getLogger(__name__)
 
 ACTION_FOLDER = "action_library"
 LIBRARY_FILE = "actions.yaml"
+
+# Identity sentinel for _read_mapping's empty_as: distinguishes an all-empty
+# YAML document (safe_load returns None → empty library) from a literal
+# ``{}`` mapping, which must still flow through the legacy converter.
+_EMPTY_DOCUMENT: dict = {}
 
 
 class ActionLibraryStoreError(RuntimeError):
@@ -73,44 +78,11 @@ def referencing_plans(library: ActionPlanLibrary, name: str) -> list[str]:
     )
 
 
-class ActionLibraryStore:
-    """Load/save named action plans for one experiment's library file.
+class ActionLibraryStore(ExperimentConfigStore):
+    """Load/save named action plans for one experiment's library file."""
 
-    Parameters
-    ----------
-    experiment : str, optional
-        Experiment folder under ``scanner_configs/experiments``.  May be
-        empty at construction (before the operator picks one) — listing is
-        then empty and saving raises.
-    experiments_root : str or Path, optional
-        Override for the experiments root (tests point this at a tmp dir);
-        defaults to the production resolution
-        (:func:`geecs_bluesky.scanner_configs.scanner_configs_base`,
-        resolved lazily so the module stays import-safe offline).
-    """
-
-    def __init__(
-        self, experiment: str = "", experiments_root: str | Path | None = None
-    ) -> None:
-        self._experiment = experiment
-        self._experiments_root = (
-            Path(experiments_root) if experiments_root is not None else None
-        )
-
-    @property
-    def experiment(self) -> str:
-        """The experiment this store reads and writes action plans for."""
-        return self._experiment
-
-    def set_experiment(self, experiment: str) -> None:
-        """Switch the store to *experiment*.
-
-        Parameters
-        ----------
-        experiment : str
-            The new experiment folder name ("" for none selected).
-        """
-        self._experiment = experiment
+    FOLDER = ACTION_FOLDER
+    ERROR = ActionLibraryStoreError
 
     # ------------------------------------------------------------------
     # Path resolution
@@ -122,16 +94,11 @@ class ActionLibraryStore:
         Raises
         ------
         ActionLibraryStoreError
-            When the experiment name would escape the experiments root
-            (issue #513) — checked before any path join.
+            When the experiment name would escape the experiments root —
+            checked before any path join.
         """
-        root = self._experiments_root
-        if root is None:
-            root = _configs_base()
-        if root is None or not self._experiment:
-            return None
-        check_experiment_name(self._experiment, ActionLibraryStoreError)
-        return root / self._experiment / ACTION_FOLDER / LIBRARY_FILE
+        folder = self._folder()
+        return None if folder is None else folder / LIBRARY_FILE
 
     def _library_path_or_raise(self) -> Path:
         """Return the library file path, raising a clear error when unresolvable.
@@ -147,18 +114,7 @@ class ActionLibraryStore:
             When the configs repo is not found, no experiment is selected,
             or the experiment name would escape the experiments root.
         """
-        root = self._experiments_root
-        if root is None:
-            root = _configs_base()
-        if root is None:
-            raise ActionLibraryStoreError(
-                "Configs repo not found — set GEECS_SCANNER_CONFIG_DIR or "
-                "config.ini [Paths] scanner_config_root_path."
-            )
-        if not self._experiment:
-            raise ActionLibraryStoreError("No experiment selected.")
-        check_experiment_name(self._experiment, ActionLibraryStoreError)
-        return root / self._experiment / ACTION_FOLDER / LIBRARY_FILE
+        return self._folder_or_raise() / LIBRARY_FILE
 
     @staticmethod
     def _validate_name(name: str) -> str:
@@ -216,19 +172,11 @@ class ActionLibraryStore:
         path = self._library_path_or_raise()
         if not path.exists():
             return ActionPlanLibrary(plans={})
-        try:
-            document = yaml.safe_load(path.read_text(encoding="utf-8"))
-        except yaml.YAMLError as exc:
-            raise ActionLibraryStoreError(
-                f"Action library is not valid YAML ({path}): {exc}"
-            ) from exc
-        if document is None:
+        document = self._read_mapping(
+            path, describe="Action library", empty_as=_EMPTY_DOCUMENT
+        )
+        if document is _EMPTY_DOCUMENT:
             return ActionPlanLibrary(plans={})
-        if not isinstance(document, dict):
-            raise ActionLibraryStoreError(
-                f"Action library ({path}) should be a YAML mapping, got "
-                f"{type(document).__name__}."
-            )
         if "schema_version" in document:
             try:
                 return ActionPlanLibrary.model_validate(document)
@@ -263,18 +211,9 @@ class ActionLibraryStore:
             Missing configs repo / experiment, or an OS-level write failure.
         """
         path = self._library_path_or_raise()
-        # A config dir, not a scans/ScanNNN/ data folder — parents=True is
-        # explicitly fine here (the scan-folder invariant does not apply).
-        path.parent.mkdir(parents=True, exist_ok=True)
-        document = yaml.safe_dump(
-            library.model_dump(mode="json"), sort_keys=False, allow_unicode=True
+        self._write_document(
+            path, library.model_dump(mode="json"), "the action library"
         )
-        try:
-            path.write_text(document, encoding="utf-8")
-        except OSError as exc:
-            raise ActionLibraryStoreError(
-                f"Could not write the action library: {exc}"
-            ) from exc
         logger.info("saved action library (%d plans) to %s", len(library.plans), path)
         return path
 

--- a/GEECS-Console/geecs_console/services/config_store.py
+++ b/GEECS-Console/geecs_console/services/config_store.py
@@ -1,0 +1,376 @@
+"""Shared persistence base for the per-experiment config stores.
+
+Five stores keep the console's config kinds in the configs repo
+(``scanner_configs/experiments/<Experiment>/...``): presets, save sets,
+trigger profiles, the scan-variable catalog, and the action library.
+:class:`ExperimentConfigStore` owns what they all share — experiment
+selection, configs-root and folder resolution, the experiment-name guard,
+and safe YAML read/write with status-bar-ready errors.
+:class:`NamedConfigStore` adds the file-per-name surface (name validation,
+``.yml`` twin fallback, sorted listing, delete) the preset / save-set /
+trigger-profile trio share.  Each concrete store keeps its own error
+class, folder constants, and schema-specific load/save logic in its own
+module.
+
+Directory creation policy — the canonical statement for every store:
+creating a config directory with ``mkdir(parents=True, exist_ok=True)``
+is deliberate and fine.  These are config directories in the configs
+repo, not ``scans/ScanNNN/`` data folders, so the repo's scan-folder
+creation invariant does not apply.
+
+The production configs root is resolved through each concrete store's
+module namespace: every store module imports ``_configs_base`` from
+:mod:`geecs_console.services.configs`, and :meth:`ExperimentConfigStore._root`
+reads that binding at call time — so tests can monkeypatch
+``<store module>._configs_base`` per store, exactly as before the
+extraction.  (This module deliberately does not import
+:mod:`~geecs_console.services.configs`, which imports :func:`yaml_stems`
+from here.)
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+from pathlib import Path
+from typing import Optional
+
+import yaml
+
+from geecs_console.services._experiment_name import check_experiment_name
+
+_CONFIGS_REPO_MISSING = (
+    "Configs repo not found — set GEECS_SCANNER_CONFIG_DIR or "
+    "config.ini [Paths] scanner_config_root_path."
+)
+_NO_EXPERIMENT = "No experiment selected."
+
+
+def yaml_stems(folder: Path) -> list[str]:
+    """List the YAML file stems in *folder*, sorted; empty when absent.
+
+    Parameters
+    ----------
+    folder : Path
+        The directory to scan (need not exist).
+
+    Returns
+    -------
+    list of str
+        Sorted stems of the ``.yaml``/``.yml`` files in *folder*.
+    """
+    if not folder.is_dir():
+        return []
+    return sorted(
+        path.stem for path in folder.iterdir() if path.suffix in (".yaml", ".yml")
+    )
+
+
+class ExperimentConfigStore:
+    """Base for the per-experiment config stores.
+
+    Subclasses set :attr:`FOLDER` and :attr:`ERROR` and add their
+    schema-specific load/save surface on top of the resolution and I/O
+    helpers here.
+
+    Parameters
+    ----------
+    experiment : str, optional
+        Experiment folder under ``scanner_configs/experiments``.  May be
+        empty at construction (before the operator picks one) — listing is
+        then empty and saving raises.
+    experiments_root : str or Path, optional
+        Override for the experiments root (tests point this at a tmp dir);
+        defaults to the production resolution
+        (:func:`geecs_bluesky.scanner_configs.scanner_configs_base`, resolved
+        lazily so the module stays import-safe offline).
+    """
+
+    FOLDER: str
+    """The store's per-experiment subfolder name (e.g. ``"presets"``)."""
+
+    ERROR: type[RuntimeError]
+    """The store's concrete error class (status-bar/inline-ready messages)."""
+
+    def __init__(
+        self, experiment: str = "", experiments_root: str | Path | None = None
+    ) -> None:
+        self._experiment = experiment
+        self._experiments_root = (
+            Path(experiments_root) if experiments_root is not None else None
+        )
+
+    @property
+    def experiment(self) -> str:
+        """The experiment this store reads and writes configs for."""
+        return self._experiment
+
+    def set_experiment(self, experiment: str) -> None:
+        """Switch the store to *experiment*.
+
+        Parameters
+        ----------
+        experiment : str
+            The new experiment folder name ("" for none selected).
+        """
+        self._experiment = experiment
+
+    @property
+    def _logger(self) -> logging.Logger:
+        """The concrete store module's logger (log lines keep their origin)."""
+        return logging.getLogger(type(self).__module__)
+
+    # ------------------------------------------------------------------
+    # Folder resolution
+    # ------------------------------------------------------------------
+
+    def _root(self) -> Optional[Path]:
+        """Return the experiments root, or ``None`` offline.
+
+        The production resolution is read through the concrete store's
+        module namespace (each store module imports ``_configs_base``), so
+        tests can monkeypatch ``<store module>._configs_base``.
+        """
+        if self._experiments_root is not None:
+            return self._experiments_root
+        return sys.modules[type(self).__module__]._configs_base()
+
+    def _folder(self) -> Optional[Path]:
+        """Return the store's per-experiment dir, or ``None`` offline/unselected.
+
+        The experiment name is validated before any path join by the shared
+        guard in :mod:`geecs_console.services._experiment_name` (see its
+        module docstring for the traversal rationale).
+
+        Raises
+        ------
+        RuntimeError
+            The store's :attr:`ERROR` when the experiment name would escape
+            the experiments root; a merely missing root or unselected
+            experiment yields ``None``, not an error.
+        """
+        root = self._root()
+        if root is None or not self._experiment:
+            return None
+        check_experiment_name(self._experiment, self.ERROR)
+        return root / self._experiment / self.FOLDER
+
+    def _folder_or_raise(self) -> Path:
+        """Return the store's per-experiment dir, raising when unresolvable.
+
+        Returns
+        -------
+        Path
+            ``<experiments root>/<experiment>/<FOLDER>``.
+
+        Raises
+        ------
+        RuntimeError
+            The store's :attr:`ERROR` when the configs repo is not found,
+            no experiment is selected, or the experiment name would escape
+            the experiments root.
+        """
+        root = self._root()
+        if root is None:
+            raise self.ERROR(_CONFIGS_REPO_MISSING)
+        if not self._experiment:
+            raise self.ERROR(_NO_EXPERIMENT)
+        check_experiment_name(self._experiment, self.ERROR)
+        return root / self._experiment / self.FOLDER
+
+    # ------------------------------------------------------------------
+    # YAML I/O
+    # ------------------------------------------------------------------
+
+    def _read_mapping(
+        self,
+        path: Path,
+        *,
+        describe: str,
+        mapping_hint: str = "",
+        empty_as: Optional[dict] = None,
+    ) -> dict:
+        """Read *path* as one YAML mapping, with status-bar-ready errors.
+
+        Parameters
+        ----------
+        path : Path
+            The YAML file to read (must exist — callers check first where a
+            friendlier not-found message applies).
+        describe : str
+            Message subject, e.g. ``"Preset 'align'"`` — rendered as
+            ``"<describe> is not valid YAML (<path>): ..."``.
+        mapping_hint : str, optional
+            Message tail after "should be a YAML mapping", e.g.
+            ``" of ScanRequest fields"``.
+        empty_as : dict, optional
+            Returned as-is for an all-empty document (YAML ``None``); when
+            omitted, an empty document fails the mapping check instead.
+
+        Returns
+        -------
+        dict
+            The parsed top-level mapping.
+
+        Raises
+        ------
+        RuntimeError
+            The store's :attr:`ERROR` on unparsable YAML or a non-mapping
+            document.
+        """
+        try:
+            document = yaml.safe_load(path.read_text(encoding="utf-8"))
+        except yaml.YAMLError as exc:
+            raise self.ERROR(f"{describe} is not valid YAML ({path}): {exc}") from exc
+        if document is None and empty_as is not None:
+            return empty_as
+        if not isinstance(document, dict):
+            raise self.ERROR(
+                f"{describe} ({path}) should be a YAML mapping{mapping_hint}, "
+                f"got {type(document).__name__}."
+            )
+        return document
+
+    def _write_document(self, path: Path, document: dict, describe: str) -> None:
+        """Write *document* to *path* as YAML, creating the config dir.
+
+        Parameters
+        ----------
+        path : Path
+            The YAML file to write.
+        document : dict
+            The mapping to dump.  Each store's ``model_dump`` call stays
+            with the store — the dump kwargs differ between them.
+        describe : str
+            Message subject for a write failure, e.g. ``"preset 'align'"``.
+
+        Raises
+        ------
+        RuntimeError
+            The store's :attr:`ERROR` on an OS-level write failure.
+        """
+        # A config dir, not a scans/ScanNNN/ data folder — parents=True is
+        # explicitly fine here (see the module docstring).
+        path.parent.mkdir(parents=True, exist_ok=True)
+        text = yaml.safe_dump(document, sort_keys=False, allow_unicode=True)
+        try:
+            path.write_text(text, encoding="utf-8")
+        except OSError as exc:
+            raise self.ERROR(f"Could not write {describe}: {exc}") from exc
+
+
+class NamedConfigStore(ExperimentConfigStore):
+    """Base for stores keeping one YAML file per named config.
+
+    Adds the file-per-name surface on top of :class:`ExperimentConfigStore`;
+    subclasses also set :attr:`NOUN` and :attr:`LABEL`.
+    """
+
+    NOUN: str
+    """The name-validation noun (``"<NOUN> name must not be empty."``)."""
+
+    LABEL: str
+    """The message label for not-found/delete texts (e.g. ``"Trigger profile"``)."""
+
+    def _path(self, name: str) -> Path:
+        """Return the YAML path for config *name*, validating the name.
+
+        Parameters
+        ----------
+        name : str
+            The config name (the file stem — no path separators).
+
+        Returns
+        -------
+        Path
+            ``<store folder>/<name>.yaml`` (an existing ``.yml`` twin is
+            preferred when the ``.yaml`` spelling is absent).
+
+        Raises
+        ------
+        RuntimeError
+            The store's :attr:`ERROR` on an empty name or one that would
+            escape the store's folder.
+        """
+        cleaned = name.strip()
+        if not cleaned:
+            raise self.ERROR(f"{self.NOUN} name must not be empty.")
+        if any(sep in cleaned for sep in ("/", "\\")) or cleaned in (".", ".."):
+            raise self.ERROR(
+                f"{self.NOUN} name {name!r} must be a plain file name "
+                "(no path separators)."
+            )
+        folder = self._folder_or_raise()
+        path = folder / f"{cleaned}.yaml"
+        if not path.exists():
+            twin = folder / f"{cleaned}.yml"
+            if twin.exists():
+                return twin
+        return path
+
+    def _existing_path(self, name: str) -> Path:
+        """Return the YAML path for config *name*, raising when absent.
+
+        Parameters
+        ----------
+        name : str
+            The config name (file stem).
+
+        Returns
+        -------
+        Path
+            The existing YAML file for *name*.
+
+        Raises
+        ------
+        RuntimeError
+            The store's :attr:`ERROR` on a bad name or a config that does
+            not exist.
+        """
+        path = self._path(name)
+        if not path.exists():
+            raise self.ERROR(f"{self.LABEL} {name!r} not found ({path}).")
+        return path
+
+    def list_names(self) -> list[str]:
+        """List the saved config names, sorted.
+
+        Returns
+        -------
+        list of str
+            YAML file stems in the store's folder — empty when the configs
+            repo, experiment folder, or store folder is missing.
+
+        Raises
+        ------
+        RuntimeError
+            The store's :attr:`ERROR` when the experiment name would escape
+            the experiments root; a merely *missing* folder is not an error.
+        """
+        folder = self._folder()
+        if folder is None:
+            return []
+        return yaml_stems(folder)
+
+    def delete(self, name: str) -> None:
+        """Delete config *name*.
+
+        Parameters
+        ----------
+        name : str
+            The config name (file stem).
+
+        Raises
+        ------
+        RuntimeError
+            The store's :attr:`ERROR` on a missing configs repo /
+            experiment, a bad name, a config that does not exist, or an
+            OS-level delete failure.
+        """
+        path = self._existing_path(name)
+        label = self.LABEL.lower()
+        try:
+            path.unlink()
+        except OSError as exc:
+            raise self.ERROR(f"Could not delete {label} {name!r}: {exc}") from exc
+        self._logger.info("deleted %s %r (%s)", label, name, path)

--- a/GEECS-Console/geecs_console/services/configs.py
+++ b/GEECS-Console/geecs_console/services/configs.py
@@ -16,6 +16,8 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Optional
 
+from geecs_console.services.config_store import yaml_stems
+
 logger = logging.getLogger(__name__)
 
 SAVE_SET_FOLDER = "save_devices"
@@ -60,13 +62,9 @@ def _configs_base() -> Path | None:
         return None
 
 
-def _yaml_stems(folder: Path) -> list[str]:
-    """List the YAML file stems in *folder*, sorted; empty when absent."""
-    if not folder.is_dir():
-        return []
-    return sorted(
-        path.stem for path in folder.iterdir() if path.suffix in (".yaml", ".yml")
-    )
+# The listing helper lives with the config-store base; the private name
+# stays bound here for this module's listing surface.
+_yaml_stems = yaml_stems
 
 
 class ConsoleConfigs:

--- a/GEECS-Console/geecs_console/services/presets.py
+++ b/GEECS-Console/geecs_console/services/presets.py
@@ -11,23 +11,22 @@ the other config kinds ``ConfigsRepoResolver`` reads::
 Offline-safety mirrors :class:`~geecs_console.services.configs.ConsoleConfigs`:
 listing degrades to empty with no configs root; ``load``/``save``/``delete``
 raise :class:`PresetStoreError` with a clear message the window surfaces in
-the status bar.  Creating the ``presets/`` directory with
-``mkdir(parents=True, exist_ok=True)`` is deliberate and fine — this is a
-config directory in the configs repo, not a ``scans/ScanNNN/`` data folder,
-so the repo's scan-folder creation invariant does not apply.
+the status bar.  Directory creation and the scan-folder-invariant rationale
+live in :mod:`geecs_console.services.config_store`.
 """
 
 from __future__ import annotations
 
 import logging
 from pathlib import Path
-from typing import Optional
 
-import yaml
 from pydantic import ValidationError
 
-from geecs_console.services._experiment_name import check_experiment_name
-from geecs_console.services.configs import _configs_base
+from geecs_console.services.config_store import NamedConfigStore
+
+# The base resolves the configs root through this module's namespace, so
+# tests can monkeypatch ``presets._configs_base`` (see config_store._root).
+from geecs_console.services.configs import _configs_base  # noqa: F401
 from geecs_schemas import ScanRequest
 
 logger = logging.getLogger(__name__)
@@ -39,152 +38,13 @@ class PresetStoreError(RuntimeError):
     """A preset operation cannot be carried out (surfaced in the status bar)."""
 
 
-class PresetStore:
-    """Load/save named scan-request presets for one experiment.
+class PresetStore(NamedConfigStore):
+    """Load/save named scan-request presets for one experiment."""
 
-    Parameters
-    ----------
-    experiment : str, optional
-        Experiment folder under ``scanner_configs/experiments``.  May be
-        empty at construction (before the operator picks one) — listing is
-        then empty and saving raises.
-    experiments_root : str or Path, optional
-        Override for the experiments root (tests point this at a tmp dir);
-        defaults to the production resolution
-        (:func:`geecs_bluesky.scanner_configs.scanner_configs_base`, resolved
-        lazily so the module stays import-safe offline).
-    """
-
-    def __init__(
-        self, experiment: str = "", experiments_root: str | Path | None = None
-    ) -> None:
-        self._experiment = experiment
-        self._experiments_root = (
-            Path(experiments_root) if experiments_root is not None else None
-        )
-
-    @property
-    def experiment(self) -> str:
-        """The experiment this store reads and writes presets for."""
-        return self._experiment
-
-    def set_experiment(self, experiment: str) -> None:
-        """Switch the store to *experiment*.
-
-        Parameters
-        ----------
-        experiment : str
-            The new experiment folder name ("" for none selected).
-        """
-        self._experiment = experiment
-
-    # ------------------------------------------------------------------
-    # Folder resolution
-    # ------------------------------------------------------------------
-
-    def _folder(self) -> Optional[Path]:
-        """Return the experiment's presets dir, or ``None`` offline/unselected.
-
-        Raises
-        ------
-        PresetStoreError
-            When the experiment name would escape the experiments root
-            (issue #513) — checked before any path join.
-        """
-        root = self._experiments_root
-        if root is None:
-            root = _configs_base()
-        if root is None or not self._experiment:
-            return None
-        check_experiment_name(self._experiment, PresetStoreError)
-        return root / self._experiment / PRESET_FOLDER
-
-    def _folder_or_raise(self) -> Path:
-        """Return the presets dir, raising a clear error when unresolvable.
-
-        Returns
-        -------
-        Path
-            ``<experiments root>/<experiment>/presets``.
-
-        Raises
-        ------
-        PresetStoreError
-            When the configs repo is not found, no experiment is selected,
-            or the experiment name would escape the experiments root.
-        """
-        root = self._experiments_root
-        if root is None:
-            root = _configs_base()
-        if root is None:
-            raise PresetStoreError(
-                "Configs repo not found — set GEECS_SCANNER_CONFIG_DIR or "
-                "config.ini [Paths] scanner_config_root_path."
-            )
-        if not self._experiment:
-            raise PresetStoreError("No experiment selected.")
-        check_experiment_name(self._experiment, PresetStoreError)
-        return root / self._experiment / PRESET_FOLDER
-
-    def _path(self, name: str) -> Path:
-        """Return the YAML path for preset *name*, validating the name.
-
-        Parameters
-        ----------
-        name : str
-            The preset name (the file stem — no path separators).
-
-        Returns
-        -------
-        Path
-            ``<presets dir>/<name>.yaml`` (an existing ``.yml`` twin is
-            preferred when the ``.yaml`` spelling is absent).
-
-        Raises
-        ------
-        PresetStoreError
-            On an empty name or one that would escape the presets dir.
-        """
-        cleaned = name.strip()
-        if not cleaned:
-            raise PresetStoreError("Preset name must not be empty.")
-        if any(sep in cleaned for sep in ("/", "\\")) or cleaned in (".", ".."):
-            raise PresetStoreError(
-                f"Preset name {name!r} must be a plain file name (no path separators)."
-            )
-        folder = self._folder_or_raise()
-        path = folder / f"{cleaned}.yaml"
-        if not path.exists():
-            twin = folder / f"{cleaned}.yml"
-            if twin.exists():
-                return twin
-        return path
-
-    # ------------------------------------------------------------------
-    # The store surface
-    # ------------------------------------------------------------------
-
-    def list_names(self) -> list[str]:
-        """List the saved preset names, sorted.
-
-        Returns
-        -------
-        list of str
-            YAML file stems in the presets dir — empty when the configs
-            repo, experiment folder, or presets dir is missing.
-
-        Raises
-        ------
-        PresetStoreError
-            When the experiment name would escape the experiments root
-            (issue #513); a merely *missing* folder is not an error.
-        """
-        folder = self._folder()
-        if folder is None or not folder.is_dir():
-            return []
-        return sorted(
-            path.stem for path in folder.iterdir() if path.suffix in (".yaml", ".yml")
-        )
+    FOLDER = PRESET_FOLDER
+    NOUN = "Preset"
+    LABEL = "Preset"
+    ERROR = PresetStoreError
 
     def load(self, name: str) -> ScanRequest:
         """Load preset *name* as a validated :class:`ScanRequest`.
@@ -206,20 +66,10 @@ class PresetStore:
             document the schema rejects — always with a message fit for the
             status bar.
         """
-        path = self._path(name)
-        if not path.exists():
-            raise PresetStoreError(f"Preset {name!r} not found ({path}).")
-        try:
-            document = yaml.safe_load(path.read_text(encoding="utf-8"))
-        except yaml.YAMLError as exc:
-            raise PresetStoreError(
-                f"Preset {name!r} is not valid YAML ({path}): {exc}"
-            ) from exc
-        if not isinstance(document, dict):
-            raise PresetStoreError(
-                f"Preset {name!r} ({path}) should be a YAML mapping of "
-                f"ScanRequest fields, got {type(document).__name__}."
-            )
+        path = self._existing_path(name)
+        document = self._read_mapping(
+            path, describe=f"Preset {name!r}", mapping_hint=" of ScanRequest fields"
+        )
         try:
             return ScanRequest.model_validate(document)
         except ValidationError as exc:
@@ -249,38 +99,6 @@ class PresetStore:
             OS-level write failure.
         """
         path = self._path(name)
-        # A config dir, not a scans/ScanNNN/ data folder — parents=True is
-        # explicitly fine here (the scan-folder invariant does not apply).
-        path.parent.mkdir(parents=True, exist_ok=True)
-        document = yaml.safe_dump(
-            request.model_dump(mode="json"), sort_keys=False, allow_unicode=True
-        )
-        try:
-            path.write_text(document, encoding="utf-8")
-        except OSError as exc:
-            raise PresetStoreError(f"Could not write preset {name!r}: {exc}") from exc
+        self._write_document(path, request.model_dump(mode="json"), f"preset {name!r}")
         logger.info("saved preset %r to %s", name, path)
         return path
-
-    def delete(self, name: str) -> None:
-        """Delete preset *name*.
-
-        Parameters
-        ----------
-        name : str
-            The preset name (file stem).
-
-        Raises
-        ------
-        PresetStoreError
-            Missing configs repo / experiment, a bad name, a preset that
-            does not exist, or an OS-level delete failure.
-        """
-        path = self._path(name)
-        if not path.exists():
-            raise PresetStoreError(f"Preset {name!r} not found ({path}).")
-        try:
-            path.unlink()
-        except OSError as exc:
-            raise PresetStoreError(f"Could not delete preset {name!r}: {exc}") from exc
-        logger.info("deleted preset %r (%s)", name, path)

--- a/GEECS-Console/geecs_console/services/save_set_store.py
+++ b/GEECS-Console/geecs_console/services/save_set_store.py
@@ -72,10 +72,10 @@ class SaveSetStore(NamedConfigStore):
         Raises
         ------
         SaveSetStoreError
-            A missing file, unparsable YAML, or a non-mapping document.
+            Unparsable YAML or a non-mapping document.  Callers resolve
+            *path* through ``_existing_path``, which owns the not-found
+            error.
         """
-        if not path.exists():
-            raise SaveSetStoreError(f"Save set {name!r} not found ({path}).")
         return self._read_mapping(
             path, describe=f"Save set {name!r}", mapping_hint=" of SaveSet fields"
         )
@@ -106,7 +106,7 @@ class SaveSetStore(NamedConfigStore):
             cannot round-trip without losing its inline actions — always
             with a message fit for the status bar.
         """
-        path = self._path(name)
+        path = self._existing_path(name)
         document = self._read_document(name, path)
         if "schema_version" in document:
             try:

--- a/GEECS-Console/geecs_console/services/save_set_store.py
+++ b/GEECS-Console/geecs_console/services/save_set_store.py
@@ -20,23 +20,23 @@ instead of losing data.
 Offline-safety mirrors :class:`~geecs_console.services.presets.PresetStore`:
 listing degrades to empty with no configs root; ``load``/``save``/``delete``/
 ``rename`` raise :class:`SaveSetStoreError` with a status-bar-ready message.
-Creating the ``save_devices/`` directory with ``mkdir(parents=True,
-exist_ok=True)`` is deliberate and fine — this is a config directory in the
-configs repo, not a ``scans/ScanNNN/`` data folder, so the repo's scan-folder
-creation invariant does not apply.
+Directory creation and the scan-folder-invariant rationale live in
+:mod:`geecs_console.services.config_store`.
 """
 
 from __future__ import annotations
 
 import logging
 from pathlib import Path
-from typing import Optional
 
 import yaml
 from pydantic import ValidationError
 
-from geecs_console.services._experiment_name import check_experiment_name
-from geecs_console.services.configs import SAVE_SET_FOLDER, _configs_base
+from geecs_console.services.config_store import NamedConfigStore
+
+# The base resolves the configs root through this module's namespace, so
+# tests can monkeypatch ``save_set_store._configs_base``.
+from geecs_console.services.configs import SAVE_SET_FOLDER, _configs_base  # noqa: F401
 from geecs_schemas import SaveSet
 
 logger = logging.getLogger(__name__)
@@ -46,155 +46,13 @@ class SaveSetStoreError(RuntimeError):
     """A save-set operation cannot be carried out (surfaced in the status bar)."""
 
 
-class SaveSetStore:
-    """Load/save named save sets for one experiment.
+class SaveSetStore(NamedConfigStore):
+    """Load/save named save sets for one experiment."""
 
-    Parameters
-    ----------
-    experiment : str, optional
-        Experiment folder under ``scanner_configs/experiments``.  May be
-        empty at construction (before the operator picks one) — listing is
-        then empty and saving raises.
-    experiments_root : str or Path, optional
-        Override for the experiments root (tests point this at a tmp dir);
-        defaults to the production resolution
-        (:func:`geecs_bluesky.scanner_configs.scanner_configs_base`, resolved
-        lazily so the module stays import-safe offline).
-    """
-
-    def __init__(
-        self, experiment: str = "", experiments_root: str | Path | None = None
-    ) -> None:
-        self._experiment = experiment
-        self._experiments_root = (
-            Path(experiments_root) if experiments_root is not None else None
-        )
-
-    @property
-    def experiment(self) -> str:
-        """The experiment this store reads and writes save sets for."""
-        return self._experiment
-
-    def set_experiment(self, experiment: str) -> None:
-        """Switch the store to *experiment*.
-
-        Parameters
-        ----------
-        experiment : str
-            The new experiment folder name ("" for none selected).
-        """
-        self._experiment = experiment
-
-    # ------------------------------------------------------------------
-    # Folder resolution (mirrors PresetStore)
-    # ------------------------------------------------------------------
-
-    def _root(self) -> Optional[Path]:
-        """Return the experiments root, or ``None`` offline."""
-        if self._experiments_root is not None:
-            return self._experiments_root
-        return _configs_base()
-
-    def _folder(self) -> Optional[Path]:
-        """Return the experiment's save-set dir, or ``None`` offline/unselected.
-
-        Raises
-        ------
-        SaveSetStoreError
-            When the experiment name would escape the experiments root
-            (issue #513) — checked before any path join.
-        """
-        root = self._root()
-        if root is None or not self._experiment:
-            return None
-        check_experiment_name(self._experiment, SaveSetStoreError)
-        return root / self._experiment / SAVE_SET_FOLDER
-
-    def _folder_or_raise(self) -> Path:
-        """Return the save-set dir, raising a clear error when unresolvable.
-
-        Returns
-        -------
-        Path
-            ``<experiments root>/<experiment>/save_devices``.
-
-        Raises
-        ------
-        SaveSetStoreError
-            When the configs repo is not found, no experiment is selected,
-            or the experiment name would escape the experiments root.
-        """
-        root = self._root()
-        if root is None:
-            raise SaveSetStoreError(
-                "Configs repo not found — set GEECS_SCANNER_CONFIG_DIR or "
-                "config.ini [Paths] scanner_config_root_path."
-            )
-        if not self._experiment:
-            raise SaveSetStoreError("No experiment selected.")
-        check_experiment_name(self._experiment, SaveSetStoreError)
-        return root / self._experiment / SAVE_SET_FOLDER
-
-    def _path(self, name: str) -> Path:
-        """Return the YAML path for save set *name*, validating the name.
-
-        Parameters
-        ----------
-        name : str
-            The save-set name (the file stem — no path separators).
-
-        Returns
-        -------
-        Path
-            ``<save_devices dir>/<name>.yaml`` (an existing ``.yml`` twin is
-            preferred when the ``.yaml`` spelling is absent).
-
-        Raises
-        ------
-        SaveSetStoreError
-            On an empty name or one that would escape the save-set dir.
-        """
-        cleaned = name.strip()
-        if not cleaned:
-            raise SaveSetStoreError("Save set name must not be empty.")
-        if any(sep in cleaned for sep in ("/", "\\")) or cleaned in (".", ".."):
-            raise SaveSetStoreError(
-                f"Save set name {name!r} must be a plain file name "
-                "(no path separators)."
-            )
-        folder = self._folder_or_raise()
-        path = folder / f"{cleaned}.yaml"
-        if not path.exists():
-            twin = folder / f"{cleaned}.yml"
-            if twin.exists():
-                return twin
-        return path
-
-    # ------------------------------------------------------------------
-    # The store surface
-    # ------------------------------------------------------------------
-
-    def list_names(self) -> list[str]:
-        """List the saved save-set names, sorted.
-
-        Returns
-        -------
-        list of str
-            YAML file stems in the ``save_devices`` dir — empty when the
-            configs repo, experiment folder, or save-set dir is missing.
-
-        Raises
-        ------
-        SaveSetStoreError
-            When the experiment name would escape the experiments root
-            (issue #513); a merely *missing* folder is not an error.
-        """
-        folder = self._folder()
-        if folder is None or not folder.is_dir():
-            return []
-        return sorted(
-            path.stem for path in folder.iterdir() if path.suffix in (".yaml", ".yml")
-        )
+    FOLDER = SAVE_SET_FOLDER
+    NOUN = "Save set"
+    LABEL = "Save set"
+    ERROR = SaveSetStoreError
 
     def _read_document(self, name: str, path: Path) -> dict:
         """Read one YAML mapping, with status-bar-ready errors.
@@ -218,18 +76,9 @@ class SaveSetStore:
         """
         if not path.exists():
             raise SaveSetStoreError(f"Save set {name!r} not found ({path}).")
-        try:
-            document = yaml.safe_load(path.read_text(encoding="utf-8"))
-        except yaml.YAMLError as exc:
-            raise SaveSetStoreError(
-                f"Save set {name!r} is not valid YAML ({path}): {exc}"
-            ) from exc
-        if not isinstance(document, dict):
-            raise SaveSetStoreError(
-                f"Save set {name!r} ({path}) should be a YAML mapping of "
-                f"SaveSet fields, got {type(document).__name__}."
-            )
-        return document
+        return self._read_mapping(
+            path, describe=f"Save set {name!r}", mapping_hint=" of SaveSet fields"
+        )
 
     def load(self, name: str) -> SaveSet:
         """Load save set *name* as a validated :class:`SaveSet`.
@@ -342,45 +191,11 @@ class SaveSetStore:
             OS-level write failure.
         """
         path = self._path(name)
-        # A config dir, not a scans/ScanNNN/ data folder — parents=True is
-        # explicitly fine here (the scan-folder invariant does not apply).
-        path.parent.mkdir(parents=True, exist_ok=True)
-        document = yaml.safe_dump(
-            save_set.model_dump(mode="json"), sort_keys=False, allow_unicode=True
+        self._write_document(
+            path, save_set.model_dump(mode="json"), f"save set {name!r}"
         )
-        try:
-            path.write_text(document, encoding="utf-8")
-        except OSError as exc:
-            raise SaveSetStoreError(
-                f"Could not write save set {name!r}: {exc}"
-            ) from exc
         logger.info("saved save set %r to %s", name, path)
         return path
-
-    def delete(self, name: str) -> None:
-        """Delete save set *name*.
-
-        Parameters
-        ----------
-        name : str
-            The save-set name (file stem).
-
-        Raises
-        ------
-        SaveSetStoreError
-            Missing configs repo / experiment, a bad name, a save set that
-            does not exist, or an OS-level delete failure.
-        """
-        path = self._path(name)
-        if not path.exists():
-            raise SaveSetStoreError(f"Save set {name!r} not found ({path}).")
-        try:
-            path.unlink()
-        except OSError as exc:
-            raise SaveSetStoreError(
-                f"Could not delete save set {name!r}: {exc}"
-            ) from exc
-        logger.info("deleted save set %r (%s)", name, path)
 
     def rename(self, old: str, new: str) -> Path:
         """Rename save set *old* to *new*, keeping the document's ``name`` in step.
@@ -408,9 +223,7 @@ class SaveSetStore:
             does not exist, a target that already exists, or an OS-level
             failure.
         """
-        source = self._path(old)
-        if not source.exists():
-            raise SaveSetStoreError(f"Save set {old!r} not found ({source}).")
+        source = self._existing_path(old)
         target = self._path(new)
         if target.exists():
             raise SaveSetStoreError(

--- a/GEECS-Console/geecs_console/services/scan_variable_store.py
+++ b/GEECS-Console/geecs_console/services/scan_variable_store.py
@@ -20,10 +20,9 @@ Offline-safety mirrors :class:`~geecs_console.services.presets.PresetStore`:
 :meth:`ScanVariableStore.load` degrades to an **empty catalog** when the
 configs repo or the experiment folder is missing (the editor still opens);
 save without a resolvable target raises :class:`ScanVariableStoreError` with
-a message fit for the status bar.  Creating the ``scan_devices/`` directory
-with ``mkdir(parents=True, exist_ok=True)`` is deliberate and fine — this is
-a config directory in the configs repo, not a ``scans/ScanNNN/`` data folder,
-so the repo's scan-folder creation invariant does not apply.
+a message fit for the status bar.  Directory creation and the
+scan-folder-invariant rationale live in
+:mod:`geecs_console.services.config_store`.
 """
 
 from __future__ import annotations
@@ -32,11 +31,13 @@ import logging
 from pathlib import Path
 from typing import Optional
 
-import yaml
 from pydantic import ValidationError
 
-from geecs_console.services._experiment_name import check_experiment_name
-from geecs_console.services.configs import _configs_base
+from geecs_console.services.config_store import ExperimentConfigStore
+
+# The base resolves the configs root through this module's namespace, so
+# tests can monkeypatch ``scan_variable_store._configs_base``.
+from geecs_console.services.configs import _configs_base  # noqa: F401
 from geecs_schemas import ScanVariables
 
 logger = logging.getLogger(__name__)
@@ -62,101 +63,11 @@ def empty_catalog() -> ScanVariables:
     return ScanVariables(variables={})
 
 
-class ScanVariableStore:
-    """Load/save one experiment's scan-variable catalog.
+class ScanVariableStore(ExperimentConfigStore):
+    """Load/save one experiment's scan-variable catalog."""
 
-    Parameters
-    ----------
-    experiment : str, optional
-        Experiment folder under ``scanner_configs/experiments``.  May be
-        empty at construction (before the operator picks one) — loading is
-        then empty and saving raises.
-    experiments_root : str or Path, optional
-        Override for the experiments root (tests point this at a tmp dir);
-        defaults to the production resolution
-        (:func:`geecs_bluesky.scanner_configs.scanner_configs_base`, resolved
-        lazily so the module stays import-safe offline).
-    """
-
-    def __init__(
-        self, experiment: str = "", experiments_root: str | Path | None = None
-    ) -> None:
-        self._experiment = experiment
-        self._experiments_root = (
-            Path(experiments_root) if experiments_root is not None else None
-        )
-
-    @property
-    def experiment(self) -> str:
-        """The experiment this store reads and writes the catalog for."""
-        return self._experiment
-
-    def set_experiment(self, experiment: str) -> None:
-        """Switch the store to *experiment*.
-
-        Parameters
-        ----------
-        experiment : str
-            The new experiment folder name ("" for none selected).
-        """
-        self._experiment = experiment
-
-    # ------------------------------------------------------------------
-    # Folder resolution
-    # ------------------------------------------------------------------
-
-    def _root(self) -> Optional[Path]:
-        """Return the experiments root, or ``None`` when unresolvable."""
-        if self._experiments_root is not None:
-            return self._experiments_root
-        return _configs_base()
-
-    def _check_experiment(self) -> None:
-        """Reject an experiment name that would escape the experiments root.
-
-        Delegates to the shared
-        :func:`~geecs_console.services._experiment_name.check_experiment_name`
-        guard every config store applies before any path join (issue #513).
-
-        Raises
-        ------
-        ScanVariableStoreError
-            When the experiment name contains a path separator or is a
-            relative-path special name.
-        """
-        check_experiment_name(self._experiment, ScanVariableStoreError)
-
-    def _folder(self) -> Optional[Path]:
-        """Return the ``scan_devices/`` dir, or ``None`` offline/unselected."""
-        root = self._root()
-        if root is None or not self._experiment:
-            return None
-        self._check_experiment()
-        return root / self._experiment / SCAN_VARIABLES_FOLDER
-
-    def _folder_or_raise(self) -> Path:
-        """Return the ``scan_devices/`` dir, raising a clear error otherwise.
-
-        Returns
-        -------
-        Path
-            ``<experiments root>/<experiment>/scan_devices``.
-
-        Raises
-        ------
-        ScanVariableStoreError
-            When the configs repo is not found or no experiment is selected.
-        """
-        root = self._root()
-        if root is None:
-            raise ScanVariableStoreError(
-                "Configs repo not found — set GEECS_SCANNER_CONFIG_DIR or "
-                "config.ini [Paths] scanner_config_root_path."
-            )
-        if not self._experiment:
-            raise ScanVariableStoreError("No experiment selected.")
-        self._check_experiment()
-        return root / self._experiment / SCAN_VARIABLES_FOLDER
+    FOLDER = SCAN_VARIABLES_FOLDER
+    ERROR = ScanVariableStoreError
 
     def catalog_path(self) -> Optional[Path]:
         """Return the new-schema catalog path, or ``None`` offline/unselected.
@@ -207,17 +118,11 @@ class ScanVariableStore:
         ScanVariableStoreError
             Unparsable YAML, a non-mapping document, or schema rejection.
         """
-        try:
-            document = yaml.safe_load(path.read_text(encoding="utf-8"))
-        except yaml.YAMLError as exc:
-            raise ScanVariableStoreError(
-                f"Scan-variable catalog is not valid YAML ({path}): {exc}"
-            ) from exc
-        if not isinstance(document, dict):
-            raise ScanVariableStoreError(
-                f"Scan-variable catalog ({path}) should be a YAML mapping of "
-                f"ScanVariables fields, got {type(document).__name__}."
-            )
+        document = self._read_mapping(
+            path,
+            describe="Scan-variable catalog",
+            mapping_hint=" of ScanVariables fields",
+        )
         try:
             return ScanVariables.model_validate(document)
         except ValidationError as exc:
@@ -279,22 +184,13 @@ class ScanVariableStore:
         """
         folder = self._folder_or_raise()
         path = folder / CATALOG_FILE
-        # A config dir, not a scans/ScanNNN/ data folder — parents=True is
-        # explicitly fine here (the scan-folder invariant does not apply).
-        folder.mkdir(parents=True, exist_ok=True)
         # exclude_none omits unset optionals (confirm, inverse) the way the
         # production catalogs are written; every set field round-trips.
-        document = yaml.safe_dump(
+        self._write_document(
+            path,
             catalog.model_dump(mode="json", exclude_none=True),
-            sort_keys=False,
-            allow_unicode=True,
+            "scan-variable catalog",
         )
-        try:
-            path.write_text(document, encoding="utf-8")
-        except OSError as exc:
-            raise ScanVariableStoreError(
-                f"Could not write scan-variable catalog: {exc}"
-            ) from exc
         logger.info(
             "saved scan-variable catalog (%d variables) to %s",
             len(catalog.variables),

--- a/GEECS-Console/geecs_console/services/trigger_profile_store.py
+++ b/GEECS-Console/geecs_console/services/trigger_profile_store.py
@@ -14,27 +14,26 @@ key) are loaded through :func:`geecs_schemas.convert.convert_shot_control` —
 exactly what the resolver does — so the existing corpus opens in the editor;
 saving such a profile migrates the file to the versioned schema.
 
-Offline-safety mirrors :class:`~geecs_console.services.presets.PresetStore`
-(the store pattern this module copies): listing degrades to empty with no
-configs root; ``load``/``save``/``delete``/``rename`` raise
-:class:`TriggerProfileStoreError` with a message fit for inline display.
-Creating the ``shot_control_configurations/`` directory with
-``mkdir(parents=True, exist_ok=True)`` is deliberate and fine — this is a
-config directory in the configs repo, not a ``scans/ScanNNN/`` data folder,
-so the repo's scan-folder creation invariant does not apply.
+Offline-safety mirrors :class:`~geecs_console.services.presets.PresetStore`:
+listing degrades to empty with no configs root; ``load``/``save``/``delete``/
+``rename`` raise :class:`TriggerProfileStoreError` with a message fit for
+inline display.  Directory creation and the scan-folder-invariant rationale
+live in :mod:`geecs_console.services.config_store`.
 """
 
 from __future__ import annotations
 
 import logging
 from pathlib import Path
-from typing import Optional
 
 import yaml
 from pydantic import ValidationError
 
-from geecs_console.services._experiment_name import check_experiment_name
-from geecs_console.services.configs import TRIGGER_FOLDER, _configs_base
+from geecs_console.services.config_store import NamedConfigStore
+
+# The base resolves the configs root through this module's namespace, so
+# tests can monkeypatch ``trigger_profile_store._configs_base``.
+from geecs_console.services.configs import TRIGGER_FOLDER, _configs_base  # noqa: F401
 from geecs_schemas import TriggerProfile
 from geecs_schemas.convert import SchemaConversionError, convert_shot_control
 
@@ -45,126 +44,13 @@ class TriggerProfileStoreError(RuntimeError):
     """A trigger-profile operation cannot be carried out (shown inline)."""
 
 
-class TriggerProfileStore:
-    """Load/save named trigger profiles for one experiment.
+class TriggerProfileStore(NamedConfigStore):
+    """Load/save named trigger profiles for one experiment."""
 
-    Parameters
-    ----------
-    experiment : str, optional
-        Experiment folder under ``scanner_configs/experiments``.  May be
-        empty at construction (before the operator picks one) — listing is
-        then empty and saving raises.
-    experiments_root : str or Path, optional
-        Override for the experiments root (tests point this at a tmp dir);
-        defaults to the production resolution
-        (:func:`geecs_bluesky.scanner_configs.scanner_configs_base`, resolved
-        lazily so the module stays import-safe offline).
-    """
-
-    def __init__(
-        self, experiment: str = "", experiments_root: str | Path | None = None
-    ) -> None:
-        self._experiment = experiment
-        self._experiments_root = (
-            Path(experiments_root) if experiments_root is not None else None
-        )
-
-    @property
-    def experiment(self) -> str:
-        """The experiment this store reads and writes trigger profiles for."""
-        return self._experiment
-
-    def set_experiment(self, experiment: str) -> None:
-        """Switch the store to *experiment*.
-
-        Parameters
-        ----------
-        experiment : str
-            The new experiment folder name ("" for none selected).
-        """
-        self._experiment = experiment
-
-    # ------------------------------------------------------------------
-    # Folder resolution
-    # ------------------------------------------------------------------
-
-    def _folder(self) -> Optional[Path]:
-        """Return the shot-control dir, or ``None`` offline/unselected.
-
-        Raises
-        ------
-        TriggerProfileStoreError
-            When the experiment name would escape the experiments root
-            (issue #513) — checked before any path join.
-        """
-        root = self._experiments_root
-        if root is None:
-            root = _configs_base()
-        if root is None or not self._experiment:
-            return None
-        check_experiment_name(self._experiment, TriggerProfileStoreError)
-        return root / self._experiment / TRIGGER_FOLDER
-
-    def _folder_or_raise(self) -> Path:
-        """Return the shot-control dir, raising a clear error when unresolvable.
-
-        Returns
-        -------
-        Path
-            ``<experiments root>/<experiment>/shot_control_configurations``.
-
-        Raises
-        ------
-        TriggerProfileStoreError
-            When the configs repo is not found, no experiment is selected,
-            or the experiment name would escape the experiments root.
-        """
-        root = self._experiments_root
-        if root is None:
-            root = _configs_base()
-        if root is None:
-            raise TriggerProfileStoreError(
-                "Configs repo not found — set GEECS_SCANNER_CONFIG_DIR or "
-                "config.ini [Paths] scanner_config_root_path."
-            )
-        if not self._experiment:
-            raise TriggerProfileStoreError("No experiment selected.")
-        check_experiment_name(self._experiment, TriggerProfileStoreError)
-        return root / self._experiment / TRIGGER_FOLDER
-
-    def _path(self, name: str) -> Path:
-        """Return the YAML path for profile *name*, validating the name.
-
-        Parameters
-        ----------
-        name : str
-            The profile name (the file stem — no path separators).
-
-        Returns
-        -------
-        Path
-            ``<shot-control dir>/<name>.yaml`` (an existing ``.yml`` twin is
-            preferred when the ``.yaml`` spelling is absent).
-
-        Raises
-        ------
-        TriggerProfileStoreError
-            On an empty name or one that would escape the shot-control dir.
-        """
-        cleaned = name.strip()
-        if not cleaned:
-            raise TriggerProfileStoreError("Profile name must not be empty.")
-        if any(sep in cleaned for sep in ("/", "\\")) or cleaned in (".", ".."):
-            raise TriggerProfileStoreError(
-                f"Profile name {name!r} must be a plain file name (no path separators)."
-            )
-        folder = self._folder_or_raise()
-        path = folder / f"{cleaned}.yaml"
-        if not path.exists():
-            twin = folder / f"{cleaned}.yml"
-            if twin.exists():
-                return twin
-        return path
+    FOLDER = TRIGGER_FOLDER
+    NOUN = "Profile"
+    LABEL = "Trigger profile"
+    ERROR = TriggerProfileStoreError
 
     def _read_document(self, name: str) -> tuple[dict, Path]:
         """Read profile *name*'s raw YAML mapping (shared by load/is_legacy).
@@ -185,51 +71,11 @@ class TriggerProfileStore:
             Missing configs repo / experiment / file, unparsable YAML, or a
             document that is not a mapping.
         """
-        path = self._path(name)
-        if not path.exists():
-            raise TriggerProfileStoreError(
-                f"Trigger profile {name!r} not found ({path})."
-            )
-        try:
-            document = yaml.safe_load(path.read_text(encoding="utf-8"))
-        except yaml.YAMLError as exc:
-            raise TriggerProfileStoreError(
-                f"Trigger profile {name!r} is not valid YAML ({path}): {exc}"
-            ) from exc
-        if document is None:
-            document = {}
-        if not isinstance(document, dict):
-            raise TriggerProfileStoreError(
-                f"Trigger profile {name!r} ({path}) should be a YAML mapping, "
-                f"got {type(document).__name__}."
-            )
-        return document, path
-
-    # ------------------------------------------------------------------
-    # The store surface
-    # ------------------------------------------------------------------
-
-    def list_names(self) -> list[str]:
-        """List the saved profile names, sorted.
-
-        Returns
-        -------
-        list of str
-            YAML file stems in the shot-control dir — empty when the configs
-            repo, experiment folder, or shot-control dir is missing.
-
-        Raises
-        ------
-        TriggerProfileStoreError
-            When the experiment name would escape the experiments root
-            (issue #513); a merely *missing* folder is not an error.
-        """
-        folder = self._folder()
-        if folder is None or not folder.is_dir():
-            return []
-        return sorted(
-            path.stem for path in folder.iterdir() if path.suffix in (".yaml", ".yml")
+        path = self._existing_path(name)
+        document = self._read_mapping(
+            path, describe=f"Trigger profile {name!r}", empty_as={}
         )
+        return document, path
 
     def exists(self, name: str) -> bool:
         """Whether a profile file called *name* is on disk.
@@ -345,47 +191,11 @@ class TriggerProfileStore:
             OS-level write failure.
         """
         path = self._path(name)
-        # A config dir, not a scans/ScanNNN/ data folder — parents=True is
-        # explicitly fine here (the scan-folder invariant does not apply).
-        path.parent.mkdir(parents=True, exist_ok=True)
-        document = yaml.safe_dump(
-            profile.model_dump(mode="json"), sort_keys=False, allow_unicode=True
+        self._write_document(
+            path, profile.model_dump(mode="json"), f"trigger profile {name!r}"
         )
-        try:
-            path.write_text(document, encoding="utf-8")
-        except OSError as exc:
-            raise TriggerProfileStoreError(
-                f"Could not write trigger profile {name!r}: {exc}"
-            ) from exc
         logger.info("saved trigger profile %r to %s", name, path)
         return path
-
-    def delete(self, name: str) -> None:
-        """Delete profile *name*.
-
-        Parameters
-        ----------
-        name : str
-            The profile name (file stem).
-
-        Raises
-        ------
-        TriggerProfileStoreError
-            Missing configs repo / experiment, a bad name, a profile that
-            does not exist, or an OS-level delete failure.
-        """
-        path = self._path(name)
-        if not path.exists():
-            raise TriggerProfileStoreError(
-                f"Trigger profile {name!r} not found ({path})."
-            )
-        try:
-            path.unlink()
-        except OSError as exc:
-            raise TriggerProfileStoreError(
-                f"Could not delete trigger profile {name!r}: {exc}"
-            ) from exc
-        logger.info("deleted trigger profile %r (%s)", name, path)
 
     def rename(self, old: str, new: str) -> Path:
         """Rename profile *old* to *new*, refusing to overwrite.
@@ -414,11 +224,7 @@ class TriggerProfileStore:
             does not exist, a target that already exists, or an OS-level
             failure.
         """
-        source = self._path(old)
-        if not source.exists():
-            raise TriggerProfileStoreError(
-                f"Trigger profile {old!r} not found ({source})."
-            )
+        source = self._existing_path(old)
         target = self._folder_or_raise() / f"{new.strip()}.yaml"
         # Validate the new name (empty / path separators) with _path, but
         # target the .yaml spelling regardless of any .yml twin.

--- a/GEECS-Console/pyproject.toml
+++ b/GEECS-Console/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-console"
-version = "0.18.2"
+version = "0.18.3"
 description = "Greenfield PySide6 operator console for GEECS (Bluesky/gateway architecture)"
 authors = ["Sam Barber <sbarber@lbl.gov>"]
 readme = "README.md"


### PR DESCRIPTION
Closes #532. Extracts the duplicated persistence skeleton of the five per-experiment YAML config stores into `services/config_store.py`.

## Design (from a full duplication map of the five stores)

Two tiers, split on the storage-model taxonomy the map surfaced:

- **`ExperimentConfigStore`** (all five): the byte-identical constructor/`experiment`/`set_experiment`, configs-root + folder resolution with the experiment-name guard, and the YAML read/write wrappers (safe_load + "not valid YAML"/"YAML mapping" error convention; mkdir + safe_dump + OSError wrap). Parameterized by `FOLDER`/`ERROR` class attrs and per-call message pieces so **every rendered error string is byte-identical**.
- **`NamedConfigStore`** (presets, save sets, trigger profiles — the file-per-name trio): the name-validating `_path` with the `.yml` twin fallback, the verbatim sorted-stems `list_names` (also adopted by `configs._yaml_stems`, which was a **fourth** copy), `delete`, and the shared not-found guard.
- **Everything schema-specific stays concrete**: legacy dialects (save-set lossy refusal, trigger byte-stable/legacy-move rename, scan-variable pair conversion, action-library `run`-reference retargeting + referrer refusal), the two single-document catalogs' structure, `exclude_none` dump, error classes in their original modules.

## Numbers

**−843/+507 net (−354 LOC)**: 842 duplicated lines out of the five stores + configs against a 376-line base. The scan-folder-invariant rationale drops from ~10 in-module restatements to **one canonical home** (base module docstring + the single mkdir comment); the repeated issue-number citations are gone from the store docstrings (canonical guard rationale stays in `_experiment_name.py`).

## The one clever bit (flagged for scrutiny)

`_root()` resolves the configs root through the **concrete store's module namespace** (`sys.modules[type(self).__module__]._configs_base()`): all five test files monkeypatch `<store module>._configs_base`, and this keeps every patch effective with tests unmodified — while also avoiding a genuine import cycle (configs → config_store for `yaml_stems`). Each store keeps its `_configs_base` import with a comment; documented at both ends.

## Judgment-call additions (cheap to veto)

`LABEL` beside `NOUN` (trigger's validation noun "Profile" ≠ its message label "Trigger profile"); `_existing_path` (the shared not-found guard); an identity-sentinel `empty_as` preserving the trigger/action None-document-vs-`{}` distinction; base `delete` logging under the concrete store's logger name.

## Tests

**772 passed, 3× consecutively, with the store test suites entirely unmodified** — the zero-surface-change claim is load-bearing and the tests are the proof. Implementation was executed by a subagent against a written design; independently re-verified (suite + diff review) before this PR.

## Hardware verification

None owed — config persistence only; nothing touches scan execution or devices.

🤖 Generated with [Claude Code](https://claude.com/claude-code)