### PR TITLE
GeecsBluesky 0.47.0: pseudo (composite) scan variables execute on the ScanRequest path

### DIFF
--- a/GEECS-Schemas/CHANGELOG.md
+++ b/GEECS-Schemas/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to GEECS-Schemas are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.2] - 2026-07-21
+
+### Changed
+
+- `scan_variables.py` description sync with the pseudo-variable runtime
+  landing in geecs-bluesky 0.47.0 (documentation only, no schema shape
+  change): `PseudoComponent.forward` documents the expression language as
+  plain arithmetic with the scanned value written as `composite_var` **or
+  its new short alias `x`** (the engine's whitelist evaluator accepts
+  both; every legacy numexpr-era `relation` string remains valid
+  unchanged).  `docs/geecs_schemas/schema_reference.md` regenerated.
+
 ## [0.8.1] - 2026-07-20
 
 ### Changed

--- a/GEECS-Schemas/geecs_schemas/scan_variables.py
+++ b/GEECS-Schemas/geecs_schemas/scan_variables.py
@@ -18,11 +18,13 @@ an ``absolute``/``relative`` mode).
 - ``kind: motor`` — blocking move *plus* readback-tolerance polling; an
   explicit opt-in for real positioners (renders to ``CaMotor``).
 - ``kind: pseudo`` — a pseudo-positioner: one scanned number fanned out to
-  several components through ``forward`` expressions.  v1 keeps the legacy
-  numexpr semantics **verbatim**: each expression is written in terms of
-  ``composite_var`` (the scanned value), and ``mode`` keeps the legacy
-  meaning — ``absolute`` sets each component to its expression's value,
-  ``relative`` offsets each component from its position at scan start.
+  several components through ``forward`` expressions.  Each expression is
+  plain arithmetic (operators, parentheses, common math functions such as
+  ``sqrt``) written in terms of ``composite_var`` — or its short alias
+  ``x`` — the scanned value; the legacy corpus's numexpr ``relation``
+  strings are all valid unchanged.  ``mode`` keeps the legacy meaning —
+  ``absolute`` sets each component to its expression's value, ``relative``
+  offsets each component from its position at scan start.
 
 Limits, units, and tolerances deliberately do **not** live here — device
 facts belong below the configs (gateway PV metadata; vision doc §4.3).
@@ -175,9 +177,10 @@ class PseudoComponent(SchemaModel):
     forward: str = Field(
         min_length=1,
         description=(
-            "Formula for this device's value in terms of the scanned number, "
-            "written with 'composite_var' as the scanned value — e.g. "
-            "'composite_var * -2' or '8.5 + (composite_var-10)*2.5'."
+            "Formula for this device's value in terms of the scanned number: "
+            "plain arithmetic with 'composite_var' (or its short alias 'x') "
+            "as the scanned value — e.g. 'composite_var * -2', 'x * -2', or "
+            "'8.5 + (composite_var-10)*2.5'."
         ),
     )
 
@@ -194,7 +197,10 @@ class PseudoScanVariable(SchemaModel):
     Notes
     -----
     Successor of a legacy ``composite_variables.yaml`` entry.  ``mode`` and
-    the numexpr expressions keep their legacy semantics verbatim in v1.
+    the arithmetic expressions keep their legacy (numexpr-era) semantics
+    verbatim; the engine evaluates them with a whitelisted expression
+    evaluator, and the shorter alias ``x`` may be used for the scanned
+    value in new entries.
     ``inverse`` (a readback formula recovering the scanned number from the
     first target's position) has no legacy counterpart and is optional.
     """

--- a/GEECS-Schemas/pyproject.toml
+++ b/GEECS-Schemas/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-schemas"
-version = "0.8.1"
+version = "0.8.2"
 description = "Versioned Pydantic schemas for GEECS scanner configs (scan requests, save sets, scan variables, trigger profiles, action plans) plus legacy-YAML converters."
 authors = ["Sam Barber <sbarber@lbl.gov>"]
 readme = "README.md"

--- a/GeecsBluesky/CHANGELOG.md
+++ b/GeecsBluesky/CHANGELOG.md
@@ -4,7 +4,42 @@ All notable changes to `geecs-bluesky` are documented here.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
-## [0.46.1] - 2026-07-21
+## [0.47.0] - 2026-07-21
+
+### Added
+
+- **Pseudo (composite) scan variables execute** — the last piece of the
+  legacy composite-variable capability lands on the ScanRequest path,
+  closing the "validated, then refused" v1 gap:
+  - `forward_expr.py` — `compile_forward`: an AST-whitelist compiler for
+    `PseudoComponent.forward` formulas (arithmetic, parentheses, `sqrt`/
+    trig/`exp`/`log`/`abs`, constants `pi`/`e`; the scanned value as
+    `composite_var` or its alias `x`).  The full legacy
+    `composite_variables.yaml` corpus is pinned expression-by-expression in
+    `tests/test_forward_expr.py`; anything outside the whitelist raises
+    `GeecsConfigurationError` at compile time, never evaluated.
+  - `devices/ca/pseudo.py` — `CaPseudoMovable`: one scanned number fanned
+    out to every component's gateway `:SP` concurrently (each put rides the
+    GEECS blocking set via `GatewaySetpointPut`; the move completes when
+    the slowest target's exe response lands).  `absolute` mode sets each
+    target to its formula's value; `relative` mode offsets from baselines
+    captured per run at `stage()` (or lazily on first `set()` for unstaged
+    callers — the optimize path) and dropped on `unstage()`.  The recorded
+    event-row column is the demanded pseudo value (soft readback); v1
+    completion is setpoint-semantics per component (legacy `ScanDevice`
+    parity — per-component `kind` is a future additive field).
+  - `scan_request_runner` — `resolve_movable_target` returns a typed
+    `PlainMovableTarget | PseudoMovableTarget` (forward formulas compiled
+    fail-fast pre-claim) and `build_movable` dispatches to the new
+    `GeecsSession.pseudo_movable` factory, on **both** the step/grid-axis
+    and optimize-mode movable paths.  Pseudo provenance (mode + per-target
+    forward sources) is recorded in run metadata under `pseudo_variables`;
+    the scan parameter records the catalog friendly name.
+- Suite grows 581 → 614 (evaluator corpus/rejection tests, mock-backend
+  CaPseudoMovable tests, runner execution/metadata/fail-fast tests; the
+  four former refusal pins flipped to execution/validation pins).
+
+
 
 ### Changed
 

--- a/GeecsBluesky/CHANGELOG.md
+++ b/GeecsBluesky/CHANGELOG.md
@@ -35,11 +35,12 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
     and optimize-mode movable paths.  Pseudo provenance (mode + per-target
     forward sources) is recorded in run metadata under `pseudo_variables`;
     the scan parameter records the catalog friendly name.
-- Suite grows 581 → 614 (evaluator corpus/rejection tests, mock-backend
-  CaPseudoMovable tests, runner execution/metadata/fail-fast tests; the
-  four former refusal pins flipped to execution/validation pins).
+- Suite grows 581 → 617 (evaluator corpus/rejection tests, mock-backend
+  CaPseudoMovable tests, runner execution/metadata/fail-fast tests, the
+  non-finite `_move_movables` guard; the four former refusal pins flipped
+  to execution/validation pins).
 
-
+## [0.46.1] - 2026-07-21
 
 ### Changed
 

--- a/GeecsBluesky/CLAUDE.md
+++ b/GeecsBluesky/CLAUDE.md
@@ -69,6 +69,10 @@ geecs_bluesky/
   config_resolver.py        # ConfigResolver protocol + ConfigsRepoResolver:
                             #   ScanRequest names → schema models (new-schema
                             #   YAML directly, else legacy-convert)
+  forward_expr.py           # compile_forward — AST-whitelist compiler for
+                            #   pseudo-variable forward formulas (arithmetic +
+                            #   math functions; scanned value = composite_var
+                            #   or its alias x; corpus pinned by tests)
   scan_request_runner.py    # run a geecs_schemas.ScanRequest:
                             #   SaveSet→devices_config and
                             #   TriggerProfile→ShotControlWrites (ordered,
@@ -103,6 +107,9 @@ geecs_bluesky/
       snapshot.py           # CaSnapshotReadable — async readback
       settable.py           # CaSettable — put :SP, read streamed readback
       motor.py              # CaMotor — blocking :SP put + readback-tolerance poll
+      pseudo.py             # CaPseudoMovable — pseudo (composite) variable:
+                            #   one number fanned out to N targets' :SP
+                            #   (absolute / relative-with-staged-baselines)
       confirm.py            # CaConfirmSettable — set X, confirm on a
                             #   different variable Y (ScanVariable.confirm)
       action_signals.py     # CaActionSignalFactory — the production
@@ -348,6 +355,23 @@ backend reached verified live parity (Scans 007–015, 2026-07-03/04); a stale
   inconsistently), so an RE abort cancels the wait but the hardware finishes
   its move. If a specific device's abort variable matters, an optional
   `stop_variable` hook on `CaMotor` is the intended future shape.
+- **`CaPseudoMovable`** — the pseudo (composite) scan variable
+  (`devices/ca/pseudo.py`, 0.47.0): `set(u)` evaluates each component's
+  compiled `forward` formula (`forward_expr.compile_forward` — AST
+  whitelist, `composite_var`/`x` as the scanned value; legacy
+  `composite_variables.yaml` corpus pinned) and puts every target's `:SP`
+  concurrently through `GatewaySetpointPut` — completion when the slowest
+  target's GEECS exe response lands; setpoint semantics per component (v1,
+  legacy `ScanDevice` parity — per-component `kind: motor` is the intended
+  additive upgrade).  `relative` mode captures per-target baselines at
+  `stage()` (lazily on first `set()` for unstaged callers, i.e. optimize),
+  drops them at `unstage()`; `absolute` mode is stateless.  **The recorded
+  event-row column is the demanded pseudo value** (soft readback child,
+  header = the catalog friendly name) — include target devices in the save
+  set when their measured positions matter.  Built by
+  `GeecsSession.pseudo_movable` via `build_movable`'s dispatch on
+  `PseudoMovableTarget` (both grid-axis and optimize paths); spec + formula
+  sources recorded in run metadata under `pseudo_variables`.
 - **`CaConfirmSettable`** — the topology-C device (`devices/ca/confirm.py`):
   writes `variable` but confirms on a *different* variable's readback
   (`ScanVariable.confirm`) — the EMQ triplet's `Current_Limit.ChN` (a
@@ -530,8 +554,10 @@ lists via `ShotControlWrites`).  Action plans compile via
 `plans/action_compiler.py` against the session's `CaActionSignalFactory`;
 every signal is prefetched/connected pre-claim (a lazy connect inside the
 RE loop would deadlock).  Names still resolve fail-fast pre-claim.
-Remaining validated-then-refused v1 gaps: pseudo scan variables,
-`all_scalars`, and optimize without an injected objective/suggester.
+Remaining validated-then-refused v1 gaps: `all_scalars`, and optimize
+without an injected objective/suggester.  (Pseudo scan variables execute
+as of 0.47.0 — see `CaPseudoMovable` in the Device Layer section; a bad
+`forward` expression still fails validation pre-claim.)
 Actions on an optimize-mode request are **not** refused — optimize has no
 action hooks yet, so the actions (request, experiment defaults, and
 save-set rituals) are skipped, logged (WARNING), and recorded in run

--- a/GeecsBluesky/EVENT_SCHEMA.md
+++ b/GeecsBluesky/EVENT_SCHEMA.md
@@ -40,7 +40,11 @@ Added by the run wrapper (`geecs_run_wrapper`) when a scan number is claimed:
 is irreversible, so this map is the only way to recover legacy headers; it backs
 the Tiled→s-file exporter (`geecs_data_utils.tiled_export`). Only true device
 signals appear — derived companion columns (`-acq_timestamp`, `-shot_id`, …) are
-excluded by construction.
+excluded by construction. A **pseudo scan variable's** motor column is the one
+exception to the `Device Variable` header shape: its recorded value is the
+demanded pseudo number (no physical readback of its own), so its header is the
+catalog friendly name verbatim (e.g. `ALine_e_beam_angle_offset_x`), and the
+per-target formulas live in `pseudo_variables` (below).
 
 Strict mode adds:
 
@@ -63,6 +67,11 @@ ScanRequest runs (`GeecsSession.run`) may also add, for provenance:
 | `applied_defaults` | Experiment-defaults fields that filled a silent request |
 | `action_plans` | Assembled per-slot action execution order |
 | `background_telemetry` | `{device: [variables]}` recorded as Tier-2 telemetry (M3c get-side; present only when telemetry ran) |
+| `pseudo_variables` | `{name: {mode, targets: [{target, forward}]}}` for every pseudo scan axis/movable — the mode and per-target formula sources the move used (0.47.0) |
+| `save_sets` | The named save sets unioned for this scan |
+| `skipped_action_plans` | Actions skipped on an optimize-mode request (no action hooks yet) |
+| `provisioned_device_requirements` | What the optimizer's `device_requirements` added to the effective device set (0.38.0) |
+| `dropped_unserved_variables` / `dropped_unserved_devices` | What the unserved-variables pre-flight removed (0.36.0) |
 
 **`scan_id` note:** `scan_id` has no uniqueness contract in Bluesky — the
 day-scoped number resets to 1 each day, which is fine (`uid` is the real key).

--- a/GeecsBluesky/geecs_bluesky/devices/ca/__init__.py
+++ b/GeecsBluesky/geecs_bluesky/devices/ca/__init__.py
@@ -14,6 +14,7 @@ from geecs_bluesky.devices.ca.action_signals import CaActionSignalFactory
 from geecs_bluesky.devices.ca.confirm import CaConfirmSettable
 from geecs_bluesky.devices.ca.generic_detector import CaGenericDetector
 from geecs_bluesky.devices.ca.motor import CaMotor
+from geecs_bluesky.devices.ca.pseudo import CaPseudoMovable
 from geecs_bluesky.devices.ca.settable import CaSettable
 from geecs_bluesky.devices.ca.snapshot import CaSnapshotReadable
 from geecs_bluesky.devices.ca.telemetry import CaTelemetryReadable
@@ -26,6 +27,7 @@ __all__ = [
     "CaConfirmSettable",
     "CaGenericDetector",
     "CaMotor",
+    "CaPseudoMovable",
     "CaSettable",
     "CaSnapshotReadable",
     "CaTelemetryReadable",

--- a/GeecsBluesky/geecs_bluesky/devices/ca/pseudo.py
+++ b/GeecsBluesky/geecs_bluesky/devices/ca/pseudo.py
@@ -1,0 +1,170 @@
+"""CaPseudoMovable — one scanned number fanned out to several GEECS targets.
+
+The runtime for :class:`~geecs_schemas.scan_variables.PseudoScanVariable`:
+``set(value)`` computes each component's setting from its compiled ``forward``
+formula and puts every target's gateway ``:SP`` concurrently.  Each put rides
+GEECS's native blocking set (the move completes when the slowest target's exe
+response lands), through the shared
+:class:`~geecs_bluesky.devices.ca.gateway_put.GatewaySetpointPut` primitive —
+the same completion semantics as :class:`CaSettable`, per component.
+
+Modes (legacy ``composite_variables.yaml`` semantics, verbatim):
+
+- ``absolute`` — each target goes exactly where its formula says:
+  ``target_i = forward_i(value)``.
+- ``relative`` — each target is offset from where it was when the scan
+  started: ``target_i = baseline_i + forward_i(value)``.  Baselines are
+  captured once per run from the targets' streamed readback PVs at
+  ``stage()`` (the step plan stages every motor), or lazily on the first
+  ``set()`` for callers that do not stage (the optimize path), and cleared
+  on ``unstage()`` so the next scan re-captures.
+
+The recorded event-row column is the **demanded pseudo value** (a soft
+readback child) — the pseudo has no physical readback of its own.  Include
+the target devices in the save set when their measured positions matter.
+Captured baselines are logged at INFO.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import math
+from typing import Sequence
+
+from ophyd_async.core import AsyncStatus, StandardReadable, soft_signal_r_and_setter
+from ophyd_async.epics.core import epics_signal_r, epics_signal_rw
+
+from geecs_bluesky.devices.ca._pv import ca_pv, setpoint_pv
+from geecs_bluesky.devices.ca.gateway_put import GatewaySetpointPut
+from geecs_bluesky.forward_expr import CompiledForward
+
+logger = logging.getLogger(__name__)
+
+
+class CaPseudoMovable(StandardReadable):
+    """A pseudo (composite) scan variable as a Bluesky ``Movable`` over CA.
+
+    Parameters
+    ----------
+    components : sequence of (device, variable, CompiledForward)
+        The targets to move, each with its compiled ``forward`` formula.
+    mode : str
+        ``"absolute"`` or ``"relative"`` (see the module docstring).
+    variable_name : str
+        The catalog's friendly name (recorded as the exporter column header).
+    experiment : str, optional
+        Experiment PV-namespace prefix.
+    name : str
+        ophyd-async device name (namespaces the event keys).
+    """
+
+    def __init__(
+        self,
+        components: Sequence[tuple[str, str, CompiledForward]],
+        mode: str,
+        *,
+        variable_name: str,
+        experiment: str | None = None,
+        name: str = "pseudo",
+    ) -> None:
+        if mode not in ("absolute", "relative"):
+            raise ValueError(f"unknown pseudo mode {mode!r}")
+        self._components: list[tuple[str, str, CompiledForward]] = list(components)
+        self._mode = mode
+        # Per-component transport, CaSettable's exact pattern: the setpoint
+        # signal is the typed transport/mock seam, the shared put primitive
+        # owns addressing/coercion/timeout policy.  The target readbacks are
+        # deliberately NOT readables (baseline capture only) — the pseudo's
+        # event-row column is the demanded value, and target devices in the
+        # save set already record their own streamed positions.
+        self._puts: list[GatewaySetpointPut] = []
+        self._target_readbacks = []
+        for index, (device, variable, _forward) in enumerate(self._components):
+            readback_pv = ca_pv(experiment, device, variable)
+            setpoint = epics_signal_rw(float, setpoint_pv(readback_pv))
+            readback = epics_signal_r(float, readback_pv)
+            # Child registration is by attribute assignment (a plain list is
+            # never traversed by ophyd-async), so each signal gets its own
+            # numbered attribute; the lists are convenience views.
+            setattr(self, f"_setpoint_{index}", setpoint)
+            setattr(self, f"_target_readback_{index}", readback)
+            self._puts.append(GatewaySetpointPut(signal=setpoint, timeout=None))
+            self._target_readbacks.append(readback)
+        with self.add_children_as_readables():
+            # A relative pseudo genuinely starts at 0 (zero offset from the
+            # baselines, by definition) — and set(0) restores the baselines
+            # for the pure-offset formulas the corpus uses, which is what
+            # optimize's on_finish="initial" relies on.  An absolute pseudo's
+            # position is unknown until the first set (no inverse): NaN.
+            self.readback, self._set_readback = soft_signal_r_and_setter(
+                float, initial_value=0.0 if mode == "relative" else math.nan
+            )
+        super().__init__(name=name)
+        self._baselines: list[float] | None = None
+        self._column_headers = {f"{name}-readback": variable_name}
+
+    async def disconnect(self) -> None:
+        """Per-scan teardown hook (uniform across CA device types)."""
+
+    async def _capture_baselines(self) -> None:
+        """Read every target's streamed readback as this run's baseline."""
+        values = await asyncio.gather(
+            *(sig.get_value() for sig in self._target_readbacks)
+        )
+        self._baselines = [float(v) for v in values]
+        logger.info(
+            "%s: relative baselines captured: %s",
+            self.name,
+            {
+                f"{dev}:{var}": baseline
+                for (dev, var, _), baseline in zip(self._components, self._baselines)
+            },
+        )
+
+    @AsyncStatus.wrap
+    async def stage(self) -> None:
+        """Stage the readable children; capture relative baselines."""
+        await super().stage().task
+        if self._mode == "relative":
+            await self._capture_baselines()
+
+    @AsyncStatus.wrap
+    async def unstage(self) -> None:
+        """Unstage and drop the baselines so the next run re-captures."""
+        self._baselines = None
+        await super().unstage().task
+
+    def _target_values(self, value: float) -> list[float]:
+        """Each component's absolute setting for pseudo *value*."""
+        offsets = [forward(value) for _, _, forward in self._components]
+        if self._mode == "relative":
+            assert self._baselines is not None  # captured before use
+            return [b + o for b, o in zip(self._baselines, offsets)]
+        return offsets
+
+    def set(self, value: float) -> AsyncStatus:
+        """Fan *value* out to every target; completes when all sets do.
+
+        Implements :class:`bluesky.protocols.Movable`.
+        """
+        return AsyncStatus(self._set_and_wait(float(value)))
+
+    async def _set_and_wait(self, value: float) -> None:
+        if self._mode == "relative" and self._baselines is None:
+            # Unstaged caller (e.g. the optimize path): capture lazily once.
+            await self._capture_baselines()
+        targets = self._target_values(value)
+        logger.info(
+            "%s: %s → %s",
+            self.name,
+            value,
+            {
+                f"{dev}:{var}": target
+                for (dev, var, _), target in zip(self._components, targets)
+            },
+        )
+        await asyncio.gather(
+            *(put.put(target) for put, target in zip(self._puts, targets))
+        )
+        self._set_readback(value)

--- a/GeecsBluesky/geecs_bluesky/forward_expr.py
+++ b/GeecsBluesky/geecs_bluesky/forward_expr.py
@@ -1,0 +1,133 @@
+"""Compile a pseudo variable's ``forward`` formula into a callable.
+
+A :class:`~geecs_schemas.scan_variables.PseudoComponent` carries its device's
+setting as a math expression of the single scanned number (the schema writes
+the scanned value as ``composite_var``; the shorter alias ``x`` is also
+accepted).  This module turns that string into a plain ``float -> float``
+callable, safely: the expression is parsed with :mod:`ast` and validated
+against an explicit whitelist of node types, operators, functions, and names
+**before** anything is evaluated, so a config cannot smuggle attribute
+access, imports, subscripts, or arbitrary names into the engine.
+
+The whitelist covers the full legacy ``composite_variables.yaml`` corpus
+(arithmetic, parentheses, ``sqrt``) with ordinary math headroom (trig,
+``exp``/``log``, ``abs``, the constants ``pi``/``e``).  Compilation failures
+raise :class:`~geecs_bluesky.exceptions.GeecsConfigurationError` naming the
+offending construct — the runner compiles every formula fail-fast pre-claim,
+so a bad expression can never burn a scan number.
+"""
+
+from __future__ import annotations
+
+import ast
+import math
+from dataclasses import dataclass
+from typing import Callable
+
+from geecs_bluesky.exceptions import GeecsConfigurationError
+
+#: Names bound to the scanned value: the schema's token and its short alias.
+SCAN_VALUE_NAMES = ("composite_var", "x")
+
+#: Callables an expression may invoke, by name.
+_FUNCTIONS: dict[str, Callable[..., float]] = {
+    "sqrt": math.sqrt,
+    "sin": math.sin,
+    "cos": math.cos,
+    "tan": math.tan,
+    "asin": math.asin,
+    "acos": math.acos,
+    "atan": math.atan,
+    "exp": math.exp,
+    "log": math.log,
+    "log10": math.log10,
+    "abs": abs,
+}
+
+#: Bare names an expression may reference besides the scanned value.
+_CONSTANTS: dict[str, float] = {"pi": math.pi, "e": math.e}
+
+_BINARY_OPS = (ast.Add, ast.Sub, ast.Mult, ast.Div, ast.Pow, ast.Mod, ast.FloorDiv)
+_UNARY_OPS = (ast.UAdd, ast.USub)
+
+
+def _reject(expression: str, detail: str) -> GeecsConfigurationError:
+    return GeecsConfigurationError(
+        f"invalid forward expression {expression!r}: {detail}. Allowed: "
+        f"numbers, + - * / ** % //, parentheses, the scanned value as "
+        f"{' or '.join(SCAN_VALUE_NAMES)}, constants {sorted(_CONSTANTS)}, "
+        f"and functions {sorted(_FUNCTIONS)}"
+    )
+
+
+def _validate(node: ast.AST, expression: str) -> None:
+    """Recursively whitelist-check one AST node (raises on anything else)."""
+    if isinstance(node, ast.Expression):
+        _validate(node.body, expression)
+    elif isinstance(node, ast.BinOp) and isinstance(node.op, _BINARY_OPS):
+        _validate(node.left, expression)
+        _validate(node.right, expression)
+    elif isinstance(node, ast.UnaryOp) and isinstance(node.op, _UNARY_OPS):
+        _validate(node.operand, expression)
+    elif isinstance(node, ast.Constant):
+        if not isinstance(node.value, (int, float)):
+            raise _reject(expression, f"literal {node.value!r} is not a number")
+    elif isinstance(node, ast.Name):
+        if node.id not in SCAN_VALUE_NAMES and node.id not in _CONSTANTS:
+            raise _reject(expression, f"unknown name {node.id!r}")
+    elif isinstance(node, ast.Call):
+        if not isinstance(node.func, ast.Name) or node.func.id not in _FUNCTIONS:
+            raise _reject(expression, "only whitelisted function calls are allowed")
+        if node.keywords:
+            raise _reject(expression, "keyword arguments are not allowed")
+        for arg in node.args:
+            _validate(arg, expression)
+    else:
+        raise _reject(expression, f"disallowed syntax ({type(node).__name__})")
+
+
+@dataclass(frozen=True)
+class CompiledForward:
+    """A validated ``forward`` formula, callable as ``float -> float``.
+
+    Attributes
+    ----------
+    source : str
+        The original expression text (recorded in run metadata).
+    """
+
+    source: str
+    _code: object
+
+    def __call__(self, value: float) -> float:
+        """Evaluate the formula at scanned value *value*."""
+        names: dict[str, float] = {token: float(value) for token in SCAN_VALUE_NAMES}
+        names.update(_CONSTANTS)
+        names.update(_FUNCTIONS)  # type: ignore[arg-type]
+        try:
+            result = eval(  # noqa: S307 — AST-whitelisted at compile time
+                self._code, {"__builtins__": {}}, names
+            )
+        except (ValueError, ZeroDivisionError, OverflowError) as exc:
+            raise GeecsConfigurationError(
+                f"forward expression {self.source!r} failed at "
+                f"{SCAN_VALUE_NAMES[0]}={value}: {exc}"
+            ) from exc
+        return float(result)
+
+
+def compile_forward(expression: str) -> CompiledForward:
+    """Parse and whitelist-validate *expression*; return the callable form.
+
+    Raises
+    ------
+    GeecsConfigurationError
+        Syntax errors, or any construct outside the whitelist (unknown
+        names, attribute access, subscripts, non-numeric literals, ...).
+    """
+    try:
+        tree = ast.parse(expression, mode="eval")
+    except SyntaxError as exc:
+        raise _reject(expression, f"syntax error ({exc.msg})") from exc
+    _validate(tree, expression)
+    return CompiledForward(source=expression, _code=compile(tree, "<forward>", "eval"))

--- a/GeecsBluesky/geecs_bluesky/forward_expr.py
+++ b/GeecsBluesky/geecs_bluesky/forward_expr.py
@@ -15,6 +15,14 @@ The whitelist covers the full legacy ``composite_variables.yaml`` corpus
 raise :class:`~geecs_bluesky.exceptions.GeecsConfigurationError` naming the
 offending construct — the runner compiles every formula fail-fast pre-claim,
 so a bad expression can never burn a scan number.
+
+Known sibling: the gateway's derived-channel ``ExpressionEvaluator``
+(``geecs_ca_gateway/derived.py``) is the same compile-then-restricted-eval
+skeleton with a different whitelist (comparisons/bool-ops, ``isfinite``,
+no ``abs``).  They are deliberately separate today (different languages,
+different error contracts); if either eval site is ever hardened or its
+semantics fixed, apply the change to both — a shared stdlib-only core in
+GEECS-Schemas is the sketched consolidation home.
 """
 
 from __future__ import annotations
@@ -108,12 +116,15 @@ class CompiledForward:
             result = eval(  # noqa: S307 — AST-whitelisted at compile time
                 self._code, {"__builtins__": {}}, names
             )
-        except (ValueError, ZeroDivisionError, OverflowError) as exc:
+            # Inside the try: float() itself can raise — e.g. `x ** 0.5` at
+            # a negative x returns complex (TypeError), and an int-constant
+            # power can overflow the float conversion.
+            return float(result)
+        except (ValueError, TypeError, ZeroDivisionError, OverflowError) as exc:
             raise GeecsConfigurationError(
                 f"forward expression {self.source!r} failed at "
                 f"{SCAN_VALUE_NAMES[0]}={value}: {exc}"
             ) from exc
-        return float(result)
 
 
 def compile_forward(expression: str) -> CompiledForward:

--- a/GeecsBluesky/geecs_bluesky/scan_request_runner.py
+++ b/GeecsBluesky/geecs_bluesky/scan_request_runner.py
@@ -19,8 +19,15 @@
   outermost) and optimize modes on a
   :class:`~geecs_bluesky.session.GeecsSession`.
 
+Pseudo (composite) scan variables execute: :func:`resolve_movable_target`
+compiles every component's ``forward`` formula fail-fast pre-claim and
+:func:`build_movable` builds a
+:class:`~geecs_bluesky.devices.ca.pseudo.CaPseudoMovable` for them, on both
+the step-axis and optimize movable paths (spec + formulas recorded in run
+metadata under ``pseudo_variables``).
+
 Deliberate v1 gaps (validated, then refused loudly — never silently wrong):
-pseudo scan variables, ``all_scalars``, and optimize without either an
+``all_scalars``, and optimize without either an
 injected ``objective``/``suggester`` pair or an ``optimization_binder``
 (the Xopt stack lives in ``geecs_scanner.optimization``, which this package
 must not import — the binder is the GUI bridge's injected seam for it).
@@ -34,6 +41,7 @@ from __future__ import annotations
 import itertools
 import logging
 from collections.abc import Mapping
+from dataclasses import dataclass
 from contextlib import nullcontext
 from typing import Any, Callable
 
@@ -51,6 +59,7 @@ from geecs_bluesky.db_runtime import (
     select_telemetry_variables,
 )
 from geecs_bluesky.exceptions import GeecsConfigurationError
+from geecs_bluesky.forward_expr import CompiledForward, compile_forward
 from geecs_bluesky.models.shot_control import ShotControlWrites
 from geecs_bluesky.operator_channel import OperatorChannel
 from geecs_bluesky.plans.action_compiler import compile_action_plan
@@ -812,8 +821,9 @@ def validate_scan_request(
     request needs at least one — optimize may run save-set-less because the
     optimizer's ``device_requirements`` are auto-provisioned at execution
     time, where an empty *effective* set still refuses pre-claim), every
-    named save set + entry rituals, every step-axis movable target (pseudo
-    variables refused), and every optimize VOCS catalog name (bare names
+    named save set + entry rituals, every step-axis movable target
+    (pseudo-variable forward formulas compiled here — a bad expression
+    fails now, not mid-scan), and every optimize VOCS catalog name (bare names
     only — ``Device:Variable`` strings pass through, matching the runner's
     dispatch).
 
@@ -838,10 +848,9 @@ def validate_scan_request(
     Raises
     ------
     GeecsConfigurationError
-        Unresolvable names, an unknown trigger variant, or a step/noscan
-        request without a save set.
-    NotImplementedError
-        Pseudo (composite) scan variables — validated first, refused loudly.
+        Unresolvable names, an unknown trigger variant, a step/noscan
+        request without a save set, or a pseudo scan variable whose
+        ``forward`` expression fails to compile.
     """
     defaults = resolve_experiment_defaults(resolver)
     validated, applied = apply_experiment_defaults(request, defaults)
@@ -876,35 +885,90 @@ def validate_scan_request(
     return validated, applied, defaults
 
 
-def resolve_movable_target(
-    spec: ScanVariableSpec, name: str
-) -> tuple[str, str, str, str | None]:
-    """Return ``(device, variable, kind, confirm)`` for a plain scan variable.
+@dataclass(frozen=True)
+class PlainMovableTarget:
+    """One plain scan-variable target: a single ``Device:Variable`` write."""
 
-    ``confirm`` is the entry's optional ``"Device:Variable"`` confirming
-    target (``None`` when the set variable is also the readback).
+    device: str
+    variable: str
+    kind: str
+    confirm: str | None
+
+    @property
+    def label(self) -> str:
+        """The ``Device:Variable`` string recorded as the scan parameter."""
+        return f"{self.device}:{self.variable}"
+
+
+@dataclass(frozen=True)
+class PseudoMovableTarget:
+    """One pseudo scan variable: components with compiled forward formulas."""
+
+    variable_name: str
+    mode: str
+    components: tuple[tuple[str, str, CompiledForward], ...]
+
+    @property
+    def label(self) -> str:
+        """The catalog friendly name recorded as the scan parameter."""
+        return self.variable_name
+
+    def metadata(self) -> dict[str, Any]:
+        """The provenance record for ``md["pseudo_variables"]``."""
+        return {
+            "mode": self.mode,
+            "targets": [
+                {"target": f"{device}:{variable}", "forward": forward.source}
+                for device, variable, forward in self.components
+            ],
+        }
+
+
+MovableTarget = PlainMovableTarget | PseudoMovableTarget
+
+
+def resolve_movable_target(spec: ScanVariableSpec, name: str) -> MovableTarget:
+    """Resolve a catalog entry into its movable target, fail-fast.
+
+    A plain :class:`~geecs_schemas.scan_variables.ScanVariable` becomes a
+    :class:`PlainMovableTarget` (``confirm`` is the entry's optional
+    confirming ``"Device:Variable"``, ``None`` when the set variable is also
+    the readback).  A :class:`~geecs_schemas.scan_variables.PseudoScanVariable`
+    becomes a :class:`PseudoMovableTarget` with every component's ``forward``
+    formula compiled here — so a bad expression fails at validation time,
+    pre-claim, never mid-scan.
 
     Raises
     ------
-    NotImplementedError
-        Pseudo (composite) variables — the pseudo-positioner is not built yet.
+    GeecsConfigurationError
+        A pseudo component's ``forward`` expression fails to compile.
     """
     if isinstance(spec, PseudoScanVariable):
-        raise NotImplementedError(
-            f"scan variable {name!r} is a pseudo (composite) variable; "
-            "composite pseudo-positioner execution is not built yet — "
-            "sweep the underlying Device:Variable targets directly for now"
+        components = []
+        for component in spec.targets:
+            device, _, variable = component.target.partition(":")
+            try:
+                forward = compile_forward(component.forward)
+            except GeecsConfigurationError as exc:
+                raise GeecsConfigurationError(
+                    f"pseudo scan variable {name!r}, target {component.target!r}: {exc}"
+                ) from exc
+            components.append((device, variable, forward))
+        return PseudoMovableTarget(
+            variable_name=name,
+            mode=spec.mode.value,
+            components=tuple(components),
         )
     assert isinstance(spec, ScanVariable)
     device, _, variable = spec.target.partition(":")
-    return device, variable, spec.kind, spec.confirm
+    return PlainMovableTarget(device, variable, spec.kind, spec.confirm)
 
 
-def build_movable(
-    session: Any, device: str, variable: str, kind: str, confirm: str | None
-) -> Any:
+def build_movable(session: Any, target: MovableTarget) -> Any:
     """Build the right movable for one resolved scan-variable target.
 
+    A :class:`PseudoMovableTarget` builds via :meth:`GeecsSession.pseudo_movable`
+    (one number fanned out to every component).  For a plain target,
     ``confirm`` (a ``"Device:Variable"`` string) takes precedence over
     ``kind``: a variable with a confirming target is the topology-C case
     (:class:`~geecs_bluesky.devices.ca.confirm.CaConfirmSettable`) regardless
@@ -913,17 +977,21 @@ def build_movable(
     before: ``"motor"`` → :meth:`GeecsSession.motor`, else
     :meth:`GeecsSession.settable`.
     """
-    if confirm is not None:
-        confirm_device, _, confirm_variable = confirm.partition(":")
+    if isinstance(target, PseudoMovableTarget):
+        return session.pseudo_movable(
+            target.variable_name, list(target.components), target.mode
+        )
+    if target.confirm is not None:
+        confirm_device, _, confirm_variable = target.confirm.partition(":")
         return session.confirm_settable(
-            device,
-            variable,
+            target.device,
+            target.variable,
             confirm_device=confirm_device,
             confirm_variable=confirm_variable,
         )
-    if kind == "motor":
-        return session.motor(device, variable)
-    return session.settable(device, variable)
+    if target.kind == "motor":
+        return session.motor(target.device, target.variable)
+    return session.settable(target.device, target.variable)
 
 
 def _build_request_detectors(
@@ -1264,9 +1332,9 @@ def run_scan_request(
     Raises
     ------
     NotImplementedError
-        Pseudo scan variables, and optimize mode without an injected
-        objective/suggester or optimization_binder (the documented v1
-        gaps — validated first, refused loudly).
+        Optimize mode without an injected objective/suggester or
+        optimization_binder (a documented v1 gap — validated first,
+        refused loudly).
     GeecsConfigurationError
         Unresolvable names, a step/noscan request without a save set, or
         an optimize request with an empty effective device set (no save
@@ -1345,13 +1413,12 @@ def run_scan_request(
     warn_if_reserved_boundary_overrides(save_set)
 
     # Resolve the scan-variable movable targets up front (full movable
-    # construction happens later; only the (device, variable, kind, confirm)
-    # quadruples are needed here for the standard-scan build below).
-    axis_resolved: list[tuple[str, str, str, str | None]] = []
+    # construction happens later; only the resolved targets are needed here
+    # for the standard-scan build below).
+    axis_resolved: list[MovableTarget] = []
     for axis in request.axes:
         spec = resolver.resolve_scan_variable(axis.variable)
-        device, variable, kind, confirm = resolve_movable_target(spec, axis.variable)
-        axis_resolved.append((device, variable, kind, confirm))
+        axis_resolved.append(resolve_movable_target(spec, axis.variable))
 
     telemetry_enabled = (
         request.background_telemetry
@@ -1469,12 +1536,19 @@ def run_scan_request(
         movables: list = []
         targets: list[str] = []
         value_lists: list[list[float]] = []
-        for (device, variable, kind, confirm), axis in zip(axis_resolved, request.axes):
-            movable = build_movable(session, device, variable, kind, confirm)
+        for target, axis in zip(axis_resolved, request.axes):
+            movable = build_movable(session, target)
             created.append(movable)
             movables.append(movable)
-            targets.append(f"{device}:{variable}")
+            targets.append(target.label)
             value_lists.append(axis.positions.to_values())
+        pseudo_meta = {
+            target.variable_name: target.metadata()
+            for target in axis_resolved
+            if isinstance(target, PseudoMovableTarget)
+        }
+        if pseudo_meta:
+            md["pseudo_variables"] = pseudo_meta
 
         scan_info["scan_mode"] = "standard"
         scan_info["scan_parameter"] = ",".join(targets)
@@ -1664,14 +1738,17 @@ def _run_optimize_request(
         created.extend(detectors)
 
         variables: dict[str, Any] = {}
+        pseudo_meta: dict[str, Any] = {}
         for name in spec.variables:
             if ":" in name:
                 device, _, variable = name.partition(":")
                 movable = session.settable(device, variable)
             else:
                 var_spec = resolver.resolve_scan_variable(name)
-                device, variable, kind, confirm = resolve_movable_target(var_spec, name)
-                movable = build_movable(session, device, variable, kind, confirm)
+                target = resolve_movable_target(var_spec, name)
+                if isinstance(target, PseudoMovableTarget):
+                    pseudo_meta[target.variable_name] = target.metadata()
+                movable = build_movable(session, target)
             variables[name] = movable
             created.append(movable)
 
@@ -1679,6 +1756,8 @@ def _run_optimize_request(
             return None
 
         md: dict[str, Any] = {"scan_request_mode": request.mode.value}
+        if pseudo_meta:
+            md["pseudo_variables"] = pseudo_meta
         if request.save_sets:
             # Provenance: which named save sets were unioned for this scan.
             md["save_sets"] = list(request.save_sets)

--- a/GeecsBluesky/geecs_bluesky/session.py
+++ b/GeecsBluesky/geecs_bluesky/session.py
@@ -44,11 +44,13 @@ from geecs_bluesky.devices.ca import (
     CaConfirmSettable,
     CaGenericDetector,
     CaMotor,
+    CaPseudoMovable,
     CaSettable,
     CaSnapshotReadable,
     CaTelemetryReadable,
     CaTimestampedReadable,
 )
+from geecs_bluesky.forward_expr import CompiledForward
 from geecs_bluesky.models.shot_control import ShotControlConfig, ShotControlWrites
 from geecs_bluesky.optimize import BinData, Suggester
 from geecs_bluesky.plans.optimize import geecs_adaptive_scan
@@ -251,6 +253,16 @@ class GeecsSession:
         for name, value in targets.items():
             movable = variables.get(name)
             if movable is None:
+                continue
+            if not np.isfinite(float(value)):
+                # An absolute pseudo variable reads NaN before its first set
+                # (position unknown without an inverse) — never command a
+                # non-finite value to hardware.
+                logger.warning(
+                    "not moving %s: target %r is not finite (initial position unknown)",
+                    name,
+                    value,
+                )
                 continue
 
             async def _move(m=movable, v=float(value)) -> None:
@@ -491,6 +503,31 @@ class GeecsSession:
                 name=name or safe_name(f"{device}_{variable}"),
                 tolerance=tolerance,
                 timeout=timeout,
+            )
+        )
+
+    def pseudo_movable(
+        self,
+        variable_name: str,
+        components: Sequence[tuple[str, str, CompiledForward]],
+        mode: str,
+        *,
+        name: str | None = None,
+    ) -> CaPseudoMovable:
+        """Pseudo (composite) movable: one number fanned out to many targets.
+
+        ``components`` are ``(device, variable, compiled_forward)`` triples
+        (see :func:`geecs_bluesky.forward_expr.compile_forward`); ``mode`` is
+        the schema's ``absolute``/``relative``. See
+        :class:`~geecs_bluesky.devices.ca.pseudo.CaPseudoMovable`.
+        """
+        return self._connect(
+            CaPseudoMovable(
+                components,
+                mode,
+                variable_name=variable_name,
+                experiment=self.experiment,
+                name=name or safe_name(variable_name),
             )
         )
 

--- a/GeecsBluesky/pyproject.toml
+++ b/GeecsBluesky/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-bluesky"
-version = "0.46.1"
+version = "0.47.0"
 description = "Bluesky / ophyd-async bridge for the GEECS control system"
 authors = ["Sam Barber <sbarber@lbl.gov>"]
 readme = "README.md"

--- a/GeecsBluesky/tests/test_bluesky_scanner_scan_request_seam.py
+++ b/GeecsBluesky/tests/test_bluesky_scanner_scan_request_seam.py
@@ -528,8 +528,9 @@ def test_unknown_trigger_variant_fails_at_reinitialize() -> None:
         )
 
 
-def test_pseudo_scan_variable_fails_at_reinitialize() -> None:
-    """A pseudo (composite) variable is refused at reinitialize, not in the thread."""
+def test_pseudo_scan_variable_validates_at_reinitialize() -> None:
+    """A pseudo (composite) variable now passes reinitialize validation; a
+    bad forward formula is still refused there, not in the thread."""
     pseudo = PseudoScanVariable(
         kind="pseudo",
         targets=[{"target": "U_X:Pos", "forward": "composite_var"}],
@@ -540,8 +541,15 @@ def test_pseudo_scan_variable_fails_at_reinitialize() -> None:
         mode="step",
         axes=[{"variable": "combo", "positions": {"values": [0.0, 1.0]}}],
     )
-    with pytest.raises(NotImplementedError, match="pseudo"):
-        scanner.reinitialize(request, resolver=_resolver(variables={"combo": pseudo}))
+    scanner.reinitialize(request, resolver=_resolver(variables={"combo": pseudo}))
+
+    bad = PseudoScanVariable(
+        kind="pseudo",
+        targets=[{"target": "U_X:Pos", "forward": "import_os()"}],
+        mode="absolute",
+    )
+    with pytest.raises(GeecsConfigurationError, match="import_os"):
+        scanner.reinitialize(request, resolver=_resolver(variables={"combo": bad}))
 
 
 def test_defaults_not_applied_twice(monkeypatch) -> None:
@@ -1026,7 +1034,8 @@ def test_optimize_unknown_variable_fails_at_reinitialize() -> None:
         scanner.reinitialize(_optimize_request(), resolver=_resolver())
 
 
-def test_optimize_pseudo_variable_fails_at_reinitialize() -> None:
+def test_optimize_pseudo_variable_validates_at_reinitialize() -> None:
+    """An optimize VOCS catalog name resolving to a pseudo variable is valid."""
     pseudo = PseudoScanVariable(
         kind="pseudo",
         targets=[{"target": "U_X:Pos", "forward": "composite_var"}],
@@ -1034,10 +1043,9 @@ def test_optimize_pseudo_variable_fails_at_reinitialize() -> None:
     )
     scanner = _make_scanner(_FakeSession())
     scanner._optimization_loader = _FakeOptimizationLoader()
-    with pytest.raises(NotImplementedError, match="pseudo"):
-        scanner.reinitialize(
-            _optimize_request(), resolver=_resolver(variables={"jet_z": pseudo})
-        )
+    scanner.reinitialize(
+        _optimize_request(), resolver=_resolver(variables={"jet_z": pseudo})
+    )
 
 
 def test_optimize_request_without_loader_refused_at_reinitialize() -> None:

--- a/GeecsBluesky/tests/test_forward_expr.py
+++ b/GeecsBluesky/tests/test_forward_expr.py
@@ -1,0 +1,90 @@
+"""forward_expr: the AST-whitelist compiler for pseudo forward formulas.
+
+Pins two things: (1) every expression shape in the legacy
+``composite_variables.yaml`` corpus evaluates to the value the legacy
+numexpr path produced, and (2) anything outside the whitelist — unknown
+names, attribute access, calls to non-whitelisted functions, non-numeric
+literals — is refused at compile time with a clear error, never evaluated.
+"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from geecs_bluesky.exceptions import GeecsConfigurationError
+from geecs_bluesky.forward_expr import compile_forward
+
+# ---------------------------------------------------------------------------
+# The full production corpus (Undulator + Thomson), expression → (input, expected)
+# ---------------------------------------------------------------------------
+
+CORPUS = [
+    ("composite_var * 1", 2.5, 2.5),
+    ("composite_var * -2", 1.5, -3.0),
+    ("composite_var * -1", 0.7, -0.7),
+    ("composite_var", 41000.0, 41000.0),
+    ("(composite_var-41000) * 14/1000 - 20", 42000.0, -6.0),
+    ("composite_var * 1.0", 3.0, 3.0),
+    ("composite_var * -1.5", 2.0, -3.0),
+    ("(composite_var)*8", 0.5, 4.0),
+    ("-(composite_var + 0.2411) * 9", -0.2411, 0.0),
+    ("-(composite_var)*9.0", 1.0, -9.0),
+    ("8.5 + (composite_var-10)*2.5", 10.0, 8.5),
+    ("composite_var * 1.5", 2.0, 3.0),
+    ("sqrt(100 ** 2 * composite_var / 560968.636)", 560968.636, 100.0),
+    ("100 - composite_var", 30.0, 70.0),
+]
+
+
+@pytest.mark.parametrize(("expression", "value", "expected"), CORPUS)
+def test_corpus_expression_evaluates(expression, value, expected) -> None:
+    compiled = compile_forward(expression)
+    assert compiled(value) == pytest.approx(expected)
+    assert compiled.source == expression
+
+
+def test_x_alias_matches_composite_var() -> None:
+    """``x`` and ``composite_var`` are the same scanned value."""
+    assert compile_forward("x * -2")(1.5) == compile_forward("composite_var * -2")(1.5)
+
+
+def test_constants_and_functions() -> None:
+    assert compile_forward("sin(pi / 2)")(0.0) == pytest.approx(1.0)
+    assert compile_forward("log(e)")(0.0) == pytest.approx(1.0)
+    assert compile_forward("abs(x)")(-3.0) == 3.0
+
+
+@pytest.mark.parametrize(
+    "expression",
+    [
+        "unknown_name * 2",  # name outside the whitelist
+        "__import__('os')",  # smuggled call
+        "x.__class__",  # attribute access
+        "x[0]",  # subscript
+        "'text' + x",  # non-numeric literal
+        "lambda v: v",  # disallowed syntax
+        "open('f')",  # non-whitelisted function
+        "sqrt(x, foo=1)",  # keyword arguments
+        "x +",  # syntax error
+    ],
+)
+def test_disallowed_expression_refused_at_compile(expression) -> None:
+    with pytest.raises(GeecsConfigurationError, match="forward expression"):
+        compile_forward(expression)
+
+
+def test_runtime_domain_error_is_configuration_error() -> None:
+    """A math-domain failure at set time surfaces clearly, not as ValueError."""
+    compiled = compile_forward("sqrt(x)")
+    assert compiled(4.0) == 2.0
+    with pytest.raises(GeecsConfigurationError, match="sqrt"):
+        compiled(-1.0)
+
+
+def test_result_is_float() -> None:
+    result = compile_forward("x // 2")(5.0)
+    assert isinstance(result, float)
+    assert result == 2.0
+    assert math.isfinite(result)

--- a/GeecsBluesky/tests/test_forward_expr.py
+++ b/GeecsBluesky/tests/test_forward_expr.py
@@ -83,6 +83,20 @@ def test_runtime_domain_error_is_configuration_error() -> None:
         compiled(-1.0)
 
 
+def test_complex_and_overflow_results_are_configuration_errors() -> None:
+    """Every runtime failure class is wrapped — none escape as raw errors.
+
+    ``x ** 0.5`` at negative x returns *complex* (the natural typo for
+    ``sqrt(x)`` scanned into negative values) and an int-constant power can
+    overflow the float conversion; both must surface as the same clear
+    configuration error the sqrt case does (review finding, PR #594).
+    """
+    with pytest.raises(GeecsConfigurationError, match="failed at"):
+        compile_forward("x ** 0.5")(-1.0)
+    with pytest.raises(GeecsConfigurationError, match="failed at"):
+        compile_forward("10 ** 400")(0.0)
+
+
 def test_result_is_float() -> None:
     result = compile_forward("x // 2")(5.0)
     assert isinstance(result, float)

--- a/GeecsBluesky/tests/test_optimize.py
+++ b/GeecsBluesky/tests/test_optimize.py
@@ -241,6 +241,38 @@ def test_move_movables_uses_movable_set_not_raw_setpoint(caplog) -> None:
     assert warnings[0].exc_info is not None
 
 
+def test_move_movables_never_commands_a_non_finite_target(caplog) -> None:
+    """A NaN target (an absolute pseudo read before its first set) is skipped.
+
+    ``on_finish`` restore reads each movable's initial value; an absolute
+    :class:`CaPseudoMovable` reads NaN until its first set (position unknown
+    without an inverse).  Commanding NaN to hardware must never happen —
+    the move is skipped with a warning instead.
+    """
+    from ophyd_async.core import AsyncStatus
+
+    s = GeecsSession("Test", tiled=False, mock=True)
+
+    class _Recorder:
+        def __init__(self):
+            self.set_called_with: list[float] = []
+
+        def set(self, value: float) -> AsyncStatus:
+            self.set_called_with.append(value)
+
+            async def _ok():
+                return None
+
+            return AsyncStatus(_ok())
+
+    movable = _Recorder()
+    with caplog.at_level(logging.WARNING):
+        s._move_movables({"combo": movable}, {"combo": float("nan")})
+
+    assert movable.set_called_with == []
+    assert any("not finite" in r.getMessage() for r in caplog.records)
+
+
 def test_adaptive_scan_checkpoints_per_iteration_and_row() -> None:
     """Optimize scans carry the same deferred-pause checkpoints (issue #552).
 

--- a/GeecsBluesky/tests/test_pseudo_movable.py
+++ b/GeecsBluesky/tests/test_pseudo_movable.py
@@ -1,0 +1,131 @@
+"""CaPseudoMovable: fan-out, relative baselines, and the recorded column.
+
+Mock-backend tests (no gateway): each target's ``:SP`` put is journaled via
+``callback_on_mock_put``, target readbacks are primed with
+``set_mock_value``, and moves are driven through a real RunEngine so the
+device is exercised exactly as the step plan uses it (stage → mv → unstage).
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import bluesky.plan_stubs as bps
+import pytest
+from bluesky import RunEngine
+
+from geecs_bluesky.forward_expr import compile_forward
+
+pytest.importorskip("aioca")
+
+from ophyd_async.core import callback_on_mock_put, set_mock_value  # noqa: E402
+
+from geecs_bluesky.devices.ca import CaPseudoMovable  # noqa: E402
+from tests.ca_mock_helpers import connect_mock  # noqa: E402
+
+
+def _bump_x(run_engine: RunEngine, mode: str) -> tuple[CaPseudoMovable, list]:
+    """The corpus steering bump (S3H follows x, S4H counters at -2x),
+    mock-connected with both target ``:SP`` puts journaled."""
+    device = CaPseudoMovable(
+        [
+            ("U_S3H", "Current", compile_forward("x * 1")),
+            ("U_S4H", "Current", compile_forward("x * -2")),
+        ],
+        mode,
+        variable_name="bump_x",
+        name="bump_x",
+    )
+    connect_mock(run_engine, device)
+    journal: list = []
+    callback_on_mock_put(
+        device._setpoint_0, lambda value, **kw: journal.append(("U_S3H", value))
+    )
+    callback_on_mock_put(
+        device._setpoint_1, lambda value, **kw: journal.append(("U_S4H", value))
+    )
+    return device, journal
+
+
+def _read(run_engine: RunEngine, device: CaPseudoMovable) -> dict:
+    return asyncio.run_coroutine_threadsafe(device.read(), run_engine._loop).result(
+        timeout=10.0
+    )
+
+
+def test_absolute_fan_out_and_recorded_column() -> None:
+    RE = RunEngine()
+    device, journal = _bump_x(RE, "absolute")
+
+    RE(bps.mv(device, 1.5))
+
+    assert sorted(journal) == [("U_S3H", 1.5), ("U_S4H", -3.0)]
+    reading = _read(RE, device)
+    assert reading["bump_x-readback"]["value"] == 1.5
+    assert device._column_headers == {"bump_x-readback": "bump_x"}
+
+
+def test_relative_offsets_from_staged_baselines() -> None:
+    RE = RunEngine()
+    device, journal = _bump_x(RE, "relative")
+    set_mock_value(device._target_readback_0, 3.0)
+    set_mock_value(device._target_readback_1, 10.0)
+
+    def plan():
+        yield from bps.stage(device)
+        yield from bps.mv(device, 0.5)
+        yield from bps.unstage(device)
+
+    RE(plan())
+
+    # baseline + forward(x): 3.0 + 0.5 and 10.0 - 1.0
+    assert sorted(journal) == [("U_S3H", 3.5), ("U_S4H", 9.0)]
+
+    # unstage dropped the baselines; a new stage re-captures fresh ones.
+    journal.clear()
+    set_mock_value(device._target_readback_0, 100.0)
+
+    def plan2():
+        yield from bps.stage(device)
+        yield from bps.mv(device, 0.5)
+        yield from bps.unstage(device)
+
+    RE(plan2())
+    assert sorted(journal) == [("U_S3H", 100.5), ("U_S4H", 9.0)]
+
+
+def test_relative_lazy_baseline_without_stage() -> None:
+    """Unstaged callers (the optimize path) capture baselines on first set."""
+    RE = RunEngine()
+    device, journal = _bump_x(RE, "relative")
+    set_mock_value(device._target_readback_0, 1.0)
+    set_mock_value(device._target_readback_1, 2.0)
+
+    RE(bps.mv(device, 1.0))
+    RE(bps.mv(device, 2.0))
+
+    # Baseline captured once (at the first set), not re-read per set.
+    assert sorted(journal[:2]) == [("U_S3H", 2.0), ("U_S4H", 0.0)]
+    assert sorted(journal[2:]) == [("U_S3H", 3.0), ("U_S4H", -2.0)]
+
+
+def test_initial_readback_is_zero_for_relative_nan_for_absolute() -> None:
+    """Relative starts at 0 (zero offset by definition — optimize on_finish
+    restore relies on set(0) restoring the baselines); absolute starts NaN
+    (position unknown without an inverse — never restored blindly)."""
+    import math
+
+    RE = RunEngine()
+    relative, _ = _bump_x(RE, "relative")
+    absolute, _ = _bump_x(RE, "absolute")
+    assert _read(RE, relative)["bump_x-readback"]["value"] == 0.0
+    assert math.isnan(_read(RE, absolute)["bump_x-readback"]["value"])
+
+
+def test_bad_mode_rejected() -> None:
+    with pytest.raises(ValueError, match="mode"):
+        CaPseudoMovable(
+            [("U_S1H", "Current", compile_forward("x"))],
+            "sideways",
+            variable_name="oops",
+        )

--- a/GeecsBluesky/tests/test_scan_request_runner.py
+++ b/GeecsBluesky/tests/test_scan_request_runner.py
@@ -95,6 +95,7 @@ class _FakeSession:
         self.disconnected: list = []
         self.action_factories: list[_FakeActionFactory] = []
         self.confirm_settable_calls: list = []
+        self.pseudo_calls: list = []
 
     def _make(self, device: str, kind: str) -> _FakeDevice:
         self.devices.append((device, kind))
@@ -122,6 +123,12 @@ class _FakeSession:
             (device, variable, confirm_device, confirm_variable)
         )
         return self._make(f"{device}:{variable}", "confirm_settable")
+
+    def pseudo_movable(self, variable_name, components, mode, *, name=None):
+        self.pseudo_calls.append(
+            (variable_name, [(d, v, f.source) for d, v, f in components], mode)
+        )
+        return self._make(f"pseudo:{variable_name}", "pseudo_movable")
 
     def action_signal_factory(self):
         factory = _FakeActionFactory()
@@ -249,6 +256,17 @@ variables:
     mode: absolute
     targets:
       - {target: "U_S1H:Current", forward: "composite_var * 2"}
+  bump_x:
+    kind: pseudo
+    mode: relative
+    targets:
+      - {target: "U_S3H:Current", forward: "x * 1"}
+      - {target: "U_S4H:Current", forward: "x * -2"}
+  badcombo:
+    kind: pseudo
+    mode: absolute
+    targets:
+      - {target: "U_S1H:Current", forward: "nonsense_name * 2"}
 """
 
 LEGACY_ACTIONS = """\
@@ -805,14 +823,47 @@ def test_unknown_action_name_fails_validation_first(legacy_resolver) -> None:
     assert session.devices == []  # failed before any hardware was touched
 
 
-def test_pseudo_variable_raises_not_implemented(modern_resolver) -> None:
+def test_pseudo_variable_builds_movable_and_records_metadata(modern_resolver) -> None:
+    """A pseudo step axis executes: compiled components, movable, provenance."""
+    session = _FakeSession()
     request = _noscan_request(
         mode="step",
         save_sets=["NewSet"],
-        axes=[{"variable": "combo", "positions": {"start": 0, "end": 1, "step": 1}}],
+        axes=[{"variable": "bump_x", "positions": {"start": 0, "end": 1, "step": 1}}],
     )
-    with pytest.raises(NotImplementedError, match="pseudo"):
-        run_scan_request(_FakeSession(), request, modern_resolver)
+    run_scan_request(session, request, modern_resolver)
+    assert session.pseudo_calls == [
+        (
+            "bump_x",
+            [("U_S3H", "Current", "x * 1"), ("U_S4H", "Current", "x * -2")],
+            "relative",
+        )
+    ]
+    kwargs = session.scan_kwargs
+    assert kwargs["motor"].kind == "pseudo_movable"
+    assert kwargs["scan_info"]["scan_parameter"] == "bump_x"
+    assert kwargs["md"]["pseudo_variables"] == {
+        "bump_x": {
+            "mode": "relative",
+            "targets": [
+                {"target": "U_S3H:Current", "forward": "x * 1"},
+                {"target": "U_S4H:Current", "forward": "x * -2"},
+            ],
+        }
+    }
+
+
+def test_pseudo_variable_bad_expression_fails_preclaim(modern_resolver) -> None:
+    """A forward formula that fails to compile aborts before any hardware."""
+    session = _FakeSession()
+    request = _noscan_request(
+        mode="step",
+        save_sets=["NewSet"],
+        axes=[{"variable": "badcombo", "positions": {"start": 0, "end": 1, "step": 1}}],
+    )
+    with pytest.raises(GeecsConfigurationError, match="nonsense_name"):
+        run_scan_request(session, request, modern_resolver)
+    assert session.devices == []  # failed before any hardware was touched
 
 
 def test_noscan_without_save_set_is_rejected(legacy_resolver) -> None:

--- a/GeecsBluesky/tests/test_validate_scan_request.py
+++ b/GeecsBluesky/tests/test_validate_scan_request.py
@@ -180,17 +180,32 @@ def test_unresolvable_step_axis_refused() -> None:
         validate_scan_request(request, _resolver())
 
 
-def test_pseudo_step_axis_refused() -> None:
+def test_pseudo_step_axis_validates() -> None:
+    """A pseudo axis with a compilable forward passes validation."""
     pseudo = PseudoScanVariable(
         kind="pseudo",
-        targets=[{"target": "U_X:Pos", "forward": "combo"}],
+        targets=[{"target": "U_X:Pos", "forward": "composite_var * 2"}],
         mode="absolute",
     )
     request = _request(
         mode="step",
         axes=[{"variable": "combo", "positions": {"values": [0.0, 1.0]}}],
     )
-    with pytest.raises(NotImplementedError, match="pseudo"):
+    validate_scan_request(request, _resolver(variables={"combo": pseudo}))
+
+
+def test_pseudo_step_axis_bad_forward_refused() -> None:
+    """A forward formula outside the expression whitelist fails validation."""
+    pseudo = PseudoScanVariable(
+        kind="pseudo",
+        targets=[{"target": "U_X:Pos", "forward": "combo"}],  # unknown name
+        mode="absolute",
+    )
+    request = _request(
+        mode="step",
+        axes=[{"variable": "combo", "positions": {"values": [0.0, 1.0]}}],
+    )
+    with pytest.raises(GeecsConfigurationError, match="combo"):
         validate_scan_request(request, _resolver(variables={"combo": pseudo}))
 
 

--- a/docs/geecs_schemas/schema_reference.md
+++ b/docs/geecs_schemas/schema_reference.md
@@ -239,7 +239,7 @@ One device a pseudo variable moves, and the formula for its value.
 | Field | Type | Required | Default | What it does |
 |---|---|---|---|---|
 | `target` | `str` | yes | — | The device variable to move, written as 'Device:Variable', e.g. 'U_S1H:Current'. |
-| `forward` | `str` | yes | — | Formula for this device's value in terms of the scanned number, written with 'composite_var' as the scanned value — e.g. 'composite_var * -2' or '8.5 + (composite_var-10)*2.5'. |
+| `forward` | `str` | yes | — | Formula for this device's value in terms of the scanned number: plain arithmetic with 'composite_var' (or its short alias 'x') as the scanned value — e.g. 'composite_var * -2', 'x * -2', or '8.5 + (composite_var-10)*2.5'. |
 
 ## `trigger_profile`
 

--- a/docs/geecs_schemas/schemas_overview.md
+++ b/docs/geecs_schemas/schemas_overview.md
@@ -166,9 +166,11 @@ closeout plans run once at the end — in the reverse order, and even if the
 scan was aborted partway. If the request lists several axes, the scan
 visits every combination as a grid — the first axis is the slow outer loop —
 taking the usual batch of shots at each grid point and recording every
-axis's position in every data row. Anything the engine can't execute yet —
-a pseudo (composite) scan variable, for example — is refused up front with
-a clear "not yet" message rather than attempted halfway.
+axis's position in every data row. A pseudo (composite) scan variable —
+one scanned number moving several devices through per-target formulas —
+scans like any other axis. Anything the engine can't execute yet — an
+`all_scalars` save-set entry, for example — is refused up front with a
+clear "not yet" message rather than attempted halfway.
 
 ## Two habits worth knowing
 


### PR DESCRIPTION
## What & why

Pseudo (composite) scan variables — the legacy scanner's relative steering-bump / absolute-manifold (R56) capability — now **execute** on the Bluesky/ScanRequest path, closing the last big "validated, then refused" v1 gap. Design decisions confirmed with the owner before building: AST-whitelist evaluator (no numexpr dependency, full math freedom kept), `composite_var` + short alias `x` both accepted, setpoint-only completion per component in v1 (legacy `ScanDevice` parity), and optimize-mode pseudo axes included.

### The pieces (GeecsBluesky 0.47.0, minor)

- **`forward_expr.py` (new, 132 LOC)** — `compile_forward`: parses a `forward` formula with `ast`, validates every node against an explicit whitelist (arithmetic operators, parentheses, `sqrt`/trig/`exp`/`log`/`abs`, constants `pi`/`e`, the scanned value as `composite_var` or `x`) **before** anything is evaluated, then returns a `float -> float` callable carrying its source. Anything else — unknown names, attribute access, subscripts, smuggled calls — is `GeecsConfigurationError` at compile time. All 14 production corpus expressions (Undulator + Thomson `composite_variables.yaml`) are pinned expression-by-expression.
- **`devices/ca/pseudo.py` (new, ~170 LOC)** — `CaPseudoMovable`: `set(u)` evaluates each component's formula and puts every target's gateway `:SP` **concurrently** through the shared `GatewaySetpointPut` primitive — each put rides GEECS's native blocking set, so the move completes when the slowest target's exe response lands (identical completion semantics to `CaSettable`, per component). `absolute` = formula value; `relative` = offset from per-target baselines captured once per run at `stage()` (lazily on first `set()` for unstaged callers — the optimize path) and dropped at `unstage()`. The recorded event-row column is the demanded pseudo value (soft readback; header = the catalog friendly name).
- **Runner wiring (~90 LOC changed)** — `resolve_movable_target` now returns a typed `PlainMovableTarget | PseudoMovableTarget` union (formulas compiled fail-fast pre-claim — a bad expression can never burn a scan number) and `build_movable` dispatches to the new `GeecsSession.pseudo_movable` factory. Both call sites — step/grid axes and optimize movables — flow through it, so grids and Xopt optimization over pseudo axes work with no extra code. Provenance (mode + per-target forward sources) lands in run metadata under `pseudo_variables`.
- **Safety hardening found during integration**: optimize `on_finish` restore reads each movable's initial value — an *absolute* pseudo reads `NaN` before its first set (no inverse). Two guards: a relative pseudo's initial readback is `0.0` (zero offset is true by definition, and `set(0)` restores the baselines for the corpus's pure-offset formulas), and `_move_movables` now refuses to command any non-finite value to hardware (warning + skip). Both pinned by tests.

### GEECS-Schemas 0.8.2 (patch, docs-only)

`scan_variables.py` descriptions synced: the expression language is documented as plain arithmetic with `composite_var` **or `x`** (every legacy numexpr-era `relation` string valid unchanged); `docs/geecs_schemas/schema_reference.md` + goldens regenerated (2-line diff). No schema shape change.

### Judgment calls (cheap to veto)

- The `x` alias is engine + docs only — no converter rewrite, corpus untouched.
- `PseudoScanVariable.inverse` stays declared-but-unconsumed (as before).
- Relative baselines are logged at INFO but not written into the start doc (they're captured at stage time, post-claim; target readbacks in the save set record the same information per row).

## Per-concern LOC breakdown

| Concern | Files | LOC |
|---|---|---|
| Expression compiler + tests | forward_expr.py, test_forward_expr.py | +132 / +93 |
| Pseudo device + tests | devices/ca/pseudo.py, test_pseudo_movable.py | +173 / +135 |
| Runner/session wiring | scan_request_runner.py, session.py, ca/__init__.py | ~+150 / −40 |
| Flipped/extended pins | 4 existing test files | ~+120 / −30 |
| Docs/versioning | CLAUDE.md, CHANGELOGs, pyprojects, schema docstrings + regenerated reference | ~+110 |

## Tests

`./scripts/check.sh` (scoped, the way CI runs them): lint green, **GEECS-Schemas 211 passed / 7 deselected**, **GeecsBluesky 616 passed / 3 deselected** (suite grew from 614 on dev... from 581 pre-0.46.1 baseline; +33 net new here). The four former refusal pins (runner, validate, bridge seam step + optimize) flipped to execution/validation pins.

Note: GEECS-Schemas' corpus-integration tests fail on machines where the GEECS-Plugins-Configs checkout is reachable, due to **pre-existing** corpus drift (a new-schema `Amp4Out-copy.yaml` in the legacy folder trips the blind legacy-convert). Unrelated to this PR; spun off as its own task.

## Hardware verification

**OWED** — this PR is hermetically tested only (mock CA backends). Live checks wanted before relying on it operationally, expected numbers from the corpus:

1. **Relative bump**: scan `ALine_e_beam_position_offset_x` over ±0.1; expect `U_S3H:Current` to move +x and `U_S4H:Current` −x from their pre-scan currents, both restored at x=0; baselines in scan.log at INFO.
2. **Absolute manifold**: scan `R56_at_100MeV` (small values); expect `U_ChicaneInner/Outer:Current` = ±sqrt(100² · x / 560968.636).
3. **Event rows**: the pseudo column records the demanded x; `pseudo_variables` present in the Tiled start doc.
4. **Optimize smoke** (optional): a pseudo axis in a VOCS runs and on_finish=initial restores (relative → set(0)).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
