### PR TITLE
GeecsPvaGateway 0.3.0: pull-on-restart from the shared GEECS-Plugins clone (Active Version pattern)

### DIFF
--- a/GeecsPvaGateway/CHANGELOG.md
+++ b/GeecsPvaGateway/CHANGELOG.md
@@ -3,6 +3,19 @@
 All notable changes to this package will be documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.3.0] — 2026-07-25
+
+### Changed
+
+- **Pull-on-restart installs from the lab's shared GEECS-Plugins clone instead
+  of a wheel drop** (owner decision: reuse the "Active Version" pattern GEECS
+  itself launches from). `launch.bat` reinstalls the three packages from
+  `GEECS_PVA_SOURCE` (`--no-deps --no-build-isolation`; poetry-core installed
+  at bootstrap so restarts need no internet); the clone's checked-out commit
+  is the fleet pin — rollout = `git pull` there + restart PVs, rollback =
+  `git checkout <rev>` + restarts. Replaces the never-deployed wheel/CURRENT
+  machinery; bootstrap's `-WheelShare` becomes `-SourceShare`.
+
 ## [0.2.1] — 2026-07-25
 
 ### Added

--- a/GeecsPvaGateway/CHANGELOG.md
+++ b/GeecsPvaGateway/CHANGELOG.md
@@ -9,7 +9,8 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - **Pull-on-restart installs from the lab's shared GEECS-Plugins clone instead
   of a wheel drop** (owner decision: reuse the "Active Version" pattern GEECS
-  itself launches from). `launch.bat` reinstalls the three packages from
+  itself launches from). `launch.bat` reinstalls the four intra-repo packages (incl. the
+  transitive `GEECS-Schemas`) from
   `GEECS_PVA_SOURCE` (`--no-deps --no-build-isolation`; poetry-core installed
   at bootstrap so restarts need no internet); the clone's checked-out commit
   is the fleet pin — rollout = `git pull` there + restart PVs, rollback =

--- a/GeecsPvaGateway/CLAUDE.md
+++ b/GeecsPvaGateway/CLAUDE.md
@@ -28,7 +28,8 @@ geecs_pva_gateway/
 deploy/
   bootstrap.ps1   # one-time per-box setup (venv, firewall, NSSM service with
                   #   USERPROFILE override -> service-owned profile)
-  launch.bat      # pull-on-restart launcher (pin to CURRENT wheel on share)
+  launch.bat      # pull-on-restart launcher (reinstall from the shared
+                  #   GEECS-Plugins clone; its checked-out commit = fleet pin)
   fleet_status.bob# Phoebus fleet screen: version/heartbeat/restart per host
 tests/
   test_config.py  # scoping/naming units (fake DB rows, no network)

--- a/GeecsPvaGateway/DEPLOYMENT.md
+++ b/GeecsPvaGateway/DEPLOYMENT.md
@@ -29,7 +29,8 @@ Prereqs: **Python 3.11** installed (`py -3.11` must work) and internet access
 powershell -ExecutionPolicy Bypass -File .\GeecsPvaGateway\deploy\bootstrap.ps1 `
     -Experiment Undulator -Source .\GeecsPvaGateway `
     -ConfigSource "\\fileserver\software\path\to\user data\Configurations.INI"
-# optional pull-on-restart: add  -WheelShare \\fileserver\software\pva-wheels
+# optional pull-on-restart from the lab's shared GEECS-Plugins clone:
+#   add  -SourceShare "\\fileserver\software\...\Active Version\GEECS-Plugins"
 ```
 
 `-ConfigSource` copies the DB-credentials INI into the service profile so the
@@ -40,44 +41,30 @@ has no share credentials, so scp a copy to the box first and point at that.
 Omit the flag to place the file by hand.
 
 This stops any existing service, creates `C:\geecs\pva-gateway\{venv,profile,
-logs}`, **generates config.ini**, installs the package (use the source dir, not
-a wheel — monorepo wheels carry unresolvable path metadata, see Rollout),
-copies `launch.bat`, opens the PVA firewall ports (TCP 5075 / UDP 5076),
-fetches `nssm.exe`, and registers the `GeecsPvaGateway` service (auto-start,
-restart on any exit, online-rotating logs). If you omitted `-ConfigSource`,
-place `Configurations.INI` in the profile (rule 1); then
-`nssm start GeecsPvaGateway`. Note `launch.bat` is
-copied at bootstrap time — launcher changes need a re-bootstrap, wheels don't.
+logs}`, **generates config.ini**, installs the package from source (path deps
+resolve inside a checkout — a console session can use the share clone as
+`-Source`; over SSH use a local GitHub clone), copies `launch.bat`, opens the
+PVA firewall ports (TCP 5075 / UDP 5076), fetches `nssm.exe`, and registers
+the `GeecsPvaGateway` service (auto-start, restart on any exit, online-rotating
+logs). If you omitted `-ConfigSource`, place `Configurations.INI` in the
+profile (rule 1); then `nssm start GeecsPvaGateway`. Note `launch.bat` is
+copied at bootstrap time — launcher changes need a re-bootstrap, package
+updates don't.
 A **re**-bootstrap removes the existing service first (so pip never upgrades
 in-use files): if a later step fails, the box has no service until the
 bootstrap is re-run to completion — the failure is loud, fix and re-run.
 
 ## Rollout (fleet upgrade without touching boxes)
 
-Build a wheel for **every intra-repo package that changed** (path deps do not
-resolve from wheels — pull-on-restart installs with `--no-deps`, so anything
-not shipped explicitly stays at its installed version):
+The fleet installs from the lab's **shared GEECS-Plugins clone** (the "Active
+Version" pattern GEECS itself launches from): `GEECS_PVA_SOURCE` points every
+service at it, and the clone's checked-out commit **is** the fleet pin — no
+wheels, no version files. Rollout:
 
 ```bash
-for p in GEECS-Data-Utils GeecsCAGateway GeecsPvaGateway; do (cd $p && poetry build); done
-# copy the changed wheels to the share and update their lines in CURRENT.
-# CURRENT is a LOCKFILE, not a delta: it always lists the COMPLETE pinned
-# set (one filename per line, dependencies first), so a box that missed a
-# rollout converges to the same state on its next restart:
-#   \\fileserver\software\pva-wheels\CURRENT:
-#     geecs_data_utils-0.13.5-py3-none-any.whl
-#     geecs_ca_gateway-0.17.0-py3-none-any.whl
-#     geecs_pva_gateway-0.2.0-py3-none-any.whl
+# in the share clone (e.g. ...\Active Version\GEECS-Plugins):
+git pull            # advance the pin (or: git checkout <rev> to roll back)
 ```
-
-Two constraints inherited from the monorepo, both by design:
-
-- **External (PyPI) deps are frozen at bootstrap** — `--no-deps` never touches
-  them. A numpy/p4p bump is a re-bootstrap, not a rollout.
-- **The wheel share must be readable by the boxes' *machine accounts*** —
-  LocalSystem authenticates to shares as the computer account, not a user. If
-  the share needs user credentials, pull-on-restart silently no-ops on every
-  box, visible only as the version PV never flipping.
 
 Then restart instances **via the `:restart` PV** — canary first:
 
@@ -85,12 +72,28 @@ Then restart instances **via the `:restart` PV** — canary first:
 pvput undulator:pvagateway:192_168_6_100:restart 1
 ```
 
-The server exits with code 86, NSSM relaunches `launch.bat`, which re-pins to
-the `CURRENT` wheels and re-resolves the DB config. Watch the instance's
+The server exits with code 86, NSSM relaunches `launch.bat`, which reinstalls
+the three packages (`GEECS-Data-Utils`, `GeecsCAGateway`, `GeecsPvaGateway`)
+from the share clone and re-resolves the DB config. Watch the instance's
 `version` PV flip on the fleet screen (`deploy/fleet_status.bob` — one row per
 host: version, heartbeat, and a confirm-dialog restart button); roll the rest
 when the canary soaks clean. An unreachable share falls through to the
 installed versions — a restart never bricks an instance.
+
+Constraints, all by design:
+
+- **External (PyPI) deps are frozen at bootstrap** — the reinstall is
+  `--no-deps` (monorepo path-dep metadata never resolves outside a checkout)
+  with `--no-build-isolation` (builds use the venv's poetry-core, so restarts
+  need no internet). A numpy/p4p bump is a re-bootstrap, not a rollout.
+- **The share clone must be readable by the boxes' *machine accounts*** —
+  LocalSystem authenticates to shares as the computer account, not a user. If
+  the share needs user credentials, pull-on-restart silently no-ops on every
+  box, visible only as the version PV never flipping. Validate once on the
+  canary: set `GEECS_PVA_SOURCE`, hit `:restart`, and look for the
+  `pull-on-restart: reinstalling from …` line in the service log.
+- **Don't `git pull` the share clone mid-rollout-restart** — the reinstall
+  reads the clone live; pull first, then restart boxes.
 
 ## Smoke test
 

--- a/GeecsPvaGateway/DEPLOYMENT.md
+++ b/GeecsPvaGateway/DEPLOYMENT.md
@@ -91,7 +91,13 @@ Constraints, all by design:
   the share needs user credentials, pull-on-restart silently no-ops on every
   box, visible only as the version PV never flipping. Validate once on the
   canary: set `GEECS_PVA_SOURCE`, hit `:restart`, and look for the
-  `pull-on-restart: reinstalling from …` line in the service log.
+  `pull-on-restart: reinstalling from …` line in the service log. If the ACL
+  can't be opened to machine accounts, the fallback is running the service as
+  the lab's shared domain account — `nssm set GeecsPvaGateway ObjectName
+  DOMAIN\user <password>`, an operator-typed step per box (passwords never in
+  scripts), coupled to that password never rotating. The `USERPROFILE`
+  override stays either way: mapped drives are per-logon-session and invisible
+  to services under *any* account.
 - **Don't `git pull` the share clone mid-rollout-restart** — the reinstall
   reads the clone live; pull first, then restart boxes.
 

--- a/GeecsPvaGateway/DEPLOYMENT.md
+++ b/GeecsPvaGateway/DEPLOYMENT.md
@@ -73,8 +73,8 @@ pvput undulator:pvagateway:192_168_6_100:restart 1
 ```
 
 The server exits with code 86, NSSM relaunches `launch.bat`, which reinstalls
-the three packages (`GEECS-Data-Utils`, `GeecsCAGateway`, `GeecsPvaGateway`)
-from the share clone and re-resolves the DB config. Watch the instance's
+the four intra-repo packages (`GEECS-Schemas`, `GEECS-Data-Utils`,
+`GeecsCAGateway`, `GeecsPvaGateway`) from the share clone and re-resolves the DB config. Watch the instance's
 `version` PV flip on the fleet screen (`deploy/fleet_status.bob` — one row per
 host: version, heartbeat, and a confirm-dialog restart button); roll the rest
 when the canary soaks clean. An unreachable share falls through to the

--- a/GeecsPvaGateway/deploy/bootstrap.ps1
+++ b/GeecsPvaGateway/deploy/bootstrap.ps1
@@ -4,13 +4,14 @@
 #   powershell -ExecutionPolicy Bypass -File .\GeecsPvaGateway\deploy\bootstrap.ps1 `
 #       -Experiment Undulator -Source .\GeecsPvaGateway
 # -Source accepts the package source dir (recommended: resolves the monorepo
-# path deps) or a wheel. -WheelShare (optional) enables pull-on-restart, e.g.
-#   -WheelShare \\fileserver\software\pva-wheels
+# path deps) or a wheel. -SourceShare (optional) enables pull-on-restart from
+# the lab's shared GEECS-Plugins clone (UNC path, machine-account readable):
+#   -SourceShare "\\fileserver\software\...\Active Version\GEECS-Plugins"
 param(
     [Parameter(Mandatory = $true)][string]$Experiment,
     [Parameter(Mandatory = $true)][string]$Source,
     [string]$Root = "C:\geecs\pva-gateway",
-    [string]$WheelShare = "",
+    [string]$SourceShare = "",
     # Path to a readable Configurations.INI (share path from a console session
     # with the drive mapped, or a local copy when driving over SSH). Copied
     # into the service profile so the box is start-ready after bootstrap.
@@ -70,6 +71,10 @@ if (-not (Test-Path "$Root\venv")) {
 }
 & "$Root\venv\Scripts\python" -m pip install --quiet --upgrade pip
 Assert-Native "pip self-upgrade"
+# poetry-core lets pull-on-restart build from the source clone with
+# --no-build-isolation (no internet needed at restart time).
+& "$Root\venv\Scripts\python" -m pip install --quiet poetry-core
+Assert-Native "poetry-core install"
 # --no-cache-dir: pip's wheel cache can serve a stale same-URL build of a
 # monorepo path dep (bit the canary: cached morning build shadowed a newer
 # same-day version).
@@ -110,7 +115,7 @@ Assert-Native "nssm install"
     "USERPROFILE=$Root\profile" `
     "GEECS_PVA_ROOT=$Root" `
     "GEECS_PVA_EXPERIMENT=$Experiment" `
-    "GEECS_PVA_WHEEL_SHARE=$WheelShare"
+    "GEECS_PVA_SOURCE=$SourceShare"
 & $nssm set GeecsPvaGateway AppStdout "$Root\logs\service.log"
 & $nssm set GeecsPvaGateway AppStderr "$Root\logs\service.log"
 & $nssm set GeecsPvaGateway AppRotateFiles 1

--- a/GeecsPvaGateway/deploy/bootstrap.ps1
+++ b/GeecsPvaGateway/deploy/bootstrap.ps1
@@ -3,9 +3,10 @@
 # Run from an elevated PowerShell inside the repo checkout:
 #   powershell -ExecutionPolicy Bypass -File .\GeecsPvaGateway\deploy\bootstrap.ps1 `
 #       -Experiment Undulator -Source .\GeecsPvaGateway
-# -Source accepts the package source dir (recommended: resolves the monorepo
-# path deps) or a wheel. -SourceShare (optional) enables pull-on-restart from
-# the lab's shared GEECS-Plugins clone (UNC path, machine-account readable):
+# -Source accepts the package source dir (path deps resolve inside a
+# checkout; monorepo wheels do not work — unresolvable path metadata).
+# -SourceShare (optional) enables pull-on-restart from the lab's shared
+# GEECS-Plugins clone (UNC path, machine-account readable):
 #   -SourceShare "\\fileserver\software\...\Active Version\GEECS-Plugins"
 param(
     [Parameter(Mandatory = $true)][string]$Experiment,
@@ -107,7 +108,7 @@ if (-not (Test-Path $nssm)) {
 }
 
 # Service: launch.bat under LocalSystem, restart on any exit (the :restart PV
-# exits 86; NSSM relaunches -> DB re-resolve + wheel re-pin).
+# exits 86; NSSM relaunches -> DB re-resolve + reinstall from the source clone).
 & $nssm install GeecsPvaGateway "$Root\launch.bat"
 Assert-Native "nssm install"
 & $nssm set GeecsPvaGateway AppDirectory $Root

--- a/GeecsPvaGateway/deploy/bootstrap.ps1
+++ b/GeecsPvaGateway/deploy/bootstrap.ps1
@@ -85,7 +85,7 @@ Assert-Native "package install from $Source"
 Assert-Native "installed-entrypoint check"
 
 # Launcher (pull-on-restart logic; note: copied once here, NOT part of the
-# wheel rollout loop — a launch.bat change needs re-running this bootstrap)
+# pull-on-restart loop — a launch.bat change needs re-running this bootstrap)
 Copy-Item "$PSScriptRoot\launch.bat" "$Root\launch.bat" -Force
 
 # Firewall (idempotent): PVA server TCP + search UDP

--- a/GeecsPvaGateway/deploy/fleet_status.bob
+++ b/GeecsPvaGateway/deploy/fleet_status.bob
@@ -3,7 +3,7 @@
      To add a host: copy the three widgets of a row, bump every y by 30, and
      replace the host token (IP with dots -> underscores, e.g. 192_168_6_100).
      Rollout = write 1 to :restart (confirmation dialog) — the service
-     relaunches and re-pins to the current wheel; watch version converge. -->
+     relaunches and reinstalls from the source clone; watch version converge. -->
 <display version="2.0.0">
   <name>PVA Gateway Fleet</name>
   <width>640</width>
@@ -57,7 +57,7 @@
     </actions>
     <text>restart</text>
     <x>440</x><y>70</y><width>80</width><height>20</height>
-    <tooltip>Relaunch this instance (re-pins to the current wheel)</tooltip>
+    <tooltip>Relaunch this instance (reinstalls from the source clone)</tooltip>
     <confirm_dialog>true</confirm_dialog>
     <confirm_message>Restart the PVA gateway on 192.168.6.100?</confirm_message>
   </widget>

--- a/GeecsPvaGateway/deploy/launch.bat
+++ b/GeecsPvaGateway/deploy/launch.bat
@@ -4,7 +4,7 @@ rem NSSM runs this with USERPROFILE, GEECS_PVA_ROOT, GEECS_PVA_EXPERIMENT and
 rem (optionally) GEECS_PVA_SOURCE set (see bootstrap.ps1). GEECS_PVA_SOURCE is
 rem the UNC path of the shared GEECS-Plugins clone (the lab's "Active
 rem Version" clone): a restart — :restart PV (exit 86), crash, or reboot —
-rem reinstalls the three packages from it, so the clone's checked-out commit
+rem reinstalls the four intra-repo packages from it, so the clone's commit
 rem IS the fleet pin. Rollout = git pull in the clone + restart PVs; rollback
 rem = git checkout <rev> there + restarts. An unreachable share falls through
 rem to the installed versions (a restart never bricks an instance).
@@ -21,8 +21,8 @@ if "%GEECS_PVA_ROOT%"=="" set GEECS_PVA_ROOT=C:\geecs\pva-gateway
 
 if not "%GEECS_PVA_SOURCE%"=="" (
     if exist "%GEECS_PVA_SOURCE%\GeecsPvaGateway\pyproject.toml" (
-        echo pull-on-restart: reinstalling from %GEECS_PVA_SOURCE%
-        "%GEECS_PVA_ROOT%\venv\Scripts\python" -m pip install --quiet --upgrade --no-deps --no-build-isolation "%GEECS_PVA_SOURCE%\GEECS-Data-Utils" "%GEECS_PVA_SOURCE%\GeecsCAGateway" "%GEECS_PVA_SOURCE%\GeecsPvaGateway"
+        echo pull-on-restart: reinstalling from "%GEECS_PVA_SOURCE%"
+        "%GEECS_PVA_ROOT%\venv\Scripts\python" -m pip install --quiet --upgrade --no-deps --no-build-isolation "%GEECS_PVA_SOURCE%\GEECS-Schemas" "%GEECS_PVA_SOURCE%\GEECS-Data-Utils" "%GEECS_PVA_SOURCE%\GeecsCAGateway" "%GEECS_PVA_SOURCE%\GeecsPvaGateway"
     )
 )
 

--- a/GeecsPvaGateway/deploy/launch.bat
+++ b/GeecsPvaGateway/deploy/launch.bat
@@ -1,32 +1,28 @@
 @echo off
 rem GeecsPvaGateway service launcher: pull-on-restart, then serve.
 rem NSSM runs this with USERPROFILE, GEECS_PVA_ROOT, GEECS_PVA_EXPERIMENT and
-rem (optionally) GEECS_PVA_WHEEL_SHARE set (see bootstrap.ps1). A restart —
-rem :restart PV (exit 86), crash, or reboot — re-pins to the wheels listed in
-rem CURRENT on the share; an unreachable share falls through to the installed
-rem versions. NOTE: LocalSystem authenticates to shares as the MACHINE
-rem account — the share must be readable by it or the check silently fails
-rem every restart (visible only as version-PV skew; see DEPLOYMENT.md).
+rem (optionally) GEECS_PVA_SOURCE set (see bootstrap.ps1). GEECS_PVA_SOURCE is
+rem the UNC path of the shared GEECS-Plugins clone (the lab's "Active
+rem Version" clone): a restart — :restart PV (exit 86), crash, or reboot —
+rem reinstalls the three packages from it, so the clone's checked-out commit
+rem IS the fleet pin. Rollout = git pull in the clone + restart PVs; rollback
+rem = git checkout <rev> there + restarts. An unreachable share falls through
+rem to the installed versions (a restart never bricks an instance).
+rem NOTE: LocalSystem authenticates to shares as the MACHINE account — the
+rem share must be readable by it or the check silently fails every restart
+rem (visible only as version-PV skew; see DEPLOYMENT.md).
 rem
-rem CURRENT lists one wheel filename per line (intra-repo deps first, e.g.
-rem geecs_data_utils, geecs_ca_gateway, then geecs_pva_gateway). Wheels are
-rem installed together with --no-deps: monorepo wheels carry unresolvable
-rem build-machine path metadata, and external (PyPI) deps are frozen at
-rem bootstrap time by design.
-setlocal enabledelayedexpansion
+rem --no-deps: monorepo path-dep metadata never resolves outside a checkout;
+rem external (PyPI) deps are frozen at bootstrap by design.
+rem --no-build-isolation: build with the venv's poetry-core (installed at
+rem bootstrap), so a restart needs no internet.
 
 if "%GEECS_PVA_ROOT%"=="" set GEECS_PVA_ROOT=C:\geecs\pva-gateway
 
-if not "%GEECS_PVA_WHEEL_SHARE%"=="" (
-    if exist "%GEECS_PVA_WHEEL_SHARE%\CURRENT" (
-        set WHEELS=
-        for /f "usebackq delims=" %%w in ("%GEECS_PVA_WHEEL_SHARE%\CURRENT") do (
-            set WHEELS=!WHEELS! "%GEECS_PVA_WHEEL_SHARE%\%%w"
-        )
-        if not "!WHEELS!"=="" (
-            echo pull-on-restart: pinning to !WHEELS!
-            "%GEECS_PVA_ROOT%\venv\Scripts\python" -m pip install --quiet --upgrade --no-deps !WHEELS!
-        )
+if not "%GEECS_PVA_SOURCE%"=="" (
+    if exist "%GEECS_PVA_SOURCE%\GeecsPvaGateway\pyproject.toml" (
+        echo pull-on-restart: reinstalling from %GEECS_PVA_SOURCE%
+        "%GEECS_PVA_ROOT%\venv\Scripts\python" -m pip install --quiet --upgrade --no-deps --no-build-isolation "%GEECS_PVA_SOURCE%\GEECS-Data-Utils" "%GEECS_PVA_SOURCE%\GeecsCAGateway" "%GEECS_PVA_SOURCE%\GeecsPvaGateway"
     )
 )
 

--- a/GeecsPvaGateway/geecs_pva_gateway/server.py
+++ b/GeecsPvaGateway/geecs_pva_gateway/server.py
@@ -39,7 +39,7 @@ _HEARTBEAT_PERIOD_S = 5.0
 
 # Process exit code meaning "restart requested via the :restart PV" — the
 # service manager relaunches, which re-resolves DB config and (with the
-# pull-on-restart launcher) picks up the pinned wheel version. Mirrors the
+# pull-on-restart launcher) reinstalls from the source clone. Mirrors the
 # CA gateway's CAGateway:RESTART -> exit 86 -> systemd relaunch pattern.
 RESTART_EXIT_CODE = 86
 

--- a/GeecsPvaGateway/pyproject.toml
+++ b/GeecsPvaGateway/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-pva-gateway"
-version = "0.2.1"
+version = "0.3.0"
 description = "Distributed pvAccess gateway serving GEECS camera images as NTNDArray PVs"
 authors = ["Sam Barber <sbarber@lbl.gov>"]
 readme = "README.md"


### PR DESCRIPTION
## What + why

Owner decision: the lab's `Active Version` share already carries a GEECS-Plugins clone — the same pattern GEECS device software launches from — so the fleet should install from **it**, not from a parallel wheel drop. This replaces the wheel/`CURRENT` machinery from #607 (which never reached a box) before it ships anywhere:

- `launch.bat`: `GEECS_PVA_SOURCE` = UNC of the share clone; each restart reinstalls `GEECS-Data-Utils` + `GeecsCAGateway` + `GeecsPvaGateway` from it with `--no-deps --no-build-isolation`. The clone's checked-out commit **is** the fleet pin: rollout = `git pull` there + restart PVs; rollback = `git checkout <rev>` + restarts. Unreachable share falls through to installed versions (never-bricks contract kept).
- `bootstrap.ps1`: `-WheelShare` → `-SourceShare`; installs **poetry-core** into the venv so restart-time source builds need no internet (`--no-build-isolation`).
- `DEPLOYMENT.md`: Rollout section rewritten (three constraints: PyPI deps frozen at bootstrap; machine-account share readability with the one-shot canary validation recipe; don't pull the clone mid-restart). Bootstrap section notes console sessions can use the share clone as `-Source` while SSH-driven bootstraps use a local GitHub clone (SSH sessions hold no share credentials).

This also kills the wheel design's worst residual (per #607 review finding 1: monorepo wheels embed unresolvable build-machine `file://` metadata + leak home paths) by never building wheels at all. ~40 LOC scripts, ~40 LOC docs, single concern.

## Tests

No Python runtime changes — suite unaffected (14 passed at base). Lint green.

## Hardware verification

**OWED, next canary session** (needs the share-clone UNC from `net use` + box access): set `GEECS_PVA_SOURCE` on the canary service, `:restart`, and confirm the `pull-on-restart: reinstalling from …` log line — which simultaneously validates machine-account share readability, the one open infrastructure question. The fall-through path (unset/unreachable source) is what the canary currently runs.

## Flagged for cheap veto

- Reinstall runs on **every** restart (not only when the clone changed) — simplicity over cleverness; costs a few seconds of pip per restart, and restarts are rollouts/reboots.
- The reinstall builds from a **live** share clone; the doc constraint "pull first, then restart" is procedural, not enforced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)