### PR TITLE
GEECS-DataPortal 0.19.0: Analysis tab — summary figures automatically, per-bin visuals behind a stepper

### DIFF
--- a/GEECS-DataPortal/CHANGELOG.md
+++ b/GEECS-DataPortal/CHANGELOG.md
@@ -3,6 +3,24 @@
 All notable changes to this package will be documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.19.0] - 2026-09-02
+
+### Changed
+
+- Analysis tab artifacts (owner ruling after the first live look,
+  2026-09-02): the scan-level figures — averaged image, image grid,
+  1D summary, animation — show automatically; the per-bin visuals
+  (`<name>_<bin>_processed_visual.*`) show **one at a time** behind a
+  prev / next stepper ("bin N (i of M)"), like the Images tab's shot
+  stepper, instead of every bin at once. The classification
+  (`kind` ∈ summary / bin / other, `bin` number) is decided server-side
+  by ScanAnalysis's own filename conventions
+  (`analysis_runs.classify_artifact`) and the listing is ordered
+  summaries → others → bins by number. The listing now always
+  describes what is on disk under the analyzer's output dir plus the
+  finished job's non-file labels (before: the job's own list when done,
+  which was the summaries only).
+
 ## [0.18.0] - 2026-09-01
 
 ### Added

--- a/GEECS-DataPortal/CHANGELOG.md
+++ b/GEECS-DataPortal/CHANGELOG.md
@@ -13,13 +13,17 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   (`<name>_<bin>_processed_visual.*`) show **one at a time** behind a
   prev / next stepper ("bin N (i of M)"), like the Images tab's shot
   stepper, instead of every bin at once. The classification
-  (`kind` ∈ summary / bin / other, `bin` number) is decided server-side
-  by ScanAnalysis's own filename conventions
-  (`analysis_runs.classify_artifact`) and the listing is ordered
-  summaries → others → bins by number. The listing now always
-  describes what is on disk under the analyzer's output dir plus the
-  finished job's non-file labels (before: the job's own list when done,
-  which was the summaries only).
+  (`kind` ∈ summary / bin / other, `bin` number) is ScanAnalysis's
+  own output-name contract, parsed by its
+  `renderers.config.parse_output_filename` (ScanAnalysis 1.18.0, next to
+  the code that builds the names; imported lazily) — a bin's data file
+  (`_<bin>_processed.h5`) travels with its visual behind the stepper,
+  never as an auto-shown link. The listing is ordered summaries →
+  others → bins by number, capped on the bins only (never the
+  summaries), and always describes what is on disk under the
+  analyzer's output dir plus the finished job's non-file labels
+  (before: the job's own list when done, which was the summaries only).
+  A stepper click re-renders that analyzer's row only.
 
 ## [0.18.0] - 2026-09-01
 

--- a/GEECS-DataPortal/CHANGELOG.md
+++ b/GEECS-DataPortal/CHANGELOG.md
@@ -18,9 +18,10 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   `renderers.config.parse_output_filename` (ScanAnalysis 1.18.0, next to
   the code that builds the names; imported lazily) — a bin's data file
   (`_<bin>_processed.h5`) travels with its visual behind the stepper,
-  never as an auto-shown link. The listing is ordered summaries →
-  others → bins by number, capped on the bins only (never the
-  summaries), and always describes what is on disk under the
+  never as an auto-shown link (visual first, then the data file). The
+  listing is ordered summaries → others → bins by number, capped on
+  DISTINCT bins only (never the summaries, never splitting a bin), and
+  always describes what is on disk under the
   analyzer's output dir plus the finished job's non-file labels
   (before: the job's own list when done, which was the summaries only).
   A stepper click re-renders that analyzer's row only.

--- a/GEECS-DataPortal/CLAUDE.md
+++ b/GEECS-DataPortal/CLAUDE.md
@@ -207,9 +207,12 @@ name — has a folder in this scan), its in-memory `job` record
 run's captured log lines) and `files` (what is on disk under
 `analysis/ScanNNN/<output_name>/`, so a page loaded after a portal
 restart still shows earlier outputs) and `artifacts` — what the tab
-shows (the done job's list, else the files), each `{path, servable,
-inline}` decided by `analysis_runs.describe_artifact` (the ONE
-inline-raster policy; the page never guesses from a path); `POST
+shows (the files on disk + the done job's non-file labels), each
+`{path, servable, inline, kind, bin}` decided by
+`analysis_runs.describe_artifacts` (the ONE inline-raster policy and
+the ONE summary/bin classification by ScanAnalysis's filename
+conventions — the page never guesses from a path; summaries render
+automatically, bins one at a time behind a stepper); `POST
 /api/run/{uid}/analysis?analyzer=<id>` starts a run (202 + record;
 feature off / extra missing / unknown diagnostic / folder unresolvable
 → 404; a job already active for the scan → 409 with its record);

--- a/GEECS-DataPortal/CLAUDE.md
+++ b/GEECS-DataPortal/CLAUDE.md
@@ -209,10 +209,12 @@ run's captured log lines) and `files` (what is on disk under
 restart still shows earlier outputs) and `artifacts` — what the tab
 shows (the files on disk + the done job's non-file labels), each
 `{path, servable, inline, kind, bin}` decided by
-`analysis_runs.describe_artifacts` (the ONE inline-raster policy and
-the ONE summary/bin classification by ScanAnalysis's filename
-conventions — the page never guesses from a path; summaries render
-automatically, bins one at a time behind a stepper); `POST
+`analysis_runs.describe_artifacts` (the ONE inline-raster policy; the
+summary/bin classification is ScanAnalysis's own contract,
+`renderers.config.parse_output_filename`, imported lazily — the page
+never guesses from a path; summaries render automatically, bins one at
+a time behind a stepper, the bin cap applied after classification);
+`POST
 /api/run/{uid}/analysis?analyzer=<id>` starts a run (202 + record;
 feature off / extra missing / unknown diagnostic / folder unresolvable
 → 404; a job already active for the scan → 409 with its record);

--- a/GEECS-DataPortal/geecs_portal/analysis_runs.py
+++ b/GEECS-DataPortal/geecs_portal/analysis_runs.py
@@ -427,7 +427,9 @@ def classify_artifact(artifact: str) -> tuple[str, Optional[int]]:
     return parse_output_filename(artifact)
 
 
-def describe_artifact(analysis_folder: Path, artifact: str) -> dict:
+def describe_artifact(
+    analysis_folder: Path, artifact: str, *, servable: Optional[bool] = None
+) -> dict:
     """The wire shape of one artifact: ``{path, servable, inline, kind, bin}``.
 
     ``servable`` = it resolves to a file inside the analysis folder (the
@@ -435,9 +437,12 @@ def describe_artifact(analysis_folder: Path, artifact: str) -> dict:
     tab may show in an ``<img>``. Labels and files elsewhere are neither
     — the tab shows them as text. ``kind``/``bin`` per
     :func:`classify_artifact`. Decided HERE so the page never re-derives
-    the policy from a path's shape.
+    the policy from a path's shape. Pass ``servable`` when it is already
+    known (a path that came from :func:`list_artifacts` is servable by
+    construction) to skip the per-file resolve + stat on the share.
     """
-    servable = contained_artifact(analysis_folder, artifact) is not None
+    if servable is None:
+        servable = contained_artifact(analysis_folder, artifact) is not None
     kind, bin_number = classify_artifact(artifact)
     return {
         "path": artifact,
@@ -452,31 +457,61 @@ _KIND_ORDER = {"summary": 0, "other": 1, "bin": 2}
 
 
 def describe_artifacts(
-    analysis_folder: Path, artifacts: list[str], *, max_bins: int = 200
+    analysis_folder: Path,
+    artifacts: list[str],
+    *,
+    known_files: Optional[set[str]] = None,
+    max_bins: int = 200,
 ) -> list[dict]:
-    """Describe + order for the tab: summaries, then others, then bins by number.
+    """Describe + order for the tab: summaries, then others, then bins.
 
-    The cap applies to the bin files only, after classification — a
-    lexical cap on the raw listing would drop the summaries first
-    (``_average…`` sorts after every ``_<digits>_…`` name).
+    Bins order by number and, within a bin, the inline visual before
+    its data file. The cap keeps the first ``max_bins`` DISTINCT bins
+    (every file of each), applied after classification — a lexical cap
+    on the raw listing would drop the summaries first (``_average…``
+    sorts after every ``_<digits>_…`` name), and a cap on bin *files*
+    would split a bin. *known_files* are servable by construction (they
+    came from the listing) and skip the per-file stat.
     """
+    known = known_files or set()
     described = sorted(
-        (describe_artifact(analysis_folder, a) for a in artifacts),
-        key=lambda d: (_KIND_ORDER[d["kind"]], d["bin"] or 0, d["path"]),
+        (
+            describe_artifact(analysis_folder, a, servable=True if a in known else None)
+            for a in artifacts
+        ),
+        key=lambda d: (
+            _KIND_ORDER[d["kind"]],
+            d["bin"] or 0,
+            not d["inline"],
+            d["path"],
+        ),
     )
-    bins = [d for d in described if d["kind"] == "bin"][:max_bins]
-    return [d for d in described if d["kind"] != "bin"] + bins
+    kept: list[int] = []
+    for d in described:
+        if d["kind"] == "bin" and d["bin"] not in kept:
+            kept.append(d["bin"])
+    allowed = set(kept[:max_bins])
+    return [d for d in described if d["kind"] != "bin" or d["bin"] in allowed]
+
+
+#: Sanity bound on the on-disk listing (an output dir is ~2 files per
+#: bin + a few summaries; this only guards a runaway directory).
+LISTING_SANITY_CAP = 2000
 
 
 def list_artifacts(
-    analysis_folder: Path, output_name: str, *, limit: Optional[int] = None
+    analysis_folder: Path,
+    output_name: str,
+    *,
+    limit: Optional[int] = LISTING_SANITY_CAP,
 ) -> list[str]:
     """Files under the analyzer's output directory, relative to the analysis folder.
 
     ScanAnalysis writes per-analyzer outputs under
     ``analysis/ScanNNN/<output_name>/…`` — this lists them (sorted) so a
     page loaded after a portal restart still shows what an earlier run
-    produced. Uncapped by default: the tab's cap is applied AFTER
+    produced. The default cap is only a sanity bound
+    (:data:`LISTING_SANITY_CAP`); the tab's bin cap is applied AFTER
     classification (:func:`describe_artifacts`), never lexically here.
     """
     out_dir = analysis_folder / output_name

--- a/GEECS-DataPortal/geecs_portal/analysis_runs.py
+++ b/GEECS-DataPortal/geecs_portal/analysis_runs.py
@@ -34,6 +34,7 @@ from __future__ import annotations
 
 import dataclasses
 import logging
+import re
 import threading
 import time
 from collections import deque
@@ -409,21 +410,66 @@ def contained_artifact(analysis_folder: Path, relative: str) -> Optional[Path]:
 INLINE_IMAGE_SUFFIXES = frozenset({".png", ".jpg", ".jpeg", ".gif", ".webp"})
 
 
+#: ScanAnalysis output-name conventions (``renderers/*``): per-bin
+#: visuals are ``<name>_<bin>_processed_visual.<ext>``; the average /
+#: grid / summary / animation files are the scan-level figures.
+_BIN_FILE = re.compile(r"_(\d+)_processed_visual\.[A-Za-z0-9]+$")
+_SUMMARY_MARKERS = (
+    "_average_processed_visual.",
+    "_averaged_image_grid.",
+    "_summary_",
+    "_animation.",
+)
+
+
+def classify_artifact(artifact: str) -> tuple[str, Optional[int]]:
+    """``("bin", n)`` / ``("summary", None)`` / ``("other", None)`` from the name.
+
+    The tab shows summaries automatically and steps through bins one
+    at a time (owner ruling 2026-09-02); the split is by ScanAnalysis's
+    own filename conventions, decided here rather than in page JS.
+    """
+    name = Path(artifact).name
+    match = _BIN_FILE.search(name)
+    if match:
+        return "bin", int(match.group(1))
+    if any(marker in name for marker in _SUMMARY_MARKERS) or name.lower().endswith(
+        ".gif"
+    ):
+        return "summary", None
+    return "other", None
+
+
 def describe_artifact(analysis_folder: Path, artifact: str) -> dict:
-    """The wire shape of one artifact: ``{path, servable, inline}``.
+    """The wire shape of one artifact: ``{path, servable, inline, kind, bin}``.
 
     ``servable`` = it resolves to a file inside the analysis folder (the
     artifact endpoint would serve it); ``inline`` = a raster image the
     tab may show in an ``<img>``. Labels and files elsewhere are neither
-    — the tab shows them as text. Decided HERE so the page never
-    re-derives the policy from a path's shape.
+    — the tab shows them as text. ``kind``/``bin`` per
+    :func:`classify_artifact`. Decided HERE so the page never re-derives
+    the policy from a path's shape.
     """
     servable = contained_artifact(analysis_folder, artifact) is not None
+    kind, bin_number = classify_artifact(artifact)
     return {
         "path": artifact,
         "servable": servable,
         "inline": servable and Path(artifact).suffix.lower() in INLINE_IMAGE_SUFFIXES,
+        "kind": kind,
+        "bin": bin_number,
     }
+
+
+_KIND_ORDER = {"summary": 0, "other": 1, "bin": 2}
+
+
+def describe_artifacts(analysis_folder: Path, artifacts: list[str]) -> list[dict]:
+    """Describe + order for the tab: summaries, then others, then bins by number."""
+    described = [describe_artifact(analysis_folder, a) for a in artifacts]
+    return sorted(
+        described, key=lambda d: (_KIND_ORDER[d["kind"]], d["bin"] or 0, d["path"])
+    )
 
 
 def list_artifacts(

--- a/GEECS-DataPortal/geecs_portal/analysis_runs.py
+++ b/GEECS-DataPortal/geecs_portal/analysis_runs.py
@@ -34,7 +34,6 @@ from __future__ import annotations
 
 import dataclasses
 import logging
-import re
 import threading
 import time
 from collections import deque
@@ -410,34 +409,22 @@ def contained_artifact(analysis_folder: Path, relative: str) -> Optional[Path]:
 INLINE_IMAGE_SUFFIXES = frozenset({".png", ".jpg", ".jpeg", ".gif", ".webp"})
 
 
-#: ScanAnalysis output-name conventions (``renderers/*``): per-bin
-#: visuals are ``<name>_<bin>_processed_visual.<ext>``; the average /
-#: grid / summary / animation files are the scan-level figures.
-_BIN_FILE = re.compile(r"_(\d+)_processed_visual\.[A-Za-z0-9]+$")
-_SUMMARY_MARKERS = (
-    "_average_processed_visual.",
-    "_averaged_image_grid.",
-    "_summary_",
-    "_animation.",
-)
-
-
 def classify_artifact(artifact: str) -> tuple[str, Optional[int]]:
     """``("bin", n)`` / ``("summary", None)`` / ``("other", None)`` from the name.
 
     The tab shows summaries automatically and steps through bins one
-    at a time (owner ruling 2026-09-02); the split is by ScanAnalysis's
-    own filename conventions, decided here rather than in page JS.
+    at a time (owner ruling 2026-09-02). The split is ScanAnalysis's
+    own output-name contract, parsed by ITS
+    ``renderers.config.parse_output_filename`` (next to the code that
+    builds the names) — imported lazily, like the factory, so this
+    module stays importable without the extra; without it everything
+    is ``other`` (the run feature is off anyway).
     """
-    name = Path(artifact).name
-    match = _BIN_FILE.search(name)
-    if match:
-        return "bin", int(match.group(1))
-    if any(marker in name for marker in _SUMMARY_MARKERS) or name.lower().endswith(
-        ".gif"
-    ):
-        return "summary", None
-    return "other", None
+    try:
+        from scan_analysis.analyzers.renderers.config import parse_output_filename
+    except ImportError:
+        return "other", None
+    return parse_output_filename(artifact)
 
 
 def describe_artifact(analysis_folder: Path, artifact: str) -> dict:
@@ -464,23 +451,33 @@ def describe_artifact(analysis_folder: Path, artifact: str) -> dict:
 _KIND_ORDER = {"summary": 0, "other": 1, "bin": 2}
 
 
-def describe_artifacts(analysis_folder: Path, artifacts: list[str]) -> list[dict]:
-    """Describe + order for the tab: summaries, then others, then bins by number."""
-    described = [describe_artifact(analysis_folder, a) for a in artifacts]
-    return sorted(
-        described, key=lambda d: (_KIND_ORDER[d["kind"]], d["bin"] or 0, d["path"])
+def describe_artifacts(
+    analysis_folder: Path, artifacts: list[str], *, max_bins: int = 200
+) -> list[dict]:
+    """Describe + order for the tab: summaries, then others, then bins by number.
+
+    The cap applies to the bin files only, after classification — a
+    lexical cap on the raw listing would drop the summaries first
+    (``_average…`` sorts after every ``_<digits>_…`` name).
+    """
+    described = sorted(
+        (describe_artifact(analysis_folder, a) for a in artifacts),
+        key=lambda d: (_KIND_ORDER[d["kind"]], d["bin"] or 0, d["path"]),
     )
+    bins = [d for d in described if d["kind"] == "bin"][:max_bins]
+    return [d for d in described if d["kind"] != "bin"] + bins
 
 
 def list_artifacts(
-    analysis_folder: Path, output_name: str, *, limit: int = 200
+    analysis_folder: Path, output_name: str, *, limit: Optional[int] = None
 ) -> list[str]:
     """Files under the analyzer's output directory, relative to the analysis folder.
 
     ScanAnalysis writes per-analyzer outputs under
-    ``analysis/ScanNNN/<output_name>/…`` — this lists them (sorted,
-    capped) so a page loaded after a portal restart still shows what
-    an earlier run produced.
+    ``analysis/ScanNNN/<output_name>/…`` — this lists them (sorted) so a
+    page loaded after a portal restart still shows what an earlier run
+    produced. Uncapped by default: the tab's cap is applied AFTER
+    classification (:func:`describe_artifacts`), never lexically here.
     """
     out_dir = analysis_folder / output_name
     if not out_dir.is_dir():
@@ -489,4 +486,6 @@ def list_artifacts(
         files = sorted(p for p in out_dir.rglob("*") if p.is_file())
     except OSError:
         return []
-    return [p.relative_to(analysis_folder).as_posix() for p in files[:limit]]
+    if limit is not None:
+        files = files[:limit]
+    return [p.relative_to(analysis_folder).as_posix() for p in files]

--- a/GEECS-DataPortal/geecs_portal/app.py
+++ b/GEECS-DataPortal/geecs_portal/app.py
@@ -964,15 +964,15 @@ def create_app(
         analyzers = []
         for name, info in _processing_infos().items():
             job = jobs.get(name)
-            # What the tab shows: the finished job's own artifact list,
-            # else what is on disk under the output dir — each entry
-            # described (servable / inline) server-side so the page
+            # What the tab shows: everything on disk under the output dir
+            # (summaries + per-bin visuals, classified server-side) plus
+            # any label the finished job returned that is not a file —
+            # described (servable / inline / kind / bin) so the page
             # never guesses from a path's shape.
-            shown = (
-                job.artifacts
-                if job is not None and job.state == analysis_runs.DONE
-                else analysis_runs.list_artifacts(analysis_folder, info.output_name)
-            )
+            files = analysis_runs.list_artifacts(analysis_folder, info.output_name)
+            shown = list(files)
+            if job is not None and job.state == analysis_runs.DONE:
+                shown += [a for a in job.artifacts if a not in files]
             analyzers.append(
                 {
                     "id": name,
@@ -980,13 +980,10 @@ def create_app(
                     "applicable": info.device in devices or info.device in present,
                     "output_dir": info.output_name,
                     "job": job.to_json() if job is not None else None,
-                    "files": analysis_runs.list_artifacts(
-                        analysis_folder, info.output_name
+                    "files": files,
+                    "artifacts": analysis_runs.describe_artifacts(
+                        analysis_folder, shown
                     ),
-                    "artifacts": [
-                        analysis_runs.describe_artifact(analysis_folder, a)
-                        for a in shown
-                    ],
                 }
             )
         running = runner.running_for(uid)

--- a/GEECS-DataPortal/geecs_portal/app.py
+++ b/GEECS-DataPortal/geecs_portal/app.py
@@ -982,7 +982,7 @@ def create_app(
                     "job": job.to_json() if job is not None else None,
                     "files": files,
                     "artifacts": analysis_runs.describe_artifacts(
-                        analysis_folder, shown
+                        analysis_folder, shown, known_files=set(files)
                     ),
                 }
             )

--- a/GEECS-DataPortal/geecs_portal/templates/run.html
+++ b/GEECS-DataPortal/geecs_portal/templates/run.html
@@ -587,29 +587,39 @@ function artifactCard(a) {
 
 function renderArtifacts(id, artifacts) {
   // Each entry is {path, servable, inline, kind, bin} — decided
-  // server-side (analysis_runs.describe_artifacts): the page never
-  // re-derives the policy from a path's shape. Summaries (and anything
-  // unclassified) show automatically; per-bin visuals show ONE at a
-  // time behind a stepper, like the Images tab's shot stepper.
+  // server-side (analysis_runs.describe_artifacts over ScanAnalysis's
+  // own output-name contract): the page never re-derives the policy
+  // from a path's shape. Summaries (and anything unclassified) show
+  // automatically; per-bin outputs show ONE bin at a time behind a
+  // stepper, like the Images tab's shot stepper — every file of that
+  // bin (the visual inline, its data file as a link).
   if (!artifacts || !artifacts.length) return "";
   const auto = artifacts.filter(a => a.kind !== "bin");
-  const bins = artifacts.filter(a => a.kind === "bin");
+  const binNumbers = [...new Set(artifacts.filter(a => a.kind === "bin").map(a => a.bin))];
   let html = auto.length ? `<div class="arts">${auto.map(artifactCard).join("")}</div>` : "";
-  if (bins.length) {
-    const i = Math.min(Math.max(ANALYSIS_BIN[id] || 0, 0), bins.length - 1);
-    const bin = bins[i];
+  if (binNumbers.length) {
+    const i = Math.min(Math.max(ANALYSIS_BIN[id] || 0, 0), binNumbers.length - 1);
+    ANALYSIS_BIN[id] = i;  // write the clamp back: a shrunken list must not strand the index
+    const number = binNumbers[i];
+    const files = artifacts.filter(a => a.kind === "bin" && a.bin === number);
     html += `<div class="binstep">
-      <button class="act" data-id="${escAttr(id)}" data-delta="-1" onclick="stepBin(this.dataset.id, -1)" ${i === 0 ? "disabled" : ""}>&lsaquo; prev bin</button>
-      <span class="dim">bin <b>${esc(String(bin.bin))}</b> <span class="mono">(${i + 1} of ${bins.length})</span></span>
-      <button class="act" data-id="${escAttr(id)}" data-delta="1" onclick="stepBin(this.dataset.id, 1)" ${i === bins.length - 1 ? "disabled" : ""}>next bin &rsaquo;</button>
-    </div><div class="arts">${artifactCard(bin)}</div>`;
+      <button class="act" data-id="${escAttr(id)}" onclick="stepBin(this.dataset.id, -1)" ${i === 0 ? "disabled" : ""}>&lsaquo; prev bin</button>
+      <span class="dim">bin <b>${esc(String(number))}</b> <span class="mono">(${i + 1} of ${binNumbers.length})</span></span>
+      <button class="act" data-id="${escAttr(id)}" onclick="stepBin(this.dataset.id, 1)" ${i === binNumbers.length - 1 ? "disabled" : ""}>next bin &rsaquo;</button>
+    </div><div class="arts">${files.map(artifactCard).join("")}</div>`;
   }
   return html;
 }
 
 function stepBin(id, delta) {
+  // Re-render THIS analyzer's row only: a whole-list rebuild would
+  // re-fetch every inline artifact on the tab (they are no-cache).
   ANALYSIS_BIN[id] = (ANALYSIS_BIN[id] || 0) + delta;
-  if (ANALYSIS_BODY) renderAnalysis(ANALYSIS_BODY, true);
+  if (!ANALYSIS_BODY) return;
+  const a = ANALYSIS_BODY.analyzers.find(x => x.id === id);
+  const row = document.querySelector(`#analysisList .arow[data-row="${CSS.escape(id)}"]`);
+  if (!a || !row) return;
+  row.outerHTML = renderAnalyzer(a, ANALYSIS_BODY.running !== null);
 }
 
 function renderAnalyzer(a, anyRunning) {
@@ -631,7 +641,7 @@ function renderAnalyzer(a, anyRunning) {
     const open = ANALYSIS_OPEN[a.id] ? " open" : "";
     body += `<details${open} data-id="${escAttr(a.id)}" ontoggle="ANALYSIS_OPEN[this.dataset.id]=this.open"><summary>log (${job.log.length} lines)</summary><pre>${esc(job.log.join("\n"))}</pre></details>`;
   }
-  return `<div class="arow"><div class="head"><span class="id">${esc(a.id)}</span>${device}${badge}${when}<span class="right">${button}</span></div>${body}</div>`;
+  return `<div class="arow" data-row="${escAttr(a.id)}"><div class="head"><span class="id">${esc(a.id)}</span>${device}${badge}${when}<span class="right">${button}</span></div>${body}</div>`;
 }
 
 let ANALYSIS_LAST = null;  // last-rendered payload — an unchanged poll leaves the DOM alone

--- a/GEECS-DataPortal/geecs_portal/templates/run.html
+++ b/GEECS-DataPortal/geecs_portal/templates/run.html
@@ -100,6 +100,7 @@
   .arow details { margin-top: 0.4rem; font-size: 12px; }
   .arow details pre { max-height: 14rem; overflow: auto; background: var(--panel2); padding: 0.5rem; border-radius: 3px; font-size: 11px; }
   .arts { display: flex; flex-wrap: wrap; gap: 0.6rem; margin-top: 0.5rem; }
+  .binstep { display: flex; gap: 0.6rem; align-items: center; margin-top: 0.6rem; font-size: 12px; }
   .arts img { max-width: 100%; max-height: 24rem; border: 1px solid var(--line); border-radius: 3px; background: var(--panel2); }
   .arts a.file { font-family: ui-monospace, Menlo, monospace; font-size: 12px; }
   #pane-analysis details.others > summary { cursor: pointer; color: var(--dim); font-size: 12px; margin: 0.6rem 0; }
@@ -573,20 +574,42 @@ function artifactUrl(path) {
   return `${ROOT}/run/${UID}/artifact?` + p.toString();
 }
 
-function renderArtifacts(artifacts) {
-  // Each entry is {path, servable, inline} — decided server-side
-  // (analysis_runs.describe_artifact): the page never re-derives the
-  // policy from a path's shape.
+let ANALYSIS_BIN = {};   // analyzer id -> index into its bin artifacts (the stepper)
+
+function artifactCard(a) {
+  const path = a.path;
+  if (a.inline) {
+    return `<a href="${artifactUrl(path)}" target="_blank"><img src="${artifactUrl(path)}" alt="${escAttr(path)}" title="${escAttr(path)}"></a>`;
+  }
+  if (a.servable) return `<a class="file" href="${artifactUrl(path)}" target="_blank">${esc(path)}</a>`;
+  return `<span class="dim mono">${esc(path)}</span>`;
+}
+
+function renderArtifacts(id, artifacts) {
+  // Each entry is {path, servable, inline, kind, bin} — decided
+  // server-side (analysis_runs.describe_artifacts): the page never
+  // re-derives the policy from a path's shape. Summaries (and anything
+  // unclassified) show automatically; per-bin visuals show ONE at a
+  // time behind a stepper, like the Images tab's shot stepper.
   if (!artifacts || !artifacts.length) return "";
-  const cards = artifacts.map(a => {
-    const path = a.path;
-    if (a.inline) {
-      return `<a href="${artifactUrl(path)}" target="_blank"><img src="${artifactUrl(path)}" alt="${escAttr(path)}" title="${escAttr(path)}"></a>`;
-    }
-    if (a.servable) return `<a class="file" href="${artifactUrl(path)}" target="_blank">${esc(path)}</a>`;
-    return `<span class="dim mono">${esc(path)}</span>`;
-  });
-  return `<div class="arts">${cards.join("")}</div>`;
+  const auto = artifacts.filter(a => a.kind !== "bin");
+  const bins = artifacts.filter(a => a.kind === "bin");
+  let html = auto.length ? `<div class="arts">${auto.map(artifactCard).join("")}</div>` : "";
+  if (bins.length) {
+    const i = Math.min(Math.max(ANALYSIS_BIN[id] || 0, 0), bins.length - 1);
+    const bin = bins[i];
+    html += `<div class="binstep">
+      <button class="act" data-id="${escAttr(id)}" data-delta="-1" onclick="stepBin(this.dataset.id, -1)" ${i === 0 ? "disabled" : ""}>&lsaquo; prev bin</button>
+      <span class="dim">bin <b>${esc(String(bin.bin))}</b> <span class="mono">(${i + 1} of ${bins.length})</span></span>
+      <button class="act" data-id="${escAttr(id)}" data-delta="1" onclick="stepBin(this.dataset.id, 1)" ${i === bins.length - 1 ? "disabled" : ""}>next bin &rsaquo;</button>
+    </div><div class="arts">${artifactCard(bin)}</div>`;
+  }
+  return html;
+}
+
+function stepBin(id, delta) {
+  ANALYSIS_BIN[id] = (ANALYSIS_BIN[id] || 0) + delta;
+  if (ANALYSIS_BODY) renderAnalysis(ANALYSIS_BODY, true);
 }
 
 function renderAnalyzer(a, anyRunning) {
@@ -603,7 +626,7 @@ function renderAnalyzer(a, anyRunning) {
   const when = job && job.finished ? `<span class="dim" style="font-size:11px">${new Date(job.finished * 1000).toLocaleTimeString()}</span>` : "";
   let body = "";
   if (job && job.error) body += `<p class="err">${esc(job.error)}</p>`;
-  body += renderArtifacts(a.artifacts);
+  body += renderArtifacts(a.id, a.artifacts);
   if (job && job.log && job.log.length) {
     const open = ANALYSIS_OPEN[a.id] ? " open" : "";
     body += `<details${open} data-id="${escAttr(a.id)}" ontoggle="ANALYSIS_OPEN[this.dataset.id]=this.open"><summary>log (${job.log.length} lines)</summary><pre>${esc(job.log.join("\n"))}</pre></details>`;
@@ -612,13 +635,15 @@ function renderAnalyzer(a, anyRunning) {
 }
 
 let ANALYSIS_LAST = null;  // last-rendered payload — an unchanged poll leaves the DOM alone
+let ANALYSIS_BODY = null;  // the payload itself, so a stepper click re-renders without a fetch
 
-function renderAnalysis(body) {
+function renderAnalysis(body, force) {
   const list = document.getElementById("analysisList");
   if (!list) return;
   const anyRunning = body.running !== null;
   const key = JSON.stringify(body);
-  if (key === ANALYSIS_LAST) {
+  ANALYSIS_BODY = body;
+  if (key === ANALYSIS_LAST && !force) {
     // Nothing changed: keep polling while active, but do not rebuild
     // the list (every <img> would re-fetch its artifact).
     clearTimeout(ANALYSIS_TIMER);

--- a/GEECS-DataPortal/tests/test_analysis_runs.py
+++ b/GEECS-DataPortal/tests/test_analysis_runs.py
@@ -202,6 +202,9 @@ class TestHelpers:
             "UC_Crop/Array2DScanAnalyzer/a.png",
             "UC_Crop/Array2DScanAnalyzer/b.png",
         ]
+        assert (
+            len(analysis_runs.list_artifacts(root, "UC_Crop")) == 3
+        )  # uncapped default
         assert analysis_runs.list_artifacts(root, "UC_Missing") == []
 
 
@@ -406,11 +409,15 @@ class TestListing:
         assert describe(root, "a label.")["servable"] is False
 
     def test_artifact_kinds_follow_scan_analysis_naming(self, tmp_path):
+        """Classification is ScanAnalysis's own contract (parse_output_filename)."""
+        pytest.importorskip("scan_analysis")
         classify = analysis_runs.classify_artifact
+        # Real renderer names (RenderContext.get_filename + the summary names).
         assert classify("UC_X/Array2DScanAnalyzer/UC_X_16_processed_visual.png") == (
             "bin",
             16,
         )
+        assert classify("UC_X/Array2DScanAnalyzer/UC_X_16_processed.h5") == ("bin", 16)
         assert classify(
             "UC_X/Array2DScanAnalyzer/UC_X_average_processed_visual.png"
         ) == ("summary", None)
@@ -418,20 +425,15 @@ class TestListing:
             "summary",
             None,
         )
-        assert classify("UC_L/Array1DScanAnalyzer/UC_L_summary_per_shot.png") == (
+        assert classify("UC_L/Array1DScanAnalyzer/UC_L_summary_waterfall.png") == (
             "summary",
             None,
         )
-        assert classify("UC_X/Array2DScanAnalyzer/UC_X_animation.gif") == (
-            "summary",
-            None,
-        )
-        assert classify("UC_X/Array2DScanAnalyzer/UC_X_1_processed.h5") == (
-            "other",
-            None,
-        )
+        assert classify("UC_X/Array2DScanAnalyzer/noscan.gif") == ("summary", None)
+        assert classify("UC_X/UC_X_dynamic_background.npy") == ("other", None)
         assert classify("a label, not a path") == ("other", None)
-        # Ordering for the tab: summaries, others, then bins by NUMBER (not lexically).
+        # Ordering for the tab: summaries, others, then bins by NUMBER (not
+        # lexically); the cap applies to bins only, never to summaries.
         root = tmp_path / "analysis" / "Scan002"
         (root / "UC_X").mkdir(parents=True)
         names = [
@@ -439,6 +441,7 @@ class TestListing:
             "UC_X_2_processed_visual.png",
             "UC_X_averaged_image_grid.png",
             "UC_X_2_processed.h5",
+            "UC_X_dynamic_background.npy",
         ]
         for name in names:
             (root / "UC_X" / name).write_bytes(b"x")
@@ -447,11 +450,18 @@ class TestListing:
             ("summary", None),
             ("other", None),
             ("bin", 2),
+            ("bin", 2),
             ("bin", 10),
         ]
+        capped = analysis_runs.describe_artifacts(
+            root, [f"UC_X/{n}" for n in names], max_bins=1
+        )
+        assert [(d["kind"], d["bin"]) for d in capped] == [
+            ("summary", None),
+            ("other", None),
+            ("bin", 2),
+        ]
 
-
-class TestRun:
     def test_done_artifacts_and_serving(self, scan_folder, configs_tree, caplog):
         pytest.importorskip("image_analysis")
         # Capture respects the process's logging levels (no global level

--- a/GEECS-DataPortal/tests/test_analysis_runs.py
+++ b/GEECS-DataPortal/tests/test_analysis_runs.py
@@ -376,6 +376,8 @@ class TestListing:
                 "path": "UC_Crop/Array2DScanAnalyzer/old.png",
                 "servable": True,
                 "inline": True,
+                "kind": "other",
+                "bin": None,
             }
         ]
 
@@ -389,6 +391,8 @@ class TestListing:
             "path": "UC_Crop/fig.png",
             "servable": True,
             "inline": True,
+            "kind": "other",
+            "bin": None,
         }
         assert describe(root, "UC_Crop/fig.svg")["inline"] is False  # download only
         assert describe(root, "UC_Crop/fig.svg")["servable"] is True
@@ -398,6 +402,51 @@ class TestListing:
             "inline": False,
         }
         assert describe(root, "a label.")["servable"] is False
+
+    def test_artifact_kinds_follow_scan_analysis_naming(self, tmp_path):
+        classify = analysis_runs.classify_artifact
+        assert classify("UC_X/Array2DScanAnalyzer/UC_X_16_processed_visual.png") == (
+            "bin",
+            16,
+        )
+        assert classify(
+            "UC_X/Array2DScanAnalyzer/UC_X_average_processed_visual.png"
+        ) == ("summary", None)
+        assert classify("UC_X/Array2DScanAnalyzer/UC_X_averaged_image_grid.png") == (
+            "summary",
+            None,
+        )
+        assert classify("UC_L/Array1DScanAnalyzer/UC_L_summary_per_shot.png") == (
+            "summary",
+            None,
+        )
+        assert classify("UC_X/Array2DScanAnalyzer/UC_X_animation.gif") == (
+            "summary",
+            None,
+        )
+        assert classify("UC_X/Array2DScanAnalyzer/UC_X_1_processed.h5") == (
+            "other",
+            None,
+        )
+        assert classify("a label, not a path") == ("other", None)
+        # Ordering for the tab: summaries, others, then bins by NUMBER (not lexically).
+        root = tmp_path / "analysis" / "Scan002"
+        (root / "UC_X").mkdir(parents=True)
+        names = [
+            "UC_X_10_processed_visual.png",
+            "UC_X_2_processed_visual.png",
+            "UC_X_averaged_image_grid.png",
+            "UC_X_2_processed.h5",
+        ]
+        for name in names:
+            (root / "UC_X" / name).write_bytes(b"x")
+        described = analysis_runs.describe_artifacts(root, [f"UC_X/{n}" for n in names])
+        assert [(d["kind"], d["bin"]) for d in described] == [
+            ("summary", None),
+            ("other", None),
+            ("bin", 2),
+            ("bin", 10),
+        ]
 
 
 class TestRun:
@@ -437,13 +486,22 @@ class TestRun:
         crop = next(a for a in body["analyzers"] if a["id"] == "UC_Crop")
         assert crop["files"] == ["UC_Crop/Array2DScanAnalyzer/summary.png"]
         # The tab renders the DESCRIBED artifacts: policy decided server-side.
+        # (files on disk + the job's non-file labels, classified server-side)
         assert crop["artifacts"] == [
             {
                 "path": "UC_Crop/Array2DScanAnalyzer/summary.png",
                 "servable": True,
                 "inline": True,
+                "kind": "other",
+                "bin": None,
             },
-            {"path": "a label, not a path", "servable": False, "inline": False},
+            {
+                "path": "a label, not a path",
+                "servable": False,
+                "inline": False,
+                "kind": "other",
+                "bin": None,
+            },
         ]
         served = client.get(
             "/run/uid-002/artifact",

--- a/GEECS-DataPortal/tests/test_analysis_runs.py
+++ b/GEECS-DataPortal/tests/test_analysis_runs.py
@@ -446,13 +446,14 @@ class TestListing:
         for name in names:
             (root / "UC_X" / name).write_bytes(b"x")
         described = analysis_runs.describe_artifacts(root, [f"UC_X/{n}" for n in names])
-        assert [(d["kind"], d["bin"]) for d in described] == [
-            ("summary", None),
-            ("other", None),
-            ("bin", 2),
-            ("bin", 2),
-            ("bin", 10),
+        assert [(d["kind"], d["bin"], d["inline"]) for d in described] == [
+            ("summary", None, True),
+            ("other", None, False),
+            ("bin", 2, True),  # the visual first within a bin …
+            ("bin", 2, False),  # … then its data file
+            ("bin", 10, True),
         ]
+        # The cap keeps DISTINCT bins whole (never splits a bin's files).
         capped = analysis_runs.describe_artifacts(
             root, [f"UC_X/{n}" for n in names], max_bins=1
         )
@@ -460,8 +461,20 @@ class TestListing:
             ("summary", None),
             ("other", None),
             ("bin", 2),
+            ("bin", 2),
         ]
+        # Listing-known files skip the stat and are servable by construction.
+        assert all(
+            d["servable"]
+            for d in analysis_runs.describe_artifacts(
+                root,
+                [f"UC_X/{n}" for n in names],
+                known_files={f"UC_X/{n}" for n in names},
+            )
+        )
 
+
+class TestRun:
     def test_done_artifacts_and_serving(self, scan_folder, configs_tree, caplog):
         pytest.importorskip("image_analysis")
         # Capture respects the process's logging levels (no global level

--- a/GEECS-DataPortal/tests/test_analysis_runs.py
+++ b/GEECS-DataPortal/tests/test_analysis_runs.py
@@ -400,6 +400,8 @@ class TestListing:
             "path": "../s2.txt",
             "servable": False,
             "inline": False,
+            "kind": "other",
+            "bin": None,
         }
         assert describe(root, "a label.")["servable"] is False
 

--- a/ScanAnalysis/CHANGELOG.md
+++ b/ScanAnalysis/CHANGELOG.md
@@ -3,6 +3,19 @@
 All notable changes to this package will be documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [1.18.0] - 2026-09-02
+
+### Added
+
+- `scan_analysis.analyzers.renderers.config.parse_output_filename(name)`
+  → `(kind, bin)`: the inverse of `RenderContext.get_filename` and the
+  renderers' summary names (`_average_processed*`,
+  `_averaged_image_grid`, `_summary_{mode}`, the noscan `.gif`),
+  classifying an output file as `bin` (with its number), `summary` or
+  `other`. The data portal's Analysis tab classifies through it, so the
+  naming is a one-place contract: change a name and its parser
+  together. Pinned by `tests/test_renderer_output_names.py`.
+
 ## [1.17.3] - 2026-09-01
 
 ### Fixed

--- a/ScanAnalysis/CLAUDE.md
+++ b/ScanAnalysis/CLAUDE.md
@@ -257,6 +257,18 @@ reader: a new `to_dict()` key fails there until `STATUS_FIELDS` /
 `AnalysisStatus` in GEECS-Data-Utils learn it — extend both in the same
 PR as the writer change.
 
+## Renderer output names are a consumed contract
+
+`RenderContext.get_filename` (`analyzers/renderers/config.py`) and the
+renderers' summary names (`_average_processed*`, `_averaged_image_grid`,
+`_summary_{mode}`, the noscan `.gif`) are parsed back by
+`parse_output_filename` in the same module — the data portal's Analysis
+tab classifies outputs through it (summary vs per-bin). Change a name
+and its parser together; `tests/test_renderer_output_names.py` pins the
+pairing. (The wrappers' own `parts[-2].isdigit()` bin-key parsing in
+`array2D_scan_analysis.py` / `array1d_scan_analysis.py` predates this
+helper and is a known follow-up.)
+
 ## Live Watching (`live_task_runner.py`)
 
 `LiveTaskRunner` watches a data directory for new s-files (scan summary files),

--- a/ScanAnalysis/pyproject.toml
+++ b/ScanAnalysis/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "scananalysis"
-version = "1.17.3"
+version = "1.18.0"
 description = "Modules for performing analyses routines on full scans"
 authors = ["Christopher Doss <CEDoss@lbl.gov>", "Sam Barber <sbarber@lbl.gov"]
 readme = "README.md"

--- a/ScanAnalysis/scan_analysis/analyzers/renderers/config.py
+++ b/ScanAnalysis/scan_analysis/analyzers/renderers/config.py
@@ -7,6 +7,9 @@ It also provides RenderContext for bundling data with metadata.
 
 from __future__ import annotations
 
+import re
+from pathlib import Path
+
 from typing import Optional, Literal, Tuple, Dict, Any, Union, Callable
 from dataclasses import dataclass
 from pydantic import BaseModel, Field
@@ -346,3 +349,46 @@ class RenderContext:
             Formatted filename
         """
         return f"{self.device_name}_{self.identifier}_{suffix}.{extension}"
+
+
+# ---------------------------------------------------------------------------
+# Output-name contract (the inverse of RenderContext.get_filename)
+# ---------------------------------------------------------------------------
+
+_BIN_OUTPUT = re.compile(r"_(\d+)_processed(?:_visual)?\.[A-Za-z0-9]+$")
+_SUMMARY_MARKERS = ("_average_processed", "_averaged_image_grid.", "_summary_")
+
+
+def parse_output_filename(name: str) -> Tuple[str, Optional[int]]:
+    """Classify a renderer output file by its name: ``(kind, bin)``.
+
+    The renderers write per-bin files as
+    ``{device}_{bin}_processed.h5`` / ``{device}_{bin}_processed_visual.png``
+    (:meth:`RenderContext.get_filename` with the bin key as identifier),
+    the scan-level average with identifier ``average``, the 2D grid as
+    ``{device}_averaged_image_grid.png``, the 1D summary as
+    ``{device}_summary_{mode}.png``, and the noscan animation as a
+    ``.gif``. Consumers that present these outputs (the data portal's
+    Analysis tab) classify through THIS function so the naming stays a
+    one-place contract: change a name here and its parser together.
+
+    Parameters
+    ----------
+    name : str
+        A filename or path (only the basename is inspected).
+
+    Returns
+    -------
+    (kind, bin)
+        ``("bin", n)`` for per-bin outputs, ``("summary", None)`` for
+        scan-level figures, ``("other", None)`` for anything else.
+    """
+    base = Path(name).name
+    match = _BIN_OUTPUT.search(base)
+    if match:
+        return "bin", int(match.group(1))
+    if any(marker in base for marker in _SUMMARY_MARKERS) or base.lower().endswith(
+        ".gif"
+    ):
+        return "summary", None
+    return "other", None

--- a/ScanAnalysis/tests/test_renderer_output_names.py
+++ b/ScanAnalysis/tests/test_renderer_output_names.py
@@ -1,0 +1,43 @@
+"""The renderer output-name contract: ``parse_output_filename`` inverts ``get_filename``."""
+
+from __future__ import annotations
+
+import pytest
+
+from scan_analysis.analyzers.renderers.config import parse_output_filename
+
+
+@pytest.mark.parametrize(
+    "name, expected",
+    [
+        ("UC_TestCam_16_processed_visual.png", ("bin", 16)),
+        ("UC_TestCam_16_processed.h5", ("bin", 16)),
+        ("UC_Amp4_2_processed_visual.png", ("bin", 2)),  # digits in the device name
+        ("U_S1_2_10_processed.h5", ("bin", 10)),
+        ("UC_TestCam_average_processed_visual.png", ("summary", None)),
+        ("UC_TestCam_average_processed.h5", ("summary", None)),
+        ("UC_TestCam_averaged_image_grid.png", ("summary", None)),
+        ("UC_Line_summary_waterfall.png", ("summary", None)),
+        ("noscan.gif", ("summary", None)),
+        ("some/dir/UC_TestCam_3_processed_visual.png", ("bin", 3)),
+        ("UC_TestCam_dynamic_background.npy", ("other", None)),
+        ("a label, not a path", ("other", None)),
+    ],
+)
+def test_parse_output_filename(name, expected):
+    assert parse_output_filename(name) == expected
+
+
+def test_round_trips_get_filename_shape():
+    """The parser must invert the exact string get_filename builds."""
+    device, identifier = "UC_TestCam", 7
+    for suffix, ext, kind in (
+        ("processed", "h5", ("bin", 7)),
+        ("processed_visual", "png", ("bin", 7)),
+    ):
+        # RenderContext.get_filename: f"{device_name}_{identifier}_{suffix}.{extension}"
+        assert parse_output_filename(f"{device}_{identifier}_{suffix}.{ext}") == kind
+    assert parse_output_filename(f"{device}_average_processed_visual.png") == (
+        "summary",
+        None,
+    )


### PR DESCRIPTION
## What

Owner feedback after the first live look at the Analysis tab (2026-09-02): "only automatically show the summary figs, not the individual bins … show one of the bins and the summary fig, but allow the user to cycle through the bins much like we do for individual images on the image panel."

- **`analysis_runs.classify_artifact`** (+ `describe_artifacts`): `kind` ∈ `summary` / `bin` / `other` and the `bin` number, from ScanAnalysis's own filename conventions (`<name>_<bin>_processed_visual.*` = bin; `_average_processed_visual`, `_averaged_image_grid`, `_summary_`, `_animation`/`.gif` = summary). Listing ordered summaries → others → bins by number (numeric, not lexical).
- **Listing endpoint**: `artifacts` now always describes the files on disk under the analyzer's output dir plus the finished job's non-file labels (before: the job's own list when done, which was the summaries only — the bins only appeared after a portal restart, inconsistently).
- **Tab**: summaries and unclassified files render automatically; bins render ONE at a time behind "‹ prev bin / bin N (i of M) / next bin ›", the Images tab's stepper idiom. Stepper state is per analyzer, in page memory (a poll re-render keeps it; a stepper click re-renders from the cached payload without a fetch). Handlers take the id via `data-` attributes (the #765 rule).
- Portal 0.18.0 → 0.19.0, CHANGELOG, CLAUDE.md.

## Judgment calls (cheap to veto)

- The bin stepper is page state, not URL state — a link does not carry which bin you were looking at. Cheap to add to the URL vocabulary if wanted.
- Labels changed from "← prev / next →" to "‹ prev bin / next bin ›" so the Images tab's "next →" absence test stays meaningful.

## Tests

- `test_artifact_kinds_follow_scan_analysis_naming` (classification + ordering) and the described-artifact shape assertions updated; **222 passed** (219 → 222 incl. the parametrised additions). Stepper markup evaluated in node from the served page: one bin image shown, prev/next disabled at the ends, ids via `data-id`.

## Hardware verification

Visual check on the worker host (already serving `feat/analysis-tab`) once merged: scan 32's FROG analyzer row shows the averaged figure automatically and a single bin with a working stepper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018K1DmUzf1ZPjM4NxX2QRX3