### PR TITLE
GEECS-DataPortal 0.20.0: browsing JSON API (day list, run overview, device tier, day jump)

### DIFF
--- a/GEECS-DataPortal/CHANGELOG.md
+++ b/GEECS-DataPortal/CHANGELOG.md
@@ -20,8 +20,9 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   the click on a device name), and `GET /api/run/jump/{iso}?prefer=`
   (the day steppers' target, as data instead of a redirect). The
   listings and neighbour logic moved into shared helpers the templates
-  now use too (`_list_day`, `_neighbours`, `_resolved_folder`), so the
-  HTML and JSON surfaces cannot drift. Served `no-cache` (a day gains
+  now use too (`_list_day`, `_neighbours`, `_resolved_folder`,
+  `_jump_target`, `_scan_label`, `_parse_iso_day`), so the HTML and
+  JSON surfaces cannot drift. Served `no-cache` (a day gains
   scans, a running run gains its stop doc). Documents pass through
   `analysis.jsonable_document` (NaN / numpy / set → JSON-safe — a
   document key must never 500 a run).

--- a/GEECS-DataPortal/CHANGELOG.md
+++ b/GEECS-DataPortal/CHANGELOG.md
@@ -3,6 +3,32 @@
 All notable changes to this package will be documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.20.0] - 2026-09-02
+
+### Added
+
+- **The browsing API** — everything the pages show, as JSON, so a
+  script or an AI agent (the OSPREY assistant's `geecs-data-portal`
+  skill) can read what a browser shows and press what a browser
+  presses without scraping HTML: `GET /api/day/{iso}?experiment=&filter=`
+  (the day page's table, newest first, same filter haystack),
+  `GET /api/run/{uid}` (the rail + the Overview table verbatim +
+  start/stop documents + the device list + the scan steppers'
+  neighbours and dropdown + the processing selector's options +
+  `analysis_enabled`, the Analysis tab's gate), `GET
+  /api/run/{uid}/device?device=` (one device's gallery tier and path —
+  the click on a device name), and `GET /api/run/jump/{iso}?prefer=`
+  (the day steppers' target, as data instead of a redirect). The
+  listings and neighbour logic moved into shared helpers the templates
+  now use too (`_list_day`, `_neighbours`, `_resolved_folder`), so the
+  HTML and JSON surfaces cannot drift. Served `no-cache` (a day gains
+  scans, a running run gains its stop doc). Documents pass through
+  `analysis.jsonable_document` (NaN / numpy / set → JSON-safe — a
+  document key must never 500 a run).
+- `GET /health` now carries `version` (the same key every `/api`
+  fetch is busted by), and a test pins that `/openapi.json` lists the
+  whole agent surface — the deployed route list is discoverable.
+
 ## [0.19.0] - 2026-09-02
 
 ### Changed

--- a/GEECS-DataPortal/CLAUDE.md
+++ b/GEECS-DataPortal/CLAUDE.md
@@ -170,7 +170,21 @@ shot) · `/run/{uid}/bin-image.png?device=&bin=<index>&filters=&bincfg=`
 member shots that resolve to pixels average via the shared
 `average_frames`, windowed once after averaging; per-shot refusals
 carry over; always `no-cache` — bin membership comes off the union
-frame) · `/health` (catalog probe — the fleet-map health check).
+frame) · `/health` (catalog probe + version — the fleet-map health check)
+· **the browsing API** (0.20.0 — the pages' own data as JSON, the
+agent/script surface; served `no-cache`): `/api/day/{iso}?experiment=&filter=`
+(the run table, newest first, the page's filter haystack) ·
+`/api/run/{uid}` (summary + the Overview table verbatim + start/stop
+docs + `devices` + stepper `neighbours`/`day_runs` +
+`processing_options` + `analysis_enabled`) · `/api/run/{uid}/device?device=`
+(one device's tier/path via the same `device_kind` probe as the page) ·
+`/api/run/jump/{iso}?prefer=` (the day steppers' target as data).
+The page and JSON routes share `_list_day` / `_neighbours` /
+`_resolved_folder` — add a page-visible fact to BOTH surfaces through
+those helpers, never to one template.  `/openapi.json` stays on (the
+docs UI is off) so a client can discover the deployed routes; the OSPREY
+deployment's `skills/geecs-data-portal` reference (htu-assistant repo)
+mirrors every payload shape and must move with any change here.
 
 Both image endpoints also take `?display=` (the shared display state's
 image slice: `cmap` matplotlib-colormap name + `plo`/`phi` percentile

--- a/GEECS-DataPortal/geecs_portal/analysis.py
+++ b/GEECS-DataPortal/geecs_portal/analysis.py
@@ -341,6 +341,28 @@ def jsonable_labels(index: Any) -> list:
     return jsonable_values(list(index))
 
 
+def jsonable_document(value: Any) -> Any:
+    """A run document (or any nested value) made JSON-safe.
+
+    The browsing API serves the start/stop documents verbatim.  Tiled
+    hands them back as plain containers, but a key may still carry a
+    NaN, a numpy scalar, a date or a set — none of which ``json.dumps``
+    survives.  Dicts and lists recurse; ``str``/``bool``/``int``/``None``
+    pass through; floats follow the NaN/inf → ``None`` rule; anything
+    else goes through :func:`jsonable_values` (numeric → float, else its
+    ``str``).  A document key must never 500 a run's detail.
+    """
+    if isinstance(value, dict):
+        return {str(key): jsonable_document(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [jsonable_document(item) for item in value]
+    if value is None or isinstance(value, (str, bool, int)):
+        return value
+    if isinstance(value, float):
+        return value if math.isfinite(value) else None
+    return jsonable_values([value])[0]
+
+
 # --------------------------- show the code ----------------------------
 
 

--- a/GEECS-DataPortal/geecs_portal/app.py
+++ b/GEECS-DataPortal/geecs_portal/app.py
@@ -310,6 +310,18 @@ def _parse_iso_day(day: str) -> date:
         raise HTTPException(status_code=404, detail="bad date") from exc
 
 
+def _jump_target(runs: list[RunSummary], prefer: int) -> Optional[RunSummary]:
+    """The day steppers' rule — the run numbered ``prefer``, else the newest.
+
+    ONE implementation for the HTML redirect and the JSON twin, so the
+    two cannot drift (``None`` only for a day with no runs).
+    """
+    return next(
+        (run for run in runs if prefer and run.scan_number == prefer),
+        runs[0] if runs else None,
+    )
+
+
 @dataclasses.dataclass(frozen=True)
 class _DiagInfo:
     """A loadable diagnostic's run-side facts (the selector cache's value)."""
@@ -998,6 +1010,14 @@ def create_app(
             return False
         return True
 
+    def _analysis_enabled_for(folder: Optional[Path]) -> bool:
+        """The Analysis tab's gate: the feature on AND a resolvable scan folder.
+
+        Runs and the artifact listing are per scan folder — the page and
+        ``/api/run`` read the same answer.
+        """
+        return folder is not None and _analysis_enabled()
+
     def _analysis_available() -> None:
         """404 unless the run feature is configured AND installed."""
         if processing_config_dir is None:
@@ -1266,10 +1286,7 @@ def create_app(
         runs, error = _list_day(exp, selected, "")
         if error:
             raise HTTPException(status_code=503, detail=f"catalog unavailable: {error}")
-        target = next(
-            (run for run in runs if prefer and run.scan_number == prefer),
-            runs[0] if runs else None,
-        )
+        target = _jump_target(runs, prefer)
         page = (
             f"{_root(request)}/run/{target.uid}"
             if target
@@ -1320,7 +1337,7 @@ def create_app(
             "prev_day": (run_day - timedelta(days=1)).isoformat() if run_day else None,
             "next_day": (run_day + timedelta(days=1)).isoformat() if run_day else None,
             "processing_options": _processing_names(),
-            "analysis_enabled": folder is not None and _analysis_enabled(),
+            "analysis_enabled": _analysis_enabled_for(folder),
             "page": f"{_root(request)}/run/{uid}",
             "portal_version": _portal_version(),
         }
@@ -1379,10 +1396,7 @@ def create_app(
         request: Request, day: str, experiment: str = "", filter: str = ""
     ) -> HTMLResponse:
         """The run list for one day (newest first, as the catalog lists)."""
-        try:
-            selected = date.fromisoformat(day)
-        except ValueError as exc:
-            raise HTTPException(status_code=404, detail="bad date") from exc
+        selected = _parse_iso_day(day)
         exp = experiment or default_experiment
         runs, error = _list_day(exp, selected, filter)
         if error:
@@ -1398,6 +1412,7 @@ def create_app(
                 "experiment": exp,
                 "filter": filter,
                 "rows": [(run, fmt_time_of_day(run.start_time)) for run in runs],
+                "scan_label": _scan_label,
                 "error": error,
                 "qs": lambda **kw: _sticky_query(day_state, **kw),
             },
@@ -1413,10 +1428,7 @@ def create_app(
         columns, and tab survive the hop.  A day with no runs falls
         back to the day page.
         """
-        try:
-            selected = date.fromisoformat(day)
-        except ValueError as exc:
-            raise HTTPException(status_code=404, detail="bad date") from exc
+        selected = _parse_iso_day(day)
         carried = [
             (key, value)
             for key, value in request.query_params.multi_items()
@@ -1438,10 +1450,8 @@ def create_app(
                 f"{_root(request)}/day/{selected.isoformat()}"
                 f"{'?' + day_query if day_query else ''}"
             )
-        target = next(
-            (run for run in runs if prefer and run.scan_number == prefer),
-            runs[0],  # newest (catalog order)
-        )
+        target = _jump_target(runs, prefer)
+        assert target is not None  # runs is non-empty here
         return f"{_root(request)}/run/{target.uid}?{query}"
 
     @app.get("/run/{uid}", response_class=HTMLResponse)
@@ -1482,9 +1492,7 @@ def create_app(
             kind, kind_path = "", None
         n_rows = None if detail.data is None else len(detail.data)
         shot = max(1, min(shot, n_rows) if n_rows else shot)
-        # The Analysis tab needs a resolvable folder (runs and artifact
-        # listing are per scan folder) on top of the feature gate.
-        analysis_enabled = folder is not None and _analysis_enabled()
+        analysis_enabled = _analysis_enabled_for(folder)
         if (
             kind == "native"
             and folder is not None

--- a/GEECS-DataPortal/geecs_portal/app.py
+++ b/GEECS-DataPortal/geecs_portal/app.py
@@ -54,6 +54,7 @@ from geecs_data_utils.data.row_filters import filter_mask
 from geecs_data_utils.io.images import average_frames
 from geecs_data_utils.scan_frame import PROVENANCE_RUN, scan_frame
 from geecs_data_utils.tiled_catalog import (
+    RunSummary,
     ScanCatalog,
     fmt_time_of_day,
     metadata_rows,
@@ -100,6 +101,12 @@ _PLOT_MAX_ROWS = 100_000
 #: is emitted, so ``no-cache`` means a re-fetch, not a 304 — an ETag
 #: over the s-file's stat is the follow-up if revisits feel slow.
 _UNION_HEADERS = {"Cache-Control": "no-cache"}
+
+#: Headers for the JSON browsing surface (day listing, run detail, device
+#: probe, jump). A day gains scans while it is being taken, a running
+#: run gains its stop document, and a device folder fills in as the run
+#: writes — always re-fetch, never pin.
+_LISTING_HEADERS = {"Cache-Control": "no-cache"}
 
 #: Requests carrying a proxy mount prefix — the Grafana/JupyterHub
 #: convention every reverse proxy speaks.
@@ -259,6 +266,48 @@ def _default_x(detail, columns: list[str]) -> str:
         return ""
     scan_vars = schema_map.scan_variable_columns(columns, detail.start_doc)
     return scan_vars[0] if scan_vars else ""
+
+
+def _scan_label(summary: RunSummary) -> str:
+    """The listing's scan cell: ``Scan 002``, else the uid's first 8 chars."""
+    if summary.scan_number is not None:
+        return f"Scan {summary.scan_number:03d}"
+    return summary.uid[:8]
+
+
+def _summary_json(summary: RunSummary) -> dict:
+    """One run's listing row, as the day page's table shows it.
+
+    The JSON twin of a ``day.html`` row (scan cell, HH:MM, mode,
+    description, shots, status) plus the fields the page keeps in
+    attributes or omits (uid, epoch start, experiment, save sets).
+    """
+    started = None
+    if summary.start_time > 0:
+        started = analysis.jsonable_datetimes([summary.start_time], "unix")[0]
+    return {
+        "uid": summary.uid,
+        "scan": _scan_label(summary),
+        "scan_number": summary.scan_number,
+        "start_time": summary.start_time,
+        "started": started,
+        "time": fmt_time_of_day(summary.start_time),
+        "mode": summary.mode,
+        "description": summary.description,
+        "shots": summary.shots,
+        "exit_status": summary.exit_status,
+        "running": not summary.exit_status,
+        "experiment": summary.experiment,
+        "save_sets": list(summary.save_sets),
+    }
+
+
+def _parse_iso_day(day: str) -> date:
+    """An ISO day path segment, or the routes' shared 404."""
+    try:
+        return date.fromisoformat(day)
+    except ValueError as exc:
+        raise HTTPException(status_code=404, detail="bad date") from exc
 
 
 @dataclasses.dataclass(frozen=True)
@@ -537,11 +586,60 @@ def create_app(
             for column in columns
         }
 
+    def _list_day(experiment: str, day: date, filter_text: str) -> tuple[list, str]:
+        """The day's runs (newest first), filtered — ONE implementation.
+
+        Shared by the day page, the JSON day listing and both jump
+        routes so the surfaces cannot drift.  A catalog failure is
+        returned, not raised (``(runs, error)``): the page renders it
+        inline, the API maps it to 503, the jump degrades to the day.
+        """
+        try:
+            runs = list(catalog.list_runs(experiment, day))
+        except Exception as exc:  # noqa: BLE001 — surface, don't 500
+            logger.warning("day listing failed: %s", exc)
+            return [], str(exc)
+        needle = filter_text.strip().lower()
+        if needle:
+            runs = [run for run in runs if needle in run.filter_text()]
+        return runs, ""
+
+    def _neighbours(uid: str, experiment: str, run_day: Optional[date]):
+        """The scan steppers: ``(prev_uid, next_uid, day_runs)``.
+
+        The day's listing (newest first) feeds both the rail's scan
+        dropdown and the stepper neighbours — previous = older, next =
+        newer.  A listing failure (or a uid missing from its own day)
+        just hides them: ``("", "", [])`` — never sinks the page.
+        """
+        if run_day is None:
+            return "", "", []
+        try:
+            day_runs = list(catalog.list_runs(experiment, run_day))
+            day_uids = [run.uid for run in day_runs]
+            position = day_uids.index(uid)
+        except Exception as exc:  # noqa: BLE001 — stepper is optional
+            logger.warning("neighbour listing failed: %s", exc)
+            return "", "", []
+        next_uid = day_uids[position - 1] if position > 0 else ""
+        prev_uid = day_uids[position + 1] if position + 1 < len(day_uids) else ""
+        return prev_uid, next_uid, day_runs
+
+    def _resolved_folder(detail, day: str):
+        """``(run_day, folder)``: the run's own day and its existing scan folder."""
+        run_day = _run_day(detail, day)
+        folder = resolve_scan_folder(detail, run_day) if run_day else None
+        return run_day, folder
+
     @app.get("/health")
     def health() -> dict:
-        """Liveness + catalog probe (the fleet-map health check)."""
+        """Liveness + catalog probe (the fleet-map health check) + version."""
         status = catalog.probe()
-        return {"ok": status.ok, "catalog": status.label}
+        return {
+            "ok": status.ok,
+            "catalog": status.label,
+            "version": _portal_version(),
+        }
 
     # ------------------------- analysis JSON API -------------------------
     # One-liners over the data-utils primitives (03 design doc): every
@@ -929,8 +1027,7 @@ def create_app(
         (and TZ / experiment-spelling drift would do the same).
         """
         detail = _load_run(uid)
-        run_day = _run_day(detail, day)
-        folder = resolve_scan_folder(detail, run_day) if run_day else None
+        _, folder = _resolved_folder(detail, day)
         if folder is None:
             raise HTTPException(status_code=404, detail="scan folder not resolvable")
         try:
@@ -1132,6 +1229,135 @@ def create_app(
         }
         return JSONResponse(payload, headers=_UNION_HEADERS)
 
+    # ------------------------- browsing JSON API -------------------------
+    # The page-shaped reads (day list, run overview, device probe, the
+    # day jump) as JSON — for scripts and agents, so everything a
+    # browser shows is readable without scraping HTML.  Same helpers as
+    # the templates, so the two surfaces cannot drift.
+
+    @app.get("/api/day/{day}")
+    def api_day(
+        request: Request, day: str, experiment: str = "", filter: str = ""
+    ) -> JSONResponse:
+        """The day page as JSON: its runs (newest first), filtered."""
+        selected = _parse_iso_day(day)
+        exp = experiment or default_experiment
+        runs, error = _list_day(exp, selected, filter)
+        if error:
+            raise HTTPException(status_code=503, detail=f"catalog unavailable: {error}")
+        payload = {
+            "day": selected.isoformat(),
+            "prev_day": (selected - timedelta(days=1)).isoformat(),
+            "next_day": (selected + timedelta(days=1)).isoformat(),
+            "experiment": exp,
+            "filter": filter,
+            "runs": [_summary_json(run) for run in runs],
+            "page": f"{_root(request)}/day/{selected.isoformat()}",
+        }
+        return JSONResponse(payload, headers=_LISTING_HEADERS)
+
+    @app.get("/api/run/jump/{day}")
+    def api_run_jump(
+        request: Request, day: str, prefer: int = 0, experiment: str = ""
+    ) -> JSONResponse:
+        """The day steppers' target as JSON (see :func:`run_jump`)."""
+        selected = _parse_iso_day(day)
+        exp = experiment or default_experiment
+        runs, error = _list_day(exp, selected, "")
+        if error:
+            raise HTTPException(status_code=503, detail=f"catalog unavailable: {error}")
+        target = next(
+            (run for run in runs if prefer and run.scan_number == prefer),
+            runs[0] if runs else None,
+        )
+        page = (
+            f"{_root(request)}/run/{target.uid}"
+            if target
+            else f"{_root(request)}/day/{selected.isoformat()}"
+        )
+        payload = {
+            "day": selected.isoformat(),
+            "experiment": exp,
+            "prefer": prefer,
+            "uid": target.uid if target else None,
+            "scan_number": target.scan_number if target else None,
+            "matched": bool(target and prefer and target.scan_number == prefer),
+            "runs": len(runs),
+            "page": page,
+        }
+        return JSONResponse(payload, headers=_LISTING_HEADERS)
+
+    @app.get("/api/run/{uid}")
+    def api_run(
+        request: Request, uid: str, day: str = "", experiment: str = ""
+    ) -> JSONResponse:
+        """One run as JSON: the rail, the Overview tab and the device list.
+
+        ``metadata`` is the Overview table verbatim (``metadata_rows``);
+        ``devices`` are the image device folders (their tier is the
+        separate ``/device`` probe — one listing per device); the
+        neighbours and ``day_runs`` are the scan steppers and dropdown;
+        ``analysis_enabled`` says whether the page offers the Analysis
+        tab (same gate as the template).
+        """
+        detail = _load_run(uid)
+        run_day, folder = _resolved_folder(detail, day)
+        exp = experiment or default_experiment
+        prev_uid, next_uid, day_runs = _neighbours(uid, exp, run_day)
+        payload = {
+            "uid": uid,
+            "run_day": run_day.isoformat() if run_day else None,
+            "experiment": exp,
+            "summary": _summary_json(detail.summary),
+            "metadata": [[field, value] for field, value in metadata_rows(detail)],
+            "start_doc": analysis.jsonable_document(detail.start_doc or {}),
+            "stop_doc": analysis.jsonable_document(detail.stop_doc or {}),
+            "event_rows": None if detail.data is None else len(detail.data),
+            "scan_folder": str(folder) if folder else None,
+            "devices": resources.image_devices(folder) if folder else [],
+            "neighbours": {"prev_uid": prev_uid, "next_uid": next_uid},
+            "day_runs": [_summary_json(run) for run in day_runs],
+            "prev_day": (run_day - timedelta(days=1)).isoformat() if run_day else None,
+            "next_day": (run_day + timedelta(days=1)).isoformat() if run_day else None,
+            "processing_options": _processing_names(),
+            "analysis_enabled": folder is not None and _analysis_enabled(),
+            "page": f"{_root(request)}/run/{uid}",
+            "portal_version": _portal_version(),
+        }
+        return JSONResponse(payload, headers=_LISTING_HEADERS)
+
+    @app.get("/api/run/{uid}/device")
+    def api_device(uid: str, device: str = "", day: str = "") -> JSONResponse:
+        """One device's gallery tier — what clicking its name decides.
+
+        Same ``device_kind`` probe as the page (one directory listing,
+        no pixel reads), so the JSON and the Images tab can never
+        disagree about whether a device renders.
+        """
+        detail = _load_run(uid)
+        if not device:
+            raise HTTPException(status_code=400, detail="device is required")
+        run_day, folder = _resolved_folder(detail, day)
+        if folder is None:
+            raise HTTPException(status_code=404, detail="scan folder not resolvable")
+        probe = resources.device_kind(folder, device)
+        if probe.kind == "missing":
+            raise HTTPException(status_code=404, detail=f"unknown device {device!r}")
+        renderable = probe.kind in ("stack", "native")
+        payload = {
+            "uid": uid,
+            "run_day": run_day.isoformat() if run_day else None,
+            "device": device,
+            "kind": probe.kind,
+            "renderable": renderable,
+            "path": str(probe.path) if probe.path else None,
+            "ext": probe.ext,
+            "event_rows": None if detail.data is None else len(detail.data),
+            "planned_shots": detail.summary.shots,
+            "processing_options": _processing_names() if renderable else [],
+        }
+        return JSONResponse(payload, headers=_LISTING_HEADERS)
+
     @app.get("/", response_class=RedirectResponse)
     def index(request: Request) -> str:
         """Redirect to today's day view."""
@@ -1158,15 +1384,9 @@ def create_app(
         except ValueError as exc:
             raise HTTPException(status_code=404, detail="bad date") from exc
         exp = experiment or default_experiment
-        try:
-            runs = catalog.list_runs(exp, selected)
-            error = ""
-        except Exception as exc:  # noqa: BLE001 — surface, don't 500
-            logger.warning("day listing failed: %s", exc)
-            runs, error = [], f"catalog error: {exc}"
-        needle = filter.strip().lower()
-        if needle:
-            runs = [run for run in runs if needle in run.filter_text()]
+        runs, error = _list_day(exp, selected, filter)
+        if error:
+            error = f"catalog error: {error}"
         day_state = {"experiment": exp, "filter": filter}
         return templates.TemplateResponse(
             request,
@@ -1203,11 +1423,7 @@ def create_app(
             if key != "prefer"
         ]
         experiment = request.query_params.get("experiment", "") or default_experiment
-        try:
-            runs = catalog.list_runs(experiment, selected)
-        except Exception as exc:  # noqa: BLE001 — degrade to the day page
-            logger.warning("jump listing failed: %s", exc)
-            runs = []
+        runs, _ = _list_day(experiment, selected, "")  # failure → the day page
         carried = [(k, v) for (k, v) in carried if k != "day"]
         carried.append(("day", selected.isoformat()))
         query = urlencode(carried, doseq=True)
@@ -1255,8 +1471,7 @@ def create_app(
         keep the whole setup.
         """
         detail = _load_run(uid)
-        run_day = _run_day(detail, day)
-        folder = resolve_scan_folder(detail, run_day) if run_day else None
+        run_day, folder = _resolved_folder(detail, day)
         devices = resources.image_devices(folder) if folder else []
         sel_device = device if device in devices else ""
         if sel_device:
@@ -1303,25 +1518,9 @@ def create_app(
             data_cache.warm_native(
                 warm_key, _warm_one, list(range(1, min(n_rows, 2000) + 1))
             )
-        # The day's listing (newest first) feeds both the rail's scan
-        # dropdown and the stepper neighbours.  A listing failure just
-        # hides them — never sinks the page.
-        prev_uid = next_uid = ""
-        day_runs: list = []
-        if run_day is not None:
-            try:
-                day_runs = list(
-                    catalog.list_runs(experiment or default_experiment, run_day)
-                )
-                day_uids = [run.uid for run in day_runs]
-                position = day_uids.index(uid)
-                next_uid = day_uids[position - 1] if position > 0 else ""
-                prev_uid = (
-                    day_uids[position + 1] if position + 1 < len(day_uids) else ""
-                )
-            except Exception as exc:  # noqa: BLE001 — stepper is optional
-                logger.warning("neighbour listing failed: %s", exc)
-                day_runs = []
+        prev_uid, next_uid, day_runs = _neighbours(
+            uid, experiment or default_experiment, run_day
+        )
         state = {
             "day": day,
             "experiment": experiment or default_experiment,

--- a/GEECS-DataPortal/geecs_portal/templates/day.html
+++ b/GEECS-DataPortal/geecs_portal/templates/day.html
@@ -25,7 +25,7 @@
   {% for run, time_text in rows %}
   <tr>
     <td><a href="{{ root }}/run/{{ run.uid }}?{{ qs(day=day.isoformat()) }}">
-      {%- if run.scan_number is not none %}Scan {{ "%03d"|format(run.scan_number) }}{% else %}{{ run.uid[:8] }}{% endif -%}
+      {{- scan_label(run) -}}
     </a></td>
     <td class="mono">{{ time_text }}</td>
     <td>{{ run.mode }}</td>

--- a/GEECS-DataPortal/pyproject.toml
+++ b/GEECS-DataPortal/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-data-portal"
-version = "0.19.0"
+version = "0.20.0"
 description = "Scan-browsing web service (read-only except explicit analysis runs): a zero-install browser view over the Tiled catalog and the GEECS data share"
 authors = ["GEECS-BELLA"]
 readme = "README.md"

--- a/GEECS-DataPortal/tests/test_app.py
+++ b/GEECS-DataPortal/tests/test_app.py
@@ -12,6 +12,7 @@ from geecs_data_utils.tiled_catalog import (
     CatalogStatus,
     RunDetail,
     StubCatalog,
+    metadata_rows,
     summary_from_metadata,
 )
 
@@ -114,10 +115,12 @@ def _client(catalog=None, **kwargs) -> TestClient:
 
 
 class TestHealth:
-    def test_health_reports_probe(self):
+    def test_health_reports_probe_and_version(self):
         response = _client().get("/health")
         assert response.status_code == 200
-        assert response.json() == {"ok": True, "catalog": "fake catalog"}
+        payload = response.json()
+        assert payload["ok"] is True and payload["catalog"] == "fake catalog"
+        assert payload["version"]  # the /api cache-bust key, for scripts
 
     def test_health_with_stub_catalog(self):
         response = _client(StubCatalog()).get("/health")
@@ -1059,3 +1062,173 @@ class TestReverseProxy:
         response = _client().get("/health", headers=self.PREFIX)
         assert response.status_code == 200
         assert response.json()["ok"] is True
+
+
+class TestBrowsingApi:
+    """0.20.0: the page-shaped reads as JSON — day list, run, device, jump.
+
+    Everything a browser shows must be readable without scraping HTML
+    (the agent surface); every payload is the template's own data.
+    """
+
+    def test_day_lists_runs_newest_first_as_the_table_shows(self):
+        catalog = FakeCatalog()
+        client = _client(catalog, default_experiment="Undulator")
+        response = client.get(f"/api/day/{TEST_DAY.isoformat()}")
+        assert response.status_code == 200
+        assert response.headers["cache-control"] == "no-cache"
+        payload = response.json()
+        assert catalog.listed == ("Undulator", TEST_DAY)
+        assert payload["day"] == TEST_DAY.isoformat()
+        assert payload["experiment"] == "Undulator"
+        assert [run["scan"] for run in payload["runs"]] == ["Scan 002", "Scan 001"]
+        row = payload["runs"][0]
+        assert row["uid"] == "uid-002" and row["scan_number"] == 2
+        assert row["time"] == "09:02"
+        assert row["started"].startswith(f"{TEST_DAY.isoformat()} 09:02")
+        assert row["exit_status"] == "success" and row["running"] is False
+        assert row["save_sets"] == ["Amp4In"] and row["shots"] == 10
+        assert payload["prev_day"] == "2026-07-11"
+        assert payload["page"] == f"/day/{TEST_DAY.isoformat()}"
+
+    def test_day_filter_and_experiment_mirror_the_page(self):
+        catalog = FakeCatalog()
+        client = _client(catalog, default_experiment="Undulator")
+        payload = client.get(
+            f"/api/day/{TEST_DAY.isoformat()}?filter=scan 001&experiment=Thomson"
+        ).json()
+        assert catalog.listed[0] == "Thomson"
+        assert [run["uid"] for run in payload["runs"]] == ["uid-001"]
+        assert payload["filter"] == "scan 001"
+
+    def test_day_bad_date_is_404_and_outage_is_503(self):
+        assert _client().get("/api/day/not-a-date").status_code == 404
+        response = _client(FakeCatalog(fail_listing=True)).get(
+            f"/api/day/{TEST_DAY.isoformat()}"
+        )
+        assert response.status_code == 503
+        assert "catalog unavailable" in response.json()["detail"]
+
+    def test_empty_day_is_an_empty_list_not_an_error(self):
+        payload = _client(StubCatalog()).get(f"/api/day/{TEST_DAY.isoformat()}").json()
+        assert payload["runs"] == []
+
+    def test_run_carries_the_overview_table_verbatim(self):
+        catalog = FakeCatalog()
+        client = _client(catalog, default_experiment="Undulator")
+        response = client.get("/api/run/uid-002")
+        assert response.status_code == 200
+        assert response.headers["cache-control"] == "no-cache"
+        payload = response.json()
+        expected = [[k, v] for k, v in metadata_rows(catalog.details["uid-002"])]
+        assert payload["metadata"] == expected
+        assert payload["summary"]["scan"] == "Scan 002"
+        assert payload["run_day"] == TEST_DAY.isoformat()
+        assert payload["event_rows"] == 3
+        assert payload["start_doc"]["scan_number"] == 2
+        assert payload["stop_doc"]["exit_status"] == "success"
+        assert payload["page"] == "/run/uid-002"
+        assert payload["portal_version"]
+        assert payload["processing_options"] == []  # feature off
+        assert payload["analysis_enabled"] is False  # feature off
+
+    def test_run_neighbours_and_day_runs_are_the_steppers(self):
+        client = _client(FakeCatalog(), default_experiment="Undulator")
+        older = client.get("/api/run/uid-001").json()
+        newer = client.get("/api/run/uid-002").json()
+        assert older["neighbours"] == {"prev_uid": "", "next_uid": "uid-002"}
+        assert newer["neighbours"] == {"prev_uid": "uid-001", "next_uid": ""}
+        assert [run["uid"] for run in newer["day_runs"]] == ["uid-002", "uid-001"]
+        assert newer["prev_day"] == "2026-07-11" and newer["next_day"] == "2026-07-13"
+
+    def test_run_neighbours_degrade_when_the_listing_fails(self):
+        payload = _client(FakeCatalog(fail_listing=True)).get("/api/run/uid-002").json()
+        assert payload["neighbours"] == {"prev_uid": "", "next_uid": ""}
+        assert payload["day_runs"] == []
+
+    def test_run_documents_are_json_safe(self):
+        # A document key carrying NaN / a numpy scalar / a set must not
+        # 500 the whole run (json.dumps refuses all three).
+        import numpy as np
+
+        catalog = FakeCatalog()
+        detail = _detail(7)
+        detail.start_doc["odd"] = {
+            "nan": float("nan"),
+            "np": np.int64(3),
+            "set": {1},
+            "list": [1.5, float("inf")],
+        }
+        catalog.details["uid-007"] = detail
+        response = _client(catalog).get("/api/run/uid-007")
+        assert response.status_code == 200
+        assert b"NaN" not in response.content
+        odd = response.json()["start_doc"]["odd"]
+        assert odd["nan"] is None and odd["np"] == 3.0
+        assert odd["list"] == [1.5, None]
+        assert isinstance(odd["set"], str)
+
+    def test_run_unknown_is_404_and_outage_is_503(self):
+        assert _client().get("/api/run/nope").status_code == 404
+        assert _client(DownCatalog()).get("/api/run/uid-002").status_code == 503
+
+    def test_run_page_link_carries_the_proxy_prefix(self):
+        payload = (
+            _client()
+            .get("/api/run/uid-002", headers={"X-Forwarded-Prefix": "/portal"})
+            .json()
+        )
+        assert payload["page"] == "/portal/run/uid-002"
+
+    def test_jump_prefers_the_scan_number_else_the_newest(self):
+        client = _client(FakeCatalog(), default_experiment="Undulator")
+        hit = client.get(f"/api/run/jump/{TEST_DAY.isoformat()}?prefer=1").json()
+        assert hit["uid"] == "uid-001" and hit["matched"] is True
+        assert hit["page"] == "/run/uid-001" and hit["runs"] == 2
+        miss = client.get(f"/api/run/jump/{TEST_DAY.isoformat()}?prefer=99").json()
+        assert miss["uid"] == "uid-002" and miss["matched"] is False
+
+    def test_jump_on_an_empty_day_names_no_run(self):
+        payload = _client(StubCatalog()).get("/api/run/jump/2026-01-01?prefer=3").json()
+        assert payload["uid"] is None and payload["scan_number"] is None
+        assert payload["page"] == "/day/2026-01-01"
+
+    def test_jump_bad_date_is_404_and_outage_is_503(self):
+        assert _client().get("/api/run/jump/nope").status_code == 404
+        response = _client(FakeCatalog(fail_listing=True)).get(
+            f"/api/run/jump/{TEST_DAY.isoformat()}"
+        )
+        assert response.status_code == 503
+
+    def test_device_without_a_resolvable_folder_is_404(self, monkeypatch):
+        from geecs_data_utils import scan_paths as scan_paths_mod
+
+        monkeypatch.setattr(scan_paths_mod, "daily_scan_folder", lambda *a, **k: None)
+        client = _client()
+        assert client.get("/api/run/uid-002/device").status_code == 400
+        response = client.get("/api/run/uid-002/device?device=cam")
+        assert response.status_code == 404
+        assert "not resolvable" in response.json()["detail"]
+
+    def test_openapi_lists_the_agent_surface(self):
+        # docs_url is off, but the schema stays: scripts can discover
+        # the deployed portal's routes instead of guessing.
+        paths = _client().get("/openapi.json").json()["paths"]
+        for route in (
+            "/health",
+            "/api/day/{day}",
+            "/api/run/{uid}",
+            "/api/run/{uid}/device",
+            "/api/run/jump/{day}",
+            "/api/run/{uid}/columns",
+            "/api/run/{uid}/frame",
+            "/api/run/{uid}/binned",
+            "/api/run/{uid}/filter-count",
+            "/api/run/{uid}/bin-images",
+            "/api/run/{uid}/analysis",
+            "/run/{uid}/artifact",
+            "/run/{uid}/image.png",
+            "/run/{uid}/bin-image.png",
+            "/run/{uid}/plot.png",
+        ):
+            assert route in paths, route

--- a/GEECS-DataPortal/tests/test_app.py
+++ b/GEECS-DataPortal/tests/test_app.py
@@ -1180,6 +1180,20 @@ class TestBrowsingApi:
         )
         assert payload["page"] == "/portal/run/uid-002"
 
+    def test_day_and_jump_page_links_carry_the_proxy_prefix(self):
+        client = _client(FakeCatalog(), default_experiment="Undulator")
+        prefix = {"X-Forwarded-Prefix": "/portal"}
+        day = client.get(f"/api/day/{TEST_DAY.isoformat()}", headers=prefix).json()
+        assert day["page"] == f"/portal/day/{TEST_DAY.isoformat()}"
+        hit = client.get(f"/api/run/jump/{TEST_DAY.isoformat()}", headers=prefix).json()
+        assert hit["page"] == "/portal/run/uid-002"
+        empty = (
+            _client(StubCatalog())
+            .get("/api/run/jump/2026-01-01", headers=prefix)
+            .json()
+        )
+        assert empty["uid"] is None and empty["page"] == "/portal/day/2026-01-01"
+
     def test_jump_prefers_the_scan_number_else_the_newest(self):
         client = _client(FakeCatalog(), default_experiment="Undulator")
         hit = client.get(f"/api/run/jump/{TEST_DAY.isoformat()}?prefer=1").json()

--- a/GEECS-DataPortal/tests/test_resources.py
+++ b/GEECS-DataPortal/tests/test_resources.py
@@ -317,6 +317,44 @@ class TestGalleryRoutes:
         assert "?device=" not in response.text.replace("&amp;device=", "")
         assert client.get("/run/uid-002/image.png?device=x&shot=1").status_code == 404
 
+    def test_api_run_lists_devices_and_device_probes_tiers(self, scan_folder):
+        # 0.20.0: the browsing API's device list + tier probe over the
+        # same tree the page renders — one truth, two surfaces.
+        client = _gallery_client(scan_folder)
+        run = client.get("/api/run/uid-002").json()
+        assert run["devices"] == [
+            "UC_StackCam",
+            "UC_TestCam",
+            "U_HasoLift",
+            "U_HasoWFS",
+            "U_Scope",
+            "cam",
+        ]
+        assert run["scan_folder"] == str(scan_folder)
+        expected = {
+            "UC_StackCam": ("stack", True, None),
+            "UC_TestCam": ("native", True, "png"),
+            "U_HasoWFS": ("vendor", False, "himg"),
+            "U_Scope": ("unrenderable", False, "tdms"),
+        }
+        for device, (kind, renderable, ext) in expected.items():
+            payload = client.get(f"/api/run/uid-002/device?device={device}").json()
+            assert payload["kind"] == kind, device
+            assert payload["renderable"] is renderable, device
+            assert payload["ext"] == ext, device
+            assert device in payload["path"]
+            assert payload["event_rows"] == 3
+        stack = client.get("/api/run/uid-002/device?device=UC_StackCam").json()
+        assert stack["path"].endswith("UC_StackCam.h5")
+
+    def test_api_device_probe_is_read_only_and_404s_cleanly(self, scan_folder):
+        client = _gallery_client(scan_folder)
+        root = scan_folder.parent.parent
+        before = _tree_snapshot(root)
+        assert client.get("/api/run/uid-002/device?device=nope").status_code == 404
+        assert client.get("/api/run/uid-002/device?device=../escape").status_code == 404
+        assert _tree_snapshot(root) == before
+
 
 class TestRunDayResolution:
     """The fall-through re-basing must use the run's OWN day, never the


### PR DESCRIPTION
## What

Everything the portal's pages show, as JSON — so a script or an AI agent (the OSPREY HTU assistant's new `geecs-data-portal` skill) can read what a browser shows and press what a browser presses without scraping HTML. The Plot/Images tabs already had a JSON `/api` layer; the day table, the rail, the Overview tab and the device tier were HTML-only.

New routes (all `GET`, `no-cache`):

| Route | Page equivalent |
|---|---|
| `/api/day/{iso}?experiment=&filter=` | the day page's table (newest first, same filter haystack) |
| `/api/run/{uid}?day=` | the rail + Overview table verbatim (`metadata_rows`) + start/stop docs + `devices` + stepper `neighbours` / `day_runs` + `processing_options` + `analysis_enabled` |
| `/api/run/{uid}/device?device=` | one device's tier / path / ext (the click on a device name — same `device_kind` probe) |
| `/api/run/jump/{iso}?prefer=` | the day steppers' target, as data instead of a redirect |

Plus `version` on `/health`, and a test pinning that `/openapi.json` lists the whole agent surface.

## Why it is shaped this way

- The day listing, neighbour and folder-resolution logic moved into shared closures (`_list_day`, `_neighbours`, `_resolved_folder`) that the templates now call too — one implementation, so the HTML and JSON surfaces cannot drift.
- Documents pass through `analysis.jsonable_document` (NaN / numpy / set → JSON-safe): a document key must never 500 a run's detail.
- No new numerics, no new primitives: every payload is the template's own data.

## Tests

`cd GEECS-DataPortal && poetry run pytest tests -q` → **240 passed** (18 new: `TestBrowsingApi` in test_app.py, two device-tier/read-only pins in test_resources.py, one proxy-prefix pin from the review). Pre-commit clean.

## Hardware verification

None needed — no scan execution or device path. **Live check done 2026-09-02**: the portal host runs this branch (0.20.0) under systemd; `/health` reports `version: 0.20.0`, `/api/day/2026-09-02`, `/api/run/<uid>`, `/api/run/<uid>/device?device=UC_ModeImager` and `/api/run/jump/2026-09-02` all answered against the live catalog, and the maintainer confirmed the existing pages are unchanged in the browser. The host stays on this branch until merge, then flips back to master.

## Review

Adversarial review (fresh-context subagent) posted below with every finding dispositioned; fixes in 96fa4a3b. The consuming skill lives in the htu-assistant repo (`skills/geecs-data-portal/`); the portal `CLAUDE.md` now notes that the two must move together — that side is outside this repo (review finding 5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
