### PR TITLE
GEECS-Console 0.19.0: catalog-aware movable panel — composites settable, scan-variable auto-select

### DIFF
--- a/GEECS-Console/CHANGELOG.md
+++ b/GEECS-Console/CHANGELOG.md
@@ -4,6 +4,37 @@ All notable changes to GEECS-Console are documented here.  Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versioning is
 semantic.
 
+## [0.19.0] - 2026-07-22
+
+### Added
+
+- **The R7 device panel is now the catalog-aware movable panel**, owned by
+  `app/movable_panel.py::MovablePanelController` (issue #534 controller
+  shape; the window sheds ~170 lines of inline R7 machinery).  A selection
+  resolves catalog-first against the experiment's scan-variable catalog:
+  - a plain `ScanVariable` monitors its target readback; a composite
+    `PseudoScanVariable` monitors **every** component (`subscribe_many` on
+    the `DevicePanelBackend` — one live readback per target, rendered
+    compactly by the new `format_target_readbacks`); a raw
+    `device:variable` string keeps the historical direct path;
+  - catalog sets dispatch **`Submitter.move_variable`** (new protocol
+    member, mapping to `BlueskyScanner.move_variable`, GeecsBluesky ≥
+    0.48.0) — manual moves carry scan-identical completion semantics
+    (motor poll, confirm poll, pseudo fan-out with a fresh relative
+    baseline per move); engine refusals surface verbatim; raw strings
+    keep the direct gateway `:SP` put (no engine required);
+  - the combo's dropdown lists catalog names (composites included) ahead
+    of the DB `device:variable` completions;
+  - **the R3 axis combos auto-select the panel** (the legacy scanner
+    behavior), composites included — populate churn is signal-blocked and
+    unresolvable names never hijack the panel.
+- `ConsoleConfigs.scan_variable_specs()` — the catalog as
+  `{name: ScanVariableSpec}` (offline-safe), backing both the panel and
+  the names listing.
+- Suite grows 772 → 784 (the movable-panel capability tests +
+  `subscribe_many` service tests; the pre-existing R7 suites pin the
+  extraction as behavior-preserving).
+
 ## [0.18.3] - 2026-07-20
 
 ### Changed

--- a/GEECS-Console/CLAUDE.md
+++ b/GEECS-Console/CLAUDE.md
@@ -57,14 +57,17 @@ are prefixed by region (`r3_radio_1d`, `r5_start_button`, …).
   timing and granularity; they will drift, and shot counts must never be
   reconciled across them (live-investigated 2026-07-16 — a "pause shows
   extra steps" report was mostly this drift).
-- **R7 device panel** — device:variable combo (editable, with
-  `device:variable` dropdown completions from `GeecsDbCompletions` — see
-  Implemented seams), readback label, set field + button.  **Backend
-  live** (see Implemented
-  seams): gateway PVs — CA monitor on the readback, put to `:SP` riding
-  GEECS's native blocking set — never `geecs_python_api`'s ScanDevice.
-  Scalar-only at birth (composites arrive with the pseudo-variable
-  runtime, if ever).
+- **R7 movable panel** — an editable combo (catalog scan-variable names
+  first, then `device:variable` completions from `GeecsDbCompletions`),
+  readback label, set field + button — owned by
+  `app/movable_panel.py::MovablePanelController` since 0.19.0 (see
+  Implemented seams).  **Catalog-aware**: a catalog name (plain, confirm,
+  or pseudo/composite) monitors its target readback(s) and sets through
+  the engine's `Submitter.move_variable`; a raw `device:variable` string
+  keeps the historical direct path — CA monitor on the readback, put to
+  `:SP` riding GEECS's native blocking set — never `geecs_python_api`'s
+  ScanDevice.  The R3 axis combos auto-select the panel (the legacy
+  scanner behavior), composites included.
 
 ## Architecture rules
 
@@ -78,7 +81,9 @@ are prefixed by region (`r3_radio_1d`, `r5_start_button`, …).
   `request_builder.build_scan_request` is the only place form state becomes
   a request; keep it a pure function, keep widgets out of it.
 - **The window depends on seams, not implementations**: `Submitter`
-  (protocol over `BlueskyScanner`'s four ScanManager-compatible methods),
+  (protocol over `BlueskyScanner`'s Submitter-contract methods —
+  scan lifecycle, on-demand actions, pause/resume, and
+  `move_variable` manual moves),
   `ConsoleConfigs`, `HealthProbe`, `ScanEventsAdapter`, `PresetStore`,
   `ConsoleSettings`.  All constructor-injectable; every test drives the
   window with fakes.
@@ -120,18 +125,37 @@ are prefixed by region (`r3_radio_1d`, `r5_start_button`, …).
   `request.abort[0] = True`; either choice calls `request.response_event.set()`
   to unblock the engine.  Duck-typed on the `DialogRequest` attributes — no
   `geecs_bluesky` import.
-- **Device panel (R7)** is live via `GatewayDevicePanel` (real backend) or
-  `StubDevicePanel` (no-op offline/test default), behind the
-  `DevicePanelBackend` protocol in `services/device_panel.py`.  Readback is
-  a persistent `aioca.camonitor` on the gateway readback PV; because aioca
+- **Movable panel (R7)** — owned by
+  `app/movable_panel.py::MovablePanelController` since 0.19.0 (the #534
+  controller shape: no Qt parent, injected widgets + callables, its own
+  `BackgroundResult` set worker and queued `value_ready` signal, and a
+  `dispose()` the window's `closeEvent` calls).  Selection resolves
+  catalog-first (`ConsoleConfigs.scan_variable_specs()` — the same
+  catalog the R3 axis picker lists): a plain `ScanVariable` monitors its
+  target, a `PseudoScanVariable` monitors **every** component
+  (`subscribe_many`, one live readback per target, rendered compactly by
+  `format_target_readbacks`), and an unresolvable text falls back to the
+  raw `device:variable` parse.  **Sets fork by selection kind**: catalog
+  names dispatch `Submitter.move_variable(name, value)` on the set
+  worker — the engine seam (GeecsBluesky ≥ 0.48.0) with scan-identical
+  completion semantics (motor poll, confirm poll, pseudo fan-out with a
+  fresh relative baseline per move) and refusals ("scan in progress —
+  move not started" / "manual move in progress — …") surfaced verbatim;
+  raw `device:variable` strings keep the direct gateway put (no engine
+  required).  The R3 axis combos' `currentTextChanged` auto-selects the
+  panel (populate churn is signal-blocked; unresolvable names never
+  hijack it).  The transport backend stays `GatewayDevicePanel` (real) or
+  `StubDevicePanel` (offline/test default) behind `DevicePanelBackend`
+  in `services/device_panel.py`.  Readback is
+  a persistent `aioca.camonitor` per target PV; because aioca
   is asyncio-based and the monitor is long-lived, the backend owns **one
   persistent asyncio event loop in one daemon `threading.Thread`**
   (`run_forever`; camonitor open/close submitted via
   `run_coroutine_threadsafe`) — the same **no-QThread** rule as the health
   poller (a worker QThread aborted under offscreen pytest: "QThread
-  destroyed while running").  Values reach the GUI through the window's
-  `device_value_ready(object)` signal, connected **queued** to a
-  `@Slot(object)` — never paint widgets off the GUI thread.  Selection
+  destroyed while running").  Values reach the GUI through the
+  controller's `value_ready(int, object)` signal, connected **queued** to
+  a `@Slot(int, object)` — never paint widgets off the GUI thread.  Selection
   commits (dropdown pick / Enter / focus leave) resubscribe; per-keystroke
   edits only regate the Set button (no CA-monitor churn while typing); a
   generation counter drops straggler callbacks from retired monitors.  Set
@@ -492,9 +516,10 @@ directly.)
   legacy machinery kept for parity; a redesigned hook (bluesky-adaptive
   direction) is planned, at which point `services/optimization.py` and
   the `optimization` extra are deleted together.
-- `ConsoleConfigs._scan_variable_names` reaches into the resolver's private
-  `_scan_variables_catalog()` — promote a public "list variable names"
-  method on `ConfigsRepoResolver` when next touching geecs-bluesky.
+- `ConsoleConfigs.scan_variable_specs()` (and the names listing built on
+  it) reaches into the resolver's private `_scan_variables_catalog()` —
+  promote a public catalog accessor on `ConfigsRepoResolver` when next
+  touching geecs-bluesky.
 - **Remaining M5 item — config bootstrap/repair dialog**: deliberately
   deferred.  When the configs repo (or an experiment's folder inside it)
   is missing/broken, the console currently reports and degrades to empty

--- a/GEECS-Console/CLAUDE.md
+++ b/GEECS-Console/CLAUDE.md
@@ -516,10 +516,10 @@ directly.)
   legacy machinery kept for parity; a redesigned hook (bluesky-adaptive
   direction) is planned, at which point `services/optimization.py` and
   the `optimization` extra are deleted together.
-- `ConsoleConfigs.scan_variable_specs()` (and the names listing built on
-  it) reaches into the resolver's private `_scan_variables_catalog()` —
-  promote a public catalog accessor on `ConfigsRepoResolver` when next
-  touching geecs-bluesky.
+- `ConsoleConfigs.scan_variable_specs()` uses the public
+  `ConfigsRepoResolver.scan_variable_catalog()` accessor (promoted in
+  geecs-bluesky 0.49.0, closing the old reach-into-private debt note);
+  a getattr fallback to the private method keeps older engines working.
 - **Remaining M5 item — config bootstrap/repair dialog**: deliberately
   deferred.  When the configs repo (or an experiment's folder inside it)
   is missing/broken, the console currently reports and degrades to empty

--- a/GEECS-Console/geecs_console/app/main_window.py
+++ b/GEECS-Console/geecs_console/app/main_window.py
@@ -577,12 +577,12 @@ class MainWindow(QMainWindow):
         )
         # R3 → R7 auto-select (the legacy scanner behavior): picking a scan
         # variable re-points the movable panel at it, composites included.
-        self.variable_combo.currentTextChanged.connect(
-            self._movable.select_from_scan_combo
-        )
-        self.variable2_combo.currentTextChanged.connect(
-            self._movable.select_from_scan_combo
-        )
+        # Commit-only (textActivated: dropdown pick / Enter) — NEVER
+        # currentTextChanged: both R3 combos are editable, and a
+        # per-keystroke connection would churn CA monitors and hijack the
+        # panel while the operator types an axis name (review, PR #598).
+        self.variable_combo.textActivated.connect(self._movable.select_from_scan_combo)
+        self.variable2_combo.textActivated.connect(self._movable.select_from_scan_combo)
         # (The actions-menu fetch worker lives on ActionsMenuController;
         # the idle scan-number probe worker on NowPanelController.)
         # Stop dispatch (issue #571): stop_scanning_thread may block briefly
@@ -1608,6 +1608,10 @@ class MainWindow(QMainWindow):
             start.setValue(axis.start)
             stop.setValue(axis.stop)
             step.setValue(axis.step)
+        if form.axes:
+            # setCurrentText is programmatic (no textActivated), so follow
+            # the preset explicitly — axis 1 owns the panel.
+            self._movable.select_from_scan_combo(form.axes[0].variable)
 
         if optimization_name:
             self.optimization_combo.setCurrentText(optimization_name)

--- a/GEECS-Console/geecs_console/app/main_window.py
+++ b/GEECS-Console/geecs_console/app/main_window.py
@@ -18,7 +18,7 @@ import random
 from pathlib import Path
 from typing import Callable, Optional
 
-from PySide6.QtCore import QFile, Qt, QTimer, QUrl, Signal, Slot
+from PySide6.QtCore import QFile, Qt, QTimer, QUrl, Slot
 from PySide6.QtGui import QDesktopServices
 from PySide6.QtUiTools import QUiLoader
 from PySide6.QtWidgets import (
@@ -41,6 +41,7 @@ from PySide6.QtWidgets import (
 from pydantic import ValidationError
 
 from geecs_console.app.actions_menu import ActionsMenuController
+from geecs_console.app.movable_panel import MovablePanelController
 from geecs_console.app.now_panel import NowPanelController
 from geecs_console.editors.action_library_editor import open_action_library_editor
 from geecs_console.editors.save_set_editor import open_save_set_editor
@@ -53,7 +54,6 @@ from geecs_console.app.tooltips import ToolTipSuppressor, apply_operator_tooltip
 from geecs_console.services.background import BackgroundResult, HealthPoller
 from geecs_console.services.device_completions import (
     CompletionsProvider,
-    EmptyCompletions,
     GeecsDbCompletions,
 )
 from geecs_console.version import console_version
@@ -73,9 +73,6 @@ from geecs_console.services.settings import ConsoleSettings
 from geecs_console.services.device_panel import (
     DevicePanelBackend,
     StubDevicePanel,
-    format_readback,
-    parse_device_variable,
-    parse_set_value,
 )
 from geecs_console.services.health import (
     HealthProbe,
@@ -207,8 +204,6 @@ class MainWindow(QMainWindow):
     """
 
     #: One readback value from the device-panel backend (emitted from the CA
-    #: monitor thread; delivered queued to :meth:`_apply_device_value`).
-    device_value_ready = Signal(object)
 
     def __init__(
         self,
@@ -240,7 +235,6 @@ class MainWindow(QMainWindow):
             else ActionLibraryStore(self._configs.experiment)
         )
         self._settings = settings if settings is not None else ConsoleSettings()
-        self._device_set_in_flight = False
         self._submitter = submitter
         self._submitter_factory = (
             submitter_factory
@@ -300,7 +294,6 @@ class MainWindow(QMainWindow):
         self._start_health_poller()
         self._now.set_state_pill("idle")
         self._on_mode_changed()
-        self._refresh_device_set_enabled()
         # Startup fetches for the selected experiment (no-ops when none):
         # R7 device:variable completions, the R6 idle scan-number peek, and
         # the Actions-menu plan names.  Restoring the last experiment already
@@ -315,7 +308,7 @@ class MainWindow(QMainWindow):
         # chain is geecs_data_utils/pandas).  The completions pair still
         # double-spawns and shares the hazard shape (mysql-connector
         # chain); dedupe it the same way if this ever bites.
-        self._start_device_completions_fetch()
+        self._movable.start_completions_fetch()
         self._now.start_idle_probe()
         self._actions.start_fetch()
 
@@ -559,35 +552,36 @@ class MainWindow(QMainWindow):
         self.save_as_button.clicked.connect(self._on_preset_save_as)
         self.delete_button.clicked.connect(self._on_preset_delete)
 
-        # R7 device panel.  Selection commits (dropdown pick / Enter / focus
-        # leave) resubscribe the readback; per-keystroke edits only regate the
-        # Set button — never churn CA monitors while the operator types.
-        self.set_button.clicked.connect(self._on_device_set_clicked)
-        self.set_field.textChanged.connect(self._refresh_device_set_enabled)
-        self.set_field.returnPressed.connect(self._on_device_set_clicked)
-        self.device_combo.editTextChanged.connect(self._refresh_device_set_enabled)
-        self.device_combo.activated.connect(self._resubscribe_device)
-        device_line_edit = self.device_combo.lineEdit()
-        if device_line_edit is not None:
-            device_line_edit.editingFinished.connect(self._resubscribe_device)
-        # Force a queued connection: the signal is emitted off the GUI thread
-        # (the CA monitor thread), and an undecorated direct delivery would
-        # paint widgets there (hard crash).
-        self.device_value_ready.connect(
-            self._apply_device_value, Qt.ConnectionType.QueuedConnection
+        # R7 movable panel: selection, readback(s), completions, and manual
+        # sets/moves all live on MovablePanelController (app/movable_panel.py)
+        # — the window keeps the widget attributes and the composition (the
+        # #534 controller shape; its workers and queued value signal are
+        # controller-owned, per issue #510).
+        self._movable = MovablePanelController(
+            device_combo=self.device_combo,
+            readback_label=self.readback_label,
+            set_field=self.set_field,
+            set_button=self.set_button,
+            backend=self._device_panel,
+            current_experiment=lambda: self.experiment_combo.currentText(),
+            ensure_submitter=self._ensure_submitter,
+            # getattr-guarded: the configs seam is duck-typed and test fakes
+            # (or older injected configs) may not expose the catalog.
+            catalog_specs=lambda: getattr(self._configs, "scan_variable_specs", dict)(),
+            completions_provider=lambda experiment: (
+                self._completions_factory
+                if self._completions_factory is not None
+                else _default_completions_factory
+            )(experiment),
+            report=self._report,
         )
-        # Device-set completion, the R7 completions, and the R6 idle
-        # scan-number peek: each result is emitted by a BackgroundResult
-        # worker (never by the window itself — a daemon-thread emit on a
-        # window-owned signal races teardown, issue #510) and delivered
-        # queued to its GUI-thread apply slot.
-        self._device_set_worker = BackgroundResult()
-        self._device_set_worker.result_ready.connect(
-            self._apply_device_set_result, Qt.ConnectionType.QueuedConnection
+        # R3 → R7 auto-select (the legacy scanner behavior): picking a scan
+        # variable re-points the movable panel at it, composites included.
+        self.variable_combo.currentTextChanged.connect(
+            self._movable.select_from_scan_combo
         )
-        self._completions_worker = BackgroundResult()
-        self._completions_worker.result_ready.connect(
-            self._apply_device_completions, Qt.ConnectionType.QueuedConnection
+        self.variable2_combo.currentTextChanged.connect(
+            self._movable.select_from_scan_combo
         )
         # (The actions-menu fetch worker lives on ActionsMenuController;
         # the idle scan-number probe worker on NowPanelController.)
@@ -666,10 +660,14 @@ class MainWindow(QMainWindow):
         self.trigger_profile_combo.addItems(listing.trigger_profiles)
         self.trigger_profile_combo.blockSignals(False)
         self.trigger_variant_combo.clear()
-        self.variable_combo.clear()
-        self.variable_combo.addItems(listing.scan_variables)
-        self.variable2_combo.clear()
-        self.variable2_combo.addItems(listing.scan_variables)
+        # Repopulation is programmatic — block signals so the R7 auto-select
+        # only follows *operator* picks (and preset applies), never the
+        # populate churn itself.
+        for combo in (self.variable_combo, self.variable2_combo):
+            combo.blockSignals(True)
+            combo.clear()
+            combo.addItems(listing.scan_variables)
+            combo.blockSignals(False)
 
         root = str(listing.configs_root) if listing.configs_root else "not found"
         self._status_configs.setText(f"configs: {root}")
@@ -784,29 +782,9 @@ class MainWindow(QMainWindow):
                 poller.report_ready.disconnect(self._apply_health_report)
             except (RuntimeError, TypeError):
                 pass
-        backend = getattr(self, "_device_panel", None)
-        if backend is not None:
-            try:
-                backend.unsubscribe()
-            except Exception:  # noqa: BLE001 — teardown must not raise
-                pass
-        for worker, slot in (
-            (
-                getattr(self, "_completions_worker", None),
-                self._apply_device_completions,
-            ),
-            (getattr(self, "_device_set_worker", None), self._apply_device_set_result),
-        ):
-            if worker is None:
-                continue
-            try:
-                worker.result_ready.disconnect(slot)
-            except (RuntimeError, TypeError):
-                pass
-        try:
-            self.device_value_ready.disconnect(self._apply_device_value)
-        except (RuntimeError, TypeError):
-            pass
+        movable = getattr(self, "_movable", None)
+        if movable is not None:
+            movable.dispose()
         actions = getattr(self, "_actions", None)
         if actions is not None:
             actions.dispose()
@@ -1118,11 +1096,10 @@ class MainWindow(QMainWindow):
         self._settings.last_experiment = experiment
         self._push_experiment_to_probe(experiment)
         self._populate_from_configs()
-        # The readback PV is experiment-prefixed — re-point the monitor.
-        self._resubscribe_device()
-        # New experiment: new device list, new daily scans folder, and a
-        # new action-plan library.
-        self._start_device_completions_fetch()
+        # The readback PVs are experiment-prefixed — re-point the movable
+        # panel's monitors and refresh its completions; then the new daily
+        # scans folder and the new action-plan library.
+        self._movable.on_experiment_changed()
         self._now.start_idle_probe()
         self._actions.start_fetch()
 
@@ -1727,175 +1704,6 @@ class MainWindow(QMainWindow):
     # ------------------------------------------------------------------
     # R7 device panel
     # ------------------------------------------------------------------
-
-    def _refresh_device_set_enabled(self) -> None:
-        """Gate the Set button: valid ``device:variable``, a value, no put in flight."""
-        ready = (
-            not self._device_set_in_flight
-            and parse_device_variable(self.device_combo.currentText()) is not None
-            and bool(self.set_field.text().strip())
-        )
-        self.set_button.setEnabled(ready)
-
-    def _warn_device_format(self) -> None:
-        """Status-bar hint for an unparsable R7 device selection."""
-        self.statusBar().showMessage("Device format: DeviceName:Variable Name", 10_000)
-
-    def _start_device_completions_fetch(self) -> None:
-        """Fetch R7 ``device:variable`` completions off the GUI thread.
-
-        Mirrors the editors' completions pattern: one blocking provider call
-        on a short-lived daemon thread (via the :class:`BackgroundResult`
-        worker), marshaled back queued to :meth:`_apply_device_completions`
-        — never on the GUI thread.  No experiment (or the
-        :class:`EmptyCompletions` default in tests) answers inline with an
-        empty list, spawning no thread.
-        """
-        experiment = self.experiment_combo.currentText()
-        factory = (
-            self._completions_factory
-            if self._completions_factory is not None
-            else _default_completions_factory
-        )
-        provider = factory(experiment) if experiment else EmptyCompletions()
-        if isinstance(provider, EmptyCompletions):
-            self._apply_device_completions((experiment, []))
-            return
-
-        def fetch() -> tuple[str, list[str]]:
-            try:
-                mapping = provider.device_variables()
-            except Exception as exc:  # noqa: BLE001 — completions are best-effort
-                logger.info("device completions failed: %s", exc)
-                mapping = {}
-            words = sorted(
-                f"{device}:{variable}"
-                for device, variables in (mapping or {}).items()
-                for variable in variables
-            )
-            return (experiment, words)
-
-        self._completions_worker.run_async(fetch, name="console-device-completions")
-
-    @Slot(object)
-    def _apply_device_completions(self, payload: object) -> None:
-        """Populate the R7 combo's dropdown (GUI-thread slot, delivered queued).
-
-        Parameters
-        ----------
-        payload : tuple
-            ``(experiment, ["device:variable", ...])``; a result tagged with
-            an experiment that is no longer selected is dropped (a stale
-            fetch racing an experiment change).
-        """
-        experiment, words = payload
-        if experiment != self.experiment_combo.currentText():
-            return
-        current = self.device_combo.currentText()
-        self.device_combo.blockSignals(True)
-        self.device_combo.clear()
-        self.device_combo.addItems(list(words))
-        self.device_combo.setCurrentIndex(-1)
-        line_edit = self.device_combo.lineEdit()
-        if line_edit is not None:
-            line_edit.setText(current)
-        self.device_combo.blockSignals(False)
-
-    def _resubscribe_device(self, *_args: object) -> None:
-        """Re-point the readback monitor at the combo's current selection.
-
-        Closes the previous monitor first (the backend guarantees straggler
-        callbacks from it are dropped) and resets the label to the em-dash
-        until the new monitor's first value lands.  An unparsable selection
-        leaves the panel unsubscribed.
-        """
-        try:
-            self._device_panel.unsubscribe()
-        except Exception as exc:  # noqa: BLE001 — teardown must not break the GUI
-            self.append_log(f"Readback unsubscribe failed: {exc}")
-        self.readback_label.setText("—")
-        self._refresh_device_set_enabled()
-        parsed = parse_device_variable(self.device_combo.currentText())
-        if parsed is None:
-            # Committed text that doesn't parse gets a visible hint — a
-            # silent no-op looked like a dead panel (user report).
-            if self.device_combo.currentText().strip():
-                self._warn_device_format()
-            return
-        device, variable = parsed
-        try:
-            self._device_panel.subscribe(
-                self.experiment_combo.currentText(),
-                device,
-                variable,
-                self.device_value_ready.emit,
-            )
-        except Exception as exc:  # noqa: BLE001 — surface, don't crash
-            message = f"Readback subscribe failed for {device}:{variable}: {exc}"
-            self.statusBar().showMessage(message, 10_000)
-            self.append_log(message)
-
-    @Slot(object)
-    def _apply_device_value(self, value: object) -> None:
-        """Render one readback value (GUI-thread slot, delivered queued).
-
-        Parameters
-        ----------
-        value : object
-            The monitor value (float / int / string) from the backend.
-        """
-        self.readback_label.setText(format_readback(value))
-
-    def _on_device_set_clicked(self) -> None:
-        """Dispatch the blocking backend set through the set worker.
-
-        The blocking ``backend.set`` runs on a short-lived daemon thread via
-        the :class:`BackgroundResult` set worker, whose ``result_ready``
-        signal delivers the ``(ok, message)`` outcome queued back to
-        :meth:`_apply_device_set_result` — the worker owns the cross-thread
-        emission, never the window (issue #510).  The dispatched callable
-        catches every backend failure and returns it as a result, so the
-        in-flight flag is always re-armed.
-        """
-        parsed = parse_device_variable(self.device_combo.currentText())
-        text = self.set_field.text().strip()
-        if parsed is None:
-            if self.device_combo.currentText().strip():
-                self._warn_device_format()
-            return
-        if not text or self._device_set_in_flight:
-            return
-        device, variable = parsed
-        value = parse_set_value(text)
-        experiment = self.experiment_combo.currentText()
-        backend = self._device_panel
-
-        def run_set() -> tuple[bool, str]:
-            try:
-                backend.set(experiment, device, variable, value)
-            except Exception as exc:  # noqa: BLE001 — any failure is a status report
-                return (False, f"Set {device}:{variable} failed: {exc}")
-            return (True, f"Set {device}:{variable} = {value}")
-
-        self._device_set_in_flight = True
-        self._refresh_device_set_enabled()
-        self._device_set_worker.run_async(run_set, name="console-device-set")
-
-    @Slot(object)
-    def _apply_device_set_result(self, payload: object) -> None:
-        """Report one finished set and re-arm the button (GUI-thread slot).
-
-        Parameters
-        ----------
-        payload : tuple
-            ``(ok, message)`` from the set worker; ``ok`` is unused beyond
-            the message — failures already carry the exception text.
-        """
-        _ok, message = payload
-        self._device_set_in_flight = False
-        self.statusBar().showMessage(message, 10_000)
-        self.append_log(message)
-        self._refresh_device_set_enabled()
 
     # ------------------------------------------------------------------
     # R6 now panel

--- a/GEECS-Console/geecs_console/app/movable_panel.py
+++ b/GEECS-Console/geecs_console/app/movable_panel.py
@@ -316,15 +316,23 @@ class MovablePanelController(QObject):
                 return
 
             def run_move(name: str = name, value: Any = value) -> tuple[bool, str]:
+                # The WHOLE body is guarded: BackgroundResult swallows a
+                # raising job without emitting, which would leave
+                # _set_in_flight stuck True (Set dead for the session) —
+                # so even result-formatting surprises must become a report
+                # (review, PR #598).
                 try:
                     result = submitter.move_variable(name, value)
+                    targets_text = ", ".join(
+                        f"{target}={commanded:g}"
+                        for target, commanded in (result.get("targets") or {}).items()
+                    )
+                    return (
+                        True,
+                        f"Moved {name} = {result.get('value')} ({targets_text})",
+                    )
                 except Exception as exc:  # noqa: BLE001 — any failure is a report
                     return (False, f"Move {name} failed: {exc}")
-                targets_text = ", ".join(
-                    f"{target}={commanded:g}"
-                    for target, commanded in (result.get("targets") or {}).items()
-                )
-                return (True, f"Moved {name} = {result.get('value')} ({targets_text})")
 
             job = run_move
         else:
@@ -443,8 +451,11 @@ class MovablePanelController(QObject):
             self.value_ready.disconnect(self._apply_value)
         except (RuntimeError, TypeError):
             pass
-        # Sever every controller → window edge (the #534 lifetime rule).
+        # Sever every controller → window edge (the #534 lifetime rule) —
+        # the completions provider included: the window passes it as a
+        # lambda closing over itself (review, PR #598).
         self._current_experiment = _inert
         self._ensure_submitter = _inert
         self._catalog_specs = _inert
+        self._completions_provider = lambda _experiment: EmptyCompletions()
         self._report = lambda _message: None

--- a/GEECS-Console/geecs_console/app/movable_panel.py
+++ b/GEECS-Console/geecs_console/app/movable_panel.py
@@ -1,0 +1,450 @@
+"""MovablePanelController — the catalog-aware R7 movable panel (issue #534 shape).
+
+Owns the R7 surface the window previously ran inline: the editable
+device/variable combo (completions + selection commits), the readback
+label, and the set field/button — and makes the panel **catalog-aware**.
+A selection is resolved in this order:
+
+1. **A catalog scan-variable name** (the same names the R3 axis picker
+   lists): a plain :class:`~geecs_schemas.scan_variables.ScanVariable`
+   monitors its target readback; a composite
+   :class:`~geecs_schemas.scan_variables.PseudoScanVariable` monitors
+   *every* component readback (``subscribe_many``) and renders them
+   compactly.  Sets go through ``Submitter.move_variable`` — the engine's
+   manual-move seam (GeecsBluesky ≥ 0.48.0), carrying scan-identical
+   completion semantics (motor poll, confirm poll, pseudo fan-out with a
+   fresh relative baseline per move).
+2. **A raw ``device:variable`` string**: exactly the historical panel —
+   readback monitor + a plain gateway ``:SP`` put through the
+   :class:`~geecs_console.services.device_panel.DevicePanelBackend`
+   (no engine required).
+
+The R3 axis combos auto-select the panel: picking a scan variable for a
+scan re-points the panel at it (the legacy scanner behavior), composites
+included.
+
+Controller rules (the #534 pattern — mirrors ``NowPanelController`` /
+``ActionsMenuController``): a plain ``QObject`` with **no Qt parent**
+(the window holds the only Python reference; parenting would create the
+window↔controller cycle that defers C++ teardown to the cyclic GC — a
+segfault under offscreen pytest), every dependency constructor-injected,
+blocking work on the controller's own :class:`BackgroundResult` worker
+(issue #510: the daemon thread emits on the worker, never the window),
+monitor values delivered through the controller's **queued** ``value_ready``
+signal, and an idempotent :meth:`dispose` (called from the window's
+``closeEvent``) that unsubscribes, disconnects, and severs every
+controller→window reference.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Callable, Optional
+
+from PySide6.QtCore import QObject, Qt, Signal, Slot
+from PySide6.QtWidgets import QComboBox, QLabel, QLineEdit, QPushButton
+
+from geecs_console.services.background import BackgroundResult
+from geecs_console.services.device_panel import (
+    DevicePanelBackend,
+    format_readback,
+    format_target_readbacks,
+    parse_device_variable,
+    parse_set_value,
+)
+from geecs_console.services.device_completions import (
+    CompletionsProvider,
+    EmptyCompletions,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def _inert() -> Any:
+    """Replacement closure installed by :meth:`dispose` (returns nothing)."""
+    return None
+
+
+class MovablePanelController(QObject):
+    """Catalog-aware movable panel: selection, readback(s), manual moves.
+
+    Parameters
+    ----------
+    device_combo, readback_label, set_field, set_button :
+        The R7 widgets (stay attributes on the window — tests and tooltips
+        address them there; this controller is the only writer).
+    backend :
+        The :class:`DevicePanelBackend` (readback monitors + raw sets).
+    current_experiment :
+        Zero-arg callable returning the selected experiment name.
+    ensure_submitter :
+        Zero-arg callable returning the engine ``Submitter`` (built lazily)
+        or ``None`` when the engine is unavailable — catalog moves need it;
+        raw ``device:variable`` sets do not.
+    catalog_specs :
+        Zero-arg callable returning ``{name: ScanVariableSpec}`` for the
+        current experiment (empty offline).
+    completions_provider :
+        One-arg callable ``experiment -> CompletionsProvider`` (the window
+        resolves the injected/test factory).
+    report :
+        One-arg callable for status-bar + log-tail messages.
+    """
+
+    #: (target_index, value) from the CA monitor thread — connected queued.
+    value_ready = Signal(int, object)
+
+    def __init__(
+        self,
+        *,
+        device_combo: QComboBox,
+        readback_label: QLabel,
+        set_field: QLineEdit,
+        set_button: QPushButton,
+        backend: DevicePanelBackend,
+        current_experiment: Callable[[], str],
+        ensure_submitter: Callable[[], Any],
+        catalog_specs: Callable[[], dict],
+        completions_provider: Callable[[str], CompletionsProvider],
+        report: Callable[[str], None],
+    ) -> None:
+        super().__init__()  # no Qt parent — the window holds the only ref
+        self._combo = device_combo
+        self._readback_label = readback_label
+        self._set_field = set_field
+        self._set_button = set_button
+        self._backend = backend
+        self._current_experiment = current_experiment
+        self._ensure_submitter = ensure_submitter
+        self._catalog_specs = catalog_specs
+        self._completions_provider = completions_provider
+        self._report = report
+
+        #: The committed selection's monitored targets and their values.
+        self._targets: list[tuple[str, str]] = []
+        self._values: list[Any] = []
+        #: Catalog name when the selection is a catalog variable, else None.
+        self._catalog_name: Optional[str] = None
+        self._set_in_flight = False
+        self._disposed = False
+
+        self.value_ready.connect(self._apply_value, Qt.ConnectionType.QueuedConnection)
+        self._set_worker = BackgroundResult()
+        self._set_worker.result_ready.connect(
+            self._apply_set_result, Qt.ConnectionType.QueuedConnection
+        )
+        self._completions_worker = BackgroundResult()
+        self._completions_worker.result_ready.connect(
+            self._apply_completions, Qt.ConnectionType.QueuedConnection
+        )
+
+        # Selection commits (dropdown pick / Enter / focus leave)
+        # resubscribe; per-keystroke edits only regate the Set button —
+        # never churn CA monitors while the operator types.
+        self._set_button.clicked.connect(self._on_set_clicked)
+        self._set_field.returnPressed.connect(self._on_set_clicked)
+        self._set_field.textChanged.connect(self.refresh_set_enabled)
+        self._combo.editTextChanged.connect(self.refresh_set_enabled)
+        self._combo.activated.connect(self.resubscribe)
+        line_edit = self._combo.lineEdit()
+        if line_edit is not None:
+            line_edit.editingFinished.connect(self.resubscribe)
+
+        self.refresh_set_enabled()
+
+    # ------------------------------------------------------------------
+    # Selection & readback
+    # ------------------------------------------------------------------
+
+    def _resolve_selection(
+        self, text: str
+    ) -> tuple[Optional[str], list[tuple[str, str]]]:
+        """Resolve combo text → ``(catalog_name, monitored_targets)``.
+
+        Catalog names win over the raw ``device:variable`` parse (a name
+        never contains a colon, so the two cannot collide in practice).
+        An unresolvable text returns ``(None, [])``.
+        """
+        text = text.strip()
+        if not text:
+            return None, []
+        specs = self._catalog_specs() or {}
+        spec = specs.get(text)
+        if spec is not None:
+            if getattr(spec, "kind", None) == "pseudo":
+                targets = [
+                    parse_device_variable(component.target) or ("", "")
+                    for component in spec.targets
+                ]
+                return text, [t for t in targets if t != ("", "")]
+            parsed = parse_device_variable(getattr(spec, "target", ""))
+            return text, [parsed] if parsed else []
+        parsed = parse_device_variable(text)
+        return None, [parsed] if parsed else []
+
+    def resubscribe(self, *_args: object) -> None:
+        """Re-point the readback monitor(s) at the combo's current selection.
+
+        Closes the previous monitors first (the backend drops straggler
+        callbacks from them) and resets the label to the em-dash until new
+        values land.  An unresolvable selection leaves the panel
+        unsubscribed with a visible format hint (a silent no-op looked
+        like a dead panel — user report).
+        """
+        try:
+            self._backend.unsubscribe()
+        except Exception as exc:  # noqa: BLE001 — teardown must not break the GUI
+            self._report(f"Readback unsubscribe failed: {exc}")
+        self._readback_label.setText("—")
+        self.refresh_set_enabled()
+        text = self._combo.currentText()
+        self._catalog_name, self._targets = self._resolve_selection(text)
+        self._values = [None] * len(self._targets)
+        if not self._targets:
+            if text.strip():
+                self._warn_format()
+            return
+        try:
+            subscribe_many = getattr(self._backend, "subscribe_many", None)
+            if subscribe_many is not None:
+                subscribe_many(
+                    self._current_experiment(),
+                    list(self._targets),
+                    self.value_ready.emit,
+                )
+            elif len(self._targets) == 1:
+                # Older/injected single-monitor backends (duck-typed seam).
+                device, variable = self._targets[0]
+                self._backend.subscribe(
+                    self._current_experiment(),
+                    device,
+                    variable,
+                    lambda value: self.value_ready.emit(0, value),
+                )
+            else:
+                self._report(
+                    "This device-panel backend cannot monitor a composite "
+                    "(no subscribe_many)"
+                )
+        except Exception as exc:  # noqa: BLE001 — surface, don't crash
+            self._report(f"Readback subscribe failed for {text.strip()}: {exc}")
+
+    def select_from_scan_combo(self, text: str) -> None:
+        """Auto-select *text* when the operator picks a scan variable (R3).
+
+        The legacy scanner behavior: the variable chosen for a scan is the
+        one the operator wants on the panel — composites included.  A
+        blank text (mid-repopulation) is ignored; re-selecting the current
+        selection is a no-op (no CA-monitor churn).
+        """
+        text = text.strip()
+        if not text or text == self._combo.currentText().strip():
+            return
+        name, targets = self._resolve_selection(text)
+        if name is None and not targets:
+            # Unresolvable here (e.g. no catalog offline) — leave the panel
+            # alone rather than hijack it with a dead selection.
+            return
+        line_edit = self._combo.lineEdit()
+        self._combo.blockSignals(True)
+        if line_edit is not None:
+            line_edit.setText(text)
+        else:  # pragma: no cover — the combo is editable by construction
+            self._combo.setCurrentText(text)
+        self._combo.blockSignals(False)
+        self.resubscribe()
+
+    @Slot(int, object)
+    def _apply_value(self, index: int, value: object) -> None:
+        """Render one monitor value (GUI-thread slot, delivered queued)."""
+        if not (0 <= index < len(self._values)):
+            return  # straggler from a retired subscription shape
+        self._values[index] = value
+        if len(self._targets) == 1:
+            self._readback_label.setText(format_readback(value))
+        else:
+            self._readback_label.setText(
+                format_target_readbacks(self._targets, self._values)
+            )
+
+    # ------------------------------------------------------------------
+    # Set / move
+    # ------------------------------------------------------------------
+
+    def refresh_set_enabled(self, *_args: object) -> None:
+        """Gate the Set button: resolvable selection, a value, nothing in flight."""
+        name, targets = self._resolve_selection(self._combo.currentText())
+        ready = (
+            not self._set_in_flight
+            and (name is not None or bool(targets))
+            and bool(self._set_field.text().strip())
+        )
+        self._set_button.setEnabled(ready)
+
+    def _warn_format(self) -> None:
+        """Status-bar hint for an unresolvable R7 selection."""
+        self._report(
+            "Device format: DeviceName:Variable Name — or a catalog scan-variable name"
+        )
+
+    def _on_set_clicked(self) -> None:
+        """Dispatch the blocking set/move through the set worker.
+
+        Catalog selections go through ``Submitter.move_variable`` (the
+        engine seam — scan-identical completion semantics; refusals like
+        ``"scan in progress — move not started"`` surface verbatim).  Raw
+        ``device:variable`` selections keep the historical direct gateway
+        put.  Either way the blocking call runs on a short-lived daemon
+        thread via :class:`BackgroundResult` (issue #510) and the
+        ``(ok, message)`` outcome returns queued to
+        :meth:`_apply_set_result`.
+        """
+        text = self._set_field.text().strip()
+        if not text or self._set_in_flight:
+            return
+        name, targets = self._resolve_selection(self._combo.currentText())
+        if name is None and not targets:
+            if self._combo.currentText().strip():
+                self._warn_format()
+            return
+        value = parse_set_value(text)
+
+        if name is not None:
+            submitter = self._ensure_submitter()
+            if submitter is None:
+                self._report(f"Cannot move {name!r}: scan engine unavailable")
+                return
+
+            def run_move(name: str = name, value: Any = value) -> tuple[bool, str]:
+                try:
+                    result = submitter.move_variable(name, value)
+                except Exception as exc:  # noqa: BLE001 — any failure is a report
+                    return (False, f"Move {name} failed: {exc}")
+                targets_text = ", ".join(
+                    f"{target}={commanded:g}"
+                    for target, commanded in (result.get("targets") or {}).items()
+                )
+                return (True, f"Moved {name} = {result.get('value')} ({targets_text})")
+
+            job = run_move
+        else:
+            device, variable = targets[0]
+            backend = self._backend
+            experiment = self._current_experiment()
+
+            def run_set(
+                device: str = device, variable: str = variable, value: Any = value
+            ) -> tuple[bool, str]:
+                try:
+                    backend.set(experiment, device, variable, value)
+                except Exception as exc:  # noqa: BLE001 — any failure is a report
+                    return (False, f"Set {device}:{variable} failed: {exc}")
+                return (True, f"Set {device}:{variable} = {value}")
+
+            job = run_set
+
+        self._set_in_flight = True
+        self.refresh_set_enabled()
+        self._set_worker.run_async(job, name="console-movable-set")
+
+    @Slot(object)
+    def _apply_set_result(self, payload: object) -> None:
+        """Report one finished set/move and re-arm the button (GUI slot)."""
+        _ok, message = payload
+        self._set_in_flight = False
+        self._report(message)
+        self.refresh_set_enabled()
+
+    # ------------------------------------------------------------------
+    # Completions
+    # ------------------------------------------------------------------
+
+    def start_completions_fetch(self) -> None:
+        """Fetch the dropdown entries off the GUI thread.
+
+        The dropdown lists the experiment's **catalog scan-variable names
+        first** (composites are first-class selections here), then the DB
+        ``device:variable`` completions.  One blocking provider call on the
+        worker; no experiment (or the :class:`EmptyCompletions` test
+        default) answers inline with the catalog names only.
+        """
+        experiment = self._current_experiment()
+        catalog_names = sorted(self._catalog_specs() or {})
+        provider = (
+            self._completions_provider(experiment) if experiment else EmptyCompletions()
+        )
+        if isinstance(provider, EmptyCompletions):
+            self._apply_completions((experiment, catalog_names))
+            return
+
+        def fetch() -> tuple[str, list[str]]:
+            try:
+                mapping = provider.device_variables()
+            except Exception as exc:  # noqa: BLE001 — completions are best-effort
+                logger.info("device completions failed: %s", exc)
+                mapping = {}
+            words = sorted(
+                f"{device}:{variable}"
+                for device, variables in (mapping or {}).items()
+                for variable in variables
+            )
+            return (experiment, catalog_names + words)
+
+        self._completions_worker.run_async(fetch, name="console-device-completions")
+
+    @Slot(object)
+    def _apply_completions(self, payload: object) -> None:
+        """Populate the combo's dropdown (GUI-thread slot, delivered queued).
+
+        A result tagged with an experiment that is no longer selected is
+        dropped (a stale fetch racing an experiment change); typed text
+        survives repopulation.
+        """
+        experiment, words = payload
+        if experiment != self._current_experiment():
+            return
+        current = self._combo.currentText()
+        self._combo.blockSignals(True)
+        self._combo.clear()
+        self._combo.addItems(list(words))
+        self._combo.setCurrentIndex(-1)
+        line_edit = self._combo.lineEdit()
+        if line_edit is not None:
+            line_edit.setText(current)
+        self._combo.blockSignals(False)
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    def on_experiment_changed(self) -> None:
+        """Re-point the monitors and refresh completions (new PV prefix)."""
+        self.resubscribe()
+        self.start_completions_fetch()
+
+    def dispose(self) -> None:
+        """Idempotent teardown: unsubscribe, disconnect, sever window refs."""
+        if self._disposed:
+            return
+        self._disposed = True
+        try:
+            self._backend.unsubscribe()
+        except Exception:  # noqa: BLE001 — teardown must not raise
+            pass
+        for worker, slot in (
+            (self._set_worker, self._apply_set_result),
+            (self._completions_worker, self._apply_completions),
+        ):
+            try:
+                worker.result_ready.disconnect(slot)
+            except (RuntimeError, TypeError):
+                pass
+        try:
+            self.value_ready.disconnect(self._apply_value)
+        except (RuntimeError, TypeError):
+            pass
+        # Sever every controller → window edge (the #534 lifetime rule).
+        self._current_experiment = _inert
+        self._ensure_submitter = _inert
+        self._catalog_specs = _inert
+        self._report = lambda _message: None

--- a/GEECS-Console/geecs_console/services/configs.py
+++ b/GEECS-Console/geecs_console/services/configs.py
@@ -144,14 +144,25 @@ class ConsoleConfigs:
 
     def _scan_variable_names(self) -> list[str]:
         """Load the scan-variable catalog names (needs YAML, so resolver-backed)."""
+        return sorted(self.scan_variable_specs())
+
+    def scan_variable_specs(self) -> dict:
+        """The experiment's scan-variable catalog as ``{name: spec}``.
+
+        Each value is a validated
+        :class:`geecs_schemas.scan_variables.ScanVariableSpec` (a plain
+        ``ScanVariable`` or a composite ``PseudoScanVariable``) — the
+        movable panel branches on the spec's shape.  Empty when offline or
+        the catalog is missing/broken (never raises).
+        """
         resolver = self._get_resolver()
         if resolver is None:
-            return []
+            return {}
         try:
-            return sorted(resolver._scan_variables_catalog().variables)
+            return dict(resolver._scan_variables_catalog().variables)
         except Exception as exc:
             logger.info("scan-variable catalog unavailable: %s", exc)
-            return []
+            return {}
 
     # ------------------------------------------------------------------
     # Validation-on-demand (resolver-backed)

--- a/GEECS-Console/geecs_console/services/configs.py
+++ b/GEECS-Console/geecs_console/services/configs.py
@@ -159,7 +159,12 @@ class ConsoleConfigs:
         if resolver is None:
             return {}
         try:
-            return dict(resolver._scan_variables_catalog().variables)
+            # Public accessor since geecs-bluesky 0.49.0; fall back to the
+            # private cache method on older engines.
+            accessor = getattr(
+                resolver, "scan_variable_catalog", resolver._scan_variables_catalog
+            )
+            return dict(accessor().variables)
         except Exception as exc:
             logger.info("scan-variable catalog unavailable: %s", exc)
             return {}

--- a/GEECS-Console/geecs_console/services/device_panel.py
+++ b/GEECS-Console/geecs_console/services/device_panel.py
@@ -1,11 +1,15 @@
 """Device panel seam (R7): live gateway readback + ``:SP`` setpoint puts.
 
 The protocol and a no-op stub live here alongside the real
-:class:`GatewayDevicePanel`: a persistent ``aioca.camonitor`` on the readback
-PV (values flow to the GUI through a queued Qt signal owned by the window)
-and setpoint puts through :class:`~geecs_bluesky.devices.ca.gateway_put.
-GatewaySetpointPut` — the one blessed gateway ``:SP`` put primitive, riding
-GEECS's native blocking set.
+:class:`GatewayDevicePanel`: persistent ``aioca.camonitor`` streams on the
+readback PV(s) — one per target; ``subscribe_many`` backs the movable
+panel's composite selections (values flow to the GUI through a queued Qt
+signal owned by ``MovablePanelController``) — and setpoint puts through
+:class:`~geecs_bluesky.devices.ca.gateway_put.GatewaySetpointPut` — the one
+blessed gateway ``:SP`` put primitive, riding GEECS's native blocking set.
+Catalog-level moves (composites, motors, confirm variables) do NOT go
+through this backend: the controller routes them to the engine's
+``Submitter.move_variable``.
 
 Threading model (mirrors the health-probe precedent — **no QThread**, ever):
 ``aioca`` is asyncio-based, so the real backend owns ONE persistent asyncio
@@ -19,7 +23,7 @@ daemonic and dies with the process.
 
 Every real dependency (``aioca``, the geecs-bluesky PV helpers) is imported
 lazily inside methods, keeping this module import-safe with zero network and
-without the ``ca`` extra.  Scalar-only, per the package charter.
+without the ``ca`` extra.
 """
 
 from __future__ import annotations
@@ -53,8 +57,23 @@ class DevicePanelBackend(Protocol):
         """Start a readback stream; *on_value* may fire on any thread."""
         ...
 
+    def subscribe_many(
+        self,
+        experiment: str,
+        targets: list[tuple[str, str]],
+        on_value: Callable[[int, Any], None],
+    ) -> None:
+        """Start one readback stream per ``(device, variable)`` target.
+
+        *on_value* is called with ``(target_index, value)`` and may fire on
+        any thread.  Replaces any previous subscription (single or many).
+        Backs the movable panel's composite (pseudo) selections — one live
+        readback per component.
+        """
+        ...
+
     def unsubscribe(self) -> None:
-        """Stop the current readback stream (no-op when none is active)."""
+        """Stop the current readback stream(s) (no-op when none is active)."""
         ...
 
     def set(self, experiment: str, device: str, variable: str, value: Any) -> None:
@@ -77,6 +96,25 @@ class StubDevicePanel:
         Parameters
         ----------
         experiment, device, variable : str
+            Ignored.
+        on_value : callable
+            Never called.
+        """
+        return None
+
+    def subscribe_many(
+        self,
+        experiment: str,
+        targets: list[tuple[str, str]],
+        on_value: Callable[[int, Any], None],
+    ) -> None:
+        """No-op: the stub has no readback source.
+
+        Parameters
+        ----------
+        experiment : str
+            Ignored.
+        targets : list of tuple
             Ignored.
         on_value : callable
             Never called.
@@ -217,6 +255,36 @@ def setpoint_pv(experiment: str, device: str, variable: str) -> str:
     return sp(readback_pv(experiment, device, variable))
 
 
+def format_target_readbacks(targets: list[tuple[str, str]], values: list[Any]) -> str:
+    """Render per-target readbacks for a composite selection, compactly.
+
+    Parameters
+    ----------
+    targets : list of tuple
+        The ``(device, variable)`` pairs of a composite's components.
+    values : list
+        The latest monitor value per target (``None`` = not yet delivered).
+
+    Returns
+    -------
+    str
+        One ``device value`` chunk per target joined with a middle dot —
+        device names alone when they are unique (the common composite
+        shape), ``device:variable`` when a device appears twice.
+    """
+    em_dash = "\u2014"
+    devices = [device for device, _ in targets]
+    labels = [
+        device if devices.count(device) == 1 else f"{device}:{variable}"
+        for device, variable in targets
+    ]
+    chunks = [
+        f"{label} {format_readback(value) if value is not None else em_dash}"
+        for label, value in zip(labels, values)
+    ]
+    return " \u00b7 ".join(chunks)
+
+
 # ----------------------------------------------------------------------
 # The real backend
 # ----------------------------------------------------------------------
@@ -243,7 +311,7 @@ class GatewayDevicePanel:
         self._loop: Optional[asyncio.AbstractEventLoop] = None
         self._loop_lock = threading.Lock()
         self._generation = 0
-        self._pending_subscription: Any = None  # Future -> aioca Subscription
+        self._pending_subscription: Any = None  # list[Future -> Subscription]
 
     def _ensure_loop(self) -> asyncio.AbstractEventLoop:
         """Return the persistent CA event loop, starting it on first use.
@@ -280,39 +348,65 @@ class GatewayDevicePanel:
             Raw GEECS names; the PV comes from :func:`readback_pv`.
         on_value : callable
             Called with each monitor value **on the CA loop thread** — the
-            window passes a queued Qt signal's ``emit``, so values land on
+            caller passes a queued Qt signal's ``emit``, so values land on
             the GUI thread.
         """
+        self.subscribe_many(
+            experiment, [(device, variable)], lambda _index, value: on_value(value)
+        )
+
+    def subscribe_many(
+        self,
+        experiment: str,
+        targets: list[tuple[str, str]],
+        on_value: Callable[[int, Any], None],
+    ) -> None:
+        """Open one CA monitor per target; returns immediately.
+
+        Parameters
+        ----------
+        experiment : str
+            Experiment prefix for every target PV.
+        targets : list of tuple
+            ``(device, variable)`` pairs (a composite's components).
+        on_value : callable
+            Called with ``(target_index, value)`` **on the CA loop
+            thread** — route through a queued Qt signal.
+        """
         self.unsubscribe()
-        pv = readback_pv(experiment, device, variable)
         generation = self._generation
-
-        def _dispatch(value: Any) -> None:
-            # Drop stragglers from a monitor unsubscribe() already retired.
-            if generation == self._generation:
-                on_value(value)
-
-        async def _start() -> Any:
-            import aioca  # deferred: needs the `ca` extra
-
-            return aioca.camonitor(pv, _dispatch)
-
         loop = self._ensure_loop()
-        self._pending_subscription = asyncio.run_coroutine_threadsafe(_start(), loop)
+        pending: list[Any] = []
+        for index, (device, variable) in enumerate(targets):
+            pv = readback_pv(experiment, device, variable)
+
+            def _dispatch(value: Any, index: int = index) -> None:
+                # Drop stragglers from monitors unsubscribe() already retired.
+                if generation == self._generation:
+                    on_value(index, value)
+
+            async def _start(pv: str = pv, dispatch: Any = _dispatch) -> Any:
+                import aioca  # deferred: needs the `ca` extra
+
+                return aioca.camonitor(pv, dispatch)
+
+            pending.append(asyncio.run_coroutine_threadsafe(_start(), loop))
+        self._pending_subscription = pending
 
     def unsubscribe(self) -> None:
-        """Close the active monitor (if any); returns immediately, never joins."""
+        """Close the active monitor(s); returns immediately, never joins."""
         self._generation += 1
         pending, self._pending_subscription = self._pending_subscription, None
-        if pending is None or self._loop is None:
+        if not pending or self._loop is None:
             return
 
         async def _close() -> None:
-            try:
-                subscription = await asyncio.wrap_future(pending)
-                subscription.close()
-            except Exception as exc:  # noqa: BLE001 — teardown must not raise
-                logger.debug("closing readback monitor failed: %s", exc)
+            for item in pending:
+                try:
+                    subscription = await asyncio.wrap_future(item)
+                    subscription.close()
+                except Exception as exc:  # noqa: BLE001 — teardown must not raise
+                    logger.debug("closing readback monitor failed: %s", exc)
 
         asyncio.run_coroutine_threadsafe(_close(), self._loop)
 

--- a/GEECS-Console/geecs_console/submission.py
+++ b/GEECS-Console/geecs_console/submission.py
@@ -60,6 +60,19 @@ class Submitter(Protocol):
         """
         ...
 
+    def move_variable(self, name: str, value: float) -> dict:
+        """Move one catalog scan variable (or raw ``Device:Variable``) now.
+
+        The manual-move member (maps to ``BlueskyScanner.move_variable``,
+        GeecsBluesky ≥ 0.48.0): the move carries scan-identical completion
+        semantics (motor poll, confirm poll, pseudo/composite fan-out with
+        fresh relative baselines per call).  Blocking — dispatch off the
+        GUI thread.  Returns ``{"variable", "kind", "value", "targets"}``;
+        raises ``RuntimeError`` with an operator-readable message while a
+        scan or another move is active.
+        """
+        ...
+
     def request_pause(self) -> None:
         """Pause the running scan at its next safe point (operator Pause).
 

--- a/GEECS-Console/pyproject.toml
+++ b/GEECS-Console/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-console"
-version = "0.18.3"
+version = "0.19.0"
 description = "Greenfield PySide6 operator console for GEECS (Bluesky/gateway architecture)"
 authors = ["Sam Barber <sbarber@lbl.gov>"]
 readme = "README.md"

--- a/GEECS-Console/tests/test_device_panel.py
+++ b/GEECS-Console/tests/test_device_panel.py
@@ -207,6 +207,40 @@ class TestGatewayDevicePanel:
         subscription.callback(9.9)
         assert values == []
 
+    def test_subscribe_many_opens_one_monitor_per_target(self, fake_aioca):
+        panel = GatewayDevicePanel()
+        received = []
+        panel.subscribe_many(
+            "HTU",
+            [("U_S3H", "Current"), ("U_S4H", "Current")],
+            lambda index, value: received.append((index, value)),
+        )
+        assert wait_for(lambda: len(fake_aioca.subscriptions) == 2)
+        assert [s.pv for s in fake_aioca.subscriptions] == [
+            "htu:u_s3h:current",
+            "htu:u_s4h:current",
+        ]
+        fake_aioca.subscriptions[1].callback(-0.1)
+        fake_aioca.subscriptions[0].callback(0.05)
+        assert received == [(1, -0.1), (0, 0.05)]
+        panel.unsubscribe()
+        assert wait_for(lambda: all(s.closed for s in fake_aioca.subscriptions))
+
+    def test_subscribe_many_stragglers_dropped_after_unsubscribe(self, fake_aioca):
+        panel = GatewayDevicePanel()
+        received = []
+        panel.subscribe_many(
+            "HTU",
+            [("A", "x"), ("B", "y")],
+            lambda index, value: received.append((index, value)),
+        )
+        assert wait_for(lambda: len(fake_aioca.subscriptions) == 2)
+        retired = list(fake_aioca.subscriptions)
+        panel.unsubscribe()
+        for subscription in retired:
+            subscription.callback(9.9)
+        assert received == []
+
     def test_unsubscribe_without_subscribe_is_noop(self):
         GatewayDevicePanel().unsubscribe()  # must not raise, must not spin a loop
 

--- a/GEECS-Console/tests/test_main_window.py
+++ b/GEECS-Console/tests/test_main_window.py
@@ -1146,6 +1146,14 @@ class FakeDevicePanel:
         self.subscriptions.append((experiment, device, variable))
         self.on_value = on_value
 
+    def subscribe_many(self, experiment, targets, on_value):
+        # The controller path: record one row per target; keep the
+        # single-value `on_value` shape working for one-target tests.
+        for device, variable in targets:
+            self.subscriptions.append((experiment, device, variable))
+        self.on_value_indexed = on_value
+        self.on_value = lambda value: on_value(0, value)
+
     def unsubscribe(self):
         self.unsubscribes += 1
         self.on_value = None
@@ -1186,7 +1194,7 @@ class TestDevicePanel:
     def test_selection_commit_subscribes_with_parsed_names(self, device_window):
         win, backend = device_window
         win.device_combo.setCurrentText("U_Hexapod:ypos")
-        win._resubscribe_device()  # editingFinished path
+        win._movable.resubscribe()  # editingFinished path
         assert backend.subscriptions == [("TestExp", "U_Hexapod", "ypos")]
         assert win.readback_label.text() == "—"
 
@@ -1195,7 +1203,7 @@ class TestDevicePanel:
 
         win, backend = device_window
         win.device_combo.setCurrentText("Dev:Var")
-        win._resubscribe_device()
+        win._movable.resubscribe()
         # Fire the value from a non-GUI thread, as the CA monitor loop would;
         # the queued signal must marshal it onto the GUI-thread slot.
         threading.Thread(
@@ -1206,17 +1214,17 @@ class TestDevicePanel:
     def test_string_readback_renders_as_is(self, device_window, qtbot):
         win, backend = device_window
         win.device_combo.setCurrentText("Dev:Var")
-        win._resubscribe_device()
+        win._movable.resubscribe()
         backend.on_value("Connected")
         qtbot.waitUntil(lambda: win.readback_label.text() == "Connected", timeout=3000)
 
     def test_switching_selection_unsubscribes_then_resubscribes(self, device_window):
         win, backend = device_window
         win.device_combo.setCurrentText("Dev:Var")
-        win._resubscribe_device()
+        win._movable.resubscribe()
         unsubscribes_after_first = backend.unsubscribes
         win.device_combo.setCurrentText("Dev2:Var2")
-        win._resubscribe_device()
+        win._movable.resubscribe()
         assert backend.unsubscribes == unsubscribes_after_first + 1
         assert backend.subscriptions[-1] == ("TestExp", "Dev2", "Var2")
         assert win.readback_label.text() == "—"  # reset until the new value lands
@@ -1224,7 +1232,7 @@ class TestDevicePanel:
     def test_invalid_selection_leaves_panel_unsubscribed(self, device_window):
         win, backend = device_window
         win.device_combo.setCurrentText("not-a-pair")
-        win._resubscribe_device()
+        win._movable.resubscribe()
         assert backend.subscriptions == []
         assert win.readback_label.text() == "—"
 
@@ -1247,7 +1255,7 @@ class TestDevicePanel:
         win, backend = device_window
         win.device_combo.setCurrentText("Dev:Trigger.Source")
         win.set_field.setText("Single shot")
-        win._on_device_set_clicked()
+        win._movable._on_set_clicked()
         qtbot.waitUntil(
             lambda: backend.set_calls
             == [("TestExp", "Dev", "Trigger.Source", "Single shot")],
@@ -1261,7 +1269,7 @@ class TestDevicePanel:
         )
         win.device_combo.setCurrentText("Dev:Var")
         win.set_field.setText("1.0")
-        win._on_device_set_clicked()
+        win._movable._on_set_clicked()
         qtbot.waitUntil(
             lambda: "Set Dev:Var failed: gateway rejected"
             in win.log_tail.toPlainText(),
@@ -1272,7 +1280,7 @@ class TestDevicePanel:
     def test_stub_set_reports_unwired(self, window, qtbot):
         window.device_combo.setCurrentText("Dev:Var")
         window.set_field.setText("1.0")
-        window._on_device_set_clicked()
+        window._movable._on_set_clicked()
         qtbot.waitUntil(
             lambda: "not wired" in window.log_tail.toPlainText(), timeout=3000
         )
@@ -1280,7 +1288,7 @@ class TestDevicePanel:
     def test_experiment_change_resubscribes_readback(self, device_window):
         win, backend = device_window
         win.device_combo.setCurrentText("Dev:Var")
-        win._resubscribe_device()
+        win._movable.resubscribe()
         win._on_experiment_changed("Bella")
         assert backend.subscriptions[-1] == ("Bella", "Dev", "Var")
 
@@ -1312,7 +1320,7 @@ class TestDevicePanel:
         win.show()
         win.device_combo.setCurrentText("Dev:Var")
         win.set_field.setText("1.0")
-        win._on_device_set_clicked()  # daemon thread now sleeping in set()
+        win._movable._on_set_clicked()  # daemon thread now sleeping in set()
         started = time.monotonic()
         assert win.close()  # must not join the 0.4 s daemon set
         assert time.monotonic() - started < 0.3
@@ -1355,11 +1363,11 @@ class TestDevicePanel:
         win.device_combo.setCurrentText("Dev:Var")
         win.set_field.setText("1.0")
         before = set(threading.enumerate())
-        win._on_device_set_clicked()  # daemon thread now blocked in set()
+        win._movable._on_set_clicked()  # daemon thread now blocked in set()
         worker = next(
             t
             for t in threading.enumerate()
-            if t not in before and t.name == "console-device-set"
+            if t not in before and t.name == "console-movable-set"
         )
         assert win.close()
         win.deleteLater()

--- a/GEECS-Console/tests/test_main_window_editors_integration.py
+++ b/GEECS-Console/tests/test_main_window_editors_integration.py
@@ -174,7 +174,7 @@ class TestDeviceComboCompletions:
 
     def test_stale_experiment_result_is_dropped(self, qtbot):
         window = make_window(qtbot)
-        window._apply_device_completions(("SomeOtherExp", ["Dev:var"]))
+        window._movable._apply_completions(("SomeOtherExp", ["Dev:var"]))
         assert window.device_combo.count() == 0
 
     def test_offline_default_is_empty_but_usable(self, qtbot):
@@ -203,32 +203,30 @@ class TestDeviceParseFeedback:
     def test_unparsable_commit_shows_format_hint(self, qtbot):
         window = make_window(qtbot)
         window.device_combo.setEditText("no-colon-here")
-        window._resubscribe_device()
-        assert (
-            window.statusBar().currentMessage()
-            == "Device format: DeviceName:Variable Name"
+        window._movable.resubscribe()
+        assert window.statusBar().currentMessage() == (
+            "Device format: DeviceName:Variable Name — or a catalog scan-variable name"
         )
 
     def test_empty_commit_stays_silent(self, qtbot):
         window = make_window(qtbot)
         window.device_combo.setEditText("")
-        window._resubscribe_device()
+        window._movable.resubscribe()
         assert window.statusBar().currentMessage() == ""
 
     def test_valid_commit_stays_silent(self, qtbot):
         window = make_window(qtbot)
         window.device_combo.setEditText("Dev:var")
-        window._resubscribe_device()
+        window._movable.resubscribe()
         assert window.statusBar().currentMessage() == ""
 
     def test_set_click_with_unparsable_device_shows_hint(self, qtbot):
         window = make_window(qtbot)
         window.device_combo.setEditText("garbage")
         window.set_field.setText("1.0")
-        window._on_device_set_clicked()
-        assert (
-            window.statusBar().currentMessage()
-            == "Device format: DeviceName:Variable Name"
+        window._movable._on_set_clicked()
+        assert window.statusBar().currentMessage() == (
+            "Device format: DeviceName:Variable Name — or a catalog scan-variable name"
         )
 
 

--- a/GEECS-Console/tests/test_movable_panel.py
+++ b/GEECS-Console/tests/test_movable_panel.py
@@ -174,6 +174,28 @@ class TestCatalogMoves:
         )
         assert win.set_button.isEnabled()  # failure re-arms
 
+    def test_malformed_submitter_result_reports_instead_of_wedging(self, qtbot):
+        """A non-contract move result must re-arm Set, never wedge it.
+
+        BackgroundResult swallows a raising job without emitting, so if the
+        result formatting escaped the job's try, _set_in_flight would stay
+        True forever (PR #598 review finding).
+        """
+
+        class NoneSubmitter(FakeMoveSubmitter):
+            def move_variable(self, name, value):
+                return None  # violates the {"targets": ...} contract
+
+        win, _panel = make_window(qtbot, submitter=NoneSubmitter())
+        win.device_combo.setCurrentText("bump_x")
+        win.set_field.setText("0.1")
+        win._movable._on_set_clicked()
+        qtbot.waitUntil(
+            lambda: "Move bump_x failed" in win.log_tail.toPlainText(),
+            timeout=3000,
+        )
+        assert win.set_button.isEnabled()
+
     def test_raw_device_variable_keeps_the_direct_backend_path(self, qtbot):
         submitter = FakeMoveSubmitter()
         win, panel = make_window(qtbot, submitter=submitter)
@@ -188,10 +210,9 @@ class TestCatalogMoves:
 
 class TestAutoSelect:
     def test_scan_variable_pick_auto_selects_the_panel(self, qtbot):
-        # After populate the axis combo sits on "bump_x" (index 0), so the
-        # operator's pick of the OTHER name is what fires the change signal.
+        # textActivated = a committed operator pick (dropdown / Enter).
         win, panel = make_window(qtbot)
-        win.variable_combo.setCurrentText("jet_z")
+        win.variable_combo.textActivated.emit("jet_z")
         assert win.device_combo.currentText() == "jet_z"
         assert panel.many_calls[-1] == (
             "TestExp",
@@ -200,7 +221,39 @@ class TestAutoSelect:
 
     def test_second_axis_pick_auto_selects_too(self, qtbot):
         win, panel = make_window(qtbot)
-        win.variable2_combo.setCurrentText("jet_z")
+        win.variable2_combo.textActivated.emit("jet_z")
+        assert win.device_combo.currentText() == "jet_z"
+        assert panel.many_calls[-1] == (
+            "TestExp",
+            [("U_ESP_JetXYZ", "Position.Axis 3")],
+        )
+
+    def test_typing_in_the_axis_combo_never_hijacks_the_panel(self, qtbot):
+        """Per-keystroke text changes must not churn monitors (PR #598 review).
+
+        Both R3 combos are editable; the auto-select is wired to
+        textActivated (commit-only), so programmatic/typed text changes —
+        which fire currentTextChanged per keystroke — leave the panel and
+        its CA monitors untouched.
+        """
+        win, panel = make_window(qtbot)
+        win.device_combo.setCurrentText("Dev:Var")
+        win._movable.resubscribe()
+        calls_before = list(panel.many_calls)
+        # Simulates the keystroke path: setEditText fires currentTextChanged
+        # (editable combo) but never textActivated.
+        win.variable_combo.setEditText("jet_")
+        win.variable_combo.setEditText("jet_z")
+        assert win.device_combo.currentText() == "Dev:Var"
+        assert panel.many_calls == calls_before
+
+    def test_preset_apply_auto_selects_axis_one(self, qtbot):
+        """setCurrentText in the preset path is programmatic — the apply
+        path follows the preset explicitly, axis 1 owning the panel."""
+        win, panel = make_window(qtbot)
+        win.variable_combo.setCurrentText("jet_z")  # programmatic: no follow
+        assert win.device_combo.currentText() != "jet_z"
+        win._apply_form_state(win.form_state())
         assert win.device_combo.currentText() == "jet_z"
         assert panel.many_calls[-1] == (
             "TestExp",
@@ -212,6 +265,6 @@ class TestAutoSelect:
         win.device_combo.setCurrentText("Dev:Var")
         win._movable.resubscribe()
         calls_before = list(panel.many_calls)
-        win.variable_combo.setCurrentText("ghost_variable")
+        win.variable_combo.textActivated.emit("ghost_variable")
         assert win.device_combo.currentText() == "Dev:Var"
         assert panel.many_calls == calls_before

--- a/GEECS-Console/tests/test_movable_panel.py
+++ b/GEECS-Console/tests/test_movable_panel.py
@@ -1,0 +1,217 @@
+"""MovablePanelController — the catalog-aware R7 capabilities (new in 0.19.0).
+
+The extraction's behavior-preserving half is pinned by the existing
+``TestDevicePanel`` suites; this file pins what the controller *adds*:
+
+- catalog selections (plain and pseudo/composite) resolve through the
+  scan-variable specs and monitor the right target readbacks
+  (``subscribe_many`` — one live readback per composite component);
+- catalog sets go through ``Submitter.move_variable`` (the engine seam)
+  with refusals surfaced verbatim; raw ``device:variable`` sets keep the
+  direct gateway-put path;
+- the R3 axis combos auto-select the panel (the legacy scanner behavior),
+  composites included, while unresolvable/programmatic churn never
+  hijacks it;
+- composite readbacks render per-target.
+"""
+
+from __future__ import annotations
+
+from PySide6.QtCore import Qt
+
+from geecs_console.app.main_window import MainWindow
+from geecs_schemas import PseudoScanVariable, ScanVariable
+from test_main_window import FakeConfigs
+
+
+class FakeSpecsConfigs(FakeConfigs):
+    """The main-window FakeConfigs, plus a real scan-variable spec catalog."""
+
+    def __init__(self, specs=None, experiment="TestExp"):
+        specs = dict(specs or {})
+        super().__init__(scan_variables=sorted(specs), experiment=experiment)
+        self._specs = specs
+
+    def scan_variable_specs(self):
+        return dict(self._specs)
+
+
+class FakePanel:
+    """DevicePanelBackend stand-in recording multi-target subscriptions."""
+
+    def __init__(self):
+        self.many_calls: list[tuple[str, list[tuple[str, str]]]] = []
+        self.unsubscribes = 0
+        self.set_calls = []
+        self.on_value = None
+
+    def subscribe(self, experiment, device, variable, on_value):  # pragma: no cover
+        raise AssertionError("controller must use subscribe_many when present")
+
+    def subscribe_many(self, experiment, targets, on_value):
+        self.many_calls.append((experiment, list(targets)))
+        self.on_value = on_value
+
+    def unsubscribe(self):
+        self.unsubscribes += 1
+        self.on_value = None
+
+    def set(self, experiment, device, variable, value):
+        self.set_calls.append((experiment, device, variable, value))
+
+
+class FakeMoveSubmitter:
+    """Submitter stand-in for the manual-move member."""
+
+    def __init__(self, error: Exception | None = None):
+        self.moves = []
+        self.error = error
+
+    def is_scanning_active(self):
+        return False
+
+    def move_variable(self, name, value):
+        self.moves.append((name, value))
+        if self.error is not None:
+            raise self.error
+        return {
+            "variable": name,
+            "kind": "pseudo (relative)",
+            "value": value,
+            "targets": {"U_S3H:Current": value, "U_S4H:Current": -2 * value},
+        }
+
+
+BUMP_X = PseudoScanVariable(
+    kind="pseudo",
+    mode="relative",
+    targets=[
+        {"target": "U_S3H:Current", "forward": "x * 1"},
+        {"target": "U_S4H:Current", "forward": "x * -2"},
+    ],
+)
+JET_Z = ScanVariable(target="U_ESP_JetXYZ:Position.Axis 3", kind="motor")
+
+
+def make_window(qtbot, *, specs=None, submitter=None, panel=None):
+    panel = panel if panel is not None else FakePanel()
+    win = MainWindow(
+        configs=FakeSpecsConfigs(specs or {"bump_x": BUMP_X, "jet_z": JET_Z}),
+        device_panel=panel,
+        submitter=submitter if submitter is not None else FakeMoveSubmitter(),
+    )
+    qtbot.addWidget(win)
+    return win, panel
+
+
+class TestCatalogSelection:
+    def test_plain_catalog_name_monitors_its_target(self, qtbot):
+        win, panel = make_window(qtbot)
+        win.device_combo.setCurrentText("jet_z")
+        win._movable.resubscribe()
+        assert panel.many_calls[-1] == (
+            "TestExp",
+            [("U_ESP_JetXYZ", "Position.Axis 3")],
+        )
+
+    def test_pseudo_name_monitors_every_component(self, qtbot):
+        win, panel = make_window(qtbot)
+        win.device_combo.setCurrentText("bump_x")
+        win._movable.resubscribe()
+        assert panel.many_calls[-1] == (
+            "TestExp",
+            [("U_S3H", "Current"), ("U_S4H", "Current")],
+        )
+
+    def test_pseudo_readback_renders_per_target(self, qtbot):
+        win, panel = make_window(qtbot)
+        win.device_combo.setCurrentText("bump_x")
+        win._movable.resubscribe()
+        panel.on_value(0, 0.05)
+        qtbot.waitUntil(
+            lambda: win.readback_label.text() == "U_S3H 0.05 · U_S4H —",
+            timeout=3000,
+        )
+        panel.on_value(1, -0.0998)
+        qtbot.waitUntil(
+            lambda: win.readback_label.text() == "U_S3H 0.05 · U_S4H -0.0998",
+            timeout=3000,
+        )
+
+    def test_dropdown_lists_catalog_names_first(self, qtbot):
+        win, _panel = make_window(qtbot)
+        qtbot.waitUntil(lambda: win.device_combo.count() >= 2, timeout=3000)
+        items = [win.device_combo.itemText(i) for i in range(2)]
+        assert items == ["bump_x", "jet_z"]
+
+
+class TestCatalogMoves:
+    def test_catalog_set_goes_through_move_variable(self, qtbot):
+        submitter = FakeMoveSubmitter()
+        win, panel = make_window(qtbot, submitter=submitter)
+        win.device_combo.setCurrentText("bump_x")
+        win.set_field.setText("0.05")
+        qtbot.mouseClick(win.set_button, Qt.MouseButton.LeftButton)
+        qtbot.waitUntil(lambda: submitter.moves == [("bump_x", 0.05)], timeout=3000)
+        qtbot.waitUntil(
+            lambda: "Moved bump_x = 0.05" in win.log_tail.toPlainText(),
+            timeout=3000,
+        )
+        assert panel.set_calls == []  # never the raw-PV path
+        assert win.set_button.isEnabled()  # re-armed
+
+    def test_engine_refusal_surfaces_verbatim(self, qtbot):
+        submitter = FakeMoveSubmitter(
+            error=RuntimeError("scan in progress — move not started")
+        )
+        win, _panel = make_window(qtbot, submitter=submitter)
+        win.device_combo.setCurrentText("bump_x")
+        win.set_field.setText("0.1")
+        win._movable._on_set_clicked()
+        qtbot.waitUntil(
+            lambda: "scan in progress — move not started" in win.log_tail.toPlainText(),
+            timeout=3000,
+        )
+        assert win.set_button.isEnabled()  # failure re-arms
+
+    def test_raw_device_variable_keeps_the_direct_backend_path(self, qtbot):
+        submitter = FakeMoveSubmitter()
+        win, panel = make_window(qtbot, submitter=submitter)
+        win.device_combo.setCurrentText("Dev:Var")
+        win.set_field.setText("1.5")
+        win._movable._on_set_clicked()
+        qtbot.waitUntil(
+            lambda: panel.set_calls == [("TestExp", "Dev", "Var", 1.5)], timeout=3000
+        )
+        assert submitter.moves == []
+
+
+class TestAutoSelect:
+    def test_scan_variable_pick_auto_selects_the_panel(self, qtbot):
+        # After populate the axis combo sits on "bump_x" (index 0), so the
+        # operator's pick of the OTHER name is what fires the change signal.
+        win, panel = make_window(qtbot)
+        win.variable_combo.setCurrentText("jet_z")
+        assert win.device_combo.currentText() == "jet_z"
+        assert panel.many_calls[-1] == (
+            "TestExp",
+            [("U_ESP_JetXYZ", "Position.Axis 3")],
+        )
+
+    def test_second_axis_pick_auto_selects_too(self, qtbot):
+        win, panel = make_window(qtbot)
+        win.variable2_combo.setCurrentText("jet_z")
+        assert win.device_combo.currentText() == "jet_z"
+        assert panel.many_calls[-1] == (
+            "TestExp",
+            [("U_ESP_JetXYZ", "Position.Axis 3")],
+        )
+
+    def test_unresolvable_pick_leaves_the_panel_alone(self, qtbot):
+        win, panel = make_window(qtbot, specs={"jet_z": JET_Z})
+        win.device_combo.setCurrentText("Dev:Var")
+        win._movable.resubscribe()
+        calls_before = list(panel.many_calls)
+        win.variable_combo.setCurrentText("ghost_variable")
+        assert win.device_combo.currentText() == "Dev:Var"
+        assert panel.many_calls == calls_before

--- a/GeecsBluesky/CHANGELOG.md
+++ b/GeecsBluesky/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to `geecs-bluesky` are documented here.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.49.0] - 2026-07-22
+
+### Added
+
+- `ConfigsRepoResolver.scan_variable_catalog()` — public accessor for the
+  experiment's validated scan-variable catalog (the whole `ScanVariables`
+  document).  Promoted from the private cache method for GEECS-Console's
+  movable panel, closing the console CLAUDE.md debt note ("promote a
+  public catalog accessor when next touching geecs-bluesky").
+
+### Changed
+
+- `bluesky_scanner.py` contract comment: `move_variable` is now mirrored
+  by the console Submitter protocol (GEECS-Console 0.19.0) — the "will
+  join (PR-B)" qualifier is retired.
+
 ## [0.48.0] - 2026-07-22
 
 ### Added

--- a/GeecsBluesky/geecs_bluesky/config_resolver.py
+++ b/GeecsBluesky/geecs_bluesky/config_resolver.py
@@ -227,6 +227,22 @@ class ConfigsRepoResolver:
         self._scan_variables_cache = catalog
         return catalog
 
+    def scan_variable_catalog(self) -> ScanVariables:
+        """The experiment's validated scan-variable catalog (public accessor).
+
+        The whole :class:`~geecs_schemas.scan_variables.ScanVariables`
+        document — consumers list names or branch on each spec's shape
+        (plain vs pseudo).  Promoted from the private cache method for
+        GEECS-Console's movable panel (its CLAUDE.md carried the debt note);
+        cached per resolver, like every other catalog here.
+
+        Raises
+        ------
+        GeecsConfigurationError
+            No catalog files for the experiment, or an invalid document.
+        """
+        return self._scan_variables_catalog()
+
     def resolve_scan_variable(self, name: str) -> ScanVariableSpec:
         """Look up the scan variable *name* in the experiment catalog.
 

--- a/GeecsBluesky/geecs_bluesky/scanner_bridge/bluesky_scanner.py
+++ b/GeecsBluesky/geecs_bluesky/scanner_bridge/bluesky_scanner.py
@@ -449,10 +449,9 @@ class BlueskyScanner:
     # ------------------------------------------------------------------
     # On-demand actions (G-actions v1) + manual moves — the GUI contract
     # ------------------------------------------------------------------
-    # run_action and describe_action are mirrored by the console's
-    # Submitter protocol; move_variable will join it with the console
-    # movable-panel work (PR-B). Do not change these signatures without
-    # flagging it loudly.
+    # These three signatures (run_action, describe_action, move_variable)
+    # are mirrored by the console's Submitter protocol (GEECS-Console ≥
+    # 0.19.0); do not change them without flagging it loudly.
 
     def _action_resolver(self) -> ConfigResolver:
         """The resolver on-demand actions resolve against.

--- a/GeecsBluesky/pyproject.toml
+++ b/GeecsBluesky/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-bluesky"
-version = "0.48.0"
+version = "0.49.0"
 description = "Bluesky / ophyd-async bridge for the GEECS control system"
 authors = ["Sam Barber <sbarber@lbl.gov>"]
 readme = "README.md"

--- a/GeecsBluesky/tests/test_scan_request_runner.py
+++ b/GeecsBluesky/tests/test_scan_request_runner.py
@@ -466,6 +466,13 @@ def test_new_schema_scan_variables_load(modern_resolver) -> None:
     )
 
 
+def test_public_scan_variable_catalog_accessor(modern_resolver) -> None:
+    """The public catalog accessor (0.49.0, for GEECS-Console's panel)."""
+    catalog = modern_resolver.scan_variable_catalog()
+    assert "combo" in catalog.variables
+    assert catalog.variables["jet_z"].kind == "motor"
+
+
 def test_unknown_scan_variable_lists_known_names(legacy_resolver) -> None:
     with pytest.raises(GeecsConfigurationError, match="jet_z"):
         legacy_resolver.resolve_scan_variable("nope")


### PR DESCRIPTION
## What & why

**PR-B of the manual-composite design** (PR-A = the engine's `move_variable`, #597, merged + live-verified): the console's R7 device panel becomes a **catalog-aware movable panel**, closing the two operator gaps discussed with the owner — composites cannot be set manually from the console, and the legacy scanner's "scan variable auto-selects in the device panel" behavior was missing.

### The pieces (GEECS-Console 0.19.0, minor)

- **`app/movable_panel.py::MovablePanelController` (new, ~430 LOC)** — owns the whole R7 surface the window previously ran inline (selection commits, readback rendering, completions fetch, set dispatch), following the established #534 controller shape (no Qt parent, injected widgets + callables, own `BackgroundResult` worker per issue #510, queued `value_ready(int, object)` signal, idempotent `dispose()` from `closeEvent`). **`main_window.py` sheds ~170 lines** — this is the "rework the panel" forcing function the #534 accretion watch wanted.
- **Catalog-aware selection**: resolves against `ConsoleConfigs.scan_variable_specs()` (new offline-safe accessor). A plain `ScanVariable` monitors its target; a **pseudo/composite monitors every component** (`subscribe_many` — new `DevicePanelBackend` protocol member, implemented in `GatewayDevicePanel` with the same generation-counter straggler-drop, duck-typed fallback for older single-monitor backends) rendered compactly ("U_S3H 0.05 · U_S4H −0.0998"). Raw `device:variable` strings keep the exact historical path.
- **Sets fork by selection kind**: catalog names dispatch **`Submitter.move_variable(name, value)`** — the new protocol member mapping straight onto `BlueskyScanner.move_variable` (GeecsBluesky ≥ 0.48.0), so manual moves get scan-identical completion semantics (motor poll, confirm poll, pseudo fan-out with a fresh relative baseline per move) and the engine's refusals ("scan in progress — move not started") surface verbatim. Raw strings keep the direct gateway `:SP` put — no engine required, offline-first preserved.
- **Auto-select (the legacy behavior)**: both R3 axis combos' `currentTextChanged` now re-point the panel — composites included. Programmatic populate churn is signal-blocked, and unresolvable names never hijack the panel (offline-safety).
- The combo dropdown lists **catalog names first** (composites become discoverable), then the DB `device:variable` completions.

### Judgment calls (cheap to veto)

- The old single-target `subscribe` stays on the protocol (thin wrapper over `subscribe_many` in the gateway impl) — keeps older injected backends and the seam's simplest consumers working.
- Confirm-variable catalog entries monitor the *written* target's readback (same as what scans record); monitoring the confirming variable alongside is a possible follow-up.
- GeecsBluesky's bridge comment ("move_variable will join [the Submitter protocol] with PR-B") is now satisfied but not edited here — one-line follow-up rather than a cross-package touch in a console PR.

## Per-concern LOC breakdown

| Concern | Files | LOC |
|---|---|---|
| Controller (extraction + catalog awareness) | app/movable_panel.py | +430 |
| Window sheds R7 internals + wiring | app/main_window.py | +40/−210 |
| Backend multi-subscribe + formatter | services/device_panel.py | +120/−40 |
| Catalog accessor + protocol member | services/configs.py, submission.py | +35 |
| New capability tests | tests/test_movable_panel.py | +230 |
| Existing-test updates (surface rename, subscribe_many fake) | 3 test files | ~+60/−25 |
| Docs/versioning | CLAUDE.md, CHANGELOG, pyproject | ~+80/−30 |

## Tests

`./scripts/check.sh` (scoped, as CI): lint green, GEECS-Console **784 passed** (772 on dev → +12: movable-panel capability tests — catalog/pseudo selection, per-target rendering, move_variable dispatch + verbatim refusal, raw-path preservation, auto-select incl. the never-hijack guard — plus `subscribe_many` service tests). The pre-existing R7 suites (TestDevicePanel, parse feedback, completions, the #510 deletion test) pass against the controller surface, pinning the extraction as behavior-preserving.

## Hardware verification

**OWED** (GUI-level; the engine seam beneath is already live-verified on PR #597 against U_S3H/U_S4H): launch the console on the lab network, pick `ALine_e_beam_position_offset_x` in the R3 axis combo → panel auto-selects and shows both magnet readbacks live; Set 0.05 → status bar reports "Moved … (U_S3H:Current=…, U_S4H:Current=…)" and the readbacks move by +0.05/−0.05; Set −0.05 restores; a Set clicked during a scan shows "scan in progress — move not started".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
