### PR TITLE
GEECS-Console 0.20.1: R6 log tail dedupes consecutive narration lines

### DIFF
--- a/GEECS-Console/CHANGELOG.md
+++ b/GEECS-Console/CHANGELOG.md
@@ -9,12 +9,17 @@ semantic.
 ### Fixed
 
 - R6 log tail no longer prints duplicate lines (field report, 2026-08-19
-  Scan004: "scan running" twice and the final step line twice): the
-  events adapter's narration now suppresses exact consecutive repeats,
-  and the bridge's deliberate RUNNING re-emission (once the scan number
-  is claimed) narrates as new information — "scan running (Scan004)".
-  Data signals (state pill, progress bar, scan number) are never
-  deduped, only the human-readable tail.
+  Scan004: "scan running" twice and the final step line twice).
+  Consecutive-duplicate suppression lives at the tail's one convergence
+  point — `NowPanelController.append_log` — so it measures against the
+  actually visible tail (the adapter's narration AND the window's direct
+  status lines both flow through it; PR #624 review finding 1), and the
+  cache re-arms when a new scan announces its totals so scan N's last
+  line can never swallow scan N+1's first (finding 3). Separately, every
+  post-claim lifecycle line now carries the scan number — "scan running
+  (Scan004)", "scan done (Scan004)" — which renders the bridge's
+  deliberate RUNNING re-emission as new information. Data signals (state
+  pill, progress bar, scan number) are never deduped.
 
 ## [0.20.0] - 2026-08-20
 

--- a/GEECS-Console/CHANGELOG.md
+++ b/GEECS-Console/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to GEECS-Console are documented here.  Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versioning is
 semantic.
 
+## [0.20.1] - 2026-08-20
+
+### Fixed
+
+- R6 log tail no longer prints duplicate lines (field report, 2026-08-19
+  Scan004: "scan running" twice and the final step line twice): the
+  events adapter's narration now suppresses exact consecutive repeats,
+  and the bridge's deliberate RUNNING re-emission (once the scan number
+  is claimed) narrates as new information — "scan running (Scan004)".
+  Data signals (state pill, progress bar, scan number) are never
+  deduped, only the human-readable tail.
+
 ## [0.20.0] - 2026-08-20
 
 ### Changed

--- a/GEECS-Console/CLAUDE.md
+++ b/GEECS-Console/CLAUDE.md
@@ -50,10 +50,13 @@ are prefixed by region (`r3_radio_1d`, `r5_start_button`, …).
   `ScanEvent` stream built in `events_adapter.handle` — per-shot lines
   are event *documents*, emitted at ``bps.save()`` (end of shot, *after*
   the per-shot CA reads that ride the VPN) and delivered queued; the
-  narration suppresses exact consecutive repeats (0.20.1 — the engine
-  legitimately re-emits e.g. the final step event) and renders the
-  bridge's claimed-number RUNNING re-emission as "scan running
-  (Scan NNN)"; data signals never dedupe; the
+  tail suppresses exact consecutive repeats at its convergence point,
+  `NowPanelController.append_log` (0.20.1 — both the adapter narration
+  and the window's direct status lines flow through it; the cache
+  re-arms on set_totals so a new scan's first line always renders), and
+  every post-claim lifecycle line carries the scan number ("scan
+  running (Scan NNN)", "scan done (Scan NNN)"); data signals never
+  dedupe; the
   terminal/file log's lines fire synchronously at the point of action
   (e.g. `SINGLESHOT` logs at shot *start*).  Same process, no network
   between engine and GUI — the VPN latency enters upstream, in when the

--- a/GEECS-Console/CLAUDE.md
+++ b/GEECS-Console/CLAUDE.md
@@ -50,6 +50,10 @@ are prefixed by region (`r3_radio_1d`, `r5_start_button`, …).
   `ScanEvent` stream built in `events_adapter.handle` — per-shot lines
   are event *documents*, emitted at ``bps.save()`` (end of shot, *after*
   the per-shot CA reads that ride the VPN) and delivered queued; the
+  narration suppresses exact consecutive repeats (0.20.1 — the engine
+  legitimately re-emits e.g. the final step event) and renders the
+  bridge's claimed-number RUNNING re-emission as "scan running
+  (Scan NNN)"; data signals never dedupe; the
   terminal/file log's lines fire synchronously at the point of action
   (e.g. `SINGLESHOT` logs at shot *start*).  Same process, no network
   between engine and GUI — the VPN latency enters upstream, in when the

--- a/GEECS-Console/geecs_console/app/now_panel.py
+++ b/GEECS-Console/geecs_console/app/now_panel.py
@@ -91,6 +91,10 @@ class NowPanelController(QObject):
         #: Total shots announced by the running scan (0 = not announced).
         self._total_shots = 0
 
+        #: Bottom line of the log tail (consecutive-duplicate suppression;
+        #: re-armed by set_totals — see append_log).
+        self._last_log_line: Optional[str] = None
+
         self._scan_number_timer = QTimer(self)
         self._scan_number_timer.setSingleShot(True)
         self._scan_number_timer.setInterval(_SCAN_NUMBER_EXPIRY_MS)
@@ -113,11 +117,24 @@ class NowPanelController(QObject):
     def append_log(self, line: str) -> None:
         """Append one line to the compact log tail.
 
+        The tail is a narration, not a record: an exact repeat of the
+        line currently at the bottom adds nothing for the operator, so
+        consecutive duplicates are dropped.  Deduping HERE — the one
+        point every tail writer converges on (the events adapter's
+        narration and the window's direct status lines) — makes
+        "consecutive" mean consecutive-in-the-tail (PR #624 review
+        finding 1).  The cache re-arms on :meth:`set_totals` (a new
+        scan announcing itself), so scan N's last line can never
+        swallow scan N+1's first.
+
         Parameters
         ----------
         line : str
             The text to append (one log-tail row).
         """
+        if line == self._last_log_line:
+            return
+        self._last_log_line = line
         self._log_tail.appendPlainText(line)
 
     def set_scan_number(self, number: int) -> None:
@@ -224,6 +241,9 @@ class NowPanelController(QObject):
             The scan's announced shot total.
         """
         self._total_shots = total_shots
+        # New scan announcing itself: re-arm the tail dedupe so the last
+        # line of the previous scan can never swallow this scan's first.
+        self._last_log_line = None
         self._progress_bar.setMaximum(max(1, total_shots))
         self._progress_bar.setValue(0)
 

--- a/GEECS-Console/geecs_console/events_adapter.py
+++ b/GEECS-Console/geecs_console/events_adapter.py
@@ -49,25 +49,6 @@ class ScanEventsAdapter(QObject):
     the GUI slot answers on the main thread and sets that event to unblock it.
     """
 
-    def __init__(self, parent: Any = None) -> None:
-        super().__init__(parent)
-        #: Last line sent to the log tail (consecutive-duplicate suppression).
-        self._last_narrated: str | None = None
-
-    def _narrate(self, line: str) -> None:
-        """Emit *line* on ``log_line`` unless it repeats the previous line.
-
-        The log tail is a narration, not a record: two consecutive events
-        whose rendered text is identical (the engine legitimately re-emits
-        e.g. the final step event) add nothing for the operator, so exact
-        consecutive repeats are dropped.  Only the narration dedupes — the
-        data signals (``state_changed``, ``progress``, …) always emit.
-        """
-        if line == self._last_narrated:
-            return
-        self._last_narrated = line
-        self.log_line.emit(line)
-
     def handle(self, event: Any) -> None:
         """Consume one engine event (the ``on_event`` callback).
 
@@ -88,29 +69,33 @@ class ScanEventsAdapter(QObject):
             scan_number = getattr(event, "scan_number", None)
             if scan_number is not None:
                 self.scan_number_known.emit(int(scan_number))
-            # The bridge re-emits RUNNING once the scan number is claimed —
-            # narrate that as new information, not a duplicate line.
+            # Post-claim, EVERY lifecycle emission carries the scan number
+            # (the bridge stamps it) — narrate it on each state line, which
+            # also renders the bridge's deliberate RUNNING re-emission as
+            # new information rather than a duplicate.  Consecutive-dup
+            # suppression itself lives at the tail's convergence point
+            # (NowPanelController.append_log), not here.
             if scan_number is not None:
-                self._narrate(f"scan {state_text} (Scan{int(scan_number):03d})")
+                self.log_line.emit(f"scan {state_text} (Scan{int(scan_number):03d})")
             else:
-                self._narrate(f"scan {state_text}")
+                self.log_line.emit(f"scan {state_text}")
         elif kind == "ScanStepEvent":
             step_index = int(getattr(event, "step_index", 0))
             total_steps = int(getattr(event, "total_steps", 0))
             shots_completed = int(getattr(event, "shots_completed", 0))
             self.progress.emit(step_index, total_steps, shots_completed)
             phase = getattr(event, "phase", "")
-            self._narrate(
+            self.log_line.emit(
                 f"step {step_index + 1}/{total_steps} {phase} ({shots_completed} shots)"
             )
         elif kind == "ScanErrorEvent":
             message = str(getattr(event, "message", ""))
             self.error.emit(message)
-            self._narrate(f"error: {message}")
+            self.log_line.emit(f"error: {message}")
         elif kind == "ScanRestoreFailedEvent":
             device = getattr(event, "device", "")
             message = getattr(event, "message", "")
-            self._narrate(f"restore failed: {device}: {message}")
+            self.log_line.emit(f"restore failed: {device}: {message}")
         elif kind == "ScanDialogEvent":
             # The engine's scan thread is blocked on request.response_event;
             # emit the request so the main-thread slot renders a modal and
@@ -119,10 +104,14 @@ class ScanEventsAdapter(QObject):
             # the three-way ActionDecisionRequest (a ``verdict`` list).
             request = getattr(event, "request", None)
             if getattr(request, "verdict", None) is not None:
-                self._narrate(f"action decision: {getattr(request, 'action_name', '')}")
+                self.log_line.emit(
+                    f"action decision: {getattr(request, 'action_name', '')}"
+                )
             else:
-                self._narrate(f"operator question: {getattr(request, 'exc', None)}")
+                self.log_line.emit(
+                    f"operator question: {getattr(request, 'exc', None)}"
+                )
             if request is not None:
                 self.dialog_requested.emit(request)
         else:
-            self._narrate(kind)
+            self.log_line.emit(kind)

--- a/GEECS-Console/geecs_console/events_adapter.py
+++ b/GEECS-Console/geecs_console/events_adapter.py
@@ -49,6 +49,25 @@ class ScanEventsAdapter(QObject):
     the GUI slot answers on the main thread and sets that event to unblock it.
     """
 
+    def __init__(self, parent: Any = None) -> None:
+        super().__init__(parent)
+        #: Last line sent to the log tail (consecutive-duplicate suppression).
+        self._last_narrated: str | None = None
+
+    def _narrate(self, line: str) -> None:
+        """Emit *line* on ``log_line`` unless it repeats the previous line.
+
+        The log tail is a narration, not a record: two consecutive events
+        whose rendered text is identical (the engine legitimately re-emits
+        e.g. the final step event) add nothing for the operator, so exact
+        consecutive repeats are dropped.  Only the narration dedupes — the
+        data signals (``state_changed``, ``progress``, …) always emit.
+        """
+        if line == self._last_narrated:
+            return
+        self._last_narrated = line
+        self.log_line.emit(line)
+
     def handle(self, event: Any) -> None:
         """Consume one engine event (the ``on_event`` callback).
 
@@ -69,24 +88,29 @@ class ScanEventsAdapter(QObject):
             scan_number = getattr(event, "scan_number", None)
             if scan_number is not None:
                 self.scan_number_known.emit(int(scan_number))
-            self.log_line.emit(f"scan {state_text}")
+            # The bridge re-emits RUNNING once the scan number is claimed —
+            # narrate that as new information, not a duplicate line.
+            if scan_number is not None:
+                self._narrate(f"scan {state_text} (Scan{int(scan_number):03d})")
+            else:
+                self._narrate(f"scan {state_text}")
         elif kind == "ScanStepEvent":
             step_index = int(getattr(event, "step_index", 0))
             total_steps = int(getattr(event, "total_steps", 0))
             shots_completed = int(getattr(event, "shots_completed", 0))
             self.progress.emit(step_index, total_steps, shots_completed)
             phase = getattr(event, "phase", "")
-            self.log_line.emit(
+            self._narrate(
                 f"step {step_index + 1}/{total_steps} {phase} ({shots_completed} shots)"
             )
         elif kind == "ScanErrorEvent":
             message = str(getattr(event, "message", ""))
             self.error.emit(message)
-            self.log_line.emit(f"error: {message}")
+            self._narrate(f"error: {message}")
         elif kind == "ScanRestoreFailedEvent":
             device = getattr(event, "device", "")
             message = getattr(event, "message", "")
-            self.log_line.emit(f"restore failed: {device}: {message}")
+            self._narrate(f"restore failed: {device}: {message}")
         elif kind == "ScanDialogEvent":
             # The engine's scan thread is blocked on request.response_event;
             # emit the request so the main-thread slot renders a modal and
@@ -95,14 +119,10 @@ class ScanEventsAdapter(QObject):
             # the three-way ActionDecisionRequest (a ``verdict`` list).
             request = getattr(event, "request", None)
             if getattr(request, "verdict", None) is not None:
-                self.log_line.emit(
-                    f"action decision: {getattr(request, 'action_name', '')}"
-                )
+                self._narrate(f"action decision: {getattr(request, 'action_name', '')}")
             else:
-                self.log_line.emit(
-                    f"operator question: {getattr(request, 'exc', None)}"
-                )
+                self._narrate(f"operator question: {getattr(request, 'exc', None)}")
             if request is not None:
                 self.dialog_requested.emit(request)
         else:
-            self.log_line.emit(kind)
+            self._narrate(kind)

--- a/GEECS-Console/pyproject.toml
+++ b/GEECS-Console/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-console"
-version = "0.20.0"
+version = "0.20.1"
 description = "Greenfield PySide6 operator console for GEECS (Bluesky/gateway architecture)"
 authors = ["Sam Barber <sbarber@lbl.gov>"]
 readme = "README.md"

--- a/GEECS-Console/tests/test_events_adapter.py
+++ b/GEECS-Console/tests/test_events_adapter.py
@@ -104,10 +104,12 @@ class TestStepAndErrors:
         assert recorded["log"] == ["SomethingNewEvent"]
 
 
-class TestNarrationDedupe:
-    """The log tail is narration: consecutive identical lines collapse
-    (Sam's 2026-08-19 Scan004 showed 'scan running' x2 and the final step
-    line x2); the data signals always emit."""
+class TestScanNumberNarration:
+    """Post-claim lifecycle lines carry the scan number — every state, not
+    just RUNNING (the bridge stamps the number on each post-claim
+    emission).  Dedupe deliberately does NOT live here: the adapter emits
+    every event's line; suppression happens at the tail's convergence
+    point (NowPanelController.append_log — PR #624 review finding 1)."""
 
     def test_rerun_running_with_scan_number_narrates_the_number(
         self, adapter, recorded
@@ -115,42 +117,15 @@ class TestNarrationDedupe:
         adapter.handle(ScanLifecycleEvent(state="running"))
         adapter.handle(ScanLifecycleEvent(state="running", scan_number=4))
         assert recorded["log"] == ["scan running", "scan running (Scan004)"]
-        # The data signal is not deduped.
         assert recorded["state"] == ["running", "running"]
 
-    def test_identical_lifecycle_narrates_once(self, adapter, recorded):
+    def test_terminal_state_carries_the_number_too(self, adapter, recorded):
+        adapter.handle(ScanLifecycleEvent(state="done", scan_number=4))
+        assert recorded["log"] == ["scan done (Scan004)"]
+
+    def test_adapter_does_not_dedupe(self, adapter, recorded):
+        """Identical consecutive events both emit — suppression is the
+        now panel's job, where direct window lines interleave."""
         adapter.handle(ScanLifecycleEvent(state="running"))
         adapter.handle(ScanLifecycleEvent(state="running"))
-        assert recorded["log"] == ["scan running"]
-        assert recorded["state"] == ["running", "running"]
-
-    def test_repeated_final_step_event_narrates_once(self, adapter, recorded):
-        adapter.handle(
-            ScanStepEvent(
-                step_index=0, total_steps=1, shots_completed=10, phase="completed"
-            )
-        )
-        adapter.handle(
-            ScanStepEvent(
-                step_index=0, total_steps=1, shots_completed=10, phase="completed"
-            )
-        )
-        assert recorded["log"] == ["step 1/1 completed (10 shots)"]
-        # Progress still emitted for both events.
-        assert recorded["progress"] == [(0, 1, 10), (0, 1, 10)]
-
-    def test_alternating_lines_are_not_suppressed(self, adapter, recorded):
-        adapter.handle(
-            ScanStepEvent(
-                step_index=0, total_steps=1, shots_completed=1, phase="completed"
-            )
-        )
-        adapter.handle(
-            ScanStepEvent(
-                step_index=0, total_steps=1, shots_completed=2, phase="completed"
-            )
-        )
-        assert recorded["log"] == [
-            "step 1/1 completed (1 shots)",
-            "step 1/1 completed (2 shots)",
-        ]
+        assert recorded["log"] == ["scan running", "scan running"]

--- a/GEECS-Console/tests/test_events_adapter.py
+++ b/GEECS-Console/tests/test_events_adapter.py
@@ -102,3 +102,55 @@ class TestStepAndErrors:
 
         adapter.handle(SomethingNewEvent())
         assert recorded["log"] == ["SomethingNewEvent"]
+
+
+class TestNarrationDedupe:
+    """The log tail is narration: consecutive identical lines collapse
+    (Sam's 2026-08-19 Scan004 showed 'scan running' x2 and the final step
+    line x2); the data signals always emit."""
+
+    def test_rerun_running_with_scan_number_narrates_the_number(
+        self, adapter, recorded
+    ):
+        adapter.handle(ScanLifecycleEvent(state="running"))
+        adapter.handle(ScanLifecycleEvent(state="running", scan_number=4))
+        assert recorded["log"] == ["scan running", "scan running (Scan004)"]
+        # The data signal is not deduped.
+        assert recorded["state"] == ["running", "running"]
+
+    def test_identical_lifecycle_narrates_once(self, adapter, recorded):
+        adapter.handle(ScanLifecycleEvent(state="running"))
+        adapter.handle(ScanLifecycleEvent(state="running"))
+        assert recorded["log"] == ["scan running"]
+        assert recorded["state"] == ["running", "running"]
+
+    def test_repeated_final_step_event_narrates_once(self, adapter, recorded):
+        adapter.handle(
+            ScanStepEvent(
+                step_index=0, total_steps=1, shots_completed=10, phase="completed"
+            )
+        )
+        adapter.handle(
+            ScanStepEvent(
+                step_index=0, total_steps=1, shots_completed=10, phase="completed"
+            )
+        )
+        assert recorded["log"] == ["step 1/1 completed (10 shots)"]
+        # Progress still emitted for both events.
+        assert recorded["progress"] == [(0, 1, 10), (0, 1, 10)]
+
+    def test_alternating_lines_are_not_suppressed(self, adapter, recorded):
+        adapter.handle(
+            ScanStepEvent(
+                step_index=0, total_steps=1, shots_completed=1, phase="completed"
+            )
+        )
+        adapter.handle(
+            ScanStepEvent(
+                step_index=0, total_steps=1, shots_completed=2, phase="completed"
+            )
+        )
+        assert recorded["log"] == [
+            "step 1/1 completed (1 shots)",
+            "step 1/1 completed (2 shots)",
+        ]

--- a/GEECS-Console/tests/test_now_panel_log_tail.py
+++ b/GEECS-Console/tests/test_now_panel_log_tail.py
@@ -1,0 +1,85 @@
+"""The R6 log tail's consecutive-duplicate suppression (PR #624).
+
+The tail has two writers — the events adapter's narration and the
+window's direct status lines — so dedupe lives at their convergence
+point, ``NowPanelController.append_log``, where "consecutive" means
+consecutive-in-the-tail. Field report (Scan004, 2026-08-19): "scan
+running" x2 and the doubled final step line.
+"""
+
+from __future__ import annotations
+
+import pytest
+from PySide6.QtWidgets import QLabel, QPlainTextEdit, QProgressBar
+
+from geecs_console.app.now_panel import NowPanelController
+
+
+@pytest.fixture
+def panel(qapp):
+    tail = QPlainTextEdit()
+    controller = NowPanelController(
+        state_pill=QLabel(),
+        progress_bar=QProgressBar(),
+        scan_number_label=QLabel(),
+        log_tail=tail,
+        current_experiment=lambda: "",
+        resolve_lookup=lambda: (lambda experiment: None),
+    )
+    yield controller, tail
+    controller.dispose()
+
+
+def _lines(tail: QPlainTextEdit) -> list[str]:
+    text = tail.toPlainText()
+    return text.splitlines() if text else []
+
+
+def test_consecutive_duplicates_collapse(panel) -> None:
+    controller, tail = panel
+    controller.append_log("step 1/1 completed (10 shots)")
+    controller.append_log("step 1/1 completed (10 shots)")
+    assert _lines(tail) == ["step 1/1 completed (10 shots)"]
+
+
+def test_interleaved_writers_measure_against_the_tail(panel) -> None:
+    """Adapter line / direct window line / identical adapter line: the
+    third line is NOT a tail-consecutive duplicate and must render
+    (review finding 1's false-suppression scenario — the re-asked
+    operator question after an interleaved 'operator: continue')."""
+    controller, tail = panel
+    controller.append_log("operator question: boom")
+    controller.append_log("operator: continue")
+    controller.append_log("operator question: boom")
+    assert _lines(tail) == [
+        "operator question: boom",
+        "operator: continue",
+        "operator question: boom",
+    ]
+
+
+def test_direct_writer_duplicates_also_collapse(panel) -> None:
+    controller, tail = panel
+    controller.append_log("operator: continue")
+    controller.append_log("operator: continue")
+    assert _lines(tail) == ["operator: continue"]
+
+
+def test_new_scan_rearms_the_cache(panel) -> None:
+    """Scan N's last line must never swallow scan N+1's first (review
+    finding 3): set_totals — the new scan announcing itself — re-arms."""
+    controller, tail = panel
+    controller.append_log("scan done")
+    controller.set_totals(10)
+    controller.append_log("scan done")  # pathological but must render
+    assert _lines(tail) == ["scan done", "scan done"]
+
+
+def test_alternating_lines_never_suppressed(panel) -> None:
+    controller, tail = panel
+    controller.append_log("step 1/1 completed (1 shots)")
+    controller.append_log("step 1/1 completed (2 shots)")
+    assert _lines(tail) == [
+        "step 1/1 completed (1 shots)",
+        "step 1/1 completed (2 shots)",
+    ]


### PR DESCRIPTION
## What + why

Field report from the 2026-08-19 test scans (Scan004): the R6 log tail showed **"scan running" twice** and the **final step line twice**. Root causes, both narration-side:

- The bridge deliberately re-emits RUNNING once the scan number is claimed (that's how the "Scan NNN" label works) — the narrator rendered both identically.
- The engine legitimately re-emits the final step event; identical rendered text, two lines.

Fix, confined to `events_adapter.py`: the narration path now suppresses **exact consecutive repeats** (a `_narrate` helper all log-tail emissions route through), and the claimed-number RUNNING re-emission renders as `scan running (Scan004)` — new information instead of a duplicate. **Data signals never dedupe** — state pill, progress bar, scan-number label see every event exactly as before; only the human-readable tail changed. Scan004's ticker becomes: `scan initializing` / `scan running` / `scan running (Scan004)` / one line per shot / `scan done`.

~30 LOC + 4 pinning tests (dedupe, number narration, data-signals-not-deduped, alternating-lines-not-suppressed). Console CLAUDE.md R6 bullet updated in the same PR (the narration contract lives there).

## Tests

GEECS-Console: **791 passed, 2 skipped** (787 + 4 new), offscreen.

## Hardware verification

Not required — no engine or device surface touched (pure GUI narration); the event stream itself is unchanged and covered by the adapter's hermetic fakes. The next routine console scan will show the deduped tail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)