### PR TITLE
GEECS-DataPortal: pyproject 0.19.0 (the bump #770's CHANGELOG announced)

### DIFF
--- a/GEECS-DataPortal/pyproject.toml
+++ b/GEECS-DataPortal/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-data-portal"
-version = "0.18.0"
+version = "0.19.0"
 description = "Scan-browsing web service (read-only except explicit analysis runs): a zero-install browser view over the Tiled catalog and the GEECS data share"
 authors = ["GEECS-BELLA"]
 readme = "README.md"


### PR DESCRIPTION
## What

One line: `GEECS-DataPortal/pyproject.toml` version 0.18.0 → 0.19.0. #770's CHANGELOG entry and CLAUDE.md already describe 0.19.0; the `poetry version` bump line sat in a patch batch that aborted on an unrelated assertion, so the metadata stayed at 0.18.0 (noticed on the worker host: `poetry version` printed 0.18.0 after pulling the #770 merge).

## Tests

Metadata only; no behaviour. CI runs the usual suites.

## Review

Version-metadata fix for an already-reviewed PR — no adversarial re-review (nothing to refute); noted here per the /land ritual.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018K1DmUzf1ZPjM4NxX2QRX3