### PR TITLE
GeecsBluesky 0.59.0: worker-side CONNECTED re-check + t0-sync liveness gate (#664)

### DIFF
--- a/GeecsBluesky/CHANGELOG.md
+++ b/GeecsBluesky/CHANGELOG.md
@@ -13,23 +13,39 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   sat queued, and the dead free-run reference surfaced only as a cryptic
   mid-scan `GeecsTriggerTimeoutError`).  `_preflight_connected` runs
   pre-claim on all four execution paths (runner + queue plan, scan and
-  optimize): a Disconnected **load-bearing** device — free-run's
-  reference, or any synchronous device in strict mode — refuses with
-  `GeecsDeviceDownError` naming it (no scan number burned); any other
-  Disconnected device warns and continues, recorded in run metadata as
-  `disconnected_devices`.  Fail-open per the liveness doctrine: an
-  unreadable PV, no experiment, or missing CA support is never a
-  verdict.  The client-side pre-submit read stays — this covers the
-  submission-to-execution gap and clients that skip preflight.
+  optimize): a Disconnected **synchronous** device refuses with
+  `GeecsDeviceDownError` naming it (no scan number burned) in both
+  modes — strict rows await every sync device, and a dead free-run sync
+  device would fail t0 sync post-claim anyway (its stale cached
+  timestamp blows the spread window), so a softer disposition would
+  just defer the same death past the claim (review finding on the PR).
+  A Disconnected asynchronous (snapshot) device warns and continues,
+  recorded in run metadata as `disconnected_devices`.  Fail-open per
+  the liveness doctrine: an unreadable PV, no experiment, or missing CA
+  support is never a verdict.  The client-side pre-submit read stays —
+  this covers the submission-to-execution gap and clients that skip
+  preflight.
 - **t0-sync liveness gate**: `geecs_t0_sync` refuses to seed from a
   device whose `connected_status` reads the exact `Disconnected` choice
-  string (in-plan `bps.rd`, the strict refire gate's read; fail-open
-  otherwise).  The seed comes from the *cached* `acq_timestamp` under a
-  quiescent trigger, and a dead device serves its stale cache forever —
-  with one sync device the spread check is trivially satisfied and the
-  failure deferred to the mid-scan timeout above.  Timestamp freshness
+  string (in-plan, the strict refire gate's read; fail-open otherwise).
+  The seed comes from the *cached* `acq_timestamp` under a quiescent
+  trigger, and a dead device serves its stale cache forever — with one
+  sync device the spread check is trivially satisfied and the failure
+  deferred to the mid-scan timeout above.  Timestamp freshness
   deliberately cannot be the guard: at rest with the trigger parked
   (laser-off operation) a *healthy* cache is legitimately hours old.
+- **The liveness idioms consolidated into two shared homes** (review
+  finding — four hand-rolled copies risked silent drift of the
+  fail-open convention): `devices/ca/liveness.py::probe_disconnected`,
+  the out-of-plan CONNECTED probe (concurrent batch via the new
+  `oneshot.try_caget_many` — one timeout budget regardless of device
+  count, so the queue-plan preamble never blocks the RE loop per
+  device; owns the DBR_ENUM `datatype=str` subtlety; now used by BOTH
+  the client-side preflight and the worker re-check), and
+  `plans/liveness.py::rd_confirmed_down`, the in-plan read on built
+  devices (now used by BOTH the strict refire gate and the t0 seed
+  gate).  `oneshot.py`'s contract text names the pre-claim preamble as
+  its one sanctioned in-plan use (the devices don't exist yet).
 
 ## [0.58.0] - 2026-08-21
 

--- a/GeecsBluesky/CHANGELOG.md
+++ b/GeecsBluesky/CHANGELOG.md
@@ -4,6 +4,33 @@ All notable changes to `geecs-bluesky` are documented here.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.59.0] - 2026-08-22
+
+### Added
+
+- **Worker-side CONNECTED liveness re-check at execution** (#664 — live
+  incident 2026-08-22: a camera server rebooted uncleanly while items
+  sat queued, and the dead free-run reference surfaced only as a cryptic
+  mid-scan `GeecsTriggerTimeoutError`).  `_preflight_connected` runs
+  pre-claim on all four execution paths (runner + queue plan, scan and
+  optimize): a Disconnected **load-bearing** device — free-run's
+  reference, or any synchronous device in strict mode — refuses with
+  `GeecsDeviceDownError` naming it (no scan number burned); any other
+  Disconnected device warns and continues, recorded in run metadata as
+  `disconnected_devices`.  Fail-open per the liveness doctrine: an
+  unreadable PV, no experiment, or missing CA support is never a
+  verdict.  The client-side pre-submit read stays — this covers the
+  submission-to-execution gap and clients that skip preflight.
+- **t0-sync liveness gate**: `geecs_t0_sync` refuses to seed from a
+  device whose `connected_status` reads the exact `Disconnected` choice
+  string (in-plan `bps.rd`, the strict refire gate's read; fail-open
+  otherwise).  The seed comes from the *cached* `acq_timestamp` under a
+  quiescent trigger, and a dead device serves its stale cache forever —
+  with one sync device the spread check is trivially satisfied and the
+  failure deferred to the mid-scan timeout above.  Timestamp freshness
+  deliberately cannot be the guard: at rest with the trigger parked
+  (laser-off operation) a *healthy* cache is legitimately hours old.
+
 ## [0.58.0] - 2026-08-21
 
 ### Added

--- a/GeecsBluesky/CLAUDE.md
+++ b/GeecsBluesky/CLAUDE.md
@@ -137,10 +137,14 @@ geecs_bluesky/
       action_signals.py     # CaActionSignalFactory — the production
                             #   SettableFactory for compiled action plans
                             #   (cached :SP settables + str readbacks)
-      oneshot.py            # caget_once/try_caget_once — THE one-shot
-                            #   blocking CA read (one persistent reader
-                            #   loop; a per-call asyncio.run leaks aioca's
-                            #   per-loop channel cache)
+      oneshot.py            # caget_once/try_caget_once/try_caget_many —
+                            #   THE one-shot blocking CA read (one
+                            #   persistent reader loop; a per-call
+                            #   asyncio.run leaks aioca's per-loop cache)
+      liveness.py           # probe_disconnected — THE out-of-plan
+                            #   CONNECTED probe (concurrent batch, the
+                            #   DBR_ENUM datatype=str subtlety in one
+                            #   place); in-plan twin: plans/liveness.py
       gateway_put.py        # GatewaySetpointPut — THE one gateway :SP put
                             #   primitive (addressing rule ca://-vs-bare,
                             #   wire conventions, timeout, mock); every
@@ -594,15 +598,22 @@ console's pre-submit CONNECTED/staleness reads are their successors.)
 Since 0.59.0 the worker **re-checks CONNECTED at execution** too
 (`_preflight_connected`, pre-claim on all four runner/queue-plan paths —
 the submission-to-execution gap is long and clients can skip preflight;
-live incident 2026-08-22, issue #664): a Disconnected **load-bearing**
-device refuses with `GeecsDeviceDownError` (free-run: the reference;
-strict: any synchronous device), others warn-and-continue with the list
-recorded as `disconnected_devices` in run metadata; unreadable is never
-a verdict (fail-open).  `geecs_t0_sync` carries the same gate in-plan
-(`connected_status` read; a dead device's stale cache must never seed
-t0 — timestamp freshness deliberately cannot be the guard, because a
-parked trigger at laser-off rest makes a *healthy* cache legitimately
-old).
+live incident 2026-08-22, issue #664): a Disconnected **synchronous**
+device refuses with `GeecsDeviceDownError` in both modes (strict rows
+await all of them; a dead free-run sync device would fail t0 sync
+post-claim anyway, so warn-and-continue there would be a fiction),
+while a Disconnected asynchronous (snapshot) device warns-and-continues
+with the list recorded as `disconnected_devices` in run metadata;
+unreadable is never a verdict (fail-open).  `geecs_t0_sync` carries the
+same gate in-plan (a dead device's stale cache must never seed t0 —
+timestamp freshness deliberately cannot be the guard, because a parked
+trigger at laser-off rest makes a *healthy* cache legitimately old).
+The liveness idioms live in exactly two shared homes so the fail-open
+convention cannot drift: `devices/ca/liveness.py::probe_disconnected`
+(out-of-plan, concurrent batch — one timeout budget regardless of
+device count, used by the client preflight AND the worker re-check) and
+`plans/liveness.py::rd_confirmed_down` (in-plan `connected_status` read
+on built devices, used by the strict refire gate and the t0 seed gate).
 
 `ScanRequest` execution (`scan_request_runner` / `GeecsSession.run`) runs
 the full schema surface as of 0.23.0 (M3b): **actions execute**

--- a/GeecsBluesky/CLAUDE.md
+++ b/GeecsBluesky/CLAUDE.md
@@ -591,6 +591,18 @@ whose DB failure reads as *unknown* (check skipped with one warning),
 never as *empty*.  (The old device-level `GatewayLivenessCheck` /
 `FreeRunStalenessCheck` were bridge-hook-only and died with it; the
 console's pre-submit CONNECTED/staleness reads are their successors.)
+Since 0.59.0 the worker **re-checks CONNECTED at execution** too
+(`_preflight_connected`, pre-claim on all four runner/queue-plan paths —
+the submission-to-execution gap is long and clients can skip preflight;
+live incident 2026-08-22, issue #664): a Disconnected **load-bearing**
+device refuses with `GeecsDeviceDownError` (free-run: the reference;
+strict: any synchronous device), others warn-and-continue with the list
+recorded as `disconnected_devices` in run metadata; unreadable is never
+a verdict (fail-open).  `geecs_t0_sync` carries the same gate in-plan
+(`connected_status` read; a dead device's stale cache must never seed
+t0 — timestamp freshness deliberately cannot be the guard, because a
+parked trigger at laser-off rest makes a *healthy* cache legitimately
+old).
 
 `ScanRequest` execution (`scan_request_runner` / `GeecsSession.run`) runs
 the full schema surface as of 0.23.0 (M3b): **actions execute**
@@ -783,8 +795,10 @@ Remaining items are features/tuning, not architecture.
   streams instead).  Liveness remains CONNECTED-based (the gateway serves
   every DB device's data PVs whether or not the device is up, so
   CA-connect success never implied liveness) — read pre-submit by the
-  console's preflight; its staleness sample window still deserves a lab
-  session of tuning against real rep rates.
+  console's preflight AND re-checked at execution by the worker since
+  0.59.0 (`_preflight_connected` + the t0-sync gate, #664); the
+  client-side staleness sample window still deserves a lab session of
+  tuning against real rep rates.
 - **Scalar s-files are exported from Tiled best-effort** after a scan when the
   Tiled client extra is installed and the run can be read back.  Legacy TDMS
   output is not produced.

--- a/GeecsBluesky/geecs_bluesky/devices/ca/liveness.py
+++ b/GeecsBluesky/geecs_bluesky/devices/ca/liveness.py
@@ -1,0 +1,69 @@
+"""The one out-of-plan CONNECTED liveness probe.
+
+``CONNECTED`` is the authoritative liveness signal (the gateway serves
+every DB device's data PVs whether or not the device is up, so CA-connect
+success never implies liveness), and reading it correctly has one sharp
+edge worth keeping in exactly one place: the PV is a **DBR_ENUM**, so the
+read must pass ``datatype=str`` — a native read returns the integer index,
+which can never match the ``"Disconnected"`` choice string.
+
+Consumers: the client-side pre-submit preflight
+(:mod:`geecs_bluesky.qs_client.submit_preflight`) and the worker's
+pre-claim re-check (:func:`geecs_bluesky.scan_request_runner._preflight_connected`).
+In-plan liveness reads on *built* devices go through their
+``connected_status`` signal instead (:mod:`geecs_bluesky.plans.liveness`).
+
+``aioca`` is imported lazily on first use (the ``ca`` extra).
+"""
+
+from __future__ import annotations
+
+from typing import Iterable
+
+#: CA read budget for one probe batch (seconds) — concurrent, so N dead
+#: PVs cost one budget, not N.
+DEFAULT_PROBE_TIMEOUT_S = 2.0
+
+
+def probe_disconnected(
+    experiment: str,
+    device_names: Iterable[str],
+    *,
+    timeout: float = DEFAULT_PROBE_TIMEOUT_S,
+) -> list[str]:
+    """Return the devices whose gateway ``CONNECTED`` PV reads ``Disconnected``.
+
+    Fail-open per the liveness doctrine: an unreadable PV is not a
+    verdict — only the exact ``Disconnected`` choice string counts.  All
+    reads run concurrently on the shared one-shot loop, so the worst case
+    costs one *timeout* budget regardless of device count.
+
+    Parameters
+    ----------
+    experiment : str
+        The experiment PV prefix.
+    device_names :
+        GEECS device names to probe.
+    timeout : float
+        CA read budget for the whole batch, in seconds.
+
+    Returns
+    -------
+    list of str
+        The subset of *device_names* confirmed down, in input order.
+    """
+    from geecs_bluesky.devices.ca._pv import GATEWAY_DISCONNECTED, ca_pv
+    from geecs_bluesky.devices.ca.gateway_put import bare_pv
+    from geecs_bluesky.devices.ca.oneshot import try_caget_many
+
+    names = list(device_names)
+    if not names:
+        return []
+    pvs = [bare_pv(ca_pv(experiment, device, "CONNECTED")) for device in names]
+    # datatype=str is load-bearing — see the module docstring.
+    readings = try_caget_many(pvs, timeout=timeout, datatype=str)
+    return [
+        device
+        for device, reading in zip(names, readings)
+        if reading is not None and str(reading) == GATEWAY_DISCONNECTED
+    ]

--- a/GeecsBluesky/geecs_bluesky/devices/ca/oneshot.py
+++ b/GeecsBluesky/geecs_bluesky/devices/ca/oneshot.py
@@ -11,7 +11,13 @@ every read through it, so each PV's channel is created once and reused.
 
 This is the one blessed one-shot blocking read; long-lived subscriptions
 belong on a caller-owned loop (the console device-panel pattern), and
-in-plan reads belong to ophyd-async signals — never this module.
+in-plan reads belong to ophyd-async signals — never this module.  The
+one sanctioned in-plan exception is the pre-claim liveness probe
+(:func:`~geecs_bluesky.devices.ca.liveness.probe_disconnected`, used by
+the queue-plan preamble): it runs before the devices exist, so there is
+no signal to read yet — and it must gather its reads concurrently
+(:func:`try_caget_many`) so the worst case blocks the RE loop for one
+timeout budget, never one per device.
 
 ``aioca`` is imported lazily on first use (the ``ca`` extra), so the
 module itself imports anywhere.
@@ -99,3 +105,35 @@ def try_caget_once(pv: str, *, timeout: float, datatype: Any = None) -> Any:
         return caget_once(pv, timeout=timeout, datatype=datatype)
     except Exception:
         return None
+
+
+def try_caget_many(
+    pvs: list[str], *, timeout: float, datatype: Any = None
+) -> list[Any]:
+    """Concurrent fail-open reads of *pvs* on the shared loop.
+
+    One gather, one ``timeout`` budget for the whole batch — N dead PVs
+    cost the same wall time as one (the sequential per-PV alternative
+    would block the caller — possibly the RE loop — for ``N × timeout``).
+    Each failed read is ``None`` in the result, positionally matching
+    *pvs*.
+    """
+    from aioca import caget
+
+    async def _one(pv: str) -> Any:
+        try:
+            if datatype is None:
+                return await caget(pv, timeout=timeout)
+            return await caget(pv, datatype=datatype, timeout=timeout)
+        except Exception:
+            return None
+
+    async def _all() -> list[Any]:
+        return list(await asyncio.gather(*(_one(pv) for pv in pvs)))
+
+    future = asyncio.run_coroutine_threadsafe(_all(), _shared_loop())
+    try:
+        return future.result(timeout=timeout + _RESULT_GRACE_S)
+    except BaseException:
+        future.cancel()
+        return [None] * len(pvs)

--- a/GeecsBluesky/geecs_bluesky/devices/ca/oneshot.py
+++ b/GeecsBluesky/geecs_bluesky/devices/ca/oneshot.py
@@ -116,9 +116,14 @@ def try_caget_many(
     cost the same wall time as one (the sequential per-PV alternative
     would block the caller — possibly the RE loop — for ``N × timeout``).
     Each failed read is ``None`` in the result, positionally matching
-    *pvs*.
+    *pvs* — including the whole batch when ``aioca`` itself is missing
+    (the ``ca`` extra): fail-open covers the import too, matching
+    :func:`try_caget_once`.
     """
-    from aioca import caget
+    try:
+        from aioca import caget
+    except Exception:
+        return [None] * len(pvs)
 
     async def _one(pv: str) -> Any:
         try:

--- a/GeecsBluesky/geecs_bluesky/plans/liveness.py
+++ b/GeecsBluesky/geecs_bluesky/plans/liveness.py
@@ -1,0 +1,46 @@
+"""The one in-plan liveness read for built devices.
+
+The device family carries a non-readable ``connected_status`` child on
+the gateway's per-device ``CONNECTED`` PV — the authoritative liveness
+signal.  Plan-context consumers (the strict refire gate in
+:mod:`~geecs_bluesky.plans.single_shot`, the t0-sync seed gate in
+:mod:`~geecs_bluesky.plans.t0_sync`) read it through this one stub so the
+fail-open convention cannot drift between hand-rolled copies: only the
+exact ``Disconnected`` choice string is ever a verdict.  Out-of-plan
+probes (no device built yet) use
+:func:`geecs_bluesky.devices.ca.liveness.probe_disconnected` instead.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import bluesky.plan_stubs as bps
+
+from geecs_bluesky.devices.ca._pv import GATEWAY_DISCONNECTED
+
+logger = logging.getLogger(__name__)
+
+
+def rd_confirmed_down(device: Any):
+    """Plan stub: ``True`` iff *device*'s ``connected_status`` reads down.
+
+    **Fail-open**: no ``connected_status`` attribute (older device
+    shapes, bare fakes) or a failed read is not a verdict and returns
+    ``False``; only the exact ``Disconnected`` choice string confirms —
+    a mock backend's ``""`` default reads live.
+    """
+    signal = getattr(device, "connected_status", None)
+    if signal is None:
+        return False
+    try:
+        value = yield from bps.rd(signal)
+    except Exception:
+        logger.debug(
+            "CONNECTED read failed for %s; assuming live (fail-open)",
+            getattr(device, "name", device),
+            exc_info=True,
+        )
+        return False
+    return value == GATEWAY_DISCONNECTED

--- a/GeecsBluesky/geecs_bluesky/plans/scan_request_plan.py
+++ b/GeecsBluesky/geecs_bluesky/plans/scan_request_plan.py
@@ -506,9 +506,7 @@ def _scan_request_body(
     # CONNECTED liveness re-check (#664): the client asked pre-submit, but
     # the queue's submission-to-execution gap is long — re-check here,
     # refusing only when a row could never complete.
-    disconnected_devices = _preflight_connected(
-        session, devices_config, free_run=not strict
-    )
+    disconnected_devices = _preflight_connected(session, devices_config)
     slots = assemble_action_slots(request.actions, applied_defaults, rituals)
     warn_if_reserved_boundary_overrides(save_set)
     axis_resolved = [
@@ -746,11 +744,7 @@ def _optimize_request_body(
             "would have nothing to read"
         )
     # CONNECTED liveness re-check (#664), same terms as the step/noscan path.
-    disconnected_devices = _preflight_connected(
-        session,
-        devices_config,
-        free_run=request.acquisition is not AcquisitionMode.STRICT,
-    )
+    disconnected_devices = _preflight_connected(session, devices_config)
 
     # ---- phase 2: worker-side construction (connects deferred) -----------
     factories = _DeferredConnectFactories(session)

--- a/GeecsBluesky/geecs_bluesky/plans/scan_request_plan.py
+++ b/GeecsBluesky/geecs_bluesky/plans/scan_request_plan.py
@@ -80,6 +80,7 @@ from geecs_bluesky.scan_request_runner import (
     PseudoMovableTarget,
     _build_request_detectors,
     _defaults_flag,
+    _preflight_connected,
     _preflight_unserved,
     assemble_action_slots,
     build_action_registry,
@@ -502,6 +503,12 @@ def _scan_request_body(
             "unserved-variables pre-flight aborted the scan (pre-claim)"
         )
     devices_config = checked_config
+    # CONNECTED liveness re-check (#664): the client asked pre-submit, but
+    # the queue's submission-to-execution gap is long — re-check here,
+    # refusing only when a row could never complete.
+    disconnected_devices = _preflight_connected(
+        session, devices_config, free_run=not strict
+    )
     slots = assemble_action_slots(request.actions, applied_defaults, rituals)
     warn_if_reserved_boundary_overrides(save_set)
     axis_resolved = [
@@ -580,6 +587,7 @@ def _scan_request_body(
         slots=slots,
         dropped_unserved=dropped_unserved,
         dropped_unserved_devices=dropped_unserved_devices,
+        disconnected_devices=disconnected_devices,
         telemetry_selected=telemetry_selected if telemetry_enabled else {},
     )
     if request.mode is ScanRequestMode.NOSCAN:
@@ -737,6 +745,12 @@ def _optimize_request_body(
             "device for this optimization (pre-claim) — the objective "
             "would have nothing to read"
         )
+    # CONNECTED liveness re-check (#664), same terms as the step/noscan path.
+    disconnected_devices = _preflight_connected(
+        session,
+        devices_config,
+        free_run=request.acquisition is not AcquisitionMode.STRICT,
+    )
 
     # ---- phase 2: worker-side construction (connects deferred) -----------
     factories = _DeferredConnectFactories(session)
@@ -783,6 +797,8 @@ def _optimize_request_body(
         }
     if dropped_unserved_devices:
         md["dropped_unserved_devices"] = list(dropped_unserved_devices)
+    if disconnected_devices:
+        md["disconnected_devices"] = list(disconnected_devices)
     if applied_defaults:
         md["applied_defaults"] = metadata_applied_defaults(applied_defaults)
     submission = metadata_submission(request)

--- a/GeecsBluesky/geecs_bluesky/plans/single_shot.py
+++ b/GeecsBluesky/geecs_bluesky/plans/single_shot.py
@@ -29,7 +29,7 @@ import bluesky.plan_stubs as bps
 from bluesky.protocols import Triggerable
 from bluesky.utils import FailedStatus, short_uid
 
-from geecs_bluesky.devices.ca._pv import GATEWAY_DISCONNECTED
+from geecs_bluesky.plans.liveness import rd_confirmed_down
 from geecs_bluesky.exceptions import (
     GeecsDeviceDownError,
     GeecsQuiescenceTimeoutError,
@@ -61,13 +61,14 @@ def _confirm_device_down(devices: Sequence[Any], device_name: str):
     (its TCP stream to the gateway died — re-firing cannot help).  The
     frameless device is matched by GEECS device name (``_geecs_device_name``,
     falling back to the ophyd name) against *devices*, and its
-    ``connected_status`` signal is read in plan context via ``bps.rd``.
+    ``connected_status`` signal is read via the shared
+    :func:`~geecs_bluesky.plans.liveness.rd_confirmed_down` stub.
 
     **Fail-open**: no matching device, no ``connected_status`` attribute, or
     a failed read (old gateway without status PVs) all return ``False``
     ("not confirmed down"), preserving the refire behavior.  Only the exact
-    :data:`~geecs_bluesky.devices.ca._pv.GATEWAY_DISCONNECTED` choice string
-    confirms the device is down — a mock backend's ``""`` default reads live.
+    ``Disconnected`` choice string confirms the device is down — a mock
+    backend's ``""`` default reads live.
     """
     device = next(
         (
@@ -78,19 +79,12 @@ def _confirm_device_down(devices: Sequence[Any], device_name: str):
         ),
         None,
     )
-    signal = getattr(device, "connected_status", None)
-    if signal is None:
+    if device is None:
         return False
-    try:
-        value = yield from bps.rd(signal)
-    except Exception:
-        logger.debug(
-            "CONNECTED read failed for %s; assuming live (fail-open)",
-            device_name,
-            exc_info=True,
-        )
-        return False
-    return value == GATEWAY_DISCONNECTED
+    # The shared fail-open read (plans/liveness.py) — the one in-plan
+    # CONNECTED idiom, so the convention cannot drift between copies.
+    confirmed = yield from rd_confirmed_down(device)
+    return confirmed
 
 
 def geecs_single_shot(

--- a/GeecsBluesky/geecs_bluesky/plans/t0_sync.py
+++ b/GeecsBluesky/geecs_bluesky/plans/t0_sync.py
@@ -20,9 +20,51 @@ from typing import Any, Sequence
 
 import bluesky.plan_stubs as bps
 
+from geecs_bluesky.devices.ca._pv import GATEWAY_DISCONNECTED
 from geecs_bluesky.exceptions import GeecsT0SyncError
 
 logger = logging.getLogger(__name__)
+
+
+def _refuse_disconnected_devices(devices: Sequence[Any]):
+    """Plan stub: refuse to seed from a device the gateway reports down.
+
+    The seed comes from each device's **cached** ``acq_timestamp`` under a
+    quiescent trigger, and a dead device serves its stale cache forever —
+    with one sync device (or all dead) the spread check is trivially
+    satisfied and a dead reference "seeds" from an hours-old frame,
+    deferring the failure to a cryptic mid-scan trigger timeout (#664,
+    live incident 2026-08-22: a camera server rebooted uncleanly).
+    Timestamp freshness cannot be the guard — at rest with the trigger
+    parked (e.g. laser-off operation) a *healthy* cache is legitimately
+    old — so liveness is read from ``connected_status``, the
+    authoritative signal (the same read as the strict refire gate).
+
+    **Fail-open**: no ``connected_status`` attribute or a failed read is
+    not a verdict; only the exact ``Disconnected`` choice string refuses,
+    naming the device(s).
+    """
+    down: list[str] = []
+    for dev in devices:
+        signal = getattr(dev, "connected_status", None)
+        if signal is None:
+            continue
+        try:
+            value = yield from bps.rd(signal)
+        except Exception:
+            logger.debug(
+                "CONNECTED read failed during t0 sync; assuming live (fail-open)",
+                exc_info=True,
+            )
+            continue
+        if value == GATEWAY_DISCONNECTED:
+            down.append(getattr(dev, "_geecs_device_name", dev.name))
+    if down:
+        raise GeecsT0SyncError(
+            f"cannot seed t0: the gateway reports {', '.join(sorted(down))} "
+            "as Disconnected — the cached acq_timestamp is stale, not a "
+            "shot; restart the device(s) and resubmit"
+        )
 
 
 def geecs_t0_sync(
@@ -61,6 +103,9 @@ def geecs_t0_sync(
         If a common physical shot cannot be established.  Never proceed
         unseeded — shot IDs from unsynchronized t0s are not comparable.
     """
+    # Liveness gate first (#664): a dead device's cache would "seed" —
+    # see _refuse_disconnected_devices.
+    yield from _refuse_disconnected_devices(devices)
     last_error = ""
     timestamps: dict[str, float | None] = {}
     for attempt in range(retries + 1):

--- a/GeecsBluesky/geecs_bluesky/plans/t0_sync.py
+++ b/GeecsBluesky/geecs_bluesky/plans/t0_sync.py
@@ -20,8 +20,8 @@ from typing import Any, Sequence
 
 import bluesky.plan_stubs as bps
 
-from geecs_bluesky.devices.ca._pv import GATEWAY_DISCONNECTED
 from geecs_bluesky.exceptions import GeecsT0SyncError
+from geecs_bluesky.plans.liveness import rd_confirmed_down
 
 logger = logging.getLogger(__name__)
 
@@ -37,27 +37,17 @@ def _refuse_disconnected_devices(devices: Sequence[Any]):
     live incident 2026-08-22: a camera server rebooted uncleanly).
     Timestamp freshness cannot be the guard — at rest with the trigger
     parked (e.g. laser-off operation) a *healthy* cache is legitimately
-    old — so liveness is read from ``connected_status``, the
-    authoritative signal (the same read as the strict refire gate).
-
-    **Fail-open**: no ``connected_status`` attribute or a failed read is
-    not a verdict; only the exact ``Disconnected`` choice string refuses,
-    naming the device(s).
+    old — so liveness is read from ``connected_status`` via the shared
+    :func:`~geecs_bluesky.plans.liveness.rd_confirmed_down` (fail-open;
+    only the exact ``Disconnected`` choice string refuses, naming the
+    device(s)).  Every device here is synchronous, so any dead one would
+    also fail the spread check — refusing them all pre-seed, by name, is
+    the honest version of that failure.
     """
     down: list[str] = []
     for dev in devices:
-        signal = getattr(dev, "connected_status", None)
-        if signal is None:
-            continue
-        try:
-            value = yield from bps.rd(signal)
-        except Exception:
-            logger.debug(
-                "CONNECTED read failed during t0 sync; assuming live (fail-open)",
-                exc_info=True,
-            )
-            continue
-        if value == GATEWAY_DISCONNECTED:
+        confirmed = yield from rd_confirmed_down(dev)
+        if confirmed:
             down.append(getattr(dev, "_geecs_device_name", dev.name))
     if down:
         raise GeecsT0SyncError(

--- a/GeecsBluesky/geecs_bluesky/qs_client/submit_preflight.py
+++ b/GeecsBluesky/geecs_bluesky/qs_client/submit_preflight.py
@@ -233,13 +233,11 @@ def _read_pv(pv: str, timeout: float, datatype: Any = None) -> Any:
     timeout : float
         CA read budget in seconds.
     datatype :
-        Passed to ``caget``.  **Must be ``str`` for enum PVs whose choice
-        string is compared** (the gateway's ``CONNECTED`` is a DBR_ENUM —
-        a native read returns the integer index, and ``str(1)`` never
-        equals ``"Disconnected"``; #653 review finding 1, the same rule as
-        the engine's ``epics_signal_r(str, ...)`` liveness child).
-        ``None`` reads the channel's native type (right for
-        ``acq_timestamp``, natively a double).
+        Passed to ``caget``.  ``None`` reads the channel's native type
+        (right for ``acq_timestamp``, natively a double).  The staleness
+        sample is this seam's remaining consumer — CONNECTED reads go
+        through the shared ``probe_disconnected``, which owns the
+        DBR_ENUM ``datatype=str`` subtlety (#653 review finding 1).
     """
     from geecs_bluesky.devices.ca.oneshot import try_caget_once
 
@@ -249,23 +247,19 @@ def _read_pv(pv: str, timeout: float, datatype: Any = None) -> Any:
 def _check_liveness(
     report: PreflightReport, devices_config: dict[str, dict], experiment: str
 ) -> None:
-    """Read each device's gateway ``CONNECTED`` PV; question the down ones."""
-    from geecs_bluesky.devices.ca._pv import ca_pv
-    from geecs_bluesky.devices.ca.gateway_put import bare_pv
+    """Read each device's gateway ``CONNECTED`` PV; question the down ones.
 
-    down: list[str] = []
-    for device in devices_config:
-        # datatype=str is load-bearing: CONNECTED is an enum PV and the
-        # comparison below is against its choice string (see _read_pv).
-        reading = _read_pv(
-            bare_pv(ca_pv(experiment, device, "CONNECTED")),
-            _LIVENESS_TIMEOUT_S,
-            datatype=str,
-        )
-        # Fail-open: only the exact "Disconnected" reading means down (the
-        # engine's liveness doctrine — an unreadable status is not a verdict).
-        if reading is not None and str(reading) == "Disconnected":
-            down.append(device)
+    The probe (concurrent batch read, fail-open, the DBR_ENUM
+    ``datatype=str`` subtlety) is the shared
+    :func:`geecs_bluesky.devices.ca.liveness.probe_disconnected` — the
+    same one the worker's pre-claim re-check uses, so the two sides
+    cannot drift.  Only the disposition differs: here a down device
+    becomes an operator question; worker-side it refuses or warns
+    headlessly.
+    """
+    from geecs_bluesky.devices.ca.liveness import probe_disconnected
+
+    down = probe_disconnected(experiment, devices_config, timeout=_LIVENESS_TIMEOUT_S)
     if not down:
         report.outcomes.append(("gateway_liveness", "passed", ""))
         return

--- a/GeecsBluesky/geecs_bluesky/scan_request_runner.py
+++ b/GeecsBluesky/geecs_bluesky/scan_request_runner.py
@@ -1284,16 +1284,9 @@ def _preflight_unserved(
     )
 
 
-#: CA read budget per pre-claim CONNECTED probe (seconds) — a dead PV costs
-#: this once per device; matches the client-side preflight's budget.
-_CONNECTED_TIMEOUT_S = 2.0
-
-
 def _preflight_connected(
     session: Any,
     devices_config: dict[str, dict[str, Any]],
-    *,
-    free_run: bool,
 ) -> list[str]:
     """Pre-claim CONNECTED liveness re-check over *devices_config* (#664).
 
@@ -1303,16 +1296,26 @@ def _preflight_connected(
     worker re-checks at execution, exactly like it re-runs validation and
     the unserved-variables check.  Headless dispositions:
 
-    - A **load-bearing** device reading the exact ``Disconnected`` choice
+    - A **synchronous** device reading the exact ``Disconnected`` choice
       string refuses the scan pre-claim (:class:`GeecsDeviceDownError`
-      naming the device) — free-run: the reference (row completion is
-      paced by it, so the scan cannot produce a single row); strict:
-      every synchronous device (each row awaits all of them).
-    - Any other Disconnected device warns and continues — its columns
-      will be missing/invalid, which a queued scan survives.  The list is
-      recorded in run metadata as ``disconnected_devices``.
+      naming it) — in both modes.  Strict rows await every synchronous
+      device; free-run rows are paced by the reference AND every dead
+      sync contributor would fail t0 sync post-claim anyway (its stale
+      cached timestamp blows the spread window, and the seed gate refuses
+      it by name) — so a warn-and-continue disposition for free-run
+      contributors would be a fiction, deferring the same death past the
+      claim.  Refusing pre-claim burns no scan number.
+    - A Disconnected **asynchronous** (snapshot) device warns and
+      continues — its columns are sampled best-effort and a queued scan
+      survives without them.  The list is recorded in run metadata as
+      ``disconnected_devices``.
     - Fail-open everywhere else (the liveness doctrine): an unreadable
       PV, no experiment, or missing CA support is never a verdict.
+
+    The probe itself (one concurrent batch read, one timeout budget — the
+    queue-plan paths run this inside the RE loop, so per-device
+    sequential timeouts are not acceptable) is the shared
+    :func:`~geecs_bluesky.devices.ca.liveness.probe_disconnected`.
 
     Returns
     -------
@@ -1323,41 +1326,24 @@ def _preflight_connected(
     if not experiment or not devices_config:
         return []
     try:
-        from geecs_bluesky.devices.ca._pv import GATEWAY_DISCONNECTED, ca_pv
-        from geecs_bluesky.devices.ca.gateway_put import bare_pv
-        from geecs_bluesky.devices.ca.oneshot import try_caget_once
+        from geecs_bluesky.devices.ca.liveness import probe_disconnected
     except Exception as exc:  # ca support absent — fail open
         logger.warning("CONNECTED pre-flight skipped (no CA support): %s", exc)
         return []
-    down: list[str] = []
-    for device in devices_config:
-        # datatype=str is load-bearing: CONNECTED is a DBR_ENUM and the
-        # comparison is against its choice string (a native read returns
-        # the integer index, which never matches).
-        reading = try_caget_once(
-            bare_pv(ca_pv(experiment, device, "CONNECTED")),
-            timeout=_CONNECTED_TIMEOUT_S,
-            datatype=str,
-        )
-        if reading is not None and str(reading) == GATEWAY_DISCONNECTED:
-            down.append(device)
+    down = probe_disconnected(experiment, devices_config)
     if not down:
         return []
-    # devices_config is role-derived-ordered: the reference is the first
-    # synchronous entry (save_set_to_devices_config's contract).
-    sync_devices = [d for d, cfg in devices_config.items() if cfg.get("synchronous")]
-    load_bearing = sync_devices[:1] if free_run else sync_devices
-    fatal = [d for d in down if d in load_bearing]
+    fatal = [d for d in down if devices_config[d].get("synchronous")]
     if fatal:
         raise GeecsDeviceDownError(
             f"gateway reports {', '.join(sorted(fatal))} as Disconnected — "
-            "the scan cannot complete a row without it (free-run reference / "
-            "strict synchronous device); restart the device and resubmit "
-            "(pre-claim — no scan number was burned)",
+            "a synchronous device the scan's rows cannot complete without; "
+            "restart the device and resubmit (pre-claim — no scan number "
+            "was burned)",
             device_name=fatal[0],
         )
     logger.warning(
-        "gateway reports %s as Disconnected — continuing; their rows/columns "
+        "gateway reports %s as Disconnected — continuing; their columns "
         "will be missing or invalid (recorded as disconnected_devices)",
         ", ".join(sorted(down)),
     )
@@ -1635,9 +1621,7 @@ def run_scan_request(
     # CONNECTED liveness re-check (#664): the client asked pre-submit, but
     # the queue's submission-to-execution gap is long — re-check here,
     # refusing only when a row could never complete.
-    disconnected_devices = _preflight_connected(
-        session, devices_config, free_run=mode == "free_run"
-    )
+    disconnected_devices = _preflight_connected(session, devices_config)
     if _stopped_during_init(session, should_abort, "after configuration resolution"):
         return None
     slots = assemble_action_slots(request.actions, applied_defaults, rituals)
@@ -1873,9 +1857,7 @@ def _run_optimize_request(
         if devices_config is not None:
             # CONNECTED liveness re-check (#664), same terms as the
             # scan/noscan path.
-            disconnected_devices = _preflight_connected(
-                session, devices_config, free_run=mode == "free_run"
-            )
+            disconnected_devices = _preflight_connected(session, devices_config)
         if devices_config is None:
             logger.warning(
                 "ScanRequest preflight aborted the optimization (unserved "

--- a/GeecsBluesky/geecs_bluesky/scan_request_runner.py
+++ b/GeecsBluesky/geecs_bluesky/scan_request_runner.py
@@ -58,7 +58,7 @@ from geecs_bluesky.db_runtime import (
     resolve_entry_scalars,
     select_telemetry_variables,
 )
-from geecs_bluesky.exceptions import GeecsConfigurationError
+from geecs_bluesky.exceptions import GeecsConfigurationError, GeecsDeviceDownError
 from geecs_bluesky.forward_expr import CompiledForward, compile_forward
 from geecs_bluesky.models.shot_control import ShotControlWrites
 from geecs_bluesky.plans.action_compiler import compile_action_plan
@@ -998,6 +998,7 @@ def build_step_scan_spec(
     slots: Mapping[str, list[str]],
     dropped_unserved: Mapping[str, list[str]],
     dropped_unserved_devices: list[str],
+    disconnected_devices: list[str],
     telemetry_selected: Mapping[str, list[str]],
 ) -> StepScanSpec:
     """Assemble the pure run picture of a step/noscan request.
@@ -1034,6 +1035,10 @@ def build_step_scan_spec(
         }
     if dropped_unserved_devices:
         md["dropped_unserved_devices"] = list(dropped_unserved_devices)
+    if disconnected_devices:
+        # Provenance: devices the CONNECTED re-check found down at
+        # execution — the run proceeded without their rows/columns (#664).
+        md["disconnected_devices"] = list(disconnected_devices)
     if applied_defaults:
         # Provenance: the run records exactly which experiment defaults
         # filled in fields the submitter left unset.
@@ -1277,6 +1282,86 @@ def _preflight_unserved(
         devices_config,
         provider.served_by_device if provider is not None else None,
     )
+
+
+#: CA read budget per pre-claim CONNECTED probe (seconds) — a dead PV costs
+#: this once per device; matches the client-side preflight's budget.
+_CONNECTED_TIMEOUT_S = 2.0
+
+
+def _preflight_connected(
+    session: Any,
+    devices_config: dict[str, dict[str, Any]],
+    *,
+    free_run: bool,
+) -> list[str]:
+    """Pre-claim CONNECTED liveness re-check over *devices_config* (#664).
+
+    The client-side pre-submit preflight reads the same PVs, but the
+    submission-to-execution gap under the queue is long (a device can die
+    while the item waits, or the client skipped its checks) — so the
+    worker re-checks at execution, exactly like it re-runs validation and
+    the unserved-variables check.  Headless dispositions:
+
+    - A **load-bearing** device reading the exact ``Disconnected`` choice
+      string refuses the scan pre-claim (:class:`GeecsDeviceDownError`
+      naming the device) — free-run: the reference (row completion is
+      paced by it, so the scan cannot produce a single row); strict:
+      every synchronous device (each row awaits all of them).
+    - Any other Disconnected device warns and continues — its columns
+      will be missing/invalid, which a queued scan survives.  The list is
+      recorded in run metadata as ``disconnected_devices``.
+    - Fail-open everywhere else (the liveness doctrine): an unreadable
+      PV, no experiment, or missing CA support is never a verdict.
+
+    Returns
+    -------
+    list of str
+        The Disconnected devices the scan continues without.
+    """
+    experiment = getattr(session, "experiment", None)
+    if not experiment or not devices_config:
+        return []
+    try:
+        from geecs_bluesky.devices.ca._pv import GATEWAY_DISCONNECTED, ca_pv
+        from geecs_bluesky.devices.ca.gateway_put import bare_pv
+        from geecs_bluesky.devices.ca.oneshot import try_caget_once
+    except Exception as exc:  # ca support absent — fail open
+        logger.warning("CONNECTED pre-flight skipped (no CA support): %s", exc)
+        return []
+    down: list[str] = []
+    for device in devices_config:
+        # datatype=str is load-bearing: CONNECTED is a DBR_ENUM and the
+        # comparison is against its choice string (a native read returns
+        # the integer index, which never matches).
+        reading = try_caget_once(
+            bare_pv(ca_pv(experiment, device, "CONNECTED")),
+            timeout=_CONNECTED_TIMEOUT_S,
+            datatype=str,
+        )
+        if reading is not None and str(reading) == GATEWAY_DISCONNECTED:
+            down.append(device)
+    if not down:
+        return []
+    # devices_config is role-derived-ordered: the reference is the first
+    # synchronous entry (save_set_to_devices_config's contract).
+    sync_devices = [d for d, cfg in devices_config.items() if cfg.get("synchronous")]
+    load_bearing = sync_devices[:1] if free_run else sync_devices
+    fatal = [d for d in down if d in load_bearing]
+    if fatal:
+        raise GeecsDeviceDownError(
+            f"gateway reports {', '.join(sorted(fatal))} as Disconnected — "
+            "the scan cannot complete a row without it (free-run reference / "
+            "strict synchronous device); restart the device and resubmit "
+            "(pre-claim — no scan number was burned)",
+            device_name=fatal[0],
+        )
+    logger.warning(
+        "gateway reports %s as Disconnected — continuing; their rows/columns "
+        "will be missing or invalid (recorded as disconnected_devices)",
+        ", ".join(sorted(down)),
+    )
+    return down
 
 
 def warn_if_reserved_boundary_overrides(save_set: SaveSet | None) -> None:
@@ -1547,6 +1632,12 @@ def run_scan_request(
         )
         return None
     devices_config = checked_config
+    # CONNECTED liveness re-check (#664): the client asked pre-submit, but
+    # the queue's submission-to-execution gap is long — re-check here,
+    # refusing only when a row could never complete.
+    disconnected_devices = _preflight_connected(
+        session, devices_config, free_run=mode == "free_run"
+    )
     if _stopped_during_init(session, should_abort, "after configuration resolution"):
         return None
     slots = assemble_action_slots(request.actions, applied_defaults, rituals)
@@ -1628,6 +1719,7 @@ def run_scan_request(
             slots=slots,
             dropped_unserved=dropped_unserved,
             dropped_unserved_devices=dropped_unserved_devices,
+            disconnected_devices=disconnected_devices,
             telemetry_selected=telemetry_selected if telemetry_enabled else {},
         )
 
@@ -1731,6 +1823,7 @@ def _run_optimize_request(
     created: list = []
     dropped_unserved: dict[str, list[str]] = {}
     dropped_unserved_devices: list[str] = []
+    disconnected_devices: list[str] = []
     try:
         skipped = {k: list(v) for k, v in (skipped_actions or {}).items() if v}
         # db_scalars applies to optimize too; telemetry does not run here yet
@@ -1777,6 +1870,12 @@ def _run_optimize_request(
             dropped_unserved,
             dropped_unserved_devices,
         ) = _preflight_unserved(session, devices_config)
+        if devices_config is not None:
+            # CONNECTED liveness re-check (#664), same terms as the
+            # scan/noscan path.
+            disconnected_devices = _preflight_connected(
+                session, devices_config, free_run=mode == "free_run"
+            )
         if devices_config is None:
             logger.warning(
                 "ScanRequest preflight aborted the optimization (unserved "
@@ -1828,6 +1927,8 @@ def _run_optimize_request(
             }
         if dropped_unserved_devices:
             md["dropped_unserved_devices"] = list(dropped_unserved_devices)
+        if disconnected_devices:
+            md["disconnected_devices"] = list(disconnected_devices)
         if applied_defaults:
             md["applied_defaults"] = metadata_applied_defaults(applied_defaults)
         submission = metadata_submission(request)

--- a/GeecsBluesky/geecs_bluesky/scan_request_runner.py
+++ b/GeecsBluesky/geecs_bluesky/scan_request_runner.py
@@ -1036,8 +1036,9 @@ def build_step_scan_spec(
     if dropped_unserved_devices:
         md["dropped_unserved_devices"] = list(dropped_unserved_devices)
     if disconnected_devices:
-        # Provenance: devices the CONNECTED re-check found down at
-        # execution — the run proceeded without their rows/columns (#664).
+        # Provenance: snapshot devices the CONNECTED re-check found down
+        # at execution — the run proceeded without their columns (#664;
+        # dead synchronous devices refuse pre-claim and never get here).
         md["disconnected_devices"] = list(disconnected_devices)
     if applied_defaults:
         # Provenance: the run records exactly which experiment defaults
@@ -1327,10 +1328,11 @@ def _preflight_connected(
         return []
     try:
         from geecs_bluesky.devices.ca.liveness import probe_disconnected
-    except Exception as exc:  # ca support absent — fail open
-        logger.warning("CONNECTED pre-flight skipped (no CA support): %s", exc)
+
+        down = probe_disconnected(experiment, devices_config)
+    except Exception as exc:  # probe machinery broke — fail open, never block
+        logger.warning("CONNECTED pre-flight skipped: %s", exc)
         return []
-    down = probe_disconnected(experiment, devices_config)
     if not down:
         return []
     fatal = [d for d in down if devices_config[d].get("synchronous")]

--- a/GeecsBluesky/pyproject.toml
+++ b/GeecsBluesky/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-bluesky"
-version = "0.58.0"
+version = "0.59.0"
 description = "Bluesky / ophyd-async bridge for the GEECS control system"
 authors = ["Sam Barber <sbarber@lbl.gov>"]
 readme = "README.md"

--- a/GeecsBluesky/tests/qs_client/test_submit_preflight.py
+++ b/GeecsBluesky/tests/qs_client/test_submit_preflight.py
@@ -60,6 +60,19 @@ def engine(monkeypatch):
         _make_provider({"UC_Cam1": {"MeanCounts"}, "UC_Cam2": {"Exposure"}}),
     )
     reads = {"CONNECTED": "Connected", "acq_timestamp": [100.0, 101.5]}
+
+    # The liveness check delegates to the shared probe (its own DBR_ENUM
+    # datatype=str contract is pinned in tests/test_preflight_connected.py);
+    # here the probe outcome is faked from reads["CONNECTED"] — None means
+    # unreadable, which the real probe reads as fail-open (not down).
+    def fake_probe(experiment, device_names, *, timeout):
+        if reads["CONNECTED"] == "Disconnected":
+            return list(device_names)
+        return []
+
+    monkeypatch.setattr(
+        "geecs_bluesky.devices.ca.liveness.probe_disconnected", fake_probe
+    )
     monkeypatch.setattr(submit_preflight, "_read_pv", _make_pv_reader(reads))
     monkeypatch.setattr(submit_preflight, "_STALENESS_WINDOW_S", 0.0)
     return reads
@@ -80,18 +93,8 @@ def _make_pv_reader(reads):
     state = {"ts_calls": 0}
 
     def _read(pv, timeout, datatype=None):
-        if pv.endswith(":connected"):
-            # Enum-faithful fake (#653 review finding 1): the gateway's
-            # CONNECTED is a DBR_ENUM, so a native read returns the integer
-            # index — only datatype=str yields the choice string the check
-            # compares against.  A regression back to a native read gets
-            # the index and can never see "Disconnected".
-            value = reads["CONNECTED"]
-            if value is None:
-                return None
-            if datatype is str:
-                return value
-            return {"Disconnected": 0, "Connected": 1}[value]
+        # _read_pv's remaining consumer is the staleness sample (native
+        # reads); CONNECTED goes through the shared probe, faked above.
         if pv.endswith(":acq_timestamp"):
             values = reads["acq_timestamp"]
             value = values[min(state["ts_calls"], len(values) - 1)]

--- a/GeecsBluesky/tests/test_preflight_connected.py
+++ b/GeecsBluesky/tests/test_preflight_connected.py
@@ -5,8 +5,16 @@ client-side pre-submit read cannot cover the submission-to-execution gap —
 live incident 2026-08-22: a camera server rebooted while items sat queued
 and the dead reference surfaced only as a mid-scan trigger timeout.
 
-CA reads are faked at the oneshot seam (the check imports it lazily, so a
-module-attribute patch lands).
+The rule is mode-independent: any dead **synchronous** device refuses
+(strict rows await all of them; free-run rows are paced by the reference
+and a dead sync contributor would fail t0 sync post-claim anyway — see
+`_preflight_connected`'s docstring), while a dead asynchronous (snapshot)
+device warns and continues.
+
+CA reads are faked at the shared batch-read seam
+(`oneshot.try_caget_many`, which `probe_disconnected` imports lazily) —
+the fixture also pins the DBR_ENUM contract: the probe must request the
+choice STRING (`datatype=str`), never the native integer index.
 """
 
 from __future__ import annotations
@@ -23,8 +31,6 @@ class _Session:
 
 
 def _config() -> dict[str, dict]:
-    # Role-derived order (save_set_to_devices_config's contract): the
-    # reference is the FIRST synchronous entry.
     return {
         "UC_Ref": {"synchronous": True, "variable_list": ["a"]},
         "UC_Contrib": {"synchronous": True, "variable_list": ["b"]},
@@ -34,17 +40,16 @@ def _config() -> dict[str, dict]:
 
 @pytest.fixture
 def ca_reads(monkeypatch):
-    """Fake the oneshot read: per-device CONNECTED choice strings."""
-    state = {"values": {}, "calls": 0}
+    """Fake the shared batch read: per-device CONNECTED choice strings."""
+    state = {"values": {}, "batches": 0}
 
-    def fake(pv, *, timeout, datatype=None):
-        state["calls"] += 1
-        # The enum contract: the check must read the choice STRING.
+    def fake(pvs, *, timeout, datatype=None):
+        state["batches"] += 1
+        # The enum contract: the probe must read the choice STRING.
         assert datatype is str
-        device = pv.split(":")[-2]
-        return state["values"].get(device)
+        return [state["values"].get(pv.split(":")[-2]) for pv in pvs]
 
-    monkeypatch.setattr("geecs_bluesky.devices.ca.oneshot.try_caget_once", fake)
+    monkeypatch.setattr("geecs_bluesky.devices.ca.oneshot.try_caget_many", fake)
     return state
 
 
@@ -54,57 +59,56 @@ def test_all_connected_returns_empty(ca_reads):
         "uc_contrib": "Connected",
         "uc_snap": "Connected",
     }
-    assert _preflight_connected(_Session(), _config(), free_run=True) == []
+    assert _preflight_connected(_Session(), _config()) == []
+    # One concurrent batch — never one read per device (RE-loop blocking).
+    assert ca_reads["batches"] == 1
 
 
-def test_free_run_dead_reference_refuses(ca_reads):
+def test_dead_reference_refuses(ca_reads):
     ca_reads["values"] = {"uc_ref": "Disconnected", "uc_contrib": "Connected"}
     with pytest.raises(GeecsDeviceDownError, match="UC_Ref") as excinfo:
-        _preflight_connected(_Session(), _config(), free_run=True)
+        _preflight_connected(_Session(), _config())
     assert excinfo.value.device_name == "UC_Ref"
     # Pre-claim refusal message must say no scan number was burned.
     assert "no scan number" in str(excinfo.value)
 
 
-def test_free_run_dead_contributor_warns_and_continues(ca_reads, caplog):
-    ca_reads["values"] = {"uc_ref": "Connected", "uc_contrib": "Disconnected"}
-    import logging
-
-    with caplog.at_level(logging.WARNING, logger="geecs_bluesky.scan_request_runner"):
-        down = _preflight_connected(_Session(), _config(), free_run=True)
-    assert down == ["UC_Contrib"]
-    assert any("UC_Contrib" in r.getMessage() for r in caplog.records)
-
-
-def test_strict_dead_sync_device_refuses(ca_reads):
-    # Strict rows await ALL synchronous devices — any dead one is fatal.
+def test_dead_sync_contributor_refuses(ca_reads):
+    # Mode-independent: a dead sync contributor would die at t0 sync
+    # post-claim (stale cache blows the spread window; the seed gate
+    # refuses it) — a warn-and-continue here would be a fiction, so the
+    # refusal happens pre-claim, named.
     ca_reads["values"] = {"uc_ref": "Connected", "uc_contrib": "Disconnected"}
     with pytest.raises(GeecsDeviceDownError, match="UC_Contrib"):
-        _preflight_connected(_Session(), _config(), free_run=False)
+        _preflight_connected(_Session(), _config())
 
 
-def test_dead_snapshot_device_warns_in_both_modes(ca_reads):
+def test_dead_snapshot_device_warns_and_continues(ca_reads, caplog):
+    import logging
+
     ca_reads["values"] = {
         "uc_ref": "Connected",
         "uc_contrib": "Connected",
         "uc_snap": "Disconnected",
     }
-    assert _preflight_connected(_Session(), _config(), free_run=True) == ["UC_Snap"]
-    assert _preflight_connected(_Session(), _config(), free_run=False) == ["UC_Snap"]
+    with caplog.at_level(logging.WARNING, logger="geecs_bluesky.scan_request_runner"):
+        down = _preflight_connected(_Session(), _config())
+    assert down == ["UC_Snap"]
+    assert any("UC_Snap" in r.getMessage() for r in caplog.records)
 
 
 def test_unreadable_is_fail_open(ca_reads):
     # No values set → every read returns None: not a verdict (the liveness
     # doctrine) — the scan proceeds with nothing recorded.
-    assert _preflight_connected(_Session(), _config(), free_run=True) == []
-    assert ca_reads["calls"] == len(_config())
+    assert _preflight_connected(_Session(), _config()) == []
+    assert ca_reads["batches"] == 1
 
 
 def test_no_experiment_skips_without_reading(ca_reads):
-    assert _preflight_connected(_Session(None), _config(), free_run=True) == []
-    assert ca_reads["calls"] == 0
+    assert _preflight_connected(_Session(None), _config()) == []
+    assert ca_reads["batches"] == 0
 
 
 def test_empty_config_skips_without_reading(ca_reads):
-    assert _preflight_connected(_Session(), {}, free_run=True) == []
-    assert ca_reads["calls"] == 0
+    assert _preflight_connected(_Session(), {}) == []
+    assert ca_reads["batches"] == 0

--- a/GeecsBluesky/tests/test_preflight_connected.py
+++ b/GeecsBluesky/tests/test_preflight_connected.py
@@ -112,3 +112,14 @@ def test_no_experiment_skips_without_reading(ca_reads):
 def test_empty_config_skips_without_reading(ca_reads):
     assert _preflight_connected(_Session(), {}) == []
     assert ca_reads["batches"] == 0
+
+
+def test_missing_aioca_is_fail_open(monkeypatch):
+    # No fixture: the REAL probe chain runs, but with aioca unimportable
+    # (a worker without the ca extra).  The fail-open contract covers the
+    # import itself — the check skips, it never refuses (reviewer-caught
+    # regression on the consolidation commit).
+    import sys
+
+    monkeypatch.setitem(sys.modules, "aioca", None)
+    assert _preflight_connected(_Session(), _config()) == []

--- a/GeecsBluesky/tests/test_preflight_connected.py
+++ b/GeecsBluesky/tests/test_preflight_connected.py
@@ -1,0 +1,110 @@
+"""Pin the pre-claim CONNECTED liveness re-check (#664).
+
+The check runs at execution on both paths (runner + queue plan) because the
+client-side pre-submit read cannot cover the submission-to-execution gap —
+live incident 2026-08-22: a camera server rebooted while items sat queued
+and the dead reference surfaced only as a mid-scan trigger timeout.
+
+CA reads are faked at the oneshot seam (the check imports it lazily, so a
+module-attribute patch lands).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from geecs_bluesky.exceptions import GeecsDeviceDownError
+from geecs_bluesky.scan_request_runner import _preflight_connected
+
+
+class _Session:
+    def __init__(self, experiment: str | None = "Test") -> None:
+        self.experiment = experiment
+
+
+def _config() -> dict[str, dict]:
+    # Role-derived order (save_set_to_devices_config's contract): the
+    # reference is the FIRST synchronous entry.
+    return {
+        "UC_Ref": {"synchronous": True, "variable_list": ["a"]},
+        "UC_Contrib": {"synchronous": True, "variable_list": ["b"]},
+        "UC_Snap": {"synchronous": False, "variable_list": ["c"]},
+    }
+
+
+@pytest.fixture
+def ca_reads(monkeypatch):
+    """Fake the oneshot read: per-device CONNECTED choice strings."""
+    state = {"values": {}, "calls": 0}
+
+    def fake(pv, *, timeout, datatype=None):
+        state["calls"] += 1
+        # The enum contract: the check must read the choice STRING.
+        assert datatype is str
+        device = pv.split(":")[-2]
+        return state["values"].get(device)
+
+    monkeypatch.setattr("geecs_bluesky.devices.ca.oneshot.try_caget_once", fake)
+    return state
+
+
+def test_all_connected_returns_empty(ca_reads):
+    ca_reads["values"] = {
+        "uc_ref": "Connected",
+        "uc_contrib": "Connected",
+        "uc_snap": "Connected",
+    }
+    assert _preflight_connected(_Session(), _config(), free_run=True) == []
+
+
+def test_free_run_dead_reference_refuses(ca_reads):
+    ca_reads["values"] = {"uc_ref": "Disconnected", "uc_contrib": "Connected"}
+    with pytest.raises(GeecsDeviceDownError, match="UC_Ref") as excinfo:
+        _preflight_connected(_Session(), _config(), free_run=True)
+    assert excinfo.value.device_name == "UC_Ref"
+    # Pre-claim refusal message must say no scan number was burned.
+    assert "no scan number" in str(excinfo.value)
+
+
+def test_free_run_dead_contributor_warns_and_continues(ca_reads, caplog):
+    ca_reads["values"] = {"uc_ref": "Connected", "uc_contrib": "Disconnected"}
+    import logging
+
+    with caplog.at_level(logging.WARNING, logger="geecs_bluesky.scan_request_runner"):
+        down = _preflight_connected(_Session(), _config(), free_run=True)
+    assert down == ["UC_Contrib"]
+    assert any("UC_Contrib" in r.getMessage() for r in caplog.records)
+
+
+def test_strict_dead_sync_device_refuses(ca_reads):
+    # Strict rows await ALL synchronous devices — any dead one is fatal.
+    ca_reads["values"] = {"uc_ref": "Connected", "uc_contrib": "Disconnected"}
+    with pytest.raises(GeecsDeviceDownError, match="UC_Contrib"):
+        _preflight_connected(_Session(), _config(), free_run=False)
+
+
+def test_dead_snapshot_device_warns_in_both_modes(ca_reads):
+    ca_reads["values"] = {
+        "uc_ref": "Connected",
+        "uc_contrib": "Connected",
+        "uc_snap": "Disconnected",
+    }
+    assert _preflight_connected(_Session(), _config(), free_run=True) == ["UC_Snap"]
+    assert _preflight_connected(_Session(), _config(), free_run=False) == ["UC_Snap"]
+
+
+def test_unreadable_is_fail_open(ca_reads):
+    # No values set → every read returns None: not a verdict (the liveness
+    # doctrine) — the scan proceeds with nothing recorded.
+    assert _preflight_connected(_Session(), _config(), free_run=True) == []
+    assert ca_reads["calls"] == len(_config())
+
+
+def test_no_experiment_skips_without_reading(ca_reads):
+    assert _preflight_connected(_Session(None), _config(), free_run=True) == []
+    assert ca_reads["calls"] == 0
+
+
+def test_empty_config_skips_without_reading(ca_reads):
+    assert _preflight_connected(_Session(), {}, free_run=True) == []
+    assert ca_reads["calls"] == 0

--- a/GeecsBluesky/tests/test_read_path_staging.py
+++ b/GeecsBluesky/tests/test_read_path_staging.py
@@ -102,7 +102,15 @@ class TestStagingContract:
         finally:
             pacer.cancel()
 
-        assert counters == {}, (
+        # The t0-sync liveness gate (#664) reads each sync device's
+        # connected_status ONCE per scan — deliberately outside the staged
+        # cache (a liveness probe must not be served from a possibly-dead
+        # monitor).  Once-per-scan is not a per-row cost; anything else is.
+        allowed = {"ref-connected_status", "cam-connected_status"}
+        unexpected = {
+            key: n for key, n in counters.items() if key not in allowed or n > 1
+        }
+        assert unexpected == {}, (
             "per-row reads issued uncached backend gets — the staging "
             f"contract is broken: {counters}"
         )

--- a/GeecsBluesky/tests/test_shot_id.py
+++ b/GeecsBluesky/tests/test_shot_id.py
@@ -181,6 +181,68 @@ class TestGeecsT0Sync:
         assert "U_CamA" in str(excinfo.value)
 
 
+class TestT0SyncLivenessGate:
+    """The #664 gate: a dead device's stale cache must never seed t0.
+
+    Driven with a real RunEngine — ``bps.rd`` needs the run engine's
+    read machinery to deliver the mock ``connected_status`` value (the
+    hand-driven ``_drive`` harness makes ``rd`` fall back to its
+    fail-open default, which is itself the deliberate offline behavior).
+    """
+
+    def _detector(self, RE, status: str) -> "CaGenericDetector":
+        from bluesky import RunEngine  # noqa: F401 — for the type only
+
+        from tests.ca_mock_helpers import connect_mock
+
+        det = CaGenericDetector("U_CamA", ["Sig"], experiment="Test", name="cam_a")
+        det.configure_shot_id(rep_rate_hz=1.0)
+        connect_mock(RE, det)
+        set_mock_value(det.acq_timestamp, 1000.0)  # stale-but-present cache
+        set_mock_value(det.connected_status, status)
+        return det
+
+    def test_disconnected_device_refuses_seed(self) -> None:
+        from bluesky import RunEngine
+
+        RE = RunEngine()
+        det = self._detector(RE, "Disconnected")
+        with pytest.raises(GeecsT0SyncError) as excinfo:
+            RE(geecs_t0_sync([det], window_s=0.2, retries=0))
+        message = str(excinfo.value)
+        assert "U_CamA" in message and "Disconnected" in message
+        # Refused BEFORE seeding — the stale cache never became a t0.
+        assert det.shot_id_tracker.t0_acq_timestamp is None
+
+    def test_connected_device_seeds_normally(self) -> None:
+        from bluesky import RunEngine
+
+        RE = RunEngine()
+        det = self._detector(RE, "Connected")
+        RE(geecs_t0_sync([det], window_s=0.2, retries=0))
+        assert det.shot_id_tracker.t0_acq_timestamp == pytest.approx(1000.0)
+
+    def test_device_without_status_is_fail_open(self) -> None:
+        """No connected_status attribute (older device shape) → gate skips."""
+        from bluesky import RunEngine
+
+        class _Bare:
+            name = "bare"
+            _geecs_device_name = "U_Bare"
+            last_acq_timestamp = 1000.0
+
+            def __init__(self) -> None:
+                self.seeded: float | None = None
+
+            def seed_shot_id(self, t0: float) -> None:
+                self.seeded = t0
+
+        RE = RunEngine()
+        bare = _Bare()
+        RE(geecs_t0_sync([bare], window_s=0.2, retries=0))
+        assert bare.seeded == pytest.approx(1000.0)
+
+
 # ---------------------------------------------------------------------------
 # Stable keys / NaN policy on the generic detector
 # ---------------------------------------------------------------------------

--- a/GeecsBluesky/tests/test_telemetry_group_and_t0check.py
+++ b/GeecsBluesky/tests/test_telemetry_group_and_t0check.py
@@ -126,8 +126,10 @@ class TestTelemetryGroup:
             pacer.cancel()
 
         # Primary row + tail flush each read: ref, cam, group, scan_context
-        # — 4 reads/row regardless of how many devices the group holds.
-        assert commands.count("read") == 8
+        # — 4 reads/row regardless of how many devices the group holds —
+        # plus the t0-sync liveness gate's one connected_status read per
+        # sync device, once per scan (#664): 4×2 + 2.
+        assert commands.count("read") == 10
 
     def test_group_disconnect_forwards_to_members(self) -> None:
         RE = RunEngine()

--- a/GeecsBluesky/tests/test_timestamped_readable.py
+++ b/GeecsBluesky/tests/test_timestamped_readable.py
@@ -162,7 +162,10 @@ async def test_t0_sync_seeds_timestamped_readables() -> None:
     # Re-seed both through the plan stage instead of the manual seeds
     plan = geecs_t0_sync([ref, cam], window_s=0.2)
     try:
-        plan.send(None)
+        # Drive to completion: the liveness gate (#664) yields rd messages
+        # before the seed, so one send is no longer enough.
+        while True:
+            plan.send(None)
     except StopIteration as stop:
         t0s = stop.value
     assert t0s == {


### PR DESCRIPTION
## What + why

Live incident 2026-08-22 (evidence on #664): the camera server at 192.168.6.100 rebooted uncleanly for Windows updates, and queued free-run noscans with the now-dead `UC_Amp4_IR_input` as reference failed with a cryptic mid-scan `GeecsTriggerTimeoutError` — t0-sync had "seeded" from the dead device's stale cache (single-device spread is trivially zero), and the CONNECTED liveness check existed only client-side pre-submit, leaving the submission-to-execution gap (and preflight-skipping clients) uncovered. Diagnosis cost real time because nothing named the dead device.

Two remedies from #664, both execution-side (the client-side pre-submit check stays):

- **`_preflight_connected`** (~80 LOC + wiring): pre-claim CONNECTED re-check on all four execution paths (runner + queue plan, scan + optimize) — the execution-time analogue of the console's preflight read. A Disconnected **load-bearing** device refuses with `GeecsDeviceDownError` naming it, before any scan number is burned — free-run: the reference (rows are paced by it); strict: any synchronous device (rows await all). Any other Disconnected device warns and continues, recorded in run metadata as `disconnected_devices`. Fail-open per the liveness doctrine (unreadable ≠ down); reads via the `oneshot` helper, `datatype=str` (the DBR_ENUM contract).
- **t0-sync liveness gate** (~45 LOC): `geecs_t0_sync` refuses to seed when a device's `connected_status` reads the exact `Disconnected` choice string (in-plan `bps.rd` — the strict refire gate's read; fail-open on missing attribute/failed read). **Deliberately NOT a timestamp-freshness bound**: #664's remedy 1 as originally sketched is unsound in this facility — at rest with the trigger parked (laser-off operation) a *healthy* cache is legitimately hours old (Scan014 of 26_0821 passed t0-sync in exactly that state and ran clean), so freshness cannot distinguish dead from quiescent; `connected_status` can.

Design note flagged for cheap veto: the severity split (refuse load-bearing / warn-and-continue others) is my judgment call — a queued overnight scan shouldn't die for a snapshot device, but a scan that cannot produce a single row should refuse with the device named rather than burn a scan number and time out.

Test amendments that travel with the behavior: the read-path staging and telemetry read-count pins now allow the gate's **bounded once-per-scan** `connected_status` reads (deliberately outside the staged cache — a liveness probe must not be served from a possibly-dead monitor); per-row costs remain pinned at zero/4-per-row.

## Tests

GeecsBluesky: **609 passed, 3 deselected** (`check.sh` green end to end). New pins: `tests/test_preflight_connected.py` (8 tests — refusal by role/mode, warn-and-continue, fail-open, enum-string contract, no-read short-circuits) and `TestT0SyncLivenessGate` in `tests/test_shot_id.py` (RunEngine-driven: Disconnected refuses before seeding, Connected seeds, statusless device is fail-open).

## Hardware verification

- The incident itself is the negative case: two live failures (26_0822 Scans 001–002) with the exact signature this PR eliminates; `scan.log` + manager history preserved.
- `_preflight_connected` executed live against the real Undulator gateway from this branch (2026-08-22): with the restored `UC_Amp4_IR_input` it reads the DBR_ENUM choice string `Connected` and passes clean.
- The refusal path is pinned hermetically; a live dead-device refusal requires deliberately killing a device and is **OWED at the next natural opportunity** (e.g. next host update or device restart: submit a queued noscan against a down device and confirm the pre-claim `GeecsDeviceDownError` names it, no scan folder created).

🤖 Generated with [Claude Code](https://claude.com/claude-code)