### PR TITLE
GEECS-DataPortal 0.15.3: union-frame responses never immutable (s-file grows after the run)

### DIFF
--- a/GEECS-DataPortal/CHANGELOG.md
+++ b/GEECS-DataPortal/CHANGELOG.md
@@ -15,9 +15,10 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   when re-run by hand), so a browser that had fetched the column list
   before analysis stayed pinned to the pre-analysis shape for a year
   (scan 32 showing 7 columns while scan 33 showed 30, 2026-09-01).
-  These responses now always revalidate (`no-cache`); the per-shot
-  `image.png` and `plot.png`, which read the event table alone, keep
-  their immutable headers.
+  These responses (and `filter-count`, which had no header at all)
+  are now `no-cache` — a plain re-fetch, no validator is emitted; the
+  per-shot `image.png` and `plot.png`, which read the event table
+  alone, keep their immutable headers.
 
 ## [0.15.2] - 2026-09-01
 

--- a/GEECS-DataPortal/CHANGELOG.md
+++ b/GEECS-DataPortal/CHANGELOG.md
@@ -3,6 +3,22 @@
 All notable changes to this package will be documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.15.3] - 2026-09-01
+
+### Fixed
+
+- Responses computed over the union frame — `/api/run/{uid}/columns`,
+  `frame`, `binned`, `bin-images` and `bin-image.png` — are no longer
+  served `immutable` for completed runs. The event table is frozen once
+  the run stops, but the s-file half of the union is not: ScanAnalysis
+  appends its columns to `analysis/sN.txt` after the scan (hours later
+  when re-run by hand), so a browser that had fetched the column list
+  before analysis stayed pinned to the pre-analysis shape for a year
+  (scan 32 showing 7 columns while scan 33 showed 30, 2026-09-01).
+  These responses now always revalidate (`no-cache`); the per-shot
+  `image.png` and `plot.png`, which read the event table alone, keep
+  their immutable headers.
+
 ## [0.15.2] - 2026-09-01
 
 ### Fixed

--- a/GEECS-DataPortal/CLAUDE.md
+++ b/GEECS-DataPortal/CLAUDE.md
@@ -61,10 +61,16 @@ this package; the architecture rules below are its distillation.
   executes server-side, and its prototype-pollution guard lives with
   it: cosmetic asks should land there, not as new per-knob code):
   a link IS the analysis, which is also the multi-user story
-  (statelessness; shared caches are a feature).  Every `/api` fetch
-  additionally carries `v=<portal version>` — completed-run responses
-  cache immutable, and the version key rolls browser caches over when
-  a release changes the payload shape.
+  (statelessness; shared caches are a feature).  Cache policy is
+  by INPUT, not by URL: the per-shot `image.png` and `plot.png` read
+  the event table alone and cache immutable once the run has a stop
+  doc; everything over the union frame (`columns`, `frame`, `binned`,
+  `filter-count`, `bin-images`, `bin-image.png`) is `no-cache`
+  (`_UNION_HEADERS`), because the s-file half of the union GROWS after
+  the run — ScanAnalysis appends its columns hours later (the
+  7-vs-30-columns incident, 2026-09-01).  Every `/api` fetch and
+  bin-image card still carries `v=<portal version>` so an upgrade
+  that changes a payload shape rolls over whatever a cache kept.
 - **Prefix-agnostic URLs.**  The portal works at root and under any
   reverse-proxy mount (OSPREY panel tabs).  Templates never write a
   root-absolute portal URL directly: every href/action/src carries the
@@ -140,8 +146,8 @@ shot) · `/run/{uid}/bin-image.png?device=&bin=<index>&filters=&bincfg=`
 `bin-images` order, both endpoints run the same membership call;
 member shots that resolve to pixels average via the shared
 `average_frames`, windowed once after averaging; per-shot refusals
-carry over, and an ordinal-resolved member downgrades the response to
-`no-cache`) · `/health` (catalog probe — the fleet-map health check).
+carry over; always `no-cache` — bin membership comes off the union
+frame) · `/health` (catalog probe — the fleet-map health check).
 
 Both image endpoints also take `?display=` (the shared display state's
 image slice: `cmap` matplotlib-colormap name + `plo`/`phi` percentile
@@ -180,8 +186,10 @@ list — a new tab should be exactly these steps:
    plain-dataclass configs validate nothing themselves, so a
    wrong-typed field that only explodes inside the primitive is a 500
    waiting for a hand-edited URL), call the primitive, shape with
-   `jsonable_values`, attach a `code` snippet, serve with the
-   completed-run cache headers.
+   `jsonable_values`, attach a `code` snippet, serve with
+   `_UNION_HEADERS` (never `_png_headers` — that is for responses
+   over the event table alone; the s-file half of the union changes
+   after the run).
 3. **Figure** — if the tab plots, its figure builder goes in
    `figures.py` (pure functions, plotly.py, unit-tested in
    `tests/test_figures.py`) and the endpoint serves it as `figure`.
@@ -191,7 +199,8 @@ list — a new tab should be exactly these steps:
    `readState`/`writeState`); expansion UI goes behind a popup/⚙,
    never into the rail.
 5. **Tests** — endpoint tests against the fakes (hand-computed numbers,
-   the 400/404 ladder, NaN→null, immutable headers on completed runs).
+   the 400/404 ladder, NaN→null, `no-cache` headers even on completed
+   runs).
 
 ## Deployment
 

--- a/GEECS-DataPortal/geecs_portal/app.py
+++ b/GEECS-DataPortal/geecs_portal/app.py
@@ -70,9 +70,10 @@ _STATIC_DIR = Path(__file__).parent / "static"
 def _portal_version() -> str:
     """The installed package version — the /api cache-bust key.
 
-    Completed-run /api responses are served immutable, but their SHAPE
-    changes with portal releases; the page keys every /api fetch by
-    this version so browser caches roll over on upgrade.
+    The page keys every /api fetch by this version so any cached
+    response rolls over on upgrade (the /api JSON now always
+    revalidates — see ``_UNION_HEADERS`` — but the per-shot PNGs it
+    links are immutable, and the key is cheap insurance).
     """
     from importlib.metadata import PackageNotFoundError, version
 
@@ -84,6 +85,15 @@ def _portal_version() -> str:
 
 #: Cap on rows fed to a plot (quick-look, not a data browser).
 _PLOT_MAX_ROWS = 100_000
+
+#: Headers for every response computed over the union frame (columns,
+#: frame, binned, bin-images, bin-image.png). The event table is frozen
+#: once the run stops, but the s-file half of the union is NOT: ScanAnalysis
+#: appends its columns to ``analysis/sN.txt`` after the scan — hours later
+#: when it is re-run by hand — so a completed run's column list can grow.
+#: An immutable response would pin a browser to the pre-analysis shape
+#: for a year (the 7-vs-30-columns incident, 2026-09-01).
+_UNION_HEADERS = {"Cache-Control": "no-cache"}
 
 #: Requests carrying a proxy mount prefix — the Grafana/JupyterHub
 #: convention every reverse proxy speaks.
@@ -311,11 +321,12 @@ def create_app(
             ) from exc
 
     def _png_headers(detail) -> dict:
-        """Caching headers for the immutable-per-URL PNG endpoints.
+        """Caching headers for responses over the event table ALONE.
 
         A completed run (stop doc present) never changes, so its plot
-        and shot images are cacheable indefinitely; a still-running run
-        must revalidate.
+        and per-shot images are cacheable indefinitely; a still-running
+        run must revalidate. Anything touching the union frame (and so
+        the mutable s-file) uses ``_UNION_HEADERS`` instead.
         """
         if detail.summary.exit_status:
             return {"Cache-Control": "public, max-age=31536000, immutable"}
@@ -420,7 +431,7 @@ def create_app(
             "default_x": _default_x(detail, [c["name"] for c in columns]),
             "total": len(pf.frame),
         }
-        return JSONResponse(payload, headers=_png_headers(detail))
+        return JSONResponse(payload, headers=_UNION_HEADERS)
 
     @app.get("/api/run/{uid}/frame")
     def api_frame(
@@ -493,7 +504,7 @@ def create_app(
                 ),
                 display=disp,
             ).to_plotly_json()
-        return JSONResponse(payload, headers=_png_headers(detail))
+        return JSONResponse(payload, headers=_UNION_HEADERS)
 
     @app.get("/api/run/{uid}/binned")
     def api_binned(
@@ -601,7 +612,7 @@ def create_app(
                 pretty=pretty,
                 display=disp,
             ).to_plotly_json()
-        return JSONResponse(payload, headers=_png_headers(detail))
+        return JSONResponse(payload, headers=_UNION_HEADERS)
 
     @app.get("/api/run/{uid}/filter-count")
     def api_filter_count(uid: str, filters: str = "", day: str = "") -> dict:
@@ -814,7 +825,7 @@ def create_app(
             "total": len(pf.frame),
             "code": analysis.bin_images_code(uid, run_day, device, flt, cfg),
         }
-        return JSONResponse(payload, headers=_png_headers(detail))
+        return JSONResponse(payload, headers=_UNION_HEADERS)
 
     @app.get("/", response_class=RedirectResponse)
     def index(request: Request) -> str:
@@ -1179,7 +1190,6 @@ def create_app(
         complete = bool(detail.summary.exit_status)
         n_rows = None if detail.data is None else len(detail.data)
         arrays: list = []
-        cacheable = True
         for shot in shots:
             # Same refusals as the per-shot endpoint: never fall through
             # to an ordinal join beyond the recorded events (orphan
@@ -1204,7 +1214,6 @@ def create_app(
                         status_code=404, detail=resolved.reason or resolved.kind
                     )
                 continue
-            cacheable = cacheable and resolved.cacheable
             arrays.append(resolved.array)
         if processing and arrays:
             arrays = _apply_processing(arrays, processing)
@@ -1219,14 +1228,10 @@ def create_app(
             raise HTTPException(
                 status_code=404, detail=f"render failed: {exc}"
             ) from exc
-        # Processed responses never cache immutable: the diagnostic YAML
-        # is a mutable input the URL does not key (see run_image).
-        headers = (
-            {"Cache-Control": "no-cache"}
-            if (processing or not cacheable)
-            else _png_headers(detail)
-        )
-        return Response(content=png, media_type="image/png", headers=headers)
+        # Never immutable: bin membership comes off the union frame
+        # (mutable s-file), and the diagnostic YAML behind ``processing``
+        # is likewise a mutable input the URL does not key (see run_image).
+        return Response(content=png, media_type="image/png", headers=_UNION_HEADERS)
 
     @app.get("/run/{uid}/plot.png")
     def run_plot(uid: str, y: str, x: str = "") -> Response:

--- a/GEECS-DataPortal/geecs_portal/app.py
+++ b/GEECS-DataPortal/geecs_portal/app.py
@@ -70,10 +70,10 @@ _STATIC_DIR = Path(__file__).parent / "static"
 def _portal_version() -> str:
     """The installed package version — the /api cache-bust key.
 
-    The page keys every /api fetch by this version so any cached
-    response rolls over on upgrade (the /api JSON now always
-    revalidates — see ``_UNION_HEADERS`` — but the per-shot PNGs it
-    links are immutable, and the key is cheap insurance).
+    The page keys every /api fetch and bin-image card by this version.
+    Union-frame responses are ``no-cache`` now (``_UNION_HEADERS``), so
+    for them the key is only insurance against intermediaries; it still
+    matters for a payload-shape change behind any cached response.
     """
     from importlib.metadata import PackageNotFoundError, version
 
@@ -92,7 +92,9 @@ _PLOT_MAX_ROWS = 100_000
 #: appends its columns to ``analysis/sN.txt`` after the scan — hours later
 #: when it is re-run by hand — so a completed run's column list can grow.
 #: An immutable response would pin a browser to the pre-analysis shape
-#: for a year (the 7-vs-30-columns incident, 2026-09-01).
+#: for a year (the 7-vs-30-columns incident, 2026-09-01). No validator
+#: is emitted, so ``no-cache`` means a re-fetch, not a 304 — an ETag
+#: over the s-file's stat is the follow-up if revisits feel slow.
 _UNION_HEADERS = {"Cache-Control": "no-cache"}
 
 #: Requests carrying a proxy mount prefix — the Grafana/JupyterHub
@@ -615,12 +617,13 @@ def create_app(
         return JSONResponse(payload, headers=_UNION_HEADERS)
 
     @app.get("/api/run/{uid}/filter-count")
-    def api_filter_count(uid: str, filters: str = "", day: str = "") -> dict:
+    def api_filter_count(uid: str, filters: str = "", day: str = "") -> JSONResponse:
         """Live pass count for the filters popup: ``{pass, total}``."""
         detail = _load_run(uid)
         pf, _ = _union(detail, day)
         _, mask = _masked(pf, filters)
-        return {"pass": int(mask.sum()), "total": len(pf.frame)}
+        payload = {"pass": int(mask.sum()), "total": len(pf.frame)}
+        return JSONResponse(payload, headers=_UNION_HEADERS)
 
     def _bin_groups(pf, mask, bincfg_raw: str):
         """Per-bin shot membership over the filtered union frame.

--- a/GEECS-DataPortal/geecs_portal/templates/run.html
+++ b/GEECS-DataPortal/geecs_portal/templates/run.html
@@ -516,8 +516,9 @@ function parsedFilters() {
 function api(path, params) {
   const p = new URLSearchParams(params);
   if (DAY) p.set("day", DAY);
-  // Completed-run /api responses cache immutable; the version key rolls
-  // browser caches over when the payload shape changes on upgrade.
+  // Union-frame /api responses are no-cache (the s-file grows after
+  // the run); the version key still rolls over whatever a cache kept
+  // when the payload shape changes on upgrade.
   p.set("v", {{ portal_version | tojson }});
   return fetch(`${ROOT}/api/run/${UID}/${path}?` + p.toString()).then(r => {
     if (!r.ok) return r.json().then(b => { throw new Error(b.detail || r.statusText); });

--- a/GEECS-DataPortal/pyproject.toml
+++ b/GEECS-DataPortal/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-data-portal"
-version = "0.15.2"
+version = "0.15.3"
 description = "Read-only scan-browsing web service: a zero-install browser view over the Tiled catalog and the GEECS data share"
 authors = ["GEECS-BELLA"]
 readme = "README.md"

--- a/GEECS-DataPortal/tests/test_app.py
+++ b/GEECS-DataPortal/tests/test_app.py
@@ -473,6 +473,7 @@ class TestAnalysisApi:
             "columns",
             "frame?cols=cam-MaxCounts",
             'binned?cols=cam-MaxCounts&bincfg={"bin_col":"mono"}',
+            "filter-count",
         ):
             response = _client().get(f"/api/run/uid-002/{path}")
             assert response.status_code == 200, path

--- a/GEECS-DataPortal/tests/test_app.py
+++ b/GEECS-DataPortal/tests/test_app.py
@@ -465,9 +465,18 @@ class TestAnalysisApi:
         assert response.status_code == 400
         assert "at most 4" in response.json()["detail"]
 
-    def test_completed_run_json_is_immutable(self):
-        response = _client().get("/api/run/uid-002/columns")
-        assert "immutable" in response.headers["cache-control"]
+    def test_completed_run_json_never_immutable(self):
+        # The s-file half of the union grows after the run completes
+        # (ScanAnalysis appends columns) — a pinned response would hide
+        # them until the next portal release.
+        for path in (
+            "columns",
+            "frame?cols=cam-MaxCounts",
+            'binned?cols=cam-MaxCounts&bincfg={"bin_col":"mono"}',
+        ):
+            response = _client().get(f"/api/run/uid-002/{path}")
+            assert response.status_code == 200, path
+            assert response.headers["cache-control"] == "no-cache", path
 
     def test_api_outage_is_503(self):
         response = _client(DownCatalog()).get("/api/run/uid-002/columns")

--- a/GEECS-DataPortal/tests/test_resources.py
+++ b/GEECS-DataPortal/tests/test_resources.py
@@ -617,8 +617,28 @@ class TestBinImagesReviewPins:
         )
         assert joined.headers["cache-control"] == "no-cache"
 
-    def test_running_run_serves_no_cache(self, scan_folder):
+    def test_shot_image_cache_gates_on_completion_and_join(self, scan_folder):
+        # image.png is the one endpoint still gated on BOTH completion
+        # and a timestamp join (the union-frame endpoints are always
+        # no-cache): running → no-cache; completed timestamp-joined →
+        # immutable; completed ordinal-joined (cam2) → no-cache.
         from geecs_data_utils.tiled_catalog import RunDetail, summary_from_metadata
+
+        cam2 = scan_folder / "cam2"
+        cam2.mkdir()
+        for shot in (1, 2, 3):
+            Image.fromarray(np.zeros((5, 5), dtype=np.uint16)).save(
+                cam2 / f"cam2_{_LV + float(shot):.3f}.png"
+            )
+        done = TestBinImages()._client(scan_folder)
+        joined = done.get("/run/uid-002/image.png", params={"device": "cam", "shot": 1})
+        assert joined.status_code == 200
+        assert "immutable" in joined.headers["cache-control"]
+        ordinal = done.get(
+            "/run/uid-002/image.png", params={"device": "cam2", "shot": 1}
+        )
+        assert ordinal.status_code == 200
+        assert ordinal.headers["cache-control"] == "no-cache"
 
         catalog = FakeCatalog()
         base = _detail(2)
@@ -632,13 +652,9 @@ class TestBinImagesReviewPins:
         )
         catalog.details["uid-002"] = running
         client = TestClient(create_app(catalog))
-        listing = client.get("/api/run/uid-002/bin-images", params={"device": "cam"})
-        assert listing.headers["cache-control"] == "no-cache"
-        png = client.get(
-            "/run/uid-002/bin-image.png", params={"device": "cam", "bin": 0}
-        )
-        assert png.status_code == 200
-        assert png.headers["cache-control"] == "no-cache"
+        live = client.get("/run/uid-002/image.png", params={"device": "cam", "shot": 1})
+        assert live.status_code == 200
+        assert live.headers["cache-control"] == "no-cache"
 
     def test_unrenderable_array_degrades_never_raises(self, scan_folder):
         # A readable h5 whose /image is 4-D: the tier ladder loads it,

--- a/GEECS-DataPortal/tests/test_resources.py
+++ b/GEECS-DataPortal/tests/test_resources.py
@@ -489,7 +489,7 @@ class TestBinImages:
             (2, 1, [3]),
         ]
         assert "compute_bin_key" in payload["code"]
-        assert "immutable" in response.headers["cache-control"]
+        assert response.headers["cache-control"] == "no-cache"  # s-file mutable
 
     def test_bin_average_is_the_nanmean_of_member_shots(self, scan_folder):
         client = self._client(scan_folder)
@@ -596,10 +596,10 @@ class TestBinImagesReviewPins:
         decoded = np.array(Image.open(io.BytesIO(response.content)))
         assert decoded[0, 1] == decoded[0, 2] == 255  # still bin {1,2}'s average
 
-    def test_ordinal_member_downgrades_cache_timestamp_join_does_not(self, scan_folder):
-        # cam2: timestamp-named files but NO event acq column → every
-        # member resolves by listing order → the response must not be
-        # long-cached (SMB listing blips can shift the join).
+    def test_bin_images_never_cache_immutable(self, scan_folder):
+        # Bin membership comes off the union frame, whose s-file half
+        # grows after the run completes — so even the timestamp-joined
+        # device (cam) is no-cache, not only the ordinal one (cam2).
         cam2 = scan_folder / "cam2"
         cam2.mkdir()
         for shot in (1, 2, 3):
@@ -615,7 +615,7 @@ class TestBinImagesReviewPins:
         joined = client.get(
             "/run/uid-002/bin-image.png", params={"device": "cam", "bin": 0}
         )
-        assert "immutable" in joined.headers["cache-control"]
+        assert joined.headers["cache-control"] == "no-cache"
 
     def test_running_run_serves_no_cache(self, scan_folder):
         from geecs_data_utils.tiled_catalog import RunDetail, summary_from_metadata


### PR DESCRIPTION
## What

Responses computed over the **union frame** — `/api/run/{uid}/columns`, `frame`, `binned`, `filter-count`, `bin-images` and `bin-image.png` — are no longer served `Cache-Control: public, max-age=31536000, immutable` for completed runs. They are now `no-cache` — a plain re-fetch, no validator is emitted (an ETag over the s-file stat is the follow-up). The per-shot `image.png` and `plot.png`, which read the Tiled event table alone, keep their immutable headers unchanged.

## Why

The "completed run is immutable" premise holds for the event table but not for the s-file half of the union: ScanAnalysis **appends** its columns to `analysis/sN.txt` after the scan — hours later when it is re-run by hand. A browser that fetched the column list before analysis stayed pinned to the pre-analysis shape until the next portal release (the page keys `/api` fetches by package version only).

Live incident, 2026-09-01 (Undulator): scan 32 showed 7 columns while scan 33 showed 30. On disk both s-files had 30 columns by then — scan 32's FROG analysis ran at 19:19–19:54, three hours after the scan ended at 16:56 and after scan 33's at 19:32–19:43. The scanner-written `ScanDataScanNNN.txt` was identical (7 columns) for both.

## Changes (one concern, ~60 LOC net)

- `app.py`: module constant `_UNION_HEADERS` with the rationale; the four JSON endpoints and `bin-image.png` use it. `bin-image.png`'s per-member `cacheable` accumulation is removed — it only ever decided between `no-cache` and `immutable`, and the answer is now always `no-cache` (the per-shot `image.png` keeps its own `result.cacheable` gate). `_png_headers` and `_portal_version` docstrings updated to match.
- Tests: `test_completed_run_json_is_immutable` → `test_completed_run_json_never_immutable` (columns/frame/binned all `no-cache`); the bin-images JSON assertion and the bin-image ordinal-vs-joined test now pin `no-cache` on both devices.
- 0.15.2 → 0.15.3 + CHANGELOG.

**Judgment call, cheap to veto:** plain `no-cache` rather than an ETag keyed on the s-file's size/mtime. The server already re-reads the s-file per request (see `_union`), so the only thing an ETag would save is transfer bytes on unchanged data plus the bin-image `nanmean` recompute on revisits (the pixel cache stays warm). Happy to add the ETag as a follow-up if the Images tab feels slower on revisits.

## Tests

GEECS-DataPortal: 179 passed, 6 skipped (the `analysis`-extra tests), via `scripts/check.sh`.

## Hardware verification

None needed — no scan execution or device surface touched. Deploy check on the portal host after merge: `curl -sI http://<portal>:8200/api/run/<completed-uid>/columns | grep -i cache-control` should print `no-cache`; a hard reload of scan 32 (2026-09-01) should list 30 s-file-provenance columns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CxJgmVg7DB6xeZji9Hniw5
