### PR TITLE
GeecsCAGateway 0.14.2: DEPLOYMENT.md new-client onboarding recipe

### DIFF
--- a/GeecsCAGateway/CHANGELOG.md
+++ b/GeecsCAGateway/CHANGELOG.md
@@ -3,6 +3,27 @@
 All notable changes to `geecs-ca-gateway` are documented here, following
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and semantic versioning.
 
+## [0.14.2] - 2026-07-21
+
+### Changed
+
+- `DEPLOYMENT.md` §3 rewritten as a new-client onboarding recipe (docs only):
+  a task-vs-install table making explicit that PV access, displays, and Tiled
+  readback need nothing from GEECS-Plugins (the monorepo is only for
+  submitting scans); a "first contact" section connects with nothing but
+  `pip install caproto` +
+  `EPICS_CA_ADDR_LIST` (works over routed VPN — directed unicast name search),
+  with the off-subnet/beacon caveats moved up from §5; a new §3b covers
+  reading scans back from the Tiled catalog (`tiled[client]`, `[tiled]`
+  config.ini section, web UI at `/ui`, pointer to
+  `GeecsBluesky/TILED_SETUP.md`).
+- Removed the stale Scanner-GUI backend-toggle instructions
+  (`GEECS_USE_BLUESKY` / `GEECS_BLUESKY_ACQUISITION_MODE`): on `dev` the
+  Bluesky/CA path is the only engine and acquisition mode is declared per
+  scan in the `ScanRequest` — the section now points at GEECS-Console and
+  headless `GeecsSession.run(ScanRequest)` (`master` keeps the legacy
+  toggle).
+
 ## [0.14.1] - 2026-07-20
 
 ### Changed

--- a/GeecsCAGateway/DEPLOYMENT.md
+++ b/GeecsCAGateway/DEPLOYMENT.md
@@ -282,7 +282,7 @@ un-launchable, and acquisition mode is declared per scan in the
 `ScanRequest` itself (`acquisition: free_run | strict`) rather than by
 environment variable — a request declares intent. Scans are submitted from
 **GEECS-Console** (the PySide6 operator console) or headless via
-`geecs_bluesky.GeecsSession.run(ScanRequest)`. (`master` still carries the
+`geecs_bluesky.session.GeecsSession.run(ScanRequest)`. (`master` still carries the
 legacy scanner line and its env toggle.)
 
 ### Tiled — reading scan data back
@@ -305,15 +305,21 @@ from tiled.client import from_uri
 
 c = from_uri("http://192.168.6.14:8000", api_key="<key>")
 run = c.values().last()        # most recent scan
-run.metadata["start"]          # scan number, device list, the ScanRequest…
-df = run["primary"].read()     # per-shot scalar table (pandas DataFrame)
+run.metadata["start"]          # scan number, device list, mode, applied defaults…
+df = run["primary"].read().to_dataframe().reset_index()   # per-shot scalar table
 ```
+
+(`.read()` alone returns an xarray Dataset under the deployed Tiled's
+composite-container layout — the `.to_dataframe()` step is how the repo's
+own readers get the per-shot table.)
 
 A generic web catalog browser is served at `http://192.168.6.14:8000/ui`
 (first visit: `/ui?api_key=<key>` — the server moves the key into a cookie
-and strips the URL). Server-side state and upgrade notes live in
-`GeecsBluesky/TILED_SETUP.md`; the scan-shaped browsing workflow (day →
-Scan NNN → plot columns) is GEECS-Console's scan browser.
+and strips the URL). `GeecsBluesky/TILED_SETUP.md` is the canonical Tiled
+reference — the client recipe as well as server-side state and upgrade
+notes; if this quickstart and that file ever disagree, trust that file.
+The scan-shaped browsing workflow (day → Scan NNN → plot columns) is
+GEECS-Console's scan browser.
 
 ### Windows notes
 

--- a/GeecsCAGateway/DEPLOYMENT.md
+++ b/GeecsCAGateway/DEPLOYMENT.md
@@ -190,11 +190,68 @@ Storage placement rules:
 
 ---
 
-## 3. Client-side recipe
+## 3. Client-side recipe — new-client onboarding
 
-Battle-tested on the Windows control machines (live sessions, 2026-07-06).
+Everything a fresh client machine (lab network or VPN) needs, in the order a
+new user wants it: raw PV access first, then the shared config file, then
+Tiled readback. Battle-tested on the Windows control machines and over
+routed VPN (live sessions since 2026-07-06).
 
-### Point CA clients at the gateway
+**A client needs nothing from GEECS-Plugins.** That is the whole point of
+the gateway: GEECS is consumed as standard EPICS PVs and standard Tiled
+HTTP, so the monorepo is only required on machines that *submit scans*:
+
+| Task | What you install | From this repo |
+|---|---|---|
+| Read / write PVs | any CA client — `pip install caproto`, pyepics, EPICS base `caget`, Phoebus | nothing |
+| Live displays | Phoebus (point `EPICS_CA_ADDR_LIST` at the gateway) | nothing |
+| Read scan data | `pip install "tiled[client]"` + the API key | nothing |
+| Submit scans | GEECS-Console / GeecsBluesky | repo checkout + poetry |
+
+### First contact — PVs with nothing but a CA client
+
+No repo checkout and no config file required; any Channel Access client
+works. The caproto CLI tools are the lightest install:
+
+```bash
+python -m venv ca && source ca/bin/activate
+pip install caproto
+
+export EPICS_CA_ADDR_LIST=192.168.6.14   # directed name search — routes over VPN
+export EPICS_CA_AUTO_ADDR_LIST=NO        # don't also broadcast on your local subnet
+
+caproto-get undulator:cagateway:version undulator:cagateway:uptime
+caproto-monitor undulator:cagateway:heartbeat   # ticks every 5 s; Ctrl-C to stop
+```
+
+```powershell
+# PowerShell equivalent (same shell that runs the client)
+$env:EPICS_CA_ADDR_LIST = "192.168.6.14"
+$env:EPICS_CA_AUTO_ADDR_LIST = "NO"
+caproto-get undulator:cagateway:version
+```
+
+If the heartbeat ticks, you are connected — continue with the §4 smoke tests
+to poke real device PVs.
+
+PV names are `experiment:device:variable` with every component lowercased
+from the GEECS names, and each settable variable additionally exposes
+`…:SP` for writes — the normative naming/typing/alarm contract is
+`PV_CONTRACT.md`. The served set is the experiment's `get='yes'` monitoring
+subset plus each device's settable control surface (§1), so a variable
+visible in GEECS Master Control is usually reachable here under its
+lowercased name.
+
+**Off-subnet (VPN) notes.** CA name search with an explicit address list is
+*directed unicast* UDP, which routes over VPN — this is why the recipe above
+works off-subnet. Server *beacons* ride UDP broadcast and do **not** cross
+routed paths, so a long-lived display (Phoebus) that was searching while the
+gateway was down can look stuck for minutes after the gateway returns;
+restart the display (§5). The Python stack issues fresh searches per polling
+cycle and recovers on its own. Keep `EPICS_CA_AUTO_ADDR_LIST=NO` — a
+broadcast on your home/VPN subnet finds nothing and is never what you want.
+
+### Point the Python stack at the gateway
 
 Preferred — the shared GEECS config file, so the gateway host lives with the
 other infrastructure addresses instead of in every shell:
@@ -216,25 +273,47 @@ loads — libca reads the env when its context is created): it sets
 as expected, and a stale export can silently shadow the config: check the env
 first when name resolution misbehaves.
 
-### Switch the Scanner GUI onto the Bluesky/CA backend
+### Running scans (dev branch)
 
-```powershell
-# PowerShell
-$env:GEECS_USE_BLUESKY = "1"                          # 1/true/yes/on → BlueskyScanner
-$env:GEECS_BLUESKY_ACQUISITION_MODE = "strict_shot_control"   # or free_run_time_sync
+The Scanner-GUI backend toggle formerly documented here
+(`GEECS_USE_BLUESKY`, `GEECS_BLUESKY_ACQUISITION_MODE`) is **gone on
+`dev`**: the Bluesky/CA path is the only engine, the legacy Scanner GUI is
+un-launchable, and acquisition mode is declared per scan in the
+`ScanRequest` itself (`acquisition: free_run | strict`) rather than by
+environment variable — a request declares intent. Scans are submitted from
+**GEECS-Console** (the PySide6 operator console) or headless via
+`geecs_bluesky.GeecsSession.run(ScanRequest)`. (`master` still carries the
+legacy scanner line and its env toggle.)
+
+### Tiled — reading scan data back
+
+Every Bluesky scan's documents (start/stop metadata plus the per-shot
+scalar event table) land in the Tiled catalog on the same host,
+`http://192.168.6.14:8000`. Client needs: `pip install "tiled[client]"`
+and the API key — ask the gateway operator; the key is deliberately not in
+this public repo.
+
+```ini
+# ~/.config/geecs_python_api/config.ini — the scanner reads this same section
+[tiled]
+uri = http://192.168.6.14:8000
+api_key = <ask>
 ```
 
-```bat
-:: cmd.exe — note: no quotes, no $env:
-set GEECS_USE_BLUESKY=1
-set GEECS_BLUESKY_ACQUISITION_MODE=strict_shot_control
+```python
+from tiled.client import from_uri
+
+c = from_uri("http://192.168.6.14:8000", api_key="<key>")
+run = c.values().last()        # most recent scan
+run.metadata["start"]          # scan number, device list, the ScanRequest…
+df = run["primary"].read()     # per-shot scalar table (pandas DataFrame)
 ```
 
-Both variables must be set in the **same shell that launches the GUI**
-(PowerShell `$env:` and cmd `set` affect only that process tree, not the
-system). `GEECS_BLUESKY_ACQUISITION_MODE` defaults to strict; strict requires a
-reachable shot-control device with an `ARMED` state — use `free_run_time_sync`
-for free-running trigger acquisition.
+A generic web catalog browser is served at `http://192.168.6.14:8000/ui`
+(first visit: `/ui?api_key=<key>` — the server moves the key into a cookie
+and strips the URL). Server-side state and upgrade notes live in
+`GeecsBluesky/TILED_SETUP.md`; the scan-shaped browsing workflow (day →
+Scan NNN → plot columns) is GEECS-Console's scan browser.
 
 ### Windows notes
 
@@ -272,9 +351,11 @@ for free-running trigger acquisition.
 
 ## 4. Smoke tests — "is it alive?"
 
-Copy-pasteable, using the caproto CLI tools that ship with the gateway's own
-environment (`poetry run` from `GeecsCAGateway/`; plain `caget`/`caput` from
-EPICS base work identically). Substitute your experiment/device.
+Copy-pasteable, using the caproto CLI tools. Run them from the gateway's own
+environment (`poetry run` from `GeecsCAGateway/`) or from any client venv
+with `caproto` installed (§3 first-contact recipe — drop the `poetry run`
+prefix); plain `caget`/`caput` from EPICS base work identically. Substitute
+your experiment/device.
 
 ```bash
 # 1. Gateway process up and serving? (heartbeat ticks every 5 s)
@@ -387,13 +468,10 @@ once), then `ls` the mountpoint — the listing should trigger the mount.
 After fixing, `systemctl restart geecs-ca-gateway` and confirm a derived
 PV answers.
 
-One client-side footnote for off-subnet operators (VPN/routed): CA's
-beacon mechanism — which tells clients to re-search PVs after a server
-restart — rides UDP broadcast and does not cross routed paths. Long-lived
-displays (Phoebus) that were searching while the gateway was down back
-off to very slow retries and can look stuck for minutes after the
-gateway returns; restart the display. On-subnet clients and the Python
-stack (fresh searches per polling cycle) recover on their own.
+One client-side footnote for off-subnet operators (VPN/routed): after a
+gateway restart, long-lived displays (Phoebus) can look stuck for minutes
+because CA beacons don't cross routed paths — restart the display. Details
+in §3's off-subnet notes.
 
 ### Log expectations
 

--- a/GeecsCAGateway/pyproject.toml
+++ b/GeecsCAGateway/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-ca-gateway"
-version = "0.14.1"
+version = "0.14.2"
 description = "EPICS Channel Access soft-IOC gateway exposing GEECS devices as PVs"
 authors = ["Sam Barber <sbarber@lbl.gov>"]
 readme = "README.md"


### PR DESCRIPTION
## What + why

`DEPLOYMENT.md` §3 was stale for `dev` — it still instructed clients to set the Scanner-GUI backend toggle (`GEECS_USE_BLUESKY` / `GEECS_BLUESKY_ACQUISITION_MODE`), which died with the exec_config path (G3): acquisition mode is declared per scan in the `ScanRequest`, and the legacy GUI is un-launchable on `dev`. Trigger: onboarding a new collaborator who has VPN access and wants to start as a pure client (PVs first, then Tiled).

Docs-only, one concern: rewrite §3 as a new-client onboarding recipe.

- **Task-vs-install table** up front: PV read/write, live displays, and Tiled readback need **nothing from GEECS-Plugins** (any CA client / `tiled[client]`); the monorepo is only for submitting scans.
- **First contact** section: `pip install caproto` + `EPICS_CA_ADDR_LIST` + heartbeat PV check (bash + PowerShell), with a PV-naming orientation pointing at `PV_CONTRACT.md`.
- **Off-subnet (VPN) notes**: directed unicast name search routes over VPN; beacons don't cross routed paths (§5 footnote collapsed into a cross-reference to avoid drift).
- **Replaced the dead toggle section** with the current dev story: GEECS-Console or headless `GeecsSession.run(ScanRequest)`; `master` keeps the legacy toggle.
- **New Tiled section**: `tiled[client]`, `[tiled]` config.ini keys, 4-line readback example, web UI at `/ui`, pointers to `GeecsBluesky/TILED_SETUP.md` and the console scan browser. API key is ask-the-operator (public repo — key stays out).
- §4 smoke-test intro no longer assumes the gateway's own poetry env.

## LOC breakdown

One concern; 3 files: `DEPLOYMENT.md` +121/−25, `CHANGELOG.md` +17, `pyproject.toml` version 0.14.1 → 0.14.2 (docs-only patch bump per #536/#537 precedent).

## Tests

Docs-only — no behavior change, `PV_CONTRACT.md` untouched. `./scripts/check.sh`: GeecsCAGateway suite **182 passed** in 2:43; pre-commit hooks green.

## Hardware verification

None owed — no runtime surface. The first-contact recipe's claims (directed unicast over VPN, heartbeat/version PVs, Tiled `/ui` cookie handoff) restate behavior already live-verified in prior sessions (2026-07-06 client recipe, 2026-07-12 Tiled 0.2.14 upgrade, 2026-07-15 off-subnet beacon footnote).

🤖 Generated with [Claude Code](https://claude.com/claude-code)