### PR TITLE
GEECS-Console 0.23.1: refresh gating on every status snapshot (live-session finding)

### DIFF
--- a/GEECS-Console/CHANGELOG.md
+++ b/GEECS-Console/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to GEECS-Console are documented here.  Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versioning is
 semantic.
 
+## [0.23.1] - 2026-08-21
+
+### Fixed
+
+- Live-session finding (Scan008, 2026-08-21): Start/Stop gating froze on
+  the pre-scan snapshot for the whole scan when the document stream
+  narrated RUNNING before the first running status poll — the
+  equal-state poll skipped the refresh, leaving Stop disabled and Start
+  enabled mid-scan. `_on_queue_status` now refreshes gating on every
+  snapshot, transition or not (pinned by
+  `test_equal_state_poll_still_refreshes_gating`).
+
 ## [0.23.0] - 2026-08-21
 
 ### Removed

--- a/GEECS-Console/geecs_console/app/main_window.py
+++ b/GEECS-Console/geecs_console/app/main_window.py
@@ -838,6 +838,18 @@ class MainWindow(QMainWindow):
         document (#654 review finding 3).
         """
         self._queue_status = status
+        self._apply_status_state(status)
+        # Gating refresh on EVERY snapshot, transition or not: _scanning()
+        # reads the stored snapshot, so a poll that merely agrees with a
+        # pill the document stream already set still changes what
+        # Start/Stop must allow (2026-08-21 live finding: the start doc
+        # narrated RUNNING before the first running poll, the equal-state
+        # poll then skipped the refresh, and Stop stayed disabled — with
+        # Start enabled — for the whole scan).
+        self._refresh_submit_enabled()
+
+    def _apply_status_state(self, status: QueueStatus) -> None:
+        """Apply one snapshot's pill/state transitions (see `_on_queue_status`)."""
         pill = self._scan_state_text
         active_pill = pill not in ("idle", "done", "aborted", "unknown")
         if not status.connected or status.re_state is None:
@@ -853,10 +865,6 @@ class MainWindow(QMainWindow):
         if re_state == "idle":
             if active_pill or pill == "unknown":
                 self._on_scan_state("idle")
-            else:
-                # No state change — but Start/Stop gating may still depend
-                # on the fresh snapshot (e.g. connectivity returning).
-                self._refresh_submit_enabled()
             return
         # A live RE state (running/paused/pausing/stopping/…): assert it,
         # unless a terminal document just rendered — a pre-stop snapshot

--- a/GEECS-Console/pyproject.toml
+++ b/GEECS-Console/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-console"
-version = "0.23.0"
+version = "0.23.1"
 description = "Greenfield PySide6 operator console for GEECS (Bluesky/gateway architecture)"
 authors = ["Sam Barber <sbarber@lbl.gov>"]
 readme = "README.md"

--- a/GEECS-Console/tests/test_main_window.py
+++ b/GEECS-Console/tests/test_main_window.py
@@ -930,6 +930,22 @@ class TestSubmission:
         assert not window.pause_button.isEnabled()
         assert "Pause" in window.pause_button.text()
 
+    def test_equal_state_poll_still_refreshes_gating(self, window):
+        """2026-08-21 live finding (Scan008): the start document narrates
+        RUNNING before the first running poll; the equal-state poll must
+        still refresh gating, or Stop stays disabled (and Start enabled)
+        for the whole scan."""
+        select_save_set(window, "Amp4In")
+        window.variable_combo.setCurrentText("jet_x")
+        # Doc stream narrates first — the pill flips, but the stored
+        # snapshot still says idle (the bug's setup).
+        window._on_scan_document("start", {"scan_number": 8})
+        assert "RUNNING" in window.state_pill.text()
+        # The poll catches up, agreeing with the pill.
+        drive_status(window, "running")
+        assert window.stop_button.isEnabled()
+        assert not window.start_button.isEnabled()
+
     def test_disconnected_manager_reads_unknown(self, window):
         drive_status(window, None, connected=False)
         assert "UNKNOWN" in window.state_pill.text()


### PR DESCRIPTION
## What

Live-session finding (2026-08-21, Scan008): with a scan running, **Stop was disabled and Start still enabled**. Root cause: the document stream narrates RUNNING (start doc) before the first running status poll; when that poll arrives agreeing with the pill, `_on_queue_status` took the no-transition path and never called `_refresh_submit_enabled` — but `_scanning()` reads the *stored snapshot*, which the same handler had just updated. Gating stayed frozen on the pre-scan snapshot until some transition (a pause, or a failed double-submit's cleanup — both observed live) forced a refresh.

Fix: `_on_queue_status` stores the snapshot, applies state transitions (extracted to `_apply_status_state`, logic unchanged), then **always** refreshes gating. Refresh is idempotent widget-enable computation — no cost concern at 1 Hz.

Pinned by `test_equal_state_poll_still_refreshes_gating`, which reproduces the exact live sequence (start doc first → equal-state poll → Stop must be enabled, Start disabled).

Bonus live evidence from the same minutes (no code change needed): the double-submit-while-busy path fired exactly as #653's finding-2 fix intended — `queue_start` refused ("RE Manager is busy"), the item removed itself, honest message shown; and the sequenced stop-from-running ran end to end ("stop requested (paused, then stopped)", graceful, partial data).

## Tests

`./scripts/check.sh`: lint OK; GEECS-Console **131 window tests / 817 total passed**; GeecsBluesky 559; GEECS-Schemas 255.

## Hardware verification

This PR exists *because of* the live session; re-verification is the next ladder step (Stop enabled immediately once a scan runs, no workaround).

🤖 Generated with [Claude Code](https://claude.com/claude-code)