### PR TITLE
pva gateway: timestamp plausibility post-conversion (0.4.4) — capture-arc chip

### DIFF
--- a/GeecsPvaGateway/CHANGELOG.md
+++ b/GeecsPvaGateway/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to this package will be documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
-## [0.4.4] - 2026-08-27
+## [0.4.4] — 2026-08-27
 
 ### Fixed
 
@@ -15,7 +15,6 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   timestamp (the capture daemon's dedupe, the analysis `acq_timestamp`
   join). Found by the capture-arc audit (2026-08-27); reaches the fleet
   on next service restart (pull-on-restart launcher).
-
 
 ## [0.4.3] — 2026-08-20
 

--- a/GeecsPvaGateway/CHANGELOG.md
+++ b/GeecsPvaGateway/CHANGELOG.md
@@ -3,6 +3,20 @@
 All notable changes to this package will be documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.4.4] - 2026-08-27
+
+### Fixed
+
+- **Timestamp plausibility checked post-epoch-conversion** in
+  `_frame_timestamp` (parity with the CA gateway's PV_CONTRACT ladder):
+  a LabVIEW value in `(0, offset]` previously became a *negative* Unix
+  timestamp on the published NTNDArray instead of falling through to
+  receive time — poisoning any consumer keying frames on the PVA
+  timestamp (the capture daemon's dedupe, the analysis `acq_timestamp`
+  join). Found by the capture-arc audit (2026-08-27); reaches the fleet
+  on next service restart (pull-on-restart launcher).
+
+
 ## [0.4.3] — 2026-08-20
 
 ### Changed

--- a/GeecsPvaGateway/geecs_pva_gateway/server.py
+++ b/GeecsPvaGateway/geecs_pva_gateway/server.py
@@ -45,11 +45,22 @@ RESTART_EXIT_CODE = 86
 
 
 def _frame_timestamp(update: dict) -> float:
-    """Frame time from the GEECS timestamp ladder, else receive time."""
+    """Frame time from the GEECS timestamp ladder, else receive time.
+
+    Plausibility is checked on the *converted* (post-epoch-offset) value,
+    matching the CA gateway's contract (PV_CONTRACT.md "Timestamp ladder"):
+    a LabVIEW value in ``(0, offset]`` — a device counting from boot, or a
+    zeroed channel — must fall through to receive time, never become a
+    negative Unix timestamp (which would poison downstream consumers that
+    key frames on the PVA timestamp, e.g. the capture daemon's dedupe and
+    the analysis-side ``acq_timestamp`` join).
+    """
     for var in _TIMESTAMP_VARS:
         value = update.get(var)
-        if isinstance(value, (int, float)) and value > 0:
-            return float(value) - _LABVIEW_EPOCH_OFFSET
+        if isinstance(value, (int, float)):
+            converted = float(value) - _LABVIEW_EPOCH_OFFSET
+            if converted > 0:
+                return converted
     return time.time()
 
 

--- a/GeecsPvaGateway/pyproject.toml
+++ b/GeecsPvaGateway/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-pva-gateway"
-version = "0.4.3"
+version = "0.4.4"
 description = "Distributed pvAccess gateway serving GEECS camera images as NTNDArray PVs"
 authors = ["Sam Barber <sbarber@lbl.gov>"]
 readme = "README.md"

--- a/GeecsPvaGateway/tests/test_server.py
+++ b/GeecsPvaGateway/tests/test_server.py
@@ -345,3 +345,36 @@ async def test_restart_pv_shuts_down_cleanly():
         if not task.done():
             await _shutdown(task)
         await cam.stop()
+
+
+class TestFrameTimestampPlausibility:
+    """Plausibility is checked post-epoch-conversion (PV_CONTRACT parity)."""
+
+    def test_valid_labview_timestamp_converts(self) -> None:
+        from geecs_pva_gateway.server import _LABVIEW_EPOCH_OFFSET, _frame_timestamp
+
+        lv = _LABVIEW_EPOCH_OFFSET + 1_000_000.5
+        assert _frame_timestamp({"acq_timestamp": lv}) == 1_000_000.5
+
+    def test_small_positive_labview_value_falls_through(self) -> None:
+        """A value in (0, offset] must yield receive time, never negative."""
+        import time as _time
+
+        from geecs_pva_gateway.server import _frame_timestamp
+
+        before = _time.time()
+        ts = _frame_timestamp({"acq_timestamp": 12345.0, "systimestamp": 99.0})
+        assert ts >= before  # receive-time fallback, not a negative stamp
+
+    def test_ladder_prefers_acq_then_sys(self) -> None:
+        from geecs_pva_gateway.server import _LABVIEW_EPOCH_OFFSET, _frame_timestamp
+
+        assert (
+            _frame_timestamp(
+                {
+                    "acq_timestamp": 1.0,  # implausible → skipped
+                    "systimestamp": _LABVIEW_EPOCH_OFFSET + 42.0,
+                }
+            )
+            == 42.0
+        )

--- a/GeecsPvaGateway/tests/test_server.py
+++ b/GeecsPvaGateway/tests/test_server.py
@@ -345,36 +345,3 @@ async def test_restart_pv_shuts_down_cleanly():
         if not task.done():
             await _shutdown(task)
         await cam.stop()
-
-
-class TestFrameTimestampPlausibility:
-    """Plausibility is checked post-epoch-conversion (PV_CONTRACT parity)."""
-
-    def test_valid_labview_timestamp_converts(self) -> None:
-        from geecs_pva_gateway.server import _LABVIEW_EPOCH_OFFSET, _frame_timestamp
-
-        lv = _LABVIEW_EPOCH_OFFSET + 1_000_000.5
-        assert _frame_timestamp({"acq_timestamp": lv}) == 1_000_000.5
-
-    def test_small_positive_labview_value_falls_through(self) -> None:
-        """A value in (0, offset] must yield receive time, never negative."""
-        import time as _time
-
-        from geecs_pva_gateway.server import _frame_timestamp
-
-        before = _time.time()
-        ts = _frame_timestamp({"acq_timestamp": 12345.0, "systimestamp": 99.0})
-        assert ts >= before  # receive-time fallback, not a negative stamp
-
-    def test_ladder_prefers_acq_then_sys(self) -> None:
-        from geecs_pva_gateway.server import _LABVIEW_EPOCH_OFFSET, _frame_timestamp
-
-        assert (
-            _frame_timestamp(
-                {
-                    "acq_timestamp": 1.0,  # implausible → skipped
-                    "systimestamp": _LABVIEW_EPOCH_OFFSET + 42.0,
-                }
-            )
-            == 42.0
-        )

--- a/GeecsPvaGateway/tests/test_timestamp.py
+++ b/GeecsPvaGateway/tests/test_timestamp.py
@@ -1,0 +1,36 @@
+"""Pure-unit tests for the frame-timestamp ladder (no sockets — unmarked)."""
+
+from __future__ import annotations
+
+
+class TestFrameTimestampPlausibility:
+    """Plausibility is checked post-epoch-conversion (PV_CONTRACT parity)."""
+
+    def test_valid_labview_timestamp_converts(self) -> None:
+        from geecs_pva_gateway.server import _LABVIEW_EPOCH_OFFSET, _frame_timestamp
+
+        lv = _LABVIEW_EPOCH_OFFSET + 1_000_000.5
+        assert _frame_timestamp({"acq_timestamp": lv}) == 1_000_000.5
+
+    def test_small_positive_labview_value_falls_through(self) -> None:
+        """A value in (0, offset] must yield receive time, never negative."""
+        import time as _time
+
+        from geecs_pva_gateway.server import _frame_timestamp
+
+        before = _time.time()
+        ts = _frame_timestamp({"acq_timestamp": 12345.0, "systimestamp": 99.0})
+        assert ts >= before  # receive-time fallback, not a negative stamp
+
+    def test_ladder_prefers_acq_then_sys(self) -> None:
+        from geecs_pva_gateway.server import _LABVIEW_EPOCH_OFFSET, _frame_timestamp
+
+        assert (
+            _frame_timestamp(
+                {
+                    "acq_timestamp": 1.0,  # implausible → skipped
+                    "systimestamp": _LABVIEW_EPOCH_OFFSET + 42.0,
+                }
+            )
+            == 42.0
+        )


### PR DESCRIPTION
The audit-found bug (chip): `_frame_timestamp` checked `value > 0` BEFORE subtracting the LabVIEW epoch offset, so a value in `(0, offset]` (device counting from boot, zeroed channel) published a **negative Unix timestamp** instead of falling back to receive time — poisoning any consumer that keys frames on the PVA timestamp: the capture daemon's dedupe/stale filter and the analysis-side `acq_timestamp` join. Now checked on the converted value (CA gateway PV_CONTRACT ladder parity), with 3 tests (valid conversion, small-positive fallback, ladder preference). Patch bump 0.4.4 + CHANGELOG. Fleet pickup: pull-on-restart launcher — reaches camera servers on next service restart; no urgency (no device currently emits implausible stamps — Phase-0 evidence shows healthy ladders).

🤖 Generated with [Claude Code](https://claude.com/claude-code)