### PR TITLE
GeecsBluesky 0.48.0: move_variable — manual moves through the movable dispatch (live-verified on ALine composites)

### DIFF
--- a/GeecsBluesky/CHANGELOG.md
+++ b/GeecsBluesky/CHANGELOG.md
@@ -25,9 +25,23 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   `{"variable", "kind", "value", "targets"}` for operator feedback
   (`CaPseudoMovable` now publishes `last_commanded` — the per-target
   values of its last completed set — to back it).
-- Suite grows to 626 (manual-move contract: dispatch per kind, fresh
-  movable per call, exact refusal messages, non-finite guard, bridge
-  delegation).
+- **Mutual exclusion is symmetric** (review finding, PR #597): a manual
+  move is not a plan, so the RunEngine stays idle while it runs — a
+  session-level lock now makes the exclusion mutual.  `scan()` /
+  `optimize()` / `run_action()` refuse while a move holds it
+  (`"manual move in progress — <scan|optimization|action> not started"`),
+  and a second concurrent move is refused (the double-click race that
+  would have corrupted a relative pseudo's baselines).
+- **Timeout cancels the move** (review finding): on the wall-clock budget
+  expiring, the in-flight coroutine is cancelled and a documented
+  `TimeoutError` raised (a GEECS set already on the wire cannot be
+  recalled — stated in the contract); the bridge exposes `timeout` for
+  legitimately slow moves.  A non-numeric value is refused as
+  `GeecsConfigurationError` before any device is built.
+- Suite grows to 631 (manual-move contract: dispatch per kind incl.
+  motor, fresh movable per call, exact refusal messages both directions,
+  timeout-cancellation, non-finite/non-numeric guards, bridge
+  delegation with timeout passthrough).
 
 ## [0.47.1] - 2026-07-21
 

--- a/GeecsBluesky/CHANGELOG.md
+++ b/GeecsBluesky/CHANGELOG.md
@@ -4,6 +4,31 @@ All notable changes to `geecs-bluesky` are documented here.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.48.0] - 2026-07-22
+
+### Added
+
+- **`move_variable(name, value)` — on-demand manual moves** (session +
+  bridge; the third member of the console Submitter contract alongside
+  `run_action`/`describe_action`).  *name* is a catalog scan-variable name
+  (plain, confirm, or pseudo/composite) or a raw `"Device:Variable"`
+  string; the move dispatches through the one `build_movable` seam, so a
+  manual move carries **scan-identical completion semantics**: blocking
+  GEECS set, `CaMotor` readback poll, `CaConfirmSettable` confirming-poll
+  (manual EMQ sets no longer bypass confirmation the way raw PV puts do),
+  and pseudo concurrent fan-out.  A fresh movable is built per call —
+  deliberately, so a relative pseudo re-baselines from the targets'
+  *current* positions on every manual bump (legacy composite manual-set
+  semantics).  Refused while a scan is active with the exact message
+  `"scan in progress — move not started"`; a non-finite value is refused
+  before any device is built.  Returns
+  `{"variable", "kind", "value", "targets"}` for operator feedback
+  (`CaPseudoMovable` now publishes `last_commanded` — the per-target
+  values of its last completed set — to back it).
+- Suite grows to 626 (manual-move contract: dispatch per kind, fresh
+  movable per call, exact refusal messages, non-finite guard, bridge
+  delegation).
+
 ## [0.47.1] - 2026-07-21
 
 ### Changed

--- a/GeecsBluesky/CLAUDE.md
+++ b/GeecsBluesky/CLAUDE.md
@@ -51,6 +51,9 @@ geecs_bluesky/
   session.py                # GeecsSession — headless scans (RE + Tiled + discipline)
                             #   + session.run(ScanRequest) — the schema front door;
                             #   writes scan.log when it claimed the scan number
+                            #   + move_variable — manual scan-variable move
+                            #   (plain/confirm/pseudo, fresh movable per
+                            #   call, refused mid-scan)
                             #   + run_action / describe_action — on-demand
                             #   ActionPlan execution & dry-run (G-actions v1)
   events.py                 # THE typed event vocabulary: ScanEvent hierarchy,
@@ -171,6 +174,16 @@ scanner.stop_scanning_thread()      # request stop, returns promptly;
                                     # ABORTED/DONE arrives via events
 scanner.run_action(name)            # on-demand ActionPlan (refused mid-scan)
 scanner.describe_action(name)       # pure dry-run (allowed mid-scan)
+scanner.move_variable(name, value)  # manual move of a catalog scan variable
+                                    # or raw Device:Variable (refused
+                                    # mid-scan: "scan in progress — move
+                                    # not started"); scan-identical
+                                    # completion semantics via build_movable
+                                    # (motor poll, confirm poll, pseudo
+                                    # fan-out); a relative pseudo
+                                    # re-baselines from *now* each call;
+                                    # returns {variable, kind, value,
+                                    # targets} (0.48.0)
 ```
 
 `GEECS-Console` builds the scanner via `make_bluesky_submitter`

--- a/GeecsBluesky/geecs_bluesky/devices/ca/pseudo.py
+++ b/GeecsBluesky/geecs_bluesky/devices/ca/pseudo.py
@@ -102,6 +102,9 @@ class CaPseudoMovable(StandardReadable):
             )
         super().__init__(name=name)
         self._baselines: list[float] | None = None
+        #: ``{"Device:Variable": commanded}`` of the last completed set
+        #: (``None`` until one succeeds) — operator feedback for manual moves.
+        self.last_commanded: dict[str, float] | None = None
         self._column_headers = {f"{name}-readback": variable_name}
 
     async def disconnect(self) -> None:
@@ -155,16 +158,16 @@ class CaPseudoMovable(StandardReadable):
             # Unstaged caller (e.g. the optimize path): capture lazily once.
             await self._capture_baselines()
         targets = self._target_values(value)
-        logger.info(
-            "%s: %s → %s",
-            self.name,
-            value,
-            {
-                f"{dev}:{var}": target
-                for (dev, var, _), target in zip(self._components, targets)
-            },
-        )
+        commanded = {
+            f"{dev}:{var}": target
+            for (dev, var, _), target in zip(self._components, targets)
+        }
+        logger.info("%s: %s → %s", self.name, value, commanded)
         await asyncio.gather(
             *(put.put(target) for put, target in zip(self._puts, targets))
         )
+        # Published after a *successful* fan-out: what each target was told
+        # to do on the last completed set (consumed by manual-move callers
+        # for operator feedback).
+        self.last_commanded = commanded
         self._set_readback(value)

--- a/GeecsBluesky/geecs_bluesky/scanner_bridge/bluesky_scanner.py
+++ b/GeecsBluesky/geecs_bluesky/scanner_bridge/bluesky_scanner.py
@@ -449,9 +449,10 @@ class BlueskyScanner:
     # ------------------------------------------------------------------
     # On-demand actions (G-actions v1) + manual moves — the GUI contract
     # ------------------------------------------------------------------
-    # These three signatures (run_action, describe_action, move_variable)
-    # are mirrored by the console's Submitter protocol; do not change them
-    # without flagging it loudly.
+    # run_action and describe_action are mirrored by the console's
+    # Submitter protocol; move_variable will join it with the console
+    # movable-panel work (PR-B). Do not change these signatures without
+    # flagging it loudly.
 
     def _action_resolver(self) -> ConfigResolver:
         """The resolver on-demand actions resolve against.
@@ -490,7 +491,7 @@ class BlueskyScanner:
         """
         return self._session.describe_action(name, self._action_resolver())
 
-    def move_variable(self, name: str, value: float) -> dict:
+    def move_variable(self, name: str, value: float, *, timeout: float = 60.0) -> dict:
         """Move a scan variable on demand — refused while scanning.
 
         Thin delegation to :meth:`GeecsSession.move_variable` with this
@@ -505,15 +506,22 @@ class BlueskyScanner:
         dict
             ``{"variable", "kind", "value", "targets"}`` — see the session.
 
+        ``timeout`` is the overall wall-clock budget in seconds — raise
+        it for legitimately slow moves (long stage travel).
+
         Raises
         ------
         RuntimeError
-            While a scan is active: ``"scan in progress — move not
-            started"`` (the GUI surfaces this message verbatim).
+            While a scan is active (``"scan in progress — move not
+            started"``) or another manual move is running (``"manual move
+            in progress — move not started"``) — the GUI surfaces these
+            messages verbatim.
         """
         if self.is_scanning_active():
             raise RuntimeError("scan in progress — move not started")
-        return self._session.move_variable(name, value, self._action_resolver())
+        return self._session.move_variable(
+            name, value, self._action_resolver(), timeout=timeout
+        )
 
     def request_pause(self) -> None:
         """Pause the running scan at its next safe point (operator Pause).

--- a/GeecsBluesky/geecs_bluesky/scanner_bridge/bluesky_scanner.py
+++ b/GeecsBluesky/geecs_bluesky/scanner_bridge/bluesky_scanner.py
@@ -447,10 +447,11 @@ class BlueskyScanner:
         return min(self._completed_shots / self._total_shots, 1.0)
 
     # ------------------------------------------------------------------
-    # On-demand actions (G-actions v1) — the GUI contract
+    # On-demand actions (G-actions v1) + manual moves — the GUI contract
     # ------------------------------------------------------------------
-    # These two signatures are mirrored by the console's Submitter protocol;
-    # do not change them without flagging it loudly.
+    # These three signatures (run_action, describe_action, move_variable)
+    # are mirrored by the console's Submitter protocol; do not change them
+    # without flagging it loudly.
 
     def _action_resolver(self) -> ConfigResolver:
         """The resolver on-demand actions resolve against.
@@ -488,6 +489,31 @@ class BlueskyScanner:
         :meth:`run_action` carries the scan-in-progress refusal.
         """
         return self._session.describe_action(name, self._action_resolver())
+
+    def move_variable(self, name: str, value: float) -> dict:
+        """Move a scan variable on demand — refused while scanning.
+
+        Thin delegation to :meth:`GeecsSession.move_variable` with this
+        bridge's resolver: *name* is a catalog scan-variable name (plain,
+        confirm, or pseudo/composite) or a raw ``"Device:Variable"``
+        string.  The move carries scan-identical completion semantics (via
+        ``build_movable``), and a relative pseudo re-baselines from the
+        targets' current positions on every call.
+
+        Returns
+        -------
+        dict
+            ``{"variable", "kind", "value", "targets"}`` — see the session.
+
+        Raises
+        ------
+        RuntimeError
+            While a scan is active: ``"scan in progress — move not
+            started"`` (the GUI surfaces this message verbatim).
+        """
+        if self.is_scanning_active():
+            raise RuntimeError("scan in progress — move not started")
+        return self._session.move_variable(name, value, self._action_resolver())
 
     def request_pause(self) -> None:
         """Pause the running scan at its next safe point (operator Pause).

--- a/GeecsBluesky/geecs_bluesky/session.py
+++ b/GeecsBluesky/geecs_bluesky/session.py
@@ -1389,6 +1389,115 @@ class GeecsSession:
         return summaries
 
     # ------------------------------------------------------------------
+    # On-demand manual moves
+    # ------------------------------------------------------------------
+
+    def move_variable(
+        self,
+        name: str,
+        value: float,
+        resolver: Any | None = None,  # config_resolver.ConfigResolver
+        *,
+        timeout: float = 60.0,
+    ) -> dict:
+        """Move one scan variable to *value* on demand, outside any scan.
+
+        The manual-move counterpart of :meth:`run_action`: *name* is either
+        a catalog scan-variable name (plain, confirm, or pseudo) or a raw
+        ``"Device:Variable"`` string (plain setpoint semantics — the same
+        dispatch the optimize path uses).  The move goes through
+        :func:`~geecs_bluesky.scan_request_runner.build_movable`, so it
+        carries the exact completion semantics a scan would use: blocking
+        GEECS set per target, ``CaMotor`` readback polling, the
+        ``CaConfirmSettable`` confirming-variable poll, and a pseudo
+        variable's concurrent fan-out.
+
+        A **fresh movable is built per call** — deliberately, so a
+        *relative* pseudo variable re-baselines from where its targets are
+        *now* (each manual bump offsets from the current position, matching
+        how operators used the legacy composite manual set), rather than
+        from some earlier move's baselines.
+
+        Parameters
+        ----------
+        name : str
+            Catalog scan-variable name, or ``"Device:Variable"``.
+        value : float
+            The value to move to (the scanned number, for a pseudo).
+        resolver :
+            Optional name resolver (defaults to the configs-repo resolver,
+            as in :meth:`run`); unused for raw ``"Device:Variable"`` names.
+        timeout : float
+            Overall wall-clock budget for the move (seconds).
+
+        Returns
+        -------
+        dict
+            ``{"variable", "kind", "value", "targets"}`` — ``targets`` maps
+            each ``"Device:Variable"`` actually written to the value it was
+            commanded to (one entry for plain variables; every component,
+            baselines applied, for a pseudo).
+
+        Raises
+        ------
+        RuntimeError
+            When the RunEngine is not idle:
+            ``"scan in progress — move not started"`` (the GUI surfaces
+            this message verbatim).
+        GeecsConfigurationError
+            Unknown catalog name, a pseudo formula that fails to compile
+            or evaluate, or a non-finite *value*.
+        """
+        import asyncio
+
+        from geecs_bluesky.scan_request_runner import (
+            ConfigsRepoResolver,
+            PlainMovableTarget,
+            PseudoMovableTarget,
+            build_movable,
+            resolve_movable_target,
+        )
+
+        if self.RE.state != "idle":
+            raise RuntimeError("scan in progress — move not started")
+        value = float(value)
+        if not np.isfinite(value):
+            raise GeecsConfigurationError(
+                f"refusing to move {name!r} to non-finite value {value!r}"
+            )
+        if ":" in name:
+            device, _, variable = name.partition(":")
+            target: Any = PlainMovableTarget(device, variable, "setpoint", None)
+        else:
+            if resolver is None:
+                resolver = ConfigsRepoResolver(self.experiment)
+            target = resolve_movable_target(resolver.resolve_scan_variable(name), name)
+        movable = build_movable(self, target)
+        try:
+
+            async def _move() -> None:
+                await movable.set(value)
+
+            asyncio.run_coroutine_threadsafe(_move(), self.RE._loop).result(
+                timeout=timeout
+            )
+            if isinstance(target, PseudoMovableTarget):
+                kind = f"pseudo ({target.mode})"
+                targets = dict(getattr(movable, "last_commanded", None) or {})
+            else:
+                kind = "confirm" if target.confirm else target.kind
+                targets = {target.label: value}
+            logger.info("Manual move %s → %s (%s)", name, value, targets)
+            return {
+                "variable": name,
+                "kind": kind,
+                "value": value,
+                "targets": targets,
+            }
+        finally:
+            self.disconnect(movable)
+
+    # ------------------------------------------------------------------
     # Internals
     # ------------------------------------------------------------------
 

--- a/GeecsBluesky/geecs_bluesky/session.py
+++ b/GeecsBluesky/geecs_bluesky/session.py
@@ -29,6 +29,7 @@ from __future__ import annotations
 import logging
 import math
 import os
+import threading
 from contextlib import nullcontext
 from pathlib import Path
 from typing import Any, Callable, Sequence
@@ -187,6 +188,12 @@ class GeecsSession:
         # run, so a pause window is part of the data record — a wall-clock
         # gap between rows explains itself.
         self.RE.record_interruptions = True
+        # Held for the duration of a manual move (move_variable).  The RE
+        # is deliberately NOT occupied by manual moves (they are not
+        # plans), so this lock is what makes the exclusion *mutual*:
+        # scan()/optimize()/run_action() refuse while it is held, and
+        # move_variable refuses while the RE is busy (review, PR #597).
+        self._manual_move_lock = threading.Lock()
         # Silence upstream's RequestAbort traceback (operator aborts are
         # quiet, intentional outcomes — #563 follow-up).  RE.log is a
         # LoggerAdapter over the PROCESS-WIDE ``bluesky`` logger shared by
@@ -740,6 +747,7 @@ class GeecsSession:
         emitted (the scan number, when this call claimed one, was already
         burned; the folder holds ScanInfo and no data).
         """
+        self._refuse_if_manual_move("scan not started")
         if mode not in (_FREE_RUN, _STRICT):
             raise ValueError(f"mode={mode!r} invalid; use 'free_run' or 'strict'")
         detectors = list(detectors)
@@ -942,6 +950,7 @@ class GeecsSession:
         quietly — nothing ran, so the variables were never moved and no
         restore is needed.
         """
+        self._refuse_if_manual_move("optimization not started")
         if mode not in (_FREE_RUN, _STRICT):
             raise ValueError(f"mode={mode!r} invalid; use 'free_run' or 'strict'")
         if on_finish not in ("hold", "initial", "best"):
@@ -1307,6 +1316,7 @@ class GeecsSession:
 
         if self.RE.state != "idle":
             raise RuntimeError("scan in progress — action not started")
+        self._refuse_if_manual_move("action not started")
         plan, registry = self._resolve_action(name, resolver)
         # Fail-fast: unknown nested names / cycles surface here, before any
         # signal is created or connected.
@@ -1392,6 +1402,17 @@ class GeecsSession:
     # On-demand manual moves
     # ------------------------------------------------------------------
 
+    def _refuse_if_manual_move(self, verb: str) -> None:
+        """Raise when a manual move currently holds the engine.
+
+        The mutual-exclusion counterpart of the ``RE.state != "idle"``
+        checks: a manual move is not a plan, so the RE stays idle while it
+        runs — this lock is what keeps a scan, an action, or a second move
+        from starting mid-move (review, PR #597).
+        """
+        if self._manual_move_lock.locked():
+            raise RuntimeError(f"manual move in progress — {verb}")
+
     def move_variable(
         self,
         name: str,
@@ -1441,14 +1462,25 @@ class GeecsSession:
         Raises
         ------
         RuntimeError
-            When the RunEngine is not idle:
-            ``"scan in progress — move not started"`` (the GUI surfaces
-            this message verbatim).
+            When the RunEngine is not idle
+            (``"scan in progress — move not started"``) or another manual
+            move is already running
+            (``"manual move in progress — move not started"``) — the GUI
+            surfaces these messages verbatim.
         GeecsConfigurationError
             Unknown catalog name, a pseudo formula that fails to compile
-            or evaluate, or a non-finite *value*.
+            or evaluate, or a *value* that is non-finite or not a number.
+        TimeoutError
+            The move did not complete within *timeout*.  The in-flight
+            coroutine is cancelled, but a GEECS blocking set already sent
+            over the wire cannot be recalled — the device may still land
+            on the commanded value after this raises.
+        GeecsError
+            Device-level completion failures propagate (e.g.
+            ``GeecsMotorTimeoutError``, ``GeecsConfirmTimeoutError``).
         """
         import asyncio
+        import concurrent.futures
 
         from geecs_bluesky.scan_request_runner import (
             ConfigsRepoResolver,
@@ -1460,42 +1492,64 @@ class GeecsSession:
 
         if self.RE.state != "idle":
             raise RuntimeError("scan in progress — move not started")
-        value = float(value)
+        try:
+            value = float(value)
+        except (TypeError, ValueError) as exc:
+            raise GeecsConfigurationError(
+                f"refusing to move {name!r}: {value!r} is not a number"
+            ) from exc
         if not np.isfinite(value):
             raise GeecsConfigurationError(
                 f"refusing to move {name!r} to non-finite value {value!r}"
             )
-        if ":" in name:
-            device, _, variable = name.partition(":")
-            target: Any = PlainMovableTarget(device, variable, "setpoint", None)
-        else:
-            if resolver is None:
-                resolver = ConfigsRepoResolver(self.experiment)
-            target = resolve_movable_target(resolver.resolve_scan_variable(name), name)
-        movable = build_movable(self, target)
+        if not self._manual_move_lock.acquire(blocking=False):
+            raise RuntimeError("manual move in progress — move not started")
         try:
-
-            async def _move() -> None:
-                await movable.set(value)
-
-            asyncio.run_coroutine_threadsafe(_move(), self.RE._loop).result(
-                timeout=timeout
-            )
-            if isinstance(target, PseudoMovableTarget):
-                kind = f"pseudo ({target.mode})"
-                targets = dict(getattr(movable, "last_commanded", None) or {})
+            if ":" in name:
+                device, _, variable = name.partition(":")
+                target: Any = PlainMovableTarget(device, variable, "setpoint", None)
             else:
-                kind = "confirm" if target.confirm else target.kind
-                targets = {target.label: value}
-            logger.info("Manual move %s → %s (%s)", name, value, targets)
-            return {
-                "variable": name,
-                "kind": kind,
-                "value": value,
-                "targets": targets,
-            }
+                if resolver is None:
+                    resolver = ConfigsRepoResolver(self.experiment)
+                target = resolve_movable_target(
+                    resolver.resolve_scan_variable(name), name
+                )
+            movable = build_movable(self, target)
+            try:
+
+                async def _move() -> None:
+                    await movable.set(value)
+
+                future = asyncio.run_coroutine_threadsafe(_move(), self.RE._loop)
+                try:
+                    future.result(timeout=timeout)
+                except concurrent.futures.TimeoutError:
+                    # Cancel the coroutine so the abandoned move stops
+                    # holding the loop; the wire-level caveat is documented
+                    # above (a sent GEECS set cannot be recalled).
+                    future.cancel()
+                    raise TimeoutError(
+                        f"manual move of {name!r} to {value} did not "
+                        f"complete within {timeout}s (cancelled; an "
+                        "already-sent GEECS set may still land)"
+                    ) from None
+                if isinstance(target, PseudoMovableTarget):
+                    kind = f"pseudo ({target.mode})"
+                    targets = dict(getattr(movable, "last_commanded", None) or {})
+                else:
+                    kind = "confirm" if target.confirm else target.kind
+                    targets = {target.label: value}
+                logger.info("Manual move %s → %s (%s)", name, value, targets)
+                return {
+                    "variable": name,
+                    "kind": kind,
+                    "value": value,
+                    "targets": targets,
+                }
+            finally:
+                self.disconnect(movable)
         finally:
-            self.disconnect(movable)
+            self._manual_move_lock.release()
 
     # ------------------------------------------------------------------
     # Internals

--- a/GeecsBluesky/pyproject.toml
+++ b/GeecsBluesky/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-bluesky"
-version = "0.47.1"
+version = "0.48.0"
 description = "Bluesky / ophyd-async bridge for the GEECS control system"
 authors = ["Sam Barber <sbarber@lbl.gov>"]
 readme = "README.md"

--- a/GeecsBluesky/tests/test_move_variable.py
+++ b/GeecsBluesky/tests/test_move_variable.py
@@ -1,0 +1,212 @@
+"""On-demand manual moves (`move_variable`) — hermetic.
+
+Pins the manual-move contract, the counterpart of ``test_run_action``:
+
+- ``GeecsSession.move_variable`` dispatches through the one
+  ``build_movable`` seam (plain / confirm / pseudo — scan-identical
+  completion semantics), builds a **fresh movable per call** (a relative
+  pseudo re-baselines from the targets' current positions on every manual
+  bump), and returns the ``{"variable", "kind", "value", "targets"}``
+  summary.
+- Refusal while a scan owns the engine uses the **exact** message
+  ``"scan in progress — move not started"`` (session and bridge — the GUI
+  surfaces it verbatim).
+- A non-finite value is refused before any device is built.
+- ``BlueskyScanner.move_variable`` is a thin delegation (part of the
+  console Submitter contract).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+pytest.importorskip("aioca")  # session is CA-only
+
+from geecs_bluesky.exceptions import GeecsConfigurationError  # noqa: E402
+from geecs_bluesky.scanner_bridge.bluesky_scanner import BlueskyScanner  # noqa: E402
+from geecs_bluesky.session import GeecsSession  # noqa: E402
+from geecs_schemas import PseudoScanVariable, ScanVariable  # noqa: E402
+
+REFUSAL = "scan in progress — move not started"
+
+
+class _CatalogResolver:
+    """Minimal in-memory ConfigResolver over a scan-variable dict."""
+
+    def __init__(self, variables: dict) -> None:
+        self._variables = variables
+
+    def resolve_scan_variable(self, name: str):
+        try:
+            return self._variables[name]
+        except KeyError:
+            raise GeecsConfigurationError(f"unknown scan variable {name!r}") from None
+
+
+BUMP_X = PseudoScanVariable(
+    kind="pseudo",
+    mode="relative",
+    targets=[
+        {"target": "U_S3H:Current", "forward": "x * 1"},
+        {"target": "U_S4H:Current", "forward": "x * -2"},
+    ],
+)
+
+
+@pytest.fixture()
+def session():
+    s = GeecsSession("TestExp", tiled=False, mock=True)
+    yield s
+
+
+def _read_signal(s: GeecsSession, signal) -> float:
+    return asyncio.run_coroutine_threadsafe(signal.get_value(), s.RE._loop).result(
+        timeout=10.0
+    )
+
+
+def test_raw_device_variable_moves_plain_setpoint(session, monkeypatch) -> None:
+    """A raw Device:Variable name moves via plain settable semantics."""
+    built = []
+    real = session.settable
+
+    def spy(device, variable, **kwargs):
+        movable = real(device, variable, **kwargs)
+        built.append(movable)
+        return movable
+
+    monkeypatch.setattr(session, "settable", spy)
+    result = session.move_variable("U_S1H:Current", 2.5)
+
+    assert result == {
+        "variable": "U_S1H:Current",
+        "kind": "setpoint",
+        "value": 2.5,
+        "targets": {"U_S1H:Current": 2.5},
+    }
+    assert len(built) == 1
+    assert _read_signal(session, built[0]._setpoint) == 2.5
+
+
+def test_pseudo_move_fans_out_and_reports_commanded_targets(session) -> None:
+    """A relative pseudo fans out baseline + forward(x) and reports it.
+
+    Mock readbacks start at 0.0, so commanded = the pure offsets.
+    """
+    result = session.move_variable("bump_x", 0.5, _CatalogResolver({"bump_x": BUMP_X}))
+
+    assert result["kind"] == "pseudo (relative)"
+    assert result["value"] == 0.5
+    assert result["targets"] == {"U_S3H:Current": 0.5, "U_S4H:Current": -1.0}
+
+
+def test_each_move_builds_a_fresh_movable(session, monkeypatch) -> None:
+    """Two manual moves = two movables (relative re-baselines every call)."""
+    calls = []
+    real = session.pseudo_movable
+
+    def spy(*args, **kwargs):
+        movable = real(*args, **kwargs)
+        calls.append(movable)
+        return movable
+
+    monkeypatch.setattr(session, "pseudo_movable", spy)
+    resolver = _CatalogResolver({"bump_x": BUMP_X})
+    session.move_variable("bump_x", 0.5, resolver)
+    session.move_variable("bump_x", -0.5, resolver)
+
+    assert len(calls) == 2
+    assert calls[0] is not calls[1]
+
+
+def test_confirm_variable_dispatches_to_confirm_settable(session, monkeypatch) -> None:
+    """A catalog entry with `confirm` moves through CaConfirmSettable."""
+    from ophyd_async.core import AsyncStatus
+
+    recorded = {}
+
+    class _FakeConfirm:
+        def set(self, value):
+            recorded["value"] = value
+
+            async def _ok():
+                return None
+
+            return AsyncStatus(_ok())
+
+    def fake_confirm_settable(device, variable, *, confirm_device, confirm_variable):
+        recorded["target"] = (device, variable, confirm_device, confirm_variable)
+        return _FakeConfirm()
+
+    monkeypatch.setattr(session, "confirm_settable", fake_confirm_settable)
+    emq = ScanVariable(
+        target="U_EMQTripletBipolar:Current_Limit.Ch1",
+        confirm="U_EMQTripletBipolar:Current.Ch1",
+    )
+    result = session.move_variable("emq1", 1.5, _CatalogResolver({"emq1": emq}))
+
+    assert recorded["target"] == (
+        "U_EMQTripletBipolar",
+        "Current_Limit.Ch1",
+        "U_EMQTripletBipolar",
+        "Current.Ch1",
+    )
+    assert recorded["value"] == 1.5
+    assert result["kind"] == "confirm"
+
+
+def test_session_refuses_when_run_engine_not_idle() -> None:
+    s = GeecsSession("TestExp", tiled=False, mock=True)
+    s.RE = SimpleNamespace(state="running")  # a scan owns the engine
+
+    class _Untouchable:
+        def resolve_scan_variable(self, name: str):
+            raise AssertionError("refusal must come before resolution")
+
+    with pytest.raises(RuntimeError) as excinfo:
+        s.move_variable("anything", 1.0, _Untouchable())
+    assert str(excinfo.value) == REFUSAL
+
+
+def test_non_finite_value_refused_before_any_device(session) -> None:
+    class _Untouchable:
+        def resolve_scan_variable(self, name: str):
+            raise AssertionError("refusal must come before resolution")
+
+    with pytest.raises(GeecsConfigurationError, match="non-finite"):
+        session.move_variable("bump_x", float("nan"), _Untouchable())
+
+
+def _bare_scanner(*, scanning: bool) -> BlueskyScanner:
+    scanner = BlueskyScanner.__new__(BlueskyScanner)
+    scanner._scan_thread = SimpleNamespace(is_alive=lambda: True) if scanning else None
+    scanner._scan_finished = False
+    return scanner
+
+
+def test_bridge_refuses_while_scanning_exact_message() -> None:
+    scanner = _bare_scanner(scanning=True)
+    with pytest.raises(RuntimeError) as excinfo:
+        scanner.move_variable("anything", 1.0)
+    assert str(excinfo.value) == REFUSAL
+
+
+def test_bridge_delegates_to_session_with_its_resolver() -> None:
+    scanner = _bare_scanner(scanning=False)
+    sentinel_resolver = object()
+    seen = {}
+
+    class _Session:
+        def move_variable(self, name, value, resolver):
+            seen["call"] = (name, value, resolver)
+            return {"variable": name, "kind": "setpoint", "value": value, "targets": {}}
+
+    scanner._session = _Session()
+    scanner._request_resolver = sentinel_resolver
+    result = scanner.move_variable("jet_z", 3.0)
+
+    assert seen["call"] == ("jet_z", 3.0, sentinel_resolver)
+    assert result["variable"] == "jet_z"

--- a/GeecsBluesky/tests/test_move_variable.py
+++ b/GeecsBluesky/tests/test_move_variable.py
@@ -200,13 +200,127 @@ def test_bridge_delegates_to_session_with_its_resolver() -> None:
     seen = {}
 
     class _Session:
-        def move_variable(self, name, value, resolver):
-            seen["call"] = (name, value, resolver)
+        def move_variable(self, name, value, resolver, *, timeout=60.0):
+            seen["call"] = (name, value, resolver, timeout)
             return {"variable": name, "kind": "setpoint", "value": value, "targets": {}}
 
     scanner._session = _Session()
     scanner._request_resolver = sentinel_resolver
-    result = scanner.move_variable("jet_z", 3.0)
+    result = scanner.move_variable("jet_z", 3.0, timeout=120.0)
 
-    assert seen["call"] == ("jet_z", 3.0, sentinel_resolver)
+    assert seen["call"] == ("jet_z", 3.0, sentinel_resolver, 120.0)
     assert result["variable"] == "jet_z"
+
+
+# ---------------------------------------------------------------------------
+# Mutual exclusion + timeout + remaining dispatch (review findings, PR #597)
+# ---------------------------------------------------------------------------
+
+
+def test_motor_variable_dispatches_to_motor(session, monkeypatch) -> None:
+    """A catalog entry with kind=motor moves through CaMotor semantics."""
+    from ophyd_async.core import AsyncStatus
+
+    recorded = {}
+
+    class _FakeMotor:
+        def set(self, value):
+            recorded["value"] = value
+
+            async def _ok():
+                return None
+
+            return AsyncStatus(_ok())
+
+    def fake_motor(device, variable):
+        recorded["target"] = (device, variable)
+        return _FakeMotor()
+
+    monkeypatch.setattr(session, "motor", fake_motor)
+    jet = ScanVariable(target="U_ESP_JetXYZ:Position.Axis 3", kind="motor")
+    result = session.move_variable("jet_z", 4.5, _CatalogResolver({"jet_z": jet}))
+
+    assert recorded["target"] == ("U_ESP_JetXYZ", "Position.Axis 3")
+    assert recorded["value"] == 4.5
+    assert result["kind"] == "motor"
+
+
+def test_second_move_refused_while_one_is_running(session) -> None:
+    """The manual-move lock closes the double-click race."""
+    assert session._manual_move_lock.acquire(blocking=False)
+    try:
+        with pytest.raises(RuntimeError) as excinfo:
+            session.move_variable("U_S1H:Current", 1.0)
+        assert str(excinfo.value) == "manual move in progress — move not started"
+    finally:
+        session._manual_move_lock.release()
+
+
+def test_scan_and_optimize_and_action_refused_during_manual_move(session) -> None:
+    """The exclusion is mutual: nothing else starts while a move holds the lock.
+
+    A manual move is not a plan, so the RE stays idle for its duration —
+    without these guards a scan/action could start mid-move (review
+    finding 1, PR #597).
+    """
+    assert session._manual_move_lock.acquire(blocking=False)
+    try:
+        with pytest.raises(RuntimeError, match="manual move in progress — scan"):
+            session.scan(detectors=[object()], shots_per_step=1)
+        with pytest.raises(
+            RuntimeError, match="manual move in progress — optimization"
+        ):
+            session.optimize(
+                variables={},
+                detectors=[],
+                objective=lambda b: 0.0,
+                suggester=None,
+            )
+        with pytest.raises(RuntimeError, match="manual move in progress — action"):
+            session.run_action("anything", None)
+    finally:
+        session._manual_move_lock.release()
+
+
+def test_timeout_cancels_the_move_and_raises_timeout_error(
+    session, monkeypatch
+) -> None:
+    """A stalled move raises TimeoutError and cancels the in-flight coroutine."""
+    import asyncio as _asyncio
+    import time
+
+    from ophyd_async.core import AsyncStatus
+
+    cancelled = {"flag": False}
+
+    class _StalledMovable:
+        def set(self, value):
+            async def _hang():
+                try:
+                    await _asyncio.sleep(3600)
+                except _asyncio.CancelledError:
+                    cancelled["flag"] = True
+                    raise
+
+            return AsyncStatus(_hang())
+
+    monkeypatch.setattr(session, "settable", lambda device, variable: _StalledMovable())
+    with pytest.raises(TimeoutError, match="did not complete within"):
+        session.move_variable("U_S1H:Current", 1.0, timeout=0.2)
+    # The lock must be released after the failure (next move can start)...
+    assert not session._manual_move_lock.locked()
+    # ...and the coroutine must actually have been cancelled.
+    for _ in range(50):
+        if cancelled["flag"]:
+            break
+        time.sleep(0.02)
+    assert cancelled["flag"]
+
+
+def test_non_numeric_value_refused_as_configuration_error(session) -> None:
+    class _Untouchable:
+        def resolve_scan_variable(self, name: str):
+            raise AssertionError("refusal must come before resolution")
+
+    with pytest.raises(GeecsConfigurationError, match="not a number"):
+        session.move_variable("bump_x", "sideways", _Untouchable())


### PR DESCRIPTION
## What & why

**`move_variable(name, value)` — on-demand manual moves** (GeecsBluesky 0.48.0, minor). PR-A of the manual-composite-set design discussed with the owner: the engine seam that lets GEECS-Console (PR-B, next) manually move any catalog scan variable — including the pseudo/composite variables that the PV-oriented device panel cannot express — with **scan-identical completion semantics**.

- `GeecsSession.move_variable` + `BlueskyScanner.move_variable` (the third member of the console Submitter contract, alongside `run_action`/`describe_action`; contract comment updated). *name* = catalog scan-variable name (plain / confirm / pseudo) or raw `"Device:Variable"`.
- Dispatches through the existing `build_movable` seam — so a manual move gets the blocking GEECS set, `CaMotor`'s readback poll, `CaConfirmSettable`'s confirming poll (**manual EMQ sets no longer bypass confirmation** the way raw PV puts do), and a pseudo's concurrent fan-out. No new movable semantics were invented.
- **A fresh movable per call** — deliberate: a relative pseudo re-baselines from where its targets are *at the moment of the move* (each manual bump offsets from current position — legacy composite manual-set semantics, per owner design decision).
- Refusals mirror `run_action`: exact message `"scan in progress — move not started"` (session + bridge), and a non-finite value is refused before any device is built.
- Returns `{"variable", "kind", "value", "targets"}` for operator feedback; `CaPseudoMovable` now publishes `last_commanded` (per-target values of its last completed set) to back it.

## LOC breakdown

- `session.py` `move_variable`: ~115 (mostly docstring)
- `bluesky_scanner.py` delegation: ~28
- `devices/ca/pseudo.py` `last_commanded`: ~8
- `tests/test_move_variable.py`: ~215 (10 tests)
- CLAUDE.md / CHANGELOG / pyproject: ~50

## Tests

`./scripts/check.sh` (scoped, as CI): lint green, GeecsBluesky **626 passed, 3 deselected** (up from 616 on dev). New pins: dispatch per kind (plain / confirm / pseudo), fresh-movable-per-call, exact refusal messages (session + bridge), non-finite guard, bridge delegation with the stored resolver.

## Hardware verification — LIVE, PASSED (2026-07-22, over VPN, owner-authorized)

Ran `move_variable` headless against the live Undulator gateway (108 devices connected) on the production ALine composites:

| Step | Commanded | Expected | Measured | Result |
|---|---|---|---|---|
| initial | — | — | S3H +0.0001 A, S4H −0.0000 A | baseline |
| `ALine_e_beam_position_offset_x` +0.05 | S3H +0.0501, S4H −0.0500 | +0.05 / −0.05 from baseline | +0.0500 / −0.0498 | **OK** |
| same, −0.05 (fresh baseline = restore) | S3H +0.00001, S4H +0.00025 | back to baseline | +0.0001 / +0.0002 | **OK** |
| `ALine_e_beam_angle_offset_x` +0.05 | S3H +0.0501, S4H −0.0998 | +0.05 / −0.10 (1:−2 ratio) | +0.0500 / −0.0995 | **OK** |
| same, −0.05 (restore) | — | back to baseline | +0.0001 / +0.0004 | **OK** |

This live-verifies: relative fan-out math on real magnets, both corpus ratio shapes (1:−1 and 1:−2), the **fresh-baseline-per-call semantics** (the −0.05 restore was computed against the *bumped* currents and landed back on the originals, Δ ≤ 0.0005 A), the returned `targets` feedback, and completion via the GEECS blocking set over the gateway.

**Still OWED** (unchanged from PR #594): the *scan-path* pseudo verification (event rows + `pseudo_variables` in a real scan's start doc — needs trigger/beam state an operator must confirm), and the **R56 absolute-mode live check** — attempted, but the guard skipped it: chicane inner reads **1.0 A** (a real operating point, not zero), so an absolute move couldn't be restored to an unknown-x state. Needs an operator to confirm chicane state first. Absolute fan-out math is pinned hermetically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
