### PR TITLE
portal phase-5: deploy — systemd unit + runbook + fleet-map promotion (0.3.0)

### DIFF
--- a/GEECS-DataPortal/CHANGELOG.md
+++ b/GEECS-DataPortal/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to this package will be documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.3.0] - 2026-08-29
+
+### Added
+
+- Deployment (portal arc phase 5): `deploy/geecs-data-portal.service`
+  systemd unit (generic-account template, site specifics live in the
+  `/etc/systemd/system` copy — CA-gateway precedent) and
+  `DEPLOYMENT.md` runbook (prerequisites, own-checkout install,
+  foreground smoke test, unit install, upgrade, troubleshooting).
+  Fleet map promoted from *planned additions* to a deployed service
+  row (worker host, HTTP 8200, `GET /health`).
+
 ## [0.2.0] - 2026-08-29
 
 ### Added

--- a/GEECS-DataPortal/CLAUDE.md
+++ b/GEECS-DataPortal/CLAUDE.md
@@ -55,9 +55,11 @@ column) · `/run/{uid}/plot.png?y=&x=` (server-rendered scalar plot) ·
 ## Deployment
 
 Runs on the queueserver worker host next to the capture daemon (default
-port **8200**; Tiled is :8000, GEECS-MCP :8100).  The systemd unit +
-runbook land in `deploy/` (phase 5 of the arc); until then
-`geecs-data-portal --experiment <name>` serves directly.
+port **8200**; Tiled is :8000, GEECS-MCP :8100).  The systemd unit is
+`deploy/geecs-data-portal.service`; the runbook is `DEPLOYMENT.md`; the
+fleet map (`docs/platform/fleet_map.md`) carries the service row and
+must move in the same PR as any deployment change.
+`geecs-data-portal --experiment <name>` serves directly for development.
 
 ## The resource viewer (`resources.py`, arc phase 4)
 

--- a/GEECS-DataPortal/DEPLOYMENT.md
+++ b/GEECS-DataPortal/DEPLOYMENT.md
@@ -1,0 +1,86 @@
+# GEECS Data Portal — deployment runbook
+
+One service, one host: the portal runs on the services host (interim:
+the queueserver worker box — the same machine as Tiled and GEECS-MCP,
+so ports read `:8000` Tiled, `:8100` MCP, **`:8200` portal**). Anyone
+on the lab network then browses to `http://<host>:8200/`.
+
+The portal is **read-only by doctrine** (see `CLAUDE.md`): it renders
+the Tiled catalog and reads per-shot files off the data share, and must
+never create or modify anything on the scans path. On a dedicated
+portal host, mount the share read-only; on a shared host where other
+services (the queueserver worker) legitimately write, the guarantee is
+the code path itself — pinned by the package's tree-untouched tests.
+
+## Prerequisites
+
+- Ubuntu with **Python 3.11** and **Poetry** on the service account
+  (same account and tooling as the other services on the box).
+- `~/.config/geecs_python_api/config.ini` with a `[tiled]` section
+  (`uri`, `api_key`) and a `[Paths]` section whose
+  `geecs_data_local_base_path` points at the mounted data share —
+  the same file every GEECS-Plugins package reads.
+- The data share mounted at that path (e.g. `/mnt/<share>/data/`).
+- Port **8200** free (`ss -tlnp | grep 8200`).
+
+## Install
+
+The portal runs from its own repo checkout so it can be upgraded
+without touching the checkouts other services run from (the
+queueserver-worker precedent; paths below assume the checkout is
+`~/GEECS-Plugins` — substitute yours):
+
+```bash
+cd ~/GEECS-Plugins/GEECS-DataPortal
+poetry env use python3.11
+poetry install
+```
+
+Smoke-test in the foreground before installing the unit:
+
+```bash
+poetry run geecs-data-portal --experiment Undulator
+# in another shell:
+curl -s http://localhost:8200/health
+```
+
+`/health` returns the catalog probe — `ok` requires the Tiled server
+reachable with the configured key. Then load a real day page in a
+browser and open one run's image gallery (exercises the share mount).
+
+## systemd unit
+
+`deploy/geecs-data-portal.service` — install per its header comments
+(copy, `sudoedit` the account/paths, `daemon-reload`,
+`enable --now`). Site specifics (the real account, checkout path,
+`--experiment`) live in the `/etc/systemd/system` copy, not in the
+repo file.
+
+Verify:
+
+```bash
+systemctl status geecs-data-portal
+curl -s http://localhost:8200/health
+journalctl -u geecs-data-portal -n 20
+```
+
+## Upgrade
+
+```bash
+cd ~/GEECS-Plugins && git pull
+cd GEECS-DataPortal && poetry install
+sudo systemctl restart geecs-data-portal
+```
+
+## Troubleshooting
+
+| Symptom | Likely cause |
+|---|---|
+| `/health` reports a catalog error | Tiled down, or `[tiled]` uri/api_key wrong — `curl http://<tiled-host>:8000/api/v1/` |
+| Day pages load, images 404 | share not mounted (or moved) at `geecs_data_local_base_path`; a 404 on one shot with others fine is the exact-match rule working (that device missed the shot) |
+| Slow day listings | measure `list_runs` against the catalog first — the fix is a portal-side cache, not a schema change (scope doc, open questions) |
+| Unit exits immediately at boot | Tiled not up yet — `Restart=on-failure` retries; check `journalctl -u geecs-data-portal` |
+
+The fleet-map page (`docs/platform/fleet_map.md`) carries the
+service's row — host, port, health check — and must be updated in the
+same PR when this deployment moves or changes.

--- a/GEECS-DataPortal/DEPLOYMENT.md
+++ b/GEECS-DataPortal/DEPLOYMENT.md
@@ -1,9 +1,12 @@
 # GEECS Data Portal — deployment runbook
 
-One service, one host: the portal runs on the services host (interim:
-the queueserver worker box — the same machine as Tiled and GEECS-MCP,
-so ports read `:8000` Tiled, `:8100` MCP, **`:8200` portal**). Anyone
-on the lab network then browses to `http://<host>:8200/`.
+One service, one host: the portal runs on the worker host — the fleet
+map (`docs/platform/fleet_map.md`) is the authority on which machine
+that is at any given time. On the interim box it happens to share a
+machine with Tiled and GEECS-MCP, so the ports read `:8000` Tiled,
+`:8100` MCP, **`:8200` portal** — but only the portal's own port is
+load-bearing; nothing below assumes Tiled is local. Anyone on the lab
+network browses to `http://<host>:8200/`.
 
 The portal is **read-only by doctrine** (see `CLAUDE.md`): it renders
 the Tiled catalog and reads per-shot files off the data share, and must
@@ -27,11 +30,20 @@ the code path itself — pinned by the package's tree-untouched tests.
 
 The portal runs from its own repo checkout so it can be upgraded
 without touching the checkouts other services run from (the
-queueserver-worker precedent; paths below assume the checkout is
-`~/GEECS-Plugins` — substitute yours):
+queueserver-worker precedent). Give the checkout a portal-specific
+name — on a box that also runs the CA gateway, a checkout named plain
+`~/GEECS-Plugins` is likely the *gateway's* running checkout, and this
+runbook's Upgrade step must never `git pull` that one. Paths below
+assume `~/GEECS-Plugins-portal` — substitute yours.
+
+**Run every command in this section as the service account** (the
+`User=` of the unit): Poetry keys the project venv under the invoking
+user's cache, so an env installed by an admin account is invisible to
+the service and the unit crash-loops on an empty env while admin-side
+checks pass.
 
 ```bash
-cd ~/GEECS-Plugins/GEECS-DataPortal
+cd ~/GEECS-Plugins-portal/GEECS-DataPortal
 poetry env use python3.11
 poetry install
 ```
@@ -67,7 +79,7 @@ journalctl -u geecs-data-portal -n 20
 ## Upgrade
 
 ```bash
-cd ~/GEECS-Plugins && git pull
+cd ~/GEECS-Plugins-portal && git pull
 cd GEECS-DataPortal && poetry install
 sudo systemctl restart geecs-data-portal
 ```
@@ -79,7 +91,7 @@ sudo systemctl restart geecs-data-portal
 | `/health` reports a catalog error | Tiled down, or `[tiled]` uri/api_key wrong — `curl http://<tiled-host>:8000/api/v1/` |
 | Day pages load, images 404 | share not mounted (or moved) at `geecs_data_local_base_path`; a 404 on one shot with others fine is the exact-match rule working (that device missed the shot) |
 | Slow day listings | measure `list_runs` against the catalog first — the fix is a portal-side cache, not a schema change (scope doc, open questions) |
-| Unit exits immediately at boot | Tiled not up yet — `Restart=on-failure` retries; check `journalctl -u geecs-data-portal` |
+| Unit crash-loops at start | wrong absolute Poetry path in `ExecStart` (`status` shows 203/EXEC); env installed by a different account than `User=` (empty venv — reinstall as the service account); or port 8200 already taken. A down Tiled does **not** exit the service — that shows up as the `/health` row above |
 
 The fleet-map page (`docs/platform/fleet_map.md`) carries the
 service's row — host, port, health check — and must be updated in the

--- a/GEECS-DataPortal/deploy/geecs-data-portal.service
+++ b/GEECS-DataPortal/deploy/geecs-data-portal.service
@@ -1,0 +1,40 @@
+# GEECS Data Portal — systemd unit for the services host (interim: the
+# queueserver worker box, alongside Tiled :8000 and GEECS-MCP :8100).
+#
+# The User= and path lines below use a generic `geecs` service account —
+# substitute the real account and checkout path when installing; the copy
+# in /etc/systemd/system is the home for site specifics, not this file.
+#
+# Install (from the repo checkout on the box):
+#   sudo cp GEECS-DataPortal/deploy/geecs-data-portal.service /etc/systemd/system/
+#   sudoedit /etc/systemd/system/geecs-data-portal.service   # fix User + paths
+#   sudo systemctl daemon-reload
+#   sudo systemctl enable --now geecs-data-portal
+#
+# Upgrade:
+#   git pull && poetry install && sudo systemctl restart geecs-data-portal
+#
+# See DEPLOYMENT.md (one directory up).
+
+[Unit]
+Description=GEECS Data Portal (read-only scan browser)
+# The portal reads the Tiled catalog; when Tiled runs on the same box,
+# start after it. If Tiled is remote, drop the tiled.service reference —
+# the portal degrades gracefully (pages report catalog errors) and
+# Restart=on-failure retries a crash-at-boot either way.
+After=network-online.target tiled.service
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=geecs
+# Poetry resolves its cache/venvs under $HOME; systemd does not always set it.
+Environment=HOME=/home/geecs
+WorkingDirectory=/home/geecs/GEECS-Plugins/GEECS-DataPortal
+ExecStart=/home/geecs/.local/bin/poetry run geecs-data-portal --experiment Undulator
+Restart=on-failure
+RestartSec=10
+SyslogIdentifier=geecs-data-portal
+
+[Install]
+WantedBy=multi-user.target

--- a/GEECS-DataPortal/deploy/geecs-data-portal.service
+++ b/GEECS-DataPortal/deploy/geecs-data-portal.service
@@ -30,7 +30,9 @@ Type=simple
 User=geecs
 # Poetry resolves its cache/venvs under $HOME; systemd does not always set it.
 Environment=HOME=/home/geecs
-WorkingDirectory=/home/geecs/GEECS-Plugins/GEECS-DataPortal
+# Portal-specific checkout — never the one another service (e.g. the CA
+# gateway) runs from; see DEPLOYMENT.md § Install.
+WorkingDirectory=/home/geecs/GEECS-Plugins-portal/GEECS-DataPortal
 ExecStart=/home/geecs/.local/bin/poetry run geecs-data-portal --experiment Undulator
 Restart=on-failure
 RestartSec=10

--- a/GEECS-DataPortal/pyproject.toml
+++ b/GEECS-DataPortal/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-data-portal"
-version = "0.2.0"
+version = "0.3.0"
 description = "Read-only scan-browsing web service: a zero-install browser view over the Tiled catalog and the GEECS data share"
 authors = ["GEECS-BELLA"]
 readme = "README.md"

--- a/docs/platform/fleet_map.md
+++ b/docs/platform/fleet_map.md
@@ -11,8 +11,9 @@ the manual.
 
 !!! note "Snapshot"
     Reflects the fleet as of **August 2026**. Deployed and running: the
-    CA gateway, the GEECS DB, Tiled, the PVA image gateways, and the
-    queueserver worker (on an interim host). Documented here ahead of
+    CA gateway, the GEECS DB, Tiled, the PVA image gateways, the
+    queueserver worker (on an interim host), and the GEECS Data Portal.
+    Documented here ahead of
     deployment: the GEECS-MCP HTTP service and the capture daemon
     (which lands with the central-PVA-capture arc). When a service
     moves, deploys, or a new one lands, update this page in the same
@@ -40,6 +41,7 @@ flowchart TB
         qs["Queueserver stack<br/>RE Manager :60615 / :60625<br/>doc stream :5568<br/>Redis (loopback)"]
         mcp["GEECS-MCP server<br/>:8100 (HTTP mode — pending deploy)"]
         capture["Capture daemon<br/>(geecs-capture — pending deploy)"]
+        portal["GEECS Data Portal<br/>:8200 (GEECS-DataPortal)"]
     end
 
     subgraph camsrv["Camera servers ×9 (Windows)"]
@@ -79,6 +81,9 @@ flowchart TB
     tiled -- "HTTP API / web UI" --> browser
     tiled -- "catalog reads" --> console
     tiled -- "catalog reads" --> nb
+    tiled -- "catalog reads" --> portal
+    nas -- "SMB mount" --> portal
+    portal -- "HTTP :8200" --> browser
     nas -- "SMB mount" --> nb
 ```
 
@@ -87,8 +92,7 @@ Arrows follow the **primary flow of data or commands** over each link
 setpoint writes travel against the readback arrows, over the same
 connections.
 
-Planned additions (not yet deployed): the **GEECS Data Portal** — a
-read-only scan-browsing web app joining Tiled and the data share — and a
+Planned additions (not yet deployed): a
 consolidated services server that will absorb the central-server roles
 above (the queueserver worker and capture daemon move together — their
 co-location is a requirement, not a convenience).
@@ -102,6 +106,7 @@ co-location is a requirement, not a convenience).
 | Queueserver worker (RE Manager + Redis + doc proxy) | the worker host (interim box; the runbook targets a dedicated host) | ZMQ 60615 (control), 60625 (console stream), 5568 (documents); Redis loopback-only | systemd `geecs-qserver` | `qserver status` from any client env | [GeecsBluesky/qserver/deploy/DEPLOYMENT.md](https://github.com/GEECS-BELLA/GEECS-Plugins/blob/master/GeecsBluesky/qserver/deploy/DEPLOYMENT.md) |
 | GEECS-MCP server — *HTTP mode pending deploy* | the worker host (co-located by design; stdio mode runs per-machine today) | HTTP 8100 (`/mcp`) | systemd (HTTP mode) | tool call `scan_status` from an agent | [GEECS-MCP/deploy/DEPLOYMENT.md](https://github.com/GEECS-BELLA/GEECS-Plugins/blob/master/GEECS-MCP/deploy/DEPLOYMENT.md) |
 | Capture daemon (`geecs_bluesky.capture`) — *pending deploy* | the queueserver worker host (co-location is a **requirement**: shared filesystem view + local heartbeat) | consumes doc stream (5568) + pvAccess; no listening port | systemd `geecs-capture` | heartbeat file refreshing every ~10 s (`~/.local/state/geecs-capture/heartbeat.json` in the service user's home); discovery line in `journalctl -u geecs-capture` | [GeecsBluesky/capture/deploy/DEPLOYMENT.md](https://github.com/GEECS-BELLA/GEECS-Plugins/blob/master/GeecsBluesky/capture/deploy/DEPLOYMENT.md) |
+| GEECS Data Portal (GEECS-DataPortal) | the worker host (interim box; moves with the services-server consolidation) | HTTP 8200 | systemd `geecs-data-portal` | `GET /health` (catalog probe); any day page in a browser | [GEECS-DataPortal/DEPLOYMENT.md](https://github.com/GEECS-BELLA/GEECS-Plugins/blob/master/GEECS-DataPortal/DEPLOYMENT.md) |
 | PVA image gateways (GeecsPvaGateway) | each camera server (9 hosts) | pvAccess TCP 5075 / UDP 5076 | NSSM service `GeecsPvaGateway` (auto-start, pull-on-restart) | fleet status Phoebus screen (`deploy/fleet_status.bob`) | [GeecsPvaGateway/DEPLOYMENT.md](https://github.com/GEECS-BELLA/GEECS-Plugins/blob/master/GeecsPvaGateway/DEPLOYMENT.md) |
 | GEECS MySQL DB | 192.168.6.14 | 3306 | LabVIEW/GEECS infrastructure (not managed by this repo) | any `GeecsDb` client connect | — |
 | Data share (NAS) | NAS appliance | SMB | storage infrastructure (not managed by this repo) | mount visible, scan folders resolvable | — |
@@ -144,7 +149,9 @@ whether eligible cameras also write native files, while
 proprietary-format devices — HASO, scopes — always keep native saving).
 Analysis reads any of these surfaces: files via the mounted share,
 frame stacks via `geecs_data_utils` `scan_stack`, scalars and metadata
-via Tiled.
+via Tiled. The Data Portal is the zero-install reader over the same
+surfaces — runs and scalars from the catalog, per-shot files from the
+share — for anyone with a browser.
 
 ## Client configuration in one place
 


### PR DESCRIPTION
## What

Portal arc **phase 5** (the last constituent PR before promotion — scope doc phase plan §5): make the portal a deployable, documented fleet service.

- `GEECS-DataPortal/deploy/geecs-data-portal.service` (~40 LOC) — systemd unit on the CA-gateway template: generic `geecs` account placeholders with site specifics living in the `/etc/systemd/system` copy; `After=tiled.service` with a drop-it-if-remote comment; `Restart=on-failure`.
- `GEECS-DataPortal/DEPLOYMENT.md` (~90 LOC) — runbook: prerequisites (3.11 + Poetry + `config.ini` `[tiled]`/`[Paths]` + share mount + port 8200), own-checkout install (qserver precedent — upgrades never touch the checkout other services run from), foreground smoke test via `/health`, unit install, upgrade, troubleshooting table.
- `docs/platform/fleet_map.md` (~15 LOC) — portal promoted from *planned additions* to a deployed service row (worker host, HTTP 8200, `GET /health` + runbook link), added to the mermaid diagram (tiled/nas → portal → browser), one data-plane sentence; snapshot note updated. Same-PR-as-deployment per the page's own rule.
- `GEECS-DataPortal/CLAUDE.md` (~6 LOC) — Deployment section now points at the landed unit/runbook instead of "phase 5 will land".
- Version 0.2.0 → **0.3.0** + CHANGELOG.

**Judgment call (cheap veto):** minor bump, not patch — no runtime code changed, but "deployable as a service" reads as a feature milestone, and the docs-only-patch precedent (#536/#537) was about doc *fixes*. Happy to re-cut as 0.2.1.

## Live verification (deployed this session, 2026-08-29)

Deployed on the production box during this session — the fleet-map "deployed and running" claim is already true:

- `systemctl` `active` + `enabled`; unit installed from this branch's file (owner ran the sudo steps).
- `/health` → `{"ok":true,"catalog":"tiled: 192.168.6.14:8000"}` on loopback **and** the lab interface.
- End-to-end under the service context against today's real data: day listing 2026-08-29 (Scan 001, 63 ms), run page, scalar `plot.png` (200, image/png), per-shot camera image `UC_Amp4_IR_input` shot 1 (200, image/png, 200 KB) off the share mount.
- Foreground smoke test per the runbook was run first, unprivileged — the runbook's install sequence is exactly what was executed.

## Tests

No runtime code changed; no new tests owed. `scripts/check.sh` (lint + the three suites the diff selects): **GEECS-Console 788 passed · GEECS-Data-Utils 222 passed, 3 skipped · GEECS-DataPortal 46 passed**, lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
