### PR TITLE
GeecsPvaGateway 0.4.1 + GeecsCAGateway 0.17.1: post-rollout docs truth-up

### DIFF
--- a/GeecsCAGateway/CHANGELOG.md
+++ b/GeecsCAGateway/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to `geecs-ca-gateway` are documented here, following
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and semantic versioning.
 
-## [0.17.1] - 2026-07-31
+## [0.17.1] - 2026-08-18
 
 ### Changed
 

--- a/GeecsCAGateway/CHANGELOG.md
+++ b/GeecsCAGateway/CHANGELOG.md
@@ -3,6 +3,21 @@
 All notable changes to `geecs-ca-gateway` are documented here, following
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and semantic versioning.
 
+## [0.17.1] - 2026-07-31
+
+### Changed
+
+- Docs truth-up (no code changes): `DESIGN.md` — the protocol bullet's
+  "pvAccess later, starting with images" hedge updated to reflect that
+  PVA-for-images shipped and is deployed fleet-wide (`GeecsPvaGateway`);
+  the "Reconnect supervisor" honest-gap entry marked DONE (supervisors
+  landed long ago) with the real residual documented — half-open sockets
+  freeze readbacks without alarming (issue #611); the alarm-limits gap
+  updated for the 0.7.0 curated overlay. `README.md` — same two gap-list
+  corrections (curated alarms exist; images served by the PVA sibling, not
+  merely absent). `CLAUDE.md` — "PVA-later plan" phrasing updated to the
+  per-device-class reality.
+
 ## [0.17.0] - 2026-07-25
 
 ### Added

--- a/GeecsCAGateway/CLAUDE.md
+++ b/GeecsCAGateway/CLAUDE.md
@@ -103,7 +103,8 @@ One asyncio event loop runs everything:
   and **timestamp-ladder variables are posted last** so a client triggering on
   `acq_timestamp` observes the completed frame (PV_CONTRACT.md §3).
 - **channels/naming**: `channels.py` is the only caproto-typed layer (kept
-  swappable per DESIGN.md's PVA-later plan). Readback channels deny client
+  swappable per DESIGN.md's per-device-class PVA plan — images already run
+  on PVA via `GeecsPvaGateway/`; scalars stay CA). Readback channels deny client
   writes (access rights READ); setpoint channels forward to GEECS *before*
   storing, so a failed set fails the caput. `pv_naming.py` is the one shared
   naming module; full names are assembled by `DeviceSpec.pv_name_for`.

--- a/GeecsCAGateway/DESIGN.md
+++ b/GeecsCAGateway/DESIGN.md
@@ -144,16 +144,16 @@ Recorded so the next build phase doesn't relitigate them.
 - **Protocol: Channel Access for scalars; pvAccess adopted per-device-class
   where it pays.** CA is the stable, universally-supported substrate for
   scalars/controls. PVA/structured data (NTScalar/NTTable/NTNDArray) is
-  additive — **adopted first for images, now in production**
-  (`GeecsPvaGateway/` serves NTNDArray via `p4p` fleet-wide on the camera
-  servers). Scalars-over-PVA remains a future per-class decision.
+  additive — **adopted first for images, now in production** (NTNDArray via
+  `p4p`; deployment state lives with `GeecsPvaGateway/`). Scalars-over-PVA
+  remains a future per-class decision.
   `channels.py` is the only caproto-typed layer, kept swappable. (`p4p` is the
   PVA Python library, not "the new pyepics"; pyepics stays CA-only and
   current.)
 
 - **Images are a separate, distributed, PVA workstream — not this gateway.**
-  (Shipped and deployed fleet-wide 2026-07: `GeecsPvaGateway/`, one NSSM
-  instance per camera server, Undulator.) A
+  (Shipped 2026-07 and in production: `GeecsPvaGateway/`, one instance per
+  camera server; deployment state lives with that package.) A
   central gateway funneling ~100 cameras is a bandwidth bottleneck. Images belong
   on distributed per-camera IOCs (areaDetector-style, PVA/NTNDArray) where data
   stays at the edge. CA name resolution lets the central scalar gateway and

--- a/GeecsCAGateway/DESIGN.md
+++ b/GeecsCAGateway/DESIGN.md
@@ -141,15 +141,19 @@ Recorded so the next build phase doesn't relitigate them.
   of correct semantics (naming, timestamps, alarm/validity, types), since every
   tool consumes them.
 
-- **Protocol: Channel Access now; pvAccess later, per-device-class.** CA is the
-  stable, universally-supported substrate. PVA/structured data
-  (NTScalar/NTTable/NTNDArray) is additive, adopted where it pays — starting with
-  images. `channels.py` is the only caproto-typed layer, kept swappable; `p4p` is
-  the mature PVA-server route if/when needed. (`p4p` is the PVA Python library,
-  not "the new pyepics"; pyepics stays CA-only and current.)
+- **Protocol: Channel Access for scalars; pvAccess adopted per-device-class
+  where it pays.** CA is the stable, universally-supported substrate for
+  scalars/controls. PVA/structured data (NTScalar/NTTable/NTNDArray) is
+  additive — **adopted first for images, now in production**
+  (`GeecsPvaGateway/` serves NTNDArray via `p4p` fleet-wide on the camera
+  servers). Scalars-over-PVA remains a future per-class decision.
+  `channels.py` is the only caproto-typed layer, kept swappable. (`p4p` is the
+  PVA Python library, not "the new pyepics"; pyepics stays CA-only and
+  current.)
 
 - **Images are a separate, distributed, PVA workstream — not this gateway.**
-  (Implemented 2026-07: `GeecsPvaGateway/`, one instance per camera server.) A
+  (Shipped and deployed fleet-wide 2026-07: `GeecsPvaGateway/`, one NSSM
+  instance per camera server, Undulator.) A
   central gateway funneling ~100 cameras is a bandwidth bottleneck. Images belong
   on distributed per-camera IOCs (areaDetector-style, PVA/NTNDArray) where data
   stays at the edge. CA name resolution lets the central scalar gateway and
@@ -195,11 +199,16 @@ Recorded so the next build phase doesn't relitigate them.
 
 ## Honest gaps / next steps
 
-- **Reconnect supervisor** — `GeecsTcpSubscriber._listen_loop` exits on a dropped
-  connection; surviving a device power-cycle needs a supervising retry loop. This
-  is the piece that earns "as robust as the legacy SVE tool."
-- **Fuller metadata contract** — alarm limits (HIHI/…) and archive deadbands,
-  beyond the units/precision/control-limits already wired.
+- **Reconnect supervisor** — DONE: per-device supervising retry loops with
+  exponential backoff (see `gateway.py::_supervise`; readbacks go INVALID and
+  `CONNECTED` MAJOR while down). Known residual: a *half-open* socket (peer
+  died without FIN/RST — e.g. a host power-cycle) is invisible to the
+  supervisor and freezes readbacks without alarming; workaround is the
+  `cagateway:restart` PV, tracked as issue #611.
+- **Fuller metadata contract** — curated value-based alarm limits (HIHI/…)
+  landed in 0.7.0 (`ca_alarm_limits` overlay, PV_CONTRACT.md §5); archive
+  deadbands remain future, beyond the units/precision/control-limits already
+  wired.
 - **Archive-rate control belongs in an archive event mask, not the value
   deadband.** Through 0.5.0 the readback monitor deadband inherited the DB
   `tolerance` to pre-limit future Archiver Appliance volume — but that

--- a/GeecsCAGateway/README.md
+++ b/GeecsCAGateway/README.md
@@ -68,5 +68,5 @@ Deliberately deferred (the honest gap list — details in `DESIGN.md`):
 - **Sharding + systemd** — one central process today; target shape sketched in
   `DEPLOYMENT.md` §5.
 - **Images stay off CA** — scalars/controls only, by design; images are served
-  fleet-wide over pvAccess by the sibling `GeecsPvaGateway/` (NTNDArray, one
-  instance per camera server).
+  over pvAccess by the sibling `GeecsPvaGateway/` (NTNDArray; deployment
+  state lives with that package).

--- a/GeecsCAGateway/README.md
+++ b/GeecsCAGateway/README.md
@@ -60,10 +60,13 @@ fake-server tests. Bluesky GUI scans and Phoebus displays consume it live.
 
 Deliberately deferred (the honest gap list — details in `DESIGN.md`):
 
-- **Full alarm metadata** — no value-based alarms (HIHI/…) yet; severity means
-  liveness only (`PV_CONTRACT.md` §5).
+- **Automatic alarm metadata** — value-based alarms (HIHI/…) exist only via
+  the curated `ca_alarm_limits` overlay (0.7.0, `PV_CONTRACT.md` §5); DB
+  `min`/`max` are display metadata, never auto-interpreted as alarm limits.
 - **Archive-rate control** — MDEL/ADEL split when the Archiver Appliance
   lands; the value deadband stays 0.0.
 - **Sharding + systemd** — one central process today; target shape sketched in
   `DEPLOYMENT.md` §5.
-- **Images stay off CA** — scalars/controls only, by design.
+- **Images stay off CA** — scalars/controls only, by design; images are served
+  fleet-wide over pvAccess by the sibling `GeecsPvaGateway/` (NTNDArray, one
+  instance per camera server).

--- a/GeecsCAGateway/pyproject.toml
+++ b/GeecsCAGateway/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-ca-gateway"
-version = "0.17.0"
+version = "0.17.1"
 description = "EPICS Channel Access soft-IOC gateway exposing GEECS devices as PVs"
 authors = ["Sam Barber <sbarber@lbl.gov>"]
 readme = "README.md"

--- a/GeecsPvaGateway/CHANGELOG.md
+++ b/GeecsPvaGateway/CHANGELOG.md
@@ -11,8 +11,9 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   uniform 0.4.0): `DEPLOYMENT.md` drops the canary/pilot phase framing
   (fleet-wide is the current state; per-host restart example; machine-account
   share access stated as production-validated with the domain-account
-  fallback demoted to contingency; `HOSTS` defined as the deployed-instance
-  roster), and `CLAUDE.md` gains the load-bearing-production statement plus
+  fallback demoted to contingency; `HOSTS` defined as the should-run roster —
+  DB-derived, then hand-curated), and `CLAUDE.md` gains the
+  load-bearing-production statement plus
   the missing `gen_fleet_status.py` / `test_entrypoint.py` layout entries.
 
 ## [0.4.0] — 2026-07-31

--- a/GeecsPvaGateway/CHANGELOG.md
+++ b/GeecsPvaGateway/CHANGELOG.md
@@ -16,7 +16,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   load-bearing-production statement plus
   the missing `gen_fleet_status.py` / `test_entrypoint.py` layout entries.
 
-## [0.4.0] — 2026-07-31
+## [0.4.0] — 2026-08-17
 
 ### Added
 

--- a/GeecsPvaGateway/CHANGELOG.md
+++ b/GeecsPvaGateway/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to this package will be documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.4.1] — 2026-07-31
+
+### Changed
+
+- Docs truth-up after the fleet rollout completed (2026-07-31, 9 boxes at
+  uniform 0.4.0): `DEPLOYMENT.md` drops the canary/pilot phase framing
+  (fleet-wide is the current state; per-host restart example; machine-account
+  share access stated as production-validated with the domain-account
+  fallback demoted to contingency; `HOSTS` defined as the deployed-instance
+  roster), and `CLAUDE.md` gains the load-bearing-production statement plus
+  the missing `gen_fleet_status.py` / `test_entrypoint.py` layout entries.
+
 ## [0.4.0] — 2026-07-31
 
 ### Added

--- a/GeecsPvaGateway/CHANGELOG.md
+++ b/GeecsPvaGateway/CHANGELOG.md
@@ -3,11 +3,11 @@
 All notable changes to this package will be documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
-## [0.4.1] — 2026-07-31
+## [0.4.1] — 2026-08-18
 
 ### Changed
 
-- Docs truth-up after the fleet rollout completed (2026-07-31, 9 boxes at
+- Docs truth-up after the fleet rollout completed (2026-08, 9 boxes at
   uniform 0.4.0): `DEPLOYMENT.md` drops the canary/pilot phase framing
   (fleet-wide is the current state; per-host restart example; machine-account
   share access stated as production-validated with the domain-account

--- a/GeecsPvaGateway/CLAUDE.md
+++ b/GeecsPvaGateway/CLAUDE.md
@@ -15,6 +15,12 @@ LabVIEW camera device --loopback TCP push--> this gateway --NTNDArray--> Phoebus
 The central CA gateway and these instances are peers in one flat namespace:
 CA/PVA search finds whichever server owns a PV; nothing proxies pixels.
 
+This is **load-bearing production infrastructure, not a prototype**: deployed
+fleet-wide for Undulator since 2026-07-31 (one NSSM instance per camera-hosting
+box; Phoebus camera screens and any p4p/ophyd-async client consume it live).
+Treat its externally observable behavior — PV names, NTNDArray shape,
+instance-PV semantics — as a contract.
+
 ## Package Layout
 
 ```
@@ -27,14 +33,19 @@ geecs_pva_gateway/
                 #   version/heartbeat/restart instance PVs (restart -> exit 86)
 deploy/
   bootstrap.ps1   # one-time per-box setup (venv, firewall, NSSM service with
-                  #   USERPROFILE override -> service-owned profile)
+                  #   USERPROFILE override -> service-owned profile; installs
+                  #   Python 3.11 itself when `py -3.11` is missing)
   launch.bat      # pull-on-restart launcher (reinstall from the shared
                   #   GEECS-Plugins clone; its checked-out commit = fleet pin)
-  fleet_status.bob# Phoebus fleet screen: version/heartbeat/restart per host
+  gen_fleet_status.py # generator for fleet_status.bob; its HOSTS list is the
+                  #   fleet roster of record — edit + rerun, never hand-edit
+  fleet_status.bob# GENERATED Phoebus fleet screen: version/heartbeat/restart
+                  #   per host
 tests/
   test_config.py  # scoping/naming units (fake DB rows, no network)
   test_server.py  # end-to-end over a binary wire-format fake camera +
                   #   isolate=True PVA server
+  test_entrypoint.py # CLI exit codes (incl. the restart code 86 contract)
 ```
 
 ## Architecture (one asyncio loop)

--- a/GeecsPvaGateway/CLAUDE.md
+++ b/GeecsPvaGateway/CLAUDE.md
@@ -16,8 +16,8 @@ The central CA gateway and these instances are peers in one flat namespace:
 CA/PVA search finds whichever server owns a PV; nothing proxies pixels.
 
 This is **load-bearing production infrastructure, not a prototype**: deployed
-fleet-wide for Undulator since 2026-07-31 (one NSSM instance per camera-hosting
-box; Phoebus camera screens and any p4p/ophyd-async client consume it live).
+fleet-wide for Undulator since 2026-08 (one NSSM instance per active camera
+server; Phoebus camera screens and any p4p/ophyd-async client consume it live).
 Treat its externally observable behavior — PV names, NTNDArray shape,
 instance-PV semantics — as a contract.
 

--- a/GeecsPvaGateway/DEPLOYMENT.md
+++ b/GeecsPvaGateway/DEPLOYMENT.md
@@ -1,7 +1,7 @@
 # GeecsPvaGateway — Windows camera server deployment
 
 One NSSM service per camera server, serving that host's cameras. **Deployed
-fleet-wide for Undulator since 2026-07-31** (every camera-hosting box runs an
+fleet-wide for Undulator since 2026-08** (every active camera server runs an
 instance; 192.168.6.100 was the original pilot and remains the canary-of-habit
 for rollouts). Every step below is scripted in `deploy/`.
 
@@ -162,17 +162,19 @@ PV. Two regimes:
 - **Routed/VPN clients** (a laptop over the VPN, or any lab machine reaching
   servers on another subnet): broadcast does not traverse, so list every
   camera server's IP for unicast search — space-separated, one entry per
-  deployed server:
+  fleet server:
   - Python/p4p/ophyd-async: `EPICS_PVA_ADDR_LIST="<fleet list>"` (+
     `EPICS_PVA_AUTO_ADDR_LIST=NO`)
   - Phoebus: `org.phoebus.pv.pva/epics_pva_addr_list=<fleet list>` in the
     settings file (env vars don't reach a macOS `open`-launched app)
 
   The roster of record for `<fleet list>` is `HOSTS` in
-  `deploy/gen_fleet_status.py` (the fleet-screen generator). `HOSTS` lists
-  the **deployed gateway instances** — when a camera-hosting box is retired
-  or added, update `HOSTS`, regenerate the screen, and update this list —
-  currently:
+  `deploy/gen_fleet_status.py` (the fleet-screen generator): the DB-derived
+  camera-hosting endpoints that **should** run a gateway. When a box is
+  added, or a box is retired/confirmed deprecated, update `HOSTS`,
+  regenerate the screen, and update this list. Roster entries whose box is
+  not (yet) running an instance show as disconnected rows on the fleet
+  screen — prune them once their deprecation is confirmed. Currently:
 
   ```
   192.168.6.66 192.168.6.73 192.168.6.80 192.168.6.100 192.168.7.161

--- a/GeecsPvaGateway/DEPLOYMENT.md
+++ b/GeecsPvaGateway/DEPLOYMENT.md
@@ -1,8 +1,9 @@
 # GeecsPvaGateway — Windows camera server deployment
 
-One NSSM service per camera server, serving that host's cameras. The pilot box
-(Win10 22H2, 192.168.6.100) is the canary; every step below is scripted in
-`deploy/`.
+One NSSM service per camera server, serving that host's cameras. **Deployed
+fleet-wide for Undulator since 2026-07-31** (every camera-hosting box runs an
+instance; 192.168.6.100 was the original pilot and remains the canary-of-habit
+for rollouts). Every step below is scripted in `deploy/`.
 
 ## The two session-0 rules (hard-won; violating them hangs or breaks silently)
 
@@ -84,19 +85,21 @@ wheels, no version files. Rollout:
 git pull            # advance the pin (or: git checkout <rev> to roll back)
 ```
 
-Then restart instances **via the `:restart` PV** — canary first:
+Then restart instances **via the `:restart` PV**, one host at a time
+(restarting one box first and watching it come back clean before the rest is
+cheap insurance):
 
 ```bash
-pvput undulator:pvagateway:192_168_6_100:restart 1
+pvput undulator:pvagateway:<ip_token>:restart 1   # e.g. 192_168_6_100
 ```
 
 The server exits with code 86, NSSM relaunches `launch.bat`, which reinstalls
 the four intra-repo packages (`GEECS-Schemas`, `GEECS-Data-Utils`,
 `GeecsCAGateway`, `GeecsPvaGateway`) from the share clone and re-resolves the DB config. Watch the instance's
 `version` PV flip on the fleet screen (`deploy/fleet_status.bob` — one row per
-host: version, heartbeat, and a confirm-dialog restart button); roll the rest
-when the canary soaks clean. An unreachable share falls through to the
-installed versions — a restart never bricks an instance.
+host: version, heartbeat, and a confirm-dialog restart button); the rollout is
+done when the version column reads uniform. An unreachable share falls through
+to the installed versions — a restart never bricks an instance.
 
 Constraints, all by design:
 
@@ -105,13 +108,15 @@ Constraints, all by design:
   with `--no-build-isolation` (builds use the venv's poetry-core, so restarts
   need no internet). A numpy/p4p bump is a re-bootstrap, not a rollout.
 - **The share clone must be readable by the boxes' *machine accounts*** —
-  LocalSystem authenticates to shares as the computer account, not a user. If
-  the share needs user credentials, pull-on-restart silently no-ops on every
-  box, visible only as the version PV never flipping. Validate once on the
-  canary: set `GEECS_PVA_SOURCE`, hit `:restart`, and look for the
-  `pull-on-restart: reinstalling from …` line in the service log. If the ACL
-  can't be opened to machine accounts, the fallback is running the service as
-  the lab's shared domain account — `nssm set GeecsPvaGateway ObjectName
+  LocalSystem authenticates to shares as the computer account, not a user.
+  **Validated in production**: the whole fleet reinstalls from the share as
+  LocalSystem on every restart (canary drill 2026-07-30, then every box during
+  rollout). If a future share/ACL change breaks it, the symptom is
+  pull-on-restart silently no-oping on every box — visible only as the
+  version PV never flipping after a rollout; re-check for the
+  `pull-on-restart: reinstalling from …` line in a service log. Fallback if
+  machine-account access can't be restored: run the service as the lab's
+  shared domain account — `nssm set GeecsPvaGateway ObjectName
   DOMAIN\user <password>`, an operator-typed step per box (passwords never in
   scripts), coupled to that password never rotating. The `USERPROFILE`
   override stays either way: mapped drives are per-logon-session and invisible
@@ -157,14 +162,17 @@ PV. Two regimes:
 - **Routed/VPN clients** (a laptop over the VPN, or any lab machine reaching
   servers on another subnet): broadcast does not traverse, so list every
   camera server's IP for unicast search — space-separated, one entry per
-  server, appended as boxes come online:
+  deployed server:
   - Python/p4p/ophyd-async: `EPICS_PVA_ADDR_LIST="<fleet list>"` (+
     `EPICS_PVA_AUTO_ADDR_LIST=NO`)
   - Phoebus: `org.phoebus.pv.pva/epics_pva_addr_list=<fleet list>` in the
     settings file (env vars don't reach a macOS `open`-launched app)
 
   The roster of record for `<fleet list>` is `HOSTS` in
-  `deploy/gen_fleet_status.py` (the fleet-screen generator) — currently:
+  `deploy/gen_fleet_status.py` (the fleet-screen generator). `HOSTS` lists
+  the **deployed gateway instances** — when a camera-hosting box is retired
+  or added, update `HOSTS`, regenerate the screen, and update this list —
+  currently:
 
   ```
   192.168.6.66 192.168.6.73 192.168.6.80 192.168.6.100 192.168.7.161

--- a/GeecsPvaGateway/DEPLOYMENT.md
+++ b/GeecsPvaGateway/DEPLOYMENT.md
@@ -110,8 +110,8 @@ Constraints, all by design:
 - **The share clone must be readable by the boxes' *machine accounts*** —
   LocalSystem authenticates to shares as the computer account, not a user.
   **Validated in production**: the whole fleet reinstalls from the share as
-  LocalSystem on every restart (canary drill 2026-07-30, then every box during
-  rollout). If a future share/ACL change breaks it, the symptom is
+  LocalSystem on every restart (canary drill first, then every box during the
+  2026-08 rollout). If a future share/ACL change breaks it, the symptom is
   pull-on-restart silently no-oping on every box — visible only as the
   version PV never flipping after a rollout; re-check for the
   `pull-on-restart: reinstalling from …` line in a service log. Fallback if

--- a/GeecsPvaGateway/deploy/gen_fleet_status.py
+++ b/GeecsPvaGateway/deploy/gen_fleet_status.py
@@ -1,9 +1,12 @@
 """Regenerate ``fleet_status.bob`` from the fleet host list below.
 
-``HOSTS`` is the roster of record for the camera-server fleet: every endpoint
-IP hosting a GeecsPvaGateway instance, one screen row each. It is a snapshot
-of the experiment DB — enabled devices with image-typed variables, grouped by
-endpoint IP — derived with :class:`geecs_pva_gateway.config.PvaGatewayConfig`
+``HOSTS`` is the roster of record for the camera-server fleet: the endpoint
+IPs that *should* run a GeecsPvaGateway instance, one screen row each. It
+starts life as a snapshot of the experiment DB — enabled devices with
+image-typed variables, grouped by endpoint IP — and is then curated by hand:
+prune entries when a box is retired or confirmed deprecated (a roster entry
+with no running instance shows as a permanently disconnected screen row).
+The DB derivation uses :class:`geecs_pva_gateway.config.PvaGatewayConfig`
 building blocks::
 
     endpoints = GeecsDb.get_experiment_devices("Undulator", enabled_only=True)

--- a/GeecsPvaGateway/deploy/gen_fleet_status.py
+++ b/GeecsPvaGateway/deploy/gen_fleet_status.py
@@ -21,7 +21,7 @@ from pathlib import Path
 
 EXPERIMENT = "Undulator"
 
-# DB snapshot 2026-07-31: 13 endpoints, 49 cameras.
+# DB snapshot 2026-08: 13 endpoints, 49 cameras.
 HOSTS = [
     "192.168.6.66",
     "192.168.6.73",

--- a/GeecsPvaGateway/pyproject.toml
+++ b/GeecsPvaGateway/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-pva-gateway"
-version = "0.4.0"
+version = "0.4.1"
 description = "Distributed pvAccess gateway serving GEECS camera images as NTNDArray PVs"
 authors = ["Sam Barber <sbarber@lbl.gov>"]
 readme = "README.md"


### PR DESCRIPTION
## What + why

The PVA fleet rollout completed 2026-07-31 (9 camera servers, uniform 0.4.0 — verified by PV sweep). A repo-wide stale-docs inventory (fresh-context sweep agent over every .md) found five files still describing the pre-rollout world. This PR makes the written record match reality. **Docs only — zero code changes** (the test suites run because the packages' files changed; both green).

Per-file breakdown (~96 insertions / 37 deletions total):

**GeecsPvaGateway** (~45 LOC)
- `DEPLOYMENT.md`: canary/pilot framing → fleet-wide current state; per-host restart example (was pinned to the ex-pilot box); machine-account share access stated as production-validated (it was written as an open risk with a contingency — every box now proves it daily), fallback demoted to contingency; `HOSTS` explicitly defined as the *deployed-instance* roster (was conflatable with "every DB camera endpoint"); "appended as boxes come online" rollout-in-progress phrasing removed.
- `CLAUDE.md`: adds the load-bearing-production statement (mirroring the CA gateway's — an agent reading only this file could previously treat the package as pre-production); package layout gains the missing `gen_fleet_status.py` and `test_entrypoint.py` entries.

**GeecsCAGateway** (~35 LOC)
- `DESIGN.md`: "pvAccess later … starting with images / p4p if/when needed" → images shipped on PVA, in production fleet-wide, p4p in production use; scalars-over-PVA stays future. "Images workstream" parenthetical upgraded from "implemented" to "deployed fleet-wide". Honest-gaps list: "Reconnect supervisor" marked DONE (supervisors have existed for months) with the *real* residual documented — half-open sockets freeze readbacks without alarming, [#611](https://github.com/GEECS-BELLA/GEECS-Plugins/issues/611) (live incident 2026-07-31); "Fuller metadata" updated for the 0.7.0 curated alarm overlay.
- `README.md`: gap list — "no value-based alarms yet" corrected (curated `ca_alarm_limits` overlay landed 0.7.0); "Images stay off CA" bullet no longer implies images are unserved (points at the PVA sibling).
- `CLAUDE.md`: one phrase — "PVA-later plan" → per-device-class reality.

Plus patch bumps + CHANGELOG entries for both (docs-only patch per repo convention).

## Judgment calls (cheap to veto)

- The two CA-gateway gap-list corrections (alarms, reconnect supervisor) are **outside the PVA-rollout trigger** — pre-existing staleness the sweep surfaced. Included because the PR's concern is "docs tell the truth" and they're in files already touched; happy to strip if you want strict PVA-only scope.
- **NOT included: the fleet-roster prune** (4 endpoints in `HOSTS` answer nothing — .6.66, .6.73, .7.203, .8.207). Held pending owner confirmation that all four are genuinely deprecated (BCaveMagSpec .7.203 flagged for a double-check); lands as a trivial follow-up.

## Tests

Scoped check (= what CI gates for this diff): lint hooks green, GeecsCAGateway **191 passed**, GeecsPvaGateway **14 passed**. No code changed.

## Hardware verification

N/A — docs only. The claims the docs now make were hardware-verified during the rollout itself (fleet sweep: 9/9 at 0.4.0, frames confirmed on multiple boxes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)