### PR TITLE
GEECS-MCP 0.7.0: analysis execution slice — run_scan_analysis + listings (#686)

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -70,7 +70,9 @@ jobs:
 
       - name: Install GEECS-MCP dependencies
         working-directory: GEECS-MCP
-        run: poetry install --with dev
+        # analysis-run: the #686 execution-slice tests importorskip
+        # without it — install it so CI actually runs them.
+        run: poetry install --with dev -E analysis-run
 
       - name: Run GEECS-MCP tests
         working-directory: GEECS-MCP

--- a/GEECS-MCP/CHANGELOG.md
+++ b/GEECS-MCP/CHANGELOG.md
@@ -4,6 +4,41 @@ All notable changes to `geecs-mcp` are documented here.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.7.0] - 2026-08-24
+
+### Added
+
+- **The analysis-domain execution slice** (issue #686, owner request —
+  restores the post-migration-dormant analysis capability through the
+  new architecture; ScanAnalysis as-is is the backend by owner decision
+  2026-08-24, with the verb surface kept backend-neutral and
+  `analysis_status/` as the progress contract so the Tiled-based stack
+  can slot in behind the same tools later):
+  - `run_scan_analysis(scan_number, day?, analyzer|group, rerun_failed,
+    rerun_completed)` — Q-class (native `ask` + `write_tools`),
+    submit-and-poll: validates everything refusable *before* side
+    effects (exactly-one selector, configs root, the scan folder EXISTS
+    — the cross-package invariant, pinned by a nothing-created test —
+    and the analyzers construct on this host, so a Windows-only-SDK
+    diagnostic is refused up front instead of half-running), initializes
+    the status YAMLs server-side (a dead worker leaves visible queued
+    rows, never silence), then spawns a detached worker subprocess
+    (`analysis/run_worker.py`) driving ScanAnalysis's own task queue
+    (claim/heartbeat/stale-reclaim).  Poll with the existing
+    `get_scan_analysis`; figures via `get_scan_figure`.  Google-Doc
+    upload stays hard-off.
+  - `list_analyzers` / `list_analysis_groups` — R-class listings over
+    the configs repo's `analyzers/`/`groups/` trees
+    (`discover_analyzers`/`discover_groups`), so agents name
+    diagnostics instead of guessing (payload-capped, truncation
+    flagged).
+  - New optional `analysis-run` extra (ScanAnalysis path dep — heavy
+    via ImageAnalysis, hence an extra mirroring GeecsBluesky's
+    pattern); without it the three tools refuse naming the extra and
+    the server starts normally.  New consumed config:
+    `SCAN_ANALYSIS_CONFIG_DIR` / `[Paths] scan_analysis_configs_path`
+    (see `deploy/DEPLOYMENT.md`).
+
 ## [0.6.0] - 2026-08-24
 
 Payload discipline for figures (osprey-side integration finding: an

--- a/GEECS-MCP/CHANGELOG.md
+++ b/GEECS-MCP/CHANGELOG.md
@@ -38,6 +38,19 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
     the server starts normally.  New consumed config:
     `SCAN_ANALYSIS_CONFIG_DIR` / `[Paths] scan_analysis_configs_path`
     (see `deploy/DEPLOYMENT.md`).
+  - Review-hardened status semantics (adversarial findings 1–2): the
+    rerun flags reset `failed`/`done` (and stale-claimed) rows to
+    queued *server-side* (`reset_status_for_scan`), so the dead-worker
+    visibility contract holds on every path; a task another runner is
+    actively working (fresh heartbeat — ScanAnalysis 1.16.0's
+    `claim_is_active`) refuses the call (`policy_refusal`) instead of
+    double-running into the same output files; the envelope reports
+    `tasks` (what this call runs) vs `skipped` (done/failed without
+    their rerun flag), and an all-skipped call is an honest
+    `started: false` no-op with no worker spawned.  Task ids come from
+    ScanAnalysis's exported `analyzer_task_id` (no mirrored
+    derivation), and the server-side validation builds analyzers
+    through the same `run_worker.build_analyzers` the worker executes.
 
 ## [0.6.0] - 2026-08-24
 

--- a/GEECS-MCP/CHANGELOG.md
+++ b/GEECS-MCP/CHANGELOG.md
@@ -38,6 +38,14 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
     the server starts normally.  New consumed config:
     `SCAN_ANALYSIS_CONFIG_DIR` / `[Paths] scan_analysis_configs_path`
     (see `deploy/DEPLOYMENT.md`).
+  - **The pre-claim double-start window is closed** (Codex P1): the
+    realistic vector — a second call into this server while the first
+    worker is still importing its stack — refuses via an in-process
+    dispatch ledger (side-effect-free, before any status write; entries
+    expire when the pid dies, the tasks leave `queued`, or after the
+    queue's own 180 s staleness bound), and the cross-process backstop
+    is ScanAnalysis 1.16.0's atomic claim gate in `run_worklist` (a
+    losing worker skips the task instead of double-running it).
   - Review-hardened status semantics (adversarial findings 1–2): the
     rerun flags reset `failed`/`done` (and stale-claimed) rows to
     queued *server-side* (`reset_status_for_scan`), so the dead-worker

--- a/GEECS-MCP/CLAUDE.md
+++ b/GEECS-MCP/CLAUDE.md
@@ -11,8 +11,11 @@ Domain roadmap (add as they earn their keep, never speculatively):
 `scans/` (built: v0 read + v1 control), then candidates in rough value
 order — `health/` (gateway/Tiled/DB probes, read-only), `db/`
 (device-variable metadata lookups), `logs/` (the /triage analysis as a
-tool), `analysis/` (FIRST SLICE BUILT — the #675 figure/results verbs
-over the ScanAnalysis output tree; deeper analysis-over-Tiled later;
+tool), `analysis/` (READ + EXECUTION BUILT — the #675 figure/results verbs
+over the ScanAnalysis output tree, and the #686 `run_scan_analysis`
+execution slice (0.7.0) with ScanAnalysis-as-is as the backend by owner
+decision; deeper analysis-over-Tiled later — the verb surface is
+backend-neutral so it slots in behind the same tools;
 pure-numpy analysis is cross-platform; capabilities needing **Windows-only acquisition SDKs**
 do NOT force this server onto Windows — they become a small *satellite
 MCP server* on a Windows box (the PVA-gateway camera-server precedent),
@@ -97,6 +100,25 @@ geecs_mcp/
                   #   never be used here; pinned by a nothing-created
                   #   test.  Needs [Paths] geecs_data + the share
                   #   mounted on the serving host (degrades honestly)
+    run_tools.py  # the execution slice (#686, 0.7.0): run_scan_analysis
+                  #   (Q — validate-then-refuse BEFORE side effects:
+                  #   exactly-one selector, configs root, scan folder
+                  #   EXISTS (never created), analyzers construct on
+                  #   this host so Windows-SDK diagnostics refuse up
+                  #   front; statuses initialized server-side; then a
+                  #   detached run_worker subprocess drives ScanAnalysis's
+                  #   own task queue) + list_analyzers /
+                  #   list_analysis_groups (R).  ScanAnalysis-as-is is
+                  #   the backend BY OWNER DECISION 2026-08-24 — verb
+                  #   surface backend-neutral, analysis_status/ = the
+                  #   progress contract, so the Tiled stack can slot in
+                  #   later.  Rides the optional analysis-run extra;
+                  #   gdoc upload hard-off (an outward publish needs its
+                  #   own gated verb)
+    run_worker.py # the detached worker: one JSON argv payload ->
+                  #   build_worklist + run_worklist for one scan; stdio
+                  #   dropped — the status YAMLs are the observable
+                  #   surface
 ```
 
 ## Conventions

--- a/GEECS-MCP/deploy/DEPLOYMENT.md
+++ b/GEECS-MCP/deploy/DEPLOYMENT.md
@@ -78,7 +78,14 @@ The verb also needs the data share writable (analysis outputs +
 `analysis_status/` inside *existing* scan folders only — a missing
 scan folder is refused, never created), and each run burns CPU on this
 host in a detached worker process — mind the systemd unit's resource
-caps if agent-triggered analysis becomes routine.
+caps if agent-triggered analysis becomes routine.  Note the worker's
+detachment is session-level, not cgroup-level: **a systemd service
+restart kills mid-run analysis workers** (default
+`KillMode=control-group`).  That is recoverable, not silent — the
+task's claim goes stale after 180 s and a repeat `run_scan_analysis`
+re-runs it; in `get_scan_analysis` a dead worker shows as a task stuck
+`queued` (died before claiming) or `claimed` with a growing
+`heartbeat_age_s` (died mid-run).
 
 Two upstream osprey issues (to be filed from the osprey side): the
 silent acceptance of unknown keys like `hooks:` on custom-server

--- a/GEECS-MCP/deploy/DEPLOYMENT.md
+++ b/GEECS-MCP/deploy/DEPLOYMENT.md
@@ -53,11 +53,32 @@ either (the framework's deny augmentation walks its own
   (`stop_scan`, `pause_scan`): exempt by omission, so a halt is never
   blocked on any path. E.g. `write_tools: [mcp__geecs__submit_scan,
   mcp__geecs__clear_queue, mcp__geecs__run_action,
-  mcp__geecs__move_scan_variable, mcp__geecs__resume_scan]` (the
+  mcp__geecs__move_scan_variable, mcp__geecs__resume_scan,
+  mcp__geecs__run_scan_analysis]` (the
   deployed htu profile predates 0.5.0 and lists the first two —
-  extend it when the v2 verbs deploy).  This is the ONLY headless
+  extend it when the v2 verbs and 0.7.0's `run_scan_analysis`
+  deploy).  This is the ONLY headless
   gate — a profile missing these entries leaves an unattended agent's
   writes ungated.
+
+**Analysis execution (0.7.0, #686)** — `run_scan_analysis` needs two
+things on the serving host, both optional (the tools refuse with a
+clear message when absent, the server always starts):
+
+- The `analysis-run` extra installed (`pip install
+  '<checkout>/GEECS-MCP[analysis-run]'` / `poetry install -E
+  analysis-run`) — pulls ScanAnalysis + ImageAnalysis (scipy/opencv,
+  heavy; this is why it is an extra).
+- The scan-analysis configs root: `SCAN_ANALYSIS_CONFIG_DIR` env var,
+  or config.ini `[Paths] scan_analysis_configs_path` (the
+  GEECS-Plugins-Configs checkout holding `analyzers/` + `groups/`) —
+  the same resolution every ScanAnalysis consumer uses.
+
+The verb also needs the data share writable (analysis outputs +
+`analysis_status/` inside *existing* scan folders only — a missing
+scan folder is refused, never created), and each run burns CPU on this
+host in a detached worker process — mind the systemd unit's resource
+caps if agent-triggered analysis becomes routine.
 
 Two upstream osprey issues (to be filed from the osprey side): the
 silent acceptance of unknown keys like `hooks:` on custom-server

--- a/GEECS-MCP/geecs_mcp/analysis/run_tools.py
+++ b/GEECS-MCP/geecs_mcp/analysis/run_tools.py
@@ -1,0 +1,352 @@
+"""The analysis-domain execution tools: run ScanAnalyzers on demand (#686).
+
+``run_scan_analysis`` restores a currently-dormant capability through the
+new architecture (the LiveTaskRunner fleet has not run post-migration):
+it enqueues and executes the ScanAnalysis pipeline for one scan, on this
+serving host.  **ScanAnalysis as-is is the backend by owner decision
+(2026-08-24)** — the Tiled-based analysis stack is the recorded long-term
+direction, so the verb surface stays backend-neutral (names a diagnostic
+or group, a scan, a day) and the ``analysis_status/`` YAMLs are the
+progress contract: a future backend reports into the same files and the
+existing ``get_scan_analysis`` poll never changes.
+
+Execution shape — submit-and-poll, never a blocking tool call:
+
+1. The tool validates everything refusable *before* side effects: exactly
+   one of ``analyzer``/``group``, the configs root resolves, the scan
+   folder EXISTS (analysis never creates ``scans/ScanNNN/`` — the
+   cross-package invariant; a missing folder is a ``not_found`` refusal,
+   pinned by a nothing-created test), and the analyzer(s) actually
+   construct on this host — a diagnostic whose image-analyzer class needs
+   a Windows-only SDK (HASO WaveKit, Grenouille FROG.dll) fails right
+   here with a clear refusal instead of a half-run (those diagnostics
+   belong to the future Windows satellite server, per the domain
+   roadmap).
+2. It initializes the ``analysis_status/`` files server-side
+   (``init_status_for_scan``, idempotent) — so a worker that dies before
+   claiming leaves *visible* queued rows, never a silent nothing.
+3. It spawns a detached worker subprocess (``run_worker``) that builds
+   the worklist and runs it — the ScanAnalysis task queue's own claim /
+   heartbeat / stale-reclaim machinery narrates progress into the status
+   files the read tools already parse.
+
+Google-Doc upload stays hard-off (``run_worklist``'s ``gdoc_enabled``
+default): publishing to the experiment log is an outward-facing action
+that would need its own explicitly-gated verb.
+
+ScanAnalysis imports are lazy and guarded — the ``analysis-run`` extra is
+optional, and without it every tool here refuses with a message naming
+the extra (the server always starts).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any, Optional
+
+from geecs_mcp import errors, tool_names
+from geecs_mcp.analysis import read_tools
+from geecs_mcp.scans.read_tools import _run_guarded
+from geecs_mcp.server import mcp
+
+logger = logging.getLogger("geecs_mcp.analysis.run")
+
+#: Cap on names returned by the listing tools — a map, not a dump.
+_MAX_LISTED_NAMES = 200
+
+_EXTRA_HINT = (
+    "ScanAnalysis is not installed on the serving host — install the "
+    "geecs-mcp 'analysis-run' extra (poetry install -E analysis-run)"
+)
+
+_ROOT_HINT = (
+    "scan-analysis configs root not configured on the serving host — set "
+    "SCAN_ANALYSIS_CONFIG_DIR or config.ini [Paths] "
+    "scan_analysis_configs_path (the GEECS-Plugins-Configs checkout)"
+)
+
+
+def _config_root() -> Optional[Path]:
+    """The resolved scan-analysis configs root, or ``None`` unconfigured.
+
+    A module-level seam (tests patch it); production defers to the shared
+    ``geecs_data_utils.config_roots`` manager — the same resolution every
+    ScanAnalysis consumer uses.
+    """
+    from geecs_data_utils.config_roots import scan_analysis_config
+
+    return scan_analysis_config.base_dir
+
+
+def _analyzer_id(analyzer: Any) -> str:
+    """The status-file id for *analyzer* — task_queue's own derivation.
+
+    Mirrors ``init_status_for_scan`` exactly so the envelope's task list
+    names the same files the worker will claim.
+    """
+    analyzer_id = getattr(analyzer, "id", getattr(analyzer, "device_name", "unknown"))
+    return analyzer_id or (
+        f"{analyzer.__class__.__name__}_{getattr(analyzer, 'device_name', '')}"
+    )
+
+
+def _spawn_worker(payload: dict) -> int:
+    """Launch the detached run_worker subprocess; return its pid.
+
+    A module-level seam (tests capture the payload instead of spawning).
+    The child is detached (own session on POSIX) with all stdio dropped —
+    its observable output is the status files; analyzer failures land in
+    each task's ``error`` field via ``run_worklist``'s own capture.  The
+    unwaited child is reaped by the stdlib's internal bookkeeping on a
+    later spawn — acceptable for the verb's low call rate.
+    """
+    proc = subprocess.Popen(  # noqa: S603 — fixed argv, our own module
+        [sys.executable, "-m", "geecs_mcp.analysis.run_worker", json.dumps(payload)],
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        start_new_session=(os.name == "posix"),
+    )
+    return proc.pid
+
+
+# ---------------------------------------------------------------------------
+# listings
+# ---------------------------------------------------------------------------
+
+
+def _listing_impl(kind: str) -> str:
+    """Shared body for the two discovery listings (``kind``: analyzers|groups)."""
+    try:
+        from scan_analysis.config import discover_analyzers, discover_groups
+    except ImportError as exc:
+        return errors.make_error("invalid_request", f"{_EXTRA_HINT}: {exc}")
+    root = _config_root()
+    if root is None:
+        return errors.make_error("invalid_request", _ROOT_HINT)
+    discover = discover_analyzers if kind == "analyzers" else discover_groups
+    try:
+        index = discover(root)
+    except FileNotFoundError as exc:
+        return errors.make_error("not_found", str(exc))
+    except ValueError as exc:  # duplicate stems — a configs-repo defect
+        return errors.make_error("invalid_request", str(exc))
+    names = sorted(index)
+    payload: dict[str, Any] = {
+        kind: names[:_MAX_LISTED_NAMES],
+        "count": len(names),
+        "truncated": len(names) > _MAX_LISTED_NAMES,
+        "config_root": str(root),
+    }
+    if kind == "groups":
+        # discover_groups indexes each group under its bare stem AND its
+        # namespace-qualified form — every listed name is accepted.
+        payload["note"] = "names include both bare stems and namespace/stem forms"
+    return errors.make_ok(**payload)
+
+
+def _list_analyzers_impl() -> str:
+    """Diagnostic IDs ``run_scan_analysis(analyzer=...)`` accepts."""
+    return _listing_impl("analyzers")
+
+
+def _list_analysis_groups_impl() -> str:
+    """Group names ``run_scan_analysis(group=...)`` accepts."""
+    return _listing_impl("groups")
+
+
+@mcp.tool(name=tool_names.LIST_ANALYZERS)
+async def list_analyzers() -> str:
+    """List the diagnostic IDs available to run_scan_analysis.
+
+    Returns
+    -------
+    str
+        JSON envelope with ``analyzers`` (sorted diagnostic IDs from the
+        configs repo's ``analyzers/`` tree), ``count``, and ``truncated``.
+    """
+    return await _run_guarded(_list_analyzers_impl)
+
+
+@mcp.tool(name=tool_names.LIST_ANALYSIS_GROUPS)
+async def list_analysis_groups() -> str:
+    """List the analysis-group names available to run_scan_analysis.
+
+    Returns
+    -------
+    str
+        JSON envelope with ``groups`` (sorted names from the configs
+        repo's ``groups/`` tree — bare stems and namespace-qualified
+        forms both resolve), ``count``, and ``truncated``.
+    """
+    return await _run_guarded(_list_analysis_groups_impl)
+
+
+# ---------------------------------------------------------------------------
+# run_scan_analysis
+# ---------------------------------------------------------------------------
+
+
+def _run_scan_analysis_impl(
+    scan_number: int,
+    day: Optional[str],
+    analyzer: Optional[str],
+    group: Optional[str],
+    rerun_failed: bool,
+    rerun_completed: bool,
+) -> str:
+    """Validate, enqueue statuses, and start the detached analysis worker."""
+    if bool(analyzer) == bool(group):
+        return errors.make_error(
+            "invalid_request",
+            "pass exactly one of 'analyzer' (a diagnostic ID from "
+            "list_analyzers) or 'group' (a name from list_analysis_groups)",
+        )
+    try:
+        from scan_analysis import task_queue
+        from scan_analysis.config import create_scan_analyzer
+
+        from image_analysis.config import load_diagnostic
+    except ImportError as exc:
+        return errors.make_error("invalid_request", f"{_EXTRA_HINT}: {exc}")
+    root = _config_root()
+    if root is None:
+        return errors.make_error("invalid_request", _ROOT_HINT)
+    try:
+        tag, scan_folder, _ = read_tools._resolve_folders(scan_number, day)
+    except (ValueError, RuntimeError) as exc:
+        return errors.make_error("invalid_request", str(exc))
+    if not scan_folder.is_dir():
+        # The cross-package invariant: analysis is a consumer of scan
+        # folders, never a producer — a missing folder is refused, never
+        # created (an SMB blip healed by mkdir orphans the real data).
+        return errors.make_error(
+            "not_found",
+            f"scan folder does not exist: {scan_folder} — analysis never "
+            "creates scan folders; check the scan number/day",
+        )
+    # Build the analyzer(s) now, in-server: this validates the name, the
+    # YAML, the image-analyzer class path — and this HOST.  A diagnostic
+    # needing a Windows-only SDK fails its import here and is refused
+    # before anything is enqueued.
+    try:
+        if analyzer:
+            analyzers = [
+                create_scan_analyzer(
+                    load_diagnostic(analyzer, config_dir=root), id=analyzer
+                )
+            ]
+        else:
+            analyzers = task_queue.load_analyzers_from_config(group, config_dir=root)
+    except (FileNotFoundError, KeyError) as exc:
+        # An unknown diagnostic stem raises KeyError (with the known-names
+        # list in the message), an unknown group FileNotFoundError.
+        return errors.make_error("not_found", str(exc))
+    except ImportError as exc:
+        return errors.make_error(
+            "invalid_request",
+            f"diagnostic cannot run on this host (import failed: {exc}) — "
+            "Windows-only SDK analyzers need the future Windows satellite "
+            "server, not this one",
+        )
+    except Exception as exc:
+        return errors.make_error(
+            "invalid_request", f"could not build the analyzer(s): {exc}"
+        )
+    if not analyzers:
+        return errors.make_error(
+            "invalid_request", f"group {group!r} resolved to zero analyzers"
+        )
+    base = read_tools._base_directory()
+    # Server-side init (idempotent): a worker that dies pre-claim leaves
+    # visible queued rows for get_scan_analysis instead of silence.
+    task_queue.init_status_for_scan(tag, analyzers, base_directory=base)
+    payload = {
+        "year": tag.year,
+        "month": tag.month,
+        "day": tag.day,
+        "number": tag.number,
+        "experiment": tag.experiment,
+        "analyzer": analyzer,
+        "group": group,
+        "rerun_failed": bool(rerun_failed),
+        "rerun_completed": bool(rerun_completed),
+        "config_root": str(root),
+        "base_directory": str(base) if base is not None else None,
+    }
+    pid = _spawn_worker(payload)
+    task_ids = [_analyzer_id(a) for a in analyzers]
+    logger.info(
+        "run_scan_analysis: scan %s (%s) -> %d task(s), worker pid %s",
+        tag.number,
+        analyzer or group,
+        len(task_ids),
+        pid,
+    )
+    return errors.make_ok(
+        started=True,
+        worker_pid=pid,
+        scan_number=tag.number,
+        day=f"{tag.year:04d}-{tag.month:02d}-{tag.day:02d}",
+        scan_folder=str(scan_folder),
+        tasks=task_ids,
+        note=(
+            "analysis runs detached — poll get_scan_analysis for task "
+            "states (queued → claimed → done/failed/no_data; a task "
+            "stuck 'queued' means the worker died before claiming)"
+        ),
+    )
+
+
+@mcp.tool(name=tool_names.RUN_SCAN_ANALYSIS)
+async def run_scan_analysis(
+    scan_number: int,
+    day: str | None = None,
+    analyzer: str | None = None,
+    group: str | None = None,
+    rerun_failed: bool = False,
+    rerun_completed: bool = False,
+) -> str:
+    """Run a ScanAnalysis diagnostic or group for one scan, detached.
+
+    Submit-and-poll: the call returns as soon as the tasks are enqueued
+    and the worker is started; poll ``get_scan_analysis`` for progress
+    and ``get_scan_figure`` for the produced figures.  The scan folder
+    must already exist (analysis never creates scan folders).
+
+    Parameters
+    ----------
+    scan_number : int
+        The scan to analyze.
+    day : str, optional
+        ISO date (``YYYY-MM-DD``); today when omitted.
+    analyzer : str, optional
+        One diagnostic ID (from ``list_analyzers``).  Exactly one of
+        ``analyzer``/``group`` is required.
+    group : str, optional
+        An analysis-group name (from ``list_analysis_groups``).
+    rerun_failed, rerun_completed : bool
+        Re-run tasks already recorded ``failed``/``done`` (default:
+        only never-run tasks execute — a repeat call is a cheap no-op).
+
+    Returns
+    -------
+    str
+        JSON envelope: the enqueued task ids, worker pid, and how to
+        poll — or a refusal (bad names, missing scan folder, a
+        diagnostic this host cannot run).
+    """
+    return await _run_guarded(
+        _run_scan_analysis_impl,
+        scan_number,
+        day,
+        analyzer,
+        group,
+        rerun_failed,
+        rerun_completed,
+    )

--- a/GEECS-MCP/geecs_mcp/analysis/run_tools.py
+++ b/GEECS-MCP/geecs_mcp/analysis/run_tools.py
@@ -46,6 +46,8 @@ import logging
 import os
 import subprocess
 import sys
+import threading
+import time
 from pathlib import Path
 from typing import Any, Optional
 
@@ -81,6 +83,27 @@ def _config_root() -> Optional[Path]:
     from geecs_data_utils.config_roots import scan_analysis_config
 
     return scan_analysis_config.base_dir
+
+
+#: In-process dispatch ledger: scan-folder str -> (worker pid, task ids,
+#: spawn monotonic time).  Closes the pre-claim double-start window for
+#: the realistic vector — two calls into THIS server (agent retries,
+#: parallel tool dispatch) — before a worker has even been spawned; the
+#: cross-process backstop is ScanAnalysis 1.16.0's atomic claim gate in
+#: ``run_worklist`` (a losing worker skips, never double-runs).  Entries
+#: expire when the worker pid dies, when its tasks leave ``queued``, or
+#: after ``CLAIM_STALE_AFTER_SECONDS`` (pid-reuse bound).
+_dispatched: dict[str, tuple[int, frozenset, float]] = {}
+_dispatch_lock = threading.Lock()
+
+
+def _pid_alive(pid: int) -> bool:
+    """Best-effort liveness of a spawned worker (module seam for tests)."""
+    try:
+        os.kill(pid, 0)
+    except OSError:
+        return False
+    return True
 
 
 def _spawn_worker(payload: dict) -> int:
@@ -268,6 +291,31 @@ def _run_scan_analysis_impl(
             f"{tag.number} (claimed, heartbeat fresh) — poll "
             "get_scan_analysis and retry after it finishes",
         )
+    # The pre-claim window (a just-spawned worker importing its stack has
+    # not claimed yet, so the rows still read queued): the in-process
+    # dispatch ledger refuses a second call for the same still-queued
+    # tasks — also before any status write, so this refusal is
+    # side-effect-free too.
+    with _dispatch_lock:
+        entry = _dispatched.get(str(scan_folder))
+        if entry is not None:
+            pid, pending, spawned_at = entry
+            overlap = [
+                tid
+                for tid in task_ids
+                if tid in pending and (tid not in pre or pre[tid].state == "queued")
+            ]
+            fresh = (
+                time.monotonic() - spawned_at
+            ) <= task_queue.CLAIM_STALE_AFTER_SECONDS
+            if overlap and fresh and _pid_alive(pid):
+                return errors.make_error(
+                    "policy_refusal",
+                    f"a worker (pid {pid}) was already dispatched for "
+                    f"task(s) {overlap} on scan {tag.number} and has not "
+                    "claimed yet — poll get_scan_analysis before retrying",
+                )
+            _dispatched.pop(str(scan_folder), None)
     # Server-side status bookkeeping BEFORE the spawn, so every requested
     # task is visibly queued even if the worker dies pre-claim: init the
     # missing rows, and — the rerun paths — reset done/failed (and
@@ -327,6 +375,8 @@ def _run_scan_analysis_impl(
         "base_directory": str(base) if base is not None else None,
     }
     pid = _spawn_worker(payload)
+    with _dispatch_lock:
+        _dispatched[str(scan_folder)] = (pid, frozenset(runnable), time.monotonic())
     logger.info(
         "run_scan_analysis: scan %s (%s) -> %d task(s), worker pid %s",
         tag.number,

--- a/GEECS-MCP/geecs_mcp/analysis/run_tools.py
+++ b/GEECS-MCP/geecs_mcp/analysis/run_tools.py
@@ -83,18 +83,6 @@ def _config_root() -> Optional[Path]:
     return scan_analysis_config.base_dir
 
 
-def _analyzer_id(analyzer: Any) -> str:
-    """The status-file id for *analyzer* — task_queue's own derivation.
-
-    Mirrors ``init_status_for_scan`` exactly so the envelope's task list
-    names the same files the worker will claim.
-    """
-    analyzer_id = getattr(analyzer, "id", getattr(analyzer, "device_name", "unknown"))
-    return analyzer_id or (
-        f"{analyzer.__class__.__name__}_{getattr(analyzer, 'device_name', '')}"
-    )
-
-
 def _spawn_worker(payload: dict) -> int:
     """Launch the detached run_worker subprocess; return its pid.
 
@@ -137,16 +125,20 @@ def _listing_impl(kind: str) -> str:
     except ValueError as exc:  # duplicate stems — a configs-repo defect
         return errors.make_error("invalid_request", str(exc))
     names = sorted(index)
+    # count = distinct config FILES: discover_groups indexes each group
+    # under two accepted names (bare stem + namespace/stem), and an agent
+    # asking "how many groups exist" must not get double.
     payload: dict[str, Any] = {
         kind: names[:_MAX_LISTED_NAMES],
-        "count": len(names),
+        "count": len(set(index.values())),
         "truncated": len(names) > _MAX_LISTED_NAMES,
         "config_root": str(root),
     }
     if kind == "groups":
-        # discover_groups indexes each group under its bare stem AND its
-        # namespace-qualified form — every listed name is accepted.
-        payload["note"] = "names include both bare stems and namespace/stem forms"
+        payload["note"] = (
+            "names include both bare stems and namespace/stem forms — "
+            "every listed name is accepted; count is distinct groups"
+        )
     return errors.make_ok(**payload)
 
 
@@ -209,9 +201,6 @@ def _run_scan_analysis_impl(
         )
     try:
         from scan_analysis import task_queue
-        from scan_analysis.config import create_scan_analyzer
-
-        from image_analysis.config import load_diagnostic
     except ImportError as exc:
         return errors.make_error("invalid_request", f"{_EXTRA_HINT}: {exc}")
     root = _config_root()
@@ -230,19 +219,16 @@ def _run_scan_analysis_impl(
             f"scan folder does not exist: {scan_folder} — analysis never "
             "creates scan folders; check the scan number/day",
         )
-    # Build the analyzer(s) now, in-server: this validates the name, the
-    # YAML, the image-analyzer class path — and this HOST.  A diagnostic
-    # needing a Windows-only SDK fails its import here and is refused
-    # before anything is enqueued.
+    # Build the analyzer(s) now, in-server, through the SAME builder the
+    # worker runs (run_worker.build_analyzers — one implementation, so
+    # this validation can never drift from the execution): validates the
+    # name, the YAML, the image-analyzer class path — and this HOST.  A
+    # diagnostic needing a Windows-only SDK fails its import here and is
+    # refused before anything is enqueued.
+    from geecs_mcp.analysis.run_worker import build_analyzers
+
     try:
-        if analyzer:
-            analyzers = [
-                create_scan_analyzer(
-                    load_diagnostic(analyzer, config_dir=root), id=analyzer
-                )
-            ]
-        else:
-            analyzers = task_queue.load_analyzers_from_config(group, config_dir=root)
+        analyzers = build_analyzers(analyzer, group, root)
     except (FileNotFoundError, KeyError) as exc:
         # An unknown diagnostic stem raises KeyError (with the known-names
         # list in the message), an unknown group FileNotFoundError.
@@ -262,10 +248,67 @@ def _run_scan_analysis_impl(
         return errors.make_error(
             "invalid_request", f"group {group!r} resolved to zero analyzers"
         )
+    task_ids = [task_queue.analyzer_task_id(a) for a in analyzers]
     base = read_tools._base_directory()
-    # Server-side init (idempotent): a worker that dies pre-claim leaves
-    # visible queued rows for get_scan_analysis instead of silence.
+    # Server-side status bookkeeping BEFORE the spawn, so every requested
+    # task is visibly queued even if the worker dies pre-claim: init the
+    # missing rows, and — the rerun paths — reset done/failed (and
+    # stale-claimed) rows to queued; reset refuses to touch a live claim.
     task_queue.init_status_for_scan(tag, analyzers, base_directory=base)
+    reset_states = tuple(
+        state
+        for state, wanted in (("failed", rerun_failed), ("done", rerun_completed))
+        if wanted
+    )
+    if reset_states:
+        task_queue.reset_status_for_scan(
+            tag,
+            analyzers,
+            base_directory=base,
+            states_to_reset=reset_states + ("claimed",),
+        )
+    # Classify what this call will actually run: a task another runner is
+    # actively working (fresh heartbeat) refuses the whole call — two
+    # workers claiming the same task would run the same analysis twice
+    # into the same output files; done/failed rows without their rerun
+    # flag are reported as skipped, not silently re-listed as work.
+    statuses = {s.analyzer_id: s for s in task_queue.read_statuses(scan_folder)}
+    active = [
+        tid
+        for tid in task_ids
+        if tid in statuses and task_queue.claim_is_active(statuses[tid])
+    ]
+    if active:
+        return errors.make_error(
+            "policy_refusal",
+            f"analysis already running for task(s) {active} on scan "
+            f"{tag.number} (claimed, heartbeat fresh) — poll "
+            "get_scan_analysis and retry after it finishes",
+        )
+    # Any remaining "claimed" is stale (active ones refused above) —
+    # build_worklist reclaims those, so they count as runnable.
+    runnable = [
+        tid
+        for tid in task_ids
+        if tid not in statuses or statuses[tid].state in ("queued", "claimed")
+    ]
+    skipped = {tid: statuses[tid].state for tid in task_ids if tid not in runnable}
+    common = {
+        "scan_number": tag.number,
+        "day": f"{tag.year:04d}-{tag.month:02d}-{tag.day:02d}",
+        "scan_folder": str(scan_folder),
+    }
+    if not runnable:
+        return errors.make_ok(
+            started=False,
+            tasks=[],
+            skipped=skipped,
+            note=(
+                "nothing to run — every requested task is already "
+                "done/failed; pass rerun_completed/rerun_failed to re-run"
+            ),
+            **common,
+        )
     payload = {
         "year": tag.year,
         "month": tag.month,
@@ -280,26 +323,27 @@ def _run_scan_analysis_impl(
         "base_directory": str(base) if base is not None else None,
     }
     pid = _spawn_worker(payload)
-    task_ids = [_analyzer_id(a) for a in analyzers]
     logger.info(
         "run_scan_analysis: scan %s (%s) -> %d task(s), worker pid %s",
         tag.number,
         analyzer or group,
-        len(task_ids),
+        len(runnable),
         pid,
     )
     return errors.make_ok(
         started=True,
         worker_pid=pid,
-        scan_number=tag.number,
-        day=f"{tag.year:04d}-{tag.month:02d}-{tag.day:02d}",
-        scan_folder=str(scan_folder),
-        tasks=task_ids,
+        tasks=runnable,
+        skipped=skipped,
         note=(
             "analysis runs detached — poll get_scan_analysis for task "
-            "states (queued → claimed → done/failed/no_data; a task "
-            "stuck 'queued' means the worker died before claiming)"
+            "states (queued → claimed → done/failed/no_data).  A task "
+            "stuck 'queued' means the worker died before claiming; "
+            "'claimed' with a growing heartbeat_age_s means it died "
+            "mid-run (the claim goes stale after 180 s and a repeat "
+            "call re-runs it)"
         ),
+        **common,
     )
 
 

--- a/GEECS-MCP/geecs_mcp/analysis/run_tools.py
+++ b/GEECS-MCP/geecs_mcp/analysis/run_tools.py
@@ -311,9 +311,22 @@ def _run_scan_analysis_impl(
     # dead or expired — never a live entry for a non-overlapping task
     # (both were review-round-4 findings, one reproduced).
     scan_key = str(scan_folder)
-    window_ids = [
-        tid for tid in task_ids if tid not in pre or pre[tid].state == "queued"
-    ]
+
+    def _window_eligible(tid: str) -> bool:
+        # Everything this call could actually dispatch (round-5 review:
+        # the window must mirror the runnable classification, or rerun
+        # and stale-claim-reclaim dispatches escape the ledger): absent
+        # or queued rows; claimed rows (active ones were refused above,
+        # so any reaching here is stale ⇒ reclaimable); and done/failed
+        # rows their rerun flag will re-queue.
+        st = pre.get(tid)
+        if st is None or st.state in ("queued", "claimed"):
+            return True
+        if st.state == "failed" and rerun_failed:
+            return True
+        return st.state == "done" and rerun_completed
+
+    window_ids = [tid for tid in task_ids if _window_eligible(tid)]
     now_mono = time.monotonic()
     reserved: list[tuple[str, str]] = []
     with _dispatch_lock:

--- a/GEECS-MCP/geecs_mcp/analysis/run_tools.py
+++ b/GEECS-MCP/geecs_mcp/analysis/run_tools.py
@@ -85,16 +85,26 @@ def _config_root() -> Optional[Path]:
     return scan_analysis_config.base_dir
 
 
-#: In-process dispatch ledger: scan-folder str -> (worker pid, task ids,
-#: spawn monotonic time).  Closes the pre-claim double-start window for
+#: In-process dispatch ledger: ``(scan-folder str, task id)`` -> (worker
+#: pid, monotonic time).  Closes the pre-claim double-start window for
 #: the realistic vector — two calls into THIS server (agent retries,
 #: parallel tool dispatch) — before a worker has even been spawned; the
 #: cross-process backstop is ScanAnalysis 1.16.0's atomic claim gate in
-#: ``run_worklist`` (a losing worker skips, never double-runs).  Entries
-#: expire when the worker pid dies, when its tasks leave ``queued``, or
-#: after ``CLAIM_STALE_AFTER_SECONDS`` (pid-reuse bound).
-_dispatched: dict[str, tuple[int, frozenset, float]] = {}
+#: ``run_worklist`` (a losing worker skips, never double-runs).  Keyed
+#: per task, not per scan (one scan can legitimately carry two live
+#: pre-claim workers for different analyzers — review round 4).  An
+#: entry blocks while its pid is alive (or still ``_RESERVED``: written
+#: under the lock at check time, so two truly concurrent calls cannot
+#: both pass before either records) and it is younger than
+#: ``CLAIM_STALE_AFTER_SECONDS`` (the pid-reuse bound); dead/expired
+#: entries are evicted on the next look — never live ones.
+_dispatched: dict[tuple[str, str], tuple[int, float]] = {}
 _dispatch_lock = threading.Lock()
+
+#: Sentinel pid for a ledger entry reserved at check time, replaced by
+#: the real worker pid right after the spawn (released if the call ends
+#: without spawning).
+_RESERVED = -1
 
 
 def _pid_alive(pid: int) -> bool:
@@ -295,27 +305,82 @@ def _run_scan_analysis_impl(
     # not claimed yet, so the rows still read queued): the in-process
     # dispatch ledger refuses a second call for the same still-queued
     # tasks — also before any status write, so this refusal is
-    # side-effect-free too.
+    # side-effect-free too.  The window tasks (still queued/absent) are
+    # RESERVED under the same lock hold that checked them, so two truly
+    # concurrent calls cannot both pass; entries are evicted only when
+    # dead or expired — never a live entry for a non-overlapping task
+    # (both were review-round-4 findings, one reproduced).
+    scan_key = str(scan_folder)
+    window_ids = [
+        tid for tid in task_ids if tid not in pre or pre[tid].state == "queued"
+    ]
+    now_mono = time.monotonic()
+    reserved: list[tuple[str, str]] = []
     with _dispatch_lock:
-        entry = _dispatched.get(str(scan_folder))
-        if entry is not None:
-            pid, pending, spawned_at = entry
-            overlap = [
-                tid
-                for tid in task_ids
-                if tid in pending and (tid not in pre or pre[tid].state == "queued")
-            ]
-            fresh = (
-                time.monotonic() - spawned_at
-            ) <= task_queue.CLAIM_STALE_AFTER_SECONDS
-            if overlap and fresh and _pid_alive(pid):
-                return errors.make_error(
-                    "policy_refusal",
-                    f"a worker (pid {pid}) was already dispatched for "
-                    f"task(s) {overlap} on scan {tag.number} and has not "
-                    "claimed yet — poll get_scan_analysis before retrying",
-                )
-            _dispatched.pop(str(scan_folder), None)
+        blocked = []
+        for tid in window_ids:
+            entry = _dispatched.get((scan_key, tid))
+            if entry is None:
+                continue
+            pid, stamped = entry
+            fresh = (now_mono - stamped) <= task_queue.CLAIM_STALE_AFTER_SECONDS
+            if fresh and (pid == _RESERVED or _pid_alive(pid)):
+                blocked.append(tid)
+            else:
+                _dispatched.pop((scan_key, tid), None)  # dead/expired only
+        if blocked:
+            return errors.make_error(
+                "policy_refusal",
+                f"a worker was already dispatched for task(s) {blocked} on "
+                f"scan {tag.number} and has not claimed yet — poll "
+                "get_scan_analysis before retrying",
+            )
+        for tid in window_ids:
+            _dispatched[(scan_key, tid)] = (_RESERVED, now_mono)
+            reserved.append((scan_key, tid))
+    try:
+        return _finish_run_dispatch(
+            task_queue,
+            tag,
+            scan_folder,
+            base,
+            analyzers,
+            task_ids,
+            analyzer,
+            group,
+            rerun_failed,
+            rerun_completed,
+            root,
+            reserved,
+        )
+    finally:
+        # Release any reservation the spawn did not convert to a real
+        # pid (refused/no-op/raise paths) — never a converted entry.
+        with _dispatch_lock:
+            for key in reserved:
+                if _dispatched.get(key, (None,))[0] == _RESERVED:
+                    _dispatched.pop(key, None)
+
+
+def _finish_run_dispatch(
+    task_queue,
+    tag,
+    scan_folder: Path,
+    base: Optional[Path],
+    analyzers: list,
+    task_ids: list,
+    analyzer: Optional[str],
+    group: Optional[str],
+    rerun_failed: bool,
+    rerun_completed: bool,
+    root: Path,
+    reserved: list,
+) -> str:
+    """The post-reservation half of ``_run_scan_analysis_impl``.
+
+    Split out so the reservation release lives in exactly one
+    ``finally`` around this call.
+    """
     # Server-side status bookkeeping BEFORE the spawn, so every requested
     # task is visibly queued even if the worker dies pre-claim: init the
     # missing rows, and — the rerun paths — reset done/failed (and
@@ -376,7 +441,10 @@ def _run_scan_analysis_impl(
     }
     pid = _spawn_worker(payload)
     with _dispatch_lock:
-        _dispatched[str(scan_folder)] = (pid, frozenset(runnable), time.monotonic())
+        stamped = time.monotonic()
+        for key in reserved:
+            if key[1] in runnable:
+                _dispatched[key] = (pid, stamped)  # reservation -> real pid
     logger.info(
         "run_scan_analysis: scan %s (%s) -> %d task(s), worker pid %s",
         tag.number,

--- a/GEECS-MCP/geecs_mcp/analysis/run_tools.py
+++ b/GEECS-MCP/geecs_mcp/analysis/run_tools.py
@@ -250,6 +250,24 @@ def _run_scan_analysis_impl(
         )
     task_ids = [task_queue.analyzer_task_id(a) for a in analyzers]
     base = read_tools._base_directory()
+    # The active-claim refusal comes FIRST, before any status write, so a
+    # refused call is side-effect-free: a task another runner is actively
+    # working (fresh heartbeat) refuses the whole call — two workers
+    # claiming the same task would run the same analysis twice into the
+    # same output files.  (Resetting first would re-queue the scan's other
+    # rows and then refuse, leaving rows that read exactly like the
+    # "worker died before claiming" signature.)
+    pre = {s.analyzer_id: s for s in task_queue.read_statuses(scan_folder)}
+    active = [
+        tid for tid in task_ids if tid in pre and task_queue.claim_is_active(pre[tid])
+    ]
+    if active:
+        return errors.make_error(
+            "policy_refusal",
+            f"analysis already running for task(s) {active} on scan "
+            f"{tag.number} (claimed, heartbeat fresh) — poll "
+            "get_scan_analysis and retry after it finishes",
+        )
     # Server-side status bookkeeping BEFORE the spawn, so every requested
     # task is visibly queued even if the worker dies pre-claim: init the
     # missing rows, and — the rerun paths — reset done/failed (and
@@ -267,24 +285,10 @@ def _run_scan_analysis_impl(
             base_directory=base,
             states_to_reset=reset_states + ("claimed",),
         )
-    # Classify what this call will actually run: a task another runner is
-    # actively working (fresh heartbeat) refuses the whole call — two
-    # workers claiming the same task would run the same analysis twice
-    # into the same output files; done/failed rows without their rerun
-    # flag are reported as skipped, not silently re-listed as work.
+    # Classify what this call will actually run from the post-init/reset
+    # states: done/failed rows without their rerun flag are reported as
+    # skipped, not silently re-listed as work.
     statuses = {s.analyzer_id: s for s in task_queue.read_statuses(scan_folder)}
-    active = [
-        tid
-        for tid in task_ids
-        if tid in statuses and task_queue.claim_is_active(statuses[tid])
-    ]
-    if active:
-        return errors.make_error(
-            "policy_refusal",
-            f"analysis already running for task(s) {active} on scan "
-            f"{tag.number} (claimed, heartbeat fresh) — poll "
-            "get_scan_analysis and retry after it finishes",
-        )
     # Any remaining "claimed" is stale (active ones refused above) —
     # build_worklist reclaims those, so they count as runnable.
     runnable = [

--- a/GEECS-MCP/geecs_mcp/analysis/run_worker.py
+++ b/GEECS-MCP/geecs_mcp/analysis/run_worker.py
@@ -20,6 +20,43 @@ import sys
 from pathlib import Path
 
 
+def build_analyzers(analyzer: str | None, group: str | None, config_root: Path) -> list:
+    """Construct the analyzer(s) for one request — THE shared builder.
+
+    Called by the tool (validation: the names resolve AND the classes
+    import on this host) and by the worker (the actual instances it
+    runs) — one implementation, so the pre-flight validation can never
+    drift from what the worker executes.
+
+    Parameters
+    ----------
+    analyzer : str or None
+        A diagnostic ID; exactly one of ``analyzer``/``group`` is set
+        (the tool enforces this before calling).
+    group : str or None
+        An analysis-group name.
+    config_root : Path
+        The scan-analysis configs root (``analyzers/`` + ``groups/``).
+
+    Returns
+    -------
+    list
+        Runnable ScanAnalyzer instances, in execution order.
+    """
+    if analyzer:
+        from image_analysis.config import load_diagnostic
+        from scan_analysis.config import create_scan_analyzer
+
+        return [
+            create_scan_analyzer(
+                load_diagnostic(analyzer, config_dir=config_root), id=analyzer
+            )
+        ]
+    from scan_analysis.task_queue import load_analyzers_from_config
+
+    return load_analyzers_from_config(group, config_dir=config_root)
+
+
 def main(argv: list[str] | None = None) -> None:
     """Run the worklist described by the JSON payload in ``argv[0]``."""
     logging.basicConfig(level=logging.INFO)
@@ -39,20 +76,7 @@ def main(argv: list[str] | None = None) -> None:
     raw_base = payload.get("base_directory")
     base = Path(raw_base) if raw_base else None
 
-    if payload.get("analyzer"):
-        from image_analysis.config import load_diagnostic
-        from scan_analysis.config import create_scan_analyzer
-
-        analyzers = [
-            create_scan_analyzer(
-                load_diagnostic(payload["analyzer"], config_dir=root),
-                id=payload["analyzer"],
-            )
-        ]
-    else:
-        from scan_analysis.task_queue import load_analyzers_from_config
-
-        analyzers = load_analyzers_from_config(payload["group"], config_dir=root)
+    analyzers = build_analyzers(payload.get("analyzer"), payload.get("group"), root)
 
     from scan_analysis import task_queue
 

--- a/GEECS-MCP/geecs_mcp/analysis/run_worker.py
+++ b/GEECS-MCP/geecs_mcp/analysis/run_worker.py
@@ -1,0 +1,70 @@
+"""The detached analysis worker behind ``run_scan_analysis`` (#686).
+
+Spawned by :func:`geecs_mcp.analysis.run_tools._spawn_worker` with one
+JSON argv payload; runs the ScanAnalysis task queue for one scan and
+exits.  All progress narration goes through the ``analysis_status/``
+YAMLs (claim → heartbeat → done/failed/no_data — ``run_worklist``'s own
+machinery), which the server's ``get_scan_analysis`` polls; stdio is
+detached, so the status files are the one observable surface.
+
+The statuses were already initialized server-side (visible queued rows
+even if this process dies before claiming); this worker only builds the
+worklist and runs it.  ``gdoc_enabled`` stays at its hard-off default.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import sys
+from pathlib import Path
+
+
+def main(argv: list[str] | None = None) -> None:
+    """Run the worklist described by the JSON payload in ``argv[0]``."""
+    logging.basicConfig(level=logging.INFO)
+    args = sys.argv[1:] if argv is None else argv
+    payload = json.loads(args[0])
+
+    from geecs_data_utils import ScanTag
+
+    tag = ScanTag(
+        year=int(payload["year"]),
+        month=int(payload["month"]),
+        day=int(payload["day"]),
+        number=int(payload["number"]),
+        experiment=payload["experiment"],
+    )
+    root = Path(payload["config_root"])
+    raw_base = payload.get("base_directory")
+    base = Path(raw_base) if raw_base else None
+
+    if payload.get("analyzer"):
+        from image_analysis.config import load_diagnostic
+        from scan_analysis.config import create_scan_analyzer
+
+        analyzers = [
+            create_scan_analyzer(
+                load_diagnostic(payload["analyzer"], config_dir=root),
+                id=payload["analyzer"],
+            )
+        ]
+    else:
+        from scan_analysis.task_queue import load_analyzers_from_config
+
+        analyzers = load_analyzers_from_config(payload["group"], config_dir=root)
+
+    from scan_analysis import task_queue
+
+    worklist = task_queue.build_worklist(
+        [tag],
+        analyzers,
+        base_directory=base,
+        rerun_failed=bool(payload.get("rerun_failed")),
+        rerun_completed=bool(payload.get("rerun_completed")),
+    )
+    task_queue.run_worklist(worklist, base_directory=base)
+
+
+if __name__ == "__main__":
+    main()

--- a/GEECS-MCP/geecs_mcp/server.py
+++ b/GEECS-MCP/geecs_mcp/server.py
@@ -36,8 +36,12 @@ mcp = FastMCP(
         "get_scan_analysis (task statuses + output tree) and "
         "get_scan_figure (a figure REFERENCE — metadata plus a fetch "
         "URL served by this same server; thumbnail=true for a bounded "
-        "inline preview, never pull full figures through context). "
-        "Names must come from list_scan_configs — never invent catalog "
+        "inline preview, never pull full figures through context), "
+        "run_scan_analysis (execute a ScanAnalysis diagnostic or group "
+        "for one existing scan, detached — poll get_scan_analysis for "
+        "progress; analyzer/group names come from list_analyzers / "
+        "list_analysis_groups). "
+        "Names must come from the listing tools — never invent catalog "
         "names."
     ),
 )
@@ -45,8 +49,9 @@ mcp = FastMCP(
 
 def create_server() -> FastMCP:
     """Register every tool module and return the server."""
-    from geecs_mcp.analysis import (  # noqa: F401 — self-registers
+    from geecs_mcp.analysis import (  # noqa: F401 — self-register
         read_tools as analysis_read_tools,
+        run_tools as analysis_run_tools,
     )
     from geecs_mcp.scans import (  # noqa: F401 — self-register
         control_tools,

--- a/GEECS-MCP/geecs_mcp/tool_names.py
+++ b/GEECS-MCP/geecs_mcp/tool_names.py
@@ -19,6 +19,9 @@ VALIDATE_SCAN_REQUEST = "validate_scan_request"
 SCAN_PROGRESS = "scan_progress"
 GET_SCAN_ANALYSIS = "get_scan_analysis"
 GET_SCAN_FIGURE = "get_scan_figure"
+LIST_ANALYZERS = "list_analyzers"
+LIST_ANALYSIS_GROUPS = "list_analysis_groups"
+RUN_SCAN_ANALYSIS = "run_scan_analysis"
 SUBMIT_SCAN = "submit_scan"
 STOP_SCAN = "stop_scan"
 CLEAR_QUEUE = "clear_queue"
@@ -40,6 +43,8 @@ READ_TOOLS = (
     SCAN_PROGRESS,
     GET_SCAN_ANALYSIS,
     GET_SCAN_FIGURE,
+    LIST_ANALYZERS,
+    LIST_ANALYSIS_GROUPS,
     DESCRIBE_ACTION,
 )
 
@@ -49,12 +54,17 @@ READ_TOOLS = (
 #: below / DEPLOYMENT.md).  resume_scan is Q, not S: it *restarts*
 #: motion/acquisition (and retries the failed move), so it belongs
 #: behind the headless gate like any other go verb.
+#: run_scan_analysis is Q by effect, not by queueing semantics: it writes
+#: to the data share (analysis outputs + analysis_status/ inside an
+#: EXISTING scan folder) and burns CPU on the box shared with the
+#: production manager (#686).
 QUEUE_TOOLS = (
     SUBMIT_SCAN,
     CLEAR_QUEUE,
     RUN_ACTION,
     MOVE_SCAN_VARIABLE,
     RESUME_SCAN,
+    RUN_SCAN_ANALYSIS,
 )
 
 #: Stop direction (S) — `ask` only, and NEVER listed in `write_tools`:

--- a/GEECS-MCP/poetry.lock
+++ b/GEECS-MCP/poetry.lock
@@ -425,6 +425,48 @@ httpx = "*"
 websockets = "*"
 
 [[package]]
+name = "boto3"
+version = "1.43.79"
+description = "The AWS SDK for Python"
+optional = true
+python-versions = ">=3.10"
+groups = ["main"]
+markers = "extra == \"analysis-run\""
+files = [
+    {file = "boto3-1.43.79-py3-none-any.whl", hash = "sha256:4c2381cf99abf749c82762a636337f4aba4800fda6525412fcae2bebe4f72748"},
+    {file = "boto3-1.43.79.tar.gz", hash = "sha256:a36b4209a8170f7f8d2c19b36f350808f313b178939c9e5df0a8f683717a6d9c"},
+]
+
+[package.dependencies]
+botocore = ">=1.43.79,<1.44.0"
+jmespath = ">=0.7.1,<2.0.0"
+s3transfer = ">=0.19.0,<0.20.0"
+
+[package.extras]
+crt = ["botocore[crt] (>=1.21.0,<2.0a0)"]
+
+[[package]]
+name = "botocore"
+version = "1.43.79"
+description = "Low-level, data-driven core of boto 3."
+optional = true
+python-versions = ">=3.10"
+groups = ["main"]
+markers = "extra == \"analysis-run\""
+files = [
+    {file = "botocore-1.43.79-py3-none-any.whl", hash = "sha256:19b2c772ea2590d0baad6ae004a0e478cf2c982e0e6a39c8e2f882d9b2981445"},
+    {file = "botocore-1.43.79.tar.gz", hash = "sha256:dcc0a97b65affcef80e0499745d2e6a5d120253c11b8727b8227df44ab3e958f"},
+]
+
+[package.dependencies]
+jmespath = ">=0.7.1,<2.0.0"
+python-dateutil = ">=2.1,<3.0.0"
+urllib3 = ">=1.25.4,<2.2.0 || >2.2.0,<3"
+
+[package.extras]
+crt = ["awscrt (==0.36.0)"]
+
+[[package]]
 name = "cachetools"
 version = "7.1.7"
 description = "Extensible memoizing collections and decorators"
@@ -883,6 +925,99 @@ cloudpickle = ["cloudpickle"]
 dill = ["dill"]
 full = ["cloudpickle", "dill", "lz4"]
 lz4 = ["lz4"]
+
+[[package]]
+name = "contourpy"
+version = "1.3.3"
+description = "Python library for calculating contours of 2D quadrilateral grids"
+optional = true
+python-versions = ">=3.11"
+groups = ["main"]
+markers = "extra == \"analysis-run\""
+files = [
+    {file = "contourpy-1.3.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:709a48ef9a690e1343202916450bc48b9e51c049b089c7f79a267b46cffcdaa1"},
+    {file = "contourpy-1.3.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:23416f38bfd74d5d28ab8429cc4d63fa67d5068bd711a85edb1c3fb0c3e2f381"},
+    {file = "contourpy-1.3.3-cp311-cp311-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:929ddf8c4c7f348e4c0a5a3a714b5c8542ffaa8c22954862a46ca1813b667ee7"},
+    {file = "contourpy-1.3.3-cp311-cp311-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:9e999574eddae35f1312c2b4b717b7885d4edd6cb46700e04f7f02db454e67c1"},
+    {file = "contourpy-1.3.3-cp311-cp311-manylinux_2_26_s390x.manylinux_2_28_s390x.whl", hash = "sha256:0bf67e0e3f482cb69779dd3061b534eb35ac9b17f163d851e2a547d56dba0a3a"},
+    {file = "contourpy-1.3.3-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:51e79c1f7470158e838808d4a996fa9bac72c498e93d8ebe5119bc1e6becb0db"},
+    {file = "contourpy-1.3.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:598c3aaece21c503615fd59c92a3598b428b2f01bfb4b8ca9c4edeecc2438620"},
+    {file = "contourpy-1.3.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:322ab1c99b008dad206d406bb61d014cf0174df491ae9d9d0fac6a6fda4f977f"},
+    {file = "contourpy-1.3.3-cp311-cp311-win32.whl", hash = "sha256:fd907ae12cd483cd83e414b12941c632a969171bf90fc937d0c9f268a31cafff"},
+    {file = "contourpy-1.3.3-cp311-cp311-win_amd64.whl", hash = "sha256:3519428f6be58431c56581f1694ba8e50626f2dd550af225f82fb5f5814d2a42"},
+    {file = "contourpy-1.3.3-cp311-cp311-win_arm64.whl", hash = "sha256:15ff10bfada4bf92ec8b31c62bf7c1834c244019b4a33095a68000d7075df470"},
+    {file = "contourpy-1.3.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:b08a32ea2f8e42cf1d4be3169a98dd4be32bafe4f22b6c4cb4ba810fa9e5d2cb"},
+    {file = "contourpy-1.3.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:556dba8fb6f5d8742f2923fe9457dbdd51e1049c4a43fd3986a0b14a1d815fc6"},
+    {file = "contourpy-1.3.3-cp312-cp312-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:92d9abc807cf7d0e047b95ca5d957cf4792fcd04e920ca70d48add15c1a90ea7"},
+    {file = "contourpy-1.3.3-cp312-cp312-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:b2e8faa0ed68cb29af51edd8e24798bb661eac3bd9f65420c1887b6ca89987c8"},
+    {file = "contourpy-1.3.3-cp312-cp312-manylinux_2_26_s390x.manylinux_2_28_s390x.whl", hash = "sha256:626d60935cf668e70a5ce6ff184fd713e9683fb458898e4249b63be9e28286ea"},
+    {file = "contourpy-1.3.3-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4d00e655fcef08aba35ec9610536bfe90267d7ab5ba944f7032549c55a146da1"},
+    {file = "contourpy-1.3.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:451e71b5a7d597379ef572de31eeb909a87246974d960049a9848c3bc6c41bf7"},
+    {file = "contourpy-1.3.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:459c1f020cd59fcfe6650180678a9993932d80d44ccde1fa1868977438f0b411"},
+    {file = "contourpy-1.3.3-cp312-cp312-win32.whl", hash = "sha256:023b44101dfe49d7d53932be418477dba359649246075c996866106da069af69"},
+    {file = "contourpy-1.3.3-cp312-cp312-win_amd64.whl", hash = "sha256:8153b8bfc11e1e4d75bcb0bff1db232f9e10b274e0929de9d608027e0d34ff8b"},
+    {file = "contourpy-1.3.3-cp312-cp312-win_arm64.whl", hash = "sha256:07ce5ed73ecdc4a03ffe3e1b3e3c1166db35ae7584be76f65dbbe28a7791b0cc"},
+    {file = "contourpy-1.3.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:177fb367556747a686509d6fef71d221a4b198a3905fe824430e5ea0fda54eb5"},
+    {file = "contourpy-1.3.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:d002b6f00d73d69333dac9d0b8d5e84d9724ff9ef044fd63c5986e62b7c9e1b1"},
+    {file = "contourpy-1.3.3-cp313-cp313-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:348ac1f5d4f1d66d3322420f01d42e43122f43616e0f194fc1c9f5d830c5b286"},
+    {file = "contourpy-1.3.3-cp313-cp313-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:655456777ff65c2c548b7c454af9c6f33f16c8884f11083244b5819cc214f1b5"},
+    {file = "contourpy-1.3.3-cp313-cp313-manylinux_2_26_s390x.manylinux_2_28_s390x.whl", hash = "sha256:644a6853d15b2512d67881586bd03f462c7ab755db95f16f14d7e238f2852c67"},
+    {file = "contourpy-1.3.3-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4debd64f124ca62069f313a9cb86656ff087786016d76927ae2cf37846b006c9"},
+    {file = "contourpy-1.3.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a15459b0f4615b00bbd1e91f1b9e19b7e63aea7483d03d804186f278c0af2659"},
+    {file = "contourpy-1.3.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:ca0fdcd73925568ca027e0b17ab07aad764be4706d0a925b89227e447d9737b7"},
+    {file = "contourpy-1.3.3-cp313-cp313-win32.whl", hash = "sha256:b20c7c9a3bf701366556e1b1984ed2d0cedf999903c51311417cf5f591d8c78d"},
+    {file = "contourpy-1.3.3-cp313-cp313-win_amd64.whl", hash = "sha256:1cadd8b8969f060ba45ed7c1b714fe69185812ab43bd6b86a9123fe8f99c3263"},
+    {file = "contourpy-1.3.3-cp313-cp313-win_arm64.whl", hash = "sha256:fd914713266421b7536de2bfa8181aa8c699432b6763a0ea64195ebe28bff6a9"},
+    {file = "contourpy-1.3.3-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:88df9880d507169449d434c293467418b9f6cbe82edd19284aa0409e7fdb933d"},
+    {file = "contourpy-1.3.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:d06bb1f751ba5d417047db62bca3c8fde202b8c11fb50742ab3ab962c81e8216"},
+    {file = "contourpy-1.3.3-cp313-cp313t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e4e6b05a45525357e382909a4c1600444e2a45b4795163d3b22669285591c1ae"},
+    {file = "contourpy-1.3.3-cp313-cp313t-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ab3074b48c4e2cf1a960e6bbeb7f04566bf36b1861d5c9d4d8ac04b82e38ba20"},
+    {file = "contourpy-1.3.3-cp313-cp313t-manylinux_2_26_s390x.manylinux_2_28_s390x.whl", hash = "sha256:6c3d53c796f8647d6deb1abe867daeb66dcc8a97e8455efa729516b997b8ed99"},
+    {file = "contourpy-1.3.3-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:50ed930df7289ff2a8d7afeb9603f8289e5704755c7e5c3bbd929c90c817164b"},
+    {file = "contourpy-1.3.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:4feffb6537d64b84877da813a5c30f1422ea5739566abf0bd18065ac040e120a"},
+    {file = "contourpy-1.3.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:2b7e9480ffe2b0cd2e787e4df64270e3a0440d9db8dc823312e2c940c167df7e"},
+    {file = "contourpy-1.3.3-cp313-cp313t-win32.whl", hash = "sha256:283edd842a01e3dcd435b1c5116798d661378d83d36d337b8dde1d16a5fc9ba3"},
+    {file = "contourpy-1.3.3-cp313-cp313t-win_amd64.whl", hash = "sha256:87acf5963fc2b34825e5b6b048f40e3635dd547f590b04d2ab317c2619ef7ae8"},
+    {file = "contourpy-1.3.3-cp313-cp313t-win_arm64.whl", hash = "sha256:3c30273eb2a55024ff31ba7d052dde990d7d8e5450f4bbb6e913558b3d6c2301"},
+    {file = "contourpy-1.3.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:fde6c716d51c04b1c25d0b90364d0be954624a0ee9d60e23e850e8d48353d07a"},
+    {file = "contourpy-1.3.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:cbedb772ed74ff5be440fa8eee9bd49f64f6e3fc09436d9c7d8f1c287b121d77"},
+    {file = "contourpy-1.3.3-cp314-cp314-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:22e9b1bd7a9b1d652cd77388465dc358dafcd2e217d35552424aa4f996f524f5"},
+    {file = "contourpy-1.3.3-cp314-cp314-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a22738912262aa3e254e4f3cb079a95a67132fc5a063890e224393596902f5a4"},
+    {file = "contourpy-1.3.3-cp314-cp314-manylinux_2_26_s390x.manylinux_2_28_s390x.whl", hash = "sha256:afe5a512f31ee6bd7d0dda52ec9864c984ca3d66664444f2d72e0dc4eb832e36"},
+    {file = "contourpy-1.3.3-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f64836de09927cba6f79dcd00fdd7d5329f3fccc633468507079c829ca4db4e3"},
+    {file = "contourpy-1.3.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:1fd43c3be4c8e5fd6e4f2baeae35ae18176cf2e5cced681cca908addf1cdd53b"},
+    {file = "contourpy-1.3.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:6afc576f7b33cf00996e5c1102dc2a8f7cc89e39c0b55df93a0b78c1bd992b36"},
+    {file = "contourpy-1.3.3-cp314-cp314-win32.whl", hash = "sha256:66c8a43a4f7b8df8b71ee1840e4211a3c8d93b214b213f590e18a1beca458f7d"},
+    {file = "contourpy-1.3.3-cp314-cp314-win_amd64.whl", hash = "sha256:cf9022ef053f2694e31d630feaacb21ea24224be1c3ad0520b13d844274614fd"},
+    {file = "contourpy-1.3.3-cp314-cp314-win_arm64.whl", hash = "sha256:95b181891b4c71de4bb404c6621e7e2390745f887f2a026b2d99e92c17892339"},
+    {file = "contourpy-1.3.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:33c82d0138c0a062380332c861387650c82e4cf1747aaa6938b9b6516762e772"},
+    {file = "contourpy-1.3.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:ea37e7b45949df430fe649e5de8351c423430046a2af20b1c1961cae3afcda77"},
+    {file = "contourpy-1.3.3-cp314-cp314t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d304906ecc71672e9c89e87c4675dc5c2645e1f4269a5063b99b0bb29f232d13"},
+    {file = "contourpy-1.3.3-cp314-cp314t-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ca658cd1a680a5c9ea96dc61cdbae1e85c8f25849843aa799dfd3cb370ad4fbe"},
+    {file = "contourpy-1.3.3-cp314-cp314t-manylinux_2_26_s390x.manylinux_2_28_s390x.whl", hash = "sha256:ab2fd90904c503739a75b7c8c5c01160130ba67944a7b77bbf36ef8054576e7f"},
+    {file = "contourpy-1.3.3-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b7301b89040075c30e5768810bc96a8e8d78085b47d8be6e4c3f5a0b4ed478a0"},
+    {file = "contourpy-1.3.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:2a2a8b627d5cc6b7c41a4beff6c5ad5eb848c88255fda4a8745f7e901b32d8e4"},
+    {file = "contourpy-1.3.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:fd6ec6be509c787f1caf6b247f0b1ca598bef13f4ddeaa126b7658215529ba0f"},
+    {file = "contourpy-1.3.3-cp314-cp314t-win32.whl", hash = "sha256:e74a9a0f5e3fff48fb5a7f2fd2b9b70a3fe014a67522f79b7cca4c0c7e43c9ae"},
+    {file = "contourpy-1.3.3-cp314-cp314t-win_amd64.whl", hash = "sha256:13b68d6a62db8eafaebb8039218921399baf6e47bf85006fd8529f2a08ef33fc"},
+    {file = "contourpy-1.3.3-cp314-cp314t-win_arm64.whl", hash = "sha256:b7448cb5a725bb1e35ce88771b86fba35ef418952474492cf7c764059933ff8b"},
+    {file = "contourpy-1.3.3-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:cd5dfcaeb10f7b7f9dc8941717c6c2ade08f587be2226222c12b25f0483ed497"},
+    {file = "contourpy-1.3.3-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:0c1fc238306b35f246d61a1d416a627348b5cf0648648a031e14bb8705fcdfe8"},
+    {file = "contourpy-1.3.3-pp311-pypy311_pp73-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:70f9aad7de812d6541d29d2bbf8feb22ff7e1c299523db288004e3157ff4674e"},
+    {file = "contourpy-1.3.3-pp311-pypy311_pp73-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5ed3657edf08512fc3fe81b510e35c2012fbd3081d2e26160f27ca28affec989"},
+    {file = "contourpy-1.3.3-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:3d1a3799d62d45c18bafd41c5fa05120b96a28079f2393af559b843d1a966a77"},
+    {file = "contourpy-1.3.3.tar.gz", hash = "sha256:083e12155b210502d0bca491432bb04d56dc3432f95a979b429f2848c3dbe880"},
+]
+
+[package.dependencies]
+numpy = ">=1.25"
+
+[package.extras]
+bokeh = ["bokeh", "selenium"]
+docs = ["furo", "sphinx (>=7.2)", "sphinx-copybutton"]
+mypy = ["bokeh", "contourpy[bokeh,docs]", "docutils-stubs", "mypy (==1.17.0)", "types-Pillow"]
+test = ["Pillow", "contourpy[test-no-images]", "matplotlib"]
+test-no-images = ["pytest", "pytest-cov", "pytest-rerunfailures", "pytest-xdist", "wurlitzer"]
 
 [[package]]
 name = "cryptography"
@@ -1406,6 +1541,80 @@ typing-extensions = "*"
 test = ["pytest", "pytest-cov", "pytest-mpl", "pytest-subtests"]
 
 [[package]]
+name = "fonttools"
+version = "4.63.0"
+description = "Tools to manipulate font files"
+optional = true
+python-versions = ">=3.10"
+groups = ["main"]
+markers = "extra == \"analysis-run\""
+files = [
+    {file = "fonttools-4.63.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:e3297a6a4059b4acc3a1e9a8b04741f240a80044eef08ebd32e8b5bcdddce75b"},
+    {file = "fonttools-4.63.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:b1cd75a03ad8cb5bc40c90bfde68c0c47de423aa19e5c0f362b43520645eea94"},
+    {file = "fonttools-4.63.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c0425b277a59cff3d80ca42162a8de360f318438a2ac83570842a678d826d579"},
+    {file = "fonttools-4.63.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d7e5c9973aa04c95650c96e5f5ad865fbf42d62079163ecfab1e01cbc2504c22"},
+    {file = "fonttools-4.63.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:cb014d58140a38135f16064c74c652ed57aa0b75cbf8bb59cac821f7edb5334e"},
+    {file = "fonttools-4.63.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:032038247a96c1690f9f31e377c389383c902531b085aa4e4dabd6f57f870e69"},
+    {file = "fonttools-4.63.0-cp310-cp310-win32.whl", hash = "sha256:a8b33a82979e0a6a34ff435cc81317be1f95ec1ebb7a3a2d1c8a6a54f02ae44e"},
+    {file = "fonttools-4.63.0-cp310-cp310-win_amd64.whl", hash = "sha256:0c18358a155d75034911c5ee397a5b44cd19dd325dbb8b35fb60bf421d6a72ac"},
+    {file = "fonttools-4.63.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:2b8ae05d9eacf6081414d759c0a352769ac28ce31280d6bb8e77b03f9e3c449f"},
+    {file = "fonttools-4.63.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:79cdc9f567aec74a72918fd060283911406750cbc9fd28c1316023deb6ce31a9"},
+    {file = "fonttools-4.63.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2c14b4fd138c4bafcca294765c547914e1aa431ae1ca94ab99d8db08c958bd3b"},
+    {file = "fonttools-4.63.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d76ac49f929aecaf82d83250b8347e099d7aecba0f4726c1d9b6df3b8bb5fe18"},
+    {file = "fonttools-4.63.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:dcf076a4474fe0d7367e5bbf5b052c7284fa1feca729c04176ce513521afd8a0"},
+    {file = "fonttools-4.63.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:7dd683fef0663e9f0f45cf541d788d24caa3ec9db50796b588e1757d8b3bc007"},
+    {file = "fonttools-4.63.0-cp311-cp311-win32.whl", hash = "sha256:afefc1ed0a59785a7fb06ea7e1678e849c193e1e387db783579bc7b3056fcfcb"},
+    {file = "fonttools-4.63.0-cp311-cp311-win_amd64.whl", hash = "sha256:063e08bd17bd5a90127a14123de0d6a952dbc847695fd98b63c043d58057f90c"},
+    {file = "fonttools-4.63.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:37dd23e621e3b0aef1baa70a303b80aaf38449632cfc8fd2a55fb285bbccfc02"},
+    {file = "fonttools-4.63.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:a9faff9e0c1f76f9fd55899d2ce785832efebab37eb8ae13995853aef178bef0"},
+    {file = "fonttools-4.63.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ef3048ef05dbb552b89817713d9cac912e00d0fde4a3105c00d29e52e10c89af"},
+    {file = "fonttools-4.63.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:58dc6bb86a78d782f00f9190ca02c119cf5bbe2807536e361e18d42019f877d8"},
+    {file = "fonttools-4.63.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:ee08ebfa58f6e1aeff5697ab9582105bb620008c1caafb681e4c557e7483027b"},
+    {file = "fonttools-4.63.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:27fdc65af8da6f88b9c6121c47a464cbe359fcfff7ff6fc2d37a1f395d755b78"},
+    {file = "fonttools-4.63.0-cp312-cp312-win32.whl", hash = "sha256:af2fd1664d00a397d75f806985ddb36282091c2131a73a6485c23b4a34722263"},
+    {file = "fonttools-4.63.0-cp312-cp312-win_amd64.whl", hash = "sha256:59ac449f8cca9b4ffa08d2e7bbadad87ce710d69d1eda5c3c1ce579baa987272"},
+    {file = "fonttools-4.63.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:cd7e9857e5e63738b9d9fd707bc1f59c8b09e5177726d23664db393c59bb08bd"},
+    {file = "fonttools-4.63.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:c2a2a42198b696a6f48fad91709afb55176e66a5e566131219dba372fb7f8c59"},
+    {file = "fonttools-4.63.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1e874792a8212b44583ea02189d9e693906b2f78b261f372f95d6c563210ac1d"},
+    {file = "fonttools-4.63.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:22135da48a348785c5e2d5d2d9d6bec5ed44adacbaeb9db12d9493bf6c6bfa68"},
+    {file = "fonttools-4.63.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:ccf41f2efdf56994d22d73bef4ced1052161958169428d06ba9724ea9e9a64be"},
+    {file = "fonttools-4.63.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:9ced0bd02ac751dd6319b0da88aaef24414e3b0dbc32bb4f24944821a3741a27"},
+    {file = "fonttools-4.63.0-cp313-cp313-win32.whl", hash = "sha256:85be818f5506e8a7753153def2c9550178f0ecae6a47b5e0e8dbb23f7cc90380"},
+    {file = "fonttools-4.63.0-cp313-cp313-win_amd64.whl", hash = "sha256:ba04cb5891d4c0c21b6da95eda8d7b090021508a294fff33464fc7d241e0856b"},
+    {file = "fonttools-4.63.0-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:fd1e3094f42d806d3d7c79162fc59e5910fcbe3a7360c385b8da969bc4493745"},
+    {file = "fonttools-4.63.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:6e528da43bc3791085f8cb6141b1d13e459226790240340fcbb4625649238b03"},
+    {file = "fonttools-4.63.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6b2248c5decb223562f7902ff6325077a073f608ee8e33e88ad88db734eb9f49"},
+    {file = "fonttools-4.63.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:308f957cdeaf8abe4e5f2f124902ef405448af92c90f80e302a3b771c2e6116b"},
+    {file = "fonttools-4.63.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:bf00f21eb5fb721dbaf73d1e9da6d02a1af7768f2ebcf9798be98beab8ba90f6"},
+    {file = "fonttools-4.63.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:c1aaa4b9c75798400ac043ce04d74e7830376c85095a5a6ed7cba2f17a266bf4"},
+    {file = "fonttools-4.63.0-cp314-cp314-win32.whl", hash = "sha256:22693918177bd9ceabec4736d338045f357769416fc6b0b2508eefef75b08616"},
+    {file = "fonttools-4.63.0-cp314-cp314-win_amd64.whl", hash = "sha256:7d782fac32985914c351556f68ac0855391572bcd87de50e05970d3cd4c96fc5"},
+    {file = "fonttools-4.63.0-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:6db5140a60a5d731d21ec076745b40a310607731b0a565b50776393188649001"},
+    {file = "fonttools-4.63.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:7d76edbff9014094dbf03bd2d074709dfa6ec7aba13d838c937a2b33d2d6a86e"},
+    {file = "fonttools-4.63.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0eac00b9118c3c2f87d272e45341871c5b3066baa3c86897fa634a7c3fb59096"},
+    {file = "fonttools-4.63.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:51394295f1a51de8b5f30bdb1e1b9a4231536c7064ef5c6e211eec19fa36036f"},
+    {file = "fonttools-4.63.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:9e12f105d2b6342c559c298afb674006bb2893afc7102dcf8a1b55b0486b4e40"},
+    {file = "fonttools-4.63.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:796f27556dbe094c4824f75ca85267e4df776c79036c8441469a4df37038c196"},
+    {file = "fonttools-4.63.0-cp314-cp314t-win32.whl", hash = "sha256:948428a275741f0b64b113c955425a953314f4b9ab9997f73a72c83e68e569c8"},
+    {file = "fonttools-4.63.0-cp314-cp314t-win_amd64.whl", hash = "sha256:6d4741eb179121cab9eea4cb2393d24492373a260d7945006358c08cfbf45419"},
+    {file = "fonttools-4.63.0-py3-none-any.whl", hash = "sha256:445af2eab030a16b9171ea8bdda7ebf7d96bda2df88ee182a464252f6e05e20d"},
+    {file = "fonttools-4.63.0.tar.gz", hash = "sha256:caeb583deeb5168e694b65cda8b4ee62abedfa66cf88488734466f2366b9c4e0"},
+]
+
+[package.extras]
+all = ["brotli (>=1.0.1) ; platform_python_implementation == \"CPython\"", "brotlicffi (>=0.8.0) ; platform_python_implementation != \"CPython\"", "lxml (>=4.0)", "lz4 (>=1.7.4.2)", "matplotlib", "munkres ; platform_python_implementation == \"PyPy\"", "pycairo", "scipy ; platform_python_implementation != \"PyPy\"", "skia-pathops (>=0.5.0)", "sympy", "uharfbuzz (>=0.45.0)", "unicodedata2 (>=17.0.0) ; python_version <= \"3.14\"", "xattr ; sys_platform == \"darwin\"", "zopfli (>=0.1.4)"]
+graphite = ["lz4 (>=1.7.4.2)"]
+interpolatable = ["munkres ; platform_python_implementation == \"PyPy\"", "pycairo", "scipy ; platform_python_implementation != \"PyPy\""]
+lxml = ["lxml (>=4.0)"]
+pathops = ["skia-pathops (>=0.5.0)"]
+plot = ["matplotlib"]
+repacker = ["uharfbuzz (>=0.45.0)"]
+symfont = ["sympy"]
+type1 = ["xattr ; sys_platform == \"darwin\""]
+unicode = ["unicodedata2 (>=17.0.0) ; python_version <= \"3.14\""]
+woff = ["brotli (>=1.0.1) ; platform_python_implementation == \"CPython\"", "brotlicffi (>=0.8.0) ; platform_python_implementation != \"CPython\"", "zopfli (>=0.1.4)"]
+
+[[package]]
 name = "fsspec"
 version = "2026.7.0"
 description = "File-system specification"
@@ -1447,7 +1656,7 @@ tqdm = ["tqdm"]
 
 [[package]]
 name = "geecs-bluesky"
-version = "0.61.0"
+version = "0.62.0"
 description = "Bluesky / ophyd-async bridge for the GEECS control system"
 optional = false
 python-versions = ">=3.11,<3.12"
@@ -1465,9 +1674,9 @@ geecs-schemas = {path = "../GEECS-Schemas", develop = true}
 ophyd-async = ">=0.19.3,<1.0"
 
 [package.extras]
-analysis = ["imageanalysis @ file:///Users/samuelbarber/Desktop/Code/Github_repos/GEECS-Plugins/.claude/worktrees/sad-dewdney-870421/ImageAnalysis"]
+analysis = ["imageanalysis @ file:///Users/samuelbarber/Desktop/Code/Github_repos/GEECS-Plugins/.claude/worktrees/post-analysis-data-acquisition-56707a/ImageAnalysis"]
 ca = ["aioca (>=1.7)"]
-optimize = ["gest-api (>=0.1)", "imageanalysis @ file:///Users/samuelbarber/Desktop/Code/Github_repos/GEECS-Plugins/.claude/worktrees/sad-dewdney-870421/ImageAnalysis", "scananalysis @ file:///Users/samuelbarber/Desktop/Code/Github_repos/GEECS-Plugins/.claude/worktrees/sad-dewdney-870421/ScanAnalysis", "xopt (>=3.1,<4.0)"]
+optimize = ["gest-api (>=0.1)", "imageanalysis @ file:///Users/samuelbarber/Desktop/Code/Github_repos/GEECS-Plugins/.claude/worktrees/post-analysis-data-acquisition-56707a/ImageAnalysis", "scananalysis @ file:///Users/samuelbarber/Desktop/Code/Github_repos/GEECS-Plugins/.claude/worktrees/post-analysis-data-acquisition-56707a/ScanAnalysis", "xopt (>=3.1,<4.0)"]
 qs-client = ["bluesky-queueserver-api (>=0.0.13,<0.0.14)"]
 qserver = ["bluesky-queueserver (>=0.0.25,<0.0.26)"]
 tiled = ["tiled[client] (>=0.2)"]
@@ -1542,6 +1751,132 @@ pydantic = "^2.0"
 [package.source]
 type = "directory"
 url = "../GEECS-Schemas"
+
+[[package]]
+name = "google-api-core"
+version = "2.35.0"
+description = "Google API client core library"
+optional = true
+python-versions = ">=3.10"
+groups = ["main"]
+markers = "extra == \"analysis-run\""
+files = [
+    {file = "google_api_core-2.35.0-py3-none-any.whl", hash = "sha256:88ce7a11146e1ddd331f7d2fd379787eb7e9015c34c6ed681e4f5fb8af3615af"},
+]
+
+[package.dependencies]
+google-auth = ">=2.14.1,<3.0.0"
+googleapis-common-protos = ">=1.69.2,<2.0.0"
+proto-plus = ">=1.26.1,<2.0.0"
+protobuf = ">=6.33.5,<8.0.0"
+requests = ">=2.33.0,<3.0.0"
+
+[package.extras]
+async-rest = ["aiohttp (>=3.13.4)", "google-auth[aiohttp] (>=2.14.1,<3.0.0)"]
+grpc = ["grpcio (>=1.59.0,<2.0.0)", "grpcio (>=1.75.1,<2.0.0) ; python_version >= \"3.14\"", "grpcio-status (>=1.59.0,<2.0.0)", "grpcio-status (>=1.75.1,<2.0.0) ; python_version >= \"3.14\""]
+
+[[package]]
+name = "google-api-python-client"
+version = "2.199.0"
+description = "Google API Client Library for Python"
+optional = true
+python-versions = ">=3.10"
+groups = ["main"]
+markers = "extra == \"analysis-run\""
+files = [
+    {file = "google_api_python_client-2.199.0-py3-none-any.whl", hash = "sha256:1d2fa0e7f9d68f063b1a9ff7ed290d6e6c93176260487bf3a991e41534ca23a3"},
+    {file = "google_api_python_client-2.199.0.tar.gz", hash = "sha256:8150816e22e01b36aa4b7523cdc1a2d2164e81c4de8a9b338785d7ecb4390ec2"},
+]
+
+[package.dependencies]
+google-api-core = ">=1.31.5,<2.0.dev0 || >2.3.0,<3.0.0"
+google-auth = ">=1.32.0,<2.24.0 || >2.24.0,<2.25.0 || >2.25.0,<3.0.0"
+google-auth-httplib2 = ">=0.2.0,<1.0.0"
+httplib2 = ">=0.19.0,<1.0.0"
+uritemplate = ">=3.0.1,<5"
+
+[[package]]
+name = "google-auth"
+version = "2.57.0"
+description = "Google Authentication Library"
+optional = true
+python-versions = ">=3.10"
+groups = ["main"]
+markers = "extra == \"analysis-run\""
+files = [
+    {file = "google_auth-2.57.0-py3-none-any.whl", hash = "sha256:180dafe015cfb62193bea26b677500fab5b9fd51a1e825ebf3ad9b182047ae59"},
+]
+
+[package.dependencies]
+cryptography = {version = ">=38.0.3", markers = "python_version < \"3.14\""}
+pyasn1-modules = ">=0.2.1"
+
+[package.extras]
+aiohttp = ["aiohttp (>=3.8.0,<4.0.0) ; python_version < \"3.14\"", "aiohttp (>=3.9.0,<4.0.0) ; python_version >= \"3.14\"", "requests (>=2.30.0,<3.0.0)"]
+cryptography = ["cryptography (>=38.0.3) ; python_version < \"3.14\"", "cryptography (>=41.0.5) ; python_version >= \"3.14\""]
+enterprise-cert = ["cryptography (>=38.0.3) ; python_version < \"3.14\"", "cryptography (>=41.0.5) ; python_version >= \"3.14\""]
+grpc = ["grpcio (>=1.59.0,<2.0.0) ; python_version < \"3.14\"", "grpcio (>=1.75.1,<2.0.0) ; python_version >= \"3.14\""]
+pyjwt = ["pyjwt (>=2.0)"]
+pyopenssl = ["cryptography (>=38.0.3) ; python_version < \"3.14\"", "cryptography (>=41.0.5) ; python_version >= \"3.14\""]
+reauth = ["pyu2f (>=0.1.5)"]
+requests = ["requests (>=2.30.0,<3.0.0)"]
+rsa = ["rsa (>=4.0.0,<5)"]
+testing = ["aiohttp (>=3.8.0,<4.0.0) ; python_version < \"3.14\"", "aiohttp (>=3.9.0,<4.0.0) ; python_version >= \"3.14\"", "aioresponses", "flask", "freezegun", "grpcio (>=1.59.0,<2.0.0) ; python_version < \"3.14\"", "grpcio (>=1.75.1,<2.0.0) ; python_version >= \"3.14\"", "packaging (>=20.0)", "pyjwt (>=2.0)", "pytest", "pytest-asyncio", "pytest-cov", "pytest-localserver", "pyu2f (>=0.1.5)", "requests (>=2.30.0,<3.0.0)", "responses", "urllib3 (>=1.26.15,<3.0.0)"]
+urllib3 = ["packaging (>=20.0)", "urllib3 (>=1.26.15,<3.0.0)"]
+
+[[package]]
+name = "google-auth-httplib2"
+version = "0.4.2"
+description = "Google Authentication Library: httplib2 transport"
+optional = true
+python-versions = ">=3.10"
+groups = ["main"]
+markers = "extra == \"analysis-run\""
+files = [
+    {file = "google_auth_httplib2-0.4.2-py3-none-any.whl", hash = "sha256:4298dd6b1415972d0c464b7177e6a69a595e7aec5b972222ecdca342f6009647"},
+]
+
+[package.dependencies]
+google-auth = ">=2.14.1,<3.0.0"
+httplib2 = ">=0.19.0,<1.0.0"
+
+[[package]]
+name = "google-auth-oauthlib"
+version = "1.4.1"
+description = "Google Authentication Library"
+optional = true
+python-versions = ">=3.10"
+groups = ["main"]
+markers = "extra == \"analysis-run\""
+files = [
+    {file = "google_auth_oauthlib-1.4.1-py3-none-any.whl", hash = "sha256:a1be43ec69fe563ac9b2c4d6fc4334b323b21cbdc59a638b5fa34dd4d5a2a348"},
+]
+
+[package.dependencies]
+google-auth = ">=2.15.0,<2.43.0 || >2.43.0,<2.44.0 || >2.44.0,<2.45.0 || >2.45.0,<3.0.0"
+requests-oauthlib = ">=0.7.0"
+
+[package.extras]
+tool = ["click (>=6.0.0)"]
+
+[[package]]
+name = "googleapis-common-protos"
+version = "1.75.1"
+description = "Common protobufs used in Google APIs"
+optional = true
+python-versions = ">=3.10"
+groups = ["main"]
+markers = "extra == \"analysis-run\""
+files = [
+    {file = "googleapis_common_protos-1.75.1-py3-none-any.whl", hash = "sha256:28a1934bcd33b9c9da66ac301a0a4227e3367f095a17d0375cb98f0a09d93b79"},
+    {file = "googleapis_common_protos-1.75.1.tar.gz", hash = "sha256:d3042c6c5a2d4e67113104d6b6818b59b6bd92a197f2a91508e801fe815cf071"},
+]
+
+[package.dependencies]
+protobuf = ">=6.33.5,<8.0.0"
+
+[package.extras]
+grpc = ["grpcio (>=1.59.0,<2.0.0)"]
 
 [[package]]
 name = "griffelib"
@@ -1816,6 +2151,22 @@ socks = ["socksio (==1.*)"]
 trio = ["trio (>=0.22.0,<1.0)"]
 
 [[package]]
+name = "httplib2"
+version = "0.32.0"
+description = "A comprehensive HTTP client library."
+optional = true
+python-versions = ">=3.8"
+groups = ["main"]
+markers = "extra == \"analysis-run\""
+files = [
+    {file = "httplib2-0.32.0-py3-none-any.whl", hash = "sha256:dc6705cacdf3fb0a2aba7629fa33c90fd93e30035db0c157325826be177e4816"},
+    {file = "httplib2-0.32.0.tar.gz", hash = "sha256:48a0ef30a42db65d8f3399045e1d09ab0ba66e3b9efc360d07f80ea55d286025"},
+]
+
+[package.dependencies]
+pyparsing = ">=3.1,<4"
+
+[[package]]
 name = "httpx"
 version = "0.28.1"
 description = "The next generation HTTP client."
@@ -1879,6 +2230,37 @@ files = [
 
 [package.extras]
 all = ["coverage (>=7.10.0)", "hypothesis (>=6.141.1)", "mypy (>=1.11.2)", "pytest (>=8.3.2)", "ruff (>=0.16.0)", "ty (>=0.0.37)"]
+
+[[package]]
+name = "imageanalysis"
+version = "1.11.1"
+description = "Central sub-repository for online and offline analysis of BELLA exeriments' images."
+optional = true
+python-versions = ">=3.11,<3.12"
+groups = ["main"]
+markers = "extra == \"analysis-run\""
+files = []
+develop = true
+
+[package.dependencies]
+boto3 = "^1.28"
+geecs-data-utils = {path = "../GEECS-Data-Utils", develop = true}
+h5py = "*"
+imageio = "^2.31.1"
+nptdms = "^1.7.0"
+numpy = ">=2.0,<3.0"
+opencv-python = "^4.9.0.80"
+pandas = "^2.2.3"
+Pint = ">=0.24,<=0.28"
+pyabel = ">=0.9.1,<1.0"
+pypng = "^0.20220715.0"
+pytest = ">=7.4"
+scikit-image = ">=0.19,<1.0"
+scipy = ">=1.11,<2.0"
+
+[package.source]
+type = "directory"
+url = "../ImageAnalysis"
 
 [[package]]
 name = "imageio"
@@ -1956,7 +2338,7 @@ version = "2.3.0"
 description = "brain-dead simple config-ini parsing"
 optional = false
 python-versions = ">=3.10"
-groups = ["dev"]
+groups = ["main", "dev"]
 files = [
     {file = "iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12"},
     {file = "iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730"},
@@ -2162,6 +2544,19 @@ MarkupSafe = ">=2.0"
 
 [package.extras]
 i18n = ["Babel (>=2.7)"]
+
+[[package]]
+name = "jmespath"
+version = "1.1.0"
+description = "JSON Matching Expressions"
+optional = true
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "extra == \"analysis-run\""
+files = [
+    {file = "jmespath-1.1.0-py3-none-any.whl", hash = "sha256:a5663118de4908c91729bea0acadca56526eb2698e83de10cd116ae0f4e97c64"},
+    {file = "jmespath-1.1.0.tar.gz", hash = "sha256:472c87d80f36026ae83c6ddd0f1d05d4e510134ed462851fd5f754c8c3cbb88d"},
+]
 
 [[package]]
 name = "joserfc"
@@ -2391,6 +2786,155 @@ test = ["pyfakefs", "pytest (>=6,!=8.1.*)"]
 type = ["pygobject-stubs", "pytest-mypy (>=1.0.1)", "shtab", "types-pywin32"]
 
 [[package]]
+name = "kiwisolver"
+version = "1.5.0"
+description = "A fast implementation of the Cassowary constraint solver"
+optional = true
+python-versions = ">=3.10"
+groups = ["main"]
+markers = "extra == \"analysis-run\""
+files = [
+    {file = "kiwisolver-1.5.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:32cc0a5365239a6ea0c6ed461e8838d053b57e397443c0ca894dcc8e388d4374"},
+    {file = "kiwisolver-1.5.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:cc0b66c1eec9021353a4b4483afb12dfd50e3669ffbb9152d6842eb34c7e29fd"},
+    {file = "kiwisolver-1.5.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:86e0287879f75621ae85197b0877ed2f8b7aa57b511c7331dce2eb6f4de7d476"},
+    {file = "kiwisolver-1.5.0-cp310-cp310-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:62f59da443c4f4849f73a51a193b1d9d258dcad0c41bc4d1b8fb2bcc04bfeb22"},
+    {file = "kiwisolver-1.5.0-cp310-cp310-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9190426b7aa26c5229501fa297b8d0653cfd3f5a36f7990c264e157cbf886b3b"},
+    {file = "kiwisolver-1.5.0-cp310-cp310-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c8277104ded0a51e699c8c3aff63ce2c56d4ed5519a5f73e0fd7057f959a2b9e"},
+    {file = "kiwisolver-1.5.0-cp310-cp310-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:8f9baf6f0a6e7571c45c8863010b45e837c3ee1c2c77fcd6ef423be91b21fedb"},
+    {file = "kiwisolver-1.5.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:cff8e5383db4989311f99e814feeb90c4723eb4edca425b9d5d9c3fefcdd9537"},
+    {file = "kiwisolver-1.5.0-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:ebae99ed6764f2b5771c522477b311be313e8841d2e0376db2b10922daebbba4"},
+    {file = "kiwisolver-1.5.0-cp310-cp310-musllinux_1_2_s390x.whl", hash = "sha256:d5cd5189fc2b6a538b75ae45433140c4823463918f7b1617c31e68b085c0022c"},
+    {file = "kiwisolver-1.5.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:f42c23db5d1521218a3276bb08666dcb662896a0be7347cba864eca45ff64ede"},
+    {file = "kiwisolver-1.5.0-cp310-cp310-win_amd64.whl", hash = "sha256:94eff26096eb5395136634622515b234ecb6c9979824c1f5004c6e3c3c85ccd2"},
+    {file = "kiwisolver-1.5.0-cp310-cp310-win_arm64.whl", hash = "sha256:dd952e03bfbb096cfe2dd35cd9e00f269969b67536cb4370994afc20ff2d0875"},
+    {file = "kiwisolver-1.5.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:9eed0f7edbb274413b6ee781cca50541c8c0facd3d6fd289779e494340a2b85c"},
+    {file = "kiwisolver-1.5.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:3c4923e404d6bcd91b6779c009542e5647fef32e4a5d75e115e3bbac6f2335eb"},
+    {file = "kiwisolver-1.5.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:0df54df7e686afa55e6f21fb86195224a6d9beb71d637e8d7920c95cf0f89aac"},
+    {file = "kiwisolver-1.5.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:2517e24d7315eb51c10664cdb865195df38ab74456c677df67bb47f12d088a27"},
+    {file = "kiwisolver-1.5.0-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ff710414307fefa903e0d9bdf300972f892c23477829f49504e59834f4195398"},
+    {file = "kiwisolver-1.5.0-cp311-cp311-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:6176c1811d9d5a04fa391c490cc44f451e240697a16977f11c6f722efb9041db"},
+    {file = "kiwisolver-1.5.0-cp311-cp311-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:50847dca5d197fcbd389c805aa1a1cf32f25d2e7273dc47ab181a517666b68cc"},
+    {file = "kiwisolver-1.5.0-cp311-cp311-manylinux_2_39_riscv64.whl", hash = "sha256:01808c6d15f4c3e8559595d6d1fe6411c68e4a3822b4b9972b44473b24f4e679"},
+    {file = "kiwisolver-1.5.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:f1f9f4121ec58628c96baa3de1a55a4e3a333c5102c8e94b64e23bf7b2083309"},
+    {file = "kiwisolver-1.5.0-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:b7d335370ae48a780c6e6a6bbfa97342f563744c39c35562f3f367665f5c1de2"},
+    {file = "kiwisolver-1.5.0-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:800ee55980c18545af444d93fdd60c56b580db5cc54867d8cbf8a1dc0829938c"},
+    {file = "kiwisolver-1.5.0-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:c438f6ca858697c9ab67eb28246c92508af972e114cac34e57a6d4ba17a3ac08"},
+    {file = "kiwisolver-1.5.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:8c63c91f95173f9c2a67c7c526b2cea976828a0e7fced9cdcead2802dc10f8a4"},
+    {file = "kiwisolver-1.5.0-cp311-cp311-win_amd64.whl", hash = "sha256:beb7f344487cdcb9e1efe4b7a29681b74d34c08f0043a327a74da852a6749e7b"},
+    {file = "kiwisolver-1.5.0-cp311-cp311-win_arm64.whl", hash = "sha256:ad4ae4ffd1ee9cd11357b4c66b612da9888f4f4daf2f36995eda64bd45370cac"},
+    {file = "kiwisolver-1.5.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:4e9750bc21b886308024f8a54ccb9a2cc38ac9fa813bf4348434e3d54f337ff9"},
+    {file = "kiwisolver-1.5.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:72ec46b7eba5b395e0a7b63025490d3214c11013f4aacb4f5e8d6c3041829588"},
+    {file = "kiwisolver-1.5.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ed3a984b31da7481b103f68776f7128a89ef26ed40f4dc41a2223cda7fb24819"},
+    {file = "kiwisolver-1.5.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:bb5136fb5352d3f422df33f0c879a1b0c204004324150cc3b5e3c4f310c9049f"},
+    {file = "kiwisolver-1.5.0-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b2af221f268f5af85e776a73d62b0845fc8baf8ef0abfae79d29c77d0e776aaf"},
+    {file = "kiwisolver-1.5.0-cp312-cp312-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:b0f172dc8ffaccb8522d7c5d899de00133f2f1ca7b0a49b7da98e901de87bf2d"},
+    {file = "kiwisolver-1.5.0-cp312-cp312-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:6ab8ba9152203feec73758dad83af9a0bbe05001eb4639e547207c40cfb52083"},
+    {file = "kiwisolver-1.5.0-cp312-cp312-manylinux_2_39_riscv64.whl", hash = "sha256:cdee07c4d7f6d72008d3f73b9bf027f4e11550224c7c50d8df1ae4a37c1402a6"},
+    {file = "kiwisolver-1.5.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:7c60d3c9b06fb23bd9c6139281ccbdc384297579ae037f08ae90c69f6845c0b1"},
+    {file = "kiwisolver-1.5.0-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:e315e5ec90d88e140f57696ff85b484ff68bb311e36f2c414aa4286293e6dee0"},
+    {file = "kiwisolver-1.5.0-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:1465387ac63576c3e125e5337a6892b9e99e0627d52317f3ca79e6930d889d15"},
+    {file = "kiwisolver-1.5.0-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:530a3fd64c87cffa844d4b6b9768774763d9caa299e9b75d8eca6a4423b31314"},
+    {file = "kiwisolver-1.5.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:1d9daea4ea6b9be74fe2f01f7fbade8d6ffab263e781274cffca0dba9be9eec9"},
+    {file = "kiwisolver-1.5.0-cp312-cp312-win_amd64.whl", hash = "sha256:f18c2d9782259a6dc132fdc7a63c168cbc74b35284b6d75c673958982a378384"},
+    {file = "kiwisolver-1.5.0-cp312-cp312-win_arm64.whl", hash = "sha256:f7c7553b13f69c1b29a5bde08ddc6d9d0c8bfb84f9ed01c30db25944aeb852a7"},
+    {file = "kiwisolver-1.5.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:fd40bb9cd0891c4c3cb1ddf83f8bbfa15731a248fdc8162669405451e2724b09"},
+    {file = "kiwisolver-1.5.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:c0e1403fd7c26d77c1f03e096dc58a5c726503fa0db0456678b8668f76f521e3"},
+    {file = "kiwisolver-1.5.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:dda366d548e89a90d88a86c692377d18d8bd64b39c1fb2b92cb31370e2896bbd"},
+    {file = "kiwisolver-1.5.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:332b4f0145c30b5f5ad9374881133e5aa64320428a57c2c2b61e9d891a51c2f3"},
+    {file = "kiwisolver-1.5.0-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0c50b89ffd3e1a911c69a1dd3de7173c0cd10b130f56222e57898683841e4f96"},
+    {file = "kiwisolver-1.5.0-cp313-cp313-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:4db576bb8c3ef9365f8b40fe0f671644de6736ae2c27a2c62d7d8a1b4329f099"},
+    {file = "kiwisolver-1.5.0-cp313-cp313-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:0b85aad90cea8ac6797a53b5d5f2e967334fa4d1149f031c4537569972596cb8"},
+    {file = "kiwisolver-1.5.0-cp313-cp313-manylinux_2_39_riscv64.whl", hash = "sha256:d36ca54cb4c6c4686f7cbb7b817f66f5911c12ddb519450bbe86707155028f87"},
+    {file = "kiwisolver-1.5.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:38f4a703656f493b0ad185211ccfca7f0386120f022066b018eb5296d8613e23"},
+    {file = "kiwisolver-1.5.0-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:3ac2360e93cb41be81121755c6462cff3beaa9967188c866e5fce5cf13170859"},
+    {file = "kiwisolver-1.5.0-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:c95cab08d1965db3d84a121f1c7ce7479bdd4072c9b3dafd8fecce48a2e6b902"},
+    {file = "kiwisolver-1.5.0-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:fc20894c3d21194d8041a28b65622d5b86db786da6e3cfe73f0c762951a61167"},
+    {file = "kiwisolver-1.5.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:7a32f72973f0f950c1920475d5c5ea3d971b81b6f0ec53b8d0a956cc965f22e0"},
+    {file = "kiwisolver-1.5.0-cp313-cp313-win_amd64.whl", hash = "sha256:0bf3acf1419fa93064a4c2189ac0b58e3be7872bf6ee6177b0d4c63dc4cea276"},
+    {file = "kiwisolver-1.5.0-cp313-cp313-win_arm64.whl", hash = "sha256:fa8eb9ecdb7efb0b226acec134e0d709e87a909fa4971a54c0c4f6e88635484c"},
+    {file = "kiwisolver-1.5.0-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:db485b3847d182b908b483b2ed133c66d88d49cacf98fd278fadafe11b4478d1"},
+    {file = "kiwisolver-1.5.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:be12f931839a3bdfe28b584db0e640a65a8bcbc24560ae3fdb025a449b3d754e"},
+    {file = "kiwisolver-1.5.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:16b85d37c2cbb3253226d26e64663f755d88a03439a9c47df6246b35defbdfb7"},
+    {file = "kiwisolver-1.5.0-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4432b835675f0ea7414aab3d37d119f7226d24869b7a829caeab49ebda407b0c"},
+    {file = "kiwisolver-1.5.0-cp313-cp313t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1b0feb50971481a2cc44d94e88bdb02cdd497618252ae226b8eb1201b957e368"},
+    {file = "kiwisolver-1.5.0-cp313-cp313t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:56fa888f10d0f367155e76ce849fa1166fc9730d13bd2d65a2aa13b6f5424489"},
+    {file = "kiwisolver-1.5.0-cp313-cp313t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:940dda65d5e764406b9fb92761cbf462e4e63f712ab60ed98f70552e496f3bf1"},
+    {file = "kiwisolver-1.5.0-cp313-cp313t-manylinux_2_39_riscv64.whl", hash = "sha256:89fc958c702ee9a745e4700378f5d23fddbc46ff89e8fdbf5395c24d5c1452a3"},
+    {file = "kiwisolver-1.5.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:9027d773c4ff81487181a925945743413f6069634d0b122d0b37684ccf4f1e18"},
+    {file = "kiwisolver-1.5.0-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:5b233ea3e165e43e35dba1d2b8ecc21cf070b45b65ae17dd2747d2713d942021"},
+    {file = "kiwisolver-1.5.0-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:ce9bf03dad3b46408c08649c6fbd6ca28a9fce0eb32fdfffa6775a13103b5310"},
+    {file = "kiwisolver-1.5.0-cp313-cp313t-musllinux_1_2_s390x.whl", hash = "sha256:fc4d3f1fb9ca0ae9f97b095963bc6326f1dbfd3779d6679a1e016b9baaa153d3"},
+    {file = "kiwisolver-1.5.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:f443b4825c50a51ee68585522ab4a1d1257fac65896f282b4c6763337ac9f5d2"},
+    {file = "kiwisolver-1.5.0-cp313-cp313t-win_arm64.whl", hash = "sha256:893ff3a711d1b515ba9da14ee090519bad4610ed1962fbe298a434e8c5f8db53"},
+    {file = "kiwisolver-1.5.0-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:8df31fe574b8b3993cc61764f40941111b25c2d9fea13d3ce24a49907cd2d615"},
+    {file = "kiwisolver-1.5.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:1d49a49ac4cbfb7c1375301cd1ec90169dfeae55ff84710d782260ce77a75a02"},
+    {file = "kiwisolver-1.5.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:0cbe94b69b819209a62cb27bdfa5dc2a8977d8de2f89dfd97ba4f53ed3af754e"},
+    {file = "kiwisolver-1.5.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:80aa065ffd378ff784822a6d7c3212f2d5f5e9c3589614b5c228b311fd3063ac"},
+    {file = "kiwisolver-1.5.0-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4e7f886f47ab881692f278ae901039a234e4025a68e6dfab514263a0b1c4ae05"},
+    {file = "kiwisolver-1.5.0-cp314-cp314-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:5060731cc3ed12ca3a8b57acd4aeca5bbc2f49216dd0bec1650a1acd89486bcd"},
+    {file = "kiwisolver-1.5.0-cp314-cp314-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:7a4aa69609f40fce3cbc3f87b2061f042eee32f94b8f11db707b66a26461591a"},
+    {file = "kiwisolver-1.5.0-cp314-cp314-manylinux_2_39_riscv64.whl", hash = "sha256:d168fda2dbff7b9b5f38e693182d792a938c31db4dac3a80a4888de603c99554"},
+    {file = "kiwisolver-1.5.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:413b820229730d358efd838ecbab79902fe97094565fdc80ddb6b0a18c18a581"},
+    {file = "kiwisolver-1.5.0-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:5124d1ea754509b09e53738ec185584cc609aae4a3b510aaf4ed6aa047ef9303"},
+    {file = "kiwisolver-1.5.0-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:e4415a8db000bf49a6dd1c478bf70062eaacff0f462b92b0ba68791a905861f9"},
+    {file = "kiwisolver-1.5.0-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:d618fd27420381a4f6044faa71f46d8bfd911bd077c555f7138ed88729bfbe79"},
+    {file = "kiwisolver-1.5.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5092eb5b1172947f57d6ea7d89b2f29650414e4293c47707eb499ec07a0ac796"},
+    {file = "kiwisolver-1.5.0-cp314-cp314-win_amd64.whl", hash = "sha256:d76e2d8c75051d58177e762164d2e9ab92886534e3a12e795f103524f221dd8e"},
+    {file = "kiwisolver-1.5.0-cp314-cp314-win_arm64.whl", hash = "sha256:fa6248cd194edff41d7ea9425ced8ca3a6f838bfb295f6f1d6e6bb694a8518df"},
+    {file = "kiwisolver-1.5.0-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:d1ffeb80b5676463d7a7d56acbe8e37a20ce725570e09549fe738e02ca6b7e1e"},
+    {file = "kiwisolver-1.5.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:bc4d8e252f532ab46a1de9349e2d27b91fce46736a9eedaa37beaca66f574ed4"},
+    {file = "kiwisolver-1.5.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:6783e069732715ad0c3ce96dbf21dbc2235ab0593f2baf6338101f70371f4028"},
+    {file = "kiwisolver-1.5.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:e7c4c09a490dc4d4a7f8cbee56c606a320f9dc28cf92a7157a39d1ce7676a657"},
+    {file = "kiwisolver-1.5.0-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2a075bd7bd19c70cf67c8badfa36cf7c5d8de3c9ddb8420c51e10d9c50e94920"},
+    {file = "kiwisolver-1.5.0-cp314-cp314t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:bdd3e53429ff02aa319ba59dfe4ceeec345bf46cf180ec2cf6fd5b942e7975e9"},
+    {file = "kiwisolver-1.5.0-cp314-cp314t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:3cdcb35dc9d807259c981a85531048ede628eabcffb3239adf3d17463518992d"},
+    {file = "kiwisolver-1.5.0-cp314-cp314t-manylinux_2_39_riscv64.whl", hash = "sha256:70d593af6a6ca332d1df73d519fddb5148edb15cd90d5f0155e3746a6d4fcc65"},
+    {file = "kiwisolver-1.5.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:377815a8616074cabbf3f53354e1d040c35815a134e01d7614b7692e4bf8acfa"},
+    {file = "kiwisolver-1.5.0-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:0255a027391d52944eae1dbb5d4cc5903f57092f3674e8e544cdd2622826b3f0"},
+    {file = "kiwisolver-1.5.0-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:012b1eb16e28718fa782b5e61dc6f2da1f0792ca73bd05d54de6cb9561665fc9"},
+    {file = "kiwisolver-1.5.0-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:0e3aafb33aed7479377e5e9a82e9d4bf87063741fc99fc7ae48b0f16e32bdd6f"},
+    {file = "kiwisolver-1.5.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:e7a116ae737f0000343218c4edf5bd45893bfeaff0993c0b215d7124c9f77646"},
+    {file = "kiwisolver-1.5.0-cp314-cp314t-win_amd64.whl", hash = "sha256:1dd9b0b119a350976a6d781e7278ec7aca0b201e1a9e2d23d9804afecb6ca681"},
+    {file = "kiwisolver-1.5.0-cp314-cp314t-win_arm64.whl", hash = "sha256:58f812017cd2985c21fbffb4864d59174d4903dd66fa23815e74bbc7a0e2dd57"},
+    {file = "kiwisolver-1.5.0-graalpy312-graalpy250_312_native-macosx_10_13_x86_64.whl", hash = "sha256:5ae8e62c147495b01a0f4765c878e9bfdf843412446a247e28df59936e99e797"},
+    {file = "kiwisolver-1.5.0-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:f6764a4ccab3078db14a632420930f6186058750df066b8ea2a7106df91d3203"},
+    {file = "kiwisolver-1.5.0-graalpy312-graalpy250_312_native-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c31c13da98624f957b0fb1b5bae5383b2333c2c3f6793d9825dd5ce79b525cb7"},
+    {file = "kiwisolver-1.5.0-graalpy312-graalpy250_312_native-win_amd64.whl", hash = "sha256:1f1489f769582498610e015a8ef2d36f28f505ab3096d0e16b4858a9ec214f57"},
+    {file = "kiwisolver-1.5.0-pp310-pypy310_pp73-macosx_10_15_x86_64.whl", hash = "sha256:295d9ffe712caa9f8a3081de8d32fc60191b4b51c76f02f951fd8407253528f4"},
+    {file = "kiwisolver-1.5.0-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:51e8c4084897de9f05898c2c2a39af6318044ae969d46ff7a34ed3f96274adca"},
+    {file = "kiwisolver-1.5.0-pp310-pypy310_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:b83af57bdddef03c01a9138034c6ff03181a3028d9a1003b301eb1a55e161a3f"},
+    {file = "kiwisolver-1.5.0-pp310-pypy310_pp73-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bf4679a3d71012a7c2bf360e5cd878fbd5e4fcac0896b56393dec239d81529ed"},
+    {file = "kiwisolver-1.5.0-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:41024ed50e44ab1a60d3fe0a9d15a4ccc9f5f2b1d814ff283c8d01134d5b81bc"},
+    {file = "kiwisolver-1.5.0-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:ec4c85dc4b687c7f7f15f553ff26a98bfe8c58f5f7f0ac8905f0ba4c7be60232"},
+    {file = "kiwisolver-1.5.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:12e91c215a96e39f57989c8912ae761286ac5a9584d04030ceb3368a357f017a"},
+    {file = "kiwisolver-1.5.0-pp311-pypy311_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:be4a51a55833dc29ab5d7503e7bcb3b3af3402d266018137127450005cdfe737"},
+    {file = "kiwisolver-1.5.0-pp311-pypy311_pp73-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:daae526907e262de627d8f70058a0f64acc9e2641c164c99c8f594b34a799a16"},
+    {file = "kiwisolver-1.5.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:59cd8683f575d96df5bb48f6add94afc055012c29e28124fcae2b63661b9efb1"},
+    {file = "kiwisolver-1.5.0.tar.gz", hash = "sha256:d4193f3d9dc3f6f79aaed0e5637f45d98850ebf01f7ca20e69457f3e8946b66a"},
+]
+
+[[package]]
+name = "lazy-loader"
+version = "0.5"
+description = "Makes it easy to load subpackages and functions on demand."
+optional = true
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "extra == \"analysis-run\""
+files = [
+    {file = "lazy_loader-0.5-py3-none-any.whl", hash = "sha256:ab0ea149e9c554d4ffeeb21105ac60bed7f3b4fd69b1d2360a4add51b170b005"},
+    {file = "lazy_loader-0.5.tar.gz", hash = "sha256:717f9179a0dbed357012ddad50a5ad3d5e4d9a0b8712680d4e687f5e6e6ed9b3"},
+]
+
+[package.dependencies]
+packaging = "*"
+
+[package.extras]
+dev = ["changelist (==0.5)", "spin (==0.15)"]
+lint = ["pre-commit (==4.3.0)"]
+test = ["coverage[toml] (>=7.2)", "pytest (>=8.0)", "pytest-cov (>=5.0)"]
+
+[[package]]
 name = "llvmlite"
 version = "0.49.0"
 description = "lightweight wrapper around basic LLVM functionality"
@@ -2437,6 +2981,27 @@ files = [
     {file = "locket-1.0.0-py2.py3-none-any.whl", hash = "sha256:b6c819a722f7b6bd955b80781788e4a66a55628b858d347536b7e81325a3a5e3"},
     {file = "locket-1.0.0.tar.gz", hash = "sha256:5c0d4c052a8bbbf750e056a8e65ccd309086f4f0f18a2eac306a8dfa4112a632"},
 ]
+
+[[package]]
+name = "logmaker4googledocs"
+version = "0.1.1"
+description = ""
+optional = true
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "extra == \"analysis-run\""
+files = []
+develop = true
+
+[package.dependencies]
+google-api-python-client = "*"
+google-auth-httplib2 = "*"
+google-auth-oauthlib = "*"
+pillow = "*"
+
+[package.source]
+type = "directory"
+url = "../LogMaker4GoogleDocs"
 
 [[package]]
 name = "lz4"
@@ -2632,6 +3197,74 @@ files = [
     {file = "markupsafe-3.0.3-cp39-cp39-win_arm64.whl", hash = "sha256:38664109c14ffc9e7437e86b4dceb442b0096dfe3541d7864d9cbe1da4cf36c8"},
     {file = "markupsafe-3.0.3.tar.gz", hash = "sha256:722695808f4b6457b320fdc131280796bdceb04ab50fe1795cd540799ebe1698"},
 ]
+
+[[package]]
+name = "matplotlib"
+version = "3.11.1"
+description = "Python plotting package"
+optional = true
+python-versions = ">=3.11"
+groups = ["main"]
+markers = "extra == \"analysis-run\""
+files = [
+    {file = "matplotlib-3.11.1-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:b7cf158e7add54a8d51ac9b5a84abd6d4e13ed4951b4f25f1c5139f41c2addb2"},
+    {file = "matplotlib-3.11.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:d2ace7273b9a5061a3b420918a16fae1f2dc5dfee1abcc13aba71b5d94b1820c"},
+    {file = "matplotlib-3.11.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:aee55e9041211bf84302ab55ec3965df18dd90ae19f8b58332a7feaf208bfe83"},
+    {file = "matplotlib-3.11.1-cp311-cp311-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:96f4bdeea33a8d15a071dbfe6d119451b1d719c733ac666d65357082901a9099"},
+    {file = "matplotlib-3.11.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:b4c78ceb2f11bcac7389d305cda17aeb1f4586a857854ab5780bd3dd8dbfc407"},
+    {file = "matplotlib-3.11.1-cp311-cp311-win_amd64.whl", hash = "sha256:7f33a781e12b1e53b278deb2f5373c2e55ec4f10727be3440c0cfb5cda9f944f"},
+    {file = "matplotlib-3.11.1-cp311-cp311-win_arm64.whl", hash = "sha256:67e4c3cd578c65ebd81bdc09a1b6592ceafee6dfafe116dc85dfcb647b5bbb18"},
+    {file = "matplotlib-3.11.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:e15ef41507f3d525f46154ac9e3ae785dacde9f20e593a25de8986267892ef74"},
+    {file = "matplotlib-3.11.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:21a67b961a6d597bca54fae826cd20695ba4a6e4d05424a08da6e13e3176fd6b"},
+    {file = "matplotlib-3.11.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ba8f811b8ddfac493734d6af0b2dff96919d0c28ca0d641858dab4262777c6ea"},
+    {file = "matplotlib-3.11.1-cp312-cp312-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c52f7ad20ef476806ed212380b1d54d20310c8b86bdc2c9a68b51f0024a44472"},
+    {file = "matplotlib-3.11.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:8b14eb22961fe865efb0e4ff167e333e428908b00115a8d800ccb65ee108e481"},
+    {file = "matplotlib-3.11.1-cp312-cp312-win_amd64.whl", hash = "sha256:88a2a27dd9691ae448dfae4b26f59036be90c3c28757edd3553a29559d00859f"},
+    {file = "matplotlib-3.11.1-cp312-cp312-win_arm64.whl", hash = "sha256:480194afceca4df2f137c2721227d3cba67121fbf4397b69cee7f83714b0a58a"},
+    {file = "matplotlib-3.11.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:6771b0cd7838c6a857a7209814158c0ad09bfef878db3033dd82d70ad101f191"},
+    {file = "matplotlib-3.11.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2abdee5ffa2fe11b2d19f7a5c63b785fb7c28cc46c7bc1814156341d9d1a33e1"},
+    {file = "matplotlib-3.11.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:b0a19dcf73406d3746d25a5ed42d713604c9a3e024d129b102852b0d941cb9f3"},
+    {file = "matplotlib-3.11.1-cp313-cp313-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7389b77ed2ab0552f46d9a90b81b7b8e6dfcdc42adc36c37a0865799843e0e3e"},
+    {file = "matplotlib-3.11.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:c90be0b73568da4f662afac580956a76e308437e641b4a45aa08925eeb67d95f"},
+    {file = "matplotlib-3.11.1-cp313-cp313-win_amd64.whl", hash = "sha256:68408341f2312836fbbdf6b3c78047f65b2d8752f5fd221c3e72d348f5b34f8b"},
+    {file = "matplotlib-3.11.1-cp313-cp313-win_arm64.whl", hash = "sha256:0c1f44890d435c1b4ef52f701ad5828cb450ea97bcc83918fda6be74965d6cd2"},
+    {file = "matplotlib-3.11.1-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:5e510088c27a89d53580a752f959146893563e63c330e161d159b0fee652af6f"},
+    {file = "matplotlib-3.11.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:1524e2bdd48a93557aa47ddcfe9c225dfdd57d5a01a5c49128c20f0632980ee1"},
+    {file = "matplotlib-3.11.1-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:11664c551345553db92e61cae6cf1376f138f8c47cafdf13b64b18f3e3e9e464"},
+    {file = "matplotlib-3.11.1-cp313-cp313t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5e1f8922ba31959cf6a9dfb51be64b7f7bc582801a3957dc0c2f3afcd3537adf"},
+    {file = "matplotlib-3.11.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:83235693abde86e5e0129998f80ee39fc7f58e6d56a88fafb28a9278833e9d5f"},
+    {file = "matplotlib-3.11.1-cp313-cp313t-win_amd64.whl", hash = "sha256:9a076f4fc5cdc43fdf510f5981418d25c2db4973418d9f22d8bb3dc8045ada78"},
+    {file = "matplotlib-3.11.1-cp313-cp313t-win_arm64.whl", hash = "sha256:216fbb93a74add02ddb4cb38ef5348f59ac00b3e84567eaf16598772d40e150a"},
+    {file = "matplotlib-3.11.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:30c492d4ba9448595b6fd8708c6725963f8148e25c0d8842948da5b05f0ee8d3"},
+    {file = "matplotlib-3.11.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:ac104be2768ffdd8655db9e71b768cbb45f2b9aa7b450cf1595e8f65d3822319"},
+    {file = "matplotlib-3.11.1-cp314-cp314-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6be943cb68bc6660ead58c55b3aa6366cba2ef7feb06460fbcce32360376f19f"},
+    {file = "matplotlib-3.11.1-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5af0dcda57d471440a7b5b623e70e0a61003518443d9098f211a96ecfbbc25be"},
+    {file = "matplotlib-3.11.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:3d3fd84082b1afbd9398466c81309e20045be20d48fe0fb18c43504d164cbbb2"},
+    {file = "matplotlib-3.11.1-cp314-cp314-win_amd64.whl", hash = "sha256:9601a1e90be21e4884c53b4f3dc3ee0544654946f9975258d691f1c2e2f119c6"},
+    {file = "matplotlib-3.11.1-cp314-cp314-win_arm64.whl", hash = "sha256:ae30c6109848ac0f9fa36c5d6270938487614c47ba31860bd5361266dabc5685"},
+    {file = "matplotlib-3.11.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:dadfe80797174e2984aae3be0b77594a3c72d2c0a40fbd4a0de48d2728caf3ae"},
+    {file = "matplotlib-3.11.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:89b193b255f4f6f7948dbcee3691f4f341ab05d9a8874a67b45ddb4182922eda"},
+    {file = "matplotlib-3.11.1-cp314-cp314t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:191163532cdefcb1571ca38a6d7e6474baccde64495783e6ba47aa07ec4b9bbb"},
+    {file = "matplotlib-3.11.1-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9fdf1c818ab05d0e74002091ddaf414478a3a449ec9d51c8976d45be7e3a01e2"},
+    {file = "matplotlib-3.11.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:b937b9dba5f5f6c1e31c47abe2186c865c0914fd18f2ce0dfc39c9adcef5951d"},
+    {file = "matplotlib-3.11.1-cp314-cp314t-win_amd64.whl", hash = "sha256:f2912f647f3fbe1ccf085f91e213936f9101bead81a5e670565b1f1b3712f4fb"},
+    {file = "matplotlib-3.11.1-cp314-cp314t-win_arm64.whl", hash = "sha256:54d47b8ae8b579633a3902ca5b4ad6c1e132a5626d64447b2e22a66394e79987"},
+    {file = "matplotlib-3.11.1-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:427258425f9a3fc4ed79a91f9e9b9aaf5a82cb6571e85dc14063cc6fbb993741"},
+    {file = "matplotlib-3.11.1-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:1ac697e591c11b6ad04679a73c2d2f9980fe9d9f0311fb414a2e329706343dfb"},
+    {file = "matplotlib-3.11.1-pp311-pypy311_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:e4b9ac2f1f607ecda2af90a5232beee2af7582fce1cc30c4b6a1b012dc21ee99"},
+    {file = "matplotlib-3.11.1.tar.gz", hash = "sha256:69647db5746941c793d6e445a4cd349323ffb87d9cc958c2ad84a659b4832d30"},
+]
+
+[package.dependencies]
+contourpy = ">=1.0.1"
+cycler = ">=0.10"
+fonttools = ">=4.28.2"
+kiwisolver = ">=1.3.1"
+numpy = ">=1.25"
+packaging = ">=20.0"
+pillow = ">=9"
+pyparsing = ">=3"
+python-dateutil = ">=2.7"
 
 [[package]]
 name = "matplotlib-inline"
@@ -3173,6 +3806,24 @@ files = [
 sphinx = ">=6"
 
 [[package]]
+name = "oauthlib"
+version = "3.3.1"
+description = "A generic, spec-compliant, thorough implementation of the OAuth request-signing logic"
+optional = true
+python-versions = ">=3.8"
+groups = ["main"]
+markers = "extra == \"analysis-run\""
+files = [
+    {file = "oauthlib-3.3.1-py3-none-any.whl", hash = "sha256:88119c938d2b8fb88561af5f6ee0eec8cc8d552b7bb1f712743136eb7523b7a1"},
+    {file = "oauthlib-3.3.1.tar.gz", hash = "sha256:0f0f8aa759826a193cf66c12ea1af1637f87b9b4622d46e866952bb022e538c9"},
+]
+
+[package.extras]
+rsa = ["cryptography (>=3.0.0)"]
+signals = ["blinker (>=1.4.0)"]
+signedtoken = ["cryptography (>=3.0.0)", "pyjwt (>=2.0.0,<3)"]
+
+[[package]]
 name = "openapi-pydantic"
 version = "0.5.1"
 description = "Pydantic OpenAPI schema implementation"
@@ -3186,6 +3837,29 @@ files = [
 
 [package.dependencies]
 pydantic = ">=1.8"
+
+[[package]]
+name = "opencv-python"
+version = "4.14.0.94"
+description = "Wrapper package for OpenCV python bindings."
+optional = true
+python-versions = ">=3.6"
+groups = ["main"]
+markers = "extra == \"analysis-run\""
+files = [
+    {file = "opencv_python-4.14.0.94-cp37-abi3-macosx_13_0_arm64.whl", hash = "sha256:04456937c8f12ca64ff94df8bfd813ca98f5c9767da792948969a759c716ebe2"},
+    {file = "opencv_python-4.14.0.94-cp37-abi3-macosx_14_0_x86_64.whl", hash = "sha256:6a49842cc0ba9f43e35a289e61c0e15a1f8be8df60145ee5c7d42593b0d4f4b8"},
+    {file = "opencv_python-4.14.0.94-cp37-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:3198fcbcb8f98fd68063bf2c75d129b0f50d46e555a4e47578a6eb086eb38e1f"},
+    {file = "opencv_python-4.14.0.94-cp37-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4ae0b5a2acbcfb9813035f1644cfba751edd02797fac994e32180813eeef8420"},
+    {file = "opencv_python-4.14.0.94-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:add600736d0d65a39e797a9ceeb494f3cdc5736d4bd96b4f89d65a8c92451528"},
+    {file = "opencv_python-4.14.0.94-cp37-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:726a2b40c1120a0bbd0116394c6a5b2aa0a4dfa4e609a81ee10d12c6a34cd372"},
+    {file = "opencv_python-4.14.0.94-cp37-abi3-win32.whl", hash = "sha256:549c2401f8654708c702bdf0e26d45816b9c411369a0efa41907ec2b4ec0e707"},
+    {file = "opencv_python-4.14.0.94-cp37-abi3-win_amd64.whl", hash = "sha256:ace53616cdffc9643e17e075397b493e607c427d388c7508798ef7ad2ed577cc"},
+    {file = "opencv_python-4.14.0.94.tar.gz", hash = "sha256:afadc76a38a07713a4c2b4702da917cf0ed489be57e2a40a34e670189731de7d"},
+]
+
+[package.dependencies]
+numpy = {version = ">=2", markers = "python_version >= \"3.9\""}
 
 [[package]]
 name = "openpyxl"
@@ -3673,7 +4347,7 @@ version = "1.6.0"
 description = "plugin and hook calling mechanisms for python"
 optional = false
 python-versions = ">=3.9"
-groups = ["dev"]
+groups = ["main", "dev"]
 files = [
     {file = "pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746"},
     {file = "pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3"},
@@ -3697,6 +4371,44 @@ files = [
 
 [package.dependencies]
 wcwidth = ">=0.1.4"
+
+[[package]]
+name = "proto-plus"
+version = "1.28.3"
+description = "Beautiful, Pythonic protocol buffers"
+optional = true
+python-versions = ">=3.10"
+groups = ["main"]
+markers = "extra == \"analysis-run\""
+files = [
+    {file = "proto_plus-1.28.3-py3-none-any.whl", hash = "sha256:dc76880b8ee951cca002098574376cf71e055f9f16d9ba6570fb8a06f726d281"},
+    {file = "proto_plus-1.28.3.tar.gz", hash = "sha256:5f91b30dafa6bb38d432c5557a6ee1d35ffd40b4b1e0e3ca27260448560b91d9"},
+]
+
+[package.dependencies]
+protobuf = ">=6.33.5,<8.0.0"
+
+[package.extras]
+testing = ["google-api-core (>=2.25.0)"]
+
+[[package]]
+name = "protobuf"
+version = "7.36.0"
+description = ""
+optional = true
+python-versions = ">=3.10"
+groups = ["main"]
+markers = "extra == \"analysis-run\""
+files = [
+    {file = "protobuf-7.36.0-cp310-abi3-macosx_10_9_universal2.whl", hash = "sha256:9103532dffd80c6fab7e50c65a31007680a06eb57537d437bb1b35812c138a37"},
+    {file = "protobuf-7.36.0-cp310-abi3-manylinux2014_aarch64.whl", hash = "sha256:bf94a5917c71058262de683669bc0a797a7669d3de71f0b36d058e3194f47b44"},
+    {file = "protobuf-7.36.0-cp310-abi3-manylinux2014_s390x.whl", hash = "sha256:3297e60abdff301e5f74393d87f6cc59dacab5f024a89548a6e8de1d26576b16"},
+    {file = "protobuf-7.36.0-cp310-abi3-manylinux2014_x86_64.whl", hash = "sha256:70f5ec8eb0da81a44360c0dc0beac99a0d78071d21956a7076bae8bd2051841b"},
+    {file = "protobuf-7.36.0-cp310-abi3-win32.whl", hash = "sha256:7326fd717bdc419162a735938d89d4032332bcc3408804012b24ff3a37086071"},
+    {file = "protobuf-7.36.0-cp310-abi3-win_amd64.whl", hash = "sha256:1781cc1de61249b750848029bca452c0a8b7e990080316b9bbc2518b2117b488"},
+    {file = "protobuf-7.36.0-py3-none-any.whl", hash = "sha256:53374d53fc29a67f7dbbf0ade47d7526a0f0137bf0f9c90e48d8a60790ef748c"},
+    {file = "protobuf-7.36.0.tar.gz", hash = "sha256:e8e09cb0d794c6687926fa558a8a6e72aa10edb997d5ca61da0765f12a3e00ea"},
+]
 
 [[package]]
 name = "psutil"
@@ -3808,6 +4520,36 @@ vault = ["hvac (>=2.3.0)", "types-hvac (>=2.3.0)"]
 wrappers-encryption = ["cryptography (>=45.0.0)"]
 
 [[package]]
+name = "pyabel"
+version = "0.9.1"
+description = "A Python package for forward and inverse Abel transforms"
+optional = true
+python-versions = "*"
+groups = ["main"]
+markers = "extra == \"analysis-run\""
+files = [
+    {file = "pyabel-0.9.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:1b247e205ca438b91d7af76509fed524fd53c4eca0b198522d4be2ecc68895d8"},
+    {file = "pyabel-0.9.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:4af8b6cafcdddae068e998cef3a32121b11bbe9a6b341636a990a52e663a927f"},
+    {file = "pyabel-0.9.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c513bc4d29e0c3cbe4f725af4276cb573f45d27b50b3fdbbc689366dcc78e92c"},
+    {file = "pyabel-0.9.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:46f6c6919b1b9e04e8a146b78da6172c63e8b38d3e4e4a1f9e7b6cf5464ccbf8"},
+    {file = "pyabel-0.9.1-cp312-cp312-win_amd64.whl", hash = "sha256:e550da7d48a2209282e5ea62bd524144d5d5f480db97b9a0b891e1f9337ebc47"},
+    {file = "pyabel-0.9.1-cp312-cp312-win_arm64.whl", hash = "sha256:187bfb6aea9b19f2a465857b915c075011c12de97a6f4ea2bce6166e6fda8182"},
+    {file = "pyabel-0.9.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:2e2214d026b7b8a51497a48a8114ec9ff6ce62b95e3b8e6fb607ffd6f91987df"},
+    {file = "pyabel-0.9.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:82b8bdb367e55f4ae2d046763ad468b24a744767099776182c51a705f4e6e65c"},
+    {file = "pyabel-0.9.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f4c5e847052e80c11be9c9b8261640c589b5d0376e6a6d86467248fa61be997f"},
+    {file = "pyabel-0.9.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:005745341f20532fb04a4e6506d324eb6a5bf08db73278fb322b373586e91a98"},
+    {file = "pyabel-0.9.1-cp313-cp313-win_amd64.whl", hash = "sha256:903a60c66440f0b5a4a57a1f89faa2ddeb47c216893e333f7d0c3afe3242ac17"},
+    {file = "pyabel-0.9.1-cp313-cp313-win_arm64.whl", hash = "sha256:8626e9aae6b5e82e9c8cc982f8b730540d849db6f27a314dc7baa8682a7dc287"},
+    {file = "pyabel-0.9.1.tar.gz", hash = "sha256:59652a2d8474d53523617c8fa442b18e5384c525f1895a3c43eb1261bb2a339c"},
+]
+
+[package.dependencies]
+numpy = ">=1.16"
+scipy = ">=1.2"
+setuptools = ">=44.0"
+six = ">=1.10.0"
+
+[[package]]
 name = "pyarrow"
 version = "25.0.1"
 description = "Python library for Apache Arrow"
@@ -3859,6 +4601,35 @@ files = [
     {file = "pyarrow-25.0.1-cp314-cp314t-win_amd64.whl", hash = "sha256:4288f27577352d608ca08553b0865e4a9b3aa14820c5d95b53337218d609835b"},
     {file = "pyarrow-25.0.1.tar.gz", hash = "sha256:9150a83248bfed9813ea3c3af74c3856c1984d444aa28e58bf7733b9750ddf6a"},
 ]
+
+[[package]]
+name = "pyasn1"
+version = "0.6.4"
+description = "Pure-Python implementation of ASN.1 types and DER/BER/CER codecs (X.208)"
+optional = true
+python-versions = ">=3.8"
+groups = ["main"]
+markers = "extra == \"analysis-run\""
+files = [
+    {file = "pyasn1-0.6.4-py3-none-any.whl", hash = "sha256:deda9277cfd454080ec40b207fb6df82206a3a2688735233cdcd8d3d565f088b"},
+    {file = "pyasn1-0.6.4.tar.gz", hash = "sha256:9c447d8431c947fe4c8febc4ed9e760bc29011a5b01e5c74b67025bd9fb8ce81"},
+]
+
+[[package]]
+name = "pyasn1-modules"
+version = "0.4.2"
+description = "A collection of ASN.1-based protocols modules"
+optional = true
+python-versions = ">=3.8"
+groups = ["main"]
+markers = "extra == \"analysis-run\""
+files = [
+    {file = "pyasn1_modules-0.4.2-py3-none-any.whl", hash = "sha256:29253a9207ce32b64c3ac6600edc75368f98473906e8fd1043bd6b5b1de2c14a"},
+    {file = "pyasn1_modules-0.4.2.tar.gz", hash = "sha256:677091de870a80aae844b1ca6134f54652fa2c8c5a52aa396440ac3106e941e6"},
+]
+
+[package.dependencies]
+pyasn1 = ">=0.6.1,<0.7.0"
 
 [[package]]
 name = "pycparser"
@@ -4124,6 +4895,22 @@ cryptography = {version = ">=3.4.0", optional = true, markers = "extra == \"cryp
 crypto = ["cryptography (>=3.4.0)"]
 
 [[package]]
+name = "pyparsing"
+version = "3.3.2"
+description = "pyparsing - Classes and methods to define and execute parsing grammars"
+optional = true
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "extra == \"analysis-run\""
+files = [
+    {file = "pyparsing-3.3.2-py3-none-any.whl", hash = "sha256:850ba148bd908d7e2411587e247a1e4f0327839c40e2e5e6d05a007ecc69911d"},
+    {file = "pyparsing-3.3.2.tar.gz", hash = "sha256:c777f4d763f140633dcb6d8a3eda953bf7a214dc4eff598413c070bcdc117cbc"},
+]
+
+[package.extras]
+diagrams = ["jinja2", "railroad-diagrams"]
+
+[[package]]
 name = "pyperclip"
 version = "1.11.0"
 description = "A cross-platform clipboard module for Python. (Only handles plain text for now.)"
@@ -4148,12 +4935,134 @@ files = [
 ]
 
 [[package]]
+name = "pyqt5"
+version = "5.15.9"
+description = "Python bindings for the Qt cross platform application toolkit"
+optional = true
+python-versions = ">=3.7"
+groups = ["main"]
+markers = "extra == \"analysis-run\" and sys_platform == \"win32\""
+files = [
+    {file = "PyQt5-5.15.9-cp37-abi3-macosx_10_13_x86_64.whl", hash = "sha256:883ba5c8a348be78c8be6a3d3ba014c798e679503bce00d76c666c2dc6afe828"},
+    {file = "PyQt5-5.15.9-cp37-abi3-manylinux_2_17_x86_64.whl", hash = "sha256:dd5ce10e79fbf1df29507d2daf99270f2057cdd25e4de6fbf2052b46c652e3a5"},
+    {file = "PyQt5-5.15.9-cp37-abi3-win32.whl", hash = "sha256:e45c5cc15d4fd26ab5cb0e5cdba60691a3e9086411f8e3662db07a5a4222a696"},
+    {file = "PyQt5-5.15.9-cp37-abi3-win_amd64.whl", hash = "sha256:e030d795df4cbbfcf4f38b18e2e119bcc9e177ef658a5094b87bb16cac0ce4c5"},
+    {file = "PyQt5-5.15.9.tar.gz", hash = "sha256:dc41e8401a90dc3e2b692b411bd5492ab559ae27a27424eed4bd3915564ec4c0"},
+]
+
+[package.dependencies]
+PyQt5-Qt5 = ">=5.15.2"
+PyQt5-sip = ">=12.11,<13"
+
+[[package]]
+name = "pyqt5-plugins"
+version = "5.15.9.2.3"
+description = "PyQt Designer and QML plugins"
+optional = true
+python-versions = ">=3.7"
+groups = ["main"]
+markers = "extra == \"analysis-run\" and sys_platform == \"win32\""
+files = [
+    {file = "pyqt5_plugins-5.15.9.2.3-cp310-cp310-macosx_11_0_x86_64.whl", hash = "sha256:798b9f7d212972ac3940425d0cfe3a90669520b29b113da9d63a0996b7e121f4"},
+    {file = "pyqt5_plugins-5.15.9.2.3-cp310-cp310-manylinux2014_x86_64.whl", hash = "sha256:a818862de6a19965fca26174d462097829f523e177025e96c415e0389d212616"},
+    {file = "pyqt5_plugins-5.15.9.2.3-cp310-cp310-win32.whl", hash = "sha256:a1abd0aaaf4bb1c0d35ed33eba9707f2212a235f45bf9bd103e65d60147d8865"},
+    {file = "pyqt5_plugins-5.15.9.2.3-cp310-cp310-win_amd64.whl", hash = "sha256:b3f2c1598a171c36bcc78f68d58370e6876afacdda66e0c1e2c1ce861907a7c9"},
+    {file = "pyqt5_plugins-5.15.9.2.3-cp311-cp311-macosx_10_13_universal2.whl", hash = "sha256:078b1564a54c1549e40a87c32deb9cf9e77d72f004cd0f5f42a2acfd4d6aea36"},
+    {file = "pyqt5_plugins-5.15.9.2.3-cp311-cp311-manylinux2014_x86_64.whl", hash = "sha256:c883469f6d17859c8991d44d72fff6b2b9e3fa18b371c86ff002afb5e790f9c6"},
+    {file = "pyqt5_plugins-5.15.9.2.3-cp311-cp311-win32.whl", hash = "sha256:f48754c09ed46a0b6305109c0c19ed7cd8b13925ba81ef2df2e8a870437b3aa7"},
+    {file = "pyqt5_plugins-5.15.9.2.3-cp311-cp311-win_amd64.whl", hash = "sha256:1d9acf423062c6694a5e68782fb54ce90355481d33281c9193da45c43426853c"},
+    {file = "pyqt5_plugins-5.15.9.2.3-cp37-cp37m-macosx_10_15_x86_64.whl", hash = "sha256:ed24621fbfc20964899ea5b4d1339e765847be532cedc2f195a0adb6cd2b2447"},
+    {file = "pyqt5_plugins-5.15.9.2.3-cp37-cp37m-manylinux2014_x86_64.whl", hash = "sha256:b26d7af31c0e42705a4c24fdffb29f069e3bf089f1f7b3927aff9f4adfa75b72"},
+    {file = "pyqt5_plugins-5.15.9.2.3-cp37-cp37m-win32.whl", hash = "sha256:d50304b6ffa684c08bc717db55e9cfe834937fc312888a7a64cd31fac27b0067"},
+    {file = "pyqt5_plugins-5.15.9.2.3-cp37-cp37m-win_amd64.whl", hash = "sha256:808f5456f205520af3a1e48cd935a81e7a3c032d069a6436a07ec276e486f4dd"},
+    {file = "pyqt5_plugins-5.15.9.2.3-cp38-cp38-macosx_10_15_x86_64.whl", hash = "sha256:b862c340b13cf782f77778cc9c5e28ceeb7ecbf9da0c7410b5c55050a59efe59"},
+    {file = "pyqt5_plugins-5.15.9.2.3-cp38-cp38-manylinux2014_x86_64.whl", hash = "sha256:b4225d531773c3c69814a05877651b29d639f1887f25b8b19dcc0e160427582a"},
+    {file = "pyqt5_plugins-5.15.9.2.3-cp38-cp38-win32.whl", hash = "sha256:e0715d4149701fac3ad3b6777a272edab7ca375524d4c3742b3a6c11d46b2d35"},
+    {file = "pyqt5_plugins-5.15.9.2.3-cp38-cp38-win_amd64.whl", hash = "sha256:ad82f31bfd6c7039909980628fcbcc7e843013dbdfcf3674f1ffaf53f90b71cc"},
+    {file = "pyqt5_plugins-5.15.9.2.3-cp39-cp39-macosx_11_0_x86_64.whl", hash = "sha256:3e7ba7995e71ba06d536c8a36168ae03199a3983a727d627000f170d6e3a29f4"},
+    {file = "pyqt5_plugins-5.15.9.2.3-cp39-cp39-manylinux2014_x86_64.whl", hash = "sha256:b3e747cd3be0885b12e8bde32234df0ee082dfc9607751ce81fb2aa694462048"},
+    {file = "pyqt5_plugins-5.15.9.2.3-cp39-cp39-win32.whl", hash = "sha256:e4670917c36b039b6d195af177afa369f603aa00376890fd540c955ec56c9284"},
+    {file = "pyqt5_plugins-5.15.9.2.3-cp39-cp39-win_amd64.whl", hash = "sha256:bacaae333802856871e24045f121967f73e2b5f95a55b633f76b78c6a87e034c"},
+]
+
+[package.dependencies]
+click = "*"
+pyqt5 = "5.15.9"
+pyqt5-qt5 = "5.15.2"
+qt5-tools = ">=5.15.2.1.2,<5.15.2.2"
+
+[[package]]
+name = "pyqt5-qt5"
+version = "5.15.2"
+description = "The subset of a Qt installation needed by PyQt5."
+optional = true
+python-versions = "*"
+groups = ["main"]
+markers = "extra == \"analysis-run\" and sys_platform == \"win32\""
+files = [
+    {file = "PyQt5_Qt5-5.15.2-py3-none-macosx_10_13_intel.whl", hash = "sha256:76980cd3d7ae87e3c7a33bfebfaee84448fd650bad6840471d6cae199b56e154"},
+    {file = "PyQt5_Qt5-5.15.2-py3-none-manylinux2014_x86_64.whl", hash = "sha256:1988f364ec8caf87a6ee5d5a3a5210d57539988bf8e84714c7d60972692e2f4a"},
+    {file = "PyQt5_Qt5-5.15.2-py3-none-win32.whl", hash = "sha256:9cc7a768b1921f4b982ebc00a318ccb38578e44e45316c7a4a850e953e1dd327"},
+    {file = "PyQt5_Qt5-5.15.2-py3-none-win_amd64.whl", hash = "sha256:750b78e4dba6bdf1607febedc08738e318ea09e9b10aea9ff0d73073f11f6962"},
+]
+
+[[package]]
+name = "pyqt5-sip"
+version = "12.19.0"
+description = "The sip module support for PyQt5"
+optional = true
+python-versions = ">=3.10"
+groups = ["main"]
+markers = "extra == \"analysis-run\" and sys_platform == \"win32\""
+files = [
+    {file = "pyqt5_sip-12.19.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:d3d1348235e0b2e01c962d14d5fe410b962ae49ee2cfaac5c66fe5f1edd50487"},
+    {file = "pyqt5_sip-12.19.0-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:ec8d8cbada7a92a8ab5994503ee6f6274b41c4ecbb7d60ebf858450ba5e1cc01"},
+    {file = "pyqt5_sip-12.19.0-cp310-cp310-win32.whl", hash = "sha256:92df9d2ddf99d3a8a3fab6736077cc8d0531be4db4d8ff01d03ce6e0b07e00bf"},
+    {file = "pyqt5_sip-12.19.0-cp310-cp310-win_amd64.whl", hash = "sha256:0a7ca72b06a98e4456d7f5a25e741064fb0d6f7c5d0f7302fd41384e2ec9e1c5"},
+    {file = "pyqt5_sip-12.19.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:b29e97d6aacbdc3535f17f83d11d6bd95abb0e36865a250c3d1c14719bb2f1b4"},
+    {file = "pyqt5_sip-12.19.0-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:40ed8341b7c6681d102708b65acbccf0c26908189bfa2e05e180a3b515296a87"},
+    {file = "pyqt5_sip-12.19.0-cp311-cp311-win32.whl", hash = "sha256:3d8a08fad1bc89e083d712378af4fddee9f6102cd4254e6a5c0ad7055a09670a"},
+    {file = "pyqt5_sip-12.19.0-cp311-cp311-win_amd64.whl", hash = "sha256:f01cd36afef40bd0d81d0d98ff125112ce0df725b936d9eee3f1be1cc7e96e91"},
+    {file = "pyqt5_sip-12.19.0-cp312-cp312-macosx_10_9_universal2.whl", hash = "sha256:6f7cd8a868f20fe450b6d17016ff0b0e0c8fecf32d620dcbf319a2174cbcad00"},
+    {file = "pyqt5_sip-12.19.0-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:3c5e0da86b5ae71b7acf2134e15fc8734a129549119cade25accddb3f28cb950"},
+    {file = "pyqt5_sip-12.19.0-cp312-cp312-win32.whl", hash = "sha256:aa94140b8f8255f87f85b55a471b0cabfd6c8a41a752a6d3f3d3f34942b8ee3d"},
+    {file = "pyqt5_sip-12.19.0-cp312-cp312-win_amd64.whl", hash = "sha256:628f58e13d47bd7f1a002c0c1d874b5ad7e5644c10d9334c7de4b91b001f6607"},
+    {file = "pyqt5_sip-12.19.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:a50aacf432f62e288af179040aea7bf79571f7671a89ac7064d7224a3734c22b"},
+    {file = "pyqt5_sip-12.19.0-cp313-cp313-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:16f31c35b767e45c017ce3966a48a57ff6e9a3cf9317b1e5bb71ac3cf3718e6b"},
+    {file = "pyqt5_sip-12.19.0-cp313-cp313-win32.whl", hash = "sha256:2de029b867c725f3bc5806d7640ab48696abd4e9e044cf5e26dc958dec9233b8"},
+    {file = "pyqt5_sip-12.19.0-cp313-cp313-win_amd64.whl", hash = "sha256:ab5f4753a67663ba773babf7d32d1c4a447740aa0acdc5f33d385b70952d8cc5"},
+    {file = "pyqt5_sip-12.19.0-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:2cee6450c8646b40fd8f9e75b0a340b6dfc652a4bfec338cf126b66ac61d5638"},
+    {file = "pyqt5_sip-12.19.0-cp314-cp314-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:e7bef99160b0b812be12789b5febe005ca8ed07e4804df32f0a9dbd0f747e32e"},
+    {file = "pyqt5_sip-12.19.0-cp314-cp314-win32.whl", hash = "sha256:b7a651db2339f81831050029e5363aa7adb6873ac7002e786dc07782538da6cd"},
+    {file = "pyqt5_sip-12.19.0-cp314-cp314-win_amd64.whl", hash = "sha256:4058fcb39306719c79c5c52da45208093b11c2c92c09eb2f77b950b12a5a87c2"},
+    {file = "pyqt5_sip-12.19.0.tar.gz", hash = "sha256:71cacf1879da2cd3e50cb239e21673cfe02d358af70ab6768817c960428868c3"},
+]
+
+[[package]]
+name = "pyqt5-tools"
+version = "5.15.9.3.3"
+description = "PyQt Designer and QML plugins"
+optional = true
+python-versions = ">=3.7"
+groups = ["main"]
+markers = "extra == \"analysis-run\" and sys_platform == \"win32\""
+files = [
+    {file = "pyqt5_tools-5.15.9.3.3-py3-none-any.whl", hash = "sha256:4b45b26111c583a34fa364b98d7120f5aeca4f96ac72e251f1b37a9cca809f86"},
+]
+
+[package.dependencies]
+click = "*"
+pyqt5 = "5.15.9"
+pyqt5-plugins = ">=5.15.9.2.2,<5.15.9.3"
+python-dotenv = "*"
+
+[[package]]
 name = "pytest"
 version = "9.1.1"
 description = "pytest: simple powerful testing with Python"
 optional = false
 python-versions = ">=3.10"
-groups = ["dev"]
+groups = ["main", "dev"]
 files = [
     {file = "pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c"},
     {file = "pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313"},
@@ -4451,6 +5360,37 @@ files = [
 cffi = {version = "*", markers = "implementation_name == \"pypy\""}
 
 [[package]]
+name = "qt5-applications"
+version = "5.15.2.2.3"
+description = "The collection of Qt tools easily installable in Python"
+optional = true
+python-versions = ">=3.7"
+groups = ["main"]
+markers = "extra == \"analysis-run\" and sys_platform == \"win32\""
+files = [
+    {file = "qt5_applications-5.15.2.2.3-py3-none-macosx_10_14_x86_64.whl", hash = "sha256:45395074b742ca6765990d3645d5e24a59415c1d968c40c6a3443da22c621ba8"},
+    {file = "qt5_applications-5.15.2.2.3-py3-none-manylinux_2_17_x86_64.whl", hash = "sha256:9ac537caf18fc339149391f58e6716c472296df4431d68e76670e75a14238de0"},
+    {file = "qt5_applications-5.15.2.2.3-py3-none-win32.whl", hash = "sha256:8d4ebdd955653f693edac4697f80e016270efcf861ebb1b8b7e238fd6faba5f5"},
+    {file = "qt5_applications-5.15.2.2.3-py3-none-win_amd64.whl", hash = "sha256:5156cc710ed3942f736ec2c46889f73d829fcd4093bed8dbddf2fd83929fdf0b"},
+]
+
+[[package]]
+name = "qt5-tools"
+version = "5.15.2.1.3"
+description = "Wrappers for the raw Qt programs from qt5-applications"
+optional = true
+python-versions = ">=3.7"
+groups = ["main"]
+markers = "extra == \"analysis-run\" and sys_platform == \"win32\""
+files = [
+    {file = "qt5_tools-5.15.2.1.3-py3-none-any.whl", hash = "sha256:3e73b7aa3cd03abba6e703aa1d21a5934eff42a068292500a1f02c9bc6da95cb"},
+]
+
+[package.dependencies]
+click = "*"
+qt5-applications = ">=5.15.2.2.2,<5.15.2.3"
+
+[[package]]
 name = "ragged"
 version = "0.3.0"
 description = "Ragged array library, complying with Python API specification."
@@ -4533,6 +5473,26 @@ urllib3 = ">=1.26,<3"
 [package.extras]
 socks = ["PySocks (>=1.5.6,!=1.5.7)"]
 use-chardet-on-py3 = ["chardet (>=3.0.2,<8)"]
+
+[[package]]
+name = "requests-oauthlib"
+version = "2.0.0"
+description = "OAuthlib authentication support for Requests."
+optional = true
+python-versions = ">=3.4"
+groups = ["main"]
+markers = "extra == \"analysis-run\""
+files = [
+    {file = "requests-oauthlib-2.0.0.tar.gz", hash = "sha256:b3dffaebd884d8cd778494369603a9e7b58d29111bf6b41bdc2dcd87203af4e9"},
+    {file = "requests_oauthlib-2.0.0-py2.py3-none-any.whl", hash = "sha256:7dd8a5c40426b779b0868c404bdef9768deccf22749cde15852df527e6269b36"},
+]
+
+[package.dependencies]
+oauthlib = ">=3.0.0"
+requests = ">=2.0.0"
+
+[package.extras]
+rsa = ["oauthlib[signedtoken] (>=3.0.0)"]
 
 [[package]]
 name = "rich"
@@ -4832,6 +5792,53 @@ files = [
 ]
 
 [[package]]
+name = "s3transfer"
+version = "0.19.2"
+description = "An Amazon S3 Transfer Manager"
+optional = true
+python-versions = ">=3.10"
+groups = ["main"]
+markers = "extra == \"analysis-run\""
+files = [
+    {file = "s3transfer-0.19.2-py3-none-any.whl", hash = "sha256:d8168eccca828cbb2cd573675333f3bddd254313a9c42494b84c76b539e8ba25"},
+    {file = "s3transfer-0.19.2.tar.gz", hash = "sha256:ba0309fd86be3c27dbf78cdd813c13c5e1df16e5874b99d2535ebbdfb9892993"},
+]
+
+[package.dependencies]
+botocore = ">=1.37.4,<2.0a.0"
+
+[package.extras]
+crt = ["botocore[crt] (>=1.37.4,<2.0a.0)"]
+
+[[package]]
+name = "scananalysis"
+version = "1.15.1"
+description = "Modules for performing analyses routines on full scans"
+optional = true
+python-versions = ">=3.11,<3.12"
+groups = ["main"]
+markers = "extra == \"analysis-run\""
+files = []
+develop = true
+
+[package.dependencies]
+geecs_data_utils = {path = "../GEECS-Data-Utils", develop = true}
+h5py = "^3.8.0"
+ImageAnalysis = {path = "../ImageAnalysis", develop = true}
+LogMaker4GoogleDocs = {path = "../LogMaker4GoogleDocs", develop = true}
+matplotlib = "^3.9.2"
+pandas = "^2.2.3"
+PyQt5 = {version = "^5.15.9", markers = "sys_platform == \"win32\""}
+pyqt5-tools = {version = "^5.15.9.3.3", markers = "sys_platform == \"win32\""}
+pyyaml = "^6.0.2"
+requests = "^2.28.0"
+watchdog = "^6.0.0"
+
+[package.source]
+type = "directory"
+url = "../ScanAnalysis"
+
+[[package]]
 name = "scanspec"
 version = "1.0.0"
 description = "Specify step and flyscan paths in a serializable, efficient and Pythonic way"
@@ -4851,6 +5858,166 @@ pydantic = ">=2.0"
 [package.extras]
 plotting = ["matplotlib", "scipy"]
 service = ["fastapi (>=0.100.0)", "uvicorn"]
+
+[[package]]
+name = "scikit-image"
+version = "0.26.0"
+description = "Image processing in Python"
+optional = true
+python-versions = ">=3.11"
+groups = ["main"]
+markers = "extra == \"analysis-run\""
+files = [
+    {file = "scikit_image-0.26.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:b1ede33a0fb3731457eaf53af6361e73dd510f449dac437ab54573b26788baf0"},
+    {file = "scikit_image-0.26.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:7af7aa331c6846bd03fa28b164c18d0c3fd419dbb888fb05e958ac4257a78fdd"},
+    {file = "scikit_image-0.26.0-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9ea6207d9e9d21c3f464efe733121c0504e494dbdc7728649ff3e23c3c5a4953"},
+    {file = "scikit_image-0.26.0-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:74aa5518ccea28121f57a95374581d3b979839adc25bb03f289b1bc9b99c58af"},
+    {file = "scikit_image-0.26.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:d5c244656de905e195a904e36dbc18585e06ecf67d90f0482cbde63d7f9ad59d"},
+    {file = "scikit_image-0.26.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:21a818ee6ca2f2131b9e04d8eb7637b5c18773ebe7b399ad23dcc5afaa226d2d"},
+    {file = "scikit_image-0.26.0-cp311-cp311-win_amd64.whl", hash = "sha256:9490360c8d3f9a7e85c8de87daf7c0c66507960cf4947bb9610d1751928721c7"},
+    {file = "scikit_image-0.26.0-cp311-cp311-win_arm64.whl", hash = "sha256:0baa0108d2d027f34d748e84e592b78acc23e965a5de0e4bb03cf371de5c0581"},
+    {file = "scikit_image-0.26.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:d454b93a6fa770ac5ae2d33570f8e7a321bb80d29511ce4b6b78058ebe176e8c"},
+    {file = "scikit_image-0.26.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:3409e89d66eff5734cd2b672d1c48d2759360057e714e1d92a11df82c87cba37"},
+    {file = "scikit_image-0.26.0-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4c717490cec9e276afb0438dd165b7c3072d6c416709cc0f9f5a4c1070d23a44"},
+    {file = "scikit_image-0.26.0-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7df650e79031634ac90b11e64a9eedaf5a5e06fcd09bcd03a34be01745744466"},
+    {file = "scikit_image-0.26.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:cefd85033e66d4ea35b525bb0937d7f42d4cdcfed2d1888e1570d5ce450d3932"},
+    {file = "scikit_image-0.26.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:3f5bf622d7c0435884e1e141ebbe4b2804e16b2dd23ae4c6183e2ea99233be70"},
+    {file = "scikit_image-0.26.0-cp312-cp312-win_amd64.whl", hash = "sha256:abed017474593cd3056ae0fe948d07d0747b27a085e92df5474f4955dd65aec0"},
+    {file = "scikit_image-0.26.0-cp312-cp312-win_arm64.whl", hash = "sha256:4d57e39ef67a95d26860c8caf9b14b8fb130f83b34c6656a77f191fa6d1d04d8"},
+    {file = "scikit_image-0.26.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:a2e852eccf41d2d322b8e60144e124802873a92b8d43a6f96331aa42888491c7"},
+    {file = "scikit_image-0.26.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:98329aab3bc87db352b9887f64ce8cdb8e75f7c2daa19927f2e121b797b678d5"},
+    {file = "scikit_image-0.26.0-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:915bb3ba66455cf8adac00dc8fdf18a4cd29656aec7ddd38cb4dda90289a6f21"},
+    {file = "scikit_image-0.26.0-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b36ab5e778bf50af5ff386c3ac508027dc3aaeccf2161bdf96bde6848f44d21b"},
+    {file = "scikit_image-0.26.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:09bad6a5d5949c7896c8347424c4cca899f1d11668030e5548813ab9c2865dcb"},
+    {file = "scikit_image-0.26.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:aeb14db1ed09ad4bee4ceb9e635547a8d5f3549be67fc6c768c7f923e027e6cd"},
+    {file = "scikit_image-0.26.0-cp313-cp313-win_amd64.whl", hash = "sha256:ac529eb9dbd5954f9aaa2e3fe9a3fd9661bfe24e134c688587d811a0233127f1"},
+    {file = "scikit_image-0.26.0-cp313-cp313-win_arm64.whl", hash = "sha256:a2d211bc355f59725efdcae699b93b30348a19416cc9e017f7b2fb599faf7219"},
+    {file = "scikit_image-0.26.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:9eefb4adad066da408a7601c4c24b07af3b472d90e08c3e7483d4e9e829d8c49"},
+    {file = "scikit_image-0.26.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:6caec76e16c970c528d15d1c757363334d5cb3069f9cea93d2bead31820511f3"},
+    {file = "scikit_image-0.26.0-cp313-cp313t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a07200fe09b9d99fcdab959859fe0f7db8df6333d6204344425d476850ce3604"},
+    {file = "scikit_image-0.26.0-cp313-cp313t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:92242351bccf391fc5df2d1529d15470019496d2498d615beb68da85fe7fdf37"},
+    {file = "scikit_image-0.26.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:52c496f75a7e45844d951557f13c08c81487c6a1da2e3c9c8a39fcde958e02cc"},
+    {file = "scikit_image-0.26.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:20ef4a155e2e78b8ab973998e04d8a361d49d719e65412405f4dadd9155a61d9"},
+    {file = "scikit_image-0.26.0-cp313-cp313t-win_amd64.whl", hash = "sha256:c9087cf7d0e7f33ab5c46d2068d86d785e70b05400a891f73a13400f1e1faf6a"},
+    {file = "scikit_image-0.26.0-cp313-cp313t-win_arm64.whl", hash = "sha256:27d58bc8b2acd351f972c6508c1b557cfed80299826080a4d803dd29c51b707e"},
+    {file = "scikit_image-0.26.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:63af3d3a26125f796f01052052f86806da5b5e54c6abef152edb752683075a9c"},
+    {file = "scikit_image-0.26.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:ce00600cd70d4562ed59f80523e18cdcc1fae0e10676498a01f73c255774aefd"},
+    {file = "scikit_image-0.26.0-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6381edf972b32e4f54085449afde64365a57316637496c1325a736987083e2ab"},
+    {file = "scikit_image-0.26.0-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c6624a76c6085218248154cc7e1500e6b488edcd9499004dd0d35040607d7505"},
+    {file = "scikit_image-0.26.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:f775f0e420faac9c2aa6757135f4eb468fb7b70e0b67fa77a5e79be3c30ee331"},
+    {file = "scikit_image-0.26.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ede4d6d255cc5da9faeb2f9ba7fedbc990abbc652db429f40a16b22e770bb578"},
+    {file = "scikit_image-0.26.0-cp314-cp314-win_amd64.whl", hash = "sha256:0660b83968c15293fd9135e8d860053ee19500d52bf55ca4fb09de595a1af650"},
+    {file = "scikit_image-0.26.0-cp314-cp314-win_arm64.whl", hash = "sha256:b8d14d3181c21c11170477a42542c1addc7072a90b986675a71266ad17abc37f"},
+    {file = "scikit_image-0.26.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:cde0bbd57e6795eba83cb10f71a677f7239271121dc950bc060482834a668ad1"},
+    {file = "scikit_image-0.26.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:163e9afb5b879562b9aeda0dd45208a35316f26cc7a3aed54fd601604e5cf46f"},
+    {file = "scikit_image-0.26.0-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:724f79fd9b6cb6f4a37864fe09f81f9f5d5b9646b6868109e1b100d1a7019e59"},
+    {file = "scikit_image-0.26.0-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3268f13310e6857508bd87202620df996199a016a1d281b309441d227c822394"},
+    {file = "scikit_image-0.26.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:fac96a1f9b06cd771cbbb3cd96c5332f36d4efd839b1d8b053f79e5887acde62"},
+    {file = "scikit_image-0.26.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:2c1e7bd342f43e7a97e571b3f03ba4c1293ea1a35c3f13f41efdc8a81c1dc8f2"},
+    {file = "scikit_image-0.26.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b702c3bb115e1dcf4abf5297429b5c90f2189655888cbed14921f3d26f81d3a4"},
+    {file = "scikit_image-0.26.0-cp314-cp314t-win_arm64.whl", hash = "sha256:0608aa4a9ec39e0843de10d60edb2785a30c1c47819b67866dd223ebd149acaf"},
+    {file = "scikit_image-0.26.0.tar.gz", hash = "sha256:f5f970ab04efad85c24714321fcc91613fcb64ef2a892a13167df2f3e59199fa"},
+]
+
+[package.dependencies]
+imageio = ">=2.33,<2.35.0 || >2.35.0"
+lazy-loader = ">=0.4"
+networkx = ">=3.0"
+numpy = ">=1.24"
+packaging = ">=21"
+pillow = ">=10.1"
+scipy = ">=1.11.4"
+tifffile = ">=2022.8.12"
+
+[package.extras]
+asv = ["asv ; sys_platform != \"emscripten\""]
+build = ["Cython (>=3.0.8,!=3.2.0b1)", "build (>=1.2.1)", "meson-python (>=0.16)", "ninja (>=1.11.1.1)", "numpy (>=2.0)", "pythran (>=0.16)", "spin (==0.13)"]
+data = ["pooch (>=1.6.0)"]
+developer = ["docstub (==0.3.0.post0)", "ipython", "pre-commit", "scikit-image[asv]"]
+docs = ["PyWavelets (>=1.6)", "dask[array] (>=2023.2.0)", "intersphinx-registry (>=0.2411.14)", "ipykernel", "ipywidgets", "kaleido (==0.2.1)", "matplotlib (>=3.7)", "myst-parser", "numpydoc (>=1.7)", "pandas (>=2.0)", "plotly (>=5.20)", "pooch (>=1.6)", "pydata-sphinx-theme (>=0.16)", "pytest-doctestplus (>=1.6.0)", "scikit-learn (>=1.2)", "seaborn (>=0.11)", "sphinx (>=8.0)", "sphinx-copybutton", "sphinx-gallery[parallel] (>=0.18)", "sphinx_design (>=0.5)", "tifffile (>=2022.8.12)"]
+optional = ["SimpleITK ; sys_platform != \"emscripten\"", "pyamg (>=5.2) ; sys_platform != \"emscripten\" and python_version < \"3.14\"", "scikit-image[optional-free-threaded]", "scikit-learn (>=1.2)"]
+optional-free-threaded = ["PyWavelets (>=1.6)", "astropy (>=6.0)", "dask[array] (>=2023.2.0)", "matplotlib (>=3.7)", "pooch (>=1.6.0) ; sys_platform != \"emscripten\""]
+test = ["numpydoc (>=1.7)", "pooch (>=1.6.0) ; sys_platform != \"emscripten\"", "pytest (>=8.3)", "pytest-cov (>=2.11.0)", "pytest-doctestplus (>=1.6.0)", "pytest-faulthandler", "pytest-localserver", "pytest-pretty"]
+
+[[package]]
+name = "scipy"
+version = "1.17.1"
+description = "Fundamental algorithms for scientific computing in Python"
+optional = true
+python-versions = ">=3.11"
+groups = ["main"]
+markers = "extra == \"analysis-run\""
+files = [
+    {file = "scipy-1.17.1-cp311-cp311-macosx_10_14_x86_64.whl", hash = "sha256:1f95b894f13729334fb990162e911c9e5dc1ab390c58aa6cbecb389c5b5e28ec"},
+    {file = "scipy-1.17.1-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:e18f12c6b0bc5a592ed23d3f7b891f68fd7f8241d69b7883769eb5d5dfb52696"},
+    {file = "scipy-1.17.1-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:a3472cfbca0a54177d0faa68f697d8ba4c80bbdc19908c3465556d9f7efce9ee"},
+    {file = "scipy-1.17.1-cp311-cp311-macosx_14_0_x86_64.whl", hash = "sha256:766e0dc5a616d026a3a1cffa379af959671729083882f50307e18175797b3dfd"},
+    {file = "scipy-1.17.1-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:744b2bf3640d907b79f3fd7874efe432d1cf171ee721243e350f55234b4cec4c"},
+    {file = "scipy-1.17.1-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:43af8d1f3bea642559019edfe64e9b11192a8978efbd1539d7bc2aaa23d92de4"},
+    {file = "scipy-1.17.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:cd96a1898c0a47be4520327e01f874acfd61fb48a9420f8aa9f6483412ffa444"},
+    {file = "scipy-1.17.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:4eb6c25dd62ee8d5edf68a8e1c171dd71c292fdae95d8aeb3dd7d7de4c364082"},
+    {file = "scipy-1.17.1-cp311-cp311-win_amd64.whl", hash = "sha256:d30e57c72013c2a4fe441c2fcb8e77b14e152ad48b5464858e07e2ad9fbfceff"},
+    {file = "scipy-1.17.1-cp311-cp311-win_arm64.whl", hash = "sha256:9ecb4efb1cd6e8c4afea0daa91a87fbddbce1b99d2895d151596716c0b2e859d"},
+    {file = "scipy-1.17.1-cp312-cp312-macosx_10_14_x86_64.whl", hash = "sha256:35c3a56d2ef83efc372eaec584314bd0ef2e2f0d2adb21c55e6ad5b344c0dcb8"},
+    {file = "scipy-1.17.1-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:fcb310ddb270a06114bb64bbe53c94926b943f5b7f0842194d585c65eb4edd76"},
+    {file = "scipy-1.17.1-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:cc90d2e9c7e5c7f1a482c9875007c095c3194b1cfedca3c2f3291cdc2bc7c086"},
+    {file = "scipy-1.17.1-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:c80be5ede8f3f8eded4eff73cc99a25c388ce98e555b17d31da05287015ffa5b"},
+    {file = "scipy-1.17.1-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e19ebea31758fac5893a2ac360fedd00116cbb7628e650842a6691ba7ca28a21"},
+    {file = "scipy-1.17.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:02ae3b274fde71c5e92ac4d54bc06c42d80e399fec704383dcd99b301df37458"},
+    {file = "scipy-1.17.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8a604bae87c6195d8b1045eddece0514d041604b14f2727bbc2b3020172045eb"},
+    {file = "scipy-1.17.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:f590cd684941912d10becc07325a3eeb77886fe981415660d9265c4c418d0bea"},
+    {file = "scipy-1.17.1-cp312-cp312-win_amd64.whl", hash = "sha256:41b71f4a3a4cab9d366cd9065b288efc4d4f3c0b37a91a8e0947fb5bd7f31d87"},
+    {file = "scipy-1.17.1-cp312-cp312-win_arm64.whl", hash = "sha256:f4115102802df98b2b0db3cce5cb9b92572633a1197c77b7553e5203f284a5b3"},
+    {file = "scipy-1.17.1-cp313-cp313-macosx_10_14_x86_64.whl", hash = "sha256:5e3c5c011904115f88a39308379c17f91546f77c1667cea98739fe0fccea804c"},
+    {file = "scipy-1.17.1-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:6fac755ca3d2c3edcb22f479fceaa241704111414831ddd3bc6056e18516892f"},
+    {file = "scipy-1.17.1-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:7ff200bf9d24f2e4d5dc6ee8c3ac64d739d3a89e2326ba68aaf6c4a2b838fd7d"},
+    {file = "scipy-1.17.1-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:4b400bdc6f79fa02a4d86640310dde87a21fba0c979efff5248908c6f15fad1b"},
+    {file = "scipy-1.17.1-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2b64ca7d4aee0102a97f3ba22124052b4bd2152522355073580bf4845e2550b6"},
+    {file = "scipy-1.17.1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:581b2264fc0aa555f3f435a5944da7504ea3a065d7029ad60e7c3d1ae09c5464"},
+    {file = "scipy-1.17.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:beeda3d4ae615106d7094f7e7cef6218392e4465cc95d25f900bebabfded0950"},
+    {file = "scipy-1.17.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6609bc224e9568f65064cfa72edc0f24ee6655b47575954ec6339534b2798369"},
+    {file = "scipy-1.17.1-cp313-cp313-win_amd64.whl", hash = "sha256:37425bc9175607b0268f493d79a292c39f9d001a357bebb6b88fdfaff13f6448"},
+    {file = "scipy-1.17.1-cp313-cp313-win_arm64.whl", hash = "sha256:5cf36e801231b6a2059bf354720274b7558746f3b1a4efb43fcf557ccd484a87"},
+    {file = "scipy-1.17.1-cp313-cp313t-macosx_10_14_x86_64.whl", hash = "sha256:d59c30000a16d8edc7e64152e30220bfbd724c9bbb08368c054e24c651314f0a"},
+    {file = "scipy-1.17.1-cp313-cp313t-macosx_12_0_arm64.whl", hash = "sha256:010f4333c96c9bb1a4516269e33cb5917b08ef2166d5556ca2fd9f082a9e6ea0"},
+    {file = "scipy-1.17.1-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:2ceb2d3e01c5f1d83c4189737a42d9cb2fc38a6eeed225e7515eef71ad301dce"},
+    {file = "scipy-1.17.1-cp313-cp313t-macosx_14_0_x86_64.whl", hash = "sha256:844e165636711ef41f80b4103ed234181646b98a53c8f05da12ca5ca289134f6"},
+    {file = "scipy-1.17.1-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:158dd96d2207e21c966063e1635b1063cd7787b627b6f07305315dd73d9c679e"},
+    {file = "scipy-1.17.1-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:74cbb80d93260fe2ffa334efa24cb8f2f0f622a9b9febf8b483c0b865bfb3475"},
+    {file = "scipy-1.17.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:dbc12c9f3d185f5c737d801da555fb74b3dcfa1a50b66a1a93e09190f41fab50"},
+    {file = "scipy-1.17.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:94055a11dfebe37c656e70317e1996dc197e1a15bbcc351bcdd4610e128fe1ca"},
+    {file = "scipy-1.17.1-cp313-cp313t-win_amd64.whl", hash = "sha256:e30bdeaa5deed6bc27b4cc490823cd0347d7dae09119b8803ae576ea0ce52e4c"},
+    {file = "scipy-1.17.1-cp313-cp313t-win_arm64.whl", hash = "sha256:a720477885a9d2411f94a93d16f9d89bad0f28ca23c3f8daa521e2dcc3f44d49"},
+    {file = "scipy-1.17.1-cp314-cp314-macosx_10_14_x86_64.whl", hash = "sha256:a48a72c77a310327f6a3a920092fa2b8fd03d7deaa60f093038f22d98e096717"},
+    {file = "scipy-1.17.1-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:45abad819184f07240d8a696117a7aacd39787af9e0b719d00285549ed19a1e9"},
+    {file = "scipy-1.17.1-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:3fd1fcdab3ea951b610dc4cef356d416d5802991e7e32b5254828d342f7b7e0b"},
+    {file = "scipy-1.17.1-cp314-cp314-macosx_14_0_x86_64.whl", hash = "sha256:7bdf2da170b67fdf10bca777614b1c7d96ae3ca5794fd9587dce41eb2966e866"},
+    {file = "scipy-1.17.1-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:adb2642e060a6549c343603a3851ba76ef0b74cc8c079a9a58121c7ec9fe2350"},
+    {file = "scipy-1.17.1-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:eee2cfda04c00a857206a4330f0c5e3e56535494e30ca445eb19ec624ae75118"},
+    {file = "scipy-1.17.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:d2650c1fb97e184d12d8ba010493ee7b322864f7d3d00d3f9bb97d9c21de4068"},
+    {file = "scipy-1.17.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:08b900519463543aa604a06bec02461558a6e1cef8fdbb8098f77a48a83c8118"},
+    {file = "scipy-1.17.1-cp314-cp314-win_amd64.whl", hash = "sha256:3877ac408e14da24a6196de0ddcace62092bfc12a83823e92e49e40747e52c19"},
+    {file = "scipy-1.17.1-cp314-cp314-win_arm64.whl", hash = "sha256:f8885db0bc2bffa59d5c1b72fad7a6a92d3e80e7257f967dd81abb553a90d293"},
+    {file = "scipy-1.17.1-cp314-cp314t-macosx_10_14_x86_64.whl", hash = "sha256:1cc682cea2ae55524432f3cdff9e9a3be743d52a7443d0cba9017c23c87ae2f6"},
+    {file = "scipy-1.17.1-cp314-cp314t-macosx_12_0_arm64.whl", hash = "sha256:2040ad4d1795a0ae89bfc7e8429677f365d45aa9fd5e4587cf1ea737f927b4a1"},
+    {file = "scipy-1.17.1-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:131f5aaea57602008f9822e2115029b55d4b5f7c070287699fe45c661d051e39"},
+    {file = "scipy-1.17.1-cp314-cp314t-macosx_14_0_x86_64.whl", hash = "sha256:9cdc1a2fcfd5c52cfb3045feb399f7b3ce822abdde3a193a6b9a60b3cb5854ca"},
+    {file = "scipy-1.17.1-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6e3dcd57ab780c741fde8dc68619de988b966db759a3c3152e8e9142c26295ad"},
+    {file = "scipy-1.17.1-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a9956e4d4f4a301ebf6cde39850333a6b6110799d470dbbb1e25326ac447f52a"},
+    {file = "scipy-1.17.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:a4328d245944d09fd639771de275701ccadf5f781ba0ff092ad141e017eccda4"},
+    {file = "scipy-1.17.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:a77cbd07b940d326d39a1d1b37817e2ee4d79cb30e7338f3d0cddffae70fcaa2"},
+    {file = "scipy-1.17.1-cp314-cp314t-win_amd64.whl", hash = "sha256:eb092099205ef62cd1782b006658db09e2fed75bffcae7cc0d44052d8aa0f484"},
+    {file = "scipy-1.17.1-cp314-cp314t-win_arm64.whl", hash = "sha256:200e1050faffacc162be6a486a984a0497866ec54149a01270adc8a59b7c7d21"},
+    {file = "scipy-1.17.1.tar.gz", hash = "sha256:95d8e012d8cb8816c226aef832200b1d45109ed4464303e997c5b13122b297c0"},
+]
+
+[package.dependencies]
+numpy = ">=1.26.4,<2.7"
+
+[package.extras]
+dev = ["click (<8.3.0)", "cython-lint (>=0.12.2)", "mypy (==1.10.0)", "pycodestyle", "ruff (>=0.12.0)", "spin", "types-psutil", "typing_extensions"]
+doc = ["intersphinx_registry", "jupyterlite-pyodide-kernel", "jupyterlite-sphinx (>=0.19.1)", "jupytext", "linkify-it-py", "matplotlib (>=3.5)", "myst-nb (>=1.2.0)", "numpydoc", "pooch", "pydata-sphinx-theme (>=0.15.2)", "sphinx (>=5.0.0,<8.2.0)", "sphinx-copybutton", "sphinx-design (>=0.4.0)", "tabulate"]
+test = ["Cython", "array-api-strict (>=2.3.1)", "asv", "gmpy2", "hypothesis (>=6.30)", "meson", "mpmath", "ninja ; sys_platform != \"emscripten\"", "pooch", "pytest (>=8.0.0)", "pytest-cov", "pytest-timeout", "pytest-xdist", "scikit-umfpack", "threadpoolctl"]
 
 [[package]]
 name = "secretstorage"
@@ -5217,6 +6384,30 @@ files = [
 ]
 
 [[package]]
+name = "tifffile"
+version = "2026.3.3"
+description = "Read and write TIFF files"
+optional = true
+python-versions = ">=3.11"
+groups = ["main"]
+markers = "extra == \"analysis-run\""
+files = [
+    {file = "tifffile-2026.3.3-py3-none-any.whl", hash = "sha256:e8be15c94273113d31ecb7aa3a39822189dd11c4967e3cc88c178f1ad2fd1170"},
+    {file = "tifffile-2026.3.3.tar.gz", hash = "sha256:d9a1266bed6f2ee1dd0abde2018a38b4f8b2935cb843df381d70ac4eac5458b7"},
+]
+
+[package.dependencies]
+numpy = "*"
+
+[package.extras]
+all = ["defusedxml", "fsspec", "imagecodecs (>=2025.11.11)", "kerchunk", "lxml", "matplotlib", "zarr (>=3.1.5)"]
+codecs = ["imagecodecs (>=2025.11.11)"]
+plot = ["matplotlib"]
+test = ["cmapfile", "czifile", "dask", "defusedxml", "fsspec", "imagecodecs", "kerchunk", "lfdfiles", "lxml", "ndtiff", "oiffile", "psdtags", "pytest", "requests", "roifile", "xarray", "zarr (>=3.1.5)"]
+xml = ["defusedxml", "lxml"]
+zarr = ["fsspec", "kerchunk", "zarr (>=3.1.5)"]
+
+[[package]]
 name = "tiled"
 version = "0.2.16"
 description = "Structured Scientific Data Access Service"
@@ -5414,6 +6605,19 @@ files = [
 ]
 
 [[package]]
+name = "uritemplate"
+version = "4.2.0"
+description = "Implementation of RFC 6570 URI Templates"
+optional = true
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "extra == \"analysis-run\""
+files = [
+    {file = "uritemplate-4.2.0-py3-none-any.whl", hash = "sha256:962201ba1c4edcab02e60f9a0d3821e82dfc5d2d6662a21abd533879bdb8a686"},
+    {file = "uritemplate-4.2.0.tar.gz", hash = "sha256:480c2ed180878955863323eea31b0ede668795de182617fef9c6ca09e6ec9d0e"},
+]
+
+[[package]]
 name = "urllib3"
 version = "2.7.0"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
@@ -5467,6 +6671,50 @@ numpy = "*"
 
 [package.extras]
 dev = ["copier", "mypy", "pipdeptree", "pre-commit", "pydantic (<2.0)", "pytest", "pytest-cov", "ruff", "scanspec", "tox-direct", "types-mock"]
+
+[[package]]
+name = "watchdog"
+version = "6.0.0"
+description = "Filesystem events monitoring"
+optional = true
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "extra == \"analysis-run\""
+files = [
+    {file = "watchdog-6.0.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:d1cdb490583ebd691c012b3d6dae011000fe42edb7a82ece80965b42abd61f26"},
+    {file = "watchdog-6.0.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:bc64ab3bdb6a04d69d4023b29422170b74681784ffb9463ed4870cf2f3e66112"},
+    {file = "watchdog-6.0.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:c897ac1b55c5a1461e16dae288d22bb2e412ba9807df8397a635d88f671d36c3"},
+    {file = "watchdog-6.0.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:6eb11feb5a0d452ee41f824e271ca311a09e250441c262ca2fd7ebcf2461a06c"},
+    {file = "watchdog-6.0.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:ef810fbf7b781a5a593894e4f439773830bdecb885e6880d957d5b9382a960d2"},
+    {file = "watchdog-6.0.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:afd0fe1b2270917c5e23c2a65ce50c2a4abb63daafb0d419fde368e272a76b7c"},
+    {file = "watchdog-6.0.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:bdd4e6f14b8b18c334febb9c4425a878a2ac20efd1e0b231978e7b150f92a948"},
+    {file = "watchdog-6.0.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:c7c15dda13c4eb00d6fb6fc508b3c0ed88b9d5d374056b239c4ad1611125c860"},
+    {file = "watchdog-6.0.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6f10cb2d5902447c7d0da897e2c6768bca89174d0c6e1e30abec5421af97a5b0"},
+    {file = "watchdog-6.0.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:490ab2ef84f11129844c23fb14ecf30ef3d8a6abafd3754a6f75ca1e6654136c"},
+    {file = "watchdog-6.0.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:76aae96b00ae814b181bb25b1b98076d5fc84e8a53cd8885a318b42b6d3a5134"},
+    {file = "watchdog-6.0.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:a175f755fc2279e0b7312c0035d52e27211a5bc39719dd529625b1930917345b"},
+    {file = "watchdog-6.0.0-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:e6f0e77c9417e7cd62af82529b10563db3423625c5fce018430b249bf977f9e8"},
+    {file = "watchdog-6.0.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:90c8e78f3b94014f7aaae121e6b909674df5b46ec24d6bebc45c44c56729af2a"},
+    {file = "watchdog-6.0.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:e7631a77ffb1f7d2eefa4445ebbee491c720a5661ddf6df3498ebecae5ed375c"},
+    {file = "watchdog-6.0.0-pp310-pypy310_pp73-macosx_10_15_x86_64.whl", hash = "sha256:c7ac31a19f4545dd92fc25d200694098f42c9a8e391bc00bdd362c5736dbf881"},
+    {file = "watchdog-6.0.0-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:9513f27a1a582d9808cf21a07dae516f0fab1cf2d7683a742c498b93eedabb11"},
+    {file = "watchdog-6.0.0-pp39-pypy39_pp73-macosx_10_15_x86_64.whl", hash = "sha256:7a0e56874cfbc4b9b05c60c8a1926fedf56324bb08cfbc188969777940aef3aa"},
+    {file = "watchdog-6.0.0-pp39-pypy39_pp73-macosx_11_0_arm64.whl", hash = "sha256:e6439e374fc012255b4ec786ae3c4bc838cd7309a540e5fe0952d03687d8804e"},
+    {file = "watchdog-6.0.0-py3-none-manylinux2014_aarch64.whl", hash = "sha256:7607498efa04a3542ae3e05e64da8202e58159aa1fa4acddf7678d34a35d4f13"},
+    {file = "watchdog-6.0.0-py3-none-manylinux2014_armv7l.whl", hash = "sha256:9041567ee8953024c83343288ccc458fd0a2d811d6a0fd68c4c22609e3490379"},
+    {file = "watchdog-6.0.0-py3-none-manylinux2014_i686.whl", hash = "sha256:82dc3e3143c7e38ec49d61af98d6558288c415eac98486a5c581726e0737c00e"},
+    {file = "watchdog-6.0.0-py3-none-manylinux2014_ppc64.whl", hash = "sha256:212ac9b8bf1161dc91bd09c048048a95ca3a4c4f5e5d4a7d1b1a7d5752a7f96f"},
+    {file = "watchdog-6.0.0-py3-none-manylinux2014_ppc64le.whl", hash = "sha256:e3df4cbb9a450c6d49318f6d14f4bbc80d763fa587ba46ec86f99f9e6876bb26"},
+    {file = "watchdog-6.0.0-py3-none-manylinux2014_s390x.whl", hash = "sha256:2cce7cfc2008eb51feb6aab51251fd79b85d9894e98ba847408f662b3395ca3c"},
+    {file = "watchdog-6.0.0-py3-none-manylinux2014_x86_64.whl", hash = "sha256:20ffe5b202af80ab4266dcd3e91aae72bf2da48c0d33bdb15c66658e685e94e2"},
+    {file = "watchdog-6.0.0-py3-none-win32.whl", hash = "sha256:07df1fdd701c5d4c8e55ef6cf55b8f0120fe1aef7ef39a1c6fc6bc2e606d517a"},
+    {file = "watchdog-6.0.0-py3-none-win_amd64.whl", hash = "sha256:cbafb470cf848d93b5d013e2ecb245d4aa1c8fd0504e863ccefa32445359d680"},
+    {file = "watchdog-6.0.0-py3-none-win_ia64.whl", hash = "sha256:a1914259fa9e1454315171103c6a30961236f508b9b623eae470268bbcc6a22f"},
+    {file = "watchdog-6.0.0.tar.gz", hash = "sha256:9ddf7c82fda3ae8e24decda1338ede66e1c99883db93711d8fb941eaa2d8c282"},
+]
+
+[package.extras]
+watchmedo = ["PyYAML (>=3.10)"]
 
 [[package]]
 name = "watchfiles"
@@ -5876,7 +7124,10 @@ files = [
 [package.extras]
 cffi = ["cffi (>=1.17,<2.0) ; platform_python_implementation != \"PyPy\" and python_version < \"3.14\"", "cffi (>=2.0.0b) ; platform_python_implementation != \"PyPy\" and python_version >= \"3.14\""]
 
+[extras]
+analysis-run = ["scananalysis"]
+
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<3.12"
-content-hash = "d2a266b3bfbc35773ec6713a45853a09c0f3154b6967da6617d2563fe778480e"
+content-hash = "2ff0d0cd7f6e9a6ab2f580f569d6942daa71e7896374e22b2632320120154d86"

--- a/GEECS-MCP/pyproject.toml
+++ b/GEECS-MCP/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-mcp"
-version = "0.6.0"
+version = "0.7.0"
 description = "MCP server exposing GEECS scan submission, monitoring, and config discovery to AI agents (OSPREY)"
 authors = ["Sam Barber <sbarber@lbl.gov>"]
 readme = "README.md"
@@ -36,6 +36,16 @@ geecs-data-utils = { path = "../GEECS-Data-Utils", develop = true, extras = ["ti
 
 # The one submission shape (ScanRequest) — validation at the tool boundary.
 geecs-schemas = { path = "../GEECS-Schemas", develop = true }
+
+# On-demand ScanAnalysis execution (#686: run_scan_analysis + the
+# analyzer/group listings) — heavy (scipy/opencv/scikit-image ride in via
+# ImageAnalysis), so it is an extra mirroring GeecsBluesky's
+# analysis/optimize pattern.  Without it the run/listing tools refuse with
+# a clear message naming the extra; the server always starts.
+scananalysis = { path = "../ScanAnalysis", develop = true, optional = true }
+
+[tool.poetry.extras]
+analysis-run = ["scananalysis"]
 
 [tool.poetry.group.dev.dependencies]
 pytest = ">=7.0"

--- a/GEECS-MCP/tests/test_analysis_run_tools.py
+++ b/GEECS-MCP/tests/test_analysis_run_tools.py
@@ -319,6 +319,62 @@ class TestExistingStatusRows:
         assert second["ok"] and second["started"]
         assert len(spawned) == 2
 
+    def test_unrelated_dispatch_does_not_evict_the_ledger(
+        self, share, configs, spawned, monkeypatch
+    ):
+        """Review round 4 (reproduced): dispatching a DIFFERENT analyzer
+        on the same scan must not evict the first worker's live entry —
+        the ledger is keyed per task, and only dead/expired entries go."""
+        monkeypatch.setattr(run_tools, "_pid_alive", lambda pid: True)
+        (configs / "analyzers" / "HTU" / "test_diag_b.yaml").write_text(
+            yaml.safe_dump(
+                {
+                    "name": "test_diag_b",
+                    "image_analyzer": _BEAM,
+                    "image": {"type": "camera", "bit_depth": 16},
+                    "scan": {},
+                }
+            )
+        )
+        first = _load(
+            run_tools._run_scan_analysis_impl(7, DAY, "test_diag", None, False, False)
+        )
+        assert first["ok"] and first["started"]
+        second = _load(
+            run_tools._run_scan_analysis_impl(7, DAY, "test_diag_b", None, False, False)
+        )
+        assert second["ok"] and second["started"]  # different task: allowed
+        third = _load(
+            run_tools._run_scan_analysis_impl(7, DAY, "test_diag", None, False, False)
+        )
+        assert not third["ok"]
+        assert third["error_kind"] == "policy_refusal"  # first entry survived
+        assert len(spawned) == 2
+
+    def test_failed_spawn_releases_the_reservation(
+        self, share, configs, spawned, monkeypatch
+    ):
+        """A call that reserves but never spawns (raise mid-way) must not
+        leave a phantom reservation blocking the retry."""
+        monkeypatch.setattr(run_tools, "_pid_alive", lambda pid: True)
+
+        def boom(payload):
+            raise RuntimeError("spawn exploded")
+
+        monkeypatch.setattr(run_tools, "_spawn_worker", boom)
+        with pytest.raises(RuntimeError):
+            run_tools._run_scan_analysis_impl(7, DAY, "test_diag", None, False, False)
+        # Retry with a working spawn: the reservation must be gone.
+        calls: list[dict] = []
+        monkeypatch.setattr(
+            run_tools, "_spawn_worker", lambda p: calls.append(p) or 4242
+        )
+        retry = _load(
+            run_tools._run_scan_analysis_impl(7, DAY, "test_diag", None, False, False)
+        )
+        assert retry["ok"] and retry["started"]
+        assert len(calls) == 1
+
     def test_claimed_tasks_release_the_dispatch_ledger(
         self, share, configs, spawned, monkeypatch
     ):

--- a/GEECS-MCP/tests/test_analysis_run_tools.py
+++ b/GEECS-MCP/tests/test_analysis_run_tools.py
@@ -30,8 +30,10 @@ DAY = "2026-08-22"
 def _fresh_runtime(monkeypatch):
     runtime.clear_runtime_cache()
     monkeypatch.setattr(runtime, "get_experiment", lambda: "TestExp")
+    run_tools._dispatched.clear()
     yield
     runtime.clear_runtime_cache()
+    run_tools._dispatched.clear()
 
 
 def _load(payload) -> dict:
@@ -283,6 +285,63 @@ class TestExistingStatusRows:
         assert _tree_snapshot(share) == before_tree
         assert path.read_bytes() == before_content  # not even a rewrite
         assert spawned == []
+
+    def test_second_call_in_the_preclaim_window_refuses(
+        self, share, configs, spawned, monkeypatch
+    ):
+        """Codex P1 (#690): a second run_scan_analysis call while the
+        first worker is dispatched but has not claimed yet must not
+        double-start — and the refusal is side-effect-free."""
+        monkeypatch.setattr(run_tools, "_pid_alive", lambda pid: True)
+        first = _load(
+            run_tools._run_scan_analysis_impl(7, DAY, "test_diag", None, False, False)
+        )
+        assert first["ok"] and first["started"]
+        before = _tree_snapshot(share)
+        second = _load(
+            run_tools._run_scan_analysis_impl(7, DAY, "test_diag", None, False, False)
+        )
+        assert not second["ok"]
+        assert second["error_kind"] == "policy_refusal"
+        assert "dispatched" in second["message"]
+        assert _tree_snapshot(share) == before
+        assert len(spawned) == 1  # exactly one worker
+
+    def test_dead_dispatched_worker_allows_redispatch(
+        self, share, configs, spawned, monkeypatch
+    ):
+        """A worker that died pre-claim (pid gone) must not block retries."""
+        monkeypatch.setattr(run_tools, "_pid_alive", lambda pid: False)
+        run_tools._run_scan_analysis_impl(7, DAY, "test_diag", None, False, False)
+        second = _load(
+            run_tools._run_scan_analysis_impl(7, DAY, "test_diag", None, False, False)
+        )
+        assert second["ok"] and second["started"]
+        assert len(spawned) == 2
+
+    def test_claimed_tasks_release_the_dispatch_ledger(
+        self, share, configs, spawned, monkeypatch
+    ):
+        """Once the worker claims (rows leave queued), the ledger no longer
+        gates — the heartbeat-based active-claim refusal takes over."""
+        from datetime import datetime, timezone
+
+        monkeypatch.setattr(run_tools, "_pid_alive", lambda pid: True)
+        run_tools._run_scan_analysis_impl(7, DAY, "test_diag", None, False, False)
+        # The worker claims: the status row leaves "queued".
+        _seed_status(
+            share,
+            "test_diag",
+            state="claimed",
+            claimed_by="worker",
+            last_heartbeat=datetime.now(timezone.utc).isoformat(),
+        )
+        second = _load(
+            run_tools._run_scan_analysis_impl(7, DAY, "test_diag", None, False, False)
+        )
+        assert not second["ok"]
+        assert second["error_kind"] == "policy_refusal"
+        assert "already running" in second["message"]  # the claim path, not the ledger
 
     def test_stale_claim_is_runnable_again(self, share, configs, spawned):
         """A claim whose runner died (old heartbeat) does not block."""

--- a/GEECS-MCP/tests/test_analysis_run_tools.py
+++ b/GEECS-MCP/tests/test_analysis_run_tools.py
@@ -351,6 +351,26 @@ class TestExistingStatusRows:
         assert third["error_kind"] == "policy_refusal"  # first entry survived
         assert len(spawned) == 2
 
+    def test_rerun_dispatch_is_also_ledger_guarded(
+        self, share, configs, spawned, monkeypatch
+    ):
+        """Round-5 review (reproduced): a rerun dispatch (failed row in
+        the pre-snapshot) must enter the ledger window too — an identical
+        second rerun call in the pre-claim window refuses."""
+        monkeypatch.setattr(run_tools, "_pid_alive", lambda pid: True)
+        _seed_status(share, "test_diag", state="failed", error="x")
+        first = _load(
+            run_tools._run_scan_analysis_impl(7, DAY, "test_diag", None, True, False)
+        )
+        assert first["ok"] and first["started"]
+        second = _load(
+            run_tools._run_scan_analysis_impl(7, DAY, "test_diag", None, True, False)
+        )
+        assert not second["ok"]
+        assert second["error_kind"] == "policy_refusal"
+        assert "dispatched" in second["message"]
+        assert len(spawned) == 1
+
     def test_failed_spawn_releases_the_reservation(
         self, share, configs, spawned, monkeypatch
     ):

--- a/GEECS-MCP/tests/test_analysis_run_tools.py
+++ b/GEECS-MCP/tests/test_analysis_run_tools.py
@@ -1,0 +1,279 @@
+"""Hermetic tests for the analysis-domain execution tools (#686).
+
+Skips whole without the ``analysis-run`` extra (ScanAnalysis) — the same
+pattern as GeecsBluesky's optional-stack suites.  A tmp data share stands
+in for the netapp via the ``read_tools._base_directory`` seam, a tmp
+configs tree via the ``run_tools._config_root`` seam, and the worker
+spawn is captured through the ``run_tools._spawn_worker`` seam — no real
+subprocess, no real analysis.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+
+pytest.importorskip("scan_analysis")
+
+from geecs_mcp import runtime  # noqa: E402
+from geecs_mcp.analysis import read_tools, run_tools  # noqa: E402
+
+_BEAM = "image_analysis.analyzers.beam_analyzer.BeamAnalyzer"
+
+DAY = "2026-08-22"
+
+
+@pytest.fixture(autouse=True)
+def _fresh_runtime(monkeypatch):
+    runtime.clear_runtime_cache()
+    monkeypatch.setattr(runtime, "get_experiment", lambda: "TestExp")
+    yield
+    runtime.clear_runtime_cache()
+
+
+def _load(payload) -> dict:
+    return json.loads(payload)
+
+
+def _scan_folder(base: Path) -> Path:
+    return base / "TestExp" / "Y2026" / "08-Aug" / "26_0822" / "scans" / "Scan007"
+
+
+@pytest.fixture
+def share(tmp_path, monkeypatch):
+    """A fake data share holding one existing scan folder (Scan007)."""
+    _scan_folder(tmp_path).mkdir(parents=True)
+    monkeypatch.setattr(read_tools, "_base_directory", lambda: tmp_path)
+    return tmp_path
+
+
+@pytest.fixture
+def configs(tmp_path, monkeypatch):
+    """A tmp scan-analysis configs tree: two diagnostics + one group."""
+    root = tmp_path / "configs"
+    diag_dir = root / "analyzers" / "HTU"
+    diag_dir.mkdir(parents=True)
+    (diag_dir / "test_diag.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "name": "test_diag",
+                "image_analyzer": _BEAM,
+                "image": {"type": "camera", "bit_depth": 16},
+                "scan": {"priority": 5},
+            }
+        )
+    )
+    (diag_dir / "windows_only.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "name": "windows_only",
+                # Stands in for a Windows-SDK class: unimportable here.
+                "image_analyzer": "no_such_sdk.wavekit.HasoAnalyzer",
+                "image": {"type": "camera", "bit_depth": 16},
+                "scan": {},
+            }
+        )
+    )
+    group_dir = root / "groups" / "HTU"
+    group_dir.mkdir(parents=True)
+    (group_dir / "baseline.yaml").write_text(
+        yaml.safe_dump({"name": "baseline", "analyzers": ["test_diag"]})
+    )
+    monkeypatch.setattr(run_tools, "_config_root", lambda: root)
+    return root
+
+
+@pytest.fixture
+def spawned(monkeypatch):
+    """Capture the worker spawn instead of launching a subprocess."""
+    calls: list[dict] = []
+
+    def fake_spawn(payload: dict) -> int:
+        calls.append(payload)
+        return 4242
+
+    monkeypatch.setattr(run_tools, "_spawn_worker", fake_spawn)
+    return calls
+
+
+def _tree_snapshot(base: Path) -> set[str]:
+    return {str(p.relative_to(base)) for p in base.rglob("*")}
+
+
+# ---------------------------------------------------------------------------
+# refusals
+# ---------------------------------------------------------------------------
+
+
+class TestRefusals:
+    def test_requires_exactly_one_selector(self, share, configs, spawned):
+        neither = _load(
+            run_tools._run_scan_analysis_impl(7, DAY, None, None, False, False)
+        )
+        both = _load(
+            run_tools._run_scan_analysis_impl(
+                7, DAY, "test_diag", "baseline", False, False
+            )
+        )
+        for result in (neither, both):
+            assert not result["ok"]
+            assert result["error_kind"] == "invalid_request"
+            assert "exactly one" in result["message"]
+        assert spawned == []
+
+    def test_missing_scan_folder_refuses_and_creates_nothing(
+        self, share, configs, spawned
+    ):
+        before = _tree_snapshot(share)
+        result = _load(
+            run_tools._run_scan_analysis_impl(99, DAY, "test_diag", None, False, False)
+        )
+        assert not result["ok"]
+        assert result["error_kind"] == "not_found"
+        assert "never" in result["message"]  # the invariant, stated to the agent
+        assert _tree_snapshot(share) == before  # NOTHING created on the share
+        assert spawned == []
+
+    def test_unknown_analyzer_is_not_found(self, share, configs, spawned):
+        result = _load(
+            run_tools._run_scan_analysis_impl(
+                7, DAY, "no_such_diag", None, False, False
+            )
+        )
+        assert not result["ok"]
+        assert result["error_kind"] == "not_found"
+        assert spawned == []
+
+    def test_unimportable_diagnostic_refused_before_enqueue(
+        self, share, configs, spawned
+    ):
+        before = _tree_snapshot(share)
+        result = _load(
+            run_tools._run_scan_analysis_impl(
+                7, DAY, "windows_only", None, False, False
+            )
+        )
+        assert not result["ok"]
+        assert result["error_kind"] == "invalid_request"
+        assert "cannot run on this host" in result["message"]
+        assert _tree_snapshot(share) == before
+        assert spawned == []
+
+    def test_unconfigured_root_refused(self, share, spawned, monkeypatch):
+        monkeypatch.setattr(run_tools, "_config_root", lambda: None)
+        result = _load(
+            run_tools._run_scan_analysis_impl(7, DAY, "test_diag", None, False, False)
+        )
+        assert not result["ok"]
+        assert "scan_analysis_configs_path" in result["message"]
+        assert spawned == []
+
+
+# ---------------------------------------------------------------------------
+# the happy paths
+# ---------------------------------------------------------------------------
+
+
+class TestRun:
+    def test_single_analyzer_enqueues_and_spawns(self, share, configs, spawned):
+        result = _load(
+            run_tools._run_scan_analysis_impl(7, DAY, "test_diag", None, False, False)
+        )
+        assert result["ok"] and result["started"]
+        assert result["tasks"] == ["test_diag"]
+        assert result["worker_pid"] == 4242
+        # Server-side init: the queued status row is on disk already.
+        status = yaml.safe_load(
+            (_scan_folder(share) / "analysis_status" / "test_diag.yaml").read_text()
+        )
+        assert status["state"] == "queued"
+        assert status["priority"] == 5
+        # The worker payload carries everything it needs, verbatim.
+        (payload,) = spawned
+        assert payload["number"] == 7 and payload["experiment"] == "TestExp"
+        assert payload["analyzer"] == "test_diag" and payload["group"] is None
+        assert payload["base_directory"] == str(share)
+
+    def test_group_enqueues_and_spawns(self, share, configs, spawned):
+        result = _load(
+            run_tools._run_scan_analysis_impl(7, DAY, None, "baseline", False, False)
+        )
+        assert result["ok"]
+        assert result["tasks"] == ["test_diag"]
+        (payload,) = spawned
+        assert payload["group"] == "baseline" and payload["analyzer"] is None
+
+    def test_rerun_flags_travel_to_the_worker(self, share, configs, spawned):
+        run_tools._run_scan_analysis_impl(7, DAY, "test_diag", None, True, True)
+        (payload,) = spawned
+        assert payload["rerun_failed"] is True
+        assert payload["rerun_completed"] is True
+
+
+# ---------------------------------------------------------------------------
+# listings
+# ---------------------------------------------------------------------------
+
+
+class TestListings:
+    def test_list_analyzers(self, configs):
+        result = _load(run_tools._list_analyzers_impl())
+        assert result["ok"]
+        assert result["analyzers"] == ["test_diag", "windows_only"]
+        assert result["truncated"] is False
+
+    def test_list_groups_indexes_both_name_forms(self, configs):
+        result = _load(run_tools._list_analysis_groups_impl())
+        assert result["ok"]
+        assert set(result["groups"]) == {"baseline", "HTU/baseline"}
+
+    def test_listings_refuse_without_root(self, monkeypatch):
+        monkeypatch.setattr(run_tools, "_config_root", lambda: None)
+        result = _load(run_tools._list_analyzers_impl())
+        assert not result["ok"]
+        assert "scan_analysis_configs_path" in result["message"]
+
+
+# ---------------------------------------------------------------------------
+# the worker
+# ---------------------------------------------------------------------------
+
+
+class TestWorker:
+    def test_worker_builds_and_runs_the_worklist(self, share, configs, monkeypatch):
+        """run_worker parses the payload and drives the real task queue
+        (run_worklist itself is captured — no actual analysis)."""
+        from scan_analysis import task_queue
+
+        from geecs_mcp.analysis import run_worker
+
+        ran: dict = {}
+
+        def fake_run_worklist(worklist, *, base_directory=None, **kwargs):
+            ran["worklist"] = worklist
+            ran["base_directory"] = base_directory
+
+        monkeypatch.setattr(task_queue, "run_worklist", fake_run_worklist)
+        payload = {
+            "year": 2026,
+            "month": 8,
+            "day": 22,
+            "number": 7,
+            "experiment": "TestExp",
+            "analyzer": "test_diag",
+            "group": None,
+            "rerun_failed": False,
+            "rerun_completed": False,
+            "config_root": str(configs),
+            "base_directory": str(share),
+        }
+        run_worker.main([json.dumps(payload)])
+        assert ran["base_directory"] == Path(share)
+        (item,) = ran["worklist"]
+        priority, tag, analyzer = item
+        assert priority == 5
+        assert tag.number == 7 and tag.experiment == "TestExp"
+        assert getattr(analyzer, "id", None) == "test_diag"

--- a/GEECS-MCP/tests/test_analysis_run_tools.py
+++ b/GEECS-MCP/tests/test_analysis_run_tools.py
@@ -260,22 +260,28 @@ class TestExistingStatusRows:
         assert spawned == []
 
     def test_actively_claimed_task_refuses_the_call(self, share, configs, spawned):
-        """Two near-simultaneous calls must not double-run one task."""
+        """Two near-simultaneous calls must not double-run one task —
+        and the refusal is side-effect-free: it happens before init/reset,
+        so a rerun flag on the refused call must not re-queue anything."""
         from datetime import datetime, timezone
 
-        _seed_status(
+        path = _seed_status(
             share,
             "test_diag",
             state="claimed",
             claimed_by="another-runner",
             last_heartbeat=datetime.now(timezone.utc).isoformat(),
         )
+        before_tree = _tree_snapshot(share)
+        before_content = path.read_bytes()
         result = _load(
-            run_tools._run_scan_analysis_impl(7, DAY, "test_diag", None, False, False)
+            run_tools._run_scan_analysis_impl(7, DAY, "test_diag", None, True, True)
         )
         assert not result["ok"]
         assert result["error_kind"] == "policy_refusal"
         assert "already running" in result["message"]
+        assert _tree_snapshot(share) == before_tree
+        assert path.read_bytes() == before_content  # not even a rewrite
         assert spawned == []
 
     def test_stale_claim_is_runnable_again(self, share, configs, spawned):
@@ -305,12 +311,16 @@ class TestListings:
         result = _load(run_tools._list_analyzers_impl())
         assert result["ok"]
         assert result["analyzers"] == ["test_diag", "windows_only"]
+        assert result["count"] == 2
         assert result["truncated"] is False
 
     def test_list_groups_indexes_both_name_forms(self, configs):
         result = _load(run_tools._list_analysis_groups_impl())
         assert result["ok"]
         assert set(result["groups"]) == {"baseline", "HTU/baseline"}
+        # count = distinct group FILES, not accepted names — one group
+        # listed under two name forms must not read as two groups.
+        assert result["count"] == 1
 
     def test_listings_refuse_without_root(self, monkeypatch):
         monkeypatch.setattr(run_tools, "_config_root", lambda: None)

--- a/GEECS-MCP/tests/test_analysis_run_tools.py
+++ b/GEECS-MCP/tests/test_analysis_run_tools.py
@@ -213,6 +213,88 @@ class TestRun:
         assert payload["rerun_completed"] is True
 
 
+def _seed_status(share: Path, analyzer_id: str, **fields) -> Path:
+    status_dir = _scan_folder(share) / "analysis_status"
+    status_dir.mkdir(exist_ok=True)
+    path = status_dir / f"{analyzer_id}.yaml"
+    path.write_text(
+        yaml.safe_dump({"analyzer_id": analyzer_id, "priority": 5, **fields})
+    )
+    return path
+
+
+class TestExistingStatusRows:
+    """The rerun/concurrency contract over pre-existing status rows."""
+
+    def test_rerun_failed_resets_the_row_to_queued_before_spawn(
+        self, share, configs, spawned
+    ):
+        """The dead-worker visibility contract holds on the rerun path:
+        the failed row is re-queued server-side, so a worker that dies
+        pre-claim leaves a visible queued row, not the stale failure."""
+        path = _seed_status(
+            share, "test_diag", state="failed", error="old failure text"
+        )
+        result = _load(
+            run_tools._run_scan_analysis_impl(7, DAY, "test_diag", None, True, False)
+        )
+        assert result["ok"] and result["started"]
+        assert result["tasks"] == ["test_diag"]
+        status = yaml.safe_load(path.read_text())
+        assert status["state"] == "queued"
+        assert status["error"] is None
+        assert len(spawned) == 1
+
+    def test_done_without_rerun_flag_is_skipped_and_nothing_spawns(
+        self, share, configs, spawned
+    ):
+        _seed_status(share, "test_diag", state="done")
+        result = _load(
+            run_tools._run_scan_analysis_impl(7, DAY, "test_diag", None, False, False)
+        )
+        assert result["ok"]
+        assert result["started"] is False
+        assert result["tasks"] == []
+        assert result["skipped"] == {"test_diag": "done"}
+        assert "rerun" in result["note"]
+        assert spawned == []
+
+    def test_actively_claimed_task_refuses_the_call(self, share, configs, spawned):
+        """Two near-simultaneous calls must not double-run one task."""
+        from datetime import datetime, timezone
+
+        _seed_status(
+            share,
+            "test_diag",
+            state="claimed",
+            claimed_by="another-runner",
+            last_heartbeat=datetime.now(timezone.utc).isoformat(),
+        )
+        result = _load(
+            run_tools._run_scan_analysis_impl(7, DAY, "test_diag", None, False, False)
+        )
+        assert not result["ok"]
+        assert result["error_kind"] == "policy_refusal"
+        assert "already running" in result["message"]
+        assert spawned == []
+
+    def test_stale_claim_is_runnable_again(self, share, configs, spawned):
+        """A claim whose runner died (old heartbeat) does not block."""
+        _seed_status(
+            share,
+            "test_diag",
+            state="claimed",
+            claimed_by="dead-runner",
+            last_heartbeat="2026-08-22T00:00:00+00:00",
+        )
+        result = _load(
+            run_tools._run_scan_analysis_impl(7, DAY, "test_diag", None, False, False)
+        )
+        assert result["ok"] and result["started"]
+        assert result["tasks"] == ["test_diag"]
+        assert len(spawned) == 1
+
+
 # ---------------------------------------------------------------------------
 # listings
 # ---------------------------------------------------------------------------

--- a/ScanAnalysis/CHANGELOG.md
+++ b/ScanAnalysis/CHANGELOG.md
@@ -27,7 +27,13 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   re-queued row — and the old error text then survived onto the
   rerun's `done` row (found by #690's adversarial review path).
   Priority still carries over; pinned by
-  `TestResetClearsStaleFields`.
+  `TestResetClearsStaleFields`.  Two deliberate consequences: the
+  fresh record drops `display_files` for the re-queued window (a
+  re-queued task genuinely has no current outputs), and the direct
+  write means a scan folder vanishing mid-reset (SMB blip) now raises
+  to the caller instead of `update_status`'s log-and-skip — nothing is
+  created either way (the invariant holds), but callers driving reset
+  in a loop should expect the exception.
 
 ## [1.15.1] — 2026-07-16
 

--- a/ScanAnalysis/CHANGELOG.md
+++ b/ScanAnalysis/CHANGELOG.md
@@ -18,6 +18,22 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   timestamp semantics.  Pure refactor + exports; behavior unchanged,
   pinned by `TestPublicQueueHelpers`.
 
+- **Atomic per-task claim gate in `run_worklist`** (#690 review, Codex
+  P1: two runners whose worklists both saw `queued` would each
+  overwrite the status to `claimed` and run the same analyzer into the
+  same output files — the check-then-claim was a pure race, and the MCP
+  verb spawns workers at call time).  `try_acquire_claim` /
+  `release_claim` (both public): an `O_CREAT|O_EXCL` lock file at
+  `analysis_status/<id>.claim` — the "future multi-app can add lock
+  files" extension the module docstring reserved.  Exactly one runner
+  passes per task; a loser skips with a log line.  Liveness stays in
+  the status heartbeat (`claim_is_active`), with the lock's own mtime
+  covering the instant before the claimed row lands; a dead holder's
+  lock is broken.  Lock files are invisible to status readers
+  (`read_statuses` globs `*.yaml`).  The gate never creates a missing
+  scan folder (invariant pinned).  Pinned by `TestClaimGate`, incl. an
+  end-to-end run_worklist skip.
+
 ### Fixed
 
 - `reset_status_for_scan` now writes a genuinely fresh queued record:

--- a/ScanAnalysis/CHANGELOG.md
+++ b/ScanAnalysis/CHANGELOG.md
@@ -3,6 +3,32 @@
 All notable changes to this package will be documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [1.16.0] — 2026-08-24
+
+### Added
+
+- Two public task-queue helpers for external queue clients (the
+  GEECS-MCP `run_scan_analysis` verb, #686 — the first out-of-package
+  status *writer* consumer): `task_queue.analyzer_task_id(analyzer)` —
+  THE status-file id derivation, now called by all four internal sites
+  (init/reset/build/run) instead of four inlined copies — and
+  `task_queue.claim_is_active(status, now=None)` — the public face of
+  the claim-staleness rule (`CLAIM_STALE_AFTER_SECONDS`), so clients
+  refusing to double-run an actively-claimed task never re-derive the
+  timestamp semantics.  Pure refactor + exports; behavior unchanged,
+  pinned by `TestPublicQueueHelpers`.
+
+### Fixed
+
+- `reset_status_for_scan` now writes a genuinely fresh queued record:
+  it previously routed the reset through `update_status`, whose
+  keep-on-None semantics silently kept the stale `error`,
+  `claimed_by`, `claimed_at`, and `last_heartbeat` fields on the
+  re-queued row — and the old error text then survived onto the
+  rerun's `done` row (found by #690's adversarial review path).
+  Priority still carries over; pinned by
+  `TestResetClearsStaleFields`.
+
 ## [1.15.1] — 2026-07-16
 
 ### Changed

--- a/ScanAnalysis/CLAUDE.md
+++ b/ScanAnalysis/CLAUDE.md
@@ -215,6 +215,14 @@ Enables multiple `LiveTaskRunner` processes to divide work without conflicts.
 4. A claimed task is considered **stale** after 180s without a heartbeat update
 5. Other runners can re-claim stale tasks — safe parallelism without a central
    coordinator
+6. **Claims are atomic since 1.16.0** (`try_acquire_claim`/`release_claim`,
+   an `O_CREAT|O_EXCL` lock file at `analysis_status/<id>.claim` —
+   invisible to status readers, which glob `*.yaml`): two runners whose
+   worklists both saw `queued` can no longer double-run one task
+   (previously a pure check-then-claim race; surfaced when GEECS-MCP's
+   `run_scan_analysis` began spawning workers at call time, #690).
+   Liveness stays in the status heartbeat (`claim_is_active`, public);
+   a dead holder's lock is broken automatically
 
 ### `TaskStatus` fields
 

--- a/ScanAnalysis/pyproject.toml
+++ b/ScanAnalysis/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "scananalysis"
-version = "1.15.1"
+version = "1.16.0"
 description = "Modules for performing analyses routines on full scans"
 authors = ["Christopher Doss <CEDoss@lbl.gov>", "Sam Barber <sbarber@lbl.gov"]
 readme = "README.md"

--- a/ScanAnalysis/scan_analysis/task_queue.py
+++ b/ScanAnalysis/scan_analysis/task_queue.py
@@ -226,10 +226,22 @@ def _break_stale_lock(lock: Path) -> bool:
     else:
         if sentinel_age <= CLAIM_STALE_AFTER_SECONDS:
             return False  # a live breaker owns this — back off
+        # A crashed breaker's leftover.  Removed by ATOMIC RENAME to a
+        # unique tombstone, not unlink: a bare check-then-unlink here
+        # would repeat the TOCTOU one level up (two cleaners both
+        # stat-stale, the slow one unlinking the fast one's *fresh*
+        # sentinel — the cascade the round-5 review constructed).  Rename
+        # admits exactly one winner; the loser's rename raises and backs
+        # off.
+        tomb = Path(f"{sentinel}.{os.getpid()}.{time.monotonic_ns()}")
         try:
-            sentinel.unlink()  # crashed breaker's leftover
+            sentinel.rename(tomb)
         except OSError:
-            return False
+            return False  # lost the cleanup race — back off
+        try:
+            tomb.unlink()
+        except OSError:
+            pass
     try:
         fd = os.open(str(sentinel), os.O_CREAT | os.O_EXCL | os.O_WRONLY)
     except OSError:

--- a/ScanAnalysis/scan_analysis/task_queue.py
+++ b/ScanAnalysis/scan_analysis/task_queue.py
@@ -1,10 +1,14 @@
 """
 Lightweight task queue for scan analysis.
 
-Single-app assumptions:
-- No cross-process locking (safe to run one app). Future multi-app can add lock files.
+Assumptions:
 - Per-scan status files stored under `<scan_folder>/analysis_status/<analyzer_id>.yaml`.
 - Worklist sorted by (priority, scan_number).
+- Claims are cross-process exclusive since 1.16.0: `run_worklist` passes
+  each task through the `try_acquire_claim` gate (an O_EXCL lock file
+  beside the status YAML), so concurrent runners — the MCP verb's
+  detached workers, a future fleet — never double-run one task; liveness
+  stays in the status heartbeat, and a dead holder's lock is broken.
 
 States: queued -> claimed -> done/failed/no_data.
 """
@@ -186,6 +190,97 @@ def analyzer_task_id(analyzer: object) -> str:
     return analyzer_id or (
         f"{analyzer.__class__.__name__}_{getattr(analyzer, 'device_name', '')}"
     )
+
+
+def _claim_lock_path(scan_folder: Path, analyzer_id: str) -> Path:
+    return _status_dir(scan_folder) / f"{analyzer_id}.claim"
+
+
+def try_acquire_claim(scan_folder: Path, analyzer_id: str, owner: str) -> bool:
+    """Atomically acquire the exclusive claim gate for one task.
+
+    The check-then-claim in :func:`run_worklist` used to be a pure race:
+    two runners whose worklists both saw ``queued`` would each overwrite
+    the status to ``claimed`` and run the same analyzer into the same
+    output files (surfaced by the #690 review — the MCP verb spawns
+    workers at call time, so near-simultaneous calls hit the window the
+    old polling fleet rarely did).  The gate is an ``O_CREAT | O_EXCL``
+    lock file at ``analysis_status/<id>.claim`` — exactly the "future
+    multi-app can add lock files" extension this module's docstring
+    reserved.
+
+    Liveness stays where it always was — the STATUS row's heartbeat: on a
+    lock collision the holder counts as alive while
+    :func:`claim_is_active` says so, or (covering the instant between
+    lock-acquire and the claimed-status write) while the lock file itself
+    is younger than ``CLAIM_STALE_AFTER_SECONDS``.  A dead holder's lock
+    is broken and the acquire retried once.
+
+    Parameters
+    ----------
+    scan_folder : Path
+        The scan folder (must already exist — never created here).
+    analyzer_id : str
+        The task id (the status-file stem).
+    owner : str
+        Identifier written into the lock file (host:pid), for forensics.
+
+    Returns
+    -------
+    bool
+        True when this caller now holds the claim gate; False when a
+        live runner holds it (skip the task) or the scan folder is not
+        visible.
+    """
+    if not _require_scan_folder(scan_folder):
+        return False
+    _status_dir(scan_folder).mkdir(exist_ok=True)
+    lock = _claim_lock_path(scan_folder, analyzer_id)
+    for attempt in (0, 1):
+        try:
+            fd = os.open(str(lock), os.O_CREAT | os.O_EXCL | os.O_WRONLY)
+            with os.fdopen(fd, "w") as f:
+                f.write(f"{owner} {datetime.now(timezone.utc).isoformat()}\n")
+            return True
+        except FileExistsError:
+            if attempt:
+                return False
+            status_path = _status_path(scan_folder, analyzer_id)
+            if status_path.exists() and claim_is_active(
+                TaskStatus.from_file(status_path)
+            ):
+                return False
+            try:
+                # No live claim in the status row: alive only if the lock
+                # itself is fresh (its holder may not have written the
+                # claimed row yet).  mtime vs local clock tolerates the
+                # usual cross-machine skew at the 180 s threshold.
+                age = datetime.now(timezone.utc).timestamp() - lock.stat().st_mtime
+            except OSError:
+                continue  # lock vanished under us — retry the acquire
+            if age <= CLAIM_STALE_AFTER_SECONDS:
+                return False
+            logger.warning(
+                "breaking stale claim lock %s (age %.0fs, holder dead)", lock, age
+            )
+            try:
+                lock.unlink()
+            except OSError:
+                return False  # someone else broke/won it — let them have it
+        except OSError:
+            logger.warning("could not create claim lock %s", lock, exc_info=True)
+            return False
+    return False
+
+
+def release_claim(scan_folder: Path, analyzer_id: str) -> None:
+    """Release the claim gate taken by :func:`try_acquire_claim` (idempotent)."""
+    try:
+        _claim_lock_path(scan_folder, analyzer_id).unlink()
+    except FileNotFoundError:
+        pass
+    except OSError:
+        logger.debug("could not remove claim lock for %s", analyzer_id, exc_info=True)
 
 
 def _write_atomic(path: Path, content: str) -> None:
@@ -513,6 +608,18 @@ def run_worklist(
         )
         analyzer_id = analyzer_task_id(analyzer)
 
+        owner = f"{socket.gethostname()}:{os.getpid()}"
+        # The atomic claim gate: exactly one runner passes per task (a
+        # loser here means another live runner owns it — skip, never
+        # double-run the same analyzer into the same output files).
+        if not try_acquire_claim(scan_folder, analyzer_id, owner):
+            logger.info(
+                "run_worklist: %s on scan %s is claimed by a live runner "
+                "(or the folder is not visible); skipping",
+                analyzer_id,
+                tag,
+            )
+            continue
         logger.info(
             "run_worklist: claiming scan=%s analyzer=%s priority=%s dry_run=%s",
             tag,
@@ -520,7 +627,6 @@ def run_worklist(
             priority,
             dry_run,
         )
-        owner = f"{socket.gethostname()}:{os.getpid()}"
         now_iso = datetime.now(timezone.utc).isoformat()
         update_status(
             scan_folder,
@@ -614,6 +720,7 @@ def run_worklist(
         finally:
             stop_event.set()  # idempotent safety net
             hb_thread.join(timeout=HEARTBEAT_INTERVAL_SECONDS)  # safe to join twice
+            release_claim(scan_folder, analyzer_id)
             analyzer.cleanup()
 
 

--- a/ScanAnalysis/scan_analysis/task_queue.py
+++ b/ScanAnalysis/scan_analysis/task_queue.py
@@ -211,6 +211,19 @@ def _break_stale_lock(lock: Path) -> bool:
     certainly dead, and its breaker only ever removes a *stale* main
     lock).
 
+    Accepted floor (review round 5, do not engineer further): POSIX/SMB
+    offer no compare-and-remove primitive over path names, so *any*
+    check-then-remove scheme retains a syscall-granularity window in
+    which a cleaner acts on a path whose file was just recreated.  Here
+    that residue requires a breaker killed inside its milliseconds-wide
+    sentinel window, plus 180 s elapsing, plus two independent
+    syscall-granularity straddles in cascade — and even then each holder
+    re-checks the main lock's age before removing it and final admission
+    is the main-lock ``O_EXCL``.  Further rounds of the same pattern
+    cannot reach zero; the same class covers the standard unfenced-lease
+    hazard (a holder stalling past the heartbeat window can be reclaimed
+    and later resume).
+
     Returns
     -------
     bool

--- a/ScanAnalysis/scan_analysis/task_queue.py
+++ b/ScanAnalysis/scan_analysis/task_queue.py
@@ -21,6 +21,7 @@ import re
 import socket
 import tempfile
 import threading
+import time
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
@@ -196,6 +197,65 @@ def _claim_lock_path(scan_folder: Path, analyzer_id: str) -> Path:
     return _status_dir(scan_folder) / f"{analyzer_id}.claim"
 
 
+def _break_stale_lock(lock: Path) -> bool:
+    """Break a stale claim lock under a single-breaker sentinel.
+
+    A bare re-stat-then-unlink cannot close the two-breaker race (breaker
+    B stats the old stale lock, breaker A unlinks it and creates a fresh
+    one, B then unlinks A's *live* lock — both acquire).  So breaking is
+    itself exclusive: only the ``O_EXCL`` creator of ``<lock>.breaking``
+    may unlink, and it re-checks the lock's age *while holding the
+    sentinel* — a lock that became fresh meanwhile is respected.  A
+    crashed breaker's sentinel is itself broken by age (the recursion
+    grounds here: the sentinel lives milliseconds, so an old one is
+    certainly dead, and its breaker only ever removes a *stale* main
+    lock).
+
+    Returns
+    -------
+    bool
+        True when the path is clear for an acquire attempt (the stale
+        lock was removed, or was already gone); False when another
+        breaker holds the sentinel or the lock turned out to be live.
+    """
+    sentinel = Path(str(lock) + ".breaking")
+    try:
+        sentinel_age = time.time() - sentinel.stat().st_mtime
+    except OSError:
+        pass  # no sentinel — proceed to claim it
+    else:
+        if sentinel_age <= CLAIM_STALE_AFTER_SECONDS:
+            return False  # a live breaker owns this — back off
+        try:
+            sentinel.unlink()  # crashed breaker's leftover
+        except OSError:
+            return False
+    try:
+        fd = os.open(str(sentinel), os.O_CREAT | os.O_EXCL | os.O_WRONLY)
+    except OSError:
+        return False  # lost the sentinel race — back off
+    try:
+        os.close(fd)
+        try:
+            lock_age = time.time() - lock.stat().st_mtime
+        except OSError:
+            return True  # lock already gone — path clear
+        if lock_age <= CLAIM_STALE_AFTER_SECONDS:
+            return False  # re-acquired while we raced here — respect it
+        try:
+            lock.unlink()
+        except FileNotFoundError:
+            pass
+        except OSError:
+            return False
+        return True
+    finally:
+        try:
+            sentinel.unlink()
+        except OSError:
+            pass
+
+
 def try_acquire_claim(scan_folder: Path, analyzer_id: str, owner: str) -> bool:
     """Atomically acquire the exclusive claim gate for one task.
 
@@ -255,7 +315,7 @@ def try_acquire_claim(scan_folder: Path, analyzer_id: str, owner: str) -> bool:
                 # itself is fresh (its holder may not have written the
                 # claimed row yet).  mtime vs local clock tolerates the
                 # usual cross-machine skew at the 180 s threshold.
-                age = datetime.now(timezone.utc).timestamp() - lock.stat().st_mtime
+                age = time.time() - lock.stat().st_mtime
             except OSError:
                 continue  # lock vanished under us — retry the acquire
             if age <= CLAIM_STALE_AFTER_SECONDS:
@@ -263,10 +323,8 @@ def try_acquire_claim(scan_folder: Path, analyzer_id: str, owner: str) -> bool:
             logger.warning(
                 "breaking stale claim lock %s (age %.0fs, holder dead)", lock, age
             )
-            try:
-                lock.unlink()
-            except OSError:
-                return False  # someone else broke/won it — let them have it
+            if not _break_stale_lock(lock):
+                return False  # another breaker owns it, or it went live
         except OSError:
             logger.warning("could not create claim lock %s", lock, exc_info=True)
             return False

--- a/ScanAnalysis/scan_analysis/task_queue.py
+++ b/ScanAnalysis/scan_analysis/task_queue.py
@@ -136,6 +136,58 @@ def _is_stale(status: TaskStatus, now: datetime) -> bool:
     return (now - last).total_seconds() > CLAIM_STALE_AFTER_SECONDS
 
 
+def claim_is_active(status: TaskStatus, now: Optional[datetime] = None) -> bool:
+    """True when *status* is a claimed task whose runner looks alive.
+
+    The public face of the staleness rule (heartbeat/claim age vs
+    ``CLAIM_STALE_AFTER_SECONDS``) for external queue clients — e.g. the
+    GEECS-MCP ``run_scan_analysis`` verb refuses to double-run a task
+    another runner is actively working (#686) — so consumers never
+    re-derive the timestamp semantics.
+
+    Parameters
+    ----------
+    status : TaskStatus
+        The task status to inspect.
+    now : datetime, optional
+        Reference time (aware, UTC); defaults to the current time.
+
+    Returns
+    -------
+    bool
+        True for a claimed task with a fresh heartbeat; False for any
+        other state, and for a claimed task gone stale (reclaimable).
+    """
+    return status.state == "claimed" and not _is_stale(
+        status, now or datetime.now(timezone.utc)
+    )
+
+
+def analyzer_task_id(analyzer: object) -> str:
+    """The status-file id for *analyzer* — THE one derivation.
+
+    Every id-consuming site (init/reset/build/run and external clients
+    such as GEECS-MCP) must call this rather than restating the
+    fallback chain — mirrored copies of this shape have shipped drift
+    before.
+
+    Parameters
+    ----------
+    analyzer : object
+        A ScanAnalyzer-like object (``id``/``device_name`` attributes
+        honored, class-name fallback otherwise).
+
+    Returns
+    -------
+    str
+        The id used for ``analysis_status/<id>.yaml``.
+    """
+    analyzer_id = getattr(analyzer, "id", getattr(analyzer, "device_name", "unknown"))
+    return analyzer_id or (
+        f"{analyzer.__class__.__name__}_{getattr(analyzer, 'device_name', '')}"
+    )
+
+
 def _write_atomic(path: Path, content: str) -> None:
     """Write content to path, atomically where the OS supports it.
 
@@ -184,14 +236,7 @@ def init_status_for_scan(
     status_dir.mkdir(exist_ok=True)
 
     for analyzer in analyzers:
-        analyzer_id = getattr(
-            analyzer, "id", getattr(analyzer, "device_name", "unknown")
-        )
-        # If analyzer objects have no id, fall back to class name + device
-        analyzer_id = (
-            analyzer_id
-            or f"{analyzer.__class__.__name__}_{getattr(analyzer, 'device_name', '')}"
-        )
+        analyzer_id = analyzer_task_id(analyzer)
         path = _status_path(scan_folder, analyzer_id)
         if path.exists():
             continue
@@ -361,13 +406,7 @@ def reset_status_for_scan(
     )
     statuses = {s.analyzer_id: s for s in read_statuses(scan_folder)}
     for analyzer in analyzers:
-        analyzer_id = getattr(
-            analyzer, "id", getattr(analyzer, "device_name", "unknown")
-        )
-        analyzer_id = (
-            analyzer_id
-            or f"{analyzer.__class__.__name__}_{getattr(analyzer, 'device_name', '')}"
-        )
+        analyzer_id = analyzer_task_id(analyzer)
         if analyzer_id in skip_ids:
             continue
         if only_ids is not None and analyzer_id not in only_ids:
@@ -380,15 +419,17 @@ def reset_status_for_scan(
                 if not _is_stale(st, now):
                     # Live claimed task – do not reset to queued.
                     continue
-            update_status(
-                scan_folder,
-                analyzer_id,
-                priority=st.priority,
-                state="queued",
-                error=None,
-                claimed_by=None,
-                claimed_at=None,
-                last_heartbeat=None,
+            # A fresh queued record, written directly: update_status treats
+            # None as "keep current", so routing the reset through it left
+            # the stale error/claimed_by/heartbeat fields on the re-queued
+            # row (and the old error then survived onto the rerun's done
+            # row).  Only the priority carries over.
+            fresh = TaskStatus(
+                analyzer_id=analyzer_id, priority=st.priority, state="queued"
+            )
+            _write_atomic(
+                _status_path(scan_folder, analyzer_id),
+                yaml.safe_dump(fresh.to_dict()),
             )
 
 
@@ -417,13 +458,7 @@ def build_worklist(
         )
         statuses = {s.analyzer_id: s for s in read_statuses(scan_folder)}
         for analyzer in analyzers:
-            analyzer_id = getattr(
-                analyzer, "id", getattr(analyzer, "device_name", "unknown")
-            )
-            analyzer_id = (
-                analyzer_id
-                or f"{analyzer.__class__.__name__}_{getattr(analyzer, 'device_name', '')}"
-            )
+            analyzer_id = analyzer_task_id(analyzer)
             st = statuses.get(analyzer_id)
             include = st is None or st.state == "queued"
             eligible_for_rerun = analyzer_id not in skip_ids and (
@@ -476,13 +511,7 @@ def run_worklist(
         scan_folder = ScanPaths.get_scan_folder_path(
             tag=tag, base_directory=base_directory
         )
-        analyzer_id = getattr(
-            analyzer, "id", getattr(analyzer, "device_name", "unknown")
-        )
-        analyzer_id = (
-            analyzer_id
-            or f"{analyzer.__class__.__name__}_{getattr(analyzer, 'device_name', '')}"
-        )
+        analyzer_id = analyzer_task_id(analyzer)
 
         logger.info(
             "run_worklist: claiming scan=%s analyzer=%s priority=%s dry_run=%s",

--- a/ScanAnalysis/tests/test_task_queue.py
+++ b/ScanAnalysis/tests/test_task_queue.py
@@ -217,6 +217,94 @@ class TestResetClearsStaleFields:
         assert status.last_heartbeat is None
 
 
+class TestClaimGate:
+    """The atomic per-task claim gate (#690 P1: no double-run)."""
+
+    def _folder(self, tmp_path: Path) -> Path:
+        scan_folder = tmp_path / "Scan042"
+        (scan_folder / STATUS_DIR_NAME).mkdir(parents=True)
+        return scan_folder
+
+    def test_exclusive_second_acquire_fails(self, tmp_path):
+        from scan_analysis.task_queue import release_claim, try_acquire_claim
+
+        folder = self._folder(tmp_path)
+        assert try_acquire_claim(folder, "diag", "host:1")
+        assert not try_acquire_claim(folder, "diag", "host:2")
+        release_claim(folder, "diag")
+        assert try_acquire_claim(folder, "diag", "host:2")
+
+    def test_stale_holder_lock_is_broken(self, tmp_path):
+        import os as os_mod
+
+        from scan_analysis.task_queue import try_acquire_claim
+
+        folder = self._folder(tmp_path)
+        lock = folder / STATUS_DIR_NAME / "diag.claim"
+        lock.write_text("dead-host:9 2026-08-22T00:00:00+00:00\n")
+        old = datetime.now(timezone.utc).timestamp() - (CLAIM_STALE_AFTER_SECONDS + 60)
+        os_mod.utime(lock, (old, old))
+        assert try_acquire_claim(folder, "diag", "host:2")
+
+    def test_lock_with_live_status_claim_is_respected(self, tmp_path):
+        from scan_analysis.task_queue import try_acquire_claim
+
+        folder = self._folder(tmp_path)
+        (folder / STATUS_DIR_NAME / "diag.claim").write_text("other\n")
+        _write_status(
+            folder / STATUS_DIR_NAME,
+            TaskStatus(
+                analyzer_id="diag",
+                priority=0,
+                state="claimed",
+                last_heartbeat=_iso(datetime.now(timezone.utc)),
+            ),
+        )
+        assert not try_acquire_claim(folder, "diag", "host:2")
+
+    def test_missing_scan_folder_never_created(self, tmp_path):
+        from scan_analysis.task_queue import try_acquire_claim
+
+        missing = tmp_path / "Scan777"
+        assert not try_acquire_claim(missing, "diag", "host:1")
+        assert not missing.exists()  # the invariant: never create
+
+    def test_run_worklist_skips_a_task_another_runner_holds(
+        self, tmp_path, monkeypatch
+    ):
+        """The end-to-end pin for the #690 double-run race: a held claim
+        gate makes run_worklist skip the task without touching it."""
+        from scan_analysis.task_queue import run_worklist, try_acquire_claim
+
+        scan_folder = self._folder(tmp_path)
+        _write_status(
+            scan_folder / STATUS_DIR_NAME,
+            TaskStatus(analyzer_id="diag", priority=1, state="queued"),
+        )
+        import scan_analysis.task_queue as tq
+
+        monkeypatch.setattr(
+            tq.ScanPaths,
+            "get_scan_folder_path",
+            staticmethod(lambda tag, base_directory=None: scan_folder),
+        )
+        assert try_acquire_claim(scan_folder, "diag", "other-runner:1")
+
+        ran: list[str] = []
+        analyzer = SimpleNamespace(
+            id="diag",
+            priority=1,
+            device_name="diag",
+            run_analysis=lambda tag: ran.append("ran"),
+            cleanup=lambda: None,
+        )
+        tag = ScanTag(year=2025, month=1, day=1, number=42, experiment="Test")
+        run_worklist([(1, tag, analyzer)])
+        assert ran == []  # skipped — the other runner owns the claim
+        (status,) = read_statuses(scan_folder)
+        assert status.state == "queued"  # untouched
+
+
 class TestPublicQueueHelpers:
     """The exported helpers external queue clients consume (#686)."""
 

--- a/ScanAnalysis/tests/test_task_queue.py
+++ b/ScanAnalysis/tests/test_task_queue.py
@@ -269,6 +269,50 @@ class TestClaimGate:
         assert not try_acquire_claim(missing, "diag", "host:1")
         assert not missing.exists()  # the invariant: never create
 
+    def test_break_is_single_breaker(self, tmp_path):
+        """A live breaker sentinel makes a second breaker back off — the
+        two-breaker TOCTOU (B unlinking A's fresh lock) is closed."""
+        import os as os_mod
+
+        from scan_analysis.task_queue import try_acquire_claim
+
+        folder = self._folder(tmp_path)
+        lock = folder / STATUS_DIR_NAME / "diag.claim"
+        lock.write_text("dead-host:9\n")
+        old = datetime.now(timezone.utc).timestamp() - (CLAIM_STALE_AFTER_SECONDS + 60)
+        os_mod.utime(lock, (old, old))
+        # A live breaker holds the sentinel right now:
+        (folder / STATUS_DIR_NAME / "diag.claim.breaking").write_text("breaker\n")
+        assert not try_acquire_claim(folder, "diag", "host:2")
+        assert lock.exists()  # nothing was unlinked by the loser
+
+    def test_crashed_breaker_sentinel_is_broken_by_age(self, tmp_path):
+        import os as os_mod
+
+        from scan_analysis.task_queue import try_acquire_claim
+
+        folder = self._folder(tmp_path)
+        lock = folder / STATUS_DIR_NAME / "diag.claim"
+        sentinel = folder / STATUS_DIR_NAME / "diag.claim.breaking"
+        lock.write_text("dead-host:9\n")
+        sentinel.write_text("dead-breaker\n")
+        old = datetime.now(timezone.utc).timestamp() - (CLAIM_STALE_AFTER_SECONDS + 60)
+        os_mod.utime(lock, (old, old))
+        os_mod.utime(sentinel, (old, old))
+        assert try_acquire_claim(folder, "diag", "host:2")
+        assert not sentinel.exists()  # cleaned up on the way through
+
+    def test_breaker_respects_a_lock_that_went_fresh(self, tmp_path):
+        """The sentinel-held re-check: a lock re-created (fresh mtime)
+        between the caller's staleness stat and the break must survive."""
+        from scan_analysis.task_queue import _break_stale_lock
+
+        folder = self._folder(tmp_path)
+        lock = folder / STATUS_DIR_NAME / "diag.claim"
+        lock.write_text("live-holder\n")  # fresh mtime = now
+        assert not _break_stale_lock(lock)
+        assert lock.exists()
+
     def test_run_worklist_skips_a_task_another_runner_holds(
         self, tmp_path, monkeypatch
     ):

--- a/ScanAnalysis/tests/test_task_queue.py
+++ b/ScanAnalysis/tests/test_task_queue.py
@@ -18,7 +18,9 @@ from scan_analysis.task_queue import (
     STATUS_DIR_NAME,
     TaskStatus,
     _is_stale,
+    analyzer_task_id,
     build_worklist,
+    claim_is_active,
     extract_scan_number,
     init_status_for_scan,
     read_statuses,
@@ -169,6 +171,91 @@ class TestIsStale:
             last_heartbeat=None,
         )
         assert _is_stale(ts, self.now)
+
+
+class TestResetClearsStaleFields:
+    def test_reset_writes_a_genuinely_fresh_queued_record(self, tmp_path, monkeypatch):
+        """Reset must clear error/claim/heartbeat, not just flip the state —
+        update_status's keep-on-None semantics silently defeated the old
+        implementation, leaving the stale error to survive onto the
+        rerun's done row."""
+        from scan_analysis.task_queue import reset_status_for_scan
+
+        scan_folder = tmp_path / "Scan042"
+        scan_folder.mkdir()
+        _write_status(
+            scan_folder / STATUS_DIR_NAME,
+            TaskStatus(
+                analyzer_id="diag",
+                priority=7,
+                state="failed",
+                error="old failure",
+                claimed_by="dead-runner",
+                claimed_at="2026-08-22T00:00:00+00:00",
+                last_heartbeat="2026-08-22T00:00:00+00:00",
+            ),
+        )
+        import scan_analysis.task_queue as tq
+
+        monkeypatch.setattr(
+            tq.ScanPaths,
+            "get_scan_folder_path",
+            staticmethod(lambda tag, base_directory=None: scan_folder),
+        )
+        tag = ScanTag(year=2025, month=1, day=1, number=42, experiment="Test")
+        reset_status_for_scan(
+            tag,
+            [SimpleNamespace(id="diag", priority=7)],
+            states_to_reset=("failed",),
+        )
+        (status,) = read_statuses(scan_folder)
+        assert status.state == "queued"
+        assert status.priority == 7
+        assert status.error is None
+        assert status.claimed_by is None
+        assert status.claimed_at is None
+        assert status.last_heartbeat is None
+
+
+class TestPublicQueueHelpers:
+    """The exported helpers external queue clients consume (#686)."""
+
+    def test_claim_is_active_is_the_inverse_of_stale_for_claims(self):
+        fresh = TaskStatus(
+            analyzer_id="a",
+            priority=0,
+            state="claimed",
+            last_heartbeat=_iso(datetime.now(timezone.utc)),
+        )
+        stale = TaskStatus(analyzer_id="a", priority=0, state="claimed")
+        queued = TaskStatus(analyzer_id="a", priority=0, state="queued")
+        assert claim_is_active(fresh)
+        assert not claim_is_active(stale)
+        assert not claim_is_active(queued)
+
+    def test_analyzer_task_id_derivation_chain(self):
+        assert analyzer_task_id(SimpleNamespace(id="my_diag")) == "my_diag"
+        assert analyzer_task_id(SimpleNamespace(device_name="UC_Cam")) == "UC_Cam"
+        empty = SimpleNamespace(id="", device_name="UC_Cam")
+        assert analyzer_task_id(empty) == "SimpleNamespace_UC_Cam"
+
+    def test_analyzer_task_id_matches_what_init_writes(self, tmp_path, monkeypatch):
+        """The exported derivation and init_status_for_scan agree — the
+        drift this export exists to prevent."""
+        scan_folder = tmp_path / "Scan042"
+        scan_folder.mkdir()
+        import scan_analysis.task_queue as tq
+
+        monkeypatch.setattr(
+            tq.ScanPaths,
+            "get_scan_folder_path",
+            staticmethod(lambda tag, base_directory=None: scan_folder),
+        )
+        tag = ScanTag(year=2025, month=1, day=1, number=42, experiment="Test")
+        analyzer = SimpleNamespace(id="pin_check", priority=3)
+        init_status_for_scan(tag, [analyzer], base_directory=tmp_path)
+        (status,) = read_statuses(scan_folder)
+        assert status.analyzer_id == analyzer_task_id(analyzer)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #686 (owner request). The MCP server can now *execute* ScanAnalysis, not just read its outputs — restoring a capability that has been dormant since the queueserver migration (no `analysis_status/` files on the share since ~May: the LiveTaskRunner fleet stopped running). Design settled with the owner 2026-08-24: **ScanAnalysis as-is is the backend; the Tiled-based analysis stack is the recorded long-term direction**, so the verb surface is backend-neutral (names a diagnostic/group + scan + day) and `analysis_status/` is the progress contract — a future Tiled backend slots in behind the same tools with `get_scan_analysis` polling unchanged.

## What (per-concern LOC)

**1. `run_scan_analysis` (Q-class) — `analysis/run_tools.py` + `analysis/run_worker.py`, ~330 LOC:** submit-and-poll, never blocking. The tool validates *everything refusable before any side effect*:
- exactly one of `analyzer`/`group` (names from the new listings);
- the configs root resolves (`SCAN_ANALYSIS_CONFIG_DIR` / `[Paths] scan_analysis_configs_path` — the shared `config_roots` resolution every ScanAnalysis consumer uses);
- **the scan folder exists** — the cross-package invariant in full: analysis never creates `scans/ScanNNN/`; a missing folder is a `not_found` refusal, pinned by a nothing-created tree-snapshot test;
- **the analyzers construct on this host** — a diagnostic whose image-analyzer class needs a Windows-only SDK (HASO WaveKit, Grenouille FROG.dll — both verified Windows-bound at analysis time) fails its import at build and is refused up front with a message naming the future Windows satellite server, instead of half-running.

Then it initializes the status YAMLs server-side (`init_status_for_scan`, idempotent — a worker that dies pre-claim leaves *visible* queued rows, never silence) and spawns a detached worker subprocess that drives ScanAnalysis's own task queue (claim / 30 s heartbeat / stale-reclaim). `rerun_failed`/`rerun_completed` ride `build_worklist`'s native flags. **Google-Doc upload stays hard-off** (`gdoc_enabled` default) — publishing to the experiment log would need its own explicitly gated verb.

**2. `list_analyzers` / `list_analysis_groups` (R-class) — ~60 LOC:** discovery over the configs repo's `analyzers/`/`groups/` trees so agents name diagnostics instead of guessing; payload-capped with explicit `truncated` flags per the 0.6.0 payload doctrine.

**3. Packaging + gating + docs:** new optional `analysis-run` extra (ScanAnalysis path dep — scipy/opencv ride in via ImageAnalysis, hence an extra mirroring GeecsBluesky's pattern; without it all three tools refuse naming the extra and the server starts normally). `run_scan_analysis` joins `QUEUE_TOOLS` (native `ask` + headless `write_tools` — DEPLOYMENT.md's gating section updated with the new entry and the host requirements). CI installs the extra so the new suite actually runs there. CLAUDE.md layout/roadmap truth-up.

## Deliberately out of scope (cheap to veto)

- **Day-sweep** (`scan_number` omitted = whole day): dropped for scope — one scan per call; an agent loops. Add later with a scans-per-call cap if usage asks.
- **A `requires_windows` marker on the diagnostic YAML schema**: not needed — the construct-to-validate check refuses unrunnable diagnostics with zero schema changes across three packages. Revisit only if construction cost ever becomes a problem.
- **Issue #682** (shared tolerant `analysis_status` reader in geecs-data-utils): considered and not tripped — this PR adds a status *writer* consumer (ScanAnalysis's own `task_queue`), not a second tolerant reader; the MCP read tools remain the only independent reader.

## Tests

GEECS-MCP: **109 passed** (12 new in `test_analysis_run_tools.py`: selector/root/unknown-name refusals, the missing-scan-folder refusal with a tree-snapshot nothing-created pin, the unimportable-diagnostic refusal, happy paths for analyzer and group with server-side queued statuses + captured worker payload, rerun-flag passthrough, both listings, and a worker test driving the real `build_worklist` against a tmp share). The suite `importorskip`s without the extra; CI now installs it. Lint clean via `scripts/check.sh`.

## Hardware verification

**OWED (live, needs the share + configs repo on the serving host — no scan hardware involved):** after deploy with the extra,
1. `list_analyzers` returns the real diagnostic corpus;
2. `run_scan_analysis` on a known archived scan (e.g. a May Scan with camera data) produces `analysis_status/` rows transitioning queued → claimed → done, figures land in the analysis tree, and `get_scan_figure` serves them;
3. the refusal path on a nonexistent scan number returns `not_found` and creates nothing (spot-check the share).
Also owed osprey-side: add `run_scan_analysis` to the profile's `write_tools` and re-render (`osprey build`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)