### PR TITLE
GEECS-Console 0.24.1 / GEECS-MCP 0.6.1: purge session-worktree paths from poetry.lock files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -64,6 +64,15 @@ repos:
 
   - repo: local
     hooks:
+      # A lock generated from inside a session worktree records that
+      # worktree's absolute path in the geecs-bluesky extras lines and
+      # dangles when the worktree is removed — always run `poetry lock`
+      # from the main checkout (PR #690 finding 6).
+      - id: poetry-lock-no-worktree-paths
+        name: poetry.lock free of session-worktree paths
+        language: pygrep
+        entry: '\.claude/worktrees/'
+        files: poetry\.lock$
       - id: jupyter-notebook-clear-output
         name: jupyter-notebook-jupyter-clear
         files: \.ipynb$

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,6 +79,18 @@ case, but the right fix is to launch from the repo root.
 Remove worktrees after their PR is merged unless they are intentionally
 long-lived for a distinct development stream.
 
+**Never run `poetry lock` from inside a session worktree.** Poetry
+serializes the geecs-bluesky extras as absolute `file://` URLs resolved
+from wherever the lock runs, so a worktree-generated lock embeds that
+worktree's path — which dangles when the worktree is removed. A
+pre-commit hook (`poetry-lock-no-worktree-paths`) rejects any
+`poetry.lock` containing `.claude/worktrees/`. If your worktree PR needs
+a relock, run `poetry lock` in the same package directory of the **main
+checkout** and copy the resulting lock into the worktree (the output is
+byte-identical apart from that path prefix, so stripping the
+`/.claude/worktrees/<name>` prefix from a worktree-generated lock is an
+equivalent fix).
+
 `geecs-plugins-bluesky` (a sibling directory of this checkout) is **no longer
 a worktree** — it has been promoted to its own standalone clone with an
 independent `.git`, sharing only the `GEECS-BELLA/GEECS-Plugins` origin. Treat

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,11 +85,13 @@ from wherever the lock runs, so a worktree-generated lock embeds that
 worktree's path — which dangles when the worktree is removed. A
 pre-commit hook (`poetry-lock-no-worktree-paths`) rejects any
 `poetry.lock` containing `.claude/worktrees/`. If your worktree PR needs
-a relock, run `poetry lock` in the same package directory of the **main
-checkout** and copy the resulting lock into the worktree (the output is
-byte-identical apart from that path prefix, so stripping the
-`/.claude/worktrees/<name>` prefix from a worktree-generated lock is an
-equivalent fix).
+a relock, relock inside the worktree and then strip the
+`/.claude/worktrees/<name>` prefix from the generated lock — that is the
+general remedy, correct even when the PR itself edited a
+`pyproject.toml` (the usual reason a relock is needed, and a state the
+main checkout does not have). Only when no pyproject changed is running
+`poetry lock` in the same package directory of the **main checkout** and
+copying the lock over an equivalent shortcut.
 
 `geecs-plugins-bluesky` (a sibling directory of this checkout) is **no longer
 a worktree** — it has been promoted to its own standalone clone with an

--- a/GEECS-Console/CHANGELOG.md
+++ b/GEECS-Console/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to GEECS-Console are documented here.  Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versioning is
 semantic.
 
+## [0.24.1] - 2026-08-24
+
+### Fixed
+
+- `poetry.lock` regenerated from the main checkout: the geecs-bluesky
+  extras lines referenced a deleted `.claude/worktrees/` session
+  worktree (the lock had been generated from inside one), leaving
+  dangling absolute paths.  Lock-file refresh only — no code change.
+
 ## [0.24.0] - 2026-08-21
 
 ### Changed

--- a/GEECS-Console/poetry.lock
+++ b/GEECS-Console/poetry.lock
@@ -1027,7 +1027,7 @@ tqdm = ["tqdm"]
 
 [[package]]
 name = "geecs-bluesky"
-version = "0.58.0"
+version = "0.62.0"
 description = "Bluesky / ophyd-async bridge for the GEECS control system"
 optional = false
 python-versions = ">=3.11,<3.12"
@@ -1046,9 +1046,9 @@ ophyd-async = ">=0.19.3,<1.0"
 tiled = {version = ">=0.2", extras = ["client"], optional = true}
 
 [package.extras]
-analysis = ["imageanalysis @ file:///Users/samuelbarber/Desktop/Code/Github_repos/GEECS-Plugins/.claude/worktrees/angry-lederberg-436e6d/ImageAnalysis"]
+analysis = ["imageanalysis @ file:///Users/samuelbarber/Desktop/Code/Github_repos/GEECS-Plugins/ImageAnalysis"]
 ca = ["aioca (>=1.7)"]
-optimize = ["gest-api (>=0.1)", "imageanalysis @ file:///Users/samuelbarber/Desktop/Code/Github_repos/GEECS-Plugins/.claude/worktrees/angry-lederberg-436e6d/ImageAnalysis", "scananalysis @ file:///Users/samuelbarber/Desktop/Code/Github_repos/GEECS-Plugins/.claude/worktrees/angry-lederberg-436e6d/ScanAnalysis", "xopt (>=3.1,<4.0)"]
+optimize = ["gest-api (>=0.1)", "imageanalysis @ file:///Users/samuelbarber/Desktop/Code/Github_repos/GEECS-Plugins/ImageAnalysis", "scananalysis @ file:///Users/samuelbarber/Desktop/Code/Github_repos/GEECS-Plugins/ScanAnalysis", "xopt (>=3.1,<4.0)"]
 qs-client = ["bluesky-queueserver-api (>=0.0.13,<0.0.14)"]
 qserver = ["bluesky-queueserver (>=0.0.25,<0.0.26)"]
 tiled = ["tiled[client] (>=0.2)"]
@@ -1109,7 +1109,7 @@ url = "../GEECS-Data-Utils"
 
 [[package]]
 name = "geecs-schemas"
-version = "0.10.2"
+version = "0.11.0"
 description = "Versioned Pydantic schemas for GEECS scanner configs (scan requests, save sets, scan variables, trigger profiles, action plans) plus legacy-YAML converters."
 optional = false
 python-versions = ">=3.11,<3.12"

--- a/GEECS-Console/pyproject.toml
+++ b/GEECS-Console/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-console"
-version = "0.24.0"
+version = "0.24.1"
 description = "Greenfield PySide6 operator console for GEECS (Bluesky/gateway architecture)"
 authors = ["Sam Barber <sbarber@lbl.gov>"]
 readme = "README.md"

--- a/GEECS-MCP/CHANGELOG.md
+++ b/GEECS-MCP/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to `geecs-mcp` are documented here.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.6.1] - 2026-08-24
+
+### Fixed
+
+- `poetry.lock` regenerated from the main checkout: the geecs-bluesky
+  extras lines referenced a deleted `.claude/worktrees/` session
+  worktree (the lock had been generated from inside one), leaving
+  dangling absolute paths.  Lock-file refresh only — no code change.
+
 ## [0.6.0] - 2026-08-24
 
 Payload discipline for figures (osprey-side integration finding: an

--- a/GEECS-MCP/poetry.lock
+++ b/GEECS-MCP/poetry.lock
@@ -1447,7 +1447,7 @@ tqdm = ["tqdm"]
 
 [[package]]
 name = "geecs-bluesky"
-version = "0.61.0"
+version = "0.62.0"
 description = "Bluesky / ophyd-async bridge for the GEECS control system"
 optional = false
 python-versions = ">=3.11,<3.12"
@@ -1465,9 +1465,9 @@ geecs-schemas = {path = "../GEECS-Schemas", develop = true}
 ophyd-async = ">=0.19.3,<1.0"
 
 [package.extras]
-analysis = ["imageanalysis @ file:///Users/samuelbarber/Desktop/Code/Github_repos/GEECS-Plugins/.claude/worktrees/sad-dewdney-870421/ImageAnalysis"]
+analysis = ["imageanalysis @ file:///Users/samuelbarber/Desktop/Code/Github_repos/GEECS-Plugins/ImageAnalysis"]
 ca = ["aioca (>=1.7)"]
-optimize = ["gest-api (>=0.1)", "imageanalysis @ file:///Users/samuelbarber/Desktop/Code/Github_repos/GEECS-Plugins/.claude/worktrees/sad-dewdney-870421/ImageAnalysis", "scananalysis @ file:///Users/samuelbarber/Desktop/Code/Github_repos/GEECS-Plugins/.claude/worktrees/sad-dewdney-870421/ScanAnalysis", "xopt (>=3.1,<4.0)"]
+optimize = ["gest-api (>=0.1)", "imageanalysis @ file:///Users/samuelbarber/Desktop/Code/Github_repos/GEECS-Plugins/ImageAnalysis", "scananalysis @ file:///Users/samuelbarber/Desktop/Code/Github_repos/GEECS-Plugins/ScanAnalysis", "xopt (>=3.1,<4.0)"]
 qs-client = ["bluesky-queueserver-api (>=0.0.13,<0.0.14)"]
 qserver = ["bluesky-queueserver (>=0.0.25,<0.0.26)"]
 tiled = ["tiled[client] (>=0.2)"]

--- a/GEECS-MCP/pyproject.toml
+++ b/GEECS-MCP/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-mcp"
-version = "0.6.0"
+version = "0.6.1"
 description = "MCP server exposing GEECS scan submission, monitoring, and config discovery to AI agents (OSPREY)"
 authors = ["Sam Barber <sbarber@lbl.gov>"]
 readme = "README.md"

--- a/poetry.lock
+++ b/poetry.lock
@@ -1046,7 +1046,7 @@ files = [
 
 [[package]]
 name = "geecs-bluesky"
-version = "0.52.2"
+version = "0.62.0"
 description = "Bluesky / ophyd-async bridge for the GEECS control system"
 optional = false
 python-versions = ">=3.11,<3.12"
@@ -1062,9 +1062,11 @@ geecs-schemas = {path = "../GEECS-Schemas", develop = true}
 ophyd-async = ">=0.19.3,<1.0"
 
 [package.extras]
-analysis = ["imageanalysis @ file:///Users/samuelbarber/Desktop/Code/Github_repos/GEECS-Plugins/.claude/worktrees/geecs-python-api-declutter-fd76fa/ImageAnalysis"]
+analysis = ["imageanalysis @ file:///Users/samuelbarber/Desktop/Code/Github_repos/GEECS-Plugins/ImageAnalysis"]
 ca = ["aioca (>=1.7)"]
-optimize = ["gest-api (>=0.1)", "imageanalysis @ file:///Users/samuelbarber/Desktop/Code/Github_repos/GEECS-Plugins/.claude/worktrees/geecs-python-api-declutter-fd76fa/ImageAnalysis", "scananalysis @ file:///Users/samuelbarber/Desktop/Code/Github_repos/GEECS-Plugins/.claude/worktrees/geecs-python-api-declutter-fd76fa/ScanAnalysis", "xopt (>=3.1,<4.0)"]
+optimize = ["gest-api (>=0.1)", "imageanalysis @ file:///Users/samuelbarber/Desktop/Code/Github_repos/GEECS-Plugins/ImageAnalysis", "scananalysis @ file:///Users/samuelbarber/Desktop/Code/Github_repos/GEECS-Plugins/ScanAnalysis", "xopt (>=3.1,<4.0)"]
+qs-client = ["bluesky-queueserver-api (>=0.0.13,<0.0.14)"]
+qserver = ["bluesky-queueserver (>=0.0.25,<0.0.26)"]
 tiled = ["tiled[client] (>=0.2)"]
 
 [package.source]
@@ -1124,7 +1126,7 @@ url = "GEECS-Data-Utils"
 
 [[package]]
 name = "geecs-schemas"
-version = "0.9.1"
+version = "0.11.0"
 description = "Versioned Pydantic schemas for GEECS scanner configs (scan requests, save sets, scan variables, trigger profiles, action plans) plus legacy-YAML converters."
 optional = false
 python-versions = ">=3.11,<3.12"


### PR DESCRIPTION
## What + why

The root, `GEECS-Console`, and `GEECS-MCP` `poetry.lock` files recorded absolute `file:///Users/...` paths into **deleted** `.claude/worktrees/` session worktrees (`geecs-python-api-declutter-fd76fa`, `angry-lederberg-436e6d`, `sad-dewdney-870421`) in the geecs-bluesky `[package.extras]` lines — the tell that each lock was last generated from *inside* a session worktree instead of the main checkout. Those paths dangle the moment the worktree is removed, and they put home-directory paths pointing at ephemeral locations into a public repo.

Fix: regenerated all three locks with `poetry lock` (Poetry 2.1.3, no version updates) from the main checkout. The diffs are minimal — the extras paths now point at the main checkout, plus the path-dep version metadata catching up to current pyprojects (geecs-bluesky → 0.62.0, geecs-schemas → 0.11.0). Zero `.claude/worktrees` references remain in any lock.

Flagged by the adversarial review of PR #690 (finding 6, waived there as pre-existing).

## Per-concern LOC breakdown

| Concern | Files | LOC |
|---|---|---|
| Lock regeneration | `poetry.lock`, `GEECS-Console/poetry.lock`, `GEECS-MCP/poetry.lock` | ~24 |
| Recurrence guard (judgment-call addition, cheap to veto) | `.pre-commit-config.yaml` | +9 |
| Version + changelog ritual | 2× `pyproject.toml`, 2× `CHANGELOG.md` | ~20 |

**Judgment-call addition:** a local pygrep pre-commit hook that fails any commit where a `poetry.lock` contains `.claude/worktrees/` — verified both directions (passes on the fixed locks; fails with pinpointed lines on the old GEECS-MCP lock). Veto freely if you'd rather keep the config lean.

## Known residual (structural, surfaced for the record)

The regenerated extras lines still contain `/Users/samuelbarber/.../GEECS-Plugins/...` absolute paths. This is Poetry behavior, not fixable by where you run the lock: directory-dependency extras are serialized as PEP 508 direct-URL requirements, and PEP 508 has no relative `file://` form. These absolute paths are stable and only advisory metadata (the actual dep entries use relative `path = "../..."`; CI has been `poetry install`ing these locks on ubuntu runners, where macOS paths never resolve, and stayed green). Historical note, corrected per review: the root lock carried the main-checkout form before the regression — this is the third time a lock de-worktree cleanup has landed (`78ba6f04`, `06fb3e99`, now here), which is the strongest argument for the new hook. `GEECS-Console/poetry.lock` was born referencing a session worktree, was briefly clean at `c531e064` (2026-08-20), and regressed the same day. A literal reading of the no-home-paths hygiene rule still catches them — eliminating them entirely would mean restructuring the optional path-deps or not committing consumer locks, which is out of scope here and probably not worth it. Flagging so the waiver is explicit.

## Process note

This branch was prepared in the **main checkout**, not a session worktree — deliberately: a lock generated inside a worktree records that worktree's path, which is the exact bug being fixed.

## Tests

`./scripts/check.sh --all`: **2759 passed, 6 skipped, 0 failed** across all 12 suites (root 2, ImageAnalysis 224+1s, ScanAnalysis 171, GEECS-Data-Utils 201, GEECS-Schemas 266, GeecsBluesky 720+5s, GeecsCAGateway 133, GeecsPvaGateway 14, GEECS-Console 785, GEECS-Core 87, GEECS-LogTriage 59, GEECS-MCP 97). The gateway/core suites needed fresh local Poetry envs first (missing-venv env gap on this machine, unrelated to this diff). `poetry install` verified green in all three re-locked environments.

## Hardware verification

N/A — dependency-metadata refresh plus a pre-commit hook; no scan-execution or device surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

