### PR TITLE
GeecsBluesky 0.56.0: worker-side enablers for the console queueserver client (#648)

### DIFF
--- a/GeecsBluesky/CHANGELOG.md
+++ b/GeecsBluesky/CHANGELOG.md
@@ -4,6 +4,32 @@ All notable changes to `geecs-bluesky` are documented here.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.56.0] - 2026-08-21
+
+### Added
+
+- Worker-side enablers for the W6 console queueserver client (#648):
+  - **`md["submission"]` recording** — a `ScanRequest.submission`
+    provenance record (geecs-schemas 0.10.0) is copied verbatim into run
+    metadata at all three emission sites (runner step/optimize, plan
+    optimize; the shared step-path builder covers both entry points).
+    `metadata_submission()` in `scan_request_runner` is the one helper.
+  - **`geecs_run_action_plan(name)`** — on-demand ActionPlan execution as
+    an ordinary queue item (decision 2: actions are queue items). Same
+    resolution/flattening/prefetch code paths as the in-scan action
+    slots, in-plan connects, finalize disconnect, no run opened. Manager
+    signature validation pinned (the 0.55.3 bare-namespace lesson).
+  - **ZMQ document publisher** — the startup profile publishes bluesky
+    documents to a `bluesky-0MQ-proxy` (launcher-started, 5567 in /
+    5568 out, `QS_DOC_PROXY*` / `QS_DOC_PUBLISH_ADDR` overrides,
+    best-effort with a loud warning). This is the GUI progress stream;
+    the manager's `--zmq-publish-console` stream is text, not documents.
+  - **Manual-verb functions** — `geecs_move_variable` /
+    `geecs_describe_action` in the startup namespace for the manager's
+    idle-only `function_execute` (the queueserver enforcement of the
+    session's "scan in progress" refusals); `operator` group gains
+    `:geecs_.*` allowed_functions.
+
 ## [0.55.3] - 2026-08-21
 
 ### Fixed

--- a/GeecsBluesky/CHANGELOG.md
+++ b/GeecsBluesky/CHANGELOG.md
@@ -22,13 +22,18 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   - **ZMQ document publisher** — the startup profile publishes bluesky
     documents to a `bluesky-0MQ-proxy` (launcher-started, 5567 in /
     5568 out, `QS_DOC_PROXY*` / `QS_DOC_PUBLISH_ADDR` overrides,
-    best-effort with a loud warning). This is the GUI progress stream;
-    the manager's `--zmq-publish-console` stream is text, not documents.
+    best-effort; a startup TCP probe warns when no proxy answers, since
+    a zmq PUB connect succeeds silently). This is the GUI progress
+    stream; the manager's `--zmq-publish-console` stream is text, not
+    documents.
   - **Manual-verb functions** — `geecs_move_variable` /
     `geecs_describe_action` in the startup namespace for the manager's
-    idle-only `function_execute` (the queueserver enforcement of the
-    session's "scan in progress" refusals); `operator` group gains
-    `:geecs_.*` allowed_functions.
+    `function_execute` (foreground calls require an idle manager — the
+    queueserver enforcement of the session's "scan in progress"
+    refusals); `operator` group allows exactly those two functions.
+    Both queue plans now check the session's manual-move lock before
+    starting (the PR #597 mutual exclusion, carried to the queue path —
+    background-executed moves leave the manager IDLE while converging).
 
 ## [0.55.4] - 2026-08-21
 

--- a/GeecsBluesky/geecs_bluesky/plans/scan_request_plan.py
+++ b/GeecsBluesky/geecs_bluesky/plans/scan_request_plan.py
@@ -88,6 +88,7 @@ from geecs_bluesky.scan_request_runner import (
     compile_action_slot,
     make_scalar_policy,
     metadata_applied_defaults,
+    metadata_submission,
     merge_optimizer_device_requirements,
     prefetch_action_signals,
     resolve_movable_target,
@@ -103,7 +104,12 @@ from geecs_schemas import AcquisitionMode, ScanRequest, ScanRequestMode
 
 logger = logging.getLogger(__name__)
 
-__all__ = ["geecs_scan_request_plan", "set_plan_session", "set_optimization_loader"]
+__all__ = [
+    "geecs_scan_request_plan",
+    "geecs_run_action_plan",
+    "set_plan_session",
+    "set_optimization_loader",
+]
 
 #: Per-connect timeout for the in-plan strict batches.  Near-parity, not
 #: parity, with ``GeecsSession._connect``: there 20 s is the outer wall on
@@ -793,6 +799,9 @@ def _optimize_request_body(
         md["dropped_unserved_devices"] = list(dropped_unserved_devices)
     if applied_defaults:
         md["applied_defaults"] = metadata_applied_defaults(applied_defaults)
+    submission = metadata_submission(request)
+    if submission is not None:
+        md["submission"] = submission
     if skipped:
         md["skipped_action_plans"] = skipped
         logger.warning(
@@ -1011,3 +1020,80 @@ def _optimize_request_body(
         raise
 
     return uid
+
+
+# Same signature constraint as geecs_scan_request_plan (see the comment
+# above its `def`): the RE Manager re-evaluates annotation strings in a bare
+# namespace at `queue add`, so only builtin names may appear — `name: str`
+# is safe, the keyword-only injection seams stay unannotated.
+def geecs_run_action_plan(
+    name: str,
+    *,
+    session=None,
+    resolver=None,
+):
+    """Run one named ActionPlan as its own queue item (decision 2, #648).
+
+    The queueserver replacement for on-demand action execution
+    (:meth:`~geecs_bluesky.session.GeecsSession.run_action`, whose direct
+    ``RE(...)`` call cannot run under a manager-owned RunEngine): the
+    console's Actions menu submits this plan to the queue, so a manual
+    action gets the same queue provenance, ordering, and idle-only
+    semantics as any scan.  No run is opened — an action emits no
+    documents, exactly like today's ``run_action``.
+
+    Resolution, nested-``run`` flattening, signal prefetch, and the
+    compiled step semantics are the same code paths the in-scan action
+    slots use; connects happen via plan messages (the in-plan pattern of
+    :func:`geecs_scan_request_plan`) and a finalize disconnects everything
+    created — success, failure, and abort alike.
+
+    Parameters
+    ----------
+    name :
+        Action-plan name in the experiment's action library.
+    session :
+        The :class:`~geecs_bluesky.session.GeecsSession` whose signal
+        factory builds the action targets.  Defaults to the worker-wide
+        session installed by :func:`set_plan_session`.
+    resolver :
+        Name resolver; defaults to
+        :class:`~geecs_bluesky.config_resolver.ConfigsRepoResolver` over
+        the session's experiment.
+
+    Raises
+    ------
+    GeecsConfigurationError
+        No session configured, or an unknown plan name / bad nested
+        reference (fail-fast, before any signal connects).
+    """
+    if session is None:
+        session = _worker_session
+        if session is None:
+            raise GeecsConfigurationError(
+                "geecs_run_action_plan has no session: install one with "
+                "set_plan_session(...) at worker startup, or pass session=..."
+            )
+    if resolver is None:
+        resolver = ConfigsRepoResolver(session.experiment)
+
+    registry = build_action_registry(resolver)
+    factories = _DeferredConnectFactories(session)
+    factory = factories.action_signal_factory()
+    created: list = [factory]
+
+    def _body():
+        # Fail-fast: unknown names / nested cycles surface in resolution
+        # and prefetch, before any connect message is emitted.
+        stub, plans = compile_action_slot([name], resolver, registry, factory)
+        if stub is None:  # pragma: no cover - [name] is never empty
+            return
+        prefetch_action_signals(plans, registry, factory)
+        created.extend(factories.created)
+        if factories.created:
+            yield from _connect_in_batches(factories.created, mock=session._mock)
+        logger.info("Running action %r (queue item)", name)
+        yield from stub()
+        logger.info("Action %r completed", name)
+
+    return (yield from bpp.finalize_wrapper(_body(), lambda: _disconnect_plan(created)))

--- a/GeecsBluesky/geecs_bluesky/plans/scan_request_plan.py
+++ b/GeecsBluesky/geecs_bluesky/plans/scan_request_plan.py
@@ -424,6 +424,11 @@ def geecs_scan_request_plan(
                 "geecs_scan_request_plan has no session: install one with "
                 "set_plan_session(...) at worker startup, or pass session=..."
             )
+    # The session's manual-move mutual exclusion (PR #597 contract) must
+    # travel to the queue path: a background-executed geecs_move_variable
+    # leaves the manager IDLE while a move converges, so a queue start could
+    # otherwise drive hardware mid-move (#652 review finding 1).
+    session._refuse_if_manual_move("scan not started")
     if resolver is None:
         resolver = ConfigsRepoResolver(session.experiment)
 
@@ -1074,6 +1079,9 @@ def geecs_run_action_plan(
                 "geecs_run_action_plan has no session: install one with "
                 "set_plan_session(...) at worker startup, or pass session=..."
             )
+    # Same manual-move mutual exclusion as geecs_scan_request_plan (the
+    # session contract must travel to the queue path — #652 review).
+    session._refuse_if_manual_move("action not started")
     if resolver is None:
         resolver = ConfigsRepoResolver(session.experiment)
 

--- a/GeecsBluesky/geecs_bluesky/scan_request_runner.py
+++ b/GeecsBluesky/geecs_bluesky/scan_request_runner.py
@@ -773,9 +773,22 @@ def metadata_applied_defaults(
     document.  Emit them as values instead.
     """
     return [
-        {"field": field, "value": value}
-        for field, value in applied_defaults.items()
+        {"field": field, "value": value} for field, value in applied_defaults.items()
     ]
+
+
+def metadata_submission(request: ScanRequest) -> dict[str, Any] | None:
+    """Return the request's submission-provenance record for run metadata.
+
+    ``ScanRequest.submission`` (geecs-schemas 0.10.0) is stamped by the
+    submitting client at queue time — who queued the request, when, and the
+    pre-submit preflight outcomes.  The engine records it verbatim and never
+    acts on it.  ``None`` when the client stamped nothing (headless callers,
+    saved presets), so callers gate the metadata key on the return value.
+    """
+    if request.submission is None:
+        return None
+    return request.submission.model_dump(mode="json")
 
 
 def resolve_experiment_defaults(resolver: ConfigResolver) -> Any | None:
@@ -1025,6 +1038,11 @@ def build_step_scan_spec(
         # Provenance: the run records exactly which experiment defaults
         # filled in fields the submitter left unset.
         md["applied_defaults"] = metadata_applied_defaults(applied_defaults)
+    submission = metadata_submission(request)
+    if submission is not None:
+        # Provenance: the submitting client's record — who queued the
+        # request, when, and the pre-submit preflight outcomes (#648).
+        md["submission"] = submission
     if any(slots.values()):
         # Provenance: the assembled per-slot execution order (defaults +
         # entry rituals + the request's own, mirrored on closeout).
@@ -1864,6 +1882,9 @@ def _run_optimize_request(
             md["dropped_unserved_devices"] = list(dropped_unserved_devices)
         if applied_defaults:
             md["applied_defaults"] = metadata_applied_defaults(applied_defaults)
+        submission = metadata_submission(request)
+        if submission is not None:
+            md["submission"] = submission
         if skipped:
             md["skipped_action_plans"] = skipped
             logger.warning(

--- a/GeecsBluesky/pyproject.toml
+++ b/GeecsBluesky/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-bluesky"
-version = "0.55.3"
+version = "0.56.0"
 description = "Bluesky / ophyd-async bridge for the GEECS control system"
 authors = ["Sam Barber <sbarber@lbl.gov>"]
 readme = "README.md"

--- a/GeecsBluesky/qserver/README.md
+++ b/GeecsBluesky/qserver/README.md
@@ -69,6 +69,54 @@ the CLI, or use `bluesky-queueserver-api`, which takes real dicts.
 the manager starts — the profile fails loud at import time otherwise (see
 `startup/startup.py`).
 
+## Document stream (GUI progress)
+
+The startup profile publishes every bluesky document to a
+`bluesky-0MQ-proxy`, which the launcher starts alongside Redis (in port
+`QS_DOC_PROXY_IN`, default 5567; out port `QS_DOC_PROXY_OUT`, default
+5568). GUI clients get live per-shot progress by subscribing to the out
+port:
+
+```python
+from bluesky.callbacks.zmq import RemoteDispatcher
+
+dispatcher = RemoteDispatcher("<worker-host>:5568")
+dispatcher.subscribe(lambda name, doc: ...)
+dispatcher.start()  # blocking — run it in a background thread
+```
+
+Do not confuse this with the manager's `--zmq-publish-console` stream
+(port 60625): that one carries captured stdout/stderr **text** for log
+tails, never documents. The two are complementary — documents for
+progress, console text for the failed-move reason lines and log tail.
+
+Opt out with `QS_DOC_PROXY=OFF` (launcher) plus `QS_DOC_PUBLISH_ADDR=OFF`
+(worker). The stream is best-effort: a worker without it still runs scans
+correctly — only live GUI progress is lost.
+
+## Manual verbs (console Actions menu / Movable panel)
+
+- **Run an action** — submit `geecs_run_action_plan` as an ordinary queue
+  item (decision 2: actions are queue items, with queue provenance and
+  idle-only ordering):
+
+  ```bash
+  qserver queue add plan '{"name": "geecs_run_action_plan", "args": ["close_shutters"], "item_type": "plan"}'
+  ```
+
+- **Move a scan variable** — call `geecs_move_variable(name, value)` via
+  the manager's `function_execute` API. Deliberately *not* a plan:
+  `GeecsSession.move_variable` moves outside the RunEngine. Function
+  execution requires a fully **idle** manager (not running, not paused) —
+  the queueserver enforcement of the old "scan in progress — move not
+  started" refusal.
+
+- **Preview an action** — `geecs_describe_action(name)` via
+  `function_execute`: pure config resolution against *this worker's*
+  configs checkout (authoritative even when a client's checkout drifted).
+  Idle-only like every function — clients wanting a mid-scan preview must
+  resolve client-side instead.
+
 ## Troubleshooting
 
 - **`queue add` returns `success: False` with no reason at the CLI** — the

--- a/GeecsBluesky/qserver/README.md
+++ b/GeecsBluesky/qserver/README.md
@@ -106,16 +106,20 @@ correctly — only live GUI progress is lost.
 
 - **Move a scan variable** — call `geecs_move_variable(name, value)` via
   the manager's `function_execute` API. Deliberately *not* a plan:
-  `GeecsSession.move_variable` moves outside the RunEngine. Function
-  execution requires a fully **idle** manager (not running, not paused) —
-  the queueserver enforcement of the old "scan in progress — move not
-  started" refusal.
+  `GeecsSession.move_variable` moves outside the RunEngine. **Foreground**
+  function execution (`run_in_background=False`, the client default)
+  requires a fully idle manager (not running, not paused) — the
+  queueserver enforcement of the old "scan in progress — move not
+  started" refusal. Background execution bypasses that gate, so the GEECS
+  plans guard the other direction themselves: both queue plans refuse to
+  start while the session's manual-move lock is held ("manual move in
+  progress — scan/action not started").
 
 - **Preview an action** — `geecs_describe_action(name)` via
   `function_execute`: pure config resolution against *this worker's*
   configs checkout (authoritative even when a client's checkout drifted).
-  Idle-only like every function — clients wanting a mid-scan preview must
-  resolve client-side instead.
+  Foreground-idle-only like the move verb — clients wanting a mid-scan
+  preview must resolve client-side instead.
 
 ## Troubleshooting
 

--- a/GeecsBluesky/qserver/deploy/DEPLOYMENT.md
+++ b/GeecsBluesky/qserver/deploy/DEPLOYMENT.md
@@ -166,8 +166,12 @@ The launcher starts a `bluesky-0MQ-proxy` (5567 in / 5568 out) alongside
 Redis when one is not already answering; the startup profile publishes
 bluesky documents into it for GUI progress (see `../README.md`, "Document
 stream"). The proxy runs inside the unit's cgroup on purpose — it is
-stateless, so dying and restarting with the manager is correct behavior;
-no second systemd unit is needed. Override the ports with
+stateless and dies with the unit; no second systemd unit is needed. Caveat
+of that choice: systemd supervises only the main process, so a proxy that
+dies *alone* is not restarted until the next manager restart — the symptom
+is GUI progress going quiet while scans keep running fine (the proxy's
+stderr goes to the journal; the worker also logs a warning at startup when
+nothing answers on the publish port). Override the ports with
 `Environment="QS_DOC_PROXY_IN=…"` / `QS_DOC_PROXY_OUT=…` (paired with
 `QS_DOC_PUBLISH_ADDR` for the worker side), or disable with
 `QS_DOC_PROXY=OFF` + `QS_DOC_PUBLISH_ADDR=OFF`.

--- a/GeecsBluesky/qserver/deploy/DEPLOYMENT.md
+++ b/GeecsBluesky/qserver/deploy/DEPLOYMENT.md
@@ -160,6 +160,31 @@ The unit intentionally carries a commented-out
 key management is still open; the design item is tracked in
 `../../../Planning/cutover_strategy/02_queueserver_migration.md`.
 
+### Document stream (no extra unit)
+
+The launcher starts a `bluesky-0MQ-proxy` (5567 in / 5568 out) alongside
+Redis when one is not already answering; the startup profile publishes
+bluesky documents into it for GUI progress (see `../README.md`, "Document
+stream"). The proxy runs inside the unit's cgroup on purpose — it is
+stateless, so dying and restarting with the manager is correct behavior;
+no second systemd unit is needed. Override the ports with
+`Environment="QS_DOC_PROXY_IN=…"` / `QS_DOC_PROXY_OUT=…` (paired with
+`QS_DOC_PUBLISH_ADDR` for the worker side), or disable with
+`QS_DOC_PROXY=OFF` + `QS_DOC_PUBLISH_ADDR=OFF`.
+
+### Network ports
+
+Client machines (console GUIs) need to reach, on the worker host:
+
+- **60615** — the RE Manager control socket (`bluesky-queueserver-api`),
+- **60625** — the manager's console-output stream (log tail / failed-move
+  reason lines; text, not documents),
+- **5568** — the document-stream out port (live per-shot progress).
+
+Redis (6379) stays loopback-only. The proxy's in port (5567) is only
+ever used by the worker itself (same host) — nothing remote needs it,
+though the proxy binds all interfaces; firewall it with the rest.
+
 ---
 
 ## 3. Verify the manager

--- a/GeecsBluesky/qserver/launch_re_manager.sh
+++ b/GeecsBluesky/qserver/launch_re_manager.sh
@@ -12,8 +12,12 @@ PERMISSIONS_FILE="${SCRIPT_DIR}/user_group_permissions.yaml"
 QS_STARTUP_DIR="${QS_STARTUP_DIR:-./startup}"
 QS_REDIS_SERVER="${QS_REDIS_SERVER:-redis-server}"
 
+port_is_answering() {
+    (exec 3<>"/dev/tcp/127.0.0.1/$1") >/dev/null 2>&1
+}
+
 redis_is_answering() {
-    (exec 3<>/dev/tcp/127.0.0.1/6379) >/dev/null 2>&1
+    port_is_answering 6379
 }
 
 if ! redis_is_answering; then
@@ -36,6 +40,23 @@ if ! redis_is_answering; then
     if ! redis_is_answering; then
         echo "ERROR: Redis did not start or did not answer on 127.0.0.1:6379." >&2
         exit 1
+    fi
+fi
+
+# Document stream (#648): the startup profile publishes bluesky documents to
+# a bluesky-0MQ-proxy (in QS_DOC_PROXY_IN, out QS_DOC_PROXY_OUT); GUI clients
+# subscribe to the out port for live progress. Stateless — restarting with
+# the manager is fine. QS_DOC_PROXY=OFF skips it (pair with
+# QS_DOC_PUBLISH_ADDR=OFF for the worker side).
+QS_DOC_PROXY_IN="${QS_DOC_PROXY_IN:-5567}"
+QS_DOC_PROXY_OUT="${QS_DOC_PROXY_OUT:-5568}"
+if [[ "${QS_DOC_PROXY:-ON}" != "OFF" ]] && ! port_is_answering "${QS_DOC_PROXY_IN}"; then
+    if command -v bluesky-0MQ-proxy >/dev/null 2>&1; then
+        echo "Starting bluesky-0MQ-proxy ${QS_DOC_PROXY_IN} -> ${QS_DOC_PROXY_OUT}." >&2
+        bluesky-0MQ-proxy "${QS_DOC_PROXY_IN}" "${QS_DOC_PROXY_OUT}" >/dev/null 2>&1 &
+    else
+        echo "WARNING: bluesky-0MQ-proxy not on PATH; document stream disabled" >&2
+        echo "(GUI live progress will be empty; set QS_DOC_PROXY=OFF to silence)." >&2
     fi
 fi
 

--- a/GeecsBluesky/qserver/launch_re_manager.sh
+++ b/GeecsBluesky/qserver/launch_re_manager.sh
@@ -50,10 +50,14 @@ fi
 # QS_DOC_PUBLISH_ADDR=OFF for the worker side).
 QS_DOC_PROXY_IN="${QS_DOC_PROXY_IN:-5567}"
 QS_DOC_PROXY_OUT="${QS_DOC_PROXY_OUT:-5568}"
-if [[ "${QS_DOC_PROXY:-ON}" != "OFF" ]] && ! port_is_answering "${QS_DOC_PROXY_IN}"; then
+# Case-insensitive OFF, matching the worker's QS_DOC_PUBLISH_ADDR check.
+QS_DOC_PROXY_MODE="$(printf '%s' "${QS_DOC_PROXY:-ON}" | tr '[:lower:]' '[:upper:]')"
+if [[ "${QS_DOC_PROXY_MODE}" != "OFF" ]] && ! port_is_answering "${QS_DOC_PROXY_IN}"; then
     if command -v bluesky-0MQ-proxy >/dev/null 2>&1; then
         echo "Starting bluesky-0MQ-proxy ${QS_DOC_PROXY_IN} -> ${QS_DOC_PROXY_OUT}." >&2
-        bluesky-0MQ-proxy "${QS_DOC_PROXY_IN}" "${QS_DOC_PROXY_OUT}" >/dev/null 2>&1 &
+        # stderr stays attached (journal / terminal) so a bind failure —
+        # e.g. the out port already taken — is diagnosable, not silent.
+        bluesky-0MQ-proxy "${QS_DOC_PROXY_IN}" "${QS_DOC_PROXY_OUT}" >/dev/null &
     else
         echo "WARNING: bluesky-0MQ-proxy not on PATH; document stream disabled" >&2
         echo "(GUI live progress will be empty; set QS_DOC_PROXY=OFF to silence)." >&2

--- a/GeecsBluesky/qserver/startup/startup.py
+++ b/GeecsBluesky/qserver/startup/startup.py
@@ -104,20 +104,38 @@ RE.subscribe(SFileExportCallback())
 # Redis); clients (GEECS-Console) consume them with
 # bluesky.callbacks.zmq.RemoteDispatcher on the proxy's out port. NOTE the
 # manager's --zmq-publish-console stream is a different thing entirely
-# (captured stdout/stderr text, not documents). Best-effort with a loud
-# warning, same posture as Tiled: a worker without the stream still runs
-# scans correctly — only live GUI progress is lost.
+# (captured stdout/stderr text, not documents). Best-effort, same posture
+# as Tiled: a worker without the stream still runs scans correctly — only
+# live GUI progress is lost. A zmq PUB connect always "succeeds" (it is
+# asynchronous and simply drops while unconnected), so an absent proxy is
+# probed explicitly below — that TCP check is what makes the warning real
+# (#652 review finding 2).
 _doc_publish_addr = os.environ.get("QS_DOC_PUBLISH_ADDR", "localhost:5567")
 if _doc_publish_addr.upper() != "OFF":
     try:
+        import socket
+
         from bluesky.callbacks.zmq import Publisher
 
+        _doc_host, _, _doc_port = _doc_publish_addr.rpartition(":")
+        try:
+            socket.create_connection(
+                (_doc_host or "localhost", int(_doc_port)), timeout=1.0
+            ).close()
+        except OSError:
+            logger.warning(
+                "No document proxy listening at %s — GUI progress streams "
+                "will be empty until one appears (zmq reconnects on its "
+                "own; set QS_DOC_PUBLISH_ADDR, or OFF to silence this)",
+                _doc_publish_addr,
+            )
         RE.subscribe(Publisher(_doc_publish_addr))
         logger.info("Publishing documents to 0MQ proxy at %s", _doc_publish_addr)
     except Exception:
         logger.warning(
-            "Could not publish documents to %s — GUI progress streams will "
-            "be empty (set QS_DOC_PUBLISH_ADDR, or OFF to silence this)",
+            "Could not set up the document publisher for %s — GUI progress "
+            "streams will be empty (set QS_DOC_PUBLISH_ADDR, or OFF to "
+            "silence this)",
             _doc_publish_addr,
             exc_info=True,
         )
@@ -126,9 +144,12 @@ if _doc_publish_addr.upper() != "OFF":
 def geecs_move_variable(name: str, value: float) -> dict:
     """Manually move a scan variable — the console Movable panel's verb (#648).
 
-    Executed via the manager's ``function_execute`` API, which requires a
+    Executed via the manager's ``function_execute`` API. **Foreground**
+    execution (``run_in_background=False``, the client default) requires a
     fully idle manager — the queueserver enforcement of the session's own
-    "scan in progress — move not started" refusal. Not a plan on purpose:
+    "scan in progress — move not started" refusal; background execution
+    bypasses that gate, which is why both GEECS queue plans check the
+    session's manual-move lock before starting. Not a plan on purpose:
     :meth:`~geecs_bluesky.session.GeecsSession.move_variable` moves outside
     the RunEngine (the RE stays idle, guarded by the session's manual-move
     lock), so wrapping it in a queue item would change its semantics.
@@ -151,10 +172,10 @@ def geecs_move_variable(name: str, value: float) -> dict:
 def geecs_describe_action(name: str) -> list[dict]:
     """Dry-run a named ActionPlan against *this worker's* configs (#648).
 
-    Executed via ``function_execute`` (idle manager only). Pure config
-    resolution — no CA, no execution. Serving it worker-side means the
-    preview describes what the worker would actually run, even when a
-    client's configs checkout has drifted.
+    Executed via ``function_execute`` (foreground calls require an idle
+    manager). Pure config resolution — no CA, no execution. Serving it
+    worker-side means the preview describes what the worker would actually
+    run, even when a client's configs checkout has drifted.
 
     Parameters
     ----------

--- a/GeecsBluesky/qserver/startup/startup.py
+++ b/GeecsBluesky/qserver/startup/startup.py
@@ -41,6 +41,7 @@ import os
 import geecs_bluesky  # noqa: F401
 
 from geecs_bluesky.plans.scan_request_plan import (
+    geecs_run_action_plan,
     geecs_scan_request_plan,
     set_optimization_loader,
     set_plan_session,
@@ -98,6 +99,77 @@ set_plan_session(session)
 # Best-effort legacy scalar (s-file) export on every completed run — #635.
 RE.subscribe(SFileExportCallback())
 
+# ZMQ document publisher — the GUI progress stream (#648). bluesky documents
+# go to a bluesky-0MQ-proxy (started by launch_re_manager.sh alongside
+# Redis); clients (GEECS-Console) consume them with
+# bluesky.callbacks.zmq.RemoteDispatcher on the proxy's out port. NOTE the
+# manager's --zmq-publish-console stream is a different thing entirely
+# (captured stdout/stderr text, not documents). Best-effort with a loud
+# warning, same posture as Tiled: a worker without the stream still runs
+# scans correctly — only live GUI progress is lost.
+_doc_publish_addr = os.environ.get("QS_DOC_PUBLISH_ADDR", "localhost:5567")
+if _doc_publish_addr.upper() != "OFF":
+    try:
+        from bluesky.callbacks.zmq import Publisher
+
+        RE.subscribe(Publisher(_doc_publish_addr))
+        logger.info("Publishing documents to 0MQ proxy at %s", _doc_publish_addr)
+    except Exception:
+        logger.warning(
+            "Could not publish documents to %s — GUI progress streams will "
+            "be empty (set QS_DOC_PUBLISH_ADDR, or OFF to silence this)",
+            _doc_publish_addr,
+            exc_info=True,
+        )
+
+
+def geecs_move_variable(name: str, value: float) -> dict:
+    """Manually move a scan variable — the console Movable panel's verb (#648).
+
+    Executed via the manager's ``function_execute`` API, which requires a
+    fully idle manager — the queueserver enforcement of the session's own
+    "scan in progress — move not started" refusal. Not a plan on purpose:
+    :meth:`~geecs_bluesky.session.GeecsSession.move_variable` moves outside
+    the RunEngine (the RE stays idle, guarded by the session's manual-move
+    lock), so wrapping it in a queue item would change its semantics.
+
+    Parameters
+    ----------
+    name : str
+        Catalog scan-variable name or raw ``Device:Variable``.
+    value : float
+        Target value, in the variable's own units.
+
+    Returns
+    -------
+    dict
+        ``move_variable``'s summary: ``{variable, kind, value, targets}``.
+    """
+    return session.move_variable(name, value)
+
+
+def geecs_describe_action(name: str) -> list[dict]:
+    """Dry-run a named ActionPlan against *this worker's* configs (#648).
+
+    Executed via ``function_execute`` (idle manager only). Pure config
+    resolution — no CA, no execution. Serving it worker-side means the
+    preview describes what the worker would actually run, even when a
+    client's configs checkout has drifted.
+
+    Parameters
+    ----------
+    name : str
+        Action-plan name in the experiment's action library.
+
+    Returns
+    -------
+    list of dict
+        One dict per concrete step, in execution order (see
+        :meth:`~geecs_bluesky.session.GeecsSession.describe_action`).
+    """
+    return session.describe_action(name)
+
+
 # scan.log's root-logger attach + pre-claim buffer (GeecsBluesky 0.51.0,
 # geecs_bluesky/scan_log.py) needs no wiring here: geecs_scan_request_plan
 # itself calls begin_pre_scan_capture() at submission and the scan_log(...)
@@ -125,4 +197,10 @@ set_optimization_loader(_optimization_loader)
 if _optimization_loader is not None:
     warm_up_optimization_stack()
 
-__all__ = ["RE", "geecs_scan_request_plan"]
+__all__ = [
+    "RE",
+    "geecs_scan_request_plan",
+    "geecs_run_action_plan",
+    "geecs_move_variable",
+    "geecs_describe_action",
+]

--- a/GeecsBluesky/qserver/user_group_permissions.yaml
+++ b/GeecsBluesky/qserver/user_group_permissions.yaml
@@ -30,8 +30,7 @@ user_groups:
       - null
 
   # Operator group: queue submission is restricted to GEECS-named plans,
-  # function execution to the GEECS-named manual verbs (#648:
-  # geecs_move_variable / geecs_describe_action).
+  # function execution to exactly the manual verbs (#648).
   operator:
     allowed_plans:
       - ":geecs_.*"
@@ -41,7 +40,10 @@ user_groups:
     forbidden_devices:
       - null
     allowed_functions:
-      - ":geecs_.*"
+      # Exactly the two manual verbs — a broader :geecs_.* would also admit
+      # the plan generators as (useless but confusing) function targets.
+      - ":geecs_move_variable$"
+      - ":geecs_describe_action$"
     forbidden_functions:
       - null
 

--- a/GeecsBluesky/qserver/user_group_permissions.yaml
+++ b/GeecsBluesky/qserver/user_group_permissions.yaml
@@ -29,7 +29,9 @@ user_groups:
     forbidden_functions:
       - null
 
-  # Operator group: queue submission is restricted to GEECS-named plans.
+  # Operator group: queue submission is restricted to GEECS-named plans,
+  # function execution to the GEECS-named manual verbs (#648:
+  # geecs_move_variable / geecs_describe_action).
   operator:
     allowed_plans:
       - ":geecs_.*"
@@ -38,7 +40,8 @@ user_groups:
     allowed_devices: []
     forbidden_devices:
       - null
-    allowed_functions: []
+    allowed_functions:
+      - ":geecs_.*"
     forbidden_functions:
       - null
 

--- a/GeecsBluesky/tests/_qserver_startup_probe.py
+++ b/GeecsBluesky/tests/_qserver_startup_probe.py
@@ -84,7 +84,10 @@ def main() -> None:
 
     from bluesky import RunEngine
 
-    from geecs_bluesky.plans.scan_request_plan import geecs_scan_request_plan
+    from geecs_bluesky.plans.scan_request_plan import (
+        geecs_run_action_plan,
+        geecs_scan_request_plan,
+    )
 
     if not isinstance(ns.get("RE"), RunEngine):
         _fail(f"ns['RE'] is not a RunEngine: {ns.get('RE')!r}")
@@ -95,7 +98,20 @@ def main() -> None:
     if ns.get("geecs_scan_request_plan") is not geecs_scan_request_plan:
         _fail("ns['geecs_scan_request_plan'] is not the real plan function")
         return
-    if ns.get("__all__") != ["RE", "geecs_scan_request_plan"]:
+    if ns.get("geecs_run_action_plan") is not geecs_run_action_plan:
+        _fail("ns['geecs_run_action_plan'] is not the real plan function")
+        return
+    for verb in ("geecs_move_variable", "geecs_describe_action"):
+        if not callable(ns.get(verb)):
+            _fail(f"ns[{verb!r}] is not callable — function_execute verb missing")
+            return
+    if ns.get("__all__") != [
+        "RE",
+        "geecs_scan_request_plan",
+        "geecs_run_action_plan",
+        "geecs_move_variable",
+        "geecs_describe_action",
+    ]:
         _fail(f"ns['__all__'] was {ns.get('__all__')!r}")
         return
 

--- a/GeecsBluesky/tests/test_pause_semantics.py
+++ b/GeecsBluesky/tests/test_pause_semantics.py
@@ -642,7 +642,11 @@ def _failed_move_scan(motor: _FlakyMotor, failed_move_policy: str | None = None)
         positions=[0.0, 1.0],
         detectors=[_PlainDet("cam")],
         shots_per_step=2,
-        **({} if failed_move_policy is None else {"failed_move_policy": failed_move_policy}),
+        **(
+            {}
+            if failed_move_policy is None
+            else {"failed_move_policy": failed_move_policy}
+        ),
     )
 
 

--- a/GeecsBluesky/tests/test_scan_request_plan.py
+++ b/GeecsBluesky/tests/test_scan_request_plan.py
@@ -1250,3 +1250,103 @@ def test_optimize_path_registers_pause_quiescer() -> None:
     src = inspect.getsource(srp)
     assert "_with_pause_quiescer(" in src
     assert "ShotControlPauseQuiescer(controller)" in src
+
+
+# ---------------------------------------------------------------------------
+# Submission provenance (#648 decision 3 — geecs-schemas 0.10.0)
+# ---------------------------------------------------------------------------
+
+
+def test_submission_record_reaches_start_doc_on_both_paths(
+    resolver, tmp_path, monkeypatch
+) -> None:
+    """A client-stamped SubmissionRecord lands verbatim in run metadata.
+
+    Both entry points (the queue plan and the runner) must record
+    ``md["submission"]`` — the engine copies, never edits.
+    """
+    stamp = {
+        "client": "geecs-console 0.21.0",
+        "submitted_at": "2026-08-21T14:30:00-07:00",
+        "preflight": [
+            {
+                "check": "gateway_liveness",
+                "result": "continued",
+                "detail": "U_Test disconnected; operator continued",
+            }
+        ],
+    }
+    request = _noscan_request(submission=stamp)
+    docs_plan = _run_scan("plan", request, resolver, tmp_path / "p", monkeypatch)
+    docs_runner = _run_scan("runner", request, resolver, tmp_path / "r", monkeypatch)
+    expected = request.submission.model_dump(mode="json")
+    assert docs_plan.start["submission"] == expected
+    assert docs_runner.start["submission"] == expected
+
+
+def test_unstamped_request_emits_no_submission_key(
+    resolver, tmp_path, monkeypatch
+) -> None:
+    """No stamp, no key — absence must read as 'client recorded nothing'."""
+    docs = _run_scan("plan", _noscan_request(), resolver, tmp_path / "p", monkeypatch)
+    assert "submission" not in docs.start
+
+
+# ---------------------------------------------------------------------------
+# geecs_run_action_plan (#648 manual verbs — actions as queue items)
+# ---------------------------------------------------------------------------
+
+
+def test_run_action_plan_executes_the_named_action(resolver) -> None:
+    """The queue-item action plan compiles, connects, and issues the sets."""
+    from geecs_bluesky.plans.scan_request_plan import geecs_run_action_plan
+
+    session = _mock_session()
+    sets: list[tuple[str, tuple]] = []
+
+    def hook(msg) -> None:
+        if msg.command == "set":
+            sets.append((msg.obj.name, msg.args))
+
+    session.RE.msg_hook = hook
+    try:
+        session.RE(
+            geecs_run_action_plan("close_shutters", session=session, resolver=resolver)
+        )
+    finally:
+        session.RE.msg_hook = None
+    # LEGACY_ACTIONS close_shutters: one set of U_PLC DO.Ch9 -> 'on'.
+    assert [args for _, args in sets] == [("on",)], sets
+
+
+def test_run_action_plan_unknown_name_fails_fast(resolver) -> None:
+    """An unknown action name raises before any connect message is emitted."""
+    from geecs_bluesky.plans.scan_request_plan import geecs_run_action_plan
+
+    session = _mock_session()
+    with pytest.raises(GeecsConfigurationError, match="not_a_plan"):
+        session.RE(
+            geecs_run_action_plan("not_a_plan", session=session, resolver=resolver)
+        )
+
+
+def test_run_action_plan_signature_passes_manager_validation() -> None:
+    """Same bare-namespace pin as geecs_scan_request_plan's (0.55.3 lesson)."""
+    pytest.importorskip("bluesky_queueserver")
+
+    from bluesky_queueserver.manager.profile_ops import _process_plan, validate_plan
+
+    from geecs_bluesky.plans.scan_request_plan import geecs_run_action_plan
+
+    item = {
+        "name": "geecs_run_action_plan",
+        "args": ["close_shutters"],
+        "item_type": "plan",
+    }
+    processed = _process_plan(
+        geecs_run_action_plan, existing_devices={}, existing_plans={}
+    )
+    ok, msg = validate_plan(
+        item, allowed_plans={"geecs_run_action_plan": processed}, allowed_devices={}
+    )
+    assert ok, msg

--- a/GeecsBluesky/tests/test_scan_request_plan.py
+++ b/GeecsBluesky/tests/test_scan_request_plan.py
@@ -1350,3 +1350,29 @@ def test_run_action_plan_signature_passes_manager_validation() -> None:
         item, allowed_plans={"geecs_run_action_plan": processed}, allowed_devices={}
     )
     assert ok, msg
+
+
+def test_queue_plans_refuse_while_a_manual_move_is_in_flight(resolver) -> None:
+    """The PR #597 mutual exclusion travels to the queue path (#652 review).
+
+    A background-executed geecs_move_variable leaves the manager IDLE while
+    the move converges, so both queue plans must refuse to start while the
+    session's manual-move lock is held.
+    """
+    from geecs_bluesky.plans.scan_request_plan import geecs_run_action_plan
+
+    session = _mock_session()
+    request = _noscan_request()
+    with session._manual_move_lock:
+        with pytest.raises(RuntimeError, match="manual move in progress"):
+            session.RE(
+                geecs_scan_request_plan(
+                    request.model_dump(), session=session, resolver=resolver
+                )
+            )
+        with pytest.raises(RuntimeError, match="manual move in progress"):
+            session.RE(
+                geecs_run_action_plan(
+                    "close_shutters", session=session, resolver=resolver
+                )
+            )


### PR DESCRIPTION
## What

The worker half of W6 (#648), so the console client PR that follows is pure GUI code. Four concerns, each small:

1. **`md["submission"]` recording** (~15 LOC): the geecs-schemas 0.10.0 `ScanRequest.submission` provenance record is copied verbatim into run metadata at all three emission sites (runner step/optimize + plan optimize; the shared step-path builder covers both entry points). One helper, `metadata_submission()`. Closes the "engine copies it into run metadata" promise from #650.
2. **`geecs_run_action_plan(name)`** (~90 LOC incl. docstring): on-demand ActionPlan execution as an ordinary queue item — decision 2's replacement for `session.run_action`'s direct `RE(...)` call, which cannot run under a manager-owned RE. Reuses the in-scan action machinery (`compile_action_slot`, `prefetch_action_signals`, `_DeferredConnectFactories`, in-plan connects, finalize disconnect). No run opened, matching today's `run_action`. Manager signature validation pinned (the 0.55.3 bare-namespace lesson).
3. **ZMQ document publisher** (~25 LOC startup + ~20 LOC launcher): the startup profile publishes bluesky documents to a `bluesky-0MQ-proxy` the launcher starts alongside Redis (5567 in / 5568 out; `QS_DOC_PROXY*`/`QS_DOC_PUBLISH_ADDR` overrides; best-effort with a loud warning). **Brief correction, verified against installed bluesky-queueserver 0.0.25:** the #648 brief's "launcher already passes `--zmq-publish-console ON`" conflated two streams — that flag publishes captured stdout/stderr *text* (port 60625), never documents; 0.0.25 has no built-in document publishing. This publisher/proxy pair is the migration doc's "ZMQ document publisher" worker build item, previously unbuilt. README + DEPLOYMENT.md now spell out both streams and the port matrix.
4. **Manual-verb functions** (~50 LOC): `geecs_move_variable` / `geecs_describe_action` in the startup namespace for the manager's idle-only `function_execute`; `operator` group gains `allowed_functions: [":geecs_.*"]`. Maintainer decision 2026-08-21: the console's Actions menu and Movable panel re-home to the worker. `move_variable` is deliberately a *function*, not a plan — it moves outside the RE by design (manual-move lock, RE stays idle). Describe is served worker-side so previews reflect the worker's configs checkout, not a possibly-drifted client one; the trade (no mid-scan preview — functions are idle-only) is flagged in the README.

Judgment-call additions, cheap to veto: the `operator`-group `allowed_functions` widening; serving `describe_action` worker-side at all.

Also carries the one-hunk ruff-format cleanup of `scan_request_runner.py` from direct commit 817550da (committed without hooks); the sibling test-file hunk is its own preceding format-only commit.

## Tests

`./scripts/check.sh`: lint OK; GEECS-Schemas + GeecsBluesky suites — **696 passed, 3 deselected** (was 673+skips pre-extras; run here with `ca tiled qserver` extras all installed). New: submission-record start-doc pins on both entry points (+ absent-key case), `geecs_run_action_plan` execute/unknown-name/manager-signature pins, startup subprocess probe extended to the new namespace surface.

## Hardware verification

**OWED (maintainer, on the interim host, next live session):**
- Pull + restart the manager (env reopen insufficient — README rule), then verify a stamped `submission` request lands its record in the run start doc (Tiled or scan.log).
- `qserver queue add plan '{"name": "geecs_run_action_plan", "args": ["<some action>"], "item_type": "plan"}'` → the sets execute, queue history records the item.
- Console-output + document streams: `bluesky-0MQ-proxy` running, a scan produces documents on port 5568 (RemoteDispatcher smoke), beeps/progress deferred to the console PR's live check.
- `function_execute` of `geecs_move_variable` on a safe variable (e.g. U_S1H Current small delta and back) while idle; confirm refusal while a scan runs.

Deployment sequencing from #650 applies: worker updates before any client stamps `submission`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)