### PR TITLE
GEECS-MCP 0.4.0: the analysis domain — get_scan_analysis + get_scan_figure (#675)

### DIFF
--- a/GEECS-MCP/CHANGELOG.md
+++ b/GEECS-MCP/CHANGELOG.md
@@ -4,6 +4,27 @@ All notable changes to `geecs-mcp` are documented here.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.4.0] - 2026-08-22
+
+### Added
+
+- **The analysis domain** (#675 — the top post-promotion ask, closing
+  "scan → analyze → present"): `get_scan_analysis` (per-analyzer task
+  statuses from `analysis_status/*.yaml` — tolerantly parsed, the
+  schema is ScanAnalysis-owned — plus the capped analysis output tree)
+  and `get_scan_figure` (a rendered summary figure as actual MCP image
+  content, ≤1024 px longest edge via pillow; `display_files` routed
+  first, then tree images; ambiguous → the candidate list).  Both
+  read-only/auto-allow.  **Strictly read-only over the data share**:
+  only ScanPaths' pure static path builders (the instance
+  `get_analysis_folder()` silently `os.makedirs` and is banned here),
+  pinned by a nothing-created-on-miss test.  Requires `[Paths]
+  geecs_data` + the mounted share on the serving host; an unconfigured
+  host refuses honestly (live-verified) after a one-time
+  `reload_paths_config()` init (live-run finding: the class attribute
+  starts `None` and raised instead of degrading).
+- `pillow` declared (figure downscaling).
+
 ## [0.3.0] - 2026-08-22
 
 ### Changed

--- a/GEECS-MCP/CHANGELOG.md
+++ b/GEECS-MCP/CHANGELOG.md
@@ -39,11 +39,14 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Field coercions sit inside the per-file guard and `display_files`
   entries are type-checked — one odd YAML on the writable share
   degrades that entry to `unreadable`, never the whole tool.
-- **Figure candidates are bounded to the share root** (resolve +
-  `is_relative_to`): a `display_files` entry pointing outside the share
-  (absolute or `../`) is dropped with a warning, closing the
+- **Figure candidates are bounded to the scan's own analysis folder**
+  (resolve + `is_relative_to`): a `display_files` entry pointing
+  anywhere else — outside the share, at another scan's outputs, or into
+  the raw `scans/` tree — is dropped with a warning, closing the
   confused-deputy path where share-writers could make the MCP serve
-  arbitrary host-readable files.
+  other host-readable files.  (The first review pass bounded to the
+  share root; the codex pass tightened it to the scan's analysis folder,
+  which is where the writer puts every legitimate entry.)
 - A 64 MP decode cap refuses giant share-resident images before the
   full decode (Pillow's own bomb ceiling is ~178 MP ≈ 700 MB RAM on a
   long-lived server).

--- a/GEECS-MCP/CHANGELOG.md
+++ b/GEECS-MCP/CHANGELOG.md
@@ -23,7 +23,30 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   host refuses honestly (live-verified) after a one-time
   `reload_paths_config()` init (live-run finding: the class attribute
   starts `None` and raised instead of degrading).
-- `pillow` declared (figure downscaling).
+- `pillow` and `pyyaml` declared (direct imports).
+
+### Review hardening (same release, adversarial review on the PR)
+
+- **The status parser reads the REAL `TaskStatus.to_dict()` schema**
+  (CRITICAL finding: the first cut was written from ScanAnalysis's
+  stale CLAUDE.md prose — `status`/`heartbeat` float — which the writer
+  never produces; against production data every task would have read
+  null).  Now: `state` (queued/claimed/done/failed/no_data), `error`
+  (surfaced — the most useful failed-task field), `claimed_by`,
+  `last_heartbeat` as ISO-8601 parsed to an age (UTC-naive tolerated,
+  per task_queue's own `_parse_ts`).  The stale ScanAnalysis doc is
+  fixed in the same wave with a read-the-writer warning.
+- Field coercions sit inside the per-file guard and `display_files`
+  entries are type-checked — one odd YAML on the writable share
+  degrades that entry to `unreadable`, never the whole tool.
+- **Figure candidates are bounded to the share root** (resolve +
+  `is_relative_to`): a `display_files` entry pointing outside the share
+  (absolute or `../`) is dropped with a warning, closing the
+  confused-deputy path where share-writers could make the MCP serve
+  arbitrary host-readable files.
+- A 64 MP decode cap refuses giant share-resident images before the
+  full decode (Pillow's own bomb ceiling is ~178 MP ≈ 700 MB RAM on a
+  long-lived server).
 
 ## [0.3.0] - 2026-08-22
 

--- a/GEECS-MCP/CLAUDE.md
+++ b/GEECS-MCP/CLAUDE.md
@@ -11,8 +11,9 @@ Domain roadmap (add as they earn their keep, never speculatively):
 `scans/` (built: v0 read + v1 control), then candidates in rough value
 order — `health/` (gateway/Tiled/DB probes, read-only), `db/`
 (device-variable metadata lookups), `logs/` (the /triage analysis as a
-tool), `analysis/` (over archived Tiled runs — pure-numpy analysis is
-cross-platform; capabilities needing **Windows-only acquisition SDKs**
+tool), `analysis/` (FIRST SLICE BUILT — the #675 figure/results verbs
+over the ScanAnalysis output tree; deeper analysis-over-Tiled later;
+pure-numpy analysis is cross-platform; capabilities needing **Windows-only acquisition SDKs**
 do NOT force this server onto Windows — they become a small *satellite
 MCP server* on a Windows box (the PVA-gateway camera-server precedent),
 registered as a second `profile.yml` entry with the same envelope
@@ -69,6 +70,17 @@ geecs_mcp/
     control_tools.py # the v1 verbs: submit (cap + etiquette + the
                   #   acknowledge-warnings loop), stop (ownership),
                   #   clear_queue, scan_progress
+  analysis/       # the analysis domain (#675)
+    read_tools.py # get_scan_analysis (task statuses from
+                  #   analysis_status/ + the output tree) and
+                  #   get_scan_figure (a display_files/py-image figure,
+                  #   downscaled, returned as MCP image content).
+                  #   STRICTLY read-only over the data share: pure
+                  #   ScanPaths static builders ONLY — the instance
+                  #   get_analysis_folder() silently mkdirs and must
+                  #   never be used here; pinned by a nothing-created
+                  #   test.  Needs [Paths] geecs_data + the share
+                  #   mounted on the serving host (degrades honestly)
 ```
 
 ## Conventions

--- a/GEECS-MCP/README.md
+++ b/GEECS-MCP/README.md
@@ -8,7 +8,8 @@ the same server.
 
 **v0 + v1 (current).** Read-only: `scan_status`, `scan_history`,
 `get_scan_result`, `list_scan_configs`, `validate_scan_request`,
-`scan_progress`. Control (put these under OSPREY `ask`; list them in `config:` `write_tools` for headless):
+`scan_progress`, `get_scan_analysis`, `get_scan_figure` (analysis
+results + rendered figures — needs the data share mounted). Control (put these under OSPREY `ask`; list them in `config:` `write_tools` for headless):
 `submit_scan` (one scan in flight, 1,000-shot cap, preflight warnings
 need explicit acknowledgement), `stop_scan` (graceful; `force` for
 another client's scan is approval territory), `clear_queue` (the one

--- a/GEECS-MCP/deploy/DEPLOYMENT.md
+++ b/GEECS-MCP/deploy/DEPLOYMENT.md
@@ -18,7 +18,8 @@ mcp_servers:
     transport: http
     permissions:
       allow: [scan_status, scan_history, get_scan_result,
-              list_scan_configs, validate_scan_request, scan_progress]
+              list_scan_configs, validate_scan_request, scan_progress,
+              get_scan_analysis, get_scan_figure]
       ask:   [submit_scan, stop_scan, clear_queue]
 ```
 

--- a/GEECS-MCP/geecs_mcp/__init__.py
+++ b/GEECS-MCP/geecs_mcp/__init__.py
@@ -6,4 +6,4 @@ v1 control verbs — submit/stop/clear/progress) today; future domains
 ``CLAUDE.md`` for the domain roadmap and the safety doctrine.
 """
 
-__version__ = "0.3.0"
+__version__ = "0.4.0"

--- a/GEECS-MCP/geecs_mcp/analysis/__init__.py
+++ b/GEECS-MCP/geecs_mcp/analysis/__init__.py
@@ -1,0 +1,1 @@
+"""The analysis domain — read-only access to per-scan analysis outputs."""

--- a/GEECS-MCP/geecs_mcp/analysis/read_tools.py
+++ b/GEECS-MCP/geecs_mcp/analysis/read_tools.py
@@ -1,0 +1,304 @@
+"""The analysis-domain read tools: per-scan analysis results and figures.
+
+Closes the "scan → analyze → present" loop (#675): ``get_scan_analysis``
+reports what the ScanAnalysis pipeline produced for a scan (task
+statuses from ``analysis_status/`` plus the output tree), and
+``get_scan_figure`` returns a rendered summary figure as actual MCP
+image content (downscaled — context-sized, never the raw file).
+
+Everything is **strictly read-only over the data share**:
+
+- Paths come from :class:`geecs_data_utils.ScanPaths`'s PURE static
+  builders (``get_scan_folder_path`` / ``get_scan_analysis_folder_path``)
+  — never the instance accessors, whose ``get_analysis_folder()``
+  silently ``os.makedirs`` a missing folder.  A missing folder is a
+  ``not_found`` envelope naming the path; nothing on the data share is
+  ever created (the repo's scan-folder invariant, applied to the whole
+  share).
+- The task-status YAMLs are parsed tolerantly (``.get`` everywhere) —
+  their schema is ScanAnalysis-owned (``task_queue.TaskStatus``); this
+  module reads the documented fields and survives extras/absences.
+
+Same conventions as every domain: sync ``_*_impl`` = the tested surface,
+async wrappers via the shared guard, JSON envelopes (except a successful
+figure fetch, which returns MCP image content).
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from datetime import date
+from pathlib import Path
+from typing import Any, Optional
+
+from geecs_mcp import errors, runtime, tool_names
+from geecs_mcp.scans.read_tools import _run_guarded
+from geecs_mcp.server import mcp
+
+logger = logging.getLogger("geecs_mcp.analysis.read")
+
+#: Cap on file names listed per output directory — the tree is a map for
+#: the agent, not a dump.
+_MAX_FILES_PER_DIR = 30
+
+#: Cap on figure candidates gathered/listed.
+_MAX_FIGURE_CANDIDATES = 60
+
+#: Longest image edge after downscaling (agent context, not archival).
+_MAX_FIGURE_EDGE_PX = 1024
+
+_IMAGE_SUFFIXES = (".png", ".jpg", ".jpeg")
+
+
+def _base_directory() -> Optional[Path]:
+    """The data-share base directory override (``None`` = production config).
+
+    A module-level seam so hermetic tests point the pure path builders at
+    a tmp tree; production always returns ``None`` (the builders then use
+    ``GeecsPathsConfig``).
+    """
+    return None
+
+
+def _resolve_folders(scan_number: int, day: str | None) -> tuple[Any, Path, Path]:
+    """Resolve (tag, scan_folder, analysis_folder) — pure paths, no I/O.
+
+    Raises
+    ------
+    ValueError
+        Bad ``day`` string (caller maps to ``invalid_request``).
+    RuntimeError
+        No experiment configured (caller maps to ``invalid_request``).
+    """
+    from geecs_data_utils import ScanPaths, ScanTag
+
+    experiment = runtime.get_experiment()
+    if not experiment:
+        raise RuntimeError("no experiment configured ([Experiment] expt in config.ini)")
+    when = date.fromisoformat(day) if day else date.today()
+    tag = ScanTag(
+        year=when.year,
+        month=when.month,
+        day=when.day,
+        number=int(scan_number),
+        experiment=experiment,
+    )
+    base = _base_directory()
+    if base is None:
+        # ScanPaths.paths_config starts as None and nothing initializes it
+        # at import — consumers must call reload_paths_config() once
+        # (live-run finding: an unconfigured class attribute raised
+        # AttributeError instead of degrading).  reload swallows its own
+        # ConfigurationError and leaves None, so the honest refusal is ours.
+        if ScanPaths.paths_config is None:
+            ScanPaths.reload_paths_config()
+        if ScanPaths.paths_config is None:
+            raise RuntimeError(
+                "data share not configured — set [Paths] geecs_data in "
+                "config.ini (must point at the dir containing "
+                "Configurations.INI) on the serving host"
+            )
+    scan_folder = ScanPaths.get_scan_folder_path(tag=tag, base_directory=base)
+    analysis_folder = ScanPaths.get_scan_analysis_folder_path(
+        tag=tag, base_directory=base
+    )
+    return tag, scan_folder, analysis_folder
+
+
+def _read_task_statuses(scan_folder: Path) -> dict[str, dict]:
+    """Parse ``analysis_status/*.yaml`` tolerantly; missing folder → empty."""
+    import yaml
+
+    status_dir = scan_folder / "analysis_status"
+    statuses: dict[str, dict] = {}
+    if not status_dir.is_dir():
+        return statuses
+    now = time.time()
+    for entry in sorted(status_dir.iterdir()):
+        if entry.suffix not in (".yaml", ".yml"):
+            continue
+        try:
+            document = yaml.safe_load(entry.read_text()) or {}
+        except Exception as exc:  # a torn write mid-heartbeat is not our error
+            statuses[entry.stem] = {"status": "unreadable", "detail": str(exc)}
+            continue
+        if not isinstance(document, dict):
+            statuses[entry.stem] = {"status": "unreadable", "detail": "not a mapping"}
+            continue
+        heartbeat = document.get("heartbeat")
+        statuses[entry.stem] = {
+            "status": document.get("status"),
+            "claimed_by": document.get("claimed_by"),
+            "heartbeat_age_s": (
+                round(now - float(heartbeat), 1) if heartbeat else None
+            ),
+            "display_files": document.get("display_files") or [],
+        }
+    return statuses
+
+
+def _get_scan_analysis_impl(scan_number: int, day: str | None) -> str:
+    """Task statuses + the analysis output tree for one scan."""
+    try:
+        _tag, scan_folder, analysis_folder = _resolve_folders(scan_number, day)
+    except ValueError as exc:
+        return errors.make_error("invalid_request", str(exc))
+    except RuntimeError as exc:
+        return errors.make_error("invalid_request", str(exc))
+    if not scan_folder.is_dir():
+        return errors.make_error(
+            "not_found", f"no scan folder at {scan_folder} (share mounted?)"
+        )
+    tasks = _read_task_statuses(scan_folder)
+    outputs: dict[str, dict] = {}
+    if analysis_folder.is_dir():
+        for entry in sorted(analysis_folder.iterdir()):
+            if entry.is_dir():
+                names = sorted(p.name for p in entry.iterdir() if p.is_file())
+                outputs[entry.name] = {
+                    "n_files": len(names),
+                    "files": names[:_MAX_FILES_PER_DIR],
+                }
+            elif entry.is_file():
+                outputs.setdefault("(top level)", {"n_files": 0, "files": []})
+                top = outputs["(top level)"]
+                top["n_files"] += 1
+                if len(top["files"]) < _MAX_FILES_PER_DIR:
+                    top["files"].append(entry.name)
+    return errors.make_ok(
+        scan_number=int(scan_number),
+        scan_folder=str(scan_folder),
+        analysis_folder=str(analysis_folder),
+        analysis_present=analysis_folder.is_dir(),
+        tasks=tasks,
+        outputs=outputs,
+    )
+
+
+@mcp.tool(name=tool_names.GET_SCAN_ANALYSIS)
+async def get_scan_analysis(scan_number: int, day: str | None = None) -> str:
+    """What the analysis pipeline produced for one scan.
+
+    Returns per-analyzer task statuses (queued/claimed/done/failed, with
+    ``display_files`` — the rendered summary figures) and the analysis
+    output tree (per-analyzer directories, file names capped). ``day`` as
+    YYYY-MM-DD, default today in the server host's local timezone.
+    Requires the data share mounted on the serving host.
+    """
+    return await _run_guarded(_get_scan_analysis_impl, scan_number, day)
+
+
+def _gather_figure_candidates(scan_folder: Path, analysis_folder: Path) -> list[Path]:
+    """Figure candidates: display_files first, then images in the tree."""
+    candidates: list[Path] = []
+    seen: set[Path] = set()
+
+    def _add(path: Path) -> None:
+        if path.suffix.lower() not in _IMAGE_SUFFIXES:
+            return
+        if not path.is_absolute():
+            path = analysis_folder / path
+        if path not in seen and path.is_file():
+            seen.add(path)
+            candidates.append(path)
+
+    for status in _read_task_statuses(scan_folder).values():
+        for name in status.get("display_files") or []:
+            _add(Path(name))
+    if analysis_folder.is_dir():
+        for path in sorted(analysis_folder.rglob("*")):
+            if len(candidates) >= _MAX_FIGURE_CANDIDATES:
+                break
+            if path.is_file():
+                _add(path)
+    return candidates[:_MAX_FIGURE_CANDIDATES]
+
+
+def _relative_label(path: Path, analysis_folder: Path) -> str:
+    """A candidate's agent-facing name (relative to the analysis folder)."""
+    try:
+        return str(path.relative_to(analysis_folder))
+    except ValueError:
+        return path.name
+
+
+def _load_downscaled_png(path: Path) -> bytes:
+    """The figure as PNG bytes, longest edge capped (context, not archive)."""
+    import io
+
+    from PIL import Image as PILImage
+
+    with PILImage.open(path) as image:
+        image.load()
+        if max(image.size) > _MAX_FIGURE_EDGE_PX:
+            image.thumbnail((_MAX_FIGURE_EDGE_PX, _MAX_FIGURE_EDGE_PX))
+        if image.mode not in ("RGB", "RGBA", "L"):
+            image = image.convert("RGB")
+        buffer = io.BytesIO()
+        image.save(buffer, format="PNG")
+        return buffer.getvalue()
+
+
+def _get_scan_figure_impl(scan_number: int, name: str | None, day: str | None):
+    """One figure as image content, or the candidate list to choose from."""
+    try:
+        _tag, scan_folder, analysis_folder = _resolve_folders(scan_number, day)
+    except ValueError as exc:
+        return errors.make_error("invalid_request", str(exc))
+    except RuntimeError as exc:
+        return errors.make_error("invalid_request", str(exc))
+    if not scan_folder.is_dir():
+        return errors.make_error(
+            "not_found", f"no scan folder at {scan_folder} (share mounted?)"
+        )
+    candidates = _gather_figure_candidates(scan_folder, analysis_folder)
+    if not candidates:
+        return errors.make_error(
+            "not_found",
+            f"no figures found for Scan{int(scan_number):03d} "
+            f"(analysis folder: {analysis_folder})",
+        )
+    labels = [_relative_label(path, analysis_folder) for path in candidates]
+    if name is None:
+        if len(candidates) == 1:
+            chosen = candidates[0]
+        else:
+            return errors.make_ok(
+                message="multiple figures — call again with name=<one of these>",
+                figures=labels,
+            )
+    else:
+        matches = [
+            path
+            for path, label in zip(candidates, labels)
+            if name.lower() in label.lower()
+        ]
+        if not matches:
+            return errors.make_error(
+                "not_found", f"no figure matching {name!r}; available: {labels}"
+            )
+        if len(matches) > 1:
+            return errors.make_ok(
+                message=f"{name!r} is ambiguous — pick one",
+                figures=[_relative_label(p, analysis_folder) for p in matches],
+            )
+        chosen = matches[0]
+    from fastmcp.utilities.types import Image
+
+    return Image(data=_load_downscaled_png(chosen), format="png")
+
+
+@mcp.tool(name=tool_names.GET_SCAN_FIGURE)
+async def get_scan_figure(
+    scan_number: int, name: str | None = None, day: str | None = None
+):
+    """Fetch one rendered analysis figure for a scan, as an image.
+
+    With no ``name`` and exactly one figure, returns it; otherwise
+    returns the candidate list to pick from (``name`` matches by
+    substring of the listed path). Images are downscaled to ≤1024 px on
+    the longest edge — ask for the analysis folder path via
+    get_scan_analysis when the full-resolution file is needed.
+    """
+    return await _run_guarded(_get_scan_figure_impl, scan_number, name, day)

--- a/GEECS-MCP/geecs_mcp/analysis/read_tools.py
+++ b/GEECS-MCP/geecs_mcp/analysis/read_tools.py
@@ -222,21 +222,24 @@ async def get_scan_analysis(scan_number: int, day: str | None = None) -> str:
     return await _run_guarded(_get_scan_analysis_impl, scan_number, day)
 
 
-def _gather_figure_candidates(
-    scan_folder: Path, analysis_folder: Path, share_root: Optional[Path]
-) -> list[Path]:
+def _gather_figure_candidates(scan_folder: Path, analysis_folder: Path) -> list[Path]:
     """Figure candidates: display_files first, then images in the tree.
 
-    Every candidate must resolve **inside the share root** — the
-    ``display_files`` entries come from YAML on a writable share, and an
-    absolute or ``../`` entry must not let the tool serve arbitrary
-    host-readable files (review finding 3, confused-deputy bounding;
-    legitimate entries are always absolute paths under the day's
-    ``analysis/`` tree).
+    Every candidate must resolve **inside this scan's analysis folder**
+    — the ``display_files`` entries come from YAML on a writable share,
+    and an absolute or ``../`` entry must not let the tool serve
+    anything else (review finding 3 bounded to the share root; the #675
+    codex review tightened it to the scan's own analysis folder, which
+    is where the writer actually puts every legitimate entry —
+    ScanAnalysis analyzers write to ``<date>/analysis/Scan<NNN>/...`` —
+    so a poisoned entry cannot reach even another scan's outputs).
     """
     candidates: list[Path] = []
     seen: set[Path] = set()
-    root = share_root.resolve() if share_root is not None else None
+    try:
+        root = analysis_folder.resolve()
+    except OSError:
+        return []
 
     def _add(path: Path) -> None:
         if path.suffix.lower() not in _IMAGE_SUFFIXES:
@@ -247,8 +250,10 @@ def _gather_figure_candidates(
             path = path.resolve()
         except OSError:
             return
-        if root is not None and not path.is_relative_to(root):
-            logger.warning("figure candidate outside the share root: %s", path)
+        if not path.is_relative_to(root):
+            logger.warning(
+                "figure candidate outside the scan's analysis folder: %s", path
+            )
             return
         if path not in seen and path.is_file():
             seen.add(path)
@@ -314,12 +319,7 @@ def _get_scan_figure_impl(scan_number: int, name: str | None, day: str | None):
         return errors.make_error(
             "not_found", f"no scan folder at {scan_folder} (share mounted?)"
         )
-    from geecs_data_utils import ScanPaths
-
-    share_root = _base_directory()
-    if share_root is None and ScanPaths.paths_config is not None:
-        share_root = ScanPaths.paths_config.base_path
-    candidates = _gather_figure_candidates(scan_folder, analysis_folder, share_root)
+    candidates = _gather_figure_candidates(scan_folder, analysis_folder)
     if not candidates:
         return errors.make_error(
             "not_found",

--- a/GEECS-MCP/geecs_mcp/analysis/read_tools.py
+++ b/GEECS-MCP/geecs_mcp/analysis/read_tools.py
@@ -27,7 +27,6 @@ figure fetch, which returns MCP image content).
 from __future__ import annotations
 
 import logging
-import time
 from datetime import date
 from pathlib import Path
 from typing import Any, Optional
@@ -86,11 +85,11 @@ def _resolve_folders(scan_number: int, day: str | None) -> tuple[Any, Path, Path
     )
     base = _base_directory()
     if base is None:
-        # ScanPaths.paths_config starts as None and nothing initializes it
-        # at import — consumers must call reload_paths_config() once
-        # (live-run finding: an unconfigured class attribute raised
-        # AttributeError instead of degrading).  reload swallows its own
-        # ConfigurationError and leaves None, so the honest refusal is ours.
+        # ScanPaths runs reload_paths_config() at module import, but it
+        # swallows ConfigurationError and leaves paths_config = None on an
+        # unconfigured host (live-run finding: the bare attribute then
+        # raised AttributeError downstream instead of degrading).  The
+        # retry here is belt; the honest refusal below is ours.
         if ScanPaths.paths_config is None:
             ScanPaths.reload_paths_config()
         if ScanPaths.paths_config is None:
@@ -106,35 +105,69 @@ def _resolve_folders(scan_number: int, day: str | None) -> tuple[Any, Path, Path
     return tag, scan_folder, analysis_folder
 
 
+def _heartbeat_age_s(value: Any, now: "Any") -> Optional[float]:
+    """Age of an ISO-8601 heartbeat, tolerant; ``None`` when unparseable.
+
+    The writer stamps ``datetime.now(timezone.utc).isoformat()`` — parse
+    per task_queue's own ``_parse_ts`` semantics (assume UTC when naive).
+    """
+    from datetime import datetime, timezone
+
+    if not isinstance(value, str) or not value:
+        return None
+    try:
+        stamp = datetime.fromisoformat(value)
+    except Exception:
+        return None
+    if stamp.tzinfo is None:
+        stamp = stamp.replace(tzinfo=timezone.utc)
+    return round((now - stamp).total_seconds(), 1)
+
+
 def _read_task_statuses(scan_folder: Path) -> dict[str, dict]:
-    """Parse ``analysis_status/*.yaml`` tolerantly; missing folder → empty."""
+    """Parse ``analysis_status/*.yaml`` tolerantly; missing folder → empty.
+
+    THE AUTHORITATIVE SHAPE IS ``TaskStatus.to_dict()`` in
+    ``ScanAnalysis/scan_analysis/task_queue.py`` — keys ``state``
+    (queued/claimed/done/failed/no_data), ``error``, ``claimed_by``,
+    ``claimed_at``, ``last_heartbeat`` (ISO-8601 string), and
+    ``display_files``.  (Review finding on the #675 PR: the package's
+    CLAUDE.md prose was stale — read the writer, not the doc.)  Every
+    field coercion sits inside the per-file guard: one odd YAML on a
+    writable share degrades that one entry to ``unreadable``, never the
+    whole tool.
+    """
     import yaml
+    from datetime import datetime, timezone
 
     status_dir = scan_folder / "analysis_status"
     statuses: dict[str, dict] = {}
     if not status_dir.is_dir():
         return statuses
-    now = time.time()
+    now = datetime.now(timezone.utc)
     for entry in sorted(status_dir.iterdir()):
         if entry.suffix not in (".yaml", ".yml"):
             continue
         try:
             document = yaml.safe_load(entry.read_text()) or {}
+            if not isinstance(document, dict):
+                raise ValueError("not a mapping")
+            display_files = document.get("display_files") or []
+            if not isinstance(display_files, list):
+                display_files = []
+            statuses[entry.stem] = {
+                "state": document.get("state"),
+                "error": document.get("error"),
+                "claimed_by": document.get("claimed_by"),
+                "heartbeat_age_s": _heartbeat_age_s(
+                    document.get("last_heartbeat"), now
+                ),
+                "display_files": [
+                    name for name in display_files if isinstance(name, str)
+                ],
+            }
         except Exception as exc:  # a torn write mid-heartbeat is not our error
-            statuses[entry.stem] = {"status": "unreadable", "detail": str(exc)}
-            continue
-        if not isinstance(document, dict):
-            statuses[entry.stem] = {"status": "unreadable", "detail": "not a mapping"}
-            continue
-        heartbeat = document.get("heartbeat")
-        statuses[entry.stem] = {
-            "status": document.get("status"),
-            "claimed_by": document.get("claimed_by"),
-            "heartbeat_age_s": (
-                round(now - float(heartbeat), 1) if heartbeat else None
-            ),
-            "display_files": document.get("display_files") or [],
-        }
+            statuses[entry.stem] = {"state": "unreadable", "detail": str(exc)}
     return statuses
 
 
@@ -189,16 +222,34 @@ async def get_scan_analysis(scan_number: int, day: str | None = None) -> str:
     return await _run_guarded(_get_scan_analysis_impl, scan_number, day)
 
 
-def _gather_figure_candidates(scan_folder: Path, analysis_folder: Path) -> list[Path]:
-    """Figure candidates: display_files first, then images in the tree."""
+def _gather_figure_candidates(
+    scan_folder: Path, analysis_folder: Path, share_root: Optional[Path]
+) -> list[Path]:
+    """Figure candidates: display_files first, then images in the tree.
+
+    Every candidate must resolve **inside the share root** — the
+    ``display_files`` entries come from YAML on a writable share, and an
+    absolute or ``../`` entry must not let the tool serve arbitrary
+    host-readable files (review finding 3, confused-deputy bounding;
+    legitimate entries are always absolute paths under the day's
+    ``analysis/`` tree).
+    """
     candidates: list[Path] = []
     seen: set[Path] = set()
+    root = share_root.resolve() if share_root is not None else None
 
     def _add(path: Path) -> None:
         if path.suffix.lower() not in _IMAGE_SUFFIXES:
             return
         if not path.is_absolute():
             path = analysis_folder / path
+        try:
+            path = path.resolve()
+        except OSError:
+            return
+        if root is not None and not path.is_relative_to(root):
+            logger.warning("figure candidate outside the share root: %s", path)
+            return
         if path not in seen and path.is_file():
             seen.add(path)
             candidates.append(path)
@@ -223,6 +274,12 @@ def _relative_label(path: Path, analysis_folder: Path) -> str:
         return path.name
 
 
+#: Pixel cap for figure decode — matplotlib summaries are a few MP; far
+#: below Pillow's ~178 MP bomb ceiling so a giant share-resident image
+#: refuses instead of decoding hundreds of MB in the server process.
+_MAX_FIGURE_PIXELS = 64_000_000
+
+
 def _load_downscaled_png(path: Path) -> bytes:
     """The figure as PNG bytes, longest edge capped (context, not archive)."""
     import io
@@ -230,6 +287,11 @@ def _load_downscaled_png(path: Path) -> bytes:
     from PIL import Image as PILImage
 
     with PILImage.open(path) as image:
+        if image.width * image.height > _MAX_FIGURE_PIXELS:
+            raise ValueError(
+                f"figure {path.name} is {image.width}x{image.height} — "
+                f"over the {_MAX_FIGURE_PIXELS / 1e6:.0f} MP decode cap"
+            )
         image.load()
         if max(image.size) > _MAX_FIGURE_EDGE_PX:
             image.thumbnail((_MAX_FIGURE_EDGE_PX, _MAX_FIGURE_EDGE_PX))
@@ -252,7 +314,12 @@ def _get_scan_figure_impl(scan_number: int, name: str | None, day: str | None):
         return errors.make_error(
             "not_found", f"no scan folder at {scan_folder} (share mounted?)"
         )
-    candidates = _gather_figure_candidates(scan_folder, analysis_folder)
+    from geecs_data_utils import ScanPaths
+
+    share_root = _base_directory()
+    if share_root is None and ScanPaths.paths_config is not None:
+        share_root = ScanPaths.paths_config.base_path
+    candidates = _gather_figure_candidates(scan_folder, analysis_folder, share_root)
     if not candidates:
         return errors.make_error(
             "not_found",

--- a/GEECS-MCP/geecs_mcp/server.py
+++ b/GEECS-MCP/geecs_mcp/server.py
@@ -32,14 +32,19 @@ mcp = FastMCP(
         "submit_scan (one scan in flight, capped, preflight warnings need "
         "explicit acknowledgement), stop_scan (graceful; another client's "
         "scan needs force=true and an operator's say-so), clear_queue "
-        "(the only remover), scan_progress. Names must come from "
-        "list_scan_configs — never invent catalog names."
+        "(the only remover), scan_progress. Analysis domain: "
+        "get_scan_analysis (task statuses + output tree) and "
+        "get_scan_figure (a rendered summary figure as an image). Names "
+        "must come from list_scan_configs — never invent catalog names."
     ),
 )
 
 
 def create_server() -> FastMCP:
     """Register every tool module and return the server."""
+    from geecs_mcp.analysis import (  # noqa: F401 — self-registers
+        read_tools as analysis_read_tools,
+    )
     from geecs_mcp.scans import (  # noqa: F401 — self-register
         control_tools,
         read_tools,

--- a/GEECS-MCP/geecs_mcp/tool_names.py
+++ b/GEECS-MCP/geecs_mcp/tool_names.py
@@ -17,6 +17,8 @@ GET_SCAN_RESULT = "get_scan_result"
 LIST_SCAN_CONFIGS = "list_scan_configs"
 VALIDATE_SCAN_REQUEST = "validate_scan_request"
 SCAN_PROGRESS = "scan_progress"
+GET_SCAN_ANALYSIS = "get_scan_analysis"
+GET_SCAN_FIGURE = "get_scan_figure"
 SUBMIT_SCAN = "submit_scan"
 STOP_SCAN = "stop_scan"
 CLEAR_QUEUE = "clear_queue"
@@ -29,6 +31,8 @@ READ_TOOLS = (
     LIST_SCAN_CONFIGS,
     VALIDATE_SCAN_REQUEST,
     SCAN_PROGRESS,
+    GET_SCAN_ANALYSIS,
+    GET_SCAN_FIGURE,
 )
 
 #: Queueing tools (Q) — `ask` interactively; listed in `write_tools`

--- a/GEECS-MCP/poetry.lock
+++ b/GEECS-MCP/poetry.lock
@@ -5879,4 +5879,4 @@ cffi = ["cffi (>=1.17,<2.0) ; platform_python_implementation != \"PyPy\" and pyt
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<3.12"
-content-hash = "6c34e52c4ce8204e031f97ff875393034c1e8e95f3835f420e57db6ba0806148"
+content-hash = "d2a266b3bfbc35773ec6713a45853a09c0f3154b6967da6617d2563fe778480e"

--- a/GEECS-MCP/poetry.lock
+++ b/GEECS-MCP/poetry.lock
@@ -1465,9 +1465,9 @@ geecs-schemas = {path = "../GEECS-Schemas", develop = true}
 ophyd-async = ">=0.19.3,<1.0"
 
 [package.extras]
-analysis = ["imageanalysis @ file:///Users/samuelbarber/Desktop/Code/Github_repos/GEECS-Plugins/.claude/worktrees/angry-lederberg-436e6d/ImageAnalysis"]
+analysis = ["imageanalysis @ file:///Users/samuelbarber/Desktop/Code/Github_repos/GEECS-Plugins/.claude/worktrees/sad-dewdney-870421/ImageAnalysis"]
 ca = ["aioca (>=1.7)"]
-optimize = ["gest-api (>=0.1)", "imageanalysis @ file:///Users/samuelbarber/Desktop/Code/Github_repos/GEECS-Plugins/.claude/worktrees/angry-lederberg-436e6d/ImageAnalysis", "scananalysis @ file:///Users/samuelbarber/Desktop/Code/Github_repos/GEECS-Plugins/.claude/worktrees/angry-lederberg-436e6d/ScanAnalysis", "xopt (>=3.1,<4.0)"]
+optimize = ["gest-api (>=0.1)", "imageanalysis @ file:///Users/samuelbarber/Desktop/Code/Github_repos/GEECS-Plugins/.claude/worktrees/sad-dewdney-870421/ImageAnalysis", "scananalysis @ file:///Users/samuelbarber/Desktop/Code/Github_repos/GEECS-Plugins/.claude/worktrees/sad-dewdney-870421/ScanAnalysis", "xopt (>=3.1,<4.0)"]
 qs-client = ["bluesky-queueserver-api (>=0.0.13,<0.0.14)"]
 qserver = ["bluesky-queueserver (>=0.0.25,<0.0.26)"]
 tiled = ["tiled[client] (>=0.2)"]
@@ -5879,4 +5879,4 @@ cffi = ["cffi (>=1.17,<2.0) ; platform_python_implementation != \"PyPy\" and pyt
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<3.12"
-content-hash = "94b605ff13cfa3e88adb1fc6bbb9ef67457e8b6b74f12c472c9a50b77bfc59bd"
+content-hash = "6c34e52c4ce8204e031f97ff875393034c1e8e95f3835f420e57db6ba0806148"

--- a/GEECS-MCP/pyproject.toml
+++ b/GEECS-MCP/pyproject.toml
@@ -21,6 +21,10 @@ anyio = ">=4.0"
 # Figure downscaling (analysis domain) — imported directly, declared.
 pillow = ">=10.0"
 
+# analysis_status YAML parsing — imported directly, declared (the anyio
+# lesson, applied to BOTH new direct imports this time).
+pyyaml = ">=6.0"
+
 # The queue client + pre-submit preflight (geecs_bluesky.qs_client) and the
 # config resolver/listings.  qs-client pulls bluesky-queueserver-api; ca
 # pulls aioca for the preflight's CONNECTED/staleness reads.  The package

--- a/GEECS-MCP/pyproject.toml
+++ b/GEECS-MCP/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-mcp"
-version = "0.3.0"
+version = "0.4.0"
 description = "MCP server exposing GEECS scan submission, monitoring, and config discovery to AI agents (OSPREY)"
 authors = ["Sam Barber <sbarber@lbl.gov>"]
 readme = "README.md"
@@ -17,6 +17,9 @@ fastmcp = ">=2.0"
 # Imported directly (the to-thread tool dispatch) — declared, not ridden
 # transitively via fastmcp (review finding).
 anyio = ">=4.0"
+
+# Figure downscaling (analysis domain) — imported directly, declared.
+pillow = ">=10.0"
 
 # The queue client + pre-submit preflight (geecs_bluesky.qs_client) and the
 # config resolver/listings.  qs-client pulls bluesky-queueserver-api; ca

--- a/GEECS-MCP/tests/test_analysis_tools.py
+++ b/GEECS-MCP/tests/test_analysis_tools.py
@@ -54,17 +54,29 @@ def share(tmp_path, monkeypatch):
     image.save(out_dir / "summary.png")
     (out_dir / "results.csv").write_text("a,b\n1,2\n")
 
+    # The REAL TaskStatus.to_dict() shape (review finding: the first
+    # fixtures pinned a stale-doc schema the writer never produces —
+    # these keys/types are verified against ScanAnalysis task_queue.py).
     (status_dir / "topview_baseline.yaml").write_text(
         yaml.safe_dump(
             {
-                "status": "done",
+                "analyzer_id": "topview_baseline",
+                "priority": 0,
+                "state": "done",
+                "error": None,
                 "claimed_by": "runner-1",
-                "heartbeat": 1_000_000.0,
+                "claimed_at": "2026-08-22T10:00:00+00:00",
+                "last_heartbeat": "2026-08-22T10:05:00+00:00",
                 "display_files": [str(out_dir / "summary.png")],
             }
         )
     )
-    (status_dir / "magspec.yaml").write_text(yaml.safe_dump({"status": "queued"}))
+    (status_dir / "magspec.yaml").write_text(
+        yaml.safe_dump({"analyzer_id": "magspec", "state": "queued"})
+    )
+    (status_dir / "broken_analyzer.yaml").write_text(
+        yaml.safe_dump({"state": "failed", "error": "no s-file columns for UC_MagSpec"})
+    )
     monkeypatch.setattr(read_tools, "_base_directory", lambda: tmp_path)
     return tmp_path
 
@@ -81,14 +93,19 @@ def _mtimes(root: Path) -> set:
 def test_analysis_reports_tasks_and_outputs(share):
     result = _load(read_tools._get_scan_analysis_impl(7, DAY))
     assert result["ok"] and result["analysis_present"]
-    assert result["tasks"]["topview_baseline"]["status"] == "done"
-    assert result["tasks"]["topview_baseline"]["display_files"]
+    done = result["tasks"]["topview_baseline"]
+    assert done["state"] == "done"
+    assert done["display_files"]
+    assert done["heartbeat_age_s"] is not None  # ISO string parsed to an age
     assert result["tasks"]["magspec"] == {
-        "status": "queued",
+        "state": "queued",
+        "error": None,
         "claimed_by": None,
         "heartbeat_age_s": None,
         "display_files": [],
     }
+    # The single most useful failed-task field is surfaced (review finding).
+    assert "s-file columns" in result["tasks"]["broken_analyzer"]["error"]
     assert result["outputs"]["UC_TopView"]["n_files"] == 2
     assert "summary.png" in result["outputs"]["UC_TopView"]["files"]
 
@@ -109,7 +126,52 @@ def test_analysis_survives_torn_status_yaml(share):
     (scan_folder / "analysis_status" / "torn.yaml").write_text("{ not: [valid")
     result = _load(read_tools._get_scan_analysis_impl(7, DAY))
     assert result["ok"]
-    assert result["tasks"]["torn"]["status"] == "unreadable"
+    assert result["tasks"]["torn"]["state"] == "unreadable"
+
+
+def test_analysis_survives_odd_field_types(share):
+    # Review finding 2: the tolerant parse must be tolerant AFTER the
+    # yaml load too — odd field types degrade the ENTRY, never the tool.
+    scan_folder, _ = _tree_paths(share)
+    (scan_folder / "analysis_status" / "odd.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "state": "claimed",
+                "last_heartbeat": ["not", "a", "string"],
+                "display_files": "not-a-list.png",
+            }
+        )
+    )
+    result = _load(read_tools._get_scan_analysis_impl(7, DAY))
+    assert result["ok"]
+    odd = result["tasks"]["odd"]
+    assert odd["state"] == "claimed"
+    assert odd["heartbeat_age_s"] is None
+    assert odd["display_files"] == []  # a scalar is not a file list
+
+
+def test_figure_candidates_bounded_to_the_share(share, tmp_path_factory):
+    # Review finding 3: a display_files entry escaping the share must be
+    # dropped, not served (confused-deputy bounding).
+    outside = tmp_path_factory.mktemp("outside") / "secret.png"
+    from PIL import Image as PILImage
+
+    PILImage.new("RGB", (10, 10)).save(outside)
+    scan_folder, _ = _tree_paths(share)
+    (scan_folder / "analysis_status" / "escape.yaml").write_text(
+        yaml.safe_dump({"state": "done", "display_files": [str(outside)]})
+    )
+    result = _load(read_tools._get_scan_figure_impl(7, "secret", DAY))
+    assert not result["ok"] and result["error_kind"] == "not_found"
+
+
+def test_figure_decode_cap_refuses_giant_images(share, monkeypatch):
+    # The cap raises in the impl; at the tool layer the shared guard turns
+    # it into an internal_error envelope (pinned separately) — here we pin
+    # that the cap actually fires before any full decode.
+    monkeypatch.setattr(read_tools, "_MAX_FIGURE_PIXELS", 100)
+    with pytest.raises(ValueError, match="decode cap"):
+        read_tools._get_scan_figure_impl(7, "summary", DAY)
 
 
 def test_analysis_bad_day_is_invalid_request(share):
@@ -167,7 +229,7 @@ def test_no_figures_is_not_found(share):
     for path in (analysis_folder / "UC_TopView").iterdir():
         path.unlink()
     (scan_folder / "analysis_status" / "topview_baseline.yaml").write_text(
-        yaml.safe_dump({"status": "done", "display_files": []})
+        yaml.safe_dump({"state": "done", "display_files": []})
     )
     result = _load(read_tools._get_scan_figure_impl(7, None, DAY))
     assert not result["ok"] and result["error_kind"] == "not_found"

--- a/GEECS-MCP/tests/test_analysis_tools.py
+++ b/GEECS-MCP/tests/test_analysis_tools.py
@@ -150,19 +150,40 @@ def test_analysis_survives_odd_field_types(share):
     assert odd["display_files"] == []  # a scalar is not a file list
 
 
-def test_figure_candidates_bounded_to_the_share(share, tmp_path_factory):
-    # Review finding 3: a display_files entry escaping the share must be
-    # dropped, not served (confused-deputy bounding).
-    outside = tmp_path_factory.mktemp("outside") / "secret.png"
+def test_figure_candidates_bounded_to_the_scans_analysis_folder(
+    share, tmp_path_factory
+):
+    # Review finding 3 (+ the codex tightening): a display_files entry is
+    # served only from THIS scan's analysis folder — an entry escaping the
+    # share entirely, one pointing at ANOTHER scan's analysis outputs, and
+    # one pointing into the raw scans tree are all dropped, not served
+    # (confused-deputy bounding; the writer puts every legitimate entry
+    # under <date>/analysis/Scan<NNN>/).
     from PIL import Image as PILImage
 
+    outside = tmp_path_factory.mktemp("outside") / "secret.png"
     PILImage.new("RGB", (10, 10)).save(outside)
-    scan_folder, _ = _tree_paths(share)
+    scan_folder, analysis_folder = _tree_paths(share)
+    other_scan = analysis_folder.parent / "Scan099"
+    other_scan.mkdir()
+    PILImage.new("RGB", (10, 10)).save(other_scan / "other_secret.png")
+    in_scans_tree = scan_folder / "raw_secret.png"
+    PILImage.new("RGB", (10, 10)).save(in_scans_tree)
     (scan_folder / "analysis_status" / "escape.yaml").write_text(
-        yaml.safe_dump({"state": "done", "display_files": [str(outside)]})
+        yaml.safe_dump(
+            {
+                "state": "done",
+                "display_files": [
+                    str(outside),
+                    str(other_scan / "other_secret.png"),
+                    str(in_scans_tree),
+                ],
+            }
+        )
     )
-    result = _load(read_tools._get_scan_figure_impl(7, "secret", DAY))
-    assert not result["ok"] and result["error_kind"] == "not_found"
+    for probe in ("secret", "other_secret", "raw_secret"):
+        result = _load(read_tools._get_scan_figure_impl(7, probe, DAY))
+        assert not result["ok"] and result["error_kind"] == "not_found", probe
 
 
 def test_figure_decode_cap_refuses_giant_images(share, monkeypatch):

--- a/GEECS-MCP/tests/test_analysis_tools.py
+++ b/GEECS-MCP/tests/test_analysis_tools.py
@@ -1,0 +1,184 @@
+"""Hermetic tests for the analysis-domain read tools (#675).
+
+A tmp data-share tree stands in for the netapp (the `_base_directory`
+seam points the pure ScanPaths builders at it); figures are real PNGs
+generated with pillow.  The read-only discipline is pinned: the tools
+must never create anything on the share.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+
+from geecs_mcp import runtime
+from geecs_mcp.analysis import read_tools
+
+
+@pytest.fixture(autouse=True)
+def _fresh_runtime(monkeypatch):
+    runtime.clear_runtime_cache()
+    monkeypatch.setattr(runtime, "get_experiment", lambda: "TestExp")
+    yield
+    runtime.clear_runtime_cache()
+
+
+def _load(payload) -> dict:
+    return json.loads(payload)
+
+
+DAY = "2026-08-22"
+
+
+def _tree_paths(base: Path) -> tuple[Path, Path]:
+    date_dir = base / "TestExp" / "Y2026" / "08-Aug" / "26_0822"
+    return date_dir / "scans" / "Scan007", date_dir / "analysis" / "Scan007"
+
+
+@pytest.fixture
+def share(tmp_path, monkeypatch):
+    """A populated fake share: scan folder + statuses + analysis outputs."""
+    scan_folder, analysis_folder = _tree_paths(tmp_path)
+    status_dir = scan_folder / "analysis_status"
+    status_dir.mkdir(parents=True)
+    out_dir = analysis_folder / "UC_TopView"
+    out_dir.mkdir(parents=True)
+
+    from PIL import Image as PILImage
+
+    image = PILImage.new("RGB", (2000, 500), color=(10, 200, 30))
+    image.save(out_dir / "summary.png")
+    (out_dir / "results.csv").write_text("a,b\n1,2\n")
+
+    (status_dir / "topview_baseline.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "status": "done",
+                "claimed_by": "runner-1",
+                "heartbeat": 1_000_000.0,
+                "display_files": [str(out_dir / "summary.png")],
+            }
+        )
+    )
+    (status_dir / "magspec.yaml").write_text(yaml.safe_dump({"status": "queued"}))
+    monkeypatch.setattr(read_tools, "_base_directory", lambda: tmp_path)
+    return tmp_path
+
+
+def _mtimes(root: Path) -> set:
+    return {(p, p.stat().st_mtime_ns) for p in root.rglob("*")}
+
+
+# ---------------------------------------------------------------------------
+# get_scan_analysis
+# ---------------------------------------------------------------------------
+
+
+def test_analysis_reports_tasks_and_outputs(share):
+    result = _load(read_tools._get_scan_analysis_impl(7, DAY))
+    assert result["ok"] and result["analysis_present"]
+    assert result["tasks"]["topview_baseline"]["status"] == "done"
+    assert result["tasks"]["topview_baseline"]["display_files"]
+    assert result["tasks"]["magspec"] == {
+        "status": "queued",
+        "claimed_by": None,
+        "heartbeat_age_s": None,
+        "display_files": [],
+    }
+    assert result["outputs"]["UC_TopView"]["n_files"] == 2
+    assert "summary.png" in result["outputs"]["UC_TopView"]["files"]
+
+
+def test_analysis_missing_scan_is_not_found_and_creates_nothing(share):
+    before = _mtimes(share)
+    result = _load(read_tools._get_scan_analysis_impl(99, DAY))
+    assert not result["ok"] and result["error_kind"] == "not_found"
+    assert "Scan099" in result["message"] or "Scan" in result["message"]
+    # THE read-only pin: a miss must not plant anything on the share
+    # (the get_analysis_folder() instance accessor would have mkdir'd —
+    # this asserts we never touch it).
+    assert _mtimes(share) == before
+
+
+def test_analysis_survives_torn_status_yaml(share):
+    scan_folder, _ = _tree_paths(share)
+    (scan_folder / "analysis_status" / "torn.yaml").write_text("{ not: [valid")
+    result = _load(read_tools._get_scan_analysis_impl(7, DAY))
+    assert result["ok"]
+    assert result["tasks"]["torn"]["status"] == "unreadable"
+
+
+def test_analysis_bad_day_is_invalid_request(share):
+    result = _load(read_tools._get_scan_analysis_impl(7, "yesterday"))
+    assert not result["ok"] and result["error_kind"] == "invalid_request"
+
+
+def test_analysis_without_experiment_is_invalid_request(share, monkeypatch):
+    monkeypatch.setattr(runtime, "get_experiment", lambda: None)
+    result = _load(read_tools._get_scan_analysis_impl(7, DAY))
+    assert not result["ok"] and result["error_kind"] == "invalid_request"
+
+
+# ---------------------------------------------------------------------------
+# get_scan_figure
+# ---------------------------------------------------------------------------
+
+
+def test_single_figure_returns_downscaled_image(share):
+    from fastmcp.utilities.types import Image
+    from PIL import Image as PILImage
+
+    result = read_tools._get_scan_figure_impl(7, None, DAY)
+    assert isinstance(result, Image)
+    with PILImage.open(io.BytesIO(result.data)) as image:
+        assert max(image.size) <= read_tools._MAX_FIGURE_EDGE_PX
+        assert image.format == "PNG"
+
+
+def test_multiple_figures_list_candidates(share):
+    from PIL import Image as PILImage
+
+    _, analysis_folder = _tree_paths(share)
+    PILImage.new("RGB", (10, 10)).save(analysis_folder / "UC_TopView" / "extra.png")
+    result = _load(read_tools._get_scan_figure_impl(7, None, DAY))
+    assert result["ok"] and sorted(result["figures"]) == [
+        "UC_TopView/extra.png",
+        "UC_TopView/summary.png",
+    ]
+
+    picked = read_tools._get_scan_figure_impl(7, "extra", DAY)
+    from fastmcp.utilities.types import Image
+
+    assert isinstance(picked, Image)
+
+
+def test_figure_no_match_names_the_available(share):
+    result = _load(read_tools._get_scan_figure_impl(7, "nope", DAY))
+    assert not result["ok"] and result["error_kind"] == "not_found"
+    assert "summary.png" in result["message"]
+
+
+def test_no_figures_is_not_found(share):
+    scan_folder, analysis_folder = _tree_paths(share)
+    for path in (analysis_folder / "UC_TopView").iterdir():
+        path.unlink()
+    (scan_folder / "analysis_status" / "topview_baseline.yaml").write_text(
+        yaml.safe_dump({"status": "done", "display_files": []})
+    )
+    result = _load(read_tools._get_scan_figure_impl(7, None, DAY))
+    assert not result["ok"] and result["error_kind"] == "not_found"
+
+
+def test_analysis_tools_registered():
+    import anyio
+
+    from geecs_mcp import tool_names
+    from geecs_mcp.server import create_server
+
+    registered = {t.name for t in anyio.run(create_server().list_tools)}
+    assert tool_names.GET_SCAN_ANALYSIS in registered
+    assert tool_names.GET_SCAN_FIGURE in registered

--- a/ScanAnalysis/CLAUDE.md
+++ b/ScanAnalysis/CLAUDE.md
@@ -218,10 +218,19 @@ Enables multiple `LiveTaskRunner` processes to divide work without conflicts.
 
 ### `TaskStatus` fields
 
-- `status: str` — queued / claimed / done / failed
+**`TaskStatus.to_dict()` in `task_queue.py` is the authoritative shape**
+(this list was stale once and a downstream consumer shipped a dead
+parser from it — GEECS-MCP #675 review; read the writer when consuming):
+
+- `analyzer_id: str`, `priority: int`
+- `state: str` — queued / claimed / done / failed / no_data
+- `error: Optional[str]` — why a failed task failed
 - `claimed_by: Optional[str]` — runner identifier
-- `heartbeat: Optional[float]` — unix timestamp of last ping
-- `display_files: Optional[List[str]]` — populated when analyzer completes
+- `claimed_at`, `last_heartbeat`: Optional[str] — **ISO-8601 strings**
+  (UTC; `_parse_ts` assumes UTC when naive)
+- `display_files: Optional[List[str]]` — absolute paths under the day's
+  `analysis/` tree, populated when the analyzer completes.  Consumed by
+  GEECS-MCP's `get_scan_figure`.
 
 ## Live Watching (`live_task_runner.py`)
 


### PR DESCRIPTION
## What + why

Closes #675 — the top post-promotion ask, closing "scan → analyze → present". The first non-scans domain on the general server (`geecs_mcp/analysis/`), proving the domains-as-subpackages design:

- **`get_scan_analysis(scan_number, day?)`** — per-analyzer task statuses from `analysis_status/*.yaml` (parsed tolerantly — the `TaskStatus` schema is ScanAnalysis-owned; torn/partial YAMLs read as `unreadable`, never crash) plus the capped analysis output tree.
- **`get_scan_figure(scan_number, name?, day?)`** — a rendered summary figure as **actual MCP image content** (pillow downscale, ≤1024 px longest edge). Routing: `display_files` from completed tasks first, then tree images; no name + one candidate returns it; ambiguous returns the candidate list to pick from by substring.

**The load-bearing discipline: strictly read-only over the data share.** Only `ScanPaths`' *pure static* path builders are used — the instance `get_analysis_folder()` silently `os.makedirs` a missing folder and is explicitly banned here (documented in the module + CLAUDE.md), pinned by an mtime-snapshot test asserting a miss creates *nothing* on the share.

**Live-run finding fixed en route:** `ScanPaths.paths_config` starts `None` and nothing initializes it at import — an unconfigured host raised `AttributeError` instead of degrading. The impl now does a one-time `reload_paths_config()` and refuses honestly (naming the `[Paths] geecs_data` key) when it stays `None`.

Both tools are read-only/auto-allow; README + DEPLOYMENT.md allow-lists extended; `pillow` declared (direct import — the anyio lesson).

## Tests

**50 passed** (10 new: tree+status parsing incl. the queued/done shapes, torn-YAML tolerance, the read-only nothing-created pin, unconfigured refusals, downscale format/size, candidate listing + substring pick + no-match naming the available, registration). `check.sh GEECS-MCP` green.

## Hardware verification

- The **unconfigured-host refusal path verified live** on this machine (real `GeecsPathsConfig` resolution failing → the honest envelope).
- The happy path against the real netapp tree is **OWED at the qserver-box deployment** (the serving host mounts the share natively; the lab network is unreachable from the dev machine right now): run `get_scan_analysis`/`get_scan_figure` against a date with real ScanAnalysis outputs and confirm statuses/figures match the analysis folder.

## Review process

Fresh-context adversarial review next; then the codex gate before the maintainer merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)