### PR TITLE
capture production trio: liveness preflight, systemd kit, dual-write diff CLI (0.68.0)

### DIFF
--- a/GeecsBluesky/CHANGELOG.md
+++ b/GeecsBluesky/CHANGELOG.md
@@ -4,6 +4,29 @@ All notable changes to `geecs-bluesky` are documented here.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.68.0] - 2026-08-28
+
+### Added
+
+- **The arc-end production trio** (promotion prerequisites,
+  `Planning/data_capture/01_central_pva_capture_scope.md`):
+  1. **Daemon-liveness preflight** — `capture/heartbeat.py` (daemon
+     touches a JSON heartbeat every 10 s from a side thread; engine's
+     `preflight_capture_liveness` REFUSES a toggle-off scan pre-claim,
+     fail-closed, when the heartbeat is missing/stale — with native
+     saving off, a dead daemon means images exist nowhere). Wired in
+     both execution paths; the heartbeat file inherits the existing
+     shared-filesystem deployment constraint. Proves process liveness
+     only; subscription health stays covered by reconciliation counters.
+  2. **systemd deployment kit** — `capture/deploy/geecs-capture.service`
+     + `DEPLOYMENT.md` (the qserver pattern; co-location with the worker
+     is a stated requirement; migration = copy unit + install).
+  3. **Dual-write diff CLI** — `geecs-capture-diff` (`capture/diff.py`):
+     per scan/device, canonical-ms timestamp join of stack vs native
+     PNGs with per-pair IMAQ-decoded pixel comparison; verdicts
+     pass/mismatch/capture_only/no_stack; JSONL evidence log via
+     `--log`; exit 1 on mismatch. Weeks of clean log = the Phase-6 gate.
+
 ## [0.67.0] - 2026-08-27
 
 ### Added

--- a/GeecsBluesky/CHANGELOG.md
+++ b/GeecsBluesky/CHANGELOG.md
@@ -21,8 +21,14 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
      devices the daemon isn't covering (a daemon started before a
      camera joined the DB); the daemon **removes the heartbeat on
      clean shutdown** so `systemctl stop` refuses immediately instead
-     of after the 30 s stale window; the beat thread survives any
-     write exception; a relative `[capture] heartbeat_path` override
+     of after the 30 s stale window — including under SIGTERM, which
+     the daemon converts to `SystemExit` so the cleanup actually runs
+     (codex gate P1: Python's default SIGTERM action skips `finally`,
+     so systemd's stop signal would have left the heartbeat behind); a
+     fresh heartbeat **without a device roster is refused** as corrupt
+     state, not tolerated (codex gate P2 — coverage cannot be
+     verified); the beat thread survives any write exception; a
+     relative `[capture] heartbeat_path` override
      is rejected (it would split writer from reader by CWD). The check
      is host-local (same host + service user as the daemon — stated in
      the refusal message); proves process liveness only — subscription

--- a/GeecsBluesky/CHANGELOG.md
+++ b/GeecsBluesky/CHANGELOG.md
@@ -11,21 +11,37 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - **The arc-end production trio** (promotion prerequisites,
   `Planning/data_capture/01_central_pva_capture_scope.md`):
   1. **Daemon-liveness preflight** — `capture/heartbeat.py` (daemon
-     touches a JSON heartbeat every 10 s from a side thread; engine's
+     writes a JSON heartbeat every 10 s from a side thread; engine's
      `preflight_capture_liveness` REFUSES a toggle-off scan pre-claim,
      fail-closed, when the heartbeat is missing/stale — with native
      saving off, a dead daemon means images exist nowhere). Wired in
-     both execution paths; the heartbeat file inherits the existing
-     shared-filesystem deployment constraint. Proves process liveness
-     only; subscription health stays covered by reconciliation counters.
+     both execution paths (the queue path pinned by its own test).
+     Review hardening: the payload carries the monitored **device
+     roster** and the preflight refuses toggle-off scans whose capture
+     devices the daemon isn't covering (a daemon started before a
+     camera joined the DB); the daemon **removes the heartbeat on
+     clean shutdown** so `systemctl stop` refuses immediately instead
+     of after the 30 s stale window; the beat thread survives any
+     write exception; a relative `[capture] heartbeat_path` override
+     is rejected (it would split writer from reader by CWD). The check
+     is host-local (same host + service user as the daemon — stated in
+     the refusal message); proves process liveness only — subscription
+     health stays covered by reconciliation counters.
   2. **systemd deployment kit** — `capture/deploy/geecs-capture.service`
      + `DEPLOYMENT.md` (the qserver pattern; co-location with the worker
-     is a stated requirement; migration = copy unit + install).
+     is a stated requirement; migration = copy unit + install; runbook
+     covers toggle-off restart hazards and the recurring diff sweep).
   3. **Dual-write diff CLI** — `geecs-capture-diff` (`capture/diff.py`):
-     per scan/device, canonical-ms timestamp join of stack vs native
-     PNGs with per-pair IMAQ-decoded pixel comparison; verdicts
-     pass/mismatch/capture_only/no_stack; JSONL evidence log via
-     `--log`; exit 1 on mismatch. Weeks of clean log = the Phase-6 gate.
+     per scan/device, the analysis join's exact contract — canonical-ms
+     timestamp keys **plus its ±1 ms candidate tolerance** (review
+     Monte-Carlo: without candidates, epoch/wire float round-trips at
+     the rounding boundary produce false mismatch pairs) — with
+     per-pair IMAQ-decoded pixel comparison under numpy promotion (no
+     dtype cast: a cast can wrap values and mask a real difference);
+     verdicts pass/mismatch/capture_only/no_stack; incremental JSONL
+     evidence log via `--log`; exit 1 = mismatch, 2 = operational
+     error (unreadable scan path — the sweep continues past it).
+     Weeks of clean log = the Phase-6 gate.
 
 ## [0.67.0] - 2026-08-27
 

--- a/GeecsBluesky/capture/deploy/DEPLOYMENT.md
+++ b/GeecsBluesky/capture/deploy/DEPLOYMENT.md
@@ -1,0 +1,64 @@
+# Capture daemon deployment runbook
+
+The central PVA capture daemon (`geecs_bluesky.capture`, CLI
+`geecs-capture-daemon`) runs as a systemd service **on the queueserver
+worker host** — that co-location is a requirement, not a preference: the
+start document's save paths are composed on the worker's filesystem view,
+and the liveness heartbeat (`capture/heartbeat.py`) that gates toggle-off
+scans is a file the engine reads locally. When the services box migrates,
+the worker and the daemon move together.
+
+## Install (once per host)
+
+1. The host already has the GEECS-Plugins checkout and the worker's poetry
+   env (`qserver/deploy/DEPLOYMENT.md`). Add the capture extra:
+
+   ```bash
+   cd /opt/geecs/GEECS-Plugins/GeecsBluesky
+   poetry install --extras "ca qserver tiled capture"
+   ```
+
+   (`capture` = p4p + h5py + pyzmq. Keep whatever extras the worker
+   already uses — this env is shared.)
+
+2. Copy `geecs-capture.service` to `/etc/systemd/system/`, replace the
+   checkout-path and poetry-path placeholders (same values as the qserver
+   unit on this host), set the experiment name, then:
+
+   ```bash
+   sudo systemctl daemon-reload
+   sudo systemctl enable --now geecs-capture
+   ```
+
+3. Verify: `journalctl -u geecs-capture -n 5` shows the discovery line
+   ("capture discovery: N eligible cameras") and the running banner; the
+   heartbeat file appears at `~/.local/state/geecs-capture/heartbeat.json`
+   (override: `[capture] heartbeat_path` in the shared config.ini) and its
+   timestamp refreshes every ~10 s.
+
+## Operational contract
+
+- **Pure consumer**: subscribes (doc stream + PVA) and writes stacks;
+  commands nothing except the eager `save="off"` writes the *engine* plans
+  for capture-owned cameras. If the daemon dies, scans and native saving
+  are unaffected — but **toggle-off scans are refused pre-claim** by the
+  engine's liveness preflight until it is back (that is the safety design,
+  not a malfunction).
+- One reconciliation log line per scan per camera (`journalctl`); the
+  counter identity is documented in `geecs_bluesky/capture/FORMAT.md`.
+- Restarting is always safe between scans (`systemctl restart
+  geecs-capture`); a restart mid-scan loses that scan's capture only —
+  native files (dual-write) are untouched.
+- **Restart the daemon after camera roster changes** (devices added to the
+  experiment, devicetype fixes): targets are discovered at startup, and
+  the daemon errors loudly on engine-listed devices it has no target for.
+- Upgrades: `git pull` in the checkout + `systemctl restart geecs-capture`
+  (the env is editable-installed; re-run poetry install only when
+  dependencies changed).
+
+## Migration to a new host
+
+Copy the unit, install per step 1–2, ensure the shared `config.ini` and
+the data-share mount match the worker's view, start. Nothing else is
+host-bound — the daemon derives everything from the DB, the shared
+config, and the document stream.

--- a/GeecsBluesky/capture/deploy/DEPLOYMENT.md
+++ b/GeecsBluesky/capture/deploy/DEPLOYMENT.md
@@ -33,8 +33,11 @@ the worker and the daemon move together.
 3. Verify: `journalctl -u geecs-capture -n 5` shows the discovery line
    ("capture discovery: N eligible cameras") and the running banner; the
    heartbeat file appears at `~/.local/state/geecs-capture/heartbeat.json`
-   (override: `[capture] heartbeat_path` in the shared config.ini) and its
-   timestamp refreshes every ~10 s.
+   **in the service user's home** — under sudo that is NOT your own `~`
+   (override: `[capture] heartbeat_path` in the shared config.ini, absolute
+   paths only) — and its timestamp refreshes every ~10 s. On a clean stop
+   the daemon removes the file, so toggle-off scans are refused
+   immediately, not after the 30 s stale window.
 
 ## Operational contract
 
@@ -47,11 +50,28 @@ the worker and the daemon move together.
 - One reconciliation log line per scan per camera (`journalctl`); the
   counter identity is documented in `geecs_bluesky/capture/FORMAT.md`.
 - Restarting is always safe between scans (`systemctl restart
-  geecs-capture`); a restart mid-scan loses that scan's capture only —
-  native files (dual-write) are untouched.
+  geecs-capture`). A restart mid-scan loses that scan's capture; on a
+  **dual-write** scan the native files are untouched, but on a
+  **toggle-off** scan there are no native files — a mid-scan restart
+  loses those images outright, so never restart while a toggle-off scan
+  is running. (A daemon killed without cleanup — SIGKILL, power loss —
+  leaves its heartbeat behind for up to 30 s, during which a toggle-off
+  submission would still pass preflight; a clean stop removes it.)
 - **Restart the daemon after camera roster changes** (devices added to the
-  experiment, devicetype fixes): targets are discovered at startup, and
-  the daemon errors loudly on engine-listed devices it has no target for.
+  experiment, devicetype fixes): targets are discovered at startup, the
+  daemon errors loudly on engine-listed devices it has no target for, and
+  the engine's toggle-off preflight refuses scans whose capture devices
+  are missing from the heartbeat's roster.
+- The Phase-6 evidence log is produced by a recurring `geecs-capture-diff`
+  sweep — schedule it, e.g. a service-user cron line diffing yesterday's
+  scans nightly:
+
+  ```
+  15 6 * * * cd /opt/geecs/GEECS-Plugins/GeecsBluesky && <poetry> run geecs-capture-diff <yesterday's scans dir>/Scan* --log ~/.local/state/geecs-capture/diff-evidence.jsonl
+  ```
+
+  (exit 0 clean, 1 on a mismatch, 2 on operational errors such as an
+  unmounted share — alert on non-zero.)
 - Upgrades: `git pull` in the checkout + `systemctl restart geecs-capture`
   (the env is editable-installed; re-run poetry install only when
   dependencies changed).

--- a/GeecsBluesky/capture/deploy/geecs-capture.service
+++ b/GeecsBluesky/capture/deploy/geecs-capture.service
@@ -1,0 +1,36 @@
+# Template unit for the GEECS central PVA capture daemon.
+# Copy to /etc/systemd/system/geecs-capture.service on the worker host (the
+# daemon MUST run on the machine sharing the queueserver worker's filesystem
+# view — the start doc's save paths and the liveness heartbeat both assume
+# it), then replace every /opt/geecs/GEECS-Plugins placeholder with that
+# host's checkout path before enabling the unit.
+
+[Unit]
+Description=GEECS PVA capture daemon (per-device frame stacks)
+# Not a hard dependency: the daemon reconnects to the doc stream on its own,
+# but ordering after the qserver keeps clean-boot logs tidy.
+After=network-online.target geecs-qserver.service
+Wants=network-online.target
+
+[Service]
+Type=exec
+
+# Public repo placeholder only. Use the same unprivileged service account as
+# the queueserver (shared filesystem view, shared config.ini).
+User=geecs
+
+WorkingDirectory=/opt/geecs/GEECS-Plugins/GeecsBluesky
+
+# Placeholder: the GEECS experiment name.
+Environment="GEECS_CAPTURE_EXPERIMENT=Undulator"
+
+# Poetry's ABSOLUTE path is required (systemd PATH omits ~/.local/bin) —
+# locate it as the service user with `command -v poetry` and paste it here.
+# --doc-addr defaults to the shared config's [qserver] doc_addr; pass it
+# explicitly if the worker's proxy is not on this host's localhost:5568.
+ExecStart=/home/geecs/.local/bin/poetry run geecs-capture-daemon --experiment ${GEECS_CAPTURE_EXPERIMENT}
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target

--- a/GeecsBluesky/geecs_bluesky/capture/__main__.py
+++ b/GeecsBluesky/geecs_bluesky/capture/__main__.py
@@ -94,6 +94,12 @@ def main(argv: list[str] | None = None) -> int:
 
     threading.Thread(target=_beat, name="capture-heartbeat", daemon=True).start()
 
+    # systemctl stop sends SIGTERM, whose default action kills the process
+    # WITHOUT running the finally below — the tombstone would never fire
+    # on exactly the deployment path it exists for (codex gate P1). Convert
+    # it to SystemExit so the cleanup runs.
+    _install_sigterm_handler()
+
     from bluesky.callbacks.zmq import RemoteDispatcher
 
     dispatcher = RemoteDispatcher(doc_addr)
@@ -113,6 +119,24 @@ def main(argv: list[str] | None = None) -> int:
         # toggle-off scans immediately, not after the stale window.
         clear_heartbeat()
     return 0
+
+
+def _install_sigterm_handler() -> None:
+    """Make SIGTERM raise ``SystemExit`` so ``finally`` cleanup runs.
+
+    Only possible from the main thread; anywhere else (an embedding test
+    harness) the default disposition stays and cleanup relies on the
+    heartbeat's stale window instead.
+    """
+    import signal
+
+    def _terminate(signum, frame):  # noqa: ARG001 - signal handler signature
+        raise SystemExit(0)
+
+    try:
+        signal.signal(signal.SIGTERM, _terminate)
+    except ValueError:
+        logger.warning("not on the main thread — SIGTERM cleanup not installed")
 
 
 if __name__ == "__main__":

--- a/GeecsBluesky/geecs_bluesky/capture/__main__.py
+++ b/GeecsBluesky/geecs_bluesky/capture/__main__.py
@@ -72,6 +72,23 @@ def main(argv: list[str] | None = None) -> int:
         source_factory=lambda: P4pFrameSource(queue_size=args.queue_size),
     )
 
+    # Liveness heartbeat: the engine's toggle-off preflight refuses scans
+    # when this goes stale — start it before the dispatcher blocks.
+    import threading
+    import time
+
+    from .heartbeat import HEARTBEAT_PERIOD_S, write_heartbeat
+
+    def _beat() -> None:
+        while True:
+            try:
+                write_heartbeat(len(targets))
+            except OSError:
+                logger.warning("heartbeat write failed", exc_info=True)
+            time.sleep(HEARTBEAT_PERIOD_S)
+
+    threading.Thread(target=_beat, name="capture-heartbeat", daemon=True).start()
+
     from bluesky.callbacks.zmq import RemoteDispatcher
 
     dispatcher = RemoteDispatcher(doc_addr)

--- a/GeecsBluesky/geecs_bluesky/capture/__main__.py
+++ b/GeecsBluesky/geecs_bluesky/capture/__main__.py
@@ -77,13 +77,18 @@ def main(argv: list[str] | None = None) -> int:
     import threading
     import time
 
-    from .heartbeat import HEARTBEAT_PERIOD_S, write_heartbeat
+    from .heartbeat import HEARTBEAT_PERIOD_S, clear_heartbeat, write_heartbeat
+
+    target_names = [t.device for t in targets]
 
     def _beat() -> None:
         while True:
             try:
-                write_heartbeat(len(targets))
-            except OSError:
+                write_heartbeat(target_names)
+            except Exception:
+                # Broad on purpose: any uncaught error would kill this
+                # thread permanently while the daemon keeps capturing —
+                # a silent path to perpetual toggle-off refusal.
                 logger.warning("heartbeat write failed", exc_info=True)
             time.sleep(HEARTBEAT_PERIOD_S)
 
@@ -104,6 +109,9 @@ def main(argv: list[str] | None = None) -> int:
         pass
     finally:
         daemon.shutdown()
+        # Tombstone: a clean stop (systemctl stop, Ctrl-C) must refuse
+        # toggle-off scans immediately, not after the stale window.
+        clear_heartbeat()
     return 0
 
 

--- a/GeecsBluesky/geecs_bluesky/capture/diff.py
+++ b/GeecsBluesky/geecs_bluesky/capture/diff.py
@@ -1,0 +1,176 @@
+"""The dual-write diff: capture stacks vs native PNGs, per scan.
+
+The Phase-6 evidence engine. For every device folder in a scan that holds
+a capture stack, join the
+stack's per-frame ``acq_timestamp``s against the native per-shot files'
+filename timestamps (the same canonical-millisecond keys the analysis join
+uses) and pixel-compare every matched pair (IMAQ-decoded PNG vs stack
+frame — proven bit-identical on healthy dual-writes). One verdict line per
+device, optionally appended to a JSONL evidence log; a non-zero exit on
+any mismatch. Weeks of clean log entries are the PNG-deprecation gate
+(``Planning/data_capture/01_central_pva_capture_scope.md`` Phase 6).
+
+Vocabulary (per device):
+
+- ``matched`` — timestamps present on both sides; each is pixel-compared.
+- ``stack_only`` — frames only the daemon captured (pre-save-window extras,
+  or every frame on a toggle-off scan) — attributable, never a failure.
+- ``png_only`` — **the bad bucket**: a frame LV saved that capture missed.
+- verdicts: ``pass`` (no png_only, all matched pixel-identical),
+  ``capture_only`` (no PNGs at all — toggle-off scan, nothing to diff),
+  ``no_stack`` (PNGs but no stack — not captured; informational),
+  ``mismatch`` otherwise.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import sys
+import time
+from collections.abc import Callable
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+from geecs_data_utils.io.scan_stack import (
+    ShotRef,
+    find_stack_file,
+    read_shot,
+    read_stack_timestamps,
+)
+from geecs_data_utils.native_files import filename_timestamp_regex, timestamp_key
+
+logger = logging.getLogger(__name__)
+
+# Signature: path -> ndarray (the IMAQ-decoding native-file reader).
+PngReader = Callable[[Path], "object"]
+
+
+@dataclass
+class DeviceDiff:
+    """One device's dual-write reconciliation for one scan."""
+
+    scan: str
+    device: str
+    matched: int
+    pixel_identical: int
+    png_only: int
+    stack_only: int
+    verdict: str
+
+
+def _default_png_reader(path: Path):
+    from geecs_data_utils.io.images import read_imaq_image
+
+    return read_imaq_image(path)
+
+
+def diff_device_dir(
+    device_dir: Path, *, png_reader: PngReader | None = None
+) -> DeviceDiff | None:
+    """Diff one scan device folder; ``None`` when there is nothing to say.
+
+    A folder with neither a stack nor native files (a scalar-only device)
+    returns ``None``; every other combination gets a verdict.
+    """
+    import numpy as np
+
+    png_reader = png_reader or _default_png_reader
+    scan = device_dir.parent.name
+    stack = find_stack_file(device_dir)
+    regex = filename_timestamp_regex(".png")
+    pngs_by_key: dict[int, Path] = {}
+    for f in device_dir.iterdir():
+        m = regex.search(f.name)
+        if m:
+            pngs_by_key[timestamp_key(float(m.group("ts")))] = f
+
+    if stack is None:
+        if not pngs_by_key:
+            return None
+        return DeviceDiff(scan, device_dir.name, 0, 0, len(pngs_by_key), 0, "no_stack")
+
+    stack_ts = read_stack_timestamps(stack, labview_epoch=True)
+    stack_by_key = {timestamp_key(float(ts)): i for i, ts in enumerate(stack_ts)}
+
+    if not pngs_by_key:
+        return DeviceDiff(
+            scan, device_dir.name, 0, 0, 0, len(stack_by_key), "capture_only"
+        )
+
+    matched_keys = sorted(set(stack_by_key) & set(pngs_by_key))
+    png_only = len(set(pngs_by_key) - set(stack_by_key))
+    stack_only = len(set(stack_by_key) - set(pngs_by_key))
+    identical = 0
+    for key in matched_keys:
+        frame = read_shot(ShotRef(stack, stack_by_key[key]))
+        png = np.asarray(png_reader(pngs_by_key[key]))
+        if frame.shape == png.shape and np.array_equal(frame, png.astype(frame.dtype)):
+            identical += 1
+        else:
+            logger.error(
+                "%s/%s: pixel mismatch at timestamp key %d",
+                scan,
+                device_dir.name,
+                key,
+            )
+    verdict = "pass" if png_only == 0 and identical == len(matched_keys) else "mismatch"
+    return DeviceDiff(
+        scan,
+        device_dir.name,
+        len(matched_keys),
+        identical,
+        png_only,
+        stack_only,
+        verdict,
+    )
+
+
+def diff_scan(
+    scan_dir: Path, *, png_reader: PngReader | None = None
+) -> list[DeviceDiff]:
+    """Diff every device folder of one scan directory."""
+    results: list[DeviceDiff] = []
+    for child in sorted(scan_dir.iterdir()):
+        if not child.is_dir() or child.name == "analysis_status":
+            continue
+        result = diff_device_dir(child, png_reader=png_reader)
+        if result is not None:
+            results.append(result)
+    return results
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI: diff scan folder(s); append the evidence log; exit 1 on mismatch."""
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("scans", nargs="+", help="scan folder path(s) (ScanNNN dirs)")
+    ap.add_argument(
+        "--log", default=None, help="JSONL evidence log to append verdicts to"
+    )
+    args = ap.parse_args(argv)
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
+
+    failed = False
+    records: list[dict] = []
+    for scan in args.scans:
+        for result in diff_scan(Path(scan)):
+            row = {"checked_at": time.time(), **asdict(result)}
+            records.append(row)
+            print(
+                f"{result.scan} {result.device}: {result.verdict} "
+                f"(matched={result.matched} identical={result.pixel_identical} "
+                f"png_only={result.png_only} stack_only={result.stack_only})"
+            )
+            if result.verdict == "mismatch":
+                failed = True
+    if args.log and records:
+        log_path = Path(args.log).expanduser()
+        with log_path.open("a") as f:
+            for row in records:
+                f.write(json.dumps(row) + "\n")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/GeecsBluesky/geecs_bluesky/capture/diff.py
+++ b/GeecsBluesky/geecs_bluesky/capture/diff.py
@@ -3,8 +3,8 @@
 The Phase-6 evidence engine. For every device folder in a scan that holds
 a capture stack, join the
 stack's per-frame ``acq_timestamp``s against the native per-shot files'
-filename timestamps (the same canonical-millisecond keys the analysis join
-uses) and pixel-compare every matched pair (IMAQ-decoded PNG vs stack
+filename timestamps — the analysis join's exact contract: canonical
+millisecond keys plus its \u00b11 ms candidate tolerance — and pixel-compare every matched pair (IMAQ-decoded PNG vs stack
 frame — proven bit-identical on healthy dual-writes). One verdict line per
 device, optionally appended to a JSONL evidence log; a non-zero exit on
 any mismatch. Weeks of clean log entries are the PNG-deprecation gate
@@ -39,7 +39,11 @@ from geecs_data_utils.io.scan_stack import (
     read_shot,
     read_stack_timestamps,
 )
-from geecs_data_utils.native_files import filename_timestamp_regex, timestamp_key
+from geecs_data_utils.native_files import (
+    filename_timestamp_regex,
+    timestamp_key,
+    timestamp_key_candidates,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -92,34 +96,55 @@ def diff_device_dir(
         return DeviceDiff(scan, device_dir.name, 0, 0, len(pngs_by_key), 0, "no_stack")
 
     stack_ts = read_stack_timestamps(stack, labview_epoch=True)
-    stack_by_key = {timestamp_key(float(ts)): i for i, ts in enumerate(stack_ts)}
+    stack_by_key: dict[int, int] = {}
+    for i, ts in enumerate(stack_ts):
+        # keep-first on duplicates — parity with the analysis join
+        stack_by_key.setdefault(timestamp_key(float(ts)), i)
 
     if not pngs_by_key:
         return DeviceDiff(
             scan, device_dir.name, 0, 0, 0, len(stack_by_key), "capture_only"
         )
 
-    matched_keys = sorted(set(stack_by_key) & set(pngs_by_key))
-    png_only = len(set(pngs_by_key) - set(stack_by_key))
-    stack_only = len(set(stack_by_key) - set(pngs_by_key))
+    # The join mirrors the analysis join exactly: exact canonical-ms keys
+    # first, then ±1 ms candidate pairing for the rounding-boundary class
+    # (review of this PR Monte-Carlo'd the epoch/wire float round-trip:
+    # without candidates, boundary keys become false mismatch pairs).
+    pairs: list[tuple[int, int]] = []  # (png_key, stack_index)
+    residual_stack = dict(stack_by_key)
+    residual_png = dict(pngs_by_key)
+    for key in sorted(set(stack_by_key) & set(pngs_by_key)):
+        pairs.append((key, stack_by_key[key]))
+        residual_stack.pop(key, None)
+        residual_png.pop(key, None)
+    for key in sorted(residual_png):
+        for candidate in timestamp_key_candidates(key):
+            if candidate in residual_stack:
+                pairs.append((key, residual_stack.pop(candidate)))
+                residual_png.pop(key)
+                break
+    png_only = len(residual_png)
+    stack_only = len(residual_stack)
     identical = 0
-    for key in matched_keys:
-        frame = read_shot(ShotRef(stack, stack_by_key[key]))
-        png = np.asarray(png_reader(pngs_by_key[key]))
-        if frame.shape == png.shape and np.array_equal(frame, png.astype(frame.dtype)):
+    for png_key, stack_index in pairs:
+        frame = read_shot(ShotRef(stack, stack_index))
+        png = np.asarray(png_reader(pngs_by_key[png_key]))
+        # No dtype cast: a cast can wrap out-of-range values and mask a
+        # real difference; numpy's promotion compares values correctly.
+        if frame.shape == png.shape and np.array_equal(frame, png):
             identical += 1
         else:
             logger.error(
                 "%s/%s: pixel mismatch at timestamp key %d",
                 scan,
                 device_dir.name,
-                key,
+                png_key,
             )
-    verdict = "pass" if png_only == 0 and identical == len(matched_keys) else "mismatch"
+    verdict = "pass" if png_only == 0 and identical == len(pairs) else "mismatch"
     return DeviceDiff(
         scan,
         device_dir.name,
-        len(matched_keys),
+        len(pairs),
         identical,
         png_only,
         stack_only,
@@ -151,25 +176,37 @@ def main(argv: list[str] | None = None) -> int:
     args = ap.parse_args(argv)
     logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
 
-    failed = False
-    records: list[dict] = []
-    for scan in args.scans:
-        for result in diff_scan(Path(scan)):
-            row = {"checked_at": time.time(), **asdict(result)}
-            records.append(row)
-            print(
-                f"{result.scan} {result.device}: {result.verdict} "
-                f"(matched={result.matched} identical={result.pixel_identical} "
-                f"png_only={result.png_only} stack_only={result.stack_only})"
-            )
-            if result.verdict == "mismatch":
-                failed = True
-    if args.log and records:
-        log_path = Path(args.log).expanduser()
-        with log_path.open("a") as f:
-            for row in records:
-                f.write(json.dumps(row) + "\n")
-    return 1 if failed else 0
+    mismatch = False
+    op_error = False
+    log_file = Path(args.log).expanduser().open("a") if args.log else None
+    try:
+        for scan in args.scans:
+            try:
+                results = diff_scan(Path(scan))
+            except OSError as exc:
+                # Operational failure (missing path, unmounted share) is NOT
+                # a mismatch — distinct exit code, sweep continues.
+                logger.error("%s: unreadable (%s)", scan, exc)
+                op_error = True
+                continue
+            for result in results:
+                row = {"checked_at": time.time(), **asdict(result)}
+                print(
+                    f"{result.scan} {result.device}: {result.verdict} "
+                    f"(matched={result.matched} "
+                    f"identical={result.pixel_identical} "
+                    f"png_only={result.png_only} "
+                    f"stack_only={result.stack_only})"
+                )
+                if result.verdict == "mismatch":
+                    mismatch = True
+                if log_file is not None:
+                    log_file.write(json.dumps(row) + "\n")
+                    log_file.flush()
+    finally:
+        if log_file is not None:
+            log_file.close()
+    return 1 if mismatch else (2 if op_error else 0)
 
 
 if __name__ == "__main__":

--- a/GeecsBluesky/geecs_bluesky/capture/heartbeat.py
+++ b/GeecsBluesky/geecs_bluesky/capture/heartbeat.py
@@ -5,24 +5,34 @@ daemon is actually running; this module closes that gap (the HARD Phase-6
 precondition recorded in ``Planning/data_capture/01_central_pva_capture_scope.md``):
 
 - the daemon calls :func:`write_heartbeat` every ``HEARTBEAT_PERIOD_S``
-  from a side thread while its dispatcher runs;
-- the engine calls :func:`heartbeat_age` in its pre-claim preflight and
-  **refuses a toggle-off scan** when the heartbeat is missing or older
-  than ``STALE_AFTER_S`` — fail-closed, because the alternative is a scan
-  whose camera images exist nowhere.
+  from a side thread while its dispatcher runs, and removes the file on
+  clean shutdown (:func:`clear_heartbeat`) so a ``systemctl stop`` refuses
+  toggle-off scans *immediately* instead of after the stale window;
+- the engine calls :func:`read_heartbeat` in its pre-claim preflight and
+  **refuses a toggle-off scan** when the heartbeat is missing, older than
+  ``STALE_AFTER_S``, or does not cover every requested capture device —
+  fail-closed, because the alternative is a scan whose camera images
+  exist nowhere.
 
-The heartbeat is a small JSON file on the filesystem the daemon and the
-worker already share (the daemon must see the worker's save paths — an
-existing deployment constraint, so this adds no new one). Default location
-under the user state dir; override via ``[capture] heartbeat_path`` in the
-shared GEECS config.
+The heartbeat is a small JSON file local to the daemon's host and service
+user — the engine-side check assumes it runs on the SAME host as the
+daemon under the same account (true for the systemd deployment, where the
+worker and daemon share one service user; a headless ``run_scan_request``
+on a different machine cannot see a healthy daemon's heartbeat and will
+be refused). Default location under the user state dir; override via
+``[capture] heartbeat_path`` in the shared GEECS config (must be an
+absolute path — a relative one would resolve against each process's CWD
+and split the writer from the reader, so it is ignored with a warning).
 
 What a fresh heartbeat proves — and doesn't: the daemon *process* is alive
-and its heartbeat thread is running. It does not prove the 0MQ document
-subscription is healthy (the dispatcher reconnects on its own, and between
-scans no documents flow, so there is no cheap doc-side freshness signal)
-nor that PVA delivery will succeed — those residual gaps stay covered by
-the daemon's per-scan reconciliation counters.
+and its heartbeat thread is running, monitoring the ``targets`` named in
+the payload. It does not prove the 0MQ document subscription is healthy
+(the dispatcher reconnects on its own, and between scans no documents
+flow, so there is no cheap doc-side freshness signal) nor that PVA
+delivery will succeed — those residual gaps stay covered by the daemon's
+per-scan reconciliation counters. A daemon that dies WITHOUT running its
+cleanup (SIGKILL, power loss) still takes up to ``STALE_AFTER_S`` to read
+as down.
 """
 
 from __future__ import annotations
@@ -51,35 +61,72 @@ def heartbeat_path() -> Path:
             parser.read(cfg_path)
             override = parser.get("capture", "heartbeat_path", fallback="").strip()
             if override:
-                return Path(override).expanduser()
+                candidate = Path(override).expanduser()
+                if candidate.is_absolute():
+                    return candidate
+                logger.warning(
+                    "[capture] heartbeat_path %r is not absolute — a relative "
+                    "path resolves against each process's CWD and splits the "
+                    "daemon from the engine; using the default instead",
+                    override,
+                )
         except configparser.Error:
             logger.warning("Could not parse %s for [capture]", cfg_path)
     return Path("~/.local/state/geecs-capture/heartbeat.json").expanduser()
 
 
-def write_heartbeat(n_targets: int, *, path: Path | None = None) -> None:
+def write_heartbeat(targets: list[str], *, path: Path | None = None) -> None:
     """Write/refresh the heartbeat (atomic replace; creates its own dir).
 
+    *targets* is the list of device names the daemon is monitoring — the
+    engine's preflight checks coverage against it, so a daemon started
+    before a camera joined the roster reads as not-covering that camera.
     The heartbeat's directory is daemon state, never scan data — creating
     it does not touch the scan-folder invariant.
     """
     path = path or heartbeat_path()
     path.parent.mkdir(parents=True, exist_ok=True)
-    payload = {"time": time.time(), "pid": os.getpid(), "targets": int(n_targets)}
+    payload = {
+        "time": time.time(),
+        "pid": os.getpid(),
+        "targets": sorted(str(t) for t in targets),
+    }
     tmp = path.with_suffix(".tmp")
     tmp.write_text(json.dumps(payload))
     tmp.replace(path)
 
 
-def heartbeat_age(*, path: Path | None = None) -> float | None:
-    """Seconds since the last heartbeat, or ``None`` when absent/unreadable."""
+def clear_heartbeat(*, path: Path | None = None) -> None:
+    """Remove the heartbeat on clean daemon shutdown (best-effort).
+
+    Makes an intentional stop (``systemctl stop``, Ctrl-C) refuse
+    toggle-off scans immediately instead of leaving a ``STALE_AFTER_S``
+    window during which the preflight would still pass.
+    """
+    path = path or heartbeat_path()
+    try:
+        path.unlink(missing_ok=True)
+    except OSError:
+        logger.warning("could not remove heartbeat %s", path, exc_info=True)
+
+
+def read_heartbeat(*, path: Path | None = None) -> dict | None:
+    """The heartbeat payload, or ``None`` when absent/unreadable/corrupt."""
     path = path or heartbeat_path()
     try:
         payload = json.loads(path.read_text())
-        stamp = float(payload["time"])
+        float(payload["time"])
     except (OSError, ValueError, KeyError, TypeError):
         return None
-    return max(0.0, time.time() - stamp)
+    return payload
+
+
+def heartbeat_age(*, path: Path | None = None) -> float | None:
+    """Seconds since the last heartbeat, or ``None`` when absent/unreadable."""
+    payload = read_heartbeat(path=path)
+    if payload is None:
+        return None
+    return max(0.0, time.time() - float(payload["time"]))
 
 
 def daemon_looks_alive(*, path: Path | None = None) -> bool:

--- a/GeecsBluesky/geecs_bluesky/capture/heartbeat.py
+++ b/GeecsBluesky/geecs_bluesky/capture/heartbeat.py
@@ -1,0 +1,88 @@
+"""The capture daemon's liveness heartbeat — the toggle-off safety signal.
+
+The engine suppresses native image saving blind to whether the capture
+daemon is actually running; this module closes that gap (the HARD Phase-6
+precondition recorded in ``Planning/data_capture/01_central_pva_capture_scope.md``):
+
+- the daemon calls :func:`write_heartbeat` every ``HEARTBEAT_PERIOD_S``
+  from a side thread while its dispatcher runs;
+- the engine calls :func:`heartbeat_age` in its pre-claim preflight and
+  **refuses a toggle-off scan** when the heartbeat is missing or older
+  than ``STALE_AFTER_S`` — fail-closed, because the alternative is a scan
+  whose camera images exist nowhere.
+
+The heartbeat is a small JSON file on the filesystem the daemon and the
+worker already share (the daemon must see the worker's save paths — an
+existing deployment constraint, so this adds no new one). Default location
+under the user state dir; override via ``[capture] heartbeat_path`` in the
+shared GEECS config.
+
+What a fresh heartbeat proves — and doesn't: the daemon *process* is alive
+and its heartbeat thread is running. It does not prove the 0MQ document
+subscription is healthy (the dispatcher reconnects on its own, and between
+scans no documents flow, so there is no cheap doc-side freshness signal)
+nor that PVA delivery will succeed — those residual gaps stay covered by
+the daemon's per-scan reconciliation counters.
+"""
+
+from __future__ import annotations
+
+import configparser
+import json
+import logging
+import os
+import time
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+HEARTBEAT_PERIOD_S = 10.0
+STALE_AFTER_S = 30.0
+
+_USER_CONFIG_PATH = Path("~/.config/geecs_python_api/config.ini")
+
+
+def heartbeat_path() -> Path:
+    """The heartbeat file location: ``[capture] heartbeat_path`` else default."""
+    cfg_path = _USER_CONFIG_PATH.expanduser()
+    if cfg_path.exists():
+        parser = configparser.ConfigParser()
+        try:
+            parser.read(cfg_path)
+            override = parser.get("capture", "heartbeat_path", fallback="").strip()
+            if override:
+                return Path(override).expanduser()
+        except configparser.Error:
+            logger.warning("Could not parse %s for [capture]", cfg_path)
+    return Path("~/.local/state/geecs-capture/heartbeat.json").expanduser()
+
+
+def write_heartbeat(n_targets: int, *, path: Path | None = None) -> None:
+    """Write/refresh the heartbeat (atomic replace; creates its own dir).
+
+    The heartbeat's directory is daemon state, never scan data — creating
+    it does not touch the scan-folder invariant.
+    """
+    path = path or heartbeat_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {"time": time.time(), "pid": os.getpid(), "targets": int(n_targets)}
+    tmp = path.with_suffix(".tmp")
+    tmp.write_text(json.dumps(payload))
+    tmp.replace(path)
+
+
+def heartbeat_age(*, path: Path | None = None) -> float | None:
+    """Seconds since the last heartbeat, or ``None`` when absent/unreadable."""
+    path = path or heartbeat_path()
+    try:
+        payload = json.loads(path.read_text())
+        stamp = float(payload["time"])
+    except (OSError, ValueError, KeyError, TypeError):
+        return None
+    return max(0.0, time.time() - stamp)
+
+
+def daemon_looks_alive(*, path: Path | None = None) -> bool:
+    """The engine-side verdict: a heartbeat exists and is fresh."""
+    age = heartbeat_age(path=path)
+    return age is not None and age <= STALE_AFTER_S

--- a/GeecsBluesky/geecs_bluesky/plans/scan_request_plan.py
+++ b/GeecsBluesky/geecs_bluesky/plans/scan_request_plan.py
@@ -82,6 +82,7 @@ from geecs_bluesky.scan_request_runner import (
     _defaults_flag,
     _preflight_connected,
     apply_native_image_save_off,
+    preflight_capture_liveness,
     resolve_native_image_save,
     select_capture_devices,
     _preflight_unserved,
@@ -529,6 +530,7 @@ def _scan_request_body(
     )
     if not native_image_save:
         if capture_devices:
+            preflight_capture_liveness(capture_devices, native_image_save)
             devices_config = apply_native_image_save_off(
                 devices_config, capture_devices
             )

--- a/GeecsBluesky/geecs_bluesky/scan_request_runner.py
+++ b/GeecsBluesky/geecs_bluesky/scan_request_runner.py
@@ -1285,6 +1285,40 @@ def select_capture_devices(
     ]
 
 
+def preflight_capture_liveness(
+    capture_devices: list[str], native_image_save: bool
+) -> None:
+    """Refuse a toggle-off scan when the capture daemon looks absent.
+
+    Pre-claim and fail-CLOSED (the opposite convention from the DB
+    providers, deliberately): with native saving off, a dead daemon means
+    the captured cameras' images exist NOWHERE — refusing before a scan
+    number is burned is the only safe answer. Only consulted when the
+    operator explicitly requested off and capture devices exist; the
+    default dual-write path never touches it.
+    """
+    if native_image_save or not capture_devices:
+        return
+    from geecs_bluesky.capture.heartbeat import (
+        STALE_AFTER_S,
+        daemon_looks_alive,
+        heartbeat_age,
+        heartbeat_path,
+    )
+
+    if daemon_looks_alive():
+        return
+    age = heartbeat_age()
+    raise GeecsConfigurationError(
+        "native_image_save=off refused: the capture daemon looks absent "
+        f"(heartbeat {heartbeat_path()} "
+        f"{'missing/unreadable' if age is None else f'{age:.0f}s old'}, "
+        f"stale after {STALE_AFTER_S:.0f}s) — with native saving off, "
+        f"{', '.join(capture_devices)} would be recorded NOWHERE. Start "
+        "the capture daemon, or run with native_image_save unset/true."
+    )
+
+
 def apply_native_image_save_off(
     devices_config: dict[str, dict[str, Any]], capture_devices: list[str]
 ) -> dict[str, dict[str, Any]]:
@@ -1749,6 +1783,7 @@ def run_scan_request(
     )
     if not native_image_save:
         if capture_devices:
+            preflight_capture_liveness(capture_devices, native_image_save)
             devices_config = apply_native_image_save_off(
                 devices_config, capture_devices
             )

--- a/GeecsBluesky/geecs_bluesky/scan_request_runner.py
+++ b/GeecsBluesky/geecs_bluesky/scan_request_runner.py
@@ -1325,16 +1325,25 @@ def preflight_capture_liveness(
             "the capture daemon, or run with native_image_save unset/true."
         )
     roster = payload.get("targets")
-    if isinstance(roster, list):
-        missing = sorted(set(capture_devices) - {str(t) for t in roster})
-        if missing:
-            raise GeecsConfigurationError(
-                "native_image_save=off refused: the capture daemon is alive "
-                f"but not monitoring {', '.join(missing)} (its heartbeat "
-                "roster predates them) — their images would be recorded "
-                "NOWHERE. Restart the capture daemon to re-discover the "
-                "roster, or run with native_image_save unset/true."
-            )
+    if not isinstance(roster, list):
+        # The daemon always writes a device-name roster; a fresh heartbeat
+        # without one is corrupt or from something that is not the daemon —
+        # fail closed, coverage cannot be verified (codex gate P2).
+        raise GeecsConfigurationError(
+            "native_image_save=off refused: the heartbeat at "
+            f"{heartbeat_path()} carries no device roster, so coverage of "
+            f"{', '.join(capture_devices)} cannot be verified. Restart the "
+            "capture daemon, or run with native_image_save unset/true."
+        )
+    missing = sorted(set(capture_devices) - {str(t) for t in roster})
+    if missing:
+        raise GeecsConfigurationError(
+            "native_image_save=off refused: the capture daemon is alive "
+            f"but not monitoring {', '.join(missing)} (its heartbeat "
+            "roster predates them) — their images would be recorded "
+            "NOWHERE. Restart the capture daemon to re-discover the "
+            "roster, or run with native_image_save unset/true."
+        )
 
 
 def apply_native_image_save_off(

--- a/GeecsBluesky/geecs_bluesky/scan_request_runner.py
+++ b/GeecsBluesky/geecs_bluesky/scan_request_runner.py
@@ -40,6 +40,7 @@ from __future__ import annotations
 
 import itertools
 import logging
+import time
 from collections.abc import Mapping
 from dataclasses import dataclass
 from contextlib import nullcontext
@@ -1293,30 +1294,47 @@ def preflight_capture_liveness(
     Pre-claim and fail-CLOSED (the opposite convention from the DB
     providers, deliberately): with native saving off, a dead daemon means
     the captured cameras' images exist NOWHERE — refusing before a scan
-    number is burned is the only safe answer. Only consulted when the
-    operator explicitly requested off and capture devices exist; the
-    default dual-write path never touches it.
+    number is burned is the only safe answer. Beyond freshness, the
+    heartbeat's ``targets`` roster must cover every requested capture
+    device — a daemon started before a camera joined the DB roster is
+    alive but not monitoring it, which is the same nowhere. Only consulted
+    when the operator explicitly requested off and capture devices exist;
+    the default dual-write path never touches it.
     """
     if native_image_save or not capture_devices:
         return
     from geecs_bluesky.capture.heartbeat import (
         STALE_AFTER_S,
-        daemon_looks_alive,
-        heartbeat_age,
         heartbeat_path,
+        read_heartbeat,
     )
 
-    if daemon_looks_alive():
-        return
-    age = heartbeat_age()
-    raise GeecsConfigurationError(
-        "native_image_save=off refused: the capture daemon looks absent "
-        f"(heartbeat {heartbeat_path()} "
-        f"{'missing/unreadable' if age is None else f'{age:.0f}s old'}, "
-        f"stale after {STALE_AFTER_S:.0f}s) — with native saving off, "
-        f"{', '.join(capture_devices)} would be recorded NOWHERE. Start "
-        "the capture daemon, or run with native_image_save unset/true."
+    payload = read_heartbeat()
+    age = (
+        max(0.0, time.time() - float(payload["time"])) if payload is not None else None
     )
+    if age is None or age > STALE_AFTER_S:
+        raise GeecsConfigurationError(
+            "native_image_save=off refused: the capture daemon looks absent "
+            f"(heartbeat {heartbeat_path()} "
+            f"{'missing/unreadable' if age is None else f'{age:.0f}s old'}, "
+            f"stale after {STALE_AFTER_S:.0f}s; the check reads the daemon's "
+            "heartbeat on THIS host — a daemon on another machine cannot "
+            "satisfy it) — with native saving off, "
+            f"{', '.join(capture_devices)} would be recorded NOWHERE. Start "
+            "the capture daemon, or run with native_image_save unset/true."
+        )
+    roster = payload.get("targets")
+    if isinstance(roster, list):
+        missing = sorted(set(capture_devices) - {str(t) for t in roster})
+        if missing:
+            raise GeecsConfigurationError(
+                "native_image_save=off refused: the capture daemon is alive "
+                f"but not monitoring {', '.join(missing)} (its heartbeat "
+                "roster predates them) — their images would be recorded "
+                "NOWHERE. Restart the capture daemon to re-discover the "
+                "roster, or run with native_image_save unset/true."
+            )
 
 
 def apply_native_image_save_off(

--- a/GeecsBluesky/pyproject.toml
+++ b/GeecsBluesky/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-bluesky"
-version = "0.67.0"
+version = "0.68.0"
 description = "Bluesky / ophyd-async bridge for the GEECS control system"
 authors = ["Sam Barber <sbarber@lbl.gov>"]
 readme = "README.md"
@@ -88,6 +88,7 @@ capture = ["p4p", "h5py", "pyzmq"]
 
 [tool.poetry.scripts]
 geecs-capture-daemon = "geecs_bluesky.capture.__main__:main"
+geecs-capture-diff = "geecs_bluesky.capture.diff:main"
 
 [tool.poetry.group.dev.dependencies]
 pytest = ">=7.0"

--- a/GeecsBluesky/tests/capture/test_diff.py
+++ b/GeecsBluesky/tests/capture/test_diff.py
@@ -63,6 +63,37 @@ def test_pass_verdict_and_stack_only_extra(tmp_path):
     assert (result.png_only, result.stack_only) == (0, 1)
 
 
+def test_boundary_rounded_timestamp_still_matches(tmp_path):
+    """A stack timestamp one canonical millisecond off its PNG still pairs.
+
+    The rounding-boundary class: the epoch/wire float round-trip can land
+    the stack key one integer away from the filename key. The join must
+    apply the analysis join's ±1 ms candidate tolerance, or such frames
+    become false png_only+stack_only mismatch pairs.
+    """
+    device_dir = tmp_path / "Scan006" / "UC_Cam"
+    frames = [np.full((3, 3), 5, dtype=np.uint16)]
+    _write_stack(device_dir, [TS[0] + 0.001], frames)  # one ms past the PNG
+    _touch_pngs(device_dir, TS[:1])
+    reader = _reader_by_index(device_dir, TS[:1], frames)
+    result = diff_device_dir(device_dir, png_reader=reader)
+    assert result.verdict == "pass"
+    assert (result.matched, result.png_only, result.stack_only) == (1, 0, 0)
+
+
+def test_dtype_wrap_is_not_identical(tmp_path):
+    """An out-of-range PNG value must not wrap into a false 'identical'."""
+    device_dir = tmp_path / "Scan007" / "UC_Cam"
+    frames = [np.full((3, 3), 1, dtype=np.uint8)]
+    _write_stack(device_dir, TS[:1], frames)
+    _touch_pngs(device_dir, TS[:1])
+    # 257 wraps to 1 under a uint8 cast — the comparison must see 257.
+    reader = _reader_by_index(device_dir, TS[:1], [np.full((3, 3), 257, np.uint16)])
+    result = diff_device_dir(device_dir, png_reader=reader)
+    assert result.verdict == "mismatch"
+    assert result.pixel_identical == 0
+
+
 def test_png_only_is_a_mismatch(tmp_path):
     """A frame LV saved that capture missed fails the scan."""
     device_dir = tmp_path / "Scan002" / "UC_Cam"
@@ -127,3 +158,23 @@ def test_cli_exit_code_and_log(tmp_path, monkeypatch):
     )
     assert main([str(scan), "--log", str(log)]) == 1
     assert len(log.read_text().splitlines()) == 2
+
+
+def test_cli_operational_error_exits_2_and_continues(tmp_path, monkeypatch):
+    """An unreadable scan path is exit 2 (not a mismatch) and doesn't stop the sweep."""
+    scan = tmp_path / "Scan008"
+    device_dir = scan / "UC_Cam"
+    frames = [np.full((3, 3), 1, dtype=np.uint16)]
+    _write_stack(device_dir, TS[:1], frames)
+    _touch_pngs(device_dir, TS[:1])
+
+    import geecs_bluesky.capture.diff as diff_mod
+
+    monkeypatch.setattr(
+        diff_mod, "_default_png_reader", lambda p: np.full((3, 3), 1, np.uint16)
+    )
+    log = tmp_path / "evidence.jsonl"
+    missing = tmp_path / "ScanDoesNotExist"
+    assert main([str(missing), str(scan), "--log", str(log)]) == 2
+    row = json.loads(log.read_text().splitlines()[0])
+    assert row["verdict"] == "pass"  # the good scan still got diffed and logged

--- a/GeecsBluesky/tests/capture/test_diff.py
+++ b/GeecsBluesky/tests/capture/test_diff.py
@@ -1,0 +1,129 @@
+"""The dual-write diff: verdicts, buckets, pixel comparison, evidence log."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+h5py = pytest.importorskip("h5py")
+np = pytest.importorskip("numpy")
+
+from geecs_data_utils.io.scan_stack import LABVIEW_EPOCH_OFFSET  # noqa: E402
+
+from geecs_bluesky.capture.diff import diff_device_dir, main  # noqa: E402
+
+TS = [3866137959.524, 3866137960.525, 3866137961.526]
+
+
+def _write_stack(device_dir, lv_timestamps, frames=None):
+    device_dir.mkdir(parents=True, exist_ok=True)
+    n = len(lv_timestamps)
+    if frames is None:
+        frames = [np.full((3, 3), i, dtype=np.uint16) for i in range(n)]
+    path = device_dir / f"{device_dir.name}.h5"
+    with h5py.File(path, "w") as f:
+        f.attrs["schema"] = "geecs-capture/1"
+        f.create_dataset("frames", data=np.stack(frames), chunks=(1, 3, 3))
+        f.create_dataset(
+            "acq_timestamp",
+            data=np.asarray(lv_timestamps, dtype=float) - LABVIEW_EPOCH_OFFSET,
+        )
+    return path
+
+
+def _touch_pngs(device_dir, lv_timestamps):
+    device_dir.mkdir(parents=True, exist_ok=True)
+    for ts in lv_timestamps:
+        (device_dir / f"{device_dir.name}_{ts:.3f}.png").write_bytes(b"")
+
+
+def _reader_by_index(device_dir, lv_timestamps, frames):
+    mapping = {
+        f"{device_dir.name}_{ts:.3f}.png": frame
+        for ts, frame in zip(lv_timestamps, frames)
+    }
+
+    def read(path):
+        return mapping[path.name]
+
+    return read
+
+
+def test_pass_verdict_and_stack_only_extra(tmp_path):
+    """All PNGs matched pixel-identical; a pre-window extra is attributable."""
+    device_dir = tmp_path / "Scan001" / "UC_Cam"
+    frames = [np.full((3, 3), i, dtype=np.uint16) for i in range(4)]
+    _write_stack(device_dir, [3866137950.000, *TS], frames)  # leading extra
+    _touch_pngs(device_dir, TS)
+    reader = _reader_by_index(device_dir, TS, frames[1:])
+    result = diff_device_dir(device_dir, png_reader=reader)
+    assert result.verdict == "pass"
+    assert (result.matched, result.pixel_identical) == (3, 3)
+    assert (result.png_only, result.stack_only) == (0, 1)
+
+
+def test_png_only_is_a_mismatch(tmp_path):
+    """A frame LV saved that capture missed fails the scan."""
+    device_dir = tmp_path / "Scan002" / "UC_Cam"
+    frames = [np.zeros((3, 3), dtype=np.uint16)] * 2
+    _write_stack(device_dir, TS[:2], frames)
+    _touch_pngs(device_dir, TS)  # one extra PNG the stack lacks
+    reader = _reader_by_index(device_dir, TS, [*frames, np.zeros((3, 3), np.uint16)])
+    result = diff_device_dir(device_dir, png_reader=reader)
+    assert result.verdict == "mismatch"
+    assert result.png_only == 1
+
+
+def test_pixel_difference_is_a_mismatch(tmp_path):
+    device_dir = tmp_path / "Scan003" / "UC_Cam"
+    frames = [np.full((3, 3), 7, dtype=np.uint16)]
+    _write_stack(device_dir, TS[:1], frames)
+    _touch_pngs(device_dir, TS[:1])
+    reader = _reader_by_index(device_dir, TS[:1], [np.full((3, 3), 8, np.uint16)])
+    result = diff_device_dir(device_dir, png_reader=reader)
+    assert result.verdict == "mismatch"
+    assert result.pixel_identical == 0
+
+
+def test_capture_only_and_no_stack_verdicts(tmp_path):
+    """Toggle-off scans and uncaptured devices get informational verdicts."""
+    cap_dir = tmp_path / "Scan004" / "UC_CamA"
+    _write_stack(cap_dir, TS)
+    result = diff_device_dir(cap_dir, png_reader=lambda p: None)
+    assert result.verdict == "capture_only"
+    assert result.stack_only == 3
+
+    png_dir = tmp_path / "Scan004" / "U_Haso"
+    _touch_pngs(png_dir, TS[:1])
+    result = diff_device_dir(png_dir, png_reader=lambda p: None)
+    assert result.verdict == "no_stack"
+
+    empty_dir = tmp_path / "Scan004" / "U_ScalarOnly"
+    empty_dir.mkdir(parents=True)
+    assert diff_device_dir(empty_dir, png_reader=lambda p: None) is None
+
+
+def test_cli_exit_code_and_log(tmp_path, monkeypatch):
+    """CLI exits 1 on mismatch and appends JSONL evidence rows."""
+    scan = tmp_path / "Scan005"
+    device_dir = scan / "UC_Cam"
+    frames = [np.full((3, 3), 1, dtype=np.uint16)]
+    _write_stack(device_dir, TS[:1], frames)
+    _touch_pngs(device_dir, TS[:1])
+
+    import geecs_bluesky.capture.diff as diff_mod
+
+    monkeypatch.setattr(
+        diff_mod, "_default_png_reader", lambda p: np.full((3, 3), 1, np.uint16)
+    )
+    log = tmp_path / "evidence.jsonl"
+    assert main([str(scan), "--log", str(log)]) == 0
+    row = json.loads(log.read_text().splitlines()[0])
+    assert row["verdict"] == "pass" and row["device"] == "UC_Cam"
+
+    monkeypatch.setattr(
+        diff_mod, "_default_png_reader", lambda p: np.full((3, 3), 9, np.uint16)
+    )
+    assert main([str(scan), "--log", str(log)]) == 1
+    assert len(log.read_text().splitlines()) == 2

--- a/GeecsBluesky/tests/capture/test_heartbeat.py
+++ b/GeecsBluesky/tests/capture/test_heartbeat.py
@@ -87,13 +87,48 @@ def test_preflight_passes_with_live_daemon(monkeypatch) -> None:
     preflight_capture_liveness(["UC_Cam"], native_image_save=False)
 
 
-def test_preflight_tolerates_rosterless_payload(monkeypatch) -> None:
-    """A payload without a target list (older daemon) skips the coverage check."""
+def test_preflight_refuses_rosterless_payload(monkeypatch) -> None:
+    """A fresh payload without a target roster is corrupt state — fail closed.
+
+    The daemon always writes a device-name roster (codex gate P2): with no
+    roster, coverage cannot be verified, so tolerating it could disable
+    native saving for devices nothing is monitoring.
+    """
     _point_preflight_at(monkeypatch, {"time": time.time()})
-    preflight_capture_liveness(["UC_Cam"], native_image_save=False)
+    with pytest.raises(GeecsConfigurationError, match="no device roster"):
+        preflight_capture_liveness(["UC_Cam"], native_image_save=False)
 
 
 def test_preflight_inert_on_default_path() -> None:
     """Toggle on (or no capture devices): never consulted, never refuses."""
     preflight_capture_liveness(["UC_Cam"], native_image_save=True)
     preflight_capture_liveness([], native_image_save=False)
+
+
+def test_sigterm_runs_finally_cleanup(tmp_path) -> None:
+    """SIGTERM must reach the finally block — the systemctl-stop tombstone.
+
+    Python's default SIGTERM action kills the process WITHOUT running
+    ``finally`` (codex gate P1); the daemon installs a handler converting
+    it to ``SystemExit``. Simulate the daemon's structure: install, block,
+    receive a real SIGTERM, verify the cleanup ran.
+    """
+    import os
+    import signal
+
+    from geecs_bluesky.capture.__main__ import _install_sigterm_handler
+
+    previous = signal.getsignal(signal.SIGTERM)
+    hb = tmp_path / "heartbeat.json"
+    write_heartbeat(["UC_Cam"], path=hb)
+    try:
+        _install_sigterm_handler()
+        with pytest.raises(SystemExit):
+            try:
+                os.kill(os.getpid(), signal.SIGTERM)
+                time.sleep(5)  # interrupted by the handler's SystemExit
+            finally:
+                clear_heartbeat(path=hb)
+    finally:
+        signal.signal(signal.SIGTERM, previous)
+    assert not hb.exists()

--- a/GeecsBluesky/tests/capture/test_heartbeat.py
+++ b/GeecsBluesky/tests/capture/test_heartbeat.py
@@ -9,8 +9,10 @@ import pytest
 
 from geecs_bluesky.capture.heartbeat import (
     STALE_AFTER_S,
+    clear_heartbeat,
     daemon_looks_alive,
     heartbeat_age,
+    read_heartbeat,
     write_heartbeat,
 )
 from geecs_bluesky.exceptions import GeecsConfigurationError
@@ -18,14 +20,25 @@ from geecs_bluesky.scan_request_runner import preflight_capture_liveness
 
 
 def test_write_and_read_roundtrip(tmp_path) -> None:
-    """A fresh heartbeat reads back young and alive."""
+    """A fresh heartbeat reads back young, alive, and carrying the roster."""
     hb = tmp_path / "state" / "heartbeat.json"
-    write_heartbeat(3, path=hb)
+    write_heartbeat(["UC_CamB", "UC_CamA"], path=hb)
     payload = json.loads(hb.read_text())
-    assert payload["targets"] == 3
+    assert payload["targets"] == ["UC_CamA", "UC_CamB"]
     age = heartbeat_age(path=hb)
     assert age is not None and age < 5.0
     assert daemon_looks_alive(path=hb)
+
+
+def test_clear_heartbeat_makes_daemon_look_down(tmp_path) -> None:
+    """The clean-stop tombstone: removal reads as not-alive immediately."""
+    hb = tmp_path / "heartbeat.json"
+    write_heartbeat(["UC_Cam"], path=hb)
+    assert daemon_looks_alive(path=hb)
+    clear_heartbeat(path=hb)
+    assert not hb.exists()
+    assert not daemon_looks_alive(path=hb)
+    clear_heartbeat(path=hb)  # idempotent on an already-missing file
 
 
 def test_missing_and_stale_and_garbage(tmp_path) -> None:
@@ -39,23 +52,44 @@ def test_missing_and_stale_and_garbage(tmp_path) -> None:
 
     hb.write_text("not json")
     assert heartbeat_age(path=hb) is None
+    assert read_heartbeat(path=hb) is None
+
+
+def _point_preflight_at(monkeypatch, payload: dict | None) -> None:
+    import geecs_bluesky.capture.heartbeat as hb_mod
+
+    monkeypatch.setattr(hb_mod, "read_heartbeat", lambda **kw: payload)
 
 
 def test_preflight_refuses_toggle_off_without_daemon(monkeypatch) -> None:
     """Toggle-off + no heartbeat = refusal naming the orphaned devices."""
-    import geecs_bluesky.capture.heartbeat as hb_mod
-
-    monkeypatch.setattr(hb_mod, "daemon_looks_alive", lambda **kw: False)
-    monkeypatch.setattr(hb_mod, "heartbeat_age", lambda **kw: None)
+    _point_preflight_at(monkeypatch, None)
     with pytest.raises(GeecsConfigurationError, match="UC_Cam.*NOWHERE"):
         preflight_capture_liveness(["UC_Cam"], native_image_save=False)
 
 
-def test_preflight_passes_with_live_daemon(monkeypatch) -> None:
-    """Fresh heartbeat: toggle-off proceeds."""
-    import geecs_bluesky.capture.heartbeat as hb_mod
+def test_preflight_refuses_stale_heartbeat(monkeypatch) -> None:
+    _point_preflight_at(monkeypatch, {"time": time.time() - STALE_AFTER_S - 10})
+    with pytest.raises(GeecsConfigurationError, match="looks absent"):
+        preflight_capture_liveness(["UC_Cam"], native_image_save=False)
 
-    monkeypatch.setattr(hb_mod, "daemon_looks_alive", lambda **kw: True)
+
+def test_preflight_refuses_uncovered_device(monkeypatch) -> None:
+    """A fresh daemon whose roster predates a camera refuses for that camera."""
+    _point_preflight_at(monkeypatch, {"time": time.time(), "targets": ["UC_CamA"]})
+    with pytest.raises(GeecsConfigurationError, match="not monitoring UC_CamB"):
+        preflight_capture_liveness(["UC_CamA", "UC_CamB"], native_image_save=False)
+
+
+def test_preflight_passes_with_live_daemon(monkeypatch) -> None:
+    """Fresh heartbeat covering the devices: toggle-off proceeds."""
+    _point_preflight_at(monkeypatch, {"time": time.time(), "targets": ["UC_Cam"]})
+    preflight_capture_liveness(["UC_Cam"], native_image_save=False)
+
+
+def test_preflight_tolerates_rosterless_payload(monkeypatch) -> None:
+    """A payload without a target list (older daemon) skips the coverage check."""
+    _point_preflight_at(monkeypatch, {"time": time.time()})
     preflight_capture_liveness(["UC_Cam"], native_image_save=False)
 
 

--- a/GeecsBluesky/tests/capture/test_heartbeat.py
+++ b/GeecsBluesky/tests/capture/test_heartbeat.py
@@ -1,0 +1,65 @@
+"""Heartbeat module + the engine's fail-closed toggle-off liveness preflight."""
+
+from __future__ import annotations
+
+import json
+import time
+
+import pytest
+
+from geecs_bluesky.capture.heartbeat import (
+    STALE_AFTER_S,
+    daemon_looks_alive,
+    heartbeat_age,
+    write_heartbeat,
+)
+from geecs_bluesky.exceptions import GeecsConfigurationError
+from geecs_bluesky.scan_request_runner import preflight_capture_liveness
+
+
+def test_write_and_read_roundtrip(tmp_path) -> None:
+    """A fresh heartbeat reads back young and alive."""
+    hb = tmp_path / "state" / "heartbeat.json"
+    write_heartbeat(3, path=hb)
+    payload = json.loads(hb.read_text())
+    assert payload["targets"] == 3
+    age = heartbeat_age(path=hb)
+    assert age is not None and age < 5.0
+    assert daemon_looks_alive(path=hb)
+
+
+def test_missing_and_stale_and_garbage(tmp_path) -> None:
+    """Absent, stale, and corrupt heartbeats all read as not-alive."""
+    hb = tmp_path / "heartbeat.json"
+    assert heartbeat_age(path=hb) is None
+    assert not daemon_looks_alive(path=hb)
+
+    hb.write_text(json.dumps({"time": time.time() - STALE_AFTER_S - 5}))
+    assert not daemon_looks_alive(path=hb)
+
+    hb.write_text("not json")
+    assert heartbeat_age(path=hb) is None
+
+
+def test_preflight_refuses_toggle_off_without_daemon(monkeypatch) -> None:
+    """Toggle-off + no heartbeat = refusal naming the orphaned devices."""
+    import geecs_bluesky.capture.heartbeat as hb_mod
+
+    monkeypatch.setattr(hb_mod, "daemon_looks_alive", lambda **kw: False)
+    monkeypatch.setattr(hb_mod, "heartbeat_age", lambda **kw: None)
+    with pytest.raises(GeecsConfigurationError, match="UC_Cam.*NOWHERE"):
+        preflight_capture_liveness(["UC_Cam"], native_image_save=False)
+
+
+def test_preflight_passes_with_live_daemon(monkeypatch) -> None:
+    """Fresh heartbeat: toggle-off proceeds."""
+    import geecs_bluesky.capture.heartbeat as hb_mod
+
+    monkeypatch.setattr(hb_mod, "daemon_looks_alive", lambda **kw: True)
+    preflight_capture_liveness(["UC_Cam"], native_image_save=False)
+
+
+def test_preflight_inert_on_default_path() -> None:
+    """Toggle on (or no capture devices): never consulted, never refuses."""
+    preflight_capture_liveness(["UC_Cam"], native_image_save=True)
+    preflight_capture_liveness([], native_image_save=False)

--- a/GeecsBluesky/tests/test_scan_request_plan.py
+++ b/GeecsBluesky/tests/test_scan_request_plan.py
@@ -322,6 +322,29 @@ def test_strict_without_trigger_profile_refuses_before_claim(
     assert claims == []
 
 
+def test_toggle_off_without_daemon_heartbeat_refuses_before_claim(
+    resolver, monkeypatch
+) -> None:
+    """The queue path runs the capture liveness preflight — fail-closed, pre-claim."""
+    session = _mock_session()
+    claims: list = []
+    monkeypatch.setattr(
+        "geecs_bluesky.plans.scan_request_plan.claim_scan_number",
+        lambda experiment: claims.append(experiment) or (None, None),
+    )
+    monkeypatch.setattr(
+        "geecs_bluesky.plans.scan_request_plan.select_capture_devices",
+        lambda experiment, devices_config: ["UC_Cam"],
+    )
+    import geecs_bluesky.capture.heartbeat as hb_mod
+
+    monkeypatch.setattr(hb_mod, "read_heartbeat", lambda **kw: None)
+    request = _noscan_request(native_image_save=False).model_dump()
+    with pytest.raises(GeecsConfigurationError, match="NOWHERE"):
+        session.RE(geecs_scan_request_plan(request, session=session, resolver=resolver))
+    assert claims == [], "a refused toggle-off scan must burn no scan number"
+
+
 def test_optimize_mode_without_a_loader_is_refused_loudly_after_validation(
     resolver, monkeypatch
 ) -> None:

--- a/GeecsBluesky/tests/test_scan_request_runner.py
+++ b/GeecsBluesky/tests/test_scan_request_runner.py
@@ -2487,6 +2487,9 @@ def test_native_image_save_off_wires_through_runner(
     native save; md carries the capture list; nothing else changes."""
     import geecs_bluesky.scan_request_runner as runner_mod
 
+    monkeypatch.setattr(  # daemon heartbeat absent in tests — bypass refusal
+        runner_mod, "preflight_capture_liveness", lambda *a, **k: None
+    )
     monkeypatch.setattr(runner_mod, "select_capture_devices", _select_u_cam)
     session = _SaveRecordingSession()
     run_scan_request(
@@ -2513,6 +2516,9 @@ def test_native_image_save_off_wires_contributor_branch(
     def _select_u_cam2(experiment, devices_config, *, provider=None):
         return [d for d in devices_config if d == "U_Cam2"]
 
+    monkeypatch.setattr(  # daemon heartbeat absent in tests — bypass refusal
+        runner_mod, "preflight_capture_liveness", lambda *a, **k: None
+    )
     monkeypatch.setattr(runner_mod, "select_capture_devices", _select_u_cam2)
     session = _SaveRecordingSession()
     run_scan_request(
@@ -2537,6 +2543,9 @@ def test_native_image_save_off_wires_snapshot_branch(
     def _select_u_slow(experiment, devices_config, *, provider=None):
         return [d for d in devices_config if d == "U_Slow"]
 
+    monkeypatch.setattr(  # daemon heartbeat absent in tests — bypass refusal
+        runner_mod, "preflight_capture_liveness", lambda *a, **k: None
+    )
     monkeypatch.setattr(runner_mod, "select_capture_devices", _select_u_slow)
     session = _SaveRecordingSession()
     run_scan_request(
@@ -2554,6 +2563,9 @@ def test_native_image_save_on_leaves_saving_and_still_publishes_list(
     """Dual-write default: saving untouched, capture list still published."""
     import geecs_bluesky.scan_request_runner as runner_mod
 
+    monkeypatch.setattr(  # daemon heartbeat absent in tests — bypass refusal
+        runner_mod, "preflight_capture_liveness", lambda *a, **k: None
+    )
     monkeypatch.setattr(runner_mod, "select_capture_devices", _select_u_cam)
     session = _SaveRecordingSession()
     run_scan_request(session, _noscan_request(acquisition="strict"), legacy_resolver)


### PR DESCRIPTION
The three in-repo promotion prerequisites from the arc-end definition, bundled with per-concern breakdown (LOC ≈ 95 / 100 / 160 + tests 65 / 0 / 110):

**1. Daemon-liveness preflight** — `capture/heartbeat.py`: the daemon touches a JSON heartbeat every 10 s from a side thread (atomic replace; path = `~/.local/state/geecs-capture/heartbeat.json`, override `[capture] heartbeat_path`); the engine's `preflight_capture_liveness` **refuses a toggle-off scan pre-claim, fail-closed**, when the heartbeat is missing or >30 s old — wired identically in both execution paths, inert on the default dual-write path. Closes the HARD Phase-6 precondition from #697's review. Honest scope documented in the module: proves *process* liveness; subscription health stays covered by reconciliation counters. The file transport piggybacks the existing shared-filesystem deployment constraint (upgrades to a PV only if worker/daemon ever split hosts).

**2. systemd deployment kit** — `capture/deploy/geecs-capture.service` + `DEPLOYMENT.md` (the qserver template conventions: placeholder paths, absolute-poetry gotcha, restart policy). Worker co-location stated as a *requirement* (save-path view + heartbeat), which also makes the future services-box migration a copy-unit-and-install operation.

**3. Dual-write diff CLI** — `geecs-capture-diff`: per scan/device, joins the stack's timestamps against native PNG filenames on the same canonical-millisecond keys the analysis join uses, pixel-compares every matched pair (IMAQ-decoded), attributes extras (`stack_only` = pre-window frames; `png_only` = **the bad bucket**), verdicts `pass`/`mismatch`/`capture_only`/`no_stack`, appends JSONL evidence via `--log`, exits 1 on mismatch. Weeks of clean log = the Phase-6 gate, greppable.

## Verification
- capture suite 32/32 incl. 11 new tests; **full suite 668 passed**
- Live deployment of the unit + a heartbeat-gated toggle-off scan + a diff run over Scans 003–005 planned immediately post-merge (lab access active)

## Review
- [ ] Adversarial review — launching now
- [ ] Codex gate (maintainer-driven)

🤖 Generated with [Claude Code](https://claude.com/claude-code)