### PR TITLE
GEECS-Console 0.23.2: optimize progress totals from max_iterations (live-session finding)

### DIFF
--- a/GEECS-Console/CHANGELOG.md
+++ b/GEECS-Console/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to GEECS-Console are documented here.  Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versioning is
 semantic.
 
+## [0.23.2] - 2026-08-21
+
+### Fixed
+
+- Live-session finding (Scan013, 2026-08-21): the optimize progress bar
+  hit 100% at iteration 3 of 5 — `geecs_adaptive_scan` records
+  `max_iterations`, not `num_points`, so the console skipped the totals
+  update and inherited the previous scan's bar. Start-document totals
+  now fall back to `max_iterations × shots_per_step` (an upper bound —
+  early suggester stops finish under 100%, honestly), and a start doc
+  with no computable totals resets the bar instead of inheriting stale
+  totals. Pinned by two tests.
+
 ## [0.23.1] - 2026-08-21
 
 ### Fixed

--- a/GEECS-Console/geecs_console/app/main_window.py
+++ b/GEECS-Console/geecs_console/app/main_window.py
@@ -895,8 +895,19 @@ class MainWindow(QMainWindow):
                 self.append_log("scan running")
             num_points = doc.get("num_points")
             shots_per_step = doc.get("shots_per_step")
+            if not num_points:
+                # Adaptive plans (geecs_adaptive_scan) record their
+                # iteration bound instead of num_points; the suggester may
+                # stop early, so the bar may finish under 100% — honestly.
+                num_points = doc.get("max_iterations")
             if num_points and shots_per_step:
                 self._on_totals_known(int(num_points) * int(shots_per_step))
+            else:
+                # Unknown totals: reset the bar — never inherit the
+                # previous scan's (2026-08-21 live finding, Scan013: a
+                # 25-shot optimization filled a stale 15-shot bar at
+                # iteration 3).
+                self._on_totals_known(0)
             self._on_scan_state("running")
         elif name == "descriptor":
             self._descriptor_names[doc.get("uid")] = doc.get("name")

--- a/GEECS-Console/pyproject.toml
+++ b/GEECS-Console/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-console"
-version = "0.23.1"
+version = "0.23.2"
 description = "Greenfield PySide6 operator console for GEECS (Bluesky/gateway architecture)"
 authors = ["Sam Barber <sbarber@lbl.gov>"]
 readme = "README.md"

--- a/GEECS-Console/tests/test_main_window.py
+++ b/GEECS-Console/tests/test_main_window.py
@@ -1079,6 +1079,28 @@ class TestNowAndDevicePanel:
         window._on_scan_document("event", {"descriptor": "b1", "seq_num": 3})
         assert window.progress_bar.value() == 0
 
+    def test_optimize_start_doc_totals_come_from_max_iterations(self, window):
+        """Adaptive plans record max_iterations, not num_points — the bar
+        must size from the iteration bound (2026-08-21 live finding)."""
+        window._on_scan_document(
+            "start", {"scan_number": 13, "max_iterations": 5, "shots_per_step": 5}
+        )
+        assert window.progress_bar.maximum() == 25
+
+    def test_totals_less_start_doc_resets_a_stale_bar(self, window):
+        """A start doc with no computable totals must reset the bar, never
+        inherit the previous scan's (Scan013: 25 shots filled a stale
+        15-shot bar at iteration 3)."""
+        window._on_scan_document(
+            "start", {"scan_number": 7, "num_points": 3, "shots_per_step": 5}
+        )
+        assert window.progress_bar.maximum() == 15
+        window._on_scan_document("start", {"scan_number": 13})
+        assert window.progress_bar.maximum() == 1  # reset (empty), not 15
+        window._descriptor_names["d1"] = "primary"
+        window._on_scan_document("event", {"descriptor": "d1", "seq_num": 20})
+        assert window.progress_bar.value() == 0  # unknown totals: bar stays honest
+
     def test_stop_document_ends_the_run(self, window):
         window._on_scan_document("start", {"scan_number": 8})
         window._on_scan_document("stop", {"exit_status": "success"})


### PR DESCRIPTION
## What

Live finding (Scan013): the optimize progress bar hit 100% at iteration 3 of 5. Stream-verified root cause: `geecs_adaptive_scan`'s start doc records `max_iterations` (5) and `shots_per_step` (5) but **no `num_points`** — the console skipped its totals update and the bar kept the previous 1D scan's 15-shot total; a 25-shot optimization filled it at exactly shot 15 = iteration 3.

Fix (console-only — the iteration bound is already in the start doc): totals fall back to `max_iterations × shots_per_step` (an upper bound, same contract as the old bridge's `on_scan_start` — an early suggester stop finishes under 100%, honestly), and a start doc with *no* computable totals **resets** the bar instead of inheriting stale totals. Two pin tests (the max_iterations sizing, and the stale-bar reset incl. an event leaving an unknown-totals bar untouched).

## Tests

`./scripts/check.sh`: lint OK; GEECS-Console **132 window / 819 total passed**; GeecsBluesky 559; GEECS-Schemas 255.

## Hardware verification

Found live, re-verify live: rerun the 5-iteration optimize after pulling — the bar should size to 25 and track all 5 iterations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)