### PR TITLE
toggle-off scans keep the acq_timestamp s-file column (0.68.1) — stack join key

### DIFF
--- a/GeecsBluesky/CHANGELOG.md
+++ b/GeecsBluesky/CHANGELOG.md
@@ -4,6 +4,26 @@ All notable changes to `geecs-bluesky` are documented here.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.68.1] - 2026-08-28
+
+### Fixed
+
+- **Toggle-off scans keep the `acq_timestamp` s-file column** — the
+  stack join key. `save_control_only` devices (capture-owned cameras)
+  reused the pure-scalar column rule, so the s-file carried no
+  `<Device> acq_timestamp` column and ScanAnalysis's `device_hdf5`
+  strategy had nothing to join on: the whole scan's images were
+  orphaned from analysis. Found LIVE on the first real
+  stack-analysis run (26_0828 Scan001 — PNG-free, so the fallback
+  couldn't mask it; the prior test suite had pinned the buggy shape
+  as correct). A capture-owned camera is a file-producing device:
+  the column now survives the toggle on both sync roles
+  (`CaGenericDetector`, `CaTimestampedReadable`); the
+  `localsavingpath`/`save` native-save children still ride
+  `save_nonscalar_data` only. Async (snapshot) capture-owned cameras
+  still have no acq column — a pre-existing property of the snapshot
+  role, noted, not changed here.
+
 ## [0.68.0] - 2026-08-28
 
 ### Added

--- a/GeecsBluesky/EVENT_SCHEMA.md
+++ b/GeecsBluesky/EVENT_SCHEMA.md
@@ -40,8 +40,12 @@ Added by the run wrapper (`geecs_run_wrapper`) when a scan number is claimed:
 `Device Variable` header (`UC_Wavemeter Wavelength (nm)`). `safe_name()` mangling
 is irreversible, so this map is the only way to recover legacy headers; it backs
 the Tiled→s-file exporter (`geecs_data_utils.tiled_export`). Only true device
-signals appear — derived companion columns (`-acq_timestamp`, `-shot_id`, …) are
-excluded by construction. A **pseudo scan variable's** motor column is the one
+signals appear — derived companion columns (`-shot_id`, …) are excluded by
+construction, with one deliberate exception: a **file-producing device**
+(native saving on, or a capture-owned camera under the `native_image_save`
+toggle) surfaces its `-acq_timestamp` column so its files — per-shot
+natives or capture-stack frames — join back to scan rows by it (the
+ScanAnalysis `device_hdf5` join key; legacy parity for native savers). A **pseudo scan variable's** motor column is the one
 exception to the `Device Variable` header shape: its recorded value is the
 demanded pseudo number (no physical readback of its own), so its header is the
 catalog friendly name verbatim (e.g. `ALine_e_beam_angle_offset_x`), and the

--- a/GeecsBluesky/geecs_bluesky/devices/ca/generic_detector.py
+++ b/GeecsBluesky/geecs_bluesky/devices/ca/generic_detector.py
@@ -81,15 +81,21 @@ class CaGenericDetector(ShotIdSupport, NonScalarSaveSupport, CaTriggerable):
             if var != acq_timestamp_variable
         }
         self._save_nonscalar_data = save_nonscalar_data
-        if save_nonscalar_data:
+        if save_nonscalar_data or save_control_only:
             # A file/image-saving device surfaces acq_timestamp as an s-file
             # column so saved files tie back to scan rows (legacy parity — the
             # saved filenames are stamped with it, and an images-only device
             # otherwise contributes no scalar column at all). For a pure-scalar
             # device acq_timestamp stays an excluded companion column.
+            # A capture-owned camera (save_control_only) is a file-producing
+            # device too — its stack frames join to rows BY this column
+            # (ScanAnalysis device_hdf5 strategy), so dropping it orphans
+            # the whole scan's images from analysis (found live, 26_0828
+            # Scan001: toggle-off s-file had no join key, stack unmapped).
             self._column_headers[f"{name}-{safe_name(acq_timestamp_variable)}"] = (
                 f"{device} {acq_timestamp_variable}"
             )
+        if save_nonscalar_data:
             # Writable controls, not readable signals (mirrors the direct
             # NonScalarSaveSupport._init_save_signals): read the gateway
             # readback, write the :SP setpoint (→ GEECS UDP set). Requires the

--- a/GeecsBluesky/geecs_bluesky/devices/ca/timestamped_readable.py
+++ b/GeecsBluesky/geecs_bluesky/devices/ca/timestamped_readable.py
@@ -77,13 +77,18 @@ class CaTimestampedReadable(
             if var != acq_timestamp_variable
         }
         self._save_nonscalar_data = save_nonscalar_data
-        if save_nonscalar_data:
+        if save_nonscalar_data or save_control_only:
             # A file/image-saving device surfaces acq_timestamp as an s-file
             # column so saved files tie back to scan rows (legacy parity); a
             # pure-scalar device keeps it as an excluded companion column.
+            # A capture-owned camera (save_control_only) produces files too —
+            # its stack frames join to rows by this column (ScanAnalysis
+            # device_hdf5), so it must survive the toggle (found live,
+            # 26_0828 Scan001).
             self._column_headers[f"{name}-{safe_name(acq_timestamp_variable)}"] = (
                 f"{device} {acq_timestamp_variable}"
             )
+        if save_nonscalar_data:
             # Writable controls, not readable signals: read the gateway
             # readback, write the :SP setpoint (→ GEECS UDP set).
             for attr in ("localsavingpath", "save"):

--- a/GeecsBluesky/pyproject.toml
+++ b/GeecsBluesky/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-bluesky"
-version = "0.68.0"
+version = "0.68.1"
 description = "Bluesky / ophyd-async bridge for the GEECS control system"
 authors = ["Sam Barber <sbarber@lbl.gov>"]
 readme = "README.md"

--- a/GeecsBluesky/tests/test_ca_devices.py
+++ b/GeecsBluesky/tests/test_ca_devices.py
@@ -864,7 +864,11 @@ class TestSaveControlOnly:
         )
 
     def test_save_nonscalar_wins_over_control_only(self) -> None:
-        """A (mis)configured both-flags device stays a full native saver."""
+        """A (mis)configured both-flags device stays a full native saver.
+
+        The acq_timestamp join column is present via either operand of the
+        gate's ``or`` — asserted below so neither side can silently drop it.
+        """
         det = CaGenericDetector(
             "UC_Amp4_IR_input",
             ["centroidx"],
@@ -876,6 +880,9 @@ class TestSaveControlOnly:
         assert det._save_nonscalar_data is True
         assert det._save_control_only is False
         assert hasattr(det, "localsavingpath")
+        assert det._column_headers["both-acq_timestamp"] == (
+            "UC_Amp4_IR_input acq_timestamp"
+        )
 
     def test_contributor_save_control_only_shape(self) -> None:
         from geecs_bluesky.devices.ca import CaTimestampedReadable

--- a/GeecsBluesky/tests/test_ca_devices.py
+++ b/GeecsBluesky/tests/test_ca_devices.py
@@ -839,8 +839,29 @@ class TestSaveControlOnly:
         assert det._save_nonscalar_data is False
         assert hasattr(det, "save")
         assert not hasattr(det, "localsavingpath")
-        # No save-path column header (that rides save_nonscalar_data).
-        assert not any("acq_timestamp" in k for k in det._column_headers)
+        # The acq_timestamp column SURVIVES the toggle: the capture stack's
+        # frames join to scan rows by it (ScanAnalysis device_hdf5) — its
+        # absence orphaned a live toggle-off scan's images from analysis
+        # (26_0828 Scan001).
+        assert det._column_headers["cap-acq_timestamp"] == (
+            "UC_Amp4_IR_input acq_timestamp"
+        )
+
+    def test_contributor_save_control_only_keeps_join_column(self) -> None:
+        con = CaTimestampedReadable(
+            "UC_Amp4_IR_input",
+            ["centroidx"],
+            experiment="Undulator",
+            name="capc",
+            save_nonscalar_data=False,
+            save_control_only=True,
+        )
+        assert con._save_control_only is True
+        assert hasattr(con, "save")
+        assert not hasattr(con, "localsavingpath")
+        assert con._column_headers["capc-acq_timestamp"] == (
+            "UC_Amp4_IR_input acq_timestamp"
+        )
 
     def test_save_nonscalar_wins_over_control_only(self) -> None:
         """A (mis)configured both-flags device stays a full native saver."""


### PR DESCRIPTION
## What

Two-line gate fix in the sync device roles: the `<Device> acq_timestamp` s-file column — the key ScanAnalysis's `device_hdf5` strategy joins stack frames to scan rows by — now survives the `native_image_save` toggle. The `localsavingpath`/`save` native-save children still ride `save_nonscalar_data` only (the gate is split; both directions pinned).

## Why (found live, not by review)

First real ScanAnalysis run over a capture stack — today's PNG-free Scan001 — mapped **zero shots**: the toggle-off s-file had no device columns at all, because `save_control_only` devices fell into the pure-scalar column rule. With no PNGs, the fallback couldn't mask it: the scan's images were simply orphaned from analysis. Dual-write Scan003's s-file has the column; toggle-off Scan004/Scan001 didn't.

Notably, **three review passes (adversarial + codex, PRs #697/#699) accepted this shape** — the prior test even asserted `acq_timestamp` absent as correct for capture-owned devices. The event data itself is in Tiled (only the s-file column mapping was gated), so yesterday's toggle-off scans are recoverable by re-export if ever needed.

Known residual (unchanged, pre-existing): async (snapshot) capture-owned cameras have no acq column — the snapshot role never had one.

## Verification

- 678 passed (the flipped pin + a contributor twin + save-children gate pinned both ways)
- Live re-verification planned immediately: pull on the worker, manager restart, fresh toggle-off scan, ScanAnalysis stack run expecting 10/10 mapped ShotRefs

🤖 Generated with [Claude Code](https://claude.com/claude-code)