### PR TITLE
GEECS-Scan-MCP 0.2.0 + GeecsBluesky 0.61.0: the v1 control tools

### DIFF
--- a/GEECS-Scan-MCP/CHANGELOG.md
+++ b/GEECS-Scan-MCP/CHANGELOG.md
@@ -91,3 +91,27 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - `get_scan_result`'s missing-selector check runs before the catalog is
   constructed — pure argument validation no longer depends on archive
   setup, and its test needs no catalog patch (P3).
+
+### v1 review hardening (same release, adversarial review on the PR)
+
+- The shot cap counts via the schema's new non-materializing
+  `planned_shots()` (GEECS-Schemas 0.11.0) — a pathological
+  agent-composed range is refused arithmetically instead of OOMing the
+  server inside its own guard (HIGH finding); the three parallel
+  size-counters consolidate to one.
+- `acknowledge_warnings` names outside the known check vocabulary are
+  refused (typo guard), and the honest residual is documented: a
+  stateless server cannot stop a first-call pre-acknowledgement — the
+  backstops are OSPREY's approval prompt (which shows the arguments)
+  and the provenance record (`continued` stamps only for questions
+  actually raised).
+- The optimize-without-`max_iterations` refusal is genuinely pinned (the
+  old test's spec was schema-invalid and never reached the branch) and
+  its message no longer misstates the engine (which defaults to 20).
+- `forced` in stop results marks ONLY operator-authorized stops of
+  another client's scan — a habitual `force=true` on the MCP's own scan
+  no longer pollutes the audit marker.
+- One spelling of the must-match identity (`client_identity()` feeds
+  both the queue user and the SubmissionRecord), resolved outside the
+  runtime lock; unparseable `[scan_mcp] max_shots` warns instead of
+  silently running at the default.

--- a/GEECS-Scan-MCP/CHANGELOG.md
+++ b/GEECS-Scan-MCP/CHANGELOG.md
@@ -4,6 +4,32 @@ All notable changes to `geecs-scan-mcp` are documented here.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.2.0] - 2026-08-22
+
+### Added
+
+- **The v1 control tools** (owner decisions 2026-08-22: presets AND
+  composed dicts from day one, 1,000-shot cap, approval-gated force):
+  - `submit_scan(request|preset, description?, acknowledge_warnings?)` —
+    validate → agent shot cap (`[scan_mcp] max_shots`, default 1,000;
+    optimize needs an explicit `max_iterations`) → queue etiquette (one
+    scan in flight; refuses while anything is queued or running, never
+    clears implicitly) → full preflight with the
+    **acknowledge-warnings loop** (unacknowledged questions return as
+    `needs_acknowledgement`; acknowledgements stamp `continued` into
+    the run's `SubmissionRecord`) → stamp with the deployment identity
+    (`[scan_mcp] client_identity`, default `geecs-scan-mcp <version>`)
+    → queue. Submit-and-poll: returns `item_uid` immediately.
+  - `stop_scan(force?)` — graceful stop; refuses another client's scan
+    naming its submitting identity unless `force=true` (approval-gated
+    osprey-side, logged in the result). Approval-only, never behind the
+    kill switch (in-tool doctrine).
+  - `clear_queue()` — the one remover; lists exactly what it removed.
+  - `scan_progress()` — poll-shaped (read-only): RE state, running item
+    + submitting client, queue depth, last outcome.
+- Backed by GeecsBluesky 0.61.0's `running_item()`/`clear_queue()` on
+  the client protocol and `resolve_preset()` on the resolver.
+
 ## [0.1.0] - 2026-08-22
 
 ### Added

--- a/GEECS-Scan-MCP/CLAUDE.md
+++ b/GEECS-Scan-MCP/CLAUDE.md
@@ -64,24 +64,29 @@ geecs_scan_mcp/
   history mapping) — the queueserver's payload fields are not a contract
   we own.
 
-## Verb roadmap (the planning doc's phasing — v0 is built)
+## Verb roadmap (the planning doc's phasing, as amended by owner decisions)
 
 - **v0 (built)**: `scan_status`, `scan_history`, `get_scan_result`,
-  `list_scan_configs`, `validate_scan_request` — all read-only (R),
+  `list_scan_configs`, `validate_scan_request` — read-only (R),
   auto-allow.
-- **v1a**: `submit_scan` (presets only) + `stop_scan` + `clear_queue` +
-  poll `scan_progress`.  Blockers before building: the owner's answers
-  to the plan's open questions (agent shot cap — recommended 10,000;
-  force-override semantics; runtime host).  Key rules already decided:
-  acknowledge-warnings loop (no silent continue past a preflight
-  question; acknowledgements stamp `continued` into
-  `SubmissionRecord.preflight`), `clear_pending=False` always
-  (`clear_queue` is its own approval-gated verb), ownership etiquette
-  (refuse to stop a scan whose `submission.client` isn't ours without
-  `force`), stop is approval-only and must survive the kill switch
-  (in-tool guard, the osprey bluesky-server doctrine).
-- **v1b**: composed `request:` dicts.  **v2**: actions, moves,
-  pause/resume, doc-stream `scan_progress`.
+- **v1 (built — owner decisions 2026-08-22)**: `submit_scan` takes
+  presets AND composed dicts from day one (the plan's presets-first
+  de-risk was dropped: presets are barely used in practice), agent shot
+  cap 1,000 (`[scan_mcp] max_shots`; optimize needs explicit
+  `max_iterations`), `stop_scan` with approval-gated `force` for
+  foreign scans, `clear_queue` as the one remover, poll
+  `scan_progress`.  The standing rules, all enforced in
+  `tools/control_tools.py`: acknowledge-warnings loop (no silent
+  continue past a preflight question; acknowledgements stamp
+  `continued` into `SubmissionRecord.preflight`), `clear_pending=False`
+  always, ownership etiquette on stop, stop approval-only and never
+  behind the kill switch (in-tool doctrine — per-tool hook matchers
+  don't exist for custom servers).  The submitted-as identity is
+  `[scan_mcp] client_identity` (deployment-owned, e.g.
+  `osprey-htu-assistant`) and MUST match on the queue item and the
+  `SubmissionRecord` — the ownership check compares against it.
+- **v2**: actions, moves, pause/resume, doc-stream `scan_progress`
+  (per-shot counts, paused reasons from the console-text stream).
 
 ## Testing
 

--- a/GEECS-Scan-MCP/README.md
+++ b/GEECS-Scan-MCP/README.md
@@ -4,10 +4,14 @@ MCP server giving AI agents (the OSPREY HTU assistant) access to the GEECS
 scan service: the bluesky-queueserver RE Manager, the configs repo, and
 the Tiled archive.
 
-**v0 (current): read-only.** Five tools — `scan_status`, `scan_history`,
-`get_scan_result`, `list_scan_configs`, `validate_scan_request` — zero
-write risk. Submission and control verbs (`submit_scan`, `stop_scan`, …)
-arrive in v1 behind OSPREY's approval hooks.
+**v0 + v1 (current).** Read-only: `scan_status`, `scan_history`,
+`get_scan_result`, `list_scan_configs`, `validate_scan_request`,
+`scan_progress`. Control (put these under OSPREY `ask` + hooks):
+`submit_scan` (one scan in flight, 1,000-shot cap, preflight warnings
+need explicit acknowledgement), `stop_scan` (graceful; `force` for
+another client's scan is approval territory — and keep stop OUT of the
+kill-switch hook so a halt is always possible), `clear_queue` (the one
+remover).
 
 ## Run
 

--- a/GEECS-Scan-MCP/geecs_scan_mcp/__init__.py
+++ b/GEECS-Scan-MCP/geecs_scan_mcp/__init__.py
@@ -7,4 +7,4 @@ and request validation — zero write risk.  See ``CLAUDE.md`` for the
 verb roadmap (submit/stop in v1) and the safety doctrine.
 """
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"

--- a/GEECS-Scan-MCP/geecs_scan_mcp/errors.py
+++ b/GEECS-Scan-MCP/geecs_scan_mcp/errors.py
@@ -71,8 +71,22 @@ def make_ok(**payload: Any) -> str:
     return json.dumps({"ok": True, **_json_safe(payload)}, default=str, allow_nan=False)
 
 
-def make_error(error_kind: str, message: str) -> str:
-    """Serialize a failure envelope: ``{"ok": false, error_kind, message}``."""
+def make_error(error_kind: str, message: str, **extra: Any) -> str:
+    """Serialize a failure envelope: ``{"ok": false, error_kind, message}``.
+
+    ``extra`` carries structured refusal context (``pending_items``,
+    ``needs_acknowledgement``) — same strict-JSON discipline as
+    :func:`make_ok`.
+    """
     if error_kind not in ERROR_KINDS:  # programmer error — fail loudly in tests
         raise ValueError(f"unknown error_kind {error_kind!r}")
-    return json.dumps({"ok": False, "error_kind": error_kind, "message": message})
+    return json.dumps(
+        {
+            "ok": False,
+            "error_kind": error_kind,
+            "message": message,
+            **_json_safe(extra),
+        },
+        default=str,
+        allow_nan=False,
+    )

--- a/GEECS-Scan-MCP/geecs_scan_mcp/runtime.py
+++ b/GEECS-Scan-MCP/geecs_scan_mcp/runtime.py
@@ -27,9 +27,16 @@ from geecs_scan_mcp import __version__
 
 _USER_CONFIG_PATH = Path("~/.config/geecs_python_api/config.ini")
 
-#: The submitted-as identity the manager records on queue items, and the
-#: ``SubmissionRecord.client`` prefix — how runs trace back to this server.
+#: The default submitted-as identity — how runs trace back to this
+#: server.  A deployment can override it via ``[scan_mcp]
+#: client_identity`` (e.g. ``osprey-htu-assistant``); the queue item's
+#: ``user`` and the ``SubmissionRecord.client`` always use the same
+#: value, or stop_scan's ownership check would never match.
 CLIENT_IDENTITY = f"geecs-scan-mcp {__version__}"
+
+#: The agent scan-size cap default (owner decision 2026-08-22:
+#: conservative first posture).  Override: ``[scan_mcp] max_shots``.
+DEFAULT_MAX_SHOTS = 1000
 
 _cache: dict[str, Any] = {}
 # First-use builds race under FastMCP's concurrent tool dispatch (one agent
@@ -66,9 +73,43 @@ def _read_experiment() -> Optional[str]:
         return None
 
 
+def _read_scan_mcp_option(option: str) -> Optional[str]:
+    """One ``[scan_mcp]`` option from the shared config, or ``None``."""
+    path = _USER_CONFIG_PATH.expanduser()
+    if not path.exists():
+        return None
+    parser = configparser.ConfigParser()
+    try:
+        parser.read(path)
+        return parser.get("scan_mcp", option, fallback="").strip() or None
+    except (OSError, configparser.Error):
+        return None
+
+
 def get_experiment() -> Optional[str]:
     """The configured experiment name (``[Experiment] expt``), or ``None``."""
     return _cached("experiment", _read_experiment)
+
+
+def client_identity() -> str:
+    """The deployment's submitted-as identity (config override or default)."""
+    return _cached(
+        "client_identity",
+        lambda: _read_scan_mcp_option("client_identity") or CLIENT_IDENTITY,
+    )
+
+
+def max_shots() -> int:
+    """The agent scan-size cap (``[scan_mcp] max_shots``, default 1000)."""
+
+    def build() -> int:
+        raw = _read_scan_mcp_option("max_shots")
+        try:
+            return int(raw) if raw else DEFAULT_MAX_SHOTS
+        except ValueError:
+            return DEFAULT_MAX_SHOTS
+
+    return _cached("max_shots", build)
 
 
 def get_queue_client() -> Any:
@@ -77,7 +118,10 @@ def get_queue_client() -> Any:
     def build() -> Any:
         from geecs_bluesky.qs_client import make_queue_client
 
-        return make_queue_client(_read_experiment() or "", user=CLIENT_IDENTITY)
+        return make_queue_client(
+            _read_experiment() or "",
+            user=_read_scan_mcp_option("client_identity") or CLIENT_IDENTITY,
+        )
 
     return _cached("queue_client", build)
 

--- a/GEECS-Scan-MCP/geecs_scan_mcp/runtime.py
+++ b/GEECS-Scan-MCP/geecs_scan_mcp/runtime.py
@@ -23,7 +23,11 @@ import threading
 from pathlib import Path
 from typing import Any, Optional
 
+import logging
+
 from geecs_scan_mcp import __version__
+
+logger = logging.getLogger("geecs_scan_mcp.runtime")
 
 _USER_CONFIG_PATH = Path("~/.config/geecs_python_api/config.ini")
 
@@ -107,6 +111,13 @@ def max_shots() -> int:
         try:
             return int(raw) if raw else DEFAULT_MAX_SHOTS
         except ValueError:
+            # A deployment that intended a STRICTER cap must not silently
+            # run at the default (review finding) — warn loudly.
+            logger.warning(
+                "[scan_mcp] max_shots = %r is not an integer — using the default of %d",
+                raw,
+                DEFAULT_MAX_SHOTS,
+            )
             return DEFAULT_MAX_SHOTS
 
     return _cached("max_shots", build)
@@ -114,14 +125,17 @@ def max_shots() -> int:
 
 def get_queue_client() -> Any:
     """The shared RE Manager client, stamped with this server's identity."""
+    # THE one identity spelling: the queue item's user and the
+    # SubmissionRecord.client must match or the ownership check never
+    # fires — both read client_identity() (review finding).  Resolved
+    # BEFORE the cached build: _cached holds the non-reentrant lock, and
+    # client_identity() takes it too.
+    identity = client_identity()
 
     def build() -> Any:
         from geecs_bluesky.qs_client import make_queue_client
 
-        return make_queue_client(
-            _read_experiment() or "",
-            user=_read_scan_mcp_option("client_identity") or CLIENT_IDENTITY,
-        )
+        return make_queue_client(_read_experiment() or "", user=identity)
 
     return _cached("queue_client", build)
 

--- a/GEECS-Scan-MCP/geecs_scan_mcp/server.py
+++ b/GEECS-Scan-MCP/geecs_scan_mcp/server.py
@@ -24,18 +24,23 @@ mcp = FastMCP(
         "Read-only access to the GEECS scan service (v0): manager/queue "
         "status, recent scan history, completed-run results from the Tiled "
         "archive, the experiment's config catalogs (save sets, trigger "
-        "profiles, presets, scan variables, actions), and full dry-run "
-        "validation of a ScanRequest. Names must come from "
-        "list_scan_configs — never invent catalog names. Submission and "
-        "control verbs arrive in v1; today this server cannot start, stop, "
-        "or modify anything."
+        "profiles, presets, scan variables, actions), full dry-run "
+        "validation of a ScanRequest, and the v1 control verbs: "
+        "submit_scan (one scan in flight, capped, preflight warnings need "
+        "explicit acknowledgement), stop_scan (graceful; another client's "
+        "scan needs force=true and an operator's say-so), clear_queue "
+        "(the only remover), scan_progress. Names must come from "
+        "list_scan_configs — never invent catalog names."
     ),
 )
 
 
 def create_server() -> FastMCP:
     """Register every tool module and return the server."""
-    from geecs_scan_mcp.tools import read_tools  # noqa: F401 — self-registers
+    from geecs_scan_mcp.tools import (  # noqa: F401 — self-register
+        control_tools,
+        read_tools,
+    )
 
-    logger.info("geecs-scan MCP server initialised (v0 read-only tools)")
+    logger.info("geecs-scan MCP server initialised (v0 read + v1 control tools)")
     return mcp

--- a/GEECS-Scan-MCP/geecs_scan_mcp/tool_names.py
+++ b/GEECS-Scan-MCP/geecs_scan_mcp/tool_names.py
@@ -16,12 +16,29 @@ SCAN_HISTORY = "scan_history"
 GET_SCAN_RESULT = "get_scan_result"
 LIST_SCAN_CONFIGS = "list_scan_configs"
 VALIDATE_SCAN_REQUEST = "validate_scan_request"
+SCAN_PROGRESS = "scan_progress"
+SUBMIT_SCAN = "submit_scan"
+STOP_SCAN = "stop_scan"
+CLEAR_QUEUE = "clear_queue"
 
-#: Every v0 tool — read-only, safe to auto-allow in profile.yml.
+#: Read-only tools (R) — safe to auto-allow in profile.yml.
 READ_TOOLS = (
     SCAN_STATUS,
     SCAN_HISTORY,
     GET_SCAN_RESULT,
     LIST_SCAN_CONFIGS,
     VALIDATE_SCAN_REQUEST,
+    SCAN_PROGRESS,
 )
+
+#: Queueing tools (Q) — `ask` + the writes_check (kill switch) preset.
+QUEUE_TOOLS = (
+    SUBMIT_SCAN,
+    CLEAR_QUEUE,
+)
+
+#: Stop direction (S) — `ask` ONLY, never behind the kill switch: a halt
+#: must always be possible (the osprey bluesky-server doctrine; the
+#: exemption is enforced in-tool since per-tool hook matchers don't
+#: exist for custom servers).
+STOP_TOOLS = (STOP_SCAN,)

--- a/GEECS-Scan-MCP/geecs_scan_mcp/tools/control_tools.py
+++ b/GEECS-Scan-MCP/geecs_scan_mcp/tools/control_tools.py
@@ -38,7 +38,11 @@ logger = logging.getLogger("geecs_scan_mcp.tools.control")
 # ---------------------------------------------------------------------------
 
 
-#: The preflight checks whose warnings can be acknowledged.  Names outside
+#: The preflight checks whose warnings can be acknowledged.  Hand-kept in
+#: sync with the ``PreflightOutcome.check`` vocabulary of
+#: ``geecs_bluesky.qs_client.submit_preflight`` (fail-closed on drift: a
+#: new check's question could not be acknowledged until this tuple is
+#: updated — update BOTH when adding a check).  Names outside
 #: this vocabulary in ``acknowledge_warnings`` are refused (typo guard).
 #: HONEST RESIDUAL (review finding): the server is stateless, so an agent
 #: that pre-acknowledges these known names on its FIRST call skips the

--- a/GEECS-Scan-MCP/geecs_scan_mcp/tools/control_tools.py
+++ b/GEECS-Scan-MCP/geecs_scan_mcp/tools/control_tools.py
@@ -1,0 +1,345 @@
+"""The v1 control tools: submit, stop, clear-queue, and poll progress.
+
+Same conventions as :mod:`.read_tools` (sync ``_*_impl`` = the tested
+surface, async wrappers via the guard, JSON envelopes, engine text
+verbatim).  The safety doctrine (owner decisions 2026-08-22 + the
+planning doc §2):
+
+- ``submit_scan`` takes a preset name OR a composed request dict (both
+  from day one — presets are barely used in practice), enforces the
+  agent scan-size cap (default 1,000 shots), refuses while anything is
+  queued or running, runs the full preflight, and **never continues
+  silently past a warning** — unacknowledged questions come back as
+  ``needs_acknowledgement`` and each acknowledgement is stamped
+  ``continued`` into the run's ``SubmissionRecord``.  ``clear_pending``
+  is never used.
+- ``stop_scan`` refuses another client's scan by name unless
+  ``force=true`` (approval-gated osprey-side, and always logged in the
+  result); it is approval-only and must NEVER sit behind the kill
+  switch — a halt must always be possible.
+- ``clear_queue`` is the one verb that removes items — explicit,
+  approval-gated recovery from the failed-item-at-front state; nothing
+  clears implicitly.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from geecs_scan_mcp import errors, runtime, tool_names
+from geecs_scan_mcp.server import mcp
+from geecs_scan_mcp.tools.read_tools import _run_guarded
+
+logger = logging.getLogger("geecs_scan_mcp.tools.control")
+
+
+# ---------------------------------------------------------------------------
+# submit_scan
+# ---------------------------------------------------------------------------
+
+
+def _planned_shots(request) -> int | None:
+    """Total planned shots, or ``None`` when the request cannot say.
+
+    step/noscan: product of axis position counts × ``shots_per_step``
+    (noscan = one no-move bin).  optimize: ``max_iterations ×
+    shots_per_step`` — an optimize request WITHOUT an explicit
+    ``max_iterations`` returns ``None`` (the engine's auto budget is
+    open-ended; the agent cap needs a number, so submission requires one).
+    """
+    mode = getattr(request.mode, "value", request.mode)
+    if mode == "optimize":
+        spec = request.optimization
+        iterations = getattr(spec, "max_iterations", None) if spec else None
+        if not iterations:
+            return None
+        return int(iterations) * int(request.shots_per_step)
+    steps = 1
+    for axis in request.axes or []:
+        positions = axis.positions
+        values = getattr(positions, "values", None)
+        steps *= len(values) if values is not None else len(positions.to_values())
+    return steps * int(request.shots_per_step)
+
+
+def _submit_scan_impl(
+    request: dict | None,
+    preset: str | None,
+    description: str | None,
+    acknowledge_warnings: list[str] | None,
+) -> str:
+    """Validate → cap → etiquette → preflight → acknowledge → stamp → queue."""
+    from geecs_schemas import ScanRequest
+
+    if (request is None) == (preset is None):
+        return errors.make_error(
+            "invalid_request", "pass exactly one of request (a dict) or preset (a name)"
+        )
+    experiment = runtime.get_experiment()
+    if not experiment:
+        return errors.make_error(
+            "invalid_request",
+            "no experiment configured ([Experiment] expt in config.ini)",
+        )
+    # -- resolve + schema-validate -----------------------------------------
+    try:
+        if preset is not None:
+            resolver = runtime.get_resolver()
+            validated = resolver.resolve_preset(preset)
+        else:
+            validated = ScanRequest.model_validate(request)
+    except Exception as exc:
+        return errors.make_error("invalid_request", str(exc))
+    if description:
+        validated = validated.model_copy(update={"description": description})
+
+    # -- agent scan-size cap -------------------------------------------------
+    cap = runtime.max_shots()
+    shots = _planned_shots(validated)
+    if shots is None:
+        return errors.make_error(
+            "policy_refusal",
+            "optimize submissions need an explicit max_iterations (the "
+            f"engine's auto budget is open-ended; the agent cap is {cap} "
+            "shots)",
+        )
+    if shots > cap:
+        return errors.make_error(
+            "policy_refusal",
+            f"{shots} planned shots exceeds the agent cap of {cap} "
+            "([scan_mcp] max_shots) — shrink the scan or have an operator "
+            "run it from the console",
+        )
+
+    # -- queue etiquette: one scan in flight, never clear implicitly --------
+    client = runtime.get_queue_client()
+    status = client.status()
+    if not status.connected:
+        return errors.make_error("manager_unreachable", status.detail)
+    if status.re_state not in (None, "idle"):
+        return errors.make_error(
+            "policy_refusal",
+            f"a scan is active (RE state: {status.re_state}) — wait for it "
+            "or stop it first",
+        )
+    try:
+        pending = client.queue_items()
+    except Exception as exc:
+        return errors.make_error("manager_unreachable", str(exc))
+    if pending:
+        return errors.make_error(
+            "policy_refusal",
+            f"{len(pending)} item(s) already queued (usually a failed item "
+            "returned to the queue front) — inspect with scan_status and "
+            "clear explicitly with clear_queue",
+            pending_items=[
+                {
+                    "item_uid": item.get("item_uid"),
+                    "plan": item.get("name"),
+                    "user": item.get("user"),
+                }
+                for item in pending
+            ],
+        )
+
+    # -- preflight + acknowledge-warnings loop -------------------------------
+    from geecs_bluesky.qs_client import run_submit_preflight, stamp_submission
+
+    report = run_submit_preflight(validated, experiment)
+    if report.refusal is not None:
+        return errors.make_error("invalid_request", report.refusal)
+    acknowledged = set(acknowledge_warnings or [])
+    unacknowledged = [q for q in report.questions if q.check not in acknowledged]
+    if unacknowledged:
+        return errors.make_error(
+            "policy_refusal",
+            "preflight raised warnings that need explicit acknowledgement — "
+            "surface them to the human, then resubmit with "
+            "acknowledge_warnings listing each check name",
+            needs_acknowledgement=[
+                {"check": q.check, "title": q.title, "message": q.message}
+                for q in unacknowledged
+            ],
+        )
+    outcomes = list(report.outcomes) + [
+        (q.check, "continued", q.message[:200]) for q in report.questions
+    ]
+    stamped = stamp_submission(validated, outcomes, client=runtime.client_identity())
+
+    # -- queue it (never clear_pending) --------------------------------------
+    result = client.submit_scan(stamped.model_dump(mode="json"), clear_pending=False)
+    if not result.ok:
+        return errors.make_error(
+            "worker_refused",
+            result.message or "submission refused",
+            pending_items=result.pending_items,
+        )
+    return errors.make_ok(
+        item_uid=result.item_uid,
+        message=result.message,
+        planned_shots=shots,
+        submitted_as=runtime.client_identity(),
+    )
+
+
+@mcp.tool(name=tool_names.SUBMIT_SCAN)
+async def submit_scan(
+    request: dict | None = None,
+    preset: str | None = None,
+    description: str | None = None,
+    acknowledge_warnings: list[str] | None = None,
+) -> str:
+    """Queue one GEECS scan and start it (submit-and-poll).
+
+    Returns the queue item_uid immediately — track it with
+    scan_progress / scan_history. Pass exactly one of ``request`` (a composed ScanRequest dict — validate
+    with validate_scan_request first) or ``preset`` (a name from
+    list_scan_configs presets). Refuses while anything is queued or
+    running (one scan in flight; clear_queue is the only remover).
+    Preflight warnings return as ``needs_acknowledgement`` — show them to
+    the human, then resubmit naming each acknowledged check; the answers
+    are recorded in the run's provenance. Planned shots are capped
+    (default 1,000); optimize submissions need an explicit max_iterations.
+    """
+    return await _run_guarded(
+        _submit_scan_impl, request, preset, description, acknowledge_warnings
+    )
+
+
+# ---------------------------------------------------------------------------
+# stop_scan
+# ---------------------------------------------------------------------------
+
+
+def _stop_scan_impl(force: bool) -> str:
+    """Ownership-gated graceful stop (partial data preserved)."""
+    client = runtime.get_queue_client()
+    status = client.status()
+    if not status.connected:
+        return errors.make_error("manager_unreachable", status.detail)
+    running = None
+    try:
+        running = client.running_item()
+    except Exception:  # fail-open: an unreadable item never blocks a halt
+        logger.debug("running-item read failed before stop", exc_info=True)
+    if running and not force:
+        owner = running.get("user")
+        if owner and owner != runtime.client_identity():
+            return errors.make_error(
+                "policy_refusal",
+                f"the running scan was submitted by {owner!r} — pass "
+                "force=true only if the operator explicitly asks for the stop",
+            )
+    ok, message = client.stop_scan()
+    if not ok:
+        return errors.make_error("worker_refused", message)
+    return errors.make_ok(message=message, forced=bool(force and running))
+
+
+@mcp.tool(name=tool_names.STOP_SCAN)
+async def stop_scan(force: bool = False) -> str:
+    """Gracefully stop the current scan (partial data preserved).
+
+    May take up to ~120 s from a running scan (a deferred pause waits out
+    the in-flight move before stopping). Refuses a scan submitted by
+    another client (the submitting identity is named) unless
+    ``force=true`` — pass force only when the operator explicitly asks.
+    """
+    return await _run_guarded(_stop_scan_impl, force)
+
+
+# ---------------------------------------------------------------------------
+# clear_queue
+# ---------------------------------------------------------------------------
+
+
+def _clear_queue_impl() -> str:
+    """List what is queued, then remove it — the explicit recovery verb."""
+    client = runtime.get_queue_client()
+    try:
+        pending = client.queue_items()
+    except Exception as exc:
+        return errors.make_error("manager_unreachable", str(exc))
+    if not pending:
+        return errors.make_ok(cleared=[], message="queue already empty")
+    ok, message = client.clear_queue()
+    if not ok:
+        return errors.make_error("worker_refused", message)
+    return errors.make_ok(
+        cleared=[
+            {
+                "item_uid": item.get("item_uid"),
+                "plan": item.get("name"),
+                "user": item.get("user"),
+            }
+            for item in pending
+        ],
+        message=message,
+    )
+
+
+@mcp.tool(name=tool_names.CLEAR_QUEUE)
+async def clear_queue() -> str:
+    """Remove every queued item — the ONLY verb that clears the queue.
+
+    Usually recovers from one failed item returned to the queue front.
+    The result lists exactly what was removed, with each item's
+    submitting client.
+    """
+    return await _run_guarded(_clear_queue_impl)
+
+
+# ---------------------------------------------------------------------------
+# scan_progress (poll-shaped, read-only)
+# ---------------------------------------------------------------------------
+
+
+def _scan_progress_impl() -> str:
+    """Coarse poll: RE state, the running item, and the last outcome."""
+    client = runtime.get_queue_client()
+    status = client.status()
+    if not status.connected:
+        return errors.make_ok(state="unknown", detail=status.detail, running_item=None)
+    running = None
+    try:
+        raw = client.running_item()
+        if raw:
+            running = {
+                "item_uid": raw.get("item_uid"),
+                "plan": raw.get("name"),
+                "user": raw.get("user"),
+            }
+    except Exception:
+        logger.debug("running-item read failed in progress poll", exc_info=True)
+    last = None
+    try:
+        items = client.history_items()
+        if items:
+            tail = items[-1]
+            result = tail.get("result") or {}
+            last = {
+                "plan": tail.get("name"),
+                "user": tail.get("user"),
+                "exit_status": result.get("exit_status"),
+                "scan_ids": result.get("scan_ids"),
+            }
+    except Exception:
+        logger.debug("history read failed in progress poll", exc_info=True)
+    return errors.make_ok(
+        state=status.re_state or "idle",
+        running_item=running,
+        items_in_queue=status.items_in_queue,
+        last_completed=last,
+    )
+
+
+@mcp.tool(name=tool_names.SCAN_PROGRESS)
+async def scan_progress() -> str:
+    """Poll-shaped progress for the current scan.
+
+    RE state (idle/running/paused/…), the running item (with its
+    submitting client), queue depth, and the last completed item's
+    outcome. Coarse by design in v1 — per-shot counts arrive with the
+    document-stream upgrade (v2).
+    """
+    return await _run_guarded(_scan_progress_impl)

--- a/GEECS-Scan-MCP/geecs_scan_mcp/tools/control_tools.py
+++ b/GEECS-Scan-MCP/geecs_scan_mcp/tools/control_tools.py
@@ -38,28 +38,19 @@ logger = logging.getLogger("geecs_scan_mcp.tools.control")
 # ---------------------------------------------------------------------------
 
 
-def _planned_shots(request) -> int | None:
-    """Total planned shots, or ``None`` when the request cannot say.
-
-    step/noscan: product of axis position counts × ``shots_per_step``
-    (noscan = one no-move bin).  optimize: ``max_iterations ×
-    shots_per_step`` — an optimize request WITHOUT an explicit
-    ``max_iterations`` returns ``None`` (the engine's auto budget is
-    open-ended; the agent cap needs a number, so submission requires one).
-    """
-    mode = getattr(request.mode, "value", request.mode)
-    if mode == "optimize":
-        spec = request.optimization
-        iterations = getattr(spec, "max_iterations", None) if spec else None
-        if not iterations:
-            return None
-        return int(iterations) * int(request.shots_per_step)
-    steps = 1
-    for axis in request.axes or []:
-        positions = axis.positions
-        values = getattr(positions, "values", None)
-        steps *= len(values) if values is not None else len(positions.to_values())
-    return steps * int(request.shots_per_step)
+#: The preflight checks whose warnings can be acknowledged.  Names outside
+#: this vocabulary in ``acknowledge_warnings`` are refused (typo guard).
+#: HONEST RESIDUAL (review finding): the server is stateless, so an agent
+#: that pre-acknowledges these known names on its FIRST call skips the
+#: warning round trip — the backstop is OSPREY's approval prompt, which
+#: shows the tool arguments (a human sees the pre-acknowledgement), and
+#: the provenance record, which stamps ``continued`` only for questions
+#: actually raised.
+_ACKNOWLEDGEABLE_CHECKS = (
+    "unserved_variables",
+    "gateway_liveness",
+    "free_run_staleness",
+)
 
 
 def _submit_scan_impl(
@@ -94,14 +85,18 @@ def _submit_scan_impl(
         validated = validated.model_copy(update={"description": description})
 
     # -- agent scan-size cap -------------------------------------------------
+    # planned_shots() is THE schema derivation — arithmetic, never
+    # materializing positions, so an agent-composed pathological range
+    # ({start: 0, end: 1e15, step: 1e-9}) is counted, not expanded
+    # (review finding: the old expanding count made the guard the crash).
     cap = runtime.max_shots()
-    shots = _planned_shots(validated)
+    shots = validated.planned_shots()
     if shots is None:
         return errors.make_error(
             "policy_refusal",
-            "optimize submissions need an explicit max_iterations (the "
-            f"engine's auto budget is open-ended; the agent cap is {cap} "
-            "shots)",
+            "optimize submissions need an explicit max_iterations (without "
+            "one the engine applies its own default budget; the agent cap "
+            f"of {cap} shots needs the number stated up front)",
         )
     if shots > cap:
         return errors.make_error(
@@ -149,6 +144,13 @@ def _submit_scan_impl(
     if report.refusal is not None:
         return errors.make_error("invalid_request", report.refusal)
     acknowledged = set(acknowledge_warnings or [])
+    unknown = acknowledged - set(_ACKNOWLEDGEABLE_CHECKS)
+    if unknown:
+        return errors.make_error(
+            "invalid_request",
+            f"unknown acknowledge_warnings name(s): {', '.join(sorted(unknown))} "
+            f"— acknowledgeable checks are {', '.join(_ACKNOWLEDGEABLE_CHECKS)}",
+        )
     unacknowledged = [q for q in report.questions if q.check not in acknowledged]
     if unacknowledged:
         return errors.make_error(
@@ -222,18 +224,21 @@ def _stop_scan_impl(force: bool) -> str:
         running = client.running_item()
     except Exception:  # fail-open: an unreadable item never blocks a halt
         logger.debug("running-item read failed before stop", exc_info=True)
-    if running and not force:
-        owner = running.get("user")
-        if owner and owner != runtime.client_identity():
-            return errors.make_error(
-                "policy_refusal",
-                f"the running scan was submitted by {owner!r} — pass "
-                "force=true only if the operator explicitly asks for the stop",
-            )
+    owner = (running or {}).get("user")
+    foreign = bool(owner and owner != runtime.client_identity())
+    if foreign and not force:
+        return errors.make_error(
+            "policy_refusal",
+            f"the running scan was submitted by {owner!r} — pass "
+            "force=true only if the operator explicitly asks for the stop",
+        )
     ok, message = client.stop_scan()
     if not ok:
         return errors.make_error("worker_refused", message)
-    return errors.make_ok(message=message, forced=bool(force and running))
+    # forced marks "an operator authorized stopping ANOTHER client's scan"
+    # — a habitual force=true on the MCP's own scan must not pollute the
+    # audit marker (review finding).
+    return errors.make_ok(message=message, forced=bool(force and foreign))
 
 
 @mcp.tool(name=tool_names.STOP_SCAN)

--- a/GEECS-Scan-MCP/pyproject.toml
+++ b/GEECS-Scan-MCP/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-scan-mcp"
-version = "0.1.0"
+version = "0.2.0"
 description = "MCP server exposing GEECS scan submission, monitoring, and config discovery to AI agents (OSPREY)"
 authors = ["Sam Barber <sbarber@lbl.gov>"]
 readme = "README.md"

--- a/GEECS-Scan-MCP/tests/test_control_tools.py
+++ b/GEECS-Scan-MCP/tests/test_control_tools.py
@@ -153,21 +153,70 @@ def test_submit_enforces_the_shot_cap(wired, monkeypatch):
     assert wired.submitted == []
 
 
+def _valid_optimization_spec(**overrides) -> dict:
+    """A minimal schema-VALID OptimizationSpec (review finding: the old
+    fake was invalid on three counts, so the policy branch was never
+    genuinely pinned)."""
+    spec = {
+        "variables": {"jet_z": (0.0, 1.0)},
+        "objectives": {"counts": "MAXIMIZE"},
+        "evaluator": {"module": "geecs.eval", "class_name": "CountsEval"},
+        "generator": {"name": "random"},
+    }
+    spec.update(overrides)
+    return spec
+
+
 def test_submit_optimize_without_iterations_refused(wired):
+    optimize = dict(
+        GOOD_REQUEST, mode="optimize", optimization=_valid_optimization_spec()
+    )
+    result = _load(control_tools._submit_scan_impl(optimize, None, None, None))
+    assert result["error_kind"] == "policy_refusal"
+    assert "max_iterations" in result["message"]
+    assert wired.submitted == []
+
+
+def test_submit_optimize_with_iterations_counts_against_cap(wired, monkeypatch):
+    monkeypatch.setattr(runtime, "max_shots", lambda: 100)
     optimize = dict(
         GOOD_REQUEST,
         mode="optimize",
-        optimization={
-            "objective": {"device": "UC_X", "expression": "x"},
-            "variables": [
-                {"variable": "jet_z", "range": [0.0, 1.0]},
-            ],
-        },
+        optimization=_valid_optimization_spec(max_iterations=30),
+        shots_per_step=5,
     )
     result = _load(control_tools._submit_scan_impl(optimize, None, None, None))
-    # Either schema-invalid (spec shape drift in this fake) or the explicit
-    # policy refusal — but never a submission.
-    assert not result["ok"]
+    assert result["error_kind"] == "policy_refusal"
+    assert "150" in result["message"]
+    assert wired.submitted == []
+
+
+def test_submit_pathological_range_is_counted_not_expanded(wired):
+    # Review HIGH: {start: 0, end: 1e15, step: 1e-9} validates cleanly;
+    # the cap must refuse it arithmetically — expanding it to count it
+    # would OOM the server inside its own guard. Completing at all IS the
+    # assertion (the old code would hang here).
+    huge = dict(
+        GOOD_REQUEST,
+        mode="step",
+        axes=[
+            {
+                "variable": "jet_z",
+                "positions": {"start": 0.0, "end": 1.0e15, "step": 1.0e-9},
+            }
+        ],
+    )
+    result = _load(control_tools._submit_scan_impl(huge, None, None, None))
+    assert result["error_kind"] == "policy_refusal"
+    assert wired.submitted == []
+
+
+def test_submit_unknown_acknowledgement_names_refused(wired):
+    result = _load(
+        control_tools._submit_scan_impl(GOOD_REQUEST, None, None, ["not_a_check"])
+    )
+    assert result["error_kind"] == "invalid_request"
+    assert "not_a_check" in result["message"]
     assert wired.submitted == []
 
 
@@ -249,6 +298,15 @@ def test_stop_foreign_scan_with_force(wired):
     wired.running = {"item_uid": "r1", "user": "geecs-console"}
     result = _load(control_tools._stop_scan_impl(True))
     assert result["ok"] and result["forced"] is True
+
+
+def test_stop_own_scan_with_force_is_not_marked_forced(wired):
+    # The audit marker means "an operator authorized stopping ANOTHER
+    # client's scan" — habitual force=true on our own scan must not
+    # pollute it (review finding).
+    wired.running = {"item_uid": "r1", "user": runtime.client_identity()}
+    result = _load(control_tools._stop_scan_impl(True))
+    assert result["ok"] and result["forced"] is False
 
 
 def test_stop_failure_is_worker_refused(wired):

--- a/GEECS-Scan-MCP/tests/test_control_tools.py
+++ b/GEECS-Scan-MCP/tests/test_control_tools.py
@@ -1,0 +1,312 @@
+"""Hermetic tests for the v1 control tools.
+
+Same seams as the read-tool suite: fakes patched on ``runtime``, JSON
+envelopes asserted.  The submission flow's engine seams
+(``run_submit_preflight`` / ``stamp_submission``) are patched at their
+``geecs_bluesky.qs_client`` home — the impl from-imports at call time.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from types import SimpleNamespace
+
+import pytest
+
+from geecs_bluesky import qs_client
+from geecs_scan_mcp import runtime
+from geecs_scan_mcp.tools import control_tools
+
+
+@pytest.fixture(autouse=True)
+def _fresh_runtime():
+    runtime.clear_runtime_cache()
+    yield
+    runtime.clear_runtime_cache()
+
+
+def _load(payload: str) -> dict:
+    return json.loads(payload)
+
+
+GOOD_REQUEST = {
+    "mode": "noscan",
+    "shots_per_step": 5,
+    "acquisition": "free_run",
+    "save_sets": ["Amp4In"],
+}
+
+
+@dataclass
+class _FakeClient:
+    re_state: str = "idle"
+    connected: bool = True
+    queue: list = field(default_factory=list)
+    running: dict | None = None
+    history: list = field(default_factory=list)
+    submitted: list = field(default_factory=list)
+    submit_ok: bool = True
+    stop_result: tuple = (True, "stop requested (from paused)")
+    cleared: int = 0
+
+    def status(self):
+        return SimpleNamespace(
+            connected=self.connected,
+            re_state=self.re_state if self.connected else None,
+            manager_state="idle" if self.connected else None,
+            worker_exists=self.connected,
+            items_in_queue=len(self.queue),
+            running_item_uid=(self.running or {}).get("item_uid"),
+            detail="" if self.connected else "timeout occurred",
+        )
+
+    def queue_items(self):
+        return list(self.queue)
+
+    def running_item(self):
+        return dict(self.running) if self.running else None
+
+    def history_items(self):
+        return list(self.history)
+
+    def submit_scan(self, request, *, clear_pending=False):
+        assert clear_pending is False  # the doctrine: never clear implicitly
+        self.submitted.append(request)
+        if self.submit_ok:
+            return SimpleNamespace(
+                ok=True, message="queued", item_uid="uid-9", pending_items=[]
+            )
+        return SimpleNamespace(
+            ok=False, message="refused", item_uid=None, pending_items=[]
+        )
+
+    def stop_scan(self):
+        return self.stop_result
+
+    def clear_queue(self):
+        self.cleared += 1
+        return True, "queue cleared"
+
+
+@pytest.fixture
+def wired(monkeypatch):
+    """A connected idle manager + experiment + pass-through preflight."""
+    client = _FakeClient()
+    monkeypatch.setattr(runtime, "get_queue_client", lambda: client)
+    monkeypatch.setattr(runtime, "get_experiment", lambda: "Test")
+    monkeypatch.setattr(
+        "geecs_bluesky.qs_client.run_submit_preflight",
+        lambda req, exp: qs_client.PreflightReport(
+            outcomes=[("validate", "passed", "")]
+        ),
+    )
+    return client
+
+
+# ---------------------------------------------------------------------------
+# submit_scan
+# ---------------------------------------------------------------------------
+
+
+def test_submit_happy_path_stamps_and_queues(wired):
+    result = _load(control_tools._submit_scan_impl(GOOD_REQUEST, None, None, None))
+    assert result["ok"] and result["item_uid"] == "uid-9"
+    assert result["planned_shots"] == 5
+    (submitted,) = wired.submitted
+    record = submitted["submission"]
+    assert record["client"] == runtime.client_identity()
+    assert [o["check"] for o in record["preflight"]] == ["validate"]
+
+
+def test_submit_requires_exactly_one_selector(wired):
+    both = _load(control_tools._submit_scan_impl(GOOD_REQUEST, "preset", None, None))
+    neither = _load(control_tools._submit_scan_impl(None, None, None, None))
+    assert both["error_kind"] == "invalid_request"
+    assert neither["error_kind"] == "invalid_request"
+
+
+def test_submit_preset_resolves_via_resolver(wired, monkeypatch):
+    from geecs_schemas import ScanRequest
+
+    preset_request = ScanRequest.model_validate(GOOD_REQUEST)
+    resolver = SimpleNamespace(resolve_preset=lambda name: preset_request)
+    monkeypatch.setattr(runtime, "get_resolver", lambda: resolver)
+    result = _load(
+        control_tools._submit_scan_impl(None, "smoke", "override text", None)
+    )
+    assert result["ok"]
+    assert wired.submitted[0]["description"] == "override text"
+
+
+def test_submit_enforces_the_shot_cap(wired, monkeypatch):
+    monkeypatch.setattr(runtime, "max_shots", lambda: 10)
+    big = dict(
+        GOOD_REQUEST,
+        mode="step",
+        axes=[{"variable": "jet_z", "positions": {"start": 0, "end": 9, "step": 1}}],
+        shots_per_step=5,
+    )
+    result = _load(control_tools._submit_scan_impl(big, None, None, None))
+    assert result["error_kind"] == "policy_refusal"
+    assert "50" in result["message"] and "10" in result["message"]
+    assert wired.submitted == []
+
+
+def test_submit_optimize_without_iterations_refused(wired):
+    optimize = dict(
+        GOOD_REQUEST,
+        mode="optimize",
+        optimization={
+            "objective": {"device": "UC_X", "expression": "x"},
+            "variables": [
+                {"variable": "jet_z", "range": [0.0, 1.0]},
+            ],
+        },
+    )
+    result = _load(control_tools._submit_scan_impl(optimize, None, None, None))
+    # Either schema-invalid (spec shape drift in this fake) or the explicit
+    # policy refusal — but never a submission.
+    assert not result["ok"]
+    assert wired.submitted == []
+
+
+def test_submit_refuses_while_running_or_queued(wired):
+    wired.re_state = "running"
+    result = _load(control_tools._submit_scan_impl(GOOD_REQUEST, None, None, None))
+    assert result["error_kind"] == "policy_refusal" and "active" in result["message"]
+
+    wired.re_state = "idle"
+    wired.queue = [
+        {"item_uid": "old", "name": "geecs_scan_request_plan", "user": "console"}
+    ]
+    result = _load(control_tools._submit_scan_impl(GOOD_REQUEST, None, None, None))
+    assert result["error_kind"] == "policy_refusal"
+    assert result["pending_items"][0]["item_uid"] == "old"
+    assert wired.submitted == []
+
+
+def test_submit_warnings_need_acknowledgement(wired, monkeypatch):
+    report = qs_client.PreflightReport(
+        outcomes=[("validate", "passed", "")],
+        questions=[
+            qs_client.PreflightQuestion(
+                check="free_run_staleness",
+                title="Trigger looks stopped",
+                message="acq_timestamp did not advance. Continue anyway?",
+            )
+        ],
+    )
+    monkeypatch.setattr(
+        "geecs_bluesky.qs_client.run_submit_preflight", lambda req, exp: report
+    )
+    first = _load(control_tools._submit_scan_impl(GOOD_REQUEST, None, None, None))
+    assert first["error_kind"] == "policy_refusal"
+    assert first["needs_acknowledgement"][0]["check"] == "free_run_staleness"
+    assert wired.submitted == []
+
+    second = _load(
+        control_tools._submit_scan_impl(
+            GOOD_REQUEST, None, None, ["free_run_staleness"]
+        )
+    )
+    assert second["ok"]
+    record = wired.submitted[0]["submission"]
+    by_check = {o["check"]: o["result"] for o in record["preflight"]}
+    assert by_check["free_run_staleness"] == "continued"
+
+
+def test_submit_engine_refusal_verbatim(wired, monkeypatch):
+    monkeypatch.setattr(
+        "geecs_bluesky.qs_client.run_submit_preflight",
+        lambda req, exp: qs_client.PreflightReport(
+            refusal="save set 'Nope' is unknown"
+        ),
+    )
+    result = _load(control_tools._submit_scan_impl(GOOD_REQUEST, None, None, None))
+    assert result["error_kind"] == "invalid_request" and "Nope" in result["message"]
+
+
+# ---------------------------------------------------------------------------
+# stop_scan
+# ---------------------------------------------------------------------------
+
+
+def test_stop_own_scan_proceeds(wired, monkeypatch):
+    wired.running = {"item_uid": "r1", "user": runtime.client_identity()}
+    result = _load(control_tools._stop_scan_impl(False))
+    assert result["ok"] and "stop requested" in result["message"]
+
+
+def test_stop_foreign_scan_refused_by_name(wired):
+    wired.running = {"item_uid": "r1", "user": "geecs-console"}
+    result = _load(control_tools._stop_scan_impl(False))
+    assert result["error_kind"] == "policy_refusal"
+    assert "geecs-console" in result["message"]
+
+
+def test_stop_foreign_scan_with_force(wired):
+    wired.running = {"item_uid": "r1", "user": "geecs-console"}
+    result = _load(control_tools._stop_scan_impl(True))
+    assert result["ok"] and result["forced"] is True
+
+
+def test_stop_failure_is_worker_refused(wired):
+    wired.stop_result = (False, "pause did not land within 120 s")
+    result = _load(control_tools._stop_scan_impl(False))
+    assert result["error_kind"] == "worker_refused" and "120" in result["message"]
+
+
+# ---------------------------------------------------------------------------
+# clear_queue + scan_progress
+# ---------------------------------------------------------------------------
+
+
+def test_clear_queue_lists_what_it_removed(wired):
+    wired.queue = [
+        {"item_uid": "old", "name": "geecs_scan_request_plan", "user": "mcp"}
+    ]
+    result = _load(control_tools._clear_queue_impl())
+    assert result["ok"] and result["cleared"][0]["item_uid"] == "old"
+    assert wired.cleared == 1
+
+    wired.queue = []
+    result = _load(control_tools._clear_queue_impl())
+    assert result["ok"] and result["cleared"] == []
+    assert wired.cleared == 1  # empty queue: no clear call issued
+
+
+def test_scan_progress_shapes(wired):
+    wired.re_state = "running"
+    wired.running = {"item_uid": "r1", "name": "geecs_scan_request_plan", "user": "mcp"}
+    wired.history = [
+        {
+            "name": "geecs_scan_request_plan",
+            "user": "console",
+            "result": {"exit_status": "completed", "scan_ids": [4]},
+        },
+    ]
+    result = _load(control_tools._scan_progress_impl())
+    assert result["state"] == "running"
+    assert result["running_item"]["user"] == "mcp"
+    assert result["last_completed"]["scan_ids"] == [4]
+
+    wired.connected = False
+    result = _load(control_tools._scan_progress_impl())
+    assert result["state"] == "unknown" and "timeout" in result["detail"]
+
+
+def test_all_v1_tools_registered():
+    import anyio
+
+    from geecs_scan_mcp import tool_names
+    from geecs_scan_mcp.server import create_server
+
+    server = create_server()
+    registered = {tool.name for tool in anyio.run(server.list_tools)}
+    for name in (
+        *tool_names.QUEUE_TOOLS,
+        *tool_names.STOP_TOOLS,
+        tool_names.SCAN_PROGRESS,
+    ):
+        assert name in registered, f"{name} not registered"

--- a/GEECS-Schemas/CHANGELOG.md
+++ b/GEECS-Schemas/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to GEECS-Schemas are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.11.0] - 2026-08-22
+
+### Added
+
+- **The one non-materializing scan-size derivation** (review finding on
+  the scan-MCP v1 PR — the third parallel counter, and the expanding
+  ones could OOM a guard on agent-composed input like
+  `{start: 0, end: 1e15, step: 1e-9}`): `Positions.n_positions()`
+  (arithmetic twin of `to_values()`, exact same derivation and
+  tolerance) and `ScanRequest.planned_shots()` (step/noscan =
+  `n_steps() × shots_per_step`; optimize = `max_iterations ×
+  shots_per_step` or `None` when unset).  `grid_shape()`/`n_steps()`
+  now count without expanding.  Consumers (the scan MCP's agent cap;
+  the console's `_position_count` at its next touch) should use these
+  instead of private counters.
+
 ## [0.10.2] - 2026-08-21
 
 ### Changed

--- a/GEECS-Schemas/geecs_schemas/scan_request.py
+++ b/GEECS-Schemas/geecs_schemas/scan_request.py
@@ -115,6 +115,23 @@ class PositionRange(SchemaModel):
             raise ValueError("Position step size must not be 0.")
         return self
 
+    def n_positions(self) -> int:
+        """Count the positions WITHOUT materializing them.
+
+        The arithmetic twin of :meth:`to_values` (same derivation, same
+        tolerance).  Size guards must use this, never ``len(to_values())``
+        — an agent-composed range like ``{start: 0, end: 1e15, step:
+        1e-9}`` validates cleanly, and expanding it to count it is the
+        crash the guard exists to prevent.
+
+        Returns
+        -------
+        int
+            How many positions :meth:`to_values` would return.
+        """
+        span = self.end - self.start
+        return int(abs(span) / abs(self.step) + 1e-9) + 1
+
     def to_values(self) -> list[float]:
         """Expand the range into the explicit list of positions.
 
@@ -126,8 +143,7 @@ class PositionRange(SchemaModel):
         """
         span = self.end - self.start
         step = abs(self.step) * (1 if span >= 0 else -1)
-        count = int(abs(span) / abs(self.step) + 1e-9) + 1
-        return [self.start + i * step for i in range(count)]
+        return [self.start + i * step for i in range(self.n_positions())]
 
 
 class PositionList(SchemaModel):
@@ -141,6 +157,16 @@ class PositionList(SchemaModel):
         min_length=1,
         description="The exact positions to visit, in the order given.",
     )
+
+    def n_positions(self) -> int:
+        """Count the positions (the listed length).
+
+        Returns
+        -------
+        int
+            ``len(values)``.
+        """
+        return len(self.values)
 
     def to_values(self) -> list[float]:
         """Return the positions as a plain list.
@@ -662,7 +688,10 @@ class ScanRequest(VersionedSchemaModel):
         tuple of int
             One count per axis, in list order (empty for noscan/optimize).
         """
-        return tuple(len(axis.positions.to_values()) for axis in self.axes)
+        # n_positions, never len(to_values()): the shape must be computable
+        # without materializing a possibly-huge range (size guards call
+        # through here).
+        return tuple(axis.positions.n_positions() for axis in self.axes)
 
     def n_steps(self) -> int:
         """Return the total number of grid points the scan visits.
@@ -677,3 +706,29 @@ class ScanRequest(VersionedSchemaModel):
         for count in self.grid_shape():
             total *= count
         return total
+
+    def planned_shots(self) -> int | None:
+        """Total planned shots, or ``None`` when the request cannot say.
+
+        THE one scan-size derivation (consolidating the console's and the
+        scan MCP's former private counters): step/noscan =
+        ``n_steps() × shots_per_step`` (noscan is one motionless bin);
+        optimize = ``max_iterations × shots_per_step``, or ``None`` when
+        ``max_iterations`` is unset (the engine then applies its own
+        default budget — a size guard that needs a number should require
+        the field explicitly).  Never materializes positions
+        (:meth:`PositionRange.n_positions`), so it is safe on arbitrary
+        agent-composed input.
+
+        Returns
+        -------
+        int or None
+            The planned shot total, or ``None`` for an open budget.
+        """
+        if self.mode is ScanRequestMode.OPTIMIZE:
+            spec = self.optimization
+            iterations = spec.max_iterations if spec is not None else None
+            if not iterations:
+                return None
+            return int(iterations) * int(self.shots_per_step)
+        return self.n_steps() * int(self.shots_per_step)

--- a/GEECS-Schemas/pyproject.toml
+++ b/GEECS-Schemas/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-schemas"
-version = "0.10.2"
+version = "0.11.0"
 description = "Versioned Pydantic schemas for GEECS scanner configs (scan requests, save sets, scan variables, trigger profiles, action plans) plus legacy-YAML converters."
 authors = ["Sam Barber <sbarber@lbl.gov>"]
 readme = "README.md"

--- a/GEECS-Schemas/tests/test_planned_shots.py
+++ b/GEECS-Schemas/tests/test_planned_shots.py
@@ -1,0 +1,99 @@
+"""Pin the non-materializing scan-size derivation (0.11.0).
+
+``planned_shots()`` / ``n_positions()`` are THE size derivation for
+guards over agent-composed requests — they must agree exactly with the
+expanding ``to_values()`` reference AND never materialize positions (a
+pathological range like ``{start: 0, end: 1e15, step: 1e-9}`` validates
+cleanly and must be countable without expansion).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from geecs_schemas import ScanRequest
+from geecs_schemas.scan_request import PositionList, PositionRange
+
+
+@pytest.mark.parametrize(
+    "start,end,step",
+    [
+        (0.0, 1.0, 0.1),
+        (0.0, 1.0, 0.3),  # step does not divide the span evenly
+        (5.0, -5.0, 1.0),  # descending
+        (2.0, 2.0, 0.5),  # zero span: one position
+        (0.0, 0.999999999, 0.1),  # the 1e-9 tolerance boundary
+    ],
+)
+def test_n_positions_matches_to_values_exactly(start, end, step):
+    positions = PositionRange(start=start, end=end, step=step)
+    assert positions.n_positions() == len(positions.to_values())
+
+
+def test_position_list_count():
+    assert PositionList(values=[1.0, 2.0, 5.0]).n_positions() == 3
+
+
+def test_pathological_range_counts_without_materializing():
+    # ~1e24 positions: expanding would OOM; counting must be instant.
+    positions = PositionRange(start=0.0, end=1.0e15, step=1.0e-9)
+    assert positions.n_positions() > 10**20
+
+
+def _request(**overrides) -> ScanRequest:
+    base = dict(
+        mode="noscan",
+        shots_per_step=5,
+        acquisition="free_run",
+        save_sets=["Set"],
+    )
+    base.update(overrides)
+    return ScanRequest.model_validate(base)
+
+
+def test_planned_shots_noscan_is_one_bin():
+    assert _request().planned_shots() == 5
+
+
+def test_planned_shots_grid_is_the_outer_product():
+    request = _request(
+        mode="step",
+        axes=[
+            {"variable": "a", "positions": {"start": 0, "end": 4, "step": 1}},
+            {"variable": "b", "positions": {"values": [1.0, 2.0, 3.0]}},
+        ],
+        shots_per_step=2,
+    )
+    assert request.planned_shots() == 5 * 3 * 2
+    assert request.planned_shots() == request.n_steps() * 2  # one derivation
+
+
+def test_planned_shots_optimize_requires_explicit_iterations():
+    spec = {
+        "variables": {"x": (0.0, 1.0)},
+        "objectives": {"y": "MAXIMIZE"},
+        "evaluator": {"module": "m", "class_name": "C"},
+        "generator": {"name": "random"},
+    }
+    without = _request(mode="optimize", optimization=spec, save_sets=[])
+    assert without.planned_shots() is None
+    with_iters = _request(
+        mode="optimize",
+        optimization={**spec, "max_iterations": 7},
+        save_sets=[],
+        shots_per_step=3,
+    )
+    assert with_iters.planned_shots() == 21
+
+
+def test_pathological_grid_request_counts_fast():
+    request = _request(
+        mode="step",
+        axes=[
+            {
+                "variable": "a",
+                "positions": {"start": 0.0, "end": 1.0e15, "step": 1.0e-9},
+            }
+        ],
+    )
+    assert request.planned_shots() > 10**20  # would OOM if it expanded

--- a/GeecsBluesky/CHANGELOG.md
+++ b/GeecsBluesky/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to `geecs-bluesky` are documented here.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.61.0] - 2026-08-22
+
+### Added
+
+- **`qs_client` control-surface reads for the scan MCP's v1 verbs**:
+  `QueueClient.running_item()` (the in-flight item from `queue_get` —
+  carries `user`, the submitted-as identity that grounds client-side
+  ownership etiquette; `None` while idle) and `clear_queue()` (the
+  explicit failed-item-at-front recovery verb — submission never clears
+  implicitly).  On the protocol, `ZmqQueueClient`, and the stub.
+- **`ConfigsRepoResolver.resolve_preset(name)`** — loads a preset as a
+  validated `ScanRequest` (presets ARE saved ScanRequests; the folder
+  layout keeps one owner; `.yml` round-trips like every named config).
+
 ## [0.60.0] - 2026-08-22
 
 ### Added

--- a/GeecsBluesky/geecs_bluesky/config_resolver.py
+++ b/GeecsBluesky/geecs_bluesky/config_resolver.py
@@ -220,6 +220,28 @@ class ConfigsRepoResolver:
         """Saved preset names (each file is a ``ScanRequest``; sorted; ``[]`` if none)."""
         return self._list_folder(self.PRESET_FOLDER)
 
+    def resolve_preset(self, name: str):
+        """Load preset *name* as a validated ``ScanRequest``.
+
+        A preset IS a saved ``ScanRequest`` (one YAML per name under
+        ``presets/`` — the console's PresetStore writes them; the scan
+        MCP's ``submit_scan(preset=...)`` reads them here so the folder
+        layout keeps one owner).
+
+        Raises
+        ------
+        GeecsConfigurationError
+            Missing file or a document that is not a mapping.
+        pydantic.ValidationError
+            A document that is not a valid ``ScanRequest``.
+        """
+        from geecs_schemas import ScanRequest
+
+        stem = self._strip_yaml_suffix(name)
+        path = self._named_yaml_path(self.PRESET_FOLDER, stem)
+        document = self._load_yaml(path, "preset", name)
+        return ScanRequest.model_validate(document)
+
     def list_optimizer_configs(self) -> list[str]:
         """Optimizer-config names (``OptimizationSpec`` documents; sorted; ``[]`` if none)."""
         return self._list_folder(self.OPTIMIZER_FOLDER)

--- a/GeecsBluesky/geecs_bluesky/qs_client/client.py
+++ b/GeecsBluesky/geecs_bluesky/qs_client/client.py
@@ -207,6 +207,25 @@ class QueueClient(Protocol):
         """Return the manager's item history; raises on failure."""
         ...
 
+    def running_item(self) -> Optional[dict]:
+        """Return the currently running item (``None`` when idle); raises on failure.
+
+        The item dict carries the manager's shape — notably ``user`` (the
+        submitted-as identity), the basis of client-side ownership
+        etiquette (a client should not stop another client's scan without
+        an explicit force).
+        """
+        ...
+
+    def clear_queue(self) -> tuple[bool, str]:
+        """Remove every queued item. Returns ``(ok, message)``.
+
+        The explicit recovery verb for the failed-item-at-front trap —
+        deliberately separate from submission (``submit_scan`` never
+        clears implicitly; see ``clear_pending``).
+        """
+        ...
+
     def move_variable(self, name: str, value: float) -> dict:
         """Run ``geecs_move_variable`` on the worker; raises on refusal/failure."""
         ...
@@ -265,6 +284,14 @@ class StubQueueClient:
     def history_items(self) -> list[dict]:
         """Refuse with the missing-config message."""
         raise RuntimeError(_STUB_MESSAGE)
+
+    def running_item(self) -> Optional[dict]:
+        """Refuse with the missing-config message."""
+        raise RuntimeError(_STUB_MESSAGE)
+
+    def clear_queue(self) -> tuple[bool, str]:
+        """Refuse with the missing-config message."""
+        return False, _STUB_MESSAGE
 
     def move_variable(self, name: str, value: float) -> dict:
         """Refuse with the missing-config message."""
@@ -520,6 +547,23 @@ class ZmqQueueClient:
     def history_items(self) -> list[dict]:
         """Return the manager's item history (read-only; raises on failure)."""
         return list(self._manager().history_get().get("items") or [])
+
+    def running_item(self) -> Optional[dict]:
+        """Return the running item from ``queue_get`` (read-only; raises on failure).
+
+        The manager reports the in-flight item beside the queue —
+        ``running_item`` is ``{}`` while idle, mapped to ``None`` here.
+        """
+        raw = self._manager().queue_get().get("running_item") or None
+        return dict(raw) if raw else None
+
+    def clear_queue(self) -> tuple[bool, str]:
+        """Remove every queued item (the explicit recovery verb)."""
+        try:
+            self._manager().queue_clear()
+            return True, "queue cleared"
+        except Exception as exc:
+            return False, str(exc)
 
     def move_variable(self, name: str, value: float) -> dict:
         """Run the worker's manual move; idle-only (the manager enforces it)."""

--- a/GeecsBluesky/pyproject.toml
+++ b/GeecsBluesky/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-bluesky"
-version = "0.60.0"
+version = "0.61.0"
 description = "Bluesky / ophyd-async bridge for the GEECS control system"
 authors = ["Sam Barber <sbarber@lbl.gov>"]
 readme = "README.md"

--- a/GeecsBluesky/tests/qs_client/test_queue_client.py
+++ b/GeecsBluesky/tests/qs_client/test_queue_client.py
@@ -109,6 +109,7 @@ class _FakeManagerAPI:
         self.calls: list[tuple] = []
         self.status_payloads: list[dict] = []
         self.queue_items: list[dict] = []
+        self.running: dict | None = None
         self.task_results: list[dict] = []
         self.raise_on_status: Exception | None = None
 
@@ -127,7 +128,10 @@ class _FakeManagerAPI:
 
     def queue_get(self) -> dict:
         self.calls.append(("queue_get",))
-        return {"items": list(self.queue_items)}
+        return {
+            "items": list(self.queue_items),
+            "running_item": dict(self.running) if self.running else {},
+        }
 
     def queue_clear(self) -> None:
         self.calls.append(("queue_clear",))
@@ -249,6 +253,26 @@ class TestZmqQueueClient:
         client = _client(_FakeManagerAPI())
         assert client.info_addr == "tcp://x:2"
         assert client.doc_addr == "x:3"
+
+    def test_running_item_maps_empty_to_none(self):
+        fake = _FakeManagerAPI()
+        client = _client(fake)
+        assert client.running_item() is None  # manager reports {} while idle
+        fake.running = {"item_uid": "r1", "user": "geecs-console"}
+        assert client.running_item() == {"item_uid": "r1", "user": "geecs-console"}
+
+    def test_clear_queue_reports_ok_and_failure(self):
+        fake = _FakeManagerAPI()
+        client = _client(fake)
+        assert client.clear_queue() == (True, "queue cleared")
+        assert ("queue_clear",) in fake.calls
+
+        def boom():
+            raise RuntimeError("manager busy")
+
+        fake.queue_clear = boom
+        ok, message = client.clear_queue()
+        assert not ok and "busy" in message
 
     def test_queue_and_history_read_verbs(self):
         fake = _FakeManagerAPI()

--- a/GeecsBluesky/tests/test_config_listings.py
+++ b/GeecsBluesky/tests/test_config_listings.py
@@ -100,3 +100,31 @@ def test_unresolvable_configs_root_is_empty(monkeypatch):
     resolver = ConfigsRepoResolver("TestExp")
     assert resolver.list_save_sets() == []
     assert resolver.list_trigger_profiles() == []
+
+
+def test_resolve_preset_round_trips_a_scan_request(repo):
+    import yaml
+
+    from geecs_schemas import ScanRequest
+
+    preset = {
+        "mode": "noscan",
+        "shots_per_step": 3,
+        "acquisition": "free_run",
+        "save_sets": ["Amp4In"],
+    }
+    folder = repo / "TestExp" / ConfigsRepoResolver.PRESET_FOLDER
+    (folder / "smoke.yml").write_text(yaml.safe_dump(preset))  # .yml round-trips
+    resolver = ConfigsRepoResolver("TestExp", experiments_root=repo)
+    assert "smoke" in resolver.list_presets()
+    request = resolver.resolve_preset("smoke")
+    assert isinstance(request, ScanRequest)
+    assert request.shots_per_step == 3
+
+
+def test_resolve_preset_missing_raises_with_kind(repo):
+    from geecs_bluesky.exceptions import GeecsConfigurationError
+
+    resolver = ConfigsRepoResolver("TestExp", experiments_root=repo)
+    with pytest.raises(GeecsConfigurationError, match="preset 'nope'"):
+        resolver.resolve_preset("nope")


### PR DESCRIPTION
## What + why

The v1 tier onto `feat/scan-mcp`, built to the owner decisions (2026-08-22): **presets AND composed dicts from day one** (presets are barely used in practice — the plan's presets-first de-risk dropped), **1,000-shot agent cap**, **approval-gated `force`** on foreign-scan stops.

**GEECS-Scan-MCP 0.2.0 (~340 LOC of tools + tests):**
- `submit_scan(request|preset, description?, acknowledge_warnings?)` — validate → shot cap (`[scan_mcp] max_shots`, default 1,000; optimize requires explicit `max_iterations`) → queue etiquette (one scan in flight; refuses while anything queued/running; **never** clears implicitly) → full preflight with the **acknowledge-warnings loop** (unacknowledged questions return as `needs_acknowledgement`; acknowledgements stamp `continued` into the run's `SubmissionRecord`) → stamped with the deployment identity (`[scan_mcp] client_identity`) → queued. Submit-and-poll.
- `stop_scan(force?)` — graceful; refuses another client's scan **naming its submitting identity** unless `force=true` (approval-gated osprey-side, `forced` logged in the result). Approval-only; the README/CLAUDE.md carry the never-behind-the-kill-switch doctrine.
- `clear_queue()` — the one remover; result lists exactly what was removed.
- `scan_progress()` — poll-shaped, read-only.

**GeecsBluesky 0.61.0 rides along (~60 LOC, per-concern):** `QueueClient.running_item()` (the ownership grounding — the in-flight item's `user` from `queue_get`) + `clear_queue()` on protocol/Zmq/stub; `ConfigsRepoResolver.resolve_preset()` (presets ARE ScanRequests; the folder layout keeps one owner, `.yml` round-trips).

**Flagged judgment call:** the identity used on the queue item and in `SubmissionRecord.client` is the same configurable value (`[scan_mcp] client_identity`, default `geecs-scan-mcp <version>`) — they MUST match or the ownership check never fires; documented in runtime.py and CLAUDE.md.

## Tests

GEECS-Scan-MCP: **36 passed** (16 new control pins: the ack loop both ways, cap refusal, optimize-without-iterations, one-in-flight etiquette with pending listing, ownership refusal/force, clear listing, progress shapes, registration). GeecsBluesky: **618 passed** (new pins: running_item idle→None mapping, clear_queue ok/failure, resolve_preset round-trip incl. `.yml`). `check.sh` green on both.

## Hardware verification (live, Undulator 2026-08-22, HTU-LaserOFF)

- **Scan005** — submitted through `submit_scan` itself: first call refused with `needs_acknowledgement: [free_run_staleness]` (trigger parked — the designed dance), acknowledged resubmit queued and completed; run metadata carries the full trail including `free_run_staleness: continued`.
- **Scan006** — the MCP stopped its **own** 30-shot scan mid-run without force: ownership matched, graceful pause→stop, `exit_status: stopped`, partial data.
- **Scan007** — a foreign-identity scan (submitted as `geecs-console`): stop without force **refused naming the owner**; `force=true` stopped it gracefully with `forced: true` logged.

Nothing owed.

## Review process

Fresh-context adversarial review next (dispositioned on this PR), then **waits for the codex follow-up review** before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)