### PR TITLE
GEECS-Console 0.24.1: adopt shared resolver listings + schema shot-count derivation (#679)

### DIFF
--- a/GEECS-Console/CHANGELOG.md
+++ b/GEECS-Console/CHANGELOG.md
@@ -4,6 +4,32 @@ All notable changes to GEECS-Console are documented here.  Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versioning is
 semantic.
 
+## [0.24.1] - 2026-08-24
+
+### Changed
+
+- **Config listings consume the shared resolver** (issue #679, the
+  deferred half of #666): `ConsoleConfigs.listing()` and
+  `NamedConfigStore.list_names()` (presets / save sets / trigger
+  profiles, via the new `RESOLVER_LISTING` class attribute) delegate to
+  `ConfigsRepoResolver.list_save_sets()/list_trigger_profiles()/
+  list_presets()/list_optimizer_configs()` — the one folder-scan
+  implementation every queue client shares.  The console's duplicated
+  folder constants (`SAVE_SET_FOLDER`, `TRIGGER_FOLDER`,
+  `OPTIMIZATION_FOLDER`) and the local `yaml_stems` helper are deleted;
+  folder names come from the resolver's class constants
+  (`ConfigsRepoResolver.OPTIMIZER_FOLDER` — no third name).  Listing
+  behavior is identical (sorted stems, both suffixes, missing → empty),
+  and an I/O failure mid-scan now reads as an empty listing instead of
+  a raise (the resolver's never-raise contract — the console's listing
+  docstring always promised this).
+- **The R3 shot-count label uses the schema's derivation** (issue #679,
+  the #671 follow-up): `request_builder._position_count` is deleted;
+  `estimate_total_shots` counts axis positions via the schema's
+  `Positions.n_positions()` — the same never-materializing arithmetic
+  behind `ScanRequest.planned_shots()`, retiring the third parallel
+  derivation.
+
 ## [0.24.0] - 2026-08-21
 
 ### Changed

--- a/GEECS-Console/CHANGELOG.md
+++ b/GEECS-Console/CHANGELOG.md
@@ -20,9 +20,11 @@ semantic.
   folder names come from the resolver's class constants
   (`ConfigsRepoResolver.OPTIMIZER_FOLDER` — no third name).  Listing
   behavior is identical (sorted stems, both suffixes, missing → empty),
-  and an I/O failure mid-scan now reads as an empty listing instead of
-  a raise (the resolver's never-raise contract — the console's listing
-  docstring always promised this).
+  and an I/O failure anywhere in the listing surface — the kind folders
+  (via the resolver's never-raise contract) and the experiments
+  enumeration (now guarded too) — reads as an empty listing plus a
+  status message instead of a raise, which the listing docstring always
+  promised.
 - **The R3 shot-count label uses the schema's derivation** (issue #679,
   the #671 follow-up): `request_builder._position_count` is deleted;
   `estimate_total_shots` counts axis positions via the schema's

--- a/GEECS-Console/geecs_console/request_builder.py
+++ b/GEECS-Console/geecs_console/request_builder.py
@@ -150,26 +150,6 @@ class ConsoleFormState(BaseModel):
     max_iterations: Optional[int] = Field(None, ge=0)
 
 
-def _position_count(positions: Positions) -> int:
-    """Count the positions without materializing them (guard-safe).
-
-    Parameters
-    ----------
-    positions : PositionRange or PositionList
-        The schema positions object.
-
-    Returns
-    -------
-    int
-        How many positions the axis visits (matches
-        ``PositionRange.to_values``'s reference derivation).
-    """
-    if isinstance(positions, PositionList):
-        return len(positions.values)
-    span = positions.end - positions.start
-    return int(abs(span) / abs(positions.step) + 1e-9) + 1
-
-
 def estimate_total_shots(form: ConsoleFormState) -> int:
     """Compute the total shot count the form implies (the live R3 label).
 
@@ -182,10 +162,14 @@ def estimate_total_shots(form: ConsoleFormState) -> int:
     -------
     int
         ``shots_per_step`` times the product of the axis position counts
-        (1 for noscan/background).  Optimization mode multiplies by
-        ``max_iterations`` when set — the engine's announced upper bound —
-        and falls back to one iteration's worth when unset ("auto": the
-        window renders that case as such rather than as a count).
+        (1 for noscan/background).  Axis counts come from the schema's
+        ``Positions.n_positions()`` — the same never-materializing
+        derivation behind ``ScanRequest.planned_shots()``, so the live
+        label and the submitted request can never disagree.  Optimization
+        mode multiplies by ``max_iterations`` when set — the engine's
+        announced upper bound — and falls back to one iteration's worth
+        when unset ("auto": the window renders that case as such rather
+        than as a count).
 
     Raises
     ------
@@ -198,7 +182,7 @@ def estimate_total_shots(form: ConsoleFormState) -> int:
         return form.shots_per_step
     total = form.shots_per_step
     for axis in form.axes:
-        total *= _position_count(axis.to_positions())
+        total *= axis.to_positions().n_positions()
     return total
 
 

--- a/GEECS-Console/geecs_console/services/config_store.py
+++ b/GEECS-Console/geecs_console/services/config_store.py
@@ -7,10 +7,13 @@ trigger profiles, the scan-variable catalog, and the action library.
 selection, configs-root and folder resolution, the experiment-name guard,
 and safe YAML read/write with status-bar-ready errors.
 :class:`NamedConfigStore` adds the file-per-name surface (name validation,
-``.yml`` twin fallback, sorted listing, delete) the preset / save-set /
-trigger-profile trio share.  Each concrete store keeps its own error
-class, folder constants, and schema-specific load/save logic in its own
-module.
+``.yml`` twin fallback, delete) the preset / save-set / trigger-profile
+trio share; its listing delegates to ``ConfigsRepoResolver``'s public
+listing methods (the one folder-scan implementation, #666 — each subclass
+names its method via :attr:`NamedConfigStore.RESOLVER_LISTING`).  Each
+concrete store keeps its own error class and schema-specific load/save
+logic in its own module; folder names come from the resolver's class
+constants.
 
 Directory creation policy — the canonical statement for every store:
 creating a config directory with ``mkdir(parents=True, exist_ok=True)``
@@ -24,8 +27,8 @@ module namespace: every store module imports ``_configs_base`` from
 reads that binding at call time — so tests can monkeypatch
 ``<store module>._configs_base`` per store, exactly as before the
 extraction.  (This module deliberately does not import
-:mod:`~geecs_console.services.configs`, which imports :func:`yaml_stems`
-from here.)
+:mod:`~geecs_console.services.configs` — the dependency runs the other
+way for the ``_configs_base`` seam.)
 """
 
 from __future__ import annotations
@@ -44,26 +47,6 @@ _CONFIGS_REPO_MISSING = (
     "config.ini [Paths] scanner_config_root_path."
 )
 _NO_EXPERIMENT = "No experiment selected."
-
-
-def yaml_stems(folder: Path) -> list[str]:
-    """List the YAML file stems in *folder*, sorted; empty when absent.
-
-    Parameters
-    ----------
-    folder : Path
-        The directory to scan (need not exist).
-
-    Returns
-    -------
-    list of str
-        Sorted stems of the ``.yaml``/``.yml`` files in *folder*.
-    """
-    if not folder.is_dir():
-        return []
-    return sorted(
-        path.stem for path in folder.iterdir() if path.suffix in (".yaml", ".yml")
-    )
 
 
 class ExperimentConfigStore:
@@ -272,6 +255,10 @@ class NamedConfigStore(ExperimentConfigStore):
     LABEL: str
     """The message label for not-found/delete texts (e.g. ``"Trigger profile"``)."""
 
+    RESOLVER_LISTING: str
+    """The ``ConfigsRepoResolver`` listing method for this store's config kind
+    (e.g. ``"list_presets"``) — :meth:`list_names` delegates to it."""
+
     def _path(self, name: str) -> Path:
         """Return the YAML path for config *name*, validating the name.
 
@@ -335,6 +322,12 @@ class NamedConfigStore(ExperimentConfigStore):
     def list_names(self) -> list[str]:
         """List the saved config names, sorted.
 
+        Delegates the folder scan to ``ConfigsRepoResolver``'s public
+        listing method (:attr:`RESOLVER_LISTING`), built over the same
+        experiments root this store resolves — so the resolver scans
+        exactly the tree the store reads and writes, the
+        ``_configs_base`` monkeypatch seam included.
+
         Returns
         -------
         list of str
@@ -347,10 +340,12 @@ class NamedConfigStore(ExperimentConfigStore):
             The store's :attr:`ERROR` when the experiment name would escape
             the experiments root; a merely *missing* folder is not an error.
         """
-        folder = self._folder()
-        if folder is None:
+        if self._folder() is None:
             return []
-        return yaml_stems(folder)
+        from geecs_bluesky.config_resolver import ConfigsRepoResolver
+
+        resolver = ConfigsRepoResolver(self._experiment, experiments_root=self._root())
+        return getattr(resolver, self.RESOLVER_LISTING)()
 
     def delete(self, name: str) -> None:
         """Delete config *name*.

--- a/GEECS-Console/geecs_console/services/configs.py
+++ b/GEECS-Console/geecs_console/services/configs.py
@@ -1,12 +1,15 @@
 """Configs-repo listings for the console's combos and lists.
 
-Names come from scanning the configs-repo folders (the same roots
-``geecs_bluesky.scanner_configs`` resolves); validation happens on demand
-through ``ConfigsRepoResolver`` — listing is cheap and never parses YAML,
-resolving a specific name does.  Offline-safety is first-class: a missing
-configs root (or ``geecs-bluesky`` unimportable) degrades to empty listings
-plus a status message, never an exception out of this module's listing
-surface.
+Names come from ``ConfigsRepoResolver``'s listing surface (the resolver's
+``list_save_sets``/``list_trigger_profiles``/``list_optimizer_configs`` —
+the one implementation every queue client shares since #666); validation
+happens on demand through the same resolver — listing is cheap and never
+parses YAML, resolving a specific name does.  Offline-safety is
+first-class: a missing configs root (or ``geecs-bluesky`` unimportable)
+degrades to empty listings plus a status message, never an exception out
+of this module's listing surface.  Folder names come from the resolver's
+class constants (``ConfigsRepoResolver.OPTIMIZER_FOLDER`` etc.) — this
+module keeps no folder-name constants of its own.
 """
 
 from __future__ import annotations
@@ -16,14 +19,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Optional
 
-from geecs_console.services.config_store import yaml_stems
-
 logger = logging.getLogger(__name__)
-
-SAVE_SET_FOLDER = "save_devices"
-TRIGGER_FOLDER = "shot_control_configurations"
-#: Optimizer configs keep the legacy GEECS-Scanner-GUI folder name.
-OPTIMIZATION_FOLDER = "optimizer_configs"
 
 
 class ConsoleConfigsError(RuntimeError):
@@ -62,9 +58,20 @@ def _configs_base() -> Path | None:
         return None
 
 
-# The listing helper lives with the config-store base; the private name
-# stays bound here for this module's listing surface.
-_yaml_stems = yaml_stems
+def _listing_resolver(experiment: str, experiments_root: Path) -> Any:
+    """Build a ``ConfigsRepoResolver`` over *experiments_root*, or ``None``.
+
+    The explicit root keeps the listing coherent with the base this module
+    already resolved (and reports as ``configs_root``) — the resolver must
+    scan the same tree, monkeypatched ``_configs_base`` included.
+    """
+    try:
+        from geecs_bluesky.config_resolver import ConfigsRepoResolver
+
+        return ConfigsRepoResolver(experiment, experiments_root=experiments_root)
+    except Exception as exc:
+        logger.info("configs resolver unavailable: %s", exc)
+        return None
 
 
 class ConsoleConfigs:
@@ -133,12 +140,19 @@ class ConsoleConfigs:
                 configs_root=base,
                 message=f"No configs folder for experiment {self._experiment!r}.",
             )
+        resolver = _listing_resolver(self._experiment, base)
+        if resolver is None:
+            return ConfigListing(
+                experiments=experiments,
+                configs_root=base,
+                message="Configs resolver unavailable (geecs-bluesky import failed).",
+            )
         return ConfigListing(
             experiments=experiments,
-            save_sets=_yaml_stems(root / SAVE_SET_FOLDER),
-            trigger_profiles=_yaml_stems(root / TRIGGER_FOLDER),
+            save_sets=resolver.list_save_sets(),
+            trigger_profiles=resolver.list_trigger_profiles(),
             scan_variables=self._scan_variable_names(),
-            optimization_configs=_yaml_stems(root / OPTIMIZATION_FOLDER),
+            optimization_configs=resolver.list_optimizer_configs(),
             configs_root=base,
         )
 
@@ -263,7 +277,9 @@ class ConsoleConfigs:
             )
         if not self._experiment:
             raise ConsoleConfigsError("No experiment selected.")
-        folder = base / self._experiment / OPTIMIZATION_FOLDER
+        from geecs_bluesky.config_resolver import ConfigsRepoResolver
+
+        folder = base / self._experiment / ConfigsRepoResolver.OPTIMIZER_FOLDER
         path = folder / f"{name}.yaml"
         if not path.exists():
             twin = folder / f"{name}.yml"

--- a/GEECS-Console/geecs_console/services/configs.py
+++ b/GEECS-Console/geecs_console/services/configs.py
@@ -5,11 +5,12 @@ Names come from ``ConfigsRepoResolver``'s listing surface (the resolver's
 the one implementation every queue client shares since #666); validation
 happens on demand through the same resolver — listing is cheap and never
 parses YAML, resolving a specific name does.  Offline-safety is
-first-class: a missing configs root (or ``geecs-bluesky`` unimportable)
-degrades to empty listings plus a status message, never an exception out
-of this module's listing surface.  Folder names come from the resolver's
-class constants (``ConfigsRepoResolver.OPTIMIZER_FOLDER`` etc.) — this
-module keeps no folder-name constants of its own.
+first-class: a missing configs root, an I/O blip on a mounted share, or a
+resolver that cannot be built all degrade to empty listings plus a status
+message — never an exception out of this module's listing surface.
+Folder names come from the resolver's class constants
+(``ConfigsRepoResolver.OPTIMIZER_FOLDER`` etc.) — this module keeps no
+folder-name constants of its own.
 """
 
 from __future__ import annotations
@@ -126,7 +127,14 @@ class ConsoleConfigs:
                     "or config.ini [Paths] scanner_config_root_path."
                 )
             )
-        experiments = sorted(p.name for p in base.iterdir() if p.is_dir())
+        try:
+            experiments = sorted(p.name for p in base.iterdir() if p.is_dir())
+        except OSError as exc:  # I/O blip on a mounted share — degrade, never raise
+            logger.info("experiments listing failed: %s", exc)
+            return ConfigListing(
+                configs_root=base,
+                message=f"Configs repo unreadable ({base}): {exc}",
+            )
         if not self._experiment:
             return ConfigListing(
                 experiments=experiments,

--- a/GEECS-Console/geecs_console/services/presets.py
+++ b/GEECS-Console/geecs_console/services/presets.py
@@ -22,6 +22,9 @@ from pathlib import Path
 
 from pydantic import ValidationError
 
+# A light import chain (yaml + pydantic models) — safe at module level;
+# the folder name has one owner, the resolver's class constant.
+from geecs_bluesky.config_resolver import ConfigsRepoResolver
 from geecs_console.services.config_store import NamedConfigStore
 
 # The base resolves the configs root through this module's namespace, so
@@ -31,7 +34,7 @@ from geecs_schemas import ScanRequest
 
 logger = logging.getLogger(__name__)
 
-PRESET_FOLDER = "presets"
+PRESET_FOLDER = ConfigsRepoResolver.PRESET_FOLDER
 
 
 class PresetStoreError(RuntimeError):
@@ -45,6 +48,7 @@ class PresetStore(NamedConfigStore):
     NOUN = "Preset"
     LABEL = "Preset"
     ERROR = PresetStoreError
+    RESOLVER_LISTING = "list_presets"
 
     def load(self, name: str) -> ScanRequest:
         """Load preset *name* as a validated :class:`ScanRequest`.

--- a/GEECS-Console/geecs_console/services/save_set_store.py
+++ b/GEECS-Console/geecs_console/services/save_set_store.py
@@ -32,11 +32,14 @@ from pathlib import Path
 import yaml
 from pydantic import ValidationError
 
+# A light import chain (yaml + pydantic models) — safe at module level;
+# the folder name has one owner, the resolver's class constant.
+from geecs_bluesky.config_resolver import ConfigsRepoResolver
 from geecs_console.services.config_store import NamedConfigStore
 
 # The base resolves the configs root through this module's namespace, so
 # tests can monkeypatch ``save_set_store._configs_base``.
-from geecs_console.services.configs import SAVE_SET_FOLDER, _configs_base  # noqa: F401
+from geecs_console.services.configs import _configs_base  # noqa: F401
 from geecs_schemas import SaveSet
 
 logger = logging.getLogger(__name__)
@@ -49,10 +52,11 @@ class SaveSetStoreError(RuntimeError):
 class SaveSetStore(NamedConfigStore):
     """Load/save named save sets for one experiment."""
 
-    FOLDER = SAVE_SET_FOLDER
+    FOLDER = ConfigsRepoResolver.SAVE_SET_FOLDER
     NOUN = "Save set"
     LABEL = "Save set"
     ERROR = SaveSetStoreError
+    RESOLVER_LISTING = "list_save_sets"
 
     def _read_document(self, name: str, path: Path) -> dict:
         """Read one YAML mapping, with status-bar-ready errors.

--- a/GEECS-Console/geecs_console/services/trigger_profile_store.py
+++ b/GEECS-Console/geecs_console/services/trigger_profile_store.py
@@ -29,11 +29,14 @@ from pathlib import Path
 import yaml
 from pydantic import ValidationError
 
+# A light import chain (yaml + pydantic models) — safe at module level;
+# the folder name has one owner, the resolver's class constant.
+from geecs_bluesky.config_resolver import ConfigsRepoResolver
 from geecs_console.services.config_store import NamedConfigStore
 
 # The base resolves the configs root through this module's namespace, so
 # tests can monkeypatch ``trigger_profile_store._configs_base``.
-from geecs_console.services.configs import TRIGGER_FOLDER, _configs_base  # noqa: F401
+from geecs_console.services.configs import _configs_base  # noqa: F401
 from geecs_schemas import TriggerProfile
 from geecs_schemas.convert import SchemaConversionError, convert_shot_control
 
@@ -47,10 +50,11 @@ class TriggerProfileStoreError(RuntimeError):
 class TriggerProfileStore(NamedConfigStore):
     """Load/save named trigger profiles for one experiment."""
 
-    FOLDER = TRIGGER_FOLDER
+    FOLDER = ConfigsRepoResolver.TRIGGER_FOLDER
     NOUN = "Profile"
     LABEL = "Trigger profile"
     ERROR = TriggerProfileStoreError
+    RESOLVER_LISTING = "list_trigger_profiles"
 
     def _read_document(self, name: str) -> tuple[dict, Path]:
         """Read profile *name*'s raw YAML mapping (shared by load/is_legacy).

--- a/GEECS-Console/pyproject.toml
+++ b/GEECS-Console/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-console"
-version = "0.24.0"
+version = "0.24.1"
 description = "Greenfield PySide6 operator console for GEECS (Bluesky/gateway architecture)"
 authors = ["Sam Barber <sbarber@lbl.gov>"]
 readme = "README.md"

--- a/GEECS-Console/tests/test_configs_optimization.py
+++ b/GEECS-Console/tests/test_configs_optimization.py
@@ -3,12 +3,12 @@
 import pytest
 
 from geecs_console.services import configs as configs_module
-from geecs_console.services.configs import (
-    OPTIMIZATION_FOLDER,
-    ConsoleConfigs,
-    ConsoleConfigsError,
-)
+from geecs_console.services.configs import ConsoleConfigs, ConsoleConfigsError
 from geecs_schemas import OptimizationSpec
+
+# The on-disk contract (the resolver's OPTIMIZER_FOLDER) — a literal so the
+# test pins the actual folder name, not whatever the constant drifts to.
+OPTIMIZATION_FOLDER = "optimizer_configs"
 
 NEW_SCHEMA_YAML = """\
 variables:

--- a/GEECS-Console/tests/test_configs_optimization.py
+++ b/GEECS-Console/tests/test_configs_optimization.py
@@ -63,6 +63,17 @@ class TestListing:
         listing = ConsoleConfigs("Bella").listing()
         assert listing.optimization_configs == []
 
+    def test_unreadable_experiments_root_degrades_with_message(
+        self, tmp_path, monkeypatch
+    ):
+        """An I/O failure enumerating experiments degrades, never raises."""
+        missing = tmp_path / "not-there"
+        monkeypatch.setattr(configs_module, "_configs_base", lambda: missing)
+        listing = ConsoleConfigs("HTU").listing()
+        assert listing.experiments == []
+        assert listing.save_sets == []
+        assert "unreadable" in (listing.message or "")
+
 
 class TestOptimizationSpecLoading:
     def test_new_schema_document_loads_directly(self, configs_tree):

--- a/GEECS-Console/tests/test_presets.py
+++ b/GEECS-Console/tests/test_presets.py
@@ -12,6 +12,13 @@ from geecs_console.services.presets import PRESET_FOLDER, PresetStore, PresetSto
 from geecs_schemas import ScanRequest, ScanRequestMode
 
 
+def test_preset_folder_is_the_on_disk_contract() -> None:
+    """Pin the folder name as a literal: ``PRESET_FOLDER`` now binds to the
+    resolver's constant, so without this pin a rename there would leave every
+    suite green while deployed consoles list/write a different folder."""
+    assert PRESET_FOLDER == "presets"
+
+
 def one_d_request(variable="jet_x", description="") -> ScanRequest:
     return build_scan_request(
         ConsoleFormState(


### PR DESCRIPTION
Closes #679 — the two console-touching cleanups deferred by scope discipline during the MCP arc (the deferred halves of #666 and #671). Both are behavior-identical swaps; they ride together because the issue filed them as one bundle.

## What + why

**1. Listings rewire (#666's deferred half) — ~70 LOC across `services/`:**
- `ConsoleConfigs.listing()` and `NamedConfigStore.list_names()` now delegate to `ConfigsRepoResolver.list_save_sets()/list_trigger_profiles()/list_presets()/list_optimizer_configs()` — the one folder-scan implementation every queue client shares.
- The console's duplicated folder constants (`SAVE_SET_FOLDER`, `TRIGGER_FOLDER`, `OPTIMIZATION_FOLDER`) and the local `yaml_stems` helper are **deleted**; folder names come from the resolver's class constants (`ConfigsRepoResolver.OPTIMIZER_FOLDER` — per the issue's rename trap, no third name introduced).
- Listing semantics are identical (sorted stems, both suffixes, missing → empty). One deliberate improvement: an I/O failure mid-scan (SMB blip on a mounted configs share) now reads as an empty listing instead of raising — the resolver's never-raise contract, which `listing()`'s docstring always promised but the old `yaml_stems` path didn't deliver.
- The listing resolver is constructed over the **same experiments root the console resolved** (`experiments_root=base` / the store's `_root()`), so the `_configs_base` monkeypatch seam and `GEECS_SCANNER_CONFIG_DIR` stay coherent — a production-resolution resolver would silently scan a different tree than the one tests patch.

**2. Shot-count consolidation (#671's follow-up) — ~25 LOC in `request_builder.py`:**
- `_position_count` is deleted; `estimate_total_shots` counts axis positions via the schema's `Positions.n_positions()` (GEECS-Schemas 0.11.0) — the same never-materializing arithmetic behind `ScanRequest.planned_shots()`, retiring the third parallel derivation. No safety exposure: the console's counter was already arithmetic.

## Judgment calls (cheap to veto)

- **Module-level `from geecs_bluesky.config_resolver import ConfigsRepoResolver` in the three store modules** (needed for the `FOLDER` class attributes). The console CLAUDE.md permits light module-level geecs_bluesky imports (qs_client is already imported this way) and `config_resolver`'s chain is yaml + pydantic models only — no aioca. `services/configs.py` itself keeps its function-level import pattern per its CLAUDE.md note.
- `PRESET_FOLDER` in `presets.py` is kept as a name (tests import it) but now binds to the resolver's constant.
- `NamedConfigStore` gains a `RESOLVER_LISTING` class attribute naming each store's resolver listing method — the smallest seam I found for the trio to share one delegation.

## Tests

`./scripts/check.sh`: lint clean, **GEECS-Console: 785 passed** (0 failed, 0 skipped). The full `--all` tier was not run: this is a fresh worktree without the other packages' venvs provisioned, and nothing in the repo imports `geecs_console` (top of the dependency graph), so cross-package fallout is not possible from this diff. `tests/test_configs_optimization.py` now pins the optimizer folder name as a literal (the on-disk contract) instead of importing the deleted constant.

## Hardware verification

Not applicable — no scan-execution or device-path changes. The swapped listing surface is exercised headlessly by the existing suite (listing combos, preset round-trips, editor stores); behavior-identical by construction and by the 785-test run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)