### PR TITLE
GEECS-DataPortal 0.17.0: Analysis tab — run / re-run per diagnostic, state badges, error + log, artifacts inline

### DIFF
--- a/GEECS-DataPortal/CHANGELOG.md
+++ b/GEECS-DataPortal/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to this package will be documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
-## [0.17.0] - 2026-09-02
+## [0.17.0] - 2026-09-01
 
 ### Added
 
@@ -18,8 +18,13 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   a run is active and stops when it settles. The tab (and the
   `tab=analysis` URL state) appears only when runs are possible: the
   feature is configured, the `analysis` extra is installed and the scan
-  folder resolves; otherwise a bookmarked `tab=analysis` falls back to
-  the Plot tab.
+  folder resolves; otherwise a bookmarked or stepper-carried
+  `tab=analysis` falls back to the Plot tab (`setTab`: no pane → plot).
+  The list endpoint gains `artifacts` — each entry `{path, servable,
+  inline}` decided server-side (`analysis_runs.describe_artifact`,
+  the one inline-raster policy) so the page never re-derives it from
+  a path's shape; ids reach the run / log handlers through `data-`
+  attributes, never interpolated into attribute JS (review #765).
 
 ## [0.16.0] - 2026-09-01
 

--- a/GEECS-DataPortal/CHANGELOG.md
+++ b/GEECS-DataPortal/CHANGELOG.md
@@ -3,6 +3,24 @@
 All notable changes to this package will be documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.17.0] - 2026-09-02
+
+### Added
+
+- **Analysis tab** on the scan page (PR 3 of the 04 design): every
+  loadable diagnostic with its data device, applicability, state badge
+  (`queued`/`running`/`done`/`failed`/`no_data`), a run / re-run button
+  (disabled while any run is active for the scan), the error text and a
+  collapsible captured log on failure, and the produced artifacts inline
+  (raster images) or as download links — served through
+  `/run/{uid}/artifact`. Inapplicable analyzers are collapsed under
+  "other analyzers". The page polls the list endpoint every 1.5 s while
+  a run is active and stops when it settles. The tab (and the
+  `tab=analysis` URL state) appears only when runs are possible: the
+  feature is configured, the `analysis` extra is installed and the scan
+  folder resolves; otherwise a bookmarked `tab=analysis` falls back to
+  the Plot tab.
+
 ## [0.16.0] - 2026-09-01
 
 ### Added

--- a/GEECS-DataPortal/CLAUDE.md
+++ b/GEECS-DataPortal/CLAUDE.md
@@ -197,7 +197,10 @@ name — has a folder in this scan), its in-memory `job` record
 (`queued`/`running`/`done`/`failed`/`no_data`, artifacts, error, the
 run's captured log lines) and `files` (what is on disk under
 `analysis/ScanNNN/<output_name>/`, so a page loaded after a portal
-restart still shows earlier outputs); `POST
+restart still shows earlier outputs) and `artifacts` — what the tab
+shows (the done job's list, else the files), each `{path, servable,
+inline}` decided by `analysis_runs.describe_artifact` (the ONE
+inline-raster policy; the page never guesses from a path); `POST
 /api/run/{uid}/analysis?analyzer=<id>` starts a run (202 + record;
 feature off / extra missing / unknown diagnostic / folder unresolvable
 → 404; a job already active for the scan → 409 with its record);

--- a/GEECS-DataPortal/CLAUDE.md
+++ b/GEECS-DataPortal/CLAUDE.md
@@ -138,7 +138,8 @@ tests/
 ```
 
 Routes: `/` (redirect to today) · `/day/{iso}` (run list; `?experiment=`)
-· `/run/{uid}` (the scan page: rail + Overview/Plot/Images tabs;
+· `/run/{uid}` (the scan page: rail + Overview/Plot/Images/Analysis tabs
+— Analysis only when runs are possible, see below;
 `?tab=&y=&x=&view=&filters=&bincfg=&display=` is the Plot-tab state,
 `?device=&shot=` the Images selection) · `/run/jump/{iso}` (day-step
 redirect: `?prefer=<scan number>`, all other params carried to the
@@ -200,6 +201,13 @@ restart still shows earlier outputs); `POST
 /api/run/{uid}/analysis?analyzer=<id>` starts a run (202 + record;
 feature off / extra missing / unknown diagnostic / folder unresolvable
 → 404; a job already active for the scan → 409 with its record);
+the **Analysis tab** (0.17.0) renders that listing: badge per state, run /
+re-run (disabled while any run is active for the scan), error + captured
+log on failure, artifacts inline (raster) or as download links, the
+inapplicable analyzers collapsed; it polls every 1.5 s while a run is
+active and the tab button exists only when `analysis_enabled` (feature
+configured + extra installed + folder resolvable) — a bookmarked
+`tab=analysis` otherwise falls back to Plot.
 `GET /run/{uid}/artifact?path=<relative>` serves one produced file —
 the resolved path must stay inside the scan's own analysis folder
 (`analysis_runs.contained_artifact`; symlinks resolved), else 404.

--- a/GEECS-DataPortal/geecs_portal/analysis_runs.py
+++ b/GEECS-DataPortal/geecs_portal/analysis_runs.py
@@ -404,6 +404,28 @@ def contained_artifact(analysis_folder: Path, relative: str) -> Optional[Path]:
     return candidate if candidate.is_file() else None
 
 
+#: Artifact types the artifact endpoint renders inline (raster only —
+#: SVG can carry script and is served as a download like everything else).
+INLINE_IMAGE_SUFFIXES = frozenset({".png", ".jpg", ".jpeg", ".gif", ".webp"})
+
+
+def describe_artifact(analysis_folder: Path, artifact: str) -> dict:
+    """The wire shape of one artifact: ``{path, servable, inline}``.
+
+    ``servable`` = it resolves to a file inside the analysis folder (the
+    artifact endpoint would serve it); ``inline`` = a raster image the
+    tab may show in an ``<img>``. Labels and files elsewhere are neither
+    — the tab shows them as text. Decided HERE so the page never
+    re-derives the policy from a path's shape.
+    """
+    servable = contained_artifact(analysis_folder, artifact) is not None
+    return {
+        "path": artifact,
+        "servable": servable,
+        "inline": servable and Path(artifact).suffix.lower() in INLINE_IMAGE_SUFFIXES,
+    }
+
+
 def list_artifacts(
     analysis_folder: Path, output_name: str, *, limit: int = 200
 ) -> list[str]:

--- a/GEECS-DataPortal/geecs_portal/app.py
+++ b/GEECS-DataPortal/geecs_portal/app.py
@@ -261,11 +261,6 @@ def _default_x(detail, columns: list[str]) -> str:
     return scan_vars[0] if scan_vars else ""
 
 
-#: Artifact types the artifact endpoint renders inline (raster only —
-#: SVG can carry script and is served as a download like everything else).
-_INLINE_IMAGE_SUFFIXES = frozenset({".png", ".jpg", ".jpeg", ".gif", ".webp"})
-
-
 @dataclasses.dataclass(frozen=True)
 class _DiagInfo:
     """A loadable diagnostic's run-side facts (the selector cache's value)."""
@@ -875,6 +870,15 @@ def create_app(
         analyzers = []
         for name, info in _processing_infos().items():
             job = jobs.get(name)
+            # What the tab shows: the finished job's own artifact list,
+            # else what is on disk under the output dir — each entry
+            # described (servable / inline) server-side so the page
+            # never guesses from a path's shape.
+            shown = (
+                job.artifacts
+                if job is not None and job.state == analysis_runs.DONE
+                else analysis_runs.list_artifacts(analysis_folder, info.output_name)
+            )
             analyzers.append(
                 {
                     "id": name,
@@ -885,6 +889,10 @@ def create_app(
                     "files": analysis_runs.list_artifacts(
                         analysis_folder, info.output_name
                     ),
+                    "artifacts": [
+                        analysis_runs.describe_artifact(analysis_folder, a)
+                        for a in shown
+                    ],
                 }
             )
         running = runner.running_for(uid)
@@ -948,7 +956,7 @@ def create_app(
         if file is None:
             raise HTTPException(status_code=404, detail="no such artifact")
         headers = {"Cache-Control": "no-cache", "X-Content-Type-Options": "nosniff"}
-        inline = file.suffix.lower() in _INLINE_IMAGE_SUFFIXES
+        inline = file.suffix.lower() in analysis_runs.INLINE_IMAGE_SUFFIXES
         return FileResponse(
             file,
             headers=headers,

--- a/GEECS-DataPortal/geecs_portal/app.py
+++ b/GEECS-DataPortal/geecs_portal/app.py
@@ -803,6 +803,14 @@ def create_app(
     # ---- analysis runs (04 design: direct ScanAnalysis execution) ----
     factory = analysis_factory or analysis_runs.scan_analysis_factory
 
+    def _analysis_enabled() -> bool:
+        """Whether the scan page should offer the Analysis tab at all."""
+        try:
+            _analysis_available()
+        except HTTPException:
+            return False
+        return True
+
     def _analysis_available() -> None:
         """404 unless the run feature is configured AND installed."""
         if processing_config_dir is None:
@@ -1171,6 +1179,9 @@ def create_app(
             kind, kind_path = "", None
         n_rows = None if detail.data is None else len(detail.data)
         shot = max(1, min(shot, n_rows) if n_rows else shot)
+        # The Analysis tab needs a resolvable folder (runs and artifact
+        # listing are per scan folder) on top of the feature gate.
+        analysis_enabled = folder is not None and _analysis_enabled()
         if (
             kind == "native"
             and folder is not None
@@ -1260,7 +1271,13 @@ def create_app(
                 "next_day": (
                     (run_day + timedelta(days=1)).isoformat() if run_day else ""
                 ),
-                "tab": tab if tab in ("overview", "plot", "images") else "plot",
+                "tab": (
+                    tab
+                    if tab in ("overview", "plot", "images")
+                    or (tab == "analysis" and analysis_enabled)
+                    else "plot"
+                ),
+                "analysis_enabled": analysis_enabled,
                 "devices": devices,
                 "sel_device": sel_device,
                 "kind": kind,

--- a/GEECS-DataPortal/geecs_portal/templates/run.html
+++ b/GEECS-DataPortal/geecs_portal/templates/run.html
@@ -570,18 +570,17 @@ function artifactUrl(path) {
   return `${ROOT}/run/${UID}/artifact?` + p.toString();
 }
 
-function renderArtifacts(paths) {
-  if (!paths || !paths.length) return "";
-  const cards = paths.map(path => {
-    const lower = path.toLowerCase();
-    const image = /\.(png|jpe?g|gif|svg|webp)$/.test(lower);
-    // Anything not under the analysis folder (a label, an absolute
-    // path elsewhere) is shown as text, never linked.
-    const servable = !path.startsWith("/") && !path.includes("..") && /[\/.]/.test(path);
-    if (image && servable) {
-      return `<a href="${artifactUrl(path)}" target="_blank"><img src="${artifactUrl(path)}" alt="${esc(path)}" title="${esc(path)}"></a>`;
+function renderArtifacts(artifacts) {
+  // Each entry is {path, servable, inline} — decided server-side
+  // (analysis_runs.describe_artifact): the page never re-derives the
+  // policy from a path's shape.
+  if (!artifacts || !artifacts.length) return "";
+  const cards = artifacts.map(a => {
+    const path = a.path;
+    if (a.inline) {
+      return `<a href="${artifactUrl(path)}" target="_blank"><img src="${artifactUrl(path)}" alt="${escAttr(path)}" title="${escAttr(path)}"></a>`;
     }
-    if (servable) return `<a class="file" href="${artifactUrl(path)}" target="_blank">${esc(path)}</a>`;
+    if (a.servable) return `<a class="file" href="${artifactUrl(path)}" target="_blank">${esc(path)}</a>`;
     return `<span class="dim mono">${esc(path)}</span>`;
   });
   return `<div class="arts">${cards.join("")}</div>`;
@@ -591,30 +590,43 @@ function renderAnalyzer(a, anyRunning) {
   const job = a.job;
   const state = job ? job.state : "";
   const active = state === "running" || state === "queued";
-  const badge = state ? `<span class="badge ${state}">${esc(state)}</span>` : `<span class="badge">not run</span>`;
+  const badge = state ? `<span class="badge ${escAttr(state)}">${esc(state)}</span>` : `<span class="badge">not run</span>`;
   const label = job && !active ? "re-run" : "run";
-  const button = `<button class="act" ${anyRunning ? "disabled" : ""} onclick="startAnalysis(${JSON.stringify(a.id)})">${label}</button>`;
+  // Ids reach the handlers through data- attributes, never interpolated
+  // into JS-in-attribute source (a quote in the id would end the
+  // attribute — the #765 review's dead-button finding).
+  const button = `<button class="act" ${anyRunning ? "disabled" : ""} data-id="${escAttr(a.id)}" onclick="startAnalysis(this.dataset.id)">${label}</button>`;
   const device = a.device ? `<span class="dim mono" title="data device">${esc(a.device)}</span>` : "";
   const when = job && job.finished ? `<span class="dim" style="font-size:11px">${new Date(job.finished * 1000).toLocaleTimeString()}</span>` : "";
   let body = "";
   if (job && job.error) body += `<p class="err">${esc(job.error)}</p>`;
-  const artifacts = job && state === "done" && job.artifacts.length ? job.artifacts : a.files;
-  body += renderArtifacts(artifacts);
+  body += renderArtifacts(a.artifacts);
   if (job && job.log && job.log.length) {
     const open = ANALYSIS_OPEN[a.id] ? " open" : "";
-    body += `<details${open} ontoggle="ANALYSIS_OPEN[${JSON.stringify(a.id)}]=this.open"><summary>log (${job.log.length} lines)</summary><pre>${esc(job.log.join("\n"))}</pre></details>`;
+    body += `<details${open} data-id="${escAttr(a.id)}" ontoggle="ANALYSIS_OPEN[this.dataset.id]=this.open"><summary>log (${job.log.length} lines)</summary><pre>${esc(job.log.join("\n"))}</pre></details>`;
   }
   return `<div class="arow"><div class="head"><span class="id">${esc(a.id)}</span>${device}${badge}${when}<span class="right">${button}</span></div>${body}</div>`;
 }
 
+let ANALYSIS_LAST = null;  // last-rendered payload — an unchanged poll leaves the DOM alone
+
 function renderAnalysis(body) {
   const list = document.getElementById("analysisList");
   if (!list) return;
+  const anyRunning = body.running !== null;
+  const key = JSON.stringify(body);
+  if (key === ANALYSIS_LAST) {
+    // Nothing changed: keep polling while active, but do not rebuild
+    // the list (every <img> would re-fetch its artifact).
+    clearTimeout(ANALYSIS_TIMER);
+    ANALYSIS_TIMER = anyRunning ? setTimeout(() => refreshAnalysis(false), 1500) : null;
+    return;
+  }
+  ANALYSIS_LAST = key;
   if (!body.analyzers.length) {
     list.innerHTML = `<div class="plotmsg">no loadable diagnostics in the configs tree</div>`;
     return;
   }
-  const anyRunning = body.running !== null;
   const applicable = body.analyzers.filter(a => a.applicable);
   const others = body.analyzers.filter(a => !a.applicable);
   let html = applicable.map(a => renderAnalyzer(a, anyRunning)).join("");
@@ -634,6 +646,7 @@ function refreshAnalysis(force) {
   const list = document.getElementById("analysisList");
   if (!list || (!force && S.tab !== "analysis")) return;
   api("analysis", {}).then(renderAnalysis).catch(err => {
+    ANALYSIS_LAST = null;
     list.innerHTML = `<div class="plotmsg">${esc(err.message)}</div>`;
   });
 }
@@ -649,13 +662,24 @@ function startAnalysis(id) {
       refreshAnalysis(true);
     })
     .catch(err => {
+      // A 503 (shutting down), a proxy 502, a network blip: show it
+      // ONCE and re-render so the buttons come back (the up-front
+      // disable must never be the page's last word).
       const list = document.getElementById("analysisList");
-      list.insertAdjacentHTML("afterbegin", `<div class="plotmsg">${esc(err.message)}</div>`);
+      list.querySelectorAll(".plotmsg.starterr").forEach(n => n.remove());
+      list.insertAdjacentHTML("afterbegin", `<div class="plotmsg starterr">${esc(err.message)}</div>`);
+      ANALYSIS_LAST = null;
+      refreshAnalysis(true);
     });
 }
 
 // ---------------- tabs ----------------
 function setTab(tab) {
+  // A URL-carried tab whose pane this page does not have (tab=analysis
+  // carried by a stepper onto a scan whose folder is not resolvable, or
+  // opened on a portal without analysis runs) falls back to Plot —
+  // never a page with no tab lit and no pane shown.
+  if (!document.getElementById("pane-" + tab)) tab = "plot";
   S.tab = tab;
   document.querySelectorAll(".tab").forEach(t => t.classList.toggle("on", t.dataset.pane === tab));
   document.querySelectorAll(".pane").forEach(pane => pane.classList.toggle("on", pane.id === "pane-" + tab));

--- a/GEECS-DataPortal/geecs_portal/templates/run.html
+++ b/GEECS-DataPortal/geecs_portal/templates/run.html
@@ -86,6 +86,23 @@
   .apply { background: var(--accent); color: #10201d; border: none; border-radius: 3px;
            padding: 0.3rem 0.9rem; font-size: 12px; cursor: pointer; font-weight: 600; }
   .plotmsg { color: var(--dim); font-size: 13px; padding: 2rem 0; text-align: center; }
+  .arow { border: 1px solid var(--line); border-radius: 4px; background: var(--panel);
+          padding: 0.6rem 0.8rem; margin-bottom: 0.6rem; }
+  .arow .head { display: flex; gap: 0.7rem; align-items: center; flex-wrap: wrap; font-size: 13px; }
+  .arow .head .id { font-family: ui-monospace, Menlo, monospace; }
+  .arow .head .right { margin-left: auto; display: flex; gap: 0.5rem; align-items: center; }
+  .badge { font-size: 11px; border-radius: 3px; padding: 0.1rem 0.45rem; border: 1px solid var(--line); color: var(--dim); }
+  .badge.running, .badge.queued { color: var(--accent); border-color: var(--accent); }
+  .badge.done { color: #7fc47f; border-color: #7fc47f; }
+  .badge.failed { color: #cf5347; border-color: #cf5347; }
+  .badge.no_data { color: #d6a860; border-color: #d6a860; }
+  .arow .err { color: #cf5347; font-size: 12px; white-space: pre-wrap; margin: 0.4rem 0 0; font-family: ui-monospace, Menlo, monospace; }
+  .arow details { margin-top: 0.4rem; font-size: 12px; }
+  .arow details pre { max-height: 14rem; overflow: auto; background: var(--panel2); padding: 0.5rem; border-radius: 3px; font-size: 11px; }
+  .arts { display: flex; flex-wrap: wrap; gap: 0.6rem; margin-top: 0.5rem; }
+  .arts img { max-width: 100%; max-height: 24rem; border: 1px solid var(--line); border-radius: 3px; background: var(--panel2); }
+  .arts a.file { font-family: ui-monospace, Menlo, monospace; font-size: 12px; }
+  #pane-analysis details.others > summary { cursor: pointer; color: var(--dim); font-size: 12px; margin: 0.6rem 0; }
   .bingrid { display: grid; grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
              gap: 0.8rem; margin-top: 0.7rem; }
   .bincard { margin: 0; background: var(--panel); border: 1px solid var(--line);
@@ -138,6 +155,9 @@
       <button class="tab" data-pane="overview" onclick="setTab('overview')">Overview</button>
       <button class="tab" data-pane="plot" onclick="setTab('plot')">Plot</button>
       <button class="tab" data-pane="images" onclick="setTab('images')">Images</button>
+      {% if analysis_enabled %}
+      <button class="tab" data-pane="analysis" onclick="setTab('analysis')">Analysis</button>
+      {% endif %}
     </div>
 
     <section class="pane" id="pane-overview">
@@ -249,6 +269,19 @@
       <p class="dim">No image device folders resolvable for this run.</p>
       {% endif %}
     </section>
+
+    {% if analysis_enabled %}
+    <section class="pane" id="pane-analysis">
+      <div class="plotbar">
+        <span class="dim">Run a ScanAnalysis analyzer on this scan. Writes figures under
+          <span class="mono">analysis/Scan{{ "%03d" | format(scan_number) }}/</span> and its
+          columns into the s-file (existing columns are overwritten); the Plot tab picks
+          them up on reload.</span>
+        <span class="right"><a href="#" onclick="refreshAnalysis(true);return false;">refresh</a></span>
+      </div>
+      <div id="analysisList"><div class="plotmsg">loading analyzers…</div></div>
+    </section>
+    {% endif %}
   </div>
 </div>
 
@@ -526,6 +559,101 @@ function api(path, params) {
   });
 }
 
+// ---------------- the analysis tab (ScanAnalysis runs) ----------------
+const ANALYSIS_ENABLED = {{ analysis_enabled | tojson }};
+let ANALYSIS_TIMER = null;   // poll handle while a run is active
+let ANALYSIS_OPEN = {};      // analyzer id -> log <details> open state (survives re-render)
+
+function artifactUrl(path) {
+  const p = new URLSearchParams({ path });
+  if (DAY) p.set("day", DAY);
+  return `${ROOT}/run/${UID}/artifact?` + p.toString();
+}
+
+function renderArtifacts(paths) {
+  if (!paths || !paths.length) return "";
+  const cards = paths.map(path => {
+    const lower = path.toLowerCase();
+    const image = /\.(png|jpe?g|gif|svg|webp)$/.test(lower);
+    // Anything not under the analysis folder (a label, an absolute
+    // path elsewhere) is shown as text, never linked.
+    const servable = !path.startsWith("/") && !path.includes("..") && /[\/.]/.test(path);
+    if (image && servable) {
+      return `<a href="${artifactUrl(path)}" target="_blank"><img src="${artifactUrl(path)}" alt="${esc(path)}" title="${esc(path)}"></a>`;
+    }
+    if (servable) return `<a class="file" href="${artifactUrl(path)}" target="_blank">${esc(path)}</a>`;
+    return `<span class="dim mono">${esc(path)}</span>`;
+  });
+  return `<div class="arts">${cards.join("")}</div>`;
+}
+
+function renderAnalyzer(a, anyRunning) {
+  const job = a.job;
+  const state = job ? job.state : "";
+  const active = state === "running" || state === "queued";
+  const badge = state ? `<span class="badge ${state}">${esc(state)}</span>` : `<span class="badge">not run</span>`;
+  const label = job && !active ? "re-run" : "run";
+  const button = `<button class="act" ${anyRunning ? "disabled" : ""} onclick="startAnalysis(${JSON.stringify(a.id)})">${label}</button>`;
+  const device = a.device ? `<span class="dim mono" title="data device">${esc(a.device)}</span>` : "";
+  const when = job && job.finished ? `<span class="dim" style="font-size:11px">${new Date(job.finished * 1000).toLocaleTimeString()}</span>` : "";
+  let body = "";
+  if (job && job.error) body += `<p class="err">${esc(job.error)}</p>`;
+  const artifacts = job && state === "done" && job.artifacts.length ? job.artifacts : a.files;
+  body += renderArtifacts(artifacts);
+  if (job && job.log && job.log.length) {
+    const open = ANALYSIS_OPEN[a.id] ? " open" : "";
+    body += `<details${open} ontoggle="ANALYSIS_OPEN[${JSON.stringify(a.id)}]=this.open"><summary>log (${job.log.length} lines)</summary><pre>${esc(job.log.join("\n"))}</pre></details>`;
+  }
+  return `<div class="arow"><div class="head"><span class="id">${esc(a.id)}</span>${device}${badge}${when}<span class="right">${button}</span></div>${body}</div>`;
+}
+
+function renderAnalysis(body) {
+  const list = document.getElementById("analysisList");
+  if (!list) return;
+  if (!body.analyzers.length) {
+    list.innerHTML = `<div class="plotmsg">no loadable diagnostics in the configs tree</div>`;
+    return;
+  }
+  const anyRunning = body.running !== null;
+  const applicable = body.analyzers.filter(a => a.applicable);
+  const others = body.analyzers.filter(a => !a.applicable);
+  let html = applicable.map(a => renderAnalyzer(a, anyRunning)).join("");
+  if (!applicable.length) html += `<div class="plotmsg">no analyzer names a device present in this scan</div>`;
+  if (others.length) {
+    const wasOpen = ANALYSIS_OPEN["__others__"] ? " open" : "";
+    html += `<details class="others"${wasOpen} ontoggle="ANALYSIS_OPEN['__others__']=this.open"><summary>${others.length} other analyzer${others.length === 1 ? "" : "s"} (device not in this scan)</summary>${others.map(a => renderAnalyzer(a, anyRunning)).join("")}</details>`;
+  }
+  list.innerHTML = html;
+  // Poll while anything is active; stop as soon as the run settles.
+  clearTimeout(ANALYSIS_TIMER);
+  ANALYSIS_TIMER = anyRunning ? setTimeout(() => refreshAnalysis(false), 1500) : null;
+}
+
+function refreshAnalysis(force) {
+  if (!ANALYSIS_ENABLED) return;
+  const list = document.getElementById("analysisList");
+  if (!list || (!force && S.tab !== "analysis")) return;
+  api("analysis", {}).then(renderAnalysis).catch(err => {
+    list.innerHTML = `<div class="plotmsg">${esc(err.message)}</div>`;
+  });
+}
+
+function startAnalysis(id) {
+  const p = new URLSearchParams({ analyzer: id, v: {{ portal_version | tojson }} });
+  if (DAY) p.set("day", DAY);
+  document.querySelectorAll("#analysisList button.act").forEach(b => { b.disabled = true; });
+  fetch(`${ROOT}/api/run/${UID}/analysis?` + p.toString(), { method: "POST" })
+    .then(r => r.json().then(body => ({ ok: r.ok, status: r.status, body })))
+    .then(({ ok, status, body }) => {
+      if (!ok && status !== 409) throw new Error(body.detail || `HTTP ${status}`);
+      refreshAnalysis(true);
+    })
+    .catch(err => {
+      const list = document.getElementById("analysisList");
+      list.insertAdjacentHTML("afterbegin", `<div class="plotmsg">${esc(err.message)}</div>`);
+    });
+}
+
 // ---------------- tabs ----------------
 function setTab(tab) {
   S.tab = tab;
@@ -534,6 +662,7 @@ function setTab(tab) {
   writeState();
   if (tab === "plot") refresh();
   refreshImages();
+  if (tab === "analysis") refreshAnalysis(true);
 }
 
 function setView(view) {

--- a/GEECS-DataPortal/geecs_portal/templates/run.html
+++ b/GEECS-DataPortal/geecs_portal/templates/run.html
@@ -662,12 +662,11 @@ function startAnalysis(id) {
       refreshAnalysis(true);
     })
     .catch(err => {
-      // A 503 (shutting down), a proxy 502, a network blip: show it
-      // ONCE and re-render so the buttons come back (the up-front
-      // disable must never be the page's last word).
-      const list = document.getElementById("analysisList");
-      list.querySelectorAll(".plotmsg.starterr").forEach(n => n.remove());
-      list.insertAdjacentHTML("afterbegin", `<div class="plotmsg starterr">${esc(err.message)}</div>`);
+      // A 503 (shutting down), a proxy 502, a network blip: flash it
+      // (flashNote survives the list re-render that follows) and
+      // re-render so the buttons come back — the up-front disable must
+      // never be the page's last word.
+      flashNote("run failed: " + err.message);
       ANALYSIS_LAST = null;
       refreshAnalysis(true);
     });

--- a/GEECS-DataPortal/pyproject.toml
+++ b/GEECS-DataPortal/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-data-portal"
-version = "0.16.0"
+version = "0.17.0"
 description = "Scan-browsing web service (read-only except explicit analysis runs): a zero-install browser view over the Tiled catalog and the GEECS data share"
 authors = ["GEECS-BELLA"]
 readme = "README.md"

--- a/GEECS-DataPortal/tests/test_analysis_runs.py
+++ b/GEECS-DataPortal/tests/test_analysis_runs.py
@@ -540,3 +540,55 @@ class TestRealFactory:
         assert callable(analyzer.run_analysis) and callable(analyzer.cleanup)
         assert analyzer.id == "UC_Crop"
         assert analyzer.data_device_name == "cam"
+
+
+class TestAnalysisTab:
+    """The scan page offers the Analysis tab only when runs are possible."""
+
+    def test_tab_present_and_sticky_when_enabled(self, scan_folder, configs_tree):
+        pytest.importorskip("image_analysis")
+        client = _client(scan_folder, configs_tree)
+        page = client.get("/run/uid-002", params={"tab": "analysis"})
+        assert page.status_code == 200
+        assert 'data-pane="analysis"' in page.text
+        assert 'id="pane-analysis"' in page.text
+        assert "const ANALYSIS_ENABLED = true;" in page.text
+        # The URL-carried tab survives into the page state (a link IS the view).
+        assert 'tab: p.get("tab") || "analysis"' in page.text
+
+    def test_tab_absent_when_feature_off(self, scan_folder):
+        catalog = FakeCatalog()
+        detail = _detail(2)
+        detail.start_doc["scan_folder"] = str(scan_folder)
+        catalog.details["uid-002"] = detail
+        client = TestClient(create_app(catalog))
+        page = client.get("/run/uid-002", params={"tab": "analysis"})
+        assert page.status_code == 200
+        assert 'data-pane="analysis"' not in page.text
+        assert "const ANALYSIS_ENABLED = false;" in page.text
+        assert (
+            'tab: p.get("tab") || "plot"' in page.text
+        )  # falls back, never a dead tab
+
+    def test_tab_absent_when_folder_unresolvable(self, configs_tree):
+        pytest.importorskip("image_analysis")
+        client = TestClient(
+            create_app(
+                FakeCatalog(),
+                processing_config_dir=configs_tree,
+                analysis_factory=_factory("ok"),
+            )
+        )
+        page = client.get("/run/uid-002", params={"tab": "analysis"})
+        assert page.status_code == 200
+        assert 'data-pane="analysis"' not in page.text
+
+    def test_tab_absent_when_extra_missing(
+        self, scan_folder, configs_tree, monkeypatch
+    ):
+        pytest.importorskip("image_analysis")
+        monkeypatch.setitem(__import__("sys").modules, "scan_analysis", None)
+        client = _client(scan_folder, configs_tree, analysis_factory=None)
+        page = client.get("/run/uid-002")
+        assert page.status_code == 200
+        assert 'data-pane="analysis"' not in page.text

--- a/GEECS-DataPortal/tests/test_analysis_runs.py
+++ b/GEECS-DataPortal/tests/test_analysis_runs.py
@@ -371,6 +371,33 @@ class TestListing:
         crop = next(a for a in body["analyzers"] if a["id"] == "UC_Crop")
         assert crop["job"] is None
         assert crop["files"] == ["UC_Crop/Array2DScanAnalyzer/old.png"]
+        assert crop["artifacts"] == [
+            {
+                "path": "UC_Crop/Array2DScanAnalyzer/old.png",
+                "servable": True,
+                "inline": True,
+            }
+        ]
+
+    def test_described_artifacts_policy(self, tmp_path):
+        root = tmp_path / "analysis" / "Scan002"
+        (root / "UC_Crop").mkdir(parents=True)
+        (root / "UC_Crop" / "fig.svg").write_text("<svg/>")
+        (root / "UC_Crop" / "fig.png").write_bytes(b"x")
+        describe = analysis_runs.describe_artifact
+        assert describe(root, "UC_Crop/fig.png") == {
+            "path": "UC_Crop/fig.png",
+            "servable": True,
+            "inline": True,
+        }
+        assert describe(root, "UC_Crop/fig.svg")["inline"] is False  # download only
+        assert describe(root, "UC_Crop/fig.svg")["servable"] is True
+        assert describe(root, "../s2.txt") == {
+            "path": "../s2.txt",
+            "servable": False,
+            "inline": False,
+        }
+        assert describe(root, "a label.")["servable"] is False
 
 
 class TestRun:
@@ -409,6 +436,15 @@ class TestRun:
         body = client.get("/api/run/uid-002/analysis").json()
         crop = next(a for a in body["analyzers"] if a["id"] == "UC_Crop")
         assert crop["files"] == ["UC_Crop/Array2DScanAnalyzer/summary.png"]
+        # The tab renders the DESCRIBED artifacts: policy decided server-side.
+        assert crop["artifacts"] == [
+            {
+                "path": "UC_Crop/Array2DScanAnalyzer/summary.png",
+                "servable": True,
+                "inline": True,
+            },
+            {"path": "a label, not a path", "servable": False, "inline": False},
+        ]
         served = client.get(
             "/run/uid-002/artifact",
             params={"path": "UC_Crop/Array2DScanAnalyzer/summary.png"},
@@ -566,9 +602,11 @@ class TestAnalysisTab:
         assert page.status_code == 200
         assert 'data-pane="analysis"' not in page.text
         assert "const ANALYSIS_ENABLED = false;" in page.text
-        assert (
-            'tab: p.get("tab") || "plot"' in page.text
-        )  # falls back, never a dead tab
+        # The server default is Plot; the URL value still wins in
+        # readState, so the JS fallback (setTab: no pane → plot) is
+        # what keeps a carried tab=analysis from lighting nothing.
+        assert 'tab: p.get("tab") || "plot"' in page.text
+        assert 'if (!document.getElementById("pane-" + tab)) tab = "plot";' in page.text
 
     def test_tab_absent_when_folder_unresolvable(self, configs_tree):
         pytest.importorskip("image_analysis")


### PR DESCRIPTION
## What

PR 3 of the `feat/analysis-tab` arc (`Planning/data_portal/04_analysis_run_design.md`; backend = #763): the **Analysis tab** on the scan page, over the run endpoints #763 added. Portal 0.16.0 → 0.17.0.

- **`run.html`** (+~150 LOC, template + inline JS + CSS): a fourth tab. Each loadable diagnostic renders as a row — id, data device, state badge (`queued`/`running`/`done`/`failed`/`no_data`, or "not run"), run / re-run button (disabled while any run is active for the scan), error text and a collapsible captured log when failed, artifacts inline (raster images via `/run/{uid}/artifact`) or as download links, labels as plain text. Inapplicable analyzers (device not in this scan) collapse under "other analyzers". Polls the list endpoint every 1.5 s while a run is active and stops when it settles; a 409 on click just refreshes (the record is shown).
- **`app.py`** (+~20): `analysis_enabled` in the page context = feature configured + extra installed + folder resolvable; the tab button and pane render only then, and `tab=analysis` is accepted as URL state only then (otherwise a bookmarked link falls back to Plot, never a dead tab).
- CHANGELOG + CLAUDE.md routes paragraph.

## Judgment calls (cheap to veto)

- **Tab hidden rather than disabled** when runs are not possible — a read-only viewer deployment (no `--processing-configs`) shows no trace of the feature.
- **Artifacts shown = the job's returned list when the run is `done`, else the files on disk** under the analyzer's output dir — so a page after a portal restart still shows earlier outputs.
- **1.5 s poll** only while active; no websocket / SSE (no build chain, and runs are seconds-to-minutes).
- Rendered page JS was syntax-checked with `node --check` on the served HTML.

## Tests

- `tests/test_analysis_runs.py::TestAnalysisTab`: **4 new** — tab present + `tab=analysis` sticky when enabled; absent (and state falls back to `plot`) when the feature is off; absent when the folder is unresolvable; absent when the `analysis` extra is missing.
- Portal suite: **214 passed** (210 → 214).

## Hardware verification

**OWED at promotion** (unchanged from #763's list, plus): the tab renders the real listing on the worker host; a run's figures appear inline; a failed run shows the exception text and the log. No scan execution or devices touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018K1DmUzf1ZPjM4NxX2QRX3