### PR TITLE
/fleet-status: observed deployed-fleet picture (host → service → checkout/branch/commit/version)

### DIFF
--- a/.claude/skills/fleet-status/SKILL.md
+++ b/.claude/skills/fleet-status/SKILL.md
@@ -62,18 +62,24 @@ versions` line means a rollout is incomplete or a box's
 pull-on-restart no-oped — the GeecsPvaGateway runbook's known failure.
 
 **Stage 2 — host checkouts (ssh).** On each host derived from
-config.ini, every `geecs-*` (+ `tiled`) systemd unit is mapped to the
-clone it runs from (`WorkingDirectory`, or the baked venv's recorded
-source path for the MCP pattern), then: branch, short sha, commit date,
-dirty count, pyproject version vs the version installed in the unit's
-venv, and whether HEAD moved after the unit started. The three warnings
-to act on:
+config.ini, services are discovered two ways and deduplicated by pid:
+every `geecs-*` (+ `tiled`) systemd unit in **both** system and user
+scope, and **whoever owns each fleet port** — a queueserver started by
+hand in tmux has no unit and must still show up. Each process is mapped
+to the clone it runs from (its cwd, or the baked venv's recorded source
+path for the MCP pattern), then: branch, short sha, commit date,
+staged/unstaged counts, pyproject version vs the version installed in
+the running interpreter's venv, and whether HEAD moved after the process
+started (for a baked venv: after the install). The warnings to act on:
 
 | Warning | Meaning | Remedy (on the host, by the user or with their go) |
 |---|---|---|
-| `pyproject says X but the venv has Y installed` | a bump landed in the checkout without reinstall | `poetry install` in that package dir, then restart |
-| `checkout moved <time> after the service started` | the running process predates the code on disk | `systemctl restart <unit>` — after confirming that checkout is the intended one |
-| `DIRTY: N modified tracked file(s)` | someone edited the deployed tree in place | look before touching: it may be a live hotfix nobody committed |
+| `no systemd unit owns this process` (UNMANAGED) | started by hand; dies with its tmux/ssh session or a crash, no restart on reboot | install the runbook's unit when the dev phase ends; until then, know it |
+| `(user unit)` in the name | runs under `systemctl --user`, not the system scope the runbook describes | fine for development; note that `systemctl status` without `--user` will not see it |
+| `pyproject says X but the venv has Y installed` | a bump landed in the checkout without reinstall | `poetry install` in that package dir (pip reinstall for a baked venv), then restart |
+| `checkout moved <time> after the process started` | the running process predates the code on disk | restart it — after confirming that checkout is the intended one |
+| `checkout moved <time> after the baked install` | the MCP-style venv was baked from an older checkout state | pip reinstall from the checkout, then restart |
+| `STAGED: N` / `UNSTAGED: N` | the deployed tree differs from its HEAD | look before touching: it may be a live hotfix nobody committed, or a stray `git add` |
 
 Any unit whose clone is on a branch other than `master` is a fact to
 surface, not a fault — feature-branch deploys for live checks are
@@ -114,3 +120,7 @@ this page in the same PR".
   device roster is healthy — that is `/lab-status --hardware` and the
   gateway DB audit.
 - Tiled has no checkout (pip install); its version is the whole story.
+- Port-owner discovery needs `ss -p` to see the pid, which it does only
+  for processes owned by the ssh user (or root). A fleet port that shows
+  as listening in stage 1 but has no stage-2 record was started by a
+  different account.

--- a/.claude/skills/fleet-status/SKILL.md
+++ b/.claude/skills/fleet-status/SKILL.md
@@ -31,14 +31,18 @@ and bounded: no PV writes, no restarts, no pulls.
 
 | Situation | Command |
 |---|---|
-| The normal case | `scripts/fleet_status.sh` |
+| The normal case (full log, for reasoning) | `scripts/fleet_status.sh` |
+| One box table + attention list (for the user) | `scripts/fleet_status.sh --summary` |
+| Persistent dashboard pane (cmux/tmux) | `scripts/fleet_status.sh --watch 300` (summary every 300 s; add `--full` for the log) |
 | Off the lab network / just want the local worktree picture | `scripts/fleet_status.sh --local-only` |
 | No key-based ssh to the hosts from this machine | `scripts/fleet_status.sh --no-ssh` |
 | ssh alias not discoverable from `~/.ssh/config` | `scripts/fleet_status.sh --ssh <ip>=<alias>` |
 | config.ini has no `[Experiment]` | add `--experiment <Name>` (needed for the CA gateway PVs) |
 | Avoid the GitHub round-trip | `--no-fetch` (distances then use the last-fetched `origin/master`) |
 
-`$ARGUMENTS`, if given, passes straight through. Budget: ~10 s offline,
+The summary table is rendered by `scripts/fleet_table.py` (stdlib only)
+from the same probe records; the full log is what you reason over, the
+table is what you show. `$ARGUMENTS`, if given, passes straight through. Budget: ~10 s offline,
 under a minute on the lab network (each ssh host 25 s max, each PVA
 host 2 s per get).
 

--- a/.claude/skills/fleet-status/SKILL.md
+++ b/.claude/skills/fleet-status/SKILL.md
@@ -1,0 +1,116 @@
+---
+name: fleet-status
+description: >
+  Observed picture of the deployed fleet: which host runs which service,
+  from which checkout, on which branch/commit and package version, and
+  whether the running process matches the code on disk. Use when the user
+  asks "what is deployed where", "which version is the portal / gateway /
+  worker running", "is the host still on the feature branch", "did the
+  deploy take", "does the fleet map match reality", before deploying or
+  restarting a service, or after a PR merges that a host is expected to
+  pick up. Wraps scripts/fleet_status.sh, which gates on /lab-status
+  first. For plain reachability ("am I on the lab network") use
+  /lab-status; for the intended picture read docs/platform/fleet_map.md.
+---
+
+# /fleet-status — what code is the fleet actually running?
+
+`docs/platform/fleet_map.md` is the **intended** fleet: hosts, ports,
+units, runbooks. `scripts/fleet_status.sh` is the **observed** one. The
+two drift during rapid development — a host runs a feature-branch
+checkout for a live check, a checkout gets pulled but the unit never
+restarted, a version bump lands without a `poetry install` — and this
+skill exists to see that drift instead of remembering it.
+
+The script owns the probes, timeouts, and how endpoints are derived
+(config.ini `[tiled]`/`[qserver]`, ssh aliases from `~/.ssh/config`).
+Do not restate or hardcode hosts here. Everything it does is read-only
+and bounded: no PV writes, no restarts, no pulls.
+
+## Invocation
+
+| Situation | Command |
+|---|---|
+| The normal case | `scripts/fleet_status.sh` |
+| Off the lab network / just want the local worktree picture | `scripts/fleet_status.sh --local-only` |
+| No key-based ssh to the hosts from this machine | `scripts/fleet_status.sh --no-ssh` |
+| ssh alias not discoverable from `~/.ssh/config` | `scripts/fleet_status.sh --ssh <ip>=<alias>` |
+| config.ini has no `[Experiment]` | add `--experiment <Name>` (needed for the CA gateway PVs) |
+| Avoid the GitHub round-trip | `--no-fetch` (distances then use the last-fetched `origin/master`) |
+
+`$ARGUMENTS`, if given, passes straight through. Budget: ~10 s offline,
+under a minute on the lab network (each ssh host 25 s max, each PVA
+host 2 s per get).
+
+## Stages and what each one proves
+
+**Stage 0 — reachability.** Runs `scripts/lab_status.sh` tier 1 (the
+same gate `/lab-status` uses). If the network is DOWN the script stops
+after the local picture and says `remote: UNKNOWN`. Report exactly that:
+an unreachable service is *unknown*, not down. Never bypass this by
+calling the services directly.
+
+**Stage 1 — self-reported versions.** Each service over its own
+protocol: Tiled's library version (HTTP), the Data Portal's `/health`
+(`ok`, catalog probe, package version), MCP port liveness (no version
+endpoint; stage 2 reads its venv), the CA gateway's heartbeat /
+`devices_connected` / `version` PVs (reused from `lab_status.sh
+--hardware`, read-only), and every PVA image gateway's `version` +
+`heartbeat` PVs (roster = the checked-in Phoebus fleet screen; a
+DB-driven roster is still owed). A `[WARN] PVA fleet runs mixed
+versions` line means a rollout is incomplete or a box's
+pull-on-restart no-oped — the GeecsPvaGateway runbook's known failure.
+
+**Stage 2 — host checkouts (ssh).** On each host derived from
+config.ini, every `geecs-*` (+ `tiled`) systemd unit is mapped to the
+clone it runs from (`WorkingDirectory`, or the baked venv's recorded
+source path for the MCP pattern), then: branch, short sha, commit date,
+dirty count, pyproject version vs the version installed in the unit's
+venv, and whether HEAD moved after the unit started. The three warnings
+to act on:
+
+| Warning | Meaning | Remedy (on the host, by the user or with their go) |
+|---|---|---|
+| `pyproject says X but the venv has Y installed` | a bump landed in the checkout without reinstall | `poetry install` in that package dir, then restart |
+| `checkout moved <time> after the service started` | the running process predates the code on disk | `systemctl restart <unit>` — after confirming that checkout is the intended one |
+| `DIRTY: N modified tracked file(s)` | someone edited the deployed tree in place | look before touching: it may be a live hotfix nobody committed |
+
+Any unit whose clone is on a branch other than `master` is a fact to
+surface, not a fault — feature-branch deploys for live checks are
+normal here. Say which branch, and whether the merge has since landed
+(stage 3 tells you).
+
+**Stage 3 — local cross-reference.** Fetches origin, lists this clone's
+worktrees, then names each deployed sha: the remote branch it is the tip
+of (or the branches containing it), its distance from `origin/master`,
+and the local worktree holding it. `commit unknown to this repo` means
+the host runs something never pushed, or a branch this clone never
+fetched — say so; do not guess which.
+
+## Reporting
+
+Lead with the drift, not the table. The user wants: which services are
+on a non-master checkout, which have a pending restart or install, which
+PVA boxes lag, and what is unknown because of reachability or missing
+ssh. Then the one-line-per-service summary (host, unit state, branch @
+sha, package version). Quote versions and shas exactly as printed.
+
+When the observed picture contradicts `docs/platform/fleet_map.md`
+(a service on a different host, a checkout path the table doesn't
+name, a service the table calls "pending deploy" that is listening),
+say so explicitly and offer to update the fleet map in the same PR as
+whatever change the user makes next — the map's own rule is "update
+this page in the same PR".
+
+## Boundaries
+
+- The script never restarts, pulls, or installs. Those are the user's
+  actions on the host (sudo, service account); hand them the exact
+  command and unit name, referencing the service's runbook.
+- Stage 2 needs key-based ssh as the service account. A failed ssh is
+  reported per host with the `--ssh` override hint; it is not a fleet
+  finding.
+- "Gateway version X" says what package is running, not whether the
+  device roster is healthy — that is `/lab-status --hardware` and the
+  gateway DB audit.
+- Tiled has no checkout (pip install); its version is the whole story.

--- a/.claude/skills/lab-status/SKILL.md
+++ b/.claude/skills/lab-status/SKILL.md
@@ -16,7 +16,9 @@ description: >
 `scripts/lab_status.sh` owns the endpoints, ports, and timeouts (derived
 from `~/.config/geecs_python_api/config.ini` — do not restate or hardcode
 them here or anywhere else). This skill is about running it at the right
-moment and acting on the answer.
+moment and acting on the answer. For *what code* the reachable services
+are running (checkout/branch/version per host) use `/fleet-status`,
+which runs this probe first as its gate.
 
 ## Tiers
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,7 +42,9 @@ Recurring workflows are encoded as repo-checked skills under
 `.claude/skills/<name>/SKILL.md`: `/land` (the PR ritual), `/check`
 (lint + tests the way CI runs them, via `scripts/check.sh`), `/triage`
 (scan-log error triage), `/scan-audit` (scan timing/cadence analysis),
-`/env-doctor` (per-package Poetry env fixups). Each skill's frontmatter
+`/env-doctor` (per-package Poetry env fixups), `/lab-status` (bounded
+reachability probes), `/fleet-status` (observed deployed-fleet picture:
+host → service → checkout/branch/commit/version). Each skill's frontmatter
 `description` carries its trigger symptoms so sessions pull the skill in
 on their own — keep those descriptions current when a skill changes.
 Prefer invoking/updating a skill over re-deriving its workflow in a

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ live in the root and per-package `CLAUDE.md` files, which are the canonical
 instructions for AI-assisted development — if you work with Claude/Codex,
 those files are loaded automatically, and repo-checked skills under
 `.claude/skills/` (e.g. `/land`, `/check`, `/triage`, `/scan-audit`,
-`/env-doctor`, `/get-started`)
+`/env-doctor`, `/get-started`, `/lab-status`, `/fleet-status`)
 encode the recurring workflows. New to the repo entirely? Start with
 [Getting started](docs/tutorials/getting_started.md) (published on the
 docs site), or launch Claude Code from the repo root and type

--- a/docs/platform/fleet_map.md
+++ b/docs/platform/fleet_map.md
@@ -18,7 +18,7 @@ back into this table.
     Reflects the fleet as of **September 2026**. Deployed and running:
     the CA gateway, the GEECS DB, Tiled, the PVA image gateways, the
     queueserver worker (on an interim host), and the GEECS Data Portal
-    (0.15.x — analysis tabs, per-bin image grid, ephemeral processing).
+    (0.20.x — analysis tabs, images tab, analysis runs, browsing JSON API).
     Documented here ahead of
     deployment: the GEECS-MCP HTTP service and the capture daemon
     (which lands with the central-PVA-capture arc). When a service

--- a/docs/platform/fleet_map.md
+++ b/docs/platform/fleet_map.md
@@ -7,7 +7,12 @@ check, and the runbook.
 
 Each service's authoritative deployment guide lives next to its code in
 the repository (linked in the table below) — this page is the map, not
-the manual.
+the manual. It is also the *intended* picture; for the *observed* one —
+which checkout, branch, commit, and package version each host is
+actually running, and whether a service was restarted after its
+checkout last moved — run `scripts/fleet_status.sh` (the
+`/fleet-status` skill, gated on `/lab-status`) and reconcile drift
+back into this table.
 
 !!! note "Snapshot"
     Reflects the fleet as of **September 2026**. Deployed and running:

--- a/docs/skills/overview.md
+++ b/docs/skills/overview.md
@@ -29,15 +29,16 @@ codified procedure itself rather than a wrapped tool.
 | `/check` | Run repo lint + unit tests the way CI does, scoped to what changed; wraps `scripts/check.sh` |
 | `/env-doctor` | Diagnose and fix a package's Poetry environment when poetry, pytest, or an import fails for setup-shaped reasons |
 | `/lab-status` | Probe lab-network and hardware reachability with bounded timeouts before doing anything that needs them; wraps `scripts/lab_status.sh` |
+| `/fleet-status` | Observed picture of the deployed fleet — which host runs which service from which checkout, branch, commit and package version, and whether the running process matches the code on disk; wraps `scripts/fleet_status.sh` (gated on `/lab-status`) |
 | `/scan-audit` | Scan timing and cadence audit for the Bluesky path: "why was the scan slow", "did every shot land", per-shot cadence analysis of a scan folder |
 | `/triage` | Generate a structured error report from scan logs, then analyze bug candidates against the codebase and draft GitHub issues |
 | `/get-started` | Onboard a new developer in guide mode: environment check, orientation, a small first win, with the repo's guardrails applied on the user's behalf |
 
 `/land`, `/check`, `/env-doctor`, and `/get-started` are development
 workflow skills — they operate on the repository itself. `/lab-status`,
-`/scan-audit`, and `/triage` are lab operations skills — they operate on
-the experiment: the network, the hardware, and the data a scan left
-behind. `/triage` is the reference implementation of the CLI-backed
+`/fleet-status`, `/scan-audit`, and `/triage` are lab operations skills —
+they operate on the experiment: the network, the deployed services, the
+hardware, and the data a scan left behind. `/triage` is the reference implementation of the CLI-backed
 pattern and is documented in depth below;
 [Writing a Skill](writing_a_skill.md) uses it as the template for new
 skills.

--- a/scripts/fleet_status.sh
+++ b/scripts/fleet_status.sh
@@ -75,10 +75,17 @@ done
 # one-shot probe on an interval. No daemon, no state — the same read-only
 # run, redrawn. Ctrl-C ends it.
 if [ "$WATCH" != "0" ]; then
+    # Rebuild the child's argument list without --watch (and without the
+    # numeric interval, only when one actually followed it — a flag after
+    # --watch belongs to the child).
     args=()
+    skip_next=0
     for a in "${ORIG_ARGS[@]+"${ORIG_ARGS[@]}"}"; do
+        if [ "$skip_next" = "1" ]; then
+            skip_next=0
+            case "$a" in *[!0-9]*|'') ;; *) continue ;; esac   # digits only = the consumed interval
+        fi
         case "$a" in --watch) skip_next=1; continue ;; esac
-        if [ "${skip_next:-0}" = "1" ]; then skip_next=0; continue; fi
         args+=("$a")
     done
     [ "$FULL" -eq 0 ] && args+=("--summary")

--- a/scripts/fleet_status.sh
+++ b/scripts/fleet_status.sh
@@ -13,7 +13,8 @@
 #   scripts/fleet_status.sh --no-ssh              # service self-reports only
 #   scripts/fleet_status.sh --ssh 192.168.6.14=geecs-gw   # ssh alias override
 #   scripts/fleet_status.sh --experiment Undulator --no-fetch
-#   scripts/fleet_status.sh --watch 300           # dashboard mode: rerun every 300 s
+#   scripts/fleet_status.sh --summary             # one box table + attention list
+#   scripts/fleet_status.sh --watch 300           # dashboard pane: --summary every 300 s (--full for the log)
 #
 # Stages (each gated on the previous one):
 #   0. reachability — scripts/lab_status.sh tier 1 (the same gate /lab-status
@@ -48,17 +49,21 @@ DO_SSH=1
 DO_FETCH=1
 LOCAL_ONLY=0
 WATCH=0
+SUMMARY=0
+FULL=0
 declare -a SSH_OVERRIDES=()
 ORIG_ARGS=("$@")
 while [ $# -gt 0 ]; do
     case "$1" in
         --watch) shift; WATCH="${1:-300}" ;;
+        --summary) SUMMARY=1 ;;
+        --full) FULL=1 ;;
         --experiment) shift; EXPERIMENT="${1:-}" ;;
         --no-ssh) DO_SSH=0 ;;
         --no-fetch) DO_FETCH=0 ;;
         --local-only) LOCAL_ONLY=1 ;;
         --ssh) shift; SSH_OVERRIDES+=("${1:-}") ;;
-        *) echo "usage: fleet_status.sh [--experiment NAME] [--no-ssh] [--no-fetch] [--local-only] [--ssh IP=ALIAS]... [--watch SECS]" >&2; exit 2 ;;
+        *) echo "usage: fleet_status.sh [--experiment NAME] [--no-ssh] [--no-fetch] [--local-only] [--ssh IP=ALIAS]... [--summary|--full] [--watch SECS]" >&2; exit 2 ;;
     esac
     shift
 done
@@ -73,8 +78,9 @@ if [ "$WATCH" != "0" ]; then
         if [ "${skip_next:-0}" = "1" ]; then skip_next=0; continue; fi
         args+=("$a")
     done
+    [ "$FULL" -eq 0 ] && args+=("--summary")
     while :; do
-        out="$("$0" "${args[@]+"${args[@]}"}" 2>&1)"
+        COLUMNS="$(tput cols 2>/dev/null || echo 100)" out="$("$0" "${args[@]+"${args[@]}"}" 2>&1)"
         clear
         echo "fleet status — $(date '+%F %H:%M:%S')  (every ${WATCH}s, Ctrl-C to stop)"
         echo
@@ -117,6 +123,16 @@ bounded() {  # bounded SECS CMD... — hard wall-clock bound (macOS has no `time
 port_open() {  # port_open HOST PORT
     bounded "$TCP_TIMEOUT" bash -c "exec 3<>/dev/tcp/$1/$2" 2>/dev/null
 }
+
+# Every probe also appends a tab-separated key=value record (with a role=)
+# to REC_FILE; scripts/fleet_table.py renders those as the --summary table.
+REC_FILE="$(mktemp -t fleet_rec.XXXXXX)"
+LOG_FILE="$(mktemp -t fleet_log.XXXXXX)"
+trap 'rm -f "$REC_FILE" "$LOG_FILE"' EXIT
+rec() { printf '%s\n' "$1" >> "$REC_FILE"; }
+if [ "$SUMMARY" -eq 1 ]; then
+    exec 3>&1 1>"$LOG_FILE"   # the verbose log goes to a file; the table is printed at the end
+fi
 
 # --- endpoints from config.ini (never hardcode hosts here) -----------------
 TILED_URI="$(ini_get tiled uri)"
@@ -174,7 +190,8 @@ if [ "$NET_UP" -eq 1 ]; then
     echo "== Stage 1: what each service says about itself (read-only) =="
     # Tiled — pip-installed, no checkout; its library version is the whole story.
     tv="$(bounded "$TCP_TIMEOUT" curl -s -m "$TCP_TIMEOUT" "http://$LAB_HOST:$TILED_PORT/api/v1/" | sed -nE 's/.*"library_version":"([^"]+)".*/\1/p')"
-    if [ -n "$tv" ]; then ok "Tiled        $LAB_HOST:$TILED_PORT  tiled $tv"; else bad "Tiled        $LAB_HOST:$TILED_PORT"; fi
+    if [ -n "$tv" ]; then ok "Tiled        $LAB_HOST:$TILED_PORT  tiled $tv"; rec "role=Tiled	state=ok	version=$tv	checkout=pip install"
+    else bad "Tiled        $LAB_HOST:$TILED_PORT"; rec "role=Tiled	state=down	checkout=pip install"; fi
 
     # Data Portal — /health carries ok + catalog probe + installed version.
     PORTAL_HOST="${WORKER_HOST:-$LAB_HOST}"
@@ -185,23 +202,30 @@ if [ "$NET_UP" -eq 1 ]; then
         pcat="$(printf '%s' "$ph" | sed -nE 's/.*"catalog": *"([^"]*)".*/\1/p')"
         if [ "$pok" = "true" ]; then
             ok "Data Portal  $PORTAL_HOST:$PORTAL_PORT  geecs-data-portal ${pv:-?}  (catalog: ${pcat:-?})"
+            rec "role=Data Portal	state=ok	version=${pv:-}"
         else
             warn "Data Portal  $PORTAL_HOST:$PORTAL_PORT  geecs-data-portal ${pv:-?}  up but catalog NOT ok (${pcat:-?})"
+            rec "role=Data Portal	state=ok	version=${pv:-}	note=catalog not ok"
         fi
     else
         bad "Data Portal  $PORTAL_HOST:$PORTAL_PORT  (no /health answer)"
+        rec "role=Data Portal	state=down"
     fi
 
     # Queueserver — ZMQ, no cheap self-report; port liveness (stage 2 finds the process).
     QS_HOST="${WORKER_HOST:-$LAB_HOST}"
-    if port_open "$QS_HOST" 60615; then ok "Queueserver  $QS_HOST:60615  RE Manager control port listening"; else bad "Queueserver  $QS_HOST:60615  RE Manager not listening"; fi
-    if port_open "$QS_HOST" 5568; then ok "Doc proxy    $QS_HOST:5568   document stream listening"; else bad "Doc proxy    $QS_HOST:5568   not listening"; fi
+    if port_open "$QS_HOST" 60615; then ok "Queueserver  $QS_HOST:60615  RE Manager control port listening"; rec "role=Queueserver RE Manager	state=ok"
+    else bad "Queueserver  $QS_HOST:60615  RE Manager not listening"; rec "role=Queueserver RE Manager	state=down"; fi
+    if port_open "$QS_HOST" 5568; then ok "Doc proxy    $QS_HOST:5568   document stream listening"; rec "role=Bluesky doc proxy	state=ok"
+    else bad "Doc proxy    $QS_HOST:5568   not listening"; rec "role=Bluesky doc proxy	state=down"; fi
 
     # MCP HTTP mode — no version endpoint; port liveness only (stage 2 reads the venv).
     if port_open "${WORKER_HOST:-$LAB_HOST}" "$MCP_PORT"; then
         ok "GEECS-MCP    ${WORKER_HOST:-$LAB_HOST}:$MCP_PORT  listening (version via ssh below)"
+        rec "role=GEECS-MCP	state=ok"
     else
         skip "GEECS-MCP    ${WORKER_HOST:-$LAB_HOST}:$MCP_PORT  not listening (HTTP mode is 'pending deploy' on the fleet map)"
+        rec "role=GEECS-MCP	state=absent	note=not listening (pending deploy)"
     fi
 
     # CA gateway — reuse /lab-status tier 2 (read-only CA gets of heartbeat,
@@ -211,10 +235,14 @@ if [ "$NET_UP" -eq 1 ]; then
         alive="$(printf '%s\n' "$hw" | grep -m1 'gateway alive')"
         if [ -n "$alive" ]; then
             ok "CA gateway   $LAB_HOST:5064  ${alive#*] }"
+            gver="$(printf '%s' "$alive" | sed -nE 's/.*version=([^, ]+).*/\1/p')"
+            gdev="$(printf '%s' "$alive" | sed -nE 's/.*devices_connected=([0-9]+).*/\1/p')"
+            rec "role=CA gateway	state=ok	version=$gver	note=$gdev devices connected"
             printf '%s\n' "$hw" | grep '\[WARN\]' | sed 's/^ *\[WARN\] /  [WARN] CA gateway: /'
         else
             err="$(printf '%s\n' "$hw" | grep -m1 -E 'unreadable|not installed|no experiment' )"
             bad "CA gateway   $LAB_HOST:5064  ${err#*] }"
+            rec "role=CA gateway	state=down"
         fi
     else
         skip "CA gateway   no experiment name (config.ini [Experiment] expt, or --experiment NAME)"
@@ -225,7 +253,7 @@ if [ "$NET_UP" -eq 1 ]; then
     if [ -f "$PVA_ROSTER" ]; then
         pvs="$(grep -o 'pv_name>pva://[^<]*:version' "$PVA_ROSTER" | sed 's|pv_name>pva://||' | sort -u)"
         if [ -n "$pvs" ] && poetry -C "$REPO_ROOT/GeecsPvaGateway" env info --path >/dev/null 2>&1; then
-            PVA_PVS="$pvs" PVA_TIMEOUT="$PVA_TIMEOUT" bounded 60 poetry -C "$REPO_ROOT/GeecsPvaGateway" run python - <<'PY'
+            PVA_PVS="$pvs" PVA_TIMEOUT="$PVA_TIMEOUT" REC_FILE="$REC_FILE" bounded 60 poetry -C "$REPO_ROOT/GeecsPvaGateway" run python - <<'PY'
 import os
 import re
 
@@ -239,6 +267,7 @@ os.environ["EPICS_PVA_AUTO_ADDR_LIST"] = "NO"
 from p4p.client.thread import Context  # noqa: E402
 
 versions = {}
+down = []
 with Context("pva", unwrap=False) as ctx:  # raw Values: str(NT wrapper) carries a timestamp
     for pv, host in zip(pvs, hosts):
         base = pv[: -len(":version")]
@@ -247,6 +276,7 @@ with Context("pva", unwrap=False) as ctx:  # raw Values: str(NT wrapper) carries
             beats = int(ctx.get(base + ":heartbeat", timeout=timeout)["value"])
         except Exception as exc:  # noqa: BLE001 — a failed probe is a finding
             print(f"  [DOWN] PVA gateway  {host:<15}  ({type(exc).__name__})")
+            down.append(host)
             continue
         versions.setdefault(ver, []).append(host)
         print(f"  [ OK ] PVA gateway  {host:<15}  geecs-pva-gateway {ver}  heartbeat={beats}")
@@ -254,6 +284,14 @@ if len(versions) > 1:
     print("  [WARN] PVA fleet runs mixed versions — a rollout is incomplete or a box missed its pull-on-restart:")
     for ver, hs in sorted(versions.items()):
         print(f"         {ver}: {', '.join(hs)}")
+n_ok = sum(len(hs) for hs in versions.values())
+ver_txt = ", ".join(f"{v} ×{len(hs)}" for v, hs in sorted(versions.items())) or "?"
+note = f"{n_ok} up" + (f", {len(down)} unreachable: {' '.join(down)}" if down else "")
+if len(versions) > 1:
+    note += "|MIXED versions"
+state = "ok" if n_ok else "down"
+with open(os.environ["REC_FILE"], "a") as fh:
+    fh.write(f"role=PVA image gateways\tstate={state}\truns=NSSM\tcheckout=share clone\tversion={ver_txt}\tnote={note}\n")
 PY
         else
             skip "PVA fleet    GeecsPvaGateway poetry env not installed (needs p4p; see /env-doctor)"
@@ -281,6 +319,10 @@ command -v systemctl >/dev/null 2>&1 || { echo "nosystemd"; exit 0; }
 role_for_port() { case "$1" in
     5064) echo "CA gateway";; 8000) echo "Tiled";; 8200) echo "Data Portal";; 8100) echo "GEECS-MCP";;
     60615) echo "Queueserver RE Manager";; 5568) echo "Bluesky doc proxy";; *) echo "port $1";; esac; }
+role_for_unit() { case "$1" in
+    geecs-ca-gateway*) echo "CA gateway";; tiled*) echo "Tiled";; geecs-data-portal*) echo "Data Portal";;
+    geecs-mcp*) echo "GEECS-MCP";; geecs-qserver*) echo "Queueserver RE Manager";; geecs-capture*) echo "Capture daemon";;
+    *) echo "$1";; esac; }
 FLEET_PORTS="5064 8000 8200 8100 60615 5568"
 SEEN=" "
 reflog_ts() {  # unix time HEAD last moved (checkout/pull/reset), from the reflog
@@ -295,8 +337,8 @@ pkgdir_up() {  # nearest pyproject.toml at or above $1, not above the clone root
         d="$(dirname "$d")"
     done
 }
-emit() {  # emit NAME MANAGED STATE PID CWD PYEXE
-    local name="$1" managed="$2" state="$3" pid="$4" cwd="$5" pyexe="$6"
+emit() {  # emit ROLE NAME MANAGED STATE PID CWD PYEXE
+    local role="$1" name="$2" managed="$3" state="$4" pid="$5" cwd="$6" pyexe="$7"
     local since="" since_ts="" clone="" pkgdir="" venv="" baked="" moved=""
     if [ -n "$pid" ] && [ "$pid" != "0" ] && [ -d "/proc/$pid" ]; then
         since="$(ps -o lstart= -p "$pid" 2>/dev/null | sed -E "s/^ +//")"
@@ -304,7 +346,7 @@ emit() {  # emit NAME MANAGED STATE PID CWD PYEXE
         [ -z "$cwd" ] && cwd="$(readlink "/proc/$pid/cwd" 2>/dev/null)"
         [ -z "$pyexe" ] && pyexe="$(tr "\0" "\n" < "/proc/$pid/cmdline" 2>/dev/null | head -1)"
     fi
-    local rec="svc=$name\tmanaged=$managed\tstate=$state\tsince=${since:-?}"
+    local rec="role=$role\tsvc=$name\tmanaged=$managed\tstate=$state\tsince=${since:-?}"
     [ -n "$cwd" ] && [ -d "$cwd" ] && clone="$(git -C "$cwd" rev-parse --show-toplevel 2>/dev/null)"
     [ -n "$clone" ] && pkgdir="$(pkgdir_up "$cwd" "$clone")"
     case "$pyexe" in */bin/python*) venv="$(dirname "$(dirname "$pyexe")")";; esac
@@ -362,7 +404,7 @@ for scope in "" "--user"; do
         wd="$(systemctl $scope show -p WorkingDirectory --value "$u")"
         label="$u"; [ -n "$scope" ] && label="$u (user unit)"
         [ "$pid" != "0" ] && SEEN="$SEEN$pid "
-        emit "$label" "systemd" "$active" "$pid" "$wd" ""
+        emit "$(role_for_unit "$u")" "$label" "systemd" "$active" "$pid" "$wd" ""
     done
 done
 # 2) whoever owns each fleet port, if not already listed via its unit
@@ -373,7 +415,7 @@ for port in $FLEET_PORTS; do
     SEEN="$SEEN$pid "
     unit="$(sed -nE "s#.*/([^/]+\.service)\$#\1#p" "/proc/$pid/cgroup" 2>/dev/null | head -1)"
     if [ -n "$unit" ]; then managed="systemd ($unit)"; else managed="UNMANAGED"; fi
-    emit "$(role_for_port "$port") :$port" "$managed" "running pid $pid" "$pid" "" ""
+    emit "$(role_for_port "$port")" "$(role_for_port "$port") :$port" "$managed" "running pid $pid" "$pid" "" ""
 done
 [ "$SEEN" = " " ] && echo "nounits"
 exit 0
@@ -387,12 +429,13 @@ fmt_host_records() {  # stdin: service records -> pretty lines; side effect: not
             nosystemd) skip "no systemd on this host"; continue ;;
             nounits) skip "no geecs-* / tiled units and nothing listening on the fleet ports"; continue ;;
         esac
-        local svc managed state since clone branch sha full cdate staged unstaged stale pkg pyproject installed baked pyexe
-        svc=""; managed=""; state=""; since=""; clone=""; branch=""; sha=""; full=""; cdate=""; staged=""; unstaged=""; stale=""; pkg=""; pyproject=""; installed=""; baked=""; pyexe=""
+        rec "$line"
+        local role svc managed state since clone branch sha full cdate staged unstaged stale pkg pyproject installed baked pyexe
+        role=""; svc=""; managed=""; state=""; since=""; clone=""; branch=""; sha=""; full=""; cdate=""; staged=""; unstaged=""; stale=""; pkg=""; pyproject=""; installed=""; baked=""; pyexe=""
         local IFS=$'\t' kv
         for kv in $line; do
             case "$kv" in
-                svc=*) svc="${kv#*=}" ;; managed=*) managed="${kv#*=}" ;; state=*) state="${kv#*=}" ;; since=*) since="${kv#*=}" ;;
+                role=*) role="${kv#*=}" ;; svc=*) svc="${kv#*=}" ;; managed=*) managed="${kv#*=}" ;; state=*) state="${kv#*=}" ;; since=*) since="${kv#*=}" ;;
                 clone=*) clone="${kv#*=}" ;; branch=*) branch="${kv#*=}" ;; sha=*) sha="${kv#*=}" ;;
                 full=*) full="${kv#*=}" ;; commit_date=*) cdate="${kv#*=}" ;; staged=*) staged="${kv#*=}" ;; unstaged=*) unstaged="${kv#*=}" ;;
                 stale=*) stale="${kv#*=}" ;; pkg=*) pkg="${kv#*=}" ;; pyproject=*) pyproject="${kv#*=}" ;;
@@ -409,7 +452,7 @@ fmt_host_records() {  # stdin: service records -> pretty lines; side effect: not
             [ "${staged:-0}" != "0" ] && d="$d  STAGED: $staged file(s)"
             [ "${unstaged:-0}" != "0" ] && d="$d  UNSTAGED: $unstaged modified file(s)"
             info "$clone @ $branch $sha ($cdate)$d"
-            note_sha "$svc" "$full"
+            note_sha "${role:-$svc}" "$full"
         elif [ -n "$pyexe" ]; then
             info "no git clone behind this process (interpreter $pyexe)"
         fi
@@ -439,6 +482,7 @@ if [ "$NET_UP" -eq 1 ] && [ "$DO_SSH" -eq 1 ]; then
         rc=$?
         if [ "$rc" -ne 0 ] && ! printf '%s' "$out" | grep -q '^svc='; then
             bad "ssh $target failed (rc=$rc): $(printf '%s' "$out" | head -1)"
+            rec "role=host $host	state=ok	runs=?	checkout=ssh failed	note=$(printf '%s' "$out" | head -1 | tr '\t' ' ')"
             info "no key-based access from here? pass --ssh $host=<alias> or run the stage-2 snippet on the host by hand"
             continue
         fi
@@ -502,7 +546,26 @@ if [ -n "$(printf '%s' "$DEPLOYED_SHAS" | tr -d '\n ')" ]; then
         elif [ "$ahead" = "0" ]; then rel="$behind behind origin/master"
         else rel="$ahead ahead, $behind behind origin/master"; fi
         info "$label: $short  $rel  ($where)${local_wt:+  local worktree: $local_wt}"
+        rec "role=$label	master_rel=$rel"
     done
 fi
 [ "$NET_UP" -eq 0 ] && [ "$LOCAL_ONLY" -eq 0 ] && echo "remote: UNKNOWN (network down) — rerun on the lab network for the deployed picture"
+
+if [ "$SUMMARY" -eq 1 ]; then
+    exec 1>&3
+    if [ "$NET_UP" -eq 1 ]; then
+        python3 "$REPO_ROOT/scripts/fleet_table.py" < "$REC_FILE"
+    else
+        grep -E '^\s+\[(DOWN|WARN)\]' "$LOG_FILE" | head -6
+        echo "  network: DOWN or partial — remote fleet state UNKNOWN (see --full)"
+    fi
+    echo
+    attn="$(grep -E '^\s+\[(DOWN|WARN)\]' "$LOG_FILE" | sed -E 's/^ +//')"
+    if [ -n "$attn" ]; then
+        echo "Attention:"
+        printf '%s\n' "$attn" | sed 's/^/  /'
+    fi
+    grep -E 'origin/master = ' "$LOG_FILE" | sed -E 's/^ +/  /'
+    echo "  (full log: scripts/fleet_status.sh --full)"
+fi
 exit 0

--- a/scripts/fleet_status.sh
+++ b/scripts/fleet_status.sh
@@ -367,6 +367,18 @@ for d in m.distributions():
         unstaged="$(git -C "$clone" diff --name-only 2>/dev/null | wc -l | tr -d " ")"
         moved="$(reflog_ts "$clone")"
         rec="$rec\tclone=${clone/#$HOME/\~}\tbranch=$branch\tsha=$sha\tfull=$full\tcommit_date=$cdate\tstaged=$staged\tunstaged=$unstaged"
+        if [ "$staged" != "0" ]; then
+            # HEAD can lie: a ref advanced without a checkout leaves the files
+            # on disk (= what actually runs) at an older commit. Name it.
+            local idx_tree c
+            idx_tree="$(git -C "$clone" write-tree 2>/dev/null)"
+            for c in $(git -C "$clone" rev-list -400 --all 2>/dev/null); do
+                if [ "$(git -C "$clone" rev-parse "$c^{tree}" 2>/dev/null)" = "$idx_tree" ]; then
+                    rec="$rec\tdisk=$(git -C "$clone" rev-parse --short=8 "$c")\tdisk_full=$c\tdisk_date=$(git -C "$clone" log -1 --format=%cs "$c")"
+                    break
+                fi
+            done
+        fi
         if [ -z "${baked:-}" ] && [ -n "$moved" ] && [ -n "$since_ts" ] && [ "$moved" -gt "$since_ts" ]; then
             rec="$rec\tstale=checkout moved $(date -d @"$moved" "+%F %H:%M") after the process started"
         fi
@@ -430,8 +442,8 @@ fmt_host_records() {  # stdin: service records -> pretty lines; side effect: not
             nounits) skip "no geecs-* / tiled units and nothing listening on the fleet ports"; continue ;;
         esac
         rec "$line"
-        local role svc managed state since clone branch sha full cdate staged unstaged stale pkg pyproject installed baked pyexe
-        role=""; svc=""; managed=""; state=""; since=""; clone=""; branch=""; sha=""; full=""; cdate=""; staged=""; unstaged=""; stale=""; pkg=""; pyproject=""; installed=""; baked=""; pyexe=""
+        local role svc managed state since clone branch sha full cdate staged unstaged stale pkg pyproject installed baked pyexe disk disk_full disk_date
+        role=""; svc=""; managed=""; state=""; since=""; clone=""; branch=""; sha=""; full=""; cdate=""; staged=""; unstaged=""; stale=""; pkg=""; pyproject=""; installed=""; baked=""; pyexe=""; disk=""; disk_full=""; disk_date=""
         local IFS=$'\t' kv
         for kv in $line; do
             case "$kv" in
@@ -440,6 +452,7 @@ fmt_host_records() {  # stdin: service records -> pretty lines; side effect: not
                 full=*) full="${kv#*=}" ;; commit_date=*) cdate="${kv#*=}" ;; staged=*) staged="${kv#*=}" ;; unstaged=*) unstaged="${kv#*=}" ;;
                 stale=*) stale="${kv#*=}" ;; pkg=*) pkg="${kv#*=}" ;; pyproject=*) pyproject="${kv#*=}" ;;
                 installed=*) installed="${kv#*=}" ;; baked=*) baked="${kv#*=}" ;; pyexe=*) pyexe="${kv#*=}" ;;
+                disk=*) disk="${kv#*=}" ;; disk_full=*) disk_full="${kv#*=}" ;; disk_date=*) disk_date="${kv#*=}" ;;
             esac
         done
         unset IFS
@@ -452,7 +465,12 @@ fmt_host_records() {  # stdin: service records -> pretty lines; side effect: not
             [ "${staged:-0}" != "0" ] && d="$d  STAGED: $staged file(s)"
             [ "${unstaged:-0}" != "0" ] && d="$d  UNSTAGED: $unstaged modified file(s)"
             info "$clone @ $branch $sha ($cdate)$d"
-            note_sha "${role:-$svc}" "$full"
+            if [ -n "$disk" ]; then
+                warn "$svc: files on disk are commit $disk ($disk_date), not HEAD $sha — the branch pointer moved without a checkout; what RUNS is $disk. Remedy: git reset --hard HEAD, then restart"
+                note_sha "${role:-$svc} (disk)" "$disk_full"
+            else
+                note_sha "${role:-$svc}" "$full"
+            fi
         elif [ -n "$pyexe" ]; then
             info "no git clone behind this process (interpreter $pyexe)"
         fi

--- a/scripts/fleet_status.sh
+++ b/scripts/fleet_status.sh
@@ -125,10 +125,10 @@ ssh_target() {  # ssh_target IP — --ssh override, else ~/.ssh/config alias who
 }
 
 # Deployed shas found in stage 1/2, cross-referenced locally in stage 3.
-# Format per line: "<label> <sha>".
+# Format per line: "<label><TAB><sha>" (labels contain spaces).
 DEPLOYED_SHAS=""
 note_sha() { DEPLOYED_SHAS="$DEPLOYED_SHAS
-$1 $2"; }
+$1	$2"; }
 
 # ===========================================================================
 NET_UP=0
@@ -167,6 +167,11 @@ if [ "$NET_UP" -eq 1 ]; then
     else
         bad "Data Portal  $PORTAL_HOST:$PORTAL_PORT  (no /health answer)"
     fi
+
+    # Queueserver — ZMQ, no cheap self-report; port liveness (stage 2 finds the process).
+    QS_HOST="${WORKER_HOST:-$LAB_HOST}"
+    if port_open "$QS_HOST" 60615; then ok "Queueserver  $QS_HOST:60615  RE Manager control port listening"; else bad "Queueserver  $QS_HOST:60615  RE Manager not listening"; fi
+    if port_open "$QS_HOST" 5568; then ok "Doc proxy    $QS_HOST:5568   document stream listening"; else bad "Doc proxy    $QS_HOST:5568   not listening"; fi
 
     # MCP HTTP mode — no version endpoint; port liveness only (stage 2 reads the venv).
     if port_open "${WORKER_HOST:-$LAB_HOST}" "$MCP_PORT"; then
@@ -210,12 +215,12 @@ os.environ["EPICS_PVA_AUTO_ADDR_LIST"] = "NO"
 from p4p.client.thread import Context  # noqa: E402
 
 versions = {}
-with Context("pva") as ctx:
+with Context("pva", unwrap=False) as ctx:  # raw Values: str(NT wrapper) carries a timestamp
     for pv, host in zip(pvs, hosts):
         base = pv[: -len(":version")]
         try:
-            ver = str(ctx.get(pv, timeout=timeout))
-            beats = int(ctx.get(base + ":heartbeat", timeout=timeout))
+            ver = str(ctx.get(pv, timeout=timeout)["value"])
+            beats = int(ctx.get(base + ":heartbeat", timeout=timeout)["value"])
         except Exception as exc:  # noqa: BLE001 — a failed probe is a finding
             print(f"  [DOWN] PVA gateway  {host:<15}  ({type(exc).__name__})")
             continue
@@ -236,102 +241,165 @@ PY
 fi
 
 # ===========================================================================
-# Stage 2 runs this on each host. Output: one "unit=..." record per systemd
-# unit (key=value pairs, tab-separated), which the local side formats.
-# Read-only: git queries, systemctl show, a venv python -c for the installed
-# version. `poetry` is looked up in ~/.local/bin because plain ssh has no
-# login PATH (fleet map bootstrap gotcha 4).
+# Stage 2 runs this on each host. Output: one "svc=..." record per service
+# (key=value pairs, tab-separated), which the local side formats. Services
+# are discovered two ways and deduplicated by pid: systemd units (system AND
+# user scope — a dev-deployed daemon often lives in `systemctl --user`) and
+# the process that owns each fleet port (a queueserver started by hand in
+# tmux has no unit at all — it must still show up, as UNMANAGED). Read-only:
+# git queries, systemctl show, /proc reads, a venv python -c for the
+# installed version. `poetry` is looked up in ~/.local/bin because plain ssh
+# has no login PATH (fleet map bootstrap gotcha 4).
 REMOTE_SNIPPET='
 set -u
-POETRY="$HOME/.local/bin/poetry"; command -v "$POETRY" >/dev/null 2>&1 || POETRY="$(command -v poetry 2>/dev/null || true)"
 command -v systemctl >/dev/null 2>&1 || { echo "nosystemd"; exit 0; }
-units="$(systemctl list-units --all --plain --no-legend "geecs-*" "tiled.service" 2>/dev/null | awk "{print \$1}")"
-[ -n "$units" ] || { echo "nounits"; exit 0; }
+# fleet map ports -> role label (what a listener on that port is)
+role_for_port() { case "$1" in
+    5064) echo "CA gateway";; 8000) echo "Tiled";; 8200) echo "Data Portal";; 8100) echo "GEECS-MCP";;
+    60615) echo "Queueserver RE Manager";; 5568) echo "Bluesky doc proxy";; *) echo "port $1";; esac; }
+FLEET_PORTS="5064 8000 8200 8100 60615 5568"
+SEEN=" "
 reflog_ts() {  # unix time HEAD last moved (checkout/pull/reset), from the reflog
     local f; f="$(git -C "$1" rev-parse --git-path logs/HEAD 2>/dev/null)"
     [ -f "$f" ] && tail -1 "$f" | sed -E "s/^[0-9a-f]+ [0-9a-f]+ .*> ([0-9]+) [-+][0-9]{4}\t.*/\1/"
 }
-for u in $units; do
-    active="$(systemctl show -p ActiveState --value "$u")"; sub="$(systemctl show -p SubState --value "$u")"
-    since="$(systemctl show -p ActiveEnterTimestamp --value "$u")"
-    since_ts=""; [ -n "$since" ] && since_ts="$(date -d "$since" +%s 2>/dev/null)"
-    workdir="$(systemctl show -p WorkingDirectory --value "$u")"
-    exec_py="$(systemctl show -p ExecStart --value "$u" | sed -nE "s/.*path=([^ ;]+).*/\1/p")"
-    rec="unit=$u\tactive=$active/$sub\tsince=${since:-?}"
-    clone=""; pkgdir=""; venv=""
-    if [ -n "$workdir" ] && [ -d "$workdir" ]; then
-        clone="$(git -C "$workdir" rev-parse --show-toplevel 2>/dev/null)"; pkgdir="$workdir"
-        [ -n "$clone" ] && [ -x "$POETRY" ] && venv="$(cd "$workdir" && "$POETRY" env info --path 2>/dev/null)"
-    elif [ -n "$exec_py" ] && [ -x "$exec_py" ]; then
-        # Baked venv (MCP pattern): the install records its source path.
-        venv="$(dirname "$(dirname "$exec_py")")"
-        src="$("$exec_py" -c "import importlib.metadata as m,json,sys
+pkgdir_up() {  # nearest pyproject.toml at or above $1, not above the clone root $2
+    local d="$1"
+    while [ -n "$d" ] && [ "$d" != "/" ]; do
+        [ -f "$d/pyproject.toml" ] && { echo "$d"; return; }
+        [ "$d" = "$2" ] && return
+        d="$(dirname "$d")"
+    done
+}
+emit() {  # emit NAME MANAGED STATE PID CWD PYEXE
+    local name="$1" managed="$2" state="$3" pid="$4" cwd="$5" pyexe="$6"
+    local since="" since_ts="" clone="" pkgdir="" venv="" baked="" moved=""
+    if [ -n "$pid" ] && [ "$pid" != "0" ] && [ -d "/proc/$pid" ]; then
+        since="$(ps -o lstart= -p "$pid" 2>/dev/null | sed -E "s/^ +//")"
+        [ -n "$since" ] && since_ts="$(date -d "$since" +%s 2>/dev/null)"
+        [ -z "$cwd" ] && cwd="$(readlink "/proc/$pid/cwd" 2>/dev/null)"
+        [ -z "$pyexe" ] && pyexe="$(tr "\0" "\n" < "/proc/$pid/cmdline" 2>/dev/null | head -1)"
+    fi
+    local rec="svc=$name\tmanaged=$managed\tstate=$state\tsince=${since:-?}"
+    [ -n "$cwd" ] && [ -d "$cwd" ] && clone="$(git -C "$cwd" rev-parse --show-toplevel 2>/dev/null)"
+    [ -n "$clone" ] && pkgdir="$(pkgdir_up "$cwd" "$clone")"
+    case "$pyexe" in */bin/python*) venv="$(dirname "$(dirname "$pyexe")")";; esac
+    if [ -z "$clone" ] && [ -n "$venv" ] && [ -x "$venv/bin/python" ]; then
+        # Baked venv (MCP pattern): the non-editable install records its source path.
+        src="$("$venv/bin/python" -c "import importlib.metadata as m,json
 for d in m.distributions():
     t=d.read_text(\"direct_url.json\")
     if t and \"GEECS\" in t: print(json.loads(t)[\"url\"]); break" 2>/dev/null | sed "s|^file://||")"
-        [ -n "$src" ] && [ -d "$src" ] && { pkgdir="$src"; clone="$(git -C "$src" rev-parse --show-toplevel 2>/dev/null)"; }
+        if [ -n "$src" ] && [ -d "$src" ]; then pkgdir="$src"; clone="$(git -C "$src" rev-parse --show-toplevel 2>/dev/null)"; baked="$venv"; rec="$rec\tbaked=${venv/#$HOME/\~}"; fi
     fi
     if [ -n "$clone" ]; then
+        local branch sha full cdate staged unstaged
         branch="$(git -C "$clone" rev-parse --abbrev-ref HEAD 2>/dev/null)"; [ "$branch" = "HEAD" ] && branch="(detached)"
         sha="$(git -C "$clone" rev-parse --short=8 HEAD 2>/dev/null)"; full="$(git -C "$clone" rev-parse HEAD 2>/dev/null)"
         cdate="$(git -C "$clone" log -1 --format=%cs 2>/dev/null)"
-        dirty="$(git -C "$clone" status --porcelain --untracked-files=no 2>/dev/null | wc -l | tr -d " ")"
+        staged="$(git -C "$clone" diff --cached --name-only 2>/dev/null | wc -l | tr -d " ")"
+        unstaged="$(git -C "$clone" diff --name-only 2>/dev/null | wc -l | tr -d " ")"
         moved="$(reflog_ts "$clone")"
-        rec="$rec\tclone=${clone/#$HOME/\~}\tbranch=$branch\tsha=$sha\tfull=$full\tcommit_date=$cdate\tdirty=$dirty"
-        if [ -n "$moved" ] && [ -n "$since_ts" ] && [ "$active" = "active" ] && [ "$moved" -gt "$since_ts" ]; then
-            rec="$rec\tstale=checkout moved $(date -d @"$moved" "+%F %H:%M") after the service started"
+        rec="$rec\tclone=${clone/#$HOME/\~}\tbranch=$branch\tsha=$sha\tfull=$full\tcommit_date=$cdate\tstaged=$staged\tunstaged=$unstaged"
+        if [ -z "${baked:-}" ] && [ -n "$moved" ] && [ -n "$since_ts" ] && [ "$moved" -gt "$since_ts" ]; then
+            rec="$rec\tstale=checkout moved $(date -d @"$moved" "+%F %H:%M") after the process started"
         fi
     fi
     if [ -n "$pkgdir" ] && [ -f "$pkgdir/pyproject.toml" ]; then
+        local pname pver iver
         pname="$(sed -nE "s/^name *= *\"([^\"]+)\".*/\1/p" "$pkgdir/pyproject.toml" | head -1)"
         pver="$(sed -nE "s/^version *= *\"([^\"]+)\".*/\1/p" "$pkgdir/pyproject.toml" | head -1)"
         rec="$rec\tpkg=$pname\tpyproject=$pver"
         if [ -n "$venv" ] && [ -x "$venv/bin/python" ] && [ -n "$pname" ]; then
             iver="$("$venv/bin/python" -c "import importlib.metadata as m; print(m.version(\"$pname\"))" 2>/dev/null)"
             rec="$rec\tinstalled=${iver:-?}"
+            if [ -n "${baked:-}" ]; then
+                # Baked install: the code that runs is what was installed, so
+                # compare the checkout move against the install, not the process.
+                distinfo="$(ls -d "$venv"/lib/python*/site-packages/${pname//-/_}-*.dist-info 2>/dev/null | head -1)"
+                inst_ts=""; [ -n "$distinfo" ] && inst_ts="$(stat -c %Y "$distinfo" 2>/dev/null)"
+                if [ -n "$inst_ts" ] && [ -n "${moved:-}" ] && [ "$moved" -gt "$inst_ts" ]; then
+                    rec="$rec\tstale=checkout moved $(date -d @"$moved" "+%F %H:%M") after the baked install ($(date -d @"$inst_ts" "+%F %H:%M")) — pip reinstall + restart pending"
+                elif [ -n "$inst_ts" ] && [ -n "$since_ts" ] && [ "$inst_ts" -gt "$since_ts" ]; then
+                    rec="$rec\tstale=reinstalled $(date -d @"$inst_ts" "+%F %H:%M") after the process started — restart pending"
+                fi
+            fi
         fi
     fi
+    [ -n "$pyexe" ] && rec="$rec\tpyexe=${pyexe/#$HOME/\~}"
     printf "%b\n" "$rec"
+}
+# 1) systemd units, system and user scope
+for scope in "" "--user"; do
+    units="$(systemctl $scope list-units --all --plain --no-legend "geecs-*" "tiled.service" 2>/dev/null | awk "{print \$1}")"
+    for u in $units; do
+        active="$(systemctl $scope show -p ActiveState --value "$u")/$(systemctl $scope show -p SubState --value "$u")"
+        pid="$(systemctl $scope show -p MainPID --value "$u")"
+        wd="$(systemctl $scope show -p WorkingDirectory --value "$u")"
+        label="$u"; [ -n "$scope" ] && label="$u (user unit)"
+        [ "$pid" != "0" ] && SEEN="$SEEN$pid "
+        emit "$label" "systemd" "$active" "$pid" "$wd" ""
+    done
 done
+# 2) whoever owns each fleet port, if not already listed via its unit
+for port in $FLEET_PORTS; do
+    pid="$(ss -ltnpH "sport = :$port" 2>/dev/null | sed -nE "s/.*pid=([0-9]+).*/\1/p" | head -1)"
+    [ -n "$pid" ] || continue
+    case "$SEEN" in *" $pid "*) continue;; esac
+    SEEN="$SEEN$pid "
+    unit="$(sed -nE "s#.*/([^/]+\.service)\$#\1#p" "/proc/$pid/cgroup" 2>/dev/null | head -1)"
+    if [ -n "$unit" ]; then managed="systemd ($unit)"; else managed="UNMANAGED"; fi
+    emit "$(role_for_port "$port") :$port" "$managed" "running pid $pid" "$pid" "" ""
+done
+[ "$SEEN" = " " ] && echo "nounits"
+exit 0
 '
 
-fmt_host_records() {  # stdin: unit records -> pretty lines; side effect: note_sha
+fmt_host_records() {  # stdin: service records -> pretty lines; side effect: note_sha
     local line
     while IFS= read -r line; do
         [ -n "$line" ] || continue
         case "$line" in
             nosystemd) skip "no systemd on this host"; continue ;;
-            nounits) skip "no geecs-* / tiled units installed here"; continue ;;
+            nounits) skip "no geecs-* / tiled units and nothing listening on the fleet ports"; continue ;;
         esac
-        local unit active since clone branch sha full cdate dirty stale pkg pyproject installed
-        unit=""; active=""; since=""; clone=""; branch=""; sha=""; full=""; cdate=""; dirty=""; stale=""; pkg=""; pyproject=""; installed=""
+        local svc managed state since clone branch sha full cdate staged unstaged stale pkg pyproject installed baked pyexe
+        svc=""; managed=""; state=""; since=""; clone=""; branch=""; sha=""; full=""; cdate=""; staged=""; unstaged=""; stale=""; pkg=""; pyproject=""; installed=""; baked=""; pyexe=""
         local IFS=$'\t' kv
         for kv in $line; do
             case "$kv" in
-                unit=*) unit="${kv#*=}" ;; active=*) active="${kv#*=}" ;; since=*) since="${kv#*=}" ;;
+                svc=*) svc="${kv#*=}" ;; managed=*) managed="${kv#*=}" ;; state=*) state="${kv#*=}" ;; since=*) since="${kv#*=}" ;;
                 clone=*) clone="${kv#*=}" ;; branch=*) branch="${kv#*=}" ;; sha=*) sha="${kv#*=}" ;;
-                full=*) full="${kv#*=}" ;; commit_date=*) cdate="${kv#*=}" ;; dirty=*) dirty="${kv#*=}" ;;
+                full=*) full="${kv#*=}" ;; commit_date=*) cdate="${kv#*=}" ;; staged=*) staged="${kv#*=}" ;; unstaged=*) unstaged="${kv#*=}" ;;
                 stale=*) stale="${kv#*=}" ;; pkg=*) pkg="${kv#*=}" ;; pyproject=*) pyproject="${kv#*=}" ;;
-                installed=*) installed="${kv#*=}" ;;
+                installed=*) installed="${kv#*=}" ;; baked=*) baked="${kv#*=}" ;; pyexe=*) pyexe="${kv#*=}" ;;
             esac
         done
         unset IFS
         local tag="[ OK ]"
-        case "$active" in active/*) ;; *) tag="[DOWN]" ;; esac
-        printf '  %s %-26s %-16s since %s\n' "$tag" "$unit" "$active" "${since:-?}"
+        case "$state" in active/*|running*) ;; *) tag="[DOWN]" ;; esac
+        printf '  %s %-34s %-16s since %s\n' "$tag" "$svc" "$state" "${since:-?}"
+        [ "$managed" = "UNMANAGED" ] && warn "$svc: no systemd unit owns this process (started by hand — tmux/nohup?); it will not survive a reboot or crash"
         if [ -n "$clone" ]; then
-            local d=""; [ "${dirty:-0}" != "0" ] && d="  DIRTY: $dirty modified tracked file(s)"
+            local d=""
+            [ "${staged:-0}" != "0" ] && d="$d  STAGED: $staged file(s)"
+            [ "${unstaged:-0}" != "0" ] && d="$d  UNSTAGED: $unstaged modified file(s)"
             info "$clone @ $branch $sha ($cdate)$d"
-            note_sha "$unit" "$full"
+            note_sha "$svc" "$full"
+        elif [ -n "$pyexe" ]; then
+            info "no git clone behind this process (interpreter $pyexe)"
         fi
+        [ -n "$baked" ] && info "baked venv $baked (non-editable install — the clone can move without changing the running code)"
         if [ -n "$pkg" ]; then
             if [ -n "$installed" ] && [ "$installed" != "$pyproject" ]; then
-                warn "$pkg: pyproject says $pyproject but the venv has $installed installed — poetry install pending"
+                warn "$pkg: pyproject says $pyproject but the venv has $installed installed — poetry install / pip reinstall pending"
             else
                 info "$pkg $pyproject${installed:+ (installed $installed)}"
             fi
         fi
-        [ -n "$stale" ] && warn "$unit: $stale — the running process predates the code on disk (restart pending?)"
+        if [ -n "$stale" ]; then
+            case "$stale" in *pending*) warn "$svc: $stale" ;; *) warn "$svc: $stale — the running process predates the code on disk (restart pending?)" ;; esac
+        fi
     done
 }
 
@@ -345,7 +413,7 @@ if [ "$NET_UP" -eq 1 ] && [ "$DO_SSH" -eq 1 ]; then
         echo "host $host (ssh $target)"
         out="$(printf '%s' "$REMOTE_SNIPPET" | bounded "$SSH_TIMEOUT" ssh -o BatchMode=yes -o ConnectTimeout=5 -o StrictHostKeyChecking=accept-new "$target" bash -s 2>&1)"
         rc=$?
-        if [ "$rc" -ne 0 ] && ! printf '%s' "$out" | grep -q '^unit='; then
+        if [ "$rc" -ne 0 ] && ! printf '%s' "$out" | grep -q '^svc='; then
             bad "ssh $target failed (rc=$rc): $(printf '%s' "$out" | head -1)"
             info "no key-based access from here? pass --ssh $host=<alias> or run the stage-2 snippet on the host by hand"
             continue
@@ -382,7 +450,7 @@ git -C "$REPO_ROOT" worktree list 2>/dev/null | while IFS= read -r wl; do
 done
 if [ -n "$(printf '%s' "$DEPLOYED_SHAS" | tr -d '\n ')" ]; then
     echo "  deployed shas vs this repo:"
-    printf '%s\n' "$DEPLOYED_SHAS" | while read -r label full; do
+    printf '%s\n' "$DEPLOYED_SHAS" | while IFS=$'\t' read -r label full; do
         [ -n "$full" ] || continue
         short="${full:0:8}"
         if ! git -C "$REPO_ROOT" cat-file -e "$full^{commit}" 2>/dev/null; then

--- a/scripts/fleet_status.sh
+++ b/scripts/fleet_status.sh
@@ -1,0 +1,416 @@
+#!/usr/bin/env bash
+# fleet_status.sh — what code is each fleet service actually running?
+#
+# The fleet map (docs/platform/fleet_map.md) is the intended picture; this
+# script is the observed one. During rapid development a host may run a
+# feature-branch checkout, a checkout may have moved under a service that
+# was never restarted, or a pyproject bump may never have been installed —
+# none of which the doc can tell you. Every probe is bounded and read-only:
+# it never writes a PV, never restarts a unit, never pulls a checkout.
+#
+#   scripts/fleet_status.sh                       # full picture (needs the lab)
+#   scripts/fleet_status.sh --local-only          # just the local checkouts
+#   scripts/fleet_status.sh --no-ssh              # service self-reports only
+#   scripts/fleet_status.sh --ssh 192.168.6.14=geecs-gw   # ssh alias override
+#   scripts/fleet_status.sh --experiment Undulator --no-fetch
+#
+# Stages (each gated on the previous one):
+#   0. reachability — scripts/lab_status.sh tier 1 (the same gate /lab-status
+#      uses); network DOWN => stage 3 only, remote = UNKNOWN
+#   1. self-reported versions over the services' own protocols: Tiled
+#      (HTTP), Data Portal (/health), MCP (port), CA gateway (lab_status.sh
+#      --hardware, read-only CA), PVA image fleet (read-only pvAccess gets)
+#   2. host checkouts over ssh: every geecs-* systemd unit -> the clone it
+#      runs from -> branch / sha / dirty / installed-vs-pyproject version /
+#      "checkout moved after the service started"
+#   3. local cross-reference: which local worktree/branch holds each
+#      deployed sha, and how far each is from origin/master
+#
+# Endpoints come from ~/.config/geecs_python_api/config.ini (the one client
+# contract) — the lab server from [tiled] uri, the worker from [qserver]
+# host, ssh aliases from ~/.ssh/config by matching HostName. Nothing lab-
+# specific is hardcoded here beyond the fleet map's port numbers.
+set -u  # deliberately not -e: a failed probe is a *finding*, not an error
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+CONFIG="$HOME/.config/geecs_python_api/config.ini"
+PORTAL_PORT=8200       # fleet map: GEECS Data Portal
+MCP_PORT=8100          # fleet map: GEECS-MCP HTTP mode
+TCP_TIMEOUT=2          # seconds per port probe / HTTP get
+SSH_TIMEOUT=25         # seconds per host (one ssh call per host)
+PVA_TIMEOUT=2          # seconds per PVA get
+FETCH_TIMEOUT=20       # seconds for the local `git fetch origin`
+PVA_ROSTER="$REPO_ROOT/GeecsPvaGateway/deploy/fleet_status.bob"  # the checked-in fleet roster
+
+EXPERIMENT=""
+DO_SSH=1
+DO_FETCH=1
+LOCAL_ONLY=0
+declare -a SSH_OVERRIDES=()
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --experiment) shift; EXPERIMENT="${1:-}" ;;
+        --no-ssh) DO_SSH=0 ;;
+        --no-fetch) DO_FETCH=0 ;;
+        --local-only) LOCAL_ONLY=1 ;;
+        --ssh) shift; SSH_OVERRIDES+=("${1:-}") ;;
+        *) echo "usage: fleet_status.sh [--experiment NAME] [--no-ssh] [--no-fetch] [--local-only] [--ssh IP=ALIAS]..." >&2; exit 2 ;;
+    esac
+    shift
+done
+
+ini_get() {  # ini_get SECTION KEY — first match, trimmed
+    awk -F'=' -v s="[$1]" -v k="$2" '
+        $0 == s { insec = 1; next }
+        /^\[/   { insec = 0 }
+        insec && $1 ~ "^[ \t]*"k"[ \t]*$" { gsub(/^[ \t]+|[ \t\r]+$/, "", $2); print $2; exit }
+    ' "$CONFIG" 2>/dev/null
+}
+
+ok()   { printf '  [ OK ] %s\n' "$1"; }
+bad()  { printf '  [DOWN] %s\n' "$1"; }
+warn() { printf '  [WARN] %s\n' "$1"; }
+skip() { printf '  [ -- ] %s\n' "$1"; }
+info() { printf '         %s\n' "$1"; }
+
+bounded() {  # bounded SECS CMD... — hard wall-clock bound (macOS has no `timeout`)
+    local secs="$1"; shift
+    # Explicit stdin redirect: a background job in a non-interactive shell
+    # otherwise gets /dev/null, which would starve `ssh bash -s` / `python -`.
+    "$@" </dev/stdin &
+    local job=$!
+    # Watchdog detached from our stdout so a command substitution around
+    # bounded() does not wait out the full timeout on the held pipe.
+    ( sleep "$secs"; kill -9 "$job" 2>/dev/null ) >/dev/null 2>&1 </dev/null &
+    local watchdog=$!
+    wait "$job" 2>/dev/null
+    local rc=$?
+    kill "$watchdog" 2>/dev/null
+    wait "$watchdog" 2>/dev/null
+    return "$rc"
+}
+
+port_open() {  # port_open HOST PORT
+    bounded "$TCP_TIMEOUT" bash -c "exec 3<>/dev/tcp/$1/$2" 2>/dev/null
+}
+
+# --- endpoints from config.ini (never hardcode hosts here) -----------------
+TILED_URI="$(ini_get tiled uri)"
+LAB_HOST="$(printf '%s' "$TILED_URI" | sed -E 's|^[a-z]+://||; s|[:/].*$||')"
+TILED_PORT="$(printf '%s' "$TILED_URI" | sed -nE 's|^[a-z]+://[^:/]+:([0-9]+).*|\1|p')"
+TILED_PORT="${TILED_PORT:-8000}"
+WORKER_HOST="$(ini_get qserver host)"
+if [ -z "$EXPERIMENT" ]; then EXPERIMENT="$(ini_get Experiment expt)"; fi
+if [ -z "$EXPERIMENT" ]; then EXPERIMENT="$(ini_get Experiment exp_name)"; fi
+
+# Hosts to visit over ssh: the lab server and the worker, deduplicated
+# (today they are one box; the fleet map says which services live where).
+HOSTS=""
+for h in "$LAB_HOST" "$WORKER_HOST"; do
+    [ -n "$h" ] || continue
+    case " $HOSTS " in *" $h "*) ;; *) HOSTS="$HOSTS $h" ;; esac
+done
+
+ssh_target() {  # ssh_target IP — --ssh override, else ~/.ssh/config alias whose HostName is IP, else IP
+    local ip="$1" ov
+    for ov in "${SSH_OVERRIDES[@]+"${SSH_OVERRIDES[@]}"}"; do
+        case "$ov" in "$ip="*) printf '%s' "${ov#*=}"; return ;; esac
+    done
+    local alias
+    alias="$(awk -v ip="$ip" '
+        tolower($1) == "host" && NF == 2 { h = $2 }
+        tolower($1) == "hostname" && $2 == ip && h != "" { print h; exit }
+    ' "$HOME/.ssh/config" 2>/dev/null)"
+    printf '%s' "${alias:-$ip}"
+}
+
+# Deployed shas found in stage 1/2, cross-referenced locally in stage 3.
+# Format per line: "<label> <sha>".
+DEPLOYED_SHAS=""
+note_sha() { DEPLOYED_SHAS="$DEPLOYED_SHAS
+$1 $2"; }
+
+# ===========================================================================
+NET_UP=0
+if [ "$LOCAL_ONLY" -eq 0 ]; then
+    echo "== Stage 0: reachability (scripts/lab_status.sh, tier 1) =="
+    lab_out="$("$REPO_ROOT/scripts/lab_status.sh" 2>&1)"
+    printf '%s\n' "$lab_out" | grep -v '^== \|^network:'
+    if printf '%s\n' "$lab_out" | grep -q '^network: UP'; then
+        NET_UP=1
+        echo "  network: UP"
+    else
+        echo "  network: DOWN or partial — remote fleet state is UNKNOWN from here (nothing below is a service verdict)"
+    fi
+    echo
+fi
+
+# ===========================================================================
+if [ "$NET_UP" -eq 1 ]; then
+    echo "== Stage 1: what each service says about itself (read-only) =="
+    # Tiled — pip-installed, no checkout; its library version is the whole story.
+    tv="$(bounded "$TCP_TIMEOUT" curl -s -m "$TCP_TIMEOUT" "http://$LAB_HOST:$TILED_PORT/api/v1/" | sed -nE 's/.*"library_version":"([^"]+)".*/\1/p')"
+    if [ -n "$tv" ]; then ok "Tiled        $LAB_HOST:$TILED_PORT  tiled $tv"; else bad "Tiled        $LAB_HOST:$TILED_PORT"; fi
+
+    # Data Portal — /health carries ok + catalog probe + installed version.
+    PORTAL_HOST="${WORKER_HOST:-$LAB_HOST}"
+    ph="$(bounded "$TCP_TIMEOUT" curl -s -m "$TCP_TIMEOUT" "http://$PORTAL_HOST:$PORTAL_PORT/health")"
+    if [ -n "$ph" ]; then
+        pv="$(printf '%s' "$ph" | sed -nE 's/.*"version": *"([^"]+)".*/\1/p')"
+        pok="$(printf '%s' "$ph" | sed -nE 's/.*"ok": *(true|false).*/\1/p')"
+        pcat="$(printf '%s' "$ph" | sed -nE 's/.*"catalog": *"([^"]*)".*/\1/p')"
+        if [ "$pok" = "true" ]; then
+            ok "Data Portal  $PORTAL_HOST:$PORTAL_PORT  geecs-data-portal ${pv:-?}  (catalog: ${pcat:-?})"
+        else
+            warn "Data Portal  $PORTAL_HOST:$PORTAL_PORT  geecs-data-portal ${pv:-?}  up but catalog NOT ok (${pcat:-?})"
+        fi
+    else
+        bad "Data Portal  $PORTAL_HOST:$PORTAL_PORT  (no /health answer)"
+    fi
+
+    # MCP HTTP mode — no version endpoint; port liveness only (stage 2 reads the venv).
+    if port_open "${WORKER_HOST:-$LAB_HOST}" "$MCP_PORT"; then
+        ok "GEECS-MCP    ${WORKER_HOST:-$LAB_HOST}:$MCP_PORT  listening (version via ssh below)"
+    else
+        skip "GEECS-MCP    ${WORKER_HOST:-$LAB_HOST}:$MCP_PORT  not listening (HTTP mode is 'pending deploy' on the fleet map)"
+    fi
+
+    # CA gateway — reuse /lab-status tier 2 (read-only CA gets of heartbeat,
+    # devices_connected, version). Contract: it prints "version=<str>".
+    if [ -n "$EXPERIMENT" ]; then
+        hw="$("$REPO_ROOT/scripts/lab_status.sh" --hardware --experiment "$EXPERIMENT" 2>&1 | sed -n '/Tier 2/,$p')"
+        alive="$(printf '%s\n' "$hw" | grep -m1 'gateway alive')"
+        if [ -n "$alive" ]; then
+            ok "CA gateway   $LAB_HOST:5064  ${alive#*] }"
+            printf '%s\n' "$hw" | grep '\[WARN\]' | sed 's/^ *\[WARN\] /  [WARN] CA gateway: /'
+        else
+            err="$(printf '%s\n' "$hw" | grep -m1 -E 'unreadable|not installed|no experiment' )"
+            bad "CA gateway   $LAB_HOST:5064  ${err#*] }"
+        fi
+    else
+        skip "CA gateway   no experiment name (config.ini [Experiment] expt, or --experiment NAME)"
+    fi
+
+    # PVA image fleet — one gateway per camera server; roster = the checked-in
+    # Phoebus fleet screen (the DB-driven roster is still owed). Read-only gets.
+    if [ -f "$PVA_ROSTER" ]; then
+        pvs="$(grep -o 'pv_name>pva://[^<]*:version' "$PVA_ROSTER" | sed 's|pv_name>pva://||' | sort -u)"
+        if [ -n "$pvs" ] && poetry -C "$REPO_ROOT/GeecsPvaGateway" env info --path >/dev/null 2>&1; then
+            PVA_PVS="$pvs" PVA_TIMEOUT="$PVA_TIMEOUT" bounded 60 poetry -C "$REPO_ROOT/GeecsPvaGateway" run python - <<'PY'
+import os
+import re
+
+pvs = os.environ["PVA_PVS"].split()
+timeout = float(os.environ["PVA_TIMEOUT"])
+# Host IPs are encoded in the PV name (dots -> underscores, PV_CONTRACT).
+hosts = [re.sub(r"_", ".", pv.split(":")[2]) for pv in pvs]
+# Unicast search to each camera server: UDP broadcast does not cross a VPN.
+os.environ["EPICS_PVA_ADDR_LIST"] = " ".join(hosts)
+os.environ["EPICS_PVA_AUTO_ADDR_LIST"] = "NO"
+from p4p.client.thread import Context  # noqa: E402
+
+versions = {}
+with Context("pva") as ctx:
+    for pv, host in zip(pvs, hosts):
+        base = pv[: -len(":version")]
+        try:
+            ver = str(ctx.get(pv, timeout=timeout))
+            beats = int(ctx.get(base + ":heartbeat", timeout=timeout))
+        except Exception as exc:  # noqa: BLE001 — a failed probe is a finding
+            print(f"  [DOWN] PVA gateway  {host:<15}  ({type(exc).__name__})")
+            continue
+        versions.setdefault(ver, []).append(host)
+        print(f"  [ OK ] PVA gateway  {host:<15}  geecs-pva-gateway {ver}  heartbeat={beats}")
+if len(versions) > 1:
+    print("  [WARN] PVA fleet runs mixed versions — a rollout is incomplete or a box missed its pull-on-restart:")
+    for ver, hs in sorted(versions.items()):
+        print(f"         {ver}: {', '.join(hs)}")
+PY
+        else
+            skip "PVA fleet    GeecsPvaGateway poetry env not installed (needs p4p; see /env-doctor)"
+        fi
+    else
+        skip "PVA fleet    roster file missing ($PVA_ROSTER)"
+    fi
+    echo
+fi
+
+# ===========================================================================
+# Stage 2 runs this on each host. Output: one "unit=..." record per systemd
+# unit (key=value pairs, tab-separated), which the local side formats.
+# Read-only: git queries, systemctl show, a venv python -c for the installed
+# version. `poetry` is looked up in ~/.local/bin because plain ssh has no
+# login PATH (fleet map bootstrap gotcha 4).
+REMOTE_SNIPPET='
+set -u
+POETRY="$HOME/.local/bin/poetry"; command -v "$POETRY" >/dev/null 2>&1 || POETRY="$(command -v poetry 2>/dev/null || true)"
+command -v systemctl >/dev/null 2>&1 || { echo "nosystemd"; exit 0; }
+units="$(systemctl list-units --all --plain --no-legend "geecs-*" "tiled.service" 2>/dev/null | awk "{print \$1}")"
+[ -n "$units" ] || { echo "nounits"; exit 0; }
+reflog_ts() {  # unix time HEAD last moved (checkout/pull/reset), from the reflog
+    local f; f="$(git -C "$1" rev-parse --git-path logs/HEAD 2>/dev/null)"
+    [ -f "$f" ] && tail -1 "$f" | sed -E "s/^[0-9a-f]+ [0-9a-f]+ .*> ([0-9]+) [-+][0-9]{4}\t.*/\1/"
+}
+for u in $units; do
+    active="$(systemctl show -p ActiveState --value "$u")"; sub="$(systemctl show -p SubState --value "$u")"
+    since="$(systemctl show -p ActiveEnterTimestamp --value "$u")"
+    since_ts=""; [ -n "$since" ] && since_ts="$(date -d "$since" +%s 2>/dev/null)"
+    workdir="$(systemctl show -p WorkingDirectory --value "$u")"
+    exec_py="$(systemctl show -p ExecStart --value "$u" | sed -nE "s/.*path=([^ ;]+).*/\1/p")"
+    rec="unit=$u\tactive=$active/$sub\tsince=${since:-?}"
+    clone=""; pkgdir=""; venv=""
+    if [ -n "$workdir" ] && [ -d "$workdir" ]; then
+        clone="$(git -C "$workdir" rev-parse --show-toplevel 2>/dev/null)"; pkgdir="$workdir"
+        [ -n "$clone" ] && [ -x "$POETRY" ] && venv="$(cd "$workdir" && "$POETRY" env info --path 2>/dev/null)"
+    elif [ -n "$exec_py" ] && [ -x "$exec_py" ]; then
+        # Baked venv (MCP pattern): the install records its source path.
+        venv="$(dirname "$(dirname "$exec_py")")"
+        src="$("$exec_py" -c "import importlib.metadata as m,json,sys
+for d in m.distributions():
+    t=d.read_text(\"direct_url.json\")
+    if t and \"GEECS\" in t: print(json.loads(t)[\"url\"]); break" 2>/dev/null | sed "s|^file://||")"
+        [ -n "$src" ] && [ -d "$src" ] && { pkgdir="$src"; clone="$(git -C "$src" rev-parse --show-toplevel 2>/dev/null)"; }
+    fi
+    if [ -n "$clone" ]; then
+        branch="$(git -C "$clone" rev-parse --abbrev-ref HEAD 2>/dev/null)"; [ "$branch" = "HEAD" ] && branch="(detached)"
+        sha="$(git -C "$clone" rev-parse --short=8 HEAD 2>/dev/null)"; full="$(git -C "$clone" rev-parse HEAD 2>/dev/null)"
+        cdate="$(git -C "$clone" log -1 --format=%cs 2>/dev/null)"
+        dirty="$(git -C "$clone" status --porcelain --untracked-files=no 2>/dev/null | wc -l | tr -d " ")"
+        moved="$(reflog_ts "$clone")"
+        rec="$rec\tclone=${clone/#$HOME/\~}\tbranch=$branch\tsha=$sha\tfull=$full\tcommit_date=$cdate\tdirty=$dirty"
+        if [ -n "$moved" ] && [ -n "$since_ts" ] && [ "$active" = "active" ] && [ "$moved" -gt "$since_ts" ]; then
+            rec="$rec\tstale=checkout moved $(date -d @"$moved" "+%F %H:%M") after the service started"
+        fi
+    fi
+    if [ -n "$pkgdir" ] && [ -f "$pkgdir/pyproject.toml" ]; then
+        pname="$(sed -nE "s/^name *= *\"([^\"]+)\".*/\1/p" "$pkgdir/pyproject.toml" | head -1)"
+        pver="$(sed -nE "s/^version *= *\"([^\"]+)\".*/\1/p" "$pkgdir/pyproject.toml" | head -1)"
+        rec="$rec\tpkg=$pname\tpyproject=$pver"
+        if [ -n "$venv" ] && [ -x "$venv/bin/python" ] && [ -n "$pname" ]; then
+            iver="$("$venv/bin/python" -c "import importlib.metadata as m; print(m.version(\"$pname\"))" 2>/dev/null)"
+            rec="$rec\tinstalled=${iver:-?}"
+        fi
+    fi
+    printf "%b\n" "$rec"
+done
+'
+
+fmt_host_records() {  # stdin: unit records -> pretty lines; side effect: note_sha
+    local line
+    while IFS= read -r line; do
+        [ -n "$line" ] || continue
+        case "$line" in
+            nosystemd) skip "no systemd on this host"; continue ;;
+            nounits) skip "no geecs-* / tiled units installed here"; continue ;;
+        esac
+        local unit active since clone branch sha full cdate dirty stale pkg pyproject installed
+        unit=""; active=""; since=""; clone=""; branch=""; sha=""; full=""; cdate=""; dirty=""; stale=""; pkg=""; pyproject=""; installed=""
+        local IFS=$'\t' kv
+        for kv in $line; do
+            case "$kv" in
+                unit=*) unit="${kv#*=}" ;; active=*) active="${kv#*=}" ;; since=*) since="${kv#*=}" ;;
+                clone=*) clone="${kv#*=}" ;; branch=*) branch="${kv#*=}" ;; sha=*) sha="${kv#*=}" ;;
+                full=*) full="${kv#*=}" ;; commit_date=*) cdate="${kv#*=}" ;; dirty=*) dirty="${kv#*=}" ;;
+                stale=*) stale="${kv#*=}" ;; pkg=*) pkg="${kv#*=}" ;; pyproject=*) pyproject="${kv#*=}" ;;
+                installed=*) installed="${kv#*=}" ;;
+            esac
+        done
+        unset IFS
+        local tag="[ OK ]"
+        case "$active" in active/*) ;; *) tag="[DOWN]" ;; esac
+        printf '  %s %-26s %-16s since %s\n' "$tag" "$unit" "$active" "${since:-?}"
+        if [ -n "$clone" ]; then
+            local d=""; [ "${dirty:-0}" != "0" ] && d="  DIRTY: $dirty modified tracked file(s)"
+            info "$clone @ $branch $sha ($cdate)$d"
+            note_sha "$unit" "$full"
+        fi
+        if [ -n "$pkg" ]; then
+            if [ -n "$installed" ] && [ "$installed" != "$pyproject" ]; then
+                warn "$pkg: pyproject says $pyproject but the venv has $installed installed — poetry install pending"
+            else
+                info "$pkg $pyproject${installed:+ (installed $installed)}"
+            fi
+        fi
+        [ -n "$stale" ] && warn "$unit: $stale — the running process predates the code on disk (restart pending?)"
+    done
+}
+
+if [ "$NET_UP" -eq 1 ] && [ "$DO_SSH" -eq 1 ]; then
+    echo "== Stage 2: host checkouts (ssh, read-only) =="
+    if [ -z "$HOSTS" ]; then
+        skip "no hosts derivable from config.ini ([tiled] uri / [qserver] host)"
+    fi
+    for host in $HOSTS; do
+        target="$(ssh_target "$host")"
+        echo "host $host (ssh $target)"
+        out="$(printf '%s' "$REMOTE_SNIPPET" | bounded "$SSH_TIMEOUT" ssh -o BatchMode=yes -o ConnectTimeout=5 -o StrictHostKeyChecking=accept-new "$target" bash -s 2>&1)"
+        rc=$?
+        if [ "$rc" -ne 0 ] && ! printf '%s' "$out" | grep -q '^unit='; then
+            bad "ssh $target failed (rc=$rc): $(printf '%s' "$out" | head -1)"
+            info "no key-based access from here? pass --ssh $host=<alias> or run the stage-2 snippet on the host by hand"
+            continue
+        fi
+        fmt_host_records <<< "$out"   # here-string, not a pipe: note_sha must run in this shell
+    done
+    echo
+elif [ "$NET_UP" -eq 1 ]; then
+    echo "== Stage 2: host checkouts — skipped (--no-ssh) =="
+    echo
+fi
+
+# ===========================================================================
+echo "== Stage 3: local checkouts and cross-reference =="
+if [ "$DO_FETCH" -eq 1 ]; then
+    if bounded "$FETCH_TIMEOUT" git -C "$REPO_ROOT" fetch --quiet origin 2>/dev/null; then
+        info "origin fetched"
+    else
+        warn "git fetch origin failed/timed out — distances below use the last-fetched origin/master"
+    fi
+fi
+master_sha="$(git -C "$REPO_ROOT" rev-parse --short=8 origin/master 2>/dev/null)"
+info "origin/master = ${master_sha:-?}"
+echo "  local worktrees:"
+git -C "$REPO_ROOT" worktree list 2>/dev/null | while IFS= read -r wl; do
+    wpath="${wl%% *}"; rest="${wl#"$wpath"}"
+    case "$wpath" in
+        "$REPO_ROOT") rel="(this checkout)" ;;
+        "$REPO_ROOT"/*) rel="${wpath#"$REPO_ROOT"/}" ;;
+        *) rel="$wpath" ;;
+    esac
+    dirty="$(git -C "$wpath" status --porcelain --untracked-files=no 2>/dev/null | wc -l | tr -d ' ')"
+    printf '    %-48s %s%s\n' "$rel" "$(printf '%s' "$rest" | sed -E 's/^ +//')" "$([ "$dirty" != "0" ] && printf '  DIRTY:%s' "$dirty")"
+done
+if [ -n "$(printf '%s' "$DEPLOYED_SHAS" | tr -d '\n ')" ]; then
+    echo "  deployed shas vs this repo:"
+    printf '%s\n' "$DEPLOYED_SHAS" | while read -r label full; do
+        [ -n "$full" ] || continue
+        short="${full:0:8}"
+        if ! git -C "$REPO_ROOT" cat-file -e "$full^{commit}" 2>/dev/null; then
+            warn "$label runs $short — commit unknown to this repo (unpushed on the host, or a branch this clone never fetched)"
+            continue
+        fi
+        counts="$(git -C "$REPO_ROOT" rev-list --left-right --count "origin/master...$full" 2>/dev/null)"
+        behind="${counts%%	*}"; ahead="${counts##*	}"
+        # Name the sha: the remote branch it is the tip of, else the
+        # branches that contain it (a merged commit), else nothing pushed.
+        tips="$(git -C "$REPO_ROOT" branch -r --points-at "$full" 2>/dev/null | grep -v 'HEAD ->' | sed -E 's/^ +//' | paste -sd, -)"
+        if [ -n "$tips" ]; then
+            where="tip of $tips"
+        else
+            holders="$(git -C "$REPO_ROOT" branch -r --contains "$full" 2>/dev/null | grep -v 'HEAD ->' | sed -E 's/^ +//')"
+            nh="$(printf '%s\n' "$holders" | grep -c .)"
+            first="$(printf '%s\n' "$holders" | grep -m1 -E 'origin/master$' || printf '%s\n' "$holders" | head -1)"
+            if [ "$nh" -eq 0 ]; then where="on no remote branch"
+            elif [ "$nh" -eq 1 ]; then where="contained in $first"
+            else where="contained in $first (+$((nh - 1)) more)"; fi
+        fi
+        local_wt="$(git -C "$REPO_ROOT" worktree list 2>/dev/null | awk -v s="${full:0:7}" -v root="$REPO_ROOT" '
+            index($2, s) == 1 { p = $1; if (p == root) p = "(this checkout)"; else sub("^" root "/", "", p); print p }' | paste -sd, -)"
+        if [ "$behind" = "0" ] && [ "$ahead" = "0" ]; then rel="= origin/master"
+        elif [ "$ahead" = "0" ]; then rel="$behind behind origin/master"
+        else rel="$ahead ahead, $behind behind origin/master"; fi
+        info "$label: $short  $rel  ($where)${local_wt:+  local worktree: $local_wt}"
+    done
+fi
+[ "$NET_UP" -eq 0 ] && [ "$LOCAL_ONLY" -eq 0 ] && echo "remote: UNKNOWN (network down) — rerun on the lab network for the deployed picture"
+exit 0

--- a/scripts/fleet_status.sh
+++ b/scripts/fleet_status.sh
@@ -11,7 +11,7 @@
 #   scripts/fleet_status.sh                       # full picture (needs the lab)
 #   scripts/fleet_status.sh --local-only          # just the local checkouts
 #   scripts/fleet_status.sh --no-ssh              # service self-reports only
-#   scripts/fleet_status.sh --ssh 192.168.6.14=geecs-gw   # ssh alias override
+#   scripts/fleet_status.sh --ssh 192.168.6.14=<alias>   # ssh alias override
 #   scripts/fleet_status.sh --experiment Undulator --no-fetch
 #   scripts/fleet_status.sh --summary             # one box table + attention list
 #   scripts/fleet_status.sh --watch 300           # dashboard pane: --summary every 300 s (--full for the log)

--- a/scripts/fleet_status.sh
+++ b/scripts/fleet_status.sh
@@ -13,6 +13,7 @@
 #   scripts/fleet_status.sh --no-ssh              # service self-reports only
 #   scripts/fleet_status.sh --ssh 192.168.6.14=geecs-gw   # ssh alias override
 #   scripts/fleet_status.sh --experiment Undulator --no-fetch
+#   scripts/fleet_status.sh --watch 300           # dashboard mode: rerun every 300 s
 #
 # Stages (each gated on the previous one):
 #   0. reachability — scripts/lab_status.sh tier 1 (the same gate /lab-status
@@ -46,18 +47,41 @@ EXPERIMENT=""
 DO_SSH=1
 DO_FETCH=1
 LOCAL_ONLY=0
+WATCH=0
 declare -a SSH_OVERRIDES=()
+ORIG_ARGS=("$@")
 while [ $# -gt 0 ]; do
     case "$1" in
+        --watch) shift; WATCH="${1:-300}" ;;
         --experiment) shift; EXPERIMENT="${1:-}" ;;
         --no-ssh) DO_SSH=0 ;;
         --no-fetch) DO_FETCH=0 ;;
         --local-only) LOCAL_ONLY=1 ;;
         --ssh) shift; SSH_OVERRIDES+=("${1:-}") ;;
-        *) echo "usage: fleet_status.sh [--experiment NAME] [--no-ssh] [--no-fetch] [--local-only] [--ssh IP=ALIAS]..." >&2; exit 2 ;;
+        *) echo "usage: fleet_status.sh [--experiment NAME] [--no-ssh] [--no-fetch] [--local-only] [--ssh IP=ALIAS]... [--watch SECS]" >&2; exit 2 ;;
     esac
     shift
 done
+
+# Dashboard mode: a persistent terminal pane (cmux/tmux) that reruns the
+# one-shot probe on an interval. No daemon, no state — the same read-only
+# run, redrawn. Ctrl-C ends it.
+if [ "$WATCH" != "0" ]; then
+    args=()
+    for a in "${ORIG_ARGS[@]+"${ORIG_ARGS[@]}"}"; do
+        case "$a" in --watch) skip_next=1; continue ;; esac
+        if [ "${skip_next:-0}" = "1" ]; then skip_next=0; continue; fi
+        args+=("$a")
+    done
+    while :; do
+        out="$("$0" "${args[@]+"${args[@]}"}" 2>&1)"
+        clear
+        echo "fleet status — $(date '+%F %H:%M:%S')  (every ${WATCH}s, Ctrl-C to stop)"
+        echo
+        printf '%s\n' "$out"
+        sleep "$WATCH"
+    done
+fi
 
 ini_get() {  # ini_get SECTION KEY — first match, trimmed
     awk -F'=' -v s="[$1]" -v k="$2" '

--- a/scripts/fleet_status.sh
+++ b/scripts/fleet_status.sh
@@ -57,7 +57,8 @@ declare -a SSH_OVERRIDES=()
 ORIG_ARGS=("$@")
 while [ $# -gt 0 ]; do
     case "$1" in
-        --watch) shift; WATCH="${1:-300}" ;;
+        --watch)  # optional numeric interval; a following flag is not the interval
+            case "${2:-}" in ''|-*) WATCH=300 ;; *[!0-9]*) echo "--watch wants a number of seconds, got '$2'" >&2; exit 2 ;; *) shift; WATCH="$1" ;; esac ;;
         --summary) SUMMARY=1 ;;
         --full) FULL=1 ;;
         --experiment) shift; EXPERIMENT="${1:-}" ;;
@@ -636,6 +637,8 @@ if [ "$SUMMARY" -eq 1 ]; then
     exec 1>&3
     if [ "$NET_UP" -eq 1 ]; then
         python3 "$REPO_ROOT/scripts/fleet_table.py" < "$REC_FILE"
+    elif [ "$LOCAL_ONLY" -eq 1 ]; then
+        sed -n '/^== Stage 3/,$p' "$LOG_FILE"   # local checkouts are the whole picture here
     else
         grep -E '^\s+\[(DOWN|WARN)\]' "$LOG_FILE" | head -6
         echo "  network: DOWN or partial — remote fleet state UNKNOWN (see --full)"

--- a/scripts/fleet_status.sh
+++ b/scripts/fleet_status.sh
@@ -6,7 +6,9 @@
 # feature-branch checkout, a checkout may have moved under a service that
 # was never restarted, or a pyproject bump may never have been installed —
 # none of which the doc can tell you. Every probe is bounded and read-only:
-# it never writes a PV, never restarts a unit, never pulls a checkout.
+# it never writes a PV, never restarts a unit, never pulls a checkout (the
+# one write is `git write-tree` in a clone with staged changes, which adds an
+# unreferenced tree object to that clone's object store — harmless, gc'd).
 #
 #   scripts/fleet_status.sh                       # full picture (needs the lab)
 #   scripts/fleet_status.sh --local-only          # just the local checkouts
@@ -165,10 +167,11 @@ ssh_target() {  # ssh_target IP — --ssh override, else ~/.ssh/config alias who
 }
 
 # Deployed shas found in stage 1/2, cross-referenced locally in stage 3.
-# Format per line: "<label><TAB><sha>" (labels contain spaces).
+# Format per line: "<role><TAB><sha><TAB><kind>" (kind: head = the clone's
+# HEAD, disk = the commit the files on disk match when they differ).
 DEPLOYED_SHAS=""
 note_sha() { DEPLOYED_SHAS="$DEPLOYED_SHAS
-$1	$2"; }
+$1	$2	$3"; }
 
 # ===========================================================================
 NET_UP=0
@@ -303,7 +306,7 @@ PY
 fi
 
 # ===========================================================================
-# Stage 2 runs this on each host. Output: one "svc=..." record per service
+# Stage 2 runs this on each host. Output: one "role=..." record per service
 # (key=value pairs, tab-separated), which the local side formats. Services
 # are discovered two ways and deduplicated by pid: systemd units (system AND
 # user scope — a dev-deployed daemon often lives in `systemctl --user`) and
@@ -329,14 +332,64 @@ reflog_ts() {  # unix time HEAD last moved (checkout/pull/reset), from the reflo
     local f; f="$(git -C "$1" rev-parse --git-path logs/HEAD 2>/dev/null)"
     [ -f "$f" ] && tail -1 "$f" | sed -E "s/^[0-9a-f]+ [0-9a-f]+ .*> ([0-9]+) [-+][0-9]{4}\t.*/\1/"
 }
-pkgdir_up() {  # nearest pyproject.toml at or above $1, not above the clone root $2
+pkgdir_up() {  # nearest pyproject.toml at or above $1, BELOW the clone root $2 (the root pyproject is the docs env, never a service)
     local d="$1"
-    while [ -n "$d" ] && [ "$d" != "/" ]; do
+    while [ -n "$d" ] && [ "$d" != "/" ] && [ "$d" != "$2" ]; do
         [ -f "$d/pyproject.toml" ] && { echo "$d"; return; }
-        [ "$d" = "$2" ] && return
         d="$(dirname "$d")"
     done
 }
+# Which distribution IS this process? From its own command line (-m module,
+# a console script, or the poetry import_module shim), resolved by the
+# interpreter that runs it — never by guessing from a directory. Prints
+# dist / installed version / source dir (direct_url) / editable yes|no.
+HELPER="$(mktemp)"; trap "rm -f $HELPER" EXIT
+cat > "$HELPER" <<"PYH"
+import importlib.metadata as m
+import json
+import os
+import re
+import sys
+
+pid = sys.argv[1]
+try:
+    raw = open("/proc/%s/cmdline" % pid, "rb").read()
+except OSError:
+    sys.exit(0)
+args = [a.decode(errors="replace") for a in raw.split(b"\0") if a]
+mod = None
+if "-m" in args and args.index("-m") + 1 < len(args):
+    mod = args[args.index("-m") + 1]
+elif "-c" in args and args.index("-c") + 1 < len(args):
+    mm = re.search(r"import_module\(.([\w.]+)", args[args.index("-c") + 1])
+    if mm:
+        mod = mm.group(1)
+dist = None
+if mod:
+    dist = (m.packages_distributions().get(mod.split(".")[0]) or [None])[0]
+elif len(args) > 1 and not args[1].startswith("-"):
+    name = os.path.basename(args[1])
+    for ep in m.entry_points(group="console_scripts"):
+        if ep.name == name:
+            dist = ep.dist.name
+            break
+if not dist:
+    sys.exit(0)
+d = m.distribution(dist)
+src = ""
+editable = "no"
+t = d.read_text("direct_url.json")
+if t:
+    j = json.loads(t)
+    url = j.get("url", "")
+    src = url[7:] if url.startswith("file://") else ""
+    if j.get("dir_info", {}).get("editable"):
+        editable = "yes"
+print(dist)
+print(d.version)
+print(src)
+print(editable)
+PYH
 emit() {  # emit ROLE NAME MANAGED STATE PID CWD PYEXE
     local role="$1" name="$2" managed="$3" state="$4" pid="$5" cwd="$6" pyexe="$7"
     local since="" since_ts="" clone="" pkgdir="" venv="" baked="" moved=""
@@ -348,15 +401,20 @@ emit() {  # emit ROLE NAME MANAGED STATE PID CWD PYEXE
     fi
     local rec="role=$role\tsvc=$name\tmanaged=$managed\tstate=$state\tsince=${since:-?}"
     [ -n "$cwd" ] && [ -d "$cwd" ] && clone="$(git -C "$cwd" rev-parse --show-toplevel 2>/dev/null)"
-    [ -n "$clone" ] && pkgdir="$(pkgdir_up "$cwd" "$clone")"
     case "$pyexe" in */bin/python*) venv="$(dirname "$(dirname "$pyexe")")";; esac
-    if [ -z "$clone" ] && [ -n "$venv" ] && [ -x "$venv/bin/python" ]; then
-        # Baked venv (MCP pattern): the non-editable install records its source path.
-        src="$("$venv/bin/python" -c "import importlib.metadata as m,json
-for d in m.distributions():
-    t=d.read_text(\"direct_url.json\")
-    if t and \"GEECS\" in t: print(json.loads(t)[\"url\"]); break" 2>/dev/null | sed "s|^file://||")"
-        if [ -n "$src" ] && [ -d "$src" ]; then pkgdir="$src"; clone="$(git -C "$src" rev-parse --show-toplevel 2>/dev/null)"; baked="$venv"; rec="$rec\tbaked=${venv/#$HOME/\~}"; fi
+    local h_dist="" h_ver="" h_src="" h_edit=""
+    if [ -n "$venv" ] && [ -x "$venv/bin/python" ] && [ -n "$pid" ] && [ -d "/proc/$pid" ]; then
+        { read -r h_dist; read -r h_ver; read -r h_src; read -r h_edit; } < <("$venv/bin/python" "$HELPER" "$pid" 2>/dev/null)
+    fi
+    if [ -n "$h_src" ] && [ -d "$h_src" ]; then
+        # The process names its own repo package (editable or baked install).
+        pkgdir="$h_src"
+        [ -z "$clone" ] && clone="$(git -C "$h_src" rev-parse --show-toplevel 2>/dev/null)"
+        if [ "$h_edit" = "no" ]; then baked="$venv"; rec="$rec\tbaked=${venv/#$HOME/\~}"; fi
+    elif [ -n "$clone" ]; then
+        # A third-party entry point (start-re-manager, the 0MQ proxy): the
+        # deployable is the repo package the process was launched from.
+        pkgdir="$(pkgdir_up "$cwd" "$clone")"
     fi
     if [ -n "$clone" ]; then
         local branch sha full cdate staged unstaged
@@ -368,16 +426,15 @@ for d in m.distributions():
         moved="$(reflog_ts "$clone")"
         rec="$rec\tclone=${clone/#$HOME/\~}\tbranch=$branch\tsha=$sha\tfull=$full\tcommit_date=$cdate\tstaged=$staged\tunstaged=$unstaged"
         if [ "$staged" != "0" ]; then
-            # HEAD can lie: a ref advanced without a checkout leaves the files
-            # on disk (= what actually runs) at an older commit. Name it.
-            local idx_tree c
+            # HEAD can lie: a ref advanced without a checkout (or a staged
+            # rollback) leaves the files on disk — what actually runs — at
+            # another commit. Name it if it is one (one git log, one awk).
+            local idx_tree match
             idx_tree="$(git -C "$clone" write-tree 2>/dev/null)"
-            for c in $(git -C "$clone" rev-list -400 --all 2>/dev/null); do
-                if [ "$(git -C "$clone" rev-parse "$c^{tree}" 2>/dev/null)" = "$idx_tree" ]; then
-                    rec="$rec\tdisk=$(git -C "$clone" rev-parse --short=8 "$c")\tdisk_full=$c\tdisk_date=$(git -C "$clone" log -1 --format=%cs "$c")"
-                    break
-                fi
-            done
+            match="$(git -C "$clone" log --all -400 --format="%H %cs %T" 2>/dev/null | awk -v t="$idx_tree" "\$3 == t {print \$1, \$2; exit}")"
+            if [ -n "$match" ]; then
+                rec="$rec\tdisk=${match:0:8}\tdisk_full=${match%% *}\tdisk_date=${match##* }"
+            fi
         fi
         if [ -z "${baked:-}" ] && [ -n "$moved" ] && [ -n "$since_ts" ] && [ "$moved" -gt "$since_ts" ]; then
             rec="$rec\tstale=checkout moved $(date -d @"$moved" "+%F %H:%M") after the process started"
@@ -440,6 +497,8 @@ fmt_host_records() {  # stdin: service records -> pretty lines; side effect: not
         case "$line" in
             nosystemd) skip "no systemd on this host"; continue ;;
             nounits) skip "no geecs-* / tiled units and nothing listening on the fleet ports"; continue ;;
+            role=*) ;;
+            *) info "ssh: $line"; continue ;;   # known-hosts notices, remote warnings — not records
         esac
         rec "$line"
         local role svc managed state since clone branch sha full cdate staged unstaged stale pkg pyproject installed baked pyexe disk disk_full disk_date
@@ -465,11 +524,10 @@ fmt_host_records() {  # stdin: service records -> pretty lines; side effect: not
             [ "${staged:-0}" != "0" ] && d="$d  STAGED: $staged file(s)"
             [ "${unstaged:-0}" != "0" ] && d="$d  UNSTAGED: $unstaged modified file(s)"
             info "$clone @ $branch $sha ($cdate)$d"
+            note_sha "${role:-$svc}" "$full" "head"
             if [ -n "$disk" ]; then
-                warn "$svc: files on disk are commit $disk ($disk_date), not HEAD $sha — the branch pointer moved without a checkout; what RUNS is $disk. Remedy: git reset --hard HEAD, then restart"
-                note_sha "${role:-$svc} (disk)" "$disk_full"
-            else
-                note_sha "${role:-$svc}" "$full"
+                warn "$svc: files on disk are commit $disk ($disk_date), not HEAD $sha — HEAD moved without a checkout, or a staged rollback is pending; what RUNS is $disk. Confirm which tree is intended before touching (skill: the STAGED/UNSTAGED row)"
+                note_sha "${role:-$svc}" "$disk_full" "disk"
             fi
         elif [ -n "$pyexe" ]; then
             info "no git clone behind this process (interpreter $pyexe)"
@@ -498,7 +556,7 @@ if [ "$NET_UP" -eq 1 ] && [ "$DO_SSH" -eq 1 ]; then
         echo "host $host (ssh $target)"
         out="$(printf '%s' "$REMOTE_SNIPPET" | bounded "$SSH_TIMEOUT" ssh -o BatchMode=yes -o ConnectTimeout=5 -o StrictHostKeyChecking=accept-new "$target" bash -s 2>&1)"
         rc=$?
-        if [ "$rc" -ne 0 ] && ! printf '%s' "$out" | grep -q '^svc='; then
+        if [ "$rc" -ne 0 ] && ! printf '%s' "$out" | grep -q '^role='; then
             bad "ssh $target failed (rc=$rc): $(printf '%s' "$out" | head -1)"
             rec "role=host $host	state=ok	runs=?	checkout=ssh failed	note=$(printf '%s' "$out" | head -1 | tr '\t' ' ')"
             info "no key-based access from here? pass --ssh $host=<alias> or run the stage-2 snippet on the host by hand"
@@ -536,9 +594,10 @@ git -C "$REPO_ROOT" worktree list 2>/dev/null | while IFS= read -r wl; do
 done
 if [ -n "$(printf '%s' "$DEPLOYED_SHAS" | tr -d '\n ')" ]; then
     echo "  deployed shas vs this repo:"
-    printf '%s\n' "$DEPLOYED_SHAS" | while IFS=$'\t' read -r label full; do
+    printf '%s\n' "$DEPLOYED_SHAS" | while IFS=$'\t' read -r role full kind; do
         [ -n "$full" ] || continue
         short="${full:0:8}"
+        label="$role"; [ "$kind" = "disk" ] && label="$role (files on disk)"
         if ! git -C "$REPO_ROOT" cat-file -e "$full^{commit}" 2>/dev/null; then
             warn "$label runs $short — commit unknown to this repo (unpushed on the host, or a branch this clone never fetched)"
             continue
@@ -564,7 +623,7 @@ if [ -n "$(printf '%s' "$DEPLOYED_SHAS" | tr -d '\n ')" ]; then
         elif [ "$ahead" = "0" ]; then rel="$behind behind origin/master"
         else rel="$ahead ahead, $behind behind origin/master"; fi
         info "$label: $short  $rel  ($where)${local_wt:+  local worktree: $local_wt}"
-        rec "role=$label	master_rel=$rel"
+        if [ "$kind" = "disk" ]; then rec "role=$role	disk_master_rel=$rel"; else rec "role=$role	master_rel=$rel"; fi
     done
 fi
 [ "$NET_UP" -eq 0 ] && [ "$LOCAL_ONLY" -eq 0 ] && echo "remote: UNKNOWN (network down) — rerun on the lab network for the deployed picture"

--- a/scripts/fleet_status.sh
+++ b/scripts/fleet_status.sh
@@ -407,9 +407,12 @@ emit() {  # emit ROLE NAME MANAGED STATE PID CWD PYEXE
         { read -r h_dist; read -r h_ver; read -r h_src; read -r h_edit; } < <("$venv/bin/python" "$HELPER" "$pid" 2>/dev/null)
     fi
     if [ -n "$h_src" ] && [ -d "$h_src" ]; then
-        # The process names its own repo package (editable or baked install).
+        # The process names its own repo package (editable or baked install);
+        # ITS clone is the truth, even if the process was launched from
+        # another checkout directory.
         pkgdir="$h_src"
-        [ -z "$clone" ] && clone="$(git -C "$h_src" rev-parse --show-toplevel 2>/dev/null)"
+        src_clone="$(git -C "$h_src" rev-parse --show-toplevel 2>/dev/null)"
+        [ -n "$src_clone" ] && clone="$src_clone"
         if [ "$h_edit" = "no" ]; then baked="$venv"; rec="$rec\tbaked=${venv/#$HOME/\~}"; fi
     elif [ -n "$clone" ]; then
         # A third-party entry point (start-re-manager, the 0MQ proxy): the
@@ -623,7 +626,8 @@ if [ -n "$(printf '%s' "$DEPLOYED_SHAS" | tr -d '\n ')" ]; then
         elif [ "$ahead" = "0" ]; then rel="$behind behind origin/master"
         else rel="$ahead ahead, $behind behind origin/master"; fi
         info "$label: $short  $rel  ($where)${local_wt:+  local worktree: $local_wt}"
-        if [ "$kind" = "disk" ]; then rec "role=$role	disk_master_rel=$rel"; else rec "role=$role	master_rel=$rel"; fi
+        # Keyed by sha so the table attaches the distance to the right process.
+        if [ "$kind" = "disk" ]; then rec "role=$role	for_sha=$short	disk_master_rel=$rel"; else rec "role=$role	for_sha=$short	master_rel=$rel"; fi
     done
 fi
 [ "$NET_UP" -eq 0 ] && [ "$LOCAL_ONLY" -eq 0 ] && echo "remote: UNKNOWN (network down) — rerun on the lab network for the deployed picture"

--- a/scripts/fleet_table.py
+++ b/scripts/fleet_table.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python3
+"""Render fleet_status.sh records as one box table (the dashboard view).
+
+Reads tab-separated ``key=value`` records on stdin — one line per probe
+result, each carrying a ``role=`` — merges them per service role, and
+prints a wrapped table plus an attention list. Stdlib only, so it runs
+under the system python3 from any terminal pane; ``scripts/fleet_status.sh
+--summary`` is the only caller.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import sys
+import textwrap
+
+# Display order for the roles fleet_status.sh emits; unknown roles append.
+ROLE_ORDER = [
+    "CA gateway",
+    "Tiled",
+    "Data Portal",
+    "Queueserver RE Manager",
+    "Bluesky doc proxy",
+    "Capture daemon",
+    "GEECS-MCP",
+    "PVA image gateways",
+]
+HEADERS = ["", "Service", "Runs as", "Checkout", "Version", "Notes"]
+
+
+def parse(lines: list[str]) -> dict[str, dict[str, str]]:
+    """Merge records by role; later keys never overwrite earlier non-empty ones."""
+    merged: dict[str, dict[str, str]] = {}
+    for line in lines:
+        line = line.rstrip("\n")
+        if not line:
+            continue
+        kv: dict[str, str] = {}
+        for part in line.split("\t"):
+            if "=" in part:
+                k, v = part.split("=", 1)
+                kv[k] = v
+        role = kv.get("role")
+        if not role:
+            continue
+        rec = merged.setdefault(role, {})
+        for k, v in kv.items():
+            if k == "note":
+                rec["notes"] = (rec.get("notes", "") + "|" + v).strip("|")
+            elif v and not rec.get(k):
+                rec[k] = v
+    return merged
+
+
+def runs_as(rec: dict[str, str]) -> str:
+    """Supervision label from stage-2 evidence, else the role's known shape."""
+    managed = rec.get("managed", "")
+    if managed == "UNMANAGED":
+        return "unmanaged"
+    if "(user unit)" in rec.get("svc", ""):
+        return "user unit"
+    if managed.startswith("systemd"):
+        return "systemd"
+    return rec.get("runs", "?")
+
+
+def checkout(rec: dict[str, str]) -> str:
+    """Clone @ branch sha, or the role's non-git provenance."""
+    if rec.get("clone"):
+        return f"{rec['clone']} {rec.get('branch', '')} {rec.get('sha', '')}".strip()
+    return rec.get("checkout", "—")
+
+
+def version(rec: dict[str, str]) -> str:
+    """Self-reported version first (what is running), else the venv's."""
+    ver = rec.get("version") or rec.get("installed") or rec.get("pyproject") or "?"
+    pkg = rec.get("pkg", "")
+    # Name the package when the role does not imply it (the Bluesky family).
+    if (
+        pkg
+        and pkg not in ("tiled",)
+        and rec.get("role")
+        in ("Capture daemon", "Queueserver RE Manager", "Bluesky doc proxy")
+    ):
+        return f"{pkg} {ver}"
+    return ver
+
+
+def notes(rec: dict[str, str]) -> list[str]:
+    """Everything that makes this row need attention, short form."""
+    out: list[str] = []
+    if rec.get("managed") == "UNMANAGED":
+        out.append("no systemd unit")
+    if rec.get("baked"):
+        out.append("baked venv")
+    staged, unstaged = rec.get("staged", "0"), rec.get("unstaged", "0")
+    if staged not in ("", "0"):
+        out.append(f"{staged} staged")
+    if unstaged not in ("", "0"):
+        out.append(f"{unstaged} unstaged")
+    inst, proj = rec.get("installed"), rec.get("pyproject")
+    if inst and proj and inst != proj:
+        out.append(f"venv {inst} ≠ pyproject {proj}")
+    if rec.get("stale"):
+        out.append(
+            "restart pending"
+            if "baked" not in rec.get("stale", "")
+            else "reinstall pending"
+        )
+    if rec.get("master_rel") and rec["master_rel"] != "= origin/master":
+        out.append(rec["master_rel"].replace(" origin/master", " master"))
+    if rec.get("notes"):
+        out.extend(n for n in rec["notes"].split("|") if n)
+    return out
+
+
+def glyph(rec: dict[str, str]) -> str:
+    """✗ down, ! needs attention, ✓ clean."""
+    state = rec.get("state", "")
+    if state.startswith(("down", "inactive", "failed")) or "DOWN" in state:
+        return "✗"
+    if state.startswith("absent"):
+        return "·"
+    return "!" if notes(rec) else "✓"
+
+
+def render(merged: dict[str, dict[str, str]], width: int) -> str:
+    """Box table sized to the terminal, columns wrapped, one service per row."""
+    roles = [r for r in ROLE_ORDER if r in merged] + sorted(
+        r for r in merged if r not in ROLE_ORDER
+    )
+    rows = []
+    for role in roles:
+        rec = merged[role]
+        rec.setdefault("role", role)
+        rows.append(
+            [
+                glyph(rec),
+                role,
+                runs_as(rec),
+                checkout(rec),
+                version(rec),
+                "; ".join(notes(rec)) or "—",
+            ]
+        )
+    # Column widths: fixed-ish for the first five, the notes column absorbs the rest.
+    fixed = [1, 12, 10, 24, 14]
+    borders = 3 * len(HEADERS) + 1
+    notes_w = max(12, width - sum(fixed) - borders)
+    widths = fixed + [notes_w]
+
+    def wrap_row(cells: list[str]) -> list[list[str]]:
+        wrapped = [textwrap.wrap(c, w) or [""] for c, w in zip(cells, widths)]
+        height = max(len(col) for col in wrapped)
+        return [
+            [col[i] if i < len(col) else "" for col in wrapped] for i in range(height)
+        ]
+
+    def line(left: str, mid: str, right: str) -> str:
+        return left + mid.join("─" * (w + 2) for w in widths) + right
+
+    def fmt(cells: list[str]) -> str:
+        return "│" + "│".join(f" {c:<{w}} " for c, w in zip(cells, widths)) + "│"
+
+    out = [line("┌", "┬", "┐"), fmt(HEADERS), line("├", "┼", "┤")]
+    for i, row in enumerate(rows):
+        for sub in wrap_row(row):
+            out.append(fmt(sub))
+        out.append(line("├", "┼", "┤") if i < len(rows) - 1 else line("└", "┴", "┘"))
+    return "\n".join(out)
+
+
+def main() -> int:
+    """Stdin records -> table on stdout."""
+    width = int(
+        os.environ.get("COLUMNS") or shutil.get_terminal_size((100, 24)).columns
+    )
+    merged = parse(sys.stdin.readlines())
+    if not merged:
+        print("(no fleet records — nothing reachable, or stages 1-2 did not run)")
+        return 0
+    print(render(merged, max(72, width)))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/fleet_table.py
+++ b/scripts/fleet_table.py
@@ -44,6 +44,7 @@ def parse(lines: list[str]) -> dict[str, dict[str, str]]:
     """
     base: dict[str, dict[str, str]] = {}
     procs: dict[str, list[dict[str, str]]] = {}
+    by_sha: dict[str, list[dict[str, str]]] = {}  # stage-3 distances, keyed by sha
     for line in lines:
         line = line.rstrip("\n")
         if not line:
@@ -58,6 +59,9 @@ def parse(lines: list[str]) -> dict[str, dict[str, str]]:
             continue
         if kv.get("svc"):
             procs.setdefault(role, []).append(kv)
+            continue
+        if kv.get("for_sha"):
+            by_sha.setdefault(role, []).append(kv)
             continue
         rec = base.setdefault(role, {})
         for k, v in kv.items():
@@ -79,8 +83,19 @@ def parse(lines: list[str]) -> dict[str, dict[str, str]]:
             for k, v in chosen.items():
                 if k == "note":
                     _add_note(rec, v)
+                elif k == "state":
+                    # The service's own verdict (stage 1) stays the verdict;
+                    # the process state is kept beside it for the glyph.
+                    rec["proc_state"] = v
+                    rec.setdefault("state", v)
                 elif v:
                     rec[k] = v  # the process's own facts win over role-level ones
+            # Stage-3 distances attach to the sha this process actually has.
+            for d in by_sha.get(role, []):
+                if d["for_sha"] in (chosen.get("sha", ""), chosen.get("disk", "")):
+                    for k in ("master_rel", "disk_master_rel"):
+                        if d.get(k):
+                            rec[k] = d[k]
             if len(plist) > 1:
                 others = "; ".join(
                     f"{p.get('svc', '?')} {p.get('state', '?')}"
@@ -88,6 +103,11 @@ def parse(lines: list[str]) -> dict[str, dict[str, str]]:
                     if p is not chosen
                 )
                 _add_note(rec, f"{len(plist)} processes for this role (also: {others})")
+        else:
+            for d in by_sha.get(role, []):
+                for k in ("master_rel", "disk_master_rel"):
+                    if d.get(k) and not rec.get(k):
+                        rec[k] = d[k]
         merged[role] = rec
     return merged
 
@@ -157,18 +177,28 @@ def notes(rec: dict[str, str]) -> list[str]:
         out.append(
             "disk " + rec["disk_master_rel"].replace(" origin/master", " master")
         )
+    proc = rec.get("proc_state", "")
+    if proc and not proc.startswith(("active/", "running")):
+        out.append(f"unit {proc}")
     if rec.get("notes"):
         out.extend(n for n in rec["notes"].split("|") if n)
     return out
 
 
 def glyph(rec: dict[str, str]) -> str:
-    """✗ down, ! needs attention, ✓ clean."""
+    """✗ down, ! needs attention, ✓ clean.
+
+    The stage-1 verdict (did the service answer?) decides ✗; a process
+    that is not active/running (crash-looping, dead unit) can never be ✓.
+    """
     state = rec.get("state", "")
+    proc = rec.get("proc_state", "")
     if state.startswith(("down", "inactive", "failed")) or "DOWN" in state:
         return "✗"
     if state.startswith("absent"):
         return "·"
+    if proc and not proc.startswith(("active/", "running")):
+        return "!"
     return "!" if notes(rec) else "✓"
 
 

--- a/scripts/fleet_table.py
+++ b/scripts/fleet_table.py
@@ -92,7 +92,11 @@ def parse(lines: list[str]) -> dict[str, dict[str, str]]:
                     rec[k] = v  # the process's own facts win over role-level ones
             # Stage-3 distances attach to the sha this process actually has.
             for d in by_sha.get(role, []):
-                if d["for_sha"] in (chosen.get("sha", ""), chosen.get("disk", "")):
+                # prefix match: --short=8 may return more digits when ambiguous
+                if any(
+                    x and x.startswith(d["for_sha"])
+                    for x in (chosen.get("sha", ""), chosen.get("disk", ""))
+                ):
                     for k in ("master_rel", "disk_master_rel"):
                         if d.get(k):
                             rec[k] = d[k]

--- a/scripts/fleet_table.py
+++ b/scripts/fleet_table.py
@@ -29,9 +29,21 @@ ROLE_ORDER = [
 HEADERS = ["", "Service", "Runs as", "Checkout", "Version", "Notes"]
 
 
+def _add_note(rec: dict[str, str], text: str) -> None:
+    rec["notes"] = (rec.get("notes", "") + "|" + text).strip("|")
+
+
 def parse(lines: list[str]) -> dict[str, dict[str, str]]:
-    """Merge records by role; later keys never overwrite earlier non-empty ones."""
-    merged: dict[str, dict[str, str]] = {}
+    """Merge records by role.
+
+    Stage-1/3 records (no ``svc=``) describe the role and merge first-wins.
+    Stage-2 records (``svc=``) each describe ONE process; a role can have
+    several (a loaded-but-dead unit plus the hand-started process that
+    really owns the port). The row is the live one; the others are named
+    in a note, and no field is ever combined across two processes.
+    """
+    base: dict[str, dict[str, str]] = {}
+    procs: dict[str, list[dict[str, str]]] = {}
     for line in lines:
         line = line.rstrip("\n")
         if not line:
@@ -44,12 +56,39 @@ def parse(lines: list[str]) -> dict[str, dict[str, str]]:
         role = kv.get("role")
         if not role:
             continue
-        rec = merged.setdefault(role, {})
+        if kv.get("svc"):
+            procs.setdefault(role, []).append(kv)
+            continue
+        rec = base.setdefault(role, {})
         for k, v in kv.items():
             if k == "note":
-                rec["notes"] = (rec.get("notes", "") + "|" + v).strip("|")
+                _add_note(rec, v)
             elif v and not rec.get(k):
                 rec[k] = v
+    merged: dict[str, dict[str, str]] = {}
+    for role in list(base) + [r for r in procs if r not in base]:
+        rec = dict(base.get(role, {}))
+        plist = procs.get(role, [])
+        if plist:
+            live = [
+                p
+                for p in plist
+                if p.get("state", "").startswith(("active/", "running"))
+            ]
+            chosen = (live or plist)[0]
+            for k, v in chosen.items():
+                if k == "note":
+                    _add_note(rec, v)
+                elif v:
+                    rec[k] = v  # the process's own facts win over role-level ones
+            if len(plist) > 1:
+                others = "; ".join(
+                    f"{p.get('svc', '?')} {p.get('state', '?')}"
+                    for p in plist
+                    if p is not chosen
+                )
+                _add_note(rec, f"{len(plist)} processes for this role (also: {others})")
+        merged[role] = rec
     return merged
 
 
@@ -114,6 +153,10 @@ def notes(rec: dict[str, str]) -> list[str]:
         )
     if rec.get("master_rel") and rec["master_rel"] != "= origin/master":
         out.append(rec["master_rel"].replace(" origin/master", " master"))
+    if rec.get("disk_master_rel"):
+        out.append(
+            "disk " + rec["disk_master_rel"].replace(" origin/master", " master")
+        )
     if rec.get("notes"):
         out.extend(n for n in rec["notes"].split("|") if n)
     return out

--- a/scripts/fleet_table.py
+++ b/scripts/fleet_table.py
@@ -68,6 +68,8 @@ def runs_as(rec: dict[str, str]) -> str:
 def checkout(rec: dict[str, str]) -> str:
     """Clone @ branch sha, or the role's non-git provenance."""
     if rec.get("clone"):
+        if rec.get("disk"):
+            return f"{rec['clone']} DISK={rec['disk']} (HEAD {rec.get('sha', '')} {rec.get('branch', '')})"
         return f"{rec['clone']} {rec.get('branch', '')} {rec.get('sha', '')}".strip()
     return rec.get("checkout", "—")
 
@@ -94,6 +96,8 @@ def notes(rec: dict[str, str]) -> list[str]:
         out.append("no systemd unit")
     if rec.get("baked"):
         out.append("baked venv")
+    if rec.get("disk"):
+        out.append(f"disk ≠ HEAD ({rec.get('disk_date', '')})")
     staged, unstaged = rec.get("staged", "0"), rec.get("unstaged", "0")
     if staged not in ("", "0"):
         out.append(f"{staged} staged")


### PR DESCRIPTION
## What

A repo skill + script that reports what the fleet is **actually running**, as opposed to the fleet map's intended picture: for every service on every host, which checkout it runs from, which branch/commit and package version, whether the running process matches the code on disk, and how each deployed commit relates to `origin/master` and the local worktrees. Gated on `/lab-status` tier 1 first (per owner request); read-only and bounded throughout — no PV writes, no restarts, no pulls.

- `scripts/fleet_status.sh` — four stages: (0) `lab_status.sh` reachability gate; (1) each service's self-report over its own protocol (Tiled HTTP, portal `/health`, queueserver/MCP ports, CA gateway identity PVs via `lab_status.sh --hardware`, PVA fleet `version`/`heartbeat` PVs from the checked-in Phoebus roster); (2) per-host ssh discovery — system **and user** systemd units plus **whoever owns each fleet port** (a hand-started queueserver has no unit and must still show), mapped to its clone via cwd (or the baked venv's `direct_url` for the MCP pattern) → branch/sha/staged/unstaged, pyproject-vs-installed version, "checkout moved after the process started", and **"files on disk = commit X, not HEAD"** (tree-hash search — HEAD can lie when a ref advances without a checkout); (3) local cross-reference (fetch, worktrees, branch tip/containment, distance from master). `--summary` renders one box table + attention list; `--watch SECS` makes a terminal pane the dashboard; `--full` keeps the log.
- `scripts/fleet_table.py` — stdlib-only renderer for the summary table (reads the tab-separated `role=` records the script emits).
- `.claude/skills/fleet-status/SKILL.md` — when to use it, what each stage proves, the warnings-to-act-on table, reporting + boundaries.
- Cross-references: fleet map intro (intended vs observed), skills overview row, root `CLAUDE.md` skill inventory, `CONTRIBUTING.md`, `/lab-status` pointer.

Hosts/aliases come from `config.ini` (`[tiled] uri`, `[qserver] host`) and `~/.ssh/config` HostName matching — nothing lab-specific is committed beyond the fleet map's port numbers and the existing `.bob` roster.

## Why

During rapid development hosts run feature-branch checkouts for live checks, checkouts get pulled under running services, and version bumps land without reinstall; the fleet map cannot show any of that. First live run found: RE Manager / doc proxy / MCP hand-started with no unit, the capture daemon as a `--user` unit, and the gateway clone's working tree three weeks older than its HEAD pointer (fixed on the host today). Those findings drive the follow-on plan in #775.

## LOC by concern

| Concern | Files | LOC |
|---|---|---|
| Probe script | `scripts/fleet_status.sh` | +589 |
| Table renderer | `scripts/fleet_table.py` | +192 |
| Skill | `.claude/skills/fleet-status/SKILL.md` | +130 |
| Cross-references | fleet_map, skills overview, CLAUDE.md, CONTRIBUTING.md, lab-status skill | +17 / −7 |

No package code changed → no version bumps.

## Tests

`./scripts/check.sh --base origin/master`: lint clean (ruff, ruff-format, pydocstyle, pre-commit hooks); no package suites implied by the diff (repo-level `scripts/` + skills + docs). Offline paths exercised (network-down → local picture only, `--local-only`), plus a stubbed end-to-end run (fake lab_status/ssh/gateway) for stages 1–3 formatting.

## Hardware verification

**Live on the lab network 2026-09-03**, full run ~18 s: stage 1 reported Tiled 0.2.14, portal 0.20.0, CA gateway 0.20.0 with 98→99 devices, 9 PVA gateways at 0.4.4 (4 roster hosts unreachable); stage 2 found all 7 services on the host (3 UNMANAGED, 1 user unit) with correct clones/versions; the disk≠HEAD detection named the gateway clone's real tree (9c9681de vs HEAD 28749780) — confirmed by hand, reset, gateway restarted, row now clean. Dashboard pane running `--watch 300` since this afternoon.

Judgment-call additions (cheap to veto): `--watch`/`--summary`/`fleet_table.py` were added on request during the session rather than in the original brief; the disk-vs-HEAD tree search (`rev-list -400 --all` per dirty clone) is the one probe that costs more than a few ms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N8myqX2WHYm38s14FBwn8E