### PR TITLE
Multi-Y axis rendering fixed the library's way (portal 0.8.1)

### DIFF
--- a/GEECS-DataPortal/CHANGELOG.md
+++ b/GEECS-DataPortal/CHANGELOG.md
@@ -3,6 +3,25 @@
 All notable changes to this package will be documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.8.1] - 2026-08-31
+
+### Fixed
+
+Multi-Y axis rendering (owner feedback: overlapping tick numbers,
+grey always-there labels):
+
+- Axes 3–4 stack outward via Plotly's native `autoshift` (the previous
+  hand-set `position` put them on top of axes 1–2's ticks).
+- Real color-matched axis titles on the two anchored axes; axes 3–4
+  rely on colored ticks + the legend (Plotly does not shift a
+  free-anchored axis's title with the axis — measured).
+- The grey "Click to enter …" placeholders are gone: in-place editing
+  is now granular (legend names, annotations, shapes) instead of
+  blanket `editable: true` — axis titles are auto-set, or settable via
+  the advanced layout box.
+- Single-trace plots hide the redundant legend (the colored axis title
+  names the trace); `automargin` on all axes.
+
 ## [0.8.0] - 2026-08-30
 
 ### Added

--- a/GEECS-DataPortal/geecs_portal/templates/run.html
+++ b/GEECS-DataPortal/geecs_portal/templates/run.html
@@ -164,7 +164,7 @@
         </span>
         <span class="gear" title="bin settings" onclick="openBinset()">⚙</span>
         <span class="right">
-          <span class="dim" title="click any axis title or legend entry to edit it in place">zoom · pan · export = Plotly built-ins</span>
+          <span class="dim" title="click a legend entry's name to edit it in place">zoom · pan · export = Plotly built-ins</span>
           <a href="#" onclick="openDisplay();return false;">display…</a>
           <a href="#" onclick="document.getElementById('codebox').classList.toggle('on');return false;">show the code</a>
         </span>
@@ -264,7 +264,8 @@
         style="flex:1; background:var(--panel2); color:var(--ink); border:1px solid var(--line); border-radius:3px; padding:0.3rem 0.45rem; font-family:ui-monospace,Menlo,monospace; font-size:11px;"></textarea></div>
     <div class="error" id="ds-error" style="display:none;"></div>
     <div class="dim" style="font-size:11px; margin-top:0.4rem;">
-      Titles and legend names are editable in place — click them on the plot.</div>
+      Legend names are click-to-edit on the plot; titles via the advanced box
+      (e.g. {"title":{"text":"…"}}).</div>
     <div class="btnrow">
       <button class="act" onclick="closeModals()">Cancel</button>
       <button class="apply" onclick="applyDisplay()">Apply</button>
@@ -312,7 +313,12 @@ const TRACE_COLORS = ["#4cc2b4", "#d6a860", "#6f9fd8", "#c47ab8"];
 // title/legend editing, spike lines + hover modes, and the drawing
 // tools (annotate directly on the plot; shapes are editable/erasable).
 const PLOT_CONFIG = {
-  responsive: true, displaylogo: false, editable: true, scrollZoom: true,
+  responsive: true, displaylogo: false, scrollZoom: true,
+  // Granular (not editable:true): blanket editability renders grey
+  // "Click to enter …" placeholders for every unset title — and
+  // axisTitleText does too on the title-less stacked axes (3-4), so
+  // axis titles are auto-set/passthrough-set instead of in-place-edited.
+  edits: { legendText: true, annotationText: true, shapePosition: true },
   modeBarButtonsToAdd: [
     "togglespikelines", "hoverclosest", "hovercompare",
     "drawline", "drawopenpath", "drawrect", "drawcircle", "eraseshape",
@@ -559,10 +565,25 @@ function deepMerge(target, patch) {
 }
 
 function multiYAxes(layout, n) {
+  // First axis: title + ticks in the trace's color; extra grid lines
+  // only from axis 1 (overlaid grids are unreadable).
+  layout.yaxis.title = { text: prettyName(S.y[0]), font: { color: traceColor(0) } };
+  layout.yaxis.automargin = true;
+  layout.showlegend = n > 1;  // one trace: the axis title says it all
   for (let i = 1; i < n; i++) {
     layout["yaxis" + (i + 1)] = {
       overlaying: "y", side: i % 2 ? "right" : "left",
-      position: i >= 2 ? (i % 2 ? 1.0 : 0.0) : undefined,
+      // Plotly's native mechanism for stacking multiple axes on one
+      // side: free-anchored + autoshift moves each outward cleanly.
+      anchor: i >= 2 ? "free" : undefined,
+      autoshift: i >= 2 ? true : undefined,
+      automargin: true,
+      // Rotated titles only on the two ANCHORED axes: Plotly does not
+      // shift a free-anchored axis's title with the axis (measured), so
+      // axes 3-4 rely on color-matched ticks + the legend instead.
+      title: i < 2
+        ? { text: prettyName(S.y[i]), font: { color: traceColor(i) } }
+        : undefined,
       gridcolor: "rgba(0,0,0,0)", zerolinecolor: "#2c353d",
       tickfont: { color: traceColor(i) },
     };
@@ -583,6 +604,7 @@ function drawShots(data) {
   layout.yaxis = { gridcolor: "#2c353d", zerolinecolor: "#2c353d",
                    tickfont: { color: traceColor(0) } };
   multiYAxes(layout, S.y.length);
+  layout.xaxis.automargin = true;
   const yIsDate = !!(data.kinds && data.kinds[S.y[0]] === "datetime");
   applyDisplayToLayout(layout, xIsDate, yIsDate);
   Plotly.react(plotHost(), traces, layout, PLOT_CONFIG);

--- a/GEECS-DataPortal/geecs_portal/templates/run.html
+++ b/GEECS-DataPortal/geecs_portal/templates/run.html
@@ -264,8 +264,8 @@
         style="flex:1; background:var(--panel2); color:var(--ink); border:1px solid var(--line); border-radius:3px; padding:0.3rem 0.45rem; font-family:ui-monospace,Menlo,monospace; font-size:11px;"></textarea></div>
     <div class="error" id="ds-error" style="display:none;"></div>
     <div class="dim" style="font-size:11px; margin-top:0.4rem;">
-      Legend names are click-to-edit on the plot; titles via the advanced box
-      (e.g. {"title":{"text":"…"}}).</div>
+      Legend names are click-to-edit on the plot; axis titles via the advanced
+      box (e.g. {"yaxis":{"title":{"text":"…"}}}).</div>
     <div class="btnrow">
       <button class="act" onclick="closeModals()">Cancel</button>
       <button class="apply" onclick="applyDisplay()">Apply</button>
@@ -310,7 +310,7 @@ const UID = {{ uid | tojson }};
 const DAY = {{ day | tojson }};
 const TRACE_COLORS = ["#4cc2b4", "#d6a860", "#6f9fd8", "#c47ab8"];
 // Everything Plotly gives for free, switched ON: wheel zoom, in-place
-// title/legend editing, spike lines + hover modes, and the drawing
+// legend-name editing, spike lines + hover modes, and the drawing
 // tools (annotate directly on the plot; shapes are editable/erasable).
 const PLOT_CONFIG = {
   responsive: true, displaylogo: false, scrollZoom: true,
@@ -628,6 +628,7 @@ function drawBinned(data) {
   const layout = structuredClone(PLOT_LAYOUT);
   const cfg = S.bincfg ? JSON.parse(S.bincfg) : {};
   layout.xaxis.title = { text: cfg.bin_col || "Bin #" };
+  layout.xaxis.automargin = true;
   layout.yaxis = { gridcolor: "#2c353d", zerolinecolor: "#2c353d",
                    tickfont: { color: traceColor(0) } };
   multiYAxes(layout, S.y.length);

--- a/GEECS-DataPortal/pyproject.toml
+++ b/GEECS-DataPortal/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-data-portal"
-version = "0.8.0"
+version = "0.8.1"
 description = "Read-only scan-browsing web service: a zero-install browser view over the Tiled catalog and the GEECS data share"
 authors = ["GEECS-BELLA"]
 readme = "README.md"


### PR DESCRIPTION
Owner feedback: overlapping tick numbers on multi-column plots, grey always-there axis labels — "each little custom thing slightly off makes the UX look forced/cheap." Both symptoms traced to the same root: hand-rolled layout where Plotly has native mechanisms. Targets `feat/analysis-tabs`.

## Root causes → fixes

| Symptom | Root cause | Fix |
|---|---|---|
| Tick numbers of axes 3–4 rendered on top of axes 1–2 | Hand-set `position: 0.0/1.0` put free axes at the plot edges where the anchored axes already sit | Plotly's **`autoshift`** (built for exactly this) stacks them outward; `automargin` everywhere |
| Grey "Click to enter Y axis title" text always visible, overlapping when multi | Blanket `editable: true` renders placeholders for every unset title | **Granular `edits`** (legend names / annotations / shapes stay click-to-edit); axis titles are real, color-matched to their trace |
| — | Plotly does **not** shift a free-anchored axis's rotated title with the axis (measured live; `standoff` doesn't help) | Titles on the two anchored axes only; axes 3–4 identified by colored ticks + the legend (the standard dashboard pattern) |
| Redundant single-trace legend | — | Hidden when one column: the colored axis title names it |

## Verification (live, real scan, structural)

Bounding-box intersection over all tick blocks + titles with **4 columns picked: zero collisions, zero placeholders**; single column: colored title, no legend, no placeholders. Suite: 113 passed.

Note: this is deliberately a Plotly-native fix regardless of the pending renderer conversation (Altair/Vega-Lite vs plotly.py spec-authoring) — the lesson either way is lean on the library's mechanisms, not hand-positioning.

Agent merges after review.