### PR TITLE
GEECS-Schemas 0.9.0 + GeecsCAGateway 0.14.3 + GeecsBluesky 0.47.1: one shared AST-whitelist expression core

### DIFF
--- a/GEECS-Schemas/CHANGELOG.md
+++ b/GEECS-Schemas/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable changes to GEECS-Schemas are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.0] - 2026-07-21
+
+### Added
+
+- `restricted_expr.py` — the shared AST-whitelist expression core behind
+  both GEECS eval sites (the gateway's derived channels and the engine's
+  pseudo-variable forward formulas): `compile_expression` parses with
+  `ast`, validates every node against a consumer-supplied
+  `ExpressionWhitelist` (functions, constants, operator sets, optional
+  bool/compare ops) **before** anything is evaluated, and returns a
+  frozen `CompiledExpression` whose `evaluate()` runs with empty
+  builtins and returns the raw result (`is_boolean` flags top-level
+  boolean intent for consumers that publish floats).  Stdlib-only
+  (`ast` + `dataclasses`) per this package's import-from-anywhere rule;
+  each consumer keeps its own whitelist, error wrapping, and result
+  coercion.  Extracted from `geecs_ca_gateway.derived.ExpressionEvaluator`
+  and `geecs_bluesky.forward_expr` so a hardening or semantics fix lands
+  once instead of twice; both consumers' behaviors stay pinned by their
+  existing test suites.
+
 ## [0.8.2] - 2026-07-21
 
 ### Changed

--- a/GEECS-Schemas/README.md
+++ b/GEECS-Schemas/README.md
@@ -70,6 +70,11 @@ fields are kept for a possible future re-enable),
 `TriggerVariant` / `TriggerState`, `DefaultActions`, and the four action
 step types.
 
+One non-model module: `geecs_schemas.restricted_expr` — the shared
+AST-whitelist core behind both GEECS expression eval sites (the gateway's
+derived channels and the engine's pseudo-variable forward formulas).
+Stdlib-only; each consumer supplies its whitelist and error wrapping.
+
 ## Converter usage
 
 Converters take a parsed dict or a YAML path (path input needs PyYAML, which

--- a/GEECS-Schemas/geecs_schemas/restricted_expr.py
+++ b/GEECS-Schemas/geecs_schemas/restricted_expr.py
@@ -1,0 +1,188 @@
+"""Shared AST-whitelist core for restricted math expressions.
+
+Two GEECS eval sites compile small operator-authored math expressions —
+the gateway's derived channels (``geecs_ca_gateway.derived``) and the
+engine's pseudo-variable forward formulas (``geecs_bluesky.forward_expr``).
+Both follow the same security-sensitive skeleton: parse with :mod:`ast`,
+validate every node against an explicit whitelist **before** anything is
+evaluated (so a config cannot smuggle attribute access, imports,
+subscripts, or arbitrary names), then evaluate the compiled code with an
+empty ``__builtins__``.  This module is that skeleton, factored out once
+so a hardening or semantics fix lands in one place.
+
+Each consumer supplies its own :class:`ExpressionWhitelist` (functions,
+constants, operator sets) and the set of symbol names its expressions may
+reference, and wraps :class:`ExpressionWhitelistError` into its own error
+contract.  The core stays stdlib-only (``ast`` + ``dataclasses``) and
+imposes no result coercion: :meth:`CompiledExpression.evaluate` returns
+the raw value, and runtime failures (domain errors, overflow, division by
+zero) propagate for the consumer to translate.
+"""
+
+from __future__ import annotations
+
+import ast
+from collections.abc import Callable, Mapping
+from collections.abc import Set as AbstractSet
+from dataclasses import dataclass, field
+from types import CodeType
+from typing import Any
+
+
+class ExpressionWhitelistError(ValueError):
+    """Raised when an expression falls outside the supported subset.
+
+    Covers both syntax errors and whitelist violations; the message names
+    the offending construct.  Consumers wrap this into their own error
+    type (``DerivedExpressionError``, ``GeecsConfigurationError``, ...).
+    """
+
+
+@dataclass(frozen=True)
+class ExpressionWhitelist:
+    """The constructs one eval site permits in its expressions.
+
+    Attributes
+    ----------
+    functions : Mapping[str, Callable]
+        Callables an expression may invoke, by name.
+    constants : Mapping[str, float]
+        Bare names an expression may reference besides the symbols.
+    binary_ops, unary_ops : tuple of ast operator types
+        Permitted arithmetic operators.
+    bool_ops, compare_ops : tuple of ast operator types
+        Permitted boolean/comparison operators; empty (the default)
+        refuses those node shapes entirely.
+    """
+
+    functions: Mapping[str, Callable[..., float]]
+    constants: Mapping[str, float]
+    binary_ops: tuple[type[ast.operator], ...]
+    unary_ops: tuple[type[ast.unaryop], ...]
+    bool_ops: tuple[type[ast.boolop], ...] = ()
+    compare_ops: tuple[type[ast.cmpop], ...] = ()
+
+
+def _is_boolean_expression(node: ast.AST) -> bool:
+    """Return whether the expression's top-level result is boolean intent."""
+    return isinstance(node, (ast.BoolOp, ast.Compare)) or (
+        isinstance(node, ast.UnaryOp) and isinstance(node.op, ast.Not)
+    )
+
+
+def _validate(
+    node: ast.AST, symbols: AbstractSet[str], whitelist: ExpressionWhitelist
+) -> None:
+    """Recursively whitelist-check one AST node (raises on anything else)."""
+    if isinstance(node, ast.Expression):
+        _validate(node.body, symbols, whitelist)
+    elif isinstance(node, ast.BinOp) and isinstance(node.op, whitelist.binary_ops):
+        _validate(node.left, symbols, whitelist)
+        _validate(node.right, symbols, whitelist)
+    elif isinstance(node, ast.UnaryOp) and isinstance(node.op, whitelist.unary_ops):
+        _validate(node.operand, symbols, whitelist)
+    elif isinstance(node, ast.BoolOp) and isinstance(node.op, whitelist.bool_ops):
+        for value in node.values:
+            _validate(value, symbols, whitelist)
+    elif isinstance(node, ast.Compare) and all(
+        isinstance(op, whitelist.compare_ops) for op in node.ops
+    ):
+        _validate(node.left, symbols, whitelist)
+        for comparator in node.comparators:
+            _validate(comparator, symbols, whitelist)
+    elif isinstance(node, ast.Constant):
+        if not isinstance(node.value, (int, float)):
+            raise ExpressionWhitelistError(f"literal {node.value!r} is not a number")
+    elif isinstance(node, ast.Name):
+        if node.id not in symbols and node.id not in whitelist.constants:
+            raise ExpressionWhitelistError(f"unknown name {node.id!r}")
+    elif isinstance(node, ast.Call):
+        if (
+            not isinstance(node.func, ast.Name)
+            or node.func.id not in whitelist.functions
+        ):
+            raise ExpressionWhitelistError(
+                "only whitelisted function calls are allowed"
+            )
+        if node.keywords:
+            raise ExpressionWhitelistError("keyword arguments are not allowed")
+        for arg in node.args:
+            _validate(arg, symbols, whitelist)
+    else:
+        raise ExpressionWhitelistError(f"disallowed syntax ({type(node).__name__})")
+
+
+@dataclass(frozen=True)
+class CompiledExpression:
+    """A validated, compiled expression ready for restricted evaluation.
+
+    Attributes
+    ----------
+    source : str
+        The original expression text.
+    is_boolean : bool
+        Whether the top-level node is boolean intent (a comparison,
+        ``and``/``or``, or ``not``) — consumers that publish floats use
+        this to coerce ``True``/``False`` to ``1.0``/``0.0``.
+    """
+
+    source: str
+    is_boolean: bool
+    _code: CodeType = field(repr=False)
+    _whitelist: ExpressionWhitelist = field(repr=False)
+
+    def evaluate(self, values: Mapping[str, Any]) -> Any:
+        """Evaluate with *values* bound to the symbol names; return the raw result.
+
+        The namespace is functions, then constants, then *values* — so a
+        symbol deliberately shadows a same-named constant or function.
+        Runtime failures propagate unwrapped.
+        """
+        namespace: dict[str, Any] = {}
+        namespace.update(self._whitelist.functions)
+        namespace.update(self._whitelist.constants)
+        namespace.update(values)
+        return eval(  # noqa: S307 — AST-whitelisted at compile time
+            self._code, {"__builtins__": {}}, namespace
+        )
+
+
+def compile_expression(
+    expression: str,
+    symbols: AbstractSet[str],
+    whitelist: ExpressionWhitelist,
+    *,
+    filename: str = "<restricted-expr>",
+) -> CompiledExpression:
+    """Parse, whitelist-validate, and compile *expression*.
+
+    Parameters
+    ----------
+    expression : str
+        The expression text (``eval`` mode: a single expression).
+    symbols : set of str
+        Names the expression may reference as input values, in addition
+        to the whitelist's constants.
+    whitelist : ExpressionWhitelist
+        The permitted functions, constants, and operators.
+    filename : str, optional
+        The pseudo-filename recorded in the compiled code (shows up in
+        runtime tracebacks).
+
+    Raises
+    ------
+    ExpressionWhitelistError
+        Syntax errors, or any construct outside the whitelist (unknown
+        names, attribute access, subscripts, non-numeric literals, ...).
+    """
+    try:
+        tree = ast.parse(expression, mode="eval")
+    except SyntaxError as exc:
+        raise ExpressionWhitelistError(f"syntax error ({exc.msg})") from exc
+    _validate(tree, symbols, whitelist)
+    return CompiledExpression(
+        source=expression,
+        is_boolean=_is_boolean_expression(tree.body),
+        _code=compile(tree, filename, "eval"),
+        _whitelist=whitelist,
+    )

--- a/GEECS-Schemas/pyproject.toml
+++ b/GEECS-Schemas/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-schemas"
-version = "0.8.2"
+version = "0.9.0"
 description = "Versioned Pydantic schemas for GEECS scanner configs (scan requests, save sets, scan variables, trigger profiles, action plans) plus legacy-YAML converters."
 authors = ["Sam Barber <sbarber@lbl.gov>"]
 readme = "README.md"

--- a/GEECS-Schemas/tests/test_restricted_expr.py
+++ b/GEECS-Schemas/tests/test_restricted_expr.py
@@ -1,0 +1,140 @@
+"""restricted_expr: the shared AST-whitelist expression core.
+
+Pins the security contract both consumers (the gateway's derived channels
+and the engine's forward formulas) stand on: everything outside the
+supplied whitelist — unknown names, attribute access, subscripts, calls
+to non-whitelisted functions, non-numeric literals, operators the
+whitelist omits — is refused at compile time with
+``ExpressionWhitelistError``, never evaluated; evaluation runs with empty
+builtins; and the parameterization points (operator sets, bool/compare
+gating, symbol shadowing, ``is_boolean``) behave as the consumers assume.
+"""
+
+from __future__ import annotations
+
+import ast
+import math
+
+import pytest
+
+from geecs_schemas.restricted_expr import (
+    ExpressionWhitelist,
+    ExpressionWhitelistError,
+    compile_expression,
+)
+
+ARITHMETIC = ExpressionWhitelist(
+    functions={"sqrt": math.sqrt, "abs": abs},
+    constants={"pi": math.pi, "e": math.e},
+    binary_ops=(ast.Add, ast.Sub, ast.Mult, ast.Div, ast.Pow, ast.Mod, ast.FloorDiv),
+    unary_ops=(ast.UAdd, ast.USub),
+)
+
+WITH_LOGIC = ExpressionWhitelist(
+    functions={"isfinite": math.isfinite},
+    constants={"pi": math.pi},
+    binary_ops=(ast.Add, ast.Sub, ast.Mult, ast.Div, ast.Pow, ast.Mod),
+    unary_ops=(ast.UAdd, ast.USub, ast.Not),
+    bool_ops=(ast.And, ast.Or),
+    compare_ops=(ast.Eq, ast.NotEq, ast.Lt, ast.LtE, ast.Gt, ast.GtE),
+)
+
+
+def test_arithmetic_evaluates() -> None:
+    compiled = compile_expression("(x - 41000) * 14 / 1000 - 20", {"x"}, ARITHMETIC)
+    assert compiled.evaluate({"x": 42000.0}) == pytest.approx(-6.0)
+    assert compiled.source == "(x - 41000) * 14 / 1000 - 20"
+    assert compiled.is_boolean is False
+
+
+def test_functions_and_constants() -> None:
+    compiled = compile_expression("sqrt(abs(x)) + pi - pi", {"x"}, ARITHMETIC)
+    assert compiled.evaluate({"x": -4.0}) == pytest.approx(2.0)
+
+
+def test_multiple_symbols() -> None:
+    compiled = compile_expression("a * b", {"a", "b"}, ARITHMETIC)
+    assert compiled.evaluate({"a": 3.0, "b": 4.0}) == 12.0
+
+
+def test_symbol_shadows_constant_and_function() -> None:
+    """Values are bound last, so a symbol wins over a same-named constant."""
+    compiled = compile_expression("pi", {"pi"}, ARITHMETIC)
+    assert compiled.evaluate({"pi": 1.5}) == 1.5
+
+
+def test_operator_outside_whitelist_refused() -> None:
+    """The same expression compiles or not purely per the operator set."""
+    assert compile_expression("x // 2", {"x"}, ARITHMETIC).evaluate({"x": 5.0}) == 2.0
+    with pytest.raises(ExpressionWhitelistError):
+        compile_expression("x // 2", {"x"}, WITH_LOGIC)
+
+
+def test_bool_and_compare_gated_by_whitelist() -> None:
+    with pytest.raises(ExpressionWhitelistError):
+        compile_expression("x < 1", {"x"}, ARITHMETIC)
+    with pytest.raises(ExpressionWhitelistError):
+        compile_expression("x and 1", {"x"}, ARITHMETIC)
+    compiled = compile_expression("x < 1e-5 and isfinite(x)", {"x"}, WITH_LOGIC)
+    assert compiled.evaluate({"x": 1e-6}) is True
+
+
+@pytest.mark.parametrize(
+    ("expression", "expected"),
+    [("x < 1", True), ("x and 1", True), ("not x", True), ("x + 1", False)],
+)
+def test_is_boolean_reflects_top_level_intent(expression, expected) -> None:
+    assert compile_expression(expression, {"x"}, WITH_LOGIC).is_boolean is expected
+
+
+@pytest.mark.parametrize(
+    "expression",
+    [
+        "unknown_name * 2",  # name outside symbols and constants
+        "__import__('os')",  # smuggled call
+        "x.__class__",  # attribute access
+        "x[0]",  # subscript
+        "'text' + x",  # non-numeric literal
+        "lambda v: v",  # disallowed syntax
+        "open('f')",  # non-whitelisted function
+        "sqrt(x, foo=1)",  # keyword arguments
+        "[x for x in (1,)]",  # comprehension
+        "f'{x}'",  # f-string
+        "x +",  # syntax error
+    ],
+)
+def test_disallowed_expression_refused_at_compile(expression) -> None:
+    with pytest.raises(ExpressionWhitelistError):
+        compile_expression(expression, {"x"}, ARITHMETIC)
+
+
+def test_evaluation_namespace_has_no_builtins() -> None:
+    """Names resolve only from the whitelist and *values* — no builtins.
+
+    A declared-but-unbound symbol is a NameError at evaluate time, not a
+    silent fallback to a builtin; consumers guard missing inputs upstream.
+    """
+    compiled = compile_expression("x", {"x"}, ARITHMETIC)
+    with pytest.raises(NameError):
+        compiled.evaluate({})
+
+
+def test_runtime_errors_propagate_unwrapped() -> None:
+    """The core imposes no error contract — consumers wrap."""
+    compiled = compile_expression("sqrt(x)", {"x"}, ARITHMETIC)
+    with pytest.raises(ValueError):
+        compiled.evaluate({"x": -1.0})
+    with pytest.raises(ZeroDivisionError):
+        compile_expression("1 / x", {"x"}, ARITHMETIC).evaluate({"x": 0.0})
+
+
+def test_extra_symbols_permit_bare_function_names() -> None:
+    """A consumer may pass function names as symbols (gateway legacy)."""
+    symbols = {"v"} | set(ARITHMETIC.functions)
+    compiled = compile_expression("sqrt", symbols, ARITHMETIC)
+    assert compiled.evaluate({"v": 0.0}) is math.sqrt
+
+
+def test_syntax_error_message_names_the_problem() -> None:
+    with pytest.raises(ExpressionWhitelistError, match="syntax error"):
+        compile_expression("x +", {"x"}, ARITHMETIC)

--- a/GEECS-Schemas/tests/test_restricted_expr.py
+++ b/GEECS-Schemas/tests/test_restricted_expr.py
@@ -108,11 +108,46 @@ def test_disallowed_expression_refused_at_compile(expression) -> None:
         compile_expression(expression, {"x"}, ARITHMETIC)
 
 
-def test_evaluation_namespace_has_no_builtins() -> None:
-    """Names resolve only from the whitelist and *values* — no builtins.
+@pytest.mark.parametrize(
+    "expression",
+    [
+        "x < x[0]",  # subscript inside a comparator
+        "1 and x.__class__",  # attribute access inside a bool-op operand
+        "x < 1 < open('f')",  # call inside a chained comparison
+        "not x.__class__",  # attribute access under a whitelisted `not`
+    ],
+)
+def test_nested_logic_positions_refused(expression) -> None:
+    """Refusal reaches comparator/bool-op/unary recursion, not just top level.
 
-    A declared-but-unbound symbol is a NameError at evaluate time, not a
-    silent fallback to a builtin; consumers guard missing inputs upstream.
+    These would compile — and *evaluate*, since empty builtins do not
+    block attribute access on a bound symbol — if the comparator or
+    bool-op operand recursion in ``_validate`` were dropped.
+    """
+    with pytest.raises(ExpressionWhitelistError):
+        compile_expression(expression, {"x"}, WITH_LOGIC)
+
+
+def test_bool_literals_count_as_numbers() -> None:
+    """``True``/``False`` literals compile (``bool`` is ``int``).
+
+    A preserved quirk both consumers inherited from their pre-core
+    validators; pinned so a future tightening (e.g. ``type(...) in
+    (int, float)``) is a deliberate, test-visible change at both eval
+    sites rather than a silent one.
+    """
+    assert compile_expression("True + x", {"x"}, ARITHMETIC).evaluate({"x": 1.0}) == 2.0
+
+
+def test_declared_but_unbound_symbol_is_nameerror() -> None:
+    """Names resolve only from the whitelist and *values*.
+
+    A declared-but-unbound symbol is a NameError at evaluate time;
+    consumers guard missing inputs upstream.  (The empty-``__builtins__``
+    eval globals are defense-in-depth behind compile-time name
+    validation — builtin names never pass ``_validate`` — and are not
+    observable black-box, so this pins the name-resolution contract,
+    not the sandbox layer.)
     """
     compiled = compile_expression("x", {"x"}, ARITHMETIC)
     with pytest.raises(NameError):

--- a/GeecsBluesky/CHANGELOG.md
+++ b/GeecsBluesky/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to `geecs-bluesky` are documented here.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.47.1] - 2026-07-21
+
+### Changed
+
+- `forward_expr.py` now delegates its compile-then-restricted-eval
+  skeleton to the shared `geecs_schemas.restricted_expr` core
+  (geecs-schemas 0.9.0) — a behavior-preserving refactor so security
+  hardening of the eval sites lands once, not twice (the 0.47.0 module
+  docstring's sketched consolidation, executed).  The forward-formula
+  language is unchanged (arithmetic incl. `//`, math functions, `abs`,
+  `composite_var`/`x`, no comparisons), as are the
+  `GeecsConfigurationError` contract at compile and call time and
+  `CompiledForward.source`; pinned by the existing
+  `test_forward_expr.py` corpus + refusal suite.
+
 ## [0.47.0] - 2026-07-21
 
 ### Added

--- a/GeecsBluesky/CLAUDE.md
+++ b/GeecsBluesky/CLAUDE.md
@@ -72,7 +72,9 @@ geecs_bluesky/
   forward_expr.py           # compile_forward — AST-whitelist compiler for
                             #   pseudo-variable forward formulas (arithmetic +
                             #   math functions; scanned value = composite_var
-                            #   or its alias x; corpus pinned by tests)
+                            #   or its alias x; corpus pinned by tests;
+                            #   skeleton = geecs_schemas.restricted_expr,
+                            #   shared with the gateway's derived channels)
   scan_request_runner.py    # run a geecs_schemas.ScanRequest:
                             #   SaveSet→devices_config and
                             #   TriggerProfile→ShotControlWrites (ordered,

--- a/GeecsBluesky/geecs_bluesky/forward_expr.py
+++ b/GeecsBluesky/geecs_bluesky/forward_expr.py
@@ -41,6 +41,8 @@ from geecs_schemas.restricted_expr import (
 from geecs_bluesky.exceptions import GeecsConfigurationError
 
 #: Names bound to the scanned value: the schema's token and its short alias.
+#: Must stay disjoint from ``_FUNCTIONS``/``_CONSTANTS`` — under the shared
+#: core, symbols shadow same-named functions/constants at evaluate time.
 SCAN_VALUE_NAMES = ("composite_var", "x")
 
 #: Callables an expression may invoke, by name.

--- a/GeecsBluesky/geecs_bluesky/forward_expr.py
+++ b/GeecsBluesky/geecs_bluesky/forward_expr.py
@@ -16,13 +16,12 @@ raise :class:`~geecs_bluesky.exceptions.GeecsConfigurationError` naming the
 offending construct — the runner compiles every formula fail-fast pre-claim,
 so a bad expression can never burn a scan number.
 
-Known sibling: the gateway's derived-channel ``ExpressionEvaluator``
-(``geecs_ca_gateway/derived.py``) is the same compile-then-restricted-eval
-skeleton with a different whitelist (comparisons/bool-ops, ``isfinite``,
-no ``abs``).  They are deliberately separate today (different languages,
-different error contracts); if either eval site is ever hardened or its
-semantics fixed, apply the change to both — a shared stdlib-only core in
-GEECS-Schemas is the sketched consolidation home.
+The compile-then-restricted-eval skeleton is the shared
+:mod:`geecs_schemas.restricted_expr` core (also behind the gateway's
+derived-channel ``ExpressionEvaluator``) — a hardening or semantics fix
+lands there once.  This module supplies the forward-formula whitelist
+(arithmetic incl. ``//``, ``abs``, no comparisons/bool-ops), the scanned-value
+symbols, and the engine's error contract.
 """
 
 from __future__ import annotations
@@ -31,6 +30,13 @@ import ast
 import math
 from dataclasses import dataclass
 from typing import Callable
+
+from geecs_schemas.restricted_expr import (
+    CompiledExpression,
+    ExpressionWhitelist,
+    ExpressionWhitelistError,
+    compile_expression,
+)
 
 from geecs_bluesky.exceptions import GeecsConfigurationError
 
@@ -55,8 +61,12 @@ _FUNCTIONS: dict[str, Callable[..., float]] = {
 #: Bare names an expression may reference besides the scanned value.
 _CONSTANTS: dict[str, float] = {"pi": math.pi, "e": math.e}
 
-_BINARY_OPS = (ast.Add, ast.Sub, ast.Mult, ast.Div, ast.Pow, ast.Mod, ast.FloorDiv)
-_UNARY_OPS = (ast.UAdd, ast.USub)
+_WHITELIST = ExpressionWhitelist(
+    functions=_FUNCTIONS,
+    constants=_CONSTANTS,
+    binary_ops=(ast.Add, ast.Sub, ast.Mult, ast.Div, ast.Pow, ast.Mod, ast.FloorDiv),
+    unary_ops=(ast.UAdd, ast.USub),
+)
 
 
 def _reject(expression: str, detail: str) -> GeecsConfigurationError:
@@ -66,32 +76,6 @@ def _reject(expression: str, detail: str) -> GeecsConfigurationError:
         f"{' or '.join(SCAN_VALUE_NAMES)}, constants {sorted(_CONSTANTS)}, "
         f"and functions {sorted(_FUNCTIONS)}"
     )
-
-
-def _validate(node: ast.AST, expression: str) -> None:
-    """Recursively whitelist-check one AST node (raises on anything else)."""
-    if isinstance(node, ast.Expression):
-        _validate(node.body, expression)
-    elif isinstance(node, ast.BinOp) and isinstance(node.op, _BINARY_OPS):
-        _validate(node.left, expression)
-        _validate(node.right, expression)
-    elif isinstance(node, ast.UnaryOp) and isinstance(node.op, _UNARY_OPS):
-        _validate(node.operand, expression)
-    elif isinstance(node, ast.Constant):
-        if not isinstance(node.value, (int, float)):
-            raise _reject(expression, f"literal {node.value!r} is not a number")
-    elif isinstance(node, ast.Name):
-        if node.id not in SCAN_VALUE_NAMES and node.id not in _CONSTANTS:
-            raise _reject(expression, f"unknown name {node.id!r}")
-    elif isinstance(node, ast.Call):
-        if not isinstance(node.func, ast.Name) or node.func.id not in _FUNCTIONS:
-            raise _reject(expression, "only whitelisted function calls are allowed")
-        if node.keywords:
-            raise _reject(expression, "keyword arguments are not allowed")
-        for arg in node.args:
-            _validate(arg, expression)
-    else:
-        raise _reject(expression, f"disallowed syntax ({type(node).__name__})")
 
 
 @dataclass(frozen=True)
@@ -105,21 +89,16 @@ class CompiledForward:
     """
 
     source: str
-    _code: object
+    _compiled: CompiledExpression
 
     def __call__(self, value: float) -> float:
         """Evaluate the formula at scanned value *value*."""
-        names: dict[str, float] = {token: float(value) for token in SCAN_VALUE_NAMES}
-        names.update(_CONSTANTS)
-        names.update(_FUNCTIONS)  # type: ignore[arg-type]
+        values = {token: float(value) for token in SCAN_VALUE_NAMES}
         try:
-            result = eval(  # noqa: S307 — AST-whitelisted at compile time
-                self._code, {"__builtins__": {}}, names
-            )
             # Inside the try: float() itself can raise — e.g. `x ** 0.5` at
             # a negative x returns complex (TypeError), and an int-constant
             # power can overflow the float conversion.
-            return float(result)
+            return float(self._compiled.evaluate(values))
         except (ValueError, TypeError, ZeroDivisionError, OverflowError) as exc:
             raise GeecsConfigurationError(
                 f"forward expression {self.source!r} failed at "
@@ -137,8 +116,9 @@ def compile_forward(expression: str) -> CompiledForward:
         names, attribute access, subscripts, non-numeric literals, ...).
     """
     try:
-        tree = ast.parse(expression, mode="eval")
-    except SyntaxError as exc:
-        raise _reject(expression, f"syntax error ({exc.msg})") from exc
-    _validate(tree, expression)
-    return CompiledForward(source=expression, _code=compile(tree, "<forward>", "eval"))
+        compiled = compile_expression(
+            expression, frozenset(SCAN_VALUE_NAMES), _WHITELIST, filename="<forward>"
+        )
+    except ExpressionWhitelistError as exc:
+        raise _reject(expression, str(exc)) from exc
+    return CompiledForward(source=expression, _compiled=compiled)

--- a/GeecsBluesky/pyproject.toml
+++ b/GeecsBluesky/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-bluesky"
-version = "0.47.0"
+version = "0.47.1"
 description = "Bluesky / ophyd-async bridge for the GEECS control system"
 authors = ["Sam Barber <sbarber@lbl.gov>"]
 readme = "README.md"

--- a/GeecsBluesky/tests/test_forward_expr.py
+++ b/GeecsBluesky/tests/test_forward_expr.py
@@ -14,7 +14,12 @@ import math
 import pytest
 
 from geecs_bluesky.exceptions import GeecsConfigurationError
-from geecs_bluesky.forward_expr import compile_forward
+from geecs_bluesky.forward_expr import (
+    _CONSTANTS,
+    _FUNCTIONS,
+    SCAN_VALUE_NAMES,
+    compile_forward,
+)
 
 # ---------------------------------------------------------------------------
 # The full production corpus (Undulator + Thomson), expression → (input, expected)
@@ -95,6 +100,17 @@ def test_complex_and_overflow_results_are_configuration_errors() -> None:
         compile_forward("x ** 0.5")(-1.0)
     with pytest.raises(GeecsConfigurationError, match="failed at"):
         compile_forward("10 ** 400")(0.0)
+
+
+def test_scan_value_names_disjoint_from_whitelist_names() -> None:
+    """The scanned-value tokens must not collide with functions/constants.
+
+    Under the shared core, symbols shadow same-named whitelist entries at
+    evaluate time — disjointness is what keeps that direction unobservable
+    here.  Adding e.g. a constant ``x`` would silently change semantics;
+    this makes it a test failure instead.
+    """
+    assert not set(SCAN_VALUE_NAMES) & (set(_FUNCTIONS) | set(_CONSTANTS))
 
 
 def test_result_is_float() -> None:

--- a/GeecsCAGateway/CHANGELOG.md
+++ b/GeecsCAGateway/CHANGELOG.md
@@ -3,6 +3,22 @@
 All notable changes to `geecs-ca-gateway` are documented here, following
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and semantic versioning.
 
+## [0.14.3] - 2026-07-21
+
+### Changed
+
+- `derived.py`'s `ExpressionEvaluator` now delegates its
+  compile-then-restricted-eval skeleton to the shared
+  `geecs_schemas.restricted_expr` core (geecs-schemas 0.9.0) — a
+  behavior-preserving refactor so security hardening of the eval sites
+  lands once, not twice.  The derived-channel language is unchanged
+  (comparisons/bool-ops with `1.0`/`0.0` publication, `isfinite`,
+  `tau`, no `abs`/`//`; bare function names still compile-legal), as are
+  the `DerivedExpressionError` contract and the class's public surface;
+  pinned by the existing derived-channel suite.  Rejection message
+  phrasing for invalid expressions changed slightly (now the core's
+  wording).
+
 ## [0.14.2] - 2026-07-21
 
 ### Changed

--- a/GeecsCAGateway/geecs_ca_gateway/derived.py
+++ b/GeecsCAGateway/geecs_ca_gateway/derived.py
@@ -8,12 +8,17 @@ import json
 import math
 import os
 from pathlib import Path
-from typing import Any
 
 from geecs_schemas import (
     DerivedChannel as DerivedChannelSpec,
     DerivedChannels,
     DerivedInput as DerivedInputSpec,
+)
+from geecs_schemas.restricted_expr import (
+    CompiledExpression,
+    ExpressionWhitelist,
+    ExpressionWhitelistError,
+    compile_expression,
 )
 
 from .naming import normalize_pv_component
@@ -35,11 +40,14 @@ _ALLOWED_FUNCS = {
     )
 }
 _ALLOWED_CONSTS = {"e": math.e, "pi": math.pi, "tau": math.tau}
-_RESERVED_NAMES = set(_ALLOWED_FUNCS) | set(_ALLOWED_CONSTS)
-_ALLOWED_BINOPS = (ast.Add, ast.Sub, ast.Mult, ast.Div, ast.Pow, ast.Mod)
-_ALLOWED_UNARYOPS = (ast.UAdd, ast.USub, ast.Not)
-_ALLOWED_BOOLOPS = (ast.And, ast.Or)
-_ALLOWED_CMPOPS = (ast.Eq, ast.NotEq, ast.Lt, ast.LtE, ast.Gt, ast.GtE)
+_WHITELIST = ExpressionWhitelist(
+    functions=_ALLOWED_FUNCS,
+    constants=_ALLOWED_CONSTS,
+    binary_ops=(ast.Add, ast.Sub, ast.Mult, ast.Div, ast.Pow, ast.Mod),
+    unary_ops=(ast.UAdd, ast.USub, ast.Not),
+    bool_ops=(ast.And, ast.Or),
+    compare_ops=(ast.Eq, ast.NotEq, ast.Lt, ast.LtE, ast.Gt, ast.GtE),
+)
 GATEWAY_CONFIG_FOLDER = "gateway"
 DERIVED_CHANNELS_FILENAME = "derived_channels.yaml"
 
@@ -132,18 +140,32 @@ def default_derived_channels_path(experiment: str) -> Path | None:
 
 
 class ExpressionEvaluator:
-    """Compile and evaluate a restricted numeric/status expression."""
+    """Compile and evaluate a restricted numeric/status expression.
+
+    The compile-then-restricted-eval skeleton is the shared
+    :mod:`geecs_schemas.restricted_expr` core; this class supplies the
+    derived-channel whitelist (comparisons/bool-ops, ``isfinite``,
+    ``tau``), the per-expression symbol set, and the gateway's error and
+    result contracts (``DerivedExpressionError``; booleans published as
+    ``1.0``/``0.0``).
+    """
 
     def __init__(self, expression: str, symbols: set[str]) -> None:
         self.expression = expression
         self.symbols = symbols
         try:
-            tree = ast.parse(expression, mode="eval")
-        except SyntaxError as exc:
+            # Function names double as extra symbols: a bare function name
+            # used as a value is compile-legal (it fails at evaluate time
+            # in float()) — longstanding behavior, kept.
+            self._compiled: CompiledExpression = compile_expression(
+                expression,
+                symbols | set(_ALLOWED_FUNCS),
+                _WHITELIST,
+                filename="<derived-channel>",
+            )
+        except ExpressionWhitelistError as exc:
             raise DerivedExpressionError(str(exc)) from exc
-        self._validate_node(tree)
-        self._coerce_bool_result = self._is_boolean_expression(tree.body)
-        self._code = compile(tree, "<derived-channel>", "eval")
+        self._coerce_bool_result = self._compiled.is_boolean
 
     def evaluate(self, values: dict[str, float]) -> float:
         """Evaluate the expression with numeric input values.
@@ -154,70 +176,7 @@ class ExpressionEvaluator:
         missing = self.symbols - values.keys()
         if missing:
             raise KeyError(f"missing derived-channel input(s): {sorted(missing)}")
-        namespace: dict[str, Any] = {}
-        namespace.update(_ALLOWED_FUNCS)
-        namespace.update(_ALLOWED_CONSTS)
-        namespace.update(values)
-        result = eval(self._code, {"__builtins__": {}}, namespace)  # noqa: S307
+        result = self._compiled.evaluate(values)
         if self._coerce_bool_result:
             return float(bool(result))
         return float(result)
-
-    @staticmethod
-    def _is_boolean_expression(node: ast.AST) -> bool:
-        """Return whether the expression's top-level result is boolean intent."""
-        return isinstance(node, (ast.BoolOp, ast.Compare)) or (
-            isinstance(node, ast.UnaryOp) and isinstance(node.op, ast.Not)
-        )
-
-    def _validate_node(self, node: ast.AST) -> None:
-        if isinstance(node, ast.Expression):
-            self._validate_node(node.body)
-            return
-        if isinstance(node, ast.Constant):
-            if not isinstance(node.value, (int, float)):
-                raise DerivedExpressionError("only numeric constants are allowed")
-            return
-        if isinstance(node, ast.Name):
-            if node.id not in self.symbols and node.id not in _RESERVED_NAMES:
-                raise DerivedExpressionError(f"unknown name in expression: {node.id}")
-            return
-        if isinstance(node, ast.BinOp):
-            if not isinstance(node.op, _ALLOWED_BINOPS):
-                raise DerivedExpressionError("unsupported binary operator")
-            self._validate_node(node.left)
-            self._validate_node(node.right)
-            return
-        if isinstance(node, ast.BoolOp):
-            if not isinstance(node.op, _ALLOWED_BOOLOPS):
-                raise DerivedExpressionError("unsupported boolean operator")
-            for value in node.values:
-                self._validate_node(value)
-            return
-        if isinstance(node, ast.Compare):
-            self._validate_node(node.left)
-            for op in node.ops:
-                if not isinstance(op, _ALLOWED_CMPOPS):
-                    raise DerivedExpressionError("unsupported comparison operator")
-            for comparator in node.comparators:
-                self._validate_node(comparator)
-            return
-        if isinstance(node, ast.UnaryOp):
-            if not isinstance(node.op, _ALLOWED_UNARYOPS):
-                raise DerivedExpressionError("unsupported unary operator")
-            self._validate_node(node.operand)
-            return
-        if isinstance(node, ast.Call):
-            if (
-                not isinstance(node.func, ast.Name)
-                or node.func.id not in _ALLOWED_FUNCS
-            ):
-                raise DerivedExpressionError("only whitelisted math calls are allowed")
-            if node.keywords:
-                raise DerivedExpressionError("keyword arguments are not allowed")
-            for arg in node.args:
-                self._validate_node(arg)
-            return
-        raise DerivedExpressionError(
-            f"unsupported expression element: {type(node).__name__}"
-        )

--- a/GeecsCAGateway/pyproject.toml
+++ b/GeecsCAGateway/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-ca-gateway"
-version = "0.14.2"
+version = "0.14.3"
 description = "EPICS Channel Access soft-IOC gateway exposing GEECS devices as PVs"
 authors = ["Sam Barber <sbarber@lbl.gov>"]
 readme = "README.md"


### PR DESCRIPTION
## What + why

Two AST-whitelist expression evaluators had grown the same compile-then-restricted-eval skeleton with diverged whitelists: the gateway's derived-channel `ExpressionEvaluator` (`geecs_ca_gateway/derived.py`) and the engine's pseudo-variable `compile_forward` (`geecs_bluesky/forward_expr.py`). Both are security-sensitive eval sites, so a hardening or semantics fix had to land twice. This PR extracts the shared skeleton into **`geecs_schemas.restricted_expr`** (stdlib-only: `ast` + `dataclasses`, honoring GEECS-Schemas' import-from-anywhere rule; both packages already depend on it) and rewrites both consumers on top of it. It executes the consolidation sketched in `forward_expr.py`'s 0.47.0 module docstring (that sketch is now replaced by a pointer to the core).

**This is a refactor, not a behavior change.** Each consumer keeps its own:

- **whitelist** — gateway: comparisons/bool-ops, `isfinite`, `tau`, no `abs`/`//`; engine: arithmetic incl. `//`, `abs`, no comparisons
- **symbol contract** — gateway: per-expression input symbols (bare function names stay compile-legal, a preserved legacy quirk, passed as extra symbols with a comment); engine: fixed `composite_var`/`x`
- **error contract** — `DerivedExpressionError` vs `GeecsConfigurationError` at compile and call time (incl. the engine's runtime-failure wrapping from PR #594)
- **result coercion** — gateway publishes booleans as `1.0`/`0.0` via the core's `is_boolean` flag; engine floats the result

Both consumers' existing test suites pass unchanged — they pin the parity. The core gets its own suite (`GEECS-Schemas/tests/test_restricted_expr.py`, 14 tests) pinning the security contract (refusal of smuggled calls, attribute access, subscripts, unknown names, non-numeric literals, comprehensions, f-strings; empty-builtins evaluation) and the parameterization points (operator gating, bool/compare gating, symbol shadowing, `is_boolean`).

One deliberate observable delta, called out in the gateway CHANGELOG: rejection-message *phrasing* for invalid derived-channel expressions now uses the core's wording (e.g. `unknown name 'foo'` instead of `unknown name in expression: foo`). No test pinned the old strings; the error types are unchanged.

## Per-concern LOC breakdown

| Concern | Files | LOC |
|---|---|---|
| The shared core (new) | `GEECS-Schemas/geecs_schemas/restricted_expr.py` | +188 |
| Core test suite (new) | `GEECS-Schemas/tests/test_restricted_expr.py` | +140 |
| Gateway consumer rewrite | `GeecsCAGateway/geecs_ca_gateway/derived.py` | +34/−111 |
| Engine consumer rewrite | `GeecsBluesky/geecs_bluesky/forward_expr.py` | +23/−53 |
| Version bumps + CHANGELOGs + doc notes | 3× `pyproject.toml`/`CHANGELOG.md`, `GEECS-Schemas/README.md`, `GeecsBluesky/CLAUDE.md` | +68 |

Judgment-call additions (cheap to veto): the README "one non-model module" note, the CLAUDE.md layout-line update, and keeping the gateway's bare-function-name quirk rather than tightening it (tightening would be a behavior change out of scope here).

## Tests

`./scripts/check.sh --all`, everything locally runnable green:

- GEECS-Schemas **236 passed**, 7 deselected (incl. the 14 new core tests)
- GeecsBluesky **617 passed**, 3 deselected
- GeecsCAGateway **182 passed**
- ImageAnalysis 224 passed / ScanAnalysis 171 passed (1 skipped each) / GEECS-Data-Utils 198 passed / GEECS-Console 772 passed / GEECS-LogTriage 53 passed / root-tests 2 passed
- lint (pre-commit, all hooks) green

## Hardware verification

**None owed.** Behavior-preserving refactor of pure expression compilation/evaluation — no wire-protocol, PV-surface, or scan-execution semantics change (`PV_CONTRACT.md` untouched). The parity is pinned by the two consumers' existing suites: the legacy `composite_variables.yaml` corpus tests and the gateway's derived-channel suite (incl. the fake-server end-to-end derived tests), all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)