### PR TITLE
chore: M6 topology collapse — one mainline, human-only master merges

### DIFF
--- a/.claude/skills/get-started/SKILL.md
+++ b/.claude/skills/get-started/SKILL.md
@@ -160,8 +160,8 @@ their successors are `geecs_core.client.GeecsDevice` and GEECS-Console.
 The canonical branch topology lives in `CONTRIBUTING.md` § "Branch
 topology" — read it at run time; the newcomer-specific shape is:
 
-- Create the user a **personal integration branch** off the default
-  development base (currently `dev`): `users/<name>`. Record it in
+- Create the user a **personal integration branch** off `master`:
+  `users/<name>`. Record it in
   memory. All their work happens on feature branches off it, in
   worktrees under `.claude/worktrees/` as usual.
 - Land finished work **per `/land`**, with the PR base set to the

--- a/.claude/skills/land/SKILL.md
+++ b/.claude/skills/land/SKILL.md
@@ -93,8 +93,8 @@ carries the mechanics.
    maintainer may merge the parent at any moment. Retarget the child to
    the parent's base BEFORE reporting the parent ready-to-merge, and
    flag any stacked child in the parent's ready-to-merge report.
-   Prefer merging the parent first and
-   retargeting before it merges, or re-file (precedent: #538 → #539).
+   For a `users/<name>`-based parent you control the timing, so merging
+   the parent first works too; otherwise re-file (precedent: #538 → #539).
 
 ## The adversarial review step
 

--- a/.claude/skills/land/SKILL.md
+++ b/.claude/skills/land/SKILL.md
@@ -38,11 +38,9 @@ session memory), feature PRs target the personal branch instead of a
 mainline base — and never merge `users/<name>` into a mainline branch
 yourself; that promotion PR is merged by a human maintainer.
 
-**Master merges are human-only (rule set at M6, 2026-08-20):** for a
-PR whose base is `master`, the agent does everything up to and including
-the adversarial-review disposition and the CI watch — and then **hands
-the merge to the maintainer** instead of running `gh pr merge`. Only
-PRs into a `users/<name>` personal branch may be agent-merged.
+**Master merges are maintainer-only** — the rule (and any future
+amendments) lives in CONTRIBUTING.md § "Branch topology"; step 8 below
+carries the mechanics.
 
 ## Steps
 
@@ -71,7 +69,10 @@ PRs into a `users/<name>` personal branch may be agent-merged.
    "OWED: <what to verify, expected numbers>" so the code-complete vs
    hardware-verified distinction is never implicit.
 7. **Adversarial review** (runs during the CI wait; see the section
-   below): spawn a fresh-context reviewer subagent on the PR's diff,
+   below — exception: a bulk integration merge whose constituent PRs
+   were each already reviewed skips the re-review and says so in the PR
+   body, per CONTRIBUTING § "Branch topology"): spawn a fresh-context
+   reviewer subagent on the PR's diff,
    post its report as a PR comment **either way** — a "no surviving
    findings" report is itself the audit record distinguishing
    "reviewed, clean" from "review skipped" — and disposition every
@@ -80,13 +81,19 @@ PRs into a `users/<name>` personal branch may be agent-merged.
 8. **Merge**: wait for CI (`gh pr checks <n> --watch`). If the base is
    `master`, STOP here and hand the merge to the maintainer (rule above)
    — report the PR as ready-to-merge; after they merge, delete the
-   feature branch. If the base is a `users/<name>` personal branch,
-   merge with `--merge --delete-branch` yourself. Remove the worktree
-   after merge unless it hosts an open stacked branch — and always
-   confirm with the user before removing any worktree.
+   feature branch **unless a stacked child PR is based on it** (deleting
+   the base auto-closes the child, unreopenable). If the base is a
+   `users/<name>` personal branch, merge with `--merge --delete-branch`
+   yourself. Remove the worktree after merge unless it hosts an open
+   stacked branch — and always confirm with the user before removing any
+   worktree.
 9. **Stacked PRs**: base on the parent PR's branch and say "merge #N
    first" in the body — but beware: GitHub auto-closes (unreopenable) a
-   PR whose base branch is deleted. Prefer merging the parent first and
+   PR whose base branch is deleted, and under the hand-off flow the
+   maintainer may merge the parent at any moment. Retarget the child to
+   the parent's base BEFORE reporting the parent ready-to-merge, and
+   flag any stacked child in the parent's ready-to-merge report.
+   Prefer merging the parent first and
    retargeting before it merges, or re-file (precedent: #538 → #539).
 
 ## The adversarial review step

--- a/.claude/skills/land/SKILL.md
+++ b/.claude/skills/land/SKILL.md
@@ -5,7 +5,9 @@ description: >
   scope check, version bump + CHANGELOG, tests run the way CI runs them,
   commit.sh, PR body with the hardware-verification section, adversarial
   review by a fresh-context subagent (correctness + redundancy +
-  placement) with dispositioned findings, CI watch, merge, roll-forward.
+  placement) with dispositioned findings, CI watch — then hand
+  master-targeted merges to the maintainer (personal-branch PRs merge
+  directly).
   Use when the user says "land this", "open a PR",
   "commit and push this", "prep this branch for review", or when a change
   in the working tree is finished and needs to become a merged PR.
@@ -25,11 +27,10 @@ and the topology in `CONTRIBUTING.md`.
 
 ## Pick the base branch
 
-The branch topology (which work targets which base, until the M6 cutover)
-lives in **CONTRIBUTING.md § "Branch topology"** — that is the single
-canonical copy; read it now and pick the base matching the content of the
-change (`dev` for vision-world work; `master` only for analysis/legacy
-work with no dev-only imports).
+The branch topology lives in **CONTRIBUTING.md § "Branch topology"** —
+that is the single canonical copy; read it now. Post-M6 the default base
+for everything is `master` (personal-branch developers target their
+`users/<name>` instead).
 
 **Personal-branch exception:** if the developer works on a personal
 integration branch (`users/<name>`, per that CONTRIBUTING section or
@@ -37,11 +38,11 @@ session memory), feature PRs target the personal branch instead of a
 mainline base — and never merge `users/<name>` into a mainline branch
 yourself; that promotion PR is merged by a human maintainer.
 
-**Roll-forward rule (until M6):** after merging an analysis/legacy PR
-into `master`, merge `master` forward into `dev` (`git merge
-origin/master --no-edit --no-verify` — `--no-verify` because pre-commit's
-auto-fixers abort merge commits) and push. Nothing merges `dev` →
-`master` until the M6 cutover.
+**Master merges are human-only (rule set at M6, 2026-08-20):** for a
+PR whose base is `master`, the agent does everything up to and including
+the adversarial-review disposition and the CI watch — and then **hands
+the merge to the maintainer** instead of running `gh pr merge`. Only
+PRs into a `users/<name>` personal branch may be agent-merged.
 
 ## Steps
 
@@ -76,11 +77,13 @@ auto-fixers abort merge commits) and push. Nothing merges `dev` →
    "reviewed, clean" from "review skipped" — and disposition every
    finding — fix it, or waive it with a stated reason — before merging.
    No PR merges with an undispositioned finding.
-8. **Merge**: wait for CI (`gh pr checks <n> --watch`), merge with
-   `--merge --delete-branch`. Then do the roll-forward merge if the base
-   was the engine branch (rule above). Remove the worktree after merge
-   unless it hosts an open stacked branch — and always confirm with the
-   user before removing any worktree.
+8. **Merge**: wait for CI (`gh pr checks <n> --watch`). If the base is
+   `master`, STOP here and hand the merge to the maintainer (rule above)
+   — report the PR as ready-to-merge; after they merge, delete the
+   feature branch. If the base is a `users/<name>` personal branch,
+   merge with `--merge --delete-branch` yourself. Remove the worktree
+   after merge unless it hosts an open stacked branch — and always
+   confirm with the user before removing any worktree.
 9. **Stacked PRs**: base on the parent PR's branch and say "merge #N
    first" in the body — but beware: GitHub auto-closes (unreopenable) a
    PR whose base branch is deleted. Prefer merging the parent first and

--- a/.github/ISSUE_TEMPLATE/task.md
+++ b/.github/ISSUE_TEMPLATE/task.md
@@ -15,6 +15,6 @@ about: Planned work with agreed timing (not a defect)
 
 <!-- Files/modules touched, tests that pin current behavior, rough size. -->
 
-## Cutover relevance
+## Context
 
-<!-- Is this an M6 cutover gate (e.g. telemetry parity)? Say so. -->
+<!-- Anything a fresh reader needs that the description doesn't carry. -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,8 +8,9 @@
 - [ ] `poetry version patch|minor` run for every package whose code changed
 - [ ] `CHANGELOG.md` entry added under the new version (Keep a Changelog)
 - [ ] Tests: exact counts reported below (not "tests pass")
-- [ ] Base branch matches the content — see CONTRIBUTING.md
-      § "Branch topology" (delete this line at M6)
+- [ ] Base branch is `master` (or your `users/<name>`) — see
+      CONTRIBUTING.md § "Branch topology"; master merges are
+      maintainer-only
 - [ ] Public-repo hygiene: no lab accounts/hostnames/home paths
 - [ ] Adversarial review posted and every finding dispositioned
       (brief in `.claude/skills/land/SKILL.md`)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -169,7 +169,8 @@ causes silent skips, not errors.
 
 1. **GEECS-Console** (via **GeecsBluesky**'s scan engine) runs a scan →
    writes per-shot data files to a date-structured folder on the data server
-   (the legacy master-line GEECS-Scanner-GUI writes the same layout)
+   (the legacy GEECS-Scanner-GUI — tag `legacy-scanner-final` — wrote the
+   same layout)
 2. **GEECS-Data-Utils** `ScanPaths` / `ScanData` resolves the folder, loads
    scalar summary data from s-files or TDMS
 3. **ImageAnalysis** `StandardAnalyzer` / `BeamAnalyzer` / etc. processes

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -204,9 +204,10 @@ equivalent). Resolved by `GeecsPathsConfig` from `~/.config/geecs_python_api/con
 PyQt5 DAQ front-end) were **deleted from `dev`** at the end of the geecs-core
 arc. Their successors: `geecs_core.client.GeecsDevice` for device
 get/set/subscribe, `GEECS-Console` + `GeecsBluesky` for scans, and
-`geecs_bluesky.optimization` for the Xopt stack. Both packages remain on
-`master` for the legacy production line until the M6 cutover; never adopt
-them in new code there either. The `~/.config/geecs_python_api/config.ini`
+`geecs_bluesky.optimization` for the Xopt stack. Their final state is
+preserved at the tag `legacy-scanner-final` (the M6 cutover merged the
+vision line into `master`, 2026-08-20); never adopt them in new code. The
+`~/.config/geecs_python_api/config.ini`
 path they named is a permanent fleet contract and deliberately keeps its
 name (see `GEECS-Core/DESIGN.md`).
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,45 +24,40 @@ docs site), or launch Claude Code from the repo root and type
   `GEECS-Console` → set `QT_QPA_PLATFORM=offscreen` for tests.
 - Install pre-commit hooks once: `poetry run pre-commit install`.
 
-## Branch topology (until the M6 cutover)
+## Branch topology (post-M6: one mainline)
 
 This section is the **single canonical copy** of the branch layout — the
-PR template and the `/land` skill point here rather than repeating it, so
-at M6 only this section (and the pointers' one-line reminders) needs
-editing. Two lines (collapsed from three on 2026-07-13 — `feat/vision-v1`
-was retired into `dev`, and `feat/greenfield-epics-bluesky-gui` was
-renamed `dev`):
+PR template and the `/land` skill point here rather than repeating it.
+The M6 cutover (2026-08-20, PR #631) collapsed the two-line layout to
+one mainline:
 
-- `dev` — the vision world, and the default target for development:
-  GeecsBluesky, GeecsCAGateway, GEECS-Schemas, GEECS-Console, the scan
-  browser, Planning docs, repo tooling, the docs site.
-- `master` — the legacy-scanner line, kept deployable through the M6 gap:
-  the pure-legacy GEECS-Scanner-GUI plus **living analysis development**
-  (ImageAnalysis, ScanAnalysis, and their data-utils needs). Target
-  `master` for analysis work *unless it imports something that only
-  exists on `dev`* (e.g. `geecs_data_utils.tiled_catalog`) — then target
-  `dev`.
+- **`master` is the mainline and the default target for every PR** —
+  engine, console, gateways, schemas, analysis, docs, tooling.
+- **Merges into `master` are ALWAYS performed by the human maintainer.**
+  Agents prepare the PR — branch, commit, adversarial review, CI watch —
+  and then hand the merge to the maintainer; they never click merge on a
+  master-targeted PR. (Bulk integration merges whose constituent PRs
+  were each already reviewed do not get a fresh adversarial re-review —
+  say so in the PR body.)
+- `dev` is **retired** — frozen at the cutover, kept only so pre-cutover
+  PRs based on it don't auto-close. Do not target it or branch from it.
+- The final legacy-scanner state (GEECS-Scanner-GUI, GEECS-PythonAPI) is
+  preserved at the tag **`legacy-scanner-final`** — anyone still on the
+  legacy line checks out the tag, never a branch.
 
 **Personal branches for new developers.** A developer new to the repo
-gets a long-lived personal integration branch off the development base
-(currently `dev`), named `users/<name>`. Their feature branches PR into
-that personal branch — the `/get-started` skill sets this up, and
-`/land` targets it — so they can merge their own work at their own
-pace. Promotion from `users/<name>` into `dev` (after M6: `master`) is
-a separate PR that **only a human maintainer merges**; agents never
-merge into the mainline on a newcomer's behalf. To keep the personal
-branch from going stale, the agent merges the development base forward
+gets a long-lived personal integration branch off `master`, named
+`users/<name>`. Their feature branches PR into that personal branch —
+the `/get-started` skill sets this up, and `/land` targets it — so they
+can merge their own work at their own pace. Promotion from
+`users/<name>` into `master` is a separate PR that **only the
+maintainer merges** (the general master-merge rule above). To keep the
+personal branch from going stale, the agent merges `master` forward
 *into* `users/<name>` periodically — that direction is routine
 maintenance, not a mainline merge.
 
-`master` is merged forward into `dev` periodically, so analysis work
-flows into the vision world automatically; nothing merges the other way
-until the M6 cutover (tag `master` first, then merge `dev` in). (At M6
-this section collapses to "everything targets `master`" — also prune the
-branch names from `pick_base()` in `scripts/check.sh` then; harmless if
-forgotten, it skips deleted branches and falls back to the default
-branch. Grep hits for the *old* branch names — Planning/ notes,
-CHANGELOGs — are historical record, not instruction: leave them.)
+(Grep hits for the old branch names — Planning/ notes, CHANGELOGs — are
+historical record, not instruction: leave them.)
 
 ## Planning/ is development scratch, not documentation
 
@@ -70,9 +65,10 @@ CHANGELOGs — are historical record, not instruction: leave them.)
 open questions, deferred items, strategy that code and CLAUDE.md files
 don't yet record. When a plan is executed (or abandoned), delete its
 directory in the PR that finishes the work; anything still load-bearing
-moves to the owning package's `CLAUDE.md` or the docs site first. The
-whole folder is purged before `dev` merges to `master` at M6 — a
-planning doc that reaches `master` is a bug. (Audited 2026-07-13: five
+moves to the owning package's `CLAUDE.md` or the docs site first.
+(Post-M6 the folder lives on the mainline like everything else — the old
+"purged before reaching master" rule died with the two-branch layout;
+delete-when-executed is the whole discipline. Audited 2026-07-13: five
 executed/superseded plans deleted; the survivors each hold live
 deferred-work or strategy content.)
 
@@ -125,9 +121,9 @@ Style: NumPy docstrings, type hints on public functions, Pydantic v2
   `GeecsCAGateway/PV_CONTRACT.md` + its pinned test in the same PR;
   event-data changes update `GeecsBluesky/EVENT_SCHEMA.md`.
 - The legacy packages (`GEECS-PythonAPI`, `GEECS-Scanner-GUI`) are deleted
-  on `dev` (2026-08-20); they live on only in `master`'s legacy line until
-  the M6 cutover — no new features there either. Successors:
-  `geecs_core.client.GeecsDevice` and GEECS-Console.
+  (2026-08-20); their final state is preserved at the tag
+  `legacy-scanner-final`. Successors: `geecs_core.client.GeecsDevice` and
+  GEECS-Console.
 
 ## Tests
 

--- a/GeecsBluesky/CLAUDE.md
+++ b/GeecsBluesky/CLAUDE.md
@@ -13,10 +13,10 @@ duck-typed `exec_config` path was deleted root-and-stem (G3, executed
 early 2026-07-16 by owner decision — the cutover doc had re-timed it to
 M6): `reinitialize` raises `TypeError` for anything but a `ScanRequest`,
 and the `shot_control_information` constructor kwarg is gone.
-GEECS-Scanner-GUI itself was **deleted from `dev`** (2026-08-20, geecs-core
-arc) after its `optimization` module relocated into this package;
-`master`'s legacy scanner line is untouched — the fallback story is
-unchanged until the M6 cutover.
+GEECS-Scanner-GUI itself was **deleted** (2026-08-20, geecs-core arc)
+after its `optimization` module relocated into this package; the legacy
+scanner line's final state is preserved at the tag `legacy-scanner-final`
+(the M6 cutover merged the vision line into `master` the same day).
 
 ## Two acquisition modes (the core architecture)
 

--- a/docs/tutorials/getting_started.md
+++ b/docs/tutorials/getting_started.md
@@ -30,14 +30,13 @@ repo's AI tooling uses when it helps a new developer get set up.
 ```bash
 git clone https://github.com/GEECS-BELLA/GEECS-Plugins.git
 cd GEECS-Plugins
-git checkout dev
 ```
 
-!!! note "Why `dev`?"
-    Until the planned branch cutover, `dev` is the active development
-    line and the default base for new work; `master` carries the legacy
-    scanner. See `CONTRIBUTING.md` at the repo root for the branch
-    topology.
+!!! note "One mainline"
+    `master` (the default branch you just cloned) is the single active
+    development line — no branch switch needed. The pre-cutover legacy
+    scanner lives at the tag `legacy-scanner-final` if you ever need it.
+    See `CONTRIBUTING.md` at the repo root for the branch topology.
 
 If you'll work on analyzer configurations, also clone the sister config
 repo **as a sibling directory** (several tools expect it at

--- a/docs/tutorials/getting_started.md
+++ b/docs/tutorials/getting_started.md
@@ -158,7 +158,7 @@ data share, and database all line up.
 The full workflow contract is `CONTRIBUTING.md` at the repo root; the
 short version for a new developer:
 
-- Work on a branch, never directly on `dev` or `master`. New developers
+- Work on a branch, never directly on `master`. New developers
   get a personal branch (`users/<yourname>`) that feature work merges
   into; moving work from there into the mainline is a reviewed pull
   request.

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -108,7 +108,7 @@ elif [ "$MODE" = "all" ]; then
 else
     [ -n "$BASE" ] || BASE="$(pick_base)"
     if [ -z "$BASE" ]; then
-        echo "check.sh: no base branch found (no origin/feat/* or origin/master); use --base" >&2
+        echo "check.sh: no base branch found (no origin/HEAD or origin/master); use --base" >&2
         exit 2
     fi
     MB="$(git merge-base HEAD "$BASE")"

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -64,13 +64,12 @@ contains() {  # contains "list of words" word
 
 pick_base() {
     # The named candidates mirror CONTRIBUTING.md § Branch topology (the
-    # canonical copy) and die with it at M6. Deleted branches are skipped by
-    # the rev-parse guard, so this degrades to origin/HEAD (the default
-    # branch) with no edit required — pruning the stale names is cleanup,
-    # not a correctness fix.
+    # canonical copy; post-M6 the mainline is master). Deleted branches are
+    # skipped by the rev-parse guard, so this degrades to origin/HEAD (the
+    # default branch) with no edit required.
     best=""
     best_n=999999
-    for c in origin/dev origin/HEAD origin/master; do
+    for c in origin/HEAD origin/master; do
         git rev-parse --verify -q "$c" >/dev/null || continue
         mb="$(git merge-base HEAD "$c" 2>/dev/null)" || continue
         n="$(git rev-list --count "$mb..HEAD")"


### PR DESCRIPTION
## What + why

The post-cutover truth-up (follow-up to #631): every doc and tool that described the two-branch world now describes the one-mainline world, and the new standing rule is codified.

- **CONTRIBUTING § Branch topology** rewritten: `master` is the mainline and default PR target; **merges into `master` are always performed by the maintainer** (agents prep the PR — review, disposition, CI — then hand over; bulk integration merges with per-PR review history skip the re-review); `dev` retired-and-frozen (kept so pre-cutover PR bases don't auto-close — do not target it); the legacy line lives at tag `legacy-scanner-final`. Personal-branch flow (`users/<name>` off master, maintainer-merged promotion) unchanged in substance.
- **`/land`** encodes the rule at its merge step and drops the dead roll-forward rule; frontmatter description updated (skill-frontmatter test passes).
- **CONTRIBUTING § Planning/**: the "purged before reaching master" rule retired — its premise (a pristine production `master`) died with the layout; delete-when-executed remains the whole discipline. (Noted: the cutover technically violated the old rule by carrying live Planning docs to master — rewriting the rule, not deleting active plans, is the honest resolution.)
- **`scripts/check.sh`** `pick_base()` drops `origin/dev`.
- **`/get-started`**: personal branches come off `master`.
- Root + GeecsBluesky CLAUDE.md tense fixes (tag reference instead of "until the M6 cutover").

## Tests

`./scripts/check.sh`: lint green, implied suites pass (skill-frontmatter validation included). No package code changed — no version bumps.

## Hardware verification

n/a — docs and tooling only.

---

**Ready for maintainer merge** (this PR's own rule applies to itself).

🤖 Generated with [Claude Code](https://claude.com/claude-code)