### PR TITLE
GEECS-MCP 0.5.1: first-deployment live fixes — Windows display_files + nested outputs

### DIFF
--- a/GEECS-MCP/CHANGELOG.md
+++ b/GEECS-MCP/CHANGELOG.md
@@ -4,6 +4,30 @@ All notable changes to `geecs-mcp` are documented here.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.5.1] - 2026-08-24
+
+First-deployment live findings (qserver-box HTTP service, real netapp
+tree — both invisible to the hermetic fixtures):
+
+### Fixed
+
+- **Windows-written `display_files` entries localize instead of
+  crashing**: production statuses come from the Windows analysis
+  machines (`Z:\data\...\analysis\Scan<NNN>\...`); on the Linux
+  service host such an entry is not absolute, was joined onto the
+  analysis folder as one giant backslash component, and the stat's
+  `OSError` killed the whole figure tool — including the healthy
+  tree-scan fallback.  Now: a Windows-style entry re-roots by its tail
+  after `analysis\Scan<NNN>\` onto the local analysis folder (served
+  like any candidate), an unmatchable one is skipped with a warning,
+  and every per-candidate filesystem touch is guarded so one bad entry
+  can never take down the tool.
+- **`get_scan_analysis` outputs walk the nested analyzer tree**: the
+  production layout is `Scan<NNN>/<device>/<Analyzer>/files`, and the
+  one-level listing read every device as `n_files: 0`.  Files are
+  counted through the whole device subtree (names relative, listing
+  still capped).
+
 ## [0.5.0] - 2026-08-23
 
 The v2 verbs (issue #676) — actions, manual moves, pause/resume, and the

--- a/GEECS-MCP/geecs_mcp/analysis/read_tools.py
+++ b/GEECS-MCP/geecs_mcp/analysis/read_tools.py
@@ -302,9 +302,12 @@ def _gather_figure_candidates(scan_folder: Path, analysis_folder: Path) -> list[
             if path not in seen and path.is_file():
                 seen.add(path)
                 candidates.append(path)
-        except OSError:
-            # e.g. a stat on a pathologically-shaped name (EINVAL on the
-            # NFS mount) — skip the entry, never the tool.
+        except (OSError, ValueError):
+            # OSError: a stat on a pathologically-shaped name (EINVAL on
+            # the NFS mount, ENAMETOOLONG on any fs).  ValueError:
+            # resolve() on an embedded null byte — legal YAML, so
+            # reachable from the writable share (review finding on this
+            # PR).  Skip the entry, never the tool.
             logger.warning("figure candidate unreadable, skipped: %s", path)
 
     for status in _read_task_statuses(scan_folder).values():

--- a/GEECS-MCP/geecs_mcp/analysis/read_tools.py
+++ b/GEECS-MCP/geecs_mcp/analysis/read_tools.py
@@ -188,7 +188,16 @@ def _get_scan_analysis_impl(scan_number: int, day: str | None) -> str:
     if analysis_folder.is_dir():
         for entry in sorted(analysis_folder.iterdir()):
             if entry.is_dir():
-                names = sorted(p.name for p in entry.iterdir() if p.is_file())
+                # The production layout nests analyzer subdirs
+                # (Scan<NNN>/<device>/<Analyzer>/files) — a one-level
+                # listing read every device as empty (n_files: 0; live
+                # deployment finding 2026-08-24), so walk the whole
+                # device tree, names relative to it.
+                names = sorted(
+                    p.relative_to(entry).as_posix()
+                    for p in entry.rglob("*")
+                    if p.is_file()
+                )
                 outputs[entry.name] = {
                     "n_files": len(names),
                     "files": names[:_MAX_FILES_PER_DIR],
@@ -222,6 +231,38 @@ async def get_scan_analysis(scan_number: int, day: str | None = None) -> str:
     return await _run_guarded(_get_scan_analysis_impl, scan_number, day)
 
 
+def _localize_display_entry(name: str, analysis_folder: Path) -> Optional[Path]:
+    r"""A ``display_files`` entry as a path on THIS host, or ``None``.
+
+    Production entries are written by the WINDOWS analysis machines
+    (``Z:\\data\\...\\analysis\\Scan<NNN>\\...`` — live deployment
+    finding 2026-08-24: on the Linux service host such a string is not
+    absolute, so it was joined onto the analysis folder as one giant
+    backslash component and the stat blew up the whole tool).  A
+    Windows-style entry is re-rooted by its tail after the scan's own
+    ``analysis\\Scan<NNN>\\`` onto the local *analysis_folder*; an entry
+    whose parts never match that pattern returns ``None`` (skipped with
+    a warning — never a crash).  Anything else passes through unchanged
+    for the normal absolute/relative handling.
+    """
+    from pathlib import PureWindowsPath
+
+    looks_windows = "\\" in name or (len(name) >= 2 and name[1] == ":")
+    if not looks_windows:
+        return Path(name)
+    parts = PureWindowsPath(name).parts
+    lowered = [part.lower() for part in parts]
+    scan_name = analysis_folder.name.lower()
+    for i in range(len(parts) - 1):
+        if lowered[i] == "analysis" and lowered[i + 1] == scan_name:
+            tail = parts[i + 2 :]
+            if tail:
+                return analysis_folder.joinpath(*tail)
+            break
+    logger.warning("display_files entry not under this scan's analysis tree: %s", name)
+    return None
+
+
 def _gather_figure_candidates(scan_folder: Path, analysis_folder: Path) -> list[Path]:
     """Figure candidates: display_files first, then images in the tree.
 
@@ -233,6 +274,11 @@ def _gather_figure_candidates(scan_folder: Path, analysis_folder: Path) -> list[
     is where the writer actually puts every legitimate entry —
     ScanAnalysis analyzers write to ``<date>/analysis/Scan<NNN>/...`` —
     so a poisoned entry cannot reach even another scan's outputs).
+    Windows-written entries are localized first (see
+    :func:`_localize_display_entry`), and every per-candidate
+    filesystem touch is guarded — one hostile or malformed entry must
+    never take down the tree-scan fallback (the live crash did exactly
+    that).
     """
     candidates: list[Path] = []
     seen: set[Path] = set()
@@ -248,20 +294,24 @@ def _gather_figure_candidates(scan_folder: Path, analysis_folder: Path) -> list[
             path = analysis_folder / path
         try:
             path = path.resolve()
+            if not path.is_relative_to(root):
+                logger.warning(
+                    "figure candidate outside the scan's analysis folder: %s", path
+                )
+                return
+            if path not in seen and path.is_file():
+                seen.add(path)
+                candidates.append(path)
         except OSError:
-            return
-        if not path.is_relative_to(root):
-            logger.warning(
-                "figure candidate outside the scan's analysis folder: %s", path
-            )
-            return
-        if path not in seen and path.is_file():
-            seen.add(path)
-            candidates.append(path)
+            # e.g. a stat on a pathologically-shaped name (EINVAL on the
+            # NFS mount) — skip the entry, never the tool.
+            logger.warning("figure candidate unreadable, skipped: %s", path)
 
     for status in _read_task_statuses(scan_folder).values():
         for name in status.get("display_files") or []:
-            _add(Path(name))
+            localized = _localize_display_entry(str(name), analysis_folder)
+            if localized is not None:
+                _add(localized)
     if analysis_folder.is_dir():
         for path in sorted(analysis_folder.rglob("*")):
             if len(candidates) >= _MAX_FIGURE_CANDIDATES:

--- a/GEECS-MCP/pyproject.toml
+++ b/GEECS-MCP/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-mcp"
-version = "0.5.0"
+version = "0.5.1"
 description = "MCP server exposing GEECS scan submission, monitoring, and config discovery to AI agents (OSPREY)"
 authors = ["Sam Barber <sbarber@lbl.gov>"]
 readme = "README.md"

--- a/GEECS-MCP/tests/test_analysis_tools.py
+++ b/GEECS-MCP/tests/test_analysis_tools.py
@@ -85,6 +85,59 @@ def _mtimes(root: Path) -> set:
     return {(p, p.stat().st_mtime_ns) for p in root.rglob("*")}
 
 
+def test_outputs_walk_the_nested_analyzer_tree(share):
+    # The production layout is Scan<NNN>/<device>/<Analyzer>/files (live
+    # deployment finding 2026-08-24: a one-level listing read every
+    # device dir as n_files: 0).
+    _, analysis_folder = _tree_paths(share)
+    nested = analysis_folder / "U_BCaveMagSpec" / "Array1DScanAnalyzer"
+    nested.mkdir(parents=True)
+    (nested / "waterfall.png").write_bytes(b"not-a-real-png")
+    (nested / "per_shot.csv").write_text("a\n1\n")
+    result = _load(read_tools._get_scan_analysis_impl(7, DAY))
+    magspec = result["outputs"]["U_BCaveMagSpec"]
+    assert magspec["n_files"] == 2
+    assert "Array1DScanAnalyzer/waterfall.png" in magspec["files"]
+
+
+def test_windows_display_files_localize_and_serve(share):
+    # Production statuses are written by the WINDOWS analysis machines:
+    # display_files carry Z:\...\analysis\Scan<NNN>\... paths.  On the
+    # Linux service host these must re-root onto the local analysis
+    # folder — the live deployment crashed on the raw entry (2026-08-24).
+    from PIL import Image as PILImage
+
+    scan_folder, analysis_folder = _tree_paths(share)
+    win_dir = analysis_folder / "UC_Amp2" / "Array2DScanAnalyzer"
+    win_dir.mkdir(parents=True)
+    PILImage.new("RGB", (10, 10)).save(win_dir / "avg_visual.png")
+    win_entry = (
+        "Z:\\data\\Undulator\\Y2026\\08-Aug\\26_0822\\analysis\\Scan007"
+        "\\UC_Amp2\\Array2DScanAnalyzer\\avg_visual.png"
+    )
+    (scan_folder / "analysis_status" / "amp2.yaml").write_text(
+        yaml.safe_dump({"state": "done", "display_files": [win_entry]})
+    )
+    from fastmcp.utilities.types import Image
+
+    result = read_tools._get_scan_figure_impl(7, "avg_visual", DAY)
+    assert isinstance(result, Image)
+
+
+def test_unlocalizable_windows_entry_never_kills_the_tool(share):
+    # An entry with no analysis\Scan<NNN> tail (or any per-entry stat
+    # blow-up) is skipped — the tree-scan fallback must still serve
+    # (the live crash aborted candidate gathering entirely).
+    scan_folder, _ = _tree_paths(share)
+    (scan_folder / "analysis_status" / "weird.yaml").write_text(
+        yaml.safe_dump({"state": "done", "display_files": ["C:\\Temp\\oddball.png"]})
+    )
+    from fastmcp.utilities.types import Image
+
+    result = read_tools._get_scan_figure_impl(7, "summary", DAY)
+    assert isinstance(result, Image)
+
+
 # ---------------------------------------------------------------------------
 # get_scan_analysis
 # ---------------------------------------------------------------------------

--- a/GEECS-MCP/tests/test_analysis_tools.py
+++ b/GEECS-MCP/tests/test_analysis_tools.py
@@ -138,6 +138,55 @@ def test_unlocalizable_windows_entry_never_kills_the_tool(share):
     assert isinstance(result, Image)
 
 
+def test_localize_display_entry_unit_contract(share):
+    # The localization itself, asserted directly (verify pass on this
+    # PR: the end-to-end tests could not tell "localized and served"
+    # from "dropped and rescued by the tree fallback").
+    _, analysis_folder = _tree_paths(share)
+    win = (
+        "Z:\\data\\Undulator\\Y2026\\08-Aug\\26_0822\\analysis\\Scan007"
+        "\\UC_Amp2\\Array2DScanAnalyzer\\avg_visual.png"
+    )
+    localized = read_tools._localize_display_entry(win, analysis_folder)
+    assert (
+        localized
+        == analysis_folder / "UC_Amp2" / "Array2DScanAnalyzer" / "avg_visual.png"
+    )
+    # No analysis\Scan<NNN> tail -> None (skipped, warned).
+    assert (
+        read_tools._localize_display_entry("C:\\Temp\\oddball.png", analysis_folder)
+        is None
+    )
+    # A POSIX entry passes through untouched.
+    posix = str(analysis_folder / "UC_TopView" / "summary.png")
+    assert read_tools._localize_display_entry(posix, analysis_folder) == Path(posix)
+
+
+def test_pathological_entries_hit_the_guard_not_the_tool(share):
+    # The guard itself (verify pass on this PR — the earlier fixtures
+    # were too tame to raise on a local fs):
+    # 1. a localized tail whose filename exceeds NAME_MAX -> the stat
+    #    raises ENAMETOOLONG (the live crash's mechanism, reproducible
+    #    on any fs);
+    # 2. an embedded null byte -> resolve() raises ValueError, which the
+    #    original except OSError let through (review finding).
+    # Both must skip the entry; the tree fallback must still serve.
+    scan_folder, _ = _tree_paths(share)
+    giant = (
+        "Z:\\data\\Undulator\\Y2026\\08-Aug\\26_0822\\analysis\\Scan007\\"
+        + "x" * 300
+        + ".png"
+    )
+    nullbyte = "evil\x00name.png"
+    (scan_folder / "analysis_status" / "pathological.yaml").write_text(
+        yaml.safe_dump({"state": "done", "display_files": [giant, nullbyte]})
+    )
+    from fastmcp.utilities.types import Image
+
+    result = read_tools._get_scan_figure_impl(7, "summary", DAY)
+    assert isinstance(result, Image)
+
+
 # ---------------------------------------------------------------------------
 # get_scan_analysis
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Two live findings from today's qserver-box HTTP deployment, caught the first time the analysis verbs met the real netapp tree (May 1 Scan001):

1. **Windows `display_files` crashed the figure tool.** Production task statuses are written by the Windows analysis machines, so `display_files` carry `Z:\data\...\analysis\Scan<NNN>\...` paths. On the Linux service host that string is not absolute → joined onto the analysis folder as one giant backslash component → the stat raised `OSError` (Errno 22 on the NFS mount) outside the per-candidate guard, aborting candidate gathering entirely — even the healthy tree-scan fallback never ran. Fix: `_localize_display_entry` re-roots a Windows-style entry by its tail after `analysis\Scan<NNN>\` onto the local analysis folder (so those figures actually **serve**, which is the point of `display_files`-first routing); unmatchable entries skip with a warning; the whole per-candidate filesystem path is guarded. The scan's-own-analysis-folder security bound (codex, #681) is unchanged.

2. **`get_scan_analysis` read every device as empty.** The real layout nests analyzer subdirs (`Scan<NNN>/<device>/<Analyzer>/files`); the one-level listing reported `n_files: 0` for every device. Outputs now walk the device subtree (relative names, listing still capped).

Live verification against the deployed service rides this PR (the raw `bellaappserver`-claimed production status must parse, localize, and serve the actual figure over HTTP) — results will be posted here. 91 tests pass (3 new pins).

🤖 Generated with [Claude Code](https://claude.com/claude-code)