### PR TITLE
Planning: analysis runs from the portal (04) — direct ScanAnalysis execution, rendered-view toggle, charter amendment

### DIFF
--- a/Planning/data_portal/04_analysis_run_design.md
+++ b/Planning/data_portal/04_analysis_run_design.md
@@ -21,8 +21,8 @@ extend / new).*
    "no worry about multiple runners", and the queue + live runner
    "deserve a complete audit" (the file-based protocol was a
    placeholder for a proper service + queue, to be designed later).
-   **→ OPEN, escalated to the owner after review** — see "The runner
-   decision" below. Nothing else in this document depends on it.
+   **Re-affirmed after review (same day)** with the MCP runner on the
+   table — see "The runner decision" below.
 3. **No Google Doc uploads** from the portal.
 4. **s-file collisions: warn and overwrite** — ScanAnalysis's existing
    protocol (`ScanAnalyzer.append_to_sfile`, "columns already exist in
@@ -168,10 +168,10 @@ the design, not to relitigate the rulings:
   deployment, where MCP's `analysis-run` extra already installs the
   same closure.
 
-## The runner decision (OPEN — owner)
+## The runner decision (RULED 2026-09-01: A)
 
-Two runners on one host for one scan is now the actual situation, not
-a hypothetical. The choice:
+Two runners on one host for one scan is the actual situation, not a
+hypothetical. The options put to the owner:
 
 - **A. Portal-private (the 2026-09-01 ruling as spoken).** A thread
   calls `build → run_analysis → cleanup`; the job record (state,
@@ -199,32 +199,43 @@ a hypothetical. The choice:
   double-run, keeps MCP blind to portal runs and keeps the private
   record. Half of B for most of B's coupling.
 
-Recommendation: **B**, with the shared builder moved into ScanAnalysis
-(a small placement PR MCP adopts too), because it reuses the most,
-honours the owner's own 08-24 contract, and makes the eventual queue
-replacement a one-seam migration. The 09-01 "just run it" instinct
-was about not *building* queue machinery — under B none is built,
-only called. The rest of this document is written for B; the deltas
-for A are noted inline.
+The agent recommended B (most reuse, honours the 08-24 contract, one
+seam to migrate at the queue audit). **The owner ruled A**: "geecs-mcp
+is fairly experimental. We probably over-specified this on 8/24.
+Someday we might try to use MCP to run scan analysis, but I don't know
+when. We will use the 'just run it' option in the data portal close to
+day 1." So: the portal is the day-1 consumer, the status-file contract
+is not extended to it, and the MCP runner's coordination is a future
+concern to revisit when MCP runs are real. Consequences accepted with
+the ruling: no coordination between portal and MCP runs on the same
+scan; MCP's `get_scan_analysis` does not see portal runs; portal
+records live in memory. The shared-builder placement finding is waived
+for now (MCP experimental; the portal's factory is two calls) — it
+becomes real the day MCP's runner is adopted. The write stance
+(read-write mount at promotion, unauthenticated run verb on the lab
+network, regenerable outputs) was accepted in the same ruling.
 
 ## The run model
 
 - **Endpoints.** `GET /api/run/{uid}/analysis` lists the loadable
-  diagnostics with applicability, the status record from disk (B) or
-  memory (A), and the files under each one's output directory.
+  diagnostics with applicability, the in-memory job record, and the
+  files under each one's output directory (so a page loaded after a
+  portal restart still shows what an earlier run produced).
   `POST /api/run/{uid}/analysis?analyzer=<id>` starts a run — 202 with
   the record; 404 when the feature is off or the extra missing (the
   existing ladder), the diagnostic unknown, or the folder unresolvable;
-  409 when a claim is active for that task (B) / a job is running for
-  the scan (A). `GET /run/{uid}/artifact?path=…` serves one file from
+  409 when a job is already running for the scan (one per scan). `GET /run/{uid}/artifact?path=…` serves one file from
   the scan's analysis folder — the portal has no generic file endpoint
   (images are decoded and re-encoded), so this one carries its own
   containment check: the resolved path must stay inside the resolved
   analysis folder (MCP's `_gather_figure_candidates` is the precedent).
 - **Execution.** One worker thread (pyplot serialisation, above);
   build + run happen on it, so config and instantiation failures land
-  in the record as `failed`, never as a 500. `cleanup()` in `finally`
-  (B: `run_worklist` does it).
+  in the record as `failed`, never as a 500. `cleanup()` in `finally`.
+  `run_analysis` returning `None` and `DataUnavailableWarning` both
+  map to `no_data` (the worklist runner's own mapping). The record
+  keeps the run's log lines, captured from the root logger filtered
+  by the worker thread's id.
 - **Applicability.** `scan.device or diag.name` among the scan's
   device folders. Every loadable diagnostic is listed; the tab
   collapses the inapplicable ones so a device-less diagnostic is still
@@ -270,17 +281,15 @@ no-auth stance is restated with the run verb in view.
 ## Wave plan → PRs (each into `feat/analysis-tab`, /land ritual)
 
 1. **`portal/analysis-run-design`** — this document.
-2. **`scan-analysis/build-analyzers`** (B) — move MCP's
-   `build_analyzers` into `scan_analysis.config`; MCP imports it.
-3. **`portal/analysis-run-backend`** — the endpoints, worker thread,
-   artifact serving, Agg pin; ScanAnalysis added to the `analysis`
-   extra; charter amendments (CLAUDE.md, scope doc, DEPLOYMENT.md,
-   root dependency graph). Tests against a fake analyzer (no share, no
-   hardware); under B, status files in a `tmp_path` scan folder.
-4. **`portal/analysis-tab`** — the tab: listing, run, poll, artifacts,
+2. **`portal/analysis-run-backend`** — the endpoints, worker thread,
+   job record, artifact serving, Agg pin; ScanAnalysis added to the
+   `analysis` extra; charter amendments (CLAUDE.md, scope doc,
+   DEPLOYMENT.md, root dependency graph). Tests against a fake
+   analyzer (no share, no hardware).
+3. **`portal/analysis-tab`** — the tab: listing, run, poll, artifacts,
    errors.
-5. **`portal/rendered-view`** — the seam + the third display mode.
-6. **Promotion PR → master** (maintainer merges), then deploy (extra +
+4. **`portal/rendered-view`** — the seam + the third display mode.
+5. **Promotion PR → master** (maintainer merges), then deploy (extra +
    read-write mount) and the live check below.
 
 ## Hardware / live verification (owed at promotion)
@@ -290,15 +299,16 @@ its figures render in the Analysis tab; the Plot tab shows the new
 `"sfile"`-provenance columns; re-run overwrites (warn logged, no
 duplicate columns, spot-check a cell); a deliberately broken YAML shows
 as `failed` with the exception text; a device-less diagnostic shows
-`no_data`; under B, MCP's `get_scan_analysis` sees the portal's run;
-the rendered toggle shows the analyzer's overlays on the per-shot image.
+`no_data`; the rendered toggle shows the analyzer's overlays on the
+per-shot image.
 
 ## Open questions (carried, not blocking)
 
-- Where the captured run log lives under B (the status record has
-  `error` only): a portal-memory side table, or a `log` field added to
-  the status contract (`STATUS_FIELDS` + `AnalysisStatus` in the same
-  PR, per the contract test).
+- Whether the job record should persist (a JSON sidecar in the
+  analysis folder) so a reload after a portal restart still shows the
+  last error and log. Today: files persist, records do not.
+- Portal ⇄ MCP run coordination, the day MCP's runner is adopted for
+  real (the claim gate, or the status contract — see B/C above).
 - Per-bin rendering with overlays that *do* average (projections):
   needs a per-analyzer "aggregate render" hook; not designed.
 - Where the rendered toggle's figure size / dpi live in the display

--- a/Planning/data_portal/04_analysis_run_design.md
+++ b/Planning/data_portal/04_analysis_run_design.md
@@ -1,0 +1,190 @@
+# Analysis runs from the portal — design
+
+*The design note for the `feat/analysis-tab` arc (owner discussion,
+2026-09-01). It amends the portal's read-only charter: the portal may
+now trigger a ScanAnalysis run on a scan the user is looking at, and
+serve what that run produced. Everything below is grounded in a
+code-level recon of the current implementations; statuses follow the
+`03_analysis_tabs_design.md` vocabulary (exists / extend / new).*
+
+## What the owner ruled
+
+1. **Single-shot view stays ephemeral ImageAnalysis** (exists — W2a's
+   `run_diagnostic_ephemeral`). Scan-wide views use the **real
+   ScanAnalysis pipeline**: the wrapper analyzers, their figures, their
+   s-file columns.
+2. **"Just run it."** The portal instantiates the scan analyzer and
+   calls `run_analysis` directly. It does **not** take part in the
+   file-based task queue (`scan_analysis.task_queue`): no status
+   records, no claim locks, no heartbeats, no worklist. The queue and
+   the live runner are a separate concern that "deserves a complete
+   audit" — the file-based protocol was a placeholder for a proper
+   service + queue, to be designed later. Out of scope here.
+3. **No Google Doc uploads** from the portal. (They live in the
+   worklist runner, which we bypass — nothing to switch off.)
+4. **s-file collisions: warn and overwrite** — ScanAnalysis's existing
+   protocol (`ScanAnalyzer.append_to_sfile`, "columns already exist in
+   s-file … (will overwrite)"). The owner regards s-files as
+   regenerable derived copies, not sacrosanct records: "people write to
+   sfiles constantly, delete them and regenerate."
+5. **Rendered-view toggle** on the Images tab: a third display mode
+   (raw / processed / *rendered*) that draws the analyzer's own
+   matplotlib figure (`render_image` + `render_data` overlays) as the
+   served PNG. Still static; a stop-gap for the missing
+   matplotlib-style interactivity, judged higher value per cost than a
+   plotly heatmap.
+6. **Deferred, not lost**: failure-log propagation for the ephemeral
+   Images path (the analysis run's job record subsumes it); a web
+   config editor over ScanAnalysis's `ConfigFileGUI` load/save layer
+   (its own arc); the live-runner/task-queue audit; the owner's further
+   Images-tab comments ("save other comments for later").
+
+## Recon findings that shape the plan
+
+- **`ScanAnalyzer.run_analysis` is queue-free.** It resolves paths
+  (`ScanPaths(read_mode=True)` — the read-only constructor, so the
+  scan-folder invariant holds), reads the ini, loads the s-file, runs
+  the subclass core, and returns the artifact list. Status files,
+  claim locks, heartbeats, `cleanup()` orchestration and the gdoc
+  upload all live in `task_queue.run_worklist`. Calling the analyzer
+  directly touches none of them. `cleanup()` is the caller's duty.
+- **One analyzer by ID is two existing calls**:
+  `image_analysis.config.load_diagnostic(id, config_dir=…)` (the
+  unified diagnostic YAML) → `scan_analysis.config.diagnostic_factory
+  .create_scan_analyzer(diag)`. The group loader is exactly this in a
+  loop. **No new ScanAnalysis helper is needed.**
+- **The config tree is already wired.** `--processing-configs` is
+  "the parent of `analyzers/`" — the same unified tree ScanAnalysis
+  reads (`image:` + `scan:` sections in one YAML). The Images tab's
+  selector fingerprints that tree (mtime+size) and re-validates on
+  change; `load_diagnostic` caches resolved *paths* only, never parsed
+  content. So YAML edits are live on the next run with no extra work;
+  analyzer *code* edits still need a restart. **No new flag.**
+- **Outputs land where the portal already reads.** Figures go to the
+  analysis folder (`ScanPaths.get_analysis_folder()`); columns go to
+  `analysis/s{N}.txt` via `append_to_sfile` (lock + merge on
+  Shotnumber). The Plot tab's frame is rebuilt per request by
+  `scan_frame` with the s-file unioned in under provenance `"sfile"`,
+  and union responses are already never immutable-cached (0.15.3). New
+  columns therefore appear on the next Plot-tab load with **no portal
+  change**.
+- **Nothing derived survives a request today.** The ephemeral path
+  runs the analyzer on every image request (no processed-result cache;
+  the pixel cache holds raw frames only) and discards `scalars`. That
+  is why config edits show up immediately, and also why the binned
+  view re-processes every member on each display change. Scan-wide
+  derived scalars are the ScanAnalysis path's job, not a second cache.
+- **`render_image` is the rendered-view hook.** `ImageAnalyzer
+  .render_image(result, vmin, vmax, cmap, figsize, dpi, ax)` returns a
+  matplotlib figure; subclasses (Standard, Standard1D, MagSpec) draw
+  their overlays there from `result.render_data`. The ephemeral seam
+  returns result objects only, so the portal cannot reach the renderer
+  — that is the one ImageAnalysis change in this arc. (Closes 03's
+  open question "`render_function`-style rich rendering … revisit if a
+  tab ever wants analyzer-drawn overlays" — it does.)
+- **Applicability.** A diagnostic names its device in
+  `ScanRuntimeConfig.device` (optional; the image config carries the
+  camera name otherwise). The scan page knows the devices present in
+  the scan (the rail's device list). Offer the analyzers whose device
+  is present; list the rest collapsed as "other analyzers" so a
+  device-less diagnostic is still reachable.
+- **Dependency.** ScanAnalysis depends on ImageAnalysis, Data-Utils and
+  LogMaker4GoogleDocs (optional everywhere — missing it is a silent
+  skip, and the portal never reaches the upload path anyway). Adding
+  ScanAnalysis to the portal's `analysis` extra pulls PyQt5 only on
+  win32 (marker-gated) and watchdog/h5py/requests generally —
+  acceptable for the worker-host deployment.
+
+## The run model (new)
+
+- **Endpoint** `POST /api/run/{uid}/analysis?analyzer=<id>` starts a
+  job; `GET /api/run/{uid}/analysis` lists the applicable analyzers
+  with each one's job state. Both 404 when `--processing-configs` is
+  unset or the `analysis` extra is missing (the existing ladder).
+- **Job record**: portal-private, in-memory, keyed `(uid, analyzer_id)`
+  — `state` (running / done / failed), `started`, `finished`,
+  `artifacts` (paths returned by `run_analysis`, relative to the
+  analysis folder), `error` (exception text), `log` (the logging
+  records emitted during the run, captured by a handler attached for
+  the job's duration). Lost on restart; the outputs on disk are the
+  durable part, and a fresh page load lists artifacts from disk.
+- **Execution**: a bounded background thread (one worker); **one job
+  per scan at a time** — a second POST while one is running returns
+  409 with the running job. The thread runs `run_analysis`, then
+  `cleanup()` in `finally`. Analyzer exceptions become `failed` +
+  text, never a 500.
+- **Serving artifacts**: a new `GET /run/{uid}/artifact?path=…`
+  serves a file from the scan's analysis folder. The portal has no
+  generic file-serving endpoint today (images are decoded and
+  re-encoded as PNG), so this one carries its own containment check:
+  the resolved path must stay inside the analysis folder (the
+  device-name allowlist in `resources.load_shot_array` is the
+  precedent for refusing traversal at the boundary).
+- **Re-run** is the same POST; on disk it overwrites (figures by name,
+  columns per the warn-and-overwrite protocol).
+
+## The Analysis tab (new)
+
+The scan page grows an **Analysis** tab: the applicable analyzers,
+each with state, a run / re-run button, error text + captured log when
+failed, and the artifacts rendered inline when done (images inline,
+other files as links). The page polls the list endpoint while any job
+is running. The Plot tab needs nothing (see recon).
+
+## The rendered-view toggle (extend)
+
+- ImageAnalysis: the ephemeral seam gains a way to render — either
+  `run_diagnostic_ephemeral(…, render=True)` returning figures
+  alongside results, or a sibling `render_diagnostic_ephemeral`. Same
+  write-free contract and denylist. Decide at build time; keep one
+  analyzer instantiation per batch.
+- Portal: `display.mode = "rendered"` on the image endpoints; the PNG
+  is the matplotlib figure (Agg backend, `dpi` from the display
+  state). Per-bin view renders the *averaged processed image* through
+  the base renderer with per-shot overlays dropped (they do not
+  average meaningfully).
+
+## Charter amendment
+
+`GEECS-DataPortal/CLAUDE.md`'s "Read-only by doctrine" becomes
+"Read-only, **except explicit analysis runs**": the portal never
+creates anything under `scans/ScanNNN/` (invariant unchanged — the
+analyzer's own `ScanPaths(read_mode=True)` enforces it), and its only
+writes are what a ScanAnalysis run writes on the user's click: figures
+in the analysis folder and s-file columns. No annotations, no config
+writes (the config editor arc will revisit that line again).
+`01_data_portal_scope.md`'s read-only line gets the same footnote in
+the PR that lands the run backend.
+
+## Wave plan → PRs (each into `feat/analysis-tab`, /land ritual)
+
+1. **`portal/analysis-run-design`** — this document.
+2. **`portal/analysis-run-backend`** — the run endpoints, job record,
+   worker thread, log capture, artifact serving; ScanAnalysis added to
+   the `analysis` extra; charter amendment in CLAUDE.md + scope doc.
+   Tests against a fake analyzer (no share, no hardware).
+3. **`portal/analysis-tab`** — the tab: listing, run, poll, artifacts,
+   errors.
+4. **`portal/rendered-view`** — the ImageAnalysis seam extension + the
+   third display mode (one concern, two packages, one PR).
+5. **Promotion PR → master** (maintainer merges), then deploy to the
+   worker-host portal checkout and the live check below.
+
+## Hardware / live verification (owed at promotion)
+
+From a browser against a real completed scan: run one 2D analyzer →
+its figures render in the Analysis tab; the Plot tab shows the new
+`"sfile"`-provenance columns; re-run overwrites cleanly (warn logged,
+no duplicate columns); a deliberately broken YAML shows as `failed`
+with the exception text and log; the rendered toggle shows the
+analyzer's overlays on the per-shot image.
+
+## Open questions (carried, not blocking)
+
+- Whether the job record should persist (e.g. a JSON sidecar in the
+  analysis folder) so a page reload after a portal restart still shows
+  the last error. Today: artifacts persist, errors do not.
+- Per-bin rendering with overlays that *do* average (projections):
+  needs a per-analyzer "aggregate render" hook; not designed.
+- Where the rendered toggle's figure size / dpi live in the display
+  state vocabulary (`analysis.py::_DISPLAY_FIELDS`).

--- a/Planning/data_portal/04_analysis_run_design.md
+++ b/Planning/data_portal/04_analysis_run_design.md
@@ -1,27 +1,29 @@
 # Analysis runs from the portal — design
 
 *The design note for the `feat/analysis-tab` arc (owner discussion,
-2026-09-01). It amends the portal's read-only charter: the portal may
-now trigger a ScanAnalysis run on a scan the user is looking at, and
-serve what that run produced. Everything below is grounded in a
-code-level recon of the current implementations; statuses follow the
-`03_analysis_tabs_design.md` vocabulary (exists / extend / new).*
+2026-09-01; adversarial review of the first draft folded in — see
+"What the review changed"). It amends the portal's read-only charter:
+the portal may trigger a ScanAnalysis run on the scan the user is
+looking at, and serve what that run produced. Everything below is
+grounded in a code-level recon of the current implementations;
+statuses follow the `03_analysis_tabs_design.md` vocabulary (exists /
+extend / new).*
 
-## What the owner ruled
+## What the owner ruled (2026-09-01)
 
 1. **Single-shot view stays ephemeral ImageAnalysis** (exists — W2a's
    `run_diagnostic_ephemeral`). Scan-wide views use the **real
    ScanAnalysis pipeline**: the wrapper analyzers, their figures, their
    s-file columns.
 2. **"Just run it."** The portal instantiates the scan analyzer and
-   calls `run_analysis` directly. It does **not** take part in the
-   file-based task queue (`scan_analysis.task_queue`): no status
-   records, no claim locks, no heartbeats, no worklist. The queue and
-   the live runner are a separate concern that "deserves a complete
-   audit" — the file-based protocol was a placeholder for a proper
-   service + queue, to be designed later. Out of scope here.
-3. **No Google Doc uploads** from the portal. (They live in the
-   worklist runner, which we bypass — nothing to switch off.)
+   calls `run_analysis` directly, without taking part in the file-based
+   task queue (`scan_analysis.task_queue`) — the owner's stated reason:
+   "no worry about multiple runners", and the queue + live runner
+   "deserve a complete audit" (the file-based protocol was a
+   placeholder for a proper service + queue, to be designed later).
+   **→ OPEN, escalated to the owner after review** — see "The runner
+   decision" below. Nothing else in this document depends on it.
+3. **No Google Doc uploads** from the portal.
 4. **s-file collisions: warn and overwrite** — ScanAnalysis's existing
    protocol (`ScanAnalyzer.append_to_sfile`, "columns already exist in
    s-file … (will overwrite)"). The owner regards s-files as
@@ -34,156 +36,269 @@ code-level recon of the current implementations; statuses follow the
    matplotlib-style interactivity, judged higher value per cost than a
    plotly heatmap.
 6. **Deferred, not lost**: failure-log propagation for the ephemeral
-   Images path (the analysis run's job record subsumes it); a web
-   config editor over ScanAnalysis's `ConfigFileGUI` load/save layer
-   (its own arc); the live-runner/task-queue audit; the owner's further
-   Images-tab comments ("save other comments for later").
+   Images path (the run record subsumes it); a web config editor over
+   ScanAnalysis's `ConfigFileGUI` load/save layer (its own arc); the
+   live-runner/task-queue audit; the owner's further Images-tab
+   comments ("save other comments for later").
+
+## What the review changed (2026-09-01, PR #760)
+
+The adversarial review of the first draft surfaced facts the owner
+discussion did not have on the table. Recorded here because they bound
+the design, not to relitigate the rulings:
+
+- **A second on-demand runner already exists on the same host.**
+  `GEECS-MCP/geecs_mcp/analysis/run_tools.py` (`run_scan_analysis`,
+  #686, MCP 0.7.0) runs one diagnostic or group on one scan from the
+  worker host: it validates, calls `init_status_for_scan`, spawns a
+  detached `run_worker` that builds the worklist and runs it through
+  `run_worklist` (claims, heartbeats, `done`/`failed`/`no_data`
+  narration into `analysis_status/`, gdoc hard-off), and its read
+  tools poll those files and serve figures with an analysis-folder
+  containment check. That was built on the owner's **2026-08-24
+  decision** that ScanAnalysis-as-is is the backend and the
+  `analysis_status/` YAMLs are the backend-neutral progress contract
+  every runner reports into (`GEECS-MCP/CLAUDE.md`,
+  `ScanAnalysis/CLAUDE.md` "analysis status contract"). Its shared
+  builder is `run_worker.build_analyzers` (= `load_diagnostic` +
+  `create_scan_analyzer`, exactly the two calls below).
+- **Runs write inside `scans/ScanNNN/` too.** The scan pipeline passes
+  `auxiliary_data["file_path"]` (the gate the ephemeral seam refuses),
+  so MagSpec / LineStitcher / HASO / Grenouille write their derived
+  per-shot outputs into `<scan_dir>/<output_name>-interp/`-style
+  subfolders (`ImageAnalysis/CLAUDE.md` "Filesystem invariants for
+  analyzers that write inside `scans/ScanNNN/`"). The scan folder
+  itself is never created (`ScanPaths(read_mode=True)`) — the
+  invariant holds — but "the portal's only writes are the analysis
+  folder and the s-file" was false. A run writes wherever ScanAnalysis
+  writes.
+- **The deployed share is documented read-only.** `DEPLOYMENT.md`
+  ("mount the share read-only") and `01_data_portal_scope.md` ruling 2
+  both prescribe a read-only mount. Analysis runs need a **read-write
+  mount on the portal host**, or every run fails — or worse, partially
+  succeeds: MagSpec's writer logs "Failed to save calibrated outputs"
+  and continues, so a run over a read-only share can finish `done`
+  with silently missing outputs. Deployment step, owed at promotion.
+- **Read-only was the no-auth argument.** Scope ruling 2: read-only
+  "is what makes 'anyone on the network' safe with no auth story". A
+  run verb is an unauthenticated POST that overwrites s-file columns
+  and writes into the share, reachable from any lab-network browser
+  and through the OSPREY reverse-proxy mount. Flagged for the owner;
+  the working assumption (same standing as the MCP verb, which is
+  likewise unauthenticated on the lab network) is that this is
+  accepted — the outputs are regenerable and the share is internal.
+- **Skips are a state.** `run_analysis` returns `None` (a warning, not
+  an error) when the s-file / ini is missing or the scan parameter is
+  absent, and the wrapper raises `DataUnavailableWarning` when the
+  device folder is missing or empty — `run_worklist` maps that to
+  `no_data`. A running / done / failed vocabulary would turn a missing
+  s-file into `done` with zero artifacts and a device-less click into
+  `failed`. The record vocabulary is **queued / running / done /
+  failed / no_data**, matching the status contract either way.
+- **pyplot on the portal's threads.** ScanAnalysis's renderers and
+  `StandardAnalyzer.render_image` (via `base_render_image`) use
+  `plt.subplots`; the portal rule is "`Figure`, never pyplot" because
+  pyplot's global registry is not thread-safe. Two consequences: the
+  process pins `matplotlib.use("Agg")` before any ScanAnalysis import
+  (in `__main__`), and pyplot users are serialised — one analysis
+  worker thread, and the rendered view either goes through a
+  `Figure`-object renderer or takes the same lock.
+- **Factual fixes.** `render_image` is a `@staticmethod` on
+  `StandardAnalyzer` (overridden by Beam / MagSpec / stitcher /
+  HiResMagCam) and an instance method on `Standard1DAnalyzer`, not a
+  base-class hook; the class is reachable from
+  `diag.image_analyzer.class_path`, so reaching the renderer from the
+  portal is a *choice* of seam, not a necessity. Applicability is
+  `scan.device or diag.name` present among the scan's device folders
+  (`data_device_name or device_name` in the wrapper; the image config's
+  camera name is not consulted). `load_diagnostic` caches nothing —
+  its discovery rglobs the tree per call; the mtime+size fingerprint
+  is the portal's own selector cache. `_merge_auxiliary_data` uses
+  `combine_first`, so a re-run that yields NaN for a shot keeps the
+  old value — "re-run overwrites cleanly" must be checked per cell.
+  Root `CLAUDE.md`'s dependency graph must gain ScanAnalysis for the
+  portal; `DEPLOYMENT.md` must name the extra; ScanAnalysis's pyproject
+  makes LogMaker4GoogleDocs a hard install dep (optional at runtime
+  only), so the install closure pulls the Google libs.
 
 ## Recon findings that shape the plan
 
 - **`ScanAnalyzer.run_analysis` is queue-free.** It resolves paths
-  (`ScanPaths(read_mode=True)` — the read-only constructor, so the
-  scan-folder invariant holds), reads the ini, loads the s-file, runs
+  (`ScanPaths(read_mode=True)`), reads the ini, loads the s-file, runs
   the subclass core, and returns the artifact list. Status files,
   claim locks, heartbeats, `cleanup()` orchestration and the gdoc
-  upload all live in `task_queue.run_worklist`. Calling the analyzer
-  directly touches none of them. `cleanup()` is the caller's duty.
+  upload all live in `task_queue.run_worklist`. `cleanup()` is the
+  caller's duty when calling it directly.
 - **One analyzer by ID is two existing calls**:
-  `image_analysis.config.load_diagnostic(id, config_dir=…)` (the
-  unified diagnostic YAML) → `scan_analysis.config.diagnostic_factory
-  .create_scan_analyzer(diag)`. The group loader is exactly this in a
-  loop. **No new ScanAnalysis helper is needed.**
+  `image_analysis.config.load_diagnostic(id, config_dir=…)` →
+  `scan_analysis.config.create_scan_analyzer(diag)`. MCP's
+  `run_worker.build_analyzers` is this plus the group form. **Two
+  clients now want it: it belongs in ScanAnalysis next to
+  `create_scan_analyzer`** (a `build_analyzers(analyzer | group,
+  config_dir)` helper both import), not copied a third time.
 - **The config tree is already wired.** `--processing-configs` is
   "the parent of `analyzers/`" — the same unified tree ScanAnalysis
-  reads (`image:` + `scan:` sections in one YAML). The Images tab's
-  selector fingerprints that tree (mtime+size) and re-validates on
-  change; `load_diagnostic` caches resolved *paths* only, never parsed
-  content. So YAML edits are live on the next run with no extra work;
-  analyzer *code* edits still need a restart. **No new flag.**
-- **Outputs land where the portal already reads.** Figures go to the
-  analysis folder (`ScanPaths.get_analysis_folder()`); columns go to
+  and MCP read (`image:` + `scan:` sections in one YAML). YAML edits
+  are live on the next run (nothing caches parsed content); analyzer
+  *code* edits need a restart. **No new flag.**
+- **Outputs land where the portal already reads.** Figures go under
+  `analysis/ScanNNN/<output_name>/<WrapperClass>/`; columns go to
   `analysis/s{N}.txt` via `append_to_sfile` (lock + merge on
   Shotnumber). The Plot tab's frame is rebuilt per request by
   `scan_frame` with the s-file unioned in under provenance `"sfile"`,
-  and union responses are already never immutable-cached (0.15.3). New
-  columns therefore appear on the next Plot-tab load with **no portal
-  change**.
+  and union responses are never immutable-cached (0.15.3). New columns
+  therefore appear on the next Plot-tab load with **no portal change**.
 - **Nothing derived survives a request today.** The ephemeral path
   runs the analyzer on every image request (no processed-result cache;
   the pixel cache holds raw frames only) and discards `scalars`. That
-  is why config edits show up immediately, and also why the binned
-  view re-processes every member on each display change. Scan-wide
-  derived scalars are the ScanAnalysis path's job, not a second cache.
-- **`render_image` is the rendered-view hook.** `ImageAnalyzer
-  .render_image(result, vmin, vmax, cmap, figsize, dpi, ax)` returns a
-  matplotlib figure; subclasses (Standard, Standard1D, MagSpec) draw
-  their overlays there from `result.render_data`. The ephemeral seam
-  returns result objects only, so the portal cannot reach the renderer
-  — that is the one ImageAnalysis change in this arc. (Closes 03's
-  open question "`render_function`-style rich rendering … revisit if a
-  tab ever wants analyzer-drawn overlays" — it does.)
-- **Applicability.** A diagnostic names its device in
-  `ScanRuntimeConfig.device` (optional; the image config carries the
-  camera name otherwise). The scan page knows the devices present in
-  the scan (the rail's device list). Offer the analyzers whose device
-  is present; list the rest collapsed as "other analyzers" so a
-  device-less diagnostic is still reachable.
+  is why config edits show up immediately, and why the binned view
+  re-processes every member on each display change. Scan-wide derived
+  scalars are the ScanAnalysis path's job, not a second cache.
+- **Status reading is already a portal dependency.**
+  `geecs_data_utils.analysis_status.read_analysis_statuses(scan_folder)`
+  is the tolerant, read-only reader of `analysis_status/` (the #682
+  envelope MCP's read tools use); `AnalysisStatus` carries `state`,
+  `error`, `display_files`, timestamps. The portal can render run
+  state from disk with no new dependency — including runs the MCP
+  verb started, and runs from before a portal restart.
 - **Dependency.** ScanAnalysis depends on ImageAnalysis, Data-Utils and
-  LogMaker4GoogleDocs (optional everywhere — missing it is a silent
-  skip, and the portal never reaches the upload path anyway). Adding
-  ScanAnalysis to the portal's `analysis` extra pulls PyQt5 only on
-  win32 (marker-gated) and watchdog/h5py/requests generally —
-  acceptable for the worker-host deployment.
+  LogMaker4GoogleDocs. Adding it to the portal's `analysis` extra
+  pulls PyQt5 only on win32 (marker-gated), plus watchdog / h5py /
+  requests and the Google client libs — acceptable for the worker-host
+  deployment, where MCP's `analysis-run` extra already installs the
+  same closure.
 
-## The run model (new)
+## The runner decision (OPEN — owner)
 
-- **Endpoint** `POST /api/run/{uid}/analysis?analyzer=<id>` starts a
-  job; `GET /api/run/{uid}/analysis` lists the applicable analyzers
-  with each one's job state. Both 404 when `--processing-configs` is
-  unset or the `analysis` extra is missing (the existing ladder).
-- **Job record**: portal-private, in-memory, keyed `(uid, analyzer_id)`
-  — `state` (running / done / failed), `started`, `finished`,
-  `artifacts` (paths returned by `run_analysis`, relative to the
-  analysis folder), `error` (exception text), `log` (the logging
-  records emitted during the run, captured by a handler attached for
-  the job's duration). Lost on restart; the outputs on disk are the
-  durable part, and a fresh page load lists artifacts from disk.
-- **Execution**: a bounded background thread (one worker); **one job
-  per scan at a time** — a second POST while one is running returns
-  409 with the running job. The thread runs `run_analysis`, then
-  `cleanup()` in `finally`. Analyzer exceptions become `failed` +
-  text, never a 500.
-- **Serving artifacts**: a new `GET /run/{uid}/artifact?path=…`
-  serves a file from the scan's analysis folder. The portal has no
-  generic file-serving endpoint today (images are decoded and
-  re-encoded as PNG), so this one carries its own containment check:
-  the resolved path must stay inside the analysis folder (the
-  device-name allowlist in `resources.load_shot_array` is the
-  precedent for refusing traversal at the boundary).
+Two runners on one host for one scan is now the actual situation, not
+a hypothetical. The choice:
+
+- **A. Portal-private (the 2026-09-01 ruling as spoken).** A thread
+  calls `build → run_analysis → cleanup`; the job record (state,
+  artifacts, error, captured log) lives in portal memory. Simplest to
+  read; no coupling to `task_queue`. Costs: no coordination with the
+  MCP runner — an OSPREY agent's `run_scan_analysis` and a browser
+  click on the same scan write the same figure tree and HDF5
+  concurrently (only the s-file has a lock); MCP's `get_scan_analysis`
+  never sees portal runs; records vanish on restart (artifacts on disk
+  survive, errors do not).
+- **B. Share the MCP shape (the 2026-08-24 contract).** The portal
+  thread runs `init_status_for_scan` → `reset_status_for_scan` (for a
+  re-run) → `build_worklist` → `run_worklist(gdoc_enabled=False)` for
+  the one analyzer — MCP's `run_worker.main` in-process — and the tab
+  reads state from `read_analysis_statuses`. Claims coordinate the two
+  runners (a losing runner skips, never double-runs); persistence,
+  error text, `no_data` and `display_files` come free; the portal
+  becomes a second *consumer* of the seam the queue audit will replace,
+  and migrates with MCP when it does. Costs: the status protocol's
+  warts (stale-claim windows, a share write per state change) reach
+  portal users; the portal imports `task_queue`; the captured log
+  needs its own home (the status record has `error` only).
+- **C. A + the claim gate only** (`try_acquire_claim` /
+  `release_claim`): coordination without narration. Removes the
+  double-run, keeps MCP blind to portal runs and keeps the private
+  record. Half of B for most of B's coupling.
+
+Recommendation: **B**, with the shared builder moved into ScanAnalysis
+(a small placement PR MCP adopts too), because it reuses the most,
+honours the owner's own 08-24 contract, and makes the eventual queue
+replacement a one-seam migration. The 09-01 "just run it" instinct
+was about not *building* queue machinery — under B none is built,
+only called. The rest of this document is written for B; the deltas
+for A are noted inline.
+
+## The run model
+
+- **Endpoints.** `GET /api/run/{uid}/analysis` lists the loadable
+  diagnostics with applicability, the status record from disk (B) or
+  memory (A), and the files under each one's output directory.
+  `POST /api/run/{uid}/analysis?analyzer=<id>` starts a run — 202 with
+  the record; 404 when the feature is off or the extra missing (the
+  existing ladder), the diagnostic unknown, or the folder unresolvable;
+  409 when a claim is active for that task (B) / a job is running for
+  the scan (A). `GET /run/{uid}/artifact?path=…` serves one file from
+  the scan's analysis folder — the portal has no generic file endpoint
+  (images are decoded and re-encoded), so this one carries its own
+  containment check: the resolved path must stay inside the resolved
+  analysis folder (MCP's `_gather_figure_candidates` is the precedent).
+- **Execution.** One worker thread (pyplot serialisation, above);
+  build + run happen on it, so config and instantiation failures land
+  in the record as `failed`, never as a 500. `cleanup()` in `finally`
+  (B: `run_worklist` does it).
+- **Applicability.** `scan.device or diag.name` among the scan's
+  device folders. Every loadable diagnostic is listed; the tab
+  collapses the inapplicable ones so a device-less diagnostic is still
+  reachable.
 - **Re-run** is the same POST; on disk it overwrites (figures by name,
-  columns per the warn-and-overwrite protocol).
+  columns per the warn-and-overwrite protocol, subject to the
+  `combine_first` NaN caveat).
 
 ## The Analysis tab (new)
 
 The scan page grows an **Analysis** tab: the applicable analyzers,
-each with state, a run / re-run button, error text + captured log when
-failed, and the artifacts rendered inline when done (images inline,
-other files as links). The page polls the list endpoint while any job
-is running. The Plot tab needs nothing (see recon).
+each with state, a run / re-run button, error text when failed, and
+the artifacts rendered inline when done (images inline, other files as
+links). The page polls the list endpoint while any run is active. The
+Plot tab needs nothing (see recon).
 
 ## The rendered-view toggle (extend)
 
-- ImageAnalysis: the ephemeral seam gains a way to render — either
-  `run_diagnostic_ephemeral(…, render=True)` returning figures
-  alongside results, or a sibling `render_diagnostic_ephemeral`. Same
-  write-free contract and denylist. Decide at build time; keep one
-  analyzer instantiation per batch.
+- Seam: either the ephemeral seam gains a render form (results +
+  figures, one analyzer instantiation per batch, same write-free
+  contract and denylist) or the portal reaches the analyzer class's
+  `render_image` directly. Decide at build time; the pyplot constraint
+  above applies either way — prefer a `Figure`-object path.
 - Portal: `display.mode = "rendered"` on the image endpoints; the PNG
-  is the matplotlib figure (Agg backend, `dpi` from the display
-  state). Per-bin view renders the *averaged processed image* through
-  the base renderer with per-shot overlays dropped (they do not
-  average meaningfully).
+  is the rendered figure. Per-bin view renders the *averaged processed
+  image* through the base renderer with per-shot overlays dropped
+  (they do not average meaningfully).
 
 ## Charter amendment
 
 `GEECS-DataPortal/CLAUDE.md`'s "Read-only by doctrine" becomes
 "Read-only, **except explicit analysis runs**": the portal never
-creates anything under `scans/ScanNNN/` (invariant unchanged — the
-analyzer's own `ScanPaths(read_mode=True)` enforces it), and its only
-writes are what a ScanAnalysis run writes on the user's click: figures
-in the analysis folder and s-file columns. No annotations, no config
-writes (the config editor arc will revisit that line again).
-`01_data_portal_scope.md`'s read-only line gets the same footnote in
-the PR that lands the run backend.
+creates `scans/ScanNNN/` (invariant unchanged), and its only writes are
+what a ScanAnalysis run writes on the user's click — figures and
+HDF5 under the analysis folder, s-file columns, and (for the analyzers
+that do so) derived subfolders inside the scan folder. No annotations,
+no config writes (the config editor arc will revisit that line).
+`01_data_portal_scope.md` ruling 2 and `DEPLOYMENT.md`'s read-only
+mount guidance get the same amendment in the PR that lands the run
+backend: the mount must be read-write where runs are enabled, and the
+no-auth stance is restated with the run verb in view.
 
 ## Wave plan → PRs (each into `feat/analysis-tab`, /land ritual)
 
 1. **`portal/analysis-run-design`** — this document.
-2. **`portal/analysis-run-backend`** — the run endpoints, job record,
-   worker thread, log capture, artifact serving; ScanAnalysis added to
-   the `analysis` extra; charter amendment in CLAUDE.md + scope doc.
-   Tests against a fake analyzer (no share, no hardware).
-3. **`portal/analysis-tab`** — the tab: listing, run, poll, artifacts,
+2. **`scan-analysis/build-analyzers`** (B) — move MCP's
+   `build_analyzers` into `scan_analysis.config`; MCP imports it.
+3. **`portal/analysis-run-backend`** — the endpoints, worker thread,
+   artifact serving, Agg pin; ScanAnalysis added to the `analysis`
+   extra; charter amendments (CLAUDE.md, scope doc, DEPLOYMENT.md,
+   root dependency graph). Tests against a fake analyzer (no share, no
+   hardware); under B, status files in a `tmp_path` scan folder.
+4. **`portal/analysis-tab`** — the tab: listing, run, poll, artifacts,
    errors.
-4. **`portal/rendered-view`** — the ImageAnalysis seam extension + the
-   third display mode (one concern, two packages, one PR).
-5. **Promotion PR → master** (maintainer merges), then deploy to the
-   worker-host portal checkout and the live check below.
+5. **`portal/rendered-view`** — the seam + the third display mode.
+6. **Promotion PR → master** (maintainer merges), then deploy (extra +
+   read-write mount) and the live check below.
 
 ## Hardware / live verification (owed at promotion)
 
 From a browser against a real completed scan: run one 2D analyzer →
 its figures render in the Analysis tab; the Plot tab shows the new
-`"sfile"`-provenance columns; re-run overwrites cleanly (warn logged,
-no duplicate columns); a deliberately broken YAML shows as `failed`
-with the exception text and log; the rendered toggle shows the
-analyzer's overlays on the per-shot image.
+`"sfile"`-provenance columns; re-run overwrites (warn logged, no
+duplicate columns, spot-check a cell); a deliberately broken YAML shows
+as `failed` with the exception text; a device-less diagnostic shows
+`no_data`; under B, MCP's `get_scan_analysis` sees the portal's run;
+the rendered toggle shows the analyzer's overlays on the per-shot image.
 
 ## Open questions (carried, not blocking)
 
-- Whether the job record should persist (e.g. a JSON sidecar in the
-  analysis folder) so a page reload after a portal restart still shows
-  the last error. Today: artifacts persist, errors do not.
+- Where the captured run log lives under B (the status record has
+  `error` only): a portal-memory side table, or a `log` field added to
+  the status contract (`STATUS_FIELDS` + `AnalysisStatus` in the same
+  PR, per the contract test).
 - Per-bin rendering with overlays that *do* average (projections):
   needs a per-analyzer "aggregate render" hook; not designed.
 - Where the rendered toggle's figure size / dpi live in the display


### PR DESCRIPTION
## What

Adds `Planning/data_portal/04_analysis_run_design.md`: the design note for the `feat/analysis-tab` arc, recording the owner discussion of 2026-09-01 and the code-level recon behind it. Planning-only — no package code, no version bumps.

## Why

The portal's Images tab runs ImageAnalysis diagnostics ephemerally per image request and discards everything but the processed frame. The owner wants scan-wide views to run the real ScanAnalysis pipeline (figures + s-file columns) from the browser. This document pins the rulings so the build PRs have a spec:

- direct `run_analysis` execution — **no task-queue participation** (status files / claim locks / live runner are a separate audit, deferred)
- no Google Doc uploads (they live in the worklist runner we bypass)
- s-file collisions = ScanAnalysis's existing warn-and-overwrite
- rendered-view toggle (analyzer `render_image`) as the interactivity stop-gap
- charter amendment: portal is read-only *except explicit analysis runs*; the scan-folder invariant is unchanged

Recon findings that removed work: one-analyzer-by-ID is already `load_diagnostic` + `create_scan_analyzer` (no ScanAnalysis helper needed); `--processing-configs` already points at the unified tree (no new flag); the Plot tab already unions the s-file per request (no Plot-tab change).

## Wave plan

1. this doc → 2. `portal/analysis-run-backend` → 3. `portal/analysis-tab` → 4. `portal/rendered-view` → 5. promotion to master (maintainer merges) + live check.

## Tests

None (docs only). Pre-commit hooks green.

## Hardware verification

N/A for this PR. The arc's owed live check is listed in the document ("Hardware / live verification (owed at promotion)").

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018K1DmUzf1ZPjM4NxX2QRX3