### PR TITLE
tooling: /get-started onboarding skill + Getting-started docs page + personal-branch topology

### DIFF
--- a/.claude/skills/env-doctor/SKILL.md
+++ b/.claude/skills/env-doctor/SKILL.md
@@ -7,8 +7,10 @@ description: >
   layer collecting as "1 skipped" (missing ca/tiled extras), "Command not
   found: pytest" inside a package dir, ModuleNotFoundError for an intra-repo
   package, pre-commit aborting a commit with "files were modified by this
-  hook", or a fresh worktree failing imports. Also consult before running any
-  package's test suite to pick the right env (root vs package).
+  hook", a fresh worktree failing imports, or a missing/incomplete
+  ~/.config/geecs_python_api/config.ini (GeecsPathsConfig errors,
+  "config.ini not found"). Also consult before running any package's
+  test suite to pick the right env (root vs package).
 ---
 
 # /env-doctor — diagnose and fix a package's Poetry environment
@@ -75,6 +77,14 @@ diagnose the package the current task is about.
 6. **Pre-commit.** `pre-commit` runs from the root env. Committing with
    plain `git commit` gets aborted by the auto-fixers ("files were
    modified by this hook") — use `./scripts/commit.sh -m "..."`.
+
+7. **GEECS config file.** Anything touching scan data or the GEECS DB
+   needs `~/.config/geecs_python_api/config.ini` with at least
+   `[Paths] geecs_data` and `[Experiment] expt`. Symptoms:
+   `GeecsPathsConfig` errors, "config.ini not found", or path
+   resolution failing with a perfectly healthy poetry env. Fix: create
+   it from the reference in `docs/tutorials/getting_started.md` —
+   values come from a teammate; never invent data paths.
 
 Report what was wrong and what you fixed; if everything checks out, say
 so and move the diagnosis back to the code.

--- a/.claude/skills/get-started/SKILL.md
+++ b/.claude/skills/get-started/SKILL.md
@@ -1,0 +1,171 @@
+---
+name: get-started
+description: >
+  Onboard a new developer in guide mode. Use when the user invokes
+  /get-started, says they are new ("I'm new here", "help me get started",
+  "first time in this repo", "how do I begin"), or when a session opens
+  with a newcomer-shaped prompt — a broad build request with no file
+  paths, package names, or repo vocabulary. Switches the session into
+  patient, hand-holding tutoring: environment check, orientation, a
+  small first win, and the repo's guardrails applied on the user's
+  behalf.
+---
+
+# /get-started — guide mode for new developers
+
+Treat the current user as **new to this repo, and possibly new to
+Python, git, and agentic coding**. Hand-holding is the job. This skill
+sets a stance, not a script — after the opening, it is a normal
+conversation governed by the rules below. The goal is as much to make
+the person comfortable working with an agent as it is to ship their
+first change.
+
+## Arguments
+
+`$ARGUMENTS` — optional: anything the user already said about what they
+want to build. If present, fold it into the goal conversation after the
+welcome instead of asking cold.
+
+## How to behave
+
+- **Open warmly and briefly.** The shape (adapt, don't recite):
+  *"Welcome — glad you're interested in developing for GEECS-Plugins.
+  This repo holds library code and applications used across BELLA
+  Center for data acquisition, visualization, and analysis. The docs
+  live at <https://geecs-plugins.readthedocs.io/en/latest/> if you want
+  to browse. I'm happy to guide you — what are you thinking about
+  building or exploring today?"*
+- **At most 1–2 questions per turn.** A wall of clarifying questions is
+  as alienating as jargon. Sequence them across turns.
+- **Gloss jargon in one line** the first time it appears ("an s-file —
+  the per-scan text file of scalar readings the scanner writes").
+- **Propose-and-confirm, never quiz.** The user cannot answer
+  architecture questions ("which package should this live in?").
+  Propose an answer with a one-line reason and ask for a yes/no.
+- **Drive the mechanics yourself and narrate.** Git branches, poetry,
+  commits, PRs: you run them; the user watches and absorbs. One plain
+  sentence per action ("I'm creating a branch so your work stays
+  separate from everyone else's until it's reviewed"). Never send the
+  user off to learn git first.
+- **Aim the first session at a small working win** — one figure
+  rendered, one image displayed, one test passing — then grow it.
+  If the ask is big, propose the thinnest working slice and build that
+  first.
+- **Record who they are in memory** (background, comfort level, their
+  goal, their personal branch name) so later sessions stay calibrated
+  without re-asking.
+- **Tell them about Sam.** Early on, mention: if you're ever confused,
+  stuck, or just have questions, feel free to contact Sam (the repo
+  owner) directly — questions are welcome.
+
+## When the goal is vague
+
+A newcomer's opening prompt is usually terse ("build me a camera gui
+for our cameras"). Never call it a bad prompt. The template:
+
+> "That's something I can likely do, but I'd benefit from more context
+> and a clearer idea of what you're trying to achieve. Do you know
+> which parts of the system this should use — or would you like me to
+> propose something? I have a good picture of how this repo is meant to
+> function and how the BELLA controls system operates, so I can fill in
+> the gaps if you give me more insight."
+
+Then narrow it with 1–2 questions per turn (what data/devices, who uses
+it, live or offline), propose a home for the work, and confirm.
+
+## Phase 0 — make sure their environment works
+
+Before building anything, walk this ladder. Fix problems as you hit
+them; the human-facing reference is
+`docs/tutorials/getting_started.md` (published on the docs site).
+
+1. **Toolchain**: Python 3.11 + Poetry present, root `poetry install`
+   succeeds. For any failure, apply `/env-doctor` — do not re-derive
+   its checks.
+2. **GEECS config**: `~/.config/geecs_python_api/config.ini` exists
+   with at least `[Paths] geecs_data` and `[Experiment] expt`. If
+   missing, help them create it from the reference in
+   `docs/tutorials/getting_started.md` (values come from a teammate or
+   Sam — do not invent paths).
+3. **Offline smoke test** (no lab network needed): from
+   `GeecsCAGateway/`, `poetry run python -m geecs_ca_gateway.demo` —
+   an in-process fake device server; proves the toolchain end to end.
+4. **Lab-network smoke test** — only after `/lab-status` says the lab
+   is reachable (never let a DB call hang blind):
+   `GeecsDb.get_all_experiment_variables("<expt>")` from the
+   GeecsCAGateway env; a device count proves config → DB works.
+5. **Sibling configs repo**: analyzer configs live in
+   `GEECS-Plugins-Configs`, expected as a sibling checkout. Only needed
+   for analysis-config work; note it, don't block on it.
+
+Off the lab network, stop after step 3 and say plainly which later
+steps will need the lab (or VPN).
+
+## The starter menu
+
+When the user has no concrete goal — or their goal maps onto one of
+these — offer 2–3 of the following, gentlest first. Read the listed
+reference before building; each is deliberately small.
+
+1. **Hook a diagnostic into the scan task queue — zero Python.**
+   Author a unified analyzer YAML in the configs repo; LiveWatch runs
+   it on every new scan. Walkthrough with screenshots:
+   `docs/tutorials/analysis.md`.
+2. **An analysis notebook.** A Jupyter notebook that loads a scan and
+   plots something: `ScanData.from_date(...)` → `data_frame` → `bin` →
+   `plot_binned` (GEECS-Data-Utils), optionally running an
+   ImageAnalysis analyzer on per-shot images. Start from the example
+   notebooks under `docs/geecs_data_utils/examples/` and
+   `docs/image_analysis/examples/`; run with
+   `poetry run jupyter lab` from the repo root.
+3. **A scalar scatter analyzer.** Subclass `ScatterPlotterAnalysis`;
+   the reference is
+   `ScanAnalysis/scan_analysis/analyzers/Undulator/ict_plot_analysis.py`
+   — about 30 lines of real production code.
+4. **A new image analyzer.** Subclass `StandardAnalyzer` (2D) or
+   `Standard1DAnalyzer` (1D); copy-pasteable template in
+   `ImageAnalysis/CLAUDE.md` § "Adding a New Analyzer"; small
+   references: `analyzers/beam_analyzer.py`, `analyzers/ict_1d_analyzer.py`.
+   Tests are hermetic via `image_analysis/tools/synthetic_generators.py`.
+5. **A live image-streaming viewer.** A small GUI subscribing to a
+   camera's PVA `NTNDArray` PV (a few lines of `p4p`) and displaying
+   frames. Orientation: `docs/geecs_gateway/image_pvs.md`; authority:
+   `GeecsPvaGateway/CLAUDE.md`. Needs the lab network.
+6. **A small single-purpose GUI.** Template: `ScanAnalysis/LiveWatchGUI/`
+   (six files — window, worker thread, log pane). For PySide6/Console
+   work, `GEECS-Console/CLAUDE.md`'s ownership-hazard sections are
+   mandatory reading first.
+7. **A small CLI/report tool**, shaped like `GEECS-LogTriage`
+   (Pydantic models → deterministic core → thin CLI; its `CLAUDE.md`
+   is the most digestible package doc in the repo).
+
+## Neighborhoods
+
+Steer first projects toward the actively developed packages
+(ImageAnalysis, ScanAnalysis, GEECS-Data-Utils, GEECS-Console,
+GeecsBluesky, the gateways). Never start a newcomer in — and never cite
+as a style reference — anything on the root `CLAUDE.md` "Known debt"
+list, `GEECS-PythonAPI` (frozen), `extras/` (legacy dump pending
+pruning), `LogMaker4GoogleDocs` (awaiting refactor), or
+`GEECS-Scanner-GUI` (legacy line, retired at the M6 cutover).
+
+## Branching and landing work
+
+The canonical branch topology lives in `CONTRIBUTING.md` § "Branch
+topology" — read it at run time; the newcomer-specific shape is:
+
+- Create the user a **personal integration branch** off the default
+  development base (currently `dev`): `users/<name>`. Record it in
+  memory. All their work happens on feature branches off it, in
+  worktrees under `.claude/worktrees/` as usual.
+- Land finished work **per `/land`**, with the PR base set to the
+  user's personal branch — their work merges at their own pace with no
+  risk to the mainline.
+- **Promotion from `users/<name>` into the mainline is always a
+  human-approved PR** — propose it when a piece of work is genuinely
+  done, but a maintainer (Sam) merges it. Never merge into the
+  mainline yourself in a guide-mode session.
+
+Tests and lint run per `/check`; environment failures go to
+`/env-doctor`; anything that needs the lab goes through `/lab-status`
+first. Do not restate those rituals — invoke them.

--- a/.claude/skills/get-started/SKILL.md
+++ b/.claude/skills/get-started/SKILL.md
@@ -2,13 +2,14 @@
 name: get-started
 description: >
   Onboard a new developer in guide mode. Use when the user invokes
-  /get-started, says they are new ("I'm new here", "help me get started",
-  "first time in this repo", "how do I begin"), or when a session opens
-  with a newcomer-shaped prompt — a broad build request with no file
-  paths, package names, or repo vocabulary. Switches the session into
-  patient, hand-holding tutoring: environment check, orientation, a
-  small first win, and the repo's guardrails applied on the user's
-  behalf.
+  /get-started or says they are new ("I'm new here", "help me get
+  started", "first time in this repo", "how do I begin"). A merely
+  newcomer-shaped prompt (a broad build request with no file paths,
+  package names, or repo vocabulary) from a user not known to be new is
+  NOT a trigger — offer the skill in one line instead of switching
+  stance uninvited. Switches the session into patient, hand-holding
+  tutoring: environment check, orientation, a small first win, and the
+  repo's guardrails applied on the user's behalf.
 ---
 
 # /get-started — guide mode for new developers
@@ -90,6 +91,10 @@ them; the human-facing reference is
 3. **Offline smoke test** (no lab network needed): from
    `GeecsCAGateway/`, `poetry run python -m geecs_ca_gateway.demo` —
    an in-process fake device server; proves the toolchain end to end.
+   Success is the two `[self-check]` lines — the demo then *serves
+   until interrupted*, so run it with a short timeout or in the
+   background; a timeout after the self-check lines is a pass, not a
+   failure.
 4. **Lab-network smoke test** — only after `/lab-status` says the lab
    is reachable (never let a DB call hang blind):
    `GeecsDb.get_all_experiment_variables("<expt>")` from the

--- a/.claude/skills/land/SKILL.md
+++ b/.claude/skills/land/SKILL.md
@@ -31,6 +31,12 @@ canonical copy; read it now and pick the base matching the content of the
 change (`dev` for vision-world work; `master` only for analysis/legacy
 work with no dev-only imports).
 
+**Personal-branch exception:** if the developer works on a personal
+integration branch (`users/<name>`, per that CONTRIBUTING section or
+session memory), feature PRs target the personal branch instead of a
+mainline base — and never merge `users/<name>` into a mainline branch
+yourself; that promotion PR is merged by a human maintainer.
+
 **Roll-forward rule (until M6):** after merging an analysis/legacy PR
 into `master`, merge `master` forward into `dev` (`git merge
 origin/master --no-edit --no-verify` — `--no-verify` because pre-commit's

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -327,6 +327,15 @@ revisit. Speculative cleanup is not.
   legacy `master`-line consumers until deletion. Don't add features, don't
   adopt it in new call sites, don't lint-fix it opportunistically.
 
+- **`extras/` is a legacy dump pending pruning** — ~26 MB of unrelated
+  one-off projects and third-party snapshots. Never build there, never cite
+  its contents as reference implementations, and don't prune it
+  opportunistically: what's still load-bearing needs the owner's judgment.
+
+- **`LogMaker4GoogleDocs` needs a refactor.** It works in production
+  (Google Doc log uploads) and is optional everywhere, but don't extend it
+  or use it as a style reference until that refactor happens.
+
 If you find yourself adding to this list, consider whether you're capturing
 real institutional knowledge or accumulating procrastination. Both are
 possible.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,7 +50,10 @@ that personal branch — the `/get-started` skill sets this up, and
 `/land` targets it — so they can merge their own work at their own
 pace. Promotion from `users/<name>` into `dev` (after M6: `master`) is
 a separate PR that **only a human maintainer merges**; agents never
-merge into the mainline on a newcomer's behalf.
+merge into the mainline on a newcomer's behalf. To keep the personal
+branch from going stale, the agent merges the development base forward
+*into* `users/<name>` periodically — that direction is routine
+maintenance, not a mainline merge.
 
 `master` is merged forward into `dev` periodically, so analysis work
 flows into the vision world automatically; nothing merges the other way

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,8 +8,11 @@ live in the root and per-package `CLAUDE.md` files, which are the canonical
 instructions for AI-assisted development — if you work with Claude/Codex,
 those files are loaded automatically, and repo-checked skills under
 `.claude/skills/` (e.g. `/land`, `/check`, `/triage`, `/scan-audit`,
-`/env-doctor`)
-encode the recurring workflows.
+`/env-doctor`, `/get-started`)
+encode the recurring workflows. New to the repo entirely? Start with
+[Getting started](docs/tutorials/getting_started.md) (published on the
+docs site), or launch Claude Code from the repo root and type
+`/get-started`.
 
 ## Setup
 
@@ -39,6 +42,15 @@ renamed `dev`):
   `master` for analysis work *unless it imports something that only
   exists on `dev`* (e.g. `geecs_data_utils.tiled_catalog`) — then target
   `dev`.
+
+**Personal branches for new developers.** A developer new to the repo
+gets a long-lived personal integration branch off the development base
+(currently `dev`), named `users/<name>`. Their feature branches PR into
+that personal branch — the `/get-started` skill sets this up, and
+`/land` targets it — so they can merge their own work at their own
+pace. Promotion from `users/<name>` into `dev` (after M6: `master`) is
+a separate PR that **only a human maintainer merges**; agents never
+merge into the mainline on a newcomer's behalf.
 
 `master` is merged forward into `dev` periodically, so analysis work
 flows into the vision world automatically; nothing merges the other way

--- a/docs/geecs_python_api/scripting_guide.md
+++ b/docs/geecs_python_api/scripting_guide.md
@@ -13,7 +13,7 @@ The path is short: configure your environment, instantiate a `GeecsDevice`, set 
 
 You need:
 
-1. A working `~/.config/geecs_python_api/config.ini` pointing at the right experiment and database. The Scanner GUI sets this up the first time you run it. If you've never run the GUI on this machine, copy a known-good config from a colleague.
+1. A working `~/.config/geecs_python_api/config.ini` pointing at the right experiment and database. The Scanner GUI sets this up the first time you run it. If you've never run the GUI on this machine, copy a known-good config from a colleague. The full key-by-key reference is in [Getting started](../tutorials/getting_started.md).
 2. Network reachability to the GEECS database server and to the device(s) you want to talk to.
 3. The device's name as it appears in the GEECS database. The Scanner GUI's "available devices" list is one way to find this; querying the database directly is another.
 

--- a/docs/tutorials/analysis.md
+++ b/docs/tutorials/analysis.md
@@ -15,7 +15,8 @@ Python required.
 You should already have:
 
 - **`~/.config/geecs_python_api/config.ini`** set up. The Scanner GUI's
-  first-launch wizard creates it; copy from a working teammate if needed.
+  first-launch wizard creates it; copy from a working teammate if needed —
+  the full key-by-key reference is in [Getting started](getting_started.md).
   Minimal contents look like:
 
     ```ini

--- a/docs/tutorials/getting_started.md
+++ b/docs/tutorials/getting_started.md
@@ -129,7 +129,10 @@ poetry install
 poetry run python -m geecs_ca_gateway.demo
 ```
 
-If this runs and reports success, your toolchain is healthy end to end.
+Success looks like two `[self-check]` lines confirming the round trip;
+the demo then keeps serving its fake PVs until you stop it with
+`Ctrl-C` — it is a server, so it won't exit on its own. If the
+self-check lines appeared, your toolchain is healthy end to end.
 
 **On the lab network (or VPN)** — prove the config → database chain with
 a three-line query:

--- a/docs/tutorials/getting_started.md
+++ b/docs/tutorials/getting_started.md
@@ -1,0 +1,180 @@
+# Getting started
+
+This page takes you from nothing to a working GEECS-Plugins development
+setup: the toolchain, the repo, the one config file everything reads,
+and a smoke test that proves it all works. It is also the reference the
+repo's AI tooling uses when it helps a new developer get set up.
+
+!!! tip "You don't have to do this alone"
+    This repo is developed heavily with AI coding agents. If you have
+    [Claude Code](https://claude.com/claude-code) installed, you can
+    clone the repo, launch `claude` from the repo root, and type
+    `/get-started` — the agent will walk you through everything on this
+    page interactively, fix problems as they come up, and help you plan
+    your first project. And if you're ever confused or stuck, contact
+    Sam — questions are welcome.
+
+## What you need first
+
+- **git** — on macOS it ships with Xcode command-line tools; on Windows
+  use [Git for Windows](https://git-scm.com/download/win).
+- **Python 3.11** — specifically 3.11 (`>=3.11,<3.12`); a newer or older
+  Python will fail with a version error at install time. Install from
+  [python.org](https://www.python.org/downloads/) alongside any other
+  Pythons you have.
+- **Poetry** — the package manager used throughout:
+  [installation instructions](https://python-poetry.org/docs/#installation).
+
+## Get the code
+
+```bash
+git clone https://github.com/GEECS-BELLA/GEECS-Plugins.git
+cd GEECS-Plugins
+git checkout dev
+```
+
+!!! note "Why `dev`?"
+    Until the planned branch cutover, `dev` is the active development
+    line and the default base for new work; `master` carries the legacy
+    scanner. See `CONTRIBUTING.md` at the repo root for the branch
+    topology.
+
+If you'll work on analyzer configurations, also clone the sister config
+repo **as a sibling directory** (several tools expect it at
+`../GEECS-Plugins-Configs/`):
+
+```bash
+cd ..
+git clone https://github.com/GEECS-BELLA/GEECS-Plugins-Configs.git
+cd GEECS-Plugins
+```
+
+## Install
+
+From the repo root:
+
+```bash
+poetry install
+poetry run pre-commit install
+```
+
+The first command builds the main development environment (ImageAnalysis,
+ScanAnalysis, GEECS-Data-Utils, and friends run from it). The second
+installs the git hooks that auto-format code on commit.
+
+Some packages keep their own environment instead — `GeecsBluesky`,
+`GeecsCAGateway`, `GEECS-Console` and others are installed by running
+`poetry install` inside that package's directory. You only need those
+when you work on them; `scripts/check.sh` knows which is which.
+
+!!! warning "The most common setup failure"
+    If any poetry command prints *"Current Python version (3.x) is not
+    allowed"*, your default `python` is not 3.11. Point poetry at the
+    right interpreter and reinstall:
+
+    ```bash
+    poetry env use /path/to/python3.11
+    poetry install
+    ```
+
+## The config file
+
+Everything in the suite reads one small INI file:
+
+```
+~/.config/geecs_python_api/config.ini
+```
+
+Create the directory and file if they don't exist. A representative
+file (ask a teammate or Sam for the right values for your machine —
+the data path in particular depends on how the data share is mounted):
+
+```ini
+[Paths]
+geecs_data = Z:/data/
+scan_analysis_configs_path = C:/path/to/GEECS-Plugins-Configs/scan_analysis_configs
+image_analysis_configs_path = C:/path/to/GEECS-Plugins-Configs/image_analysis_configs
+
+[Experiment]
+expt = Undulator
+rep_rate_hz = 1
+```
+
+What each section is for, and who reads it:
+
+| Section / key | Purpose | Read by |
+|---|---|---|
+| `[Paths] geecs_data` | Root of the experiment data share; also where `Configurations.INI` (database credentials) lives | Everything that touches scan data or the GEECS database |
+| `[Paths] scan_analysis_configs_path` | Analyzer/diagnostic YAMLs in the configs repo | ScanAnalysis, LiveWatch, ConfigFileGUI |
+| `[Paths] image_analysis_configs_path` | Camera/1D analyzer configs in the configs repo | ImageAnalysis |
+| `[Paths] scanner_config_root_path` | Scanner save-element configs (optional) | GEECS Console |
+| `[Experiment] expt` | Your experiment's GEECS name (e.g. `Undulator`) | Nearly everything |
+| `[Experiment] rep_rate_hz` | Machine rep rate, for shot-count estimates | Scanner/Console |
+| `[tiled] uri`, `[tiled] api_key` | Tiled data-server access (optional) | GeecsBluesky, Scan Browser |
+| `[epics] ca_addr_list` | EPICS client addressing (optional, gateway clients) | GeecsBluesky and other CA clients |
+
+Database credentials are **not** stored here: tools follow
+`[Paths] geecs_data` to the `Configurations.INI` file on the data share
+and read the `[Database]` section there. If the data share is mounted
+and `geecs_data` is right, database access follows automatically.
+
+## Prove it works
+
+**Offline** (no lab network needed) — run the gateway's self-checking
+demo against an in-process fake device:
+
+```bash
+cd GeecsCAGateway
+poetry install
+poetry run python -m geecs_ca_gateway.demo
+```
+
+If this runs and reports success, your toolchain is healthy end to end.
+
+**On the lab network (or VPN)** — prove the config → database chain with
+a three-line query:
+
+```python
+from geecs_ca_gateway.db.geecs_db import GeecsDb
+
+devices = GeecsDb.get_all_experiment_variables("Undulator")
+print(f"{len(devices)} devices tracked")
+```
+
+Run it from the `GeecsCAGateway` directory with
+`poetry run python your_script.py`. A device count means config file,
+data share, and database all line up.
+
+!!! note "Off the lab network?"
+    Database and device calls block for over a minute before timing out
+    when the lab isn't reachable. Everything offline — installs, tests,
+    the fake-server demo, working with already-copied data — works
+    fine from anywhere.
+
+## Contributing your work
+
+The full workflow contract is `CONTRIBUTING.md` at the repo root; the
+short version for a new developer:
+
+- Work on a branch, never directly on `dev` or `master`. New developers
+  get a personal branch (`users/<yourname>`) that feature work merges
+  into; moving work from there into the mainline is a reviewed pull
+  request.
+- Commit with `./scripts/commit.sh -m "..."` after `git add` — a plain
+  `git commit` is aborted by the auto-formatting hooks by design.
+- Run `./scripts/check.sh` before opening a pull request; it runs the
+  same lint and tests the CI does.
+
+If you work with an AI agent, it knows all of this — the repo ships
+agent instructions (`CLAUDE.md` files) and skills (`/land`, `/check`,
+`/env-doctor`) that encode the workflow, so you can let it drive the
+mechanics while you watch.
+
+## Where to next
+
+- [Analysis tutorial](analysis.md) — the end-to-end walkthrough:
+  configure an analyzer, run it on a real scan, get summary figures.
+- [Home page](../index.md) — the map of what each package does and how
+  they fit together.
+- [Camera images over PVA](../geecs_gateway/image_pvs.md) — how to
+  consume live camera images in three lines of `p4p`.

--- a/docs/tutorials/index.md
+++ b/docs/tutorials/index.md
@@ -2,6 +2,8 @@
 
 The suite's two halves — acquisition and analysis — each get their own
 end-to-end tutorial. Pick the one that matches what you're trying to do.
+No development environment yet? Do [Getting started](getting_started.md)
+first — toolchain, config file, and a smoke test.
 
 <div class="grid cards" markdown>
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -39,6 +39,7 @@ nav:
 
   - Tutorials:
       - Overview: tutorials/index.md
+      - Getting started: tutorials/getting_started.md
       - Acquisition: tutorials/acquisition.md
       - Analysis: tutorials/analysis.md
 


### PR DESCRIPTION
## What + why

Onboarding path for brand-new developers (not Python-proficient, new to agentic coding, git-shy). The repo is now strongly developed with agentic tools; this gives a new colleague a guided way in: clone, launch Claude Code, type `/get-started`, and the agent switches into patient guide mode.

One concern — "the newcomer onboarding path exists and is safe" — in four coordinated pieces:

| Piece | Files | LOC |
|---|---|---|
| `/get-started` skill: free-form guide-mode stance (1–2 questions/turn, propose-and-confirm, drive-and-narrate git/poetry, small first win, contact-Sam pointer), phase-0 env ladder, 7-archetype starter menu, no-go neighborhoods, personal-branch ritual | `.claude/skills/get-started/SKILL.md` | +171 |
| Getting-started docs page: first published setup page (toolchain, clone, install), first consolidated `config.ini` reference anywhere, python-api-free smoke tests (offline `geecs_ca_gateway.demo`; on-network `GeecsDb` query), nav + routing | `docs/tutorials/getting_started.md`, `mkdocs.yml`, `docs/tutorials/index.md` | +183 |
| Personal-branch topology for newcomers: `users/<name>` off `dev`, feature PRs target it, promotion to the mainline is human-merged only; `/get-started` added to the skills roster line | `CONTRIBUTING.md` | +16/−2 |
| Supporting guardrails: `extras/` + `LogMaker4GoogleDocs` added to root CLAUDE.md known-debt; env-doctor check 7 for missing/incomplete `config.ini` | `CLAUDE.md`, `.claude/skills/env-doctor/SKILL.md` | +23/−2 |

## Judgment calls (cheap to veto)

- Personal branch naming: `users/<name>`.
- CONTRIBUTING wording: "agents never merge into the mainline on a newcomer's behalf".
- The docs page names Claude Code explicitly and says "contact Sam" (first name only — public-repo hygiene held).
- The page instructs `git checkout dev`; one line to edit at the M6 cutover (noted inline on the page).
- env-doctor gained a check + a trigger-description line (scope addition to an existing skill).

## Tests

- `./scripts/check.sh`: lint green; no test suites owed (no package code changed — dry-run: "nothing testable changed").
- `poetry run mkdocs build` against this branch's config: exit 0, **0 ERROR lines**; only expected "no git logs" notices for the new page.
- No version bumps/CHANGELOG owed: all changes are repo-level (skills, root policy docs, docs site) — no package's code or docs tree changed.

## Hardware verification

N/A — no scan-execution or device surface. The two smoke-test commands on the docs page were verified to exist against the code (`geecs_ca_gateway/demo.py`; `GeecsDb.get_all_experiment_variables` signature read from source); the on-network query is exercised the first time a newcomer runs it with lab access.

🤖 Generated with [Claude Code](https://claude.com/claude-code)