### PR TITLE
GeecsBluesky 0.46.1: TILED_SETUP.md — refresh What Works / Known Limitations to dev state

### DIFF
--- a/GeecsBluesky/CHANGELOG.md
+++ b/GeecsBluesky/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to `geecs-bluesky` are documented here.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.46.1] - 2026-07-21
+
+### Changed
+
+- **`TILED_SETUP.md` "What Works" / "Known Limitations" refreshed to match
+  `dev`** (docs only). The stale pre-cutover claims are gone: the "GUI path
+  still partial" limitation (the legacy `GEECS-Scanner-GUI` path was deleted
+  with G3 — `GEECS-Console` drives everything through the delegated
+  `ScanRequest` path), the "no s-file output" limitation (scalar s-files are
+  exported from Tiled best-effort after a scan; TDMS still is not), and the
+  reference to the deleted `test_bluesky_scanner.py` hardware script (now
+  `tests/test_scan_request_hardware.py`).
+
 ## [0.46.0] - 2026-07-20
 
 ### Changed

--- a/GeecsBluesky/CHANGELOG.md
+++ b/GeecsBluesky/CHANGELOG.md
@@ -15,7 +15,9 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   `ScanRequest` path), the "no s-file output" limitation (scalar s-files are
   exported from Tiled best-effort after a scan; TDMS still is not), and the
   reference to the deleted `test_bluesky_scanner.py` hardware script (now
-  `tests/test_scan_request_hardware.py`).
+  `tests/test_scan_request_hardware.py`).  `ROADMAP.md`'s "Data pipeline
+  transition" section updated to match (review finding): the s-file shim is
+  live via the Tiled export, and BlueskyScanner is the production path.
 
 ## [0.46.0] - 2026-07-20
 

--- a/GeecsBluesky/ROADMAP.md
+++ b/GeecsBluesky/ROADMAP.md
@@ -105,7 +105,10 @@ These require discussion before implementation — see brainstorm notes.
 ### Data pipeline transition
 
 `ScanAnalysis` and everything downstream reads s-files and TDMS written by the
-legacy `ScanManager`.  `BlueskyScanner` writes to Tiled only.
+legacy `ScanManager`.  `BlueskyScanner` writes to Tiled, and scalar files are
+exported from Tiled best-effort after each scan
+(`geecs_data_utils.tiled_export.write_scalar_files_from_tiled` →
+`ScanDataScan{NNN}.txt` + the `s{NNN}.txt` s-file); TDMS is not produced.
 
 Options:
 - **Tiled reader for ScanAnalysis** — add a Tiled-backed data source alongside
@@ -113,14 +116,16 @@ Options:
   contract: ImageAnalysis emits bare scalar keys, ScanAnalysis owns
   prefix/suffix naming, and analysis code must never create missing scan
   folders.
-- **BlueskyScanner also writes s-files** — transitional shim; buys time for
-  ScanAnalysis migration.  If chosen, it must match the current scanner output
-  convention (`ScanDataScan{NNN}.txt`, `ScanInfoScan{NNN}.ini`, per-device file
-  folders under `scans/Scan{NNN}/`).
+- **BlueskyScanner also writes s-files** — **taken (transitional shim)**: the
+  post-scan Tiled export above is live on all engine paths; buys time for the
+  ScanAnalysis migration.
 - **Accept cold-turkey** — new scans from Bluesky path only queryable via Tiled;
   old analysis tools stop working for new data until ported.
 
-No decision yet.  Defer until BlueskyScanner is actually the production path.
+BlueskyScanner is now the production path (the legacy backend died with
+G1/G3), and the s-file shim bridges the gap.  The strategic question that
+remains open is the end state: does ScanAnalysis grow a Tiled reader, or
+keep reading exported s-files long-term?
 
 ### GUI / RunControl integration — mostly done
 

--- a/GeecsBluesky/TILED_SETUP.md
+++ b/GeecsBluesky/TILED_SETUP.md
@@ -91,8 +91,11 @@ api_key = <stable key>
   setup/per-step/closeout actions, and `ScanEvent` callbacks all flow
   through it (the legacy `GEECS-Scanner-GUI` path was deleted with G3) ✓
 - Scalar s-file exported from Tiled best-effort after each scan ✓
-- Hardware integration test (`tests/test_scan_request_hardware.py`) runs a
-  real `ScanRequest` end to end against the live gateway ✓
+- Hardware integration test: `tests/test_scan_request_hardware.py`
+  (replaces the deleted `test_bluesky_scanner.py`) runs a real
+  `ScanRequest` end to end against the live gateway — see its module
+  docstring for invocation; run it to verify, no standing pass is
+  recorded here
 
 ## Known Limitations
 

--- a/GeecsBluesky/TILED_SETUP.md
+++ b/GeecsBluesky/TILED_SETUP.md
@@ -86,18 +86,24 @@ api_key = <stable key>
 - Non-scalar device events include save directory and device `acq_timestamp` ✓
 - DG645 shot control arm/disarm per step ✓
 - Catalog readable from any network-connected Python session ✓
-- Hardware integration test (`test_bluesky_scanner.py`) passes all 6 checks ✓
+- GUI path complete — `GEECS-Console` drives `BlueskyScanner` through the
+  delegated `ScanRequest` path: shot control (trigger profiles),
+  setup/per-step/closeout actions, and `ScanEvent` callbacks all flow
+  through it (the legacy `GEECS-Scanner-GUI` path was deleted with G3) ✓
+- Scalar s-file exported from Tiled best-effort after each scan ✓
+- Hardware integration test (`tests/test_scan_request_hardware.py`) runs a
+  real `ScanRequest` end to end against the live gateway ✓
 
 ## Known Limitations
 
-- **No s-file / TDMS output** — `BlueskyScanner` writes to Tiled only.
-  `ScanAnalysis` and other downstream tools still read s-files.  Data pipeline
-  transition is an open strategic question (see `ROADMAP.md`).
-- **Tiled not yet read by ScanAnalysis** — post-scan analysis continues to use
-  the legacy file-based path.
-- **GUI path still partial** — `RunControl(use_bluesky=True)` does not yet pass
-  shot-control YAML, setup/closeout actions, or the scanner `ScanEvent` callback
-  into `BlueskyScanner`.
+- **No TDMS output** — scalar s-files are exported from Tiled best-effort
+  after a scan (needs the Tiled client extra and a readable run); legacy
+  TDMS output is not produced.  Data pipeline transition is an open
+  strategic question (see `ROADMAP.md`).
+- **Tiled not yet read by ScanAnalysis** — post-scan analysis continues to
+  use the file-based path (bridged by the s-file export).  The
+  `geecs_bluesky.analysis` contracts can run image analysis over archived
+  Tiled runs, but `ScanAnalysis` itself does not read Tiled.
 
 ---
 

--- a/GeecsBluesky/pyproject.toml
+++ b/GeecsBluesky/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-bluesky"
-version = "0.46.0"
+version = "0.46.1"
 description = "Bluesky / ophyd-async bridge for the GEECS control system"
 authors = ["Sam Barber <sbarber@lbl.gov>"]
 readme = "README.md"


### PR DESCRIPTION
## What & why

`GeecsBluesky/TILED_SETUP.md` still described the pre-cutover world in its
"What Works" and "Known Limitations" sections. Three stale claims, refreshed
to match `dev`:

1. **"GUI path still partial"** (shot-control YAML / actions / `ScanEvent`
   callback not passed into `BlueskyScanner`) — on `dev` the legacy
   `GEECS-Scanner-GUI` path was deleted (G1/G3); `GEECS-Console` is the
   front-end and shot control, setup/per-step/closeout actions, and scan
   events all flow through the delegated `ScanRequest` path. Removed as a
   limitation, recorded under "What Works".
2. **"No s-file / TDMS output — BlueskyScanner writes to Tiled only"** —
   scalar s-files are now exported from Tiled best-effort after a scan
   (per `GeecsBluesky/CLAUDE.md`); TDMS still is not produced. Narrowed to
   "No TDMS output" with the s-file export stated.
3. **`test_bluesky_scanner.py` hardware-test reference** — that script was
   deleted with G3; updated to `tests/test_scan_request_hardware.py`
   (the "Useful Commands" section already referenced the new name).

Docs-only; no runtime surface. Patch bump per the #536/#537 docs-bump
convention.

## LOC breakdown

- `TILED_SETUP.md`: +17/−10 (the refresh)
- `CHANGELOG.md`: +12 (0.46.1 entry)
- `pyproject.toml`: 0.46.0 → 0.46.1

## Tests

`./scripts/check.sh` (scoped): GeecsBluesky suite **581 passed,
3 deselected** in a freshly provisioned worktree env
(`poetry install --extras "ca tiled"`). No behavior change, so no new
pinning test.

## Hardware verification

Not applicable — docs-only, no scan-execution or device code touched. The
doc's factual claims mirror `GeecsBluesky/CLAUDE.md` (s-file export, G3
deletion, renamed hardware test), which reflect already-hardware-verified
state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
