### PR TITLE
GeecsBluesky 0.52.1: root BAX algorithm_results_file into the claimed scan folder at bind

### DIFF
--- a/GeecsBluesky/CHANGELOG.md
+++ b/GeecsBluesky/CHANGELOG.md
@@ -4,6 +4,25 @@ All notable changes to `geecs-bluesky` are documented here.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.52.1] - 2026-08-20
+
+### Fixed
+
+- **BAX algorithm-results pickles no longer land in the process working
+  directory.** Xopt's `BaxGenerator` opens
+  `<algorithm_results_file>_<n>.pkl` as-is on every generate call, and the
+  config default is a bare relative `bax_probe_results` — on the delegated
+  console path (where no `scan_data_manager` exists to root it) the pickles
+  dropped into whatever directory the process ran from (live-observed
+  2026-08-20: into the repo checkout, nearly committed; under the future
+  queueserver worker it would litter the service's cwd).
+  `SessionOptimizationBridge.bind` now roots a relative
+  `algorithm_results_file` into the claimed scan folder (writing into the
+  existing folder only — the runner claims pre-bind; scan-folder invariant
+  respected), falling back to a fresh temp directory when the claim failed.
+  Absolute paths pass through untouched; generators without the attribute
+  are a no-op.
+
 ## [0.52.0] - 2026-08-20
 
 ### Added

--- a/GeecsBluesky/CHANGELOG.md
+++ b/GeecsBluesky/CHANGELOG.md
@@ -20,8 +20,10 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   `algorithm_results_file` into the claimed scan folder (writing into the
   existing folder only — the runner claims pre-bind; scan-folder invariant
   respected), falling back to a fresh temp directory when the claim failed.
-  Absolute paths pass through untouched; generators without the attribute
-  are a no-op.
+  Absolute paths pass through untouched; a relative value with directory
+  components is flattened to its basename (nothing creates those
+  directories, and `..` must not escape the scan folder); generators
+  without the attribute are a no-op.
 
 ## [0.52.0] - 2026-08-20
 

--- a/GeecsBluesky/geecs_bluesky/optimization/base_optimizer.py
+++ b/GeecsBluesky/geecs_bluesky/optimization/base_optimizer.py
@@ -578,7 +578,9 @@ class BaseOptimizer:
                 # scan_data_manager (scan_folder stays None) — a future
                 # caller on a scans/ScanNNN path must go through
                 # claim_scan_number instead (cross-package scan-folder
-                # invariant, root CLAUDE.md).
+                # invariant, root CLAUDE.md).  On the live delegated path
+                # the equivalent rooting happens post-claim, in
+                # SessionOptimizationBridge._root_algorithm_results_file.
                 scan_folder.mkdir(parents=True, exist_ok=True)
 
                 for key, block in list(overrides.items()):

--- a/GeecsBluesky/geecs_bluesky/optimization/session_bridge.py
+++ b/GeecsBluesky/geecs_bluesky/optimization/session_bridge.py
@@ -354,13 +354,30 @@ class SessionOptimizationBridge:
         existing folder only, never creating it (cross-package scan-folder
         invariant) — or, when the claim failed (``scan_folder`` is None), into
         a fresh temp directory so a service's cwd is never littered.  Absolute
-        paths are explicit intent and pass through untouched; generators
-        without the attribute (random, UCB, ...) are a no-op.
+        paths are explicit intent and pass through untouched; a relative value
+        with directory components is flattened to its basename (nothing
+        creates those directories, and ``..`` must not escape the scan
+        folder); generators without the attribute (random, UCB, ...) are a
+        no-op.
         """
         generator = getattr(getattr(self.optimizer, "xopt", None), "generator", None)
         file_value = getattr(generator, "algorithm_results_file", None)
         if not file_value or Path(file_value).is_absolute():
             return
+        if Path(file_value).parent != Path("."):
+            # Directory components would make the generator's bare
+            # ``open()`` fail mid-run (no mkdir upstream) — or, via ``..``,
+            # escape the scan folder.  Flatten to the basename, loudly and
+            # pre-hardware.
+            flattened = Path(file_value).name
+            logger.warning(
+                "algorithm_results_file %r has directory components; "
+                "flattened to %r (results prefixes are rooted directly in "
+                "the scan folder)",
+                file_value,
+                flattened,
+            )
+            file_value = flattened
         if self._scan_folder is not None:
             base = self._scan_folder
         else:

--- a/GeecsBluesky/geecs_bluesky/optimization/session_bridge.py
+++ b/GeecsBluesky/geecs_bluesky/optimization/session_bridge.py
@@ -32,6 +32,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import re
+import tempfile
 import time
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
@@ -329,11 +330,51 @@ class SessionOptimizationBridge:
             files are awaited (bounded) before the evaluator runs — devices
             write over the network and directory listings lag behind (SMB
             caching), so the objective would otherwise race the filesystem.
+            It also becomes the root for the generator's relative
+            ``algorithm_results_file`` outputs (see
+            :meth:`_root_algorithm_results_file`).
         """
         self.source.column_map = _column_map(devices)
         self.optimizer.evaluator.scan_tag = scan_tag
         self._scan_folder = Path(scan_folder) if scan_folder else None
+        self._root_algorithm_results_file()
         return self._objective, self
+
+    def _root_algorithm_results_file(self) -> None:
+        """Root a relative generator ``algorithm_results_file`` off the cwd.
+
+        Diagnostic-dumping generators (Xopt's ``BaxGenerator``) write
+        ``<algorithm_results_file>_<n>.pkl`` on every ``generate`` call,
+        opening the path as-is — a relative value (the config default is a
+        bare ``bax_probe_results``) lands in the *process working directory*
+        (live-observed 2026-08-20: pickles dropped into the repo checkout the
+        console ran from).  The optimizer is built before any scan exists, so
+        this is the first moment the run's real folder is known: rebase a
+        relative value into the claimed scan folder — writing INTO the
+        existing folder only, never creating it (cross-package scan-folder
+        invariant) — or, when the claim failed (``scan_folder`` is None), into
+        a fresh temp directory so a service's cwd is never littered.  Absolute
+        paths are explicit intent and pass through untouched; generators
+        without the attribute (random, UCB, ...) are a no-op.
+        """
+        generator = getattr(getattr(self.optimizer, "xopt", None), "generator", None)
+        file_value = getattr(generator, "algorithm_results_file", None)
+        if not file_value or Path(file_value).is_absolute():
+            return
+        if self._scan_folder is not None:
+            base = self._scan_folder
+        else:
+            base = Path(tempfile.mkdtemp(prefix="geecs_algorithm_results_"))
+            logger.warning(
+                "No claimed scan folder at bind time; generator algorithm "
+                "results will be written to the temp directory %s",
+                base,
+            )
+        generator.algorithm_results_file = str(base / file_value)
+        logger.info(
+            "Generator algorithm_results_file rooted at %s",
+            generator.algorithm_results_file,
+        )
 
     # --- objective (called by session.optimize after each bin) --------
 

--- a/GeecsBluesky/pyproject.toml
+++ b/GeecsBluesky/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-bluesky"
-version = "0.52.0"
+version = "0.52.1"
 description = "Bluesky / ophyd-async bridge for the GEECS control system"
 authors = ["Sam Barber <sbarber@lbl.gov>"]
 readme = "README.md"

--- a/GeecsBluesky/tests/optimization/test_session_bridge.py
+++ b/GeecsBluesky/tests/optimization/test_session_bridge.py
@@ -298,6 +298,20 @@ class TestAlgorithmResultsFileRooting:
         assert rooted.parent.is_dir()  # mkdtemp created it, writes succeed
         assert "temp directory" in caplog.text
 
+    def test_relative_path_with_directories_is_flattened(self, tmp_path, caplog):
+        # Directory components would crash the generator's bare open() at
+        # the first dump (nothing mkdirs them) — or escape the scan folder
+        # via "..".  Flattened to the basename, with a warning.
+        bridge = SessionOptimizationBridge(
+            _make_bax_optimizer("../diagnostics/bax_probe")
+        )
+        with caplog.at_level(logging.WARNING):
+            bridge.bind(devices=[], scan_tag=None, scan_folder=tmp_path)
+        assert bridge.optimizer.xopt.generator.algorithm_results_file == str(
+            tmp_path / "bax_probe"
+        )
+        assert "directory components" in caplog.text
+
     def test_generator_without_results_file_is_a_noop(self, tmp_path):
         bridge = SessionOptimizationBridge(_make_optimizer())  # random generator
         bridge.bind(devices=[], scan_tag=None, scan_folder=tmp_path)

--- a/GeecsBluesky/tests/optimization/test_session_bridge.py
+++ b/GeecsBluesky/tests/optimization/test_session_bridge.py
@@ -158,6 +158,34 @@ def _make_optimizer(**optimizer_kwargs):
     )
 
 
+def _make_bax_optimizer(algorithm_results_file=None):
+    """Observables-only BAX optimizer (the one generator that dumps pickles)."""
+    from xopt import VOCS
+
+    from geecs_bluesky.optimization.base_optimizer import BaseOptimizer
+
+    evaluator = _MeanCurrentEvaluator(scalars=["U_S1H:Current"])
+    vocs = VOCS(
+        variables={"ctrl": [-1.0, 1.0], "meas": [-2.0, 2.0]},
+        observables=["x_CoM"],
+    )
+    cfg = {
+        "control_names": ["ctrl"],
+        "measurement_name": "meas",
+        "observable_names": ["x_CoM"],
+        "n_control_mesh": 5,
+    }
+    if algorithm_results_file is not None:
+        cfg["algorithm_results_file"] = algorithm_results_file
+    return BaseOptimizer(
+        vocs=vocs,
+        evaluate_function=evaluator.get_value,
+        generator_name="multipoint_bax_alignment",
+        xopt_config_overrides={"multipoint_bax_alignment": cfg},
+        evaluator=evaluator,
+    )
+
+
 class TestSessionOptimizationBridge:
     def test_full_ask_evaluate_tell_loop(self):
         bridge = SessionOptimizationBridge(_make_optimizer())
@@ -236,6 +264,44 @@ class TestSessionOptimizationBridge:
         bridge = SessionOptimizationBridge(_make_optimizer())
         bridge.bind(devices=[], scan_tag=None)
         bridge.finish()  # must not raise
+
+
+class TestAlgorithmResultsFileRooting:
+    """bind() roots a relative generator ``algorithm_results_file`` off the cwd.
+
+    Live-observed 2026-08-20: Xopt's ``BaxGenerator`` opens
+    ``<algorithm_results_file>_<n>.pkl`` as-is on every generate call, so the
+    config default (a bare ``bax_probe_results``) dropped pickles into the
+    process working directory — the repo checkout the console ran from.
+    """
+
+    def test_relative_default_rooted_into_scan_folder(self, tmp_path):
+        bridge = SessionOptimizationBridge(_make_bax_optimizer())
+        bridge.bind(devices=[], scan_tag=None, scan_folder=tmp_path)
+        assert bridge.optimizer.xopt.generator.algorithm_results_file == str(
+            tmp_path / "bax_probe_results"
+        )
+
+    def test_absolute_path_passes_through_untouched(self, tmp_path):
+        explicit = str(tmp_path / "elsewhere" / "results")
+        bridge = SessionOptimizationBridge(_make_bax_optimizer(explicit))
+        bridge.bind(devices=[], scan_tag=None, scan_folder=tmp_path)
+        assert bridge.optimizer.xopt.generator.algorithm_results_file == explicit
+
+    def test_no_scan_folder_falls_back_to_temp_dir_never_cwd(self, caplog):
+        bridge = SessionOptimizationBridge(_make_bax_optimizer())
+        with caplog.at_level(logging.WARNING):
+            bridge.bind(devices=[], scan_tag=None)
+        rooted = Path(bridge.optimizer.xopt.generator.algorithm_results_file)
+        assert rooted.is_absolute()
+        assert rooted.parent != Path.cwd()
+        assert rooted.parent.is_dir()  # mkdtemp created it, writes succeed
+        assert "temp directory" in caplog.text
+
+    def test_generator_without_results_file_is_a_noop(self, tmp_path):
+        bridge = SessionOptimizationBridge(_make_optimizer())  # random generator
+        bridge.bind(devices=[], scan_tag=None, scan_folder=tmp_path)
+        assert not hasattr(bridge.optimizer.xopt.generator, "algorithm_results_file")
 
 
 class TestObserveReadbackSubstitution:


### PR DESCRIPTION
## What + why

Xopt's `BaxGenerator` opens `<algorithm_results_file>_<n>.pkl` as-is on every `generate` call, and the config default is a bare relative `bax_probe_results`. `BaseOptimizer.from_config` only roots that path when a `scan_data_manager` provides a scan folder — but no live caller passes one (the block is dormant, per its own breadcrumb). So on the delegated console path the BAX generator wrote its probe-results pickles into the **process working directory**: live-observed 2026-08-20, a run launched from the GEECS-Console package dir dropped `bax_probe_results_1.pkl` into the repo checkout and it nearly got committed. Under the future queueserver worker the same default would litter the service's cwd.

**Fix:** `SessionOptimizationBridge.bind` — the first moment the run's real folder is known on the delegated path (the runner claims the scan pre-bind and passes `scan_folder`) — now roots a relative `algorithm_results_file` into the claimed scan folder. When the claim failed (`scan_folder=None`), it falls back to a fresh temp directory so cwd is never the destination. Absolute paths are explicit intent and pass through untouched; generators without the attribute (random, UCB, …) are a no-op.

**Scan-folder invariant:** the rebase only writes *into* the already-claimed folder (`claim_scan_number` created it, pre-bind) — no `mkdir` anywhere in this change.

## Changes (~130 LOC, one concern)

- `session_bridge.py` (+50): `_root_algorithm_results_file()` + call from `bind`, docstring update
- `base_optimizer.py` (+2): dormant-block breadcrumb now points at the live rooting site
- `tests/optimization/test_session_bridge.py` (+66): `_make_bax_optimizer` helper + 4 pinning tests (relative→scan folder, absolute passthrough, no-folder→temp dir never cwd, attribute-less generator no-op)
- version bump + CHANGELOG

## Tests

- `./scripts/check.sh`: lint green, GeecsBluesky **644 passed, 3 deselected** (CI-style env, `ca tiled` extras — optimization layer skips without the `optimize` extra, as in CI)
- Optimization layer (env with xopt 3.1.1): **128 passed** in `tests/optimization/`, including the 4 new pinning tests; the pre-fix code fails the new relative-default test

## Hardware verification

OWED: one console/delegated BAX optimize scan — expect `bax_probe_results_<n>.pkl` files inside `scans/ScanNNN/` (next to `xopt_dump.yaml`) and **no** pickles in the launch directory. (Non-BAX optimize scans are unaffected — their generators have no `algorithm_results_file`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)