### PR TITLE
GeecsBluesky 0.51.0: scan.log = complete per-scan record (root capture + pre-claim buffer)

### DIFF
--- a/GEECS-Console/CHANGELOG.md
+++ b/GEECS-Console/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to GEECS-Console are documented here.  Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versioning is
 semantic.
 
+## [0.19.2] - 2026-08-20
+
+### Fixed
+
+- `configure_logging` sets the operator's `--log-level` on the stderr and
+  `console.log` handlers explicitly (they were NOTSET): the engine's
+  per-scan scan.log capture (GeecsBluesky 0.51.0) lowers the *root* level
+  to INFO for a scan's duration, and NOTSET handlers would silently
+  inherit that — printing INFO against an explicit `--log-level WARNING`
+  (PR #620 review finding 1).
+
 ## [0.19.1] - 2026-07-22
 
 ### Changed

--- a/GEECS-Console/main.py
+++ b/GEECS-Console/main.py
@@ -31,7 +31,13 @@ def configure_logging(level_name: str = "INFO") -> None:
     # logs one line per request (every 5 s, forever).  Quiet it to WARNING.
     logging.getLogger("httpx").setLevel(logging.WARNING)
     formatter = logging.Formatter("%(asctime)s %(levelname)s %(name)s: %(message)s")
+    # Handlers carry the operator's --log-level explicitly: the engine's
+    # per-scan scan.log capture (geecs_bluesky.scan_log) lowers the ROOT
+    # level to INFO for a scan's duration, and NOTSET handlers would
+    # silently inherit that — printing INFO to stderr/console.log against
+    # an explicit --log-level WARNING.
     stderr_handler = logging.StreamHandler()
+    stderr_handler.setLevel(level)
     stderr_handler.setFormatter(formatter)
     root.addHandler(stderr_handler)
     try:
@@ -42,6 +48,7 @@ def configure_logging(level_name: str = "INFO") -> None:
             backupCount=_LOG_BACKUP_COUNT,
             encoding="utf-8",
         )
+        file_handler.setLevel(level)
         file_handler.setFormatter(formatter)
         root.addHandler(file_handler)
     except OSError as exc:  # an unwritable config dir must not kill the GUI

--- a/GEECS-Console/pyproject.toml
+++ b/GEECS-Console/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-console"
-version = "0.19.1"
+version = "0.19.2"
 description = "Greenfield PySide6 operator console for GEECS (Bluesky/gateway architecture)"
 authors = ["Sam Barber <sbarber@lbl.gov>"]
 readme = "README.md"

--- a/GeecsBluesky/CHANGELOG.md
+++ b/GeecsBluesky/CHANGELOG.md
@@ -4,6 +4,35 @@ All notable changes to `geecs-bluesky` are documented here.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.51.0] - 2026-08-20
+
+### Changed
+
+- **`scan.log` is now the complete per-scan record** (owner request from
+  the 2026-08-19 console test scans, and queueserver prep — under a worker
+  there is no operator-attached terminal, only a machine-global journal):
+  the per-scan file handler attaches to the **root logger** instead of a
+  four-namespace allowlist, so `bluesky` RunEngine state changes,
+  `ophyd_async` connect-failure tracebacks, and `geecs_data_utils`
+  folder/export lines land in the file — everything the terminal shows.
+  The root level is lowered to INFO for the scan's duration and restored.
+  `CAPTURE_LOGGER_NAMES` is gone (no external importers).
+
+### Added
+
+- **Pre-claim log capture** (`begin_pre_scan_capture` /
+  `discard_pre_scan_capture` in `scan_log.py`): a bounded buffer starts at
+  submission (`BlueskyScanner.reinitialize` / `GeecsSession.run`) and
+  flushes into `scan.log` the moment the folder is claimed, so the file
+  opens with the most diagnostic window — submission, device connects,
+  soft-telemetry drops (previously terminal-only).  A buffer with no
+  scan.log home (refused submission, `save_data=False`, claim failure) is
+  discarded, never leaked into a later scan's file.
+- Known-noisy transport namespaces (`httpx`, `mysql.connector`) are kept
+  out of the scan.log capture below WARNING (live finding, 2026-08-20
+  Scan001: ~15 non-scan-story lines per scan); their WARNING+ records
+  still land, and the terminal is untouched.
+
 ## [0.50.1] - 2026-07-25
 
 ### Changed

--- a/GeecsBluesky/CLAUDE.md
+++ b/GeecsBluesky/CLAUDE.md
@@ -138,7 +138,13 @@ geecs_bluesky/
                             #   before aioca import (called by geecs_bluesky/__init__)
   scan_log.py               # shared per-scan scan.log handler (scan_log() ctx
                             #   manager) — bridge delegates; GeecsSession
-                            #   attaches it when it claimed the scan number
+                            #   attaches it when it claimed the scan number.
+                            #   Root-logger capture (0.51.0): scan.log records
+                            #   the whole process story (bluesky/ophyd_async/
+                            #   geecs_data_utils included), with a pre-claim
+                            #   buffer started at submission so the file opens
+                            #   with connects/telemetry drops; httpx +
+                            #   mysql.connector INFO chatter filtered out
   shot_controller.py        # ShotController — arm/disarm/quiesce/fire plan stubs (gateway :SP)
   optimize.py               # suggester protocol, RandomSuggester, XoptSuggester, BinData
   tiled_integration.py      # subscribe_tiled + descriptor patch + safe callback

--- a/GeecsBluesky/geecs_bluesky/scan_log.py
+++ b/GeecsBluesky/geecs_bluesky/scan_log.py
@@ -67,7 +67,10 @@ class _QuietNoisyLoggers(logging.Filter):
         """
         if record.levelno >= logging.WARNING:
             return True
-        return not record.name.startswith(QUIET_LOGGER_PREFIXES)
+        return not any(
+            record.name == prefix or record.name.startswith(prefix + ".")
+            for prefix in QUIET_LOGGER_PREFIXES
+        )
 
 
 class PreScanLogBuffer(logging.Handler):
@@ -76,6 +79,11 @@ class PreScanLogBuffer(logging.Handler):
     A plain bounded buffer: :meth:`emit` appends, and :meth:`flush_into`
     replays every held record through a target handler (whose own filters —
     the scan-id stamp — apply on replay).  Never auto-flushes.
+
+    Captures at INFO+ (``level=logging.INFO``), matching the scan.log file
+    handler's own INFO threshold — under a ``--log-level DEBUG`` root the
+    per-scan file is an INFO+ record on both sides of the claim, by design
+    (DEBUG-heavy startups would also evict the bounded buffer's story).
     """
 
     def __init__(self, capacity: int = PRE_SCAN_BUFFER_CAPACITY) -> None:
@@ -96,6 +104,10 @@ class PreScanLogBuffer(logging.Handler):
             The record to buffer.
         """
         self._records.append(record)
+
+    def __len__(self) -> int:
+        """Number of buffered records."""
+        return len(self._records)
 
     def flush_into(self, handler: logging.Handler) -> None:
         """Replay every buffered record through *handler*, then clear.
@@ -291,11 +303,23 @@ def scan_log(scan_number: int | None, scan_folder: str | None):
     # Pre-claim records (submission, connects, telemetry drops) replay into
     # the file first — they are chronologically earlier than everything the
     # live handler will see, and the handler's filter stamps them.
+    flushed = 0
     if buffer is not None:
+        flushed = len(buffer)
         buffer.flush_into(handler)
 
     root.addHandler(handler)
     try:
+        if flushed:
+            # The flush announces itself: the buffer is an unowned
+            # module-level slot (one scan at a time per process), so if a
+            # foreign scan ever consumes a submission's buffer, this line
+            # makes the theft visible.
+            logger.info(
+                "scan %s: opened with %d buffered pre-claim records",
+                scan_id,
+                flushed,
+            )
         logger.info("scan %s: starting (dir=%s)", scan_id, scan_folder)
         yield
         logger.info("scan %s: finished", scan_id)

--- a/GeecsBluesky/geecs_bluesky/scan_log.py
+++ b/GeecsBluesky/geecs_bluesky/scan_log.py
@@ -7,27 +7,151 @@ headless ``GeecsSession.run()`` scans had no scan.log because the helper was
 bridge-internal) so both front doors share one implementation — the session
 must not import the bridge.
 
-The handler captures the whole scan story, not just this package: during
-optimization scans the evaluator (``geecs_scanner.optimization``) and its
-analyzers (``scan_analysis``, ``image_analysis``) do the per-bin work, and
-their file-mapping / objective lines belong in ``scan.log`` too.
+The handler attaches to the **root logger**, so ``scan.log`` records the
+same story the process's terminal shows — ``bluesky`` RunEngine state
+changes, ``ophyd_async`` connect failures, ``geecs_data_utils`` folder and
+export lines — not just this package's namespaces.  The per-scan file must
+stay the complete record: once the engine runs inside a queueserver worker
+there is no operator-attached terminal, only a machine-global journal.
+
+Two mechanisms cover the window before the scan folder exists (the file
+cannot be created earlier, and the most diagnostic lines — submission,
+device connects, telemetry drops — happen there):
+
+- :func:`begin_pre_scan_capture` starts buffering root-logger records at
+  submission time (the bridge's ``reinitialize`` calls it; headless callers
+  may call it themselves).
+- :func:`scan_log` flushes that buffer into the file the moment it attaches,
+  and discards it on the no-claim paths (nothing was saved, so the buffered
+  lines have no per-scan home — they remain on the terminal/journal).
 """
 
 from __future__ import annotations
 
 import logging
+from collections import deque
 from contextlib import contextmanager
 from pathlib import Path
 
 logger = logging.getLogger(__name__)
 
-#: Logger namespaces captured into every scan.log (see module docstring).
-CAPTURE_LOGGER_NAMES = (
-    "geecs_bluesky",
-    "geecs_scanner.optimization",
-    "scan_analysis",
-    "image_analysis",
-)
+#: Maximum buffered pre-claim records (older records drop first).  Sized far
+#: above a real submission window (tens of lines); the cap only bounds a
+#: pathological reinitialize-then-never-start session.
+PRE_SCAN_BUFFER_CAPACITY = 2000
+
+#: Third-party transport chatter kept out of scan.log below WARNING (live
+#: finding, 2026-08-20 Scan001: Tiled's per-request httpx lines and MySQL
+#: auth-plugin loads added ~15 lines of non-scan-story noise per scan).
+#: Their WARNING+ records still land — only INFO chatter is dropped, and
+#: only from the scan.log capture, never from the terminal.
+QUIET_LOGGER_PREFIXES = ("httpx", "mysql.connector")
+
+
+class _QuietNoisyLoggers(logging.Filter):
+    """Drop sub-WARNING records from the known-noisy transport namespaces."""
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        """Keep *record* unless it is INFO-level transport chatter.
+
+        Parameters
+        ----------
+        record : logging.LogRecord
+            The record about to be captured.
+
+        Returns
+        -------
+        bool
+            ``False`` only for sub-WARNING records from
+            :data:`QUIET_LOGGER_PREFIXES` namespaces.
+        """
+        if record.levelno >= logging.WARNING:
+            return True
+        return not record.name.startswith(QUIET_LOGGER_PREFIXES)
+
+
+class PreScanLogBuffer(logging.Handler):
+    """Buffer root-logger records emitted before the scan folder exists.
+
+    A plain bounded buffer: :meth:`emit` appends, and :meth:`flush_into`
+    replays every held record through a target handler (whose own filters —
+    the scan-id stamp — apply on replay).  Never auto-flushes.
+    """
+
+    def __init__(self, capacity: int = PRE_SCAN_BUFFER_CAPACITY) -> None:
+        super().__init__(level=logging.INFO)
+        self.addFilter(_QuietNoisyLoggers())
+        self._records: deque[logging.LogRecord] = deque(maxlen=capacity)
+        #: Root-logger level before the capture lowered it (restored by
+        #: discard/take — record *creation* is gated by the root level, so
+        #: the capture window must run the root at INFO to see the story).
+        self.original_root_level: int = logging.NOTSET
+
+    def emit(self, record: logging.LogRecord) -> None:
+        """Hold *record* for a later :meth:`flush_into`.
+
+        Parameters
+        ----------
+        record : logging.LogRecord
+            The record to buffer.
+        """
+        self._records.append(record)
+
+    def flush_into(self, handler: logging.Handler) -> None:
+        """Replay every buffered record through *handler*, then clear.
+
+        Parameters
+        ----------
+        handler : logging.Handler
+            The destination handler (the scan.log file handler).
+        """
+        for record in self._records:
+            handler.handle(record)
+        self._records.clear()
+
+
+#: The at-most-one pending pre-scan buffer (one scan at a time per process).
+_pending_buffer: PreScanLogBuffer | None = None
+
+
+def begin_pre_scan_capture() -> None:
+    """Start buffering root-logger records for the next scan's ``scan.log``.
+
+    Called at submission time (bridge ``reinitialize`` / headless callers).
+    Any previous pending buffer is discarded first — a superseded submission
+    must not leak its lines into the next scan's file.
+    """
+    global _pending_buffer
+    discard_pre_scan_capture()
+    root = logging.getLogger()
+    buffer = PreScanLogBuffer()
+    buffer.original_root_level = root.level
+    if root.level == logging.NOTSET or root.level > logging.INFO:
+        root.setLevel(logging.INFO)
+    _pending_buffer = buffer
+    root.addHandler(buffer)
+
+
+def discard_pre_scan_capture() -> None:
+    """Drop any pending pre-scan buffer without writing it anywhere."""
+    _detach_pending_buffer()
+
+
+def _take_pending_buffer() -> PreScanLogBuffer | None:
+    """Detach and return the pending buffer (None when nothing is pending)."""
+    return _detach_pending_buffer()
+
+
+def _detach_pending_buffer() -> PreScanLogBuffer | None:
+    """Remove the pending buffer from the root logger, restoring its level."""
+    global _pending_buffer
+    buffer = _pending_buffer
+    if buffer is not None:
+        root = logging.getLogger()
+        root.removeHandler(buffer)
+        root.setLevel(buffer.original_root_level)
+        _pending_buffer = None
+    return buffer
 
 
 class ScanLogContextFilter(logging.Filter):
@@ -109,8 +233,10 @@ def scan_log(scan_number: int | None, scan_folder: str | None):
 
     A no-op when the scan number/folder are unknown (nothing was claimed —
     e.g. ``save_data=False`` or the NetApp is unreachable) or the folder
-    does not exist.  On exit the handler is removed and closed and every
-    captured logger's level is restored, even on abort.
+    does not exist; any pending pre-scan buffer is discarded on those paths.
+    On attach, buffered pre-claim records flush into the file first.  On
+    exit the handler is removed and closed and the root logger's level is
+    restored, even on abort.
 
     Parameters
     ----------
@@ -125,11 +251,13 @@ def scan_log(scan_number: int | None, scan_folder: str | None):
         Run the scan inside the ``with`` block.
     """
     if scan_number is None or scan_folder is None:
+        discard_pre_scan_capture()
         yield
         return
 
     folder = Path(scan_folder)
     if not folder.is_dir():
+        discard_pre_scan_capture()
         logger.warning("Scan folder %s does not exist; skipping scan.log", folder)
         yield
         return
@@ -145,19 +273,33 @@ def scan_log(scan_number: int | None, scan_folder: str | None):
         )
     )
     handler.addFilter(ScanLogContextFilter(scan_id))
+    handler.addFilter(_QuietNoisyLoggers())
 
-    capture_loggers = [logging.getLogger(name) for name in CAPTURE_LOGGER_NAMES]
-    old_levels = [lg.level for lg in capture_loggers]
-    for lg in capture_loggers:
-        if lg.level == logging.NOTSET or lg.level > logging.INFO:
-            lg.setLevel(logging.INFO)
-        lg.addHandler(handler)
+    # Take the pending buffer FIRST — it restores the pre-capture root level,
+    # so the save/restore below brackets the true original.
+    buffer = _take_pending_buffer()
+
+    # Root-logger attach: scan.log records what the terminal shows.  The
+    # root level is lowered to INFO for the scan (and restored) so records
+    # from NOTSET-level loggers reach the handler; loggers with an explicit
+    # higher level keep it — terminal parity, not extra verbosity.
+    root = logging.getLogger()
+    old_root_level = root.level
+    if root.level == logging.NOTSET or root.level > logging.INFO:
+        root.setLevel(logging.INFO)
+
+    # Pre-claim records (submission, connects, telemetry drops) replay into
+    # the file first — they are chronologically earlier than everything the
+    # live handler will see, and the handler's filter stamps them.
+    if buffer is not None:
+        buffer.flush_into(handler)
+
+    root.addHandler(handler)
     try:
         logger.info("scan %s: starting (dir=%s)", scan_id, scan_folder)
         yield
         logger.info("scan %s: finished", scan_id)
     finally:
-        for lg, old_level in zip(capture_loggers, old_levels):
-            lg.removeHandler(handler)
-            lg.setLevel(old_level)
+        root.removeHandler(handler)
+        root.setLevel(old_root_level)
         handler.close()

--- a/GeecsBluesky/geecs_bluesky/scanner_bridge/bluesky_scanner.py
+++ b/GeecsBluesky/geecs_bluesky/scanner_bridge/bluesky_scanner.py
@@ -276,7 +276,11 @@ class BlueskyScanner:
         # From here every log line belongs to the upcoming scan's story:
         # buffer root-logger records so scan.log can open with them once
         # the folder is claimed (a refused submission discards the buffer).
-        begin_pre_scan_capture()
+        # Guarded on the scan state: a protocol-violating mid-scan
+        # reinitialize must not steal the active scan's capture or snapshot
+        # the scan-lowered root level as "original".
+        if not self.is_scanning_active():
+            begin_pre_scan_capture()
         try:
             if request.mode is ScanRequestMode.OPTIMIZE and (
                 self._optimization_loader is None
@@ -442,11 +446,10 @@ class BlueskyScanner:
         Stop).  A thread that is genuinely stuck mid-plan still reports
         active: the flag is only set once the ``finally`` cleanup ran.
         """
+        # getattr: hermetic tests build bare scanners via __new__.
+        thread = getattr(self, "_scan_thread", None)
         return bool(
-            self._scan_thread
-            and self._scan_thread.is_alive()
-            # getattr: hermetic tests build bare scanners via __new__.
-            and not getattr(self, "_scan_finished", False)
+            thread and thread.is_alive() and not getattr(self, "_scan_finished", False)
         )
 
     def estimate_current_completion(self) -> float:

--- a/GeecsBluesky/geecs_bluesky/scanner_bridge/bluesky_scanner.py
+++ b/GeecsBluesky/geecs_bluesky/scanner_bridge/bluesky_scanner.py
@@ -54,6 +54,7 @@ from typing import Any, Callable
 
 from geecs_bluesky.devices.ca._pv import GATEWAY_DISCONNECTED
 from geecs_bluesky.exceptions import GeecsConfigurationError
+from geecs_bluesky.scan_log import begin_pre_scan_capture, discard_pre_scan_capture
 
 # Bound at module level (not via the events module) because hermetic tests
 # monkeypatch these names — the `is None` guards downstream are that seam.
@@ -272,25 +273,33 @@ class BlueskyScanner:
         if resolver is None:
             resolver = ConfigsRepoResolver(self._experiment_dir)
 
-        if request.mode is ScanRequestMode.OPTIMIZE and (
-            self._optimization_loader is None
-        ):
-            raise NotImplementedError(
-                "optimize-mode ScanRequest execution through BlueskyScanner "
-                "needs the GUI-injected optimization_loader (the config-"
-                "driven Xopt/evaluator stack lives in geecs_scanner."
-                "optimization, which this package cannot import); construct "
-                "the scanner with optimization_loader=..., or run headless "
-                "via GeecsSession.run(request, resolver, objective=..., "
-                "suggester=...)"
-            )
+        # From here every log line belongs to the upcoming scan's story:
+        # buffer root-logger records so scan.log can open with them once
+        # the folder is claimed (a refused submission discards the buffer).
+        begin_pre_scan_capture()
+        try:
+            if request.mode is ScanRequestMode.OPTIMIZE and (
+                self._optimization_loader is None
+            ):
+                raise NotImplementedError(
+                    "optimize-mode ScanRequest execution through BlueskyScanner "
+                    "needs the GUI-injected optimization_loader (the config-"
+                    "driven Xopt/evaluator stack lives in geecs_scanner."
+                    "optimization, which this package cannot import); construct "
+                    "the scanner with optimization_loader=..., or run headless "
+                    "via GeecsSession.run(request, resolver, objective=..., "
+                    "suggester=...)"
+                )
 
-        # Fail-fast validation through THE one definition of "what must
-        # resolve" (scan_request_runner.validate_scan_request, issue #529);
-        # results are discarded — run_scan_request re-resolves at execution
-        # time (it runs the same function as its own first phase, so this
-        # submission-time check can never drift from execution).
-        validate_scan_request(request, resolver)
+            # Fail-fast validation through THE one definition of "what must
+            # resolve" (scan_request_runner.validate_scan_request, issue #529);
+            # results are discarded — run_scan_request re-resolves at execution
+            # time (it runs the same function as its own first phase, so this
+            # submission-time check can never drift from execution).
+            validate_scan_request(request, resolver)
+        except Exception:
+            discard_pre_scan_capture()
+            raise
 
         # Store the ORIGINAL pre-defaults request (see docstring).
         self._scan_request = request
@@ -1038,6 +1047,9 @@ class BlueskyScanner:
             # state, so a consumer reacting to DONE/ABORTED observes
             # is_scanning_active() == False (see its docstring).  The runner's
             # own ``finally`` disconnected everything it created.
+            # A pre-scan log buffer not consumed by a scan.log attach
+            # (failure before the claim) must not leak into a later scan.
+            discard_pre_scan_capture()
             self._scan_finished = True
             if self._abort_requested or failed:
                 self._set_state("ABORTED")

--- a/GeecsBluesky/geecs_bluesky/session.py
+++ b/GeecsBluesky/geecs_bluesky/session.py
@@ -1224,21 +1224,34 @@ class GeecsSession:
         str or None
             The Bluesky run uid (``None`` when nothing was persisted).
         """
+        from geecs_bluesky.scan_log import (
+            begin_pre_scan_capture,
+            discard_pre_scan_capture,
+        )
         from geecs_bluesky.scan_request_runner import (
             ConfigsRepoResolver,
             run_scan_request,
         )
 
-        if resolver is None:
-            resolver = ConfigsRepoResolver(self.experiment)
-        return run_scan_request(
-            self,
-            request,
-            resolver,
-            objective=objective,
-            suggester=suggester,
-            device_requirements=device_requirements,
-        )
+        # Buffer pre-claim log lines (validation, device connects, telemetry
+        # drops) so scan.log opens with them; the bridge path starts its
+        # buffer earlier, at reinitialize.  A buffer not consumed by a
+        # scan.log attach (failure before the claim) is discarded — it must
+        # never leak into a later scan's file.
+        begin_pre_scan_capture()
+        try:
+            if resolver is None:
+                resolver = ConfigsRepoResolver(self.experiment)
+            return run_scan_request(
+                self,
+                request,
+                resolver,
+                objective=objective,
+                suggester=suggester,
+                device_requirements=device_requirements,
+            )
+        finally:
+            discard_pre_scan_capture()
 
     # ------------------------------------------------------------------
     # On-demand actions (G-actions v1)

--- a/GeecsBluesky/pyproject.toml
+++ b/GeecsBluesky/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-bluesky"
-version = "0.50.1"
+version = "0.51.0"
 description = "Bluesky / ophyd-async bridge for the GEECS control system"
 authors = ["Sam Barber <sbarber@lbl.gov>"]
 readme = "README.md"

--- a/GeecsBluesky/tests/test_scan_log.py
+++ b/GeecsBluesky/tests/test_scan_log.py
@@ -96,28 +96,50 @@ def test_scan_log_quiets_transport_chatter(tmp_path) -> None:
     with scan_log(14, str(folder)):
         logging.getLogger("httpx").info("HTTP Request: POST /api/v1/metadata")
         logging.getLogger("mysql.connector").info("plugin_name: sha2")
+        logging.getLogger("mysql.connector.plugins").info("AUTH_PLUGIN_CLASS: x")
         logging.getLogger("httpx").warning("retrying after timeout")
+        # Sibling namespaces that merely share a string prefix are NOT quieted.
+        logging.getLogger("httpx_sse").info("sse stream opened")
     content = (folder / "scan.log").read_text()
     assert "HTTP Request" not in content
     assert "plugin_name" not in content
+    assert "AUTH_PLUGIN_CLASS" not in content
     assert "retrying after timeout" in content
+    assert "sse stream opened" in content
 
 
 def test_pre_scan_buffer_flushes_into_scan_log(tmp_path) -> None:
-    """Records emitted between submission and the folder claim open the file."""
+    """Records emitted between submission and the folder claim open the file.
+
+    Runs with the root at WARNING so the level bookkeeping is observable:
+    the capture must lower the root to INFO (or the story is never emitted)
+    and the exit must restore the TRUE pre-capture level — pinning the
+    take-buffer-before-saving-root-level ordering in ``scan_log``.
+    """
     folder = tmp_path / "Scan011"
     folder.mkdir()
-    begin_pre_scan_capture()
-    module_logger.info("reinitialised from ScanRequest")
-    logging.getLogger("ophyd_async.core").warning("telemetry device dropped")
-    with scan_log(11, str(folder)):
-        module_logger.info("mid-scan line")
+    root = logging.getLogger()
+    old_level = root.level
+    root.setLevel(logging.WARNING)
+    try:
+        begin_pre_scan_capture()
+        module_logger.info("reinitialised from ScanRequest")
+        logging.getLogger("ophyd_async.core").warning("telemetry device dropped")
+        with scan_log(11, str(folder)):
+            module_logger.info("mid-scan line")
+        # The WARNING root from before the capture is restored — not the
+        # INFO the capture/scan window ran at.
+        assert root.level == logging.WARNING
+    finally:
+        root.setLevel(old_level)
     content = (folder / "scan.log").read_text()
     # Buffered lines appear, stamped, and BEFORE the "starting" banner.
     assert "reinitialised from ScanRequest" in content
     assert "telemetry device dropped" in content
     assert content.index("reinitialised") < content.index("Scan011: starting")
     assert "scan=Scan011" in content.splitlines()[0]
+    # The flush announces itself with the record count.
+    assert "opened with 2 buffered pre-claim records" in content
     # The buffer handler is gone from the root logger after the attach.
     assert not any(
         type(h).__name__ == "PreScanLogBuffer" for h in logging.getLogger().handlers

--- a/GeecsBluesky/tests/test_scan_log.py
+++ b/GeecsBluesky/tests/test_scan_log.py
@@ -11,9 +11,21 @@ import logging
 
 import pytest
 
-from geecs_bluesky.scan_log import scan_log
+from geecs_bluesky.scan_log import (
+    begin_pre_scan_capture,
+    discard_pre_scan_capture,
+    scan_log,
+)
 
 module_logger = logging.getLogger("geecs_bluesky.tests.scan_log")
+
+
+@pytest.fixture(autouse=True)
+def _no_leftover_buffer():
+    """Every test starts and ends without a pending pre-scan buffer."""
+    discard_pre_scan_capture()
+    yield
+    discard_pre_scan_capture()
 
 
 def test_scan_log_writes_stamped_lines(tmp_path) -> None:
@@ -47,14 +59,102 @@ def test_scan_log_missing_folder_warns_and_skips(tmp_path, caplog) -> None:
 def test_scan_log_detaches_and_restores_levels(tmp_path) -> None:
     folder = tmp_path / "Scan008"
     folder.mkdir()
-    pkg_logger = logging.getLogger("geecs_bluesky")
-    before_level = pkg_logger.level
-    before_handlers = list(pkg_logger.handlers)
+    root = logging.getLogger()
+    before_level = root.level
+    before_handlers = list(root.handlers)
     with pytest.raises(RuntimeError, match="mid-scan"):
         with scan_log(8, str(folder)):
             raise RuntimeError("mid-scan failure")
-    assert pkg_logger.level == before_level
-    assert pkg_logger.handlers == before_handlers
+    assert root.level == before_level
+    assert root.handlers == before_handlers
     # Post-exit records do not land in the file.
     module_logger.info("after the scan")
     assert "after the scan" not in (folder / "scan.log").read_text()
+
+
+def test_scan_log_captures_foreign_namespaces(tmp_path) -> None:
+    """scan.log records the whole process story (root attach), not an
+    allowlist — RunEngine state changes and ophyd connect failures included."""
+    folder = tmp_path / "Scan010"
+    folder.mkdir()
+    with scan_log(10, str(folder)):
+        logging.getLogger("bluesky").info("Change state from 'idle' -> 'running'")
+        logging.getLogger("ophyd_async.core").warning("NotConnectedError: ca://x")
+        logging.getLogger("geecs_data_utils.tiled_export").info("Wrote s-file")
+    content = (folder / "scan.log").read_text()
+    assert "idle' -> 'running'" in content
+    assert "NotConnectedError" in content
+    assert "Wrote s-file" in content
+    # Foreign records are stamped with the scan id too.
+    assert content.count("scan=Scan010") >= 5
+
+
+def test_scan_log_quiets_transport_chatter(tmp_path) -> None:
+    """httpx / mysql.connector INFO chatter stays out; their WARNINGs land."""
+    folder = tmp_path / "Scan014"
+    folder.mkdir()
+    with scan_log(14, str(folder)):
+        logging.getLogger("httpx").info("HTTP Request: POST /api/v1/metadata")
+        logging.getLogger("mysql.connector").info("plugin_name: sha2")
+        logging.getLogger("httpx").warning("retrying after timeout")
+    content = (folder / "scan.log").read_text()
+    assert "HTTP Request" not in content
+    assert "plugin_name" not in content
+    assert "retrying after timeout" in content
+
+
+def test_pre_scan_buffer_flushes_into_scan_log(tmp_path) -> None:
+    """Records emitted between submission and the folder claim open the file."""
+    folder = tmp_path / "Scan011"
+    folder.mkdir()
+    begin_pre_scan_capture()
+    module_logger.info("reinitialised from ScanRequest")
+    logging.getLogger("ophyd_async.core").warning("telemetry device dropped")
+    with scan_log(11, str(folder)):
+        module_logger.info("mid-scan line")
+    content = (folder / "scan.log").read_text()
+    # Buffered lines appear, stamped, and BEFORE the "starting" banner.
+    assert "reinitialised from ScanRequest" in content
+    assert "telemetry device dropped" in content
+    assert content.index("reinitialised") < content.index("Scan011: starting")
+    assert "scan=Scan011" in content.splitlines()[0]
+    # The buffer handler is gone from the root logger after the attach.
+    assert not any(
+        type(h).__name__ == "PreScanLogBuffer" for h in logging.getLogger().handlers
+    )
+
+
+def test_pre_scan_buffer_discarded_on_no_claim(tmp_path) -> None:
+    """A buffer with no scan.log home never leaks into a later scan's file."""
+    begin_pre_scan_capture()
+    module_logger.info("from the unclaimed attempt")
+    with scan_log(None, None):
+        pass  # save_data=False path — discards the buffer
+    folder = tmp_path / "Scan012"
+    folder.mkdir()
+    with scan_log(12, str(folder)):
+        module_logger.info("second scan line")
+    content = (folder / "scan.log").read_text()
+    assert "from the unclaimed attempt" not in content
+    assert "second scan line" in content
+
+
+def test_begin_pre_scan_capture_supersedes_previous_buffer(tmp_path) -> None:
+    """A re-submission's buffer replaces the stale one, lines and handler both."""
+    begin_pre_scan_capture()
+    module_logger.info("stale submission line")
+    begin_pre_scan_capture()
+    module_logger.info("fresh submission line")
+    buffers = [
+        h
+        for h in logging.getLogger().handlers
+        if type(h).__name__ == "PreScanLogBuffer"
+    ]
+    assert len(buffers) == 1
+    folder = tmp_path / "Scan013"
+    folder.mkdir()
+    with scan_log(13, str(folder)):
+        pass
+    content = (folder / "scan.log").read_text()
+    assert "stale submission line" not in content
+    assert "fresh submission line" in content

--- a/Planning/cutover_strategy/02_queueserver_migration.md
+++ b/Planning/cutover_strategy/02_queueserver_migration.md
@@ -1,0 +1,195 @@
+# Queueserver adoption — engine service-ification scope (2026-08-19)
+
+Decided 2026-08-19 (maintainer + agent discussion, held in the OSPREY
+deployment session; full GeecsBluesky subsystem trace at repo tip
+`c8aed444`). This note resolves the REPLACE-WITH-STANDARD line in
+`01_gui_feature_inventory.md` (MultiScanner → bluesky-queueserver) into a
+concrete scope — and widens it: the queueserver is not just MultiScanner's
+replacement, it is the engine's **service surface**. The driver is
+multi-client execution: GEECS-Console, a future web panel, and an external
+agent framework (OSPREY, deployed for HTU) all become peer clients of one
+RE Manager. Every one of those clients is gated on the same move — the RE
+leaves the console's process.
+
+## What the trace found (classification: where does it execute?)
+
+- **(A)** inside plan generators / ophyd-async devices → runs unchanged in
+  a headless worker
+- **(B)** host-process machinery around the RE → relocates to worker
+  startup or a plan preamble; mechanical
+- **(C)** crosses to a human/GUI mid-run → no stock equivalent; redesign
+  or drop
+
+| Subsystem | Class | Verdict |
+|---|---|---|
+| step / free-run / single-shot / t0-sync / adaptive plans | A | port unchanged — the bespoke acquisition physics is *not* the problem |
+| shot-control stubs (`arm`/`disarm`/`quiesce`/`fire`, `shot_controller.py:195-290`) | A | port unchanged |
+| `save_enable_plan` + save-off finalize (`plans/run_wrapper.py:83-129`) | A | port unchanged (note: `os.makedirs` inside the plan) |
+| `action_compiler` (`plans/action_compiler.py:160`) | A | cleanest piece in the package — pure generator, factory-injected |
+| per-row telemetry read (`devices/ca/telemetry.py`) | A | port unchanged |
+| `run_scan_request` prologue (~370 lines, `scan_request_runner.py:1350-1597`) | B | **the** refactor target — see "the one structural task" |
+| per-scan device construction + connect on `RE._loop` (`session.py:227-235`) | B | moves inside the plan preamble (`ensure_connected`) |
+| `ShotController` construction + `connect_setters` (`session.py:559-605`) | B | worker startup / preamble |
+| `claim_scan_number` + scan-folder creation (`run_wrapper.py:43-74`) | B | relocates into the worker preamble (worker needs the share) |
+| TiledWriter subscription (`session.py:217`) | B | trivially moves to worker startup |
+| s-file export (`session.py:1672-1685`, post-`RE()`, uid-dependent) | B | becomes a stop-document callback |
+| telemetry selection / DB policy / asset config (MySQL `GeecsDb`) | B | worker startup; all already failure-tolerant |
+| `trigger_profile`/`trigger_variant` resolution | B | name+variant are already JSON; resolution moves worker-side |
+| preflight dialogs (unserved / liveness / staleness, `preflight.py`) | B+C | logic portable; dialogs move **client-side pre-submit** (they run pre-claim today) |
+| `OperatorChannel` / `DialogRequest` transport (`events.py:115-154`) | C | deleted — see decisions |
+| `action_direct` + pause-window actions (`action_direct.py`, `pause_supervisor.py:316-351`) | C | **dropped** — see decisions |
+| `BlueskyScanner` thread/flags/progress (`scanner_bridge/bluesky_scanner.py`) | C | deleted — RE Manager's queue/status API *is* this |
+| optimize ask/tell loop (`session.py:1009-1047`, `plans/optimize.py`) | B | moves wholesale into the worker — see decisions |
+
+Test posture: everything above is hermetically covered except the bridge
+(whose tests pin GUI-thread semantics and die with the bridge) — the
+migration works over a tested core.
+
+## Decisions (2026-08-19, maintainer)
+
+1. **Pause means quiesce.** "Stop triggering" is already a plan stub;
+   pause semantics become plan-level pause handling (checkpoints placed so
+   rewind is safe, quiesce on pause). The pause *supervisor* otherwise
+   deletes.
+2. **Pause-window actions are dropped.** Rationale: a paused RE never
+   locks the machine — manual intervention via Phoebus/GEECS GUIs works
+   during pause exactly as it always has, so the *capability* survives;
+   what `action_direct` added was a formalized in-engine path, judged not
+   worth its migration cost. Actions become ordinary queue items; the
+   manager's state-gating ("a scan is paused — resume or stop first")
+   replaces the bespoke interlock. Known trade, accepted: long scans lose
+   fix-and-resume (stop → action → restart claims a new scan number).
+   Deletes with this decision: `action_direct.py`, the three-way
+   `ActionDecisionRequest` dialog, most of `pause_supervisor.py`.
+3. **Preflight questions move to the client, pre-submit.** They run
+   pre-claim today, so nothing about them is mid-run; in the queue world
+   the console runs the checks and asks the operator with ordinary
+   synchronous GUI code *before* queueing. The cross-thread
+   `DialogRequest`/`threading.Event` transport and `NullOperator`
+   layering delete.
+4. **Mid-run operator interaction reduces to the stock pause verbs.** The
+   remaining mid-run question ("didn't reach position — continue or
+   not?") is binary and maps 1:1: plan catches the failed move status,
+   records the reason, `bps.pause()`; clients render the paused state;
+   resume = retry from checkpoint, stop = end gracefully. No structured
+   question side channel is needed.
+5. **Optimization stays in-worker; the loader call moves, not the code.**
+   `OptimizationSpec` is already a Pydantic schema in `geecs_schemas`
+   (rides in ScanRequest — JSON by construction) and the console's
+   `optimization_loader` (`GEECS-Console/geecs_console/services/
+   optimization.py`) is already a config→Xopt-stack factory. The
+   queueserver change is only the injection site: the worker preamble
+   invokes the loader when `request.optimization` is present, instead of
+   the GUI injecting live objects into the bridge. Keeping ask/tell
+   in-worker preserves one-scan-one-number. bluesky-adaptive is *not*
+   adopted now; it remains the future shape for cross-scan campaigns
+   (where each evaluation legitimately is its own scan).
+   Prerequisite: the Xopt/evaluator stack relocates out of legacy
+   `geecs_scanner.optimization` into an importable-headless home —
+   already implied by the M6 deletion of GEECS-Scanner-GUI.
+
+## The one structural task
+
+There is no plan generator meaning "run this ScanRequest" —
+`run_scan_request()` is a plain function that builds/connects devices,
+claims the scan number, then calls `session.scan`, which builds the plan
+and calls `RE`. Queueserver registers plans by name with JSON args, so the
+new unit is:
+
+    def geecs_scan_request_plan(request: dict):  # ScanRequest.model_dump()
+        # prologue as plan preamble, inside the worker:
+        # validate → resolve save sets/actions/trigger → construct+connect
+        # devices → claim scan number → inner plans exactly as today
+
+This **dissolves the serialization question**: bound methods and closures
+(ShotController stubs, per-step callables, the optimize loader's output)
+never cross a process boundary — the preamble constructs them worker-side
+from the JSON request. The prologue is mostly pure, tested functions;
+this is relocation, not rewrite.
+
+## Scope
+
+**Build**
+- `geecs_scan_request_plan` preamble (above)
+- quiesce-on-pause plan logic + checkpoint placement
+- worker startup script: config.ini, `EPICS_CA_ADDR_LIST` *before*
+  `geecs_bluesky` import (`__init__.py:12` contract), TiledWriter
+  subscription, ZMQ document publisher (replaces bridge-derived progress
+  events for GUIs), scan-log handler, optimization loader registration
+- s-file export as a stop-document callback
+
+**Relocate**
+- Xopt/evaluator stack out of `geecs_scanner.optimization` (couples to M6)
+
+**Delete**
+- `BlueskyScanner` thread/state/progress machinery and its tests
+- `action_direct.py`, `ActionDecisionRequest`, most of `pause_supervisor`
+- `OperatorChannel` transport (`DialogRequest` events/threading)
+
+**Console (client refactor)**
+- pre-submit preflight (keeps its dialogs as plain GUI code)
+- queue submission via manager API; paused-state rendering (device-error
+  Continue/Abort dialog renders `re_state: paused` + recorded reason)
+- progress from the ZMQ document stream (also re-drives per-shot beeps,
+  per `01` RE-HOME)
+- MultiScanner capability = the queue itself (closes `01`'s
+  REPLACE-WITH-STANDARD line)
+
+## Worker environment requirements
+
+The worker runs where the console runs today: lab network (CA gateway
+reachable), NetApp share mounted (scan-folder claim + ScanInfo writes),
+MySQL reachable, `~/.config/geecs_python_api/config.ini` present,
+`GEECS_SCANNER_CONFIG_DIR` → configs repo. Queueserver control-plane
+security (CurveZMQ keypair) is new operational surface — key management is
+an open item below.
+
+## Open items
+
+- CurveZMQ key management / who may submit (auth model per client).
+- Verify manager behavior details before build: function-execution while
+  paused (not relied on — informational), deferred-pause boundaries with
+  GEECS blocking puts.
+- Resumable long scans: dropping pause-window actions makes
+  stop→fix→restart the recovery path; if operationally painful, the answer
+  is resumable scan design (progress checkpointing), not resurrecting
+  `action_direct`.
+- Manual-intervention provenance: PV changes made from Phoebus during a
+  pause are recorded by readbacks/telemetry but not annotated; consider a
+  console habit or annotation hook.
+
+## Amendments from the console test-scan review (2026-08-20)
+
+- **scan.log is the worker's per-scan record — built early, on purpose.**
+  The 2026-08-19 test scans showed scan.log, the terminal, and the GUI
+  ticker telling three different stories; the terminal was the only
+  complete one, and under a worker the "terminal" is a machine-global
+  journal. Landed pre-migration (GeecsBluesky 0.51.0, cleanup pass):
+  `scan_log.py` now attaches at the **root logger** and a pre-claim buffer
+  (started at submission) opens the file with the connects/telemetry-drop
+  window. The doc's "scan-log handler" worker-startup build item is
+  therefore this existing mechanism relocated, not new design. Client-side
+  pre-submit lines (preflight answers) stay client-side by decision 3 —
+  the client stamps outcomes into request metadata, not into scan.log.
+- **`reinitialize` disposition (bridge deletion detail).** Its essential
+  content is already the plan's first phase: the fail-fast
+  `validate_scan_request` call is the same function `run_scan_request`
+  runs at execution (issue #529, no-drift by construction). Under the
+  queue it runs twice by design — authoritative in the worker preamble,
+  and **client-side pre-submit** for immediate feedback (a queue makes
+  submission-to-execution gaps long; a typo must fail at submit, not at
+  queue-front). The optimize-loader presence check becomes a
+  worker-startup fact (decision 5); request storage and progress counters
+  delete (the queue item and the document stream own them). No
+  "validation plan stub" — it would run at the same moment as the
+  preamble anyway and costs queue-item atomicity.
+
+## External context (informational)
+
+The HTU OSPREY deployment (separate repo) integrates against this repo
+read-only today (Tiled, scan folders, analysis outputs, log triage) and
+composes ScanRequests without executing them. When the queueserver exists,
+OSPREY attaches its bluesky bridge to it and the agent becomes another
+peer client, subject to the same queue and review semantics as every other
+client. Nothing in this migration depends on OSPREY; the ordering benefit
+is one-directional.


### PR DESCRIPTION
## What + why

The 2026-08-19 console test scans showed three surfaces telling three different stories: the terminal (complete), `scan.log` (a four-namespace allowlist attached only after the folder claim — missing the 13-second pre-claim window and every foreign namespace), and the GUI ticker (a progress event stream, fine as-is). The terminal being the only complete record is an accident that dies with the queueserver migration, where the engine's "terminal" becomes a machine-global systemd journal.

This PR makes `scan.log` the complete per-scan record:

- **Root-logger capture**: the per-scan file handler attaches at the root, so `bluesky` RE state changes, `ophyd_async` connect-failure tracebacks, and `geecs_data_utils` folder/export lines land in the file — terminal parity. Root level lowered to INFO for the scan and restored; `CAPTURE_LOGGER_NAMES` deleted (no external importers; it had already gone stale — `tiled_export` was never in it).
- **Pre-claim buffer**: `begin_pre_scan_capture()` starts a bounded buffer at submission (`reinitialize` / `session.run`) and `scan_log()` flushes it into the file at the claim, so the file opens with device connects, telemetry drops, and the claim itself. A buffer with no scan.log home (refused submission, `save_data=False`, pre-claim failure) is discarded on every path — never leaked into a later scan's file.

## Judgment-call flags (cheap to veto)

1. **`QUIET_LOGGER_PREFIXES = ("httpx", "mysql.connector")`** — live Scan001 showed ~15 lines/scan of Tiled HTTP request and MySQL auth-plugin chatter. Filtered below WARNING from the scan.log capture only (terminal untouched, WARNING+ still lands). If you want strict verbatim capture, deleting the filter is one line.
2. **Planning doc rides along** (separate commit): `Planning/cutover_strategy/02_queueserver_migration.md` — the 2026-08-19 scope doc (previously untracked) + 2026-08-20 amendments (scan.log worker story, `reinitialize` disposition).

## Per-concern LOC

- scan.log unification (GeecsBluesky): ~360 insertions / 58 deletions across 7 files (scan_log.py rewrite + 2 attach points + tests + version/CHANGELOG/CLAUDE.md)
- planning doc: +195 lines, docs only

## Tests

- `test_scan_log.py`: 11 pass (5 new: foreign-namespace capture, buffer flush ordering + stamp, no-claim discard, superseded-buffer reset, transport-chatter filter)
- GeecsBluesky full suite: **644 passed**, 3 deselected
- `check.sh --all`: all suites green (787+53+644+…), repo-wide pre-commit green

## Hardware verification (live, 2026-08-20, lab network)

Two real strict-mode noscan runs via `test_scan_request_hardware.py` (HTU-LaserOFF profile, 5 shots @ 1 Hz):

- **Scan001**: scan.log opens pre-claim — shot-control attach, the `U_GhostLowPowerWFS` soft-telemetry drop **with full NotConnectedError traceback** (previously terminal-only), folder claim — through RE state changes to the s-file export line. Exposed the httpx/mysql chatter → flag 1.
- **Scan002** (with filter): 54 lines, **0** transport-chatter lines, same complete story, all stamped `scan=Scan002`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)