### PR TITLE
qs/W2b: queueserver deployment assets

### DIFF
--- a/GeecsBluesky/CHANGELOG.md
+++ b/GeecsBluesky/CHANGELOG.md
@@ -4,7 +4,15 @@ All notable changes to `geecs-bluesky` are documented here.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
-<<<<<<< HEAD
+## [0.53.1] - 2026-08-20
+
+### Added
+
+- Added queueserver host deployment assets under `qserver/deploy/`: Redis
+  package notes, a placeholder-only systemd service unit, and an Ubuntu 22.04
+  runbook for installing, starting, and verifying the RE Manager service
+  (issue #642).
+
 ## [0.53.0] - 2026-08-20
 
 ### Added
@@ -39,7 +47,6 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   extracted into the pure `build_step_scan_spec()` (+ `StepScanSpec`),
   shared verbatim with the new plan preamble so the two entry points cannot
   drift.  No behavior change (pinned by the existing runner suite).
->>>>>>> origin/qs/w1-scan-request-plan
 
 ## [0.52.4] - 2026-08-20
 
@@ -60,7 +67,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   best-effort Tiled export posture for queueserver worker wiring. Export
   is **success-only** (`exit_status == "success"`): aborted/failed runs
   write no s-file, matching the post-`RE()` call sites this replaces.
-=======
+
 ## [0.52.2] - 2026-08-20
 
 ### Changed

--- a/GeecsBluesky/pyproject.toml
+++ b/GeecsBluesky/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-bluesky"
-version = "0.53.0"
+version = "0.53.1"
 description = "Bluesky / ophyd-async bridge for the GEECS control system"
 authors = ["Sam Barber <sbarber@lbl.gov>"]
 readme = "README.md"

--- a/GeecsBluesky/qserver/deploy/DEPLOYMENT.md
+++ b/GeecsBluesky/qserver/deploy/DEPLOYMENT.md
@@ -27,11 +27,23 @@ sudo apt install python3.11 python3.11-venv redis-server
 sudo systemctl enable --now redis-server.service
 ```
 
-Install Poetry by the method approved for the host image, then install the
-worker environment from the repository checkout:
+Clone the repository if the host does not have it yet:
+
+```bash
+sudo mkdir -p /opt/geecs && sudo chown "$USER" /opt/geecs
+git clone https://github.com/GEECS-BELLA/GEECS-Plugins.git /opt/geecs/GEECS-Plugins
+```
+
+Install Poetry by the method approved for the host image (note where it
+lands — the official installer uses `~/.local/bin`, which systemd's service
+PATH does not include; the unit template therefore takes poetry's absolute
+path). Then install the worker environment, pointing poetry at 3.11
+explicitly (jammy's default `python3` is 3.10, which this package refuses —
+the repo's documented top environment failure):
 
 ```bash
 cd /opt/geecs/GEECS-Plugins/GeecsBluesky
+poetry env use python3.11
 poetry install --extras "ca tiled qserver"
 ```
 
@@ -154,13 +166,9 @@ If `environment open` fails, inspect the service journal first:
 journalctl -u geecs-qserver.service -n 200 --no-pager
 ```
 
-Follow the troubleshooting notes in `../README.md` for the known queueserver
-failure shapes:
-
-- missing or incomplete `user_group_permissions.yaml`,
-- a startup profile that does not define `RE = RunEngine({})` while the
-  launcher uses `--keep-re`,
-- attempts to run `qserver function execute` while the manager is not idle.
+Follow the troubleshooting section in `../README.md` for the known
+queueserver failure shapes — it is the single maintained list; symptoms and
+fixes are not restated here.
 
 After the environment is open, submit only the smoke-test queue items approved
 for the current startup profile. Do not use a deployment host to discover

--- a/GeecsBluesky/qserver/deploy/DEPLOYMENT.md
+++ b/GeecsBluesky/qserver/deploy/DEPLOYMENT.md
@@ -29,19 +29,28 @@ sudo systemctl enable --now redis-server.service
 
 Clone the repository if the host does not have it yet:
 
+**Everything below runs AS THE SERVICE ACCOUNT** (the unit's `User=`,
+`geecs` in this template): Poetry keys project virtualenvs under the
+*invoking user's* cache, so an env installed by an admin account is
+invisible to the service — the unit would crash-loop on a fresh,
+dependency-less env while admin-side verification passes. Clone, install,
+and verify as the service user (`sudo -u geecs -i` or a direct login):
+
 ```bash
-sudo mkdir -p /opt/geecs && sudo chown "$USER" /opt/geecs
-git clone https://github.com/GEECS-BELLA/GEECS-Plugins.git /opt/geecs/GEECS-Plugins
+sudo mkdir -p /opt/geecs && sudo chown geecs:geecs /opt/geecs
+sudo -u geecs git clone https://github.com/GEECS-BELLA/GEECS-Plugins.git /opt/geecs/GEECS-Plugins
 ```
 
-Install Poetry by the method approved for the host image (note where it
-lands — the official installer uses `~/.local/bin`, which systemd's service
-PATH does not include; the unit template therefore takes poetry's absolute
-path). Then install the worker environment, pointing poetry at 3.11
-explicitly (jammy's default `python3` is 3.10, which this package refuses —
-the repo's documented top environment failure):
+Install Poetry **as the service user** by the method approved for the host
+image (note where it lands — the official installer uses `~/.local/bin`,
+which systemd's service PATH does not include; the unit template therefore
+takes poetry's absolute path). Then install the worker environment,
+pointing poetry at 3.11 explicitly (jammy's default `python3` is 3.10,
+which this package refuses — the repo's documented top environment
+failure):
 
 ```bash
+sudo -u geecs -i
 cd /opt/geecs/GEECS-Plugins/GeecsBluesky
 poetry env use python3.11
 poetry install --extras "ca tiled qserver"
@@ -111,7 +120,9 @@ Edit the placeholder values in `geecs-qserver.service` for the host:
 - `QS_STARTUP_DIR=` — the queueserver startup profile directory.
 - `QS_EXPERIMENT=` — the GEECS experiment name served by this manager.
 - `EPICS_CA_ADDR_LIST=` — the CA gateway host, for example `192.168.6.14`.
-- `ExecStart=` — the checked-out `qserver/launch_re_manager.sh`.
+- `ExecStart=` — the service user's **absolute poetry path** (locate with
+  `command -v poetry` as that user) followed by
+  `run <checkout>/GeecsBluesky/qserver/launch_re_manager.sh`.
 
 Install and start:
 
@@ -141,6 +152,8 @@ Run these commands from a shell that has the `qserver` CLI available. The
 Poetry environment from the checkout is the expected source:
 
 ```bash
+cd /opt/geecs/GEECS-Plugins/GeecsBluesky
+sudo -u geecs -i
 cd /opt/geecs/GEECS-Plugins/GeecsBluesky
 poetry run qserver status
 ```

--- a/GeecsBluesky/qserver/deploy/DEPLOYMENT.md
+++ b/GeecsBluesky/qserver/deploy/DEPLOYMENT.md
@@ -1,0 +1,168 @@
+# GEECS Queueserver Deployment
+
+How to install the bluesky-queueserver RE Manager as a service on a dedicated
+Ubuntu host, what local services it depends on, and how an operator verifies
+the manager is ready to accept scan requests. The launch mechanics are in
+`../launch_re_manager.sh`; day-to-day operator checks and known failure modes
+are in `../README.md`.
+
+---
+
+## 1. Host prerequisites
+
+Use a dedicated Ubuntu 22.04 host on the lab network. The worker must be able
+to reach:
+
+- the Channel Access gateway host,
+- the GEECS MySQL database,
+- the Tiled server when Tiled publishing is enabled,
+- the mounted GEECS data share used for scan-folder claim, ScanInfo writes,
+  native assets, and legacy s-file export.
+
+Install Python 3.11, Poetry, Redis, and a checkout of this repository:
+
+```bash
+sudo apt update
+sudo apt install python3.11 python3.11-venv redis-server
+sudo systemctl enable --now redis-server.service
+```
+
+Install Poetry by the method approved for the host image, then install the
+worker environment from the repository checkout:
+
+```bash
+cd /opt/geecs/GEECS-Plugins/GeecsBluesky
+poetry install --extras "ca tiled qserver"
+```
+
+The `qserver` extra is the queueserver dependency bundle. If that extra has
+not landed on the deployment branch yet, install the branch that provides it
+before enabling the systemd unit.
+
+Redis is provided by the Ubuntu `redis-server` package and should stay bound
+to `127.0.0.1`; see `redis.conf-notes.md` for the Redis-specific notes and
+the `vm.overcommit_memory=1` sysctl fix.
+
+### Shared config
+
+Create the standard GEECS config file for the service account:
+
+```bash
+sudo -u geecs sh -c 'mkdir -p "$HOME/.config/geecs_python_api"'
+sudo -u geecs sh -c 'install -m 600 /dev/null "$HOME/.config/geecs_python_api/config.ini"'
+sudo -u geecs sh -c 'editor "$HOME/.config/geecs_python_api/config.ini"'
+```
+
+Use the [Getting Started config.ini section](../../../docs/tutorials/getting_started.md)
+as the key-by-key reference. Do not invent a queueserver-specific config
+format; this worker reads the same `~/.config/geecs_python_api/config.ini`
+contract as the rest of GEECS-Plugins.
+
+At minimum, verify that the service account's config resolves:
+
+- the GEECS data root on the mounted data share,
+- the scanner configs repository,
+- database credentials through the normal `Configurations.INI` chain,
+- Tiled connection details when Tiled publishing is enabled,
+- optional `[epics] ca_addr_list` if the unit-level `EPICS_CA_ADDR_LIST`
+  override is not being used.
+
+The systemd unit sets `EPICS_CA_ADDR_LIST` explicitly. That is the deployment
+standard because `systemctl cat geecs-qserver.service` then shows the active
+Channel Access target without inspecting a private config file.
+
+### Data share
+
+Mount the production data share before starting the manager. The worker must
+write to the same scan-folder tree used by the console path; otherwise scan
+number claim, ScanInfo creation, native asset references, and s-file export
+will fail or point at the wrong location.
+
+Validate the mount as the service account before enabling the unit:
+
+```bash
+sudo -u geecs test -d /mnt/geecs-data
+sudo -u geecs test -w /mnt/geecs-data
+```
+
+Replace `/mnt/geecs-data` with the path configured in `config.ini`.
+
+---
+
+## 2. Install the service unit
+
+Edit the placeholder values in `geecs-qserver.service` for the host:
+
+- `User=geecs` — replace only with the unprivileged service account created
+  for this host.
+- `WorkingDirectory=` — the `GeecsBluesky` checkout directory.
+- `QS_STARTUP_DIR=` — the queueserver startup profile directory.
+- `QS_EXPERIMENT=` — the GEECS experiment name served by this manager.
+- `EPICS_CA_ADDR_LIST=` — the CA gateway host, for example `192.168.6.14`.
+- `ExecStart=` — the checked-out `qserver/launch_re_manager.sh`.
+
+Install and start:
+
+```bash
+sudo cp geecs-qserver.service /etc/systemd/system/geecs-qserver.service
+sudo systemctl daemon-reload
+sudo systemctl enable --now geecs-qserver.service
+```
+
+Check the service and journal:
+
+```bash
+systemctl status geecs-qserver.service
+journalctl -u geecs-qserver.service -n 100 --no-pager
+```
+
+The unit intentionally carries a commented-out
+`Environment=QSERVER_ZMQ_PRIVATE_KEY_FOR_SERVER=` line. CurveZMQ control-plane
+key management is still open; the design item is tracked in
+`../../../Planning/cutover_strategy/02_queueserver_migration.md`.
+
+---
+
+## 3. Verify the manager
+
+Run these commands from a shell that has the `qserver` CLI available. The
+Poetry environment from the checkout is the expected source:
+
+```bash
+cd /opt/geecs/GEECS-Plugins/GeecsBluesky
+poetry run qserver status
+```
+
+Expected: the manager responds, Redis is reachable, and the RE Manager state
+is visible.
+
+Open the worker environment:
+
+```bash
+poetry run qserver environment open
+```
+
+Then confirm the environment reaches the opened or idle state:
+
+```bash
+poetry run qserver status
+```
+
+If `environment open` fails, inspect the service journal first:
+
+```bash
+journalctl -u geecs-qserver.service -n 200 --no-pager
+```
+
+Follow the troubleshooting notes in `../README.md` for the known queueserver
+failure shapes:
+
+- missing or incomplete `user_group_permissions.yaml`,
+- a startup profile that does not define `RE = RunEngine({})` while the
+  launcher uses `--keep-re`,
+- attempts to run `qserver function execute` while the manager is not idle.
+
+After the environment is open, submit only the smoke-test queue items approved
+for the current startup profile. Do not use a deployment host to discover
+machine-control behavior ad hoc; the manager is the production execution
+surface once this service is enabled.

--- a/GeecsBluesky/qserver/deploy/DEPLOYMENT.md
+++ b/GeecsBluesky/qserver/deploy/DEPLOYMENT.md
@@ -30,7 +30,10 @@ sudo systemctl enable --now redis-server.service
 Clone the repository if the host does not have it yet:
 
 **Everything below runs AS THE SERVICE ACCOUNT** (the unit's `User=`,
-`geecs` in this template): Poetry keys project virtualenvs under the
+`geecs` in this template — create it *with a login shell*, or substitute
+`sudo -u geecs -H bash` wherever `sudo -u geecs -i` appears; a
+`/usr/sbin/nologin` account fails `-i` with "account is currently not
+available"): Poetry keys project virtualenvs under the
 *invoking user's* cache, so an env installed by an admin account is
 invisible to the service — the unit would crash-loop on a fresh,
 dependency-less env while admin-side verification passes. Clone, install,
@@ -152,7 +155,6 @@ Run these commands from a shell that has the `qserver` CLI available. The
 Poetry environment from the checkout is the expected source:
 
 ```bash
-cd /opt/geecs/GEECS-Plugins/GeecsBluesky
 sudo -u geecs -i
 cd /opt/geecs/GEECS-Plugins/GeecsBluesky
 poetry run qserver status

--- a/GeecsBluesky/qserver/deploy/geecs-qserver.service
+++ b/GeecsBluesky/qserver/deploy/geecs-qserver.service
@@ -1,0 +1,39 @@
+# Template unit for the GEECS bluesky-queueserver RE Manager.
+# Copy to /etc/systemd/system/geecs-qserver.service on the dedicated host,
+# then replace every /opt/geecs/GEECS-Plugins placeholder with that host's
+# checkout path before enabling the unit.
+
+[Unit]
+Description=GEECS Bluesky Queueserver RE Manager
+After=network-online.target redis-server.service
+Wants=network-online.target
+
+[Service]
+Type=exec
+
+# Public repo placeholder only. Set this to the unprivileged service account
+# created for the queueserver host; never commit a real account name here.
+User=geecs
+
+# Placeholder: path to the GeecsBluesky checkout directory on this host.
+WorkingDirectory=/opt/geecs/GEECS-Plugins/GeecsBluesky
+
+Environment="QS_STARTUP_DIR=/opt/geecs/GEECS-Plugins/GeecsBluesky/qserver/startup"
+Environment="QS_EXPERIMENT=Undulator"
+
+# Set to the Channel Access gateway host. This explicit unit-level override is
+# the deployment-standard form; config.ini [epics] ca_addr_list also works, but
+# the unit wins operationally by making the runtime CA target visible here.
+Environment="EPICS_CA_ADDR_LIST=192.168.6.14"
+
+# CurveZMQ control-plane key management is still an open design item. When that
+# decision lands, put the server private key here; see
+# Planning/cutover_strategy/02_queueserver_migration.md.
+# Environment="QSERVER_ZMQ_PRIVATE_KEY_FOR_SERVER="
+
+ExecStart=/usr/bin/env poetry run /opt/geecs/GEECS-Plugins/GeecsBluesky/qserver/launch_re_manager.sh
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target

--- a/GeecsBluesky/qserver/deploy/geecs-qserver.service
+++ b/GeecsBluesky/qserver/deploy/geecs-qserver.service
@@ -19,19 +19,30 @@ User=geecs
 WorkingDirectory=/opt/geecs/GEECS-Plugins/GeecsBluesky
 
 Environment="QS_STARTUP_DIR=/opt/geecs/GEECS-Plugins/GeecsBluesky/qserver/startup"
+# Placeholder: the GEECS experiment name, consumed by the startup profile
+# (landing in the worker-startup task). Set per facility.
 Environment="QS_EXPERIMENT=Undulator"
 
 # Set to the Channel Access gateway host. This explicit unit-level override is
 # the deployment-standard form; config.ini [epics] ca_addr_list also works, but
 # the unit wins operationally by making the runtime CA target visible here.
 Environment="EPICS_CA_ADDR_LIST=192.168.6.14"
+# Always paired with the directed list (same pairing epics_env.py applies for
+# the config.ini route, and the gateway DEPLOYMENT.md client recipes): without
+# it, CA also broadcasts on the local subnet and a second CA server serving
+# colliding names produces nondeterministic connects.
+Environment="EPICS_CA_AUTO_ADDR_LIST=NO"
 
 # CurveZMQ control-plane key management is still an open design item. When that
 # decision lands, put the server private key here; see
 # Planning/cutover_strategy/02_queueserver_migration.md.
 # Environment="QSERVER_ZMQ_PRIVATE_KEY_FOR_SERVER="
 
-ExecStart=/usr/bin/env poetry run /opt/geecs/GEECS-Plugins/GeecsBluesky/qserver/launch_re_manager.sh
+# Poetry's ABSOLUTE path is required: systemd's service PATH omits
+# ~/.local/bin (where the official installer and pipx put poetry), so a bare
+# `env poetry` crash-loops with "No such file or directory" every RestartSec.
+# Locate it as the service user with `command -v poetry` and paste it here.
+ExecStart=/home/geecs/.local/bin/poetry run /opt/geecs/GEECS-Plugins/GeecsBluesky/qserver/launch_re_manager.sh
 Restart=on-failure
 RestartSec=5
 

--- a/GeecsBluesky/qserver/deploy/redis.conf-notes.md
+++ b/GeecsBluesky/qserver/deploy/redis.conf-notes.md
@@ -1,0 +1,29 @@
+# Redis Notes for the Queueserver Host
+
+The dedicated Ubuntu 22.04 queueserver host should use the distro Redis
+package and its systemd unit:
+
+```bash
+sudo apt update
+sudo apt install redis-server
+sudo systemctl enable --now redis-server.service
+```
+
+Keep Redis bound to loopback only. The Ubuntu package default is suitable for
+the RE Manager control-plane shape:
+
+```conf
+bind 127.0.0.1 ::1
+protected-mode yes
+```
+
+The source-built Redis used during sandbox testing was only a no-sudo
+workaround. It is not the deployment shape for the service host.
+
+Redis may warn at startup that `vm.overcommit_memory` is disabled. Apply the
+host-level sysctl fix once:
+
+```bash
+echo 'vm.overcommit_memory = 1' | sudo tee /etc/sysctl.d/99-redis-overcommit.conf
+sudo sysctl --system
+```


### PR DESCRIPTION
## Summary

- Add `GeecsBluesky/qserver/deploy/` with Redis deployment notes, a placeholder-only systemd service unit, and an Ubuntu 22.04 host runbook for the RE Manager.
- Bump `geecs-bluesky` to `0.53.1` and add the changelog entry.
- Keep the committed diff limited to `GeecsBluesky/{qserver/deploy/**, pyproject.toml, CHANGELOG.md}`.

## Dependency note

`GeecsBluesky/pyproject.toml` on `feat/queueserver` does not yet define the `qserver` extra. The runbook intentionally documents `poetry install --extras "ca tiled qserver"` as the deployment shape per issue #642; deployment depends on the parallel PR that adds that extra.

## Validation

`bash -n GeecsBluesky/qserver/launch_re_manager.sh`

```text
# no output; exit 0
```

`git diff --check`

```text
# no output; exit 0
```

`poetry check` from `GeecsBluesky/`

```text
Warning: [tool.poetry.name] is deprecated. Use [project.name] instead.
Warning: [tool.poetry.version] is set but 'version' is not in [project.dynamic]. If it is static use [project.version]. If it is dynamic, add 'version' to [project.dynamic].
If you want to set the version dynamically via `poetry build --local-version` or you are using a plugin, which sets the version dynamically, you should define the version in [tool.poetry] and add 'version' to [project.dynamic].
Warning: [tool.poetry.description] is deprecated. Use [project.description] instead.
Warning: [tool.poetry.readme] is set but 'readme' is not in [project.dynamic]. If it is static use [project.readme]. If it is dynamic, add 'readme' to [project.dynamic].
If you want to define multiple readmes, you should define them in [tool.poetry] and add 'readme' to [project.dynamic].
Warning: [tool.poetry.authors] is deprecated. Use [project.authors] instead.
Warning: [tool.poetry.extras] is deprecated. Use [project.optional-dependencies] instead.
```

`git diff --name-only HEAD~1..HEAD`

```text
GeecsBluesky/CHANGELOG.md
GeecsBluesky/pyproject.toml
GeecsBluesky/qserver/deploy/DEPLOYMENT.md
GeecsBluesky/qserver/deploy/geecs-qserver.service
GeecsBluesky/qserver/deploy/redis.conf-notes.md
```

`scripts/commit.sh -m "Add queueserver deployment assets"`

```text
commit.sh: effective pre-commit cannot find 'jupyter' — skipping jupyter-notebook-clear-output (CI still runs it)
don't commit to branch...................................................Passed
trim trailing whitespace.................................................Passed
fix end of files.........................................................Passed
check python ast.....................................(no files to check)Skipped
check for case conflicts.................................................Passed
check json...........................................(no files to check)Skipped
check for merge conflicts................................................Passed
check for broken symlinks............................(no files to check)Skipped
check xml............................................(no files to check)Skipped
check yaml...........................................(no files to check)Skipped
check toml...............................................................Passed
check for added large files..............................................Passed
mixed line ending........................................................Passed
ruff.................................................(no files to check)Skipped
ruff-format..........................................(no files to check)Skipped
pydocstyle...........................................(no files to check)Skipped
jupyter-notebook-jupyter-clear..........................................Skipped
```

`systemd-analyze verify` was not run, per the issue note that it is not runnable in CI. Unit file pasted for eyeball review:

```ini
# Template unit for the GEECS bluesky-queueserver RE Manager.
# Copy to /etc/systemd/system/geecs-qserver.service on the dedicated host,
# then replace every /opt/geecs/GEECS-Plugins placeholder with that host's
# checkout path before enabling the unit.

[Unit]
Description=GEECS Bluesky Queueserver RE Manager
After=network-online.target redis-server.service
Wants=network-online.target

[Service]
Type=exec

# Public repo placeholder only. Set this to the unprivileged service account
# created for the queueserver host; never commit a real account name here.
User=geecs

# Placeholder: path to the GeecsBluesky checkout directory on this host.
WorkingDirectory=/opt/geecs/GEECS-Plugins/GeecsBluesky

Environment="QS_STARTUP_DIR=/opt/geecs/GEECS-Plugins/GeecsBluesky/qserver/startup"
Environment="QS_EXPERIMENT=Undulator"

# Set to the Channel Access gateway host. This explicit unit-level override is
# the deployment-standard form; config.ini [epics] ca_addr_list also works, but
# the unit wins operationally by making the runtime CA target visible here.
Environment="EPICS_CA_ADDR_LIST=192.168.6.14"

# CurveZMQ control-plane key management is still an open design item. When that
# decision lands, put the server private key here; see
# Planning/cutover_strategy/02_queueserver_migration.md.
# Environment="QSERVER_ZMQ_PRIVATE_KEY_FOR_SERVER="

ExecStart=/usr/bin/env poetry run /opt/geecs/GEECS-Plugins/GeecsBluesky/qserver/launch_re_manager.sh
Restart=on-failure
RestartSec=5

[Install]
WantedBy=multi-user.target
```

Closes #642.
