### PR TITLE
GeecsBluesky 0.50.0: relative pseudo scan axes restore captured baselines at end of scan

### DIFF
--- a/GeecsBluesky/CHANGELOG.md
+++ b/GeecsBluesky/CHANGELOG.md
@@ -4,6 +4,26 @@ All notable changes to `geecs-bluesky` are documented here.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.50.0] - 2026-07-22
+
+### Added
+
+- **Relative pseudo (composite) scan axes return to their captured
+  baselines at end of scan** (owner request from the first live composite
+  scans): `CaPseudoMovable.restore_baselines_plan()` puts every component
+  back to its captured baseline — direct per-target puts, exact and
+  formula-independent (no `f(0) = 0` assumption) — and
+  `build_step_scan_plan` runs it as a finalize on **every** exit path
+  (success and mid-scan abort), after closeout, inside the stage wrapper
+  (before `unstage()` drops the baselines).  Deliberately scoped:
+  absolute-mode pseudos are NOT restored (their pre-scan x is unknowable
+  without an inverse) and plain axes keep the legacy end-at-last-position
+  behavior.  Manual `move_variable` semantics are unchanged (fresh
+  baseline per move; "Set 0" still means "no move").
+- Suite grows to 638 (`tests/test_pseudo_scan_restore.py`: end-of-scan
+  restore, abort-path restore through the full composition and at the
+  finalize level, absolute-not-restored, restore-without-baselines noop).
+
 ## [0.49.0] - 2026-07-22
 
 ### Added

--- a/GeecsBluesky/CHANGELOG.md
+++ b/GeecsBluesky/CHANGELOG.md
@@ -13,16 +13,24 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   scans): `CaPseudoMovable.restore_baselines_plan()` puts every component
   back to its captured baseline — direct per-target puts, exact and
   formula-independent (no `f(0) = 0` assumption) — and
-  `build_step_scan_plan` runs it as a finalize on **every** exit path
-  (success and mid-scan abort), after closeout, inside the stage wrapper
+  `build_step_scan_plan` runs it as a finalize on success and mid-scan
+  abort (a `halt` skips finalizes by bluesky contract, same as
+  disarm/closeout), after closeout, inside the stage wrapper
   (before `unstage()` drops the baselines).  Deliberately scoped:
   absolute-mode pseudos are NOT restored (their pre-scan x is unknowable
   without an inverse) and plain axes keep the legacy end-at-last-position
   behavior.  Manual `move_variable` semantics are unchanged (fresh
   baseline per move; "Set 0" still means "no move").
-- Suite grows to 638 (`tests/test_pseudo_scan_restore.py`: end-of-scan
+- The restore puts ride `bps.abs_set`/`bps.wait` on the
+  `GatewaySetpointPut` movables — the RE's own set machinery — so a
+  failed restore **fails the scan visibly** instead of being swallowed
+  (review finding: `bps.wait_for` never retrieves task exceptions), and
+  the success log prints only after the waits complete.
+- Suite grows to 639 (`tests/test_pseudo_scan_restore.py`: end-of-scan
   restore, abort-path restore through the full composition and at the
-  finalize level, absolute-not-restored, restore-without-baselines noop).
+  finalize level, failed-restore propagation, mixed-grid
+  only-the-pseudo-restored, absolute-not-restored,
+  restore-without-baselines noop).
 
 ## [0.49.0] - 2026-07-22
 

--- a/GeecsBluesky/CLAUDE.md
+++ b/GeecsBluesky/CLAUDE.md
@@ -380,7 +380,12 @@ backend reached verified live parity (Scans 007–015, 2026-07-03/04); a stale
   legacy `ScanDevice` parity — per-component `kind: motor` is the intended
   additive upgrade).  `relative` mode captures per-target baselines at
   `stage()` (lazily on first `set()` for unstaged callers, i.e. optimize),
-  drops them at `unstage()`; `absolute` mode is stateless.  **The recorded
+  drops them at `unstage()`; `absolute` mode is stateless.  **A scan
+  restores a relative pseudo axis to its captured baselines at the
+  end** (0.50.0, owner request): `restore_baselines_plan()` runs as a
+  finalize in `build_step_scan_plan` — success and abort, after
+  closeout, before unstage — with exact per-target puts; absolute
+  pseudos and plain axes are deliberately not restored.  **The recorded
   event-row column is the demanded pseudo value** (soft readback child,
   header = the catalog friendly name) — include target devices in the save
   set when their measured positions matter.  Built by

--- a/GeecsBluesky/geecs_bluesky/devices/ca/pseudo.py
+++ b/GeecsBluesky/geecs_bluesky/devices/ca/pseudo.py
@@ -151,33 +151,41 @@ class CaPseudoMovable(StandardReadable):
 
         The end-of-scan restore for **relative** mode (owner request,
         2026-07-22): the scan orchestration runs this as a finalize —
-        success *and* abort — so a relative composite scan always hands the
-        targets back where it found them.  Direct per-target puts of the
-        captured baselines (exact, formula-independent — no ``f(0) = 0``
-        assumption).  A no-op for absolute mode, and for a run where no
-        baselines were captured; must run before ``unstage()`` drops them
-        (the orchestration's stage wrapper is outermost, so it does).
+        success *and* abort (a ``halt`` skips finalizes by bluesky
+        contract, same as disarm/closeout) — so a relative composite scan
+        hands the targets back where it found them.  Direct per-target
+        puts of the captured baselines (exact, formula-independent — no
+        ``f(0) = 0`` assumption).  A no-op for absolute mode, and for a
+        run where no baselines were captured; must run before
+        ``unstage()`` drops them (the orchestration's stage wrapper is
+        outermost, so it does).
+
+        The puts go through ``bps.abs_set``/``bps.wait`` on the
+        :class:`GatewaySetpointPut` movables — the RE's own set machinery —
+        so a **failed restore fails the scan visibly** instead of being
+        swallowed (review, PR #600: ``bps.wait_for`` never retrieves task
+        exceptions), and the success log only prints after the waits
+        complete.
         """
         import bluesky.plan_stubs as bps
 
         if self._mode != "relative":
             yield from bps.null()
             return
-        yield from bps.wait_for([self._restore_baselines])
-
-    async def _restore_baselines(self) -> None:
         baselines = self._baselines
         if baselines is None:
             logger.info("%s: no baselines captured — nothing to restore", self.name)
+            yield from bps.null()
             return
         commanded = {
             f"{dev}:{var}": baseline
             for (dev, var, _), baseline in zip(self._components, baselines)
         }
-        logger.info("%s: restoring baselines %s", self.name, commanded)
-        await asyncio.gather(
-            *(put.put(baseline) for put, baseline in zip(self._puts, baselines))
-        )
+        group = f"{self.name}-restore"
+        for put, baseline in zip(self._puts, baselines):
+            yield from bps.abs_set(put, baseline, group=group)
+        yield from bps.wait(group=group)
+        logger.info("%s: baselines restored: %s", self.name, commanded)
         # Back at zero offset from the (still-current) baselines.
         self._set_readback(0.0)
         self.last_commanded = commanded

--- a/GeecsBluesky/geecs_bluesky/devices/ca/pseudo.py
+++ b/GeecsBluesky/geecs_bluesky/devices/ca/pseudo.py
@@ -146,6 +146,42 @@ class CaPseudoMovable(StandardReadable):
             return [b + o for b, o in zip(self._baselines, offsets)]
         return offsets
 
+    def restore_baselines_plan(self):
+        """Plan stub: return every target to its captured baseline.
+
+        The end-of-scan restore for **relative** mode (owner request,
+        2026-07-22): the scan orchestration runs this as a finalize —
+        success *and* abort — so a relative composite scan always hands the
+        targets back where it found them.  Direct per-target puts of the
+        captured baselines (exact, formula-independent — no ``f(0) = 0``
+        assumption).  A no-op for absolute mode, and for a run where no
+        baselines were captured; must run before ``unstage()`` drops them
+        (the orchestration's stage wrapper is outermost, so it does).
+        """
+        import bluesky.plan_stubs as bps
+
+        if self._mode != "relative":
+            yield from bps.null()
+            return
+        yield from bps.wait_for([self._restore_baselines])
+
+    async def _restore_baselines(self) -> None:
+        baselines = self._baselines
+        if baselines is None:
+            logger.info("%s: no baselines captured — nothing to restore", self.name)
+            return
+        commanded = {
+            f"{dev}:{var}": baseline
+            for (dev, var, _), baseline in zip(self._components, baselines)
+        }
+        logger.info("%s: restoring baselines %s", self.name, commanded)
+        await asyncio.gather(
+            *(put.put(baseline) for put, baseline in zip(self._puts, baselines))
+        )
+        # Back at zero offset from the (still-current) baselines.
+        self._set_readback(0.0)
+        self.last_commanded = commanded
+
     def set(self, value: float) -> AsyncStatus:
         """Fan *value* out to every target; completes when all sets do.
 

--- a/GeecsBluesky/geecs_bluesky/plans/orchestration.py
+++ b/GeecsBluesky/geecs_bluesky/plans/orchestration.py
@@ -50,6 +50,12 @@ def _chain_setup(setup: Callable, inner):
     yield from inner
 
 
+def _restore_movables(movables: Sequence[Any]):
+    """Finalize plan: each movable's baseline restore, in axis order."""
+    for movable in movables:
+        yield from movable.restore_baselines_plan()
+
+
 def build_step_scan_plan(
     *,
     strict: bool,
@@ -178,6 +184,17 @@ def build_step_scan_plan(
         plan = bpp.finalize_wrapper(plan, controller.disarm())
     if closeout is not None:
         plan = bpp.finalize_wrapper(plan, closeout)
+    # Relative pseudo (composite) axes return to their captured baselines at
+    # the very end (owner request, 2026-07-22) — success AND abort, after
+    # closeout so operator rituals see the scan's final state, and inside
+    # the stage wrapper so unstage has not yet dropped the baselines.
+    restorers = [
+        m
+        for m in normalize_motors(motor)
+        if callable(getattr(m, "restore_baselines_plan", None))
+    ]
+    if restorers:
+        plan = bpp.finalize_wrapper(plan, _restore_movables(restorers))
     # Outermost: stage every per-row read device so each signal gets a caching
     # CA monitor and per-shot reads are served locally instead of issuing one
     # network get per signal per row (the read-path contract —

--- a/GeecsBluesky/pyproject.toml
+++ b/GeecsBluesky/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-bluesky"
-version = "0.49.0"
+version = "0.50.0"
 description = "Bluesky / ophyd-async bridge for the GEECS control system"
 authors = ["Sam Barber <sbarber@lbl.gov>"]
 readme = "README.md"

--- a/GeecsBluesky/tests/test_pseudo_scan_restore.py
+++ b/GeecsBluesky/tests/test_pseudo_scan_restore.py
@@ -195,7 +195,17 @@ def test_failed_restore_fails_the_scan_visibly() -> None:
     set_mock_value(pseudo._target_readback_1, BASELINES["U_S4H"])
 
     class _DeadPut:
+        """Scan-path put() succeeds; only the restore's set() fails.
+
+        The scan body must complete cleanly so this pins the advertised
+        property — a restore failure ALONE fails an otherwise-clean scan
+        (reviewer re-check, PR #600).
+        """
+
         name = "dead-put"
+
+        async def put(self, value, timeout=None):
+            return None
 
         def set(self, value):
             async def _fail():

--- a/GeecsBluesky/tests/test_pseudo_scan_restore.py
+++ b/GeecsBluesky/tests/test_pseudo_scan_restore.py
@@ -175,3 +175,89 @@ def test_restore_without_baselines_is_a_noop() -> None:
     RE = RunEngine()
     connect_mock(RE, pseudo)
     RE(pseudo.restore_baselines_plan())  # never staged/moved — must not raise
+
+
+def test_failed_restore_fails_the_scan_visibly() -> None:
+    """A restore whose put fails must raise, never end the scan clean.
+
+    Review finding (PR #600): the original ``bps.wait_for`` fan-out never
+    retrieved task exceptions, so a dead supply/gateway during the finalize
+    left the magnets displaced while the scan ended looking normal.  The
+    restore now rides ``bps.abs_set``/``bps.wait`` — the RE's own set
+    machinery — so the failure propagates.
+    """
+    import bluesky.preprocessors as bpp
+
+    pseudo = _pseudo("relative")
+    RE = RunEngine()
+    connect_mock(RE, pseudo)
+    set_mock_value(pseudo._target_readback_0, BASELINES["U_S3H"])
+    set_mock_value(pseudo._target_readback_1, BASELINES["U_S4H"])
+
+    class _DeadPut:
+        name = "dead-put"
+
+        def set(self, value):
+            async def _fail():
+                raise RuntimeError("supply unreachable")
+
+            return AsyncStatus(_fail())
+
+    def scan_body():
+        yield from bps.stage(pseudo)
+        yield from bps.mv(pseudo, 0.5)
+
+    pseudo._puts[1] = _DeadPut()  # the restore's second target put dies
+    plan = bpp.finalize_wrapper(scan_body(), pseudo.restore_baselines_plan())
+    with pytest.raises(Exception, match="supply unreachable"):
+        RE(plan)
+
+
+def test_mixed_grid_restores_only_the_pseudo_axis() -> None:
+    """Grid of (plain motor, relative pseudo): only the pseudo is restored."""
+    from geecs_bluesky.devices.ca import CaMotor
+    from tests.ca_mock_helpers import follow_setpoint
+
+    pseudo = _pseudo("relative")
+    plain = CaMotor("U_Stage", "Position (mm)", name="plain_motor")
+    ref = CaGenericDetector("U_Ref", ["Sig"], name="ref")
+    ref.configure_shot_id(rep_rate_hz=1.0)
+    config = ShotControlConfig(
+        device="U_DG645",
+        variables={
+            "Trigger.Source": {"OFF": "Single", "SCAN": "Ext", "STANDBY": "Ext"}
+        },
+    )
+    controller = ShotController(config, {"Trigger.Source": _NoopSetter()})
+    RE = RunEngine()
+    connect_mock(RE, pseudo, plain, ref)
+    follow_setpoint(plain)
+    set_mock_value(pseudo._target_readback_0, BASELINES["U_S3H"])
+    set_mock_value(pseudo._target_readback_1, BASELINES["U_S4H"])
+    set_mock_value(ref.acq_timestamp, 1000.0)
+    pacer = start_pacer(RE, [(ref, 1000.0)], initial_delay=1.0, interval=0.15)
+    plan = build_step_scan_plan(
+        strict=False,
+        motor=[plain, pseudo],
+        positions=[(1.0, 0.0), (2.0, 0.5)],
+        reference=ref,
+        detectors=[ref],
+        shots_per_step=1,
+        controller=controller,
+        experiment="",
+        scan_number=None,
+        scan_folder=None,
+        saving_detectors=[],
+    )
+    try:
+        RE(plan)
+    finally:
+        pacer.cancel()
+    # Pseudo back at baselines; the plain axis stays at its last position.
+    assert _setpoints(RE, pseudo) == (BASELINES["U_S3H"], BASELINES["U_S4H"])
+    import asyncio as _asyncio
+
+    plain_setpoint = _asyncio.run_coroutine_threadsafe(
+        plain._setpoint.get_value(), RE._loop
+    ).result(timeout=10.0)
+    assert plain_setpoint == 2.0

--- a/GeecsBluesky/tests/test_pseudo_scan_restore.py
+++ b/GeecsBluesky/tests/test_pseudo_scan_restore.py
@@ -1,0 +1,177 @@
+"""End-of-scan baseline restore for relative pseudo (composite) axes.
+
+Owner request (2026-07-22, from the first live composite scans): a relative
+composite scan must hand its targets back where it found them.  The
+orchestration adds a finalize — success AND abort, after closeout, inside
+the stage wrapper (so ``unstage`` has not yet dropped the baselines) — that
+puts every component back to its captured baseline, exactly (direct target
+puts, no ``f(0) = 0`` assumption).
+
+Absolute-mode pseudos and plain motors are deliberately NOT restored (an
+absolute pseudo's pre-scan x is unknowable without an inverse; plain axes
+match legacy end-at-last-position behavior).
+"""
+
+from __future__ import annotations
+
+import bluesky.plan_stubs as bps
+import pytest
+from bluesky import RunEngine
+
+from geecs_bluesky.forward_expr import compile_forward
+from geecs_bluesky.models.shot_control import ShotControlConfig
+from geecs_bluesky.plans.orchestration import build_step_scan_plan
+from geecs_bluesky.shot_controller import ShotController
+
+pytest.importorskip("aioca")
+
+from ophyd_async.core import AsyncStatus, set_mock_value  # noqa: E402
+
+from geecs_bluesky.devices.ca import CaGenericDetector, CaPseudoMovable  # noqa: E402
+from tests.ca_mock_helpers import connect_mock, start_pacer  # noqa: E402
+
+BASELINES = {"U_S3H": 3.0, "U_S4H": 10.0}
+
+
+class _NoopSetter:
+    def __init__(self):
+        self.name = "trigger"
+
+    def set(self, value):
+        async def _ok():
+            return None
+
+        return AsyncStatus(_ok())
+
+
+def _pseudo(mode: str) -> CaPseudoMovable:
+    return CaPseudoMovable(
+        [
+            ("U_S3H", "Current", compile_forward("x * 1")),
+            ("U_S4H", "Current", compile_forward("x * -2")),
+        ],
+        mode,
+        variable_name="bump_x",
+        name="bump_x",
+    )
+
+
+def _setpoints(run_engine: RunEngine, device: CaPseudoMovable) -> tuple[float, float]:
+    import asyncio
+
+    def read(sig):
+        return asyncio.run_coroutine_threadsafe(
+            sig.get_value(), run_engine._loop
+        ).result(timeout=10.0)
+
+    return read(device._setpoint_0), read(device._setpoint_1)
+
+
+def _build_scan(mode: str, *, per_step=None):
+    """Build a two-step free-run scan with a pseudo axis.
+
+    Returns ``(RE, pseudo, plan, pacer)`` — the caller runs the plan, so
+    abort tests can still reach the pseudo afterwards.
+    """
+    pseudo = _pseudo(mode)
+    ref = CaGenericDetector("U_Ref", ["Sig"], name="ref")
+    ref.configure_shot_id(rep_rate_hz=1.0)
+    config = ShotControlConfig(
+        device="U_DG645",
+        variables={
+            "Trigger.Source": {"OFF": "Single", "SCAN": "Ext", "STANDBY": "Ext"}
+        },
+    )
+    controller = ShotController(config, {"Trigger.Source": _NoopSetter()})
+
+    RE = RunEngine()
+    connect_mock(RE, pseudo, ref)
+    set_mock_value(pseudo._target_readback_0, BASELINES["U_S3H"])
+    set_mock_value(pseudo._target_readback_1, BASELINES["U_S4H"])
+    set_mock_value(ref.acq_timestamp, 1000.0)
+    pacer = start_pacer(RE, [(ref, 1000.0)], initial_delay=1.0, interval=0.15)
+    plan = build_step_scan_plan(
+        strict=False,
+        motor=pseudo,
+        positions=[0.0, 0.5],
+        reference=ref,
+        detectors=[ref],
+        shots_per_step=1,
+        controller=controller,
+        experiment="",
+        scan_number=None,
+        scan_folder=None,
+        saving_detectors=[],
+        per_step=per_step,
+    )
+    return RE, pseudo, plan, pacer
+
+
+def _run_scan(mode: str, *, per_step=None) -> tuple[RunEngine, CaPseudoMovable]:
+    RE, pseudo, plan, pacer = _build_scan(mode, per_step=per_step)
+    try:
+        RE(plan)
+    finally:
+        pacer.cancel()
+    return RE, pseudo
+
+
+def test_relative_pseudo_scan_restores_baselines_at_end() -> None:
+    RE, pseudo = _run_scan("relative")
+    # Last scan position was x=0.5 (targets 3.5 / 9.0); the finalize put
+    # them back to the captured baselines, exactly.
+    assert _setpoints(RE, pseudo) == (BASELINES["U_S3H"], BASELINES["U_S4H"])
+
+
+def test_relative_pseudo_scan_restores_on_abort_too() -> None:
+    calls = {"n": 0}
+
+    def exploding_per_step():
+        calls["n"] += 1
+        if calls["n"] == 2:
+            raise RuntimeError("boom mid-scan")
+        yield from bps.null()
+
+    RE, pseudo, plan, pacer = _build_scan("relative", per_step=exploding_per_step)
+    try:
+        with pytest.raises(RuntimeError, match="boom"):
+            RE(plan)
+    finally:
+        pacer.cancel()
+    # The finalize chain ran on the abort path and put the targets back.
+    assert _setpoints(RE, pseudo) == (BASELINES["U_S3H"], BASELINES["U_S4H"])
+
+
+def test_abort_restore_at_the_finalize_level() -> None:
+    """Directly: finalize restore runs even when the wrapped plan raises."""
+    import bluesky.preprocessors as bpp
+
+    pseudo = _pseudo("relative")
+    RE = RunEngine()
+    connect_mock(RE, pseudo)
+    set_mock_value(pseudo._target_readback_0, BASELINES["U_S3H"])
+    set_mock_value(pseudo._target_readback_1, BASELINES["U_S4H"])
+
+    def exploding_scan():
+        yield from bps.stage(pseudo)
+        yield from bps.mv(pseudo, 0.5)
+        raise RuntimeError("boom")
+
+    plan = bpp.finalize_wrapper(exploding_scan(), pseudo.restore_baselines_plan())
+    with pytest.raises(RuntimeError, match="boom"):
+        RE(plan)
+    assert _setpoints(RE, pseudo) == (BASELINES["U_S3H"], BASELINES["U_S4H"])
+
+
+def test_absolute_pseudo_scan_is_not_restored() -> None:
+    RE, pseudo = _run_scan("absolute")
+    # Absolute mode: targets stay where the last position put them
+    # (x=0.5 -> 0.5 / -1.0); no baseline to restore to.
+    assert _setpoints(RE, pseudo) == (0.5, -1.0)
+
+
+def test_restore_without_baselines_is_a_noop() -> None:
+    pseudo = _pseudo("relative")
+    RE = RunEngine()
+    connect_mock(RE, pseudo)
+    RE(pseudo.restore_baselines_plan())  # never staged/moved — must not raise


### PR DESCRIPTION
## What & why

**Relative pseudo (composite) scan axes now return to their captured baselines at end of scan** (GeecsBluesky 0.50.0, minor) — owner request from the first live composite scans ("doesn't return to initial setting from start of scan, which would be nice"), and the one piece kept from the broader mark/return design discussion (explicitly tabled by the owner to avoid console feature creep; manual-move semantics are untouched — "Set 0" still means "no move from here", fresh baseline per manual move).

- `CaPseudoMovable.restore_baselines_plan()` — puts every component back to its captured baseline with **direct per-target puts**: exact and formula-independent (no `f(0) = 0` assumption), riding the same `GatewaySetpointPut` blocking-set completion as every other move.
- `build_step_scan_plan` runs it as a **finalize** — success *and* mid-scan abort — placed after closeout (operator rituals see the scan's final state first) and inside the stage wrapper (before `unstage()` drops the baselines; the nesting makes this ordering structural, not incidental).
- **Deliberate scope**: absolute-mode pseudos are *not* restored (their pre-scan x is unknowable without an inverse — restoring blindly is the NaN-command class of bug this feature must not introduce) and plain axes keep the legacy end-at-last-position behavior. Optimize mode already has its own `on_finish` restore semantics and is untouched.

## LOC breakdown

- `devices/ca/pseudo.py` (`restore_baselines_plan` + `_restore_baselines`): ~36
- `plans/orchestration.py` (finalize + `_restore_movables`): ~16
- `tests/test_pseudo_scan_restore.py`: ~175 (5 tests)
- CHANGELOG / CLAUDE.md / pyproject: ~30

## Tests

`./scripts/check.sh` (as CI): lint green, GeecsBluesky **637 passed, 3 deselected** (632 on dev → +5): end-of-scan restore through the full free-run composition, abort-path restore through the composition *and* directly at the finalize level, absolute-mode-not-restored, and restore-without-baselines no-op.

## Hardware verification

**OWED** (one check, rides the next lab session): run a relative composite scan (e.g. `ALine_e_beam_position_offset_x`) and confirm S3H/S4H return to their pre-scan currents at scan end — including once with a mid-scan Stop. Expected: readbacks equal the pre-scan values within readback jitter (the manual-move restore verified ≤0.0005 A on the same magnets).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
