### PR TITLE
tooling: lab_status.sh --hardware — drop the legacy mixed-case heartbeat fallback

### DIFF
--- a/scripts/lab_status.sh
+++ b/scripts/lab_status.sh
@@ -159,11 +159,10 @@ async def main():
     # PV_CONTRACT.md §1) — never hand-assemble them here.
     from geecs_ca_gateway.pv_naming import pv_name
 
-    prefix = pv_name(experiment, "CAGateway")
     try:
-        heartbeat = await read(f"{prefix}:heartbeat")
-        connected = await read(f"{prefix}:devices_connected")
-        version = await read(f"{prefix}:version")
+        heartbeat = await read(pv_name(experiment, "CAGateway", "heartbeat"))
+        connected = await read(pv_name(experiment, "CAGateway", "devices_connected"))
+        version = await read(pv_name(experiment, "CAGateway", "version"))
     except Exception as exc:  # noqa: BLE001 — a failed probe is a finding
         print(f"  [DOWN] gateway PVs unreadable ({type(exc).__name__}: {exc})")
         print("         network may be up while the gateway service is not")

--- a/scripts/lab_status.sh
+++ b/scripts/lab_status.sh
@@ -154,47 +154,24 @@ async def read(pv):
     return await asyncio.wait_for(aioca.caget(pv), timeout=timeout)
 
 
-async def probe(prefix, names):
-    heartbeat = await read(f"{prefix}:{names['heartbeat']}")
-    connected = await read(f"{prefix}:{names['connected']}")
-    version = await read(f"{prefix}:{names['version']}")
-    return heartbeat, connected, version
-
-
 async def main():
-    # geecs-ca-gateway >= 0.14.0 serves lowercase PV components (PV_CONTRACT.md
-    # §1); older deployments serve mixed case. Probe new-contract names first,
-    # fall back to the legacy ones — which contract answers doubles as a
-    # deployed-generation indicator during the transition. New-contract names
-    # come from the naming contract itself; only the legacy fallback needs
-    # literals (pre-0.14.0 normalize_component preserved case, so today's
-    # pv_name can no longer produce those names).
+    # PV names come from the naming contract (lowercase components,
+    # PV_CONTRACT.md §1) — never hand-assemble them here.
     from geecs_ca_gateway.pv_naming import pv_name
 
-    contracts = [
-        ("lowercase (>=0.14.0)", pv_name(experiment, "CAGateway"),
-         {"heartbeat": "heartbeat", "connected": "devices_connected", "version": "version"}),
-        ("legacy mixed-case (<0.14.0)", f"{experiment}:CAGateway",
-         {"heartbeat": "HEARTBEAT", "connected": "DEVICES_CONNECTED", "version": "VERSION"}),
-    ]
-    last_exc = None
-    for label, prefix, names in contracts:
-        try:
-            heartbeat, connected, version = await probe(prefix, names)
-        except Exception as exc:  # noqa: BLE001 — try the other contract
-            last_exc = exc
-            continue
-        print(f"  [ OK ] gateway alive: heartbeat={int(heartbeat)}, "
-              f"devices_connected={int(connected)}, version={version} "
-              f"[{label} naming]")
-        if int(connected) == 0:
-            print("  [WARN] zero devices connected — GEECS side likely down")
-        return
-    exc = last_exc
-    print(f"  [DOWN] gateway PVs unreadable under either naming contract "
-          f"({type(exc).__name__}: {exc})")
-    print("         network may be up while the gateway service is not")
-    raise SystemExit(1)
+    prefix = pv_name(experiment, "CAGateway")
+    try:
+        heartbeat = await read(f"{prefix}:heartbeat")
+        connected = await read(f"{prefix}:devices_connected")
+        version = await read(f"{prefix}:version")
+    except Exception as exc:  # noqa: BLE001 — a failed probe is a finding
+        print(f"  [DOWN] gateway PVs unreadable ({type(exc).__name__}: {exc})")
+        print("         network may be up while the gateway service is not")
+        raise SystemExit(1)
+    print(f"  [ OK ] gateway alive: heartbeat={int(heartbeat)}, "
+          f"devices_connected={int(connected)}, version={version}")
+    if int(connected) == 0:
+        print("  [WARN] zero devices connected — GEECS side likely down")
 
 
 asyncio.run(main())


### PR DESCRIPTION
## What + why

Removes the legacy mixed-case gateway-heartbeat fallback (and its
which-contract-answered labeling) from the `--hardware` tier of
`scripts/lab_status.sh`, leaving the lowercase naming contract
(`pv_name()`, PV_CONTRACT.md §1) as the only probe path.

The bilingual probe was added in PR #587 explicitly as a
deploy-generation indicator "until the deploy is verified". That
verification is complete: the PR #585 hardware close-out (2026-07-22)
confirmed the deployed gateway answers on the lowercase contract after a
week of live operation. The fallback is now dead code, and its removal
was already flagged as owed follow-up.

Single concern, one file: `scripts/lab_status.sh` (+15/−38). No package
code changed, so no version bump / CHANGELOG (scripts/ is repo tooling,
same as #480/#492).

## Tests

`./scripts/check.sh --all`: lint green (from the root env; a PATH-level
`pre-commit` without `jupyter` misreports the notebook hook — env quirk,
not this diff) and all locally runnable suites pass — root-tests 2,
ImageAnalysis 224, ScanAnalysis 171, GEECS-Data-Utils 198, GEECS-Schemas
244, GeecsBluesky 639, GeecsCAGateway 182, GEECS-Console 789,
GEECS-LogTriage 53 (plus 1–2 skips where noted by the suites).

`scripts/` has no CI-mirrored test suite; the change is covered by
`bash -n` plus `py_compile` of the extracted heredoc, both clean.

## Hardware verification

Not owed for this PR: it removes a fallback whose obsolescence was
itself established by hardware verification (PR #585 close-out,
2026-07-22 — deployed gateway serves the lowercase contract). The
surviving lowercase path is byte-identical to the one exercised live
during that verification week. If the gateway were ever rolled back to
<0.14.0, this script would now report DOWN instead of falling back —
that is the intended post-transition behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)