### PR TITLE
Planning: schema refactor Phase 2 amendment (three steps after #734)

### DIFF
--- a/Planning/schema_refactor/00_overview.md
+++ b/Planning/schema_refactor/00_overview.md
@@ -1,9 +1,11 @@
 # ScanRequest schema refactor + named scan plans
 
 Handoff design doc, 2026-09-01 (Sam + Claude session on the HTU/OSPREY integration).
-Status: **approved direction, implementation starting** (amended 2026-09-01 after
-review with Sam: priorities, naming, migration story, invariants). Written for
-whoever picks this up; assumes no context from the originating conversation.
+Status: **Phase 1 landed** (#734, merged 2026-09-01, hardware-verified on
+Undulator Scan004/Scan005 the same day); **Phase 2 amended 2026-09-01** after
+reading the engine with Sam (see "Findings from reading the engine" and the
+three-step Phase 2 below). Written for whoever picks this up; assumes no
+context from the originating conversation.
 
 ## Priorities: the console comes first
 
@@ -106,7 +108,90 @@ two things:
 This phase is worth doing regardless of Phase 2, and Phase 2 is thin only if
 this lands first.
 
-### Phase 2 — three named plans (thin wrappers over the same path)
+**Landed** as #734 (GEECS-Schemas 0.14.0, GeecsBluesky 0.70.0, Console 0.26.0,
+MCP 0.8.0): everything above as written. Two things settled on the way that
+the next phase inherits:
+
+- **Versioning policy** (GEECS-Schemas `README.md`, "Versioning policy — two
+  dials"): the integer `schema_version` bumps only with a lifting migration;
+  additive fields ride the package version, the changelog, and the schema
+  artifact's git history. No `1.1`-style markers. Phase 2 adds no document
+  fields, so `schema_version` stays 2.
+- **Deploy order is worker-first** whenever the funnel's signature changes
+  (a stamping client against an older worker fails queue-add validation).
+  Phase 2 adds plans rather than changing the funnel, so it has no such
+  edge — but the preamble unification below touches the funnel body and
+  must keep its signature.
+
+### Findings from reading the engine (2026-09-01, pre-Phase 2)
+
+Phase 2 as first written assumed the wrappers could be thin because they
+would "delegate to the exact same execution path". Reading GeecsBluesky with
+that in mind:
+
+- **The prologue exists twice.** `plans/scan_request_plan.py`'s plan body
+  (`_scan_request_body` / `_optimize_request_body`) and the headless
+  `scan_request_runner.run_scan_request` / `_run_optimize_request` each walk
+  validate → resolve → construct → connect → claim over the same pure
+  helpers. The queueserver migration relocated the prologue into the plan
+  preamble deliberately and left the headless one for the in-process
+  session; the two are kept aligned by hand ("mirrors …" comments). Three
+  named plans on top of this would either pick one (drift) or add a third.
+- **Caller audit of the headless path** (non-test, whole repo): the only
+  caller of `run_scan_request` is `GeecsSession.run`; nothing in
+  GEECS-Console, GEECS-MCP, or GEECS-DataPortal calls the session method.
+  What keeps it alive: the hermetic engine suite (`test_scan_request_runner`
+  alone references it ~57 times), the env-gated hardware sweep test
+  (`test_scan_request_hardware.py` drives `session.run`), and its standing
+  as the documented headless/scripting API (GeecsBluesky `CLAUDE.md`). It is
+  a test harness and a scripting API, not a dead limb — keep the entry
+  point, drop the second orchestration.
+- **`scan_request_runner.py` is a grab-bag, not a runner** (~2200 lines):
+  save-set merging and rituals, action-slot assembly, experiment defaults,
+  validation, movable/detector construction, liveness preflight, telemetry
+  readables, and the headless run functions share one module because they
+  accreted during the consolidation. Distinct concerns, distinct tests.
+- **Mode behaviour is scattered branches**, not one place per mode:
+  noscan-as-one-step and the motor-argument choice in the spec builder,
+  optimize-skips-actions in the run function, the step/optimize dispatch in
+  the plan body. Fine at three modes; not at five.
+- **What a plan can express.** A named plan can only assemble what
+  `ScanRequest` already executes (noscan / step / optimize). Recombining
+  existing capability into an operator-shaped plan is cheap after Phase 2.
+  A genuinely new *execution* semantics (traversal ordering, burst, a
+  different shot loop) is engine work first — enum + validator in the
+  schema, a spec-builder branch or new generator in GeecsBluesky — and only
+  then a cheap plan. Two-tier cost, by design.
+
+### Phase 2 — three named plans, in three steps
+
+Phase 2 is now three ordered steps. Step 2a is the one the engine reading
+added; 2b is the original Phase 2; 2c is the OSPREY tail.
+
+#### 2a — one preamble (pure refactor, no behaviour change)
+
+Make the plan body the single orchestration: `GeecsSession.run` becomes
+`RE(geecs_scan_request_plan(...))` over the same body (or both call one
+named preamble function — whichever keeps `scan.log`'s pre-claim capture
+and the session's optimization suggester/objective seam intact; decide in
+the PR, not here). `run_scan_request` / `_run_optimize_request` then either
+delegate or go. The funnel's public signature (`request`, `submission`,
+`session`, `resolver`) does not change — no client or deploy-order impact.
+
+Acceptance: the hermetic suite passes with its entry point unchanged (it
+becomes the pin that the headless and queue paths cannot drift), the
+hardware sweep test still runs through `session.run`, and the "mirrors …"
+comments in the plan body have nothing left to mirror.
+
+**Judgment call, flagged for veto:** splitting `scan_request_runner.py` by
+concern (save sets / actions / defaults / validation / devices / preflight /
+telemetry) as a move-only commit in the same PR, while those tests are
+already open. Zero logic change, large diff. If the PR-size cost outweighs
+the navigability win, defer it to the first new-mode PR. The per-mode
+spec-builder registry is **deferred** regardless — build it when a fourth
+mode forces it, not before.
+
+#### 2b — the three named plans
 
 Register in the qserver startup profile, beside the existing funnel:
 
@@ -136,6 +221,18 @@ submitting through the funnel and adopts named plans only if they earn it.
 GEECS-Console and GEECS-MCP `submit_scan` keep submitting ScanRequest documents
 untouched, into the same queue. The funnel retires (or stays forever as the
 machine API) on usage evidence — strangler-fig, no migration cliff.
+
+Each named plan's parameter model lives in GEECS-Schemas (pydantic-only, so
+it exports through `schema_export` like `ScanRequest`), its plan function in
+GeecsBluesky beside the funnel, its `user_group_permissions` entry in the
+qserver profile. Per-plan JSON Schema artifacts land under
+`docs/geecs_schemas/` with the same no-drift guard.
+
+#### 2c — OSPREY tail (optional, no deadline)
+
+Per-plan `parameter_schemas` entries in the HTU deployment profile, optional
+`PLAN_LAYOUTS` polish, and the permissions-granularity check (gate
+`geecs_optimize_plan` for a test group). Detailed under "OSPREY-side impact".
 
 ### Why three plans rather than a discriminated union on `mode`
 
@@ -177,8 +274,11 @@ and gates.
   scoped, not yet implemented — tracked in the osprey#816 orbit, not here.
 - **GEECS-Plugins#727 item 3**: document-stream contract (`:5568`) for live
   scan rows in the OSPREY panel.
-- **OWED from #730**: worker restart on the qserver host so `plans_allowed`
-  serves the parameter annotations.
+- ~~OWED from #730: worker restart on the qserver host~~ — closed 2026-09-01
+  by the #734 verification restart (worker at GeecsBluesky 0.70.0).
+- **Interim-host checkout drift**: the worker host's GEECS-Plugins checkout
+  was left detached at the #734 branch tip; sync it to master before the 2a
+  deploy.
 
 ## Pointers
 
@@ -201,10 +301,16 @@ and gates.
    got simpler, not just different — this is the checkpoint that matters.
    (Re-vendoring the artifact into the HTU deployment repo to eyeball the
    OSPREY form is a nice-to-have, not a gate.)
-3. Phase 2 PR (GeecsBluesky: three wrappers + annotations + startup
-   registration; funnel untouched; shared-execution invariant pinned by
-   tests).
-4. Optional OSPREY tail, no deadline: publish per-plan schema artifacts;
-   add the three `parameter_schemas` entries in the HTU profile; verify
-   permissions granularity end-to-end (gate `geecs_optimize_plan` for a
-   test group).
+3. ~~Phase 2 PR~~ → now three PRs, in order:
+   - **2a** (GeecsBluesky only): one preamble; hermetic suite unchanged at
+     its entry point; hardware sweep test still green; runner module split
+     as a flagged, vetoable move-only commit.
+   - **2b** (GEECS-Schemas minor + GeecsBluesky minor): three parameter
+     models + three plans + annotations + startup registration + permissions
+     + per-plan artifacts; funnel untouched; shared-execution invariant
+     pinned by tests (each plan's recorded start doc is a `ScanRequest`).
+   - **2c** OSPREY tail, no deadline (see above).
+4. Hardware verification per PR, worker-first: 2a = one console noscan and
+   one optimize smoke through the funnel (nothing should look different);
+   2b = one queue item per named plan from the qserver CLI, start docs
+   checked for the canonical `ScanRequest` shape.


### PR DESCRIPTION
Planning-only. Amends `Planning/schema_refactor/00_overview.md` after #734 merged and was hardware-verified (Undulator Scan004/Scan005, 2026-09-01).

## What

- Status + Phase 1 marked **landed**, with the two things Phase 2 inherits: the versioning policy written down in #734 (integer `schema_version` bumps only with a migration) and the worker-first deploy order.
- New section **"Findings from reading the engine"**: the prologue exists twice (plan body + headless `run_scan_request`), the headless path's caller audit (only `GeecsSession.run`; alive as the hermetic-suite entry point, the hardware sweep test, and the documented scripting API — not a dead limb), `scan_request_runner.py` as a grab-bag module, scattered mode branches, and the two-tier cost of new plans vs new execution modes.
- **Phase 2 split into three ordered steps**: 2a one preamble (pure refactor, funnel signature unchanged), 2b the three named plans (unchanged from the original Phase 2, plus where each piece lives), 2c the OSPREY tail.
- Open items: #730 OWED restart closed by the #734 verification restart; worker-host checkout drift noted.
- Sequencing updated to three PRs with per-PR hardware verification.

## Why

Sam asked whether the schema change was smaller than imagined and where the per-mode split went; the answer is Phase 2, and reading the engine before building it showed the wrappers cannot be thin while two orchestrations exist. This records that so the implementer starts at 2a.

## Judgment calls flagged for veto (in the doc itself)

- 2a's runner module split by concern as a move-only commit in the same PR (large diff, zero logic change) — or deferred to the first new-mode PR.
- Per-mode spec-builder registry explicitly **deferred** until a fourth mode forces it.

## Tests / versions

No package code changed; no version bump; no test suites affected.

## Hardware verification

N/A (planning document).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N6sdn4meUHi3R1qD9yC4Hf