### PR TITLE
qs/W2a: add queueserver launch assets

### DIFF
--- a/GeecsBluesky/CHANGELOG.md
+++ b/GeecsBluesky/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to `geecs-bluesky` are documented here.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.52.4] - 2026-08-21
+
+### Added
+
+- Added `qserver/` launch mechanics for the queueserver migration: a
+  user-group permissions file, a user-level RE Manager launcher that brings up
+  local Redis when needed, operator README notes, and a placeholder startup
+  directory for the separate plan-preamble task.
+
 ## [0.52.3] - 2026-08-20
 
 ### Added

--- a/GeecsBluesky/CHANGELOG.md
+++ b/GeecsBluesky/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to `geecs-bluesky` are documented here.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
-## [0.52.4] - 2026-08-21
+## [0.52.4] - 2026-08-20
 
 ### Added
 

--- a/GeecsBluesky/pyproject.toml
+++ b/GeecsBluesky/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-bluesky"
-version = "0.52.3"
+version = "0.52.4"
 description = "Bluesky / ophyd-async bridge for the GEECS control system"
 authors = ["Sam Barber <sbarber@lbl.gov>"]
 readme = "README.md"

--- a/GeecsBluesky/qserver/README.md
+++ b/GeecsBluesky/qserver/README.md
@@ -1,0 +1,47 @@
+# GEECS Queueserver Launch Assets
+
+This directory contains the user-level launch mechanics for a local
+bluesky-queueserver RE Manager. The startup profile content is intentionally
+not here; it lands with the separate plan-preamble task.
+
+## Launch
+
+From this directory:
+
+```bash
+./launch_re_manager.sh
+```
+
+The launcher expects `start-re-manager` on `PATH`. It checks
+`127.0.0.1:6379` and starts a local Redis server when that port is not
+answering. The Redis binary can be overridden with `QS_REDIS_SERVER`; the
+default is `redis-server`.
+
+```bash
+QS_REDIS_SERVER=/path/to/redis-server ./launch_re_manager.sh
+```
+
+The startup directory defaults to `./startup` and can be overridden with
+`QS_STARTUP_DIR`.
+
+```bash
+QS_STARTUP_DIR=/path/to/startup ./launch_re_manager.sh
+```
+
+The launcher passes `user_group_permissions.yaml` explicitly. Keep that
+argument: without a permissions file, RE Manager may accept startup but reject
+queue submissions with `success: False`, and the command-line failure can be
+silent.
+
+## Verify
+
+In another terminal:
+
+```bash
+qserver status
+qserver environment open
+```
+
+The placeholder `startup/` profile contains no Python yet, so environment
+opening verifies the manager mechanics only. Plan registration and GEECS
+preamble setup arrive in the separate startup-profile task.

--- a/GeecsBluesky/qserver/README.md
+++ b/GeecsBluesky/qserver/README.md
@@ -45,3 +45,18 @@ qserver environment open
 The placeholder `startup/` profile contains no Python yet, so environment
 opening verifies the manager mechanics only. Plan registration and GEECS
 preamble setup arrive in the separate startup-profile task.
+
+## Troubleshooting
+
+- **`queue add` returns `success: False` with no reason at the CLI** — the
+  manager was launched without a permissions file, or the file lacks the
+  group the client submits as (the `qserver` CLI uses `primary` by
+  default). See `user_group_permissions.yaml`.
+- **`queue start` succeeds but the item bounces back and nothing runs** —
+  the startup profile does not define `RE = RunEngine({})` (paired with
+  the launcher's `--keep-re`). Only the manager log shows the cause:
+  `Run Engine is not found in the RE Worker environment`.
+- **`qserver function execute` fails with `RE Manager must be in idle
+  state`** — function execution requires a fully idle manager; it is not
+  available while a plan is running *or paused*. Nothing in the GEECS
+  design may rely on it mid-run.

--- a/GeecsBluesky/qserver/launch_re_manager.sh
+++ b/GeecsBluesky/qserver/launch_re_manager.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if ! command -v start-re-manager >/dev/null 2>&1; then
+    echo "ERROR: start-re-manager is not on PATH." >&2
+    echo "Install bluesky-queueserver or activate its environment." >&2
+    exit 127
+fi
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+PERMISSIONS_FILE="${SCRIPT_DIR}/user_group_permissions.yaml"
+QS_STARTUP_DIR="${QS_STARTUP_DIR:-./startup}"
+QS_REDIS_SERVER="${QS_REDIS_SERVER:-redis-server}"
+
+redis_is_answering() {
+    (exec 3<>/dev/tcp/127.0.0.1/6379) >/dev/null 2>&1
+}
+
+if ! redis_is_answering; then
+    if ! command -v "${QS_REDIS_SERVER}" >/dev/null 2>&1; then
+        echo "ERROR: Redis is not answering on 127.0.0.1:6379." >&2
+        echo "QS_REDIS_SERVER='${QS_REDIS_SERVER}' is not executable." >&2
+        exit 127
+    fi
+
+    echo "Redis is not answering on 127.0.0.1:6379; starting ${QS_REDIS_SERVER}." >&2
+    "${QS_REDIS_SERVER}" --bind 127.0.0.1 --port 6379 --daemonize yes
+
+    for _ in {1..50}; do
+        if redis_is_answering; then
+            break
+        fi
+        sleep 0.1
+    done
+
+    if ! redis_is_answering; then
+        echo "ERROR: Redis did not start or did not answer on 127.0.0.1:6379." >&2
+        exit 1
+    fi
+fi
+
+exec start-re-manager \
+    --startup-dir "${QS_STARTUP_DIR}" \
+    --user-group-permissions "${PERMISSIONS_FILE}" \
+    --zmq-publish-console ON

--- a/GeecsBluesky/qserver/launch_re_manager.sh
+++ b/GeecsBluesky/qserver/launch_re_manager.sh
@@ -39,7 +39,12 @@ if ! redis_is_answering; then
     fi
 fi
 
+# --keep-re: the startup profile defines RE = RunEngine({}) and the manager
+# must keep it — without this pairing, `queue start` silently bounces items
+# and only the manager log shows "Run Engine is not found in the RE Worker
+# environment" (empirical, issue #636).
 exec start-re-manager \
     --startup-dir "${QS_STARTUP_DIR}" \
     --user-group-permissions "${PERMISSIONS_FILE}" \
+    --keep-re \
     --zmq-publish-console ON

--- a/GeecsBluesky/qserver/startup/README.md
+++ b/GeecsBluesky/qserver/startup/README.md
@@ -1,0 +1,1 @@
+Startup profile content arrives with the plan-preamble task; this directory intentionally contains no Python yet.

--- a/GeecsBluesky/qserver/startup/README.md
+++ b/GeecsBluesky/qserver/startup/README.md
@@ -1,1 +1,6 @@
 Startup profile content arrives with the plan-preamble task; this directory intentionally contains no Python yet.
+
+The profile MUST define `RE = RunEngine({})` — the launcher passes
+`--keep-re`, and without a startup-defined RE the manager silently bounces
+every `queue start` (the failure appears only in the manager log as
+"Run Engine is not found in the RE Worker environment").

--- a/GeecsBluesky/qserver/user_group_permissions.yaml
+++ b/GeecsBluesky/qserver/user_group_permissions.yaml
@@ -41,3 +41,15 @@ user_groups:
     allowed_functions: []
     forbidden_functions:
       - null
+
+  # The `qserver` CLI submits as user group `primary` by default — without
+  # this group EVERY CLI submission is rejected with "Unknown user group:
+  # 'primary'" (empirical, issue #636). Admin-equivalent for now; production
+  # tightens it to the `operator` shape.
+  primary:
+    allowed_plans:
+      - ":.*"
+    allowed_devices:
+      - ":?.*:depth=5"
+    allowed_functions:
+      - ":.*"

--- a/GeecsBluesky/qserver/user_group_permissions.yaml
+++ b/GeecsBluesky/qserver/user_group_permissions.yaml
@@ -1,0 +1,43 @@
+user_groups:
+  # Global baseline: allow every discovered plan, device, and function.
+  root:
+    allowed_plans:
+      - null
+    forbidden_plans:
+      - null
+    allowed_devices:
+      - null
+    forbidden_devices:
+      - null
+    allowed_functions:
+      - null
+    forbidden_functions:
+      - null
+
+  # Staff/admin group: regex-all access to plans, devices, and functions.
+  admin:
+    allowed_plans:
+      - ":.*"
+    forbidden_plans:
+      - null
+    allowed_devices:
+      - ":?.*:depth=5"
+    forbidden_devices:
+      - null
+    allowed_functions:
+      - ":.*"
+    forbidden_functions:
+      - null
+
+  # Operator group: queue submission is restricted to GEECS-named plans.
+  operator:
+    allowed_plans:
+      - ":geecs_.*"
+    forbidden_plans:
+      - null
+    allowed_devices: []
+    forbidden_devices:
+      - null
+    allowed_functions: []
+    forbidden_functions:
+      - null


### PR DESCRIPTION
## Summary
- Add `GeecsBluesky/qserver/user_group_permissions.yaml` with root, admin, and restricted operator groups for RE Manager startup.
- Add `launch_re_manager.sh` to check `start-re-manager`, start local Redis when `127.0.0.1:6379` is not answering, and exec RE Manager with the permissions file and console publishing enabled.
- Add qserver operator notes plus a placeholder `startup/` README for the separate plan-preamble task.
- Bump `geecs-bluesky` to 0.52.4 and add a changelog entry.

## Validation
- `bash -n GeecsBluesky/qserver/launch_re_manager.sh` -> no output, exit 0.
- `python3.11 -c "import yaml,sys; yaml.safe_load(open('GeecsBluesky/qserver/user_group_permissions.yaml'))"` -> no output, exit 0.
- `cd GeecsBluesky && poetry run python -c "import yaml,sys; yaml.safe_load(open('qserver/user_group_permissions.yaml'))"` -> no output, exit 0.
- `git diff --check` -> no output, exit 0.
- `scripts/commit.sh -m "Add queueserver launch assets"` -> hooks passed, including `check yaml` and `check toml`; jupyter clear-output skipped because `jupyter` is not installed locally.

Note: the literal `python -c ...` form from the issue cannot run on this machine because there is no bare `python` executable on `PATH`; the YAML was validated with both `python3.11` and Poetry's package Python.

Refs #636