### PR TITLE
portal 0.12.0: Images tab per-bin averaged grid (the W2a checkpoint PR)

### DIFF
--- a/GEECS-DataPortal/CHANGELOG.md
+++ b/GEECS-DataPortal/CHANGELOG.md
@@ -18,8 +18,11 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   once after averaging). Both run the same `compute_bin_key` +
   groupby membership call, so the `bin` index is stable between
   listing and render; per-shot refusals carry over (never average a
-  neighbour in: events bound, missed-shot skip, vendor 404), and a
-  bin whose only resolutions were ordinal serves `no-cache`.
+  neighbour in: events bound, missed-shot skip, vendor 404), and a bin
+  containing any native listing-order (ordinal-fallback) resolution
+  serves `no-cache` — the same per-shot rule. `min_count` applies to
+  the grid exactly as `bin_frame` applies it to `/binned` (per-bin row
+  counts), so the shared binset popup governs both tabs.
 - `resources.load_shot_array` (+ `ShotArray`): the tier ladder now
   resolves to raw pixels, with `load_shot_image` reduced to the
   render-one-shot wrapper — single-shot serving and per-bin averaging

--- a/GEECS-DataPortal/CHANGELOG.md
+++ b/GEECS-DataPortal/CHANGELOG.md
@@ -3,6 +3,28 @@
 All notable changes to this package will be documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.12.0] - 2026-09-01
+
+### Added
+
+- **Images tab per-bin averaged grid** (W2a): a per-shot ⇄ per-bin
+  toggle mirroring the Plot tab's ONE URL-carried `view` state (a
+  binned link means binned everywhere — deliberate), rendering a lazy
+  grid of per-bin `nanmean` averages. Two new routes:
+  `/api/run/{uid}/bin-images?device=&filters=&bincfg=` (membership
+  JSON — bins/counts/member shots, notebook-reproducible via its
+  `code` snippet) and `/run/{uid}/bin-image.png?bin=<index>` (one
+  bin's average via the shared `average_frames`, display-windowed
+  once after averaging). Both run the same `compute_bin_key` +
+  groupby membership call, so the `bin` index is stable between
+  listing and render; per-shot refusals carry over (never average a
+  neighbour in: events bound, missed-shot skip, vendor 404), and a
+  bin whose only resolutions were ordinal serves `no-cache`.
+- `resources.load_shot_array` (+ `ShotArray`): the tier ladder now
+  resolves to raw pixels, with `load_shot_image` reduced to the
+  render-one-shot wrapper — single-shot serving and per-bin averaging
+  share one resolution path (and one `ShotDataCache` ride).
+
 ## [0.11.0] - 2026-09-01
 
 ### Added

--- a/GEECS-DataPortal/CLAUDE.md
+++ b/GEECS-DataPortal/CLAUDE.md
@@ -127,10 +127,21 @@ positions are raw seconds too when X is a timestamp column — datetime
 rendering is per-shot-only, deliberately; `x_centers` come reindexed
 onto the y result's bins so diverging per-column dropna can never
 shift points) ·
-`/api/run/{uid}/filter-count?filters=` (live pass count)
+`/api/run/{uid}/filter-count?filters=` (live pass count) ·
+`/api/run/{uid}/bin-images?device=&filters=&bincfg=` (the Images tab's
+per-bin membership: bins/counts/member shots over `compute_bin_key` +
+the same groupby semantics as `/binned`; the `view` URL state is ONE
+per-shot ⇄ binned toggle shared by the Plot and Images tabs —
+deliberate: a binned link means binned everywhere)
 · `/run/{uid}/plot.png?y=&x=` (server-rendered scalar PNG, kept for
 embedding) · `/run/{uid}/image.png?device=&shot=` (one rendered device
-shot) · `/health` (catalog probe — the fleet-map health check).
+shot) · `/run/{uid}/bin-image.png?device=&bin=<index>&filters=&bincfg=`
+(one bin's `nanmean`-averaged device image — `bin` is the INDEX in
+`bin-images` order, both endpoints run the same membership call;
+member shots that resolve to pixels average via the shared
+`average_frames`, windowed once after averaging; per-shot refusals
+carry over, and an ordinal-resolved member downgrades the response to
+`no-cache`) · `/health` (catalog probe — the fleet-map health check).
 Template links build their queries through the one sticky-query helper
 (and the page JS mirrors the analysis state into the stepper links) so
 navigating one control never resets another; the day page's "clear"
@@ -174,7 +185,11 @@ must move in the same PR as any deployment change.
 
 ## The resource viewer (`resources.py`, arc phase 4)
 
-(run, device, shot) → displayable image, per the scope doc's tiering:
+(run, device, shot) → displayable image, per the scope doc's tiering.
+Since 0.12.0 the ladder resolves to raw pixels first
+(`load_shot_array` → `ShotArray`); `load_shot_image` is the
+render-one-shot wrapper over it, and per-bin averaging consumes the
+arrays directly — one resolution path, one cache ride:
 capture HDF5 stacks first (`geecs_data_utils.io.scan_stack` — joined by
 `read_stack_timestamps` + `native_files` millisecond keys against the
 event row's `acq_timestamp`, ScanAnalysis parity; NEVER by frame

--- a/GEECS-DataPortal/geecs_portal/analysis.py
+++ b/GEECS-DataPortal/geecs_portal/analysis.py
@@ -408,6 +408,48 @@ def frame_code(
     )
 
 
+def bin_images_code(
+    uid: str,
+    run_day: Optional[str],
+    device: str,
+    filters: RowFilters,
+    cfg: BinningConfig,
+) -> str:
+    """The notebook snippet reproducing a ``/api/.../bin-images`` response.
+
+    Reproduces the endpoint's NUMBERS exactly (bins, counts, member
+    shots — the same ``compute_bin_key`` + groupby); the pixel side is
+    sketched with the shared ``average_frames`` primitive over the
+    reader layer, since the portal's tier ladder (stack vs native vs
+    vendor) is serving logic, not numerics.
+    """
+    non_default = {
+        f.name: getattr(cfg, f.name)
+        for f in dataclasses.fields(BinningConfig)
+        if getattr(cfg, f.name) != f.default
+    }
+    kwargs = ", ".join(f"{k}={v!r}" for k, v in sorted(non_default.items()))
+    return (
+        "# reproduces this listing exactly — the endpoint calls the same functions\n"
+        + _snippet_prelude(uid, run_day)
+        + _snippet_filters(filters)
+        + "from geecs_data_utils.data.binning import BinningConfig, compute_bin_key\n"
+        + "from geecs_portal.figures import shot_axis_for_frame"
+        + "  # pip install geecs-data-portal\n"
+        + "\n"
+        + f"cfg = BinningConfig({kwargs})\n"
+        + "labels, _ = compute_bin_key(frame, cfg)\n"
+        + "members = shot_axis_for_frame(frame).groupby(\n"
+        + "    labels, dropna=False, observed=True\n"
+        + ").apply(lambda s: sorted({int(v) for v in s.dropna()}))\n"
+        + "members  # per-bin shot lists; counts = members.map(len)\n"
+        + "\n"
+        + "# each grid image = average_frames([...pixels of a bin's shots...])\n"
+        + "# (geecs_data_utils.io: read_imaq_image / scan_stack readers under\n"
+        + f"#  folder / {device!r}), display-windowed once after averaging\n"
+    )
+
+
 def binned_code(
     uid: str,
     run_day: Optional[str],

--- a/GEECS-DataPortal/geecs_portal/app.py
+++ b/GEECS-DataPortal/geecs_portal/app.py
@@ -47,8 +47,9 @@ from starlette.requests import Request
 from starlette.staticfiles import StaticFiles
 
 from geecs_data_utils import tiled_schema as schema_map
-from geecs_data_utils.data.binning import bin_frame
+from geecs_data_utils.data.binning import bin_frame, compute_bin_key
 from geecs_data_utils.data.row_filters import filter_mask
+from geecs_data_utils.io.images import average_frames
 from geecs_data_utils.scan_frame import PROVENANCE_RUN, scan_frame
 from geecs_data_utils.tiled_catalog import (
     ScanCatalog,
@@ -589,6 +590,85 @@ def create_app(catalog: ScanCatalog, *, default_experiment: str = "") -> FastAPI
         _, mask = _masked(pf, filters)
         return {"pass": int(mask.sum()), "total": len(pf.frame)}
 
+    def _bin_groups(pf, mask, bincfg_raw: str):
+        """Per-bin shot membership over the filtered union frame.
+
+        Same primitives and grouping semantics as ``/binned``
+        (``compute_bin_key`` + ``groupby(dropna=False, observed=True,
+        sort)``), so the two endpoints' bin orders agree — and the same
+        code path serves both bin-images endpoints, so a ``bin`` INDEX
+        is stable between the JSON listing and the PNG renders
+        regardless of how labels serialize.
+
+        Returns
+        -------
+        tuple of (BinningConfig, list of (label, list of int))
+            The parsed config and, per bin in group order, the label
+            and the sorted 1-based shot numbers (rows with no shot
+            identity are dropped — no shot number, no image).
+        """
+        try:
+            cfg = analysis.parse_bincfg(bincfg_raw)
+        except analysis.BadParam as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+        frame = pf.frame[mask]
+        try:
+            labels, _ = compute_bin_key(frame, cfg)
+        except KeyError as exc:
+            raise HTTPException(
+                status_code=404, detail=f"no bin column: {exc}"
+            ) from exc
+        except (TypeError, ValueError) as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+        shots = figures.shot_axis_for_frame(frame)
+        groups = [
+            (label, sorted({int(s) for s in group.dropna()}))
+            for label, group in shots.groupby(labels, dropna=False, observed=True)
+        ]
+        return cfg, groups
+
+    def _image_folder(detail, day: str, device: str):
+        """Resolve + validate the (folder, device) pair for image endpoints."""
+        run_day = _run_day(detail, day)
+        folder = resolve_scan_folder(detail, run_day) if run_day else None
+        if folder is None:
+            raise HTTPException(status_code=404, detail="scan folder not resolvable")
+        if device not in resources.image_devices(folder):
+            raise HTTPException(status_code=404, detail=f"unknown device {device!r}")
+        return folder, (run_day.isoformat() if run_day else None)
+
+    @app.get("/api/run/{uid}/bin-images")
+    def api_bin_images(
+        uid: str, device: str = "", filters: str = "", bincfg: str = "", day: str = ""
+    ) -> JSONResponse:
+        """Per-bin membership for the Images tab's averaged grid.
+
+        The JSON carries the numbers (bins, counts, member shots — all
+        notebook-reproducible via the snippet); the pixels are served
+        by ``/run/{uid}/bin-image.png?bin=<index>`` per bin, so the
+        grid lazy-loads exactly like the per-shot gallery.
+        """
+        detail = _load_run(uid)
+        if not device:
+            raise HTTPException(status_code=400, detail="device is required")
+        folder, run_day = _image_folder(detail, day, device)
+        pf = scan_frame(detail, folder)
+        flt, mask = _masked(pf, filters)
+        cfg, groups = _bin_groups(pf, mask, bincfg)
+        bin_labels = analysis.jsonable_labels([label for label, _ in groups])
+        payload = {
+            "device": device,
+            "bin_col": cfg.bin_col,
+            "bins": [
+                {"bin": label, "count": len(shots), "shots": shots}
+                for label, (_, shots) in zip(bin_labels, groups)
+            ],
+            "pass": int(mask.sum()),
+            "total": len(pf.frame),
+            "code": analysis.bin_images_code(uid, run_day, device, flt, cfg),
+        }
+        return JSONResponse(payload, headers=_png_headers(detail))
+
     @app.get("/", response_class=RedirectResponse)
     def index(request: Request) -> str:
         """Redirect to today's day view."""
@@ -865,6 +945,76 @@ def create_app(catalog: ScanCatalog, *, default_experiment: str = "") -> FastAPI
             _png_headers(detail) if result.cacheable else {"Cache-Control": "no-cache"}
         )
         return Response(content=result.png, media_type="image/png", headers=headers)
+
+    @app.get("/run/{uid}/bin-image.png")
+    def run_bin_image(
+        uid: str,
+        device: str,
+        bin_index: int = Query(default=0, alias="bin"),
+        filters: str = "",
+        bincfg: str = "",
+        day: str = "",
+    ) -> Response:
+        """One bin's ``nanmean``-averaged device image, display-rendered.
+
+        ``bin`` is the bin's INDEX in ``/api/.../bin-images`` order
+        (same ``_bin_groups`` call, so the two always agree). Member
+        shots that resolve to pixels are averaged (``average_frames``)
+        and windowed once; shots the device missed (no timestamp) or
+        that fail to load are skipped — the JSON's ``count`` is the
+        membership, the pixels are what actually loaded.
+        """
+        detail = _load_run(uid)
+        folder, _ = _image_folder(detail, day, device)
+        pf = scan_frame(detail, folder)
+        _, mask = _masked(pf, filters)
+        _, groups = _bin_groups(pf, mask, bincfg)
+        if not 0 <= bin_index < len(groups):
+            raise HTTPException(
+                status_code=404, detail=f"bin index {bin_index} of {len(groups)}"
+            )
+        _, shots = groups[bin_index]
+        complete = bool(detail.summary.exit_status)
+        n_rows = None if detail.data is None else len(detail.data)
+        arrays: list = []
+        cacheable = True
+        for shot in shots:
+            # Same refusals as the per-shot endpoint: never fall through
+            # to an ordinal join beyond the recorded events (orphan
+            # frames), never average a neighbour's image in.
+            if n_rows is not None and shot > n_rows:
+                continue
+            acq, column_present = _acq_timestamp(detail, device, shot)
+            if column_present and acq is None:
+                continue  # device missed this shot
+            resolved = resources.load_shot_array(
+                folder,
+                device,
+                shot,
+                acq_timestamp=acq,
+                data_cache=data_cache if complete else None,
+                cache_key=(uid, device) if complete else None,
+            )
+            if resolved.array is None:
+                if resolved.kind in ("vendor", "unrenderable"):
+                    # Device-level refusal — identical for every shot.
+                    raise HTTPException(
+                        status_code=404, detail=resolved.reason or resolved.kind
+                    )
+                continue
+            cacheable = cacheable and resolved.cacheable
+            arrays.append(resolved.array)
+        averaged = average_frames(arrays, label=f"{device} bin {bin_index}")
+        if averaged is None:
+            raise HTTPException(
+                status_code=404, detail="no renderable frames in this bin"
+            )
+        headers = _png_headers(detail) if cacheable else {"Cache-Control": "no-cache"}
+        return Response(
+            content=resources.to_display_png(averaged),
+            media_type="image/png",
+            headers=headers,
+        )
 
     @app.get("/run/{uid}/plot.png")
     def run_plot(uid: str, y: str, x: str = "") -> Response:

--- a/GEECS-DataPortal/geecs_portal/app.py
+++ b/GEECS-DataPortal/geecs_portal/app.py
@@ -595,10 +595,12 @@ def create_app(catalog: ScanCatalog, *, default_experiment: str = "") -> FastAPI
 
         Same primitives and grouping semantics as ``/binned``
         (``compute_bin_key`` + ``groupby(dropna=False, observed=True,
-        sort)``), so the two endpoints' bin orders agree — and the same
-        code path serves both bin-images endpoints, so a ``bin`` INDEX
-        is stable between the JSON listing and the PNG renders
-        regardless of how labels serialize.
+        sort)``, ``min_count`` applied to per-bin ROW counts exactly as
+        ``bin_frame`` does), so the two tabs' bins agree under one
+        shared ``bincfg`` — and the same code path serves both
+        bin-images endpoints, so a ``bin`` INDEX is stable between the
+        JSON listing and the PNG renders regardless of how labels
+        serialize.
 
         Returns
         -------
@@ -624,6 +626,10 @@ def create_app(catalog: ScanCatalog, *, default_experiment: str = "") -> FastAPI
         groups = [
             (label, sorted({int(s) for s in group.dropna()}))
             for label, group in shots.groupby(labels, dropna=False, observed=True)
+            # min_count mirrors bin_frame (row counts, not shot counts):
+            # the binset popup's "min shots / bin" must govern this grid
+            # exactly as it governs the Plot tab's binned view.
+            if cfg.min_count <= 1 or len(group) >= cfg.min_count
         ]
         return cfg, groups
 
@@ -913,10 +919,7 @@ def create_app(catalog: ScanCatalog, *, default_experiment: str = "") -> FastAPI
     def run_image(uid: str, device: str, shot: int = 1, day: str = "") -> Response:
         """One device shot rendered for display (stack or native file)."""
         detail = _load_run(uid)
-        run_day = _run_day(detail, day)
-        folder = resolve_scan_folder(detail, run_day) if run_day else None
-        if folder is None:
-            raise HTTPException(status_code=404, detail="scan folder not resolvable")
+        folder, _ = _image_folder(detail, day, device)
         # A shot beyond the recorded event rows must refuse outright:
         # falling through to the ordinal join would serve an orphan
         # frame (pre/post-scan extras) labeled as a shot that never
@@ -1009,12 +1012,14 @@ def create_app(catalog: ScanCatalog, *, default_experiment: str = "") -> FastAPI
             raise HTTPException(
                 status_code=404, detail="no renderable frames in this bin"
             )
+        try:
+            png = resources.to_display_png(averaged)
+        except Exception as exc:  # noqa: BLE001 — unrenderable shape must not 500
+            raise HTTPException(
+                status_code=404, detail=f"render failed: {exc}"
+            ) from exc
         headers = _png_headers(detail) if cacheable else {"Cache-Control": "no-cache"}
-        return Response(
-            content=resources.to_display_png(averaged),
-            media_type="image/png",
-            headers=headers,
-        )
+        return Response(content=png, media_type="image/png", headers=headers)
 
     @app.get("/run/{uid}/plot.png")
     def run_plot(uid: str, y: str, x: str = "") -> Response:

--- a/GEECS-DataPortal/geecs_portal/resources.py
+++ b/GEECS-DataPortal/geecs_portal/resources.py
@@ -354,9 +354,23 @@ def load_shot_image(
         data_cache=data_cache,
         cache_key=cache_key,
     )
+    png = None
+    if resolved.array is not None:
+        try:
+            png = to_display_png(resolved.array)
+        except Exception as exc:  # noqa: BLE001 — unrenderable shape must not 500
+            # A readable-but-unrenderable array (e.g. a stacked .npy or
+            # an odd-shaped h5 in a dev/scratch folder) degrades to the
+            # missing card, same as a corrupt file always has.
+            return ShotImage(
+                kind="missing",
+                path=resolved.path,
+                reason=f"render failed: {exc}",
+                cacheable=resolved.cacheable,
+            )
     return ShotImage(
         kind=resolved.kind,
-        png=to_display_png(resolved.array) if resolved.array is not None else None,
+        png=png,
         path=resolved.path,
         reason=resolved.reason,
         cacheable=resolved.cacheable,

--- a/GEECS-DataPortal/geecs_portal/resources.py
+++ b/GEECS-DataPortal/geecs_portal/resources.py
@@ -63,6 +63,23 @@ class ShotImage:
     cacheable: bool = True
 
 
+@dataclass(frozen=True)
+class ShotArray:
+    """One resolved shot's raw pixels, or a tiered refusal.
+
+    The array-level result :func:`load_shot_array` returns — consumers
+    that combine shots (per-bin averaging) work on arrays and render
+    once; :func:`load_shot_image` is the render-one-shot wrapper.
+    """
+
+    kind: str  # "stack" | "native" | "vendor" | "unrenderable" | "missing"
+    array: Optional[np.ndarray] = None
+    path: Optional[Path] = None
+    reason: str = ""
+    #: Same contract as :attr:`ShotImage.cacheable`.
+    cacheable: bool = True
+
+
 def image_devices(scan_folder: Path) -> list[str]:
     """Device subfolders of *scan_folder* (read-only listing, sorted).
 
@@ -147,36 +164,36 @@ def _ordinal_native_file(device_dir: Path, ext: str, shot: int) -> Optional[Path
 
 def _stack_shot_from_memory(
     index_map: dict, frames, shot: int, acq_timestamp: Optional[float], path=None
-) -> ShotImage:
-    """Render one shot from cached stack data (no filesystem access)."""
+) -> ShotArray:
+    """Resolve one shot's pixels from cached stack data (no filesystem access)."""
     from geecs_data_utils.io.scan_stack import frame_index_for_timestamp
 
     if acq_timestamp is not None:
         index = frame_index_for_timestamp(index_map, acq_timestamp)
         if index is None:
-            return ShotImage(
+            return ShotArray(
                 kind="missing", path=path, reason="no stack frame for this shot"
             )
     else:
         index = shot - 1
         if not 0 <= index < len(frames):
-            return ShotImage(
+            return ShotArray(
                 kind="missing",
                 path=path,
                 reason=f"stack: shot {shot} outside {len(frames)} frames",
             )
-    return ShotImage(kind="stack", png=to_display_png(frames[index]), path=path)
+    return ShotArray(kind="stack", array=frames[index], path=path)
 
 
-def load_shot_image(
+def load_shot_array(
     scan_folder: Path,
     device: str,
     shot: int,
     acq_timestamp: Optional[float] = None,
     data_cache=None,
     cache_key: Optional[tuple[str, str]] = None,
-) -> ShotImage:
-    """Resolve and render one device shot from an existing scan folder.
+) -> ShotArray:
+    """Resolve one device shot's pixel array from an existing scan folder.
 
     Parameters
     ----------
@@ -205,8 +222,8 @@ def load_shot_image(
 
     Returns
     -------
-    ShotImage
-        Rendered PNG bytes, or the tiered refusal (vendor path /
+    ShotArray
+        The decoded pixels, or the tiered refusal (vendor path /
         missing reason).
     """
     caching = data_cache is not None and cache_key is not None
@@ -218,13 +235,13 @@ def load_shot_image(
             return _stack_shot_from_memory(*stack_hit, shot, acq_timestamp)
         cached = data_cache.native_shot(cache_key, shot)
         if cached is not None:
-            return ShotImage(kind="native", png=to_display_png(cached))
+            return ShotArray(kind="native", array=cached)
 
     kind = device_kind(scan_folder, device)
     if kind.kind == "missing":
-        return ShotImage(kind="missing", reason=kind.reason or "unknown device")
+        return ShotArray(kind="missing", reason=kind.reason or "unknown device")
     if shot < 1:
-        return ShotImage(kind="missing", reason="bad shot")
+        return ShotArray(kind="missing", reason="bad shot")
     device_dir = scan_folder / device
 
     if kind.kind == "stack":
@@ -249,7 +266,7 @@ def load_shot_image(
                 # LabVIEW-epoch double, converted inside the helper.
                 joined = read_shot_for_acq_timestamp(stack, acq_timestamp)
                 if joined is None:
-                    return ShotImage(
+                    return ShotArray(
                         kind="missing",
                         path=stack,
                         reason="no stack frame for this shot",
@@ -257,17 +274,17 @@ def load_shot_image(
                 _, frame = joined
             else:
                 frame = read_shot(stack, shot - 1)
-            return ShotImage(kind="stack", png=to_display_png(frame), path=stack)
+            return ShotArray(kind="stack", array=frame, path=stack)
         # KeyError/TypeError: a malformed-but-schema-valid stack (missing
         # or mistyped /acq_timestamp) — same enumeration ScanAnalysis
         # defends against (PR #693 review); must 404, never 500.
         except (IndexError, KeyError, OSError, TypeError, ValueError) as exc:
-            return ShotImage(kind="missing", path=stack, reason=f"stack: {exc}")
+            return ShotArray(kind="missing", path=stack, reason=f"stack: {exc}")
 
     if kind.kind == "vendor":
-        return ShotImage(kind="vendor", path=kind.path, reason="vendor SDK format")
+        return ShotArray(kind="vendor", path=kind.path, reason="vendor SDK format")
     if kind.kind == "unrenderable":
-        return ShotImage(
+        return ShotArray(
             kind="unrenderable",
             path=kind.path,
             reason=f"no renderer for .{kind.ext}",
@@ -282,7 +299,7 @@ def load_shot_image(
         # A folder that exists but fails the canonical-layout validation
         # (dev/scratch runs, or a share blip between probes) — degrade,
         # never 500.
-        return ShotImage(kind="missing", path=scan_folder, reason=f"layout: {exc}")
+        return ShotArray(kind="missing", path=scan_folder, reason=f"layout: {exc}")
     cacheable = True
     if not native.is_file():
         if acq_timestamp is not None:
@@ -294,7 +311,7 @@ def load_shot_image(
             chosen = _ordinal_native_file(device_dir, ext, shot)
             cacheable = False  # listing-order join: never long-cache
         if chosen is None:
-            return ShotImage(kind="missing", path=native, reason="file not found")
+            return ShotArray(kind="missing", path=native, reason="file not found")
         native = chosen
     try:
         from geecs_data_utils.io.images import read_imaq_image
@@ -304,14 +321,46 @@ def load_shot_image(
             # Never cache an ordinal (listing-order) resolution — the
             # same rule as the no-long-cache header.
             data_cache.store_native_shot(cache_key, shot, array)
-        return ShotImage(
+        return ShotArray(
             kind="native",
-            png=to_display_png(array),
+            array=array,
             path=native,
             cacheable=cacheable,
         )
     except Exception as exc:  # noqa: BLE001 — corrupt file must not 500
-        return ShotImage(kind="missing", path=native, reason=f"read failed: {exc}")
+        return ShotArray(kind="missing", path=native, reason=f"read failed: {exc}")
+
+
+def load_shot_image(
+    scan_folder: Path,
+    device: str,
+    shot: int,
+    acq_timestamp: Optional[float] = None,
+    data_cache=None,
+    cache_key: Optional[tuple[str, str]] = None,
+) -> ShotImage:
+    """Resolve and render one device shot — :func:`load_shot_array` + PNG.
+
+    Same parameters and tier ladder as :func:`load_shot_array` (which
+    carries the full docs); this wrapper only adds the display
+    rendering, so single-shot serving and per-bin averaging share one
+    resolution path.
+    """
+    resolved = load_shot_array(
+        scan_folder,
+        device,
+        shot,
+        acq_timestamp=acq_timestamp,
+        data_cache=data_cache,
+        cache_key=cache_key,
+    )
+    return ShotImage(
+        kind=resolved.kind,
+        png=to_display_png(resolved.array) if resolved.array is not None else None,
+        path=resolved.path,
+        reason=resolved.reason,
+        cacheable=resolved.cacheable,
+    )
 
 
 class DeviceKind(NamedTuple):

--- a/GEECS-DataPortal/geecs_portal/templates/run.html
+++ b/GEECS-DataPortal/geecs_portal/templates/run.html
@@ -86,6 +86,11 @@
   .apply { background: var(--accent); color: #10201d; border: none; border-radius: 3px;
            padding: 0.3rem 0.9rem; font-size: 12px; cursor: pointer; font-weight: 600; }
   .plotmsg { color: var(--dim); font-size: 13px; padding: 2rem 0; text-align: center; }
+  .bingrid { display: grid; grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+             gap: 0.8rem; margin-top: 0.7rem; }
+  .bincard { margin: 0; background: var(--panel); border: 1px solid var(--line);
+             border-radius: 4px; padding: 0.4rem; }
+  .bincard figcaption { font-size: 11px; padding-top: 0.3rem; text-align: center; }
 </style>
 <script src="{{ root }}/static/plotly-cartesian-3.1.1.min.js"></script>
 {% endblock %}
@@ -191,6 +196,14 @@
       render (trace/array data, not an image). Files live at:</p>
       <p class="mono">{{ kind_path }}</p>
       {% else %}
+      <div class="plotbar">
+        <span class="seg">
+          <button id="seg-img-shot" onclick="setView('shot')">per-shot</button>
+          <button id="seg-img-bin" onclick="setView('bin')">per-bin avg</button>
+        </span>
+        <span class="gear" title="bin settings" onclick="openBinset()">⚙</span>
+      </div>
+      <div id="imgshot">
       <form class="nav" method="get" action="{{ root }}/run/{{ uid }}">
         <input type="hidden" name="device" value="{{ sel_device }}">
         <input type="hidden" name="day" value="{{ day }}">
@@ -207,6 +220,8 @@
         <span class="dim mono">{{ kind }}</span>
       </form>
       <img class="plot" src="{{ root }}/run/{{ uid }}/image.png?device={{ sel_device | urlencode }}&amp;shot={{ shot }}&amp;day={{ day | urlencode }}" alt="{{ sel_device }} shot {{ shot }}">
+      </div>
+      <div id="imggrid" class="bingrid" hidden></div>
       {% endif %}
       {% else %}
       <p class="dim">Pick a device above.</p>
@@ -313,6 +328,8 @@
 const UID = {{ uid | tojson }};
 const ROOT = {{ root | tojson }};  // proxy mount prefix ("" at root)
 const DAY = {{ day | tojson }};
+const SEL_DEVICE = {{ sel_device | tojson }};
+const VERSION = {{ portal_version | tojson }};
 const TRACE_COLORS = {{ trace_colors | tojson }};
 const MSIZE_DEFAULT = {{ msize_default | tojson }};
 // Everything Plotly gives for free, switched ON: wheel zoom, in-place
@@ -458,14 +475,65 @@ function setTab(tab) {
   document.querySelectorAll(".pane").forEach(pane => pane.classList.toggle("on", pane.id === "pane-" + tab));
   writeState();
   if (tab === "plot") refresh();
+  refreshImages();
 }
 
 function setView(view) {
+  // ONE per-shot ⇄ binned state, deliberately shared by the Plot and
+  // Images tabs (the link IS the analysis: a binned link means binned
+  // everywhere) — both segmented controls mirror it.
   S.view = view;
   document.getElementById("seg-shot").classList.toggle("on", view === "shot");
   document.getElementById("seg-bin").classList.toggle("on", view === "bin");
+  const imgSeg = document.getElementById("seg-img-shot");
+  if (imgSeg) {
+    imgSeg.classList.toggle("on", view === "shot");
+    document.getElementById("seg-img-bin").classList.toggle("on", view === "bin");
+  }
   writeState();
   refresh();
+  refreshImages();
+}
+
+// ---------------- the images tab's per-bin grid ----------------
+let IMG_KEY = null;  // last-rendered grid params — skip redundant refetches
+
+function refreshImages() {
+  const shotBox = document.getElementById("imgshot");
+  const grid = document.getElementById("imggrid");
+  if (!shotBox || !SEL_DEVICE) return;  // no device / vendor / unrenderable
+  const binned = S.view === "bin";
+  shotBox.hidden = binned;
+  grid.hidden = !binned;
+  if (!binned || S.tab !== "images") return;
+  const key = JSON.stringify([SEL_DEVICE, S.filters, S.bincfg]);
+  if (key === IMG_KEY) return;
+  IMG_KEY = key;  // set before the fetch: dedupes the boot's setTab+setView pair
+  const params = new URLSearchParams({ device: SEL_DEVICE });
+  if (S.filters) params.set("filters", S.filters);
+  if (S.bincfg) params.set("bincfg", S.bincfg);
+  grid.innerHTML = `<div class="plotmsg">loading bins…</div>`;
+  api("bin-images", params).then(data => {
+    if (!data.bins.length) {
+      grid.innerHTML = `<div class="plotmsg">no bins (check filters / bin column)</div>`;
+      return;
+    }
+    grid.innerHTML = data.bins.map((b, i) => {
+      const q = new URLSearchParams({ device: SEL_DEVICE, bin: i, v: VERSION });
+      if (S.filters) q.set("filters", S.filters);
+      if (S.bincfg) q.set("bincfg", S.bincfg);
+      if (DAY) q.set("day", DAY);
+      const label = b.bin === null ? "—" : String(b.bin);
+      return `<figure class="bincard">
+        <img class="plot" loading="lazy" src="${ROOT}/run/${UID}/bin-image.png?${q.toString()}"
+             alt="${escAttr(data.bin_col)} ${escAttr(label)}">
+        <figcaption class="dim mono">${esc(data.bin_col)}: ${esc(label)} · n=${b.count}</figcaption>
+      </figure>`;
+    }).join("");
+  }).catch(err => {
+    IMG_KEY = null;
+    grid.innerHTML = `<div class="plotmsg">${esc(err.message)}</div>`;
+  });
 }
 
 // ---------------- column picker ----------------
@@ -626,7 +694,7 @@ function renderChips() {
 function setFilters(model) {
   const active = (model.groups || []).length;
   S.filters = active || model.nan_policy !== "exclude" ? JSON.stringify(model) : "";
-  renderChips(); writeState(); updatePassCount(); refresh();
+  renderChips(); writeState(); updatePassCount(); refresh(); refreshImages();
 }
 
 function toggleGroup(i, on) {
@@ -740,7 +808,7 @@ function applyBinset() {
   if (Number.isFinite(minCount) && minCount > 1) cfg.min_count = minCount;
   S.bincfg = Object.keys(cfg).length ? JSON.stringify(cfg) : "";
   closeModals(); writeState();
-  if (S.view !== "bin") setView("bin"); else refresh();
+  if (S.view !== "bin") setView("bin"); else { refresh(); refreshImages(); }
 }
 
 // ---------------- display settings popup ----------------

--- a/GEECS-DataPortal/geecs_portal/templates/run.html
+++ b/GEECS-DataPortal/geecs_portal/templates/run.html
@@ -514,6 +514,7 @@ function refreshImages() {
   if (S.bincfg) params.set("bincfg", S.bincfg);
   grid.innerHTML = `<div class="plotmsg">loading bins…</div>`;
   api("bin-images", params).then(data => {
+    if (key !== IMG_KEY) return;  // superseded in flight — never render stale bins
     if (!data.bins.length) {
       grid.innerHTML = `<div class="plotmsg">no bins (check filters / bin column)</div>`;
       return;
@@ -527,10 +528,11 @@ function refreshImages() {
       return `<figure class="bincard">
         <img class="plot" loading="lazy" src="${ROOT}/run/${UID}/bin-image.png?${q.toString()}"
              alt="${escAttr(data.bin_col)} ${escAttr(label)}">
-        <figcaption class="dim mono">${esc(data.bin_col)}: ${esc(label)} · n=${b.count}</figcaption>
+        <figcaption class="dim mono" title="n counts member shots passing filters — frames the device missed or that fail to load are skipped in the average">${esc(data.bin_col)}: ${esc(label)} · n=${b.count}</figcaption>
       </figure>`;
     }).join("");
   }).catch(err => {
+    if (key !== IMG_KEY) return;
     IMG_KEY = null;
     grid.innerHTML = `<div class="plotmsg">${esc(err.message)}</div>`;
   });

--- a/GEECS-DataPortal/pyproject.toml
+++ b/GEECS-DataPortal/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-data-portal"
-version = "0.11.0"
+version = "0.12.0"
 description = "Read-only scan-browsing web service: a zero-install browser view over the Tiled catalog and the GEECS data share"
 authors = ["GEECS-BELLA"]
 readme = "README.md"

--- a/GEECS-DataPortal/tests/test_resources.py
+++ b/GEECS-DataPortal/tests/test_resources.py
@@ -456,3 +456,122 @@ class TestUnionColumns:
         client = _gallery_client(scan_folder)
         assert client.get("/api/run/uid-002/columns").status_code == 200
         assert _tree_snapshot(scan_folder.parent.parent) == before
+
+
+class TestBinImages:
+    """The Images tab's per-bin endpoints: membership JSON + averaged PNGs."""
+
+    _FILTERS = (
+        '{"groups":[{"conditions":'
+        '[{"column":"cam-MaxCounts","low":10.5,"high":13.0}]}]}'
+    )
+
+    def _client(self, scan_folder, bins=(1, 1, 2)):
+        catalog = FakeCatalog()
+        detail = _detail(2)
+        detail.start_doc["scan_folder"] = str(scan_folder)
+        detail.data["Bin #"] = list(bins)  # the default bincfg bin column
+        # Companion column so the stack device joins by TIMESTAMP (the
+        # leading pre-scan extra frame must not shift the average).
+        detail.data["UC_StackCam-acq_timestamp"] = [_LV + 1.0, _LV + 2.0, _LV + 3.0]
+        catalog.details["uid-002"] = detail
+        return TestClient(create_app(catalog))
+
+    def test_membership_json_counts_and_order(self, scan_folder):
+        response = self._client(scan_folder).get(
+            "/api/run/uid-002/bin-images", params={"device": "cam"}
+        )
+        assert response.status_code == 200
+        payload = response.json()
+        assert payload["bin_col"] == "Bin #"
+        assert [(b["bin"], b["count"], b["shots"]) for b in payload["bins"]] == [
+            (1, 2, [1, 2]),
+            (2, 1, [3]),
+        ]
+        assert "compute_bin_key" in payload["code"]
+        assert "immutable" in response.headers["cache-control"]
+
+    def test_bin_average_is_the_nanmean_of_member_shots(self, scan_folder):
+        client = self._client(scan_folder)
+        response = client.get(
+            "/run/uid-002/bin-image.png", params={"device": "cam", "bin": 0}
+        )
+        assert response.status_code == 200
+        decoded = np.array(Image.open(io.BytesIO(response.content)))
+        # cam shots carry an identity marker at [0, shot]; the bin-0
+        # average (shots 1+2) holds both markers at HALF intensity —
+        # equal after windowing, and nothing else lights up.
+        assert decoded[0, 1] == decoded[0, 2] == 255
+        rest = decoded.copy()
+        rest[0, 1] = rest[0, 2] = 0
+        assert not rest.any()
+
+    def test_single_shot_bin_renders_that_shot(self, scan_folder):
+        response = self._client(scan_folder).get(
+            "/run/uid-002/bin-image.png", params={"device": "cam", "bin": 1}
+        )
+        decoded = np.array(Image.open(io.BytesIO(response.content)))
+        assert decoded[0, 3] == 255
+        rest = decoded.copy()
+        rest[0, 3] = 0
+        assert not rest.any()
+
+    def test_filters_narrow_membership_and_pixels(self, scan_folder):
+        client = self._client(scan_folder)
+        payload = client.get(
+            "/api/run/uid-002/bin-images",
+            params={"device": "cam", "filters": self._FILTERS},
+        ).json()
+        # cam-MaxCounts >= 10.5 keeps shots 2 and 3 only.
+        assert [(b["bin"], b["shots"]) for b in payload["bins"]] == [
+            (1, [2]),
+            (2, [3]),
+        ]
+        response = client.get(
+            "/run/uid-002/bin-image.png",
+            params={"device": "cam", "bin": 0, "filters": self._FILTERS},
+        )
+        decoded = np.array(Image.open(io.BytesIO(response.content)))
+        assert decoded[0, 2] == 255  # shot 2's marker — shot 1 filtered OUT
+        rest = decoded.copy()
+        rest[0, 2] = 0
+        assert not rest.any()
+
+    def test_stack_device_bins_average_too(self, scan_folder):
+        response = self._client(scan_folder).get(
+            "/run/uid-002/bin-image.png", params={"device": "UC_StackCam", "bin": 0}
+        )
+        assert response.status_code == 200
+        decoded = np.array(Image.open(io.BytesIO(response.content)))
+        # Stack frames 1+2 join shots 1+2 by timestamp (the leading
+        # pre-scan extra frame 0 must NOT shift into the average).
+        assert decoded[0, 1] == decoded[0, 2] == 255
+        assert decoded[0, 0] == 0
+
+    def test_error_ladder(self, scan_folder):
+        client = self._client(scan_folder)
+        api = "/api/run/uid-002/bin-images"
+        png = "/run/uid-002/bin-image.png"
+        assert client.get(api).status_code == 400  # device required
+        assert client.get(api, params={"device": "nope"}).status_code == 404
+        assert (
+            client.get(api, params={"device": "cam", "bincfg": "notjson"}).status_code
+            == 400
+        )
+        assert (
+            client.get(
+                api, params={"device": "cam", "bincfg": '{"bin_col": "nope"}'}
+            ).status_code
+            == 404
+        )
+        assert client.get(png, params={"device": "cam", "bin": 5}).status_code == 404
+        vendor = client.get(png, params={"device": "U_HasoWFS", "bin": 0})
+        assert vendor.status_code == 404  # vendor tier: path card, never pixels
+
+    def test_bin_endpoints_touch_nothing(self, scan_folder):
+        client = self._client(scan_folder)
+        before = _tree_snapshot(scan_folder)
+        client.get("/api/run/uid-002/bin-images", params={"device": "cam"})
+        client.get("/run/uid-002/bin-image.png", params={"device": "cam", "bin": 0})
+        client.get("/run/uid-002/bin-image.png", params={"device": "nope", "bin": 0})
+        assert _tree_snapshot(scan_folder) == before

--- a/GEECS-DataPortal/tests/test_resources.py
+++ b/GEECS-DataPortal/tests/test_resources.py
@@ -575,3 +575,86 @@ class TestBinImages:
         client.get("/run/uid-002/bin-image.png", params={"device": "cam", "bin": 0})
         client.get("/run/uid-002/bin-image.png", params={"device": "nope", "bin": 0})
         assert _tree_snapshot(scan_folder) == before
+
+
+class TestBinImagesReviewPins:
+    """736 review pins: min_count parity, cache downgrades, render guard."""
+
+    def test_min_count_governs_the_grid_like_binned(self, scan_folder):
+        client = TestBinImages()._client(scan_folder)
+        payload = client.get(
+            "/api/run/uid-002/bin-images",
+            params={"device": "cam", "bincfg": '{"min_count": 2}'},
+        ).json()
+        # Bin 2 has one row — dropped, exactly as bin_frame drops it in
+        # /binned (the shared binset popup must govern both tabs).
+        assert [(b["bin"], b["shots"]) for b in payload["bins"]] == [(1, [1, 2])]
+        response = client.get(
+            "/run/uid-002/bin-image.png",
+            params={"device": "cam", "bin": 0, "bincfg": '{"min_count": 2}'},
+        )
+        decoded = np.array(Image.open(io.BytesIO(response.content)))
+        assert decoded[0, 1] == decoded[0, 2] == 255  # still bin {1,2}'s average
+
+    def test_ordinal_member_downgrades_cache_timestamp_join_does_not(self, scan_folder):
+        # cam2: timestamp-named files but NO event acq column → every
+        # member resolves by listing order → the response must not be
+        # long-cached (SMB listing blips can shift the join).
+        cam2 = scan_folder / "cam2"
+        cam2.mkdir()
+        for shot in (1, 2, 3):
+            arr = np.zeros((5, 5), dtype=np.uint16)
+            arr[0, shot] = 1000
+            Image.fromarray(arr).save(cam2 / f"cam2_{_LV + float(shot):.3f}.png")
+        client = TestBinImages()._client(scan_folder)
+        ordinal = client.get(
+            "/run/uid-002/bin-image.png", params={"device": "cam2", "bin": 0}
+        )
+        assert ordinal.status_code == 200
+        assert ordinal.headers["cache-control"] == "no-cache"
+        joined = client.get(
+            "/run/uid-002/bin-image.png", params={"device": "cam", "bin": 0}
+        )
+        assert "immutable" in joined.headers["cache-control"]
+
+    def test_running_run_serves_no_cache(self, scan_folder):
+        from geecs_data_utils.tiled_catalog import RunDetail, summary_from_metadata
+
+        catalog = FakeCatalog()
+        base = _detail(2)
+        base.start_doc["scan_folder"] = str(scan_folder)
+        base.data["Bin #"] = [1, 1, 2]
+        running = RunDetail(
+            summary=summary_from_metadata(base.start_doc["uid"], base.start_doc, None),
+            start_doc=base.start_doc,
+            stop_doc=None,
+            data=base.data,
+        )
+        catalog.details["uid-002"] = running
+        client = TestClient(create_app(catalog))
+        listing = client.get("/api/run/uid-002/bin-images", params={"device": "cam"})
+        assert listing.headers["cache-control"] == "no-cache"
+        png = client.get(
+            "/run/uid-002/bin-image.png", params={"device": "cam", "bin": 0}
+        )
+        assert png.status_code == 200
+        assert png.headers["cache-control"] == "no-cache"
+
+    def test_unrenderable_array_degrades_never_raises(self, scan_folder):
+        # A readable h5 whose /image is 4-D: the tier ladder loads it,
+        # the display render cannot — must degrade to the missing card
+        # (and the endpoint to 404), never a 500.
+        import h5py
+
+        odd = scan_folder / "U_OddH5"
+        odd.mkdir()
+        with h5py.File(odd / f"U_OddH5_{_LV + 1.0:.3f}.h5", "w") as handle:
+            handle.create_dataset("image", data=np.zeros((2, 3, 4, 5), dtype="u2"))
+        result = resources.load_shot_image(scan_folder, "U_OddH5", 1)
+        assert result.kind == "missing"
+        assert "render failed" in result.reason
+        client = TestBinImages()._client(scan_folder)
+        response = client.get(
+            "/run/uid-002/image.png", params={"device": "U_OddH5", "shot": 1}
+        )
+        assert response.status_code == 404


### PR DESCRIPTION
Second PR of the **W2a Images-tab arc** — the tab feature itself, and **the architecture checkpoint**: the doctrine says W2a must be dramatically cheaper than W1d or we stop and fix seams. Verdict below.

## What it adds (portal 0.9.1→0.11.0 was plot-tools; this is 0.11.0 → 0.12.0)

**The Images tab gains a per-shot ⇄ per-bin toggle** (the same URL-carried `view` state as the Plot tab — deliberate judgment call, cheap to veto: one binned⇄per-shot state for the whole analysis, "a binned link means binned everywhere"). Per-bin view renders a lazy grid of `nanmean`-averaged device images, one card per bin with `bin_col: label · n=count` captions.

Per the adding-a-tab checklist:

1. **Primitives** (already landed in #735): `average_frames`, plus this PR's `compute_bin_key` reuse — no new math anywhere in the portal.
2. **Endpoints** (~150 LOC in `app.py`):
   - `/api/run/{uid}/bin-images?device=&filters=&bincfg=` — membership JSON (bins, counts, member shots) over `compute_bin_key` + the same `groupby(dropna=False, observed=True)` semantics as `/binned`; carries a `code` snippet reproducing the numbers exactly (the pixel side is a sketch — the tier ladder is serving logic, not numerics).
   - `/run/{uid}/bin-image.png?device=&bin=<index>&filters=&bincfg=` — one bin's average, display-windowed once *after* averaging. `bin` is the index in `bin-images` order; both endpoints run the identical membership call, so the index is stable regardless of label serialization. Per-shot refusals carry over: events-bound guard, missed-shot (no timestamp) skip, vendor/unrenderable 404 — **never average a neighbour's image in**; any ordinal-resolved member downgrades the response to `no-cache`.
3. **Resource layer** (~70 LOC moved, not added): `load_shot_image` split into `load_shot_array` (`ShotArray` — the tier ladder resolving to raw pixels, riding `ShotDataCache` exactly as before) + a thin PNG wrapper. Averaging must precede windowing, so the array level is the natural seam; single-shot serving is unchanged (pinned by the untouched 34 pre-existing resource tests).
4. **Tab** (~90 LOC template/JS): segmented toggle + lazy `<img>` grid, prefix-agnostic URLs via `ROOT`, boot-deduped fetch, filter/binset applies refresh the grid; all state URL-carried.
5. **Tests**: 7 new in `tests/test_resources.py::TestBinImages` — hand-computed averaged pixels (identity markers at half intensity, native + stack devices; the stack case pins that the leading pre-scan extra frame stays OUT of the average via the timestamp join), filters narrowing membership and pixels, the 400/404 ladder, immutable headers, tree-untouched invariant.

## The checkpoint verdict

W1d (#722) was ~2,600 added lines building the rail, three tabs, four endpoints, the vendored renderer, and the URL-state machinery. **W2a's tab feature is ~430 added lines** (including tests and docs), containing zero new numerics, zero new parsing vocabulary, and zero new rendering machinery — every piece composed from existing primitives (`compute_bin_key`, `average_frames`, `shot_axis_for_frame`, the tier ladder, `parse_filters`/`parse_bincfg`, `_png_headers`, the sticky URL state). The checklist held; the seams are earning their keep.

## Testing

Portal suite: **166 passed** (was 159; 7 new). Read-only view layer, no hardware verification owed. Live .14 verification happens at the arc's promotion per the settled staging strategy.

Adversarial review to follow as a PR comment before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)