### PR TITLE
GEECS-DataPortal 0.9.0: reverse-proxy mountability (OSPREY panel-tab feedback)

### DIFF
--- a/GEECS-DataPortal/CHANGELOG.md
+++ b/GEECS-DataPortal/CHANGELOG.md
@@ -3,6 +3,24 @@
 All notable changes to this package will be documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.9.0] - 2026-08-31
+
+### Added
+
+Reverse-proxy mountability (OSPREY panel-tab feedback): the portal now
+works at root **and** under any URL prefix — `proxy /portal → :8200`.
+
+- Every template href/form/img/script URL and the page JS's `/api`
+  fetch base (`const ROOT`) build through one per-request `root`
+  prefix; the `/`, `/go`, and `/run/jump` redirects carry it too.
+- The prefix auto-derives from the proxy's `X-Forwarded-Prefix` header
+  (validated: root-absolute, no `//`/whitespace/backslash — malformed
+  values are ignored, a bare `/` means root); a static fallback is
+  available as `geecs-data-portal --root-path /portal`. The header,
+  when present, wins.
+- `/health` (present since 0.1.0) is the panel health probe — wire
+  OSPREY's `web.panels.dataview.health_endpoint` at it.
+
 ## [0.8.1] - 2026-08-31
 
 ### Fixed

--- a/GEECS-DataPortal/CHANGELOG.md
+++ b/GEECS-DataPortal/CHANGELOG.md
@@ -14,10 +14,13 @@ works at root **and** under any URL prefix — `proxy /portal → :8200`.
   fetch base (`const ROOT`) build through one per-request `root`
   prefix; the `/`, `/go`, and `/run/jump` redirects carry it too.
 - The prefix auto-derives from the proxy's `X-Forwarded-Prefix` header
-  (validated: root-absolute, no `//`/whitespace/backslash — malformed
-  values are ignored, a bare `/` means root); a static fallback is
-  available as `geecs-data-portal --root-path /portal`. The header,
-  when present, wins.
+  (validated against a strict path-segment pattern — malformed values
+  are ignored, a bare `/` means root). The middleware also re-prefixes
+  the request path to the ASGI-canonical shape, so mounts named like a
+  route head (`/run`, `/api`, …) route correctly and trailing-slash
+  redirects keep the prefix. A static fallback is available as
+  `geecs-data-portal --root-path /portal` (without those two
+  guarantees — see DEPLOYMENT.md); the header, when present, wins.
 - `/health` (present since 0.1.0) is the panel health probe — wire
   OSPREY's `web.panels.dataview.health_endpoint` at it.
 

--- a/GEECS-DataPortal/CLAUDE.md
+++ b/GEECS-DataPortal/CLAUDE.md
@@ -54,6 +54,14 @@ this package; the architecture rules below are its distillation.
   additionally carries `v=<portal version>` — completed-run responses
   cache immutable, and the version key rolls browser caches over when
   a release changes the payload shape.
+- **Prefix-agnostic URLs.**  The portal works at root and under any
+  reverse-proxy mount (OSPREY panel tabs).  Templates never write a
+  root-absolute portal URL directly: every href/action/src carries the
+  `{{ root }}` context value (the per-request root path —
+  `X-Forwarded-Prefix` via `_ForwardedPrefixMiddleware`, else
+  `--root-path`), page JS builds fetches from `const ROOT`, and
+  redirect endpoints prefix with `_root(request)`.  Pinned by
+  `tests/test_app.py::TestReverseProxy`.
 - **Hermetic tests.**  `tests/` drives the app through
   `fastapi.testclient.TestClient` over fake catalogs — no network, no
   data root, no config.ini.  Catalog failures must surface in the page

--- a/GEECS-DataPortal/DEPLOYMENT.md
+++ b/GEECS-DataPortal/DEPLOYMENT.md
@@ -76,6 +76,30 @@ curl -s http://localhost:8200/health
 journalctl -u geecs-data-portal -n 20
 ```
 
+## Behind a reverse proxy (OSPREY panels, etc.)
+
+The portal is prefix-agnostic: mount it under any path and every link,
+form, image, `/api` fetch, and redirect carries the prefix. Configure
+the proxy to **strip the prefix and name it** in `X-Forwarded-Prefix`
+(the Grafana/JupyterHub convention) — nginx example:
+
+```
+location /portal/ {
+    proxy_pass http://<worker-host>:8200/;
+    proxy_set_header X-Forwarded-Prefix /portal;
+}
+```
+
+The header is per-request and needs no portal-side config. For a proxy
+that cannot send it, start the service with a static prefix instead:
+`geecs-data-portal --root-path /portal` (the header, when present,
+wins). Malformed header values (not root-absolute, `//`, whitespace)
+are ignored rather than propagated into page links.
+
+For a panel health LED, probe `GET /health` — 200 always (the JSON
+`ok` field reports the catalog probe, so a down Tiled shows as a
+degraded catalog, not a dead portal).
+
 ## Upgrade
 
 ```bash

--- a/GEECS-DataPortal/DEPLOYMENT.md
+++ b/GEECS-DataPortal/DEPLOYMENT.md
@@ -90,11 +90,17 @@ location /portal/ {
 }
 ```
 
-The header is per-request and needs no portal-side config. For a proxy
-that cannot send it, start the service with a static prefix instead:
-`geecs-data-portal --root-path /portal` (the header, when present,
-wins). Malformed header values (not root-absolute, `//`, whitespace)
-are ignored rather than propagated into page links.
+The header is per-request and needs no portal-side config; any mount
+name works, including ones that collide with portal route heads
+(`/run`, `/api`, …). For a proxy that cannot send it, start the
+service with a static prefix instead: `geecs-data-portal --root-path
+/portal` (the header, when present, wins) — in that fallback mode
+avoid mount names that collide with a portal route head, and know that
+trailing-slash redirects drop the prefix (Starlette builds them from
+the un-prefixed path; the header mode re-prefixes the path and has
+neither limitation). Malformed header values (not root-absolute, `//`,
+whitespace, query/fragment characters) are ignored rather than
+propagated into page links.
 
 For a panel health LED, probe `GET /health` — 200 always (the JSON
 `ok` field reports the catalog probe, so a down Tiled shows as a

--- a/GEECS-DataPortal/DEPLOYMENT.md
+++ b/GEECS-DataPortal/DEPLOYMENT.md
@@ -100,7 +100,9 @@ trailing-slash redirects drop the prefix (Starlette builds them from
 the un-prefixed path; the header mode re-prefixes the path and has
 neither limitation). Malformed header values (not root-absolute, `//`,
 whitespace, query/fragment characters) are ignored rather than
-propagated into page links.
+propagated into page links. The header is a strip-style contract: a
+proxy that does **not** strip the prefix must not send it (the symptom
+of that misconfiguration is loud — every page 404s).
 
 For a panel health LED, probe `GET /health` — 200 always (the JSON
 `ok` field reports the catalog probe, so a down Tiled shows as a

--- a/GEECS-DataPortal/geecs_portal/__main__.py
+++ b/GEECS-DataPortal/geecs_portal/__main__.py
@@ -23,6 +23,15 @@ def main() -> None:
         help="default experiment for day listings (query param overrides)",
     )
     parser.add_argument("--log-level", default="INFO", help="Python logging level")
+    parser.add_argument(
+        "--root-path",
+        default="",
+        help=(
+            "URL prefix the portal is mounted under behind a reverse proxy "
+            "(e.g. /portal); a proxy-sent X-Forwarded-Prefix header "
+            "overrides this per request"
+        ),
+    )
     args = parser.parse_args()
 
     logging.basicConfig(
@@ -41,7 +50,13 @@ def main() -> None:
     # requests stop re-downloading the full event table from Tiled.
     catalog = CachingScanCatalog(TiledScanCatalog.from_config())
     app = create_app(catalog, default_experiment=args.experiment)
-    uvicorn.run(app, host=args.host, port=args.port, log_level=args.log_level.lower())
+    uvicorn.run(
+        app,
+        host=args.host,
+        port=args.port,
+        log_level=args.log_level.lower(),
+        root_path=args.root_path,
+    )
 
 
 if __name__ == "__main__":

--- a/GEECS-DataPortal/geecs_portal/app.py
+++ b/GEECS-DataPortal/geecs_portal/app.py
@@ -83,6 +83,61 @@ def _portal_version() -> str:
 #: Cap on rows fed to a plot (quick-look, not a data browser).
 _PLOT_MAX_ROWS = 100_000
 
+#: Requests carrying a proxy mount prefix — the Grafana/JupyterHub
+#: convention every reverse proxy speaks.
+_FORWARDED_PREFIX_HEADER = b"x-forwarded-prefix"
+
+
+def _clean_prefix(raw: str) -> str:
+    """Normalize a mount prefix: ``/portal/`` → ``/portal``; bad → ``""``.
+
+    Accepts only a root-absolute, single-slash path (no whitespace,
+    backslashes, control characters, or ``//``) — anything else is
+    treated as no prefix rather than propagated into every link on the
+    page.  A bare ``/`` means "mounted at root", i.e. no prefix.
+    """
+    prefix = raw.strip().rstrip("/")
+    if not prefix:
+        return ""
+    if not prefix.startswith("/") or "//" in prefix or "\\" in prefix:
+        return ""
+    if any(ch.isspace() or ord(ch) < 32 for ch in prefix):
+        return ""
+    return prefix
+
+
+class _ForwardedPrefixMiddleware:
+    """Adopt the proxy's ``X-Forwarded-Prefix`` as the ASGI root_path.
+
+    Behind ``proxy /portal → portal:8200`` the app itself never sees
+    the mount point; the proxy names it in this header.  Setting
+    ``scope["root_path"]`` makes every link, form, redirect, and JS
+    fetch (all built through the one ``root`` context value) carry the
+    prefix, so the portal works at root and under any mount point —
+    including OSPREY panel tabs.  The header, when present, wins over a
+    static ``--root-path`` (the proxy is authoritative for where it
+    mounted us); a client faking it only rewrites its own page's links.
+    """
+
+    def __init__(self, app):
+        self.app = app
+
+    async def __call__(self, scope, receive, send):
+        if scope["type"] == "http":
+            for name, value in scope.get("headers", []):
+                if name == _FORWARDED_PREFIX_HEADER:
+                    prefix = _clean_prefix(value.decode("latin-1"))
+                    if prefix:
+                        scope["root_path"] = prefix
+                    break
+        await self.app(scope, receive, send)
+
+
+def _root(request: Request) -> str:
+    """The request's URL prefix (``""`` at root) — prepend to every path."""
+    return request.scope.get("root_path", "").rstrip("/")
+
+
 #: Multi-Y ceiling on the Plot tab (mockup ruling: up to 4).
 _MAX_Y_COLUMNS = 4
 
@@ -192,7 +247,13 @@ def create_app(catalog: ScanCatalog, *, default_experiment: str = "") -> FastAPI
         The configured application.
     """
     app = FastAPI(title="GEECS Data Portal", docs_url=None, redoc_url=None)
-    templates = Jinja2Templates(directory=str(_TEMPLATES_DIR))
+    app.add_middleware(_ForwardedPrefixMiddleware)
+    # Every template gets `root`: the mount prefix each root-absolute
+    # href/action/src/fetch must carry (empty when served at root).
+    templates = Jinja2Templates(
+        directory=str(_TEMPLATES_DIR),
+        context_processors=[lambda request: {"root": _root(request)}],
+    )
     # The one committed JS asset: the version-pinned vendored Plotly
     # bundle (doctrine amendment 2026-08-30 — still no npm, no CDN).
     app.mount("/static", StaticFiles(directory=str(_STATIC_DIR)), name="static")
@@ -412,16 +473,20 @@ def create_app(catalog: ScanCatalog, *, default_experiment: str = "") -> FastAPI
         return {"pass": int(mask.sum()), "total": len(pf.frame)}
 
     @app.get("/", response_class=RedirectResponse)
-    def index() -> str:
+    def index(request: Request) -> str:
         """Redirect to today's day view."""
-        return f"/day/{date.today().isoformat()}"
+        return f"{_root(request)}/day/{date.today().isoformat()}"
 
     @app.get("/go", response_class=RedirectResponse)
-    def go(day: str = "", experiment: str = "", filter: str = "") -> str:
+    def go(
+        request: Request, day: str = "", experiment: str = "", filter: str = ""
+    ) -> str:
         """The day/experiment picker form's target: redirect to the day view."""
         selected = _parse_day(day)
         query = _sticky_query({"experiment": experiment, "filter": filter})
-        return f"/day/{selected.isoformat()}{'?' + query if query else ''}"
+        return (
+            f"{_root(request)}/day/{selected.isoformat()}{'?' + query if query else ''}"
+        )
 
     @app.get("/day/{day}", response_class=HTMLResponse)
     def day_view(
@@ -493,12 +558,15 @@ def create_app(catalog: ScanCatalog, *, default_experiment: str = "") -> FastAPI
                     "filter": request.query_params.get("filter", ""),
                 }
             )
-            return f"/day/{selected.isoformat()}{'?' + day_query if day_query else ''}"
+            return (
+                f"{_root(request)}/day/{selected.isoformat()}"
+                f"{'?' + day_query if day_query else ''}"
+            )
         target = next(
             (run for run in runs if prefer and run.scan_number == prefer),
             runs[0],  # newest (catalog order)
         )
-        return f"/run/{target.uid}?{query}"
+        return f"{_root(request)}/run/{target.uid}?{query}"
 
     @app.get("/run/{uid}", response_class=HTMLResponse)
     def run_view(

--- a/GEECS-DataPortal/geecs_portal/app.py
+++ b/GEECS-DataPortal/geecs_portal/app.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 import dataclasses
 import io
 import logging
+import re
 from datetime import date, datetime, timedelta
 from pathlib import Path
 from typing import Optional
@@ -88,20 +89,23 @@ _PLOT_MAX_ROWS = 100_000
 _FORWARDED_PREFIX_HEADER = b"x-forwarded-prefix"
 
 
+#: A valid mount prefix: non-empty ``/segment`` parts of RFC-3986-ish
+#: path characters — no ``//``, no query/fragment/quote characters, no
+#:  whitespace or backslashes.
+_PREFIX_RE = re.compile(r"(?:/[A-Za-z0-9._~%@+-]+)+")
+
+
 def _clean_prefix(raw: str) -> str:
     """Normalize a mount prefix: ``/portal/`` → ``/portal``; bad → ``""``.
 
-    Accepts only a root-absolute, single-slash path (no whitespace,
-    backslashes, control characters, or ``//``) — anything else is
+    Accepts only what :data:`_PREFIX_RE` matches — anything else is
     treated as no prefix rather than propagated into every link on the
     page.  A bare ``/`` means "mounted at root", i.e. no prefix.
     """
     prefix = raw.strip().rstrip("/")
     if not prefix:
         return ""
-    if not prefix.startswith("/") or "//" in prefix or "\\" in prefix:
-        return ""
-    if any(ch.isspace() or ord(ch) < 32 for ch in prefix):
+    if _PREFIX_RE.fullmatch(prefix) is None:
         return ""
     return prefix
 
@@ -117,6 +121,15 @@ class _ForwardedPrefixMiddleware:
     including OSPREY panel tabs.  The header, when present, wins over a
     static ``--root-path`` (the proxy is authoritative for where it
     mounted us); a client faking it only rewrites its own page's links.
+
+    The path is re-prefixed too (the ASGI-canonical shape: ``path``
+    includes ``root_path``).  Starlette's router strips ``root_path``
+    from the FRONT of ``path`` wherever it happens to match, so the
+    proxy-stripped path alone would double-strip under a mount named
+    like a route head (``/run``, ``/api``, …), 404ing that whole route
+    family — and its trailing-slash redirects build the Location from
+    ``path``, which would drop the prefix.  Re-prefixing makes the
+    strip exact and the redirects complete.
     """
 
     def __init__(self, app):
@@ -129,6 +142,7 @@ class _ForwardedPrefixMiddleware:
                     prefix = _clean_prefix(value.decode("latin-1"))
                     if prefix:
                         scope["root_path"] = prefix
+                        scope["path"] = prefix + scope["path"]
                     break
         await self.app(scope, receive, send)
 

--- a/GEECS-DataPortal/geecs_portal/templates/day.html
+++ b/GEECS-DataPortal/geecs_portal/templates/day.html
@@ -2,21 +2,21 @@
 {% block title %}{{ day.isoformat() }} — GEECS Data Portal{% endblock %}
 {% block content %}
 <div class="nav">
-  <a href="/day/{{ prev_day }}?{{ qs() }}">&larr; {{ prev_day }}</a>
+  <a href="{{ root }}/day/{{ prev_day }}?{{ qs() }}">&larr; {{ prev_day }}</a>
   <h1>{{ day.isoformat() }}</h1>
-  <a href="/day/{{ next_day }}?{{ qs() }}">{{ next_day }} &rarr;</a>
+  <a href="{{ root }}/day/{{ next_day }}?{{ qs() }}">{{ next_day }} &rarr;</a>
 </div>
-<form class="nav" method="get" action="/go">
+<form class="nav" method="get" action="{{ root }}/go">
   <input type="date" name="day" value="{{ day.isoformat() }}">
   <input type="text" name="experiment" value="{{ experiment }}" placeholder="experiment">
   {% if filter %}<input type="hidden" name="filter" value="{{ filter }}">{% endif %}
   <button type="submit">Go</button>
 </form>
-<form class="nav" method="get" action="/day/{{ day.isoformat() }}">
+<form class="nav" method="get" action="{{ root }}/day/{{ day.isoformat() }}">
   <input type="hidden" name="experiment" value="{{ experiment }}">
   <input type="text" name="filter" value="{{ filter }}" placeholder="filter — scan number, mode, status, description, save set">
   <button type="submit">Filter</button>
-  {% if filter %}<a href="/day/{{ day.isoformat() }}?experiment={{ experiment | urlencode }}">clear</a>{% endif %}
+  {% if filter %}<a href="{{ root }}/day/{{ day.isoformat() }}?experiment={{ experiment | urlencode }}">clear</a>{% endif %}
 </form>
 {% if error %}<p class="error">{{ error }}</p>{% endif %}
 {% if rows %}
@@ -24,7 +24,7 @@
   <tr><th>Scan</th><th>Time</th><th>Mode</th><th>Description</th><th>Shots</th><th>Status</th></tr>
   {% for run, time_text in rows %}
   <tr>
-    <td><a href="/run/{{ run.uid }}?{{ qs(day=day.isoformat()) }}">
+    <td><a href="{{ root }}/run/{{ run.uid }}?{{ qs(day=day.isoformat()) }}">
       {%- if run.scan_number is not none %}Scan {{ "%03d"|format(run.scan_number) }}{% else %}{{ run.uid[:8] }}{% endif -%}
     </a></td>
     <td class="mono">{{ time_text }}</td>

--- a/GEECS-DataPortal/geecs_portal/templates/run.html
+++ b/GEECS-DataPortal/geecs_portal/templates/run.html
@@ -87,7 +87,7 @@
            padding: 0.3rem 0.9rem; font-size: 12px; cursor: pointer; font-weight: 600; }
   .plotmsg { color: var(--dim); font-size: 13px; padding: 2rem 0; text-align: center; }
 </style>
-<script src="/static/plotly-cartesian-3.1.1.min.js"></script>
+<script src="{{ root }}/static/plotly-cartesian-3.1.1.min.js"></script>
 {% endblock %}
 {% block content %}
 <div class="frame">
@@ -100,21 +100,21 @@
         · {{ summary.exit_status or "running" }}{% if start_time_of_day %} · {{ start_time_of_day }}{% endif %}</div>
       <div class="steprow">
         {% if run_day %}
-        <a class="act" href="/run/jump/{{ prev_day }}?prefer={{ scan_number }}&amp;{{ qs(device="", shot="") }}" title="previous day (same scan number, else its latest)">‹ day</a>
-        <a class="act" href="/day/{{ run_day }}?{{ qs(device="", shot="") }}" title="browse this day's list">{{ run_day }}</a>
-        <a class="act" href="/run/jump/{{ next_day }}?prefer={{ scan_number }}&amp;{{ qs(device="", shot="") }}" title="next day (same scan number, else its latest)">day ›</a>
+        <a class="act" href="{{ root }}/run/jump/{{ prev_day }}?prefer={{ scan_number }}&amp;{{ qs(device="", shot="") }}" title="previous day (same scan number, else its latest)">‹ day</a>
+        <a class="act" href="{{ root }}/day/{{ run_day }}?{{ qs(device="", shot="") }}" title="browse this day's list">{{ run_day }}</a>
+        <a class="act" href="{{ root }}/run/jump/{{ next_day }}?prefer={{ scan_number }}&amp;{{ qs(device="", shot="") }}" title="next day (same scan number, else its latest)">day ›</a>
         {% endif %}
       </div>
       <div class="steprow">
-        <a class="act {{ "off" if not prev_uid }}" href="/run/{{ prev_uid }}?{{ qs() }}" title="previous scan">‹ scan</a>
+        <a class="act {{ "off" if not prev_uid }}" href="{{ root }}/run/{{ prev_uid }}?{{ qs() }}" title="previous scan">‹ scan</a>
         {% if day_runs %}
-        <select class="act" onchange="if(this.value) location = '/run/' + this.value + location.search" title="jump to a scan on this day">
+        <select class="act" onchange="if(this.value) location = ROOT + '/run/' + this.value + location.search" title="jump to a scan on this day">
           {% for run in day_runs %}
           <option value="{{ run.uid }}" {{ "selected" if run.uid == uid }}>Scan {{ "%03d" | format(run.scan_number) if run.scan_number is not none else "?" }} · {{ run.mode }} · {{ run.exit_status or "running" }}</option>
           {% endfor %}
         </select>
         {% endif %}
-        <a class="act {{ "off" if not next_uid }}" href="/run/{{ next_uid }}?{{ qs() }}" title="next scan">scan ›</a>
+        <a class="act {{ "off" if not next_uid }}" href="{{ root }}/run/{{ next_uid }}?{{ qs() }}" title="next scan">scan ›</a>
       </div>
       <div class="dim" style="font-size:11px; margin-top:0.2rem;">filters &amp; columns persist across day/scan steps</div>
       <div style="margin-top:0.5rem;" id="providers"></div>
@@ -178,7 +178,7 @@
       {% if devices %}
       <p>
         {% for dev in devices %}
-        <a class="mono" href="/run/{{ uid }}?{{ qs(device=dev, shot=1, tab="images") }}">{{ dev }}</a>{{ " · " if not loop.last }}
+        <a class="mono" href="{{ root }}/run/{{ uid }}?{{ qs(device=dev, shot=1, tab="images") }}">{{ dev }}</a>{{ " · " if not loop.last }}
         {% endfor %}
       </p>
       {% if sel_device %}
@@ -191,22 +191,22 @@
       render (trace/array data, not an image). Files live at:</p>
       <p class="mono">{{ kind_path }}</p>
       {% else %}
-      <form class="nav" method="get" action="/run/{{ uid }}">
+      <form class="nav" method="get" action="{{ root }}/run/{{ uid }}">
         <input type="hidden" name="device" value="{{ sel_device }}">
         <input type="hidden" name="day" value="{{ day }}">
         <input type="hidden" name="experiment" value="{{ experiment }}">
         <input type="hidden" name="tab" value="images">
         {% if filter %}<input type="hidden" name="filter" value="{{ filter }}">{% endif %}
-        {% if shot > 1 %}<a href="/run/{{ uid }}?{{ qs(shot=shot - 1, tab="images") }}">&larr; prev</a>{% endif %}
+        {% if shot > 1 %}<a href="{{ root }}/run/{{ uid }}?{{ qs(shot=shot - 1, tab="images") }}">&larr; prev</a>{% endif %}
         <label class="dim">shot
           <input type="number" name="shot" value="{{ shot }}" min="1" style="width: 5rem">
         </label>
         <button type="submit">Show</button>
-        {% if has_next_shot %}<a href="/run/{{ uid }}?{{ qs(shot=shot + 1, tab="images") }}">next &rarr;</a>{% endif %}
+        {% if has_next_shot %}<a href="{{ root }}/run/{{ uid }}?{{ qs(shot=shot + 1, tab="images") }}">next &rarr;</a>{% endif %}
         {% if total_shots %}<span class="dim mono">of ~{{ total_shots }}</span>{% endif %}
         <span class="dim mono">{{ kind }}</span>
       </form>
-      <img class="plot" src="/run/{{ uid }}/image.png?device={{ sel_device | urlencode }}&amp;shot={{ shot }}&amp;day={{ day | urlencode }}" alt="{{ sel_device }} shot {{ shot }}">
+      <img class="plot" src="{{ root }}/run/{{ uid }}/image.png?device={{ sel_device | urlencode }}&amp;shot={{ shot }}&amp;day={{ day | urlencode }}" alt="{{ sel_device }} shot {{ shot }}">
       {% endif %}
       {% else %}
       <p class="dim">Pick a device above.</p>
@@ -307,6 +307,7 @@
 <script>
 "use strict";
 const UID = {{ uid | tojson }};
+const ROOT = {{ root | tojson }};  // proxy mount prefix ("" at root)
 const DAY = {{ day | tojson }};
 const TRACE_COLORS = ["#4cc2b4", "#d6a860", "#6f9fd8", "#c47ab8"];
 // Everything Plotly gives for free, switched ON: wheel zoom, in-place
@@ -397,7 +398,7 @@ function api(path, params) {
   // Completed-run /api responses cache immutable; the version key rolls
   // browser caches over when the payload shape changes on upgrade.
   p.set("v", {{ portal_version | tojson }});
-  return fetch(`/api/run/${UID}/${path}?` + p.toString()).then(r => {
+  return fetch(`${ROOT}/api/run/${UID}/${path}?` + p.toString()).then(r => {
     if (!r.ok) return r.json().then(b => { throw new Error(b.detail || r.statusText); });
     return r.json();
   });

--- a/GEECS-DataPortal/pyproject.toml
+++ b/GEECS-DataPortal/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-data-portal"
-version = "0.8.1"
+version = "0.9.0"
 description = "Read-only scan-browsing web service: a zero-install browser view over the Tiled catalog and the GEECS data share"
 authors = ["GEECS-BELLA"]
 readme = "README.md"

--- a/GEECS-DataPortal/tests/test_app.py
+++ b/GEECS-DataPortal/tests/test_app.py
@@ -770,11 +770,41 @@ class TestReverseProxy:
         assert response.headers["location"].startswith("/portal/day/")
 
     def test_malformed_prefixes_are_ignored(self):
-        for bad in ("portal", "//evil.example", "/a b", "/", "/x\\y"):
+        for bad in (
+            "portal",
+            "//evil.example",
+            "/a b",
+            "/",
+            "/x\\y",
+            "/p?x=1",  # query/fragment/quote characters are not a path
+            "/p#frag",
+            '/p"x',
+            "/p<q>",
+        ):
             response = _client().get(
                 "/", headers={"X-Forwarded-Prefix": bad}, follow_redirects=False
             )
             assert response.headers["location"].startswith("/day/"), bad
+
+    def test_mount_name_colliding_with_a_route_head_works(self):
+        # A mount literally named /run: the middleware re-prefixes the
+        # path so starlette's front-strip is exact — without it this
+        # whole route family double-strips to a 404.
+        client = _client(FakeCatalog(), default_experiment="Undulator")
+        response = client.get("/run/uid-002", headers={"X-Forwarded-Prefix": "/run"})
+        assert response.status_code == 200
+        assert 'const ROOT = "/run";' in response.text
+        assert '"/run/run/uid-001?' in response.text  # prev-scan stepper
+
+    def test_trailing_slash_redirect_keeps_the_prefix(self):
+        # Starlette's redirect_slashes builds the Location from the
+        # scope path — re-prefixed, so the hop stays under the mount.
+        client = _client(FakeCatalog(), default_experiment="Undulator")
+        response = client.get(
+            "/run/uid-002/", headers=self.PREFIX, follow_redirects=False
+        )
+        assert response.status_code in (301, 307)
+        assert "/portal/run/uid-002" in response.headers["location"]
 
     def test_api_still_serves_under_a_prefix(self):
         client = _client(FakeCatalog(), default_experiment="Undulator")

--- a/GEECS-DataPortal/tests/test_app.py
+++ b/GEECS-DataPortal/tests/test_app.py
@@ -704,3 +704,85 @@ class TestPlotTabPolish:
         assert "drawrect" in text
         assert "togglespikelines" in text
         assert "deepMerge(layout, d.layout)" in text  # the passthrough
+
+
+class TestReverseProxy:
+    """Behind a mount prefix every link, fetch base, and redirect carries it.
+
+    The Grafana/JupyterHub convention: the proxy strips the prefix from
+    the path and names it in ``X-Forwarded-Prefix``; the app derives
+    its root path per request (OSPREY panel tabs mount the portal this
+    way).  Served at root — no header — nothing changes.
+    """
+
+    PREFIX = {"X-Forwarded-Prefix": "/portal"}
+
+    def test_day_links_and_forms_carry_the_prefix(self):
+        client = _client(FakeCatalog(), default_experiment="Undulator")
+        response = client.get(f"/day/{TEST_DAY.isoformat()}", headers=self.PREFIX)
+        assert response.status_code == 200
+        assert '"/portal/run/uid-002?' in response.text
+        assert 'action="/portal/go"' in response.text
+        assert 'action="/portal/day/' in response.text
+        # No unprefixed portal link survives (external hrefs excluded).
+        assert 'href="/run/' not in response.text
+        assert 'href="/day/' not in response.text
+
+    def test_run_page_static_fetch_base_and_steppers_carry_the_prefix(self):
+        client = _client(FakeCatalog(), default_experiment="Undulator")
+        response = client.get("/run/uid-002", headers=self.PREFIX)
+        assert response.status_code == 200
+        assert 'src="/portal/static/plotly-cartesian-' in response.text
+        # The JS builds every /api fetch (and the scan-jump dropdown)
+        # from this constant.
+        assert 'const ROOT = "/portal";' in response.text
+        assert '"/portal/run/uid-001?' in response.text  # prev-scan stepper
+        assert 'src="/static/' not in response.text
+
+    def test_index_and_go_redirects_carry_the_prefix(self):
+        response = _client().get("/", headers=self.PREFIX, follow_redirects=False)
+        assert response.headers["location"].startswith("/portal/day/")
+        response = _client().get(
+            "/go?day=2026-07-12", headers=self.PREFIX, follow_redirects=False
+        )
+        assert response.headers["location"] == "/portal/day/2026-07-12"
+
+    def test_run_jump_redirect_carries_the_prefix(self):
+        client = _client(FakeCatalog(), default_experiment="Undulator")
+        response = client.get(
+            f"/run/jump/{TEST_DAY.isoformat()}",
+            headers=self.PREFIX,
+            follow_redirects=False,
+        )
+        assert response.headers["location"].startswith("/portal/run/uid-002?")
+
+    def test_served_at_root_nothing_changes(self):
+        client = _client(FakeCatalog(), default_experiment="Undulator")
+        response = client.get("/run/uid-002")
+        assert 'const ROOT = "";' in response.text
+        assert 'src="/static/plotly-cartesian-' in response.text
+        assert '"/run/uid-001?' in response.text
+
+    def test_trailing_slash_prefix_is_normalized(self):
+        response = _client().get(
+            "/", headers={"X-Forwarded-Prefix": "/portal/"}, follow_redirects=False
+        )
+        assert response.headers["location"].startswith("/portal/day/")
+
+    def test_malformed_prefixes_are_ignored(self):
+        for bad in ("portal", "//evil.example", "/a b", "/", "/x\\y"):
+            response = _client().get(
+                "/", headers={"X-Forwarded-Prefix": bad}, follow_redirects=False
+            )
+            assert response.headers["location"].startswith("/day/"), bad
+
+    def test_api_still_serves_under_a_prefix(self):
+        client = _client(FakeCatalog(), default_experiment="Undulator")
+        response = client.get("/api/run/uid-002/columns", headers=self.PREFIX)
+        assert response.status_code == 200
+        assert response.json()["total"] == 3
+
+    def test_health_still_serves_under_a_prefix(self):
+        response = _client().get("/health", headers=self.PREFIX)
+        assert response.status_code == 200
+        assert response.json()["ok"] is True


### PR DESCRIPTION
## What + why

OSPREY panel-tab integration feedback: the portal broke behind a reverse proxy because every navigation link, form action, image/script URL, JS `/api` fetch, and redirect was root-absolute. This makes the portal **prefix-agnostic** — it works at root and under any mount point (`proxy /portal → :8200`), the same way Grafana/JupyterHub solved it.

- **`_ForwardedPrefixMiddleware`** adopts the proxy's `X-Forwarded-Prefix` header as the ASGI `root_path`, per request. Values are validated (`_clean_prefix`: root-absolute, no `//`/whitespace/backslash/control chars; bare `/` = root) — malformed headers are ignored, never propagated into page links. The header, when present, wins over a static setting (the proxy is authoritative for where it mounted us; a client faking it only rewrites its own page's links).
- **One `root` context value** (a Jinja context processor) prefixes every template href/action/src; the page JS gets `const ROOT` and builds all `/api` fetches and the scan-jump dropdown from it. The `/`, `/go`, and `/run/jump` redirects prefix via `_root(request)`.
- **`--root-path` CLI fallback** → uvicorn `root_path`, for proxies that can't send the header.
- **`/health` already existed** (0.1.0) and is untouched — it's the panel health probe for `web.panels.dataview.health_endpoint`. It returns 200 always; the JSON `ok` field carries the catalog probe, so a down Tiled reads as degraded catalog, not dead portal.
- Docs: DEPLOYMENT.md gains a reverse-proxy section (nginx example, strip-prefix + header convention); CLAUDE.md pins the prefix-agnostic rule so future templates keep the `{{ root }}` discipline.

Design note (why prefix-injection rather than the feedback's literal `./relative` links + `<base href>`): relative links are depth-sensitive (`/run/{uid}` vs `/run/{uid}/image.png` resolve `./` differently) and `<base>` hijacks `href="#"` anchors the page uses for popups. One explicit per-request prefix covers every URL uniformly and degrades to exactly the current behavior at root.

## LOC breakdown (one concern; 244 insertions / 28 deletions)

| Piece | ~LOC |
|---|---|
| app.py: middleware + `_clean_prefix` + `_root` + context processor + 3 prefixed redirects | ~75 |
| templates: `{{ root }}` on 16 URL sites + `const ROOT` in the JS | ~30 changed |
| `__main__.py`: `--root-path` | ~15 |
| tests: `TestReverseProxy` (9 tests) | ~85 |
| CHANGELOG + CLAUDE.md rule + DEPLOYMENT.md section | ~65 |

## Tests

`./scripts/check.sh` green: **GEECS-DataPortal 122 passed** (113 existing + 9 new: prefixed links/forms/static/fetch-base/steppers, prefixed redirects incl. `/run/jump`, root-unchanged, trailing-slash normalization, malformed-header rejection, `/api` + `/health` under prefix), **GEECS-Data-Utils 294 passed**, root-tests 2 passed, lint/pre-commit clean.

## Hardware verification

No scan-execution or device surface. **OWED (integration, not hardware):** load the portal through an actual OSPREY panel / reverse-proxy mount and click through day → run → tabs → images; expected: all navigation and plots work identically under the prefix, and the health LED goes green once `web.panels.dataview.health_endpoint` points at `/health`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)