### PR TITLE
GeecsCAGateway 0.15.0: set-failure observability — :SP WRITE/INVALID alarm + sticky LAST_SET_ERROR PV

### DIFF
--- a/GeecsCAGateway/CHANGELOG.md
+++ b/GeecsCAGateway/CHANGELOG.md
@@ -3,6 +3,29 @@
 All notable changes to `geecs-ca-gateway` are documented here, following
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and semantic versioning.
 
+## [0.15.0] - 2026-07-23
+
+### Added
+
+- **Set-failure observability** (PV_CONTRACT §7): a failed GEECS set — e.g.
+  an out-of-bounds value the device ACKs `accepted` but rejects in the exe
+  reply (live-verified on U_S1H `Current`, 2026-07-23) — now surfaces as
+  published channel state, not only as put-completion failure, so
+  fire-and-forget CA writers (plain `caput`, default Phoebus writes) are no
+  longer blind to it:
+  - the `:SP` channel alarm goes `WRITE`/`INVALID` on a failed set and
+    clears to `NO_ALARM` on the next successful one (transition-only
+    publishes; pre-forward client errors such as an uncastable value do
+    not alarm);
+  - every device with a settable variable gains a
+    `[experiment:]device:last_set_error` long-string PV holding the most
+    recent failure message, sticky until the next failure.
+- `FakeGeecsDevice` gains per-variable `limits` — an out-of-range set is
+  ACKed but fails in the exe reply with the real hardware's
+  `value not in range (hi,lo)` phrasing, for offline pinning of the above.
+- `DEPLOYMENT.md` §3: always write with put-completion; documented why a
+  plain caput cannot see set failures (CA protocol semantics).
+
 ## [0.14.3] - 2026-07-21
 
 ### Changed

--- a/GeecsCAGateway/DEPLOYMENT.md
+++ b/GeecsCAGateway/DEPLOYMENT.md
@@ -242,6 +242,14 @@ subset plus each device's settable control surface (§1), so a variable
 visible in GEECS Master Control is usually reachable here under its
 lowercased name.
 
+**Always write with put-completion** (`caput -c`, caproto-put's default,
+aioca `wait=True`, ophyd-async `set()`). A fire-and-forget write returns
+before the GEECS exchange starts, so a rejected set (e.g. out of the
+device's limits) *looks* successful to that client. A failed set also stamps
+the `:SP` PV with a `WRITE`/`INVALID` alarm and records its message on
+`experiment:device:last_set_error` (read with `caget -S`) — see
+`PV_CONTRACT.md` §7.
+
 **Off-subnet (VPN) notes.** CA name search with an explicit address list is
 *directed unicast* UDP, which routes over VPN — this is why the recipe above
 works off-subnet. Server *beacons* ride UDP broadcast and do **not** cross

--- a/GeecsCAGateway/PV_CONTRACT.md
+++ b/GeecsCAGateway/PV_CONTRACT.md
@@ -122,15 +122,29 @@ ground truth; an instance row with no surviving type link (NULL or dangling
 `devicetype_variable_id`) defines an instance-only variable and is served
 too. Pinned by the inheritance-chain tests in `tests/test_geecs_db.py`.
 
-### Per-device status PV — `CONNECTED`
+### Per-device status PVs — `CONNECTED`, `LAST_SET_ERROR`
 
-Every device gets exactly one status PV: `[experiment:]device:connected`.
+Every device gets a connection-state PV: `[experiment:]device:connected`.
 
 - Type: enum with `enum_strings = ["Disconnected", "Connected"]`
   (index 0 = Disconnected, 1 = Connected).
 - Severity: `NO_ALARM` while connected; **`MAJOR_ALARM`** with status `COMM`
   while the device's TCP subscription is down.
 - Client-read-only.
+
+Every device with at least one settable variable additionally gets
+`[experiment:]device:last_set_error` — the most recent failed GEECS set's
+message (e.g. `U_S1H/Current: Error occurred during setCurrent - -100.0 -
+value not in range (5.000000,-5.000000)`).
+
+- Type: long-string (char-array, capacity 512, UTF-8) — the messages exceed
+  the 40-char `DBR_STRING` cap; read with `caget -S`.
+- **Sticky**: it is *not* cleared by a later successful set — the `:SP`
+  channel's `WRITE`/`INVALID` alarm carries the current/cleared state (§7),
+  this PV is the forensic record of what the last failure said. Empty string
+  until the first failure. One PV per device (GEECS serializes one command
+  per device), so the message names the variable.
+- Client-read-only; timestamped at failure time.
 
 ### Gateway self-diagnostics — the reserved `CAGateway` namespace
 
@@ -188,7 +202,16 @@ GEECS device  <--blocking UDP set-----------  setpoint PV   (caput :SP)
   physical move.
 - If the GEECS set fails (rejection, error, timeout), the setter raises, the
   value is **not** stored, and the CA put fails. Correct put semantics: a
-  failed put leaves the setpoint PV unchanged.
+  failed put leaves the setpoint PV unchanged. The failure is also published
+  as channel state — `:SP` alarm `WRITE`/`INVALID` plus the device's
+  `LAST_SET_ERROR` message PV — because a **no-callback write cannot see the
+  put fail** (see §7, set-failure observability).
+- **Write with put-completion** (`caput -c`, aioca `wait=True`, ophyd-async
+  `set()`) whenever you care about the outcome. A plain fire-and-forget
+  `caput` returns before the GEECS exchange even starts; its failure surfaces
+  only in the CA client library's asynchronous exception handler and the
+  alarm/error PVs above. This is Channel Access protocol semantics, not a
+  gateway limitation.
 - **Set timeout: 30 s default, configurable** (`GeecsCaGateway(set_timeout_s=…)`).
   This deliberately matches `CaMotor._DEFAULT_MOVE_TIMEOUT` (30 s) in
   GeecsBluesky — "a slow axis is not a dead one". A legitimate 10–30 s stage
@@ -492,6 +515,31 @@ At `pvdb` build time (startup), every PV registers in the manifest:
 
 ## 7. Failure semantics
 
+### Set-failure observability — alarm + `LAST_SET_ERROR`
+
+Live-verified against real hardware (U_S1H `Current`, 2026-07-23): an
+out-of-range set is ACKed `accepted` by the device, then fails in the exe
+reply (`error,… value not in range …`). The gateway surfaces that outcome
+three ways, so no client class is blind to it:
+
+1. **Put-completion** (callback writers): the caput fails with
+   `ECA_PUTFAIL`; the exception text carries the GEECS message. The value is
+   not stored (§2).
+2. **`:SP` channel alarm** (monitor clients): a failed set stamps the
+   setpoint channel `WRITE`/`INVALID`; the next successful set clears it to
+   `NO_ALARM`. Transitions only — repeated identical failures do not
+   re-publish. Alarm-sensitive Phoebus widgets show the failure with no
+   screen changes.
+3. **`device:last_set_error`** (any reader): the failure message, sticky
+   until overwritten by the next failure (§1).
+
+Scope: the alarm/error PVs mirror **GEECS forward outcomes** only. A put the
+gateway rejects before any UDP exchange (an uncastable value) fails the caput
+but leaves them untouched; an unresolvable enum label forwards verbatim (§4)
+and alarms only when GEECS rejects it. Fire-and-forget writes can never see
+the put fail — that is CA protocol semantics; use put-completion (§2) or
+monitor the alarm.
+
 ### Per-device startup fault tolerance
 
 - One device failing its UDP bind at `connect()` (e.g. an unroutable IP making
@@ -568,6 +616,8 @@ that branch and are part of this contract's target behavior.
 | Readbacks client-read-only; setpoints writable | `test_gateway.py::test_readback_channels_deny_client_writes` |
 | Stream → readback; caput `:SP` → GEECS → readback | `test_gateway.py::test_stream_updates_readback`, `::test_setpoint_write_reaches_geecs` |
 | Failed GEECS set ⇒ CA put fails, value not stored | `test_pv_contract.py::test_setpoint_put_failure_leaves_value_unstored` |
+| Failed set alarms `:SP` WRITE/INVALID, success clears; pre-forward client errors don't alarm | `test_pv_contract.py::test_setpoint_put_failure_stamps_write_invalid_alarm`, `::test_client_value_error_does_not_alarm_setpoint` |
+| Out-of-range set end-to-end: ACK accepted + exe error ⇒ put fails, alarm, sticky `LAST_SET_ERROR`; PV only on settable devices | `test_gateway.py::test_out_of_range_set_fails_put_alarms_sp_and_records_error`, `::test_last_set_error_pv_exists_only_for_settable_devices` |
 | 30 s configurable set budget; 10 s get budget | `test_gateway.py::test_setpoint_write_uses_move_budget_timeout`, `::test_set_timeout_is_configurable`, `::test_get_uses_standard_exe_timeout` |
 | Timestamp ladder, LabVIEW→Unix, implausible rejected | `test_gateway.py::test_extract_timestamp_converts_labview_to_unix`, `::test_extract_timestamp_ladder_prefers_first_present`, `::test_extract_timestamp_none_when_absent_or_implausible`; `test_config_from_db.py::test_timestamp_ladder_default_prefers_acq_then_sys` |
 | PV stamped with device time; timestamp PVs carry raw LabVIEW value | `test_gateway.py::test_pv_timestamp_from_systimestamp`, `::test_timestamp_vars_exposed_as_pvs_with_raw_value` |

--- a/GeecsCAGateway/PV_CONTRACT.md
+++ b/GeecsCAGateway/PV_CONTRACT.md
@@ -617,6 +617,7 @@ that branch and are part of this contract's target behavior.
 | Stream → readback; caput `:SP` → GEECS → readback | `test_gateway.py::test_stream_updates_readback`, `::test_setpoint_write_reaches_geecs` |
 | Failed GEECS set ⇒ CA put fails, value not stored | `test_pv_contract.py::test_setpoint_put_failure_leaves_value_unstored` |
 | Failed set alarms `:SP` WRITE/INVALID, success clears; pre-forward client errors don't alarm | `test_pv_contract.py::test_setpoint_put_failure_stamps_write_invalid_alarm`, `::test_client_value_error_does_not_alarm_setpoint` |
+| Failure alarm published, transition-only; clear rides the value publish | `test_pv_contract.py::test_failed_set_alarm_is_published_on_transition_only` |
 | Out-of-range set end-to-end: ACK accepted + exe error ⇒ put fails, alarm, sticky `LAST_SET_ERROR`; PV only on settable devices | `test_gateway.py::test_out_of_range_set_fails_put_alarms_sp_and_records_error`, `::test_last_set_error_pv_exists_only_for_settable_devices` |
 | 30 s configurable set budget; 10 s get budget | `test_gateway.py::test_setpoint_write_uses_move_budget_timeout`, `::test_set_timeout_is_configurable`, `::test_get_uses_standard_exe_timeout` |
 | Timestamp ladder, LabVIEW→Unix, implausible rejected | `test_gateway.py::test_extract_timestamp_converts_labview_to_unix`, `::test_extract_timestamp_ladder_prefers_first_present`, `::test_extract_timestamp_none_when_absent_or_implausible`; `test_config_from_db.py::test_timestamp_ladder_default_prefers_acq_then_sys` |

--- a/GeecsCAGateway/geecs_ca_gateway/channels.py
+++ b/GeecsCAGateway/geecs_ca_gateway/channels.py
@@ -16,6 +16,7 @@ string (:func:`enum_geecs_value`).
 
 from __future__ import annotations
 
+import logging
 from typing import Any, Awaitable, Callable
 
 from caproto import (
@@ -32,6 +33,8 @@ from caproto import (
 )
 
 from .config import DType, VariableSpec
+
+logger = logging.getLogger(__name__)
 
 #: Async callable that pushes a value to a GEECS device (``udp.set``-shaped).
 Setter = Callable[[Any], Awaitable[Any]]
@@ -344,9 +347,14 @@ async def _forward_set(channel: ChannelData, setter: Setter, geecs_value: Any) -
             AlarmSeverity.INVALID_ALARM,
             AlarmStatus.WRITE,
         ):
-            await alarm.write(
-                status=AlarmStatus.WRITE, severity=AlarmSeverity.INVALID_ALARM
-            )
+            try:
+                await alarm.write(
+                    status=AlarmStatus.WRITE, severity=AlarmSeverity.INVALID_ALARM
+                )
+            except Exception:
+                # Alarm bookkeeping is best-effort — the caput must fail with
+                # the real set error, never a publish-side one.
+                logger.debug("failed to publish set-failure alarm", exc_info=True)
         raise
     alarm = channel.alarm
     if (alarm.severity, alarm.status) != (

--- a/GeecsCAGateway/geecs_ca_gateway/channels.py
+++ b/GeecsCAGateway/geecs_ca_gateway/channels.py
@@ -321,6 +321,45 @@ def make_description_channel(description: str) -> ChannelData:
     return read_only(ChannelString)(value=description[:_DESC_MAX_LENGTH])
 
 
+async def _forward_set(channel: ChannelData, setter: Setter, geecs_value: Any) -> None:
+    """Forward one GEECS set, mirroring its outcome onto the channel alarm.
+
+    A failed forward stamps ``WRITE``/``INVALID`` on the setpoint channel and
+    re-raises (failing the CA put) — published, so monitor-based clients that
+    never wait for put-completion (plain ``caput``, default Phoebus writes)
+    still observe the failure.  The next successful forward clears the alarm;
+    the clear is not published here because the value store that follows
+    publishes it.  Both directions write on transition only, so a repeated
+    failure does not re-publish an identical alarm state.
+
+    Only the GEECS forward outcome is mirrored: value-shape errors raised
+    *before* the setter (an unknown enum label, an uncastable scalar) are
+    client errors, not device state, and leave the alarm untouched.
+    """
+    try:
+        await setter(geecs_value)
+    except Exception:
+        alarm = channel.alarm
+        if (alarm.severity, alarm.status) != (
+            AlarmSeverity.INVALID_ALARM,
+            AlarmStatus.WRITE,
+        ):
+            await alarm.write(
+                status=AlarmStatus.WRITE, severity=AlarmSeverity.INVALID_ALARM
+            )
+        raise
+    alarm = channel.alarm
+    if (alarm.severity, alarm.status) != (
+        AlarmSeverity.NO_ALARM,
+        AlarmStatus.NO_ALARM,
+    ):
+        await alarm.write(
+            status=AlarmStatus.NO_ALARM,
+            severity=AlarmSeverity.NO_ALARM,
+            publish=False,
+        )
+
+
 def make_setpoint_channel(spec: VariableSpec, setter: Setter) -> ChannelData:
     """Build a writable channel that forwards CA puts to GEECS.
 
@@ -330,7 +369,10 @@ def make_setpoint_channel(spec: VariableSpec, setter: Setter) -> ChannelData:
         The variable being exposed (dtype, metadata, enum choices).
     setter : Setter
         Async callable invoked with the value to send to GEECS.  If it raises,
-        the value is not stored and the CA put fails — the correct semantics.
+        the value is not stored and the CA put fails — the correct semantics —
+        and the channel alarm goes ``WRITE``/``INVALID`` until the next
+        successful set (:func:`_forward_set`), so the failure is observable
+        without put-completion.
     """
     if spec.dtype == "enum":
         choices = list(spec.choices)
@@ -340,7 +382,7 @@ def make_setpoint_channel(spec: VariableSpec, setter: Setter) -> ChannelData:
 
             async def write(self, value: Any, **kwargs: Any) -> Any:
                 """Forward the put (as the GEECS string), then store it."""
-                await setter(enum_geecs_value(choices, value))
+                await _forward_set(self, setter, enum_geecs_value(choices, value))
                 return await super().write(value, **kwargs)
 
         return _GeecsEnumSetpoint(value=0, enum_strings=choices)
@@ -353,7 +395,7 @@ def make_setpoint_channel(spec: VariableSpec, setter: Setter) -> ChannelData:
             async def write(self, value: Any, **kwargs: Any) -> Any:
                 """Forward the put (decoded to text), then store it."""
                 text = _to_text(value)
-                await setter(text)
+                await _forward_set(self, setter, text)
                 return await super().write(text, **kwargs)
 
         return _GeecsPathSetpoint(
@@ -370,7 +412,7 @@ def make_setpoint_channel(spec: VariableSpec, setter: Setter) -> ChannelData:
 
         async def write(self, value: Any, **kwargs: Any) -> Any:
             """Forward the put to GEECS, then store the value locally."""
-            await setter(cast_value(dtype, value))
+            await _forward_set(self, setter, cast_value(dtype, value))
             return await super().write(value, **kwargs)
 
     return _GeecsSetpoint(**_metadata_kwargs(spec))

--- a/GeecsCAGateway/geecs_ca_gateway/gateway.py
+++ b/GeecsCAGateway/geecs_ca_gateway/gateway.py
@@ -183,6 +183,9 @@ class GeecsCaGateway:
         # PVs plus gateway uptime/heartbeat, so Phoebus/alarm layers see
         # liveness explicitly instead of inferring it from INVALID severity.
         self._connected: dict[str, ChannelData] = {}
+        # device name -> LAST_SET_ERROR channel (most recent failed-set message;
+        # sticky — the :SP channel alarm carries the current/cleared state).
+        self._set_errors: dict[str, ChannelData] = {}
         self._gateway_status: dict[str, ChannelData] = {}
         self._status_task: asyncio.Task | None = None
         self._started_at: float | None = None
@@ -254,6 +257,20 @@ class GeecsCaGateway:
                 )
                 self.pvdb[conn_pv] = conn
                 self._connected[dev.name] = conn
+
+            # Per-device last-set-error PV: the most recent failed GEECS set's
+            # message, as a long-string (char-array) channel — the messages
+            # exceed the 40-char DBR_STRING cap. Sticky by design: the :SP
+            # channel's WRITE/INVALID alarm says whether the *latest* set
+            # failed; this PV is the forensic record of what the failure said.
+            if any(v.settable for v in dev.variables):
+                err_pv = dev.pv_name_for(VariableSpec(geecs_var="LAST_SET_ERROR"))
+                if self._register(err_pv, dev.name, "LAST_SET_ERROR", "status"):
+                    err_channel = make_readback_channel(
+                        VariableSpec(geecs_var="LAST_SET_ERROR", dtype="path")
+                    )
+                    self.pvdb[err_pv] = err_channel
+                    self._set_errors[dev.name] = err_channel
 
         self._build_derived_pvs()
         self._build_gateway_status_pvs()
@@ -359,20 +376,41 @@ class GeecsCaGateway:
         the client's default exe timeout: GEECS sets block until the device
         reports convergence, and a legitimate slow move (~10-30 s stage travel)
         must not be failed as a dead connection mid-flight.
+
+        Any failure is recorded on the device's ``LAST_SET_ERROR`` PV before it
+        propagates (and fails the caput) — put-completion is invisible to
+        no-callback writers, so the message must survive somewhere readable.
         """
 
         async def setter(value: Any) -> Any:
-            udp = self._udp.get(device_name)
-            if udp is None:
-                # UDP bind failed at startup (see connect()) — fail the caput
-                # with a clear cause rather than a KeyError.
-                raise GeecsConnectionError(
-                    f"{device_name}: no UDP client (bind failed at startup); "
-                    f"cannot forward set of {geecs_var!r}"
-                )
-            return await udp.set(geecs_var, value, timeout=self._set_timeout)
+            try:
+                udp = self._udp.get(device_name)
+                if udp is None:
+                    # UDP bind failed at startup (see connect()) — fail the
+                    # caput with a clear cause rather than a KeyError.
+                    raise GeecsConnectionError(
+                        f"{device_name}: no UDP client (bind failed at startup); "
+                        f"cannot forward set of {geecs_var!r}"
+                    )
+                return await udp.set(geecs_var, value, timeout=self._set_timeout)
+            except Exception as exc:
+                await self._record_set_error(device_name, exc)
+                raise
 
         return setter
+
+    async def _record_set_error(self, device: str, exc: Exception) -> None:
+        """Write a failed set's message onto the device's ``LAST_SET_ERROR`` PV."""
+        channel = self._set_errors.get(device)
+        if channel is None:
+            return
+        message = str(exc) or type(exc).__name__
+        try:
+            await channel.write(message[: channel.max_length])
+        except Exception:
+            # Recording is best-effort — the caput still fails with the real
+            # cause; never let bookkeeping mask it.
+            logger.debug("failed to record set error for %s", device, exc_info=True)
 
     def _warn_once(self, device: str, geecs_var: str, message: str) -> None:
         """Log a per-(device, variable) warning once, to avoid ~5 Hz spam."""

--- a/GeecsCAGateway/geecs_ca_gateway/testing/fake_device_server.py
+++ b/GeecsCAGateway/geecs_ca_gateway/testing/fake_device_server.py
@@ -63,21 +63,42 @@ class FakeGeecsDevice:
     variables:
         Initial state dict mapping variable name → value.
         Values may be float, int, bool, or str.
+    limits:
+        Optional per-variable ``(lo, hi)`` set limits. A numeric set outside
+        the span is ACKed ``accepted`` but fails in the exe response with the
+        real hardware's out-of-range error phrasing (observed live on
+        ``U_S1H`` ``Current``, 2026-07-23) — the value is not stored.
     """
 
     name: str
     variables: dict[str, Any] = field(default_factory=dict)
+    limits: dict[str, tuple[float, float]] = field(default_factory=dict)
 
     def get(self, var: str) -> Any:
         """Return the current value of ``var``, or ``None`` if not found."""
         return self.variables.get(var)
 
     def set(self, var: str, value: Any) -> bool:
-        """Set ``var`` to ``value``; return ``False`` if the variable is unknown."""
+        """Set ``var`` to ``value``; return ``False`` on any set failure."""
+        return self.try_set(var, value) is None
+
+    def try_set(self, var: str, value: Any) -> str | None:
+        """Set ``var`` to ``value``; return the error detail, ``None`` on success."""
         if var not in self.variables:
-            return False
+            return "unknown variable"
+        span = self.limits.get(var)
+        if span is not None and isinstance(value, (int, float)):
+            lo, hi = span
+            if not lo <= value <= hi:
+                # Real GEECS phrasing, including the (hi, lo) span order:
+                # "Error occurred during setCurrent -  -100.000000000000 -
+                #  value not in range (5.000000,-5.000000)"
+                return (
+                    f"Error occurred during set{var} - {value} - "
+                    f"value not in range ({hi:.6f},{lo:.6f})"
+                )
         self.variables[var] = value
-        return True
+        return None
 
     def build_subscription_payload(self, var_names: list[str], shot: int) -> str:
         """Format the 5-Hz push message for the requested variables."""
@@ -89,11 +110,13 @@ class FakeGeecsDevice:
             parts.append(f"{v} nval,{val} nvar")
         return f"{self.name}>>{shot}>>" + ",".join(parts)
 
-    def build_exe_response(self, var: str, error: bool = False) -> str:
+    def build_exe_response(
+        self, var: str, error: bool = False, detail: str = "unknown variable"
+    ) -> str:
         """Build a GEECS exe-response string for ``var``."""
         val = self.variables.get(var, 0.0)
         if error:
-            return f"{self.name}>>{var}>>{val}>>error,unknown variable"
+            return f"{self.name}>>{var}>>{val}>>error,{detail}"
         return f"{self.name}>>{var}>>{val}>>ok,"
 
 
@@ -136,10 +159,10 @@ class _GeecsUdpProtocol(asyncio.DatagramProtocol):
         if op_and_var.startswith("set"):
             var = op_and_var[3:]
             value = coerce_scalar(value_str)
-            ok = self._device.set(var, value)
+            error_detail = self._device.try_set(var, value)
         elif op_and_var.startswith("get"):
             var = op_and_var[3:]
-            ok = var in self._device.variables
+            error_detail = None if var in self._device.variables else "unknown variable"
         else:
             logger.warning("unknown UDP op: %r", op_and_var)
             return
@@ -150,7 +173,11 @@ class _GeecsUdpProtocol(asyncio.DatagramProtocol):
         self._transport.sendto(b"accepted", (client_ip, client_cmd_port))
 
         # 2) Exe response on the client's exe port (cmd_port + 1)
-        exe_msg = self._device.build_exe_response(var, error=not ok)
+        exe_msg = self._device.build_exe_response(
+            var,
+            error=error_detail is not None,
+            detail=error_detail or "unknown variable",
+        )
         self._transport.sendto(exe_msg.encode("ascii"), (client_ip, client_exe_port))
         logger.debug("UDP tx exe → %s:%s  %r", client_ip, client_exe_port, exe_msg)
 

--- a/GeecsCAGateway/pyproject.toml
+++ b/GeecsCAGateway/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-ca-gateway"
-version = "0.14.3"
+version = "0.15.0"
 description = "EPICS Channel Access soft-IOC gateway exposing GEECS devices as PVs"
 authors = ["Sam Barber <sbarber@lbl.gov>"]
 readme = "README.md"

--- a/GeecsCAGateway/tests/test_gateway.py
+++ b/GeecsCAGateway/tests/test_gateway.py
@@ -21,6 +21,7 @@ from geecs_ca_gateway.testing.fake_device_server import FakeGeecsDevice, FakeGee
 
 from geecs_ca_gateway.alarms import AlarmLimits
 from geecs_ca_gateway.config import DeviceSpec, GatewayConfig, VariableSpec
+from geecs_ca_gateway.exceptions import GeecsCommandFailedError
 from geecs_ca_gateway.gateway import GeecsCaGateway, _extract_timestamp
 
 pytestmark = pytest.mark.fake_server
@@ -467,6 +468,85 @@ async def test_enum_readback_and_setpoint() -> None:
             assert device.get("Enable_Output") == "on"
             # readback follows back to "on"
             assert await _wait_until(lambda: _enum_label(rb) == "on")
+        finally:
+            await gw.close()
+
+
+def _text(value: Any) -> str:
+    """A char-array channel value as a str."""
+    if isinstance(value, (bytes, bytearray)):
+        return value.decode()
+    if not isinstance(value, str) and hasattr(value, "__len__"):
+        return bytes(bytearray(int(v) for v in value)).decode()
+    return str(value)
+
+
+def test_last_set_error_pv_exists_only_for_settable_devices() -> None:
+    """Devices with a settable variable get a LAST_SET_ERROR PV; others don't."""
+    gw = GeecsCaGateway(_config("127.0.0.1", 1))  # Position is settable
+    assert f"{DEVICE_PV}:last_set_error" in gw.pvdb
+
+    readonly_cfg = GatewayConfig(
+        devices=[
+            DeviceSpec(
+                name=DEVICE,
+                host="127.0.0.1",
+                port=1,
+                variables=[VariableSpec(geecs_var="Position", dtype="float")],
+            )
+        ]
+    )
+    assert f"{DEVICE_PV}:last_set_error" not in GeecsCaGateway(readonly_cfg).pvdb
+
+
+async def test_out_of_range_set_fails_put_alarms_sp_and_records_error() -> None:
+    """A GEECS-rejected set fails the put, alarms the :SP, records the message.
+
+    Pins the live-verified out-of-bounds behavior (U_S1H ``Current``,
+    2026-07-23): the device ACKs ``accepted`` but the exe reply is
+    ``error,… value not in range …``. The gateway must surface that as a
+    failed caput + ``WRITE``/``INVALID`` alarm on the ``:SP`` + the message
+    on ``LAST_SET_ERROR`` — never as a silent success. A subsequent in-range
+    set succeeds, clears the alarm, and leaves the error record sticky.
+    """
+    device = FakeGeecsDevice(
+        DEVICE,
+        variables={"Current": 0.0},
+        limits={"Current": (-5.0, 5.0)},
+    )
+    async with FakeGeecsServer(device) as srv:
+        cfg = GatewayConfig(
+            devices=[
+                DeviceSpec(
+                    name=DEVICE,
+                    host=srv.host,
+                    port=srv.port,
+                    variables=[
+                        VariableSpec(geecs_var="Current", dtype="float", settable=True)
+                    ],
+                )
+            ]
+        )
+        gw = GeecsCaGateway(cfg)
+        await gw.connect()
+        sp = gw.pvdb[f"{DEVICE_PV}:current:SP"]
+        err = gw.pvdb[f"{DEVICE_PV}:last_set_error"]
+        try:
+            with pytest.raises(GeecsCommandFailedError, match="value not in range"):
+                await sp.write(-100.0)
+            assert device.get("Current") == pytest.approx(0.0)  # hardware untouched
+            assert sp.value != pytest.approx(-100.0)  # not stored
+            assert int(sp.alarm.severity) == int(AlarmSeverity.INVALID_ALARM)
+            assert int(sp.alarm.status) == int(AlarmStatus.WRITE)
+            assert "value not in range" in _text(err.value)
+
+            await sp.write(2.5)
+            assert device.get("Current") == pytest.approx(2.5)
+            assert sp.value == pytest.approx(2.5)
+            assert int(sp.alarm.severity) == int(AlarmSeverity.NO_ALARM)
+            assert int(sp.alarm.status) == int(AlarmStatus.NO_ALARM)
+            # Sticky forensic record — the alarm carries the cleared state.
+            assert "value not in range" in _text(err.value)
         finally:
             await gw.close()
 

--- a/GeecsCAGateway/tests/test_gateway.py
+++ b/GeecsCAGateway/tests/test_gateway.py
@@ -20,6 +20,7 @@ from caproto import AlarmSeverity, AlarmStatus
 from geecs_ca_gateway.testing.fake_device_server import FakeGeecsDevice, FakeGeecsServer
 
 from geecs_ca_gateway.alarms import AlarmLimits
+from geecs_ca_gateway.channels import _to_text
 from geecs_ca_gateway.config import DeviceSpec, GatewayConfig, VariableSpec
 from geecs_ca_gateway.exceptions import GeecsCommandFailedError
 from geecs_ca_gateway.gateway import GeecsCaGateway, _extract_timestamp
@@ -473,12 +474,8 @@ async def test_enum_readback_and_setpoint() -> None:
 
 
 def _text(value: Any) -> str:
-    """A char-array channel value as a str."""
-    if isinstance(value, (bytes, bytearray)):
-        return value.decode()
-    if not isinstance(value, str) and hasattr(value, "__len__"):
-        return bytes(bytearray(int(v) for v in value)).decode()
-    return str(value)
+    """A char-array channel value as a str (the package's own decode helper)."""
+    return _to_text(value)
 
 
 def test_last_set_error_pv_exists_only_for_settable_devices() -> None:

--- a/GeecsCAGateway/tests/test_pv_contract.py
+++ b/GeecsCAGateway/tests/test_pv_contract.py
@@ -145,6 +145,50 @@ async def test_setpoint_put_failure_stamps_write_invalid_alarm() -> None:
     assert channel.value == pytest.approx(1.0)
 
 
+async def test_failed_set_alarm_is_published_on_transition_only() -> None:
+    """The failure alarm is *published*; identical repeats and clears are not.
+
+    Contract §7: monitor clients are the audience for the failure alarm, so
+    the failed-set ``WRITE``/``INVALID`` write must publish (a state change a
+    subscriber never receives would make the whole feature a no-op — this
+    test fails if the failure path passes ``publish=False``). A repeated
+    identical failure must not re-publish, and the success-path clear rides
+    the value publish that follows (``publish=False`` here).
+    """
+    fail = True
+
+    async def setter(value: Any) -> Any:
+        if fail:
+            raise RuntimeError("GEECS set failed")
+
+    channel = make_setpoint_channel(
+        VariableSpec(geecs_var="Current", dtype="float", settable=True),
+        setter,
+    )
+    calls: list[dict[str, Any]] = []
+    original_write = channel.alarm.write
+
+    async def counting_write(**kwargs: Any) -> Any:
+        calls.append(kwargs)
+        return await original_write(**kwargs)
+
+    channel.alarm.write = counting_write  # type: ignore[method-assign]
+
+    with pytest.raises(RuntimeError):
+        await channel.write(4.2)
+    assert len(calls) == 1
+    assert calls[0].get("publish", True) is True  # the failure IS published
+
+    with pytest.raises(RuntimeError):
+        await channel.write(4.3)
+    assert len(calls) == 1  # repeated identical failure: no re-publish
+
+    fail = False
+    await channel.write(1.0)
+    assert len(calls) == 2  # the clear...
+    assert calls[1]["publish"] is False  # ...rides the value publish instead
+
+
 async def test_client_value_error_does_not_alarm_setpoint() -> None:
     """A value-shape error the gateway rejects pre-forward does not alarm.
 

--- a/GeecsCAGateway/tests/test_pv_contract.py
+++ b/GeecsCAGateway/tests/test_pv_contract.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 from typing import Any
 
 import pytest
+from caproto import AlarmSeverity, AlarmStatus
 
 from geecs_ca_gateway.channels import make_readback_channel, make_setpoint_channel
 from geecs_ca_gateway.config import DeviceSpec, GatewayConfig, VariableSpec
@@ -111,6 +112,61 @@ async def test_setpoint_put_failure_leaves_value_unstored() -> None:
     with pytest.raises(_Boom):
         await channel.write(4.2)
     assert channel.value == before  # not stored — put fails atomically
+
+
+async def test_setpoint_put_failure_stamps_write_invalid_alarm() -> None:
+    """A failed GEECS set alarms the ``:SP`` WRITE/INVALID; success clears it.
+
+    Contract §7 (set-failure observability): put-completion is invisible to
+    no-callback writers, so the failure must also surface as channel state —
+    the ``:SP`` alarm goes ``WRITE``/``INVALID`` on a failed set and returns
+    to ``NO_ALARM`` on the next successful one.
+    """
+    fail = True
+
+    async def setter(value: Any) -> Any:
+        if fail:
+            raise RuntimeError("GEECS set failed")
+
+    channel = make_setpoint_channel(
+        VariableSpec(geecs_var="Current", dtype="float", settable=True),
+        setter,
+    )
+    assert channel.alarm.severity == AlarmSeverity.NO_ALARM
+    with pytest.raises(RuntimeError):
+        await channel.write(4.2)
+    assert channel.alarm.severity == AlarmSeverity.INVALID_ALARM
+    assert channel.alarm.status == AlarmStatus.WRITE
+
+    fail = False
+    await channel.write(1.0)
+    assert channel.alarm.severity == AlarmSeverity.NO_ALARM
+    assert channel.alarm.status == AlarmStatus.NO_ALARM
+    assert channel.value == pytest.approx(1.0)
+
+
+async def test_client_value_error_does_not_alarm_setpoint() -> None:
+    """A value-shape error the gateway rejects pre-forward does not alarm.
+
+    Contract §7: the ``WRITE``/``INVALID`` alarm mirrors GEECS *forward*
+    outcomes only — a put that fails before any UDP exchange (here an
+    uncastable scalar) fails the caput but leaves the alarm untouched.
+    (Unknown enum labels are different: they forward verbatim so GEECS
+    itself rejects them — §4 — and that rejection *does* alarm.)
+    """
+    forwarded: list[Any] = []
+
+    async def setter(value: Any) -> Any:
+        forwarded.append(value)
+
+    channel = make_setpoint_channel(
+        VariableSpec(geecs_var="Current", dtype="float", settable=True),
+        setter,
+    )
+    with pytest.raises(ValueError):
+        await channel.write("not-a-number")
+    assert forwarded == []  # never reached GEECS
+    assert channel.alarm.severity == AlarmSeverity.NO_ALARM
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What + why

A failed GEECS set (e.g. an out-of-bounds value the device ACKs `accepted` but rejects in the exe reply) was visible **only** through CA put-completion. No-callback writers — plain `caput`, default Phoebus writes, and any future agent tooling doing raw CA — saw the put as successful; the device's error message vanished into the gateway log. Live-diagnosed on `U_S1H` `Current` 2026-07-23 (put −100 A, limits ±5): the gateway correctly failed a put-callback write in 0.17 s, but nothing was published for anyone else.

This PR makes the outcome **published channel state** (the standard EPICS idiom), so every client class observes it:

1. **`:SP` channel alarm** (`channels.py`): a failed forward stamps `WRITE`/`INVALID` and re-raises (put still fails, value still unstored — no change for callback clients); the next successful set clears to `NO_ALARM`. Transition-only publishes. Pre-forward client errors (uncastable value) deliberately do not alarm; unresolvable enum labels keep their existing forward-verbatim semantics and alarm only when GEECS rejects them.
2. **Per-device `…:last_set_error` PV** (`gateway.py`): long-string, read-only, sticky record of the most recent failure message (e.g. `U_S1H/Current: … value not in range (5.000000,-5.000000)`); built only for devices with a settable variable.
3. **Docs**: PV_CONTRACT §1/§2/§7 (new "Set-failure observability" section + put-callback requirement), DEPLOYMENT §3 client recipe ("always write with put-completion"), CHANGELOG, version minor → 0.15.0.

## Per-concern LOC (net)

| Concern | Files | ~LOC |
|---|---|---|
| Alarm on failed set | `channels.py` | +45 |
| `LAST_SET_ERROR` PV + failure recording | `gateway.py` | +47 |
| Fake-server per-variable limits (real error phrasing) | `testing/fake_device_server.py` | +33 |
| Pinned tests | `tests/test_gateway.py`, `tests/test_pv_contract.py` | +136 |
| Contract/docs/version | `PV_CONTRACT.md`, `DEPLOYMENT.md`, `CHANGELOG.md`, `pyproject.toml` | +87 |

## Judgment calls (cheap to veto)

- **`WRITE`/`INVALID`** as the failure alarm (consistent with the gateway's INVALID-on-comm-loss idiom).
- **Per-device** (not per-variable) error PV — GEECS serializes one command per device; the message names the variable.
- **Sticky** error text (the alarm carries current/cleared state; the PV is the forensic record).
- Fake server keeps `set() -> bool` for compat; new `try_set()` returns the error detail.

## Tests

`./scripts/check.sh` (scoped): lint green, **GeecsCAGateway 186 passed** (was 182; +4 pinned: alarm transitions, pre-forward no-alarm, e2e out-of-range with ACK-accepted + exe-error, `LAST_SET_ERROR` only on settable devices).

## Hardware verification (done — live, 2026-07-23)

Patched gateway run locally (CA on 127.0.0.1) against the **real U_S1H** over VPN:

- Out-of-bounds put (−100): aioca put-callback **failed in 0.21 s**, value unstored, hardware untouched (readback 8e-05 throughout).
- `:SP` alarm → `INVALID/WRITE` after the failure; → `NO_ALARM` after a subsequent in-bounds put (0.0, the standing setpoint; succeeded in 1.14 s).
- `last_set_error` = `U_S1H/Current: Error occurred during setCurrent -  -100.000000000000 - value not in range (5.000000,-5.000000)` — exact hardware phrasing, sticky across the successful set.
- Note: caproto's *threading client* `write(wait=True)` times out instead of surfacing the server's `ECA_PUTFAIL` ErrorResponse (client-side quirk; libca/aioca — what our stack and EPICS-base `caput` use — fail promptly). Not a server regression; deployed-gateway behavior identical pre-patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)