### PR TITLE
portal 0.14.0: loadable-only selector + in-place image error surfacing (Sam's first live test)

### DIFF
--- a/GEECS-DataPortal/CHANGELOG.md
+++ b/GEECS-DataPortal/CHANGELOG.md
@@ -3,6 +3,25 @@
 All notable changes to this package will be documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.14.0] - 2026-09-01
+
+### Fixed
+
+Sam's first live test of the selector (Amp4, 2026-09-01) — the
+diagnostic YAML was a legacy flat camera config, and the failure was
+invisible:
+
+- **The selector now offers only LOADABLE diagnostics**: each
+  discovered stem is validated with a real `load_diagnostic` (cached
+  against the tree's YAML mtimes), and an unloadable legacy config is
+  an INFO log line naming the file — never a pickable entry that can
+  only produce a broken image. A hand-edited URL still gets the
+  honest 400.
+- **Image failures surface their reason**: the per-shot image and
+  every bin card carry an `onerror` hook that fetches the endpoint's
+  4xx `detail` and shows it in place of the browser's broken-image
+  icon (cleared on the next processing change).
+
 ## [0.13.1] - 2026-09-01
 
 ### Fixed

--- a/GEECS-DataPortal/geecs_portal/app.py
+++ b/GEECS-DataPortal/geecs_portal/app.py
@@ -656,25 +656,62 @@ def create_app(
             raise HTTPException(status_code=404, detail=f"unknown device {device!r}")
         return folder, (run_day.isoformat() if run_day else None)
 
+    # (fingerprint → valid names): re-validated only when the tree
+    # changes — discovery lists every YAML stem, but legacy flat camera
+    # configs in the same tree don't LOAD as diagnostics, and offering
+    # one puts an unfixable broken image in front of the operator
+    # (found live: UNCLASSIFIED/UC_Amp4_IR_input.yaml, 2026-09-01).
+    processing_cache: dict = {}
+
     def _processing_names() -> list[str]:
-        """Diagnostic IDs for the processing selector (``[]`` = hidden).
+        """LOADABLE diagnostic IDs for the processing selector (``[]`` = hidden).
 
         Explicit-opt-in: no configured tree, no feature (never the
         global fallback). Degrades to empty — never errors a page —
         when the ``analysis`` extra is not installed or the tree
-        cannot be listed.
+        cannot be listed. Each discovered stem is validated with a
+        real ``load_diagnostic`` (cached against the tree's YAML
+        mtimes); invalid ones are dropped with an INFO log naming the
+        file, so a legacy config is a log line, not a broken image.
         """
         if processing_config_dir is None:
             return []
         try:
-            from image_analysis.config import list_diagnostics
+            from image_analysis.config import list_diagnostics, load_diagnostic
         except ImportError:
             return []
         try:
-            return list_diagnostics(config_dir=processing_config_dir)
+            names = list_diagnostics(config_dir=processing_config_dir)
         except Exception as exc:  # noqa: BLE001 — unlistable tree = no selector
             logger.debug("processing configs unavailable: %s", exc)
             return []
+        tree = Path(processing_config_dir) / "analyzers"
+        try:
+            fingerprint = frozenset(
+                (str(path), path.stat().st_mtime)
+                for pattern in ("*.yaml", "*.yml")
+                for path in tree.rglob(pattern)
+            )
+        except OSError:
+            fingerprint = None
+        if fingerprint is not None and fingerprint in processing_cache:
+            return processing_cache[fingerprint]
+        valid = []
+        for name in names:
+            try:
+                load_diagnostic(name, config_dir=processing_config_dir)
+                valid.append(name)
+            except Exception as exc:  # noqa: BLE001 — one bad YAML must not hide the rest
+                logger.info(
+                    "processing selector: skipping %r — not a loadable "
+                    "unified diagnostic (%s)",
+                    name,
+                    exc,
+                )
+        if fingerprint is not None:
+            processing_cache.clear()  # one entry: the current tree state
+            processing_cache[fingerprint] = valid
+        return valid
 
     def _apply_processing(arrays: list, processing: str) -> list:
         """Ephemeral-process *arrays* → the analyzers' processed images.

--- a/GEECS-DataPortal/geecs_portal/app.py
+++ b/GEECS-DataPortal/geecs_portal/app.py
@@ -680,22 +680,28 @@ def create_app(
             from image_analysis.config import list_diagnostics, load_diagnostic
         except ImportError:
             return []
-        try:
-            names = list_diagnostics(config_dir=processing_config_dir)
-        except Exception as exc:  # noqa: BLE001 — unlistable tree = no selector
-            logger.debug("processing configs unavailable: %s", exc)
-            return []
+        # Fingerprint BEFORE listing: a YAML landing between the two
+        # scans then costs one harmless revalidation, instead of a
+        # cache entry permanently missing it. mtime+size so same-second
+        # edits are caught even on coarse-mtime SMB-mounted trees.
         tree = Path(processing_config_dir) / "analyzers"
         try:
             fingerprint = frozenset(
-                (str(path), path.stat().st_mtime)
+                (str(path), path.stat().st_mtime, path.stat().st_size)
                 for pattern in ("*.yaml", "*.yml")
                 for path in tree.rglob(pattern)
             )
         except OSError:
             fingerprint = None
-        if fingerprint is not None and fingerprint in processing_cache:
-            return processing_cache[fingerprint]
+        if fingerprint is not None:
+            cached = processing_cache.get(fingerprint)  # .get: a racing
+            if cached is not None:  # clear() must degrade to revalidate
+                return cached
+        try:
+            names = list_diagnostics(config_dir=processing_config_dir)
+        except Exception as exc:  # noqa: BLE001 — unlistable tree = no selector
+            logger.debug("processing configs unavailable: %s", exc)
+            return []
         valid = []
         for name in names:
             try:

--- a/GEECS-DataPortal/geecs_portal/app.py
+++ b/GEECS-DataPortal/geecs_portal/app.py
@@ -687,9 +687,10 @@ def create_app(
         tree = Path(processing_config_dir) / "analyzers"
         try:
             fingerprint = frozenset(
-                (str(path), path.stat().st_mtime, path.stat().st_size)
+                (str(path), stat.st_mtime, stat.st_size)
                 for pattern in ("*.yaml", "*.yml")
                 for path in tree.rglob(pattern)
+                for stat in (path.stat(),)  # one syscall, untearable tuple
             )
         except OSError:
             fingerprint = None

--- a/GEECS-DataPortal/geecs_portal/templates/run.html
+++ b/GEECS-DataPortal/geecs_portal/templates/run.html
@@ -230,7 +230,7 @@
         {% if total_shots %}<span class="dim mono">of ~{{ total_shots }}</span>{% endif %}
         <span class="dim mono">{{ kind }}</span>
       </form>
-      <img class="plot" id="shotimg" src="{{ root }}/run/{{ uid }}/image.png?device={{ sel_device | urlencode }}&amp;shot={{ shot }}&amp;day={{ day | urlencode }}{% if processing %}&amp;processing={{ processing | urlencode }}{% endif %}" alt="{{ sel_device }} shot {{ shot }}">
+      <img class="plot" id="shotimg" onerror="imgFailed(this)" src="{{ root }}/run/{{ uid }}/image.png?device={{ sel_device | urlencode }}&amp;shot={{ shot }}&amp;day={{ day | urlencode }}{% if processing %}&amp;processing={{ processing | urlencode }}{% endif %}" alt="{{ sel_device }} shot {{ shot }}">
       </div>
       <div id="imggrid" class="bingrid" hidden></div>
       {% endif %}
@@ -528,10 +528,37 @@ function updateShotImage() {
   // needs its src re-pointed (the URL carries the whole state anyway).
   const img = document.getElementById("shotimg");
   if (!img) return;
+  clearImgError(img);  // a previous failure must not mask the retry
   const url = new URL(img.src, location.origin);
   if (S.processing) url.searchParams.set("processing", S.processing);
   else url.searchParams.delete("processing");
   img.src = url.pathname + "?" + url.searchParams.toString();
+}
+
+function clearImgError(img) {
+  img.hidden = false;
+  const note = img.nextElementSibling;
+  if (note && note.classList.contains("imgerr")) note.remove();
+}
+
+function imgFailed(img) {
+  // A 4xx from the image endpoints carries an honest `detail` the
+  // <img> tag can only show as a broken icon — fetch and surface it
+  // (the failing response is a cheap validation error, not pixels).
+  const show = msg => {
+    img.hidden = true;
+    let note = img.nextElementSibling;
+    if (!note || !note.classList.contains("imgerr")) {
+      note = document.createElement("div");
+      note.className = "plotmsg imgerr";
+      img.after(note);
+    }
+    note.textContent = msg;
+  };
+  fetch(img.src)
+    .then(r => r.json())
+    .then(body => show(body.detail || "image failed to load"))
+    .catch(() => show("image failed to load"));
 }
 
 function refreshImages() {
@@ -563,7 +590,8 @@ function refreshImages() {
       if (DAY) q.set("day", DAY);
       const label = b.bin === null ? "—" : String(b.bin);
       return `<figure class="bincard">
-        <img class="plot" loading="lazy" src="${ROOT}/run/${UID}/bin-image.png?${q.toString()}"
+        <img class="plot" loading="lazy" onerror="imgFailed(this)"
+             src="${ROOT}/run/${UID}/bin-image.png?${q.toString()}"
              alt="${escAttr(data.bin_col)} ${escAttr(label)}">
         <figcaption class="dim mono" title="n counts member shots passing filters — frames the device missed or that fail to load are skipped in the average">${esc(data.bin_col)}: ${esc(label)} · n=${b.count}</figcaption>
       </figure>`;

--- a/GEECS-DataPortal/geecs_portal/templates/run.html
+++ b/GEECS-DataPortal/geecs_portal/templates/run.html
@@ -207,6 +207,12 @@
           <select id="procsel" onchange="setProcessing(this.value)"
                   style="background:var(--panel2); color:var(--ink); border:1px solid var(--line); border-radius:3px; padding:0.2rem 0.4rem; font-size:12px; max-width:16rem;">
             <option value="">raw</option>
+            {% if processing and processing not in processing_options %}
+            {# A bookmarked link naming a since-dropped diagnostic must
+               render as selected (not silently as "raw") so picking
+               raw fires a change event and actually clears it. #}
+            <option value="{{ processing }}" selected>{{ processing }} (unavailable)</option>
+            {% endif %}
             {% for name in processing_options %}
             <option value="{{ name }}"{% if name == processing %} selected{% endif %}>{{ name }}</option>
             {% endfor %}
@@ -543,9 +549,14 @@ function clearImgError(img) {
 
 function imgFailed(img) {
   // A 4xx from the image endpoints carries an honest `detail` the
-  // <img> tag can only show as a broken icon — fetch and surface it
-  // (the failing response is a cheap validation error, not pixels).
+  // <img> tag can only show as a broken icon — fetch and surface it.
+  // Cost note: config-validation 400s are cheap, but an ANALYZER
+  // failure 400s only after the server loaded+processed the frames,
+  // so this refetch re-runs that work once — bounded at 2× (onerror
+  // fires once per src assignment), accepted for an error path.
+  const src = img.src;  // staleness guard: a retry must not be masked
   const show = msg => {
+    if (img.src !== src || !img.isConnected) return;  // superseded
     img.hidden = true;
     let note = img.nextElementSibling;
     if (!note || !note.classList.contains("imgerr")) {
@@ -555,7 +566,7 @@ function imgFailed(img) {
     }
     note.textContent = msg;
   };
-  fetch(img.src)
+  fetch(src)
     .then(r => r.json())
     .then(body => show(body.detail || "image failed to load"))
     .catch(() => show("image failed to load"));

--- a/GEECS-DataPortal/pyproject.toml
+++ b/GEECS-DataPortal/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-data-portal"
-version = "0.13.1"
+version = "0.14.0"
 description = "Read-only scan-browsing web service: a zero-install browser view over the Tiled catalog and the GEECS data share"
 authors = ["GEECS-BELLA"]
 readme = "README.md"

--- a/GEECS-DataPortal/tests/test_resources.py
+++ b/GEECS-DataPortal/tests/test_resources.py
@@ -725,6 +725,20 @@ class TestProcessingSelector:
                 }
             )
         )
+        # A legacy flat camera config (no image_analyzer/pipeline —
+        # discoverable by stem, NOT loadable as a unified diagnostic):
+        # the selector must drop it, per the live Amp4 incident.
+        legacy = tree / "analyzers" / "UNCLASSIFIED" / "UC_Legacy.yaml"
+        legacy.parent.mkdir(parents=True)
+        legacy.write_text(
+            yaml.safe_dump(
+                {
+                    "name": "UC_Legacy",
+                    "bit_depth": 16,
+                    "background": {"enabled": True, "method": "constant"},
+                }
+            )
+        )
         haso = tree / "analyzers" / "HTU" / "U_Haso.yaml"
         haso.write_text(
             yaml.safe_dump(
@@ -831,6 +845,16 @@ class TestProcessingSelector:
         )
         assert "procsel" in with_configs.text
         assert "UC_Crop" in with_configs.text
+        # Discoverable-but-unloadable legacy config: dropped from the
+        # selector (a log line, not a broken image)…
+        assert "UC_Legacy" not in with_configs.text
+        # …while a hand-edited URL still gets the honest refusal.
+        forced = self._client(scan_folder, configs_tree).get(
+            "/run/uid-002/image.png",
+            params={"device": "cam", "shot": 1, "processing": "UC_Legacy"},
+        )
+        assert forced.status_code == 400
+        assert "Invalid diagnostic" in forced.json()["detail"]
         without = _gallery_client(scan_folder).get(
             "/run/uid-002", params={"device": "cam", "tab": "images"}
         )

--- a/GEECS-DataPortal/tests/test_resources.py
+++ b/GEECS-DataPortal/tests/test_resources.py
@@ -855,6 +855,14 @@ class TestProcessingSelector:
         )
         assert forced.status_code == 400
         assert "Invalid diagnostic" in forced.json()["detail"]
+        # A bookmarked link naming the dropped diagnostic renders it as
+        # a selected "(unavailable)" option — picking raw then fires a
+        # real change event instead of silently showing "raw".
+        bookmarked = self._client(scan_folder, configs_tree).get(
+            "/run/uid-002",
+            params={"device": "cam", "tab": "images", "processing": "UC_Legacy"},
+        )
+        assert "UC_Legacy (unavailable)" in bookmarked.text
         without = _gallery_client(scan_folder).get(
             "/run/uid-002", params={"device": "cam", "tab": "images"}
         )


### PR DESCRIPTION
Two defects from the owner's first live test of the processing selector (Amp4, 2026-09-01). The failure itself was a **legacy flat camera config** (`UNCLASSIFIED/UC_Amp4_IR_input.yaml` — no `image_analyzer`, no `pipeline`, pre-#412 `enabled:` flags) that discovery lists but `load_diagnostic` rightly refuses; the config has been migrated in GEECS-Plugins-Configs (owner to review/commit). What the portal got wrong:

1. **The selector offered an unloadable diagnostic.** `_processing_names` now validates each discovered stem with a real `load_diagnostic`, cached against the tree's YAML `(path, mtime)` fingerprint so re-validation happens only when the tree changes; an invalid config becomes an INFO log naming the file. A hand-edited URL still gets the honest 400 (pinned).
2. **The failure was invisible** — the endpoints returned an honest 400 with the exact validation error, but an `<img>` can only render a broken icon. The per-shot image and every bin-grid card now carry an `onerror` hook that fetches the response's `detail` and shows it in place (cleared on the next processing change, so a retry isn't masked).

Tests: **178 passed** — the fixture gains a discoverable-but-unloadable legacy YAML; pinned that it's absent from the page while `UC_Crop` remains, and that forcing it by URL still 400s with "Invalid diagnostic". (The `onerror` path is browser behavior — the hook's presence ships in the template; verified live on :8214.)

Adversarial review to follow as a PR comment before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)