### PR TITLE
GEECS-DataPortal 0.9.1: #728 review fixes (XSS sinks, union shot axis, bin_width guard)

### DIFF
--- a/GEECS-DataPortal/CHANGELOG.md
+++ b/GEECS-DataPortal/CHANGELOG.md
@@ -3,6 +3,25 @@
 All notable changes to this package will be documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.9.1] - 2026-08-31
+
+### Fixed
+
+Fix wave from the #728 promotion review (cloud review findings):
+
+- **XSS via URL-carried display/filters JSON** (`run.html`): the three
+  attribute sinks that interpolated shared-link state unescaped are
+  closed — `traceColor()` now admits only hex colors (falling back to
+  the palette), and the filter modal's low/high inputs render only
+  actual numbers. Shared analysis links can no longer inject markup.
+- **Union shot axis**: `/api/run/{uid}/frame` coalesces NA
+  `scan_event_index` cells with the s-file's own `Shotnumber` (plain or
+  collision-suffixed), so s-file-only union rows keep a shot axis
+  instead of a null that Plotly silently dropped from the default plot.
+  A run-only frame with a genuinely unknown shot still serializes null.
+- **`bin_width <= 0` is a 400** at the `parse_bincfg` boundary (zero
+  divided to `inf` inside `compute_bin_key` and escaped as a 500).
+
 ## [0.9.0] - 2026-08-31
 
 ### Added

--- a/GEECS-DataPortal/geecs_portal/analysis.py
+++ b/GEECS-DataPortal/geecs_portal/analysis.py
@@ -145,6 +145,10 @@ def parse_bincfg(raw: str) -> BinningConfig:
     for key in _BIN_FLOATS:
         if payload.get(key) is not None:
             payload[key] = _bin_number(key, payload[key], float)
+    if payload.get("bin_width") is not None and payload["bin_width"] <= 0:
+        # 0 divides to inf inside compute_bin_key (OverflowError → 500);
+        # negative widths build empty edge arrays.
+        raise BadParam("bad bincfg param: bin_width must be > 0")
     for key in _BIN_BOOLS:
         if key in payload and not isinstance(payload[key], bool):
             raise BadParam(f"bad bincfg param: {key} must be a boolean")

--- a/GEECS-DataPortal/geecs_portal/app.py
+++ b/GEECS-DataPortal/geecs_portal/app.py
@@ -414,6 +414,18 @@ def create_app(catalog: ScanCatalog, *, default_experiment: str = "") -> FastAPI
             if schema_map.SHOT_INDEX_COLUMN in pf.frame.columns
             else pf.frame.index.to_series() + 1
         )
+        if shot_key.isna().any():
+            # Union rows the event side missed carry NA here — coalesce
+            # with the s-file's own shot identity (plain, or suffixed by
+            # scan_frame's collision rename) so those rows keep a shot
+            # axis; Plotly silently drops points with a null x.
+            import pandas as pd
+
+            for name in ("Shotnumber", "Shotnumber (s-file)"):
+                if name in pf.frame.columns:
+                    shot_key = shot_key.fillna(
+                        pd.to_numeric(pf.frame[name], errors="coerce")
+                    )
         payload = {
             "series": series,
             "kinds": kinds,

--- a/GEECS-DataPortal/geecs_portal/templates/run.html
+++ b/GEECS-DataPortal/geecs_portal/templates/run.html
@@ -516,8 +516,12 @@ function dispCfg() {
 }
 
 function traceColor(i) {
+  // display JSON rides the URL (shared-link threat model, same as
+  // deepMerge's guard): only a hex color may reach the attribute
+  // sinks this feeds — anything else falls back to the palette.
   const d = dispCfg();
-  return (d.colors && d.colors[i]) || TRACE_COLORS[i];
+  const c = d.colors && d.colors[i];
+  return (typeof c === "string" && /^#[0-9a-fA-F]{3,8}$/.test(c)) ? c : TRACE_COLORS[i];
 }
 
 function markerSize() {
@@ -704,10 +708,10 @@ function renderFilterModal() {
             <option ${c.mode !== "outside" ? "selected" : ""}>within</option>
             <option ${c.mode === "outside" ? "selected" : ""}>outside</option>
           </select>
-          <input class="val" value="${c.low ?? ""}" placeholder="low"
+          <input class="val" value="${typeof c.low === "number" ? c.low : ""}" placeholder="low"
                  onchange="FDRAFT.groups[${gi}].conditions[${ci}].low=parseFloat(this.value); draftCount();">
           <span class="dim">–</span>
-          <input class="val" value="${c.high ?? ""}" placeholder="high"
+          <input class="val" value="${typeof c.high === "number" ? c.high : ""}" placeholder="high"
                  onchange="FDRAFT.groups[${gi}].conditions[${ci}].high=parseFloat(this.value); draftCount();">
           <span class="x" onclick="FDRAFT.groups[${gi}].conditions.splice(${ci},1); renderFilterModal();">✕</span>
         </div>`).join("")}

--- a/GEECS-DataPortal/pyproject.toml
+++ b/GEECS-DataPortal/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-data-portal"
-version = "0.9.0"
+version = "0.9.1"
 description = "Read-only scan-browsing web service: a zero-install browser view over the Tiled catalog and the GEECS data share"
 authors = ["GEECS-BELLA"]
 readme = "README.md"

--- a/GEECS-DataPortal/tests/test_app.py
+++ b/GEECS-DataPortal/tests/test_app.py
@@ -510,6 +510,8 @@ class TestAnalysisApi:
             '{"ddof":Infinity}',  # ... and Infinity
             '{"min_count":1e400}',  # float overflow to inf
             '{"quantile_bins":' + "9" * 400 + "}",  # unbounded int
+            '{"bin_col":"mono","bin_width":0}',  # /0 → inf → OverflowError
+            '{"bin_col":"mono","bin_width":-0.5}',  # empty edge array
         ]
         for bincfg in bad:
             response = client.get(
@@ -541,6 +543,20 @@ class TestAnalysisApi:
         assert response.status_code == 200
         assert b"<NA>" not in response.content
         assert response.json()["shot"] == [1.0, None, 3.0]
+
+    def test_union_shot_key_coalesces_from_shotnumber(self):
+        # An s-file-only union row has no event index but does have a
+        # Shotnumber — the shot axis must coalesce to it, not go null
+        # (Plotly silently drops null-x points from the default plot).
+        catalog = FakeCatalog()
+        detail = _detail(7)
+        detail.data["scan_event_index"] = pd.array([1, 2, pd.NA], dtype="Int64")
+        detail.data["Shotnumber"] = [1.0, 2.0, 4.0]
+        catalog.details["uid-007"] = detail
+        payload = (
+            _client(catalog).get("/api/run/uid-007/frame?cols=cam-MaxCounts").json()
+        )
+        assert payload["shot"] == [1.0, 2.0, 4.0]
 
     def test_binned_counts_are_integers(self):
         payload = (


### PR DESCRIPTION
Fix wave for the #728 promotion review (cloud review, 3 findings — all verified against the code and fixed). **GEECS-DataPortal 0.9.1**, +59/−4 across 6 files. Merge into `feat/analysis-tabs` so #728 picks it up.

## Findings → fixes

1. **XSS via URL-carried display/filters JSON** (`run.html`, ~30 LOC) — three attribute sinks interpolated shared-link state unescaped while their siblings used `escAttr`:
   - `traceColor()` now admits only `/^#[0-9a-fA-F]{3,8}$/` strings, falling back to the palette — closes both the `renderPicked()` `style` sink (fires on page load with `?y=` set) and the display popup's `value` sink at the source.
   - The filter modal's low/high inputs render only actual JS numbers (`typeof === "number"`, so legal ±Infinity half-open bounds still display; a number can never stringify into markup).
2. **Union shot axis null for s-file-only rows** (`app.py`, ~15 LOC) — `/api/.../frame` took `scan_event_index` verbatim, so union rows the event side missed serialized `shot: null` and Plotly silently dropped them from the default per-shot plot. Now coalesced with the s-file's own `Shotnumber` (plain or scan-frame collision-suffixed). A run-only frame with a genuinely unknown shot still serializes null (existing pin `test_na_shot_key_serializes_as_null` unchanged).
3. **`bin_width<=0` → 500** (`analysis.py`, 4 LOC) — zero divided to `inf` inside `compute_bin_key`, `int(inf)` raised OverflowError past the 400 mapping. Now refused at the `parse_bincfg` boundary per the portal's validation doctrine.

## Tests

New pins: `test_union_shot_key_coalesces_from_shotnumber`, plus `bin_width:0` / `bin_width:-0.5` rows in `test_wrong_typed_bincfg_fields_are_400_not_500`. The XSS fixes are client-side template JS (no JS harness — fix only). Full run: **GEECS-DataPortal 125 passed**, GEECS-Data-Utils + root suites green via `scripts/check.sh`.

**Judgment call, cheap to veto:** finding 2's fix lives in the portal (presentation-layer coalesce) rather than in `scan_frame` (filling `scan_event_index` from the join key). Rationale: `scan_event_index` honestly means "the event stream's index" — NaN on an event-less row is correct data; totalizing it belongs to the consumer building a shot axis.

No hardware surface (read-only view layer) — nothing owed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
