### PR TITLE
portal 0.13.1: CI installs the analysis extra; processing tests importorskip (the #737 CI-red fix)

### DIFF
--- a/.claude/skills/env-doctor/SKILL.md
+++ b/.claude/skills/env-doctor/SKILL.md
@@ -50,6 +50,7 @@ diagnose the package the current task is about.
    | `GEECS-Core` | `poetry install` (self-contained) |
    | `GEECS-Console` | `poetry install` (the optimization stack is worker-side — no console extra) |
    | `GEECS-LogTriage` | `poetry install` |
+   | `GEECS-DataPortal` | `poetry install --extras analysis` (the processing-selector test class importorskips `image_analysis` without it) |
 
    Symptom of missing `ca`: the whole GeecsBluesky mock-device test layer
    collects as "1 skipped" (`pytest.importorskip("aioca")`).

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -37,7 +37,10 @@ jobs:
 
       - name: Install GEECS-DataPortal dependencies
         working-directory: GEECS-DataPortal
-        run: poetry install --with dev
+        # --extras analysis: the Images tab's processing-selector tests
+        # (TestProcessingSelector) importorskip image_analysis and would
+        # silently skip without it (the #737 CI-red lesson, 2026-09-01).
+        run: poetry install --with dev --extras analysis
 
       - name: Run GEECS-DataPortal tests
         working-directory: GEECS-DataPortal

--- a/GEECS-DataPortal/CHANGELOG.md
+++ b/GEECS-DataPortal/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this package will be documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.13.1] - 2026-09-01
+
+### Fixed
+
+- The processing-selector test class now `importorskip`s
+  `image_analysis`, and CI installs the portal with
+  `--extras analysis` so those tests always **run** there (they
+  failed red in the 0.13.0 CI, whose env lacked the extra; a minimal
+  local env now skips them gracefully instead). Test/CI-only — no
+  runtime change.
+
 ## [0.13.0] - 2026-09-01
 
 ### Added

--- a/GEECS-DataPortal/pyproject.toml
+++ b/GEECS-DataPortal/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-data-portal"
-version = "0.13.0"
+version = "0.13.1"
 description = "Read-only scan-browsing web service: a zero-install browser view over the Tiled catalog and the GEECS data share"
 authors = ["GEECS-BELLA"]
 readme = "README.md"

--- a/GEECS-DataPortal/tests/test_resources.py
+++ b/GEECS-DataPortal/tests/test_resources.py
@@ -664,11 +664,19 @@ class TestProcessingSelector:
     """The ephemeral-processing selector: write-free pipeline over served pixels."""
 
     @pytest.fixture()
-    def configs_tree(self, tmp_path):
-        # The whole class needs the `analysis` extra (image_analysis):
-        # skip gracefully in a minimal env — CI installs the extra, so
-        # there these tests always RUN (never silently skip).
+    def analysis_extra(self):
+        """Skip in a minimal env — only for tests that IMPORT the extra.
+
+        CI installs the extra so these always run there. Deliberately
+        NOT on ``configs_tree``: the missing-extra degradation test and
+        the raw-serving test must stay live in a truly extra-less env
+        (they passed in #737's extra-less CI — the guard must not
+        retire that real coverage).
+        """
         pytest.importorskip("image_analysis")
+
+    @pytest.fixture()
+    def configs_tree(self, tmp_path):
         import yaml
 
         tree = tmp_path / "proc_configs"
@@ -743,7 +751,9 @@ class TestProcessingSelector:
         catalog.details["uid-002"] = detail
         return TestClient(create_app(catalog, processing_config_dir=configs_tree))
 
-    def test_per_shot_processing_applies_the_pipeline(self, scan_folder, configs_tree):
+    def test_per_shot_processing_applies_the_pipeline(
+        self, scan_folder, configs_tree, analysis_extra
+    ):
         response = self._client(scan_folder, configs_tree).get(
             "/run/uid-002/image.png",
             params={"device": "cam", "shot": 1, "processing": "UC_Crop"},
@@ -759,7 +769,7 @@ class TestProcessingSelector:
         assert not rest.any()
 
     def test_bin_average_processes_each_shot_then_averages(
-        self, scan_folder, configs_tree
+        self, scan_folder, configs_tree, analysis_extra
     ):
         response = self._client(scan_folder, configs_tree).get(
             "/run/uid-002/bin-image.png",
@@ -775,7 +785,9 @@ class TestProcessingSelector:
         rest[0, 0] = rest[0, 1] = 0
         assert not rest.any()
 
-    def test_bin_average_order_is_process_then_average(self, scan_folder, configs_tree):
+    def test_bin_average_order_is_process_then_average(
+        self, scan_folder, configs_tree, analysis_extra
+    ):
         """A NONLINEAR step distinguishes the order (the crop test alone
         cannot: crop commutes with averaging). Threshold 600 sits between
         the raw marker (1000) and the averaged marker (500): only
@@ -790,7 +802,9 @@ class TestProcessingSelector:
         decoded = np.array(Image.open(io.BytesIO(response.content)))
         assert decoded[0, 0] == decoded[0, 1] == 255
 
-    def test_processed_responses_never_cache_immutable(self, scan_folder, configs_tree):
+    def test_processed_responses_never_cache_immutable(
+        self, scan_folder, configs_tree, analysis_extra
+    ):
         """The diagnostic YAML is a mutable input the URL does not key —
         an edited config must show on reload, on every viewer, even
         behind a caching reverse proxy (completed run or not).
@@ -809,7 +823,9 @@ class TestProcessingSelector:
         raw = client.get("/run/uid-002/image.png", params={"device": "cam", "shot": 1})
         assert "immutable" in raw.headers["cache-control"]  # raw path unchanged
 
-    def test_selector_rendered_only_with_configs(self, scan_folder, configs_tree):
+    def test_selector_rendered_only_with_configs(
+        self, scan_folder, configs_tree, analysis_extra
+    ):
         with_configs = self._client(scan_folder, configs_tree).get(
             "/run/uid-002", params={"device": "cam", "tab": "images"}
         )
@@ -820,7 +836,7 @@ class TestProcessingSelector:
         )
         assert "procsel" not in without.text
 
-    def test_processing_error_ladder(self, scan_folder, configs_tree):
+    def test_processing_error_ladder(self, scan_folder, configs_tree, analysis_extra):
         client = self._client(scan_folder, configs_tree)
         unknown = client.get(
             "/run/uid-002/image.png",

--- a/GEECS-DataPortal/tests/test_resources.py
+++ b/GEECS-DataPortal/tests/test_resources.py
@@ -665,6 +665,10 @@ class TestProcessingSelector:
 
     @pytest.fixture()
     def configs_tree(self, tmp_path):
+        # The whole class needs the `analysis` extra (image_analysis):
+        # skip gracefully in a minimal env — CI installs the extra, so
+        # there these tests always RUN (never silently skip).
+        pytest.importorskip("image_analysis")
         import yaml
 
         tree = tmp_path / "proc_configs"


### PR DESCRIPTION
**Fixes the red `unit-tests` on `feat/images-tab`.** #737's `TestProcessingSelector` failed in CI because the workflow installs the portal with plain `poetry install --with dev` — no `analysis` extra, so `image_analysis` wasn't importable there and the six processing tests 404'd. My local runs had the extra installed, and the merge slipped past the red check because my CI watch was piped through `tail`, which discarded the failing exit status — a process error on my side, corrected (checks are now verified by exit code before any merge).

The fix, per the GeecsBluesky extras precedent (its workflow comment documents the same lesson from 2026-08-21):

- **Workflow**: the portal install step gains `--extras analysis`, with a comment naming the importorskip it guards — in CI these tests always **run**, never silently skip.
- **Tests**: `TestProcessingSelector`'s shared fixture gains `pytest.importorskip("image_analysis")`, so a minimal local env skips gracefully instead of failing.
- **/env-doctor**: the extras table gains the `GEECS-DataPortal` row.
- Portal 0.13.1 (test/CI-only patch, CHANGELOG entry).

Suite locally (with extra): 178 passed — the guard no-ops. The real verification is this PR's own CI run, which now exercises the previously failing path with the extra installed.

Review note: this is a 5-file test/CI patch reverting no behavior; per the /land ritual a fresh-context review still runs and its report lands as a comment before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)