### PR TITLE
GeecsCAGateway 0.16.0: mirror DB set limits as :SP control limits — pre-forward CA rejection, GEECS backstop unchanged

### DIFF
--- a/GeecsCAGateway/CHANGELOG.md
+++ b/GeecsCAGateway/CHANGELOG.md
@@ -9,9 +9,11 @@ All notable changes to `geecs-ca-gateway` are documented here, following
 
 - **Control (drive) limits on setpoint PVs** (PV_CONTRACT §2): `:SP`
   channels now serve the DB `min`/`max` span as enforced `DBR_CTRL` limits —
-  mirroring GEECS's own enforcement at the gateway per standard EPICS
-  gateway practice — and reject out-of-range puts **pre-forward**
-  (`CannotExceedLimits`, no UDP traffic, no device perturbation; the check
+  mirroring GEECS's own enforcement at the gateway the way native EPICS
+  drive limits (`DRVL`/`DRVH`) express a record's valid span — and reject
+  out-of-range puts **pre-forward** (`CannotExceedLimits`; rejection, never
+  the EPICS record's clamp-to-limit — clamping would move hardware to an
+  uncommanded value; no UDP traffic, no device perturbation; the check
   runs before the GEECS forward because caproto's own `verify_value` runs
   after it). Pre-forward rejection is a client error: no `:SP` alarm, no
   `LAST_SET_ERROR` (those keep mirroring device-side outcomes only).

--- a/GeecsCAGateway/CHANGELOG.md
+++ b/GeecsCAGateway/CHANGELOG.md
@@ -3,6 +3,27 @@
 All notable changes to `geecs-ca-gateway` are documented here, following
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and semantic versioning.
 
+## [0.16.0] - 2026-07-24
+
+### Added
+
+- **Control (drive) limits on setpoint PVs** (PV_CONTRACT §2): `:SP`
+  channels now serve the DB `min`/`max` span as enforced `DBR_CTRL` limits —
+  mirroring GEECS's own enforcement at the gateway per standard EPICS
+  gateway practice — and reject out-of-range puts **pre-forward**
+  (`CannotExceedLimits`, no UDP traffic, no device perturbation; the check
+  runs before the GEECS forward because caproto's own `verify_value` runs
+  after it). Pre-forward rejection is a client error: no `:SP` alarm, no
+  `LAST_SET_ERROR` (those keep mirroring device-side outcomes only).
+  Served only for well-formed spans (both bounds, `lo < hi`; DB audit
+  2026-07-24: 1480/1550 settable Undulator variables qualify) — missing,
+  one-sided, or degenerate rows leave the `:SP` unenforced so a bad DB row
+  can never brick an axis. **GEECS device-side enforcement remains the
+  guaranteed backstop** (interlocks, DB-edit drift): values inside the DB
+  span that the device rejects still fail with the device's error and the
+  0.15.0 alarm machinery. Readbacks are untouched — display limits only
+  (the 9396c61f NaN-readback behavior, now pinned per channel kind).
+
 ## [0.15.0] - 2026-07-23
 
 ### Added

--- a/GeecsCAGateway/DEPLOYMENT.md
+++ b/GeecsCAGateway/DEPLOYMENT.md
@@ -146,8 +146,9 @@ export EPICS_CAS_BEACON_ADDR_LIST="192.168.6.255"  # beacon to the lab subnet
 ```
 
 Serving CA only on the intended subnet is the write-safety residual from
-`DESIGN.md` — GEECS enforces value limits server-side, but there is no CA-level
-auth.
+`DESIGN.md` — value limits are enforced at both layers (gateway `DBR_CTRL`
+drive limits + the GEECS device-side backstop, `PV_CONTRACT.md` §2), but
+there is no CA-level auth.
 
 ---
 
@@ -244,11 +245,15 @@ lowercased name.
 
 **Always write with put-completion** (`caput -c`, caproto-put's default,
 aioca `wait=True`, ophyd-async `set()`). A fire-and-forget write returns
-before the GEECS exchange starts, so a rejected set (e.g. out of the
-device's limits) *looks* successful to that client. A failed set also stamps
-the `:SP` PV with a `WRITE`/`INVALID` alarm and records its message on
-`experiment:device:last_set_error` (read with `caget -S`) — see
-`PV_CONTRACT.md` §7.
+before anything is checked or forwarded, so any rejected set *looks*
+successful to that client. Rejections come in two layers
+(`PV_CONTRACT.md` §2/§7): out-of-DB-range values fail at the CA layer
+itself (`:SP` PVs serve and enforce the DB span as `DBR_CTRL` drive
+limits — visible to put-completion writers and the gateway log only),
+while *device-side* failures (interlocks, local mode, device limits the
+DB doesn't express) additionally stamp the `:SP` PV with a
+`WRITE`/`INVALID` alarm and record their message on
+`experiment:device:last_set_error` (read with `caget -S`).
 
 **Off-subnet (VPN) notes.** CA name search with an explicit address list is
 *directed unicast* UDP, which routes over VPN — this is why the recipe above

--- a/GeecsCAGateway/DESIGN.md
+++ b/GeecsCAGateway/DESIGN.md
@@ -173,8 +173,10 @@ Recorded so the next build phase doesn't relitigate them.
 
 - **Authorization/write-safety is NOT foundational here.** GEECS enforces the DB
   value limits server-side and returns an error the setter propagates (→ CA put
-  fails correctly), so the gateway inherits range safety; the DB-derived CA
-  control limits are a UX hint with GEECS as backstop. A client commanding an
+  fails correctly), so the gateway inherits range safety; since 0.16.0 the
+  gateway additionally *mirrors* the DB span as enforced `DBR_CTRL` drive
+  limits on `:SP` PVs (pre-forward rejection, `PV_CONTRACT.md` §2), with
+  GEECS remaining the guaranteed backstop. A client commanding an
   in-range value is "how things are" today — not a regression. Residual: serve CA
   only on the intended subnet (`EPICS_CAS_INTF_ADDR_LIST`); optional read-only
   mode. *Operational-envelope interlocks* are a genuine future EPICS/Bluesky

--- a/GeecsCAGateway/PV_CONTRACT.md
+++ b/GeecsCAGateway/PV_CONTRACT.md
@@ -220,10 +220,30 @@ GEECS device  <--blocking UDP set-----------  setpoint PV   (caput :SP)
 - The setpoint PV reflects the last *successfully forwarded* put, not the
   device readback. Read state from the readback PV; the `:SP` value is the
   commanded value.
-- Write safety: GEECS enforces DB value limits server-side and returns an error
-  the setter propagates, so an out-of-range `caput` fails correctly. The
-  DB-derived limits on the PV are **display** limits (a UX hint), not
-  gateway-enforced control limits — see §4.
+- Write safety — **layered, gateway mirror + GEECS backstop**. `:SP` channels
+  serve the DB `min`/`max` span as standard EPICS **control (drive) limits**
+  (`DBR_CTRL` metadata — Phoebus sliders bound themselves, ophyd-style
+  clients can validate before putting) and enforce them **pre-forward**: an
+  out-of-range put fails at the CA layer (`CannotExceedLimits`, the same
+  rejection a native IOC would produce) before any UDP traffic reaches the
+  device. The ordering is deliberate — enforcement inside the value store
+  would run *after* the forward, so with DB limits tighter than the
+  device's, the hardware would move and the put would then fail.
+  - Pre-forward rejection is a *client* error (§7): no `:SP` alarm, no
+    `LAST_SET_ERROR` entry — those mirror device-side outcomes only.
+  - Control limits are served only for well-formed spans (both bounds
+    present, `lo < hi`). Missing, one-sided, or degenerate (`lo == hi`)
+    DB rows leave the `:SP` unenforced — a bad row must never brick an
+    axis. (`lo == hi` is also caproto's "limits disabled" sentinel.)
+  - **GEECS device-side enforcement remains the guaranteed backstop and
+    the authority** — unchanged, and it also covers limits the DB doesn't
+    express (interlocks, local mode, drift between a DB edit and the next
+    gateway restart). A put inside the DB span that the device rejects
+    fails with the device's error and drives the §7 alarm/`LAST_SET_ERROR`
+    machinery exactly as before.
+  - Readback PVs keep the same span as **display** limits only, never
+    control limits — see §4 (faithful out-of-range readbacks, e.g. NaN,
+    must publish).
 
 ---
 
@@ -378,11 +398,13 @@ Resolution quirks (all DB-driven, all pinned by tests):
   only the dropdown is lost.
 - `int` exists as a dtype (served as `ChannelInteger`) but is reachable only
   via an explicit `dtypes=` override — the DB never produces it.
-- Metadata: DB `units` → EGU; DB `min`/`max` → **display** limits only, never
-  enforced control limits. caproto enforces control limits on write and would
-  reject faithful-but-out-of-range readbacks — notably `NaN` from a failed
-  online analysis, which the contract requires be *reported*, not clamped.
-  GEECS remains the authority on valid set values (§2).
+- Metadata: DB `units` → EGU; DB `min`/`max` → limits, split by channel kind.
+  **Readbacks: display limits only, never control limits** — caproto enforces
+  control limits on write and would reject faithful-but-out-of-range
+  readbacks, notably `NaN` from a failed online analysis, which the contract
+  requires be *reported*, not clamped. **Setpoints: the span is additionally
+  served and enforced as control (drive) limits** when well-formed (§2).
+  GEECS device-side enforcement remains the guaranteed backstop on sets (§2).
 
 ### Description — the `.DESC` field
 
@@ -534,9 +556,10 @@ three ways, so no client class is blind to it:
    until overwritten by the next failure (§1).
 
 Scope: the alarm/error PVs mirror **GEECS forward outcomes** only. A put the
-gateway rejects before any UDP exchange (an uncastable value) fails the caput
-but leaves them untouched; an unresolvable enum label forwards verbatim (§4)
-and alarms only when GEECS rejects it. Fire-and-forget writes can never see
+gateway rejects before any UDP exchange (an uncastable value, or an
+out-of-control-limits value — §2) fails the caput but leaves them untouched;
+an unresolvable enum label forwards verbatim (§4) and alarms only when GEECS
+rejects it. Fire-and-forget writes can never see
 the put fail — that is CA protocol semantics; use put-completion (§2) or
 monitor the alarm.
 
@@ -637,7 +660,8 @@ that branch and are part of this contract's target behavior.
 | Deadband 0.0 from DB (`tolerance` never a deadband) | `test_pv_contract.py::test_db_tolerance_is_not_used_as_monitor_deadband` |
 | Zero deadband: every change posts, exact repeats suppressed | `test_pv_contract.py::test_zero_deadband_posts_changes_suppresses_exact_repeats` |
 | Explicit non-zero deadband suppression | `test_gateway.py::test_deadband_suppresses_small_changes` |
-| Display (not control) limits; NaN readback reported | `test_config_from_db.py::test_pvdb_built_from_db_spec_has_limits`; `test_gateway.py::test_nan_readback_accepted_despite_limits` |
+| Limits split by kind (readback display-only + NaN reported; `:SP` control limits) | `test_config_from_db.py::test_pvdb_built_from_db_spec_has_limits`; `test_gateway.py::test_nan_readback_accepted_despite_limits` |
+| Out-of-ctrl-limit put rejected pre-forward (no UDP, no alarm/`LAST_SET_ERROR`); degenerate spans stay unlimited; device backstop still alarms behind the gate | `test_pv_contract.py::test_out_of_ctrl_limit_put_rejected_before_forward`, `::test_missing_or_degenerate_db_span_stays_unlimited`; `test_gateway.py::test_ctrl_limit_gate_layers_with_device_side_rejection` |
 | Optional `ca_alarm_limits` table; curated scalar alarms attach only to served numeric readbacks | `test_geecs_db.py::test_get_ca_alarm_limits_returns_validated_rows`, `::test_get_ca_alarm_limits_missing_table_is_fail_open`; `test_config_from_db.py::test_alarm_limits_validate_order_and_presence`, `::test_from_geecs_experiment_attaches_numeric_alarm_limits` |
 | Value alarm severity/status on live readbacks; disconnect INVALID wins until next live frame | `test_gateway.py::test_value_alarm_limits_set_live_readback_severity`, `::test_invalid_liveness_overrides_value_alarm_until_live_frame` |
 | INVALID on drop, auto-recovery; CONNECTED MAJOR while down | `test_gateway.py::test_reconnect_and_validity`, `::test_set_connected_updates_pv_severity_and_count` |

--- a/GeecsCAGateway/PV_CONTRACT.md
+++ b/GeecsCAGateway/PV_CONTRACT.md
@@ -224,11 +224,14 @@ GEECS device  <--blocking UDP set-----------  setpoint PV   (caput :SP)
   serve the DB `min`/`max` span as standard EPICS **control (drive) limits**
   (`DBR_CTRL` metadata — Phoebus sliders bound themselves, ophyd-style
   clients can validate before putting) and enforce them **pre-forward**: an
-  out-of-range put fails at the CA layer (`CannotExceedLimits`, the same
-  rejection a native IOC would produce) before any UDP traffic reaches the
-  device. The ordering is deliberate — enforcement inside the value store
-  would run *after* the forward, so with DB limits tighter than the
-  device's, the hardware would move and the put would then fail.
+  out-of-range put fails at the CA layer (`CannotExceedLimits`) before any
+  UDP traffic reaches the device. **Rejection, never clamping** — a native
+  EPICS `ao` record clamps to `DRVL`/`DRVH`, but clamping here would move
+  hardware to a value the client never commanded; failing the put is the
+  deliberate choice (and caproto's native semantics). The pre-forward
+  ordering is equally deliberate — enforcement inside the value store would
+  run *after* the forward, so with DB limits tighter than the device's, the
+  hardware would move and the put would then fail.
   - Pre-forward rejection is a *client* error (§7): no `:SP` alarm, no
     `LAST_SET_ERROR` entry — those mirror device-side outcomes only.
   - Control limits are served only for well-formed spans (both bounds
@@ -241,6 +244,12 @@ GEECS device  <--blocking UDP set-----------  setpoint PV   (caput :SP)
     gateway restart). A put inside the DB span that the device rejects
     fails with the device's error and drives the §7 alarm/`LAST_SET_ERROR`
     machinery exactly as before.
+  - **Drift cuts both ways.** A DB span looser than the device's is
+    harmless (the backstop catches it). A DB span *wrong-tight* — or
+    widened after the gateway started — hard-blocks valid sets at the CA
+    layer until the gateway restarts (restart *is* the DB-resync
+    mechanism, §"self-diagnostics"/`RESTART`). Fix the row, bounce the
+    gateway.
   - Readback PVs keep the same span as **display** limits only, never
     control limits — see §4 (faithful out-of-range readbacks, e.g. NaN,
     must publish).
@@ -560,8 +569,13 @@ gateway rejects before any UDP exchange (an uncastable value, or an
 out-of-control-limits value — §2) fails the caput but leaves them untouched;
 an unresolvable enum label forwards verbatim (§4) and alarms only when GEECS
 rejects it. Fire-and-forget writes can never see
-the put fail — that is CA protocol semantics; use put-completion (§2) or
-monitor the alarm.
+the put fail — that is CA protocol semantics; use put-completion (§2). The
+alarm/`LAST_SET_ERROR` surface is a net for *device-side* failures only —
+a pre-forward control-limit rejection is visible to put-completion writers
+(and the gateway log) alone, so a fire-and-forget out-of-range write
+vanishes without a PV trace. Accepted trade-off: the served `DBR_CTRL`
+metadata lets well-behaved clients (sliders, ophyd-style limit checks)
+refuse the value before ever putting.
 
 ### Per-device startup fault tolerance
 

--- a/GeecsCAGateway/geecs_ca_gateway/channels.py
+++ b/GeecsCAGateway/geecs_ca_gateway/channels.py
@@ -32,6 +32,11 @@ from caproto import (
     ChannelString,
 )
 
+# Not re-exported at caproto top level; it is the exact class caproto's own
+# verify_value raises, reused so pre-forward rejections are indistinguishable
+# from caproto-native control-limit rejections to CA clients.
+from caproto._data import CannotExceedLimits
+
 from .config import DType, VariableSpec
 
 logger = logging.getLogger(__name__)
@@ -239,8 +244,26 @@ def _metadata_kwargs(
     *,
     initial_severity: AlarmSeverity | None = None,
     initial_status: AlarmStatus | None = None,
+    control_limits: bool = False,
 ) -> dict[str, Any]:
-    """Caproto kwargs (value + EGU/precision/limits) for a scalar channel."""
+    """Caproto kwargs (value + EGU/precision/limits) for a scalar channel.
+
+    Parameters
+    ----------
+    spec : VariableSpec
+        The variable being exposed.
+    initial_severity, initial_status : optional
+        Initial alarm state for the channel.
+    control_limits : bool
+        Additionally serve ``spec.lo``/``spec.hi`` as *control* limits
+        (``DBR_CTRL``) — **setpoint channels only**. Readbacks must stay
+        display-limits-only: caproto enforces control limits on every write,
+        including the gateway's own stream mirroring, and would reject
+        faithful-but-out-of-range readbacks (e.g. NaN from a failed
+        analysis). Only well-formed spans (both bounds present, ``lo < hi``)
+        are served — a degenerate or one-sided DB row must not brick an axis
+        (``lo == hi`` is caproto's "limits disabled" sentinel).
+    """
     kwargs: dict[str, Any] = {"value": _initial(spec.dtype)}
     if initial_severity is not None or initial_status is not None:
         kwargs["alarm"] = ChannelAlarm(
@@ -252,13 +275,20 @@ def _metadata_kwargs(
     if spec.dtype in ("float", "int"):
         if spec.egu:
             kwargs["units"] = spec.egu
-        # Display (informational) limits only — NOT control limits, which caproto
-        # *enforces* on write and would reject faithful-but-out-of-range readbacks
-        # (e.g. NaN from a failed analysis). GEECS is the authority on valid values.
+        # Display (informational) limits on every scalar channel; control
+        # limits only where `control_limits` says so (see the docstring).
         if spec.lo is not None:
             kwargs["lower_disp_limit"] = spec.lo
         if spec.hi is not None:
             kwargs["upper_disp_limit"] = spec.hi
+        if (
+            control_limits
+            and spec.lo is not None
+            and spec.hi is not None
+            and spec.lo < spec.hi
+        ):
+            kwargs["lower_ctrl_limit"] = spec.lo
+            kwargs["upper_ctrl_limit"] = spec.hi
     return kwargs
 
 
@@ -419,11 +449,29 @@ def make_setpoint_channel(spec: VariableSpec, setter: Setter) -> ChannelData:
         """Scalar channel whose CA puts are forwarded to a GEECS device."""
 
         async def write(self, value: Any, **kwargs: Any) -> Any:
-            """Forward the put to GEECS, then store the value locally."""
-            await _forward_set(self, setter, cast_value(dtype, value))
+            """Forward the put to GEECS, then store the value locally.
+
+            Control limits are checked **before** the GEECS forward, not
+            merely via caproto's own ``verify_value`` (which runs inside
+            ``super().write`` — i.e. *after* the UDP set has gone out; with
+            DB limits tighter than the device's, the hardware would move and
+            the put would then fail). The pre-forward check is the same
+            semantics caproto applies: equal limits mean disabled.
+            """
+            geecs_value = cast_value(dtype, value)
+            if dtype in ("float", "int"):
+                lo, hi = self.lower_ctrl_limit, self.upper_ctrl_limit
+                if lo != hi and not lo <= geecs_value <= hi:
+                    # Pre-forward rejection: a client error, not a device
+                    # outcome — no UDP, no :SP alarm, no LAST_SET_ERROR.
+                    raise CannotExceedLimits(
+                        f"Cannot write data {geecs_value}. Limits are set to "
+                        f"{lo} and {hi}."
+                    )
+            await _forward_set(self, setter, geecs_value)
             return await super().write(value, **kwargs)
 
-    return _GeecsSetpoint(**_metadata_kwargs(spec))
+    return _GeecsSetpoint(**_metadata_kwargs(spec, control_limits=True))
 
 
 #: Enum states of the ``CAGateway:RESTART`` control PV.

--- a/GeecsCAGateway/geecs_ca_gateway/channels.py
+++ b/GeecsCAGateway/geecs_ca_gateway/channels.py
@@ -34,8 +34,17 @@ from caproto import (
 
 # Not re-exported at caproto top level; it is the exact class caproto's own
 # verify_value raises, reused so pre-forward rejections are indistinguishable
-# from caproto-native control-limit rejections to CA clients.
-from caproto._data import CannotExceedLimits
+# from caproto-native control-limit rejections to CA clients. Guarded because
+# the private module may move under the uncapped caproto pin — the fallback
+# subclasses the same public base, so client-observable failure is unchanged.
+try:
+    from caproto._data import CannotExceedLimits
+except ImportError:  # pragma: no cover — future caproto moved the private module
+    from caproto import CaprotoValueError
+
+    class CannotExceedLimits(CaprotoValueError):  # type: ignore[no-redef]
+        """Control-limit rejection (local stand-in for caproto's own class)."""
+
 
 from .config import DType, VariableSpec
 

--- a/GeecsCAGateway/pyproject.toml
+++ b/GeecsCAGateway/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-ca-gateway"
-version = "0.15.0"
+version = "0.16.0"
 description = "EPICS Channel Access soft-IOC gateway exposing GEECS devices as PVs"
 authors = ["Sam Barber <sbarber@lbl.gov>"]
 readme = "README.md"

--- a/GeecsCAGateway/tests/test_config_from_db.py
+++ b/GeecsCAGateway/tests/test_config_from_db.py
@@ -172,7 +172,14 @@ def test_dtypes_override() -> None:
 
 
 def test_pvdb_built_from_db_spec_has_limits() -> None:
-    """A gateway built from the DB spec carries CA control limits on channels."""
+    """DB limits split by channel kind: display on readback, control on :SP.
+
+    The readback must stay display-limits-only (caproto enforces control
+    limits on every write, including the gateway's own stream mirroring —
+    the 9396c61f NaN-readback lesson); the setpoint additionally serves the
+    span as enforced ``DBR_CTRL`` limits so out-of-range client puts fail at
+    the CA layer.
+    """
     spec = DeviceSpec.from_db_metadata(
         "U_S1H", "h", 1, U_S1H_META, include=["Current", "Voltage"]
     )
@@ -180,11 +187,18 @@ def test_pvdb_built_from_db_spec_has_limits() -> None:
     gw = GeecsCaGateway(GatewayConfig(devices=[spec]))
 
     current = gw.pvdb["u_s1h:current"]
-    # display (informational) limits, not enforced control limits
+    # readback: display (informational) limits, control limits DISABLED (0/0)
     assert current.upper_disp_limit == 5.0
     assert current.lower_disp_limit == -5.0
     assert current.units == "A"
-    assert "u_s1h:current:SP" in gw.pvdb  # settable -> setpoint exists
+    assert current.lower_ctrl_limit == current.upper_ctrl_limit == 0
+
+    sp = gw.pvdb["u_s1h:current:SP"]  # settable -> setpoint exists
+    # setpoint: same span served as BOTH display and enforced control limits
+    assert sp.lower_disp_limit == -5.0
+    assert sp.upper_disp_limit == 5.0
+    assert sp.lower_ctrl_limit == -5.0
+    assert sp.upper_ctrl_limit == 5.0
 
 
 def test_from_db_metadata_dedupes_duplicate_variables() -> None:

--- a/GeecsCAGateway/tests/test_gateway.py
+++ b/GeecsCAGateway/tests/test_gateway.py
@@ -17,6 +17,7 @@ from typing import Any
 
 import pytest
 from caproto import AlarmSeverity, AlarmStatus
+from caproto._data import CannotExceedLimits
 from geecs_ca_gateway.testing.fake_device_server import FakeGeecsDevice, FakeGeecsServer
 
 from geecs_ca_gateway.alarms import AlarmLimits
@@ -543,6 +544,63 @@ async def test_out_of_range_set_fails_put_alarms_sp_and_records_error() -> None:
             assert int(sp.alarm.severity) == int(AlarmSeverity.NO_ALARM)
             assert int(sp.alarm.status) == int(AlarmStatus.NO_ALARM)
             # Sticky forensic record — the alarm carries the cleared state.
+            assert "value not in range" in _text(err.value)
+        finally:
+            await gw.close()
+
+
+async def test_ctrl_limit_gate_layers_with_device_side_rejection() -> None:
+    """DB ctrl limits gate at CA; device-side rejection still alarms behind it.
+
+    Layered enforcement end-to-end: a put outside the DB span fails with
+    ``CannotExceedLimits`` before any UDP traffic (no alarm, no
+    ``LAST_SET_ERROR`` — a client error, §2/§7); a put *inside* the DB span
+    but outside the device's own (tighter) limits reaches the device, is
+    rejected in the exe reply, and drives the 0.15.0 machinery — put fails,
+    ``WRITE``/``INVALID`` alarm, message recorded.
+    """
+    device = FakeGeecsDevice(
+        DEVICE,
+        variables={"Current": 0.0},
+        limits={"Current": (-3.0, 3.0)},  # device enforces tighter than DB
+    )
+    async with FakeGeecsServer(device) as srv:
+        cfg = GatewayConfig(
+            devices=[
+                DeviceSpec(
+                    name=DEVICE,
+                    host=srv.host,
+                    port=srv.port,
+                    variables=[
+                        VariableSpec(
+                            geecs_var="Current",
+                            dtype="float",
+                            settable=True,
+                            lo=-5.0,
+                            hi=5.0,  # DB span, served as :SP ctrl limits
+                        )
+                    ],
+                )
+            ]
+        )
+        gw = GeecsCaGateway(cfg)
+        await gw.connect()
+        sp = gw.pvdb[f"{DEVICE_PV}:current:SP"]
+        err = gw.pvdb[f"{DEVICE_PV}:last_set_error"]
+        try:
+            # Outside the DB span: rejected at the CA layer, pre-forward.
+            with pytest.raises(CannotExceedLimits):
+                await sp.write(100.0)
+            assert device.get("Current") == pytest.approx(0.0)
+            assert int(sp.alarm.severity) == int(AlarmSeverity.NO_ALARM)
+            assert _text(err.value) == ""  # no device outcome to record
+
+            # Inside the DB span, outside the device's: device-side path.
+            with pytest.raises(GeecsCommandFailedError, match="value not in range"):
+                await sp.write(4.0)
+            assert device.get("Current") == pytest.approx(0.0)
+            assert int(sp.alarm.severity) == int(AlarmSeverity.INVALID_ALARM)
+            assert int(sp.alarm.status) == int(AlarmStatus.WRITE)
             assert "value not in range" in _text(err.value)
         finally:
             await gw.close()

--- a/GeecsCAGateway/tests/test_pv_contract.py
+++ b/GeecsCAGateway/tests/test_pv_contract.py
@@ -16,6 +16,7 @@ from typing import Any
 
 import pytest
 from caproto import AlarmSeverity, AlarmStatus
+from caproto._data import CannotExceedLimits
 
 from geecs_ca_gateway.channels import make_readback_channel, make_setpoint_channel
 from geecs_ca_gateway.config import DeviceSpec, GatewayConfig, VariableSpec
@@ -211,6 +212,64 @@ async def test_client_value_error_does_not_alarm_setpoint() -> None:
         await channel.write("not-a-number")
     assert forwarded == []  # never reached GEECS
     assert channel.alarm.severity == AlarmSeverity.NO_ALARM
+
+
+async def test_out_of_ctrl_limit_put_rejected_before_forward() -> None:
+    """An out-of-range put fails at the CA layer, BEFORE any UDP forward.
+
+    Contract §2: ``:SP`` channels enforce the DB span as control limits
+    pre-forward. The ordering is the load-bearing part — with DB limits
+    tighter than the device's, a post-forward check would move the hardware
+    and then fail the put. And per §7 it is a *client* error: no ``:SP``
+    alarm, nothing on ``LAST_SET_ERROR`` (the setter — where the gateway's
+    error recording hangs — is never invoked).
+    """
+    forwarded: list[Any] = []
+
+    async def setter(value: Any) -> Any:
+        forwarded.append(value)
+
+    channel = make_setpoint_channel(
+        VariableSpec(geecs_var="Current", dtype="float", settable=True, lo=-5, hi=5),
+        setter,
+    )
+    with pytest.raises(CannotExceedLimits, match="Limits are set to"):
+        await channel.write(100.0)
+    assert forwarded == []  # the device never saw the put
+    assert channel.alarm.severity == AlarmSeverity.NO_ALARM
+    assert float(channel.value) != 100.0  # not stored
+
+    await channel.write(2.5)  # in-range put forwards and stores as before
+    assert forwarded == [2.5]
+    assert float(channel.value) == 2.5
+
+
+async def test_missing_or_degenerate_db_span_stays_unlimited() -> None:
+    """No/one-sided/degenerate DB spans serve an unenforced ``:SP``.
+
+    Contract §2: control limits are served only for well-formed spans (both
+    bounds, ``lo < hi``). A variable with no DB limits, one bound, or a
+    degenerate ``lo == hi`` row keeps an unlimited setpoint — a bad DB row
+    must never brick an axis at the CA layer.
+    """
+    for spec_kwargs in (
+        {},  # no bounds
+        {"lo": -5.0},  # one-sided
+        {"lo": 0.0, "hi": 0.0},  # degenerate (real rows: U_TRAServer01)
+    ):
+        forwarded: list[Any] = []
+
+        async def setter(value: Any) -> Any:
+            forwarded.append(value)
+
+        channel = make_setpoint_channel(
+            VariableSpec(
+                geecs_var="Current", dtype="float", settable=True, **spec_kwargs
+            ),
+            setter,
+        )
+        await channel.write(1e6)  # any value forwards
+        assert forwarded == [1e6], f"blocked with {spec_kwargs!r}"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What + why

Restores control-limit enforcement removed (as a side effect) by `9396c61f` — but on **setpoint channels only**, keeping that commit's readback fix intact. `:SP` channels now serve the DB `min`/`max` span as standard EPICS **control (drive) limits** (`DBR_CTRL`) and reject out-of-range puts at the CA layer, mirroring GEECS's own enforcement per usual EPICS gateway practice. **GEECS device-side enforcement remains the guaranteed backstop** (owner-stated framing): interlocks, local mode, and DB-edit drift are still caught device-side and drive the 0.15.0 alarm/`LAST_SET_ERROR` machinery unchanged.

Two implementation findings that shaped the code (both verified against installed caproto source):

1. **caproto rejects (`CannotExceedLimits`), it does not clamp** — so a failed put is a real failure, not a silently altered value.
2. **caproto's own enforcement (`verify_value`) runs inside `super().write()` — i.e. *after* our GEECS forward.** Naive ctrl-limit kwargs alone would let the UDP set go out first; with DB limits tighter than the device's, the hardware would move and *then* the put would fail. The check is therefore explicit and **pre-forward** in the setpoint write path (raising caproto's own exception class so rejections are indistinguishable from a native IOC's). Pinned by an ordering test (counting setter never invoked).

**Data-quality guard**: ctrl limits are served only for well-formed spans (both bounds, `lo < hi`). DB audit today: 1480/1550 settable Undulator numerics qualify; 62 are degenerate `0,0` rows, 1 one-sided, 0 swapped — all of those (and future bad rows) leave the `:SP` unenforced rather than bricking the axis. Pre-forward rejection is a *client* error per PV_CONTRACT §7: no `:SP` alarm, no `LAST_SET_ERROR`.

**Honest premise note**: the original ticket framed this as fixing clients "misreading success" — that's not quite it (post-0.15.0, callback clients already get `ECA_PUTFAIL`, and no-callback clients see ctrl-limit rejections no better — CA delivers those asynchronously too). The real wins: fail-fast with zero device perturbation, and `DBR_CTRL` metadata that ophyd-style clients (incl. the OSPREY epics_connector) and Phoebus sliders use to validate/bound *before* putting.

## Per-concern LOC (net)

| Concern | Files | ~LOC |
|---|---|---|
| Ctrl-limit metadata (SP-only) + pre-forward check | `channels.py` | +54 |
| Pinned tests (limits split, ordering, degenerate spans, layered backstop) | `tests/test_pv_contract.py`, `tests/test_gateway.py`, `tests/test_config_from_db.py` | +125 |
| Contract/docs/version | `PV_CONTRACT.md`, `CHANGELOG.md`, `pyproject.toml` | +69 |

## Tests

`./scripts/check.sh` (scoped): lint green, **GeecsCAGateway 190 passed** (was 187; +3 pinned: pre-forward rejection ordering, missing/one-sided/degenerate spans stay unlimited, CA-gate + device-backstop layering e2e; 1 updated: `test_pvdb_built_from_db_spec_has_limits` now asserts the readback/setpoint split; NaN-readback regression test untouched and green).

## Hardware verification (done — live, 2026-07-24)

Patched gateway run locally (CA on 127.0.0.1) against the **real U_S1H** over VPN:

- `:SP` serves `DBR_CTRL` metadata: ctrl (−5, 5), disp (−5, 5), EGU `A`.
- `caput …current:SP 100` (put-callback) **failed in 0.002 s** — faster than one VPN round-trip (20 ms rtt), proving no UDP reached the device; `:SP` alarm stayed `NO_ALARM` and `last_set_error` stayed empty (client error, not device outcome).
- In-range `caput …current:SP 0.0` succeeded in 1.12 s — blocking GEECS set semantics unchanged; readback steady at 8e-05 A throughout (magnet never moved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)