### PR TITLE
GEECS-Console 0.28.0: R8 queue panel (running / waiting / finished, Clear queue) + BackgroundResult GUI hop

### DIFF
--- a/GEECS-Console/CHANGELOG.md
+++ b/GEECS-Console/CHANGELOG.md
@@ -17,8 +17,12 @@ semantic.
   `app/queue_panel.py::QueuePanelController`; refreshed from the existing
   1 s manager status poll when the queue-shaped fields change (plus a 5 s
   fallback), three bounded 0MQ reads on a background thread, one in
-  flight. Item summaries are pure functions tolerant of every request
-  schema version the manager's history may hold.
+  flight; a change arriving mid-fetch is fetched as soon as that fetch
+  lands, and the fallback tick re-reads the queue only (the manager's
+  history is unbounded and can only change with the status key). Item
+  summaries are pure functions tolerant of every request schema version
+  the manager's history may hold, including the named plans' keyword
+  shape (GeecsBluesky ≥ 0.73.0).
 
 ### Fixed
 

--- a/GEECS-Console/CHANGELOG.md
+++ b/GEECS-Console/CHANGELOG.md
@@ -4,6 +4,33 @@ All notable changes to GEECS-Console are documented here.  Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versioning is
 semantic.
 
+## [0.28.0] - 2026-09-02
+
+### Added
+
+- **R8 queue panel** (right column, below the now panel): what the RE
+  Manager holds — a summary line, a read-only table of the running item,
+  the waiting items (front first, any client's) and the last 10 finished
+  items with their exit status / finish time / first message line, and a
+  **Clear queue** button (confirmation modal) as the recovery verb for a
+  failed item returned to the queue front. Owned by
+  `app/queue_panel.py::QueuePanelController`; refreshed from the existing
+  1 s manager status poll when the queue-shaped fields change (plus a 5 s
+  fallback), three bounded 0MQ reads on a background thread, one in
+  flight. Item summaries are pure functions tolerant of every request
+  schema version the manager's history may hold.
+
+### Fixed
+
+- `BackgroundResult` no longer emits toward its consumer from the daemon
+  thread: the result hops onto the GUI thread through the worker's own
+  queued signal (the worker is held alive until the hop lands) and
+  `result_ready` is emitted there. A daemon-thread emission aimed at a
+  consumer QObject races the consumer's destruction and segfaulted the
+  offscreen suite once the queue panel added a fetch per status snapshot.
+  Delivery now takes two event-loop turns; consumer connections are
+  unchanged.
+
 ## [0.27.0] - 2026-09-02
 
 ### Removed

--- a/GEECS-Console/CLAUDE.md
+++ b/GEECS-Console/CLAUDE.md
@@ -3,7 +3,7 @@
 The greenfield PySide6 operator console (decided 2026-07-10).  **The screen
 map is the spec**: `Planning/cutover_strategy/01_gui_feature_inventory.md`
 (the legacy-GUI capability inventory with dispositions) and the approved
-screen-map artifact (regions R1–R7).  This package is the "one working screen" half of
+screen-map artifact (regions R1–R7, plus R8 added in 0.28.0).  This package is the "one working screen" half of
 the commit/abort checkpoint's criterion (c).
 
 ## The screen map (regions → widgets)
@@ -83,7 +83,7 @@ are prefixed by region (`r3_radio_1d`, `r5_start_button`, …).
   re-arms on set_totals so a new scan's first line always renders); data
   signals never dedupe.
 - **R7 movable panel** (middle column, below R4/R5 since 0.19.1 — the
-  right column is R6's alone) — an editable combo (catalog scan-variable names
+  right column holds R6 and R8) — an editable combo (catalog scan-variable names
   first, then `device:variable` completions from `GeecsDbCompletions`),
   readback label, set field + button — owned by
   `app/movable_panel.py::MovablePanelController` since 0.19.0 (see
@@ -94,6 +94,31 @@ are prefixed by region (`r3_radio_1d`, `r5_start_button`, …).
   `:SP` riding GEECS's native blocking set — never `geecs_python_api`'s
   ScanDevice.  The R3 axis combos auto-select the panel (the legacy
   scanner behavior), composites included.
+- **R8 queue panel** (right column, below R6, since 0.28.0) — what the
+  RE Manager holds, which R6 deliberately does not show: a summary line
+  ("Running · 2 waiting" / "Queue empty" / "manager unreachable"), a
+  read-only table (State / Item / By / Detail) of the running item,
+  the waiting items front-first (any client's — the MCP's, a
+  notebook's), and the last `HISTORY_ROWS` finished items newest-first
+  with the manager's `exit_status`, finish clock and first message
+  line, plus **Clear queue** (confirmation modal; the recovery verb for
+  the failed-item-at-front trap — a running scan is untouched).  Owned
+  by `app/queue_panel.py::QueuePanelController` (#534 controller
+  shape).  The manager ships this as data only (`queue_get` /
+  `history_get`) — the panel is the console's view; per-plan progress
+  stays R6's (the document stream), the manager has no notion of it.
+  **Refresh policy**: the R6 status poll is the trigger — the window's
+  `_on_queue_status` fans each snapshot into `on_status`, which
+  refetches (three bounded 0MQ round trips on a `BackgroundResult`
+  thread, one in flight) when the queue-shaped fields
+  (`items_in_queue` / `running_item_uid` / `re_state`) change or every
+  `FALLBACK_REFRESH_S`; a failed fetch renders "unavailable", never an
+  empty queue.  Item summaries (`summarize_item` / `summarize_request`)
+  are pure functions tolerant of every request schema version the
+  history may hold.  The client is read at refresh time
+  (`client_provider`) — the window's submitter exists before the first
+  poll.  Removing a single item needs a client verb `qs_client` does
+  not expose yet (deferred).
 
 ## Architecture rules
 
@@ -340,9 +365,23 @@ are prefixed by region (`r3_radio_1d`, `r5_start_button`, …).
   segfaults under offscreen pytest (observed directly when the idle scan
   probe emitted a `MainWindow` signal; the R7 device-set completion was
   the last such emission and moved to a `BackgroundResult` worker in
-  0.7.0 — issue #510).  `closeEvent` disconnects each window-owned
-  worker's `result_ready`; the actions-menu and now-panel controllers'
-  workers are detached inside their `dispose()` instead.
+  0.7.0 — issue #510).  **Since 0.28.0 the daemon thread does not emit
+  toward the consumer at all**: it hops the result onto the GUI thread
+  through the worker's own queued `_landed` signal (receiver = the
+  worker, held in the module's `_INFLIGHT` set until the hop lands) and
+  `_forward` re-emits `result_ready` there — a daemon-thread emission
+  aimed at *any* consumer QObject, controller or window, races that
+  consumer's destruction (Qt's C++ bookkeeping survives it, PySide's
+  Python-slot delivery does not; the queue panel's fetch landing while
+  a test window was torn down segfaulted the suite at random
+  positions).  Consumers keep connecting `result_ready`
+  `QueuedConnection`; delivery now takes two event-loop turns, so a
+  test that assumes a startup result has landed waits for it
+  (`qtbot.waitUntil`).  `HealthPoller` still emits from its thread
+  straight at the window (the pre-existing shape; move it to the same
+  hop if it ever bites).  `closeEvent` disconnects each window-owned
+  worker's `result_ready`; the actions-menu, now-panel and queue-panel
+  controllers' workers are detached inside their `dispose()` instead.
 - **Actions menu (G-actions v1)** — owned by
   `app/actions_menu.py::ActionsMenuController` since 0.18.1 (issue #534
   step 3): the window creates the QMenu (kept in `self._menus`) and the

--- a/GEECS-Console/geecs_console/app/main_window.py
+++ b/GEECS-Console/geecs_console/app/main_window.py
@@ -37,6 +37,7 @@ from PySide6.QtWidgets import (
     QPushButton,
     QRadioButton,
     QSpinBox,
+    QTableWidget,
     QWidget,
 )
 from pydantic import ValidationError
@@ -44,6 +45,7 @@ from pydantic import ValidationError
 from geecs_console.app.actions_menu import ActionsMenuController
 from geecs_console.app.movable_panel import MovablePanelController
 from geecs_console.app.now_panel import NowPanelController
+from geecs_console.app.queue_panel import QueuePanelController
 from geecs_console.app.scan_monitor import ScanMonitorController
 from geecs_console.editors.action_library_editor import open_action_library_editor
 from geecs_console.editors.save_set_editor import open_save_set_editor
@@ -299,6 +301,20 @@ class MainWindow(QMainWindow):
                 else _idle_scan_lookup
             ),
         )
+        # R8 rendering lives on QueuePanelController (app/queue_panel.py);
+        # fed by the same status poll as the pill (_on_queue_status).  The
+        # client is read at refresh time — it exists once
+        # _start_scan_monitor has built it, which is before the first poll.
+        self._queue_panel = QueuePanelController(
+            table=self.queue_table,
+            summary_label=self.queue_summary_label,
+            clear_button=self.queue_clear_button,
+            client_provider=lambda: self._submitter,
+            confirm=lambda title, message: self._ask_binary(
+                title, message, continue_label="Clear queue", abort_label="Cancel"
+            ),
+            report=self._report,
+        )
 
         # First populate quietly: a remembered experiment restored on the
         # next line makes its "No experiment selected." a lie (it used to
@@ -432,6 +448,12 @@ class MainWindow(QMainWindow):
         self.progress_bar: QProgressBar = self._child(QProgressBar, "r6_progress")
         self.scan_number_label: QLabel = self._child(QLabel, "r6_scan_number_label")
         self.log_tail: QPlainTextEdit = self._child(QPlainTextEdit, "r6_log_tail")
+        # R8 queue panel
+        self.queue_summary_label: QLabel = self._child(QLabel, "r8_summary_label")
+        self.queue_clear_button: QPushButton = self._child(
+            QPushButton, "r8_clear_button"
+        )
+        self.queue_table: QTableWidget = self._child(QTableWidget, "r8_table")
         # R7 device panel
         self.device_combo: QComboBox = self._child(QComboBox, "r7_device_combo")
         self.readback_label: QLabel = self._child(QLabel, "r7_readback_label")
@@ -833,6 +855,7 @@ class MainWindow(QMainWindow):
         """
         self._queue_status = status
         self._apply_status_state(status)
+        self._queue_panel.on_status(status)
         # Gating refresh on EVERY snapshot, transition or not: _scanning()
         # reads the stored snapshot, so a poll that merely agrees with a
         # pill the document stream already set still changes what
@@ -981,6 +1004,9 @@ class MainWindow(QMainWindow):
         now = getattr(self, "_now", None)
         if now is not None:
             now.dispose()
+        queue_panel = getattr(self, "_queue_panel", None)
+        if queue_panel is not None:
+            queue_panel.dispose()
         super().closeEvent(event)
 
     # ------------------------------------------------------------------

--- a/GEECS-Console/geecs_console/app/queue_panel.py
+++ b/GEECS-Console/geecs_console/app/queue_panel.py
@@ -28,7 +28,7 @@ from __future__ import annotations
 
 import logging
 import time
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from datetime import datetime
 from typing import Any, Callable, Optional
 
@@ -58,7 +58,9 @@ FALLBACK_REFRESH_S = 5.0
 COLUMNS = ("State", "Item", "By", "Detail")
 
 #: Screen-map palette (see app/style.qss header; a shared palette module
-#: is a recorded deferral — now_panel.py carries the same values).
+#: is a recorded deferral — now_panel.py carries its own copy).  Grey is
+#: the QSS ``--w-dim`` text tone, not the pill's ``--w-line`` dot grey:
+#: this one colors words.
 _COLOR_GREY = "#6b7681"
 _COLOR_GREEN = "#2f9e63"
 _COLOR_AMBER = "#d9a21b"
@@ -79,11 +81,16 @@ _STATE_COLORS = {
 
 @dataclass(frozen=True)
 class QueueSnapshot:
-    """One fetch of the manager's queue-shaped data (or why it failed)."""
+    """One fetch of the manager's queue-shaped data (or why it failed).
+
+    ``history`` is ``None`` when the fetch deliberately skipped it (the
+    fallback tick re-reads the queue only — the history can change only
+    when the status key does, and the manager's history is unbounded).
+    """
 
     running: Optional[dict] = None
     queued: list[dict] = field(default_factory=list)
-    history: list[dict] = field(default_factory=list)
+    history: Optional[list[dict]] = None
     error: str = ""
 
 
@@ -196,10 +203,20 @@ def summarize_item(item: dict) -> str:
     """
     name = str(item.get("name") or "")
     args = item.get("args") or []
+    kwargs = item.get("kwargs") or {}
     if name == "geecs_scan_request_plan" and args and isinstance(args[0], dict):
         return summarize_request(args[0])
     if name == "geecs_run_action_plan" and args:
         return f"Action: {args[0]}"
+    # Forward-compatible with the named plans (GeecsBluesky ≥ 0.73.0:
+    # geecs_noscan_plan / geecs_scan_plan / geecs_optimize_plan take the
+    # request's parts as keyword arguments — axes / capture / optimization).
+    if (
+        name.startswith("geecs_")
+        and isinstance(kwargs, dict)
+        and any(key in kwargs for key in ("capture", "axes", "optimization"))
+    ):
+        return summarize_request(kwargs)
     kind = str(item.get("item_type") or "item")
     return f"{name or '?'} ({kind})"
 
@@ -257,7 +274,8 @@ def build_rows(
                 f"#{position}",
             )
         )
-    recent = list(snapshot.history)[-history_rows:] if history_rows > 0 else []
+    history = snapshot.history or []
+    recent = list(history)[-history_rows:] if history_rows > 0 else []
     rows.extend(_history_row(item) for item in reversed(recent))
     return rows
 
@@ -329,6 +347,12 @@ class QueuePanelController(QObject):
         self._last_refresh_at = float("-inf")
         self._items_in_queue = 0
         self._fetch_inflight = False
+        #: A refresh asked for while one was in flight (and whether it
+        #: wants the history) — honoured as soon as the in-flight one lands.
+        self._refresh_pending = False
+        self._pending_history = False
+        #: The last fetched history (a queue-only refresh reuses it).
+        self._history: list[dict] = []
         self._clear_inflight = False
         self._disposed = False
 
@@ -385,14 +409,36 @@ class QueuePanelController(QObject):
         self._items_in_queue = int(status.items_in_queue or 0)
         self._refresh_clear_enabled()
         key = (status.items_in_queue, status.running_item_uid, status.re_state)
-        stale = time.monotonic() - self._last_refresh_at >= self._fallback_refresh_s
-        if key != self._last_key or stale:
+        if key != self._last_key:
+            # The key is what the history can change on (an item finished
+            # or started): full refresh.  Committed before the call — a
+            # refresh that cannot start now is queued behind the one in
+            # flight (``_refresh_pending``), never lost.
             self._last_key = key
-            self.refresh()
+            self.refresh(include_history=True)
+        elif time.monotonic() - self._last_refresh_at >= self._fallback_refresh_s:
+            # Nothing the status shows changed: re-read the queue only (a
+            # reorder by another client); the cached history stands.
+            self.refresh(include_history=False)
 
-    def refresh(self) -> None:
-        """Fetch the queue on a daemon thread (skipped while one is in flight)."""
-        if self._disposed or self._fetch_inflight:
+    def refresh(self, *, include_history: bool = True) -> None:
+        """Fetch the queue on a daemon thread.
+
+        While a fetch is in flight the request is remembered and honoured
+        when that fetch lands (``_apply_snapshot``), so a queue change
+        arriving mid-fetch is never dropped until the fallback tick.
+
+        Parameters
+        ----------
+        include_history : bool
+            Also re-read the manager's (unbounded) history; ``False``
+            re-renders with the cached one.
+        """
+        if self._disposed:
+            return
+        if self._fetch_inflight:
+            self._refresh_pending = True
+            self._pending_history = self._pending_history or include_history
             return
         client = self._client_provider()
         if client is None:
@@ -405,12 +451,21 @@ class QueuePanelController(QObject):
                 return QueueSnapshot(
                     running=client.running_item(),
                     queued=list(client.queue_items()),
-                    history=list(client.history_items()),
+                    history=list(client.history_items()) if include_history else None,
                 )
             except Exception as exc:  # noqa: BLE001 — rendered, never raised
                 return QueueSnapshot(error=str(exc) or exc.__class__.__name__)
 
         self._fetch_worker.run_async(fetch, name="console-queue-fetch")
+
+    def _run_pending_refresh(self) -> None:
+        """Start the refresh that was asked for while the last one was in flight."""
+        if not self._refresh_pending:
+            return
+        include_history = self._pending_history
+        self._refresh_pending = False
+        self._pending_history = False
+        self.refresh(include_history=include_history)
 
     # ------------------------------------------------------------------
     # Rendering (GUI thread)
@@ -424,10 +479,16 @@ class QueuePanelController(QObject):
             return
         if snapshot.error:
             self._render_message(f"Queue: unavailable ({snapshot.error})")
+            self._run_pending_refresh()
             return
-        rows = build_rows(snapshot, history_rows=self._history_rows)
+        if snapshot.history is not None:
+            self._history = list(snapshot.history)
+        rows = build_rows(
+            replace(snapshot, history=self._history), history_rows=self._history_rows
+        )
         self._render_rows(rows)
         self._summary_label.setText(summarize_counts(snapshot))
+        self._run_pending_refresh()
 
     def _render_rows(self, rows: list[QueueRow]) -> None:
         table = self._table

--- a/GEECS-Console/geecs_console/app/queue_panel.py
+++ b/GEECS-Console/geecs_console/app/queue_panel.py
@@ -1,0 +1,528 @@
+"""The R8 queue panel: what the manager holds — running, waiting, finished.
+
+The RE Manager exposes the queue as data (``queue_get`` / ``history_get``)
+and ships no operator view of it; this panel is the console's.  It
+renders three things the R6 now panel deliberately does not: the items
+*waiting* behind the running scan (any client's — the MCP's, a
+notebook's), the recent *history* with each item's exit status, and the
+one recovery verb the queue needs, **Clear queue** (the failed-item-at-
+front trap: a failed plan returns to the queue front and would re-run
+before the next submission — see ``qs_client``).
+
+Refresh policy: the 1 s manager status poll the scan monitor already
+runs is the trigger.  A refresh (three bounded 0MQ round trips on a
+daemon thread) runs when the snapshot's queue-shaped fields change
+(``items_in_queue`` / ``running_item_uid`` / ``re_state``) and, as a
+fallback for edits that change nothing the status shows (a reorder by
+another client), every :data:`FALLBACK_REFRESH_S`.  One fetch in flight
+at a time; a fetch that fails renders as "unavailable", never as an
+empty queue.
+
+Controller rules (#534 checklist): ``QObject`` with **no Qt parent**;
+injected widgets and callables, never the window; daemon threads emit
+on worker-owned signals connected ``QueuedConnection``; an idempotent
+:meth:`dispose` the window's ``closeEvent`` calls.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any, Callable, Optional
+
+from PySide6.QtCore import QObject, Qt, Slot
+from PySide6.QtGui import QColor
+from PySide6.QtWidgets import (
+    QAbstractItemView,
+    QHeaderView,
+    QLabel,
+    QPushButton,
+    QTableWidget,
+    QTableWidgetItem,
+)
+
+from geecs_console.services.background import BackgroundResult
+
+logger = logging.getLogger(__name__)
+
+#: Finished items shown (newest first).  The manager's history is
+#: oldest-first and grows for the life of its Redis store.
+HISTORY_ROWS = 10
+
+#: Fallback refresh cadence (seconds) when the status poll shows no change.
+FALLBACK_REFRESH_S = 5.0
+
+#: Table columns, left to right.
+COLUMNS = ("State", "Item", "By", "Detail")
+
+#: Screen-map palette (see app/style.qss header; a shared palette module
+#: is a recorded deferral — now_panel.py carries the same values).
+_COLOR_GREY = "#6b7681"
+_COLOR_GREEN = "#2f9e63"
+_COLOR_AMBER = "#d9a21b"
+_COLOR_RED = "#c4453a"
+
+#: Row state → State-cell color.  ``exit_status`` values are the
+#: manager's (completed / failed / stopped / aborted / halted / unknown).
+_STATE_COLORS = {
+    "running": _COLOR_GREEN,
+    "completed": _COLOR_GREEN,
+    "queued": _COLOR_GREY,
+    "stopped": _COLOR_AMBER,
+    "failed": _COLOR_RED,
+    "aborted": _COLOR_RED,
+    "halted": _COLOR_RED,
+}
+
+
+@dataclass(frozen=True)
+class QueueSnapshot:
+    """One fetch of the manager's queue-shaped data (or why it failed)."""
+
+    running: Optional[dict] = None
+    queued: list[dict] = field(default_factory=list)
+    history: list[dict] = field(default_factory=list)
+    error: str = ""
+
+
+@dataclass(frozen=True)
+class QueueRow:
+    """One rendered table row."""
+
+    state: str
+    item: str
+    user: str
+    detail: str = ""
+
+
+# ----------------------------------------------------------------------
+# Pure summarizers (tested without Qt)
+# ----------------------------------------------------------------------
+
+
+def _fmt(value: Any) -> str:
+    """Format a position number compactly (``0.5``, ``10``, ``1e-06``)."""
+    try:
+        return f"{float(value):g}"
+    except (TypeError, ValueError):
+        return str(value)
+
+
+def _summarize_axis(axis: dict) -> str:
+    """Render one ``ScanAxis`` dict: ``jet_x 0 → 5 step 0.5`` or ``jet_x [4 values]``."""
+    variable = str(axis.get("variable") or "?")
+    positions = axis.get("positions") or {}
+    if isinstance(positions, dict) and "values" in positions:
+        values = positions.get("values") or []
+        return f"{variable} [{len(values)} values]"
+    if isinstance(positions, dict) and "start" in positions:
+        return (
+            f"{variable} {_fmt(positions.get('start'))} → "
+            f"{_fmt(positions.get('end'))} step {_fmt(positions.get('step'))}"
+        )
+    return variable
+
+
+def _shots_per_step(request: dict) -> Optional[int]:
+    """The request's shots per step (v2+ ``capture`` block, else the v1 flat key)."""
+    capture = request.get("capture")
+    raw = (
+        capture.get("shots_per_step")
+        if isinstance(capture, dict)
+        else request.get("shots_per_step")
+    )
+    try:
+        return int(raw) if raw is not None else None
+    except (TypeError, ValueError):
+        return None
+
+
+def summarize_request(request: dict) -> str:
+    """One line for a ``ScanRequest`` dict as the manager stored it.
+
+    Tolerant of every schema version the queue may hold — a history item
+    outlives the console that submitted it.
+
+    Parameters
+    ----------
+    request : dict
+        The plan's first positional argument (the request JSON).
+
+    Returns
+    -------
+    str
+        e.g. ``jet_x 0 → 5 step 0.5 · 10 shots/step — "focus check"``.
+    """
+    mode = str(request.get("mode") or "").lower()
+    axes = [a for a in (request.get("axes") or []) if isinstance(a, dict)]
+    if mode == "optimize" or request.get("optimization"):
+        spec = request.get("optimization") or {}
+        objectives = spec.get("objectives") if isinstance(spec, dict) else None
+        names = ", ".join(objectives) if isinstance(objectives, dict) else ""
+        head = f"Optimize {names}".rstrip()
+    elif axes:
+        head = " × ".join(_summarize_axis(a) for a in axes)
+    else:
+        head = "No-scan"
+    parts = [head]
+    shots = _shots_per_step(request)
+    if shots is not None:
+        parts.append(f"{shots} shots" if head == "No-scan" else f"{shots} shots/step")
+    if request.get("background"):
+        parts.insert(0, "Background")
+    line = " · ".join(parts)
+    description = str(request.get("description") or "").strip()
+    if description:
+        line = f'{line} — "{description}"'
+    return line
+
+
+def summarize_item(item: dict) -> str:
+    """One line for a manager queue/history item.
+
+    Parameters
+    ----------
+    item : dict
+        The manager's item shape (``name`` / ``args`` / ``kwargs`` /
+        ``item_type`` / ``user`` / ``item_uid`` [/ ``result``]).
+
+    Returns
+    -------
+    str
+        The GEECS plans render by their arguments (a scan by its request,
+        an action by its name); anything else by its plan name.
+    """
+    name = str(item.get("name") or "")
+    args = item.get("args") or []
+    if name == "geecs_scan_request_plan" and args and isinstance(args[0], dict):
+        return summarize_request(args[0])
+    if name == "geecs_run_action_plan" and args:
+        return f"Action: {args[0]}"
+    kind = str(item.get("item_type") or "item")
+    return f"{name or '?'} ({kind})"
+
+
+def _clock(epoch: Any) -> str:
+    """``HH:MM:SS`` local time for a manager epoch timestamp ('' when absent)."""
+    try:
+        return datetime.fromtimestamp(float(epoch)).strftime("%H:%M:%S")
+    except (TypeError, ValueError, OSError, OverflowError):
+        return ""
+
+
+def _history_row(item: dict) -> QueueRow:
+    """Render one finished item: exit status, finish time, first message line."""
+    result = item.get("result") or {}
+    if not isinstance(result, dict):
+        result = {}
+    status = str(result.get("exit_status") or "unknown")
+    when = _clock(result.get("time_stop"))
+    message = str(result.get("msg") or "").strip()
+    first_line = message.splitlines()[0] if message else ""
+    detail = " · ".join(part for part in (when, first_line) if part)
+    return QueueRow(status, summarize_item(item), str(item.get("user") or ""), detail)
+
+
+def build_rows(
+    snapshot: QueueSnapshot, *, history_rows: int = HISTORY_ROWS
+) -> list[QueueRow]:
+    """Order the snapshot for display: running, waiting (front first), finished (newest first).
+
+    Parameters
+    ----------
+    snapshot : QueueSnapshot
+        A successful fetch (``error`` is not consulted here).
+    history_rows : int
+        How many finished items to keep.
+
+    Returns
+    -------
+    list of QueueRow
+        The table rows, top to bottom.
+    """
+    rows: list[QueueRow] = []
+    if snapshot.running:
+        item = snapshot.running
+        rows.append(
+            QueueRow("running", summarize_item(item), str(item.get("user") or ""))
+        )
+    for position, item in enumerate(snapshot.queued, start=1):
+        rows.append(
+            QueueRow(
+                "queued",
+                summarize_item(item),
+                str(item.get("user") or ""),
+                f"#{position}",
+            )
+        )
+    recent = list(snapshot.history)[-history_rows:] if history_rows > 0 else []
+    rows.extend(_history_row(item) for item in reversed(recent))
+    return rows
+
+
+def summarize_counts(snapshot: QueueSnapshot) -> str:
+    """The one-line summary above the table (``Running · 2 waiting``)."""
+    parts = []
+    if snapshot.running:
+        parts.append("Running")
+    waiting = len(snapshot.queued)
+    if waiting:
+        parts.append(f"{waiting} waiting")
+    if not parts:
+        return "Queue empty"
+    return " · ".join(parts)
+
+
+# ----------------------------------------------------------------------
+# Controller
+# ----------------------------------------------------------------------
+
+
+class QueuePanelController(QObject):
+    """Render the R8 queue region on behalf of the main window.
+
+    Parameters
+    ----------
+    table, summary_label, clear_button : QWidget
+        The R8 widgets (bound from the ``.ui`` by the window, which
+        remains their attribute home for tests and tooltips).
+    client_provider : callable
+        Returns the window's current queue client (``None`` before one
+        exists).  Called on the GUI thread; only the returned client's
+        read verbs run on the daemon thread.
+    confirm : callable
+        ``confirm(title, message) -> bool`` — the Clear-queue question
+        (the window's ``_ask_binary``); ``False`` leaves the queue as-is.
+    report : callable
+        Status-bar/log-tail line sink (the window's ``_report``).
+    history_rows : int
+        Finished items shown.
+    fallback_refresh_s : float
+        Refresh cadence when the status poll shows no queue change.
+    """
+
+    def __init__(
+        self,
+        *,
+        table: QTableWidget,
+        summary_label: QLabel,
+        clear_button: QPushButton,
+        client_provider: Callable[[], Any],
+        confirm: Callable[[str, str], bool],
+        report: Callable[[str], None],
+        history_rows: int = HISTORY_ROWS,
+        fallback_refresh_s: float = FALLBACK_REFRESH_S,
+    ) -> None:
+        super().__init__()
+        self._table = table
+        self._summary_label = summary_label
+        self._clear_button = clear_button
+        self._client_provider = client_provider
+        self._confirm = confirm
+        self._report = report
+        self._history_rows = history_rows
+        self._fallback_refresh_s = fallback_refresh_s
+
+        self._last_key: Optional[tuple] = None
+        self._last_refresh_at = float("-inf")
+        self._items_in_queue = 0
+        self._fetch_inflight = False
+        self._clear_inflight = False
+        self._disposed = False
+
+        self._fetch_worker = BackgroundResult()
+        self._fetch_worker.result_ready.connect(
+            self._apply_snapshot, Qt.ConnectionType.QueuedConnection
+        )
+        self._clear_worker = BackgroundResult()
+        self._clear_worker.result_ready.connect(
+            self._apply_clear_result, Qt.ConnectionType.QueuedConnection
+        )
+        self._clear_button.clicked.connect(self._on_clear_clicked)
+        self._clear_button.setEnabled(False)
+
+        self._setup_table()
+        self._render_message("Queue: waiting for the manager")
+
+    def _setup_table(self) -> None:
+        """Read-only, row-selecting table with the Item column taking the width."""
+        table = self._table
+        table.setColumnCount(len(COLUMNS))
+        table.setHorizontalHeaderLabels(list(COLUMNS))
+        table.setRowCount(0)
+        table.setEditTriggers(QAbstractItemView.EditTrigger.NoEditTriggers)
+        table.setSelectionBehavior(QAbstractItemView.SelectionBehavior.SelectRows)
+        table.setSelectionMode(QAbstractItemView.SelectionMode.SingleSelection)
+        table.setWordWrap(False)
+        table.verticalHeader().setVisible(False)
+        header = table.horizontalHeader()
+        header.setStretchLastSection(False)
+        header.setSectionResizeMode(QHeaderView.ResizeMode.ResizeToContents)
+        header.setSectionResizeMode(1, QHeaderView.ResizeMode.Stretch)
+
+    # ------------------------------------------------------------------
+    # Inputs
+    # ------------------------------------------------------------------
+
+    def on_status(self, status: Any) -> None:
+        """Consume one manager status snapshot (GUI thread; the poll's fan-out).
+
+        Parameters
+        ----------
+        status : QueueStatus
+            The scan monitor's polled snapshot.
+        """
+        if self._disposed:
+            return
+        if not status.connected:
+            self._last_key = None
+            self._items_in_queue = 0
+            self._clear_button.setEnabled(False)
+            self._render_message("Queue: manager unreachable")
+            return
+        self._items_in_queue = int(status.items_in_queue or 0)
+        self._refresh_clear_enabled()
+        key = (status.items_in_queue, status.running_item_uid, status.re_state)
+        stale = time.monotonic() - self._last_refresh_at >= self._fallback_refresh_s
+        if key != self._last_key or stale:
+            self._last_key = key
+            self.refresh()
+
+    def refresh(self) -> None:
+        """Fetch the queue on a daemon thread (skipped while one is in flight)."""
+        if self._disposed or self._fetch_inflight:
+            return
+        client = self._client_provider()
+        if client is None:
+            return
+        self._fetch_inflight = True
+        self._last_refresh_at = time.monotonic()
+
+        def fetch() -> QueueSnapshot:
+            try:
+                return QueueSnapshot(
+                    running=client.running_item(),
+                    queued=list(client.queue_items()),
+                    history=list(client.history_items()),
+                )
+            except Exception as exc:  # noqa: BLE001 — rendered, never raised
+                return QueueSnapshot(error=str(exc) or exc.__class__.__name__)
+
+        self._fetch_worker.run_async(fetch, name="console-queue-fetch")
+
+    # ------------------------------------------------------------------
+    # Rendering (GUI thread)
+    # ------------------------------------------------------------------
+
+    @Slot(object)
+    def _apply_snapshot(self, snapshot: object) -> None:
+        """Render one fetch result (queued delivery from the daemon thread)."""
+        self._fetch_inflight = False
+        if self._disposed or not isinstance(snapshot, QueueSnapshot):
+            return
+        if snapshot.error:
+            self._render_message(f"Queue: unavailable ({snapshot.error})")
+            return
+        rows = build_rows(snapshot, history_rows=self._history_rows)
+        self._render_rows(rows)
+        self._summary_label.setText(summarize_counts(snapshot))
+
+    def _render_rows(self, rows: list[QueueRow]) -> None:
+        table = self._table
+        table.setRowCount(len(rows))
+        for index, row in enumerate(rows):
+            cells = (row.state, row.item, row.user, row.detail)
+            for column, text in enumerate(cells):
+                cell = QTableWidgetItem(text)
+                cell.setToolTip(text)
+                if column == 0:
+                    color = _STATE_COLORS.get(row.state.lower(), _COLOR_GREY)
+                    cell.setForeground(QColor(color))
+                table.setItem(index, column, cell)
+
+    def _render_message(self, text: str) -> None:
+        """Replace the table contents with nothing and say why in the summary."""
+        self._table.setRowCount(0)
+        self._summary_label.setText(text)
+
+    def _refresh_clear_enabled(self) -> None:
+        self._clear_button.setEnabled(
+            self._items_in_queue > 0 and not self._clear_inflight
+        )
+
+    # ------------------------------------------------------------------
+    # Clear queue
+    # ------------------------------------------------------------------
+
+    @Slot()
+    def _on_clear_clicked(self) -> None:
+        """Ask, then remove every waiting item on a daemon thread."""
+        if self._disposed or self._clear_inflight:
+            return
+        client = self._client_provider()
+        if client is None:
+            return
+        count = self._items_in_queue
+        if not self._confirm(
+            "Clear queue",
+            (
+                f"Remove all {count} waiting item(s) from the queue? A running "
+                "scan is not affected — use Stop for that."
+            ),
+        ):
+            return
+        self._clear_inflight = True
+        self._refresh_clear_enabled()
+
+        def clear() -> tuple[bool, str]:
+            try:
+                return client.clear_queue()
+            except Exception as exc:  # noqa: BLE001 — rendered, never raised
+                return False, str(exc) or exc.__class__.__name__
+
+        self._clear_worker.run_async(clear, name="console-queue-clear")
+
+    @Slot(object)
+    def _apply_clear_result(self, result: object) -> None:
+        """Report the clear's outcome and force a refresh (queued delivery)."""
+        self._clear_inflight = False
+        if self._disposed:
+            return
+        ok, message = result if isinstance(result, tuple) else (False, str(result))
+        self._report(message if ok else f"Clear queue failed: {message}")
+        # The next status poll re-derives the button; the queue itself is
+        # re-read now rather than waiting for the poll to notice.
+        self._last_key = None
+        self.refresh()
+
+    # ------------------------------------------------------------------
+    # Teardown
+    # ------------------------------------------------------------------
+
+    def dispose(self) -> None:
+        """Sever every controller → window reference; idempotent.
+
+        Detaches both workers so a straggling result lands nowhere and
+        replaces the injected closures — the only Python edges back to
+        the window — so the dead window is freed by refcount.
+        """
+        if self._disposed:
+            return
+        self._disposed = True
+        for worker, slot in (
+            (self._fetch_worker, self._apply_snapshot),
+            (self._clear_worker, self._apply_clear_result),
+        ):
+            try:
+                worker.result_ready.disconnect(slot)
+            except (RuntimeError, TypeError):
+                pass
+        try:
+            self._clear_button.clicked.disconnect(self._on_clear_clicked)
+        except (RuntimeError, TypeError):
+            pass
+        self._client_provider = lambda: None
+        self._confirm = lambda title, message: False
+        self._report = lambda message: None

--- a/GEECS-Console/geecs_console/app/style.qss
+++ b/GEECS-Console/geecs_console/app/style.qss
@@ -259,6 +259,32 @@ QListWidget::item:hover {
     background-color: #f0f5f9;
 }
 
+QTableWidget {
+    background-color: #ffffff;
+    border: 1px solid #b9c0c7;
+    border-radius: 3px;
+    outline: none;
+    gridline-color: #eef1f3;
+}
+
+QTableWidget::item {
+    padding: 2px 6px;
+    color: #2a323a;
+}
+
+QTableWidget::item:selected {
+    background-color: #dcebf5;
+    color: #2a323a;
+}
+
+QHeaderView::section {
+    background-color: #f3f5f7;
+    color: #6b7681;
+    border: none;
+    border-bottom: 1px solid #b9c0c7;
+    padding: 3px 6px;
+}
+
 /* ------------------------------------------------------------------ */
 /* Radios: accent when checked                                        */
 /* ------------------------------------------------------------------ */

--- a/GEECS-Console/geecs_console/app/tooltips.py
+++ b/GEECS-Console/geecs_console/app/tooltips.py
@@ -202,6 +202,21 @@ OPERATOR_TOOLTIPS: dict[str, str] = {
         "is the last scan found in today's data folder."
     ),
     "log_tail": "The most recent scan-engine and console messages.",
+    "queue_summary_label": (
+        "What the scan manager holds: the running item, items waiting "
+        "behind it, and the last few finished ones."
+    ),
+    "queue_table": (
+        "Running, waiting (front first), then finished items newest first "
+        "with their exit status. Waiting items run in order once the "
+        "current one ends."
+    ),
+    "queue_clear_button": (
+        "Remove every waiting item from the queue after a confirmation. "
+        "The running scan is not affected (use Stop for that). A failed "
+        "scan returns to the queue front and would re-run — this is how "
+        "you drop it."
+    ),
     # R7 device panel
     "device_combo": (
         "Type or pick 'DeviceName:Variable Name' to watch its live "

--- a/GEECS-Console/geecs_console/app/ui/main_window.ui
+++ b/GEECS-Console/geecs_console/app/ui/main_window.ui
@@ -852,7 +852,7 @@
      </item>
      <!-- Right column: R6 now panel (R7 moved to the middle column, 0.19.1) -->
      <item>
-      <layout class="QVBoxLayout" name="right_column">
+      <layout class="QVBoxLayout" name="right_column" stretch="3,2">
         <property name="spacing">
          <number>8</number>
         </property>
@@ -910,6 +910,63 @@
             </property>
             <property name="maximumBlockCount">
              <number>200</number>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <!-- R8: queue panel (running / waiting / finished items on the manager) -->
+       <item>
+        <widget class="QGroupBox" name="r8_group">
+         <property name="title">
+          <string>QUEUE</string>
+         </property>
+         <layout class="QVBoxLayout" name="r8_layout">
+          <property name="spacing">
+           <number>8</number>
+          </property>
+          <item>
+           <layout class="QHBoxLayout" name="r8_summary_layout">
+            <item>
+             <widget class="QLabel" name="r8_summary_label">
+              <property name="text">
+               <string>Queue: waiting for the manager</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <spacer name="r8_summary_spacer">
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>20</width>
+                <height>20</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+            <item>
+             <widget class="QPushButton" name="r8_clear_button">
+              <property name="text">
+               <string>Clear queue</string>
+              </property>
+              <property name="enabled">
+               <bool>false</bool>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+          <item>
+           <widget class="QTableWidget" name="r8_table">
+            <property name="minimumSize">
+             <size>
+              <width>0</width>
+              <height>120</height>
+             </size>
             </property>
            </widget>
           </item>

--- a/GEECS-Console/geecs_console/services/background.py
+++ b/GEECS-Console/geecs_console/services/background.py
@@ -12,11 +12,12 @@ in the issue #534 slimming (step 1).
 
 from __future__ import annotations
 
+import functools
 import logging
 import threading
-from typing import TYPE_CHECKING, Callable
+from typing import TYPE_CHECKING, Callable, Optional
 
-from PySide6.QtCore import QObject, Signal, Slot
+from PySide6.QtCore import QObject, Qt, QTimer, Signal, Slot
 
 if TYPE_CHECKING:
     from geecs_console.services.health import HealthProbe
@@ -24,20 +25,47 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+#: Workers with a call in flight, held on the GUI thread until the result
+#: has landed there (see ``BackgroundResult._forward``).  The daemon
+#: thread's one cross-thread emission targets the worker itself, so the
+#: worker must outlive that emission whatever the consumer does meanwhile.
+_INFLIGHT: set = set()
+
+#: Sentinel routed through the GUI hop when the callable raised (no
+#: ``result_ready`` emission, but the in-flight hold is still released).
+_FAILED = object()
+
+
 class BackgroundResult(QObject):
     """Runs one blocking callable on a daemon thread and reports its result.
 
     The ``HealthPoller`` shape, generalized: the worker lives on the
     GUI thread, each :meth:`run_async` call spawns a short-lived daemon
-    thread, and the result comes back through the queued
-    :attr:`result_ready` signal.  Crucially the daemon thread emits on
-    *this worker*, never on the main window — emitting a window-owned
-    signal from a daemon thread races window teardown and segfaults under
-    offscreen pytest (observed with the idle scan-number probe).
+    thread, and the result comes back through :attr:`result_ready`,
+    **emitted on the GUI thread**.  The daemon thread never emits toward
+    the consumer: it hops the result onto the GUI thread through the
+    worker's own queued ``_landed`` signal (receiver = this worker, held
+    alive in :data:`_INFLIGHT` until the hop completes), and
+    :meth:`_forward` re-emits ``result_ready`` there.  Emitting from a
+    daemon thread straight at a consumer QObject races the consumer's
+    destruction — Qt's C++ connection bookkeeping survives that, PySide's
+    Python-slot delivery does not, and it segfaults under offscreen pytest
+    (first seen with a window-owned signal and the idle scan-number probe;
+    again in 0.28.0 with a controller-owned slot, the queue panel's fetch
+    landing while a test window was torn down).  Consumers connect
+    ``result_ready`` ``QueuedConnection`` as before; it now merely
+    defers the call by one event-loop turn.
     """
 
     result_ready = Signal(object)
     """Carries the callable's return value, one emission per finished call."""
+
+    _landed = Signal(object)
+    """The daemon thread → GUI thread hop (internal; receiver = self)."""
+
+    def __init__(self, parent: Optional[QObject] = None) -> None:
+        super().__init__(parent)
+        self._landed.connect(self._forward, Qt.ConnectionType.QueuedConnection)
 
     def run_async(self, func: Callable[[], object], name: str) -> None:
         """Run *func* on a fresh daemon thread and emit its result.
@@ -51,19 +79,32 @@ class BackgroundResult(QObject):
         name : str
             The daemon thread's name (debugging).
         """
+        _INFLIGHT.add(self)
         threading.Thread(target=self._run, args=(func,), name=name, daemon=True).start()
 
     def _run(self, func: Callable[[], object]) -> None:
-        """Call *func* (on the daemon thread) and emit the result."""
+        """Call *func* (on the daemon thread) and hop the result to the GUI thread."""
         try:
             result = func()
         except Exception as exc:  # noqa: BLE001 — background work is best-effort
             logger.info("background call failed: %s", exc)
-            return
+            result = _FAILED
         try:
-            self.result_ready.emit(result)
+            self._landed.emit(result)
         except RuntimeError:
             pass  # the worker was deleted while the call ran
+
+    @Slot(object)
+    def _forward(self, result: object) -> None:
+        """Re-emit on the GUI thread and release the in-flight hold (deferred).
+
+        The hold is released one event-loop turn later rather than here:
+        dropping the last reference to a QObject from inside its own slot
+        would delete the C++ object under the running metacall.
+        """
+        QTimer.singleShot(0, functools.partial(_INFLIGHT.discard, self))
+        if result is not _FAILED:
+            self.result_ready.emit(result)
 
 
 class HealthPoller(QObject):

--- a/GEECS-Console/geecs_console/services/background.py
+++ b/GEECS-Console/geecs_console/services/background.py
@@ -25,11 +25,27 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-#: Workers with a call in flight, held on the GUI thread until the result
-#: has landed there (see ``BackgroundResult._forward``).  The daemon
-#: thread's one cross-thread emission targets the worker itself, so the
-#: worker must outlive that emission whatever the consumer does meanwhile.
-_INFLIGHT: set = set()
+#: Workers with calls in flight (worker → count), held on the GUI thread
+#: until each result has landed there (see ``BackgroundResult._forward``).
+#: The daemon thread's one cross-thread emission targets the worker
+#: itself, so the worker must outlive that emission whatever the consumer
+#: does meanwhile.  A count, not a set: one worker may carry overlapping
+#: calls (the now panel's per-experiment probes across an experiment
+#: switch), and the first landing must not release the second's hold.
+_INFLIGHT: dict = {}
+
+
+def _hold(worker: "BackgroundResult") -> None:
+    _INFLIGHT[worker] = _INFLIGHT.get(worker, 0) + 1
+
+
+def _release(worker: "BackgroundResult") -> None:
+    remaining = _INFLIGHT.get(worker, 0) - 1
+    if remaining > 0:
+        _INFLIGHT[worker] = remaining
+    else:
+        _INFLIGHT.pop(worker, None)
+
 
 #: Sentinel routed through the GUI hop when the callable raised (no
 #: ``result_ready`` emission, but the in-flight hold is still released).
@@ -79,7 +95,7 @@ class BackgroundResult(QObject):
         name : str
             The daemon thread's name (debugging).
         """
-        _INFLIGHT.add(self)
+        _hold(self)
         threading.Thread(target=self._run, args=(func,), name=name, daemon=True).start()
 
     def _run(self, func: Callable[[], object]) -> None:
@@ -92,7 +108,10 @@ class BackgroundResult(QObject):
         try:
             self._landed.emit(result)
         except RuntimeError:
-            pass  # the worker was deleted while the call ran
+            # A Qt-parented worker was deleted with its parent while the
+            # call ran (the hold protects unparented workers only): drop
+            # the dead wrapper's hold so the registry does not grow.
+            _INFLIGHT.pop(self, None)
 
     @Slot(object)
     def _forward(self, result: object) -> None:
@@ -102,7 +121,7 @@ class BackgroundResult(QObject):
         dropping the last reference to a QObject from inside its own slot
         would delete the C++ object under the running metacall.
         """
-        QTimer.singleShot(0, functools.partial(_INFLIGHT.discard, self))
+        QTimer.singleShot(0, functools.partial(_release, self))
         if result is not _FAILED:
             self.result_ready.emit(result)
 

--- a/GEECS-Console/pyproject.toml
+++ b/GEECS-Console/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-console"
-version = "0.27.0"
+version = "0.28.0"
 description = "Greenfield PySide6 operator console for GEECS (Bluesky/gateway architecture)"
 authors = ["Sam Barber <sbarber@lbl.gov>"]
 readme = "README.md"

--- a/GEECS-Console/tests/test_background.py
+++ b/GEECS-Console/tests/test_background.py
@@ -1,0 +1,99 @@
+"""The BackgroundResult GUI hop (services/background.py, 0.28.0).
+
+The daemon thread never emits toward the consumer: the result hops onto
+the GUI thread through the worker's own queued signal and ``result_ready``
+is emitted there.  These pin the properties the mechanism exists for —
+where the consumer's slot runs, that a raising callable still releases
+the in-flight hold, that overlapping calls on one worker keep the hold
+until the last one lands, and that a consumer dropped mid-flight is safe.
+"""
+
+from __future__ import annotations
+
+import gc
+import threading
+
+from PySide6.QtCore import QObject, Qt, Slot
+
+from geecs_console.services import background
+from geecs_console.services.background import BackgroundResult
+
+
+class Consumer(QObject):
+    """A throwaway receiver recording the thread its slot ran on."""
+
+    def __init__(self):
+        super().__init__()
+        self.results: list = []
+        self.threads: list[int] = []
+
+    @Slot(object)
+    def take(self, result):
+        self.results.append(result)
+        self.threads.append(threading.get_ident())
+
+
+def _drain(qtbot, predicate, timeout=3000):
+    qtbot.waitUntil(predicate, timeout=timeout)
+
+
+class TestGuiHop:
+    def test_result_ready_is_emitted_on_the_gui_thread(self, qtbot):
+        worker = BackgroundResult()
+        consumer = Consumer()
+        # A DIRECT connection runs the slot on the *emitting* thread — so
+        # the recorded thread is where result_ready was emitted from.
+        worker.result_ready.connect(consumer.take, Qt.ConnectionType.DirectConnection)
+        worker.run_async(lambda: 42, name="hop-test")
+        _drain(qtbot, lambda: consumer.results == [42])
+        assert consumer.threads == [threading.main_thread().ident]
+
+    def test_raising_callable_emits_nothing_but_releases_the_hold(self, qtbot):
+        worker = BackgroundResult()
+        consumer = Consumer()
+        worker.result_ready.connect(consumer.take, Qt.ConnectionType.QueuedConnection)
+
+        def boom():
+            raise RuntimeError("nope")
+
+        worker.run_async(boom, name="hop-raise")
+        _drain(qtbot, lambda: worker not in background._INFLIGHT)
+        assert consumer.results == []
+
+    def test_overlapping_calls_hold_the_worker_until_the_last_lands(self, qtbot):
+        worker = BackgroundResult()
+        consumer = Consumer()
+        worker.result_ready.connect(consumer.take, Qt.ConnectionType.QueuedConnection)
+        gate = threading.Event()
+
+        def slow():
+            gate.wait(3.0)
+            return "slow"
+
+        worker.run_async(slow, name="hop-slow")
+        worker.run_async(lambda: "fast", name="hop-fast")
+        assert background._INFLIGHT[worker] == 2
+        _drain(qtbot, lambda: consumer.results == ["fast"])
+        # The fast landing released ONE hold; the slow call keeps the worker.
+        _drain(qtbot, lambda: background._INFLIGHT.get(worker) == 1)
+        gate.set()
+        _drain(qtbot, lambda: consumer.results == ["fast", "slow"])
+        _drain(qtbot, lambda: worker not in background._INFLIGHT)
+
+    def test_consumer_dropped_mid_flight_is_safe(self, qtbot):
+        """The teardown race that motivated the hop: the consumer dies while
+        the call is out; the result lands nowhere and nothing crashes."""
+        worker = BackgroundResult()
+        consumer = Consumer()
+        worker.result_ready.connect(consumer.take, Qt.ConnectionType.QueuedConnection)
+        gate = threading.Event()
+
+        def slow():
+            gate.wait(3.0)
+            return "late"
+
+        worker.run_async(slow, name="hop-orphan")
+        del consumer
+        gc.collect()
+        gate.set()
+        _drain(qtbot, lambda: worker not in background._INFLIGHT)

--- a/GEECS-Console/tests/test_main_window.py
+++ b/GEECS-Console/tests/test_main_window.py
@@ -111,6 +111,18 @@ class FakeSubmitter:
 
         return QueueStatus(connected=True, re_state="idle", worker_exists=True)
 
+    def queue_items(self):
+        return []
+
+    def history_items(self):
+        return []
+
+    def running_item(self):
+        return None
+
+    def clear_queue(self):
+        return (True, "queue cleared")
+
 
 class FakeHealth:
     def poll(self):
@@ -1112,7 +1124,7 @@ class TestNowAndDevicePanel:
         assert "operator abort" in window.log_tail.toPlainText()
 
     def test_concurrent_idle_probes_for_one_experiment_are_deduplicated(
-        self, window, monkeypatch
+        self, window, monkeypatch, qtbot
     ):
         """One in-flight idle probe per experiment — never two racing threads.
 
@@ -1121,6 +1133,9 @@ class TestNowAndDevicePanel:
         threads racing a lazy native first import can abort the process.
         """
         controller = window._now
+        # The startup probe must have landed first (its delivery takes two
+        # event-loop turns since the BackgroundResult GUI hop, 0.28.0).
+        qtbot.waitUntil(lambda: controller._probe_inflight is None, timeout=2000)
         spawned = []
         monkeypatch.setattr(
             controller._worker,

--- a/GEECS-Console/tests/test_main_window.py
+++ b/GEECS-Console/tests/test_main_window.py
@@ -1150,6 +1150,35 @@ class TestNowAndDevicePanel:
         controller.start_idle_probe()
         assert len(spawned) == 2
 
+    def test_queue_panel_is_fed_by_the_status_poll_and_disposed_on_close(self, qtbot):
+        # Own window (not the fixture): close() must run exactly once here,
+        # or the second closeEvent's disconnects warn.
+        submitter = FakeSubmitter()
+        submitter.queue_items = lambda: [
+            {"name": "geecs_run_action_plan", "args": ["a1"]}
+        ]
+        win = MainWindow(
+            configs=FakeConfigs(),
+            presets=FakePresetStore(),
+            settings=FakeSettings(),
+            submitter=submitter,
+        )
+        win._monitor.dispose()
+        from geecs_bluesky.qs_client import QueueStatus
+
+        # A changed queue-shaped field (items_in_queue) is what refetches;
+        # the construction-time poll already committed the empty key.
+        win._on_queue_status(
+            QueueStatus(
+                connected=True, re_state="idle", worker_exists=True, items_in_queue=1
+            )
+        )
+        qtbot.waitUntil(lambda: win.queue_table.rowCount() == 1, timeout=3000)
+        assert win.queue_table.item(0, 1).text() == "Action: a1"
+        assert win.queue_summary_label.text() == "1 waiting"
+        win.close()
+        assert win._queue_panel._disposed
+
     def test_no_experiment_probe_answers_inline_without_a_thread(
         self, qtbot, monkeypatch
     ):

--- a/GEECS-Console/tests/test_queue_panel.py
+++ b/GEECS-Console/tests/test_queue_panel.py
@@ -1,0 +1,321 @@
+"""Hermetic tests for the R8 queue panel (app/queue_panel.py).
+
+The summarizers are pure functions over the manager's item shapes; the
+controller runs against an in-memory fake client with the same read
+verbs as ``QueueClient`` (fetches still ride the daemon-thread worker,
+so results are awaited with ``qtbot.waitUntil``).
+"""
+
+from __future__ import annotations
+
+import pytest
+from PySide6.QtWidgets import QLabel, QPushButton, QTableWidget
+
+from geecs_console.app.queue_panel import (
+    COLUMNS,
+    QueuePanelController,
+    QueueSnapshot,
+    build_rows,
+    summarize_counts,
+    summarize_item,
+    summarize_request,
+)
+from geecs_bluesky.qs_client import QueueStatus
+
+
+def _scan_item(request: dict, *, user: str = "geecs-console", uid: str = "u1") -> dict:
+    return {
+        "name": "geecs_scan_request_plan",
+        "args": [request],
+        "kwargs": {},
+        "item_type": "plan",
+        "user": user,
+        "item_uid": uid,
+    }
+
+
+def _finished(
+    item: dict, exit_status: str, *, msg: str = "", stop: float = 0.0
+) -> dict:
+    return {
+        **item,
+        "result": {"exit_status": exit_status, "msg": msg, "time_stop": stop},
+    }
+
+
+STEP_REQUEST = {
+    "mode": "step",
+    "axes": [{"variable": "jet_x", "positions": {"start": 0, "end": 5, "step": 0.5}}],
+    "capture": {"shots_per_step": 10},
+    "description": "focus check",
+}
+
+
+class TestSummarizeRequest:
+    def test_step_scan(self):
+        assert (
+            summarize_request(STEP_REQUEST)
+            == 'jet_x 0 → 5 step 0.5 · 10 shots/step — "focus check"'
+        )
+
+    def test_grid_joins_axes_and_values_list_counts(self):
+        request = {
+            "mode": "step",
+            "axes": [
+                {"variable": "jet_x", "positions": {"start": 0, "end": 1, "step": 1}},
+                {"variable": "jet_z", "positions": {"values": [1.0, 2.0, 4.0]}},
+            ],
+            "capture": {"shots_per_step": 3},
+        }
+        assert summarize_request(request) == (
+            "jet_x 0 → 1 step 1 × jet_z [3 values] · 3 shots/step"
+        )
+
+    def test_noscan_says_shots_not_shots_per_step(self):
+        request = {"mode": "noscan", "axes": [], "capture": {"shots_per_step": 50}}
+        assert summarize_request(request) == "No-scan · 50 shots"
+
+    def test_background_flag_leads(self):
+        request = {
+            "mode": "noscan",
+            "capture": {"shots_per_step": 5},
+            "background": True,
+        }
+        assert summarize_request(request) == "Background · No-scan · 5 shots"
+
+    def test_optimize_names_the_objectives(self):
+        request = {
+            "mode": "optimize",
+            "optimization": {"objectives": {"charge": "MAXIMIZE"}},
+            "capture": {"shots_per_step": 4},
+        }
+        assert summarize_request(request) == "Optimize charge · 4 shots/step"
+
+    def test_v1_flat_shots_key_still_reads(self):
+        # A history item from before the capture block (geecs-schemas < 0.14)
+        # must still render — the manager keeps old submissions verbatim.
+        request = {"mode": "noscan", "shots_per_step": 7}
+        assert summarize_request(request) == "No-scan · 7 shots"
+
+    def test_garbage_never_raises(self):
+        assert summarize_request({}) == "No-scan"
+        assert summarize_request({"axes": ["nope"], "capture": "x"}) == "No-scan"
+
+
+class TestSummarizeItem:
+    def test_scan_and_action_plans_render_by_argument(self):
+        assert summarize_item(_scan_item(STEP_REQUEST)).startswith("jet_x 0 → 5")
+        item = {"name": "geecs_run_action_plan", "args": ["shutdown_laser"]}
+        assert summarize_item(item) == "Action: shutdown_laser"
+
+    def test_unknown_plan_renders_its_name(self):
+        assert summarize_item({"name": "count", "item_type": "plan"}) == "count (plan)"
+        assert summarize_item({}) == "? (item)"
+
+
+class TestBuildRows:
+    def test_order_is_running_then_waiting_then_newest_history(self):
+        snapshot = QueueSnapshot(
+            running=_scan_item(STEP_REQUEST, user="osprey"),
+            queued=[
+                {"name": "geecs_run_action_plan", "args": ["a1"], "user": "u"},
+                {"name": "geecs_run_action_plan", "args": ["a2"], "user": "u"},
+            ],
+            history=[
+                _finished(_scan_item(STEP_REQUEST), "completed", stop=1.0),
+                _finished(
+                    _scan_item(STEP_REQUEST),
+                    "failed",
+                    msg="boom\ntraceback...",
+                    stop=2.0,
+                ),
+            ],
+        )
+        rows = build_rows(snapshot)
+        assert [r.state for r in rows] == [
+            "running",
+            "queued",
+            "queued",
+            "failed",
+            "completed",
+        ]
+        assert rows[0].user == "osprey"
+        assert [r.detail for r in rows[1:3]] == ["#1", "#2"]
+        # First message line only, after the finish clock.
+        assert rows[3].detail.endswith(" · boom")
+        assert "traceback" not in rows[3].detail
+
+    def test_history_limit_keeps_the_newest(self):
+        history = [
+            _finished(_scan_item({"description": f"s{i}"}), "completed")
+            for i in range(5)
+        ]
+        rows = build_rows(QueueSnapshot(history=history), history_rows=2)
+        assert [r.item for r in rows] == ['No-scan — "s4"', 'No-scan — "s3"']
+        assert build_rows(QueueSnapshot(history=history), history_rows=0) == []
+
+    def test_counts_line(self):
+        assert summarize_counts(QueueSnapshot()) == "Queue empty"
+        assert summarize_counts(QueueSnapshot(running={"name": "x"})) == "Running"
+        assert (
+            summarize_counts(QueueSnapshot(running={"name": "x"}, queued=[{}, {}]))
+            == "Running · 2 waiting"
+        )
+
+
+class FakeQueueClient:
+    """The QueueClient read verbs + clear, with call counting."""
+
+    def __init__(self):
+        self.running = None
+        self.queued: list[dict] = []
+        self.history: list[dict] = []
+        self.fetches = 0
+        self.clears = 0
+        self.clear_result = (True, "queue cleared")
+        self.raise_on_fetch: Exception | None = None
+
+    def running_item(self):
+        self.fetches += 1
+        if self.raise_on_fetch is not None:
+            raise self.raise_on_fetch
+        return self.running
+
+    def queue_items(self):
+        return list(self.queued)
+
+    def history_items(self):
+        return list(self.history)
+
+    def clear_queue(self):
+        self.clears += 1
+        return self.clear_result
+
+
+@pytest.fixture
+def panel(qtbot):
+    table = QTableWidget()
+    label = QLabel()
+    button = QPushButton()
+    qtbot.addWidget(table)
+    qtbot.addWidget(label)
+    qtbot.addWidget(button)
+    client = FakeQueueClient()
+    answers = {"confirm": True}
+    reports: list[str] = []
+    controller = QueuePanelController(
+        table=table,
+        summary_label=label,
+        clear_button=button,
+        client_provider=lambda: client,
+        confirm=lambda title, message: answers["confirm"],
+        report=reports.append,
+        fallback_refresh_s=3600.0,
+    )
+    yield controller, client, table, label, button, answers, reports
+    controller.dispose()
+
+
+def _status(items=0, running_uid=None, re_state="idle", connected=True):
+    return QueueStatus(
+        connected=connected,
+        re_state=re_state,
+        worker_exists=connected,
+        items_in_queue=items,
+        running_item_uid=running_uid,
+    )
+
+
+class TestQueuePanelController:
+    def test_table_shape_and_initial_message(self, panel):
+        _, _, table, label, button, _, _ = panel
+        assert table.columnCount() == len(COLUMNS)
+        assert [
+            table.horizontalHeaderItem(i).text() for i in range(len(COLUMNS))
+        ] == list(COLUMNS)
+        assert "waiting for the manager" in label.text()
+        assert not button.isEnabled()
+
+    def test_status_change_fetches_and_renders(self, panel, qtbot):
+        controller, client, table, label, button, _, _ = panel
+        client.running = _scan_item(STEP_REQUEST, user="osprey", uid="r")
+        client.queued = [{"name": "geecs_run_action_plan", "args": ["a1"], "user": "c"}]
+        controller.on_status(_status(items=1, running_uid="r", re_state="running"))
+        qtbot.waitUntil(lambda: table.rowCount() == 2, timeout=3000)
+        assert table.item(0, 0).text() == "running"
+        assert table.item(0, 2).text() == "osprey"
+        assert table.item(1, 1).text() == "Action: a1"
+        assert label.text() == "Running · 1 waiting"
+        assert button.isEnabled()
+
+    def test_unchanged_status_does_not_refetch(self, panel, qtbot):
+        controller, client, table, _, _, _, _ = panel
+        controller.on_status(_status())
+        qtbot.waitUntil(lambda: client.fetches == 1, timeout=3000)
+        qtbot.waitUntil(lambda: not controller._fetch_inflight, timeout=3000)
+        controller.on_status(_status())
+        controller.on_status(_status())
+        assert client.fetches == 1
+        controller.on_status(_status(items=1))
+        qtbot.waitUntil(lambda: client.fetches == 2, timeout=3000)
+
+    def test_disconnected_status_reads_unreachable_and_disables_clear(
+        self, panel, qtbot
+    ):
+        controller, client, table, label, button, _, _ = panel
+        client.queued = [{"name": "x"}]
+        controller.on_status(_status(items=1))
+        qtbot.waitUntil(lambda: table.rowCount() == 1, timeout=3000)
+        assert button.isEnabled()
+        controller.on_status(_status(connected=False))
+        assert table.rowCount() == 0
+        assert "unreachable" in label.text()
+        assert not button.isEnabled()
+
+    def test_fetch_failure_renders_unavailable_not_empty(self, panel, qtbot):
+        controller, client, table, label, _, _, _ = panel
+        client.raise_on_fetch = RuntimeError("socket wedged")
+        controller.on_status(_status(items=2))
+        qtbot.waitUntil(lambda: "unavailable" in label.text(), timeout=3000)
+        assert "socket wedged" in label.text()
+        # The failure released the in-flight guard: a later change refetches.
+        client.raise_on_fetch = None
+        client.queued = [{"name": "x"}]
+        controller.on_status(_status(items=1))
+        qtbot.waitUntil(lambda: table.rowCount() == 1, timeout=3000)
+
+    def test_clear_declined_leaves_the_queue(self, panel, qtbot):
+        controller, client, _, _, button, answers, reports = panel
+        controller.on_status(_status(items=1))
+        answers["confirm"] = False
+        button.click()
+        assert client.clears == 0
+        assert reports == []
+
+    def test_clear_confirmed_runs_the_verb_and_reports(self, panel, qtbot):
+        controller, client, _, _, button, _, reports = panel
+        client.queued = [{"name": "x"}]
+        controller.on_status(_status(items=1))
+        qtbot.waitUntil(lambda: client.fetches == 1, timeout=3000)
+        button.click()
+        assert not button.isEnabled()  # in flight
+        qtbot.waitUntil(lambda: reports == ["queue cleared"], timeout=3000)
+        assert client.clears == 1
+        # The clear forced a re-read of the queue (a second fetch).
+        qtbot.waitUntil(lambda: client.fetches == 2, timeout=3000)
+
+    def test_clear_failure_is_reported(self, panel, qtbot):
+        controller, client, _, _, button, _, reports = panel
+        client.clear_result = (False, "manager refused")
+        controller.on_status(_status(items=1))
+        button.click()
+        qtbot.waitUntil(lambda: bool(reports), timeout=3000)
+        assert reports == ["Clear queue failed: manager refused"]
+
+    def test_dispose_severs_the_window_edges(self, panel):
+        controller, client, _, _, _, _, _ = panel
+        controller.dispose()
+        controller.dispose()  # idempotent
+        controller.on_status(_status(items=1))
+        assert client.fetches == 0
+        assert controller._client_provider() is None

--- a/GEECS-Console/tests/test_queue_panel.py
+++ b/GEECS-Console/tests/test_queue_panel.py
@@ -8,6 +8,8 @@ so results are awaited with ``qtbot.waitUntil``).
 
 from __future__ import annotations
 
+import threading
+
 import pytest
 from PySide6.QtWidgets import QLabel, QPushButton, QTableWidget
 
@@ -108,6 +110,29 @@ class TestSummarizeItem:
         item = {"name": "geecs_run_action_plan", "args": ["shutdown_laser"]}
         assert summarize_item(item) == "Action: shutdown_laser"
 
+    def test_named_plans_render_from_their_keyword_arguments(self):
+        # GeecsBluesky ≥ 0.73.0 named plans carry the request's parts as
+        # kwargs (no request dict at args[0]).
+        item = {
+            "name": "geecs_scan_plan",
+            "args": [],
+            "kwargs": {
+                "axes": [
+                    {
+                        "variable": "jet_x",
+                        "positions": {"start": 0, "end": 1, "step": 1},
+                    }
+                ],
+                "capture": {"shots_per_step": 4},
+            },
+        }
+        assert summarize_item(item) == "jet_x 0 → 1 step 1 · 4 shots/step"
+        item = {
+            "name": "geecs_noscan_plan",
+            "kwargs": {"capture": {"shots_per_step": 9}},
+        }
+        assert summarize_item(item) == "No-scan · 9 shots"
+
     def test_unknown_plan_renders_its_name(self):
         assert summarize_item({"name": "count", "item_type": "plan"}) == "count (plan)"
         assert summarize_item({}) == "? (item)"
@@ -171,9 +196,12 @@ class FakeQueueClient:
         self.queued: list[dict] = []
         self.history: list[dict] = []
         self.fetches = 0
+        self.history_reads = 0
         self.clears = 0
         self.clear_result = (True, "queue cleared")
         self.raise_on_fetch: Exception | None = None
+        #: When set, ``queue_items`` blocks until released (mid-fetch races).
+        self.gate: threading.Event | None = None
 
     def running_item(self):
         self.fetches += 1
@@ -182,9 +210,12 @@ class FakeQueueClient:
         return self.running
 
     def queue_items(self):
+        if self.gate is not None:
+            self.gate.wait(3.0)
         return list(self.queued)
 
     def history_items(self):
+        self.history_reads += 1
         return list(self.history)
 
     def clear_queue(self):
@@ -258,6 +289,39 @@ class TestQueuePanelController:
         assert client.fetches == 1
         controller.on_status(_status(items=1))
         qtbot.waitUntil(lambda: client.fetches == 2, timeout=3000)
+
+    def test_change_arriving_mid_fetch_is_fetched_when_the_fetch_lands(
+        self, panel, qtbot
+    ):
+        """Review finding 1: a key change during an in-flight fetch used to
+        be consumed by the key compare and dropped until the fallback."""
+        controller, client, table, label, _, _, _ = panel
+        client.gate = threading.Event()
+        controller.on_status(_status(items=0))  # fetch 1 starts, blocked
+        qtbot.waitUntil(lambda: client.fetches == 1, timeout=3000)
+        client.queued = [{"name": "x"}]
+        controller.on_status(_status(items=1))  # arrives mid-fetch
+        controller.on_status(_status(items=1))
+        client.gate.set()
+        qtbot.waitUntil(lambda: client.fetches == 2, timeout=3000)
+        qtbot.waitUntil(lambda: table.rowCount() == 1, timeout=3000)
+        assert label.text() == "1 waiting"
+
+    def test_fallback_tick_rereads_the_queue_but_not_the_history(self, panel, qtbot):
+        """Review finding 3: the manager's history is unbounded and can only
+        change with the status key — the fallback re-reads the queue only."""
+        controller, client, table, _, _, _, _ = panel
+        client.history = [_finished(_scan_item(STEP_REQUEST), "completed")]
+        controller.on_status(_status())
+        qtbot.waitUntil(lambda: table.rowCount() == 1, timeout=3000)
+        assert client.history_reads == 1
+        controller._last_refresh_at = float("-inf")  # make the tick stale
+        client.queued = [{"name": "x"}]
+        controller.on_status(_status())  # same key
+        qtbot.waitUntil(lambda: client.fetches == 2, timeout=3000)
+        qtbot.waitUntil(lambda: table.rowCount() == 2, timeout=3000)
+        assert client.history_reads == 1  # cached history reused
+        assert table.item(1, 0).text() == "completed"
 
     def test_disconnected_status_reads_unreachable_and_disables_clear(
         self, panel, qtbot

--- a/GEECS-Console/tests/test_tooltips.py
+++ b/GEECS-Console/tests/test_tooltips.py
@@ -95,6 +95,8 @@ class TestMainWindowOperatorTooltips:
         "stop_button",
         "state_pill",
         "progress_bar",
+        "queue_table",
+        "queue_clear_button",
         "device_combo",
         "set_field",
         "set_button",


### PR DESCRIPTION
## What

**R8 queue panel** in the console's right column, below the NOW panel: what the RE Manager holds. bluesky-queueserver ships the queue as data (`queue_get` / `history_get`) and no operator view of it; the console's now panel shows the running scan but nothing behind it. The new panel shows:

- a summary line: `Running · 2 waiting` / `Queue empty` / `manager unreachable` / `unavailable (<error>)`
- a read-only table (State / Item / By / Detail): the running item, the waiting items front-first (any client's — the MCP's, a notebook's), then the last 10 finished items newest-first with the manager's `exit_status`, finish clock and first message line
- **Clear queue** (enabled only with waiting items; confirmation modal): the recovery verb for the failed-item-at-front trap, without going through a Start attempt

Item summaries (`summarize_item` / `summarize_request`) are pure functions tolerant of every ScanRequest schema version the history may hold (v1 flat `shots_per_step`, v2+ `capture`, step / grid / noscan / optimize / background, action plans, unknown plans).

**Refresh policy**: no new poll. The existing 1 s manager status poll (`_on_queue_status`) fans each snapshot into the panel, which refetches when the queue-shaped fields change (`items_in_queue` / `running_item_uid` / `re_state`) or every 5 s as a fallback — three bounded 0MQ reads on a `BackgroundResult` thread, one in flight. A failed fetch renders "unavailable", never an empty queue.

## BackgroundResult fix (bundled, same package — the panel exposed it)

Adding a fetch per status snapshot made the offscreen suite segfault at random positions (native stack: `QWidget::ensurePolished` walking a dangling child). Bisected to: a daemon-thread emission aimed at a consumer QObject races that consumer's destruction — keeping the controller alive forever removed the crash; slot body, payload type and the `dispose()` disconnect were irrelevant. `BackgroundResult` now hops the result onto the GUI thread through its own queued signal (receiver = the worker, held in a module-level in-flight set until the hop lands, released one event-loop turn later) and emits `result_ready` there. Consumer connections are unchanged; delivery takes two event-loop turns instead of one (one test that assumed the startup idle probe had already landed now waits for it). `HealthPoller` keeps its pre-existing emit-from-thread shape; noted in CLAUDE.md as the next candidate if it ever bites.

## LOC (≈1115 added / 18 removed)

| concern | files | LOC |
|---|---|---|
| queue panel controller + summarizers | `app/queue_panel.py` | ~430 |
| tests for it | `tests/test_queue_panel.py` | ~320 |
| window wiring, `.ui` R8 group, QSS table styling, tooltips | `main_window.py`, `main_window.ui`, `style.qss`, `tooltips.py` | ~130 |
| `BackgroundResult` GUI hop | `services/background.py` | ~50 |
| test fakes / one timing wait | `tests/test_main_window.py`, `tests/test_tooltips.py` | ~20 |
| CLAUDE.md + CHANGELOG + version | | ~90 |

## Judgment calls (cheap to veto)

- History depth 10 rows, fallback refresh 5 s — both module constants.
- Clear queue lives in the panel (not a menu item); single-item Remove is deferred because `qs_client` exposes no `item_remove` verb (would touch GeecsBluesky).
- The R6/R8 vertical stretch is 3:2; the log tail shrinks accordingly on small windows.

## Tests

GEECS-Console suite (main-checkout console env, `PYTHONPATH` on the worktree): **806 passed** ×3 runs (master baseline: 783). New: `tests/test_queue_panel.py` — 21 tests (summarizers, row ordering/limits, refresh gating on status change, unreachable / fetch-failure rendering, clear declined / confirmed / failed, dispose). Pre-commit clean on all changed files. `scripts/check.sh` could not run inside the worktree (no per-package venv there) — CI is the authoritative run.

## Hardware verification

**OWED** (Sam testing live now): with the worker up, submit a scan from the console and confirm the panel shows it as `running` with the console's user, then as `completed` in history with a finish time; queue a second scan while one runs (e.g. via the MCP) and confirm `1 waiting`; let a scan fail and confirm it appears at the queue front + Clear queue removes it and reports "queue cleared".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UpBh2v5DycM2Twh3aUuoZT
