### PR TITLE
GeecsBluesky 0.54.0: RE Manager startup profile + optimize loader seam (#640)

### DIFF
--- a/GeecsBluesky/CHANGELOG.md
+++ b/GeecsBluesky/CHANGELOG.md
@@ -4,6 +4,55 @@ All notable changes to `geecs-bluesky` are documented here.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.54.0] - 2026-08-20
+
+### Added
+
+- **RE Manager startup profile — the worker is now runnable**
+  (`qserver/startup/startup.py`, issue #640, queueserver migration round 2).
+  Imports `geecs_bluesky` first (before any `aioca` import, so
+  `EPICS_CA_ADDR_LIST`/`EPICS_CA_AUTO_ADDR_LIST` are set from
+  `~/.config/geecs_python_api/config.ini` before libca's CA context is
+  created — config-file/systemd-env sourcing is deliberate, never
+  DB-sourced, to avoid an import-time network round trip and a bootstrap
+  circularity), resolves the experiment from `QS_EXPERIMENT` (falling back
+  to `config.ini`'s `[Experiment] expt`, failing loud at startup if
+  neither yields a name), builds the worker's `GeecsSession`, exposes
+  `session.RE` as the module-level `RE` the manager keeps alive
+  (`--keep-re`), subscribes `SFileExportCallback` (#635) and the session's
+  own best-effort Tiled subscription, and registers
+  `geecs_scan_request_plan` in the manager's plan list.
+- **The optimization loader seam is closed** (the deferred cross-vendor P1
+  from #639, decision 5 in
+  `Planning/cutover_strategy/02_queueserver_migration.md`):
+  `plans/scan_request_plan.py` gains `set_optimization_loader()`, and the
+  optimize-mode body of the preamble now invokes the registered loader
+  in-plan (worker-side construction with deferred connects, unserved-vars
+  pre-flight over the save-set devices plus the loader's
+  `device_requirements`, the claim boundary, then
+  `plans.optimize.geecs_adaptive_scan` wrapped exactly as
+  `GeecsSession.optimize` wraps it) instead of refusing loudly. A worker
+  without the `optimize` extra still refuses loudly — no loader registered
+  means no silent degradation. `geecs_bluesky/optimization/worker_loader.py`
+  is the loader implementation (`OptimizationSpec` → `SessionOptimizationBridge`
+  via `BaseOptimizer.from_config`), modeled on GEECS-Console's
+  `services/optimization.py` but independently implemented (GeecsBluesky
+  imports nothing from GEECS-Console).
+- New optional extra `qserver = ["bluesky-queueserver"]`, pinned `^0.0.25`
+  (the sandbox-validated release); `poetry.lock` refreshed to match.
+- `tests/test_qserver_startup.py` (hermetic — no lab, no redis): the
+  startup profile defines `RE`/`geecs_scan_request_plan` headlessly with
+  `QS_EXPERIMENT` set, fails loud with neither `QS_EXPERIMENT` nor
+  `config.ini`'s `[Experiment] expt`, and (when the `qserver` extra is
+  installed) `bluesky_queueserver`'s own
+  `gen_list_of_plans_and_devices` succeeds against `qserver/startup/` —
+  skipped by default since the CI job does not install the `qserver`
+  extra. `tests/test_scan_request_plan.py` gains the optimize-loader-seam
+  coverage: no loader registered still refuses loudly post-validation,
+  and a fake loader/bridge drives a scripted suggester through real bins
+  (mock acq-timestamp pacing seeded from the bridge's `bind(devices=...)`,
+  since the adaptive scan's t0 sync runs before any staging message).
+
 ## [0.53.1] - 2026-08-20
 
 ### Added

--- a/GeecsBluesky/CHANGELOG.md
+++ b/GeecsBluesky/CHANGELOG.md
@@ -52,6 +52,18 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   and a fake loader/bridge drives a scripted suggester through real bins
   (mock acq-timestamp pacing seeded from the bridge's `bind(devices=...)`,
   since the adaptive scan's t0 sync runs before any staging message).
+- PR #644 review fix wave: `worker_loader.py` gains
+  `warm_up_optimization_stack()`, which imports the heavy optimize-extra
+  modules (`xopt`, `scan_analysis`, the loader's own submodules) on a
+  daemon thread right after a loader is registered, so the first real
+  `geecs_scan_request_plan` optimize call in a worker session doesn't pay
+  that import cost in-plan; `startup.py` calls it immediately after
+  `set_optimization_loader()`, a no-op when the `optimize` extra isn't
+  installed. `tests/test_qserver_startup.py`'s import-order test is now a
+  `_qserver_startup_probe.py` subprocess run in a fresh interpreter — the
+  prior in-process `runpy.run_path` version could never actually observe
+  first-import order since `geecs_bluesky`/`aioca` are already cached in
+  `sys.modules` by the time any in-process test runs.
 
 ## [0.53.1] - 2026-08-20
 

--- a/GeecsBluesky/CLAUDE.md
+++ b/GeecsBluesky/CLAUDE.md
@@ -107,9 +107,13 @@ geecs_bluesky/
                             #   the plan preamble (validate → resolve →
                             #   construct+connect in-plan → claim → the same
                             #   inner plan); set_plan_session installs the
-                            #   worker default session; optimize refused
-                            #   loudly (later round); s-file export is NOT
-                            #   here (worker stop-doc callback seam)
+                            #   worker default session; optimize-mode
+                            #   requests run in-plan too (set_optimization_
+                            #   loader registers the worker's loader — see
+                            #   optimization/worker_loader.py — refused
+                            #   loudly, not mid-scan, when unregistered);
+                            #   s-file export is NOT here (worker stop-doc
+                            #   callback seam)
   devices/
     ca/                     # THE device family: CA-backed via GeecsCAGateway PVs (`ca` extra)
       triggerable.py        # CaAcqTimestampReadable (persistent CA monitor) + CaTriggerable
@@ -161,6 +165,13 @@ geecs_bluesky/
                             #   — the legacy engine re-imports them via shims).
                             #   Heavy deps ride the `optimize` extra; tests
                             #   skip whole without it
+    worker_loader.py         # the queueserver worker's optimization_loader:
+                            #   OptimizationSpec -> SessionOptimizationBridge
+                            #   (worker-side twin of GEECS-Console's
+                            #   geecs_console.services.optimization); also
+                            #   warm_up_optimization_stack(), called once at
+                            #   worker startup (qserver/startup/startup.py)
+                            #   to pre-import the heavy stack off-thread
   tiled_integration.py      # subscribe_tiled + descriptor patch + safe callback
   data_paths.py             # local ↔ device-server path mapping, asset roots
   scanner_configs.py        # configs-repo resolution + shot-control YAML loading

--- a/GeecsBluesky/geecs_bluesky/optimization/worker_loader.py
+++ b/GeecsBluesky/geecs_bluesky/optimization/worker_loader.py
@@ -1,0 +1,155 @@
+"""The queueserver worker's ``optimization_loader``: OptimizationSpec → bridge.
+
+Decision 5 (``Planning/cutover_strategy/02_queueserver_migration.md``):
+optimization stays in-worker — the stack's code
+(``geecs_bluesky.optimization``) does not move, only the *call site* that
+invokes it moves from the GUI process into the queueserver worker's plan
+preamble (``geecs_bluesky.plans.scan_request_plan``,
+:func:`~geecs_bluesky.plans.scan_request_plan.set_optimization_loader`).
+
+This module is the worker-side twin of GEECS-Console's
+``geecs_console.services.optimization`` — same three functions, same
+shapes, independently implemented so GeecsBluesky imports nothing from
+GEECS-Console (the dependency graph runs the other way: Console depends on
+GeecsBluesky, never the reverse). Keep the two in sync by hand if the
+``OptimizationSpec``/``BaseOptimizerConfig`` mapping changes.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import logging
+from typing import Any, Callable, Optional
+
+logger = logging.getLogger(__name__)
+
+
+def optimizer_config_from_spec(spec: Any) -> dict:
+    """Map an ``OptimizationSpec`` onto the ``BaseOptimizerConfig`` dict shape.
+
+    Pure and import-light (duck-typed off the spec's attributes), so the
+    mapping is testable without the ``optimize`` extra installed. The exact
+    inverse of ``geecs_schemas.convert.convert_optimizer_config``
+    (``generator.options`` <-> ``xopt_config_overrides[generator.name]``).
+    ``max_iterations`` is deliberately not mapped — the plan consumes it
+    from the spec directly.
+
+    Parameters
+    ----------
+    spec : geecs_schemas.OptimizationSpec
+        The request's resolved optimization block.
+
+    Returns
+    -------
+    dict
+        The parsed-YAML shape ``BaseOptimizer.from_config`` validates:
+        ``vocs`` (variables/objectives/observables/constraints),
+        ``evaluator`` (module/class/kwargs), ``generator`` (name),
+        ``xopt_config_overrides`` keyed by the generator name (only when
+        the spec carries generator options), ``seed_dump_files`` and
+        ``move_to_best_on_finish``.
+    """
+    config: dict[str, Any] = {
+        "vocs": {
+            "variables": {
+                name: list(bounds) for name, bounds in spec.variables.items()
+            },
+            "objectives": dict(spec.objectives),
+            "observables": list(spec.observables),
+            "constraints": {
+                name: list(bound) for name, bound in spec.constraints.items()
+            },
+        },
+        "evaluator": {
+            "module": spec.evaluator.module,
+            "class": spec.evaluator.class_name,
+            "kwargs": dict(spec.evaluator.kwargs),
+        },
+        "generator": {"name": spec.generator.name},
+        "seed_dump_files": [str(path) for path in spec.seed_dump_files],
+        "move_to_best_on_finish": spec.move_to_best_on_finish,
+    }
+    if spec.generator.options:
+        config["xopt_config_overrides"] = {
+            spec.generator.name: dict(spec.generator.options)
+        }
+    return config
+
+
+def load_worker_optimization(spec: Any) -> Any:
+    """Build the optimization bridge for one resolved ``OptimizationSpec``.
+
+    The worker's ``optimization_loader`` implementation: instantiates the
+    config-driven optimizer stack (``BaseOptimizer`` — Xopt generator +
+    dynamically imported evaluator with its analyzers) and wraps it in the
+    ``SessionOptimizationBridge`` whose ``bind`` the plan calls with the
+    connected devices and the claimed scan tag/folder.
+
+    Relative ``seed_dump_files`` entries are not resolved on this path
+    (there is no config-file directory once the spec is inline in the
+    request) — use absolute paths in optimizer configs that warm-start.
+
+    Parameters
+    ----------
+    spec : geecs_schemas.OptimizationSpec
+        The request's resolved optimization block.
+
+    Returns
+    -------
+    geecs_bluesky.optimization.session_bridge.SessionOptimizationBridge
+        The bridge exposing ``bind(devices=..., scan_tag=...,
+        scan_folder=...) -> (objective, suggester)``, ``finish()``, and
+        ``device_requirements`` (auto-generated from the evaluator's
+        analyzers).
+    """
+    from geecs_bluesky.optimization.base_optimizer import BaseOptimizer
+    from geecs_bluesky.optimization.session_bridge import SessionOptimizationBridge
+
+    optimizer = BaseOptimizer.from_config(optimizer_config_from_spec(spec))
+    return SessionOptimizationBridge(optimizer)
+
+
+def optimization_available() -> bool:
+    """Whether the optimization stack's heavy dependencies are installed.
+
+    The stack's *code* (``geecs_bluesky.optimization``) always ships with
+    geecs-bluesky; the ``optimize`` extra adds the dependency tree (xopt ->
+    torch/botorch, ScanAnalysis). A light ``find_spec`` probe on the
+    stack's two import roots (``xopt`` AND ``scan_analysis`` — an
+    environment with only one would die mid-scan instead of getting the
+    clean needs-a-loader refusal); nothing heavy is imported.
+    """
+    try:
+        return (
+            importlib.util.find_spec("xopt") is not None
+            and importlib.util.find_spec("scan_analysis") is not None
+        )
+    except (ImportError, ModuleNotFoundError):
+        return False
+
+
+def make_worker_optimization_loader() -> Optional[Callable[[Any], Any]]:
+    """Return the worker's ``optimization_loader``, or ``None`` if unavailable.
+
+    ``None`` (the ``optimize`` extra not installed) is what the worker
+    startup profile passes to
+    :func:`~geecs_bluesky.plans.scan_request_plan.set_optimization_loader`,
+    which makes the plan refuse optimize-mode requests loudly rather than
+    failing mid-scan on a missing import.
+    """
+    if not optimization_available():
+        logger.info(
+            "the optimization stack's dependencies are not installed "
+            "(the `optimize` extra) — optimize-mode ScanRequests will be "
+            "refused by geecs_scan_request_plan"
+        )
+        return None
+    return load_worker_optimization
+
+
+__all__ = [
+    "optimizer_config_from_spec",
+    "load_worker_optimization",
+    "optimization_available",
+    "make_worker_optimization_loader",
+]

--- a/GeecsBluesky/geecs_bluesky/optimization/worker_loader.py
+++ b/GeecsBluesky/geecs_bluesky/optimization/worker_loader.py
@@ -8,20 +8,33 @@ preamble (``geecs_bluesky.plans.scan_request_plan``,
 :func:`~geecs_bluesky.plans.scan_request_plan.set_optimization_loader`).
 
 This module is the worker-side twin of GEECS-Console's
-``geecs_console.services.optimization`` — same three functions, same
-shapes, independently implemented so GeecsBluesky imports nothing from
-GEECS-Console (the dependency graph runs the other way: Console depends on
-GeecsBluesky, never the reverse). Keep the two in sync by hand if the
-``OptimizationSpec``/``BaseOptimizerConfig`` mapping changes.
+``geecs_console.services.optimization`` — same four functions (including
+the startup warm-up), same shapes, independently implemented so
+GeecsBluesky imports nothing from GEECS-Console (the dependency graph runs
+the other way: Console depends on GeecsBluesky, never the reverse). Keep
+the two in sync by hand if the ``OptimizationSpec``/``BaseOptimizerConfig``
+mapping changes.
 """
 
 from __future__ import annotations
 
+import importlib
 import importlib.util
 import logging
+import threading
+import time
 from typing import Any, Callable, Optional
 
 logger = logging.getLogger(__name__)
+
+#: The heavy modules :func:`load_worker_optimization` imports at call time —
+#: pulling in the whole Xopt/botorch/torch stack transitively.  The warm-up
+#: thread imports exactly these so a later loader call is a pure
+#: ``sys.modules`` cache hit.
+_HEAVY_MODULES = (
+    "geecs_bluesky.optimization.base_optimizer",
+    "geecs_bluesky.optimization.session_bridge",
+)
 
 
 def optimizer_config_from_spec(spec: Any) -> dict:
@@ -147,9 +160,68 @@ def make_worker_optimization_loader() -> Optional[Callable[[Any], Any]]:
     return load_worker_optimization
 
 
+def warm_up_optimization_stack() -> Optional[threading.Thread]:
+    """Pre-import the optimization stack on a daemon thread.
+
+    The loader's first call pays the torch/botorch/xopt cold import — tens
+    of seconds — which would otherwise freeze the worker's first optimize
+    request. The worker startup profile (``qserver/startup/startup.py``)
+    calls this once, right after registering a non-``None``
+    :func:`make_worker_optimization_loader` result via ``set_optimization_
+    loader``: when the ``optimize`` extra is present (the same light
+    ``find_spec`` probe as :func:`optimization_available`), a daemon thread
+    imports ``_HEAVY_MODULES`` in the background so the stack is warm
+    before the first optimize-mode ``ScanRequest`` ever arrives on the
+    queue. Without the extra this is a no-op.
+
+    Warm-up failures are logged and swallowed — they never affect startup;
+    the loader's own lazy import simply pays the cost (and raises its own
+    error) later.
+
+    No double-import guard is needed for a request arriving mid-warm-up:
+    Python's per-module import locks already serialize concurrent imports,
+    so :func:`load_worker_optimization`'s import statements block until
+    the warm-up thread finishes that module, then reuse it from
+    ``sys.modules``. The work happens exactly once per process either way.
+
+    Returns
+    -------
+    threading.Thread or None
+        The started daemon thread, or ``None`` when the ``optimize``
+        extra is absent (nothing to warm). Callers need not join it.
+    """
+    if not optimization_available():
+        logger.debug(
+            "optimization stack warm-up skipped — its dependencies are not "
+            "installed (the `optimize` extra)"
+        )
+        return None
+
+    def _warm_up() -> None:
+        start = time.perf_counter()
+        try:
+            for name in _HEAVY_MODULES:
+                importlib.import_module(name)
+        except Exception:
+            logger.warning(
+                "optimization stack warm-up failed — the first optimize "
+                "request will pay the import cost instead",
+                exc_info=True,
+            )
+            return
+        logger.info(
+            "optimization stack preloaded in %.1f s", time.perf_counter() - start
+        )
+
+    thread = threading.Thread(target=_warm_up, name="optimization-warmup", daemon=True)
+    thread.start()
+    return thread
+
+
 __all__ = [
     "optimizer_config_from_spec",
     "load_worker_optimization",
     "optimization_available",
     "make_worker_optimization_loader",
+    "warm_up_optimization_stack",
 ]

--- a/GeecsBluesky/geecs_bluesky/plans/scan_request_plan.py
+++ b/GeecsBluesky/geecs_bluesky/plans/scan_request_plan.py
@@ -47,7 +47,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from typing import Any
+from typing import Any, Callable
 
 import bluesky.plan_stubs as bps
 import bluesky.preprocessors as bpp
@@ -56,14 +56,22 @@ from ophyd_async.plan_stubs import ensure_connected
 from geecs_bluesky.config_resolver import ConfigResolver, ConfigsRepoResolver
 from geecs_bluesky.db_runtime import select_telemetry_variables
 from geecs_bluesky.exceptions import GeecsConfigurationError
+from geecs_bluesky.optimize import BinData
+from geecs_bluesky.plans.optimize import geecs_adaptive_scan
 from geecs_bluesky.plans.orchestration import build_step_scan_plan
-from geecs_bluesky.plans.run_wrapper import claim_scan_number
+from geecs_bluesky.plans.run_wrapper import (
+    claim_scan,
+    claim_scan_number,
+    geecs_run_wrapper,
+)
 from geecs_bluesky.scan_log import (
     begin_pre_scan_capture,
     discard_pre_scan_capture,
+    log_claimed_scan_failure,
     scan_log,
 )
 from geecs_bluesky.scan_request_runner import (
+    PseudoMovableTarget,
     _build_request_detectors,
     _defaults_flag,
     _preflight_unserved,
@@ -73,6 +81,7 @@ from geecs_bluesky.scan_request_runner import (
     build_step_scan_spec,
     compile_action_slot,
     make_scalar_policy,
+    merge_optimizer_device_requirements,
     prefetch_action_signals,
     resolve_movable_target,
     resolve_save_sets_and_rituals,
@@ -86,7 +95,7 @@ from geecs_schemas import AcquisitionMode, ScanRequest, ScanRequestMode
 
 logger = logging.getLogger(__name__)
 
-__all__ = ["geecs_scan_request_plan", "set_plan_session"]
+__all__ = ["geecs_scan_request_plan", "set_plan_session", "set_optimization_loader"]
 
 #: Per-connect timeout for the in-plan strict batches.  Near-parity, not
 #: parity, with ``GeecsSession._connect``: there 20 s is the outer wall on
@@ -132,6 +141,38 @@ def set_plan_session(session: Any | None) -> None:
     """
     global _worker_session
     _worker_session = session
+
+
+#: The worker-wide optimization loader (installed once at worker startup,
+#: when the `optimize` extra is present).  ``None`` means optimize-mode
+#: requests are refused loudly (see the OPTIMIZE branch of
+#: :func:`_scan_request_body`).
+_optimization_loader: Callable[[Any], Any] | None = None
+
+
+def set_optimization_loader(loader: Callable[[Any], Any] | None) -> None:
+    """Install the worker-wide optimization loader for the plan.
+
+    Modeled on how GEECS-Console's ``services.optimization`` builds its
+    ``optimization_loader`` (imports nothing from GEECS-Console): a worker
+    startup script calls this once with a callable built from
+    ``geecs_bluesky.optimization`` when the ``optimize`` extra is
+    installed. The plan then calls ``loader(request.optimization)`` for
+    every optimize-mode request it serves. Pass ``None`` to clear (tests,
+    or a headless install without the extra) — the plan refuses
+    optimize-mode requests loudly rather than silently degrading.
+
+    Parameters
+    ----------
+    loader :
+        ``loader(spec: geecs_schemas.OptimizationSpec) -> bridge`` where
+        ``bridge`` exposes ``bind(devices=..., scan_tag=..., scan_folder=...)
+        -> (objective, suggester)``, an optional ``device_requirements``
+        property, and an optional ``finish()`` — the same shape as
+        :class:`~geecs_bluesky.optimization.session_bridge.SessionOptimizationBridge`.
+    """
+    global _optimization_loader
+    _optimization_loader = loader
 
 
 class _DeferredConnectFactories:
@@ -342,11 +383,9 @@ def geecs_scan_request_plan(
     ------
     GeecsConfigurationError
         No session configured, unresolvable names, a bad pseudo formula,
-        a strict request without usable shot control, or an empty
-        effective device set — all pre-claim.
-    NotImplementedError
-        Optimize-mode requests (validated first, refused loudly — a later
-        round moves the optimization loader in-worker per decision 5).
+        a strict request without usable shot control, an empty effective
+        device set, or (optimize mode) no optimization loader registered
+        (see :func:`set_optimization_loader`) — all pre-claim.
     """
     if session is None:
         session = _worker_session
@@ -388,15 +427,6 @@ def _scan_request_body(
         request = ScanRequest.model_validate(request)
     request, applied_defaults, defaults = validate_scan_request(request, resolver)
 
-    if request.mode is ScanRequestMode.OPTIMIZE:
-        raise NotImplementedError(
-            "optimize-mode ScanRequests are not yet served by "
-            "geecs_scan_request_plan: the optimization loader is registered "
-            "by the worker startup script, which lands in the worker-startup "
-            "round (W2) — round 1 covers step and noscan. Until then, run "
-            "optimize requests through GeecsSession.run / run_scan_request"
-        )
-
     controller = None
     if request.trigger_profile:
         profile = resolver.resolve_trigger_profile(request.trigger_profile)
@@ -410,6 +440,13 @@ def _scan_request_body(
                 rep_rate_hz=session.rep_rate_hz,
             )
     strict = request.acquisition is AcquisitionMode.STRICT
+
+    if request.mode is ScanRequestMode.OPTIMIZE:
+        return (
+            yield from _optimize_request_body(
+                session, resolver, request, controller, strict, created
+            )
+        )
 
     save_set, rituals = resolve_save_sets_and_rituals(resolver, request.save_sets)
     scalar_policy = make_scalar_policy(session)
@@ -557,3 +594,289 @@ def _scan_request_body(
     # (the GeecsSession.scan claimed-here rule; tolerates a failed claim).
     with scan_log(scan_number, scan_folder):
         return (yield from inner)
+
+
+def _optimize_request_body(
+    session: Any,
+    resolver: ConfigResolver,
+    request: ScanRequest,
+    controller: ShotController | None,
+    strict: bool,
+    created: list,
+):
+    """The optimize-mode body of :func:`_scan_request_body`.
+
+    Mirrors :func:`~geecs_bluesky.scan_request_runner._run_optimize_request`
+    (the binder path) in-plan: worker-side construction with deferred
+    connects, the unserved-variables pre-flight over the *effective*
+    device set (save-set devices plus the loader's ``device_requirements``),
+    the claim boundary (the full :class:`ScanTag`, since the loader's
+    analyzers may need it), then :func:`~geecs_bluesky.plans.optimize.geecs_adaptive_scan`
+    wrapped exactly as :meth:`GeecsSession.optimize` wraps it.
+
+    Deliberately dropped relative to ``GeecsSession.optimize``: the
+    ``should_abort``/``pause_supervisor`` GUI hooks (no plan-side
+    equivalent, same as the step/noscan body above) and the
+    ``on_finish='best'|'initial'`` variable-restore convenience — a plan
+    that raises or is stopped simply leaves the variables where the
+    suggester last set them (the scan-plan convention), never restores.
+    Both are acceptable gaps for a queueserver worker: restores are an
+    operator convenience, not a data-integrity concern.
+
+    Raises
+    ------
+    GeecsConfigurationError
+        No optimization loader registered (see :func:`set_optimization_loader`),
+        an empty effective device set, or a strict request without usable
+        shot control — all pre-claim.
+    """
+    spec = request.optimization
+    assert spec is not None  # guaranteed by ScanRequest validation
+
+    loader = _optimization_loader
+    if loader is None:
+        raise GeecsConfigurationError(
+            "optimize-mode ScanRequest reached geecs_scan_request_plan "
+            "without an optimization loader registered — call "
+            "set_optimization_loader(...) at worker startup with a loader "
+            "built from geecs_bluesky.optimization (needs the `optimize` "
+            "extra); headless installs without one refuse optimize-mode "
+            "requests here rather than silently degrading"
+        )
+    opt_bridge = loader(spec)
+    device_requirements = getattr(opt_bridge, "device_requirements", None)
+
+    save_set, rituals = resolve_save_sets_and_rituals(resolver, request.save_sets)
+    warn_if_reserved_boundary_overrides(save_set)
+    skipped: dict[str, list[str]] = {}
+    ritual_names = [n for names in rituals.values() for n in names]
+    if ritual_names:
+        # Optimize mode does not run action plans yet (mirrors
+        # _run_optimize_request) — record rather than refuse.
+        skipped["save_set_rituals"] = ritual_names
+    scalar_policy = make_scalar_policy(session)
+    devices_config = save_set_to_devices_config(save_set, scalar_policy)
+    # Auto-provision the optimizer's device requirements (issue #520's
+    # reversal): the objective's diagnostics acquire and save even when the
+    # request names no save sets naming them.
+    provisioned = merge_optimizer_device_requirements(
+        devices_config, device_requirements
+    )
+    if not devices_config:
+        raise GeecsConfigurationError(
+            "an 'optimize' ScanRequest needs at least one recording device "
+            "— name save sets in save_sets, or use an optimizer whose "
+            "evaluator declares device_requirements (auto-generated from "
+            "its analyzers); without either the objective has nothing to "
+            "read"
+        )
+    devices_config, dropped_unserved, dropped_unserved_devices = _preflight_unserved(
+        session, devices_config, None
+    )
+    if devices_config is None:
+        # No operator preflight hook on this path (same design position as
+        # the step/noscan body) — _preflight_unserved never returns None
+        # without one; defensive only.
+        raise GeecsConfigurationError(
+            "unserved-variables pre-flight aborted the optimization (pre-claim)"
+        )
+
+    # ---- phase 2: worker-side construction (connects deferred) -----------
+    factories = _DeferredConnectFactories(session)
+    detectors = _build_request_detectors(factories, devices_config, free_run=not strict)
+    variables: dict[str, Any] = {}
+    pseudo_meta: dict[str, Any] = {}
+    for name in spec.variables:
+        if ":" in name:
+            device, _, variable = name.partition(":")
+            movable = factories.settable(device, variable)
+        else:
+            var_spec = resolver.resolve_scan_variable(name)
+            target = resolve_movable_target(var_spec, name)
+            if isinstance(target, PseudoMovableTarget):
+                pseudo_meta[target.variable_name] = target.metadata()
+            movable = build_movable(factories, target)
+        variables[name] = movable
+    created.extend(factories.created)
+
+    # ---- phase 3: in-plan connects (still pre-claim) ----------------------
+    if factories.created:
+        yield from _connect_in_batches(factories.created, mock=session._mock)
+    if controller is not None and not session._mock:
+        yield from _await_in_plan(controller.connect_setters)
+
+    if strict:
+        if controller is None:
+            raise GeecsConfigurationError(
+                "strict_shot_control requires a reachable shot-control device. "
+                "Use free-run mode for free-running trigger acquisition."
+            )
+        controller.require_strict_single_shot()
+
+    md: dict[str, Any] = {"scan_request_mode": request.mode.value}
+    if pseudo_meta:
+        md["pseudo_variables"] = pseudo_meta
+    if request.save_sets:
+        md["save_sets"] = list(request.save_sets)
+    if provisioned:
+        md["provisioned_device_requirements"] = provisioned
+    if dropped_unserved:
+        md["dropped_unserved_variables"] = {
+            dev: list(vars_) for dev, vars_ in dropped_unserved.items()
+        }
+    if dropped_unserved_devices:
+        md["dropped_unserved_devices"] = list(dropped_unserved_devices)
+    if skipped:
+        md["skipped_action_plans"] = skipped
+        logger.warning(
+            "Optimize mode does not run action plans yet — skipping the "
+            "following for this optimization (setup/per_step/closeout and "
+            "save-set rituals do not run during optimization): %s",
+            skipped,
+        )
+
+    # ---- phase 4: the claim boundary --------------------------------------
+    # The full ScanTag (not just the number): the loader's analyzers may
+    # need it (mirrors _run_optimize_request's binder-path claim).
+    scan_tag, scan_folder = claim_scan(session.experiment)
+    scan_number = scan_tag.number if scan_tag is not None else None
+    if scan_number is not None:
+        session._write_scan_info(
+            scan_number,
+            scan_folder,
+            motor=None,
+            positions=[None],
+            shots_per_step=request.shots_per_step,
+            description=request.description,
+            overrides={
+                "scan_parameter": ",".join(variables),
+                "scan_mode": "optimization",
+                "shots": request.shots_per_step,
+            },
+        )
+
+    try:
+        objective, suggester = opt_bridge.bind(
+            devices=list(variables.values()) + detectors,
+            scan_tag=scan_tag,
+            scan_folder=scan_folder,
+        )
+
+        reference = detectors[0]
+        for det in detectors:
+            if hasattr(det, "configure_shot_id"):
+                det.configure_shot_id(session.rep_rate_hz)
+        saving_detectors = session._configure_saving(
+            detectors, scan_number, scan_folder
+        )
+
+        max_iterations = spec.max_iterations or 20
+
+        # In-process row collection (plan-native equivalent of
+        # GeecsSession.optimize's self.RE.subscribe(_collect)): the
+        # objective evaluates between bins without a Tiled round trip.
+        descriptors: dict[str, str] = {}
+        rows: list[dict] = []
+        history: list[dict] = []
+        pending: dict[str, float] | None = None
+
+        def _collect(name: str, doc: dict) -> None:
+            if name == "descriptor":
+                descriptors[doc["uid"]] = doc.get("name", "")
+            elif name == "event" and descriptors.get(doc["descriptor"]) == "primary":
+                rows.append(dict(doc["data"]))
+
+        def _observe_previous(iteration: int) -> None:
+            nonlocal pending
+            if pending is None:
+                return
+            bin_rows = [r for r in rows if r.get("bin_number") == iteration]
+            bin_data = BinData(iteration, bin_rows)
+            try:
+                value = float(objective(bin_data))
+            except Exception:
+                logger.warning(
+                    "objective failed on iteration %d; recording NaN",
+                    iteration,
+                    exc_info=True,
+                )
+                value = float("nan")
+            suggester.observe(pending, value, bin_data)
+            history.append(
+                {
+                    "iteration": iteration,
+                    "inputs": pending,
+                    "objective": value,
+                    "n_rows": len(bin_rows),
+                }
+            )
+            pending = None
+
+        def _propose(iteration: int) -> dict[str, float] | None:
+            nonlocal pending
+            _observe_previous(iteration - 1)
+            inputs = suggester.suggest()
+            if inputs is None:
+                logger.info("suggester stopped at iteration %d", iteration)
+                return None
+            unknown = set(inputs) - set(variables)
+            if unknown:
+                raise KeyError(f"suggester proposed unknown variables: {unknown}")
+            pending = inputs
+            logger.info("iteration %d: %s", iteration, inputs)
+            return inputs
+
+        plan = geecs_adaptive_scan(
+            movables=dict(variables),
+            propose=_propose,
+            detectors=detectors[1:] if not strict else detectors,
+            reference=reference if not strict else None,
+            shots_per_iteration=request.shots_per_step,
+            max_iterations=max_iterations,
+            fire_shot=controller.fire_shot if strict and controller else None,
+            setup_trigger=(
+                (lambda: controller.arm_single_shot(detectors))
+                if strict and controller
+                else None
+            ),
+            arm_trigger=controller.arm if not strict and controller else None,
+            disarm_trigger=controller.disarm if not strict and controller else None,
+            quiesce_trigger=controller.quiesce if not strict and controller else None,
+            md={"description": request.description, **md},
+        )
+        run_plan = geecs_run_wrapper(
+            plan,
+            experiment=session.experiment,
+            scan_number=scan_number,
+            scan_folder=scan_folder,
+            saving_detectors=saving_detectors,
+            devices=detectors + list(variables.values()),
+            extra_md={"description": request.description, **md},
+        )
+        if controller is not None:
+            run_plan = bpp.finalize_wrapper(run_plan, controller.disarm())
+
+        # The plan claimed the number, so the plan owns the per-scan
+        # scan.log (mirrors the step/noscan body above).
+        token = yield from bps.subscribe("all", _collect)
+        try:
+            with scan_log(scan_number, scan_folder):
+                uid = yield from run_plan
+        finally:
+            yield from bps.unsubscribe(token)
+        _observe_previous(len(history) + 1)  # final bin
+    except BaseException:
+        if scan_number is not None:
+            log_claimed_scan_failure(
+                scan_number, scan_folder, label="Optimization scan"
+            )
+        raise
+    finally:
+        finish = getattr(opt_bridge, "finish", None)
+        if finish is not None:
+            try:
+                finish()
+            except Exception:
+                logger.warning("optimization bridge finish() failed", exc_info=True)
+
+    return uid

--- a/GeecsBluesky/geecs_bluesky/plans/scan_request_plan.py
+++ b/GeecsBluesky/geecs_bluesky/plans/scan_request_plan.py
@@ -46,7 +46,10 @@ worker-wide default session via :func:`set_plan_session`) later.
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
+import math
+from pathlib import Path
 from typing import Any, Callable
 
 import bluesky.plan_stubs as bps
@@ -90,6 +93,7 @@ from geecs_bluesky.scan_request_runner import (
     validate_scan_request,
     warn_if_reserved_boundary_overrides,
 )
+from geecs_bluesky.session import _json_safe
 from geecs_bluesky.shot_controller import ShotController
 from geecs_schemas import AcquisitionMode, ScanRequest, ScanRequestMode
 
@@ -444,7 +448,13 @@ def _scan_request_body(
     if request.mode is ScanRequestMode.OPTIMIZE:
         return (
             yield from _optimize_request_body(
-                session, resolver, request, controller, strict, created
+                session,
+                resolver,
+                request,
+                controller,
+                strict,
+                created,
+                applied_defaults=applied_defaults,
             )
         )
 
@@ -596,6 +606,17 @@ def _scan_request_body(
         return (yield from inner)
 
 
+def _flatten_move_targets(
+    variables: dict[str, Any], targets: dict[str, float]
+) -> list[Any]:
+    """``{name: value}`` -> the flat ``(movable, value, ...)`` args ``bps.mv`` wants."""
+    args: list[Any] = []
+    for name, value in targets.items():
+        args.append(variables[name])
+        args.append(value)
+    return args
+
+
 def _optimize_request_body(
     session: Any,
     resolver: ConfigResolver,
@@ -603,6 +624,8 @@ def _optimize_request_body(
     controller: ShotController | None,
     strict: bool,
     created: list,
+    *,
+    applied_defaults: dict[str, Any] | None = None,
 ):
     """The optimize-mode body of :func:`_scan_request_body`.
 
@@ -612,23 +635,27 @@ def _optimize_request_body(
     device set (save-set devices plus the loader's ``device_requirements``),
     the claim boundary (the full :class:`ScanTag`, since the loader's
     analyzers may need it), then :func:`~geecs_bluesky.plans.optimize.geecs_adaptive_scan`
-    wrapped exactly as :meth:`GeecsSession.optimize` wraps it.
+    wrapped exactly as :meth:`GeecsSession.optimize` wraps it — including its
+    ``on_finish`` ladder: ``spec.move_to_best_on_finish`` maps onto
+    ``on_finish="best"`` (move to the best-observed inputs on success,
+    restore to initial values on abort/failure — never best on abort, same
+    as :meth:`GeecsSession.optimize`'s docstring contract) or
+    ``on_finish="hold"`` (leave the variables wherever the suggester last
+    set them, in every outcome) when unset. The schema exposes only the
+    boolean, not the three-way string, so ``on_finish="initial"`` alone has
+    no plan-side equivalent.
 
     Deliberately dropped relative to ``GeecsSession.optimize``: the
     ``should_abort``/``pause_supervisor`` GUI hooks (no plan-side
-    equivalent, same as the step/noscan body above) and the
-    ``on_finish='best'|'initial'`` variable-restore convenience — a plan
-    that raises or is stopped simply leaves the variables where the
-    suggester last set them (the scan-plan convention), never restores.
-    Both are acceptable gaps for a queueserver worker: restores are an
-    operator convenience, not a data-integrity concern.
+    equivalent, same as the step/noscan body above).
 
     Raises
     ------
     GeecsConfigurationError
         No optimization loader registered (see :func:`set_optimization_loader`),
-        an empty effective device set, or a strict request without usable
-        shot control — all pre-claim.
+        an empty effective device set (before *or* after the unserved-
+        variables pre-flight), or a strict request without usable shot
+        control — all pre-claim.
     """
     spec = request.optimization
     assert spec is not None  # guaranteed by ScanRequest validation
@@ -680,6 +707,17 @@ def _optimize_request_body(
         raise GeecsConfigurationError(
             "unserved-variables pre-flight aborted the optimization (pre-claim)"
         )
+    if not devices_config:
+        # The pre-flight check above can drop every device that WAS present
+        # (unlike the emptiness check above it, which only catches an empty
+        # save_sets/device_requirements union). An empty devices_config here
+        # would otherwise reach `reference = detectors[0]` after the claim
+        # boundary below (IndexError, burning a scan number for nothing).
+        raise GeecsConfigurationError(
+            "the unserved-variables pre-flight dropped every recording "
+            "device for this optimization (pre-claim) — the objective "
+            "would have nothing to read"
+        )
 
     # ---- phase 2: worker-side construction (connects deferred) -----------
     factories = _DeferredConnectFactories(session)
@@ -726,6 +764,8 @@ def _optimize_request_body(
         }
     if dropped_unserved_devices:
         md["dropped_unserved_devices"] = list(dropped_unserved_devices)
+    if applied_defaults:
+        md["applied_defaults"] = dict(applied_defaults)
     if skipped:
         md["skipped_action_plans"] = skipped
         logger.warning(
@@ -734,6 +774,19 @@ def _optimize_request_body(
             "save-set rituals do not run during optimization): %s",
             skipped,
         )
+    # Telemetry is not wired into optimize yet; db_scalars above applies
+    # regardless (mirrors _run_optimize_request's binder-path metadata).
+    md["db_scan_runtime"] = {
+        "db_scalars": "applied",
+        "background_telemetry": "not_run_in_optimize",
+    }
+
+    # Initial values, read before the claim (mirrors GeecsSession.optimize):
+    # the on_finish ladder below restores to these on abort/failure, and to
+    # them (as a fallback) or the best-observed inputs on success.
+    initial_values: dict[str, float] = {}
+    for name, movable in variables.items():
+        initial_values[name] = yield from bps.rd(movable)
 
     # ---- phase 4: the claim boundary --------------------------------------
     # The full ScanTag (not just the number): the loader's analyzers may
@@ -865,18 +918,61 @@ def _optimize_request_body(
         finally:
             yield from bps.unsubscribe(token)
         _observe_previous(len(history) + 1)  # final bin
-    except BaseException:
-        if scan_number is not None:
-            log_claimed_scan_failure(
-                scan_number, scan_folder, label="Optimization scan"
-            )
-        raise
-    finally:
+
+        if spec.move_to_best_on_finish:
+            finite = [h for h in history if math.isfinite(h["objective"])]
+            if finite:
+                target = max(finite, key=lambda h: h["objective"])["inputs"]
+            else:
+                logger.warning(
+                    "move_to_best_on_finish is set but no finite objectives "
+                    "were observed; restoring initial values instead"
+                )
+                target = initial_values
+            yield from bps.mv(*_flatten_move_targets(variables, target))
+            logger.info("optimize move_to_best_on_finish -> %s", target)
+
+        if scan_folder is not None and history:
+            # Same shape/guard as GeecsSession.optimize's optimization.json
+            # (failed objectives are NaN in-process; allow_nan=False makes
+            # any regression fail loudly instead of writing invalid JSON).
+            try:
+                path = Path(scan_folder) / "optimization.json"
+                path.write_text(
+                    json.dumps(_json_safe(history), indent=2, allow_nan=False)
+                )
+                logger.info("Optimization history written to %s", path)
+            except Exception:
+                logger.warning("Could not write optimization history", exc_info=True)
+
+        # Success-only bookkeeping (mirrors BlueskyScanner's delegated-path
+        # call site: skipped on failure — the except clause below re-raises
+        # before reaching here — and, on this path, on abort too, since an
+        # operator abort surfaces as an exception through the generator
+        # chain rather than the settled-and-quiet outcome GeecsSession.RE
+        # gets from _run_supervised).
         finish = getattr(opt_bridge, "finish", None)
         if finish is not None:
             try:
                 finish()
             except Exception:
                 logger.warning("optimization bridge finish() failed", exc_info=True)
+    except BaseException:
+        if scan_number is not None:
+            log_claimed_scan_failure(
+                scan_number, scan_folder, label="Optimization scan"
+            )
+        if spec.move_to_best_on_finish:
+            # Abort restores *initial*, never best — same contract as
+            # GeecsSession.optimize (docstring above). Best-effort: a
+            # restore failure must not mask the original exception.
+            try:
+                yield from bps.mv(*_flatten_move_targets(variables, initial_values))
+            except Exception:
+                logger.warning(
+                    "could not restore initial values after an optimize failure/abort",
+                    exc_info=True,
+                )
+        raise
 
     return uid

--- a/GeecsBluesky/poetry.lock
+++ b/GeecsBluesky/poetry.lock
@@ -18,6 +18,19 @@ epicscorelibs = ">=7.0.3.99.4.0"
 numpy = "*"
 
 [[package]]
+name = "alabaster"
+version = "1.0.0"
+description = "A light, configurable Sphinx theme"
+optional = true
+python-versions = ">=3.10"
+groups = ["main"]
+markers = "extra == \"qserver\""
+files = [
+    {file = "alabaster-1.0.0-py3-none-any.whl", hash = "sha256:fc6786402dc3fcb2de3cabd5fe455a2db534b371124f1f21de8731783dec828b"},
+    {file = "alabaster-1.0.0.tar.gz", hash = "sha256:c00dca57bca26fa62a6d7d0a9fcce65f3e026e9bfe33e9c538fd3fbb2144fd9e"},
+]
+
+[[package]]
 name = "annotated-doc"
 version = "0.0.4"
 description = "Document parameters, class attributes, return types, and variables inline, with Annotated."
@@ -63,13 +76,26 @@ typing_extensions = {version = ">=4.5", markers = "python_version < \"3.13\""}
 trio = ["trio (>=0.32.0)"]
 
 [[package]]
+name = "appnope"
+version = "1.0.0"
+description = "Disable App Nap on macOS >= 10.9"
+optional = true
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "extra == \"qserver\" and platform_system == \"Darwin\""
+files = [
+    {file = "appnope-1.0.0-py3-none-any.whl", hash = "sha256:6fe0c04218aab65c54c4ff81638cdbf848d89f5653b74d68638a137f200dd16e"},
+    {file = "appnope-1.0.0.tar.gz", hash = "sha256:685db59cb6043c3c2e528adc0b3bce3a5f8d09bcf7492c6ea650d1b7421f3c49"},
+]
+
+[[package]]
 name = "asttokens"
 version = "3.0.1"
 description = "Annotate AST trees with source code positions"
 optional = true
 python-versions = ">=3.8"
 groups = ["main"]
-markers = "extra == \"optimize\""
+markers = "extra == \"optimize\" or extra == \"qserver\""
 files = [
     {file = "asttokens-3.0.1-py3-none-any.whl", hash = "sha256:15a3ebc0f43c2d0a50eeafea25e19046c68398e487b9f1f5b517f7c0f40f976a"},
     {file = "asttokens-3.0.1.tar.gz", hash = "sha256:71a4ee5de0bde6a31d64f6b13f2293ac190344478f081c3d1bccfcf5eacb0cb7"},
@@ -78,6 +104,19 @@ files = [
 [package.extras]
 astroid = ["astroid (>=2,<5)"]
 test = ["astroid (>=2,<5)", "pytest (<9.0)", "pytest-cov", "pytest-xdist"]
+
+[[package]]
+name = "async-timeout"
+version = "5.0.1"
+description = "Timeout context manager for asyncio programs"
+optional = true
+python-versions = ">=3.8"
+groups = ["main"]
+markers = "extra == \"qserver\" and python_full_version < \"3.11.3\""
+files = [
+    {file = "async_timeout-5.0.1-py3-none-any.whl", hash = "sha256:39e3809566ff85354557ec2398b55e096c8364bacac9405a7a1fa429e77fe76c"},
+    {file = "async_timeout-5.0.1.tar.gz", hash = "sha256:d9321a7a3d5a6a5e187e824d2fa0793ce379a202935782d555d6e9d2735677d3"},
+]
 
 [[package]]
 name = "attrs"
@@ -175,6 +214,22 @@ files = [
 numpy = ">=1.21.3"
 
 [[package]]
+name = "babel"
+version = "2.18.0"
+description = "Internationalization utilities"
+optional = true
+python-versions = ">=3.8"
+groups = ["main"]
+markers = "extra == \"qserver\""
+files = [
+    {file = "babel-2.18.0-py3-none-any.whl", hash = "sha256:e2b422b277c2b9a9630c1d7903c2a00d0830c409c59ac8cae9081c92f1aeba35"},
+    {file = "babel-2.18.0.tar.gz", hash = "sha256:b80b99a14bd085fcacfa15c9165f651fbb3406e66cc603abf11c5750937c992d"},
+]
+
+[package.extras]
+dev = ["backports.zoneinfo ; python_version < \"3.9\"", "freezegun (>=1.0,<2.0)", "jinja2 (>=3.0)", "pytest (>=6.0)", "pytest-cov", "pytz", "setuptools", "tzdata ; sys_platform == \"win32\""]
+
+[[package]]
 name = "blosc2"
 version = "4.2.0"
 description = "A fast & compressed ndarray library with a flexible compute engine."
@@ -264,6 +319,39 @@ plotting = ["matplotlib"]
 streamz = ["streamz"]
 tools = ["doct", "historydict", "lmfit", "tifffile"]
 zmq = ["pyzmq"]
+
+[[package]]
+name = "bluesky-queueserver"
+version = "0.0.25"
+description = "Server for queueing and executing Bluesky plans."
+optional = true
+python-versions = ">=3.10"
+groups = ["main"]
+markers = "extra == \"qserver\""
+files = [
+    {file = "bluesky_queueserver-0.0.25-py3-none-any.whl", hash = "sha256:489a0304343c52942cdef52357895c1dc0c38b18931c3c9e924e5762ff0eea05"},
+    {file = "bluesky_queueserver-0.0.25.tar.gz", hash = "sha256:3d597c5c00a0b016d77991a841b916aaa880d6623318e9105b72b95a6cd0fdb1"},
+]
+
+[package.dependencies]
+bluesky = ">=1.7.0"
+ipykernel = "*"
+jsonschema = "*"
+jupyter-client = ">=7.4.2"
+jupyter-console = "*"
+numpydoc = "*"
+openpyxl = "*"
+ophyd = "*"
+packaging = "*"
+pydantic = "*"
+python-multipart = "*"
+pyyaml = "*"
+pyzmq = "*"
+redis = {version = "*", extras = ["hiredis"]}
+requests = "*"
+
+[package.extras]
+dev = ["aioca", "build", "coverage", "h5py", "happi (>=1.14.0)", "intake", "ipython", "matplotlib", "numpy", "numpydoc", "ophyd-async", "pandas", "pre-commit", "py", "pyarrow", "pytest", "pytest-split", "pytest-xprocess", "ruff", "scikit-image", "sphinx", "sphinx_rtd_theme", "twine"]
 
 [[package]]
 name = "boto3"
@@ -357,7 +445,7 @@ description = "Foreign Function Interface for Python calling C code."
 optional = true
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "extra == \"optimize\""
+markers = "extra == \"qserver\" and implementation_name == \"pypy\" or extra == \"optimize\""
 files = [
     {file = "cffi-2.0.0-cp310-cp310-macosx_10_13_x86_64.whl", hash = "sha256:0cf2d91ecc3fcc0625c2c530fe004f82c110405f101548512cce44322fa8ac44"},
     {file = "cffi-2.0.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:f73b96c41e3b2adedc34a7356e64c8eb96e03a3782b535e043a986276ce12a49"},
@@ -653,7 +741,7 @@ description = "Jupyter Python Comm implementation, for usage in ipykernel, xeus-
 optional = true
 python-versions = ">=3.8"
 groups = ["main"]
-markers = "extra == \"optimize\""
+markers = "extra == \"optimize\" or extra == \"qserver\""
 files = [
     {file = "comm-0.2.3-py3-none-any.whl", hash = "sha256:c615d91d75f7f04f095b30d1c1711babd43bdc6419c1be9886a85f2f4e489417"},
     {file = "comm-0.2.3.tar.gz", hash = "sha256:2dc8048c10962d55d7ad693be1e7045d891b7ce8d999c97963a5e3e99c055971"},
@@ -961,16 +1049,70 @@ moocore = "*"
 numpy = "*"
 
 [[package]]
+name = "debugpy"
+version = "1.8.21"
+description = "An implementation of the Debug Adapter Protocol for Python"
+optional = true
+python-versions = ">=3.8"
+groups = ["main"]
+markers = "extra == \"qserver\""
+files = [
+    {file = "debugpy-1.8.21-cp310-cp310-macosx_15_0_x86_64.whl", hash = "sha256:8eeab7b5462f683452c57c0126aaa5ec4e974ddb705f39ba87dff8818c8e08f9"},
+    {file = "debugpy-1.8.21-cp310-cp310-manylinux_2_34_x86_64.whl", hash = "sha256:0fddfdc130ac6d8bfc0415b0409822fa901c8f310e5c945ac5653a0352532344"},
+    {file = "debugpy-1.8.21-cp310-cp310-win32.whl", hash = "sha256:72b5d676c4cbfac3bac5bb01c138a4656e843f93f03ce2a5f4e394ad49fbee73"},
+    {file = "debugpy-1.8.21-cp310-cp310-win_amd64.whl", hash = "sha256:a7fe47fd23da57b9e0bec3f4a8ee65a2dc55782455ed7f2141d75ab5d2eaeef5"},
+    {file = "debugpy-1.8.21-cp311-cp311-macosx_15_0_universal2.whl", hash = "sha256:da456226c7b4c69e35dbe35dcee6623d912000a77816db7856a41af1c72a0264"},
+    {file = "debugpy-1.8.21-cp311-cp311-manylinux_2_34_x86_64.whl", hash = "sha256:f68b891688e61bdc08b8d364d919ff0051e0b94657b39dcd027bc3173edb7cdc"},
+    {file = "debugpy-1.8.21-cp311-cp311-win32.whl", hash = "sha256:f843a8b08c2edeaf9b1582eed4f25441af21a297c22ff16bf76a662557aa9c9e"},
+    {file = "debugpy-1.8.21-cp311-cp311-win_amd64.whl", hash = "sha256:84c564d8cc701d41843b29a92814c1f1bef6798724ca9d675c284ad9f6a547d7"},
+    {file = "debugpy-1.8.21-cp312-cp312-macosx_15_0_universal2.whl", hash = "sha256:9f96713896f39c3dff0ee841f47320c3f2983d33c341e009361bb0ebc79adc4e"},
+    {file = "debugpy-1.8.21-cp312-cp312-manylinux_2_34_x86_64.whl", hash = "sha256:c193d474f0a211191f2b4449d2d06157c689013035bd952f3b617e0ef422b176"},
+    {file = "debugpy-1.8.21-cp312-cp312-win32.whl", hash = "sha256:4743373c1cac7f9e74a1b9915bf1dbe0e900eca657ffb170ae07ac8363205ae9"},
+    {file = "debugpy-1.8.21-cp312-cp312-win_amd64.whl", hash = "sha256:bd7ba9dd3daa7c2f942c6ca8d4695a16bf9ac16b63615261c7982bc74f7ed20c"},
+    {file = "debugpy-1.8.21-cp313-cp313-macosx_15_0_universal2.whl", hash = "sha256:13678151fc401e2d68c9880b91e28714f797d40422994572b24560ef80910a88"},
+    {file = "debugpy-1.8.21-cp313-cp313-manylinux_2_34_x86_64.whl", hash = "sha256:ecbd158386c31ffe71d46f72d44d56e66331ab9b16cad649156d514368f23ab2"},
+    {file = "debugpy-1.8.21-cp313-cp313-win32.whl", hash = "sha256:2c2ae706dec41d99a9ca1f7ebc987a83e65578363be6f6b3ac9067504917fae1"},
+    {file = "debugpy-1.8.21-cp313-cp313-win_amd64.whl", hash = "sha256:aa648733047443eb1d07682c4ef287d36a54507b643ffdf38b09a3ef002c72a0"},
+    {file = "debugpy-1.8.21-cp314-cp314-macosx_15_0_universal2.whl", hash = "sha256:9bb2a685287a2ac9b181cde89edcec64845cb51de7faaa75badb9a698bc24782"},
+    {file = "debugpy-1.8.21-cp314-cp314-manylinux_2_34_x86_64.whl", hash = "sha256:3d6922439bf33fd38a3e2c447869ebc7b97da5cd3d329ff1ef9bc06c4903437e"},
+    {file = "debugpy-1.8.21-cp314-cp314-win32.whl", hash = "sha256:15d4963bd5ffa48f0da0947fd06757fa7621945048a14ad7705431566d3c0e7c"},
+    {file = "debugpy-1.8.21-cp314-cp314-win_amd64.whl", hash = "sha256:fe0744a12353406de0ae8ccff0d0a4a666f00801a3db8fd04e7a5f761cd520e8"},
+    {file = "debugpy-1.8.21-cp38-cp38-macosx_15_0_x86_64.whl", hash = "sha256:0042da0ecd0a8b50dc4a54395ecd870d258d73fa18776f50c91fdcabdcad2675"},
+    {file = "debugpy-1.8.21-cp38-cp38-manylinux_2_34_x86_64.whl", hash = "sha256:ffd932c6796afadab6993ec96745918a8cb2444dbd392074f769db5ea40ab440"},
+    {file = "debugpy-1.8.21-cp38-cp38-win32.whl", hash = "sha256:4e7c2d784d78ad4b71a5f8cd7b59c167719ec8a7a0211dbb3eb1bfeda78bc4e2"},
+    {file = "debugpy-1.8.21-cp38-cp38-win_amd64.whl", hash = "sha256:aa9d941d6dfe3d0407e4b3ca0b9ec466030e260fbf1174094f68785680f66db6"},
+    {file = "debugpy-1.8.21-cp39-cp39-macosx_15_0_x86_64.whl", hash = "sha256:9f5171176a0084b95d2ebe55a4d1f7b2a75b74c5dbec577ebd3a85c740551c36"},
+    {file = "debugpy-1.8.21-cp39-cp39-manylinux_2_34_x86_64.whl", hash = "sha256:f15c10084f9861b5e8414a48f18f8e4aadf51a98a59e72c16aa28281ca994672"},
+    {file = "debugpy-1.8.21-cp39-cp39-win32.whl", hash = "sha256:4e70cc8b5079f885cb43910924ee0aab73b8b6b2a14eff23afdd9895d86e79eb"},
+    {file = "debugpy-1.8.21-cp39-cp39-win_amd64.whl", hash = "sha256:e935f9dc0501be523c8a8e1853c39432e1354e9ece717ae5998fd2371c4542c3"},
+    {file = "debugpy-1.8.21-py2.py3-none-any.whl", hash = "sha256:b1e37d333663c8851516a47364ef473da127f9caebe4417e6df6f5825a7e9a92"},
+    {file = "debugpy-1.8.21.tar.gz", hash = "sha256:a3c53278e84c94e11bd87c53970ec391d1a67396c8b22609fcac576520e611a6"},
+]
+
+[[package]]
 name = "decorator"
 version = "5.3.1"
 description = "Decorators for Humans"
 optional = true
 python-versions = ">=3.8"
 groups = ["main"]
-markers = "extra == \"optimize\""
+markers = "extra == \"optimize\" or extra == \"qserver\""
 files = [
     {file = "decorator-5.3.1-py3-none-any.whl", hash = "sha256:f47fe6fdbd2edd623ecfe36875d37aba411624e2670dd395dddae1358689bb3c"},
     {file = "decorator-5.3.1.tar.gz", hash = "sha256:4cbcdd55a6efadb9dbea26b858f4fb3264567b52d69ca0d25b721b553f60ea82"},
+]
+
+[[package]]
+name = "docutils"
+version = "0.22.4"
+description = "Docutils -- Python Documentation Utilities"
+optional = true
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "extra == \"qserver\""
+files = [
+    {file = "docutils-0.22.4-py3-none-any.whl", hash = "sha256:d0013f540772d1420576855455d050a2180186c91c15779301ac2ccb3eeb68de"},
+    {file = "docutils-0.22.4.tar.gz", hash = "sha256:4db53b1fde9abecbb74d91230d32ab626d94f6badfc575d6db9194a49df29968"},
 ]
 
 [[package]]
@@ -1075,6 +1217,19 @@ setuptools = "*"
 setuptools-dso = ">=2.11a2"
 
 [[package]]
+name = "et-xmlfile"
+version = "2.0.0"
+description = "An implementation of lxml.xmlfile for the standard library"
+optional = true
+python-versions = ">=3.8"
+groups = ["main"]
+markers = "extra == \"qserver\""
+files = [
+    {file = "et_xmlfile-2.0.0-py3-none-any.whl", hash = "sha256:7a91720bc756843502c3b7504c77b8fe44217c85c537d85037f0f536151b2caa"},
+    {file = "et_xmlfile-2.0.0.tar.gz", hash = "sha256:dab3f4764309081ce75662649be815c4c9081e88f0837825f90fd28317d4da54"},
+]
+
+[[package]]
 name = "event-model"
 version = "1.23.1"
 description = "Data model used by the bluesky ecosystem."
@@ -1102,7 +1257,7 @@ description = "Get the currently executing AST node of a frame, and other inform
 optional = true
 python-versions = ">=3.8"
 groups = ["main"]
-markers = "extra == \"optimize\""
+markers = "extra == \"optimize\" or extra == \"qserver\""
 files = [
     {file = "executing-2.2.1-py2.py3-none-any.whl", hash = "sha256:760643d3452b4d777d295bb167ccc74c64a81df23fb5e08eff250c425a4b2017"},
     {file = "executing-2.2.1.tar.gz", hash = "sha256:3632cc370565f6648cc328b32435bd120a1e4ebb20c77e3fdde9a13cd1e533c4"},
@@ -1131,7 +1286,7 @@ description = "Saves and loads to the cache a transformed versions of a source o
 optional = true
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "extra == \"analysis\" or extra == \"optimize\""
+markers = "extra == \"analysis\" or extra == \"optimize\" or extra == \"qserver\""
 files = [
     {file = "flexcache-0.3-py3-none-any.whl", hash = "sha256:d43c9fea82336af6e0115e308d9d33a185390b8346a017564611f1466dcd2e32"},
     {file = "flexcache-0.3.tar.gz", hash = "sha256:18743bd5a0621bfe2cf8d519e4c3bfdf57a269c15d1ced3fb4b64e0ff4600656"},
@@ -1150,7 +1305,7 @@ description = "Parsing made fun ... using typing."
 optional = true
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "extra == \"analysis\" or extra == \"optimize\""
+markers = "extra == \"analysis\" or extra == \"optimize\" or extra == \"qserver\""
 files = [
     {file = "flexparser-0.4-py3-none-any.whl", hash = "sha256:3738b456192dcb3e15620f324c447721023c0293f6af9955b481e91d00179846"},
     {file = "flexparser-0.4.tar.gz", hash = "sha256:266d98905595be2ccc5da964fe0a2c3526fbbffdc45b65b3146d75db992ef6b2"},
@@ -1279,8 +1434,8 @@ tqdm = ["tqdm"]
 
 [[package]]
 name = "geecs-core"
-version = "0.1.0"
-description = "The GEECS access library: UDP/TCP wire protocol, experiment database, PV naming contract, and the entry-level GeecsDevice client"
+version = "0.2.0"
+description = "The GEECS access library: UDP/TCP wire protocol, experiment database, PV naming contract, exceptions, the wire-protocol test double, and the entry-level GeecsDevice client"
 optional = false
 python-versions = ">=3.11,<3.12"
 groups = ["main"]
@@ -1591,6 +1746,129 @@ files = [
 numpy = ">=1.21.2"
 
 [[package]]
+name = "hiredis"
+version = "3.4.1"
+description = "Python wrapper for hiredis"
+optional = true
+python-versions = ">=3.8"
+groups = ["main"]
+markers = "extra == \"qserver\""
+files = [
+    {file = "hiredis-3.4.1-cp310-cp310-macosx_10_15_universal2.whl", hash = "sha256:82358041521c4da1a635b5d4819c7d22cfdfa44d73a61e4fa6696057b7c9f0b9"},
+    {file = "hiredis-3.4.1-cp310-cp310-macosx_10_15_x86_64.whl", hash = "sha256:66958d145d6560f116542539acc625744c5e61a19ae33c840fb3d46c6b1e1c2a"},
+    {file = "hiredis-3.4.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:60f648860614725242df1322ce9937cb58101b95efeff558a658963ca4e40125"},
+    {file = "hiredis-3.4.1-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:40032f28be64352e6d5024bfd707f3f8d2ce1369064b1f730ce248b23f8ed8c7"},
+    {file = "hiredis-3.4.1-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:f8f5299a5c22724d440fe762acbaf21f8e825acf87793c543c26692ac110341e"},
+    {file = "hiredis-3.4.1-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:c51d8c57a11fba6175419272b542428d9186f86285e4f634d180b47908f9478f"},
+    {file = "hiredis-3.4.1-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:41fd6a4780c874726900891717a16032c0cc78ba5fabc8412ccf2f4fa9d831e8"},
+    {file = "hiredis-3.4.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:aa51ccf31c7bfcc808ed7371fb90bb1e19eea1b4c842a6f8132546f2b7d2e205"},
+    {file = "hiredis-3.4.1-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:392533ad3f209ad0cbfb84fa753081daa6416f45030ef3a379734311295c89a0"},
+    {file = "hiredis-3.4.1-cp310-cp310-musllinux_1_2_s390x.whl", hash = "sha256:9a034785409ac0a74d16c9bd05ac803a53261e0b0f4ec249ba3bb2bc159fd700"},
+    {file = "hiredis-3.4.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:c944aea7b4dc44294f90ecfd8c2b320f13e608a043dd4f654bdc728ffa256197"},
+    {file = "hiredis-3.4.1-cp310-cp310-win32.whl", hash = "sha256:3cd9a9de43b191739b46df22c01016c842f129e149cdeb0a7f6862bfbf6f0a19"},
+    {file = "hiredis-3.4.1-cp310-cp310-win_amd64.whl", hash = "sha256:9f77015efbdceb83b1c8751d967e31fd08114af5bc0b523e3562149894bf3ad4"},
+    {file = "hiredis-3.4.1-cp310-cp310-win_arm64.whl", hash = "sha256:ffa742a05493eefa1c8d37ea8296b35cc4c26a6f589540fad71c6f58322bc960"},
+    {file = "hiredis-3.4.1-cp311-cp311-macosx_10_15_universal2.whl", hash = "sha256:8f2ccefce627b6caee2e9605ef6eeb7cba50eaed49331789301a678c3c661703"},
+    {file = "hiredis-3.4.1-cp311-cp311-macosx_10_15_x86_64.whl", hash = "sha256:8852e54d87cd2e6481c0d0a843d01b0bc46a0300e13afc312228ee4eb4cc470f"},
+    {file = "hiredis-3.4.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:67326dd115b5e0bfea5a448f2102357b9957ea0a6d1f15e41916588845b57a2c"},
+    {file = "hiredis-3.4.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:dd98896fb410dfc5c47362e5f4af04cd7e179472a57052531b44b043adf360af"},
+    {file = "hiredis-3.4.1-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:8dabc962e38f7cb2e5ed934edaa57777d00d05e432a0ae9a3f22b6d64680fdc7"},
+    {file = "hiredis-3.4.1-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:2bd12118559e36bd38081c128b4c98f1e96d0a04890770d2750604cdd6a3ca83"},
+    {file = "hiredis-3.4.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:606abfff97de808f1bfd7ca2960e4a92176133229490cd33260d6a179dc62b04"},
+    {file = "hiredis-3.4.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:e2dd565a51444d4016217c9be9f389a30d641955ae8227eab0c3224497936690"},
+    {file = "hiredis-3.4.1-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:4148ca8973da6dff84628209ebc40722e56463425c9ec3fd18508de0a163f3bb"},
+    {file = "hiredis-3.4.1-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:e021c48a2f6ff58f04f3344d3dfb6511cfcb120823d6a632af3af608da907cff"},
+    {file = "hiredis-3.4.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:be2cb4733754cda4fa07b8a5ee7f792f341fa830fe28f62be8c6342ffade98d0"},
+    {file = "hiredis-3.4.1-cp311-cp311-win32.whl", hash = "sha256:0dd0dda7c9f0e909e1c87a73ec3461ec3bc746962dcdfc3a7cf34d6d1bc57873"},
+    {file = "hiredis-3.4.1-cp311-cp311-win_amd64.whl", hash = "sha256:cc40bae8bca39768eba82820248fcc18ae4d9bf66d8e9c7b51cca40c272863b7"},
+    {file = "hiredis-3.4.1-cp311-cp311-win_arm64.whl", hash = "sha256:48facb01c32fe6234c95f1e5f9d0a730c8e0a184f86962b46369818cf28ba209"},
+    {file = "hiredis-3.4.1-cp312-cp312-macosx_10_15_universal2.whl", hash = "sha256:fd5f86d937ecb5aa1dfed21d774f5ae8f8379eed607b1d9ab0ab6e80c4717981"},
+    {file = "hiredis-3.4.1-cp312-cp312-macosx_10_15_x86_64.whl", hash = "sha256:7630086181d75cd4e377fbbb00ed903619121bcf30b7ae84250366b2717ddebf"},
+    {file = "hiredis-3.4.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:c8efc144cc467c62c14cd49d276f1aaec5232ba46300164d59a5fdb68ba77fff"},
+    {file = "hiredis-3.4.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:66953abbda35703727a596bd3a83e86acc4da781e258780c3d85dd6acc1f39f9"},
+    {file = "hiredis-3.4.1-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:7b083a1deee1124a7c47baf1d3db85251f4ecd9812a974f586d59ef7d28f6007"},
+    {file = "hiredis-3.4.1-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5c3e191e6514c54f68a0b3d2b18aa6e73885393be16a31ae74b15c12b544cbaa"},
+    {file = "hiredis-3.4.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7a2cd31cba425ae954abeafa5dd74552e5ffa61661d3c8098cc66787330c1779"},
+    {file = "hiredis-3.4.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:742b4f7ce4b28820ef3fd45c7866f09e07dbf1904895eecd56b482eaa7bd26f5"},
+    {file = "hiredis-3.4.1-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:90de946ceac709797efcf3278e3f004f2a60ebd6bb5761bc35d7212d56fc1e5a"},
+    {file = "hiredis-3.4.1-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:404ce858750c6e31d420818d79bceda89869f521c990b01e7ce8fcc95916eb8b"},
+    {file = "hiredis-3.4.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:9f2656e2c11339e7e93df3c0d73c442129fb1381fb709706848f1b49e85677d1"},
+    {file = "hiredis-3.4.1-cp312-cp312-win32.whl", hash = "sha256:e333eb85c9ab16538d43b2e4e1fa564244d3f0c4a8a84e7c640812419b597180"},
+    {file = "hiredis-3.4.1-cp312-cp312-win_amd64.whl", hash = "sha256:b0d11936e377f305024953ae25ba52ae48edc26fe49f47af1e934f642deb3ed6"},
+    {file = "hiredis-3.4.1-cp312-cp312-win_arm64.whl", hash = "sha256:50d821b6195c9a4ba5cda44d950ba6205fdac5a7cf03e1ac4cdf0294f2df886c"},
+    {file = "hiredis-3.4.1-cp313-cp313-macosx_10_15_universal2.whl", hash = "sha256:7c3632721df2a3addca9a9707f7baa062bb0c004a585873f461b3b7a629c2516"},
+    {file = "hiredis-3.4.1-cp313-cp313-macosx_10_15_x86_64.whl", hash = "sha256:2b5b4cc3e1806f44f022389ade780aa1054336357defcb87613fe5267470e6f4"},
+    {file = "hiredis-3.4.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:d856ba70bd97db7cc136ca1dfa72b98044647d08913335949aa70477c8ebfe9a"},
+    {file = "hiredis-3.4.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:026639fa97c4b4fcc0f502454287ef1254cc1d067b610cbb958c392c46ff54ae"},
+    {file = "hiredis-3.4.1-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:d94c41779ae3eaee75c1668f23d26d9eda526055e37cd9052e980c64fb4127cc"},
+    {file = "hiredis-3.4.1-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:464f27b0521375a8179e24f19889d7953a88d22ec00808714a0c78ac8ebffbe7"},
+    {file = "hiredis-3.4.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:54d077e062804fa1eb49d25032bc0cadb085c50a5adc6f6fc43262dde6428471"},
+    {file = "hiredis-3.4.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:9186f49f2f45220d1dde7981f7766b7195497d6f3b85617dc0bc519f1e456482"},
+    {file = "hiredis-3.4.1-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:28c6f40eab7dd56dc63ff0e100e9d5d2759b191615d3134abcb48de5ff1f037a"},
+    {file = "hiredis-3.4.1-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:1e52aee6e7c9f97ae6df104388292568ce34ad5f1aae8acc843f4686b4745362"},
+    {file = "hiredis-3.4.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:e238e434d22c767b638d591f32532b7b34077267055481fce10bab1a4fa82d39"},
+    {file = "hiredis-3.4.1-cp313-cp313-win32.whl", hash = "sha256:0ebfbff143596d0b8957e67972ab14591b7427891e2d22b5939ddb1185fe14d2"},
+    {file = "hiredis-3.4.1-cp313-cp313-win_amd64.whl", hash = "sha256:ba678bbf5bd590e5c5b23560e5dcc73b9bbc4ccb4639d1eda1dba669bd8c6cb7"},
+    {file = "hiredis-3.4.1-cp313-cp313-win_arm64.whl", hash = "sha256:b6bef7f8753b0ab1e2a29781b589e4a64645bbe2753581cd57f32659756ccae2"},
+    {file = "hiredis-3.4.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:c54721b67df1cbdd0f78e0421b0b9768818109fcadbfa6b4a8d761c2506dd846"},
+    {file = "hiredis-3.4.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:718b86c425c8e2b3505d428ca632f9c9f5ea1c1582edcb76a77aa9c0d0a82580"},
+    {file = "hiredis-3.4.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:d151dd3d715cb62dcc09132e4a8f16c9ec0b0874ab9c6fca3b2cbdc09d52660f"},
+    {file = "hiredis-3.4.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5b59b49cbe1ee36e88a629a6653258cca4a89c3711b5836efde0ef1e011f0ab2"},
+    {file = "hiredis-3.4.1-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:279258dfc81ee6e2235f45e2fc9af00177bdaea5c72eaca6f6bbed56812c1018"},
+    {file = "hiredis-3.4.1-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:98788950e4a973b925a1b5cfe6d74736726732d8785437fcc4b80bbc563d2a47"},
+    {file = "hiredis-3.4.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b980b63a189ed8e2a42274f260430dae2f33a4a61e2f18ce31248909e36bd14a"},
+    {file = "hiredis-3.4.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:4e1e92095b511e2a778302b9acd160eceb1f20d49a1c9716a864358fc4ffc236"},
+    {file = "hiredis-3.4.1-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:7eb8b46d2f453030a3514d8ba76edeb92b920b627f883ec3685873c018a96494"},
+    {file = "hiredis-3.4.1-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:6fd1472d5e5d82929411ea08d002eb4a8e200558d05b66458b9fcd058214aa33"},
+    {file = "hiredis-3.4.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:7b72464f56c3f40f1ae1c784933686c3f0135d15e84fa7eb90166df18577b645"},
+    {file = "hiredis-3.4.1-cp314-cp314-win32.whl", hash = "sha256:a5e68f33bfdd542f659066ae7fb4ad37d4634d67fd330903feb0088f01808298"},
+    {file = "hiredis-3.4.1-cp314-cp314-win_amd64.whl", hash = "sha256:7cf4cf0735806049d2ada98ef0ac605e70b6bd303277857f459a8183b38b88c0"},
+    {file = "hiredis-3.4.1-cp314-cp314-win_arm64.whl", hash = "sha256:16fb7453720d846168281619021cd3562e4d6252b39ee0dd29610ab26847a0ee"},
+    {file = "hiredis-3.4.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:fd69048bb3870b962a2e09aff2ebfd0a3a4ee868bd280404c553235c36d43f7f"},
+    {file = "hiredis-3.4.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:bfd850dbf9c221d4a9e3eae819a91ecc8cdf9843a9ccdbc49cc94fe3f49dec59"},
+    {file = "hiredis-3.4.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:0a70be2b3a2280d48a0c46823455d83a863b8285563177a76667fcd62c686b5c"},
+    {file = "hiredis-3.4.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c4eba0bacd389e350470a883aad5f6733c721c65d408b32ba50b6624025660c4"},
+    {file = "hiredis-3.4.1-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c874e1f25fff64a0cd0ac990813950d59c9586094df0ce95cfc0372a6bc750ab"},
+    {file = "hiredis-3.4.1-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:1bca03bec5515ab7367fb84d5bdc3cd7bae901320eda89e059f1639e3f9e0793"},
+    {file = "hiredis-3.4.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:885220a6a495365961b8124865ccd5ea5ff7d39772fc79265d947befe418cc1b"},
+    {file = "hiredis-3.4.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:bfb1f5806a54f643b13065c2c5d05be993401421b8fef309d36f511ed3d13e06"},
+    {file = "hiredis-3.4.1-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:da1c8485246d0ec238d76c6689440c0e1bc28409a46592cda89f2ef1c008f26d"},
+    {file = "hiredis-3.4.1-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:00073e9b794229daca1089af62e6d2af8ec0a0f5540ced414eede10de2f43dae"},
+    {file = "hiredis-3.4.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:23667bce8ea8e5c300d4b13e369ef3f8d836b07cfea0dba46b839f1f1bd52548"},
+    {file = "hiredis-3.4.1-cp314-cp314t-win32.whl", hash = "sha256:e5377c51a30a09f0e302221dfe93e6f137b0a95f0d45c7756d995408a842627a"},
+    {file = "hiredis-3.4.1-cp314-cp314t-win_amd64.whl", hash = "sha256:5ba1921fc110294a80e28e2cc145edf69f038c263deb22543e787b07394ef5d2"},
+    {file = "hiredis-3.4.1-cp314-cp314t-win_arm64.whl", hash = "sha256:fd46a3fdec76283264e5a564fe38ba813e962bd3af1860970585c242eace683d"},
+    {file = "hiredis-3.4.1-cp38-cp38-macosx_10_15_universal2.whl", hash = "sha256:e63ccac57eb71e457b90b63b0905535cc3e058797ec1fbbc1e6d56de5052d3a1"},
+    {file = "hiredis-3.4.1-cp38-cp38-macosx_10_15_x86_64.whl", hash = "sha256:33e48e61f93279382740e67eac9fe57c2207272f00bde7325d455078518e9d5c"},
+    {file = "hiredis-3.4.1-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:be3be6c9fa4cc756c27ae9744b821473fe76989fa8429f0af63e49ce8c32314e"},
+    {file = "hiredis-3.4.1-cp38-cp38-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1e14e068d911a45321fc4383d222fac8efefc3fabaea1ab61c9a23bb90ee3b0a"},
+    {file = "hiredis-3.4.1-cp38-cp38-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:50f789b574373915daffe1e8cf3536218b03e42823774f7f502dfbb3b909f1dc"},
+    {file = "hiredis-3.4.1-cp38-cp38-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:cfca3c3c4410a9c127bde2ac164a5ac7c6cbb4a0875c9455221b453c7748d18f"},
+    {file = "hiredis-3.4.1-cp38-cp38-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7f7ef731e65cb9d45b3c8f27d51d4b325a97a141d090936672fba5b49b5a43c3"},
+    {file = "hiredis-3.4.1-cp38-cp38-musllinux_1_2_aarch64.whl", hash = "sha256:d84092a3e25502d505aa445ce1978c18c65e2b369b3812fa85fccf04bf8e788e"},
+    {file = "hiredis-3.4.1-cp38-cp38-musllinux_1_2_ppc64le.whl", hash = "sha256:3465347ce84bed21381072f534329f535df7f7517bb194482aa8817d9c333aec"},
+    {file = "hiredis-3.4.1-cp38-cp38-musllinux_1_2_s390x.whl", hash = "sha256:24d1c839feac4d6bb64486096fbb5a72eb43b8b0d677996e3d6b21670fb2a7bb"},
+    {file = "hiredis-3.4.1-cp38-cp38-musllinux_1_2_x86_64.whl", hash = "sha256:6f2b0b3c2f2c584dd8790b8ebbf574fa94042302eefc1cc00fae6b2d62de5b7c"},
+    {file = "hiredis-3.4.1-cp38-cp38-win32.whl", hash = "sha256:09ec2a32cdbb91c04a471e7d79ff98ee06185ea1a6bada44a0da1baa201c74ba"},
+    {file = "hiredis-3.4.1-cp38-cp38-win_amd64.whl", hash = "sha256:556971339bcb3bd6acf21c93d28acd21600c5d792511531a602fbc7e0f361fe8"},
+    {file = "hiredis-3.4.1-cp39-cp39-macosx_10_15_universal2.whl", hash = "sha256:6598c6e9dd158f54ea43a3036b75fdc36427a9ba96bfa159b4169d1a5e0ea68b"},
+    {file = "hiredis-3.4.1-cp39-cp39-macosx_10_15_x86_64.whl", hash = "sha256:211c1a503fa100fa958f8463aea4e21778fb3d9b27423a918403cd68e76b3b19"},
+    {file = "hiredis-3.4.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:8e90f85e072197049e48a578f5d4a3a09b3d0e0e0605fa0b96204659c074e5eb"},
+    {file = "hiredis-3.4.1-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:75face2cbb978a1df104c88aacbf9ec56f6f00495d64f8de2f852148c9a23e49"},
+    {file = "hiredis-3.4.1-cp39-cp39-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:fb971a32a2623b087ea86368ed762c5b47545173206bc95a987d2499150a4ab7"},
+    {file = "hiredis-3.4.1-cp39-cp39-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:738b044df56eb8fe2283237ceeadd5ec425395b98cd067e9f233877f9e1cfe9b"},
+    {file = "hiredis-3.4.1-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:05c9a679f2e22d64d4d624f5fd93825061c23d88f4b9cf2ba70ff8fc34781e3a"},
+    {file = "hiredis-3.4.1-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:19e2a62fb6650f2a7631cbe0925e3455e24630dda210b4e773e075b59129bbf8"},
+    {file = "hiredis-3.4.1-cp39-cp39-musllinux_1_2_ppc64le.whl", hash = "sha256:b8e655e8f6883c901588f92d1b2aaa40ac438de70146dcddd8291858d17c9d2b"},
+    {file = "hiredis-3.4.1-cp39-cp39-musllinux_1_2_s390x.whl", hash = "sha256:966d9a4198bfe43fb200655a855ab8f1ad60b9649f16f4b68c297f8e56c3dc12"},
+    {file = "hiredis-3.4.1-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:8874cd9366f9f812c4966fa1185475adf0a53b5d795a81c499619427843e88e8"},
+    {file = "hiredis-3.4.1-cp39-cp39-win32.whl", hash = "sha256:c00e3ad8a4cccd3258f6fc3094177ffcd3a69f7d87a82d1e32fdf9c143d6e5c3"},
+    {file = "hiredis-3.4.1-cp39-cp39-win_amd64.whl", hash = "sha256:8753ae9912993c28081204999f8be18847d99c67268bee8ec52bda55639b3319"},
+    {file = "hiredis-3.4.1-cp39-cp39-win_arm64.whl", hash = "sha256:fffa6cb2d713bd2ec45a1b68aa2ba37d01aefecf127acd323fbd5df564dab274"},
+    {file = "hiredis-3.4.1.tar.gz", hash = "sha256:2bbb55435506e481d270df8d0b29dd94acb85d11d71df4b8efce23849a4d0bb7"},
+]
+
+[[package]]
 name = "historydict"
 version = "1.2.6"
 description = "A persistent dictionary with history backed by sqlite"
@@ -1748,6 +2026,19 @@ test = ["fsspec[github]", "pytest", "pytest-cov"]
 tifffile = ["tifffile"]
 
 [[package]]
+name = "imagesize"
+version = "2.0.0"
+description = "Get image size from headers (BMP/PNG/JPEG/JPEG2000/GIF/TIFF/SVG/Netpbm/WebP/AVIF/HEIC/HEIF)"
+optional = true
+python-versions = "<3.15,>=3.10"
+groups = ["main"]
+markers = "extra == \"qserver\""
+files = [
+    {file = "imagesize-2.0.0-py2.py3-none-any.whl", hash = "sha256:5667c5bbb57ab3f1fa4bc366f4fbc971db3d5ed011fd2715fd8001f782718d96"},
+    {file = "imagesize-2.0.0.tar.gz", hash = "sha256:8e8358c4a05c304f1fccf7ff96f036e7243a189e9e42e90851993c558cfe9ee3"},
+]
+
+[[package]]
 name = "importlib-metadata"
 version = "8.7.1"
 description = "Read metadata from Python packages"
@@ -1804,13 +2095,48 @@ files = [
 ]
 
 [[package]]
+name = "ipykernel"
+version = "7.3.0"
+description = "IPython Kernel for Jupyter"
+optional = true
+python-versions = ">=3.10"
+groups = ["main"]
+markers = "extra == \"qserver\""
+files = [
+    {file = "ipykernel-7.3.0-py3-none-any.whl", hash = "sha256:897eb64da762549ef610698fca5e9675195ec6ac8ec7f19d81ce1ca20c876057"},
+    {file = "ipykernel-7.3.0.tar.gz", hash = "sha256:9acaaaf97d16355166e4085afe9d225bfbdf2b7ef520f9df3be8f2b248275e09"},
+]
+
+[package.dependencies]
+appnope = {version = ">=0.1.2", markers = "platform_system == \"Darwin\""}
+comm = ">=0.1.1"
+debugpy = ">=1.6.5"
+ipython = ">=7.23.1"
+jupyter-client = ">=8.9.0"
+jupyter-core = ">=5.1,<6.0.dev0 || >=6.1.dev0"
+matplotlib-inline = ">=0.1"
+nest-asyncio2 = ">=1.7.0"
+packaging = ">=22"
+psutil = ">=5.7"
+pyzmq = ">=25"
+tornado = ">=6.4.1"
+traitlets = ">=5.4.0"
+
+[package.extras]
+cov = ["coverage[toml]", "matplotlib", "pytest-cov", "trio"]
+docs = ["intersphinx-registry", "myst-parser", "pydata-sphinx-theme", "sphinx", "sphinx-autodoc-typehints", "sphinxcontrib-github-alt", "sphinxcontrib-spelling", "trio"]
+pyqt5 = ["pyqt5"]
+pyside6 = ["pyside6"]
+test = ["flaky", "ipyparallel", "pre-commit", "pytest (>=7.0,<10)", "pytest-asyncio (>=0.23.5)", "pytest-cov", "pytest-timeout"]
+
+[[package]]
 name = "ipython"
 version = "9.15.0"
 description = "IPython: Productive Interactive Computing"
 optional = true
 python-versions = ">=3.11"
 groups = ["main"]
-markers = "extra == \"optimize\""
+markers = "extra == \"optimize\" or extra == \"qserver\""
 files = [
     {file = "ipython-9.15.0-py3-none-any.whl", hash = "sha256:515ad9c3cdf0c932a5a9f6245419e8aba706b7bd03c3e1d3a1c83d9351d6aa6e"},
     {file = "ipython-9.15.0.tar.gz", hash = "sha256:da2819ce2aa83135257df830660b1176d986c3d2876db24df01974fa955b2756"},
@@ -1845,7 +2171,7 @@ description = "Defines a variety of Pygments lexers for highlighting IPython cod
 optional = true
 python-versions = ">=3.8"
 groups = ["main"]
-markers = "extra == \"optimize\""
+markers = "extra == \"optimize\" or extra == \"qserver\""
 files = [
     {file = "ipython_pygments_lexers-1.1.1-py3-none-any.whl", hash = "sha256:a9462224a505ade19a605f71f8fa63c2048833ce50abc86768a0d81d876dc81c"},
     {file = "ipython_pygments_lexers-1.1.1.tar.gz", hash = "sha256:09c0138009e56b6854f9535736f4171d855c8c08a563a0dcd8022f78355c7e81"},
@@ -1884,7 +2210,7 @@ description = "An autocompletion tool for Python that can be used for text edito
 optional = true
 python-versions = ">=3.10"
 groups = ["main"]
-markers = "extra == \"optimize\""
+markers = "extra == \"optimize\" or extra == \"qserver\""
 files = [
     {file = "jedi-0.20.0-py2.py3-none-any.whl", hash = "sha256:7bdd9c2634f56713299976f4cbd59cb3fa92165cc5e05ea811fb253480728b67"},
     {file = "jedi-0.20.0.tar.gz", hash = "sha256:c3f4ccbd276696f4b19c54618d4fb18f9fc24b0aef02acf704b23f487daa1011"},
@@ -1904,7 +2230,7 @@ description = "A very fast and expressive template engine."
 optional = true
 python-versions = ">=3.7"
 groups = ["main"]
-markers = "extra == \"optimize\""
+markers = "extra == \"optimize\" or extra == \"qserver\""
 files = [
     {file = "jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67"},
     {file = "jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d"},
@@ -2020,6 +2346,79 @@ files = [
 
 [package.dependencies]
 referencing = ">=0.31.0"
+
+[[package]]
+name = "jupyter-client"
+version = "8.9.1"
+description = "Jupyter protocol implementation and client libraries"
+optional = true
+python-versions = ">=3.10"
+groups = ["main"]
+markers = "extra == \"qserver\""
+files = [
+    {file = "jupyter_client-8.9.1-py3-none-any.whl", hash = "sha256:0b7a295bc46e8751e9adae84781f726c851c1d911bd793edc4a3bde942e3da81"},
+    {file = "jupyter_client-8.9.1.tar.gz", hash = "sha256:a58f730dd9e728ba16ba1d62ebccf7ffe1ebbdbce4e95cfae941b7321ae1f4fa"},
+]
+
+[package.dependencies]
+jupyter-core = ">=5.1"
+python-dateutil = ">=2.8.2"
+pyzmq = ">=25.0"
+tornado = ">=6.4.1"
+traitlets = ">=5.3"
+typing-extensions = ">=4.13.0"
+
+[package.extras]
+docs = ["ipykernel", "myst-parser", "pydata-sphinx-theme", "sphinx (>=4)", "sphinx-autodoc-typehints", "sphinxcontrib-github-alt", "sphinxcontrib-spelling"]
+orjson = ["orjson"]
+test = ["anyio", "coverage", "ipykernel (>=6.14)", "msgpack", "mypy ; platform_python_implementation != \"PyPy\"", "paramiko ; sys_platform == \"win32\"", "pre-commit", "pytest", "pytest-cov", "pytest-jupyter[client] (>=0.6.2)", "pytest-timeout"]
+
+[[package]]
+name = "jupyter-console"
+version = "6.6.3"
+description = "Jupyter terminal console"
+optional = true
+python-versions = ">=3.7"
+groups = ["main"]
+markers = "extra == \"qserver\""
+files = [
+    {file = "jupyter_console-6.6.3-py3-none-any.whl", hash = "sha256:309d33409fcc92ffdad25f0bcdf9a4a9daa61b6f341177570fdac03de5352485"},
+    {file = "jupyter_console-6.6.3.tar.gz", hash = "sha256:566a4bf31c87adbfadf22cdf846e3069b59a71ed5da71d6ba4d8aaad14a53539"},
+]
+
+[package.dependencies]
+ipykernel = ">=6.14"
+ipython = "*"
+jupyter-client = ">=7.0.0"
+jupyter-core = ">=4.12,<5.0.dev0 || >=5.1.dev0"
+prompt-toolkit = ">=3.0.30"
+pygments = "*"
+pyzmq = ">=17"
+traitlets = ">=5.4"
+
+[package.extras]
+test = ["flaky", "pexpect", "pytest"]
+
+[[package]]
+name = "jupyter-core"
+version = "5.9.1"
+description = "Jupyter core package. A base package on which Jupyter projects rely."
+optional = true
+python-versions = ">=3.10"
+groups = ["main"]
+markers = "extra == \"qserver\""
+files = [
+    {file = "jupyter_core-5.9.1-py3-none-any.whl", hash = "sha256:ebf87fdc6073d142e114c72c9e29a9d7ca03fad818c5d300ce2adc1fb0743407"},
+    {file = "jupyter_core-5.9.1.tar.gz", hash = "sha256:4d09aaff303b9566c3ce657f580bd089ff5c91f5f89cf7d8846c3cdf465b5508"},
+]
+
+[package.dependencies]
+platformdirs = ">=2.5"
+traitlets = ">=5.3"
+
+[package.extras]
+docs = ["intersphinx-registry", "myst-parser", "pydata-sphinx-theme", "sphinx-autodoc-typehints", "sphinxcontrib-spelling", "traitlets"]
+test = ["ipykernel", "pre-commit", "pytest (<9)", "pytest-cov", "pytest-timeout"]
 
 [[package]]
 name = "jupyterlab-widgets"
@@ -2379,7 +2778,7 @@ description = "Safely add untrusted strings to HTML/XML markup."
 optional = true
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "extra == \"optimize\""
+markers = "extra == \"optimize\" or extra == \"qserver\""
 files = [
     {file = "markupsafe-3.0.3-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:2f981d352f04553a7171b8e44369f2af4055f888dfb147d55e42d29e29e74559"},
     {file = "markupsafe-3.0.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:e1c1493fb6e50ab01d20a22826e57520f1284df32f2d8601fdd90b6304601419"},
@@ -2547,7 +2946,7 @@ description = "Inline Matplotlib backend for Jupyter"
 optional = true
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "extra == \"optimize\""
+markers = "extra == \"optimize\" or extra == \"qserver\""
 files = [
     {file = "matplotlib_inline-0.2.2-py3-none-any.whl", hash = "sha256:3c821cf1c209f59fb2d2d64abbf5b23b67bcb2210d663f9918dd851c6da1fcf6"},
     {file = "matplotlib_inline-0.2.2.tar.gz", hash = "sha256:72f3fe8fce36b70d4a5b612f899090cd0401deddc4ea90e1572b9f4bfb058c79"},
@@ -2885,13 +3284,26 @@ files = [
 arrays = ["numpy"]
 
 [[package]]
+name = "nest-asyncio2"
+version = "1.7.2"
+description = "Patch asyncio to allow nested event loops"
+optional = true
+python-versions = ">=3.5"
+groups = ["main"]
+markers = "extra == \"qserver\""
+files = [
+    {file = "nest_asyncio2-1.7.2-py3-none-any.whl", hash = "sha256:f5dfa702f3f81f6a03857e9a19e2ba578c0946a4ad417b4c50a24d7ba641fe01"},
+    {file = "nest_asyncio2-1.7.2.tar.gz", hash = "sha256:1921d70b92cc4612c374928d081552efb59b83d91b2b789d935c665fa01729a8"},
+]
+
+[[package]]
 name = "networkx"
 version = "3.6.1"
 description = "Python package for creating and manipulating graphs and networks"
 optional = true
 python-versions = "!=3.14.1,>=3.11"
 groups = ["main"]
-markers = "extra == \"analysis\" or extra == \"optimize\""
+markers = "extra == \"analysis\" or extra == \"optimize\" or extra == \"qserver\""
 files = [
     {file = "networkx-3.6.1-py3-none-any.whl", hash = "sha256:d47fbf302e7d9cbbb9e2555a0d267983d2aa476bac30e90dfbe5669bd57f3762"},
     {file = "networkx-3.6.1.tar.gz", hash = "sha256:26b7c357accc0c8cde558ad486283728b65b6a95d85ee1cd66bafab4c8168509"},
@@ -3151,6 +3563,22 @@ files = [
     {file = "numpy-2.3.5-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:f16417ec91f12f814b10bafe79ef77e70113a2f5f7018640e7425ff979253425"},
     {file = "numpy-2.3.5.tar.gz", hash = "sha256:784db1dcdab56bf0517743e746dfb0f885fc68d948aba86eeec2cba234bdf1c0"},
 ]
+
+[[package]]
+name = "numpydoc"
+version = "1.10.0"
+description = "Sphinx extension to support docstrings in Numpy format"
+optional = true
+python-versions = ">=3.10"
+groups = ["main"]
+markers = "extra == \"qserver\""
+files = [
+    {file = "numpydoc-1.10.0-py3-none-any.whl", hash = "sha256:3149da9874af890bcc2a82ef7aae5484e5aa81cb2778f08e3c307ba6d963721b"},
+    {file = "numpydoc-1.10.0.tar.gz", hash = "sha256:3f7970f6eee30912260a6b31ac72bba2432830cd6722569ec17ee8d3ef5ffa01"},
+]
+
+[package.dependencies]
+sphinx = ">=6"
 
 [[package]]
 name = "nvidia-cublas-cu12"
@@ -3414,6 +3842,22 @@ files = [
 numpy = {version = ">=2", markers = "python_version >= \"3.9\""}
 
 [[package]]
+name = "openpyxl"
+version = "3.1.5"
+description = "A Python library to read/write Excel 2010 xlsx/xlsm files"
+optional = true
+python-versions = ">=3.8"
+groups = ["main"]
+markers = "extra == \"qserver\""
+files = [
+    {file = "openpyxl-3.1.5-py2.py3-none-any.whl", hash = "sha256:5282c12b107bffeef825f4617dc029afaf41d0ea60823bbb665ef3079dc79de2"},
+    {file = "openpyxl-3.1.5.tar.gz", hash = "sha256:cf0e3cf56142039133628b5acffe8ef0c12bc902d2aadd3e0fe5878dc08d1050"},
+]
+
+[package.dependencies]
+et-xmlfile = "*"
+
+[[package]]
 name = "opentelemetry-api"
 version = "1.41.0"
 description = "OpenTelemetry Python API"
@@ -3428,6 +3872,29 @@ files = [
 [package.dependencies]
 importlib-metadata = ">=6.0,<8.8.0"
 typing-extensions = ">=4.5.0"
+
+[[package]]
+name = "ophyd"
+version = "1.11.2"
+description = "Bluesky hardware abstraction with an emphasis on EPICS"
+optional = true
+python-versions = ">=3.8"
+groups = ["main"]
+markers = "extra == \"qserver\""
+files = [
+    {file = "ophyd-1.11.2-py3-none-any.whl", hash = "sha256:0254dbced299fbff1841b4f80102dd0e0c482176d5812a2246a08763acd87a75"},
+    {file = "ophyd-1.11.2.tar.gz", hash = "sha256:ef63cc291a34d55823ec2f62be91991786ce4b9100e374df097b785d849466c3"},
+]
+
+[package.dependencies]
+networkx = ">=2.0"
+numpy = "*"
+opentelemetry-api = "*"
+packaging = "*"
+pint = "*"
+
+[package.extras]
+dev = ["attrs (>=19.3.0)", "black (==22.3.0)", "bluesky (>=1.11.0)", "caproto[standard] (>=0.4.2rc1,!=1.2.0)", "databroker (>=1.0.0b1)", "doctr", "epics-pypdb", "flake8", "flake8-isort", "h5py", "inflection", "ipython", "ipywidgets", "matplotlib", "mypy", "myst-parser", "numpydoc", "pipdeptree", "pre-commit", "pydata-sphinx-theme", "pyepics (>=3.4.2,<3.5.7)", "pytest", "pytest-asyncio", "pytest-codecov", "pytest-cov", "pytest-faulthandler", "pytest-rerunfailures", "pytest-timeout", "setuptools (>=64)", "setuptools_scm[toml] (>=6.2)", "sphinx-autobuild", "sphinx-design", "tox-direct"]
 
 [[package]]
 name = "ophyd-async"
@@ -3660,7 +4127,7 @@ description = "A Python Parser"
 optional = true
 python-versions = ">=3.6"
 groups = ["main"]
-markers = "extra == \"optimize\""
+markers = "extra == \"optimize\" or extra == \"qserver\""
 files = [
     {file = "parso-0.8.7-py2.py3-none-any.whl", hash = "sha256:a8926eb2a1b915486941fdbd31e86a4baf88fe8c210f25f2f35ecec5b574ca1c"},
     {file = "parso-0.8.7.tar.gz", hash = "sha256:eaaac4c9fdd5e9e8852dc778d2d7405897ec510f2a298071453e5e3a07914bb1"},
@@ -3697,7 +4164,7 @@ description = "Pexpect allows easy control of interactive console applications."
 optional = true
 python-versions = "*"
 groups = ["main"]
-markers = "extra == \"optimize\" and sys_platform != \"win32\" and sys_platform != \"emscripten\""
+markers = "(extra == \"optimize\" or extra == \"qserver\") and sys_platform != \"win32\" and sys_platform != \"emscripten\""
 files = [
     {file = "pexpect-4.9.0-py2.py3-none-any.whl", hash = "sha256:7236d1e080e4936be2dc3e326cec0af72acf9212a7e1d060210e70a47e253523"},
     {file = "pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f"},
@@ -3822,7 +4289,7 @@ description = "Physical quantities module"
 optional = true
 python-versions = ">=3.11"
 groups = ["main"]
-markers = "extra == \"analysis\" or extra == \"optimize\""
+markers = "extra == \"analysis\" or extra == \"optimize\" or extra == \"qserver\""
 files = [
     {file = "pint-0.25.3-py3-none-any.whl", hash = "sha256:27eb25143bd5de9fcc4d5a4b484f16faf6b4615aa93ece6b3373a8c1a3c1b97d"},
     {file = "pint-0.25.3.tar.gz", hash = "sha256:f8f5df6cf65314d74da1ade1bf96f8e3e4d0c41b51577ac53c49e7d44ca5acee"},
@@ -3857,7 +4324,7 @@ description = "A small Python package for determining appropriate platform-speci
 optional = true
 python-versions = ">=3.10"
 groups = ["main"]
-markers = "extra == \"analysis\" or extra == \"optimize\" or extra == \"tiled\""
+markers = "extra == \"analysis\" or extra == \"optimize\" or extra == \"qserver\" or extra == \"tiled\""
 files = [
     {file = "platformdirs-4.9.6-py3-none-any.whl", hash = "sha256:e61adb1d5e5cb3441b4b7710bea7e4c12250ca49439228cc1021c00dcfac0917"},
     {file = "platformdirs-4.9.6.tar.gz", hash = "sha256:3bfa75b0ad0db84096ae777218481852c0ebc6c727b3168c1b9e0118e458cf0a"},
@@ -3886,7 +4353,7 @@ description = "Library for building powerful interactive command lines in Python
 optional = true
 python-versions = ">=3.8"
 groups = ["main"]
-markers = "extra == \"optimize\""
+markers = "extra == \"optimize\" or extra == \"qserver\""
 files = [
     {file = "prompt_toolkit-3.0.52-py3-none-any.whl", hash = "sha256:9aac639a3bbd33284347de5ad8d68ecc044b91a762dc39b7c21095fcd6a19955"},
     {file = "prompt_toolkit-3.0.52.tar.gz", hash = "sha256:28cde192929c8e7321de85de1ddbe736f1375148b02f2e17edd840042b1be855"},
@@ -3940,7 +4407,7 @@ description = "Cross-platform lib for process and system monitoring."
 optional = true
 python-versions = ">=3.6"
 groups = ["main"]
-markers = "extra == \"optimize\" and sys_platform != \"emscripten\" and sys_platform != \"cygwin\""
+markers = "(extra == \"optimize\" or extra == \"qserver\") and sys_platform != \"emscripten\" and sys_platform != \"cygwin\" or extra == \"qserver\""
 files = [
     {file = "psutil-7.2.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:2edccc433cbfa046b980b0df0171cd25bcaeb3a68fe9022db0979e7aa74a826b"},
     {file = "psutil-7.2.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:e78c8603dcd9a04c7364f1a3e670cea95d51ee865e4efb3556a3a63adef958ea"},
@@ -3976,7 +4443,7 @@ description = "Run a subprocess in a pseudo terminal"
 optional = true
 python-versions = "*"
 groups = ["main"]
-markers = "extra == \"optimize\" and sys_platform != \"win32\" and sys_platform != \"emscripten\""
+markers = "(extra == \"optimize\" or extra == \"qserver\") and sys_platform != \"win32\" and sys_platform != \"emscripten\""
 files = [
     {file = "ptyprocess-0.7.0-py2.py3-none-any.whl", hash = "sha256:4b41f3967fce3af57cc7e94b888626c18bf37a083e3651ca8feeb66d492fef35"},
     {file = "ptyprocess-0.7.0.tar.gz", hash = "sha256:5c5d0a3b48ceee0b48485e0c26037c0acd7d29765ca3fbb5cb3831d347423220"},
@@ -3989,7 +4456,7 @@ description = "Safely evaluate AST nodes without side effects"
 optional = true
 python-versions = "*"
 groups = ["main"]
-markers = "extra == \"optimize\""
+markers = "extra == \"optimize\" or extra == \"qserver\""
 files = [
     {file = "pure_eval-0.2.3-py3-none-any.whl", hash = "sha256:1db8e35b67b3d218d818ae653e27f06c3aa420901fa7b081ca98cbedc874e0d0"},
     {file = "pure_eval-0.2.3.tar.gz", hash = "sha256:5f4e983f40564c576c7c8635ae88db5956bb2229d7e9237d03b3c0b0190eaf42"},
@@ -4124,7 +4591,7 @@ description = "C parser in Python"
 optional = true
 python-versions = ">=3.10"
 groups = ["main"]
-markers = "extra == \"optimize\" and implementation_name != \"PyPy\""
+markers = "extra == \"qserver\" and implementation_name == \"pypy\" or extra == \"optimize\" and implementation_name != \"PyPy\""
 files = [
     {file = "pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992"},
     {file = "pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29"},
@@ -4337,7 +4804,7 @@ description = "Pygments is a syntax highlighting package written in Python."
 optional = true
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "extra == \"tiled\" or extra == \"optimize\""
+markers = "extra == \"tiled\" or extra == \"optimize\" or extra == \"qserver\""
 files = [
     {file = "pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176"},
     {file = "pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f"},
@@ -4600,6 +5067,19 @@ files = [
 cli = ["click (>=5.0)"]
 
 [[package]]
+name = "python-multipart"
+version = "0.0.32"
+description = "A streaming multipart parser for Python"
+optional = true
+python-versions = ">=3.10"
+groups = ["main"]
+markers = "extra == \"qserver\""
+files = [
+    {file = "python_multipart-0.0.32-py3-none-any.whl", hash = "sha256:ff6d3f776f16878c894e52e107296ffc890e913c611b1a4ec6c44e2821fe2e23"},
+    {file = "python_multipart-0.0.32.tar.gz", hash = "sha256:be54b7f3fa167bb83e4fcd936b887b708f4e57fe75911c02aebf53efaf8d938e"},
+]
+
+[[package]]
 name = "pytz"
 version = "2026.2"
 description = "World timezone definitions, modern and historical"
@@ -4695,6 +5175,106 @@ files = [
 ]
 
 [[package]]
+name = "pyzmq"
+version = "27.2.0"
+description = "Python bindings for 0MQ"
+optional = true
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "extra == \"qserver\""
+files = [
+    {file = "pyzmq-27.2.0-cp310-cp310-macosx_10_15_universal2.whl", hash = "sha256:480dba27b145373b5e103890f17969d891bc9e86746d6b8b29dd70b0d4addc62"},
+    {file = "pyzmq-27.2.0-cp310-cp310-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:722f0a6940be1a483c81029a271d950e04dc2ff113a42e21b3d2b7a0d8e59638"},
+    {file = "pyzmq-27.2.0-cp310-cp310-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3ee556ed1cf836f96de9d5e545563116426d4a94f21b8041fdc79408eff18ebb"},
+    {file = "pyzmq-27.2.0-cp310-cp310-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d64da42cae09e6b0c61368b4cc8ca80f23ce3af17584d08053f3dc957433d5ed"},
+    {file = "pyzmq-27.2.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:376981d106598beb70be384f44d8f589832fd0051d184d38d10043da3cc3b080"},
+    {file = "pyzmq-27.2.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:40d96cb7a8f6a43aa9617c00215c2b73e1b5e4a1d6cbc9f5860ed7ac682599f0"},
+    {file = "pyzmq-27.2.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:4ebc7889b31bc11c72e9f17ba3ebb0a8b0911cce413f41b498e55383a94819a3"},
+    {file = "pyzmq-27.2.0-cp310-cp310-win32.whl", hash = "sha256:650c6cd7cb39a069e7048261efe66fce8bf2e0052c831a7a099b7a0f2ea860d7"},
+    {file = "pyzmq-27.2.0-cp310-cp310-win_amd64.whl", hash = "sha256:82a09aa67871d4f2fcafd47bf670fb93210b232a7c2d4b8a54676314edf04033"},
+    {file = "pyzmq-27.2.0-cp310-cp310-win_arm64.whl", hash = "sha256:bad4813f270592cedf56977e31ac1fc374fb0f6f67ea5134a5e37c19cb429a8e"},
+    {file = "pyzmq-27.2.0-cp311-cp311-macosx_10_15_universal2.whl", hash = "sha256:9216132843d139a123f243c07fe70f7487dce5041093dd77040f9adb5dc91872"},
+    {file = "pyzmq-27.2.0-cp311-cp311-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:d41ebb260b69329b7d4a2936d44c872c86dd785355b51366c8b14e07ed7e9373"},
+    {file = "pyzmq-27.2.0-cp311-cp311-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:468139ddb2e494d06e586bd3a6835077e8b3764560c8db552fe685c5867fc24e"},
+    {file = "pyzmq-27.2.0-cp311-cp311-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:39755dc4a923021bd0677990ffdbc21cff0e1ee1cf07fe3817acea153ef4cb67"},
+    {file = "pyzmq-27.2.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:714f8cbd66c7e405338d668f79d2fe83fe923defe348e843be998603cf92eeff"},
+    {file = "pyzmq-27.2.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:1132805970045adb9f5f05dd57040978286a8e21a5475f2c2ddf1bc983b9a2c7"},
+    {file = "pyzmq-27.2.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:b26f2d0493b79ce3c3112c8a12649418915582ba4707b8ed9f44febf2be71f42"},
+    {file = "pyzmq-27.2.0-cp311-cp311-win32.whl", hash = "sha256:44f261eca7dfb9904ea2b56428f59ab693bbe2715c0413a701f17b067ebf877c"},
+    {file = "pyzmq-27.2.0-cp311-cp311-win_amd64.whl", hash = "sha256:8b86e04f55af0f4d8cd8ecf14c0b8b81ebc8fd66fa20126b753514628ecadc7e"},
+    {file = "pyzmq-27.2.0-cp311-cp311-win_arm64.whl", hash = "sha256:917d601e9540098f580d2723d0ce6402cdb6f02bc8dc2de74e0dca6e13bffd1b"},
+    {file = "pyzmq-27.2.0-cp312-abi3-macosx_10_15_universal2.whl", hash = "sha256:591c8de5851c5ea372194469fe97587b97c3b641e9a70f31bb3474acbfde0241"},
+    {file = "pyzmq-27.2.0-cp312-abi3-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:00e73942ef12cecbc7951c4a9104bb8ffaed742abb13af2da6833d90dd368cef"},
+    {file = "pyzmq-27.2.0-cp312-abi3-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1f8079d0521fe94bbb401fe9407578b28f3701627c8be2c9f7e0c5b77dcb0109"},
+    {file = "pyzmq-27.2.0-cp312-abi3-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:dea74fd65f1fc5f7fe167916a473ebe6ed6174e5e5d9de11ea6583661be6cf43"},
+    {file = "pyzmq-27.2.0-cp312-abi3-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:dcc99ca132b667a4ed750afd42db4ea73288f18425a9b2e3c0af095665c491f5"},
+    {file = "pyzmq-27.2.0-cp312-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:b8d5f66e4a8246cf77f7b8f7902af64f00553368fa0373c89d99b78f0ad79394"},
+    {file = "pyzmq-27.2.0-cp312-abi3-musllinux_1_2_i686.whl", hash = "sha256:d1526b42a2e725b84ed226f37becedc250c6347594e5ed304e4e9aff68c9aec3"},
+    {file = "pyzmq-27.2.0-cp312-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:f707bcf2c1d007d14d70531d4dd7b41060881c73efa845580bf6faaf9ea24d42"},
+    {file = "pyzmq-27.2.0-cp312-abi3-win32.whl", hash = "sha256:fdaaa4ea3242f6ad298eb5177eb042aea5c73c30e76d20caee7b15af20d24ec2"},
+    {file = "pyzmq-27.2.0-cp312-abi3-win_amd64.whl", hash = "sha256:2c218c6ab8bc447ba62054b581fd30209689d199c6ecb253f79615ca74a38e12"},
+    {file = "pyzmq-27.2.0-cp312-abi3-win_arm64.whl", hash = "sha256:348d6fd3e4b81ae4580622ea8c2ea60224e84b2ac1b3be4482e6edc7de06e7a3"},
+    {file = "pyzmq-27.2.0-cp313-cp313-android_24_arm64_v8a.whl", hash = "sha256:c551b9e2f86dc625fcb1a032c0d68042678caf96a8dd7c28796766b673bd5b52"},
+    {file = "pyzmq-27.2.0-cp313-cp313-android_24_x86_64.whl", hash = "sha256:288cc790da0e3064a14a38ddc56ba169dada8c8af4cb86518db2bcbd380eedbb"},
+    {file = "pyzmq-27.2.0-cp314-cp314-android_24_arm64_v8a.whl", hash = "sha256:3d45189c0c3c99f817b7fefff0d32eeef684cf33e1e3c0fc4281515357c54702"},
+    {file = "pyzmq-27.2.0-cp314-cp314-android_24_x86_64.whl", hash = "sha256:d61910b52be5b2cd8b248dbcbe3a1b0275556a7d99fb613fc43323b546e273b8"},
+    {file = "pyzmq-27.2.0-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:3ab6eb88590e510ab16715c32dbba12000da9bee989fdadd9ee19a234c492eb7"},
+    {file = "pyzmq-27.2.0-cp314-cp314t-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:1ecbdd131b9669f62d3a45afee5527c7ae9f141e4301267f21714c90bd21725f"},
+    {file = "pyzmq-27.2.0-cp314-cp314t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3146385b94a760236c5eceff468a66a296a716ca98a2e0f9217b1518118466b1"},
+    {file = "pyzmq-27.2.0-cp314-cp314t-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9846e881620dd62566ca76a53e384c3f37490faf4b9240aebc7498810dfca853"},
+    {file = "pyzmq-27.2.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:d9527e3dbaef1edaeeb2446fa7379446814a43ade8adc7c4a5ebe69437815ddd"},
+    {file = "pyzmq-27.2.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:56b48fa9d478a3af7254f397697a62f5ad3e1bb677e200b2701f0c290d97e5af"},
+    {file = "pyzmq-27.2.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:bf0b6e4ce1bb089751c504c5493d6b0557eabd02dd21b76e9086cf964234b103"},
+    {file = "pyzmq-27.2.0-cp314-cp314t-win32.whl", hash = "sha256:fba8afcf265c6e9fbe1594cb045d4765c6c9a7d607653a8196067ef23566b843"},
+    {file = "pyzmq-27.2.0-cp314-cp314t-win_amd64.whl", hash = "sha256:d1bc1d380a91d954ed5fc9f12915dba014eed0978d2de05ee7ca688bdaac144a"},
+    {file = "pyzmq-27.2.0-cp314-cp314t-win_arm64.whl", hash = "sha256:c7cfb75caa83f5153c687e9d2107f64b5ef0ef0d6edd260d3ff920baaaa69101"},
+    {file = "pyzmq-27.2.0-cp315-cp315-android_24_arm64_v8a.whl", hash = "sha256:c5129a8fe43ecc49b99eb75616603d483a3c2fcaef504988fafe8ea392aea98b"},
+    {file = "pyzmq-27.2.0-cp315-cp315-android_24_x86_64.whl", hash = "sha256:baa2ce3485145653194d6c8c5beedd1e9f0bf46a0919c9fa2fe2204fc35b74d9"},
+    {file = "pyzmq-27.2.0-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:e1ed46048d1920cabc96d952a0d5cfe4127ad8db572c335aae4e3c57b9278d7f"},
+    {file = "pyzmq-27.2.0-cp315-cp315t-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:e0fa0bc6b1a184aee59b32efcd1b7f0e6d5b8f9387799e4c16a4cb66a86747d6"},
+    {file = "pyzmq-27.2.0-cp315-cp315t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0f4bd6743e8bf854c3bfce892dd6578a514aabf128e37a4b2eafcf01856f7e44"},
+    {file = "pyzmq-27.2.0-cp315-cp315t-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:95369ed6626afcfe2ac89832fb1b917c077fbeb905fbbe5d918349ce0222b89b"},
+    {file = "pyzmq-27.2.0-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:40124779c3a56ad5d91902df1ff89159cb414b6c1a0ee697abcc66cf5e6db62d"},
+    {file = "pyzmq-27.2.0-cp315-cp315t-musllinux_1_2_i686.whl", hash = "sha256:ec8a318dfc27c7d946651b3d9e8025d5734f30c168a822195601827207bac09b"},
+    {file = "pyzmq-27.2.0-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:88c0fac061bac269076edeb3a209acefc96cd6167c239daf1c2b404ac48d7012"},
+    {file = "pyzmq-27.2.0-cp315-cp315t-win32.whl", hash = "sha256:ac126d48cf18aa955daabef43bf0009ff76ad4deee437d09ecf15388214b5beb"},
+    {file = "pyzmq-27.2.0-cp315-cp315t-win_amd64.whl", hash = "sha256:edce90a1e588ec63adbf612cc0ad582de4169cd216c7ae53c15f42a2ee902f35"},
+    {file = "pyzmq-27.2.0-cp315-cp315t-win_arm64.whl", hash = "sha256:a843094b4d3d633bc3623e47a2ff50742d6af02bc1f7606aa2e67e971e21878d"},
+    {file = "pyzmq-27.2.0-cp39-cp39-macosx_10_15_universal2.whl", hash = "sha256:76afba06ae698f2b8fe4fb34b32c760a650f168c2e622f370f2c528035b7f650"},
+    {file = "pyzmq-27.2.0-cp39-cp39-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:c9322f9c87b0935870516c2876e1e29497fdc50439c785ece63e3fbbab06c821"},
+    {file = "pyzmq-27.2.0-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7e2579c5de82ddf4544d723c1bc8b44c3b806d157acc9fb2a2d18e10ef28e202"},
+    {file = "pyzmq-27.2.0-cp39-cp39-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:95f52b877149b06bbdeec2e8ea6230aad14950bbfbcfa16e7eb88951f07d6b28"},
+    {file = "pyzmq-27.2.0-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:a0ee3c49be2aa15abd12cbbd14d4ea2892f872c688e1e487af39ec1972ed549d"},
+    {file = "pyzmq-27.2.0-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:6eb63cc61ab93b01b9afc887a160255e2fbe703fdbacfe5feaef87214f51bd6c"},
+    {file = "pyzmq-27.2.0-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:f52f08101907609cc08db6a1f9f2a7a9afd54e9b2ca16178c9c38e99fb593cef"},
+    {file = "pyzmq-27.2.0-cp39-cp39-win32.whl", hash = "sha256:507c0b33f95502723d325487e8e50c2cdd3b37444143f05423a3861327f69bf7"},
+    {file = "pyzmq-27.2.0-cp39-cp39-win_amd64.whl", hash = "sha256:ff60f0f7ccfda0e303ac43bec7096007b7cdf2c41b3739d1ec667febe67acab3"},
+    {file = "pyzmq-27.2.0-cp39-cp39-win_arm64.whl", hash = "sha256:d61a0169ba05ab7ebc48dc793f092df12f789bf378dac8321ccd966fd93d94e8"},
+    {file = "pyzmq-27.2.0-pp310-pypy310_pp73-macosx_10_15_x86_64.whl", hash = "sha256:770a37f28ddfbe1d2c40a2e3ce37e5fd10831daa6ae9634105aa8a5d23507b00"},
+    {file = "pyzmq-27.2.0-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:b398c5fe102b41e1559f7ffdae760aabd5f432d73b047b4ae0eac4e01cb594d2"},
+    {file = "pyzmq-27.2.0-pp310-pypy310_pp73-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:0e1af01858d6dc0c09cea57f9cb1ddf4601f04897b6bb1efc3a2038123c87d79"},
+    {file = "pyzmq-27.2.0-pp310-pypy310_pp73-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:211350c3ccd4746bc5a85e8fe961bad1f7f2f274f67cf1f785fad7f96f562eea"},
+    {file = "pyzmq-27.2.0-pp310-pypy310_pp73-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:dde5e291548ca0f397623b5e523db5c90172b32aa4fd3ba464a79ea31a580b43"},
+    {file = "pyzmq-27.2.0-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:94242bd4de6af7e74665e14a88630bccd615057f6acfaf08a3a432551d604645"},
+    {file = "pyzmq-27.2.0-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:a7c1144dc61777938e932a2c9011b980b89fd8ff3733033b34c44c299187a6e1"},
+    {file = "pyzmq-27.2.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:c218b816220d05acf6ab1bafca58926d95cbcc5fec5024724666030466308f0c"},
+    {file = "pyzmq-27.2.0-pp311-pypy311_pp73-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:ae6ebbc0bfe5a21ce21e32ba567bf73df2d93888109c65acbd42506cf9395759"},
+    {file = "pyzmq-27.2.0-pp311-pypy311_pp73-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:679b5b1dde326a921ea2c9ec1f9ea3115bfe1b4735779bbc6eb0473a0ed93f71"},
+    {file = "pyzmq-27.2.0-pp311-pypy311_pp73-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f5c6d8744d10b5e1eadd90a7c58f8546acf6bf680ee463f7e6ada09ad6c9f802"},
+    {file = "pyzmq-27.2.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:3ee8dd7031d5e23f632e0e7eee67183ca7d2536e0de35dc1e5d69f3471a791e8"},
+    {file = "pyzmq-27.2.0-pp39-pypy39_pp73-macosx_10_15_x86_64.whl", hash = "sha256:97d4c6622f129b514a4f5939af1b5f434c97f47085d9311b5f7f36e24b3bd447"},
+    {file = "pyzmq-27.2.0-pp39-pypy39_pp73-macosx_11_0_arm64.whl", hash = "sha256:dfcd024eade5870b25f890c4df0ba9421ed8167d8d3d82334237512c1158dada"},
+    {file = "pyzmq-27.2.0-pp39-pypy39_pp73-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:a070a9cdad1f8f8a85ea153afcc4654f11b10895d14c0acabe10f1df0e0892ea"},
+    {file = "pyzmq-27.2.0-pp39-pypy39_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:010db74a1dd67c7cd8b8b30916355735db7d633a070510bb34e41ab679ab2c0e"},
+    {file = "pyzmq-27.2.0-pp39-pypy39_pp73-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9ab72ee77b313d0658447204c8201f9b315146e923b48c56ea7dbd005d464a91"},
+    {file = "pyzmq-27.2.0-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:8a5c04ad2e368142aea52d1abdf6631cb2534864e3c16ab78268ab957060b2a6"},
+    {file = "pyzmq-27.2.0.tar.gz", hash = "sha256:54d4259d1bfae24ecdb5ca79f7acc2eac6c286a02d6a0ae617797cb45f0726d3"},
+]
+
+[package.dependencies]
+cffi = {version = "*", markers = "implementation_name == \"pypy\""}
+
+[[package]]
 name = "qt5-applications"
 version = "5.15.2.2.3"
 description = "The collection of Qt tools easily installable in Python"
@@ -4724,6 +5304,31 @@ files = [
 [package.dependencies]
 click = "*"
 qt5-applications = ">=5.15.2.2.2,<5.15.2.3"
+
+[[package]]
+name = "redis"
+version = "8.1.0"
+description = "Python client for Redis database and key-value store"
+optional = true
+python-versions = ">=3.10"
+groups = ["main"]
+markers = "extra == \"qserver\""
+files = [
+    {file = "redis-8.1.0-py3-none-any.whl", hash = "sha256:a4fe1aac3d3b3cc791d4b3d5931c5a956045dc951ee74d1c913ee3ac4d2ee9fb"},
+    {file = "redis-8.1.0.tar.gz", hash = "sha256:6e1a19beef9225c83efd689c7e6b7da2d5215b1f42cd13b7fc3714d0a09c7b25"},
+]
+
+[package.dependencies]
+async-timeout = {version = ">=4.0.3", markers = "python_full_version < \"3.11.3\""}
+hiredis = {version = ">=3.2.0", optional = true, markers = "extra == \"hiredis\""}
+
+[package.extras]
+circuit-breaker = ["pybreaker (>=1.4.0)"]
+hiredis = ["hiredis (>=3.2.0)"]
+jwt = ["pyjwt (>=2.13.0)"]
+ocsp = ["cryptography (>=36.0.1)", "pyopenssl (>=20.0.1)", "requests (>=2.31.0)"]
+otel = ["opentelemetry-api (>=1.39.1)", "opentelemetry-exporter-otlp-proto-http (>=1.39.1)", "opentelemetry-sdk (>=1.39.1)"]
+xxhash = ["xxhash (>=3.6.0,<3.7.0)"]
 
 [[package]]
 name = "referencing"
@@ -4803,6 +5408,19 @@ pygments = ">=2.13.0,<3.0.0"
 
 [package.extras]
 jupyter = ["ipywidgets (>=7.5.1,<9)"]
+
+[[package]]
+name = "roman-numerals"
+version = "4.1.0"
+description = "Manipulate well-formed Roman numerals"
+optional = true
+python-versions = ">=3.10"
+groups = ["main"]
+markers = "extra == \"qserver\""
+files = [
+    {file = "roman_numerals-4.1.0-py3-none-any.whl", hash = "sha256:647ba99caddc2cc1e55a51e4360689115551bf4476d90e8162cf8c345fe233c7"},
+    {file = "roman_numerals-4.1.0.tar.gz", hash = "sha256:1af8b147eb1405d5839e78aeb93131690495fe9da5c91856cb33ad55a7f1e5b2"},
+]
 
 [[package]]
 name = "rpds-py"
@@ -5382,6 +6000,19 @@ files = [
 ]
 
 [[package]]
+name = "snowballstemmer"
+version = "3.1.1"
+description = "This package provides 36 stemmers for 34 languages generated from Snowball algorithms."
+optional = true
+python-versions = ">=3.3"
+groups = ["main"]
+markers = "extra == \"qserver\""
+files = [
+    {file = "snowballstemmer-3.1.1-py3-none-any.whl", hash = "sha256:7e207fa178741da09cdee59d3ecec3827ad5f92b1fc5c9ff3755b639f71f5752"},
+    {file = "snowballstemmer-3.1.1.tar.gz", hash = "sha256:e07bbc54a0d798fe6010a12398422e62a8bfbba95c394fd0956ef58cb4d3e260"},
+]
+
+[[package]]
 name = "sparse"
 version = "0.18.0"
 description = "Sparse n-dimensional arrays for the PyData ecosystem"
@@ -5409,13 +6040,151 @@ tests = ["pre-commit", "pytest (>=3.5)", "pytest-codspeed", "pytest-cov", "pytes
 tox = ["sparse[tests]", "tox"]
 
 [[package]]
+name = "sphinx"
+version = "9.0.4"
+description = "Python documentation generator"
+optional = true
+python-versions = ">=3.11"
+groups = ["main"]
+markers = "extra == \"qserver\""
+files = [
+    {file = "sphinx-9.0.4-py3-none-any.whl", hash = "sha256:5bebc595a5e943ea248b99c13814c1c5e10b3ece718976824ffa7959ff95fffb"},
+    {file = "sphinx-9.0.4.tar.gz", hash = "sha256:594ef59d042972abbc581d8baa577404abe4e6c3b04ef61bd7fc2acbd51f3fa3"},
+]
+
+[package.dependencies]
+alabaster = ">=0.7.14"
+babel = ">=2.13"
+colorama = {version = ">=0.4.6", markers = "sys_platform == \"win32\""}
+docutils = ">=0.20,<0.23"
+imagesize = ">=1.3"
+Jinja2 = ">=3.1"
+packaging = ">=23.0"
+Pygments = ">=2.17"
+requests = ">=2.30.0"
+roman-numerals = ">=1.0.0"
+snowballstemmer = ">=2.2"
+sphinxcontrib-applehelp = ">=1.0.7"
+sphinxcontrib-devhelp = ">=1.0.6"
+sphinxcontrib-htmlhelp = ">=2.0.6"
+sphinxcontrib-jsmath = ">=1.0.1"
+sphinxcontrib-qthelp = ">=1.0.6"
+sphinxcontrib-serializinghtml = ">=1.1.9"
+
+[[package]]
+name = "sphinxcontrib-applehelp"
+version = "2.0.0"
+description = "sphinxcontrib-applehelp is a Sphinx extension which outputs Apple help books"
+optional = true
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "extra == \"qserver\""
+files = [
+    {file = "sphinxcontrib_applehelp-2.0.0-py3-none-any.whl", hash = "sha256:4cd3f0ec4ac5dd9c17ec65e9ab272c9b867ea77425228e68ecf08d6b28ddbdb5"},
+    {file = "sphinxcontrib_applehelp-2.0.0.tar.gz", hash = "sha256:2f29ef331735ce958efa4734873f084941970894c6090408b079c61b2e1c06d1"},
+]
+
+[package.extras]
+lint = ["mypy", "ruff (==0.5.5)", "types-docutils"]
+standalone = ["Sphinx (>=5)"]
+test = ["pytest"]
+
+[[package]]
+name = "sphinxcontrib-devhelp"
+version = "2.0.0"
+description = "sphinxcontrib-devhelp is a sphinx extension which outputs Devhelp documents"
+optional = true
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "extra == \"qserver\""
+files = [
+    {file = "sphinxcontrib_devhelp-2.0.0-py3-none-any.whl", hash = "sha256:aefb8b83854e4b0998877524d1029fd3e6879210422ee3780459e28a1f03a8a2"},
+    {file = "sphinxcontrib_devhelp-2.0.0.tar.gz", hash = "sha256:411f5d96d445d1d73bb5d52133377b4248ec79db5c793ce7dbe59e074b4dd1ad"},
+]
+
+[package.extras]
+lint = ["mypy", "ruff (==0.5.5)", "types-docutils"]
+standalone = ["Sphinx (>=5)"]
+test = ["pytest"]
+
+[[package]]
+name = "sphinxcontrib-htmlhelp"
+version = "2.1.0"
+description = "sphinxcontrib-htmlhelp is a sphinx extension which renders HTML help files"
+optional = true
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "extra == \"qserver\""
+files = [
+    {file = "sphinxcontrib_htmlhelp-2.1.0-py3-none-any.whl", hash = "sha256:166759820b47002d22914d64a075ce08f4c46818e17cfc9470a9786b759b19f8"},
+    {file = "sphinxcontrib_htmlhelp-2.1.0.tar.gz", hash = "sha256:c9e2916ace8aad64cc13a0d233ee22317f2b9025b9cf3295249fa985cc7082e9"},
+]
+
+[package.extras]
+lint = ["mypy", "ruff (==0.5.5)", "types-docutils"]
+standalone = ["Sphinx (>=5)"]
+test = ["html5lib", "pytest"]
+
+[[package]]
+name = "sphinxcontrib-jsmath"
+version = "1.0.1"
+description = "A sphinx extension which renders display math in HTML via JavaScript"
+optional = true
+python-versions = ">=3.5"
+groups = ["main"]
+markers = "extra == \"qserver\""
+files = [
+    {file = "sphinxcontrib-jsmath-1.0.1.tar.gz", hash = "sha256:a9925e4a4587247ed2191a22df5f6970656cb8ca2bd6284309578f2153e0c4b8"},
+    {file = "sphinxcontrib_jsmath-1.0.1-py2.py3-none-any.whl", hash = "sha256:2ec2eaebfb78f3f2078e73666b1415417a116cc848b72e5172e596c871103178"},
+]
+
+[package.extras]
+test = ["flake8", "mypy", "pytest"]
+
+[[package]]
+name = "sphinxcontrib-qthelp"
+version = "2.0.0"
+description = "sphinxcontrib-qthelp is a sphinx extension which outputs QtHelp documents"
+optional = true
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "extra == \"qserver\""
+files = [
+    {file = "sphinxcontrib_qthelp-2.0.0-py3-none-any.whl", hash = "sha256:b18a828cdba941ccd6ee8445dbe72ffa3ef8cbe7505d8cd1fa0d42d3f2d5f3eb"},
+    {file = "sphinxcontrib_qthelp-2.0.0.tar.gz", hash = "sha256:4fe7d0ac8fc171045be623aba3e2a8f613f8682731f9153bb2e40ece16b9bbab"},
+]
+
+[package.extras]
+lint = ["mypy", "ruff (==0.5.5)", "types-docutils"]
+standalone = ["Sphinx (>=5)"]
+test = ["defusedxml (>=0.7.1)", "pytest"]
+
+[[package]]
+name = "sphinxcontrib-serializinghtml"
+version = "2.0.0"
+description = "sphinxcontrib-serializinghtml is a sphinx extension which outputs \"serialized\" HTML files (json and pickle)"
+optional = true
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "extra == \"qserver\""
+files = [
+    {file = "sphinxcontrib_serializinghtml-2.0.0-py3-none-any.whl", hash = "sha256:6e2cb0eef194e10c27ec0023bfeb25badbbb5868244cf5bc5bdc04e4464bf331"},
+    {file = "sphinxcontrib_serializinghtml-2.0.0.tar.gz", hash = "sha256:e9d912827f872c029017a53f0ef2180b327c3f7fd23c87229f7a8e8b70031d4d"},
+]
+
+[package.extras]
+lint = ["mypy", "ruff (==0.5.5)", "types-docutils"]
+standalone = ["Sphinx (>=5)"]
+test = ["pytest"]
+
+[[package]]
 name = "stack-data"
 version = "0.6.3"
 description = "Extract data from python stack frames and tracebacks for informative displays"
 optional = true
 python-versions = "*"
 groups = ["main"]
-markers = "extra == \"optimize\""
+markers = "extra == \"optimize\" or extra == \"qserver\""
 files = [
     {file = "stack_data-0.6.3-py3-none-any.whl", hash = "sha256:d5558e0c25a4cb0853cddad3d77da9891a08cb85dd9f9f91b9f8cd66e511e695"},
     {file = "stack_data-0.6.3.tar.gz", hash = "sha256:836a778de4fec4dcd1dcd89ed8abff8a221f58308462e1c4aa2a3cf30148f0b9"},
@@ -5657,6 +6426,27 @@ optree = ["optree (>=0.13.0)"]
 pyyaml = ["pyyaml"]
 
 [[package]]
+name = "tornado"
+version = "6.5.8"
+description = "Tornado is a Python web framework and asynchronous networking library, originally developed at FriendFeed."
+optional = true
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "extra == \"qserver\""
+files = [
+    {file = "tornado-6.5.8-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:cc6aa787d7cfab7c3d35189dc7a56fbd2399a569624c730c6b55b3d6531d0403"},
+    {file = "tornado-6.5.8-cp39-abi3-macosx_10_9_x86_64.whl", hash = "sha256:9715b5eb79735b2bcd454ce216a9275b7c0470e64ea1bf5742f78b2f72b26eeb"},
+    {file = "tornado-6.5.8-cp39-abi3-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:547d63f450d570c14fe0e8db2cfb14c9bbd1c2503b4a6612586267955aa47b58"},
+    {file = "tornado-6.5.8-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7e2360a0ffbe145eca8af0b19cb7203d79b1a98dd4cccdd6b368f6f49c2e3808"},
+    {file = "tornado-6.5.8-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:5d242290bdf7ab3151bc1065fdd75c0dcc21cbc7b49f22a4c56329c2d6566d22"},
+    {file = "tornado-6.5.8-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:7b94ff0e128fe0542f3bd331fb44d06260fc4ac16881545159f34ef08aad4195"},
+    {file = "tornado-6.5.8-cp39-abi3-win32.whl", hash = "sha256:67832909c4779c64942380cb5f044a5c6163d00831472d80e25e115de9917836"},
+    {file = "tornado-6.5.8-cp39-abi3-win_amd64.whl", hash = "sha256:11881db6b7c168494be2c2d12e65931451bdf7ee718535418ae1d8855dd5a0ee"},
+    {file = "tornado-6.5.8-cp39-abi3-win_arm64.whl", hash = "sha256:68a7468c7e289f8514d7d664101753903217eff1bb6822c6b5994a0b5f5bcb26"},
+    {file = "tornado-6.5.8.tar.gz", hash = "sha256:9452e1b208a8bd771e2cb1f2ff564985b9b214bdebbe622793e1799e0a6bd23f"},
+]
+
+[[package]]
 name = "tqdm"
 version = "4.67.3"
 description = "Fast, Extensible Progress Meter"
@@ -5685,7 +6475,7 @@ description = "Traitlets Python configuration system"
 optional = true
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "extra == \"optimize\""
+markers = "extra == \"optimize\" or extra == \"qserver\""
 files = [
     {file = "traitlets-5.15.1-py3-none-any.whl", hash = "sha256:770a53705f84b81ac107e83a1b3328ff2dae16094d8fc3cfc004e4b22dfd8e92"},
     {file = "traitlets-5.15.1.tar.gz", hash = "sha256:7b1c07854fe25acb39e009bae49f11b79ff6cbb2f27999104e9110e7a6b53722"},
@@ -6023,7 +6813,7 @@ description = "Measures the displayed width of unicode strings in a terminal"
 optional = true
 python-versions = ">=3.8"
 groups = ["main"]
-markers = "extra == \"optimize\""
+markers = "extra == \"optimize\" or extra == \"qserver\""
 files = [
     {file = "wcwidth-0.8.2-py3-none-any.whl", hash = "sha256:d63947694a0539a1d51e01eda7caf800c291020e6cdd7e28ad7b14dd33ad4f85"},
     {file = "wcwidth-0.8.2.tar.gz", hash = "sha256:91fbef97204b96a3d4d421609b80340b760cf33e26da123ff243d76b1fda8dda"},
@@ -6309,9 +7099,10 @@ cffi = ["cffi (>=1.17,<2.0) ; platform_python_implementation != \"PyPy\" and pyt
 analysis = ["imageanalysis"]
 ca = ["aioca"]
 optimize = ["gest-api", "imageanalysis", "scananalysis", "xopt"]
+qserver = ["bluesky-queueserver"]
 tiled = ["tiled"]
 
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<3.12"
-content-hash = "a8ca9bb0d59596a4a3583f22c76a745c70c3c7c89083136ecda7b9980f847f11"
+content-hash = "b12586b5aea43e9a1dff4b78b15db4f9d579ab650c5ab0190edd7cef0d427125"

--- a/GeecsBluesky/pyproject.toml
+++ b/GeecsBluesky/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-bluesky"
-version = "0.53.1"
+version = "0.54.0"
 description = "Bluesky / ophyd-async bridge for the GEECS control system"
 authors = ["Sam Barber <sbarber@lbl.gov>"]
 readme = "README.md"
@@ -51,11 +51,18 @@ gest-api = { version = ">=0.1", optional = true }
 # core engine never imports either.
 scananalysis = { path = "../ScanAnalysis", develop = true, optional = true }
 
+# The queueserver worker (GeecsBluesky/qserver/) — RE Manager itself, not a
+# runtime import of geecs_bluesky. Pinned to the sandbox-validated release
+# (Planning/cutover_strategy/02_queueserver_migration.md, RE Manager sandbox
+# spike, 2026-08-20).
+bluesky-queueserver = { version = "^0.0.25", optional = true }
+
 [tool.poetry.extras]
 tiled = ["tiled"]
 analysis = ["imageanalysis"]
 ca = ["aioca"]
 optimize = ["xopt", "gest-api", "scananalysis", "imageanalysis"]
+qserver = ["bluesky-queueserver"]
 
 [tool.poetry.group.dev.dependencies]
 pytest = ">=7.0"

--- a/GeecsBluesky/qserver/README.md
+++ b/GeecsBluesky/qserver/README.md
@@ -1,8 +1,15 @@
 # GEECS Queueserver Launch Assets
 
 This directory contains the user-level launch mechanics for a local
-bluesky-queueserver RE Manager. The startup profile content is intentionally
-not here; it lands with the separate plan-preamble task.
+bluesky-queueserver RE Manager, plus the startup profile itself
+(`startup/startup.py`) that turns the launched manager into a runnable GEECS
+worker: it builds the `GeecsSession`, defines the module-level `RE` the
+manager keeps alive across queue items, subscribes the Tiled/s-file/scan-log
+callbacks, registers the optimization loader when the `optimize` extra is
+installed, and exposes `geecs_scan_request_plan` — the one plan every
+`ScanRequest` (step, noscan, optimize) runs through. See
+`startup/startup.py`'s module docstring for the import-order and
+experiment-resolution contracts.
 
 ## Launch
 
@@ -42,9 +49,17 @@ qserver status
 qserver environment open
 ```
 
-The placeholder `startup/` profile contains no Python yet, so environment
-opening verifies the manager mechanics only. Plan registration and GEECS
-preamble setup arrive in the separate startup-profile task.
+Once the environment is open, `geecs_scan_request_plan` is registered and
+callable; submit a `ScanRequest` dict as its sole argument, for example:
+
+```bash
+qserver queue add plan '{"name": "geecs_scan_request_plan", "args": [{"mode": "noscan", "shots_per_step": 2, "acquisition": "free_run", "save_sets": ["UC_Test"]}], "item_type": "plan"}'
+qserver queue start
+```
+
+`QS_EXPERIMENT` (or `config.ini`'s `[Experiment] expt`) must resolve before
+the manager starts — the profile fails loud at import time otherwise (see
+`startup/startup.py`).
 
 ## Troubleshooting
 

--- a/GeecsBluesky/qserver/startup/README.md
+++ b/GeecsBluesky/qserver/startup/README.md
@@ -1,6 +1,18 @@
-Startup profile content arrives with the plan-preamble task; this directory intentionally contains no Python yet.
+`startup.py` is the bluesky-queueserver RE Manager startup profile for a
+GEECS worker. It builds the worker-wide `GeecsSession`, defines the
+module-level `RE` (see below), subscribes the Tiled/s-file/scan-log
+callbacks, registers the optimization loader when the `optimize` extra is
+installed, and registers `geecs_scan_request_plan` — the one plan every
+`ScanRequest` (step, noscan, optimize) runs through. See its module
+docstring for the import-order (`geecs_bluesky` first, before any `aioca`
+import) and experiment-resolution (`QS_EXPERIMENT` env, falling back to
+`config.ini`) contracts.
 
 The profile MUST define `RE = RunEngine({})` — the launcher passes
 `--keep-re`, and without a startup-defined RE the manager silently bounces
 every `queue start` (the failure appears only in the manager log as
-"Run Engine is not found in the RE Worker environment").
+"Run Engine is not found in the RE Worker environment"). `startup.py`
+satisfies this by exposing `session.RE` as the top-level `RE` — the plan
+preamble requires running on that exact session's RunEngine, so the two
+must be the same object rather than two independently-constructed
+RunEngines.

--- a/GeecsBluesky/qserver/startup/startup.py
+++ b/GeecsBluesky/qserver/startup/startup.py
@@ -1,0 +1,118 @@
+"""bluesky-queueserver RE Manager startup profile for a GEECS worker.
+
+Loaded by ``start-re-manager --startup-dir <this directory>`` (see
+``launch_re_manager.sh``). Defines the module-level ``RE`` the manager keeps
+alive across queue items (``--keep-re`` — see ``qserver/README.md``'s
+Troubleshooting section for the silent-bounce failure mode without it) and
+registers :func:`~geecs_bluesky.plans.scan_request_plan.geecs_scan_request_plan`,
+the one plan every ``ScanRequest`` (step, noscan, optimize) runs through.
+
+Import order is load-bearing
+-----------------------------
+``geecs_bluesky`` is imported **first**, before anything that might pull in
+``aioca``. Its ``__init__`` calls
+:func:`~geecs_bluesky.epics_env.apply_epics_address_config`, which sets
+``EPICS_CA_ADDR_LIST``/``EPICS_CA_AUTO_ADDR_LIST`` from
+``~/.config/geecs_python_api/config.ini``'s ``[epics]`` section *before* the
+device imports create libca's CA context — libca reads that env var once, at
+context creation, and never again. A gateway address sourced from the GEECS
+database instead of the config file would need a DB round trip at import
+time (a network hazard this early) and would be circular besides (the
+database itself is one of the devices CA reaches through the gateway).
+config-file/systemd-env sourcing is deliberate, not a placeholder.
+
+Experiment resolution
+----------------------
+``QS_EXPERIMENT`` wins when set (the natural queueserver/systemd knob —
+one worker process per experiment); otherwise falls back to
+``config.ini``'s ``[Experiment] expt`` via ``GeecsPathsConfig`` (the same
+default every other headless entry point in this repo uses). Neither
+present is a startup-time configuration error, not a runtime one: fail
+loud here rather than have every submitted plan fail identically later.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+
+# Must import geecs_bluesky before anything that could pull in aioca — see
+# the module docstring above.
+import geecs_bluesky  # noqa: F401
+
+from geecs_bluesky.plans.scan_request_plan import (
+    geecs_scan_request_plan,
+    set_optimization_loader,
+    set_plan_session,
+)
+from geecs_bluesky.session import GeecsSession
+from geecs_bluesky.sfile_callback import SFileExportCallback
+
+logger = logging.getLogger(__name__)
+
+
+def _resolve_experiment() -> str:
+    """``QS_EXPERIMENT`` env, falling back to ``config.ini``'s ``[Experiment]``.
+
+    Raises
+    ------
+    RuntimeError
+        Neither source yields a name — fail loud at worker startup.
+    """
+    experiment = os.environ.get("QS_EXPERIMENT")
+    if experiment:
+        return experiment
+
+    from geecs_data_utils import GeecsPathsConfig
+
+    experiment = GeecsPathsConfig().experiment
+    if experiment:
+        return experiment
+
+    raise RuntimeError(
+        "No GEECS experiment configured for this worker: set QS_EXPERIMENT "
+        "or configure [Experiment] expt in "
+        "~/.config/geecs_python_api/config.ini"
+    )
+
+
+_experiment = _resolve_experiment()
+
+# tiled=True (default): GeecsSession's own [tiled] config mechanism
+# (geecs_bluesky.tiled_integration.subscribe_tiled) subscribes a TiledWriter
+# to session.RE — best-effort, skip-with-log if the catalog is unreachable,
+# the same posture every other headless GeecsSession gets. Reused as-is
+# (not reimplemented) because session.RE, not a second RunEngine, is the
+# one this profile hands to the manager below.
+session = GeecsSession(_experiment, tiled=True)
+
+# The manager's --keep-re contract needs a top-level `RE` in this module's
+# namespace; the plan preamble's own comment (scan_request_plan.py) requires
+# running on `session.RE` specifically (a different RunEngine is
+# unsupported), so the two must be the same object rather than two
+# independently-constructed RunEngines.
+RE = session.RE
+
+set_plan_session(session)
+
+# Best-effort legacy scalar (s-file) export on every completed run — #635.
+RE.subscribe(SFileExportCallback())
+
+# scan.log's root-logger attach + pre-claim buffer (GeecsBluesky 0.51.0,
+# geecs_bluesky/scan_log.py) needs no wiring here: geecs_scan_request_plan
+# itself calls begin_pre_scan_capture() at submission and the scan_log(...)
+# context manager attaches the per-scan file handler directly to the root
+# logger at the claim. The doc's "scan-log root capture" worker-startup
+# build item is this existing mechanism relocated, not new design (see
+# Planning/cutover_strategy/02_queueserver_migration.md, "Amendments from
+# the console test-scan review").
+
+# Optimize-mode ScanRequests: registered only when the `optimize` extra's
+# heavy deps (xopt, ScanAnalysis) are importable — a headless worker without
+# them refuses optimize-mode requests loudly at the plan (see
+# set_optimization_loader's docstring) instead of failing mid-scan.
+from geecs_bluesky.optimization.worker_loader import make_worker_optimization_loader  # noqa: E402
+
+set_optimization_loader(make_worker_optimization_loader())
+
+__all__ = ["RE", "geecs_scan_request_plan"]

--- a/GeecsBluesky/qserver/startup/startup.py
+++ b/GeecsBluesky/qserver/startup/startup.py
@@ -111,8 +111,18 @@ RE.subscribe(SFileExportCallback())
 # heavy deps (xopt, ScanAnalysis) are importable — a headless worker without
 # them refuses optimize-mode requests loudly at the plan (see
 # set_optimization_loader's docstring) instead of failing mid-scan.
-from geecs_bluesky.optimization.worker_loader import make_worker_optimization_loader  # noqa: E402
+from geecs_bluesky.optimization.worker_loader import (  # noqa: E402
+    make_worker_optimization_loader,
+    warm_up_optimization_stack,
+)
 
-set_optimization_loader(make_worker_optimization_loader())
+_optimization_loader = make_worker_optimization_loader()
+set_optimization_loader(_optimization_loader)
+
+# Pre-import the stack's heavy modules (torch/botorch/xopt) off-thread now,
+# so the cold-import cost is paid here rather than freezing the worker's
+# first optimize-mode request (mirrors GEECS-Console's main.py warm-up).
+if _optimization_loader is not None:
+    warm_up_optimization_stack()
 
 __all__ = ["RE", "geecs_scan_request_plan"]

--- a/GeecsBluesky/tests/_qserver_startup_probe.py
+++ b/GeecsBluesky/tests/_qserver_startup_probe.py
@@ -1,0 +1,107 @@
+"""Subprocess probe: qserver/startup/startup.py's import order + namespace shape.
+
+Run as ``python _qserver_startup_probe.py <startup_path>`` in a **fresh**
+interpreter — that is the whole point. ``runpy.run_path`` executed
+in-process (inside the pytest session) can never actually exercise the
+module docstring's "import order is load-bearing" claim: by the time any
+test function runs, ``geecs_bluesky`` and ``aioca`` are already sitting in
+``sys.modules`` from earlier test-file collection, so the ordering
+``qserver/startup/startup.py`` itself performs is untestable in-process —
+the cache hides it either way. A subprocess starts with an empty
+``sys.modules`` (PR #644 review row 8), so a ``sys.meta_path`` finder can
+watch the *live* first-import order and catch a real regression (e.g. some
+future import creeping in ahead of ``import geecs_bluesky`` that pulls in
+``aioca`` before ``EPICS_CA_ADDR_LIST`` is set — see
+``geecs_bluesky/epics_env.py``).
+
+Prints ``PROBE_OK`` and exits 0 on success; prints ``FAIL: <reason>`` and
+exits 1 otherwise. Never raises past ``main()`` — every failure mode is a
+reported string, so the parent test gets a legible reason instead of a
+subprocess traceback dump.
+"""
+
+from __future__ import annotations
+
+import os
+import runpy
+import sys
+
+
+def _fail(reason: str) -> None:
+    print(f"FAIL: {reason}")
+    sys.exit(1)
+
+
+def main() -> None:
+    if len(sys.argv) != 2:
+        _fail(f"usage: {sys.argv[0]} <startup_path>")
+        return
+    startup_path = sys.argv[1]
+
+    import_order: list[str] = []
+    epics_addr_at_aioca_import: dict[str, str | None] = {}
+
+    class _RecordingFinder:
+        """Records first-import order of the two names that matter here.
+
+        Declines every lookup (returns ``None``) so the real finders run
+        unmodified — this only observes, it never changes what imports.
+        """
+
+        def find_spec(self, fullname, path, target=None):
+            top = fullname.split(".", 1)[0]
+            if top in ("geecs_bluesky", "aioca") and top not in import_order:
+                import_order.append(top)
+                if top == "aioca":
+                    epics_addr_at_aioca_import["EPICS_CA_ADDR_LIST"] = os.environ.get(
+                        "EPICS_CA_ADDR_LIST"
+                    )
+            return None
+
+    sys.meta_path.insert(0, _RecordingFinder())
+
+    try:
+        ns = runpy.run_path(startup_path, run_name="__not_main__")
+    except Exception as exc:
+        _fail(f"startup.py raised {exc!r}")
+        return
+
+    if import_order != ["geecs_bluesky", "aioca"]:
+        _fail(
+            f"import order was {import_order!r}, expected "
+            "['geecs_bluesky', 'aioca'] — aioca must not be importable "
+            "before geecs_bluesky sets EPICS_CA_ADDR_LIST"
+        )
+        return
+
+    if not epics_addr_at_aioca_import.get("EPICS_CA_ADDR_LIST"):
+        _fail(
+            "EPICS_CA_ADDR_LIST was not set in the environment by the time "
+            "aioca was first imported — apply_epics_address_config() ran "
+            "too late (or not at all)"
+        )
+        return
+
+    from bluesky import RunEngine
+
+    from geecs_bluesky.plans.scan_request_plan import geecs_scan_request_plan
+
+    if not isinstance(ns.get("RE"), RunEngine):
+        _fail(f"ns['RE'] is not a RunEngine: {ns.get('RE')!r}")
+        return
+    if ns["RE"] is not ns["session"].RE:
+        _fail("ns['RE'] is not ns['session'].RE — --keep-re contract broken")
+        return
+    if ns.get("geecs_scan_request_plan") is not geecs_scan_request_plan:
+        _fail("ns['geecs_scan_request_plan'] is not the real plan function")
+        return
+    if ns.get("__all__") != ["RE", "geecs_scan_request_plan"]:
+        _fail(f"ns['__all__'] was {ns.get('__all__')!r}")
+        return
+
+    print("PROBE_OK")
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/GeecsBluesky/tests/test_optimization_warmup.py
+++ b/GeecsBluesky/tests/test_optimization_warmup.py
@@ -1,0 +1,123 @@
+"""The worker startup warm-up: pre-importing the optimization stack off-thread.
+
+PR #644 review row 6. Mirrors GEECS-Console's
+``tests/test_optimization_warmup.py`` — same fake-stack/event-gated-import
+technique — adapted to ``geecs_bluesky.optimization.worker_loader``.
+
+Hermetic — the ``optimize`` extra's dependencies (xopt) are NOT installed
+in CI, where the no-op path is exercised against the real ``find_spec``
+probe; on dev machines that installed the extra, that real-probe test
+skips (the environment, not the code, decides its premise). The warm path
+runs against fake ``geecs_bluesky.optimization`` modules planted in
+``sys.modules``, and the never-blocks pin against an import stub gated on
+an event. Deliberately placed at the top level (not under
+``tests/optimization/``): that directory's ``conftest.py`` skips collection
+entirely when the ``optimize`` extra is absent, which is exactly the
+no-op branch this file must exercise in CI.
+"""
+
+from __future__ import annotations
+
+import importlib
+import logging
+import sys
+import threading
+import types
+
+import pytest
+
+from geecs_bluesky.optimization import worker_loader as worker_loader_module
+from geecs_bluesky.optimization.worker_loader import (
+    optimization_available,
+    warm_up_optimization_stack,
+)
+
+_JOIN_TIMEOUT_S = 5.0
+
+
+def _plant_fake_stack(monkeypatch) -> None:
+    """Put importable fakes at the heavy-module paths in ``sys.modules``."""
+    for name in (
+        "geecs_bluesky.optimization",
+        *worker_loader_module._HEAVY_MODULES,
+    ):
+        monkeypatch.setitem(sys.modules, name, types.ModuleType(name))
+
+
+@pytest.mark.skipif(
+    # optimization_available() is the probe under test itself — agreement
+    # by construction, and (unlike a bare dotted find_spec) it guards the
+    # ModuleNotFoundError that an absent parent package raises.
+    optimization_available(),
+    reason="the optimize extra IS installed here — the test's premise "
+    "(extra absent, as in CI) does not hold",
+)
+def test_warm_up_no_ops_without_the_extra(caplog) -> None:
+    """Extra absent (real find_spec probe): no thread, nothing logged loudly."""
+    with caplog.at_level(logging.INFO, logger=worker_loader_module.__name__):
+        assert warm_up_optimization_stack() is None
+    assert "preloaded" not in caplog.text
+
+
+def test_warm_up_imports_the_heavy_modules_and_logs(monkeypatch, caplog) -> None:
+    monkeypatch.setattr(worker_loader_module, "optimization_available", lambda: True)
+    _plant_fake_stack(monkeypatch)
+    imported: list[str] = []
+    real_import = importlib.import_module
+
+    def recording_import(name, package=None):
+        imported.append(name)
+        return real_import(name, package)
+
+    monkeypatch.setattr(importlib, "import_module", recording_import)
+
+    with caplog.at_level(logging.INFO, logger=worker_loader_module.__name__):
+        thread = warm_up_optimization_stack()
+        assert thread is not None
+        assert thread.daemon is True
+        thread.join(timeout=_JOIN_TIMEOUT_S)
+        assert not thread.is_alive()
+
+    assert imported == list(worker_loader_module._HEAVY_MODULES)
+    assert "optimization stack preloaded in" in caplog.text
+
+
+def test_warm_up_returns_immediately_while_the_import_runs(monkeypatch) -> None:
+    """The startup path never blocks: the call returns mid-import."""
+    monkeypatch.setattr(worker_loader_module, "optimization_available", lambda: True)
+    release = threading.Event()
+
+    def blocking_import(name, package=None):
+        release.wait(timeout=_JOIN_TIMEOUT_S)
+        return types.ModuleType(name)
+
+    monkeypatch.setattr(importlib, "import_module", blocking_import)
+
+    thread = warm_up_optimization_stack()
+    try:
+        # Back on the caller immediately — the import is still parked on
+        # the event, so a blocking implementation would never get here.
+        assert thread is not None
+        assert thread.is_alive()
+    finally:
+        release.set()
+        thread.join(timeout=_JOIN_TIMEOUT_S)
+    assert not thread.is_alive()
+
+
+def test_warm_up_failure_is_logged_and_swallowed(monkeypatch, caplog) -> None:
+    monkeypatch.setattr(worker_loader_module, "optimization_available", lambda: True)
+
+    def failing_import(name, package=None):
+        raise ImportError(f"boom: {name}")
+
+    monkeypatch.setattr(importlib, "import_module", failing_import)
+
+    with caplog.at_level(logging.WARNING, logger=worker_loader_module.__name__):
+        thread = warm_up_optimization_stack()
+        assert thread is not None
+        thread.join(timeout=_JOIN_TIMEOUT_S)
+        assert not thread.is_alive()
+
+    assert "optimization stack warm-up failed" in caplog.text
+    assert "preloaded" not in caplog.text

--- a/GeecsBluesky/tests/test_qserver_startup.py
+++ b/GeecsBluesky/tests/test_qserver_startup.py
@@ -1,23 +1,34 @@
 """Hermetic tests for the RE Manager startup profile (issue #640).
 
-No lab, no redis, no queueserver process: ``runpy.run_path`` executes
-``qserver/startup/startup.py`` in-process the same way the manager's worker
-would import it, with the experiment-resolution and Tiled-subscription
-config chains monkeypatched so nothing here depends on this machine's
-``~/.config/geecs_python_api/config.ini``.
+No lab, no redis, no queueserver process. Most tests here run
+``qserver/startup/startup.py`` in-process via ``runpy.run_path`` the same
+way the manager's worker would import it, with the experiment-resolution
+and Tiled-subscription config chains monkeypatched so nothing depends on
+this machine's ``~/.config/geecs_python_api/config.ini``.
+
+The import-order test is the exception: it shells out to
+``_qserver_startup_probe.py`` in a fresh interpreter. The module's own
+docstring calls the ``geecs_bluesky``-before-``aioca`` ordering
+load-bearing, but by the time any in-process test function runs, both are
+already cached in this test session's ``sys.modules`` from earlier
+collection — an in-process ``runpy.run_path`` here could never actually
+observe first-import order, only appear to.
 """
 
 from __future__ import annotations
 
+import os
 import runpy
+import subprocess
+import sys
 from pathlib import Path
 
 import pytest
-from bluesky import RunEngine
 
 STARTUP_PATH = (
     Path(__file__).resolve().parents[1] / "qserver" / "startup" / "startup.py"
 )
+_PROBE_PATH = Path(__file__).resolve().parent / "_qserver_startup_probe.py"
 
 
 @pytest.fixture(autouse=True)
@@ -36,22 +47,35 @@ def _no_tiled_subscription(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr("geecs_bluesky.session.subscribe_tiled", lambda *a, **kw: None)
 
 
-def test_startup_profile_defines_re_and_plan_headless(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """QS_EXPERIMENT resolves the experiment; RE and the plan land in the namespace."""
-    monkeypatch.setenv("QS_EXPERIMENT", "TestExp")
+def test_startup_profile_defines_re_and_plan_headless(tmp_path: Path) -> None:
+    """QS_EXPERIMENT resolves the experiment; RE and the plan land in the namespace.
 
-    ns = runpy.run_path(str(STARTUP_PATH), run_name="__not_main__")
+    Also asserts the load-bearing import order documented at the top of
+    ``qserver/startup/startup.py``: ``geecs_bluesky`` (which sets
+    ``EPICS_CA_ADDR_LIST`` from config) must be imported, and that variable
+    must be set, before ``aioca`` is first imported. Run as a subprocess so
+    both modules start uncached — see the module docstring above.
+    """
+    config_dir = tmp_path / "home" / ".config" / "geecs_python_api"
+    config_dir.mkdir(parents=True)
+    (config_dir / "config.ini").write_text("[epics]\nca_addr_list = 127.0.0.1\n")
 
-    from geecs_bluesky.plans.scan_request_plan import geecs_scan_request_plan
+    env = dict(os.environ)
+    env["QS_EXPERIMENT"] = "TestExp"
+    env["HOME"] = str(tmp_path / "home")
+    env.pop("EPICS_CA_ADDR_LIST", None)
+    env.pop("EPICS_CA_AUTO_ADDR_LIST", None)
 
-    assert isinstance(ns["RE"], RunEngine)
-    # --keep-re requires the manager's RE to be the plan preamble's RE —
-    # a second, independently-constructed RunEngine is unsupported.
-    assert ns["RE"] is ns["session"].RE
-    assert ns["geecs_scan_request_plan"] is geecs_scan_request_plan
-    assert ns["__all__"] == ["RE", "geecs_scan_request_plan"]
+    result = subprocess.run(
+        [sys.executable, str(_PROBE_PATH), str(STARTUP_PATH)],
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=60,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "PROBE_OK" in result.stdout, result.stdout + result.stderr
 
 
 def test_startup_profile_fails_loud_without_an_experiment(

--- a/GeecsBluesky/tests/test_qserver_startup.py
+++ b/GeecsBluesky/tests/test_qserver_startup.py
@@ -1,0 +1,97 @@
+"""Hermetic tests for the RE Manager startup profile (issue #640).
+
+No lab, no redis, no queueserver process: ``runpy.run_path`` executes
+``qserver/startup/startup.py`` in-process the same way the manager's worker
+would import it, with the experiment-resolution and Tiled-subscription
+config chains monkeypatched so nothing here depends on this machine's
+``~/.config/geecs_python_api/config.ini``.
+"""
+
+from __future__ import annotations
+
+import runpy
+from pathlib import Path
+
+import pytest
+from bluesky import RunEngine
+
+STARTUP_PATH = (
+    Path(__file__).resolve().parents[1] / "qserver" / "startup" / "startup.py"
+)
+
+
+@pytest.fixture(autouse=True)
+def _no_tiled_subscription(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Stub out Tiled subscription — its config chain is not hermetic.
+
+    ``subscribe_tiled`` itself already degrades gracefully off-network (a
+    bounded reachability check), but *reading* its config
+    (``geecs_data_utils.tiled_catalog.read_tiled_config``) touches the same
+    ``config.ini`` this test suite otherwise avoids entirely (see every
+    other ``GeecsSession(..., tiled=False, mock=True)`` fixture in this
+    package). Startup profile testing is about the profile's own wiring,
+    not Tiled's config resolution, so it is stubbed rather than routed
+    through a real or fake config file.
+    """
+    monkeypatch.setattr("geecs_bluesky.session.subscribe_tiled", lambda *a, **kw: None)
+
+
+def test_startup_profile_defines_re_and_plan_headless(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """QS_EXPERIMENT resolves the experiment; RE and the plan land in the namespace."""
+    monkeypatch.setenv("QS_EXPERIMENT", "TestExp")
+
+    ns = runpy.run_path(str(STARTUP_PATH), run_name="__not_main__")
+
+    from geecs_bluesky.plans.scan_request_plan import geecs_scan_request_plan
+
+    assert isinstance(ns["RE"], RunEngine)
+    # --keep-re requires the manager's RE to be the plan preamble's RE —
+    # a second, independently-constructed RunEngine is unsupported.
+    assert ns["RE"] is ns["session"].RE
+    assert ns["geecs_scan_request_plan"] is geecs_scan_request_plan
+    assert ns["__all__"] == ["RE", "geecs_scan_request_plan"]
+
+
+def test_startup_profile_fails_loud_without_an_experiment(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Neither QS_EXPERIMENT nor config.ini's [Experiment] expt: fail at import."""
+    monkeypatch.delenv("QS_EXPERIMENT", raising=False)
+
+    class _NoExperimentConfig:
+        def __init__(self, *args, **kwargs) -> None:
+            self.experiment = None
+
+    monkeypatch.setattr(
+        "geecs_data_utils.GeecsPathsConfig", _NoExperimentConfig, raising=False
+    )
+
+    with pytest.raises(RuntimeError, match="No GEECS experiment configured"):
+        runpy.run_path(str(STARTUP_PATH), run_name="__not_main__")
+
+
+def test_gen_list_of_plans_and_devices_succeeds_on_startup_dir(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """The manager's own profile-load check passes against the startup dir.
+
+    Skipped unless the optional ``qserver`` extra (``bluesky-queueserver``)
+    is installed — the default CI job (``poetry install --with dev``) does
+    not pull it in, only ``poetry install --with dev -E qserver`` does.
+    """
+    pytest.importorskip("bluesky_queueserver")
+    monkeypatch.setenv("QS_EXPERIMENT", "TestExp")
+
+    from bluesky_queueserver.manager.gen_lists import gen_list_of_plans_and_devices
+
+    out_name = "startup_existing_plans_and_devices.yaml"
+    gen_list_of_plans_and_devices(
+        startup_dir=str(STARTUP_PATH.parent),
+        file_dir=str(tmp_path),
+        file_name=out_name,
+        overwrite=True,
+    )
+
+    assert (tmp_path / out_name).exists()

--- a/GeecsBluesky/tests/test_scan_request_plan.py
+++ b/GeecsBluesky/tests/test_scan_request_plan.py
@@ -22,11 +22,14 @@ is always inside the run.
 from __future__ import annotations
 
 import configparser
+import json
+from types import SimpleNamespace
 
 import pytest
 
 pytest.importorskip("aioca")
 
+import bluesky.plan_stubs as bps  # noqa: E402
 from bluesky.utils import RunEngineInterrupted  # noqa: F401  (doc import guard)
 from ophyd_async.core import set_mock_value  # noqa: E402
 
@@ -327,8 +330,12 @@ def test_optimize_mode_without_a_loader_is_refused_loudly_after_validation(
 
     session = _mock_session()
     claims: list = []
+    # The optimize path claims via claim_scan (NOT claim_scan_number, which
+    # is the noscan/step path's claim function) — patching the wrong name
+    # here would make this tripwire pass vacuously even if the no-loader
+    # refusal moved to after the claim (row 4, PR #644 review).
     monkeypatch.setattr(
-        "geecs_bluesky.plans.scan_request_plan.claim_scan_number",
+        "geecs_bluesky.plans.scan_request_plan.claim_scan",
         lambda experiment: claims.append(experiment) or (None, None),
     )
     monkeypatch.setattr(srp, "_optimization_loader", None)
@@ -494,6 +501,484 @@ def test_optimize_mode_reaches_a_registered_loader_and_runs_the_bins(
     assert finish_calls == [True]
     assert docs.start is not None and docs.start["plan_name"] == "geecs_adaptive_scan"
     assert docs.stop is not None and docs.stop["exit_status"] == "success"
+
+
+def test_optimize_empty_effective_device_set_after_preflight_refused_pre_claim(
+    resolver, monkeypatch
+) -> None:
+    """PR #644 review row 3: an unserved-preflight that drops every device
+    must refuse *before* the claim — not fall through to
+    ``reference = detectors[0]`` after the claim and blow up with an
+    unrelated ``IndexError`` (burning a scan number for nothing).
+    """
+    import geecs_bluesky.plans.scan_request_plan as srp
+    import geecs_bluesky.scan_request_runner as runner_module
+
+    monkeypatch.setattr(
+        runner_module,
+        "make_served_set_provider",
+        lambda session: SimpleNamespace(served_by_device=lambda: {}),
+    )
+    monkeypatch.setattr(
+        srp,
+        "_optimization_loader",
+        lambda spec: SimpleNamespace(device_requirements=None),
+    )
+    claims: list = []
+    monkeypatch.setattr(
+        srp,
+        "claim_scan",
+        lambda experiment: claims.append(experiment) or (None, None),
+    )
+    session = _mock_session()
+    request = ScanRequest.model_validate(
+        dict(
+            mode="optimize",
+            shots_per_step=2,
+            acquisition="free_run",
+            save_sets=["UC_Test"],
+            optimization={
+                "variables": {"jet_z": [0.0, 1.0]},
+                "objectives": {"counts": "MAXIMIZE"},
+                "evaluator": {"module": "m", "class": "C"},
+                "generator": {"name": "bayes_default"},
+                "max_iterations": 3,
+            },
+        )
+    )
+    with pytest.raises(
+        GeecsConfigurationError, match="unserved-variables pre-flight dropped"
+    ):
+        session.RE(
+            geecs_scan_request_plan(
+                request.model_dump(), session=session, resolver=resolver
+            )
+        )
+    assert claims == [], "the preflight refusal must burn no scan number"
+
+
+# ---------------------------------------------------------------------------
+# Optimize mode: on_finish ladder, history persistence, metadata parity
+# (PR #644 review rows 1, 2, 5, 7)
+# ---------------------------------------------------------------------------
+
+
+def _optimize_request(
+    *, move_to_best_on_finish: bool = False, max_iterations: int = 5
+) -> ScanRequest:
+    return ScanRequest.model_validate(
+        dict(
+            mode="optimize",
+            shots_per_step=2,
+            acquisition="free_run",
+            save_sets=["UC_Test"],
+            optimization={
+                "variables": {"jet_z": [0.0, 1.0]},
+                "objectives": {"counts": "MAXIMIZE"},
+                "evaluator": {"module": "m", "class": "C"},
+                "generator": {"name": "bayes_default"},
+                "max_iterations": max_iterations,
+                "move_to_best_on_finish": move_to_best_on_finish,
+            },
+        )
+    )
+
+
+class _ScriptedSuggester:
+    def __init__(self, points: list[dict]) -> None:
+        self._points = list(points)
+        self.observed: list[tuple] = []
+
+    def suggest(self):
+        return self._points.pop(0) if self._points else None
+
+    def observe(self, inputs, objective_value, bin_data):
+        self.observed.append((inputs, objective_value, bin_data))
+
+
+class _RaisingSuggester(_ScriptedSuggester):
+    """Scripted points, then a crash — simulates a suggester/operator abort
+    mid-optimization (on_finish restore-on-failure tests)."""
+
+    def __init__(self, points: list[dict], fail_after: int) -> None:
+        super().__init__(points)
+        self._fail_after = fail_after
+        self._calls = 0
+
+    def suggest(self):
+        self._calls += 1
+        if self._calls > self._fail_after:
+            raise RuntimeError("suggester exploded")
+        return super().suggest()
+
+
+def _track_mv_and_rd(monkeypatch):
+    """Wrap ``bluesky.plan_stubs.mv``/``rd`` to record calls without
+    changing behavior — ``bps.mv``/``bps.rd`` are shared module functions
+    used by both the plan body and ``geecs_adaptive_scan``, so this must
+    wrap-and-delegate rather than replace.
+    """
+    real_mv = bps.mv
+    real_rd = bps.rd
+    mv_calls: list[tuple] = []
+    rd_calls: list[tuple] = []
+
+    def mv_wrapper(*args, **kwargs):
+        mv_calls.append(args)
+        return (yield from real_mv(*args, **kwargs))
+
+    def rd_wrapper(obj, *args, **kwargs):
+        value = yield from real_rd(obj, *args, **kwargs)
+        rd_calls.append((obj, value))
+        return value
+
+    monkeypatch.setattr(bps, "mv", mv_wrapper)
+    monkeypatch.setattr(bps, "rd", rd_wrapper)
+    return mv_calls, rd_calls
+
+
+def _run_optimize_with_bridge(
+    session,
+    resolver,
+    request,
+    monkeypatch,
+    *,
+    suggester,
+    objective,
+    scan_folder=None,
+    finish_calls: list | None = None,
+    bind_calls: list | None = None,
+):
+    """Drive ``geecs_scan_request_plan`` through optimize mode with a
+    scripted bridge; returns ``(docs, finish_calls, bind_calls)``.
+
+    *finish_calls*/*bind_calls* may be passed in by the caller so they stay
+    inspectable even when the run raises (an abort/failure test cannot rely
+    on this function's return value).
+    """
+    import geecs_bluesky.plans.scan_request_plan as srp
+
+    if finish_calls is None:
+        finish_calls = []
+    if bind_calls is None:
+        bind_calls = []
+    monkeypatch.setattr(
+        srp,
+        "claim_scan",
+        lambda experiment: (
+            None,
+            str(scan_folder) if scan_folder is not None else None,
+        ),
+    )
+    pacers: list = []
+
+    class FakeBridge:
+        device_requirements = None
+
+        def bind(self, devices, scan_tag, scan_folder):
+            bind_calls.append(
+                {"devices": devices, "scan_tag": scan_tag, "scan_folder": scan_folder}
+            )
+            for device in devices:
+                if hasattr(device, "acq_timestamp"):
+                    set_mock_value(device.acq_timestamp, 1000.0)
+                    pacers.append(
+                        start_pacer(
+                            session.RE,
+                            [(device, 1000.0)],
+                            initial_delay=1.0,
+                            interval=0.15,
+                        )
+                    )
+            return objective, suggester
+
+        def finish(self):
+            finish_calls.append(True)
+
+    monkeypatch.setattr(srp, "_optimization_loader", lambda spec: FakeBridge())
+
+    docs = _DocCollector()
+    token = session.RE.subscribe(docs)
+    try:
+        session.RE(
+            geecs_scan_request_plan(
+                request.model_dump(), session=session, resolver=resolver
+            )
+        )
+    finally:
+        for pacer in pacers:
+            pacer.cancel()
+        session.RE.unsubscribe(token)
+        session.RE.msg_hook = None
+    return docs, finish_calls, bind_calls
+
+
+def test_optimize_on_finish_best_moves_to_the_best_observed_inputs(
+    resolver, monkeypatch
+) -> None:
+    """PR #644 review row 1: move_to_best_on_finish selects the
+    best-observed inputs across the whole run, not just the last suggested
+    point."""
+    session = _mock_session()
+    mv_calls, _rd_calls = _track_mv_and_rd(monkeypatch)
+    suggester = _ScriptedSuggester([{"jet_z": 0.1}, {"jet_z": 0.4}, {"jet_z": 0.7}])
+    values = iter([1.0, 5.0, 2.0])  # best is the *middle* point, not the last
+
+    def objective(bin_data):
+        return next(values)
+
+    request = _optimize_request(move_to_best_on_finish=True)
+    docs, finish_calls, _bind_calls = _run_optimize_with_bridge(
+        session,
+        resolver,
+        request,
+        monkeypatch,
+        suggester=suggester,
+        objective=objective,
+    )
+    assert docs.stop is not None and docs.stop["exit_status"] == "success"
+    assert len(mv_calls) == 4  # 3 suggested moves + the final move-to-best
+    assert mv_calls[-1][1] == pytest.approx(0.4)
+    assert finish_calls == [True]
+
+
+def test_optimize_on_finish_best_falls_back_to_initial_when_no_finite_objective(
+    resolver, monkeypatch, caplog
+) -> None:
+    """PR #644 review row 1: if every objective evaluation came back
+    non-finite, on_finish=best falls back to the initial values (with a
+    WARNING) instead of silently moving to nan."""
+    import logging
+
+    session = _mock_session()
+    mv_calls, rd_calls = _track_mv_and_rd(monkeypatch)
+    suggester = _ScriptedSuggester([{"jet_z": 0.1}, {"jet_z": 0.4}])
+
+    def objective(bin_data):
+        raise RuntimeError("evaluator is down")
+
+    request = _optimize_request(move_to_best_on_finish=True)
+    with caplog.at_level(logging.WARNING):
+        docs, finish_calls, _bind_calls = _run_optimize_with_bridge(
+            session,
+            resolver,
+            request,
+            monkeypatch,
+            suggester=suggester,
+            objective=objective,
+        )
+    assert docs.stop is not None and docs.stop["exit_status"] == "success"
+    initial_value = rd_calls[0][1]
+    assert mv_calls[-1][1] == pytest.approx(initial_value)
+    assert any("no finite objectives" in r.message for r in caplog.records)
+    assert finish_calls == [True]
+
+
+def test_optimize_on_finish_best_restores_initial_on_failure_and_skips_finish(
+    resolver, monkeypatch, tmp_path
+) -> None:
+    """PR #644 review rows 1 + 5 (negative): a hard failure/abort restores
+    the *initial* values (never best-so-far) before re-raising, writes no
+    optimization.json, and never calls the bridge's finish()."""
+    session = _mock_session()
+    mv_calls, rd_calls = _track_mv_and_rd(monkeypatch)
+    suggester = _RaisingSuggester([{"jet_z": 0.1}], fail_after=1)
+
+    def objective(bin_data):
+        return 5.0
+
+    scan_folder = tmp_path / "Scan007"
+    scan_folder.mkdir()
+    finish_calls: list = []
+    request = _optimize_request(move_to_best_on_finish=True)
+    with pytest.raises(RuntimeError, match="suggester exploded"):
+        _run_optimize_with_bridge(
+            session,
+            resolver,
+            request,
+            monkeypatch,
+            suggester=suggester,
+            objective=objective,
+            scan_folder=scan_folder,
+            finish_calls=finish_calls,
+        )
+    initial_value = rd_calls[0][1]
+    assert mv_calls[-1][1] == pytest.approx(initial_value)
+    assert not (scan_folder / "optimization.json").exists()
+    assert finish_calls == []
+
+
+def test_optimize_on_finish_hold_never_moves(resolver, monkeypatch) -> None:
+    """PR #644 review row 5: on_finish left unset (move_to_best_on_finish
+    False) means the plan never issues an extra move, in any outcome — the
+    variables stay wherever the suggester last set them."""
+    session = _mock_session()
+    mv_calls, _rd_calls = _track_mv_and_rd(monkeypatch)
+    suggester = _ScriptedSuggester([{"jet_z": 0.1}, {"jet_z": 0.4}])
+
+    def objective(bin_data):
+        return 5.0
+
+    request = _optimize_request(move_to_best_on_finish=False)
+    docs, finish_calls, _bind_calls = _run_optimize_with_bridge(
+        session,
+        resolver,
+        request,
+        monkeypatch,
+        suggester=suggester,
+        objective=objective,
+    )
+    assert docs.stop is not None and docs.stop["exit_status"] == "success"
+    assert len(mv_calls) == 2  # exactly the 2 suggested moves, no extra move
+    assert mv_calls[-1][1] == pytest.approx(0.4)
+    assert finish_calls == [True]
+
+
+def test_optimize_persists_history_to_optimization_json(
+    resolver, monkeypatch, tmp_path
+) -> None:
+    """PR #644 review row 2: optimization.json persistence is gated on a
+    real scan folder + non-empty history — exercised here with an actual
+    tmp folder (the ``claim_scan`` stub used elsewhere in this file returns
+    ``(None, None)``, which never reaches this code path at all)."""
+    session = _mock_session()
+    scan_folder = tmp_path / "Scan007"
+    scan_folder.mkdir()
+    suggester = _ScriptedSuggester([{"jet_z": 0.1}, {"jet_z": 0.4}])
+    values = iter([1.0, 5.0])
+
+    def objective(bin_data):
+        return next(values)
+
+    request = _optimize_request(move_to_best_on_finish=False)
+    docs, _finish_calls, _bind_calls = _run_optimize_with_bridge(
+        session,
+        resolver,
+        request,
+        monkeypatch,
+        suggester=suggester,
+        objective=objective,
+        scan_folder=scan_folder,
+    )
+    assert docs.stop is not None and docs.stop["exit_status"] == "success"
+    history_path = scan_folder / "optimization.json"
+    assert history_path.exists()
+    history = json.loads(history_path.read_text())
+    assert [h["inputs"] for h in history] == [{"jet_z": 0.1}, {"jet_z": 0.4}]
+    assert [h["objective"] for h in history] == [pytest.approx(1.0), pytest.approx(5.0)]
+
+
+def test_optimize_mode_records_db_scan_runtime_metadata(
+    configs_root, resolver, monkeypatch
+) -> None:
+    """PR #644 review row 7: metadata parity between the plan's optimize
+    body and the binder path's ``_run_optimize_request`` — ``db_scan_runtime``
+    must land in the optimize start doc too, not just the noscan/step one.
+    No existing test on either entry point asserted this positively before.
+    """
+    session = _mock_session()
+    suggester = _ScriptedSuggester([{"jet_z": 0.1}])
+
+    def objective(bin_data):
+        return 1.0
+
+    request = _optimize_request(move_to_best_on_finish=False)
+    docs, _finish_calls, _bind_calls = _run_optimize_with_bridge(
+        session,
+        resolver,
+        request,
+        monkeypatch,
+        suggester=suggester,
+        objective=objective,
+    )
+    assert docs.start is not None
+    assert docs.start["db_scan_runtime"] == {
+        "db_scalars": "applied",
+        "background_telemetry": "not_run_in_optimize",
+    }
+
+
+def test_optimize_mode_threads_applied_defaults_into_run_wrapper_metadata(
+    configs_root, resolver, monkeypatch
+) -> None:
+    """PR #644 review row 7: ``applied_defaults`` provenance must reach
+    ``geecs_run_wrapper``'s ``extra_md`` on the optimize path the same way
+    it reaches ``build_step_scan_spec``'s ``md`` on the noscan/step path.
+
+    This spies on the ``extra_md`` handed to ``geecs_run_wrapper`` rather
+    than asserting on the real start doc, and sanitizes the dotted
+    ``"actions.setup"`` key before letting the (otherwise unmodified) call
+    proceed. An actions-based default is the only hermetic way to populate
+    ``applied_defaults`` in optimize mode — a ``trigger_profile`` default
+    would construct a real, network-backed ``ShotController`` that a mock
+    session cannot satisfy — but real ``event_model.compose_run`` schema
+    validation (only exercised here, never by the ``_FakeSession``
+    binder-path tests) rejects any top-level start-doc key containing
+    ``.``/``/``, so running the dotted key through unmodified would fail
+    for a reason unrelated to what this test checks. That rejection is a
+    real, pre-existing gap shared by both plan paths (`apply_experiment_
+    defaults` in ``scan_request_runner.py`` is what produces the dotted
+    key, for both step/noscan and optimize) — flagged to the coordinator
+    separately rather than fixed here, since sanitizing it one-sidedly on
+    the optimize path would itself break the parity this test checks.
+    """
+    import geecs_bluesky.plans.scan_request_plan as srp
+
+    (configs_root / "LegacyExp" / "experiment_defaults.yaml").write_text(
+        "actions:\n  setup: [close_shutters]\n"
+    )
+    session = _mock_session()
+    suggester = _ScriptedSuggester([{"jet_z": 0.1}])
+
+    def objective(bin_data):
+        return 1.0
+
+    request = _optimize_request(move_to_best_on_finish=False)
+
+    captured_extra_md: dict = {}
+    real_geecs_run_wrapper = srp.geecs_run_wrapper
+    real_geecs_adaptive_scan = srp.geecs_adaptive_scan
+
+    def _sanitize(md: dict) -> dict:
+        # ``applied_defaults`` keys are dotted (e.g. "actions.setup") by
+        # convention (see apply_experiment_defaults in scan_request_runner.py)
+        # — real event-model schema validation rejects dots in ANY top-level
+        # start-doc key, and validates ``applied_defaults``'s own keys under
+        # that same rule. Only the nested keys need sanitizing here.
+        sanitized = dict(md)
+        if "applied_defaults" in sanitized:
+            sanitized["applied_defaults"] = {
+                k.replace(".", "_"): v for k, v in sanitized["applied_defaults"].items()
+            }
+        return sanitized
+
+    def spy_geecs_run_wrapper(plan, **kwargs):
+        extra_md = kwargs.get("extra_md") or {}
+        captured_extra_md.update(extra_md)
+        kwargs["extra_md"] = _sanitize(extra_md)
+        return real_geecs_run_wrapper(plan, **kwargs)
+
+    def spy_geecs_adaptive_scan(**kwargs):
+        md = kwargs.get("md") or {}
+        captured_extra_md.update(md)
+        kwargs["md"] = _sanitize(md)
+        return real_geecs_adaptive_scan(**kwargs)
+
+    monkeypatch.setattr(srp, "geecs_run_wrapper", spy_geecs_run_wrapper)
+    monkeypatch.setattr(srp, "geecs_adaptive_scan", spy_geecs_adaptive_scan)
+
+    docs, _finish_calls, _bind_calls = _run_optimize_with_bridge(
+        session,
+        resolver,
+        request,
+        monkeypatch,
+        suggester=suggester,
+        objective=objective,
+    )
+    assert docs.start is not None
+    assert captured_extra_md["applied_defaults"] == {
+        "actions.setup": ["close_shutters"]
+    }
 
 
 def test_no_session_configured_is_a_clear_error(resolver) -> None:

--- a/GeecsBluesky/tests/test_scan_request_plan.py
+++ b/GeecsBluesky/tests/test_scan_request_plan.py
@@ -319,16 +319,19 @@ def test_strict_without_trigger_profile_refuses_before_claim(
     assert claims == []
 
 
-def test_optimize_mode_is_refused_loudly_after_validation(
+def test_optimize_mode_without_a_loader_is_refused_loudly_after_validation(
     resolver, monkeypatch
 ) -> None:
-    """Optimize relocates in a later round (decision 5): validated, refused."""
+    """No loader registered (W2): validated, then refused — never silently."""
+    from geecs_bluesky.plans import scan_request_plan as srp
+
     session = _mock_session()
     claims: list = []
     monkeypatch.setattr(
         "geecs_bluesky.plans.scan_request_plan.claim_scan_number",
         lambda experiment: claims.append(experiment) or (None, None),
     )
+    monkeypatch.setattr(srp, "_optimization_loader", None)
     request = ScanRequest.model_validate(
         dict(
             mode="optimize",
@@ -344,7 +347,7 @@ def test_optimize_mode_is_refused_loudly_after_validation(
             },
         )
     )
-    with pytest.raises(NotImplementedError, match="optimize"):
+    with pytest.raises(GeecsConfigurationError, match="set_optimization_loader"):
         session.RE(
             geecs_scan_request_plan(
                 request.model_dump(), session=session, resolver=resolver
@@ -366,6 +369,131 @@ def test_optimize_mode_is_refused_loudly_after_validation(
                 bad.model_dump(), session=session, resolver=resolver
             )
         )
+
+
+def test_optimize_mode_reaches_a_registered_loader_and_runs_the_bins(
+    resolver, monkeypatch
+) -> None:
+    """With a loader registered, the request reaches it and its objective/
+    suggester drive the run — the W2 seam close (issue #640)."""
+    import geecs_bluesky.plans.scan_request_plan as srp
+    from geecs_bluesky.optimize import BinData
+
+    session = _mock_session()
+    monkeypatch.setattr(
+        "geecs_bluesky.plans.scan_request_plan.claim_scan",
+        lambda experiment: (None, None),
+    )
+
+    bind_calls: list[dict] = []
+    finish_calls: list[bool] = []
+
+    class ScriptedSuggester:
+        def __init__(self) -> None:
+            self._points = [{"jet_z": 0.1}, {"jet_z": 0.4}]
+            self.observed: list[tuple] = []
+
+        def suggest(self):
+            return self._points.pop(0) if self._points else None
+
+        def observe(self, inputs, objective_value, bin_data):
+            self.observed.append((inputs, objective_value, bin_data))
+
+    suggester = ScriptedSuggester()
+
+    def objective(bin_data: BinData) -> float:
+        # A real (non-stub) value derived from the bin's actual collected
+        # rows — proves the bridge's objective ran against real event data
+        # threaded through by the plan, not a canned return.
+        return float(len(bin_data.rows))
+
+    pacers: list = []
+
+    class FakeBridge:
+        device_requirements = None
+
+        def bind(self, devices, scan_tag, scan_folder):
+            bind_calls.append(
+                {
+                    "devices": devices,
+                    "scan_tag": scan_tag,
+                    "scan_folder": scan_folder,
+                }
+            )
+            # geecs_adaptive_scan's t0 sync runs before any staging message —
+            # devices are already connected by this point (bind() is called
+            # after in-plan connects, before the adaptive-scan plan starts),
+            # so this is the last hook available to seed acq_timestamp before
+            # geecs_t0_sync reads it.
+            for device in devices:
+                if hasattr(device, "acq_timestamp"):
+                    set_mock_value(device.acq_timestamp, 1000.0)
+                    pacers.append(
+                        start_pacer(
+                            session.RE,
+                            [(device, 1000.0)],
+                            initial_delay=1.0,
+                            interval=0.15,
+                        )
+                    )
+            return objective, suggester
+
+        def finish(self):
+            finish_calls.append(True)
+
+    loader_calls: list = []
+
+    def fake_loader(spec):
+        loader_calls.append(spec)
+        return FakeBridge()
+
+    monkeypatch.setattr(srp, "_optimization_loader", fake_loader)
+    request = ScanRequest.model_validate(
+        dict(
+            mode="optimize",
+            shots_per_step=2,
+            acquisition="free_run",
+            save_sets=["UC_Test"],
+            optimization={
+                "variables": {"jet_z": [0.0, 1.0]},
+                "objectives": {"counts": "MAXIMIZE"},
+                "evaluator": {"module": "m", "class": "C"},
+                "generator": {"name": "bayes_default"},
+                "max_iterations": 5,
+            },
+        )
+    )
+    docs = _DocCollector()
+    token = session.RE.subscribe(docs)
+    try:
+        session.RE(
+            geecs_scan_request_plan(
+                request.model_dump(), session=session, resolver=resolver
+            )
+        )
+    finally:
+        for pacer in pacers:
+            pacer.cancel()
+        session.RE.unsubscribe(token)
+
+    assert len(loader_calls) == 1
+    assert loader_calls[0].model_dump() == request.optimization.model_dump()
+    assert len(bind_calls) == 1
+    assert bind_calls[0]["scan_tag"] is None and bind_calls[0]["scan_folder"] is None
+    # The suggester's two scripted points both ran, and observed a real
+    # objective value computed from the bin's actual collected rows — proof
+    # the binder's objective/suggester threaded into the run, not a stub.
+    assert [inputs for inputs, _, _ in suggester.observed] == [
+        {"jet_z": 0.1},
+        {"jet_z": 0.4},
+    ]
+    assert [value for _, value, _ in suggester.observed] == [
+        pytest.approx(request.shots_per_step),
+        pytest.approx(request.shots_per_step),
+    ]
+    assert finish_calls == [True]
+    assert docs.start is not None and docs.start["plan_name"] == "geecs_adaptive_scan"
+    assert docs.stop is not None and docs.stop["exit_status"] == "success"
 
 
 def test_no_session_configured_is_a_clear_error(resolver) -> None:


### PR DESCRIPTION
## Summary

Closes #640 (queueserver migration, round 2): builds the RE Manager startup
profile and closes the deferred cross-vendor optimize-mode seam.

- **`qserver/startup/startup.py`** (new): imports `geecs_bluesky` first
  (before any `aioca` import — sets `EPICS_CA_ADDR_LIST`/`EPICS_CA_AUTO_ADDR_LIST`
  from `config.ini` before libca's CA context is created), resolves the
  experiment from `QS_EXPERIMENT` (falling back to `config.ini`'s
  `[Experiment] expt`, failing loud at import time if neither yields a
  name), builds `GeecsSession(experiment, tiled=True)`, exposes `session.RE`
  as the module-level `RE` the manager keeps alive across queue items
  (`--keep-re` requires this — see the startup README's failure-mode note),
  subscribes `SFileExportCallback` (#635) and the session's own best-effort
  Tiled subscription, and registers `geecs_scan_request_plan`.
- **`geecs_bluesky/plans/scan_request_plan.py`** (optimize seam only):
  `set_optimization_loader()` installs a worker-wide loader; the OPTIMIZE
  branch now invokes it in-plan (worker-side deferred-connect construction,
  unserved-vars preflight merged with the loader's `device_requirements`,
  the claim boundary, then `geecs_adaptive_scan` wrapped the same way
  `GeecsSession.optimize` wraps it) instead of the old `NotImplementedError`
  refusal. No loader registered still refuses loudly — never silent
  degradation.
- **`geecs_bluesky/optimization/worker_loader.py`** (new): the loader
  implementation (`OptimizationSpec` → `SessionOptimizationBridge` via
  `BaseOptimizer.from_config`), modeled on GEECS-Console's
  `services/optimization.py` but independently implemented — imports
  nothing from GEECS-Console. `optimization_available()` gates registration
  on `xopt`/`scan_analysis` being importable.
- New optional extra `qserver = ["bluesky-queueserver"]` pinned `^0.0.25`;
  `poetry.lock` refreshed to match (purely additive — new transitive deps
  from `bluesky-queueserver` plus marker updates on already-shared deps;
  no existing package version changed, confirmed via diff).
- `qserver/README.md` / `qserver/startup/README.md` updated, placeholder
  language dropped.

### Per-concern LOC breakdown

- Startup profile + its README + worker_loader.py: new files, ~230 LOC
- Optimize seam in `scan_request_plan.py`: ~350 LOC (the loader hookup +
  the in-plan ask/move/bin/objective/tell loop body, mirroring
  `GeecsSession.optimize`'s existing shape)
- Tests: `test_qserver_startup.py` (new, 3 tests) + `test_scan_request_plan.py`
  additions (2 tests) — ~215 LOC
- `pyproject.toml` + `poetry.lock` + `CHANGELOG.md`: mechanical

## File-ownership contract (per #640)

Touched only: `qserver/**`, `geecs_bluesky/plans/scan_request_plan.py`
(optimize-seam only), new tests, `pyproject.toml`, `poetry.lock`,
`CHANGELOG.md`. Did not touch `session.py`, `scanner_bridge/`,
`plans/orchestration.py`/`step_scan.py`/`free_run_step_scan.py`,
GEECS-Console, or geecs-core.

## Tests (hermetic — no lab, no redis)

`GeecsBluesky`: **661 passed, 1 skipped (pre-existing), 3 deselected**
(`poetry run pytest -q`, with the `qserver` extra installed so all 3
`test_qserver_startup.py` cases execute rather than skip). Lint
(`./scripts/check.sh --lint`) clean.

New coverage:
- `test_qserver_startup.py` (new): startup profile defines `RE`/
  `geecs_scan_request_plan` headlessly with `QS_EXPERIMENT` set and a
  stubbed Tiled subscription; fails loud (`RuntimeError`) with neither
  `QS_EXPERIMENT` nor a resolvable `config.ini` experiment; `bluesky_queueserver`'s
  own `gen_list_of_plans_and_devices` succeeds against `qserver/startup/`
  — this last case is skipped when the `qserver` extra isn't installed
  (CI's default `poetry install --with dev` does not install it).
- `test_scan_request_plan.py`: renamed/updated
  `test_optimize_mode_without_a_loader_is_refused_loudly_after_validation`
  (loud refusal still stands, existing test updated not deleted) plus new
  `test_optimize_mode_reaches_a_registered_loader_and_runs_the_bins` — a
  fake loader/bridge drives a scripted suggester through real bins with
  mock CA backends. Notable wrinkle: `geecs_adaptive_scan`'s t0 sync runs
  *before* any staging message (unlike the step/noscan path, which sits
  inside `bpp.stage_wrapper`), so the existing `_install_stage_pacer`
  "stage"-triggered test helper fires too late for this path. The fix
  seeds/paces mock `acq_timestamp` from inside the fake bridge's
  `bind(devices=...)` call instead — devices are already connected by
  that point (bind() runs after in-plan connects, before the adaptive-scan
  generator starts), which is the last hook available ahead of the t0 sync
  read.

## Hardware verification

**OWED** — this PR is code-complete and hermetically tested only. Owed
before/at the coordinator's live checkpoint:
- `start-re-manager --startup-dir qserver/startup/` actually boots against
  a real `QS_EXPERIMENT` and gateway, `--keep-re` holds across two queued
  plans (no "Run Engine is not found" bounce)
- A real `qserver queue add plan 'geecs_scan_request_plan' ...` /
  `queue start` round-trip against live devices (step, noscan, and — if
  the `optimize` extra is installed on that worker — optimize mode)
- SFileExportCallback and Tiled actually receive documents from a
  manager-run scan (this PR only exercises the subscription wiring, not a
  live write)

## Not merging this myself

Per repo convention, `feat/queueserver` merges are coordinator-handled.
Reporting as ready-to-merge once the adversarial review (below) is
dispositioned and CI is green.