### PR TITLE
Fleet map: checkout column, one-clone-per-service pattern, fresh-host bootstrap gotchas

### DIFF
--- a/GEECS-DataPortal/CHANGELOG.md
+++ b/GEECS-DataPortal/CHANGELOG.md
@@ -3,6 +3,16 @@
 All notable changes to this package will be documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.15.1] - 2026-09-01
+
+### Fixed
+
+- DEPLOYMENT.md now names the `analysis` extra and the
+  `--processing-configs` `ExecStart` flag (quoted — share paths carry
+  spaces) that the processing selector needs — the fleet map's
+  "each runbook names its extras" claim was false for this runbook
+  (docs-only; #745 review finding).
+
 ## [0.15.0] - 2026-09-01
 
 ### Added

--- a/GEECS-DataPortal/DEPLOYMENT.md
+++ b/GEECS-DataPortal/DEPLOYMENT.md
@@ -45,8 +45,21 @@ checks pass.
 ```bash
 cd ~/GEECS-Plugins-portal/GEECS-DataPortal
 poetry env use python3.11
-poetry install
+poetry install --extras analysis
 ```
+
+The `analysis` extra installs ImageAnalysis for the Images tab's
+**processing selector** (0.13.0+). The feature is explicit-opt-in
+twice over: the extra installs the code, and the unit's `ExecStart`
+must name the scan-analysis configs tree —
+
+```
+--processing-configs "/path/to/GEECS-Plugins-Configs/scan_analysis_configs"
+```
+
+(quote it — the lab's share paths contain spaces). Omit both for a
+raw-images-only portal; the selector hides itself and nothing else
+changes. A misconfigured tree logs a startup WARNING naming the path.
 
 Smoke-test in the foreground before installing the unit:
 
@@ -112,9 +125,12 @@ degraded catalog, not a dead portal).
 
 ```bash
 cd ~/GEECS-Plugins-portal && git pull
-cd GEECS-DataPortal && poetry install
+cd GEECS-DataPortal && poetry install --extras analysis
 sudo systemctl restart geecs-data-portal
 ```
+
+(Drop `--extras analysis` only on a deployment that deliberately runs
+without the processing selector.)
 
 ## Troubleshooting
 

--- a/GEECS-DataPortal/deploy/geecs-data-portal.service
+++ b/GEECS-DataPortal/deploy/geecs-data-portal.service
@@ -38,6 +38,9 @@ Environment=TZ=America/Los_Angeles
 # Portal-specific checkout — never the one another service (e.g. the CA
 # gateway) runs from; see DEPLOYMENT.md § Install.
 WorkingDirectory=/home/geecs/GEECS-Plugins-portal/GEECS-DataPortal
+# To enable the Images tab's processing selector, install the 'analysis'
+# extra and append (quoted — share paths carry spaces):
+#   --processing-configs "/path/to/GEECS-Plugins-Configs/scan_analysis_configs"
 ExecStart=/home/geecs/.local/bin/poetry run geecs-data-portal --experiment Undulator
 Restart=on-failure
 RestartSec=10

--- a/GEECS-DataPortal/pyproject.toml
+++ b/GEECS-DataPortal/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-data-portal"
-version = "0.15.0"
+version = "0.15.1"
 description = "Read-only scan-browsing web service: a zero-install browser view over the Tiled catalog and the GEECS data share"
 authors = ["GEECS-BELLA"]
 readme = "README.md"

--- a/docs/platform/fleet_map.md
+++ b/docs/platform/fleet_map.md
@@ -10,9 +10,10 @@ the repository (linked in the table below) — this page is the map, not
 the manual.
 
 !!! note "Snapshot"
-    Reflects the fleet as of **August 2026**. Deployed and running: the
-    CA gateway, the GEECS DB, Tiled, the PVA image gateways, the
-    queueserver worker (on an interim host), and the GEECS Data Portal.
+    Reflects the fleet as of **September 2026**. Deployed and running:
+    the CA gateway, the GEECS DB, Tiled, the PVA image gateways, the
+    queueserver worker (on an interim host), and the GEECS Data Portal
+    (0.15.x — analysis tabs, per-bin image grid, ephemeral processing).
     Documented here ahead of
     deployment: the GEECS-MCP HTTP service and the capture daemon
     (which lands with the central-PVA-capture arc). When a service
@@ -99,18 +100,78 @@ co-location is a requirement, not a convenience).
 
 ## The services
 
-| Service | Host | Port(s) | Supervision | Health check | Runbook |
-|---|---|---|---|---|---|
-| CA gateway (GeecsCAGateway) | 192.168.6.14 | CA 5064/5065 | systemd `geecs-ca-gateway` | heartbeat + per-device `CONNECTED` PVs; `systemctl status` | [GeecsCAGateway/DEPLOYMENT.md](https://github.com/GEECS-BELLA/GEECS-Plugins/blob/master/GeecsCAGateway/DEPLOYMENT.md) |
-| Tiled catalog | 192.168.6.14 | HTTP 8000 | systemd `tiled` | `GET /api/v1/`; web UI at `/ui` | [GeecsBluesky/TILED_SETUP.md](https://github.com/GEECS-BELLA/GEECS-Plugins/blob/master/GeecsBluesky/TILED_SETUP.md) |
-| Queueserver worker (RE Manager + Redis + doc proxy) | the worker host (interim box; the runbook targets a dedicated host) | ZMQ 60615 (control), 60625 (console stream), 5568 (documents); Redis loopback-only | systemd `geecs-qserver` | `qserver status` from any client env | [GeecsBluesky/qserver/deploy/DEPLOYMENT.md](https://github.com/GEECS-BELLA/GEECS-Plugins/blob/master/GeecsBluesky/qserver/deploy/DEPLOYMENT.md) |
-| GEECS-MCP server — *HTTP mode pending deploy* | the worker host (co-located by design; stdio mode runs per-machine today) | HTTP 8100 (`/mcp`) | systemd (HTTP mode) | tool call `scan_status` from an agent | [GEECS-MCP/deploy/DEPLOYMENT.md](https://github.com/GEECS-BELLA/GEECS-Plugins/blob/master/GEECS-MCP/deploy/DEPLOYMENT.md) |
-| Capture daemon (`geecs_bluesky.capture`) — *pending deploy* | the queueserver worker host (co-location is a **requirement**: shared filesystem view + local heartbeat) | consumes doc stream (5568) + pvAccess; no listening port | systemd `geecs-capture` | heartbeat file refreshing every ~10 s (`~/.local/state/geecs-capture/heartbeat.json` in the service user's home); discovery line in `journalctl -u geecs-capture` | [GeecsBluesky/capture/deploy/DEPLOYMENT.md](https://github.com/GEECS-BELLA/GEECS-Plugins/blob/master/GeecsBluesky/capture/deploy/DEPLOYMENT.md) |
-| GEECS Data Portal (GEECS-DataPortal) | the worker host (interim box; moves with the services-server consolidation) | HTTP 8200 | systemd `geecs-data-portal` | `GET /health` (catalog probe); any day page in a browser | [GEECS-DataPortal/DEPLOYMENT.md](https://github.com/GEECS-BELLA/GEECS-Plugins/blob/master/GEECS-DataPortal/DEPLOYMENT.md) |
-| PVA image gateways (GeecsPvaGateway) | each camera server (9 hosts) | pvAccess TCP 5075 / UDP 5076 | NSSM service `GeecsPvaGateway` (auto-start, pull-on-restart) | fleet status Phoebus screen (`deploy/fleet_status.bob`) | [GeecsPvaGateway/DEPLOYMENT.md](https://github.com/GEECS-BELLA/GEECS-Plugins/blob/master/GeecsPvaGateway/DEPLOYMENT.md) |
-| GEECS MySQL DB | 192.168.6.14 | 3306 | LabVIEW/GEECS infrastructure (not managed by this repo) | any `GeecsDb` client connect | — |
-| Data share (NAS) | NAS appliance | SMB | storage infrastructure (not managed by this repo) | mount visible, scan folders resolvable | — |
-| GEECS LabVIEW devices | Windows device hosts | GEECS wire protocol (UDP/TCP) | Master Control / device GUIs | device `CONNECTED` PV via the gateway | — |
+The **Checkout** column names the git clone a service runs from, as a
+path in the service account's home on its host — see
+[one clone per service](#one-clone-per-service) below for why each
+service gets its own.
+
+| Service | Host | Checkout | Port(s) | Supervision | Health check | Runbook |
+|---|---|---|---|---|---|---|
+| CA gateway (GeecsCAGateway) | 192.168.6.14 | `~/GEECS-Plugins` | CA 5064/5065 | systemd `geecs-ca-gateway` | heartbeat + per-device `CONNECTED` PVs; `systemctl status` | [GeecsCAGateway/DEPLOYMENT.md](https://github.com/GEECS-BELLA/GEECS-Plugins/blob/master/GeecsCAGateway/DEPLOYMENT.md) |
+| Tiled catalog | 192.168.6.14 | — (pip install + `~/tiled/config.yml`) | HTTP 8000 | systemd `tiled` | `GET /api/v1/`; web UI at `/ui` | [GeecsBluesky/TILED_SETUP.md](https://github.com/GEECS-BELLA/GEECS-Plugins/blob/master/GeecsBluesky/TILED_SETUP.md) |
+| Queueserver worker (RE Manager + Redis + doc proxy) | the worker host (interim box; the runbook targets a dedicated host) | `~/qs-checkout` | ZMQ 60615 (control), 60625 (console stream), 5568 (documents); Redis loopback-only | systemd `geecs-qserver` | `qserver status` from any client env | [GeecsBluesky/qserver/deploy/DEPLOYMENT.md](https://github.com/GEECS-BELLA/GEECS-Plugins/blob/master/GeecsBluesky/qserver/deploy/DEPLOYMENT.md) |
+| GEECS-MCP server — *HTTP mode pending deploy* | the worker host (co-located by design; stdio mode runs per-machine today) | own clone when deployed (per the pattern below) | HTTP 8100 (`/mcp`) | systemd (HTTP mode) | tool call `scan_status` from an agent | [GEECS-MCP/deploy/DEPLOYMENT.md](https://github.com/GEECS-BELLA/GEECS-Plugins/blob/master/GEECS-MCP/deploy/DEPLOYMENT.md) |
+| Capture daemon (`geecs_bluesky.capture`) — *pending deploy* | the queueserver worker host (co-location is a **requirement**: shared filesystem view + local heartbeat) | `~/qs-checkout` (shares the worker's clone — the co-location requirement extends to code state) | consumes doc stream (5568) + pvAccess; no listening port | systemd `geecs-capture` | heartbeat file refreshing every ~10 s (`~/.local/state/geecs-capture/heartbeat.json` in the service user's home); discovery line in `journalctl -u geecs-capture` | [GeecsBluesky/capture/deploy/DEPLOYMENT.md](https://github.com/GEECS-BELLA/GEECS-Plugins/blob/master/GeecsBluesky/capture/deploy/DEPLOYMENT.md) |
+| GEECS Data Portal (GEECS-DataPortal) | the worker host (interim box; moves with the services-server consolidation) | `~/portal-checkout` | HTTP 8200 | systemd `geecs-data-portal` | `GET /health` (catalog probe); any day page in a browser | [GEECS-DataPortal/DEPLOYMENT.md](https://github.com/GEECS-BELLA/GEECS-Plugins/blob/master/GEECS-DataPortal/DEPLOYMENT.md) |
+| PVA image gateways (GeecsPvaGateway) | each camera server (9 hosts) | per-host clone (NSSM pulls on restart) | pvAccess TCP 5075 / UDP 5076 | NSSM service `GeecsPvaGateway` (auto-start, pull-on-restart) | fleet status Phoebus screen (`deploy/fleet_status.bob`) | [GeecsPvaGateway/DEPLOYMENT.md](https://github.com/GEECS-BELLA/GEECS-Plugins/blob/master/GeecsPvaGateway/DEPLOYMENT.md) |
+| GEECS MySQL DB | 192.168.6.14 | — | 3306 | LabVIEW/GEECS infrastructure (not managed by this repo) | any `GeecsDb` client connect | — |
+| Data share (NAS) | NAS appliance | — | SMB | storage infrastructure (not managed by this repo) | mount visible, scan folders resolvable | — |
+| GEECS LabVIEW devices | Windows device hosts | — | GEECS wire protocol (UDP/TCP) | Master Control / device GUIs | device `CONNECTED` PV via the gateway | — |
+
+## One clone per service
+
+When several services from this monorepo share a host, **each service
+family runs from its own clone** of GEECS-Plugins (and installs its own
+Poetry env inside it). This is deliberate, not accumulation:
+
+- **A pull for one service must never change the code under another
+  running service.** Units run with `Restart=on-failure`: with a shared
+  working tree, deploying service A would leave service B one crash
+  away from auto-restarting onto code nobody validated for B.
+- **Deploy cadence differs per service.** The portal iterates in days;
+  the CA gateway is control-room-critical and moves rarely; the worker
+  moves only at hardware-verified milestones. Each clone sits pinned at
+  its service's last *verified* deploy — a per-service rollback point,
+  not drift.
+- The queueserver worker and capture daemon are the one deliberate
+  exception: they share `~/qs-checkout` because their co-location (and
+  co-versioning) is a requirement of the capture design.
+
+A clone is deployed by `git pull` (or checkout of a pinned ref) +
+`poetry install` **with the extras that service needs** (each runbook
+names them; e.g. the portal's optional processing selector needs
+`--extras analysis`) + `systemctl restart <unit>`. Never `git pull` a
+clone that isn't the one your service runs from.
+
+### Fresh-host bootstrap (collected from live deploys)
+
+The services-server consolidation will redo these steps; gotchas that
+cost real time, so they aren't re-learned:
+
+1. Create the dedicated service account; install everything as that
+   account (units run as it). Python 3.11 and `~/.local/bin/poetry`
+   per the runbooks.
+2. One clone per service family, named for the service
+   (`~/<service>-checkout`); per-clone `poetry install` **inside the
+   package directory**, with that service's extras.
+3. `~/.config/geecs_python_api/config.ini` per the
+   [Getting started](../tutorials/getting_started.md) reference — it
+   feeds every service (CA address, Tiled URI/key, data-share path,
+   qserver address, config-repo paths).
+4. Non-login shells (plain `ssh host 'cmd'`, systemd) don't have
+   `~/.local/bin` on `PATH` — use `bash -lc` for remote poetry
+   commands, and absolute `ExecStart` paths in units.
+5. A GEECS-Plugins-Configs checkout consumed from the data share is
+   typically Windows-authored (CRLF): set `core.autocrlf true` on that
+   checkout before pulling from Linux, or every file reads as locally
+   modified and pulls abort. Never "fix" the line endings in place —
+   LabVIEW consumers read the same files.
+6. Quote systemd `ExecStart` arguments that carry share paths — the
+   lab's paths contain spaces (`.../Active Version/...`).
+7. Install units from each package's `deploy/` template (generic
+   service-account placeholders), then `systemctl daemon-reload`,
+   `enable`, `start`, and run the runbook's health check before
+   calling it deployed. Update this page's table in the same PR.
 
 ## How the planes connect
 

--- a/docs/platform/fleet_map.md
+++ b/docs/platform/fleet_map.md
@@ -110,10 +110,10 @@ service gets its own.
 | CA gateway (GeecsCAGateway) | 192.168.6.14 | `~/GEECS-Plugins` | CA 5064/5065 | systemd `geecs-ca-gateway` | heartbeat + per-device `CONNECTED` PVs; `systemctl status` | [GeecsCAGateway/DEPLOYMENT.md](https://github.com/GEECS-BELLA/GEECS-Plugins/blob/master/GeecsCAGateway/DEPLOYMENT.md) |
 | Tiled catalog | 192.168.6.14 | — (pip install + `~/tiled/config.yml`) | HTTP 8000 | systemd `tiled` | `GET /api/v1/`; web UI at `/ui` | [GeecsBluesky/TILED_SETUP.md](https://github.com/GEECS-BELLA/GEECS-Plugins/blob/master/GeecsBluesky/TILED_SETUP.md) |
 | Queueserver worker (RE Manager + Redis + doc proxy) | the worker host (interim box; the runbook targets a dedicated host) | `~/qs-checkout` | ZMQ 60615 (control), 60625 (console stream), 5568 (documents); Redis loopback-only | systemd `geecs-qserver` | `qserver status` from any client env | [GeecsBluesky/qserver/deploy/DEPLOYMENT.md](https://github.com/GEECS-BELLA/GEECS-Plugins/blob/master/GeecsBluesky/qserver/deploy/DEPLOYMENT.md) |
-| GEECS-MCP server — *HTTP mode pending deploy* | the worker host (co-located by design; stdio mode runs per-machine today) | own clone when deployed (per the pattern below) | HTTP 8100 (`/mcp`) | systemd (HTTP mode) | tool call `scan_status` from an agent | [GEECS-MCP/deploy/DEPLOYMENT.md](https://github.com/GEECS-BELLA/GEECS-Plugins/blob/master/GEECS-MCP/deploy/DEPLOYMENT.md) |
+| GEECS-MCP server — *HTTP mode pending deploy* | the worker host (co-located by design; stdio mode runs per-machine today) | reads the **worker's** checkout (config-truth parity, by design), baked into its own non-editable venv — see the runbook | HTTP 8100 (`/mcp`) | systemd (HTTP mode) | tool call `scan_status` from an agent | [GEECS-MCP/deploy/DEPLOYMENT.md](https://github.com/GEECS-BELLA/GEECS-Plugins/blob/master/GEECS-MCP/deploy/DEPLOYMENT.md) |
 | Capture daemon (`geecs_bluesky.capture`) — *pending deploy* | the queueserver worker host (co-location is a **requirement**: shared filesystem view + local heartbeat) | `~/qs-checkout` (shares the worker's clone — the co-location requirement extends to code state) | consumes doc stream (5568) + pvAccess; no listening port | systemd `geecs-capture` | heartbeat file refreshing every ~10 s (`~/.local/state/geecs-capture/heartbeat.json` in the service user's home); discovery line in `journalctl -u geecs-capture` | [GeecsBluesky/capture/deploy/DEPLOYMENT.md](https://github.com/GEECS-BELLA/GEECS-Plugins/blob/master/GeecsBluesky/capture/deploy/DEPLOYMENT.md) |
 | GEECS Data Portal (GEECS-DataPortal) | the worker host (interim box; moves with the services-server consolidation) | `~/portal-checkout` | HTTP 8200 | systemd `geecs-data-portal` | `GET /health` (catalog probe); any day page in a browser | [GEECS-DataPortal/DEPLOYMENT.md](https://github.com/GEECS-BELLA/GEECS-Plugins/blob/master/GEECS-DataPortal/DEPLOYMENT.md) |
-| PVA image gateways (GeecsPvaGateway) | each camera server (9 hosts) | per-host clone (NSSM pulls on restart) | pvAccess TCP 5075 / UDP 5076 | NSSM service `GeecsPvaGateway` (auto-start, pull-on-restart) | fleet status Phoebus screen (`deploy/fleet_status.bob`) | [GeecsPvaGateway/DEPLOYMENT.md](https://github.com/GEECS-BELLA/GEECS-Plugins/blob/master/GeecsPvaGateway/DEPLOYMENT.md) |
+| PVA image gateways (GeecsPvaGateway) | each camera server (9 hosts) | — (installs from the lab's shared "Active Version" clone on the data share; per host only a baked venv — **the share clone's checked-out commit is the fleet pin**) | pvAccess TCP 5075 / UDP 5076 | NSSM service `GeecsPvaGateway` (auto-start, pull-on-restart) | fleet status Phoebus screen (`deploy/fleet_status.bob`) | [GeecsPvaGateway/DEPLOYMENT.md](https://github.com/GEECS-BELLA/GEECS-Plugins/blob/master/GeecsPvaGateway/DEPLOYMENT.md) |
 | GEECS MySQL DB | 192.168.6.14 | — | 3306 | LabVIEW/GEECS infrastructure (not managed by this repo) | any `GeecsDb` client connect | — |
 | Data share (NAS) | NAS appliance | — | SMB | storage infrastructure (not managed by this repo) | mount visible, scan folders resolvable | — |
 | GEECS LabVIEW devices | Windows device hosts | — | GEECS wire protocol (UDP/TCP) | Master Control / device GUIs | device `CONNECTED` PV via the gateway | — |
@@ -133,9 +133,19 @@ Poetry env inside it). This is deliberate, not accumulation:
   moves only at hardware-verified milestones. Each clone sits pinned at
   its service's last *verified* deploy — a per-service rollback point,
   not drift.
-- The queueserver worker and capture daemon are the one deliberate
-  exception: they share `~/qs-checkout` because their co-location (and
-  co-versioning) is a requirement of the capture design.
+- Two deliberate exceptions, each with its own isolation story: the
+  queueserver worker and capture daemon **share** their clone because
+  co-location (and co-versioning) is a requirement of the capture
+  design; the MCP server reads the worker's checkout (its config
+  validation must exactly match worker truth) but isolates by
+  installing **non-editably into its own baked venv** — a pull never
+  mutates code under the running service. The Windows PVA fleet
+  inverts the pattern entirely: no per-host clones, one shared
+  "Active Version" clone as the fleet pin, baked per-host venvs.
+- The path is a convention, not the invariant: the interim host uses
+  `~/<service>-checkout` names; the qserver runbook's
+  `/opt/geecs/GEECS-Plugins` layout for a dedicated host is the same
+  pattern — one clone per service family, wherever it lives.
 
 A clone is deployed by `git pull` (or checkout of a pinned ref) +
 `poetry install` **with the extras that service needs** (each runbook


### PR DESCRIPTION
Docs-only, from the owner's question after the W2a deploy ("are we accumulating clones at different states?" — answer: it's the deliberate pattern, but it deserved to be a documented fact rather than archaeology):

- **Checkout column** in the services table: which clone each service runs from, as service-account-relative paths (public-repo hygiene: no account names). Tiled/DB/NAS marked as non-repo services; the capture daemon's shared clone with the worker called out as the one deliberate exception (co-versioning is part of the co-location requirement).
- **"One clone per service" section**: the rule and its teeth — `Restart=on-failure` means a shared tree leaves every other service one crash away from restarting onto unvalidated code; per-service cadence; each clone as a pinned rollback point.
- **Fresh-host bootstrap gotchas** collected from the live deploys, ahead of the services-server consolidation: service-account installs, per-clone extras, config.ini, non-login-shell PATH (`bash -lc`), the CRLF trap on share-hosted config checkouts (`core.autocrlf true`, never rewrite in place — LabVIEW reads the same files), quoting space-bearing share paths in `ExecStart`, and the deploy-then-health-check-then-update-this-page loop.
- Snapshot note bumped to September 2026 (portal 0.15.x deployed).

`mkdocs build` clean (exit 0). No package code touched — no version bumps owed (fleet map lives in root docs/).

Landing to master per the owner's explicit instruction; adversarial review to follow as a PR comment before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)