### PR TITLE
docs: GEECS-Core section — overview, GeecsDevice example notebook, client API reference

### DIFF
--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -21,8 +21,9 @@ constituent packages:
   Bluesky-backed acquisition front-end, including its Scan Browser).
 - **Analysis** — turning acquired data into results: Image Analysis, Scan
   Analysis, and the Data Utils path/loading layer they build on.
-- **Platform** — the access-and-contract layer everything sits on: the
-  Python API (device transport + DB), the GEECS Gateway (the EPICS access
+- **Platform** — the access-and-contract layer everything sits on:
+  GEECS-Core (device transport + DB + the GeecsDevice client), the GEECS
+  Gateway (the EPICS access
   layer — central CA soft-IOC for scalars plus the distributed PVA image
   gateways on the camera servers), and GEECS Schemas (the typed
   scan-config contract).

--- a/docs/geecs_core/api/client.md
+++ b/docs/geecs_core/api/client.md
@@ -1,0 +1,11 @@
+# API Reference — `geecs_core.client`
+
+The entry-level synchronous client. For the async transport underneath it
+(`GeecsUdpClient`, `GeecsTcpSubscriber`) see the module docstrings in
+`geecs_core.transport` — those are the building blocks for applications with
+their own event loop.
+
+::: geecs_core.client.geecs_device
+    options:
+      show_root_heading: true
+      members_order: source

--- a/docs/geecs_core/examples/geecs_device_basics.ipynb
+++ b/docs/geecs_core/examples/geecs_device_basics.ipynb
@@ -12,7 +12,7 @@
     "\n",
     "Requirements: the lab network (or VPN) and the standard\n",
     "`~/.config/geecs_python_api/config.ini` — see the\n",
-    "[Getting Started tutorial](../../tutorials/getting_started.md). Run\n",
+    "[Getting Started tutorial](../../../tutorials/getting_started/). Run\n",
     "`scripts/lab_status.sh` first if you are unsure whether the lab is reachable.\n",
     "\n",
     "The examples use `U_S1H` (an HTU steering magnet supply) and its `Current`\n",
@@ -70,9 +70,11 @@
     "reports the value settled (default budget 30 s), and what it returns is the\n",
     "**device's reported readback**, not an echo of what you sent.\n",
     "\n",
-    "!!! warning\n",
-    "    This commands real hardware. The cell below writes back the value just\n",
-    "    read (a no-op move) — adapt with care."
+    "<div class=\"admonition warning\">\n",
+    "<p class=\"admonition-title\">Warning</p>\n",
+    "<p>This commands real hardware. The cell below writes back the value just\n",
+    "read (a no-op move) — adapt with care.</p>\n",
+    "</div>"
    ]
   },
   {
@@ -166,7 +168,7 @@
     "## Where to go next\n",
     "\n",
     "- Migrating a legacy `geecs_python_api` script? The\n",
-    "  [overview](../overview.md) has the side-by-side table.\n",
+    "  [overview](../../overview/) has the side-by-side table.\n",
     "- Need this inside an asyncio application? Skip the client and use\n",
     "  `geecs_core.transport` directly — same wire protocol, no background\n",
     "  thread.\n",

--- a/docs/geecs_core/examples/geecs_device_basics.ipynb
+++ b/docs/geecs_core/examples/geecs_device_basics.ipynb
@@ -1,0 +1,191 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "intro",
+   "metadata": {},
+   "source": [
+    "# GeecsDevice basics\n",
+    "\n",
+    "The entry-level way to talk to a GEECS device from Python: **get**, **set**,\n",
+    "and **subscribe**, with errors that raise instead of returning `None`.\n",
+    "\n",
+    "Requirements: the lab network (or VPN) and the standard\n",
+    "`~/.config/geecs_python_api/config.ini` — see the\n",
+    "[Getting Started tutorial](../../tutorials/getting_started.md). Run\n",
+    "`scripts/lab_status.sh` first if you are unsure whether the lab is reachable.\n",
+    "\n",
+    "The examples use `U_S1H` (an HTU steering magnet supply) and its `Current`\n",
+    "variable — substitute your own device and variable names."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "construct",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from geecs_core import GeecsDevice\n",
+    "\n",
+    "# One database query resolves the device's endpoint; no sockets are\n",
+    "# opened until the first get/set/subscribe. Unknown names raise\n",
+    "# GeecsDeviceNotFoundError immediately.\n",
+    "dev = GeecsDevice(\"U_S1H\")\n",
+    "dev"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "get-md",
+   "metadata": {},
+   "source": [
+    "## Read a variable\n",
+    "\n",
+    "`get` blocks until the device answers (default budget 10 s) and returns the\n",
+    "value typed — `float`/`int` for numerics, `str` for text. A failure raises\n",
+    "(`GeecsCommandFailedError` for a device-reported error,\n",
+    "`GeecsConnectionError` for a timeout) — you never have to `None`-check."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "get",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "current = dev.get(\"Current\")\n",
+    "print(f\"Current = {current!r}  (type: {type(current).__name__})\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "set-md",
+   "metadata": {},
+   "source": [
+    "## Write a variable\n",
+    "\n",
+    "`set` rides GEECS's native blocking convergence — it returns when the device\n",
+    "reports the value settled (default budget 30 s), and what it returns is the\n",
+    "**device's reported readback**, not an echo of what you sent.\n",
+    "\n",
+    "!!! warning\n",
+    "    This commands real hardware. The cell below writes back the value just\n",
+    "    read (a no-op move) — adapt with care."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "set",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "readback = dev.set(\"Current\", current)\n",
+    "print(f\"device reports Current = {readback!r}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "subscribe-md",
+   "metadata": {},
+   "source": [
+    "## Subscribe to live updates\n",
+    "\n",
+    "`subscribe` opens the device's TCP push stream (a few Hz). Every frame\n",
+    "updates `dev.state` and adds two reserved keys: `\"shot number\"` (the\n",
+    "device's frame counter) and `\"connected\"`. The stream auto-reconnects\n",
+    "through device restarts; pass `reconnect=False` to opt out.\n",
+    "\n",
+    "An optional `on_update` callback receives each parsed frame. It runs on the\n",
+    "client's background thread — keep it quick, and **never call `get`/`set`\n",
+    "from inside it** (that raises a `RuntimeError` by design: blocking the\n",
+    "stream's own thread would deadlock). Hand work to a queue instead."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "subscribe",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import time\n",
+    "\n",
+    "frames = []\n",
+    "dev.subscribe([\"Current\"], on_update=frames.append)\n",
+    "\n",
+    "time.sleep(2)  # let a few frames arrive\n",
+    "print(f\"{len(frames)} frames; latest state: {dev.state}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "state-md",
+   "metadata": {},
+   "source": [
+    "`dev.state` always holds the last-known values — subscription frames and\n",
+    "get/set responses both feed it — so a monitoring loop can just read the\n",
+    "dict. Subscribing with `variables=None` subscribes the device's full\n",
+    "database-declared variable set."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "close-md",
+   "metadata": {},
+   "source": [
+    "## Clean up\n",
+    "\n",
+    "`close()` releases the subscription and the UDP sockets; it is idempotent,\n",
+    "and using the device after close raises. For scripts, the context-manager\n",
+    "form handles it:\n",
+    "\n",
+    "```python\n",
+    "with GeecsDevice(\"U_S1H\") as dev:\n",
+    "    print(dev.get(\"Current\"))\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "close",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dev.close()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "outro",
+   "metadata": {},
+   "source": [
+    "## Where to go next\n",
+    "\n",
+    "- Migrating a legacy `geecs_python_api` script? The\n",
+    "  [overview](../overview.md) has the side-by-side table.\n",
+    "- Need this inside an asyncio application? Skip the client and use\n",
+    "  `geecs_core.transport` directly — same wire protocol, no background\n",
+    "  thread.\n",
+    "- Running scans? That is the GEECS Console / Bluesky engine's job, not\n",
+    "  `GeecsDevice`'s."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/geecs_core/overview.md
+++ b/docs/geecs_core/overview.md
@@ -1,0 +1,84 @@
+# GEECS-Core
+
+The GEECS access **library**: everything a Python consumer of GEECS devices
+needs, and nothing else. It is the layer under both EPICS gateways and the
+Bluesky engine — and it carries **`GeecsDevice`**, the entry-level way to talk
+to a GEECS device from a script or notebook.
+
+## Quickstart
+
+```python
+from geecs_core import GeecsDevice
+
+with GeecsDevice("U_S1H") as dev:
+    value = dev.get("Current")          # blocking read, typed result
+    dev.set("Current", value)           # blocking write; returns the
+                                        # device's reported readback
+    dev.subscribe(["Current"])          # live push stream into dev.state
+    ...
+    print(dev.state)                    # {"Current": 0.103,
+                                        #  "shot number": 117,
+                                        #  "connected": True}
+```
+
+Construction looks the device up in the experiment database (one query, no
+sockets). `get`/`set` block until the device answers; failures **raise**
+(`GeecsCommandFailedError`, `GeecsCommandRejectedError`,
+`GeecsConnectionError`) — a returned value is always a real device response.
+Subscriptions feed `dev.state` at the device's push rate, add the reserved
+keys `"shot number"` and `"connected"`, and auto-reconnect through device
+restarts. See the [example notebook](examples/geecs_device_basics.ipynb) for
+the full tour, and the [API reference](api/client.md) for signatures.
+
+Prerequisite: the standard `~/.config/geecs_python_api/config.ini` (the
+directory name is historical — the file is the fleet-wide contract). The
+[Getting Started tutorial](../tutorials/getting_started.md) is the
+key-by-key reference.
+
+## Migrating from GEECS-PythonAPI
+
+`GeecsDevice` succeeds the legacy `GeecsDevice`/`ScanDevice` objects (the
+`GEECS-PythonAPI` package was removed 2026-08-20). The shape is deliberately
+familiar:
+
+```python
+# old
+from geecs_python_api.controls.devices.scan_device import ScanDevice
+dev = ScanDevice("U_S1H")
+dev.set("Current", 0)
+
+# new
+from geecs_core import GeecsDevice
+dev = GeecsDevice("U_S1H")
+dev.set("Current", 0)
+```
+
+What changed, and why it's better:
+
+| Legacy behavior | New behavior |
+|---|---|
+| `get`/`set` return `None` on failure | Failures **raise** typed exceptions |
+| `set` echoes back through a state cache | `set` returns the device's actual exe-response readback |
+| `subscribe_var_values([...])` | `subscribe([...])` — same `state` feed, plus `"connected"` |
+| Global `exp_info` + `collect_exp_info` setup | None needed — construction resolves the device directly |
+| Variable aliases (`use_alias_in_TCP_subscription`) | Raw GEECS variable names only |
+| One global lock serialized all devices | Devices command independently |
+| Composite `ScanDevice(name, spec)` | No equivalent here — pseudo scan variables live in the Bluesky engine |
+
+## What else is in the library
+
+- **`geecs_core.transport`** — the asyncio UDP/TCP wire protocol
+  (`GeecsUdpClient`, `GeecsTcpSubscriber`) that `GeecsDevice` and both
+  gateways are built on. Use it directly if your application has its own
+  event loop.
+- **`geecs_core.db.GeecsDb`** — the experiment MySQL database: device
+  endpoints, variable metadata, experiment rosters.
+- **`geecs_core.pv_naming`** — the one shared GEECS→EPICS PV naming policy.
+- **`geecs_core.testing`** — `FakeGeecsServer`, an in-process server speaking
+  the real wire protocol, so your code can be tested with no hardware.
+
+When should you *not* use `GeecsDevice`? For data-taking scans (use the GEECS
+Console / Bluesky engine — scans need numbering, saving, and shot control),
+and for monitoring dashboards at HTU (the [gateway PVs](../geecs_gateway/client_overview.md)
+serve that better). `GeecsDevice` is the right tool for scripts, notebooks,
+feedback loops, and facilities where the EPICS layer is not deployed.

--- a/docs/index.md
+++ b/docs/index.md
@@ -51,7 +51,8 @@ follow that split; the bottom row is for navigation and troubleshooting.
     [:octicons-arrow-right-24: GEECS Console](geecs_console/overview.md) ·
     [Image Analysis](image_analysis/overview.md) ·
     [Scan Analysis](scan_analysis/overview.md) ·
-    [Data Utils](geecs_data_utils/overview.md)
+    [Data Utils](geecs_data_utils/overview.md) ·
+    [GEECS-Core](geecs_core/overview.md)
 
 -   :material-bug-outline:{ .lg .middle } **Troubleshooting & internals**
 
@@ -112,10 +113,11 @@ s-file appending. Runs interactively or as a `LiveTaskRunner` that processes
 scans automatically as they complete. Optional integration with Google Doc
 e-logs via `LogMaker4GoogleDocs`.
 
-**GEECS-Core** — the GEECS access library: device communication (UDP/TCP
-transport and the entry-level `GeecsDevice` client), the experiment database,
-and the PV naming contract. The shared `config.ini` it reads is documented in
-the [Getting Started tutorial](tutorials/getting_started.md).
+**[GEECS-Core](geecs_core/overview.md)** — the GEECS access library: device
+communication (UDP/TCP transport and the entry-level `GeecsDevice` client),
+the experiment database, and the PV naming contract. The shared `config.ini`
+it reads is documented in the
+[Getting Started tutorial](tutorials/getting_started.md).
 
 **[GEECS Data Utils](geecs_data_utils/overview.md)** — path resolution and
 data loading for scan folders. Resolves `(experiment, date, scan_number)` to

--- a/docs/platform/index.md
+++ b/docs/platform/index.md
@@ -17,7 +17,8 @@ scan and its data are described.
     reads is documented in the
     [Getting Started tutorial](../tutorials/getting_started.md).
 
-    [:octicons-arrow-right-24: Getting started](../tutorials/getting_started.md)
+    [:octicons-arrow-right-24: Overview](../geecs_core/overview.md) ·
+    [Example notebook](../geecs_core/examples/geecs_device_basics.ipynb)
 
 -   :material-transit-connection-variant:{ .lg .middle } **GEECS Gateway**
 

--- a/docs/platform/index.md
+++ b/docs/platform/index.md
@@ -47,9 +47,3 @@ scan and its data are described.
     [Schema reference](../geecs_schemas/schema_reference.md)
 
 </div>
-
-!!! note "Python API is under refactoring"
-
-    The Python API is being reworked. Treat `ScanDevice` and the
-    experiment-database lookup as the stable public surface; other
-    internals may move.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -95,6 +95,12 @@ nav:
 
   - Platform:
       - platform/index.md
+      - GEECS-Core:
+          - Overview: geecs_core/overview.md
+          - Examples:
+              - GeecsDevice Basics: geecs_core/examples/geecs_device_basics.ipynb
+          - API Reference:
+              - Client: geecs_core/api/client.md
       - GEECS Gateway:
           - Client Overview: geecs_gateway/client_overview.md
           - Camera Images (PVA): geecs_gateway/image_pvs.md


### PR DESCRIPTION
## What + why

Follow-up to the geecs-core arc (#626–#629), filling the gap the deletion PR left: the mkdocs site had no user-facing page for the python-api successor — the Platform group lost its Python API section without gaining a GEECS-Core one, and the owner asked for a short example notebook.

New Platform → GEECS-Core section (the slot the old Python API section occupied), per docs/CLAUDE.md's Diátaxis layout:

- **`docs/geecs_core/overview.md`** — quickstart, the **migrating-from-GEECS-PythonAPI** side-by-side (old `ScanDevice` → new `GeecsDevice`) with a what-changed table, the rest of the library at a glance, and when *not* to use `GeecsDevice` (scans → Console/Bluesky; HTU dashboards → gateway PVs).
- **`docs/geecs_core/examples/geecs_device_basics.ipynb`** — get / set / subscribe / state / close walkthrough with hardware-safety callouts (the set cell is an explicit no-op write-back) and the on_update no-sync-calls rule. Outputs cleared, nbformat 4.5 cell IDs (docs/CLAUDE.md notebook hygiene); renders via mkdocs-jupyter (`execute: false`).
- **`docs/geecs_core/api/client.md`** — mkdocstrings over `geecs_core.client.geecs_device` (importable in the docs env via the geecs-bluesky dev dep added in #629).
- Nav + homepage/platform cards wired in.

## Tests

Docs-only (no package code): `mkdocs build` exit 0, zero errors; rendered API page and notebook page verified to contain real content. No version bumps (site content belongs to no package — #619 precedent).

## Hardware verification

n/a — though the notebook's exact commands are what the live-verified `-m hardware` tier runs (all green on U_S1H today, evidence on #628).

🤖 Generated with [Claude Code](https://claude.com/claude-code)