### PR TITLE
pva launch.bat installs GEECS-Core (0.4.5) — post-split fleet crash-loop fix

### DIFF
--- a/GeecsPvaGateway/CHANGELOG.md
+++ b/GeecsPvaGateway/CHANGELOG.md
@@ -3,6 +3,21 @@
 All notable changes to this package will be documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.4.5] - 2026-08-29
+
+### Fixed
+
+- **`deploy/launch.bat` installs GEECS-Core** — the pull-on-restart
+  package list predated the geecs-core split (2026-08-20), so the first
+  post-split fleet restart installed a gateway that imports `geecs_core`
+  without installing it: an NSSM crash loop (found live on the canary
+  during the capture-arc 0.4.4 rollout; healed by installing GEECS-Core
+  into the venv, which persists across restarts). **Fleet operational
+  note: every box bootstrapped before this fix carries the old local
+  `launch.bat` — do NOT `:restart` such a box onto a post-split source
+  clone until it has GEECS-Core in its venv (one console pip line) or
+  has been re-bootstrapped (which copies the fixed launcher).**
+
 ## [0.4.4] — 2026-08-27
 
 ### Fixed

--- a/GeecsPvaGateway/DEPLOYMENT.md
+++ b/GeecsPvaGateway/DEPLOYMENT.md
@@ -85,6 +85,15 @@ wheels, no version files. Rollout:
 git pull            # advance the pin (or: git checkout <rev> to roll back)
 ```
 
+**Package-list changes need a per-box step**: `launch.bat` is copied
+locally at bootstrap, so a change to its pip package list (e.g. the
+GEECS-Core addition, 0.4.5) does NOT reach a box via `:restart` alone —
+either re-run the bootstrap console paste (copies the fixed launcher) or
+one-time-install the new package into the box's venv from a console
+session (the ssh session's token cannot read the share; a logged-in
+console can). Restarting a box whose launcher predates the current
+package list can crash-loop it.
+
 Then restart instances **via the `:restart` PV**, one host at a time
 (restarting one box first and watching it come back clean before the rest is
 cheap insurance):

--- a/GeecsPvaGateway/deploy/launch.bat
+++ b/GeecsPvaGateway/deploy/launch.bat
@@ -4,7 +4,7 @@ rem NSSM runs this with USERPROFILE, GEECS_PVA_ROOT, GEECS_PVA_EXPERIMENT and
 rem (optionally) GEECS_PVA_SOURCE set (see bootstrap.ps1). GEECS_PVA_SOURCE is
 rem the UNC path of the shared GEECS-Plugins clone (the lab's "Active
 rem Version" clone): a restart — :restart PV (exit 86), crash, or reboot —
-rem reinstalls the four intra-repo packages from it, so the clone's commit
+rem reinstalls the five intra-repo packages from it, so the clone's commit
 rem IS the fleet pin. Rollout = git pull in the clone + restart PVs; rollback
 rem = git checkout <rev> there + restarts. An unreachable share falls through
 rem to the installed versions (a restart never bricks an instance).
@@ -22,7 +22,7 @@ if "%GEECS_PVA_ROOT%"=="" set GEECS_PVA_ROOT=C:\geecs\pva-gateway
 if not "%GEECS_PVA_SOURCE%"=="" (
     if exist "%GEECS_PVA_SOURCE%\GeecsPvaGateway\pyproject.toml" (
         echo pull-on-restart: reinstalling from "%GEECS_PVA_SOURCE%"
-        "%GEECS_PVA_ROOT%\venv\Scripts\python" -m pip install --quiet --upgrade --no-deps --no-build-isolation "%GEECS_PVA_SOURCE%\GEECS-Schemas" "%GEECS_PVA_SOURCE%\GEECS-Data-Utils" "%GEECS_PVA_SOURCE%\GeecsCAGateway" "%GEECS_PVA_SOURCE%\GeecsPvaGateway"
+        "%GEECS_PVA_ROOT%\venv\Scripts\python" -m pip install --quiet --upgrade --no-deps --no-build-isolation "%GEECS_PVA_SOURCE%\GEECS-Schemas" "%GEECS_PVA_SOURCE%\GEECS-Core" "%GEECS_PVA_SOURCE%\GEECS-Data-Utils" "%GEECS_PVA_SOURCE%\GeecsCAGateway" "%GEECS_PVA_SOURCE%\GeecsPvaGateway"
     )
 )
 

--- a/GeecsPvaGateway/pyproject.toml
+++ b/GeecsPvaGateway/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-pva-gateway"
-version = "0.4.4"
+version = "0.4.5"
 description = "Distributed pvAccess gateway serving GEECS camera images as NTNDArray PVs"
 authors = ["Sam Barber <sbarber@lbl.gov>"]
 readme = "README.md"


### PR DESCRIPTION
Found live during the post-#693 fleet rollout: `deploy/launch.bat`'s pip list predates the geecs-core split (2026-08-20), so the canary's first post-split `:restart` installed gateway 0.4.4 — which imports `geecs_core` — without installing it. NSSM crash loop; PVA image serving on 192.168.6.100 was down until healed by a one-time `pip install` of GEECS-Core into the venv (persists across restarts since the launcher runs `--no-deps`). Canary verified back and serving 0.4.4.

This PR is the durable fix (GEECS-Core added to the five-package list) plus the operational lesson in DEPLOYMENT.md: `launch.bat` is a bootstrap-time **local copy**, so package-list changes never propagate via `:restart` — each pre-fix box needs either a re-bootstrap or the one-line venv install **before** its next restart onto a post-split source clone.

Fleet state: canary (.100) healed and at 0.4.4; the other 8 boxes still run 0.4.0 and are safe **as long as nobody pokes their `:restart` PVs** before the per-box step.

None of #693's reviews could have caught this: the bat's list was correct when written, and the breakage only manifests on the first post-split restart of a live fleet box.

🤖 Generated with [Claude Code](https://claude.com/claude-code)