### PR TITLE
docs site: Camera Images (PVA) client page + gateway section truth-up

### DIFF
--- a/GeecsPvaGateway/CHANGELOG.md
+++ b/GeecsPvaGateway/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this package will be documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.4.2] — 2026-08-18
+
+### Fixed
+
+- `DEPLOYMENT.md` smoke test corrected from a bare p4p `get` to a held
+  `monitor`: a bare `get` returns the cached value immediately (startup
+  placeholder or stale last frame) and never waits out the gating
+  round-trip, so the old snippet read `(1, 1)` on a healthy fresh instance
+  — verified empirically during review of the docs-site image page, which
+  now documents the same behavior.
+
 ## [0.4.1] — 2026-08-18
 
 ### Changed

--- a/GeecsPvaGateway/DEPLOYMENT.md
+++ b/GeecsPvaGateway/DEPLOYMENT.md
@@ -139,14 +139,22 @@ From any machine with p4p (over VPN, set the address list per **Client
 access** below so name search unicasts):
 
 ```python
+import time
 from p4p.client.thread import Context
-img = Context("pva").get("undulator:uc_amp2_ir_input:image", timeout=5)
-print(img.shape, img.dtype)
+
+ctx = Context("pva")
+sub = ctx.monitor("undulator:uc_amp2_ir_input:image", lambda v: print(v.shape, v.dtype))
+time.sleep(5)
+sub.close()
 ```
 
-First read after idle takes one gating round-trip (subscribe + next device
-push, ~1–2 s at 1 Hz) — that is the unwatched-variables-are-free trade
-(gating is per image variable; an unwatched camera holds zero connections).
+The first update is the cached value — the `(1, 1)` startup placeholder, or
+the last frame from a previous watch; the first *fresh* frame lands one
+gating round-trip later (subscribe + next device push, ~1–2 s at 1 Hz) —
+that is the unwatched-variables-are-free trade (gating is per image
+variable; an unwatched camera holds zero connections). A bare `get` returns
+the cached value immediately and never waits for the round-trip — hold a
+monitor instead, as above.
 
 ## Client access
 

--- a/GeecsPvaGateway/pyproject.toml
+++ b/GeecsPvaGateway/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-pva-gateway"
-version = "0.4.1"
+version = "0.4.2"
 description = "Distributed pvAccess gateway serving GEECS camera images as NTNDArray PVs"
 authors = ["Sam Barber <sbarber@lbl.gov>"]
 readme = "README.md"

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -18,7 +18,7 @@ short section-index landing page (`docs/<group>/index.md`, surfaced via the
 constituent packages:
 
 - **Acquisition** — running scans on the beamline: the GEECS Console (the
-  Bluesky-backed acquisition front-end) and the legacy Scanner GUI.
+  Bluesky-backed acquisition front-end, including its Scan Browser).
 - **Analysis** — turning acquired data into results: Image Analysis, Scan
   Analysis, and the Data Utils path/loading layer they build on.
 - **Platform** — the access-and-contract layer everything sits on: the

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -17,13 +17,15 @@ short section-index landing page (`docs/<group>/index.md`, surfaced via the
 `navigation.indexes` theme feature) that orients the reader and links to the
 constituent packages:
 
-- **Acquisition** — running scans on the beamline. Currently the Scanner
-  GUI; future acquisition backends (e.g. a Bluesky-driven scanner) join here.
+- **Acquisition** — running scans on the beamline: the GEECS Console (the
+  Bluesky-backed acquisition front-end) and the legacy Scanner GUI.
 - **Analysis** — turning acquired data into results: Image Analysis, Scan
   Analysis, and the Data Utils path/loading layer they build on.
 - **Platform** — the access-and-contract layer everything sits on: the
-  Python API (device transport + DB), the GEECS Gateway (EPICS soft-IOC),
-  and GEECS Schemas (the typed scan-config contract).
+  Python API (device transport + DB), the GEECS Gateway (the EPICS access
+  layer — central CA soft-IOC for scalars plus the distributed PVA image
+  gateways on the camera servers), and GEECS Schemas (the typed
+  scan-config contract).
 
 Inside a group, each package is its own nav **section** (`navigation.sections`)
 and follows roughly Diátaxis: Overview (explanation), Tutorial (when

--- a/docs/geecs_gateway/client_overview.md
+++ b/docs/geecs_gateway/client_overview.md
@@ -1,10 +1,12 @@
 # GEECS Gateway — client orientation
 
-The **GeecsCAGateway** is the GEECS access layer: a caproto Channel Access
-soft-IOC that mirrors GEECS devices as EPICS PVs, so any EPICS-ecosystem
-consumer — Phoebus displays, an Archiver Appliance, ophyd-async / Bluesky — can
-talk to GEECS the same way it talks to any IOC, without growing its own bespoke
-bridge.
+The **GeecsCAGateway** is the scalar/control half of the GEECS access layer: a
+caproto Channel Access soft-IOC that mirrors GEECS devices as EPICS PVs, so any
+EPICS-ecosystem consumer — Phoebus displays, an Archiver Appliance,
+ophyd-async / Bluesky — can talk to GEECS the same way it talks to any IOC,
+without growing its own bespoke bridge. (Camera *images* are served separately,
+as pvAccess NTNDArray PVs in the same namespace — see
+[Camera images (PVA)](image_pvs.md).)
 
 ```
 GEECS device  --TCP push stream-->  readback PV   (caget / camonitor)
@@ -93,7 +95,8 @@ The timestamp variables are themselves float readback PVs carrying the **raw
 LabVIEW-epoch** value; the same raw value is stamped on saved external assets
 (images), which is how saved files tie back to acquisition. A non-positive
 `acq_timestamp` means "no acquisition yet" (the `0.0` pre-acquisition
-placeholder), never a shot at the epoch.
+placeholder), never a shot at the epoch. (For *live* images — as opposed to
+the saved files referenced here — see [Camera images (PVA)](image_pvs.md).)
 
 ## Curated alarm limits (gateway 0.7.0)
 

--- a/docs/geecs_gateway/image_pvs.md
+++ b/docs/geecs_gateway/image_pvs.md
@@ -1,0 +1,140 @@
+# Camera images over PVA — client orientation
+
+GEECS camera images are served live as EPICS **pvAccess (PVA)** PVs of the
+standard **NTNDArray** type by **GeecsPvaGateway** — a distributed service
+running on each Windows camera server, serving only that host's cameras.
+Any PVA-speaking consumer — a stock Phoebus *Image* widget, three lines of
+`p4p`, an ophyd-async signal — gets typed pixel arrays with normalized
+timestamps, with zero knowledge of GEECS internals.
+
+```
+LabVIEW camera device --loopback TCP--> per-server gateway --NTNDArray--> Phoebus / p4p / ophyd-async
+```
+
+The central [GEECS CA gateway](client_overview.md) (scalars/controls) and the
+per-server image gateways are **peers in one flat namespace**: CA/PVA name
+search finds whichever server owns a PV, and nothing proxies pixels through a
+central box — image bandwidth stays at the edge, by design.
+
+This page is a client-facing orientation. The authoritative detail lives in
+the package alongside the code — `GeecsPvaGateway/DEPLOYMENT.md` (fleet
+runbook, addressing) and `GeecsPvaGateway/CLAUDE.md` (architecture); treat
+those as the source of truth if anything disagrees.
+
+## Why not just read the camera's TCP stream yourself?
+
+You could — the GEECS wire format is decodable, and for a one-off diagnostic
+script running *on the camera server itself* that remains legitimate. For
+everything else, the gateway exists so that the hard parts are solved exactly
+once:
+
+- **The wire format is a hazard.** Values that can't be comma-tokenized,
+  latin-1 byte-mangling, and IMAQ image wrappers with multiple structural
+  variants that have silently drifted before. Every bespoke decoder
+  re-inherits all of it; the gateway's decoder is fixed in one place for
+  everyone.
+- **Fan-out economics.** GEECS TCP push is per-connection — N direct
+  subscribers make LabVIEW flatten and send every frame N times. The gateway
+  subscribes once per image variable and PVA fans out to any number of
+  clients. Subscriptions are **gated**: a camera nobody is watching costs the
+  device *nothing at all*.
+- **The ecosystem is free.** Phoebus renders these PVs with a stock widget;
+  ophyd-async speaks PVA natively (the door to live images in scans); a
+  "bespoke image GUI" starts at one `p4p` line instead of at a socket.
+
+## PV naming
+
+Image PVs follow the same shared naming contract as the scalar gateway
+(lowercase components joined by `:` — see
+[PV naming](client_overview.md#pv-naming) for the normalization rules):
+
+```
+[experiment:]device:variable            e.g. undulator:uc_tubein:image
+```
+
+A camera device typically serves several image-typed variables
+(`image`, `processed_image`, …); each is its own PV, gated independently —
+watching `image` costs nothing for `processed_image`.
+
+Each gateway instance also serves three **instance PVs** for fleet health:
+
+```
+[experiment:]pvagateway:<host_token>:version     installed package version
+[experiment:]pvagateway:<host_token>:heartbeat   counter, +1 per 5 s
+[experiment:]pvagateway:<host_token>:restart     write 1 → clean relaunch
+```
+
+`<host_token>` is the server's IP with dots as underscores
+(`192.168.6.100` → `192_168_6_100`). A Phoebus fleet screen reading these
+ships in the package (`GeecsPvaGateway/deploy/fleet_status.bob`).
+
+## Reading images
+
+**Phoebus**: add an *Image* widget and set its PV to
+`pva://undulator:<camera>:image`. That's the whole recipe.
+
+**Python (p4p)** — note `Context("pva")`, not `"ca"`:
+
+```python
+from p4p.client.thread import Context
+
+ctx = Context("pva")
+sub = ctx.monitor("undulator:uc_tubein:image", lambda v: print(v.shape, v.dtype))
+```
+
+!!! tip "Use a held `monitor`, not a bare `get`"
+
+    Subscriptions are gated on client interest: the gateway only subscribes
+    to the camera while at least one client channel is open, and the first
+    frame arrives one gating round-trip later (subscribe + next device push,
+    ~1–2 s at 1 Hz). A bare `get` connects and disconnects in milliseconds —
+    it typically sees only the `(1, 1)` startup placeholder. Hold a
+    `monitor` open for at least one push interval.
+
+**ophyd-async** consumes the same PVs as standard PVA signals — live camera
+frames become readable device signals with no GEECS-specific code.
+
+## Addressing — who needs a PV address list
+
+PVA name search is UDP broadcast, and broadcast is **subnet-local**. The
+camera-server fleet spans several lab subnets, so:
+
+- A client on the *same subnet* as a camera server finds it with zero config.
+- **Any client that wants cameras across the whole fleet** — control-room
+  machines included, and all VPN/routed clients — needs the full fleet
+  address list for unicast search:
+    - Python / p4p / ophyd-async: `EPICS_PVA_ADDR_LIST="<fleet list>"` plus
+      `EPICS_PVA_AUTO_ADDR_LIST=NO`
+    - Phoebus: `org.phoebus.pv.pva/epics_pva_addr_list=<fleet list>` in the
+      settings file (environment variables don't reach a macOS
+      `open`-launched app)
+
+The roster of record for the fleet list is `HOSTS` in
+`GeecsPvaGateway/deploy/gen_fleet_status.py`; the current expansion is kept
+in `GeecsPvaGateway/DEPLOYMENT.md` §Client access. The CA variables
+(`EPICS_CA_*`) belong to the scalar gateway and are unaffected — a client
+using both gateways sets both families.
+
+## Semantics worth knowing
+
+- **Latest-wins, never backlogged**: a slow consumer gets the newest frame
+  and skips stale ones; nothing queues. The live stream is for *watching* —
+  shot-complete data acquisition lives in the GEECS file path and scan
+  system, not here.
+- **Timestamps are normalized**: each frame carries the device's own
+  acquisition timestamp (GEECS's LabVIEW-epoch clock converted to Unix) when
+  available, falling back to receive time — so NTNDArray timestamps line up
+  with the scalar gateway's convention.
+- **Uptime is unattended**: instances run as auto-start Windows services
+  that survive reboots and crashes, reinstall themselves from the lab's
+  shared clone on every restart, and report liveness via the
+  heartbeat/version PVs above.
+
+## Reading more
+
+- [GEECS Gateway client orientation](client_overview.md) — the scalar/control
+  side of the same namespace: naming rules, readbacks vs setpoints, alarms.
+- `GeecsPvaGateway/DEPLOYMENT.md` (in the source tree) — the fleet runbook:
+  per-box onboarding, rollout via restart PVs, addressing detail.
+- `GeecsPvaGateway/CLAUDE.md` — architecture: gating, supervision, the
+  frame path.

--- a/docs/geecs_gateway/image_pvs.md
+++ b/docs/geecs_gateway/image_pvs.md
@@ -76,20 +76,27 @@ ships in the package (`GeecsPvaGateway/deploy/fleet_status.bob`).
 **Python (p4p)** — note `Context("pva")`, not `"ca"`:
 
 ```python
+import time
+
 from p4p.client.thread import Context
 
 ctx = Context("pva")
 sub = ctx.monitor("undulator:uc_tubein:image", lambda v: print(v.shape, v.dtype))
+time.sleep(5)  # hold the gate open — the first update is the current cached
+               # value; the first real frame lands ~1-2 s later (1 Hz camera)
+sub.close()
 ```
 
 !!! tip "Use a held `monitor`, not a bare `get`"
 
     Subscriptions are gated on client interest: the gateway only subscribes
     to the camera while at least one client channel is open, and the first
-    frame arrives one gating round-trip later (subscribe + next device push,
-    ~1–2 s at 1 Hz). A bare `get` connects and disconnects in milliseconds —
-    it typically sees only the `(1, 1)` startup placeholder. Hold a
-    `monitor` open for at least one push interval.
+    *fresh* frame arrives one gating round-trip after connecting (subscribe +
+    next device push, ~1–2 s at 1 Hz). A bare `get` returns immediately with
+    whatever is cached — the `(1, 1)` startup placeholder on a fresh
+    instance, or a **stale last frame** from a previous watch — and never
+    waits for that round-trip. Hold a `monitor` open for at least one push
+    interval.
 
 **ophyd-async** consumes the same PVs as standard PVA signals — live camera
 frames become readable device signals with no GEECS-specific code.

--- a/docs/platform/index.md
+++ b/docs/platform/index.md
@@ -23,12 +23,15 @@ scan and its data are described.
 
     ---
 
-    The GEECS access layer as an EPICS soft-IOC: a caproto Channel Access
-    server that mirrors GEECS devices as PVs, so Phoebus, an Archiver
-    Appliance, or ophyd-async / Bluesky can talk to GEECS like any other
-    IOC — no bespoke bridge required.
+    The GEECS access layer as EPICS services: a central Channel Access
+    server mirroring GEECS devices as scalar/control PVs, plus distributed
+    pvAccess gateways on the camera servers serving live images as
+    NTNDArray PVs — so Phoebus, an Archiver Appliance, or ophyd-async /
+    Bluesky can talk to GEECS like any other IOC, no bespoke bridge
+    required.
 
-    [:octicons-arrow-right-24: Client overview](../geecs_gateway/client_overview.md)
+    [:octicons-arrow-right-24: Client overview](../geecs_gateway/client_overview.md) ·
+    [Camera images (PVA)](../geecs_gateway/image_pvs.md)
 
 -   :material-file-tree:{ .lg .middle } **GEECS Schemas**
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -101,6 +101,7 @@ nav:
               - Controls: geecs_python_api/api/controls.md
       - GEECS Gateway:
           - Client Overview: geecs_gateway/client_overview.md
+          - Camera Images (PVA): geecs_gateway/image_pvs.md
       - GEECS Schemas:
           - Scanner Configs Overview: geecs_schemas/schemas_overview.md
           - Running a Scan: geecs_schemas/running_a_scan.md


### PR DESCRIPTION
## What + why

The published mkdocs site had **zero mention** of the PVA image serving that is now deployed fleet-wide (confirmed by repo-wide grep during the #612 sweep). This adds the client-facing page and folds the PVA gateway into the site's existing gateway story. Companion to #612 (in-repo docs truth-up); together they close the documentation item of the image-server arc.

- **New page `docs/geecs_gateway/image_pvs.md`** (~150 lines): what the image PVs are and why they beat bespoke TCP decoding (solved-once wire format, fan-out economics, free ecosystem — the direct-TCP boundary stated honestly); PV naming incl. instance PVs; client recipes for Phoebus / p4p / ophyd-async, with the held-monitor-not-bare-get gating tip; the subnet-local broadcast caveat and address-list recipe; latest-wins / timestamp semantics; pointers to the package docs as source of truth. Same voice and structure as its CA sibling `client_overview.md`.
- **`mkdocs.yml`**: nav entry under Platform → GEECS Gateway.
- **`docs/platform/index.md`**: the gateway card now describes both halves (central CA scalars + distributed PVA images) and links both pages.
- **`docs/geecs_gateway/client_overview.md`**: two cross-links (intro scoped to "the scalar/control half"; the saved-images timestamp paragraph points at the live-image page).
- **`docs/CLAUDE.md`** (authoring guide): Platform group enumeration now includes the PVA gateways; also fixed the stale Acquisition line ("Currently the Scanner GUI; future … Bluesky-driven scanner") — the Console has been in the nav for months (adjacent staleness from the #612 sweep, included because this file was already in scope).

No package code touched → no version bumps (docs/ + mkdocs.yml are not a package).

## Tests

`mkdocs build` exit 0, no errors and no warnings on any touched page (built from the worktree config with the root docs env). Scoped `check.sh` green (lint hooks; no test suites map to these files).

## Hardware verification

N/A — docs. Client recipes on the new page are transcriptions of commands exercised live during the rollout (p4p monitor gating behavior, Phoebus Image widget, address-list settings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)