### PR TITLE
GEECS-Core 0.3.0 + GeecsCAGateway 0.20.0: close the half-open-socket blind spot (#611)

### DIFF
--- a/GEECS-Core/CHANGELOG.md
+++ b/GEECS-Core/CHANGELOG.md
@@ -3,6 +3,27 @@
 All notable changes to `geecs-core` are documented here, following
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and semantic versioning.
 
+## [0.3.0] - 2026-08-24
+
+### Added
+
+- **TCP keepalive on `GeecsTcpSubscriber`, on by default** (issue #611 —
+  the half-open-socket blind spot; live incident 2026-08-17, u_s1h): the
+  subscription is read-only after the `Wait>>` command, so an ungracefully
+  dead peer (host crash, power cycle, a partition that eats the FIN/RST)
+  used to leave the listener waiting forever on a half-open socket, with
+  readbacks frozen at valid-stale values and no alarm.  With keepalive the
+  OS probes the idle peer and a dead one resets the connection, ending the
+  listener — the supervised-reconnect path.  Probes are answered by a live
+  peer's TCP stack even when its application is silent, so the "silence is
+  not a drop" doctrine is preserved.  New constructor knobs `keepalive`
+  (default True), `keepalive_idle_s` (30), `keepalive_interval_s` (10),
+  `keepalive_count` (3) — dead-peer detection in roughly a minute where
+  the platform exposes the tuning (Linux/macOS; a bare `SO_KEEPALIVE`
+  fallback with OS defaults elsewhere).  Tuning failures are logged and
+  never fail the connect.  Pinned by `test_keepalive_enabled_by_default` /
+  `test_keepalive_can_be_disabled`.
+
 ## [0.2.0] - 2026-08-20
 
 ### Added

--- a/GEECS-Core/geecs_core/transport/tcp_subscriber.py
+++ b/GEECS-Core/geecs_core/transport/tcp_subscriber.py
@@ -338,6 +338,12 @@ class GeecsTcpSubscriber:
             logger.debug("TCP connection closed by server")
         except asyncio.CancelledError:
             pass
+        except OSError as exc:
+            # The ungraceful peer-death path — e.g. ConnectionResetError from
+            # a keepalive-detected dead peer (#611) or an RST from a rebooted
+            # host.  Ordinary connection loss, not "unexpected": the caller's
+            # supervisor owns the once-per-episode down logging.
+            logger.info("TCP connection to %s:%s lost: %s", self._host, self._port, exc)
         except Exception:
             logger.exception("unexpected error in TCP listener")
 

--- a/GEECS-Core/geecs_core/transport/tcp_subscriber.py
+++ b/GEECS-Core/geecs_core/transport/tcp_subscriber.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import re
+import socket
 import struct
 from typing import Any, Callable, Awaitable, Collection, Sequence
 
@@ -32,6 +33,49 @@ from ._coerce import coerce_scalar
 logger = logging.getLogger(__name__)
 
 Callback = Callable[[dict[str, Any]], Awaitable[None] | None]
+
+
+def _apply_keepalive(
+    sock: socket.socket, idle_s: float, interval_s: float, count: int
+) -> None:
+    """Enable TCP keepalive on *sock*, tuned where the platform allows.
+
+    Why: the subscription is read-only after the ``Wait>>`` command, so the
+    OS never sends on it — an *ungracefully* dead peer (host crash, power
+    cycle, a partition that eats the FIN/RST) leaves a half-open socket the
+    listener waits on forever, with readbacks frozen at valid-stale values
+    (live incident 2026-08-17, u_s1h; issue #611).  Keepalive probes are
+    answered by the peer's TCP stack even when the application is silent,
+    so a legitimately idle GEECS device is never disturbed — only a truly
+    dead peer fails the probes, which surfaces as a connection reset ending
+    the listener (the supervised-reconnect path).
+
+    Tuning knobs are platform-guarded: ``TCP_KEEPIDLE`` (Linux, newer
+    Windows) / ``TCP_KEEPALIVE`` (macOS) for the idle time, then
+    ``TCP_KEEPINTVL`` / ``TCP_KEEPCNT`` where present.  Where only
+    ``SO_KEEPALIVE`` exists the OS defaults apply (typically ~2 h — still
+    strictly better than never).  A tuning failure is logged and ignored;
+    it must never fail the connect.
+    """
+    try:
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)
+    except OSError:
+        logger.warning("could not enable TCP keepalive", exc_info=True)
+        return
+    idle = max(1, round(idle_s))
+    interval = max(1, round(interval_s))
+    probes = max(1, int(count))
+    try:
+        if hasattr(socket, "TCP_KEEPIDLE"):
+            sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPIDLE, idle)
+        elif hasattr(socket, "TCP_KEEPALIVE"):  # macOS spelling of the idle knob
+            sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPALIVE, idle)
+        if hasattr(socket, "TCP_KEEPINTVL"):
+            sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPINTVL, interval)
+        if hasattr(socket, "TCP_KEEPCNT"):
+            sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPCNT, probes)
+    except OSError:
+        logger.warning("could not tune TCP keepalive timing", exc_info=True)
 
 
 def _compile_frame_pattern(variables: Sequence[str]) -> re.Pattern[str] | None:
@@ -80,6 +124,19 @@ class GeecsTcpSubscriber:
         Device TCP port (same as UDP port for GEECS devices).
     connect_timeout:
         Seconds allowed for the initial TCP connection.
+    keepalive:
+        Enable TCP keepalive on the connection (default True) — the OS
+        probes an idle peer, so an *ungracefully* dead one (host crash,
+        power cycle, FIN-eating partition) resets the connection instead
+        of leaving it half-open with the listener waiting forever (issue
+        #611).  Probes never disturb a live-but-quiet device, so the
+        "silence is not a drop" doctrine is preserved.
+    keepalive_idle_s, keepalive_interval_s, keepalive_count:
+        Probe timing where the platform exposes it (see
+        :func:`_apply_keepalive`): start probing after ``idle`` seconds of
+        silence, every ``interval`` seconds, declaring the peer dead after
+        ``count`` unanswered probes — defaults detect a dead peer in
+        roughly a minute.
     """
 
     def __init__(
@@ -87,10 +144,18 @@ class GeecsTcpSubscriber:
         host: str,
         port: int,
         connect_timeout: float = 5.0,
+        keepalive: bool = True,
+        keepalive_idle_s: float = 30.0,
+        keepalive_interval_s: float = 10.0,
+        keepalive_count: int = 3,
     ) -> None:
         self._host = host
         self._port = port
         self.connect_timeout = connect_timeout
+        self._keepalive = keepalive
+        self._keepalive_idle_s = keepalive_idle_s
+        self._keepalive_interval_s = keepalive_interval_s
+        self._keepalive_count = keepalive_count
 
         self._reader: asyncio.StreamReader | None = None
         self._writer: asyncio.StreamWriter | None = None
@@ -98,11 +163,20 @@ class GeecsTcpSubscriber:
         self._warned_missing_variables: set[str] = set()
 
     async def connect(self) -> None:
-        """Open the TCP connection."""
+        """Open the TCP connection (keepalive-enabled unless disabled)."""
         self._reader, self._writer = await asyncio.wait_for(
             asyncio.open_connection(self._host, self._port),
             timeout=self.connect_timeout,
         )
+        if self._keepalive:
+            sock = self._writer.get_extra_info("socket")
+            if sock is not None:
+                _apply_keepalive(
+                    sock,
+                    self._keepalive_idle_s,
+                    self._keepalive_interval_s,
+                    self._keepalive_count,
+                )
         logger.debug("TCP connected to %s:%s", self._host, self._port)
 
     async def close(self) -> None:

--- a/GEECS-Core/pyproject.toml
+++ b/GEECS-Core/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-core"
-version = "0.2.0"
+version = "0.3.0"
 description = "The GEECS access library: UDP/TCP wire protocol, experiment database, PV naming contract, exceptions, the wire-protocol test double, and the entry-level GeecsDevice client"
 authors = ["Sam Barber <sbarber@lbl.gov>"]
 readme = "README.md"

--- a/GEECS-Core/tests/test_transport.py
+++ b/GEECS-Core/tests/test_transport.py
@@ -110,6 +110,31 @@ class TestUdpClient:
 
 
 class TestTcpSubscriber:
+    async def test_keepalive_enabled_by_default(
+        self, fake_device: FakeGeecsDevice
+    ) -> None:
+        """The connected socket has SO_KEEPALIVE set (the #611 half-open fix)."""
+        import socket as socket_mod
+
+        async with FakeGeecsServer(fake_device) as srv:
+            async with GeecsTcpSubscriber(srv.host, srv.port) as sub:
+                sock = sub._writer.get_extra_info("socket")
+                assert (
+                    sock.getsockopt(socket_mod.SOL_SOCKET, socket_mod.SO_KEEPALIVE) != 0
+                )
+
+    async def test_keepalive_can_be_disabled(
+        self, fake_device: FakeGeecsDevice
+    ) -> None:
+        import socket as socket_mod
+
+        async with FakeGeecsServer(fake_device) as srv:
+            async with GeecsTcpSubscriber(srv.host, srv.port, keepalive=False) as sub:
+                sock = sub._writer.get_extra_info("socket")
+                assert (
+                    sock.getsockopt(socket_mod.SOL_SOCKET, socket_mod.SO_KEEPALIVE) == 0
+                )
+
     async def test_receives_updates(self, fake_device: FakeGeecsDevice) -> None:
         received: list[dict] = []
 

--- a/GeecsCAGateway/CHANGELOG.md
+++ b/GeecsCAGateway/CHANGELOG.md
@@ -3,6 +3,42 @@
 All notable changes to `geecs-ca-gateway` are documented here, following
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and semantic versioning.
 
+## [0.20.0] - 2026-08-24
+
+### Added
+
+- **The half-open-socket blind spot is closed** (issue #611; live incident
+  2026-08-17, u_s1h — readbacks frozen at valid-stale values, `:SP` writes
+  working, no alarm, for the want of a TCP FIN).  Two mechanisms:
+  - **TCP keepalive on every subscription socket** (geecs-core 0.3.0's
+    `GeecsTcpSubscriber` default): an ungracefully dead peer now resets
+    the connection within about a minute, which surfaces as the ordinary
+    drop path — INVALID readbacks, `CONNECTED` MAJOR, supervised
+    reconnect.  Quiet-but-live devices are never disturbed ("silence is
+    not a drop" preserved).  Contract-pinned by
+    `test_subscription_socket_has_keepalive`; PV_CONTRACT §5 updated.
+  - **Endpoint re-resolve at the backoff ceiling** (the adjacent gap):
+    once a device's reconnect backoff hits its cap, the supervisor
+    re-queries the device's `(host, port)` from the GEECS DB (off-loop,
+    10 s budget) before further dials, so a device app that re-registered
+    on a different endpoint heals without a gateway restart — and its UDP
+    set client follows the move (`_rebuild_udp`; setter closures resolve
+    the client at call time).  A failed re-resolve (DB down mid-partition)
+    keeps the last known endpoint — exactly the old behavior.  Production
+    wiring: `__main__` passes `GeecsDb.find_device`; the
+    `endpoint_resolver` constructor param is injectable and `None`
+    disables.  Pinned by `test_endpoint_re_resolve_heals_moved_device` /
+    `test_endpoint_resolver_failure_keeps_old_endpoint`; PV_CONTRACT §7
+    and DEPLOYMENT.md updated (restart remains the resync mechanism for
+    added/removed devices and variables).
+
+  Deliberately NOT built from the issue's proposal list: app-level
+  last-push-age probing (keepalive detects dead peers at the transport
+  level without interpreting application silence) and the per-device
+  `last_push_age` diagnostic PV (with self-healing subscriptions the
+  frozen state it would surface no longer persists) — both cheap to add
+  later if a real case asks for them.
+
 ## [0.19.1] - 2026-08-21
 
 ### Changed

--- a/GeecsCAGateway/DEPLOYMENT.md
+++ b/GeecsCAGateway/DEPLOYMENT.md
@@ -465,7 +465,13 @@ sudo systemctl enable --now geecs-ca-gateway
   queries, so PVs appear within seconds of start.
 - A **restart is also the upgrade and the DB-resync mechanism**: `git pull &&
   poetry install && systemctl restart geecs-ca-gateway` — matching the
-  existing GEECS master-GUI reboot pattern for device-set changes.
+  existing GEECS master-GUI reboot pattern for device-set changes. Two former
+  reasons to bounce the gateway heal on their own since 0.20.0 (#611): a
+  half-open subscription (frozen readbacks, working `:SP`, no alarm — TCP
+  keepalive now resets it within about a minute), and a device app
+  re-registered on a different endpoint (re-resolved from the DB once the
+  reconnect backoff hits its ceiling). Restart remains the mechanism for
+  added/removed devices and variables.
 - **DB edits don't need shell access**: any CA client can write the
   `[experiment:]cagateway:restart` PV (devIocStats `SYSRESET` pattern) and
   the gateway exits with code 86, which the unit's `RestartForceExitStatus`

--- a/GeecsCAGateway/PV_CONTRACT.md
+++ b/GeecsCAGateway/PV_CONTRACT.md
@@ -525,9 +525,15 @@ otherwise run a second independent limit evaluator on every write.
   (DESIGN.md "Honest gaps").
 - A device merely going *quiet* raises no alarm and does not age severity —
   GEECS devices are legitimately silent for seconds (waiting on triggers, slow
-  online analysis). Only an actual socket drop marks INVALID. The known gap —
-  hard power-off with the socket left open (no TCP FIN) — is deferred to TCP
-  keepalive.
+  online analysis). Only an actual socket drop marks INVALID. The former gap —
+  hard power-off with the socket left open (no TCP FIN) — is closed since
+  0.20.0 by TCP keepalive on the subscription socket (pinned by
+  `test_subscription_socket_has_keepalive`): the OS probes the idle peer and a
+  dead one resets the connection, which surfaces as the ordinary drop path
+  above. Detection latency is the keepalive budget (roughly a minute with the
+  defaults: 30 s idle + 3 probes × 10 s), not instant. Probes are answered by
+  a live peer's TCP stack even when the application is silent, so quiet
+  devices still never alarm.
 - Setpoint PVs carry no alarm semantics; a failed put raises at the client
   instead.
 
@@ -597,6 +603,13 @@ refuse the value before ever putting.
   supervisor retries with exponential backoff (0.5 s → 30 s cap by default),
   and the PVs sit at INVALID / `CONNECTED=Disconnected` until the device
   appears. Down/up transitions are logged once per episode, not per attempt.
+- Once a device's backoff hits its ceiling, the supervisor re-queries the
+  device's endpoint from the GEECS DB before further dials (0.20.0, pinned by
+  `test_endpoint_re_resolve_heals_moved_device`) — a device app that
+  re-registered on a different host/port heals without a gateway restart, and
+  its UDP set client follows the move. A failed re-resolve (DB unreachable)
+  keeps the last known endpoint; restarting the gateway remains the resync
+  mechanism for everything else (added/removed devices and variables).
 - Whole-experiment config build (`from_geecs_experiment`) skips (with a
   warning) any device whose spec cannot be built from the DB.
 
@@ -669,6 +682,7 @@ that branch and are part of this contract's target behavior.
 | PV stamped with device time; timestamp PVs carry raw LabVIEW value | `test_gateway.py::test_pv_timestamp_from_systimestamp`, `::test_timestamp_vars_exposed_as_pvs_with_raw_value` |
 | `0.0` pre-acquisition placeholder | `test_pv_contract.py::test_float_readback_initializes_to_zero_placeholder` |
 | Frame ordering: data before timestamps *(PR #452)* | `test_gateway.py::test_callback_posts_timestamp_variables_last` |
+| Subscription socket keepalive (half-open detection, #611); reconnect endpoint re-resolve at backoff ceiling, resolver failure keeps old endpoint | `test_gateway.py::test_subscription_socket_has_keepalive`, `::test_endpoint_re_resolve_heals_moved_device`, `::test_endpoint_resolver_failure_keeps_old_endpoint`; `GEECS-Core/tests/test_transport.py::TestTcpSubscriber::test_keepalive_enabled_by_default`, `::test_keepalive_can_be_disabled` |
 | Derived-channel manifest kind and numeric output PV metadata | `test_derived_channels.py::test_derived_pvdb_has_numeric_readback_and_manifest` |
 | Derived-channel expression subset and cross-device `stale_after` schema rule | `test_derived_channels.py::test_expression_evaluator_supports_convectron_formula`, `::test_expression_evaluator_supports_status_logic`, `::test_expression_evaluator_bool_ops_publish_binary_floats`, `::test_expression_evaluator_rejects_non_numeric_python`, `::test_derived_channel_schema_requires_stale_after_for_cross_device` |
 | Derived values evaluate from one source frame; derived-only inputs are subscribed without raw PVs | `test_derived_channels.py::test_derived_channel_updates_from_same_source_frame`, `::test_derived_only_input_is_subscribed_without_raw_pv` |

--- a/GeecsCAGateway/geecs_ca_gateway/__main__.py
+++ b/GeecsCAGateway/geecs_ca_gateway/__main__.py
@@ -96,6 +96,19 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     return parser.parse_args(argv)
 
 
+def _db_endpoint_resolver(device_name: str) -> tuple[str, int]:
+    """Re-query a device's ``(ip, port)`` from the GEECS DB.
+
+    Passed to the gateway as its ``endpoint_resolver`` (issue #611: a device
+    app that re-registers on a new endpoint heals without a gateway restart).
+    Called off the event loop by the supervisor, which treats a raise as
+    "keep the last known endpoint" — no guarding needed here.
+    """
+    from geecs_core.db.geecs_db import GeecsDb
+
+    return GeecsDb.find_device(device_name)
+
+
 async def _run(
     experiment: str,
     *,
@@ -121,7 +134,7 @@ async def _run(
             len(config.derived_channels),
             path,
         )
-    gateway = GeecsCaGateway(config)
+    gateway = GeecsCaGateway(config, endpoint_resolver=_db_endpoint_resolver)
     logger.info(
         "serving %d PV(s) across %d device(s) for experiment %r",
         len(gateway.pvdb),

--- a/GeecsCAGateway/geecs_ca_gateway/gateway.py
+++ b/GeecsCAGateway/geecs_ca_gateway/gateway.py
@@ -17,7 +17,7 @@ import asyncio
 import logging
 import math
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, Callable
 
 from caproto import (
     AlarmSeverity,
@@ -131,9 +131,12 @@ class GeecsCaGateway:
     A device merely going *quiet* is not treated as a drop: GEECS devices are
     legitimately silent for seconds (waiting on triggers, slow online analysis,
     toggled), so silence just ages the PV timestamp rather than forcing a
-    (pointless) reconnect.  The remaining gap — a device hard-powered-off with the
-    socket left open (no TCP FIN) — is best handled by TCP keepalive, a future
-    refinement; app-level silence-guessing conflates "slow" with "dead".
+    (pointless) reconnect.  The former blind spot — a device hard-powered-off
+    with the socket left open (no TCP FIN) — is closed by TCP keepalive on the
+    subscription socket (``GeecsTcpSubscriber``'s default since geecs-core
+    0.3.0; issue #611, live incident 2026-08-17): the OS probes the idle peer,
+    a dead one resets the connection, and the supervisor reconnects.  Probes
+    never disturb a live-but-quiet device, so silence still is not a drop.
 
     Parameters
     ----------
@@ -146,6 +149,14 @@ class GeecsCaGateway:
         sets block until convergence, so this must cover the slowest legitimate
         move; the default matches CaMotor's 30 s move budget in GeecsBluesky
         (see ``_SET_EXE_TIMEOUT``). Gets are unaffected.
+    endpoint_resolver : callable, optional
+        ``device_name -> (host, port) | None`` — re-queried (off-loop, with a
+        timeout) once a device's reconnect backoff hits its ceiling, so a
+        device app that re-registered on a different endpoint heals without a
+        gateway restart (the #611 adjacent gap).  ``None``/a raise keeps the
+        last known endpoint.  Production wiring passes
+        ``GeecsDb.find_device``; the default ``None`` disables re-resolve
+        (startup endpoints are retried forever, the pre-0.20 behavior).
     """
 
     def __init__(
@@ -155,11 +166,13 @@ class GeecsCaGateway:
         reconnect_min_s: float = 0.5,
         reconnect_max_s: float = 30.0,
         set_timeout_s: float = _SET_EXE_TIMEOUT,
+        endpoint_resolver: Callable[[str], tuple[str, int] | None] | None = None,
     ) -> None:
         self.config = config
         self._reconnect_min = reconnect_min_s
         self._reconnect_max = reconnect_max_s
         self._set_timeout = set_timeout_s
+        self._endpoint_resolver = endpoint_resolver
         self._supervisors: list[asyncio.Task] = []
         # device name -> {geecs_var -> last value written} for deadband suppression
         self._last_written: dict[str, dict[str, Any]] = {}
@@ -797,8 +810,11 @@ class GeecsCaGateway:
         }
         callback = self._make_callback(dev)
         backoff = self._reconnect_min
+        # The effective endpoint — startup value until a re-resolve (below)
+        # learns the device moved.
+        host, port = dev.host, dev.port
         while not self._closing:
-            sub = GeecsTcpSubscriber(dev.host, dev.port)
+            sub = GeecsTcpSubscriber(host, port)
             try:
                 await sub.connect()
                 self._subs[dev.name] = sub
@@ -850,8 +866,100 @@ class GeecsCaGateway:
                     dev.name,
                     self._reconnect_max,
                 )
+            # Once the backoff hits its ceiling the outage is not a blip —
+            # re-ask the DB where the device lives now, so an app that
+            # re-registered on a different endpoint heals without a gateway
+            # restart (#611 adjacent gap).  Not on every retry: during a
+            # network partition the DB is likely unreachable too, and the
+            # resolve (off-loop, but bounded) must not pace the fast retries.
+            if self._endpoint_resolver is not None and backoff >= self._reconnect_max:
+                resolved = await self._resolve_endpoint(dev.name)
+                if resolved is not None and resolved != (host, port):
+                    logger.warning(
+                        "%s: endpoint moved %s:%s -> %s:%s (DB re-resolve); "
+                        "redialing there",
+                        dev.name,
+                        host,
+                        port,
+                        *resolved,
+                    )
+                    host, port = resolved
+                    await self._rebuild_udp(dev.name, host, port)
+                    backoff = self._reconnect_min  # dial the new endpoint promptly
             await asyncio.sleep(backoff)
             backoff = min(backoff * 2, self._reconnect_max)
+
+    #: Budget for one off-loop DB endpoint lookup — generous enough for a lab
+    #: MySQL round trip, small enough that an unreachable DB (partitions take
+    #: the DB down with the devices) cannot stall a supervisor for long.
+    _ENDPOINT_RESOLVE_TIMEOUT_S = 10.0
+
+    async def _resolve_endpoint(self, device_name: str) -> tuple[str, int] | None:
+        """Re-query the device's endpoint off-loop; ``None`` keeps the old one.
+
+        Any failure — resolver raise (DB down), timeout, or a malformed
+        result — degrades to "no change": the supervisor keeps retrying the
+        last known endpoint, exactly the pre-resolve behavior.
+        """
+        assert self._endpoint_resolver is not None
+        try:
+            resolved = await asyncio.wait_for(
+                asyncio.to_thread(self._endpoint_resolver, device_name),
+                timeout=self._ENDPOINT_RESOLVE_TIMEOUT_S,
+            )
+        except Exception as exc:
+            logger.info(
+                "%s: endpoint re-resolve failed (%s); keeping the last known endpoint",
+                device_name,
+                exc,
+            )
+            return None
+        if resolved is None:
+            return None
+        try:
+            host, port = resolved
+            return str(host), int(port)
+        except (TypeError, ValueError):
+            logger.warning(
+                "%s: endpoint resolver returned %r (expected (host, port)); "
+                "keeping the last known endpoint",
+                device_name,
+                resolved,
+            )
+            return None
+
+    async def _rebuild_udp(self, device_name: str, host: str, port: int) -> None:
+        """Point the device's UDP set client at a new endpoint.
+
+        The setter closures look ``self._udp`` up at call time, so swapping
+        the entry heals setpoint writes along with the subscription.  A
+        failed rebuild leaves sets broken exactly as a startup bind failure
+        does (logged loudly; readbacks unaffected).
+        """
+        old = self._udp.pop(device_name, None)
+        if old is not None:
+            try:
+                await old.close()
+            except Exception:
+                logger.debug(
+                    "%s: closing stale UDP client failed", device_name, exc_info=True
+                )
+        udp = GeecsUdpClient(host, port, device_name=device_name)
+        try:
+            await udp.connect()
+        except OSError:
+            logger.error(
+                "%s: UDP rebind to %s:%s failed — setpoint writes stay broken "
+                "until the endpoint resolves again or the gateway restarts",
+                device_name,
+                host,
+                port,
+                exc_info=True,
+            )
+            await udp.close()
+            return
+        self._udp[device_name] = udp
+        logger.info("%s: UDP set client re-pointed at %s:%s", device_name, host, port)
 
     async def _set_connected(self, device: str, connected: bool) -> None:
         """Update the device's CONNECTED PV and the gateway connected-count."""

--- a/GeecsCAGateway/geecs_ca_gateway/gateway.py
+++ b/GeecsCAGateway/geecs_ca_gateway/gateway.py
@@ -839,6 +839,10 @@ class GeecsCaGateway:
                     logger.info("%s: subscription live", dev.name)
                 await self._set_connected(dev.name, True)
                 backoff = self._reconnect_min
+                # A fresh down episode starts with a prompt first resolve —
+                # leftover holdoff from a previous episode must not delay
+                # discovering a genuine move by minutes.
+                resolve_holdoff = 0
                 # Wait for an actual disconnect — the listener task ends when the
                 # socket closes. A device merely going quiet is NOT a drop; poll
                 # so we stay cleanly cancellable at the sleep.

--- a/GeecsCAGateway/geecs_ca_gateway/gateway.py
+++ b/GeecsCAGateway/geecs_ca_gateway/gateway.py
@@ -399,10 +399,13 @@ class GeecsCaGateway:
             try:
                 udp = self._udp.get(device_name)
                 if udp is None:
-                    # UDP bind failed at startup (see connect()) — fail the
-                    # caput with a clear cause rather than a KeyError.
+                    # No client: UDP bind failed at startup (see connect()),
+                    # or an endpoint-move rebind failed / is in flight
+                    # (_rebuild_udp) — fail the caput with a clear cause
+                    # rather than a KeyError.
                     raise GeecsConnectionError(
-                        f"{device_name}: no UDP client (bind failed at startup); "
+                        f"{device_name}: no UDP client (bind failed at startup, "
+                        f"or endpoint rebind failed/in progress); "
                         f"cannot forward set of {geecs_var!r}"
                     )
                 return await udp.set(geecs_var, value, timeout=self._set_timeout)
@@ -813,6 +816,8 @@ class GeecsCaGateway:
         # The effective endpoint — startup value until a re-resolve (below)
         # learns the device moved.
         host, port = dev.host, dev.port
+        # Ceiling cycles to skip between DB endpoint re-resolves (see below).
+        resolve_holdoff = 0
         while not self._closing:
             sub = GeecsTcpSubscriber(host, port)
             try:
@@ -869,23 +874,32 @@ class GeecsCaGateway:
             # Once the backoff hits its ceiling the outage is not a blip —
             # re-ask the DB where the device lives now, so an app that
             # re-registered on a different endpoint heals without a gateway
-            # restart (#611 adjacent gap).  Not on every retry: during a
-            # network partition the DB is likely unreachable too, and the
-            # resolve (off-loop, but bounded) must not pace the fast retries.
+            # restart (#611 adjacent gap).  Throttled twice over: never
+            # during the backoff climb (a blip must not pay a DB query, and
+            # during a partition the DB is likely down too — the bounded
+            # off-loop resolve must not pace the fast retries), and at the
+            # ceiling only every ``_ENDPOINT_RESOLVE_HOLDOFF_CYCLES``-th
+            # cycle — a device left off overnight must not hold a ~once-a-
+            # cycle MySQL connection churn open indefinitely.
             if self._endpoint_resolver is not None and backoff >= self._reconnect_max:
-                resolved = await self._resolve_endpoint(dev.name)
-                if resolved is not None and resolved != (host, port):
-                    logger.warning(
-                        "%s: endpoint moved %s:%s -> %s:%s (DB re-resolve); "
-                        "redialing there",
-                        dev.name,
-                        host,
-                        port,
-                        *resolved,
-                    )
-                    host, port = resolved
-                    await self._rebuild_udp(dev.name, host, port)
-                    backoff = self._reconnect_min  # dial the new endpoint promptly
+                if resolve_holdoff > 0:
+                    resolve_holdoff -= 1
+                else:
+                    resolve_holdoff = self._ENDPOINT_RESOLVE_HOLDOFF_CYCLES
+                    resolved = await self._resolve_endpoint(dev.name)
+                    if resolved is not None and resolved != (host, port):
+                        logger.warning(
+                            "%s: endpoint moved %s:%s -> %s:%s (DB re-resolve); "
+                            "redialing there",
+                            dev.name,
+                            host,
+                            port,
+                            *resolved,
+                        )
+                        host, port = resolved
+                        await self._rebuild_udp(dev.name, host, port)
+                        backoff = self._reconnect_min  # dial the new one promptly
+                        resolve_holdoff = 0
             await asyncio.sleep(backoff)
             backoff = min(backoff * 2, self._reconnect_max)
 
@@ -893,6 +907,12 @@ class GeecsCaGateway:
     #: MySQL round trip, small enough that an unreachable DB (partitions take
     #: the DB down with the devices) cannot stall a supervisor for long.
     _ENDPOINT_RESOLVE_TIMEOUT_S = 10.0
+
+    #: Ceiling cycles between DB endpoint re-resolves per down device — at the
+    #: default 30 s ceiling this is one MySQL query per ~5 min per device, so
+    #: a rack left off overnight costs a trickle, not a per-cycle connection
+    #: churn (each ``GeecsDb`` query opens a fresh connection).
+    _ENDPOINT_RESOLVE_HOLDOFF_CYCLES = 10
 
     async def _resolve_endpoint(self, device_name: str) -> tuple[str, int] | None:
         """Re-query the device's endpoint off-loop; ``None`` keeps the old one.

--- a/GeecsCAGateway/pyproject.toml
+++ b/GeecsCAGateway/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-ca-gateway"
-version = "0.19.1"
+version = "0.20.0"
 description = "EPICS Channel Access soft-IOC gateway exposing GEECS devices as PVs"
 authors = ["Sam Barber <sbarber@lbl.gov>"]
 readme = "README.md"

--- a/GeecsCAGateway/tests/test_entrypoint.py
+++ b/GeecsCAGateway/tests/test_entrypoint.py
@@ -133,3 +133,7 @@ derived_channels:
 
     assert restart is False
     assert seen["config"].derived_channels[0].device == "U_ChamberVac"
+    # The production endpoint-resolver wiring (#611) — without this pin,
+    # dropping the kwarg from _run would silently disable re-resolve in
+    # production while every gateway-level test injects its own resolver.
+    assert seen["init_kwargs"]["endpoint_resolver"] is entry._db_endpoint_resolver

--- a/GeecsCAGateway/tests/test_entrypoint.py
+++ b/GeecsCAGateway/tests/test_entrypoint.py
@@ -114,8 +114,9 @@ derived_channels:
     seen: dict[str, GatewayConfig] = {}
 
     class FakeGateway:
-        def __init__(self, config: GatewayConfig) -> None:
+        def __init__(self, config: GatewayConfig, **kwargs: object) -> None:
             seen["config"] = config
+            seen["init_kwargs"] = kwargs
             self.pvdb = {}
 
         async def run(self) -> bool:

--- a/GeecsCAGateway/tests/test_gateway.py
+++ b/GeecsCAGateway/tests/test_gateway.py
@@ -317,9 +317,12 @@ async def test_endpoint_re_resolve_heals_moved_device() -> None:
         srv2 = await _start_on_port(device2, port_b)
         endpoint["port"] = port_b
         try:
+            # Generous timeout: a first resolve can race the move (returning
+            # the old port) and the next one waits out the holdoff cycles.
             assert await _wait_until(
                 lambda: int(rb.severity) == int(AlarmSeverity.NO_ALARM)
-                and rb.value == pytest.approx(9.0)
+                and rb.value == pytest.approx(9.0),
+                timeout=12.0,
             )
             # The UDP set client followed the move too.
             assert await _wait_until(lambda: gw._udp[DEVICE]._port == port_b)

--- a/GeecsCAGateway/tests/test_gateway.py
+++ b/GeecsCAGateway/tests/test_gateway.py
@@ -265,6 +265,115 @@ async def test_reconnect_and_validity() -> None:
         await gw.close()
 
 
+async def test_subscription_socket_has_keepalive() -> None:
+    """The live subscription socket carries SO_KEEPALIVE (PV_CONTRACT §5:
+    the half-open blind spot is closed by TCP keepalive — issue #611)."""
+    device = FakeGeecsDevice(
+        DEVICE, variables={"Position": 7.5, "acq_timestamp": 1000.0}
+    )
+    async with FakeGeecsServer(device) as srv:
+        gw = GeecsCaGateway(_config(srv.host, srv.port))
+        await gw.connect()
+        await gw.subscribe()
+        try:
+            assert await _wait_until(lambda: DEVICE in gw._subs)
+            sock = gw._subs[DEVICE]._writer.get_extra_info("socket")
+            assert sock.getsockopt(socket.SOL_SOCKET, socket.SO_KEEPALIVE) != 0
+        finally:
+            await gw.close()
+
+
+async def test_endpoint_re_resolve_heals_moved_device() -> None:
+    """A device that re-registers on a new port heals once backoff hits its
+    ceiling and the resolver reports the move — no gateway restart (#611)."""
+    port_a, port_b = _free_port(), _free_port()
+    endpoint = {"port": port_a}
+
+    def resolver(name: str) -> tuple[str, int]:
+        assert name == DEVICE
+        return "127.0.0.1", endpoint["port"]
+
+    device = FakeGeecsDevice(
+        DEVICE, variables={"Position": 7.5, "acq_timestamp": 1000.0}
+    )
+    srv = await _start_on_port(device, port_a)
+    gw = GeecsCaGateway(
+        _config("127.0.0.1", port_a),
+        reconnect_min_s=0.1,
+        reconnect_max_s=0.2,
+        endpoint_resolver=resolver,
+    )
+    await gw.connect()
+    await gw.subscribe()
+    rb = gw.pvdb[f"{DEVICE_PV}:position"]
+    try:
+        assert await _wait_until(lambda: rb.value == pytest.approx(7.5))
+
+        # The device moves: old endpoint dies, new one appears on port B.
+        await srv.stop()
+        device2 = FakeGeecsDevice(
+            DEVICE, variables={"Position": 9.0, "acq_timestamp": 1001.0}
+        )
+        srv2 = await _start_on_port(device2, port_b)
+        endpoint["port"] = port_b
+        try:
+            assert await _wait_until(
+                lambda: int(rb.severity) == int(AlarmSeverity.NO_ALARM)
+                and rb.value == pytest.approx(9.0)
+            )
+            # The UDP set client followed the move too.
+            assert await _wait_until(lambda: gw._udp[DEVICE]._port == port_b)
+        finally:
+            await srv2.stop()
+    finally:
+        await gw.close()
+
+
+async def test_endpoint_resolver_failure_keeps_old_endpoint() -> None:
+    """A raising resolver (DB down) degrades to the pre-resolve behavior:
+    the supervisor keeps retrying the last known endpoint and still
+    recovers when the device returns there."""
+    port = _free_port()
+
+    def resolver(name: str) -> tuple[str, int]:
+        raise RuntimeError("DB unreachable")
+
+    device = FakeGeecsDevice(
+        DEVICE, variables={"Position": 7.5, "acq_timestamp": 1000.0}
+    )
+    srv = await _start_on_port(device, port)
+    gw = GeecsCaGateway(
+        _config("127.0.0.1", port),
+        reconnect_min_s=0.1,
+        reconnect_max_s=0.2,
+        endpoint_resolver=resolver,
+    )
+    await gw.connect()
+    await gw.subscribe()
+    rb = gw.pvdb[f"{DEVICE_PV}:position"]
+    try:
+        assert await _wait_until(lambda: rb.value == pytest.approx(7.5))
+        await srv.stop()
+        assert await _wait_until(
+            lambda: int(rb.severity) == int(AlarmSeverity.INVALID_ALARM)
+        )
+        # Long enough for several ceiling-rate retries, each with a failing
+        # resolve — none of which may crash the supervisor or move the dial.
+        device2 = FakeGeecsDevice(
+            DEVICE, variables={"Position": 9.0, "acq_timestamp": 1001.0}
+        )
+        srv2 = await _start_on_port(device2, port)
+        try:
+            assert await _wait_until(
+                lambda: int(rb.severity) == int(AlarmSeverity.NO_ALARM)
+                and rb.value == pytest.approx(9.0)
+            )
+        finally:
+            await srv2.stop()
+    finally:
+        await gw.close()
+
+
 async def test_value_alarm_limits_set_live_readback_severity() -> None:
     """Curated scalar limits set MINOR/MAJOR severity on live values."""
     cfg = _alarm_config()


### PR DESCRIPTION
Closes #611 — the silent failure mode from the 2026-08-17 live incident (u_s1h readbacks frozen at valid-stale values, `:SP` writes working, no alarm, for 24 days of gateway uptime until a manual `cagateway:restart`).

## What + why

**1. TCP keepalive on the subscription socket — GEECS-Core 0.3.0, ~60 LOC (`transport/tcp_subscriber.py`):**
The subscription is read-only after the `Wait>>` command, so the OS never sends on it — an *ungracefully* dead peer (host crash, power cycle, a partition that eats the FIN/RST) left a half-open socket the listener waited on forever. `GeecsTcpSubscriber` now enables `SO_KEEPALIVE` by default with platform-guarded tuning (`TCP_KEEPIDLE`/`TCP_KEEPALIVE`, `TCP_KEEPINTVL`, `TCP_KEEPCNT`; bare `SO_KEEPALIVE` + OS defaults where unexposed): dead-peer detection in roughly a minute (30 s idle + 3 × 10 s probes), surfacing as the ordinary drop path — INVALID readbacks, `CONNECTED` MAJOR, supervised reconnect. **The "silence is not a drop" doctrine is preserved**: keepalive probes are answered by a live peer's TCP stack even when its application is silent, so quiet devices are never disturbed. This was the fix the supervisor's own docstring and PV_CONTRACT §5 already named as the intended future refinement.

**2. Endpoint re-resolve at the backoff ceiling — GeecsCAGateway 0.20.0, ~110 LOC (`gateway.py`, `__main__.py`):**
The issue's adjacent gap: reconnects retried the endpoint resolved at startup forever. Once a device's backoff hits its cap (the outage is not a blip), the supervisor re-queries the device's `(host, port)` via a new injectable `endpoint_resolver` (production: `GeecsDb.find_device`, wired in `__main__`) — off the event loop with a 10 s budget, so an unreachable DB mid-partition cannot stall the supervisor. On a move, the UDP set client is rebuilt too (`_rebuild_udp`; the setter closures resolve `self._udp` at call time, so sets heal along with readbacks). Any resolve failure keeps the last known endpoint — exactly the old behavior. Not on every retry by design: during a partition the DB is down too, and fast retries must not be paced by DB timeouts.

**Contract/docs travel with the behavior** (per the gateway's ground rule): PV_CONTRACT §5 (the known-gap bullet becomes the closed-gap statement with detection-latency honesty), §7 (re-resolve semantics; restart remains the resync mechanism for added/removed devices/variables), the pinned-by test map, DEPLOYMENT.md's restart section, and the gateway class docstring.

## Deliberately not built (from the issue's proposal list — cheap to veto)

- **App-level last-push-age probing**: keepalive detects dead peers at the transport level without interpreting application silence; an age-based prober would re-introduce the "slow vs dead" conflation the doctrine exists to avoid.
- **Per-device `last_push_age` diagnostic PV**: with self-healing subscriptions the frozen state it would surface no longer persists. Add later if a real case asks.

## Tests

- GEECS-Core: **89 passed** (2 new: keepalive on by default / can be disabled, socket-option asserted against a live fake-server connection).
- GeecsCAGateway: **136 passed** (3 new: keepalive present on the gateway's live subscription socket; endpoint re-resolve heals a device that moved ports end-to-end incl. the UDP client following; a raising resolver degrades to the old retry-same-endpoint behavior and still recovers).
- Lint clean via `scripts/check.sh` (plan: GEECS-Core + GeecsCAGateway).

## Hardware verification

**OWED** (this is the production gateway path): after merge + deploy to the gateway host, two checks —
1. *Keepalive is active in production*: `ss -o state established '( sport = :* )' | grep -A1 <device-ip>` on the gateway host shows a `timer:(keepalive,…)` on device subscription sockets. Expected: present on every device connection.
2. *The incident scenario heals*: hard-drop one expendable device (pull its network / kill the host, not a graceful app exit) and confirm within ~2 minutes: readbacks go INVALID, `CONNECTED` goes MAJOR, and recovery is automatic when the device returns — no `cagateway:restart` needed. The endpoint-move case can ride the next natural device re-registration rather than a staged test.

Note the deployed host runs 0.19.x; this PR does not change wire behavior toward devices (same subscribe command, same UDP protocol), so the upgrade is the routine `git pull && poetry install && systemctl restart`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)