### PR TITLE
Named scan plans: GeecsBluesky 0.73.0 + GEECS-Schemas 0.17.0 (schema refactor Phase 2b-ii)

### DIFF
--- a/GEECS-Schemas/CHANGELOG.md
+++ b/GEECS-Schemas/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to GEECS-Schemas are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.17.0] - 2026-09-02
+
+### Added
+
+- **Named-plan parameter artifacts** (Phase 2b-ii): the export registry
+  gains `capture_settings`, `action_bindings`, `scan_axis`, and
+  `optimization_spec` — the sub-models the queueserver's named plans
+  (`geecs_noscan_plan`, `geecs_scan_plan`, `geecs_optimize_plan`, GeecsBluesky
+  0.73.0) take as parameters, published under `docs/geecs_schemas/` so a
+  generic client grafts one JSON Schema per plan parameter. No new models:
+  the named plans are thin wrappers over the existing ScanRequest vocabulary.
+
 ## [0.16.0] - 2026-09-02
 
 ### Added

--- a/GEECS-Schemas/geecs_schemas/schema_export.py
+++ b/GEECS-Schemas/geecs_schemas/schema_export.py
@@ -29,13 +29,31 @@ from typing import Optional
 
 from pydantic import BaseModel
 
-from geecs_schemas.scan_request import ScanRequest
+from geecs_schemas.scan_request import (
+    ActionBindings,
+    CaptureSettings,
+    OptimizationSpec,
+    ScanAxis,
+    ScanRequest,
+)
 
 #: The published JSON Schema contracts: artifact name → model.  Each entry
 #: renders to ``docs/geecs_schemas/<name>.schema.json``.  Add a line here
 #: and regenerate; the no-drift guard covers it from then on.
+#:
+#: ``scan_request`` is the funnel plan's one parameter.  The four
+#: sub-models are the named plans' parameters (Phase 2b-ii):
+#: ``geecs_noscan_plan(capture, actions=...)``,
+#: ``geecs_scan_plan(axes, capture, actions=...)`` (``axes`` is a list of
+#: ``scan_axis`` objects), ``geecs_optimize_plan(optimization, capture,
+#: actions=...)`` — a generic client grafts one artifact per plan
+#: parameter.
 EXPORTED_SCHEMAS: dict[str, type[BaseModel]] = {
     "scan_request": ScanRequest,
+    "capture_settings": CaptureSettings,
+    "action_bindings": ActionBindings,
+    "scan_axis": ScanAxis,
+    "optimization_spec": OptimizationSpec,
 }
 
 #: Where the artifacts live, relative to the repo root.

--- a/GEECS-Schemas/pyproject.toml
+++ b/GEECS-Schemas/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-schemas"
-version = "0.16.0"
+version = "0.17.0"
 description = "Versioned Pydantic schemas for GEECS scanner configs (scan requests, save sets, scan variables, trigger profiles, action plans) plus legacy-YAML converters."
 authors = ["Sam Barber <sbarber@lbl.gov>"]
 readme = "README.md"

--- a/GeecsBluesky/CHANGELOG.md
+++ b/GeecsBluesky/CHANGELOG.md
@@ -4,6 +4,25 @@ All notable changes to `geecs-bluesky` are documented here.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.73.0] - 2026-09-02
+
+### Added
+
+- **Three named scan plans** (schema refactor Phase 2b-ii;
+  `plans/named_plans.py`, registered by the worker startup beside the
+  funnel): `geecs_noscan_plan(capture, actions=, description=, background=)`,
+  `geecs_scan_plan(axes, capture, …)` (1-D and grid as one plan), and
+  `geecs_optimize_plan(optimization, capture, …)` (the search space stays
+  inside `OptimizationSpec.variables`, as it always has — no bounds model).
+  Each assembles the canonical `ScanRequest` and yields from
+  `geecs_scan_request_plan`, so validation, the claim, the run discipline,
+  and the recorded metadata are identical to the funnel's (pinned by
+  document-parity tests on the mock RunEngine). They exist for humans and
+  gates: per-mode forms (one published JSON Schema per parameter,
+  GEECS-Schemas 0.17.0), per-plan `user_group_permissions`, and a manager
+  history that names the kind of scan. The funnel stays the document API
+  for GEECS-Console and GEECS-MCP — no client change.
+
 ## [0.72.0] - 2026-09-02
 
 ### Changed

--- a/GeecsBluesky/CLAUDE.md
+++ b/GeecsBluesky/CLAUDE.md
@@ -121,6 +121,11 @@ geecs_bluesky/
     single_shot.py          # geecs_single_shot + geecs_confirm_quiescent
     t0_sync.py              # geecs_t0_sync — coordinated per-device t0 capture
     run_wrapper.py          # geecs_run_wrapper + claim_scan_number (numbering + save + md)
+    named_plans.py          # geecs_noscan_plan / geecs_scan_plan /
+                            #   geecs_optimize_plan — per-mode vocabulary at the
+                            #   gate (Phase 2b-ii): each assembles the canonical
+                            #   ScanRequest and yields from the funnel; one
+                            #   published JSON Schema per parameter
     scan_request_plan.py    # geecs_scan_request_plan — "run this ScanRequest"
                             #   as ONE plan (queueserver round 1, issue #633;
                             #   the only orchestration since Phase 2a): the
@@ -236,7 +241,10 @@ EVENT_SCHEMA.md — the canonical event-schema v1 data contract (read it).
 `qserver/` holds the worker: `launch_re_manager.sh` (Redis + the
 bluesky-0MQ-proxy document stream + `start-re-manager --keep-re`),
 `startup/startup.py` (builds the headless `GeecsSession`, exposes its
-`RE`, registers `geecs_scan_request_plan` + `geecs_run_action_plan` and
+`RE`, registers `geecs_scan_request_plan` + `geecs_run_action_plan` + the
+three named plans (`plans/named_plans.py`: `geecs_noscan_plan` /
+`geecs_scan_plan` / `geecs_optimize_plan` — per-mode parameters, each
+assembling a `ScanRequest` and yielding from the funnel; Phase 2b-ii) and
 the `function_execute` manual verbs `geecs_move_variable` /
 `geecs_describe_action`, subscribes Tiled + the s-file stop-doc callback,
 registers the optimization loader), `user_group_permissions.yaml`, and

--- a/GeecsBluesky/geecs_bluesky/plans/named_plans.py
+++ b/GeecsBluesky/geecs_bluesky/plans/named_plans.py
@@ -35,7 +35,10 @@ seams stay unannotated.  Pinned by ``tests/test_named_plans.py``.
 
 from __future__ import annotations
 
-from geecs_bluesky.plans.scan_request_plan import geecs_scan_request_plan
+from geecs_bluesky.plans.scan_request_plan import (
+    SCAN_REQUEST_PLAN_ANNOTATION,
+    geecs_scan_request_plan,
+)
 
 __all__ = [
     "geecs_noscan_plan",
@@ -50,9 +53,11 @@ __all__ = [
 def _request(mode: str, **fields: object) -> dict:
     """Assemble the canonical ScanRequest document for *mode*.
 
-    Only the fields the caller set travel; ``None`` values are omitted so
-    the schema's own defaults apply (an omitted ``actions`` is the empty
-    bindings, an omitted ``background`` is ``False``).
+    ``None`` values are omitted so the schema's own default applies (an
+    omitted ``actions`` is the empty bindings); the plans' other defaults
+    (``description=""``, ``background=False``) equal the schema's, so a
+    document assembled here validates to the same request the funnel would
+    be handed for the same operator input.
     """
     document: dict = {"mode": mode}
     document.update({key: value for key, value in fields.items() if value is not None})
@@ -65,6 +70,7 @@ def geecs_noscan_plan(
     actions=None,
     description: str = "",
     background: bool = False,
+    failed_move_policy=None,
     submission=None,
     session=None,
     resolver=None,
@@ -82,8 +88,9 @@ def geecs_noscan_plan(
         Free-text note for the scan metadata and the experiment log.
     background : bool
         Mark the shots as background/calibration data.
-    submission, session, resolver :
-        As on :func:`~geecs_bluesky.plans.scan_request_plan.geecs_scan_request_plan`.
+    failed_move_policy, submission, session, resolver :
+        As on :func:`~geecs_bluesky.plans.scan_request_plan.geecs_scan_request_plan`
+        — the funnel's queue-settable surface, unchanged.
 
     Yields
     ------
@@ -99,7 +106,11 @@ def geecs_noscan_plan(
     )
     return (
         yield from geecs_scan_request_plan(
-            request, submission=submission, session=session, resolver=resolver
+            request,
+            submission=submission,
+            session=session,
+            resolver=resolver,
+            failed_move_policy=failed_move_policy,
         )
     )
 
@@ -111,6 +122,7 @@ def geecs_scan_plan(
     actions=None,
     description: str = "",
     background: bool = False,
+    failed_move_policy=None,
     submission=None,
     session=None,
     resolver=None,
@@ -130,8 +142,9 @@ def geecs_scan_plan(
         Free-text note for the scan metadata and the experiment log.
     background : bool
         Mark the shots as background/calibration data.
-    submission, session, resolver :
-        As on :func:`~geecs_bluesky.plans.scan_request_plan.geecs_scan_request_plan`.
+    failed_move_policy, submission, session, resolver :
+        As on :func:`~geecs_bluesky.plans.scan_request_plan.geecs_scan_request_plan`
+        — the funnel's queue-settable surface, unchanged.
 
     Yields
     ------
@@ -148,7 +161,11 @@ def geecs_scan_plan(
     )
     return (
         yield from geecs_scan_request_plan(
-            request, submission=submission, session=session, resolver=resolver
+            request,
+            submission=submission,
+            session=session,
+            resolver=resolver,
+            failed_move_policy=failed_move_policy,
         )
     )
 
@@ -159,6 +176,8 @@ def geecs_optimize_plan(
     *,
     actions=None,
     description: str = "",
+    background: bool = False,
+    failed_move_policy=None,
     submission=None,
     session=None,
     resolver=None,
@@ -181,8 +200,11 @@ def geecs_optimize_plan(
         action hooks yet; see the funnel).
     description : str
         Free-text note for the scan metadata and the experiment log.
-    submission, session, resolver :
-        As on :func:`~geecs_bluesky.plans.scan_request_plan.geecs_scan_request_plan`.
+    background : bool
+        Mark the shots as background/calibration data.
+    failed_move_policy, submission, session, resolver :
+        As on :func:`~geecs_bluesky.plans.scan_request_plan.geecs_scan_request_plan`
+        — the funnel's queue-settable surface, unchanged.
 
     Yields
     ------
@@ -195,10 +217,15 @@ def geecs_optimize_plan(
         capture=capture,
         actions=actions,
         description=description,
+        background=background,
     )
     return (
         yield from geecs_scan_request_plan(
-            request, submission=submission, session=session, resolver=resolver
+            request,
+            submission=submission,
+            session=session,
+            resolver=resolver,
+            failed_move_policy=failed_move_policy,
         )
     )
 
@@ -224,23 +251,17 @@ _SHARED_PARAMETERS: dict = {
         "description": "Free-text note for the scan metadata and the experiment log.",
         "annotation": "str",
     },
-    "submission": {
+    "failed_move_policy": {
         "description": (
-            "Optional client-stamped SubmissionRecord as a JSON object; "
-            "recorded verbatim in run metadata."
+            "What a failed scan-axis move does: 'pause' (the default — the "
+            "RE Manager renders the paused state; resume/stop are queue "
+            "verbs) or 'raise'. As on geecs_scan_request_plan."
         ),
     },
-    "session": {
-        "description": (
-            "Worker-internal GeecsSession — leave unset; the worker startup "
-            "installs the default."
-        ),
-    },
-    "resolver": {
-        "description": (
-            "Worker-internal config resolver — leave unset; defaults to the "
-            "worker's configs checkout."
-        ),
+    # The funnel's own prose for its seams — one wording, imported.
+    **{
+        key: SCAN_REQUEST_PLAN_ANNOTATION["parameters"][key]
+        for key in ("submission", "session", "resolver")
     },
 }
 _BACKGROUND_PARAMETER: dict = {
@@ -296,5 +317,6 @@ OPTIMIZE_PLAN_ANNOTATION: dict = {
             "annotation": "dict",
         },
         **_SHARED_PARAMETERS,
+        **_BACKGROUND_PARAMETER,
     },
 }

--- a/GeecsBluesky/geecs_bluesky/plans/named_plans.py
+++ b/GeecsBluesky/geecs_bluesky/plans/named_plans.py
@@ -1,0 +1,300 @@
+"""The three named scan plans — per-mode vocabulary at the queue gate.
+
+Phase 2b-ii of ``Planning/schema_refactor/00_overview.md``: beside the
+funnel (:func:`~geecs_bluesky.plans.scan_request_plan.geecs_scan_request_plan`,
+which takes one whole ``ScanRequest`` document) the worker registers one
+plan per scan mode, each taking only that mode's fields:
+
+- :func:`geecs_noscan_plan` — capture settings + actions (+ background);
+- :func:`geecs_scan_plan` — axes (1-D or grid) + the shared components;
+- :func:`geecs_optimize_plan` — the optimization spec (which carries its
+  own variables and bounds) + the shared components.
+
+They exist for the humans and the gates, not the machines: a generic
+client renders a per-mode form (one published JSON Schema per parameter —
+see ``geecs_schemas.schema_export.EXPORTED_SCHEMAS``), the manager's
+``user_group_permissions`` can allow noscans to a group while gating
+optimize, and the manager history names the kind of scan that ran.
+
+**Shared-execution invariant (non-negotiable):** every named plan assembles
+a canonical ``ScanRequest`` document and yields from the funnel — the same
+preamble, validation, claim, run discipline, and run metadata — so the
+document recorded in every start doc is a ``ScanRequest`` regardless of
+entry plan, and every downstream reader sees one shape.  Nothing here
+validates, resolves, or touches hardware; a bad parameter fails inside the
+funnel's authoritative validation, pre-claim.
+
+The funnel stays as the programmatic/compat entry point for GEECS-Console
+and GEECS-MCP (the document API); these are wrappers, not a migration.
+
+Signature constraint (queueserver contract, as on the funnel): the RE
+Manager re-evaluates the annotation strings in a bare namespace at ``queue
+add``, so parameters carry builtin annotations only and the worker-internal
+seams stay unannotated.  Pinned by ``tests/test_named_plans.py``.
+"""
+
+from __future__ import annotations
+
+from geecs_bluesky.plans.scan_request_plan import geecs_scan_request_plan
+
+__all__ = [
+    "geecs_noscan_plan",
+    "geecs_scan_plan",
+    "geecs_optimize_plan",
+    "NOSCAN_PLAN_ANNOTATION",
+    "SCAN_PLAN_ANNOTATION",
+    "OPTIMIZE_PLAN_ANNOTATION",
+]
+
+
+def _request(mode: str, **fields: object) -> dict:
+    """Assemble the canonical ScanRequest document for *mode*.
+
+    Only the fields the caller set travel; ``None`` values are omitted so
+    the schema's own defaults apply (an omitted ``actions`` is the empty
+    bindings, an omitted ``background`` is ``False``).
+    """
+    document: dict = {"mode": mode}
+    document.update({key: value for key, value in fields.items() if value is not None})
+    return document
+
+
+def geecs_noscan_plan(
+    capture: dict,
+    *,
+    actions=None,
+    description: str = "",
+    background: bool = False,
+    submission=None,
+    session=None,
+    resolver=None,
+):
+    """Take shots without moving anything — a ``noscan`` ScanRequest.
+
+    Parameters
+    ----------
+    capture : dict
+        ``CaptureSettings`` as JSON: shots, acquisition discipline, save
+        sets, telemetry / native-image toggles, trigger profile.
+    actions : dict, optional
+        ``ActionBindings`` as JSON (setup / per_step / closeout plan names).
+    description : str
+        Free-text note for the scan metadata and the experiment log.
+    background : bool
+        Mark the shots as background/calibration data.
+    submission, session, resolver :
+        As on :func:`~geecs_bluesky.plans.scan_request_plan.geecs_scan_request_plan`.
+
+    Yields
+    ------
+    Msg
+        The funnel plan's messages, unchanged.
+    """
+    request = _request(
+        "noscan",
+        capture=capture,
+        actions=actions,
+        description=description,
+        background=background,
+    )
+    return (
+        yield from geecs_scan_request_plan(
+            request, submission=submission, session=session, resolver=resolver
+        )
+    )
+
+
+def geecs_scan_plan(
+    axes: list,
+    capture: dict,
+    *,
+    actions=None,
+    description: str = "",
+    background: bool = False,
+    submission=None,
+    session=None,
+    resolver=None,
+):
+    """Sweep one axis (1-D) or several (a grid) — a ``step`` ScanRequest.
+
+    Parameters
+    ----------
+    axes : list
+        One or more ``ScanAxis`` objects as JSON; the first is the
+        outermost (slowest) loop, the last the innermost.
+    capture : dict
+        ``CaptureSettings`` as JSON.
+    actions : dict, optional
+        ``ActionBindings`` as JSON.
+    description : str
+        Free-text note for the scan metadata and the experiment log.
+    background : bool
+        Mark the shots as background/calibration data.
+    submission, session, resolver :
+        As on :func:`~geecs_bluesky.plans.scan_request_plan.geecs_scan_request_plan`.
+
+    Yields
+    ------
+    Msg
+        The funnel plan's messages, unchanged.
+    """
+    request = _request(
+        "step",
+        axes=axes,
+        capture=capture,
+        actions=actions,
+        description=description,
+        background=background,
+    )
+    return (
+        yield from geecs_scan_request_plan(
+            request, submission=submission, session=session, resolver=resolver
+        )
+    )
+
+
+def geecs_optimize_plan(
+    optimization: dict,
+    capture: dict,
+    *,
+    actions=None,
+    description: str = "",
+    submission=None,
+    session=None,
+    resolver=None,
+):
+    """Let an algorithm pick the settings — an ``optimize`` ScanRequest.
+
+    Parameters
+    ----------
+    optimization : dict
+        ``OptimizationSpec`` as JSON: the variables the optimizer may move
+        and their bounds (``variables: {name: [low, high]}``), objectives,
+        evaluator, generator, iteration budget.  An optimize request has no
+        ``axes`` — the search space lives here, as it always has (the
+        optimization refactor decides whether bounds ever earn another
+        shape).
+    capture : dict
+        ``CaptureSettings`` as JSON (shots per iteration, save sets, …).
+    actions : dict, optional
+        ``ActionBindings`` as JSON — recorded, not run (optimize has no
+        action hooks yet; see the funnel).
+    description : str
+        Free-text note for the scan metadata and the experiment log.
+    submission, session, resolver :
+        As on :func:`~geecs_bluesky.plans.scan_request_plan.geecs_scan_request_plan`.
+
+    Yields
+    ------
+    Msg
+        The funnel plan's messages, unchanged.
+    """
+    request = _request(
+        "optimize",
+        optimization=optimization,
+        capture=capture,
+        actions=actions,
+        description=description,
+    )
+    return (
+        yield from geecs_scan_request_plan(
+            request, submission=submission, session=session, resolver=resolver
+        )
+    )
+
+
+_ARTIFACT = "docs/geecs_schemas/{name}.schema.json in GEECS-Plugins"
+_SHARED_PARAMETERS: dict = {
+    "capture": {
+        "description": (
+            "CaptureSettings as a JSON object: shots per step, acquisition "
+            "discipline, save sets, telemetry / native-image toggles, "
+            "trigger profile. JSON Schema: " + _ARTIFACT.format(name="capture_settings")
+        ),
+        "annotation": "dict",
+    },
+    "actions": {
+        "description": (
+            "Optional ActionBindings as a JSON object (setup / per_step / "
+            "closeout plan names). JSON Schema: "
+            + _ARTIFACT.format(name="action_bindings")
+        ),
+    },
+    "description": {
+        "description": "Free-text note for the scan metadata and the experiment log.",
+        "annotation": "str",
+    },
+    "submission": {
+        "description": (
+            "Optional client-stamped SubmissionRecord as a JSON object; "
+            "recorded verbatim in run metadata."
+        ),
+    },
+    "session": {
+        "description": (
+            "Worker-internal GeecsSession — leave unset; the worker startup "
+            "installs the default."
+        ),
+    },
+    "resolver": {
+        "description": (
+            "Worker-internal config resolver — leave unset; defaults to the "
+            "worker's configs checkout."
+        ),
+    },
+}
+_BACKGROUND_PARAMETER: dict = {
+    "background": {
+        "description": "Mark the shots as background/calibration data.",
+        "annotation": "bool",
+    }
+}
+_AXES_PARAMETER = {
+    "description": (
+        "One or more ScanAxis objects as JSON — the first axis is the outermost "
+        "(slowest) loop. JSON Schema per element: " + _ARTIFACT.format(name="scan_axis")
+    ),
+    "annotation": "list",
+}
+
+#: ``parameter_annotation_decorator`` payloads (see the funnel's for the
+#: constraints); the worker startup applies them so ``plans_allowed`` carries
+#: typed, described parameters per plan.
+NOSCAN_PLAN_ANNOTATION: dict = {
+    "description": (
+        "Take shots without moving anything (a noscan ScanRequest). Assembles "
+        "the canonical ScanRequest and runs the same validated path as "
+        "geecs_scan_request_plan."
+    ),
+    "parameters": {**_SHARED_PARAMETERS, **_BACKGROUND_PARAMETER},
+}
+SCAN_PLAN_ANNOTATION: dict = {
+    "description": (
+        "Sweep one axis (1-D) or several (a grid) — a step ScanRequest, run "
+        "through the same validated path as geecs_scan_request_plan."
+    ),
+    "parameters": {
+        "axes": _AXES_PARAMETER,
+        **_SHARED_PARAMETERS,
+        **_BACKGROUND_PARAMETER,
+    },
+}
+OPTIMIZE_PLAN_ANNOTATION: dict = {
+    "description": (
+        "Let an algorithm pick the settings — an optimize ScanRequest, run "
+        "through the same validated path as geecs_scan_request_plan. The "
+        "optimization block carries the search space (variables and bounds), "
+        "the objectives, the evaluator, and the generator."
+    ),
+    "parameters": {
+        "optimization": {
+            "description": (
+                "OptimizationSpec as a JSON object: variables with bounds, "
+                "objectives, evaluator, generator, iteration budget. JSON "
+                "Schema: " + _ARTIFACT.format(name="optimization_spec")
+            ),
+            "annotation": "dict",
+        },
+        **_SHARED_PARAMETERS,
+    },
+}

--- a/GeecsBluesky/pyproject.toml
+++ b/GeecsBluesky/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-bluesky"
-version = "0.72.0"
+version = "0.73.0"
 description = "Bluesky / ophyd-async bridge for the GEECS control system"
 authors = ["Sam Barber <sbarber@lbl.gov>"]
 readme = "README.md"

--- a/GeecsBluesky/qserver/README.md
+++ b/GeecsBluesky/qserver/README.md
@@ -50,7 +50,10 @@ qserver status
 qserver environment open
 ```
 
-Once the environment is open, `geecs_scan_request_plan` is registered and
+Once the environment is open, `geecs_scan_request_plan` (the document API)
+and the three named plans — `geecs_noscan_plan`, `geecs_scan_plan`,
+`geecs_optimize_plan` (per-mode parameters, same execution underneath; Phase
+2b-ii) — are registered and
 callable; submit a `ScanRequest` dict as its sole argument, for example
 (the v2 shape groups the capture fields under `capture`; the flat v1
 layout still validates):
@@ -59,6 +62,20 @@ layout still validates):
 qserver queue add plan '{"name": "geecs_scan_request_plan", "args": [{"mode": "noscan", "capture": {"shots_per_step": 2, "acquisition": "free_run", "save_sets": ["UC_Test"]}}], "item_type": "plan"}'
 qserver queue start
 ```
+
+The named plans take the same vocabulary one mode at a time — the same
+noscan through `geecs_noscan_plan`, and a 1-D sweep through
+`geecs_scan_plan` (a grid is just more axes):
+
+```bash
+qserver queue add plan '{"name": "geecs_noscan_plan", "args": [{"shots_per_step": 2, "acquisition": "free_run", "save_sets": ["UC_Test"]}], "item_type": "plan"}'
+qserver queue add plan '{"name": "geecs_scan_plan", "args": [[{"variable": "jet_z", "positions": {"start": 0, "end": 1, "step": 0.5}}], {"shots_per_step": 2, "acquisition": "free_run", "save_sets": ["UC_Test"]}], "item_type": "plan"}'
+```
+
+Every named plan assembles the canonical `ScanRequest` and runs the funnel
+underneath, so the start document, ScanInfo, and data tree are identical to
+a funnel submission of the equivalent request; the manager history names
+the plan that was submitted.
 
 The `qserver` CLI parses that argument as a **Python literal, not JSON**:
 `null` / `true` / `false` are rejected with an unhelpful "Error occurred

--- a/GeecsBluesky/qserver/startup/startup.py
+++ b/GeecsBluesky/qserver/startup/startup.py
@@ -42,6 +42,14 @@ import geecs_bluesky  # noqa: F401
 
 from bluesky_queueserver import parameter_annotation_decorator
 
+from geecs_bluesky.plans.named_plans import (
+    NOSCAN_PLAN_ANNOTATION,
+    OPTIMIZE_PLAN_ANNOTATION,
+    SCAN_PLAN_ANNOTATION,
+    geecs_noscan_plan,
+    geecs_optimize_plan,
+    geecs_scan_plan,
+)
 from geecs_bluesky.plans.scan_request_plan import (
     RUN_ACTION_PLAN_ANNOTATION,
     SCAN_REQUEST_PLAN_ANNOTATION,
@@ -67,6 +75,15 @@ geecs_scan_request_plan = parameter_annotation_decorator(SCAN_REQUEST_PLAN_ANNOT
 )
 geecs_run_action_plan = parameter_annotation_decorator(RUN_ACTION_PLAN_ANNOTATION)(
     geecs_run_action_plan
+)
+# The named plans (Phase 2b-ii): per-mode vocabulary at the gate, the same
+# execution underneath (each yields from geecs_scan_request_plan).
+geecs_noscan_plan = parameter_annotation_decorator(NOSCAN_PLAN_ANNOTATION)(
+    geecs_noscan_plan
+)
+geecs_scan_plan = parameter_annotation_decorator(SCAN_PLAN_ANNOTATION)(geecs_scan_plan)
+geecs_optimize_plan = parameter_annotation_decorator(OPTIMIZE_PLAN_ANNOTATION)(
+    geecs_optimize_plan
 )
 
 
@@ -237,6 +254,9 @@ __all__ = [
     "RE",
     "geecs_scan_request_plan",
     "geecs_run_action_plan",
+    "geecs_noscan_plan",
+    "geecs_scan_plan",
+    "geecs_optimize_plan",
     "geecs_move_variable",
     "geecs_describe_action",
 ]

--- a/GeecsBluesky/qserver/user_group_permissions.yaml
+++ b/GeecsBluesky/qserver/user_group_permissions.yaml
@@ -30,7 +30,11 @@ user_groups:
       - null
 
   # Operator group: queue submission is restricted to GEECS-named plans,
-  # function execution to exactly the manual verbs (#648).
+  # function execution to exactly the manual verbs (#648). The named plans
+  # (geecs_noscan_plan / geecs_scan_plan / geecs_optimize_plan, Phase 2b-ii)
+  # are the unit every gate sees: a group that may take noscans but not
+  # launch optimizations lists ":geecs_optimize_plan$" (and the funnel,
+  # which can carry any mode) under forbidden_plans.
   operator:
     allowed_plans:
       - ":geecs_.*"

--- a/GeecsBluesky/tests/_qserver_startup_probe.py
+++ b/GeecsBluesky/tests/_qserver_startup_probe.py
@@ -117,6 +117,9 @@ def main() -> None:
         "RE",
         "geecs_scan_request_plan",
         "geecs_run_action_plan",
+        "geecs_noscan_plan",
+        "geecs_scan_plan",
+        "geecs_optimize_plan",
         "geecs_move_variable",
         "geecs_describe_action",
     ]:

--- a/GeecsBluesky/tests/_qserver_startup_probe.py
+++ b/GeecsBluesky/tests/_qserver_startup_probe.py
@@ -84,6 +84,11 @@ def main() -> None:
 
     from bluesky import RunEngine
 
+    from geecs_bluesky.plans.named_plans import (
+        geecs_noscan_plan,
+        geecs_optimize_plan,
+        geecs_scan_plan,
+    )
     from geecs_bluesky.plans.scan_request_plan import (
         geecs_run_action_plan,
         geecs_scan_request_plan,
@@ -101,6 +106,9 @@ def main() -> None:
     for plan_name, real_plan in (
         ("geecs_scan_request_plan", geecs_scan_request_plan),
         ("geecs_run_action_plan", geecs_run_action_plan),
+        ("geecs_noscan_plan", geecs_noscan_plan),
+        ("geecs_scan_plan", geecs_scan_plan),
+        ("geecs_optimize_plan", geecs_optimize_plan),
     ):
         wrapped = ns.get(plan_name)
         if getattr(wrapped, "__wrapped__", None) is not real_plan:

--- a/GeecsBluesky/tests/test_named_plans.py
+++ b/GeecsBluesky/tests/test_named_plans.py
@@ -1,0 +1,168 @@
+"""The three named plans (Phase 2b-ii): thin wrappers over the funnel.
+
+Hermetic pins of the shared-execution invariant at the seam — each named
+plan assembles exactly the canonical ScanRequest document for its mode and
+delegates to ``geecs_scan_request_plan`` with the worker seams passed
+through — plus the queueserver signature/annotation contract (skipped
+without the ``qserver`` extra, as the funnel's own pins are).  Document
+parity on a real mock RunEngine lives in ``test_scan_request_plan.py``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from geecs_bluesky.plans import named_plans
+from geecs_bluesky.plans.named_plans import (
+    NOSCAN_PLAN_ANNOTATION,
+    OPTIMIZE_PLAN_ANNOTATION,
+    SCAN_PLAN_ANNOTATION,
+    geecs_noscan_plan,
+    geecs_optimize_plan,
+    geecs_scan_plan,
+)
+from geecs_schemas import ScanRequest
+
+CAPTURE = {"shots_per_step": 3, "acquisition": "free_run", "save_sets": ["UC_Test"]}
+AXIS = {"variable": "jet_z", "positions": {"start": 0.0, "end": 1.0, "step": 0.5}}
+OPTIMIZATION = {
+    "variables": {"jet_z": [0.0, 1.0]},
+    "objectives": {"counts": "MAXIMIZE"},
+    "evaluator": {"module": "m", "class": "C"},
+    "generator": {"name": "bayes_default"},
+    "max_iterations": 4,
+}
+
+
+def _recording_funnel(monkeypatch):
+    """Replace the funnel with a recorder that yields once and returns a uid."""
+    calls: list[tuple[dict, dict]] = []
+
+    def fake_funnel(request, **kwargs):
+        calls.append((request, kwargs))
+        yield "funnel-message"
+        return "uid-funnel"
+
+    monkeypatch.setattr(named_plans, "geecs_scan_request_plan", fake_funnel)
+    return calls
+
+
+def _drive(plan):
+    messages = []
+    try:
+        while True:
+            messages.append(plan.send(None))
+    except StopIteration as stop:
+        return messages, stop.value
+
+
+def test_noscan_plan_assembles_the_canonical_request(monkeypatch) -> None:
+    calls = _recording_funnel(monkeypatch)
+    messages, uid = _drive(
+        geecs_noscan_plan(
+            CAPTURE,
+            actions={"setup": ["scan_prep"]},
+            description="stats",
+            background=True,
+            submission={"client": "t", "preflight": []},
+            session="S",
+            resolver="R",
+        )
+    )
+    assert messages == ["funnel-message"] and uid == "uid-funnel"
+    (request, kwargs) = calls[0]
+    assert request == {
+        "mode": "noscan",
+        "capture": CAPTURE,
+        "actions": {"setup": ["scan_prep"]},
+        "description": "stats",
+        "background": True,
+    }
+    assert kwargs == {
+        "submission": {"client": "t", "preflight": []},
+        "session": "S",
+        "resolver": "R",
+    }
+    # The assembled document IS a valid canonical ScanRequest.
+    assert ScanRequest.model_validate(request).capture.shots_per_step == 3
+
+
+def test_scan_plan_assembles_a_step_request_with_axes(monkeypatch) -> None:
+    calls = _recording_funnel(monkeypatch)
+    _drive(geecs_scan_plan([AXIS, {**AXIS, "variable": "jet_x"}], CAPTURE))
+    (request, kwargs) = calls[0]
+    assert request["mode"] == "step"
+    assert [a["variable"] for a in request["axes"]] == ["jet_z", "jet_x"]
+    assert "actions" not in request and request["background"] is False
+    assert kwargs == {"submission": None, "session": None, "resolver": None}
+    validated = ScanRequest.model_validate(request)
+    assert validated.grid_shape() == (3, 3)
+
+
+def test_optimize_plan_assembles_an_optimize_request(monkeypatch) -> None:
+    calls = _recording_funnel(monkeypatch)
+    _drive(geecs_optimize_plan(OPTIMIZATION, CAPTURE, description="opt"))
+    (request, _kwargs) = calls[0]
+    assert request["mode"] == "optimize"
+    assert request["optimization"] == OPTIMIZATION
+    assert "axes" not in request and "background" not in request
+    validated = ScanRequest.model_validate(request)
+    assert validated.optimization.max_iterations == 4
+
+
+# ---------------------------------------------------------------------------
+# Queueserver contract: builtin-only signatures, described parameters
+# ---------------------------------------------------------------------------
+
+_PLANS = [
+    (geecs_noscan_plan, NOSCAN_PLAN_ANNOTATION, [CAPTURE]),
+    (geecs_scan_plan, SCAN_PLAN_ANNOTATION, [[AXIS], CAPTURE]),
+    (geecs_optimize_plan, OPTIMIZE_PLAN_ANNOTATION, [OPTIMIZATION, CAPTURE]),
+]
+
+
+@pytest.mark.parametrize(
+    "plan,annotation,args", _PLANS, ids=[p[0].__name__ for p in _PLANS]
+)
+def test_named_plan_signature_passes_manager_validation(plan, annotation, args):
+    """A real ``queue add`` item validates against each annotated signature,
+    and ``plans_allowed`` carries a description for every annotated parameter
+    (the funnel's own pins, applied per named plan)."""
+    pytest.importorskip("bluesky_queueserver")
+    from bluesky_queueserver import parameter_annotation_decorator
+    from bluesky_queueserver.manager.profile_ops import _process_plan, validate_plan
+
+    wrapped = parameter_annotation_decorator(annotation)(plan)
+    processed = _process_plan(wrapped, existing_devices={}, existing_plans={})
+    described = {p["name"]: p.get("description") for p in processed["parameters"]}
+    assert set(annotation["parameters"]) <= set(described)
+    assert all(described[name] for name in annotation["parameters"])
+    ok, msg = validate_plan(
+        {"name": plan.__name__, "args": args, "item_type": "plan"},
+        allowed_plans={plan.__name__: processed},
+        allowed_devices={},
+    )
+    assert ok, msg
+
+
+def test_every_named_plan_points_at_a_published_artifact() -> None:
+    """Each JSON-object parameter's description names the artifact a generic
+    client grafts, and every named artifact is a registry entry (published)."""
+    import re
+
+    from geecs_schemas.schema_export import EXPORTED_SCHEMAS, artifact_path
+
+    published = {artifact_path(name).as_posix() for name in EXPORTED_SCHEMAS}
+    for annotation in (
+        NOSCAN_PLAN_ANNOTATION,
+        SCAN_PLAN_ANNOTATION,
+        OPTIMIZE_PLAN_ANNOTATION,
+    ):
+        named = {
+            m
+            for p in annotation["parameters"].values()
+            for m in re.findall(
+                r"docs/geecs_schemas/\w+\.schema\.json", p["description"]
+            )
+        }
+        assert named and named <= published, (named, published)

--- a/GeecsBluesky/tests/test_named_plans.py
+++ b/GeecsBluesky/tests/test_named_plans.py
@@ -82,6 +82,7 @@ def test_noscan_plan_assembles_the_canonical_request(monkeypatch) -> None:
         "submission": {"client": "t", "preflight": []},
         "session": "S",
         "resolver": "R",
+        "failed_move_policy": None,
     }
     # The assembled document IS a valid canonical ScanRequest.
     assert ScanRequest.model_validate(request).capture.shots_per_step == 3
@@ -94,18 +95,32 @@ def test_scan_plan_assembles_a_step_request_with_axes(monkeypatch) -> None:
     assert request["mode"] == "step"
     assert [a["variable"] for a in request["axes"]] == ["jet_z", "jet_x"]
     assert "actions" not in request and request["background"] is False
-    assert kwargs == {"submission": None, "session": None, "resolver": None}
+    assert kwargs == {
+        "submission": None,
+        "session": None,
+        "resolver": None,
+        "failed_move_policy": None,
+    }
     validated = ScanRequest.model_validate(request)
     assert validated.grid_shape() == (3, 3)
 
 
 def test_optimize_plan_assembles_an_optimize_request(monkeypatch) -> None:
     calls = _recording_funnel(monkeypatch)
-    _drive(geecs_optimize_plan(OPTIMIZATION, CAPTURE, description="opt"))
-    (request, _kwargs) = calls[0]
+    _drive(
+        geecs_optimize_plan(
+            OPTIMIZATION,
+            CAPTURE,
+            description="opt",
+            background=True,
+            failed_move_policy="raise",
+        )
+    )
+    (request, kwargs) = calls[0]
     assert request["mode"] == "optimize"
     assert request["optimization"] == OPTIMIZATION
-    assert "axes" not in request and "background" not in request
+    assert "axes" not in request and request["background"] is True
+    assert kwargs["failed_move_policy"] == "raise"
     validated = ScanRequest.model_validate(request)
     assert validated.optimization.max_iterations == 4
 
@@ -145,24 +160,39 @@ def test_named_plan_signature_passes_manager_validation(plan, annotation, args):
     assert ok, msg
 
 
-def test_every_named_plan_points_at_a_published_artifact() -> None:
-    """Each JSON-object parameter's description names the artifact a generic
-    client grafts, and every named artifact is a registry entry (published)."""
+def test_every_json_parameter_points_at_a_published_artifact() -> None:
+    """Every JSON-object/list parameter's description names exactly one
+    artifact a generic client grafts, and that artifact is a registry entry."""
     import re
 
     from geecs_schemas.schema_export import EXPORTED_SCHEMAS, artifact_path
 
     published = {artifact_path(name).as_posix() for name in EXPORTED_SCHEMAS}
+    json_parameters = {"capture", "actions", "axes", "optimization"}
     for annotation in (
         NOSCAN_PLAN_ANNOTATION,
         SCAN_PLAN_ANNOTATION,
         OPTIMIZE_PLAN_ANNOTATION,
     ):
-        named = {
-            m
-            for p in annotation["parameters"].values()
-            for m in re.findall(
-                r"docs/geecs_schemas/\w+\.schema\.json", p["description"]
+        for name, parameter in annotation["parameters"].items():
+            if name not in json_parameters:
+                continue
+            named = re.findall(
+                r"docs/geecs_schemas/\w+\.schema\.json", parameter["description"]
             )
-        }
-        assert named and named <= published, (named, published)
+            assert len(named) == 1 and named[0] in published, (name, named)
+
+
+def test_named_plans_cover_the_funnels_queue_settable_surface() -> None:
+    """Every kwarg a queue item may set on the funnel (beyond the request
+    document itself) is settable on each named plan too — a group allowed
+    only the named plans loses no knob."""
+    import inspect
+
+    from geecs_bluesky.plans.scan_request_plan import geecs_scan_request_plan
+
+    funnel = set(inspect.signature(geecs_scan_request_plan).parameters) - {"request"}
+    for plan in (geecs_noscan_plan, geecs_scan_plan, geecs_optimize_plan):
+        assert funnel - {"optimization_loader"} <= set(
+            inspect.signature(plan).parameters
+        )

--- a/GeecsBluesky/tests/test_scan_request_plan.py
+++ b/GeecsBluesky/tests/test_scan_request_plan.py
@@ -1913,6 +1913,102 @@ def test_session_run_accepts_a_json_document(resolver, monkeypatch, tmp_path) ->
 
 
 # ---------------------------------------------------------------------------
+# Named plans (Phase 2b-ii): the shared-execution invariant on the mock RE
+# ---------------------------------------------------------------------------
+
+
+def _run_named(plan, resolver, folder, monkeypatch):
+    """Run a named plan on a mock session; return its collected documents."""
+    folder.mkdir(parents=True, exist_ok=True)
+    session = _mock_session()
+    docs = _DocCollector()
+    token = session.RE.subscribe(docs)
+    pacers: list = []
+    _install_stage_pacer(session, pacers)
+    monkeypatch.setattr(
+        "geecs_bluesky.plans.scan_request_plan.claim_scan_number",
+        lambda experiment: (7, str(folder)),
+    )
+    set_plan_session(session)
+    try:
+        session.RE(plan(session=session, resolver=resolver))
+    finally:
+        for pacer in pacers:
+            pacer.cancel()
+        session.RE.unsubscribe(token)
+        session.RE.msg_hook = None
+    return docs
+
+
+def test_named_noscan_plan_matches_the_funnel(resolver, monkeypatch, tmp_path) -> None:
+    """``geecs_noscan_plan(capture, ...)`` and the funnel given the equivalent
+    ScanRequest produce the same documents and ScanInfo: the record is the
+    canonical ScanRequest regardless of entry plan."""
+    from functools import partial
+
+    from geecs_bluesky.plans.named_plans import geecs_noscan_plan
+
+    request = _noscan_request()
+    docs_funnel = _run_scan(
+        "plan", request, resolver, tmp_path / "f" / "Scan007", monkeypatch
+    )
+    docs_named = _run_named(
+        partial(
+            geecs_noscan_plan,
+            request.capture.model_dump(mode="json"),
+            description=request.description,
+        ),
+        resolver,
+        tmp_path / "n" / "Scan007",
+        monkeypatch,
+    )
+    _assert_same_run(
+        docs_funnel, docs_named, tmp_path / "f" / "Scan007", tmp_path / "n" / "Scan007"
+    )
+    assert docs_named.start["scan_request_mode"] == "noscan"
+
+
+def test_named_scan_plan_matches_the_funnel(resolver, monkeypatch, tmp_path) -> None:
+    from functools import partial
+
+    from geecs_bluesky.plans.named_plans import geecs_scan_plan
+
+    request = ScanRequest.model_validate(
+        {
+            "mode": "step",
+            "axes": [
+                {"variable": "jet_z", "positions": {"start": 0, "end": 1, "step": 0.5}}
+            ],
+            "capture": {
+                "shots_per_step": 2,
+                "acquisition": "free_run",
+                "save_sets": ["UC_Test"],
+            },
+            "description": "sweep",
+        }
+    )
+    docs_funnel = _run_scan(
+        "plan", request, resolver, tmp_path / "f" / "Scan007", monkeypatch
+    )
+    docs_named = _run_named(
+        partial(
+            geecs_scan_plan,
+            [a.model_dump(mode="json") for a in request.axes],
+            request.capture.model_dump(mode="json"),
+            description="sweep",
+        ),
+        resolver,
+        tmp_path / "n" / "Scan007",
+        monkeypatch,
+    )
+    _assert_same_run(
+        docs_funnel, docs_named, tmp_path / "f" / "Scan007", tmp_path / "n" / "Scan007"
+    )
+    assert docs_named.start["scan_request_mode"] == "step"
+    assert docs_named.start["num_points"] == 3
+
+
+# ---------------------------------------------------------------------------
 # geecs_run_action_plan (#648 manual verbs — actions as queue items)
 # ---------------------------------------------------------------------------
 

--- a/GeecsBluesky/tests/test_scan_request_plan.py
+++ b/GeecsBluesky/tests/test_scan_request_plan.py
@@ -178,7 +178,15 @@ class _DocCollector:
             self.events.append(dict(doc))
 
 
-def _run_scan(entry_point, request, resolver, folder, monkeypatch, submission=None):
+def _run_scan(
+    entry_point,
+    request,
+    resolver,
+    folder,
+    monkeypatch,
+    submission=None,
+    plan_factory=None,
+):
     """Run *request* through one door; return the collected documents.
 
     ``entry_point`` is ``"session"`` (the headless door,
@@ -188,7 +196,9 @@ def _run_scan(entry_point, request, resolver, folder, monkeypatch, submission=No
     one plan; the claim is stubbed to scan 7 in *folder* at the plan's
     claim site.  ``submission`` travels beside the request on both doors
     (the request/record split, geecs-schemas 0.14.0).  The headless door's
-    post-run s-file export is stubbed (no Tiled here).
+    post-run s-file export is stubbed (no Tiled here).  ``plan_factory``
+    (queue door only) swaps in a named plan: ``plan_factory(session=,
+    resolver=)`` is run instead of the funnel — the shared-execution pin.
     """
     folder.mkdir(parents=True, exist_ok=True)
     session = _mock_session()
@@ -208,6 +218,9 @@ def _run_scan(entry_point, request, resolver, folder, monkeypatch, submission=No
         if entry_point == "session":
             monkeypatch.setattr(session, "_export_scalar_files", lambda n: None)
             session.run(request, resolver, submission=submission)
+        elif plan_factory is not None:
+            set_plan_session(session)
+            session.RE(plan_factory(session=session, resolver=resolver))
         else:
             set_plan_session(session)
             session.RE(
@@ -1917,29 +1930,6 @@ def test_session_run_accepts_a_json_document(resolver, monkeypatch, tmp_path) ->
 # ---------------------------------------------------------------------------
 
 
-def _run_named(plan, resolver, folder, monkeypatch):
-    """Run a named plan on a mock session; return its collected documents."""
-    folder.mkdir(parents=True, exist_ok=True)
-    session = _mock_session()
-    docs = _DocCollector()
-    token = session.RE.subscribe(docs)
-    pacers: list = []
-    _install_stage_pacer(session, pacers)
-    monkeypatch.setattr(
-        "geecs_bluesky.plans.scan_request_plan.claim_scan_number",
-        lambda experiment: (7, str(folder)),
-    )
-    set_plan_session(session)
-    try:
-        session.RE(plan(session=session, resolver=resolver))
-    finally:
-        for pacer in pacers:
-            pacer.cancel()
-        session.RE.unsubscribe(token)
-        session.RE.msg_hook = None
-    return docs
-
-
 def test_named_noscan_plan_matches_the_funnel(resolver, monkeypatch, tmp_path) -> None:
     """``geecs_noscan_plan(capture, ...)`` and the funnel given the equivalent
     ScanRequest produce the same documents and ScanInfo: the record is the
@@ -1952,15 +1942,17 @@ def test_named_noscan_plan_matches_the_funnel(resolver, monkeypatch, tmp_path) -
     docs_funnel = _run_scan(
         "plan", request, resolver, tmp_path / "f" / "Scan007", monkeypatch
     )
-    docs_named = _run_named(
-        partial(
+    docs_named = _run_scan(
+        "plan",
+        request,
+        resolver,
+        tmp_path / "n" / "Scan007",
+        monkeypatch,
+        plan_factory=partial(
             geecs_noscan_plan,
             request.capture.model_dump(mode="json"),
             description=request.description,
         ),
-        resolver,
-        tmp_path / "n" / "Scan007",
-        monkeypatch,
     )
     _assert_same_run(
         docs_funnel, docs_named, tmp_path / "f" / "Scan007", tmp_path / "n" / "Scan007"
@@ -1990,16 +1982,18 @@ def test_named_scan_plan_matches_the_funnel(resolver, monkeypatch, tmp_path) -> 
     docs_funnel = _run_scan(
         "plan", request, resolver, tmp_path / "f" / "Scan007", monkeypatch
     )
-    docs_named = _run_named(
-        partial(
+    docs_named = _run_scan(
+        "plan",
+        request,
+        resolver,
+        tmp_path / "n" / "Scan007",
+        monkeypatch,
+        plan_factory=partial(
             geecs_scan_plan,
             [a.model_dump(mode="json") for a in request.axes],
             request.capture.model_dump(mode="json"),
             description="sweep",
         ),
-        resolver,
-        tmp_path / "n" / "Scan007",
-        monkeypatch,
     )
     _assert_same_run(
         docs_funnel, docs_named, tmp_path / "f" / "Scan007", tmp_path / "n" / "Scan007"

--- a/Planning/schema_refactor/00_overview.md
+++ b/Planning/schema_refactor/00_overview.md
@@ -229,9 +229,12 @@ Register in the qserver startup profile, beside the existing funnel:
   `OptimizationSpec.variables`, so the plan takes no axes and no new bounds
   shape; Sam's smaller-change call, and even smaller than the doc assumed.)
 
-Each is a mode-pinned parameter model **composed from the Phase-1 sub-models**,
-building a ScanRequest internally and delegating to the exact same execution
-path. No triplicated validation, no forked run discipline.
+Each takes the Phase-1 sub-models **as its parameters** (JSON objects at the
+queue gate — no new parameter models; the published artifacts are the
+sub-models' own schemas), builds a ScanRequest internally and delegates to
+the exact same execution path. No triplicated validation, no forked run
+discipline. (**As built in 2b-ii:** raw `dict`/`list` parameters, one
+published artifact per parameter — see the `EXPORTED_SCHEMAS` comment.)
 
 **Shared-execution invariant (non-negotiable)**: every named plan builds a
 canonical `ScanRequest` internally and delegates to the single existing
@@ -248,20 +251,19 @@ GEECS-Console and GEECS-MCP `submit_scan` keep submitting ScanRequest documents
 untouched, into the same queue. The funnel retires (or stays forever as the
 machine API) on usage evidence — strangler-fig, no migration cliff.
 
-Each named plan's parameter model lives in GEECS-Schemas (pydantic-only),
-its plan function in GeecsBluesky beside the funnel, its
-`user_group_permissions` entry in the qserver profile. Per-plan JSON Schema
+Each named plan's parameters are existing GEECS-Schemas sub-models (no
+new pydantic types), its plan function in GeecsBluesky beside the funnel,
+its `user_group_permissions` entry in the qserver profile. Per-plan JSON Schema
 artifacts land under `docs/geecs_schemas/` through the export registry
 (`schema_export.EXPORTED_SCHEMAS`, **built as 2b-i**, GEECS-Schemas 0.16.0:
 one artifact per entry, the no-drift guard parametrized over the registry,
 an orphan-artifact check, `SCHEMA_ARTIFACT` kept as the ScanRequest alias
 the worker annotation and OSPREY point at). Each named plan's parameter
-model is one registry line plus a regenerate. The Markdown reference for
-the plan models (2b-ii) has docgen iterate `EXPORTED_SCHEMAS` for a
-plan-models page — each plan model registered exactly once — not a change
-to the config-kind registry (`SCHEMA_REGISTRY` stays the 8 versioned YAML
-kinds; `scan_request` is the one model in both, pinned); mkdocs nav stays
-as is.
+model is one registry line plus a regenerate. No plan-models docgen page
+was needed: the parameters are sub-models the existing reference already
+documents under ScanRequest, so `SCHEMA_REGISTRY` stays the 8 versioned
+YAML kinds (`scan_request` is the one model in both registries, pinned)
+and mkdocs nav stays as is.
 
 #### 2c — OSPREY tail (optional, no deadline)
 

--- a/Planning/schema_refactor/00_overview.md
+++ b/Planning/schema_refactor/00_overview.md
@@ -223,8 +223,11 @@ Register in the qserver startup profile, beside the existing funnel:
 - `geecs_scan_plan` — 1-D and grid as one plan (a grid is the multi-axis case
   of the same sweep; splitting them would be artificial); params: `axes` +
   shared components.
-- `geecs_optimize_plan` — params: `axes`-as-bounds per current optimize
-  semantics + `OptimizationSpec` + shared components.
+- `geecs_optimize_plan` — params: `OptimizationSpec` + shared components.
+  (**Corrected while building 2b-ii:** an optimize request has no `axes` —
+  the schema forbids them — its variables and bounds live inside
+  `OptimizationSpec.variables`, so the plan takes no axes and no new bounds
+  shape; Sam's smaller-change call, and even smaller than the doc assumed.)
 
 Each is a mode-pinned parameter model **composed from the Phase-1 sub-models**,
 building a ScanRequest internally and delegating to the exact same execution

--- a/docs/geecs_schemas/action_bindings.schema.json
+++ b/docs/geecs_schemas/action_bindings.schema.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "description": "Which named action plans run around (and inside) the scan.\n\nEach slot lists plan names from the experiment's action library.  Leave\na slot empty for \"nothing\".",
+  "properties": {
+    "setup": {
+      "description": "Plans to run once before the scan starts.",
+      "items": {
+        "type": "string"
+      },
+      "title": "Setup",
+      "type": "array"
+    },
+    "per_step": {
+      "description": "Plans to run between scan steps \u2014 after each move, before the shots at that position.",
+      "items": {
+        "type": "string"
+      },
+      "title": "Per Step",
+      "type": "array"
+    },
+    "closeout": {
+      "description": "Plans to run once after the scan finishes (even on abort).",
+      "items": {
+        "type": "string"
+      },
+      "title": "Closeout",
+      "type": "array"
+    }
+  },
+  "title": "ActionBindings",
+  "type": "object"
+}

--- a/docs/geecs_schemas/capture_settings.schema.json
+++ b/docs/geecs_schemas/capture_settings.schema.json
@@ -1,0 +1,79 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$defs": {
+    "AcquisitionMode": {
+      "description": "How shots are taken.\n\nAttributes\n----------\nFREE_RUN : str\n    The trigger free-runs at the machine repetition rate; devices are\n    matched up by their timestamps afterwards.\nSTRICT : str\n    The scan fires each shot itself and requires every device to report\n    in before the next one \u2014 slower, but nothing is ever missing.",
+      "enum": [
+        "free_run",
+        "strict"
+      ],
+      "title": "AcquisitionMode",
+      "type": "string"
+    }
+  },
+  "additionalProperties": false,
+  "description": "How shots are taken and what gets recorded \u2014 the capture concern.\n\nEvery scan, whatever its mode, captures data the same way: a number of\nshots per step, an acquisition discipline, the save sets naming the\nrecorded devices, the telemetry and native-image-save toggles, and the\ntrigger profile driving the shot trigger.  This model groups those\nsix settings; conceptually they are three sub-groups \u2014 shot control\n(``shots_per_step`` + ``acquisition``), data logging (``save_sets`` +\n``background_telemetry`` + ``native_image_save``), and the trigger\nprofile \u2014 kept one level flat here on purpose.\n\nEvery field has a usable default, so an omitted ``capture`` block is a\nvalid one-shot strict capture with no named save sets.",
+  "properties": {
+    "shots_per_step": {
+      "default": 1,
+      "description": "How many shots to take at each scan position / grid point (or in total for a noscan).",
+      "minimum": 1,
+      "title": "Shots Per Step",
+      "type": "integer"
+    },
+    "acquisition": {
+      "$ref": "#/$defs/AcquisitionMode",
+      "default": "strict",
+      "description": "'strict' fires shot by shot and guarantees every device is in every row; 'free_run' lets the trigger run at the machine rate and matches devices up by timestamp."
+    },
+    "save_sets": {
+      "description": "Names of the save sets \u2014 reusable named device groups \u2014 recorded for this scan; devices are unioned across them. Each names the devices that get guarantees (completeness, dialogs, images, rituals). A bare string is accepted and stored as a one-element list. Empty means no required devices beyond scan bookkeeping.",
+      "items": {
+        "type": "string"
+      },
+      "title": "Save Sets",
+      "type": "array"
+    },
+    "background_telemetry": {
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "Also log every other live experiment device as best-effort snapshot columns \u2014 the variables the GEECS experiment database marks for scan logging (MySQL table expt_device_variable, get='yes') \u2014 read from the gateway's always-on monitor cache: read-only and never waited on, so it cannot slow or stall the scan; dead devices are dropped with a log line, never a dialog or abort. Leave unset to inherit the experiment default; set true/false to override for this scan.",
+      "title": "Background Telemetry"
+    },
+    "native_image_save": {
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "Whether capture-eligible cameras (Point Grey \u2014 the devicetypes the central PVA capture daemon owns) write their native per-shot image files during this scan. When false, those cameras' images are recorded only by the capture daemon's per-device frame stack (one HDF5 per camera per scan); all other devices \u2014 proprietary formats like the HASO, scope traces \u2014 keep their native save regardless. Leave unset to inherit the experiment default; set true/false to override for this scan (e.g. force native files back on for one scan while the capture path is being validated). Two engine behaviors to expect when false: the scan is REFUSED before a scan number is claimed if the capture daemon looks absent or is not monitoring every capture camera (fail-closed \u2014 start the daemon or drop the override), and the request is silently inert when no capture-eligible cameras resolve (DB unreachable, or none in the save set) \u2014 native saving then proceeds unchanged, with a warning in the scan log.",
+      "title": "Native Image Save"
+    },
+    "trigger_profile": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "Name of the trigger profile that drives the shot trigger. Unset means the scan does not manage the trigger.",
+      "title": "Trigger Profile"
+    }
+  },
+  "title": "CaptureSettings",
+  "type": "object"
+}

--- a/docs/geecs_schemas/optimization_spec.schema.json
+++ b/docs/geecs_schemas/optimization_spec.schema.json
@@ -1,0 +1,155 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$defs": {
+    "EvaluatorSpec": {
+      "additionalProperties": false,
+      "description": "Which analysis code turns raw shots into the number being optimized.\n\nPoints at the Python evaluator class and carries its configuration.",
+      "properties": {
+        "module": {
+          "description": "Python import path of the evaluator module, e.g. 'geecs_bluesky.optimization.evaluators.beam_sum_counts_evaluator'.",
+          "title": "Module",
+          "type": "string"
+        },
+        "class": {
+          "description": "Name of the evaluator class inside that module.",
+          "title": "Class",
+          "type": "string"
+        },
+        "kwargs": {
+          "additionalProperties": true,
+          "description": "Settings passed to the evaluator when it is created \u2014 e.g. which diagnostics/analyzers it should read. Free-form: each evaluator documents its own options.",
+          "title": "Kwargs",
+          "type": "object"
+        }
+      },
+      "required": [
+        "module",
+        "class"
+      ],
+      "title": "EvaluatorSpec",
+      "type": "object"
+    },
+    "GeneratorSpec": {
+      "additionalProperties": false,
+      "description": "Which optimization algorithm proposes the next settings.\n\nNames the generator and carries its algorithm-specific options.",
+      "properties": {
+        "name": {
+          "description": "Name of the optimization algorithm, e.g. 'bayes_default', 'random', or 'multipoint_bax_alignment_l2'.",
+          "title": "Name",
+          "type": "string"
+        },
+        "options": {
+          "additionalProperties": true,
+          "description": "Algorithm-specific tuning options. Free-form: each generator documents its own options (legacy 'xopt_config_overrides').",
+          "title": "Options",
+          "type": "object"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "title": "GeneratorSpec",
+      "type": "object"
+    }
+  },
+  "additionalProperties": false,
+  "description": "The optimization problem: what to vary, within what limits, to improve what.\n\nOnly used when the scan's mode is ``optimize``.  Lists the variables the\noptimizer may move (with their allowed ranges), what is being minimized\nor maximized, and which algorithm drives the search.\n\nNotes\n-----\nMirrors what the legacy optimizer YAML (``BaseOptimizerConfig`` +\nXopt VOCS) could express: objectives may be empty for BAX-style\ngenerators that model ``observables`` only; ``constraints`` follow the\nVOCS ``[bound_type, value]`` form.",
+  "properties": {
+    "variables": {
+      "additionalProperties": {
+        "maxItems": 2,
+        "minItems": 2,
+        "prefixItems": [
+          {
+            "type": "number"
+          },
+          {
+            "type": "number"
+          }
+        ],
+        "type": "array"
+      },
+      "description": "What the optimizer may move and how far, as 'variable name: [lowest, highest]'. Names may be scan-variable names or 'Device:Variable' strings.",
+      "minProperties": 1,
+      "title": "Variables",
+      "type": "object"
+    },
+    "objectives": {
+      "additionalProperties": {
+        "type": "string"
+      },
+      "description": "What counts as better, as 'objective name: MINIMIZE' or 'objective name: MAXIMIZE'. May be empty for algorithms that only model observables (BAX).",
+      "title": "Objectives",
+      "type": "object"
+    },
+    "observables": {
+      "description": "Extra measured quantities the algorithm should track without optimizing them, e.g. ['x_CoM'].",
+      "items": {
+        "type": "string"
+      },
+      "title": "Observables",
+      "type": "array"
+    },
+    "constraints": {
+      "additionalProperties": {
+        "maxItems": 2,
+        "minItems": 2,
+        "prefixItems": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "number"
+          }
+        ],
+        "type": "array"
+      },
+      "description": "Hard limits on measured quantities, as 'name: [LESS_THAN or GREATER_THAN, value]'. Usually empty.",
+      "title": "Constraints",
+      "type": "object"
+    },
+    "evaluator": {
+      "$ref": "#/$defs/EvaluatorSpec",
+      "description": "The analysis code that scores each iteration."
+    },
+    "generator": {
+      "$ref": "#/$defs/GeneratorSpec",
+      "description": "The algorithm that proposes the next settings."
+    },
+    "max_iterations": {
+      "anyOf": [
+        {
+          "minimum": 1,
+          "type": "integer"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "Stop after this many optimization iterations. Leave unset to run until stopped by hand.",
+      "title": "Max Iterations"
+    },
+    "seed_dump_files": {
+      "description": "Optional earlier results (ECS dump files) used to warm-start the optimizer. Usually empty.",
+      "items": {
+        "type": "string"
+      },
+      "title": "Seed Dump Files",
+      "type": "array"
+    },
+    "move_to_best_on_finish": {
+      "default": false,
+      "description": "After the optimization ends, drive the variables back to the best settings found.",
+      "title": "Move To Best On Finish",
+      "type": "boolean"
+    }
+  },
+  "required": [
+    "variables",
+    "evaluator",
+    "generator"
+  ],
+  "title": "OptimizationSpec",
+  "type": "object"
+}

--- a/docs/geecs_schemas/scan_axis.schema.json
+++ b/docs/geecs_schemas/scan_axis.schema.json
@@ -1,0 +1,80 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$defs": {
+    "PositionList": {
+      "additionalProperties": false,
+      "description": "Scan positions given as an explicit list of values.\n\nUse this instead of start/end/step when the positions are irregular \u2014\ne.g. ``values: [0.0, 0.5, 2.0, 8.0]``.",
+      "properties": {
+        "values": {
+          "description": "The exact positions to visit, in the order given.",
+          "items": {
+            "type": "number"
+          },
+          "minItems": 1,
+          "title": "Values",
+          "type": "array"
+        }
+      },
+      "required": [
+        "values"
+      ],
+      "title": "PositionList",
+      "type": "object"
+    },
+    "PositionRange": {
+      "additionalProperties": false,
+      "description": "Scan positions given as start / end / step size.\n\nThe scan visits start, start\u00b1step, \u2026 up to and including the end (when\nthe step divides the range evenly).  Start may be above or below end \u2014\nthe direction follows start\u2192end and the sign of ``step`` is ignored.",
+      "properties": {
+        "start": {
+          "description": "First position of the sweep.",
+          "title": "Start",
+          "type": "number"
+        },
+        "end": {
+          "description": "Last position of the sweep.",
+          "title": "End",
+          "type": "number"
+        },
+        "step": {
+          "description": "Spacing between positions. Its sign is ignored \u2014 the sweep direction comes from start and end.",
+          "title": "Step",
+          "type": "number"
+        }
+      },
+      "required": [
+        "start",
+        "end",
+        "step"
+      ],
+      "title": "PositionRange",
+      "type": "object"
+    }
+  },
+  "additionalProperties": false,
+  "description": "One swept variable and the positions it visits.\n\nA step scan sweeps one or more axes.  One axis is the familiar 1-D\nscan; several axes form a grid \u2014 see :class:`ScanRequest` for how the\naxes loop together.",
+  "properties": {
+    "variable": {
+      "description": "The friendly name of the variable this axis sweeps (from the experiment's scan-variables catalog).",
+      "title": "Variable",
+      "type": "string"
+    },
+    "positions": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/PositionRange"
+        },
+        {
+          "$ref": "#/$defs/PositionList"
+        }
+      ],
+      "description": "The positions this axis visits, either as {start, end, step} or as {values: [...]}.",
+      "title": "Positions"
+    }
+  },
+  "required": [
+    "variable",
+    "positions"
+  ],
+  "title": "ScanAxis",
+  "type": "object"
+}


### PR DESCRIPTION
Phase 2b-ii of `Planning/schema_refactor/00_overview.md`, on top of #762 (the export registry) and #758. **Reviewed before opening** — the adversarial report and dispositions are the first comment.

## What

**Three named scan plans** (`GeecsBluesky/geecs_bluesky/plans/named_plans.py`), registered by the worker startup beside the funnel with per-parameter annotations:

| Plan | Parameters |
|---|---|
| `geecs_noscan_plan` | `capture`, `actions=`, `description=`, `background=` |
| `geecs_scan_plan` | `axes` (1-D and grid as one plan), `capture`, `actions=`, `description=`, `background=` |
| `geecs_optimize_plan` | `optimization`, `capture`, `actions=`, `description=`, `background=` |

plus the funnel's queue-settable seams (`failed_move_policy`, `submission`, `session`, `resolver`) on every plan, pinned. Each assembles the canonical `ScanRequest` and **yields from `geecs_scan_request_plan`** — the same preamble, validation, claim, run discipline and metadata — so the start document is the ScanRequest regardless of entry plan (the shared-execution invariant, pinned by document-parity tests on the mock RunEngine for noscan and 1-D, and by seam tests for all three).

**No new schema types.** The plans take the existing sub-models as JSON; GEECS-Schemas 0.17.0 adds them to the export registry so a generic client grafts one published JSON Schema per parameter (`capture_settings`, `action_bindings`, `scan_axis`, `optimization_spec`).

**Correction to the plan** (recorded in the planning doc): the optimize plan takes **no axes** — an optimize ScanRequest forbids them and its variables and bounds live in `OptimizationSpec.variables`, as they always have. Smaller than either shape discussed.

**What it buys:** per-mode forms in OSPREY (one form per plan, no fields from other modes); permission granularity — `user_group_permissions.yaml` documents gating optimize by forbidding `geecs_optimize_plan` (and the funnel, which carries any mode); a manager history that names the kind of scan. The funnel stays the document API for GEECS-Console and GEECS-MCP — **no client change**.

## Per-concern LOC

| Commit | Files | +/− |
|---|---|---|
| GEECS-Schemas 0.17.0 (4 registry lines, 4 artifacts, changelog) | 7 | +379 / −2 |
| GeecsBluesky 0.73.0 (plans, startup, permissions note, README, CLAUDE, tests, planning) | 11 | +644 / −6 |
| Review fixes (probe pin, seam parity, per-parameter artifact pin, one harness, planning text) | 5 | +144 / −88 |

(Most of the Schemas count is four generated JSON Schema artifacts.)

## Tests

- GEECS-Schemas: **286 passed** (CI way, from the repo root; no-drift guard covers the five artifacts)
- GeecsBluesky: **782 passed, 2 skipped** full suite — this env now has the `qserver` extra, so the manager-validation pins (`test_qserver_startup.py`, `test_named_plans.py`) ran locally, not only in CI
- Reviewer additionally drove the manager's own `_process_plan`/`validate_plan` against all three plans with positional and kwargs-only items and bad types.

## Deploy order

**Worker first.** A client submitting a named plan to a worker that has not registered it fails at queue add. Nothing else changes: the funnel's signature and the existing plans are untouched, so today's console/MCP clients keep working against either worker.

## Hardware verification

**OWED**: restart the worker at GeecsBluesky 0.73.0 (host checkout → master), then one queue item per named plan from the qserver CLI (the README's two examples plus an optimize item), each start document checked for the canonical `ScanRequest` shape (`scan_request_mode`, `save_sets`, `submission` absent for CLI items). Expect the noscan/scan items to run exactly like a funnel submission of the equivalent request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N6sdn4meUHi3R1qD9yC4Hf
