### PR TITLE
GEECS-MCP 0.5.0: v2 verbs — actions, manual moves, pause/resume, stream progress (#676)

### DIFF
--- a/GEECS-MCP/CHANGELOG.md
+++ b/GEECS-MCP/CHANGELOG.md
@@ -50,8 +50,26 @@ landing separately from PR #681.)
   `deploy/DEPLOYMENT.md`), `PAUSE_SCAN` to `STOP_TOOLS`,
   `DESCRIBE_ACTION` to `READ_TOOLS`.
 - Requires geecs-bluesky ≥ 0.62.0 (`FAILED_MOVE_LOG_PREFIX` re-exported
-  lazily from `geecs_bluesky.qs_client` — the light-import contract
-  holds).
+  from `geecs_bluesky.qs_client`, defined in its import-light
+  `log_markers` module — the light-import contract holds down to name
+  resolution).
+
+### Fixed (in review, pre-merge)
+
+- The failed-move `paused_reason` is cleared when primary-stream
+  progress resumes — a second (manual) pause of the same run no longer
+  reports the first pause's text as the current why.
+- `resume_scan` fails CLOSED on an unreadable running item (a go verb
+  must not restart a possibly-foreign scan unforced); the halt family
+  stays fail-open by doctrine.  `forced` also marks force past unknown
+  ownership.
+- The client's ~120 s task-poll timeout on `move_scan_variable` /
+  `describe_action` now reports `task_timeout` (the taxonomy kind
+  existed but nothing emitted it).
+- Action/variable names are submitted stripped, matching how they are
+  validated; `move_scan_variable`'s description states the raw
+  `Device:Variable` pass-through honestly (a direct setpoint write, no
+  catalog semantics).
 
 ## [0.3.0] - 2026-08-22
 

--- a/GEECS-MCP/CHANGELOG.md
+++ b/GEECS-MCP/CHANGELOG.md
@@ -4,6 +4,55 @@ All notable changes to `geecs-mcp` are documented here.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.5.0] - 2026-08-23
+
+The v2 verbs (issue #676) — actions, manual moves, pause/resume, and the
+document-stream `scan_progress` upgrade.  (0.4.0 is the analysis domain,
+landing separately from PR #681.)
+
+### Added
+
+- **`run_action` (Q) + `describe_action` (R)**: run a named ActionPlan
+  on demand through the queue (`geecs_run_action_plan`; idle-only —
+  submitting mid-scan would silently queue the action to auto-run when
+  the scan finishes, so an active RE state refuses like `submit_scan`),
+  and preview its resolved steps via the worker's
+  `geecs_describe_action` dry-run (read-only by effect, but needs an
+  idle manager to answer).
+- **`move_scan_variable` (Q)**: one manual scan-variable move via the
+  worker's `geecs_move_variable` (`function_execute`) — plain, confirm,
+  and pseudo variables resolve exactly as a scan axis would; idle-only
+  (manager-enforced), blocking up to the client's ~120 s task budget;
+  non-finite / non-numeric values refused before reaching the worker.
+- **`pause_scan` (S) + `resume_scan` (Q)**: deferred pause / resume with
+  the same ownership etiquette as `stop_scan` (a foreign scan is refused
+  by name unless `force=true`; `forced` marks only genuinely foreign
+  overrides).  `pause_scan` joins the halt family (`STOP_TOOLS` — never
+  behind the headless `write_tools` gate: pausing makes the machine
+  strictly quieter); `resume_scan` restarts motion (and retries a failed
+  move), so it gates like a submission (`QUEUE_TOOLS`).
+- **`scan_progress` stream upgrade**: a process-wide `ProgressCache`
+  (`scans/progress_stream.py`) consumes the worker's document stream
+  (start-doc totals `num_points × shots_per_step` with the
+  `max_iterations` fallback for optimize runs; primary-stream `seq_num`
+  → shots done; stop-doc exit status) and the manager's console-output
+  stream (the engine's failed-move line → the paused scan's reason,
+  surfaced only while actually paused).  Strictly best-effort: the
+  result's `stream.available=false` (with the reason) degrades to the
+  v1 poll answer; the manager poll stays authoritative.  Threading per
+  the console's #653 rules — daemon threads, zmq sockets never touched
+  cross-thread, no `stop`.
+
+### Changed
+
+- `tool_names`: `RUN_ACTION`/`MOVE_SCAN_VARIABLE`/`RESUME_SCAN` appended
+  to `QUEUE_TOOLS` (headless `write_tools` additions — see
+  `deploy/DEPLOYMENT.md`), `PAUSE_SCAN` to `STOP_TOOLS`,
+  `DESCRIBE_ACTION` to `READ_TOOLS`.
+- Requires geecs-bluesky ≥ 0.62.0 (`FAILED_MOVE_LOG_PREFIX` re-exported
+  lazily from `geecs_bluesky.qs_client` — the light-import contract
+  holds).
+
 ## [0.3.0] - 2026-08-22
 
 ### Changed

--- a/GEECS-MCP/CLAUDE.md
+++ b/GEECS-MCP/CLAUDE.md
@@ -68,7 +68,13 @@ geecs_mcp/
                   #   tested surface
     control_tools.py # the v1 verbs: submit (cap + etiquette + the
                   #   acknowledge-warnings loop), stop (ownership),
-                  #   clear_queue, scan_progress
+                  #   clear_queue, scan_progress — plus the v2 verbs:
+                  #   run_action/describe_action, move_scan_variable,
+                  #   pause_scan/resume_scan (ownership like stop)
+    progress_stream.py # ProgressCache — the best-effort document-stream
+                  #   + console-text-stream picture behind scan_progress
+                  #   (daemon threads, zmq never touched cross-thread,
+                  #   no stop — the console's #653 rules)
 ```
 
 ## Conventions
@@ -118,8 +124,22 @@ geecs_mcp/
   `[mcp] client_identity` (deployment-owned, e.g.
   `osprey-htu-assistant`) and MUST match on the queue item and the
   `SubmissionRecord` — the ownership check compares against it.
-- **v2**: actions, moves, pause/resume, doc-stream `scan_progress`
-  (per-shot counts, paused reasons from the console-text stream).
+- **v2 (built — issue #676)**: `run_action` (Q; idle-only — an active
+  RE state refuses, because a mid-scan submission would silently queue
+  the action to auto-run when the scan finishes) with `describe_action`
+  (R; worker dry-run, needs an idle manager), `move_scan_variable` (Q;
+  the worker's `geecs_move_variable`, idle-only + blocking ≤ ~120 s,
+  non-finite values refused), `pause_scan` (S — the halt family, never
+  in `write_tools`) and `resume_scan` (Q — it restarts motion and
+  retries a failed move, so it gates like a submission), both with
+  stop's ownership etiquette (`force` only for genuinely foreign scans,
+  `forced` marks only those).  `scan_progress` gains the best-effort
+  `stream` picture from `scans/progress_stream.py`: start-doc totals
+  (`num_points × shots_per_step`, `max_iterations` fallback),
+  primary-stream `seq_num` → shots done, stop-doc exit status, and the
+  console-text stream's failed-move line as the paused reason
+  (surfaced only while actually paused — sticky otherwise).  The
+  manager poll stays authoritative; `stream.available=false` names why.
 
 ## Testing
 

--- a/GEECS-MCP/README.md
+++ b/GEECS-MCP/README.md
@@ -6,16 +6,22 @@ bluesky-queueserver RE Manager, the configs repo, and the Tiled archive.
 Future domains (health, DB metadata, log triage, analysis) register on
 the same server.
 
-**v0 + v1 (current).** Read-only: `scan_status`, `scan_history`,
+**v0 + v1 + v2 (current).** Read-only: `scan_status`, `scan_history`,
 `get_scan_result`, `list_scan_configs`, `validate_scan_request`,
-`scan_progress`. Control (put these under OSPREY `ask`; list them in `config:` `write_tools` for headless):
-`submit_scan` (one scan in flight, 1,000-shot cap, preflight warnings
-need explicit acknowledgement), `stop_scan` (graceful; `force` for
-another client's scan is approval territory), `clear_queue` (the one
-remover). Gating semantics — what osprey actually enforces for custom
-servers — are documented in `deploy/DEPLOYMENT.md` (verified: hook
-presets and the interactive kill switch do NOT apply; the native ask
-prompt is the interactive gate).
+`scan_progress` (with per-shot counts and paused reasons from the
+worker's streams, best-effort), `describe_action` (dry-run preview).
+Control (put these under OSPREY `ask`; list the `QUEUE_TOOLS` in
+`config:` `write_tools` for headless): `submit_scan` (one scan in
+flight, 1,000-shot cap, preflight warnings need explicit
+acknowledgement), `run_action` (idle-only queue item),
+`move_scan_variable` (idle-only, blocking), `resume_scan` (restarts
+motion — gated like a submission), `clear_queue` (the one remover); the
+halt family — `stop_scan` and `pause_scan` (graceful; `force` for
+another client's scan is approval territory) — is deliberately never
+behind the headless gate. Gating semantics — what osprey actually
+enforces for custom servers — are documented in `deploy/DEPLOYMENT.md`
+(verified: hook presets and the interactive kill switch do NOT apply;
+the native ask prompt is the interactive gate).
 
 ## Run
 

--- a/GEECS-MCP/deploy/DEPLOYMENT.md
+++ b/GEECS-MCP/deploy/DEPLOYMENT.md
@@ -29,22 +29,29 @@ the interactive writes kill switch does not cover custom-server tools
 either (the framework's deny augmentation walks its own
 `FRAMEWORK_SERVERS` only). The actual gates are therefore:
 
-- **Interactive**: the native `ask` permission prompt on the three
-  control verbs — a human sees every `submit_scan`/`stop_scan`/
-  `clear_queue` call with its arguments (this is also the backstop for
-  the acknowledge-warnings residual). `stop_scan` is NOT behind the
-  kill switch on either path: interactively because the kill switch
-  does not cover custom servers (upstream gap), headless by the
-  deliberate `write_tools` omission below — halts are never blocked.
+- **Interactive**: the native `ask` permission prompt on every control
+  verb — a human sees each `submit_scan`/`stop_scan`/`clear_queue`/
+  `run_action`/`move_scan_variable`/`pause_scan`/`resume_scan` call
+  with its arguments (this is also the backstop for the
+  acknowledge-warnings residual). The halt family (`stop_scan`,
+  `pause_scan`) is NOT behind the kill switch on either path:
+  interactively because the kill switch does not cover custom servers
+  (upstream gap), headless by the deliberate `write_tools` omission
+  below — halts are never blocked.
 - **Headless** (`osprey query`): the framework reads
   `hook_config.json`'s `write_tools` (populated from the profile's
-  `config:`) — list `submit_scan` and `clear_queue` there and
-  **deliberately NOT `stop_scan`**: exempt by omission, so a halt is
-  never blocked on any path (the deployed htu profile is the working
-  example: `write_tools: [mcp__geecs__submit_scan,
-  mcp__geecs__clear_queue]`).  This is the ONLY headless gate — a
-  profile without those two entries leaves an unattended agent's
-  submits ungated.
+  `config:`) — list every `tool_names.QUEUE_TOOLS` entry there
+  (`submit_scan`, `clear_queue`, and since 0.5.0 `run_action`,
+  `move_scan_variable`, `resume_scan` — resume restarts motion, so it
+  gates like a submission) and **deliberately NOT the halt family**
+  (`stop_scan`, `pause_scan`): exempt by omission, so a halt is never
+  blocked on any path. E.g. `write_tools: [mcp__geecs__submit_scan,
+  mcp__geecs__clear_queue, mcp__geecs__run_action,
+  mcp__geecs__move_scan_variable, mcp__geecs__resume_scan]` (the
+  deployed htu profile predates 0.5.0 and lists the first two —
+  extend it when the v2 verbs deploy).  This is the ONLY headless
+  gate — a profile missing these entries leaves an unattended agent's
+  writes ungated.
 
 Two upstream osprey issues (to be filed from the osprey side): the
 silent acceptance of unknown keys like `hooks:` on custom-server

--- a/GEECS-MCP/deploy/DEPLOYMENT.md
+++ b/GEECS-MCP/deploy/DEPLOYMENT.md
@@ -18,9 +18,15 @@ mcp_servers:
     transport: http
     permissions:
       allow: [scan_status, scan_history, get_scan_result,
-              list_scan_configs, validate_scan_request, scan_progress]
-      ask:   [submit_scan, stop_scan, clear_queue]
+              list_scan_configs, validate_scan_request, scan_progress,
+              describe_action]
+      ask:   [submit_scan, stop_scan, clear_queue,
+              run_action, move_scan_variable, pause_scan, resume_scan]
 ```
+
+(The lists mirror `geecs_mcp/tool_names.py` — `READ_TOOLS` under
+`allow`, `QUEUE_TOOLS` + `STOP_TOOLS` under `ask`; update both together
+when a verb lands.)
 
 **Hook/kill-switch semantics (VERIFIED against osprey, 2026-08-22)**:
 a `hooks:` key on a profile-level custom-server block is **silently

--- a/GEECS-MCP/geecs_mcp/scans/control_tools.py
+++ b/GEECS-MCP/geecs_mcp/scans/control_tools.py
@@ -1,4 +1,4 @@
-"""The v1 control tools: submit, stop, clear-queue, and poll progress.
+"""The control tools: submit, stop, clear-queue, progress, and the v2 verbs.
 
 Same conventions as :mod:`.read_tools` (sync ``_*_impl`` = the tested
 surface, async wrappers via the guard, JSON envelopes, engine text
@@ -20,6 +20,14 @@ planning doc §2):
 - ``clear_queue`` is the one verb that removes items — explicit,
   approval-gated recovery from the failed-item-at-front state; nothing
   clears implicitly.
+
+The v2 verbs (#676) extend the same doctrine: ``run_action`` /
+``move_scan_variable`` are idle-only writes gated like submission
+(``describe_action`` is their read-only preview), ``pause_scan`` joins
+the halt family (never behind the headless gate — see
+``tool_names.STOP_TOOLS``), ``resume_scan`` restarts motion so it gates
+like a submission, and ``scan_progress`` grows the best-effort
+document-stream picture (:mod:`.progress_stream`).
 """
 
 from __future__ import annotations
@@ -299,12 +307,252 @@ async def clear_queue() -> str:
 
 
 # ---------------------------------------------------------------------------
-# scan_progress (poll-shaped, read-only)
+# run_action / describe_action
 # ---------------------------------------------------------------------------
 
 
+def _run_action_impl(name: str) -> str:
+    """Queue the named ActionPlan (idle-only, same etiquette as submit)."""
+    if not name or not name.strip():
+        return errors.make_error("invalid_request", "pass the action plan's name")
+    client = runtime.get_queue_client()
+    status = client.status()
+    if not status.connected:
+        return errors.make_error("manager_unreachable", status.detail)
+    # Actions ride the queue: submitting while a scan runs would silently
+    # queue the action to auto-run the moment the scan finishes (the queue
+    # is already started) — refuse instead, exactly like submit_scan.
+    if status.re_state not in (None, "idle"):
+        return errors.make_error(
+            "policy_refusal",
+            f"a scan is active (RE state: {status.re_state}) — actions are "
+            "idle-only; wait for it or stop it first",
+        )
+    result = client.submit_action(name)
+    if not result.ok:
+        if result.pending_items:
+            return errors.make_error(
+                "policy_refusal",
+                result.message,
+                pending_items=[
+                    {
+                        "item_uid": item.get("item_uid"),
+                        "plan": item.get("name"),
+                        "user": item.get("user"),
+                    }
+                    for item in result.pending_items
+                ],
+            )
+        return errors.make_error(
+            "worker_refused", result.message or "action submission refused"
+        )
+    return errors.make_ok(
+        item_uid=result.item_uid,
+        message=result.message,
+        submitted_as=runtime.client_identity(),
+    )
+
+
+@mcp.tool(name=tool_names.RUN_ACTION)
+async def run_action(name: str) -> str:
+    """Run a named action plan on demand (idle-only).
+
+    Actions are the experiment's configured rituals (insert a screen,
+    block the laser, …) — list them with list_scan_configs and preview
+    the exact steps with describe_action first. Refuses while a scan is
+    active or anything is queued. Returns the queue item_uid; observe
+    completion with scan_progress / scan_history.
+    """
+    return await _run_guarded(_run_action_impl, name)
+
+
+def _describe_action_impl(name: str) -> str:
+    """Dry-run the named action against the worker's configs (idle-only)."""
+    if not name or not name.strip():
+        return errors.make_error("invalid_request", "pass the action plan's name")
+    client = runtime.get_queue_client()
+    status = client.status()
+    if not status.connected:
+        return errors.make_error("manager_unreachable", status.detail)
+    try:
+        steps = client.describe_action(name)
+    except Exception as exc:
+        return errors.make_error("worker_refused", str(exc))
+    steps = list(steps or [])
+    return errors.make_ok(action=name, step_count=len(steps), steps=steps)
+
+
+@mcp.tool(name=tool_names.DESCRIBE_ACTION)
+async def describe_action(name: str) -> str:
+    """Preview a named action plan's resolved steps without running it.
+
+    A worker-side dry-run against the live configs — the flattened
+    device writes/waits the action would perform, in order. Read-only,
+    but needs an idle manager to answer (refused mid-scan).
+    """
+    return await _run_guarded(_describe_action_impl, name)
+
+
+# ---------------------------------------------------------------------------
+# move_scan_variable
+# ---------------------------------------------------------------------------
+
+
+def _move_scan_variable_impl(name: str, value: float) -> str:
+    """One manual scan-variable move on the worker (idle-only, blocking)."""
+    import math
+
+    if not name or not name.strip():
+        return errors.make_error("invalid_request", "pass the scan variable's name")
+    try:
+        target = float(value)
+    except (TypeError, ValueError):
+        return errors.make_error("invalid_request", f"value {value!r} is not a number")
+    if not math.isfinite(target):
+        return errors.make_error("invalid_request", f"value {value!r} is not finite")
+    client = runtime.get_queue_client()
+    status = client.status()
+    if not status.connected:
+        return errors.make_error("manager_unreachable", status.detail)
+    try:
+        result = client.move_variable(name, target)
+    except Exception as exc:
+        return errors.make_error("worker_refused", str(exc))
+    return errors.make_ok(variable=name, requested=target, result=result)
+
+
+@mcp.tool(name=tool_names.MOVE_SCAN_VARIABLE)
+async def move_scan_variable(name: str, value: float) -> str:
+    """Move one scan variable to a value, outside any scan.
+
+    ``name`` is a scan-variable name from list_scan_configs (plain,
+    confirm, or pseudo — the worker resolves it exactly as a scan axis
+    would, limits and confirmation included). Idle-only (the manager
+    refuses while a scan runs) and BLOCKING: the call returns when the
+    move completes or fails, up to ~120 s. The result carries the
+    worker's move report verbatim.
+    """
+    return await _run_guarded(_move_scan_variable_impl, name, value)
+
+
+# ---------------------------------------------------------------------------
+# pause_scan / resume_scan
+# ---------------------------------------------------------------------------
+
+
+def _running_scan_owner(client) -> str | None:
+    """The running item's submitted-as identity, fail-open on read failure."""
+    try:
+        running = client.running_item()
+    except Exception:
+        logger.debug("running-item read failed before pause/resume", exc_info=True)
+        return None
+    return (running or {}).get("user") or None
+
+
+def _pause_scan_impl(force: bool) -> str:
+    """Ownership-gated deferred pause (the halt family, like stop)."""
+    client = runtime.get_queue_client()
+    status = client.status()
+    if not status.connected:
+        return errors.make_error("manager_unreachable", status.detail)
+    if status.re_state != "running":
+        return errors.make_error(
+            "invalid_request", f"nothing to pause (RE state: {status.re_state})"
+        )
+    owner = _running_scan_owner(client)
+    foreign = bool(owner and owner != runtime.client_identity())
+    if foreign and not force:
+        return errors.make_error(
+            "policy_refusal",
+            f"the running scan was submitted by {owner!r} — pass "
+            "force=true only if the operator explicitly asks for the pause",
+        )
+    ok, message = client.request_pause()
+    if not ok:
+        return errors.make_error("worker_refused", message)
+    return errors.make_ok(message=message, forced=bool(force and foreign))
+
+
+@mcp.tool(name=tool_names.PAUSE_SCAN)
+async def pause_scan(force: bool = False) -> str:
+    """Pause the running scan at the next checkpoint (deferred pause).
+
+    The in-flight shot and any in-flight move always finish first (1–2
+    shots of latency — the architectural floor). Nothing is lost: resume
+    continues exactly where the scan paused; stop ends it gracefully with
+    partial data. Refuses a scan submitted by another client (named in
+    the refusal) unless ``force=true`` — pass force only when the
+    operator explicitly asks.
+    """
+    return await _run_guarded(_pause_scan_impl, force)
+
+
+def _resume_scan_impl(force: bool) -> str:
+    """Ownership-gated resume from the paused state."""
+    client = runtime.get_queue_client()
+    status = client.status()
+    if not status.connected:
+        return errors.make_error("manager_unreachable", status.detail)
+    if status.re_state != "paused":
+        return errors.make_error(
+            "invalid_request", f"nothing to resume (RE state: {status.re_state})"
+        )
+    owner = _running_scan_owner(client)
+    foreign = bool(owner and owner != runtime.client_identity())
+    if foreign and not force:
+        return errors.make_error(
+            "policy_refusal",
+            f"the paused scan was submitted by {owner!r} — pass "
+            "force=true only if the operator explicitly asks for the resume",
+        )
+    ok, message = client.request_resume()
+    if not ok:
+        return errors.make_error("worker_refused", message)
+    return errors.make_ok(message=message, forced=bool(force and foreign))
+
+
+@mcp.tool(name=tool_names.RESUME_SCAN)
+async def resume_scan(force: bool = False) -> str:
+    """Resume a paused scan (nothing replays; a failed move is retried).
+
+    Check scan_progress first — a scan paused on a failed axis move
+    reports the reason, and resuming retries that exact move. This
+    restarts motion and acquisition, so it is gated like a submission.
+    Refuses a scan submitted by another client unless ``force=true`` —
+    pass force only when the operator explicitly asks.
+    """
+    return await _run_guarded(_resume_scan_impl, force)
+
+
+# ---------------------------------------------------------------------------
+# scan_progress (read-only: manager poll + best-effort document stream)
+# ---------------------------------------------------------------------------
+
+
+def _stream_snapshot(client, re_state: str | None) -> dict:
+    """The document-stream picture, started lazily from the client's addrs.
+
+    Best-effort BY DESIGN: ``available=false`` (with the reason) when the
+    stream cannot be consumed, and the poll fields stand alone.  The
+    sticky ``paused_reason`` (the console-text stream's failed-move line)
+    is only surfaced while the RE is actually paused — after a resume the
+    stale reason would read as current.
+    """
+    from geecs_mcp.scans import progress_stream
+
+    cache = progress_stream.get_progress_cache()
+    cache.ensure_started(
+        getattr(client, "doc_addr", None), getattr(client, "info_addr", None)
+    )
+    snapshot = cache.snapshot()
+    if re_state != "paused":
+        snapshot.pop("paused_reason", None)
+    return snapshot
+
+
 def _scan_progress_impl() -> str:
-    """Coarse poll: RE state, the running item, and the last outcome."""
+    """Manager poll (authoritative) + the per-shot stream picture (best-effort)."""
     client = runtime.get_queue_client()
     status = client.status()
     if not status.connected:
@@ -334,21 +582,30 @@ def _scan_progress_impl() -> str:
             }
     except Exception:
         logger.debug("history read failed in progress poll", exc_info=True)
+    try:
+        stream = _stream_snapshot(client, status.re_state)
+    except Exception:  # the poll answer must never die on the stream extra
+        logger.debug("stream snapshot failed in progress poll", exc_info=True)
+        stream = {"available": False, "detail": "stream snapshot failed"}
     return errors.make_ok(
         state=status.re_state or "idle",
         running_item=running,
         items_in_queue=status.items_in_queue,
         last_completed=last,
+        stream=stream,
     )
 
 
 @mcp.tool(name=tool_names.SCAN_PROGRESS)
 async def scan_progress() -> str:
-    """Poll-shaped progress for the current scan.
+    """Progress for the current scan: manager state + per-shot counts.
 
-    RE state (idle/running/paused/…), the running item (with its
-    submitting client), queue depth, and the last completed item's
-    outcome. Coarse by design in v1 — per-shot counts arrive with the
-    document-stream upgrade (v2).
+    The manager poll is authoritative: RE state (idle/running/paused/…),
+    the running item (with its submitting client), queue depth, and the
+    last completed item's outcome. ``stream`` adds the document-stream
+    picture when available — scan number, shots done / planned total,
+    and (while paused) the failed-move reason; ``stream.available=false``
+    means only the poll fields apply (one manager runs one scan at a
+    time, so the stream's latest run IS the running scan).
     """
     return await _run_guarded(_scan_progress_impl)

--- a/GEECS-MCP/geecs_mcp/scans/control_tools.py
+++ b/GEECS-MCP/geecs_mcp/scans/control_tools.py
@@ -313,7 +313,8 @@ async def clear_queue() -> str:
 
 def _run_action_impl(name: str) -> str:
     """Queue the named ActionPlan (idle-only, same etiquette as submit)."""
-    if not name or not name.strip():
+    name = (name or "").strip()  # validated stripped ⇒ submitted stripped
+    if not name:
         return errors.make_error("invalid_request", "pass the action plan's name")
     client = runtime.get_queue_client()
     status = client.status()
@@ -368,7 +369,8 @@ async def run_action(name: str) -> str:
 
 def _describe_action_impl(name: str) -> str:
     """Dry-run the named action against the worker's configs (idle-only)."""
-    if not name or not name.strip():
+    name = (name or "").strip()
+    if not name:
         return errors.make_error("invalid_request", "pass the action plan's name")
     client = runtime.get_queue_client()
     status = client.status()
@@ -377,7 +379,7 @@ def _describe_action_impl(name: str) -> str:
     try:
         steps = client.describe_action(name)
     except Exception as exc:
-        return errors.make_error("worker_refused", str(exc))
+        return errors.make_error(_task_error_kind(exc), str(exc))
     steps = list(steps or [])
     return errors.make_ok(action=name, step_count=len(steps), steps=steps)
 
@@ -398,11 +400,22 @@ async def describe_action(name: str) -> str:
 # ---------------------------------------------------------------------------
 
 
+def _task_error_kind(exc: Exception) -> str:
+    """``task_timeout`` for the client's task-poll timeout, else worker_refused.
+
+    The string match is the only seam: ``_wait_for_task`` raises a plain
+    ``RuntimeError("worker task did not finish within N s")`` on timeout
+    (same type as every other task failure).
+    """
+    return "task_timeout" if "did not finish within" in str(exc) else "worker_refused"
+
+
 def _move_scan_variable_impl(name: str, value: float) -> str:
     """One manual scan-variable move on the worker (idle-only, blocking)."""
     import math
 
-    if not name or not name.strip():
+    name = (name or "").strip()
+    if not name:
         return errors.make_error("invalid_request", "pass the scan variable's name")
     try:
         target = float(value)
@@ -417,7 +430,7 @@ def _move_scan_variable_impl(name: str, value: float) -> str:
     try:
         result = client.move_variable(name, target)
     except Exception as exc:
-        return errors.make_error("worker_refused", str(exc))
+        return errors.make_error(_task_error_kind(exc), str(exc))
     return errors.make_ok(variable=name, requested=target, result=result)
 
 
@@ -425,12 +438,15 @@ def _move_scan_variable_impl(name: str, value: float) -> str:
 async def move_scan_variable(name: str, value: float) -> str:
     """Move one scan variable to a value, outside any scan.
 
-    ``name`` is a scan-variable name from list_scan_configs (plain,
+    Prefer a catalog scan-variable name from list_scan_configs (plain,
     confirm, or pseudo — the worker resolves it exactly as a scan axis
-    would, limits and confirmation included). Idle-only (the manager
-    refuses while a scan runs) and BLOCKING: the call returns when the
-    move completes or fails, up to ~120 s. The result carries the
-    worker's move report verbatim.
+    would, confirmation included). A raw ``Device:Variable`` string is
+    ALSO accepted (the worker's manual-move surface): a direct setpoint
+    write with no catalog semantics — setpoint limits are whatever the
+    gateway enforces on that variable. Idle-only (the manager refuses
+    while a scan runs) and BLOCKING: the call returns when the move
+    completes or fails, up to ~120 s. The result carries the worker's
+    move report verbatim.
     """
     return await _run_guarded(_move_scan_variable_impl, name, value)
 
@@ -440,14 +456,21 @@ async def move_scan_variable(name: str, value: float) -> str:
 # ---------------------------------------------------------------------------
 
 
-def _running_scan_owner(client) -> str | None:
-    """The running item's submitted-as identity, fail-open on read failure."""
+def _running_scan_owner(client) -> tuple[str | None, bool]:
+    """The running item's submitted-as identity, as ``(owner, readable)``.
+
+    The two consumers treat an unreadable item OPPOSITELY by doctrine:
+    the halt family (pause, like stop) fails open — a flaky read must
+    never block making the machine quieter — while resume (a go verb)
+    fails closed, so a transient read failure cannot let this client
+    restart another client's scan unforced (review finding #683-2).
+    """
     try:
         running = client.running_item()
     except Exception:
         logger.debug("running-item read failed before pause/resume", exc_info=True)
-        return None
-    return (running or {}).get("user") or None
+        return None, False
+    return (running or {}).get("user") or None, True
 
 
 def _pause_scan_impl(force: bool) -> str:
@@ -460,7 +483,7 @@ def _pause_scan_impl(force: bool) -> str:
         return errors.make_error(
             "invalid_request", f"nothing to pause (RE state: {status.re_state})"
         )
-    owner = _running_scan_owner(client)
+    owner, _readable = _running_scan_owner(client)  # unreadable = fail open
     foreign = bool(owner and owner != runtime.client_identity())
     if foreign and not force:
         return errors.make_error(
@@ -498,7 +521,15 @@ def _resume_scan_impl(force: bool) -> str:
         return errors.make_error(
             "invalid_request", f"nothing to resume (RE state: {status.re_state})"
         )
-    owner = _running_scan_owner(client)
+    owner, readable = _running_scan_owner(client)
+    if not readable and not force:
+        # Fail CLOSED: resume restarts motion, so unknown ownership
+        # refuses (unlike the halt family's fail-open).
+        return errors.make_error(
+            "policy_refusal",
+            "the paused scan's owner could not be read — retry, or pass "
+            "force=true only if the operator explicitly asks for the resume",
+        )
     foreign = bool(owner and owner != runtime.client_identity())
     if foreign and not force:
         return errors.make_error(
@@ -509,7 +540,11 @@ def _resume_scan_impl(force: bool) -> str:
     ok, message = client.request_resume()
     if not ok:
         return errors.make_error("worker_refused", message)
-    return errors.make_ok(message=message, forced=bool(force and foreign))
+    # forced also covers force past UNKNOWN ownership — the audit marker
+    # means "an operator authorized resuming a scan not known to be ours".
+    return errors.make_ok(
+        message=message, forced=bool(force and (foreign or not readable))
+    )
 
 
 @mcp.tool(name=tool_names.RESUME_SCAN)

--- a/GEECS-MCP/geecs_mcp/scans/progress_stream.py
+++ b/GEECS-MCP/geecs_mcp/scans/progress_stream.py
@@ -15,7 +15,12 @@ cache fed by two daemon threads —
   scan's *why*.
 
 Best-effort BY DESIGN: setup failure marks the cache unavailable with a
-reason and ``scan_progress`` degrades to its poll answer.  The threading
+reason and ``scan_progress`` degrades to its poll answer.  The honesty
+boundary: ``available=true`` means the dispatcher is consuming, not that
+the address is *right* — zmq connects lazily, so a wrong/unreachable
+``doc_addr`` reads as an available-but-forever-empty picture (console
+parity; the manager poll stays the authoritative answer either way), and
+a one-time setup failure stays down until process restart.  The threading
 rules are the console's, inherited from the #653 review: threads are
 daemons, ``stop`` never exists — a zmq socket must never be touched from
 another thread (a cross-thread close can trip a libzmq assertion that
@@ -38,6 +43,7 @@ class ProgressCache:
     def __init__(self) -> None:
         self._lock = threading.Lock()
         self._started = False
+        self._doc_addr: Optional[str] = None
         self._available = False
         self._detail = "stream cache not started"
         self._state: dict[str, Any] = {}
@@ -57,11 +63,28 @@ class ProgressCache:
     # -- stream plumbing ----------------------------------------------------
 
     def ensure_started(self, doc_addr: Optional[str], info_addr: Optional[str]) -> None:
-        """Start both consumer threads once (idempotent, never raises)."""
+        """Start both consumer threads once (idempotent, never raises).
+
+        Once-only BY DESIGN: the first call's addresses latch for the
+        process lifetime (the #653 rule leaves no way to retire a zmq
+        consumer thread).  A later call with *different* addresses —
+        possible only after ``runtime.clear_runtime_cache()`` rebuilt the
+        queue client against an edited config — is ignored with one
+        warning; a config change needs a server restart, like runtime's
+        other singletons.
+        """
         with self._lock:
             if self._started:
+                if doc_addr and doc_addr != self._doc_addr:
+                    logger.warning(
+                        "progress stream already consuming %r — new address %r "
+                        "ignored (restart the server to re-point streams)",
+                        self._doc_addr,
+                        doc_addr,
+                    )
                 return
             self._started = True
+            self._doc_addr = doc_addr
             if not doc_addr:
                 self._detail = "no document-stream address configured"
                 return
@@ -161,6 +184,11 @@ class ProgressCache:
                 elif name == "event":
                     if str(doc.get("descriptor")) in self._primary_descriptors:
                         self._state["shots_done"] = int(doc.get("seq_num") or 0)
+                        # Progress proves the resume: without this, a scan
+                        # paused a second time (manually) would report the
+                        # FIRST pause's failed-move text as the current why
+                        # (review finding #683-1).
+                        self._state["paused_reason"] = None
                 elif name == "stop":
                     if doc.get("run_start") == self._state.get("run_uid"):
                         self._state["exit_status"] = doc.get("exit_status")

--- a/GEECS-MCP/geecs_mcp/scans/progress_stream.py
+++ b/GEECS-MCP/geecs_mcp/scans/progress_stream.py
@@ -1,0 +1,177 @@
+"""The best-effort progress cache: document + console-text stream consumers.
+
+The v2 ``scan_progress`` upgrade (#676): one lazily-started, process-wide
+cache fed by two daemon threads —
+
+- the worker's bluesky **document stream** (``RemoteDispatcher`` on the
+  proxy out-port): the start document seeds scan number and planned
+  totals (``num_points × shots_per_step``, falling back to
+  ``max_iterations`` for optimize runs — the console's live-verified
+  Scan013 lesson), primary-stream events advance ``shots_done``, the
+  stop document records the exit status;
+- the manager's **console-output text stream**: lines carrying the
+  engine's failed-move prefix (``FAILED_MOVE_LOG_PREFIX``, via the
+  qs_client re-export — never a ``plans/*`` import) become the paused
+  scan's *why*.
+
+Best-effort BY DESIGN: setup failure marks the cache unavailable with a
+reason and ``scan_progress`` degrades to its poll answer.  The threading
+rules are the console's, inherited from the #653 review: threads are
+daemons, ``stop`` never exists — a zmq socket must never be touched from
+another thread (a cross-thread close can trip a libzmq assertion that
+ABORTS the process), so the threads live for the process lifetime and
+emission is simply gated by the cache's own lock.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+from typing import Any, Optional
+
+logger = logging.getLogger("geecs_mcp.scans.progress_stream")
+
+
+class ProgressCache:
+    """Lock-protected latest-run picture built from the two streams."""
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._started = False
+        self._available = False
+        self._detail = "stream cache not started"
+        self._state: dict[str, Any] = {}
+        self._primary_descriptors: set[str] = set()
+
+    # -- consumption --------------------------------------------------------
+
+    def snapshot(self) -> dict[str, Any]:
+        """A copy of the cached picture (``available`` + fields or reason)."""
+        with self._lock:
+            return {
+                "available": self._available,
+                "detail": self._detail,
+                **dict(self._state),
+            }
+
+    # -- stream plumbing ----------------------------------------------------
+
+    def ensure_started(self, doc_addr: Optional[str], info_addr: Optional[str]) -> None:
+        """Start both consumer threads once (idempotent, never raises)."""
+        with self._lock:
+            if self._started:
+                return
+            self._started = True
+            if not doc_addr:
+                self._detail = "no document-stream address configured"
+                return
+        threading.Thread(
+            target=self._run_documents,
+            args=(doc_addr,),
+            name="geecs-mcp-doc-stream",
+            daemon=True,
+        ).start()
+        if info_addr:
+            threading.Thread(
+                target=self._run_console_text,
+                args=(info_addr,),
+                name="geecs-mcp-console-stream",
+                daemon=True,
+            ).start()
+
+    def _run_documents(self, doc_addr: str) -> None:
+        try:
+            from bluesky.callbacks.zmq import RemoteDispatcher
+
+            dispatcher = RemoteDispatcher(doc_addr)
+            dispatcher.subscribe(self._on_document)
+            with self._lock:
+                self._available = True
+                self._detail = ""
+            dispatcher.start()  # blocks for the thread's lifetime
+        except Exception as exc:
+            logger.warning("document stream unavailable: %s", exc)
+            with self._lock:
+                self._available = False
+                self._detail = f"document stream unavailable: {exc}"
+
+    def _run_console_text(self, info_addr: str) -> None:
+        try:
+            from bluesky_queueserver_api.console_monitor import (
+                ConsoleMonitor_ZMQ_Threads,
+            )
+
+            from geecs_bluesky.qs_client import FAILED_MOVE_LOG_PREFIX
+
+            monitor = ConsoleMonitor_ZMQ_Threads(
+                zmq_info_addr=info_addr,
+                zmq_encoding="json",
+                poll_timeout=0.5,
+                max_msgs=10_000,
+                max_lines=1_000,
+            )
+            monitor.enable()
+            while True:
+                try:
+                    msg = monitor.next_msg(timeout=5.0)
+                except Exception:  # timeout — nothing to read
+                    continue
+                # One message can carry several lines (the console's own
+                # parsing rule) — match per line so the reason never
+                # drags trailing unrelated output along.
+                for line in str(msg.get("msg", "")).splitlines():
+                    if FAILED_MOVE_LOG_PREFIX not in line:
+                        continue
+                    reason = line.split(FAILED_MOVE_LOG_PREFIX, 1)[1]
+                    reason = reason.lstrip(" :-").strip()
+                    with self._lock:
+                        self._state["paused_reason"] = reason or FAILED_MOVE_LOG_PREFIX
+        except Exception as exc:
+            logger.warning("console-text stream unavailable: %s", exc)
+
+    # -- document handling --------------------------------------------------
+
+    def _on_document(self, name: str, doc: dict) -> None:
+        try:
+            with self._lock:
+                if name == "start":
+                    shots_per_step = int(doc.get("shots_per_step") or 1)
+                    num_points = doc.get("num_points")
+                    max_iterations = doc.get("max_iterations")
+                    if num_points:
+                        total: Optional[int] = int(num_points) * shots_per_step
+                    elif max_iterations:
+                        # Optimize runs record max_iterations, not
+                        # num_points (the Scan013 live lesson).
+                        total = int(max_iterations) * shots_per_step
+                    else:
+                        total = None
+                    self._state = {
+                        "run_uid": doc.get("uid"),
+                        "scan_number": doc.get("scan_number"),
+                        "shots_total": total,
+                        "shots_done": 0,
+                        "exit_status": None,
+                        "paused_reason": None,
+                    }
+                    self._primary_descriptors = set()
+                elif name == "descriptor":
+                    if doc.get("name") == "primary":
+                        self._primary_descriptors.add(str(doc.get("uid")))
+                elif name == "event":
+                    if str(doc.get("descriptor")) in self._primary_descriptors:
+                        self._state["shots_done"] = int(doc.get("seq_num") or 0)
+                elif name == "stop":
+                    if doc.get("run_start") == self._state.get("run_uid"):
+                        self._state["exit_status"] = doc.get("exit_status")
+        except Exception:  # a malformed document must never kill the stream
+            logger.debug("progress document ignored", exc_info=True)
+
+
+#: The process-wide cache (the server is one process; tests build their own).
+_cache = ProgressCache()
+
+
+def get_progress_cache() -> ProgressCache:
+    """The process-wide cache instance (module attribute = the patch seam)."""
+    return _cache

--- a/GEECS-MCP/geecs_mcp/tool_names.py
+++ b/GEECS-MCP/geecs_mcp/tool_names.py
@@ -20,8 +20,15 @@ SCAN_PROGRESS = "scan_progress"
 SUBMIT_SCAN = "submit_scan"
 STOP_SCAN = "stop_scan"
 CLEAR_QUEUE = "clear_queue"
+RUN_ACTION = "run_action"
+DESCRIBE_ACTION = "describe_action"
+MOVE_SCAN_VARIABLE = "move_scan_variable"
+PAUSE_SCAN = "pause_scan"
+RESUME_SCAN = "resume_scan"
 
 #: Read-only tools (R) — safe to auto-allow in profile.yml.
+#: describe_action is R by effect (a worker-side dry-run that changes
+#: nothing), though it does require an idle manager to answer.
 READ_TOOLS = (
     SCAN_STATUS,
     SCAN_HISTORY,
@@ -29,20 +36,27 @@ READ_TOOLS = (
     LIST_SCAN_CONFIGS,
     VALIDATE_SCAN_REQUEST,
     SCAN_PROGRESS,
+    DESCRIBE_ACTION,
 )
 
 #: Queueing tools (Q) — `ask` interactively; listed in `write_tools`
 #: (hook_config.json, from the profile's `config:`) for the headless
 #: gate (hook presets do NOT attach to custom servers — see STOP_TOOLS
-#: below / DEPLOYMENT.md).
+#: below / DEPLOYMENT.md).  resume_scan is Q, not S: it *restarts*
+#: motion/acquisition (and retries the failed move), so it belongs
+#: behind the headless gate like any other go verb.
 QUEUE_TOOLS = (
     SUBMIT_SCAN,
     CLEAR_QUEUE,
+    RUN_ACTION,
+    MOVE_SCAN_VARIABLE,
+    RESUME_SCAN,
 )
 
 #: Stop direction (S) — `ask` only, and NEVER listed in `write_tools`:
 #: exempt by omission from the headless gate BY DESIGN, and outside the
 #: interactive kill switch because it does not cover custom servers
 #: (upstream gap) — so a halt is never blocked on any path.  VERIFIED
-#: osprey semantics 2026-08-22; see deploy/DEPLOYMENT.md.
-STOP_TOOLS = (STOP_SCAN,)
+#: osprey semantics 2026-08-22; see deploy/DEPLOYMENT.md.  pause_scan
+#: joins stop_scan here: a pause makes the machine strictly quieter.
+STOP_TOOLS = (STOP_SCAN, PAUSE_SCAN)

--- a/GEECS-MCP/pyproject.toml
+++ b/GEECS-MCP/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-mcp"
-version = "0.3.0"
+version = "0.5.0"
 description = "MCP server exposing GEECS scan submission, monitoring, and config discovery to AI agents (OSPREY)"
 authors = ["Sam Barber <sbarber@lbl.gov>"]
 readme = "README.md"

--- a/GEECS-MCP/tests/test_control_tools.py
+++ b/GEECS-MCP/tests/test_control_tools.py
@@ -49,6 +49,19 @@ class _FakeClient:
     submit_ok: bool = True
     stop_result: tuple = (True, "stop requested (from paused)")
     cleared: int = 0
+    # v2 seams
+    doc_addr: str | None = None
+    info_addr: str | None = None
+    actions_submitted: list = field(default_factory=list)
+    action_ok: bool = True
+    action_pending: list = field(default_factory=list)
+    describe_steps: list = field(default_factory=list)
+    describe_error: str | None = None
+    moves: list = field(default_factory=list)
+    move_error: str | None = None
+    move_result: dict = field(default_factory=lambda: {"variable": "jet_z"})
+    pause_result: tuple = (True, "pause requested")
+    resume_result: tuple = (True, "resumed")
 
     def status(self):
         return SimpleNamespace(
@@ -87,6 +100,40 @@ class _FakeClient:
     def clear_queue(self):
         self.cleared += 1
         return True, "queue cleared"
+
+    def submit_action(self, name):
+        self.actions_submitted.append(name)
+        if self.action_pending:
+            return SimpleNamespace(
+                ok=False,
+                message="queue not empty",
+                item_uid=None,
+                pending_items=list(self.action_pending),
+            )
+        if self.action_ok:
+            return SimpleNamespace(
+                ok=True, message="queued", item_uid="act-1", pending_items=[]
+            )
+        return SimpleNamespace(
+            ok=False, message="unknown action", item_uid=None, pending_items=[]
+        )
+
+    def describe_action(self, name):
+        if self.describe_error:
+            raise RuntimeError(self.describe_error)
+        return list(self.describe_steps)
+
+    def move_variable(self, name, value):
+        if self.move_error:
+            raise RuntimeError(self.move_error)
+        self.moves.append((name, value))
+        return dict(self.move_result)
+
+    def request_pause(self):
+        return self.pause_result
+
+    def request_resume(self):
+        return self.resume_result
 
 
 @pytest.fixture
@@ -354,7 +401,208 @@ def test_scan_progress_shapes(wired):
     assert result["state"] == "unknown" and "timeout" in result["detail"]
 
 
-def test_all_v1_tools_registered():
+# ---------------------------------------------------------------------------
+# run_action / describe_action (v2)
+# ---------------------------------------------------------------------------
+
+
+def test_run_action_happy_path(wired):
+    result = _load(control_tools._run_action_impl("Insert Screen"))
+    assert result["ok"] and result["item_uid"] == "act-1"
+    assert wired.actions_submitted == ["Insert Screen"]
+    assert result["submitted_as"] == runtime.client_identity()
+
+
+def test_run_action_refused_while_scan_active(wired):
+    # Submitting mid-scan would silently queue the action to auto-run the
+    # moment the scan finishes — the guard this pins.
+    wired.re_state = "running"
+    result = _load(control_tools._run_action_impl("Insert Screen"))
+    assert result["error_kind"] == "policy_refusal" and "idle-only" in result["message"]
+    assert wired.actions_submitted == []
+
+
+def test_run_action_pending_items_surfaced(wired):
+    wired.action_pending = [
+        {"item_uid": "old", "name": "geecs_scan_request_plan", "user": "console"}
+    ]
+    result = _load(control_tools._run_action_impl("Insert Screen"))
+    assert result["error_kind"] == "policy_refusal"
+    assert result["pending_items"][0]["item_uid"] == "old"
+
+
+def test_run_action_blank_name_refused(wired):
+    result = _load(control_tools._run_action_impl("  "))
+    assert result["error_kind"] == "invalid_request"
+
+
+def test_run_action_worker_refusal_verbatim(wired):
+    wired.action_ok = False
+    result = _load(control_tools._run_action_impl("Bogus"))
+    assert result["error_kind"] == "worker_refused"
+    assert result["message"] == "unknown action"
+
+
+def test_describe_action_returns_steps(wired):
+    wired.describe_steps = [
+        {"kind": "set", "device": "U_Screen4", "variable": "position", "value": "IN"}
+    ]
+    result = _load(control_tools._describe_action_impl("Insert Screen"))
+    assert result["ok"] and result["step_count"] == 1
+    assert result["steps"][0]["device"] == "U_Screen4"
+
+
+def test_describe_action_failure_is_worker_refused(wired):
+    wired.describe_error = "manager busy: RE state is running"
+    result = _load(control_tools._describe_action_impl("Insert Screen"))
+    assert result["error_kind"] == "worker_refused" and "busy" in result["message"]
+
+
+# ---------------------------------------------------------------------------
+# move_scan_variable (v2)
+# ---------------------------------------------------------------------------
+
+
+def test_move_variable_happy_path(wired):
+    result = _load(control_tools._move_scan_variable_impl("jet_z", 12.5))
+    assert result["ok"] and result["requested"] == 12.5
+    assert result["result"] == {"variable": "jet_z"}
+    assert wired.moves == [("jet_z", 12.5)]
+
+
+def test_move_variable_nonfinite_refused(wired):
+    for bad in (float("nan"), float("inf")):
+        result = _load(control_tools._move_scan_variable_impl("jet_z", bad))
+        assert result["error_kind"] == "invalid_request"
+    assert wired.moves == []
+
+
+def test_move_variable_non_number_refused(wired):
+    result = _load(control_tools._move_scan_variable_impl("jet_z", "twelve"))
+    assert result["error_kind"] == "invalid_request"
+    assert wired.moves == []
+
+
+def test_move_variable_worker_failure_verbatim(wired):
+    wired.move_error = "manual-move lock held"
+    result = _load(control_tools._move_scan_variable_impl("jet_z", 1.0))
+    assert result["error_kind"] == "worker_refused" and "lock" in result["message"]
+
+
+# ---------------------------------------------------------------------------
+# pause_scan / resume_scan (v2)
+# ---------------------------------------------------------------------------
+
+
+def test_pause_own_scan_proceeds(wired):
+    wired.re_state = "running"
+    wired.running = {"item_uid": "r1", "user": runtime.client_identity()}
+    result = _load(control_tools._pause_scan_impl(False))
+    assert result["ok"] and result["forced"] is False
+
+
+def test_pause_nothing_running(wired):
+    result = _load(control_tools._pause_scan_impl(False))
+    assert result["error_kind"] == "invalid_request" and "idle" in result["message"]
+
+
+def test_pause_foreign_scan_refused_then_forced(wired):
+    wired.re_state = "running"
+    wired.running = {"item_uid": "r1", "user": "geecs-console"}
+    result = _load(control_tools._pause_scan_impl(False))
+    assert result["error_kind"] == "policy_refusal"
+    assert "geecs-console" in result["message"]
+    result = _load(control_tools._pause_scan_impl(True))
+    assert result["ok"] and result["forced"] is True
+
+
+def test_pause_failure_is_worker_refused(wired):
+    wired.re_state = "running"
+    wired.pause_result = (False, "no plan is running")
+    result = _load(control_tools._pause_scan_impl(False))
+    assert result["error_kind"] == "worker_refused"
+
+
+def test_resume_requires_paused(wired):
+    wired.re_state = "running"
+    result = _load(control_tools._resume_scan_impl(False))
+    assert result["error_kind"] == "invalid_request" and "running" in result["message"]
+
+
+def test_resume_own_paused_scan(wired):
+    wired.re_state = "paused"
+    wired.running = {"item_uid": "r1", "user": runtime.client_identity()}
+    result = _load(control_tools._resume_scan_impl(False))
+    assert result["ok"] and result["message"] == "resumed"
+
+
+def test_resume_foreign_scan_refused_then_forced(wired):
+    wired.re_state = "paused"
+    wired.running = {"item_uid": "r1", "user": "geecs-console"}
+    result = _load(control_tools._resume_scan_impl(False))
+    assert result["error_kind"] == "policy_refusal"
+    result = _load(control_tools._resume_scan_impl(True))
+    assert result["ok"] and result["forced"] is True
+
+
+# ---------------------------------------------------------------------------
+# scan_progress + the stream picture (v2)
+# ---------------------------------------------------------------------------
+
+
+class _FakeCache:
+    def __init__(self, snapshot):
+        self._snapshot = snapshot
+        self.started_with = None
+
+    def ensure_started(self, doc_addr, info_addr):
+        self.started_with = (doc_addr, info_addr)
+
+    def snapshot(self):
+        return dict(self._snapshot)
+
+
+def test_scan_progress_merges_stream_picture(wired, monkeypatch):
+    from geecs_mcp.scans import progress_stream
+
+    wired.re_state = "running"
+    wired.doc_addr = "localhost:5568"
+    wired.info_addr = "tcp://localhost:60625"
+    cache = _FakeCache(
+        {
+            "available": True,
+            "detail": "",
+            "scan_number": 42,
+            "shots_done": 30,
+            "shots_total": 55,
+            "paused_reason": "stale from an earlier pause",
+        }
+    )
+    monkeypatch.setattr(progress_stream, "get_progress_cache", lambda: cache)
+    result = _load(control_tools._scan_progress_impl())
+    assert cache.started_with == ("localhost:5568", "tcp://localhost:60625")
+    assert result["stream"]["shots_done"] == 30
+    assert result["stream"]["shots_total"] == 55
+    # The sticky failed-move reason is only shown while actually paused.
+    assert "paused_reason" not in result["stream"]
+
+    wired.re_state = "paused"
+    result = _load(control_tools._scan_progress_impl())
+    assert result["stream"]["paused_reason"] == "stale from an earlier pause"
+
+
+def test_scan_progress_survives_stream_failure(wired, monkeypatch):
+    from geecs_mcp.scans import progress_stream
+
+    def boom():
+        raise RuntimeError("stream exploded")
+
+    monkeypatch.setattr(progress_stream, "get_progress_cache", boom)
+    result = _load(control_tools._scan_progress_impl())
+    assert result["ok"] and result["stream"]["available"] is False
+
+
+def test_all_control_tools_registered():
     import anyio
 
     from geecs_mcp import tool_names

--- a/GEECS-MCP/tests/test_control_tools.py
+++ b/GEECS-MCP/tests/test_control_tools.py
@@ -489,6 +489,21 @@ def test_move_variable_worker_failure_verbatim(wired):
     assert result["error_kind"] == "worker_refused" and "lock" in result["message"]
 
 
+def test_move_variable_timeout_is_task_timeout(wired):
+    wired.move_error = "worker task did not finish within 120 s"
+    result = _load(control_tools._move_scan_variable_impl("jet_z", 1.0))
+    assert result["error_kind"] == "task_timeout"
+
+
+def test_names_are_submitted_stripped(wired):
+    # Validated stripped ⇒ submitted stripped — " Insert Screen " must
+    # not reach the worker as an unknown padded name.
+    result = _load(control_tools._run_action_impl("  Insert Screen  "))
+    assert result["ok"] and wired.actions_submitted == ["Insert Screen"]
+    result = _load(control_tools._move_scan_variable_impl(" jet_z ", 1.0))
+    assert result["ok"] and wired.moves[-1] == ("jet_z", 1.0)
+
+
 # ---------------------------------------------------------------------------
 # pause_scan / resume_scan (v2)
 # ---------------------------------------------------------------------------
@@ -545,6 +560,35 @@ def test_resume_foreign_scan_refused_then_forced(wired):
     assert result["ok"] and result["forced"] is True
 
 
+def test_resume_fails_closed_on_unreadable_ownership(wired, monkeypatch):
+    # Review finding #683-2: resume is a GO verb — a transient
+    # running-item read failure must not let this client restart another
+    # client's paused scan unforced (the halt family stays fail-open).
+    wired.re_state = "paused"
+
+    def boom():
+        raise RuntimeError("recv timeout")
+
+    monkeypatch.setattr(wired, "running_item", boom)
+    result = _load(control_tools._resume_scan_impl(False))
+    assert result["error_kind"] == "policy_refusal"
+    assert "could not be read" in result["message"]
+    # force past unknown ownership works and is audit-marked forced.
+    result = _load(control_tools._resume_scan_impl(True))
+    assert result["ok"] and result["forced"] is True
+
+
+def test_pause_stays_fail_open_on_unreadable_ownership(wired, monkeypatch):
+    wired.re_state = "running"
+
+    def boom():
+        raise RuntimeError("recv timeout")
+
+    monkeypatch.setattr(wired, "running_item", boom)
+    result = _load(control_tools._pause_scan_impl(False))
+    assert result["ok"] and result["forced"] is False
+
+
 # ---------------------------------------------------------------------------
 # scan_progress + the stream picture (v2)
 # ---------------------------------------------------------------------------
@@ -575,7 +619,7 @@ def test_scan_progress_merges_stream_picture(wired, monkeypatch):
             "scan_number": 42,
             "shots_done": 30,
             "shots_total": 55,
-            "paused_reason": "stale from an earlier pause",
+            "paused_reason": "U_Hexapod move failed",
         }
     )
     monkeypatch.setattr(progress_stream, "get_progress_cache", lambda: cache)
@@ -583,12 +627,14 @@ def test_scan_progress_merges_stream_picture(wired, monkeypatch):
     assert cache.started_with == ("localhost:5568", "tcp://localhost:60625")
     assert result["stream"]["shots_done"] == 30
     assert result["stream"]["shots_total"] == 55
-    # The sticky failed-move reason is only shown while actually paused.
+    # The failed-move reason is only shown while actually paused (the
+    # cache itself clears it on resumed progress — pinned in
+    # test_progress_stream.py).
     assert "paused_reason" not in result["stream"]
 
     wired.re_state = "paused"
     result = _load(control_tools._scan_progress_impl())
-    assert result["stream"]["paused_reason"] == "stale from an earlier pause"
+    assert result["stream"]["paused_reason"] == "U_Hexapod move failed"
 
 
 def test_scan_progress_survives_stream_failure(wired, monkeypatch):

--- a/GEECS-MCP/tests/test_progress_stream.py
+++ b/GEECS-MCP/tests/test_progress_stream.py
@@ -1,0 +1,108 @@
+"""Unit tests for the document-driven ``ProgressCache`` (no zmq, no threads).
+
+The document handler is exercised directly — feeding the same start /
+descriptor / event / stop shapes the worker's proxy emits — because the
+stream plumbing itself (RemoteDispatcher, ConsoleMonitor) is upstream
+code this package only wires up.
+"""
+
+from __future__ import annotations
+
+from geecs_mcp.scans.progress_stream import ProgressCache
+
+
+def _started_cache() -> ProgressCache:
+    cache = ProgressCache()
+    cache._available = True  # what _run_documents sets once the dispatcher is up
+    cache._detail = ""
+    return cache
+
+
+START = {
+    "uid": "run-1",
+    "scan_number": 42,
+    "num_points": 11,
+    "shots_per_step": 5,
+}
+
+
+def test_start_doc_seeds_totals_and_resets():
+    cache = _started_cache()
+    cache._on_document("start", START)
+    snap = cache.snapshot()
+    assert snap["scan_number"] == 42
+    assert snap["shots_total"] == 55
+    assert snap["shots_done"] == 0
+    assert snap["exit_status"] is None
+
+
+def test_optimize_falls_back_to_max_iterations():
+    cache = _started_cache()
+    cache._on_document(
+        "start", {"uid": "run-2", "max_iterations": 20, "shots_per_step": 3}
+    )
+    assert cache.snapshot()["shots_total"] == 60
+
+
+def test_totals_none_when_neither_field_present():
+    cache = _started_cache()
+    cache._on_document("start", {"uid": "run-3"})
+    assert cache.snapshot()["shots_total"] is None
+
+
+def test_only_primary_stream_events_advance_shots():
+    cache = _started_cache()
+    cache._on_document("start", START)
+    cache._on_document("descriptor", {"uid": "d-prim", "name": "primary"})
+    cache._on_document("descriptor", {"uid": "d-base", "name": "baseline"})
+    cache._on_document("event", {"descriptor": "d-prim", "seq_num": 7})
+    cache._on_document("event", {"descriptor": "d-base", "seq_num": 999})
+    assert cache.snapshot()["shots_done"] == 7
+
+
+def test_stop_doc_records_exit_status_for_matching_run_only():
+    cache = _started_cache()
+    cache._on_document("start", START)
+    cache._on_document("stop", {"run_start": "someone-else", "exit_status": "failed"})
+    assert cache.snapshot()["exit_status"] is None
+    cache._on_document("stop", {"run_start": "run-1", "exit_status": "success"})
+    assert cache.snapshot()["exit_status"] == "success"
+
+
+def test_new_start_clears_previous_run():
+    cache = _started_cache()
+    cache._on_document("start", START)
+    cache._on_document("descriptor", {"uid": "d-prim", "name": "primary"})
+    cache._on_document("event", {"descriptor": "d-prim", "seq_num": 55})
+    cache._state["paused_reason"] = "U_Hexapod move failed"
+    cache._on_document("start", {"uid": "run-2", "num_points": 3, "shots_per_step": 1})
+    snap = cache.snapshot()
+    assert snap["shots_done"] == 0 and snap["shots_total"] == 3
+    assert snap["paused_reason"] is None
+    # The old primary descriptor no longer counts.
+    cache._on_document("event", {"descriptor": "d-prim", "seq_num": 9})
+    assert cache.snapshot()["shots_done"] == 0
+
+
+def test_malformed_documents_never_raise():
+    cache = _started_cache()
+    cache._on_document("start", {"uid": "run-1", "num_points": "eleven"})
+    cache._on_document("event", {"descriptor": None, "seq_num": object()})
+    snap = cache.snapshot()  # still answers
+    assert snap["available"] is True
+
+
+def test_unstarted_cache_reports_unavailable():
+    snap = ProgressCache().snapshot()
+    assert snap["available"] is False and "not started" in snap["detail"]
+
+
+def test_ensure_started_without_doc_addr_degrades_honestly():
+    cache = ProgressCache()
+    cache.ensure_started(None, "tcp://localhost:60625")
+    snap = cache.snapshot()
+    assert snap["available"] is False
+    assert "no document-stream address" in snap["detail"]
+    # Idempotent: a second call must not spawn anything or reset state.
+    cache.ensure_started(None, None)
+    assert cache.snapshot()["detail"] == snap["detail"]

--- a/GEECS-MCP/tests/test_progress_stream.py
+++ b/GEECS-MCP/tests/test_progress_stream.py
@@ -84,6 +84,26 @@ def test_new_start_clears_previous_run():
     assert cache.snapshot()["shots_done"] == 0
 
 
+def test_primary_progress_clears_the_paused_reason():
+    # Review finding #683-1: the failed-move reason must not survive a
+    # successful resume — otherwise a SECOND (manual) pause of the same
+    # run reports the first pause's text as the current why.  Progress
+    # on the primary stream proves the resume.
+    cache = _started_cache()
+    cache._on_document("start", START)
+    cache._on_document("descriptor", {"uid": "d-prim", "name": "primary"})
+    cache._state["paused_reason"] = "U_Hexapod move failed"
+    cache._on_document("event", {"descriptor": "d-prim", "seq_num": 8})
+    assert cache.snapshot()["paused_reason"] is None
+
+
+def test_ensure_started_ignores_a_different_address_after_latch():
+    cache = ProgressCache()
+    cache.ensure_started(None, None)  # latches unconfigured
+    cache.ensure_started("otherhost:5568", None)  # ignored with a warning
+    assert cache.snapshot()["available"] is False
+
+
 def test_malformed_documents_never_raise():
     cache = _started_cache()
     cache._on_document("start", {"uid": "run-1", "num_points": "eleven"})

--- a/GeecsBluesky/CHANGELOG.md
+++ b/GeecsBluesky/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to `geecs-bluesky` are documented here.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.62.0] - 2026-08-23
+
+### Added
+
+- **`FAILED_MOVE_LOG_PREFIX` re-exported from `geecs_bluesky.qs_client`**
+  (PEP 562 lazy — an eager import would drag `plans/pause_semantics`
+  and bluesky into the pinned light-import contract): stream consumers
+  (the console monitor's twin in GEECS-MCP's `scan_progress`) match the
+  engine's failed-move pause line without importing engine internals.
+
 ## [0.61.0] - 2026-08-22
 
 ### Added

--- a/GeecsBluesky/CHANGELOG.md
+++ b/GeecsBluesky/CHANGELOG.md
@@ -8,11 +8,16 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
-- **`FAILED_MOVE_LOG_PREFIX` re-exported from `geecs_bluesky.qs_client`**
-  (PEP 562 lazy — an eager import would drag `plans/pause_semantics`
-  and bluesky into the pinned light-import contract): stream consumers
-  (the console monitor's twin in GEECS-MCP's `scan_progress`) match the
-  engine's failed-move pause line without importing engine internals.
+- **`FAILED_MOVE_LOG_PREFIX` re-exported from `geecs_bluesky.qs_client`**,
+  with its definition moved to the new import-light
+  `geecs_bluesky/log_markers.py` (stdlib-only; `plans.pause_semantics`
+  re-exports it from its historical home): stream consumers (the console
+  monitor's twin in GEECS-MCP's `scan_progress`) match the engine's
+  failed-move pause line without importing engine internals.  A PEP 562
+  lazy shim was tried first and rejected in review — attribute access
+  dragged the whole device stack (bluesky *and* the optional-`ca`
+  aioca) into qs-client-only installs; the light-import test now pins
+  name resolution, not just the package import.
 
 ## [0.61.0] - 2026-08-22
 

--- a/GeecsBluesky/geecs_bluesky/log_markers.py
+++ b/GeecsBluesky/geecs_bluesky/log_markers.py
@@ -1,0 +1,23 @@
+"""Log-line contract strings that clients grep/parse — import-light on purpose.
+
+A marker lives here (not beside the code that emits it) exactly when
+out-of-process consumers parse it from a log/text stream: the emitting
+module usually sits deep in the engine (bluesky, devices, aioca), and a
+client that only *matches* the string must never pay for that stack —
+the ``geecs_bluesky.qs_client`` package import is pinned light, and its
+re-export of these markers is a plain eager import of this module.
+
+This module may depend on nothing heavier than the standard library.
+"""
+
+from __future__ import annotations
+
+#: The decision-4 failed-move pause reason line: the engine logs
+#: ``f"{FAILED_MOVE_LOG_PREFIX}: <reason>"`` (ERROR) when a queue-plan
+#: axis move fails and the scan pauses for the operator.  Stream
+#: consumers (the console's paused pill, the MCP's ``scan_progress``)
+#: match this prefix in the manager's console-output stream to surface
+#: the *why*.  Emitted by ``plans/step_scan.py``; re-exported by
+#: ``plans.pause_semantics`` (its historical home) and
+#: ``geecs_bluesky.qs_client`` (the client-facing spelling).
+FAILED_MOVE_LOG_PREFIX = "FAILED MOVE - pausing for operator"

--- a/GeecsBluesky/geecs_bluesky/plans/pause_semantics.py
+++ b/GeecsBluesky/geecs_bluesky/plans/pause_semantics.py
@@ -84,6 +84,9 @@ from typing import TYPE_CHECKING
 
 from bluesky.utils import Msg
 
+# Re-exported from its historical home here; defined in the import-light
+# log_markers so stream-parsing clients (qs_client) never pull bluesky.
+from geecs_bluesky.log_markers import FAILED_MOVE_LOG_PREFIX
 from geecs_bluesky.models.shot_control import ShotControlState
 
 if TYPE_CHECKING:  # import-light on purpose: step_scan imports this module
@@ -91,8 +94,7 @@ if TYPE_CHECKING:  # import-light on purpose: step_scan imports this module
 
 logger = logging.getLogger(__name__)
 
-#: Stable grep target for the decision-4 reason record (docs contract above).
-FAILED_MOVE_LOG_PREFIX = "FAILED MOVE - pausing for operator"
+__all__ = ["FAILED_MOVE_LOG_PREFIX", "QUIESCE_FROM", "ShotControlPauseQuiescer"]
 
 #: Standing states the quiescer must stop the trigger from.  ARMED is
 #: deliberately absent: strict mode's single-shot source cannot free-run, so

--- a/GeecsBluesky/geecs_bluesky/qs_client/__init__.py
+++ b/GeecsBluesky/geecs_bluesky/qs_client/__init__.py
@@ -37,6 +37,7 @@ from geecs_bluesky.qs_client.submit_preflight import (
 )
 
 __all__ = [
+    "FAILED_MOVE_LOG_PREFIX",  # lazy — see __getattr__
     "QserverConfig",
     "QueueClient",
     "QueueStatus",
@@ -50,3 +51,19 @@ __all__ = [
     "run_submit_preflight",
     "stamp_submission",
 ]
+
+
+def __getattr__(name: str):
+    """Lazy re-exports (PEP 562) that must not weigh down the package import.
+
+    ``FAILED_MOVE_LOG_PREFIX`` is the log-line contract clients parse for
+    the paused-scan reason (the console pill, the MCP's scan_progress) —
+    re-exported here so clients never import ``plans/*`` directly, but
+    lazily, because its home module pulls bluesky and the qs_client
+    import must stay light (the pinned contract).
+    """
+    if name == "FAILED_MOVE_LOG_PREFIX":
+        from geecs_bluesky.plans.pause_semantics import FAILED_MOVE_LOG_PREFIX
+
+        return FAILED_MOVE_LOG_PREFIX
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/GeecsBluesky/geecs_bluesky/qs_client/__init__.py
+++ b/GeecsBluesky/geecs_bluesky/qs_client/__init__.py
@@ -19,6 +19,12 @@ methods, and the parent package's device re-exports are lazy too — a
 client that only submits scans never pays for aioca/ophyd-async.
 """
 
+# The failed-move pause-reason line clients parse from the manager's
+# console-output stream (the console pill, the MCP's scan_progress).
+# Its definition lives in the import-light log_markers module precisely
+# so this eager re-export cannot violate the pinned light-import
+# contract (the engine home, plans.pause_semantics, pulls bluesky).
+from geecs_bluesky.log_markers import FAILED_MOVE_LOG_PREFIX
 from geecs_bluesky.qs_client.client import (
     QserverConfig,
     QueueClient,
@@ -37,7 +43,7 @@ from geecs_bluesky.qs_client.submit_preflight import (
 )
 
 __all__ = [
-    "FAILED_MOVE_LOG_PREFIX",  # lazy — see __getattr__
+    "FAILED_MOVE_LOG_PREFIX",
     "QserverConfig",
     "QueueClient",
     "QueueStatus",
@@ -51,19 +57,3 @@ __all__ = [
     "run_submit_preflight",
     "stamp_submission",
 ]
-
-
-def __getattr__(name: str):
-    """Lazy re-exports (PEP 562) that must not weigh down the package import.
-
-    ``FAILED_MOVE_LOG_PREFIX`` is the log-line contract clients parse for
-    the paused-scan reason (the console pill, the MCP's scan_progress) —
-    re-exported here so clients never import ``plans/*`` directly, but
-    lazily, because its home module pulls bluesky and the qs_client
-    import must stay light (the pinned contract).
-    """
-    if name == "FAILED_MOVE_LOG_PREFIX":
-        from geecs_bluesky.plans.pause_semantics import FAILED_MOVE_LOG_PREFIX
-
-        return FAILED_MOVE_LOG_PREFIX
-    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/GeecsBluesky/geecs_bluesky/qs_client/client.py
+++ b/GeecsBluesky/geecs_bluesky/qs_client/client.py
@@ -375,6 +375,9 @@ class ZmqQueueClient:
             if status not in (None, "running", "accepted", "pending"):
                 raise RuntimeError(f"worker task ended with status {status!r}")
             time.sleep(0.2)
+        # "did not finish within" is a parsed seam: GEECS-MCP's
+        # _task_error_kind matches it to report task_timeout instead of
+        # worker_refused — reword both together.
         raise RuntimeError(f"worker task did not finish within {timeout_s:.0f} s")
 
     # -- protocol -----------------------------------------------------------

--- a/GeecsBluesky/pyproject.toml
+++ b/GeecsBluesky/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-bluesky"
-version = "0.61.0"
+version = "0.62.0"
 description = "Bluesky / ophyd-async bridge for the GEECS control system"
 authors = ["Sam Barber <sbarber@lbl.gov>"]
 readme = "README.md"

--- a/GeecsBluesky/tests/test_lazy_package_import.py
+++ b/GeecsBluesky/tests/test_lazy_package_import.py
@@ -24,7 +24,15 @@ for heavy in ("aioca", "ophyd_async", "bluesky_queueserver_api"):
 import geecs_bluesky.qs_client
 from geecs_bluesky.qs_client import make_queue_client  # noqa: F401
 
-for heavy in ("aioca", "ophyd_async", "bluesky_queueserver_api"):
+# The log-marker re-export must stay light too — resolving the NAME, not
+# just importing the package (a PEP 562 lazy shim once passed the import
+# leg while attribute access dragged in bluesky + aioca; the constant
+# now lives in the import-light log_markers module).
+from geecs_bluesky.qs_client import FAILED_MOVE_LOG_PREFIX
+
+assert FAILED_MOVE_LOG_PREFIX.startswith("FAILED MOVE")
+
+for heavy in ("aioca", "ophyd_async", "bluesky_queueserver_api", "bluesky"):
     assert heavy not in sys.modules, f"qs_client import pulled {heavy}"
 
 # The lazy re-exports still resolve (this leg MAY pull the device stack).


### PR DESCRIPTION
Closes #676.

The scans domain's v2 tier, per the planning doc's phasing as amended by the verified osprey gating semantics.

## What's here (per-concern LOC)

**GEECS-MCP 0.5.0** (~+900 incl. tests/docs):
- `run_action` (Q) + `describe_action` (R): on-demand ActionPlan execution through `geecs_run_action_plan` queue items, with the worker's `geecs_describe_action` dry-run as the read-only preview. Idle-only — an active RE state refuses like `submit_scan`, because a mid-scan submission would silently queue the action to auto-run the moment the scan finishes.
- `move_scan_variable` (Q): the worker's `geecs_move_variable` via `function_execute` — plain/confirm/pseudo variables resolve exactly as a scan axis would; idle-only (manager-enforced), blocking ≤ ~120 s; non-finite/non-numeric values refused before the worker sees them.
- `pause_scan` (S) + `resume_scan` (Q): stop's ownership etiquette (foreign scan refused by name unless `force=true`; `forced` marks only genuinely foreign overrides). Pause joins the halt family — never behind the headless `write_tools` gate; resume restarts motion and retries the failed move, so it gates like a submission.
- `scan_progress` stream upgrade (`scans/progress_stream.py`): a process-wide `ProgressCache` fed by two daemon threads — the worker's document stream (start-doc totals `num_points × shots_per_step` with the `max_iterations` fallback; primary-stream `seq_num` → shots done; stop-doc exit status) and the manager's console-output stream (the engine's failed-move line → paused reason, surfaced only while actually paused). Best-effort by design: `stream.available=false` names why and the v1 poll answer stands alone; threading per the console's #653 rules (daemon threads, zmq never touched cross-thread, no stop).

**GeecsBluesky 0.62.0** (+13): `FAILED_MOVE_LOG_PREFIX` re-exported from `geecs_bluesky.qs_client` via PEP 562 lazy `__getattr__` — an eager import would drag bluesky into the pinned light-import contract (verified: bluesky absent from `sys.modules` after import).

## Tests

- 69 passed in GEECS-MCP (30 new: the four verbs' happy/refusal/ownership paths, the stream merge + paused-reason gating + stream-failure survival, `ProgressCache` document handling incl. the max_iterations fallback, primary-only counting, run-matched stop docs, malformed-doc tolerance, and honest degradation without a doc address).
- GeecsBluesky: `test_lazy_package_import.py` + `tests/qs_client` green (light import holds).

## Merge-order note

The unmerged #680 branch carries GeecsBluesky 0.61.1 and #681 carries GEECS-MCP 0.4.0 — whichever merges second resolves a trivial version/CHANGELOG conflict (this branch deliberately took 0.62.0 / 0.5.0 and the 0.5.0 changelog entry says 0.4.0 lands separately).

## Owed at deployment

The v2 live checks ride the qserver-box deployment checklist with the analysis verbs: a live `run_action`/`describe_action` round-trip, one manual move, a pause/resume on a real scan with the stream counts against the console's bar, and the `write_tools` extension on the deployed profile (`run_action`, `move_scan_variable`, `resume_scan`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)