### PR TITLE
GeecsBluesky 0.54.0: qs/W3 pause semantics — quiesce-on-pause, hard-pause replay audit, failed-move retry (#641)

### DIFF
--- a/GeecsBluesky/CHANGELOG.md
+++ b/GeecsBluesky/CHANGELOG.md
@@ -32,20 +32,32 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
     pre-move checkpoint** — the retry, at the same absolute target
     (`pause` is uncacheable, so the pause itself never replays); a retry
     that fails pauses again; stop ends the run gracefully through the
-    finalize chain.
+    finalize chain.  Gated behind a new `failed_move_policy: "raise" |
+    "pause"` flag on `geecs_step_scan` / `geecs_free_run_step_scan` /
+    `build_step_scan_plan`, **default `"raise"`** — exact pre-#641
+    behavior, so the bridge/console path (which does not pass the flag)
+    is unaffected, sidestepping both the coexisting pause supervisor's
+    auto-resume-on-failed-move loop and the related stop-from-paused
+    bypass (cross-vendor review on #645; the queueserver-side opt-in wires
+    up separately once `plans/scan_request_plan.py`'s parallel PR merges).
 
 ### Changed
 
 - **Checkpoint placement is now a hard-pause replay contract** (the #641
   audit): both step plans add a post-move checkpoint (a replayed per-step
-  action prefix no longer re-runs the move) and a post-rows checkpoint (a
-  bin's last completed row can no longer replay into the disarm window —
-  previously a hard pause there duplicated the event row and re-fired the
-  shot); the free-run plan adds a post-flush checkpoint (the tail-flush
-  event can no longer replay into the finalize chain).  A rewind-cache
-  reconstruction walk over both plans' message streams pins the invariant
+  action prefix no longer re-runs the move), a post-per_step checkpoint
+  (a replayed arm can no longer drag a completed ActionPlan write along
+  with it — cross-vendor review on #645, item P1; the residual mid-action
+  pause is documented as irreducible, same class as strict's bounded
+  refire), and a post-rows checkpoint (a bin's last completed row can no
+  longer replay into the disarm window — previously a hard pause there
+  duplicated the event row and re-fired the shot); the free-run plan adds
+  a post-flush checkpoint (the tail-flush event can no longer replay into
+  the finalize chain).  A rewind-cache reconstruction walk over both
+  plans' message streams pins the invariant
   (`tests/test_pause_semantics.py`); deferred-pause behavior is unchanged
   (still lands at the next checkpoint, still replays nothing).
+
 ## [0.53.1] - 2026-08-20
 
 ### Added

--- a/GeecsBluesky/CHANGELOG.md
+++ b/GeecsBluesky/CHANGELOG.md
@@ -4,6 +4,48 @@ All notable changes to `geecs-bluesky` are documented here.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.54.0] - 2026-08-20
+
+### Added
+
+- **Plan-level pause semantics for the queueserver world** (issue #641;
+  decisions 1 + 4 of `Planning/cutover_strategy/02_queueserver_migration.md`
+  — the pause supervisor's successors, ahead of its Round-3 deletion):
+  - **Quiesce-on-pause** (`plans/pause_semantics.py`):
+    `ShotControlPauseQuiescer` rides the RunEngine's `Pausable` device
+    notification — the one seam covering both operator pause verbs *and*
+    the in-plan failed-move pause, with `RunEngine.resume()` awaiting the
+    re-assert **before** the rewind replay runs.  Pausing from a
+    free-running standing state (`SCAN`/`STANDBY`) drives the shot
+    controller's `OFF` writes (profile order, each completing first);
+    resume re-asserts the interrupted state.  `ARMED` (strict) is
+    deliberately skipped — already quiescent by construction (pinned);
+    a trigger profile without `OFF` writes draws a loud warning instead
+    of a silent no-quiesce.  `build_step_scan_plan` registers the
+    quiescer as the composed plan's first message whenever it has a
+    controller — both front doors get it for free.
+  - **Failed-move → pause** (`move_with_failed_move_pause`, wired at both
+    step plans' move sites): a failed move status records its reason as
+    the documented `FAILED MOVE - pausing for operator: ...` ERROR line
+    (scan.log captures it via the root-logger handler) and issues a hard
+    `bps.pause()`.  Resume **replays the failed `set`/`wait` from the
+    pre-move checkpoint** — the retry, at the same absolute target
+    (`pause` is uncacheable, so the pause itself never replays); a retry
+    that fails pauses again; stop ends the run gracefully through the
+    finalize chain.
+
+### Changed
+
+- **Checkpoint placement is now a hard-pause replay contract** (the #641
+  audit): both step plans add a post-move checkpoint (a replayed per-step
+  action prefix no longer re-runs the move) and a post-rows checkpoint (a
+  bin's last completed row can no longer replay into the disarm window —
+  previously a hard pause there duplicated the event row and re-fired the
+  shot); the free-run plan adds a post-flush checkpoint (the tail-flush
+  event can no longer replay into the finalize chain).  A rewind-cache
+  reconstruction walk over both plans' message streams pins the invariant
+  (`tests/test_pause_semantics.py`); deferred-pause behavior is unchanged
+  (still lands at the next checkpoint, still replays nothing).
 ## [0.53.1] - 2026-08-20
 
 ### Added

--- a/GeecsBluesky/geecs_bluesky/plans/free_run_step_scan.py
+++ b/GeecsBluesky/geecs_bluesky/plans/free_run_step_scan.py
@@ -51,7 +51,7 @@ from geecs_bluesky.devices.scan_context import ScanContext
 from geecs_bluesky.devices.shot_id import ShotIdSupport
 from geecs_bluesky.plans.step_scan import (
     motor_md,
-    move_changed_axes,
+    move_with_failed_move_pause,
     normalize_motors,
 )
 from geecs_bluesky.plans.t0_sync import geecs_t0_sync
@@ -256,14 +256,20 @@ def geecs_free_run_step_scan(
         scan_event_index = 0
         previous: tuple | None = None
         for bin_number, pos in enumerate(_positions, start=1):
-            # Deferred-pause boundary (issue #552): a checkpoint before the
-            # move and before every row means request_pause(defer=True)
-            # lands with an empty rewind cache — resume replays nothing.
-            # A between-rows pause sits inside a SCAN window; the pause
-            # supervisor owns driving the trigger to a safe state there.
+            # Checkpoint placement is a pause contract (issues #552/#641) —
+            # the full rationale lives in geecs_step_scan (same layout).
+            # Free-run specifics: the pre-move checkpoint sits in the
+            # disarmed STANDBY window, but the per-row checkpoints sit
+            # INSIDE the SCAN window — a pause landing there (either verb)
+            # relies on the ShotControlPauseQuiescer (pause_semantics) to
+            # stop the trigger; plan structure alone cannot make those
+            # windows quiescent without whole-bin pause latency.
             yield from bps.checkpoint()
             if _motors and pos is not None:
-                previous = yield from move_changed_axes(_motors, pos, previous)
+                previous = yield from move_with_failed_move_pause(
+                    _motors, pos, previous
+                )
+            yield from bps.checkpoint()
             if per_step is not None:
                 # After the move, before arming: per-step actions run with
                 # the shot controller disarmed (outside the SCAN window).
@@ -289,6 +295,11 @@ def geecs_free_run_step_scan(
                     )
                 if scan_event_index == 1:
                     _t0_seed_check(detectors)
+            # Post-rows checkpoint: the bin's last completed row must never
+            # sit in a hard-pause replay landing in the disarm window
+            # (re-saving it would duplicate the event row) — see
+            # geecs_step_scan's placement rationale.
+            yield from bps.checkpoint()
             if disarm_trigger is not None:
                 yield from disarm_trigger()
         # End of scan: stop the trigger BEFORE the tail machinery — STANDBY
@@ -303,6 +314,10 @@ def geecs_free_run_step_scan(
             for dev in _read_devices:
                 yield from bps.read(dev)
             yield from bps.save()
+            # Post-flush checkpoint: a hard pause during the finalize chain
+            # must not replay the completed flush event (or the end quiesce)
+            # into the cleanup path.
+            yield from bps.checkpoint()
 
     _end_quiesced = {"done": False}
 

--- a/GeecsBluesky/geecs_bluesky/plans/free_run_step_scan.py
+++ b/GeecsBluesky/geecs_bluesky/plans/free_run_step_scan.py
@@ -41,7 +41,7 @@ from __future__ import annotations
 
 import logging
 import time
-from typing import Any, Callable, Iterable, Sequence
+from typing import Any, Callable, Iterable, Literal, Sequence
 
 import bluesky.plan_stubs as bps
 import bluesky.preprocessors as bpp
@@ -51,6 +51,7 @@ from geecs_bluesky.devices.scan_context import ScanContext
 from geecs_bluesky.devices.shot_id import ShotIdSupport
 from geecs_bluesky.plans.step_scan import (
     motor_md,
+    move_changed_axes,
     move_with_failed_move_pause,
     normalize_motors,
 )
@@ -98,6 +99,7 @@ def geecs_free_run_step_scan(
     enable_saving: Callable | None = None,
     t0_sync_window_s: float = 0.2,
     tail_flush: bool = True,
+    failed_move_policy: Literal["raise", "pause"] = "raise",
     md: dict[str, Any] | None = None,
 ):
     """Free-run step scan: rows paced by *reference*, contributors never block.
@@ -166,6 +168,18 @@ def geecs_free_run_step_scan(
     tail_flush:
         Emit one final ``flush``-stream event after the last disarm so
         lagging contributors' final shot is captured.
+    failed_move_policy:
+        ``"raise"`` (default): a failed move's ``FailedStatus`` propagates
+        normally — exact pre-#641 behavior, so any caller that does not
+        opt in is unaffected (in particular the bridge/console path, which
+        also sidesteps the coexisting engine-side pause supervisor's
+        auto-resume-on-failed-move interaction and the related stop-from-
+        paused bypass — both are properties of *entering* the pause path,
+        not of this plan).  ``"pause"``: use
+        :func:`~geecs_bluesky.plans.step_scan.move_with_failed_move_pause`
+        — a failed move logs the documented reason and hard-pauses the RE;
+        resume retries the move by replay (decision 4).  Queueserver
+        callers with no supervisor in the loop opt into ``"pause"``.
     md:
         Extra metadata merged into the start document.
 
@@ -251,6 +265,12 @@ def geecs_free_run_step_scan(
     t0s = yield from geecs_t0_sync(sync_devices, window_s=effective_window_s)
     _md["device_t0s"] = t0s
 
+    move = (
+        move_with_failed_move_pause
+        if failed_move_policy == "pause"
+        else move_changed_axes
+    )
+
     @bpp.run_decorator(md=_md)
     def _inner():
         scan_event_index = 0
@@ -263,17 +283,22 @@ def geecs_free_run_step_scan(
             # INSIDE the SCAN window — a pause landing there (either verb)
             # relies on the ShotControlPauseQuiescer (pause_semantics) to
             # stop the trigger; plan structure alone cannot make those
-            # windows quiescent without whole-bin pause latency.
+            # windows quiescent without whole-bin pause latency.  The
+            # post-per_step checkpoint (issue #645 cross-vendor addendum,
+            # P1) keeps per_step's compiled ActionPlan writes out of a
+            # replay landing before arm — same rationale as geecs_step_scan;
+            # a hard pause landing DURING per_step() itself is an
+            # irreducible mid-action residual, same class as the documented
+            # bounded-refire windows.
             yield from bps.checkpoint()
             if _motors and pos is not None:
-                previous = yield from move_with_failed_move_pause(
-                    _motors, pos, previous
-                )
+                previous = yield from move(_motors, pos, previous)
             yield from bps.checkpoint()
             if per_step is not None:
                 # After the move, before arming: per-step actions run with
                 # the shot controller disarmed (outside the SCAN window).
                 yield from per_step()
+            yield from bps.checkpoint()
             if arm_trigger is not None:
                 yield from arm_trigger()
             for shot_index_in_bin in range(1, shots_per_step + 1):

--- a/GeecsBluesky/geecs_bluesky/plans/orchestration.py
+++ b/GeecsBluesky/geecs_bluesky/plans/orchestration.py
@@ -31,7 +31,7 @@ rationale: ``GeecsBluesky/CLAUDE.md`` (shot-control composition per mode).
 from __future__ import annotations
 
 import logging
-from typing import Any, Callable, Sequence
+from typing import Any, Callable, Literal, Sequence
 
 import bluesky.preprocessors as bpp
 
@@ -80,6 +80,7 @@ def build_step_scan_plan(
     setup: Callable | None = None,
     per_step: Callable | None = None,
     closeout: Callable | None = None,
+    failed_move_policy: Literal["raise", "pause"] = "raise",
 ):
     """Build the full scan plan for one step scan / statistics collection.
 
@@ -106,6 +107,12 @@ def build_step_scan_plan(
         Plan-stub callables (each call returns a fresh message generator) —
         typically compiled ActionPlans.  See the module docstring for the
         exact placement and abort semantics of each hook.
+    failed_move_policy : {"raise", "pause"}
+        Forwarded to :func:`~geecs_bluesky.plans.step_scan.geecs_step_scan` /
+        :func:`~geecs_bluesky.plans.free_run_step_scan.geecs_free_run_step_scan`.
+        ``"raise"`` (default) is exact pre-#641 behavior — every existing
+        caller (the bridge/console path via ``scan_request_plan.py``) is
+        unaffected until it explicitly opts into ``"pause"``.
 
     Returns
     -------
@@ -136,6 +143,7 @@ def build_step_scan_plan(
             fire_shot=controller.fire_shot,
             per_step=per_step,
             enable_saving=enable_saving,
+            failed_move_policy=failed_move_policy,
         )
     else:
         if reference is None:
@@ -167,6 +175,7 @@ def build_step_scan_plan(
             quiesce_trigger=controller.quiesce if controller else None,
             per_step=per_step,
             enable_saving=enable_saving,
+            failed_move_policy=failed_move_policy,
         )
 
     if setup is not None:

--- a/GeecsBluesky/geecs_bluesky/plans/orchestration.py
+++ b/GeecsBluesky/geecs_bluesky/plans/orchestration.py
@@ -37,6 +37,7 @@ import bluesky.preprocessors as bpp
 
 from geecs_bluesky.exceptions import GeecsConfigurationError
 from geecs_bluesky.plans.free_run_step_scan import geecs_free_run_step_scan
+from geecs_bluesky.plans.pause_semantics import ShotControlPauseQuiescer
 from geecs_bluesky.plans.run_wrapper import geecs_run_wrapper, save_enable_plan
 from geecs_bluesky.plans.step_scan import geecs_step_scan, normalize_motors
 from geecs_bluesky.shot_controller import ShotController
@@ -47,6 +48,12 @@ logger = logging.getLogger(__name__)
 def _chain_setup(setup: Callable, inner):
     """Prepend the setup plan to *inner* (fresh generator via the callable)."""
     yield from setup()
+    yield from inner
+
+
+def _with_pause_quiescer(quiescer: ShotControlPauseQuiescer, inner):
+    """Register the quiescer as the plan's very first message, then run it."""
+    yield from quiescer.register()
     yield from inner
 
 
@@ -205,4 +212,13 @@ def build_step_scan_plan(
     # every exit path (ophyd-async staging is a bool, not a refcount — nested
     # plans must not re-stage these devices).
     plan = bpp.stage_wrapper(plan, scalar_devices)
+    # Quiesce-on-pause (queueserver decision 1, issue #641): register a
+    # Pausable quiescer as the very first message, so ANY pause — operator
+    # deferred/immediate or the in-plan failed-move pause — stops the
+    # trigger (OFF) and resume re-asserts the interrupted standing state
+    # before the rewind replay runs.  Registration must precede everything,
+    # staging included, so even a pause during setup is covered.  Mechanism
+    # rationale: geecs_bluesky/plans/pause_semantics.py.
+    if controller is not None:
+        plan = _with_pause_quiescer(ShotControlPauseQuiescer(controller), plan)
     return plan

--- a/GeecsBluesky/geecs_bluesky/plans/pause_semantics.py
+++ b/GeecsBluesky/geecs_bluesky/plans/pause_semantics.py
@@ -36,6 +36,17 @@ is already quiescent by construction — the single-shot source cannot
 free-run — so the quiescer deliberately does nothing (pinned by test);
 ``OFF``/``None`` mean the trigger is already stopped / never touched.
 
+**Coexistence with the engine-side pause supervisor (transitional, dies at
+Round 3).**  While the supervisor and this quiescer are both live on the
+bridge/console path, a pause double-quiesces (the supervisor's own
+OFF/restore races this class's, ~3 redundant gateway writes) and the
+supervisor's restore is no longer a safety net for a *plan*-driven pause —
+the end state is provably correct either way, but the redundancy and the
+now-vestigial restore path are worth remembering when the supervisor is
+deleted: this coexistence-era behavior (and the two classes' write
+ordering relative to each other) goes away with it, not before (cross-
+vendor review on #645).
+
 **Failed-move → pause (decision 4).**
 :func:`~geecs_bluesky.plans.step_scan.move_with_failed_move_pause` (living
 at the move site itself, in ``step_scan.py``) catches a failed move status,
@@ -57,7 +68,15 @@ scan.log)::
     retries the move from the last checkpoint, stop ends the scan gracefully
 
 Checkpoint-placement rules for hard-pause replay idempotence live with the
-step plans; the audit table is on the PR for issue #641.
+step plans; the audit table is on the PR for issue #641.  Both step plans
+also checkpoint immediately after ``per_step()`` (cross-vendor review,
+issue #645 addendum, item P1) — a compiled ActionPlan's writes
+(``bps.abs_set`` calls) are not guaranteed idempotent the way an absolute
+move is, so a hard pause landing between ``per_step()`` finishing and arm
+must not replay them.  The irreducible residual — a hard pause landing
+DURING ``per_step()`` itself replays the in-flight action sequence from the
+post-move checkpoint — is the same class as strict mode's documented
+bounded-refire window and is not closable by checkpoint placement alone.
 """
 
 from __future__ import annotations

--- a/GeecsBluesky/geecs_bluesky/plans/pause_semantics.py
+++ b/GeecsBluesky/geecs_bluesky/plans/pause_semantics.py
@@ -1,0 +1,178 @@
+"""Plan-level pause semantics for the queueserver world (issue #641).
+
+Implements decisions 1 and 4 of
+``Planning/cutover_strategy/02_queueserver_migration.md`` at the plan layer,
+replacing the engine-side pause supervisor (a Round-3 deletion) for the two
+behaviors that must survive it:
+
+**Quiesce-on-pause (decision 1).**  When a scan pauses — either operator verb
+(deferred or immediate) or an in-plan :func:`bluesky.plan_stubs.pause` — the
+free-running trigger must stop.  The chosen seam is the RunEngine's own
+:class:`~bluesky.protocols.Pausable` device notification: while entering the
+paused state the RE awaits ``obj.pause()`` on every object it has seen, and
+``RunEngine.resume()`` awaits ``obj.resume()`` on the same objects **before**
+replaying any cached message.  :class:`ShotControlPauseQuiescer` rides that
+seam: on pause it drives the shot controller's ``OFF`` writes (stopping the
+trigger) whenever the plan last drove a free-running standing state
+(``SCAN``/``STANDBY``), and on resume it re-asserts the captured state —
+sequenced strictly before the resume replay, so replayed rows never race the
+re-arm.  Why this over the alternatives considered:
+
+- it is one mechanism for **both** pause verbs *and* the in-plan failed-move
+  pause (all three funnel through the same RE pausing path);
+- the resume-side ordering guarantee (re-assert completes before the first
+  replayed message) cannot be had from ``state_hook`` or a document-stream
+  callback without re-growing a supervisor thread;
+- pure checkpoint placement (candidate (b) on the issue) cannot satisfy
+  "the trigger must stop": free-run per-row checkpoints sit inside the SCAN
+  window by design (removing them means whole-bin pause latency), and even
+  the disarmed step-boundary window is ``STANDBY``, which keeps passing
+  external edges — an unbounded pause there saves orphan frames for its
+  whole duration (the Gate-2 failure mode, unbounded).
+
+State rules (mode-agnostic, keyed on ``ShotController.last_state``):
+``SCAN``/``STANDBY`` → drive ``OFF``, re-assert on resume; ``ARMED`` (strict)
+is already quiescent by construction — the single-shot source cannot
+free-run — so the quiescer deliberately does nothing (pinned by test);
+``OFF``/``None`` mean the trigger is already stopped / never touched.
+
+**Failed-move → pause (decision 4).**
+:func:`~geecs_bluesky.plans.step_scan.move_with_failed_move_pause` (living
+at the move site itself, in ``step_scan.py``) catches a failed move status,
+records the reason as one ERROR log line (format below — scan.log captures
+it via the root-logger handler, and ``RE.record_interruptions`` puts the
+pause itself in the data record), and issues a **hard**
+:func:`bluesky.plan_stubs.pause`.  The hard-pause resume replay is the retry
+mechanism (the sandbox-spike scoping note): ``pause`` is uncacheable, so the
+message cache at that moment holds exactly the failed ``set``/``wait`` pair
+from the last (pre-move) checkpoint — resume replays them, re-issuing the
+same absolute target; stop ends the run gracefully through the finalize
+chain.  A retry that fails again re-raises into the plan at the pause yield
+and pauses again, indefinitely, until the move lands or the operator stops.
+
+The failed-move log-line contract (the reason record; grep for it in
+scan.log)::
+
+    FAILED MOVE - pausing for operator: <axes -> targets>: <cause>; resume
+    retries the move from the last checkpoint, stop ends the scan gracefully
+
+Checkpoint-placement rules for hard-pause replay idempotence live with the
+step plans; the audit table is on the PR for issue #641.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from bluesky.utils import Msg
+
+from geecs_bluesky.models.shot_control import ShotControlState
+
+if TYPE_CHECKING:  # import-light on purpose: step_scan imports this module
+    from geecs_bluesky.shot_controller import ShotController
+
+logger = logging.getLogger(__name__)
+
+#: Stable grep target for the decision-4 reason record (docs contract above).
+FAILED_MOVE_LOG_PREFIX = "FAILED MOVE - pausing for operator"
+
+#: Standing states the quiescer must stop the trigger from.  ARMED is
+#: deliberately absent: strict mode's single-shot source cannot free-run, so
+#: the paused state is quiescent by construction (pinned by test).  OFF and
+#: None (never driven) are already stopped / not the scan's to touch.
+QUIESCE_FROM = frozenset({ShotControlState.SCAN.value, ShotControlState.STANDBY.value})
+
+
+class ShotControlPauseQuiescer:
+    """Pausable device: shot control → ``OFF`` on pause, re-asserted on resume.
+
+    Registered into a plan via :meth:`register` (one no-op message carrying
+    this object, so the RunEngine counts it among the objects seen).  The RE
+    then awaits :meth:`pause` while entering the paused state — for a
+    deferred pause landing at a checkpoint, an immediate operator pause, and
+    an in-plan ``bps.pause()`` alike — and awaits :meth:`resume` inside
+    ``RunEngine.resume()`` **before** the rewind replay restarts, so the
+    re-asserted trigger state is standing before any replayed message runs.
+
+    Writes are driven through :meth:`ShotController.state_setters` (the
+    documented non-plan accessor for exactly this situation), sequentially in
+    profile order, on the RE's event loop — the same loop the CA setters are
+    bound to.  Failures are logged loudly but never raised: an exception out
+    of the pause/resume notification would take down the run for a safety
+    side-channel; the loud ERROR plus the downstream trigger-wait timeout is
+    the honest failure surface.
+
+    Parameters
+    ----------
+    controller : ShotController
+        The scan's shot controller (its ``last_state`` names what the plan
+        last drove; its ``OFF`` write list is the quiesce).
+    """
+
+    def __init__(self, controller: ShotController) -> None:
+        self._controller = controller
+        self._reassert: str | None = None
+
+    def register(self):
+        """Plan stub: make the RunEngine see this object (one no-op message)."""
+        yield Msg("null", self)
+
+    async def _drive(self, state: str) -> None:
+        """Drive *state*'s writes in profile order, each completing first."""
+        for setter, value in self._controller.state_setters(state):
+            await setter.set(value)
+        self._controller.last_state = state
+
+    async def pause(self) -> None:
+        """RE pause notification: stop the trigger if the plan left it running."""
+        try:
+            standing = self._controller.last_state
+            if standing not in QUIESCE_FROM:
+                logger.debug(
+                    "pause quiescer: last standing state %r needs no quiesce",
+                    standing,
+                )
+                return
+            off = ShotControlState.OFF.value
+            if not self._controller.defines_state(off):
+                logger.warning(
+                    "pause quiescer: trigger profile %s defines no OFF "
+                    "writes - the scan is paused with the trigger still "
+                    "free-running (add an OFF state to the profile)",
+                    self._controller.describe_target,
+                )
+                return
+            self._reassert = standing
+            await self._drive(off)
+            logger.info(
+                "pause quiescer: trigger stopped (OFF) for the pause; %s "
+                "will be re-asserted on resume",
+                standing,
+            )
+        except Exception:
+            logger.exception(
+                "pause quiescer: quiesce failed - the scan is paused but the "
+                "trigger may still be running; check %s",
+                self._controller.describe_target,
+            )
+
+    async def resume(self) -> None:
+        """RE resume notification: re-assert the captured standing state.
+
+        Runs to completion before ``RunEngine.resume()`` replays any cached
+        message, so replayed rows see the restored trigger state.
+        """
+        standing, self._reassert = self._reassert, None
+        if standing is None:
+            return
+        try:
+            await self._drive(standing)
+            logger.info("pause quiescer: re-asserted %s on resume", standing)
+        except Exception:
+            logger.exception(
+                "pause quiescer: could not re-assert %s on resume - the next "
+                "trigger wait will surface this as a timeout; check %s",
+                standing,
+                self._controller.describe_target,
+            )

--- a/GeecsBluesky/geecs_bluesky/plans/pause_semantics.py
+++ b/GeecsBluesky/geecs_bluesky/plans/pause_semantics.py
@@ -64,8 +64,9 @@ and pauses again, indefinitely, until the move lands or the operator stops.
 The failed-move log-line contract (the reason record; grep for it in
 scan.log)::
 
-    FAILED MOVE - pausing for operator: <axes -> targets>: <cause>; resume
-    retries the move from the last checkpoint, stop ends the scan gracefully
+    FAILED MOVE - pausing for operator: commanded <axes -> targets>, one
+    axis failed - see cause for which: <cause>; resume retries the move
+    from the last checkpoint, stop ends the scan gracefully
 
 Checkpoint-placement rules for hard-pause replay idempotence live with the
 step plans; the audit table is on the PR for issue #641.  Both step plans

--- a/GeecsBluesky/geecs_bluesky/plans/step_scan.py
+++ b/GeecsBluesky/geecs_bluesky/plans/step_scan.py
@@ -29,13 +29,18 @@ Example (devices built and connected through a
 
 from __future__ import annotations
 
+import logging
 from typing import Any, Callable, Iterable, Sequence
 
 import bluesky.plan_stubs as bps
 import bluesky.preprocessors as bpp
+from bluesky.utils import FailedStatus
 
 from geecs_bluesky.devices.scan_context import ScanContext
+from geecs_bluesky.plans.pause_semantics import FAILED_MOVE_LOG_PREFIX
 from geecs_bluesky.plans.single_shot import geecs_single_shot
+
+logger = logging.getLogger(__name__)
 
 
 def normalize_motors(motor: Any | Sequence[Any] | None) -> list[Any]:
@@ -118,6 +123,60 @@ def move_changed_axes(motors: list[Any], position: Any, previous: tuple | None):
     if args:
         yield from bps.mv(*args)
     return targets
+
+
+def move_with_failed_move_pause(
+    motors: list[Any], position: Any, previous: tuple | None
+):
+    """Plan stub: :func:`move_changed_axes`, pausing the RE on a failed move.
+
+    The decision-4 move site (queueserver migration, issue #641; design
+    rationale and the log-line contract:
+    :mod:`~geecs_bluesky.plans.pause_semantics`).  On a move status failure
+    the reason is recorded — the
+    :data:`~geecs_bluesky.plans.pause_semantics.FAILED_MOVE_LOG_PREFIX`
+    ERROR line, which the root-logger scan.log handler puts in the scan's
+    record — and the plan issues a **hard** ``bps.pause()``.  Resume replays
+    the failed ``set``/``wait`` from the pre-move checkpoint (``pause`` is
+    uncacheable, so the pause itself never replays): the retry, at the same
+    absolute target.  A retry that fails again is thrown back in at the
+    pause yield and pauses again; stop ends the run gracefully through the
+    plan's finalize chain.
+
+    Parameters mirror :func:`move_changed_axes`.
+
+    Returns
+    -------
+    tuple
+        The targets commanded (the grid point), whether the move landed on
+        the first attempt or via a resume replay.
+    """
+    try:
+        return (yield from move_changed_axes(motors, position, previous))
+    except FailedStatus as exc:
+        targets = (
+            tuple(position) if isinstance(position, (list, tuple)) else (position,)
+        )
+        detail = ", ".join(
+            f"{getattr(m, 'name', m)} -> {t!r}" for m, t in zip(motors, targets)
+        )
+        while True:
+            cause = exc.__cause__ or exc
+            logger.error(
+                "%s: %s: %s; resume retries the move from the last "
+                "checkpoint, stop ends the scan gracefully",
+                FAILED_MOVE_LOG_PREFIX,
+                detail,
+                cause,
+            )
+            try:
+                yield from bps.pause()
+            except FailedStatus as retry_exc:  # the replayed retry failed too
+                exc = retry_exc
+                continue
+            # Reaching here means resume's replay re-issued the move and its
+            # wait completed - the retry landed.
+            return targets
 
 
 def geecs_step_scan(
@@ -229,14 +288,28 @@ def geecs_step_scan(
         scan_event_index = 0
         previous: tuple | None = None
         for bin_number, pos in enumerate(_positions, start=1):
-            # Deferred-pause boundary (issue #552): a checkpoint before the
-            # move and before every row means request_pause(defer=True)
-            # lands with an empty rewind cache — resume replays nothing
-            # (no re-move, no re-fire).  Never place a checkpoint between
-            # create and save (IllegalMessageSequence).
+            # Checkpoint placement is a pause contract (issues #552/#641).
+            # Deferred pause: a checkpoint before the move and before every
+            # row means request_pause(defer=True) lands with an empty rewind
+            # cache — resume replays nothing (no re-move, no re-fire).
+            # Hard pause (bps.pause / re pause immediate) resumes by
+            # REPLAYING from the last checkpoint, so each checkpoint also
+            # bounds what re-executes: the pre-move checkpoint scopes a
+            # replay to the move (absolute re-command — idempotent, and the
+            # failed-move retry mechanism); the post-move checkpoint keeps
+            # the move out of a replayed per_step action prefix; the pre-row
+            # checkpoint scopes a mid-shot replay to that shot (a re-fire,
+            # strict's bounded-refire semantics); the post-rows checkpoint
+            # keeps the bin's last COMPLETED row out of a replay landing in
+            # the disarm/tail window (re-saving it would duplicate the event
+            # row).  Never place a checkpoint between create and save
+            # (IllegalMessageSequence).
             yield from bps.checkpoint()
             if _motors and pos is not None:
-                previous = yield from move_changed_axes(_motors, pos, previous)
+                previous = yield from move_with_failed_move_pause(
+                    _motors, pos, previous
+                )
+            yield from bps.checkpoint()
             if per_step is not None:
                 # After the move, before this step's plan-owned shots — the
                 # machine is quiescent here (strict fires each shot itself).
@@ -255,6 +328,7 @@ def geecs_step_scan(
                     yield from geecs_single_shot(_read_devices, fire_shot)
                 else:
                     yield from bps.trigger_and_read(_read_devices)
+            yield from bps.checkpoint()
             if disarm_trigger is not None:
                 yield from disarm_trigger()
 

--- a/GeecsBluesky/geecs_bluesky/plans/step_scan.py
+++ b/GeecsBluesky/geecs_bluesky/plans/step_scan.py
@@ -30,7 +30,7 @@ Example (devices built and connected through a
 from __future__ import annotations
 
 import logging
-from typing import Any, Callable, Iterable, Sequence
+from typing import Any, Callable, Iterable, Literal, Sequence
 
 import bluesky.plan_stubs as bps
 import bluesky.preprocessors as bpp
@@ -157,14 +157,22 @@ def move_with_failed_move_pause(
         targets = (
             tuple(position) if isinstance(position, (list, tuple)) else (position,)
         )
+        # Changed axes move concurrently (bps.mv, one status per axis); a
+        # FailedStatus carries only the failing status, not the device
+        # (bluesky's _add_status_to_group never tags obj onto the status
+        # object), so this cannot say which axis raised.  `detail` lists
+        # every commanded target for context; `cause`'s own text (e.g.
+        # GeecsMotorTimeoutError's device/variable fields) is what actually
+        # identifies the failing axis.
         detail = ", ".join(
             f"{getattr(m, 'name', m)} -> {t!r}" for m, t in zip(motors, targets)
         )
         while True:
             cause = exc.__cause__ or exc
             logger.error(
-                "%s: %s: %s; resume retries the move from the last "
-                "checkpoint, stop ends the scan gracefully",
+                "%s: commanded %s, one axis failed - see cause for which: "
+                "%s; resume retries the move from the last checkpoint, stop "
+                "ends the scan gracefully",
                 FAILED_MOVE_LOG_PREFIX,
                 detail,
                 cause,
@@ -190,6 +198,7 @@ def geecs_step_scan(
     setup_trigger: Callable | None = None,
     per_step: Callable | None = None,
     enable_saving: Callable | None = None,
+    failed_move_policy: Literal["raise", "pause"] = "raise",
     md: dict[str, Any] | None = None,
 ):
     """Step-scan plan: move *motor* through *positions*, collect *shots_per_step* shots.
@@ -252,6 +261,18 @@ def geecs_step_scan(
         longer free-run, so no orphan frames get saved (Gate-2 save
         windowing: ``GeecsBluesky/CLAUDE.md``).  Save-*off* stays the run
         wrapper's innermost finalize, before the caller's disarm.
+    failed_move_policy:
+        ``"raise"`` (default): a failed move's ``FailedStatus`` propagates
+        normally — exact pre-#641 behavior, so any caller that does not
+        opt in is unaffected (in particular the bridge/console path, which
+        also sidesteps the coexisting engine-side pause supervisor's
+        auto-resume-on-failed-move interaction and the related stop-from-
+        paused bypass — both are properties of *entering* the pause path,
+        not of this plan).  ``"pause"``: use
+        :func:`move_with_failed_move_pause` — a failed move logs the
+        documented reason and hard-pauses the RE; resume retries the move
+        by replay (decision 4).  Queueserver callers with no supervisor in
+        the loop opt into ``"pause"``.
     md:
         Extra metadata merged into the RunEngine ``start`` document.
 
@@ -285,6 +306,11 @@ def geecs_step_scan(
         if enable_saving is not None:
             # Saving starts only after the trigger is stopped (Gate-2).
             yield from enable_saving()
+        move = (
+            move_with_failed_move_pause
+            if failed_move_policy == "pause"
+            else move_changed_axes
+        )
         scan_event_index = 0
         previous: tuple | None = None
         for bin_number, pos in enumerate(_positions, start=1):
@@ -297,23 +323,34 @@ def geecs_step_scan(
             # bounds what re-executes: the pre-move checkpoint scopes a
             # replay to the move (absolute re-command — idempotent, and the
             # failed-move retry mechanism); the post-move checkpoint keeps
-            # the move out of a replayed per_step action prefix; the pre-row
-            # checkpoint scopes a mid-shot replay to that shot (a re-fire,
-            # strict's bounded-refire semantics); the post-rows checkpoint
-            # keeps the bin's last COMPLETED row out of a replay landing in
-            # the disarm/tail window (re-saving it would duplicate the event
+            # the move out of a replayed per_step action prefix; the
+            # post-per_step checkpoint (issue #645 cross-vendor addendum,
+            # P1) keeps per_step's compiled ActionPlan writes (``bps.abs_set``
+            # calls — not guaranteed idempotent, unlike an absolute move) out
+            # of a replay landing before arm; the pre-row checkpoint scopes a
+            # mid-shot replay to that shot (a re-fire, strict's
+            # bounded-refire semantics); the post-rows checkpoint keeps the
+            # bin's last COMPLETED row out of a replay landing in the
+            # disarm/tail window (re-saving it would duplicate the event
             # row).  Never place a checkpoint between create and save
             # (IllegalMessageSequence).
+            #
+            # Irreducible residual: a hard pause landing DURING per_step()
+            # itself (mid-action, before it yields back to the loop) still
+            # replays from the post-move checkpoint through the partial
+            # per_step execution — same class as the documented bounded-
+            # refire windows, not closable by checkpoint placement alone
+            # (would need per-action idempotence in the ActionPlan compiler,
+            # out of this module's scope).
             yield from bps.checkpoint()
             if _motors and pos is not None:
-                previous = yield from move_with_failed_move_pause(
-                    _motors, pos, previous
-                )
+                previous = yield from move(_motors, pos, previous)
             yield from bps.checkpoint()
             if per_step is not None:
                 # After the move, before this step's plan-owned shots — the
                 # machine is quiescent here (strict fires each shot itself).
                 yield from per_step()
+            yield from bps.checkpoint()
             if arm_trigger is not None:
                 yield from arm_trigger()
             for shot_index_in_bin in range(1, shots_per_step + 1):

--- a/GeecsBluesky/pyproject.toml
+++ b/GeecsBluesky/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-bluesky"
-version = "0.53.1"
+version = "0.54.0"
 description = "Bluesky / ophyd-async bridge for the GEECS control system"
 authors = ["Sam Barber <sbarber@lbl.gov>"]
 readme = "README.md"

--- a/GeecsBluesky/tests/test_grid_plans_message_level.py
+++ b/GeecsBluesky/tests/test_grid_plans_message_level.py
@@ -107,12 +107,14 @@ def test_per_step_runs_after_move_before_shots_at_every_grid_point() -> None:
         if command != "per_step_marker":
             continue
         # No trigger/create between this step's moves and the marker.  The
-        # row's deferred-pause checkpoint (issue #552) sits between the
-        # marker and the first shot — skip it so the original "nothing
-        # hides between per_step and the first shot" pin keeps its teeth.
+        # pause checkpoints (issues #552/#641: the pre-row one after the
+        # marker, the post-move one before it) are placement contracts, not
+        # hidden work — skip them on both sides so the original "nothing
+        # hides between the move, per_step, and the first shot" pin keeps
+        # its teeth.
         after = next(c for c in commands[index + 1 :] if c != "checkpoint")
         assert after in ("trigger", "create"), after
-        before = commands[index - 1]
+        before = next(c for c in reversed(commands[:index]) if c != "checkpoint")
         assert before in ("wait", "open_run"), before
 
 

--- a/GeecsBluesky/tests/test_pause_checkpoints.py
+++ b/GeecsBluesky/tests/test_pause_checkpoints.py
@@ -1,22 +1,24 @@
-"""Deferred-pause groundwork for G-actions v2 (issue #552, PR-1).
+"""Deferred-pause groundwork (issue #552) + queueserver placement (issue #641).
 
 Pins three things:
 
-* **Checkpoint placement** in both step plans — one before each step's
-  move and one before every row, never between ``create`` and ``save`` —
-  so ``request_pause(defer=True)`` always lands with an empty rewind
-  cache and resume replays nothing (no re-move, no re-fire).
+* **Checkpoint placement** in both step plans — pre-move, post-move,
+  pre-row, and post-rows, never between ``create`` and ``save`` — so
+  ``request_pause(defer=True)`` always lands with an empty rewind cache
+  (resume replays nothing) AND a hard pause's resume replay is bounded
+  to an idempotent segment (issue #641; the replay-idempotence walk
+  itself is pinned in ``test_pause_semantics.py``).
 * **Resume replays nothing** at the RunEngine level: a deferred pause
   raised mid-scan and resumed yields exactly the expected event rows,
   each ``scan_event_index`` exactly once.
 * **``ShotController.last_state``** records the last *standing* state
   actually driven (never the momentary ``SINGLESHOT`` fire) — what the
-  #552 pause supervisor re-asserts after an operator action.
+  pause quiescer re-asserts on resume.
 
 Also pins that the old hard-pause bridge API (``pause_scan`` /
-``resume_scan``) is gone: with no checkpoints it was a
-resume-replays-the-scan trap, and with checkpoints a bare hard pause
-still replays a partial row (re-firing a shot in strict mode).
+``resume_scan``) is gone: hard pause is now an RE-level verb whose
+replay the plans are structured to survive (issue #641), not a bridge
+method.
 """
 
 from __future__ import annotations
@@ -80,9 +82,9 @@ def _step_plan_messages(num_points: int = 3, shots_per_step: int = 2) -> list[Ms
 
 
 def test_one_checkpoint_per_step_and_per_row() -> None:
-    """3 steps × 2 shots → 3 pre-move + 6 pre-row = 9 checkpoints."""
+    """3 steps × 2 shots → (pre-move + post-move + post-rows) × 3 + 6 pre-row."""
     commands = [m.command for m in _step_plan_messages(3, 2)]
-    assert commands.count("checkpoint") == 3 + 3 * 2
+    assert commands.count("checkpoint") == 3 * 3 + 3 * 2
 
 
 def test_checkpoint_precedes_the_move_and_every_row() -> None:
@@ -257,8 +259,9 @@ def test_hard_pause_bridge_api_deleted() -> None:
 def test_free_run_plan_checkpoints_per_step_and_row_never_in_bundle() -> None:
     """Free-run (production mode): same checkpoint contract, incl. tail flush.
 
-    Motorless statistics run, 1 bin × 2 shots → 1 pre-move + 2 pre-row
-    checkpoints; the tail-flush create/read/save bundle must contain none.
+    Motorless statistics run, 1 bin × 2 shots → pre-move + post-move +
+    2 pre-row + post-rows + post-flush checkpoints (#641 placement); the
+    tail-flush create/read/save bundle must contain none.
     """
     pytest.importorskip("aioca")
     from ophyd_async.core import set_mock_value
@@ -289,7 +292,9 @@ def test_free_run_plan_checkpoints_per_step_and_row_never_in_bundle() -> None:
     finally:
         pacer.cancel()
 
-    assert commands.count("checkpoint") == 1 + 2
+    # One no-move bin × 2 shots: pre-move + post-move + 2 pre-row +
+    # post-rows + post-flush (issue #641 placement).
+    assert commands.count("checkpoint") == 6
     open_bundle = False
     for command in commands:
         if command == "create":

--- a/GeecsBluesky/tests/test_pause_checkpoints.py
+++ b/GeecsBluesky/tests/test_pause_checkpoints.py
@@ -82,9 +82,14 @@ def _step_plan_messages(num_points: int = 3, shots_per_step: int = 2) -> list[Ms
 
 
 def test_one_checkpoint_per_step_and_per_row() -> None:
-    """3 steps × 2 shots → (pre-move + post-move + post-rows) × 3 + 6 pre-row."""
+    """3 steps x 2 shots -> (pre-move + post-move + post-per_step + post-rows) x 3 + 6 pre-row.
+
+    The post-per_step checkpoint (issue #645 cross-vendor addendum, P1)
+    keeps a replayed arm from dragging a completed per_step ActionPlan
+    write along with it.
+    """
     commands = [m.command for m in _step_plan_messages(3, 2)]
-    assert commands.count("checkpoint") == 3 * 3 + 3 * 2
+    assert commands.count("checkpoint") == 3 * 4 + 3 * 2
 
 
 def test_checkpoint_precedes_the_move_and_every_row() -> None:
@@ -260,8 +265,9 @@ def test_free_run_plan_checkpoints_per_step_and_row_never_in_bundle() -> None:
     """Free-run (production mode): same checkpoint contract, incl. tail flush.
 
     Motorless statistics run, 1 bin × 2 shots → pre-move + post-move +
-    2 pre-row + post-rows + post-flush checkpoints (#641 placement); the
-    tail-flush create/read/save bundle must contain none.
+    post-per_step + 2 pre-row + post-rows + post-flush checkpoints (#641
+    placement, #645 addendum P1); the tail-flush create/read/save bundle
+    must contain none.
     """
     pytest.importorskip("aioca")
     from ophyd_async.core import set_mock_value
@@ -292,9 +298,10 @@ def test_free_run_plan_checkpoints_per_step_and_row_never_in_bundle() -> None:
     finally:
         pacer.cancel()
 
-    # One no-move bin × 2 shots: pre-move + post-move + 2 pre-row +
-    # post-rows + post-flush (issue #641 placement).
-    assert commands.count("checkpoint") == 6
+    # One no-move bin × 2 shots: pre-move + post-move + post-per_step +
+    # 2 pre-row + post-rows + post-flush (issue #641 placement, #645
+    # addendum P1).
+    assert commands.count("checkpoint") == 7
     open_bundle = False
     for command in commands:
         if command == "create":

--- a/GeecsBluesky/tests/test_pause_semantics.py
+++ b/GeecsBluesky/tests/test_pause_semantics.py
@@ -247,6 +247,7 @@ def test_step_plan_checkpoints_immediately_after_per_step() -> None:
             shots_per_step=1,
             setup_trigger=lambda: controller.arm_single_shot([]),
             fire_shot=controller.fire_shot,
+            arm_trigger=controller.arm,
             per_step=per_step,
         )
     )
@@ -634,13 +635,14 @@ class _PlainDet(_NamedFake):
         return {self.name: {"source": "sim", "dtype": "number", "shape": []}}
 
 
-def _failed_move_scan(motor: _FlakyMotor, failed_move_policy: str = "pause"):
+def _failed_move_scan(motor: _FlakyMotor, failed_move_policy: str | None = None):
+    """None means: omit the kwarg entirely, exercising the builder's default."""
     return geecs_step_scan(
         motor=motor,
         positions=[0.0, 1.0],
         detectors=[_PlainDet("cam")],
         shots_per_step=2,
-        failed_move_policy=failed_move_policy,
+        **({} if failed_move_policy is None else {"failed_move_policy": failed_move_policy}),
     )
 
 
@@ -658,7 +660,7 @@ def test_failed_move_pauses_with_reason_and_resume_retries(caplog) -> None:
     RE.subscribe(lambda name, doc: docs.append((name, doc)))
     with caplog.at_level(logging.ERROR, logger="geecs_bluesky.plans.step_scan"):
         with pytest.raises(RunEngineInterrupted):
-            RE(_failed_move_scan(motor))
+            RE(_failed_move_scan(motor, failed_move_policy="pause"))
     assert RE.state == "paused"
     reasons = [
         record.message
@@ -685,7 +687,7 @@ def test_failed_move_retry_that_fails_pauses_again(caplog) -> None:
     RE.subscribe(lambda name, doc: docs.append((name, doc)))
     with caplog.at_level(logging.ERROR, logger="geecs_bluesky.plans.step_scan"):
         with pytest.raises(RunEngineInterrupted):
-            RE(_failed_move_scan(motor))
+            RE(_failed_move_scan(motor, failed_move_policy="pause"))
         assert RE.state == "paused"
         with pytest.raises(RunEngineInterrupted):
             RE.resume()  # the replayed retry fails → paused again
@@ -709,7 +711,7 @@ def test_failed_move_then_stop_ends_gracefully() -> None:
     docs: list[tuple[str, dict]] = []
     RE.subscribe(lambda name, doc: docs.append((name, doc)))
     with pytest.raises(RunEngineInterrupted):
-        RE(_failed_move_scan(motor))
+        RE(_failed_move_scan(motor, failed_move_policy="pause"))
     assert RE.state == "paused"
     RE.stop()
     assert RE.state == "idle"
@@ -729,10 +731,18 @@ def test_failed_move_policy_defaults_to_raise_like_legacy() -> None:
     ``scan_request_plan.py`` — must see exactly the pre-#641 behavior: the
     ``FailedStatus`` raises straight through ``RE()``, no pause.
     """
+    import inspect
+
+    from geecs_bluesky.plans.orchestration import build_step_scan_plan
+
+    assert (
+        inspect.signature(build_step_scan_plan).parameters["failed_move_policy"].default
+        == "raise"
+    )
     motor = _FlakyMotor("flaky", fail_at=1.0, failures=1)
     RE = RunEngine()
     with pytest.raises(FailedStatus):
-        RE(_failed_move_scan(motor, failed_move_policy="raise"))
+        RE(_failed_move_scan(motor))
     assert RE.state == "idle"
     # One attempt only — no retry-by-replay under "raise".
     assert motor.attempts == [0.0, 1.0]

--- a/GeecsBluesky/tests/test_pause_semantics.py
+++ b/GeecsBluesky/tests/test_pause_semantics.py
@@ -36,7 +36,7 @@ from typing import Any
 import bluesky.plan_stubs as bps
 import pytest
 from bluesky import RunEngine
-from bluesky.utils import Msg, RunEngineInterrupted
+from bluesky.utils import FailedStatus, Msg, RunEngineInterrupted
 from ophyd_async.core import AsyncStatus
 
 from geecs_bluesky.models.shot_control import ShotControlWrites
@@ -223,6 +223,87 @@ def test_free_run_plan_hard_pause_never_replays_a_completed_row() -> None:
     finally:
         pacer.cancel()
     _assert_no_replayable_completed_row(commands)
+
+
+def test_step_plan_checkpoints_immediately_after_per_step() -> None:
+    """Pins P1 (#645 cross-vendor addendum): checkpoint right after per_step.
+
+    A hard pause landing between per_step()'s (potentially non-idempotent)
+    compiled-ActionPlan writes and arm must not replay those writes — the
+    checkpoint must be the very next message once per_step yields control
+    back, before arm_trigger runs.
+    """
+    marker = _NamedFake("action_marker")
+
+    def per_step():
+        yield Msg("null", marker)
+
+    controller = _controller([])
+    messages = _collect(
+        geecs_step_scan(
+            motor=_NamedFake("jet_z"),
+            positions=[0.0],
+            detectors=[_NamedFake("cam")],
+            shots_per_step=1,
+            setup_trigger=lambda: controller.arm_single_shot([]),
+            fire_shot=controller.fire_shot,
+            per_step=per_step,
+        )
+    )
+    marker_index = next(
+        i for i, m in enumerate(messages) if m.command == "null" and m.obj is marker
+    )
+    assert messages[marker_index + 1].command == "checkpoint"
+
+
+def test_free_run_plan_checkpoints_immediately_after_per_step() -> None:
+    """Free-run counterpart of the per_step-checkpoint placement pin.
+
+    Needs a real RE + CA-mock reference (t0-sync polls real readback
+    values) — message-level ``_collect`` alone can't drive this plan, same
+    constraint as the free-run replay-cache-audit test above.
+    """
+    pytest.importorskip("aioca")
+    from ophyd_async.core import set_mock_value
+
+    from geecs_bluesky.devices.ca import CaGenericDetector
+    from geecs_bluesky.plans.free_run_step_scan import geecs_free_run_step_scan
+    from tests.ca_mock_helpers import connect_mock, start_pacer
+
+    marker = _NamedFake("action_marker")
+
+    def per_step():
+        yield Msg("null", marker)
+
+    controller = _controller([])
+    ref = CaGenericDetector("U_Ref", ["Sig"], name="ref")
+    ref.configure_shot_id(rep_rate_hz=1.0)
+
+    RE = RunEngine()
+    messages: list[Msg] = []
+    RE.msg_hook = lambda msg: messages.append(msg)
+    connect_mock(RE, ref)
+    set_mock_value(ref.acq_timestamp, 1000.0)
+    pacer = start_pacer(RE, [(ref, 1000.0)], initial_delay=0.2, interval=0.1)
+    try:
+        RE(
+            geecs_free_run_step_scan(
+                motor=None,
+                positions=[None],
+                reference=ref,
+                detectors=[],
+                shots_per_step=1,
+                arm_trigger=controller.arm,
+                disarm_trigger=controller.disarm,
+                per_step=per_step,
+            )
+        )
+    finally:
+        pacer.cancel()
+    marker_index = next(
+        i for i, m in enumerate(messages) if m.command == "null" and m.obj is marker
+    )
+    assert messages[marker_index + 1].command == "checkpoint"
 
 
 # ---------------------------------------------------------------------------
@@ -553,12 +634,13 @@ class _PlainDet(_NamedFake):
         return {self.name: {"source": "sim", "dtype": "number", "shape": []}}
 
 
-def _failed_move_scan(motor: _FlakyMotor):
+def _failed_move_scan(motor: _FlakyMotor, failed_move_policy: str = "pause"):
     return geecs_step_scan(
         motor=motor,
         positions=[0.0, 1.0],
         detectors=[_PlainDet("cam")],
         shots_per_step=2,
+        failed_move_policy=failed_move_policy,
     )
 
 
@@ -636,3 +718,21 @@ def test_failed_move_then_stop_ends_gracefully() -> None:
     assert stop_docs[0]["exit_status"] == "success"  # graceful, not aborted
     # Bin 1 completed before the failure; its rows survive exactly once.
     assert _primary_indices(docs) == [1, 2]
+
+
+def test_failed_move_policy_defaults_to_raise_like_legacy() -> None:
+    """Default policy propagates FailedStatus — bridge/console untouched.
+
+    Issue #645 F1: the pause-on-failed-move path coexists badly with the
+    engine-side pause supervisor (auto-resume loop, stop-from-paused
+    bypass).  Callers that don't opt in — the bridge/console path via
+    ``scan_request_plan.py`` — must see exactly the pre-#641 behavior: the
+    ``FailedStatus`` raises straight through ``RE()``, no pause.
+    """
+    motor = _FlakyMotor("flaky", fail_at=1.0, failures=1)
+    RE = RunEngine()
+    with pytest.raises(FailedStatus):
+        RE(_failed_move_scan(motor, failed_move_policy="raise"))
+    assert RE.state == "idle"
+    # One attempt only — no retry-by-replay under "raise".
+    assert motor.attempts == [0.0, 1.0]

--- a/GeecsBluesky/tests/test_pause_semantics.py
+++ b/GeecsBluesky/tests/test_pause_semantics.py
@@ -1,0 +1,638 @@
+"""Queueserver pause semantics (issue #641): quiesce-on-pause + hard-pause replay.
+
+Four contracts, one per section:
+
+* **Replay-cache audit** — reconstructing the RunEngine's rewind cache over
+  the step plans' message streams proves a completed event row (create+save)
+  is replayable only in the single residual instant where the very next
+  message is the post-row checkpoint.  Everything else a hard pause can
+  replay is idempotent: absolute moves, trigger-state writes, an incomplete
+  row (a re-fire — strict's bounded-refire semantics).
+* **ShotControlPauseQuiescer** — the Pausable seam: OFF driven while the RE
+  enters the paused state (both pause verbs), the interrupted standing state
+  re-asserted inside ``RunEngine.resume()`` *before* the rewind replay;
+  ARMED (strict) deliberately skipped — already quiescent by construction;
+  a profile without OFF writes warns instead of pretending.
+* **Hard pause mid-move (free-run, the flagship)** — an operator
+  ``request_pause(defer=False)`` lands inside a move; resume must replay the
+  move at the same absolute target, fire no extra trigger, duplicate no
+  event row, and sequence quiesce/re-assert around the replay.  Also pins
+  the issue's window claim: the free-run pre-move checkpoint sits in a
+  disarmed window, but per-row checkpoints sit INSIDE the SCAN window — the
+  quiescer, not checkpoint placement, is what makes those pauses quiescent.
+* **Failed-move → pause (decision 4)** — a failed move status pauses the RE
+  with the documented reason line; resume retries the move from the
+  checkpoint (the replay working *for* us); a retry that fails pauses
+  again; stop ends the run gracefully.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+import time
+from typing import Any
+
+import bluesky.plan_stubs as bps
+import pytest
+from bluesky import RunEngine
+from bluesky.utils import Msg, RunEngineInterrupted
+from ophyd_async.core import AsyncStatus
+
+from geecs_bluesky.models.shot_control import ShotControlWrites
+from geecs_bluesky.plans.orchestration import build_step_scan_plan
+from geecs_bluesky.plans.pause_semantics import (
+    FAILED_MOVE_LOG_PREFIX,
+    QUIESCE_FROM,
+    ShotControlPauseQuiescer,
+)
+from geecs_bluesky.plans.step_scan import geecs_step_scan
+from geecs_bluesky.shot_controller import ShotController
+
+# ---------------------------------------------------------------------------
+# Shared minimal fakes (no CA, no network)
+# ---------------------------------------------------------------------------
+
+
+class _NamedFake:
+    """Minimal named object for message-level plans (never actually set)."""
+
+    parent = None  # bps.mv inspects .parent for coupled-device handling
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+    def read(self):  # pragma: no cover - message-level only
+        return {}
+
+    def describe(self):  # pragma: no cover - message-level only
+        return {}
+
+
+class _RecordingSetter:
+    """Shot-control setter recording ``(target, value)`` into a journal."""
+
+    parent = None
+
+    def __init__(self, journal: list, key: tuple[str, str]) -> None:
+        self._journal = journal
+        self._key = key
+
+    def set(self, value: Any) -> AsyncStatus:
+        self._journal.append((self._key, str(value)))
+
+        async def _done() -> None:
+            return None
+
+        return AsyncStatus(_done())
+
+
+def _collect(plan) -> list[Msg]:
+    messages: list[Msg] = []
+    try:
+        msg = plan.send(None)
+        while True:
+            messages.append(msg)
+            msg = plan.send(None)
+    except StopIteration:
+        pass
+    return messages
+
+
+#: Write values name their state so tests can read the trigger state
+#: straight off the journal / message stream.
+_STATES = {
+    "SCAN": [("U_DG645", "Amplitude.Ch AB", "SCAN")],
+    "STANDBY": [("U_DG645", "Amplitude.Ch AB", "STANDBY")],
+    # Two OFF writes pin the ordered, each-completes-first drive.
+    "OFF": [
+        ("U_DG645", "Trigger.Source", "OFF-1"),
+        ("U_DG645", "Amplitude.Ch AB", "OFF-2"),
+    ],
+    "ARMED": [("U_DG645", "Trigger.Source", "ARMED")],
+    "SINGLESHOT": [("U_DG645", "Trigger.Source", "FIRE")],
+}
+
+
+def _controller(journal: list, states: dict | None = None) -> ShotController:
+    writes = ShotControlWrites(name="test profile", states=states or _STATES)
+    return ShotController.from_writes(
+        writes,
+        setter_factory=lambda device, variable: _RecordingSetter(
+            journal, (device, variable)
+        ),
+    )
+
+
+def _journal_values(journal: list) -> list[str]:
+    return [value for _key, value in journal]
+
+
+# ---------------------------------------------------------------------------
+# Replay-cache audit: what can a hard pause replay?  (message-level, CI-safe)
+# ---------------------------------------------------------------------------
+
+
+def _assert_no_replayable_completed_row(commands: list[str]) -> None:
+    """Walk the RE's rewind-cache reconstruction over *commands*.
+
+    Mirrors the RunEngine exactly: uncacheable commands are never cached, a
+    processed ``checkpoint`` empties the cache.  A hard pause landing after
+    message ``i`` replays the cache as reconstructed at ``i`` — so a cache
+    containing a ``save`` (a completed event row: re-running it duplicates
+    the row and, in strict mode, re-fires the shot) is tolerable only in the
+    residual instant where the very next message is the checkpoint that
+    clears it.  (That two-message window is irreducible: no message fits
+    between a bundle's ``save`` and the next processed message.)
+    """
+    uncacheable = set(RunEngine._UNCACHEABLE_COMMANDS)
+    cache: list[str] = []
+    for index, command in enumerate(commands):
+        if command == "checkpoint":
+            cache = []
+            continue
+        if command not in uncacheable:
+            cache.append(command)
+        if "save" in cache:
+            following = commands[index + 1] if index + 1 < len(commands) else None
+            assert following == "checkpoint", (
+                f"a completed event row is hard-pause-replayable at message "
+                f"{index} ({command!r}): the next message is {following!r}, "
+                "not the checkpoint that would clear it"
+            )
+
+
+def test_step_plan_hard_pause_never_replays_a_completed_row() -> None:
+    """Strict step scan with full trigger bracketing passes the cache walk."""
+    journal: list = []
+    controller = _controller(journal)
+    motor = _NamedFake("jet_z")
+    det = _NamedFake("cam")
+    messages = _collect(
+        geecs_step_scan(
+            motor=motor,
+            positions=[0.0, 1.0, 2.0],
+            detectors=[det],
+            shots_per_step=2,
+            setup_trigger=lambda: controller.arm_single_shot([]),
+            fire_shot=controller.fire_shot,
+        )
+    )
+    _assert_no_replayable_completed_row([m.command for m in messages])
+
+
+def test_free_run_plan_hard_pause_never_replays_a_completed_row() -> None:
+    """Free-run (arm/disarm per bin + tail flush) passes the cache walk.
+
+    The bin's disarm writes and the end-of-scan quiesce + tail flush are the
+    segments the #641 audit found unprotected: without the post-rows and
+    post-flush checkpoints, a hard pause there replayed the last completed
+    row (duplicate event + re-fired trigger).
+    """
+    pytest.importorskip("aioca")
+    from ophyd_async.core import set_mock_value
+
+    from geecs_bluesky.devices.ca import CaGenericDetector
+    from geecs_bluesky.plans.free_run_step_scan import geecs_free_run_step_scan
+    from tests.ca_mock_helpers import connect_mock, start_pacer
+
+    journal: list = []
+    controller = _controller(journal)
+    ref = CaGenericDetector("U_Ref", ["Sig"], name="ref")
+    ref.configure_shot_id(rep_rate_hz=1.0)
+
+    RE = RunEngine()
+    commands: list[str] = []
+    RE.msg_hook = lambda msg: commands.append(msg.command)
+    connect_mock(RE, ref)
+    set_mock_value(ref.acq_timestamp, 1000.0)
+    pacer = start_pacer(RE, [(ref, 1000.0)], initial_delay=0.2, interval=0.1)
+    try:
+        RE(
+            geecs_free_run_step_scan(
+                motor=None,
+                positions=[None],
+                reference=ref,
+                detectors=[],
+                shots_per_step=2,
+                arm_trigger=controller.arm,
+                disarm_trigger=controller.disarm,
+                quiesce_trigger=controller.quiesce,
+            )
+        )
+    finally:
+        pacer.cancel()
+    _assert_no_replayable_completed_row(commands)
+
+
+# ---------------------------------------------------------------------------
+# ShotControlPauseQuiescer: the Pausable seam
+# ---------------------------------------------------------------------------
+
+
+def _quiesced_plan(quiescer: ShotControlPauseQuiescer, controller: ShotController):
+    yield from quiescer.register()
+    yield from controller.arm()
+    yield from bps.checkpoint()
+    yield from bps.pause()
+    yield from controller.disarm()
+
+
+def test_hard_pause_quiesces_and_resume_reasserts_in_order() -> None:
+    """SCAN → pause drives OFF (ordered); resume re-asserts SCAN first."""
+    journal: list = []
+    controller = _controller(journal)
+    RE = RunEngine()
+    with pytest.raises(RunEngineInterrupted):
+        RE(_quiesced_plan(ShotControlPauseQuiescer(controller), controller))
+    assert RE.state == "paused"
+    # The two OFF writes ran in profile order, after the plan's SCAN.
+    assert _journal_values(journal) == ["SCAN", "OFF-1", "OFF-2"]
+    assert controller.last_state == "OFF"
+    RE.resume()
+    # SCAN re-asserted (before any replay could run), then the plan's disarm.
+    assert _journal_values(journal) == [
+        "SCAN",
+        "OFF-1",
+        "OFF-2",
+        "SCAN",
+        "STANDBY",
+    ]
+    assert controller.last_state == "STANDBY"
+
+
+def test_deferred_pause_verb_quiesces_identically() -> None:
+    """The operator's deferred verb rides the same seam as the hard pause."""
+    journal: list = []
+    controller = _controller(journal)
+
+    def plan(quiescer):
+        yield from quiescer.register()
+        yield from controller.arm()
+        yield from bps.deferred_pause()
+        yield from bps.checkpoint()  # the deferred pause lands here
+        yield from controller.disarm()
+
+    RE = RunEngine()
+    with pytest.raises(RunEngineInterrupted):
+        RE(plan(ShotControlPauseQuiescer(controller)))
+    assert RE.state == "paused"
+    assert _journal_values(journal) == ["SCAN", "OFF-1", "OFF-2"]
+    RE.resume()
+    assert _journal_values(journal)[-2:] == ["SCAN", "STANDBY"]
+
+
+def test_strict_armed_is_already_quiescent_no_writes_on_pause() -> None:
+    """ARMED (strict) pauses without any quiesce write — pinned by design.
+
+    The single-shot trigger source cannot free-run, so the paused state is
+    quiescent by construction; driving OFF would be extra hardware traffic
+    for nothing.  ``QUIESCE_FROM`` is the doctrine.
+    """
+    assert QUIESCE_FROM == {"SCAN", "STANDBY"}
+    journal: list = []
+    controller = _controller(journal)
+
+    def plan(quiescer):
+        yield from quiescer.register()
+        yield from controller.set_state("ARMED")
+        yield from bps.checkpoint()
+        yield from bps.pause()
+
+    RE = RunEngine()
+    with pytest.raises(RunEngineInterrupted):
+        RE(plan(ShotControlPauseQuiescer(controller)))
+    assert RE.state == "paused"
+    assert _journal_values(journal) == ["ARMED"]
+    RE.resume()
+    assert _journal_values(journal) == ["ARMED"]  # nothing re-asserted either
+    assert controller.last_state == "ARMED"
+
+
+def test_profile_without_off_warns_and_writes_nothing(caplog) -> None:
+    """No OFF state → loud warning, no writes, pause still succeeds."""
+    journal: list = []
+    states = {key: writes for key, writes in _STATES.items() if key != "OFF"}
+    controller = _controller(journal, states)
+
+    def plan(quiescer):
+        yield from quiescer.register()
+        yield from controller.arm()
+        yield from bps.checkpoint()
+        yield from bps.pause()
+
+    RE = RunEngine()
+    with caplog.at_level(logging.WARNING, logger="geecs_bluesky.plans.pause_semantics"):
+        with pytest.raises(RunEngineInterrupted):
+            RE(plan(ShotControlPauseQuiescer(controller)))
+    assert RE.state == "paused"
+    assert _journal_values(journal) == ["SCAN"]
+    assert any("defines no OFF" in record.message for record in caplog.records)
+    RE.resume()
+
+
+def test_build_step_scan_plan_registers_the_quiescer_first() -> None:
+    """The composed plan's first message registers the quiescer (issue #641)."""
+    journal: list = []
+    controller = _controller(journal)
+    plan = build_step_scan_plan(
+        strict=True,
+        motor=None,
+        positions=[None],
+        reference=None,
+        detectors=[_NamedFake("cam")],
+        shots_per_step=1,
+        controller=controller,
+        experiment="",
+        scan_number=None,
+        scan_folder=None,
+        saving_detectors=[],
+    )
+    first = _collect(plan)[0]
+    assert first.command == "null"
+    assert isinstance(first.obj, ShotControlPauseQuiescer)
+
+
+# ---------------------------------------------------------------------------
+# Flagship: hard pause mid-move in a free-run scan (RE + CA mocks)
+# ---------------------------------------------------------------------------
+
+
+def test_hard_pause_mid_move_resume_replays_only_the_move() -> None:
+    """Immediate operator pause mid-move: the issue-#641 acceptance triple.
+
+    Resume must (1) duplicate no event document, (2) re-fire no trigger in
+    the replayed segment, (3) re-issue the move to the same absolute target
+    — with the quiescer's OFF/re-assert bracketing the pause, sequenced
+    before the replay.  Also pins the window claim: pre-move checkpoints
+    land disarmed (STANDBY/OFF), per-row checkpoints land inside SCAN.
+    """
+    pytest.importorskip("aioca")
+    from ophyd_async.core import callback_on_mock_put, set_mock_value
+
+    from geecs_bluesky.devices.ca import CaGenericDetector, CaMotor
+    from geecs_bluesky.plans.free_run_step_scan import geecs_free_run_step_scan
+    from tests.ca_mock_helpers import connect_mock, start_pacer
+
+    journal: list = []
+    controller = _controller(journal)
+    quiescer = ShotControlPauseQuiescer(controller)
+    motor = CaMotor("U_Stage", "Position (mm)", name="scan_motor", move_timeout=60.0)
+    ref = CaGenericDetector("U_Ref", ["Sig"], name="ref")
+    ref.configure_shot_id(rep_rate_hz=1.0)
+
+    RE = RunEngine()
+    messages: list[Msg] = []
+    RE.msg_hook = messages.append
+    docs: list[tuple[str, dict]] = []
+    RE.subscribe(lambda name, doc: docs.append((name, doc)))
+    connect_mock(RE, motor, ref)
+    set_mock_value(ref.acq_timestamp, 1000.0)
+    # No setpoint follower at first: the bin-2 move to 1.0 cannot converge,
+    # so the RE is deterministically stuck in that move's wait when the
+    # immediate pause arrives.  (Bin 1 moves to 0.0 = the initial readback.)
+    # One combined mock-put callback — a second callback_on_mock_put would
+    # replace the first, losing the replayed put from the record.
+    setpoint_puts: list[float] = []
+    following = {"on": False}
+
+    def _on_setpoint_put(value, **kwargs):
+        setpoint_puts.append(float(value))
+        if following["on"]:
+            set_mock_value(motor.position, value)
+
+    callback_on_mock_put(motor._setpoint, _on_setpoint_put)
+
+    def plan():
+        yield from quiescer.register()
+        yield from geecs_free_run_step_scan(
+            motor=motor,
+            positions=[0.0, 1.0],
+            reference=ref,
+            detectors=[],
+            shots_per_step=2,
+            arm_trigger=controller.arm,
+            disarm_trigger=controller.disarm,
+            quiesce_trigger=controller.quiesce,
+        )
+
+    def interrupt():
+        deadline = time.monotonic() + 20.0
+        while time.monotonic() < deadline:
+            if 1.0 in setpoint_puts and RE.state == "running":
+                time.sleep(0.3)  # let the RE settle into the move's wait
+                RE.request_pause(defer=False)
+                return
+            time.sleep(0.02)
+
+    pacer = start_pacer(RE, [(ref, 1000.0)], initial_delay=0.2, interval=0.1)
+    interrupter = threading.Thread(target=interrupt, daemon=True)
+    interrupter.start()
+    try:
+        with pytest.raises(RunEngineInterrupted):
+            RE(plan())
+        interrupter.join(timeout=25.0)
+        assert RE.state == "paused"
+        # Paused mid-move: bin 1 had disarmed (STANDBY), so the quiescer
+        # drove OFF — after the scan's own initial quiesce and bin 1.
+        assert _journal_values(journal) == [
+            "OFF-1",
+            "OFF-2",  # scan-start quiesce (pre-t0)
+            "SCAN",
+            "STANDBY",  # bin 1 arm/disarm
+            "OFF-1",
+            "OFF-2",  # quiescer: pause landed
+        ]
+        # Let the replayed move converge, then resume.
+        following["on"] = True
+        RE.resume()
+    finally:
+        pacer.cancel()
+
+    # Quiesce/re-assert bracketing: STANDBY re-asserted on resume (before
+    # the replay), then bin 2 and the end-of-scan quiesce as normal.
+    assert _journal_values(journal) == [
+        "OFF-1",
+        "OFF-2",
+        "SCAN",
+        "STANDBY",
+        "OFF-1",
+        "OFF-2",
+        "STANDBY",  # resume re-assert, ahead of the replayed move
+        "SCAN",
+        "STANDBY",  # bin 2
+        "OFF-1",
+        "OFF-2",  # end-of-scan quiesce
+    ]
+    assert controller.last_state == "OFF"
+
+    # (3) moves re-issue absolute targets only: bin-1 target, the paused
+    # move, and its replay — same absolute value, nothing else.
+    assert setpoint_puts == [0.0, 1.0, 1.0]
+
+    # (1) no duplicate event documents: 4 primary rows, indices 1-4 once.
+    streams = {
+        doc["uid"]: doc.get("name") for name, doc in docs if name == "descriptor"
+    }
+    primary_rows = [
+        doc
+        for name, doc in docs
+        if name == "event" and streams.get(doc["descriptor"]) == "primary"
+    ]
+    indices = sorted(row["data"]["scan_event_index"] for row in primary_rows)
+    assert indices == [1, 2, 3, 4]
+    seq_nums = [row["seq_num"] for row in primary_rows]
+    assert len(seq_nums) == len(set(seq_nums))
+
+    # (2) no re-fired trigger in the replayed segment: one trigger per row.
+    commands = [m.command for m in messages]
+    assert commands.count("trigger") == 4
+
+    # Window claim (the issue's candidate (b), verified): walk the
+    # plan-driven trigger state at each checkpoint.  Pre-move checkpoints sit
+    # disarmed (OFF/STANDBY); per-row checkpoints sit INSIDE SCAN — which
+    # is exactly why the quiescer exists.
+    state = None
+    states_at_checkpoints: list[str | None] = []
+    for message in messages:
+        if message.command == "set" and isinstance(message.obj, _RecordingSetter):
+            state = str(message.args[0]).split("-")[0]
+        elif message.command == "checkpoint":
+            states_at_checkpoints.append(state)
+    assert "SCAN" in states_at_checkpoints, (
+        "expected per-row checkpoints inside the SCAN window - if this "
+        "stops holding, the quiescer rationale needs re-auditing"
+    )
+    assert states_at_checkpoints[0] in (None, "OFF"), "pre-bin checkpoint armed?"
+
+
+# ---------------------------------------------------------------------------
+# Failed-move → pause (decision 4): retry from checkpoint, stop gracefully
+# ---------------------------------------------------------------------------
+
+
+class _FlakyMotor:
+    """Movable failing its move to *fail_at* the first *failures* times."""
+
+    parent = None
+
+    def __init__(self, name: str, fail_at: float, failures: int) -> None:
+        self.name = name
+        self.fail_at = fail_at
+        self.failures_left = failures
+        self.attempts: list[float] = []
+        self._position = 0.0
+
+    def set(self, value: float) -> AsyncStatus:
+        self.attempts.append(float(value))
+        fail = value == self.fail_at and self.failures_left > 0
+        if fail:
+            self.failures_left -= 1
+
+        async def _move() -> None:
+            if fail:
+                raise RuntimeError(
+                    f"simulated move failure: {self.name} did not reach {value}"
+                )
+            self._position = float(value)
+
+        return AsyncStatus(_move())
+
+    def read(self) -> dict:
+        return {self.name: {"value": self._position, "timestamp": 0.0}}
+
+    def describe(self) -> dict:
+        return {self.name: {"source": "sim", "dtype": "number", "shape": []}}
+
+
+class _PlainDet(_NamedFake):
+    def read(self) -> dict:
+        return {self.name: {"value": 42.0, "timestamp": 0.0}}
+
+    def describe(self) -> dict:
+        return {self.name: {"source": "sim", "dtype": "number", "shape": []}}
+
+
+def _failed_move_scan(motor: _FlakyMotor):
+    return geecs_step_scan(
+        motor=motor,
+        positions=[0.0, 1.0],
+        detectors=[_PlainDet("cam")],
+        shots_per_step=2,
+    )
+
+
+def _primary_indices(docs: list[tuple[str, dict]]) -> list[int]:
+    return sorted(
+        doc["data"]["scan_event_index"] for name, doc in docs if name == "event"
+    )
+
+
+def test_failed_move_pauses_with_reason_and_resume_retries(caplog) -> None:
+    """One failure: reason logged, RE paused; resume replays the move once."""
+    motor = _FlakyMotor("flaky", fail_at=1.0, failures=1)
+    RE = RunEngine()
+    docs: list[tuple[str, dict]] = []
+    RE.subscribe(lambda name, doc: docs.append((name, doc)))
+    with caplog.at_level(logging.ERROR, logger="geecs_bluesky.plans.step_scan"):
+        with pytest.raises(RunEngineInterrupted):
+            RE(_failed_move_scan(motor))
+    assert RE.state == "paused"
+    reasons = [
+        record.message
+        for record in caplog.records
+        if FAILED_MOVE_LOG_PREFIX in record.message
+    ]
+    assert len(reasons) == 1
+    assert "flaky -> 1.0" in reasons[0]
+    assert "simulated move failure" in reasons[0]
+
+    RE.resume()
+    assert RE.state == "idle"
+    # The retry came from the checkpoint replay: same absolute target again.
+    assert motor.attempts == [0.0, 1.0, 1.0]
+    # No row lost, no row duplicated across the pause/replay.
+    assert _primary_indices(docs) == [1, 2, 3, 4]
+
+
+def test_failed_move_retry_that_fails_pauses_again(caplog) -> None:
+    """Two failures: pause → resume (retry fails) → pause → resume → done."""
+    motor = _FlakyMotor("flaky", fail_at=1.0, failures=2)
+    RE = RunEngine()
+    docs: list[tuple[str, dict]] = []
+    RE.subscribe(lambda name, doc: docs.append((name, doc)))
+    with caplog.at_level(logging.ERROR, logger="geecs_bluesky.plans.step_scan"):
+        with pytest.raises(RunEngineInterrupted):
+            RE(_failed_move_scan(motor))
+        assert RE.state == "paused"
+        with pytest.raises(RunEngineInterrupted):
+            RE.resume()  # the replayed retry fails → paused again
+        assert RE.state == "paused"
+        RE.resume()
+    assert RE.state == "idle"
+    assert motor.attempts == [0.0, 1.0, 1.0, 1.0]
+    assert _primary_indices(docs) == [1, 2, 3, 4]
+    reasons = [
+        record.message
+        for record in caplog.records
+        if FAILED_MOVE_LOG_PREFIX in record.message
+    ]
+    assert len(reasons) == 2
+
+
+def test_failed_move_then_stop_ends_gracefully() -> None:
+    """Stop from the failed-move pause: graceful stop document, RE idle."""
+    motor = _FlakyMotor("flaky", fail_at=1.0, failures=10_000)
+    RE = RunEngine()
+    docs: list[tuple[str, dict]] = []
+    RE.subscribe(lambda name, doc: docs.append((name, doc)))
+    with pytest.raises(RunEngineInterrupted):
+        RE(_failed_move_scan(motor))
+    assert RE.state == "paused"
+    RE.stop()
+    assert RE.state == "idle"
+    stop_docs = [doc for name, doc in docs if name == "stop"]
+    assert len(stop_docs) == 1
+    assert stop_docs[0]["exit_status"] == "success"  # graceful, not aborted
+    # Bin 1 completed before the failure; its rows survive exactly once.
+    assert _primary_indices(docs) == [1, 2]


### PR DESCRIPTION
Implements #641 (qs/W3: pause semantics — quiesce-on-pause, checkpoint placement, failed-move retry). Base and PR target: `feat/queueserver`. Per the Planning doc's task split, this PR owns `orchestration.py`, `step_scan.py`, `free_run_step_scan.py`, the new `plans/pause_semantics.py` helper, their tests, `pyproject.toml`, `CHANGELOG.md` — it does **not** touch `plans/scan_request_plan.py` or `qserver/**` (parallel task).

Designed from the Planning doc's 2026-08-20 sandbox-spike amendment and verified directly against installed bluesky 1.15.0 source: **deferred pause** waits for the next checkpoint and replays nothing; **hard/immediate pause** replays from the last checkpoint, and a replayed GEECS `set` re-executes — hardware re-moves. That corollary drives both halves of this PR.

## 1. Quiesce-on-pause

`ShotControlPauseQuiescer` (`plans/pause_semantics.py`) implements bluesky's `Pausable` protocol (`async pause()` / `async resume()`). The RunEngine awaits `Pausable.pause()` on every object it has "seen" (via any message referencing it) while entering the paused state, and awaits `Pausable.resume()` on all of them *before* replaying cached messages on resume — so this is the correct seam to force shots off during a pause, independent of where in a plan the pause lands.

- `register()` yields a no-op `Msg("null", self)` so the RE sees the quiescer; wired into `build_step_scan_plan` in `orchestration.py` via a `_with_pause_quiescer` wrapper, registered before the wrapped plan runs.
- `QUIESCE_FROM = {SCAN, STANDBY}`: on pause, if `controller.last_state` is one of these, drive to `OFF` and stash the prior state; on resume, re-assert the stashed state. `ARMED` (strict-shot-control's baseline) is a no-op — already quiescent by construction.
- If `OFF` isn't defined for the controller, log a warning and skip quiescing rather than raising — `pause()`/`resume()` never raise, since a `Pausable` exception mid-pause would leave the RE in an inconsistent state.
- **Transitional coexistence with the console's `PauseSupervisor`** (dies at Round 3): while both are live on the bridge/console path, a pause double-quiesces (redundant `OFF`/restore writes on both sides) and the supervisor's restore is no longer a safety net for a plan-driven pause. End state is provably correct either way; documented in `pause_semantics.py` rather than fixed, since it's inherently temporary (cross-vendor review, #645).

## 2. Checkpoint-placement audit

Every `bps.checkpoint()` call was audited against "what would a hard pause replay from here" by reimplementing the RE's uncacheable/rewind cache logic as a test helper (`_assert_no_replayable_completed_row` in the new test file) and running it over the full message stream of both step plans.

| Segment | Replays on hard pause | Verdict |
|---|---|---|
| Plan setup (stage/quiescer-register) | n/a — before first checkpoint | OK, no data yet |
| Pre-move (existing) | The upcoming move | OK — re-commanding a position is idempotent |
| Post-move (NEW) | Nothing (already at checkpoint) | Closes a window: previously a pause after move-before-shots would replay the move on resume |
| **Post-per_step (NEW, #645 cross-vendor addendum, P1)** | Nothing (already at checkpoint) | Closes a window: previously a pause after `per_step()`'s compiled ActionPlan writes (`bps.abs_set` calls — not guaranteed idempotent like an absolute move) but before arm would replay those completed writes |
| Pre-row (existing) | The upcoming row's shots | OK — shots haven't fired yet |
| Post-rows / pre-disarm (NEW) | Nothing | Closes a window: previously a pause after the last row but before disarm (strict) / disarm+advance (free-run) would replay completed shot events |
| Post-flush (NEW, free-run only) | Nothing | Closes a window after the tail create/read/save flush |
| Strict-mode end | n/a — final checkpoint before unstage | OK |

Three residuals, all irreducible at checkpoint-placement granularity and documented in code comments, out of scope for this PR:
- **Mid-shot bounded refire (strict mode):** a hard pause landing between the pre-row checkpoint and the next checkpoint — i.e. during a shot's own create/read/save — replays from the pre-row checkpoint, re-firing that one shot. Bounded to a single row, but it is a real re-fire, not a no-op.
- **The save→checkpoint instant:** the two-message gap between a row's `save` completing and the following checkpoint executing is not itself checkpointed (bluesky has no finer granularity). A hard pause requested in that exact window resumes from the *previous* checkpoint, which still holds the just-completed row — so it **can** replay a completed row and duplicate its event, not merely re-arm with nothing at stake. Width is two messages; not closable without a checkpoint between every message pair, which the RE doesn't support.
- **Mid-action residual (per_step):** a hard pause landing *during* `per_step()` itself (mid-action, before it yields back to the loop) still replays from the post-move checkpoint through the partial `per_step` execution — same class as the two residuals above, not closable by checkpoint placement alone (would need per-action idempotence in the ActionPlan compiler, out of this module's scope).

## 3. Failed-move → pause → retry

`move_with_failed_move_pause` (`plans/step_scan.py`, kept in the owned file rather than `pause_semantics.py` per module ownership) wraps `move_changed_axes`: on `FailedStatus`, logs `FAILED MOVE - pausing for operator` with the failing axes/targets and the exception cause (bluesky never attaches the failing device to the status object itself, so the cause — e.g. `GeecsMotorTimeoutError.device_name`/`variable` — is the reliable attribution point when multiple axes moved concurrently), then `bps.pause()`s. Resuming replays the move from the last checkpoint (decision 4). If the replayed move also fails, the loop catches the re-thrown `FailedStatus` and pauses again — indefinitely, until the move succeeds or the operator stops the scan.

**`failed_move_policy: Literal["raise", "pause"] = "raise"`** gates this path, threaded from `build_step_scan_plan` down through both step plans. Default `"raise"` preserves exact pre-#641 behavior (propagate `FailedStatus`, no pause) for any caller that doesn't opt in — notably `scan_request_plan.py` (the bridge/console path, untouched by this PR), which never enters the new pause path. This closes a coordinator-review finding: the console's `PauseSupervisor` auto-resumes a pause it doesn't recognize as operator-intentional, which would otherwise turn a failed move into an unbounded silent retry loop (and, per a cross-vendor follow-up, also let a Stop issued mid-pause bypass the finalize chain via the supervisor's park/resume logic). With the default `raise`, the bridge path is unaffected by either issue; wiring `'pause'` into `scan_request_plan.py` for the queueserver path is a follow-up owned by the coordinator once the sibling PR merges.

## Tests

- `tests/test_pause_semantics.py`: replay-cache audit over both plans' full message streams; `ShotControlPauseQuiescer` behavior (hard/deferred pause parity, ARMED no-op, missing-OFF warning, registration order); flagship `test_hard_pause_mid_move_resume_replays_only_the_move` (threads a real `RE.request_pause(defer=False)` mid-move, asserts the move re-fires exactly once and event/seq_num integrity holds); failed-move retry tests (single failure, double failure, stop-ends-gracefully); `test_failed_move_policy_defaults_to_raise_like_legacy` (pins the default — `FailedStatus` propagates, single attempt, no pause); message-level pins for the new post-per_step checkpoint in both the strict and free-run plans (`test_step_plan_checkpoints_immediately_after_per_step`, `test_free_run_plan_checkpoints_immediately_after_per_step`).
- `tests/test_pause_checkpoints.py` (updated counts for the checkpoints added by this PR, including the post-per_step checkpoint).
- `tests/test_grid_plans_message_level.py` (fixed a placement assertion that needed to skip checkpoints, not just find the nearest preceding message; already generic enough to tolerate the post-per_step checkpoint without further changes).

`./scripts/check.sh GeecsBluesky`: **800 passed, 1 skipped, 3 deselected**.

## LOC breakdown

- `plans/pause_semantics.py`: +190 (new + F3/P1 docstring additions)
- `plans/step_scan.py`: retry helper + `failed_move_policy` flag + 3 checkpoints + comments, ~+65
- `plans/free_run_step_scan.py`: switched to retry helper + `failed_move_policy` flag + 4 checkpoints + comments, ~+45
- `plans/orchestration.py`: quiescer wiring + `failed_move_policy` passthrough, ~+15
- `tests/test_pause_semantics.py`: +~750 (new file + F1/P1 pinning tests)
- `tests/test_pause_checkpoints.py`, `tests/test_grid_plans_message_level.py`: assertion fixes only

## Judgment calls

- `QUIESCE_FROM` includes `STANDBY` as well as `SCAN` — `STANDBY` is a shots-armed-but-idle state on some controllers; quiescing from it on pause errs toward safety.
- Quiescer failures are logged and swallowed, never raised — a broken quiesce shouldn't prevent the RE's own pause/resume machinery from completing.
- Failed-move retries are unbounded (operator-driven), matching decision 4's intent — no retry-count cap was requested by the issue.
- `failed_move_policy` defaults to `"raise"` rather than `"pause"` — the new pause/retry behavior only activates where a caller explicitly opts in, so every existing caller (in-grant tests aside) keeps its pre-#641 failure behavior unless and until it's deliberately switched over.
- `Pausable` is satisfied for both `pause()` and `resume()`; there's no separate `stop()` hook to implement — plan-level cleanup on stop is unaffected by this change.

## Hardware verification — OWED

Not yet exercised against live hardware. Owed at the next campaign integration checkpoint:
- Hard pause mid-move on a real GEECS motor: confirm the move re-issues on resume and the device actually re-settles at the commanded position.
- Deferred pause: confirm no replay occurs and the scan resumes exactly where it left off.
- Quiesce-on-pause: confirm `SCAN`→`OFF`→`SCAN` round-trip on a real `ShotController`-backed device during a live pause/resume, and that no stray shots fire while paused.
- Failed-move retry: force a real move failure (e.g. out-of-range setpoint) and confirm the operator sees the `FAILED MOVE` log line and that resume retries correctly, with `failed_move_policy="pause"` explicitly selected.

Per the issue, the coordinator merges this PR — not opening it pre-merged.
