### PR TITLE
scripts/commit.sh: skip staged deletions in the re-stage loop (#761)

### DIFF
--- a/scripts/commit.sh
+++ b/scripts/commit.sh
@@ -32,7 +32,7 @@ set -euo pipefail
 # Run from the repo root, wherever the script was invoked from. This pins
 # `poetry` below to the ROOT env (a package cwd would resolve that package's
 # env instead), and makes the root-relative paths that `git diff --cached
-# --name-only` emits line up with the `git add` in the re-staging loop —
+# --name-status` emits line up with the `git add` in the re-staging loop —
 # which silently re-staged nothing when invoked from a subdirectory.
 # Consequence: any pathspec args you pass through to `git commit` are
 # interpreted relative to the repo root, not your shell's cwd.
@@ -101,6 +101,8 @@ pc run || true
 # matched by .gitignore): the path exists, so an existence test would pass it
 # to `git add`, which refuses ignored paths ("Use -f if you really want to add
 # them") and, under set -e, aborted the script before `git commit` (#761).
+# Worse, when the untracked file was NOT ignored, `git add` silently re-added
+# it: the commit went through with the user's staged untracking reverted.
 # The existence test stays as a second guard: a staged add/modify whose file
 # was since removed from the worktree would otherwise be turned into a
 # deletion by `git add` — something the user never staged.

--- a/scripts/commit.sh
+++ b/scripts/commit.sh
@@ -40,11 +40,14 @@ REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$REPO_ROOT"
 
 # The files staged for this commit, recorded NUL-delimited in a temp file
-# (space-safe; bash variables cannot hold NUL, so a file — not a var).
+# as <status>\0<path>\0 pairs (space-safe; bash variables cannot hold NUL, so
+# a file — not a var). --no-renames keeps every record a pair: a detected
+# rename would otherwise emit three fields (R<score>, src, dst), and
+# splitting it into D src + A dst is exactly the shape the loop below wants.
 staged="$(mktemp)"
 existing="$(mktemp)"
 trap 'rm -f "$staged" "$existing"' EXIT
-git diff --cached --name-only -z >"$staged"
+git diff --cached --name-status --no-renames -z >"$staged"
 if [ ! -s "$staged" ]; then
     echo "commit.sh: nothing staged — 'git add' your changes first." >&2
     exit 1
@@ -91,11 +94,18 @@ fi
 pc run || true
 
 # Re-stage exactly the originally-staged files so the fixes are included —
-# but only those that still exist on disk. A staged *deletion* is in neither
-# the index nor the worktree, so `git add` (even with -A) rejects its pathspec
-# as fatal; and there is nothing to re-stage anyway, since no hook can have
-# rewritten a file that does not exist. The deletion stays staged as-is.
-while IFS= read -r -d '' path; do
+# except staged *deletions* (index status D), which have nothing to re-stage:
+# no hook can have rewritten a file the commit removes, and the deletion stays
+# staged as-is. Filtering on the index status rather than on-disk existence
+# matters for `git rm --cached` (untracking a file that stays on disk, now
+# matched by .gitignore): the path exists, so an existence test would pass it
+# to `git add`, which refuses ignored paths ("Use -f if you really want to add
+# them") and, under set -e, aborted the script before `git commit` (#761).
+# The existence test stays as a second guard: a staged add/modify whose file
+# was since removed from the worktree would otherwise be turned into a
+# deletion by `git add` — something the user never staged.
+while IFS= read -r -d '' status && IFS= read -r -d '' path; do
+    case "$status" in D*) continue ;; esac
     if [ -e "$path" ] || [ -L "$path" ]; then
         printf '%s\0' "$path"
     fi

--- a/tests/test_commit_sh.py
+++ b/tests/test_commit_sh.py
@@ -15,16 +15,26 @@ import os
 import shutil
 import stat
 import subprocess
+import sys
 from pathlib import Path
 
 import pytest
 
+# The script is bash and the harness stubs are bash shebang scripts; on a
+# Windows dev host this is a skip, not a failure (CI runs root tests/ on Linux).
+pytestmark = pytest.mark.skipif(
+    sys.platform == "win32" or shutil.which("bash") is None,
+    reason="commit.sh and its test harness need bash",
+)
+
 REPO_ROOT = Path(__file__).resolve().parents[1]
 COMMIT_SH = REPO_ROOT / "scripts" / "commit.sh"
 
-# What the stub pre-commit appends to keep.txt, standing in for a real
-# auto-fixing hook (ruff-format, end-of-file-fixer) rewriting a staged file.
+# What the stub pre-commit appends to each of HOOK_TARGETS that exists,
+# standing in for a real auto-fixing hook (ruff-format, end-of-file-fixer)
+# rewriting a staged file.
 HOOK_SUFFIX = "rewritten-by-hook\n"
+HOOK_TARGETS = ("keep.txt", "new.txt")
 
 
 def _write_executable(path: Path, body: str) -> None:
@@ -39,9 +49,9 @@ def repo(tmp_path: Path) -> tuple[Path, dict[str, str]]:
     Layout after the fixture: ``keep.txt`` and ``vendor/blob.txt`` are
     tracked and committed; ``scripts/commit.sh`` is a copy of the real one
     (untracked — irrelevant to the scenarios); ``stubbin/`` holds a
-    ``pre-commit`` that appends :data:`HOOK_SUFFIX` to ``keep.txt`` and a
-    ``poetry`` that fails, which steers the script's runner selection onto
-    the stub pre-commit.
+    ``pre-commit`` that appends :data:`HOOK_SUFFIX` to each existing
+    :data:`HOOK_TARGETS` file and a ``poetry`` that fails, which steers the
+    script's runner selection onto the stub pre-commit.
     """
     work = tmp_path / "work"
     (work / "scripts").mkdir(parents=True)
@@ -53,7 +63,9 @@ def repo(tmp_path: Path) -> tuple[Path, dict[str, str]]:
         stubbin / "pre-commit",
         "#!/usr/bin/env bash\n"
         # `pre-commit run` is invoked from the repo root; mimic a fixer.
-        f'if [ -f keep.txt ]; then printf "%s" "{HOOK_SUFFIX}" >> keep.txt; fi\n'
+        f"for f in {' '.join(HOOK_TARGETS)}; do\n"
+        f'    if [ -f "$f" ]; then printf "%s" "{HOOK_SUFFIX}" >> "$f"; fi\n'
+        "done\n"
         "exit 0\n",
     )
     _write_executable(stubbin / "poetry", "#!/usr/bin/env bash\nexit 1\n")
@@ -72,22 +84,12 @@ def repo(tmp_path: Path) -> tuple[Path, dict[str, str]]:
     }
     env.pop("SKIP", None)
 
-    def git(*args: str) -> str:
-        return subprocess.run(
-            ["git", *args],
-            cwd=work,
-            env=env,
-            check=True,
-            capture_output=True,
-            text=True,
-        ).stdout
-
-    git("init", "-q", "-b", "main")
+    _git(work, env, "init", "-q", "-b", "main")
     (work / "keep.txt").write_text("keep\n", encoding="utf-8")
     (work / "vendor").mkdir()
     (work / "vendor" / "blob.txt").write_text("vendored\n", encoding="utf-8")
-    git("add", "keep.txt", "vendor/blob.txt")
-    git("commit", "-q", "-m", "seed")
+    _git(work, env, "add", "keep.txt", "vendor/blob.txt")
+    _git(work, env, "commit", "-q", "-m", "seed")
     return work, env
 
 
@@ -153,3 +155,52 @@ def test_staged_deletion_of_removed_file_commits(repo):
     assert _git(work, env, "rev-parse", "HEAD").strip() != before
     assert "vendor/blob.txt" not in _git(work, env, "ls-files").split()
     assert not (work / "vendor" / "blob.txt").exists()
+
+
+def test_staged_untrack_of_unignored_file_is_not_silently_reverted(repo):
+    """``git rm --cached`` of a file that stays on disk and is NOT ignored.
+
+    Before keying on the index status, ``git add`` accepted the still-present
+    path and re-added it — the commit went through with the user's staged
+    untracking silently reverted.
+    """
+    work, env = repo
+    before = _git(work, env, "rev-parse", "HEAD").strip()
+
+    _git(work, env, "rm", "-q", "--cached", "vendor/blob.txt")
+    (work / "keep.txt").write_text("keep\nedited\n", encoding="utf-8")
+    _git(work, env, "add", "keep.txt")
+
+    result = _run_commit_sh(work, env, "-q", "-m", "untrack vendor blob")
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert _git(work, env, "rev-parse", "HEAD").strip() != before
+    assert "vendor/blob.txt" not in _git(work, env, "ls-files").split()
+    assert (work / "vendor" / "blob.txt").exists()
+    assert _git(work, env, "show", "HEAD:keep.txt") == "keep\nedited\n" + HOOK_SUFFIX
+
+
+def test_staged_rename_re_stages_the_destination(repo):
+    """A staged ``git mv`` must not desynchronise the status/path pairing.
+
+    With rename detection on, ``--name-status`` emits three fields for a
+    rename (``R100``, src, dst); the loop reads pairs, so the destination —
+    and every record after it — would be skipped or mis-read and the hook's
+    fix to it dropped. ``--no-renames`` splits it into ``D src`` + ``A dst``.
+    """
+    work, env = repo
+    before = _git(work, env, "rev-parse", "HEAD").strip()
+
+    _git(work, env, "mv", "keep.txt", "new.txt")
+    (work / "zed.txt").write_text("z\n", encoding="utf-8")
+    _git(work, env, "add", "zed.txt")
+
+    result = _run_commit_sh(work, env, "-q", "-m", "rename keep")
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert _git(work, env, "rev-parse", "HEAD").strip() != before
+    tracked = _git(work, env, "ls-files").split()
+    assert "keep.txt" not in tracked
+    assert "new.txt" in tracked and "zed.txt" in tracked
+    assert _git(work, env, "show", "HEAD:new.txt") == "keep\n" + HOOK_SUFFIX
+    assert _git(work, env, "status", "--porcelain", "--untracked-files=no") == ""

--- a/tests/test_commit_sh.py
+++ b/tests/test_commit_sh.py
@@ -1,0 +1,155 @@
+"""Pin ``scripts/commit.sh``'s re-stage loop against a throwaway git repo.
+
+The script commits with pre-commit's auto-fixes applied first, then re-stages
+the originally staged files. Its failure mode is silent: ``set -e`` aborts
+before ``git commit`` and the output tail looks like a normal hook run, so
+HEAD not advancing is only noticed later. These tests drive the script end
+to end in a temporary repository (a copy of the script lives inside it,
+because the script ``cd``s to its own ``../``), with ``pre-commit`` and
+``poetry`` replaced by stubs on PATH so nothing depends on the host toolchain.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import stat
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+COMMIT_SH = REPO_ROOT / "scripts" / "commit.sh"
+
+# What the stub pre-commit appends to keep.txt, standing in for a real
+# auto-fixing hook (ruff-format, end-of-file-fixer) rewriting a staged file.
+HOOK_SUFFIX = "rewritten-by-hook\n"
+
+
+def _write_executable(path: Path, body: str) -> None:
+    path.write_text(body, encoding="utf-8")
+    path.chmod(path.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+
+
+@pytest.fixture
+def repo(tmp_path: Path) -> tuple[Path, dict[str, str]]:
+    """A git repo holding a copy of commit.sh, plus the env to run it in.
+
+    Layout after the fixture: ``keep.txt`` and ``vendor/blob.txt`` are
+    tracked and committed; ``scripts/commit.sh`` is a copy of the real one
+    (untracked — irrelevant to the scenarios); ``stubbin/`` holds a
+    ``pre-commit`` that appends :data:`HOOK_SUFFIX` to ``keep.txt`` and a
+    ``poetry`` that fails, which steers the script's runner selection onto
+    the stub pre-commit.
+    """
+    work = tmp_path / "work"
+    (work / "scripts").mkdir(parents=True)
+    shutil.copy(COMMIT_SH, work / "scripts" / "commit.sh")
+
+    stubbin = tmp_path / "stubbin"
+    stubbin.mkdir()
+    _write_executable(
+        stubbin / "pre-commit",
+        "#!/usr/bin/env bash\n"
+        # `pre-commit run` is invoked from the repo root; mimic a fixer.
+        f'if [ -f keep.txt ]; then printf "%s" "{HOOK_SUFFIX}" >> keep.txt; fi\n'
+        "exit 0\n",
+    )
+    _write_executable(stubbin / "poetry", "#!/usr/bin/env bash\nexit 1\n")
+
+    env = {
+        **os.environ,
+        "PATH": f"{stubbin}{os.pathsep}{os.environ.get('PATH', '')}",
+        # Isolate from the developer's global git config (hooks, signing,
+        # default branch) — the tmp repo must behave the same everywhere.
+        "GIT_CONFIG_GLOBAL": os.devnull,
+        "GIT_CONFIG_NOSYSTEM": "1",
+        "GIT_AUTHOR_NAME": "commit.sh test",
+        "GIT_AUTHOR_EMAIL": "test@example.invalid",
+        "GIT_COMMITTER_NAME": "commit.sh test",
+        "GIT_COMMITTER_EMAIL": "test@example.invalid",
+    }
+    env.pop("SKIP", None)
+
+    def git(*args: str) -> str:
+        return subprocess.run(
+            ["git", *args],
+            cwd=work,
+            env=env,
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout
+
+    git("init", "-q", "-b", "main")
+    (work / "keep.txt").write_text("keep\n", encoding="utf-8")
+    (work / "vendor").mkdir()
+    (work / "vendor" / "blob.txt").write_text("vendored\n", encoding="utf-8")
+    git("add", "keep.txt", "vendor/blob.txt")
+    git("commit", "-q", "-m", "seed")
+    return work, env
+
+
+def _run_commit_sh(
+    work: Path, env: dict[str, str], *args: str
+) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["bash", "scripts/commit.sh", *args],
+        cwd=work,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _git(work: Path, env: dict[str, str], *args: str) -> str:
+    return subprocess.run(
+        ["git", *args], cwd=work, env=env, check=True, capture_output=True, text=True
+    ).stdout
+
+
+def test_staged_untrack_of_ignored_file_still_on_disk_commits(repo):
+    """#761: ``git rm --cached`` of a now-ignored, still-present file.
+
+    The staged deletion exists on disk and is matched by .gitignore, so
+    re-staging it through ``git add`` is refused ("Use -f if you really want
+    to add them") and ``set -e`` used to abort before ``git commit``.
+    """
+    work, env = repo
+    before = _git(work, env, "rev-parse", "HEAD").strip()
+
+    (work / ".gitignore").write_text("vendor/\n", encoding="utf-8")
+    (work / "keep.txt").write_text("keep\nedited\n", encoding="utf-8")
+    _git(work, env, "add", ".gitignore", "keep.txt")
+    _git(work, env, "rm", "-r", "-q", "--cached", "vendor")
+
+    result = _run_commit_sh(work, env, "-q", "-m", "untrack vendor")
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    after = _git(work, env, "rev-parse", "HEAD").strip()
+    assert after != before, "HEAD did not advance"
+    tracked = _git(work, env, "ls-files").split()
+    assert "vendor/blob.txt" not in tracked
+    assert ".gitignore" in tracked
+    assert (work / "vendor" / "blob.txt").exists(), "untracking must not touch the disk"
+    # The other staged file was re-staged after the hook rewrote it, so the
+    # commit carries the auto-fix (the script's whole purpose).
+    committed = _git(work, env, "show", "HEAD:keep.txt")
+    assert committed == "keep\nedited\n" + HOOK_SUFFIX
+    assert _git(work, env, "status", "--porcelain", "--untracked-files=no") == ""
+
+
+def test_staged_deletion_of_removed_file_commits(repo):
+    """A plain ``git rm`` (file gone from disk) is skipped by the loop too."""
+    work, env = repo
+    before = _git(work, env, "rev-parse", "HEAD").strip()
+
+    _git(work, env, "rm", "-q", "vendor/blob.txt")
+
+    result = _run_commit_sh(work, env, "-q", "-m", "delete vendor")
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert _git(work, env, "rev-parse", "HEAD").strip() != before
+    assert "vendor/blob.txt" not in _git(work, env, "ls-files").split()
+    assert not (work / "vendor" / "blob.txt").exists()


### PR DESCRIPTION
## What

`scripts/commit.sh`'s re-stage loop now filters on the **index status** of each staged path (`git diff --cached --name-status --no-renames -z`) and skips status `D` outright, instead of relying only on whether the path still exists on disk.

Pinning test: `tests/test_commit_sh.py` (root `tests/`, unmarked, so CI's root step runs it) drives the script end to end in a throwaway git repo — a copy of the script inside the repo (it `cd`s to its own `../`), a stub `pre-commit` on PATH that rewrites staged files like a real fixer would, and a stub `poetry` that fails so runner selection lands on the stub. Four cases: the #761 shape (`git rm --cached` of a now-ignored file that stays on disk), the same untrack of a *non*-ignored file (which the old loop silently re-added — see below), the plain `git rm` shape, and a staged `git mv` + a following staged edit (pins `--no-renames`: without it the three-field rename record desynchronises the status/path pairing and the fixer's rewrite of the destination and every later path is dropped).

## Why

The loop kept every staged path that exists on disk and handed it to `git add --`. A deletion staged with `git rm --cached` of a file that stays on disk and is now matched by `.gitignore` therefore reached `git add`, which refuses ignored paths ("Use -f if you really want to add them"), and `set -e` aborted before `git commit` — HEAD did not advance while the output tail looked like a normal hook run. Hit while landing #759.

The review surfaced a quieter variant of the same bug: when the untracked file was **not** ignored, `git add` accepted it and silently re-added it — the commit went through with the user's staged untracking reverted. Keying on the index status fixes both.

`--no-renames` keeps every record a `<status>\0<path>\0` pair (a detected rename would emit three fields); a rename then shows as `D src` + `A dst`, which is exactly the shape the loop wants. The on-disk existence test stays as a second guard (a staged add/modify whose file was since removed would otherwise be turned into a deletion by `git add`) — flagging that as a judgment call, cheap to drop.

## Scope

Tooling only (`scripts/` + root `tests/`) — no package code changed, so no version bump / CHANGELOG. No hardware surface.

- `scripts/commit.sh`: +20 / -8
- `tests/test_commit_sh.py`: +206 (new)

## Tests

Tooling only — no hardware verification applies.

- `./scripts/check.sh` (lint + root-tests) at c7820da5: **6 passed, 62 deselected** (4 of them `test_commit_sh.py`); lint clean.
- Mutation-checked locally: against the unfixed `master` script the #761 test fails (`git add` refusal → non-zero exit); removing the `D` skip fails both untrack tests (2 failed); removing `--no-renames` fails the rename test (1 failed).
- `./scripts/check.sh --all` at 558f7006 (root-env layer, the one this diff can affect): root-tests **4 passed, 62 deselected** (6 at c7820da5, above); ImageAnalysis **250 passed, 1 skipped, 10 deselected**; ScanAnalysis **213 passed, 1 skipped, 11 deselected**; GEECS-Data-Utils **325 passed, 3 skipped**; GEECS-Schemas **286 passed, 6 deselected**; `pre-commit run --all-files` clean.
- The eight own-env suites (GeecsBluesky, GeecsCAGateway, GeecsPvaGateway, GEECS-Console, GEECS-Core, GEECS-DataPortal, GEECS-LogTriage, GEECS-MCP) errored at collection with `ModuleNotFoundError` for their own deps — the fresh worktree has no per-package venvs (env-shaped per /env-doctor, not code). This diff touches none of those packages; CI runs each from its own installed env and is the authoritative result for them.

Closes #761
