### PR TITLE
qs/W4: export s-files from stop documents

### DIFF
--- a/GeecsBluesky/CHANGELOG.md
+++ b/GeecsBluesky/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to `geecs-bluesky` are documented here.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.52.3] - 2026-08-20
+
+### Added
+
+- Legacy scalar s-file export can now run as a RunEngine stop-document
+  callback (`SFileExportCallback`), matching starts/stops by run UID,
+  reading the scan number from start metadata, and preserving the existing
+  best-effort Tiled export posture for queueserver worker wiring.
+
 ## [0.52.2] - 2026-08-20
 
 ### Changed

--- a/GeecsBluesky/CHANGELOG.md
+++ b/GeecsBluesky/CHANGELOG.md
@@ -11,7 +11,9 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Legacy scalar s-file export can now run as a RunEngine stop-document
   callback (`SFileExportCallback`), matching starts/stops by run UID,
   reading the scan number from start metadata, and preserving the existing
-  best-effort Tiled export posture for queueserver worker wiring.
+  best-effort Tiled export posture for queueserver worker wiring. Export
+  is **success-only** (`exit_status == "success"`): aborted/failed runs
+  write no s-file, matching the post-`RE()` call sites this replaces.
 
 ## [0.52.2] - 2026-08-20
 

--- a/GeecsBluesky/geecs_bluesky/sfile_callback.py
+++ b/GeecsBluesky/geecs_bluesky/sfile_callback.py
@@ -21,7 +21,11 @@ class SFileExportCallback:
     """
 
     def __init__(self, exporter: Exporter | None = None) -> None:
-        self._starts: dict[str, dict[str, object]] = {}
+        # uid -> scan_number only (never the full start document): a stop
+        # lost in transit (e.g. a dropped 0MQ message under a future
+        # RemoteDispatcher subscription) then leaks a few bytes, not a copy
+        # of the whole start doc.
+        self._starts: dict[str, int | None] = {}
         self._exporter = exporter
 
     def __call__(self, name: str, doc: Document) -> None:
@@ -43,7 +47,7 @@ class SFileExportCallback:
         if run_uid is None:
             logger.warning("Skipping start document without uid")
             return
-        self._starts[run_uid] = dict(doc)
+        self._starts[run_uid] = _scan_number(doc)
 
     def _export_for_stop(self, doc: Document) -> None:
         run_uid = _string_value(doc.get("run_start"))
@@ -51,20 +55,35 @@ class SFileExportCallback:
             logger.debug("Skipping stop document without run_start uid")
             return
 
-        start = self._starts.pop(run_uid, None)
-        if start is None:
+        if run_uid not in self._starts:
             logger.debug(
                 "Skipping legacy scalar file export for run %s: no start document",
                 run_uid,
             )
             return
-
-        scan_number = _scan_number(start)
+        scan_number = self._starts.pop(run_uid)
         if scan_number is None:
             logger.warning(
                 "Skipping legacy scalar file export for run %s: "
                 "start document has no scan_number",
                 run_uid,
+            )
+            return
+
+        # Parity with the call sites this callback replaces
+        # (GeecsSession post-RE() export): today an aborted or failed run
+        # writes no s-file — the export sites are only reached on clean
+        # completion. Preserve that; exporting partials from aborted runs
+        # is a deliberate future decision, not a side effect (PR #635
+        # review finding 1).
+        exit_status = doc.get("exit_status")
+        if exit_status != "success":
+            logger.info(
+                "Skipping legacy scalar file export for scan %s (uid=%s): "
+                "exit_status=%r",
+                scan_number,
+                run_uid,
+                exit_status,
             )
             return
 

--- a/GeecsBluesky/geecs_bluesky/sfile_callback.py
+++ b/GeecsBluesky/geecs_bluesky/sfile_callback.py
@@ -1,0 +1,116 @@
+"""RunEngine callback for best-effort legacy scalar s-file export."""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable, Mapping
+from typing import TypeAlias
+
+logger = logging.getLogger(__name__)
+
+Document: TypeAlias = Mapping[str, object]
+Exporter: TypeAlias = Callable[[str, int], object]
+
+
+class SFileExportCallback:
+    """Export legacy scalar files when a run's stop document arrives.
+
+    The callback is suitable for ``RunEngine.subscribe`` and intentionally
+    keeps all export failures best-effort: errors are logged and never raised
+    back into the RunEngine.
+    """
+
+    def __init__(self, exporter: Exporter | None = None) -> None:
+        self._starts: dict[str, dict[str, object]] = {}
+        self._exporter = exporter
+
+    def __call__(self, name: str, doc: Document) -> None:
+        """Handle one RunEngine document."""
+        try:
+            if name == "start":
+                self._remember_start(doc)
+            elif name == "stop":
+                self._export_for_stop(doc)
+        except Exception:
+            logger.warning(
+                "Legacy scalar file callback failed while handling %s document",
+                name,
+                exc_info=True,
+            )
+
+    def _remember_start(self, doc: Document) -> None:
+        run_uid = _string_value(doc.get("uid"))
+        if run_uid is None:
+            logger.warning("Skipping start document without uid")
+            return
+        self._starts[run_uid] = dict(doc)
+
+    def _export_for_stop(self, doc: Document) -> None:
+        run_uid = _string_value(doc.get("run_start"))
+        if run_uid is None:
+            logger.debug("Skipping stop document without run_start uid")
+            return
+
+        start = self._starts.pop(run_uid, None)
+        if start is None:
+            logger.debug(
+                "Skipping legacy scalar file export for run %s: no start document",
+                run_uid,
+            )
+            return
+
+        scan_number = _scan_number(start)
+        if scan_number is None:
+            logger.warning(
+                "Skipping legacy scalar file export for run %s: "
+                "start document has no scan_number",
+                run_uid,
+            )
+            return
+
+        exporter = self._exporter or _export_scalar_files
+        try:
+            exporter(run_uid, scan_number)
+        except Exception:
+            logger.warning(
+                "Could not export legacy scalar files for scan %s (uid=%s)",
+                scan_number,
+                run_uid,
+                exc_info=True,
+            )
+
+
+def _export_scalar_files(run_uid: str, scan_number: int) -> object | None:
+    """Best-effort legacy s-file export from Tiled for one completed run."""
+    try:
+        from geecs_data_utils import write_scalar_files_from_tiled
+
+        result = write_scalar_files_from_tiled(run_uid)
+        logger.info("Wrote legacy scalar files: %s", result)
+        return result
+    except Exception:
+        logger.warning(
+            "Could not export legacy scalar files for scan %s (uid=%s)",
+            scan_number,
+            run_uid,
+            exc_info=True,
+        )
+        return None
+
+
+def _scan_number(doc: Document) -> int | None:
+    value = doc.get("scan_number")
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value
+    return None
+
+
+def _string_value(value: object) -> str | None:
+    if isinstance(value, str) and value:
+        return value
+    return None
+
+
+__all__ = ["SFileExportCallback"]

--- a/GeecsBluesky/pyproject.toml
+++ b/GeecsBluesky/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-bluesky"
-version = "0.52.2"
+version = "0.52.3"
 description = "Bluesky / ophyd-async bridge for the GEECS control system"
 authors = ["Sam Barber <sbarber@lbl.gov>"]
 readme = "README.md"

--- a/GeecsBluesky/tests/test_sfile_callback.py
+++ b/GeecsBluesky/tests/test_sfile_callback.py
@@ -20,9 +20,38 @@ def test_callback_exports_matching_stop_document(monkeypatch) -> None:
     callback = SFileExportCallback()
     callback("start", {"uid": "run-a", "scan_number": 17})
     callback("start", {"uid": "run-b", "scan_number": 18})
-    callback("stop", {"uid": "stop-b", "run_start": "run-b"})
+    # Stop the EARLIER run first: an implementation that ignores the uid and
+    # exports "the latest start" fails here (PR #635 review finding 2).
+    callback("stop", {"uid": "stop-a", "run_start": "run-a", "exit_status": "success"})
+    callback("stop", {"uid": "stop-b", "run_start": "run-b", "exit_status": "success"})
 
-    assert calls == [("run-b", 18)]
+    assert calls == [("run-a", 17), ("run-b", 18)]
+
+
+def test_callback_skips_aborted_and_failed_runs(monkeypatch, caplog) -> None:
+    """Parity with the post-RE() call sites: no s-file for a non-success run."""
+    calls: list[tuple[str, int]] = []
+
+    def record_export(run_uid: str, scan_number: int) -> object:
+        calls.append((run_uid, scan_number))
+        return None
+
+    monkeypatch.setattr(sfile_callback, "_export_scalar_files", record_export)
+
+    callback = SFileExportCallback()
+    callback("start", {"uid": "run-a", "scan_number": 30})
+    callback("start", {"uid": "run-b", "scan_number": 31})
+    with caplog.at_level(logging.INFO, logger=sfile_callback.__name__):
+        callback(
+            "stop", {"uid": "stop-a", "run_start": "run-a", "exit_status": "abort"}
+        )
+        callback("stop", {"uid": "stop-b", "run_start": "run-b", "exit_status": "fail"})
+
+    assert calls == []
+    assert "exit_status='abort'" in caplog.text
+    assert "exit_status='fail'" in caplog.text
+    # State hygiene: the skipped runs' entries are released.
+    assert callback._starts == {}
 
 
 def test_callback_swallowing_export_failure_logs_warning(monkeypatch, caplog) -> None:
@@ -35,7 +64,9 @@ def test_callback_swallowing_export_failure_logs_warning(monkeypatch, caplog) ->
     callback("start", {"uid": "run-a", "scan_number": 23})
 
     with caplog.at_level(logging.WARNING, logger=sfile_callback.__name__):
-        callback("stop", {"uid": "stop-a", "run_start": "run-a"})
+        callback(
+            "stop", {"uid": "stop-a", "run_start": "run-a", "exit_status": "success"}
+        )
 
     assert "Could not export legacy scalar files for scan 23 (uid=run-a)" in caplog.text
 
@@ -53,7 +84,9 @@ def test_callback_skips_run_without_scan_number(monkeypatch, caplog) -> None:
     callback("start", {"uid": "run-a"})
 
     with caplog.at_level(logging.WARNING, logger=sfile_callback.__name__):
-        callback("stop", {"uid": "stop-a", "run_start": "run-a"})
+        callback(
+            "stop", {"uid": "stop-a", "run_start": "run-a", "exit_status": "success"}
+        )
 
     assert calls == []
     assert (

--- a/GeecsBluesky/tests/test_sfile_callback.py
+++ b/GeecsBluesky/tests/test_sfile_callback.py
@@ -1,0 +1,62 @@
+"""Tests for legacy scalar s-file export callback."""
+
+from __future__ import annotations
+
+import logging
+
+from geecs_bluesky import sfile_callback
+from geecs_bluesky.sfile_callback import SFileExportCallback
+
+
+def test_callback_exports_matching_stop_document(monkeypatch) -> None:
+    calls: list[tuple[str, int]] = []
+
+    def record_export(run_uid: str, scan_number: int) -> object:
+        calls.append((run_uid, scan_number))
+        return None
+
+    monkeypatch.setattr(sfile_callback, "_export_scalar_files", record_export)
+
+    callback = SFileExportCallback()
+    callback("start", {"uid": "run-a", "scan_number": 17})
+    callback("start", {"uid": "run-b", "scan_number": 18})
+    callback("stop", {"uid": "stop-b", "run_start": "run-b"})
+
+    assert calls == [("run-b", 18)]
+
+
+def test_callback_swallowing_export_failure_logs_warning(monkeypatch, caplog) -> None:
+    def fail_export(run_uid: str, scan_number: int) -> object:
+        raise RuntimeError(f"boom {run_uid} {scan_number}")
+
+    monkeypatch.setattr(sfile_callback, "_export_scalar_files", fail_export)
+
+    callback = SFileExportCallback()
+    callback("start", {"uid": "run-a", "scan_number": 23})
+
+    with caplog.at_level(logging.WARNING, logger=sfile_callback.__name__):
+        callback("stop", {"uid": "stop-a", "run_start": "run-a"})
+
+    assert "Could not export legacy scalar files for scan 23 (uid=run-a)" in caplog.text
+
+
+def test_callback_skips_run_without_scan_number(monkeypatch, caplog) -> None:
+    calls: list[tuple[str, int]] = []
+
+    def record_export(run_uid: str, scan_number: int) -> object:
+        calls.append((run_uid, scan_number))
+        return None
+
+    monkeypatch.setattr(sfile_callback, "_export_scalar_files", record_export)
+
+    callback = SFileExportCallback()
+    callback("start", {"uid": "run-a"})
+
+    with caplog.at_level(logging.WARNING, logger=sfile_callback.__name__):
+        callback("stop", {"uid": "stop-a", "run_start": "run-a"})
+
+    assert calls == []
+    assert (
+        "Skipping legacy scalar file export for run run-a: "
+        "start document has no scan_number"
+    ) in caplog.text


### PR DESCRIPTION
## Summary
- Add `SFileExportCallback` for RunEngine document streams, keyed by run UID and driven by matching stop documents.
- Reuse `geecs_data_utils.write_scalar_files_from_tiled(uid)` behind a best-effort export helper that logs warnings instead of raising into the RunEngine.
- Add hermetic callback tests and bump `geecs-bluesky` to 0.52.3 with a changelog entry.

## Tests
- `cd GeecsBluesky && poetry install --with dev` passed.
- `cd GeecsBluesky && poetry run pytest tests -m 'not integration and not fake_server' -q` -> `434 passed, 26 skipped, 2 deselected, 7 warnings in 6.87s`.

Refs #634