### PR TITLE
GEECS-Console 0.19.1: movable-panel polish — width-stable readbacks, R7 to the middle column

### DIFF
--- a/GEECS-Console/CHANGELOG.md
+++ b/GEECS-Console/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to GEECS-Console are documented here.  Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versioning is
 semantic.
 
+## [0.19.1] - 2026-07-22
+
+### Changed
+
+- **Movable-panel polish from first live use** (owner feedback on 0.19.0):
+  - **Width-stable readbacks** — `format_readback` renders floats with
+    fixed decimals (4) in the ordinary magnitude range (scientific with a
+    fixed mantissa outside it), and the readback label no longer drives
+    layout (`Ignored` horizontal size policy + minimum width): noise in a
+    streamed value's trailing digits made the window width jitter at the
+    stream rate.
+  - **R7 relocated to the middle column**, below the scan form and presets
+    (space it fits naturally); the right column keeps only the R6 now
+    panel, which gets the freed room.  Widget object names (`r7_*`)
+    unchanged — controller, tests, and tooltips untouched by the move.
+
 ## [0.19.0] - 2026-07-22
 
 ### Added

--- a/GEECS-Console/CLAUDE.md
+++ b/GEECS-Console/CLAUDE.md
@@ -57,7 +57,8 @@ are prefixed by region (`r3_radio_1d`, `r5_start_button`, …).
   timing and granularity; they will drift, and shot counts must never be
   reconciled across them (live-investigated 2026-07-16 — a "pause shows
   extra steps" report was mostly this drift).
-- **R7 movable panel** — an editable combo (catalog scan-variable names
+- **R7 movable panel** (middle column, below R4/R5 since 0.19.1 — the
+  right column is R6's alone) — an editable combo (catalog scan-variable names
   first, then `device:variable` completions from `GeecsDbCompletions`),
   readback label, set field + button — owned by
   `app/movable_panel.py::MovablePanelController` since 0.19.0 (see

--- a/GEECS-Console/geecs_console/app/ui/main_window.ui
+++ b/GEECS-Console/geecs_console/app/ui/main_window.ui
@@ -780,6 +780,72 @@
         </widget>
        </item>
        <item>
+        <widget class="QGroupBox" name="r7_group">
+         <property name="title">
+          <string>DEVICE PANEL</string>
+         </property>
+         <layout class="QVBoxLayout" name="r7_layout">
+        <property name="spacing">
+         <number>8</number>
+        </property>
+          <item>
+           <widget class="QComboBox" name="r7_device_combo">
+            <property name="editable">
+             <bool>true</bool>
+            </property>
+            <property name="toolTip">
+             <string>device:variable</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <layout class="QHBoxLayout" name="r7_readback_layout">
+            <item>
+             <widget class="QLabel" name="r7_readback_title">
+              <property name="text">
+               <string>Readback</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QLabel" name="r7_readback_label">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Ignored" vsizetype="Preferred">
+                <horstretch>1</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="minimumSize">
+               <size>
+                <width>160</width>
+                <height>0</height>
+               </size>
+              </property>
+              <property name="text">
+               <string>—</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+          <item>
+           <layout class="QHBoxLayout" name="r7_set_layout">
+            <item>
+             <widget class="QLineEdit" name="r7_set_field"/>
+            </item>
+            <item>
+             <widget class="QPushButton" name="r7_set_button">
+              <property name="text">
+               <string>Set</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
         <spacer name="middle_column_spacer">
          <property name="orientation">
           <enum>Qt::Vertical</enum>
@@ -794,7 +860,7 @@
        </item>
       </layout>
      </item>
-     <!-- Right column: R6 now panel, R7 device panel -->
+     <!-- Right column: R6 now panel (R7 moved to the middle column, 0.19.1) -->
      <item>
       <layout class="QVBoxLayout" name="right_column">
         <property name="spacing">
@@ -856,60 +922,6 @@
              <number>200</number>
             </property>
            </widget>
-          </item>
-         </layout>
-        </widget>
-       </item>
-       <item>
-        <widget class="QGroupBox" name="r7_group">
-         <property name="title">
-          <string>DEVICE PANEL</string>
-         </property>
-         <layout class="QVBoxLayout" name="r7_layout">
-        <property name="spacing">
-         <number>8</number>
-        </property>
-          <item>
-           <widget class="QComboBox" name="r7_device_combo">
-            <property name="editable">
-             <bool>true</bool>
-            </property>
-            <property name="toolTip">
-             <string>device:variable</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <layout class="QHBoxLayout" name="r7_readback_layout">
-            <item>
-             <widget class="QLabel" name="r7_readback_title">
-              <property name="text">
-               <string>Readback</string>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="QLabel" name="r7_readback_label">
-              <property name="text">
-               <string>—</string>
-              </property>
-             </widget>
-            </item>
-           </layout>
-          </item>
-          <item>
-           <layout class="QHBoxLayout" name="r7_set_layout">
-            <item>
-             <widget class="QLineEdit" name="r7_set_field"/>
-            </item>
-            <item>
-             <widget class="QPushButton" name="r7_set_button">
-              <property name="text">
-               <string>Set</string>
-              </property>
-             </widget>
-            </item>
-           </layout>
           </item>
          </layout>
         </widget>

--- a/GEECS-Console/geecs_console/services/device_panel.py
+++ b/GEECS-Console/geecs_console/services/device_panel.py
@@ -188,7 +188,7 @@ def parse_set_value(text: str) -> float | str:
 
 
 def format_readback(value: Any) -> str:
-    """Render one readback value for the R7 label.
+    """Render one readback value for the R7 label, width-stable.
 
     Parameters
     ----------
@@ -199,12 +199,19 @@ def format_readback(value: Any) -> str:
     Returns
     -------
     str
-        Floats with 6 significant digits, everything else stringified.
+        Floats with **fixed** decimals (4) in the ordinary magnitude range,
+        scientific with fixed mantissa digits outside it, everything else
+        stringified.  Fixed-width rendering is deliberate: noise in a
+        streamed readback's final digits must not change the string length
+        (the old 6-significant-digits format made the window width jitter
+        at ~1 Hz — owner report, 0.19.1).
     """
     if isinstance(value, bool):
         return str(value)
     if isinstance(value, float):
-        return f"{value:.6g}"
+        if value == 0.0 or 1e-3 <= abs(value) < 1e5:
+            return f"{value:.4f}"
+        return f"{value:.3e}"
     return str(value)
 
 

--- a/GEECS-Console/pyproject.toml
+++ b/GEECS-Console/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-console"
-version = "0.19.0"
+version = "0.19.1"
 description = "Greenfield PySide6 operator console for GEECS (Bluesky/gateway architecture)"
 authors = ["Sam Barber <sbarber@lbl.gov>"]
 readme = "README.md"

--- a/GEECS-Console/tests/test_device_panel.py
+++ b/GEECS-Console/tests/test_device_panel.py
@@ -70,9 +70,18 @@ class TestParseSetValue:
 
 
 class TestFormatReadback:
-    def test_float_six_significant_digits(self):
-        assert format_readback(3.141592653589793) == "3.14159"
-        assert format_readback(0.5) == "0.5"
+    def test_float_fixed_decimals_width_stable(self):
+        """Fixed decimals: readback noise in trailing digits must not change
+        the string length (window-width jitter, owner report 0.19.1)."""
+        assert format_readback(3.141592653589793) == "3.1416"
+        assert format_readback(0.5) == "0.5000"
+        # The jitter pair that motivated this: same width either way.
+        assert len(format_readback(0.05)) == len(format_readback(0.0498))
+
+    def test_float_extreme_magnitudes_go_scientific(self):
+        assert format_readback(1.23456e-5) == "1.235e-05"
+        assert format_readback(4.2e7) == "4.200e+07"
+        assert format_readback(0.0) == "0.0000"
 
     def test_int_and_string_pass_through(self):
         assert format_readback(42) == "42"

--- a/GEECS-Console/tests/test_main_window.py
+++ b/GEECS-Console/tests/test_main_window.py
@@ -1209,7 +1209,7 @@ class TestDevicePanel:
         threading.Thread(
             target=lambda: backend.on_value(3.141592653589793), daemon=True
         ).start()
-        qtbot.waitUntil(lambda: win.readback_label.text() == "3.14159", timeout=3000)
+        qtbot.waitUntil(lambda: win.readback_label.text() == "3.1416", timeout=3000)
 
     def test_string_readback_renders_as_is(self, device_window, qtbot):
         win, backend = device_window

--- a/GEECS-Console/tests/test_movable_panel.py
+++ b/GEECS-Console/tests/test_movable_panel.py
@@ -129,12 +129,12 @@ class TestCatalogSelection:
         win._movable.resubscribe()
         panel.on_value(0, 0.05)
         qtbot.waitUntil(
-            lambda: win.readback_label.text() == "U_S3H 0.05 · U_S4H —",
+            lambda: win.readback_label.text() == "U_S3H 0.0500 · U_S4H —",
             timeout=3000,
         )
         panel.on_value(1, -0.0998)
         qtbot.waitUntil(
-            lambda: win.readback_label.text() == "U_S3H 0.05 · U_S4H -0.0998",
+            lambda: win.readback_label.text() == "U_S3H 0.0500 · U_S4H -0.0998",
             timeout=3000,
         )
 
@@ -268,3 +268,16 @@ class TestAutoSelect:
         win.variable_combo.textActivated.emit("ghost_variable")
         assert win.device_combo.currentText() == "Dev:Var"
         assert panel.many_calls == calls_before
+
+
+def test_r7_lives_in_the_middle_column() -> None:
+    """The movable panel sits below scan+presets in the middle third
+    (owner request, 0.19.1) — the right column keeps only the now panel."""
+    from pathlib import Path
+
+    ui = Path("geecs_console/app/ui/main_window.ui").read_text()
+    middle = ui.index('name="middle_column"')
+    right = ui.index('name="right_column"')
+    r7 = ui.index('name="r7_group"')
+    spacer = ui.index('name="middle_column_spacer"')
+    assert middle < r7 < spacer < right

--- a/GEECS-Console/tests/test_movable_panel.py
+++ b/GEECS-Console/tests/test_movable_panel.py
@@ -275,7 +275,13 @@ def test_r7_lives_in_the_middle_column() -> None:
     (owner request, 0.19.1) — the right column keeps only the now panel."""
     from pathlib import Path
 
-    ui = Path("geecs_console/app/ui/main_window.ui").read_text()
+    import geecs_console.app as app_pkg
+
+    # Anchored off the package (cwd-independent) and explicitly UTF-8 —
+    # Windows' cp1252 default dies on the pause glyph (PR #599 review;
+    # console-windows CI failed exactly here).
+    ui_path = Path(app_pkg.__file__).parent / "ui" / "main_window.ui"
+    ui = ui_path.read_text(encoding="utf-8")
     middle = ui.index('name="middle_column"')
     right = ui.index('name="right_column"')
     r7 = ui.index('name="r7_group"')


### PR DESCRIPTION
## What & why

Owner feedback from first live use of the 0.19.0 movable panel (both items requested explicitly):

1. **Width-stable readbacks** — the old `.6g` float format let noise in a streamed value's trailing digits change the string length, so the window width jittered at the stream rate. `format_readback` now renders floats with fixed decimals (4) in the ordinary magnitude range and fixed-mantissa scientific outside it, **and** the readback label no longer drives layout at all (`Ignored` horizontal size policy + 160 px minimum in the `.ui`) — the second half is the real cure; the first makes values read calmly.
2. **R7 moves to the middle column**, below the scan form and presets, where there's room; the right column becomes the R6 now panel's alone, giving the log tail the freed space. Widget object names (`r7_*`) are unchanged, so the controller, tests, and tooltips are untouched by the move — it's purely a `.ui` block relocation (plus the label sizing above).

## Tests

`./scripts/check.sh` (as CI): lint green, GEECS-Console **789 passed** (788 → net +5 vs 0.19.0: fixed-decimal + scientific-range format pins including the exact jitter pair `0.05`/`0.0498` asserting equal width, and a structural pin that `r7_group` sits between the middle column's spacer and `right_column` in the `.ui`). Existing readback tests updated to the new fixed-decimal expectations.

## Hardware verification

GUI-only change; nothing moves hardware. Visual confirmation on next console launch: no width jitter with a live noisy readback, R7 under presets, roomier now panel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
