### PR TITLE
GEECS-Schemas 0.10.0: ScanRequest.submission provenance record (#648)

### DIFF
--- a/GEECS-Schemas/CHANGELOG.md
+++ b/GEECS-Schemas/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to GEECS-Schemas are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.10.0] - 2026-08-21
+
+### Added
+
+- `ScanRequest.submission` — optional submission-provenance record
+  (queueserver migration, issue #648 decision 3): `SubmissionRecord`
+  carries which client queued the request and when, plus the pre-submit
+  preflight outcomes (`PreflightOutcome` /
+  `PreflightCheckResult`: passed / continued / skipped). Filled in by the
+  submitting client at queue time, copied into run metadata by the
+  engine, never acted on — a request without one runs exactly the same.
+  Saved presets leave it unset.
+
 ## [0.9.1] - 2026-08-20
 
 ### Changed

--- a/GEECS-Schemas/geecs_schemas/__init__.py
+++ b/GEECS-Schemas/geecs_schemas/__init__.py
@@ -36,9 +36,12 @@ from geecs_schemas.scan_request import (
     PositionList,
     PositionRange,
     Positions,
+    PreflightCheckResult,
+    PreflightOutcome,
     ScanAxis,
     ScanRequest,
     ScanRequestMode,
+    SubmissionRecord,
 )
 from geecs_schemas.scan_variables import (
     CompositeMode,
@@ -70,6 +73,9 @@ __all__ = [
     "OptimizationSpec",
     "EvaluatorSpec",
     "GeneratorSpec",
+    "SubmissionRecord",
+    "PreflightOutcome",
+    "PreflightCheckResult",
     # derived_channels
     "DerivedChannels",
     "DerivedChannel",

--- a/GEECS-Schemas/geecs_schemas/scan_request.py
+++ b/GEECS-Schemas/geecs_schemas/scan_request.py
@@ -360,6 +360,89 @@ class OptimizationSpec(SchemaModel):
         return self
 
 
+class PreflightCheckResult(str, Enum):
+    """How one pre-submit check ended.
+
+    Attributes
+    ----------
+    PASSED : str
+        The check found nothing to ask about.
+    CONTINUED : str
+        The check raised a question and the operator chose to continue
+        anyway.
+    SKIPPED : str
+        The check could not run (for example the database was unreachable)
+        and submission went ahead without it.
+    """
+
+    PASSED = "passed"
+    CONTINUED = "continued"
+    SKIPPED = "skipped"
+
+
+class PreflightOutcome(SchemaModel):
+    """One pre-submit check and how it ended, kept for the scan's record.
+
+    A check that would have stopped the submission never produces one of
+    these — an aborted submission is never queued, so there is nothing to
+    record.
+    """
+
+    check: str = Field(
+        description=(
+            "Name of the pre-submit check, e.g. 'unserved_variables', "
+            "'gateway_liveness', 'free_run_staleness'."
+        )
+    )
+    result: PreflightCheckResult = Field(
+        description=(
+            "How the check ended: 'passed' (nothing found), 'continued' "
+            "(the operator saw a warning and chose to go ahead), or "
+            "'skipped' (the check could not run)."
+        )
+    )
+    detail: str = Field(
+        "",
+        description=(
+            "What the check found or why it was skipped, in the words the "
+            "operator saw. Empty for a clean pass."
+        ),
+    )
+
+
+class SubmissionRecord(SchemaModel):
+    """Who submitted this request, when, and what the pre-submit checks said.
+
+    Filled in by the submitting client (the console, a script, an agent) at
+    the moment the request is queued — not written by hand.  The scan engine
+    copies it into the run metadata for provenance and never acts on it: a
+    request without one runs exactly the same.
+    """
+
+    client: str = Field(
+        "",
+        description=(
+            "What submitted the request, e.g. 'geecs-console 0.21.0'. "
+            "Free text, for the record only."
+        ),
+    )
+    submitted_at: str = Field(
+        "",
+        description=(
+            "When the request was queued, as an ISO 8601 timestamp with "
+            "timezone from the submitting machine's clock, e.g. "
+            "'2026-08-21T14:30:00-07:00'. Informational only."
+        ),
+    )
+    preflight: list[PreflightOutcome] = Field(
+        default_factory=list,
+        description=(
+            "The pre-submit checks that ran and how each ended. Empty when "
+            "the client ran no checks."
+        ),
+    )
+
+
 class ScanRequest(VersionedSchemaModel):
     """One complete scan, ready to submit: what to do, what to save, how to trigger.
 
@@ -487,6 +570,16 @@ class ScanRequest(VersionedSchemaModel):
         description=(
             "The optimization problem definition. Required for (and only "
             "allowed with) mode 'optimize'."
+        ),
+    )
+    submission: Optional[SubmissionRecord] = Field(
+        None,
+        description=(
+            "Filled in by the submitting client at queue time — who "
+            "submitted, when, and what the pre-submit checks said. Not "
+            "written by hand and never acted on by the engine; it is copied "
+            "into the run metadata for the record. Leave unset in saved "
+            "presets."
         ),
     )
 

--- a/GEECS-Schemas/pyproject.toml
+++ b/GEECS-Schemas/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-schemas"
-version = "0.9.1"
+version = "0.10.0"
 description = "Versioned Pydantic schemas for GEECS scanner configs (scan requests, save sets, scan variables, trigger profiles, action plans) plus legacy-YAML converters."
 authors = ["Sam Barber <sbarber@lbl.gov>"]
 readme = "README.md"

--- a/GEECS-Schemas/tests/golden/focuscan_scan_request.json
+++ b/GEECS-Schemas/tests/golden/focuscan_scan_request.json
@@ -25,6 +25,7 @@
   ],
   "schema_version": 1,
   "shots_per_step": 10,
+  "submission": null,
   "trigger_profile": null,
   "trigger_variant": null
 }

--- a/GEECS-Schemas/tests/test_scan_request.py
+++ b/GEECS-Schemas/tests/test_scan_request.py
@@ -8,8 +8,10 @@ from geecs_schemas import (
     OptimizationSpec,
     PositionList,
     PositionRange,
+    PreflightCheckResult,
     ScanRequest,
     ScanRequestMode,
+    SubmissionRecord,
 )
 
 
@@ -288,3 +290,53 @@ class TestOptimizationSpec:
         assert spec.evaluator.class_name == "MaxCountsEvaluator"
         dumped = spec.model_dump(by_alias=True)
         assert dumped["evaluator"]["class"] == "MaxCountsEvaluator"
+
+
+class TestSubmissionRecord:
+    def make_record(self, **overrides):
+        base = {
+            "client": "geecs-console 0.21.0",
+            "submitted_at": "2026-08-21T14:30:00-07:00",
+            "preflight": [
+                {"check": "unserved_variables", "result": "passed"},
+                {
+                    "check": "gateway_liveness",
+                    "result": "continued",
+                    "detail": "U_TopView disconnected; operator continued",
+                },
+            ],
+        }
+        base.update(overrides)
+        return base
+
+    def test_absent_defaults_none(self):
+        # Saved presets carry no submission record; the field is optional.
+        request = make_step_request()
+        assert request.submission is None
+
+    def test_round_trip_through_json_dump(self):
+        # The queue path submits model_dump(mode="json") dicts; the record
+        # must survive that round trip intact.
+        request = make_step_request(submission=self.make_record())
+        again = ScanRequest.model_validate(request.model_dump(mode="json"))
+        assert again == request
+        assert again.submission.client == "geecs-console 0.21.0"
+        assert again.submission.preflight[1].result is PreflightCheckResult.CONTINUED
+        assert again.submission.preflight[0].detail == ""
+
+    def test_unknown_result_rejected(self):
+        with pytest.raises(ValidationError):
+            SubmissionRecord.model_validate(
+                self.make_record(preflight=[{"check": "x", "result": "aborted"}])
+            )
+
+    def test_unknown_field_fails_loudly(self):
+        with pytest.raises(ValidationError):
+            SubmissionRecord.model_validate(self.make_record(operator="sam"))
+
+    def test_engine_never_requires_it(self):
+        # A bare record validates: every field has a default. The engine
+        # treats the whole record as informational.
+        record = SubmissionRecord.model_validate({})
+        assert record.client == ""
+        assert record.preflight == []

--- a/docs/geecs_schemas/schema_reference.md
+++ b/docs/geecs_schemas/schema_reference.md
@@ -27,6 +27,7 @@ One complete scan, ready to submit: what to do, what to save, how to trigger.
 | `description` | `str` | no | '' | Free-text note about this scan; it ends up in the scan's metadata and the experiment log. |
 | `background` | `bool` | no | False | Mark this scan's data as background/calibration shots so analysis can find them later. |
 | `optimization` | `OptimizationSpec (optional)` | no | None | The optimization problem definition. Required for (and only allowed with) mode 'optimize'. |
+| `submission` | `SubmissionRecord (optional)` | no | None | Filled in by the submitting client at queue time — who submitted, when, and what the pre-submit checks said. Not written by hand and never acted on by the engine; it is copied into the run metadata for the record. Leave unset in saved presets. |
 
 Example:
 
@@ -122,6 +123,26 @@ Which optimization algorithm proposes the next settings.
 |---|---|---|---|---|
 | `name` | `str` | yes | — | Name of the optimization algorithm, e.g. 'bayes_default', 'random', or 'multipoint_bax_alignment_l2'. |
 | `options` | `dict` | no | empty | Algorithm-specific tuning options. Free-form: each generator documents its own options (legacy 'xopt_config_overrides'). |
+
+### SubmissionRecord
+
+Who submitted this request, when, and what the pre-submit checks said.
+
+| Field | Type | Required | Default | What it does |
+|---|---|---|---|---|
+| `client` | `str` | no | '' | What submitted the request, e.g. 'geecs-console 0.21.0'. Free text, for the record only. |
+| `submitted_at` | `str` | no | '' | When the request was queued, as an ISO 8601 timestamp with timezone from the submitting machine's clock, e.g. '2026-08-21T14:30:00-07:00'. Informational only. |
+| `preflight` | `list[PreflightOutcome]` | no | empty | The pre-submit checks that ran and how each ended. Empty when the client ran no checks. |
+
+### PreflightOutcome
+
+One pre-submit check and how it ended, kept for the scan's record.
+
+| Field | Type | Required | Default | What it does |
+|---|---|---|---|---|
+| `check` | `str` | yes | — | Name of the pre-submit check, e.g. 'unserved_variables', 'gateway_liveness', 'free_run_staleness'. |
+| `result` | `PreflightCheckResult` | yes | — | How the check ended: 'passed' (nothing found), 'continued' (the operator saw a warning and chose to go ahead), or 'skipped' (the check could not run). |
+| `detail` | `str` | no | '' | What the check found or why it was skipped, in the words the operator saw. Empty for a clean pass. |
 
 ## `save_set`
 


### PR DESCRIPTION
## What

Adds the optional `submission` field to `ScanRequest` — the vehicle for W6 (#648) decision-3 provenance. `SubmissionRecord` carries which client queued the request and when (free-text client id + ISO-8601 timestamp), plus a list of `PreflightOutcome`s (`check`, `result`: `passed`/`continued`/`skipped`, `detail` in the operator's words). All fields default; the engine never acts on the record — a request without one runs exactly the same. Saved presets leave it unset.

## Why

Under the queue, preflight dialogs move client-side pre-submit (migration doc decision 3). The record of "operator was asked and chose to continue" must travel with the queued item into run metadata — but `ScanRequest` is `extra="forbid"` and the queue-facing plan signature is a bare `request: dict`, so provenance needs a real schema field. Maintainer approved the schema-field approach 2026-08-21.

- An aborted submission is never queued, so `aborted` is deliberately not a `PreflightCheckResult` value.
- The worker-side `md["submission"]` recording lands in the next PR (GeecsBluesky worker enablers), which depends on this one.

## Scope / LOC

One concern. ~90 LOC of models + descriptions in `scan_request.py`, exports, ~50 LOC tests, regenerated golden (`focuscan_scan_request.json` gains `"submission": null`) and generated `docs/geecs_schemas/schema_reference.md` (+22).

## Tests

`./scripts/check.sh`: lint OK; GEECS-Schemas suite passed (261 passed, corpus-integration test deselected as in CI — its pre-existing stale count floor is noted separately); GeecsBluesky 454 passed, 30 skipped, 2 deselected.

## Hardware verification

Not applicable — schema-only, no scan-execution or device surface. The field's end-to-end flow (client stamp → run metadata) gets exercised in the W6 console-client live check (maintainer's, post-merge, per #648).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Deployment sequencing (review finding 1)

The interim-host worker (running geecs-schemas 0.9.1) must be **pulled + manager-restarted before any client starts stamping `submission`**: `SchemaModel` is `extra="forbid"` and schema validation happens inside the plan at execution, so a stamped request against an old worker dequeues, fails validation, and returns to the **front** of the queue (the #648 item-3 re-run trap, triggered by validation instead of a plan failure). Reverse skew (new worker, old client) is safe — the field is optional. An environment reopen is NOT enough; restart the manager process (same empirical rule as the extras install, see qserver/README.md).
