### PR TITLE
docs: truth-up Skills pages to the .claude/skills/ roster

### DIFF
--- a/docs/skills/overview.md
+++ b/docs/skills/overview.md
@@ -1,8 +1,46 @@
 # Skills
 
-A **skill** in this repository is a markdown command file under `.claude/commands/` that wraps a CLI tool and is invoked as a slash command from a [Claude Code](https://claude.ai/code) session. The pattern works because of a clean layering: a deterministic Python CLI does the structured, reproducible work — parsing logs, querying databases, walking scan folders — and the agent handles the parts that benefit from language understanding: summarizing findings, locating relevant source code, drafting GitHub issues, asking clarifying questions. Each layer is independently testable and independently useful. The CLI can be run by a script or a human without an agent; the agent can be swapped out without changing the CLI. The same separation that makes the scan engine's typed event stream robust applies here: a well-defined contract between a deterministic core and a flexible consumer.
+A **skill** in this repository is a markdown instruction file at
+`.claude/skills/<name>/SKILL.md`, invoked as a slash command from a
+[Claude Code](https://claude.ai/code) session. Each `SKILL.md` starts with
+YAML frontmatter declaring the skill's name and a trigger description —
+that description is what tells the agent when to reach for the skill even
+if you don't type the slash command yourself.
+
+Skills come in two shapes. The first wraps a deterministic tool: a Python
+CLI or shell script does the structured, reproducible work — parsing logs,
+running the test suites, probing the network — and the agent handles the
+parts that benefit from language understanding: summarizing findings,
+locating relevant source code, drafting GitHub issues, asking clarifying
+questions. Each layer is independently testable and independently useful.
+The CLI can be run by a script or a human without an agent; the agent can
+be swapped out without changing the CLI. The same separation that makes the
+scan engine's typed event stream robust applies here: a well-defined
+contract between a deterministic core and a flexible consumer. The second
+shape is instruction-only: a workflow ritual or diagnostic playbook (how to
+land a PR, how to repair a Poetry environment) where the value is the
+codified procedure itself rather than a wrapped tool.
 
 ## Shipped skills
+
+| Skill | What it does |
+|---|---|
+| `/land` | Land a change as a PR the GEECS-Plugins way: branch off the right base, scope check, version bump + changelog, tests the way CI runs them, adversarial review, CI watch, merge |
+| `/check` | Run repo lint + unit tests the way CI does, scoped to what changed; wraps `scripts/check.sh` |
+| `/env-doctor` | Diagnose and fix a package's Poetry environment when poetry, pytest, or an import fails for setup-shaped reasons |
+| `/lab-status` | Probe lab-network and hardware reachability with bounded timeouts before doing anything that needs them; wraps `scripts/lab_status.sh` |
+| `/scan-audit` | Scan timing and cadence audit for the Bluesky path: "why was the scan slow", "did every shot land", per-shot cadence analysis of a scan folder |
+| `/triage` | Generate a structured error report from scan logs, then analyze bug candidates against the codebase and draft GitHub issues |
+| `/get-started` | Onboard a new developer in guide mode: environment check, orientation, a small first win, with the repo's guardrails applied on the user's behalf |
+
+`/land`, `/check`, `/env-doctor`, and `/get-started` are development
+workflow skills — they operate on the repository itself. `/lab-status`,
+`/scan-audit`, and `/triage` are lab operations skills — they operate on
+the experiment: the network, the hardware, and the data a scan left
+behind. `/triage` is the reference implementation of the CLI-backed
+pattern and is documented in depth below;
+[Writing a skill](writing_a_skill.md) uses it as the template for new
+skills.
 
 ### /triage — diagnose scan failures and draft bug reports
 
@@ -57,9 +95,9 @@ The `TriageReport` JSON can be piped into any downstream tool — a notebook, a 
 
 ## Installation
 
-The skill file ships with the repository at `.claude/commands/triage.md`. If Claude Code is configured to read project-level commands (the default when you open the monorepo root), `/triage` is available immediately after cloning. No extra installation step is needed for the slash command itself.
+The skill files ship with the repository under `.claude/skills/`. If Claude Code is configured to read project-level skills (the default when you open the monorepo root), every skill above is available immediately after cloning. No extra installation step is needed for the slash commands themselves.
 
-The underlying CLI requires a one-time setup:
+The CLI underlying `/triage` requires a one-time setup:
 
 ```bash
 cd GEECS-LogTriage

--- a/docs/skills/overview.md
+++ b/docs/skills/overview.md
@@ -39,12 +39,12 @@ workflow skills — they operate on the repository itself. `/lab-status`,
 the experiment: the network, the hardware, and the data a scan left
 behind. `/triage` is the reference implementation of the CLI-backed
 pattern and is documented in depth below;
-[Writing a skill](writing_a_skill.md) uses it as the template for new
+[Writing a Skill](writing_a_skill.md) uses it as the template for new
 skills.
 
 ### /triage — diagnose scan failures and draft bug reports
 
-`/triage` walks one or more scan logs, groups errors into stable fingerprints, classifies each fingerprint as a bug candidate, hardware issue, config issue, or operator error, and then — for each bug candidate — locates the relevant source code, reasons about why the failure happens, and drafts a GitHub issue for your review before filing anything.
+`/triage` walks one or more scan logs, groups errors into stable fingerprints, classifies each fingerprint as a bug candidate, hardware issue, config issue, or operator error (falling back to unknown when nothing matches), and then — for each bug candidate — locates the relevant source code, reasons about why the failure happens, and drafts a GitHub issue for your review before filing anything.
 
 **When to use it:**
 

--- a/docs/skills/writing_a_skill.md
+++ b/docs/skills/writing_a_skill.md
@@ -2,13 +2,15 @@
 
 This page is for contributors who want to add a new skill to the repository. Read the [Skills Overview](overview.md) first if you haven't — it covers what a skill is and why the pattern exists.
 
+Not every skill needs this treatment: instruction-only skills like `/land` and `/get-started` are a codified procedure with no wrapped tool, and `/check` and `/lab-status` wrap shell scripts rather than Python packages. This page describes the full two-layer pattern for skills that do deterministic data work; take from it what your skill actually needs.
+
 ## The two-layer pattern
 
-Every skill has exactly two parts:
+A CLI-backed skill has exactly two parts:
 
 **A Python CLI tool** that does the deterministic work. It accepts well-typed arguments, produces structured output (JSON to stdout, markdown to disk), and has no dependency on any agent or LLM. It can be run by a human, a script, or a CI job. It can be tested with pytest against fixtures. It has a version and a changelog.
 
-**A markdown slash command** in `.claude/commands/<name>.md` that wraps invocation of the CLI and describes to the agent how to interpret and act on the output. The markdown file is the UX layer for agentic use; it documents the argument forms, the expected output shape, and what the agent should do at each stage.
+**A markdown skill file** at `.claude/skills/<name>/SKILL.md` that wraps invocation of the CLI and describes to the agent how to interpret and act on the output. The markdown file is the UX layer for agentic use; it opens with YAML frontmatter (the skill's `name` and a `description` of when to use it — this is what triggers the skill even when the user doesn't type the slash command), then documents the argument forms, the expected output shape, and what the agent should do at each stage.
 
 The separation matters for the same reason the scanner engine's typed event stream matters: the CLI is the stable contract. The agent is a consumer of that contract, not part of its implementation. When you upgrade the LLM, the CLI doesn't change. When you want to run the CLI in a notebook, you don't need the agent. When you want to test the skill end-to-end, you test the CLI against real or synthetic inputs and separately test that the command file's instructions produce sensible agent behavior on known CLI output.
 
@@ -25,7 +27,7 @@ The separation matters for the same reason the scanner engine's typed event stre
 
 The agent uses both. It runs the CLI twice: once with `--format json` to get the structured data it reasons over, and once without to produce the human-readable file that persists on disk. This is the standard contract: **JSON to stdout for the agent, markdown to disk for the human**.
 
-**The slash command** lives at `.claude/commands/triage.md`. It defines five stages:
+**The skill file** lives at `.claude/skills/triage/SKILL.md`. It defines five stages:
 
 1. Environment check — verify the poetry env is ready before running anything.
 2. Generate the report — run both CLI invocations described above.
@@ -56,8 +58,9 @@ Keeping these two forms of output separate — machine-readable JSON for the age
 - Write the human-readable default output to a predictable location on disk (next to the data it analyzed).
 - Have tests that run against synthetic fixtures without network access.
 
-**Step 2: write the slash command.** Create `.claude/commands/<name>.md`. The file should cover:
+**Step 2: write the skill file.** Create `.claude/skills/<name>/SKILL.md`. The file should cover:
 
+- YAML frontmatter with the skill's `name` and a `description` that says when to use it (and, if a sibling skill covers adjacent ground, when to use that one instead — see how `/triage` and `/scan-audit` point at each other).
 - What arguments the underlying CLI accepts, with examples for each common form.
 - How to check that the environment is ready before running.
 - What the agent should do with each part of the CLI output.

--- a/docs/skills/writing_a_skill.md
+++ b/docs/skills/writing_a_skill.md
@@ -18,7 +18,7 @@ The separation matters for the same reason the scanner engine's typed event stre
 
 `/triage` is the reference implementation. Walking through it concretely is more useful than abstract guidelines.
 
-**The CLI** lives in `GEECS-LogTriage/`. Its entry point is `geecs_log_triage.cli:main`, registered in `pyproject.toml` as `geecs-log-triage`. The CLI walks one or more scan folders, parses each `scan.log` file, normalizes errors into stable fingerprints via `ErrorFingerprint` (exception type + file + function, hashed to a short string), classifies each fingerprint as `bug_candidate`, `hardware_issue`, `config_issue`, or `operator_error`, and assembles a `TriageReport` Pydantic model.
+**The CLI** lives in `GEECS-LogTriage/`. Its entry point is `geecs_log_triage.cli:main`, registered in `pyproject.toml` as `geecs-log-triage`. The CLI walks one or more scan folders, parses each `scan.log` file, normalizes errors into stable fingerprints via `ErrorFingerprint` (exception type + file + function, hashed to a short string), classifies each fingerprint as `bug_candidate`, `hardware_issue`, `config_issue`, or `operator_error` (with `unknown` as the fallback), and assembles a `TriageReport` Pydantic model.
 
 **Output shape.** The CLI has two output modes controlled by `--format`:
 


### PR DESCRIPTION
## What + why

`docs/skills/overview.md` was stale on two counts: it said repo skills live under `.claude/commands/` (they moved to `.claude/skills/<name>/SKILL.md`) and it documented only `/triage` — the roster is now seven skills. `docs/skills/writing_a_skill.md` carried the same stale paths and claimed every skill wraps a Python CLI, which no longer matches the roster.

**overview.md** (+41/−6):
- Location corrected to `.claude/skills/<name>/SKILL.md`, with a note on the YAML frontmatter trigger description.
- Full roster table — `/land`, `/check`, `/env-doctor`, `/lab-status`, `/scan-audit`, `/triage`, `/get-started` — one-line purposes drawn from each SKILL.md's frontmatter description.
- Intro recast to name the two skill shapes: CLI/script-backed vs instruction-only. The detailed `/triage` walkthrough is kept as the reference implementation; Installation section paths corrected.

**writing_a_skill.md** (+7/−1):
- `.claude/commands/<name>.md` → `.claude/skills/<name>/SKILL.md` (3 sites).
- Frontmatter (`name` + `description`) added to the Step-2 checklist.
- Judgment-call addition (cheap to veto): a scoping paragraph before "The two-layer pattern" saying instruction-only skills (`/land`, `/get-started`) and shell-script wrappers (`/check`, `/lab-status`) don't need the full Python-CLI treatment — without it the page's "every skill has exactly two parts" claim contradicts the roster the overview now lists.

PR #617 (`/get-started`) verified merged into `dev` (2026-08-19), so it is listed as shipped, not pending.

## Scope

Docs-only, base `dev` per CONTRIBUTING.md (docs site → dev). No package code touched, no version bumps (`docs/` is not a package).

## Tests

- `./scripts/check.sh`: lint passed, no testable packages changed (suites: none).
- `mkdocs build` from repo root: exit 0, **zero ERROR lines** (grep count 0).

## Hardware verification

Not applicable — documentation only, no scan-execution or device surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)