### PR TITLE
capture writer: shuffle+gzip-1 frame compression (0.64.1)

### DIFF
--- a/GeecsBluesky/CHANGELOG.md
+++ b/GeecsBluesky/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to `geecs-bluesky` are documented here.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
-## [0.64.1] - 2026-08-27
+## [0.65.0] - 2026-08-27
 
 ### Changed
 
@@ -12,7 +12,11 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   built-in HDF5 filters — readable everywhere, self-describing, schema
   unchanged at `geecs-capture/1`). Measured on real Scan003 frames:
   2.04 MB vs 7.92 MB raw vs ~2.5 MB for the equivalent LV PNGs, at
-  3.9 ms/frame write cost (negligible at 1–5 Hz).
+  3.9 ms/frame write cost on 600×600 frames; cost scales with frame
+  size (~25 ms/frame measured at 1025×1281) — trivial at 1 Hz fleet-wide;
+  a hypothetical many-large-camera 5 Hz scan could saturate the single
+  writer thread, degrading to counted queue_drops (per-device writer
+  threads are the future remedy).
 
 ## [0.64.0] - 2026-08-27
 

--- a/GeecsBluesky/CHANGELOG.md
+++ b/GeecsBluesky/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to `geecs-bluesky` are documented here.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.64.1] - 2026-08-27
+
+### Changed
+
+- **Capture frame stacks are now compressed** (shuffle + gzip level 1,
+  built-in HDF5 filters — readable everywhere, self-describing, schema
+  unchanged at `geecs-capture/1`). Measured on real Scan003 frames:
+  2.04 MB vs 7.92 MB raw vs ~2.5 MB for the equivalent LV PNGs, at
+  3.9 ms/frame write cost (negligible at 1–5 Hz).
+
 ## [0.64.0] - 2026-08-27
 
 ### Added

--- a/GeecsBluesky/geecs_bluesky/capture/FORMAT.md
+++ b/GeecsBluesky/geecs_bluesky/capture/FORMAT.md
@@ -12,7 +12,7 @@ the `schema` attribute, never on the file extension alone.
 
 | Path | Content |
 |---|---|
-| `/frames` | `(N, H, W)` image stack, native dtype, chunked `(1, H, W)`, appended per frame |
+| `/frames` | `(N, H, W)` image stack, native dtype, chunked `(1, H, W)`, appended per frame; shuffle + gzip-1 (built-in filters — readable by any HDF5 library; the file self-describes its filters, so readers need no knowledge of this choice and the schema stays `geecs-capture/1`) |
 | `/acq_timestamp` | `(N,)` float64 — the device acquisition timestamp (Unix s; PVA timestamp = LabVIEW time − 2082844800), the universal join key |
 | `/recv_timestamp` | `(N,)` float64 — daemon receive time (Unix s), diagnostic only |
 

--- a/GeecsBluesky/geecs_bluesky/capture/writer.py
+++ b/GeecsBluesky/geecs_bluesky/capture/writer.py
@@ -102,6 +102,13 @@ class Hdf5StackWriter:
                 maxshape=(None, *frame.shape),
                 chunks=(1, *frame.shape),
                 dtype=frame.dtype,
+                # Built-in filters only (every HDF5 reader decodes them, no
+                # plugin dependency): shuffle + gzip-1 measured 2.04 MB vs
+                # 7.92 raw vs ~2.5 PNG on real Scan003 frames at 3.9 ms/frame
+                # — beats the LV PNGs while staying self-describing.
+                shuffle=True,
+                compression="gzip",
+                compression_opts=1,
             )
         if frame.shape != self._frames.shape[1:]:
             # A mid-scan ROI/binning change breaks the stack contract —

--- a/GeecsBluesky/pyproject.toml
+++ b/GeecsBluesky/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-bluesky"
-version = "0.64.0"
+version = "0.64.1"
 description = "Bluesky / ophyd-async bridge for the GEECS control system"
 authors = ["Sam Barber <sbarber@lbl.gov>"]
 readme = "README.md"

--- a/GeecsBluesky/pyproject.toml
+++ b/GeecsBluesky/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-bluesky"
-version = "0.64.1"
+version = "0.65.0"
 description = "Bluesky / ophyd-async bridge for the GEECS control system"
 authors = ["Sam Barber <sbarber@lbl.gov>"]
 readme = "README.md"

--- a/GeecsBluesky/tests/capture/test_writer.py
+++ b/GeecsBluesky/tests/capture/test_writer.py
@@ -39,6 +39,7 @@ def test_writer_appends_and_finalizes(tmp_path) -> None:
         assert f["frames"].shape == (3, 4, 5)
         assert f["frames"].dtype == np.uint16
         assert f["frames"].compression == "gzip"
+        assert f["frames"].compression_opts == 1
         assert f["frames"].shuffle is True
         assert list(f["acq_timestamp"][:]) == [1000.0, 1001.0, 1002.0]
         assert list(f["recv_timestamp"][:]) == [2000.0, 2001.0, 2002.0]

--- a/GeecsBluesky/tests/capture/test_writer.py
+++ b/GeecsBluesky/tests/capture/test_writer.py
@@ -38,6 +38,8 @@ def test_writer_appends_and_finalizes(tmp_path) -> None:
         assert f.attrs["duplicates_dropped"] == 1
         assert f["frames"].shape == (3, 4, 5)
         assert f["frames"].dtype == np.uint16
+        assert f["frames"].compression == "gzip"
+        assert f["frames"].shuffle is True
         assert list(f["acq_timestamp"][:]) == [1000.0, 1001.0, 1002.0]
         assert list(f["recv_timestamp"][:]) == [2000.0, 2001.0, 2002.0]
         assert (f["frames"][2] == 2).all()

--- a/Planning/data_capture/01_central_pva_capture_scope.md
+++ b/Planning/data_capture/01_central_pva_capture_scope.md
@@ -240,7 +240,8 @@ handoff, systemd unit, the all-cameras save-set stress test.
   Phase 5), daemon heartbeat.
 - **(Sam) HDF5 stores decoded arrays**: `(N, H, W)` uint16/uint8 dataset
   chunked per shot, aligned shot-number + timestamp datasets, device metadata
-  as attrs, light/no compression — consumers read arrays directly, no IMAQ
+  as attrs, light compression (shuffle+gzip-1, empirically chosen 2026-08-27) —
+  consumers read arrays directly, no IMAQ
   decode at read time.
 - **(Sam) No container handcuffs**: HDF5 is the v0 *implementation* behind
   the `FrameStackWriter` protocol (`geecs_bluesky/capture/writer.py`), not


### PR DESCRIPTION
Flips the v0 'no compression' default after the owner spotted the 3x size inversion vs LV PNGs. Empirical basis (real Scan003 frames, benchmark in session): shuffle+gzip-1 = **2.04 MB vs 7.92 raw vs ~2.5 PNG**, 3.9 ms/frame write cost (negligible at 1–5 Hz). Built-in HDF5 filters only — every reader decodes them, files stay self-describing, schema unchanged (geecs-capture/1). Test asserts the filters on the dataset; capture suite 18/18. The running daemon picks this up on its next restart; existing raw stacks remain readable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)