### PR TITLE
portal 0.11.0: binned-vs-X placement, plot-size control, copy-to-clipboard

### DIFF
--- a/GEECS-DataPortal/CHANGELOG.md
+++ b/GEECS-DataPortal/CHANGELOG.md
@@ -3,6 +3,30 @@
 All notable changes to this package will be documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.11.0] - 2026-09-01
+
+### Added
+
+Owner live-feedback round on 0.10.0:
+
+- **Binned view plots against the X pick** — bins still *group* by
+  `bincfg.bin_col`, but each bin now *plots at* the per-bin **mean of
+  the selected X column** (`/binned?x=…` → `x_centers` in the payload,
+  the figure's x positions, and the axis title). Same primitive, same
+  bins: a second `bin_frame` call with `replace(cfg, value_cols=(x,),
+  agg="mean")`, mirrored verbatim in the "show the code" snippet. No
+  X keeps the bin labels as the axis, exactly as before. (X error
+  bars deliberately deferred — mean placement is the first move.)
+- **Plot size control**: `width`/`height` join the display vocabulary
+  (popup inputs; same type-400/value-degrade rules). A fixed size also
+  fixes the exported image size.
+- **Copy plot to clipboard**: a modebar button exports the figure at
+  2× and puts the PNG on the clipboard — copy-paste is how plots
+  travel around the lab. Caveat: the async Clipboard API requires a
+  secure context (https or localhost); on plain-http lab hosts the
+  button degrades to the 2× PNG download with a note. The built-in
+  camera download is 2× now too.
+
 ## [0.10.0] - 2026-08-31
 
 ### Changed

--- a/GEECS-DataPortal/CHANGELOG.md
+++ b/GEECS-DataPortal/CHANGELOG.md
@@ -17,6 +17,14 @@ Owner live-feedback round on 0.10.0:
   agg="mean")`, mirrored verbatim in the "show the code" snippet. No
   X keeps the bin labels as the axis, exactly as before. (X error
   bars deliberately deferred — mean placement is the first move.)
+  `x_centers` come **reindexed onto the y result's bins** — the x
+  call's dropna runs over x alone, so its surviving bins can differ,
+  and positional zipping would silently plot points at the wrong
+  bin's x (review-caught); a bin missing an x center degrades to a
+  skipped point. A timestamp X serves raw seconds (the binned raw
+  rule, extended deliberately). Coercible-string columns
+  (dtype-tolerant telemetry) now 400 in binned view instead of
+  500ing inside `bin_frame` — as y too, a pre-existing hole.
 - **Plot size control**: `width`/`height` join the display vocabulary
   (popup inputs; same type-400/value-degrade rules). A fixed size also
   fixes the exported image size.

--- a/GEECS-DataPortal/CLAUDE.md
+++ b/GEECS-DataPortal/CLAUDE.md
@@ -120,9 +120,13 @@ target day's matching/newest run; empty day → the day page) ·
 `/api/run/{uid}/frame?cols=&x=&filters=` (per-shot series, filtered;
 timestamp columns arrive as host-local ISO datetimes with a `kinds`
 map — presentation-side conversion the `code` snippet mirrors) ·
-`/api/run/{uid}/binned?cols=&filters=&bincfg=` (centers + asymmetric
+`/api/run/{uid}/binned?cols=&x=&filters=&bincfg=` (centers + asymmetric
 error bands — served RAW, no datetime conversion: a timestamp bin
-column keeps its epoch-second labels) ·
+column keeps its epoch-second labels, and the `x` pick's per-bin mean
+positions are raw seconds too when X is a timestamp column — datetime
+rendering is per-shot-only, deliberately; `x_centers` come reindexed
+onto the y result's bins so diverging per-column dropna can never
+shift points) ·
 `/api/run/{uid}/filter-count?filters=` (live pass count)
 · `/run/{uid}/plot.png?y=&x=` (server-rendered scalar PNG, kept for
 embedding) · `/run/{uid}/image.png?device=&shot=` (one rendered device

--- a/GEECS-DataPortal/geecs_portal/analysis.py
+++ b/GEECS-DataPortal/geecs_portal/analysis.py
@@ -178,7 +178,7 @@ def parse_bincfg(raw: str) -> BinningConfig:
 
 
 _DISPLAY_BOOLS = ("logx", "logy")
-_DISPLAY_NUMBERS = ("xmin", "xmax", "ymin", "ymax", "msize")
+_DISPLAY_NUMBERS = ("xmin", "xmax", "ymin", "ymax", "msize", "width", "height")
 _DISPLAY_FIELDS = {*_DISPLAY_BOOLS, *_DISPLAY_NUMBERS, "colors", "layout"}
 
 
@@ -414,9 +414,14 @@ def binned_code(
     columns: list[str],
     filters: RowFilters,
     cfg: BinningConfig,
+    x: Optional[str] = None,
     display: Optional[dict] = None,
 ) -> str:
-    """The notebook snippet reproducing a ``/api/.../binned`` response."""
+    """The notebook snippet reproducing a ``/api/.../binned`` response.
+
+    With an ``x``, the snippet also reproduces the per-bin mean X
+    positions the figure plots against (bins group, X places).
+    """
     non_default = {
         f.name: getattr(cfg, f.name)
         for f in dataclasses.fields(BinningConfig)
@@ -424,20 +429,36 @@ def binned_code(
     }
     non_default["value_cols"] = columns
     kwargs = ", ".join(f"{k}={v!r}" for k, v in sorted(non_default.items()))
+    x_lines = ""
+    x_args = "result.frame.index.tolist(), series"
+    if x:
+        x_lines = (
+            "from dataclasses import replace\n"
+            "\n"
+            "# bins GROUP the data; the X parameter PLACES it (per-bin mean)\n"
+            f"x_centers = bin_frame(frame, replace(cfg, value_cols=({x!r},), "
+            "agg='mean'))\n"
+        )
+        x_args += (
+            f",\n              x_values=x_centers.frame[({x!r}, 'center')].tolist(),"
+            f" x_label={x!r}"
+        )
     return (
         "# reproduces this view exactly — the endpoint calls the same functions\n"
         + _snippet_prelude(uid, run_day)
         + _snippet_filters(filters)
         + "from geecs_data_utils.data.binning import BinningConfig, bin_frame\n"
         + "\n"
-        + f"result = bin_frame(frame, BinningConfig({kwargs}))\n"
+        + f"cfg = BinningConfig({kwargs})\n"
+        + "result = bin_frame(frame, cfg)\n"
         + "result.frame  # (column, center/err_low/err_high); result.counts per bin\n"
+        + x_lines
         + "from geecs_portal.figures import binned_figure"
         + "  # pip install geecs-data-portal\n"
         + "series = {c: {s: result.frame[(c, s)].tolist()\n"
         + '               for s in ("center", "err_low", "err_high")}\n'
         + f"          for c in {columns!r} if (c, 'center') in result.frame}}\n"
-        + f"binned_figure(result.frame.index.tolist(), series, y={columns!r}, "
+        + f"binned_figure({x_args}, y={columns!r}, "
         + f"bin_col={cfg.bin_col!r}{_snippet_display(display)})"
         + "  # the figure the Plot tab renders\n"
     )

--- a/GEECS-DataPortal/geecs_portal/analysis.py
+++ b/GEECS-DataPortal/geecs_portal/analysis.py
@@ -435,14 +435,14 @@ def binned_code(
         x_lines = (
             "from dataclasses import replace\n"
             "\n"
-            "# bins GROUP the data; the X parameter PLACES it (per-bin mean)\n"
-            f"x_centers = bin_frame(frame, replace(cfg, value_cols=({x!r},), "
+            "# bins GROUP the data; the X parameter PLACES it (per-bin mean),\n"
+            "# reindexed onto the y bins so diverging dropna cannot shift points\n"
+            f"x_result = bin_frame(frame, replace(cfg, value_cols=({x!r},), "
             "agg='mean'))\n"
+            f"x_centers = x_result.frame[({x!r}, 'center')]"
+            ".reindex(result.frame.index)\n"
         )
-        x_args += (
-            f",\n              x_values=x_centers.frame[({x!r}, 'center')].tolist(),"
-            f" x_label={x!r}"
-        )
+        x_args += f",\n              x_values=x_centers.tolist(), x_label={x!r}"
     return (
         "# reproduces this view exactly — the endpoint calls the same functions\n"
         + _snippet_prelude(uid, run_day)

--- a/GEECS-DataPortal/geecs_portal/app.py
+++ b/GEECS-DataPortal/geecs_portal/app.py
@@ -515,16 +515,36 @@ def create_app(catalog: ScanCatalog, *, default_experiment: str = "") -> FastAPI
             ) from exc
         except ValueError as exc:  # e.g. degenerate percentile bounds
             raise HTTPException(status_code=400, detail=str(exc)) from exc
+        except TypeError as exc:
+            # A coercible-string column (dtype-tolerant telemetry) plots
+            # in per-shot view but bin_frame aggregates the RAW dtype —
+            # refuse honestly, never 500 (package doctrine).
+            raise HTTPException(
+                status_code=400,
+                detail=f"binned view needs numeric columns: {exc}",
+            ) from exc
         x_centers = None
         if x:
-            # Same primitive, same bins (identical bin params + frame),
-            # mean-aggregated — the snippet mirrors this exactly.
-            x_result = bin_frame(
-                pf.frame[mask],
-                dataclasses.replace(cfg, value_cols=(x,), agg="mean"),
-            )
+            # Same primitive, mean-aggregated — the snippet mirrors this
+            # exactly.  The x call's dropna/min_count runs over x ALONE,
+            # so its surviving bins can differ from the y call's:
+            # reindex onto the y bins, or points silently plot at the
+            # wrong bin's x (a missing x center degrades to a null →
+            # Plotly skips that point instead of mis-placing it).
+            try:
+                x_result = bin_frame(
+                    pf.frame[mask],
+                    dataclasses.replace(cfg, value_cols=(x,), agg="mean"),
+                )
+            except (TypeError, ValueError) as exc:
+                raise HTTPException(
+                    status_code=400,
+                    detail=f"binned view needs a numeric x: {exc}",
+                ) from exc
             if (x, "center") in x_result.frame.columns:
-                x_centers = analysis.jsonable_values(x_result.frame[(x, "center")])
+                x_centers = analysis.jsonable_values(
+                    x_result.frame[(x, "center")].reindex(result.frame.index)
+                )
         bin_labels = analysis.jsonable_labels(result.frame.index)
         binned_series = {
             column: {

--- a/GEECS-DataPortal/geecs_portal/app.py
+++ b/GEECS-DataPortal/geecs_portal/app.py
@@ -477,17 +477,26 @@ def create_app(catalog: ScanCatalog, *, default_experiment: str = "") -> FastAPI
     def api_binned(
         uid: str,
         cols: list[str] = Query(default=[]),
+        x: str = "",
         filters: str = "",
         bincfg: str = "",
         display: str = "",
         day: str = "",
     ) -> JSONResponse:
-        """Per-bin centers + error bands + the ready binned figure."""
+        """Per-bin centers + error bands + the ready binned figure.
+
+        Bins GROUP the data (``bincfg.bin_col``); the selected ``x``
+        PLACES it — each bin plots at the per-bin mean of the X column
+        (the owner's ruling: real scan-parameter positions now, x error
+        bars maybe later).  No ``x`` keeps the bin labels as the axis.
+        """
         detail = _load_run(uid)
         pf, run_day = _union(detail, day)
         flt, mask = _masked(pf, filters)
         disp = _display(display)
         requested = _y_columns(cols)
+        if x and schema_map.numeric_series(pf.frame, x) is None:
+            raise HTTPException(status_code=404, detail=f"no plottable column {x!r}")
         try:
             cfg = analysis.parse_bincfg(bincfg)
         except analysis.BadParam as exc:
@@ -506,6 +515,16 @@ def create_app(catalog: ScanCatalog, *, default_experiment: str = "") -> FastAPI
             ) from exc
         except ValueError as exc:  # e.g. degenerate percentile bounds
             raise HTTPException(status_code=400, detail=str(exc)) from exc
+        x_centers = None
+        if x:
+            # Same primitive, same bins (identical bin params + frame),
+            # mean-aggregated — the snippet mirrors this exactly.
+            x_result = bin_frame(
+                pf.frame[mask],
+                dataclasses.replace(cfg, value_cols=(x,), agg="mean"),
+            )
+            if (x, "center") in x_result.frame.columns:
+                x_centers = analysis.jsonable_values(x_result.frame[(x, "center")])
         bin_labels = analysis.jsonable_labels(result.frame.index)
         binned_series = {
             column: {
@@ -515,6 +534,8 @@ def create_app(catalog: ScanCatalog, *, default_experiment: str = "") -> FastAPI
             for column in requested
             if (column, "center") in result.frame.columns
         }
+        x_name = x or None
+        pretty = _pretty_names(detail, pf, [*requested, *([x_name] if x_name else [])])
         payload = {
             "bins": bin_labels,
             "counts": [int(count) for count in result.counts],
@@ -522,16 +543,20 @@ def create_app(catalog: ScanCatalog, *, default_experiment: str = "") -> FastAPI
             "pass": int(mask.sum()),
             "total": len(pf.frame),
             "code": analysis.binned_code(
-                uid, run_day, requested, flt, cfg, display=disp
+                uid, run_day, requested, flt, cfg, x=x_name, display=disp
             ),
         }
+        if x_centers is not None:
+            payload["x_centers"] = x_centers
         if requested:
             payload["figure"] = figures.binned_figure(
                 bin_labels,
                 binned_series,
                 requested,
                 bin_col=cfg.bin_col,
-                pretty=_pretty_names(detail, pf, requested),
+                x_values=x_centers,
+                x_label=pretty.get(x_name) if x_name else None,
+                pretty=pretty,
                 display=disp,
             ).to_plotly_json()
         return JSONResponse(payload, headers=_png_headers(detail))

--- a/GEECS-DataPortal/geecs_portal/figures.py
+++ b/GEECS-DataPortal/geecs_portal/figures.py
@@ -211,6 +211,18 @@ def _apply_display(
     if y_range and not y_is_date:
         layout["yaxis"]["range"] = y_range
         layout["yaxis"]["autorange"] = False
+    # Explicit plot dimensions (copy-paste graphics sizing): a fixed
+    # width/height also fixes the exported image size.  Non-positive
+    # values degrade to responsive autosizing, like every cosmetic.
+    for key in ("width", "height"):
+        value = d.get(key)
+        if (
+            isinstance(value, (int, float))
+            and not isinstance(value, bool)
+            and math.isfinite(value)
+            and value > 0
+        ):
+            layout[key] = float(value)
 
 
 def shot_axis_for_frame(frame: "pd.DataFrame") -> "pd.Series":
@@ -318,6 +330,8 @@ def binned_figure(
     y: Sequence[str],
     *,
     bin_col: str = "Bin #",
+    x_values: Optional[Sequence] = None,
+    x_label: Optional[str] = None,
     pretty: Optional[Mapping[str, str]] = None,
     display: Optional[Mapping] = None,
 ) -> go.Figure:
@@ -326,14 +340,20 @@ def binned_figure(
     Parameters
     ----------
     bins : Sequence
-        Bin labels (the x axis).
+        Bin labels — the x axis when no ``x_values`` are given.
     series : Mapping[str, Mapping[str, Sequence]]
         Column → ``{"center": …, "err_low": …, "err_high": …}`` — the
         ``/api`` binned payload's ``series`` shape.
     y : Sequence[str]
         The plotted columns, in trace order.
     bin_col : str
-        The x-axis title (the binning column).
+        The x-axis title when plotting against the bin labels.
+    x_values : Sequence, optional
+        Per-bin x positions (the selected X column's per-bin mean) —
+        bins group the data, the X parameter places it.  Must align
+        with ``bins`` one-to-one.
+    x_label : str, optional
+        The x-axis title for ``x_values`` (defaults to ``bin_col``).
     pretty, display
         As in :func:`shots_figure`.
 
@@ -342,11 +362,13 @@ def binned_figure(
     plotly.graph_objects.Figure
         Exactly what the Plot tab renders in binned view.
     """
+    positions = list(x_values) if x_values is not None else list(bins)
+    x_title = (x_label or bin_col) if x_values is not None else bin_col
     fig = _bare_figure()
     for i, name in enumerate(y):
         s = series.get(name) or {"center": [], "err_low": [], "err_high": []}
         fig.add_scatter(
-            x=list(bins),
+            x=positions,
             y=list(s["center"]),
             mode="markers+lines",
             name=_pretty(pretty, name),
@@ -366,7 +388,7 @@ def binned_figure(
             yaxis="y" if i == 0 else f"y{i + 1}",
         )
     layout = {**BASE_LAYOUT, "xaxis": dict(BASE_LAYOUT["xaxis"])}
-    layout["xaxis"]["title"] = {"text": bin_col}
+    layout["xaxis"]["title"] = {"text": x_title}
     layout.update(_multi_y_layout(y, pretty, display))
     # Binned serves raw numbers — no date axes on either side.
     _apply_display(layout, display, x_is_date=False, y_is_date=False)

--- a/GEECS-DataPortal/geecs_portal/templates/run.html
+++ b/GEECS-DataPortal/geecs_portal/templates/run.html
@@ -318,20 +318,23 @@ const MSIZE_DEFAULT = {{ msize_default | tojson }};
 // Everything Plotly gives for free, switched ON: wheel zoom, in-place
 // legend-name editing, spike lines + hover modes, and the drawing
 // tools (annotate directly on the plot; shapes are editable/erasable).
+const EXPORT_SCALE = 2;  // crisp paste targets — one knob for every export path
+
 async function copyPlotImage(gd) {
   // Copy-paste is how plots travel around the lab.  The async
   // Clipboard API needs a secure context (https or localhost) — on
-  // plain http lab hosts it is absent, so degrade to the PNG download
-  // rather than failing silently.
-  const url = await Plotly.toImage(gd, { format: "png", scale: 2 });
+  // plain http lab hosts it is absent — and some browsers expire the
+  // click gesture across the awaits; either way degrade to the PNG
+  // download rather than failing silently.
+  const url = await Plotly.toImage(gd, { format: "png", scale: EXPORT_SCALE });
   try {
     if (!navigator.clipboard || !window.ClipboardItem) throw new Error("no clipboard API");
     const blob = await (await fetch(url)).blob();
     await navigator.clipboard.write([new ClipboardItem({ "image/png": blob })]);
     flashNote("copied to clipboard");
   } catch (err) {
-    Plotly.downloadImage(gd, { format: "png", scale: 2, filename: "geecs-plot" });
-    flashNote("clipboard unavailable here — downloaded PNG instead");
+    Plotly.downloadImage(gd, { format: "png", scale: EXPORT_SCALE, filename: "geecs-plot" });
+    flashNote("copy failed — downloaded PNG instead");
   }
 }
 
@@ -353,8 +356,8 @@ function flashNote(text) {
 
 const PLOT_CONFIG = {
   responsive: true, displaylogo: false, scrollZoom: true,
-  // The built-in camera button exports at 2× for crisp paste targets.
-  toImageButtonOptions: { format: "png", scale: 2 },
+  // The built-in camera button exports at EXPORT_SCALE too.
+  toImageButtonOptions: { format: "png", scale: EXPORT_SCALE },
   // Granular (not editable:true): blanket editability renders grey
   // "Click to enter …" placeholders for every unset title — and
   // axisTitleText does too on the title-less stacked axes (3-4), so

--- a/GEECS-DataPortal/geecs_portal/templates/run.html
+++ b/GEECS-DataPortal/geecs_portal/templates/run.html
@@ -255,6 +255,10 @@
       <span class="dim" style="font-size:11px;">first Y axis</span></div>
     <div class="setrow"><label>marker size</label>
       <input id="ds-msize" style="width:4rem;" placeholder="5"></div>
+    <div class="setrow"><label>plot size</label>
+      <input id="ds-width" style="width:5rem;" placeholder="auto"> <span class="dim">×</span>
+      <input id="ds-height" style="width:5rem;" placeholder="auto">
+      <span class="dim" style="font-size:11px;">px — fixes the exported size too</span></div>
     <div class="setrow"><label>trace colors</label>
       <span id="ds-colors"></span></div>
     <div class="setrow" style="align-items:flex-start;"><label>advanced<br>
@@ -314,8 +318,43 @@ const MSIZE_DEFAULT = {{ msize_default | tojson }};
 // Everything Plotly gives for free, switched ON: wheel zoom, in-place
 // legend-name editing, spike lines + hover modes, and the drawing
 // tools (annotate directly on the plot; shapes are editable/erasable).
+async function copyPlotImage(gd) {
+  // Copy-paste is how plots travel around the lab.  The async
+  // Clipboard API needs a secure context (https or localhost) — on
+  // plain http lab hosts it is absent, so degrade to the PNG download
+  // rather than failing silently.
+  const url = await Plotly.toImage(gd, { format: "png", scale: 2 });
+  try {
+    if (!navigator.clipboard || !window.ClipboardItem) throw new Error("no clipboard API");
+    const blob = await (await fetch(url)).blob();
+    await navigator.clipboard.write([new ClipboardItem({ "image/png": blob })]);
+    flashNote("copied to clipboard");
+  } catch (err) {
+    Plotly.downloadImage(gd, { format: "png", scale: 2, filename: "geecs-plot" });
+    flashNote("clipboard unavailable here — downloaded PNG instead");
+  }
+}
+
+function flashNote(text) {
+  let note = document.getElementById("flashnote");
+  if (!note) {
+    note = document.createElement("div");
+    note.id = "flashnote";
+    note.style.cssText = "position:fixed; bottom:1rem; right:1rem; z-index:40;" +
+      "background:var(--panel2); color:var(--ink); border:1px solid var(--line);" +
+      "border-radius:4px; padding:0.4rem 0.7rem; font-size:12px;";
+    document.body.appendChild(note);
+  }
+  note.textContent = text;
+  note.style.display = "block";
+  clearTimeout(note._timer);
+  note._timer = setTimeout(() => { note.style.display = "none"; }, 2200);
+}
+
 const PLOT_CONFIG = {
   responsive: true, displaylogo: false, scrollZoom: true,
+  // The built-in camera button exports at 2× for crisp paste targets.
+  toImageButtonOptions: { format: "png", scale: 2 },
   // Granular (not editable:true): blanket editability renders grey
   // "Click to enter …" placeholders for every unset title — and
   // axisTitleText does too on the title-less stacked axes (3-4), so
@@ -324,6 +363,15 @@ const PLOT_CONFIG = {
   modeBarButtonsToAdd: [
     "togglespikelines", "hoverclosest", "hovercompare",
     "drawline", "drawopenpath", "drawrect", "drawcircle", "eraseshape",
+    {
+      name: "copyimage",
+      title: "Copy plot to clipboard (PNG)",
+      icon: {  // material content_copy, 24×24 viewBox
+        width: 24, height: 24,
+        path: "M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z",
+      },
+      click: copyPlotImage,
+    },
   ],
 };
 // Traces and layout are authored SERVER-SIDE (geecs_portal/figures.py)
@@ -498,11 +546,13 @@ function refresh() {
   S.y.forEach(c => params.append("cols", c));
   if (S.filters) params.set("filters", S.filters);
   if (S.display) params.set("display", S.display);
+  // Both views take the X pick: per-shot plots it directly, binned
+  // plots each bin at the per-bin mean of it (bins group, X places).
+  if (S.x) params.set("x", S.x);
   if (S.view === "bin") {
     if (S.bincfg) params.set("bincfg", S.bincfg);
     api("binned", params).then(drawFigure).catch(showPlotError);
   } else {
-    if (S.x) params.set("x", S.x);
     api("frame", params).then(drawFigure).catch(showPlotError);
   }
 }
@@ -701,6 +751,10 @@ function openDisplay() {
   }
   document.getElementById("ds-msize").value =
     Number.isFinite(d.msize) ? d.msize : "";
+  for (const key of ["width", "height"]) {
+    document.getElementById("ds-" + key).value =
+      Number.isFinite(d[key]) ? d[key] : "";
+  }
   document.getElementById("ds-layout").value =
     d.layout ? JSON.stringify(d.layout) : "";
   document.getElementById("ds-error").style.display = "none";
@@ -720,6 +774,10 @@ function applyDisplay() {
   }
   const msize = parseFloat(document.getElementById("ds-msize").value);
   if (Number.isFinite(msize) && msize > 0 && msize !== MSIZE_DEFAULT) d.msize = msize;
+  for (const key of ["width", "height"]) {
+    const value = parseFloat(document.getElementById("ds-" + key).value);
+    if (Number.isFinite(value) && value > 0) d[key] = value;
+  }
   const colors = S.y.map((name, i) => {
     const input = document.getElementById("ds-color-" + i);
     return input ? input.value : TRACE_COLORS[i];

--- a/GEECS-DataPortal/pyproject.toml
+++ b/GEECS-DataPortal/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-data-portal"
-version = "0.10.0"
+version = "0.11.0"
 description = "Read-only scan-browsing web service: a zero-install browser view over the Tiled catalog and the GEECS data share"
 authors = ["GEECS-BELLA"]
 readme = "README.md"

--- a/GEECS-DataPortal/tests/test_app.py
+++ b/GEECS-DataPortal/tests/test_app.py
@@ -715,6 +715,51 @@ class TestServerFigures:
         assert "agg='mean'" in payload["code"]
         assert "x_values=x_centers" in payload["code"]
 
+    def test_binned_x_reindexes_onto_the_y_bins(self):
+        # The x call's dropna runs over x ALONE — a y column NaN'd for
+        # one scan step (a camera down) drops that bin from the y
+        # result but not from the x result.  Positional zipping would
+        # shift every point one bin over; reindexing pins alignment.
+        catalog = FakeCatalog()
+        detail = _detail(7)
+        detail.data["sig"] = [float("nan"), 20.0, 30.0]
+        catalog.details["uid-007"] = detail
+        payload = (
+            _client(catalog)
+            .get(
+                "/api/run/uid-007/binned",
+                params={
+                    "cols": "sig",
+                    "x": "cam-MaxCounts",
+                    "bincfg": '{"bin_col":"mono"}',
+                },
+            )
+            .json()
+        )
+        assert payload["bins"] == [5.0, 6.0]  # bin 4 dropped (NaN y)
+        assert payload["x_centers"] == [12.5, 11.0]  # aligned, not shifted
+        assert payload["figure"]["data"][0]["x"] == [12.5, 11.0]
+
+    def test_binned_coercible_string_columns_400_not_500(self):
+        # telemetry columns are dtype-tolerant BY DESIGN: they plot in
+        # per-shot view (numeric_series coerces) but bin_frame sees the
+        # raw dtype — refuse honestly, never 500.
+        client = _client()
+        as_x = client.get(
+            "/api/run/uid-002/binned",
+            params={
+                "cols": "cam-MaxCounts",
+                "x": "telemetry_dev-val",
+                "bincfg": '{"bin_col":"mono"}',
+            },
+        )
+        assert as_x.status_code == 400
+        as_y = client.get(
+            "/api/run/uid-002/binned",
+            params={"cols": "telemetry_dev-val", "bincfg": '{"bin_col":"mono"}'},
+        )
+        assert as_y.status_code == 400
+
     def test_binned_without_x_keeps_bin_labels(self):
         payload = (
             _client()

--- a/GEECS-DataPortal/tests/test_app.py
+++ b/GEECS-DataPortal/tests/test_app.py
@@ -659,6 +659,8 @@ class TestServerFigures:
             '{"ghost":1}',
             '{"logy":"yes"}',
             '{"msize":"big"}',
+            '{"width":"big"}',
+            '{"height":NaN}',
             '{"ymin":NaN}',
             '{"colors":"#123456"}',
             '{"colors":[7]}',
@@ -689,6 +691,53 @@ class TestServerFigures:
         assert payload["figure"]["data"][0]["x"] == [1.0, 2.0, 3.0]
         assert payload["figure"]["layout"]["xaxis"]["title"]["text"] == "shot #"
         assert "x=" not in payload["code"]
+
+    def test_binned_x_places_bins_at_per_bin_mean(self):
+        # Identity bins on mono (one shot each) — the per-bin mean of
+        # cam-MaxCounts as X is just its own values, hand-computable.
+        payload = (
+            _client()
+            .get(
+                "/api/run/uid-002/binned",
+                params={
+                    "cols": "cam-MaxCounts",
+                    "x": "cam-MaxCounts",
+                    "bincfg": '{"bin_col":"mono"}',
+                },
+            )
+            .json()
+        )
+        assert payload["x_centers"] == [10.0, 12.5, 11.0]
+        fig = payload["figure"]
+        assert fig["data"][0]["x"] == [10.0, 12.5, 11.0]
+        assert fig["layout"]["xaxis"]["title"]["text"] == "cam : MaxCounts"
+        # The snippet reproduces the placement (replace(cfg, agg='mean')).
+        assert "agg='mean'" in payload["code"]
+        assert "x_values=x_centers" in payload["code"]
+
+    def test_binned_without_x_keeps_bin_labels(self):
+        payload = (
+            _client()
+            .get(
+                "/api/run/uid-002/binned",
+                params={"cols": "cam-MaxCounts", "bincfg": '{"bin_col":"mono"}'},
+            )
+            .json()
+        )
+        assert "x_centers" not in payload
+        assert payload["figure"]["data"][0]["x"] == [4.0, 5.0, 6.0]
+        assert payload["figure"]["layout"]["xaxis"]["title"]["text"] == "mono"
+
+    def test_binned_unplottable_x_is_404(self):
+        response = _client().get(
+            "/api/run/uid-002/binned",
+            params={
+                "cols": "cam-MaxCounts",
+                "x": "cam-label",
+                "bincfg": '{"bin_col":"mono"}',
+            },
+        )
+        assert response.status_code == 404
 
     def test_binned_figure_carries_asymmetric_errors_and_bin_col(self):
         payload = (

--- a/GEECS-DataPortal/tests/test_figures.py
+++ b/GEECS-DataPortal/tests/test_figures.py
@@ -110,6 +110,16 @@ class TestShotsFigure:
         assert fig["data"][0]["marker"]["color"] == TRACE_COLORS[0]
         assert fig["data"][0]["marker"]["size"] == 5.0
 
+    def test_display_dimensions_fix_the_plot_size(self):
+        layout = _fig_dict(
+            shots_figure(SERIES, ["a"], display={"width": 800, "height": 500})
+        )["layout"]
+        assert layout["width"] == 800.0 and layout["height"] == 500.0
+        # Non-positive degrades to responsive autosizing, like every
+        # cosmetic value.
+        bad = _fig_dict(shots_figure(SERIES, ["a"], display={"width": -1}))["layout"]
+        assert "width" not in bad
+
     def test_custom_hex_colors_apply_to_trace_axis_and_title(self):
         fig = _fig_dict(
             shots_figure(SERIES, ["a", "b"], display={"colors": ["#123456"]})
@@ -189,6 +199,27 @@ class TestBinnedFigure:
     def test_missing_column_renders_empty_not_error(self):
         fig = _fig_dict(binned_figure(self.BINS, self.SERIES, ["a", "ghost"]))
         assert fig["data"][1]["y"] == []
+
+    def test_x_values_place_the_bins(self):
+        # Bins GROUP the data; the X parameter PLACES it — per-bin mean
+        # positions replace the bin labels, and the axis is titled for
+        # the X column, not the bin column.
+        fig = _fig_dict(
+            binned_figure(
+                self.BINS,
+                self.SERIES,
+                ["a"],
+                bin_col="Bin #",
+                x_values=[0.95, 1.0, 1.05],
+                x_label="U_S1H Current",
+            )
+        )
+        assert fig["data"][0]["x"] == [0.95, 1.0, 1.05]
+        assert fig["layout"]["xaxis"]["title"]["text"] == "U_S1H Current"
+        # Without x_values the bin labels stay the axis.
+        plain = _fig_dict(binned_figure(self.BINS, self.SERIES, ["a"]))
+        assert plain["data"][0]["x"] == self.BINS
+        assert plain["layout"]["xaxis"]["title"]["text"] == "Bin #"
 
     def test_display_ranges_apply_raw(self):
         layout = _fig_dict(


### PR DESCRIPTION
## What + why

Owner live-feedback round on 0.10.0 (three asks, tested live on `feat/plot-tools`):

1. **Binned view plots against the X pick** (~90 LOC server+figure+snippet): bins still *group* by `bincfg.bin_col`, but each bin *plots at* the per-bin **mean** of the selected X column — real scan-parameter positions instead of bin indices ("bins group, X places"). Implementation is the same primitive twice: a second `bin_frame` with `replace(cfg, value_cols=(x,), agg="mean")`, so the "show the code" snippet mirrors it verbatim. Payload gains `x_centers` (only when `x` given); no `x` keeps bin labels exactly as before. Unplottable `x` 404s (same rule as `/frame`). X error bars deliberately deferred per the owner ("wouldn't make that the first move").
2. **Plot size control** (~30 LOC): `width`/`height` join the display vocabulary — popup inputs, same type-400/value-degrade boundary rules, applied in the shared `_apply_display`. A fixed size fixes the exported image size too.
3. **Copy plot to clipboard** (~60 LOC, client-only): a modebar button exporting the figure at 2× and writing the PNG to the clipboard ("a lot of times we copy paste graphics"). Caveat handled honestly: the async Clipboard API needs a secure context (https/localhost) — on plain-http lab hosts the button degrades to the 2× PNG download with a visible note. Built-in camera download bumped to 2× as well.

## Tests

157 passed (was 152): binned-x endpoint pins (hand-computed mean centers, no-x unchanged, unplottable-x 404, snippet mirror), figure-level x_values/x_label pin, width/height application + 400-ladder additions.

## Hardware verification

Live-verified over VPN against lab Tiled (U_S1H current scan `112e50d7…`, 2026-08-21): binned view plots at the real per-bin currents `[0.94995, 0.97492, 0.99989, 1.02509, 1.05006]` A (was bin indices 1–5), axis titled `U_S1H Current`; the binned snippet **ran verbatim** in the venv and produced a figure element-wise identical to the served one (x/y/error arrays compared). Copy button + size inputs verified present and wired in the browser. OWED: nothing — no scan execution or device I/O.

🤖 Generated with [Claude Code](https://claude.com/claude-code)