### PR TITLE
GEECS-MCP 0.8.1: warm the progress stream at HTTP-server startup (#685)

### DIFF
--- a/GEECS-MCP/CHANGELOG.md
+++ b/GEECS-MCP/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to `geecs-mcp` are documented here.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.8.1] - 2026-09-01
+
+### Fixed
+
+- **First scan after an HTTP-service restart streamed no counts**
+  (#685): the `ProgressCache` consumer threads started lazily on the
+  first `scan_progress` call, so a long-lived `--transport http` service
+  whose first poll came after the run's start document showed
+  `stream: {available: true}` with no scan number / shot counts. The
+  HTTP entry point now warms the cache at startup
+  (`__main__.warm_progress_stream`) from the queue client's own
+  `doc_addr` / `info_addr` — the same resolution `scan_progress` uses,
+  now shared as `progress_stream.start_for_client`. Best-effort: a
+  client that will not build or a missing address is logged and the
+  server still comes up. Stdio sessions keep the lazy start.
+
 ## [0.8.0] - 2026-09-01
 
 ### Changed

--- a/GEECS-MCP/CLAUDE.md
+++ b/GEECS-MCP/CLAUDE.md
@@ -192,6 +192,10 @@ geecs_mcp/
   console-text stream's failed-move line as the paused reason
   (surfaced only while actually paused — sticky otherwise).  The
   manager poll stays authoritative; `stream.available=false` names why.
+  The consumer threads start lazily on the first `scan_progress` call
+  (stdio) but the HTTP entry point warms them at startup (#685) — a
+  long-lived service must be consuming before its first start document
+  passes, or that run shows no counts.
 
 ## Testing
 

--- a/GEECS-MCP/CLAUDE.md
+++ b/GEECS-MCP/CLAUDE.md
@@ -192,10 +192,13 @@ geecs_mcp/
   console-text stream's failed-move line as the paused reason
   (surfaced only while actually paused — sticky otherwise).  The
   manager poll stays authoritative; `stream.available=false` names why.
-  The consumer threads start lazily on the first `scan_progress` call
-  (stdio) but the HTTP entry point warms them at startup (#685) — a
-  long-lived service must be consuming before its first start document
-  passes, or that run shows no counts.
+  The HTTP entry point warms the consumer threads at startup (#685) —
+  a long-lived service must be consuming before its first start
+  document passes, or that run shows no counts.  Stdio still starts
+  them lazily on the first `scan_progress` call (owner scope on #685),
+  so a stdio session that submits before its first poll has the same
+  first-run exposure; dropping the transport gate in
+  `__main__.main` is the one-line remedy if that bites.
 
 ## Testing
 

--- a/GEECS-MCP/geecs_mcp/__main__.py
+++ b/GEECS-MCP/geecs_mcp/__main__.py
@@ -24,8 +24,8 @@ def warm_progress_stream() -> None:
 
     HTTP mode only: a long-lived service must be consuming BEFORE its
     first run's start document passes — the lazy start behind
-    ``scan_progress`` (fine for a short-lived stdio session) left the
-    first scan after a service restart with no scan number or counts.
+    ``scan_progress`` (stdio keeps it — see ``_stream_snapshot``) left
+    the first scan after a service restart with no scan number or counts.
     Best-effort like the cache itself: nothing here can stop the server
     from coming up.  The cache logs what it did (consuming from which
     address, or latched unconfigured); the guard below only covers a

--- a/GEECS-MCP/geecs_mcp/__main__.py
+++ b/GEECS-MCP/geecs_mcp/__main__.py
@@ -27,30 +27,21 @@ def warm_progress_stream() -> None:
     ``scan_progress`` (fine for a short-lived stdio session) left the
     first scan after a service restart with no scan number or counts.
     Best-effort like the cache itself: nothing here can stop the server
-    from coming up — a client that will not build is logged, and a
-    missing address is the cache's own honest ``available=false``.
+    from coming up.  The cache logs what it did (consuming from which
+    address, or latched unconfigured); the guard below only covers a
+    client that will not build — a path the seams underneath promise not
+    to take, kept so the boot can never die on it.
     """
     try:
         from geecs_mcp import runtime
         from geecs_mcp.scans import progress_stream
 
-        client = runtime.get_queue_client()
-        progress_stream.start_for_client(client)
+        progress_stream.start_for_client(runtime.get_queue_client())
     except Exception as exc:
         logger.warning(
             "progress stream not warmed at startup (%s) — scan_progress "
             "will start it lazily on first call",
             exc,
-        )
-        return
-    doc_addr = getattr(client, "doc_addr", None)
-    if doc_addr:
-        logger.info("progress stream warming from document stream %s", doc_addr)
-    else:
-        logger.warning(
-            "progress stream not warmed: no document-stream address "
-            "([qserver] unconfigured?) — scan_progress reports "
-            "stream.available=false"
         )
 
 

--- a/GEECS-MCP/geecs_mcp/__main__.py
+++ b/GEECS-MCP/geecs_mcp/__main__.py
@@ -16,6 +16,43 @@ from __future__ import annotations
 import argparse
 import logging
 
+logger = logging.getLogger("geecs_mcp.main")
+
+
+def warm_progress_stream() -> None:
+    """Start the ``scan_progress`` stream consumers before the first run (#685).
+
+    HTTP mode only: a long-lived service must be consuming BEFORE its
+    first run's start document passes — the lazy start behind
+    ``scan_progress`` (fine for a short-lived stdio session) left the
+    first scan after a service restart with no scan number or counts.
+    Best-effort like the cache itself: nothing here can stop the server
+    from coming up — a client that will not build is logged, and a
+    missing address is the cache's own honest ``available=false``.
+    """
+    try:
+        from geecs_mcp import runtime
+        from geecs_mcp.scans import progress_stream
+
+        client = runtime.get_queue_client()
+        progress_stream.start_for_client(client)
+    except Exception as exc:
+        logger.warning(
+            "progress stream not warmed at startup (%s) — scan_progress "
+            "will start it lazily on first call",
+            exc,
+        )
+        return
+    doc_addr = getattr(client, "doc_addr", None)
+    if doc_addr:
+        logger.info("progress stream warming from document stream %s", doc_addr)
+    else:
+        logger.warning(
+            "progress stream not warmed: no document-stream address "
+            "([qserver] unconfigured?) — scan_progress reports "
+            "stream.available=false"
+        )
+
 
 def main() -> None:
     """Parse transport options and run the server."""
@@ -34,6 +71,7 @@ def main() -> None:
 
     server = create_server()
     if args.transport == "http":
+        warm_progress_stream()
         server.run(transport="http", host=args.host, port=args.port)
     else:
         server.run()

--- a/GEECS-MCP/geecs_mcp/scans/control_tools.py
+++ b/GEECS-MCP/geecs_mcp/scans/control_tools.py
@@ -574,7 +574,9 @@ async def resume_scan(force: bool = False) -> str:
 def _stream_snapshot(client, re_state: str | None) -> dict:
     """The document-stream picture, started lazily from the client's addrs.
 
-    Best-effort BY DESIGN: ``available=false`` (with the reason) when the
+    Lazy is the stdio posture; the HTTP service warms the same cache at
+    startup (``__main__.warm_progress_stream``, #685) and this call is
+    then the idempotent no-op.  Best-effort BY DESIGN: ``available=false`` (with the reason) when the
     stream cannot be consumed, and the poll fields stand alone.  The
     sticky ``paused_reason`` (the console-text stream's failed-move line)
     is only surfaced while the RE is actually paused — after a resume the
@@ -582,11 +584,7 @@ def _stream_snapshot(client, re_state: str | None) -> dict:
     """
     from geecs_mcp.scans import progress_stream
 
-    cache = progress_stream.get_progress_cache()
-    cache.ensure_started(
-        getattr(client, "doc_addr", None), getattr(client, "info_addr", None)
-    )
-    snapshot = cache.snapshot()
+    snapshot = progress_stream.start_for_client(client).snapshot()
     if re_state != "paused":
         snapshot.pop("paused_reason", None)
     return snapshot

--- a/GEECS-MCP/geecs_mcp/scans/control_tools.py
+++ b/GEECS-MCP/geecs_mcp/scans/control_tools.py
@@ -574,9 +574,11 @@ async def resume_scan(force: bool = False) -> str:
 def _stream_snapshot(client, re_state: str | None) -> dict:
     """The document-stream picture, started lazily from the client's addrs.
 
-    Lazy is the stdio posture; the HTTP service warms the same cache at
-    startup (``__main__.warm_progress_stream``, #685) and this call is
-    then the idempotent no-op.  Best-effort BY DESIGN: ``available=false`` (with the reason) when the
+    The HTTP service warms the same cache at startup
+    (``__main__.warm_progress_stream``, #685) and this call is then the
+    idempotent no-op; stdio relies on this lazy start alone, so a run
+    submitted before the first poll streams no counts there.  Best-effort
+    BY DESIGN: ``available=false`` (with the reason) when the
     stream cannot be consumed, and the poll fields stand alone.  The
     sticky ``paused_reason`` (the console-text stream's failed-move line)
     is only surfaced while the RE is actually paused — after a resume the

--- a/GEECS-MCP/geecs_mcp/scans/progress_stream.py
+++ b/GEECS-MCP/geecs_mcp/scans/progress_stream.py
@@ -203,3 +203,21 @@ _cache = ProgressCache()
 def get_progress_cache() -> ProgressCache:
     """The process-wide cache instance (module attribute = the patch seam)."""
     return _cache
+
+
+def start_for_client(client: Any) -> ProgressCache:
+    """Start the process-wide cache from a queue client's stream addresses.
+
+    THE one address resolution — ``doc_addr`` / ``info_addr`` read off the
+    client (``None`` on a stub or an unconfigured ``[qserver]``, which the
+    cache reports honestly).  Two callers: ``scan_progress`` on every poll
+    (the lazy start, stdio's posture) and the HTTP entry point once at
+    startup (#685), so a long-lived service is already consuming when its
+    first run's start document passes.  Returns the cache for the caller's
+    snapshot.
+    """
+    cache = get_progress_cache()
+    cache.ensure_started(
+        getattr(client, "doc_addr", None), getattr(client, "info_addr", None)
+    )
+    return cache

--- a/GEECS-MCP/geecs_mcp/scans/progress_stream.py
+++ b/GEECS-MCP/geecs_mcp/scans/progress_stream.py
@@ -87,7 +87,13 @@ class ProgressCache:
             self._doc_addr = doc_addr
             if not doc_addr:
                 self._detail = "no document-stream address configured"
+                logger.warning(
+                    "progress stream not started: no document-stream address "
+                    "([qserver] unconfigured?) — scan_progress reports "
+                    "stream.available=false"
+                )
                 return
+        logger.info("progress stream consuming document stream %s", doc_addr)
         threading.Thread(
             target=self._run_documents,
             args=(doc_addr,),

--- a/GEECS-MCP/pyproject.toml
+++ b/GEECS-MCP/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-mcp"
-version = "0.8.0"
+version = "0.8.1"
 description = "MCP server exposing GEECS scan submission, monitoring, and config discovery to AI agents (OSPREY)"
 authors = ["Sam Barber <sbarber@lbl.gov>"]
 readme = "README.md"

--- a/GEECS-MCP/tests/test_entry_point.py
+++ b/GEECS-MCP/tests/test_entry_point.py
@@ -1,0 +1,109 @@
+"""``python -m geecs_mcp`` transport wiring: the HTTP-mode stream warm-up (#685).
+
+Hermetic like the rest of the suite: the server, the queue client and the
+process-wide cache are all patched on their modules — no zmq, no threads.
+"""
+
+from __future__ import annotations
+
+import logging
+from types import SimpleNamespace
+
+import pytest
+
+from geecs_mcp import __main__ as entry
+from geecs_mcp import runtime, server
+from geecs_mcp.scans import progress_stream
+
+
+class _FakeCache:
+    def __init__(self, log):
+        self._log = log
+        self.started_with = None
+
+    def ensure_started(self, doc_addr, info_addr):
+        self.started_with = (doc_addr, info_addr)
+        self._log.append("ensure_started")
+
+    def snapshot(self):
+        return {"available": False, "detail": ""}
+
+
+class _FakeServer:
+    def __init__(self, log):
+        self._log = log
+        self.run_kwargs = None
+
+    def run(self, **kwargs):
+        self.run_kwargs = kwargs
+        self._log.append("run")
+
+
+@pytest.fixture
+def wired(monkeypatch):
+    """Patched server + client + cache; returns (log, cache, fake_server)."""
+    log: list[str] = []
+    cache = _FakeCache(log)
+    fake_server = _FakeServer(log)
+    client = SimpleNamespace(
+        doc_addr="localhost:5568", info_addr="tcp://localhost:60625"
+    )
+    monkeypatch.setattr(server, "create_server", lambda: fake_server)
+    monkeypatch.setattr(runtime, "get_queue_client", lambda: client)
+    monkeypatch.setattr(progress_stream, "get_progress_cache", lambda: cache)
+    return log, cache, fake_server
+
+
+def test_http_transport_warms_the_stream_before_serving(wired, monkeypatch):
+    log, cache, fake_server = wired
+    monkeypatch.setattr(
+        "sys.argv", ["geecs_mcp", "--transport", "http", "--port", "8123"]
+    )
+    entry.main()
+    # Started from the queue client's own addresses, and BEFORE the server
+    # blocks in run() — the whole point: consuming before the first start doc.
+    assert cache.started_with == ("localhost:5568", "tcp://localhost:60625")
+    assert log == ["ensure_started", "run"]
+    assert fake_server.run_kwargs == {
+        "transport": "http",
+        "host": "0.0.0.0",
+        "port": 8123,
+    }
+
+
+def test_stdio_transport_keeps_the_lazy_start(wired, monkeypatch):
+    log, cache, fake_server = wired
+    monkeypatch.setattr("sys.argv", ["geecs_mcp"])
+    entry.main()
+    assert cache.started_with is None
+    assert log == ["run"]
+    assert fake_server.run_kwargs == {}
+
+
+def test_warm_up_failure_never_stops_the_server(wired, monkeypatch, caplog):
+    log, cache, fake_server = wired
+
+    def boom():
+        raise RuntimeError("config.ini unreadable")
+
+    monkeypatch.setattr(runtime, "get_queue_client", boom)
+    monkeypatch.setattr("sys.argv", ["geecs_mcp", "--transport", "http"])
+    with caplog.at_level(logging.WARNING, logger="geecs_mcp.main"):
+        entry.main()
+    assert cache.started_with is None
+    assert log == ["run"]
+    assert "not warmed at startup" in caplog.text
+    assert "config.ini unreadable" in caplog.text
+
+
+def test_warm_up_without_addresses_degrades_honestly(wired, monkeypatch, caplog):
+    log, cache, _ = wired
+    # The stub client of an unconfigured [qserver]: addresses are None.
+    monkeypatch.setattr(runtime, "get_queue_client", lambda: SimpleNamespace())
+    monkeypatch.setattr("sys.argv", ["geecs_mcp", "--transport", "http"])
+    with caplog.at_level(logging.WARNING, logger="geecs_mcp.main"):
+        entry.main()
+    # Latched unconfigured (the cache's own honest available=false), served anyway.
+    assert cache.started_with == (None, None)
+    assert log == ["ensure_started", "run"]
+    assert "no document-stream address" in caplog.text

--- a/GEECS-MCP/tests/test_entry_point.py
+++ b/GEECS-MCP/tests/test_entry_point.py
@@ -81,6 +81,9 @@ def test_stdio_transport_keeps_the_lazy_start(wired, monkeypatch):
 
 
 def test_warm_up_failure_never_stops_the_server(wired, monkeypatch, caplog):
+    # Pins the boot guarantee, not a known path: runtime.get_queue_client
+    # returns the stub on bad/missing config by the seams' own contracts,
+    # so this branch is defence in depth — the server must come up anyway.
     log, cache, fake_server = wired
 
     def boom():
@@ -96,14 +99,13 @@ def test_warm_up_failure_never_stops_the_server(wired, monkeypatch, caplog):
     assert "config.ini unreadable" in caplog.text
 
 
-def test_warm_up_without_addresses_degrades_honestly(wired, monkeypatch, caplog):
+def test_warm_up_without_addresses_degrades_honestly(wired, monkeypatch):
     log, cache, _ = wired
     # The stub client of an unconfigured [qserver]: addresses are None.
     monkeypatch.setattr(runtime, "get_queue_client", lambda: SimpleNamespace())
     monkeypatch.setattr("sys.argv", ["geecs_mcp", "--transport", "http"])
-    with caplog.at_level(logging.WARNING, logger="geecs_mcp.main"):
-        entry.main()
-    # Latched unconfigured (the cache's own honest available=false), served anyway.
+    entry.main()
+    # Latched unconfigured (the cache's own honest available=false — and its
+    # own warning, pinned in test_progress_stream.py), served anyway.
     assert cache.started_with == (None, None)
     assert log == ["ensure_started", "run"]
-    assert "no document-stream address" in caplog.text

--- a/GEECS-MCP/tests/test_progress_stream.py
+++ b/GEECS-MCP/tests/test_progress_stream.py
@@ -126,3 +126,27 @@ def test_ensure_started_without_doc_addr_degrades_honestly():
     # Idempotent: a second call must not spawn anything or reset state.
     cache.ensure_started(None, None)
     assert cache.snapshot()["detail"] == snap["detail"]
+
+
+def test_start_for_client_reads_the_client_addresses(monkeypatch):
+    # THE one address resolution shared by scan_progress and the HTTP
+    # startup warm-up (#685): both go through start_for_client.
+    from types import SimpleNamespace
+
+    from geecs_mcp.scans import progress_stream
+
+    seen = []
+
+    class _Recorder:
+        def ensure_started(self, doc_addr, info_addr):
+            seen.append((doc_addr, info_addr))
+
+    recorder = _Recorder()
+    monkeypatch.setattr(progress_stream, "get_progress_cache", lambda: recorder)
+    client = SimpleNamespace(
+        doc_addr="localhost:5568", info_addr="tcp://localhost:60625"
+    )
+    assert progress_stream.start_for_client(client) is recorder
+    # A stub client without the attributes resolves to None, not an error.
+    progress_stream.start_for_client(object())
+    assert seen == [("localhost:5568", "tcp://localhost:60625"), (None, None)]

--- a/GEECS-MCP/tests/test_progress_stream.py
+++ b/GEECS-MCP/tests/test_progress_stream.py
@@ -117,12 +117,18 @@ def test_unstarted_cache_reports_unavailable():
     assert snap["available"] is False and "not started" in snap["detail"]
 
 
-def test_ensure_started_without_doc_addr_degrades_honestly():
+def test_ensure_started_without_doc_addr_degrades_honestly(caplog):
+    import logging
+
     cache = ProgressCache()
-    cache.ensure_started(None, "tcp://localhost:60625")
+    with caplog.at_level(logging.WARNING, logger="geecs_mcp.scans.progress_stream"):
+        cache.ensure_started(None, "tcp://localhost:60625")
     snap = cache.snapshot()
     assert snap["available"] is False
     assert "no document-stream address" in snap["detail"]
+    # The cache itself says why (the startup warm-up and the lazy path
+    # share this one log line — #748 review finding 2).
+    assert "no document-stream address" in caplog.text
     # Idempotent: a second call must not spawn anything or reset state.
     cache.ensure_started(None, None)
     assert cache.snapshot()["detail"] == snap["detail"]


### PR DESCRIPTION
Closes #685.

## What + why

Live finding from the v2 deployment checks: the `ProgressCache` consumer threads (document stream + console-text stream) started **lazily on the first `scan_progress` call**. In `--transport http` mode — a long-lived systemd service — the first scan after a restart was typically submitted before any `scan_progress` poll, so the dispatcher subscribed *after* the start document had passed and that whole run showed `stream: {available: true}` with no scan number / shot counts. The second scan streamed fine (warm cache).

Fix, one concern:

- `geecs_mcp/__main__.py` — new `warm_progress_stream()`, called in the `http` branch of `main()` **before** `server.run(...)`. Resolves the queue client via `runtime.get_queue_client()` and starts the cache from its `doc_addr` / `info_addr`. Best-effort: a client that will not build is logged (`WARNING`) and the server still comes up; a missing address (stub client / unconfigured `[qserver]`) latches the cache's own honest `available=false` and logs why. Stdio sessions keep the lazy start (short-lived; first call usually precedes the first submit).
- `geecs_mcp/scans/progress_stream.py` — `start_for_client(client)`: the **one** address resolution (the two `getattr`s that lived inline in `control_tools._stream_snapshot`), now shared by the lazy path and the startup warm-up rather than duplicated. Returns the cache.
- `geecs_mcp/scans/control_tools.py` — `_stream_snapshot` calls `start_for_client` (idempotent no-op after the warm-up); docstring says so.
- `CLAUDE.md` — one sentence on the lazy-vs-warmed rule under the `scan_progress` stream paragraph.
- `CHANGELOG.md` 0.8.1 (patch — a bug fix, no API change).

LOC: runtime code +38 / −6 / +18 across the three modules; tests +133; docs +20.

**Judgment call (cheap to veto):** when `doc_addr` is `None` at startup the warm-up still calls `ensure_started(None, None)` and latches the cache unconfigured (the same picture `scan_progress` would latch a moment later, since the queue client is cached by `runtime` too — a config change already needs a restart per the cache's own docstring). The alternative — skipping the latch so a later lazy call could retry — buys nothing while the client stays cached, so I kept the single code path.

## Tests

`./scripts/check.sh` (lint + GEECS-MCP suite, the way CI runs it): **102 passed, 1 skipped** (was 97 + 1; 5 new):

- `tests/test_entry_point.py` (new, 4): http warms the cache with the client's addresses **before** `run()` is entered (order pinned via a shared event log); stdio does not touch the cache; a queue-client build failure logs and the server still runs; a client without addresses latches `(None, None)`, logs the honest warning, and still serves.
- `tests/test_progress_stream.py` (+1): `start_for_client` reads `doc_addr`/`info_addr` off the client, returns the cache, and resolves a bare object to `(None, None)`.

## Hardware verification

**OWED** (touches the deployed HTTP service, not scan execution): restart `geecs-mcp` on the qserver host with 0.8.1, confirm the startup log line `progress stream warming from document stream <host>:5568`, submit a scan and call `scan_progress` only *after* ~10 s into the run — expected: `stream.scan_number` set and `shots_done` advancing (e.g. `2 → … → 25/25` with `shots_total`) on that **first** run, not just the second. Also expected: the warm-up latches the addresses from `~/.config/geecs_python_api/config.ini` `[qserver]` — if the service's config points at the wrong host the stream reads available-but-empty exactly as before (documented honesty boundary, unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TaoM69XhJ6EJQfMwBpbpf4