### PR TITLE
GEECS-DataPortal 0.16.0: analysis runs — ScanAnalysis executed directly from the portal (run/list/artifact endpoints, AnalysisRunner)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -166,10 +166,11 @@ GEECS-DataPortal     →  GEECS-Data-Utils (tiled extra — the ScanCatalog
                         seam + the shared browser helpers; a peer VIEW
                         LAYER of the console's scan browser, one web one
                         Qt — never imports the console or tiled directly)
-                        (+ ImageAnalysis, optional via the `analysis`
-                        extra — the Images tab's ephemeral-processing
-                        selector over image_analysis.ephemeral's
-                        write-free seam)
+                        (+ ImageAnalysis + ScanAnalysis, optional via the
+                        `analysis` extra — the Images tab's
+                        ephemeral-processing selector over
+                        image_analysis.ephemeral's write-free seam, and
+                        the Analysis tab's direct ScanAnalyzer runs)
 ScanAnalysis         →  GEECS-Data-Utils, ImageAnalysis, LogMaker4GoogleDocs
 GEECS-MCP            →  GeecsBluesky (qs-client + ca extras — the queue
                         client, preflight, config resolver/listings),

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,7 @@ tooling. Each subdirectory is an independent Python package with its own
 | `GeecsCAGateway/` | The caproto CA gateway serving GEECS devices as PVs (readback + `:SP`) for Phoebus/Archiver/ophyd-async, built on GEECS-Core — see its `PV_CONTRACT.md` (client API contract), `DEPLOYMENT.md`, and `DESIGN.md` |
 | `GeecsPvaGateway/` | The PVA peer of GeecsCAGateway: distributed pvAccess server on each Windows camera server, exposing that host's GEECS camera images as NTNDArray PVs (gated subscriptions, latest-wins). Images stay off the central CA gateway by design |
 | `GEECS-MCP/` | The general GEECS MCP server for AI agents (OSPREY) — domains as modules, scans first: read tools (status/history/results/config listings/validation) + control verbs (submit with cap/etiquette/acknowledge-loop, ownership-gated stop, clear_queue) over `geecs_bluesky.qs_client` + the resolver + Tiled. Osprey integrates via `profile.yml` — central HTTP (the multi-machine mode) or stdio; see its `deploy/DEPLOYMENT.md` |
-| `GEECS-DataPortal/` | Read-only scan-browsing web service (FastAPI, port 8200 on the worker host): day → scan → metadata/scalar plots in any browser, over the same `ScanCatalog` layer as the console's scan browser. Arc spec: `Planning/data_portal/` |
+| `GEECS-DataPortal/` | Scan-browsing web service (FastAPI, port 8200 on the worker host), read-only except explicit ScanAnalysis runs from its Analysis tab: day → scan → metadata/scalar plots/images in any browser, over the same `ScanCatalog` layer as the console's scan browser. Arc spec: `Planning/data_portal/` |
 | `LogMaker4GoogleDocs/` | Google Docs/Drive API wrapper for automated experiment logs |
 
 Each subpackage has its own `CLAUDE.md` with deep architectural detail.

--- a/GEECS-DataPortal/CHANGELOG.md
+++ b/GEECS-DataPortal/CHANGELOG.md
@@ -3,6 +3,41 @@
 All notable changes to this package will be documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.16.0] - 2026-09-01
+
+### Added
+
+- **Analysis runs** — the portal can now run one ScanAnalysis analyzer
+  on one scan from the browser (`Planning/data_portal/04_analysis_run_design.md`,
+  owner ruling 2026-09-01; the charter amendment "read-only except
+  explicit analysis runs"). `geecs_portal/analysis_runs.py`:
+  `AnalysisRunner` (one worker thread, one active job per scan,
+  in-memory records with `queued`/`running`/`done`/`failed`/`no_data`,
+  artifacts, error text and the run's log lines captured from the
+  worker thread only), the analyzer factory seam (default =
+  `load_diagnostic` + `create_scan_analyzer`, the same two calls the
+  group loader runs in a loop; tests inject a fake), and the artifact
+  containment helper. Endpoints: `GET /api/run/{uid}/analysis`
+  (loadable diagnostics with applicability by data device, job record,
+  files on disk under the analyzer's output dir), `POST
+  /api/run/{uid}/analysis?analyzer=` (202 / 404 ladder / 409 while a
+  job is active), `GET /run/{uid}/artifact?path=` (serves a produced
+  file, resolved path must stay inside the scan's analysis folder).
+  Deliberately NOT a task-queue participant — `run_analysis` is called
+  directly; no status records, claims, heartbeats or Google Doc
+  uploads. `cleanup()` runs on every outcome.
+- The `analysis` extra now carries ScanAnalysis alongside
+  ImageAnalysis; `__main__` pins `matplotlib.use("Agg")` before any
+  analysis import (ScanAnalysis renderers use pyplot; the single
+  worker thread serialises them).
+
+### Changed
+
+- `DEPLOYMENT.md`: the share must be mounted read-write where analysis
+  runs are enabled; the extra and the flag are named in the
+  prerequisites. Scope doc ruling 2 and the root dependency graph
+  amended to match.
+
 ## [0.15.3] - 2026-09-01
 
 ### Fixed

--- a/GEECS-DataPortal/CHANGELOG.md
+++ b/GEECS-DataPortal/CHANGELOG.md
@@ -25,7 +25,14 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   file, resolved path must stay inside the scan's analysis folder).
   Deliberately NOT a task-queue participant — `run_analysis` is called
   directly; no status records, claims, heartbeats or Google Doc
-  uploads. `cleanup()` runs on every outcome.
+  uploads. `cleanup()` runs on every outcome. Review-hardened (#763):
+  the scan tag is parsed from the resolved folder (`ScanPaths(folder=…)`),
+  never rebuilt from the start doc's time; the artifact endpoint is
+  gated with the feature, serves raster images inline and everything
+  else as `attachment` + `nosniff`; the job's final state is assigned
+  after its log/finished fields; a `BaseException` from an analyzer is
+  recorded (never a record stuck at `running`); the lifespan refuses
+  new runs at shutdown and logs an in-flight one.
 - The `analysis` extra now carries ScanAnalysis alongside
   ImageAnalysis; `__main__` pins `matplotlib.use("Agg")` before any
   analysis import (ScanAnalysis renderers use pyplot; the single

--- a/GEECS-DataPortal/CLAUDE.md
+++ b/GEECS-DataPortal/CLAUDE.md
@@ -210,10 +210,23 @@ and analyzer failures become `failed` records, never 500s;
 (`create_app(analysis_factory=…)`) is how the tests drive the whole
 ladder without ScanAnalysis; the default is `load_diagnostic` +
 `create_scan_analyzer`, needing the `analysis` extra (which since
-0.16.0 also carries ScanAnalysis).  `__main__` pins `matplotlib.use("Agg")`
-before anything imports ScanAnalysis: its renderers use pyplot, and the
-one worker thread is what serialises them — never add a second pyplot
-user on a request thread.
+0.16.0 also carries ScanAnalysis).  The factory (and `__main__`,
+earlier) pins `matplotlib.use("Agg")` before importing ScanAnalysis:
+its renderers use pyplot, and the one worker thread is what
+serialises pyplot *in this process* — never add a second pyplot user
+on a request thread.  Known and accepted: the 2D wrapper's per-shot
+stage forks a `ProcessPoolExecutor` from this thread-rich process
+(asyncio loop, request threadpool, cache warmers) — the classic
+fork-with-threads hazard, pre-existing in every embedding of
+ScanAnalysis (LiveWatch, MCP) and not fixable portal-side; the live
+check runs an analyzer *while* images are being browsed.  The scan tag
+handed to the analyzer is parsed from the resolved folder
+(`ScanPaths(folder=…)`), never rebuilt from the start doc (the
+folder's day is the claim-time day; the start doc's time is stamped
+later).  Artifacts: raster images inline, every other type an
+`attachment` with `nosniff` (the share is writable by many hands).
+Shutdown: the lifespan refuses new runs and logs an in-flight one; it
+cannot interrupt it (DEPLOYMENT.md, stop timeout).
 Template links build their queries through the one sticky-query helper
 (and the page JS mirrors the analysis state into the stepper links) so
 navigating one control never resets another; the day page's "clear"

--- a/GEECS-DataPortal/CLAUDE.md
+++ b/GEECS-DataPortal/CLAUDE.md
@@ -1,17 +1,35 @@
 # GEECS-DataPortal — Developer Context for Claude
 
-The read-only scan-browsing web service: a zero-install browser view over
-the Tiled catalog (and, from phase 4, the data share's image files) for
-anyone on the lab network.  **The scope document is the spec**:
+The scan-browsing web service — read-only except explicit analysis runs
+(0.16.0): a zero-install browser view over the Tiled catalog (and, from
+phase 4, the data share's image files) for anyone on the lab network.  **The scope document is the spec**:
 `Planning/data_portal/01_data_portal_scope.md` — read it before extending
 this package; the architecture rules below are its distillation.
 
 ## Architecture rules
 
-- **Read-only by doctrine.**  No write verbs, no analysis triggering, no
-  annotations.  Nothing on the scans path is ever created (repo
-  scan-folder invariant — see root `CLAUDE.md`); the data share, when
-  mounted for the resource viewer, is mounted read-only.
+- **Read-only, except explicit analysis runs** (charter amendment,
+  owner ruling 2026-09-01 — `Planning/data_portal/04_analysis_run_design.md`).
+  The portal itself has no write verbs: no annotations, no config
+  writes.  The one exception is `POST /api/run/{uid}/analysis`, which
+  runs ONE ScanAnalysis analyzer on ONE scan on the user's click —
+  `geecs_portal/analysis_runs.py`, calling `ScanAnalyzer.run_analysis`
+  directly on a single worker thread with an in-memory job record.
+  Deliberately **not** a participant in the file-based task queue
+  (`scan_analysis.task_queue`: no status records, claim locks,
+  heartbeats or Google Doc uploads) — "just run it"; GEECS-MCP's
+  `run_scan_analysis` is a separate, experimental runner and the two
+  do not coordinate (accepted with the ruling).  A run writes wherever
+  ScanAnalysis writes: figures/HDF5 under `analysis/ScanNNN/`, s-file
+  columns (warn-and-overwrite), and for some analyzers derived
+  subfolders inside the scan folder.  Nothing on the scans path is
+  ever *created* by this package (repo scan-folder invariant — see
+  root `CLAUDE.md`; the analyzer's own `ScanPaths(read_mode=True)`
+  holds it on the run side), and every lookup the portal makes leaves
+  the tree untouched.  The share must be mounted read-write where runs
+  are enabled (`DEPLOYMENT.md`).  The run verb is unauthenticated on
+  the lab network, same standing as the MCP verb — accepted: outputs
+  are regenerable and the share is internal.
 - **The ScanCatalog seam.**  `create_app(catalog)` takes any
   `geecs_data_utils.tiled_catalog.ScanCatalog`; this package never
   imports `tiled` directly and never talks to the catalog server except
@@ -104,6 +122,9 @@ geecs_portal/
   app.py         # create_app(catalog, default_experiment=…) — all routes
   analysis.py    # /api boundary chores: filters/bincfg/display parsing,
                  #   JSON shaping (NaN→null), "show the code" snippets
+  analysis_runs.py  # analysis runs: AnalysisRunner (one worker thread,
+                 #   one job per scan, thread-scoped log capture), the
+                 #   ScanAnalysis factory seam, artifact containment
   figures.py     # server-side Plot-tab figure authoring (plotly.py):
                  #   palette, base layout, multi-axis ladder, display
   resources.py   # (folder, device, shot) → PNG bytes / tiered refusal
@@ -113,6 +134,7 @@ geecs_portal/
 tests/
   test_app.py        # TestClient over FakeCatalog/StubCatalog (+ /api)
   test_resources.py  # tmp scan trees: gallery routes + tier ladder + union
+  test_analysis_runs.py  # the run ladder over an injected fake analyzer
 ```
 
 Routes: `/` (redirect to today) · `/day/{iso}` (run list; `?experiment=`)
@@ -167,6 +189,31 @@ portal deliberately never falls back to the global config resolution
 `analysis` extra; missing either hides the selector and 404s the
 param.  Errors map honestly: unknown diagnostic 404,
 denylisted/miswired 400, analyzer failure 400 — never a 500.
+**Analysis runs** (0.16.0, the 04 design): `GET /api/run/{uid}/analysis`
+lists every loadable diagnostic in the same `--processing-configs`
+tree with `applicable` (its data device — `scan.device`, else the
+name — has a folder in this scan), its in-memory `job` record
+(`queued`/`running`/`done`/`failed`/`no_data`, artifacts, error, the
+run's captured log lines) and `files` (what is on disk under
+`analysis/ScanNNN/<output_name>/`, so a page loaded after a portal
+restart still shows earlier outputs); `POST
+/api/run/{uid}/analysis?analyzer=<id>` starts a run (202 + record;
+feature off / extra missing / unknown diagnostic / folder unresolvable
+→ 404; a job already active for the scan → 409 with its record);
+`GET /run/{uid}/artifact?path=<relative>` serves one produced file —
+the resolved path must stay inside the scan's own analysis folder
+(`analysis_runs.contained_artifact`; symlinks resolved), else 404.
+Build + run + `cleanup()` all happen on the worker thread, so config
+and analyzer failures become `failed` records, never 500s;
+`run_analysis` returning `None` and `DataUnavailableWarning` map to
+`no_data` (the worklist runner's own mapping).  The factory seam
+(`create_app(analysis_factory=…)`) is how the tests drive the whole
+ladder without ScanAnalysis; the default is `load_diagnostic` +
+`create_scan_analyzer`, needing the `analysis` extra (which since
+0.16.0 also carries ScanAnalysis).  `__main__` pins `matplotlib.use("Agg")`
+before anything imports ScanAnalysis: its renderers use pyplot, and the
+one worker thread is what serialises them — never add a second pyplot
+user on a request thread.
 Template links build their queries through the one sticky-query helper
 (and the page JS mirrors the analysis state into the stepper links) so
 navigating one control never resets another; the day page's "clear"

--- a/GEECS-DataPortal/DEPLOYMENT.md
+++ b/GEECS-DataPortal/DEPLOYMENT.md
@@ -8,12 +8,18 @@ machine with Tiled and GEECS-MCP, so the ports read `:8000` Tiled,
 load-bearing; nothing below assumes Tiled is local. Anyone on the lab
 network browses to `http://<host>:8200/`.
 
-The portal is **read-only by doctrine** (see `CLAUDE.md`): it renders
-the Tiled catalog and reads per-shot files off the data share, and must
-never create or modify anything on the scans path. On a dedicated
-portal host, mount the share read-only; on a shared host where other
-services (the queueserver worker) legitimately write, the guarantee is
-the code path itself — pinned by the package's tree-untouched tests.
+The portal is **read-only except explicit analysis runs** (see
+`CLAUDE.md`): it renders the Tiled catalog and reads per-shot files off
+the data share, never creates anything on the scans path, and — only
+when started with `--processing-configs` and the `analysis` extra —
+runs a ScanAnalysis analyzer on a scan when a user clicks Run on the
+Analysis tab. That run writes what ScanAnalysis writes (figures under
+`analysis/ScanNNN/`, s-file columns, some analyzers' derived subfolders
+inside the scan folder), so **where analysis runs are enabled the share
+must be mounted read-write**; a read-only mount makes every run fail —
+or, for analyzers that swallow write errors, finish `done` with missing
+outputs. Without `--processing-configs` the portal never writes, and a
+read-only mount is the right choice on a dedicated viewer host.
 
 ## Prerequisites
 
@@ -23,7 +29,13 @@ the code path itself — pinned by the package's tree-untouched tests.
   (`uri`, `api_key`) and a `[Paths]` section whose
   `geecs_data_local_base_path` points at the mounted data share —
   the same file every GEECS-Plugins package reads.
-- The data share mounted at that path (e.g. `/mnt/<share>/data/`).
+- The data share mounted at that path (e.g. `/mnt/<share>/data/`) —
+  read-write if analysis runs are enabled (above).
+- For the Images tab's processing selector and the Analysis tab's
+  runs: `poetry install -E analysis` (ImageAnalysis + ScanAnalysis and
+  their closure, incl. the Google client libs ScanAnalysis lists) and
+  `--processing-configs <scan_analysis_configs tree>` on the command
+  line. Omit both for a read-only viewer.
 - Port **8200** free (`ss -tlnp | grep 8200`).
 
 ## Install

--- a/GEECS-DataPortal/DEPLOYMENT.md
+++ b/GEECS-DataPortal/DEPLOYMENT.md
@@ -21,6 +21,13 @@ or, for analyzers that swallow write errors, finish `done` with missing
 outputs. Without `--processing-configs` the portal never writes, and a
 read-only mount is the right choice on a dedicated viewer host.
 
+A run in flight cannot be interrupted: on `systemctl stop/restart` the
+portal refuses new runs, logs the in-flight one, and the process exits
+when that run finishes. systemd's default `TimeoutStopSec` (90 s)
+would then SIGKILL a long analysis mid-write (s-file merge, HDF5) — set
+`TimeoutStopSec=` in the unit to the longest analysis you expect, or
+restart between runs.
+
 ## Prerequisites
 
 - Ubuntu with **Python 3.11** and **Poetry** on the service account

--- a/GEECS-DataPortal/deploy/geecs-data-portal.service
+++ b/GEECS-DataPortal/deploy/geecs-data-portal.service
@@ -17,7 +17,7 @@
 # See DEPLOYMENT.md (one directory up).
 
 [Unit]
-Description=GEECS Data Portal (read-only scan browser)
+Description=GEECS Data Portal (scan browser; analysis runs when configured)
 # The portal reads the Tiled catalog; when Tiled runs on the same box,
 # start after it. If Tiled is remote, drop the tiled.service reference —
 # the portal degrades gracefully (pages report catalog errors) and
@@ -44,6 +44,10 @@ WorkingDirectory=/home/geecs/GEECS-Plugins-portal/GEECS-DataPortal
 ExecStart=/home/geecs/.local/bin/poetry run geecs-data-portal --experiment Undulator
 Restart=on-failure
 RestartSec=10
+# An analysis run in flight cannot be interrupted (DEPLOYMENT.md): give a
+# stop/restart long enough to let one finish instead of SIGKILLing it
+# mid-write. Raise if your longest analyzer takes longer.
+TimeoutStopSec=600
 SyslogIdentifier=geecs-data-portal
 
 [Install]

--- a/GEECS-DataPortal/geecs_portal/__main__.py
+++ b/GEECS-DataPortal/geecs_portal/__main__.py
@@ -2,8 +2,8 @@
 
 Injects the real catalog (``TiledScanCatalog.from_config()`` — the
 ``[tiled]`` section of ``~/.config/geecs_python_api/config.ini``) and
-serves with uvicorn.  The service is read-only by doctrine; see the
-package ``CLAUDE.md``.
+serves with uvicorn.  The service is read-only except explicit analysis
+runs; see the package ``CLAUDE.md``.
 """
 
 from __future__ import annotations
@@ -12,10 +12,18 @@ import argparse
 import logging
 from pathlib import Path
 
+import matplotlib
+
+# Pinned BEFORE any ScanAnalysis / ImageAnalysis import: the analysis
+# runs execute ScanAnalysis renderers (pyplot) on a worker thread, and a
+# GUI backend selected lazily on a non-main thread is a crash. The
+# portal's own figures use the Figure API and need no backend at all.
+matplotlib.use("Agg")
+
 
 def main() -> None:
     """Parse CLI arguments, build the app over the real catalog, serve."""
-    parser = argparse.ArgumentParser(description="GEECS Data Portal (read-only)")
+    parser = argparse.ArgumentParser(description="GEECS Data Portal")
     parser.add_argument("--host", default="0.0.0.0", help="bind address")
     parser.add_argument("--port", type=int, default=8200, help="HTTP port")
     parser.add_argument(

--- a/GEECS-DataPortal/geecs_portal/analysis_runs.py
+++ b/GEECS-DataPortal/geecs_portal/analysis_runs.py
@@ -1,0 +1,364 @@
+"""Analysis runs: ScanAnalysis executed directly from the portal.
+
+The run model of ``Planning/data_portal/04_analysis_run_design.md``:
+a browser click runs ONE scan analyzer on ONE scan by calling
+``ScanAnalyzer.run_analysis`` directly — no task-queue participation
+(no status records, claim locks, heartbeats or Google Doc uploads;
+those live in ``scan_analysis.task_queue.run_worklist``, which this
+module deliberately bypasses). Outputs are whatever the analyzer
+writes on its own: figures under the scan's analysis folder and
+columns in the s-file (ScanAnalysis's warn-and-overwrite protocol).
+
+Pieces:
+
+- :class:`AnalysisJob` — the portal-private, in-memory job record
+  (state / artifacts / error / captured log). Lost on restart; the
+  outputs on disk are the durable part.
+- :class:`AnalysisRunner` — one worker thread, one job per scan at a
+  time, log capture scoped to the worker thread.
+- :func:`scan_analysis_factory` — the default analyzer factory
+  (``load_diagnostic`` + ``create_scan_analyzer``, imported lazily so
+  the portal still boots without the ``analysis`` extra). The app
+  takes any factory with the same shape, which is how the tests run
+  the whole endpoint ladder against a fake analyzer.
+- :func:`analysis_folder_for` / :func:`contained_artifact` — pure
+  path helpers for serving what a run produced without ever serving
+  outside the scan's own analysis folder.
+
+Nothing here creates anything under ``scans/ScanNNN/`` (repo
+scan-folder invariant); the analyzer's own ``ScanPaths(read_mode=True)``
+enforces it on the run side.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import logging
+import threading
+import time
+from collections import deque
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from typing import Callable, Optional, Protocol
+
+logger = logging.getLogger(__name__)
+
+#: Job states — the wire vocabulary the tab renders. The same words as
+#: the task queue's status contract (queued → claimed/running →
+#: done / failed / no_data) so a reader of either recognises them.
+QUEUED = "queued"
+RUNNING = "running"
+DONE = "done"
+FAILED = "failed"
+NO_DATA = "no_data"
+ACTIVE = (QUEUED, RUNNING)
+
+
+class ScanAnalyzerLike(Protocol):
+    """The two calls a run needs — ``ScanAnalyzer``'s public run contract."""
+
+    def run_analysis(self, scan_tag: object) -> Optional[list]:
+        """Run on *scan_tag*; return notable artifact paths/labels or None."""
+
+    def cleanup(self) -> None:
+        """Release per-scan memory (the caller's duty after every run)."""
+
+
+#: ``factory(analyzer_id, config_dir) -> analyzer`` — built INSIDE the
+#: worker thread so config/instantiation failures land in the job
+#: record as ``failed`` rather than as a request error.
+AnalyzerFactory = Callable[[str, Path], ScanAnalyzerLike]
+
+
+def scan_analysis_factory(analyzer_id: str, config_dir: Path) -> ScanAnalyzerLike:
+    """Build the real ScanAnalysis analyzer for one diagnostic ID.
+
+    The single-analyzer path the group loader runs in a loop:
+    :func:`image_analysis.config.load_diagnostic` (the unified
+    diagnostic YAML under ``<config_dir>/analyzers/``) wrapped by
+    :func:`scan_analysis.config.create_scan_analyzer`.
+
+    Parameters
+    ----------
+    analyzer_id : str
+        Diagnostic ID (YAML stem, or ``namespace/stem`` when ambiguous).
+    config_dir : Path
+        The configs tree root (the parent of ``analyzers/``).
+
+    Returns
+    -------
+    ScanAnalyzerLike
+        A runnable ``Array1DScanAnalyzer`` / ``Array2DScanAnalyzer``.
+
+    Raises
+    ------
+    ImportError
+        When the ``analysis`` extra (ImageAnalysis + ScanAnalysis) is
+        not installed.
+    """
+    from image_analysis.config import load_diagnostic
+    from scan_analysis.config import create_scan_analyzer
+
+    diag = load_diagnostic(analyzer_id, config_dir=config_dir)
+    return create_scan_analyzer(diag)
+
+
+@dataclasses.dataclass
+class AnalysisJob:
+    """One analysis run's record — what the tab polls."""
+
+    uid: str
+    analyzer_id: str
+    state: str = QUEUED
+    submitted: float = dataclasses.field(default_factory=time.time)
+    started: Optional[float] = None
+    finished: Optional[float] = None
+    #: Paths returned by ``run_analysis`` — relative to the analysis
+    #: folder when they live under it (servable), verbatim otherwise
+    #: (labels, or files elsewhere: shown, never served).
+    artifacts: list[str] = dataclasses.field(default_factory=list)
+    error: Optional[str] = None
+    #: Formatted log records emitted by the run (last N lines) — what the
+    #: process's logging levels admit (the portal's ``--log-level``);
+    #: the capture never changes a logger's level.
+    log: list[str] = dataclasses.field(default_factory=list)
+
+    def to_json(self) -> dict:
+        """The JSON shape the ``/api/run/{uid}/analysis`` endpoints emit."""
+        return dataclasses.asdict(self)
+
+
+class RunInProgress(RuntimeError):
+    """A second run was requested while one is running for the scan."""
+
+    def __init__(self, job: AnalysisJob):
+        super().__init__(f"{job.analyzer_id} is running for {job.uid}")
+        self.job = job
+
+
+class _ThreadLogCapture(logging.Handler):
+    """Capture the records ONE thread emits (the worker's, not the app's)."""
+
+    def __init__(self, thread_ident: int, max_lines: int):
+        super().__init__(level=logging.DEBUG)
+        self._thread = thread_ident
+        self.lines: deque[str] = deque(maxlen=max_lines)
+        self.setFormatter(logging.Formatter("%(levelname)s %(name)s: %(message)s"))
+
+    def emit(self, record: logging.LogRecord) -> None:
+        if record.thread != self._thread:
+            return
+        try:
+            self.lines.append(self.format(record))
+        except Exception:  # noqa: BLE001 — a broken record must not kill the run
+            self.handleError(record)
+
+
+def _relativize(artifact: object, relative_to: Optional[Path]) -> str:
+    """Artifact → servable relative path when under *relative_to*, else str."""
+    if relative_to is None or not isinstance(artifact, (str, Path)):
+        return str(artifact)
+    try:
+        path = Path(artifact)
+        if not path.is_absolute():
+            return str(artifact)
+        return path.resolve().relative_to(relative_to.resolve()).as_posix()
+    except (ValueError, OSError):
+        return str(artifact)
+
+
+class AnalysisRunner:
+    """One worker thread; one job per scan at a time; records kept in memory.
+
+    Parameters
+    ----------
+    max_log_lines : int
+        How many trailing log lines each job keeps.
+    """
+
+    def __init__(self, *, max_log_lines: int = 400):
+        self._jobs: dict[tuple[str, str], AnalysisJob] = {}
+        self._lock = threading.Lock()
+        self._max_log_lines = max_log_lines
+        self._executor = ThreadPoolExecutor(
+            max_workers=1, thread_name_prefix="portal-analysis"
+        )
+
+    def job(self, uid: str, analyzer_id: str) -> Optional[AnalysisJob]:
+        """The record for (*uid*, *analyzer_id*), or None when never run."""
+        with self._lock:
+            return self._jobs.get((uid, analyzer_id))
+
+    def jobs_for(self, uid: str) -> dict[str, AnalysisJob]:
+        """All records for *uid*, keyed by analyzer id."""
+        with self._lock:
+            return {
+                analyzer_id: job
+                for (job_uid, analyzer_id), job in self._jobs.items()
+                if job_uid == uid
+            }
+
+    def running_for(self, uid: str) -> Optional[AnalysisJob]:
+        """The running job for *uid*, if any (the one-per-scan gate)."""
+        with self._lock:
+            return self._running_locked(uid)
+
+    def _running_locked(self, uid: str) -> Optional[AnalysisJob]:
+        for (job_uid, _), job in self._jobs.items():
+            if job_uid == uid and job.state in ACTIVE:
+                return job
+        return None
+
+    def start(
+        self,
+        uid: str,
+        analyzer_id: str,
+        run: Callable[[], Optional[list]],
+        *,
+        relative_to: Optional[Path] = None,
+    ) -> AnalysisJob:
+        """Submit *run* for (*uid*, *analyzer_id*); return its fresh record.
+
+        Parameters
+        ----------
+        uid : str
+            The run's catalog uid.
+        analyzer_id : str
+            The diagnostic ID (the record key with *uid*).
+        run : callable
+            Executes the analysis and returns the artifact list (the
+            factory + ``run_analysis`` + ``cleanup`` composition is the
+            caller's — see :func:`run_scan_analyzer`).
+        relative_to : Path, optional
+            The analysis folder: artifacts under it are recorded
+            relative to it so the artifact endpoint can serve them.
+
+        Raises
+        ------
+        RunInProgress
+            When a job is already running for *uid* — one per scan.
+        """
+        with self._lock:
+            running = self._running_locked(uid)
+            if running is not None:
+                raise RunInProgress(running)
+            job = AnalysisJob(uid=uid, analyzer_id=analyzer_id)
+            self._jobs[(uid, analyzer_id)] = job
+        self._executor.submit(self._execute, job, run, relative_to)
+        return job
+
+    def _execute(
+        self,
+        job: AnalysisJob,
+        run: Callable[[], Optional[list]],
+        relative_to: Optional[Path],
+    ) -> None:
+        capture = _ThreadLogCapture(threading.get_ident(), self._max_log_lines)
+        root = logging.getLogger()
+        root.addHandler(capture)
+        job.started = time.time()
+        job.state = RUNNING
+        try:
+            artifacts = run()
+            if artifacts is None:
+                # run_analysis's "inputs missing" return (no s-file / ini /
+                # scan parameter): a skip, not a success — the worklist
+                # runner's own no_data mapping.
+                job.state = NO_DATA
+                job.error = "analysis skipped: inputs missing (see log)"
+            else:
+                job.artifacts = [_relativize(a, relative_to) for a in artifacts]
+                job.state = DONE
+        except Exception as exc:  # noqa: BLE001 — every failure becomes a record
+            job.error = f"{type(exc).__name__}: {exc}"
+            job.state = NO_DATA if _is_no_data(exc) else FAILED
+            logger.log(
+                logging.INFO if job.state == NO_DATA else logging.WARNING,
+                "analysis %s on %s %s: %s",
+                job.analyzer_id,
+                job.uid,
+                job.state,
+                job.error,
+            )
+        finally:
+            root.removeHandler(capture)
+            job.log = list(capture.lines)
+            job.finished = time.time()
+
+    def shutdown(self) -> None:
+        """Stop the worker (tests; app shutdown)."""
+        self._executor.shutdown(wait=False, cancel_futures=True)
+
+
+def _is_no_data(exc: BaseException) -> bool:
+    """True for ScanAnalysis's ``DataUnavailableWarning`` (device folder missing/empty).
+
+    Matched by name so the runner module imports nothing from
+    ScanAnalysis at import time (the extra is optional).
+    """
+    return type(exc).__name__ == "DataUnavailableWarning"
+
+
+def run_scan_analyzer(
+    factory: AnalyzerFactory, analyzer_id: str, config_dir: Path, scan_tag: object
+) -> Optional[list]:
+    """Build, run and clean up one analyzer — the body of a job.
+
+    ``cleanup()`` runs whether or not ``run_analysis`` raised: it is the
+    task runner's duty in the queue path and ours here.
+    """
+    analyzer = factory(analyzer_id, config_dir)
+    try:
+        return analyzer.run_analysis(scan_tag)
+    finally:
+        analyzer.cleanup()
+
+
+def analysis_folder_for(scan_folder: Path) -> Path:
+    """``{day}/analysis/ScanNNN`` for a ``{day}/scans/ScanNNN`` folder.
+
+    Pure path construction — the same ``parts[-2] = "analysis"`` rule
+    as ``ScanPaths.get_analysis_folder`` without its create-if-missing
+    side effect (the analyzer creates it when it runs; the portal only
+    reads it).
+    """
+    return scan_folder.parents[1] / "analysis" / scan_folder.name
+
+
+def contained_artifact(analysis_folder: Path, relative: str) -> Optional[Path]:
+    """Resolve *relative* inside *analysis_folder*, or None when it escapes.
+
+    The artifact endpoint's containment check: the resolved path must
+    stay under the resolved analysis folder (symlinks included) and be
+    an existing regular file. Absolute, ``..``-climbing and dangling
+    paths all return None — never an exception.
+    """
+    if not relative or Path(relative).is_absolute():
+        return None
+    try:
+        root = analysis_folder.resolve()
+        candidate = (analysis_folder / relative).resolve()
+        candidate.relative_to(root)
+    except (ValueError, OSError):
+        return None
+    return candidate if candidate.is_file() else None
+
+
+def list_artifacts(
+    analysis_folder: Path, output_name: str, *, limit: int = 200
+) -> list[str]:
+    """Files under the analyzer's output directory, relative to the analysis folder.
+
+    ScanAnalysis writes per-analyzer outputs under
+    ``analysis/ScanNNN/<output_name>/…`` — this lists them (sorted,
+    capped) so a page loaded after a portal restart still shows what
+    an earlier run produced.
+    """
+    out_dir = analysis_folder / output_name
+    if not out_dir.is_dir():
+        return []
+    try:
+        files = sorted(p for p in out_dir.rglob("*") if p.is_file())
+    except OSError:
+        return []
+    return [p.relative_to(analysis_folder).as_posix() for p in files[:limit]]

--- a/GEECS-DataPortal/geecs_portal/analysis_runs.py
+++ b/GEECS-DataPortal/geecs_portal/analysis_runs.py
@@ -146,15 +146,23 @@ class RunInProgress(RuntimeError):
 #: Logger-name prefixes that are the portal's own traffic, never the
 #: run's: excluded from a job's captured log.
 _CAPTURE_EXCLUDE = ("geecs_portal", "uvicorn", "httpx", "httpcore", "asyncio")
+#: Thread-name prefixes that serve requests / warm caches in this
+#: process — a record from one of them during a run is a concurrent
+#: browser's (the Images tab's ephemeral path logs under
+#: ``image_analysis.*`` too), not the run's. Analyzer pool threads are
+#: ``ThreadPoolExecutor-*``; the worker itself is ``portal-analysis_*``.
+_CAPTURE_EXCLUDE_THREADS = ("AnyIO worker thread", "MainThread", "warm-", "uvicorn")
 
 
 class _RunLogCapture(logging.Handler):
     """Capture every record emitted during a run, minus the portal's own.
 
-    Jobs are serialised on one worker, so "everything in the window"
-    IS the run — including the per-shot lines the analyzers emit from
-    their own thread pools (a thread-id filter would drop those).
-    Records from process-pool children never reach this process.
+    Jobs are serialised on one worker, so the window is the run —
+    including the per-shot lines the analyzers emit from their own
+    thread pools (a worker-thread-id filter would drop those) — minus
+    what the request threads and cache warmers emit meanwhile (a
+    concurrent browser's traffic, filtered by thread name). Records
+    from process-pool children never reach this process.
     """
 
     def __init__(self, max_lines: int):
@@ -163,7 +171,9 @@ class _RunLogCapture(logging.Handler):
         self.setFormatter(logging.Formatter("%(levelname)s %(name)s: %(message)s"))
 
     def emit(self, record: logging.LogRecord) -> None:
-        if record.name.startswith(_CAPTURE_EXCLUDE):
+        if record.name.startswith(_CAPTURE_EXCLUDE) or str(
+            record.threadName
+        ).startswith(_CAPTURE_EXCLUDE_THREADS):
             return
         try:
             self.lines.append(self.format(record))

--- a/GEECS-DataPortal/geecs_portal/analysis_runs.py
+++ b/GEECS-DataPortal/geecs_portal/analysis_runs.py
@@ -96,6 +96,13 @@ def scan_analysis_factory(analyzer_id: str, config_dir: Path) -> ScanAnalyzerLik
         When the ``analysis`` extra (ImageAnalysis + ScanAnalysis) is
         not installed.
     """
+    import matplotlib
+
+    # The contract travels with the behaviour: ScanAnalysis's renderers
+    # use pyplot, and a GUI backend picked lazily on a worker thread is
+    # a crash — pin Agg (idempotent) before the import that needs it,
+    # whatever the entry point (``__main__`` pins it too, earlier).
+    matplotlib.use("Agg")
     from image_analysis.config import load_diagnostic
     from scan_analysis.config import create_scan_analyzer
 
@@ -136,17 +143,27 @@ class RunInProgress(RuntimeError):
         self.job = job
 
 
-class _ThreadLogCapture(logging.Handler):
-    """Capture the records ONE thread emits (the worker's, not the app's)."""
+#: Logger-name prefixes that are the portal's own traffic, never the
+#: run's: excluded from a job's captured log.
+_CAPTURE_EXCLUDE = ("geecs_portal", "uvicorn", "httpx", "httpcore", "asyncio")
 
-    def __init__(self, thread_ident: int, max_lines: int):
+
+class _RunLogCapture(logging.Handler):
+    """Capture every record emitted during a run, minus the portal's own.
+
+    Jobs are serialised on one worker, so "everything in the window"
+    IS the run — including the per-shot lines the analyzers emit from
+    their own thread pools (a thread-id filter would drop those).
+    Records from process-pool children never reach this process.
+    """
+
+    def __init__(self, max_lines: int):
         super().__init__(level=logging.DEBUG)
-        self._thread = thread_ident
         self.lines: deque[str] = deque(maxlen=max_lines)
         self.setFormatter(logging.Formatter("%(levelname)s %(name)s: %(message)s"))
 
     def emit(self, record: logging.LogRecord) -> None:
-        if record.thread != self._thread:
+        if record.name.startswith(_CAPTURE_EXCLUDE):
             return
         try:
             self.lines.append(self.format(record))
@@ -180,6 +197,7 @@ class AnalysisRunner:
         self._jobs: dict[tuple[str, str], AnalysisJob] = {}
         self._lock = threading.Lock()
         self._max_log_lines = max_log_lines
+        self._closed = False
         self._executor = ThreadPoolExecutor(
             max_workers=1, thread_name_prefix="portal-analysis"
         )
@@ -237,8 +255,12 @@ class AnalysisRunner:
         ------
         RunInProgress
             When a job is already running for *uid* — one per scan.
+        RuntimeError
+            After :meth:`shutdown` — the app is stopping.
         """
         with self._lock:
+            if self._closed:
+                raise RuntimeError("analysis runner is shutting down")
             running = self._running_locked(uid)
             if running is not None:
                 raise RunInProgress(running)
@@ -253,40 +275,68 @@ class AnalysisRunner:
         run: Callable[[], Optional[list]],
         relative_to: Optional[Path],
     ) -> None:
-        capture = _ThreadLogCapture(threading.get_ident(), self._max_log_lines)
+        capture = _RunLogCapture(self._max_log_lines)
         root = logging.getLogger()
         root.addHandler(capture)
         job.started = time.time()
         job.state = RUNNING
+        # The final state is assigned LAST (after log/finished/artifacts)
+        # so a poller that sees an inactive state sees a complete record.
+        final = FAILED
+        reraise: Optional[BaseException] = None
         try:
             artifacts = run()
             if artifacts is None:
                 # run_analysis's "inputs missing" return (no s-file / ini /
                 # scan parameter): a skip, not a success — the worklist
                 # runner's own no_data mapping.
-                job.state = NO_DATA
                 job.error = "analysis skipped: inputs missing (see log)"
+                final = NO_DATA
             else:
                 job.artifacts = [_relativize(a, relative_to) for a in artifacts]
-                job.state = DONE
-        except Exception as exc:  # noqa: BLE001 — every failure becomes a record
+                final = DONE
+        except BaseException as exc:  # noqa: BLE001 — every outcome becomes a record
             job.error = f"{type(exc).__name__}: {exc}"
-            job.state = NO_DATA if _is_no_data(exc) else FAILED
+            final = NO_DATA if _is_no_data(exc) else FAILED
+            if not isinstance(exc, Exception):
+                # SystemExit / KeyboardInterrupt from an analyzer: record
+                # it (never a record stuck at ``running`` → permanent 409),
+                # then let the executor see it.
+                reraise = exc
             logger.log(
-                logging.INFO if job.state == NO_DATA else logging.WARNING,
+                logging.INFO if final == NO_DATA else logging.WARNING,
                 "analysis %s on %s %s: %s",
                 job.analyzer_id,
                 job.uid,
-                job.state,
+                final,
                 job.error,
             )
         finally:
             root.removeHandler(capture)
             job.log = list(capture.lines)
             job.finished = time.time()
+            job.state = final
+        if reraise is not None:
+            raise reraise
 
     def shutdown(self) -> None:
-        """Stop the worker (tests; app shutdown)."""
+        """Refuse new jobs and stop the worker (app shutdown; tests).
+
+        A job already running cannot be interrupted — the interpreter
+        joins the worker at exit, so a service stop waits for it (see
+        ``DEPLOYMENT.md`` on the stop timeout). Logged so the operator
+        knows what the wait is.
+        """
+        with self._lock:
+            self._closed = True
+            active = [j for j in self._jobs.values() if j.state in ACTIVE]
+        for job in active:
+            logger.warning(
+                "shutdown with analysis %s on %s still %s — waiting for it",
+                job.analyzer_id,
+                job.uid,
+                job.state,
+            )
         self._executor.shutdown(wait=False, cancel_futures=True)
 
 

--- a/GEECS-DataPortal/geecs_portal/app.py
+++ b/GEECS-DataPortal/geecs_portal/app.py
@@ -25,6 +25,7 @@ Architecture rules (see this package's ``CLAUDE.md`` and
 
 from __future__ import annotations
 
+import contextlib
 import dataclasses
 import io
 import logging
@@ -59,7 +60,7 @@ from geecs_data_utils.tiled_catalog import (
     resolve_scan_folder,
 )
 
-from geecs_data_utils.type_defs import ScanTag
+from geecs_data_utils.scan_paths import ScanPaths
 
 from geecs_portal import analysis, analysis_runs, figures, resources
 from geecs_portal.cache import ShotDataCache
@@ -260,6 +261,11 @@ def _default_x(detail, columns: list[str]) -> str:
     return scan_vars[0] if scan_vars else ""
 
 
+#: Artifact types the artifact endpoint renders inline (raster only —
+#: SVG can carry script and is served as a download like everything else).
+_INLINE_IMAGE_SUFFIXES = frozenset({".png", ".jpg", ".jpeg", ".gif", ".webp"})
+
+
 @dataclasses.dataclass(frozen=True)
 class _DiagInfo:
     """A loadable diagnostic's run-side facts (the selector cache's value)."""
@@ -272,14 +278,12 @@ class _DiagInfo:
 
     @classmethod
     def from_diagnostic(cls, diag) -> "_DiagInfo":
+        # ``diag.scan`` is the raw ``scan:`` mapping at the ImageAnalysis
+        # layer (ScanRuntimeConfig lives in ScanAnalysis, which the
+        # selector must not need) — read the one key the wrapper reads.
         scan = diag.scan or {}
-        device = (
-            scan.get("device")
-            if isinstance(scan, dict)
-            else getattr(scan, "device", None)
-        )
         return cls(
-            device=str(device or diag.name),
+            device=str(scan.get("device") or diag.name),
             output_name=str(getattr(diag, "effective_output_name", None) or diag.name),
         )
 
@@ -321,7 +325,22 @@ def create_app(
     FastAPI
         The configured application.
     """
-    app = FastAPI(title="GEECS Data Portal", docs_url=None, redoc_url=None)
+    # The analysis-run worker (04 design) outlives requests: built
+    # before the app so the lifespan can refuse new runs and log any
+    # in-flight one at shutdown (a running job cannot be interrupted —
+    # the interpreter joins the worker at exit; see DEPLOYMENT.md).
+    runner = analysis_runs.AnalysisRunner()
+
+    @contextlib.asynccontextmanager
+    async def _lifespan(_app: FastAPI):
+        try:
+            yield
+        finally:
+            runner.shutdown()
+
+    app = FastAPI(
+        title="GEECS Data Portal", docs_url=None, redoc_url=None, lifespan=_lifespan
+    )
     app.add_middleware(_ForwardedPrefixMiddleware)
     # Every template gets `root`: the mount prefix each root-absolute
     # href/action/src/fetch must carry (empty when served at root).
@@ -782,7 +801,6 @@ def create_app(
         return valid
 
     # ---- analysis runs (04 design: direct ScanAnalysis execution) ----
-    runner = analysis_runs.AnalysisRunner()
     factory = analysis_factory or analysis_runs.scan_analysis_factory
 
     def _analysis_available() -> None:
@@ -804,24 +822,29 @@ def create_app(
                 ) from exc
 
     def _analysis_context(uid: str, day: str):
-        """(detail, scan folder, analysis folder, ScanTag) or 404."""
+        """(detail, scan folder, analysis folder, ScanTag) or 404.
+
+        The tag is parsed FROM THE RESOLVED FOLDER (``ScanPaths(folder=…)``,
+        read-only), never rebuilt from the start doc: the folder's day
+        is the claim-time day, the start doc's ``time`` is stamped later
+        — a scan claimed at 23:59:58 and opened at 00:00:01 would
+        otherwise run the analyzer on the NEXT day's same-numbered scan
+        (and TZ / experiment-spelling drift would do the same).
+        """
         detail = _load_run(uid)
         run_day = _run_day(detail, day)
         folder = resolve_scan_folder(detail, run_day) if run_day else None
-        if folder is None or run_day is None:
+        if folder is None:
             raise HTTPException(status_code=404, detail="scan folder not resolvable")
-        number = detail.summary.scan_number
-        if number is None or not detail.summary.experiment:
+        try:
+            tag = ScanPaths(folder=folder, read_mode=True).get_tag()
+        except (ValueError, OSError) as exc:
             raise HTTPException(
-                status_code=404, detail="run has no scan number / experiment"
-            )
-        tag = ScanTag(
-            year=run_day.year,
-            month=run_day.month,
-            day=run_day.day,
-            number=int(number),
-            experiment=detail.summary.experiment,
-        )
+                status_code=404,
+                detail=f"scan folder is not a canonical scans/ScanNNN path: {exc}",
+            ) from exc
+        if tag is None:
+            raise HTTPException(status_code=404, detail="scan folder has no tag")
         return detail, folder, analysis_runs.analysis_folder_for(folder), tag
 
     @app.get("/api/run/{uid}/analysis")
@@ -894,6 +917,8 @@ def create_app(
                 },
                 status_code=409,
             )
+        except RuntimeError as exc:  # shutting down
+            raise HTTPException(status_code=503, detail=str(exc)) from exc
         return JSONResponse(job.to_json(), status_code=202)
 
     @app.get("/run/{uid}/artifact")
@@ -902,14 +927,26 @@ def create_app(
 
         Containment is the contract (:func:`analysis_runs.contained_artifact`):
         anything that resolves outside the scan's own analysis folder is
-        a 404, same as a missing file. ``no-cache``: re-runs overwrite
-        by name.
+        a 404, same as a missing file. Same feature gate as the run
+        endpoints. Raster images render inline; every other type is a
+        download (``attachment`` + ``nosniff``) — the share is writable
+        by many hands, and a planted HTML/SVG must never execute in the
+        portal's (or, behind the OSPREY proxy, OSPREY's) origin.
+        ``no-cache``: re-runs overwrite by name.
         """
+        _analysis_available()
         _, _, analysis_folder, _ = _analysis_context(uid, day)
         file = analysis_runs.contained_artifact(analysis_folder, path)
         if file is None:
             raise HTTPException(status_code=404, detail="no such artifact")
-        return FileResponse(file, headers={"Cache-Control": "no-cache"})
+        headers = {"Cache-Control": "no-cache", "X-Content-Type-Options": "nosniff"}
+        inline = file.suffix.lower() in _INLINE_IMAGE_SUFFIXES
+        return FileResponse(
+            file,
+            headers=headers,
+            content_disposition_type="inline" if inline else "attachment",
+            filename=file.name,
+        )
 
     def _apply_processing(arrays: list, processing: str) -> list:
         """Ephemeral-process *arrays* → the analyzers' processed images.

--- a/GEECS-DataPortal/geecs_portal/app.py
+++ b/GEECS-DataPortal/geecs_portal/app.py
@@ -36,6 +36,7 @@ from urllib.parse import urlencode
 
 from fastapi import FastAPI, HTTPException, Query
 from fastapi.responses import (
+    FileResponse,
     HTMLResponse,
     JSONResponse,
     RedirectResponse,
@@ -58,7 +59,9 @@ from geecs_data_utils.tiled_catalog import (
     resolve_scan_folder,
 )
 
-from geecs_portal import analysis, figures, resources
+from geecs_data_utils.type_defs import ScanTag
+
+from geecs_portal import analysis, analysis_runs, figures, resources
 from geecs_portal.cache import ShotDataCache
 
 logger = logging.getLogger(__name__)
@@ -257,11 +260,36 @@ def _default_x(detail, columns: list[str]) -> str:
     return scan_vars[0] if scan_vars else ""
 
 
+@dataclasses.dataclass(frozen=True)
+class _DiagInfo:
+    """A loadable diagnostic's run-side facts (the selector cache's value)."""
+
+    #: The data device the wrapper reads: ``scan.device``, else the name
+    #: (``data_device_name or device_name`` in ScanAnalysis's wrapper).
+    device: str
+    #: Per-analyzer output directory under ``analysis/ScanNNN/``.
+    output_name: str
+
+    @classmethod
+    def from_diagnostic(cls, diag) -> "_DiagInfo":
+        scan = diag.scan or {}
+        device = (
+            scan.get("device")
+            if isinstance(scan, dict)
+            else getattr(scan, "device", None)
+        )
+        return cls(
+            device=str(device or diag.name),
+            output_name=str(getattr(diag, "effective_output_name", None) or diag.name),
+        )
+
+
 def create_app(
     catalog: ScanCatalog,
     *,
     default_experiment: str = "",
     processing_config_dir: Optional[Path] = None,
+    analysis_factory: Optional[analysis_runs.AnalyzerFactory] = None,
 ) -> FastAPI:
     """Build the portal application over an injected catalog.
 
@@ -280,6 +308,13 @@ def create_app(
         competing resolution paths exist, so the portal names its
         tree explicitly). The selector also hides itself when
         ImageAnalysis (the ``analysis`` extra) is not installed.
+    analysis_factory : callable, optional
+        ``(analyzer_id, config_dir) -> ScanAnalyzer`` for the analysis
+        runs (``/api/run/{uid}/analysis``, the 04 design). ``None``
+        (the default) uses the real ScanAnalysis factory, which then
+        also needs the ``analysis`` extra; tests inject a fake. The
+        feature shares ``processing_config_dir`` — the unified
+        diagnostic tree — and is OFF with it.
 
     Returns
     -------
@@ -686,7 +721,11 @@ def create_app(
     processing_cache: dict = {}
 
     def _processing_names() -> list[str]:
-        """LOADABLE diagnostic IDs for the processing selector (``[]`` = hidden).
+        """LOADABLE diagnostic IDs for the processing selector (``[]`` = hidden)."""
+        return list(_processing_infos())
+
+    def _processing_infos() -> dict[str, _DiagInfo]:
+        """LOADABLE diagnostics → their run-side facts (``{}`` = hidden).
 
         Explicit-opt-in: no configured tree, no feature (never the
         global fallback). Degrades to empty — never errors a page —
@@ -725,11 +764,11 @@ def create_app(
         except Exception as exc:  # noqa: BLE001 — unlistable tree = no selector
             logger.debug("processing configs unavailable: %s", exc)
             return []
-        valid = []
+        valid: dict[str, _DiagInfo] = {}
         for name in names:
             try:
-                load_diagnostic(name, config_dir=processing_config_dir)
-                valid.append(name)
+                diag = load_diagnostic(name, config_dir=processing_config_dir)
+                valid[name] = _DiagInfo.from_diagnostic(diag)
             except Exception as exc:  # noqa: BLE001 — one bad YAML must not hide the rest
                 logger.info(
                     "processing selector: skipping %r — not a loadable "
@@ -741,6 +780,136 @@ def create_app(
             processing_cache.clear()  # one entry: the current tree state
             processing_cache[fingerprint] = valid
         return valid
+
+    # ---- analysis runs (04 design: direct ScanAnalysis execution) ----
+    runner = analysis_runs.AnalysisRunner()
+    factory = analysis_factory or analysis_runs.scan_analysis_factory
+
+    def _analysis_available() -> None:
+        """404 unless the run feature is configured AND installed."""
+        if processing_config_dir is None:
+            raise HTTPException(
+                status_code=404,
+                detail="analysis runs are not configured on this portal "
+                "(start it with --processing-configs)",
+            )
+        if analysis_factory is None:
+            try:
+                import scan_analysis  # noqa: F401 — the real factory's need
+            except ImportError as exc:
+                raise HTTPException(
+                    status_code=404,
+                    detail="analysis runs need the portal's 'analysis' extra "
+                    "(pip install geecs-data-portal[analysis])",
+                ) from exc
+
+    def _analysis_context(uid: str, day: str):
+        """(detail, scan folder, analysis folder, ScanTag) or 404."""
+        detail = _load_run(uid)
+        run_day = _run_day(detail, day)
+        folder = resolve_scan_folder(detail, run_day) if run_day else None
+        if folder is None or run_day is None:
+            raise HTTPException(status_code=404, detail="scan folder not resolvable")
+        number = detail.summary.scan_number
+        if number is None or not detail.summary.experiment:
+            raise HTTPException(
+                status_code=404, detail="run has no scan number / experiment"
+            )
+        tag = ScanTag(
+            year=run_day.year,
+            month=run_day.month,
+            day=run_day.day,
+            number=int(number),
+            experiment=detail.summary.experiment,
+        )
+        return detail, folder, analysis_runs.analysis_folder_for(folder), tag
+
+    @app.get("/api/run/{uid}/analysis")
+    def run_analysis_list(uid: str, day: str = "") -> JSONResponse:
+        """The scan's analyzers: applicability, job record, files on disk.
+
+        ``applicable`` = the diagnostic's data device (``scan.device``,
+        else its name) has a data folder in this scan. Every loadable
+        diagnostic is listed regardless, so a device-less one is still
+        reachable; the tab collapses the inapplicable ones.
+        """
+        _analysis_available()
+        detail, folder, analysis_folder, _ = _analysis_context(uid, day)
+        devices = set(resources.image_devices(folder))
+        try:
+            present = {p.name for p in folder.iterdir() if p.is_dir()}
+        except OSError:
+            present = set()
+        jobs = runner.jobs_for(uid)
+        analyzers = []
+        for name, info in _processing_infos().items():
+            job = jobs.get(name)
+            analyzers.append(
+                {
+                    "id": name,
+                    "device": info.device,
+                    "applicable": info.device in devices or info.device in present,
+                    "output_dir": info.output_name,
+                    "job": job.to_json() if job is not None else None,
+                    "files": analysis_runs.list_artifacts(
+                        analysis_folder, info.output_name
+                    ),
+                }
+            )
+        running = runner.running_for(uid)
+        return JSONResponse(
+            {
+                "analyzers": analyzers,
+                "running": running.analyzer_id if running is not None else None,
+            },
+            headers={"Cache-Control": "no-cache"},
+        )
+
+    @app.post("/api/run/{uid}/analysis", status_code=202)
+    def run_analysis_start(uid: str, analyzer: str, day: str = "") -> JSONResponse:
+        """Start one analyzer on this scan (202 + the fresh job record).
+
+        Ladder: feature off / extra missing 404 · unknown or unloadable
+        diagnostic 404 · folder unresolvable 404 · a job already running
+        for this scan 409 (its record in the body). Build + run + cleanup
+        happen on the worker thread, so everything past this point —
+        config errors included — lands in the record as ``failed``.
+        """
+        _analysis_available()
+        if analyzer not in _processing_infos():
+            raise HTTPException(status_code=404, detail=f"no diagnostic: {analyzer!r}")
+        _, _, analysis_folder, tag = _analysis_context(uid, day)
+        config_dir = Path(processing_config_dir)
+
+        def run() -> Optional[list]:
+            return analysis_runs.run_scan_analyzer(factory, analyzer, config_dir, tag)
+
+        try:
+            job = runner.start(uid, analyzer, run, relative_to=analysis_folder)
+        except analysis_runs.RunInProgress as exc:
+            return JSONResponse(
+                {
+                    "detail": "a run is in progress for this scan",
+                    "job": exc.job.to_json(),
+                },
+                status_code=409,
+            )
+        return JSONResponse(job.to_json(), status_code=202)
+
+    @app.get("/run/{uid}/artifact")
+    def run_artifact(uid: str, path: str, day: str = "") -> FileResponse:
+        """Serve one file a run produced, from the scan's analysis folder only.
+
+        Containment is the contract (:func:`analysis_runs.contained_artifact`):
+        anything that resolves outside the scan's own analysis folder is
+        a 404, same as a missing file. ``no-cache``: re-runs overwrite
+        by name.
+        """
+        _, _, analysis_folder, _ = _analysis_context(uid, day)
+        file = analysis_runs.contained_artifact(analysis_folder, path)
+        if file is None:
+            raise HTTPException(status_code=404, detail="no such artifact")
+        return FileResponse(file, headers={"Cache-Control": "no-cache"})
 
     def _apply_processing(arrays: list, processing: str) -> list:
         """Ephemeral-process *arrays* → the analyzers' processed images.

--- a/GEECS-DataPortal/poetry.lock
+++ b/GEECS-DataPortal/poetry.lock
@@ -241,6 +241,120 @@ files = [
 ]
 
 [[package]]
+name = "cffi"
+version = "2.1.1"
+description = "Foreign Function Interface for Python calling C code."
+optional = true
+python-versions = ">=3.10"
+groups = ["main"]
+markers = "extra == \"analysis\" and platform_python_implementation != \"PyPy\""
+files = [
+    {file = "cffi-2.1.1-cp310-cp310-macosx_10_15_x86_64.whl", hash = "sha256:baed1e86cc735622097354b9d1281406caf42ff42a886d29faa8e8d1630333be"},
+    {file = "cffi-2.1.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:ca82be1a1d406ecfe1d25dc16cb33488e5a16bf4438c9fb590484ea29d92478b"},
+    {file = "cffi-2.1.1-cp310-cp310-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:42e2f76b9455f5a9a844f770bf3e200ed3da0e15f5df3db9c31fe80b04b3d004"},
+    {file = "cffi-2.1.1-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:5a59cc1c4442bc3d5c703bf720b51138d0bfc173618807c9ee2490a7541dd3d9"},
+    {file = "cffi-2.1.1-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:9f8d177621de5cb38ee3e731eda45d421db093ec0739f46a5594babda7987a98"},
+    {file = "cffi-2.1.1-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:75f80557d1389eddbd0de2681f6a390a0c5338c31ddaa821381c203fc3fd50d9"},
+    {file = "cffi-2.1.1-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:194cffa889098ced9976c3fc6340305e43f6303657d298da55366907c05c22d6"},
+    {file = "cffi-2.1.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:5bb4e7ea95dcd6a014a6fef62e62467d67d8e582326443f3d68e71d6320a9fcf"},
+    {file = "cffi-2.1.1-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:3d22a20b1fb1632cc72c22f95f7b0d2961c3e1c235f245ba4c606c4771035659"},
+    {file = "cffi-2.1.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:1dea0e4d7d4f11f619fe8c1d76caf49e24405b4b5743c0e3be16a500ecd930c9"},
+    {file = "cffi-2.1.1-cp310-cp310-win32.whl", hash = "sha256:7ce713ace7c0e4520535b42b77eaa742c16dab813978064913e5a3cf82973b41"},
+    {file = "cffi-2.1.1-cp310-cp310-win_amd64.whl", hash = "sha256:a48d62ab9d6f4f98c983223a547af44be6ca3691074c31cecced6facd3ba2dc1"},
+    {file = "cffi-2.1.1-cp311-cp311-macosx_10_15_x86_64.whl", hash = "sha256:c8d2c9fd1f2d16f780d15127abb050d13d1a76c03a4bd87d7e4980e45e511e12"},
+    {file = "cffi-2.1.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:398aff33cee2767e3e781d2554c54bd0dff386bb437581e0d8011fde1a942ec1"},
+    {file = "cffi-2.1.1-cp311-cp311-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:154852545011f779917b11c78db2358d095da62a9a172b78ad0a583ee5adc0d0"},
+    {file = "cffi-2.1.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:3311ed60d36f83378794e1009ac6258bafbf81f7888b4caa7b35a521e3f95813"},
+    {file = "cffi-2.1.1-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:6e192623c49c94421616a5778fba35cf0d5a8d000650c1967ef4448ee5cdd990"},
+    {file = "cffi-2.1.1-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:a6e721d4b0e45d5b65e87534470e67b18dcd092c83f68fba09f152b9cbc061af"},
+    {file = "cffi-2.1.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:34e261f78cb6ceaaa36f42f2613f4380d94d9c759a9c73c769ee6e0247364632"},
+    {file = "cffi-2.1.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:7225e4514edb64eb6740324353e0da0711954fd8d7da4576755b1c6e09b697cd"},
+    {file = "cffi-2.1.1-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:df913725b79db7bcf03448f36b7bf8815363417d5b58deecf9305e3e30f0f21a"},
+    {file = "cffi-2.1.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:f5cfbc5fe74540d335175b656c725d74d90e3730c626d92575eea35029d9afaa"},
+    {file = "cffi-2.1.1-cp311-cp311-win32.whl", hash = "sha256:f8ec5e643a9a937f64e1999eb9f75d072263751912dc5cd06d3c85f8f44be7c3"},
+    {file = "cffi-2.1.1-cp311-cp311-win_amd64.whl", hash = "sha256:42f6930c31dc7f50732c9ae793c2786c7b6b044195967bbdde40bb9be81c4cc0"},
+    {file = "cffi-2.1.1-cp311-cp311-win_arm64.whl", hash = "sha256:c7659f22557c5a0bc4855cd635f55edec690cc008a40768527762cb9fb263455"},
+    {file = "cffi-2.1.1-cp312-cp312-macosx_10_15_x86_64.whl", hash = "sha256:c8c69575568085ba0b1b10c0249d779a214aea6f6522e949a0fc9fb0fcb449d0"},
+    {file = "cffi-2.1.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f81b3b8f3d4e343550fa4baa0e479bba9f2d29ce9c2e9b51d1ce1718d7442fcf"},
+    {file = "cffi-2.1.1-cp312-cp312-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:811bd1e21d32de12efca32393a0ab3f5133b54fce9bd44b8bd77ab07da14bf6a"},
+    {file = "cffi-2.1.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:68e62fe11f30d5ca8289242866f0a5291402d8529ca2178ab8afc5c9694ae890"},
+    {file = "cffi-2.1.1-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:4a7c934f7360e8cd64fe9efadcbd10c7c6364f531e432b9a4bf5ccbc9e0e8b50"},
+    {file = "cffi-2.1.1-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:3143d81e29e1e20a9ce10901ec369012947876596f75a222235965f2b7ae832e"},
+    {file = "cffi-2.1.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c1453022f490d2459a11819d83ad1d586e9ff65a12ac3e705ffebd46d3685dcf"},
+    {file = "cffi-2.1.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:208f941bb9d18e768138677f0a6d2ce01f590df56043dda1df1535ac57c88517"},
+    {file = "cffi-2.1.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:210019b6c7cf07f081b4c54635c8cf744377001350e29cc0f81c4377b4797735"},
+    {file = "cffi-2.1.1-cp312-cp312-win32.whl", hash = "sha256:046bfc24911b37851ee1b51aab8bffe713d89c68c6a057b09484ce9fd5f69b4e"},
+    {file = "cffi-2.1.1-cp312-cp312-win_amd64.whl", hash = "sha256:f53e442b08449d42821fa4a4fba000095af9f62742a500f978a9f557ec44339a"},
+    {file = "cffi-2.1.1-cp312-cp312-win_arm64.whl", hash = "sha256:7bde5e4cc5c10140859842b9d383af292b22639a4dffb725314baf45968cef80"},
+    {file = "cffi-2.1.1-cp313-cp313-ios_13_0_arm64_iphoneos.whl", hash = "sha256:b5bdfd1c873d4e093aabc0ca84c4ca6dbc4f752afb5c86f146d9742580c9da2e"},
+    {file = "cffi-2.1.1-cp313-cp313-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:31348097ff5bbe827ccc41795d4dd099d9f0625e7def00ee653c137a490c2a6c"},
+    {file = "cffi-2.1.1-cp313-cp313-macosx_10_15_x86_64.whl", hash = "sha256:9d2055050ea716bd38b7f7f1579c275386646b4894c155a3e2f3cd62ed41b7c6"},
+    {file = "cffi-2.1.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:19ee6127ee34de7d83ce3d371ebc5ed91addbdcc39f9ab15ce4eb35a4e534971"},
+    {file = "cffi-2.1.1-cp313-cp313-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:6a8dddef476fab96d066d578fc88526767b836ab5ab21754e1d5bf3879c31c7c"},
+    {file = "cffi-2.1.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f16c709686a78c727bbbf059f92b0bf41c6fc60deec706d2dc19f529175a6125"},
+    {file = "cffi-2.1.1-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:fcd22650c908d7b7da162bbfaab594a1227a15d1643a98c68b122ac642fa2264"},
+    {file = "cffi-2.1.1-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:aa9511c62d14da7aacc9b4bf51f3f697a621e83b2d6919008243c3aad168eea3"},
+    {file = "cffi-2.1.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:a931079504ecc49efed7744c476a5c343a92fabf66dec2db95edb1b2fdc770e2"},
+    {file = "cffi-2.1.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a2d7755bef5a12ed488f4ef1f1b69ee9191d7396083b755a5d2295f6edb4768b"},
+    {file = "cffi-2.1.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:e0bcb7e0f677f543555d2adff3bf19c05f66cdb4796e5ff602442ab2fe3c4ef7"},
+    {file = "cffi-2.1.1-cp313-cp313-win32.whl", hash = "sha256:334644fbac4eff73d985a17a91226df55d0f394160c4cfb880e084c8f7161cac"},
+    {file = "cffi-2.1.1-cp313-cp313-win_amd64.whl", hash = "sha256:1aa5645c30469b09530c4ebca77ebf8f17618293c58f8549cb1a543a50236e7d"},
+    {file = "cffi-2.1.1-cp313-cp313-win_arm64.whl", hash = "sha256:63bbfd5ded17c4840ac07cd8f1c21ba9d9708141f840b324f422f41b207e3973"},
+    {file = "cffi-2.1.1-cp314-cp314-ios_13_0_arm64_iphoneos.whl", hash = "sha256:7dbb61fe3a7699468030f71bbe5f8a0e326a151daa91beb11a6fc1f980c55e1c"},
+    {file = "cffi-2.1.1-cp314-cp314-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:f24fb43132a4c6b4cb4eb029492919b2db645be6808d738f244fd146c03c32cb"},
+    {file = "cffi-2.1.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:d28630f5854ab07ab1fd4aba756de52326c82e6be15d414b12793f1975048b54"},
+    {file = "cffi-2.1.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:661c298b4821edebead0c91edd2b00374d67ad7c5a1f7a91d4442633b79d6a72"},
+    {file = "cffi-2.1.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:58acb8ab8e295e6c5ea12f888cbb13cf21511ef2a3303a23f4325c29d17fe5c1"},
+    {file = "cffi-2.1.1-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:456a61fa52d579ebf9df2e9552ead5129855dbaff6c1e5a9b1bc408809bdc062"},
+    {file = "cffi-2.1.1-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:a4f00aa42f75d6e4595e8866e748cc1705adc0cddfeb2ca86d0d03993d63ba03"},
+    {file = "cffi-2.1.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:b0431303acaea1089ad4b3e9ce4e6518193def1118d4073ca848635ee4ea2e96"},
+    {file = "cffi-2.1.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:64faea20f4e2613363a1a9b9c7dd73058f3ecd00133a511e72ad7c511658f527"},
+    {file = "cffi-2.1.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5c58fe613dc5e5336357eff555824a314d8e43282600435c8d1cb6a7a2fedd13"},
+    {file = "cffi-2.1.1-cp314-cp314-win32.whl", hash = "sha256:1a18a57b58cfb21fc28d72e876acf10eaed67a1ed96226f92af4df681d571c4c"},
+    {file = "cffi-2.1.1-cp314-cp314-win_amd64.whl", hash = "sha256:3222ba5d678f80a030e6afbcc33dc1ae5cb45facabb61cee2c7016b8432fde48"},
+    {file = "cffi-2.1.1-cp314-cp314-win_arm64.whl", hash = "sha256:ab36d55f9ed2d067327667c2fea18dda018eb628dd6347aa01dda6cf1f5d3836"},
+    {file = "cffi-2.1.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:7750c6449dff7864bb9bb27ddfb0267756189201a3afc911d82b3caacd70dfc3"},
+    {file = "cffi-2.1.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:0beceaabe56af686895136a2de78db54ecd8e4046b236b8fd6d6cb61389e9bf2"},
+    {file = "cffi-2.1.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:49cbc70e6542d4ccccb936558d1064a8012541e78f821f955cff24e357776c94"},
+    {file = "cffi-2.1.1-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:e2d65b31f36619cda3999b78b2aa9632e76b78448e7a56fc4240824200e7c4fc"},
+    {file = "cffi-2.1.1-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:28907ab9bfb6aa13184cfc17c6b8e1023c5ab6fd7076d8c20a35e59fe04f8f29"},
+    {file = "cffi-2.1.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:51b31d1c98274844cfd7838ce00bfc27c7423a4dc00fc0772fc3331c2cc90676"},
+    {file = "cffi-2.1.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:5e7cecbaadb83884793e05828cee59b210b24583b9c7425d0ba6a754fe22eb4e"},
+    {file = "cffi-2.1.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:25792eac27877609e7bb06d42ff88278a6624fff2ba9bbb523c09616b117e80f"},
+    {file = "cffi-2.1.1-cp314-cp314t-win32.whl", hash = "sha256:8ef53b2de9bcb9197d31854256575d59dbac0cba72ac627bb291ef5eceb74be4"},
+    {file = "cffi-2.1.1-cp314-cp314t-win_amd64.whl", hash = "sha256:616f097f2fe415bc92a247f02e11f634e1f9e9a83d327e3c915c15089c87869e"},
+    {file = "cffi-2.1.1-cp314-cp314t-win_arm64.whl", hash = "sha256:ad2c86c495b899d862ea0f4b42891b8713a3bd45dd4105c7fd51c2a72f39f3a5"},
+    {file = "cffi-2.1.1-cp315-cp315-ios_13_0_arm64_iphoneos.whl", hash = "sha256:dddad92b554513a31f272570678ba307fb9f618f05e3d4a5eacafff9eae03e1d"},
+    {file = "cffi-2.1.1-cp315-cp315-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:da0e573f9f97159390c89d9f1a9e41908b66d408cc5b58d08cf3847d844c531b"},
+    {file = "cffi-2.1.1-cp315-cp315-macosx_10_15_x86_64.whl", hash = "sha256:fb92203a88b3d3053034db775110081c49d28be6551923805e039924093761e4"},
+    {file = "cffi-2.1.1-cp315-cp315-macosx_11_0_arm64.whl", hash = "sha256:2ae64be792b8966f2c69538199728b290e34726562896df1e5dc8ffd8d8188e8"},
+    {file = "cffi-2.1.1-cp315-cp315-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:507a24c282e0f42f8ed737cf048572cbf580468da5555764a8331735e9c736b6"},
+    {file = "cffi-2.1.1-cp315-cp315-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:246fa40ce8645a614ff682e0b70f37134e460eaf93a775e0cbe3cca585a67a80"},
+    {file = "cffi-2.1.1-cp315-cp315-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:471cee653ae88de62096552e6d24ccb4a5adb8c8c9f10b5054d0122c15bf2779"},
+    {file = "cffi-2.1.1-cp315-cp315-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:aeae0e330c9f6acd681f647d46cefd30c29f93e3392882e792e82080c9691399"},
+    {file = "cffi-2.1.1-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:42a494cee34437f05546455144f2b5d9ac09b1face62bcfce597d2e521066688"},
+    {file = "cffi-2.1.1-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:cc572dace3f60ef98d7b12ff411d20f5362feb31a0439eab0085bbfd349982d7"},
+    {file = "cffi-2.1.1-cp315-cp315-win32.whl", hash = "sha256:4f42141fc14250de6dde5ee7ea4432be017252d91f19c5ad043c084cea629cac"},
+    {file = "cffi-2.1.1-cp315-cp315-win_amd64.whl", hash = "sha256:e6e8cff14d6fb0be70a09c0bdc58096f501952d04624ebf867e0e56da2df8960"},
+    {file = "cffi-2.1.1-cp315-cp315-win_arm64.whl", hash = "sha256:27350daa11d4f10c540e6e89dada4c54feb7256ad03e9a4dc075ebad7ba360d1"},
+    {file = "cffi-2.1.1-cp315-cp315t-macosx_10_15_x86_64.whl", hash = "sha256:c26608d2222fb1e94487e4a387d85f13eb55d5ed725cb25a0c589ac4ee60e7bc"},
+    {file = "cffi-2.1.1-cp315-cp315t-macosx_11_0_arm64.whl", hash = "sha256:4be96343e422f2dfcd12ab5c9f5aebe03f82f737c6bffeca6830b3875cb44aab"},
+    {file = "cffi-2.1.1-cp315-cp315t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:937c0052c05a31ca1daf18de3158eed4dbfcb9cc107adbea227728d647be701e"},
+    {file = "cffi-2.1.1-cp315-cp315t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:df423d40ee8654634421812bc3b196da3f9bd7d32929da813f8394c4348a5358"},
+    {file = "cffi-2.1.1-cp315-cp315t-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:a730a083190634c65cca36ba5f489531576ebd79bcd5c8e172130f6453127231"},
+    {file = "cffi-2.1.1-cp315-cp315t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:363e05fa78e15116c3c32c210ee36884fd6b9afa6d440e47112c3bd511d64cb6"},
+    {file = "cffi-2.1.1-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:770de9db11e84213beec501cfcaa013b019820ca881e03344dea5844f7876d94"},
+    {file = "cffi-2.1.1-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:7da0c5eff80f0197f3b3d1232ec5a682a9325f4ae9016a78f5f5ca35f9ced1f5"},
+    {file = "cffi-2.1.1-cp315-cp315t-win32.whl", hash = "sha256:06c72bb76605a4b0cd0aad6930b69d4baf7dd5d806cfc409b824191099700e66"},
+    {file = "cffi-2.1.1-cp315-cp315t-win_amd64.whl", hash = "sha256:d9c275eaacd24aa73f94ffd6de08fc3f932424d8b6c376f4bed7cde376fe7bc3"},
+    {file = "cffi-2.1.1-cp315-cp315t-win_arm64.whl", hash = "sha256:d18e5ac0f2f03f4f518d3e23db0f0cad7faa1da8620e9c09461d443bbf6e6692"},
+    {file = "cffi-2.1.1.tar.gz", hash = "sha256:dd31f52ea1086513bb9df30f8fcee9b8918323ae067a3d5b78bc826a000712be"},
+]
+
+[package.dependencies]
+pycparser = {version = "*", markers = "implementation_name != \"PyPy\""}
+
+[[package]]
 name = "charset-normalizer"
 version = "3.5.1"
 description = "The Real First Universal Charset Detector. Open, modern and actively maintained alternative to Chardet."
@@ -552,6 +666,69 @@ test = ["Pillow", "contourpy[test-no-images]", "matplotlib"]
 test-no-images = ["pytest", "pytest-cov", "pytest-rerunfailures", "pytest-xdist", "wurlitzer"]
 
 [[package]]
+name = "cryptography"
+version = "50.0.1"
+description = "cryptography is a package which provides cryptographic recipes and primitives to Python developers."
+optional = true
+python-versions = "!=3.9.0,!=3.9.1,>=3.9"
+groups = ["main"]
+markers = "extra == \"analysis\""
+files = [
+    {file = "cryptography-50.0.1-cp311-abi3-macosx_11_0_arm64.whl", hash = "sha256:b8f852c65863251b9e3a1b8c150ce21e59b522dbb6a7d4bc80e680d38388e986"},
+    {file = "cryptography-50.0.1-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:53e279950892dc102c6b4e52af03ae5ea92fac572a1ddab78ca73a997f62b69f"},
+    {file = "cryptography-50.0.1-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ff838d62ec1bfce4f9ba7fa16f4a7b554cd8d0c299e6be37502161a660c84eef"},
+    {file = "cryptography-50.0.1-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:e74591e283fe6eb956416c929eb58262a719fe0311fd9054c62c3350ed8760d8"},
+    {file = "cryptography-50.0.1-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:5fe002589592ed749ce77fe0695fcbd3500dd61d7d6db5858a7544c612fa8e45"},
+    {file = "cryptography-50.0.1-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:51593d180cf6d179bde5c5d065bed81386b1f381656ae7d042b7ffc87a9895ad"},
+    {file = "cryptography-50.0.1-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:359e62deae718bce96170e223fdcb6357e4fbd3bb7a3a75f4430763532560e49"},
+    {file = "cryptography-50.0.1-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:e2ca8fd1b6b4b82a1c4cb02841d0837e3c12336c2e24b520ab8ab3b969733d8f"},
+    {file = "cryptography-50.0.1-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:76de83fbd91ac49c0feaaa983d0748fd7a53176afac5fb3bf7478d244f0eb527"},
+    {file = "cryptography-50.0.1-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:51afcfceb15597cf2635068e4ac9a56b2abde622edde17f37d85fd7b5306497a"},
+    {file = "cryptography-50.0.1-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:be224a65493ec5b74a158ff22a5522ce4a5ca1e543c647a3a4730d4a09e5f959"},
+    {file = "cryptography-50.0.1-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:9ebcdd5519be9b652a46f507817a74591774fc3d6923ac364e4dfa64e36b291b"},
+    {file = "cryptography-50.0.1-cp311-abi3-win_amd64.whl", hash = "sha256:aed8db4f6d71c51efb89530e12d9464e7bf2923d46c3205dc794a2a93f8c0648"},
+    {file = "cryptography-50.0.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:30a125032e5642a21ff816e021152bd4e7e94f03eff3f4b7fca41cd22bc3110f"},
+    {file = "cryptography-50.0.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:a0b1a59e3a089064a0ec309e9428c8e3ae4e161419d20ac33600767e83fc658a"},
+    {file = "cryptography-50.0.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8921d58f426793c5f1b47f0b59575780de9a095214958d0eb37d909593db8367"},
+    {file = "cryptography-50.0.1-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:a8f40ea47330e71b594a7e246898f93177c259490c63183dbaf9e571d71ed9a5"},
+    {file = "cryptography-50.0.1-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:a255449073358275b64b67d3f595f268bbef70e72b6edb65e0c70c735bf739c9"},
+    {file = "cryptography-50.0.1-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:8df2de9102026855887e4587084f6eabd80ed0f345b8ad8a7ac27ab9bf4723e0"},
+    {file = "cryptography-50.0.1-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:ac02b07824d4d1001bd4367599f839c19cb171924c796e52c23508ac14c2c0cc"},
+    {file = "cryptography-50.0.1-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:cbf74a81765ee67413503ca6e26dcc4f6f5a519822436cc0a1b97aab6c1b8a17"},
+    {file = "cryptography-50.0.1-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:16c5ecd954b3330ebfb6605eca4fd952da8bef376551d5cc264534e3770a9ee6"},
+    {file = "cryptography-50.0.1-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:79bf008d1f9af6071c797ad133e39915dfee7614f18f18f4db9072eb715064a3"},
+    {file = "cryptography-50.0.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:330fbb252391c596f1ae42c5754449dc924e6ad012dca8efe0d703f9f2d12ec6"},
+    {file = "cryptography-50.0.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:42be3bb70596b3abe4ac097b75be223e8b3ab614a0e5de068e3dcc54d71d6149"},
+    {file = "cryptography-50.0.1-cp314-cp314t-win_amd64.whl", hash = "sha256:f74455bb086a85d5e81246412602aaa97ed095e504cd40dd261ef50be42205bf"},
+    {file = "cryptography-50.0.1-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:ca83d00d9e69cd5eb63f2e69c3a5a59e0cecae5ae14c6ae0b35830fe3b37bad0"},
+    {file = "cryptography-50.0.1-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:05ba322c4da95b262a212c345af888ef2c37c88c0509756ea00a0e6d68850f23"},
+    {file = "cryptography-50.0.1-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:e22dfed744bd4002e909464cb23d2f0b05c6f3113a79ef2e9864a53db737c733"},
+    {file = "cryptography-50.0.1-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:4c4188f7c0cf655be5c06342b817ed0f9595b69ffa2b12026e5353eed29dea88"},
+    {file = "cryptography-50.0.1-cp39-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:2ebbfb0f1fed745e91796e3e1080a1440423fdae8ece1b995a1d80883a409054"},
+    {file = "cryptography-50.0.1-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:407fe2b6db00939c05c0e945e9914238f2f0a430974839429dafc82b1ee6bee5"},
+    {file = "cryptography-50.0.1-cp39-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:2b34d76a652ea2b6faf777c35df230c5637842cd904e04f16230c3f9f03e4361"},
+    {file = "cryptography-50.0.1-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:01f41478cf33fc605a6a089cd56d28b45c6c0b45a1928b61797f2621a04bac71"},
+    {file = "cryptography-50.0.1-cp39-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:fc3ed7ebd2a8c96f5b166de0ab9b624996bef3b07bbeb19364dfb78222c22c80"},
+    {file = "cryptography-50.0.1-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:9dde0a357190eb3b1da1bb9ab750e9c85cba82ca5977aa0836cbb94e92611239"},
+    {file = "cryptography-50.0.1-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:fd3718b960d0b5dd213cdf03f3bcb7000e69dda0de8b956061947ff6bcff5558"},
+    {file = "cryptography-50.0.1-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:2a93d05e34d5f67fba6f891fe85d929999baa7195e853923ea6d7576c9e68c5e"},
+    {file = "cryptography-50.0.1-cp39-abi3-win_amd64.whl", hash = "sha256:55d16b1ef3ee0958d893a977b19777887e546c9954ea81b200c3301a864013f2"},
+    {file = "cryptography-50.0.1-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:9cb3cb952cf5a8abd50c782a98a89d71699715e802fe349704b47f2425b42a94"},
+    {file = "cryptography-50.0.1-pp311-pypy311_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:5fe939deeb161024a6be98229c953b6591fef1f41214497a78fe793a244c017f"},
+    {file = "cryptography-50.0.1-pp311-pypy311_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:fb4b9672d389c738b175c4166e78310f8a70358886aacd9173ee03a85ffdc671"},
+    {file = "cryptography-50.0.1-pp311-pypy311_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:d63ae8f6481fec907ac0f588eee8a90aefde112c633131fe540e5711ddbb5a4e"},
+    {file = "cryptography-50.0.1-pp311-pypy311_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:804728ce710890870f3aaa344b2e161172d258d768ac139d02cfd9092d0d94e6"},
+    {file = "cryptography-50.0.1-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:693c99b49bd37d0d096e4334c10232c77248c415b98d35236094cdf96d57258b"},
+    {file = "cryptography-50.0.1.tar.gz", hash = "sha256:5dd9bda1c12b4162f6ff568eeb5e0ff956c28d14406e875cfe8a63a2d414ff20"},
+]
+
+[package.dependencies]
+cffi = {version = ">=2.0.0", markers = "platform_python_implementation != \"PyPy\""}
+
+[package.extras]
+ssh = ["bcrypt (>=3.1.5)"]
+
+[[package]]
 name = "cycler"
 version = "0.12.1"
 description = "Composable style cycles"
@@ -837,7 +1014,7 @@ tqdm = ["tqdm"]
 
 [[package]]
 name = "geecs-data-utils"
-version = "0.25.0"
+version = "0.26.0"
 description = "Utilities for working with data generated by GEECS."
 optional = false
 python-versions = ">=3.11,<3.12"
@@ -866,6 +1043,133 @@ tiled = ["tiled[client] (>=0.1.0b9)"]
 [package.source]
 type = "directory"
 url = "../GEECS-Data-Utils"
+
+[[package]]
+name = "google-api-core"
+version = "2.34.0"
+description = "Google API client core library"
+optional = true
+python-versions = ">=3.10"
+groups = ["main"]
+markers = "extra == \"analysis\""
+files = [
+    {file = "google_api_core-2.34.0-py3-none-any.whl", hash = "sha256:cdf9c67e7ca2402d86ccbfde5f2503fc83e3cc3f58cc78456ae96cad24a6d2de"},
+    {file = "google_api_core-2.34.0.tar.gz", hash = "sha256:98a779fe72de956eb1c9c2f47ff4c4432a668ece1a002ec38bed07ec2698ae59"},
+]
+
+[package.dependencies]
+google-auth = ">=2.14.1,<3.0.0"
+googleapis-common-protos = ">=1.69.2,<2.0.0"
+proto-plus = ">=1.26.1,<2.0.0"
+protobuf = ">=6.33.5,<8.0.0"
+requests = ">=2.33.0,<3.0.0"
+
+[package.extras]
+async-rest = ["aiohttp (>=3.13.4)", "google-auth[aiohttp] (>=2.14.1,<3.0.0)"]
+grpc = ["grpcio (>=1.59.0,<2.0.0)", "grpcio (>=1.75.1,<2.0.0) ; python_version >= \"3.14\"", "grpcio-status (>=1.59.0,<2.0.0)", "grpcio-status (>=1.75.1,<2.0.0) ; python_version >= \"3.14\""]
+
+[[package]]
+name = "google-api-python-client"
+version = "2.200.0"
+description = "Google API Client Library for Python"
+optional = true
+python-versions = ">=3.10"
+groups = ["main"]
+markers = "extra == \"analysis\""
+files = [
+    {file = "google_api_python_client-2.200.0-py3-none-any.whl", hash = "sha256:c0c2c4072a110b7fcc30ac151744d4410cddaba99c53cb4e815463308952b638"},
+    {file = "google_api_python_client-2.200.0.tar.gz", hash = "sha256:82aa18b851328ea04867fd51c5a0c8da2e1b86ec45ce08487e902e7726d4ee50"},
+]
+
+[package.dependencies]
+google-api-core = ">=1.31.5,<2.0.dev0 || >2.3.0,<3.0.0"
+google-auth = ">=1.32.0,<2.24.0 || >2.24.0,<2.25.0 || >2.25.0,<3.0.0"
+google-auth-httplib2 = ">=0.2.0,<1.0.0"
+httplib2 = ">=0.19.0,<1.0.0"
+uritemplate = ">=3.0.1,<5"
+
+[[package]]
+name = "google-auth"
+version = "2.57.0"
+description = "Google Authentication Library"
+optional = true
+python-versions = ">=3.10"
+groups = ["main"]
+markers = "extra == \"analysis\""
+files = [
+    {file = "google_auth-2.57.0-py3-none-any.whl", hash = "sha256:180dafe015cfb62193bea26b677500fab5b9fd51a1e825ebf3ad9b182047ae59"},
+]
+
+[package.dependencies]
+cryptography = {version = ">=38.0.3", markers = "python_version < \"3.14\""}
+pyasn1-modules = ">=0.2.1"
+
+[package.extras]
+aiohttp = ["aiohttp (>=3.8.0,<4.0.0) ; python_version < \"3.14\"", "aiohttp (>=3.9.0,<4.0.0) ; python_version >= \"3.14\"", "requests (>=2.30.0,<3.0.0)"]
+cryptography = ["cryptography (>=38.0.3) ; python_version < \"3.14\"", "cryptography (>=41.0.5) ; python_version >= \"3.14\""]
+enterprise-cert = ["cryptography (>=38.0.3) ; python_version < \"3.14\"", "cryptography (>=41.0.5) ; python_version >= \"3.14\""]
+grpc = ["grpcio (>=1.59.0,<2.0.0) ; python_version < \"3.14\"", "grpcio (>=1.75.1,<2.0.0) ; python_version >= \"3.14\""]
+pyjwt = ["pyjwt (>=2.0)"]
+pyopenssl = ["cryptography (>=38.0.3) ; python_version < \"3.14\"", "cryptography (>=41.0.5) ; python_version >= \"3.14\""]
+reauth = ["pyu2f (>=0.1.5)"]
+requests = ["requests (>=2.30.0,<3.0.0)"]
+rsa = ["rsa (>=4.0.0,<5)"]
+testing = ["aiohttp (>=3.8.0,<4.0.0) ; python_version < \"3.14\"", "aiohttp (>=3.9.0,<4.0.0) ; python_version >= \"3.14\"", "aioresponses", "flask", "freezegun", "grpcio (>=1.59.0,<2.0.0) ; python_version < \"3.14\"", "grpcio (>=1.75.1,<2.0.0) ; python_version >= \"3.14\"", "packaging (>=20.0)", "pyjwt (>=2.0)", "pytest", "pytest-asyncio", "pytest-cov", "pytest-localserver", "pyu2f (>=0.1.5)", "requests (>=2.30.0,<3.0.0)", "responses", "urllib3 (>=1.26.15,<3.0.0)"]
+urllib3 = ["packaging (>=20.0)", "urllib3 (>=1.26.15,<3.0.0)"]
+
+[[package]]
+name = "google-auth-httplib2"
+version = "0.4.2"
+description = "Google Authentication Library: httplib2 transport"
+optional = true
+python-versions = ">=3.10"
+groups = ["main"]
+markers = "extra == \"analysis\""
+files = [
+    {file = "google_auth_httplib2-0.4.2-py3-none-any.whl", hash = "sha256:4298dd6b1415972d0c464b7177e6a69a595e7aec5b972222ecdca342f6009647"},
+]
+
+[package.dependencies]
+google-auth = ">=2.14.1,<3.0.0"
+httplib2 = ">=0.19.0,<1.0.0"
+
+[[package]]
+name = "google-auth-oauthlib"
+version = "1.4.1"
+description = "Google Authentication Library"
+optional = true
+python-versions = ">=3.10"
+groups = ["main"]
+markers = "extra == \"analysis\""
+files = [
+    {file = "google_auth_oauthlib-1.4.1-py3-none-any.whl", hash = "sha256:a1be43ec69fe563ac9b2c4d6fc4334b323b21cbdc59a638b5fa34dd4d5a2a348"},
+]
+
+[package.dependencies]
+google-auth = ">=2.15.0,<2.43.0 || >2.43.0,<2.44.0 || >2.44.0,<2.45.0 || >2.45.0,<3.0.0"
+requests-oauthlib = ">=0.7.0"
+
+[package.extras]
+tool = ["click (>=6.0.0)"]
+
+[[package]]
+name = "googleapis-common-protos"
+version = "1.75.2"
+description = "Common protobufs used in Google APIs"
+optional = true
+python-versions = ">=3.10"
+groups = ["main"]
+markers = "extra == \"analysis\""
+files = [
+    {file = "googleapis_common_protos-1.75.2-py3-none-any.whl", hash = "sha256:6b83302f554ea93a0f48409c7fc2050f954bcbcddb7e3a9c76d4a823cb22920e"},
+    {file = "googleapis_common_protos-1.75.2.tar.gz", hash = "sha256:8829a3d1e4508c5b7b9a6b9525f7fccff611f8531644579a76466c29295d4bb2"},
+]
+
+[package.dependencies]
+protobuf = ">=6.33.5,<8.0.0"
+
+[package.extras]
+grpc = ["grpcio (>=1.59.0,<2.0.0)"]
 
 [[package]]
 name = "h11"
@@ -989,6 +1293,22 @@ asyncio = ["anyio (>=4.0,<5.0)"]
 http2 = ["h2 (>=3,<5)"]
 socks = ["socksio (==1.*)"]
 trio = ["trio (>=0.22.0,<1.0)"]
+
+[[package]]
+name = "httplib2"
+version = "0.32.0"
+description = "A comprehensive HTTP client library."
+optional = true
+python-versions = ">=3.8"
+groups = ["main"]
+markers = "extra == \"analysis\""
+files = [
+    {file = "httplib2-0.32.0-py3-none-any.whl", hash = "sha256:dc6705cacdf3fb0a2aba7629fa33c90fd93e30035db0c157325826be177e4816"},
+    {file = "httplib2-0.32.0.tar.gz", hash = "sha256:48a0ef30a42db65d8f3399045e1d09ab0ba66e3b9efc360d07f80ea55d286025"},
+]
+
+[package.dependencies]
+pyparsing = ">=3.1,<4"
 
 [[package]]
 name = "httpx"
@@ -1469,6 +1789,27 @@ files = [
     {file = "locket-1.0.0-py2.py3-none-any.whl", hash = "sha256:b6c819a722f7b6bd955b80781788e4a66a55628b858d347536b7e81325a3a5e3"},
     {file = "locket-1.0.0.tar.gz", hash = "sha256:5c0d4c052a8bbbf750e056a8e65ccd309086f4f0f18a2eac306a8dfa4112a632"},
 ]
+
+[[package]]
+name = "logmaker4googledocs"
+version = "0.1.1"
+description = ""
+optional = true
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "extra == \"analysis\""
+files = []
+develop = true
+
+[package.dependencies]
+google-api-python-client = "*"
+google-auth-httplib2 = "*"
+google-auth-oauthlib = "*"
+pillow = "*"
+
+[package.source]
+type = "directory"
+url = "../LogMaker4GoogleDocs"
 
 [[package]]
 name = "lz4"
@@ -2173,6 +2514,24 @@ files = [
 ]
 
 [[package]]
+name = "oauthlib"
+version = "3.3.1"
+description = "A generic, spec-compliant, thorough implementation of the OAuth request-signing logic"
+optional = true
+python-versions = ">=3.8"
+groups = ["main"]
+markers = "extra == \"analysis\""
+files = [
+    {file = "oauthlib-3.3.1-py3-none-any.whl", hash = "sha256:88119c938d2b8fb88561af5f6ee0eec8cc8d552b7bb1f712743136eb7523b7a1"},
+    {file = "oauthlib-3.3.1.tar.gz", hash = "sha256:0f0f8aa759826a193cf66c12ea1af1637f87b9b4622d46e866952bb022e538c9"},
+]
+
+[package.extras]
+rsa = ["cryptography (>=3.0.0)"]
+signals = ["blinker (>=1.4.0)"]
+signedtoken = ["cryptography (>=3.0.0)", "pyjwt (>=2.0.0,<3)"]
+
+[[package]]
 name = "opencv-python"
 version = "4.14.0.94"
 description = "Wrapper package for OpenCV python bindings."
@@ -2594,6 +2953,44 @@ dev = ["pre-commit", "tox"]
 testing = ["coverage", "pytest", "pytest-benchmark"]
 
 [[package]]
+name = "proto-plus"
+version = "1.28.4"
+description = "Beautiful, Pythonic protocol buffers"
+optional = true
+python-versions = ">=3.10"
+groups = ["main"]
+markers = "extra == \"analysis\""
+files = [
+    {file = "proto_plus-1.28.4-py3-none-any.whl", hash = "sha256:4b01341272f8a348db3f003b6143109f83ab43091019d5181b3fcdf500ab32aa"},
+    {file = "proto_plus-1.28.4.tar.gz", hash = "sha256:5ff7ecad828e032a491fcb86947801768e32237f99dd049b649965b892ae9a63"},
+]
+
+[package.dependencies]
+protobuf = ">=6.33.5,<8.0.0"
+
+[package.extras]
+testing = ["google-api-core (>=2.25.0)"]
+
+[[package]]
+name = "protobuf"
+version = "7.36.1"
+description = ""
+optional = true
+python-versions = ">=3.10"
+groups = ["main"]
+markers = "extra == \"analysis\""
+files = [
+    {file = "protobuf-7.36.1-cp310-abi3-macosx_10_9_universal2.whl", hash = "sha256:3cf2ee25d006cee57294a1196ea43b37feb78e0dcd1e8af5c1aeddb777655aca"},
+    {file = "protobuf-7.36.1-cp310-abi3-manylinux2014_aarch64.whl", hash = "sha256:43d3d37b1eb24c113b9b7d02008cac44e423f00b611b7781ae998d7623972969"},
+    {file = "protobuf-7.36.1-cp310-abi3-manylinux2014_s390x.whl", hash = "sha256:39c518c05586c016d7874ff6079ee115bcec1ea5fbb1d177fbf7867ef4c67e44"},
+    {file = "protobuf-7.36.1-cp310-abi3-manylinux2014_x86_64.whl", hash = "sha256:97198b77e369a0abd8e262b8f6c7266c55ddb796a3a12c76d7b8881188ed83aa"},
+    {file = "protobuf-7.36.1-cp310-abi3-win32.whl", hash = "sha256:0b53ce95272aad50ad25d7ff03373743209822e8ba42ea7fad27d2bee1547d00"},
+    {file = "protobuf-7.36.1-cp310-abi3-win_amd64.whl", hash = "sha256:51139351435d9b43d88a55eaa49fb6f737fbb478fb0cbf2cf694d1a04a9d3363"},
+    {file = "protobuf-7.36.1-py3-none-any.whl", hash = "sha256:7d951e46b3f963d6c264c367c437921de9d5aedd9c3f9612b9077736b4e3ad5c"},
+    {file = "protobuf-7.36.1.tar.gz", hash = "sha256:d0f6470f0ce2b84e3feaea2d4b816378b37ba4d4aa08a274305373de93e2d524"},
+]
+
+[[package]]
 name = "pyabel"
 version = "0.9.1"
 description = "A Python package for forward and inverse Abel transforms"
@@ -2674,6 +3071,48 @@ files = [
     {file = "pyarrow-25.0.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:119297a6dc197e45d9c6d4415f7814a67ffa36c180d26f68c154c58067ae782d"},
     {file = "pyarrow-25.0.1-cp314-cp314t-win_amd64.whl", hash = "sha256:4288f27577352d608ca08553b0865e4a9b3aa14820c5d95b53337218d609835b"},
     {file = "pyarrow-25.0.1.tar.gz", hash = "sha256:9150a83248bfed9813ea3c3af74c3856c1984d444aa28e58bf7733b9750ddf6a"},
+]
+
+[[package]]
+name = "pyasn1"
+version = "0.6.4"
+description = "Pure-Python implementation of ASN.1 types and DER/BER/CER codecs (X.208)"
+optional = true
+python-versions = ">=3.8"
+groups = ["main"]
+markers = "extra == \"analysis\""
+files = [
+    {file = "pyasn1-0.6.4-py3-none-any.whl", hash = "sha256:deda9277cfd454080ec40b207fb6df82206a3a2688735233cdcd8d3d565f088b"},
+    {file = "pyasn1-0.6.4.tar.gz", hash = "sha256:9c447d8431c947fe4c8febc4ed9e760bc29011a5b01e5c74b67025bd9fb8ce81"},
+]
+
+[[package]]
+name = "pyasn1-modules"
+version = "0.4.2"
+description = "A collection of ASN.1-based protocols modules"
+optional = true
+python-versions = ">=3.8"
+groups = ["main"]
+markers = "extra == \"analysis\""
+files = [
+    {file = "pyasn1_modules-0.4.2-py3-none-any.whl", hash = "sha256:29253a9207ce32b64c3ac6600edc75368f98473906e8fd1043bd6b5b1de2c14a"},
+    {file = "pyasn1_modules-0.4.2.tar.gz", hash = "sha256:677091de870a80aae844b1ca6134f54652fa2c8c5a52aa396440ac3106e941e6"},
+]
+
+[package.dependencies]
+pyasn1 = ">=0.6.1,<0.7.0"
+
+[[package]]
+name = "pycparser"
+version = "3.0"
+description = "C parser in Python"
+optional = true
+python-versions = ">=3.10"
+groups = ["main"]
+markers = "extra == \"analysis\" and platform_python_implementation != \"PyPy\" and implementation_name != \"PyPy\""
+files = [
+    {file = "pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992"},
+    {file = "pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29"},
 ]
 
 [[package]]
@@ -2898,6 +3337,128 @@ files = [
 ]
 
 [[package]]
+name = "pyqt5"
+version = "5.15.9"
+description = "Python bindings for the Qt cross platform application toolkit"
+optional = true
+python-versions = ">=3.7"
+groups = ["main"]
+markers = "extra == \"analysis\" and sys_platform == \"win32\""
+files = [
+    {file = "PyQt5-5.15.9-cp37-abi3-macosx_10_13_x86_64.whl", hash = "sha256:883ba5c8a348be78c8be6a3d3ba014c798e679503bce00d76c666c2dc6afe828"},
+    {file = "PyQt5-5.15.9-cp37-abi3-manylinux_2_17_x86_64.whl", hash = "sha256:dd5ce10e79fbf1df29507d2daf99270f2057cdd25e4de6fbf2052b46c652e3a5"},
+    {file = "PyQt5-5.15.9-cp37-abi3-win32.whl", hash = "sha256:e45c5cc15d4fd26ab5cb0e5cdba60691a3e9086411f8e3662db07a5a4222a696"},
+    {file = "PyQt5-5.15.9-cp37-abi3-win_amd64.whl", hash = "sha256:e030d795df4cbbfcf4f38b18e2e119bcc9e177ef658a5094b87bb16cac0ce4c5"},
+    {file = "PyQt5-5.15.9.tar.gz", hash = "sha256:dc41e8401a90dc3e2b692b411bd5492ab559ae27a27424eed4bd3915564ec4c0"},
+]
+
+[package.dependencies]
+PyQt5-Qt5 = ">=5.15.2"
+PyQt5-sip = ">=12.11,<13"
+
+[[package]]
+name = "pyqt5-plugins"
+version = "5.15.9.2.3"
+description = "PyQt Designer and QML plugins"
+optional = true
+python-versions = ">=3.7"
+groups = ["main"]
+markers = "extra == \"analysis\" and sys_platform == \"win32\""
+files = [
+    {file = "pyqt5_plugins-5.15.9.2.3-cp310-cp310-macosx_11_0_x86_64.whl", hash = "sha256:798b9f7d212972ac3940425d0cfe3a90669520b29b113da9d63a0996b7e121f4"},
+    {file = "pyqt5_plugins-5.15.9.2.3-cp310-cp310-manylinux2014_x86_64.whl", hash = "sha256:a818862de6a19965fca26174d462097829f523e177025e96c415e0389d212616"},
+    {file = "pyqt5_plugins-5.15.9.2.3-cp310-cp310-win32.whl", hash = "sha256:a1abd0aaaf4bb1c0d35ed33eba9707f2212a235f45bf9bd103e65d60147d8865"},
+    {file = "pyqt5_plugins-5.15.9.2.3-cp310-cp310-win_amd64.whl", hash = "sha256:b3f2c1598a171c36bcc78f68d58370e6876afacdda66e0c1e2c1ce861907a7c9"},
+    {file = "pyqt5_plugins-5.15.9.2.3-cp311-cp311-macosx_10_13_universal2.whl", hash = "sha256:078b1564a54c1549e40a87c32deb9cf9e77d72f004cd0f5f42a2acfd4d6aea36"},
+    {file = "pyqt5_plugins-5.15.9.2.3-cp311-cp311-manylinux2014_x86_64.whl", hash = "sha256:c883469f6d17859c8991d44d72fff6b2b9e3fa18b371c86ff002afb5e790f9c6"},
+    {file = "pyqt5_plugins-5.15.9.2.3-cp311-cp311-win32.whl", hash = "sha256:f48754c09ed46a0b6305109c0c19ed7cd8b13925ba81ef2df2e8a870437b3aa7"},
+    {file = "pyqt5_plugins-5.15.9.2.3-cp311-cp311-win_amd64.whl", hash = "sha256:1d9acf423062c6694a5e68782fb54ce90355481d33281c9193da45c43426853c"},
+    {file = "pyqt5_plugins-5.15.9.2.3-cp37-cp37m-macosx_10_15_x86_64.whl", hash = "sha256:ed24621fbfc20964899ea5b4d1339e765847be532cedc2f195a0adb6cd2b2447"},
+    {file = "pyqt5_plugins-5.15.9.2.3-cp37-cp37m-manylinux2014_x86_64.whl", hash = "sha256:b26d7af31c0e42705a4c24fdffb29f069e3bf089f1f7b3927aff9f4adfa75b72"},
+    {file = "pyqt5_plugins-5.15.9.2.3-cp37-cp37m-win32.whl", hash = "sha256:d50304b6ffa684c08bc717db55e9cfe834937fc312888a7a64cd31fac27b0067"},
+    {file = "pyqt5_plugins-5.15.9.2.3-cp37-cp37m-win_amd64.whl", hash = "sha256:808f5456f205520af3a1e48cd935a81e7a3c032d069a6436a07ec276e486f4dd"},
+    {file = "pyqt5_plugins-5.15.9.2.3-cp38-cp38-macosx_10_15_x86_64.whl", hash = "sha256:b862c340b13cf782f77778cc9c5e28ceeb7ecbf9da0c7410b5c55050a59efe59"},
+    {file = "pyqt5_plugins-5.15.9.2.3-cp38-cp38-manylinux2014_x86_64.whl", hash = "sha256:b4225d531773c3c69814a05877651b29d639f1887f25b8b19dcc0e160427582a"},
+    {file = "pyqt5_plugins-5.15.9.2.3-cp38-cp38-win32.whl", hash = "sha256:e0715d4149701fac3ad3b6777a272edab7ca375524d4c3742b3a6c11d46b2d35"},
+    {file = "pyqt5_plugins-5.15.9.2.3-cp38-cp38-win_amd64.whl", hash = "sha256:ad82f31bfd6c7039909980628fcbcc7e843013dbdfcf3674f1ffaf53f90b71cc"},
+    {file = "pyqt5_plugins-5.15.9.2.3-cp39-cp39-macosx_11_0_x86_64.whl", hash = "sha256:3e7ba7995e71ba06d536c8a36168ae03199a3983a727d627000f170d6e3a29f4"},
+    {file = "pyqt5_plugins-5.15.9.2.3-cp39-cp39-manylinux2014_x86_64.whl", hash = "sha256:b3e747cd3be0885b12e8bde32234df0ee082dfc9607751ce81fb2aa694462048"},
+    {file = "pyqt5_plugins-5.15.9.2.3-cp39-cp39-win32.whl", hash = "sha256:e4670917c36b039b6d195af177afa369f603aa00376890fd540c955ec56c9284"},
+    {file = "pyqt5_plugins-5.15.9.2.3-cp39-cp39-win_amd64.whl", hash = "sha256:bacaae333802856871e24045f121967f73e2b5f95a55b633f76b78c6a87e034c"},
+]
+
+[package.dependencies]
+click = "*"
+pyqt5 = "5.15.9"
+pyqt5-qt5 = "5.15.2"
+qt5-tools = ">=5.15.2.1.2,<5.15.2.2"
+
+[[package]]
+name = "pyqt5-qt5"
+version = "5.15.2"
+description = "The subset of a Qt installation needed by PyQt5."
+optional = true
+python-versions = "*"
+groups = ["main"]
+markers = "extra == \"analysis\" and sys_platform == \"win32\""
+files = [
+    {file = "PyQt5_Qt5-5.15.2-py3-none-macosx_10_13_intel.whl", hash = "sha256:76980cd3d7ae87e3c7a33bfebfaee84448fd650bad6840471d6cae199b56e154"},
+    {file = "PyQt5_Qt5-5.15.2-py3-none-manylinux2014_x86_64.whl", hash = "sha256:1988f364ec8caf87a6ee5d5a3a5210d57539988bf8e84714c7d60972692e2f4a"},
+    {file = "PyQt5_Qt5-5.15.2-py3-none-win32.whl", hash = "sha256:9cc7a768b1921f4b982ebc00a318ccb38578e44e45316c7a4a850e953e1dd327"},
+    {file = "PyQt5_Qt5-5.15.2-py3-none-win_amd64.whl", hash = "sha256:750b78e4dba6bdf1607febedc08738e318ea09e9b10aea9ff0d73073f11f6962"},
+]
+
+[[package]]
+name = "pyqt5-sip"
+version = "12.19.0"
+description = "The sip module support for PyQt5"
+optional = true
+python-versions = ">=3.10"
+groups = ["main"]
+markers = "extra == \"analysis\" and sys_platform == \"win32\""
+files = [
+    {file = "pyqt5_sip-12.19.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:d3d1348235e0b2e01c962d14d5fe410b962ae49ee2cfaac5c66fe5f1edd50487"},
+    {file = "pyqt5_sip-12.19.0-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:ec8d8cbada7a92a8ab5994503ee6f6274b41c4ecbb7d60ebf858450ba5e1cc01"},
+    {file = "pyqt5_sip-12.19.0-cp310-cp310-win32.whl", hash = "sha256:92df9d2ddf99d3a8a3fab6736077cc8d0531be4db4d8ff01d03ce6e0b07e00bf"},
+    {file = "pyqt5_sip-12.19.0-cp310-cp310-win_amd64.whl", hash = "sha256:0a7ca72b06a98e4456d7f5a25e741064fb0d6f7c5d0f7302fd41384e2ec9e1c5"},
+    {file = "pyqt5_sip-12.19.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:b29e97d6aacbdc3535f17f83d11d6bd95abb0e36865a250c3d1c14719bb2f1b4"},
+    {file = "pyqt5_sip-12.19.0-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:40ed8341b7c6681d102708b65acbccf0c26908189bfa2e05e180a3b515296a87"},
+    {file = "pyqt5_sip-12.19.0-cp311-cp311-win32.whl", hash = "sha256:3d8a08fad1bc89e083d712378af4fddee9f6102cd4254e6a5c0ad7055a09670a"},
+    {file = "pyqt5_sip-12.19.0-cp311-cp311-win_amd64.whl", hash = "sha256:f01cd36afef40bd0d81d0d98ff125112ce0df725b936d9eee3f1be1cc7e96e91"},
+    {file = "pyqt5_sip-12.19.0-cp312-cp312-macosx_10_9_universal2.whl", hash = "sha256:6f7cd8a868f20fe450b6d17016ff0b0e0c8fecf32d620dcbf319a2174cbcad00"},
+    {file = "pyqt5_sip-12.19.0-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:3c5e0da86b5ae71b7acf2134e15fc8734a129549119cade25accddb3f28cb950"},
+    {file = "pyqt5_sip-12.19.0-cp312-cp312-win32.whl", hash = "sha256:aa94140b8f8255f87f85b55a471b0cabfd6c8a41a752a6d3f3d3f34942b8ee3d"},
+    {file = "pyqt5_sip-12.19.0-cp312-cp312-win_amd64.whl", hash = "sha256:628f58e13d47bd7f1a002c0c1d874b5ad7e5644c10d9334c7de4b91b001f6607"},
+    {file = "pyqt5_sip-12.19.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:a50aacf432f62e288af179040aea7bf79571f7671a89ac7064d7224a3734c22b"},
+    {file = "pyqt5_sip-12.19.0-cp313-cp313-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:16f31c35b767e45c017ce3966a48a57ff6e9a3cf9317b1e5bb71ac3cf3718e6b"},
+    {file = "pyqt5_sip-12.19.0-cp313-cp313-win32.whl", hash = "sha256:2de029b867c725f3bc5806d7640ab48696abd4e9e044cf5e26dc958dec9233b8"},
+    {file = "pyqt5_sip-12.19.0-cp313-cp313-win_amd64.whl", hash = "sha256:ab5f4753a67663ba773babf7d32d1c4a447740aa0acdc5f33d385b70952d8cc5"},
+    {file = "pyqt5_sip-12.19.0-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:2cee6450c8646b40fd8f9e75b0a340b6dfc652a4bfec338cf126b66ac61d5638"},
+    {file = "pyqt5_sip-12.19.0-cp314-cp314-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:e7bef99160b0b812be12789b5febe005ca8ed07e4804df32f0a9dbd0f747e32e"},
+    {file = "pyqt5_sip-12.19.0-cp314-cp314-win32.whl", hash = "sha256:b7a651db2339f81831050029e5363aa7adb6873ac7002e786dc07782538da6cd"},
+    {file = "pyqt5_sip-12.19.0-cp314-cp314-win_amd64.whl", hash = "sha256:4058fcb39306719c79c5c52da45208093b11c2c92c09eb2f77b950b12a5a87c2"},
+    {file = "pyqt5_sip-12.19.0.tar.gz", hash = "sha256:71cacf1879da2cd3e50cb239e21673cfe02d358af70ab6768817c960428868c3"},
+]
+
+[[package]]
+name = "pyqt5-tools"
+version = "5.15.9.3.3"
+description = "PyQt Designer and QML plugins"
+optional = true
+python-versions = ">=3.7"
+groups = ["main"]
+markers = "extra == \"analysis\" and sys_platform == \"win32\""
+files = [
+    {file = "pyqt5_tools-5.15.9.3.3-py3-none-any.whl", hash = "sha256:4b45b26111c583a34fa364b98d7120f5aeca4f96ac72e251f1b37a9cca809f86"},
+]
+
+[package.dependencies]
+click = "*"
+pyqt5 = "5.15.9"
+pyqt5-plugins = ">=5.15.9.2.2,<5.15.9.3"
+python-dotenv = "*"
+
+[[package]]
 name = "pytest"
 version = "9.1.1"
 description = "pytest: simple powerful testing with Python"
@@ -3045,6 +3606,37 @@ files = [
 ]
 
 [[package]]
+name = "qt5-applications"
+version = "5.15.2.2.3"
+description = "The collection of Qt tools easily installable in Python"
+optional = true
+python-versions = ">=3.7"
+groups = ["main"]
+markers = "extra == \"analysis\" and sys_platform == \"win32\""
+files = [
+    {file = "qt5_applications-5.15.2.2.3-py3-none-macosx_10_14_x86_64.whl", hash = "sha256:45395074b742ca6765990d3645d5e24a59415c1d968c40c6a3443da22c621ba8"},
+    {file = "qt5_applications-5.15.2.2.3-py3-none-manylinux_2_17_x86_64.whl", hash = "sha256:9ac537caf18fc339149391f58e6716c472296df4431d68e76670e75a14238de0"},
+    {file = "qt5_applications-5.15.2.2.3-py3-none-win32.whl", hash = "sha256:8d4ebdd955653f693edac4697f80e016270efcf861ebb1b8b7e238fd6faba5f5"},
+    {file = "qt5_applications-5.15.2.2.3-py3-none-win_amd64.whl", hash = "sha256:5156cc710ed3942f736ec2c46889f73d829fcd4093bed8dbddf2fd83929fdf0b"},
+]
+
+[[package]]
+name = "qt5-tools"
+version = "5.15.2.1.3"
+description = "Wrappers for the raw Qt programs from qt5-applications"
+optional = true
+python-versions = ">=3.7"
+groups = ["main"]
+markers = "extra == \"analysis\" and sys_platform == \"win32\""
+files = [
+    {file = "qt5_tools-5.15.2.1.3-py3-none-any.whl", hash = "sha256:3e73b7aa3cd03abba6e703aa1d21a5934eff42a068292500a1f02c9bc6da95cb"},
+]
+
+[package.dependencies]
+click = "*"
+qt5-applications = ">=5.15.2.2.2,<5.15.2.3"
+
+[[package]]
 name = "ragged"
 version = "0.3.0"
 description = "Ragged array library, complying with Python API specification."
@@ -3103,6 +3695,26 @@ urllib3 = ">=1.26,<3"
 [package.extras]
 socks = ["PySocks (>=1.5.6,!=1.5.7)"]
 use-chardet-on-py3 = ["chardet (>=3.0.2,<8)"]
+
+[[package]]
+name = "requests-oauthlib"
+version = "2.0.0"
+description = "OAuthlib authentication support for Requests."
+optional = true
+python-versions = ">=3.4"
+groups = ["main"]
+markers = "extra == \"analysis\""
+files = [
+    {file = "requests-oauthlib-2.0.0.tar.gz", hash = "sha256:b3dffaebd884d8cd778494369603a9e7b58d29111bf6b41bdc2dcd87203af4e9"},
+    {file = "requests_oauthlib-2.0.0-py2.py3-none-any.whl", hash = "sha256:7dd8a5c40426b779b0868c404bdef9768deccf22749cde15852df527e6269b36"},
+]
+
+[package.dependencies]
+oauthlib = ">=3.0.0"
+requests = ">=2.0.0"
+
+[package.extras]
+rsa = ["oauthlib[signedtoken] (>=3.0.0)"]
 
 [[package]]
 name = "rich"
@@ -3267,6 +3879,34 @@ botocore = ">=1.37.4,<2.0a.0"
 
 [package.extras]
 crt = ["botocore[crt] (>=1.37.4,<2.0a.0)"]
+
+[[package]]
+name = "scananalysis"
+version = "1.17.3"
+description = "Modules for performing analyses routines on full scans"
+optional = true
+python-versions = ">=3.11,<3.12"
+groups = ["main"]
+markers = "extra == \"analysis\""
+files = []
+develop = true
+
+[package.dependencies]
+geecs_data_utils = {path = "../GEECS-Data-Utils", develop = true}
+h5py = "^3.8.0"
+ImageAnalysis = {path = "../ImageAnalysis", develop = true}
+LogMaker4GoogleDocs = {path = "../LogMaker4GoogleDocs", develop = true}
+matplotlib = "^3.9.2"
+pandas = "^2.2.3"
+PyQt5 = {version = "^5.15.9", markers = "sys_platform == \"win32\""}
+pyqt5-tools = {version = "^5.15.9.3.3", markers = "sys_platform == \"win32\""}
+pyyaml = "^6.0.2"
+requests = "^2.28.0"
+watchdog = "^6.0.0"
+
+[package.source]
+type = "directory"
+url = "../ScanAnalysis"
 
 [[package]]
 name = "scikit-image"
@@ -3716,6 +4356,19 @@ files = [
 ]
 
 [[package]]
+name = "uritemplate"
+version = "4.2.0"
+description = "Implementation of RFC 6570 URI Templates"
+optional = true
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "extra == \"analysis\""
+files = [
+    {file = "uritemplate-4.2.0-py3-none-any.whl", hash = "sha256:962201ba1c4edcab02e60f9a0d3821e82dfc5d2d6662a21abd533879bdb8a686"},
+    {file = "uritemplate-4.2.0.tar.gz", hash = "sha256:480c2ed180878955863323eea31b0ede668795de182617fef9c6ca09e6ec9d0e"},
+]
+
+[[package]]
 name = "urllib3"
 version = "2.7.0"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
@@ -3751,6 +4404,50 @@ h11 = ">=0.8"
 
 [package.extras]
 standard = ["httptools (>=0.8.0)", "python-dotenv (>=0.13)", "pyyaml (>=5.1)", "uvloop (>=0.15.1) ; sys_platform != \"win32\" and sys_platform != \"cygwin\" and platform_python_implementation != \"PyPy\"", "watchfiles (>=0.20)", "websockets (>=13.0)"]
+
+[[package]]
+name = "watchdog"
+version = "6.0.0"
+description = "Filesystem events monitoring"
+optional = true
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "extra == \"analysis\""
+files = [
+    {file = "watchdog-6.0.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:d1cdb490583ebd691c012b3d6dae011000fe42edb7a82ece80965b42abd61f26"},
+    {file = "watchdog-6.0.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:bc64ab3bdb6a04d69d4023b29422170b74681784ffb9463ed4870cf2f3e66112"},
+    {file = "watchdog-6.0.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:c897ac1b55c5a1461e16dae288d22bb2e412ba9807df8397a635d88f671d36c3"},
+    {file = "watchdog-6.0.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:6eb11feb5a0d452ee41f824e271ca311a09e250441c262ca2fd7ebcf2461a06c"},
+    {file = "watchdog-6.0.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:ef810fbf7b781a5a593894e4f439773830bdecb885e6880d957d5b9382a960d2"},
+    {file = "watchdog-6.0.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:afd0fe1b2270917c5e23c2a65ce50c2a4abb63daafb0d419fde368e272a76b7c"},
+    {file = "watchdog-6.0.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:bdd4e6f14b8b18c334febb9c4425a878a2ac20efd1e0b231978e7b150f92a948"},
+    {file = "watchdog-6.0.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:c7c15dda13c4eb00d6fb6fc508b3c0ed88b9d5d374056b239c4ad1611125c860"},
+    {file = "watchdog-6.0.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6f10cb2d5902447c7d0da897e2c6768bca89174d0c6e1e30abec5421af97a5b0"},
+    {file = "watchdog-6.0.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:490ab2ef84f11129844c23fb14ecf30ef3d8a6abafd3754a6f75ca1e6654136c"},
+    {file = "watchdog-6.0.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:76aae96b00ae814b181bb25b1b98076d5fc84e8a53cd8885a318b42b6d3a5134"},
+    {file = "watchdog-6.0.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:a175f755fc2279e0b7312c0035d52e27211a5bc39719dd529625b1930917345b"},
+    {file = "watchdog-6.0.0-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:e6f0e77c9417e7cd62af82529b10563db3423625c5fce018430b249bf977f9e8"},
+    {file = "watchdog-6.0.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:90c8e78f3b94014f7aaae121e6b909674df5b46ec24d6bebc45c44c56729af2a"},
+    {file = "watchdog-6.0.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:e7631a77ffb1f7d2eefa4445ebbee491c720a5661ddf6df3498ebecae5ed375c"},
+    {file = "watchdog-6.0.0-pp310-pypy310_pp73-macosx_10_15_x86_64.whl", hash = "sha256:c7ac31a19f4545dd92fc25d200694098f42c9a8e391bc00bdd362c5736dbf881"},
+    {file = "watchdog-6.0.0-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:9513f27a1a582d9808cf21a07dae516f0fab1cf2d7683a742c498b93eedabb11"},
+    {file = "watchdog-6.0.0-pp39-pypy39_pp73-macosx_10_15_x86_64.whl", hash = "sha256:7a0e56874cfbc4b9b05c60c8a1926fedf56324bb08cfbc188969777940aef3aa"},
+    {file = "watchdog-6.0.0-pp39-pypy39_pp73-macosx_11_0_arm64.whl", hash = "sha256:e6439e374fc012255b4ec786ae3c4bc838cd7309a540e5fe0952d03687d8804e"},
+    {file = "watchdog-6.0.0-py3-none-manylinux2014_aarch64.whl", hash = "sha256:7607498efa04a3542ae3e05e64da8202e58159aa1fa4acddf7678d34a35d4f13"},
+    {file = "watchdog-6.0.0-py3-none-manylinux2014_armv7l.whl", hash = "sha256:9041567ee8953024c83343288ccc458fd0a2d811d6a0fd68c4c22609e3490379"},
+    {file = "watchdog-6.0.0-py3-none-manylinux2014_i686.whl", hash = "sha256:82dc3e3143c7e38ec49d61af98d6558288c415eac98486a5c581726e0737c00e"},
+    {file = "watchdog-6.0.0-py3-none-manylinux2014_ppc64.whl", hash = "sha256:212ac9b8bf1161dc91bd09c048048a95ca3a4c4f5e5d4a7d1b1a7d5752a7f96f"},
+    {file = "watchdog-6.0.0-py3-none-manylinux2014_ppc64le.whl", hash = "sha256:e3df4cbb9a450c6d49318f6d14f4bbc80d763fa587ba46ec86f99f9e6876bb26"},
+    {file = "watchdog-6.0.0-py3-none-manylinux2014_s390x.whl", hash = "sha256:2cce7cfc2008eb51feb6aab51251fd79b85d9894e98ba847408f662b3395ca3c"},
+    {file = "watchdog-6.0.0-py3-none-manylinux2014_x86_64.whl", hash = "sha256:20ffe5b202af80ab4266dcd3e91aae72bf2da48c0d33bdb15c66658e685e94e2"},
+    {file = "watchdog-6.0.0-py3-none-win32.whl", hash = "sha256:07df1fdd701c5d4c8e55ef6cf55b8f0120fe1aef7ef39a1c6fc6bc2e606d517a"},
+    {file = "watchdog-6.0.0-py3-none-win_amd64.whl", hash = "sha256:cbafb470cf848d93b5d013e2ecb245d4aa1c8fd0504e863ccefa32445359d680"},
+    {file = "watchdog-6.0.0-py3-none-win_ia64.whl", hash = "sha256:a1914259fa9e1454315171103c6a30961236f508b9b623eae470268bbcc6a22f"},
+    {file = "watchdog-6.0.0.tar.gz", hash = "sha256:9ddf7c82fda3ae8e24decda1338ede66e1c99883db93711d8fb941eaa2d8c282"},
+]
+
+[package.extras]
+watchmedo = ["PyYAML (>=3.10)"]
 
 [[package]]
 name = "watchfiles"
@@ -4189,9 +4886,9 @@ files = [
 cffi = ["cffi (>=1.17,<2.0) ; platform_python_implementation != \"PyPy\" and python_version < \"3.14\"", "cffi (>=2.0.0b) ; platform_python_implementation != \"PyPy\" and python_version >= \"3.14\""]
 
 [extras]
-analysis = ["imageanalysis"]
+analysis = ["imageanalysis", "scananalysis"]
 
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<3.12"
-content-hash = "b57b3281427a960ff4eeb621a047ae6b7ce71c93ad7d33b43d30edd3332aabd6"
+content-hash = "de0895afbca960f5cc7d542c1d405afecd0688560b29ab9c44ad284e9ad88a15"

--- a/GEECS-DataPortal/pyproject.toml
+++ b/GEECS-DataPortal/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-data-portal"
-version = "0.15.3"
+version = "0.16.0"
 description = "Read-only scan-browsing web service: a zero-install browser view over the Tiled catalog and the GEECS data share"
 authors = ["GEECS-BELLA"]
 readme = "README.md"
@@ -16,11 +16,14 @@ pillow = ">=10"
 geecs-data-utils = { path = "../GEECS-Data-Utils", develop = true, extras = ["tiled"] }
 plotly = "^7.0"
 imageanalysis = { path = "../ImageAnalysis", develop = true, optional = true }
+scananalysis = { path = "../ScanAnalysis", develop = true, optional = true }
 
 [tool.poetry.extras]
-# The Images tab's ephemeral-processing selector (run_diagnostic_ephemeral);
-# without it the portal serves raw images and the selector stays hidden.
-analysis = ["imageanalysis"]
+# The Images tab's ephemeral-processing selector (run_diagnostic_ephemeral)
+# AND the Analysis tab's runs (ScanAnalysis executed directly — the 04
+# design); without it the portal serves raw images, the selector stays
+# hidden and the run endpoints 404.
+analysis = ["imageanalysis", "scananalysis"]
 
 [tool.poetry.group.dev.dependencies]
 pytest = ">=8.0"

--- a/GEECS-DataPortal/pyproject.toml
+++ b/GEECS-DataPortal/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "geecs-data-portal"
 version = "0.16.0"
-description = "Read-only scan-browsing web service: a zero-install browser view over the Tiled catalog and the GEECS data share"
+description = "Scan-browsing web service (read-only except explicit analysis runs): a zero-install browser view over the Tiled catalog and the GEECS data share"
 authors = ["GEECS-BELLA"]
 readme = "README.md"
 packages = [{ include = "geecs_portal" }]

--- a/GEECS-DataPortal/tests/test_analysis_runs.py
+++ b/GEECS-DataPortal/tests/test_analysis_runs.py
@@ -1,0 +1,435 @@
+"""Analysis runs: the 04-design run model over a fake analyzer.
+
+No share, no hardware, no ScanAnalysis needed for the endpoint ladder
+(the factory seam is injected); the one test that builds the REAL
+factory skips without the ``analysis`` extra.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import threading
+import time
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from geecs_portal import analysis_runs
+from geecs_portal.app import create_app
+from test_app import FakeCatalog, _detail
+
+logger = logging.getLogger("fake.analyzer")
+
+
+# ---------------------------------------------------------------- fixtures
+
+
+@pytest.fixture()
+def scan_folder(tmp_path) -> Path:
+    """A Scan002 folder with a ``cam`` device dir (data files irrelevant here)."""
+    folder = (
+        tmp_path / "Undulator" / "Y2026" / "07-Jul" / "26_0712" / "scans" / "Scan002"
+    )
+    (folder / "cam").mkdir(parents=True)
+    (folder / "cam" / "Scan002_cam_001.png").write_bytes(b"not-a-real-png")
+    return folder
+
+
+@pytest.fixture()
+def configs_tree(tmp_path) -> Path:
+    """Two loadable diagnostics (one per device) + one legacy flat YAML."""
+    yaml = pytest.importorskip("yaml")
+    tree = tmp_path / "proc_configs"
+    analyzers = tree / "analyzers" / "HTU"
+    analyzers.mkdir(parents=True)
+
+    def diag(name: str, device: str) -> None:
+        (analyzers / f"{name}.yaml").write_text(
+            yaml.safe_dump(
+                {
+                    "name": name,
+                    "image_analyzer": (
+                        "image_analysis.analyzers.standard_analyzer.StandardAnalyzer"
+                    ),
+                    "image": {"type": "camera", "bit_depth": 16},
+                    "scan": {"priority": 100, "device": device},
+                }
+            )
+        )
+
+    diag("UC_Crop", "cam")
+    diag("UC_Other", "elsewhere")
+    (analyzers / "UC_Legacy.yaml").write_text(
+        yaml.safe_dump({"name": "UC_Legacy", "bit_depth": 16})
+    )
+    return tree
+
+
+class FakeAnalyzer:
+    """The two-call contract, scripted per test."""
+
+    instances: list = []
+
+    def __init__(self, behaviour: str, analysis_folder: Path):
+        self.behaviour = behaviour
+        self.analysis_folder = analysis_folder
+        self.cleaned = False
+        self.release = threading.Event()
+        self.started = threading.Event()
+        FakeAnalyzer.instances.append(self)
+
+    def run_analysis(self, scan_tag):
+        self.scan_tag = scan_tag
+        self.started.set()
+        logger.info("fake analyzer running on scan %s", scan_tag.number)
+        if self.behaviour == "block":
+            self.release.wait(timeout=10)
+        if self.behaviour == "fail":
+            logger.warning("about to fail")
+            raise RuntimeError("boom")
+        if self.behaviour == "none":
+            return None
+        if self.behaviour == "no_data":
+
+            class DataUnavailableWarning(Exception):
+                pass
+
+            raise DataUnavailableWarning("device folder empty")
+        out = self.analysis_folder / "UC_Crop" / "Array2DScanAnalyzer"
+        out.mkdir(parents=True, exist_ok=True)
+        figure = out / "summary.png"
+        figure.write_bytes(b"\x89PNG fake")
+        return [figure, "a label, not a path"]
+
+    def cleanup(self):
+        self.cleaned = True
+
+
+def _factory(behaviour: str):
+    def factory(analyzer_id: str, config_dir: Path):
+        assert analyzer_id == "UC_Crop"
+        return FakeAnalyzer(behaviour, factory.analysis_folder)
+
+    return factory
+
+
+def _client(scan_folder, configs_tree, behaviour="ok", **kwargs) -> TestClient:
+    catalog = FakeCatalog()
+    detail = _detail(2)
+    detail.start_doc["scan_folder"] = str(scan_folder)
+    catalog.details["uid-002"] = detail
+    factory = _factory(behaviour)
+    factory.analysis_folder = analysis_runs.analysis_folder_for(scan_folder)
+    kwargs.setdefault("analysis_factory", factory)
+    return TestClient(create_app(catalog, processing_config_dir=configs_tree, **kwargs))
+
+
+def _wait(client: TestClient, analyzer="UC_Crop", timeout=10.0) -> dict:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        body = client.get("/api/run/uid-002/analysis").json()
+        job = next(a["job"] for a in body["analyzers"] if a["id"] == analyzer)
+        if job is not None and job["state"] not in analysis_runs.ACTIVE:
+            return job
+        time.sleep(0.02)
+    raise AssertionError("job never finished")
+
+
+@pytest.fixture(autouse=True)
+def _reset_instances():
+    FakeAnalyzer.instances = []
+    yield
+    for inst in FakeAnalyzer.instances:
+        inst.release.set()
+
+
+# ------------------------------------------------------------ pure helpers
+
+
+class TestHelpers:
+    def test_analysis_folder_is_the_scans_sibling(self, scan_folder):
+        assert analysis_runs.analysis_folder_for(scan_folder) == (
+            scan_folder.parents[1] / "analysis" / "Scan002"
+        )
+
+    def test_contained_artifact_refuses_escapes(self, tmp_path):
+        root = tmp_path / "analysis" / "Scan002"
+        (root / "UC_Crop").mkdir(parents=True)
+        inside = root / "UC_Crop" / "fig.png"
+        inside.write_bytes(b"x")
+        outside = tmp_path / "analysis" / "s2.txt"
+        outside.write_text("secret")
+        assert analysis_runs.contained_artifact(root, "UC_Crop/fig.png") == inside
+        assert analysis_runs.contained_artifact(root, "../s2.txt") is None
+        assert analysis_runs.contained_artifact(root, str(outside)) is None
+        assert analysis_runs.contained_artifact(root, "") is None
+        assert analysis_runs.contained_artifact(root, "UC_Crop") is None  # a dir
+        assert analysis_runs.contained_artifact(root, "UC_Crop/missing.png") is None
+        link = root / "UC_Crop" / "link.txt"
+        os.symlink(outside, link)
+        assert analysis_runs.contained_artifact(root, "UC_Crop/link.txt") is None
+
+    def test_relativize_only_under_root(self, tmp_path):
+        root = tmp_path / "analysis" / "Scan002"
+        (root / "x").mkdir(parents=True)
+        assert analysis_runs._relativize(root / "x" / "f.png", root) == "x/f.png"
+        assert analysis_runs._relativize(tmp_path / "elsewhere.png", root) == str(
+            tmp_path / "elsewhere.png"
+        )
+        assert analysis_runs._relativize("just a label", root) == "just a label"
+        assert analysis_runs._relativize(root / "x" / "f.png", None) == str(
+            root / "x" / "f.png"
+        )
+
+    def test_list_artifacts_is_scoped_sorted_and_capped(self, tmp_path):
+        root = tmp_path / "analysis" / "Scan002"
+        out = root / "UC_Crop" / "Array2DScanAnalyzer"
+        out.mkdir(parents=True)
+        for name in ("b.png", "a.png", "c.h5"):
+            (out / name).write_bytes(b"x")
+        (root / "UC_Other").mkdir()
+        (root / "UC_Other" / "other.png").write_bytes(b"x")
+        assert analysis_runs.list_artifacts(root, "UC_Crop") == [
+            "UC_Crop/Array2DScanAnalyzer/a.png",
+            "UC_Crop/Array2DScanAnalyzer/b.png",
+            "UC_Crop/Array2DScanAnalyzer/c.h5",
+        ]
+        assert analysis_runs.list_artifacts(root, "UC_Crop", limit=2) == [
+            "UC_Crop/Array2DScanAnalyzer/a.png",
+            "UC_Crop/Array2DScanAnalyzer/b.png",
+        ]
+        assert analysis_runs.list_artifacts(root, "UC_Missing") == []
+
+
+class TestRunner:
+    def test_one_active_job_per_scan(self):
+        runner = analysis_runs.AnalysisRunner()
+        gate = threading.Event()
+        try:
+            job = runner.start("u", "A", lambda: gate.wait(5) and [])
+            with pytest.raises(analysis_runs.RunInProgress) as excinfo:
+                runner.start("u", "B", lambda: [])
+            assert excinfo.value.job is job
+            # A different scan is not gated by this one.
+            other = runner.start("v", "A", lambda: [])
+            assert other.state in analysis_runs.ACTIVE
+        finally:
+            gate.set()
+            runner.shutdown()
+
+    def test_log_capture_is_scoped_to_the_worker_thread(self):
+        runner = analysis_runs.AnalysisRunner()
+        seen = threading.Event()
+        noise = logging.getLogger("request.thread")
+
+        def run():
+            logging.getLogger("worker").warning("from the worker")
+            seen.set()
+            time.sleep(0.05)
+            return []
+
+        try:
+            job = runner.start("u", "A", run)
+            assert seen.wait(5)
+            noise.warning("from a request thread")  # concurrent, must not leak
+            deadline = time.monotonic() + 5
+            while job.state in analysis_runs.ACTIVE and time.monotonic() < deadline:
+                time.sleep(0.01)
+            assert job.state == analysis_runs.DONE
+            assert job.log == ["WARNING worker: from the worker"]
+        finally:
+            runner.shutdown()
+
+
+# ---------------------------------------------------------- the endpoints
+
+
+class TestFeatureGates:
+    def test_off_without_configs_tree(self, scan_folder):
+        catalog = FakeCatalog()
+        client = TestClient(create_app(catalog))
+        assert client.get("/api/run/uid-002/analysis").status_code == 404
+        response = client.post("/api/run/uid-002/analysis", params={"analyzer": "x"})
+        assert response.status_code == 404
+        assert "processing-configs" in response.json()["detail"]
+
+    def test_real_factory_needs_the_extra(self, scan_folder, configs_tree, monkeypatch):
+        pytest.importorskip("image_analysis")
+        monkeypatch.setitem(__import__("sys").modules, "scan_analysis", None)
+        client = _client(scan_folder, configs_tree, analysis_factory=None)
+        response = client.get("/api/run/uid-002/analysis")
+        assert response.status_code == 404
+        assert "analysis" in response.json()["detail"]
+
+    def test_folder_unresolvable(self, configs_tree):
+        pytest.importorskip("image_analysis")
+        catalog = FakeCatalog()  # uid-002 has no scan_folder; daily path is stubbed
+        client = TestClient(
+            create_app(
+                catalog,
+                processing_config_dir=configs_tree,
+                analysis_factory=_factory("ok"),
+            )
+        )
+        response = client.post(
+            "/api/run/uid-002/analysis", params={"analyzer": "UC_Crop"}
+        )
+        assert response.status_code == 404
+        assert "not resolvable" in response.json()["detail"]
+        assert FakeAnalyzer.instances == []  # nothing built, nothing run
+
+
+class TestListing:
+    def test_applicability_and_empty_records(self, scan_folder, configs_tree):
+        pytest.importorskip("image_analysis")
+        client = _client(scan_folder, configs_tree)
+        body = client.get("/api/run/uid-002/analysis").json()
+        by_id = {a["id"]: a for a in body["analyzers"]}
+        assert set(by_id) == {"UC_Crop", "UC_Other"}  # the legacy flat YAML is dropped
+        assert by_id["UC_Crop"]["applicable"] is True
+        assert by_id["UC_Crop"]["device"] == "cam"
+        assert by_id["UC_Other"]["applicable"] is False
+        assert all(a["job"] is None and a["files"] == [] for a in body["analyzers"])
+        assert body["running"] is None
+
+    def test_files_on_disk_survive_without_a_record(self, scan_folder, configs_tree):
+        """A page loaded after a portal restart still lists earlier outputs."""
+        pytest.importorskip("image_analysis")
+        analysis = analysis_runs.analysis_folder_for(scan_folder)
+        (analysis / "UC_Crop" / "Array2DScanAnalyzer").mkdir(parents=True)
+        (analysis / "UC_Crop" / "Array2DScanAnalyzer" / "old.png").write_bytes(b"x")
+        client = _client(scan_folder, configs_tree)
+        body = client.get("/api/run/uid-002/analysis").json()
+        crop = next(a for a in body["analyzers"] if a["id"] == "UC_Crop")
+        assert crop["job"] is None
+        assert crop["files"] == ["UC_Crop/Array2DScanAnalyzer/old.png"]
+
+
+class TestRun:
+    def test_done_artifacts_and_serving(self, scan_folder, configs_tree, caplog):
+        pytest.importorskip("image_analysis")
+        # Capture respects the process's logging levels (no global level
+        # mutation): the analyzer's INFO line is seen only when its
+        # logger admits INFO — the portal runs at INFO by default.
+        caplog.set_level(logging.INFO, logger="fake.analyzer")
+        client = _client(scan_folder, configs_tree)
+        before = sorted(p.relative_to(scan_folder) for p in scan_folder.rglob("*"))
+        response = client.post(
+            "/api/run/uid-002/analysis", params={"analyzer": "UC_Crop"}
+        )
+        assert response.status_code == 202
+        assert response.json()["state"] in analysis_runs.ACTIVE
+        job = _wait(client)
+        assert job["state"] == "done"
+        assert job["error"] is None
+        assert job["artifacts"] == [
+            "UC_Crop/Array2DScanAnalyzer/summary.png",
+            "a label, not a path",
+        ]
+        assert "fake analyzer running on scan 2" in " ".join(job["log"])
+        (analyzer,) = FakeAnalyzer.instances
+        assert analyzer.cleaned is True
+        tag = analyzer.scan_tag
+        assert (tag.number, tag.experiment) == (2, "Undulator")
+        # The scan folder itself is untouched by the portal side.
+        after = sorted(p.relative_to(scan_folder) for p in scan_folder.rglob("*"))
+        assert after == before
+        # Listing now shows the file on disk too; the artifact endpoint serves it.
+        body = client.get("/api/run/uid-002/analysis").json()
+        crop = next(a for a in body["analyzers"] if a["id"] == "UC_Crop")
+        assert crop["files"] == ["UC_Crop/Array2DScanAnalyzer/summary.png"]
+        served = client.get(
+            "/run/uid-002/artifact",
+            params={"path": "UC_Crop/Array2DScanAnalyzer/summary.png"},
+        )
+        assert served.status_code == 200
+        assert served.content == b"\x89PNG fake"
+        assert served.headers["cache-control"] == "no-cache"
+        assert served.headers["content-type"].startswith("image/png")
+
+    def test_failure_is_a_record_not_a_500(self, scan_folder, configs_tree):
+        pytest.importorskip("image_analysis")
+        client = _client(scan_folder, configs_tree, behaviour="fail")
+        assert (
+            client.post(
+                "/api/run/uid-002/analysis", params={"analyzer": "UC_Crop"}
+            ).status_code
+            == 202
+        )
+        job = _wait(client)
+        assert job["state"] == "failed"
+        assert job["error"] == "RuntimeError: boom"
+        assert "WARNING fake.analyzer: about to fail" in job["log"]
+        (analyzer,) = FakeAnalyzer.instances
+        assert analyzer.cleaned is True  # cleanup runs on failure too
+
+    @pytest.mark.parametrize("behaviour", ["none", "no_data"])
+    def test_skips_are_no_data(self, scan_folder, configs_tree, behaviour):
+        pytest.importorskip("image_analysis")
+        client = _client(scan_folder, configs_tree, behaviour=behaviour)
+        client.post("/api/run/uid-002/analysis", params={"analyzer": "UC_Crop"})
+        job = _wait(client)
+        assert job["state"] == "no_data"
+        assert job["artifacts"] == []
+        assert job["error"]
+
+    def test_second_post_409_while_running(self, scan_folder, configs_tree):
+        pytest.importorskip("image_analysis")
+        client = _client(scan_folder, configs_tree, behaviour="block")
+        first = client.post("/api/run/uid-002/analysis", params={"analyzer": "UC_Crop"})
+        assert first.status_code == 202
+        (analyzer,) = FakeAnalyzer.instances
+        assert analyzer.started.wait(5)
+        again = client.post("/api/run/uid-002/analysis", params={"analyzer": "UC_Crop"})
+        assert again.status_code == 409
+        assert again.json()["job"]["state"] == "running"
+        assert client.get("/api/run/uid-002/analysis").json()["running"] == "UC_Crop"
+        analyzer.release.set()
+        assert _wait(client)["state"] == "done"
+        # Re-run after completion is allowed (overwrites by name).
+        assert (
+            client.post(
+                "/api/run/uid-002/analysis", params={"analyzer": "UC_Crop"}
+            ).status_code
+            == 202
+        )
+        FakeAnalyzer.instances[-1].release.set()
+        assert _wait(client)["state"] == "done"
+
+    @pytest.mark.parametrize("analyzer", ["UC_Nope", "UC_Legacy"])
+    def test_unknown_or_unloadable_diagnostic_404(
+        self, scan_folder, configs_tree, analyzer
+    ):
+        pytest.importorskip("image_analysis")
+        client = _client(scan_folder, configs_tree)
+        response = client.post(
+            "/api/run/uid-002/analysis", params={"analyzer": analyzer}
+        )
+        assert response.status_code == 404
+        assert FakeAnalyzer.instances == []
+
+
+class TestArtifactEndpoint:
+    def test_containment(self, scan_folder, configs_tree):
+        pytest.importorskip("image_analysis")
+        analysis = analysis_runs.analysis_folder_for(scan_folder)
+        analysis.mkdir(parents=True)
+        sfile = analysis.parent / "s2.txt"
+        sfile.write_text("Shotnumber\n1\n")
+        client = _client(scan_folder, configs_tree)
+        for path in ("../s2.txt", str(sfile), "", "..", "UC_Crop/../../s2.txt"):
+            response = client.get("/run/uid-002/artifact", params={"path": path})
+            assert response.status_code == 404, path
+
+
+class TestRealFactory:
+    def test_builds_a_scan_analyzer_from_the_tree(self, configs_tree):
+        """The default factory = load_diagnostic + create_scan_analyzer."""
+        pytest.importorskip("image_analysis")
+        pytest.importorskip("scan_analysis")
+        analyzer = analysis_runs.scan_analysis_factory("UC_Crop", configs_tree)
+        assert callable(analyzer.run_analysis) and callable(analyzer.cleanup)
+        assert analyzer.id == "UC_Crop"
+        assert analyzer.data_device_name == "cam"

--- a/GEECS-DataPortal/tests/test_analysis_runs.py
+++ b/GEECS-DataPortal/tests/test_analysis_runs.py
@@ -219,13 +219,20 @@ class TestRunner:
             gate.set()
             runner.shutdown()
 
-    def test_log_capture_is_scoped_to_the_worker_thread(self):
+    def test_log_capture_is_the_window_minus_portal_traffic(self):
+        """Everything the run emits — sub-threads included — minus the app's own."""
         runner = analysis_runs.AnalysisRunner()
         seen = threading.Event()
-        noise = logging.getLogger("request.thread")
 
         def run():
             logging.getLogger("worker").warning("from the worker")
+            helper = threading.Thread(
+                target=lambda: logging.getLogger("scan_analysis.pool").warning(
+                    "from an analyzer sub-thread"
+                )
+            )
+            helper.start()
+            helper.join()
             seen.set()
             time.sleep(0.05)
             return []
@@ -233,12 +240,42 @@ class TestRunner:
         try:
             job = runner.start("u", "A", run)
             assert seen.wait(5)
-            noise.warning("from a request thread")  # concurrent, must not leak
+            # Portal / server traffic during the window is not the run's.
+            logging.getLogger("uvicorn.access").warning("GET /health")
+            logging.getLogger("geecs_portal.app").warning("request-side noise")
             deadline = time.monotonic() + 5
             while job.state in analysis_runs.ACTIVE and time.monotonic() < deadline:
                 time.sleep(0.01)
             assert job.state == analysis_runs.DONE
-            assert job.log == ["WARNING worker: from the worker"]
+            assert job.log == [
+                "WARNING worker: from the worker",
+                "WARNING scan_analysis.pool: from an analyzer sub-thread",
+            ]
+            assert job.finished is not None  # assigned before the state flips
+        finally:
+            runner.shutdown()
+
+    def test_shutdown_refuses_new_jobs(self):
+        runner = analysis_runs.AnalysisRunner()
+        runner.shutdown()
+        with pytest.raises(RuntimeError):
+            runner.start("u", "A", lambda: [])
+
+    def test_base_exception_is_recorded_not_stuck(self):
+        runner = analysis_runs.AnalysisRunner()
+
+        def run():
+            raise SystemExit(3)
+
+        try:
+            job = runner.start("u", "A", run)
+            deadline = time.monotonic() + 5
+            while job.state in analysis_runs.ACTIVE and time.monotonic() < deadline:
+                time.sleep(0.01)
+            assert job.state == analysis_runs.FAILED
+            assert job.error == "SystemExit: 3"
+            # The scan is not left permanently 409.
+            assert runner.running_for("u") is None
         finally:
             runner.shutdown()
 
@@ -333,6 +370,9 @@ class TestRun:
         assert analyzer.cleaned is True
         tag = analyzer.scan_tag
         assert (tag.number, tag.experiment) == (2, "Undulator")
+        # The tag comes from the RESOLVED FOLDER (26_0712), not from the
+        # start doc's time (TEST_DAY) — the midnight-claim / TZ hazard.
+        assert (tag.year, tag.month, tag.day) == (2026, 7, 12)
         # The scan folder itself is untouched by the portal side.
         after = sorted(p.relative_to(scan_folder) for p in scan_folder.rglob("*"))
         assert after == before
@@ -412,6 +452,44 @@ class TestRun:
 
 
 class TestArtifactEndpoint:
+    def test_gated_with_the_feature(self, scan_folder):
+        analysis = analysis_runs.analysis_folder_for(scan_folder)
+        (analysis / "UC_Crop").mkdir(parents=True)
+        (analysis / "UC_Crop" / "fig.png").write_bytes(b"x")
+        catalog = FakeCatalog()
+        detail = _detail(2)
+        detail.start_doc["scan_folder"] = str(scan_folder)
+        catalog.details["uid-002"] = detail
+        client = TestClient(create_app(catalog))  # feature off
+        response = client.get(
+            "/run/uid-002/artifact", params={"path": "UC_Crop/fig.png"}
+        )
+        assert response.status_code == 404
+
+    def test_only_raster_images_render_inline(self, scan_folder, configs_tree):
+        """A planted HTML/SVG on the share must never execute in the portal's origin."""
+        pytest.importorskip("image_analysis")
+        analysis = analysis_runs.analysis_folder_for(scan_folder)
+        (analysis / "UC_Crop").mkdir(parents=True)
+        (analysis / "UC_Crop" / "fig.png").write_bytes(b"\x89PNG")
+        (analysis / "UC_Crop" / "evil.html").write_text("<script>alert(1)</script>")
+        (analysis / "UC_Crop" / "plot.svg").write_text("<svg onload='alert(1)'/>")
+        (analysis / "UC_Crop" / "data.h5").write_bytes(b"\x89HDF")
+        client = _client(scan_folder, configs_tree)
+        png = client.get("/run/uid-002/artifact", params={"path": "UC_Crop/fig.png"})
+        assert png.status_code == 200
+        assert png.headers["content-disposition"].startswith("inline")
+        assert png.headers["x-content-type-options"] == "nosniff"
+        for name in ("evil.html", "plot.svg", "data.h5"):
+            response = client.get(
+                "/run/uid-002/artifact", params={"path": f"UC_Crop/{name}"}
+            )
+            assert response.status_code == 200, name
+            assert response.headers["content-disposition"].startswith("attachment"), (
+                name
+            )
+            assert response.headers["x-content-type-options"] == "nosniff"
+
     def test_containment(self, scan_folder, configs_tree):
         pytest.importorskip("image_analysis")
         analysis = analysis_runs.analysis_folder_for(scan_folder)

--- a/GEECS-DataPortal/tests/test_analysis_runs.py
+++ b/GEECS-DataPortal/tests/test_analysis_runs.py
@@ -29,8 +29,10 @@ logger = logging.getLogger("fake.analyzer")
 @pytest.fixture()
 def scan_folder(tmp_path) -> Path:
     """A Scan002 folder with a ``cam`` device dir (data files irrelevant here)."""
+    # Dated the day AFTER test_app.TEST_DAY (the start doc's time) on
+    # purpose: the run's tag must come from the folder, never the doc.
     folder = (
-        tmp_path / "Undulator" / "Y2026" / "07-Jul" / "26_0712" / "scans" / "Scan002"
+        tmp_path / "Undulator" / "Y2026" / "07-Jul" / "26_0713" / "scans" / "Scan002"
     )
     (folder / "cam").mkdir(parents=True)
     (folder / "cam" / "Scan002_cam_001.png").write_bytes(b"not-a-real-png")
@@ -240,9 +242,19 @@ class TestRunner:
         try:
             job = runner.start("u", "A", run)
             assert seen.wait(5)
-            # Portal / server traffic during the window is not the run's.
+            # Portal / server traffic during the window is not the run's:
+            # by logger name, and by thread name for the libraries a
+            # concurrent browser exercises (the ephemeral Images path).
             logging.getLogger("uvicorn.access").warning("GET /health")
             logging.getLogger("geecs_portal.app").warning("request-side noise")
+            browser = threading.Thread(
+                name="AnyIO worker thread",
+                target=lambda: logging.getLogger("image_analysis.ephemeral").warning(
+                    "a concurrent browser's processing"
+                ),
+            )
+            browser.start()
+            browser.join()
             deadline = time.monotonic() + 5
             while job.state in analysis_runs.ACTIVE and time.monotonic() < deadline:
                 time.sleep(0.01)
@@ -284,6 +296,23 @@ class TestRunner:
 
 
 class TestFeatureGates:
+    def test_shutdown_turns_posts_into_503(self, scan_folder, configs_tree):
+        pytest.importorskip("image_analysis")
+        client = _client(scan_folder, configs_tree, behaviour="ok")
+        with client:  # runs the lifespan: startup … shutdown
+            assert (
+                client.post(
+                    "/api/run/uid-002/analysis", params={"analyzer": "UC_Crop"}
+                ).status_code
+                == 202
+            )
+            _wait(client)
+        response = client.post(
+            "/api/run/uid-002/analysis", params={"analyzer": "UC_Crop"}
+        )
+        assert response.status_code == 503
+        assert "shutting down" in response.json()["detail"]
+
     def test_off_without_configs_tree(self, scan_folder):
         catalog = FakeCatalog()
         client = TestClient(create_app(catalog))
@@ -370,9 +399,9 @@ class TestRun:
         assert analyzer.cleaned is True
         tag = analyzer.scan_tag
         assert (tag.number, tag.experiment) == (2, "Undulator")
-        # The tag comes from the RESOLVED FOLDER (26_0712), not from the
-        # start doc's time (TEST_DAY) — the midnight-claim / TZ hazard.
-        assert (tag.year, tag.month, tag.day) == (2026, 7, 12)
+        # The tag comes from the RESOLVED FOLDER (26_0713), not from the
+        # start doc's time (TEST_DAY = 07-12) — the midnight-claim / TZ hazard.
+        assert (tag.year, tag.month, tag.day) == (2026, 7, 13)
         # The scan folder itself is untouched by the portal side.
         after = sorted(p.relative_to(scan_folder) for p in scan_folder.rglob("*"))
         assert after == before

--- a/Planning/data_portal/01_data_portal_scope.md
+++ b/Planning/data_portal/01_data_portal_scope.md
@@ -76,6 +76,12 @@ Three properties carry the design:
    portal has no write verbs — no analysis triggering, no annotations
    in v1. That is what makes "anyone on the network" safe with no auth
    story, and keeps the service solo-maintainable.
+   *Amended 2026-09-01 (`04_analysis_run_design.md`): one write verb —
+   explicit ScanAnalysis runs from the Analysis tab, opt-in via
+   `--processing-configs`, read-write mount where enabled,
+   unauthenticated on the lab network by the owner's acceptance
+   (regenerable outputs, internal share). Annotations and config
+   writes stay out.*
 3. **Python-native, no build chain (Sam, standing doctrine).** FastAPI +
    server-rendered templates. No npm. One `poetry install`, one systemd
    unit, a `deploy/` runbook — the same service pattern as the gateways
@@ -126,7 +132,8 @@ finding stories, not two formats.
 
 ## Deliberately out of scope (v1)
 
-- Any write path (annotations, analysis triggering, re-processing).
+- Any write path (annotations, analysis triggering, re-processing) —
+  *analysis triggering admitted 2026-09-01, see ruling 2's amendment.*
 - Authentication (lab-network-internal + read-only; revisit only if
   exposure changes).
 - Serving assets *through* Tiled — see "Future work".

--- a/Planning/data_portal/04_analysis_run_design.md
+++ b/Planning/data_portal/04_analysis_run_design.md
@@ -299,8 +299,10 @@ its figures render in the Analysis tab; the Plot tab shows the new
 `"sfile"`-provenance columns; re-run overwrites (warn logged, no
 duplicate columns, spot-check a cell); a deliberately broken YAML shows
 as `failed` with the exception text; a device-less diagnostic shows
-`no_data`; the rendered toggle shows the analyzer's overlays on the
-per-shot image.
+`no_data`; run a 2D analyzer *while* browsing images in another tab
+(the process-pool fork from a thread-rich process — #763 review
+finding 3); `systemctl restart` during a run waits, then serves; the
+rendered toggle shows the analyzer's overlays on the per-shot image.
 
 ## Open questions (carried, not blocking)
 


### PR DESCRIPTION
## What

PR 2 of the `feat/analysis-tab` arc (`Planning/data_portal/04_analysis_run_design.md`, merged as #760): the run backend. The portal can now run **one ScanAnalysis analyzer on one scan** on a browser click, and serve what the run produced. No UI yet — that is PR 3 (`portal/analysis-tab`).

- **`geecs_portal/analysis_runs.py`** (new, 364 LOC): `AnalysisRunner` — one worker thread, one active job per scan, in-memory records (`queued`/`running`/`done`/`failed`/`no_data`, artifacts, error text, the run's log lines captured from the worker thread only, never the app's); the analyzer **factory seam** (default = `load_diagnostic` + `create_scan_analyzer`, the same two calls the group loader runs in a loop — lazy import, the extra stays optional); `run_scan_analyzer` (`cleanup()` in `finally`); `analysis_folder_for` / `contained_artifact` / `list_artifacts`.
- **`app.py`** (+179): `GET /api/run/{uid}/analysis` (loadable diagnostics with `applicable` by data device, `job`, `files` on disk under the analyzer's output dir), `POST /api/run/{uid}/analysis?analyzer=` (202 / 404 ladder / 409 while a job is active for the scan), `GET /run/{uid}/artifact?path=` (resolved path must stay inside the scan's analysis folder — symlinks resolved — else 404). The selector cache now stores per-diagnostic run facts (`_DiagInfo`) instead of bare names.
- **`__main__`**: `matplotlib.use("Agg")` pinned before any analysis import (ScanAnalysis renderers use pyplot; the single worker thread serialises them).
- **`pyproject` + lock**: ScanAnalysis joins the `analysis` extra. Relocked inside the worktree; the lock carries relative `url = "../ScanAnalysis"`, zero worktree paths (hook green).
- **Docs**: portal `CLAUDE.md` charter → "read-only except explicit analysis runs" + routes + layout; `DEPLOYMENT.md` (read-write mount where runs are enabled; extra + flag named); scope doc ruling 2 amendment; root dependency graph; `CHANGELOG` 0.16.0.

## Why

Owner ruling 2026-09-01 (recorded in the 04 doc after review): scan-wide views use the real ScanAnalysis pipeline; "just run it" — the portal is **not** a task-queue participant (no status records, claims, heartbeats, gdoc); GEECS-MCP's runner is experimental and the two do not coordinate (accepted); s-file collisions follow ScanAnalysis's warn-and-overwrite; write stance (read-write mount, unauthenticated verb on the lab network) accepted.

## Design notes / judgment calls (cheap to veto)

- **`no_data` mapping**: `run_analysis` returning `None` and `DataUnavailableWarning` (matched by class name so the module imports nothing from ScanAnalysis at import time) both become `no_data`, not `done`/`failed` — the worklist runner's own mapping.
- **Log capture respects logger levels** (no global level mutation): the record holds what the process's `--log-level` admits.
- **Build happens on the worker thread** so config/instantiation errors are `failed` records, not request errors; unknown diagnostics are still refused at the boundary (404) via the existing loadable-diagnostics cache.
- **One active job per scan**, not per analyzer — keeps the pyplot serialisation simple and matches "just run it".
- **`files` on disk are listed per analyzer output dir** so a page loaded after a portal restart still shows earlier outputs; records themselves are lost on restart (documented open question).

## Tests

- `tests/test_analysis_runs.py`: **20 new** — helpers (containment incl. symlink escape, relativize, listing cap), runner (one-per-scan gate, thread-scoped log capture), the endpoint ladder over an injected fake analyzer (done + artifact serving, failed with error + log + cleanup, `no_data` ×2, 409 while running then re-run, 404s for unknown/legacy diagnostics, feature-off and missing-extra gates, folder unresolvable builds nothing, **scan folder tree untouched**), and the real factory building an `Array2DScanAnalyzer` from a tmp tree (skips without the extra).
- Portal suite: **205 passed** (185 before) in the worktree env with the `analysis` extra.

## Hardware verification

**OWED at promotion** (listed in the 04 doc): from a browser against a real completed scan on the worker host with a read-write mount — run one 2D analyzer → figures appear in `analysis/ScanNNN/<output>/`; Plot tab shows the new `sfile`-provenance columns; re-run overwrites (spot-check a cell, `combine_first` caveat); a broken YAML → `failed` with the exception text; a device-less diagnostic → `no_data`. Nothing in this PR touches scan execution or devices.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018K1DmUzf1ZPjM4NxX2QRX3