### PR TITLE
GeecsBluesky 0.60.0: config listings on ConfigsRepoResolver (#666)

### DIFF
--- a/GeecsBluesky/CHANGELOG.md
+++ b/GeecsBluesky/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to `geecs-bluesky` are documented here.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.60.0] - 2026-08-22
+
+### Added
+
+- **Config listings on `ConfigsRepoResolver`** (#666, the scan-MCP
+  prerequisite): `list_save_sets()`, `list_trigger_profiles()`,
+  `list_presets()`, and `list_optimizer_configs()` — sorted YAML stems
+  with the console's listing semantics (a missing configs root,
+  experiment folder, or kind folder reads as `[]`, never an exception;
+  a listed name is a file, not a promise — resolution can still refuse
+  it).  Non-GUI clients (the scan MCP, notebooks) can now enumerate an
+  experiment's catalogs without importing console code; the resolver
+  gains the `PRESET_FOLDER`/`OPTIMIZER_FOLDER` constants so the folder
+  layout has one owner.  Console consumption of the shared surface is
+  deferred to the next console-touching PR.
+
 ## [0.59.0] - 2026-08-22
 
 ### Added

--- a/GeecsBluesky/CHANGELOG.md
+++ b/GeecsBluesky/CHANGELOG.md
@@ -14,11 +14,17 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   with the console's listing semantics (a missing configs root,
   experiment folder, or kind folder reads as `[]`, never an exception;
   a listed name is a file, not a promise — resolution can still refuse
-  it).  Non-GUI clients (the scan MCP, notebooks) can now enumerate an
+  it, but every listed name now round-trips: `resolve_save_set` /
+  `resolve_trigger_profile` resolve the `.yml` twin spelling too,
+  matching the console's `NamedConfigStore` behavior — review finding).
+  Non-GUI clients (the scan MCP, notebooks) can now enumerate an
   experiment's catalogs without importing console code; the resolver
   gains the `PRESET_FOLDER`/`OPTIMIZER_FOLDER` constants so the folder
-  layout has one owner.  Console consumption of the shared surface is
-  deferred to the next console-touching PR.
+  layout has one owner **once the console rewires onto them** (deferred
+  to the next console-touching PR; rewire trap noted: the console's
+  copies are named `PRESET_FOLDER` in `presets.py` but
+  `OPTIMIZATION_FOLDER` in `configs.py` — map both onto the resolver's
+  constants, don't add a third name).
 
 ## [0.59.0] - 2026-08-22
 

--- a/GeecsBluesky/CLAUDE.md
+++ b/GeecsBluesky/CLAUDE.md
@@ -78,7 +78,11 @@ geecs_bluesky/
                             #   extra, lazily imported inside methods
   config_resolver.py        # ConfigResolver protocol + ConfigsRepoResolver:
                             #   ScanRequest names → schema models (new-schema
-                            #   YAML directly, else legacy-convert)
+                            #   YAML directly, else legacy-convert) + the
+                            #   list_save_sets/list_trigger_profiles/
+                            #   list_presets/list_optimizer_configs listing
+                            #   surface for non-GUI clients (#666 — sorted
+                            #   stems, missing-anything reads as [])
   forward_expr.py           # compile_forward — AST-whitelist compiler for
                             #   pseudo-variable forward formulas (arithmetic +
                             #   math functions; scanned value = composite_var

--- a/GeecsBluesky/geecs_bluesky/config_resolver.py
+++ b/GeecsBluesky/geecs_bluesky/config_resolver.py
@@ -89,10 +89,16 @@ class ConfigsRepoResolver:
       ``scan_devices/scan_devices.yaml`` + ``scan_devices/composite_variables.yaml``
       pair — the scan-variable catalog
     - ``action_library/actions.yaml`` — the action-plan library
+    - ``presets/<name>.yaml`` and ``optimizer_configs/<name>.yaml`` —
+      listed (for clients) but not resolved here: presets are
+      ``ScanRequest`` documents and optimizer configs are
+      ``OptimizationSpec`` documents, both validated by their consumers.
 
     A file whose top level carries ``schema_version`` is loaded as the new
     schema; anything else goes through the matching legacy converter — so
     the existing corpus works unchanged and files can migrate one at a time.
+    Named configs resolve from either the ``.yaml`` or ``.yml`` spelling
+    (console parity), so every listed name round-trips through resolution.
 
     Parameters
     ----------
@@ -139,6 +145,22 @@ class ConfigsRepoResolver:
                 return name[: -len(suffix)]
         return name
 
+    def _named_yaml_path(self, folder: str, stem: str) -> Path:
+        """The config file for *stem* in *folder*: ``.yaml``, else its ``.yml`` twin.
+
+        The console resolves both spellings (``NamedConfigStore._named_path``
+        parity) and the listings count both, so resolution must round-trip
+        every listed name.  When neither exists, the ``.yaml`` path is
+        returned so the not-found error names the canonical spelling.
+        """
+        base = self._root / folder
+        path = base / f"{stem}.yaml"
+        if not path.exists():
+            twin = base / f"{stem}.yml"
+            if twin.exists():
+                return twin
+        return path
+
     def _load_yaml(self, path: Path, kind: str, name: str) -> dict:
         """Load one YAML mapping, failing loudly with the config kind/name."""
         if not path.exists():
@@ -164,20 +186,27 @@ class ConfigsRepoResolver:
         """Sorted YAML stems of one config folder; ``[]`` when anything is missing.
 
         Never raises — an unresolvable configs root, a missing experiment
-        folder, or a missing kind folder all read as an empty listing
-        (clients render "nothing available", they do not crash).  A listed
-        name is a *file*, not a promise: resolution/validation can still
-        refuse it (e.g. an action-only legacy save element).
+        folder, a missing kind folder, or an I/O failure mid-scan (an SMB
+        visibility blip on a mounted configs share, a permissions problem)
+        all read as an empty listing: clients render "nothing available",
+        they do not crash.  A listed name is a *file*, not a promise:
+        resolution/validation can still refuse it (e.g. an action-only
+        legacy save element).
         """
         try:
             path = self._root / folder
-        except Exception:  # configs root unresolvable — empty, not an error
+            if not path.is_dir():
+                return []
+            return sorted(
+                entry.stem
+                for entry in path.iterdir()
+                if entry.suffix in (".yaml", ".yml")
+            )
+        except Exception:  # root unresolvable / I/O failure — empty, never raise
+            logger.debug(
+                "config listing failed for %s (read as empty)", folder, exc_info=True
+            )
             return []
-        if not path.is_dir():
-            return []
-        return sorted(
-            entry.stem for entry in path.iterdir() if entry.suffix in (".yaml", ".yml")
-        )
 
     def list_save_sets(self) -> list[str]:
         """Names accepted by :meth:`resolve_save_set` (sorted; ``[]`` if none)."""
@@ -204,7 +233,7 @@ class ConfigsRepoResolver:
             Missing file, or an action-only legacy element (nothing to record).
         """
         stem = self._strip_yaml_suffix(name)
-        path = self._root / self.SAVE_SET_FOLDER / f"{stem}.yaml"
+        path = self._named_yaml_path(self.SAVE_SET_FOLDER, stem)
         document = self._load_yaml(path, "save set", name)
         if "schema_version" in document:
             return SaveSet.model_validate(document)
@@ -231,7 +260,7 @@ class ConfigsRepoResolver:
             Missing file, or a profile that names no trigger device.
         """
         stem = self._strip_yaml_suffix(name)
-        path = self._root / self.TRIGGER_FOLDER / f"{stem}.yaml"
+        path = self._named_yaml_path(self.TRIGGER_FOLDER, stem)
         document = self._load_yaml(path, "trigger profile", name)
         if "schema_version" in document:
             return TriggerProfile.model_validate(document)

--- a/GeecsBluesky/geecs_bluesky/config_resolver.py
+++ b/GeecsBluesky/geecs_bluesky/config_resolver.py
@@ -108,6 +108,8 @@ class ConfigsRepoResolver:
     TRIGGER_FOLDER = SHOT_CONTROL_FOLDER
     SCAN_VARIABLES_FOLDER = "scan_devices"
     ACTION_FOLDER = "action_library"
+    PRESET_FOLDER = "presets"
+    OPTIMIZER_FOLDER = "optimizer_configs"
 
     def __init__(
         self, experiment: str, experiments_root: str | Path | None = None
@@ -153,6 +155,45 @@ class ConfigsRepoResolver:
                 f"{path}, got {type(document).__name__}"
             )
         return document
+
+    # ------------------------------------------------------------------
+    # Listings (folder scans — no YAML parsing, never raise)
+    # ------------------------------------------------------------------
+
+    def _list_folder(self, folder: str) -> list[str]:
+        """Sorted YAML stems of one config folder; ``[]`` when anything is missing.
+
+        Never raises — an unresolvable configs root, a missing experiment
+        folder, or a missing kind folder all read as an empty listing
+        (clients render "nothing available", they do not crash).  A listed
+        name is a *file*, not a promise: resolution/validation can still
+        refuse it (e.g. an action-only legacy save element).
+        """
+        try:
+            path = self._root / folder
+        except Exception:  # configs root unresolvable — empty, not an error
+            return []
+        if not path.is_dir():
+            return []
+        return sorted(
+            entry.stem for entry in path.iterdir() if entry.suffix in (".yaml", ".yml")
+        )
+
+    def list_save_sets(self) -> list[str]:
+        """Names accepted by :meth:`resolve_save_set` (sorted; ``[]`` if none)."""
+        return self._list_folder(self.SAVE_SET_FOLDER)
+
+    def list_trigger_profiles(self) -> list[str]:
+        """Names accepted by :meth:`resolve_trigger_profile` (sorted; ``[]`` if none)."""
+        return self._list_folder(self.TRIGGER_FOLDER)
+
+    def list_presets(self) -> list[str]:
+        """Saved preset names (each file is a ``ScanRequest``; sorted; ``[]`` if none)."""
+        return self._list_folder(self.PRESET_FOLDER)
+
+    def list_optimizer_configs(self) -> list[str]:
+        """Optimizer-config names (``OptimizationSpec`` documents; sorted; ``[]`` if none)."""
+        return self._list_folder(self.OPTIMIZER_FOLDER)
 
     def resolve_save_set(self, name: str) -> SaveSet:
         """Load the save set *name* (new schema, else converted save element).

--- a/GeecsBluesky/pyproject.toml
+++ b/GeecsBluesky/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-bluesky"
-version = "0.59.0"
+version = "0.60.0"
 description = "Bluesky / ophyd-async bridge for the GEECS control system"
 authors = ["Sam Barber <sbarber@lbl.gov>"]
 readme = "README.md"

--- a/GeecsBluesky/tests/test_config_listings.py
+++ b/GeecsBluesky/tests/test_config_listings.py
@@ -62,6 +62,34 @@ def test_missing_experiment_is_empty(repo):
     assert resolver.list_save_sets() == []
 
 
+def test_listed_yml_names_round_trip_through_resolution(repo):
+    # Review finding: the listings count .yml files, so resolution must
+    # accept them too (console NamedConfigStore parity) — a listed name
+    # that resolve_* refuses on spelling alone is a client-facing trap.
+    exp = repo / "TestExp"
+    (exp / ConfigsRepoResolver.SAVE_SET_FOLDER / "YmlSet.yml").write_text(
+        "Devices:\n  UC_Cam:\n    variable_list: [MeanCounts]\n    synchronous: true\n"
+    )
+    resolver = ConfigsRepoResolver("TestExp", experiments_root=repo)
+    assert "YmlSet" in resolver.list_save_sets()
+    save_set = resolver.resolve_save_set("YmlSet")
+    assert [entry.device for entry in save_set.entries] == ["UC_Cam"]
+
+
+def test_io_failure_mid_scan_is_empty(repo, monkeypatch):
+    # The never-raises contract covers the scan itself, not just root
+    # resolution — an SMB blip / permissions failure during iterdir must
+    # read as empty (review finding).
+    from pathlib import Path
+
+    def boom(self):
+        raise PermissionError("share blipped")
+
+    monkeypatch.setattr(Path, "iterdir", boom)
+    resolver = ConfigsRepoResolver("TestExp", experiments_root=repo)
+    assert resolver.list_save_sets() == []
+
+
 def test_unresolvable_configs_root_is_empty(monkeypatch):
     # No experiments_root override and the production resolution raises
     # (no env var, no config.ini entry) — listing reads empty, never raises.

--- a/GeecsBluesky/tests/test_config_listings.py
+++ b/GeecsBluesky/tests/test_config_listings.py
@@ -1,0 +1,74 @@
+"""Pin the resolver's config-listing surface (#666).
+
+Non-GUI clients (the scan MCP, notebooks) need to enumerate the
+experiment's save sets / trigger profiles / presets without importing
+console code — the listing lives beside the resolution it feeds, with the
+console-matching semantics: sorted YAML stems, and every missing layer
+(configs root, experiment folder, kind folder) reads as an empty list,
+never an exception.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from geecs_bluesky.config_resolver import ConfigsRepoResolver
+
+
+@pytest.fixture
+def repo(tmp_path):
+    """A minimal configs-repo experiments root with one experiment."""
+    exp = tmp_path / "TestExp"
+    for folder, names in {
+        ConfigsRepoResolver.SAVE_SET_FOLDER: ["Amp4In", "BCave"],
+        ConfigsRepoResolver.TRIGGER_FOLDER: ["HTU-LaserOFF"],
+        ConfigsRepoResolver.PRESET_FOLDER: ["basic test"],
+        ConfigsRepoResolver.OPTIMIZER_FOLDER: ["bayes_jet"],
+    }.items():
+        d = exp / folder
+        d.mkdir(parents=True)
+        for name in names:
+            (d / f"{name}.yaml").write_text("{}\n")
+    return tmp_path
+
+
+def test_listings_return_sorted_stems(repo):
+    resolver = ConfigsRepoResolver("TestExp", experiments_root=repo)
+    assert resolver.list_save_sets() == ["Amp4In", "BCave"]
+    assert resolver.list_trigger_profiles() == ["HTU-LaserOFF"]
+    assert resolver.list_presets() == ["basic test"]
+    assert resolver.list_optimizer_configs() == ["bayes_jet"]
+
+
+def test_yml_suffix_counts_and_others_do_not(repo):
+    folder = repo / "TestExp" / ConfigsRepoResolver.SAVE_SET_FOLDER
+    (folder / "Extra.yml").write_text("{}\n")
+    (folder / "notes.txt").write_text("not a config\n")
+    (folder / "README.md").write_text("docs\n")
+    resolver = ConfigsRepoResolver("TestExp", experiments_root=repo)
+    assert resolver.list_save_sets() == ["Amp4In", "BCave", "Extra"]
+
+
+def test_missing_kind_folder_is_empty(repo):
+    import shutil
+
+    shutil.rmtree(repo / "TestExp" / ConfigsRepoResolver.PRESET_FOLDER)
+    resolver = ConfigsRepoResolver("TestExp", experiments_root=repo)
+    assert resolver.list_presets() == []
+
+
+def test_missing_experiment_is_empty(repo):
+    resolver = ConfigsRepoResolver("NoSuchExp", experiments_root=repo)
+    assert resolver.list_save_sets() == []
+
+
+def test_unresolvable_configs_root_is_empty(monkeypatch):
+    # No experiments_root override and the production resolution raises
+    # (no env var, no config.ini entry) — listing reads empty, never raises.
+    monkeypatch.setattr(
+        "geecs_bluesky.config_resolver.scanner_configs_base",
+        lambda: (_ for _ in ()).throw(RuntimeError("unconfigured")),
+    )
+    resolver = ConfigsRepoResolver("TestExp")
+    assert resolver.list_save_sets() == []
+    assert resolver.list_trigger_profiles() == []


### PR DESCRIPTION
## What + why

Closes #666 — the scan-MCP prerequisite (the MCP is homed in this repo by owner decision, 2026-08-22; #666 carries that record). Non-GUI clients (the MCP's v0 `list_scan_configs` verb, notebooks) need to enumerate an experiment's save sets / trigger profiles / presets without importing console code. Per the issue (and a second confirming review): the listing lives beside the resolution it feeds — `ConfigsRepoResolver` already owns the folder layout.

- `list_save_sets()` / `list_trigger_profiles()` / `list_presets()` / `list_optimizer_configs()` — sorted YAML stems (`.yaml`/`.yml`), console-matching semantics: a missing configs root, experiment folder, or kind folder reads as `[]`, never an exception; a listed name is a file, not a promise (resolution can still refuse it, e.g. an action-only legacy save element).
- `PRESET_FOLDER` / `OPTIMIZER_FOLDER` constants added so the layout knowledge has one owner (they were console-local strings).

**Flagged judgment calls (cheap to veto):**
- `list_optimizer_configs()` is beyond #666's literal scope (+3 lines) — included so the surface is complete for the console rewire.
- Console consumption of the shared surface is **deferred** to the next console-touching PR (scope discipline; the console's local folder scan is behavior-identical today).
- The `ConfigResolver` *protocol* deliberately does not grow the listing methods — listing is a repo-resolver capability, not something every resolver must provide.

## Tests

GeecsBluesky: **614 passed, 3 deselected** (`check.sh` green). New pins in `tests/test_config_listings.py`: sorted stems across all four kinds, `.yml` counted / other suffixes not, missing kind folder → `[]`, missing experiment → `[]`, unresolvable configs root → `[]` (never raises).

## Hardware verification

Not applicable — pure filesystem listing, no scan execution or device surface. (The semantics were sanity-checked against the live Undulator configs checkout during development: the listings match the console's dropdowns' source folders.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)