### PR TITLE
GEECS-MCP 0.6.0: figure references + /figures/ fetch route (payload discipline)

### DIFF
--- a/GEECS-MCP/CHANGELOG.md
+++ b/GEECS-MCP/CHANGELOG.md
@@ -4,6 +4,30 @@ All notable changes to `geecs-mcp` are documented here.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.5.1] - 2026-08-24
+
+First-deployment live findings (qserver-box HTTP service, real netapp
+tree — both invisible to the hermetic fixtures):
+
+### Fixed
+
+- **Windows-written `display_files` entries localize instead of
+  crashing**: production statuses come from the Windows analysis
+  machines (`Z:\data\...\analysis\Scan<NNN>\...`); on the Linux
+  service host such an entry is not absolute, was joined onto the
+  analysis folder as one giant backslash component, and the stat's
+  `OSError` killed the whole figure tool — including the healthy
+  tree-scan fallback.  Now: a Windows-style entry re-roots by its tail
+  after `analysis\Scan<NNN>\` onto the local analysis folder (served
+  like any candidate), an unmatchable one is skipped with a warning,
+  and every per-candidate filesystem touch is guarded so one bad entry
+  can never take down the tool.
+- **`get_scan_analysis` outputs walk the nested analyzer tree**: the
+  production layout is `Scan<NNN>/<device>/<Analyzer>/files`, and the
+  one-level listing read every device as `n_files: 0`.  Files are
+  counted through the whole device subtree (names relative, listing
+  still capped).
+
 ## [0.5.0] - 2026-08-23
 
 The v2 verbs (issue #676) — actions, manual moves, pause/resume, and the

--- a/GEECS-MCP/CHANGELOG.md
+++ b/GEECS-MCP/CHANGELOG.md
@@ -4,6 +4,41 @@ All notable changes to `geecs-mcp` are documented here.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.6.0] - 2026-08-24
+
+Payload discipline for figures (osprey-side integration finding: an
+inline 247 KB PNG forced context compaction on the deployment's
+haiku-tier agent — image bytes never ride model context by default
+again).
+
+### Changed
+
+- **`get_scan_figure` returns a REFERENCE by default**: figure label,
+  pixel dimensions (header read, no decode), byte size, a
+  share-relative path (POSIX, relative to the GEECS data root — never a
+  `Z:\` or `/mnt/` primary handle), and `figure_url`.  Candidate and
+  ambiguity listings carry the same reference entries (label, bytes,
+  URL) instead of bare names.  `thumbnail=true` opts into bounded inline
+  image content: ≤768 px longest edge, JPEG q80 — the only path that
+  decodes, still behind the 64 MP decode cap.
+
+### Added
+
+- **`GET /figures/{day}/{scan_number}/{label}`** on the same HTTP
+  server: streams the ORIGINAL figure bytes (bypasses model context, so
+  no downscale) for clients to fetch and save as local artifacts.
+  Bounded by exactly the tool's candidate set (the scan's own analysis
+  folder, exact label match) plus a 50 MB byte cap; never raises (plain
+  4xx/5xx text).  The tool's `figure_url` is SERVER-RELATIVE by design —
+  clients resolve it against the MCP base URL they already hold, so no
+  advertised host is baked into results and service re-homing stays a
+  client-config-only change.  Unreachable over stdio (no HTTP app), by
+  construction.
+- **Payload budgets on `get_scan_analysis`** (the audit ask): one
+  task's `display_files` listing caps at 20 and the outputs listing at
+  40 device dirs, each with an explicit `*_truncated` flag — truncation
+  is never silent.
+
 ## [0.5.1] - 2026-08-24
 
 First-deployment live findings (qserver-box HTTP service, real netapp

--- a/GEECS-MCP/CLAUDE.md
+++ b/GEECS-MCP/CLAUDE.md
@@ -78,9 +78,19 @@ geecs_mcp/
                   #   no stop — the console's #653 rules)
   analysis/       # the analysis domain (#675)
     read_tools.py # get_scan_analysis (task statuses from
-                  #   analysis_status/ + the output tree) and
-                  #   get_scan_figure (a display_files/py-image figure,
-                  #   downscaled, returned as MCP image content).
+                  #   analysis_status/ + the output tree, payload-
+                  #   budgeted with explicit *_truncated flags) and
+                  #   get_scan_figure — a figure REFERENCE by default
+                  #   (label, dims, bytes, share-relative path,
+                  #   server-relative figure_url), 0.6.0 payload
+                  #   doctrine: a 247 KB inline PNG blew a haiku-tier
+                  #   agent context in the first web-UI integration, so
+                  #   image bytes ride model context ONLY via the
+                  #   opt-in thumbnail=true (≤768 px JPEG).  The
+                  #   /figures/{day}/{scan}/{label} custom route on the
+                  #   same server streams the ORIGINAL bytes (bounded
+                  #   by the tool's own candidate set + a byte cap) for
+                  #   clients to fetch-and-save as artifacts.
                   #   STRICTLY read-only over the data share: pure
                   #   ScanPaths static builders ONLY — the instance
                   #   get_analysis_folder() silently mkdirs and must

--- a/GEECS-MCP/deploy/DEPLOYMENT.md
+++ b/GEECS-MCP/deploy/DEPLOYMENT.md
@@ -86,7 +86,11 @@ running service), `systemctl restart geecs-mcp`.
 
 Interim security posture: no transport auth, lab-network-internal —
 identical to the manager's control socket; issue #660 (CurveZMQ / fleet
-auth) covers the eventual answer for both.
+auth) covers the eventual answer for both.  This covers the
+``/figures/{day}/{scan}/{label}`` route too (0.6.0): it serves raw
+analysis-figure bytes off the data share on the same port, bounded to
+each scan's own analysis folder with a 50 MB cap — same posture, same
+eventual auth answer.
 
 ## Per-machine stdio (dev loop / single host)
 

--- a/GEECS-MCP/geecs_mcp/analysis/read_tools.py
+++ b/GEECS-MCP/geecs_mcp/analysis/read_tools.py
@@ -302,9 +302,12 @@ def _gather_figure_candidates(scan_folder: Path, analysis_folder: Path) -> list[
             if path not in seen and path.is_file():
                 seen.add(path)
                 candidates.append(path)
-        except OSError:
-            # e.g. a stat on a pathologically-shaped name (EINVAL on the
-            # NFS mount) — skip the entry, never the tool.
+        except (OSError, ValueError):
+            # OSError: a stat on a pathologically-shaped name (EINVAL on
+            # the NFS mount, ENAMETOOLONG on any fs).  ValueError:
+            # resolve() on an embedded null byte — legal YAML, so
+            # reachable from the writable share (review finding on this
+            # PR).  Skip the entry, never the tool.
             logger.warning("figure candidate unreadable, skipped: %s", path)
 
     for status in _read_task_statuses(scan_folder).values():

--- a/GEECS-MCP/geecs_mcp/analysis/read_tools.py
+++ b/GEECS-MCP/geecs_mcp/analysis/read_tools.py
@@ -188,7 +188,16 @@ def _get_scan_analysis_impl(scan_number: int, day: str | None) -> str:
     if analysis_folder.is_dir():
         for entry in sorted(analysis_folder.iterdir()):
             if entry.is_dir():
-                names = sorted(p.name for p in entry.iterdir() if p.is_file())
+                # The production layout nests analyzer subdirs
+                # (Scan<NNN>/<device>/<Analyzer>/files) — a one-level
+                # listing read every device as empty (n_files: 0; live
+                # deployment finding 2026-08-24), so walk the whole
+                # device tree, names relative to it.
+                names = sorted(
+                    p.relative_to(entry).as_posix()
+                    for p in entry.rglob("*")
+                    if p.is_file()
+                )
                 outputs[entry.name] = {
                     "n_files": len(names),
                     "files": names[:_MAX_FILES_PER_DIR],
@@ -222,6 +231,38 @@ async def get_scan_analysis(scan_number: int, day: str | None = None) -> str:
     return await _run_guarded(_get_scan_analysis_impl, scan_number, day)
 
 
+def _localize_display_entry(name: str, analysis_folder: Path) -> Optional[Path]:
+    r"""A ``display_files`` entry as a path on THIS host, or ``None``.
+
+    Production entries are written by the WINDOWS analysis machines
+    (``Z:\\data\\...\\analysis\\Scan<NNN>\\...`` — live deployment
+    finding 2026-08-24: on the Linux service host such a string is not
+    absolute, so it was joined onto the analysis folder as one giant
+    backslash component and the stat blew up the whole tool).  A
+    Windows-style entry is re-rooted by its tail after the scan's own
+    ``analysis\\Scan<NNN>\\`` onto the local *analysis_folder*; an entry
+    whose parts never match that pattern returns ``None`` (skipped with
+    a warning — never a crash).  Anything else passes through unchanged
+    for the normal absolute/relative handling.
+    """
+    from pathlib import PureWindowsPath
+
+    looks_windows = "\\" in name or (len(name) >= 2 and name[1] == ":")
+    if not looks_windows:
+        return Path(name)
+    parts = PureWindowsPath(name).parts
+    lowered = [part.lower() for part in parts]
+    scan_name = analysis_folder.name.lower()
+    for i in range(len(parts) - 1):
+        if lowered[i] == "analysis" and lowered[i + 1] == scan_name:
+            tail = parts[i + 2 :]
+            if tail:
+                return analysis_folder.joinpath(*tail)
+            break
+    logger.warning("display_files entry not under this scan's analysis tree: %s", name)
+    return None
+
+
 def _gather_figure_candidates(scan_folder: Path, analysis_folder: Path) -> list[Path]:
     """Figure candidates: display_files first, then images in the tree.
 
@@ -233,6 +274,11 @@ def _gather_figure_candidates(scan_folder: Path, analysis_folder: Path) -> list[
     is where the writer actually puts every legitimate entry —
     ScanAnalysis analyzers write to ``<date>/analysis/Scan<NNN>/...`` —
     so a poisoned entry cannot reach even another scan's outputs).
+    Windows-written entries are localized first (see
+    :func:`_localize_display_entry`), and every per-candidate
+    filesystem touch is guarded — one hostile or malformed entry must
+    never take down the tree-scan fallback (the live crash did exactly
+    that).
     """
     candidates: list[Path] = []
     seen: set[Path] = set()
@@ -248,20 +294,24 @@ def _gather_figure_candidates(scan_folder: Path, analysis_folder: Path) -> list[
             path = analysis_folder / path
         try:
             path = path.resolve()
+            if not path.is_relative_to(root):
+                logger.warning(
+                    "figure candidate outside the scan's analysis folder: %s", path
+                )
+                return
+            if path not in seen and path.is_file():
+                seen.add(path)
+                candidates.append(path)
         except OSError:
-            return
-        if not path.is_relative_to(root):
-            logger.warning(
-                "figure candidate outside the scan's analysis folder: %s", path
-            )
-            return
-        if path not in seen and path.is_file():
-            seen.add(path)
-            candidates.append(path)
+            # e.g. a stat on a pathologically-shaped name (EINVAL on the
+            # NFS mount) — skip the entry, never the tool.
+            logger.warning("figure candidate unreadable, skipped: %s", path)
 
     for status in _read_task_statuses(scan_folder).values():
         for name in status.get("display_files") or []:
-            _add(Path(name))
+            localized = _localize_display_entry(str(name), analysis_folder)
+            if localized is not None:
+                _add(localized)
     if analysis_folder.is_dir():
         for path in sorted(analysis_folder.rglob("*")):
             if len(candidates) >= _MAX_FIGURE_CANDIDATES:

--- a/GEECS-MCP/geecs_mcp/analysis/read_tools.py
+++ b/GEECS-MCP/geecs_mcp/analysis/read_tools.py
@@ -44,6 +44,12 @@ _MAX_FILES_PER_DIR = 30
 #: Cap on figure candidates gathered/listed.
 _MAX_FIGURE_CANDIDATES = 60
 
+#: Payload budgets for get_scan_analysis (osprey-side audit ask): one
+#: task's display_files list and the number of device dirs listed —
+#: truncation is flagged, never silent.
+_MAX_DISPLAY_FILES_PER_TASK = 20
+_MAX_OUTPUT_DIRS = 40
+
 #: Longest image edge after downscaling (agent context, not archival).
 _MAX_FIGURE_EDGE_PX = 1024
 
@@ -155,17 +161,22 @@ def _read_task_statuses(scan_folder: Path) -> dict[str, dict]:
             display_files = document.get("display_files") or []
             if not isinstance(display_files, list):
                 display_files = []
-            statuses[entry.stem] = {
+            display_files = [name for name in display_files if isinstance(name, str)]
+            record = {
                 "state": document.get("state"),
                 "error": document.get("error"),
                 "claimed_by": document.get("claimed_by"),
                 "heartbeat_age_s": _heartbeat_age_s(
                     document.get("last_heartbeat"), now
                 ),
-                "display_files": [
-                    name for name in display_files if isinstance(name, str)
-                ],
+                # Payload budget (osprey-side audit ask, 2026-08-24): the
+                # writer owns this list's length; cap what one task can
+                # put into a tool answer.
+                "display_files": display_files[:_MAX_DISPLAY_FILES_PER_TASK],
             }
+            if len(display_files) > _MAX_DISPLAY_FILES_PER_TASK:
+                record["display_files_truncated"] = True
+            statuses[entry.stem] = record
         except Exception as exc:  # a torn write mid-heartbeat is not our error
             statuses[entry.stem] = {"state": "unreadable", "detail": str(exc)}
     return statuses
@@ -185,8 +196,14 @@ def _get_scan_analysis_impl(scan_number: int, day: str | None) -> str:
         )
     tasks = _read_task_statuses(scan_folder)
     outputs: dict[str, dict] = {}
+    outputs_truncated = False
     if analysis_folder.is_dir():
         for entry in sorted(analysis_folder.iterdir()):
+            if len(outputs) >= _MAX_OUTPUT_DIRS:
+                # Payload budget: a pathological analysis tree must not
+                # balloon the answer (osprey-side audit ask).
+                outputs_truncated = True
+                break
             if entry.is_dir():
                 # The production layout nests analyzer subdirs
                 # (Scan<NNN>/<device>/<Analyzer>/files) — a one-level
@@ -208,6 +225,7 @@ def _get_scan_analysis_impl(scan_number: int, day: str | None) -> str:
                 top["n_files"] += 1
                 if len(top["files"]) < _MAX_FILES_PER_DIR:
                     top["files"].append(entry.name)
+    extra = {"outputs_truncated": True} if outputs_truncated else {}
     return errors.make_ok(
         scan_number=int(scan_number),
         scan_folder=str(scan_folder),
@@ -215,6 +233,7 @@ def _get_scan_analysis_impl(scan_number: int, day: str | None) -> str:
         analysis_present=analysis_folder.is_dir(),
         tasks=tasks,
         outputs=outputs,
+        **extra,
     )
 
 
@@ -325,9 +344,9 @@ def _gather_figure_candidates(scan_folder: Path, analysis_folder: Path) -> list[
 
 
 def _relative_label(path: Path, analysis_folder: Path) -> str:
-    """A candidate's agent-facing name (relative to the analysis folder)."""
+    """A candidate's agent-facing name (relative, POSIX separators)."""
     try:
-        return str(path.relative_to(analysis_folder))
+        return path.relative_to(analysis_folder).as_posix()
     except ValueError:
         return path.name
 
@@ -337,9 +356,23 @@ def _relative_label(path: Path, analysis_folder: Path) -> str:
 #: refuses instead of decoding hundreds of MB in the server process.
 _MAX_FIGURE_PIXELS = 64_000_000
 
+#: Thumbnail bounds (the opt-in ``thumbnail=true`` return — the only
+#: path that puts image bytes through model context, so it is bounded
+#: hard: ≤768 px longest edge, JPEG q80 ≈ 30–60 KB for a matplotlib
+#: summary).  The first web-UI integration blew a haiku-tier context on
+#: a 247 KB inline PNG (osprey-side finding, 2026-08-24) — inline image
+#: content is never the default again.
+_THUMBNAIL_EDGE_PX = 768
+_THUMBNAIL_JPEG_QUALITY = 80
 
-def _load_downscaled_png(path: Path) -> bytes:
-    """The figure as PNG bytes, longest edge capped (context, not archive)."""
+#: Byte cap for the raw ``/figures/`` route (streams the original file,
+#: never through model context — the cap is a DoS guard, not a context
+#: budget).
+_MAX_ROUTE_FILE_BYTES = 50_000_000
+
+
+def _load_thumbnail_jpeg(path: Path) -> bytes:
+    """The figure as bounded JPEG bytes (model context, not archive)."""
     import io
 
     from PIL import Image as PILImage
@@ -351,19 +384,101 @@ def _load_downscaled_png(path: Path) -> bytes:
                 f"over the {_MAX_FIGURE_PIXELS / 1e6:.0f} MP decode cap"
             )
         image.load()
-        if max(image.size) > _MAX_FIGURE_EDGE_PX:
-            image.thumbnail((_MAX_FIGURE_EDGE_PX, _MAX_FIGURE_EDGE_PX))
-        if image.mode not in ("RGB", "RGBA", "L"):
+        if max(image.size) > _THUMBNAIL_EDGE_PX:
+            image.thumbnail((_THUMBNAIL_EDGE_PX, _THUMBNAIL_EDGE_PX))
+        if image.mode != "RGB":
             image = image.convert("RGB")
         buffer = io.BytesIO()
-        image.save(buffer, format="PNG")
+        image.save(buffer, format="JPEG", quality=_THUMBNAIL_JPEG_QUALITY)
         return buffer.getvalue()
 
 
-def _get_scan_figure_impl(scan_number: int, name: str | None, day: str | None):
-    """One figure as image content, or the candidate list to choose from."""
+def _day_string(tag) -> str:
+    """The resolved day as YYYY-MM-DD (the route's day segment)."""
+    return f"{int(tag.year):04d}-{int(tag.month):02d}-{int(tag.day):02d}"
+
+
+def _figure_url(day: str, scan_number: int, label: str) -> str:
+    """The SERVER-RELATIVE fetch URL for one figure.
+
+    Relative by design: the server binds 0.0.0.0 and cannot know its
+    advertised host, and baking an address into results would break the
+    planned service re-homing.  Clients resolve it against the MCP base
+    URL they already hold (the profile's ``url:`` minus the ``/mcp``
+    path).
+    """
+    from urllib.parse import quote
+
+    return f"/figures/{day}/{int(scan_number)}/{quote(label, safe='/')}"
+
+
+def _share_relative(path: Path) -> str:
+    r"""The path relative to the GEECS data root (POSIX), else absolute.
+
+    The *primary* file handle in tool results — never a ``Z:\\`` or
+    ``/mnt/`` form (osprey-side ask): clients resolve it against their
+    own mount of the share.
+    """
+    from geecs_data_utils import ScanPaths
+
+    base = _base_directory()
+    if base is None and ScanPaths.paths_config is not None:
+        base = ScanPaths.paths_config.base_path
+    if base is not None:
+        try:
+            return path.relative_to(Path(base).resolve()).as_posix()
+        except ValueError:
+            pass
+    return path.as_posix()
+
+
+def _figure_metadata(path: Path, label: str, day: str, scan_number: int) -> dict:
+    """One figure's reference record (no image bytes)."""
+    from PIL import Image as PILImage
+
+    width = height = None
     try:
-        _tag, scan_folder, analysis_folder = _resolve_folders(scan_number, day)
+        with PILImage.open(path) as image:  # header read only — no decode
+            width, height = image.width, image.height
+    except Exception:
+        logger.debug("figure header unreadable: %s", path, exc_info=True)
+    return {
+        "figure": label,
+        "day": day,
+        "scan_number": int(scan_number),
+        "share_relative_path": _share_relative(path),
+        "bytes": path.stat().st_size,
+        "width": width,
+        "height": height,
+        "figure_url": _figure_url(day, scan_number, label),
+    }
+
+
+def _candidate_listing(paths, analysis_folder: Path, day: str, scan_number: int):
+    """Compact reference entries for a candidate list (cheap stats only)."""
+    entries = []
+    for path in paths:
+        label = _relative_label(path, analysis_folder)
+        try:
+            size = path.stat().st_size
+        except OSError:
+            size = None
+        entries.append(
+            {
+                "figure": label,
+                "bytes": size,
+                "figure_url": _figure_url(day, scan_number, label),
+            }
+        )
+    return entries
+
+
+def _get_scan_figure_impl(
+    scan_number: int, name: str | None, day: str | None, thumbnail: bool
+):
+    """Figure reference (default) / bounded thumbnail / candidate list."""
+    try:
+        tag, scan_folder, analysis_folder = _resolve_folders(scan_number, day)
     except ValueError as exc:
         return errors.make_error("invalid_request", str(exc))
     except RuntimeError as exc:
@@ -379,6 +494,7 @@ def _get_scan_figure_impl(scan_number: int, name: str | None, day: str | None):
             f"no figures found for Scan{int(scan_number):03d} "
             f"(analysis folder: {analysis_folder})",
         )
+    resolved_day = _day_string(tag)
     labels = [_relative_label(path, analysis_folder) for path in candidates]
     if name is None:
         if len(candidates) == 1:
@@ -386,7 +502,9 @@ def _get_scan_figure_impl(scan_number: int, name: str | None, day: str | None):
         else:
             return errors.make_ok(
                 message="multiple figures — call again with name=<one of these>",
-                figures=labels,
+                figures=_candidate_listing(
+                    candidates, analysis_folder, resolved_day, scan_number
+                ),
             )
     else:
         matches = [
@@ -401,24 +519,91 @@ def _get_scan_figure_impl(scan_number: int, name: str | None, day: str | None):
         if len(matches) > 1:
             return errors.make_ok(
                 message=f"{name!r} is ambiguous — pick one",
-                figures=[_relative_label(p, analysis_folder) for p in matches],
+                figures=_candidate_listing(
+                    matches, analysis_folder, resolved_day, scan_number
+                ),
             )
         chosen = matches[0]
-    from fastmcp.utilities.types import Image
+    if thumbnail:
+        from fastmcp.utilities.types import Image
 
-    return Image(data=_load_downscaled_png(chosen), format="png")
+        return Image(data=_load_thumbnail_jpeg(chosen), format="jpeg")
+    meta = _figure_metadata(
+        chosen, _relative_label(chosen, analysis_folder), resolved_day, scan_number
+    )
+    return errors.make_ok(
+        message=(
+            "figure reference — fetch the full-resolution bytes from "
+            "figure_url (relative to the MCP server's base URL) or the "
+            "share_relative_path; pass thumbnail=true only when the "
+            "model itself needs to see it"
+        ),
+        **meta,
+    )
 
 
 @mcp.tool(name=tool_names.GET_SCAN_FIGURE)
 async def get_scan_figure(
-    scan_number: int, name: str | None = None, day: str | None = None
+    scan_number: int,
+    name: str | None = None,
+    day: str | None = None,
+    thumbnail: bool = False,
 ):
-    """Fetch one rendered analysis figure for a scan, as an image.
+    """Locate one rendered analysis figure for a scan.
 
-    With no ``name`` and exactly one figure, returns it; otherwise
-    returns the candidate list to pick from (``name`` matches by
-    substring of the listed path). Images are downscaled to ≤1024 px on
-    the longest edge — ask for the analysis folder path via
-    get_scan_analysis when the full-resolution file is needed.
+    Default return is a REFERENCE, not the image: the figure's name,
+    dimensions, byte size, its path relative to the GEECS data root,
+    and ``figure_url`` — a server-relative HTTP route serving the
+    original file bytes (resolve against the MCP base URL). Fetch the
+    URL and save it as a local artifact instead of pulling pixels
+    through the model. ``thumbnail=true`` returns a bounded preview
+    (≤768 px JPEG) as image content — use it only when the figure must
+    actually be looked at. With no ``name`` and several figures, the
+    candidate list (with URLs) comes back to pick from; ``name``
+    matches by substring.
     """
-    return await _run_guarded(_get_scan_figure_impl, scan_number, name, day)
+    return await _run_guarded(_get_scan_figure_impl, scan_number, name, day, thumbnail)
+
+
+async def _serve_figure_route(request):
+    """GET /figures/{day}/{scan_number}/{label:path} — the raw file bytes.
+
+    The fetch counterpart of ``get_scan_figure``'s ``figure_url``:
+    serves the ORIGINAL figure (it bypasses model context, so no
+    downscale), bounded by exactly the same candidate set as the tool —
+    only files the scan's own analysis folder legitimately offers, by
+    exact label match — plus a byte cap.  Registered on the FastMCP
+    app, so it is live under ``--transport http`` and simply never
+    reachable over stdio.  Never raises: every failure is a plain
+    status response.
+    """
+    from starlette.responses import FileResponse, PlainTextResponse
+
+    try:
+        day = request.path_params["day"]
+        try:
+            scan_number = int(request.path_params["scan_number"])
+        except (TypeError, ValueError):
+            return PlainTextResponse("scan_number must be an integer", status_code=400)
+        label = request.path_params["label"]
+        try:
+            tag, scan_folder, analysis_folder = _resolve_folders(scan_number, day)
+        except (ValueError, RuntimeError) as exc:
+            return PlainTextResponse(str(exc), status_code=400)
+        if not scan_folder.is_dir():
+            return PlainTextResponse("no such scan", status_code=404)
+        for path in _gather_figure_candidates(scan_folder, analysis_folder):
+            if _relative_label(path, analysis_folder) == label:
+                if path.stat().st_size > _MAX_ROUTE_FILE_BYTES:
+                    return PlainTextResponse("figure too large", status_code=413)
+                media = "image/png" if path.suffix.lower() == ".png" else "image/jpeg"
+                return FileResponse(path, media_type=media)
+        return PlainTextResponse("no such figure", status_code=404)
+    except Exception:
+        logger.exception("figure route failed")
+        return PlainTextResponse("internal error", status_code=500)
+
+
+mcp.custom_route("/figures/{day}/{scan_number}/{label:path}", methods=["GET"])(
+    _serve_figure_route
+)

--- a/GEECS-MCP/geecs_mcp/analysis/read_tools.py
+++ b/GEECS-MCP/geecs_mcp/analysis/read_tools.py
@@ -50,9 +50,6 @@ _MAX_FIGURE_CANDIDATES = 60
 _MAX_DISPLAY_FILES_PER_TASK = 20
 _MAX_OUTPUT_DIRS = 40
 
-#: Longest image edge after downscaling (agent context, not archival).
-_MAX_FIGURE_EDGE_PX = 1024
-
 _IMAGE_SUFFIXES = (".png", ".jpg", ".jpeg")
 
 
@@ -329,6 +326,9 @@ def _gather_figure_candidates(scan_folder: Path, analysis_folder: Path) -> list[
             # PR).  Skip the entry, never the tool.
             logger.warning("figure candidate unreadable, skipped: %s", path)
 
+    # NOTE: the statuses' display_files lists arrive payload-capped (20
+    # per task) — the cap deliberately bounds discovery here too; a
+    # figure past the cap is still found by the tree scan below.
     for status in _read_task_statuses(scan_folder).values():
         for name in status.get("display_files") or []:
             localized = _localize_display_entry(str(name), analysis_folder)
@@ -344,9 +344,21 @@ def _gather_figure_candidates(scan_folder: Path, analysis_folder: Path) -> list[
 
 
 def _relative_label(path: Path, analysis_folder: Path) -> str:
-    """A candidate's agent-facing name (relative, POSIX separators)."""
+    """A candidate's agent-facing name (relative, POSIX separators).
+
+    Candidates arrive RESOLVED (``_add`` resolves before bounding), so
+    the folder must be resolved too before ``relative_to`` — with a
+    symlinked base path, an unresolved folder would fail every
+    ``relative_to`` and collapse all labels to colliding basenames
+    (#687 review finding 3: the route's exact match would then serve
+    the first collision — wrong bytes under the right name).
+    """
     try:
-        return path.relative_to(analysis_folder).as_posix()
+        root = analysis_folder.resolve()
+    except OSError:
+        root = analysis_folder
+    try:
+        return path.relative_to(root).as_posix()
     except ValueError:
         return path.name
 
@@ -437,17 +449,19 @@ def _figure_metadata(path: Path, label: str, day: str, scan_number: int) -> dict
     from PIL import Image as PILImage
 
     width = height = None
+    size = None
     try:
+        size = path.stat().st_size
         with PILImage.open(path) as image:  # header read only — no decode
             width, height = image.width, image.height
-    except Exception:
+    except Exception:  # a vanished/unreadable file degrades the fields
         logger.debug("figure header unreadable: %s", path, exc_info=True)
     return {
         "figure": label,
         "day": day,
         "scan_number": int(scan_number),
         "share_relative_path": _share_relative(path),
-        "bytes": path.stat().st_size,
+        "bytes": size,
         "width": width,
         "height": height,
         "figure_url": _figure_url(day, scan_number, label),
@@ -565,6 +579,27 @@ async def get_scan_figure(
     return await _run_guarded(_get_scan_figure_impl, scan_number, name, day, thumbnail)
 
 
+def _locate_figure(day: str, scan_number: int, label: str):
+    """The route's SYNC lookup: ``(status_code, detail)`` or a file Path.
+
+    Runs in a worker thread (see :func:`_serve_figure_route`) — every
+    filesystem touch here can hang on the share's mount timeout, and
+    must never do so on the event loop.
+    """
+    try:
+        _tag, scan_folder, analysis_folder = _resolve_folders(scan_number, day)
+    except (ValueError, RuntimeError) as exc:
+        return (400, str(exc))
+    if not scan_folder.is_dir():
+        return (404, "no such scan")
+    for path in _gather_figure_candidates(scan_folder, analysis_folder):
+        if _relative_label(path, analysis_folder) == label:
+            if path.stat().st_size > _MAX_ROUTE_FILE_BYTES:
+                return (413, "figure too large")
+            return path
+    return (404, "no such figure")
+
+
 async def _serve_figure_route(request):
     """GET /figures/{day}/{scan_number}/{label:path} — the raw file bytes.
 
@@ -572,11 +607,20 @@ async def _serve_figure_route(request):
     serves the ORIGINAL figure (it bypasses model context, so no
     downscale), bounded by exactly the same candidate set as the tool —
     only files the scan's own analysis folder legitimately offers, by
-    exact label match — plus a byte cap.  Registered on the FastMCP
-    app, so it is live under ``--transport http`` and simply never
-    reachable over stdio.  Never raises: every failure is a plain
+    exact label match — plus a byte cap.  The label is only ever
+    COMPARED against candidate labels, never used to build a path, so
+    traversal sequences can only fail to match.  Registered on the
+    FastMCP app, so it is live under ``--transport http`` and simply
+    never reachable over stdio.  Never raises: every failure is a plain
     status response.
+
+    The share lookup runs via ``anyio.to_thread`` — fastmcp runs async
+    endpoints directly on the event loop, and one hung NFS stat here
+    would otherwise stall EVERY request on the server, including the
+    halt verbs (#687 review finding 1; the tools already thread via
+    ``_run_guarded``).
     """
+    import anyio.to_thread
     from starlette.responses import FileResponse, PlainTextResponse
 
     try:
@@ -586,19 +630,14 @@ async def _serve_figure_route(request):
         except (TypeError, ValueError):
             return PlainTextResponse("scan_number must be an integer", status_code=400)
         label = request.path_params["label"]
-        try:
-            tag, scan_folder, analysis_folder = _resolve_folders(scan_number, day)
-        except (ValueError, RuntimeError) as exc:
-            return PlainTextResponse(str(exc), status_code=400)
-        if not scan_folder.is_dir():
-            return PlainTextResponse("no such scan", status_code=404)
-        for path in _gather_figure_candidates(scan_folder, analysis_folder):
-            if _relative_label(path, analysis_folder) == label:
-                if path.stat().st_size > _MAX_ROUTE_FILE_BYTES:
-                    return PlainTextResponse("figure too large", status_code=413)
-                media = "image/png" if path.suffix.lower() == ".png" else "image/jpeg"
-                return FileResponse(path, media_type=media)
-        return PlainTextResponse("no such figure", status_code=404)
+        located = await anyio.to_thread.run_sync(
+            _locate_figure, day, scan_number, label
+        )
+        if isinstance(located, tuple):
+            status, detail = located
+            return PlainTextResponse(detail, status_code=status)
+        media = "image/png" if located.suffix.lower() == ".png" else "image/jpeg"
+        return FileResponse(located, media_type=media)
     except Exception:
         logger.exception("figure route failed")
         return PlainTextResponse("internal error", status_code=500)

--- a/GEECS-MCP/geecs_mcp/server.py
+++ b/GEECS-MCP/geecs_mcp/server.py
@@ -34,8 +34,11 @@ mcp = FastMCP(
         "scan needs force=true and an operator's say-so), clear_queue "
         "(the only remover), scan_progress. Analysis domain: "
         "get_scan_analysis (task statuses + output tree) and "
-        "get_scan_figure (a rendered summary figure as an image). Names "
-        "must come from list_scan_configs — never invent catalog names."
+        "get_scan_figure (a figure REFERENCE — metadata plus a fetch "
+        "URL served by this same server; thumbnail=true for a bounded "
+        "inline preview, never pull full figures through context). "
+        "Names must come from list_scan_configs — never invent catalog "
+        "names."
     ),
 )
 

--- a/GEECS-MCP/pyproject.toml
+++ b/GEECS-MCP/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-mcp"
-version = "0.5.1"
+version = "0.6.0"
 description = "MCP server exposing GEECS scan submission, monitoring, and config discovery to AI agents (OSPREY)"
 authors = ["Sam Barber <sbarber@lbl.gov>"]
 readme = "README.md"

--- a/GEECS-MCP/pyproject.toml
+++ b/GEECS-MCP/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-mcp"
-version = "0.5.0"
+version = "0.5.1"
 description = "MCP server exposing GEECS scan submission, monitoring, and config discovery to AI agents (OSPREY)"
 authors = ["Sam Barber <sbarber@lbl.gov>"]
 readme = "README.md"

--- a/GEECS-MCP/tests/test_analysis_tools.py
+++ b/GEECS-MCP/tests/test_analysis_tools.py
@@ -85,6 +85,40 @@ def _mtimes(root: Path) -> set:
     return {(p, p.stat().st_mtime_ns) for p in root.rglob("*")}
 
 
+def test_payload_caps_truncate_with_explicit_flags(share):
+    # The 0.6.0 payload budgets (#687 review finding 4: the caps shipped
+    # untested): >20 display_files per task and >40 output dirs both
+    # truncate WITH a flag — never silently.
+    scan_folder, analysis_folder = _tree_paths(share)
+    many = [f"/somewhere/fig_{i:03d}.png" for i in range(30)]
+    (scan_folder / "analysis_status" / "prolific.yaml").write_text(
+        yaml.safe_dump({"state": "done", "display_files": many})
+    )
+    for i in range(45):
+        (analysis_folder / f"Device_{i:02d}").mkdir()
+    result = _load(read_tools._get_scan_analysis_impl(7, DAY))
+    prolific = result["tasks"]["prolific"]
+    assert len(prolific["display_files"]) == read_tools._MAX_DISPLAY_FILES_PER_TASK
+    assert prolific["display_files_truncated"] is True
+    # An un-truncated task carries no flag.
+    assert "display_files_truncated" not in result["tasks"]["topview_baseline"]
+    assert len(result["outputs"]) == read_tools._MAX_OUTPUT_DIRS
+    assert result["outputs_truncated"] is True
+
+
+def test_route_label_is_compared_never_pathed(share):
+    # Pin the comparison-only property directly (#687 review: the
+    # TestClient ".." probe is neutered by httpx URL normalization) —
+    # a crafted traversal label reaching the handler can only fail to
+    # match a candidate, never address a file.
+    located = read_tools._locate_figure(DAY, 7, "../escape.png")
+    assert located == (404, "no such figure")
+    located = read_tools._locate_figure(DAY, 7, "/etc/passwd")
+    assert located == (404, "no such figure")
+    located = read_tools._locate_figure(DAY, 7, "UC_TopView/summary.png")
+    assert isinstance(located, Path) and located.name == "summary.png"
+
+
 def test_outputs_walk_the_nested_analyzer_tree(share):
     # The production layout is Scan<NNN>/<device>/<Analyzer>/files (live
     # deployment finding 2026-08-24: a one-level listing read every

--- a/GEECS-MCP/tests/test_analysis_tools.py
+++ b/GEECS-MCP/tests/test_analysis_tools.py
@@ -85,6 +85,59 @@ def _mtimes(root: Path) -> set:
     return {(p, p.stat().st_mtime_ns) for p in root.rglob("*")}
 
 
+def test_outputs_walk_the_nested_analyzer_tree(share):
+    # The production layout is Scan<NNN>/<device>/<Analyzer>/files (live
+    # deployment finding 2026-08-24: a one-level listing read every
+    # device dir as n_files: 0).
+    _, analysis_folder = _tree_paths(share)
+    nested = analysis_folder / "U_BCaveMagSpec" / "Array1DScanAnalyzer"
+    nested.mkdir(parents=True)
+    (nested / "waterfall.png").write_bytes(b"not-a-real-png")
+    (nested / "per_shot.csv").write_text("a\n1\n")
+    result = _load(read_tools._get_scan_analysis_impl(7, DAY))
+    magspec = result["outputs"]["U_BCaveMagSpec"]
+    assert magspec["n_files"] == 2
+    assert "Array1DScanAnalyzer/waterfall.png" in magspec["files"]
+
+
+def test_windows_display_files_localize_and_serve(share):
+    # Production statuses are written by the WINDOWS analysis machines:
+    # display_files carry Z:\...\analysis\Scan<NNN>\... paths.  On the
+    # Linux service host these must re-root onto the local analysis
+    # folder — the live deployment crashed on the raw entry (2026-08-24).
+    from PIL import Image as PILImage
+
+    scan_folder, analysis_folder = _tree_paths(share)
+    win_dir = analysis_folder / "UC_Amp2" / "Array2DScanAnalyzer"
+    win_dir.mkdir(parents=True)
+    PILImage.new("RGB", (10, 10)).save(win_dir / "avg_visual.png")
+    win_entry = (
+        "Z:\\data\\Undulator\\Y2026\\08-Aug\\26_0822\\analysis\\Scan007"
+        "\\UC_Amp2\\Array2DScanAnalyzer\\avg_visual.png"
+    )
+    (scan_folder / "analysis_status" / "amp2.yaml").write_text(
+        yaml.safe_dump({"state": "done", "display_files": [win_entry]})
+    )
+    from fastmcp.utilities.types import Image
+
+    result = read_tools._get_scan_figure_impl(7, "avg_visual", DAY)
+    assert isinstance(result, Image)
+
+
+def test_unlocalizable_windows_entry_never_kills_the_tool(share):
+    # An entry with no analysis\Scan<NNN> tail (or any per-entry stat
+    # blow-up) is skipped — the tree-scan fallback must still serve
+    # (the live crash aborted candidate gathering entirely).
+    scan_folder, _ = _tree_paths(share)
+    (scan_folder / "analysis_status" / "weird.yaml").write_text(
+        yaml.safe_dump({"state": "done", "display_files": ["C:\\Temp\\oddball.png"]})
+    )
+    from fastmcp.utilities.types import Image
+
+    result = read_tools._get_scan_figure_impl(7, "summary", DAY)
+    assert isinstance(result, Image)
+
+
 # ---------------------------------------------------------------------------
 # get_scan_analysis
 # ---------------------------------------------------------------------------

--- a/GEECS-MCP/tests/test_analysis_tools.py
+++ b/GEECS-MCP/tests/test_analysis_tools.py
@@ -118,10 +118,9 @@ def test_windows_display_files_localize_and_serve(share):
     (scan_folder / "analysis_status" / "amp2.yaml").write_text(
         yaml.safe_dump({"state": "done", "display_files": [win_entry]})
     )
-    from fastmcp.utilities.types import Image
-
-    result = read_tools._get_scan_figure_impl(7, "avg_visual", DAY)
-    assert isinstance(result, Image)
+    result = _load(read_tools._get_scan_figure_impl(7, "avg_visual", DAY, False))
+    assert result["ok"]
+    assert result["figure"] == "UC_Amp2/Array2DScanAnalyzer/avg_visual.png"
 
 
 def test_unlocalizable_windows_entry_never_kills_the_tool(share):
@@ -132,10 +131,8 @@ def test_unlocalizable_windows_entry_never_kills_the_tool(share):
     (scan_folder / "analysis_status" / "weird.yaml").write_text(
         yaml.safe_dump({"state": "done", "display_files": ["C:\\Temp\\oddball.png"]})
     )
-    from fastmcp.utilities.types import Image
-
-    result = read_tools._get_scan_figure_impl(7, "summary", DAY)
-    assert isinstance(result, Image)
+    result = _load(read_tools._get_scan_figure_impl(7, "summary", DAY, False))
+    assert result["ok"] and result["figure"] == "UC_TopView/summary.png"
 
 
 def test_localize_display_entry_unit_contract(share):
@@ -181,10 +178,8 @@ def test_pathological_entries_hit_the_guard_not_the_tool(share):
     (scan_folder / "analysis_status" / "pathological.yaml").write_text(
         yaml.safe_dump({"state": "done", "display_files": [giant, nullbyte]})
     )
-    from fastmcp.utilities.types import Image
-
-    result = read_tools._get_scan_figure_impl(7, "summary", DAY)
-    assert isinstance(result, Image)
+    result = _load(read_tools._get_scan_figure_impl(7, "summary", DAY, False))
+    assert result["ok"] and result["figure"] == "UC_TopView/summary.png"
 
 
 # ---------------------------------------------------------------------------
@@ -284,17 +279,18 @@ def test_figure_candidates_bounded_to_the_scans_analysis_folder(
         )
     )
     for probe in ("secret", "other_secret", "raw_secret"):
-        result = _load(read_tools._get_scan_figure_impl(7, probe, DAY))
+        result = _load(read_tools._get_scan_figure_impl(7, probe, DAY, False))
         assert not result["ok"] and result["error_kind"] == "not_found", probe
 
 
-def test_figure_decode_cap_refuses_giant_images(share, monkeypatch):
+def test_figure_decode_cap_refuses_giant_thumbnails(share, monkeypatch):
     # The cap raises in the impl; at the tool layer the shared guard turns
     # it into an internal_error envelope (pinned separately) — here we pin
-    # that the cap actually fires before any full decode.
+    # that the cap fires before any full decode.  Only the thumbnail path
+    # decodes at all since 0.6.0 (the reference default reads headers).
     monkeypatch.setattr(read_tools, "_MAX_FIGURE_PIXELS", 100)
     with pytest.raises(ValueError, match="decode cap"):
-        read_tools._get_scan_figure_impl(7, "summary", DAY)
+        read_tools._get_scan_figure_impl(7, "summary", DAY, True)
 
 
 def test_analysis_bad_day_is_invalid_request(share):
@@ -313,15 +309,32 @@ def test_analysis_without_experiment_is_invalid_request(share, monkeypatch):
 # ---------------------------------------------------------------------------
 
 
-def test_single_figure_returns_downscaled_image(share):
+def test_single_figure_returns_a_reference_not_pixels(share):
+    # The 0.6.0 default: metadata + fetch URL, NO image content — a
+    # 247 KB inline PNG blew a haiku-tier agent context in the first
+    # web-UI integration (osprey-side finding, 2026-08-24).
+    result = _load(read_tools._get_scan_figure_impl(7, None, DAY, False))
+    assert result["ok"]
+    assert result["figure"] == "UC_TopView/summary.png"
+    assert result["day"] == DAY
+    assert result["width"] == 2000 and result["height"] == 500
+    assert result["bytes"] > 0
+    # Share-relative, POSIX, never an absolute /mnt or Z:\ handle.
+    assert result["share_relative_path"].startswith("TestExp/Y2026/")
+    assert not result["share_relative_path"].startswith("/")
+    # Server-relative fetch route.
+    assert result["figure_url"] == f"/figures/{DAY}/7/UC_TopView/summary.png"
+
+
+def test_thumbnail_returns_bounded_jpeg(share):
     from fastmcp.utilities.types import Image
     from PIL import Image as PILImage
 
-    result = read_tools._get_scan_figure_impl(7, None, DAY)
+    result = read_tools._get_scan_figure_impl(7, None, DAY, True)
     assert isinstance(result, Image)
     with PILImage.open(io.BytesIO(result.data)) as image:
-        assert max(image.size) <= read_tools._MAX_FIGURE_EDGE_PX
-        assert image.format == "PNG"
+        assert max(image.size) <= read_tools._THUMBNAIL_EDGE_PX
+        assert image.format == "JPEG"
 
 
 def test_multiple_figures_list_candidates(share):
@@ -329,20 +342,40 @@ def test_multiple_figures_list_candidates(share):
 
     _, analysis_folder = _tree_paths(share)
     PILImage.new("RGB", (10, 10)).save(analysis_folder / "UC_TopView" / "extra.png")
-    result = _load(read_tools._get_scan_figure_impl(7, None, DAY))
-    assert result["ok"] and sorted(result["figures"]) == [
-        "UC_TopView/extra.png",
-        "UC_TopView/summary.png",
-    ]
+    result = _load(read_tools._get_scan_figure_impl(7, None, DAY, False))
+    assert result["ok"]
+    labels = sorted(f["figure"] for f in result["figures"])
+    assert labels == ["UC_TopView/extra.png", "UC_TopView/summary.png"]
+    for entry in result["figures"]:
+        assert entry["figure_url"].startswith(f"/figures/{DAY}/7/")
+        assert entry["bytes"] > 0
 
-    picked = read_tools._get_scan_figure_impl(7, "extra", DAY)
-    from fastmcp.utilities.types import Image
+    picked = _load(read_tools._get_scan_figure_impl(7, "extra", DAY, False))
+    assert picked["ok"] and picked["figure"] == "UC_TopView/extra.png"
 
-    assert isinstance(picked, Image)
+
+def test_figure_route_serves_the_original_bytes(share):
+    from starlette.testclient import TestClient
+
+    from geecs_mcp.server import create_server
+
+    app = create_server().http_app()
+    with TestClient(app) as client:
+        r = client.get(f"/figures/{DAY}/7/UC_TopView/summary.png")
+        assert r.status_code == 200
+        assert r.headers["content-type"].startswith("image/png")
+        original = (_tree_paths(share)[1] / "UC_TopView" / "summary.png").read_bytes()
+        assert r.content == original  # ORIGINAL bytes — no downscale
+        # Only labels the candidate set offers are served.
+        assert client.get(f"/figures/{DAY}/7/UC_TopView/results.csv").status_code == 404
+        # The client URL-normalizes ".." into a malformed scan segment —
+        # either way it must be a clean 4xx, never a 500 or a file.
+        assert client.get(f"/figures/{DAY}/7/../escape.png").status_code in (400, 404)
+        assert client.get("/figures/not-a-day/7/x.png").status_code == 400
 
 
 def test_figure_no_match_names_the_available(share):
-    result = _load(read_tools._get_scan_figure_impl(7, "nope", DAY))
+    result = _load(read_tools._get_scan_figure_impl(7, "nope", DAY, False))
     assert not result["ok"] and result["error_kind"] == "not_found"
     assert "summary.png" in result["message"]
 
@@ -354,7 +387,7 @@ def test_no_figures_is_not_found(share):
     (scan_folder / "analysis_status" / "topview_baseline.yaml").write_text(
         yaml.safe_dump({"state": "done", "display_files": []})
     )
-    result = _load(read_tools._get_scan_figure_impl(7, None, DAY))
+    result = _load(read_tools._get_scan_figure_impl(7, None, DAY, False))
     assert not result["ok"] and result["error_kind"] == "not_found"
 
 

--- a/GEECS-MCP/tests/test_analysis_tools.py
+++ b/GEECS-MCP/tests/test_analysis_tools.py
@@ -138,6 +138,55 @@ def test_unlocalizable_windows_entry_never_kills_the_tool(share):
     assert isinstance(result, Image)
 
 
+def test_localize_display_entry_unit_contract(share):
+    # The localization itself, asserted directly (verify pass on this
+    # PR: the end-to-end tests could not tell "localized and served"
+    # from "dropped and rescued by the tree fallback").
+    _, analysis_folder = _tree_paths(share)
+    win = (
+        "Z:\\data\\Undulator\\Y2026\\08-Aug\\26_0822\\analysis\\Scan007"
+        "\\UC_Amp2\\Array2DScanAnalyzer\\avg_visual.png"
+    )
+    localized = read_tools._localize_display_entry(win, analysis_folder)
+    assert (
+        localized
+        == analysis_folder / "UC_Amp2" / "Array2DScanAnalyzer" / "avg_visual.png"
+    )
+    # No analysis\Scan<NNN> tail -> None (skipped, warned).
+    assert (
+        read_tools._localize_display_entry("C:\\Temp\\oddball.png", analysis_folder)
+        is None
+    )
+    # A POSIX entry passes through untouched.
+    posix = str(analysis_folder / "UC_TopView" / "summary.png")
+    assert read_tools._localize_display_entry(posix, analysis_folder) == Path(posix)
+
+
+def test_pathological_entries_hit_the_guard_not_the_tool(share):
+    # The guard itself (verify pass on this PR — the earlier fixtures
+    # were too tame to raise on a local fs):
+    # 1. a localized tail whose filename exceeds NAME_MAX -> the stat
+    #    raises ENAMETOOLONG (the live crash's mechanism, reproducible
+    #    on any fs);
+    # 2. an embedded null byte -> resolve() raises ValueError, which the
+    #    original except OSError let through (review finding).
+    # Both must skip the entry; the tree fallback must still serve.
+    scan_folder, _ = _tree_paths(share)
+    giant = (
+        "Z:\\data\\Undulator\\Y2026\\08-Aug\\26_0822\\analysis\\Scan007\\"
+        + "x" * 300
+        + ".png"
+    )
+    nullbyte = "evil\x00name.png"
+    (scan_folder / "analysis_status" / "pathological.yaml").write_text(
+        yaml.safe_dump({"state": "done", "display_files": [giant, nullbyte]})
+    )
+    from fastmcp.utilities.types import Image
+
+    result = read_tools._get_scan_figure_impl(7, "summary", DAY)
+    assert isinstance(result, Image)
+
+
 # ---------------------------------------------------------------------------
 # get_scan_analysis
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
**Stacked on #684** (0.5.1 live fixes) — merge that first; this contains it.

Integration finding from the first osprey web-UI test (reported by the osprey-side session, verified against the live service): `get_scan_figure`'s inline PNG return (247 KB → 337k base64 chars) forced context compaction on the deployment's haiku-tier agent. Direction per the osprey side: references + artifacts, not smaller inline images.

## Changes (GEECS-MCP 0.6.0)

- **`get_scan_figure` default = a reference, not pixels**: figure label, dimensions (header read, no decode), byte size, share-relative POSIX path (never a `Z:\` or `/mnt/` primary handle), and `figure_url`. Candidate/ambiguity listings carry the same reference entries.
- **`thumbnail=true`** opts into bounded inline image content: ≤768 px longest edge, JPEG q80 (~30–60 KB for a matplotlib summary) — the only decode path, still behind the 64 MP cap.
- **New `GET /figures/{day}/{scan_number}/{label}`** custom route on the same FastMCP HTTP app: streams the ORIGINAL file bytes (bypasses model context — the osprey bridge fetches and saves as a local artifact). Bounded by exactly the tool's candidate set (the scan's-own-analysis-folder security bound from the #681 codex review, exact label match) + a 50 MB byte cap; clean 4xx on bad inputs, never a 500 for malformed paths; unreachable over stdio by construction. `figure_url` is **server-relative by design** — clients resolve against the MCP base URL they already hold, so no advertised host is baked into results and the planned service re-homing stays client-config-only (osprey side confirmed this works for their bridge).
- **Payload budgets on `get_scan_analysis`**: 20 `display_files` per task, 40 output dirs, explicit `*_truncated` flags — truncation never silent.

95 tests pass (new pins: reference shape incl. share-relative path + URL, bounded JPEG thumbnail, route serves original bytes / 404 non-candidates / 4xx malformed, truncation flags). Live verification on the deployed service + the osprey bridge test ride this PR — the osprey-side session adds its fetch-and-save skill once the route is live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)