### PR TITLE
portal 0.5.0: within-scan prefetch caches (owner feature — eager within a scan, lazy across scans)

### DIFF
--- a/GEECS-DataPortal/CHANGELOG.md
+++ b/GEECS-DataPortal/CHANGELOG.md
@@ -3,6 +3,23 @@
 All notable changes to this package will be documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.5.0] - 2026-08-29
+
+### Added
+
+- **Within-scan prefetch caches** (`geecs_portal/cache.py` — owner
+  feature request, amending the scope doc's blanket lazy rule to "eager
+  within a scan, lazy across scans"): `CachingScanCatalog` keeps
+  completed runs' details (LRU-8; still-running runs expire in seconds),
+  ending the repeated full-event-table Tiled reads; `ShotDataCache`
+  (bytes-bounded LRU, ~1.5 GB) keeps completed runs' pixel data — a
+  stack device's whole frames array in ONE HDF5 read on first touch, a
+  native device's decoded shots warmed by a background thread walking
+  the event rows — so stepping through a gallery serves from memory
+  with zero filesystem access (pinned by delete-the-file-then-serve
+  tests).  Still-running runs and ordinal (listing-order) resolutions
+  are never cached.  `__main__` wraps the real catalog.
+
 ## [0.4.2] - 2026-08-29
 
 ### Changed

--- a/GEECS-DataPortal/CHANGELOG.md
+++ b/GEECS-DataPortal/CHANGELOG.md
@@ -18,7 +18,14 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   the event rows — so stepping through a gallery serves from memory
   with zero filesystem access (pinned by delete-the-file-then-serve
   tests).  Still-running runs and ordinal (listing-order) resolutions
-  are never cached.  `__main__` wraps the real catalog.
+  are never cached.  `__main__` wraps the real catalog.  Hardened per
+  review: the budget genuinely bounds the cache (per-entry cap =
+  budget/3 — a single warming entry can never exceed it; oversize
+  stacks serve per shot from disk, uncached), stack admission requires
+  the daemon's `finalized=True` stamp (the stop doc lands before
+  finalization — caching an un-finalized stack would 404 tail shots
+  from memory forever), warms are throttled (2 threads) and run once
+  per key per process (no hole re-probing per page view).
 
 ## [0.4.2] - 2026-08-29
 

--- a/GEECS-DataPortal/CLAUDE.md
+++ b/GEECS-DataPortal/CLAUDE.md
@@ -36,6 +36,16 @@ this package; the architecture rules below are its distillation.
 - **Blocking catalog calls are fine here** (unlike the Qt console):
   FastAPI runs sync endpoints on a threadpool.  Keep endpoints sync
   unless something genuinely needs async.
+- **Eager WITHIN a scan, lazy ACROSS scans** (owner amendment,
+  2026-08-29, superseding the scope doc's blanket "lazy loading is a
+  hard rule"): one diagnostic's per-scan data is ~100s of MB — trivial
+  against server RAM, while every NAS/Tiled round trip is the real
+  cost.  `geecs_portal.cache` holds completed runs' details
+  (`CachingScanCatalog`) and pixel data (`ShotDataCache`: whole stack
+  frames arrays; native shots warmed in the background) so shot
+  navigation serves from memory.  The lazy rule still binds across
+  scans: never eager-load a day, and never cache a still-running run's
+  pixels or an ordinal (listing-order) resolution.
 
 ## Package layout
 

--- a/GEECS-DataPortal/geecs_portal/__main__.py
+++ b/GEECS-DataPortal/geecs_portal/__main__.py
@@ -35,8 +35,11 @@ def main() -> None:
     from geecs_data_utils.tiled_catalog import TiledScanCatalog
 
     from geecs_portal.app import create_app
+    from geecs_portal.cache import CachingScanCatalog
 
-    catalog = TiledScanCatalog.from_config()
+    # Completed runs are immutable: cache their details so plot/image
+    # requests stop re-downloading the full event table from Tiled.
+    catalog = CachingScanCatalog(TiledScanCatalog.from_config())
     app = create_app(catalog, default_experiment=args.experiment)
     uvicorn.run(app, host=args.host, port=args.port, log_level=args.log_level.lower())
 

--- a/GEECS-DataPortal/geecs_portal/app.py
+++ b/GEECS-DataPortal/geecs_portal/app.py
@@ -47,6 +47,7 @@ from geecs_data_utils.tiled_catalog import (
 )
 
 from geecs_portal import resources
+from geecs_portal.cache import ShotDataCache
 
 logger = logging.getLogger(__name__)
 
@@ -161,6 +162,10 @@ def create_app(catalog: ScanCatalog, *, default_experiment: str = "") -> FastAPI
     """
     app = FastAPI(title="GEECS Data Portal", docs_url=None, redoc_url=None)
     templates = Jinja2Templates(directory=str(_TEMPLATES_DIR))
+    # Per-app pixel cache: completed runs' shot data kept in memory so
+    # within-scan navigation never re-reads the share (owner doctrine,
+    # 2026-08-29 — lazy stays the rule ACROSS scans only).
+    data_cache = ShotDataCache()
 
     def _load_run(uid: str):
         """Load one run, mapping failures to honest HTTP status codes.
@@ -279,6 +284,39 @@ def create_app(catalog: ScanCatalog, *, default_experiment: str = "") -> FastAPI
             kind, kind_path = "", None
         n_rows = None if detail.data is None else len(detail.data)
         shot = max(1, min(shot, n_rows) if n_rows else shot)
+        if (
+            kind == "native"
+            and folder is not None
+            and n_rows
+            and detail.summary.exit_status
+            and detail.data is not None
+            and schema_map.device_acq_timestamp_column(
+                [str(c) for c in detail.data.columns], sel_device
+            )
+            is not None
+        ):
+            # Background-warm the whole diagnostic (timestamp-joined shots
+            # only — ordinal resolutions are never cached), so stepping
+            # through shots serves from memory.
+            warm_key = (uid, sel_device)
+            warm_folder, warm_device, warm_detail = folder, sel_device, detail
+
+            def _warm_one(s: int) -> None:
+                acq_s, present = _acq_timestamp(warm_detail, warm_device, s)
+                if acq_s is None:
+                    return  # device missed the shot (or no column)
+                resources.load_shot_image(
+                    warm_folder,
+                    warm_device,
+                    s,
+                    acq_timestamp=acq_s,
+                    data_cache=data_cache,
+                    cache_key=warm_key,
+                )
+
+            data_cache.warm_native(
+                warm_key, _warm_one, list(range(1, min(n_rows, 2000) + 1))
+            )
         state = {
             "day": day,
             "experiment": experiment or default_experiment,
@@ -331,7 +369,15 @@ def create_app(catalog: ScanCatalog, *, default_experiment: str = "") -> FastAPI
             raise HTTPException(
                 status_code=404, detail="device missed this shot (no timestamp)"
             )
-        result = resources.load_shot_image(folder, device, shot, acq_timestamp=acq)
+        complete = bool(detail.summary.exit_status)
+        result = resources.load_shot_image(
+            folder,
+            device,
+            shot,
+            acq_timestamp=acq,
+            data_cache=data_cache if complete else None,
+            cache_key=(uid, device) if complete else None,
+        )
         if result.png is None:
             raise HTTPException(status_code=404, detail=result.reason or result.kind)
         headers = (

--- a/GEECS-DataPortal/geecs_portal/cache.py
+++ b/GEECS-DataPortal/geecs_portal/cache.py
@@ -1,0 +1,262 @@
+"""In-memory caches: seamless navigation instead of per-shot round trips.
+
+The owner's doctrine amendment (2026-08-29): a diagnostic's full data for
+one scan is ~100s of MB — trivial against server RAM, while every NAS/
+Tiled round trip is the real cost.  So the portal now loads *within-scan*
+data eagerly and keeps it: the scope doc's "lazy loading is a hard rule"
+still governs *across-scan* eagerness (never thumbnail whole days), but
+navigating one run's shots must not re-read the share per click.
+
+Two caches, both process-local and thread-safe (FastAPI threadpool):
+
+- :class:`CachingScanCatalog` — a delegating ``ScanCatalog`` that caches
+  ``load_run``.  A **completed** run (stop doc present) is immutable, so
+  its detail is kept until LRU eviction; a still-running run is cached
+  for a short TTL only.  Kills the full-event-table Tiled read that every
+  ``plot.png``/``image.png`` request used to repeat.
+- :class:`ShotDataCache` — per ``(uid, device)`` pixel data for
+  **completed** runs only: a stack device's whole ``/frames`` array in
+  one HDF5 read on first touch; a native device's decoded per-shot
+  arrays, warmed by a background thread walking the run's event rows.
+  Rendering to PNG then happens from memory.  Bytes-bounded LRU.
+
+Invalidation is deliberately trivial: completed runs never change (the
+same property the immutable cache headers rely on); running runs are
+never entered into ``ShotDataCache`` and expire from the detail cache in
+seconds.  Everything here is read-only over the scans path (repo
+scan-folder invariant).
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+import time
+from collections import OrderedDict
+from pathlib import Path
+from typing import Callable, Optional
+
+import numpy as np
+
+logger = logging.getLogger(__name__)
+
+#: Detail-cache size (completed runs kept, LRU).
+_DETAIL_CACHE_RUNS = 8
+
+#: Seconds a still-running run's detail stays fresh.
+_RUNNING_TTL_S = 5.0
+
+#: Byte budget for cached pixel data across all (uid, device) entries.
+_PIXEL_BUDGET_BYTES = 1_500_000_000
+
+
+class CachingScanCatalog:
+    """A delegating ``ScanCatalog`` that caches ``load_run`` results.
+
+    Wraps any catalog implementation; every method routes to the wrapped
+    instance (never back through a registry).  ``list_runs`` and
+    ``probe`` pass straight through — the day listing stays live.
+
+    Parameters
+    ----------
+    catalog : ScanCatalog
+        The wrapped implementation.
+    clock : callable, optional
+        Monotonic time source (tests inject a fake).
+    """
+
+    def __init__(self, catalog, clock: Callable[[], float] = time.monotonic):
+        self._catalog = catalog
+        self._clock = clock
+        self._lock = threading.Lock()
+        self._details: OrderedDict[str, tuple[object, float]] = OrderedDict()
+
+    def probe(self):
+        """Delegate the liveness probe (never cached)."""
+        return self._catalog.probe()
+
+    def list_runs(self, experiment: str, day):
+        """Delegate the day listing (never cached — new scans must appear)."""
+        return self._catalog.list_runs(experiment, day)
+
+    def load_run(self, uid: str):
+        """Load one run, serving completed runs from the cache.
+
+        Raises ``KeyError`` for an unknown uid (the protocol's not-found
+        contract — misses are never cached, so a run that appears later
+        loads normally).
+        """
+        now = self._clock()
+        with self._lock:
+            hit = self._details.get(uid)
+            if hit is not None:
+                detail, fetched_at = hit
+                complete = bool(detail.summary.exit_status)
+                if complete or (now - fetched_at) < _RUNNING_TTL_S:
+                    self._details.move_to_end(uid)
+                    return detail
+                del self._details[uid]
+        detail = self._catalog.load_run(uid)
+        with self._lock:
+            self._details[uid] = (detail, now)
+            self._details.move_to_end(uid)
+            while len(self._details) > _DETAIL_CACHE_RUNS:
+                self._details.popitem(last=False)
+        return detail
+
+
+class ShotDataCache:
+    """Bytes-bounded LRU of per-``(uid, device)`` pixel data.
+
+    Entries exist only for completed runs.  A stack entry holds the whole
+    frames array plus its millisecond-key index map (one HDF5 read); a
+    native entry accumulates decoded per-shot arrays — served shots
+    immediately, the rest by :meth:`warm_native` on a background thread.
+
+    Parameters
+    ----------
+    budget_bytes : int, optional
+        Total pixel-byte budget; least-recently-used entries evict.
+    """
+
+    def __init__(self, budget_bytes: int = _PIXEL_BUDGET_BYTES):
+        self._budget = budget_bytes
+        self._lock = threading.Lock()
+        self._entries: OrderedDict[tuple[str, str], dict] = OrderedDict()
+        self._warming: set[tuple[str, str]] = set()
+
+    def _entry_bytes(self, entry: dict) -> int:
+        frames = entry.get("frames")
+        if frames is not None:
+            return int(frames.nbytes)
+        return int(sum(a.nbytes for a in entry.get("shots", {}).values()))
+
+    def _evict_over_budget(self) -> None:
+        total = sum(self._entry_bytes(e) for e in self._entries.values())
+        while total > self._budget and len(self._entries) > 1:
+            _, evicted = self._entries.popitem(last=False)
+            total -= self._entry_bytes(evicted)
+
+    def stack_frames(
+        self, key: tuple[str, str], stack_path: Path
+    ) -> tuple[dict, np.ndarray]:
+        """The stack's ``(index_map, frames)`` — whole array, one read.
+
+        First touch reads every frame (the owner's eager-within-scan
+        doctrine: ~100s MB, one open); navigation then never reopens the
+        file.
+
+        Parameters
+        ----------
+        key : tuple of (str, str)
+            ``(uid, device)``.
+        stack_path : Path
+            The validated stack file.
+
+        Returns
+        -------
+        tuple of (dict, numpy.ndarray)
+            The keep-first millisecond-key → index map and the frames.
+        """
+        with self._lock:
+            entry = self._entries.get(key)
+            if entry is not None and "frames" in entry:
+                self._entries.move_to_end(key)
+                return entry["index_map"], entry["frames"]
+        import h5py
+
+        from geecs_data_utils.io.scan_stack import (
+            LABVIEW_EPOCH_OFFSET,
+            stack_frame_index_map,
+        )
+
+        with h5py.File(stack_path, "r") as f:
+            stamps = np.asarray(f["acq_timestamp"][:], dtype=float)
+            stamps = stamps + LABVIEW_EPOCH_OFFSET
+            frames = np.asarray(f["frames"][:])
+        index_map = stack_frame_index_map(stamps)
+        with self._lock:
+            self._entries[key] = {"index_map": index_map, "frames": frames}
+            self._entries.move_to_end(key)
+            self._evict_over_budget()
+        return index_map, frames
+
+    def stack_entry(self, key: tuple[str, str]) -> Optional[tuple[dict, np.ndarray]]:
+        """The cached ``(index_map, frames)`` for *key*, or ``None``.
+
+        A hit serves shots with zero filesystem access (no listing, no
+        open) — the whole point of the eager load.
+        """
+        with self._lock:
+            entry = self._entries.get(key)
+            if entry is None or "frames" not in entry:
+                return None
+            self._entries.move_to_end(key)
+            return entry["index_map"], entry["frames"]
+
+    def native_shot(self, key: tuple[str, str], shot: int) -> Optional[np.ndarray]:
+        """A cached decoded array for *shot*, or ``None`` on a miss."""
+        with self._lock:
+            entry = self._entries.get(key)
+            if entry is None:
+                return None
+            self._entries.move_to_end(key)
+            return entry.get("shots", {}).get(shot)
+
+    def store_native_shot(
+        self, key: tuple[str, str], shot: int, array: np.ndarray
+    ) -> None:
+        """Keep one decoded shot array (creates the entry as needed)."""
+        with self._lock:
+            entry = self._entries.setdefault(key, {"shots": {}})
+            entry.setdefault("shots", {})[shot] = array
+            self._entries.move_to_end(key)
+            self._evict_over_budget()
+
+    def warm_native(
+        self,
+        key: tuple[str, str],
+        load_shot: Callable[[int], None],
+        shots: list[int],
+        *,
+        synchronous: bool = False,
+    ) -> None:
+        """Background-load a native device's remaining shots, once per key.
+
+        *load_shot* performs its own storing (the normal loader path does,
+        via :meth:`store_native_shot`); already-cached shots are skipped.
+        Best-effort: individual failures are logged at debug and skipped.
+
+        Parameters
+        ----------
+        key : tuple of (str, str)
+            ``(uid, device)``.
+        load_shot : callable
+            Loads (and stores) one 1-based shot.
+        shots : list of int
+            The run's shot numbers to warm.
+        synchronous : bool, optional
+            Run inline instead of on a daemon thread (tests only).
+        """
+        with self._lock:
+            if key in self._warming:
+                return
+            self._warming.add(key)
+
+        def _run() -> None:
+            try:
+                for shot in shots:
+                    if self.native_shot(key, shot) is not None:
+                        continue
+                    try:
+                        load_shot(shot)
+                    except Exception as exc:  # noqa: BLE001 — warming is best-effort
+                        logger.debug("warm %s shot %d failed: %s", key, shot, exc)
+            finally:
+                with self._lock:
+                    self._warming.discard(key)
+
+        if synchronous:
+            _run()
+            return
+        threading.Thread(target=_run, name=f"warm-{key[1]}", daemon=True).start()

--- a/GEECS-DataPortal/geecs_portal/cache.py
+++ b/GEECS-DataPortal/geecs_portal/cache.py
@@ -49,6 +49,15 @@ _RUNNING_TTL_S = 5.0
 #: Byte budget for cached pixel data across all (uid, device) entries.
 _PIXEL_BUDGET_BYTES = 1_500_000_000
 
+#: No single (uid, device) entry may exceed this fraction of the budget —
+#: the budget must bound the cache even while one entry is warming, and
+#: two doctrine-sized diagnostics must coexist without evicting each other.
+_ENTRY_CAP_FRACTION = 3
+
+#: At most this many background warm threads at once (the NAS path is the
+#: bottleneck — warms must not compete with a live experiment's writes).
+_MAX_WARM_THREADS = 2
+
 
 class CachingScanCatalog:
     """A delegating ``ScanCatalog`` that caches ``load_run`` results.
@@ -121,9 +130,11 @@ class ShotDataCache:
 
     def __init__(self, budget_bytes: int = _PIXEL_BUDGET_BYTES):
         self._budget = budget_bytes
+        self._entry_cap = max(1, budget_bytes // _ENTRY_CAP_FRACTION)
         self._lock = threading.Lock()
         self._entries: OrderedDict[tuple[str, str], dict] = OrderedDict()
         self._warming: set[tuple[str, str]] = set()
+        self._warmed: set[tuple[str, str]] = set()
 
     def _entry_bytes(self, entry: dict) -> int:
         frames = entry.get("frames")
@@ -139,12 +150,18 @@ class ShotDataCache:
 
     def stack_frames(
         self, key: tuple[str, str], stack_path: Path
-    ) -> tuple[dict, np.ndarray]:
+    ) -> Optional[tuple[dict, np.ndarray]]:
         """The stack's ``(index_map, frames)`` — whole array, one read.
 
         First touch reads every frame (the owner's eager-within-scan
         doctrine: ~100s MB, one open); navigation then never reopens the
-        file.
+        file.  Admission is gated: the stack must be **finalized** (the
+        daemon's stop-doc handler stamps ``finalized=True`` *after* the
+        Tiled stop document lands, so an un-finalized file may still be
+        missing tail frames — caching it would 404 those shots from
+        memory forever) and must fit the per-entry cap (the budget must
+        bound the cache even mid-warm).  ``None`` means "don't cache" —
+        the caller serves from disk per shot as before.
 
         Parameters
         ----------
@@ -155,8 +172,9 @@ class ShotDataCache:
 
         Returns
         -------
-        tuple of (dict, numpy.ndarray)
-            The keep-first millisecond-key → index map and the frames.
+        tuple of (dict, numpy.ndarray) or None
+            The keep-first millisecond-key → index map and the frames,
+            or ``None`` when the stack is not admissible.
         """
         with self._lock:
             entry = self._entries.get(key)
@@ -171,9 +189,21 @@ class ShotDataCache:
         )
 
         with h5py.File(stack_path, "r") as f:
+            if not bool(f.attrs.get("finalized", False)):
+                return None
+            dataset = f["frames"]
+            size = int(np.prod(dataset.shape)) * dataset.dtype.itemsize
+            if size > self._entry_cap:
+                logger.info(
+                    "stack %s (%d bytes) exceeds the per-entry cap — serving "
+                    "per shot from disk",
+                    stack_path,
+                    size,
+                )
+                return None
             stamps = np.asarray(f["acq_timestamp"][:], dtype=float)
             stamps = stamps + LABVIEW_EPOCH_OFFSET
-            frames = np.asarray(f["frames"][:])
+            frames = np.asarray(dataset[:])
         index_map = stack_frame_index_map(stamps)
         with self._lock:
             self._entries[key] = {"index_map": index_map, "frames": frames}
@@ -205,13 +235,28 @@ class ShotDataCache:
 
     def store_native_shot(
         self, key: tuple[str, str], shot: int, array: np.ndarray
-    ) -> None:
-        """Keep one decoded shot array (creates the entry as needed)."""
+    ) -> bool:
+        """Keep one decoded shot array (creates the entry as needed).
+
+        Returns
+        -------
+        bool
+            False when the entry is at its per-entry cap (the shot is not
+            stored — the budget bounds the cache even mid-warm).
+        """
         with self._lock:
             entry = self._entries.setdefault(key, {"shots": {}})
+            if self._entry_bytes(entry) + array.nbytes > self._entry_cap:
+                return False
             entry.setdefault("shots", {})[shot] = array
             self._entries.move_to_end(key)
             self._evict_over_budget()
+            return True
+
+    def _entry_at_cap(self, key: tuple[str, str]) -> bool:
+        with self._lock:
+            entry = self._entries.get(key)
+            return entry is not None and self._entry_bytes(entry) >= self._entry_cap
 
     def warm_native(
         self,
@@ -239,13 +284,21 @@ class ShotDataCache:
             Run inline instead of on a daemon thread (tests only).
         """
         with self._lock:
-            if key in self._warming:
+            if key in self._warming or key in self._warmed:
+                # Once per key per process: a device with genuinely
+                # missing shot files must not re-probe every hole on
+                # every page view.
                 return
+            if not synchronous and len(self._warming) >= _MAX_WARM_THREADS:
+                return  # NAS throttle; a later view reschedules
             self._warming.add(key)
 
         def _run() -> None:
             try:
                 for shot in shots:
+                    if self._entry_at_cap(key):
+                        logger.info("warm %s stopped at the per-entry cap", key)
+                        break
                     if self.native_shot(key, shot) is not None:
                         continue
                     try:
@@ -255,6 +308,7 @@ class ShotDataCache:
             finally:
                 with self._lock:
                     self._warming.discard(key)
+                    self._warmed.add(key)
 
         if synchronous:
             _run()

--- a/GEECS-DataPortal/geecs_portal/resources.py
+++ b/GEECS-DataPortal/geecs_portal/resources.py
@@ -233,10 +233,14 @@ def load_shot_image(
             if caching:
                 # Eager within-scan load (owner doctrine): the whole
                 # frames array in one open; navigation never reopens.
-                index_map, frames = data_cache.stack_frames(cache_key, stack)
-                return _stack_shot_from_memory(
-                    index_map, frames, shot, acq_timestamp, path=stack
-                )
+                # None = not admissible (un-finalized tail-race window,
+                # or over the per-entry cap) — serve per shot from disk.
+                admitted = data_cache.stack_frames(cache_key, stack)
+                if admitted is not None:
+                    index_map, frames = admitted
+                    return _stack_shot_from_memory(
+                        index_map, frames, shot, acq_timestamp, path=stack
+                    )
             if acq_timestamp is not None:
                 # The canonical-millisecond join, ONE file open — the
                 # shared keep-first contract lives in

--- a/GEECS-DataPortal/geecs_portal/resources.py
+++ b/GEECS-DataPortal/geecs_portal/resources.py
@@ -145,11 +145,36 @@ def _ordinal_native_file(device_dir: Path, ext: str, shot: int) -> Optional[Path
     return None
 
 
+def _stack_shot_from_memory(
+    index_map: dict, frames, shot: int, acq_timestamp: Optional[float], path=None
+) -> ShotImage:
+    """Render one shot from cached stack data (no filesystem access)."""
+    from geecs_data_utils.io.scan_stack import frame_index_for_timestamp
+
+    if acq_timestamp is not None:
+        index = frame_index_for_timestamp(index_map, acq_timestamp)
+        if index is None:
+            return ShotImage(
+                kind="missing", path=path, reason="no stack frame for this shot"
+            )
+    else:
+        index = shot - 1
+        if not 0 <= index < len(frames):
+            return ShotImage(
+                kind="missing",
+                path=path,
+                reason=f"stack: shot {shot} outside {len(frames)} frames",
+            )
+    return ShotImage(kind="stack", png=to_display_png(frames[index]), path=path)
+
+
 def load_shot_image(
     scan_folder: Path,
     device: str,
     shot: int,
     acq_timestamp: Optional[float] = None,
+    data_cache=None,
+    cache_key: Optional[tuple[str, str]] = None,
 ) -> ShotImage:
     """Resolve and render one device shot from an existing scan folder.
 
@@ -172,12 +197,29 @@ def load_shot_image(
         can shift the ordinal join — pass the timestamp when the event
         table is at hand).
 
+    data_cache : ShotDataCache, optional
+        The per-``(uid, device)`` pixel cache (``geecs_portal.cache``).
+        Pass ONLY for completed runs — their data is immutable.
+    cache_key : tuple of (str, str), optional
+        The cache key (``uid``, ``device``); required with *data_cache*.
+
     Returns
     -------
     ShotImage
         Rendered PNG bytes, or the tiered refusal (vendor path /
         missing reason).
     """
+    caching = data_cache is not None and cache_key is not None
+    if caching and shot >= 1:
+        # Fast paths: a cached entry was created after full validation,
+        # so a hit serves with zero filesystem access.
+        stack_hit = data_cache.stack_entry(cache_key)
+        if stack_hit is not None:
+            return _stack_shot_from_memory(*stack_hit, shot, acq_timestamp)
+        cached = data_cache.native_shot(cache_key, shot)
+        if cached is not None:
+            return ShotImage(kind="native", png=to_display_png(cached))
+
     kind = device_kind(scan_folder, device)
     if kind.kind == "missing":
         return ShotImage(kind="missing", reason=kind.reason or "unknown device")
@@ -188,6 +230,13 @@ def load_shot_image(
     if kind.kind == "stack":
         stack = kind.path
         try:
+            if caching:
+                # Eager within-scan load (owner doctrine): the whole
+                # frames array in one open; navigation never reopens.
+                index_map, frames = data_cache.stack_frames(cache_key, stack)
+                return _stack_shot_from_memory(
+                    index_map, frames, shot, acq_timestamp, path=stack
+                )
             if acq_timestamp is not None:
                 # The canonical-millisecond join, ONE file open — the
                 # shared keep-first contract lives in
@@ -246,9 +295,14 @@ def load_shot_image(
     try:
         from geecs_data_utils.io.images import read_imaq_image
 
+        array = read_imaq_image(native)
+        if caching and cacheable:
+            # Never cache an ordinal (listing-order) resolution — the
+            # same rule as the no-long-cache header.
+            data_cache.store_native_shot(cache_key, shot, array)
         return ShotImage(
             kind="native",
-            png=to_display_png(read_imaq_image(native)),
+            png=to_display_png(array),
             path=native,
             cacheable=cacheable,
         )

--- a/GEECS-DataPortal/pyproject.toml
+++ b/GEECS-DataPortal/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-data-portal"
-version = "0.4.2"
+version = "0.5.0"
 description = "Read-only scan-browsing web service: a zero-install browser view over the Tiled catalog and the GEECS data share"
 authors = ["GEECS-BELLA"]
 readme = "README.md"

--- a/GEECS-DataPortal/tests/test_cache.py
+++ b/GEECS-DataPortal/tests/test_cache.py
@@ -1,0 +1,208 @@
+"""Cache tests — the eager within-scan doctrine, pinned hermetically.
+
+The strongest pins delete the underlying file after the first (caching)
+access and assert the shot still serves — proving zero filesystem access
+on the hit path, not just a faster one.
+"""
+
+from __future__ import annotations
+
+
+import pytest
+from fastapi.testclient import TestClient
+
+from geecs_portal import resources
+from geecs_portal.app import create_app
+from geecs_portal.cache import CachingScanCatalog, ShotDataCache
+
+from test_app import _LV, TEST_DAY, FakeCatalog, _detail
+from test_resources import scan_folder  # noqa: F401 — fixture import
+
+
+class _CountingCatalog(FakeCatalog):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.load_calls: list[str] = []
+
+    def load_run(self, uid: str):
+        self.load_calls.append(uid)
+        return super().load_run(uid)
+
+
+class TestCachingScanCatalog:
+    def test_completed_run_loads_once(self):
+        inner = _CountingCatalog()
+        catalog = CachingScanCatalog(inner)
+        first = catalog.load_run("uid-002")
+        second = catalog.load_run("uid-002")
+        assert first is second
+        assert inner.load_calls == ["uid-002"]
+
+    def test_running_run_expires_after_ttl(self):
+        from dataclasses import replace
+
+        inner = _CountingCatalog()
+        detail = _detail(9)
+        running = type(detail)(
+            summary=replace(detail.summary, exit_status=None),
+            start_doc=detail.start_doc,
+            stop_doc=None,
+            data=detail.data,
+        )
+        inner.details["uid-009"] = running
+        now = [0.0]
+        catalog = CachingScanCatalog(inner, clock=lambda: now[0])
+        catalog.load_run("uid-009")
+        catalog.load_run("uid-009")  # within TTL: cached
+        assert inner.load_calls == ["uid-009"]
+        now[0] = 10.0  # past the TTL: refetch (new shots may exist)
+        catalog.load_run("uid-009")
+        assert inner.load_calls == ["uid-009", "uid-009"]
+
+    def test_unknown_uid_raises_and_is_not_cached(self):
+        inner = _CountingCatalog()
+        catalog = CachingScanCatalog(inner)
+        with pytest.raises(KeyError):
+            catalog.load_run("nope")
+        with pytest.raises(KeyError):
+            catalog.load_run("nope")
+        assert inner.load_calls == ["nope", "nope"]
+
+    def test_listing_and_probe_pass_through_uncached(self):
+        inner = _CountingCatalog()
+        catalog = CachingScanCatalog(inner)
+        catalog.list_runs("Undulator", TEST_DAY)
+        assert inner.listed == ("Undulator", TEST_DAY)
+        assert catalog.probe().ok is True
+
+
+class TestShotDataCache:
+    def test_stack_hit_needs_no_filesystem(self, scan_folder):  # noqa: F811
+        cache = ShotDataCache()
+        key = ("uid-002", "UC_StackCam")
+        stack = scan_folder / "UC_StackCam" / "UC_StackCam.h5"
+        first = resources.load_shot_image(
+            scan_folder,
+            "UC_StackCam",
+            2,
+            acq_timestamp=_LV + 2.0,
+            data_cache=cache,
+            cache_key=key,
+        )
+        assert first.kind == "stack"
+        stack.unlink()  # the proof: a hit never touches the share
+        again = resources.load_shot_image(
+            scan_folder,
+            "UC_StackCam",
+            2,
+            acq_timestamp=_LV + 2.0,
+            data_cache=cache,
+            cache_key=key,
+        )
+        assert again.kind == "stack"
+        assert again.png == first.png
+        # exact-key refusal still enforced from memory
+        miss = resources.load_shot_image(
+            scan_folder,
+            "UC_StackCam",
+            2,
+            acq_timestamp=_LV + 9.0,
+            data_cache=cache,
+            cache_key=key,
+        )
+        assert miss.kind == "missing"
+
+    def test_native_timestamp_shot_cached_ordinal_never(self, scan_folder):  # noqa: F811
+        cache = ShotDataCache()
+        key = ("uid-002", "cam")
+        joined = resources.load_shot_image(
+            scan_folder,
+            "cam",
+            2,
+            acq_timestamp=_LV + 2.0,
+            data_cache=cache,
+            cache_key=key,
+        )
+        assert joined.kind == "native"
+        assert cache.native_shot(key, 2) is not None
+        # ordinal (listing-order) resolution must never enter the cache
+        ordinal = resources.load_shot_image(
+            scan_folder, "cam", 3, data_cache=cache, cache_key=key
+        )
+        assert ordinal.kind == "native"
+        assert cache.native_shot(key, 3) is None
+        # and the cached shot serves after the file disappears
+        (scan_folder / "cam" / f"cam_{_LV + 2.0:.3f}.png").unlink()
+        again = resources.load_shot_image(
+            scan_folder,
+            "cam",
+            2,
+            acq_timestamp=_LV + 2.0,
+            data_cache=cache,
+            cache_key=key,
+        )
+        assert again.kind == "native" and again.png == joined.png
+
+    def test_warm_native_loads_every_joined_shot(self, scan_folder):  # noqa: F811
+        cache = ShotDataCache()
+        key = ("uid-002", "cam")
+
+        def _load(shot: int) -> None:
+            resources.load_shot_image(
+                scan_folder,
+                "cam",
+                shot,
+                acq_timestamp=_LV + float(shot),
+                data_cache=cache,
+                cache_key=key,
+            )
+
+        cache.warm_native(key, _load, [1, 2, 3], synchronous=True)
+        assert all(cache.native_shot(key, s) is not None for s in (1, 2, 3))
+
+    def test_budget_evicts_least_recently_used(self, scan_folder):  # noqa: F811
+        import numpy as np
+
+        cache = ShotDataCache(budget_bytes=1)  # everything is over budget
+        cache.store_native_shot(("u", "a"), 1, np.zeros((16, 16)))
+        cache.store_native_shot(("u", "b"), 1, np.zeros((16, 16)))
+        # at least one entry always survives; the older one evicts
+        assert cache.native_shot(("u", "a"), 1) is None
+        assert cache.native_shot(("u", "b"), 1) is not None
+
+
+class TestCachedRoutes:
+    def _client(self, scan_folder, exit_status="success"):  # noqa: F811
+        catalog = FakeCatalog()
+        detail = _detail(2)
+        if exit_status is None:
+            from geecs_data_utils.tiled_catalog import RunDetail, summary_from_metadata
+
+            detail = RunDetail(
+                summary=summary_from_metadata(
+                    detail.start_doc["uid"], detail.start_doc, None
+                ),
+                start_doc=detail.start_doc,
+                stop_doc=None,
+                data=detail.data,
+            )
+        detail.start_doc["scan_folder"] = str(scan_folder)
+        catalog.details["uid-002"] = detail
+        return TestClient(create_app(catalog))
+
+    def test_completed_run_serves_after_file_vanishes(self, scan_folder):  # noqa: F811
+        client = self._client(scan_folder)
+        first = client.get("/run/uid-002/image.png?device=UC_StackCam&shot=2")
+        assert first.status_code == 200
+        (scan_folder / "UC_StackCam" / "UC_StackCam.h5").unlink()
+        again = client.get("/run/uid-002/image.png?device=UC_StackCam&shot=2")
+        assert again.status_code == 200
+        assert again.content == first.content
+
+    def test_running_run_never_caches(self, scan_folder):  # noqa: F811
+        client = self._client(scan_folder, exit_status=None)
+        first = client.get("/run/uid-002/image.png?device=UC_StackCam&shot=2")
+        assert first.status_code == 200
+        (scan_folder / "UC_StackCam" / "UC_StackCam.h5").unlink()
+        again = client.get("/run/uid-002/image.png?device=UC_StackCam&shot=2")
+        assert again.status_code == 404  # live runs always read the share

--- a/GEECS-DataPortal/tests/test_cache.py
+++ b/GEECS-DataPortal/tests/test_cache.py
@@ -160,15 +160,106 @@ class TestShotDataCache:
         cache.warm_native(key, _load, [1, 2, 3], synchronous=True)
         assert all(cache.native_shot(key, s) is not None for s in (1, 2, 3))
 
-    def test_budget_evicts_least_recently_used(self, scan_folder):  # noqa: F811
+    def test_budget_evicts_least_recently_used(self):
         import numpy as np
 
-        cache = ShotDataCache(budget_bytes=1)  # everything is over budget
-        cache.store_native_shot(("u", "a"), 1, np.zeros((16, 16)))
-        cache.store_native_shot(("u", "b"), 1, np.zeros((16, 16)))
-        # at least one entry always survives; the older one evicts
+        # budget for ~4 shots; per-entry cap = budget // 3 ≈ 1.3 shots
+        shot_bytes = np.zeros((16, 16)).nbytes
+        cache = ShotDataCache(budget_bytes=4 * shot_bytes)
+        assert cache.store_native_shot(("u", "a"), 1, np.zeros((16, 16)))
+        assert cache.store_native_shot(("u", "b"), 1, np.zeros((16, 16)))
+        assert cache.store_native_shot(("u", "c"), 1, np.zeros((16, 16)))
+        assert cache.store_native_shot(("u", "d"), 1, np.zeros((16, 16)))
+        assert cache.store_native_shot(("u", "e"), 1, np.zeros((16, 16)))
+        # over budget: the oldest evicted, the newest kept
         assert cache.native_shot(("u", "a"), 1) is None
-        assert cache.native_shot(("u", "b"), 1) is not None
+        assert cache.native_shot(("u", "e"), 1) is not None
+
+    def test_per_entry_cap_bounds_a_single_warming_entry(self):
+        import numpy as np
+
+        shot_bytes = np.zeros((16, 16)).nbytes
+        cache = ShotDataCache(budget_bytes=6 * shot_bytes)  # cap = 2 shots
+        key = ("u", "big")
+        assert cache.store_native_shot(key, 1, np.zeros((16, 16)))
+        assert cache.store_native_shot(key, 2, np.zeros((16, 16)))
+        # the third shot would exceed the per-entry cap: refused, and the
+        # warm loop's cap check would stop the thread here too
+        assert cache.store_native_shot(key, 3, np.zeros((16, 16))) is False
+        assert cache.native_shot(key, 3) is None
+        assert cache._entry_at_cap(key)
+
+    def test_unfinalized_stack_is_never_cached(self, scan_folder):  # noqa: F811
+        # The stop doc lands BEFORE the daemon finalizes the stack (a
+        # seconds-wide race): an un-finalized file may miss tail frames,
+        # so it must serve from disk per shot, never enter the cache.
+        import h5py
+
+        stack = scan_folder / "UC_StackCam" / "UC_StackCam.h5"
+        with h5py.File(stack, "a") as handle:
+            del handle.attrs["finalized"]
+        cache = ShotDataCache()
+        key = ("uid-002", "UC_StackCam")
+        result = resources.load_shot_image(
+            scan_folder,
+            "UC_StackCam",
+            2,
+            acq_timestamp=_LV + 2.0,
+            data_cache=cache,
+            cache_key=key,
+        )
+        assert result.kind == "stack"  # still serves — from disk
+        assert cache.stack_entry(key) is None  # but never cached
+
+    def test_oversize_stack_serves_from_disk_uncached(self, scan_folder):  # noqa: F811
+        cache = ShotDataCache(budget_bytes=8)  # cap far below the stack
+        key = ("uid-002", "UC_StackCam")
+        result = resources.load_shot_image(
+            scan_folder,
+            "UC_StackCam",
+            2,
+            acq_timestamp=_LV + 2.0,
+            data_cache=cache,
+            cache_key=key,
+        )
+        assert result.kind == "stack"
+        assert cache.stack_entry(key) is None
+
+    def test_warm_runs_once_per_key_per_process(self, scan_folder):  # noqa: F811
+        cache = ShotDataCache()
+        key = ("uid-002", "cam")
+        calls: list[int] = []
+
+        def _load(shot: int) -> None:
+            calls.append(shot)
+
+        cache.warm_native(key, _load, [1, 2], synchronous=True)
+        cache.warm_native(key, _load, [1, 2], synchronous=True)  # no re-probe
+        assert calls == [1, 2]
+
+    def test_threaded_warm_completes(self, scan_folder):  # noqa: F811
+        import time as _time
+
+        cache = ShotDataCache()
+        key = ("uid-002", "cam")
+
+        def _load(shot: int) -> None:
+            resources.load_shot_image(
+                scan_folder,
+                "cam",
+                shot,
+                acq_timestamp=_LV + float(shot),
+                data_cache=cache,
+                cache_key=key,
+            )
+
+        cache.warm_native(key, _load, [1, 2, 3])  # real daemon thread
+        deadline = _time.monotonic() + 5.0
+        while _time.monotonic() < deadline:
+            if all(cache.native_shot(key, s) is not None for s in (1, 2, 3)):
+                break
+            _time.sleep(0.02)
+        assert all(cache.native_shot(key, s) is not None for s in (1, 2, 3))
 
 
 class TestCachedRoutes:

--- a/GEECS-DataPortal/tests/test_resources.py
+++ b/GEECS-DataPortal/tests/test_resources.py
@@ -48,6 +48,7 @@ def scan_folder(tmp_path):
 
     with h5py.File(stacked / "UC_StackCam.h5", "w") as handle:
         handle.attrs["schema"] = "geecs-capture/1"
+        handle.attrs["finalized"] = True  # daemon-stamped completed stack
         # FOUR frames: a leading pre-scan extra (FORMAT.md caveat a) that
         # must NOT shift the timestamp join. Identity marker per index.
         frames = np.zeros((4, 6, 6), dtype=np.uint16)


### PR DESCRIPTION
## What

**PR D — the owner's prefetch feature** (2026-08-29 request): per-shot round trips optimize for the wrong constraint when a diagnostic's per-scan data is ~100s of MB and RAM is free; navigation should serve from memory. Doctrine amendment recorded in CLAUDE.md: **eager within a scan, lazy across scans** (the scope doc's lazy rule still binds across scans — no day-thumbnailing).

- `geecs_portal/cache.py` (~250 LOC): **`CachingScanCatalog`** — delegating ScanCatalog caching `load_run` (completed runs LRU-8 forever, still-running runs 5 s TTL; KeyError misses never cached; `list_runs`/`probe` pass through so the day list stays live). Ends the repeated full-event-table Tiled reads (`__main__` wraps the real catalog). **`ShotDataCache`** — bytes-bounded LRU (~1.5 GB) of pixel data keyed `(uid, device)`, completed runs only: stack devices load the **whole frames array in one HDF5 read** on first touch; native devices cache decoded per-shot arrays, background-warmed by a daemon thread walking the run's event rows (timestamp-joined shots only).
- `resources.py`: cache-aware fast paths (a hit serves with zero filesystem access — no listing, no open); ordinal (listing-order) resolutions are **never cached** (same rule as the no-long-cache header from wave A).
- `app.py`: `run_image` passes the cache for completed runs; `run_view` schedules the native warm on first gallery touch (only when the device has an acq_timestamp column — ordinal-only devices never warm-loop).

Safety properties, each pinned: still-running runs never enter the pixel cache (live-run test deletes the file → 404, proving the share is still read); completed-run hits serve **after the underlying file is deleted** (the zero-filesystem proof); exact-key refusal (never-serve-a-neighbour) enforced identically from memory; budget eviction LRU.

Version: portal 0.4.2 → **0.5.0**.

## Tests

`scripts/check.sh`: **Portal 71 passed (+10 cache pins) · Console 790 · Data-Utils 231 · ScanAnalysis 192**, lint clean.

## Hardware / live

Deploys with the promotion (host pull + restart). Memory ceiling ~1.5 GB pixel budget + 8 run details — comfortable on the .14 box.

🤖 Generated with [Claude Code](https://claude.com/claude-code)