### PR TITLE
Drop trigger-profile variants: GEECS-Schemas 0.15.0 (TriggerProfile v2, ScanRequest v3), GeecsBluesky 0.72.0, GEECS-Console 0.27.0

### DIFF
--- a/GEECS-Console/CHANGELOG.md
+++ b/GEECS-Console/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to GEECS-Console are documented here.  Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versioning is
 semantic.
 
+## [0.27.0] - 2026-09-02
+
+### Removed
+
+- **Trigger-profile variants** everywhere in the console (GEECS-Schemas
+  0.15.0 removed them): the R1 trigger-variant combo, `ConsoleFormState
+  .trigger_variant`, `ConsoleConfigs.trigger_variants`, and the shot-control
+  editor's variant layer (the layer combo, Add/Remove variant, per-layer
+  description). The editor now edits one profile: its description and its
+  state write tree. One profile file per operating condition, picked by
+  name in the trigger-profile combo, is the only shape; older presets with
+  `trigger_variant: null` load unchanged through the schema's lifting
+  validator.
+
 ## [0.26.0] - 2026-09-01
 
 ### Changed

--- a/GEECS-Console/CLAUDE.md
+++ b/GEECS-Console/CLAUDE.md
@@ -12,8 +12,8 @@ One main window, menu bar (Ops / Actions / Editors / Preferences / Help),
 status bar (gateway addr, configs path, version).  Object names in the `.ui`
 are prefixed by region (`r3_radio_1d`, `r5_start_button`, …).
 
-- **R1 session bar** — experiment combo, rep-rate field, trigger-profile +
-  variant combos, gateway/tiled/db health chips.
+- **R1 session bar** — experiment combo, rep-rate field, trigger-profile
+  combo, gateway/tiled/db health chips.
 - **R2 save sets** — available/selected lists, Add/Remove, union preview
   line ("union: N devices"), role-conflict/reference hint line.
 - **R3 scan form** — mode radios (No-scan / 1D / Grid / Optimization /

--- a/GEECS-Console/geecs_console/app/main_window.py
+++ b/GEECS-Console/geecs_console/app/main_window.py
@@ -378,9 +378,6 @@ class MainWindow(QMainWindow):
         self.trigger_profile_combo: QComboBox = self._child(
             QComboBox, "r1_trigger_profile_combo"
         )
-        self.trigger_variant_combo: QComboBox = self._child(
-            QComboBox, "r1_trigger_variant_combo"
-        )
         self.gateway_chip: QLabel = self._child(QLabel, "r1_gateway_chip")
         self.tiled_chip: QLabel = self._child(QLabel, "r1_tiled_chip")
         self.db_chip: QLabel = self._child(QLabel, "r1_db_chip")
@@ -562,9 +559,6 @@ class MainWindow(QMainWindow):
         self.add_button.clicked.connect(self._on_add_save_set)
         self.remove_button.clicked.connect(self._on_remove_save_set)
         self.experiment_combo.currentTextChanged.connect(self._on_experiment_changed)
-        self.trigger_profile_combo.currentTextChanged.connect(
-            self._on_trigger_profile_changed
-        )
         self.start_button.clicked.connect(self._on_start_clicked)
         self.stop_button.clicked.connect(self._on_stop_clicked)
         self.pause_button.clicked.connect(self._on_pause_clicked)
@@ -691,7 +685,6 @@ class MainWindow(QMainWindow):
         self.trigger_profile_combo.addItem("")
         self.trigger_profile_combo.addItems(listing.trigger_profiles)
         self.trigger_profile_combo.blockSignals(False)
-        self.trigger_variant_combo.clear()
         # Repopulation is programmatic — block signals so the R7 auto-select
         # only follows *operator* picks (and preset applies), never the
         # populate churn itself.
@@ -1071,7 +1064,6 @@ class MainWindow(QMainWindow):
             # The spinner's special value 0 renders as "auto" = no limit.
             max_iterations = self.iterations_spin.value() or None
         profile = self.trigger_profile_combo.currentText() or None
-        variant = self.trigger_variant_combo.currentText() or None
         from geecs_schemas import AcquisitionMode
 
         return ConsoleFormState(
@@ -1080,7 +1072,6 @@ class MainWindow(QMainWindow):
             shots_per_step=self.shots_per_step.value(),
             save_sets=self.selected_save_sets(),
             trigger_profile=profile,
-            trigger_variant=variant if profile else None,
             acquisition=AcquisitionMode(self.acquisition_combo.currentText()),
             description=self.description_edit.text(),
             optimization=optimization,
@@ -1323,13 +1314,6 @@ class MainWindow(QMainWindow):
             return False
         self.experiment_combo.setCurrentText(remembered)
         return True
-
-    def _on_trigger_profile_changed(self, profile: str) -> None:
-        """Repopulate the variant combo for the selected trigger profile."""
-        self.trigger_variant_combo.clear()
-        if profile:
-            self.trigger_variant_combo.addItem("")
-            self.trigger_variant_combo.addItems(self._configs.trigger_variants(profile))
 
     # ------------------------------------------------------------------
     # Ops menu (path resolution lives in services/ops_paths — pure & tested)
@@ -2000,9 +1984,6 @@ class MainWindow(QMainWindow):
         self.acquisition_combo.setCurrentText(form.acquisition.value)
         self.description_edit.setText(form.description)
         self.trigger_profile_combo.setCurrentText(form.trigger_profile or "")
-        # Changing the profile text repopulated the variant combo (the
-        # currentTextChanged handler); now pick the preset's variant.
-        self.trigger_variant_combo.setCurrentText(form.trigger_variant or "")
         self._apply_save_sets(form.save_sets)
         self._refresh_shot_count()
 

--- a/GEECS-Console/geecs_console/app/tooltips.py
+++ b/GEECS-Console/geecs_console/app/tooltips.py
@@ -84,11 +84,6 @@ OPERATOR_TOOLTIPS: dict[str, str] = {
         "STANDBY / SCAN / ... device writes). Empty means the scan "
         "leaves the trigger alone."
     ),
-    "trigger_variant_combo": (
-        "Named operating condition of the trigger profile (e.g. "
-        "laser_off) — overlays a few writes on the base profile. "
-        "Empty runs the base behaviour."
-    ),
     "gateway_chip": (
         "CA gateway health: reads the experiment's heartbeat PV "
         "every few seconds. WARN means the gateway runs but reports "

--- a/GEECS-Console/geecs_console/app/ui/main_window.ui
+++ b/GEECS-Console/geecs_console/app/ui/main_window.ui
@@ -89,16 +89,6 @@
       </widget>
      </item>
      <item>
-      <widget class="QComboBox" name="r1_trigger_variant_combo">
-       <property name="minimumWidth">
-        <number>100</number>
-       </property>
-       <property name="toolTip">
-        <string>Trigger-profile variant (base behaviour when empty)</string>
-       </property>
-      </widget>
-     </item>
-     <item>
       <spacer name="r1_spacer">
        <property name="orientation">
         <enum>Qt::Horizontal</enum>

--- a/GEECS-Console/geecs_console/app/ui/shot_control_editor.ui
+++ b/GEECS-Console/geecs_console/app/ui/shot_control_editor.ui
@@ -125,7 +125,7 @@
         <item>
          <widget class="QLineEdit" name="sce_description_edit">
           <property name="toolTip">
-           <string>Note on the selected layer: the profile when (base) is shown, otherwise the variant</string>
+           <string>Note on what setup this profile is for</string>
           </property>
          </widget>
         </item>

--- a/GEECS-Console/geecs_console/app/ui/shot_control_editor.ui
+++ b/GEECS-Console/geecs_console/app/ui/shot_control_editor.ui
@@ -114,54 +114,6 @@
        </layout>
       </item>
       <item>
-       <layout class="QHBoxLayout" name="sce_variant_layout">
-        <item>
-         <widget class="QLabel" name="sce_variant_label">
-          <property name="text">
-           <string>Variant</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QComboBox" name="sce_variant_combo">
-          <property name="minimumWidth">
-           <number>160</number>
-          </property>
-          <property name="toolTip">
-           <string>Which layer the table edits: the base profile, or one variant's overlay writes</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QPushButton" name="sce_add_variant_button">
-          <property name="text">
-           <string>Add variant…</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QPushButton" name="sce_remove_variant_button">
-          <property name="text">
-           <string>Remove variant</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <spacer name="sce_variant_spacer">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>10</width>
-            <height>10</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-       </layout>
-      </item>
-      <item>
        <layout class="QHBoxLayout" name="sce_description_layout">
         <item>
          <widget class="QLabel" name="sce_description_label">

--- a/GEECS-Console/geecs_console/editors/shot_control_editor.py
+++ b/GEECS-Console/geecs_console/editors/shot_control_editor.py
@@ -10,8 +10,7 @@ real schema, and Save refuses anything pydantic rejects — the error is
 shown inline, never raised at the operator.
 
 Layout: a profile list (New / Duplicate / Rename / Delete) on the left; the
-document on the right — a variant selector (the table edits the base
-profile or one variant's overlay), a per-layer description, and the
+document on the right — the profile description and the
 state × (device, variable, value) write tree with Add/Remove/Move up/Move
 down (order matters within a transition: writes are sent top to bottom).
 Dirty tracking with Save/Revert and an unsaved-changes prompt on profile
@@ -36,7 +35,6 @@ from typing import Optional
 from PySide6.QtCore import Qt
 from PySide6.QtWidgets import (
     QAbstractItemView,
-    QComboBox,
     QCompleter,
     QDialog,
     QLabel,
@@ -66,8 +64,6 @@ logger = logging.getLogger(__name__)
 
 _UI_PATH = Path(__file__).parent.parent / "app" / "ui" / "shot_control_editor.ui"
 
-#: The variant combo's entry for editing the profile's base states.
-BASE_LAYER = "(base)"
 
 #: Semantic colors matching the main window's palette (style.qss header).
 _COLOR_RED = "#c4453a"
@@ -195,8 +191,6 @@ class ShotControlEditor(ConfigEditorDialog):
         self._snapshot: Optional[dict] = None
         #: The profile (file stem) the document belongs to.
         self._current_name: str = ""
-        #: The layer the tree edits: ``BASE_LAYER`` or a variant name.
-        self._current_layer: str = BASE_LAYER
         #: True while code (not the operator) is populating widgets.
         self._loading = False
 
@@ -224,13 +218,6 @@ class ShotControlEditor(ConfigEditorDialog):
         self.delete_button: QPushButton = self._child(QPushButton, "sce_delete_button")
         self.profile_name_label: QLabel = self._child(QLabel, "sce_profile_name_label")
         self.legacy_label: QLabel = self._child(QLabel, "sce_legacy_label")
-        self.variant_combo: QComboBox = self._child(QComboBox, "sce_variant_combo")
-        self.add_variant_button: QPushButton = self._child(
-            QPushButton, "sce_add_variant_button"
-        )
-        self.remove_variant_button: QPushButton = self._child(
-            QPushButton, "sce_remove_variant_button"
-        )
         self.description_edit: QLineEdit = self._child(
             QLineEdit, "sce_description_edit"
         )
@@ -272,7 +259,6 @@ class ShotControlEditor(ConfigEditorDialog):
             {
                 "description": self.description_edit,
                 "states": self.states_tree,
-                "variants": self.variant_combo,
             },
         )
 
@@ -283,9 +269,6 @@ class ShotControlEditor(ConfigEditorDialog):
         self.duplicate_button.clicked.connect(self._on_duplicate)
         self.rename_button.clicked.connect(self._on_rename)
         self.delete_button.clicked.connect(self._on_delete)
-        self.variant_combo.currentTextChanged.connect(self._on_layer_changed)
-        self.add_variant_button.clicked.connect(self._on_add_variant)
-        self.remove_variant_button.clicked.connect(self._on_remove_variant)
         self.description_edit.textChanged.connect(self._on_description_edited)
         self.states_tree.itemChanged.connect(self._on_tree_edited)
         self.add_write_button.clicked.connect(self._on_add_write)
@@ -345,7 +328,7 @@ class ShotControlEditor(ConfigEditorDialog):
         """Drop empty state lists (a state with no writes is "not defined").
 
         Keeps dirty tracking honest: the tree omits empty states when it
-        rebuilds its layer, so the loaded document must not carry them
+        rebuilds the states, so the loaded document must not carry them
         either.  Semantically identical per the schema's ``defines_state``.
 
         Parameters
@@ -356,37 +339,21 @@ class ShotControlEditor(ConfigEditorDialog):
         Returns
         -------
         dict
-            The same document, with empty state lists removed from the base
-            profile and every variant.
+            The same document, with empty state lists removed.
         """
         doc["states"] = {
             state: writes for state, writes in doc.get("states", {}).items() if writes
         }
-        for variant in doc.get("variants", {}).values():
-            variant["states"] = {
-                state: writes
-                for state, writes in variant.get("states", {}).items()
-                if writes
-            }
         return doc
 
-    def _layer_states(self) -> Optional[dict]:
-        """Return the states dict of the layer the tree currently edits."""
-        if self._doc is None:
-            return None
-        if self._current_layer == BASE_LAYER:
-            return self._doc["states"]
-        variant = self._doc["variants"].get(self._current_layer)
-        return None if variant is None else variant["states"]
+    def _states(self) -> Optional[dict]:
+        """Return the document's states dict (``None`` with no document)."""
+        return None if self._doc is None else self._doc["states"]
 
-    def _set_layer_states(self, states: dict) -> None:
-        """Replace the current layer's states dict with *states*."""
-        if self._doc is None:
-            return
-        if self._current_layer == BASE_LAYER:
+    def _set_states(self, states: dict) -> None:
+        """Replace the document's states dict with *states*."""
+        if self._doc is not None:
             self._doc["states"] = states
-        elif self._current_layer in self._doc["variants"]:
-            self._doc["variants"][self._current_layer]["states"] = states
 
     def _show_document(self, doc: Optional[dict]) -> None:
         """Render *doc* (or the empty no-selection state) into the widgets.
@@ -397,14 +364,10 @@ class ShotControlEditor(ConfigEditorDialog):
             The working document; ``None`` clears and disables the editor.
         """
         self._doc = doc
-        self._current_layer = BASE_LAYER
         self._loading = True
         try:
             enabled = doc is not None
             for widget in (
-                self.variant_combo,
-                self.add_variant_button,
-                self.remove_variant_button,
                 self.description_edit,
                 self.states_tree,
                 self.add_write_button,
@@ -413,7 +376,6 @@ class ShotControlEditor(ConfigEditorDialog):
                 self.move_down_button,
             ):
                 widget.setEnabled(enabled)
-            self._populate_variant_combo()
             self._populate_tree()
             self._refresh_description()
             if doc is None:
@@ -428,24 +390,11 @@ class ShotControlEditor(ConfigEditorDialog):
             self._loading = False
         self._refresh_validation()
 
-    def _populate_variant_combo(self) -> None:
-        """Fill the layer selector: (base) plus the document's variants."""
-        self.variant_combo.blockSignals(True)
-        self.variant_combo.clear()
-        if self._doc is not None:
-            self.variant_combo.addItem(BASE_LAYER)
-            self.variant_combo.addItems(sorted(self._doc.get("variants", {})))
-            self.variant_combo.setCurrentText(self._current_layer)
-        self.variant_combo.blockSignals(False)
-        self.remove_variant_button.setEnabled(
-            self._doc is not None and self._current_layer != BASE_LAYER
-        )
-
     def _populate_tree(self) -> None:
-        """Rebuild the state tree from the current layer's states dict."""
+        """Rebuild the state tree from the document's states dict."""
         self.states_tree.blockSignals(True)
         self.states_tree.clear()
-        states = self._layer_states()
+        states = self._states()
         if states is not None:
             for state in TriggerState:
                 state_item = QTreeWidgetItem(self.states_tree)
@@ -487,8 +436,8 @@ class ShotControlEditor(ConfigEditorDialog):
         )
         return item
 
-    def _rebuild_layer_from_tree(self) -> None:
-        """Read the tree back into the current layer's states dict."""
+    def _rebuild_states_from_tree(self) -> None:
+        """Read the tree back into the document's states dict."""
         states: dict[str, list[dict]] = {}
         for row in range(self.states_tree.topLevelItemCount()):
             state_item = self.states_tree.topLevelItem(row)
@@ -503,18 +452,14 @@ class ShotControlEditor(ConfigEditorDialog):
             ]
             if writes:
                 states[state] = writes
-        self._set_layer_states(states)
+        self._set_states(states)
 
     def _refresh_description(self) -> None:
-        """Bind the description edit to the current layer's description."""
+        """Bind the description edit to the document's description."""
         self.description_edit.blockSignals(True)
-        if self._doc is None:
-            self.description_edit.setText("")
-        elif self._current_layer == BASE_LAYER:
-            self.description_edit.setText(self._doc.get("description", ""))
-        else:
-            variant = self._doc["variants"].get(self._current_layer, {})
-            self.description_edit.setText(variant.get("description", ""))
+        self.description_edit.setText(
+            "" if self._doc is None else self._doc.get("description", "")
+        )
         self.description_edit.blockSignals(False)
 
     def _validated_profile(self) -> Optional[TriggerProfile]:
@@ -717,74 +662,11 @@ class ShotControlEditor(ConfigEditorDialog):
         self._show_document(None)
         self._refresh_profile_list()
 
-    # ------------------------------------------------------------------
-    # Layer (base/variant) handling
-    # ------------------------------------------------------------------
-
-    def _on_layer_changed(self, layer: str) -> None:
-        """Point the tree and description at the newly selected layer."""
-        if self._loading or self._doc is None or not layer:
-            return
-        self._current_layer = layer
-        self._loading = True
-        try:
-            self._populate_tree()
-            self._refresh_description()
-        finally:
-            self._loading = False
-        self.remove_variant_button.setEnabled(layer != BASE_LAYER)
-
-    def _on_add_variant(self) -> None:
-        """Add an empty variant and switch the tree to it."""
-        if self._doc is None:
-            return
-        name = self._prompt_name("Add variant", "Variant name:")
-        if not name:
-            return
-        if name == BASE_LAYER or name in self._doc["variants"]:
-            self._report_store_error(
-                TriggerProfileStoreError(f"Variant {name!r} is taken.")
-            )
-            return
-        self._doc["variants"][name] = {"states": {}, "description": ""}
-        self._current_layer = name
-        self._loading = True
-        try:
-            self._populate_variant_combo()
-            self._populate_tree()
-            self._refresh_description()
-        finally:
-            self._loading = False
-        self._refresh_validation()
-
-    def _on_remove_variant(self) -> None:
-        """Remove the selected variant (with confirmation) — Save persists."""
-        if self._doc is None or self._current_layer == BASE_LAYER:
-            return
-        name = self._current_layer
-        if not self._confirm(
-            "Remove variant", f"Remove variant {name!r} from this profile?"
-        ):
-            return
-        self._doc["variants"].pop(name, None)
-        self._current_layer = BASE_LAYER
-        self._loading = True
-        try:
-            self._populate_variant_combo()
-            self._populate_tree()
-            self._refresh_description()
-        finally:
-            self._loading = False
-        self._refresh_validation()
-
     def _on_description_edited(self, text: str) -> None:
-        """Write the description edit into the current layer."""
+        """Write the description edit into the document."""
         if self._loading or self._doc is None:
             return
-        if self._current_layer == BASE_LAYER:
-            self._doc["description"] = text
-        elif self._current_layer in self._doc["variants"]:
-            self._doc["variants"][self._current_layer]["description"] = text
+        self._doc["description"] = text
         self._refresh_validation()
 
     # ------------------------------------------------------------------
@@ -795,7 +677,7 @@ class ShotControlEditor(ConfigEditorDialog):
         """Fold a cell edit back into the document and re-validate."""
         if self._loading or self._doc is None:
             return
-        self._rebuild_layer_from_tree()
+        self._rebuild_states_from_tree()
         self._refresh_validation()
 
     def _target_state_item(self) -> Optional[QTreeWidgetItem]:
@@ -823,7 +705,7 @@ class ShotControlEditor(ConfigEditorDialog):
         )
         state_item.setExpanded(True)
         self.states_tree.blockSignals(False)
-        self._rebuild_layer_from_tree()
+        self._rebuild_states_from_tree()
         self._refresh_validation()
         self.states_tree.setCurrentItem(row)
         if self.states_tree.isVisible():
@@ -840,7 +722,7 @@ class ShotControlEditor(ConfigEditorDialog):
         if item is None or item.parent() is None:
             return
         item.parent().removeChild(item)
-        self._rebuild_layer_from_tree()
+        self._rebuild_states_from_tree()
         self._refresh_validation()
 
     def _on_move_write(self, delta: int) -> None:
@@ -870,7 +752,7 @@ class ShotControlEditor(ConfigEditorDialog):
         parent.insertChild(target, item)
         self.states_tree.blockSignals(False)
         self.states_tree.setCurrentItem(item)
-        self._rebuild_layer_from_tree()
+        self._rebuild_states_from_tree()
         self._refresh_validation()
 
     # ------------------------------------------------------------------

--- a/GEECS-Console/geecs_console/request_builder.py
+++ b/GEECS-Console/geecs_console/request_builder.py
@@ -143,7 +143,6 @@ class ConsoleFormState(BaseModel):
     shots_per_step: int = Field(1, ge=1)
     save_sets: list[str] = Field(default_factory=list)
     trigger_profile: Optional[str] = None
-    trigger_variant: Optional[str] = None
     acquisition: AcquisitionMode = AcquisitionMode.FREE_RUN
     description: str = ""
     background: bool = False
@@ -207,8 +206,8 @@ def build_scan_request(form: ConsoleFormState) -> ScanRequest:
         missing/extra axis for the mode, or a total shot count above
         :data:`MAXIMUM_SCAN_SIZE`.
     pydantic.ValidationError
-        When the schema itself rejects the assembled request (e.g. a
-        trigger variant without a profile, duplicate axis variables).
+        When the schema itself rejects the assembled request (e.g.
+        duplicate axis variables).
     """
     # A stray spec on a non-optimize form is a bug the schema's consistency
     # validator surfaces loudly rather than being silently dropped here.
@@ -258,7 +257,6 @@ def build_scan_request(form: ConsoleFormState) -> ScanRequest:
             acquisition=form.acquisition,
             save_sets=list(form.save_sets),
             trigger_profile=form.trigger_profile,
-            trigger_variant=form.trigger_variant,
         ),
         description=form.description,
         background=form.background or form.mode is ConsoleMode.BACKGROUND,
@@ -336,7 +334,6 @@ def form_state_from_request(request: ScanRequest) -> ConsoleFormState:
         shots_per_step=request.capture.shots_per_step,
         save_sets=list(request.capture.save_sets),
         trigger_profile=request.capture.trigger_profile,
-        trigger_variant=request.capture.trigger_variant,
         acquisition=request.capture.acquisition,
         description=request.description,
         background=background,

--- a/GEECS-Console/geecs_console/services/configs.py
+++ b/GEECS-Console/geecs_console/services/configs.py
@@ -335,27 +335,3 @@ class ConsoleConfigs:
                 f"Optimizer config {name!r} ({path}) is not a valid "
                 f"OptimizationSpec: {exc}"
             ) from exc
-
-    def trigger_variants(self, profile_name: str) -> list[str]:
-        """List the variants of one trigger profile (R1 variant combo).
-
-        Parameters
-        ----------
-        profile_name : str
-            The trigger-profile name to resolve.
-
-        Returns
-        -------
-        list of str
-            Sorted variant names; empty offline or on any resolution error.
-        """
-        if not profile_name:
-            return []
-        resolver = self._get_resolver()
-        if resolver is None:
-            return []
-        try:
-            return sorted(resolver.resolve_trigger_profile(profile_name).variants)
-        except Exception as exc:
-            logger.info("trigger profile %r unavailable: %s", profile_name, exc)
-            return []

--- a/GEECS-Console/geecs_console/services/trigger_profile_store.py
+++ b/GEECS-Console/geecs_console/services/trigger_profile_store.py
@@ -173,7 +173,7 @@ class TriggerProfileStore(NamedConfigStore):
 
         The document is a plain ``model_dump(mode="json")`` in declared field
         order — every schema field (``schema_version``, ``name``, ``states``,
-        ``variants``, ``description``) is preserved, and loading it back
+        ``description``) is preserved, and loading it back
         yields a model equal to *profile*.
 
         Parameters

--- a/GEECS-Console/pyproject.toml
+++ b/GEECS-Console/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-console"
-version = "0.26.0"
+version = "0.27.0"
 description = "Greenfield PySide6 operator console for GEECS (Bluesky/gateway architecture)"
 authors = ["Sam Barber <sbarber@lbl.gov>"]
 readme = "README.md"

--- a/GEECS-Console/tests/test_actions_menu.py
+++ b/GEECS-Console/tests/test_actions_menu.py
@@ -39,9 +39,6 @@ class FakeConfigs:
     def union_preview(self, names):
         return UnionPreview(device_count=len(names), hint="")
 
-    def trigger_variants(self, profile_name):
-        return []
-
 
 class FakeActionStore:
     """ActionLibraryStore stand-in: names per experiment, no filesystem."""

--- a/GEECS-Console/tests/test_main_window.py
+++ b/GEECS-Console/tests/test_main_window.py
@@ -60,9 +60,6 @@ class FakeConfigs:
     def union_preview(self, names):
         return UnionPreview(device_count=3 * len(names), hint="")
 
-    def trigger_variants(self, profile_name):
-        return ["laser_off"] if profile_name else []
-
     def optimization_spec(self, name):
         if name not in self.optimization_specs:
             raise ConsoleConfigsError(f"Optimizer config {name!r} not found.")
@@ -1052,14 +1049,12 @@ class TestStateModel:
         window.shots_per_step.setValue(5)
         window.description_edit.setText("grid check")
         window.trigger_profile_combo.setCurrentText("HTU-Standard")
-        window.trigger_variant_combo.setCurrentText("laser_off")
         request = build_scan_request(window.form_state())
         assert [axis.variable for axis in request.axes] == ["jet_x", "jet_z"]
         assert request.grid_shape() == (3, 3)
         assert request.capture.shots_per_step == 5
         assert request.description == "grid check"
         assert request.capture.trigger_profile == "HTU-Standard"
-        assert request.capture.trigger_variant == "laser_off"
 
 
 class TestNowAndDevicePanel:
@@ -1649,7 +1644,6 @@ def preset_request(**overrides):
         shots_per_step=7,
         save_sets=["EBeamDiags"],
         trigger_profile="HTU-Standard",
-        trigger_variant="laser_off",
         description="preset check",
     )
     form.update(overrides)
@@ -1730,7 +1724,6 @@ class TestPresets:
         assert window.shots_per_step.value() == 7
         assert window.description_edit.text() == "preset check"
         assert window.trigger_profile_combo.currentText() == "HTU-Standard"
-        assert window.trigger_variant_combo.currentText() == "laser_off"
         assert window.selected_save_sets() == ["EBeamDiags"]
         assert "total shots: 49" in window.shot_count_label.text()
         # The applied form is submit-ready and rebuilds an equal request.
@@ -1742,7 +1735,6 @@ class TestPresets:
             axes=[],
             shots_per_step=100,
             trigger_profile=None,
-            trigger_variant=None,
         )
         self._select_preset(window, "stats")
         window._on_preset_apply()
@@ -1772,7 +1764,6 @@ class TestPresets:
         window._presets.presets["list"] = preset_request(
             axes=[FormAxis(variable="jet_z", values=[0.0, 0.5, 2.0])],
             trigger_profile=None,
-            trigger_variant=None,
         )
         before = window.form_state()
         self._select_preset(window, "list")
@@ -1784,7 +1775,6 @@ class TestPresets:
         window._presets.presets["mixed"] = preset_request(
             save_sets=["EBeamDiags", "GhostSet"],
             trigger_profile=None,
-            trigger_variant=None,
         )
         self._select_preset(window, "mixed")
         window._on_preset_apply()

--- a/GEECS-Console/tests/test_request_builder.py
+++ b/GEECS-Console/tests/test_request_builder.py
@@ -123,19 +123,11 @@ class TestOneD:
         built = build_scan_request(form)
         assert built.capture.save_sets == ["Amp4In", "EBeamDiags"]
 
-    def test_trigger_profile_and_variant(self):
-        form = self.default_form(
-            trigger_profile="HTU-Standard", trigger_variant="laser_off"
-        )
+    def test_trigger_profile(self):
+        form = self.default_form(trigger_profile="HTU-Standard")
         request = build_scan_request(form)
         assert request.capture.trigger_profile == "HTU-Standard"
-        assert request.capture.trigger_variant == "laser_off"
         roundtrip(request)
-
-    def test_variant_without_profile_rejected_by_schema(self):
-        form = self.default_form(trigger_variant="laser_off")
-        with pytest.raises(ValidationError, match="trigger_profile"):
-            build_scan_request(form)
 
     def test_zero_step_raises_form_error(self):
         with pytest.raises(ConsoleFormError, match="step"):
@@ -267,7 +259,6 @@ class TestFormStateFromRequest:
             shots_per_step=10,
             save_sets=["Amp4In", "EBeamDiags"],
             trigger_profile="HTU-Standard",
-            trigger_variant="laser_off",
             acquisition=AcquisitionMode.STRICT,
             description="align the jet",
         )

--- a/GEECS-Console/tests/test_shot_control_editor.py
+++ b/GEECS-Console/tests/test_shot_control_editor.py
@@ -10,7 +10,6 @@ from PySide6.QtCore import Qt
 from PySide6.QtWidgets import QLineEdit
 
 from geecs_console.editors.shot_control_editor import (
-    BASE_LAYER,
     ShotControlEditor,
     open_shot_control_editor,
 )
@@ -120,14 +119,6 @@ class TestLoading:
         ]
         assert states == ["OFF", "STANDBY", "SCAN", "SINGLESHOT", "ARMED"]
 
-    def test_variant_combo_lists_base_plus_variants(self, editor):
-        select_profile(editor, "HTU-Normal")
-        entries = [
-            editor.variant_combo.itemText(i)
-            for i in range(editor.variant_combo.count())
-        ]
-        assert entries == [BASE_LAYER, "laser_off"]
-
     def test_loading_is_not_dirty(self, editor):
         select_profile(editor, "HTU-Normal")
         assert not editor.is_dirty()
@@ -166,7 +157,6 @@ class TestEditing:
         assert loaded.writes_for("SCAN")[0].value == "3.5"
         # Everything else survives the edit untouched.
         expected = representative_profile()
-        assert loaded.variants == expected.variants
         assert loaded.writes_for("ARMED") == expected.writes_for("ARMED")
 
     def test_revert_restores_the_disk_state(self, editor, store):
@@ -238,53 +228,6 @@ class TestEditing:
         editor.description_edit.setText("retimed 2026-07")
         editor.save_button.click()
         assert store.load("HTU-Normal").description == "retimed 2026-07"
-
-
-class TestVariants:
-    def test_variant_layer_shows_only_overlay_writes(self, editor):
-        select_profile(editor, "HTU-Normal")
-        editor.variant_combo.setCurrentText("laser_off")
-        assert write_rows(editor, "SCAN") == [
-            (DG, "Trigger.Source", "Single shot external rising edges"),
-        ]
-        assert write_rows(editor, "OFF") == []
-        assert editor.description_edit.text() == (
-            "Trigger internally while the laser is off."
-        )
-
-    def test_editing_a_variant_write_saves_into_the_variant(self, editor, store):
-        select_profile(editor, "HTU-Normal")
-        editor.variant_combo.setCurrentText("laser_off")
-        state_item(editor, "SCAN").child(0).setText(2, "Internal")
-        editor.save_button.click()
-        loaded = store.load("HTU-Normal")
-        assert loaded.variants["laser_off"].states["SCAN"][0].value == "Internal"
-        # The base states are untouched.
-        assert loaded.states == representative_profile().states
-
-    def test_add_variant(self, editor, store, monkeypatch):
-        select_profile(editor, "HTU-Normal")
-        monkeypatch.setattr(editor, "_prompt_name", lambda *a, **k: "no_gas")
-        editor.add_variant_button.click()
-        assert editor.variant_combo.currentText() == "no_gas"
-        assert editor.is_dirty()
-        editor.save_button.click()
-        assert "no_gas" in store.load("HTU-Normal").variants
-
-    def test_add_variant_rejects_taken_names(self, editor, monkeypatch):
-        select_profile(editor, "HTU-Normal")
-        monkeypatch.setattr(editor, "_prompt_name", lambda *a, **k: "laser_off")
-        editor.add_variant_button.click()
-        assert "taken" in editor.validation_label.text()
-
-    def test_remove_variant(self, editor, store, monkeypatch):
-        select_profile(editor, "HTU-Normal")
-        editor.variant_combo.setCurrentText("laser_off")
-        monkeypatch.setattr(editor, "_confirm", lambda *a, **k: True)
-        editor.remove_variant_button.click()
-        assert editor.variant_combo.currentText() == BASE_LAYER
-        editor.save_button.click()
-        assert store.load("HTU-Normal").variants == {}
 
 
 class TestProfileOperations:

--- a/GEECS-Console/tests/test_tooltips.py
+++ b/GEECS-Console/tests/test_tooltips.py
@@ -249,7 +249,6 @@ class TestShotControlEditorTooltips:
         fields = TriggerProfile.model_fields
         assert editor.description_edit.toolTip() == fields["description"].description
         assert editor.states_tree.toolTip() == fields["states"].description
-        assert editor.variant_combo.toolTip() == fields["variants"].description
 
 
 class TestActionLibraryEditorTooltips:

--- a/GEECS-Console/tests/test_trigger_profile_store.py
+++ b/GEECS-Console/tests/test_trigger_profile_store.py
@@ -21,7 +21,7 @@ DG = "U_DG645_ShotControl"
 
 
 def representative_profile() -> TriggerProfile:
-    """The HTU shape: DG645 drives trigger + gas jet, one laser-off variant."""
+    """The HTU shape: DG645 drives trigger + gas jet."""
     return TriggerProfile(
         name="HTU-Normal",
         description="DG645 drives the machine trigger and gas jet",
@@ -61,20 +61,6 @@ def representative_profile() -> TriggerProfile:
                     "value": "Single shot external rising edges",
                 },
             ],
-        },
-        variants={
-            "laser_off": {
-                "states": {
-                    "SCAN": [
-                        {
-                            "device": DG,
-                            "variable": "Trigger.Source",
-                            "value": "Single shot external rising edges",
-                        }
-                    ]
-                },
-                "description": "Trigger internally while the laser is off.",
-            }
         },
     )
 
@@ -128,7 +114,6 @@ class TestRoundTrip:
         assert loaded.name == profile.name
         assert loaded.description == profile.description
         assert loaded.states == profile.states
-        assert loaded.variants == profile.variants
 
     def test_off_state_survives_yaml_11_boolean_parsing(self, store):
         # A bare OFF: key parses as boolean False in YAML 1.1 — the schema

--- a/GEECS-Schemas/CHANGELOG.md
+++ b/GEECS-Schemas/CHANGELOG.md
@@ -5,6 +5,35 @@ All notable changes to GEECS-Schemas are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.15.0] - 2026-09-02
+
+### Removed
+
+- **Trigger-profile variants** (`TriggerProfile.variants`, `TriggerVariant`,
+  `writes_for(..., variant=)`, `defines_state(..., variant=)`,
+  `convert.merge_trigger_variant`) and **`CaptureSettings.trigger_variant`**.
+  Variants were the schema's answer to parallel laser-on/laser-off files;
+  nobody adopted them — every experiment kept one profile file per
+  operating condition — so they were a second way to say what the profile
+  name already says, costing a field on every scan form, a console combo,
+  a validator, and an adapter parameter.
+
+### Changed
+
+- **TriggerProfile format v2** (`schema_version` default 2): a
+  before-validator drops an empty v1 `variants` block (the corpus shape),
+  refuses a populated one with the remedy (split it into its own profile),
+  and normalizes `schema_version` ≤ 1 to 2.
+- **ScanRequest format v3** (`schema_version` default 3): the lifting
+  validator now also drops an unset `trigger_variant` — flat v1 or inside
+  `capture` — refuses a set one with the remedy, and normalizes
+  `schema_version` ≤ 2 to 3. Both bumps follow the README's versioning
+  policy: a removed field is a migration.
+
+Regenerated: the JSON Schema artifact, the Markdown schema reference, and
+the converter golden files (the HTU trigger-profile golden is now the plain
+`HTU-Normal` conversion).
+
 ## [0.14.0] - 2026-09-01
 
 ### Changed

--- a/GEECS-Schemas/README.md
+++ b/GEECS-Schemas/README.md
@@ -62,9 +62,11 @@ independently:
   schema version: a document is either liftable or already current. The
   finer-grained story lives in the changelog. Do not introduce `1.1`-style
   markers.
-- **Each document kind versions on its own.** A ScanRequest at v2 says
-  nothing about SaveSet or TriggerProfile, which stay at v1 until their own
-  layout changes.
+- **Each document kind versions on its own.** ScanRequest is at v3 and
+  TriggerProfile at v2 (each bumped by its own removed field); SaveSet and
+  the rest stay at v1 until their own layout changes.  The staleness test
+  is one helper, `stale_schema_version` in `_base.py`, shared by every
+  kind's lifting validator.
 
 ## Model inventory
 

--- a/GEECS-Schemas/README.md
+++ b/GEECS-Schemas/README.md
@@ -73,7 +73,7 @@ independently:
 | `scan_request` | `ScanRequest` | scan presets, `ScanConfig`, GUI submission state |
 | `save_set` | `SaveSet` | save elements (`save_devices/*.yaml`) — now tier 1 of the two-tier recording model: the *required* devices with guarantees; everything else is background telemetry (soft, read-only, never waited on) |
 | `scan_variables` | `ScanVariables` | `scan_devices.yaml` + `composite_variables.yaml` |
-| `trigger_profile` | `TriggerProfile` | shot-control configs (incl. laser-on/off file pairs → variants); states are machine states holding *ordered, multi-device* write lists |
+| `trigger_profile` | `TriggerProfile` | shot-control configs (one profile per operating condition); states are machine states holding *ordered, multi-device* write lists |
 | `action_plan` | `ActionPlan` | one entry of the action library |
 | `action_plan_library` | `ActionPlanLibrary` | `action_library/actions.yaml` |
 | `experiment_defaults` | `ExperimentDefaults` | (new — legacy kept these choices in GUI state) per-experiment fallbacks where a scan request is silent; defaults run first, then the scan's own |
@@ -98,7 +98,7 @@ the DB's set-side start/end writes but are **not honored in this version**
 trigger profile / shot controller and the scanner's save-windowing), and the
 fields are kept for a possible future re-enable),
 `ScanVariable` / `PseudoScanVariable`, `TriggerWrite` /
-`TriggerVariant` / `TriggerState`, `DefaultActions`, and the four action
+`TriggerState`, `DefaultActions`, and the four action
 step types.
 
 One non-model module: `geecs_schemas.restricted_expr` — the shared
@@ -117,7 +117,6 @@ from geecs_schemas.convert import (
     convert_save_element,
     convert_scan_variables,
     convert_shot_control,
-    merge_trigger_variant,
     convert_action_library,
     convert_scan_preset,
     convert_optimizer_config,
@@ -132,11 +131,9 @@ catalog = convert_scan_variables(
     "scan_devices/scan_devices.yaml", "scan_devices/composite_variables.yaml"
 )
 
-# Shot control → TriggerProfile; fold the parallel laser-off file into a variant
-base = convert_shot_control("shot_control_configurations/HTU-Normal.yaml")
-off = convert_shot_control("shot_control_configurations/HTU-LaserOFF.yaml")
-profile = merge_trigger_variant(base, off, "laser_off")
-profile.writes_for("SCAN", variant="laser_off")
+# Shot control → TriggerProfile (one profile per operating condition)
+profile = convert_shot_control("shot_control_configurations/HTU-Normal.yaml")
+profile.writes_for("SCAN")
 
 # Action library → ActionPlanLibrary (nested run-references validated)
 library = convert_action_library("action_library/actions.yaml")

--- a/GEECS-Schemas/geecs_schemas/__init__.py
+++ b/GEECS-Schemas/geecs_schemas/__init__.py
@@ -55,7 +55,6 @@ from geecs_schemas.scan_variables import (
 from geecs_schemas.trigger_profile import (
     TriggerProfile,
     TriggerState,
-    TriggerVariant,
     TriggerWrite,
 )
 
@@ -95,7 +94,6 @@ __all__ = [
     "CompositeMode",
     # trigger_profile
     "TriggerProfile",
-    "TriggerVariant",
     "TriggerState",
     "TriggerWrite",
     # experiment_defaults

--- a/GEECS-Schemas/geecs_schemas/_base.py
+++ b/GEECS-Schemas/geecs_schemas/_base.py
@@ -13,6 +13,8 @@ guarantees:
 
 from __future__ import annotations
 
+from collections.abc import Mapping
+
 from pydantic import BaseModel, ConfigDict, Field
 
 
@@ -52,4 +54,34 @@ class VersionedSchemaModel(SchemaModel):
             "Format version of this config file. Leave at 1 — tools update "
             "this automatically when the file format changes."
         ),
+    )
+
+
+def stale_schema_version(data: Mapping[str, object], current: int) -> bool:
+    """Whether *data* declares a ``schema_version`` older than *current*.
+
+    The one definition every document kind's lifting validator uses to
+    decide "normalize the stamp up".  A quoted digit (``"1"`` from YAML or
+    JSON) counts the same as the int — pydantic's lax mode coerces it at
+    field validation, so the staleness check must see it the same way.  An
+    absent or unparseable version is *not* stale: the field default (the
+    current version) applies.
+
+    Parameters
+    ----------
+    data : Mapping
+        The raw document.
+    current : int
+        The format version the model is at.
+
+    Returns
+    -------
+    bool
+        ``True`` when a declared version is strictly older than *current*.
+    """
+    version = data.get("schema_version")
+    if isinstance(version, str) and version.isdigit():
+        version = int(version)
+    return (
+        isinstance(version, int) and not isinstance(version, bool) and version < current
     )

--- a/GEECS-Schemas/geecs_schemas/convert/__init__.py
+++ b/GEECS-Schemas/geecs_schemas/convert/__init__.py
@@ -27,7 +27,6 @@ from geecs_schemas.convert.save_elements import (
 from geecs_schemas.convert.scan_variables import convert_scan_variables
 from geecs_schemas.convert.trigger_profiles import (
     convert_shot_control,
-    merge_trigger_variant,
 )
 
 __all__ = [
@@ -38,7 +37,6 @@ __all__ = [
     "SaveElementConversion",
     "convert_scan_variables",
     "convert_shot_control",
-    "merge_trigger_variant",
     "convert_scan_preset",
     "compose_save_sets",
     "PresetConversion",

--- a/GEECS-Schemas/geecs_schemas/convert/trigger_profiles.py
+++ b/GEECS-Schemas/geecs_schemas/convert/trigger_profiles.py
@@ -27,9 +27,8 @@ Mapping (semantics reused, not contradicted):
   means "no shot control configured" and converts to ``None``, mirroring
   ``ShotControlConfig.from_information``.
 
-The laser-on/off duality — parallel near-identical files — becomes an
-explicit **variant** via :func:`merge_trigger_variant`: the second file is
-diffed against the base and only the differing writes are stored.
+Parallel operating-condition files (the laser-on/off pair) stay separate
+profiles — format v2 has no variant overlay; each converts on its own.
 """
 
 from __future__ import annotations
@@ -47,8 +46,6 @@ from geecs_schemas.convert._common import (
 from geecs_schemas.trigger_profile import (
     TriggerProfile,
     TriggerState,
-    TriggerVariant,
-    TriggerWrite,
 )
 
 
@@ -114,62 +111,3 @@ def convert_shot_control(
             )
 
     return TriggerProfile(name=profile_name, states=states)
-
-
-def merge_trigger_variant(
-    base: TriggerProfile, other: TriggerProfile, variant_name: str
-) -> TriggerProfile:
-    """Fold a parallel legacy profile into *base* as a named variant.
-
-    Parameters
-    ----------
-    base : TriggerProfile
-        The profile whose states are the defaults (e.g. converted
-        ``HTU-Normal``).
-    other : TriggerProfile
-        The parallel condition to express as a variant (e.g. converted
-        ``HTU-LaserOFF``).
-    variant_name : str
-        Name for the variant (e.g. ``"laser_off"``).
-
-    Returns
-    -------
-    TriggerProfile
-        A copy of *base* with ``variants[variant_name]`` holding exactly the
-        writes where *other* differs from (or adds to) *base*.
-
-    Raises
-    ------
-    SchemaConversionError
-        If *other* omits a device variable that *base* writes (a variant
-        overlay can override and add writes, but cannot remove one).
-    """
-    overlay: dict[str, list[TriggerWrite]] = {}
-    for state in TriggerState:
-        base_values = {
-            (write.device, write.variable): write.value
-            for write in base.writes_for(state)
-        }
-        other_writes = other.writes_for(state)
-        other_targets = {(write.device, write.variable) for write in other_writes}
-        removed = sorted(set(base_values) - other_targets)
-        if removed:
-            raise SchemaConversionError(
-                f"Cannot fold {other.name!r} into {base.name!r} as variant "
-                f"{variant_name!r}: state {state.value} drops write(s) "
-                f"{removed}, which a variant overlay cannot express."
-            )
-        diff = [
-            write
-            for write in other_writes
-            if base_values.get((write.device, write.variable)) != write.value
-        ]
-        if diff:
-            overlay[state.value] = diff
-
-    variants = dict(base.variants)
-    variants[variant_name] = TriggerVariant(
-        states=overlay,
-        description=f"Folded from legacy profile {other.name!r}.",
-    )
-    return base.model_copy(update={"variants": variants})

--- a/GEECS-Schemas/geecs_schemas/docgen.py
+++ b/GEECS-Schemas/geecs_schemas/docgen.py
@@ -52,7 +52,7 @@ REFERENCE_PAGE = Path("docs/geecs_schemas/schema_reference.md")
 # be longer than a docstring comfortably allows.
 EXAMPLES: dict[str, str] = {
     "scan_request": """\
-schema_version: 2
+schema_version: 3
 mode: step
 axes:
   - variable: jet_z
@@ -116,7 +116,7 @@ variables:
         forward: "composite_var * -2"
 """,
     "trigger_profile": """\
-schema_version: 1
+schema_version: 2
 name: htu_shot_control
 # each state lists its writes IN ORDER (top to bottom); a transition may
 # touch several devices

--- a/GEECS-Schemas/geecs_schemas/docgen.py
+++ b/GEECS-Schemas/geecs_schemas/docgen.py
@@ -141,18 +141,6 @@ states:
   SINGLESHOT:
     - {device: U_DG645_ShotControl, variable: Trigger.ExecuteSingleShot,
        value: "on"}
-variants:
-  laser_off:
-    states:
-      OFF:
-        - {device: U_DG645_ShotControl, variable: Trigger.Source,
-           value: Single shot}
-      SCAN:
-        - {device: U_DG645_ShotControl, variable: Trigger.Source,
-           value: Internal}
-      ARMED:
-        - {device: U_DG645_ShotControl, variable: Trigger.Source,
-           value: Single shot}
 """,
     "action_plan": """\
 schema_version: 1

--- a/GEECS-Schemas/geecs_schemas/scan_request.py
+++ b/GEECS-Schemas/geecs_schemas/scan_request.py
@@ -45,6 +45,16 @@ Schema v2 (the capture refactor, ``Planning/schema_refactor/00_overview.md``):
 - A ``mode="before"`` validator lifts the flat v1 layout into ``capture``
   (and drops a v1 ``submission`` key), so saved presets, archived run
   metadata, and stale clients keep validating forever.
+
+Schema v3 (drop the trigger variant):
+
+- ``trigger_variant`` left :class:`CaptureSettings`: profile variants were
+  never adopted (every experiment kept one profile file per operating
+  condition), and :class:`~geecs_schemas.trigger_profile.TriggerProfile`
+  v2 removed them.  The same before-validator drops an unset
+  ``trigger_variant`` (flat v1 or inside ``capture``) and refuses a set
+  one with the remedy (name the condition's own profile); ``schema_version``
+  ≤ 2 is normalized to 3.
 """
 
 from __future__ import annotations
@@ -250,11 +260,10 @@ class CaptureSettings(SchemaModel):
     shots per step, an acquisition discipline, the save sets naming the
     recorded devices, the telemetry and native-image-save toggles, and the
     trigger profile driving the shot trigger.  This model groups those
-    seven settings; conceptually they are three sub-groups — shot control
+    six settings; conceptually they are three sub-groups — shot control
     (``shots_per_step`` + ``acquisition``), data logging (``save_sets`` +
-    ``background_telemetry`` + ``native_image_save``), and trigger
-    (``trigger_profile`` + ``trigger_variant``) — kept one level flat
-    here on purpose.
+    ``background_telemetry`` + ``native_image_save``), and the trigger
+    profile — kept one level flat here on purpose.
 
     Every field has a usable default, so an omitted ``capture`` block is a
     valid one-shot strict capture with no named save sets.
@@ -329,13 +338,6 @@ class CaptureSettings(SchemaModel):
             "Unset means the scan does not manage the trigger."
         ),
     )
-    trigger_variant: Optional[str] = Field(
-        None,
-        description=(
-            "Optional variant of the trigger profile to use, e.g. "
-            "'laser_off'. Leave unset for the profile's base behaviour."
-        ),
-    )
 
     @field_validator("save_sets", mode="before")
     @classmethod
@@ -360,24 +362,6 @@ class CaptureSettings(SchemaModel):
         if isinstance(value, str):
             return [value]
         return value
-
-    @model_validator(mode="after")
-    def _check_trigger_consistency(self) -> "CaptureSettings":
-        """Require a trigger profile when a variant is named.
-
-        Returns
-        -------
-        CaptureSettings
-            The validated model.
-
-        Raises
-        ------
-        ValueError
-            If ``trigger_variant`` is set without ``trigger_profile``.
-        """
-        if self.trigger_variant is not None and self.trigger_profile is None:
-            raise ValueError("'trigger_variant' needs 'trigger_profile' to be set too.")
-        return self
 
 
 class EvaluatorSpec(SchemaModel):
@@ -631,7 +615,13 @@ _V1_CAPTURE_FIELDS = (
     "background_telemetry",
     "native_image_save",
     "trigger_profile",
-    "trigger_variant",
+)
+#: Removed in v3: dropped when unset, refused when set (no overlay exists).
+_REMOVED_TRIGGER_VARIANT = "trigger_variant"
+_TRIGGER_VARIANT_REMEDY = (
+    "'trigger_variant' was removed in ScanRequest format v3 (profile "
+    "variants never existed in practice): save the operating condition as "
+    "its own trigger profile and name it in 'trigger_profile'."
 )
 
 
@@ -667,17 +657,18 @@ class ScanRequest(VersionedSchemaModel):
     anticipated extension point.
 
     Format v2 moved the capture-concern fields into ``capture`` and dropped
-    ``submission`` (see the module docstring).  The flat v1 layout — those
-    fields at the top level, plus an optional ``submission`` record — is
-    lifted into the v2 shape by a before-validator, so v1 documents keep
-    validating; a declared ``schema_version`` ≤ 1 is normalized to 2 (even
-    on a sparse document with nothing to lift).
+    ``submission``; format v3 dropped ``trigger_variant`` (see the module
+    docstring).  One before-validator lifts every older layout — the flat
+    v1 fields into ``capture``, a v1 ``submission`` key and an unset
+    ``trigger_variant`` dropped — so older documents keep validating; a
+    declared ``schema_version`` ≤ 2 is normalized to 3 (even on a sparse
+    document with nothing to lift).
     """
 
     schema_version: int = Field(
-        2,
+        3,
         description=(
-            "Format version of this config file. Leave at 2 — tools update "
+            "Format version of this config file. Leave at 3 — tools update "
             "this automatically when the file format changes."
         ),
     )
@@ -738,15 +729,16 @@ class ScanRequest(VersionedSchemaModel):
     @model_validator(mode="before")
     @classmethod
     def _lift_v1_layout(cls, data: object) -> object:
-        """Lift the flat v1 document layout into the v2 ``capture`` shape.
+        """Lift older document layouts into the current (v3) shape.
 
-        The v1→v2 migration, applied mechanically at validation: the seven
-        capture fields found at the top level move into ``capture``, a v1
-        ``submission`` record is dropped (it left the request document —
-        the engine's run metadata carries submission provenance
-        independently), and a declared ``schema_version`` ≤ 1 is
-        normalized to 2 (a version ≥ 2 is never overwritten — a future
-        v3 document must keep its stamp through this validator).  Saved
+        Applied mechanically at validation: the v1 capture fields found at
+        the top level move into ``capture``, a v1 ``submission`` record is
+        dropped (it left the request document — the engine's run metadata
+        carries submission provenance independently), an unset
+        ``trigger_variant`` (flat, or inside ``capture``) is dropped and a
+        set one refused (v3), and a declared ``schema_version`` ≤ 2 is
+        normalized to 3 (a version ≥ 3 is never overwritten — a future v4
+        document must keep its stamp through this validator).  Saved
         presets, archived run-metadata documents, and stale clients
         therefore keep validating forever.  Mixing the flat fields with an
         explicit ``capture`` block is ambiguous and rejected.
@@ -765,7 +757,7 @@ class ScanRequest(VersionedSchemaModel):
         ------
         ValueError
             If flat v1 capture fields and a ``capture`` block are both
-            present.
+            present, or if ``trigger_variant`` is set.
         """
         if not isinstance(data, dict):
             return data
@@ -775,20 +767,37 @@ class ScanRequest(VersionedSchemaModel):
             # Pydantic's lax mode coerces a quoted "1" to int at field
             # validation, so the staleness check must see it the same way.
             version = int(version)
-        stale_version = isinstance(version, int) and version <= 1
-        if not flat and "submission" not in data and not stale_version:
+        stale_version = isinstance(version, int) and version <= 2
+        capture = data.get("capture")
+        variant_in_capture = isinstance(capture, dict) and (
+            _REMOVED_TRIGGER_VARIANT in capture
+        )
+        variant_flat = _REMOVED_TRIGGER_VARIANT in data
+        if (
+            not flat
+            and "submission" not in data
+            and not stale_version
+            and not variant_flat
+            and not variant_in_capture
+        ):
             return data
-        if flat and "capture" in data:
+        if (flat or variant_flat) and "capture" in data:
             raise ValueError(
                 f"Give capture settings either flat (v1: {flat}) or inside "
-                "'capture' (v2), not both."
+                "'capture' (v2+), not both."
             )
         lifted = dict(data)
         lifted.pop("submission", None)
+        if variant_flat and lifted.pop(_REMOVED_TRIGGER_VARIANT) is not None:
+            raise ValueError(_TRIGGER_VARIANT_REMEDY)
+        if variant_in_capture:
+            lifted["capture"] = dict(capture)
+            if lifted["capture"].pop(_REMOVED_TRIGGER_VARIANT) is not None:
+                raise ValueError(_TRIGGER_VARIANT_REMEDY)
         if flat:
             lifted["capture"] = {key: lifted.pop(key) for key in flat}
         if stale_version:
-            lifted["schema_version"] = 2
+            lifted["schema_version"] = 3
         return lifted
 
     @model_validator(mode="after")

--- a/GEECS-Schemas/geecs_schemas/scan_request.py
+++ b/GEECS-Schemas/geecs_schemas/scan_request.py
@@ -64,7 +64,11 @@ from typing import Optional, Union
 
 from pydantic import Field, field_validator, model_validator
 
-from geecs_schemas._base import SchemaModel, VersionedSchemaModel
+from geecs_schemas._base import (
+    SchemaModel,
+    VersionedSchemaModel,
+    stale_schema_version,
+)
 
 
 class ScanRequestMode(str, Enum):
@@ -762,12 +766,7 @@ class ScanRequest(VersionedSchemaModel):
         if not isinstance(data, dict):
             return data
         flat = [key for key in _V1_CAPTURE_FIELDS if key in data]
-        version = data.get("schema_version")
-        if isinstance(version, str) and version.isdigit():
-            # Pydantic's lax mode coerces a quoted "1" to int at field
-            # validation, so the staleness check must see it the same way.
-            version = int(version)
-        stale_version = isinstance(version, int) and version <= 2
+        stale_version = stale_schema_version(data, 3)
         capture = data.get("capture")
         variant_in_capture = isinstance(capture, dict) and (
             _REMOVED_TRIGGER_VARIANT in capture
@@ -781,19 +780,22 @@ class ScanRequest(VersionedSchemaModel):
             and not variant_in_capture
         ):
             return data
-        if (flat or variant_flat) and "capture" in data:
-            raise ValueError(
-                f"Give capture settings either flat (v1: {flat}) or inside "
-                "'capture' (v2+), not both."
-            )
         lifted = dict(data)
         lifted.pop("submission", None)
+        # The removed field first, on its own terms: an unset one is dropped
+        # wherever it sits; a set one gets the v3 remedy — before the
+        # flat-vs-capture check, which is about the six live fields.
         if variant_flat and lifted.pop(_REMOVED_TRIGGER_VARIANT) is not None:
             raise ValueError(_TRIGGER_VARIANT_REMEDY)
         if variant_in_capture:
             lifted["capture"] = dict(capture)
             if lifted["capture"].pop(_REMOVED_TRIGGER_VARIANT) is not None:
                 raise ValueError(_TRIGGER_VARIANT_REMEDY)
+        if flat and "capture" in data:
+            raise ValueError(
+                f"Give capture settings either flat (v1: {flat}) or inside "
+                "'capture' (v2+), not both."
+            )
         if flat:
             lifted["capture"] = {key: lifted.pop(key) for key in flat}
         if stale_version:

--- a/GEECS-Schemas/geecs_schemas/trigger_profile.py
+++ b/GEECS-Schemas/geecs_schemas/trigger_profile.py
@@ -284,6 +284,12 @@ class TriggerProfile(VersionedSchemaModel):
             return data
         lifted = dict(data)
         variants = lifted.pop("variants", None) or {}
+        if not isinstance(variants, dict):
+            raise ValueError(
+                f"trigger profile {lifted.get('name', '?')!r}: 'variants' must be a "
+                "mapping (and profile variants were removed in format v2 — drop "
+                "the block)."
+            )
         populated = sorted(
             name
             for name, variant in variants.items()

--- a/GEECS-Schemas/geecs_schemas/trigger_profile.py
+++ b/GEECS-Schemas/geecs_schemas/trigger_profile.py
@@ -9,12 +9,16 @@ timing hardware changes, when a state needs an extra write, or when a new
 device joins the transition.  A scan picks a profile by name in its
 :class:`~geecs_schemas.scan_request.ScanRequest`.
 
-Variants replace parallel files
--------------------------------
-Operating conditions that used to be near-duplicate YAML files (the classic
-laser-on / laser-off pair) become **variants** inside one profile: a variant
-overlays a few state writes on top of the base profile (e.g. ``laser_off``
-switches ``Trigger.Source`` to internal).  One file, explicit differences.
+One operating condition, one profile
+------------------------------------
+Operating conditions (the classic laser-on / laser-off pair, no-gas, …) are
+separate profile files, each complete on its own, and a scan names the one
+it wants.  Format v1 also allowed named *variants* inside a profile (an
+overlay of a few writes); nobody adopted them — every experiment kept
+separate files — so format v2 removed them.  A v1 file with an empty
+``variants`` block still loads (the block is dropped); one that actually
+defines a variant is refused with the remedy: split it into its own
+profile.
 
 Developer notes
 ---------------
@@ -49,7 +53,7 @@ from __future__ import annotations
 
 from enum import Enum
 
-from pydantic import Field, field_validator
+from pydantic import model_validator, Field, field_validator
 
 from geecs_schemas._base import SchemaModel, VersionedSchemaModel
 
@@ -196,47 +200,34 @@ def _reject_duplicate_targets(states: dict) -> dict:
     return states
 
 
-class TriggerVariant(SchemaModel):
-    """A named operating condition that tweaks a few writes of the profile.
-
-    A variant lists only what *differs* from the base profile — for example
-    a ``laser_off`` variant that flips the trigger source to internal while
-    everything else stays as the base defines it.
-    """
-
-    states: dict[TriggerState, StateWrites] = Field(
-        description=(
-            "Only the writes that differ from the base profile, per state. "
-            "A write here replaces the base write to the same device "
-            "variable; writes to new device variables are added after the "
-            "base ones. Anything not listed keeps its base value."
-        )
-    )
-    description: str = Field(
-        "",
-        description="Optional note about when to use this variant.",
-    )
-
-    _fix_off_key = field_validator("states", mode="before")(_normalize_state_keys)
-    _no_duplicates = field_validator("states")(_reject_duplicate_targets)
-
-
 class TriggerProfile(VersionedSchemaModel):
     """The device writes that drive the machine through its trigger states.
 
     For each state (OFF, STANDBY, SCAN, SINGLESHOT, ARMED) list the writes —
     possibly to several devices — that put the machine into it, **in the
     order they should be sent**.  Edit it when timing hardware or its
-    settings change; add a variant when you need a named alternative
-    condition (e.g. laser off) instead of a copy of the whole file.
+    settings change; make a separate profile for a different operating
+    condition (e.g. laser off).
 
     Notes
     -----
     Values are sent verbatim over the GEECS wire protocol.  Use
     :meth:`writes_for` / :meth:`defines_state` instead of digging the lists —
-    they implement the variant overlay and the "state with no writes is not
-    defined" rule.  :attr:`devices` lists every device the profile touches.
+    they implement the "state with no writes is not defined" rule.
+    :attr:`devices` lists every device the profile touches.
+
+    Format v2 removed the v1 ``variants`` overlay (see the module
+    docstring); a before-validator drops an empty v1 block, refuses a
+    populated one, and normalizes ``schema_version`` ≤ 1 to 2.
     """
+
+    schema_version: int = Field(
+        2,
+        description=(
+            "Format version of this config file. Leave at 2 — tools update "
+            "this automatically when the file format changes."
+        ),
+    )
 
     name: str = Field(
         description="The name scans use to refer to this trigger profile."
@@ -250,13 +241,6 @@ class TriggerProfile(VersionedSchemaModel):
             "leave it untouched."
         ),
     )
-    variants: dict[str, TriggerVariant] = Field(
-        default_factory=dict,
-        description=(
-            "Named alternative operating conditions (e.g. 'laser_off'), each "
-            "listing only the writes that differ from the base states."
-        ),
-    )
     description: str = Field(
         "",
         description="Optional note about what setup this profile is for.",
@@ -265,6 +249,48 @@ class TriggerProfile(VersionedSchemaModel):
     _fix_off_key = field_validator("states", mode="before")(_normalize_state_keys)
     _no_duplicates = field_validator("states")(_reject_duplicate_targets)
 
+    @model_validator(mode="before")
+    @classmethod
+    def _lift_v1_layout(cls, data: object) -> object:
+        """Drop the removed v1 ``variants`` block; normalize the version.
+
+        Parameters
+        ----------
+        data : object
+            The raw input; non-mapping input passes through untouched.
+
+        Returns
+        -------
+        object
+            The (copied) mapping in v2 layout, or *data* unchanged.
+
+        Raises
+        ------
+        ValueError
+            If the document defines a variant — format v2 has no overlay;
+            the remedy is a separate profile per operating condition.
+        """
+        if not isinstance(data, dict):
+            return data
+        version = data.get("schema_version")
+        if isinstance(version, str) and version.isdigit():
+            version = int(version)
+        stale = isinstance(version, int) and version <= 1
+        if "variants" not in data and not stale:
+            return data
+        lifted = dict(data)
+        variants = lifted.pop("variants", None)
+        if variants:
+            raise ValueError(
+                f"trigger profile {lifted.get('name', '?')!r} defines variant(s) "
+                f"{sorted(variants)} — profile variants were removed in format "
+                "v2; save each operating condition as its own profile file "
+                "and name that profile in the scan request."
+            )
+        if stale:
+            lifted["schema_version"] = 2
+        return lifted
+
     @property
     def devices(self) -> list[str]:
         """Every device this profile writes, in order of first appearance.
@@ -272,71 +298,37 @@ class TriggerProfile(VersionedSchemaModel):
         Returns
         -------
         list of str
-            Distinct device names across all base states and variants.
+            Distinct device names across all states.
         """
         seen: dict[str, None] = {}
         for writes in self.states.values():
             for write in writes:
                 seen.setdefault(write.device)
-        for variant in self.variants.values():
-            for writes in variant.states.values():
-                for write in writes:
-                    seen.setdefault(write.device)
         return list(seen)
 
-    def writes_for(
-        self, state: "TriggerState | str", variant: str | None = None
-    ) -> StateWrites:
+    def writes_for(self, state: "TriggerState | str") -> StateWrites:
         """Return the ordered writes that drive *state*.
 
         Parameters
         ----------
         state : TriggerState or str
             The target state.
-        variant : str, optional
-            Name of a variant to overlay on the base writes.
 
         Returns
         -------
         list of TriggerWrite
-            The merged transition: base writes in their declared order, with
-            variant writes replacing same-(device, variable) entries in
-            place and any additional variant writes appended after them.
-
-        Raises
-        ------
-        KeyError
-            If *variant* is given but not defined on this profile.
+            The transition's writes in their declared order (empty when the
+            state is not defined).
         """
-        key = TriggerState(state)
-        writes = list(self.states.get(key, []))
-        if variant is not None:
-            if variant not in self.variants:
-                raise KeyError(
-                    f"Trigger profile {self.name!r} has no variant "
-                    f"{variant!r}. Known variants: {sorted(self.variants)}"
-                )
-            overlay = {
-                (write.device, write.variable): write
-                for write in self.variants[variant].states.get(key, [])
-            }
-            writes = [
-                overlay.pop((write.device, write.variable), write) for write in writes
-            ]
-            writes.extend(overlay.values())
-        return writes
+        return list(self.states.get(TriggerState(state), []))
 
-    def defines_state(
-        self, state: "TriggerState | str", variant: str | None = None
-    ) -> bool:
+    def defines_state(self, state: "TriggerState | str") -> bool:
         """Whether driving to *state* would write anything at all.
 
         Parameters
         ----------
         state : TriggerState or str
             The state to query.
-        variant : str, optional
-            Name of a variant to overlay before deciding.
 
         Returns
         -------
@@ -344,4 +336,4 @@ class TriggerProfile(VersionedSchemaModel):
             ``True`` if at least one write exists for the state (matching the
             legacy ``ShotControlConfig.defines_state`` semantics).
         """
-        return bool(self.writes_for(state, variant))
+        return bool(self.writes_for(state))

--- a/GEECS-Schemas/geecs_schemas/trigger_profile.py
+++ b/GEECS-Schemas/geecs_schemas/trigger_profile.py
@@ -55,7 +55,11 @@ from enum import Enum
 
 from pydantic import model_validator, Field, field_validator
 
-from geecs_schemas._base import SchemaModel, VersionedSchemaModel
+from geecs_schemas._base import (
+    SchemaModel,
+    VersionedSchemaModel,
+    stale_schema_version,
+)
 
 
 class TriggerState(str, Enum):
@@ -267,25 +271,30 @@ class TriggerProfile(VersionedSchemaModel):
         Raises
         ------
         ValueError
-            If the document defines a variant — format v2 has no overlay;
-            the remedy is a separate profile per operating condition.
+            If the document defines a variant *with writes* — format v2 has
+            no overlay; the remedy is a separate profile per operating
+            condition.  A variant with no writes (what the retired editor's
+            "Add variant" saved when never filled in) is a no-op and is
+            dropped like an empty block.
         """
         if not isinstance(data, dict):
             return data
-        version = data.get("schema_version")
-        if isinstance(version, str) and version.isdigit():
-            version = int(version)
-        stale = isinstance(version, int) and version <= 1
+        stale = stale_schema_version(data, 2)
         if "variants" not in data and not stale:
             return data
         lifted = dict(data)
-        variants = lifted.pop("variants", None)
-        if variants:
+        variants = lifted.pop("variants", None) or {}
+        populated = sorted(
+            name
+            for name, variant in variants.items()
+            if isinstance(variant, dict) and any(variant.get("states", {}).values())
+        )
+        if populated:
             raise ValueError(
                 f"trigger profile {lifted.get('name', '?')!r} defines variant(s) "
-                f"{sorted(variants)} — profile variants were removed in format "
-                "v2; save each operating condition as its own profile file "
-                "and name that profile in the scan request."
+                f"{populated} — profile variants were removed in format v2; "
+                "save each operating condition as its own profile file and "
+                "name that profile in the scan request."
             )
         if stale:
             lifted["schema_version"] = 2

--- a/GEECS-Schemas/pyproject.toml
+++ b/GEECS-Schemas/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-schemas"
-version = "0.14.0"
+version = "0.15.0"
 description = "Versioned Pydantic schemas for GEECS scanner configs (scan requests, save sets, scan variables, trigger profiles, action plans) plus legacy-YAML converters."
 authors = ["Sam Barber <sbarber@lbl.gov>"]
 readme = "README.md"

--- a/GEECS-Schemas/tests/generate_golden.py
+++ b/GEECS-Schemas/tests/generate_golden.py
@@ -15,7 +15,6 @@ from geecs_schemas.convert import (
     convert_scan_preset,
     convert_scan_variables,
     convert_shot_control,
-    merge_trigger_variant,
 )
 
 TESTS = Path(__file__).parent
@@ -66,9 +65,7 @@ def main() -> None:
     )
     write("undulator_scan_variables.json", undulator.model_dump(mode="json"))
 
-    base = convert_shot_control(FIXTURES / "shot_control/HTU-Normal.yaml")
-    off = convert_shot_control(FIXTURES / "shot_control/HTU-LaserOFF.yaml")
-    profile = merge_trigger_variant(base, off, "laser_off")
+    profile = convert_shot_control(FIXTURES / "shot_control/HTU-Normal.yaml")
     write("htu_trigger_profile.json", profile.model_dump(mode="json"))
 
     library = convert_action_library(FIXTURES / "actions/actions_undulator.yaml")

--- a/GEECS-Schemas/tests/golden/focuscan_scan_request.json
+++ b/GEECS-Schemas/tests/golden/focuscan_scan_request.json
@@ -23,11 +23,10 @@
       "LP-FocusDiagnostics"
     ],
     "shots_per_step": 10,
-    "trigger_profile": null,
-    "trigger_variant": null
+    "trigger_profile": null
   },
   "description": "Focus Scan",
   "mode": "step",
   "optimization": null,
-  "schema_version": 2
+  "schema_version": 3
 }

--- a/GEECS-Schemas/tests/golden/htu_trigger_profile.json
+++ b/GEECS-Schemas/tests/golden/htu_trigger_profile.json
@@ -1,7 +1,7 @@
 {
   "description": "",
   "name": "HTU-Normal",
-  "schema_version": 1,
+  "schema_version": 2,
   "states": {
     "ARMED": [
       {
@@ -58,33 +58,5 @@
         "variable": "Trigger.Source"
       }
     ]
-  },
-  "variants": {
-    "laser_off": {
-      "description": "Folded from legacy profile 'HTU-LaserOFF'.",
-      "states": {
-        "ARMED": [
-          {
-            "device": "U_DG645_ShotControl",
-            "value": "Single shot",
-            "variable": "Trigger.Source"
-          }
-        ],
-        "OFF": [
-          {
-            "device": "U_DG645_ShotControl",
-            "value": "Single shot",
-            "variable": "Trigger.Source"
-          }
-        ],
-        "SCAN": [
-          {
-            "device": "U_DG645_ShotControl",
-            "value": "Internal",
-            "variable": "Trigger.Source"
-          }
-        ]
-      }
-    }
   }
 }

--- a/GEECS-Schemas/tests/test_converters.py
+++ b/GEECS-Schemas/tests/test_converters.py
@@ -10,7 +10,7 @@ from pathlib import Path
 
 import pytest
 
-from geecs_schemas import SaveRole, TriggerState
+from geecs_schemas import SaveRole
 from geecs_schemas.convert import (
     SchemaConversionError,
     convert_action_library,
@@ -20,7 +20,6 @@ from geecs_schemas.convert import (
     convert_scan_preset,
     convert_scan_variables,
     convert_shot_control,
-    merge_trigger_variant,
 )
 
 # Defined locally (not imported from conftest) so the module imports cleanly
@@ -219,26 +218,13 @@ class TestTriggerProfiles:
         assert convert_shot_control(FIXTURES / "shot_control/Bella Normal.yaml") is None
         assert convert_shot_control(FIXTURES / "shot_control/No Device.yaml") is None
 
-    def test_laser_off_pair_becomes_variant(self):
-        base = convert_shot_control(FIXTURES / "shot_control/HTU-Normal.yaml")
+    def test_laser_off_file_converts_as_its_own_profile(self):
         off = convert_shot_control(FIXTURES / "shot_control/HTU-LaserOFF.yaml")
-        profile = merge_trigger_variant(base, off, "laser_off")
-        assert set(profile.variants) == {"laser_off"}
-        # the variant carries only the differing writes
-        overlay = profile.variants["laser_off"].states
-        assert as_tuples(overlay[TriggerState.SCAN]) == [
-            ("U_DG645_ShotControl", "Trigger.Source", "Internal")
-        ]
-        # resolving through the variant reproduces the parallel file's writes
-        # (as a set — order within a transition may legitimately differ when
-        # the variant appends writes the base lacked)
-        for state in TriggerState:
-            assert set(
-                as_tuples(profile.writes_for(state, variant="laser_off"))
-            ) == set(as_tuples(off.writes_for(state)))
-        assert_matches_golden(
-            profile.model_dump(mode="json"), "htu_trigger_profile.json"
-        )
+        scan = {(w.device, w.variable): w.value for w in off.writes_for("SCAN")}
+        assert scan[("U_DG645_ShotControl", "Trigger.Source")] == "Internal"
+        assert "variants" not in off.model_dump(mode="json")
+        base = convert_shot_control(FIXTURES / "shot_control/HTU-Normal.yaml")
+        assert_matches_golden(base.model_dump(mode="json"), "htu_trigger_profile.json")
 
     def test_unknown_state_fails_loudly(self):
         with pytest.raises(SchemaConversionError, match="BLASTOFF"):

--- a/GEECS-Schemas/tests/test_corpus_integration.py
+++ b/GEECS-Schemas/tests/test_corpus_integration.py
@@ -41,7 +41,6 @@ from geecs_schemas.convert import (
     convert_scan_preset,
     convert_scan_variables,
     convert_shot_control,
-    merge_trigger_variant,
 )
 
 
@@ -190,33 +189,6 @@ class TestFullCorpus:
                 else:
                     converted += 1
         assert converted >= 8 and no_device >= 2
-
-    def test_laser_pairs_fold_into_variants(self):
-        pairs = [
-            ("Undulator", "HTU-Normal", "HTU-LaserOFF"),
-            ("Thomson", "HTT-Normal", "HTT-LaserOFF"),
-        ]
-        for experiment, base_name, off_name in pairs:
-            directory = (
-                CONFIGS
-                / "scanner_configs/experiments"
-                / experiment
-                / "shot_control_configurations"
-            )
-            base = convert_shot_control(directory / f"{base_name}.yaml")
-            off = convert_shot_control(directory / f"{off_name}.yaml")
-            merged = merge_trigger_variant(base, off, "laser_off")
-            for state in ("OFF", "STANDBY", "SCAN", "SINGLESHOT", "ARMED"):
-                # set comparison: write order within a transition may differ
-                # when the variant appends writes the base lacked
-                resolved = {
-                    (w.device, w.variable, w.value)
-                    for w in merged.writes_for(state, variant="laser_off")
-                }
-                expected = {
-                    (w.device, w.variable, w.value) for w in off.writes_for(state)
-                }
-                assert resolved == expected, (experiment, state)
 
     def test_every_action_library_converts(self):
         libraries = {}

--- a/GEECS-Schemas/tests/test_docgen.py
+++ b/GEECS-Schemas/tests/test_docgen.py
@@ -65,3 +65,13 @@ class TestReference:
         for kind, model in SCHEMA_REGISTRY.items():
             document = yaml.safe_load(EXAMPLES[kind])
             model.model_validate(document)
+
+    def test_examples_stamp_the_current_schema_version(self):
+        # The lifting validators normalize a stale stamp up, so validation
+        # alone cannot see an example that disagrees with the reference
+        # table it sits under — pin the raw stamp to the model's default.
+        yaml = pytest.importorskip("yaml")
+        for kind, model in SCHEMA_REGISTRY.items():
+            document = yaml.safe_load(EXAMPLES[kind])
+            current = model.model_fields["schema_version"].default
+            assert document.get("schema_version") == current, (kind, current)

--- a/GEECS-Schemas/tests/test_scan_request.py
+++ b/GEECS-Schemas/tests/test_scan_request.py
@@ -216,12 +216,6 @@ class TestScanRequest:
                 }
             )
 
-    def test_trigger_variant_needs_profile(self):
-        with pytest.raises(ValidationError, match="trigger_variant"):
-            ScanRequest.model_validate(
-                {"mode": "noscan", "trigger_variant": "laser_off"}
-            )
-
     def test_explicit_position_list(self):
         request = make_step_request(
             axes=[{"variable": "jet_z", "positions": {"values": [0.0, 0.5, 2.0]}}]
@@ -348,7 +342,7 @@ class TestSubmissionRecord:
 
 
 class TestV1Migration:
-    """The v1→v2 lifting validator (Planning/schema_refactor/00_overview.md)."""
+    """The v1→v3 lifting validator (Planning/schema_refactor/00_overview.md)."""
 
     def test_flat_v1_layout_lifts_into_capture(self):
         request = make_step_request()  # flat layout by construction
@@ -358,7 +352,7 @@ class TestV1Migration:
 
     def test_lifted_document_normalizes_schema_version(self):
         request = make_step_request(schema_version=1)
-        assert request.schema_version == 2
+        assert request.schema_version == 3
 
     def test_quoted_v1_schema_version_also_normalizes(self):
         # A quoted "1" (string-typed YAML/JSON) coerces to int at field
@@ -366,31 +360,31 @@ class TestV1Migration:
         request = ScanRequest.model_validate(
             {"mode": "noscan", "schema_version": "1", "shots_per_step": 2}
         )
-        assert request.schema_version == 2
+        assert request.schema_version == 3
 
     def test_sparse_v1_document_normalizes_schema_version(self):
         # A declared version <= 1 is normalized even with NO flat fields to
         # lift — otherwise a sparse v1 preset would round-trip a v2-shaped
         # dump stamped schema_version: 1.
         request = ScanRequest.model_validate({"mode": "noscan", "schema_version": 1})
-        assert request.schema_version == 2
-        assert request.model_dump(mode="json")["schema_version"] == 2
+        assert request.schema_version == 3
+        assert request.model_dump(mode="json")["schema_version"] == 3
 
     def test_future_schema_version_is_never_clobbered_down(self):
         # The submission-drop path must not stamp a future document back to
-        # 2 — a v3 stamp survives this validator.
+        # 3 — a v4 stamp survives this validator.
         request = ScanRequest.model_validate(
             {
-                "schema_version": 3,
+                "schema_version": 4,
                 "mode": "noscan",
                 "capture": {"shots_per_step": 4},
                 "submission": {"client": "x", "preflight": []},
             }
         )
-        assert request.schema_version == 3
+        assert request.schema_version == 4
         assert "submission" not in request.model_dump(mode="json")
 
-    def test_v2_document_round_trips_untouched(self):
+    def test_v2_document_lifts_to_v3(self):
         v2 = {
             "schema_version": 2,
             "mode": "noscan",
@@ -398,8 +392,48 @@ class TestV1Migration:
         }
         request = ScanRequest.model_validate(v2)
         assert request.capture.shots_per_step == 7
+        assert request.schema_version == 3
         again = ScanRequest.model_validate(request.model_dump(mode="json"))
         assert again == request
+
+    def test_v3_document_round_trips_untouched(self):
+        v3 = {
+            "schema_version": 3,
+            "mode": "noscan",
+            "capture": {"shots_per_step": 7, "save_sets": ["diag"]},
+        }
+        request = ScanRequest.model_validate(v3)
+        assert request.model_dump(mode="json")["schema_version"] == 3
+        assert ScanRequest.model_validate(request.model_dump(mode="json")) == request
+
+    def test_unset_trigger_variant_is_dropped_flat_and_nested(self):
+        # v1 presets carry `trigger_variant: null` at the top level and v2
+        # documents inside `capture` — both are dropped, not refused.
+        flat = ScanRequest.model_validate(
+            {"schema_version": 1, "mode": "noscan", "trigger_variant": None}
+        )
+        nested = ScanRequest.model_validate(
+            {
+                "schema_version": 2,
+                "mode": "noscan",
+                "capture": {"shots_per_step": 2, "trigger_variant": None},
+            }
+        )
+        for request in (flat, nested):
+            assert request.schema_version == 3
+            assert "trigger_variant" not in request.model_dump(mode="json")["capture"]
+        assert nested.capture.shots_per_step == 2
+
+    def test_set_trigger_variant_is_refused_with_the_remedy(self):
+        for document in (
+            {"mode": "noscan", "trigger_profile": "p", "trigger_variant": "laser_off"},
+            {
+                "mode": "noscan",
+                "capture": {"trigger_profile": "p", "trigger_variant": "laser_off"},
+            },
+        ):
+            with pytest.raises(ValidationError, match="own trigger profile"):
+                ScanRequest.model_validate(document)
 
     def test_capture_omitted_defaults(self):
         request = ScanRequest.model_validate({"mode": "noscan"})
@@ -425,4 +459,4 @@ class TestV1Migration:
             submission={"client": "geecs-console 0.21.0", "preflight": []}
         )
         assert "submission" not in request.model_dump(mode="json")
-        assert request.schema_version == 2
+        assert request.schema_version == 3

--- a/GEECS-Schemas/tests/test_scan_request.py
+++ b/GEECS-Schemas/tests/test_scan_request.py
@@ -424,6 +424,26 @@ class TestV1Migration:
             assert "trigger_variant" not in request.model_dump(mode="json")["capture"]
         assert nested.capture.shots_per_step == 2
 
+    def test_flat_trigger_variant_beside_capture_gets_the_variant_verdict(self):
+        # Only the removed field is flat: it is judged on its own terms —
+        # unset → dropped (no "mixed layout" refusal), set → the v3 remedy.
+        dropped = ScanRequest.model_validate(
+            {
+                "mode": "noscan",
+                "capture": {"shots_per_step": 2},
+                "trigger_variant": None,
+            }
+        )
+        assert dropped.capture.shots_per_step == 2
+        with pytest.raises(ValidationError, match="own trigger profile"):
+            ScanRequest.model_validate(
+                {
+                    "mode": "noscan",
+                    "capture": {"shots_per_step": 2},
+                    "trigger_variant": "laser_off",
+                }
+            )
+
     def test_set_trigger_variant_is_refused_with_the_remedy(self):
         for document in (
             {"mode": "noscan", "trigger_profile": "p", "trigger_variant": "laser_off"},

--- a/GEECS-Schemas/tests/test_trigger_profile.py
+++ b/GEECS-Schemas/tests/test_trigger_profile.py
@@ -102,6 +102,16 @@ class TestTriggerProfile:
         assert profile.schema_version == 2
         assert "variants" not in profile.model_dump(mode="json")
 
+    def test_v1_variants_of_the_wrong_shape_is_a_validation_error(self):
+        with pytest.raises(ValidationError, match="must be a mapping"):
+            TriggerProfile.model_validate(
+                {
+                    "name": "x",
+                    "states": {"SCAN": [write(DG, "Trigger.Source", "External")]},
+                    "variants": ["laser_off"],
+                }
+            )
+
     def test_v2_document_round_trips_untouched(self):
         profile = make_profile()
         assert profile.schema_version == 2

--- a/GEECS-Schemas/tests/test_trigger_profile.py
+++ b/GEECS-Schemas/tests/test_trigger_profile.py
@@ -3,7 +3,7 @@
 import pytest
 from pydantic import ValidationError
 
-from geecs_schemas import TriggerProfile, TriggerState, TriggerWrite
+from geecs_schemas import TriggerProfile
 
 
 def write(device, variable, value):
@@ -38,15 +38,6 @@ def make_profile():
                 ],
                 "SINGLESHOT": [write(DG, "Trigger.ExecuteSingleShot", "on")],
             },
-            "variants": {
-                "laser_off": {
-                    "states": {
-                        "SCAN": [write(DG, "Trigger.Source", "Internal")],
-                        "ARMED": [write(DG, "Trigger.Source", "Single shot")],
-                        "OFF": [write(DG, "Trigger.Source", "Single shot")],
-                    }
-                }
-            },
         }
     )
 
@@ -70,40 +61,40 @@ class TestTriggerProfile:
     def test_devices_property_lists_distinct_devices(self):
         assert make_profile().devices == [DG, JET]
 
-    def test_variant_overlays_in_place_and_keeps_order(self):
-        profile = make_profile()
-        writes = profile.writes_for(TriggerState.SCAN, variant="laser_off")
-        assert [(w.device, w.variable, w.value) for w in writes] == [
-            (DG, "Amplitude.Ch AB", "4.0"),  # inherited from base
-            (DG, "Trigger.Source", "Internal"),  # replaced in place
-            (JET, "DO.Jet", "on"),  # inherited from base
-        ]
-
-    def test_variant_appends_new_writes_after_base(self):
+    def test_v1_empty_variants_block_is_dropped_and_version_normalized(self):
+        # The corpus shape (`variants: {}` on a v1 file) loads as v2.
         profile = TriggerProfile.model_validate(
             {
+                "schema_version": 1,
                 "name": "x",
                 "states": {"SCAN": [write(DG, "Trigger.Source", "External")]},
-                "variants": {
-                    "with_jet": {"states": {"SCAN": [write(JET, "DO.Jet", "on")]}}
-                },
+                "variants": {},
             }
         )
-        writes = profile.writes_for("SCAN", variant="with_jet")
-        assert [(w.device, w.variable) for w in writes] == [
-            (DG, "Trigger.Source"),
-            (JET, "DO.Jet"),
-        ]
+        assert profile.schema_version == 2
+        assert "variants" not in profile.model_dump(mode="json")
 
-    def test_variant_leaves_untouched_states_alone(self):
+    def test_v1_populated_variant_is_refused_with_the_remedy(self):
+        with pytest.raises(ValidationError, match="own profile file"):
+            TriggerProfile.model_validate(
+                {
+                    "name": "x",
+                    "states": {"SCAN": [write(DG, "Trigger.Source", "External")]},
+                    "variants": {
+                        "laser_off": {
+                            "states": {
+                                "SCAN": [write(DG, "Trigger.Source", "Internal")]
+                            }
+                        }
+                    },
+                }
+            )
+
+    def test_v2_document_round_trips_untouched(self):
         profile = make_profile()
-        [only] = profile.writes_for("SINGLESHOT", variant="laser_off")
-        assert isinstance(only, TriggerWrite)
-        assert (only.variable, only.value) == ("Trigger.ExecuteSingleShot", "on")
-
-    def test_unknown_variant_raises(self):
-        with pytest.raises(KeyError, match="laser_on"):
-            make_profile().writes_for("SCAN", variant="laser_on")
+        assert profile.schema_version == 2
+        again = TriggerProfile.model_validate(profile.model_dump(mode="json"))
+        assert again == profile
 
     def test_defines_state_semantics(self):
         # A state with no writes is "not defined" — legacy

--- a/GEECS-Schemas/tests/test_trigger_profile.py
+++ b/GEECS-Schemas/tests/test_trigger_profile.py
@@ -90,6 +90,18 @@ class TestTriggerProfile:
                 }
             )
 
+    def test_v1_variant_without_writes_is_a_dropped_no_op(self):
+        # What the retired editor's "Add variant" saved when never filled in.
+        profile = TriggerProfile.model_validate(
+            {
+                "name": "x",
+                "states": {"SCAN": [write(DG, "Trigger.Source", "External")]},
+                "variants": {"no_gas": {"states": {}, "description": ""}},
+            }
+        )
+        assert profile.schema_version == 2
+        assert "variants" not in profile.model_dump(mode="json")
+
     def test_v2_document_round_trips_untouched(self):
         profile = make_profile()
         assert profile.schema_version == 2

--- a/GeecsBluesky/CHANGELOG.md
+++ b/GeecsBluesky/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to `geecs-bluesky` are documented here.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.72.0] - 2026-09-02
+
+### Changed
+
+- `trigger_writes_from_profile(profile)` lost its `variant` parameter, and
+  the plan preamble / `validate_scan_request` no longer read
+  `capture.trigger_variant` — trigger-profile variants were removed
+  (GEECS-Schemas 0.15.0: TriggerProfile v2, ScanRequest v3). One profile
+  file per operating condition, named in `trigger_profile`, is the only
+  shape; older documents lift automatically.
+
 ## [0.71.0] - 2026-09-01
 
 ### Changed

--- a/GeecsBluesky/geecs_bluesky/plans/scan_request_plan.py
+++ b/GeecsBluesky/geecs_bluesky/plans/scan_request_plan.py
@@ -600,7 +600,7 @@ def _scan_request_body(
     controller = None
     if request.capture.trigger_profile:
         profile = resolver.resolve_trigger_profile(request.capture.trigger_profile)
-        writes = trigger_writes_from_profile(profile, request.capture.trigger_variant)
+        writes = trigger_writes_from_profile(profile)
         if writes.states:
             # Constructed worker-side, unconnected; the setter reachability
             # check joins the in-plan connect stage below.

--- a/GeecsBluesky/geecs_bluesky/scan_request_runner.py
+++ b/GeecsBluesky/geecs_bluesky/scan_request_runner.py
@@ -98,7 +98,7 @@ logger = logging.getLogger(__name__)
 
 
 def _state_write_triples(
-    profile: TriggerProfile, state: "TriggerState", variant: str | None
+    profile: TriggerProfile, state: "TriggerState"
 ) -> list[tuple[str | None, str, str]]:
     """Normalize one state's writes to ``(device, variable, value)`` triples.
 
@@ -106,7 +106,7 @@ def _state_write_triples(
     multi-device ordered write lists); order is preserved exactly
     (schema-documented: writes apply top to bottom).
     """
-    writes = profile.writes_for(state, variant)
+    writes = profile.writes_for(state)
     if isinstance(writes, dict):
         device = getattr(profile, "device", None)
         return [(device, variable, value) for variable, value in writes.items()]
@@ -119,9 +119,7 @@ def _state_write_triples(
     return triples
 
 
-def trigger_writes_from_profile(
-    profile: TriggerProfile, variant: str | None = None
-) -> ShotControlWrites:
+def trigger_writes_from_profile(profile: TriggerProfile) -> ShotControlWrites:
     """Adapt a TriggerProfile into the engine's ShotControlWrites.
 
     Each state becomes the profile's **ordered** write list (possibly
@@ -132,24 +130,17 @@ def trigger_writes_from_profile(
     ----------
     profile :
         The trigger profile to adapt.
-    variant :
-        Optional profile variant overlaid first (e.g. ``"laser_off"``).
 
     Raises
     ------
     GeecsConfigurationError
-        Unknown *variant*, or the profile writes no device at all.
+        The profile writes no device at all.
     """
-    if variant is not None and variant not in profile.variants:
-        raise GeecsConfigurationError(
-            f"trigger profile {profile.name!r} has no variant {variant!r}. "
-            f"Known variants: {sorted(profile.variants)}"
-        )
     states: dict[str, list[tuple[str, str, str]]] = {}
     any_device = False
     for state in TriggerState:
         triples: list[tuple[str, str, str]] = []
-        for device, variable, value in _state_write_triples(profile, state, variant):
+        for device, variable, value in _state_write_triples(profile, state):
             if device is None:
                 raise GeecsConfigurationError(
                     f"trigger profile {profile.name!r} has a write to "
@@ -856,7 +847,7 @@ def validate_scan_request(
     products beyond the returned pair are discarded — execution re-resolves
     what it needs.  Checks, in order: experiment defaults apply, every
     action name (request-level; unknown nested ``run`` references included),
-    the trigger profile + variant, the save-set rule (a non-optimize
+    the trigger profile, the save-set rule (a non-optimize
     request needs at least one — optimize may run save-set-less because the
     optimizer's ``device_requirements`` are auto-provisioned at execution
     time, where an empty *effective* set still refuses pre-claim), every
@@ -887,7 +878,7 @@ def validate_scan_request(
     Raises
     ------
     GeecsConfigurationError
-        Unresolvable names, an unknown trigger variant, a step/noscan
+        Unresolvable names, a deviceless trigger profile, a step/noscan
         request without a save set, or a pseudo scan variable whose
         ``forward`` expression fails to compile.
     """
@@ -896,10 +887,10 @@ def validate_scan_request(
     resolve_and_validate_actions(validated.actions, resolver)
 
     if validated.capture.trigger_profile:
-        # Adapt (and discard) the writes so an unknown trigger_variant
-        # fails here, not at execution time.
+        # Adapt (and discard) the writes so a deviceless profile fails
+        # here, not at execution time.
         profile = resolver.resolve_trigger_profile(validated.capture.trigger_profile)
-        trigger_writes_from_profile(profile, validated.capture.trigger_variant)
+        trigger_writes_from_profile(profile)
 
     if not validated.capture.save_sets:
         if validated.mode is not ScanRequestMode.OPTIMIZE:

--- a/GeecsBluesky/pyproject.toml
+++ b/GeecsBluesky/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-bluesky"
-version = "0.71.0"
+version = "0.72.0"
 description = "Bluesky / ophyd-async bridge for the GEECS control system"
 authors = ["Sam Barber <sbarber@lbl.gov>"]
 readme = "README.md"

--- a/GeecsBluesky/tests/test_scan_request_runner.py
+++ b/GeecsBluesky/tests/test_scan_request_runner.py
@@ -318,16 +318,11 @@ variables:
 """
 
 NEW_TRIGGER_PROFILE = """\
-schema_version: 1
+schema_version: 2
 name: NewProfile
 states:
   SCAN:
     - {device: U_DG645_ShotControl, variable: Trigger.Source, value: External rising edges}
-variants:
-  laser_off:
-    states:
-      SCAN:
-        - {device: U_DG645_ShotControl, variable: Trigger.Source, value: Internal}
 """
 
 STRICT_TRIGGER_PROFILE = """\
@@ -582,11 +577,11 @@ def test_empty_shot_control_raises(legacy_resolver) -> None:
         legacy_resolver.resolve_trigger_profile("Empty")
 
 
-def test_new_schema_trigger_profile_with_variant(modern_resolver) -> None:
+def test_new_schema_trigger_profile_loads_directly(modern_resolver) -> None:
     profile = modern_resolver.resolve_trigger_profile("NewProfile")
-    writes = profile.writes_for("SCAN", variant="laser_off")
-    assert [(w.device, w.variable, w.value) for w in writes] == [
-        ("U_DG645_ShotControl", "Trigger.Source", "Internal")
+    assert profile.schema_version == 2
+    assert [(w.device, w.variable, w.value) for w in profile.writes_for("SCAN")] == [
+        ("U_DG645_ShotControl", "Trigger.Source", "External rising edges")
     ]
 
 
@@ -639,20 +634,6 @@ def test_trigger_adapter_preserves_state_semantics(legacy_resolver) -> None:
         expected = [(w.device, w.variable, w.value) for w in profile.writes_for(state)]
         assert writes.writes_for_state(state) == expected, state
         assert writes.defines_state(state) == profile.defines_state(state), state
-
-
-def test_trigger_adapter_applies_variant(modern_resolver) -> None:
-    profile = modern_resolver.resolve_trigger_profile("NewProfile")
-    writes = trigger_writes_from_profile(profile, "laser_off")
-    assert writes.writes_for_state("SCAN") == [
-        ("U_DG645_ShotControl", "Trigger.Source", "Internal")
-    ]
-
-
-def test_trigger_adapter_unknown_variant_raises(modern_resolver) -> None:
-    profile = modern_resolver.resolve_trigger_profile("NewProfile")
-    with pytest.raises(GeecsConfigurationError, match="laser_off"):
-        trigger_writes_from_profile(profile, "nope")
 
 
 # ---------------------------------------------------------------------------
@@ -1247,33 +1228,6 @@ def test_multi_device_writes_preserve_declared_order() -> None:
     assert writes.writes_for_state("STANDBY") == [
         ("U_PLC", "DO.Ch9", "off"),
         ("U_DG645", "Trigger.Source", "Int"),
-    ]
-
-
-def test_multi_device_span_via_variant_adapts() -> None:
-    """A variant dragging in a second device lands in the writes."""
-    profile = TriggerProfile(
-        name="variant-spans",
-        states={
-            "SCAN": [
-                {"device": "U_DG645", "variable": "Trigger.Source", "value": "Ext"},
-            ],
-        },
-        variants={
-            "jet_on": {
-                "states": {
-                    "SCAN": [
-                        {"device": "U_Jet", "variable": "Pressure", "value": "5"},
-                    ],
-                }
-            }
-        },
-    )
-    assert trigger_writes_from_profile(profile).devices == ["U_DG645"]
-    overlaid = trigger_writes_from_profile(profile, "jet_on")
-    assert overlaid.writes_for_state("SCAN") == [
-        ("U_DG645", "Trigger.Source", "Ext"),
-        ("U_Jet", "Pressure", "5"),
     ]
 
 

--- a/GeecsBluesky/tests/test_validate_scan_request.py
+++ b/GeecsBluesky/tests/test_validate_scan_request.py
@@ -163,18 +163,6 @@ def test_unknown_trigger_profile_refused() -> None:
         validate_scan_request(_request(trigger_profile="HTU"), _resolver())
 
 
-def test_unknown_trigger_variant_refused() -> None:
-    profile = TriggerProfile(
-        name="HTU",
-        states={
-            "SCAN": [{"device": "U_DG", "variable": "Trigger.Source", "value": "Ext"}]
-        },
-    )
-    request = _request(trigger_profile="HTU", trigger_variant="no-such-variant")
-    with pytest.raises(GeecsConfigurationError, match="variant"):
-        validate_scan_request(request, _resolver(trigger_profiles={"HTU": profile}))
-
-
 def test_unresolvable_step_axis_refused() -> None:
     request = _request(
         mode="step",

--- a/Planning/schema_refactor/00_overview.md
+++ b/Planning/schema_refactor/00_overview.md
@@ -110,7 +110,11 @@ This phase is worth doing regardless of Phase 2, and Phase 2 is thin only if
 this lands first.
 
 **Landed** as #734 (GEECS-Schemas 0.14.0, GeecsBluesky 0.70.0, Console 0.26.0,
-MCP 0.8.0): everything above as written. Two things settled on the way that
+MCP 0.8.0): everything above as written. **Amendment (2026-09-02):**
+`trigger_variant` was then deleted outright (ScanRequest v3, TriggerProfile v2
+— profile variants were never adopted; one profile file per operating
+condition is the shape), so `CaptureSettings` carries six fields, not seven,
+and 2b's parameter models build on that. Two things settled on the way that
 the next phase inherits:
 
 - **Versioning policy** (GEECS-Schemas `README.md`, "Versioning policy — two

--- a/docs/geecs_schemas/scan_request.schema.json
+++ b/docs/geecs_schemas/scan_request.schema.json
@@ -44,7 +44,7 @@
     },
     "CaptureSettings": {
       "additionalProperties": false,
-      "description": "How shots are taken and what gets recorded \u2014 the capture concern.\n\nEvery scan, whatever its mode, captures data the same way: a number of\nshots per step, an acquisition discipline, the save sets naming the\nrecorded devices, the telemetry and native-image-save toggles, and the\ntrigger profile driving the shot trigger.  This model groups those\nseven settings; conceptually they are three sub-groups \u2014 shot control\n(``shots_per_step`` + ``acquisition``), data logging (``save_sets`` +\n``background_telemetry`` + ``native_image_save``), and trigger\n(``trigger_profile`` + ``trigger_variant``) \u2014 kept one level flat\nhere on purpose.\n\nEvery field has a usable default, so an omitted ``capture`` block is a\nvalid one-shot strict capture with no named save sets.",
+      "description": "How shots are taken and what gets recorded \u2014 the capture concern.\n\nEvery scan, whatever its mode, captures data the same way: a number of\nshots per step, an acquisition discipline, the save sets naming the\nrecorded devices, the telemetry and native-image-save toggles, and the\ntrigger profile driving the shot trigger.  This model groups those\nsix settings; conceptually they are three sub-groups \u2014 shot control\n(``shots_per_step`` + ``acquisition``), data logging (``save_sets`` +\n``background_telemetry`` + ``native_image_save``), and the trigger\nprofile \u2014 kept one level flat here on purpose.\n\nEvery field has a usable default, so an omitted ``capture`` block is a\nvalid one-shot strict capture with no named save sets.",
       "properties": {
         "shots_per_step": {
           "default": 1,
@@ -104,19 +104,6 @@
           "default": null,
           "description": "Name of the trigger profile that drives the shot trigger. Unset means the scan does not manage the trigger.",
           "title": "Trigger Profile"
-        },
-        "trigger_variant": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "Optional variant of the trigger profile to use, e.g. 'laser_off'. Leave unset for the profile's base behaviour.",
-          "title": "Trigger Variant"
         }
       },
       "title": "CaptureSettings",
@@ -363,11 +350,11 @@
     }
   },
   "additionalProperties": false,
-  "description": "One complete scan, ready to submit: what to do, what to save, how to trigger.\n\nFill in the mode (sweep / stand still / optimize), the axis (or axes) to\nsweep, how many shots per position, and the names of the save sets,\ntrigger profile, and action plans to use.  Saving a request you like\n*is* a preset.\n\nA step scan may sweep **one axis or several**.  With several axes the\nscan visits every combination (a grid): the *first* axis in the list is\nthe outermost, slowest-changing loop and the *last* axis is the\ninnermost, fastest-changing one.  ``shots_per_step`` shots are taken at\neach grid point, and each grid point is one bin in the scan data.\n\nNotes\n-----\nName-valued fields (``capture.save_sets``, ``capture.trigger_profile``,\nentries in ``actions``) are resolved against the experiment's config\nlibrary at submission time; this model checks shape and mode\nconsistency, not name existence.  ``capture.save_sets`` is a list \u2014 the\nengine resolves each named set and **unions** their devices into the\nrecorded device set (a device in more than one set is merged), so\noperators mix and match named diagnostic groups per scan.  A bare\nstring is accepted for the single-set case and stored as a one-element\nlist.\n\nGrid semantics are a plain outer product in list order.  Traversal\nordering options (snake/raster, per-axis direction) are deliberately not\nmodelled yet; a future ``ordering`` field on this model is the\nanticipated extension point.\n\nFormat v2 moved the capture-concern fields into ``capture`` and dropped\n``submission`` (see the module docstring).  The flat v1 layout \u2014 those\nfields at the top level, plus an optional ``submission`` record \u2014 is\nlifted into the v2 shape by a before-validator, so v1 documents keep\nvalidating; a declared ``schema_version`` \u2264 1 is normalized to 2 (even\non a sparse document with nothing to lift).",
+  "description": "One complete scan, ready to submit: what to do, what to save, how to trigger.\n\nFill in the mode (sweep / stand still / optimize), the axis (or axes) to\nsweep, how many shots per position, and the names of the save sets,\ntrigger profile, and action plans to use.  Saving a request you like\n*is* a preset.\n\nA step scan may sweep **one axis or several**.  With several axes the\nscan visits every combination (a grid): the *first* axis in the list is\nthe outermost, slowest-changing loop and the *last* axis is the\ninnermost, fastest-changing one.  ``shots_per_step`` shots are taken at\neach grid point, and each grid point is one bin in the scan data.\n\nNotes\n-----\nName-valued fields (``capture.save_sets``, ``capture.trigger_profile``,\nentries in ``actions``) are resolved against the experiment's config\nlibrary at submission time; this model checks shape and mode\nconsistency, not name existence.  ``capture.save_sets`` is a list \u2014 the\nengine resolves each named set and **unions** their devices into the\nrecorded device set (a device in more than one set is merged), so\noperators mix and match named diagnostic groups per scan.  A bare\nstring is accepted for the single-set case and stored as a one-element\nlist.\n\nGrid semantics are a plain outer product in list order.  Traversal\nordering options (snake/raster, per-axis direction) are deliberately not\nmodelled yet; a future ``ordering`` field on this model is the\nanticipated extension point.\n\nFormat v2 moved the capture-concern fields into ``capture`` and dropped\n``submission``; format v3 dropped ``trigger_variant`` (see the module\ndocstring).  One before-validator lifts every older layout \u2014 the flat\nv1 fields into ``capture``, a v1 ``submission`` key and an unset\n``trigger_variant`` dropped \u2014 so older documents keep validating; a\ndeclared ``schema_version`` \u2264 2 is normalized to 3 (even on a sparse\ndocument with nothing to lift).",
   "properties": {
     "schema_version": {
-      "default": 2,
-      "description": "Format version of this config file. Leave at 2 \u2014 tools update this automatically when the file format changes.",
+      "default": 3,
+      "description": "Format version of this config file. Leave at 3 \u2014 tools update this automatically when the file format changes.",
       "title": "Schema Version",
       "type": "integer"
     },

--- a/docs/geecs_schemas/schema_reference.md
+++ b/docs/geecs_schemas/schema_reference.md
@@ -14,10 +14,10 @@ One complete scan, ready to submit: what to do, what to save, how to trigger.
 
 | Field | Type | Required | Default | What it does |
 |---|---|---|---|---|
-| `schema_version` | `int` | no | 2 | Format version of this config file. Leave at 2 — tools update this automatically when the file format changes. |
+| `schema_version` | `int` | no | 3 | Format version of this config file. Leave at 3 — tools update this automatically when the file format changes. |
 | `mode` | `ScanRequestMode` | yes | — | What kind of scan: 'step' sweeps one or more axes, 'noscan' collects shots without moving anything, 'optimize' lets an algorithm pick the settings. |
 | `axes` | `list[ScanAxis]` | no | empty | For step scans: what to sweep. One entry is a simple 1-D scan; several entries form a grid visiting every combination, with the first axis as the outermost (slowest) loop and the last as the innermost (fastest). Leave empty for noscan and optimize. |
-| `capture` | `CaptureSettings` | no | CaptureSettings(shots_per_step=1, acquisition=<AcquisitionMode.STRICT: 'strict'>, save_sets=[], background_telemetry=None, native_image_save=None, trigger_profile=None, trigger_variant=None) | How shots are taken and what gets recorded: shots per step, acquisition discipline, save sets, telemetry and native-image toggles, and the trigger profile. Omit for a one-shot strict capture with no named save sets. |
+| `capture` | `CaptureSettings` | no | CaptureSettings(shots_per_step=1, acquisition=<AcquisitionMode.STRICT: 'strict'>, save_sets=[], background_telemetry=None, native_image_save=None, trigger_profile=None) | How shots are taken and what gets recorded: shots per step, acquisition discipline, save sets, telemetry and native-image toggles, and the trigger profile. Omit for a one-shot strict capture with no named save sets. |
 | `actions` | `ActionBindings` | no | ActionBindings(setup=[], per_step=[], closeout=[]) | Named action plans to run before the scan (setup), between steps (per_step), and after it (closeout). |
 | `description` | `str` | no | '' | Free-text note about this scan; it ends up in the scan's metadata and the experiment log. |
 | `background` | `bool` | no | False | Mark this scan's data as background/calibration shots so analysis can find them later. |
@@ -88,7 +88,6 @@ How shots are taken and what gets recorded — the capture concern.
 | `background_telemetry` | `bool (optional)` | no | None | Also log every other live experiment device as best-effort snapshot columns — the variables the GEECS experiment database marks for scan logging (MySQL table expt_device_variable, get='yes') — read from the gateway's always-on monitor cache: read-only and never waited on, so it cannot slow or stall the scan; dead devices are dropped with a log line, never a dialog or abort. Leave unset to inherit the experiment default; set true/false to override for this scan. |
 | `native_image_save` | `bool (optional)` | no | None | Whether capture-eligible cameras (Point Grey — the devicetypes the central PVA capture daemon owns) write their native per-shot image files during this scan. When false, those cameras' images are recorded only by the capture daemon's per-device frame stack (one HDF5 per camera per scan); all other devices — proprietary formats like the HASO, scope traces — keep their native save regardless. Leave unset to inherit the experiment default; set true/false to override for this scan (e.g. force native files back on for one scan while the capture path is being validated). Two engine behaviors to expect when false: the scan is REFUSED before a scan number is claimed if the capture daemon looks absent or is not monitoring every capture camera (fail-closed — start the daemon or drop the override), and the request is silently inert when no capture-eligible cameras resolve (DB unreachable, or none in the save set) — native saving then proceeds unchanged, with a warning in the scan log. |
 | `trigger_profile` | `str (optional)` | no | None | Name of the trigger profile that drives the shot trigger. Unset means the scan does not manage the trigger. |
-| `trigger_variant` | `str (optional)` | no | None | Optional variant of the trigger profile to use, e.g. 'laser_off'. Leave unset for the profile's base behaviour. |
 
 ### ActionBindings
 
@@ -261,10 +260,9 @@ The device writes that drive the machine through its trigger states.
 
 | Field | Type | Required | Default | What it does |
 |---|---|---|---|---|
-| `schema_version` | `int` | no | 1 | Format version of this config file. Leave at 1 — tools update this automatically when the file format changes. |
+| `schema_version` | `int` | no | 2 | Format version of this config file. Leave at 2 — tools update this automatically when the file format changes. |
 | `name` | `str` | yes | — | The name scans use to refer to this trigger profile. |
 | `states` | `dict[TriggerState, list[TriggerWrite]]` | no | empty | For each trigger state, the writes that put the machine into it, applied in order from top to bottom. A transition may write several devices. Omit a device variable from a state to leave it untouched. |
-| `variants` | `dict[str, TriggerVariant]` | no | empty | Named alternative operating conditions (e.g. 'laser_off'), each listing only the writes that differ from the base states. |
 | `description` | `str` | no | '' | Optional note about what setup this profile is for. |
 
 Example:
@@ -295,18 +293,6 @@ states:
   SINGLESHOT:
     - {device: U_DG645_ShotControl, variable: Trigger.ExecuteSingleShot,
        value: "on"}
-variants:
-  laser_off:
-    states:
-      OFF:
-        - {device: U_DG645_ShotControl, variable: Trigger.Source,
-           value: Single shot}
-      SCAN:
-        - {device: U_DG645_ShotControl, variable: Trigger.Source,
-           value: Internal}
-      ARMED:
-        - {device: U_DG645_ShotControl, variable: Trigger.Source,
-           value: Single shot}
 ```
 
 ### TriggerWrite
@@ -318,15 +304,6 @@ One device variable set during a state transition.
 | `device` | `str` | yes | — | The device to write to, e.g. 'U_DG645_ShotControl' or a gas-jet controller — any settable device can take part in a transition. |
 | `variable` | `str` | yes | — | Which variable on the device to set, e.g. 'Trigger.Source'. |
 | `value` | `str` | yes | — | The value to send, exactly as the device expects it — a number as text ('4.0'), a word ('on'), or a device option name ('External rising edges'). |
-
-### TriggerVariant
-
-A named operating condition that tweaks a few writes of the profile.
-
-| Field | Type | Required | Default | What it does |
-|---|---|---|---|---|
-| `states` | `dict[TriggerState, list[TriggerWrite]]` | yes | — | Only the writes that differ from the base profile, per state. A write here replaces the base write to the same device variable; writes to new device variables are added after the base ones. Anything not listed keeps its base value. |
-| `description` | `str` | no | '' | Optional note about when to use this variant. |
 
 ## `action_plan`
 

--- a/docs/geecs_schemas/schema_reference.md
+++ b/docs/geecs_schemas/schema_reference.md
@@ -26,7 +26,7 @@ One complete scan, ready to submit: what to do, what to save, how to trigger.
 Example:
 
 ```yaml
-schema_version: 2
+schema_version: 3
 mode: step
 axes:
   - variable: jet_z
@@ -268,7 +268,7 @@ The device writes that drive the machine through its trigger states.
 Example:
 
 ```yaml
-schema_version: 1
+schema_version: 2
 name: htu_shot_control
 # each state lists its writes IN ORDER (top to bottom); a transition may
 # touch several devices

--- a/docs/geecs_schemas/schemas_overview.md
+++ b/docs/geecs_schemas/schemas_overview.md
@@ -42,10 +42,9 @@ probe stage, for example).
 The machine's trigger states — OFF, STANDBY, SCAN, SINGLESHOT, ARMED — and,
 for each one, the exact device writes that put the machine there, in the
 order they are sent. A transition can touch several devices (the delay
-generator, a gas-jet controller, a shutter), not just one. Alternative
-conditions that used to be copy-pasted files — laser on vs laser off — are
-now *variants* inside one profile, so the difference is explicit and
-reviewable.
+generator, a gas-jet controller, a shutter), not just one. Each operating
+condition — laser on, laser off, no gas — is its own profile file, and a
+scan names the one it wants.
 
 **Action plans — "what happens automatically around the scan?"**
 Named checklists of steps — set a variable, wait, check a readback, run


### PR DESCRIPTION
Follows #734/#755; the pre-2b cleanup Sam asked for. One concern across three packages: the trigger variant goes away.

## What

The schemas had two ways to say "this operating condition": a separate trigger-profile file, or a named *variant* overlaid inside one profile (`TriggerProfile.variants` + `CaptureSettings.trigger_variant`). Nobody adopted variants — every experiment kept one file per condition (`HTU-Normal`, `HTU-LaserOFF`, `HTU-NoGas`); the only corpus file with a `variants` key has it empty. So the variant cost a field on every scan form, a console combo, a validator, an adapter parameter, and a whole editor layer, for nothing. Deleted end to end:

- **GEECS-Schemas 0.15.0** — `TriggerVariant`, `TriggerProfile.variants`, the `variant=` parameter on `writes_for`/`defines_state`, `convert.merge_trigger_variant`, `CaptureSettings.trigger_variant` + its needs-a-profile validator. Per the README versioning policy a removed field is a migration: **TriggerProfile v2** (before-validator drops an empty v1 `variants` block, refuses a populated one with the remedy, normalizes `schema_version` ≤ 1 → 2) and **ScanRequest v3** (the existing lifting validator also drops an unset `trigger_variant` — flat v1 or inside `capture` — refuses a set one, normalizes ≤ 2 → 3). Artifact, reference page, and goldens regenerated.
- **GeecsBluesky 0.72.0** — `trigger_writes_from_profile(profile)` loses the parameter; the plan preamble and `validate_scan_request` stop reading it.
- **GEECS-Console 0.27.0** — the R1 variant combo (+ `.ui`), `ConsoleFormState.trigger_variant`, `ConsoleConfigs.trigger_variants`, the tooltip, and the shot-control editor's variant layer (layer combo, Add/Remove variant, per-layer description, `BASE_LAYER`, the layer handlers). The editor edits one profile: description + state write tree. This is the "console gets simpler" acceptance test the schema refactor set for itself.
- Planning doc: one amendment line (CaptureSettings is six fields; 2b builds on that).

**Corpus check:** both real files that carry the old keys lift cleanly — `HTU-test.yaml` (`variants: {}`) → TriggerProfile v2 with no `variants`; the July preset `basic test.yaml` (`trigger_variant: null`) → ScanRequest v3.

## Per-concern LOC

| Commit | Files | +/− |
|---|---|---|
| GEECS-Schemas (schema, converter, docgen, tests, goldens, artifact, reference, README, overview) | 19 | +273 / −410 |
| GeecsBluesky (adapter, plan call site, tests) | 6 | +28 / −84 |
| GEECS-Console (builder, main window + `.ui`, services, editor + `.ui`, tests) + planning note | 17 | +50 / −354 |

## Tests

- GEECS-Schemas: **273 passed** (6 integration-marked deselected), run the CI way from the repo root
- GeecsBluesky: trigger-touching suites (runner, validate, plan, listings) **143 passed, 1 skipped**
- GEECS-Console: **783 passed** (full suite, offscreen)
- GEECS-MCP / Data-Utils / DataPortal: no references, untouched (grep-verified)

## Compatibility

Old documents → new code: fine forever (both lifting validators). New documents → old code: a v3 request with no `trigger_variant` key validates on an old worker too (the field was optional), so **no deploy-order edge**; a v2 TriggerProfile likewise loads on an old reader. Console and worker can upgrade in either order.

## Hardware verification

Not owed: no scan-execution semantics change (the only production trigger path is "profile named → its writes", untouched). One console noscan after deploy is a nice-to-have, not a gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N6sdn4meUHi3R1qD9yC4Hf
