### PR TITLE
GeecsBluesky 0.53.0: geecs_scan_request_plan — run a ScanRequest as one plan (qs/W1, #633)

### DIFF
--- a/GeecsBluesky/CHANGELOG.md
+++ b/GeecsBluesky/CHANGELOG.md
@@ -4,6 +4,41 @@ All notable changes to `geecs-bluesky` are documented here.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.53.0] - 2026-08-20
+
+### Added
+
+- **`geecs_scan_request_plan` — "run this ScanRequest" as one Bluesky plan**
+  (`plans/scan_request_plan.py`), the queueserver migration's one structural
+  unit (issue #633, round 1;
+  `Planning/cutover_strategy/02_queueserver_migration.md`).  The
+  `run_scan_request` prologue relocates into the plan **preamble**, executed
+  worker-side inside the RunEngine: authoritative fail-fast validation →
+  name resolution → worker-side construction of the ShotController, action
+  signals, detectors, and scan-axis movables (bound methods/closures never
+  cross a process boundary) → in-plan connects (`ensure_connected` batches
+  for the strict tier, a soft gather for Tier-2 telemetry, the shot-control
+  reachability check) → the scan-number claim → the same inner plan as today
+  (`build_step_scan_plan`), with ScanInfo, per-scan `scan.log`, and a
+  finalize that disconnects everything the plan created.  Everything before
+  the claim burns no scan number.  `set_plan_session()` installs the
+  worker-wide default session so `RE(geecs_scan_request_plan(request))`
+  needs only the JSON request; no bluesky-queueserver import exists — a
+  later round registers the callable with a manager.  Optimize-mode requests
+  are validated then refused loudly (`NotImplementedError`; the in-worker
+  optimization-loader invocation is a later round); step and noscan produce
+  the same documents as `run_scan_request` (pinned by hermetic
+  document-parity tests in `tests/test_scan_request_plan.py`).  The post-run
+  s-file export is deliberately absent from the plan — it becomes a worker
+  stop-document callback (a parallel task owns that seam).
+
+### Changed
+
+- `run_scan_request`'s inline run-metadata / ScanInfo / grid assembly is
+  extracted into the pure `build_step_scan_spec()` (+ `StepScanSpec`),
+  shared verbatim with the new plan preamble so the two entry points cannot
+  drift.  No behavior change (pinned by the existing runner suite).
+
 ## [0.52.2] - 2026-08-20
 
 ### Changed

--- a/GeecsBluesky/CLAUDE.md
+++ b/GeecsBluesky/CLAUDE.md
@@ -101,6 +101,15 @@ geecs_bluesky/
     single_shot.py          # geecs_single_shot + geecs_confirm_quiescent
     t0_sync.py              # geecs_t0_sync — coordinated per-device t0 capture
     run_wrapper.py          # geecs_run_wrapper + claim_scan_number (numbering + save + md)
+    scan_request_plan.py    # geecs_scan_request_plan — "run this ScanRequest"
+                            #   as ONE plan (queueserver round 1, issue #633):
+                            #   the run_scan_request prologue relocated into
+                            #   the plan preamble (validate → resolve →
+                            #   construct+connect in-plan → claim → the same
+                            #   inner plan); set_plan_session installs the
+                            #   worker default session; optimize refused
+                            #   loudly (later round); s-file export is NOT
+                            #   here (worker stop-doc callback seam)
   devices/
     ca/                     # THE device family: CA-backed via GeecsCAGateway PVs (`ca` extra)
       triggerable.py        # CaAcqTimestampReadable (persistent CA monitor) + CaTriggerable

--- a/GeecsBluesky/geecs_bluesky/plans/scan_request_plan.py
+++ b/GeecsBluesky/geecs_bluesky/plans/scan_request_plan.py
@@ -88,7 +88,11 @@ logger = logging.getLogger(__name__)
 
 __all__ = ["geecs_scan_request_plan", "set_plan_session"]
 
-#: Per-batch device connect budget — parity with ``GeecsSession._connect``.
+#: Per-connect timeout for the in-plan strict batches.  Near-parity, not
+#: parity, with ``GeecsSession._connect``: there 20 s is the outer wall on
+#: the loop hop while each connect runs at the ophyd-async default (10 s),
+#: so an unreachable device fails at ~10 s; here the 20 s *is* the
+#: per-connect timeout, so the same failure surfaces ~10 s later.
 _CONNECT_TIMEOUT = 20.0
 
 #: The session factory methods whose *construction* code the plan reuses
@@ -311,6 +315,15 @@ def geecs_scan_request_plan(
     and abort alike.  The post-run s-file export is deliberately absent
     (worker stop-document callback; see the module docstring).
 
+    The preamble's I/O is deliberately *blocking* inside the generator:
+    config-repo reads, the DB policy queries, the claim's folder listing,
+    and the ScanInfo write all run in the RunEngine thread, so a pause or
+    stop request is not serviced until the current call returns — the
+    accepted consequence of relocating the prologue into the plan.  The
+    worst case is a DB or data-share stall (off the lab network, the DB
+    socket timeout is ~75 s).  Executor offload of these calls is the
+    filed hardening follow-up if that window bites in operation.
+
     Parameters
     ----------
     request :
@@ -378,9 +391,10 @@ def _scan_request_body(
     if request.mode is ScanRequestMode.OPTIMIZE:
         raise NotImplementedError(
             "optimize-mode ScanRequests are not yet served by "
-            "geecs_scan_request_plan (queueserver round 1 covers step and "
-            "noscan; the in-worker optimization-loader invocation is a later "
-            "round) — run them through GeecsSession.run / run_scan_request"
+            "geecs_scan_request_plan: the optimization loader is registered "
+            "by the worker startup script, which lands in the worker-startup "
+            "round (W2) — round 1 covers step and noscan. Until then, run "
+            "optimize requests through GeecsSession.run / run_scan_request"
         )
 
     controller = None

--- a/GeecsBluesky/geecs_bluesky/plans/scan_request_plan.py
+++ b/GeecsBluesky/geecs_bluesky/plans/scan_request_plan.py
@@ -1,0 +1,545 @@
+"""geecs_scan_request_plan — "run this ScanRequest" as one Bluesky plan.
+
+The queueserver migration's one structural unit
+(``Planning/cutover_strategy/02_queueserver_migration.md`` § The one
+structural task): a plan generator whose **preamble** relocates the
+:func:`~geecs_bluesky.scan_request_runner.run_scan_request` prologue to the
+worker side — validate → resolve save sets/actions/trigger → construct +
+connect devices → claim the scan number — and then yields the same inner
+plan (:func:`~geecs_bluesky.plans.orchestration.build_step_scan_plan`) a
+``run_scan_request`` scan runs today.  Because the preamble runs *inside*
+the plan, every bound method and closure (ShotController stubs, per-step
+action callables) is constructed worker-side from the JSON request and
+never crosses a process boundary.
+
+The prologue pieces are the runner's own module-level functions — shared,
+not copied — so the legacy entry point (which the console keeps using until
+Round 3) and this plan cannot drift.  Differences from the legacy path are
+deliberate, per the Planning doc's decisions and 2026-08-20 amendments:
+
+- **Validation runs here, authoritatively** (amendment 2: no separate
+  validation plan stub; clients re-run :func:`validate_scan_request`
+  pre-submit for immediate feedback).
+- **No operator seams.**  Pre-flight questions move client-side pre-submit
+  (decision 3), so the unserved-variables check runs with the headless
+  default (continue-and-drop with a WARNING); the GUI ``preflight`` /
+  ``on_scan_start`` / ``should_abort`` / ``pause_supervisor`` hooks have no
+  plan-side equivalent (the manager's queue/status API owns stop/pause,
+  decision 4; progress rides the document stream).
+- **Device connects are plan messages.**  The session factories connect via
+  ``run_coroutine_threadsafe`` onto the RE loop — a deadlock from inside a
+  plan — so construction is deferred through a session facade and the
+  batch connects ride :func:`ophyd_async.plan_stubs.ensure_connected` /
+  ``bps.wait_for``, still pre-claim (a connect failure burns no number).
+- **s-file export is not the plan's job**: it becomes a worker-side
+  stop-document callback (a parallel task owns that seam in
+  ``session.py``); the emitted documents are identical either way.
+- **Optimize mode is refused loudly** (validated first).  Decision 5's
+  in-worker optimization-loader invocation is a later round; step and
+  noscan are this round's acceptance surface.
+
+No queueserver import lives here — this is an ordinary plan callable; a
+worker startup script registers it with the manager (and installs the
+worker-wide default session via :func:`set_plan_session`) later.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any
+
+import bluesky.plan_stubs as bps
+import bluesky.preprocessors as bpp
+from ophyd_async.plan_stubs import ensure_connected
+
+from geecs_bluesky.config_resolver import ConfigResolver, ConfigsRepoResolver
+from geecs_bluesky.db_runtime import select_telemetry_variables
+from geecs_bluesky.exceptions import GeecsConfigurationError
+from geecs_bluesky.plans.orchestration import build_step_scan_plan
+from geecs_bluesky.plans.run_wrapper import claim_scan_number
+from geecs_bluesky.scan_log import (
+    begin_pre_scan_capture,
+    discard_pre_scan_capture,
+    scan_log,
+)
+from geecs_bluesky.scan_request_runner import (
+    _build_request_detectors,
+    _defaults_flag,
+    _preflight_unserved,
+    assemble_action_slots,
+    build_action_registry,
+    build_movable,
+    build_step_scan_spec,
+    compile_action_slot,
+    make_scalar_policy,
+    prefetch_action_signals,
+    resolve_movable_target,
+    resolve_save_sets_and_rituals,
+    save_set_to_devices_config,
+    trigger_writes_from_profile,
+    validate_scan_request,
+    warn_if_reserved_boundary_overrides,
+)
+from geecs_bluesky.shot_controller import ShotController
+from geecs_schemas import AcquisitionMode, ScanRequest, ScanRequestMode
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["geecs_scan_request_plan", "set_plan_session"]
+
+#: Per-batch device connect budget — parity with ``GeecsSession._connect``.
+_CONNECT_TIMEOUT = 20.0
+
+#: The session factory methods whose *construction* code the plan reuses
+#: verbatim (only the connect step is deferred — see
+#: :class:`_DeferredConnectFactories`).
+_SESSION_FACTORIES = frozenset(
+    {
+        "detector",
+        "contributor",
+        "snapshot",
+        "motor",
+        "settable",
+        "confirm_settable",
+        "pseudo_movable",
+        "action_signal_factory",
+    }
+)
+
+#: The worker-wide default session (installed once at worker startup).
+_worker_session: Any | None = None
+
+
+def set_plan_session(session: Any | None) -> None:
+    """Install the worker-wide default :class:`GeecsSession` for the plan.
+
+    The queueserver registers plans by name with JSON args, so the session
+    cannot travel in the call — a worker startup script constructs one
+    headless session and installs it here; ``RE(geecs_scan_request_plan(
+    request))`` then needs nothing else.  Pass ``None`` to clear (tests).
+
+    Parameters
+    ----------
+    session :
+        The session whose RunEngine will execute the plan.  The plan's
+        connect messages run on that engine's loop, so running the plan on
+        a *different* RunEngine than ``session.RE`` is unsupported.
+    """
+    global _worker_session
+    _worker_session = session
+
+
+class _DeferredConnectFactories:
+    """A session facade: identical device construction, connect deferred.
+
+    The session's factory methods (``detector``, ``motor``, …) are the one
+    definition of how request devices are constructed — but each ends in
+    ``self._connect(device)``, a blocking hop onto the RE loop that would
+    deadlock inside a plan.  This facade binds those *same* class functions
+    to itself (so the construction code cannot drift from the session's)
+    and swaps only ``_connect``: devices are recorded on :attr:`created`
+    and connected later in one in-plan batch.  Everything else (attributes
+    like ``experiment`` / ``_mock`` / ``rep_rate_hz``) delegates to the
+    wrapped session.
+
+    Deliberately *not* covering ``telemetry``/``telemetry_batch``: the soft
+    tier's connect-failure-drops semantics need their own in-plan gather
+    (:func:`_connect_telemetry_plan`), not the strict batch connect.
+    """
+
+    def __init__(self, session: Any) -> None:
+        self._session = session
+        self.created: list = []
+
+    def _connect(self, device: Any) -> Any:
+        self.created.append(device)
+        return device
+
+    def __getattr__(self, name: str) -> Any:
+        if name in _SESSION_FACTORIES:
+            func = getattr(type(self._session), name, None)
+            if func is not None:
+                return func.__get__(self, type(self))
+        return getattr(self._session, name)
+
+
+def _await_in_plan(coro_fn: Any):
+    """Plan stub: await one no-arg coroutine function, propagating its error.
+
+    ``bps.wait_for`` alone parks the plan on the future but discards its
+    outcome; re-raising through ``task.result()`` keeps in-plan connects
+    fail-fast (the ophyd-async ``wait_for_awaitable`` idiom, not exported
+    by the pinned release).
+    """
+    tasks = yield from bps.wait_for([coro_fn])
+    return tasks[0].result()
+
+
+def _connect_in_batches(devices: list, *, mock: bool):
+    """Plan stub: strict-connect *devices* via ``ensure_connected``.
+
+    ``ensure_connected`` refuses duplicate device names within one call, and
+    an action-check signal can legitimately share a name with a scan-axis
+    movable on the same ``Device:Variable`` — so the list is split into
+    unique-name batches instead of failing the scan on a naming accident.
+    Failures propagate (strict tier fails loudly), pre-claim.
+    """
+    pending = list(devices)
+    while pending:
+        batch: list = []
+        rest: list = []
+        seen: set[str] = set()
+        for device in pending:
+            if device.name in seen:
+                rest.append(device)
+            else:
+                seen.add(device.name)
+                batch.append(device)
+        yield from ensure_connected(*batch, mock=mock, timeout=_CONNECT_TIMEOUT)
+        pending = rest
+
+
+def _connect_telemetry_plan(session: Any, save_set: Any, scalar_policy: Any):
+    """Plan stub: build + soft-connect the Tier-2 telemetry group in-plan.
+
+    The in-plan sibling of the runner's
+    :func:`~geecs_bluesky.scan_request_runner.build_telemetry_readables`
+    over ``session.telemetry_batch`` (which hops onto the RE loop — a
+    deadlock from inside a plan): same selection
+    (:func:`~geecs_bluesky.db_runtime.select_telemetry_variables`), same
+    soft-tier contract (a device unreachable at scan start is dropped with
+    a warning, never an abort; only connected devices are recorded), same
+    single :class:`~geecs_bluesky.devices.ca.telemetry.CaTelemetryGroup`
+    per scan.  One concurrent gather, so wall time is the slowest device.
+
+    Returns
+    -------
+    tuple
+        ``(readables, recorded)`` as ``build_telemetry_readables``.
+    """
+    if scalar_policy is None:
+        return [], {}
+    selected = select_telemetry_variables(
+        save_set, scalar_policy.subscribed_by_device()
+    )
+    if not selected:
+        return [], {}
+    # Lazy import: keeps this module importable without the `ca` extra
+    # (same discipline as the runner).
+    from geecs_bluesky.devices.ca.telemetry import CaTelemetryGroup, CaTelemetryReadable
+
+    members = [
+        CaTelemetryReadable(device, variables, experiment=session.experiment)
+        for device, variables in selected.items()
+    ]
+    results: list = []
+
+    async def _connect_all() -> None:
+        results.extend(
+            await asyncio.gather(
+                *(m.connect(mock=session._mock) for m in members),
+                return_exceptions=True,
+            )
+        )
+
+    yield from bps.wait_for([_connect_all])
+
+    connected: list = []
+    recorded: dict[str, list[str]] = {}
+    for member, variables, result in zip(members, selected.values(), results):
+        if isinstance(result, BaseException):
+            logger.warning(
+                "Dropping background-telemetry device %s: unreachable at scan "
+                "start (soft tier — never aborts the scan)",
+                member._geecs_device_name,
+                exc_info=result,
+            )
+        else:
+            connected.append(member)
+            recorded[member._geecs_device_name] = list(variables)
+    if not connected:
+        return [], recorded
+    return [CaTelemetryGroup(connected)], recorded
+
+
+def _disconnect_plan(created: list):
+    """Plan stub: best-effort disconnect of everything the plan created.
+
+    The in-plan counterpart of the runner's ``finally:
+    session.disconnect(*created)`` (which hops onto the RE loop).  Runs as
+    a finalize, so it executes on success, failure, and abort alike; each
+    device's failure is swallowed (gather with exceptions returned) —
+    cleanup never masks the plan's own outcome.
+    """
+    closers = [d for d in created if hasattr(d, "disconnect")]
+    if not closers:
+        return
+
+    async def _disconnect_all() -> None:
+        await asyncio.gather(*(d.disconnect() for d in closers), return_exceptions=True)
+
+    yield from bps.wait_for([_disconnect_all])
+
+
+def geecs_scan_request_plan(
+    request: dict | ScanRequest,
+    *,
+    session: Any | None = None,
+    resolver: ConfigResolver | None = None,
+):
+    """Run one ScanRequest as a single Bluesky plan (preamble + inner plan).
+
+    ``RE(geecs_scan_request_plan(request))`` is the queueserver-shaped
+    equivalent of :func:`~geecs_bluesky.scan_request_runner.run_scan_request`
+    for step and noscan requests: the same documents, the same data tree,
+    the same ScanInfo and per-scan ``scan.log`` — with every prologue stage
+    relocated inside the plan.  Order of operations (everything before the
+    claim is fail-fast and burns no scan number):
+
+    1. validate (authoritative — the same :func:`validate_scan_request`
+       clients run pre-submit) and resolve every name;
+    2. construct the shot controller, action-signal stubs, detectors, and
+       scan-axis movables worker-side (deferred connects);
+    3. connect everything via plan messages (strict tier fails loudly,
+       telemetry drops soft);
+    4. claim the scan number, write ScanInfo, attach ``scan.log``;
+    5. yield the same inner plan as today
+       (:func:`~geecs_bluesky.plans.orchestration.build_step_scan_plan`).
+
+    A finalize disconnects everything the plan created — success, failure,
+    and abort alike.  The post-run s-file export is deliberately absent
+    (worker stop-document callback; see the module docstring).
+
+    Parameters
+    ----------
+    request :
+        ``ScanRequest.model_dump()`` output (the queue's JSON shape) or an
+        already-validated :class:`~geecs_schemas.ScanRequest`.
+    session :
+        The :class:`~geecs_bluesky.session.GeecsSession` whose RunEngine
+        executes this plan.  Defaults to the worker-wide session installed
+        by :func:`set_plan_session`.
+    resolver :
+        Name resolver; defaults to
+        :class:`~geecs_bluesky.config_resolver.ConfigsRepoResolver` over
+        the session's experiment.
+
+    Raises
+    ------
+    GeecsConfigurationError
+        No session configured, unresolvable names, a bad pseudo formula,
+        a strict request without usable shot control, or an empty
+        effective device set — all pre-claim.
+    NotImplementedError
+        Optimize-mode requests (validated first, refused loudly — a later
+        round moves the optimization loader in-worker per decision 5).
+    """
+    if session is None:
+        session = _worker_session
+        if session is None:
+            raise GeecsConfigurationError(
+                "geecs_scan_request_plan has no session: install one with "
+                "set_plan_session(...) at worker startup, or pass session=..."
+            )
+    if resolver is None:
+        resolver = ConfigsRepoResolver(session.experiment)
+
+    created: list = []
+    # Pre-claim log lines (validation, connects, telemetry drops) buffer
+    # into the scan.log attach at the claim, exactly as GeecsSession.run
+    # does; a buffer never consumed (failure before the claim) is discarded.
+    begin_pre_scan_capture()
+    try:
+        return (
+            yield from bpp.finalize_wrapper(
+                _scan_request_body(session, resolver, request, created),
+                lambda: _disconnect_plan(created),
+            )
+        )
+    finally:
+        discard_pre_scan_capture()
+
+
+def _scan_request_body(
+    session: Any, resolver: ConfigResolver, request: dict | ScanRequest, created: list
+):
+    """The plan body behind :func:`geecs_scan_request_plan` (see its doc).
+
+    *created* is the caller-owned cleanup list: everything appended here is
+    disconnected by the enclosing finalize, so a failure at any stage still
+    tears down whatever already existed.
+    """
+    # ---- phase 1: authoritative validation + pure resolution (pre-claim) --
+    if not isinstance(request, ScanRequest):
+        request = ScanRequest.model_validate(request)
+    request, applied_defaults, defaults = validate_scan_request(request, resolver)
+
+    if request.mode is ScanRequestMode.OPTIMIZE:
+        raise NotImplementedError(
+            "optimize-mode ScanRequests are not yet served by "
+            "geecs_scan_request_plan (queueserver round 1 covers step and "
+            "noscan; the in-worker optimization-loader invocation is a later "
+            "round) — run them through GeecsSession.run / run_scan_request"
+        )
+
+    controller = None
+    if request.trigger_profile:
+        profile = resolver.resolve_trigger_profile(request.trigger_profile)
+        writes = trigger_writes_from_profile(profile, request.trigger_variant)
+        if writes.states:
+            # Constructed worker-side, unconnected; the setter reachability
+            # check joins the in-plan connect stage below.
+            controller = ShotController.from_writes(
+                writes,
+                experiment=session.experiment,
+                rep_rate_hz=session.rep_rate_hz,
+            )
+    strict = request.acquisition is AcquisitionMode.STRICT
+
+    save_set, rituals = resolve_save_sets_and_rituals(resolver, request.save_sets)
+    scalar_policy = make_scalar_policy(session)
+    devices_config = save_set_to_devices_config(save_set, scalar_policy)
+    # Unserved-variables check, headless by decision 3 (operator questions
+    # are client-side pre-submit): continue-and-drop with a WARNING.
+    checked_config, dropped_unserved, dropped_unserved_devices = _preflight_unserved(
+        session, devices_config, None
+    )
+    if checked_config is None:  # defensive: the headless default never aborts
+        raise GeecsConfigurationError(
+            "unserved-variables pre-flight aborted the scan (pre-claim)"
+        )
+    devices_config = checked_config
+    slots = assemble_action_slots(request.actions, applied_defaults, rituals)
+    warn_if_reserved_boundary_overrides(save_set)
+    axis_resolved = [
+        resolve_movable_target(
+            resolver.resolve_scan_variable(axis.variable), axis.variable
+        )
+        for axis in request.axes
+    ]
+    telemetry_enabled = (
+        request.background_telemetry
+        if request.background_telemetry is not None
+        else _defaults_flag(defaults, "background_telemetry", True)
+    )
+
+    # ---- phase 2: worker-side construction (connects deferred) -----------
+    factories = _DeferredConnectFactories(session)
+    setup = per_step = closeout = None
+    if any(slots.values()):
+        factory = factories.action_signal_factory()
+        created.append(factory)
+        registry = build_action_registry(resolver)
+        setup, setup_plans = compile_action_slot(
+            slots["setup"], resolver, registry, factory
+        )
+        per_step, per_step_plans = compile_action_slot(
+            slots["per_step"], resolver, registry, factory
+        )
+        closeout, closeout_plans = compile_action_slot(
+            slots["closeout"], resolver, registry, factory
+        )
+        # With the facade, "prefetch" records the signals for the batch
+        # connect below — same fail-fast property, now a plan message.
+        prefetch_action_signals(
+            setup_plans + per_step_plans + closeout_plans, registry, factory
+        )
+
+    detectors = _build_request_detectors(factories, devices_config, free_run=not strict)
+    movables = [build_movable(factories, target) for target in axis_resolved]
+    created.extend(factories.created)
+
+    # ---- phase 3: in-plan connects (still pre-claim) ----------------------
+    if factories.created:
+        yield from _connect_in_batches(factories.created, mock=session._mock)
+    telemetry_selected: dict[str, list[str]] = {}
+    telemetry_readables: list = []
+    if telemetry_enabled:
+        telemetry_readables, telemetry_selected = yield from _connect_telemetry_plan(
+            session, save_set, scalar_policy
+        )
+        created.extend(telemetry_readables)
+    # Telemetry is soft: appended as extra snapshot columns, never the
+    # reference (index 0 stays the save set's).
+    all_detectors = list(detectors) + telemetry_readables
+    if controller is not None and not session._mock:
+        # Fail fast on an unreachable shot-control PV (the session does this
+        # at attach time; in-plan it joins the pre-claim connect stage).
+        yield from _await_in_plan(controller.connect_setters)
+
+    if not all_detectors:
+        raise GeecsConfigurationError(
+            "ScanRequest produced no detectors (empty effective device set) — "
+            "nothing would be recorded"
+        )
+    if strict:
+        if controller is None:
+            raise GeecsConfigurationError(
+                "strict_shot_control requires a reachable shot-control device. "
+                "Use free-run mode for free-running trigger acquisition."
+            )
+        controller.require_strict_single_shot()
+
+    spec = build_step_scan_spec(
+        request,
+        axis_resolved,
+        applied_defaults=applied_defaults,
+        slots=slots,
+        dropped_unserved=dropped_unserved,
+        dropped_unserved_devices=dropped_unserved_devices,
+        telemetry_selected=telemetry_selected if telemetry_enabled else {},
+    )
+    if request.mode is ScanRequestMode.NOSCAN:
+        motor_arg: Any = None
+    elif len(movables) == 1:
+        motor_arg = movables[0]
+    else:
+        motor_arg = movables
+
+    # ---- phase 4: the claim boundary --------------------------------------
+    scan_number, scan_folder = claim_scan_number(session.experiment)
+    if scan_number is not None:
+        session._write_scan_info(
+            scan_number,
+            scan_folder,
+            motor=motor_arg,
+            positions=spec.positions,
+            shots_per_step=request.shots_per_step,
+            description=request.description,
+            overrides=spec.scan_info,
+        )
+
+    # Role wiring + native-save configuration, exactly as GeecsSession.scan.
+    reference = all_detectors[0]
+    for det in all_detectors:
+        if hasattr(det, "configure_shot_id"):
+            det.configure_shot_id(session.rep_rate_hz)
+        if hasattr(det, "set_reference") and det is not reference:
+            det.set_reference(reference)
+    saving_detectors = session._configure_saving(
+        all_detectors, scan_number, scan_folder
+    )
+
+    # ---- phase 5: the inner plans, exactly as today ------------------------
+    inner = build_step_scan_plan(
+        strict=strict,
+        motor=motor_arg,
+        positions=spec.positions,
+        reference=reference,
+        detectors=all_detectors,
+        shots_per_step=request.shots_per_step,
+        controller=controller,
+        experiment=session.experiment,
+        scan_number=scan_number,
+        scan_folder=scan_folder,
+        saving_detectors=saving_detectors,
+        extra_md={"description": request.description, **spec.md},
+        setup=setup,
+        per_step=per_step,
+        closeout=closeout,
+    )
+    # The plan claimed the number, so the plan owns the per-scan scan.log
+    # (the GeecsSession.scan claimed-here rule; tolerates a failed claim).
+    with scan_log(scan_number, scan_folder):
+        return (yield from inner)

--- a/GeecsBluesky/geecs_bluesky/scan_request_runner.py
+++ b/GeecsBluesky/geecs_bluesky/scan_request_runner.py
@@ -1846,7 +1846,7 @@ def _run_optimize_request(
         if dropped_unserved_devices:
             md["dropped_unserved_devices"] = list(dropped_unserved_devices)
         if applied_defaults:
-            md["applied_defaults"] = applied_defaults
+            md["applied_defaults"] = dict(applied_defaults)
         if skipped:
             md["skipped_action_plans"] = skipped
             logger.warning(

--- a/GeecsBluesky/geecs_bluesky/scan_request_runner.py
+++ b/GeecsBluesky/geecs_bluesky/scan_request_runner.py
@@ -927,6 +927,142 @@ class PseudoMovableTarget:
 MovableTarget = PlainMovableTarget | PseudoMovableTarget
 
 
+@dataclass(frozen=True)
+class StepScanSpec:
+    """The pure execution picture of a step/noscan request (no devices).
+
+    Everything :func:`run_scan_request` derives from the request *before*
+    touching hardware, packaged so the legacy entry point and the
+    queueserver plan preamble
+    (:func:`~geecs_bluesky.plans.scan_request_plan.geecs_scan_request_plan`)
+    share one definition of the run metadata / ScanInfo / grid shapes and
+    cannot drift (the acceptance contract is document equality).
+
+    Attributes
+    ----------
+    md :
+        The run-metadata dict (``scan_request_mode``, provenance keys,
+        grid/pseudo metadata) — the caller merges ``description`` on top.
+    scan_info :
+        The ScanInfo ini overrides (``scan_mode``, ``scan_parameter``,
+        legacy 1-D grid fields).
+    positions :
+        The positions list handed to the scan plan: ``[None]`` for noscan,
+        the axis values for a single axis, grid-point tuples for a grid.
+    n_steps, n_shots :
+        Progress totals (the ``on_scan_start`` hook contract).
+    """
+
+    md: dict[str, Any]
+    scan_info: dict[str, Any]
+    positions: list[Any]
+    n_steps: int
+    n_shots: int
+
+
+def build_step_scan_spec(
+    request: ScanRequest,
+    axis_resolved: list["MovableTarget"],
+    *,
+    applied_defaults: Mapping[str, Any],
+    slots: Mapping[str, list[str]],
+    dropped_unserved: Mapping[str, list[str]],
+    dropped_unserved_devices: list[str],
+    telemetry_selected: Mapping[str, list[str]],
+) -> StepScanSpec:
+    """Assemble the pure run picture of a step/noscan request.
+
+    Relocated verbatim from :func:`run_scan_request`'s inline metadata
+    assembly (queueserver round 1) so the plan preamble reuses it; behavior
+    is pinned by the existing runner suite.  Multi-axis requests become an
+    outer-product grid (first axis outermost/slowest, one bin per grid
+    point) with the legacy 1-D ScanInfo fields describing the outermost
+    axis.
+
+    Parameters
+    ----------
+    request :
+        The **post-defaults** validated request (step or noscan mode).
+    axis_resolved :
+        The resolved movable target per ``request.axes`` entry (empty for
+        noscan) — :func:`resolve_movable_target` output, in axis order.
+    applied_defaults, slots, dropped_unserved, dropped_unserved_devices,
+    telemetry_selected :
+        The provenance records accumulated by the prologue; each lands in
+        run metadata only when non-empty (pass ``{}``/``[]`` to omit —
+        e.g. ``telemetry_selected`` must already be gated on the
+        telemetry-enabled flag).
+    """
+    md: dict[str, Any] = {"scan_request_mode": request.mode.value}
+    # Provenance: which named save sets were unioned for this scan.
+    md["save_sets"] = list(request.save_sets)
+    if dropped_unserved:
+        # Provenance: variables (and whole devices) dropped by the
+        # unserved-variables pre-flight — the run proceeded without them.
+        md["dropped_unserved_variables"] = {
+            dev: list(vars_) for dev, vars_ in dropped_unserved.items()
+        }
+    if dropped_unserved_devices:
+        md["dropped_unserved_devices"] = list(dropped_unserved_devices)
+    if applied_defaults:
+        # Provenance: the run records exactly which experiment defaults
+        # filled in fields the submitter left unset.
+        md["applied_defaults"] = dict(applied_defaults)
+    if any(slots.values()):
+        # Provenance: the assembled per-slot execution order (defaults +
+        # entry rituals + the request's own, mirrored on closeout).
+        md["action_plans"] = {k: list(v) for k, v in slots.items() if v}
+    if telemetry_selected:
+        md["background_telemetry"] = {
+            dev: list(vars_) for dev, vars_ in telemetry_selected.items()
+        }
+    scan_info: dict[str, Any] = {
+        "shots": request.shots_per_step,
+        "background": request.background,
+    }
+
+    if request.mode is ScanRequestMode.NOSCAN:
+        scan_info["scan_mode"] = "noscan"
+        return StepScanSpec(md, scan_info, [None], 1, request.shots_per_step)
+
+    targets = [target.label for target in axis_resolved]
+    value_lists = [axis.positions.to_values() for axis in request.axes]
+    pseudo_meta = {
+        target.variable_name: target.metadata()
+        for target in axis_resolved
+        if isinstance(target, PseudoMovableTarget)
+    }
+    if pseudo_meta:
+        md["pseudo_variables"] = pseudo_meta
+
+    scan_info["scan_mode"] = "standard"
+    scan_info["scan_parameter"] = ",".join(targets)
+    if len(request.axes) == 1:
+        positions: list[Any] = list(value_lists[0])
+        md["scan_variable"] = request.axes[0].variable
+    else:
+        # Outer product, first axis outermost/slowest (the schema's
+        # documented grid semantics); one bin per grid point.
+        positions = [tuple(point) for point in itertools.product(*value_lists)]
+        md["scan_variable"] = ",".join(a.variable for a in request.axes)
+        md["scan_axes"] = [a.variable for a in request.axes]
+        md["grid_shape"] = list(request.grid_shape())
+        md["num_grid_points"] = request.n_steps()
+        # ScanInfo is a legacy 1-D format: Start/End/Step describe the
+        # outermost axis; the grid truth lives in the run metadata.
+        outer = value_lists[0]
+        scan_info["start"] = outer[0]
+        scan_info["end"] = outer[-1]
+        scan_info["step"] = (outer[1] - outer[0]) if len(outer) > 1 else 0
+    return StepScanSpec(
+        md,
+        scan_info,
+        positions,
+        len(positions),
+        len(positions) * request.shots_per_step,
+    )
+
+
 def resolve_movable_target(spec: ScanVariableSpec, name: str) -> MovableTarget:
     """Resolve a catalog entry into its movable target, fail-fast.
 
@@ -1481,111 +1617,45 @@ def run_scan_request(
             if _stopped_during_init(session, should_abort, "after preflight"):
                 return None
 
-        md: dict[str, Any] = {"scan_request_mode": request.mode.value}
-        # Provenance: which named save sets were unioned for this scan.
-        md["save_sets"] = list(request.save_sets)
-        if dropped_unserved:
-            # Provenance: variables (and whole devices) dropped by the
-            # unserved-variables pre-flight — the run proceeded without them.
-            md["dropped_unserved_variables"] = {
-                dev: list(vars_) for dev, vars_ in dropped_unserved.items()
-            }
-        if dropped_unserved_devices:
-            md["dropped_unserved_devices"] = list(dropped_unserved_devices)
-        if applied_defaults:
-            # Provenance: the run records exactly which experiment defaults
-            # filled in fields the submitter left unset.
-            md["applied_defaults"] = applied_defaults
-        if any(slots.values()):
-            # Provenance: the assembled per-slot execution order (defaults +
-            # entry rituals + the request's own, mirrored on closeout).
-            md["action_plans"] = {k: v for k, v in slots.items() if v}
-        if telemetry_enabled and telemetry_selected:
-            md["background_telemetry"] = {
-                dev: list(vars_) for dev, vars_ in telemetry_selected.items()
-            }
-        scan_info: dict[str, Any] = {
-            "shots": request.shots_per_step,
-            "background": request.background,
-        }
-
-        if request.mode is ScanRequestMode.NOSCAN:
-            scan_info["scan_mode"] = "noscan"
-            # The last pre-claim checkpoint: the claim happens inside
-            # session.scan, immediately below.
-            if _stopped_during_init(session, should_abort, "before scan-number claim"):
-                return None
-            if on_scan_start is not None:
-                on_scan_start(1, request.shots_per_step)
-            return session.scan(
-                detectors=detectors,
-                motor=None,
-                positions=[None],
-                shots_per_step=request.shots_per_step,
-                mode=mode,
-                description=request.description,
-                md=md,
-                scan_info=scan_info,
-                setup=setup,
-                per_step=per_step,
-                closeout=closeout,
-                should_abort=should_abort,
-                pause_supervisor=pause_supervisor,
-            )
-
         movables: list = []
-        targets: list[str] = []
-        value_lists: list[list[float]] = []
-        for target, axis in zip(axis_resolved, request.axes):
+        for target in axis_resolved:
             movable = build_movable(session, target)
             created.append(movable)
             movables.append(movable)
-            targets.append(target.label)
-            value_lists.append(axis.positions.to_values())
-        pseudo_meta = {
-            target.variable_name: target.metadata()
-            for target in axis_resolved
-            if isinstance(target, PseudoMovableTarget)
-        }
-        if pseudo_meta:
-            md["pseudo_variables"] = pseudo_meta
-
-        scan_info["scan_mode"] = "standard"
-        scan_info["scan_parameter"] = ",".join(targets)
-        if len(request.axes) == 1:
-            motor_arg: Any = movables[0]
-            positions: list[Any] = value_lists[0]
-            md["scan_variable"] = request.axes[0].variable
+        if request.mode is ScanRequestMode.NOSCAN:
+            motor_arg: Any = None
+        elif len(request.axes) == 1:
+            motor_arg = movables[0]
         else:
-            # Outer product, first axis outermost/slowest (the schema's
-            # documented grid semantics); one bin per grid point.
             motor_arg = movables
-            positions = [tuple(point) for point in itertools.product(*value_lists)]
-            md["scan_variable"] = ",".join(a.variable for a in request.axes)
-            md["scan_axes"] = [a.variable for a in request.axes]
-            md["grid_shape"] = list(request.grid_shape())
-            md["num_grid_points"] = request.n_steps()
-            # ScanInfo is a legacy 1-D format: Start/End/Step describe the
-            # outermost axis; the grid truth lives in the run metadata.
-            outer = value_lists[0]
-            scan_info["start"] = outer[0]
-            scan_info["end"] = outer[-1]
-            scan_info["step"] = (outer[1] - outer[0]) if len(outer) > 1 else 0
+
+        # The pure run picture (md / ScanInfo / positions / totals) — one
+        # definition shared with the queueserver plan preamble.
+        spec = build_step_scan_spec(
+            request,
+            axis_resolved,
+            applied_defaults=applied_defaults,
+            slots=slots,
+            dropped_unserved=dropped_unserved,
+            dropped_unserved_devices=dropped_unserved_devices,
+            telemetry_selected=telemetry_selected if telemetry_enabled else {},
+        )
+
         # The last pre-claim checkpoint: the claim happens inside
         # session.scan, immediately below.
         if _stopped_during_init(session, should_abort, "before scan-number claim"):
             return None
         if on_scan_start is not None:
-            on_scan_start(len(positions), len(positions) * request.shots_per_step)
+            on_scan_start(spec.n_steps, spec.n_shots)
         return session.scan(
             detectors=detectors,
             motor=motor_arg,
-            positions=positions,
+            positions=spec.positions,
             shots_per_step=request.shots_per_step,
             mode=mode,
             description=request.description,
-            md=md,
-            scan_info=scan_info,
+            md=spec.md,
+            scan_info=spec.scan_info,
             setup=setup,
             per_step=per_step,
             closeout=closeout,

--- a/GeecsBluesky/pyproject.toml
+++ b/GeecsBluesky/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-bluesky"
-version = "0.52.2"
+version = "0.53.0"
 description = "Bluesky / ophyd-async bridge for the GEECS control system"
 authors = ["Sam Barber <sbarber@lbl.gov>"]
 readme = "README.md"

--- a/GeecsBluesky/tests/test_scan_request_plan.py
+++ b/GeecsBluesky/tests/test_scan_request_plan.py
@@ -1,0 +1,561 @@
+"""Tests for geecs_scan_request_plan — the ScanRequest plan preamble (QS round 1).
+
+Hermetic (ophyd-async mock backends, no gateway, no DB, no network).  Pins
+the issue #633 acceptance surface:
+
+- the preamble validates **fail-fast** on a bad request (nothing claimed,
+  nothing constructed);
+- devices are constructed **inside** the plan (RunEngine already running);
+- the scan number is claimed **inside** the plan;
+- for representative noscan and step-scan requests, ``RE(geecs_scan_
+  request_plan(request))`` produces the same documents/ScanInfo as today's
+  ``run_scan_request`` (start-doc metadata, streams/columns, row counts,
+  exit status — uids/timestamps/folders normalized).
+
+The mock trigger problem is new here: devices exist only mid-plan, so the
+free-run pacer cannot be started up front.  An ``RE.msg_hook`` watches for
+``stage`` messages and starts a pacer per staged device that has an
+``acq_timestamp`` — works identically for both entry points, since staging
+is always inside the run.
+"""
+
+from __future__ import annotations
+
+import configparser
+
+import pytest
+
+pytest.importorskip("aioca")
+
+from bluesky.utils import RunEngineInterrupted  # noqa: F401  (doc import guard)
+from ophyd_async.core import set_mock_value  # noqa: E402
+
+from geecs_bluesky.config_resolver import ConfigsRepoResolver  # noqa: E402
+from geecs_bluesky.exceptions import GeecsConfigurationError  # noqa: E402
+from geecs_bluesky.plans.scan_request_plan import (  # noqa: E402
+    geecs_scan_request_plan,
+    set_plan_session,
+)
+from geecs_bluesky.scan_request_runner import run_scan_request  # noqa: E402
+from geecs_schemas import ScanRequest  # noqa: E402
+from tests.ca_mock_helpers import start_pacer  # noqa: E402
+from tests.test_scan_request_runner import (  # noqa: E402
+    LEGACY_ACTIONS,
+    LEGACY_SAVE_ELEMENT,
+    LEGACY_SCAN_DEVICES,
+    LEGACY_SHOT_CONTROL,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures: configs repo (reusing the runner suite's YAML corpus), sessions
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def configs_root(tmp_path):
+    exp = tmp_path / "LegacyExp"
+    (exp / "save_devices").mkdir(parents=True)
+    (exp / "save_devices" / "UC_Test.yaml").write_text(LEGACY_SAVE_ELEMENT)
+    (exp / "shot_control_configurations").mkdir()
+    (exp / "shot_control_configurations" / "HTU-Normal.yaml").write_text(
+        LEGACY_SHOT_CONTROL
+    )
+    (exp / "scan_devices").mkdir()
+    (exp / "scan_devices" / "scan_devices.yaml").write_text(LEGACY_SCAN_DEVICES)
+    (exp / "action_library").mkdir()
+    (exp / "action_library" / "actions.yaml").write_text(LEGACY_ACTIONS)
+    return tmp_path
+
+
+@pytest.fixture
+def resolver(configs_root):
+    return ConfigsRepoResolver("LegacyExp", experiments_root=configs_root)
+
+
+@pytest.fixture(autouse=True)
+def no_db(monkeypatch):
+    """Neutralize the DB-backed providers (hermetic: no MySQL, no gateway).
+
+    A real ``GeecsSession`` exposes ``experiment``, so the runner's policy /
+    served-set factories would otherwise try the lab DB.  ``None`` policy =
+    explicit-scalars-only + no telemetry + unserved check skipped, on BOTH
+    entry points — parity is preserved.
+    """
+    monkeypatch.setattr(
+        "geecs_bluesky.scan_request_runner.make_scalar_policy", lambda session: None
+    )
+    monkeypatch.setattr(
+        "geecs_bluesky.plans.scan_request_plan.make_scalar_policy",
+        lambda session: None,
+    )
+    monkeypatch.setattr(
+        "geecs_bluesky.scan_request_runner.make_served_set_provider",
+        lambda session: None,
+    )
+
+
+@pytest.fixture(autouse=True)
+def clear_worker_session():
+    yield
+    set_plan_session(None)
+
+
+def _mock_session():
+    from geecs_bluesky.session import GeecsSession
+
+    return GeecsSession("LegacyExp", tiled=False, mock=True)
+
+
+def _noscan_request(**overrides) -> ScanRequest:
+    base = dict(
+        mode="noscan",
+        shots_per_step=2,
+        acquisition="free_run",
+        save_sets=["UC_Test"],
+        description="stats",
+    )
+    base.update(overrides)
+    return ScanRequest.model_validate(base)
+
+
+# ---------------------------------------------------------------------------
+# Mock pacing + document collection
+# ---------------------------------------------------------------------------
+
+
+def _install_stage_pacer(session, pacers: list) -> None:
+    """Start a mock-trigger pacer for every staged acq_timestamp device.
+
+    Devices are constructed inside the runner/plan, so the pacer cannot be
+    wired up front; ``stage`` is the first message that carries the device
+    object after it is connected.
+    """
+    paced: set = set()
+
+    def hook(msg) -> None:
+        obj = msg.obj
+        if (
+            msg.command == "stage"
+            and obj not in paced
+            and hasattr(obj, "acq_timestamp")
+        ):
+            paced.add(obj)
+            set_mock_value(obj.acq_timestamp, 1000.0)
+            pacers.append(
+                start_pacer(
+                    session.RE,
+                    [(obj, 1000.0)],
+                    initial_delay=1.0,
+                    interval=0.15,
+                )
+            )
+
+    session.RE.msg_hook = hook
+
+
+class _DocCollector:
+    def __init__(self) -> None:
+        self.start: dict | None = None
+        self.stop: dict | None = None
+        self.descriptors: list[dict] = []
+        self.events: list[dict] = []
+
+    def __call__(self, name: str, doc: dict) -> None:
+        if name == "start":
+            self.start = dict(doc)
+        elif name == "stop":
+            self.stop = dict(doc)
+        elif name == "descriptor":
+            self.descriptors.append(dict(doc))
+        elif name == "event":
+            self.events.append(dict(doc))
+
+
+def _run_scan(entry_point, request, resolver, folder, monkeypatch):
+    """Run *request* through one entry point; return the collected documents.
+
+    ``entry_point`` is ``"runner"`` (today's ``run_scan_request``) or
+    ``"plan"`` (``RE(geecs_scan_request_plan(request.model_dump()))`` with
+    the worker-default session — the queue's exact call shape).  The claim
+    is stubbed to scan 7 in *folder* at each entry point's claim site.
+    """
+    folder.mkdir(parents=True, exist_ok=True)
+    session = _mock_session()
+    docs = _DocCollector()
+    token = session.RE.subscribe(docs)
+    pacers: list = []
+    _install_stage_pacer(session, pacers)
+
+    def claim(experiment):
+        assert experiment == "LegacyExp"
+        return 7, str(folder)
+
+    try:
+        if entry_point == "runner":
+            monkeypatch.setattr("geecs_bluesky.session.claim_scan_number", claim)
+            run_scan_request(session, request, resolver)
+        else:
+            monkeypatch.setattr(
+                "geecs_bluesky.plans.scan_request_plan.claim_scan_number", claim
+            )
+            set_plan_session(session)
+            session.RE(geecs_scan_request_plan(request.model_dump(), resolver=resolver))
+    finally:
+        for pacer in pacers:
+            pacer.cancel()
+        session.RE.unsubscribe(token)
+        session.RE.msg_hook = None
+    return docs
+
+
+# ---------------------------------------------------------------------------
+# Document normalization / comparison
+# ---------------------------------------------------------------------------
+
+_VOLATILE_START_KEYS = {"uid", "time"}
+
+
+def _normalize(value, folder):
+    if isinstance(value, str):
+        return value.replace(str(folder), "<scan_folder>")
+    if isinstance(value, dict):
+        return {k: _normalize(v, folder) for k, v in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_normalize(v, folder) for v in value]
+    return value
+
+
+def _start_essence(doc: dict, folder) -> dict:
+    return {
+        k: _normalize(v, folder)
+        for k, v in doc.items()
+        if k not in _VOLATILE_START_KEYS
+    }
+
+
+def _descriptor_essence(docs: _DocCollector) -> list[tuple]:
+    return sorted(
+        (d["name"], sorted(d["data_keys"]), sorted(d.get("object_keys", {})))
+        for d in docs.descriptors
+    )
+
+
+def _event_essence(docs: _DocCollector) -> list[tuple[int, list[str]]]:
+    return [(e["seq_num"], sorted(e["data"])) for e in docs.events]
+
+
+def _assert_same_run(docs_a: _DocCollector, docs_b: _DocCollector, folder_a, folder_b):
+    assert docs_a.start is not None and docs_b.start is not None
+    assert _start_essence(docs_a.start, folder_a) == _start_essence(
+        docs_b.start, folder_b
+    )
+    assert _descriptor_essence(docs_a) == _descriptor_essence(docs_b)
+    assert _event_essence(docs_a) == _event_essence(docs_b)
+    assert docs_a.stop is not None and docs_b.stop is not None
+    assert docs_a.stop["exit_status"] == docs_b.stop["exit_status"] == "success"
+    assert docs_a.stop["num_events"] == docs_b.stop["num_events"]
+
+
+# ---------------------------------------------------------------------------
+# Fail-fast + in-plan pins (issue #633 acceptance)
+# ---------------------------------------------------------------------------
+
+
+def test_bad_request_fails_in_the_preamble_and_claims_nothing(
+    resolver, monkeypatch
+) -> None:
+    """Authoritative preamble validation: unknown name → error, no claim."""
+    session = _mock_session()
+    claims: list = []
+    monkeypatch.setattr(
+        "geecs_bluesky.plans.scan_request_plan.claim_scan_number",
+        lambda experiment: claims.append(experiment) or (None, None),
+    )
+    request = _noscan_request(save_sets=["Nope"]).model_dump()
+    with pytest.raises(GeecsConfigurationError, match="Nope"):
+        session.RE(geecs_scan_request_plan(request, session=session, resolver=resolver))
+    assert claims == [], "a failed validation must burn no scan number"
+
+
+def test_creating_the_generator_does_no_work(resolver, monkeypatch) -> None:
+    """The preamble runs when the RE iterates the plan, not at call time."""
+    session = _mock_session()
+    claims: list = []
+    monkeypatch.setattr(
+        "geecs_bluesky.plans.scan_request_plan.claim_scan_number",
+        lambda experiment: claims.append(experiment) or (None, None),
+    )
+    resolved: list = []
+    original = type(resolver).resolve_save_set
+
+    def counting(self, name):
+        resolved.append(name)
+        return original(self, name)
+
+    monkeypatch.setattr(type(resolver), "resolve_save_set", counting)
+    plan = geecs_scan_request_plan(
+        _noscan_request(save_sets=["Nope"]).model_dump(),
+        session=session,
+        resolver=resolver,
+    )
+    assert resolved == [] and claims == []
+    with pytest.raises(GeecsConfigurationError):
+        session.RE(plan)
+    assert resolved == ["Nope"]
+
+
+def test_strict_without_trigger_profile_refuses_before_claim(
+    resolver, monkeypatch
+) -> None:
+    session = _mock_session()
+    claims: list = []
+    monkeypatch.setattr(
+        "geecs_bluesky.plans.scan_request_plan.claim_scan_number",
+        lambda experiment: claims.append(experiment) or (None, None),
+    )
+    request = _noscan_request(acquisition="strict").model_dump()
+    with pytest.raises(GeecsConfigurationError, match="strict_shot_control"):
+        session.RE(geecs_scan_request_plan(request, session=session, resolver=resolver))
+    assert claims == []
+
+
+def test_optimize_mode_is_refused_loudly_after_validation(
+    resolver, monkeypatch
+) -> None:
+    """Optimize relocates in a later round (decision 5): validated, refused."""
+    session = _mock_session()
+    claims: list = []
+    monkeypatch.setattr(
+        "geecs_bluesky.plans.scan_request_plan.claim_scan_number",
+        lambda experiment: claims.append(experiment) or (None, None),
+    )
+    request = ScanRequest.model_validate(
+        dict(
+            mode="optimize",
+            shots_per_step=5,
+            acquisition="free_run",
+            save_sets=["UC_Test"],
+            optimization={
+                "variables": {"jet_z": [0.0, 1.0]},
+                "objectives": {"counts": "MAXIMIZE"},
+                "evaluator": {"module": "m", "class": "C"},
+                "generator": {"name": "bayes_default"},
+                "max_iterations": 3,
+            },
+        )
+    )
+    with pytest.raises(NotImplementedError, match="optimize"):
+        session.RE(
+            geecs_scan_request_plan(
+                request.model_dump(), session=session, resolver=resolver
+            )
+        )
+    assert claims == []
+    # An unknown optimize VOCS name still fails *validation* first — the
+    # authoritative preamble runs before the refusal.
+    bad = request.model_copy(
+        update={
+            "optimization": request.optimization.model_copy(
+                update={"variables": {"nope": [0.0, 1.0]}}
+            )
+        }
+    )
+    with pytest.raises(GeecsConfigurationError, match="nope"):
+        session.RE(
+            geecs_scan_request_plan(
+                bad.model_dump(), session=session, resolver=resolver
+            )
+        )
+
+
+def test_no_session_configured_is_a_clear_error(resolver) -> None:
+    from bluesky import RunEngine
+
+    plan = geecs_scan_request_plan(_noscan_request().model_dump(), resolver=resolver)
+    with pytest.raises(GeecsConfigurationError, match="set_plan_session"):
+        RunEngine(context_managers=[])(plan)
+
+
+def test_devices_and_claim_happen_inside_the_running_plan(
+    resolver, monkeypatch, tmp_path
+) -> None:
+    """The relocation pins: construction and the claim are plan-time events."""
+    from geecs_bluesky.session import GeecsSession
+
+    session = _mock_session()
+    folder = tmp_path / "Scan007"
+    folder.mkdir()
+
+    factory_states: list[str] = []
+    real_detector = GeecsSession.detector
+
+    def recording_detector(self, *args, **kwargs):
+        factory_states.append(session.RE.state)
+        return real_detector(self, *args, **kwargs)
+
+    monkeypatch.setattr(GeecsSession, "detector", recording_detector)
+
+    claim_states: list[str] = []
+
+    def claim(experiment):
+        claim_states.append(session.RE.state)
+        return 7, str(folder)
+
+    monkeypatch.setattr(
+        "geecs_bluesky.plans.scan_request_plan.claim_scan_number", claim
+    )
+    pacers: list = []
+    _install_stage_pacer(session, pacers)
+    try:
+        session.RE(
+            geecs_scan_request_plan(
+                _noscan_request().model_dump(), session=session, resolver=resolver
+            )
+        )
+    finally:
+        for pacer in pacers:
+            pacer.cancel()
+        session.RE.msg_hook = None
+    assert factory_states == ["running"], "detector must be constructed in-plan"
+    assert claim_states == ["running"], "scan number must be claimed in-plan"
+    # The claim boundary held: ScanInfo + scan.log landed in the folder.
+    assert (folder / "ScanInfoScan007.ini").exists()
+    assert (folder / "scan.log").exists()
+
+
+def test_trigger_profile_builds_the_controller_worker_side(
+    resolver, monkeypatch, tmp_path
+) -> None:
+    """The ShotController is constructed inside the plan from the JSON names.
+
+    A stub controller class stands in (mock CaPutSetter puts would need a
+    gateway); the pin is construction-from-writes with the session's
+    experiment/rep-rate, plus the mock-session skip of the reachability
+    check — the writes themselves are the runner-suite-pinned adapter
+    output.
+    """
+    session = _mock_session()
+    built: list = []
+
+    class _StubController:
+        def __init__(self, writes) -> None:
+            self.writes = writes
+            self.connected = False
+
+        @classmethod
+        def from_writes(cls, writes, *, experiment=None, rep_rate_hz=1.0):
+            controller = cls(writes)
+            built.append((controller, experiment, rep_rate_hz))
+            return controller
+
+        async def connect_setters(self, timeout: float = 2.0) -> None:
+            self.connected = True
+
+        def require_strict_single_shot(self) -> None:  # pragma: no cover
+            pass
+
+        def arm(self):
+            yield from ()
+
+        def disarm(self):
+            yield from ()
+
+        def quiesce(self):
+            yield from ()
+
+    monkeypatch.setattr(
+        "geecs_bluesky.plans.scan_request_plan.ShotController", _StubController
+    )
+    folder = tmp_path / "Scan007"
+    monkeypatch.setattr(
+        "geecs_bluesky.plans.scan_request_plan.claim_scan_number",
+        lambda experiment: (7, str(folder)) if folder.mkdir() is None else None,
+    )
+    pacers: list = []
+    _install_stage_pacer(session, pacers)
+    try:
+        session.RE(
+            geecs_scan_request_plan(
+                _noscan_request(trigger_profile="HTU-Normal").model_dump(),
+                session=session,
+                resolver=resolver,
+            )
+        )
+    finally:
+        for pacer in pacers:
+            pacer.cancel()
+        session.RE.msg_hook = None
+    assert len(built) == 1
+    controller, experiment, rep_rate = built[0]
+    assert experiment == "LegacyExp" and rep_rate == session.rep_rate_hz
+    assert controller.writes.defines_state("SCAN")
+    assert not controller.connected, "mock sessions skip the CA reachability check"
+
+
+# ---------------------------------------------------------------------------
+# Document parity with run_scan_request (the acceptance contract)
+# ---------------------------------------------------------------------------
+
+
+def test_noscan_documents_match_run_scan_request(
+    resolver, monkeypatch, tmp_path
+) -> None:
+    request = _noscan_request()
+    docs_runner = _run_scan(
+        "runner", request, resolver, tmp_path / "runner" / "Scan007", monkeypatch
+    )
+    docs_plan = _run_scan(
+        "plan", request, resolver, tmp_path / "plan" / "Scan007", monkeypatch
+    )
+    _assert_same_run(
+        docs_runner,
+        docs_plan,
+        tmp_path / "runner" / "Scan007",
+        tmp_path / "plan" / "Scan007",
+    )
+    assert docs_plan.start["scan_number"] == 7
+    assert docs_plan.start["scan_request_mode"] == "noscan"
+    # Both entry points wrote the same legacy ScanInfo ini.
+    ini_a = (tmp_path / "runner" / "Scan007" / "ScanInfoScan007.ini").read_text()
+    ini_b = (tmp_path / "plan" / "Scan007" / "ScanInfoScan007.ini").read_text()
+    assert ini_a == ini_b
+    parser = configparser.ConfigParser()
+    parser.read_string(ini_b)
+    assert parser["Scan Info"]["scanmode"] == '"noscan"'
+    # The plan claimed the number, so the plan owns the per-scan scan.log.
+    assert (tmp_path / "plan" / "Scan007" / "scan.log").exists()
+
+
+def test_step_scan_documents_match_run_scan_request(
+    resolver, monkeypatch, tmp_path
+) -> None:
+    """Representative step scan: one setpoint axis + a request setup action."""
+    request = _noscan_request(
+        mode="step",
+        axes=[{"variable": "jet_x", "positions": {"values": [1.0, 2.0]}}],
+        actions={"setup": ["close_shutters"]},
+    )
+    docs_runner = _run_scan(
+        "runner", request, resolver, tmp_path / "runner" / "Scan007", monkeypatch
+    )
+    docs_plan = _run_scan(
+        "plan", request, resolver, tmp_path / "plan" / "Scan007", monkeypatch
+    )
+    _assert_same_run(
+        docs_runner,
+        docs_plan,
+        tmp_path / "runner" / "Scan007",
+        tmp_path / "plan" / "Scan007",
+    )
+    start = docs_plan.start
+    assert start["scan_request_mode"] == "step"
+    assert start["scan_variable"] == "jet_x"
+    assert start["action_plans"] == {"setup": ["close_shutters"]}
+    assert start["num_points"] == 2
+    assert docs_plan.stop["num_events"]["primary"] == 4  # 2 positions × 2 shots
+    ini_a = (tmp_path / "runner" / "Scan007" / "ScanInfoScan007.ini").read_text()
+    ini_b = (tmp_path / "plan" / "Scan007" / "ScanInfoScan007.ini").read_text()
+    assert ini_a == ini_b
+    parser = configparser.ConfigParser()
+    parser.read_string(ini_b)
+    assert parser["Scan Info"]["scan parameter"] == '"U_ESP_JetXYZ:Position.Axis 1"'

--- a/GeecsBluesky/tests/test_scan_request_plan.py
+++ b/GeecsBluesky/tests/test_scan_request_plan.py
@@ -559,3 +559,75 @@ def test_step_scan_documents_match_run_scan_request(
     parser = configparser.ConfigParser()
     parser.read_string(ini_b)
     assert parser["Scan Info"]["scan parameter"] == '"U_ESP_JetXYZ:Position.Axis 1"'
+
+
+def test_telemetry_documents_match_run_scan_request(
+    resolver, monkeypatch, tmp_path
+) -> None:
+    """Telemetry parity: the in-plan connect fork cannot drift silently.
+
+    The autouse ``no_db`` fixture forces the scalar policy to ``None`` (no
+    telemetry) on both entry points, so the other parity tests never touch
+    the Tier-2 path.  This test swaps in a hermetic fake
+    ``ScalarPolicyProvider`` so the telemetry fork
+    (``_connect_telemetry_plan`` vs the runner's
+    ``build_telemetry_readables`` over ``session.telemetry_batch``) is
+    actually exercised on BOTH entry points: same soft event columns, same
+    ``background_telemetry`` metadata, same save-set wholesale exclusion.
+    """
+
+    class _FakeScalarPolicy:
+        """Protocol-complete ScalarPolicyProvider over a fixed table."""
+
+        _subscribed = {
+            # Not in the UC_Test save set -> becomes Tier-2 telemetry.
+            "U_BgMonitor": ["Pressure", "Temp"],
+            # In the save set -> excluded wholesale (Tier-1 owns it).
+            "U_Cam": ["MaxCounts"],
+        }
+
+        def get_variables(self, device: str) -> list[str]:
+            return list(self._subscribed.get(device, []))
+
+        def all_variables(self, device: str) -> list[str]:
+            return list(self._subscribed.get(device, []))
+
+        def subscribed_by_device(self) -> dict[str, list[str]]:
+            return {d: list(v) for d, v in self._subscribed.items()}
+
+    for target in (
+        "geecs_bluesky.scan_request_runner.make_scalar_policy",
+        "geecs_bluesky.plans.scan_request_plan.make_scalar_policy",
+    ):
+        monkeypatch.setattr(target, lambda session: _FakeScalarPolicy())
+
+    request = _noscan_request()
+    docs_runner = _run_scan(
+        "runner", request, resolver, tmp_path / "runner" / "Scan007", monkeypatch
+    )
+    docs_plan = _run_scan(
+        "plan", request, resolver, tmp_path / "plan" / "Scan007", monkeypatch
+    )
+    _assert_same_run(
+        docs_runner,
+        docs_plan,
+        tmp_path / "runner" / "Scan007",
+        tmp_path / "plan" / "Scan007",
+    )
+    # The Tier-2 selection made it into the run metadata (parity of the
+    # value itself is already pinned by _assert_same_run's start essence).
+    assert docs_plan.start["background_telemetry"] == {
+        "U_BgMonitor": ["Pressure", "Temp"]
+    }
+    # ...and into the event columns (the group keeps member names).
+    telemetry_keys = {
+        k
+        for d in docs_plan.descriptors
+        for k in d["data_keys"]
+        if k.startswith("telemetry_")
+    }
+    assert telemetry_keys, "telemetry columns must exist in the event stream"
+    assert all("u_bgmonitor" in k for k in telemetry_keys)
+    assert not any("u_cam" in k for k in telemetry_keys), (
+        "a save-set device must never be duplicated as telemetry"
+    )


### PR DESCRIPTION
Executes #633 (queueserver campaign, round 1, worker W1). **Base = `feat/queueserver`; the coordinator merges — do not merge from this side.**

## What + why

The queueserver migration's one structural unit (`Planning/cutover_strategy/02_queueserver_migration.md` § The one structural task): `geecs_scan_request_plan(request)` — a plan generator meaning "run this ScanRequest". The `run_scan_request()` prologue relocates into the plan **preamble**, executed worker-side inside the RunEngine, so every bound method/closure (ShotController stubs, per-step action callables) is constructed from the JSON request and never crosses a process boundary:

1. authoritative fail-fast validation (`validate_scan_request` — amendment 2: no separate validation stub; clients re-run it pre-submit),
2. name resolution + worker-side construction (shot controller, action signals, detectors, axis movables — connects deferred),
3. in-plan connects (`ensure_connected` batches for the strict tier, soft gather for Tier-2 telemetry, shot-control reachability) — still pre-claim, so failures burn no scan number,
4. scan-number claim + ScanInfo + per-scan `scan.log`,
5. the same inner plan as today (`build_step_scan_plan`), with a finalize disconnecting everything the plan created.

No bluesky-queueserver import — an ordinary plan callable; W2 registers it with the manager. `set_plan_session()` installs the worker-wide default session so `RE(geecs_scan_request_plan(request))` needs only the JSON request.

This is **relocation, not rewrite**: the preamble calls the runner's own module-level prologue functions. The one extraction: `run_scan_request`'s inline md/ScanInfo/grid assembly became the pure `build_step_scan_spec()` (+ `StepScanSpec`), consumed verbatim by both entry points so they cannot drift. `run_scan_request` and the GUI-bridge path are otherwise unchanged (the whole existing suite pins them).

## Per-concern LOC breakdown

| Concern | Files | ~LOC |
|---|---|---|
| Runner extraction (`StepScanSpec` + `build_step_scan_spec`, tail rewired) | `scan_request_runner.py` | +145 / −90 (net logic unchanged) |
| The plan callable + facade + in-plan connect/cleanup stubs | `plans/scan_request_plan.py` (new) | +560 |
| Hermetic pins + document-parity tests | `tests/test_scan_request_plan.py` (new) | +500 |
| Bookkeeping (version, CHANGELOG, CLAUDE.md layout entry) | 3 files | +50 |

## Deliberate scope cuts (per the issue / Planning doc — flagged for cheap veto)

- **Optimize mode: validated then refused loudly** (`NotImplementedError`). Decision 5's in-worker loader invocation is a later round; the issue's acceptance surface is step + noscan. The legacy optimize paths are untouched.
- **s-file export absent from the plan** — the parallel task owns that seam (`session.py::_export_scalar_files` → stop-document callback); untouched here per the collision contract. Emitted documents are identical either way.
- **No operator/GUI seams in the plan** (`preflight`/`on_scan_start`/`should_abort`/`pause_supervisor`): decisions 3–4 move them client-side / to the manager's stock verbs. The unserved-variables check runs with the headless continue-and-drop default.
- **Judgment call:** `_DeferredConnectFactories` binds the session's own factory functions with only `_connect` swapped (zero construction duplication, at the cost of a facade's `__getattr__` indirection). The alternative — duplicating seven device constructors — was rejected as drift-prone.

## Tests

- `GeecsBluesky` suite via `./scripts/check.sh`: **782 passed, 3 deselected** (includes the 105-test runner suite pinning the extraction, unchanged).
- New `tests/test_scan_request_plan.py`: **9 tests** — fail-fast preamble validation with zero claims; generator laziness; strict-without-trigger refusal; optimize refusal (validation still first); no-session error; devices constructed + number claimed while `RE.state == "running"` (plus ScanInfo/scan.log landing); worker-side ShotController construction from a TriggerProfile; **document parity vs `run_scan_request`** for noscan and a representative step scan (setpoint axis + setup action): start-doc metadata (uid/time/folder-normalized), stream/column sets, per-event keys and seq_nums, stop-doc counts, and byte-identical ScanInfo inis.
- Test infrastructure note: devices exist only mid-plan, so the mock free-run pacer is started from an `RE.msg_hook` on `stage` messages — symmetric for both entry points.
- Lint: pre-commit green (ruff, ruff-format, pydocstyle).

## Hardware verification

**OWED (deferred to the campaign's integration checkpoint, coordinator's call):** one live noscan + one live step scan submitted as `RE(geecs_scan_request_plan(request))` on the lab network, expecting a normally-numbered scan folder with ScanInfo, scan.log, native images, and Tiled documents identical in shape to a `run_scan_request` scan of the same request. Round-1 code is not yet reachable from any production path (nothing calls the plan until W2 registers it), so the hermetic document-parity pins are the gate for merging into the integration branch.

Closes #633.

🤖 Generated with [Claude Code](https://claude.com/claude-code)