### PR TITLE
GEECS-Console 0.21.0: queueserver client services layer (#648, W6 part 1)

### DIFF
--- a/GEECS-Console/CHANGELOG.md
+++ b/GEECS-Console/CHANGELOG.md
@@ -4,6 +4,39 @@ All notable changes to GEECS-Console are documented here.  Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versioning is
 semantic.
 
+## [0.21.0] - 2026-08-21
+
+### Added
+
+- The queueserver client services layer (#648, W6 part 1 — built and
+  tested, not yet wired into the window; the window switch is the next
+  PR):
+  - `services/queue_client.py` — the RE Manager client seam
+    (protocol + `ZmqQueueClient` over `bluesky-queueserver-api` +
+    offline `StubQueueClient`): submission with the failed-item-at-front
+    guard (surface pending items, clear only on explicit confirm),
+    deferred pause / resume, graceful stop (from paused directly; from
+    running via pause-then-stop sequencing), `function_execute` manual
+    verbs with task polling, and a never-raises `status()` for polling.
+    Config: the new `[qserver]` section (`host` + optional address
+    overrides) of the shared config file.
+  - `services/submit_preflight.py` — client-side pre-submit checks
+    (decision 3): the engine's own `validate_scan_request` (hard gate),
+    the engine's `UnservedVariablesCheck` (reused, not reimplemented),
+    gateway `CONNECTED` liveness reads (fail-open), and a free-run
+    trigger-staleness sample; plus `stamp_submission`, which stamps the
+    geecs-schemas 0.10.0 `SubmissionRecord` (aware timestamp pinned by
+    test) onto the outgoing request.
+  - `app/scan_monitor.py` — `ScanMonitorController` (#534 controller
+    shape): manager status polling on the `HealthPoller` pattern, the
+    document stream (`RemoteDispatcher`, per-shot progress source), and
+    the manager console-output stream with failed-move reason
+    extraction (pinned against the engine's `FAILED_MOVE_LOG_PREFIX`).
+- New dependency: `bluesky-queueserver-api` (pulls pyzmq).
+- Cross-reference rider (#648 item 6): `services/optimization.py` now
+  names its worker-side twin (`geecs_bluesky.optimization.worker_loader`)
+  with the keep-in-sync rule; the twin already pointed here.
+
 ## [0.20.2] - 2026-08-20
 
 ### Changed

--- a/GEECS-Console/geecs_console/app/scan_monitor.py
+++ b/GEECS-Console/geecs_console/app/scan_monitor.py
@@ -54,19 +54,25 @@ def _failed_move_prefix() -> str:
 class DocumentStreamWorker(QObject):
     """Daemon-thread consumer of the worker's bluesky document stream.
 
-    Emits ``document(name, doc)`` for every document received.  The signal
-    is worker-owned; consumers connect it ``QueuedConnection``.  ``start()``
-    spawns the thread; :meth:`stop` makes further emissions impossible and
-    best-effort closes the dispatcher (never joins — the thread is daemon).
+    Emits ``document(name, doc)`` for every document received and
+    ``stream_failed(str)`` if the stream cannot be set up (bad address,
+    missing import) — post-setup, the zmq SUB socket reconnects on its own
+    and needs no supervision.  Signals are worker-owned; consumers connect
+    them ``QueuedConnection``.  ``start()`` spawns the thread; :meth:`stop`
+    only gates emission and **abandons** the daemon thread: the
+    dispatcher's zmq socket/loop must never be touched from another thread
+    (pyzmq sockets are not thread-safe — a cross-thread close can trip a
+    libzmq assertion, which *aborts* the process rather than raising; #653
+    review finding 3).
     """
 
     document = Signal(str, object)
+    stream_failed = Signal(str)
 
     def __init__(self, doc_addr: str) -> None:
         super().__init__()
         self._addr = doc_addr
         self._stopped = False
-        self._dispatcher: Any = None
         self._thread: Optional[threading.Thread] = None
 
     def start(self) -> None:
@@ -83,7 +89,6 @@ class DocumentStreamWorker(QObject):
             from bluesky.callbacks.zmq import RemoteDispatcher
 
             dispatcher = RemoteDispatcher(self._addr)
-            self._dispatcher = dispatcher
 
             def _forward(name: str, doc: dict) -> None:
                 if not self._stopped:
@@ -91,32 +96,40 @@ class DocumentStreamWorker(QObject):
 
             dispatcher.subscribe(_forward)
             dispatcher.start()  # blocks for the thread's lifetime
-        except Exception:
+        except Exception as exc:
             if not self._stopped:
                 logger.warning("document stream at %s ended", self._addr, exc_info=True)
+                try:
+                    self.stream_failed.emit(
+                        f"document stream unavailable ({exc}) — live "
+                        "per-shot progress is off"
+                    )
+                except RuntimeError:
+                    pass  # the worker was deleted during teardown
 
     def stop(self) -> None:
-        """Stop emitting and best-effort close the dispatcher (idempotent)."""
+        """Gate further emissions (idempotent).
+
+        Deliberately touches nothing else: the dispatcher is abandoned
+        with its daemon thread (see the class docstring — a cross-thread
+        zmq close can abort the process, and the thread dies with the app
+        anyway).
+        """
         self._stopped = True
-        dispatcher = self._dispatcher
-        if dispatcher is not None:
-            try:
-                dispatcher.stop()
-            except Exception:  # cross-thread close is best-effort teardown
-                logger.debug("dispatcher stop raised (ignored)", exc_info=True)
-            self._dispatcher = None
 
 
 class ConsoleStreamWorker(QObject):
     """Daemon-thread consumer of the manager's console-output text stream.
 
-    Emits ``line(str)`` per received line and ``pause_reason(str)`` when a
-    line carries the engine's failed-move prefix — the paused pill's "why".
+    Emits ``line(str)`` per received line, ``pause_reason(str)`` when a
+    line carries the engine's failed-move prefix — the paused pill's "why"
+    — and ``stream_failed(str)`` if the monitor cannot be set up.
     Text only: this stream never carries documents (see qserver/README.md).
     """
 
     line = Signal(str)
     pause_reason = Signal(str)
+    stream_failed = Signal(str)
 
     def __init__(self, info_addr: str) -> None:
         super().__init__()
@@ -157,9 +170,16 @@ class ConsoleStreamWorker(QObject):
                     self._handle_text(str(msg.get("msg", "")), prefix)
             finally:
                 monitor.disable()
-        except Exception:
+        except Exception as exc:
             if not self._stopped:
                 logger.warning("console stream at %s ended", self._addr, exc_info=True)
+                try:
+                    self.stream_failed.emit(
+                        f"console-output stream unavailable ({exc}) — the "
+                        "log tail and pause reasons are off"
+                    )
+                except RuntimeError:
+                    pass  # the worker was deleted during teardown
 
     def _handle_text(self, text: str, prefix: str) -> None:
         for raw_line in text.splitlines():

--- a/GEECS-Console/geecs_console/app/scan_monitor.py
+++ b/GEECS-Console/geecs_console/app/scan_monitor.py
@@ -1,0 +1,271 @@
+"""Scan monitoring for the queueserver path (#648): status poll + two streams.
+
+Owns the three live inputs the R6 now-panel renders once the console is a
+manager client:
+
+- **Manager status poll** — ``QueueClient.status()`` on the shared
+  :class:`~geecs_console.services.background.HealthPoller` (GUI-thread
+  ``QTimer`` + short-lived daemon thread; in-flight skip).  ``re_state``
+  drives the state pill.
+- **Document stream** — a ``bluesky.callbacks.zmq.RemoteDispatcher`` on
+  the worker's document proxy (per-shot progress, totals, scan number,
+  terminal states; re-drives the per-shot beeps).
+- **Console-output stream** — the manager's captured stdout/stderr text
+  (the log tail), watched for the engine's failed-move reason line
+  (``FAILED_MOVE_LOG_PREFIX``) so a ``paused`` pill can say *why*.
+
+Controller rules (#534 checklist): ``QObject`` with **no Qt parent**;
+injected addresses and callables, never the window; every daemon thread
+emits on a **worker-owned** signal connected ``QueuedConnection`` by the
+consumer (emitting a window-owned signal from a daemon thread segfaults
+under offscreen pytest — ``services/background.py`` rule); an idempotent
+:meth:`dispose` the window's ``closeEvent`` calls.  The stream sockets are
+long-lived daemon threads: ``dispose()`` marks them stale (signals stop),
+closes what can be closed safely, and never joins.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+from typing import Any, Optional
+
+from PySide6.QtCore import QObject, Signal
+
+logger = logging.getLogger(__name__)
+
+#: The engine's failed-move reason line prefix (pause_semantics contract).
+#: Imported lazily where used; this fallback keeps the module import-safe
+#: and the tests hermetic. Keep in sync with
+#: ``geecs_bluesky.plans.pause_semantics.FAILED_MOVE_LOG_PREFIX``.
+_FAILED_MOVE_PREFIX_FALLBACK = "FAILED MOVE - pausing for operator"
+
+
+def _failed_move_prefix() -> str:
+    """The engine's prefix when importable, else the pinned fallback."""
+    try:
+        from geecs_bluesky.plans.pause_semantics import FAILED_MOVE_LOG_PREFIX
+
+        return FAILED_MOVE_LOG_PREFIX
+    except Exception:  # pragma: no cover - engine always present in prod
+        return _FAILED_MOVE_PREFIX_FALLBACK
+
+
+class DocumentStreamWorker(QObject):
+    """Daemon-thread consumer of the worker's bluesky document stream.
+
+    Emits ``document(name, doc)`` for every document received.  The signal
+    is worker-owned; consumers connect it ``QueuedConnection``.  ``start()``
+    spawns the thread; :meth:`stop` makes further emissions impossible and
+    best-effort closes the dispatcher (never joins — the thread is daemon).
+    """
+
+    document = Signal(str, object)
+
+    def __init__(self, doc_addr: str) -> None:
+        super().__init__()
+        self._addr = doc_addr
+        self._stopped = False
+        self._dispatcher: Any = None
+        self._thread: Optional[threading.Thread] = None
+
+    def start(self) -> None:
+        """Spawn the dispatcher thread (idempotent)."""
+        if self._thread is not None:
+            return
+        self._thread = threading.Thread(
+            target=self._run, name="qs-doc-stream", daemon=True
+        )
+        self._thread.start()
+
+    def _run(self) -> None:
+        try:
+            from bluesky.callbacks.zmq import RemoteDispatcher
+
+            dispatcher = RemoteDispatcher(self._addr)
+            self._dispatcher = dispatcher
+
+            def _forward(name: str, doc: dict) -> None:
+                if not self._stopped:
+                    self.document.emit(name, dict(doc))
+
+            dispatcher.subscribe(_forward)
+            dispatcher.start()  # blocks for the thread's lifetime
+        except Exception:
+            if not self._stopped:
+                logger.warning("document stream at %s ended", self._addr, exc_info=True)
+
+    def stop(self) -> None:
+        """Stop emitting and best-effort close the dispatcher (idempotent)."""
+        self._stopped = True
+        dispatcher = self._dispatcher
+        if dispatcher is not None:
+            try:
+                dispatcher.stop()
+            except Exception:  # cross-thread close is best-effort teardown
+                logger.debug("dispatcher stop raised (ignored)", exc_info=True)
+            self._dispatcher = None
+
+
+class ConsoleStreamWorker(QObject):
+    """Daemon-thread consumer of the manager's console-output text stream.
+
+    Emits ``line(str)`` per received line and ``pause_reason(str)`` when a
+    line carries the engine's failed-move prefix — the paused pill's "why".
+    Text only: this stream never carries documents (see qserver/README.md).
+    """
+
+    line = Signal(str)
+    pause_reason = Signal(str)
+
+    def __init__(self, info_addr: str) -> None:
+        super().__init__()
+        self._addr = info_addr
+        self._stopped = False
+        self._thread: Optional[threading.Thread] = None
+
+    def start(self) -> None:
+        """Spawn the monitor thread (idempotent)."""
+        if self._thread is not None:
+            return
+        self._thread = threading.Thread(
+            target=self._run, name="qs-console-stream", daemon=True
+        )
+        self._thread.start()
+
+    def _run(self) -> None:
+        try:
+            from bluesky_queueserver_api.console_monitor import (
+                ConsoleMonitor_ZMQ_Threads,
+            )
+
+            monitor = ConsoleMonitor_ZMQ_Threads(
+                zmq_info_addr=self._addr,
+                zmq_encoding="json",
+                poll_timeout=0.5,
+                max_msgs=10_000,
+                max_lines=1_000,
+            )
+            monitor.enable()
+            prefix = _failed_move_prefix()
+            try:
+                while not self._stopped:
+                    try:
+                        msg = monitor.next_msg(timeout=0.5)
+                    except Exception:  # timeout — poll the stop flag
+                        continue
+                    self._handle_text(str(msg.get("msg", "")), prefix)
+            finally:
+                monitor.disable()
+        except Exception:
+            if not self._stopped:
+                logger.warning("console stream at %s ended", self._addr, exc_info=True)
+
+    def _handle_text(self, text: str, prefix: str) -> None:
+        for raw_line in text.splitlines():
+            stripped = raw_line.rstrip()
+            if not stripped or self._stopped:
+                continue
+            self.line.emit(stripped)
+            if prefix in stripped:
+                # Everything after the prefix is the engine's reason text.
+                reason = stripped.split(prefix, 1)[1].lstrip(" :-")
+                self.pause_reason.emit(reason or stripped)
+
+    def stop(self) -> None:
+        """Stop the loop and further emissions (idempotent; never joins)."""
+        self._stopped = True
+
+
+class _StatusProbe:
+    """Adapter: ``QueueClient.status`` as the ``HealthPoller`` probe shape."""
+
+    def __init__(self, client: Any) -> None:
+        self._client = client
+
+    def poll(self) -> Any:
+        """One manager status snapshot (never raises — client contract)."""
+        return self._client.status()
+
+
+class ScanMonitorController(QObject):
+    """Owns the poller and both stream workers; the window consumes signals.
+
+    Parameters
+    ----------
+    queue_client :
+        The :class:`~geecs_console.services.queue_client.QueueClient` whose
+        ``status()`` the poller runs.
+    info_addr, doc_addr :
+        Stream addresses (``None`` disables that stream — the stub/offline
+        case).
+    poll_interval_ms :
+        Manager status poll cadence. 1 s default: snappy enough for the
+        state pill, far below the manager's cost floor.
+    """
+
+    def __init__(
+        self,
+        queue_client: Any,
+        *,
+        info_addr: Optional[str] = None,
+        doc_addr: Optional[str] = None,
+        poll_interval_ms: int = 1_000,
+    ) -> None:
+        super().__init__()
+        from geecs_console.services.background import HealthPoller
+
+        self._poller = HealthPoller(_StatusProbe(queue_client))
+        self._poll_interval_ms = poll_interval_ms
+        self._timer: Any = None
+        self.documents: Optional[DocumentStreamWorker] = (
+            DocumentStreamWorker(doc_addr) if doc_addr else None
+        )
+        self.console: Optional[ConsoleStreamWorker] = (
+            ConsoleStreamWorker(info_addr) if info_addr else None
+        )
+        self._disposed = False
+
+    @property
+    def status_ready(self) -> Any:
+        """The poller's queued result signal (``report_ready(object)``)."""
+        return self._poller.report_ready
+
+    def start(self, timer_parent: Any) -> None:
+        """Begin polling (QTimer on *timer_parent*, the window) and streaming.
+
+        The timer lives on the GUI thread via *timer_parent* — the health
+        poller pattern; controllers themselves have no Qt parent.
+        """
+        from PySide6.QtCore import QTimer
+
+        if self._disposed or self._timer is not None:
+            return
+        self._timer = QTimer(timer_parent)
+        self._timer.timeout.connect(self._poller.poll_async)
+        self._timer.start(self._poll_interval_ms)
+        self._poller.poll_async()
+        if self.documents is not None:
+            self.documents.start()
+        if self.console is not None:
+            self.console.start()
+
+    def dispose(self) -> None:
+        """Stop the timer and streams; sever consumers (idempotent)."""
+        if self._disposed:
+            return
+        self._disposed = True
+        if self._timer is not None:
+            self._timer.stop()
+            self._timer = None
+        for worker in (self.documents, self.console):
+            if worker is not None:
+                worker.stop()
+                try:
+                    worker.disconnect()
+                except (RuntimeError, TypeError):
+                    pass
+        try:
+            self._poller.report_ready.disconnect()
+        except (RuntimeError, TypeError):
+            pass

--- a/GEECS-Console/geecs_console/services/optimization.py
+++ b/GEECS-Console/geecs_console/services/optimization.py
@@ -36,6 +36,13 @@ The stack behind the loader (evaluators → ScanAnalysis/ImageAnalysis
 analyzers) is the legacy machinery kept for old-GUI parity; a redesigned
 hook (bluesky-adaptive direction) is a planned follow-up, so this module is
 written to be deletable.
+
+KEEP IN SYNC: this module is the console-side twin of the queueserver
+worker's loader, ``geecs_bluesky.optimization.worker_loader`` — same four
+functions, same shapes, independently implemented because the dependency
+graph runs Console → GeecsBluesky, never the reverse.  A change to the
+``OptimizationSpec``/``BaseOptimizerConfig`` mapping here must be mirrored
+there (and vice versa — its module docstring points back here).
 """
 
 from __future__ import annotations

--- a/GEECS-Console/geecs_console/services/queue_client.py
+++ b/GEECS-Console/geecs_console/services/queue_client.py
@@ -1,0 +1,435 @@
+"""Queueserver manager client seam (#648): the console as a peer RE Manager client.
+
+The console submits scans to a bluesky-queueserver RE Manager (the GEECS
+worker, ``GeecsBluesky/qserver/``) instead of an in-process engine.  This
+module is the one place that speaks ``bluesky-queueserver-api``:
+
+- :class:`QueueClient` — the protocol the window and controllers depend on;
+- :class:`ZmqQueueClient` — the real client (0MQ control socket, lazy
+  imports so the module stays import-safe offline);
+- :class:`StubQueueClient` — the offline/test default (disconnected status,
+  every verb refuses with a clear message);
+- :func:`read_qserver_config` — the ``[qserver]`` section of the shared
+  ``~/.config/geecs_python_api/config.ini``.
+
+Threading contract (the console's standing rules): every method here
+**blocks** — 0MQ request/reply with a short timeout, or a polled
+``function_execute`` task.  :meth:`QueueClient.status` is cheap and bounded
+(one request, ``timeout_recv``) and is polled from a background thread
+(``HealthPoller`` pattern); the submit/stop/manual-verb calls run on
+``BackgroundResult`` workers.  Nothing here touches Qt.
+
+Queue semantics this client owns (#648 item 3): on plan failure the manager
+returns the failed item to the **front** of the queue (``ignore_failures``
+default false), so a client that blindly add-and-starts re-runs the failed
+item.  :meth:`ZmqQueueClient.submit_scan` therefore surfaces the queue's
+front items to the caller (``pending_items``) and only clears them when
+told to (``clear_pending=True``).
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from dataclasses import dataclass, field
+from typing import Any, Optional, Protocol, runtime_checkable
+
+logger = logging.getLogger(__name__)
+
+#: The manager's default 0MQ control / console-info ports and the document
+#: stream's default out port (see GeecsBluesky/qserver/deploy/DEPLOYMENT.md,
+#: "Network ports").
+_CONTROL_PORT = 60615
+_INFO_PORT = 60625
+_DOC_PORT = 5568
+
+#: Bound on one control-socket round trip (seconds). Chosen above the api's
+#: 2 s default recv timeout so a wedged manager degrades to "disconnected"
+#: instead of stacking retries.
+_RECV_TIMEOUT_S = 2.0
+
+#: How long a foreground ``function_execute`` task may run before the client
+#: reports a timeout. Manual moves ride GEECS blocking sets — a slow magnet
+#: legitimately takes tens of seconds.
+_TASK_TIMEOUT_S = 120.0
+
+#: How long a stop-while-running may wait for the deferred pause to land
+#: before giving up. The pause waits out an in-flight blocking move (the
+#: engine's pause-latency floor), so this must cover the slowest move.
+_STOP_PAUSE_TIMEOUT_S = 120.0
+
+
+@dataclass(frozen=True)
+class QserverConfig:
+    """Client-side addresses for one GEECS RE Manager."""
+
+    control_addr: str
+    info_addr: str
+    doc_addr: str
+
+
+def read_qserver_config() -> Optional[QserverConfig]:
+    """Read the ``[qserver]`` section of the shared GEECS config file.
+
+    Keys: ``host`` (required — the worker machine) plus optional full
+    overrides ``control_addr`` (``tcp://host:60615``), ``info_addr``
+    (``tcp://host:60625``), and ``doc_addr`` (``host:5568``).  Defaults are
+    derived from ``host`` with the deployment-standard ports.
+
+    Returns
+    -------
+    QserverConfig or None
+        ``None`` when the file or section is absent — the console then runs
+        with the stub client (submission disabled, everything else works).
+    """
+    import configparser
+
+    from geecs_console.services.ops_paths import USER_CONFIG_PATH
+
+    path = USER_CONFIG_PATH.expanduser()
+    if not path.exists():
+        return None
+    parser = configparser.ConfigParser()
+    try:
+        parser.read(path)
+    except (OSError, configparser.Error) as exc:
+        logger.warning("Could not read %s: %s", path, exc)
+        return None
+    if not parser.has_section("qserver"):
+        return None
+    host = parser.get("qserver", "host", fallback="").strip()
+    control = parser.get("qserver", "control_addr", fallback="").strip()
+    info = parser.get("qserver", "info_addr", fallback="").strip()
+    doc = parser.get("qserver", "doc_addr", fallback="").strip()
+    if not host and not control:
+        logger.warning("[qserver] section present but no host/control_addr set")
+        return None
+    return QserverConfig(
+        control_addr=control or f"tcp://{host}:{_CONTROL_PORT}",
+        info_addr=info or f"tcp://{host}:{_INFO_PORT}",
+        doc_addr=doc or f"{host}:{_DOC_PORT}",
+    )
+
+
+@dataclass(frozen=True)
+class QueueStatus:
+    """One poll's snapshot of the manager, GUI-shaped.
+
+    ``connected=False`` means the manager did not answer — every other
+    field is then meaningless and ``detail`` says why.  ``re_state`` is the
+    worker RunEngine state string (``idle`` / ``running`` / ``paused`` /
+    ``None`` while the worker environment is closed).
+    """
+
+    connected: bool = False
+    re_state: Optional[str] = None
+    manager_state: Optional[str] = None
+    worker_exists: bool = False
+    items_in_queue: int = 0
+    running_item_uid: Optional[str] = None
+    detail: str = ""
+
+
+@dataclass(frozen=True)
+class SubmitResult:
+    """Outcome of a queue submission attempt.
+
+    ``ok=False`` with non-empty ``pending_items`` means the queue already
+    held items (typically a failed item returned to the front — the #648
+    item-3 trap) and nothing was submitted: the caller surfaces them and
+    retries with ``clear_pending=True`` once the operator agrees.
+    """
+
+    ok: bool
+    message: str = ""
+    item_uid: Optional[str] = None
+    pending_items: list[dict] = field(default_factory=list)
+
+
+@runtime_checkable
+class QueueClient(Protocol):
+    """What the console needs from a RE Manager (all methods block; see module doc)."""
+
+    def status(self) -> QueueStatus:
+        """Return the manager snapshot. Never raises."""
+        ...
+
+    def submit_scan(
+        self, request: dict, *, clear_pending: bool = False
+    ) -> SubmitResult:
+        """Queue ``geecs_scan_request_plan(request)`` and start the queue."""
+        ...
+
+    def submit_action(self, name: str) -> SubmitResult:
+        """Queue ``geecs_run_action_plan(name)`` and start the queue."""
+        ...
+
+    def request_pause(self) -> tuple[bool, str]:
+        """Deferred-pause the running plan. Returns ``(ok, message)``."""
+        ...
+
+    def request_resume(self) -> tuple[bool, str]:
+        """Resume a paused plan. Returns ``(ok, message)``."""
+        ...
+
+    def stop_scan(self) -> tuple[bool, str]:
+        """Gracefully stop: from paused directly, from running via pause."""
+        ...
+
+    def move_variable(self, name: str, value: float) -> dict:
+        """Run ``geecs_move_variable`` on the worker; raises on refusal/failure."""
+        ...
+
+    def describe_action(self, name: str) -> list[dict]:
+        """Run ``geecs_describe_action`` on the worker; raises on failure."""
+        ...
+
+
+_STUB_MESSAGE = (
+    "no queueserver configured — add a [qserver] section (host = <worker>) "
+    "to ~/.config/geecs_python_api/config.ini"
+)
+
+
+class StubQueueClient:
+    """The offline default: disconnected status, every verb refuses clearly."""
+
+    def status(self) -> QueueStatus:
+        """Return a disconnected snapshot naming the missing config."""
+        return QueueStatus(connected=False, detail=_STUB_MESSAGE)
+
+    def submit_scan(
+        self, request: dict, *, clear_pending: bool = False
+    ) -> SubmitResult:
+        """Refuse with the missing-config message."""
+        return SubmitResult(ok=False, message=_STUB_MESSAGE)
+
+    def submit_action(self, name: str) -> SubmitResult:
+        """Refuse with the missing-config message."""
+        return SubmitResult(ok=False, message=_STUB_MESSAGE)
+
+    def request_pause(self) -> tuple[bool, str]:
+        """Refuse with the missing-config message."""
+        return False, _STUB_MESSAGE
+
+    def request_resume(self) -> tuple[bool, str]:
+        """Refuse with the missing-config message."""
+        return False, _STUB_MESSAGE
+
+    def stop_scan(self) -> tuple[bool, str]:
+        """Refuse with the missing-config message."""
+        return False, _STUB_MESSAGE
+
+    def move_variable(self, name: str, value: float) -> dict:
+        """Refuse with the missing-config message."""
+        raise RuntimeError(_STUB_MESSAGE)
+
+    def describe_action(self, name: str) -> list[dict]:
+        """Refuse with the missing-config message."""
+        raise RuntimeError(_STUB_MESSAGE)
+
+
+class ZmqQueueClient:
+    """The real manager client over the 0MQ control socket.
+
+    One :class:`bluesky_queueserver_api.zmq.REManagerAPI` is created lazily
+    on first use and reused (it is thread-safe for the console's usage: the
+    status poller and the one-at-a-time worker calls).  All
+    ``bluesky_queueserver_api`` imports live inside methods — the module
+    must import offline (console standing rule).
+
+    Parameters
+    ----------
+    config : QserverConfig
+        The manager addresses (see :func:`read_qserver_config`).
+    user : str
+        Submitted-as identity recorded by the manager on every queue item.
+    """
+
+    def __init__(self, config: QserverConfig, *, user: str = "geecs-console") -> None:
+        self._config = config
+        self._user = user
+        self._api: Any = None
+
+    # -- plumbing -----------------------------------------------------------
+
+    def _manager(self) -> Any:
+        """Return the cached ``REManagerAPI``, creating it on first use."""
+        if self._api is None:
+            from bluesky_queueserver_api.zmq import REManagerAPI
+
+            self._api = REManagerAPI(
+                zmq_control_addr=self._config.control_addr,
+                zmq_info_addr=self._config.info_addr,
+                timeout_recv=_RECV_TIMEOUT_S,
+            )
+        return self._api
+
+    def _wait_for_task(self, task_uid: str, *, timeout_s: float) -> dict:
+        """Poll ``task_result`` until the task completes; return its payload.
+
+        Raises
+        ------
+        RuntimeError
+            Task failure (with the worker's message) or timeout.
+        """
+        api = self._manager()
+        deadline = time.monotonic() + timeout_s
+        while time.monotonic() < deadline:
+            result = api.task_result(task_uid)
+            status = result.get("status")
+            if status == "completed":
+                task = result.get("result") or {}
+                if not task.get("success", False):
+                    raise RuntimeError(task.get("msg") or "worker task failed")
+                return task.get("return_value")
+            if status not in (None, "running", "accepted", "pending"):
+                raise RuntimeError(f"worker task ended with status {status!r}")
+            time.sleep(0.2)
+        raise RuntimeError(f"worker task did not finish within {timeout_s:.0f} s")
+
+    # -- protocol -----------------------------------------------------------
+
+    def status(self) -> QueueStatus:
+        """Return the manager snapshot; a failed request reads as disconnected."""
+        try:
+            raw = self._manager().status()
+        except Exception as exc:
+            return QueueStatus(connected=False, detail=str(exc))
+        return QueueStatus(
+            connected=True,
+            re_state=raw.get("re_state"),
+            manager_state=raw.get("manager_state"),
+            worker_exists=bool(raw.get("worker_environment_exists")),
+            items_in_queue=int(raw.get("items_in_queue") or 0),
+            running_item_uid=raw.get("running_item_uid") or None,
+            detail="",
+        )
+
+    def _submit_item(
+        self, plan_name: str, args: list, *, clear_pending: bool
+    ) -> SubmitResult:
+        """Shared add-and-start with the failed-item-at-front guard."""
+        from bluesky_queueserver_api import BPlan
+
+        api = self._manager()
+        try:
+            queue = api.queue_get()
+            pending = list(queue.get("items") or [])
+            if pending and not clear_pending:
+                return SubmitResult(
+                    ok=False,
+                    message=(
+                        f"{len(pending)} item(s) already queued (a failed "
+                        "item returns to the queue front) — clear before "
+                        "resubmitting"
+                    ),
+                    pending_items=pending,
+                )
+            if pending:
+                api.queue_clear()
+            item = BPlan(plan_name, *args)
+            response = api.item_add(item, user=self._user)
+            item_uid = (response.get("item") or {}).get("item_uid")
+            api.queue_start()
+            return SubmitResult(ok=True, message="queued", item_uid=item_uid)
+        except Exception as exc:
+            return SubmitResult(ok=False, message=str(exc))
+
+    def submit_scan(
+        self, request: dict, *, clear_pending: bool = False
+    ) -> SubmitResult:
+        """Queue the one scan plan with *request* as its sole argument."""
+        return self._submit_item(
+            "geecs_scan_request_plan", [request], clear_pending=clear_pending
+        )
+
+    def submit_action(self, name: str) -> SubmitResult:
+        """Queue the on-demand action plan (actions are queue items, decision 2)."""
+        return self._submit_item("geecs_run_action_plan", [name], clear_pending=False)
+
+    def request_pause(self) -> tuple[bool, str]:
+        """Deferred pause (the stock verb; hard pause replays — never default it)."""
+        try:
+            self._manager().re_pause(option="deferred")
+            return True, "pause requested"
+        except Exception as exc:
+            return False, str(exc)
+
+    def request_resume(self) -> tuple[bool, str]:
+        """Resume from the paused state (replays nothing on the deferred verb)."""
+        try:
+            self._manager().re_resume()
+            return True, "resumed"
+        except Exception as exc:
+            return False, str(exc)
+
+    def stop_scan(self) -> tuple[bool, str]:
+        """Gracefully stop the current plan, preserving partial data.
+
+        From ``paused``: ``re_stop`` directly (the live-verified
+        stop-from-paused path — Scan003, 2026-08-21).  From ``running``:
+        the manager only accepts stop while paused, so this sequences
+        deferred-pause → wait for ``paused`` → ``re_stop``.  The wait is
+        bounded but long (a deferred pause waits out an in-flight blocking
+        move).  Also stops the queue so no follow-on item auto-starts.
+        """
+        api = self._manager()
+        try:
+            api.queue_stop()
+        except Exception:  # queue may be empty/stopped already — irrelevant
+            logger.debug("queue_stop refused (ignored)", exc_info=True)
+        try:
+            state = self.status()
+            if not state.connected:
+                return False, f"manager unreachable: {state.detail}"
+            if state.re_state == "paused":
+                api.re_stop()
+                return True, "stop requested (from paused)"
+            if state.re_state != "running":
+                return False, f"nothing to stop (RE state: {state.re_state})"
+            api.re_pause(option="deferred")
+            deadline = time.monotonic() + _STOP_PAUSE_TIMEOUT_S
+            while time.monotonic() < deadline:
+                st = self.status()
+                if st.connected and st.re_state == "paused":
+                    api.re_stop()
+                    return True, "stop requested (paused, then stopped)"
+                if st.connected and st.re_state == "idle":
+                    # The plan finished on its own while we waited.
+                    return True, "scan already finished"
+                time.sleep(0.5)
+            return False, (
+                "pause did not land within "
+                f"{_STOP_PAUSE_TIMEOUT_S:.0f} s — scan still running"
+            )
+        except Exception as exc:
+            return False, str(exc)
+
+    def move_variable(self, name: str, value: float) -> dict:
+        """Run the worker's manual move; idle-only (the manager enforces it)."""
+        from bluesky_queueserver_api import BFunc
+
+        api = self._manager()
+        response = api.function_execute(
+            BFunc("geecs_move_variable", name, value), user=self._user
+        )
+        return self._wait_for_task(response["task_uid"], timeout_s=_TASK_TIMEOUT_S)
+
+    def describe_action(self, name: str) -> list[dict]:
+        """Dry-run a named action against the worker's configs; idle-only."""
+        from bluesky_queueserver_api import BFunc
+
+        api = self._manager()
+        response = api.function_execute(
+            BFunc("geecs_describe_action", name), user=self._user
+        )
+        return self._wait_for_task(response["task_uid"], timeout_s=30.0)
+
+
+def make_queue_client(user: str = "geecs-console") -> QueueClient:
+    """Build the configured client, or the stub when no ``[qserver]`` exists."""
+    config = read_qserver_config()
+    if config is None:
+        return StubQueueClient()
+    return ZmqQueueClient(config, user=user)

--- a/GEECS-Console/geecs_console/services/queue_client.py
+++ b/GEECS-Console/geecs_console/services/queue_client.py
@@ -30,6 +30,7 @@ told to (``clear_pending=True``).
 from __future__ import annotations
 
 import logging
+import threading
 import time
 from dataclasses import dataclass, field
 from typing import Any, Optional, Protocol, runtime_checkable
@@ -250,20 +251,26 @@ class ZmqQueueClient:
         self._config = config
         self._user = user
         self._api: Any = None
+        # The status poller's first call and an early worker-thread verb can
+        # race the lazy init; without the lock the loser's REManagerAPI (and
+        # its zmq receive thread) would leak for the process lifetime (#653
+        # review finding 5).
+        self._api_lock = threading.Lock()
 
     # -- plumbing -----------------------------------------------------------
 
     def _manager(self) -> Any:
         """Return the cached ``REManagerAPI``, creating it on first use."""
-        if self._api is None:
-            from bluesky_queueserver_api.zmq import REManagerAPI
+        with self._api_lock:
+            if self._api is None:
+                from bluesky_queueserver_api.zmq import REManagerAPI
 
-            self._api = REManagerAPI(
-                zmq_control_addr=self._config.control_addr,
-                zmq_info_addr=self._config.info_addr,
-                timeout_recv=_RECV_TIMEOUT_S,
-            )
-        return self._api
+                self._api = REManagerAPI(
+                    zmq_control_addr=self._config.control_addr,
+                    zmq_info_addr=self._config.info_addr,
+                    timeout_recv=_RECV_TIMEOUT_S,
+                )
+            return self._api
 
     def _wait_for_task(self, task_uid: str, *, timeout_s: float) -> dict:
         """Poll ``task_result`` until the task completes; return its payload.
@@ -309,7 +316,15 @@ class ZmqQueueClient:
     def _submit_item(
         self, plan_name: str, args: list, *, clear_pending: bool
     ) -> SubmitResult:
-        """Shared add-and-start with the failed-item-at-front guard."""
+        """Shared add-and-start with the failed-item-at-front guard.
+
+        The add and the start are separate manager calls with separate
+        failure handling (#653 review finding 2): a start failure after a
+        successful add must never report plain "failed" while the item
+        sits queued and runs later on its own — the item is best-effort
+        removed, and when even that fails the message says exactly what
+        remains queued.
+        """
         from bluesky_queueserver_api import BPlan
 
         api = self._manager()
@@ -331,10 +346,36 @@ class ZmqQueueClient:
             item = BPlan(plan_name, *args)
             response = api.item_add(item, user=self._user)
             item_uid = (response.get("item") or {}).get("item_uid")
-            api.queue_start()
-            return SubmitResult(ok=True, message="queued", item_uid=item_uid)
         except Exception as exc:
             return SubmitResult(ok=False, message=str(exc))
+        try:
+            api.queue_start()
+        except Exception as exc:
+            try:
+                if item_uid:
+                    api.item_remove(uid=item_uid)
+                removed = bool(item_uid)
+            except Exception:
+                removed = False
+            if removed:
+                return SubmitResult(
+                    ok=False,
+                    message=(
+                        f"queue start refused ({exc}) — the item was "
+                        "removed again; nothing will run"
+                    ),
+                )
+            return SubmitResult(
+                ok=False,
+                message=(
+                    f"queue start refused ({exc}) and the item could NOT "
+                    f"be removed — {plan_name} (uid {item_uid}) REMAINS "
+                    "queued and will run when the queue next starts; "
+                    "clear the queue if that is not intended"
+                ),
+                item_uid=item_uid,
+            )
+        return SubmitResult(ok=True, message="queued", item_uid=item_uid)
 
     def submit_scan(
         self, request: dict, *, clear_pending: bool = False

--- a/GEECS-Console/geecs_console/services/submit_preflight.py
+++ b/GEECS-Console/geecs_console/services/submit_preflight.py
@@ -1,0 +1,344 @@
+"""Client-side pre-submit preflight (#648 decision 3): checks before queueing.
+
+Under the queue, submission-to-execution gaps are long — a typo must fail
+at submit, not at queue-front — and the worker cannot ask the operator
+anything (its checks run headless: default-continue with a warning).  So
+the console runs the checks *before* queueing and asks its questions as
+ordinary synchronous dialogs.  The worker re-runs validation and the
+unserved-variables check authoritatively at execution — the duplication is
+by design (migration doc, "reinitialize disposition").
+
+This module is the pure layer: it computes findings and questions on a
+background thread and returns them; the **dialogs live in the window**.
+Outcomes are stamped into the request's ``submission`` record
+(geecs-schemas 0.10.0) by :func:`stamp_submission`, giving the run
+metadata a provenance trail of who was asked what and what they answered.
+
+Checks, in order (names are the ``PreflightOutcome.check`` vocabulary):
+
+- ``validate`` — the engine's own :func:`validate_scan_request` (THE one
+  definition of what must resolve; issue #529).  A failure is a hard
+  refusal, never a question.
+- ``unserved_variables`` — the engine's :class:`UnservedVariablesCheck`
+  over the resolved save sets (reused, not reimplemented — no drift).
+  DB unreachable → skipped with a warning, never a block.
+- ``gateway_liveness`` — one CA read of each save-set device's
+  ``CONNECTED`` PV; only the exact ``"Disconnected"`` reading counts as
+  down (fail-open, the engine's doctrine).
+- ``free_run_staleness`` — free-run requests only: the reference device's
+  ``acq_timestamp`` must advance within a short window, else the trigger
+  looks stopped.
+
+Every real dependency (``geecs_bluesky``, ``aioca``) is imported lazily
+inside functions — this module must import offline (console standing rule).
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from dataclasses import dataclass, field
+from typing import Any, Optional
+
+logger = logging.getLogger(__name__)
+
+#: CA read budget per liveness probe (seconds) — a dead PV costs this, once.
+_LIVENESS_TIMEOUT_S = 2.0
+
+#: Free-run staleness window (seconds): the reference ``acq_timestamp``
+#: must advance within it. Two samples bracket the window, so a submit
+#: click on a free-run request costs at most this long.
+_STALENESS_WINDOW_S = 2.0
+
+
+@dataclass(frozen=True)
+class PreflightQuestion:
+    """One operator question a check raised (rendered as a modal by the window)."""
+
+    check: str
+    title: str
+    message: str
+    continue_label: str = "Continue"
+    abort_label: str = "Abort"
+
+
+@dataclass
+class PreflightReport:
+    """Everything the check phase computed, for the window's ask phase.
+
+    ``refusal`` set means submission must not proceed (validation failed) —
+    ``questions`` and ``outcomes`` are then partial and irrelevant.
+    ``outcomes`` holds the already-decided checks as
+    ``(check, result, detail)`` tuples in the ``PreflightOutcome``
+    vocabulary (``passed`` / ``skipped``); each entry in ``questions``
+    becomes ``continued`` (or an abort) once the operator answers.
+    """
+
+    refusal: Optional[str] = None
+    outcomes: list[tuple[str, str, str]] = field(default_factory=list)
+    questions: list[PreflightQuestion] = field(default_factory=list)
+
+
+def _resolve_devices_config(request: Any, resolver: Any) -> dict[str, dict]:
+    """Resolve the request's save sets into the effective devices config.
+
+    Explicit-scalars-only (no DB scalar policy client-side) — the unserved
+    and liveness checks need the device *names* and explicit variables;
+    the worker's authoritative pass applies the full policy.
+    """
+    from geecs_bluesky.scan_request_runner import (
+        resolve_save_sets_and_rituals,
+        save_set_to_devices_config,
+    )
+
+    if not request.save_sets:
+        # A save-set-less optimize request: the optimizer's requirements are
+        # provisioned worker-side; nothing to check here.
+        return {}
+    save_set, _rituals = resolve_save_sets_and_rituals(
+        resolver, list(request.save_sets)
+    )
+    return save_set_to_devices_config(save_set)
+
+
+def run_submit_preflight(request: Any, experiment: str) -> PreflightReport:
+    """Run every pre-submit check; return findings for the window to render.
+
+    Blocking (config reads, one DB query, a few CA reads) — call it on a
+    background worker, never the GUI thread.  Never raises: any check that
+    blows up unexpectedly is recorded as ``skipped`` with the error text.
+
+    Parameters
+    ----------
+    request : geecs_schemas.ScanRequest
+        The validated request the form built (not yet stamped).
+    experiment : str
+        The selected experiment (resolver + PV prefix).
+
+    Returns
+    -------
+    PreflightReport
+        Refusal, decided outcomes, and the questions still to ask.
+    """
+    report = PreflightReport()
+
+    # -- validate (hard gate) ----------------------------------------------
+    try:
+        from geecs_bluesky.config_resolver import ConfigsRepoResolver
+        from geecs_bluesky.scan_request_runner import validate_scan_request
+
+        resolver = ConfigsRepoResolver(experiment)
+        validate_scan_request(request, resolver)
+        report.outcomes.append(("validate", "passed", ""))
+    except Exception as exc:
+        report.refusal = str(exc)
+        return report
+
+    try:
+        devices_config = _resolve_devices_config(request, resolver)
+    except Exception as exc:  # validate passed, so this is unexpected
+        logger.warning("preflight device resolution failed: %s", exc)
+        report.outcomes.append(
+            ("unserved_variables", "skipped", f"device resolution failed: {exc}")
+        )
+        devices_config = {}
+
+    # -- unserved variables (engine check, reused) --------------------------
+    if devices_config:
+        try:
+            _check_unserved(report, devices_config, experiment)
+        except Exception as exc:
+            logger.warning("unserved-variables preflight failed: %s", exc)
+            report.outcomes.append(("unserved_variables", "skipped", str(exc)))
+
+    # -- gateway liveness ----------------------------------------------------
+    if devices_config:
+        try:
+            _check_liveness(report, devices_config, experiment)
+        except Exception as exc:
+            logger.warning("liveness preflight failed: %s", exc)
+            report.outcomes.append(("gateway_liveness", "skipped", str(exc)))
+
+    # -- free-run staleness --------------------------------------------------
+    if devices_config and getattr(request.acquisition, "value", None) == "free_run":
+        try:
+            _check_staleness(report, devices_config, experiment)
+        except Exception as exc:
+            logger.warning("staleness preflight failed: %s", exc)
+            report.outcomes.append(("free_run_staleness", "skipped", str(exc)))
+
+    return report
+
+
+def _check_unserved(
+    report: PreflightReport, devices_config: dict[str, dict], experiment: str
+) -> None:
+    """Engine ``UnservedVariablesCheck`` over the resolved config (reused)."""
+    from geecs_bluesky.db_runtime import GeecsDbServedSetProvider
+    from geecs_bluesky.preflight import (
+        Ask,
+        Passed,
+        PreflightContext,
+        UnservedVariablesCheck,
+    )
+
+    provider = GeecsDbServedSetProvider(experiment)
+    check = UnservedVariablesCheck(devices_config, provider.served_by_device)
+    # The check inspects the devices config only; the detector-level context
+    # fields are unused by it (its own documented contract).
+    ctx = PreflightContext(
+        detectors=[],
+        strict=False,
+        read_liveness=lambda device: True,
+        drop_devices=lambda detectors, drop_ids: detectors,
+        device_label=lambda device: str(device),
+    )
+    result = check(ctx)
+    if isinstance(result, Passed):
+        served_known = provider.served_by_device() is not None
+        report.outcomes.append(
+            (
+                "unserved_variables",
+                "passed" if served_known else "skipped",
+                "" if served_known else "served set unknown (DB unreachable)",
+            )
+        )
+    elif isinstance(result, Ask):
+        report.questions.append(
+            PreflightQuestion(
+                check="unserved_variables",
+                title=result.question.title,
+                message=result.question.message,
+                continue_label=getattr(result.question, "continue_label", "Continue"),
+                abort_label=getattr(result.question, "abort_label", "Abort"),
+            )
+        )
+
+
+def _read_pv(pv: str, timeout: float) -> Any:
+    """One blocking CA read (aioca in a private loop); ``None`` on failure."""
+    import asyncio
+
+    from aioca import caget
+
+    async def _get() -> Any:
+        return await caget(pv, timeout=timeout)
+
+    try:
+        return asyncio.run(_get())
+    except Exception:
+        return None
+
+
+def _check_liveness(
+    report: PreflightReport, devices_config: dict[str, dict], experiment: str
+) -> None:
+    """Read each device's gateway ``CONNECTED`` PV; question the down ones."""
+    from geecs_bluesky.devices.ca._pv import ca_pv
+    from geecs_bluesky.devices.ca.gateway_put import bare_pv
+
+    down: list[str] = []
+    for device in devices_config:
+        reading = _read_pv(
+            bare_pv(ca_pv(experiment, device, "CONNECTED")), _LIVENESS_TIMEOUT_S
+        )
+        # Fail-open: only the exact "Disconnected" reading means down (the
+        # engine's liveness doctrine — an unreadable status is not a verdict).
+        if reading is not None and str(reading) == "Disconnected":
+            down.append(device)
+    if not down:
+        report.outcomes.append(("gateway_liveness", "passed", ""))
+        return
+    names = ", ".join(sorted(down))
+    report.questions.append(
+        PreflightQuestion(
+            check="gateway_liveness",
+            title="Devices disconnected",
+            message=(
+                f"The gateway reports these save-set devices as "
+                f"Disconnected: {names}. Their rows will be missing or "
+                "invalid. Continue anyway?"
+            ),
+        )
+    )
+
+
+def _check_staleness(
+    report: PreflightReport, devices_config: dict[str, dict], experiment: str
+) -> None:
+    """Free-run only: the reference ``acq_timestamp`` must advance."""
+    from geecs_bluesky.devices.ca._pv import ca_pv
+    from geecs_bluesky.devices.ca.gateway_put import bare_pv
+
+    reference = next(
+        (d for d, cfg in devices_config.items() if cfg.get("synchronous")), None
+    )
+    if reference is None:
+        report.outcomes.append(
+            ("free_run_staleness", "skipped", "no synchronous device to sample")
+        )
+        return
+    pv = bare_pv(ca_pv(experiment, reference, "acq_timestamp"))
+    first = _read_pv(pv, _LIVENESS_TIMEOUT_S)
+    time.sleep(_STALENESS_WINDOW_S)
+    second = _read_pv(pv, _LIVENESS_TIMEOUT_S)
+    advanced = (
+        first is not None and second is not None and float(second) > float(first) > 0.0
+    )
+    if advanced:
+        report.outcomes.append(("free_run_staleness", "passed", ""))
+        return
+    if first is None and second is None:
+        report.outcomes.append(
+            ("free_run_staleness", "skipped", f"could not read {reference}")
+        )
+        return
+    report.questions.append(
+        PreflightQuestion(
+            check="free_run_staleness",
+            title="Trigger looks stopped",
+            message=(
+                f"{reference}'s acq_timestamp did not advance within "
+                f"{_STALENESS_WINDOW_S:.0f} s — free-run acquisition needs "
+                "the trigger free-running (check the trigger profile / rep "
+                "rate). Continue anyway?"
+            ),
+        )
+    )
+
+
+def stamp_submission(
+    request: Any, outcomes: list[tuple[str, str, str]], *, client: str
+) -> Any:
+    """Return *request* with the ``submission`` provenance record stamped.
+
+    Parameters
+    ----------
+    request : geecs_schemas.ScanRequest
+        The request about to be queued.
+    outcomes :
+        Final ``(check, result, detail)`` tuples — the report's decided
+        outcomes plus one ``continued`` entry per question answered.
+    client :
+        Client identity string, e.g. ``"geecs-console 0.21.0"``.
+
+    Returns
+    -------
+    geecs_schemas.ScanRequest
+        A copy with ``submission`` set; the original is untouched.
+    """
+    from datetime import datetime, timezone
+
+    from geecs_schemas import PreflightOutcome, SubmissionRecord
+
+    record = SubmissionRecord(
+        client=client,
+        # Aware local time — the tz-offset contract the schema documents
+        # (naive datetime.now().isoformat() is exactly the bug to avoid).
+        submitted_at=datetime.now(timezone.utc).astimezone().isoformat(),
+        preflight=[
+            PreflightOutcome(check=check, result=result, detail=detail)
+            for check, result, detail in outcomes
+        ],
+    )
+    return request.model_copy(update={"submission": record})

--- a/GEECS-Console/geecs_console/services/submit_preflight.py
+++ b/GEECS-Console/geecs_console/services/submit_preflight.py
@@ -215,14 +215,32 @@ def _check_unserved(
         )
 
 
-def _read_pv(pv: str, timeout: float) -> Any:
-    """One blocking CA read (aioca in a private loop); ``None`` on failure."""
+def _read_pv(pv: str, timeout: float, datatype: Any = None) -> Any:
+    """One blocking CA read (aioca in a private loop); ``None`` on failure.
+
+    Parameters
+    ----------
+    pv : str
+        Bare PV name (no ``ca://`` prefix).
+    timeout : float
+        CA read budget in seconds.
+    datatype :
+        Passed to ``caget``.  **Must be ``str`` for enum PVs whose choice
+        string is compared** (the gateway's ``CONNECTED`` is a DBR_ENUM —
+        a native read returns the integer index, and ``str(1)`` never
+        equals ``"Disconnected"``; #653 review finding 1, the same rule as
+        the engine's ``epics_signal_r(str, ...)`` liveness child).
+        ``None`` reads the channel's native type (right for
+        ``acq_timestamp``, natively a double).
+    """
     import asyncio
 
     from aioca import caget
 
     async def _get() -> Any:
-        return await caget(pv, timeout=timeout)
+        if datatype is None:
+            return await caget(pv, timeout=timeout)
+        return await caget(pv, datatype=datatype, timeout=timeout)
 
     try:
         return asyncio.run(_get())
@@ -239,8 +257,12 @@ def _check_liveness(
 
     down: list[str] = []
     for device in devices_config:
+        # datatype=str is load-bearing: CONNECTED is an enum PV and the
+        # comparison below is against its choice string (see _read_pv).
         reading = _read_pv(
-            bare_pv(ca_pv(experiment, device, "CONNECTED")), _LIVENESS_TIMEOUT_S
+            bare_pv(ca_pv(experiment, device, "CONNECTED")),
+            _LIVENESS_TIMEOUT_S,
+            datatype=str,
         )
         # Fail-open: only the exact "Disconnected" reading means down (the
         # engine's liveness doctrine — an unreadable status is not a verdict).

--- a/GEECS-Console/poetry.lock
+++ b/GEECS-Console/poetry.lock
@@ -17,6 +17,18 @@ epicscorelibs = ">=7.0.3.99.4.0"
 numpy = "*"
 
 [[package]]
+name = "alabaster"
+version = "1.0.0"
+description = "A light, configurable Sphinx theme"
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+files = [
+    {file = "alabaster-1.0.0-py3-none-any.whl", hash = "sha256:fc6786402dc3fcb2de3cabd5fe455a2db534b371124f1f21de8731783dec828b"},
+    {file = "alabaster-1.0.0.tar.gz", hash = "sha256:c00dca57bca26fa62a6d7d0a9fcce65f3e026e9bfe33e9c538fd3fbb2144fd9e"},
+]
+
+[[package]]
 name = "annotated-doc"
 version = "0.0.4"
 description = "Document parameters, class attributes, return types, and variables inline, with Annotated."
@@ -60,13 +72,25 @@ typing_extensions = {version = ">=4.5", markers = "python_version < \"3.13\""}
 trio = ["trio (>=0.32.0)"]
 
 [[package]]
+name = "appnope"
+version = "1.0.0"
+description = "Disable App Nap on macOS >= 10.9"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "platform_system == \"Darwin\""
+files = [
+    {file = "appnope-1.0.0-py3-none-any.whl", hash = "sha256:6fe0c04218aab65c54c4ff81638cdbf848d89f5653b74d68638a137f200dd16e"},
+    {file = "appnope-1.0.0.tar.gz", hash = "sha256:685db59cb6043c3c2e528adc0b3bce3a5f8d09bcf7492c6ea650d1b7421f3c49"},
+]
+
+[[package]]
 name = "asttokens"
 version = "3.0.2"
 description = "Annotate AST trees with source code positions"
-optional = true
+optional = false
 python-versions = ">=3.8"
 groups = ["main"]
-markers = "extra == \"optimization\""
 files = [
     {file = "asttokens-3.0.2-py3-none-any.whl", hash = "sha256:9da13157f5b28becde0bd374fc677dcd3c290614264eff096f167c469cd9f933"},
     {file = "asttokens-3.0.2.tar.gz", hash = "sha256:3ecdbd8f2cc195f53ccada3a613538bb5f9ef6f6869129f13e03c30a677b8fe2"},
@@ -75,6 +99,19 @@ files = [
 [package.extras]
 astroid = ["astroid (>=2,<5)"]
 test = ["astroid (>=2,<5)", "pytest (<9.0)", "pytest-cov", "pytest-xdist"]
+
+[[package]]
+name = "async-timeout"
+version = "5.0.1"
+description = "Timeout context manager for asyncio programs"
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+markers = "python_full_version < \"3.11.3\""
+files = [
+    {file = "async_timeout-5.0.1-py3-none-any.whl", hash = "sha256:39e3809566ff85354557ec2398b55e096c8364bacac9405a7a1fa429e77fe76c"},
+    {file = "async_timeout-5.0.1.tar.gz", hash = "sha256:d9321a7a3d5a6a5e187e824d2fa0793ce379a202935782d555d6e9d2735677d3"},
+]
 
 [[package]]
 name = "attrs"
@@ -177,6 +214,21 @@ files = [
 numpy = ">=1.21.3"
 
 [[package]]
+name = "babel"
+version = "2.18.0"
+description = "Internationalization utilities"
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "babel-2.18.0-py3-none-any.whl", hash = "sha256:e2b422b277c2b9a9630c1d7903c2a00d0830c409c59ac8cae9081c92f1aeba35"},
+    {file = "babel-2.18.0.tar.gz", hash = "sha256:b80b99a14bd085fcacfa15c9165f651fbb3406e66cc603abf11c5750937c992d"},
+]
+
+[package.extras]
+dev = ["backports.zoneinfo ; python_version < \"3.9\"", "freezegun (>=1.0,<2.0)", "jinja2 (>=3.0)", "pytest (>=6.0)", "pytest-cov", "pytz", "setuptools", "tzdata ; sys_platform == \"win32\""]
+
+[[package]]
 name = "blosc2"
 version = "4.8.0"
 description = "A fast & compressed ndarray library with a flexible compute engine."
@@ -267,6 +319,55 @@ tools = ["doct", "historydict", "lmfit", "tifffile"]
 zmq = ["pyzmq"]
 
 [[package]]
+name = "bluesky-queueserver"
+version = "0.0.25"
+description = "Server for queueing and executing Bluesky plans."
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+files = [
+    {file = "bluesky_queueserver-0.0.25-py3-none-any.whl", hash = "sha256:489a0304343c52942cdef52357895c1dc0c38b18931c3c9e924e5762ff0eea05"},
+    {file = "bluesky_queueserver-0.0.25.tar.gz", hash = "sha256:3d597c5c00a0b016d77991a841b916aaa880d6623318e9105b72b95a6cd0fdb1"},
+]
+
+[package.dependencies]
+bluesky = ">=1.7.0"
+ipykernel = "*"
+jsonschema = "*"
+jupyter-client = ">=7.4.2"
+jupyter-console = "*"
+numpydoc = "*"
+openpyxl = "*"
+ophyd = "*"
+packaging = "*"
+pydantic = "*"
+python-multipart = "*"
+pyyaml = "*"
+pyzmq = "*"
+redis = {version = "*", extras = ["hiredis"]}
+requests = "*"
+
+[package.extras]
+dev = ["aioca", "build", "coverage", "h5py", "happi (>=1.14.0)", "intake", "ipython", "matplotlib", "numpy", "numpydoc", "ophyd-async", "pandas", "pre-commit", "py", "pyarrow", "pytest", "pytest-split", "pytest-xprocess", "ruff", "scikit-image", "sphinx", "sphinx_rtd_theme", "twine"]
+
+[[package]]
+name = "bluesky-queueserver-api"
+version = "0.0.13"
+description = "Python API for Bluesky Queue Server"
+optional = false
+python-versions = ">=3.7"
+groups = ["main"]
+files = [
+    {file = "bluesky_queueserver_api-0.0.13-py3-none-any.whl", hash = "sha256:e00c22e611f47dbcd464f7a7c28d764422366d04b9f9cbfc4012fc1b1ba7056c"},
+    {file = "bluesky_queueserver_api-0.0.13.tar.gz", hash = "sha256:696846f8755050853172b79ad346ce5003e38e9077b8cadc667768cb908c9cc2"},
+]
+
+[package.dependencies]
+bluesky-queueserver = "*"
+httpx = "*"
+websockets = "*"
+
+[[package]]
 name = "boto3"
 version = "1.43.46"
 description = "The AWS SDK for Python"
@@ -355,10 +456,10 @@ files = [
 name = "cffi"
 version = "2.1.0"
 description = "Foreign Function Interface for Python calling C code."
-optional = true
+optional = false
 python-versions = ">=3.10"
 groups = ["main"]
-markers = "extra == \"optimization\""
+markers = "extra == \"optimization\" or implementation_name == \"pypy\""
 files = [
     {file = "cffi-2.1.0-cp310-cp310-macosx_10_15_x86_64.whl", hash = "sha256:b65f590ef2a44640f9a05dbb548a429b4ade77913ce683ac8b1480777658a6c0"},
     {file = "cffi-2.1.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:164bff1657b2a74f0b6d54e11c9b375bc97b931f2ca9c43fcf875838da1570dd"},
@@ -630,10 +731,9 @@ development = ["black", "flake8", "mypy", "pytest", "types-colorama"]
 name = "comm"
 version = "0.2.3"
 description = "Jupyter Python Comm implementation, for usage in ipykernel, xeus-python etc."
-optional = true
+optional = false
 python-versions = ">=3.8"
 groups = ["main"]
-markers = "extra == \"optimization\""
 files = [
     {file = "comm-0.2.3-py3-none-any.whl", hash = "sha256:c615d91d75f7f04f095b30d1c1711babd43bdc6419c1be9886a85f2f4e489417"},
     {file = "comm-0.2.3.tar.gz", hash = "sha256:2dc8048c10962d55d7ad693be1e7045d891b7ce8d999c97963a5e3e99c055971"},
@@ -986,16 +1086,67 @@ moocore = "*"
 numpy = "*"
 
 [[package]]
+name = "debugpy"
+version = "1.8.21"
+description = "An implementation of the Debug Adapter Protocol for Python"
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "debugpy-1.8.21-cp310-cp310-macosx_15_0_x86_64.whl", hash = "sha256:8eeab7b5462f683452c57c0126aaa5ec4e974ddb705f39ba87dff8818c8e08f9"},
+    {file = "debugpy-1.8.21-cp310-cp310-manylinux_2_34_x86_64.whl", hash = "sha256:0fddfdc130ac6d8bfc0415b0409822fa901c8f310e5c945ac5653a0352532344"},
+    {file = "debugpy-1.8.21-cp310-cp310-win32.whl", hash = "sha256:72b5d676c4cbfac3bac5bb01c138a4656e843f93f03ce2a5f4e394ad49fbee73"},
+    {file = "debugpy-1.8.21-cp310-cp310-win_amd64.whl", hash = "sha256:a7fe47fd23da57b9e0bec3f4a8ee65a2dc55782455ed7f2141d75ab5d2eaeef5"},
+    {file = "debugpy-1.8.21-cp311-cp311-macosx_15_0_universal2.whl", hash = "sha256:da456226c7b4c69e35dbe35dcee6623d912000a77816db7856a41af1c72a0264"},
+    {file = "debugpy-1.8.21-cp311-cp311-manylinux_2_34_x86_64.whl", hash = "sha256:f68b891688e61bdc08b8d364d919ff0051e0b94657b39dcd027bc3173edb7cdc"},
+    {file = "debugpy-1.8.21-cp311-cp311-win32.whl", hash = "sha256:f843a8b08c2edeaf9b1582eed4f25441af21a297c22ff16bf76a662557aa9c9e"},
+    {file = "debugpy-1.8.21-cp311-cp311-win_amd64.whl", hash = "sha256:84c564d8cc701d41843b29a92814c1f1bef6798724ca9d675c284ad9f6a547d7"},
+    {file = "debugpy-1.8.21-cp312-cp312-macosx_15_0_universal2.whl", hash = "sha256:9f96713896f39c3dff0ee841f47320c3f2983d33c341e009361bb0ebc79adc4e"},
+    {file = "debugpy-1.8.21-cp312-cp312-manylinux_2_34_x86_64.whl", hash = "sha256:c193d474f0a211191f2b4449d2d06157c689013035bd952f3b617e0ef422b176"},
+    {file = "debugpy-1.8.21-cp312-cp312-win32.whl", hash = "sha256:4743373c1cac7f9e74a1b9915bf1dbe0e900eca657ffb170ae07ac8363205ae9"},
+    {file = "debugpy-1.8.21-cp312-cp312-win_amd64.whl", hash = "sha256:bd7ba9dd3daa7c2f942c6ca8d4695a16bf9ac16b63615261c7982bc74f7ed20c"},
+    {file = "debugpy-1.8.21-cp313-cp313-macosx_15_0_universal2.whl", hash = "sha256:13678151fc401e2d68c9880b91e28714f797d40422994572b24560ef80910a88"},
+    {file = "debugpy-1.8.21-cp313-cp313-manylinux_2_34_x86_64.whl", hash = "sha256:ecbd158386c31ffe71d46f72d44d56e66331ab9b16cad649156d514368f23ab2"},
+    {file = "debugpy-1.8.21-cp313-cp313-win32.whl", hash = "sha256:2c2ae706dec41d99a9ca1f7ebc987a83e65578363be6f6b3ac9067504917fae1"},
+    {file = "debugpy-1.8.21-cp313-cp313-win_amd64.whl", hash = "sha256:aa648733047443eb1d07682c4ef287d36a54507b643ffdf38b09a3ef002c72a0"},
+    {file = "debugpy-1.8.21-cp314-cp314-macosx_15_0_universal2.whl", hash = "sha256:9bb2a685287a2ac9b181cde89edcec64845cb51de7faaa75badb9a698bc24782"},
+    {file = "debugpy-1.8.21-cp314-cp314-manylinux_2_34_x86_64.whl", hash = "sha256:3d6922439bf33fd38a3e2c447869ebc7b97da5cd3d329ff1ef9bc06c4903437e"},
+    {file = "debugpy-1.8.21-cp314-cp314-win32.whl", hash = "sha256:15d4963bd5ffa48f0da0947fd06757fa7621945048a14ad7705431566d3c0e7c"},
+    {file = "debugpy-1.8.21-cp314-cp314-win_amd64.whl", hash = "sha256:fe0744a12353406de0ae8ccff0d0a4a666f00801a3db8fd04e7a5f761cd520e8"},
+    {file = "debugpy-1.8.21-cp38-cp38-macosx_15_0_x86_64.whl", hash = "sha256:0042da0ecd0a8b50dc4a54395ecd870d258d73fa18776f50c91fdcabdcad2675"},
+    {file = "debugpy-1.8.21-cp38-cp38-manylinux_2_34_x86_64.whl", hash = "sha256:ffd932c6796afadab6993ec96745918a8cb2444dbd392074f769db5ea40ab440"},
+    {file = "debugpy-1.8.21-cp38-cp38-win32.whl", hash = "sha256:4e7c2d784d78ad4b71a5f8cd7b59c167719ec8a7a0211dbb3eb1bfeda78bc4e2"},
+    {file = "debugpy-1.8.21-cp38-cp38-win_amd64.whl", hash = "sha256:aa9d941d6dfe3d0407e4b3ca0b9ec466030e260fbf1174094f68785680f66db6"},
+    {file = "debugpy-1.8.21-cp39-cp39-macosx_15_0_x86_64.whl", hash = "sha256:9f5171176a0084b95d2ebe55a4d1f7b2a75b74c5dbec577ebd3a85c740551c36"},
+    {file = "debugpy-1.8.21-cp39-cp39-manylinux_2_34_x86_64.whl", hash = "sha256:f15c10084f9861b5e8414a48f18f8e4aadf51a98a59e72c16aa28281ca994672"},
+    {file = "debugpy-1.8.21-cp39-cp39-win32.whl", hash = "sha256:4e70cc8b5079f885cb43910924ee0aab73b8b6b2a14eff23afdd9895d86e79eb"},
+    {file = "debugpy-1.8.21-cp39-cp39-win_amd64.whl", hash = "sha256:e935f9dc0501be523c8a8e1853c39432e1354e9ece717ae5998fd2371c4542c3"},
+    {file = "debugpy-1.8.21-py2.py3-none-any.whl", hash = "sha256:b1e37d333663c8851516a47364ef473da127f9caebe4417e6df6f5825a7e9a92"},
+    {file = "debugpy-1.8.21.tar.gz", hash = "sha256:a3c53278e84c94e11bd87c53970ec391d1a67396c8b22609fcac576520e611a6"},
+]
+
+[[package]]
 name = "decorator"
 version = "5.3.1"
 description = "Decorators for Humans"
-optional = true
+optional = false
 python-versions = ">=3.8"
 groups = ["main"]
-markers = "extra == \"optimization\""
 files = [
     {file = "decorator-5.3.1-py3-none-any.whl", hash = "sha256:f47fe6fdbd2edd623ecfe36875d37aba411624e2670dd395dddae1358689bb3c"},
     {file = "decorator-5.3.1.tar.gz", hash = "sha256:4cbcdd55a6efadb9dbea26b858f4fb3264567b52d69ca0d25b721b553f60ea82"},
+]
+
+[[package]]
+name = "docutils"
+version = "0.22.4"
+description = "Docutils -- Python Documentation Utilities"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "docutils-0.22.4-py3-none-any.whl", hash = "sha256:d0013f540772d1420576855455d050a2180186c91c15779301ac2ccb3eeb68de"},
+    {file = "docutils-0.22.4.tar.gz", hash = "sha256:4db53b1fde9abecbb74d91230d32ab626d94f6badfc575d6db9194a49df29968"},
 ]
 
 [[package]]
@@ -1098,6 +1249,18 @@ setuptools = "*"
 setuptools-dso = ">=2.11a2"
 
 [[package]]
+name = "et-xmlfile"
+version = "2.0.0"
+description = "An implementation of lxml.xmlfile for the standard library"
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "et_xmlfile-2.0.0-py3-none-any.whl", hash = "sha256:7a91720bc756843502c3b7504c77b8fe44217c85c537d85037f0f536151b2caa"},
+    {file = "et_xmlfile-2.0.0.tar.gz", hash = "sha256:dab3f4764309081ce75662649be815c4c9081e88f0837825f90fd28317d4da54"},
+]
+
+[[package]]
 name = "event-model"
 version = "1.24.0"
 description = "Data model used by the bluesky ecosystem."
@@ -1121,10 +1284,9 @@ dev = ["copier", "datamodel-code-generator (>=0.53.0)", "ipython", "matplotlib",
 name = "executing"
 version = "2.2.1"
 description = "Get the currently executing AST node of a frame, and other information"
-optional = true
+optional = false
 python-versions = ">=3.8"
 groups = ["main"]
-markers = "extra == \"optimization\""
 files = [
     {file = "executing-2.2.1-py2.py3-none-any.whl", hash = "sha256:760643d3452b4d777d295bb167ccc74c64a81df23fb5e08eff250c425a4b2017"},
     {file = "executing-2.2.1.tar.gz", hash = "sha256:3632cc370565f6648cc328b32435bd120a1e4ebb20c77e3fdde9a13cd1e533c4"},
@@ -1150,10 +1312,9 @@ files = [
 name = "flexcache"
 version = "0.3"
 description = "Saves and loads to the cache a transformed versions of a source object."
-optional = true
+optional = false
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "extra == \"optimization\""
 files = [
     {file = "flexcache-0.3-py3-none-any.whl", hash = "sha256:d43c9fea82336af6e0115e308d9d33a185390b8346a017564611f1466dcd2e32"},
     {file = "flexcache-0.3.tar.gz", hash = "sha256:18743bd5a0621bfe2cf8d519e4c3bfdf57a269c15d1ced3fb4b64e0ff4600656"},
@@ -1169,10 +1330,9 @@ test = ["pytest", "pytest-cov", "pytest-mpl", "pytest-subtests"]
 name = "flexparser"
 version = "0.4"
 description = "Parsing made fun ... using typing."
-optional = true
+optional = false
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "extra == \"optimization\""
 files = [
     {file = "flexparser-0.4-py3-none-any.whl", hash = "sha256:3738b456192dcb3e15620f324c447721023c0293f6af9955b481e91d00179846"},
     {file = "flexparser-0.4.tar.gz", hash = "sha256:266d98905595be2ccc5da964fe0a2c3526fbbffdc45b65b3146d75db992ef6b2"},
@@ -1300,7 +1460,7 @@ tqdm = ["tqdm"]
 
 [[package]]
 name = "geecs-bluesky"
-version = "0.52.2"
+version = "0.56.0"
 description = "Bluesky / ophyd-async bridge for the GEECS control system"
 optional = false
 python-versions = ">=3.11,<3.12"
@@ -1318,9 +1478,10 @@ ophyd-async = ">=0.19.3,<1.0"
 tiled = {version = ">=0.2", extras = ["client"], optional = true}
 
 [package.extras]
-analysis = ["imageanalysis @ file:///Users/samuelbarber/Desktop/Code/Github_repos/GEECS-Plugins/.claude/worktrees/geecs-python-api-declutter-fd76fa/ImageAnalysis"]
+analysis = ["imageanalysis @ file:///Users/samuelbarber/Desktop/Code/Github_repos/GEECS-Plugins/.claude/worktrees/angry-lederberg-436e6d/ImageAnalysis"]
 ca = ["aioca (>=1.7)"]
-optimize = ["gest-api (>=0.1)", "imageanalysis @ file:///Users/samuelbarber/Desktop/Code/Github_repos/GEECS-Plugins/.claude/worktrees/geecs-python-api-declutter-fd76fa/ImageAnalysis", "scananalysis @ file:///Users/samuelbarber/Desktop/Code/Github_repos/GEECS-Plugins/.claude/worktrees/geecs-python-api-declutter-fd76fa/ScanAnalysis", "xopt (>=3.1,<4.0)"]
+optimize = ["gest-api (>=0.1)", "imageanalysis @ file:///Users/samuelbarber/Desktop/Code/Github_repos/GEECS-Plugins/.claude/worktrees/angry-lederberg-436e6d/ImageAnalysis", "scananalysis @ file:///Users/samuelbarber/Desktop/Code/Github_repos/GEECS-Plugins/.claude/worktrees/angry-lederberg-436e6d/ScanAnalysis", "xopt (>=3.1,<4.0)"]
+qserver = ["bluesky-queueserver (>=0.0.25,<0.0.26)"]
 tiled = ["tiled[client] (>=0.2)"]
 
 [package.source]
@@ -1657,6 +1818,128 @@ files = [
 numpy = ">=1.21.2"
 
 [[package]]
+name = "hiredis"
+version = "3.4.1"
+description = "Python wrapper for hiredis"
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "hiredis-3.4.1-cp310-cp310-macosx_10_15_universal2.whl", hash = "sha256:82358041521c4da1a635b5d4819c7d22cfdfa44d73a61e4fa6696057b7c9f0b9"},
+    {file = "hiredis-3.4.1-cp310-cp310-macosx_10_15_x86_64.whl", hash = "sha256:66958d145d6560f116542539acc625744c5e61a19ae33c840fb3d46c6b1e1c2a"},
+    {file = "hiredis-3.4.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:60f648860614725242df1322ce9937cb58101b95efeff558a658963ca4e40125"},
+    {file = "hiredis-3.4.1-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:40032f28be64352e6d5024bfd707f3f8d2ce1369064b1f730ce248b23f8ed8c7"},
+    {file = "hiredis-3.4.1-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:f8f5299a5c22724d440fe762acbaf21f8e825acf87793c543c26692ac110341e"},
+    {file = "hiredis-3.4.1-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:c51d8c57a11fba6175419272b542428d9186f86285e4f634d180b47908f9478f"},
+    {file = "hiredis-3.4.1-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:41fd6a4780c874726900891717a16032c0cc78ba5fabc8412ccf2f4fa9d831e8"},
+    {file = "hiredis-3.4.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:aa51ccf31c7bfcc808ed7371fb90bb1e19eea1b4c842a6f8132546f2b7d2e205"},
+    {file = "hiredis-3.4.1-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:392533ad3f209ad0cbfb84fa753081daa6416f45030ef3a379734311295c89a0"},
+    {file = "hiredis-3.4.1-cp310-cp310-musllinux_1_2_s390x.whl", hash = "sha256:9a034785409ac0a74d16c9bd05ac803a53261e0b0f4ec249ba3bb2bc159fd700"},
+    {file = "hiredis-3.4.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:c944aea7b4dc44294f90ecfd8c2b320f13e608a043dd4f654bdc728ffa256197"},
+    {file = "hiredis-3.4.1-cp310-cp310-win32.whl", hash = "sha256:3cd9a9de43b191739b46df22c01016c842f129e149cdeb0a7f6862bfbf6f0a19"},
+    {file = "hiredis-3.4.1-cp310-cp310-win_amd64.whl", hash = "sha256:9f77015efbdceb83b1c8751d967e31fd08114af5bc0b523e3562149894bf3ad4"},
+    {file = "hiredis-3.4.1-cp310-cp310-win_arm64.whl", hash = "sha256:ffa742a05493eefa1c8d37ea8296b35cc4c26a6f589540fad71c6f58322bc960"},
+    {file = "hiredis-3.4.1-cp311-cp311-macosx_10_15_universal2.whl", hash = "sha256:8f2ccefce627b6caee2e9605ef6eeb7cba50eaed49331789301a678c3c661703"},
+    {file = "hiredis-3.4.1-cp311-cp311-macosx_10_15_x86_64.whl", hash = "sha256:8852e54d87cd2e6481c0d0a843d01b0bc46a0300e13afc312228ee4eb4cc470f"},
+    {file = "hiredis-3.4.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:67326dd115b5e0bfea5a448f2102357b9957ea0a6d1f15e41916588845b57a2c"},
+    {file = "hiredis-3.4.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:dd98896fb410dfc5c47362e5f4af04cd7e179472a57052531b44b043adf360af"},
+    {file = "hiredis-3.4.1-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:8dabc962e38f7cb2e5ed934edaa57777d00d05e432a0ae9a3f22b6d64680fdc7"},
+    {file = "hiredis-3.4.1-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:2bd12118559e36bd38081c128b4c98f1e96d0a04890770d2750604cdd6a3ca83"},
+    {file = "hiredis-3.4.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:606abfff97de808f1bfd7ca2960e4a92176133229490cd33260d6a179dc62b04"},
+    {file = "hiredis-3.4.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:e2dd565a51444d4016217c9be9f389a30d641955ae8227eab0c3224497936690"},
+    {file = "hiredis-3.4.1-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:4148ca8973da6dff84628209ebc40722e56463425c9ec3fd18508de0a163f3bb"},
+    {file = "hiredis-3.4.1-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:e021c48a2f6ff58f04f3344d3dfb6511cfcb120823d6a632af3af608da907cff"},
+    {file = "hiredis-3.4.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:be2cb4733754cda4fa07b8a5ee7f792f341fa830fe28f62be8c6342ffade98d0"},
+    {file = "hiredis-3.4.1-cp311-cp311-win32.whl", hash = "sha256:0dd0dda7c9f0e909e1c87a73ec3461ec3bc746962dcdfc3a7cf34d6d1bc57873"},
+    {file = "hiredis-3.4.1-cp311-cp311-win_amd64.whl", hash = "sha256:cc40bae8bca39768eba82820248fcc18ae4d9bf66d8e9c7b51cca40c272863b7"},
+    {file = "hiredis-3.4.1-cp311-cp311-win_arm64.whl", hash = "sha256:48facb01c32fe6234c95f1e5f9d0a730c8e0a184f86962b46369818cf28ba209"},
+    {file = "hiredis-3.4.1-cp312-cp312-macosx_10_15_universal2.whl", hash = "sha256:fd5f86d937ecb5aa1dfed21d774f5ae8f8379eed607b1d9ab0ab6e80c4717981"},
+    {file = "hiredis-3.4.1-cp312-cp312-macosx_10_15_x86_64.whl", hash = "sha256:7630086181d75cd4e377fbbb00ed903619121bcf30b7ae84250366b2717ddebf"},
+    {file = "hiredis-3.4.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:c8efc144cc467c62c14cd49d276f1aaec5232ba46300164d59a5fdb68ba77fff"},
+    {file = "hiredis-3.4.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:66953abbda35703727a596bd3a83e86acc4da781e258780c3d85dd6acc1f39f9"},
+    {file = "hiredis-3.4.1-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:7b083a1deee1124a7c47baf1d3db85251f4ecd9812a974f586d59ef7d28f6007"},
+    {file = "hiredis-3.4.1-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5c3e191e6514c54f68a0b3d2b18aa6e73885393be16a31ae74b15c12b544cbaa"},
+    {file = "hiredis-3.4.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7a2cd31cba425ae954abeafa5dd74552e5ffa61661d3c8098cc66787330c1779"},
+    {file = "hiredis-3.4.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:742b4f7ce4b28820ef3fd45c7866f09e07dbf1904895eecd56b482eaa7bd26f5"},
+    {file = "hiredis-3.4.1-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:90de946ceac709797efcf3278e3f004f2a60ebd6bb5761bc35d7212d56fc1e5a"},
+    {file = "hiredis-3.4.1-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:404ce858750c6e31d420818d79bceda89869f521c990b01e7ce8fcc95916eb8b"},
+    {file = "hiredis-3.4.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:9f2656e2c11339e7e93df3c0d73c442129fb1381fb709706848f1b49e85677d1"},
+    {file = "hiredis-3.4.1-cp312-cp312-win32.whl", hash = "sha256:e333eb85c9ab16538d43b2e4e1fa564244d3f0c4a8a84e7c640812419b597180"},
+    {file = "hiredis-3.4.1-cp312-cp312-win_amd64.whl", hash = "sha256:b0d11936e377f305024953ae25ba52ae48edc26fe49f47af1e934f642deb3ed6"},
+    {file = "hiredis-3.4.1-cp312-cp312-win_arm64.whl", hash = "sha256:50d821b6195c9a4ba5cda44d950ba6205fdac5a7cf03e1ac4cdf0294f2df886c"},
+    {file = "hiredis-3.4.1-cp313-cp313-macosx_10_15_universal2.whl", hash = "sha256:7c3632721df2a3addca9a9707f7baa062bb0c004a585873f461b3b7a629c2516"},
+    {file = "hiredis-3.4.1-cp313-cp313-macosx_10_15_x86_64.whl", hash = "sha256:2b5b4cc3e1806f44f022389ade780aa1054336357defcb87613fe5267470e6f4"},
+    {file = "hiredis-3.4.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:d856ba70bd97db7cc136ca1dfa72b98044647d08913335949aa70477c8ebfe9a"},
+    {file = "hiredis-3.4.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:026639fa97c4b4fcc0f502454287ef1254cc1d067b610cbb958c392c46ff54ae"},
+    {file = "hiredis-3.4.1-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:d94c41779ae3eaee75c1668f23d26d9eda526055e37cd9052e980c64fb4127cc"},
+    {file = "hiredis-3.4.1-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:464f27b0521375a8179e24f19889d7953a88d22ec00808714a0c78ac8ebffbe7"},
+    {file = "hiredis-3.4.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:54d077e062804fa1eb49d25032bc0cadb085c50a5adc6f6fc43262dde6428471"},
+    {file = "hiredis-3.4.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:9186f49f2f45220d1dde7981f7766b7195497d6f3b85617dc0bc519f1e456482"},
+    {file = "hiredis-3.4.1-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:28c6f40eab7dd56dc63ff0e100e9d5d2759b191615d3134abcb48de5ff1f037a"},
+    {file = "hiredis-3.4.1-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:1e52aee6e7c9f97ae6df104388292568ce34ad5f1aae8acc843f4686b4745362"},
+    {file = "hiredis-3.4.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:e238e434d22c767b638d591f32532b7b34077267055481fce10bab1a4fa82d39"},
+    {file = "hiredis-3.4.1-cp313-cp313-win32.whl", hash = "sha256:0ebfbff143596d0b8957e67972ab14591b7427891e2d22b5939ddb1185fe14d2"},
+    {file = "hiredis-3.4.1-cp313-cp313-win_amd64.whl", hash = "sha256:ba678bbf5bd590e5c5b23560e5dcc73b9bbc4ccb4639d1eda1dba669bd8c6cb7"},
+    {file = "hiredis-3.4.1-cp313-cp313-win_arm64.whl", hash = "sha256:b6bef7f8753b0ab1e2a29781b589e4a64645bbe2753581cd57f32659756ccae2"},
+    {file = "hiredis-3.4.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:c54721b67df1cbdd0f78e0421b0b9768818109fcadbfa6b4a8d761c2506dd846"},
+    {file = "hiredis-3.4.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:718b86c425c8e2b3505d428ca632f9c9f5ea1c1582edcb76a77aa9c0d0a82580"},
+    {file = "hiredis-3.4.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:d151dd3d715cb62dcc09132e4a8f16c9ec0b0874ab9c6fca3b2cbdc09d52660f"},
+    {file = "hiredis-3.4.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5b59b49cbe1ee36e88a629a6653258cca4a89c3711b5836efde0ef1e011f0ab2"},
+    {file = "hiredis-3.4.1-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:279258dfc81ee6e2235f45e2fc9af00177bdaea5c72eaca6f6bbed56812c1018"},
+    {file = "hiredis-3.4.1-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:98788950e4a973b925a1b5cfe6d74736726732d8785437fcc4b80bbc563d2a47"},
+    {file = "hiredis-3.4.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b980b63a189ed8e2a42274f260430dae2f33a4a61e2f18ce31248909e36bd14a"},
+    {file = "hiredis-3.4.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:4e1e92095b511e2a778302b9acd160eceb1f20d49a1c9716a864358fc4ffc236"},
+    {file = "hiredis-3.4.1-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:7eb8b46d2f453030a3514d8ba76edeb92b920b627f883ec3685873c018a96494"},
+    {file = "hiredis-3.4.1-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:6fd1472d5e5d82929411ea08d002eb4a8e200558d05b66458b9fcd058214aa33"},
+    {file = "hiredis-3.4.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:7b72464f56c3f40f1ae1c784933686c3f0135d15e84fa7eb90166df18577b645"},
+    {file = "hiredis-3.4.1-cp314-cp314-win32.whl", hash = "sha256:a5e68f33bfdd542f659066ae7fb4ad37d4634d67fd330903feb0088f01808298"},
+    {file = "hiredis-3.4.1-cp314-cp314-win_amd64.whl", hash = "sha256:7cf4cf0735806049d2ada98ef0ac605e70b6bd303277857f459a8183b38b88c0"},
+    {file = "hiredis-3.4.1-cp314-cp314-win_arm64.whl", hash = "sha256:16fb7453720d846168281619021cd3562e4d6252b39ee0dd29610ab26847a0ee"},
+    {file = "hiredis-3.4.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:fd69048bb3870b962a2e09aff2ebfd0a3a4ee868bd280404c553235c36d43f7f"},
+    {file = "hiredis-3.4.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:bfd850dbf9c221d4a9e3eae819a91ecc8cdf9843a9ccdbc49cc94fe3f49dec59"},
+    {file = "hiredis-3.4.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:0a70be2b3a2280d48a0c46823455d83a863b8285563177a76667fcd62c686b5c"},
+    {file = "hiredis-3.4.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c4eba0bacd389e350470a883aad5f6733c721c65d408b32ba50b6624025660c4"},
+    {file = "hiredis-3.4.1-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c874e1f25fff64a0cd0ac990813950d59c9586094df0ce95cfc0372a6bc750ab"},
+    {file = "hiredis-3.4.1-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:1bca03bec5515ab7367fb84d5bdc3cd7bae901320eda89e059f1639e3f9e0793"},
+    {file = "hiredis-3.4.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:885220a6a495365961b8124865ccd5ea5ff7d39772fc79265d947befe418cc1b"},
+    {file = "hiredis-3.4.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:bfb1f5806a54f643b13065c2c5d05be993401421b8fef309d36f511ed3d13e06"},
+    {file = "hiredis-3.4.1-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:da1c8485246d0ec238d76c6689440c0e1bc28409a46592cda89f2ef1c008f26d"},
+    {file = "hiredis-3.4.1-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:00073e9b794229daca1089af62e6d2af8ec0a0f5540ced414eede10de2f43dae"},
+    {file = "hiredis-3.4.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:23667bce8ea8e5c300d4b13e369ef3f8d836b07cfea0dba46b839f1f1bd52548"},
+    {file = "hiredis-3.4.1-cp314-cp314t-win32.whl", hash = "sha256:e5377c51a30a09f0e302221dfe93e6f137b0a95f0d45c7756d995408a842627a"},
+    {file = "hiredis-3.4.1-cp314-cp314t-win_amd64.whl", hash = "sha256:5ba1921fc110294a80e28e2cc145edf69f038c263deb22543e787b07394ef5d2"},
+    {file = "hiredis-3.4.1-cp314-cp314t-win_arm64.whl", hash = "sha256:fd46a3fdec76283264e5a564fe38ba813e962bd3af1860970585c242eace683d"},
+    {file = "hiredis-3.4.1-cp38-cp38-macosx_10_15_universal2.whl", hash = "sha256:e63ccac57eb71e457b90b63b0905535cc3e058797ec1fbbc1e6d56de5052d3a1"},
+    {file = "hiredis-3.4.1-cp38-cp38-macosx_10_15_x86_64.whl", hash = "sha256:33e48e61f93279382740e67eac9fe57c2207272f00bde7325d455078518e9d5c"},
+    {file = "hiredis-3.4.1-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:be3be6c9fa4cc756c27ae9744b821473fe76989fa8429f0af63e49ce8c32314e"},
+    {file = "hiredis-3.4.1-cp38-cp38-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1e14e068d911a45321fc4383d222fac8efefc3fabaea1ab61c9a23bb90ee3b0a"},
+    {file = "hiredis-3.4.1-cp38-cp38-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:50f789b574373915daffe1e8cf3536218b03e42823774f7f502dfbb3b909f1dc"},
+    {file = "hiredis-3.4.1-cp38-cp38-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:cfca3c3c4410a9c127bde2ac164a5ac7c6cbb4a0875c9455221b453c7748d18f"},
+    {file = "hiredis-3.4.1-cp38-cp38-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7f7ef731e65cb9d45b3c8f27d51d4b325a97a141d090936672fba5b49b5a43c3"},
+    {file = "hiredis-3.4.1-cp38-cp38-musllinux_1_2_aarch64.whl", hash = "sha256:d84092a3e25502d505aa445ce1978c18c65e2b369b3812fa85fccf04bf8e788e"},
+    {file = "hiredis-3.4.1-cp38-cp38-musllinux_1_2_ppc64le.whl", hash = "sha256:3465347ce84bed21381072f534329f535df7f7517bb194482aa8817d9c333aec"},
+    {file = "hiredis-3.4.1-cp38-cp38-musllinux_1_2_s390x.whl", hash = "sha256:24d1c839feac4d6bb64486096fbb5a72eb43b8b0d677996e3d6b21670fb2a7bb"},
+    {file = "hiredis-3.4.1-cp38-cp38-musllinux_1_2_x86_64.whl", hash = "sha256:6f2b0b3c2f2c584dd8790b8ebbf574fa94042302eefc1cc00fae6b2d62de5b7c"},
+    {file = "hiredis-3.4.1-cp38-cp38-win32.whl", hash = "sha256:09ec2a32cdbb91c04a471e7d79ff98ee06185ea1a6bada44a0da1baa201c74ba"},
+    {file = "hiredis-3.4.1-cp38-cp38-win_amd64.whl", hash = "sha256:556971339bcb3bd6acf21c93d28acd21600c5d792511531a602fbc7e0f361fe8"},
+    {file = "hiredis-3.4.1-cp39-cp39-macosx_10_15_universal2.whl", hash = "sha256:6598c6e9dd158f54ea43a3036b75fdc36427a9ba96bfa159b4169d1a5e0ea68b"},
+    {file = "hiredis-3.4.1-cp39-cp39-macosx_10_15_x86_64.whl", hash = "sha256:211c1a503fa100fa958f8463aea4e21778fb3d9b27423a918403cd68e76b3b19"},
+    {file = "hiredis-3.4.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:8e90f85e072197049e48a578f5d4a3a09b3d0e0e0605fa0b96204659c074e5eb"},
+    {file = "hiredis-3.4.1-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:75face2cbb978a1df104c88aacbf9ec56f6f00495d64f8de2f852148c9a23e49"},
+    {file = "hiredis-3.4.1-cp39-cp39-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:fb971a32a2623b087ea86368ed762c5b47545173206bc95a987d2499150a4ab7"},
+    {file = "hiredis-3.4.1-cp39-cp39-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:738b044df56eb8fe2283237ceeadd5ec425395b98cd067e9f233877f9e1cfe9b"},
+    {file = "hiredis-3.4.1-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:05c9a679f2e22d64d4d624f5fd93825061c23d88f4b9cf2ba70ff8fc34781e3a"},
+    {file = "hiredis-3.4.1-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:19e2a62fb6650f2a7631cbe0925e3455e24630dda210b4e773e075b59129bbf8"},
+    {file = "hiredis-3.4.1-cp39-cp39-musllinux_1_2_ppc64le.whl", hash = "sha256:b8e655e8f6883c901588f92d1b2aaa40ac438de70146dcddd8291858d17c9d2b"},
+    {file = "hiredis-3.4.1-cp39-cp39-musllinux_1_2_s390x.whl", hash = "sha256:966d9a4198bfe43fb200655a855ab8f1ad60b9649f16f4b68c297f8e56c3dc12"},
+    {file = "hiredis-3.4.1-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:8874cd9366f9f812c4966fa1185475adf0a53b5d795a81c499619427843e88e8"},
+    {file = "hiredis-3.4.1-cp39-cp39-win32.whl", hash = "sha256:c00e3ad8a4cccd3258f6fc3094177ffcd3a69f7d87a82d1e32fdf9c143d6e5c3"},
+    {file = "hiredis-3.4.1-cp39-cp39-win_amd64.whl", hash = "sha256:8753ae9912993c28081204999f8be18847d99c67268bee8ec52bda55639b3319"},
+    {file = "hiredis-3.4.1-cp39-cp39-win_arm64.whl", hash = "sha256:fffa6cb2d713bd2ec45a1b68aa2ba37d01aefecf127acd323fbd5df564dab274"},
+    {file = "hiredis-3.4.1.tar.gz", hash = "sha256:2bbb55435506e481d270df8d0b29dd94acb85d11d71df4b8efce23849a4d0bb7"},
+]
+
+[[package]]
 name = "historydict"
 version = "1.2.6"
 description = "A persistent dictionary with history backed by sqlite"
@@ -1837,6 +2120,18 @@ test = ["fsspec[github]", "pytest", "pytest-cov"]
 tifffile = ["tifffile"]
 
 [[package]]
+name = "imagesize"
+version = "2.0.0"
+description = "Get image size from headers (BMP/PNG/JPEG/JPEG2000/GIF/TIFF/SVG/Netpbm/WebP/AVIF/HEIC/HEIF)"
+optional = false
+python-versions = "<3.15,>=3.10"
+groups = ["main"]
+files = [
+    {file = "imagesize-2.0.0-py2.py3-none-any.whl", hash = "sha256:5667c5bbb57ab3f1fa4bc366f4fbc971db3d5ed011fd2715fd8001f782718d96"},
+    {file = "imagesize-2.0.0.tar.gz", hash = "sha256:8e8358c4a05c304f1fccf7ff96f036e7243a189e9e42e90851993c558cfe9ee3"},
+]
+
+[[package]]
 name = "importlib-metadata"
 version = "9.0.0"
 description = "Read metadata from Python packages"
@@ -1873,13 +2168,46 @@ files = [
 ]
 
 [[package]]
+name = "ipykernel"
+version = "7.3.0"
+description = "IPython Kernel for Jupyter"
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+files = [
+    {file = "ipykernel-7.3.0-py3-none-any.whl", hash = "sha256:897eb64da762549ef610698fca5e9675195ec6ac8ec7f19d81ce1ca20c876057"},
+    {file = "ipykernel-7.3.0.tar.gz", hash = "sha256:9acaaaf97d16355166e4085afe9d225bfbdf2b7ef520f9df3be8f2b248275e09"},
+]
+
+[package.dependencies]
+appnope = {version = ">=0.1.2", markers = "platform_system == \"Darwin\""}
+comm = ">=0.1.1"
+debugpy = ">=1.6.5"
+ipython = ">=7.23.1"
+jupyter-client = ">=8.9.0"
+jupyter-core = ">=5.1,<6.0.dev0 || >=6.1.dev0"
+matplotlib-inline = ">=0.1"
+nest-asyncio2 = ">=1.7.0"
+packaging = ">=22"
+psutil = ">=5.7"
+pyzmq = ">=25"
+tornado = ">=6.4.1"
+traitlets = ">=5.4.0"
+
+[package.extras]
+cov = ["coverage[toml]", "matplotlib", "pytest-cov", "trio"]
+docs = ["intersphinx-registry", "myst-parser", "pydata-sphinx-theme", "sphinx", "sphinx-autodoc-typehints", "sphinxcontrib-github-alt", "sphinxcontrib-spelling", "trio"]
+pyqt5 = ["pyqt5"]
+pyside6 = ["pyside6"]
+test = ["flaky", "ipyparallel", "pre-commit", "pytest (>=7.0,<10)", "pytest-asyncio (>=0.23.5)", "pytest-cov", "pytest-timeout"]
+
+[[package]]
 name = "ipython"
 version = "9.15.0"
 description = "IPython: Productive Interactive Computing"
-optional = true
+optional = false
 python-versions = ">=3.11"
 groups = ["main"]
-markers = "extra == \"optimization\""
 files = [
     {file = "ipython-9.15.0-py3-none-any.whl", hash = "sha256:515ad9c3cdf0c932a5a9f6245419e8aba706b7bd03c3e1d3a1c83d9351d6aa6e"},
     {file = "ipython-9.15.0.tar.gz", hash = "sha256:da2819ce2aa83135257df830660b1176d986c3d2876db24df01974fa955b2756"},
@@ -1911,10 +2239,9 @@ test-extra = ["curio", "ipykernel (>6.30)", "ipython[matplotlib]", "ipython[test
 name = "ipython-pygments-lexers"
 version = "1.1.1"
 description = "Defines a variety of Pygments lexers for highlighting IPython code."
-optional = true
+optional = false
 python-versions = ">=3.8"
 groups = ["main"]
-markers = "extra == \"optimization\""
 files = [
     {file = "ipython_pygments_lexers-1.1.1-py3-none-any.whl", hash = "sha256:a9462224a505ade19a605f71f8fa63c2048833ce50abc86768a0d81d876dc81c"},
     {file = "ipython_pygments_lexers-1.1.1.tar.gz", hash = "sha256:09c0138009e56b6854f9535736f4171d855c8c08a563a0dcd8022f78355c7e81"},
@@ -1950,10 +2277,9 @@ test = ["ipykernel", "jsonschema", "pytest (>=3.6.0)", "pytest-cov", "pytz"]
 name = "jedi"
 version = "0.20.0"
 description = "An autocompletion tool for Python that can be used for text editors."
-optional = true
+optional = false
 python-versions = ">=3.10"
 groups = ["main"]
-markers = "extra == \"optimization\""
 files = [
     {file = "jedi-0.20.0-py2.py3-none-any.whl", hash = "sha256:7bdd9c2634f56713299976f4cbd59cb3fa92165cc5e05ea811fb253480728b67"},
     {file = "jedi-0.20.0.tar.gz", hash = "sha256:c3f4ccbd276696f4b19c54618d4fb18f9fc24b0aef02acf704b23f487daa1011"},
@@ -1970,10 +2296,9 @@ docs = ["Jinja2 (==3.1.6)", "MarkupSafe (==3.0.3)", "Pygments (==2.20.0)", "Sphi
 name = "jinja2"
 version = "3.1.6"
 description = "A very fast and expressive template engine."
-optional = true
+optional = false
 python-versions = ">=3.7"
 groups = ["main"]
-markers = "extra == \"optimization\""
 files = [
     {file = "jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67"},
     {file = "jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d"},
@@ -2086,6 +2411,76 @@ files = [
 
 [package.dependencies]
 referencing = ">=0.31.0"
+
+[[package]]
+name = "jupyter-client"
+version = "8.9.1"
+description = "Jupyter protocol implementation and client libraries"
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+files = [
+    {file = "jupyter_client-8.9.1-py3-none-any.whl", hash = "sha256:0b7a295bc46e8751e9adae84781f726c851c1d911bd793edc4a3bde942e3da81"},
+    {file = "jupyter_client-8.9.1.tar.gz", hash = "sha256:a58f730dd9e728ba16ba1d62ebccf7ffe1ebbdbce4e95cfae941b7321ae1f4fa"},
+]
+
+[package.dependencies]
+jupyter-core = ">=5.1"
+python-dateutil = ">=2.8.2"
+pyzmq = ">=25.0"
+tornado = ">=6.4.1"
+traitlets = ">=5.3"
+typing-extensions = ">=4.13.0"
+
+[package.extras]
+docs = ["ipykernel", "myst-parser", "pydata-sphinx-theme", "sphinx (>=4)", "sphinx-autodoc-typehints", "sphinxcontrib-github-alt", "sphinxcontrib-spelling"]
+orjson = ["orjson"]
+test = ["anyio", "coverage", "ipykernel (>=6.14)", "msgpack", "mypy ; platform_python_implementation != \"PyPy\"", "paramiko ; sys_platform == \"win32\"", "pre-commit", "pytest", "pytest-cov", "pytest-jupyter[client] (>=0.6.2)", "pytest-timeout"]
+
+[[package]]
+name = "jupyter-console"
+version = "6.6.3"
+description = "Jupyter terminal console"
+optional = false
+python-versions = ">=3.7"
+groups = ["main"]
+files = [
+    {file = "jupyter_console-6.6.3-py3-none-any.whl", hash = "sha256:309d33409fcc92ffdad25f0bcdf9a4a9daa61b6f341177570fdac03de5352485"},
+    {file = "jupyter_console-6.6.3.tar.gz", hash = "sha256:566a4bf31c87adbfadf22cdf846e3069b59a71ed5da71d6ba4d8aaad14a53539"},
+]
+
+[package.dependencies]
+ipykernel = ">=6.14"
+ipython = "*"
+jupyter-client = ">=7.0.0"
+jupyter-core = ">=4.12,<5.0.dev0 || >=5.1.dev0"
+prompt-toolkit = ">=3.0.30"
+pygments = "*"
+pyzmq = ">=17"
+traitlets = ">=5.4"
+
+[package.extras]
+test = ["flaky", "pexpect", "pytest"]
+
+[[package]]
+name = "jupyter-core"
+version = "5.9.1"
+description = "Jupyter core package. A base package on which Jupyter projects rely."
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+files = [
+    {file = "jupyter_core-5.9.1-py3-none-any.whl", hash = "sha256:ebf87fdc6073d142e114c72c9e29a9d7ca03fad818c5d300ce2adc1fb0743407"},
+    {file = "jupyter_core-5.9.1.tar.gz", hash = "sha256:4d09aaff303b9566c3ce657f580bd089ff5c91f5f89cf7d8846c3cdf465b5508"},
+]
+
+[package.dependencies]
+platformdirs = ">=2.5"
+traitlets = ">=5.3"
+
+[package.extras]
+docs = ["intersphinx-registry", "myst-parser", "pydata-sphinx-theme", "sphinx-autodoc-typehints", "sphinxcontrib-spelling", "traitlets"]
+test = ["ipykernel", "pre-commit", "pytest (<9)", "pytest-cov", "pytest-timeout"]
 
 [[package]]
 name = "jupyterlab-widgets"
@@ -2439,10 +2834,9 @@ testing = ["coverage", "pytest", "pytest-cov", "pytest-regressions", "pytest-tim
 name = "markupsafe"
 version = "3.0.3"
 description = "Safely add untrusted strings to HTML/XML markup."
-optional = true
+optional = false
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "extra == \"optimization\""
 files = [
     {file = "markupsafe-3.0.3-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:2f981d352f04553a7171b8e44369f2af4055f888dfb147d55e42d29e29e74559"},
     {file = "markupsafe-3.0.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:e1c1493fb6e50ab01d20a22826e57520f1284df32f2d8601fdd90b6304601419"},
@@ -2607,10 +3001,9 @@ python-dateutil = ">=2.7"
 name = "matplotlib-inline"
 version = "0.2.2"
 description = "Inline Matplotlib backend for Jupyter"
-optional = true
+optional = false
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "extra == \"optimization\""
 files = [
     {file = "matplotlib_inline-0.2.2-py3-none-any.whl", hash = "sha256:3c821cf1c209f59fb2d2d64abbf5b23b67bcb2210d663f9918dd851c6da1fcf6"},
     {file = "matplotlib_inline-0.2.2.tar.gz", hash = "sha256:72f3fe8fce36b70d4a5b612f899090cd0401deddc4ea90e1572b9f4bfb058c79"},
@@ -2950,13 +3343,24 @@ files = [
 arrays = ["numpy"]
 
 [[package]]
+name = "nest-asyncio2"
+version = "1.7.2"
+description = "Patch asyncio to allow nested event loops"
+optional = false
+python-versions = ">=3.5"
+groups = ["main"]
+files = [
+    {file = "nest_asyncio2-1.7.2-py3-none-any.whl", hash = "sha256:f5dfa702f3f81f6a03857e9a19e2ba578c0946a4ad417b4c50a24d7ba641fe01"},
+    {file = "nest_asyncio2-1.7.2.tar.gz", hash = "sha256:1921d70b92cc4612c374928d081552efb59b83d91b2b789d935c665fa01729a8"},
+]
+
+[[package]]
 name = "networkx"
 version = "3.6.1"
 description = "Python package for creating and manipulating graphs and networks"
-optional = true
+optional = false
 python-versions = "!=3.14.1,>=3.11"
 groups = ["main"]
-markers = "extra == \"optimization\""
 files = [
     {file = "networkx-3.6.1-py3-none-any.whl", hash = "sha256:d47fbf302e7d9cbbb9e2555a0d267983d2aa476bac30e90dfbe5669bd57f3762"},
     {file = "networkx-3.6.1.tar.gz", hash = "sha256:26b7c357accc0c8cde558ad486283728b65b6a95d85ee1cd66bafab4c8168509"},
@@ -3216,6 +3620,21 @@ files = [
     {file = "numpy-2.3.5-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:f16417ec91f12f814b10bafe79ef77e70113a2f5f7018640e7425ff979253425"},
     {file = "numpy-2.3.5.tar.gz", hash = "sha256:784db1dcdab56bf0517743e746dfb0f885fc68d948aba86eeec2cba234bdf1c0"},
 ]
+
+[[package]]
+name = "numpydoc"
+version = "1.10.0"
+description = "Sphinx extension to support docstrings in Numpy format"
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+files = [
+    {file = "numpydoc-1.10.0-py3-none-any.whl", hash = "sha256:3149da9874af890bcc2a82ef7aae5484e5aa81cb2778f08e3c307ba6d963721b"},
+    {file = "numpydoc-1.10.0.tar.gz", hash = "sha256:3f7970f6eee30912260a6b31ac72bba2432830cd6722569ec17ee8d3ef5ffa01"},
+]
+
+[package.dependencies]
+sphinx = ">=6"
 
 [[package]]
 name = "nvidia-cublas"
@@ -3530,6 +3949,21 @@ files = [
 numpy = {version = ">=2", markers = "python_version >= \"3.9\""}
 
 [[package]]
+name = "openpyxl"
+version = "3.1.5"
+description = "A Python library to read/write Excel 2010 xlsx/xlsm files"
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "openpyxl-3.1.5-py2.py3-none-any.whl", hash = "sha256:5282c12b107bffeef825f4617dc029afaf41d0ea60823bbb665ef3079dc79de2"},
+    {file = "openpyxl-3.1.5.tar.gz", hash = "sha256:cf0e3cf56142039133628b5acffe8ef0c12bc902d2aadd3e0fe5878dc08d1050"},
+]
+
+[package.dependencies]
+et-xmlfile = "*"
+
+[[package]]
 name = "opentelemetry-api"
 version = "1.43.0"
 description = "OpenTelemetry Python API"
@@ -3543,6 +3977,28 @@ files = [
 
 [package.dependencies]
 typing-extensions = ">=4.5.0"
+
+[[package]]
+name = "ophyd"
+version = "1.11.2"
+description = "Bluesky hardware abstraction with an emphasis on EPICS"
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "ophyd-1.11.2-py3-none-any.whl", hash = "sha256:0254dbced299fbff1841b4f80102dd0e0c482176d5812a2246a08763acd87a75"},
+    {file = "ophyd-1.11.2.tar.gz", hash = "sha256:ef63cc291a34d55823ec2f62be91991786ce4b9100e374df097b785d849466c3"},
+]
+
+[package.dependencies]
+networkx = ">=2.0"
+numpy = "*"
+opentelemetry-api = "*"
+packaging = "*"
+pint = "*"
+
+[package.extras]
+dev = ["attrs (>=19.3.0)", "black (==22.3.0)", "bluesky (>=1.11.0)", "caproto[standard] (>=0.4.2rc1,!=1.2.0)", "databroker (>=1.0.0b1)", "doctr", "epics-pypdb", "flake8", "flake8-isort", "h5py", "inflection", "ipython", "ipywidgets", "matplotlib", "mypy", "myst-parser", "numpydoc", "pipdeptree", "pre-commit", "pydata-sphinx-theme", "pyepics (>=3.4.2,<3.5.7)", "pytest", "pytest-asyncio", "pytest-codecov", "pytest-cov", "pytest-faulthandler", "pytest-rerunfailures", "pytest-timeout", "setuptools (>=64)", "setuptools_scm[toml] (>=6.2)", "sphinx-autobuild", "sphinx-design", "tox-direct"]
 
 [[package]]
 name = "ophyd-async"
@@ -3771,10 +4227,9 @@ xml = ["lxml (>=4.9.2)"]
 name = "parso"
 version = "0.8.7"
 description = "A Python Parser"
-optional = true
+optional = false
 python-versions = ">=3.6"
 groups = ["main"]
-markers = "extra == \"optimization\""
 files = [
     {file = "parso-0.8.7-py2.py3-none-any.whl", hash = "sha256:a8926eb2a1b915486941fdbd31e86a4baf88fe8c210f25f2f35ecec5b574ca1c"},
     {file = "parso-0.8.7.tar.gz", hash = "sha256:eaaac4c9fdd5e9e8852dc778d2d7405897ec510f2a298071453e5e3a07914bb1"},
@@ -3807,10 +4262,10 @@ complete = ["blosc", "numpy (>=1.20.0)", "pandas (>=1.3)", "pyzmq"]
 name = "pexpect"
 version = "4.9.0"
 description = "Pexpect allows easy control of interactive console applications."
-optional = true
+optional = false
 python-versions = "*"
 groups = ["main"]
-markers = "extra == \"optimization\" and sys_platform != \"win32\" and sys_platform != \"emscripten\""
+markers = "sys_platform != \"win32\" and sys_platform != \"emscripten\""
 files = [
     {file = "pexpect-4.9.0-py2.py3-none-any.whl", hash = "sha256:7236d1e080e4936be2dc3e326cec0af72acf9212a7e1d060210e70a47e253523"},
     {file = "pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f"},
@@ -3928,10 +4383,9 @@ xmp = ["defusedxml"]
 name = "pint"
 version = "0.25.3"
 description = "Physical quantities module"
-optional = true
+optional = false
 python-versions = ">=3.11"
 groups = ["main"]
-markers = "extra == \"optimization\""
 files = [
     {file = "pint-0.25.3-py3-none-any.whl", hash = "sha256:27eb25143bd5de9fcc4d5a4b484f16faf6b4615aa93ece6b3373a8c1a3c1b97d"},
     {file = "pint-0.25.3.tar.gz", hash = "sha256:f8f5df6cf65314d74da1ade1bf96f8e3e4d0c41b51577ac53c49e7d44ca5acee"},
@@ -3991,10 +4445,9 @@ testing = ["coverage", "pytest", "pytest-benchmark"]
 name = "prompt-toolkit"
 version = "3.0.52"
 description = "Library for building powerful interactive command lines in Python"
-optional = true
+optional = false
 python-versions = ">=3.8"
 groups = ["main"]
-markers = "extra == \"optimization\""
 files = [
     {file = "prompt_toolkit-3.0.52-py3-none-any.whl", hash = "sha256:9aac639a3bbd33284347de5ad8d68ecc044b91a762dc39b7c21095fcd6a19955"},
     {file = "prompt_toolkit-3.0.52.tar.gz", hash = "sha256:28cde192929c8e7321de85de1ddbe736f1375148b02f2e17edd840042b1be855"},
@@ -4045,10 +4498,9 @@ files = [
 name = "psutil"
 version = "7.2.2"
 description = "Cross-platform lib for process and system monitoring."
-optional = true
+optional = false
 python-versions = ">=3.6"
 groups = ["main"]
-markers = "extra == \"optimization\" and (sys_platform == \"linux\" or sys_platform == \"win32\") or extra == \"optimization\" and sys_platform != \"emscripten\" and sys_platform != \"cygwin\""
 files = [
     {file = "psutil-7.2.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:2edccc433cbfa046b980b0df0171cd25bcaeb3a68fe9022db0979e7aa74a826b"},
     {file = "psutil-7.2.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:e78c8603dcd9a04c7364f1a3e670cea95d51ee865e4efb3556a3a63adef958ea"},
@@ -4081,10 +4533,10 @@ test = ["psleak", "pytest", "pytest-instafail", "pytest-xdist", "pywin32 ; os_na
 name = "ptyprocess"
 version = "0.7.0"
 description = "Run a subprocess in a pseudo terminal"
-optional = true
+optional = false
 python-versions = "*"
 groups = ["main"]
-markers = "extra == \"optimization\" and sys_platform != \"win32\" and sys_platform != \"emscripten\""
+markers = "sys_platform != \"win32\" and sys_platform != \"emscripten\""
 files = [
     {file = "ptyprocess-0.7.0-py2.py3-none-any.whl", hash = "sha256:4b41f3967fce3af57cc7e94b888626c18bf37a083e3651ca8feeb66d492fef35"},
     {file = "ptyprocess-0.7.0.tar.gz", hash = "sha256:5c5d0a3b48ceee0b48485e0c26037c0acd7d29765ca3fbb5cb3831d347423220"},
@@ -4094,10 +4546,9 @@ files = [
 name = "pure-eval"
 version = "0.2.3"
 description = "Safely evaluate AST nodes without side effects"
-optional = true
+optional = false
 python-versions = "*"
 groups = ["main"]
-markers = "extra == \"optimization\""
 files = [
     {file = "pure_eval-0.2.3-py3-none-any.whl", hash = "sha256:1db8e35b67b3d218d818ae653e27f06c3aa420901fa7b081ca98cbedc874e0d0"},
     {file = "pure_eval-0.2.3.tar.gz", hash = "sha256:5f4e983f40564c576c7c8635ae88db5956bb2229d7e9237d03b3c0b0190eaf42"},
@@ -4222,10 +4673,10 @@ pyasn1 = ">=0.6.1,<0.7.0"
 name = "pycparser"
 version = "3.0"
 description = "C parser in Python"
-optional = true
+optional = false
 python-versions = ">=3.10"
 groups = ["main"]
-markers = "extra == \"optimization\" and implementation_name != \"PyPy\""
+markers = "extra == \"optimization\" and implementation_name != \"PyPy\" or implementation_name == \"pypy\""
 files = [
     {file = "pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992"},
     {file = "pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29"},
@@ -4781,6 +5232,18 @@ files = [
 cli = ["click (>=5.0)"]
 
 [[package]]
+name = "python-multipart"
+version = "0.0.32"
+description = "A streaming multipart parser for Python"
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+files = [
+    {file = "python_multipart-0.0.32-py3-none-any.whl", hash = "sha256:ff6d3f776f16878c894e52e107296ffc890e913c611b1a4ec6c44e2821fe2e23"},
+    {file = "python_multipart-0.0.32.tar.gz", hash = "sha256:be54b7f3fa167bb83e4fcd936b887b708f4e57fe75911c02aebf53efaf8d938e"},
+]
+
+[[package]]
 name = "pytz"
 version = "2026.2"
 description = "World timezone definitions, modern and historical"
@@ -4876,6 +5339,105 @@ files = [
 ]
 
 [[package]]
+name = "pyzmq"
+version = "27.2.0"
+description = "Python bindings for 0MQ"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "pyzmq-27.2.0-cp310-cp310-macosx_10_15_universal2.whl", hash = "sha256:480dba27b145373b5e103890f17969d891bc9e86746d6b8b29dd70b0d4addc62"},
+    {file = "pyzmq-27.2.0-cp310-cp310-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:722f0a6940be1a483c81029a271d950e04dc2ff113a42e21b3d2b7a0d8e59638"},
+    {file = "pyzmq-27.2.0-cp310-cp310-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3ee556ed1cf836f96de9d5e545563116426d4a94f21b8041fdc79408eff18ebb"},
+    {file = "pyzmq-27.2.0-cp310-cp310-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d64da42cae09e6b0c61368b4cc8ca80f23ce3af17584d08053f3dc957433d5ed"},
+    {file = "pyzmq-27.2.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:376981d106598beb70be384f44d8f589832fd0051d184d38d10043da3cc3b080"},
+    {file = "pyzmq-27.2.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:40d96cb7a8f6a43aa9617c00215c2b73e1b5e4a1d6cbc9f5860ed7ac682599f0"},
+    {file = "pyzmq-27.2.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:4ebc7889b31bc11c72e9f17ba3ebb0a8b0911cce413f41b498e55383a94819a3"},
+    {file = "pyzmq-27.2.0-cp310-cp310-win32.whl", hash = "sha256:650c6cd7cb39a069e7048261efe66fce8bf2e0052c831a7a099b7a0f2ea860d7"},
+    {file = "pyzmq-27.2.0-cp310-cp310-win_amd64.whl", hash = "sha256:82a09aa67871d4f2fcafd47bf670fb93210b232a7c2d4b8a54676314edf04033"},
+    {file = "pyzmq-27.2.0-cp310-cp310-win_arm64.whl", hash = "sha256:bad4813f270592cedf56977e31ac1fc374fb0f6f67ea5134a5e37c19cb429a8e"},
+    {file = "pyzmq-27.2.0-cp311-cp311-macosx_10_15_universal2.whl", hash = "sha256:9216132843d139a123f243c07fe70f7487dce5041093dd77040f9adb5dc91872"},
+    {file = "pyzmq-27.2.0-cp311-cp311-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:d41ebb260b69329b7d4a2936d44c872c86dd785355b51366c8b14e07ed7e9373"},
+    {file = "pyzmq-27.2.0-cp311-cp311-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:468139ddb2e494d06e586bd3a6835077e8b3764560c8db552fe685c5867fc24e"},
+    {file = "pyzmq-27.2.0-cp311-cp311-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:39755dc4a923021bd0677990ffdbc21cff0e1ee1cf07fe3817acea153ef4cb67"},
+    {file = "pyzmq-27.2.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:714f8cbd66c7e405338d668f79d2fe83fe923defe348e843be998603cf92eeff"},
+    {file = "pyzmq-27.2.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:1132805970045adb9f5f05dd57040978286a8e21a5475f2c2ddf1bc983b9a2c7"},
+    {file = "pyzmq-27.2.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:b26f2d0493b79ce3c3112c8a12649418915582ba4707b8ed9f44febf2be71f42"},
+    {file = "pyzmq-27.2.0-cp311-cp311-win32.whl", hash = "sha256:44f261eca7dfb9904ea2b56428f59ab693bbe2715c0413a701f17b067ebf877c"},
+    {file = "pyzmq-27.2.0-cp311-cp311-win_amd64.whl", hash = "sha256:8b86e04f55af0f4d8cd8ecf14c0b8b81ebc8fd66fa20126b753514628ecadc7e"},
+    {file = "pyzmq-27.2.0-cp311-cp311-win_arm64.whl", hash = "sha256:917d601e9540098f580d2723d0ce6402cdb6f02bc8dc2de74e0dca6e13bffd1b"},
+    {file = "pyzmq-27.2.0-cp312-abi3-macosx_10_15_universal2.whl", hash = "sha256:591c8de5851c5ea372194469fe97587b97c3b641e9a70f31bb3474acbfde0241"},
+    {file = "pyzmq-27.2.0-cp312-abi3-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:00e73942ef12cecbc7951c4a9104bb8ffaed742abb13af2da6833d90dd368cef"},
+    {file = "pyzmq-27.2.0-cp312-abi3-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1f8079d0521fe94bbb401fe9407578b28f3701627c8be2c9f7e0c5b77dcb0109"},
+    {file = "pyzmq-27.2.0-cp312-abi3-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:dea74fd65f1fc5f7fe167916a473ebe6ed6174e5e5d9de11ea6583661be6cf43"},
+    {file = "pyzmq-27.2.0-cp312-abi3-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:dcc99ca132b667a4ed750afd42db4ea73288f18425a9b2e3c0af095665c491f5"},
+    {file = "pyzmq-27.2.0-cp312-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:b8d5f66e4a8246cf77f7b8f7902af64f00553368fa0373c89d99b78f0ad79394"},
+    {file = "pyzmq-27.2.0-cp312-abi3-musllinux_1_2_i686.whl", hash = "sha256:d1526b42a2e725b84ed226f37becedc250c6347594e5ed304e4e9aff68c9aec3"},
+    {file = "pyzmq-27.2.0-cp312-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:f707bcf2c1d007d14d70531d4dd7b41060881c73efa845580bf6faaf9ea24d42"},
+    {file = "pyzmq-27.2.0-cp312-abi3-win32.whl", hash = "sha256:fdaaa4ea3242f6ad298eb5177eb042aea5c73c30e76d20caee7b15af20d24ec2"},
+    {file = "pyzmq-27.2.0-cp312-abi3-win_amd64.whl", hash = "sha256:2c218c6ab8bc447ba62054b581fd30209689d199c6ecb253f79615ca74a38e12"},
+    {file = "pyzmq-27.2.0-cp312-abi3-win_arm64.whl", hash = "sha256:348d6fd3e4b81ae4580622ea8c2ea60224e84b2ac1b3be4482e6edc7de06e7a3"},
+    {file = "pyzmq-27.2.0-cp313-cp313-android_24_arm64_v8a.whl", hash = "sha256:c551b9e2f86dc625fcb1a032c0d68042678caf96a8dd7c28796766b673bd5b52"},
+    {file = "pyzmq-27.2.0-cp313-cp313-android_24_x86_64.whl", hash = "sha256:288cc790da0e3064a14a38ddc56ba169dada8c8af4cb86518db2bcbd380eedbb"},
+    {file = "pyzmq-27.2.0-cp314-cp314-android_24_arm64_v8a.whl", hash = "sha256:3d45189c0c3c99f817b7fefff0d32eeef684cf33e1e3c0fc4281515357c54702"},
+    {file = "pyzmq-27.2.0-cp314-cp314-android_24_x86_64.whl", hash = "sha256:d61910b52be5b2cd8b248dbcbe3a1b0275556a7d99fb613fc43323b546e273b8"},
+    {file = "pyzmq-27.2.0-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:3ab6eb88590e510ab16715c32dbba12000da9bee989fdadd9ee19a234c492eb7"},
+    {file = "pyzmq-27.2.0-cp314-cp314t-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:1ecbdd131b9669f62d3a45afee5527c7ae9f141e4301267f21714c90bd21725f"},
+    {file = "pyzmq-27.2.0-cp314-cp314t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3146385b94a760236c5eceff468a66a296a716ca98a2e0f9217b1518118466b1"},
+    {file = "pyzmq-27.2.0-cp314-cp314t-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9846e881620dd62566ca76a53e384c3f37490faf4b9240aebc7498810dfca853"},
+    {file = "pyzmq-27.2.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:d9527e3dbaef1edaeeb2446fa7379446814a43ade8adc7c4a5ebe69437815ddd"},
+    {file = "pyzmq-27.2.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:56b48fa9d478a3af7254f397697a62f5ad3e1bb677e200b2701f0c290d97e5af"},
+    {file = "pyzmq-27.2.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:bf0b6e4ce1bb089751c504c5493d6b0557eabd02dd21b76e9086cf964234b103"},
+    {file = "pyzmq-27.2.0-cp314-cp314t-win32.whl", hash = "sha256:fba8afcf265c6e9fbe1594cb045d4765c6c9a7d607653a8196067ef23566b843"},
+    {file = "pyzmq-27.2.0-cp314-cp314t-win_amd64.whl", hash = "sha256:d1bc1d380a91d954ed5fc9f12915dba014eed0978d2de05ee7ca688bdaac144a"},
+    {file = "pyzmq-27.2.0-cp314-cp314t-win_arm64.whl", hash = "sha256:c7cfb75caa83f5153c687e9d2107f64b5ef0ef0d6edd260d3ff920baaaa69101"},
+    {file = "pyzmq-27.2.0-cp315-cp315-android_24_arm64_v8a.whl", hash = "sha256:c5129a8fe43ecc49b99eb75616603d483a3c2fcaef504988fafe8ea392aea98b"},
+    {file = "pyzmq-27.2.0-cp315-cp315-android_24_x86_64.whl", hash = "sha256:baa2ce3485145653194d6c8c5beedd1e9f0bf46a0919c9fa2fe2204fc35b74d9"},
+    {file = "pyzmq-27.2.0-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:e1ed46048d1920cabc96d952a0d5cfe4127ad8db572c335aae4e3c57b9278d7f"},
+    {file = "pyzmq-27.2.0-cp315-cp315t-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:e0fa0bc6b1a184aee59b32efcd1b7f0e6d5b8f9387799e4c16a4cb66a86747d6"},
+    {file = "pyzmq-27.2.0-cp315-cp315t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0f4bd6743e8bf854c3bfce892dd6578a514aabf128e37a4b2eafcf01856f7e44"},
+    {file = "pyzmq-27.2.0-cp315-cp315t-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:95369ed6626afcfe2ac89832fb1b917c077fbeb905fbbe5d918349ce0222b89b"},
+    {file = "pyzmq-27.2.0-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:40124779c3a56ad5d91902df1ff89159cb414b6c1a0ee697abcc66cf5e6db62d"},
+    {file = "pyzmq-27.2.0-cp315-cp315t-musllinux_1_2_i686.whl", hash = "sha256:ec8a318dfc27c7d946651b3d9e8025d5734f30c168a822195601827207bac09b"},
+    {file = "pyzmq-27.2.0-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:88c0fac061bac269076edeb3a209acefc96cd6167c239daf1c2b404ac48d7012"},
+    {file = "pyzmq-27.2.0-cp315-cp315t-win32.whl", hash = "sha256:ac126d48cf18aa955daabef43bf0009ff76ad4deee437d09ecf15388214b5beb"},
+    {file = "pyzmq-27.2.0-cp315-cp315t-win_amd64.whl", hash = "sha256:edce90a1e588ec63adbf612cc0ad582de4169cd216c7ae53c15f42a2ee902f35"},
+    {file = "pyzmq-27.2.0-cp315-cp315t-win_arm64.whl", hash = "sha256:a843094b4d3d633bc3623e47a2ff50742d6af02bc1f7606aa2e67e971e21878d"},
+    {file = "pyzmq-27.2.0-cp39-cp39-macosx_10_15_universal2.whl", hash = "sha256:76afba06ae698f2b8fe4fb34b32c760a650f168c2e622f370f2c528035b7f650"},
+    {file = "pyzmq-27.2.0-cp39-cp39-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:c9322f9c87b0935870516c2876e1e29497fdc50439c785ece63e3fbbab06c821"},
+    {file = "pyzmq-27.2.0-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7e2579c5de82ddf4544d723c1bc8b44c3b806d157acc9fb2a2d18e10ef28e202"},
+    {file = "pyzmq-27.2.0-cp39-cp39-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:95f52b877149b06bbdeec2e8ea6230aad14950bbfbcfa16e7eb88951f07d6b28"},
+    {file = "pyzmq-27.2.0-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:a0ee3c49be2aa15abd12cbbd14d4ea2892f872c688e1e487af39ec1972ed549d"},
+    {file = "pyzmq-27.2.0-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:6eb63cc61ab93b01b9afc887a160255e2fbe703fdbacfe5feaef87214f51bd6c"},
+    {file = "pyzmq-27.2.0-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:f52f08101907609cc08db6a1f9f2a7a9afd54e9b2ca16178c9c38e99fb593cef"},
+    {file = "pyzmq-27.2.0-cp39-cp39-win32.whl", hash = "sha256:507c0b33f95502723d325487e8e50c2cdd3b37444143f05423a3861327f69bf7"},
+    {file = "pyzmq-27.2.0-cp39-cp39-win_amd64.whl", hash = "sha256:ff60f0f7ccfda0e303ac43bec7096007b7cdf2c41b3739d1ec667febe67acab3"},
+    {file = "pyzmq-27.2.0-cp39-cp39-win_arm64.whl", hash = "sha256:d61a0169ba05ab7ebc48dc793f092df12f789bf378dac8321ccd966fd93d94e8"},
+    {file = "pyzmq-27.2.0-pp310-pypy310_pp73-macosx_10_15_x86_64.whl", hash = "sha256:770a37f28ddfbe1d2c40a2e3ce37e5fd10831daa6ae9634105aa8a5d23507b00"},
+    {file = "pyzmq-27.2.0-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:b398c5fe102b41e1559f7ffdae760aabd5f432d73b047b4ae0eac4e01cb594d2"},
+    {file = "pyzmq-27.2.0-pp310-pypy310_pp73-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:0e1af01858d6dc0c09cea57f9cb1ddf4601f04897b6bb1efc3a2038123c87d79"},
+    {file = "pyzmq-27.2.0-pp310-pypy310_pp73-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:211350c3ccd4746bc5a85e8fe961bad1f7f2f274f67cf1f785fad7f96f562eea"},
+    {file = "pyzmq-27.2.0-pp310-pypy310_pp73-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:dde5e291548ca0f397623b5e523db5c90172b32aa4fd3ba464a79ea31a580b43"},
+    {file = "pyzmq-27.2.0-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:94242bd4de6af7e74665e14a88630bccd615057f6acfaf08a3a432551d604645"},
+    {file = "pyzmq-27.2.0-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:a7c1144dc61777938e932a2c9011b980b89fd8ff3733033b34c44c299187a6e1"},
+    {file = "pyzmq-27.2.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:c218b816220d05acf6ab1bafca58926d95cbcc5fec5024724666030466308f0c"},
+    {file = "pyzmq-27.2.0-pp311-pypy311_pp73-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:ae6ebbc0bfe5a21ce21e32ba567bf73df2d93888109c65acbd42506cf9395759"},
+    {file = "pyzmq-27.2.0-pp311-pypy311_pp73-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:679b5b1dde326a921ea2c9ec1f9ea3115bfe1b4735779bbc6eb0473a0ed93f71"},
+    {file = "pyzmq-27.2.0-pp311-pypy311_pp73-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f5c6d8744d10b5e1eadd90a7c58f8546acf6bf680ee463f7e6ada09ad6c9f802"},
+    {file = "pyzmq-27.2.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:3ee8dd7031d5e23f632e0e7eee67183ca7d2536e0de35dc1e5d69f3471a791e8"},
+    {file = "pyzmq-27.2.0-pp39-pypy39_pp73-macosx_10_15_x86_64.whl", hash = "sha256:97d4c6622f129b514a4f5939af1b5f434c97f47085d9311b5f7f36e24b3bd447"},
+    {file = "pyzmq-27.2.0-pp39-pypy39_pp73-macosx_11_0_arm64.whl", hash = "sha256:dfcd024eade5870b25f890c4df0ba9421ed8167d8d3d82334237512c1158dada"},
+    {file = "pyzmq-27.2.0-pp39-pypy39_pp73-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:a070a9cdad1f8f8a85ea153afcc4654f11b10895d14c0acabe10f1df0e0892ea"},
+    {file = "pyzmq-27.2.0-pp39-pypy39_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:010db74a1dd67c7cd8b8b30916355735db7d633a070510bb34e41ab679ab2c0e"},
+    {file = "pyzmq-27.2.0-pp39-pypy39_pp73-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9ab72ee77b313d0658447204c8201f9b315146e923b48c56ea7dbd005d464a91"},
+    {file = "pyzmq-27.2.0-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:8a5c04ad2e368142aea52d1abdf6631cb2534864e3c16ab78268ab957060b2a6"},
+    {file = "pyzmq-27.2.0.tar.gz", hash = "sha256:54d4259d1bfae24ecdb5ca79f7acc2eac6c286a02d6a0ae617797cb45f0726d3"},
+]
+
+[package.dependencies]
+cffi = {version = "*", markers = "implementation_name == \"pypy\""}
+
+[[package]]
 name = "qt5-applications"
 version = "5.15.2.2.3"
 description = "The collection of Qt tools easily installable in Python"
@@ -4926,6 +5488,30 @@ numpy = ">=1.24.0"
 dev = ["mypy", "pytest (>=6)", "pytest-cov (>=3)", "ruff"]
 docs = ["furo (>=2023.08.17)", "myst-parser (>=0.13)", "sphinx (>=7.0)", "sphinx-autodoc-typehints", "sphinx-copybutton"]
 test = ["pytest (>=6)", "pytest-cov (>=3)"]
+
+[[package]]
+name = "redis"
+version = "8.1.0"
+description = "Python client for Redis database and key-value store"
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+files = [
+    {file = "redis-8.1.0-py3-none-any.whl", hash = "sha256:a4fe1aac3d3b3cc791d4b3d5931c5a956045dc951ee74d1c913ee3ac4d2ee9fb"},
+    {file = "redis-8.1.0.tar.gz", hash = "sha256:6e1a19beef9225c83efd689c7e6b7da2d5215b1f42cd13b7fc3714d0a09c7b25"},
+]
+
+[package.dependencies]
+async-timeout = {version = ">=4.0.3", markers = "python_full_version < \"3.11.3\""}
+hiredis = {version = ">=3.2.0", optional = true, markers = "extra == \"hiredis\""}
+
+[package.extras]
+circuit-breaker = ["pybreaker (>=1.4.0)"]
+hiredis = ["hiredis (>=3.2.0)"]
+jwt = ["pyjwt (>=2.13.0)"]
+ocsp = ["cryptography (>=36.0.1)", "pyopenssl (>=20.0.1)", "requests (>=2.31.0)"]
+otel = ["opentelemetry-api (>=1.39.1)", "opentelemetry-exporter-otlp-proto-http (>=1.39.1)", "opentelemetry-sdk (>=1.39.1)"]
+xxhash = ["xxhash (>=3.6.0,<3.7.0)"]
 
 [[package]]
 name = "referencing"
@@ -5004,6 +5590,18 @@ pygments = ">=2.13.0,<3.0.0"
 
 [package.extras]
 jupyter = ["ipywidgets (>=7.5.1,<9)"]
+
+[[package]]
+name = "roman-numerals"
+version = "4.1.0"
+description = "Manipulate well-formed Roman numerals"
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+files = [
+    {file = "roman_numerals-4.1.0-py3-none-any.whl", hash = "sha256:647ba99caddc2cc1e55a51e4360689115551bf4476d90e8162cf8c345fe233c7"},
+    {file = "roman_numerals-4.1.0.tar.gz", hash = "sha256:1af8b147eb1405d5839e78aeb93131690495fe9da5c91856cb33ad55a7f1e5b2"},
+]
 
 [[package]]
 name = "rpds-py"
@@ -5629,7 +6227,7 @@ version = "3.1.1"
 description = "This package provides 36 stemmers for 34 languages generated from Snowball algorithms."
 optional = false
 python-versions = ">=3.3"
-groups = ["dev"]
+groups = ["main", "dev"]
 files = [
     {file = "snowballstemmer-3.1.1-py3-none-any.whl", hash = "sha256:7e207fa178741da09cdee59d3ecec3827ad5f92b1fc5c9ff3755b639f71f5752"},
     {file = "snowballstemmer-3.1.1.tar.gz", hash = "sha256:e07bbc54a0d798fe6010a12398422e62a8bfbba95c394fd0956ef58cb4d3e260"},
@@ -5662,13 +6260,143 @@ tests = ["pre-commit", "pytest (>=3.5)", "pytest-codspeed", "pytest-cov", "pytes
 tox = ["sparse[tests]", "tox"]
 
 [[package]]
+name = "sphinx"
+version = "9.0.4"
+description = "Python documentation generator"
+optional = false
+python-versions = ">=3.11"
+groups = ["main"]
+files = [
+    {file = "sphinx-9.0.4-py3-none-any.whl", hash = "sha256:5bebc595a5e943ea248b99c13814c1c5e10b3ece718976824ffa7959ff95fffb"},
+    {file = "sphinx-9.0.4.tar.gz", hash = "sha256:594ef59d042972abbc581d8baa577404abe4e6c3b04ef61bd7fc2acbd51f3fa3"},
+]
+
+[package.dependencies]
+alabaster = ">=0.7.14"
+babel = ">=2.13"
+colorama = {version = ">=0.4.6", markers = "sys_platform == \"win32\""}
+docutils = ">=0.20,<0.23"
+imagesize = ">=1.3"
+Jinja2 = ">=3.1"
+packaging = ">=23.0"
+Pygments = ">=2.17"
+requests = ">=2.30.0"
+roman-numerals = ">=1.0.0"
+snowballstemmer = ">=2.2"
+sphinxcontrib-applehelp = ">=1.0.7"
+sphinxcontrib-devhelp = ">=1.0.6"
+sphinxcontrib-htmlhelp = ">=2.0.6"
+sphinxcontrib-jsmath = ">=1.0.1"
+sphinxcontrib-qthelp = ">=1.0.6"
+sphinxcontrib-serializinghtml = ">=1.1.9"
+
+[[package]]
+name = "sphinxcontrib-applehelp"
+version = "2.0.0"
+description = "sphinxcontrib-applehelp is a Sphinx extension which outputs Apple help books"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "sphinxcontrib_applehelp-2.0.0-py3-none-any.whl", hash = "sha256:4cd3f0ec4ac5dd9c17ec65e9ab272c9b867ea77425228e68ecf08d6b28ddbdb5"},
+    {file = "sphinxcontrib_applehelp-2.0.0.tar.gz", hash = "sha256:2f29ef331735ce958efa4734873f084941970894c6090408b079c61b2e1c06d1"},
+]
+
+[package.extras]
+lint = ["mypy", "ruff (==0.5.5)", "types-docutils"]
+standalone = ["Sphinx (>=5)"]
+test = ["pytest"]
+
+[[package]]
+name = "sphinxcontrib-devhelp"
+version = "2.0.0"
+description = "sphinxcontrib-devhelp is a sphinx extension which outputs Devhelp documents"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "sphinxcontrib_devhelp-2.0.0-py3-none-any.whl", hash = "sha256:aefb8b83854e4b0998877524d1029fd3e6879210422ee3780459e28a1f03a8a2"},
+    {file = "sphinxcontrib_devhelp-2.0.0.tar.gz", hash = "sha256:411f5d96d445d1d73bb5d52133377b4248ec79db5c793ce7dbe59e074b4dd1ad"},
+]
+
+[package.extras]
+lint = ["mypy", "ruff (==0.5.5)", "types-docutils"]
+standalone = ["Sphinx (>=5)"]
+test = ["pytest"]
+
+[[package]]
+name = "sphinxcontrib-htmlhelp"
+version = "2.1.0"
+description = "sphinxcontrib-htmlhelp is a sphinx extension which renders HTML help files"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "sphinxcontrib_htmlhelp-2.1.0-py3-none-any.whl", hash = "sha256:166759820b47002d22914d64a075ce08f4c46818e17cfc9470a9786b759b19f8"},
+    {file = "sphinxcontrib_htmlhelp-2.1.0.tar.gz", hash = "sha256:c9e2916ace8aad64cc13a0d233ee22317f2b9025b9cf3295249fa985cc7082e9"},
+]
+
+[package.extras]
+lint = ["mypy", "ruff (==0.5.5)", "types-docutils"]
+standalone = ["Sphinx (>=5)"]
+test = ["html5lib", "pytest"]
+
+[[package]]
+name = "sphinxcontrib-jsmath"
+version = "1.0.1"
+description = "A sphinx extension which renders display math in HTML via JavaScript"
+optional = false
+python-versions = ">=3.5"
+groups = ["main"]
+files = [
+    {file = "sphinxcontrib-jsmath-1.0.1.tar.gz", hash = "sha256:a9925e4a4587247ed2191a22df5f6970656cb8ca2bd6284309578f2153e0c4b8"},
+    {file = "sphinxcontrib_jsmath-1.0.1-py2.py3-none-any.whl", hash = "sha256:2ec2eaebfb78f3f2078e73666b1415417a116cc848b72e5172e596c871103178"},
+]
+
+[package.extras]
+test = ["flake8", "mypy", "pytest"]
+
+[[package]]
+name = "sphinxcontrib-qthelp"
+version = "2.0.0"
+description = "sphinxcontrib-qthelp is a sphinx extension which outputs QtHelp documents"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "sphinxcontrib_qthelp-2.0.0-py3-none-any.whl", hash = "sha256:b18a828cdba941ccd6ee8445dbe72ffa3ef8cbe7505d8cd1fa0d42d3f2d5f3eb"},
+    {file = "sphinxcontrib_qthelp-2.0.0.tar.gz", hash = "sha256:4fe7d0ac8fc171045be623aba3e2a8f613f8682731f9153bb2e40ece16b9bbab"},
+]
+
+[package.extras]
+lint = ["mypy", "ruff (==0.5.5)", "types-docutils"]
+standalone = ["Sphinx (>=5)"]
+test = ["defusedxml (>=0.7.1)", "pytest"]
+
+[[package]]
+name = "sphinxcontrib-serializinghtml"
+version = "2.0.0"
+description = "sphinxcontrib-serializinghtml is a sphinx extension which outputs \"serialized\" HTML files (json and pickle)"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "sphinxcontrib_serializinghtml-2.0.0-py3-none-any.whl", hash = "sha256:6e2cb0eef194e10c27ec0023bfeb25badbbb5868244cf5bc5bdc04e4464bf331"},
+    {file = "sphinxcontrib_serializinghtml-2.0.0.tar.gz", hash = "sha256:e9d912827f872c029017a53f0ef2180b327c3f7fd23c87229f7a8e8b70031d4d"},
+]
+
+[package.extras]
+lint = ["mypy", "ruff (==0.5.5)", "types-docutils"]
+standalone = ["Sphinx (>=5)"]
+test = ["pytest"]
+
+[[package]]
 name = "stack-data"
 version = "0.6.3"
 description = "Extract data from python stack frames and tracebacks for informative displays"
-optional = true
+optional = false
 python-versions = "*"
 groups = ["main"]
-markers = "extra == \"optimization\""
 files = [
     {file = "stack_data-0.6.3-py3-none-any.whl", hash = "sha256:d5558e0c25a4cb0853cddad3d77da9891a08cb85dd9f9f91b9f8cd66e511e695"},
     {file = "stack_data-0.6.3.tar.gz", hash = "sha256:836a778de4fec4dcd1dcd89ed8abff8a221f58308462e1c4aa2a3cf30148f0b9"},
@@ -5897,6 +6625,26 @@ optree = ["optree (>=0.13.0)"]
 pyyaml = ["pyyaml"]
 
 [[package]]
+name = "tornado"
+version = "6.5.8"
+description = "Tornado is a Python web framework and asynchronous networking library, originally developed at FriendFeed."
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "tornado-6.5.8-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:cc6aa787d7cfab7c3d35189dc7a56fbd2399a569624c730c6b55b3d6531d0403"},
+    {file = "tornado-6.5.8-cp39-abi3-macosx_10_9_x86_64.whl", hash = "sha256:9715b5eb79735b2bcd454ce216a9275b7c0470e64ea1bf5742f78b2f72b26eeb"},
+    {file = "tornado-6.5.8-cp39-abi3-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:547d63f450d570c14fe0e8db2cfb14c9bbd1c2503b4a6612586267955aa47b58"},
+    {file = "tornado-6.5.8-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7e2360a0ffbe145eca8af0b19cb7203d79b1a98dd4cccdd6b368f6f49c2e3808"},
+    {file = "tornado-6.5.8-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:5d242290bdf7ab3151bc1065fdd75c0dcc21cbc7b49f22a4c56329c2d6566d22"},
+    {file = "tornado-6.5.8-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:7b94ff0e128fe0542f3bd331fb44d06260fc4ac16881545159f34ef08aad4195"},
+    {file = "tornado-6.5.8-cp39-abi3-win32.whl", hash = "sha256:67832909c4779c64942380cb5f044a5c6163d00831472d80e25e115de9917836"},
+    {file = "tornado-6.5.8-cp39-abi3-win_amd64.whl", hash = "sha256:11881db6b7c168494be2c2d12e65931451bdf7ee718535418ae1d8855dd5a0ee"},
+    {file = "tornado-6.5.8-cp39-abi3-win_arm64.whl", hash = "sha256:68a7468c7e289f8514d7d664101753903217eff1bb6822c6b5994a0b5f5bcb26"},
+    {file = "tornado-6.5.8.tar.gz", hash = "sha256:9452e1b208a8bd771e2cb1f2ff564985b9b214bdebbe622793e1799e0a6bd23f"},
+]
+
+[[package]]
 name = "tqdm"
 version = "4.68.4"
 description = "Fast, Extensible Progress Meter"
@@ -5921,10 +6669,9 @@ telegram = ["envwrap", "requests"]
 name = "traitlets"
 version = "5.15.1"
 description = "Traitlets Python configuration system"
-optional = true
+optional = false
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "extra == \"optimization\""
 files = [
     {file = "traitlets-5.15.1-py3-none-any.whl", hash = "sha256:770a53705f84b81ac107e83a1b3328ff2dae16094d8fc3cfc004e4b22dfd8e92"},
     {file = "traitlets-5.15.1.tar.gz", hash = "sha256:7b1c07854fe25acb39e009bae49f11b79ff6cbb2f27999104e9110e7a6b53722"},
@@ -6253,10 +7000,9 @@ anyio = ">=3.0.0"
 name = "wcwidth"
 version = "0.8.2"
 description = "Measures the displayed width of unicode strings in a terminal"
-optional = true
+optional = false
 python-versions = ">=3.8"
 groups = ["main"]
-markers = "extra == \"optimization\""
 files = [
     {file = "wcwidth-0.8.2-py3-none-any.whl", hash = "sha256:d63947694a0539a1d51e01eda7caf800c291020e6cdd7e28ad7b14dd33ad4f85"},
     {file = "wcwidth-0.8.2.tar.gz", hash = "sha256:91fbef97204b96a3d4d421609b80340b760cf33e26da123ff243d76b1fda8dda"},
@@ -6589,4 +7335,4 @@ optimization = ["gest-api", "imageanalysis", "scananalysis", "xopt"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<3.12"
-content-hash = "c18a504a7f685097b5b5360c9f288bd96ac5feb7e8ec03f0f8c1455e1df10348"
+content-hash = "c58e25777188e19bc48d33a795509f51511edeb8355d4f1d9c8c13f43e86e8b9"

--- a/GEECS-Console/pyproject.toml
+++ b/GEECS-Console/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-console"
-version = "0.20.2"
+version = "0.21.0"
 description = "Greenfield PySide6 operator console for GEECS (Bluesky/gateway architecture)"
 authors = ["Sam Barber <sbarber@lbl.gov>"]
 readme = "README.md"
@@ -46,6 +46,11 @@ xopt = { version = "^3.1", optional = true }
 gest-api = { version = ">=0.1", optional = true }
 scananalysis = { path = "../ScanAnalysis", develop = true, optional = true }
 imageanalysis = { path = "../ImageAnalysis", develop = true, optional = true }
+# The RE Manager client (queueserver migration, #648): queue submission,
+# status polling, and the manager's console-output monitor all ride this
+# small api package (it pulls pyzmq; the document stream's
+# RemoteDispatcher comes from bluesky via geecs-bluesky).
+bluesky-queueserver-api = "^0.0.13"
 
 [tool.poetry.extras]
 optimization = ["xopt", "gest-api", "scananalysis", "imageanalysis"]

--- a/GEECS-Console/tests/test_queue_client.py
+++ b/GEECS-Console/tests/test_queue_client.py
@@ -1,0 +1,293 @@
+"""Hermetic tests for the queueserver client seam (services/queue_client.py).
+
+No manager, no network: the real client's lazy ``REManagerAPI`` is replaced
+by setting the ``_api`` cache directly (the documented injection point for
+tests), and the config reader runs against a temp home.
+"""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+
+import pytest
+
+from geecs_console.services.queue_client import (
+    QserverConfig,
+    QueueClient,
+    QueueStatus,
+    StubQueueClient,
+    ZmqQueueClient,
+    make_queue_client,
+    read_qserver_config,
+)
+
+
+@pytest.fixture
+def home(tmp_path, monkeypatch):
+    # The reader expands ops_paths.USER_CONFIG_PATH ("~/...") — point the
+    # tilde at a temp home on both POSIX and Windows (the console-windows
+    # CI job runs this suite too).
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
+    return tmp_path
+
+
+def _write_config(home: Path, body: str) -> None:
+    cfg = home / ".config" / "geecs_python_api"
+    cfg.mkdir(parents=True)
+    (cfg / "config.ini").write_text(body)
+
+
+class TestReadQserverConfig:
+    def test_missing_file_reads_none(self, home):
+        assert read_qserver_config() is None
+
+    def test_missing_section_reads_none(self, home):
+        _write_config(home, "[Experiment]\nexpt = Undulator\n")
+        assert read_qserver_config() is None
+
+    def test_host_derives_the_standard_ports(self, home):
+        _write_config(home, "[qserver]\nhost = 192.168.6.99\n")
+        config = read_qserver_config()
+        assert config == QserverConfig(
+            control_addr="tcp://192.168.6.99:60615",
+            info_addr="tcp://192.168.6.99:60625",
+            doc_addr="192.168.6.99:5568",
+        )
+
+    def test_explicit_addresses_win(self, home):
+        _write_config(
+            home,
+            "[qserver]\nhost = h\ncontrol_addr = tcp://h:1\n"
+            "info_addr = tcp://h:2\ndoc_addr = h:3\n",
+        )
+        config = read_qserver_config()
+        assert config.control_addr == "tcp://h:1"
+        assert config.info_addr == "tcp://h:2"
+        assert config.doc_addr == "h:3"
+
+    def test_empty_section_reads_none(self, home):
+        _write_config(home, "[qserver]\n")
+        assert read_qserver_config() is None
+
+    def test_factory_returns_stub_without_config(self, home):
+        client = make_queue_client()
+        assert isinstance(client, StubQueueClient)
+        assert isinstance(client, QueueClient)  # protocol conformance
+
+
+class TestStubQueueClient:
+    def test_status_disconnected_names_the_config(self):
+        status = StubQueueClient().status()
+        assert not status.connected
+        assert "[qserver]" in status.detail
+
+    def test_verbs_refuse_clearly(self):
+        stub = StubQueueClient()
+        assert not stub.submit_scan({}).ok
+        assert not stub.request_pause()[0]
+        with pytest.raises(RuntimeError, match=r"\[qserver\]"):
+            stub.move_variable("x", 1.0)
+
+
+class _FakeManagerAPI:
+    """Recording stand-in for REManagerAPI (the ``_api`` injection point)."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple] = []
+        self.status_payloads: list[dict] = []
+        self.queue_items: list[dict] = []
+        self.task_results: list[dict] = []
+        self.raise_on_status: Exception | None = None
+
+    def status(self) -> dict:
+        self.calls.append(("status",))
+        if self.raise_on_status is not None:
+            raise self.raise_on_status
+        if self.status_payloads:
+            return self.status_payloads.pop(0)
+        return {
+            "re_state": "idle",
+            "manager_state": "idle",
+            "worker_environment_exists": True,
+            "items_in_queue": len(self.queue_items),
+        }
+
+    def queue_get(self) -> dict:
+        self.calls.append(("queue_get",))
+        return {"items": list(self.queue_items)}
+
+    def queue_clear(self) -> None:
+        self.calls.append(("queue_clear",))
+        self.queue_items = []
+
+    def item_add(self, item, *, user=None) -> dict:
+        self.calls.append(("item_add", item.to_dict(), user))
+        return {"item": {"item_uid": "uid-1"}}
+
+    def queue_start(self) -> None:
+        self.calls.append(("queue_start",))
+
+    def queue_stop(self) -> None:
+        self.calls.append(("queue_stop",))
+
+    def re_pause(self, option=None) -> None:
+        self.calls.append(("re_pause", option))
+
+    def re_resume(self) -> None:
+        self.calls.append(("re_resume",))
+
+    def re_stop(self) -> None:
+        self.calls.append(("re_stop",))
+
+    def function_execute(self, item, *, user=None) -> dict:
+        self.calls.append(("function_execute", item.to_dict(), user))
+        return {"task_uid": "task-1"}
+
+    def task_result(self, uid) -> dict:
+        self.calls.append(("task_result", uid))
+        if self.task_results:
+            return self.task_results.pop(0)
+        return {"status": "running"}
+
+
+def _client(fake: _FakeManagerAPI) -> ZmqQueueClient:
+    client = ZmqQueueClient(
+        QserverConfig("tcp://x:1", "tcp://x:2", "x:3"), user="test-console"
+    )
+    client._api = fake
+    return client
+
+
+class TestZmqQueueClient:
+    def test_status_maps_the_manager_payload(self):
+        fake = _FakeManagerAPI()
+        fake.status_payloads = [
+            {
+                "re_state": "paused",
+                "manager_state": "paused",
+                "worker_environment_exists": True,
+                "items_in_queue": 2,
+                "running_item_uid": "abc",
+            }
+        ]
+        status = _client(fake).status()
+        assert status == QueueStatus(
+            connected=True,
+            re_state="paused",
+            manager_state="paused",
+            worker_exists=True,
+            items_in_queue=2,
+            running_item_uid="abc",
+        )
+
+    def test_status_failure_reads_disconnected(self):
+        fake = _FakeManagerAPI()
+        fake.raise_on_status = OSError("timeout occurred")
+        status = _client(fake).status()
+        assert not status.connected
+        assert "timeout" in status.detail
+
+    def test_submit_scan_adds_and_starts(self):
+        fake = _FakeManagerAPI()
+        result = _client(fake).submit_scan({"mode": "noscan"})
+        assert result.ok and result.item_uid == "uid-1"
+        names = [c[0] for c in fake.calls]
+        assert names == ["queue_get", "item_add", "queue_start"]
+        added = fake.calls[1][1]
+        assert added["name"] == "geecs_scan_request_plan"
+        assert added["args"] == [{"mode": "noscan"}]
+        assert fake.calls[1][2] == "test-console"
+
+    def test_submit_scan_surfaces_pending_items_without_clearing(self):
+        # The #648 item-3 trap: a failed item returns to the queue FRONT;
+        # blind add-and-start would re-run it.
+        fake = _FakeManagerAPI()
+        fake.queue_items = [{"name": "geecs_scan_request_plan", "item_uid": "old"}]
+        result = _client(fake).submit_scan({"mode": "noscan"})
+        assert not result.ok
+        assert result.pending_items[0]["item_uid"] == "old"
+        assert ("queue_clear",) not in fake.calls
+        assert not any(c[0] == "item_add" for c in fake.calls)
+
+    def test_submit_scan_clear_pending_clears_then_submits(self):
+        fake = _FakeManagerAPI()
+        fake.queue_items = [{"item_uid": "old"}]
+        result = _client(fake).submit_scan({"mode": "noscan"}, clear_pending=True)
+        assert result.ok
+        names = [c[0] for c in fake.calls]
+        assert names == ["queue_get", "queue_clear", "item_add", "queue_start"]
+
+    def test_submit_action_queues_the_action_plan(self):
+        fake = _FakeManagerAPI()
+        result = _client(fake).submit_action("close_shutters")
+        assert result.ok
+        added = next(c[1] for c in fake.calls if c[0] == "item_add")
+        assert added["name"] == "geecs_run_action_plan"
+        assert added["args"] == ["close_shutters"]
+
+    def test_stop_from_paused_stops_directly(self):
+        fake = _FakeManagerAPI()
+        fake.status_payloads = [{"re_state": "paused"}]
+        ok, message = _client(fake).stop_scan()
+        assert ok and "paused" in message
+        assert ("re_stop",) in fake.calls
+        assert not any(c[0] == "re_pause" for c in fake.calls)
+
+    def test_stop_from_running_pauses_then_stops(self):
+        fake = _FakeManagerAPI()
+        fake.status_payloads = [
+            {"re_state": "running"},  # initial
+            {"re_state": "running"},  # first poll
+            {"re_state": "paused"},  # pause landed
+        ]
+        ok, message = _client(fake).stop_scan()
+        assert ok, message
+        names = [c[0] for c in fake.calls]
+        assert names.index("re_pause") < names.index("re_stop")
+
+    def test_stop_when_idle_reports_nothing_to_stop(self):
+        fake = _FakeManagerAPI()
+        fake.status_payloads = [{"re_state": "idle"}]
+        ok, message = _client(fake).stop_scan()
+        assert not ok and "nothing to stop" in message
+
+    def test_move_variable_runs_the_worker_function(self):
+        fake = _FakeManagerAPI()
+        fake.task_results = [
+            {"status": "running"},
+            {
+                "status": "completed",
+                "result": {
+                    "success": True,
+                    "return_value": {"variable": "u_s1h", "value": 1.0},
+                },
+            },
+        ]
+        result = _client(fake).move_variable("u_s1h", 1.0)
+        assert result == {"variable": "u_s1h", "value": 1.0}
+        executed = next(c[1] for c in fake.calls if c[0] == "function_execute")
+        assert executed["name"] == "geecs_move_variable"
+        assert executed["args"] == ["u_s1h", 1.0]
+
+    def test_worker_task_failure_raises_with_the_message(self):
+        fake = _FakeManagerAPI()
+        fake.task_results = [
+            {
+                "status": "completed",
+                "result": {"success": False, "msg": "scan in progress"},
+            }
+        ]
+        with pytest.raises(RuntimeError, match="scan in progress"):
+            _client(fake).move_variable("u_s1h", 1.0)
+
+    def test_task_timeout_raises(self, monkeypatch):
+        fake = _FakeManagerAPI()  # always "running"
+        client = _client(fake)
+        # Collapse the polling clock so the timeout path runs instantly.
+        ticks = iter([0.0, 0.1, 1000.0])
+        monkeypatch.setattr(time, "monotonic", lambda: next(ticks, 2000.0))
+        monkeypatch.setattr(time, "sleep", lambda s: None)
+        with pytest.raises(RuntimeError, match="did not finish"):
+            client.move_variable("u_s1h", 1.0)

--- a/GEECS-Console/tests/test_queue_client.py
+++ b/GEECS-Console/tests/test_queue_client.py
@@ -291,3 +291,35 @@ class TestZmqQueueClient:
         monkeypatch.setattr(time, "sleep", lambda s: None)
         with pytest.raises(RuntimeError, match="did not finish"):
             client.move_variable("u_s1h", 1.0)
+
+
+class TestQueueStartFailure:
+    """#653 review finding 2: a start failure must never silently leave the
+    item queued while reporting plain failure."""
+
+    def test_start_refusal_removes_the_item_and_says_so(self):
+        fake = _FakeManagerAPI()
+        removed: list[str] = []
+        fake.queue_start = lambda: (_ for _ in ()).throw(RuntimeError("busy"))
+
+        def item_remove(*, uid=None, pos=None):
+            removed.append(uid)
+
+        fake.item_remove = item_remove
+        result = _client(fake).submit_scan({"mode": "noscan"})
+        assert not result.ok
+        assert removed == ["uid-1"]
+        assert "removed again" in result.message
+
+    def test_start_refusal_with_failed_removal_names_the_stuck_item(self):
+        fake = _FakeManagerAPI()
+        fake.queue_start = lambda: (_ for _ in ()).throw(RuntimeError("busy"))
+
+        def item_remove(*, uid=None, pos=None):
+            raise RuntimeError("remove refused")
+
+        fake.item_remove = item_remove
+        result = _client(fake).submit_scan({"mode": "noscan"})
+        assert not result.ok
+        assert "REMAINS queued" in result.message
+        assert result.item_uid == "uid-1"

--- a/GEECS-Console/tests/test_scan_monitor.py
+++ b/GEECS-Console/tests/test_scan_monitor.py
@@ -1,0 +1,98 @@
+"""Hermetic tests for the scan monitor controller (app/scan_monitor.py).
+
+No sockets: the stream workers' parsing and lifecycle are tested without
+their daemon threads (the parse helpers are called directly; ``stop()``
+gates emission), and the controller runs against the stub queue client.
+"""
+
+from __future__ import annotations
+
+from geecs_console.app.scan_monitor import (
+    ConsoleStreamWorker,
+    DocumentStreamWorker,
+    ScanMonitorController,
+    _FAILED_MOVE_PREFIX_FALLBACK,
+    _failed_move_prefix,
+)
+from geecs_console.services.queue_client import StubQueueClient
+
+
+class TestFailedMovePrefix:
+    def test_matches_the_engine_constant_when_importable(self):
+        # The fallback exists for hermetic installs; when the engine is
+        # importable (it is, in this env) the two must agree — this is the
+        # keep-in-sync pin.
+        try:
+            from geecs_bluesky.plans.pause_semantics import FAILED_MOVE_LOG_PREFIX
+        except ImportError:
+            return
+        assert _failed_move_prefix() == FAILED_MOVE_LOG_PREFIX
+        assert _FAILED_MOVE_PREFIX_FALLBACK == FAILED_MOVE_LOG_PREFIX
+
+
+class TestConsoleStreamWorker:
+    def test_lines_and_pause_reason_extraction(self, qtbot):
+        worker = ConsoleStreamWorker("tcp://x:1")
+        lines: list[str] = []
+        reasons: list[str] = []
+        worker.line.connect(lines.append)
+        worker.pause_reason.connect(reasons.append)
+        prefix = _failed_move_prefix()
+        worker._handle_text(
+            f"some noise\n{prefix}: commanded u_s1h -> 1.05, one axis "
+            "failed - see cause\n\ntrailing",
+            prefix,
+        )
+        assert lines[0] == "some noise"
+        assert len(lines) == 3  # blank line dropped
+        assert len(reasons) == 1
+        assert reasons[0].startswith("commanded u_s1h")
+
+    def test_stop_gates_emission(self, qtbot):
+        worker = ConsoleStreamWorker("tcp://x:1")
+        seen: list[str] = []
+        worker.line.connect(seen.append)
+        worker.stop()
+        worker._handle_text("a line", "PREFIX")
+        assert seen == []
+
+
+class TestDocumentStreamWorker:
+    def test_stop_is_idempotent_without_a_thread(self, qtbot):
+        worker = DocumentStreamWorker("x:5568")
+        worker.stop()
+        worker.stop()
+        assert worker._stopped
+
+
+class TestScanMonitorController:
+    def test_stub_client_disables_the_streams(self, qtbot):
+        controller = ScanMonitorController(StubQueueClient())
+        assert controller.documents is None
+        assert controller.console is None
+        controller.dispose()
+
+    def test_poller_delivers_the_stub_status(self, qtbot):
+        controller = ScanMonitorController(StubQueueClient())
+        reports: list = []
+        controller.status_ready.connect(reports.append)
+        controller._poller.poll_async()
+        qtbot.waitUntil(lambda: bool(reports), timeout=2000)
+        assert not reports[0].connected
+        controller.dispose()
+
+    def test_start_and_dispose_are_idempotent(self, qtbot):
+        from PySide6.QtWidgets import QWidget
+
+        parent = QWidget()
+        qtbot.addWidget(parent)
+        controller = ScanMonitorController(
+            StubQueueClient(), info_addr=None, doc_addr=None
+        )
+        controller.start(parent)
+        controller.start(parent)  # second start is a no-op
+        controller.dispose()
+        controller.dispose()
+        # After dispose, start must not resurrect the timer.
+        controller.start(parent)
+        assert controller._timer is None

--- a/GEECS-Console/tests/test_submit_preflight.py
+++ b/GEECS-Console/tests/test_submit_preflight.py
@@ -79,9 +79,19 @@ def _make_provider(served):
 def _make_pv_reader(reads):
     state = {"ts_calls": 0}
 
-    def _read(pv, timeout):
+    def _read(pv, timeout, datatype=None):
         if pv.endswith(":connected"):
-            return reads["CONNECTED"]
+            # Enum-faithful fake (#653 review finding 1): the gateway's
+            # CONNECTED is a DBR_ENUM, so a native read returns the integer
+            # index — only datatype=str yields the choice string the check
+            # compares against.  A regression back to a native read gets
+            # the index and can never see "Disconnected".
+            value = reads["CONNECTED"]
+            if value is None:
+                return None
+            if datatype is str:
+                return value
+            return {"Disconnected": 0, "Connected": 1}[value]
         if pv.endswith(":acq_timestamp"):
             values = reads["acq_timestamp"]
             value = values[min(state["ts_calls"], len(values) - 1)]

--- a/GEECS-Console/tests/test_submit_preflight.py
+++ b/GEECS-Console/tests/test_submit_preflight.py
@@ -1,0 +1,209 @@
+"""Hermetic tests for the client-side pre-submit preflight (#648 decision 3).
+
+The engine seams (`validate_scan_request`, the resolver, the served-set
+provider) are monkeypatched at their `geecs_bluesky` homes — the lazy
+imports inside `submit_preflight` resolve at call time, so patching the
+source modules is enough.  CA reads are patched at `_read_pv`.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from geecs_console.services import submit_preflight
+from geecs_console.services.submit_preflight import (
+    PreflightReport,
+    run_submit_preflight,
+    stamp_submission,
+)
+from geecs_schemas import ScanRequest
+
+
+def _request(**overrides) -> ScanRequest:
+    base = dict(
+        mode="noscan",
+        shots_per_step=2,
+        acquisition="free_run",
+        save_sets=["UC_Test"],
+    )
+    base.update(overrides)
+    return ScanRequest.model_validate(base)
+
+
+_DEVICES_CONFIG = {
+    "UC_Cam1": {"variable_list": ["MeanCounts"], "synchronous": True},
+    "UC_Cam2": {"variable_list": ["Exposure"], "synchronous": False},
+}
+
+
+@pytest.fixture
+def engine(monkeypatch):
+    """Patch the engine seams: validation passes, devices resolve canned."""
+
+    class _Resolver:
+        def __init__(self, experiment):
+            self.experiment = experiment
+
+    monkeypatch.setattr("geecs_bluesky.config_resolver.ConfigsRepoResolver", _Resolver)
+    monkeypatch.setattr(
+        "geecs_bluesky.scan_request_runner.validate_scan_request",
+        lambda request, resolver: (request, {}),
+    )
+    monkeypatch.setattr(
+        submit_preflight,
+        "_resolve_devices_config",
+        lambda request, resolver: dict(_DEVICES_CONFIG),
+    )
+    # Default: everything served, everything connected, trigger alive.
+    monkeypatch.setattr(
+        "geecs_bluesky.db_runtime.GeecsDbServedSetProvider",
+        _make_provider({"UC_Cam1": {"MeanCounts"}, "UC_Cam2": {"Exposure"}}),
+    )
+    reads = {"CONNECTED": "Connected", "acq_timestamp": [100.0, 101.5]}
+    monkeypatch.setattr(submit_preflight, "_read_pv", _make_pv_reader(reads))
+    monkeypatch.setattr(submit_preflight, "_STALENESS_WINDOW_S", 0.0)
+    return reads
+
+
+def _make_provider(served):
+    class _Provider:
+        def __init__(self, experiment):
+            self.experiment = experiment
+
+        def served_by_device(self):
+            return served
+
+    return _Provider
+
+
+def _make_pv_reader(reads):
+    state = {"ts_calls": 0}
+
+    def _read(pv, timeout):
+        if pv.endswith(":connected"):
+            return reads["CONNECTED"]
+        if pv.endswith(":acq_timestamp"):
+            values = reads["acq_timestamp"]
+            value = values[min(state["ts_calls"], len(values) - 1)]
+            state["ts_calls"] += 1
+            return value
+        return None
+
+    return _read
+
+
+class TestRunSubmitPreflight:
+    def test_all_green_records_three_passes(self, engine):
+        report = run_submit_preflight(_request(), "Undulator")
+        assert report.refusal is None
+        assert report.questions == []
+        assert ("validate", "passed", "") in report.outcomes
+        assert ("gateway_liveness", "passed", "") in report.outcomes
+        assert ("free_run_staleness", "passed", "") in report.outcomes
+        assert ("unserved_variables", "passed", "") in report.outcomes
+
+    def test_validation_failure_is_a_refusal(self, engine, monkeypatch):
+        def _boom(request, resolver):
+            raise ValueError("save set 'Nope' is unknown")
+
+        monkeypatch.setattr(
+            "geecs_bluesky.scan_request_runner.validate_scan_request", _boom
+        )
+        report = run_submit_preflight(_request(), "Undulator")
+        assert report.refusal is not None
+        assert "Nope" in report.refusal
+        # A refusal short-circuits — no other checks ran.
+        assert report.questions == []
+
+    def test_unserved_variable_raises_a_question(self, engine, monkeypatch):
+        monkeypatch.setattr(
+            "geecs_bluesky.db_runtime.GeecsDbServedSetProvider",
+            _make_provider({"UC_Cam1": {"MeanCounts"}, "UC_Cam2": set()}),
+        )
+        report = run_submit_preflight(_request(), "Undulator")
+        questions = [q for q in report.questions if q.check == "unserved_variables"]
+        assert len(questions) == 1
+        assert "Exposure" in questions[0].message
+
+    def test_unknown_served_set_is_skipped_not_blocking(self, engine, monkeypatch):
+        monkeypatch.setattr(
+            "geecs_bluesky.db_runtime.GeecsDbServedSetProvider",
+            _make_provider(None),
+        )
+        report = run_submit_preflight(_request(), "Undulator")
+        assert report.refusal is None
+        assert not [q for q in report.questions if q.check == "unserved_variables"]
+        assert any(
+            check == "unserved_variables" and result == "skipped"
+            for check, result, _ in report.outcomes
+        )
+
+    def test_disconnected_device_raises_a_question(self, engine):
+        engine["CONNECTED"] = "Disconnected"
+        report = run_submit_preflight(_request(), "Undulator")
+        questions = [q for q in report.questions if q.check == "gateway_liveness"]
+        assert len(questions) == 1
+        assert "UC_Cam1" in questions[0].message
+
+    def test_unreadable_liveness_is_fail_open(self, engine):
+        engine["CONNECTED"] = None  # CA read failed — not a verdict
+        report = run_submit_preflight(_request(), "Undulator")
+        assert not [q for q in report.questions if q.check == "gateway_liveness"]
+
+    def test_stale_trigger_raises_a_question(self, engine):
+        engine["acq_timestamp"] = [100.0, 100.0]  # not advancing
+        report = run_submit_preflight(_request(), "Undulator")
+        questions = [q for q in report.questions if q.check == "free_run_staleness"]
+        assert len(questions) == 1
+        assert "UC_Cam1" in questions[0].message
+
+    def test_strict_request_skips_staleness(self, engine):
+        report = run_submit_preflight(_request(acquisition="strict"), "Undulator")
+        assert not any(check == "free_run_staleness" for check, _, _ in report.outcomes)
+        assert not [q for q in report.questions if q.check == "free_run_staleness"]
+
+    def test_saveset_less_request_skips_device_checks(self, engine, monkeypatch):
+        monkeypatch.setattr(
+            submit_preflight,
+            "_resolve_devices_config",
+            lambda request, resolver: {},
+        )
+        report = run_submit_preflight(_request(), "Undulator")
+        assert report.refusal is None
+        assert report.outcomes == [("validate", "passed", "")]
+
+
+class TestStampSubmission:
+    def test_stamps_an_aware_timestamp_and_outcomes(self):
+        request = _request()
+        stamped = stamp_submission(
+            request,
+            [("validate", "passed", ""), ("gateway_liveness", "continued", "x down")],
+            client="geecs-console 0.21.0",
+        )
+        record = stamped.submission
+        assert record.client == "geecs-console 0.21.0"
+        # The schema's documented contract: ISO 8601 WITH timezone — a naive
+        # datetime.now().isoformat() has no offset and must never appear.
+        from datetime import datetime
+
+        assert datetime.fromisoformat(record.submitted_at).tzinfo is not None
+        assert [o.check for o in record.preflight] == [
+            "validate",
+            "gateway_liveness",
+        ]
+        assert record.preflight[1].result.value == "continued"
+        # The original request is untouched (model_copy semantics).
+        assert request.submission is None
+
+    def test_stamped_request_survives_the_queue_dump(self):
+        stamped = stamp_submission(_request(), [], client="c")
+        again = ScanRequest.model_validate(stamped.model_dump(mode="json"))
+        assert again.submission.client == "c"
+
+
+class TestReportShape:
+    def test_default_report_is_empty(self):
+        report = PreflightReport()
+        assert report.refusal is None
+        assert report.outcomes == [] and report.questions == []


### PR DESCRIPTION
## What

The console half of W6, part 1 of 2: the **services layer** for the queueserver client — built, tested, and deliberately **not yet wired into the window** (part 2 is the window switch: submission path, paused rendering, progress/beeps, bridge import removal). Splitting keeps each review tractable.

Three new modules, each following the console's standing seam conventions (protocol + real + stub, lazy imports import-safe offline, never-raises pollers, #534 controller checklist):

1. **`services/queue_client.py`** (~450 LOC with docstrings): the one module that speaks `bluesky-queueserver-api`. `ZmqQueueClient` — submission with the **failed-item-at-front guard** (#648 item 3: pending queue items are surfaced, cleared only on explicit `clear_pending=True`), deferred pause/resume, graceful **stop sequencing** (from paused → `re_stop` directly, the live-verified Scan003 path; from running → `queue_stop` + deferred pause + bounded wait + `re_stop`), `function_execute` manual verbs with task polling, never-raises `status()`. Config: new `[qserver]` section (`host` + optional `control_addr`/`info_addr`/`doc_addr`) in the shared config file, path via the blessed `ops_paths.USER_CONFIG_PATH` literal.
2. **`services/submit_preflight.py`** (~330 LOC): decision-3 client-side pre-submit — the engine's own `validate_scan_request` as the hard gate, the engine's `UnservedVariablesCheck` **reused not reimplemented** (no drift; DB-unknown reads as skipped, never blocking), `CONNECTED` liveness reads (fail-open — only the exact `"Disconnected"` reading counts), free-run staleness sample on the reference device. `stamp_submission` writes the geecs-schemas 0.10.0 `SubmissionRecord` with an **aware** timestamp (the #650 review's naive-timestamp bug, pinned by test). Pure check layer — dialogs stay in the window (part 2).
3. **`app/scan_monitor.py`** (~280 LOC): `ScanMonitorController` — manager status polling on the `HealthPoller` pattern, the document stream (`RemoteDispatcher` on a daemon thread, worker-owned signals), and the manager console-output stream with **failed-move reason extraction** (prefix pinned against the engine's `FAILED_MOVE_LOG_PREFIX` — the paused pill's "why" in part 2).

Dependency: `bluesky-queueserver-api ^0.0.13` (pulls pyzmq). Rider (#648 item 6): reciprocal keep-in-sync cross-reference on `services/optimization.py` (its worker twin already pointed here).

**W5 heads-up:** the preflight module is a live consumer of `geecs_bluesky.preflight` (`UnservedVariablesCheck`, `PreflightContext`, `Ask`/`Passed`) — W5's deletion pass must keep that module importable (`Ask.question`'s `OperatorQuestion` type will need a new home when `operator_channel.py` dies).

Judgment calls, cheap to veto: the `[qserver]` config section shape (host + derived standard ports); the 2 s staleness sample window (a submit click on free-run costs at most that); worker-side `describe_action` (idle-only) as the actions-preview source in part 2.

## Tests

`./scripts/check.sh`: lint OK; **GEECS-Console 836 passed** (39 new across `test_queue_client.py` / `test_submit_preflight.py` / `test_scan_monitor.py` — config reader, pending-guard, stop sequencing, task polling incl. failure/timeout, every preflight check's pass/question/skip paths, aware-timestamp pin, stream parsing, controller lifecycle); GEECS-Schemas + GeecsBluesky 697 passed, 3 deselected.

## Hardware verification

Nothing here executes against hardware yet (unwired services). The live check rides part 2's OWED list (submission end-to-end against the interim worker). Note the #650 deployment sequencing still applies: interim worker must be at ≥0.56.0 (pull + manager restart) before this client's stamped submissions run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)