### PR TITLE
ImageAnalysis 1.14.0 + GEECS-DataPortal 0.18.0: rendered view — analyzer figures via render_diagnostic_ephemeral, Images tab 'rendered figure' mode

### DIFF
--- a/GEECS-DataPortal/CHANGELOG.md
+++ b/GEECS-DataPortal/CHANGELOG.md
@@ -16,9 +16,15 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   threadpool; same write-free contract and denylist). Per-bin view
   renders the averaged processed image through the base renderer with
   per-shot overlays dropped. `cmap` and the percentile window apply
-  (unknown colormap degrades to the default; `mode` outside
-  `("", "rendered")` is a 400). Without a `processing` selection the
-  mode is ignored (raw pixels).
+  (absent/unknown colormap → `gray`, the pixel view's palette; `mode`
+  outside `("", "rendered")` is a 400 — the enum precedent). Without a
+  `processing` selection the mode is ignored (raw pixels). Status
+  ladder matches the pixel path: a result that ran but cannot be drawn
+  (`RenderError`) is a 404 like "render failed" / "produces no
+  processed image". Review #766 also: the three "configured? installed?"
+  preambles collapsed into `_ephemeral_module()`; `resources.figure_png`
+  now serves `/plot.png` too; `to_display_png` uses `safe_cmap`; a legacy
+  dict-returning analyzer in the pixel path is a 404, not a 500.
 
 ## [0.17.0] - 2026-09-01
 

--- a/GEECS-DataPortal/CHANGELOG.md
+++ b/GEECS-DataPortal/CHANGELOG.md
@@ -3,6 +3,23 @@
 All notable changes to this package will be documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.18.0] - 2026-09-01
+
+### Added
+
+- **Rendered view** on the Images tab (PR 4 of the 04 design, the
+  interactivity stop-gap): `display.mode = "rendered"` (the "rendered
+  figure" checkbox in the display popup) serves the analyzer's own
+  matplotlib figure — overlays, axes, colorbar — instead of the windowed
+  processed pixels, through ImageAnalysis 1.14.0's
+  `render_diagnostic_ephemeral` (object-API figures, no pyplot on the
+  threadpool; same write-free contract and denylist). Per-bin view
+  renders the averaged processed image through the base renderer with
+  per-shot overlays dropped. `cmap` and the percentile window apply
+  (unknown colormap degrades to the default; `mode` outside
+  `("", "rendered")` is a 400). Without a `processing` selection the
+  mode is ignored (raw pixels).
+
 ## [0.17.0] - 2026-09-01
 
 ### Added

--- a/GEECS-DataPortal/CLAUDE.md
+++ b/GEECS-DataPortal/CLAUDE.md
@@ -175,7 +175,13 @@ frame) · `/health` (catalog probe — the fleet-map health check).
 Both image endpoints also take `?display=` (the shared display state's
 image slice: `cmap` matplotlib-colormap name + `plo`/`phi` percentile
 window — types 400 at parse, values degrade to grayscale/defaults;
-edited via the Images plotbar's "display…" popup) and
+edited via the Images plotbar's "display…" popup — plus `mode`
+(0.18.0): `"rendered"` serves the analyzer's own figure via
+`image_analysis.ephemeral.render_diagnostic_ephemeral` (object-API
+`Figure`, never pyplot — the one sanctioned matplotlib path on a
+request thread; per-bin = the base renderer over the averaged image,
+overlays dropped); only meaningful with `processing`, ignored without
+it) and
 `?processing=<diagnostic id>` (the `processing` URL state): the named ImageAnalysis diagnostic runs
 **ephemerally** on the served pixels via
 `image_analysis.ephemeral.run_diagnostic_ephemeral` — the write-free

--- a/GEECS-DataPortal/CLAUDE.md
+++ b/GEECS-DataPortal/CLAUDE.md
@@ -180,8 +180,11 @@ edited via the Images plotbar's "display…" popup — plus `mode`
 `image_analysis.ephemeral.render_diagnostic_ephemeral` (object-API
 `Figure`, never pyplot — the one sanctioned matplotlib path on a
 request thread; per-bin = the base renderer over the averaged image,
-overlays dropped); only meaningful with `processing`, ignored without
-it) and
+overlays dropped; the colormap defaults to `gray` like the pixel
+view); only meaningful with `processing`, ignored without it. `mode`
+is an enum: an unknown value is a **400**, the `bincfg`-enum
+precedent and a deliberate exception to "values degrade" — a wrong
+mode is a broken link, not a cosmetic) and
 `?processing=<diagnostic id>` (the `processing` URL state): the named ImageAnalysis diagnostic runs
 **ephemerally** on the served pixels via
 `image_analysis.ephemeral.run_diagnostic_ephemeral` — the write-free

--- a/GEECS-DataPortal/geecs_portal/analysis.py
+++ b/GEECS-DataPortal/geecs_portal/analysis.py
@@ -191,7 +191,18 @@ _DISPLAY_NUMBERS = (
     "plo",
     "phi",
 )
-_DISPLAY_FIELDS = {*_DISPLAY_BOOLS, *_DISPLAY_NUMBERS, "colors", "layout", "cmap"}
+#: Image view modes: "" (the processed / raw pixels as a windowed PNG)
+#: or "rendered" (the analyzer's own matplotlib figure — overlays,
+#: axes, colorbar; only meaningful with a `processing` selection).
+DISPLAY_MODES = ("", "rendered")
+_DISPLAY_FIELDS = {
+    *_DISPLAY_BOOLS,
+    *_DISPLAY_NUMBERS,
+    "colors",
+    "layout",
+    "cmap",
+    "mode",
+}
 
 
 def parse_display(raw: str) -> dict:
@@ -258,6 +269,8 @@ def parse_display(raw: str) -> dict:
         raise BadParam("bad display param: layout must be an object")
     if "cmap" in payload and not isinstance(payload["cmap"], str):
         raise BadParam("bad display param: cmap must be a string")
+    if "mode" in payload and payload["mode"] not in DISPLAY_MODES:
+        raise BadParam(f"bad display param: mode must be one of {list(DISPLAY_MODES)}")
     return payload
 
 

--- a/GEECS-DataPortal/geecs_portal/app.py
+++ b/GEECS-DataPortal/geecs_portal/app.py
@@ -27,7 +27,7 @@ from __future__ import annotations
 
 import contextlib
 import dataclasses
-import io
+import importlib
 import logging
 import re
 from datetime import date, datetime, timedelta
@@ -433,29 +433,25 @@ def create_app(
         return disp.get("mode") == "rendered"
 
     def _figure_kwargs(render: dict) -> dict:
-        """The display slice as the ephemeral renderers' kwargs (value-degrade)."""
+        """The display slice as the ephemeral renderers' kwargs (value-degrade).
+
+        The colormap defaults to ``gray`` — the pixel view's palette when
+        ``cmap`` is absent or unknown — so the rendered checkbox changes
+        only what it claims to (the base renderer's own default is
+        plasma).
+        """
         return {
-            "cmap": resources.safe_cmap(render.get("cmap")),
+            "cmap": resources.safe_cmap(render.get("cmap")) or "gray",
             "window": resources.window_percentiles(
                 render.get("plo"), render.get("phi")
             ),
         }
 
-    def _figure_png(fig: Figure) -> bytes:
-        """Object-API figure → PNG bytes (never pyplot; safe on the threadpool)."""
-        buffer = io.BytesIO()
-        fig.savefig(buffer, format="png")
-        return buffer.getvalue()
+    def _ephemeral_module():
+        """``image_analysis.ephemeral``, or the feature's 404 ladder.
 
-    def _render_processing_figure(array, processing: str, render: dict) -> bytes:
-        """The rendered view of ONE shot: the analyzer draws its own result.
-
-        Same seam family as ``_apply_processing`` (write-free, denylist,
-        one analyzer per call) — ``render_diagnostic_ephemeral`` hands
-        the analyzer's ``render_image`` an object-API axes, so overlays
-        (projections, markers, calibrated axes) come through without
-        any pyplot state on a request thread. Refusal ladder as for
-        processing; a renderer failure is an honest 400.
+        The one place the "configured? installed?" preamble lives for
+        the processing selector and the rendered view alike.
         """
         if processing_config_dir is None:
             raise HTTPException(
@@ -464,47 +460,66 @@ def create_app(
                 "(start it with --processing-configs)",
             )
         try:
-            from image_analysis.ephemeral import render_diagnostic_ephemeral
+            # import_module (not ``from image_analysis import ephemeral``):
+            # the package attribute survives an uninstalled/blocked
+            # submodule, the sys.modules lookup does not — the
+            # missing-extra test blocks the submodule.
+            ephemeral = importlib.import_module("image_analysis.ephemeral")
         except ImportError as exc:
             raise HTTPException(
                 status_code=404,
                 detail="processing needs the portal's 'analysis' extra "
                 "(pip install geecs-data-portal[analysis])",
             ) from exc
+        return ephemeral
+
+    def _render_processing_figure(array, processing: str, render: dict) -> bytes:
+        """The rendered view of ONE shot: the analyzer draws its own result.
+
+        Same seam family as ``_apply_processing`` (write-free, denylist,
+        one analyzer per call) — ``render_diagnostic_ephemeral`` hands
+        the analyzer's ``render_image`` an object-API axes, so overlays
+        (projections, markers, calibrated axes) come through without
+        any pyplot state on a request thread. Same status ladder as the
+        pixel path: unknown diagnostic 404, denylisted / invalid config
+        400, analyzer failure 400, and "ran but cannot be drawn"
+        (``RenderError``) 404 — the pixel path's "render failed" /
+        "produces no processed image" code.
+        """
+        ephemeral = _ephemeral_module()
         try:
-            (fig,) = render_diagnostic_ephemeral(
+            (fig,) = ephemeral.render_diagnostic_ephemeral(
                 processing,
                 [array],
                 config_dir=processing_config_dir,
                 **_figure_kwargs(render),
             )
-            return _figure_png(fig)
+            return resources.figure_png(fig)
         except (KeyError, FileNotFoundError) as exc:
             raise HTTPException(
                 status_code=404, detail=f"no diagnostic: {exc}"
             ) from exc
-        except ValueError as exc:  # denylisted, invalid config, or unrenderable result
-            raise HTTPException(status_code=400, detail=str(exc)) from exc
-        except Exception as exc:  # noqa: BLE001 — analyzer/renderer failure, never a 500
+        except ephemeral.RenderError as exc:
             raise HTTPException(
-                status_code=400, detail=f"render failed: {exc}"
+                status_code=404, detail=f"render failed: {exc}"
+            ) from exc
+        except ValueError as exc:  # denylisted, or invalid config
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+        except Exception as exc:  # noqa: BLE001 — analyzer failure, never a 500
+            raise HTTPException(
+                status_code=400, detail=f"processing failed: {exc}"
             ) from exc
 
     def _render_frame_figure(array, render: dict) -> bytes:
         """The rendered view of an averaged image: base renderer, no overlays."""
+        ephemeral = _ephemeral_module()
         try:
-            from image_analysis.ephemeral import render_frame_figure
-        except ImportError as exc:
-            raise HTTPException(
-                status_code=404,
-                detail="processing needs the portal's 'analysis' extra "
-                "(pip install geecs-data-portal[analysis])",
-            ) from exc
-        try:
-            return _figure_png(render_frame_figure(array, **_figure_kwargs(render)))
+            return resources.figure_png(
+                ephemeral.render_frame_figure(array, **_figure_kwargs(render))
+            )
         except Exception as exc:  # noqa: BLE001 — never a 500
             raise HTTPException(
-                status_code=400, detail=f"render failed: {exc}"
+                status_code=404, detail=f"render failed: {exc}"
             ) from exc
 
     def _pretty_names(detail, pf, columns: list[str]) -> dict:
@@ -1052,22 +1067,9 @@ def create_app(
         endpoint ladder: unknown diagnostic → 404, denylisted/miswired
         → 400, analyzer failure → 400 honestly — never a 500.
         """
-        if processing_config_dir is None:
-            raise HTTPException(
-                status_code=404,
-                detail="processing is not configured on this portal "
-                "(start it with --processing-configs)",
-            )
+        ephemeral = _ephemeral_module()
         try:
-            from image_analysis.ephemeral import run_diagnostic_ephemeral
-        except ImportError as exc:
-            raise HTTPException(
-                status_code=404,
-                detail="processing needs the portal's 'analysis' extra "
-                "(pip install geecs-data-portal[analysis])",
-            ) from exc
-        try:
-            results = run_diagnostic_ephemeral(
+            results = ephemeral.run_diagnostic_ephemeral(
                 processing, arrays, config_dir=processing_config_dir
             )
         except (KeyError, FileNotFoundError) as exc:
@@ -1080,7 +1082,9 @@ def create_app(
             raise HTTPException(
                 status_code=400, detail=f"processing failed: {exc}"
             ) from exc
-        processed = [result.processed_image for result in results]
+        # getattr: a legacy analyzer returning a dict (BCaveMagSpecStitcher)
+        # must be a refusal here, not an AttributeError → 500.
+        processed = [getattr(result, "processed_image", None) for result in results]
         if any(image is None for image in processed):
             raise HTTPException(
                 status_code=404,
@@ -1590,10 +1594,8 @@ def create_app(
         ax.set_ylabel(y, parse_math=False)
         ax.grid(True, alpha=0.3)
         fig.tight_layout()
-        buffer = io.BytesIO()
-        fig.savefig(buffer, format="png")
         return Response(
-            content=buffer.getvalue(),
+            content=resources.figure_png(fig),
             media_type="image/png",
             headers=_png_headers(detail),
         )

--- a/GEECS-DataPortal/geecs_portal/app.py
+++ b/GEECS-DataPortal/geecs_portal/app.py
@@ -428,6 +428,85 @@ def create_app(
             "phi": disp.get("phi"),
         }
 
+    def _rendered(disp: dict) -> bool:
+        """``display.mode == "rendered"`` — the analyzer-figure view."""
+        return disp.get("mode") == "rendered"
+
+    def _figure_kwargs(render: dict) -> dict:
+        """The display slice as the ephemeral renderers' kwargs (value-degrade)."""
+        return {
+            "cmap": resources.safe_cmap(render.get("cmap")),
+            "window": resources.window_percentiles(
+                render.get("plo"), render.get("phi")
+            ),
+        }
+
+    def _figure_png(fig: Figure) -> bytes:
+        """Object-API figure → PNG bytes (never pyplot; safe on the threadpool)."""
+        buffer = io.BytesIO()
+        fig.savefig(buffer, format="png")
+        return buffer.getvalue()
+
+    def _render_processing_figure(array, processing: str, render: dict) -> bytes:
+        """The rendered view of ONE shot: the analyzer draws its own result.
+
+        Same seam family as ``_apply_processing`` (write-free, denylist,
+        one analyzer per call) — ``render_diagnostic_ephemeral`` hands
+        the analyzer's ``render_image`` an object-API axes, so overlays
+        (projections, markers, calibrated axes) come through without
+        any pyplot state on a request thread. Refusal ladder as for
+        processing; a renderer failure is an honest 400.
+        """
+        if processing_config_dir is None:
+            raise HTTPException(
+                status_code=404,
+                detail="processing is not configured on this portal "
+                "(start it with --processing-configs)",
+            )
+        try:
+            from image_analysis.ephemeral import render_diagnostic_ephemeral
+        except ImportError as exc:
+            raise HTTPException(
+                status_code=404,
+                detail="processing needs the portal's 'analysis' extra "
+                "(pip install geecs-data-portal[analysis])",
+            ) from exc
+        try:
+            (fig,) = render_diagnostic_ephemeral(
+                processing,
+                [array],
+                config_dir=processing_config_dir,
+                **_figure_kwargs(render),
+            )
+            return _figure_png(fig)
+        except (KeyError, FileNotFoundError) as exc:
+            raise HTTPException(
+                status_code=404, detail=f"no diagnostic: {exc}"
+            ) from exc
+        except ValueError as exc:  # denylisted, invalid config, or unrenderable result
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+        except Exception as exc:  # noqa: BLE001 — analyzer/renderer failure, never a 500
+            raise HTTPException(
+                status_code=400, detail=f"render failed: {exc}"
+            ) from exc
+
+    def _render_frame_figure(array, render: dict) -> bytes:
+        """The rendered view of an averaged image: base renderer, no overlays."""
+        try:
+            from image_analysis.ephemeral import render_frame_figure
+        except ImportError as exc:
+            raise HTTPException(
+                status_code=404,
+                detail="processing needs the portal's 'analysis' extra "
+                "(pip install geecs-data-portal[analysis])",
+            ) from exc
+        try:
+            return _figure_png(render_frame_figure(array, **_figure_kwargs(render)))
+        except Exception as exc:  # noqa: BLE001 — never a 500
+            raise HTTPException(
+                status_code=400, detail=f"render failed: {exc}"
+            ) from exc
+
     def _pretty_names(detail, pf, columns: list[str]) -> dict:
         """Figure titles/legend names, by the columns endpoint's rule.
 
@@ -1325,7 +1404,8 @@ def create_app(
         values degrade, per the display doctrine).
         """
         detail = _load_run(uid)
-        render = _render_opts(_display(display))
+        disp = _display(display)
+        render = _render_opts(disp)
         folder, _ = _image_folder(detail, day, device)
         # A shot beyond the recorded event rows must refuse outright:
         # falling through to the ordinal join would serve an orphan
@@ -1354,13 +1434,18 @@ def create_app(
                 raise HTTPException(
                     status_code=404, detail=resolved.reason or resolved.kind
                 )
-            (processed,) = _apply_processing([resolved.array], processing)
-            try:
-                png = resources.to_display_png(processed, **render)
-            except Exception as exc:  # noqa: BLE001 — must not 500
-                raise HTTPException(
-                    status_code=404, detail=f"render failed: {exc}"
-                ) from exc
+            if _rendered(disp):
+                # The analyzer's own figure (overlays + axes + colorbar)
+                # instead of the windowed processed pixels.
+                png = _render_processing_figure(resolved.array, processing, render)
+            else:
+                (processed,) = _apply_processing([resolved.array], processing)
+                try:
+                    png = resources.to_display_png(processed, **render)
+                except Exception as exc:  # noqa: BLE001 — must not 500
+                    raise HTTPException(
+                        status_code=404, detail=f"render failed: {exc}"
+                    ) from exc
             # A processed response is a function of (pixels, diagnostic
             # YAML, ImageAnalysis version); the URL keys only the first,
             # and the configs tree is local and MUTABLE — iterating on
@@ -1411,7 +1496,8 @@ def create_app(
         correct order for nonlinear pipeline steps like thresholding).
         """
         detail = _load_run(uid)
-        render = _render_opts(_display(display))
+        disp = _display(display)
+        render = _render_opts(disp)
         folder, _ = _image_folder(detail, day, device)
         pf = scan_frame(detail, folder)
         _, mask = _masked(pf, filters)
@@ -1456,12 +1542,17 @@ def create_app(
             raise HTTPException(
                 status_code=404, detail="no renderable frames in this bin"
             )
-        try:
-            png = resources.to_display_png(averaged, **render)
-        except Exception as exc:  # noqa: BLE001 — unrenderable shape must not 500
-            raise HTTPException(
-                status_code=404, detail=f"render failed: {exc}"
-            ) from exc
+        if processing and _rendered(disp):
+            # An average of several results is not one result: the base
+            # renderer (axes + colorbar), per-shot overlays dropped.
+            png = _render_frame_figure(averaged, render)
+        else:
+            try:
+                png = resources.to_display_png(averaged, **render)
+            except Exception as exc:  # noqa: BLE001 — unrenderable shape must not 500
+                raise HTTPException(
+                    status_code=404, detail=f"render failed: {exc}"
+                ) from exc
         # Never immutable: bin membership comes off the union frame
         # (mutable s-file), and the diagnostic YAML behind ``processing``
         # is likewise a mutable input the URL does not key (see run_image).

--- a/GEECS-DataPortal/geecs_portal/resources.py
+++ b/GEECS-DataPortal/geecs_portal/resources.py
@@ -104,6 +104,20 @@ def image_devices(scan_folder: Path) -> list[str]:
         return []
 
 
+def safe_cmap(cmap: Optional[str]) -> Optional[str]:
+    """A known matplotlib colormap name, else None (value-degrade: grayscale)."""
+    if not cmap:
+        return None
+    import matplotlib as mpl
+
+    return str(cmap) if str(cmap) in mpl.colormaps else None
+
+
+def window_percentiles(plo, phi) -> tuple[float, float]:
+    """Public alias of :func:`_window_percentiles` (the rendered view shares it)."""
+    return _window_percentiles(plo, phi)
+
+
 def _window_percentiles(plo, phi) -> tuple[float, float]:
     """The display window's percentile pair — value-degrade semantics.
 

--- a/GEECS-DataPortal/geecs_portal/resources.py
+++ b/GEECS-DataPortal/geecs_portal/resources.py
@@ -113,12 +113,14 @@ def safe_cmap(cmap: Optional[str]) -> Optional[str]:
     return str(cmap) if str(cmap) in mpl.colormaps else None
 
 
+def figure_png(fig) -> bytes:
+    """Object-API figure → PNG bytes (never pyplot; safe on the threadpool)."""
+    buffer = io.BytesIO()
+    fig.savefig(buffer, format="png")
+    return buffer.getvalue()
+
+
 def window_percentiles(plo, phi) -> tuple[float, float]:
-    """Public alias of :func:`_window_percentiles` (the rendered view shares it)."""
-    return _window_percentiles(plo, phi)
-
-
-def _window_percentiles(plo, phi) -> tuple[float, float]:
     """The display window's percentile pair — value-degrade semantics.
 
     Display values ride shared links and must never make a link fail
@@ -176,7 +178,7 @@ def to_display_png(
 
     data = np.asarray(array, dtype=np.float32)
     lo_pct, hi_pct = (
-        _window_percentiles(plo, phi)
+        window_percentiles(plo, phi)
         if (plo is not None or phi is not None)
         else (_P_LO, _P_HI)
     )
@@ -190,13 +192,11 @@ def to_display_png(
     else:
         norm = np.clip((data - lo) / (hi - lo), 0.0, 1.0)
     colormap = None
-    if cmap and data.ndim == 2:
+    known = safe_cmap(cmap)  # unknown name: grayscale, never a failure
+    if known and data.ndim == 2:
         import matplotlib as mpl
 
-        try:
-            colormap = mpl.colormaps[str(cmap)]
-        except KeyError:
-            colormap = None  # unknown name: grayscale, never a failure
+        colormap = mpl.colormaps[known]
     if colormap is not None:
         # bytes=True skips the H×W×4 float64 RGBA intermediate — same
         # output bytes at ~1/8 the transient memory on full frames.

--- a/GEECS-DataPortal/geecs_portal/templates/run.html
+++ b/GEECS-DataPortal/geecs_portal/templates/run.html
@@ -393,6 +393,9 @@
     <div class="setrow"><label>window percentiles</label>
       <input id="id-plo" style="width:4.5rem;"> <span class="dim">–</span>
       <input id="id-phi" style="width:4.5rem;"></div>
+    <div class="setrow"><label>rendered figure</label>
+      <input type="checkbox" id="id-mode" style="width:auto;">
+      <span class="dim" style="font-size:11px;">the analyzer's own plot (overlays, axes, colorbar) — needs a processing selection; per-bin shows the averaged image without overlays</span></div>
     <p class="dim" style="font-size:11px;">Applies to the served images (per-shot and per-bin);
     defaults 1 – 99.7. Out-of-range values fall back to the defaults.</p>
     <div class="btnrow">
@@ -734,6 +737,7 @@ function openImgDisplay() {
   document.getElementById("id-cmap").value = typeof d.cmap === "string" ? d.cmap : "";
   document.getElementById("id-plo").value = typeof d.plo === "number" ? d.plo : 1;
   document.getElementById("id-phi").value = typeof d.phi === "number" ? d.phi : 99.7;
+  document.getElementById("id-mode").checked = d.mode === "rendered";
   document.getElementById("modal-imgdisplay").classList.add("on");
 }
 
@@ -748,6 +752,7 @@ function applyImgDisplay() {
   const phi = parseFloat(document.getElementById("id-phi").value);
   if (isFinite(plo) && plo !== 1) d.plo = plo; else delete d.plo;
   if (isFinite(phi) && phi !== 99.7) d.phi = phi; else delete d.phi;
+  if (document.getElementById("id-mode").checked) d.mode = "rendered"; else delete d.mode;
   S.display = Object.keys(d).length ? JSON.stringify(d) : "";
   closeModals();
   writeState();

--- a/GEECS-DataPortal/pyproject.toml
+++ b/GEECS-DataPortal/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-data-portal"
-version = "0.17.0"
+version = "0.18.0"
 description = "Scan-browsing web service (read-only except explicit analysis runs): a zero-install browser view over the Tiled catalog and the GEECS data share"
 authors = ["GEECS-BELLA"]
 readme = "README.md"

--- a/GEECS-DataPortal/tests/test_resources.py
+++ b/GEECS-DataPortal/tests/test_resources.py
@@ -1008,3 +1008,87 @@ class TestImageDisplay:
         )
         assert response.status_code == 200
         assert np.array(Image.open(io.BytesIO(response.content))).ndim == 3
+
+
+class TestRenderedView:
+    """``display.mode = "rendered"``: the analyzer's figure instead of the pixels."""
+
+    # Borrow the selector's fixtures + client (not inheritance: that
+    # would re-collect its tests under this class).
+    configs_tree = TestProcessingSelector.configs_tree
+    analysis_extra = TestProcessingSelector.analysis_extra
+    _client = TestProcessingSelector._client
+
+    def test_per_shot_rendered_is_a_figure_not_the_pixels(
+        self, scan_folder, configs_tree, analysis_extra
+    ):
+        client = self._client(scan_folder, configs_tree)
+        pixels = client.get(
+            "/run/uid-002/image.png",
+            params={"device": "cam", "shot": 1, "processing": "UC_Crop"},
+        )
+        rendered = client.get(
+            "/run/uid-002/image.png",
+            params={
+                "device": "cam",
+                "shot": 1,
+                "processing": "UC_Crop",
+                "display": '{"mode": "rendered", "cmap": "viridis"}',
+            },
+        )
+        assert pixels.status_code == 200 and rendered.status_code == 200
+        assert rendered.headers["cache-control"] == "no-cache"
+        # The pixel view is the 2x3 crop; the figure is a full plot canvas.
+        assert np.array(Image.open(io.BytesIO(pixels.content))).shape == (2, 3)
+        canvas = Image.open(io.BytesIO(rendered.content))
+        assert canvas.size[0] > 200 and canvas.size[1] > 200
+
+    def test_rendered_without_processing_is_the_raw_pixels(
+        self, scan_folder, configs_tree, analysis_extra
+    ):
+        client = self._client(scan_folder, configs_tree)
+        response = client.get(
+            "/run/uid-002/image.png",
+            params={"device": "cam", "shot": 1, "display": '{"mode": "rendered"}'},
+        )
+        assert response.status_code == 200
+        assert np.array(Image.open(io.BytesIO(response.content))).shape == (5, 5)
+
+    def test_per_bin_rendered_is_the_averaged_base_figure(
+        self, scan_folder, configs_tree, analysis_extra
+    ):
+        client = self._client(scan_folder, configs_tree)
+        response = client.get(
+            "/run/uid-002/bin-image.png",
+            params={
+                "device": "cam",
+                "bin": 0,
+                "processing": "UC_Crop",
+                "display": '{"mode": "rendered"}',
+            },
+        )
+        assert response.status_code == 200
+        assert response.headers["cache-control"] == "no-cache"
+        canvas = Image.open(io.BytesIO(response.content))
+        assert canvas.size[0] > 200
+
+    def test_bad_mode_is_400_and_unknown_cmap_degrades(
+        self, scan_folder, configs_tree, analysis_extra
+    ):
+        client = self._client(scan_folder, configs_tree)
+        bad = client.get(
+            "/run/uid-002/image.png",
+            params={"device": "cam", "shot": 1, "display": '{"mode": "3d"}'},
+        )
+        assert bad.status_code == 400
+        assert "mode" in bad.json()["detail"]
+        degraded = client.get(
+            "/run/uid-002/image.png",
+            params={
+                "device": "cam",
+                "shot": 1,
+                "processing": "UC_Crop",
+                "display": '{"mode": "rendered", "cmap": "no-such-map"}',
+            },
+        )
+        assert degraded.status_code == 200

--- a/GEECS-DataPortal/tests/test_resources.py
+++ b/GEECS-DataPortal/tests/test_resources.py
@@ -1092,3 +1092,35 @@ class TestRenderedView:
             },
         )
         assert degraded.status_code == 200
+
+    def test_unrenderable_result_matches_the_pixel_paths_404(
+        self, scan_folder, configs_tree, analysis_extra
+    ):
+        """A diagnostic that ran but cannot be drawn is a 404 in both views."""
+        import yaml
+
+        scalars = configs_tree / "analyzers" / "HTU" / "UC_Scalars.yaml"
+        scalars.write_text(
+            yaml.safe_dump(
+                {
+                    "name": "UC_Scalars",
+                    "image_analyzer": (
+                        "image_analysis.analyzers.standard_analyzer.StandardAnalyzer"
+                    ),
+                    "image": {"type": "camera", "bit_depth": 16},
+                    "scan": {"priority": 100},
+                }
+            )
+        )
+        client = self._client(scan_folder, configs_tree)
+        # Sanity: the plain rendered path works for this diagnostic.
+        ok = client.get(
+            "/run/uid-002/image.png",
+            params={
+                "device": "cam",
+                "shot": 1,
+                "processing": "UC_Scalars",
+                "display": '{"mode": "rendered"}',
+            },
+        )
+        assert ok.status_code == 200

--- a/GEECS-DataPortal/tests/test_resources.py
+++ b/GEECS-DataPortal/tests/test_resources.py
@@ -1094,33 +1094,75 @@ class TestRenderedView:
         assert degraded.status_code == 200
 
     def test_unrenderable_result_matches_the_pixel_paths_404(
-        self, scan_folder, configs_tree, analysis_extra
+        self, scan_folder, configs_tree, analysis_extra, monkeypatch
     ):
-        """A diagnostic that ran but cannot be drawn is a 404 in both views."""
-        import yaml
+        """A diagnostic that ran but cannot be drawn is a 404 in every view.
 
-        scalars = configs_tree / "analyzers" / "HTU" / "UC_Scalars.yaml"
-        scalars.write_text(
-            yaml.safe_dump(
-                {
-                    "name": "UC_Scalars",
-                    "image_analyzer": (
-                        "image_analysis.analyzers.standard_analyzer.StandardAnalyzer"
-                    ),
-                    "image": {"type": "camera", "bit_depth": 16},
-                    "scan": {"priority": 100},
-                }
-            )
+        ``StandardAnalyzer`` is patched to hand back a scalars-only result
+        (the per-frame-copy test's trick): the pixel path refuses it as
+        "produces no processed image", the rendered paths as
+        ``RenderError`` → "render failed" — same code, so a display
+        checkbox never changes the status of the same input.
+        """
+        from image_analysis.analyzers.standard_analyzer import StandardAnalyzer
+        from image_analysis.types import ImageAnalyzerResult
+
+        monkeypatch.setattr(
+            StandardAnalyzer,
+            "analyze_image",
+            lambda self, image, aux=None: ImageAnalyzerResult(
+                data_type="scalars_only", scalars={"x": 1.0}
+            ),
         )
         client = self._client(scan_folder, configs_tree)
-        # Sanity: the plain rendered path works for this diagnostic.
-        ok = client.get(
+        pixel = client.get(
+            "/run/uid-002/image.png",
+            params={"device": "cam", "shot": 1, "processing": "UC_Crop"},
+        )
+        rendered = client.get(
             "/run/uid-002/image.png",
             params={
                 "device": "cam",
                 "shot": 1,
-                "processing": "UC_Scalars",
+                "processing": "UC_Crop",
                 "display": '{"mode": "rendered"}',
             },
         )
-        assert ok.status_code == 200
+        binned = client.get(
+            "/run/uid-002/bin-image.png",
+            params={
+                "device": "cam",
+                "bin": 0,
+                "processing": "UC_Crop",
+                "display": '{"mode": "rendered"}',
+            },
+        )
+        assert pixel.status_code == 404
+        assert "no processed image" in pixel.json()["detail"]
+        assert rendered.status_code == 404
+        assert "render failed" in rendered.json()["detail"]
+        assert binned.status_code == 404
+
+    def test_legacy_dict_result_is_a_404_in_both_views(
+        self, scan_folder, configs_tree, analysis_extra, monkeypatch
+    ):
+        """BCaveMagSpecStitcher-style dict returns: refused, never a 500."""
+        from image_analysis.analyzers.standard_analyzer import StandardAnalyzer
+
+        monkeypatch.setattr(
+            StandardAnalyzer,
+            "analyze_image",
+            lambda self, image, aux=None: {"legacy": 1},
+        )
+        client = self._client(scan_folder, configs_tree)
+        for display in ("", '{"mode": "rendered"}'):
+            response = client.get(
+                "/run/uid-002/image.png",
+                params={
+                    "device": "cam",
+                    "shot": 1,
+                    "processing": "UC_Crop",
+                    "display": display,
+                },
+            )
+            assert response.status_code == 404, display

--- a/ImageAnalysis/CHANGELOG.md
+++ b/ImageAnalysis/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to this package will be documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
-## [1.14.0] — 2026-09-02
+## [1.14.0] — 2026-09-01
 
 ### Added
 
@@ -17,10 +17,14 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   `cmap` and a percentile `window` (→ `vmin`/`vmax`); 1D renderers take
   neither. Same write-free contract (the `file_path` refusal and
   `EPHEMERAL_DENYLIST` apply unchanged). Companions:
-  `render_result_figure(analyzer, result, …)` and
+  `render_result_figure(renderer, result, …)` and
   `render_frame_figure(image, …)` (base renderer only — for averaged
-  images whose per-shot overlays do not average). The data portal's
-  "rendered figure" display mode is the first consumer.
+  images whose per-shot overlays do not average) live in
+  `image_analysis.tools.rendering` with `new_figure`, `window_limits`
+  and `RenderError` (the typed "diagnostic ran, picture cannot be
+  drawn" failure); `ephemeral` re-exports them. The `ax=` contract of
+  every Standard-family `render_image` is now pinned by tests. The data
+  portal's "rendered figure" display mode is the first consumer.
 - `run_diagnostic_ephemeral` is unchanged in behaviour; its body is now
   shared helpers (`_ephemeral_analyzer`, `_analyze_frames`).
 

--- a/ImageAnalysis/CHANGELOG.md
+++ b/ImageAnalysis/CHANGELOG.md
@@ -3,6 +3,27 @@
 All notable changes to this package will be documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [1.14.0] — 2026-09-02
+
+### Added
+
+- `image_analysis.ephemeral.render_diagnostic_ephemeral(name, frames, *,
+  config_dir, overrides, auxiliary_data, window, cmap, figsize, dpi)` —
+  the render form of the ephemeral seam: one analyzer instantiation,
+  `analyze_image` per frame, then the analyzer's own `render_image`
+  drawn into an **object-API** `matplotlib.figure.Figure` (never
+  pyplot — no global registry, safe on a request threadpool), with the
+  colorbar the base renderer skips when handed an axes. 2D results take
+  `cmap` and a percentile `window` (→ `vmin`/`vmax`); 1D renderers take
+  neither. Same write-free contract (the `file_path` refusal and
+  `EPHEMERAL_DENYLIST` apply unchanged). Companions:
+  `render_result_figure(analyzer, result, …)` and
+  `render_frame_figure(image, …)` (base renderer only — for averaged
+  images whose per-shot overlays do not average). The data portal's
+  "rendered figure" display mode is the first consumer.
+- `run_diagnostic_ephemeral` is unchanged in behaviour; its body is now
+  shared helpers (`_ephemeral_analyzer`, `_analyze_frames`).
+
 ## [1.13.1] — 2026-09-01
 
 ### Fixed

--- a/ImageAnalysis/CLAUDE.md
+++ b/ImageAnalysis/CLAUDE.md
@@ -355,7 +355,17 @@ Invariant is pinned by tests:
 diagnostic over already-loaded frames with a hard no-writes guarantee —
 the seam read-only viewers (the data portal's processing selector,
 exploratory notebooks) use to get the production pipeline without the
-production side effects.
+production side effects. Its render form,
+`render_diagnostic_ephemeral(..., window=, cmap=, figsize=, dpi=)`
+(1.14.0), additionally draws each result with the analyzer's own
+`render_image` into an **object-API `Figure`** — never pyplot, so it is
+safe on a web server's threadpool — and adds the colorbar the base
+renderer skips when handed an axes. `render_image` must therefore keep
+honouring an `ax=` argument (every Standard-family renderer does; the
+2D ones are `@staticmethod`s taking `vmin`/`vmax`/`cmap`, the 1D one an
+instance method taking plot kwargs). `render_frame_figure(image, …)`
+is the base-renderer-only companion for images that are not one
+result (bin averages).
 
 The write gate is structural, and it depends on two conventions that
 **must survive analyzer changes**:

--- a/ImageAnalysis/CLAUDE.md
+++ b/ImageAnalysis/CLAUDE.md
@@ -373,9 +373,10 @@ that ignored `ax` would return an empty seam figure AND leak a
 pyplot-registered figure per request on a server thread. Known
 exception: `Undulator/BCaveMagSpecStitcher.py` keeps a legacy
 `render_image(image, analysis_results_dict, …)` signature (and a
-legacy dict `analyze_image` return) — through the seam it raises
-`RenderError` honestly; it predates the `ImageAnalyzerResult` contract
-and is not a template. `render_frame_figure(image, …)` is the
+legacy dict `analyze_image` return) — through the seam either shape
+ends as a `RenderError` (the dict reaches its renderer and fails
+there); it predates the `ImageAnalyzerResult` contract and is not a
+template. `render_frame_figure(image, …)` is the
 base-renderer-only companion for images that are not one result (bin
 averages).
 

--- a/ImageAnalysis/CLAUDE.md
+++ b/ImageAnalysis/CLAUDE.md
@@ -360,12 +360,24 @@ production side effects. Its render form,
 (1.14.0), additionally draws each result with the analyzer's own
 `render_image` into an **object-API `Figure`** — never pyplot, so it is
 safe on a web server's threadpool — and adds the colorbar the base
-renderer skips when handed an axes. `render_image` must therefore keep
-honouring an `ax=` argument (every Standard-family renderer does; the
-2D ones are `@staticmethod`s taking `vmin`/`vmax`/`cmap`, the 1D one an
-instance method taking plot kwargs). `render_frame_figure(image, …)`
-is the base-renderer-only companion for images that are not one
-result (bin averages).
+renderer skips when handed an axes. The object-API helpers live in
+`image_analysis.tools.rendering` (`new_figure`, `window_limits`,
+`render_result_figure`, `render_frame_figure`, `RenderError`) next to
+`base_render_image`; the ephemeral module only composes them with the
+write gate. **`render_image` must keep honouring an `ax=` argument** —
+pinned by `tests/test_ephemeral.py` for `StandardAnalyzer`,
+`BeamAnalyzer`, `HiResMagCamAnalyzer`, `MagSpecManualCalibAnalyzer`
+(2D `@staticmethod`s taking `vmin`/`vmax`/`cmap`) and
+`Standard1DAnalyzer` (instance method taking plot kwargs). A renderer
+that ignored `ax` would return an empty seam figure AND leak a
+pyplot-registered figure per request on a server thread. Known
+exception: `Undulator/BCaveMagSpecStitcher.py` keeps a legacy
+`render_image(image, analysis_results_dict, …)` signature (and a
+legacy dict `analyze_image` return) — through the seam it raises
+`RenderError` honestly; it predates the `ImageAnalyzerResult` contract
+and is not a template. `render_frame_figure(image, …)` is the
+base-renderer-only companion for images that are not one result (bin
+averages).
 
 The write gate is structural, and it depends on two conventions that
 **must survive analyzer changes**:

--- a/ImageAnalysis/image_analysis/ephemeral.py
+++ b/ImageAnalysis/image_analysis/ephemeral.py
@@ -32,9 +32,8 @@ from __future__ import annotations
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Sequence, Tuple, Union
 
-import numpy as np
-
 from .config import create_image_analyzer, load_diagnostic
+from .tools.rendering import RenderError, render_frame_figure, render_result_figure
 from .types import Array2D, ImageAnalyzerResult
 
 if TYPE_CHECKING:
@@ -44,6 +43,7 @@ if TYPE_CHECKING:
 
 __all__ = [
     "EPHEMERAL_DENYLIST",
+    "RenderError",
     "render_diagnostic_ephemeral",
     "render_frame_figure",
     "render_result_figure",
@@ -168,92 +168,6 @@ def _analyze_frames(
     ]
 
 
-def _new_figure(figsize: Tuple[float, float], dpi: int) -> Tuple["Figure", Any]:
-    """An object-API figure + axes (no pyplot: no global registry, thread-safe)."""
-    from matplotlib.figure import Figure
-
-    fig = Figure(figsize=figsize, dpi=dpi, constrained_layout=True)
-    return fig, fig.subplots()
-
-
-def _window_limits(
-    image: Optional[np.ndarray], window: Optional[Tuple[float, float]]
-) -> Dict[str, float]:
-    """``vmin``/``vmax`` from a percentile *window* over *image* (or nothing)."""
-    if window is None or image is None:
-        return {}
-    lo, hi = np.nanpercentile(np.asarray(image, dtype=float), list(window))
-    if not np.isfinite(lo) or not np.isfinite(hi) or lo >= hi:
-        return {}
-    return {"vmin": float(lo), "vmax": float(hi)}
-
-
-def render_result_figure(
-    analyzer: "ImageAnalyzer",
-    result: ImageAnalyzerResult,
-    *,
-    window: Optional[Tuple[float, float]] = None,
-    cmap: Optional[str] = None,
-    figsize: Tuple[float, float] = (5.0, 4.2),
-    dpi: int = 110,
-) -> "Figure":
-    """Draw *result* with *analyzer*'s own ``render_image`` into an object-API figure.
-
-    The renderer is handed our axes, so its overlays (projections,
-    markers, calibrated axes — whatever ``render_data`` carries) land on
-    a ``matplotlib.figure.Figure`` that never touched pyplot. The base
-    renderer skips its colorbar when given an axes, so one is added
-    here whenever an image was drawn. 2D results take ``cmap`` and a
-    percentile ``window`` (→ ``vmin``/``vmax`` over the processed
-    image); 1D renderers take neither (their signature is
-    ``ax`` + plot kwargs).
-
-    Raises
-    ------
-    AttributeError
-        If the analyzer has no ``render_image`` (every Standard-family
-        analyzer does).
-    ValueError
-        Propagated from the renderer (e.g. a 1D result handed to a 2D
-        renderer).
-    """
-    fig, ax = _new_figure(figsize, dpi)
-    kwargs: Dict[str, Any] = {}
-    if result.data_type == "2d":
-        if cmap:
-            kwargs["cmap"] = cmap
-        kwargs.update(_window_limits(result.processed_image, window))
-    analyzer.render_image(result, ax=ax, **kwargs)
-    if ax.images:
-        fig.colorbar(ax.images[0], ax=ax, shrink=0.65)
-    return fig
-
-
-def render_frame_figure(
-    image: Array2D,
-    *,
-    window: Optional[Tuple[float, float]] = None,
-    cmap: Optional[str] = None,
-    figsize: Tuple[float, float] = (5.0, 4.2),
-    dpi: int = 110,
-) -> "Figure":
-    """Draw a bare 2D image with the base renderer (no analyzer overlays).
-
-    For images that are not one analyzer result — an average of several
-    processed frames, whose per-shot overlays do not average meaningfully.
-    """
-    from .tools.rendering import base_render_image
-
-    fig, ax = _new_figure(figsize, dpi)
-    result = ImageAnalyzerResult(data_type="2d", processed_image=np.asarray(image))
-    kwargs: Dict[str, Any] = {"cmap": cmap} if cmap else {}
-    kwargs.update(_window_limits(result.processed_image, window))
-    base_render_image(result, ax=ax, **kwargs)
-    if ax.images:
-        fig.colorbar(ax.images[0], ax=ax, shrink=0.65)
-    return fig
-
-
 def render_diagnostic_ephemeral(
     name_or_path: Union[str, Path],
     frames: Sequence[Array2D],
@@ -268,11 +182,14 @@ def render_diagnostic_ephemeral(
 ) -> List["Figure"]:
     """Run a diagnostic over in-memory frames and draw each result its own way.
 
-    :func:`run_diagnostic_ephemeral` plus :func:`render_result_figure`
-    per frame, with one analyzer instantiation for the batch and the
-    same write-free contract (the ``file_path`` refusal and the
-    denylist apply unchanged). Returns object-API figures — no pyplot
-    state is created, so this is safe on a request threadpool.
+    :func:`run_diagnostic_ephemeral` plus
+    :func:`image_analysis.tools.rendering.render_result_figure` per
+    frame, with one analyzer instantiation for the batch and the same
+    write-free contract (the ``file_path`` refusal and the denylist
+    apply unchanged). Returns object-API figures — no pyplot state is
+    created, so this is safe on a request threadpool. A renderer that
+    cannot draw a result raises :class:`RenderError` (distinct from the
+    contract/config errors raised before any frame is analyzed).
 
     Parameters
     ----------

--- a/ImageAnalysis/image_analysis/ephemeral.py
+++ b/ImageAnalysis/image_analysis/ephemeral.py
@@ -30,12 +30,25 @@ structural, not conventional:
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Sequence, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Sequence, Tuple, Union
+
+import numpy as np
 
 from .config import create_image_analyzer, load_diagnostic
 from .types import Array2D, ImageAnalyzerResult
 
-__all__ = ["EPHEMERAL_DENYLIST", "run_diagnostic_ephemeral"]
+if TYPE_CHECKING:
+    from matplotlib.figure import Figure
+
+    from .base import ImageAnalyzer
+
+__all__ = [
+    "EPHEMERAL_DENYLIST",
+    "render_diagnostic_ephemeral",
+    "render_frame_figure",
+    "render_result_figure",
+    "run_diagnostic_ephemeral",
+]
 
 #: Analyzer class paths that cannot run ephemerally: their side effects
 #: are not gated on ``auxiliary_data["file_path"]``, so no calling
@@ -103,6 +116,23 @@ def run_diagnostic_ephemeral(
         If ``auxiliary_data`` contains ``file_path``, or the diagnostic's
         analyzer class is on :data:`EPHEMERAL_DENYLIST`.
     """
+    analyzer = _ephemeral_analyzer(
+        name_or_path,
+        config_dir=config_dir,
+        overrides=overrides,
+        auxiliary_data=auxiliary_data,
+    )
+    return _analyze_frames(analyzer, frames, auxiliary_data)
+
+
+def _ephemeral_analyzer(
+    name_or_path: Union[str, Path],
+    *,
+    config_dir: Optional[Path],
+    overrides: Optional[Dict[str, Any]],
+    auxiliary_data: Optional[Dict[str, Any]],
+) -> "ImageAnalyzer":
+    """The write-free gate + one analyzer instantiation (shared by both runners)."""
     if auxiliary_data is not None and "file_path" in auxiliary_data:
         raise ValueError(
             "auxiliary_data['file_path'] is forbidden in ephemeral runs: "
@@ -122,10 +152,153 @@ def run_diagnostic_ephemeral(
             f"remove it from EPHEMERAL_DENYLIST."
         )
 
-    analyzer = create_image_analyzer(diag)
+    return create_image_analyzer(diag)
+
+
+def _analyze_frames(
+    analyzer: "ImageAnalyzer",
+    frames: Sequence[Array2D],
+    auxiliary_data: Optional[Dict[str, Any]],
+) -> List[ImageAnalyzerResult]:
     return [
         analyzer.analyze_image(
             frame, dict(auxiliary_data) if auxiliary_data is not None else None
         )
         for frame in frames
+    ]
+
+
+def _new_figure(figsize: Tuple[float, float], dpi: int) -> Tuple["Figure", Any]:
+    """An object-API figure + axes (no pyplot: no global registry, thread-safe)."""
+    from matplotlib.figure import Figure
+
+    fig = Figure(figsize=figsize, dpi=dpi, constrained_layout=True)
+    return fig, fig.subplots()
+
+
+def _window_limits(
+    image: Optional[np.ndarray], window: Optional[Tuple[float, float]]
+) -> Dict[str, float]:
+    """``vmin``/``vmax`` from a percentile *window* over *image* (or nothing)."""
+    if window is None or image is None:
+        return {}
+    lo, hi = np.nanpercentile(np.asarray(image, dtype=float), list(window))
+    if not np.isfinite(lo) or not np.isfinite(hi) or lo >= hi:
+        return {}
+    return {"vmin": float(lo), "vmax": float(hi)}
+
+
+def render_result_figure(
+    analyzer: "ImageAnalyzer",
+    result: ImageAnalyzerResult,
+    *,
+    window: Optional[Tuple[float, float]] = None,
+    cmap: Optional[str] = None,
+    figsize: Tuple[float, float] = (5.0, 4.2),
+    dpi: int = 110,
+) -> "Figure":
+    """Draw *result* with *analyzer*'s own ``render_image`` into an object-API figure.
+
+    The renderer is handed our axes, so its overlays (projections,
+    markers, calibrated axes — whatever ``render_data`` carries) land on
+    a ``matplotlib.figure.Figure`` that never touched pyplot. The base
+    renderer skips its colorbar when given an axes, so one is added
+    here whenever an image was drawn. 2D results take ``cmap`` and a
+    percentile ``window`` (→ ``vmin``/``vmax`` over the processed
+    image); 1D renderers take neither (their signature is
+    ``ax`` + plot kwargs).
+
+    Raises
+    ------
+    AttributeError
+        If the analyzer has no ``render_image`` (every Standard-family
+        analyzer does).
+    ValueError
+        Propagated from the renderer (e.g. a 1D result handed to a 2D
+        renderer).
+    """
+    fig, ax = _new_figure(figsize, dpi)
+    kwargs: Dict[str, Any] = {}
+    if result.data_type == "2d":
+        if cmap:
+            kwargs["cmap"] = cmap
+        kwargs.update(_window_limits(result.processed_image, window))
+    analyzer.render_image(result, ax=ax, **kwargs)
+    if ax.images:
+        fig.colorbar(ax.images[0], ax=ax, shrink=0.65)
+    return fig
+
+
+def render_frame_figure(
+    image: Array2D,
+    *,
+    window: Optional[Tuple[float, float]] = None,
+    cmap: Optional[str] = None,
+    figsize: Tuple[float, float] = (5.0, 4.2),
+    dpi: int = 110,
+) -> "Figure":
+    """Draw a bare 2D image with the base renderer (no analyzer overlays).
+
+    For images that are not one analyzer result — an average of several
+    processed frames, whose per-shot overlays do not average meaningfully.
+    """
+    from .tools.rendering import base_render_image
+
+    fig, ax = _new_figure(figsize, dpi)
+    result = ImageAnalyzerResult(data_type="2d", processed_image=np.asarray(image))
+    kwargs: Dict[str, Any] = {"cmap": cmap} if cmap else {}
+    kwargs.update(_window_limits(result.processed_image, window))
+    base_render_image(result, ax=ax, **kwargs)
+    if ax.images:
+        fig.colorbar(ax.images[0], ax=ax, shrink=0.65)
+    return fig
+
+
+def render_diagnostic_ephemeral(
+    name_or_path: Union[str, Path],
+    frames: Sequence[Array2D],
+    *,
+    config_dir: Optional[Path] = None,
+    overrides: Optional[Dict[str, Any]] = None,
+    auxiliary_data: Optional[Dict[str, Any]] = None,
+    window: Optional[Tuple[float, float]] = None,
+    cmap: Optional[str] = None,
+    figsize: Tuple[float, float] = (5.0, 4.2),
+    dpi: int = 110,
+) -> List["Figure"]:
+    """Run a diagnostic over in-memory frames and draw each result its own way.
+
+    :func:`run_diagnostic_ephemeral` plus :func:`render_result_figure`
+    per frame, with one analyzer instantiation for the batch and the
+    same write-free contract (the ``file_path`` refusal and the
+    denylist apply unchanged). Returns object-API figures — no pyplot
+    state is created, so this is safe on a request threadpool.
+
+    Parameters
+    ----------
+    name_or_path, frames, config_dir, overrides, auxiliary_data
+        As for :func:`run_diagnostic_ephemeral`.
+    window : (lo, hi) percentiles, optional
+        Display window over each processed image → ``vmin``/``vmax``.
+    cmap : str, optional
+        Matplotlib colormap name for 2D results.
+    figsize, dpi
+        Figure geometry.
+
+    Returns
+    -------
+    list of matplotlib.figure.Figure
+        One figure per input frame, in order.
+    """
+    analyzer = _ephemeral_analyzer(
+        name_or_path,
+        config_dir=config_dir,
+        overrides=overrides,
+        auxiliary_data=auxiliary_data,
+    )
+    return [
+        render_result_figure(
+            analyzer, result, window=window, cmap=cmap, figsize=figsize, dpi=dpi
+        )
+        for result in _analyze_frames(analyzer, frames, auxiliary_data)
     ]

--- a/ImageAnalysis/image_analysis/tools/rendering.py
+++ b/ImageAnalysis/image_analysis/tools/rendering.py
@@ -420,7 +420,10 @@ def render_result_figure(
         result with no 2D image, ``TypeError`` for a legacy signature).
     """
     kwargs: Dict[str, Any] = {}
-    if result.data_type == "2d":
+    # getattr: a legacy analyzer handing back a dict (no ``data_type``)
+    # must reach the renderer and fail as a RenderError like every
+    # other undrawable result, not as a bare AttributeError here.
+    if getattr(result, "data_type", None) == "2d":
         if cmap:
             kwargs["cmap"] = cmap
         kwargs.update(window_limits(result.processed_image, window))

--- a/ImageAnalysis/image_analysis/tools/rendering.py
+++ b/ImageAnalysis/image_analysis/tools/rendering.py
@@ -8,7 +8,7 @@ docstring conventions.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Optional, Tuple, Literal
+from typing import TYPE_CHECKING, Any, Callable, Dict, Optional, Tuple, Literal
 
 import numpy as np
 import matplotlib.pyplot as plt
@@ -323,3 +323,131 @@ def add_marker(
         alpha=alpha,
         label=label,
     )
+
+
+# ---------------------------------------------------------------------------
+# Object-API figures (no pyplot): thread-safe rendering for servers/notebooks
+# ---------------------------------------------------------------------------
+
+
+class RenderError(RuntimeError):
+    """A renderer failed on a result it could not draw.
+
+    Raised by :func:`render_result_figure` / :func:`render_frame_figure`
+    wrapping the renderer's own exception, so a caller can tell "the
+    diagnostic ran but its picture cannot be drawn" (a result with no
+    2D image, a legacy renderer signature) from configuration or
+    contract errors raised before rendering.
+    """
+
+
+def new_figure(
+    figsize: Tuple[float, float] = (5.0, 4.2), dpi: int = 110
+) -> Tuple["Figure", "Axes"]:
+    """An object-API figure + axes — never pyplot, so no global registry.
+
+    The figure has no window and is garbage-collected after ``savefig``;
+    safe on a web server's threadpool.
+    """
+    from matplotlib.figure import Figure
+
+    fig = Figure(figsize=figsize, dpi=dpi, constrained_layout=True)
+    return fig, fig.subplots()
+
+
+def window_limits(
+    image: Optional[np.ndarray], window: Optional[Tuple[float, float]]
+) -> Dict[str, float]:
+    """``vmin``/``vmax`` from a percentile *window* over *image*'s finite pixels.
+
+    Empty, all-NaN, constant or degenerate inputs return ``{}`` (autoscale)
+    rather than raising or warning — display cosmetics must never fail a
+    request.
+    """
+    if window is None or image is None:
+        return {}
+    data = np.asarray(image, dtype=float).ravel()
+    finite = data[np.isfinite(data)]
+    if finite.size < 2:
+        return {}
+    lo, hi = np.percentile(finite, list(window))
+    if not (lo < hi):
+        return {}
+    return {"vmin": float(lo), "vmax": float(hi)}
+
+
+def _draw(
+    draw: Callable[["Axes"], object],
+    figsize: Tuple[float, float],
+    dpi: int,
+) -> "Figure":
+    """Run *draw(ax)* on a fresh object-API axes; add the colorbar the base renderer skips."""
+    fig, ax = new_figure(figsize, dpi)
+    try:
+        draw(ax)
+    except Exception as exc:  # noqa: BLE001 — typed so callers can map it
+        raise RenderError(f"{type(exc).__name__}: {exc}") from exc
+    if ax.images:
+        # base_render_image only adds a colorbar when IT created the axes.
+        fig.colorbar(ax.images[0], ax=ax, shrink=0.65)
+    return fig
+
+
+def render_result_figure(
+    renderer: Any,
+    result: ImageAnalyzerResult,
+    *,
+    window: Optional[Tuple[float, float]] = None,
+    cmap: Optional[str] = None,
+    figsize: Tuple[float, float] = (5.0, 4.2),
+    dpi: int = 110,
+) -> "Figure":
+    """Draw *result* with *renderer*'s own ``render_image`` into an object-API figure.
+
+    *renderer* is an analyzer instance or class exposing
+    ``render_image(result, ..., ax=)`` — the 2D Standard family's are
+    ``@staticmethod``s taking ``vmin``/``vmax``/``cmap``, the 1D one an
+    instance method taking plot kwargs — so its overlays (projections,
+    markers, calibrated axes, whatever ``render_data`` carries) land on
+    our axes without pyplot. 2D results take ``cmap`` and a percentile
+    ``window`` (→ ``vmin``/``vmax`` over the processed image); 1D results
+    take neither.
+
+    Raises
+    ------
+    RenderError
+        Wrapping whatever the renderer raised (e.g. ``ValueError`` for a
+        result with no 2D image, ``TypeError`` for a legacy signature).
+    """
+    kwargs: Dict[str, Any] = {}
+    if result.data_type == "2d":
+        if cmap:
+            kwargs["cmap"] = cmap
+        kwargs.update(window_limits(result.processed_image, window))
+    return _draw(
+        lambda ax: renderer.render_image(result, ax=ax, **kwargs), figsize, dpi
+    )
+
+
+def render_frame_figure(
+    image: np.ndarray,
+    *,
+    window: Optional[Tuple[float, float]] = None,
+    cmap: Optional[str] = None,
+    figsize: Tuple[float, float] = (5.0, 4.2),
+    dpi: int = 110,
+) -> "Figure":
+    """Draw a bare 2D image with :func:`base_render_image` (no analyzer overlays).
+
+    For images that are not one analyzer result — an average of several
+    processed frames, whose per-shot overlays do not average meaningfully.
+
+    Raises
+    ------
+    RenderError
+        Wrapping the base renderer's failure (e.g. a non-2D array).
+    """
+    result = ImageAnalyzerResult(data_type="2d", processed_image=np.asarray(image))
+    kwargs: Dict[str, Any] = {"cmap": cmap} if cmap else {}
+    kwargs.update(window_limits(result.processed_image, window))
+    return _draw(lambda ax: base_render_image(result, ax=ax, **kwargs), figsize, dpi)

--- a/ImageAnalysis/pyproject.toml
+++ b/ImageAnalysis/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "imageanalysis"
-version = "1.13.1"
+version = "1.14.0"
 description = "Central sub-repository for online and offline analysis of BELLA exeriments' images."
 authors = ["Reinier van Mourik <reinier.vanmourik@tausystems.com>"]
 readme = "README.md"

--- a/ImageAnalysis/tests/test_ephemeral.py
+++ b/ImageAnalysis/tests/test_ephemeral.py
@@ -170,3 +170,65 @@ class TestListDiagnostics:
     def test_missing_analyzers_dir_raises(self, tmp_path):
         with pytest.raises(FileNotFoundError, match="Analyzer directory"):
             list_diagnostics(config_dir=tmp_path)
+
+
+class TestRenderedEphemeral:
+    """The render form: the analyzer's own figure, object API, still write-free."""
+
+    def test_one_figure_per_frame_with_image_and_colorbar(self, configs_tree):
+        from image_analysis.ephemeral import render_diagnostic_ephemeral
+
+        rng = np.random.default_rng(0)
+        frames = [rng.integers(0, 100, (8, 6)).astype(np.uint16) for _ in range(2)]
+        figs = render_diagnostic_ephemeral(
+            "UC_Test", frames, config_dir=configs_tree, cmap="viridis", window=(1, 99)
+        )
+        assert len(figs) == 2
+        for fig in figs:
+            ax = fig.axes[0]
+            assert len(ax.images) == 1  # the processed image
+            assert len(fig.axes) == 2  # + the colorbar the base renderer skipped
+            assert ax.images[0].get_cmap().name == "viridis"
+            lo, hi = ax.images[0].get_clim()
+            assert 0 <= lo < hi <= 100  # the percentile window became vmin/vmax
+
+    def test_no_pyplot_state_is_created(self, configs_tree):
+        """Object-API figures only — safe on a request threadpool."""
+        import matplotlib.pyplot as plt
+
+        from image_analysis.ephemeral import render_diagnostic_ephemeral
+
+        plt.close("all")
+        render_diagnostic_ephemeral(
+            "UC_Test", [np.ones((4, 4))], config_dir=configs_tree
+        )
+        assert plt.get_fignums() == []
+
+    def test_render_form_keeps_the_write_gate(self, configs_tree, tmp_path):
+        from image_analysis.ephemeral import render_diagnostic_ephemeral
+
+        with pytest.raises(ValueError, match="file_path"):
+            render_diagnostic_ephemeral(
+                "UC_Test",
+                [np.ones((4, 4))],
+                config_dir=configs_tree,
+                auxiliary_data={"file_path": tmp_path / "x.png"},
+            )
+        _write_diagnostic(
+            tmp_path / "analyzers" / "HTU" / "U_HasoR.yaml",
+            "U_HasoR",
+            image_analyzer=_HASO_PATH,
+        )
+        with pytest.raises(ValueError, match="cannot run ephemerally"):
+            render_diagnostic_ephemeral(
+                "U_HasoR", [np.ones((4, 4))], config_dir=tmp_path
+            )
+
+    def test_frame_figure_is_base_render_only(self):
+        from image_analysis.ephemeral import render_frame_figure
+
+        fig = render_frame_figure(np.arange(16.0).reshape(4, 4), window=(0, 100))
+        ax = fig.axes[0]
+        assert len(ax.images) == 1 and len(fig.axes) == 2
+        assert ax.images[0].get_clim() == (0.0, 15.0)
+        assert not ax.lines  # no overlays on an averaged image

--- a/ImageAnalysis/tests/test_ephemeral.py
+++ b/ImageAnalysis/tests/test_ephemeral.py
@@ -232,3 +232,91 @@ class TestRenderedEphemeral:
         assert len(ax.images) == 1 and len(fig.axes) == 2
         assert ax.images[0].get_clim() == (0.0, 15.0)
         assert not ax.lines  # no overlays on an averaged image
+
+    def test_the_analyzers_own_overlays_are_drawn(self):
+        """The point of the seam: render_image is the ANALYZER's, not the base."""
+        from image_analysis.analyzers.beam_analyzer import BeamAnalyzer
+        from image_analysis.tools.rendering import render_result_figure
+
+        image = np.zeros((6, 8))
+        image[2, 3] = 10.0
+        result = ImageAnalyzerResult(
+            data_type="2d",
+            processed_image=image,
+            render_data={
+                "horizontal_projection": image.sum(axis=0),
+                "vertical_projection": image.sum(axis=1),
+            },
+        )
+        fig = render_result_figure(BeamAnalyzer, result)
+        ax = fig.axes[0]
+        assert len(ax.images) == 1
+        assert ax.lines, "BeamAnalyzer's projection overlays must reach the seam's axes"
+
+    @pytest.mark.parametrize(
+        "class_path",
+        [
+            "image_analysis.analyzers.standard_analyzer.StandardAnalyzer",
+            "image_analysis.analyzers.beam_analyzer.BeamAnalyzer",
+            "image_analysis.analyzers.Undulator.hi_res_mag_cam_analyzer.HiResMagCamAnalyzer",
+            "image_analysis.analyzers.magspec_manual_calib_analyzer.MagSpecManualCalibAnalyzer",
+        ],
+    )
+    def test_2d_renderers_honour_the_ax_contract(self, class_path):
+        """Every 2D render_image draws INTO the axes it is given, without pyplot.
+
+        The load-bearing contract of the render seam (ImageAnalysis
+        CLAUDE.md "Ephemeral runs"): a renderer that ignored ``ax`` would
+        return an empty seam figure AND leak a pyplot-registered figure
+        per request on a server thread.
+        """
+        import importlib
+
+        import matplotlib.pyplot as plt
+
+        from image_analysis.tools.rendering import render_result_figure
+
+        module_path, class_name = class_path.rsplit(".", 1)
+        renderer = getattr(importlib.import_module(module_path), class_name)
+        plt.close("all")
+        result = ImageAnalyzerResult(data_type="2d", processed_image=np.ones((5, 7)))
+        fig = render_result_figure(renderer, result, cmap="viridis")
+        assert len(fig.axes[0].images) == 1
+        assert plt.get_fignums() == []
+
+    def test_1d_renderer_honours_the_ax_contract(self):
+        import matplotlib.pyplot as plt
+
+        from image_analysis.analyzers.standard_1d_analyzer import Standard1DAnalyzer
+        from image_analysis.tools.rendering import render_result_figure
+
+        plt.close("all")
+        line = np.column_stack([np.arange(10.0), np.arange(10.0) ** 2])
+        result = ImageAnalyzerResult(data_type="1d", line_data=line)
+        fig = render_result_figure(
+            Standard1DAnalyzer.__new__(Standard1DAnalyzer), result
+        )
+        assert fig.axes[0].lines
+        assert plt.get_fignums() == []
+
+    def test_unrenderable_result_is_a_render_error(self):
+        from image_analysis.analyzers.standard_analyzer import StandardAnalyzer
+        from image_analysis.tools.rendering import RenderError, render_result_figure
+
+        result = ImageAnalyzerResult(data_type="scalars_only", scalars={"x": 1.0})
+        with pytest.raises(RenderError, match="data_type='2d'"):
+            render_result_figure(StandardAnalyzer, result)
+
+    @pytest.mark.parametrize(
+        "image",
+        [np.zeros((0, 5)), np.full((4, 4), np.nan), np.ones((4, 4)), np.zeros((4, 4))],
+        ids=["empty", "all-nan", "constant", "zeros"],
+    )
+    def test_window_limits_degrade_never_raise(self, image):
+        import warnings
+
+        from image_analysis.tools.rendering import window_limits
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            assert window_limits(image, (1, 99)) == {}

--- a/ImageAnalysis/tests/test_ephemeral.py
+++ b/ImageAnalysis/tests/test_ephemeral.py
@@ -306,6 +306,9 @@ class TestRenderedEphemeral:
         result = ImageAnalyzerResult(data_type="scalars_only", scalars={"x": 1.0})
         with pytest.raises(RenderError, match="data_type='2d'"):
             render_result_figure(StandardAnalyzer, result)
+        # A legacy dict "result" (no data_type) is the same typed failure.
+        with pytest.raises(RenderError):
+            render_result_figure(StandardAnalyzer, {"legacy": 1})
 
     @pytest.mark.parametrize(
         "image",

--- a/Planning/data_portal/04_analysis_run_design.md
+++ b/Planning/data_portal/04_analysis_run_design.md
@@ -288,7 +288,9 @@ no-auth stance is restated with the run verb in view.
    analyzer (no share, no hardware).
 3. **`portal/analysis-tab`** — the tab: listing, run, poll, artifacts,
    errors.
-4. **`portal/rendered-view`** — the seam + the third display mode.
+4. **`portal/rendered-view`** — the seam + the third display mode
+   (#766: `render_diagnostic_ephemeral` composing
+   `tools.rendering.render_result_figure`; `display.mode`).
 5. **Promotion PR → master** (maintainer merges), then deploy (extra +
    read-write mount) and the live check below.
 
@@ -313,5 +315,7 @@ rendered toggle shows the analyzer's overlays on the per-shot image.
   real (the claim gate, or the status contract — see B/C above).
 - Per-bin rendering with overlays that *do* average (projections):
   needs a per-analyzer "aggregate render" hook; not designed.
-- Where the rendered toggle's figure size / dpi live in the display
-  state vocabulary (`analysis.py::_DISPLAY_FIELDS`).
+- ~~Where the rendered toggle's figure size / dpi live in the display
+  state vocabulary~~ — answered by PR 4 (#766): they are the seam's
+  defaults (5.0×4.2 in @ 110 dpi), not display state; add knobs only
+  when someone asks.


### PR DESCRIPTION
## What

PR 4 of the `feat/analysis-tab` arc (`Planning/data_portal/04_analysis_run_design.md`): the **rendered view** — the interactivity stop-gap the owner chose over a plotly heatmap. **Stacked on #765 (merge #765 first)**; will be retargeted to `feat/analysis-tab` once it lands.

Per-concern LOC:

- **ImageAnalysis 1.13.1 → 1.14.0** (`ephemeral.py`, +~150): `render_diagnostic_ephemeral(name, frames, *, config_dir, overrides, auxiliary_data, window, cmap, figsize, dpi)` — one analyzer instantiation, `analyze_image` per frame, then the analyzer's own `render_image` drawn into an **object-API `Figure`** (never pyplot; no global registry; the test pins `plt.get_fignums() == []`), plus the colorbar the base renderer skips when handed an axes. Same write-free contract: the `file_path` refusal and `EPHEMERAL_DENYLIST` apply unchanged (pinned). Companions `render_result_figure` and `render_frame_figure` (base renderer only, for averaged images). `run_diagnostic_ephemeral` is unchanged in behaviour; its body became the shared helpers.
- **GEECS-DataPortal 0.17.0 → 0.18.0** (+~120 across `analysis.py`, `resources.py`, `app.py`, `run.html`): `display.mode ∈ ("", "rendered")` (else 400); per-shot `image.png` with `processing` + rendered → the analyzer's figure; per-bin `bin-image.png` rendered → base renderer over the averaged processed image (overlays dropped — they do not average); `cmap` value-degrades via `resources.safe_cmap`, the percentile window becomes `vmin`/`vmax`; without `processing` the mode is ignored. The display popup gains a "rendered figure" checkbox stored as `mode` in the shared display state (URL-carried like everything else).
- Docs: ImageAnalysis CLAUDE.md "Ephemeral runs" (the `ax=` contract renderers must keep), portal CLAUDE.md display paragraph, both CHANGELOGs.

## Judgment calls (cheap to veto)

- **Seam placement**: the render form lives in `image_analysis.ephemeral` next to the run form (same gate, same denylist, one instantiation) rather than the portal reaching `render_image` directly — the doc left this open; this keeps the write-free contract in one module.
- **Per-bin = base renderer, no overlays** (the doc's ruling). A per-analyzer "aggregate render" hook stays an open question.
- **Figure geometry fixed** (5.0×4.2 in @ 110 dpi); the display-state vocabulary gains no size knobs yet (open question in the doc).
- Colorbar added by the seam whenever an image was drawn — the base renderer only adds one when it created the axes.

## Tests

- ImageAnalysis `tests/test_ephemeral.py::TestRenderedEphemeral`: **4 new** (figure per frame with image + colorbar + cmap + clim from the window; no pyplot state; write gate + denylist on the render form; frame figure = base render, no overlays). Existing 9 ephemeral tests unchanged and green.
- Portal `tests/test_resources.py::TestRenderedView`: **4 new** (per-shot rendered is a plot canvas, not the 2×3 crop; rendered without processing = raw pixels; per-bin rendered; bad mode 400 + unknown cmap degrades).
- Portal suite + ImageAnalysis ephemeral tests, run together in the portal env: **231 passed** (portal 218 = 214 + 4 new; ephemeral 13 = 9 + 4 new).

## Hardware verification

**OWED at promotion**: on the worker host, pick a processing diagnostic on a real scan, tick "rendered figure" → the analyzer's overlays (projections / markers / calibrated axes) appear on the per-shot image; per-bin shows the averaged image with axes and colorbar. No scan execution or devices touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018K1DmUzf1ZPjM4NxX2QRX3
