### PR TITLE
GeecsBluesky 0.58.0 + GEECS-Console 0.24.0: extract the RE Manager client into geecs_bluesky.qs_client

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -114,3 +114,11 @@ jobs:
         env:
           QT_QPA_PLATFORM: offscreen
         run: poetry run pytest -q --tb=short
+
+      - name: Run qs_client tests on Windows
+        # The RE Manager client (geecs_bluesky.qs_client) moved out of the
+        # console but the console still runs it on Windows control-room
+        # machines — keep its Windows leg (tilde-expanding config reader
+        # included).  geecs-bluesky is installed in this env as a path dep
+        # with the qs-client extra, so the suite collects here directly.
+        run: poetry run pytest ../GeecsBluesky/tests/qs_client -q --tb=short -p no:cacheprovider

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -60,7 +60,9 @@ jobs:
         # --extras qserver: the queueserver manager-validation pin test
         # (test_qserver_startup.py) importorskips bluesky_queueserver and
         # would silently skip without it (review finding, 2026-08-21).
-        run: poetry install --with dev --extras qserver
+        # --extras qs-client: tests/qs_client/test_queue_client.py
+        # importorskips bluesky_queueserver_api the same way.
+        run: poetry install --with dev --extras qserver --extras qs-client
 
       - name: Run GeecsBluesky pure unit tests
         working-directory: GeecsBluesky

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -142,15 +142,19 @@ GeecsBluesky         →  GEECS-Data-Utils, GEECS-Core, GEECS-Schemas
                         post-run image analysis over archived Tiled runs;
                         + ScanAnalysis/ImageAnalysis/xopt, optional via the
                         `optimize` extra — the relocated Xopt/evaluator
-                        stack in geecs_bluesky.optimization)
+                        stack in geecs_bluesky.optimization;
+                        + bluesky-queueserver-api, optional via the
+                        `qs-client` extra — geecs_bluesky.qs_client, the
+                        RE Manager client every queue client uses)
 ScanAnalysis         →  GEECS-Data-Utils, ImageAnalysis, LogMaker4GoogleDocs
 GEECS-Console        →  GeecsBluesky, GEECS-Schemas, GEECS-Data-Utils,
                         GEECS-Core (GeecsDb for completions/health)
                         (scan execution is remote: the console submits to
-                        GeecsBluesky's queueserver worker via
-                        bluesky-queueserver-api; the optimization stack's
-                        heavy deps install worker-side via GeecsBluesky's
-                        `optimize` extra — the console ships none)
+                        GeecsBluesky's queueserver worker through
+                        geecs_bluesky.qs_client — the `qs-client` extra;
+                        the optimization stack's heavy deps install
+                        worker-side via GeecsBluesky's `optimize` extra —
+                        the console ships none)
 ```
 
 `GEECS-Core` is the GEECS access library: the UDP/TCP wire protocol, the

--- a/GEECS-Console/CHANGELOG.md
+++ b/GEECS-Console/CHANGELOG.md
@@ -4,6 +4,27 @@ All notable changes to GEECS-Console are documented here.  Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versioning is
 semantic.
 
+## [0.24.0] - 2026-08-21
+
+### Changed
+
+- **The RE Manager client moved to `geecs_bluesky.qs_client`** (the
+  console is one queue client among several — notebooks and the OSPREY
+  scan MCP use the same seam): `services/queue_client.py` and
+  `services/submit_preflight.py` are deleted, and `submission.py` is now
+  the console's thin identity layer — `Submitter` is an alias of the one
+  `geecs_bluesky.qs_client.QueueClient` protocol (the former twin
+  protocols are collapsed; the `QueueSubmitter` adapter is gone, its
+  `run_action` mapping and stream addresses live on the client itself),
+  and `make_queue_submitter` builds the shared client with the
+  `geecs-console` submitted-as identity.  The window's submit call is
+  `submit_scan` (was `submit`).  `bluesky-queueserver-api` now arrives
+  via geecs-bluesky's `qs-client` extra instead of a direct dependency.
+- The health probe's gateway check reads through the shared
+  `geecs_bluesky.devices.ca.oneshot` helper (one persistent reader
+  loop) — the previous per-poll `asyncio.run()` re-created the CA
+  channels and leaked aioca's per-loop cache on every 5 s poll.
+
 ## [0.23.3] - 2026-08-21
 
 ### Changed

--- a/GEECS-Console/CLAUDE.md
+++ b/GEECS-Console/CLAUDE.md
@@ -105,8 +105,10 @@ are prefixed by region (`r3_radio_1d`, `r5_start_button`, …).
   `request_builder.build_scan_request` is the only place form state becomes
   a request; keep it a pure function, keep widgets out of it.
 - **The window depends on seams, not implementations**: `Submitter`
-  (the queueserver-client protocol since #648 — `QueueSubmitter` over
-  the RE Manager: queue submission with the failed-item guard, sequenced
+  (the console's name for `geecs_bluesky.qs_client.QueueClient` — the
+  ONE queueserver-client protocol since the extraction, aliased in
+  `submission.py` whose `make_queue_submitter` stamps the console's
+  identity: queue submission with the failed-item guard, sequenced
   stop, pause/resume, worker-side actions and `move_variable`, and a
   never-raises `status()` the monitor polls), `ConsoleConfigs`,
   `HealthProbe`, `PresetStore`, `ConsoleSettings`.  All
@@ -114,14 +116,15 @@ are prefixed by region (`r3_radio_1d`, `r5_start_button`, …).
   disposes the window's `ScanMonitorController` so state slots are
   driven directly, never raced by the background poll).
 - **Offline-first**: the window must open and run with zero network and
-  zero configs.  `geecs_bluesky` is imported lazily (function-level) in
-  `services/submit_preflight.py` and `services/configs.py` — it pulls
-  `aioca` at package import, so a module-level import would couple
-  opening the window to the `ca` extra; `bluesky-queueserver-api`
-  imports live inside `services/queue_client.py` methods the same way.
-  Without a `[qserver]` config section the stub client refuses
-  submission with a message naming the missing section — everything
-  else works.
+  zero configs.  The `geecs_bluesky` *package* import is light since the
+  qs_client extraction (its device re-exports are PEP 562-lazy), so
+  importing `geecs_bluesky.qs_client` at module level is fine — but the
+  heavy submodules (`devices/*`, the engine internals) still load
+  aioca/ophyd, so `services/configs.py` and the CA helpers keep their
+  function-level imports, and `bluesky-queueserver-api` stays inside
+  qs_client method bodies.  Without a `[qserver]` config section the
+  stub client refuses submission with a message naming the missing
+  section — everything else works.
 - PySide6 only (LGPL, agent-editable `.ui` XML).  Never PyQt.
 - The `.ui` is hand-authored XML loaded at runtime via `QUiLoader` — no
   generated `*_ui.py` files to keep in sync.
@@ -149,7 +152,8 @@ are prefixed by region (`r3_radio_1d`, `r5_start_button`, …).
 - **Pre-submit preflight dialogs** (queueserver decision 3 — the old
   mid-run `ScanDialogEvent`/`DialogRequest` transport is gone with the
   bridge): the checks run *before* queueing on the submit worker
-  (`services/submit_preflight.py` — the engine's own
+  (`geecs_bluesky.qs_client.submit_preflight`, shared with every other
+  queue client since the extraction — the engine's own
   `validate_scan_request` and `UnservedVariablesCheck` reused, plus
   client-side CONNECTED liveness (fail-open; the read passes
   `datatype=str` because CONNECTED is a DBR_ENUM — a native read returns

--- a/GEECS-Console/geecs_console/app/main_window.py
+++ b/GEECS-Console/geecs_console/app/main_window.py
@@ -81,9 +81,10 @@ from geecs_console.services.health import (
     HealthStatus,
     StubHealth,
 )
-from geecs_console.services.queue_client import QueueStatus, SubmitResult
-from geecs_console.services.submit_preflight import (
+from geecs_bluesky.qs_client import (
     PreflightReport,
+    QueueStatus,
+    SubmitResult,
     run_submit_preflight,
     stamp_submission,
 )
@@ -777,9 +778,9 @@ class MainWindow(QMainWindow):
     def _start_scan_monitor(self) -> None:
         """Start the queueserver scan monitor (status poll + streams).
 
-        Built from the submitter: its ``status()`` is the poll probe, and a
-        real :class:`~geecs_console.submission.QueueSubmitter` carries the
-        stream addresses (fakes without them get a poll-only monitor).  A
+        Built from the submitter: its ``status()`` is the poll probe, and
+        the real :class:`~geecs_bluesky.qs_client.ZmqQueueClient` carries
+        the stream addresses (fakes without them get a poll-only monitor).  A
         submitter that cannot be built leaves the monitor off — the pill
         stays wherever the last state put it and submission reports the
         reason on Start.
@@ -1653,7 +1654,7 @@ class MainWindow(QMainWindow):
             try:
                 return (
                     "submit",
-                    submitter.submit(
+                    submitter.submit_scan(
                         stamped.model_dump(mode="json"), clear_pending=clear_pending
                     ),
                 )

--- a/GEECS-Console/geecs_console/app/scan_monitor.py
+++ b/GEECS-Console/geecs_console/app/scan_monitor.py
@@ -214,7 +214,7 @@ class ScanMonitorController(QObject):
     Parameters
     ----------
     queue_client :
-        The :class:`~geecs_console.services.queue_client.QueueClient` whose
+        The :class:`~geecs_bluesky.qs_client.QueueClient` whose
         ``status()`` the poller runs.
     info_addr, doc_addr :
         Stream addresses (``None`` disables that stream — the stub/offline

--- a/GEECS-Console/geecs_console/services/health.py
+++ b/GEECS-Console/geecs_console/services/health.py
@@ -144,30 +144,21 @@ class GatewayTiledDbHealth:
         if not experiment:
             return HealthStatus.UNKNOWN
         try:
-            import asyncio
-
-            import aioca
+            # One-shot reads ride the shared persistent reader loop — a
+            # per-poll asyncio.run() would re-create the CA channels and
+            # leak aioca's per-loop cache on every 5 s poll, forever.
             from geecs_bluesky.devices.ca._pv import ca_pv
             from geecs_bluesky.devices.ca.gateway_put import bare_pv
+            from geecs_bluesky.devices.ca.oneshot import caget_once, try_caget_once
 
             heartbeat_pv = bare_pv(ca_pv(experiment, "CAGateway", "HEARTBEAT"))
             connected_pv = bare_pv(ca_pv(experiment, "CAGateway", "DEVICES_CONNECTED"))
 
-            async def _read() -> tuple[object, object]:
-                heartbeat = await asyncio.wait_for(
-                    aioca.caget(heartbeat_pv), timeout=_CHECK_TIMEOUT_S
-                )
-                try:
-                    connected = await asyncio.wait_for(
-                        aioca.caget(connected_pv), timeout=_CHECK_TIMEOUT_S
-                    )
-                except Exception:
-                    # Heartbeat is the primary liveness signal; a missing
-                    # DEVICES_CONNECTED PV must not flip a live gateway to DOWN.
-                    connected = None
-                return heartbeat, connected
-
-            _heartbeat, connected = asyncio.run(_read())
+            # Heartbeat is the primary liveness signal (raises → DOWN); a
+            # missing DEVICES_CONNECTED PV must not flip a live gateway to
+            # DOWN, so that read is fail-open.
+            caget_once(heartbeat_pv, timeout=_CHECK_TIMEOUT_S)
+            connected = try_caget_once(connected_pv, timeout=_CHECK_TIMEOUT_S)
             if connected is not None and int(connected) == 0:
                 return HealthStatus.WARN
             return HealthStatus.OK

--- a/GEECS-Console/geecs_console/submission.py
+++ b/GEECS-Console/geecs_console/submission.py
@@ -1,174 +1,40 @@
-"""The submission seam: what the console needs from the scan service.
+"""The submission seam: the console's identity over the shared queue client.
 
-Since the queueserver migration (#648) the console is a **peer client of
-the RE Manager** — scans are queue items executed by the GEECS worker
-(``GeecsBluesky/qserver/``), not an in-process engine.  :class:`Submitter`
-is the protocol the window and controllers depend on;
-:class:`QueueSubmitter` implements it over the
-:class:`~geecs_console.services.queue_client.QueueClient`, and
-:func:`make_queue_submitter` is the default factory (offline it wraps the
-stub client, whose every verb refuses with the missing-``[qserver]``
-message).
+The RE Manager client machinery lives in :mod:`geecs_bluesky.qs_client`
+since the extraction (2026-08-21) — the console is one peer client of the
+queue among several (notebooks, the OSPREY scan MCP submit the same
+``ScanRequest`` dicts through the same verbs).  What stays here is the
+console's part:
 
-Scan *state* is deliberately not on this protocol: the window observes it
+- :data:`Submitter` — the console's historical name for the ONE client
+  protocol, :class:`geecs_bluesky.qs_client.QueueClient` (the extraction
+  collapsed the former twin protocols into it; window/controller type
+  hints and docstrings keep the name).
+- :func:`make_queue_submitter` — the default factory, building the shared
+  client with the **console's** submitted-as identity (offline it returns
+  the stub client, whose every verb refuses with the missing-``[qserver]``
+  message).
+
+Scan *state* is deliberately not on the protocol: the window observes it
 from the manager status poll and the document stream
 (:class:`~geecs_console.app.scan_monitor.ScanMonitorController`), never by
-asking the submitter.  The dropped pause-window action flow
-(``request_action_during_scan``, decision 2 of the migration) has no
-successor member — actions run as ordinary queue items when the manager is
-idle.
-
-Threading contract: every member here **blocks** (0MQ round trips; manual
-moves poll a worker task to completion), so the window and controllers
-dispatch them through their ``BackgroundResult`` workers — with two
-deliberate exceptions, :meth:`Submitter.request_pause` and
-:meth:`Submitter.request_resume`, which are single short-timeout requests
-the window calls directly (the old prompt-returning pause semantics).
+asking the submitter.  Threading contract: every member blocks (0MQ round
+trips; manual moves poll a worker task to completion), so the window and
+controllers dispatch them through their ``BackgroundResult`` workers —
+with two deliberate exceptions, ``request_pause`` and ``request_resume``,
+which are single short-timeout requests the window calls directly.
 """
 
 from __future__ import annotations
 
-from typing import Optional, Protocol, runtime_checkable
+from geecs_bluesky.qs_client import QueueClient, make_queue_client
 
-from geecs_console.services.queue_client import (
-    QueueClient,
-    QueueStatus,
-    SubmitResult,
-)
+#: The console's name for the one queue-client protocol.
+Submitter = QueueClient
 
 
-@runtime_checkable
-class Submitter(Protocol):
-    """The scan-service surface the console submits through."""
-
-    def submit(self, request: dict, *, clear_pending: bool = False) -> SubmitResult:
-        """Queue one ``ScanRequest`` dict and start the queue.
-
-        ``ok=False`` with ``pending_items`` means the queue already held
-        items (the failed-item-at-front trap) and nothing was submitted —
-        the window asks the operator, then retries with
-        ``clear_pending=True``.
-        """
-        ...
-
-    def stop_scan(self) -> tuple[bool, str]:
-        """Gracefully stop the current scan (partial data preserved).
-
-        From paused: stop directly.  From running: sequenced deferred
-        pause → stop, waiting out an in-flight blocking move — may take
-        tens of seconds, so the window dispatches it on the stop worker.
-        """
-        ...
-
-    def request_pause(self) -> tuple[bool, str]:
-        """Deferred-pause the running scan (returns promptly)."""
-        ...
-
-    def request_resume(self) -> tuple[bool, str]:
-        """Resume a paused scan — replays nothing (returns promptly)."""
-        ...
-
-    def run_action(self, name: str) -> None:
-        """Queue action plan *name* as its own item (idle manager only).
-
-        Raises ``RuntimeError`` with an operator-readable message when the
-        submission is refused (manager unreachable, queue busy).
-        Completion/failure of the action itself is observed through the
-        manager status, not this call.
-        """
-        ...
-
-    def describe_action(self, name: str) -> list[dict]:
-        """Dry-run action plan *name* against the worker's configs.
-
-        Blocking (a worker ``function_execute`` task; idle manager only).
-        Returns one dict per step in execution order, with keys ``kind``,
-        ``device``, ``variable``, ``value``, ``wait_s``, ``from_plan``.
-        Raises ``RuntimeError`` with an operator-readable message on
-        refusal or failure.
-        """
-        ...
-
-    def move_variable(self, name: str, value: float) -> dict:
-        """Move one catalog scan variable (or raw ``Device:Variable``) now.
-
-        Runs the worker's ``geecs_move_variable`` (scan-identical
-        completion semantics; idle manager only) and blocks until the move
-        lands — dispatch off the GUI thread.  Returns ``{"variable",
-        "kind", "value", "targets"}``; raises ``RuntimeError`` with the
-        worker's refusal/failure message (e.g. the engine's exact
-        ``"scan in progress — move not started"``).
-        """
-        ...
-
-    def status(self) -> QueueStatus:
-        """One manager status snapshot (never raises) — the poller's probe."""
-        ...
-
-
-class QueueSubmitter:
-    """The real :class:`Submitter`: a thin adapter over the queue client.
-
-    Also carries the stream addresses
-    (:attr:`info_addr` / :attr:`doc_addr`, ``None`` when unconfigured) so
-    the window can build its
-    :class:`~geecs_console.app.scan_monitor.ScanMonitorController` from the
-    same configuration in one place.
-    """
-
-    def __init__(
-        self,
-        client: QueueClient,
-        *,
-        info_addr: Optional[str] = None,
-        doc_addr: Optional[str] = None,
-    ) -> None:
-        self.client = client
-        self.info_addr = info_addr
-        self.doc_addr = doc_addr
-
-    def submit(self, request: dict, *, clear_pending: bool = False) -> SubmitResult:
-        """Queue the scan request (see :class:`Submitter`)."""
-        return self.client.submit_scan(request, clear_pending=clear_pending)
-
-    def stop_scan(self) -> tuple[bool, str]:
-        """Gracefully stop the current scan (see :class:`Submitter`)."""
-        return self.client.stop_scan()
-
-    def request_pause(self) -> tuple[bool, str]:
-        """Deferred-pause the running scan."""
-        return self.client.request_pause()
-
-    def request_resume(self) -> tuple[bool, str]:
-        """Resume a paused scan."""
-        return self.client.request_resume()
-
-    def run_action(self, name: str) -> None:
-        """Queue the action item; raise the refusal message on failure."""
-        result = self.client.submit_action(name)
-        if not result.ok:
-            if result.pending_items:
-                raise RuntimeError(
-                    f"queue not empty ({len(result.pending_items)} item(s) "
-                    "pending) — clear the queue before running an action"
-                )
-            raise RuntimeError(result.message or "action submission refused")
-
-    def describe_action(self, name: str) -> list[dict]:
-        """Worker-side dry run (see :class:`Submitter`)."""
-        return self.client.describe_action(name)
-
-    def move_variable(self, name: str, value: float) -> dict:
-        """Worker-side manual move (see :class:`Submitter`)."""
-        return self.client.move_variable(name, value)
-
-    def status(self) -> QueueStatus:
-        """One manager status snapshot (never raises)."""
-        return self.client.status()
-
-
-def make_queue_submitter(experiment: str = "") -> QueueSubmitter:
-    """Build the configured submitter (stub-backed when no ``[qserver]``).
+def make_queue_submitter(experiment: str = "") -> Submitter:
+    """Build the shared queue client with the console's identity.
 
     Parameters
     ----------
@@ -180,22 +46,9 @@ def make_queue_submitter(experiment: str = "") -> QueueSubmitter:
 
     Returns
     -------
-    QueueSubmitter
+    Submitter
         Ready to use; unconfigured installs get the stub client (every
         verb refuses with the missing-config message) and no stream
         addresses.
     """
-    from geecs_console.services.queue_client import (
-        StubQueueClient,
-        ZmqQueueClient,
-        read_qserver_config,
-    )
-
-    config = read_qserver_config()
-    if config is None:
-        return QueueSubmitter(StubQueueClient())
-    return QueueSubmitter(
-        ZmqQueueClient(config),
-        info_addr=config.info_addr,
-        doc_addr=config.doc_addr,
-    )
+    return make_queue_client(experiment, user="geecs-console")

--- a/GEECS-Console/poetry.lock
+++ b/GEECS-Console/poetry.lock
@@ -1027,7 +1027,7 @@ tqdm = ["tqdm"]
 
 [[package]]
 name = "geecs-bluesky"
-version = "0.57.0"
+version = "0.58.0"
 description = "Bluesky / ophyd-async bridge for the GEECS control system"
 optional = false
 python-versions = ">=3.11,<3.12"
@@ -1038,6 +1038,7 @@ develop = true
 [package.dependencies]
 aioca = {version = ">=1.7", optional = true}
 bluesky = ">=1.12"
+bluesky-queueserver-api = {version = "^0.0.13", optional = true}
 geecs-core = {path = "../GEECS-Core", develop = true}
 geecs_data_utils = {path = "../GEECS-Data-Utils", develop = true}
 geecs-schemas = {path = "../GEECS-Schemas", develop = true}
@@ -1048,6 +1049,7 @@ tiled = {version = ">=0.2", extras = ["client"], optional = true}
 analysis = ["imageanalysis @ file:///Users/samuelbarber/Desktop/Code/Github_repos/GEECS-Plugins/.claude/worktrees/angry-lederberg-436e6d/ImageAnalysis"]
 ca = ["aioca (>=1.7)"]
 optimize = ["gest-api (>=0.1)", "imageanalysis @ file:///Users/samuelbarber/Desktop/Code/Github_repos/GEECS-Plugins/.claude/worktrees/angry-lederberg-436e6d/ImageAnalysis", "scananalysis @ file:///Users/samuelbarber/Desktop/Code/Github_repos/GEECS-Plugins/.claude/worktrees/angry-lederberg-436e6d/ScanAnalysis", "xopt (>=3.1,<4.0)"]
+qs-client = ["bluesky-queueserver-api (>=0.0.13,<0.0.14)"]
 qserver = ["bluesky-queueserver (>=0.0.25,<0.0.26)"]
 tiled = ["tiled[client] (>=0.2)"]
 
@@ -1107,7 +1109,7 @@ url = "../GEECS-Data-Utils"
 
 [[package]]
 name = "geecs-schemas"
-version = "0.10.1"
+version = "0.10.2"
 description = "Versioned Pydantic schemas for GEECS scanner configs (scan requests, save sets, scan variables, trigger profiles, action plans) plus legacy-YAML converters."
 optional = false
 python-versions = ">=3.11,<3.12"
@@ -5094,4 +5096,4 @@ cffi = ["cffi (>=1.17,<2.0) ; platform_python_implementation != \"PyPy\" and pyt
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<3.12"
-content-hash = "9217f3908d68458c9cfe9b7552fe6a4cf6984d3885c987033d0616791be6fe7a"
+content-hash = "df0cf63601b07fbf81dfb1b7ba3801e409d6e91736ef193a438f0ebf23d7f7b7"

--- a/GEECS-Console/pyproject.toml
+++ b/GEECS-Console/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-console"
-version = "0.23.3"
+version = "0.24.0"
 description = "Greenfield PySide6 operator console for GEECS (Bluesky/gateway architecture)"
 authors = ["Sam Barber <sbarber@lbl.gov>"]
 readme = "README.md"
@@ -10,12 +10,12 @@ packages = [{ include = "geecs_console" }]
 python = ">=3.11,<3.12"
 pyside6 = ">=6.7"
 
-# The scan engine package: the preflight checks the console runs
-# pre-submit, configs-repo resolution, and the CA helpers behind the
-# device panel / health probes.  Scan execution itself is remote — the
-# queueserver worker (GeecsBluesky/qserver/) — reached via
-# bluesky-queueserver-api below.
-geecs-bluesky = { path = "../GeecsBluesky", develop = true, extras = ["tiled", "ca"] }
+# The scan engine package: the RE Manager client + pre-submit preflight
+# (geecs_bluesky.qs_client, via the qs-client extra — it pulls
+# bluesky-queueserver-api), configs-repo resolution, and the CA helpers
+# behind the device panel / health probes.  Scan execution itself is
+# remote — the queueserver worker (GeecsBluesky/qserver/).
+geecs-bluesky = { path = "../GeecsBluesky", develop = true, extras = ["tiled", "ca", "qs-client"] }
 
 # The config vocabulary: ScanRequest is the one submission object this GUI
 # builds.  Pydantic-only — the request builder imports nothing heavier.
@@ -34,12 +34,6 @@ geecs-data-utils = { path = "../GEECS-Data-Utils", develop = true, extras = ["ti
 # B4 plotting (scan browser): Qt-native, imported lazily with
 # PYQTGRAPH_QT_LIB=PySide6 pinned before the first import.
 pyqtgraph = "^0.13"
-
-# The RE Manager client (queueserver migration, #648): queue submission,
-# status polling, and the manager's console-output monitor all ride this
-# small api package (it pulls pyzmq; the document stream's
-# RemoteDispatcher comes from bluesky via geecs-bluesky).
-bluesky-queueserver-api = "^0.0.13"
 
 [tool.poetry.group.dev.dependencies]
 pytest = ">=7.0"

--- a/GEECS-Console/tests/test_actions_menu.py
+++ b/GEECS-Console/tests/test_actions_menu.py
@@ -94,7 +94,7 @@ class FakeActionSubmitter:
         self.run_release.set()
 
     def status(self):
-        from geecs_console.services.queue_client import QueueStatus
+        from geecs_bluesky.qs_client import QueueStatus
 
         return QueueStatus(connected=True, re_state="idle", worker_exists=True)
 

--- a/GEECS-Console/tests/test_main_window.py
+++ b/GEECS-Console/tests/test_main_window.py
@@ -73,7 +73,7 @@ class FakeSubmitter:
     """Queue-submitter stand-in (the #648 Submitter protocol shape)."""
 
     def __init__(self):
-        from geecs_console.services.queue_client import SubmitResult
+        from geecs_bluesky.qs_client import SubmitResult
 
         self.submitted = []  # (request_dict, clear_pending) per submit call
         self.stops = 0
@@ -82,7 +82,7 @@ class FakeSubmitter:
         self.submit_result = SubmitResult(ok=True, item_uid="uid-1")
         self.stop_result = (True, "stop requested (from paused)")
 
-    def submit(self, request, *, clear_pending=False):
+    def submit_scan(self, request, *, clear_pending=False):
         self.submitted.append((request, clear_pending))
         return self.submit_result
 
@@ -108,7 +108,7 @@ class FakeSubmitter:
         return {"variable": name, "value": value}
 
     def status(self):
-        from geecs_console.services.queue_client import QueueStatus
+        from geecs_bluesky.qs_client import QueueStatus
 
         return QueueStatus(connected=True, re_state="idle", worker_exists=True)
 
@@ -186,7 +186,7 @@ def window(qtbot):
 
 def drive_status(window, re_state, connected=True, worker_exists=None):
     """Feed one manager status snapshot straight into the window's slot."""
-    from geecs_console.services.queue_client import QueueStatus
+    from geecs_bluesky.qs_client import QueueStatus
 
     if worker_exists is None:
         worker_exists = connected and re_state is not None
@@ -198,7 +198,7 @@ def drive_status(window, re_state, connected=True, worker_exists=None):
 def passing_preflight(monkeypatch, questions=()):
     """Patch the preflight phase to a canned report (no engine, no CA)."""
     from geecs_console.app import main_window as module
-    from geecs_console.services.submit_preflight import PreflightReport
+    from geecs_bluesky.qs_client import PreflightReport
 
     report = PreflightReport(
         outcomes=[("validate", "passed", "")], questions=list(questions)
@@ -480,7 +480,7 @@ class TestOptimizationMode:
         self, opt_window, qtbot, monkeypatch
     ):
         """A refused queue submission is surfaced, never pre-blocked."""
-        from geecs_console.services.queue_client import SubmitResult
+        from geecs_bluesky.qs_client import SubmitResult
 
         opt_window._submitter.submit_result = SubmitResult(
             ok=False, message="optimization loader not registered"
@@ -501,7 +501,7 @@ class TestOptimizationMode:
         def boom(request, *, clear_pending=False):
             raise RuntimeError("manager exploded")
 
-        opt_window._submitter.submit = boom
+        opt_window._submitter.submit_scan = boom
         select_save_set(opt_window, "Amp4In")
         opt_window.radio_optimization.setChecked(True)
         opt_window.optimization_combo.setCurrentText("bayes_jet")
@@ -727,7 +727,7 @@ class TestSubmission:
 
     def test_preflight_refusal_never_queues(self, window, qtbot, monkeypatch):
         from geecs_console.app import main_window as module
-        from geecs_console.services.submit_preflight import PreflightReport
+        from geecs_bluesky.qs_client import PreflightReport
 
         monkeypatch.setattr(
             module,
@@ -748,7 +748,7 @@ class TestSubmission:
     ):
         from PySide6.QtWidgets import QMessageBox
 
-        from geecs_console.services.submit_preflight import PreflightQuestion
+        from geecs_bluesky.qs_client import PreflightQuestion
 
         _auto_answer(monkeypatch, QMessageBox.ButtonRole.AcceptRole)
         question = PreflightQuestion(
@@ -766,7 +766,7 @@ class TestSubmission:
     def test_preflight_question_abort_never_queues(self, window, qtbot, monkeypatch):
         from PySide6.QtWidgets import QMessageBox
 
-        from geecs_console.services.submit_preflight import PreflightQuestion
+        from geecs_bluesky.qs_client import PreflightQuestion
 
         _auto_answer(monkeypatch, QMessageBox.ButtonRole.RejectRole)
         question = PreflightQuestion(
@@ -786,7 +786,7 @@ class TestSubmission:
         """The failed-item-at-front trap (#648 item 3): surface, ask, clear."""
         from PySide6.QtWidgets import QMessageBox
 
-        from geecs_console.services.queue_client import SubmitResult
+        from geecs_bluesky.qs_client import SubmitResult
 
         _auto_answer(monkeypatch, QMessageBox.ButtonRole.AcceptRole)
         submitter = window._submitter
@@ -799,21 +799,21 @@ class TestSubmission:
             if len(submitter.submitted) == 1:
                 submitter.submit_result = SubmitResult(ok=True, item_uid="uid-2")
 
-        original = submitter.submit
+        original = submitter.submit_scan
 
-        def submit(request, *, clear_pending=False):
+        def submit_scan(request, *, clear_pending=False):
             result = original(request, clear_pending=clear_pending)
             arm_second_try()
             return result
 
-        submitter.submit = submit
+        submitter.submit_scan = submit_scan
         self._submit(window, qtbot, monkeypatch)
         assert [clear for _, clear in submitter.submitted] == [False, True]
 
     def test_pending_items_cancel_leaves_the_queue(self, window, qtbot, monkeypatch):
         from PySide6.QtWidgets import QMessageBox
 
-        from geecs_console.services.queue_client import SubmitResult
+        from geecs_bluesky.qs_client import SubmitResult
 
         _auto_answer(monkeypatch, QMessageBox.ButtonRole.RejectRole)
         window._submitter.submit_result = SubmitResult(

--- a/GEECS-Console/tests/test_scan_monitor.py
+++ b/GEECS-Console/tests/test_scan_monitor.py
@@ -14,7 +14,7 @@ from geecs_console.app.scan_monitor import (
     _FAILED_MOVE_PREFIX_FALLBACK,
     _failed_move_prefix,
 )
-from geecs_console.services.queue_client import StubQueueClient
+from geecs_bluesky.qs_client import StubQueueClient
 
 
 class TestFailedMovePrefix:

--- a/GeecsBluesky/CHANGELOG.md
+++ b/GeecsBluesky/CHANGELOG.md
@@ -23,7 +23,11 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   - New `qs-client` extra carrying `bluesky-queueserver-api` (lazily
     imported inside methods; the modules import without it).
   - Tests moved/extended to `tests/qs_client/` (skip whole without the
-    extra, the optimize-extra pattern).
+    extra, the optimize-extra pattern); the light-package-import
+    contract and the oneshot one-loop contract are pinned by
+    `tests/test_lazy_package_import.py` / `tests/test_oneshot.py`
+    (review findings on the extraction PR), and the qs_client suite
+    keeps a Windows CI leg via the `console-windows` job.
 - **`devices/ca/oneshot.py` — the one blessed one-shot blocking CA
   read** (`caget_once`/`try_caget_once`): one persistent reader loop in
   one daemon thread.  A per-call `asyncio.run()` re-created the CA

--- a/GeecsBluesky/CHANGELOG.md
+++ b/GeecsBluesky/CHANGELOG.md
@@ -4,6 +4,46 @@ All notable changes to `geecs-bluesky` are documented here.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.58.0] - 2026-08-21
+
+### Added
+
+- **`geecs_bluesky.qs_client` — the RE Manager client seam, extracted
+  from GEECS-Console** (the console is one queue client among several;
+  notebooks and the OSPREY scan MCP submit the same `ScanRequest` dicts
+  through the same verbs):
+  - `client.py` — the ONE `QueueClient` protocol (it absorbed the
+    console's former `Submitter` twin: `run_action` raise-mapping and
+    the `info_addr`/`doc_addr` stream addresses now live on the client),
+    `ZmqQueueClient`/`StubQueueClient`, the `[qserver]` config reader,
+    and `make_queue_client(experiment, user=...)`.  New read-only verbs
+    `queue_items()`/`history_items()` (the OSPREY MCP plan's first gap).
+  - `submit_preflight.py` — the client-side pre-submit checks and
+    `stamp_submission` provenance, moved verbatim from the console.
+  - New `qs-client` extra carrying `bluesky-queueserver-api` (lazily
+    imported inside methods; the modules import without it).
+  - Tests moved/extended to `tests/qs_client/` (skip whole without the
+    extra, the optimize-extra pattern).
+- **`devices/ca/oneshot.py` — the one blessed one-shot blocking CA
+  read** (`caget_once`/`try_caget_once`): one persistent reader loop in
+  one daemon thread.  A per-call `asyncio.run()` re-created the CA
+  channels and leaked aioca's per-loop channel cache on every read —
+  the preflight's liveness/staleness samples and the console health
+  probe now share this helper instead.
+
+### Changed
+
+- **`geecs_bluesky` package import is light** (PEP 562): the top-level
+  device re-exports load lazily, so `import geecs_bluesky.qs_client`
+  (or the bare package) no longer pays for aioca/ophyd-async.
+  `from geecs_bluesky import CaMotor` still works and
+  `apply_epics_address_config()` still runs before any device import.
+- `qserver/launch_re_manager.sh`: `QS_STARTUP_DIR` defaults to the
+  `startup/` folder **beside the script** instead of the CWD-relative
+  `./startup`, so the launcher works from any working directory (live
+  finding 2026-08-21: launching from the package root failed with a
+  missing-startup-dir error).
+
 ## [0.57.3] - 2026-08-21
 
 ### Removed

--- a/GeecsBluesky/CLAUDE.md
+++ b/GeecsBluesky/CLAUDE.md
@@ -64,6 +64,18 @@ geecs_bluesky/
                             #   renders Ask as a modal (its submit_preflight
                             #   is the live consumer — OperatorQuestion +
                             #   ANSWER_* live here since W5)
+  qs_client/                # the RE Manager CLIENT seam (extracted from
+                            #   GEECS-Console 2026-08-21, shared by every
+                            #   client — console, notebooks, OSPREY MCP):
+                            #   client.py = the ONE QueueClient protocol +
+                            #   ZmqQueueClient/StubQueueClient + the
+                            #   [qserver] config reader (submission with the
+                            #   failed-item-at-front guard, sequenced stop,
+                            #   read verbs, function-verb task polling);
+                            #   submit_preflight.py = client-side pre-submit
+                            #   checks + stamp_submission provenance.
+                            #   bluesky-queueserver-api rides the qs-client
+                            #   extra, lazily imported inside methods
   config_resolver.py        # ConfigResolver protocol + ConfigsRepoResolver:
                             #   ScanRequest names → schema models (new-schema
                             #   YAML directly, else legacy-convert)
@@ -125,6 +137,10 @@ geecs_bluesky/
       action_signals.py     # CaActionSignalFactory — the production
                             #   SettableFactory for compiled action plans
                             #   (cached :SP settables + str readbacks)
+      oneshot.py            # caget_once/try_caget_once — THE one-shot
+                            #   blocking CA read (one persistent reader
+                            #   loop; a per-call asyncio.run leaks aioca's
+                            #   per-loop channel cache)
       gateway_put.py        # GatewaySetpointPut — THE one gateway :SP put
                             #   primitive (addressing rule ca://-vs-bare,
                             #   wire conventions, timeout, mock); every
@@ -200,7 +216,20 @@ its Troubleshooting section is the empirical contract (permissions file,
 CLI parses Python literals not JSON).
 
 Clients submit `ScanRequest.model_dump(mode="json")` dicts as queue items;
-GEECS-Console's client lives in `geecs_console/services/queue_client.py`.
+the client machinery lives in **this package** since the extraction
+(2026-08-21): `geecs_bluesky/qs_client/` — `client.py` (the ONE
+`QueueClient` protocol + `ZmqQueueClient`/`StubQueueClient` + the
+`[qserver]` config reader; it absorbed the console's former `Submitter`
+twin) and `submit_preflight.py` (the client-side pre-submit checks +
+`stamp_submission` provenance).  `bluesky-queueserver-api` rides the
+`qs-client` extra, imported lazily inside methods; the package import
+itself is light (the top-level device re-exports are PEP 562-lazy so a
+client never pays for aioca/ophyd-async).  One-shot blocking CA reads
+(the preflight's liveness/staleness samples, the console health probe)
+go through `devices/ca/oneshot.py` — one persistent reader loop, never a
+per-call `asyncio.run` (which leaks aioca's per-loop channel cache).
+The console keeps only its identity wrapper
+(`geecs_console/submission.py`) and the Qt-side monitor.
 Operator pause/resume/stop are the manager's own verbs (decision 4):
 deferred pause lands at the next plan checkpoint and resume replays
 nothing; stop-from-paused finalizes gracefully with partial data (both

--- a/GeecsBluesky/geecs_bluesky/__init__.py
+++ b/GeecsBluesky/geecs_bluesky/__init__.py
@@ -2,23 +2,23 @@
 
 Devices are CA-backed: they consume the GeecsCAGateway PVs as a standard
 EPICS IOC (the gateway is the only component that speaks GEECS TCP/UDP).
+
+The device re-exports below are **lazy** (PEP 562): importing the package
+— in particular :mod:`geecs_bluesky.qs_client`, the RE Manager client any
+GEECS client uses — must stay light, and the device family pulls
+aioca/ophyd-async at import.  ``from geecs_bluesky import CaMotor`` still
+works; it just pays the device-family import at that moment.
 """
 
 from .epics_env import apply_epics_address_config
 
-# Must run before the device imports below: they pull in aioca (via
+# Must run before any device import: the device family pulls in aioca (via
 # ophyd-async), and libca reads EPICS_CA_ADDR_LIST when the CA context is
-# created at that import.  Explicit env vars win (setdefault semantics).
+# created at that import.  Every ``geecs_bluesky.devices`` import runs this
+# package init first, so laziness preserves the ordering.  Explicit env
+# vars win (setdefault semantics).
 apply_epics_address_config()
 
-from .devices import (  # noqa: E402
-    CaGenericDetector,
-    CaMotor,
-    CaSettable,
-    CaSnapshotReadable,
-    CaTimestampedReadable,
-    CaTriggerable,
-)
 from .exceptions import (  # noqa: E402
     GeecsError,
     GeecsConnectionError,
@@ -30,13 +30,18 @@ from .exceptions import (  # noqa: E402
     GeecsDeviceNotFoundError,
 )
 
-__all__ = [
+#: Names served lazily from the (heavy) device family.
+_DEVICE_EXPORTS = (
     "CaGenericDetector",
     "CaMotor",
     "CaSettable",
     "CaSnapshotReadable",
     "CaTimestampedReadable",
     "CaTriggerable",
+)
+
+__all__ = [
+    *_DEVICE_EXPORTS,
     "GeecsError",
     "GeecsConnectionError",
     "GeecsCommandError",
@@ -46,3 +51,17 @@ __all__ = [
     "GeecsMotorTimeoutError",
     "GeecsDeviceNotFoundError",
 ]
+
+
+def __getattr__(name: str):
+    """Resolve the device re-exports on first access (PEP 562)."""
+    if name in _DEVICE_EXPORTS:
+        from . import devices
+
+        return getattr(devices, name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__() -> list[str]:
+    """Advertise the lazy device names alongside the eager ones."""
+    return sorted(set(globals()) | set(_DEVICE_EXPORTS))

--- a/GeecsBluesky/geecs_bluesky/devices/ca/oneshot.py
+++ b/GeecsBluesky/geecs_bluesky/devices/ca/oneshot.py
@@ -1,0 +1,101 @@
+"""One-shot blocking CA reads on a shared persistent event loop.
+
+aioca caches its CA channels per asyncio event loop, so a per-call
+``asyncio.run()`` (a fresh loop every read) re-creates the channel on
+every call and strands the previous loop's cache entries for the process
+lifetime — the aioca loop-cache leak.  Sync callers that need an
+occasional blocking read (the console health probe, the pre-submit
+preflight's liveness/staleness samples) go through this module instead:
+it owns **one** persistent asyncio loop in one daemon thread and serves
+every read through it, so each PV's channel is created once and reused.
+
+This is the one blessed one-shot blocking read; long-lived subscriptions
+belong on a caller-owned loop (the console device-panel pattern), and
+in-plan reads belong to ophyd-async signals — never this module.
+
+``aioca`` is imported lazily on first use (the ``ca`` extra), so the
+module itself imports anywhere.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+from typing import Any, Optional
+
+#: Grace added to the CA timeout for the cross-thread ``future.result``
+#: backstop, so a wedged loop surfaces as a timeout instead of a hang.
+_RESULT_GRACE_S = 2.0
+
+_loop_lock = threading.Lock()
+_loop: Optional[asyncio.AbstractEventLoop] = None
+
+
+def _shared_loop() -> asyncio.AbstractEventLoop:
+    """Return the process-wide reader loop, starting its thread on first use."""
+    global _loop
+    with _loop_lock:
+        if _loop is None or _loop.is_closed():
+            loop = asyncio.new_event_loop()
+            thread = threading.Thread(
+                target=loop.run_forever, name="geecs-ca-oneshot", daemon=True
+            )
+            thread.start()
+            _loop = loop
+        return _loop
+
+
+def caget_once(pv: str, *, timeout: float, datatype: Any = None) -> Any:
+    """One blocking CA read of *pv* on the shared loop.
+
+    Parameters
+    ----------
+    pv : str
+        Bare PV name (no ``ca://`` prefix).
+    timeout : float
+        CA read budget in seconds.
+    datatype :
+        Passed to ``caget``.  **Must be ``str`` for enum PVs whose choice
+        string is compared** (e.g. the gateway's ``CONNECTED`` is a
+        DBR_ENUM — a native read returns the integer index, and
+        ``str(1)`` never equals ``"Disconnected"``).  ``None`` reads the
+        channel's native type.
+
+    Returns
+    -------
+    Any
+        The channel value.
+
+    Raises
+    ------
+    Exception
+        Whatever ``aioca`` raises on failure or timeout (``CANothing``),
+        or ``concurrent.futures.TimeoutError`` if the shared loop itself
+        is wedged past the grace budget.
+    """
+    from aioca import caget
+
+    async def _get() -> Any:
+        if datatype is None:
+            return await caget(pv, timeout=timeout)
+        return await caget(pv, datatype=datatype, timeout=timeout)
+
+    future = asyncio.run_coroutine_threadsafe(_get(), _shared_loop())
+    try:
+        return future.result(timeout=timeout + _RESULT_GRACE_S)
+    except BaseException:
+        future.cancel()
+        raise
+
+
+def try_caget_once(pv: str, *, timeout: float, datatype: Any = None) -> Any:
+    """:func:`caget_once`, with every failure read as ``None``.
+
+    For fail-open probes where an unreadable PV is not a verdict (the
+    liveness doctrine) — callers that must distinguish failure use
+    :func:`caget_once` directly.
+    """
+    try:
+        return caget_once(pv, timeout=timeout, datatype=datatype)
+    except Exception:
+        return None

--- a/GeecsBluesky/geecs_bluesky/preflight.py
+++ b/GeecsBluesky/geecs_bluesky/preflight.py
@@ -3,8 +3,8 @@
 A check inspects the scan about to start and returns *pass*, *ask the
 operator a question*, or *abort*.  Since the queueserver migration
 (decision 3, issue #649) questions are answered **client-side pre-submit**
-— GEECS-Console runs the checks itself and renders each :class:`Ask` as an
-ordinary modal (``geecs_console.services.submit_preflight``, the live
+— clients run the checks pre-submit and render each :class:`Ask` their own
+way (``geecs_bluesky.qs_client.submit_preflight``, the live
 consumer of this module's :class:`UnservedVariablesCheck` /
 :class:`PreflightContext` / :class:`Ask` / :class:`Passed`).  Engine-side,
 :func:`run_preflight` runs headless: an :class:`Ask` takes its

--- a/GeecsBluesky/geecs_bluesky/qs_client/__init__.py
+++ b/GeecsBluesky/geecs_bluesky/qs_client/__init__.py
@@ -1,0 +1,52 @@
+"""The GEECS RE Manager client seam — for every queueserver client.
+
+Extracted from GEECS-Console (2026-08-21) because the console is just one
+client of the queue: notebooks and the OSPREY scan MCP submit the same
+``geecs_schemas.ScanRequest`` dicts through the same verbs.  Two modules:
+
+- :mod:`.client` — the :class:`QueueClient` protocol and its
+  implementations (:class:`ZmqQueueClient` over the manager's 0MQ control
+  socket, :class:`StubQueueClient` offline), plus the ``[qserver]``
+  section reader of the shared ``~/.config/geecs_python_api/config.ini``.
+- :mod:`.submit_preflight` — the client-side pre-submit checks (engine
+  validation, unserved variables, CONNECTED liveness, free-run staleness)
+  and :func:`stamp_submission`, which records client identity and check
+  outcomes into ``ScanRequest.submission`` for run-metadata provenance.
+
+Importing this package is deliberately light: ``bluesky-queueserver-api``
+(the ``qs-client`` extra) and the engine/CA internals load lazily inside
+methods, and the parent package's device re-exports are lazy too — a
+client that only submits scans never pays for aioca/ophyd-async.
+"""
+
+from geecs_bluesky.qs_client.client import (
+    QserverConfig,
+    QueueClient,
+    QueueStatus,
+    StubQueueClient,
+    SubmitResult,
+    ZmqQueueClient,
+    make_queue_client,
+    read_qserver_config,
+)
+from geecs_bluesky.qs_client.submit_preflight import (
+    PreflightQuestion,
+    PreflightReport,
+    run_submit_preflight,
+    stamp_submission,
+)
+
+__all__ = [
+    "QserverConfig",
+    "QueueClient",
+    "QueueStatus",
+    "StubQueueClient",
+    "SubmitResult",
+    "ZmqQueueClient",
+    "make_queue_client",
+    "read_qserver_config",
+    "PreflightQuestion",
+    "PreflightReport",
+    "run_submit_preflight",
+    "stamp_submission",
+]

--- a/GeecsBluesky/geecs_bluesky/qs_client/client.py
+++ b/GeecsBluesky/geecs_bluesky/qs_client/client.py
@@ -1,23 +1,26 @@
-"""Queueserver manager client seam (#648): the console as a peer RE Manager client.
+"""Queueserver manager client: any GEECS client as a peer of the RE Manager.
 
-The console submits scans to a bluesky-queueserver RE Manager (the GEECS
-worker, ``GeecsBluesky/qserver/``) instead of an in-process engine.  This
-module is the one place that speaks ``bluesky-queueserver-api``:
+Clients (the console, notebooks, the OSPREY scan MCP) submit scans to a
+bluesky-queueserver RE Manager (the GEECS worker, ``GeecsBluesky/qserver/``)
+as queue items.  This module is the one place that speaks
+``bluesky-queueserver-api``:
 
-- :class:`QueueClient` — the protocol the window and controllers depend on;
+- :class:`QueueClient` — the ONE protocol clients depend on (it absorbed
+  the console's former ``Submitter`` twin in the extraction);
 - :class:`ZmqQueueClient` — the real client (0MQ control socket, lazy
-  imports so the module stays import-safe offline);
-- :class:`StubQueueClient` — the offline/test default (disconnected status,
-  every verb refuses with a clear message);
+  imports so the module stays import-safe offline and without the
+  ``qs-client`` extra);
+- :class:`StubQueueClient` — the offline/test default (disconnected
+  status, every verb refuses with a clear message);
 - :func:`read_qserver_config` — the ``[qserver]`` section of the shared
-  ``~/.config/geecs_python_api/config.ini``.
+  ``~/.config/geecs_python_api/config.ini``;
+- :func:`make_queue_client` — the factory (stub when unconfigured).
 
-Threading contract (the console's standing rules): every method here
-**blocks** — 0MQ request/reply with a short timeout, or a polled
-``function_execute`` task.  :meth:`QueueClient.status` is cheap and bounded
-(one request, ``timeout_recv``) and is polled from a background thread
-(``HealthPoller`` pattern); the submit/stop/manual-verb calls run on
-``BackgroundResult`` workers.  Nothing here touches Qt.
+Threading contract: every method here **blocks** — 0MQ request/reply with
+a short timeout, or a polled ``function_execute`` task.
+:meth:`QueueClient.status` is cheap and bounded (one request,
+``timeout_recv``) and safe to poll from a background thread; dispatch the
+submit/stop/manual-verb calls off any GUI thread.  Nothing here touches Qt.
 
 Queue semantics this client owns (#648 item 3): on plan failure the manager
 returns the failed item to the **front** of the queue (``ignore_failures``
@@ -33,9 +36,13 @@ import logging
 import threading
 import time
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import Any, Optional, Protocol, runtime_checkable
 
 logger = logging.getLogger(__name__)
+
+#: The shared GEECS user config (the permanent fleet contract path).
+_USER_CONFIG_PATH = Path("~/.config/geecs_python_api/config.ini")
 
 #: The manager's default 0MQ control / console-info ports and the document
 #: stream's default out port (see GeecsBluesky/qserver/deploy/DEPLOYMENT.md,
@@ -80,14 +87,12 @@ def read_qserver_config() -> Optional[QserverConfig]:
     Returns
     -------
     QserverConfig or None
-        ``None`` when the file or section is absent — the console then runs
+        ``None`` when the file or section is absent — clients then run
         with the stub client (submission disabled, everything else works).
     """
     import configparser
 
-    from geecs_console.services.ops_paths import USER_CONFIG_PATH
-
-    path = USER_CONFIG_PATH.expanduser()
+    path = _USER_CONFIG_PATH.expanduser()
     if not path.exists():
         return None
     parser = configparser.ConfigParser()
@@ -114,7 +119,7 @@ def read_qserver_config() -> Optional[QserverConfig]:
 
 @dataclass(frozen=True)
 class QueueStatus:
-    """One poll's snapshot of the manager, GUI-shaped.
+    """One poll's snapshot of the manager, client-shaped.
 
     ``connected=False`` means the manager did not answer — every other
     field is then meaningless and ``detail`` says why.  ``re_state`` is the
@@ -149,7 +154,16 @@ class SubmitResult:
 
 @runtime_checkable
 class QueueClient(Protocol):
-    """What the console needs from a RE Manager (all methods block; see module doc)."""
+    """What a GEECS client needs from a RE Manager (all methods block).
+
+    The one client protocol (it replaced the console's ``Submitter`` twin
+    in the extraction).  ``info_addr`` / ``doc_addr`` carry the manager's
+    console-output and document stream addresses (``None`` when
+    unconfigured) so stream consumers build from the same configuration.
+    """
+
+    info_addr: Optional[str]
+    doc_addr: Optional[str]
 
     def status(self) -> QueueStatus:
         """Return the manager snapshot. Never raises."""
@@ -165,6 +179,14 @@ class QueueClient(Protocol):
         """Queue ``geecs_run_action_plan(name)`` and start the queue."""
         ...
 
+    def run_action(self, name: str) -> None:
+        """:meth:`submit_action`, raising ``RuntimeError`` on refusal.
+
+        Completion/failure of the action itself is observed through the
+        manager status, not this call.
+        """
+        ...
+
     def request_pause(self) -> tuple[bool, str]:
         """Deferred-pause the running plan. Returns ``(ok, message)``."""
         ...
@@ -175,6 +197,14 @@ class QueueClient(Protocol):
 
     def stop_scan(self) -> tuple[bool, str]:
         """Gracefully stop: from paused directly, from running via pause."""
+        ...
+
+    def queue_items(self) -> list[dict]:
+        """Return the queued items (front first); raises on failure."""
+        ...
+
+    def history_items(self) -> list[dict]:
+        """Return the manager's item history; raises on failure."""
         ...
 
     def move_variable(self, name: str, value: float) -> dict:
@@ -195,6 +225,9 @@ _STUB_MESSAGE = (
 class StubQueueClient:
     """The offline default: disconnected status, every verb refuses clearly."""
 
+    info_addr: Optional[str] = None
+    doc_addr: Optional[str] = None
+
     def status(self) -> QueueStatus:
         """Return a disconnected snapshot naming the missing config."""
         return QueueStatus(connected=False, detail=_STUB_MESSAGE)
@@ -209,6 +242,10 @@ class StubQueueClient:
         """Refuse with the missing-config message."""
         return SubmitResult(ok=False, message=_STUB_MESSAGE)
 
+    def run_action(self, name: str) -> None:
+        """Refuse with the missing-config message."""
+        raise RuntimeError(_STUB_MESSAGE)
+
     def request_pause(self) -> tuple[bool, str]:
         """Refuse with the missing-config message."""
         return False, _STUB_MESSAGE
@@ -220,6 +257,14 @@ class StubQueueClient:
     def stop_scan(self) -> tuple[bool, str]:
         """Refuse with the missing-config message."""
         return False, _STUB_MESSAGE
+
+    def queue_items(self) -> list[dict]:
+        """Refuse with the missing-config message."""
+        raise RuntimeError(_STUB_MESSAGE)
+
+    def history_items(self) -> list[dict]:
+        """Refuse with the missing-config message."""
+        raise RuntimeError(_STUB_MESSAGE)
 
     def move_variable(self, name: str, value: float) -> dict:
         """Refuse with the missing-config message."""
@@ -234,10 +279,10 @@ class ZmqQueueClient:
     """The real manager client over the 0MQ control socket.
 
     One :class:`bluesky_queueserver_api.zmq.REManagerAPI` is created lazily
-    on first use and reused (it is thread-safe for the console's usage: the
-    status poller and the one-at-a-time worker calls).  All
-    ``bluesky_queueserver_api`` imports live inside methods — the module
-    must import offline (console standing rule).
+    on first use and reused (it is thread-safe for this usage: a status
+    poller plus one-at-a-time verb calls).  All ``bluesky_queueserver_api``
+    imports live inside methods — the module must import without the
+    ``qs-client`` extra installed.
 
     Parameters
     ----------
@@ -247,15 +292,25 @@ class ZmqQueueClient:
         Submitted-as identity recorded by the manager on every queue item.
     """
 
-    def __init__(self, config: QserverConfig, *, user: str = "geecs-console") -> None:
+    def __init__(self, config: QserverConfig, *, user: str = "geecs-qs-client") -> None:
         self._config = config
         self._user = user
         self._api: Any = None
-        # The status poller's first call and an early worker-thread verb can
+        # A status poller's first call and an early worker-thread verb can
         # race the lazy init; without the lock the loser's REManagerAPI (and
         # its zmq receive thread) would leak for the process lifetime (#653
         # review finding 5).
         self._api_lock = threading.Lock()
+
+    @property
+    def info_addr(self) -> Optional[str]:
+        """The manager's console-output stream address."""
+        return self._config.info_addr
+
+    @property
+    def doc_addr(self) -> Optional[str]:
+        """The document stream's out-port address."""
+        return self._config.doc_addr
 
     # -- plumbing -----------------------------------------------------------
 
@@ -389,6 +444,17 @@ class ZmqQueueClient:
         """Queue the on-demand action plan (actions are queue items, decision 2)."""
         return self._submit_item("geecs_run_action_plan", [name], clear_pending=False)
 
+    def run_action(self, name: str) -> None:
+        """Queue the action item; raise the refusal message on failure."""
+        result = self.submit_action(name)
+        if not result.ok:
+            if result.pending_items:
+                raise RuntimeError(
+                    f"queue not empty ({len(result.pending_items)} item(s) "
+                    "pending) — clear the queue before running an action"
+                )
+            raise RuntimeError(result.message or "action submission refused")
+
     def request_pause(self) -> tuple[bool, str]:
         """Deferred pause (the stock verb; hard pause replays — never default it)."""
         try:
@@ -447,6 +513,14 @@ class ZmqQueueClient:
         except Exception as exc:
             return False, str(exc)
 
+    def queue_items(self) -> list[dict]:
+        """Return the queued items, front first (read-only; raises on failure)."""
+        return list(self._manager().queue_get().get("items") or [])
+
+    def history_items(self) -> list[dict]:
+        """Return the manager's item history (read-only; raises on failure)."""
+        return list(self._manager().history_get().get("items") or [])
+
     def move_variable(self, name: str, value: float) -> dict:
         """Run the worker's manual move; idle-only (the manager enforces it)."""
         from bluesky_queueserver_api import BFunc
@@ -468,8 +542,29 @@ class ZmqQueueClient:
         return self._wait_for_task(response["task_uid"], timeout_s=30.0)
 
 
-def make_queue_client(user: str = "geecs-console") -> QueueClient:
-    """Build the configured client, or the stub when no ``[qserver]`` exists."""
+def make_queue_client(
+    experiment: str = "", *, user: str = "geecs-qs-client"
+) -> QueueClient:
+    """Build the configured client, or the stub when no ``[qserver]`` exists.
+
+    Parameters
+    ----------
+    experiment : str, optional
+        The selected experiment.  Currently informational — one manager
+        serves one experiment by deployment contract (``QS_EXPERIMENT``),
+        and the ``[qserver]`` config names that manager; a mismatch
+        surfaces as the worker refusing the request's names at validation.
+    user : str
+        Submitted-as identity the manager records on every queue item
+        (e.g. ``"geecs-console"``, ``"osprey-htu-assistant"``).
+
+    Returns
+    -------
+    QueueClient
+        Ready to use; unconfigured installs get the stub client (every
+        verb refuses with the missing-config message, stream addresses
+        ``None``).
+    """
     config = read_qserver_config()
     if config is None:
         return StubQueueClient()

--- a/GeecsBluesky/geecs_bluesky/qs_client/submit_preflight.py
+++ b/GeecsBluesky/geecs_bluesky/qs_client/submit_preflight.py
@@ -3,15 +3,17 @@
 Under the queue, submission-to-execution gaps are long — a typo must fail
 at submit, not at queue-front — and the worker cannot ask the operator
 anything (its checks run headless: default-continue with a warning).  So
-the console runs the checks *before* queueing and asks its questions as
-ordinary synchronous dialogs.  The worker re-runs validation and the
-unserved-variables check authoritatively at execution — the duplication is
-by design (migration doc, "reinitialize disposition").
+clients run the checks *before* queueing and ask the questions their own
+way: the console renders each as a synchronous modal; a headless client
+(notebook, the OSPREY MCP) surfaces them programmatically.  The worker
+re-runs validation and the unserved-variables check authoritatively at
+execution — the duplication is by design (migration doc, "reinitialize
+disposition").
 
-This module is the pure layer: it computes findings and questions on a
-background thread and returns them; the **dialogs live in the window**.
-Outcomes are stamped into the request's ``submission`` record
-(geecs-schemas 0.10.0) by :func:`stamp_submission`, giving the run
+This module is the pure layer: it computes findings and questions on the
+caller's thread and returns them; **rendering/answering lives in the
+client**.  Outcomes are stamped into the request's ``submission`` record
+(geecs-schemas ≥ 0.10.0) by :func:`stamp_submission`, giving the run
 metadata a provenance trail of who was asked what and what they answered.
 
 Checks, in order (names are the ``PreflightOutcome.check`` vocabulary):
@@ -29,8 +31,8 @@ Checks, in order (names are the ``PreflightOutcome.check`` vocabulary):
   ``acq_timestamp`` must advance within a short window, else the trigger
   looks stopped.
 
-Every real dependency (``geecs_bluesky``, ``aioca``) is imported lazily
-inside functions — this module must import offline (console standing rule).
+Every heavy dependency (the engine internals, ``aioca``) is imported
+lazily inside functions — this module must import light and offline.
 """
 
 from __future__ import annotations
@@ -53,7 +55,7 @@ _STALENESS_WINDOW_S = 2.0
 
 @dataclass(frozen=True)
 class PreflightQuestion:
-    """One operator question a check raised (rendered as a modal by the window)."""
+    """One operator question a check raised (rendered by the client)."""
 
     check: str
     title: str
@@ -64,7 +66,7 @@ class PreflightQuestion:
 
 @dataclass
 class PreflightReport:
-    """Everything the check phase computed, for the window's ask phase.
+    """Everything the check phase computed, for the client's ask phase.
 
     ``refusal`` set means submission must not proceed (validation failed) —
     ``questions`` and ``outcomes`` are then partial and irrelevant.
@@ -102,16 +104,17 @@ def _resolve_devices_config(request: Any, resolver: Any) -> dict[str, dict]:
 
 
 def run_submit_preflight(request: Any, experiment: str) -> PreflightReport:
-    """Run every pre-submit check; return findings for the window to render.
+    """Run every pre-submit check; return findings for the client to render.
 
-    Blocking (config reads, one DB query, a few CA reads) — call it on a
-    background worker, never the GUI thread.  Never raises: any check that
-    blows up unexpectedly is recorded as ``skipped`` with the error text.
+    Blocking (config reads, one DB query, a few CA reads) — GUI clients
+    call it on a background worker, never the GUI thread.  Never raises:
+    any check that blows up unexpectedly is recorded as ``skipped`` with
+    the error text.
 
     Parameters
     ----------
     request : geecs_schemas.ScanRequest
-        The validated request the form built (not yet stamped).
+        The validated request the client built (not yet stamped).
     experiment : str
         The selected experiment (resolver + PV prefix).
 
@@ -216,7 +219,12 @@ def _check_unserved(
 
 
 def _read_pv(pv: str, timeout: float, datatype: Any = None) -> Any:
-    """One blocking CA read (aioca in a private loop); ``None`` on failure.
+    """One blocking CA read on the shared reader loop; ``None`` on failure.
+
+    Delegates to :func:`geecs_bluesky.devices.ca.oneshot.try_caget_once`
+    (one persistent loop — never a per-call ``asyncio.run``, whose fresh
+    loop leaks aioca's per-loop channel cache on every read).  Kept as a
+    module-level seam so tests patch the reads here.
 
     Parameters
     ----------
@@ -233,19 +241,9 @@ def _read_pv(pv: str, timeout: float, datatype: Any = None) -> Any:
         ``None`` reads the channel's native type (right for
         ``acq_timestamp``, natively a double).
     """
-    import asyncio
+    from geecs_bluesky.devices.ca.oneshot import try_caget_once
 
-    from aioca import caget
-
-    async def _get() -> Any:
-        if datatype is None:
-            return await caget(pv, timeout=timeout)
-        return await caget(pv, datatype=datatype, timeout=timeout)
-
-    try:
-        return asyncio.run(_get())
-    except Exception:
-        return None
+    return try_caget_once(pv, timeout=timeout, datatype=datatype)
 
 
 def _check_liveness(
@@ -342,7 +340,7 @@ def stamp_submission(
         Final ``(check, result, detail)`` tuples — the report's decided
         outcomes plus one ``continued`` entry per question answered.
     client :
-        Client identity string, e.g. ``"geecs-console 0.21.0"``.
+        Client identity string, e.g. ``"geecs-console 0.24.0"``.
 
     Returns
     -------

--- a/GeecsBluesky/poetry.lock
+++ b/GeecsBluesky/poetry.lock
@@ -24,7 +24,7 @@ description = "A light, configurable Sphinx theme"
 optional = true
 python-versions = ">=3.10"
 groups = ["main"]
-markers = "extra == \"qserver\""
+markers = "extra == \"qserver\" or extra == \"qs-client\""
 files = [
     {file = "alabaster-1.0.0-py3-none-any.whl", hash = "sha256:fc6786402dc3fcb2de3cabd5fe455a2db534b371124f1f21de8731783dec828b"},
     {file = "alabaster-1.0.0.tar.gz", hash = "sha256:c00dca57bca26fa62a6d7d0a9fcce65f3e026e9bfe33e9c538fd3fbb2144fd9e"},
@@ -62,7 +62,7 @@ description = "High-level concurrency and networking framework on top of asyncio
 optional = true
 python-versions = ">=3.10"
 groups = ["main"]
-markers = "extra == \"tiled\""
+markers = "extra == \"tiled\" or extra == \"qs-client\""
 files = [
     {file = "anyio-4.13.0-py3-none-any.whl", hash = "sha256:08b310f9e24a9594186fd75b4f73f4a4152069e3853f1ed8bfbf58369f4ad708"},
     {file = "anyio-4.13.0.tar.gz", hash = "sha256:334b70e641fd2221c1505b3890c69882fe4a2df910cba14d97019b90b24439dc"},
@@ -82,7 +82,7 @@ description = "Disable App Nap on macOS >= 10.9"
 optional = true
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "extra == \"qserver\" and platform_system == \"Darwin\""
+markers = "(extra == \"qserver\" or extra == \"qs-client\") and platform_system == \"Darwin\""
 files = [
     {file = "appnope-1.0.0-py3-none-any.whl", hash = "sha256:6fe0c04218aab65c54c4ff81638cdbf848d89f5653b74d68638a137f200dd16e"},
     {file = "appnope-1.0.0.tar.gz", hash = "sha256:685db59cb6043c3c2e528adc0b3bce3a5f8d09bcf7492c6ea650d1b7421f3c49"},
@@ -95,7 +95,7 @@ description = "Annotate AST trees with source code positions"
 optional = true
 python-versions = ">=3.8"
 groups = ["main"]
-markers = "extra == \"optimize\" or extra == \"qserver\""
+markers = "extra == \"optimize\" or extra == \"qserver\" or extra == \"qs-client\""
 files = [
     {file = "asttokens-3.0.1-py3-none-any.whl", hash = "sha256:15a3ebc0f43c2d0a50eeafea25e19046c68398e487b9f1f5b517f7c0f40f976a"},
     {file = "asttokens-3.0.1.tar.gz", hash = "sha256:71a4ee5de0bde6a31d64f6b13f2293ac190344478f081c3d1bccfcf5eacb0cb7"},
@@ -112,7 +112,7 @@ description = "Timeout context manager for asyncio programs"
 optional = true
 python-versions = ">=3.8"
 groups = ["main"]
-markers = "extra == \"qserver\" and python_full_version < \"3.11.3\""
+markers = "(extra == \"qserver\" or extra == \"qs-client\") and python_full_version < \"3.11.3\""
 files = [
     {file = "async_timeout-5.0.1-py3-none-any.whl", hash = "sha256:39e3809566ff85354557ec2398b55e096c8364bacac9405a7a1fa429e77fe76c"},
     {file = "async_timeout-5.0.1.tar.gz", hash = "sha256:d9321a7a3d5a6a5e187e824d2fa0793ce379a202935782d555d6e9d2735677d3"},
@@ -220,7 +220,7 @@ description = "Internationalization utilities"
 optional = true
 python-versions = ">=3.8"
 groups = ["main"]
-markers = "extra == \"qserver\""
+markers = "extra == \"qserver\" or extra == \"qs-client\""
 files = [
     {file = "babel-2.18.0-py3-none-any.whl", hash = "sha256:e2b422b277c2b9a9630c1d7903c2a00d0830c409c59ac8cae9081c92f1aeba35"},
     {file = "babel-2.18.0.tar.gz", hash = "sha256:b80b99a14bd085fcacfa15c9165f651fbb3406e66cc603abf11c5750937c992d"},
@@ -327,7 +327,7 @@ description = "Server for queueing and executing Bluesky plans."
 optional = true
 python-versions = ">=3.10"
 groups = ["main"]
-markers = "extra == \"qserver\""
+markers = "extra == \"qserver\" or extra == \"qs-client\""
 files = [
     {file = "bluesky_queueserver-0.0.25-py3-none-any.whl", hash = "sha256:489a0304343c52942cdef52357895c1dc0c38b18931c3c9e924e5762ff0eea05"},
     {file = "bluesky_queueserver-0.0.25.tar.gz", hash = "sha256:3d597c5c00a0b016d77991a841b916aaa880d6623318e9105b72b95a6cd0fdb1"},
@@ -352,6 +352,24 @@ requests = "*"
 
 [package.extras]
 dev = ["aioca", "build", "coverage", "h5py", "happi (>=1.14.0)", "intake", "ipython", "matplotlib", "numpy", "numpydoc", "ophyd-async", "pandas", "pre-commit", "py", "pyarrow", "pytest", "pytest-split", "pytest-xprocess", "ruff", "scikit-image", "sphinx", "sphinx_rtd_theme", "twine"]
+
+[[package]]
+name = "bluesky-queueserver-api"
+version = "0.0.13"
+description = "Python API for Bluesky Queue Server"
+optional = true
+python-versions = ">=3.7"
+groups = ["main"]
+markers = "extra == \"qs-client\""
+files = [
+    {file = "bluesky_queueserver_api-0.0.13-py3-none-any.whl", hash = "sha256:e00c22e611f47dbcd464f7a7c28d764422366d04b9f9cbfc4012fc1b1ba7056c"},
+    {file = "bluesky_queueserver_api-0.0.13.tar.gz", hash = "sha256:696846f8755050853172b79ad346ce5003e38e9077b8cadc667768cb908c9cc2"},
+]
+
+[package.dependencies]
+bluesky-queueserver = "*"
+httpx = "*"
+websockets = "*"
 
 [[package]]
 name = "boto3"
@@ -445,7 +463,7 @@ description = "Foreign Function Interface for Python calling C code."
 optional = true
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "extra == \"qserver\" and implementation_name == \"pypy\" or extra == \"optimize\""
+markers = "(extra == \"qserver\" or extra == \"qs-client\") and implementation_name == \"pypy\" or extra == \"optimize\""
 files = [
     {file = "cffi-2.0.0-cp310-cp310-macosx_10_13_x86_64.whl", hash = "sha256:0cf2d91ecc3fcc0625c2c530fe004f82c110405f101548512cce44322fa8ac44"},
     {file = "cffi-2.0.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:f73b96c41e3b2adedc34a7356e64c8eb96e03a3782b535e043a986276ce12a49"},
@@ -741,7 +759,7 @@ description = "Jupyter Python Comm implementation, for usage in ipykernel, xeus-
 optional = true
 python-versions = ">=3.8"
 groups = ["main"]
-markers = "extra == \"optimize\" or extra == \"qserver\""
+markers = "extra == \"optimize\" or extra == \"qserver\" or extra == \"qs-client\""
 files = [
     {file = "comm-0.2.3-py3-none-any.whl", hash = "sha256:c615d91d75f7f04f095b30d1c1711babd43bdc6419c1be9886a85f2f4e489417"},
     {file = "comm-0.2.3.tar.gz", hash = "sha256:2dc8048c10962d55d7ad693be1e7045d891b7ce8d999c97963a5e3e99c055971"},
@@ -1055,7 +1073,7 @@ description = "An implementation of the Debug Adapter Protocol for Python"
 optional = true
 python-versions = ">=3.8"
 groups = ["main"]
-markers = "extra == \"qserver\""
+markers = "extra == \"qserver\" or extra == \"qs-client\""
 files = [
     {file = "debugpy-1.8.21-cp310-cp310-macosx_15_0_x86_64.whl", hash = "sha256:8eeab7b5462f683452c57c0126aaa5ec4e974ddb705f39ba87dff8818c8e08f9"},
     {file = "debugpy-1.8.21-cp310-cp310-manylinux_2_34_x86_64.whl", hash = "sha256:0fddfdc130ac6d8bfc0415b0409822fa901c8f310e5c945ac5653a0352532344"},
@@ -1096,7 +1114,7 @@ description = "Decorators for Humans"
 optional = true
 python-versions = ">=3.8"
 groups = ["main"]
-markers = "extra == \"optimize\" or extra == \"qserver\""
+markers = "extra == \"optimize\" or extra == \"qserver\" or extra == \"qs-client\""
 files = [
     {file = "decorator-5.3.1-py3-none-any.whl", hash = "sha256:f47fe6fdbd2edd623ecfe36875d37aba411624e2670dd395dddae1358689bb3c"},
     {file = "decorator-5.3.1.tar.gz", hash = "sha256:4cbcdd55a6efadb9dbea26b858f4fb3264567b52d69ca0d25b721b553f60ea82"},
@@ -1109,7 +1127,7 @@ description = "Docutils -- Python Documentation Utilities"
 optional = true
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "extra == \"qserver\""
+markers = "extra == \"qserver\" or extra == \"qs-client\""
 files = [
     {file = "docutils-0.22.4-py3-none-any.whl", hash = "sha256:d0013f540772d1420576855455d050a2180186c91c15779301ac2ccb3eeb68de"},
     {file = "docutils-0.22.4.tar.gz", hash = "sha256:4db53b1fde9abecbb74d91230d32ab626d94f6badfc575d6db9194a49df29968"},
@@ -1223,7 +1241,7 @@ description = "An implementation of lxml.xmlfile for the standard library"
 optional = true
 python-versions = ">=3.8"
 groups = ["main"]
-markers = "extra == \"qserver\""
+markers = "extra == \"qserver\" or extra == \"qs-client\""
 files = [
     {file = "et_xmlfile-2.0.0-py3-none-any.whl", hash = "sha256:7a91720bc756843502c3b7504c77b8fe44217c85c537d85037f0f536151b2caa"},
     {file = "et_xmlfile-2.0.0.tar.gz", hash = "sha256:dab3f4764309081ce75662649be815c4c9081e88f0837825f90fd28317d4da54"},
@@ -1257,7 +1275,7 @@ description = "Get the currently executing AST node of a frame, and other inform
 optional = true
 python-versions = ">=3.8"
 groups = ["main"]
-markers = "extra == \"optimize\" or extra == \"qserver\""
+markers = "extra == \"optimize\" or extra == \"qserver\" or extra == \"qs-client\""
 files = [
     {file = "executing-2.2.1-py2.py3-none-any.whl", hash = "sha256:760643d3452b4d777d295bb167ccc74c64a81df23fb5e08eff250c425a4b2017"},
     {file = "executing-2.2.1.tar.gz", hash = "sha256:3632cc370565f6648cc328b32435bd120a1e4ebb20c77e3fdde9a13cd1e533c4"},
@@ -1286,7 +1304,7 @@ description = "Saves and loads to the cache a transformed versions of a source o
 optional = true
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "extra == \"analysis\" or extra == \"optimize\" or extra == \"qserver\""
+markers = "extra == \"analysis\" or extra == \"optimize\" or extra == \"qserver\" or extra == \"qs-client\""
 files = [
     {file = "flexcache-0.3-py3-none-any.whl", hash = "sha256:d43c9fea82336af6e0115e308d9d33a185390b8346a017564611f1466dcd2e32"},
     {file = "flexcache-0.3.tar.gz", hash = "sha256:18743bd5a0621bfe2cf8d519e4c3bfdf57a269c15d1ced3fb4b64e0ff4600656"},
@@ -1305,7 +1323,7 @@ description = "Parsing made fun ... using typing."
 optional = true
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "extra == \"analysis\" or extra == \"optimize\" or extra == \"qserver\""
+markers = "extra == \"analysis\" or extra == \"optimize\" or extra == \"qserver\" or extra == \"qs-client\""
 files = [
     {file = "flexparser-0.4-py3-none-any.whl", hash = "sha256:3738b456192dcb3e15620f324c447721023c0293f6af9955b481e91d00179846"},
     {file = "flexparser-0.4.tar.gz", hash = "sha256:266d98905595be2ccc5da964fe0a2c3526fbbffdc45b65b3146d75db992ef6b2"},
@@ -1483,7 +1501,7 @@ url = "../GEECS-Data-Utils"
 
 [[package]]
 name = "geecs-schemas"
-version = "0.9.1"
+version = "0.10.2"
 description = "Versioned Pydantic schemas for GEECS scanner configs (scan requests, save sets, scan variables, trigger profiles, action plans) plus legacy-YAML converters."
 optional = false
 python-versions = ">=3.11,<3.12"
@@ -1678,7 +1696,7 @@ description = "A pure-Python, bring-your-own-I/O implementation of HTTP/1.1"
 optional = true
 python-versions = ">=3.8"
 groups = ["main"]
-markers = "extra == \"tiled\""
+markers = "extra == \"tiled\" or extra == \"qs-client\""
 files = [
     {file = "h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86"},
     {file = "h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1"},
@@ -1752,7 +1770,7 @@ description = "Python wrapper for hiredis"
 optional = true
 python-versions = ">=3.8"
 groups = ["main"]
-markers = "extra == \"qserver\""
+markers = "extra == \"qserver\" or extra == \"qs-client\""
 files = [
     {file = "hiredis-3.4.1-cp310-cp310-macosx_10_15_universal2.whl", hash = "sha256:82358041521c4da1a635b5d4819c7d22cfdfa44d73a61e4fa6696057b7c9f0b9"},
     {file = "hiredis-3.4.1-cp310-cp310-macosx_10_15_x86_64.whl", hash = "sha256:66958d145d6560f116542539acc625744c5e61a19ae33c840fb3d46c6b1e1c2a"},
@@ -1887,7 +1905,7 @@ description = "A minimal low-level HTTP client."
 optional = true
 python-versions = ">=3.8"
 groups = ["main"]
-markers = "extra == \"tiled\""
+markers = "extra == \"tiled\" or extra == \"qs-client\""
 files = [
     {file = "httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55"},
     {file = "httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8"},
@@ -1926,7 +1944,7 @@ description = "The next generation HTTP client."
 optional = true
 python-versions = ">=3.8"
 groups = ["main"]
-markers = "extra == \"tiled\""
+markers = "extra == \"tiled\" or extra == \"qs-client\""
 files = [
     {file = "httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad"},
     {file = "httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc"},
@@ -2032,7 +2050,7 @@ description = "Get image size from headers (BMP/PNG/JPEG/JPEG2000/GIF/TIFF/SVG/N
 optional = true
 python-versions = "<3.15,>=3.10"
 groups = ["main"]
-markers = "extra == \"qserver\""
+markers = "extra == \"qserver\" or extra == \"qs-client\""
 files = [
     {file = "imagesize-2.0.0-py2.py3-none-any.whl", hash = "sha256:5667c5bbb57ab3f1fa4bc366f4fbc971db3d5ed011fd2715fd8001f782718d96"},
     {file = "imagesize-2.0.0.tar.gz", hash = "sha256:8e8358c4a05c304f1fccf7ff96f036e7243a189e9e42e90851993c558cfe9ee3"},
@@ -2101,7 +2119,7 @@ description = "IPython Kernel for Jupyter"
 optional = true
 python-versions = ">=3.10"
 groups = ["main"]
-markers = "extra == \"qserver\""
+markers = "extra == \"qserver\" or extra == \"qs-client\""
 files = [
     {file = "ipykernel-7.3.0-py3-none-any.whl", hash = "sha256:897eb64da762549ef610698fca5e9675195ec6ac8ec7f19d81ce1ca20c876057"},
     {file = "ipykernel-7.3.0.tar.gz", hash = "sha256:9acaaaf97d16355166e4085afe9d225bfbdf2b7ef520f9df3be8f2b248275e09"},
@@ -2136,7 +2154,7 @@ description = "IPython: Productive Interactive Computing"
 optional = true
 python-versions = ">=3.11"
 groups = ["main"]
-markers = "extra == \"optimize\" or extra == \"qserver\""
+markers = "extra == \"optimize\" or extra == \"qserver\" or extra == \"qs-client\""
 files = [
     {file = "ipython-9.15.0-py3-none-any.whl", hash = "sha256:515ad9c3cdf0c932a5a9f6245419e8aba706b7bd03c3e1d3a1c83d9351d6aa6e"},
     {file = "ipython-9.15.0.tar.gz", hash = "sha256:da2819ce2aa83135257df830660b1176d986c3d2876db24df01974fa955b2756"},
@@ -2171,7 +2189,7 @@ description = "Defines a variety of Pygments lexers for highlighting IPython cod
 optional = true
 python-versions = ">=3.8"
 groups = ["main"]
-markers = "extra == \"optimize\" or extra == \"qserver\""
+markers = "extra == \"optimize\" or extra == \"qserver\" or extra == \"qs-client\""
 files = [
     {file = "ipython_pygments_lexers-1.1.1-py3-none-any.whl", hash = "sha256:a9462224a505ade19a605f71f8fa63c2048833ce50abc86768a0d81d876dc81c"},
     {file = "ipython_pygments_lexers-1.1.1.tar.gz", hash = "sha256:09c0138009e56b6854f9535736f4171d855c8c08a563a0dcd8022f78355c7e81"},
@@ -2210,7 +2228,7 @@ description = "An autocompletion tool for Python that can be used for text edito
 optional = true
 python-versions = ">=3.10"
 groups = ["main"]
-markers = "extra == \"optimize\" or extra == \"qserver\""
+markers = "extra == \"optimize\" or extra == \"qserver\" or extra == \"qs-client\""
 files = [
     {file = "jedi-0.20.0-py2.py3-none-any.whl", hash = "sha256:7bdd9c2634f56713299976f4cbd59cb3fa92165cc5e05ea811fb253480728b67"},
     {file = "jedi-0.20.0.tar.gz", hash = "sha256:c3f4ccbd276696f4b19c54618d4fb18f9fc24b0aef02acf704b23f487daa1011"},
@@ -2230,7 +2248,7 @@ description = "A very fast and expressive template engine."
 optional = true
 python-versions = ">=3.7"
 groups = ["main"]
-markers = "extra == \"optimize\" or extra == \"qserver\""
+markers = "extra == \"optimize\" or extra == \"qserver\" or extra == \"qs-client\""
 files = [
     {file = "jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67"},
     {file = "jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d"},
@@ -2354,7 +2372,7 @@ description = "Jupyter protocol implementation and client libraries"
 optional = true
 python-versions = ">=3.10"
 groups = ["main"]
-markers = "extra == \"qserver\""
+markers = "extra == \"qserver\" or extra == \"qs-client\""
 files = [
     {file = "jupyter_client-8.9.1-py3-none-any.whl", hash = "sha256:0b7a295bc46e8751e9adae84781f726c851c1d911bd793edc4a3bde942e3da81"},
     {file = "jupyter_client-8.9.1.tar.gz", hash = "sha256:a58f730dd9e728ba16ba1d62ebccf7ffe1ebbdbce4e95cfae941b7321ae1f4fa"},
@@ -2380,7 +2398,7 @@ description = "Jupyter terminal console"
 optional = true
 python-versions = ">=3.7"
 groups = ["main"]
-markers = "extra == \"qserver\""
+markers = "extra == \"qserver\" or extra == \"qs-client\""
 files = [
     {file = "jupyter_console-6.6.3-py3-none-any.whl", hash = "sha256:309d33409fcc92ffdad25f0bcdf9a4a9daa61b6f341177570fdac03de5352485"},
     {file = "jupyter_console-6.6.3.tar.gz", hash = "sha256:566a4bf31c87adbfadf22cdf846e3069b59a71ed5da71d6ba4d8aaad14a53539"},
@@ -2406,7 +2424,7 @@ description = "Jupyter core package. A base package on which Jupyter projects re
 optional = true
 python-versions = ">=3.10"
 groups = ["main"]
-markers = "extra == \"qserver\""
+markers = "extra == \"qserver\" or extra == \"qs-client\""
 files = [
     {file = "jupyter_core-5.9.1-py3-none-any.whl", hash = "sha256:ebf87fdc6073d142e114c72c9e29a9d7ca03fad818c5d300ce2adc1fb0743407"},
     {file = "jupyter_core-5.9.1.tar.gz", hash = "sha256:4d09aaff303b9566c3ce657f580bd089ff5c91f5f89cf7d8846c3cdf465b5508"},
@@ -2778,7 +2796,7 @@ description = "Safely add untrusted strings to HTML/XML markup."
 optional = true
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "extra == \"optimize\" or extra == \"qserver\""
+markers = "extra == \"optimize\" or extra == \"qserver\" or extra == \"qs-client\""
 files = [
     {file = "markupsafe-3.0.3-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:2f981d352f04553a7171b8e44369f2af4055f888dfb147d55e42d29e29e74559"},
     {file = "markupsafe-3.0.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:e1c1493fb6e50ab01d20a22826e57520f1284df32f2d8601fdd90b6304601419"},
@@ -2946,7 +2964,7 @@ description = "Inline Matplotlib backend for Jupyter"
 optional = true
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "extra == \"optimize\" or extra == \"qserver\""
+markers = "extra == \"optimize\" or extra == \"qserver\" or extra == \"qs-client\""
 files = [
     {file = "matplotlib_inline-0.2.2-py3-none-any.whl", hash = "sha256:3c821cf1c209f59fb2d2d64abbf5b23b67bcb2210d663f9918dd851c6da1fcf6"},
     {file = "matplotlib_inline-0.2.2.tar.gz", hash = "sha256:72f3fe8fce36b70d4a5b612f899090cd0401deddc4ea90e1572b9f4bfb058c79"},
@@ -3290,7 +3308,7 @@ description = "Patch asyncio to allow nested event loops"
 optional = true
 python-versions = ">=3.5"
 groups = ["main"]
-markers = "extra == \"qserver\""
+markers = "extra == \"qserver\" or extra == \"qs-client\""
 files = [
     {file = "nest_asyncio2-1.7.2-py3-none-any.whl", hash = "sha256:f5dfa702f3f81f6a03857e9a19e2ba578c0946a4ad417b4c50a24d7ba641fe01"},
     {file = "nest_asyncio2-1.7.2.tar.gz", hash = "sha256:1921d70b92cc4612c374928d081552efb59b83d91b2b789d935c665fa01729a8"},
@@ -3303,7 +3321,7 @@ description = "Python package for creating and manipulating graphs and networks"
 optional = true
 python-versions = "!=3.14.1,>=3.11"
 groups = ["main"]
-markers = "extra == \"analysis\" or extra == \"optimize\" or extra == \"qserver\""
+markers = "extra == \"analysis\" or extra == \"optimize\" or extra == \"qserver\" or extra == \"qs-client\""
 files = [
     {file = "networkx-3.6.1-py3-none-any.whl", hash = "sha256:d47fbf302e7d9cbbb9e2555a0d267983d2aa476bac30e90dfbe5669bd57f3762"},
     {file = "networkx-3.6.1.tar.gz", hash = "sha256:26b7c357accc0c8cde558ad486283728b65b6a95d85ee1cd66bafab4c8168509"},
@@ -3571,7 +3589,7 @@ description = "Sphinx extension to support docstrings in Numpy format"
 optional = true
 python-versions = ">=3.10"
 groups = ["main"]
-markers = "extra == \"qserver\""
+markers = "extra == \"qserver\" or extra == \"qs-client\""
 files = [
     {file = "numpydoc-1.10.0-py3-none-any.whl", hash = "sha256:3149da9874af890bcc2a82ef7aae5484e5aa81cb2778f08e3c307ba6d963721b"},
     {file = "numpydoc-1.10.0.tar.gz", hash = "sha256:3f7970f6eee30912260a6b31ac72bba2432830cd6722569ec17ee8d3ef5ffa01"},
@@ -3848,7 +3866,7 @@ description = "A Python library to read/write Excel 2010 xlsx/xlsm files"
 optional = true
 python-versions = ">=3.8"
 groups = ["main"]
-markers = "extra == \"qserver\""
+markers = "extra == \"qserver\" or extra == \"qs-client\""
 files = [
     {file = "openpyxl-3.1.5-py2.py3-none-any.whl", hash = "sha256:5282c12b107bffeef825f4617dc029afaf41d0ea60823bbb665ef3079dc79de2"},
     {file = "openpyxl-3.1.5.tar.gz", hash = "sha256:cf0e3cf56142039133628b5acffe8ef0c12bc902d2aadd3e0fe5878dc08d1050"},
@@ -3880,7 +3898,7 @@ description = "Bluesky hardware abstraction with an emphasis on EPICS"
 optional = true
 python-versions = ">=3.8"
 groups = ["main"]
-markers = "extra == \"qserver\""
+markers = "extra == \"qserver\" or extra == \"qs-client\""
 files = [
     {file = "ophyd-1.11.2-py3-none-any.whl", hash = "sha256:0254dbced299fbff1841b4f80102dd0e0c482176d5812a2246a08763acd87a75"},
     {file = "ophyd-1.11.2.tar.gz", hash = "sha256:ef63cc291a34d55823ec2f62be91991786ce4b9100e374df097b785d849466c3"},
@@ -4127,7 +4145,7 @@ description = "A Python Parser"
 optional = true
 python-versions = ">=3.6"
 groups = ["main"]
-markers = "extra == \"optimize\" or extra == \"qserver\""
+markers = "extra == \"optimize\" or extra == \"qserver\" or extra == \"qs-client\""
 files = [
     {file = "parso-0.8.7-py2.py3-none-any.whl", hash = "sha256:a8926eb2a1b915486941fdbd31e86a4baf88fe8c210f25f2f35ecec5b574ca1c"},
     {file = "parso-0.8.7.tar.gz", hash = "sha256:eaaac4c9fdd5e9e8852dc778d2d7405897ec510f2a298071453e5e3a07914bb1"},
@@ -4164,7 +4182,7 @@ description = "Pexpect allows easy control of interactive console applications."
 optional = true
 python-versions = "*"
 groups = ["main"]
-markers = "(extra == \"optimize\" or extra == \"qserver\") and sys_platform != \"win32\" and sys_platform != \"emscripten\""
+markers = "(extra == \"optimize\" or extra == \"qserver\" or extra == \"qs-client\") and sys_platform != \"win32\" and sys_platform != \"emscripten\""
 files = [
     {file = "pexpect-4.9.0-py2.py3-none-any.whl", hash = "sha256:7236d1e080e4936be2dc3e326cec0af72acf9212a7e1d060210e70a47e253523"},
     {file = "pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f"},
@@ -4289,7 +4307,7 @@ description = "Physical quantities module"
 optional = true
 python-versions = ">=3.11"
 groups = ["main"]
-markers = "extra == \"analysis\" or extra == \"optimize\" or extra == \"qserver\""
+markers = "extra == \"analysis\" or extra == \"optimize\" or extra == \"qserver\" or extra == \"qs-client\""
 files = [
     {file = "pint-0.25.3-py3-none-any.whl", hash = "sha256:27eb25143bd5de9fcc4d5a4b484f16faf6b4615aa93ece6b3373a8c1a3c1b97d"},
     {file = "pint-0.25.3.tar.gz", hash = "sha256:f8f5df6cf65314d74da1ade1bf96f8e3e4d0c41b51577ac53c49e7d44ca5acee"},
@@ -4324,7 +4342,7 @@ description = "A small Python package for determining appropriate platform-speci
 optional = true
 python-versions = ">=3.10"
 groups = ["main"]
-markers = "extra == \"analysis\" or extra == \"optimize\" or extra == \"qserver\" or extra == \"tiled\""
+markers = "extra == \"analysis\" or extra == \"optimize\" or extra == \"qserver\" or extra == \"qs-client\" or extra == \"tiled\""
 files = [
     {file = "platformdirs-4.9.6-py3-none-any.whl", hash = "sha256:e61adb1d5e5cb3441b4b7710bea7e4c12250ca49439228cc1021c00dcfac0917"},
     {file = "platformdirs-4.9.6.tar.gz", hash = "sha256:3bfa75b0ad0db84096ae777218481852c0ebc6c727b3168c1b9e0118e458cf0a"},
@@ -4353,7 +4371,7 @@ description = "Library for building powerful interactive command lines in Python
 optional = true
 python-versions = ">=3.8"
 groups = ["main"]
-markers = "extra == \"optimize\" or extra == \"qserver\""
+markers = "extra == \"optimize\" or extra == \"qserver\" or extra == \"qs-client\""
 files = [
     {file = "prompt_toolkit-3.0.52-py3-none-any.whl", hash = "sha256:9aac639a3bbd33284347de5ad8d68ecc044b91a762dc39b7c21095fcd6a19955"},
     {file = "prompt_toolkit-3.0.52.tar.gz", hash = "sha256:28cde192929c8e7321de85de1ddbe736f1375148b02f2e17edd840042b1be855"},
@@ -4407,7 +4425,7 @@ description = "Cross-platform lib for process and system monitoring."
 optional = true
 python-versions = ">=3.6"
 groups = ["main"]
-markers = "(extra == \"optimize\" or extra == \"qserver\") and sys_platform != \"emscripten\" and sys_platform != \"cygwin\" or extra == \"qserver\""
+markers = "(extra == \"optimize\" or extra == \"qserver\" or extra == \"qs-client\") and sys_platform != \"emscripten\" and sys_platform != \"cygwin\" or extra == \"qserver\" or extra == \"qs-client\""
 files = [
     {file = "psutil-7.2.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:2edccc433cbfa046b980b0df0171cd25bcaeb3a68fe9022db0979e7aa74a826b"},
     {file = "psutil-7.2.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:e78c8603dcd9a04c7364f1a3e670cea95d51ee865e4efb3556a3a63adef958ea"},
@@ -4443,7 +4461,7 @@ description = "Run a subprocess in a pseudo terminal"
 optional = true
 python-versions = "*"
 groups = ["main"]
-markers = "(extra == \"optimize\" or extra == \"qserver\") and sys_platform != \"win32\" and sys_platform != \"emscripten\""
+markers = "(extra == \"optimize\" or extra == \"qserver\" or extra == \"qs-client\") and sys_platform != \"win32\" and sys_platform != \"emscripten\""
 files = [
     {file = "ptyprocess-0.7.0-py2.py3-none-any.whl", hash = "sha256:4b41f3967fce3af57cc7e94b888626c18bf37a083e3651ca8feeb66d492fef35"},
     {file = "ptyprocess-0.7.0.tar.gz", hash = "sha256:5c5d0a3b48ceee0b48485e0c26037c0acd7d29765ca3fbb5cb3831d347423220"},
@@ -4456,7 +4474,7 @@ description = "Safely evaluate AST nodes without side effects"
 optional = true
 python-versions = "*"
 groups = ["main"]
-markers = "extra == \"optimize\" or extra == \"qserver\""
+markers = "extra == \"optimize\" or extra == \"qserver\" or extra == \"qs-client\""
 files = [
     {file = "pure_eval-0.2.3-py3-none-any.whl", hash = "sha256:1db8e35b67b3d218d818ae653e27f06c3aa420901fa7b081ca98cbedc874e0d0"},
     {file = "pure_eval-0.2.3.tar.gz", hash = "sha256:5f4e983f40564c576c7c8635ae88db5956bb2229d7e9237d03b3c0b0190eaf42"},
@@ -4591,7 +4609,7 @@ description = "C parser in Python"
 optional = true
 python-versions = ">=3.10"
 groups = ["main"]
-markers = "extra == \"qserver\" and implementation_name == \"pypy\" or extra == \"optimize\" and implementation_name != \"PyPy\""
+markers = "(extra == \"qserver\" or extra == \"qs-client\") and implementation_name == \"pypy\" or extra == \"optimize\" and implementation_name != \"PyPy\""
 files = [
     {file = "pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992"},
     {file = "pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29"},
@@ -4804,7 +4822,7 @@ description = "Pygments is a syntax highlighting package written in Python."
 optional = true
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "extra == \"tiled\" or extra == \"optimize\" or extra == \"qserver\""
+markers = "extra == \"tiled\" or extra == \"optimize\" or extra == \"qserver\" or extra == \"qs-client\""
 files = [
     {file = "pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176"},
     {file = "pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f"},
@@ -5073,7 +5091,7 @@ description = "A streaming multipart parser for Python"
 optional = true
 python-versions = ">=3.10"
 groups = ["main"]
-markers = "extra == \"qserver\""
+markers = "extra == \"qserver\" or extra == \"qs-client\""
 files = [
     {file = "python_multipart-0.0.32-py3-none-any.whl", hash = "sha256:ff6d3f776f16878c894e52e107296ffc890e913c611b1a4ec6c44e2821fe2e23"},
     {file = "python_multipart-0.0.32.tar.gz", hash = "sha256:be54b7f3fa167bb83e4fcd936b887b708f4e57fe75911c02aebf53efaf8d938e"},
@@ -5181,7 +5199,7 @@ description = "Python bindings for 0MQ"
 optional = true
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "extra == \"qserver\""
+markers = "extra == \"qserver\" or extra == \"qs-client\""
 files = [
     {file = "pyzmq-27.2.0-cp310-cp310-macosx_10_15_universal2.whl", hash = "sha256:480dba27b145373b5e103890f17969d891bc9e86746d6b8b29dd70b0d4addc62"},
     {file = "pyzmq-27.2.0-cp310-cp310-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:722f0a6940be1a483c81029a271d950e04dc2ff113a42e21b3d2b7a0d8e59638"},
@@ -5312,7 +5330,7 @@ description = "Python client for Redis database and key-value store"
 optional = true
 python-versions = ">=3.10"
 groups = ["main"]
-markers = "extra == \"qserver\""
+markers = "extra == \"qserver\" or extra == \"qs-client\""
 files = [
     {file = "redis-8.1.0-py3-none-any.whl", hash = "sha256:a4fe1aac3d3b3cc791d4b3d5931c5a956045dc951ee74d1c913ee3ac4d2ee9fb"},
     {file = "redis-8.1.0.tar.gz", hash = "sha256:6e1a19beef9225c83efd689c7e6b7da2d5215b1f42cd13b7fc3714d0a09c7b25"},
@@ -5416,7 +5434,7 @@ description = "Manipulate well-formed Roman numerals"
 optional = true
 python-versions = ">=3.10"
 groups = ["main"]
-markers = "extra == \"qserver\""
+markers = "extra == \"qserver\" or extra == \"qs-client\""
 files = [
     {file = "roman_numerals-4.1.0-py3-none-any.whl", hash = "sha256:647ba99caddc2cc1e55a51e4360689115551bf4476d90e8162cf8c345fe233c7"},
     {file = "roman_numerals-4.1.0.tar.gz", hash = "sha256:1af8b147eb1405d5839e78aeb93131690495fe9da5c91856cb33ad55a7f1e5b2"},
@@ -6006,7 +6024,7 @@ description = "This package provides 36 stemmers for 34 languages generated from
 optional = true
 python-versions = ">=3.3"
 groups = ["main"]
-markers = "extra == \"qserver\""
+markers = "extra == \"qserver\" or extra == \"qs-client\""
 files = [
     {file = "snowballstemmer-3.1.1-py3-none-any.whl", hash = "sha256:7e207fa178741da09cdee59d3ecec3827ad5f92b1fc5c9ff3755b639f71f5752"},
     {file = "snowballstemmer-3.1.1.tar.gz", hash = "sha256:e07bbc54a0d798fe6010a12398422e62a8bfbba95c394fd0956ef58cb4d3e260"},
@@ -6046,7 +6064,7 @@ description = "Python documentation generator"
 optional = true
 python-versions = ">=3.11"
 groups = ["main"]
-markers = "extra == \"qserver\""
+markers = "extra == \"qserver\" or extra == \"qs-client\""
 files = [
     {file = "sphinx-9.0.4-py3-none-any.whl", hash = "sha256:5bebc595a5e943ea248b99c13814c1c5e10b3ece718976824ffa7959ff95fffb"},
     {file = "sphinx-9.0.4.tar.gz", hash = "sha256:594ef59d042972abbc581d8baa577404abe4e6c3b04ef61bd7fc2acbd51f3fa3"},
@@ -6078,7 +6096,7 @@ description = "sphinxcontrib-applehelp is a Sphinx extension which outputs Apple
 optional = true
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "extra == \"qserver\""
+markers = "extra == \"qserver\" or extra == \"qs-client\""
 files = [
     {file = "sphinxcontrib_applehelp-2.0.0-py3-none-any.whl", hash = "sha256:4cd3f0ec4ac5dd9c17ec65e9ab272c9b867ea77425228e68ecf08d6b28ddbdb5"},
     {file = "sphinxcontrib_applehelp-2.0.0.tar.gz", hash = "sha256:2f29ef331735ce958efa4734873f084941970894c6090408b079c61b2e1c06d1"},
@@ -6096,7 +6114,7 @@ description = "sphinxcontrib-devhelp is a sphinx extension which outputs Devhelp
 optional = true
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "extra == \"qserver\""
+markers = "extra == \"qserver\" or extra == \"qs-client\""
 files = [
     {file = "sphinxcontrib_devhelp-2.0.0-py3-none-any.whl", hash = "sha256:aefb8b83854e4b0998877524d1029fd3e6879210422ee3780459e28a1f03a8a2"},
     {file = "sphinxcontrib_devhelp-2.0.0.tar.gz", hash = "sha256:411f5d96d445d1d73bb5d52133377b4248ec79db5c793ce7dbe59e074b4dd1ad"},
@@ -6114,7 +6132,7 @@ description = "sphinxcontrib-htmlhelp is a sphinx extension which renders HTML h
 optional = true
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "extra == \"qserver\""
+markers = "extra == \"qserver\" or extra == \"qs-client\""
 files = [
     {file = "sphinxcontrib_htmlhelp-2.1.0-py3-none-any.whl", hash = "sha256:166759820b47002d22914d64a075ce08f4c46818e17cfc9470a9786b759b19f8"},
     {file = "sphinxcontrib_htmlhelp-2.1.0.tar.gz", hash = "sha256:c9e2916ace8aad64cc13a0d233ee22317f2b9025b9cf3295249fa985cc7082e9"},
@@ -6132,7 +6150,7 @@ description = "A sphinx extension which renders display math in HTML via JavaScr
 optional = true
 python-versions = ">=3.5"
 groups = ["main"]
-markers = "extra == \"qserver\""
+markers = "extra == \"qserver\" or extra == \"qs-client\""
 files = [
     {file = "sphinxcontrib-jsmath-1.0.1.tar.gz", hash = "sha256:a9925e4a4587247ed2191a22df5f6970656cb8ca2bd6284309578f2153e0c4b8"},
     {file = "sphinxcontrib_jsmath-1.0.1-py2.py3-none-any.whl", hash = "sha256:2ec2eaebfb78f3f2078e73666b1415417a116cc848b72e5172e596c871103178"},
@@ -6148,7 +6166,7 @@ description = "sphinxcontrib-qthelp is a sphinx extension which outputs QtHelp d
 optional = true
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "extra == \"qserver\""
+markers = "extra == \"qserver\" or extra == \"qs-client\""
 files = [
     {file = "sphinxcontrib_qthelp-2.0.0-py3-none-any.whl", hash = "sha256:b18a828cdba941ccd6ee8445dbe72ffa3ef8cbe7505d8cd1fa0d42d3f2d5f3eb"},
     {file = "sphinxcontrib_qthelp-2.0.0.tar.gz", hash = "sha256:4fe7d0ac8fc171045be623aba3e2a8f613f8682731f9153bb2e40ece16b9bbab"},
@@ -6166,7 +6184,7 @@ description = "sphinxcontrib-serializinghtml is a sphinx extension which outputs
 optional = true
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "extra == \"qserver\""
+markers = "extra == \"qserver\" or extra == \"qs-client\""
 files = [
     {file = "sphinxcontrib_serializinghtml-2.0.0-py3-none-any.whl", hash = "sha256:6e2cb0eef194e10c27ec0023bfeb25badbbb5868244cf5bc5bdc04e4464bf331"},
     {file = "sphinxcontrib_serializinghtml-2.0.0.tar.gz", hash = "sha256:e9d912827f872c029017a53f0ef2180b327c3f7fd23c87229f7a8e8b70031d4d"},
@@ -6184,7 +6202,7 @@ description = "Extract data from python stack frames and tracebacks for informat
 optional = true
 python-versions = "*"
 groups = ["main"]
-markers = "extra == \"optimize\" or extra == \"qserver\""
+markers = "extra == \"optimize\" or extra == \"qserver\" or extra == \"qs-client\""
 files = [
     {file = "stack_data-0.6.3-py3-none-any.whl", hash = "sha256:d5558e0c25a4cb0853cddad3d77da9891a08cb85dd9f9f91b9f8cd66e511e695"},
     {file = "stack_data-0.6.3.tar.gz", hash = "sha256:836a778de4fec4dcd1dcd89ed8abff8a221f58308462e1c4aa2a3cf30148f0b9"},
@@ -6432,7 +6450,7 @@ description = "Tornado is a Python web framework and asynchronous networking lib
 optional = true
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "extra == \"qserver\""
+markers = "extra == \"qserver\" or extra == \"qs-client\""
 files = [
     {file = "tornado-6.5.8-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:cc6aa787d7cfab7c3d35189dc7a56fbd2399a569624c730c6b55b3d6531d0403"},
     {file = "tornado-6.5.8-cp39-abi3-macosx_10_9_x86_64.whl", hash = "sha256:9715b5eb79735b2bcd454ce216a9275b7c0470e64ea1bf5742f78b2f72b26eeb"},
@@ -6475,7 +6493,7 @@ description = "Traitlets Python configuration system"
 optional = true
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "extra == \"optimize\" or extra == \"qserver\""
+markers = "extra == \"optimize\" or extra == \"qserver\" or extra == \"qs-client\""
 files = [
     {file = "traitlets-5.15.1-py3-none-any.whl", hash = "sha256:770a53705f84b81ac107e83a1b3328ff2dae16094d8fc3cfc004e4b22dfd8e92"},
     {file = "traitlets-5.15.1.tar.gz", hash = "sha256:7b1c07854fe25acb39e009bae49f11b79ff6cbb2f27999104e9110e7a6b53722"},
@@ -6813,7 +6831,7 @@ description = "Measures the displayed width of unicode strings in a terminal"
 optional = true
 python-versions = ">=3.8"
 groups = ["main"]
-markers = "extra == \"optimize\" or extra == \"qserver\""
+markers = "extra == \"optimize\" or extra == \"qserver\" or extra == \"qs-client\""
 files = [
     {file = "wcwidth-0.8.2-py3-none-any.whl", hash = "sha256:d63947694a0539a1d51e01eda7caf800c291020e6cdd7e28ad7b14dd33ad4f85"},
     {file = "wcwidth-0.8.2.tar.gz", hash = "sha256:91fbef97204b96a3d4d421609b80340b760cf33e26da123ff243d76b1fda8dda"},
@@ -6826,7 +6844,7 @@ description = "An implementation of the WebSocket Protocol (RFC 6455 & 7692)"
 optional = true
 python-versions = ">=3.10"
 groups = ["main"]
-markers = "extra == \"tiled\""
+markers = "extra == \"tiled\" or extra == \"qs-client\""
 files = [
     {file = "websockets-16.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:04cdd5d2d1dacbad0a7bf36ccbcd3ccd5a30ee188f2560b7a62a30d14107b31a"},
     {file = "websockets-16.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:8ff32bb86522a9e5e31439a58addbb0166f0204d64066fb955265c4e214160f0"},
@@ -7099,10 +7117,11 @@ cffi = ["cffi (>=1.17,<2.0) ; platform_python_implementation != \"PyPy\" and pyt
 analysis = ["imageanalysis"]
 ca = ["aioca"]
 optimize = ["gest-api", "imageanalysis", "scananalysis", "xopt"]
+qs-client = ["bluesky-queueserver-api"]
 qserver = ["bluesky-queueserver"]
 tiled = ["tiled"]
 
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<3.12"
-content-hash = "b12586b5aea43e9a1dff4b78b15db4f9d579ab650c5ab0190edd7cef0d427125"
+content-hash = "e6e4b228cac50a47879583ad091afde3289321a948854ad5013e4b5dc8d868fe"

--- a/GeecsBluesky/pyproject.toml
+++ b/GeecsBluesky/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-bluesky"
-version = "0.57.3"
+version = "0.58.0"
 description = "Bluesky / ophyd-async bridge for the GEECS control system"
 authors = ["Sam Barber <sbarber@lbl.gov>"]
 readme = "README.md"
@@ -57,12 +57,20 @@ scananalysis = { path = "../ScanAnalysis", develop = true, optional = true }
 # Troubleshooting).
 bluesky-queueserver = { version = "^0.0.25", optional = true }
 
+# The client side of the queue (geecs_bluesky/qs_client/ — extracted from
+# GEECS-Console 2026-08-21): queue submission, status polling, and the
+# manual function verbs for ANY manager client (console, notebooks, the
+# OSPREY scan MCP). Small (pyzmq + msgpack); optional so the worker and
+# headless installs don't carry it.
+bluesky-queueserver-api = { version = "^0.0.13", optional = true }
+
 [tool.poetry.extras]
 tiled = ["tiled"]
 analysis = ["imageanalysis"]
 ca = ["aioca"]
 optimize = ["xopt", "gest-api", "scananalysis", "imageanalysis"]
 qserver = ["bluesky-queueserver"]
+qs-client = ["bluesky-queueserver-api"]
 
 [tool.poetry.group.dev.dependencies]
 pytest = ">=7.0"

--- a/GeecsBluesky/pyproject.toml
+++ b/GeecsBluesky/pyproject.toml
@@ -60,8 +60,10 @@ bluesky-queueserver = { version = "^0.0.25", optional = true }
 # The client side of the queue (geecs_bluesky/qs_client/ — extracted from
 # GEECS-Console 2026-08-21): queue submission, status polling, and the
 # manual function verbs for ANY manager client (console, notebooks, the
-# OSPREY scan MCP). Small (pyzmq + msgpack); optional so the worker and
-# headless installs don't carry it.
+# OSPREY scan MCP). The api package itself is small, but it requires
+# bluesky-queueserver and thereby a heavy transitive closure (ipykernel,
+# jupyter-client, ophyd, redis, …) — do NOT treat this extra as a light
+# add. Optional so the worker and headless installs don't carry it.
 bluesky-queueserver-api = { version = "^0.0.13", optional = true }
 
 [tool.poetry.extras]

--- a/GeecsBluesky/qserver/README.md
+++ b/GeecsBluesky/qserver/README.md
@@ -28,8 +28,9 @@ default is `redis-server`.
 QS_REDIS_SERVER=/path/to/redis-server ./launch_re_manager.sh
 ```
 
-The startup directory defaults to `./startup` and can be overridden with
-`QS_STARTUP_DIR`.
+The startup directory defaults to the `startup/` folder beside the
+launcher (so the script works from any working directory) and can be
+overridden with `QS_STARTUP_DIR`.
 
 ```bash
 QS_STARTUP_DIR=/path/to/startup ./launch_re_manager.sh

--- a/GeecsBluesky/qserver/launch_re_manager.sh
+++ b/GeecsBluesky/qserver/launch_re_manager.sh
@@ -9,7 +9,11 @@ fi
 
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 PERMISSIONS_FILE="${SCRIPT_DIR}/user_group_permissions.yaml"
-QS_STARTUP_DIR="${QS_STARTUP_DIR:-./startup}"
+# Default beside this script, not the CWD — the launcher must work when
+# invoked from anywhere (a CWD-relative ./startup made a launch from the
+# package root fail with a missing-startup-dir error; live finding
+# 2026-08-21).
+QS_STARTUP_DIR="${QS_STARTUP_DIR:-${SCRIPT_DIR}/startup}"
 QS_REDIS_SERVER="${QS_REDIS_SERVER:-redis-server}"
 
 port_is_answering() {

--- a/GeecsBluesky/tests/qs_client/test_queue_client.py
+++ b/GeecsBluesky/tests/qs_client/test_queue_client.py
@@ -1,8 +1,10 @@
-"""Hermetic tests for the queueserver client seam (services/queue_client.py).
+"""Hermetic tests for the queueserver client seam (qs_client/client.py).
 
 No manager, no network: the real client's lazy ``REManagerAPI`` is replaced
 by setting the ``_api`` cache directly (the documented injection point for
-tests), and the config reader runs against a temp home.
+tests), and the config reader runs against a temp home.  The submit paths
+build ``BPlan``/``BFunc`` items, so the module needs the ``qs-client``
+extra (skipped whole without it — the optimize-extra pattern).
 """
 
 from __future__ import annotations
@@ -12,7 +14,9 @@ from pathlib import Path
 
 import pytest
 
-from geecs_console.services.queue_client import (
+pytest.importorskip("bluesky_queueserver_api")
+
+from geecs_bluesky.qs_client import (  # noqa: E402
     QserverConfig,
     QueueClient,
     QueueStatus,
@@ -25,9 +29,8 @@ from geecs_console.services.queue_client import (
 
 @pytest.fixture
 def home(tmp_path, monkeypatch):
-    # The reader expands ops_paths.USER_CONFIG_PATH ("~/...") — point the
-    # tilde at a temp home on both POSIX and Windows (the console-windows
-    # CI job runs this suite too).
+    # The reader expands the "~/..." config path — point the tilde at a
+    # temp home on both POSIX and Windows.
     monkeypatch.setenv("HOME", str(tmp_path))
     monkeypatch.setenv("USERPROFILE", str(tmp_path))
     return tmp_path
@@ -89,6 +92,14 @@ class TestStubQueueClient:
         assert not stub.request_pause()[0]
         with pytest.raises(RuntimeError, match=r"\[qserver\]"):
             stub.move_variable("x", 1.0)
+        with pytest.raises(RuntimeError, match=r"\[qserver\]"):
+            stub.run_action("close_shutters")
+        with pytest.raises(RuntimeError, match=r"\[qserver\]"):
+            stub.queue_items()
+
+    def test_stream_addresses_are_none(self):
+        stub = StubQueueClient()
+        assert stub.info_addr is None and stub.doc_addr is None
 
 
 class _FakeManagerAPI:
@@ -226,6 +237,26 @@ class TestZmqQueueClient:
         added = next(c[1] for c in fake.calls if c[0] == "item_add")
         assert added["name"] == "geecs_run_action_plan"
         assert added["args"] == ["close_shutters"]
+
+    def test_run_action_raises_the_refusal_with_pending_items(self):
+        # The raise-mapping the console's QueueSubmitter used to own.
+        fake = _FakeManagerAPI()
+        fake.queue_items = [{"item_uid": "old"}]
+        with pytest.raises(RuntimeError, match="queue not empty"):
+            _client(fake).run_action("close_shutters")
+
+    def test_stream_addresses_come_from_the_config(self):
+        client = _client(_FakeManagerAPI())
+        assert client.info_addr == "tcp://x:2"
+        assert client.doc_addr == "x:3"
+
+    def test_queue_and_history_read_verbs(self):
+        fake = _FakeManagerAPI()
+        fake.queue_items = [{"item_uid": "a"}]
+        fake.history_get = lambda: {"items": [{"item_uid": "done"}]}
+        client = _client(fake)
+        assert client.queue_items() == [{"item_uid": "a"}]
+        assert client.history_items() == [{"item_uid": "done"}]
 
     def test_stop_from_paused_stops_directly(self):
         fake = _FakeManagerAPI()

--- a/GeecsBluesky/tests/qs_client/test_submit_preflight.py
+++ b/GeecsBluesky/tests/qs_client/test_submit_preflight.py
@@ -10,8 +10,8 @@ from __future__ import annotations
 
 import pytest
 
-from geecs_console.services import submit_preflight
-from geecs_console.services.submit_preflight import (
+from geecs_bluesky.qs_client import submit_preflight
+from geecs_bluesky.qs_client.submit_preflight import (
     PreflightReport,
     run_submit_preflight,
     stamp_submission,

--- a/GeecsBluesky/tests/test_lazy_package_import.py
+++ b/GeecsBluesky/tests/test_lazy_package_import.py
@@ -1,0 +1,44 @@
+"""Pin the light-package-import contract (PEP 562 lazy device re-exports).
+
+The console's offline-first rule and the qs_client extraction both depend
+on it: ``import geecs_bluesky`` / ``import geecs_bluesky.qs_client`` must
+not pull the heavy device stack (ophyd-async/aioca) or the queueserver
+api — a client that only submits scans imports light.  Runs in a
+subprocess so the assertion is immune to whatever the pytest process has
+already imported.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+_LIGHT_IMPORT_CODE = """
+import sys
+
+import geecs_bluesky
+
+for heavy in ("aioca", "ophyd_async", "bluesky_queueserver_api"):
+    assert heavy not in sys.modules, f"package import pulled {heavy}"
+
+import geecs_bluesky.qs_client
+from geecs_bluesky.qs_client import make_queue_client  # noqa: F401
+
+for heavy in ("aioca", "ophyd_async", "bluesky_queueserver_api"):
+    assert heavy not in sys.modules, f"qs_client import pulled {heavy}"
+
+# The lazy re-exports still resolve (this leg MAY pull the device stack).
+from geecs_bluesky import CaMotor
+
+assert CaMotor.__name__ == "CaMotor"
+"""
+
+
+def test_package_and_qs_client_import_light() -> None:
+    """The package and qs_client import without the heavy device stack."""
+    result = subprocess.run(
+        [sys.executable, "-c", _LIGHT_IMPORT_CODE],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr

--- a/GeecsBluesky/tests/test_oneshot.py
+++ b/GeecsBluesky/tests/test_oneshot.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import asyncio
 import sys
+import threading
 import types
 
 import pytest
@@ -18,19 +19,25 @@ import pytest
 
 @pytest.fixture
 def fake_aioca(monkeypatch):
-    """Install a recording ``aioca`` whose caget notes its running loop."""
+    """Install a recording ``aioca`` whose caget notes its loop and thread.
+
+    The recorded entry keeps a strong reference to the **loop object**
+    (never its ``id()`` — a freed loop's address can be reused by the
+    next ``asyncio.run()`` loop, which made an id-based assertion pass
+    with the bug present; reviewer-caught on the extraction PR).
+    """
     module = types.ModuleType("aioca")
-    loop_ids: list[int] = []
+    calls: list[tuple[asyncio.AbstractEventLoop, str]] = []
 
     async def caget(pv, timeout=None, datatype=None):
-        loop_ids.append(id(asyncio.get_running_loop()))
+        calls.append((asyncio.get_running_loop(), threading.current_thread().name))
         if pv == "dead:pv":
             raise RuntimeError("no channel")
         return "Connected" if datatype is str else 42
 
     module.caget = caget
     monkeypatch.setitem(sys.modules, "aioca", module)
-    return loop_ids
+    return calls
 
 
 def test_reads_share_one_persistent_loop(fake_aioca):
@@ -38,10 +45,16 @@ def test_reads_share_one_persistent_loop(fake_aioca):
 
     assert caget_once("some:pv", timeout=1.0) == 42
     assert caget_once("other:pv", timeout=1.0) == 42
-    # THE contract: both reads ran on the same loop — a per-call
-    # asyncio.run() would record two distinct loop ids here.
+    # THE contract: both reads ran on the same loop object, on the shared
+    # reader thread.  A per-call asyncio.run() necessarily allocates a
+    # second loop (the recorded strong references keep the first alive,
+    # so no address reuse can alias them) and runs on the caller's
+    # thread, failing both assertions.
+    loops = {loop for loop, _thread in fake_aioca}
+    threads = {thread for _loop, thread in fake_aioca}
     assert len(fake_aioca) == 2
-    assert len(set(fake_aioca)) == 1
+    assert len(loops) == 1
+    assert threads == {"geecs-ca-oneshot"}
 
 
 def test_datatype_is_forwarded(fake_aioca):

--- a/GeecsBluesky/tests/test_oneshot.py
+++ b/GeecsBluesky/tests/test_oneshot.py
@@ -1,0 +1,58 @@
+"""Pin the one-persistent-loop contract of ``devices/ca/oneshot``.
+
+The module exists to close the aioca loop-cache leak: a per-call
+``asyncio.run()`` gives every read a fresh event loop, re-creating the CA
+channel each time and stranding the previous loop's cache entries.  The
+fix is only real if every read runs on the SAME loop — that is what these
+tests pin (a revert to per-call ``asyncio.run`` fails them).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+import types
+
+import pytest
+
+
+@pytest.fixture
+def fake_aioca(monkeypatch):
+    """Install a recording ``aioca`` whose caget notes its running loop."""
+    module = types.ModuleType("aioca")
+    loop_ids: list[int] = []
+
+    async def caget(pv, timeout=None, datatype=None):
+        loop_ids.append(id(asyncio.get_running_loop()))
+        if pv == "dead:pv":
+            raise RuntimeError("no channel")
+        return "Connected" if datatype is str else 42
+
+    module.caget = caget
+    monkeypatch.setitem(sys.modules, "aioca", module)
+    return loop_ids
+
+
+def test_reads_share_one_persistent_loop(fake_aioca):
+    from geecs_bluesky.devices.ca.oneshot import caget_once
+
+    assert caget_once("some:pv", timeout=1.0) == 42
+    assert caget_once("other:pv", timeout=1.0) == 42
+    # THE contract: both reads ran on the same loop — a per-call
+    # asyncio.run() would record two distinct loop ids here.
+    assert len(fake_aioca) == 2
+    assert len(set(fake_aioca)) == 1
+
+
+def test_datatype_is_forwarded(fake_aioca):
+    from geecs_bluesky.devices.ca.oneshot import caget_once
+
+    assert caget_once("enum:pv", timeout=1.0, datatype=str) == "Connected"
+
+
+def test_caget_once_raises_and_try_variant_fails_open(fake_aioca):
+    from geecs_bluesky.devices.ca.oneshot import caget_once, try_caget_once
+
+    with pytest.raises(RuntimeError, match="no channel"):
+        caget_once("dead:pv", timeout=1.0)
+    assert try_caget_once("dead:pv", timeout=1.0) is None


### PR DESCRIPTION
## What + why

The console is one queue client among several — notebooks and the coming OSPREY scan MCP submit the same `ScanRequest` dicts through the same verbs — so the RE Manager client machinery moves out of the GUI package into `geecs_bluesky/qs_client/` (the follow-up Sam green-lit from the post-migration organizational assessment).

**The move (the core concern, ~1,000 LOC moved):**
- `GEECS-Console/geecs_console/services/queue_client.py` → `geecs_bluesky/qs_client/client.py`; `services/submit_preflight.py` → `qs_client/submit_preflight.py` (checks + `stamp_submission` unchanged in behavior).
- The twin protocols collapse into **one**: `QueueClient` absorbed the console's `Submitter` (the `run_action` raise-mapping and the `info_addr`/`doc_addr` stream addresses now live on the client; the `QueueSubmitter` adapter is deleted). The console keeps `Submitter` as a documented alias plus `make_queue_submitter`, which stamps the `geecs-console` submitted-as identity — `geecs_console/submission.py` is now ~55 lines.
- New GeecsBluesky extra `qs-client` carries `bluesky-queueserver-api` (lazy inside methods); the console drops its direct dependency and rides the extra.
- Tests moved to `GeecsBluesky/tests/qs_client/` (module skips whole without the extra — the optimize-extra pattern; CI installs `--extras qs-client`).

**Riding along, each flagged for cheap veto (judgment calls):**
- **PEP 562 lazy device re-exports in `geecs_bluesky/__init__`** (~40 LOC): the package import no longer pays for aioca/ophyd-async, so a client that only submits scans imports light. `from geecs_bluesky import CaMotor` still works; `apply_epics_address_config()` still runs before any device import (laziness preserves the ordering because every `devices` import runs the package init first).
- **`devices/ca/oneshot.py`** (~100 LOC, closes the aioca-leak chip): the one blessed one-shot blocking CA read on a single persistent reader loop — the per-call `asyncio.run()` in the preflight and the console health probe re-created CA channels and leaked aioca's per-loop cache on every read (the health probe polls every 5 s, forever). Both call sites switched.
- **`queue_items()` / `history_items()` read verbs** (~30 LOC): the first gap the OSPREY MCP planning pass flagged — read-only queue/history inspection for non-GUI clients.
- **Launcher CWD fix** (1 line + comment, closes the launcher chip): `QS_STARTUP_DIR` defaults to `${SCRIPT_DIR}/startup` instead of `./startup` (live finding 2026-08-21 — launching from the package root failed).

## Tests

- GeecsBluesky: **594 passed, 3 deselected** (includes the 38 moved/extended qs_client tests; new pins: `run_action` refusal mapping, stream addresses, read verbs).
- GEECS-Console: **785 passed** (offscreen).
- `./scripts/check.sh GeecsBluesky GEECS-Console` green end to end.
- Lazy-import contract **pinned by test** (`tests/test_lazy_package_import.py`, added on review finding 1a): `import geecs_bluesky.qs_client` loads neither `aioca`, `ophyd_async`, nor `bluesky_queueserver_api`; `from geecs_bluesky import CaMotor` still resolves.
- oneshot one-loop contract pinned (`tests/test_oneshot.py`, review finding 1b): repeated `caget_once` reads share ONE persistent loop — a revert to per-call `asyncio.run` fails it.
- The qs_client suite keeps a Windows CI leg via the `console-windows` job (review finding 3).

## Hardware verification (live, this branch)

Headless submission through the new import path — the notebook story — verified on Undulator hardware 2026-08-21 (laser off, `HTU-LaserOFF` trigger profile): **Scan014**, a 5-shot free-run noscan on save set `Amp4In`, submitted via `geecs_bluesky.qs_client` (`run_submit_preflight` → staleness question answered `continued` → `stamp_submission` → `submit_scan`), completed clean (`exit_status: completed`), and the run metadata carries the full `SubmissionRecord` (`client: "geecs-bluesky qs_client 0.58.0 (extraction smoke)"`, aware timestamp, all four preflight outcomes). The new `queue_items()`/`history_items()` verbs were exercised live against the manager in the same session. Nothing owed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
