### PR TITLE
GEECS-LogTriage 0.3.0: classify NotConnectedError + expected soft-drop down-ranking (#621)

### DIFF
--- a/.claude/skills/triage/SKILL.md
+++ b/.claude/skills/triage/SKILL.md
@@ -147,7 +147,7 @@ show the draft body so the user can file manually.
 
 ## Notes
 
-- Only file for `bug_candidate`. `hardware_issue`, `config_issue`, and
+- Only file for `bug_candidate`. `hardware_issue`, `config_issue`,
   `operator_error`, and `expected_condition` (engine-tolerated
   soft-telemetry drops — only present on `--level warning` runs; the
   default min level is ERROR) are noted in the summary but do not

--- a/.claude/skills/triage/SKILL.md
+++ b/.claude/skills/triage/SKILL.md
@@ -148,7 +148,10 @@ show the draft body so the user can file manually.
 ## Notes
 
 - Only file for `bug_candidate`. `hardware_issue`, `config_issue`, and
-  `operator_error` are noted in the summary but do not produce issues unless the
+  `operator_error`, and `expected_condition` (engine-tolerated
+  soft-telemetry drops — only present on `--level warning` runs; the
+  default min level is ERROR) are noted in the summary but do not
+  produce issues unless the
   user explicitly asks.
 - Deduplicate: if the same fingerprint hash already appears in an open GitHub
   issue (check with `gh issue list --search "<fingerprint_hash>"`), skip it and

--- a/GEECS-LogTriage/CHANGELOG.md
+++ b/GEECS-LogTriage/CHANGELOG.md
@@ -20,7 +20,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ghost device (the DB orphan-row situation) is grouped and rendered
   in its own trailing report section instead of filing as a fresh
   per-scan hardware issue.  Stage-2 issue filing must not act on this
-  category.
+  category.  Note: the report's Expected-conditions section only
+  populates on `--level warning` runs (the harvester's default min
+  level is ERROR).
+
+### Fixed (review findings on the PR)
+
+- The exception-type map lookup normalizes to the last dotted segment —
+  real tracebacks print non-builtins fully qualified
+  (`ophyd_async.core._utils.NotConnectedError`), so the exact-key match
+  was dead code for every record the harvester can produce; the
+  normalization also rescues the pre-existing dotted-class entries.
+  Pinned end-to-end through the fingerprint extractor.
+- The cross-package phrase coupling is bidirectional: GeecsBluesky
+  0.61.1 names the message (`SOFT_TELEMETRY_DROP_MSG`, both drop
+  sites, with a reword-only-together warning) and a triage-side test
+  greps the sibling source when present.
 
 ## [0.2.4] — 2026-06-29
 

--- a/GEECS-LogTriage/CHANGELOG.md
+++ b/GEECS-LogTriage/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to `geecs-log-triage` will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.0] - 2026-08-22
+
+### Added
+
+- **`NotConnectedError` classification** (#621): the CA device layer's
+  connect failure now maps to `hardware_issue` instead of producing
+  `unknown` fingerprints (in scan.log since GeecsBluesky 0.51.0 made
+  the file the complete per-scan record).
+- **`EXPECTED_CONDITION` classification**: the engine's own tolerated
+  soft-telemetry drop WARNING ("soft tier — never aborts the scan",
+  from `GeecsBluesky` `session.telemetry`) classifies as an expected
+  condition — checked BEFORE the exception-type map, so a standing
+  ghost device (the DB orphan-row situation) is grouped and rendered
+  in its own trailing report section instead of filing as a fresh
+  per-scan hardware issue.  Stage-2 issue filing must not act on this
+  category.
+
 ## [0.2.4] — 2026-06-29
 
 ### Fixed

--- a/GEECS-LogTriage/CLAUDE.md
+++ b/GEECS-LogTriage/CLAUDE.md
@@ -59,11 +59,11 @@ record's `traceback` field.
   `GeecsDeviceInstantiationError`, `ConnectionRefusedError`, `TimeoutError`,
   `OSError` with errno EINVAL/EBADF (the SafeFileHandler ignored class).
 - `operator_error` — recoverable runtime conditions: missing data files,
+  invalid scan parameters caught at scan start.
 - `expected_condition` — tolerated by the engine BY DESIGN (the
   soft-telemetry drop, keyed on GeecsBluesky's `SOFT_TELEMETRY_DROP_MSG`
   — reword only together); grouped in a trailing report section; Stage 2
-  must NOT file these
-  invalid scan parameters caught at scan start.
+  must NOT file these.
 - `unknown` — fallback when the exception type or message can't be mapped.
 
 When the GEECS exception taxonomy grows, edit `classifier.CLASSIFICATION_MAP`.

--- a/GEECS-LogTriage/CLAUDE.md
+++ b/GEECS-LogTriage/CLAUDE.md
@@ -59,6 +59,10 @@ record's `traceback` field.
   `GeecsDeviceInstantiationError`, `ConnectionRefusedError`, `TimeoutError`,
   `OSError` with errno EINVAL/EBADF (the SafeFileHandler ignored class).
 - `operator_error` — recoverable runtime conditions: missing data files,
+- `expected_condition` — tolerated by the engine BY DESIGN (the
+  soft-telemetry drop, keyed on GeecsBluesky's `SOFT_TELEMETRY_DROP_MSG`
+  — reword only together); grouped in a trailing report section; Stage 2
+  must NOT file these
   invalid scan parameters caught at scan start.
 - `unknown` — fallback when the exception type or message can't be mapped.
 

--- a/GEECS-LogTriage/geecs_log_triage/classifier.py
+++ b/GEECS-LogTriage/geecs_log_triage/classifier.py
@@ -46,6 +46,12 @@ CLASSIFICATION_MAP: dict[str, Classification] = {
     "GeecsDeviceCommandRejected": Classification.HARDWARE_ISSUE,
     "GeecsDeviceExeTimeout": Classification.HARDWARE_ISSUE,
     "GeecsDeviceCommandFailed": Classification.HARDWARE_ISSUE,
+    # ophyd-async connect failures (the CA device layer): a device whose
+    # PVs never connected.  In scan.log since GeecsBluesky 0.51.0 made the
+    # file the complete record (#620/#621) — soft-telemetry drops carry
+    # the full traceback.  The expected-soft-drop guard in classify()
+    # takes precedence for the tolerated case.
+    "NotConnectedError": Classification.HARDWARE_ISSUE,
     # Python builtins commonly indicating a code bug.
     "KeyError": Classification.BUG_CANDIDATE,
     "AttributeError": Classification.BUG_CANDIDATE,
@@ -128,6 +134,15 @@ def classify(
     Classification
         The triage category.
     """
+    # Engine-tolerated soft-telemetry drop (#621): the WARNING's own
+    # message marks it ("soft tier — never aborts the scan", from
+    # GeecsBluesky session.telemetry), and the attached NotConnectedError
+    # traceback is expected — checked BEFORE the exception-type map so a
+    # standing ghost device (the DB orphan-row situation) doesn't file as
+    # a fresh hardware issue on every scan.
+    if "soft tier — never aborts the scan" in entry.message:
+        return Classification.EXPECTED_CONDITION
+
     if exception_type and exception_type in CLASSIFICATION_MAP:
         return CLASSIFICATION_MAP[exception_type]
 

--- a/GEECS-LogTriage/geecs_log_triage/classifier.py
+++ b/GEECS-LogTriage/geecs_log_triage/classifier.py
@@ -10,6 +10,8 @@ Classifications drive Stage 2 routing:
 - ``BUG_CANDIDATE``  - file as a bug, eligible for Stage 3 fix attempts.
 - ``CONFIG_ISSUE``   - file as needs-human-review, do **not** auto-fix code.
 - ``HARDWARE_ISSUE`` - file as flaky-hardware tracking, do not auto-fix.
+- ``EXPECTED_CONDITION`` - tolerated by the engine BY DESIGN (the
+  soft-telemetry drop); Stage 2 must NOT file these.
 - ``OPERATOR_ERROR`` - typically batch into a daily digest, not per-fingerprint.
 - ``UNKNOWN``        - fall through; Stage 2 will likely defer.
 """
@@ -143,8 +145,18 @@ def classify(
     if "soft tier — never aborts the scan" in entry.message:
         return Classification.EXPECTED_CONDITION
 
-    if exception_type and exception_type in CLASSIFICATION_MAP:
-        return CLASSIFICATION_MAP[exception_type]
+    if exception_type:
+        # Real tracebacks print non-builtin exceptions FULLY QUALIFIED
+        # (e.g. ophyd_async.core._utils.NotConnectedError), so the map
+        # lookup normalizes to the last dotted segment — an exact-key
+        # match would be dead code for every record the harvester can
+        # actually produce (#680 review finding; also rescues the
+        # pre-existing dotted-class entries the message hints only
+        # partially covered).  The fingerprint signature keeps the full
+        # dotted form — dedup stability must not change.
+        bare_type = exception_type.rsplit(".", 1)[-1]
+        if bare_type in CLASSIFICATION_MAP:
+            return CLASSIFICATION_MAP[bare_type]
 
     # Try to peel an exception type out of the message itself
     # (e.g., "Failed to ...: ConnectionRefusedError").

--- a/GEECS-LogTriage/geecs_log_triage/render.py
+++ b/GEECS-LogTriage/geecs_log_triage/render.py
@@ -15,6 +15,7 @@ _SECTION_ORDER = [
     Classification.HARDWARE_ISSUE,
     Classification.CONFIG_ISSUE,
     Classification.OPERATOR_ERROR,
+    Classification.EXPECTED_CONDITION,
     Classification.UNKNOWN,
 ]
 
@@ -23,6 +24,7 @@ _SECTION_LABEL = {
     Classification.HARDWARE_ISSUE: "Hardware issues",
     Classification.CONFIG_ISSUE: "Config / operator issues",
     Classification.OPERATOR_ERROR: "Operator actions",
+    Classification.EXPECTED_CONDITION: "Expected conditions (tolerated by design)",
     Classification.UNKNOWN: "Unclassified",
 }
 

--- a/GEECS-LogTriage/geecs_log_triage/schemas.py
+++ b/GEECS-LogTriage/geecs_log_triage/schemas.py
@@ -37,6 +37,12 @@ class Classification(str, Enum):
     CONFIG_ISSUE = "config_issue"
     HARDWARE_ISSUE = "hardware_issue"
     OPERATOR_ERROR = "operator_error"
+    #: A condition the engine tolerates BY DESIGN (e.g. a soft-telemetry
+    #: device dropped at scan start — the WARNING carries a full traceback
+    #: but the scan proceeds unharmed).  Grouped and rendered last so
+    #: standing conditions don't masquerade as per-scan hardware issues
+    #: (#621); Stage 2 must not file these.
+    EXPECTED_CONDITION = "expected_condition"
     UNKNOWN = "unknown"
 
 

--- a/GEECS-LogTriage/pyproject.toml
+++ b/GEECS-LogTriage/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-log-triage"
-version = "0.2.4"
+version = "0.3.0"
 description = "Harvest, classify, and aggregate errors from GEECS scan execution logs."
 authors = ["Sam Barber <sbarber@lbl.gov>"]
 readme = "README.md"

--- a/GEECS-LogTriage/tests/test_classifier.py
+++ b/GEECS-LogTriage/tests/test_classifier.py
@@ -120,3 +120,51 @@ def test_unrelated_hardware_error_not_downranked():
     hardware failure mentioning a device stays a hardware issue."""
     entry = _entry("device not responding: U_Amp4_IR_input")
     assert classify(entry, "NotConnectedError") is Classification.HARDWARE_ISSUE
+
+
+def test_dotted_exception_type_normalizes_for_the_map():
+    """Real tracebacks print non-builtins fully qualified — the map lookup
+    must normalize (#680 review finding: the exact-key match was dead code
+    for every record the harvester can produce)."""
+    entry = _entry("device connect failed")
+    assert (
+        classify(entry, "ophyd_async.core._utils.NotConnectedError")
+        is Classification.HARDWARE_ISSUE
+    )
+
+
+def test_dotted_type_end_to_end_through_the_fingerprint_extractor():
+    """The honest pipeline test: a traceback rendered the way ophyd-async
+    renders it → signature extraction → classification."""
+    from geecs_log_triage.fingerprint import _extract_traceback_signature
+
+    traceback_text = (
+        "Traceback (most recent call last):\n"
+        '  File "connector.py", line 10, in connect\n'
+        "    await device.connect()\n"
+        "ophyd_async.core._utils.NotConnectedError: device connect failed\n"
+    )
+    exc_type = _extract_traceback_signature(traceback_text)[0]
+    assert exc_type == "ophyd_async.core._utils.NotConnectedError"
+    assert classify(_entry("boom"), exc_type) is Classification.HARDWARE_ISSUE
+
+
+def test_expected_drop_phrase_matches_the_engine_source():
+    """Bidirectional pin of the cross-package phrase coupling: when the
+    sibling GeecsBluesky checkout is present (the monorepo layout), the
+    engine's SOFT_TELEMETRY_DROP_MSG must contain the classifier's guard
+    phrase — a wording pass in either package fails this test instead of
+    silently reverting ghost devices to per-scan noise."""
+    from pathlib import Path
+
+    session_py = (
+        Path(__file__).resolve().parents[2]
+        / "GeecsBluesky"
+        / "geecs_bluesky"
+        / "session.py"
+    )
+    if not session_py.is_file():
+        pytest.skip("standalone checkout — no sibling GeecsBluesky source")
+    source = session_py.read_text(encoding="utf-8")
+    assert "SOFT_TELEMETRY_DROP_MSG" in source
+    assert "soft tier — never aborts the scan" in source

--- a/GEECS-LogTriage/tests/test_classifier.py
+++ b/GEECS-LogTriage/tests/test_classifier.py
@@ -89,3 +89,34 @@ def test_classify_unknown_when_no_match():
 def test_classify_unknown_exc_type_falls_back_to_message():
     e = _entry("something completely unrecognised happened")
     assert classify(e, exception_type="SomeObscureError") == Classification.UNKNOWN
+
+
+# ---------------------------------------------------------------------------
+# #621: NotConnectedError + the expected-soft-drop guard
+# ---------------------------------------------------------------------------
+
+
+def test_notconnectederror_is_a_hardware_issue():
+    """A bare CA connect failure classifies as hardware, never unknown."""
+    entry = _entry("device connect failed")
+    assert classify(entry, "NotConnectedError") is Classification.HARDWARE_ISSUE
+
+
+def test_engine_tolerated_soft_drop_is_expected_condition():
+    """The engine's own soft-tier drop WARNING (GeecsBluesky
+    session.telemetry) marks a tolerated-by-design condition — it must not
+    file as a per-scan hardware issue even though the record carries a
+    NotConnectedError traceback (the guard precedes the type map)."""
+    entry = _entry(
+        "Dropping background-telemetry device U_GhostLowPowerWFS: "
+        "unreachable at scan start (soft tier — never aborts the scan)"
+    )
+    assert classify(entry, "NotConnectedError") is Classification.EXPECTED_CONDITION
+    assert classify(entry) is Classification.EXPECTED_CONDITION
+
+
+def test_unrelated_hardware_error_not_downranked():
+    """The guard keys on the engine's exact tolerated-drop phrase — a real
+    hardware failure mentioning a device stays a hardware issue."""
+    entry = _entry("device not responding: U_Amp4_IR_input")
+    assert classify(entry, "NotConnectedError") is Classification.HARDWARE_ISSUE

--- a/GeecsBluesky/CHANGELOG.md
+++ b/GeecsBluesky/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to `geecs-bluesky` are documented here.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.61.1] - 2026-08-22
+
+### Changed
+
+- The tolerated soft-telemetry drop message is a named module constant
+  (`session.SOFT_TELEMETRY_DROP_MSG`, both drop sites) with a
+  load-bearing warning: GEECS-LogTriage's classifier keys its
+  `EXPECTED_CONDITION` down-ranking on the exact phrase (#621/#680) —
+  reword only together with `geecs_log_triage/classifier.py` (the
+  `FAILED_MOVE_LOG_PREFIX` pattern).  Byte-identical message, no
+  behavior change.
+
 ## [0.61.0] - 2026-08-22
 
 ### Added

--- a/GeecsBluesky/geecs_bluesky/session.py
+++ b/GeecsBluesky/geecs_bluesky/session.py
@@ -66,6 +66,16 @@ from geecs_bluesky.utils import safe_name
 
 logger = logging.getLogger(__name__)
 
+#: The tolerated soft-telemetry drop message (both drop sites below).
+#: LOAD-BEARING DOWNSTREAM: GEECS-LogTriage's classifier keys its
+#: EXPECTED_CONDITION down-ranking on this exact phrase (#621/#680) —
+#: reword it ONLY together with geecs_log_triage/classifier.py (the
+#: FAILED_MOVE_LOG_PREFIX pattern: parsed log lines get named constants).
+SOFT_TELEMETRY_DROP_MSG = (
+    "Dropping background-telemetry device %s: unreachable at scan start "
+    "(soft tier — never aborts the scan)"
+)
+
 _FREE_RUN = "free_run"
 _STRICT = "strict"
 
@@ -379,12 +389,7 @@ class GeecsSession:
         try:
             return self._connect(det)
         except Exception:
-            logger.warning(
-                "Dropping background-telemetry device %s: unreachable at scan "
-                "start (soft tier — never aborts the scan)",
-                device,
-                exc_info=True,
-            )
+            logger.warning(SOFT_TELEMETRY_DROP_MSG, device, exc_info=True)
             return None
 
     def telemetry_batch(
@@ -437,8 +442,7 @@ class GeecsSession:
         for device_obj, result in zip(devices, results):
             if isinstance(result, BaseException):
                 logger.warning(
-                    "Dropping background-telemetry device %s: unreachable at "
-                    "scan start (soft tier — never aborts the scan)",
+                    SOFT_TELEMETRY_DROP_MSG,
                     device_obj._geecs_device_name,
                     exc_info=result,
                 )

--- a/GeecsBluesky/pyproject.toml
+++ b/GeecsBluesky/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-bluesky"
-version = "0.61.0"
+version = "0.61.1"
 description = "Bluesky / ophyd-async bridge for the GEECS control system"
 authors = ["Sam Barber <sbarber@lbl.gov>"]
 readme = "README.md"


### PR DESCRIPTION
## What + why

Closes #621 (both halves of its ask, including the down-ranking decision it left open):

- **`NotConnectedError` → `hardware_issue`** in `CLASSIFICATION_MAP` — since GeecsBluesky 0.51.0 made scan.log the complete per-scan record (#620), every scan with a ghost soft-telemetry device (the standing DB orphan-row situation, e.g. `U_GhostLowPowerWFS`) produced an `unknown` fingerprint.
- **The down-rank, decided and implemented**: a new `EXPECTED_CONDITION` classification for conditions the engine tolerates *by design*. The guard keys on the engine's own tolerated-drop phrase (`"soft tier — never aborts the scan"`, the exact string `GeecsBluesky` `session.telemetry` logs) and runs **before** the exception-type map — so a standing ghost device groups into a trailing "Expected conditions (tolerated by design)" report section instead of filing as a fresh per-scan hardware issue, while a genuine `NotConnectedError` anywhere else stays `hardware_issue`. The enum docstring pins the rule that Stage-2 issue filing must not act on this category.

Minor bump (new report category = behavior change). Render section order/labels extended; `/triage` skill unchanged (it wraps the CLI).

## Tests

**56 passed** (3 new pins: bare `NotConnectedError` → hardware; the exact engine phrase → expected, with and without the exception type present; an unrelated hardware message carrying the same exception type is NOT down-ranked). `check.sh GEECS-LogTriage` green.

## Hardware verification

Not applicable — pure log classification, no scan/device surface. The classifier change is exercised against the exact production strings (the engine phrase verified against `session.py`, the ghost-device scenario from the #621 report).

## Review process

Fresh-context adversarial review next; then the codex gate before the maintainer merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)