### PR TITLE
docs: analyzer index — repoint stale offline_analyzers/ paths to the PR-E analyzers/ layout

### DIFF
--- a/docs/image_analysis/analyzer_index.md
+++ b/docs/image_analysis/analyzer_index.md
@@ -1,6 +1,6 @@
 # Analyzer Index
 
-This page is a discovery aid: pick what you're trying to measure, find the analyzer, follow it to the worked example. The full set of analyzers lives in `image_analysis/offline_analyzers/`.
+This page is a discovery aid: pick what you're trying to measure, find the analyzer, follow it to the worked example. The full set of analyzers lives in `image_analysis/analyzers/`.
 
 If you don't see an analyzer for what you need, the right starting point for a new one is `StandardAnalyzer` (for 2D images) or `Standard1DAnalyzer` (for 1D traces and lineouts) — both are designed to be subclassed.
 
@@ -8,63 +8,68 @@ If you don't see an analyzer for what you need, the right starting point for a n
 
 ### Beam profile, position, size
 
-**`BeamAnalyzer`** (`offline_analyzers/beam_analyzer.py`) — beam centroid, width, height, FWHM, optional slope/straightness metrics. Renders an annotated beam image with overlays. The standard tool for camera images of a beam profile.
+**`BeamAnalyzer`** (`analyzers/beam_analyzer.py`) — beam centroid, width, height, FWHM, optional slope/straightness metrics. Renders an annotated beam image with overlays. The standard tool for camera images of a beam profile.
 
 Inherits from `StandardAnalyzer` and adds beam-specific outputs while delegating image processing (background subtraction, masking, filtering) to the base class.
 
 ### Pulse characterization (FROG / Grenouille)
 
-**`GrenouilleAnalyzer`** (`offline_analyzers/grenouille_analyzer.py`) — FROG pulse retrieval via the FrogDll backend. Outputs temporal and spectral FWHM, retrieved trace, and lineout exports. The right tool for a Grenouille trace where you want a pulse duration estimate.
+**`GrenouilleAnalyzer`** (`analyzers/grenouille_analyzer.py`) — FROG pulse retrieval via the FrogDll backend. Outputs temporal and spectral FWHM, retrieved trace, and lineout exports. The right tool for a Grenouille trace where you want a pulse duration estimate.
 
 Worked example: [Grenouille Analysis notebook](examples/grenouille_analysis.ipynb).
 
 ### Magnetic spectrometer (energy spectra)
 
-**`MagSpecManualCalibAnalyzer`** (`offline_analyzers/magspec_manual_calib_analyzer.py`) — magnetic spectrometer images with pixel-to-energy conversion using device-specific calibrations. Configured via YAML with `analysis.energy_range` and per-device calibration parameters.
+**`MagSpecManualCalibAnalyzer`** (`analyzers/magspec_manual_calib_analyzer.py`) — magnetic spectrometer images with pixel-to-energy conversion using device-specific calibrations. Configured via YAML with `analysis.energy_range` and per-device calibration parameters.
 
 ### 1D line profiles, ICT charge traces
 
-**`LineAnalyzer`** (`offline_analyzers/line_analyzer.py`) — center of mass, FWHM, RMS width, peak analysis, integrated signal for 1D profile data. Unit-aware reporting.
+**`LineAnalyzer`** (`analyzers/line_analyzer.py`) — center of mass, FWHM, RMS width, peak analysis, integrated signal for 1D profile data. Unit-aware reporting.
 
-**`ICT1DAnalyzer`** (`offline_analyzers/ict_1d_analyzer.py`) — ICT charge measurement on oscilloscope voltage traces. Uses the `ict_algorithms` module. Configured by adding `ict_analysis_params` to the device's YAML config.
+**`ICT1DAnalyzer`** (`analyzers/ict_1d_analyzer.py`) — ICT charge measurement on oscilloscope voltage traces. Uses the `ict_algorithms` module. Configured by adding `ict_analysis_params` to the device's YAML config.
 
-**`LineStitcher`** (`offline_analyzers/line_stitcher.py`) — for the case where multiple devices each cover a portion of a shared physical axis (e.g. magspec1 + magspec2 + magspec3 covering different energy ranges). Concatenates and sorts the per-device files into one analysis.
+**`LineStitcher`** (`analyzers/line_stitcher.py`) — for the case where multiple devices each cover a portion of a shared physical axis (e.g. magspec1 + magspec2 + magspec3 covering different energy ranges). Concatenates and sorts the per-device files into one analysis.
 
 ### Wavefront / phase
 
-**`HASOHimgHasProcessor`** (`offline_analyzers/HASO_himg_has_processor.py`) — loads HASO `.himg` / `.has` files, applies masking and background subtraction, computes phase via zonal reconstruction. Saves slopes, phases, and intensity alongside the source. Requires WaveKit 4.3 (Windows-only at runtime).
+**`HASOHimgHasProcessor`** (`analyzers/HASO_himg_has_processor.py`) — loads HASO `.himg` / `.has` files, applies masking and background subtraction, computes phase via zonal reconstruction. Saves slopes, phases, and intensity alongside the source. Requires WaveKit 4.3 (Windows-only at runtime).
 
 Worked example: [HasoLift Analysis notebook](examples/HasoLift_analysis.ipynb).
 
-**`DownrampPhaseAnalyzer`** (`offline_analyzers/downramp_phase_analyzer.py`) — plasma downramp shock analysis from phase data. Shock angle estimation, gradient and position detection, plateau and peak-to-plateau delta calculation. Output is a combined diagnostic figure as vector PDF.
+**`DownrampPhaseAnalyzer`** (`analyzers/downramp_phase_analyzer.py`) — plasma downramp shock analysis from phase data. Shock angle estimation, gradient and position detection, plateau and peak-to-plateau delta calculation. Output is a combined diagnostic figure as vector PDF.
 
-**`PhaseDownrampProcessor`** (in `density_from_phase_analysis.py`) — class-based phase-map → plasma-density pipeline using PyAbel. Includes utilities for background removal, cropping, rotation alignment, Gaussian masking, and thresholding.
+**`PhaseDownrampProcessor`** (in `analyzers/density_from_phase_analysis.py`) — class-based phase-map → plasma-density pipeline using PyAbel. Includes utilities for background removal, cropping, rotation alignment, Gaussian masking, and thresholding.
 
 ### Generic / starting points
 
-**`StandardAnalyzer`** (`offline_analyzers/standard_analyzer.py`) — general-purpose 2D image analyzer with YAML config, Pydantic-validated parameters, and a modular processing pipeline (background subtraction, masking, filtering, transforms, thresholding). The parent class for most specialized 2D analyzers.
+**`StandardAnalyzer`** (`analyzers/standard_analyzer.py`) — general-purpose 2D image analyzer with YAML config, Pydantic-validated parameters, and a modular processing pipeline (background subtraction, masking, filtering, transforms, thresholding). The parent class for most specialized 2D analyzers.
 
-**`Standard1DAnalyzer`** (`offline_analyzers/standard_1d_analyzer.py`) — equivalent for 1D traces, spectra, and lineouts. Parent class for `LineAnalyzer` and `ICT1DAnalyzer`.
+**`Standard1DAnalyzer`** (`analyzers/standard_1d_analyzer.py`) — equivalent for 1D traces, spectra, and lineouts. Parent class for `LineAnalyzer` and `ICT1DAnalyzer`.
 
 If you're writing a new analyzer, start by inheriting from one of these. The `StandardAnalyzer` docstring documents the pipeline hooks; the [Image Analysis Overview](overview.md) shows the broader architecture.
 
 ## What each analyzer needs
 
-Every analyzer takes a YAML config (one per device) describing its processing pipeline and analysis parameters. Configs are typically stored alongside your experiment configuration so they're version-controlled with your scan setup. The general structure:
+Every analyzer takes a YAML config (one per device) describing its processing pipeline and analysis parameters. Configs are typically stored alongside your experiment configuration so they're version-controlled with your scan setup. A diagnostic config has an `image:` section (the per-shot processing pipeline — `type: camera` selects the `CameraConfig` schema, `type: line` the `Line1DConfig` schema for 1D signals) and a `scan:` section (how the analyzer runs at the scan orchestration level). The general structure:
 
 ```yaml
-device: U_DeviceName
-processing:
-  background:
-    method: dynamic
-    # ...
-  masking:
-    # ...
-analysis:
-  # analyzer-specific parameters
+name: U_DeviceName
+image_analyzer: image_analysis.analyzers.beam_analyzer.BeamAnalyzer
+image:
+  type: camera
+  bit_depth: 16
+  roi: {x_min: 0, x_max: 650, y_min: 350, y_max: 650}
+  background: {method: constant, constant_level: 5.0}
+  pipeline:
+    steps: [background, roi]
+  analysis:
+    # analyzer-specific parameters
+scan:
+  priority: 50
+  mode: per_shot
 ```
 
-The exact shape of the `analysis` block depends on the analyzer. The simplest way to learn the schema is to look at an existing config or run the analyzer once and let the Pydantic validation tell you what it expects.
+The exact shape of the `analysis` block depends on the analyzer. The simplest way to learn the schema is to look at an existing config or run the analyzer once and let the Pydantic validation tell you what it expects. The [Analysis tutorial](../tutorials/analysis.md) walks through editing one of these configs field by field.
 
 ## When an analyzer is part of a scan
 
@@ -74,4 +79,4 @@ This is also how analyzer outputs end up appended to the scan's s-file — the s
 
 ## Discoverability tip
 
-Run `python -c "import image_analysis.offline_analyzers as oa; help(oa)"` to see the full list of analyzers in your installed version. The package's `__init__.py` re-exports them; the help output is a fast way to confirm what's available without browsing source.
+Run `python -c "import image_analysis.analyzers as a; help(a)"` to see the analyzers your installed version re-exports. The package's `__init__.py` re-exports the most commonly used classes; the more specialized analyzers (ICT, MagSpec, Grenouille, HASO, phase) live in their own modules under `image_analysis/analyzers/` and are imported from there directly.

--- a/docs/image_analysis/analyzer_index.md
+++ b/docs/image_analysis/analyzer_index.md
@@ -18,6 +18,8 @@ Inherits from `StandardAnalyzer` and adds beam-specific outputs while delegating
 
 Worked example: [Grenouille Analysis notebook](examples/grenouille_analysis.ipynb).
 
+**`FrogSpectralPhaseAnalyzer`** (`analyzers/frog_spectral_phase_analyzer.py`) — consumes the retrieved lineout TSV files written by `GrenouilleAnalyzer`, fits the spectral phase as a polynomial in angular-frequency detuning, and reports dispersion terms (GD, GDD, TOD).
+
 ### Magnetic spectrometer (energy spectra)
 
 **`MagSpecManualCalibAnalyzer`** (`analyzers/magspec_manual_calib_analyzer.py`) — magnetic spectrometer images with pixel-to-energy conversion using device-specific calibrations. Configured via YAML with `analysis.energy_range` and per-device calibration parameters.
@@ -50,18 +52,14 @@ If you're writing a new analyzer, start by inheriting from one of these. The `St
 
 ## What each analyzer needs
 
-Every analyzer takes a YAML config (one per device) describing its processing pipeline and analysis parameters. Configs are typically stored alongside your experiment configuration so they're version-controlled with your scan setup. A diagnostic config has an `image:` section (the per-shot processing pipeline — `type: camera` selects the `CameraConfig` schema, `type: line` the `Line1DConfig` schema for 1D signals) and a `scan:` section (how the analyzer runs at the scan orchestration level). The general structure:
+Every analyzer takes a YAML config (one per device) describing its processing pipeline and analysis parameters. Configs are typically stored alongside your experiment configuration so they're version-controlled with your scan setup. A diagnostic config typically has an `image:` section (the per-shot processing pipeline, `type: camera` or `type: line`) and a `scan:` section (how the analyzer runs at the scan orchestration level) — HASO-style analyzers omit `image:` and pass constructor kwargs through the verbose `image_analyzer:` form instead. The skeleton:
 
 ```yaml
 name: U_DeviceName
 image_analyzer: image_analysis.analyzers.beam_analyzer.BeamAnalyzer
 image:
-  type: camera
-  bit_depth: 16
-  roi: {x_min: 0, x_max: 650, y_min: 350, y_max: 650}
-  background: {method: constant, constant_level: 5.0}
-  pipeline:
-    steps: [background, roi]
+  type: camera   # or "line" for a 1D signal
+  # processing step blocks (roi, background, ...) + pipeline.steps
   analysis:
     # analyzer-specific parameters
 scan:
@@ -69,7 +67,7 @@ scan:
   mode: per_shot
 ```
 
-The exact shape of the `analysis` block depends on the analyzer. The simplest way to learn the schema is to look at an existing config or run the analyzer once and let the Pydantic validation tell you what it expects. The [Analysis tutorial](../tutorials/analysis.md) walks through editing one of these configs field by field.
+The annotated version of this file — every section explained, with a full worked example — is in the [Image Analysis Overview](overview.md#how-a-diagnostic-is-described); the [Analysis tutorial](../tutorials/analysis.md) walks through editing one field by field. The exact shape of the `analysis` block depends on the analyzer — look at an existing config or run the analyzer once and let the Pydantic validation tell you what it expects.
 
 ## When an analyzer is part of a scan
 


### PR DESCRIPTION
## What + why

`docs/image_analysis/analyzer_index.md` still described the pre-PR-E package layout: every analyzer was referenced by an `image_analysis/offline_analyzers/...` path. Since the loader-API refactor (ImageAnalysis 1.5.0) the modern analyzers live in `image_analysis/analyzers/`, and `offline_analyzers/` is deprecated (`ImageAnalysis/CLAUDE.md` Scope Note) — on `dev` the directory no longer exists at all. Every path on the published page was a dead reference.

Three fixes, all on this one page (docs-only, +29/−24):

1. **Paths** — all 11 analyzer references repointed from `offline_analyzers/...` to `analyzers/...`. Each target file verified present in `ImageAnalysis/image_analysis/analyzers/`, and each named class verified in its module (`BeamAnalyzer`, `GrenouilleAnalyzer`, `MagSpecManualCalibAnalyzer`, `LineAnalyzer`, `ICT1DAnalyzer`, `LineStitcher`, `HASOHimgHasProcessor`, `DownrampPhaseAnalyzer`, `PhaseDownrampProcessor`, `StandardAnalyzer`, `Standard1DAnalyzer`).
2. **Config example** — the "What each analyzer needs" YAML showed a pre-unified-diagnostic `device:` / `processing:` shape. Replaced with the real shape (`name` / `image_analyzer` / `image:` with the `type:` discriminator / `scan:`), mirroring the worked example in `docs/tutorials/analysis.md`, with a cross-link to that tutorial.
3. **Discoverability tip** — `import image_analysis.offline_analyzers` no longer works. Now points at `image_analysis.analyzers`, and honestly notes that its `__init__.py` re-exports only the commonly used classes (verified: 6 exports) while the specialized analyzers are imported from their own modules.

## Versioning

No version bump: no package code changed — the edit is entirely in the repo-level `docs/` site, outside `ImageAnalysis/`. Flagging as a judgment call in case the #536/#537 docs-bump precedent is read to cover site pages about a package.

## Tests

Docs-only. `mkdocs build` on this branch: clean, exit 0, no ERRORs, no warnings referencing this page (19 preexisting warnings elsewhere, unchanged). No package test suite is affected.

## Hardware verification

Not applicable — documentation page only; no scan-execution or device surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)