### PR TITLE
portal 0.15.0: image colormaps + display windowing (owner's step 1)

### DIFF
--- a/GEECS-DataPortal/CHANGELOG.md
+++ b/GEECS-DataPortal/CHANGELOG.md
@@ -3,6 +3,23 @@
 All notable changes to this package will be documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.15.0] - 2026-09-01
+
+### Added
+
+- **Image colormaps + display windowing** (owner ask, "step 1" of the
+  interactive-images plan): the image endpoints (`image.png`,
+  `bin-image.png` — raw and processed alike) take the shared
+  `display` state's new curated fields `cmap` (matplotlib colormap
+  name) and `plo`/`phi` (percentile-window overrides, defaults
+  1/99.7). Types 400 at the parse boundary, values degrade (unknown
+  colormap → grayscale, insane window → defaults) — display state
+  rides shared links and must never fail one. A small "display…"
+  popup in the Images plotbar edits them; URLs carry them everywhere
+  (per-shot, grid, steppers). RGB inputs keep their own colors.
+  Step 2 (interactive per-shot Heatmap view with hover pixel values)
+  is planned post-promotion.
+
 ## [0.14.0] - 2026-09-01
 
 ### Fixed

--- a/GEECS-DataPortal/CLAUDE.md
+++ b/GEECS-DataPortal/CLAUDE.md
@@ -143,8 +143,11 @@ member shots that resolve to pixels average via the shared
 carry over, and an ordinal-resolved member downgrades the response to
 `no-cache`) · `/health` (catalog probe — the fleet-map health check).
 
-Both image endpoints also take `?processing=<diagnostic id>` (the
-`processing` URL state): the named ImageAnalysis diagnostic runs
+Both image endpoints also take `?display=` (the shared display state's
+image slice: `cmap` matplotlib-colormap name + `plo`/`phi` percentile
+window — types 400 at parse, values degrade to grayscale/defaults;
+edited via the Images plotbar's "display…" popup) and
+`?processing=<diagnostic id>` (the `processing` URL state): the named ImageAnalysis diagnostic runs
 **ephemerally** on the served pixels via
 `image_analysis.ephemeral.run_diagnostic_ephemeral` — the write-free
 seam (its structural no-writes contract lives in ImageAnalysis

--- a/GEECS-DataPortal/geecs_portal/analysis.py
+++ b/GEECS-DataPortal/geecs_portal/analysis.py
@@ -178,8 +178,20 @@ def parse_bincfg(raw: str) -> BinningConfig:
 
 
 _DISPLAY_BOOLS = ("logx", "logy")
-_DISPLAY_NUMBERS = ("xmin", "xmax", "ymin", "ymax", "msize", "width", "height")
-_DISPLAY_FIELDS = {*_DISPLAY_BOOLS, *_DISPLAY_NUMBERS, "colors", "layout"}
+# plo/phi = the image endpoints' percentile-window overrides (the plot
+# figures ignore them, same one-display-state doctrine as cmap).
+_DISPLAY_NUMBERS = (
+    "xmin",
+    "xmax",
+    "ymin",
+    "ymax",
+    "msize",
+    "width",
+    "height",
+    "plo",
+    "phi",
+)
+_DISPLAY_FIELDS = {*_DISPLAY_BOOLS, *_DISPLAY_NUMBERS, "colors", "layout", "cmap"}
 
 
 def parse_display(raw: str) -> dict:
@@ -244,6 +256,8 @@ def parse_display(raw: str) -> dict:
             raise BadParam("bad display param: colors must be a list of strings")
     if "layout" in payload and not isinstance(payload["layout"], dict):
         raise BadParam("bad display param: layout must be an object")
+    if "cmap" in payload and not isinstance(payload["cmap"], str):
+        raise BadParam("bad display param: cmap must be a string")
     return payload
 
 

--- a/GEECS-DataPortal/geecs_portal/app.py
+++ b/GEECS-DataPortal/geecs_portal/app.py
@@ -358,6 +358,14 @@ def create_app(
         except analysis.BadParam as exc:
             raise HTTPException(status_code=400, detail=str(exc)) from exc
 
+    def _render_opts(disp: dict) -> dict:
+        """The image-rendering slice of the display state (value-degrade)."""
+        return {
+            "cmap": disp.get("cmap"),
+            "plo": disp.get("plo"),
+            "phi": disp.get("phi"),
+        }
+
     def _pretty_names(detail, pf, columns: list[str]) -> dict:
         """Figure titles/legend names, by the columns endpoint's rule.
 
@@ -1042,6 +1050,7 @@ def create_app(
                 "total_shots": detail.summary.shots,
                 "processing": processing,
                 "processing_options": _processing_names() if sel_device else [],
+                "display": display,
                 "portal_version": _portal_version(),
                 # The rail's chips and the display popup must stay in
                 # step with the server-authored figures — one palette,
@@ -1054,16 +1063,24 @@ def create_app(
 
     @app.get("/run/{uid}/image.png")
     def run_image(
-        uid: str, device: str, shot: int = 1, day: str = "", processing: str = ""
+        uid: str,
+        device: str,
+        shot: int = 1,
+        day: str = "",
+        processing: str = "",
+        display: str = "",
     ) -> Response:
         """One device shot rendered for display (stack or native file).
 
         ``processing`` names a diagnostic to run ephemerally on the
         loaded pixels first (its ``processed_image`` renders instead of
         the raw frame) — the write-free seam; raw serving is untouched
-        when the param is absent.
+        when the param is absent. ``display`` carries the image
+        cosmetics (``cmap`` + ``plo``/``phi`` window — types 400,
+        values degrade, per the display doctrine).
         """
         detail = _load_run(uid)
+        render = _render_opts(_display(display))
         folder, _ = _image_folder(detail, day, device)
         # A shot beyond the recorded event rows must refuse outright:
         # falling through to the ordinal join would serve an orphan
@@ -1094,7 +1111,7 @@ def create_app(
                 )
             (processed,) = _apply_processing([resolved.array], processing)
             try:
-                png = resources.to_display_png(processed)
+                png = resources.to_display_png(processed, **render)
             except Exception as exc:  # noqa: BLE001 — must not 500
                 raise HTTPException(
                     status_code=404, detail=f"render failed: {exc}"
@@ -1116,6 +1133,7 @@ def create_app(
             acq_timestamp=acq,
             data_cache=data_cache if complete else None,
             cache_key=(uid, device) if complete else None,
+            **render,
         )
         if result.png is None:
             raise HTTPException(status_code=404, detail=result.reason or result.kind)
@@ -1133,6 +1151,7 @@ def create_app(
         bincfg: str = "",
         day: str = "",
         processing: str = "",
+        display: str = "",
     ) -> Response:
         """One bin's ``nanmean``-averaged device image, display-rendered.
 
@@ -1147,6 +1166,7 @@ def create_app(
         correct order for nonlinear pipeline steps like thresholding).
         """
         detail = _load_run(uid)
+        render = _render_opts(_display(display))
         folder, _ = _image_folder(detail, day, device)
         pf = scan_frame(detail, folder)
         _, mask = _masked(pf, filters)
@@ -1194,7 +1214,7 @@ def create_app(
                 status_code=404, detail="no renderable frames in this bin"
             )
         try:
-            png = resources.to_display_png(averaged)
+            png = resources.to_display_png(averaged, **render)
         except Exception as exc:  # noqa: BLE001 — unrenderable shape must not 500
             raise HTTPException(
                 status_code=404, detail=f"render failed: {exc}"

--- a/GEECS-DataPortal/geecs_portal/resources.py
+++ b/GEECS-DataPortal/geecs_portal/resources.py
@@ -104,36 +104,84 @@ def image_devices(scan_folder: Path) -> list[str]:
         return []
 
 
-def to_display_png(array: np.ndarray) -> bytes:
+def _window_percentiles(plo, phi) -> tuple[float, float]:
+    """The display window's percentile pair — value-degrade semantics.
+
+    Display values ride shared links and must never make a link fail
+    (the ``display`` doctrine): anything that isn't a sane
+    ``0 <= lo < hi <= 100`` pair falls back to the defaults.
+    """
+    try:
+        lo, hi = float(plo), float(phi)
+    except (TypeError, ValueError):
+        return _P_LO, _P_HI
+    if not (0.0 <= lo < hi <= 100.0):
+        return _P_LO, _P_HI
+    return lo, hi
+
+
+def to_display_png(
+    array: np.ndarray,
+    *,
+    cmap: Optional[str] = None,
+    plo: Optional[float] = None,
+    phi: Optional[float] = None,
+) -> bytes:
     """Render a 2D (or RGB) array to 8-bit PNG bytes with robust scaling.
 
-    Percentile windowing (1–99.7) maps the camera's dynamic range into
-    display range — the raw 16-bit files render near-black in a browser
-    otherwise.  A flat image renders black rather than dividing by zero.
+    Percentile windowing (default 1–99.7, overridable per request via
+    the ``display`` state) maps the camera's dynamic range into display
+    range — the raw 16-bit files render near-black in a browser
+    otherwise.  A flat image renders black rather than dividing by
+    zero.  ``cmap`` names a matplotlib colormap applied to the windowed
+    image (2D input only — an RGB input keeps its own colors); an
+    unknown name degrades to grayscale, same value-degrade rule as the
+    window (display values ride shared links and must never fail one).
 
     Parameters
     ----------
     array : numpy.ndarray
         The image data.
+    cmap : str, optional
+        Matplotlib colormap name (``viridis``, ``magma``, …); ``None``
+        renders grayscale.
+    plo, phi : float, optional
+        Percentile window overrides (defaults 1 / 99.7).
 
     Returns
     -------
     bytes
-        PNG-encoded 8-bit image.
+        PNG-encoded 8-bit image (RGB when a colormap applied).
     """
     from PIL import Image
 
     data = np.asarray(array, dtype=np.float32)
+    lo_pct, hi_pct = (
+        _window_percentiles(plo, phi)
+        if (plo is not None or phi is not None)
+        else (_P_LO, _P_HI)
+    )
     finite = data[np.isfinite(data)]
     if finite.size:
-        lo, hi = np.percentile(finite, [_P_LO, _P_HI])
+        lo, hi = np.percentile(finite, [lo_pct, hi_pct])
     else:
         lo, hi = 0.0, 0.0
     if hi <= lo:
-        scaled = np.zeros(data.shape, dtype=np.uint8)
+        norm = np.zeros(data.shape, dtype=np.float32)
     else:
-        scaled = np.clip((data - lo) / (hi - lo), 0.0, 1.0)
-        scaled = (scaled * 255).astype(np.uint8)
+        norm = np.clip((data - lo) / (hi - lo), 0.0, 1.0)
+    colormap = None
+    if cmap and data.ndim == 2:
+        import matplotlib as mpl
+
+        try:
+            colormap = mpl.colormaps[str(cmap)]
+        except KeyError:
+            colormap = None  # unknown name: grayscale, never a failure
+    if colormap is not None:
+        scaled = (colormap(norm)[..., :3] * 255).astype(np.uint8)
+    else:
+        scaled = (norm * 255).astype(np.uint8)
     buffer = io.BytesIO()
     Image.fromarray(scaled).save(buffer, format="PNG")
     return buffer.getvalue()
@@ -338,13 +386,17 @@ def load_shot_image(
     acq_timestamp: Optional[float] = None,
     data_cache=None,
     cache_key: Optional[tuple[str, str]] = None,
+    cmap: Optional[str] = None,
+    plo: Optional[float] = None,
+    phi: Optional[float] = None,
 ) -> ShotImage:
     """Resolve and render one device shot — :func:`load_shot_array` + PNG.
 
     Same parameters and tier ladder as :func:`load_shot_array` (which
     carries the full docs); this wrapper only adds the display
-    rendering, so single-shot serving and per-bin averaging share one
-    resolution path.
+    rendering (``cmap``/``plo``/``phi`` per :func:`to_display_png`),
+    so single-shot serving and per-bin averaging share one resolution
+    path.
     """
     resolved = load_shot_array(
         scan_folder,
@@ -357,7 +409,7 @@ def load_shot_image(
     png = None
     if resolved.array is not None:
         try:
-            png = to_display_png(resolved.array)
+            png = to_display_png(resolved.array, cmap=cmap, plo=plo, phi=phi)
         except Exception as exc:  # noqa: BLE001 — unrenderable shape must not 500
             # A readable-but-unrenderable array (e.g. a stacked .npy or
             # an odd-shaped h5 in a dev/scratch folder) degrades to the

--- a/GEECS-DataPortal/geecs_portal/resources.py
+++ b/GEECS-DataPortal/geecs_portal/resources.py
@@ -112,7 +112,11 @@ def _window_percentiles(plo, phi) -> tuple[float, float]:
     ``0 <= lo < hi <= 100`` pair falls back to the defaults.
     """
     try:
-        lo, hi = float(plo), float(phi)
+        # Per-field defaulting: a one-sided override ({"plo": 5}, the
+        # popup's stores-defaults-as-absent shape) must apply, not
+        # silently no-op the pair.
+        lo = _P_LO if plo is None else float(plo)
+        hi = _P_HI if phi is None else float(phi)
     except (TypeError, ValueError):
         return _P_LO, _P_HI
     if not (0.0 <= lo < hi <= 100.0):
@@ -132,8 +136,9 @@ def to_display_png(
     Percentile windowing (default 1–99.7, overridable per request via
     the ``display`` state) maps the camera's dynamic range into display
     range — the raw 16-bit files render near-black in a browser
-    otherwise.  A flat image renders black rather than dividing by
-    zero.  ``cmap`` names a matplotlib colormap applied to the windowed
+    otherwise.  A flat image renders at the scale's floor rather than
+    dividing by zero (black in grayscale; the colormap's lowest color
+    under a ``cmap``).  ``cmap`` names a matplotlib colormap applied to the windowed
     image (2D input only — an RGB input keeps its own colors); an
     unknown name degrades to grayscale, same value-degrade rule as the
     window (display values ride shared links and must never fail one).
@@ -179,7 +184,9 @@ def to_display_png(
         except KeyError:
             colormap = None  # unknown name: grayscale, never a failure
     if colormap is not None:
-        scaled = (colormap(norm)[..., :3] * 255).astype(np.uint8)
+        # bytes=True skips the H×W×4 float64 RGBA intermediate — same
+        # output bytes at ~1/8 the transient memory on full frames.
+        scaled = colormap(norm, bytes=True)[..., :3]
     else:
         scaled = (norm * 255).astype(np.uint8)
     buffer = io.BytesIO()

--- a/GEECS-DataPortal/geecs_portal/templates/run.html
+++ b/GEECS-DataPortal/geecs_portal/templates/run.html
@@ -218,6 +218,7 @@
             {% endfor %}
           </select></label>
         {% endif %}
+        <span class="right"><a href="#" onclick="openImgDisplay();return false;">display…</a></span>
       </div>
       <div id="imgshot">
       <form class="nav" method="get" action="{{ root }}/run/{{ uid }}">
@@ -236,7 +237,7 @@
         {% if total_shots %}<span class="dim mono">of ~{{ total_shots }}</span>{% endif %}
         <span class="dim mono">{{ kind }}</span>
       </form>
-      <img class="plot" id="shotimg" onerror="imgFailed(this)" src="{{ root }}/run/{{ uid }}/image.png?device={{ sel_device | urlencode }}&amp;shot={{ shot }}&amp;day={{ day | urlencode }}{% if processing %}&amp;processing={{ processing | urlencode }}{% endif %}" alt="{{ sel_device }} shot {{ shot }}">
+      <img class="plot" id="shotimg" onerror="imgFailed(this)" src="{{ root }}/run/{{ uid }}/image.png?device={{ sel_device | urlencode }}&amp;shot={{ shot }}&amp;day={{ day | urlencode }}{% if processing %}&amp;processing={{ processing | urlencode }}{% endif %}{% if display %}&amp;display={{ display | urlencode }}{% endif %}" alt="{{ sel_device }} shot {{ shot }}">
       </div>
       <div id="imggrid" class="bingrid" hidden></div>
       {% endif %}
@@ -336,6 +337,33 @@
     <div class="btnrow">
       <button class="act" onclick="closeModals()">Cancel</button>
       <button class="apply" onclick="applyBinset()">Apply</button>
+    </div>
+  </div>
+</div>
+
+<!-- images display popup: colormap + percentile window -->
+<div class="overlay" id="modal-imgdisplay" onclick="if(event.target===this)closeModals()">
+  <div class="modal">
+    <h3>Image display</h3>
+    <div class="setrow"><label>colormap</label>
+      <select id="id-cmap">
+        <option value="">grayscale</option>
+        <option value="viridis">viridis</option>
+        <option value="magma">magma</option>
+        <option value="inferno">inferno</option>
+        <option value="plasma">plasma</option>
+        <option value="turbo">turbo</option>
+        <option value="jet">jet</option>
+        <option value="hot">hot</option>
+      </select></div>
+    <div class="setrow"><label>window percentiles</label>
+      <input id="id-plo" style="width:4.5rem;"> <span class="dim">–</span>
+      <input id="id-phi" style="width:4.5rem;"></div>
+    <p class="dim" style="font-size:11px;">Applies to the served images (per-shot and per-bin);
+    defaults 1 – 99.7. Out-of-range values fall back to the defaults.</p>
+    <div class="btnrow">
+      <button class="act" onclick="closeModals()">Cancel</button>
+      <button class="apply" onclick="applyImgDisplay()">Apply</button>
     </div>
   </div>
 </div>
@@ -530,15 +558,43 @@ function setProcessing(name) {
 }
 
 function updateShotImage() {
-  // The per-shot image is server-rendered; a processing change only
-  // needs its src re-pointed (the URL carries the whole state anyway).
+  // The per-shot image is server-rendered; a processing/display change
+  // only needs its src re-pointed (the URL carries the whole state).
   const img = document.getElementById("shotimg");
   if (!img) return;
   clearImgError(img);  // a previous failure must not mask the retry
   const url = new URL(img.src, location.origin);
   if (S.processing) url.searchParams.set("processing", S.processing);
   else url.searchParams.delete("processing");
+  if (S.display) url.searchParams.set("display", S.display);
+  else url.searchParams.delete("display");
   img.src = url.pathname + "?" + url.searchParams.toString();
+}
+
+function openImgDisplay() {
+  const d = dispCfg();
+  document.getElementById("id-cmap").value = typeof d.cmap === "string" ? d.cmap : "";
+  document.getElementById("id-plo").value = typeof d.plo === "number" ? d.plo : 1;
+  document.getElementById("id-phi").value = typeof d.phi === "number" ? d.phi : 99.7;
+  document.getElementById("modal-imgdisplay").classList.add("on");
+}
+
+function applyImgDisplay() {
+  // Image cosmetics merge into the ONE shared display state (the plot
+  // figures ignore these keys); defaults are stored as key-absent so
+  // pristine links stay short.
+  const d = dispCfg();
+  const cmap = document.getElementById("id-cmap").value;
+  if (cmap) d.cmap = cmap; else delete d.cmap;
+  const plo = parseFloat(document.getElementById("id-plo").value);
+  const phi = parseFloat(document.getElementById("id-phi").value);
+  if (isFinite(plo) && plo !== 1) d.plo = plo; else delete d.plo;
+  if (isFinite(phi) && phi !== 99.7) d.phi = phi; else delete d.phi;
+  S.display = Object.keys(d).length ? JSON.stringify(d) : "";
+  closeModals();
+  writeState();
+  updateShotImage();
+  refreshImages();
 }
 
 function clearImgError(img) {
@@ -580,7 +636,7 @@ function refreshImages() {
   shotBox.hidden = binned;
   grid.hidden = !binned;
   if (!binned || S.tab !== "images") return;
-  const key = JSON.stringify([SEL_DEVICE, S.filters, S.bincfg, S.processing]);
+  const key = JSON.stringify([SEL_DEVICE, S.filters, S.bincfg, S.processing, S.display]);
   if (key === IMG_KEY) return;
   IMG_KEY = key;  // set before the fetch: dedupes the boot's setTab+setView pair
   const params = new URLSearchParams({ device: SEL_DEVICE });
@@ -598,6 +654,7 @@ function refreshImages() {
       if (S.filters) q.set("filters", S.filters);
       if (S.bincfg) q.set("bincfg", S.bincfg);
       if (S.processing) q.set("processing", S.processing);
+      if (S.display) q.set("display", S.display);
       if (DAY) q.set("day", DAY);
       const label = b.bin === null ? "—" : String(b.bin);
       return `<figure class="bincard">

--- a/GEECS-DataPortal/geecs_portal/templates/run.html
+++ b/GEECS-DataPortal/geecs_portal/templates/run.html
@@ -228,6 +228,7 @@
         <input type="hidden" name="tab" value="images">
         {% if filter %}<input type="hidden" name="filter" value="{{ filter }}">{% endif %}
         <input type="hidden" name="processing" id="procfield" value="{{ processing }}">
+        <input type="hidden" name="display" id="dispfield" value="{{ display }}">
         {% if shot > 1 %}<a class="carry" href="{{ root }}/run/{{ uid }}?{{ qs(shot=shot - 1, tab="images") }}">&larr; prev</a>{% endif %}
         <label class="dim">shot
           <input type="number" name="shot" value="{{ shot }}" min="1" style="width: 5rem">
@@ -479,8 +480,14 @@ function writeState() {
   if (S.processing) p.set("processing", S.processing);
   if (S.tab !== "plot") p.set("tab", S.tab);
   history.replaceState(null, "", location.pathname + "?" + p.toString());
-  // Server-rendered stepper links must carry the latest state too.
+  // Server-rendered stepper links must carry the latest state too —
+  // and so must the Show form's hidden fields (a form submit is a
+  // navigation like any stepper click).
   syncRailLinks(p);
+  const procField = document.getElementById("procfield");
+  if (procField) procField.value = S.processing;
+  const dispField = document.getElementById("dispfield");
+  if (dispField) dispField.value = S.display;
 }
 
 function syncRailLinks(p) {
@@ -550,9 +557,7 @@ let IMG_KEY = null;  // last-rendered grid params — skip redundant refetches
 
 function setProcessing(name) {
   S.processing = name;
-  const field = document.getElementById("procfield");
-  if (field) field.value = name;  // the Show form must submit the live pick
-  writeState();
+  writeState();  // syncs the Show form's hidden fields too
   updateShotImage();
   refreshImages();
 }
@@ -971,7 +976,14 @@ function openDisplay() {
 }
 
 function applyDisplay() {
+  // Start from the SHARED state and rebuild only the keys this popup
+  // owns — the image slice (cmap/plo/phi) belongs to the Images
+  // popup and must survive a plot-cosmetics apply.
   const d = {};
+  const prior = dispCfg();
+  for (const key of ["cmap", "plo", "phi"]) {
+    if (key in prior) d[key] = prior[key];
+  }
   if (document.getElementById("ds-logx").checked) d.logx = true;
   if (document.getElementById("ds-logy").checked) d.logy = true;
   for (const key of ["xmin", "xmax", "ymin", "ymax"]) {

--- a/GEECS-DataPortal/pyproject.toml
+++ b/GEECS-DataPortal/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-data-portal"
-version = "0.14.0"
+version = "0.15.0"
 description = "Read-only scan-browsing web service: a zero-install browser view over the Tiled catalog and the GEECS data share"
 authors = ["GEECS-BELLA"]
 readme = "README.md"

--- a/GEECS-DataPortal/tests/test_resources.py
+++ b/GEECS-DataPortal/tests/test_resources.py
@@ -946,6 +946,15 @@ class TestImageDisplay:
         # Halving the top percentile saturates the whole upper half.
         assert (squeezed == 255).sum() > (default == 255).sum()
 
+    def test_one_sided_window_override_applies(self):
+        """The popup stores defaults as key-absent, so {"phi": 50} alone
+        is the COMMON payload — it must apply (742 review HIGH: the
+        pair-wise float() silently discarded one-sided overrides)."""
+        gradient = np.arange(100, dtype=np.float32).reshape(10, 10)
+        one_sided = resources.to_display_png(gradient, phi=50)
+        assert one_sided != resources.to_display_png(gradient)
+        assert one_sided == resources.to_display_png(gradient, plo=1, phi=50)
+
     def test_inverted_window_degrades_to_default(self):
         gradient = np.arange(100, dtype=np.float32).reshape(10, 10)
         assert resources.to_display_png(

--- a/GEECS-DataPortal/tests/test_resources.py
+++ b/GEECS-DataPortal/tests/test_resources.py
@@ -910,3 +910,76 @@ class TestProcessingSelector:
         )
         decoded = np.array(Image.open(io.BytesIO(response.content)))
         assert decoded.shape == (5, 5)  # full frame — no processing applied
+
+
+class TestImageDisplay:
+    """cmap + percentile-window display state on the image endpoints."""
+
+    def test_cmap_renders_rgb_via_matplotlib(self):
+        import matplotlib as mpl
+
+        arr = np.zeros((4, 4), dtype=np.uint16)
+        arr[1, 2] = 1000
+        decoded = np.array(
+            Image.open(io.BytesIO(resources.to_display_png(arr, cmap="viridis")))
+        )
+        assert decoded.shape == (4, 4, 3)
+        expected_top = (np.array(mpl.colormaps["viridis"](1.0)[:3]) * 255).astype(
+            np.uint8
+        )
+        np.testing.assert_array_equal(decoded[1, 2], expected_top)
+
+    def test_unknown_cmap_degrades_to_grayscale(self):
+        arr = np.zeros((4, 4), dtype=np.uint16)
+        arr[0, 0] = 10
+        decoded = np.array(
+            Image.open(io.BytesIO(resources.to_display_png(arr, cmap="not-a-map")))
+        )
+        assert decoded.ndim == 2  # grayscale, not a failure
+
+    def test_window_override_changes_saturation(self):
+        gradient = np.arange(100, dtype=np.float32).reshape(10, 10)
+        default = np.array(Image.open(io.BytesIO(resources.to_display_png(gradient))))
+        squeezed = np.array(
+            Image.open(io.BytesIO(resources.to_display_png(gradient, plo=0, phi=50)))
+        )
+        # Halving the top percentile saturates the whole upper half.
+        assert (squeezed == 255).sum() > (default == 255).sum()
+
+    def test_inverted_window_degrades_to_default(self):
+        gradient = np.arange(100, dtype=np.float32).reshape(10, 10)
+        assert resources.to_display_png(
+            gradient, plo=90, phi=10
+        ) == resources.to_display_png(gradient)
+
+    def test_endpoint_display_ladder_and_cmap(self, scan_folder):
+        client = _gallery_client(scan_folder)
+        colored = client.get(
+            "/run/uid-002/image.png",
+            params={"device": "cam", "shot": 1, "display": '{"cmap": "viridis"}'},
+        )
+        assert colored.status_code == 200
+        assert np.array(Image.open(io.BytesIO(colored.content))).ndim == 3
+        assert (
+            client.get(
+                "/run/uid-002/image.png",
+                params={"device": "cam", "shot": 1, "display": "notjson"},
+            ).status_code
+            == 400
+        )
+        assert (
+            client.get(
+                "/run/uid-002/image.png",
+                params={"device": "cam", "shot": 1, "display": '{"nope": 1}'},
+            ).status_code
+            == 400
+        )
+
+    def test_bin_image_takes_display(self, scan_folder):
+        client = TestBinImages()._client(scan_folder)
+        response = client.get(
+            "/run/uid-002/bin-image.png",
+            params={"device": "cam", "bin": 0, "display": '{"cmap": "magma"}'},
+        )
+        assert response.status_code == 200
+        assert np.array(Image.open(io.BytesIO(response.content))).ndim == 3


### PR DESCRIPTION
The owner-requested "step 1" of the interactive-images plan (step 2 — the plotly Heatmap hover/zoom view — is planned post-promotion): **colormaps and window control on every served image**, with zero payload cost.

## What it adds (portal 0.14.0 → 0.15.0)

- `to_display_png` grows `cmap` (any matplotlib colormap; applied to the windowed 2D image, RGB inputs keep their own colors) and `plo`/`phi` percentile-window overrides (defaults 1/99.7). Value-degrade semantics per the display doctrine: unknown colormap → grayscale, insane window (inverted/out-of-range) → defaults — display state rides shared links and must never fail one. matplotlib is already a portal dependency (plot.png).
- Both image endpoints (`image.png`, `bin-image.png`) — raw, processed, and averaged paths alike — take the shared `display` state, whose curated vocabulary gains `cmap`/`plo`/`phi` (types 400 at `parse_display`, the existing boundary; the plot figures simply ignore the new keys — one display state, per doctrine).
- A small **"display…" popup in the Images plotbar** (colormap select + window inputs) merging into the same `display` JSON; the per-shot image, the bin grid, the steppers, and the grid's refresh key all carry it.

## Testing

Portal suite: **184 passed** (6 new): viridis pixel checked against matplotlib's own colormap value (no palette literals to go stale), unknown-cmap grayscale degrade, window override provably changing saturation, inverted-window byte-identical to defaults, the 400 ladder on the image endpoints (`notjson`, unknown field), and a colored bin-average render.

No cache-semantics change: `display` is in the URL, so distinct renders are distinct cache entries; the processed-path `no-cache` rule from #741's review is untouched.

Adversarial review to follow as a PR comment before merge. This is the last W2a feature PR — promotion follows its merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)