### PR TITLE
GEECS-Schemas 0.9.2: drift-tolerant corpus count in save-element test

### DIFF
--- a/GEECS-Schemas/CHANGELOG.md
+++ b/GEECS-Schemas/CHANGELOG.md
@@ -11,9 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Test-only: `TestFullCorpus::test_every_save_element_converts` no longer
   pins a hard floor on the legacy save_devices file count (`>= 70`). The
-  corpus is a live GEECS-Plugins-Configs checkout and legacy files
-  disappear as they migrate to the new schema (68 remain as of this
-  change), so the count assertion is now drift-tolerant
+  corpus is a live GEECS-Plugins-Configs checkout and legacy files are
+  rewritten in place to the new schema as they migrate (68 remain as of
+  this change), so the count assertion is now drift-tolerant
   (`converted > 0`); the per-entry legacy-pin assertions are unchanged
   and remain the real guard.
 

--- a/GEECS-Schemas/CHANGELOG.md
+++ b/GEECS-Schemas/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to GEECS-Schemas are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.2] - 2026-08-21
+
+### Fixed
+
+- Test-only: `TestFullCorpus::test_every_save_element_converts` no longer
+  pins a hard floor on the legacy save_devices file count (`>= 70`). The
+  corpus is a live GEECS-Plugins-Configs checkout and legacy files
+  disappear as they migrate to the new schema (68 remain as of this
+  change), so the count assertion is now drift-tolerant
+  (`converted > 0`); the per-entry legacy-pin assertions are unchanged
+  and remain the real guard.
+
 ## [0.9.1] - 2026-08-20
 
 ### Changed

--- a/GEECS-Schemas/pyproject.toml
+++ b/GEECS-Schemas/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-schemas"
-version = "0.9.1"
+version = "0.9.2"
 description = "Versioned Pydantic schemas for GEECS scanner configs (scan requests, save sets, scan variables, trigger profiles, action plans) plus legacy-YAML converters."
 authors = ["Sam Barber <sbarber@lbl.gov>"]
 readme = "README.md"

--- a/GEECS-Schemas/tests/test_corpus_integration.py
+++ b/GEECS-Schemas/tests/test_corpus_integration.py
@@ -154,7 +154,10 @@ class TestFullCorpus:
                     assert entry.at_scan_start == {}, path
                     assert entry.at_scan_end == {}, path
                 converted += 1
-        assert converted >= 70  # 71 legacy files at the time of writing
+        # The corpus is a live checkout: legacy files disappear as they are
+        # migrated to the new schema, so pin only that the conversion path
+        # was exercised — the per-entry assertions above do the real checking.
+        assert converted > 0, "no legacy save_devices files found in corpus"
 
     def test_every_scan_variable_catalog_converts(self):
         converted = 0

--- a/GEECS-Schemas/tests/test_corpus_integration.py
+++ b/GEECS-Schemas/tests/test_corpus_integration.py
@@ -154,10 +154,14 @@ class TestFullCorpus:
                     assert entry.at_scan_start == {}, path
                     assert entry.at_scan_end == {}, path
                 converted += 1
-        # The corpus is a live checkout: legacy files disappear as they are
-        # migrated to the new schema, so pin only that the conversion path
-        # was exercised — the per-entry assertions above do the real checking.
-        assert converted > 0, "no legacy save_devices files found in corpus"
+        # The corpus is a live checkout: legacy files are rewritten in place
+        # to the new schema as they migrate, so the legacy count only shrinks.
+        # Pin only that the conversion path was exercised — the per-entry
+        # assertions above do the real checking.
+        assert converted > 0, (
+            "no legacy save_devices files converted — glob broken, or corpus "
+            "migration complete (retire this legacy pin)"
+        )
 
     def test_every_scan_variable_catalog_converts(self):
         converted = 0

--- a/GeecsBluesky/CHANGELOG.md
+++ b/GeecsBluesky/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to `geecs-bluesky` are documented here.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.55.4] - 2026-08-21
+
+### Fixed
+
+- Formatting-only: `ruff format` applied to two files left unformatted by
+  0.55.3 (`scan_request_runner.py`, `tests/test_pause_semantics.py`) —
+  they failed the pre-commit CI job on every PR targeting the branch. No
+  behavior change.
+
 ## [0.55.3] - 2026-08-21
 
 ### Fixed

--- a/GeecsBluesky/geecs_bluesky/scan_request_runner.py
+++ b/GeecsBluesky/geecs_bluesky/scan_request_runner.py
@@ -773,8 +773,7 @@ def metadata_applied_defaults(
     document.  Emit them as values instead.
     """
     return [
-        {"field": field, "value": value}
-        for field, value in applied_defaults.items()
+        {"field": field, "value": value} for field, value in applied_defaults.items()
     ]
 
 

--- a/GeecsBluesky/pyproject.toml
+++ b/GeecsBluesky/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-bluesky"
-version = "0.55.3"
+version = "0.55.4"
 description = "Bluesky / ophyd-async bridge for the GEECS control system"
 authors = ["Sam Barber <sbarber@lbl.gov>"]
 readme = "README.md"

--- a/GeecsBluesky/tests/test_pause_semantics.py
+++ b/GeecsBluesky/tests/test_pause_semantics.py
@@ -642,7 +642,11 @@ def _failed_move_scan(motor: _FlakyMotor, failed_move_policy: str | None = None)
         positions=[0.0, 1.0],
         detectors=[_PlainDet("cam")],
         shots_per_step=2,
-        **({} if failed_move_policy is None else {"failed_move_policy": failed_move_policy}),
+        **(
+            {}
+            if failed_move_policy is None
+            else {"failed_move_policy": failed_move_policy}
+        ),
     )
 
 


### PR DESCRIPTION
## What + why

`TestFullCorpus::test_every_save_element_converts` pinned a hard floor on the legacy save_devices file count (`converted >= 70`, "71 legacy files at the time of writing"). The corpus is a **live** sibling GEECS-Plugins-Configs checkout, and legacy files are rewritten in place to the new schema as they migrate — three flipped around 2026-08-20 (see GEECS-Plugins-Configs#13), leaving 68 legacy files, so the test fails on every branch with no code change, and any new floor would just fail again as migration continues.

Fix: make the count assertion drift-tolerant — `assert converted > 0` (pins that the legacy-conversion path was actually exercised, i.e. the corpus glob found files and the loop ran; the failure message names both possible causes: broken glob, or migration complete). The **per-entry legacy-pin assertions are unchanged** (`db_scalars is False`, empty `at_scan_start`/`at_scan_end` on every converted entry) — they remain the real guard.

## Second concern (flagged for cheap veto): GeecsBluesky ruff-format fix

The pre-commit CI job failed on this PR's first push for changes that are **not in this PR's diff**: `scan_request_runner.py` and `tests/test_pause_semantics.py` were committed on feat/queueserver (817550da) unformatted, so every PR targeting the branch goes red. Included here as a formatting-only fix (ruff-format output verbatim, 2 files / 9 lines) with a GeecsBluesky 0.55.3 → 0.55.4 patch bump per convention. Veto = drop commit fd2ff692 and this PR stays red on pre-commit through no fault of its own.

## Scope (LOC per concern)

- **Corpus drift fix**: `GEECS-Schemas/tests/test_corpus_integration.py` — 1 assertion → drift-tolerant assert + comment (~9 lines); `pyproject.toml` + `CHANGELOG.md` bump 0.9.1 → 0.10.1 (re-versioned after merging the base forward: #650 landed GEECS-Schemas 0.10.0 mid-flight)
- **Inherited format fix**: `GeecsBluesky/geecs_bluesky/scan_request_runner.py` + `GeecsBluesky/tests/test_pause_semantics.py` — 9 lines mechanical ruff-format; `pyproject.toml` + `CHANGELOG.md` bump 0.55.3 → 0.55.4

## Tests

- `GEECS-Schemas` corpus integration suite against the live sibling checkout: **10 passed**
- `./scripts/check.sh --base origin/feat/queueserver` (GEECS-Schemas + dependent GeecsBluesky): **819 passed, 1 skipped, 3 deselected**
- Lint (pre-commit full hook chain): passed

## Hardware verification

Not applicable — test-only + formatting-only change, no scan-execution or device surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
