### PR TITLE
capture daemon v0: geecs_bluesky.capture — scan-gated PVA capture, per-device HDF5 frame stacks

### DIFF
--- a/GEECS-Core/CHANGELOG.md
+++ b/GEECS-Core/CHANGELOG.md
@@ -3,6 +3,16 @@
 All notable changes to `geecs-core` are documented here, following
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and semantic versioning.
 
+## [0.4.0] - 2026-08-27
+
+### Added
+
+- **`GeecsDb.get_experiment_device_types(experiment, *, enabled_only=True)`**
+  — batch `{device: devicetype}` for an experiment in one connection, the
+  batch counterpart of `get_device_type` (mirrors `get_experiment_devices`).
+  First consumer: the capture daemon's devicetype-keyed camera discovery
+  (GeecsBluesky `geecs_bluesky.capture`).
+
 ## [0.3.0] - 2026-08-24
 
 ### Added

--- a/GEECS-Core/geecs_core/db/geecs_db.py
+++ b/GEECS-Core/geecs_core/db/geecs_db.py
@@ -556,6 +556,37 @@ class GeecsDb:
         return {name: (ip.strip(), int(port)) for name, ip, port in rows}
 
     @classmethod
+    def get_experiment_device_types(
+        cls, experiment: str, *, enabled_only: bool = True
+    ) -> dict[str, str]:
+        """Return ``{device: devicetype}`` for an experiment — one query.
+
+        The batch counterpart of :meth:`get_device_type`: devicetypes for every
+        device in *experiment* in a single connection, so devicetype-keyed
+        selection (e.g. picking every "Point Grey Camera") doesn't open one
+        MySQL connection per device.
+
+        Parameters
+        ----------
+        experiment:
+            GEECS experiment name.
+        enabled_only:
+            Restrict to devices enabled in the experiment (default true).
+        """
+        query = (
+            "SELECT DISTINCT d.name, d.devicetype "
+            "FROM expt_device ed "
+            "JOIN device d ON d.name = ed.device "
+            "WHERE ed.expt = %s"
+        )
+        if enabled_only:
+            query += " AND LOWER(ed.enabled) = 'yes'"
+        query += " ORDER BY d.name"
+        rows = _query(query, (experiment,))
+
+        return {name: (dtype or "").strip() for name, dtype in rows}
+
+    @classmethod
     def get_experiment_device_variables(
         cls, experiment: str, *, enabled_only: bool = True
     ) -> dict[str, list[dict]]:

--- a/GEECS-Core/pyproject.toml
+++ b/GEECS-Core/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-core"
-version = "0.3.0"
+version = "0.4.0"
 description = "The GEECS access library: UDP/TCP wire protocol, experiment database, PV naming contract, exceptions, the wire-protocol test double, and the entry-level GeecsDevice client"
 authors = ["Sam Barber <sbarber@lbl.gov>"]
 readme = "README.md"

--- a/GEECS-Core/tests/test_geecs_db.py
+++ b/GEECS-Core/tests/test_geecs_db.py
@@ -179,6 +179,36 @@ def test_get_experiment_devices_batches_endpoints(monkeypatch) -> None:
     assert "enabled" not in queries[0][0]
 
 
+def test_get_experiment_device_types_batches_types(monkeypatch) -> None:
+    """One query returns every device's devicetype; enabled filter in SQL."""
+    queries: list = []
+    _patch_rows(
+        monkeypatch,
+        [
+            ("UC_Amp4_IR_input", " Point Grey Camera "),
+            ("U_S1H", "EMQ_TDK"),
+            ("U_Odd", None),
+        ],
+        queries,
+    )
+
+    result = GeecsDb.get_experiment_device_types("Undulator")
+    assert result == {
+        "UC_Amp4_IR_input": "Point Grey Camera",
+        "U_S1H": "EMQ_TDK",
+        "U_Odd": "",
+    }
+    assert len(queries) == 1
+    query, params = queries[0]
+    assert params == ("Undulator",)
+    assert "d.devicetype" in query
+    assert "LOWER(ed.enabled) = 'yes'" in query
+
+    queries.clear()
+    GeecsDb.get_experiment_device_types("Undulator", enabled_only=False)
+    assert "enabled" not in queries[0][0]
+
+
 def _patch_query_sequence(
     monkeypatch, responses: list[list[tuple]], queries: list
 ) -> None:

--- a/GeecsBluesky/CHANGELOG.md
+++ b/GeecsBluesky/CHANGELOG.md
@@ -4,6 +4,28 @@ All notable changes to `geecs-bluesky` are documented here.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.64.0] - 2026-08-27
+
+### Added
+
+- **`geecs_bluesky.capture` — the central PVA image-capture daemon**
+  (`capture` extra: p4p + h5py; CLI `geecs-capture-daemon`). Scan-gated
+  capture per the arc scope doc
+  (`Planning/data_capture/01_central_pva_capture_scope.md`): consumes the
+  worker's 0MQ document stream (`[qserver] doc_addr`), and for every run
+  with `nonscalar_save_paths` subscribes deep-queue PVA monitors on the
+  run's capture-eligible cameras (devicetype registry, v0 = Point Grey),
+  dedupes on `acq_timestamp` (idle re-push), drops the gateway's stale
+  pre-scan cached frame, and trail-flushes one `<device>.h5` frame stack
+  (schema `geecs-capture/1`, `capture/FORMAT.md`; container swappable
+  behind the `FrameStackWriter` protocol) into the engine-created device
+  dirs — the daemon never creates directories (cross-package invariant).
+  Finalize stamps per-device reconciliation counters into the file and
+  logs them (the dual-write diff seed). Runs ALONGSIDE the LV per-shot
+  file save (Phase-1 dual-write doctrine — a daemon failure cannot lose
+  data). Requires geecs-core ≥0.4.0
+  (`GeecsDb.get_experiment_device_types` batch query).
+
 ## [0.63.0] - 2026-08-27
 
 ### Added

--- a/GeecsBluesky/CLAUDE.md
+++ b/GeecsBluesky/CLAUDE.md
@@ -161,6 +161,18 @@ geecs_bluesky/
                             #   FeatureRow, provenance), derived analysis runs
                             #   published to Tiled, ImageAnalyzerAdapter, camera
                             #   end-to-end analysis over archived Tiled runs
+  capture/                  # the central PVA image-capture daemon (`capture`
+                            #   extra: p4p + h5py; CLI geecs-capture-daemon):
+                            #   scan-gated doc-stream consumer → deep-queue
+                            #   PVA monitors on the run's Point Grey cameras
+                            #   → acq_timestamp dedupe + stale filter → one
+                            #   <device>.h5 frame stack per scan (FORMAT.md,
+                            #   schema geecs-capture/1; container swappable
+                            #   behind FrameStackWriter). NEVER creates scan
+                            #   dirs; dual-writes beside the LV file save.
+                            #   Arc scope: Planning/data_capture/. Phase-0
+                            #   probes = GeecsBluesky/capture/probes/
+                            #   (top-level operational scripts, NOT package)
   assets/                   # External asset helpers for native GEECS files
                             #   (handlers, readback, registry)
   epics_env.py              # Applies [epics] ca_addr_list from the shared config
@@ -530,14 +542,19 @@ the gateway's CA PVs; it imports geecs-core's library modules (`GeecsDb`,
 the server.  See `GEECS-Core/DESIGN.md` and `GeecsCAGateway/README.md` for
 the protocol details that used to be documented here.
 
-**Images: two paths, deliberately separate.** Per-shot *scan data* stays on
+**Images: two paths, deliberately separate — plus the capture daemon
+dual-writing across them (2026-08-27).** Per-shot *scan data* stays on
 the file path — the LabVIEW device writes files, this package's asset
 registry/handlers reference them, Tiled serves them post-hoc. *Live* frames
 are NTNDArray PVs over pvAccess served by `GeecsPvaGateway/` (distributed,
 per camera server, same `pv_naming` namespace). ophyd-async speaks PVA
 natively, so a live-image signal is a stock EPICS signal when a use case
 wants one — never a bespoke transport, and never 2 MB frames through the
-document stream.
+document stream. `geecs_bluesky/capture/` consumes the live-PV path to
+build per-scan frame stacks ALONGSIDE the LV file save (the dual-write
+phase of `Planning/data_capture/01_central_pva_capture_scope.md` — Phase-0
+probes measured the unmodified gateway lossless at 1 Hz); the LV file path
+remains the system of record until the arc's deprecation phase.
 
 ## Test Infrastructure
 

--- a/GeecsBluesky/geecs_bluesky/capture/FORMAT.md
+++ b/GeecsBluesky/geecs_bluesky/capture/FORMAT.md
@@ -1,0 +1,40 @@
+# Capture container format — `geecs-capture/1`
+
+The capture daemon writes **one frame-stack file per device per scan** into
+the engine-created `scans/ScanNNN/<device>/` directory. The *contract* is
+this document plus the provenance attributes stamped into every file — the
+container technology is an implementation detail behind the
+`FrameStackWriter` protocol (`writer.py`), deliberately swappable (e.g. a
+future Zarr writer) without touching the daemon. Readers must dispatch on
+the `schema` attribute, never on the file extension alone.
+
+## v0 container: HDF5 (`<device>.h5`)
+
+| Path | Content |
+|---|---|
+| `/frames` | `(N, H, W)` image stack, native dtype, chunked `(1, H, W)`, appended per frame |
+| `/acq_timestamp` | `(N,)` float64 — the device acquisition timestamp (Unix s; PVA timestamp = LabVIEW time − 2082844800), the universal join key |
+| `/recv_timestamp` | `(N,)` float64 — daemon receive time (Unix s), diagnostic only |
+
+Root attributes: `schema` (`"geecs-capture/1"`), `device`, `experiment`,
+`scan_number`, `source_pv`, `created` (Unix s), and — written at finalize —
+the reconciliation counters `frames_written`, `duplicates_dropped`,
+`stale_skipped`, `writer_queue_drops`, `disconnect_events`, `finalized`
+(bool; absent/False means the daemon died mid-scan and the tail of
+`/frames` is still valid up to `N`).
+
+## Semantics
+
+- **Dedupe by `acq_timestamp`**: the device re-pushes its last frame at
+  1 Hz with an unchanged timestamp when idle (measured 2026-08-27), and the
+  gateway re-posts it. A frame whose timestamp was already written is
+  dropped and counted.
+- **Stale-window filter**: frames stamped earlier than the run's start-doc
+  `time` minus a small margin are the gateway's cached pre-scan frame —
+  skipped and counted, never written.
+- **Append-per-frame with flush** (trailing flush): a crash loses at most
+  the un-flushed tail, never the scan.
+- The daemon **never creates directories**: the engine's save-enable plan
+  owns `scans/ScanNNN/<device>/` creation; a missing directory means the
+  device is skipped loudly (cross-package invariant — analysis/services
+  never create scan folders).

--- a/GeecsBluesky/geecs_bluesky/capture/FORMAT.md
+++ b/GeecsBluesky/geecs_bluesky/capture/FORMAT.md
@@ -18,10 +18,34 @@ the `schema` attribute, never on the file extension alone.
 
 Root attributes: `schema` (`"geecs-capture/1"`), `device`, `experiment`,
 `scan_number`, `source_pv`, `created` (Unix s), and — written at finalize —
-the reconciliation counters `frames_written`, `duplicates_dropped`,
-`stale_skipped`, `writer_queue_drops`, `disconnect_events`, `finalized`
-(bool; absent/False means the daemon died mid-scan and the tail of
-`/frames` is still valid up to `N`).
+the per-device reconciliation counters `frames_received`, `frames_written`,
+`duplicates_dropped`, `stale_skipped`, `shape_errors`, `queue_drops`,
+`late_frames`, `writer_create_failures`, `disconnect_events`, plus
+`finalized` (bool; absent means the daemon died mid-scan, a wedged writer
+prevented safe finalization, or the file belongs to a session closed by a
+mismatched/missing stop document — the tail of `/frames` is still valid up
+to `N`).
+
+**The counter identity** (every received frame lands in exactly one bucket):
+
+```
+frames_received == frames_written + duplicates_dropped + stale_skipped
+                 + shape_errors + queue_drops + late_frames
+                 + writer_create_failures
+```
+
+`late_frames` counts frames delivered after session close (p4p can hand a
+few in-flight events to the callback after unsubscribe) or left unwritten
+behind a wedged writer. `disconnect_events` counts **real** connection
+losses only — the initial not-yet-connected event p4p delivers on every
+healthy subscription is absorbed, so a clean scan reads 0.
+
+Writers are created **lazily on the first accepted frame** (the engine
+creates `scans/ScanNNN/<device>/` after the start document, in the
+save-enable plan): a device that accepts no frames produces **no file at
+all** — readers must treat an absent `<device>.h5` as "not captured", not
+as an error. A file always contains `/frames` (created with the first
+append).
 
 ## Semantics
 
@@ -30,8 +54,15 @@ the reconciliation counters `frames_written`, `duplicates_dropped`,
   gateway re-posts it. A frame whose timestamp was already written is
   dropped and counted.
 - **Stale-window filter**: frames stamped earlier than the run's start-doc
-  `time` minus a small margin are the gateway's cached pre-scan frame —
-  skipped and counted, never written.
+  `time` minus a small margin (2 s) are the gateway's cached pre-scan frame
+  — skipped and counted, never written. The gateway's `(1,1)` placeholder
+  initial post carries timestamp 0.0 and is always filtered. Two documented
+  caveats: (a) if another PVA client (e.g. a live viewer) holds the
+  gateway's gate open between scans, the pre-scan cache refreshes at 1 Hz
+  and a <2 s-old cached frame can pass the filter — it then appears in the
+  stack but not in the LV files, showing as a +1 in the dual-write diff;
+  (b) a camera-server clock lagging the worker by >2 s would stale-drop
+  real first frames — visible as `stale_skipped` > the expected 0–1.
 - **Append-per-frame with flush** (trailing flush): a crash loses at most
   the un-flushed tail, never the scan.
 - The daemon **never creates directories**: the engine's save-enable plan

--- a/GeecsBluesky/geecs_bluesky/capture/FORMAT.md
+++ b/GeecsBluesky/geecs_bluesky/capture/FORMAT.md
@@ -20,7 +20,8 @@ Root attributes: `schema` (`"geecs-capture/1"`), `device`, `experiment`,
 `scan_number`, `source_pv`, `created` (Unix s), and — written at finalize —
 the per-device reconciliation counters `frames_received`, `frames_written`,
 `duplicates_dropped`, `stale_skipped`, `shape_errors`, `queue_drops`,
-`late_frames`, `writer_create_failures`, `disconnect_events`, plus
+`late_frames`, `writer_create_failures`, `append_failures`,
+`disconnect_events`, plus
 `finalized` (bool; absent means the daemon died mid-scan, a wedged writer
 prevented safe finalization, or the file belongs to a session closed by a
 mismatched/missing stop document — the tail of `/frames` is still valid up
@@ -31,8 +32,12 @@ to `N`).
 ```
 frames_received == frames_written + duplicates_dropped + stale_skipped
                  + shape_errors + queue_drops + late_frames
-                 + writer_create_failures
+                 + writer_create_failures + append_failures
 ```
+
+`append_failures` counts frames the writer accepted but could not append
+(an HDF5/NAS write error) — the file's `/frames` tail stays valid; the
+frame is lost from the stack but never from the books.
 
 `late_frames` counts frames delivered after session close (p4p can hand a
 few in-flight events to the callback after unsubscribe) or left unwritten

--- a/GeecsBluesky/geecs_bluesky/capture/__init__.py
+++ b/GeecsBluesky/geecs_bluesky/capture/__init__.py
@@ -1,0 +1,30 @@
+"""Central PVA image capture (the ``capture`` extra: p4p + h5py).
+
+Scan-gated capture daemon: subscribes to Point Grey camera NTNDArray PVs
+during a scan, dedupes on ``acq_timestamp``, and trail-flushes one
+frame-stack file per device per scan (``FORMAT.md`` — schema
+``geecs-capture/1``) into the engine-created scan folders. Runs ALONGSIDE
+the LV per-shot file save (dual-write doctrine); the arc's scope doc is
+``Planning/data_capture/01_central_pva_capture_scope.md``.
+
+Import surface is light: p4p/h5py load lazily inside the classes that need
+them.
+"""
+
+from .daemon import CaptureDaemon, ScanCaptureSession
+from .discovery import CAPTURE_DEVICE_TYPES, CameraTarget, discover_capture_cameras
+from .subscriber import FrameSource, P4pFrameSource
+from .writer import SCHEMA_ID, FrameStackWriter, Hdf5StackWriter
+
+__all__ = [
+    "CAPTURE_DEVICE_TYPES",
+    "SCHEMA_ID",
+    "CameraTarget",
+    "CaptureDaemon",
+    "FrameSource",
+    "FrameStackWriter",
+    "Hdf5StackWriter",
+    "P4pFrameSource",
+    "ScanCaptureSession",
+    "discover_capture_cameras",
+]

--- a/GeecsBluesky/geecs_bluesky/capture/__main__.py
+++ b/GeecsBluesky/geecs_bluesky/capture/__main__.py
@@ -1,0 +1,88 @@
+"""Run the capture daemon: ``python -m geecs_bluesky.capture`` or ``geecs-capture-daemon``.
+
+Wires DB-driven camera discovery, the p4p frame source, and the Bluesky
+document stream (the worker's 0MQ proxy out-port, from the shared
+``[qserver]`` config's ``doc_addr``) into a long-running ``CaptureDaemon``.
+Requires the ``capture`` extra (p4p + h5py) and, for the document stream,
+the worker's proxy reachable on the network.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+
+logger = logging.getLogger(__name__)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point."""
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("--experiment", required=True, help="GEECS experiment name")
+    ap.add_argument(
+        "--doc-addr",
+        default=None,
+        help="document-stream address host:port (default: [qserver] doc_addr)",
+    )
+    ap.add_argument(
+        "--queue-size", type=int, default=100, help="p4p monitor queue depth"
+    )
+    ap.add_argument("--log-level", default="INFO")
+    args = ap.parse_args(argv)
+
+    logging.basicConfig(
+        level=args.log_level.upper(),
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    )
+
+    doc_addr = args.doc_addr
+    if doc_addr is None:
+        from geecs_bluesky.qs_client.client import read_qserver_config
+
+        config = read_qserver_config()
+        if config is None:
+            print(
+                "ERROR: no --doc-addr and no [qserver] section in the shared config",
+                file=sys.stderr,
+            )
+            return 2
+        doc_addr = config.doc_addr
+
+    from .daemon import CaptureDaemon
+    from .discovery import discover_capture_cameras
+    from .subscriber import P4pFrameSource
+
+    targets = discover_capture_cameras(args.experiment)
+    if not targets:
+        print(
+            f"ERROR: no capture-eligible cameras in {args.experiment}", file=sys.stderr
+        )
+        return 2
+
+    daemon = CaptureDaemon(
+        experiment=args.experiment,
+        targets=targets,
+        source_factory=lambda: P4pFrameSource(queue_size=args.queue_size),
+    )
+
+    from bluesky.callbacks.zmq import RemoteDispatcher
+
+    dispatcher = RemoteDispatcher(doc_addr)
+    dispatcher.subscribe(daemon)
+    logger.info(
+        "capture daemon: %d cameras, doc stream %s — running (Ctrl-C to stop)",
+        len(targets),
+        doc_addr,
+    )
+    try:
+        dispatcher.start()  # blocks
+    except KeyboardInterrupt:
+        pass
+    finally:
+        daemon.shutdown()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/GeecsBluesky/geecs_bluesky/capture/__main__.py
+++ b/GeecsBluesky/geecs_bluesky/capture/__main__.py
@@ -5,6 +5,12 @@ document stream (the worker's 0MQ proxy out-port, from the shared
 ``[qserver]`` config's ``doc_addr``) into a long-running ``CaptureDaemon``.
 Requires the ``capture`` extra (p4p + h5py) and, for the document stream,
 the worker's proxy reachable on the network.
+
+Deployment constraint: the start document's ``nonscalar_save_paths`` are
+composed on the WORKER's filesystem view, so the daemon must run on the
+worker box (or a machine sharing its exact mount layout). Discovery hits
+the GEECS DB at startup — off-network this fails after the bounded DB
+connect timeout.
 """
 
 from __future__ import annotations

--- a/GeecsBluesky/geecs_bluesky/capture/daemon.py
+++ b/GeecsBluesky/geecs_bluesky/capture/daemon.py
@@ -11,13 +11,27 @@ engine-created ``scans/ScanNNN/<device>/`` directories.
 Design constraints this module enforces (scope doc,
 ``Planning/data_capture/01_central_pva_capture_scope.md``):
 
-- The daemon NEVER creates scan folders or device directories — a missing
-  directory skips that device loudly (cross-package invariant).
+- The daemon NEVER creates scan folders or device directories — and because
+  the engine creates the device dirs *after* the start document (the
+  save-enable plan runs post-trigger-setup under ``defer_save_on``), writers
+  are constructed **lazily on the first accepted frame**, on the writer
+  thread. First frames can only arrive after save-on, so the directory
+  exists by then; a still-missing directory drops that device's frames with
+  a counted failure, never a ``mkdir``.
 - Frames dedupe on ``acq_timestamp`` (the device re-pushes its last frame
   with an unchanged timestamp when idle) and frames older than the run
-  start are the gateway's cached pre-scan frame — skipped, counted.
-- Writing happens on ONE thread (h5py is not thread-safe); PVA callbacks
-  enqueue into a bounded queue whose overflow is counted, never silent.
+  start are the gateway's cached pre-scan frame — skipped, counted. The
+  gateway's ``(1,1)`` placeholder initial post carries timestamp 0.0 and is
+  therefore always stale-filtered before it could fix dataset geometry.
+- Every h5py call happens on ONE thread (the writer thread), except
+  finalize/abort which run strictly after that thread has been joined; if
+  the join times out (wedged writer — e.g. a NAS hang inside a flush), the
+  files are left un-finalized and untouched rather than contended from a
+  second thread.
+- Every frame is accounted: the per-device counter identity is
+  ``received == written + duplicates_dropped + stale_skipped +
+  shape_errors + queue_drops + late_frames + writer_create_failures``
+  (see ``FORMAT.md``).
 - Phase-1 dual-write doctrine: the LV per-shot file save stays ON; this
   daemon runs alongside and its files are the diff surface, so a daemon
   failure can never lose data.
@@ -29,10 +43,10 @@ import logging
 import queue
 import threading
 import time
-from collections.abc import Mapping
+from collections.abc import Callable, Mapping
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import TYPE_CHECKING, Callable
+from typing import TYPE_CHECKING
 
 from .discovery import CameraTarget
 from .subscriber import FrameSource
@@ -47,7 +61,10 @@ Document = Mapping[str, object]
 
 # Frames stamped earlier than run start minus this margin are the gateway's
 # cached pre-scan frame (or clock skew); the t0-sync doctrine bounds
-# inter-machine skew well under this.
+# inter-machine skew well under this. Caveats documented in FORMAT.md: a
+# viewer-held gate can keep the pre-scan cache <2 s old, and a camera-server
+# clock lagging by >2 s would drop real first frames — both show up as
+# attributable counter entries, not silent loss.
 STALE_MARGIN_S = 2.0
 
 # At 1 Hz the queue never holds more than a few frames; the bound exists so
@@ -61,14 +78,35 @@ WriterFactory = Callable[..., FrameStackWriter]
 class _DeviceCapture:
     """Per-device state within one scan."""
 
-    writer: FrameStackWriter
+    target: CameraTarget
+    save_dir: Path
+    writer: FrameStackWriter | None = None
+    writer_failure_logged: bool = False
     seen_ts: set[float] = field(default_factory=set)
     received: int = 0
     written: int = 0
     duplicates_dropped: int = 0
     stale_skipped: int = 0
     shape_errors: int = 0
+    queue_drops: int = 0
+    late_frames: int = 0
+    writer_create_failures: int = 0
     disconnect_events: int = 0
+    initial_disconnect_absorbed: bool = False
+
+    def counters(self) -> dict[str, int]:
+        """Snapshot the reconciliation counters (call with the session lock held)."""
+        return {
+            "frames_received": self.received,
+            "frames_written": self.written,
+            "duplicates_dropped": self.duplicates_dropped,
+            "stale_skipped": self.stale_skipped,
+            "shape_errors": self.shape_errors,
+            "queue_drops": self.queue_drops,
+            "late_frames": self.late_frames,
+            "writer_create_failures": self.writer_create_failures,
+            "disconnect_events": self.disconnect_events,
+        }
 
 
 class ScanCaptureSession:
@@ -87,48 +125,50 @@ class ScanCaptureSession:
         writer_factory: WriterFactory = Hdf5StackWriter,
     ) -> None:
         self.run_uid = run_uid
+        self._experiment = experiment
+        self._scan_number = scan_number
         self._start_time = start_time
+        self._writer_factory = writer_factory
         self._devices: dict[str, _DeviceCapture] = {}
         self._queue: queue.Queue[tuple[str, "np.ndarray", float, float] | None] = (
             queue.Queue(maxsize=WRITER_QUEUE_MAX)
         )
-        self._queue_drops = 0
+        self._closing = threading.Event()
         self._lock = threading.Lock()
         self._source = source
 
-        captured: list[CameraTarget] = []
         for target in targets:
             save_path = save_paths.get(target.device)
             if save_path is None:
                 continue
-            try:
-                writer = writer_factory(
-                    Path(save_path),
-                    device=target.device,
-                    experiment=experiment,
-                    scan_number=scan_number,
-                    source_pv=target.pv,
-                )
-            except FileNotFoundError as exc:
-                # Never create the dir — the engine owns it. Skip loudly.
-                logger.error("capture skipping %s: %s", target.device, exc)
-                continue
-            self._devices[target.device] = _DeviceCapture(writer=writer)
-            captured.append(target)
+            # No writer construction here: at start-doc time the engine has
+            # not created the device dirs yet (save-enable runs later).
+            self._devices[target.device] = _DeviceCapture(
+                target=target, save_dir=Path(save_path)
+            )
 
         self._writer_thread = threading.Thread(
             target=self._drain, name="capture-writer", daemon=True
         )
         self._writer_thread.start()
-        if captured:
-            self._source.subscribe(captured, self._on_frame, self._on_connection)
+        if self._devices:
+            try:
+                self._source.subscribe(
+                    [dev.target for dev in self._devices.values()],
+                    self._on_frame,
+                    self._on_connection,
+                )
+            except Exception:
+                # Fail the session cleanly: stop the writer thread first so
+                # nothing leaks, then let the daemon's catch log it.
+                self._stop_writer_thread()
+                raise
         logger.info(
-            "capture session %s: scan %s, %d/%d cameras (%s)",
+            "capture session %s: scan %s, %d camera(s): %s",
             run_uid[:8],
             scan_number,
-            len(captured),
-            len(targets),
-            ", ".join(t.device for t in captured) or "none",
+            len(self._devices),
+            ", ".join(sorted(self._devices)) or "none",
         )
 
     # -- callbacks (p4p threads) -------------------------------------------
@@ -152,54 +192,120 @@ class ScanCaptureSession:
             self._queue.put_nowait((device, frame, acq_ts, recv_ts))
         except queue.Full:
             with self._lock:
-                self._queue_drops += 1
+                dev.queue_drops += 1
                 dev.seen_ts.discard(acq_ts)  # not written — keep books honest
             logger.error("capture writer queue full — dropped %s frame", device)
 
     def _on_connection(self, device: str, connected: bool) -> None:
         dev = self._devices.get(device)
-        if dev is not None and not connected:
-            with self._lock:
-                dev.disconnect_events += 1
+        if dev is None or connected:
+            return
+        with self._lock:
+            # p4p's notify_disconnect delivers one initial Disconnected at
+            # subscribe time on every healthy monitor — absorb it so
+            # disconnect_events counts real losses only (FORMAT.md).
+            if not dev.initial_disconnect_absorbed and dev.received == 0:
+                dev.initial_disconnect_absorbed = True
+                return
+            dev.disconnect_events += 1
 
-    # -- writer thread ------------------------------------------------------
+    # -- writer thread (the ONLY thread that touches h5py while running) ----
 
     def _drain(self) -> None:
         while True:
-            item = self._queue.get()
+            try:
+                item = self._queue.get(timeout=0.5)
+            except queue.Empty:
+                if self._closing.is_set():
+                    return
+                continue
             if item is None:
                 return
             device, frame, acq_ts, recv_ts = item
             dev = self._devices[device]
+            if dev.writer is None and not self._create_writer(dev, acq_ts):
+                continue
             try:
-                dev.writer.append(frame, acq_ts, recv_ts)
-                dev.written += 1
+                dev.writer.append(frame, acq_ts, recv_ts)  # type: ignore[union-attr]
+                with self._lock:
+                    dev.written += 1
             except ValueError:
-                dev.shape_errors += 1
+                with self._lock:
+                    dev.shape_errors += 1
                 logger.warning("capture %s: frame shape mismatch dropped", device)
             except Exception:  # noqa: BLE001 - one bad frame must not kill the scan
                 logger.exception("capture %s: writer append failed", device)
+
+    def _create_writer(self, dev: _DeviceCapture, acq_ts: float) -> bool:
+        """Lazily build *dev*'s writer; on failure drop the frame, counted."""
+        try:
+            dev.writer = self._writer_factory(
+                dev.save_dir,
+                device=dev.target.device,
+                experiment=self._experiment,
+                scan_number=self._scan_number,
+                source_pv=dev.target.pv,
+            )
+            return True
+        except Exception:  # noqa: BLE001 - incl. FileNotFoundError, OSError, h5py errors
+            with self._lock:
+                dev.writer_create_failures += 1
+                dev.seen_ts.discard(acq_ts)
+            if not dev.writer_failure_logged:
+                dev.writer_failure_logged = True
+                logger.error(
+                    "capture %s: writer creation failed (dir %s) — frames will "
+                    "drop, counted, until it succeeds; the daemon never "
+                    "creates directories",
+                    dev.target.device,
+                    dev.save_dir,
+                    exc_info=True,
+                )
+            return False
+
+    def _stop_writer_thread(self) -> bool:
+        """Signal and join the writer thread; return True if it exited."""
+        try:
+            self._queue.put_nowait(None)
+        except queue.Full:
+            pass  # the closing event below still ends the drain loop
+        self._closing.set()
+        self._writer_thread.join(timeout=30.0)
+        return not self._writer_thread.is_alive()
 
     # -- lifecycle ----------------------------------------------------------
 
     def close(self, *, finalized: bool) -> dict[str, dict[str, int]]:
         """Unsubscribe, drain, finalize (or abort) writers; return counters."""
         self._source.close()
-        self._queue.put(None)
-        self._writer_thread.join(timeout=30.0)
-        if self._writer_thread.is_alive():
-            logger.error("capture writer thread did not drain within 30 s")
+        drained = self._stop_writer_thread()
+        if not drained:
+            logger.error(
+                "capture writer thread did not drain within 30 s — leaving "
+                "files un-finalized and untouched (a wedged writer may still "
+                "hold the HDF5 lock)"
+            )
+        # Frames still in the queue were never written: late deliveries after
+        # unsubscribe (p4p can deliver a few in-flight events after close())
+        # or residue behind a wedged writer. Count them so the books close.
+        while True:
+            try:
+                item = self._queue.get_nowait()
+            except queue.Empty:
+                break
+            if item is None:
+                continue
+            dev = self._devices.get(item[0])
+            if dev is not None:
+                with self._lock:
+                    dev.late_frames += 1
         summary: dict[str, dict[str, int]] = {}
         for device, dev in self._devices.items():
-            counters = {
-                "frames_written": dev.written,
-                "frames_received": dev.received,
-                "duplicates_dropped": dev.duplicates_dropped,
-                "stale_skipped": dev.stale_skipped,
-                "shape_errors": dev.shape_errors,
-                "writer_queue_drops": self._queue_drops,
-                "disconnect_events": dev.disconnect_events,
-            }
+            with self._lock:
+                counters = dev.counters()
+            summary[device] = counters
+            if dev.writer is None or not drained:
+                continue  # no file, or unsafe to touch it from this thread
             try:
                 if finalized:
                     dev.writer.finalize(counters)
@@ -207,7 +313,6 @@ class ScanCaptureSession:
                     dev.writer.abort()
             except Exception:  # noqa: BLE001 - close every writer regardless
                 logger.exception("capture %s: writer close failed", device)
-            summary[device] = counters
         return summary
 
 
@@ -279,25 +384,30 @@ class CaptureDaemon:
         if session is None:
             return
         run_start = doc.get("run_start")
-        if isinstance(run_start, str) and run_start != session.run_uid:
+        matched = not isinstance(run_start, str) or run_start == session.run_uid
+        if not matched:
             logger.warning(
-                "stop for %s does not match open session %s — closing anyway",
-                run_start[:8],
+                "stop for %s does not match open session %s — closing "
+                "UN-finalized (never stamp the wrong run's files)",
+                str(run_start)[:8],
                 session.run_uid[:8],
             )
-        summary = session.close(finalized=True)
+        summary = session.close(finalized=matched)
         self._session = None
         for device, counters in sorted(summary.items()):
             logger.info(
                 "capture reconciliation %s: written=%d received=%d dup=%d "
-                "stale=%d shape_err=%d q_drops=%d disconnects=%d",
+                "stale=%d shape_err=%d q_drops=%d late=%d create_fail=%d "
+                "disconnects=%d",
                 device,
                 counters["frames_written"],
                 counters["frames_received"],
                 counters["duplicates_dropped"],
                 counters["stale_skipped"],
                 counters["shape_errors"],
-                counters["writer_queue_drops"],
+                counters["queue_drops"],
+                counters["late_frames"],
+                counters["writer_create_failures"],
                 counters["disconnect_events"],
             )
 

--- a/GeecsBluesky/geecs_bluesky/capture/daemon.py
+++ b/GeecsBluesky/geecs_bluesky/capture/daemon.py
@@ -1,0 +1,308 @@
+"""The capture daemon: scan-gated central image capture over PVA.
+
+One ``CaptureDaemon`` consumes the worker's Bluesky document stream and, for
+every run whose start document carries ``nonscalar_save_paths``, opens a
+``ScanCaptureSession``: PVA subscriptions on the run's capture-eligible
+cameras (scan-gated per the design decision — the gateway's gate opens on
+first subscriber), an ``acq_timestamp`` dedupe + stale-window filter, and a
+single writer thread trail-flushing one frame-stack file per device into the
+engine-created ``scans/ScanNNN/<device>/`` directories.
+
+Design constraints this module enforces (scope doc,
+``Planning/data_capture/01_central_pva_capture_scope.md``):
+
+- The daemon NEVER creates scan folders or device directories — a missing
+  directory skips that device loudly (cross-package invariant).
+- Frames dedupe on ``acq_timestamp`` (the device re-pushes its last frame
+  with an unchanged timestamp when idle) and frames older than the run
+  start are the gateway's cached pre-scan frame — skipped, counted.
+- Writing happens on ONE thread (h5py is not thread-safe); PVA callbacks
+  enqueue into a bounded queue whose overflow is counted, never silent.
+- Phase-1 dual-write doctrine: the LV per-shot file save stays ON; this
+  daemon runs alongside and its files are the diff surface, so a daemon
+  failure can never lose data.
+"""
+
+from __future__ import annotations
+
+import logging
+import queue
+import threading
+import time
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import TYPE_CHECKING, Callable
+
+from .discovery import CameraTarget
+from .subscriber import FrameSource
+from .writer import FrameStackWriter, Hdf5StackWriter
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    import numpy as np
+
+logger = logging.getLogger(__name__)
+
+Document = Mapping[str, object]
+
+# Frames stamped earlier than run start minus this margin are the gateway's
+# cached pre-scan frame (or clock skew); the t0-sync doctrine bounds
+# inter-machine skew well under this.
+STALE_MARGIN_S = 2.0
+
+# At 1 Hz the queue never holds more than a few frames; the bound exists so
+# a wedged writer surfaces as a counted drop, not unbounded RAM growth.
+WRITER_QUEUE_MAX = 256
+
+WriterFactory = Callable[..., FrameStackWriter]
+
+
+@dataclass
+class _DeviceCapture:
+    """Per-device state within one scan."""
+
+    writer: FrameStackWriter
+    seen_ts: set[float] = field(default_factory=set)
+    received: int = 0
+    written: int = 0
+    duplicates_dropped: int = 0
+    stale_skipped: int = 0
+    shape_errors: int = 0
+    disconnect_events: int = 0
+
+
+class ScanCaptureSession:
+    """Capture for one run: subscriptions, dedupe, one writer thread."""
+
+    def __init__(
+        self,
+        *,
+        run_uid: str,
+        experiment: str,
+        scan_number: int | None,
+        start_time: float,
+        targets: list[CameraTarget],
+        save_paths: Mapping[str, str],
+        source: FrameSource,
+        writer_factory: WriterFactory = Hdf5StackWriter,
+    ) -> None:
+        self.run_uid = run_uid
+        self._start_time = start_time
+        self._devices: dict[str, _DeviceCapture] = {}
+        self._queue: queue.Queue[tuple[str, "np.ndarray", float, float] | None] = (
+            queue.Queue(maxsize=WRITER_QUEUE_MAX)
+        )
+        self._queue_drops = 0
+        self._lock = threading.Lock()
+        self._source = source
+
+        captured: list[CameraTarget] = []
+        for target in targets:
+            save_path = save_paths.get(target.device)
+            if save_path is None:
+                continue
+            try:
+                writer = writer_factory(
+                    Path(save_path),
+                    device=target.device,
+                    experiment=experiment,
+                    scan_number=scan_number,
+                    source_pv=target.pv,
+                )
+            except FileNotFoundError as exc:
+                # Never create the dir — the engine owns it. Skip loudly.
+                logger.error("capture skipping %s: %s", target.device, exc)
+                continue
+            self._devices[target.device] = _DeviceCapture(writer=writer)
+            captured.append(target)
+
+        self._writer_thread = threading.Thread(
+            target=self._drain, name="capture-writer", daemon=True
+        )
+        self._writer_thread.start()
+        if captured:
+            self._source.subscribe(captured, self._on_frame, self._on_connection)
+        logger.info(
+            "capture session %s: scan %s, %d/%d cameras (%s)",
+            run_uid[:8],
+            scan_number,
+            len(captured),
+            len(targets),
+            ", ".join(t.device for t in captured) or "none",
+        )
+
+    # -- callbacks (p4p threads) -------------------------------------------
+
+    def _on_frame(
+        self, device: str, frame: "np.ndarray", acq_ts: float, recv_ts: float
+    ) -> None:
+        dev = self._devices.get(device)
+        if dev is None:
+            return
+        with self._lock:
+            dev.received += 1
+            if acq_ts < self._start_time - STALE_MARGIN_S:
+                dev.stale_skipped += 1
+                return
+            if acq_ts in dev.seen_ts:
+                dev.duplicates_dropped += 1
+                return
+            dev.seen_ts.add(acq_ts)
+        try:
+            self._queue.put_nowait((device, frame, acq_ts, recv_ts))
+        except queue.Full:
+            with self._lock:
+                self._queue_drops += 1
+                dev.seen_ts.discard(acq_ts)  # not written — keep books honest
+            logger.error("capture writer queue full — dropped %s frame", device)
+
+    def _on_connection(self, device: str, connected: bool) -> None:
+        dev = self._devices.get(device)
+        if dev is not None and not connected:
+            with self._lock:
+                dev.disconnect_events += 1
+
+    # -- writer thread ------------------------------------------------------
+
+    def _drain(self) -> None:
+        while True:
+            item = self._queue.get()
+            if item is None:
+                return
+            device, frame, acq_ts, recv_ts = item
+            dev = self._devices[device]
+            try:
+                dev.writer.append(frame, acq_ts, recv_ts)
+                dev.written += 1
+            except ValueError:
+                dev.shape_errors += 1
+                logger.warning("capture %s: frame shape mismatch dropped", device)
+            except Exception:  # noqa: BLE001 - one bad frame must not kill the scan
+                logger.exception("capture %s: writer append failed", device)
+
+    # -- lifecycle ----------------------------------------------------------
+
+    def close(self, *, finalized: bool) -> dict[str, dict[str, int]]:
+        """Unsubscribe, drain, finalize (or abort) writers; return counters."""
+        self._source.close()
+        self._queue.put(None)
+        self._writer_thread.join(timeout=30.0)
+        if self._writer_thread.is_alive():
+            logger.error("capture writer thread did not drain within 30 s")
+        summary: dict[str, dict[str, int]] = {}
+        for device, dev in self._devices.items():
+            counters = {
+                "frames_written": dev.written,
+                "frames_received": dev.received,
+                "duplicates_dropped": dev.duplicates_dropped,
+                "stale_skipped": dev.stale_skipped,
+                "shape_errors": dev.shape_errors,
+                "writer_queue_drops": self._queue_drops,
+                "disconnect_events": dev.disconnect_events,
+            }
+            try:
+                if finalized:
+                    dev.writer.finalize(counters)
+                else:
+                    dev.writer.abort()
+            except Exception:  # noqa: BLE001 - close every writer regardless
+                logger.exception("capture %s: writer close failed", device)
+            summary[device] = counters
+        return summary
+
+
+class CaptureDaemon:
+    """Document-stream consumer that opens one capture session per run.
+
+    Best-effort like ``SFileExportCallback``: a failure is logged and never
+    raised back into the dispatcher. One session runs at a time (the
+    queueserver serializes runs); an unexpected second start closes the
+    first session un-finalized rather than interleaving.
+    """
+
+    def __init__(
+        self,
+        *,
+        experiment: str,
+        targets: list[CameraTarget],
+        source_factory: Callable[[], FrameSource],
+        writer_factory: WriterFactory = Hdf5StackWriter,
+    ) -> None:
+        self._experiment = experiment
+        self._targets = targets
+        self._source_factory = source_factory
+        self._writer_factory = writer_factory
+        self._session: ScanCaptureSession | None = None
+
+    def __call__(self, name: str, doc: Document) -> None:
+        """Handle one document from the stream."""
+        try:
+            if name == "start":
+                self._on_start(doc)
+            elif name == "stop":
+                self._on_stop(doc)
+        except Exception:
+            logger.exception("capture daemon failed handling %s document", name)
+
+    def _on_start(self, doc: Document) -> None:
+        save_paths = doc.get("nonscalar_save_paths")
+        if not isinstance(save_paths, Mapping) or not save_paths:
+            return
+        uid = doc.get("uid")
+        if not isinstance(uid, str):
+            return
+        if self._session is not None:
+            logger.error(
+                "start %s arrived with session %s open — closing un-finalized",
+                uid[:8],
+                self._session.run_uid[:8],
+            )
+            self._session.close(finalized=False)
+            self._session = None
+        scan_number = doc.get("scan_number")
+        start_time = doc.get("time")
+        self._session = ScanCaptureSession(
+            run_uid=uid,
+            experiment=str(doc.get("experiment") or self._experiment),
+            scan_number=scan_number if isinstance(scan_number, int) else None,
+            start_time=float(start_time)
+            if isinstance(start_time, (int, float))
+            else time.time(),
+            targets=self._targets,
+            save_paths={str(k): str(v) for k, v in save_paths.items()},
+            source=self._source_factory(),
+            writer_factory=self._writer_factory,
+        )
+
+    def _on_stop(self, doc: Document) -> None:
+        session = self._session
+        if session is None:
+            return
+        run_start = doc.get("run_start")
+        if isinstance(run_start, str) and run_start != session.run_uid:
+            logger.warning(
+                "stop for %s does not match open session %s — closing anyway",
+                run_start[:8],
+                session.run_uid[:8],
+            )
+        summary = session.close(finalized=True)
+        self._session = None
+        for device, counters in sorted(summary.items()):
+            logger.info(
+                "capture reconciliation %s: written=%d received=%d dup=%d "
+                "stale=%d shape_err=%d q_drops=%d disconnects=%d",
+                device,
+                counters["frames_written"],
+                counters["frames_received"],
+                counters["duplicates_dropped"],
+                counters["stale_skipped"],
+                counters["shape_errors"],
+                counters["writer_queue_drops"],
+                counters["disconnect_events"],
+            )
+
+    def shutdown(self) -> None:
+        """Close any open session un-finalized (daemon exit)."""
+        if self._session is not None:
+            self._session.close(finalized=False)
+            self._session = None

--- a/GeecsBluesky/geecs_bluesky/capture/daemon.py
+++ b/GeecsBluesky/geecs_bluesky/capture/daemon.py
@@ -30,8 +30,8 @@ Design constraints this module enforces (scope doc,
   second thread.
 - Every frame is accounted: the per-device counter identity is
   ``received == written + duplicates_dropped + stale_skipped +
-  shape_errors + queue_drops + late_frames + writer_create_failures``
-  (see ``FORMAT.md``).
+  shape_errors + queue_drops + late_frames + writer_create_failures +
+  append_failures`` (see ``FORMAT.md``).
 - Phase-1 dual-write doctrine: the LV per-shot file save stays ON; this
   daemon runs alongside and its files are the diff surface, so a daemon
   failure can never lose data.
@@ -91,6 +91,7 @@ class _DeviceCapture:
     queue_drops: int = 0
     late_frames: int = 0
     writer_create_failures: int = 0
+    append_failures: int = 0
     disconnect_events: int = 0
     initial_disconnect_absorbed: bool = False
 
@@ -105,6 +106,7 @@ class _DeviceCapture:
             "queue_drops": self.queue_drops,
             "late_frames": self.late_frames,
             "writer_create_failures": self.writer_create_failures,
+            "append_failures": self.append_failures,
             "disconnect_events": self.disconnect_events,
         }
 
@@ -234,6 +236,8 @@ class ScanCaptureSession:
                     dev.shape_errors += 1
                 logger.warning("capture %s: frame shape mismatch dropped", device)
             except Exception:  # noqa: BLE001 - one bad frame must not kill the scan
+                with self._lock:
+                    dev.append_failures += 1
                 logger.exception("capture %s: writer append failed", device)
 
     def _create_writer(self, dev: _DeviceCapture, acq_ts: float) -> bool:
@@ -398,7 +402,7 @@ class CaptureDaemon:
             logger.info(
                 "capture reconciliation %s: written=%d received=%d dup=%d "
                 "stale=%d shape_err=%d q_drops=%d late=%d create_fail=%d "
-                "disconnects=%d",
+                "append_fail=%d disconnects=%d",
                 device,
                 counters["frames_written"],
                 counters["frames_received"],
@@ -408,6 +412,7 @@ class CaptureDaemon:
                 counters["queue_drops"],
                 counters["late_frames"],
                 counters["writer_create_failures"],
+                counters["append_failures"],
                 counters["disconnect_events"],
             )
 

--- a/GeecsBluesky/geecs_bluesky/capture/discovery.py
+++ b/GeecsBluesky/geecs_bluesky/capture/discovery.py
@@ -1,0 +1,79 @@
+"""Devicetype-keyed discovery of capture-eligible cameras.
+
+Eligibility v0: the device's GEECS devicetype appears in
+``CAPTURE_DEVICE_TYPES`` (today: Point Grey cameras — ~90% of scan data by
+the owner's estimate; proprietary-format devices keep the legacy per-shot
+file save). The registry maps devicetype → the image variable the PVA
+gateway serves for it, so PV names compose from ``geecs_core.pv_naming``
+without importing any gateway code (dependency-graph rule: gateways are
+consumed as services, never imported).
+
+Uses the batch ``GeecsDb.get_experiment_device_types`` /
+``get_experiment_devices`` queries — two connections total, never one per
+device.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+
+from geecs_core.db.geecs_db import GeecsDb
+from geecs_core.pv_naming import pv_name
+
+from geecs_bluesky.assets.specs import POINTGREY_CAMERA_DEVICE_TYPE
+
+logger = logging.getLogger(__name__)
+
+# devicetype -> the GEECS image variable name the PVA gateway serves for it.
+CAPTURE_DEVICE_TYPES: dict[str, str] = {
+    POINTGREY_CAMERA_DEVICE_TYPE: "image",
+}
+
+
+@dataclass(frozen=True)
+class CameraTarget:
+    """One capture-eligible camera: identity plus its PVA coordinates."""
+
+    device: str
+    device_type: str
+    pv: str
+    server_ip: str
+
+
+def discover_capture_cameras(experiment: str) -> list[CameraTarget]:
+    """Return every capture-eligible camera in *experiment*, sorted by device.
+
+    Two batched DB queries; a device whose endpoint row is missing is
+    skipped with a warning (it cannot be reached over PVA anyway).
+    """
+    device_types = GeecsDb.get_experiment_device_types(experiment)
+    endpoints = GeecsDb.get_experiment_devices(experiment)
+    targets: list[CameraTarget] = []
+    for device, dtype in sorted(device_types.items()):
+        image_var = CAPTURE_DEVICE_TYPES.get(dtype)
+        if image_var is None:
+            continue
+        endpoint = endpoints.get(device)
+        if endpoint is None:
+            logger.warning(
+                "capture-eligible device %s (%s) has no endpoint row — skipped",
+                device,
+                dtype,
+            )
+            continue
+        targets.append(
+            CameraTarget(
+                device=device,
+                device_type=dtype,
+                pv=pv_name(experiment, device, image_var),
+                server_ip=endpoint[0],
+            )
+        )
+    logger.info(
+        "capture discovery: %d eligible cameras of %d devices in %s",
+        len(targets),
+        len(device_types),
+        experiment,
+    )
+    return targets

--- a/GeecsBluesky/geecs_bluesky/capture/discovery.py
+++ b/GeecsBluesky/geecs_bluesky/capture/discovery.py
@@ -49,6 +49,7 @@ def discover_capture_cameras(experiment: str) -> list[CameraTarget]:
     """
     device_types = GeecsDb.get_experiment_device_types(experiment)
     endpoints = GeecsDb.get_experiment_devices(experiment)
+    device_variables = GeecsDb.get_experiment_device_variables(experiment)
     targets: list[CameraTarget] = []
     for device, dtype in sorted(device_types.items()):
         image_var = CAPTURE_DEVICE_TYPES.get(dtype)
@@ -62,6 +63,18 @@ def discover_capture_cameras(experiment: str) -> list[CameraTarget]:
                 dtype,
             )
             continue
+        # Loud-warning cross-check: the registry hardcodes the image variable
+        # per devicetype; a device whose DB variables don't include it shows
+        # the silent dead-PV signature (0 frames) at capture time.
+        var_names = {m.get("name") for m in device_variables.get(device, [])}
+        if var_names and image_var not in var_names:
+            logger.warning(
+                "capture %s: registry image variable %r not among its DB "
+                "variables — expect a dead PV (0 frames) unless the registry "
+                "mapping is corrected",
+                device,
+                image_var,
+            )
         targets.append(
             CameraTarget(
                 device=device,

--- a/GeecsBluesky/geecs_bluesky/capture/subscriber.py
+++ b/GeecsBluesky/geecs_bluesky/capture/subscriber.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import logging
 import os
 import threading
+import time
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any, Protocol
 
@@ -123,10 +124,9 @@ class _MonitorHandler:
 
     def __call__(self, value: Any) -> None:  # p4p ntndarray or Disconnected
         """Handle one monitor delivery on a p4p worker thread."""
-        import time
-
         if isinstance(value, Exception):
-            # Includes the initial not-yet-connected Disconnected event.
+            # Includes the initial not-yet-connected Disconnected event
+            # (absorbed by the session so healthy scans count 0 — FORMAT.md).
             self._on_connection(self._device, False)
             return
         ts = getattr(value, "timestamp", None)

--- a/GeecsBluesky/geecs_bluesky/capture/subscriber.py
+++ b/GeecsBluesky/geecs_bluesky/capture/subscriber.py
@@ -1,0 +1,136 @@
+"""PVA frame source: the p4p seam of the capture daemon.
+
+``FrameSource`` is the test seam — capture logic (`daemon.py`) never touches
+p4p directly, so hermetic tests drive a fake source. ``P4pFrameSource`` is
+the production implementation: one deep-queue monitor per camera against the
+GeecsPvaGateway fleet.
+
+Empirical basis (Phase-0 probes, 2026-08-27): the unmodified gateway
+delivers every frame at 1 Hz even to default-queue clients; the deep
+``record[queueSize=N]`` request is burst margin, not a correctness
+requirement at current rates.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import threading
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any, Protocol
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    import numpy as np
+
+    from .discovery import CameraTarget
+
+logger = logging.getLogger(__name__)
+
+# device, frame, acq_timestamp (Unix s), recv_timestamp (Unix s)
+FrameCallback = Callable[[str, "np.ndarray", float, float], None]
+# device, connected (False on a Disconnected event)
+ConnectionCallback = Callable[[str, bool], None]
+
+
+class FrameSource(Protocol):
+    """Something that can stream camera frames to a callback."""
+
+    def subscribe(
+        self,
+        targets: list["CameraTarget"],
+        on_frame: FrameCallback,
+        on_connection: ConnectionCallback,
+    ) -> None:
+        """Open one monitor per target; callbacks may fire from any thread."""
+        ...
+
+    def close(self) -> None:
+        """Tear down every monitor (idempotent)."""
+        ...
+
+
+class P4pFrameSource:
+    """Deep-queue p4p monitors against the distributed PVA gateway fleet."""
+
+    def __init__(self, *, queue_size: int = 100) -> None:
+        self._queue_size = queue_size
+        self._ctx: Any = None  # p4p.client.thread.Context; Any: p4p is lazy
+        self._subs: list[Any] = []  # p4p Subscription handles
+        self._lock = threading.Lock()
+
+    def subscribe(
+        self,
+        targets: list["CameraTarget"],
+        on_frame: FrameCallback,
+        on_connection: ConnectionCallback,
+    ) -> None:
+        """Open monitors for *targets*, building the address list from them.
+
+        ``EPICS_PVA_ADDR_LIST`` is composed from the targets' camera-server
+        IPs and must be in place before the p4p Context exists — the fleet
+        spans subnets, so broadcast search cannot find it.
+        """
+        with self._lock:
+            if self._ctx is not None:
+                raise RuntimeError("P4pFrameSource is already subscribed")
+            addr_list = " ".join(sorted({t.server_ip for t in targets}))
+            os.environ["EPICS_PVA_ADDR_LIST"] = addr_list
+            os.environ["EPICS_PVA_AUTO_ADDR_LIST"] = "NO"
+            from p4p.client.thread import Context
+
+            self._ctx = Context("pva")
+            request = f"record[queueSize={self._queue_size}]field()"
+            for target in targets:
+                handler = _MonitorHandler(target.device, on_frame, on_connection)
+                self._subs.append(
+                    self._ctx.monitor(
+                        target.pv,
+                        handler,
+                        request=request,
+                        notify_disconnect=True,
+                    )
+                )
+            logger.info(
+                "PVA source: %d monitors (queueSize=%d, addr_list=%s)",
+                len(self._subs),
+                self._queue_size,
+                addr_list,
+            )
+
+    def close(self) -> None:
+        """Close all monitors and the context (idempotent)."""
+        with self._lock:
+            for sub in self._subs:
+                try:
+                    sub.close()
+                except Exception:  # noqa: BLE001 - best-effort shutdown
+                    logger.warning("PVA subscription close failed", exc_info=True)
+            self._subs.clear()
+            if self._ctx is not None:
+                self._ctx.close()
+                self._ctx = None
+
+
+class _MonitorHandler:
+    """Per-camera p4p monitor callback: unwrap, timestamp, forward."""
+
+    def __init__(
+        self, device: str, on_frame: FrameCallback, on_connection: ConnectionCallback
+    ) -> None:
+        self._device = device
+        self._on_frame = on_frame
+        self._on_connection = on_connection
+
+    def __call__(self, value: Any) -> None:  # p4p ntndarray or Disconnected
+        """Handle one monitor delivery on a p4p worker thread."""
+        import time
+
+        if isinstance(value, Exception):
+            # Includes the initial not-yet-connected Disconnected event.
+            self._on_connection(self._device, False)
+            return
+        ts = getattr(value, "timestamp", None)
+        if ts is None:
+            logger.warning("%s: frame without timestamp dropped", self._device)
+            return
+        self._on_frame(self._device, value, float(ts), time.time())

--- a/GeecsBluesky/geecs_bluesky/capture/writer.py
+++ b/GeecsBluesky/geecs_bluesky/capture/writer.py
@@ -1,0 +1,135 @@
+"""Frame-stack writers: the container seam of the capture daemon.
+
+``FrameStackWriter`` is the deliberate format-agnostic boundary — the daemon
+talks only to this protocol, so the container technology (HDF5 today, e.g.
+Zarr tomorrow) can change without touching capture logic. The contract lives
+in ``FORMAT.md`` next to this module; every file is self-describing via its
+``schema`` attribute.
+
+``h5py`` rides the ``capture`` extra and is imported lazily so the package
+import stays light for non-capture consumers.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from pathlib import Path
+from typing import TYPE_CHECKING, Protocol
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    import numpy as np
+
+logger = logging.getLogger(__name__)
+
+SCHEMA_ID = "geecs-capture/1"
+
+
+class FrameStackWriter(Protocol):
+    """One device's frame-stack file for one scan."""
+
+    def append(
+        self, frame: "np.ndarray", acq_timestamp: float, recv_timestamp: float
+    ) -> None:
+        """Append one frame with its timestamps."""
+        ...
+
+    def finalize(self, counters: dict[str, int]) -> int:
+        """Stamp reconciliation *counters*, mark finalized, close; return frame count."""
+        ...
+
+    def abort(self) -> None:
+        """Close without marking finalized (daemon shutdown mid-scan)."""
+        ...
+
+
+class Hdf5StackWriter:
+    """The v0 ``FrameStackWriter``: one ``<device>.h5`` per device per scan.
+
+    The target directory must already exist — the engine's save-enable plan
+    owns ``scans/ScanNNN/<device>/`` creation and this class refuses to
+    create it (cross-package invariant).
+    """
+
+    def __init__(
+        self,
+        target_dir: Path,
+        *,
+        device: str,
+        experiment: str,
+        scan_number: int | None,
+        source_pv: str,
+    ) -> None:
+        if not target_dir.is_dir():
+            raise FileNotFoundError(
+                f"capture target dir missing (never created by the daemon): {target_dir}"
+            )
+        import h5py
+
+        self._path = target_dir / f"{device}.h5"
+        # libver="latest" enables efficient appends; flush-per-append keeps
+        # the crash window to the unflushed tail (trailing-flush design).
+        self._h5 = h5py.File(self._path, "w", libver="latest")
+        self._h5.attrs["schema"] = SCHEMA_ID
+        self._h5.attrs["device"] = device
+        self._h5.attrs["experiment"] = experiment
+        if scan_number is not None:
+            self._h5.attrs["scan_number"] = scan_number
+        self._h5.attrs["source_pv"] = source_pv
+        self._h5.attrs["created"] = time.time()
+        self._frames = None
+        self._acq = self._h5.create_dataset(
+            "acq_timestamp", shape=(0,), maxshape=(None,), dtype="f8"
+        )
+        self._recv = self._h5.create_dataset(
+            "recv_timestamp", shape=(0,), maxshape=(None,), dtype="f8"
+        )
+        self._n = 0
+
+    @property
+    def path(self) -> Path:
+        """The file being written."""
+        return self._path
+
+    def append(
+        self, frame: "np.ndarray", acq_timestamp: float, recv_timestamp: float
+    ) -> None:
+        """Append one frame; dataset geometry is fixed by the first frame."""
+        if self._frames is None:
+            self._frames = self._h5.create_dataset(
+                "frames",
+                shape=(0, *frame.shape),
+                maxshape=(None, *frame.shape),
+                chunks=(1, *frame.shape),
+                dtype=frame.dtype,
+            )
+        if frame.shape != self._frames.shape[1:]:
+            # A mid-scan ROI/binning change breaks the stack contract —
+            # count upstream, never write a mismatched frame.
+            raise ValueError(
+                f"frame shape {frame.shape} != stack shape {self._frames.shape[1:]}"
+            )
+        n = self._n
+        self._frames.resize(n + 1, axis=0)
+        self._frames[n] = frame
+        self._acq.resize(n + 1, axis=0)
+        self._acq[n] = acq_timestamp
+        self._recv.resize(n + 1, axis=0)
+        self._recv[n] = recv_timestamp
+        self._n = n + 1
+        self._h5.flush()
+
+    def finalize(self, counters: dict[str, int]) -> int:
+        """Stamp *counters* + ``finalized=True`` and close; return frame count."""
+        for key, value in counters.items():
+            self._h5.attrs[key] = value
+        self._h5.attrs["finalized"] = True
+        self._h5.close()
+        return self._n
+
+    def abort(self) -> None:
+        """Close without the finalized stamp (data written so far stays valid)."""
+        try:
+            self._h5.close()
+        except Exception:  # noqa: BLE001 - best-effort shutdown
+            logger.warning("Hdf5StackWriter abort close failed for %s", self._path)

--- a/GeecsBluesky/poetry.lock
+++ b/GeecsBluesky/poetry.lock
@@ -463,7 +463,7 @@ description = "Foreign Function Interface for Python calling C code."
 optional = true
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "(extra == \"qserver\" or extra == \"qs-client\") and implementation_name == \"pypy\" or extra == \"optimize\""
+markers = "(extra == \"qserver\" or extra == \"qs-client\" or extra == \"capture\") and implementation_name == \"pypy\" or extra == \"optimize\""
 files = [
     {file = "cffi-2.0.0-cp310-cp310-macosx_10_13_x86_64.whl", hash = "sha256:0cf2d91ecc3fcc0625c2c530fe004f82c110405f101548512cce44322fa8ac44"},
     {file = "cffi-2.0.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:f73b96c41e3b2adedc34a7356e64c8eb96e03a3782b535e043a986276ce12a49"},
@@ -4719,7 +4719,7 @@ description = "C parser in Python"
 optional = true
 python-versions = ">=3.10"
 groups = ["main"]
-markers = "(extra == \"qserver\" or extra == \"qs-client\") and implementation_name == \"pypy\" or extra == \"optimize\" and implementation_name != \"PyPy\""
+markers = "(extra == \"qserver\" or extra == \"qs-client\" or extra == \"capture\") and implementation_name == \"pypy\" or extra == \"optimize\" and implementation_name != \"PyPy\""
 files = [
     {file = "pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992"},
     {file = "pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29"},
@@ -5309,7 +5309,7 @@ description = "Python bindings for 0MQ"
 optional = true
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "extra == \"qserver\" or extra == \"qs-client\""
+markers = "extra == \"qserver\" or extra == \"qs-client\" or extra == \"capture\""
 files = [
     {file = "pyzmq-27.2.0-cp310-cp310-macosx_10_15_universal2.whl", hash = "sha256:480dba27b145373b5e103890f17969d891bc9e86746d6b8b29dd70b0d4addc62"},
     {file = "pyzmq-27.2.0-cp310-cp310-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:722f0a6940be1a483c81029a271d950e04dc2ff113a42e21b3d2b7a0d8e59638"},
@@ -7226,7 +7226,7 @@ cffi = ["cffi (>=1.17,<2.0) ; platform_python_implementation != \"PyPy\" and pyt
 [extras]
 analysis = ["imageanalysis"]
 ca = ["aioca"]
-capture = ["h5py", "p4p"]
+capture = ["h5py", "p4p", "pyzmq"]
 optimize = ["gest-api", "imageanalysis", "scananalysis", "xopt"]
 qs-client = ["bluesky-queueserver-api"]
 qserver = ["bluesky-queueserver"]
@@ -7235,4 +7235,4 @@ tiled = ["tiled"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<3.12"
-content-hash = "a95683b1f996bdfcfe04eef9c4a74ee3bb7b096ec00133e6aec328112e3d42a0"
+content-hash = "e5dddb83499e23fa6ecb90c52f47be83ff58123c4762f84b5f029061af52d361"

--- a/GeecsBluesky/poetry.lock
+++ b/GeecsBluesky/poetry.lock
@@ -1201,7 +1201,7 @@ description = "The EPICS Core libraries for use by python modules"
 optional = true
 python-versions = ">=2.7"
 groups = ["main"]
-markers = "extra == \"ca\""
+markers = "extra == \"ca\" or extra == \"capture\""
 files = [
     {file = "epicscorelibs-7.0.10.99.0.1-cp310-cp310-macosx_11_0_universal2.whl", hash = "sha256:4ca3a5f49a31f6e8c1ef8eab0b9d762827a8cced0de9159cb7e1c14730c0322b"},
     {file = "epicscorelibs-7.0.10.99.0.1-cp310-cp310-manylinux2014_x86_64.whl", hash = "sha256:5e3188984ac4765713bedc52e8d47121bc8dfc7d49ed54598d0849c58c70622c"},
@@ -1452,7 +1452,7 @@ tqdm = ["tqdm"]
 
 [[package]]
 name = "geecs-core"
-version = "0.2.0"
+version = "0.4.0"
 description = "The GEECS access library: UDP/TCP wire protocol, experiment database, PV naming contract, exceptions, the wire-protocol test double, and the entry-level GeecsDevice client"
 optional = false
 python-versions = ">=3.11,<3.12"
@@ -1501,7 +1501,7 @@ url = "../GEECS-Data-Utils"
 
 [[package]]
 name = "geecs-schemas"
-version = "0.10.2"
+version = "0.11.0"
 description = "Versioned Pydantic schemas for GEECS scanner configs (scan requests, save sets, scan variables, trigger profiles, action plans) plus legacy-YAML converters."
 optional = false
 python-versions = ">=3.11,<3.12"
@@ -3369,6 +3369,23 @@ files = [
 ]
 
 [[package]]
+name = "nose2"
+version = "0.16.0"
+description = "unittest with plugins"
+optional = true
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "extra == \"capture\""
+files = [
+    {file = "nose2-0.16.0-py3-none-any.whl", hash = "sha256:a637c508b1fff5882c5f0f573226abe6f43b2f8005fef8896f57174d7d0e0c31"},
+    {file = "nose2-0.16.0.tar.gz", hash = "sha256:19db5ad20e264501a8ee64e3e157a3766a5e744170e54ceecb4e5ca09b08655a"},
+]
+
+[package.extras]
+coverage-plugin = ["coverage"]
+dev = ["sphinx", "sphinx-issues", "sphinx-rtd-theme"]
+
+[[package]]
 name = "nptdms"
 version = "1.10.0"
 description = "Cross-platform, NumPy based module for reading TDMS files produced by LabView"
@@ -4031,6 +4048,50 @@ files = [
 ]
 
 [[package]]
+name = "p4p"
+version = "4.2.2"
+description = "Python interface to PVAccess protocol client"
+optional = true
+python-versions = ">=2.7"
+groups = ["main"]
+markers = "extra == \"capture\""
+files = [
+    {file = "p4p-4.2.2-cp310-cp310-macosx_11_0_universal2.whl", hash = "sha256:35034739b3dd80fda352ff54fd340329254a59ced66710438d4e365d9bb50327"},
+    {file = "p4p-4.2.2-cp310-cp310-manylinux2014_x86_64.whl", hash = "sha256:7cfc916e126213b62fd7cc84ddce7ed42a11e2b7b4f8273a8919841cc06a30df"},
+    {file = "p4p-4.2.2-cp310-cp310-win_amd64.whl", hash = "sha256:8ea3527dbb81ff5aaf1e5aa089fdebf69a14c0e177e2d0213c8bdb3996be8ce0"},
+    {file = "p4p-4.2.2-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:a778596f0cd9fd83546d9684523d20923d2ff0aa7300f43a5b591dad704cdff6"},
+    {file = "p4p-4.2.2-cp311-cp311-manylinux2014_x86_64.whl", hash = "sha256:90c2fbcc1adc72cc18194f7287c9c97ac4244e03e9c0b4196a3405c6315f48de"},
+    {file = "p4p-4.2.2-cp311-cp311-win_amd64.whl", hash = "sha256:92e6f9225e24941b5c83062229a21e552d46f59a4246794e1155216da4e58873"},
+    {file = "p4p-4.2.2-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:7e614f602e8d1e977afb85a23321d878e3f1131f8e06c385bff270314a6c1814"},
+    {file = "p4p-4.2.2-cp312-cp312-manylinux2014_x86_64.whl", hash = "sha256:a1fbd9c52169e849546dcaf5689a09340bb79ce28eacf4abeff6babf203dac3d"},
+    {file = "p4p-4.2.2-cp312-cp312-win_amd64.whl", hash = "sha256:82dee1207a72a3ea5dbb086c12b8897eb349f594b7855c8bfe1a4e2e5e332704"},
+    {file = "p4p-4.2.2-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:1d30d0bb36c1b7e23f5c9cb82723d34621507a3dfd2b53de40c7781c54e42e8d"},
+    {file = "p4p-4.2.2-cp313-cp313-manylinux2014_x86_64.whl", hash = "sha256:106b1dc2c54eaf2d90da6d1fbe2a79dadfb8c796341edaaabe9fedac90246e07"},
+    {file = "p4p-4.2.2-cp313-cp313-win_amd64.whl", hash = "sha256:ef94ae9d56885ce6419816671941bb06f8f6c621d1ebba1cb0d352282d6849a9"},
+    {file = "p4p-4.2.2-cp313-cp313t-manylinux2014_x86_64.whl", hash = "sha256:553a19531a33f49998db0c68b43f86869b139ccb34d01853415ea43696fbbb3d"},
+    {file = "p4p-4.2.2-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:61b932ccb4ebf93920dd181907fa2642071be7ae235c1c95088affaae1d258a2"},
+    {file = "p4p-4.2.2-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:31d5a53e68c633a9d791e74950ac0ce9d336809e6a250e9b66fbe60de7e18e0b"},
+    {file = "p4p-4.2.2-cp314-cp314-win_amd64.whl", hash = "sha256:1e8972d75fb7500e4a4fc72beb4136438d84b5fdf89869c5b70171971a143d50"},
+    {file = "p4p-4.2.2-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:11f9e61162380535a5ef074de6f0cd127e65ef3a6399c7cba16115aedf70b8e1"},
+    {file = "p4p-4.2.2-cp38-cp38-macosx_11_0_universal2.whl", hash = "sha256:67154203416966530c347a5a87a888e4eca029308c96a55d7e89eb4bbdae3af9"},
+    {file = "p4p-4.2.2-cp38-cp38-manylinux2014_x86_64.whl", hash = "sha256:f1abbc83788d9699fc19319d69d7af4cd0d95bcf5ddc44b5a4fed2cd6c507794"},
+    {file = "p4p-4.2.2-cp38-cp38-win_amd64.whl", hash = "sha256:9876d01bfa7fdb13508ae6f69cc4a67722048350c9b748b7514b57e574a136a5"},
+    {file = "p4p-4.2.2-cp39-cp39-macosx_11_0_universal2.whl", hash = "sha256:a99197a6a2a384b8f27649821d3d41351cf33751ff19ea0ace28811c6314f07f"},
+    {file = "p4p-4.2.2-cp39-cp39-manylinux2014_x86_64.whl", hash = "sha256:30ecd73bc33c2f645a70e30be752d584a985bd6ac91fecaf2dd3342595c1cd5b"},
+    {file = "p4p-4.2.2.tar.gz", hash = "sha256:1685ffab0d0a1a1e3da647dd9f027933a10d57b71b3c4f5dd762fcabeba7e31e"},
+]
+
+[package.dependencies]
+epicscorelibs = ">=7.0.10.99.0.0,<7.0.10.99.1"
+nose2 = ">=0.8.0"
+numpy = ">=1.7,<3"
+ply = "*"
+pvxslibs = ">=1.5.0,<1.6.0a1"
+
+[package.extras]
+qt = ["qtpy"]
+
+[[package]]
 name = "packaging"
 version = "26.1"
 description = "Core utilities for Python packages"
@@ -4365,6 +4426,19 @@ dev = ["pre-commit", "tox"]
 testing = ["coverage", "pytest", "pytest-benchmark"]
 
 [[package]]
+name = "ply"
+version = "3.11"
+description = "Python Lex & Yacc"
+optional = true
+python-versions = "*"
+groups = ["main"]
+markers = "extra == \"capture\""
+files = [
+    {file = "ply-3.11-py2.py3-none-any.whl", hash = "sha256:096f9b8350b65ebd2fd1346b12452efe5b9607f7482813ffca50c22722a807ce"},
+    {file = "ply-3.11.tar.gz", hash = "sha256:00c7c1aaa88358b9c765b6d3000c6eec0ba42abca5351b095321aef446081da3"},
+]
+
+[[package]]
 name = "prompt-toolkit"
 version = "3.0.52"
 description = "Library for building powerful interactive command lines in Python"
@@ -4482,6 +4556,42 @@ files = [
 
 [package.extras]
 tests = ["pytest"]
+
+[[package]]
+name = "pvxslibs"
+version = "1.5.2"
+description = "PVXS libraries packaged for python"
+optional = true
+python-versions = ">=2.7"
+groups = ["main"]
+markers = "extra == \"capture\""
+files = [
+    {file = "pvxslibs-1.5.2-cp310-cp310-macosx_11_0_universal2.whl", hash = "sha256:f9d05dbbd5fb223b36a7223236b05964cd18af8b42f8f0b4d088ca828457377d"},
+    {file = "pvxslibs-1.5.2-cp310-cp310-manylinux2014_x86_64.whl", hash = "sha256:be11a559362f7e43c530c9ca923222aa136d50e05cadeedad1a7a5b71a14e673"},
+    {file = "pvxslibs-1.5.2-cp310-cp310-win_amd64.whl", hash = "sha256:181921ceed2b3b9df946e3df63708fca1309bdcaaea9cb0539b3ef46d4933ea6"},
+    {file = "pvxslibs-1.5.2-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:24209b6c2871b5d43dea8a0c524d7efa25f8d2fb5dbe1247ec81dc72248e8756"},
+    {file = "pvxslibs-1.5.2-cp311-cp311-manylinux2014_x86_64.whl", hash = "sha256:3765818f4e825c37002a595267d5f0ece2ef6090eaa83ab1973474fdeb7bc5f5"},
+    {file = "pvxslibs-1.5.2-cp311-cp311-win_amd64.whl", hash = "sha256:01c6487c06420420034d380b853a404647b3cdcfe1c7d7f07ae6e5f540fba6f6"},
+    {file = "pvxslibs-1.5.2-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:f426764ad577083b2eeec91be696acdd38d787ffc719c5efac3a9e4edb575721"},
+    {file = "pvxslibs-1.5.2-cp312-cp312-manylinux2014_x86_64.whl", hash = "sha256:1a8389e834db03c6b341d21d84cb5456be039ea04cac3be3b2f68c8b5d41cd92"},
+    {file = "pvxslibs-1.5.2-cp312-cp312-win_amd64.whl", hash = "sha256:0d14a421dda824b4132b66292e24a1b8e67954176e394186476536edfc56b1bc"},
+    {file = "pvxslibs-1.5.2-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:95b1016c3ebd143868def8ee50445b0da3d766e9226952cf80bca71f9f352cbd"},
+    {file = "pvxslibs-1.5.2-cp313-cp313-manylinux2014_x86_64.whl", hash = "sha256:b5721ae340b146e13c44034af48e5d259e1df1a65b9bacb878cde786dd01791f"},
+    {file = "pvxslibs-1.5.2-cp313-cp313-win_amd64.whl", hash = "sha256:c69ebe78e2c15fd2f562f97094cfffc873594815a7450352d3ec195dcf00685d"},
+    {file = "pvxslibs-1.5.2-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:ea089238451e447fc8bee155b3c813f28bb02b47043a8160d5f923f09f251bf9"},
+    {file = "pvxslibs-1.5.2-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:7037d85c6d363a09cdd2ab79a78de15262d18482fc0bee0957cd46210811cf9b"},
+    {file = "pvxslibs-1.5.2-cp314-cp314-win_amd64.whl", hash = "sha256:74b835293774a7bfde59ffb94ffcc16bea1554d7213cd743813d19e2dbb4cb82"},
+    {file = "pvxslibs-1.5.2-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:859adec425aa21250eb1e556f1d832fbfde64f025d0f380b2e6871fe8cda5afc"},
+    {file = "pvxslibs-1.5.2-cp38-cp38-macosx_11_0_universal2.whl", hash = "sha256:63e0d227c868e770c15709e7f61b63180138e5ab21fb504b71e76f85a6ff46c6"},
+    {file = "pvxslibs-1.5.2-cp38-cp38-win_amd64.whl", hash = "sha256:cba9c850816bd5a3d04708bfa37e68e0a6c41d0652dc86acb939814bf37a64b1"},
+    {file = "pvxslibs-1.5.2-cp39-cp39-macosx_11_0_universal2.whl", hash = "sha256:d82eaeb87e075f1afff667b41e935fd40a5694aca1edddba972df9c486b9a54b"},
+    {file = "pvxslibs-1.5.2-cp39-cp39-manylinux2014_x86_64.whl", hash = "sha256:aec1fd96a02156a219c0c76ce488067650f5f9387c30696248a0be102188cd1a"},
+    {file = "pvxslibs-1.5.2.tar.gz", hash = "sha256:dcf58897451951e9b7ea1021a001d7d826047d29186bf5b64bb1b4688fdacf5f"},
+]
+
+[package.dependencies]
+epicscorelibs = ">=7.0.10.99.0.1,<7.0.10.99.1"
+setuptools_dso = ">=2.7a1"
 
 [[package]]
 name = "pyabel"
@@ -5677,7 +5787,7 @@ crt = ["botocore[crt] (>=1.37.4,<2.0a.0)"]
 
 [[package]]
 name = "scananalysis"
-version = "1.15.1"
+version = "1.16.0"
 description = "Modules for performing analyses routines on full scans"
 optional = true
 python-versions = ">=3.11,<3.12"
@@ -5961,7 +6071,7 @@ description = "Most extensible Python build backend with support for C/C++ exten
 optional = true
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "extra == \"analysis\" or extra == \"optimize\" or extra == \"ca\""
+markers = "extra == \"analysis\" or extra == \"optimize\" or extra == \"ca\" or extra == \"capture\""
 files = [
     {file = "setuptools-82.0.1-py3-none-any.whl", hash = "sha256:a59e362652f08dcd477c78bb6e7bd9d80a7995bc73ce773050228a348ce2e5bb"},
     {file = "setuptools-82.0.1.tar.gz", hash = "sha256:7d872682c5d01cfde07da7bccc7b65469d3dca203318515ada1de5eda35efbf9"},
@@ -5983,7 +6093,7 @@ description = "setuptools extension to build non-python shared libraries"
 optional = true
 python-versions = ">=2.7"
 groups = ["main"]
-markers = "extra == \"ca\""
+markers = "extra == \"ca\" or extra == \"capture\""
 files = [
     {file = "setuptools_dso-2.12.3-py2.py3-none-any.whl", hash = "sha256:5040be8628bd6cb82653391cf59f22126b261941cdbc9c36becca87e09c011c3"},
     {file = "setuptools_dso-2.12.3.tar.gz", hash = "sha256:9effb7bc38f87ff9aed33cc69e860320804ca6c69af8896dbba10996a49b5d7e"},
@@ -7116,6 +7226,7 @@ cffi = ["cffi (>=1.17,<2.0) ; platform_python_implementation != \"PyPy\" and pyt
 [extras]
 analysis = ["imageanalysis"]
 ca = ["aioca"]
+capture = ["h5py", "p4p"]
 optimize = ["gest-api", "imageanalysis", "scananalysis", "xopt"]
 qs-client = ["bluesky-queueserver-api"]
 qserver = ["bluesky-queueserver"]
@@ -7124,4 +7235,4 @@ tiled = ["tiled"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<3.12"
-content-hash = "e6e4b228cac50a47879583ad091afde3289321a948854ad5013e4b5dc8d868fe"
+content-hash = "a95683b1f996bdfcfe04eef9c4a74ee3bb7b096ec00133e6aec328112e3d42a0"

--- a/GeecsBluesky/pyproject.toml
+++ b/GeecsBluesky/pyproject.toml
@@ -72,6 +72,10 @@ bluesky-queueserver-api = { version = "^0.0.13", optional = true }
 # (h5py, the v0 container behind the FrameStackWriter seam — FORMAT.md).
 p4p = { version = ">=4.1", optional = true }
 h5py = { version = ">=3.8", optional = true }
+# The daemon's document stream (bluesky.callbacks.zmq.RemoteDispatcher)
+# needs pyzmq, which bluesky does NOT hard-depend on — without this a pure
+# `--extras capture` install fails at daemon start (codex gate P1).
+pyzmq = { version = ">=24", optional = true }
 
 [tool.poetry.extras]
 tiled = ["tiled"]
@@ -80,7 +84,7 @@ ca = ["aioca"]
 optimize = ["xopt", "gest-api", "scananalysis", "imageanalysis"]
 qserver = ["bluesky-queueserver"]
 qs-client = ["bluesky-queueserver-api"]
-capture = ["p4p", "h5py"]
+capture = ["p4p", "h5py", "pyzmq"]
 
 [tool.poetry.scripts]
 geecs-capture-daemon = "geecs_bluesky.capture.__main__:main"

--- a/GeecsBluesky/pyproject.toml
+++ b/GeecsBluesky/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-bluesky"
-version = "0.63.0"
+version = "0.64.0"
 description = "Bluesky / ophyd-async bridge for the GEECS control system"
 authors = ["Sam Barber <sbarber@lbl.gov>"]
 readme = "README.md"
@@ -66,6 +66,13 @@ bluesky-queueserver = { version = "^0.0.25", optional = true }
 # add. Optional so the worker and headless installs don't carry it.
 bluesky-queueserver-api = { version = "^0.0.13", optional = true }
 
+# The capture daemon (geecs_bluesky/capture/): PVA image subscription (p4p —
+# the same client library the PVA gateway serves; consumed as a network
+# service, no gateway code imported) and the per-device frame-stack writer
+# (h5py, the v0 container behind the FrameStackWriter seam — FORMAT.md).
+p4p = { version = ">=4.1", optional = true }
+h5py = { version = ">=3.8", optional = true }
+
 [tool.poetry.extras]
 tiled = ["tiled"]
 analysis = ["imageanalysis"]
@@ -73,6 +80,10 @@ ca = ["aioca"]
 optimize = ["xopt", "gest-api", "scananalysis", "imageanalysis"]
 qserver = ["bluesky-queueserver"]
 qs-client = ["bluesky-queueserver-api"]
+capture = ["p4p", "h5py"]
+
+[tool.poetry.scripts]
+geecs-capture-daemon = "geecs_bluesky.capture.__main__:main"
 
 [tool.poetry.group.dev.dependencies]
 pytest = ">=7.0"

--- a/GeecsBluesky/tests/capture/test_daemon.py
+++ b/GeecsBluesky/tests/capture/test_daemon.py
@@ -1,0 +1,147 @@
+"""CaptureDaemon + ScanCaptureSession over a fake frame source.
+
+Real Hdf5StackWriter against tmp dirs (integration of the seam), fake p4p.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+h5py = pytest.importorskip("h5py")
+np = pytest.importorskip("numpy")
+
+from geecs_bluesky.capture.daemon import CaptureDaemon  # noqa: E402
+from geecs_bluesky.capture.discovery import CameraTarget  # noqa: E402
+
+
+class FakeSource:
+    """FrameSource test double: exposes the callbacks for direct injection."""
+
+    def __init__(self) -> None:
+        self.subscribed: list[CameraTarget] = []
+        self.on_frame = None
+        self.on_connection = None
+        self.closed = False
+
+    def subscribe(self, targets, on_frame, on_connection) -> None:
+        """Record the subscription and capture the callbacks."""
+        self.subscribed = list(targets)
+        self.on_frame = on_frame
+        self.on_connection = on_connection
+
+    def close(self) -> None:
+        """Record teardown."""
+        self.closed = True
+
+
+def _targets() -> list[CameraTarget]:
+    return [
+        CameraTarget(
+            "UC_CamA", "Point Grey Camera", "undulator:uc_cama:image", "192.168.6.100"
+        ),
+        CameraTarget(
+            "UC_CamB", "Point Grey Camera", "undulator:uc_camb:image", "192.168.6.100"
+        ),
+    ]
+
+
+def _start_doc(tmp_path, *, uid="run-1", missing_device=False):
+    cam_a = tmp_path / "ScanXXX" / "UC_CamA"
+    cam_a.mkdir(parents=True)  # the ENGINE creates these — the test plays engine
+    paths = {"UC_CamA": str(cam_a)}
+    if missing_device:
+        paths["UC_CamB"] = str(tmp_path / "ScanXXX" / "UC_CamB")  # never created
+    return {
+        "uid": uid,
+        "time": 1000.0,
+        "scan_number": 7,
+        "experiment": "Undulator",
+        "nonscalar_save_paths": paths,
+    }
+
+
+def test_full_scan_capture_flow(tmp_path) -> None:
+    """Start → frames (with dup + stale) → stop: dedupe, filter, finalize."""
+    source = FakeSource()
+    daemon = CaptureDaemon(
+        experiment="Undulator", targets=_targets(), source_factory=lambda: source
+    )
+
+    daemon("start", _start_doc(tmp_path))
+    assert [t.device for t in source.subscribed] == ["UC_CamA"]
+
+    frame = np.full((3, 3), 5, dtype=np.uint16)
+    source.on_frame("UC_CamA", frame, 995.0, 1001.0)  # stale (pre-start cache)
+    source.on_frame("UC_CamA", frame, 1001.0, 1001.5)  # real shot 1
+    source.on_frame("UC_CamA", frame, 1002.0, 1002.5)  # real shot 2
+    source.on_frame("UC_CamA", frame, 1002.0, 1003.5)  # idle re-push duplicate
+    source.on_frame("UC_Ghost", frame, 1002.0, 1003.5)  # unknown device ignored
+    source.on_connection("UC_CamA", False)
+
+    daemon("stop", {"run_start": "run-1", "exit_status": "success"})
+    assert source.closed
+
+    with h5py.File(tmp_path / "ScanXXX" / "UC_CamA" / "UC_CamA.h5", "r") as f:
+        assert f["frames"].shape == (2, 3, 3)
+        assert list(f["acq_timestamp"][:]) == [1001.0, 1002.0]
+        assert f.attrs["frames_written"] == 2
+        assert f.attrs["frames_received"] == 4
+        assert f.attrs["duplicates_dropped"] == 1
+        assert f.attrs["stale_skipped"] == 1
+        assert f.attrs["disconnect_events"] == 1
+        assert bool(f.attrs["finalized"]) is True
+        assert f.attrs["scan_number"] == 7
+
+
+def test_missing_device_dir_skipped_never_created(tmp_path) -> None:
+    """A camera whose engine dir is absent is skipped — and NOT mkdir'ed."""
+    source = FakeSource()
+    daemon = CaptureDaemon(
+        experiment="Undulator", targets=_targets(), source_factory=lambda: source
+    )
+    daemon("start", _start_doc(tmp_path, missing_device=True))
+    assert [t.device for t in source.subscribed] == ["UC_CamA"]
+    assert not (tmp_path / "ScanXXX" / "UC_CamB").exists()
+    daemon("stop", {"run_start": "run-1"})
+
+
+def test_start_without_save_paths_ignored(tmp_path) -> None:
+    """Runs that save nothing (or non-scan runs) open no session."""
+    source = FakeSource()
+    daemon = CaptureDaemon(
+        experiment="Undulator", targets=_targets(), source_factory=lambda: source
+    )
+    daemon("start", {"uid": "run-x", "time": 1.0})
+    daemon("stop", {"run_start": "run-x"})
+    assert source.subscribed == []
+
+
+def test_second_start_closes_first_unfinalized(tmp_path) -> None:
+    """Overlapping starts close the stale session without the finalized stamp."""
+    sources = [FakeSource(), FakeSource()]
+    it = iter(sources)
+    daemon = CaptureDaemon(
+        experiment="Undulator", targets=_targets(), source_factory=lambda: next(it)
+    )
+    daemon("start", _start_doc(tmp_path, uid="run-1"))
+    doc2 = _start_doc(tmp_path / "second", uid="run-2")
+    daemon("start", doc2)
+    assert sources[0].closed
+
+    with h5py.File(tmp_path / "ScanXXX" / "UC_CamA" / "UC_CamA.h5", "r") as f:
+        assert "finalized" not in f.attrs
+
+    daemon("stop", {"run_start": "run-2"})
+
+
+def test_daemon_shutdown_closes_open_session(tmp_path) -> None:
+    """shutdown() aborts an in-flight session (daemon exit mid-scan)."""
+    source = FakeSource()
+    daemon = CaptureDaemon(
+        experiment="Undulator", targets=_targets(), source_factory=lambda: source
+    )
+    daemon("start", _start_doc(tmp_path))
+    daemon.shutdown()
+    assert source.closed
+    with h5py.File(tmp_path / "ScanXXX" / "UC_CamA" / "UC_CamA.h5", "r") as f:
+        assert "finalized" not in f.attrs

--- a/GeecsBluesky/tests/capture/test_daemon.py
+++ b/GeecsBluesky/tests/capture/test_daemon.py
@@ -5,11 +5,15 @@ Real Hdf5StackWriter against tmp dirs (integration of the seam), fake p4p.
 
 from __future__ import annotations
 
+import threading
+import time
+
 import pytest
 
 h5py = pytest.importorskip("h5py")
 np = pytest.importorskip("numpy")
 
+import geecs_bluesky.capture.daemon as daemon_mod  # noqa: E402
 from geecs_bluesky.capture.daemon import CaptureDaemon  # noqa: E402
 from geecs_bluesky.capture.discovery import CameraTarget  # noqa: E402
 
@@ -45,12 +49,13 @@ def _targets() -> list[CameraTarget]:
     ]
 
 
-def _start_doc(tmp_path, *, uid="run-1", missing_device=False):
-    cam_a = tmp_path / "ScanXXX" / "UC_CamA"
-    cam_a.mkdir(parents=True)  # the ENGINE creates these — the test plays engine
-    paths = {"UC_CamA": str(cam_a)}
-    if missing_device:
-        paths["UC_CamB"] = str(tmp_path / "ScanXXX" / "UC_CamB")  # never created
+def _start_doc(tmp_path, *, uid="run-1", devices=("UC_CamA",), create_dirs=True):
+    paths = {}
+    for device in devices:
+        d = tmp_path / "ScanXXX" / device
+        if create_dirs:
+            d.mkdir(parents=True)  # the ENGINE creates these
+        paths[device] = str(d)
     return {
         "uid": uid,
         "time": 1000.0,
@@ -58,6 +63,21 @@ def _start_doc(tmp_path, *, uid="run-1", missing_device=False):
         "experiment": "Undulator",
         "nonscalar_save_paths": paths,
     }
+
+
+def _wait_written(path, n, timeout=10.0) -> None:
+    """Poll until the stack file holds *n* frames (writer thread is async)."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if path.exists():
+            try:
+                with h5py.File(path, "r") as f:
+                    if "frames" in f and f["frames"].shape[0] >= n:
+                        return
+            except OSError:
+                pass  # writer mid-append
+        time.sleep(0.05)
+    raise AssertionError(f"{path} never reached {n} frames")
 
 
 def test_full_scan_capture_flow(tmp_path) -> None:
@@ -76,7 +96,8 @@ def test_full_scan_capture_flow(tmp_path) -> None:
     source.on_frame("UC_CamA", frame, 1002.0, 1002.5)  # real shot 2
     source.on_frame("UC_CamA", frame, 1002.0, 1003.5)  # idle re-push duplicate
     source.on_frame("UC_Ghost", frame, 1002.0, 1003.5)  # unknown device ignored
-    source.on_connection("UC_CamA", False)
+    source.on_connection("UC_CamA", False)  # initial Disconnected — absorbed?
+    # No: received > 0 by now, so this counts as a REAL disconnect.
 
     daemon("stop", {"run_start": "run-1", "exit_status": "success"})
     assert source.closed
@@ -91,18 +112,159 @@ def test_full_scan_capture_flow(tmp_path) -> None:
         assert f.attrs["disconnect_events"] == 1
         assert bool(f.attrs["finalized"]) is True
         assert f.attrs["scan_number"] == 7
+        # The counter identity closes.
+        assert f.attrs["frames_received"] == (
+            f.attrs["frames_written"]
+            + f.attrs["duplicates_dropped"]
+            + f.attrs["stale_skipped"]
+            + f.attrs["shape_errors"]
+            + f.attrs["queue_drops"]
+            + f.attrs["late_frames"]
+            + f.attrs["writer_create_failures"]
+        )
 
 
-def test_missing_device_dir_skipped_never_created(tmp_path) -> None:
-    """A camera whose engine dir is absent is skipped — and NOT mkdir'ed."""
+def test_dirs_created_after_start_doc(tmp_path) -> None:
+    """THE production ordering: start doc first, engine mkdir later, then frames.
+
+    The engine's save-enable plan creates scans/ScanNNN/<device>/ AFTER the
+    start document (defer_save_on); writers must therefore be lazy. This is
+    the regression pin for the review's HIGH finding.
+    """
     source = FakeSource()
     daemon = CaptureDaemon(
         experiment="Undulator", targets=_targets(), source_factory=lambda: source
     )
-    daemon("start", _start_doc(tmp_path, missing_device=True))
+    daemon("start", _start_doc(tmp_path, create_dirs=False))
     assert [t.device for t in source.subscribed] == ["UC_CamA"]
-    assert not (tmp_path / "ScanXXX" / "UC_CamB").exists()
+
+    # Engine creates the dir only now (save-enable), before the first trigger.
+    (tmp_path / "ScanXXX" / "UC_CamA").mkdir(parents=True)
+    frame = np.full((2, 2), 1, dtype=np.uint16)
+    source.on_frame("UC_CamA", frame, 1001.0, 1001.5)
+    source.on_frame("UC_CamA", frame, 1002.0, 1002.5)
+    _wait_written(tmp_path / "ScanXXX" / "UC_CamA" / "UC_CamA.h5", 2)
+
     daemon("stop", {"run_start": "run-1"})
+    with h5py.File(tmp_path / "ScanXXX" / "UC_CamA" / "UC_CamA.h5", "r") as f:
+        assert f["frames"].shape == (2, 2, 2)
+        assert f.attrs["writer_create_failures"] == 0
+        assert bool(f.attrs["finalized"]) is True
+
+
+def test_missing_device_dir_drops_counted_never_created(tmp_path) -> None:
+    """A device whose dir never appears: frames drop counted, no mkdir, no file."""
+    source = FakeSource()
+    daemon = CaptureDaemon(
+        experiment="Undulator", targets=_targets(), source_factory=lambda: source
+    )
+    daemon("start", _start_doc(tmp_path, devices=("UC_CamA", "UC_CamB")))
+    # Remove CamB's dir to simulate it never being created by the engine.
+    (tmp_path / "ScanXXX" / "UC_CamB").rmdir()
+    assert sorted(t.device for t in source.subscribed) == ["UC_CamA", "UC_CamB"]
+
+    frame = np.full((2, 2), 1, dtype=np.uint16)
+    source.on_frame("UC_CamB", frame, 1001.0, 1001.5)
+    time.sleep(0.3)  # let the writer thread attempt (and fail) creation
+
+    daemon("stop", {"run_start": "run-1"})
+    assert not (tmp_path / "ScanXXX" / "UC_CamB").exists()
+    assert not (tmp_path / "ScanXXX" / "UC_CamB" / "UC_CamB.h5").exists()
+
+
+def test_placeholder_timestamp_zero_is_always_stale(tmp_path) -> None:
+    """The gateway's (1,1) placeholder (timestamp 0.0) can never lock geometry."""
+    source = FakeSource()
+    daemon = CaptureDaemon(
+        experiment="Undulator", targets=_targets(), source_factory=lambda: source
+    )
+    daemon("start", _start_doc(tmp_path))
+
+    placeholder = np.zeros((1, 1), dtype=np.uint8)
+    real = np.full((4, 4), 3, dtype=np.uint16)
+    source.on_frame("UC_CamA", placeholder, 0.0, 1001.0)  # placeholder post
+    source.on_frame("UC_CamA", real, 1001.0, 1001.5)
+    source.on_frame("UC_CamA", real, 1002.0, 1002.5)
+    _wait_written(tmp_path / "ScanXXX" / "UC_CamA" / "UC_CamA.h5", 2)
+
+    daemon("stop", {"run_start": "run-1"})
+    with h5py.File(tmp_path / "ScanXXX" / "UC_CamA" / "UC_CamA.h5", "r") as f:
+        assert f["frames"].shape == (2, 4, 4)  # geometry from the REAL frame
+        assert f.attrs["stale_skipped"] == 1
+        assert f.attrs["shape_errors"] == 0
+
+
+def test_queue_overflow_is_counted_per_device(tmp_path, monkeypatch) -> None:
+    """put_nowait Full → per-device queue_drops; identity still closes."""
+    monkeypatch.setattr(daemon_mod, "WRITER_QUEUE_MAX", 1)
+    release = threading.Event()
+
+    class BlockingWriter:
+        def __init__(self, *args, **kwargs) -> None:
+            self.frames = 0
+
+        def append(self, frame, acq_ts, recv_ts) -> None:
+            release.wait(timeout=10.0)
+            self.frames += 1
+
+        def finalize(self, counters) -> int:
+            return self.frames
+
+        def abort(self) -> None:
+            pass
+
+    source = FakeSource()
+    daemon = CaptureDaemon(
+        experiment="Undulator",
+        targets=_targets(),
+        source_factory=lambda: source,
+        writer_factory=BlockingWriter,
+    )
+    daemon("start", _start_doc(tmp_path))
+
+    frame = np.full((2, 2), 1, dtype=np.uint16)
+    source.on_frame("UC_CamA", frame, 1001.0, 1001.5)  # taken by writer thread
+    time.sleep(0.2)  # writer now blocked inside append
+    source.on_frame("UC_CamA", frame, 1002.0, 1002.5)  # fills queue (max 1)
+    source.on_frame("UC_CamA", frame, 1003.0, 1003.5)  # queue Full → dropped
+    release.set()
+
+    session = daemon._session
+    daemon("stop", {"run_start": "run-1"})
+    counters = None
+    # Summary logged; recover counters from the session's device state.
+    dev = session._devices["UC_CamA"]
+    counters = dev.counters()
+    assert counters["queue_drops"] == 1
+    assert counters["frames_received"] == 3
+    assert counters["frames_received"] == (
+        counters["frames_written"]
+        + counters["duplicates_dropped"]
+        + counters["stale_skipped"]
+        + counters["shape_errors"]
+        + counters["queue_drops"]
+        + counters["late_frames"]
+        + counters["writer_create_failures"]
+    )
+
+
+def test_initial_disconnect_absorbed_before_frames(tmp_path) -> None:
+    """p4p's subscribe-time Disconnected is absorbed; later ones count."""
+    source = FakeSource()
+    daemon = CaptureDaemon(
+        experiment="Undulator", targets=_targets(), source_factory=lambda: source
+    )
+    daemon("start", _start_doc(tmp_path))
+
+    source.on_connection("UC_CamA", False)  # initial — absorbed
+    frame = np.full((2, 2), 1, dtype=np.uint16)
+    source.on_frame("UC_CamA", frame, 1001.0, 1001.5)
+    source.on_connection("UC_CamA", False)  # real loss — counted
+    _wait_written(tmp_path / "ScanXXX" / "UC_CamA" / "UC_CamA.h5", 1)
+
+    daemon("stop", {"run_start": "run-1"})
+    with h5py.File(tmp_path / "ScanXXX" / "UC_CamA" / "UC_CamA.h5", "r") as f:
+        assert f.attrs["disconnect_events"] == 1
 
 
 def test_start_without_save_paths_ignored(tmp_path) -> None:
@@ -124,14 +286,33 @@ def test_second_start_closes_first_unfinalized(tmp_path) -> None:
         experiment="Undulator", targets=_targets(), source_factory=lambda: next(it)
     )
     daemon("start", _start_doc(tmp_path, uid="run-1"))
-    doc2 = _start_doc(tmp_path / "second", uid="run-2")
-    daemon("start", doc2)
-    assert sources[0].closed
+    frame = np.full((2, 2), 1, dtype=np.uint16)
+    sources[0].on_frame("UC_CamA", frame, 1001.0, 1001.5)
+    _wait_written(tmp_path / "ScanXXX" / "UC_CamA" / "UC_CamA.h5", 1)
 
+    daemon("start", _start_doc(tmp_path / "second", uid="run-2"))
+    assert sources[0].closed
     with h5py.File(tmp_path / "ScanXXX" / "UC_CamA" / "UC_CamA.h5", "r") as f:
         assert "finalized" not in f.attrs
 
     daemon("stop", {"run_start": "run-2"})
+
+
+def test_mismatched_stop_never_finalizes(tmp_path) -> None:
+    """A stop for a different run closes the session UN-finalized."""
+    source = FakeSource()
+    daemon = CaptureDaemon(
+        experiment="Undulator", targets=_targets(), source_factory=lambda: source
+    )
+    daemon("start", _start_doc(tmp_path, uid="run-1"))
+    frame = np.full((2, 2), 1, dtype=np.uint16)
+    source.on_frame("UC_CamA", frame, 1001.0, 1001.5)
+    _wait_written(tmp_path / "ScanXXX" / "UC_CamA" / "UC_CamA.h5", 1)
+
+    daemon("stop", {"run_start": "run-OTHER"})
+    assert source.closed
+    with h5py.File(tmp_path / "ScanXXX" / "UC_CamA" / "UC_CamA.h5", "r") as f:
+        assert "finalized" not in f.attrs
 
 
 def test_daemon_shutdown_closes_open_session(tmp_path) -> None:
@@ -141,6 +322,9 @@ def test_daemon_shutdown_closes_open_session(tmp_path) -> None:
         experiment="Undulator", targets=_targets(), source_factory=lambda: source
     )
     daemon("start", _start_doc(tmp_path))
+    frame = np.full((2, 2), 1, dtype=np.uint16)
+    source.on_frame("UC_CamA", frame, 1001.0, 1001.5)
+    _wait_written(tmp_path / "ScanXXX" / "UC_CamA" / "UC_CamA.h5", 1)
     daemon.shutdown()
     assert source.closed
     with h5py.File(tmp_path / "ScanXXX" / "UC_CamA" / "UC_CamA.h5", "r") as f:

--- a/GeecsBluesky/tests/capture/test_daemon.py
+++ b/GeecsBluesky/tests/capture/test_daemon.py
@@ -121,6 +121,7 @@ def test_full_scan_capture_flow(tmp_path) -> None:
             + f.attrs["queue_drops"]
             + f.attrs["late_frames"]
             + f.attrs["writer_create_failures"]
+            + f.attrs["append_failures"]
         )
 
 
@@ -245,6 +246,55 @@ def test_queue_overflow_is_counted_per_device(tmp_path, monkeypatch) -> None:
         + counters["queue_drops"]
         + counters["late_frames"]
         + counters["writer_create_failures"]
+        + counters["append_failures"]
+    )
+
+
+def test_append_failure_is_counted(tmp_path) -> None:
+    """A writer append error (HDF5/NAS blip) lands in append_failures."""
+
+    class FlakyWriter:
+        def __init__(self, *args, **kwargs) -> None:
+            self.calls = 0
+
+        def append(self, frame, acq_ts, recv_ts) -> None:
+            self.calls += 1
+            if self.calls == 1:
+                raise OSError("simulated NAS write failure")
+
+        def finalize(self, counters) -> int:
+            return self.calls - 1
+
+        def abort(self) -> None:
+            pass
+
+    source = FakeSource()
+    daemon = CaptureDaemon(
+        experiment="Undulator",
+        targets=_targets(),
+        source_factory=lambda: source,
+        writer_factory=FlakyWriter,
+    )
+    daemon("start", _start_doc(tmp_path))
+    frame = np.full((2, 2), 1, dtype=np.uint16)
+    source.on_frame("UC_CamA", frame, 1001.0, 1001.5)  # append raises
+    source.on_frame("UC_CamA", frame, 1002.0, 1002.5)  # append succeeds
+
+    session = daemon._session
+    daemon("stop", {"run_start": "run-1"})
+    counters = session._devices["UC_CamA"].counters()
+    assert counters["append_failures"] == 1
+    assert counters["frames_written"] == 1
+    assert counters["frames_received"] == 2
+    assert counters["frames_received"] == (
+        counters["frames_written"]
+        + counters["duplicates_dropped"]
+        + counters["stale_skipped"]
+        + counters["shape_errors"]
+        + counters["queue_drops"]
+        + counters["late_frames"]
+        + counters["writer_create_failures"]
+        + counters["append_failures"]
     )
 
 

--- a/GeecsBluesky/tests/capture/test_discovery.py
+++ b/GeecsBluesky/tests/capture/test_discovery.py
@@ -1,0 +1,58 @@
+"""Discovery: devicetype-keyed camera selection from batched DB queries."""
+
+from __future__ import annotations
+
+import geecs_bluesky.capture.discovery as discovery
+from geecs_bluesky.capture.discovery import CameraTarget, discover_capture_cameras
+
+
+def test_discovery_selects_registry_devicetypes_only(monkeypatch) -> None:
+    """Only registry devicetypes become targets; PVs compose via pv_naming."""
+    monkeypatch.setattr(
+        discovery.GeecsDb,
+        "get_experiment_device_types",
+        classmethod(
+            lambda cls, experiment: {
+                "UC_Amp4_IR_input": "Point Grey Camera",
+                "U_S1H": "EMQ_TDK",
+                "U_Haso": "HASO WFS",
+            }
+        ),
+    )
+    monkeypatch.setattr(
+        discovery.GeecsDb,
+        "get_experiment_devices",
+        classmethod(
+            lambda cls, experiment: {
+                "UC_Amp4_IR_input": ("192.168.6.100", 5005),
+                "U_S1H": ("192.168.6.20", 5001),
+                "U_Haso": ("192.168.6.30", 5002),
+            }
+        ),
+    )
+
+    targets = discover_capture_cameras("Undulator")
+    assert targets == [
+        CameraTarget(
+            device="UC_Amp4_IR_input",
+            device_type="Point Grey Camera",
+            pv="undulator:uc_amp4_ir_input:image",
+            server_ip="192.168.6.100",
+        )
+    ]
+
+
+def test_discovery_skips_missing_endpoint_row(monkeypatch) -> None:
+    """A camera without an endpoint row is skipped, not fatal."""
+    monkeypatch.setattr(
+        discovery.GeecsDb,
+        "get_experiment_device_types",
+        classmethod(lambda cls, experiment: {"UC_Ghost": "Point Grey Camera"}),
+    )
+    monkeypatch.setattr(
+        discovery.GeecsDb,
+        "get_experiment_devices",
+        classmethod(lambda cls, experiment: {}),
+    )
+
+    assert discover_capture_cameras("Undulator") == []

--- a/GeecsBluesky/tests/capture/test_discovery.py
+++ b/GeecsBluesky/tests/capture/test_discovery.py
@@ -30,6 +30,15 @@ def test_discovery_selects_registry_devicetypes_only(monkeypatch) -> None:
             }
         ),
     )
+    monkeypatch.setattr(
+        discovery.GeecsDb,
+        "get_experiment_device_variables",
+        classmethod(
+            lambda cls, experiment: {
+                "UC_Amp4_IR_input": [{"name": "image"}, {"name": "exposure"}],
+            }
+        ),
+    )
 
     targets = discover_capture_cameras("Undulator")
     assert targets == [
@@ -54,5 +63,34 @@ def test_discovery_skips_missing_endpoint_row(monkeypatch) -> None:
         "get_experiment_devices",
         classmethod(lambda cls, experiment: {}),
     )
+    monkeypatch.setattr(
+        discovery.GeecsDb,
+        "get_experiment_device_variables",
+        classmethod(lambda cls, experiment: {}),
+    )
 
     assert discover_capture_cameras("Undulator") == []
+
+
+def test_discovery_warns_on_missing_image_variable(monkeypatch, caplog) -> None:
+    """A camera lacking the registry's image variable draws a loud warning."""
+    monkeypatch.setattr(
+        discovery.GeecsDb,
+        "get_experiment_device_types",
+        classmethod(lambda cls, experiment: {"UC_Odd": "Point Grey Camera"}),
+    )
+    monkeypatch.setattr(
+        discovery.GeecsDb,
+        "get_experiment_devices",
+        classmethod(lambda cls, experiment: {"UC_Odd": ("192.168.6.100", 5005)}),
+    )
+    monkeypatch.setattr(
+        discovery.GeecsDb,
+        "get_experiment_device_variables",
+        classmethod(lambda cls, experiment: {"UC_Odd": [{"name": "picture"}]}),
+    )
+
+    with caplog.at_level("WARNING"):
+        targets = discover_capture_cameras("Undulator")
+    assert len(targets) == 1  # still targeted — the warning is advisory
+    assert any("not among its DB variables" in r.message for r in caplog.records)

--- a/GeecsBluesky/tests/capture/test_writer.py
+++ b/GeecsBluesky/tests/capture/test_writer.py
@@ -1,0 +1,69 @@
+"""Hdf5StackWriter: container contract, invariants, failure modes."""
+
+from __future__ import annotations
+
+import pytest
+
+h5py = pytest.importorskip("h5py")
+np = pytest.importorskip("numpy")
+
+from geecs_bluesky.capture.writer import SCHEMA_ID, Hdf5StackWriter  # noqa: E402
+
+
+def _writer(tmp_path, **overrides):
+    kwargs = {
+        "device": "UC_Cam",
+        "experiment": "Undulator",
+        "scan_number": 42,
+        "source_pv": "undulator:uc_cam:image",
+    }
+    kwargs.update(overrides)
+    return Hdf5StackWriter(tmp_path, **kwargs)
+
+
+def test_writer_appends_and_finalizes(tmp_path) -> None:
+    """Frames + aligned timestamps land; finalize stamps counters."""
+    w = _writer(tmp_path)
+    frames = [np.full((4, 5), i, dtype=np.uint16) for i in range(3)]
+    for i, frame in enumerate(frames):
+        w.append(frame, 1000.0 + i, 2000.0 + i)
+    n = w.finalize({"frames_written": 3, "duplicates_dropped": 1})
+    assert n == 3
+
+    with h5py.File(tmp_path / "UC_Cam.h5", "r") as f:
+        assert f.attrs["schema"] == SCHEMA_ID
+        assert f.attrs["device"] == "UC_Cam"
+        assert f.attrs["scan_number"] == 42
+        assert bool(f.attrs["finalized"]) is True
+        assert f.attrs["duplicates_dropped"] == 1
+        assert f["frames"].shape == (3, 4, 5)
+        assert f["frames"].dtype == np.uint16
+        assert list(f["acq_timestamp"][:]) == [1000.0, 1001.0, 1002.0]
+        assert list(f["recv_timestamp"][:]) == [2000.0, 2001.0, 2002.0]
+        assert (f["frames"][2] == 2).all()
+
+
+def test_writer_refuses_missing_directory(tmp_path) -> None:
+    """The daemon never creates directories — the writer enforces it."""
+    with pytest.raises(FileNotFoundError):
+        _writer(tmp_path / "does_not_exist")
+    assert not (tmp_path / "does_not_exist").exists()
+
+
+def test_writer_rejects_shape_change(tmp_path) -> None:
+    """A mid-scan geometry change raises instead of corrupting the stack."""
+    w = _writer(tmp_path)
+    w.append(np.zeros((4, 5), dtype=np.uint16), 1.0, 2.0)
+    with pytest.raises(ValueError):
+        w.append(np.zeros((6, 7), dtype=np.uint16), 3.0, 4.0)
+    assert w.finalize({}) == 1
+
+
+def test_writer_abort_leaves_valid_unfinalized_file(tmp_path) -> None:
+    """Abort closes the file; written frames survive, finalized stays unset."""
+    w = _writer(tmp_path)
+    w.append(np.ones((2, 2), dtype=np.uint8), 1.0, 2.0)
+    w.abort()
+    with h5py.File(tmp_path / "UC_Cam.h5", "r") as f:
+        assert f["frames"].shape == (1, 2, 2)
+        assert "finalized" not in f.attrs

--- a/Planning/data_capture/01_central_pva_capture_scope.md
+++ b/Planning/data_capture/01_central_pva_capture_scope.md
@@ -230,6 +230,15 @@ Output: probe report → design-lock addendum to this doc.
   chunked per shot, aligned shot-number + timestamp datasets, device metadata
   as attrs, light/no compression — consumers read arrays directly, no IMAQ
   decode at read time.
+- **(Sam) No container handcuffs**: HDF5 is the v0 *implementation* behind
+  the `FrameStackWriter` protocol (`geecs_bluesky/capture/writer.py`), not
+  the contract. The contract = `capture/FORMAT.md` + the `schema` attribute
+  stamped in every file (`geecs-capture/1`); a future container (e.g. Zarr)
+  is a new writer implementation + a reader branch, no daemon changes.
+  GEECS-Schemas stays out of it (it owns *config* vocabulary; data-file
+  contracts follow the `EVENT_SCHEMA.md` precedent — a versioned doc beside
+  the code, schema key in the data). Revisit a `capture_mode` format field
+  only if Phase 3 shows a real need.
 - **Dual-write validation tool**: per-scan diff (HDF5 vs PNGs — count, shot
   IDs, optionally pixel checksum). Runs continuously; its accumulated record
   is the deprecation evidence.


### PR DESCRIPTION
## What

The arc's first work-item PR into `feat/pva-capture` (per #693's process): the **capture daemon v0**, built directly on the Phase-0 measurements.

**GeecsBluesky 0.64.0 — `geecs_bluesky/capture/`** (new `capture` extra: p4p + h5py; CLI `geecs-capture-daemon`):
- `daemon.py` — `CaptureDaemon` (doc-stream consumer, best-effort like `SFileExportCallback`) + `ScanCaptureSession`: scan-gated PVA subscriptions from the start doc's `nonscalar_save_paths`, `acq_timestamp` dedupe (idle re-push), stale-window filter (gateway's cached pre-scan frame), ONE writer thread with a bounded queue (overflow counted, never silent), finalize stamps per-device reconciliation counters into the file + logs them (the dual-write diff seed).
- `writer.py` — `FrameStackWriter` protocol (the deliberate container seam — owner decision: no HDF5 handcuffs) + `Hdf5StackWriter` (append-per-frame trailing flush; **refuses to create directories** — engine owns `scans/ScanNNN/<device>/`, cross-package invariant).
- `discovery.py` — devicetype-registry camera discovery (v0 = Point Grey), two batched DB queries, PV names via `pv_naming` — no gateway imports (dep-graph rule).
- `subscriber.py` — `FrameSource` protocol (test seam) + `P4pFrameSource` (deep-queue monitors, `EPICS_PVA_ADDR_LIST` composed from targets before p4p context creation).
- `FORMAT.md` — the `geecs-capture/1` container contract (EVENT_SCHEMA.md pattern: versioned doc + schema key in the data).
- 11 hermetic tests (fake source + real HDF5 writer in tmp dirs; skip-without-extra pattern); CLAUDE.md truth-ups (package layout + the "images: two paths" doctrine now records the dual-write third path).

**GEECS-Core 0.4.0** — `GeecsDb.get_experiment_device_types()` batch query (mirrors `get_experiment_devices`; the audit's missing plumbing) + test.

Per-concern LOC: capture package ~640, tests ~330, GEECS-Core ~35, docs/config the rest.

## Doctrine

Dual-write Phase: the LV per-shot file save stays ON — the daemon runs alongside, its files are the diff surface, a daemon failure cannot lose data. Scan-gated arming (owner decision); the possible first-shot race vs the ~1–2 s gate activation is a **measured** quantity in the live acceptance below, not an assumption.

## Tests

- GeecsBluesky: 630 passed, 1 skipped (full suite, no regressions); capture suite 11/11
- GEECS-Core: 18 passed incl. the new batch-query test

## Hardware verification (OWED — live acceptance)

- [ ] Daemon on the worker box, dual-writing beside a real 10-shot strict scan (Amp4In / HTU-NoGas)
- [ ] Reconciliation counters vs LV PNGs (count + `acq_timestamp` match)
- [ ] First-shot race measured (stale filter + gate activation)

## Review

- [ ] Adversarial review (fresh-context agent) — launching now
- [ ] Codex gate (maintainer-driven)

🤖 Generated with [Claude Code](https://claude.com/claude-code)