### PR TITLE
GEECS-MCP: gating docs corrected to VERIFIED osprey semantics

### DIFF
--- a/GEECS-MCP/CHANGELOG.md
+++ b/GEECS-MCP/CHANGELOG.md
@@ -18,6 +18,21 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   capabilities become a satellite server on a Windows box rather than
   moving this one (CLAUDE.md records the pattern).
 
+### Fixed
+
+- **Gating docs corrected to VERIFIED osprey semantics** (checked
+  against the deployed profile 2026-08-22, replacing the assumed
+  story): profile-level custom-server `hooks:` keys are silently
+  ignored, and the interactive writes kill switch does not cover
+  custom-server tools.  The interactive gate is the native `ask`
+  prompt (arguments visible); the headless gate is the profile's
+  `config:` `write_tools`; `stop_scan` is therefore NOT
+  kill-switch-blocked (the halt doctrine holds, by upstream gap rather
+  than design).  Two osprey-side gaps recorded for filing: hook
+  presets/per-tool matchers for custom servers, and kill-switch
+  coverage beyond framework servers.  The `hooks:` key is removed from
+  every example.
+
 ### Added
 
 - **HTTP transport** (`python -m geecs_mcp --transport http --host

--- a/GEECS-MCP/CHANGELOG.md
+++ b/GEECS-MCP/CHANGELOG.md
@@ -25,12 +25,14 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   story): profile-level custom-server `hooks:` keys are silently
   ignored, and the interactive writes kill switch does not cover
   custom-server tools.  The interactive gate is the native `ask`
-  prompt (arguments visible); the headless gate is the profile's
-  `config:` `write_tools`; `stop_scan` is therefore NOT
-  kill-switch-blocked (the halt doctrine holds, by upstream gap rather
-  than design).  Two osprey-side gaps recorded for filing: hook
-  presets/per-tool matchers for custom servers, and kill-switch
-  coverage beyond framework servers.  The `hooks:` key is removed from
+  prompt (arguments visible); the headless gate is
+  `hook_config.json`'s `write_tools` (from the profile's `config:`),
+  listing `submit_scan` + `clear_queue` and deliberately NOT
+  `stop_scan` — a halt is never blocked on any path (headless by
+  designed omission, interactive because the kill switch does not
+  cover custom servers).  Two osprey-side issues to be filed from that
+  side: silent unknown-key acceptance, and custom-server exclusion
+  from the interactive kill switch.  The `hooks:` key is removed from
   every example.
 
 ### Added

--- a/GEECS-MCP/CHANGELOG.md
+++ b/GEECS-MCP/CHANGELOG.md
@@ -64,8 +64,9 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
     → queue. Submit-and-poll: returns `item_uid` immediately.
   - `stop_scan(force?)` — graceful stop; refuses another client's scan
     naming its submitting identity unless `force=true` (approval-gated
-    osprey-side, logged in the result). Approval-only, never behind the
-    kill switch (in-tool doctrine).
+    osprey-side, logged in the result). Approval-only; not behind the
+    kill switch (since verified: holds because the kill switch does not
+    cover custom-server tools — see 0.3.0 Fixed).
   - `clear_queue()` — the one remover; lists exactly what it removed.
   - `scan_progress()` — poll-shaped (read-only): RE state, running item
     + submitting client, queue depth, last outcome.

--- a/GEECS-MCP/CLAUDE.md
+++ b/GEECS-MCP/CLAUDE.md
@@ -106,11 +106,14 @@ geecs_mcp/
   cover custom-server tools (deny augmentation walks the framework's
   own servers only).  The interactive gate is the native `ask` prompt
   on every control verb (arguments visible — also the backstop for the
-  acknowledge-warnings residual); the headless gate is the profile's
-  `config:` `write_tools` entries; `stop_scan` is consequently NOT
-  kill-switch-blocked (the halt doctrine holds, by upstream gap).  Two
-  osprey-side gaps to file: hook presets/per-tool matchers for custom
-  servers, and kill-switch coverage beyond framework servers.  See
+  acknowledge-warnings residual); the headless gate is
+  `hook_config.json`'s `write_tools` (from the profile's `config:`) —
+  listing `submit_scan` + `clear_queue` and deliberately NOT
+  `stop_scan`, so a halt is never blocked on any path (headless by
+  designed omission; interactively because the kill switch does not
+  cover custom servers — upstream gap).  Two osprey-side issues to be
+  filed from that side: silent unknown-key acceptance, and custom
+  servers excluded from the interactive kill switch.  See
   `deploy/DEPLOYMENT.md`.  The submitted-as identity is
   `[mcp] client_identity` (deployment-owned, e.g.
   `osprey-htu-assistant`) and MUST match on the queue item and the

--- a/GEECS-MCP/CLAUDE.md
+++ b/GEECS-MCP/CLAUDE.md
@@ -100,14 +100,18 @@ geecs_mcp/
   continue past a preflight question; acknowledgements stamp
   `continued` into `SubmissionRecord.preflight`), `clear_pending=False`
   always, ownership etiquette on stop, stop approval-only.
-  **Kill-switch caveat (honest)**: osprey hook presets attach
-  server-wide for custom servers (no per-tool matchers), so the
-  recommended `writes_check` on this server ALSO gates `stop_scan` —
-  unlike osprey's native bluesky server, which exempts stop in-tool
-  because it can see the kill switch; this server cannot.  The
-  kill-switch-proof stop paths remain the console and the manager
-  itself; per-tool hook matchers are the osprey-side ask that would
-  close the gap (see `deploy/DEPLOYMENT.md`).  The submitted-as identity is
+  **Gating semantics (VERIFIED against osprey 2026-08-22, replacing the
+  earlier assumed story)**: profile-level custom-server `hooks:` keys
+  are silently ignored, and the interactive writes kill switch does not
+  cover custom-server tools (deny augmentation walks the framework's
+  own servers only).  The interactive gate is the native `ask` prompt
+  on every control verb (arguments visible — also the backstop for the
+  acknowledge-warnings residual); the headless gate is the profile's
+  `config:` `write_tools` entries; `stop_scan` is consequently NOT
+  kill-switch-blocked (the halt doctrine holds, by upstream gap).  Two
+  osprey-side gaps to file: hook presets/per-tool matchers for custom
+  servers, and kill-switch coverage beyond framework servers.  See
+  `deploy/DEPLOYMENT.md`.  The submitted-as identity is
   `[mcp] client_identity` (deployment-owned, e.g.
   `osprey-htu-assistant`) and MUST match on the queue item and the
   `SubmissionRecord` — the ownership check compares against it.

--- a/GEECS-MCP/README.md
+++ b/GEECS-MCP/README.md
@@ -8,7 +8,7 @@ the same server.
 
 **v0 + v1 (current).** Read-only: `scan_status`, `scan_history`,
 `get_scan_result`, `list_scan_configs`, `validate_scan_request`,
-`scan_progress`. Control (put these under OSPREY `ask` + hooks):
+`scan_progress`. Control (put these under OSPREY `ask`; list them in `config:` `write_tools` for headless):
 `submit_scan` (one scan in flight, 1,000-shot cap, preflight warnings
 need explicit acknowledgement), `stop_scan` (graceful; `force` for
 another client's scan is approval territory), `clear_queue` (the one

--- a/GEECS-MCP/README.md
+++ b/GEECS-MCP/README.md
@@ -11,9 +11,11 @@ the same server.
 `scan_progress`. Control (put these under OSPREY `ask` + hooks):
 `submit_scan` (one scan in flight, 1,000-shot cap, preflight warnings
 need explicit acknowledgement), `stop_scan` (graceful; `force` for
-another client's scan is approval territory; note the kill-switch
-caveat in `deploy/DEPLOYMENT.md` — server-wide hooks gate stop too),
-`clear_queue` (the one remover).
+another client's scan is approval territory), `clear_queue` (the one
+remover). Gating semantics — what osprey actually enforces for custom
+servers — are documented in `deploy/DEPLOYMENT.md` (verified: hook
+presets and the interactive kill switch do NOT apply; the native ask
+prompt is the interactive gate).
 
 ## Run
 

--- a/GEECS-MCP/deploy/DEPLOYMENT.md
+++ b/GEECS-MCP/deploy/DEPLOYMENT.md
@@ -20,19 +20,28 @@ mcp_servers:
       allow: [scan_status, scan_history, get_scan_result,
               list_scan_configs, validate_scan_request, scan_progress]
       ask:   [submit_scan, stop_scan, clear_queue]
-    hooks:
-      pre_tool_use: [writes_check, approval]
 ```
 
-**Kill-switch caveat**: hook presets attach server-wide for custom
-servers (no per-tool matchers), so `writes_check` above also gates
-`stop_scan` — engaging the kill switch blocks the MCP's halt verb along
-with its submits. This is a deliberate trade-off (gating submits wins);
-the kill-switch-proof stop paths remain the console and the manager
-itself. Per-tool hook matchers are the osprey-side change that would
-let stop ride outside the kill switch (the native bluesky server's
-in-tool exemption pattern needs kill-switch visibility this external
-server does not have).
+**Hook/kill-switch semantics (VERIFIED against osprey, 2026-08-22)**:
+a `hooks:` key on a profile-level custom-server block is **silently
+ignored** — osprey hook presets do not attach to custom servers, and
+the interactive writes kill switch does not cover custom-server tools
+either (the framework's deny augmentation walks its own
+`FRAMEWORK_SERVERS` only). The actual gates are therefore:
+
+- **Interactive**: the native `ask` permission prompt on the three
+  control verbs — a human sees every `submit_scan`/`stop_scan`/
+  `clear_queue` call with its arguments (this is also the backstop for
+  the acknowledge-warnings residual). `stop_scan` is consequently NOT
+  behind the kill switch — the halt doctrine holds, by upstream gap
+  rather than by design.
+- **Headless**: the `write_tools` entries under the profile's
+  `config:` cover the control verbs.
+
+Two upstream osprey gaps to file: hook presets (or per-tool matchers)
+for custom servers, and kill-switch deny augmentation extending beyond
+the framework's own servers. Until they land, do not add a `hooks:`
+key here — it would document intent the framework does not enforce.
 
 Host setup (same checkout + ritual as the worker):
 

--- a/GEECS-MCP/deploy/DEPLOYMENT.md
+++ b/GEECS-MCP/deploy/DEPLOYMENT.md
@@ -36,7 +36,10 @@ either (the framework's deny augmentation walks its own
   behind the kill switch — the halt doctrine holds, by upstream gap
   rather than by design.
 - **Headless**: the `write_tools` entries under the profile's
-  `config:` cover the control verbs.
+  `config:` cover the control verbs — list `submit_scan`, `stop_scan`,
+  and `clear_queue` there (the deployed htu profile carries the working
+  example; this is the ONLY headless gate, so a profile without those
+  entries leaves an unattended agent ungated).
 
 Two upstream osprey gaps to file: hook presets (or per-tool matchers)
 for custom servers, and kill-switch deny augmentation extending beyond

--- a/GEECS-MCP/deploy/DEPLOYMENT.md
+++ b/GEECS-MCP/deploy/DEPLOYMENT.md
@@ -32,18 +32,24 @@ either (the framework's deny augmentation walks its own
 - **Interactive**: the native `ask` permission prompt on the three
   control verbs — a human sees every `submit_scan`/`stop_scan`/
   `clear_queue` call with its arguments (this is also the backstop for
-  the acknowledge-warnings residual). `stop_scan` is consequently NOT
-  behind the kill switch — the halt doctrine holds, by upstream gap
-  rather than by design.
-- **Headless**: the `write_tools` entries under the profile's
-  `config:` cover the control verbs — list `submit_scan`, `stop_scan`,
-  and `clear_queue` there (the deployed htu profile carries the working
-  example; this is the ONLY headless gate, so a profile without those
-  entries leaves an unattended agent ungated).
+  the acknowledge-warnings residual). `stop_scan` is NOT behind the
+  kill switch on either path: interactively because the kill switch
+  does not cover custom servers (upstream gap), headless by the
+  deliberate `write_tools` omission below — halts are never blocked.
+- **Headless** (`osprey query`): the framework reads
+  `hook_config.json`'s `write_tools` (populated from the profile's
+  `config:`) — list `submit_scan` and `clear_queue` there and
+  **deliberately NOT `stop_scan`**: exempt by omission, so a halt is
+  never blocked on any path (the deployed htu profile is the working
+  example: `write_tools: [mcp__geecs__submit_scan,
+  mcp__geecs__clear_queue]`).  This is the ONLY headless gate — a
+  profile without those two entries leaves an unattended agent's
+  submits ungated.
 
-Two upstream osprey gaps to file: hook presets (or per-tool matchers)
-for custom servers, and kill-switch deny augmentation extending beyond
-the framework's own servers. Until they land, do not add a `hooks:`
+Two upstream osprey issues (to be filed from the osprey side): the
+silent acceptance of unknown keys like `hooks:` on custom-server
+blocks, and custom servers being excluded from the interactive kill
+switch. Until they land, do not add a `hooks:`
 key here — it would document intent the framework does not enforce.
 
 Host setup (same checkout + ritual as the worker):

--- a/GEECS-MCP/geecs_mcp/tool_names.py
+++ b/GEECS-MCP/geecs_mcp/tool_names.py
@@ -31,7 +31,9 @@ READ_TOOLS = (
     SCAN_PROGRESS,
 )
 
-#: Queueing tools (Q) — `ask` + the writes_check (kill switch) preset.
+#: Queueing tools (Q) — `ask` interactively; listed in the profile's
+#: `config:` `write_tools` for the headless gate (hook presets do NOT
+#: attach to custom servers — see STOP_TOOLS below / DEPLOYMENT.md).
 QUEUE_TOOLS = (
     SUBMIT_SCAN,
     CLEAR_QUEUE,

--- a/GEECS-MCP/geecs_mcp/tool_names.py
+++ b/GEECS-MCP/geecs_mcp/tool_names.py
@@ -5,8 +5,8 @@ hook matchers import these symbols instead of retyping strings, so a
 rename cannot silently strand a permission entry.
 
 Safety classes (the planning doc's vocabulary): **R** read-only
-(auto-allow), **Q** queueing (`ask` + `writes_check`), **S** stop
-direction (`ask`; see the kill-switch caveat on ``STOP_TOOLS``).
+(auto-allow), **Q** queueing (`ask`), **S** stop direction (`ask`; see
+the verified gating semantics on ``STOP_TOOLS``).
 """
 
 from __future__ import annotations
@@ -37,11 +37,11 @@ QUEUE_TOOLS = (
     CLEAR_QUEUE,
 )
 
-#: Stop direction (S) — `ask` only.  Doctrine: a halt should never sit
-#: behind the kill switch — but osprey hook presets attach SERVER-WIDE
-#: for custom servers, so a `writes_check` on this server gates stop too
-#: (this server cannot see the kill switch to exempt itself in-tool the
-#: way osprey's native bluesky server does).  Honest posture: the
-#: console/manager remain the kill-switch-proof stop paths; per-tool
-#: matchers are the osprey-side fix.  See deploy/DEPLOYMENT.md.
+#: Stop direction (S) — `ask` only.  VERIFIED osprey semantics
+#: (2026-08-22): hook presets and the interactive kill switch do NOT
+#: apply to custom-server tools at all, so stop is not kill-switch-
+#: blocked (the halt doctrine holds, by upstream gap rather than
+#: design) and the native ask prompt is the interactive gate on every
+#: control verb.  See deploy/DEPLOYMENT.md for the full semantics and
+#: the two upstream gaps to file.
 STOP_TOOLS = (STOP_SCAN,)

--- a/GEECS-MCP/geecs_mcp/tool_names.py
+++ b/GEECS-MCP/geecs_mcp/tool_names.py
@@ -31,19 +31,18 @@ READ_TOOLS = (
     SCAN_PROGRESS,
 )
 
-#: Queueing tools (Q) — `ask` interactively; listed in the profile's
-#: `config:` `write_tools` for the headless gate (hook presets do NOT
-#: attach to custom servers — see STOP_TOOLS below / DEPLOYMENT.md).
+#: Queueing tools (Q) — `ask` interactively; listed in `write_tools`
+#: (hook_config.json, from the profile's `config:`) for the headless
+#: gate (hook presets do NOT attach to custom servers — see STOP_TOOLS
+#: below / DEPLOYMENT.md).
 QUEUE_TOOLS = (
     SUBMIT_SCAN,
     CLEAR_QUEUE,
 )
 
-#: Stop direction (S) — `ask` only.  VERIFIED osprey semantics
-#: (2026-08-22): hook presets and the interactive kill switch do NOT
-#: apply to custom-server tools at all, so stop is not kill-switch-
-#: blocked (the halt doctrine holds, by upstream gap rather than
-#: design) and the native ask prompt is the interactive gate on every
-#: control verb.  See deploy/DEPLOYMENT.md for the full semantics and
-#: the two upstream gaps to file.
+#: Stop direction (S) — `ask` only, and NEVER listed in `write_tools`:
+#: exempt by omission from the headless gate BY DESIGN, and outside the
+#: interactive kill switch because it does not cover custom servers
+#: (upstream gap) — so a halt is never blocked on any path.  VERIFIED
+#: osprey semantics 2026-08-22; see deploy/DEPLOYMENT.md.
 STOP_TOOLS = (STOP_SCAN,)


### PR DESCRIPTION
## What + why

Docs-only truth-up. The deployed-profile verification (2026-08-22, recorded in the osprey profile's own NOTE) falsified the gating story #672 shipped: profile-level custom-server `hooks:` keys are **silently ignored** by osprey, and the interactive writes kill switch does **not** cover custom-server tools (deny augmentation walks `FRAMEWORK_SERVERS` only). #672's "kill-switch caveat" described `writes_check` gating that never happens.

Corrected consistently across DEPLOYMENT.md / README / `tool_names` / CLAUDE.md / CHANGELOG to the verified reality:

- **Interactive gate** = the native `ask` prompt on every control verb, arguments visible (which also remains the backstop for the acknowledge-warnings residual).
- **Headless gate** = the profile's `config:` `write_tools` entries.
- `stop_scan` is **not** kill-switch-blocked — the halt doctrine holds, by upstream gap rather than by design.
- The `hooks:` key is removed from every example — documenting intent the framework doesn't enforce is worse than absence.
- The two osprey-side gaps are recorded for filing: hook presets / per-tool matchers for custom servers, and kill-switch coverage beyond framework servers.

## Tests

Docs-only; 40 passed (unchanged). No version bump beyond the unreleased 0.3.0 entry (Fixed section added).

## Review process

Fresh-context review + codex gate as usual — though the maintainer may reasonably waive for a docs-only truth-up of *his own* verified facts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)