### PR TITLE
docs: Agentic Tooling section — GEECS MCP server orientation

### DIFF
--- a/GEECS-MCP/CHANGELOG.md
+++ b/GEECS-MCP/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to `geecs-mcp` are documented here.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.7.2] - 2026-08-25
+
+### Changed
+
+- Docs-only: the write-surface doctrine statement in `CLAUDE.md` amended
+  to match deployed practice (owner correction on docs PR #692): osprey's
+  own EPICS write tool sets gateway `:SP` PVs directly, bounded by its
+  limits database — "raw gateway PVs are read-only to the agent" was
+  stale.  The surviving rule: GEECS-semantic writes are MCP verbs only,
+  and the MCP does no raw PV I/O of its own.
+
 ## [0.7.1] - 2026-08-25
 
 ### Fixed

--- a/GEECS-MCP/CLAUDE.md
+++ b/GEECS-MCP/CLAUDE.md
@@ -32,10 +32,18 @@ conventions), `archiver/` when that project reactivates.
   `devices/*`) — when a tool needs something private, promote it into a
   small public module in GeecsBluesky instead (the #668 discipline: the
   engine splits emerge from real seams, not guesses).
-- **Write-surface doctrine** (standing, 2026-07-23): agent writes go
-  through MCP verbs only; scans stay in the GEECS engine — the MCP
-  submits ScanRequests, never drives devices shot-by-shot; raw gateway
-  PVs are read-only to the agent.
+- **Write-surface doctrine** (2026-07-23, amended 2026-08-25 to match
+  deployed practice — owner correction): GEECS-*semantic* writes (scans,
+  actions, manual moves, analysis) go through MCP verbs only; scans stay
+  in the GEECS engine — the MCP submits ScanRequests, never drives
+  devices shot-by-shot, and does no raw PV I/O of its own.  Channel-level
+  setpoint writes (`caput` to `:SP` PVs) are NOT MCP territory: osprey's
+  own EPICS write tool performs them, bounded by osprey's limits database
+  and its own gating.  That raw path bypasses the GEECS client-side
+  hardening (put-failure visibility, wire conventions, confirm/pseudo
+  semantics, mid-scan refusals — only device limits + gateway atomicity
+  hold server-side), which is why anything with GEECS semantics still
+  belongs behind an MCP verb.
 - **No osprey imports.**  The integration surface is `profile.yml` +
   stdio or HTTP (`deploy/DEPLOYMENT.md` — central HTTP on the qserver
   box is the multi-machine mode; stdio is the dev loop);

--- a/GEECS-MCP/pyproject.toml
+++ b/GEECS-MCP/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-mcp"
-version = "0.7.1"
+version = "0.7.2"
 description = "MCP server exposing GEECS scan submission, monitoring, and config discovery to AI agents (OSPREY)"
 authors = ["Sam Barber <sbarber@lbl.gov>"]
 readme = "README.md"

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -8,7 +8,7 @@ The site is organised into top-level tabs in `mkdocs.yml`'s `nav:`. The
 canonical ordering is:
 
 ```
-Home → Tutorials → Acquisition → Analysis → Platform → Skills
+Home → Tutorials → Acquisition → Analysis → Platform → Agentic Tooling
 ```
 
 The middle three are **purpose groups**, not one-tab-per-package. Each
@@ -37,8 +37,11 @@ that one-tab-per-package sprawl is exactly what the purpose grouping replaced.
 
 The Tutorials tab is the cross-package, user-facing entry point — it holds
 the end-to-end walkthroughs (currently Analysis; Acquisition is stubbed
-— see `tutorials/acquisition.md`). Skills
-sits last because it's experimental tooling rather than core suite.
+— see `tutorials/acquisition.md`). Agentic Tooling sits last: the
+AI-agent surfaces rather than core suite, in two sections with distinct
+audiences — the GEECS MCP Server (agents operating the lab) and Skills
+(agents developing the code) — behind a landing page at
+`docs/agentic/index.md`.
 
 ## When to put what where
 

--- a/docs/agentic/index.md
+++ b/docs/agentic/index.md
@@ -1,0 +1,29 @@
+# Agentic Tooling
+
+This section covers the places where AI agents meet GEECS. There are two
+distinct strands, with different audiences, and it helps to keep them
+separate in your head:
+
+**Agents operating the lab.** The [GEECS MCP Server](../geecs_mcp/overview.md)
+is a deployed lab service — the same standing as the gateway or the
+console — that exposes GEECS-semantic operations (submit a scan, check its
+progress, look up archived results, run post-scan analysis) as typed tools
+an AI agent can call. An agent framework such as
+[OSPREY](../geecs_mcp/osprey.md) connects to it and puts those tools in the
+hands of an operator-facing assistant: "run the baseline analysis on
+scan 12" becomes a tool call instead of a person clicking through a GUI.
+If you are here to understand *what the AI assistant can actually do to the
+machine, and what stops it doing more*, start with the
+[MCP server overview](../geecs_mcp/overview.md).
+
+**Agents developing the code.** [Skills](../skills/overview.md) are
+instruction files for [Claude Code](https://claude.ai/code) sessions working
+*on this repository* — codified workflows like landing a PR, triaging scan
+logs, or repairing a Poetry environment. They never touch the beamline; they
+make development on GEECS-Plugins repeatable and guarded.
+
+The shared idea behind both strands is the same one that runs through the
+whole suite: give the flexible, language-understanding layer (the agent) a
+**well-defined contract** over a deterministic core, rather than free-form
+access. For the lab that contract is the MCP server's tool surface and its
+safety gates; for the codebase it is the skills' wrapped CLIs and rituals.

--- a/docs/geecs_mcp/analysis.md
+++ b/docs/geecs_mcp/analysis.md
@@ -1,0 +1,88 @@
+# The analysis domain
+
+The analysis domain closes the loop the scan service opens: after a scan
+runs, an agent can see what the
+[ScanAnalysis](../scan_analysis/overview.md) pipeline produced, fetch the
+summary figures, and — since GEECS-MCP 0.7.0 — trigger the analysis
+itself. The backend is the existing ScanAnalysis framework, used as-is:
+the same diagnostic YAMLs, analyzers, and task-queue bookkeeping that the
+LiveWatch tooling drives, now callable on demand.
+
+## Reading results (R)
+
+| Tool | What it returns |
+|---|---|
+| `get_scan_analysis` | Per-scan task statuses (from the scan's `analysis_status/` files: queued / claimed / done / failed / no_data, with errors and heartbeat ages) plus a capped map of the analysis output tree |
+| `get_scan_figure` | A figure **reference**: label, dimensions, byte size, and a fetch URL served by this same server. `thumbnail=true` opts into a small bounded inline preview |
+| `list_analyzers` | Every diagnostic ID in the configs repo's `analyzers/` tree — the names `run_scan_analysis` accepts |
+| `list_analysis_groups` | Every analysis-group name (`groups/` tree); both bare stems and namespace-qualified forms resolve |
+
+Figures follow the payload doctrine strictly: image bytes never ride the
+agent's context by default (a single full-size PNG can swamp a model's
+context window — a real integration finding). The reference's URL points
+at a `/figures/{day}/{scan}/{label}` route on the server, so a client
+fetches the original bytes out-of-band and saves them as an artifact.
+
+## Running analysis (Q)
+
+`run_scan_analysis(scan_number, day?, analyzer|group, rerun_failed,
+rerun_completed)` executes one diagnostic or a whole group for one scan,
+submit-and-poll style: the call returns as soon as the tasks are enqueued
+and a detached worker process is started; `get_scan_analysis` is the
+poll. The tool validates *everything refusable before any side effect*:
+
+- exactly one of `analyzer` / `group`, with names from the listing tools
+  (unknown names are refused with the known-names list);
+- the scan folder **must already exist** — analysis is a consumer of
+  scan folders, never a producer (the repo-wide invariant: a missing
+  folder is a refusal naming the path, never an auto-create);
+- the analyzers must actually construct **on this host** — a diagnostic
+  whose image-analyzer class needs a Windows-only SDK (the HASO
+  wavefront and Grenouille/FROG diagnostics) is refused up front with a
+  message naming the future Windows satellite server, instead of
+  half-running.
+
+The execution itself is the ScanAnalysis task queue's own machinery:
+statuses are initialized before the worker spawns (so a worker that dies
+is *visible* as a stuck row, never a silent nothing), the worker claims
+each task through an atomic cross-process claim gate (two near-
+simultaneous requests can never double-run one analyzer into the same
+output files), heartbeats tick every 30 s, and a dead worker's claim goes
+stale after 180 s so a repeat call re-runs it.
+
+Rerun semantics are explicit: by default only never-run tasks execute —
+a repeat call is a cheap, honest no-op that reports the already-`done`
+tasks as `skipped`. `rerun_failed` / `rerun_completed` re-queue those
+states server-side before the worker starts. Google-Doc upload stays
+hard-off: publishing figures to the experiment log is an outward-facing
+action that would need its own explicitly gated verb.
+
+## A worked example
+
+A real first-contact run, on archived data (Undulator, 2026-05-01,
+Scan 1, the `Amp2Input` diagnostic over the `UC_Amp2_IR_input` camera):
+
+```text
+list_analyzers                             → 82 diagnostics, incl. Amp2Input
+run_scan_analysis(1, "2026-05-01",
+                  analyzer="Amp2Input")    → ok, started: false —
+                                             skipped: {Amp2Input: done}
+                                             (this scan was analyzed in May)
+run_scan_analysis(..., rerun_completed=True)
+                                           → ok, started: true, worker pid
+get_scan_analysis(1, "2026-05-01")         → Amp2Input: claimed → done,
+                                             display_files: [...visual.png]
+get_scan_figure(1, day="2026-05-01")       → figure reference with
+                                             /figures/2026-05-01/1/... URL
+run_scan_analysis(999, "2026-05-01", ...)  → not_found: scan folder does
+                                             not exist (nothing created)
+```
+
+## The longer arc
+
+Using ScanAnalysis as-is is a deliberate owner decision, not an endpoint.
+The verb surface is backend-neutral (it names a diagnostic, a scan, a
+day) and the `analysis_status/` files are the progress contract — so the
+Tiled-based analysis stack in GeecsBluesky (provenance-tracked results
+published back into the archive) can slot in behind the same tools later
+without the agent-facing surface changing.

--- a/docs/geecs_mcp/osprey.md
+++ b/docs/geecs_mcp/osprey.md
@@ -1,6 +1,6 @@
 # Leveraging OSPREY
 
-[OSPREY](https://github.com/als-computing/osprey) is an agent framework
+[OSPREY](https://github.com/als-apg/osprey) is an agent framework
 for accelerators developed at the ALS: it hosts an operator-facing AI
 assistant, gives it facility tools (EPICS channel access, archiver
 lookups, logbooks), and enforces per-tool permissions around everything
@@ -36,9 +36,11 @@ code — the entire integration surface is configuration.
 OSPREY registers the server as a *custom MCP server* in its build profile
 (`profile.yml`): either a `command:` that launches the server over stdio,
 or the URL of the central HTTP service — one server process on the lab
-server that every OSPREY machine shares. Permission lists in the profile
-import the server's `tool_names` constants rather than retyping strings,
-so a renamed tool cannot silently strand a permission entry.
+server that every OSPREY machine shares. The profile's permission lists
+mirror the server's `geecs_mcp/tool_names.py` constants — the two are
+kept in sync by hand when a verb lands (the deployment doc carries the
+update-both warning), and Python-side consumers import the constants
+directly so a rename cannot silently strand an entry there.
 
 Gating has two layers, and the distinction matters (the semantics were
 verified against OSPREY directly; details and the exact `write_tools`
@@ -47,9 +49,12 @@ list live in `GEECS-MCP/deploy/DEPLOYMENT.md`):
 - **Interactive sessions**: every control verb surfaces OSPREY's native
   *ask* prompt — a human sees the tool name and its arguments and
   approves each call.
-- **Headless runs**: the profile's `write_tools` allowlist is the gate.
-  Every queueing verb is listed there; the stop family deliberately is
-  **not**, so a halt is never blocked on any path.
+- **Headless runs**: the profile's `write_tools` list is the gate — a
+  tool *listed* there is gated for unattended operation; a tool omitted
+  is ungated. The design lists every queueing verb and deliberately
+  omits the stop family, so a halt is never blocked on any path (the
+  exact current list lives in `deploy/DEPLOYMENT.md` — keep it in step
+  as verbs land).
 
 Each deployment sets a client identity (for the HTU assistant:
 `osprey-htu-assistant`) that is stamped onto every queue item and

--- a/docs/geecs_mcp/osprey.md
+++ b/docs/geecs_mcp/osprey.md
@@ -12,14 +12,21 @@ MCP server is how that assistant reaches GEECS.
 The integration deliberately splits along the
 [write-surface doctrine](overview.md#where-it-sits-in-the-architecture):
 
-- **Raw EPICS channels — OSPREY's own tools, read-only.** BELLA is an
-  EPICS facility as far as OSPREY is concerned, via the
+- **Raw EPICS channels — OSPREY's own tools.** BELLA is an EPICS
+  facility as far as OSPREY is concerned, via the
   [GEECS Gateway](../geecs_gateway/client_overview.md)'s PVs. The
-  assistant can read any served channel with the framework's generic
-  tools; it does not write them.
-- **GEECS-semantic operations — this MCP server.** Scans, configs,
-  results, analysis: everything that changes machine state or needs the
-  GEECS vocabulary goes through the server's gated verbs.
+  assistant reads any served channel with the framework's generic tools,
+  and can set individual setpoints by writing the `:SP` PVs through
+  OSPREY's own write tool — bounded by a limits database (extracted from
+  the GEECS device limits) and OSPREY's own permission gating.
+- **GEECS-semantic operations — this MCP server.** Scans, actions,
+  manual moves with scan-identical completion semantics, configs,
+  results, analysis: anything that needs the GEECS vocabulary goes
+  through the server's gated verbs. The raw `:SP` path deliberately
+  stays a simple bounded knob — it bypasses the GEECS client-side
+  hardening (put-failure visibility, confirm/pseudo semantics, mid-scan
+  refusals), so the richer the operation, the more it belongs behind an
+  MCP verb.
 
 The GEECS MCP server never imports OSPREY and OSPREY never imports GEECS
 code — the entire integration surface is configuration.

--- a/docs/geecs_mcp/osprey.md
+++ b/docs/geecs_mcp/osprey.md
@@ -1,0 +1,71 @@
+# Leveraging OSPREY
+
+[OSPREY](https://github.com/als-computing/osprey) is an agent framework
+for accelerators developed at the ALS: it hosts an operator-facing AI
+assistant, gives it facility tools (EPICS channel access, archiver
+lookups, logbooks), and enforces per-tool permissions around everything
+the assistant does. BELLA runs an OSPREY-based assistant, and the GEECS
+MCP server is how that assistant reaches GEECS.
+
+## The division of labour
+
+The integration deliberately splits along the
+[write-surface doctrine](overview.md#where-it-sits-in-the-architecture):
+
+- **Raw EPICS channels — OSPREY's own tools, read-only.** BELLA is an
+  EPICS facility as far as OSPREY is concerned, via the
+  [GEECS Gateway](../geecs_gateway/client_overview.md)'s PVs. The
+  assistant can read any served channel with the framework's generic
+  tools; it does not write them.
+- **GEECS-semantic operations — this MCP server.** Scans, configs,
+  results, analysis: everything that changes machine state or needs the
+  GEECS vocabulary goes through the server's gated verbs.
+
+The GEECS MCP server never imports OSPREY and OSPREY never imports GEECS
+code — the entire integration surface is configuration.
+
+## How the connection works
+
+OSPREY registers the server as a *custom MCP server* in its build profile
+(`profile.yml`): either a `command:` that launches the server over stdio,
+or the URL of the central HTTP service — one server process on the lab
+server that every OSPREY machine shares. Permission lists in the profile
+import the server's `tool_names` constants rather than retyping strings,
+so a renamed tool cannot silently strand a permission entry.
+
+Gating has two layers, and the distinction matters (the semantics were
+verified against OSPREY directly; details and the exact `write_tools`
+list live in `GEECS-MCP/deploy/DEPLOYMENT.md`):
+
+- **Interactive sessions**: every control verb surfaces OSPREY's native
+  *ask* prompt — a human sees the tool name and its arguments and
+  approves each call.
+- **Headless runs**: the profile's `write_tools` allowlist is the gate.
+  Every queueing verb is listed there; the stop family deliberately is
+  **not**, so a halt is never blocked on any path.
+
+Each deployment sets a client identity (for the HTU assistant:
+`osprey-htu-assistant`) that is stamped onto every queue item and
+submission record — the machine's history shows *which agent* ran what.
+
+## What an operator can ask
+
+With the server connected, the assistant can carry conversations like:
+
+- *"Is anything running right now? What's in the queue?"* —
+  `scan_status`, `scan_history`.
+- *"Run a no-scan with the Amp4In save set, 20 shots."* — names checked
+  against `list_scan_configs`, then `submit_scan` behind the ask prompt,
+  preflight warnings surfaced for explicit acknowledgement.
+- *"How is it going?"* — `scan_progress`, per-shot counts from the
+  worker's document stream.
+- *"What did scan 12 measure?"* — `get_scan_result` from the Tiled
+  archive.
+- *"Run the standard analysis on it and show me the beam profile."* —
+  `run_scan_analysis`, polled via `get_scan_analysis`, figure fetched
+  through its `/figures/…` URL.
+- *"Stop the scan."* — `stop_scan`, gracefully, always available.
+
+Each step is an auditable tool call with its own gate — which is exactly
+the trade the whole design makes: flexible language in front, a fixed and
+reviewable machine surface behind.

--- a/docs/geecs_mcp/overview.md
+++ b/docs/geecs_mcp/overview.md
@@ -49,7 +49,9 @@ matter:
 
 The MCP server exposes exactly these GEECS-semantic surfaces. It
 deliberately does **not** duplicate raw-PV channel tools — the agent
-framework's own EPICS tools cover that, read-only.
+framework's own EPICS tools cover channel-level access, including
+bounded setpoint writes (see the
+[division of labour](osprey.md#the-division-of-labour)).
 
 ## Where it sits in the architecture
 
@@ -86,10 +88,15 @@ flowchart LR
 
 Two standing doctrines shape everything above:
 
-- **Write-surface doctrine.** Agent writes to the machine go through MCP
-  verbs only. Raw gateway PVs are read-only to the agent; anything that
-  changes machine state is a named, gated tool with its own refusal
-  logic. Scans stay in the GEECS engine.
+- **Write-surface doctrine.** GEECS-*semantic* writes — scans, actions,
+  manual moves, analysis — go through MCP verbs only, each a named,
+  gated tool with its own refusal logic, and scans stay in the GEECS
+  engine. Channel-level setpoint writes are deliberately *not* MCP
+  territory: the agent framework's own EPICS write tool can set gateway
+  `:SP` PVs directly, bounded by its limits database and gating — but
+  that raw path bypasses the GEECS client-side hardening (put-failure
+  visibility, confirm/pseudo semantics, mid-scan refusals), which is
+  exactly why operations with GEECS semantics belong behind an MCP verb.
 - **A client, never an engine.** The server imports only the shared
   public seams, never engine internals. If a tool needs something
   private, the right move is to promote a small public module in

--- a/docs/geecs_mcp/overview.md
+++ b/docs/geecs_mcp/overview.md
@@ -131,8 +131,10 @@ permission lists import symbols rather than retyping strings):
   `submit_scan`, `clear_queue`, `run_action`, `move_scan_variable`,
   `resume_scan`, `run_scan_analysis`. Interactively these surface a
   native *ask* prompt (a human sees each call with its arguments before
-  it runs); headless/unattended operation gates them through an explicit
-  `write_tools` allowlist in the agent framework's configuration.
+  it runs); headless/unattended operation gates them through the agent
+  framework's explicit `write_tools` list (a tool listed there is
+  gated when no human is watching; the gating semantics live in
+  `deploy/DEPLOYMENT.md`).
 - **S — stop direction.** `stop_scan` and `pause_scan`. These are asked
   about interactively but **deliberately never listed in `write_tools`**
   — a halt must never be blocked on any path. Making the machine quieter

--- a/docs/geecs_mcp/overview.md
+++ b/docs/geecs_mcp/overview.md
@@ -122,8 +122,9 @@ server entry with the same conventions.
 ## The safety model
 
 Every tool belongs to one of three classes, and the class determines how
-it is gated (the constants live in `geecs_mcp/tool_names.py`, so
-permission lists import symbols rather than retyping strings):
+it is gated (`geecs_mcp/tool_names.py` is the one place the names and
+class groupings are spelled; anything listing tool names elsewhere is
+kept in step with it):
 
 - **R — read-only.** Status, listings, results, figures, dry-runs. Safe
   to auto-allow; calling them changes nothing.

--- a/docs/geecs_mcp/overview.md
+++ b/docs/geecs_mcp/overview.md
@@ -1,0 +1,171 @@
+# GEECS MCP Server — overview
+
+**GEECS-MCP** is the general GEECS server for AI agents: one deployed
+service that exposes the lab's GEECS-semantic operations — the scan
+service, the config catalogs, archived results, post-scan analysis — as
+typed tools an agent can call. It is what turns "ask the assistant to run
+a scan and tell me what it measured" from a demo into a governed,
+auditable interaction with the machine.
+
+This page is a concepts-first orientation. The authoritative detail lives
+in the package alongside the code: `GEECS-MCP/CLAUDE.md` (architecture and
+boundaries), `GEECS-MCP/deploy/DEPLOYMENT.md` (the one full inventory of
+configuration keys, transports, and the permission-gating semantics).
+Treat those as the source of truth if anything here disagrees.
+
+## What "MCP" is
+
+The [Model Context Protocol](https://modelcontextprotocol.io) (MCP) is an
+open standard for connecting AI agents to external systems. A server
+declares a set of **tools** — named, typed, callable functions with
+documented parameters — and an agent connected to that server can invoke
+them during a conversation. The agent decides *when* to call a tool from
+the conversation's needs; the server decides *what each call is allowed to
+do* and returns a structured result.
+
+That split is the whole point. The language model brings flexible intent
+("rerun yesterday's failed analyses"); the server brings a fixed,
+reviewable surface (a `run_scan_analysis` tool with exactly these
+parameters, exactly these refusal conditions). Nothing the agent says can
+make the server do something outside its tool surface.
+
+## Why GEECS needs its own server
+
+BELLA is already EPICS-fronted through the
+[GEECS Gateway](../geecs_gateway/client_overview.md), so an agent framework
+with generic EPICS tools can read any process variable without this server
+existing. But raw PV access cannot express the operations that actually
+matter:
+
+- "Run a 1D scan of the jet position using the `Amp4In` save set" — that
+  is a **ScanRequest** submitted to the queueserver, not a PV write.
+- "What did scan 12 measure?" — that is a **Tiled archive** lookup with
+  the run's metadata and per-column statistics.
+- "Which save sets and trigger profiles exist for this experiment?" —
+  that is the **configs repository**, resolved and validated the same way
+  the console does it.
+- "Run the standard analysis on this scan" — that is the **ScanAnalysis
+  pipeline** with its task queue and figure outputs.
+
+The MCP server exposes exactly these GEECS-semantic surfaces. It
+deliberately does **not** duplicate raw-PV channel tools — the agent
+framework's own EPICS tools cover that, read-only.
+
+## Where it sits in the architecture
+
+The server is a **peer client of the queueserver, with the same standing
+as the console** — and never an engine. It submits `ScanRequest`s through
+the same client seam the console uses (`geecs_bluesky.qs_client`),
+resolves configs through the same resolver, and reads results from the
+same Tiled catalog. Scan execution stays entirely in the GEECS engine (the
+queueserver worker); the MCP never drives devices shot-by-shot.
+
+```mermaid
+flowchart LR
+    subgraph agent side
+        O[Agent framework<br/>e.g. OSPREY assistant]
+    end
+    subgraph geecs-mcp [GEECS MCP Server]
+        S[scans domain]
+        A[analysis domain]
+    end
+    subgraph services [GEECS services]
+        Q[Queueserver worker<br/>RunEngine]
+        T[Tiled archive]
+        C[Configs repo]
+        D[Data share]
+    end
+    O -- "MCP tool calls" --> S
+    O -- "MCP tool calls" --> A
+    S -- "qs_client (submit / status / stop)" --> Q
+    S -- "resolver (listings / validation)" --> C
+    S -- "results" --> T
+    A -- "statuses / figures / analysis runs" --> D
+    Q -- "writes scans" --> D
+```
+
+Two standing doctrines shape everything above:
+
+- **Write-surface doctrine.** Agent writes to the machine go through MCP
+  verbs only. Raw gateway PVs are read-only to the agent; anything that
+  changes machine state is a named, gated tool with its own refusal
+  logic. Scans stay in the GEECS engine.
+- **A client, never an engine.** The server imports only the shared
+  public seams, never engine internals. If a tool needs something
+  private, the right move is to promote a small public module in
+  GeecsBluesky — the server's needs surface real seams rather than
+  growing a second engine.
+
+## Domains
+
+Tools are organised into **domains** — subpackages added as they earn
+their keep, never speculatively:
+
+| Domain | Status | What it covers |
+|---|---|---|
+| [Scan service](scan_service.md) | Built (v0 read, v1 control, v2 verbs) | Status, history, results, config listings, request validation, submit/stop/queue, actions, manual moves, pause/resume |
+| [Analysis](analysis.md) | Built (read + execution) | Task statuses and output trees, figures, on-demand ScanAnalysis execution |
+| Health / DB / Logs | Candidates | Gateway and archive probes, device-variable metadata, log triage as a tool |
+
+Capabilities that require Windows-only acquisition SDKs (some analysis
+diagnostics) do not force this server onto Windows — the pattern is a
+small *satellite* MCP server on a Windows box, registered as a second
+server entry with the same conventions.
+
+## The safety model
+
+Every tool belongs to one of three classes, and the class determines how
+it is gated (the constants live in `geecs_mcp/tool_names.py`, so
+permission lists import symbols rather than retyping strings):
+
+- **R — read-only.** Status, listings, results, figures, dry-runs. Safe
+  to auto-allow; calling them changes nothing.
+- **Q — queueing.** Anything that starts work or changes state:
+  `submit_scan`, `clear_queue`, `run_action`, `move_scan_variable`,
+  `resume_scan`, `run_scan_analysis`. Interactively these surface a
+  native *ask* prompt (a human sees each call with its arguments before
+  it runs); headless/unattended operation gates them through an explicit
+  `write_tools` allowlist in the agent framework's configuration.
+- **S — stop direction.** `stop_scan` and `pause_scan`. These are asked
+  about interactively but **deliberately never listed in `write_tools`**
+  — a halt must never be blocked on any path. Making the machine quieter
+  is always allowed.
+
+On top of the classes sit per-verb protections: submissions carry a shot
+cap and an **acknowledge-warnings loop** (the server never silently
+continues past a preflight question — the agent must explicitly
+acknowledge, and the acknowledgement is stamped into the run's
+`SubmissionRecord` for provenance); stop and resume carry **ownership
+etiquette** (another client's scan needs `force=true`, which is
+approval-gated). Every run submitted through the server is attributed to
+a configured client identity, so runs trace back to the agent that
+started them.
+
+## Conventions every tool follows
+
+- **Tools never raise.** Every result is a JSON envelope: `ok: true`
+  plus the payload, or `ok: false` with an `error_kind` from a fixed
+  taxonomy (`invalid_request`, `not_found`, `policy_refusal`,
+  `manager_unreachable`, …) and a message that preserves the engine's
+  own wording — those strings are the operator vocabulary.
+- **Payloads are context-sized.** Results return metadata, column names,
+  and capped statistics — never full event tables; figures return
+  *references* (path + fetch URL) rather than image bytes, with a
+  bounded thumbnail as an explicit opt-in. Anything truncated says so.
+- **No tool blocks on completion.** Long work is submit-and-poll: a
+  submit tool returns as soon as the work is enqueued, and a read tool
+  polls progress. A stuck tool call cannot wedge an agent conversation.
+- **Everything degrades honestly.** The server always starts; an
+  unconfigured or unreachable dependency turns the affected tools into
+  clear refusals that name what is missing, never crashes.
+
+## Configuration and deployment
+
+Configuration is only the standard
+`~/.config/geecs_python_api/config.ini` — the same fleet-wide file every
+GEECS Python tool reads; the server introduces no new config format.
+`GEECS-MCP/deploy/DEPLOYMENT.md` is the one full key inventory and the
+deployment runbook. Two transports exist: **stdio** (the dev loop — the
+agent framework launches the server as a subprocess) and **central HTTP**
+(the multi-machine mode — one server process on the lab server, reachable
+from any machine on the network).

--- a/docs/geecs_mcp/scan_service.md
+++ b/docs/geecs_mcp/scan_service.md
@@ -63,7 +63,7 @@ item.
 
 The stop family is the deliberate exception to headless gating: halting
 must work on every path, so `stop_scan`/`pause_scan` are never listed in
-a `write_tools` allowlist and never blocked.
+the `write_tools` gate and are never blocked.
 
 ## The submit-and-poll lifecycle
 

--- a/docs/geecs_mcp/scan_service.md
+++ b/docs/geecs_mcp/scan_service.md
@@ -1,0 +1,83 @@
+# The scan service
+
+The scans domain is the server's first and largest surface: everything an
+agent needs to observe, validate, submit, steer, and stop scans — as a
+client of the queueserver, exactly like the console.
+
+Tool classes below follow the [safety model](overview.md#the-safety-model):
+**R** read-only (auto-allow), **Q** queueing (asked/gated), **S** stop
+direction (asked, never blockable).
+
+## Observing (R)
+
+| Tool | What it returns |
+|---|---|
+| `scan_status` | The RE Manager's picture: manager/RunEngine state, queue length, the running item |
+| `scan_history` | Recent queue history items, newest last, field-tolerant |
+| `get_scan_result` | A completed run from the Tiled archive: metadata, column names, capped per-column statistics — never the full event table |
+| `list_scan_configs` | The experiment's config catalogs, by kind: save sets, trigger profiles, presets, optimizer configs, scan variables |
+| `validate_scan_request` | Full dry-run validation of a `ScanRequest` without submitting anything |
+| `scan_progress` | Poll-friendly progress: manager state plus a best-effort per-shot picture from the worker's document stream (planned totals, shots completed, exit status, and — while paused — the failed-move reason) |
+| `describe_action` | A dry-run step table for a named action plan (runs on the worker, needs an idle manager, changes nothing) |
+
+Names always come from `list_scan_configs` — an agent is told never to
+invent catalog names, and unknown names come back as clear `not_found`
+refusals rather than half-submissions.
+
+## Submitting (Q)
+
+`submit_scan` accepts either a saved **preset** by name or a composed
+`ScanRequest` dictionary — the same one submission shape as the console,
+validated against the schema at the tool boundary. Standing protections,
+all enforced server-side:
+
+- **Shot cap.** Agent submissions are capped (1,000 shots by default,
+  deployment-configurable); optimization runs must state an explicit
+  iteration budget.
+- **The acknowledge-warnings loop.** The pre-submit preflight (the same
+  checks the console runs: engine validation, unserved variables, device
+  liveness, free-run staleness) can raise *questions*. The server never
+  silently continues past one — the submission is refused with the
+  question, and the agent must resubmit with an explicit
+  acknowledgement. Every acknowledgement is stamped into the request's
+  `SubmissionRecord`, so the run's metadata records who was asked what.
+- **Identity.** The queue item and the `SubmissionRecord` both carry the
+  server's configured client identity — runs trace back to the agent
+  deployment that submitted them, and ownership checks compare against
+  it.
+- **The failed-item guard.** A failed item sitting at the front of the
+  queue is surfaced, never silently cleared.
+
+`clear_queue` is the one queue remover, and it never clears the running
+item.
+
+## Steering (Q) and stopping (S)
+
+| Tool | Class | Semantics |
+|---|---|---|
+| `pause_scan` | S | Deferred pause — lands at the next plan checkpoint (the in-flight shot always finishes; expect 1–2 shots of latency by design) |
+| `resume_scan` | Q | Resumes, retrying a failed move — it *restarts motion*, so it gates like a submission, with stop's ownership etiquette |
+| `stop_scan` | S | Graceful stop (from running: pause-then-stop sequencing; partial data is kept). Another client's scan requires `force=true`, which is approval-gated |
+| `run_action` | Q | Queue a named action plan — idle-only: an active scan refuses rather than silently queueing the action to fire later |
+| `move_scan_variable` | Q | A manual move of a catalog scan variable through the worker's own move machinery (scan-identical completion semantics); idle-only, bounded-blocking |
+
+The stop family is the deliberate exception to headless gating: halting
+must work on every path, so `stop_scan`/`pause_scan` are never listed in
+a `write_tools` allowlist and never blocked.
+
+## The submit-and-poll lifecycle
+
+No tool blocks on scan completion. A typical agent interaction:
+
+```text
+list_scan_configs            → pick a save set / preset by real name
+validate_scan_request        → optional dry-run of a composed request
+submit_scan                  → refused with a preflight question?
+submit_scan (acknowledged)   → queued + started; identity stamped
+scan_progress (repeat)       → shots completed / totals / paused reason
+get_scan_result              → archived metadata + capped statistics
+```
+
+Each step is one bounded request/response; the conversation stays
+responsive throughout, and every state transition the agent acted on is
+visible in the manager history and run metadata afterwards.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -107,10 +107,20 @@ nav:
           - Running a Scan: geecs_schemas/running_a_scan.md
           - Schema Reference: geecs_schemas/schema_reference.md
 
-  # Skills is intentionally last — experimental (agentic tooling), not core suite.
-  - Skills:
-      - Overview: skills/overview.md
-      - Writing a Skill: skills/writing_a_skill.md
+  # Agentic Tooling is intentionally last — the AI-agent surfaces, not core
+  # suite. Two strands with distinct audiences (the landing page explains):
+  # the GEECS MCP Server (agents operating the lab) and Skills (agents
+  # developing the code).
+  - Agentic Tooling:
+      - agentic/index.md
+      - GEECS MCP Server:
+          - Overview: geecs_mcp/overview.md
+          - Scan Service: geecs_mcp/scan_service.md
+          - Analysis: geecs_mcp/analysis.md
+          - Leveraging OSPREY: geecs_mcp/osprey.md
+      - Skills:
+          - Overview: skills/overview.md
+          - Writing a Skill: skills/writing_a_skill.md
 
 
 # Files that live under docs/ but should NOT be published as pages.


### PR DESCRIPTION
Owner request: concept-level mkdocs documentation for the agentic side of the suite, written for someone catching up on the fundamentals — holistic about the MCP server (its purpose and all domains at their real weight), not a write-up of the latest feature.

## What

The Skills tab (whose nav comment already labeled it "agentic tooling") grows into an **Agentic Tooling** tab with a landing page separating the two strands — agents *operating the lab* (the MCP server + OSPREY) vs agents *developing the code* (Skills, unchanged) — plus a four-page GEECS MCP Server section:

- **Overview** — concepts-first: what MCP-the-protocol is, why GEECS needs semantic surfaces beyond raw PVs, the server's architecture seat (peer client of the queueserver; "a client, never an engine"; write-surface doctrine), domains, the R/Q/S safety model (ask + write_tools, halts never blocked), the envelope/payload/submit-and-poll conventions, config + transports. Mermaid architecture diagram.
- **Scan Service** — the first and largest domain at full weight: the read tools, submit with cap/acknowledge-loop/identity/failed-item guard, steering and the stop family, the submit-and-poll lifecycle.
- **Analysis** — read slice (statuses, figure references + payload doctrine) and execution slice (validate-then-refuse, scan-folder invariant, Windows-SDK refusal, rerun semantics, claim-gate concurrency in one paragraph), a short worked example from the real 2026-05-01 Scan001 first-contact run, and the recorded longer arc (backend-neutral verbs, Tiled stack later).
- **Leveraging OSPREY** — what OSPREY is, the division of labour (raw channels read-only vs GEECS verbs), profile.yml integration and the two-layer gating, client identity, example operator conversations.

Follows the docs conventions: orientation pages that defer normative truth to the in-package docs (`GEECS-MCP/CLAUDE.md`, `deploy/DEPLOYMENT.md` named as sources of truth — the key inventory is pointed at, not duplicated).

## Scope notes

- Docs-only: five new markdown files + the `mkdocs.yml` nav block. No package code touched, so no package version bump (root site, not package docs).
- `mkdocs build` clean (no new errors/warnings; 24 s).
- Public-repo hygiene checked: no account names or home paths; the deployment specifics stay in the unpublished in-package docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)