### PR TITLE
Plot-controls suite: free Plotly features on + the layout passthrough (portal 0.8.0)

### DIFF
--- a/GEECS-DataPortal/CHANGELOG.md
+++ b/GEECS-DataPortal/CHANGELOG.md
@@ -3,6 +3,25 @@
 All notable changes to this package will be documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.8.0] - 2026-08-30
+
+### Added
+
+The plot-controls suite (owner architecture feedback: stop hand-rolling
+one knob per request):
+
+- **Everything Plotly gives for free, switched on**: scroll-wheel zoom,
+  spike lines, hover-compare modes, and the built-in drawing tools
+  (line / freehand / rect / circle / eraser) in the modebar — direct
+  on-plot annotation, zero portal code to maintain.
+- **The layout passthrough**: the display popup gains an "advanced" box
+  taking any Plotly layout JSON, deep-merged onto the figure last (and
+  URL-carried in `display.layout`). The entire Plotly layout schema —
+  tick formats, fonts, legend placement, secondary-axis styling — is
+  now reachable without new portal code; the curated fields remain the
+  common-case UI. Malformed JSON keeps the popup open with the error,
+  applying nothing.
+
 ## [0.7.0] - 2026-08-30
 
 ### Added

--- a/GEECS-DataPortal/CLAUDE.md
+++ b/GEECS-DataPortal/CLAUDE.md
@@ -46,7 +46,9 @@ this package; the architecture rules below are its distillation.
   doctrine — never put numerics in an endpoint that a notebook can't
   import).  All view state is URL-carried (`tab`/`y`/`x`/`view`/
   `filters`/`bincfg`/`display` — filters/bincfg are the
-  Pydantic/dataclass models' JSON, `display` the plot-cosmetics JSON):
+  Pydantic/dataclass models' JSON, `display` the plot-cosmetics JSON,
+  whose `layout` key is a raw Plotly-layout passthrough deep-merged
+  last: cosmetic asks should land there, not as new per-knob code):
   a link IS the analysis, which is also the multi-user story
   (statelessness; shared caches are a feature).  Every `/api` fetch
   additionally carries `v=<portal version>` — completed-run responses

--- a/GEECS-DataPortal/geecs_portal/templates/run.html
+++ b/GEECS-DataPortal/geecs_portal/templates/run.html
@@ -257,6 +257,12 @@
       <input id="ds-msize" style="width:4rem;" placeholder="5"></div>
     <div class="setrow"><label>trace colors</label>
       <span id="ds-colors"></span></div>
+    <div class="setrow" style="align-items:flex-start;"><label>advanced<br>
+      <a href="https://plotly.com/javascript/reference/layout/" target="_blank" style="font-size:11px;">layout ref ↗</a></label>
+      <textarea id="ds-layout" rows="3" spellcheck="false"
+        placeholder='any Plotly layout JSON, merged last — e.g. {"yaxis":{"tickformat":".2e"},"legend":{"orientation":"v"}}'
+        style="flex:1; background:var(--panel2); color:var(--ink); border:1px solid var(--line); border-radius:3px; padding:0.3rem 0.45rem; font-family:ui-monospace,Menlo,monospace; font-size:11px;"></textarea></div>
+    <div class="error" id="ds-error" style="display:none;"></div>
     <div class="dim" style="font-size:11px; margin-top:0.4rem;">
       Titles and legend names are editable in place — click them on the plot.</div>
     <div class="btnrow">
@@ -302,6 +308,16 @@
 const UID = {{ uid | tojson }};
 const DAY = {{ day | tojson }};
 const TRACE_COLORS = ["#4cc2b4", "#d6a860", "#6f9fd8", "#c47ab8"];
+// Everything Plotly gives for free, switched ON: wheel zoom, in-place
+// title/legend editing, spike lines + hover modes, and the drawing
+// tools (annotate directly on the plot; shapes are editable/erasable).
+const PLOT_CONFIG = {
+  responsive: true, displaylogo: false, editable: true, scrollZoom: true,
+  modeBarButtonsToAdd: [
+    "togglespikelines", "hoverclosest", "hovercompare",
+    "drawline", "drawopenpath", "drawrect", "drawcircle", "eraseshape",
+  ],
+};
 const PLOT_LAYOUT = {
   paper_bgcolor: "#1a2026", plot_bgcolor: "#12161a",
   font: { color: "#dde4ea", size: 12 },
@@ -521,6 +537,20 @@ function applyDisplayToLayout(layout, xIsDate, yIsDate) {
   if (xr && !xIsDate) { layout.xaxis.range = xr; layout.xaxis.autorange = false; }
   const yr = axisRange(d.ymin, d.ymax, !!d.logy);
   if (yr && !yIsDate) { layout.yaxis.range = yr; layout.yaxis.autorange = false; }
+  // The escape hatch: any Plotly layout attribute, merged last — the
+  // whole layout schema is reachable without new portal code.
+  if (d.layout && typeof d.layout === "object") deepMerge(layout, d.layout);
+}
+
+function deepMerge(target, patch) {
+  for (const [key, value] of Object.entries(patch)) {
+    if (value && typeof value === "object" && !Array.isArray(value)
+        && target[key] && typeof target[key] === "object" && !Array.isArray(target[key])) {
+      deepMerge(target[key], value);
+    } else {
+      target[key] = value;
+    }
+  }
 }
 
 function multiYAxes(layout, n) {
@@ -550,8 +580,7 @@ function drawShots(data) {
   multiYAxes(layout, S.y.length);
   const yIsDate = !!(data.kinds && data.kinds[S.y[0]] === "datetime");
   applyDisplayToLayout(layout, xIsDate, yIsDate);
-  Plotly.react(plotHost(), traces, layout,
-               { responsive: true, displaylogo: false, editable: true });
+  Plotly.react(plotHost(), traces, layout, PLOT_CONFIG);
   document.getElementById("codebox").textContent = data.code;
   setPassCount(data.pass, data.total);
 }
@@ -576,8 +605,7 @@ function drawBinned(data) {
                    tickfont: { color: traceColor(0) } };
   multiYAxes(layout, S.y.length);
   applyDisplayToLayout(layout, false, false);  // binned serves raw numbers
-  Plotly.react(plotHost(), traces, layout,
-               { responsive: true, displaylogo: false, editable: true });
+  Plotly.react(plotHost(), traces, layout, PLOT_CONFIG);
   document.getElementById("codebox").textContent = data.code;
   setPassCount(data.pass, data.total);
 }
@@ -729,6 +757,9 @@ function openDisplay() {
   }
   document.getElementById("ds-msize").value =
     Number.isFinite(d.msize) ? d.msize : "";
+  document.getElementById("ds-layout").value =
+    d.layout ? JSON.stringify(d.layout) : "";
+  document.getElementById("ds-error").style.display = "none";
   document.getElementById("ds-colors").innerHTML = S.y.map((name, i) =>
     `<input type="color" id="ds-color-${i}" value="${traceColor(i)}" title="${escAttr(prettyName(name))}">`
   ).join(" ") || '<span class="dim" style="font-size:11px;">pick columns first</span>';
@@ -750,6 +781,21 @@ function applyDisplay() {
     return input ? input.value : TRACE_COLORS[i];
   });
   if (colors.some((c, i) => c !== TRACE_COLORS[i])) d.colors = colors;
+  const rawLayout = document.getElementById("ds-layout").value.trim();
+  if (rawLayout) {
+    try {
+      const parsed = JSON.parse(rawLayout);
+      if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+        throw new Error("expected a JSON object");
+      }
+      d.layout = parsed;
+    } catch (err) {
+      const box = document.getElementById("ds-error");
+      box.textContent = "layout JSON: " + err.message;
+      box.style.display = "block";
+      return;  // keep the popup open — nothing applied
+    }
+  }
   S.display = Object.keys(d).length ? JSON.stringify(d) : "";
   closeModals(); renderPicked(); writeState(); refresh();
 }

--- a/GEECS-DataPortal/geecs_portal/templates/run.html
+++ b/GEECS-DataPortal/geecs_portal/templates/run.html
@@ -544,7 +544,12 @@ function applyDisplayToLayout(layout, xIsDate, yIsDate) {
 
 function deepMerge(target, patch) {
   for (const [key, value] of Object.entries(patch)) {
+    // Prototype-pollution guard: patch is URL-carried JSON, and a
+    // parsed "__proto__" key is an OWN property that would recurse
+    // into Object.prototype (shared-link threat model).
+    if (key === "__proto__" || key === "constructor" || key === "prototype") continue;
     if (value && typeof value === "object" && !Array.isArray(value)
+        && Object.prototype.hasOwnProperty.call(target, key)
         && target[key] && typeof target[key] === "object" && !Array.isArray(target[key])) {
       deepMerge(target[key], value);
     } else {
@@ -791,7 +796,7 @@ function applyDisplay() {
       d.layout = parsed;
     } catch (err) {
       const box = document.getElementById("ds-error");
-      box.textContent = "layout JSON: " + err.message;
+      box.textContent = "layout JSON: " + err.message + " — nothing applied";
       box.style.display = "block";
       return;  // keep the popup open — nothing applied
     }

--- a/GEECS-DataPortal/pyproject.toml
+++ b/GEECS-DataPortal/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-data-portal"
-version = "0.7.0"
+version = "0.8.0"
 description = "Read-only scan-browsing web service: a zero-install browser view over the Tiled catalog and the GEECS data share"
 authors = ["GEECS-BELLA"]
 readme = "README.md"

--- a/GEECS-DataPortal/tests/test_app.py
+++ b/GEECS-DataPortal/tests/test_app.py
@@ -695,3 +695,12 @@ class TestPlotTabPolish:
             line for line in response.text.splitlines() if "/run/uid-002?" in line
         )
         assert "display=" in stepper_line
+
+    def test_plot_config_suite_is_on(self):
+        # The free-suite pin: wheel zoom, draw tools, spike lines are
+        # config (one line to maintain), never per-knob code.
+        text = _client().get("/run/uid-002").text
+        assert "scrollZoom: true" in text
+        assert "drawrect" in text
+        assert "togglespikelines" in text
+        assert "deepMerge(layout, d.layout)" in text  # the passthrough


### PR DESCRIPTION
Owner architecture feedback on W1e: "each specific thing I ask for gets implemented with no extras" — the per-knob pattern doesn't scale. Two changes fix the trajectory; targets `feat/analysis-tabs`.

## 1. Everything Plotly gives for free, switched on (one config constant)

`scrollZoom`, spike lines, hover-closest/compare, and the built-in **drawing tools** (line / freehand / rect / circle / eraser) in the modebar — on-plot annotation with zero portal code to maintain. These were available in the vendored bundle all along; W1d simply hadn't enabled them.

## 2. The layout-JSON passthrough (the actual "suite")

Plotly.js deliberately ships no settings GUI (that's the separate React `react-chart-editor`, which would reintroduce npm — excluded by doctrine), so stateful knobs need *some* portal UI. Instead of a knob per request: the display popup gains an **advanced box taking any Plotly layout JSON**, deep-merged onto the figure last and URL-carried as `display.layout`. The entire layout schema — tick formats, fonts, legend placement, axis styling, thousands of attributes — is now reachable with zero new code; the curated fields (log, ranges, marker, colors) stay as the common-case UI. Malformed JSON keeps the popup open showing the error, applying nothing.

CLAUDE.md records the doctrine: cosmetic asks land in the passthrough, not as new per-knob code.

## Live verification

URL-carried `{"layout":{"yaxis":{"tickformat":".2e"},"legend":{"orientation":"v"}}}` → scientific-notation ticks + vertical legend on the real catalog; scroll zoom + draw tools confirmed active in the rendered config.

Suite: 113 passed. Agent merges after review.