### PR TITLE
bootstrap_host.sh: detect a linked git worktree posing as a service clone

### DIFF
--- a/deploy/bootstrap_host.sh
+++ b/deploy/bootstrap_host.sh
@@ -82,7 +82,18 @@ echo "  git $(git --version 2>/dev/null | awk '{print $3}'), $(python3.11 --vers
 say "clones (one per service family, at $REF)"
 for c in $(for s in $SERVICES; do wanted "$s" && clone_of "$s"; done | sort -u); do
     dir="$GEECS_CHECKOUT_ROOT/$c"
-    if [ -d "$dir/.git" ]; then
+    if [ -e "$dir/.git" ]; then
+        gitdir="$(git -C "$dir" rev-parse --git-dir 2>/dev/null || true)"
+        common="$(git -C "$dir" rev-parse --git-common-dir 2>/dev/null || true)"
+        if [ -n "$gitdir" ] && [ "$gitdir" != "$common" ]; then
+            # A linked worktree shares its object store AND its branch refs with
+            # another clone: `git pull` here advances that clone's branch pointer
+            # without touching its files (the 2026-09-03 gateway disk≠HEAD
+            # incident). Not a clone of its own — replace it in a maintenance
+            # window: stop its services, mv it aside, clone, poetry install.
+            echo "  $c: WARNING — linked worktree of $(cd "$dir" && cd "$common/.." && pwd), not a clone of its own; left untouched (see the site profile page)"
+            continue
+        fi
         echo "  $c: exists ($(git -C "$dir" rev-parse --abbrev-ref HEAD) $(git -C "$dir" rev-parse --short=8 HEAD)) — fetching, NOT moving HEAD (a pull is a deploy; do it per service, deliberately)"
         run git -C "$dir" fetch --quiet origin
     else

--- a/deploy/bootstrap_host.sh
+++ b/deploy/bootstrap_host.sh
@@ -80,21 +80,33 @@ echo "  git $(git --version 2>/dev/null | awk '{print $3}'), $(python3.11 --vers
 [ -d "$GEECS_CONFIGS_ROOT" ] && echo "  configs repo at $GEECS_CONFIGS_ROOT" || echo "  WARNING: configs repo not at $GEECS_CONFIGS_ROOT"
 
 say "clones (one per service family, at $REF)"
+# Clone dirs that are NOT usable clones are recorded here; every later stage
+# (environments, units, root steps) skips their services, so the run cannot
+# end with a clean tail after a warning scrolled off the top.
+SKIP_CLONES=" "
+skipped_clone() { case "$SKIP_CLONES" in *" $1 "*) return 0;; *) return 1;; esac; }
 for c in $(for s in $SERVICES; do wanted "$s" && clone_of "$s"; done | sort -u); do
     dir="$GEECS_CHECKOUT_ROOT/$c"
     if [ -e "$dir/.git" ]; then
         gitdir="$(git -C "$dir" rev-parse --git-dir 2>/dev/null || true)"
         common="$(git -C "$dir" rev-parse --git-common-dir 2>/dev/null || true)"
-        if [ -n "$gitdir" ] && [ "$gitdir" != "$common" ]; then
-            # A linked worktree shares its object store AND its branch refs with
-            # another clone: `git pull` here advances that clone's branch pointer
-            # without touching its files (the 2026-09-03 gateway disk≠HEAD
-            # incident). Not a clone of its own — replace it in a maintenance
-            # window: stop its services, mv it aside, clone, poetry install.
-            echo "  $c: WARNING — linked worktree of $(cd "$dir" && cd "$common/.." && pwd), not a clone of its own; left untouched (see the site profile page)"
-            continue
+        if [ -z "$gitdir" ]; then
+            echo "  $c: WARNING — .git present but git cannot read it (a worktree whose main clone was removed, or corrupt); skipped — fix by hand"
+            SKIP_CLONES="$SKIP_CLONES$c "; continue
         fi
-        echo "  $c: exists ($(git -C "$dir" rev-parse --abbrev-ref HEAD) $(git -C "$dir" rev-parse --short=8 HEAD)) — fetching, NOT moving HEAD (a pull is a deploy; do it per service, deliberately)"
+        case "$gitdir" in
+            "$common"/worktrees/*)
+                # A linked worktree shares its object store AND its branch refs
+                # with another clone. If the same branch is checked out in both
+                # (git allows that only via --ignore-other-worktrees/--force —
+                # how the 2026-09-03 state arose), a pull in one moves the
+                # other's HEAD without a checkout, and that service runs an older
+                # tree than its HEAD claims. Not a clone of its own — see the
+                # site profile page for the replacement recipe.
+                echo "  $c: WARNING — linked worktree of $(cd "$dir" && cd "$common/.." && pwd), not a clone of its own; skipped (see the site profile page)"
+                SKIP_CLONES="$SKIP_CLONES$c "; continue ;;
+        esac
+        echo "  $c: exists ($(git -C "$dir" rev-parse --abbrev-ref HEAD 2>/dev/null) $(git -C "$dir" rev-parse --short=8 HEAD 2>/dev/null)) — fetching, NOT moving HEAD (a pull is a deploy; do it per service, deliberately)"
         run git -C "$dir" fetch --quiet origin
     else
         run git clone --quiet --branch "$REF" "$GEECS_REPO_URL" "$dir"
@@ -105,6 +117,7 @@ say "environments (inside each package dir, with that service's extras)"
 for s in $SERVICES; do
     wanted "$s" || continue
     dir="$GEECS_CHECKOUT_ROOT/$(clone_of "$s")/$(pkgdir_of "$s")"
+    skipped_clone "$(clone_of "$s")" && { echo "  $s: skipped — $(clone_of "$s") is not a usable clone (see the clones stage)"; continue; }
     [ "$INSTALL" -eq 1 ] || { echo "  $s: skipped (--no-install)"; continue; }
     if [ ! -d "$dir" ]; then
         echo "  $s: clone not present yet ($dir) — rerun after the clone step has run for real"; continue
@@ -186,10 +199,12 @@ template_of() { case "$1" in
 TEMPLATE_PATHS=()
 for s in $SERVICES; do
     wanted "$s" || continue
+    skipped_clone "$(clone_of "$s")" && { echo "  $s: skipped — $(clone_of "$s") is not a usable clone"; continue; }
     t="$GEECS_CHECKOUT_ROOT/$(clone_of "$s")/$(template_of "$s")"
     if [ -f "$t" ]; then TEMPLATE_PATHS+=("$t"); else echo "  $s: clone absent — template from this clone ($REPO_ROOT)"; TEMPLATE_PATHS+=("$REPO_ROOT/$(template_of "$s")"); fi
 done
-if [ "$DRY" -eq 1 ]; then echo "  [dry] render_units.sh $SITE_ENV $STAGE ${TEMPLATE_PATHS[*]}"
+if [ "${#TEMPLATE_PATHS[@]}" -eq 0 ]; then echo "  nothing to render (every wanted service was skipped)"
+elif [ "$DRY" -eq 1 ]; then echo "  [dry] render_units.sh $SITE_ENV $STAGE ${TEMPLATE_PATHS[*]}"
 else RENDER_QUIET=1 "$REPO_ROOT/deploy/render_units.sh" "$SITE_ENV" "$STAGE" "${TEMPLATE_PATHS[@]}" | sed 's/^/  /'; fi
 
 say "root steps (a human runs these; nothing above needed sudo)"
@@ -198,6 +213,14 @@ cat <<EOF
   sudo install -m 0644 "$STAGE"/*.service /etc/systemd/system/
   sudo systemctl daemon-reload
 EOF
-for s in $SERVICES; do wanted "$s" && echo "  sudo systemctl enable --now $(unit_of "$s")"; done
+for s in $SERVICES; do
+    wanted "$s" || continue
+    if skipped_clone "$(clone_of "$s")"; then echo "  # $(unit_of "$s"): NOT enabled — $(clone_of "$s") is not a usable clone (see above)"; else echo "  sudo systemctl enable --now $(unit_of "$s")"; fi
+done
 echo
+if [ "$SKIP_CLONES" != " " ]; then
+    echo "WARNING: skipped clone dir(s):$SKIP_CLONES— not clones of their own (linked worktree or unreadable .git)." >&2
+    echo "         Replace each in a maintenance window per docs/platform/site_profile.md, then rerun this script." >&2
+    echo
+fi
 echo "Then: scripts/fleet_status.sh from any client — every row should read systemd / clean / matching versions."

--- a/deploy/bootstrap_host.sh
+++ b/deploy/bootstrap_host.sh
@@ -90,8 +90,11 @@ for c in $(for s in $SERVICES; do wanted "$s" && clone_of "$s"; done | sort -u);
     if [ -e "$dir/.git" ]; then
         gitdir="$(git -C "$dir" rev-parse --git-dir 2>/dev/null || true)"
         common="$(git -C "$dir" rev-parse --git-common-dir 2>/dev/null || true)"
-        if [ -z "$gitdir" ]; then
-            echo "  $c: WARNING — .git present but git cannot read it (a worktree whose main clone was removed, or corrupt); skipped — fix by hand"
+        top="$(git -C "$dir" rev-parse --show-toplevel 2>/dev/null || true)"
+        if [ -z "$gitdir" ] || [ "$top" != "$(cd "$dir" && pwd -P)" ]; then
+            # Unreadable .git, or git walked UP to an enclosing repository (a
+            # stray .git under a git-managed home): not this directory's repo.
+            echo "  $c: WARNING — .git present but git cannot read it as this directory's repository (dangling worktree, corrupt, or a stray .git inside another repo); skipped — fix by hand"
             SKIP_CLONES="$SKIP_CLONES$c "; continue
         fi
         case "$gitdir" in
@@ -208,18 +211,22 @@ elif [ "$DRY" -eq 1 ]; then echo "  [dry] render_units.sh $SITE_ENV $STAGE ${TEM
 else RENDER_QUIET=1 "$REPO_ROOT/deploy/render_units.sh" "$SITE_ENV" "$STAGE" "${TEMPLATE_PATHS[@]}" | sed 's/^/  /'; fi
 
 say "root steps (a human runs these; nothing above needed sudo)"
-cat <<EOF
-  sudo install -D -m 0644 "$SITE_ENV" "$SITE_ENV_INSTALLED"
-  sudo install -m 0644 "$STAGE"/*.service /etc/systemd/system/
-  sudo systemctl daemon-reload
-EOF
+echo "  sudo install -D -m 0644 \"$SITE_ENV\" \"$SITE_ENV_INSTALLED\""
+if [ "${#TEMPLATE_PATHS[@]}" -gt 0 ]; then
+    echo "  sudo install -m 0644 \"$STAGE\"/*.service /etc/systemd/system/"
+    echo "  sudo systemctl daemon-reload"
+else
+    echo "  # nothing staged — no units to install"
+fi
 for s in $SERVICES; do
     wanted "$s" || continue
     if skipped_clone "$(clone_of "$s")"; then echo "  # $(unit_of "$s"): NOT enabled — $(clone_of "$s") is not a usable clone (see above)"; else echo "  sudo systemctl enable --now $(unit_of "$s")"; fi
 done
 echo
 if [ "$SKIP_CLONES" != " " ]; then
-    echo "WARNING: skipped clone dir(s):$SKIP_CLONES— not clones of their own (linked worktree or unreadable .git)." >&2
+    # ${VAR} braces on purpose: a bare $VAR abutting a non-ASCII character is
+    # parsed as part of the name by bash 3.2 under UTF-8 (unbound variable).
+    echo "WARNING: skipped clone dir(s):${SKIP_CLONES}— not clones of their own (linked worktree or unreadable .git)." >&2
     echo "         Replace each in a maintenance window per docs/platform/site_profile.md, then rerun this script." >&2
     echo
 fi

--- a/docs/platform/fleet_map.md
+++ b/docs/platform/fleet_map.md
@@ -150,6 +150,11 @@ Poetry env inside it). This is deliberate, not accumulation:
   mutates code under the running service. The Windows PVA fleet
   inverts the pattern entirely: no per-host clones, one shared
   "Active Version" clone as the fleet pin, baked per-host venvs.
+- A linked `git worktree` is **not** a clone: it shares branch refs with
+  the clone it hangs off, so a pull in one can move the other's HEAD
+  without a checkout (the 2026-09-03 gateway incident). The bootstrap
+  refuses to provision from one and `/fleet-status` flags it — see the
+  [Site Profile](site_profile.md).
 - The clone names are fixed by the [Site Profile](site_profile.md)
   (`gateway-checkout`, `portal-checkout`, `qs-checkout`); only the root
   is the site's choice (`GEECS_CHECKOUT_ROOT` — the service account's

--- a/docs/platform/site_profile.md
+++ b/docs/platform/site_profile.md
@@ -93,6 +93,15 @@ configs repo (`GEECS-Plugins-Configs`) is **not** cloned per service: it
 is data, read at runtime, and the copy on the data share is the one
 LabVIEW reads too — `GEECS_CONFIGS_ROOT` points at it.
 
+**A clone means a clone, not a `git worktree`.** A linked worktree shares
+its object store *and its branch refs* with the clone it was made from:
+`git pull` in one advances the other's branch pointer without touching
+its files, so that service runs an older tree than its HEAD claims (the
+2026-09-03 gateway incident, where `qs-checkout` was a worktree of the
+gateway's clone). The bootstrap detects a linked worktree, warns, and
+leaves it alone; replace it with a real clone in a maintenance window
+(stop its services, move it aside, clone, `poetry install`).
+
 ## Standing up a host
 
 ```bash

--- a/docs/platform/site_profile.md
+++ b/docs/platform/site_profile.md
@@ -94,13 +94,20 @@ is data, read at runtime, and the copy on the data share is the one
 LabVIEW reads too — `GEECS_CONFIGS_ROOT` points at it.
 
 **A clone means a clone, not a `git worktree`.** A linked worktree shares
-its object store *and its branch refs* with the clone it was made from:
-`git pull` in one advances the other's branch pointer without touching
-its files, so that service runs an older tree than its HEAD claims (the
-2026-09-03 gateway incident, where `qs-checkout` was a worktree of the
-gateway's clone). The bootstrap detects a linked worktree, warns, and
-leaves it alone; replace it with a real clone in a maintenance window
-(stop its services, move it aside, clone, `poetry install`).
+its object store *and its branch refs* with the clone it was made from.
+If the same branch ends up checked out in both — git allows that only
+via `--ignore-other-worktrees` or `--force`, which is how the 2026-09-03
+state arose (`qs-checkout` was a worktree of the gateway's clone, both
+on `master`) — a `git pull` in one moves the other's HEAD with no
+checkout, and that service runs an older tree than its HEAD claims. The
+bootstrap detects a linked worktree (or an unreadable `.git`), warns,
+and **skips every stage for the services that clone hosts** (no env, no
+unit, no `enable` line), ending with the warning again. Replace it in a
+maintenance window: stop its services, `git -C <main clone> worktree
+remove --force <dir>` (or move it aside and `git -C <main clone>
+worktree prune`), rerun `deploy/bootstrap_host.sh` — it clones and
+installs — then start the services. `/fleet-status` flags a worktree on
+every run (`WORKTREE of <clone>` in the row's notes).
 
 ## Standing up a host
 

--- a/scripts/fleet_status.sh
+++ b/scripts/fleet_status.sh
@@ -436,6 +436,12 @@ emit() {  # emit ROLE NAME MANAGED STATE PID CWD PYEXE
         unstaged="$(git -C "$clone" diff --name-only 2>/dev/null | wc -l | tr -d " ")"
         moved="$(reflog_ts "$clone")"
         rec="$rec\tclone=${clone/#$HOME/\~}\tbranch=$branch\tsha=$sha\tfull=$full\tcommit_date=$cdate\tstaged=$staged\tunstaged=$unstaged"
+        # A linked worktree is not a clone of its own: it shares object store
+        # and branch refs with another clone (the 2026-09-03 disk≠HEAD root
+        # cause). Name the clone it hangs off so the row can say so.
+        local wt_gitdir wt_common
+        wt_gitdir="$(git -C "$clone" rev-parse --git-dir 2>/dev/null)"; wt_common="$(git -C "$clone" rev-parse --git-common-dir 2>/dev/null)"
+        case "$wt_gitdir" in "$wt_common"/worktrees/*) rec="$rec\tworktree_of=$(cd "$clone" && cd "$wt_common/.." && pwd | sed "s|^$HOME|~|")" ;; esac
         if [ "$staged" != "0" ]; then
             # HEAD can lie: a ref advanced without a checkout (or a staged
             # rollback) leaves the files on disk — what actually runs — at
@@ -512,8 +518,8 @@ fmt_host_records() {  # stdin: service records -> pretty lines; side effect: not
             *) info "ssh: $line"; continue ;;   # known-hosts notices, remote warnings — not records
         esac
         rec "$line"
-        local role svc managed state since clone branch sha full cdate staged unstaged stale pkg pyproject installed baked pyexe disk disk_full disk_date
-        role=""; svc=""; managed=""; state=""; since=""; clone=""; branch=""; sha=""; full=""; cdate=""; staged=""; unstaged=""; stale=""; pkg=""; pyproject=""; installed=""; baked=""; pyexe=""; disk=""; disk_full=""; disk_date=""
+        local role svc managed state since clone branch sha full cdate staged unstaged stale pkg pyproject installed baked pyexe disk disk_full disk_date worktree_of
+        role=""; svc=""; managed=""; state=""; since=""; clone=""; branch=""; sha=""; full=""; cdate=""; staged=""; unstaged=""; stale=""; pkg=""; pyproject=""; installed=""; baked=""; pyexe=""; disk=""; disk_full=""; disk_date=""; worktree_of=""
         local IFS=$'\t' kv
         for kv in $line; do
             case "$kv" in
@@ -523,6 +529,7 @@ fmt_host_records() {  # stdin: service records -> pretty lines; side effect: not
                 stale=*) stale="${kv#*=}" ;; pkg=*) pkg="${kv#*=}" ;; pyproject=*) pyproject="${kv#*=}" ;;
                 installed=*) installed="${kv#*=}" ;; baked=*) baked="${kv#*=}" ;; pyexe=*) pyexe="${kv#*=}" ;;
                 disk=*) disk="${kv#*=}" ;; disk_full=*) disk_full="${kv#*=}" ;; disk_date=*) disk_date="${kv#*=}" ;;
+                worktree_of=*) worktree_of="${kv#*=}" ;;
             esac
         done
         unset IFS
@@ -535,6 +542,7 @@ fmt_host_records() {  # stdin: service records -> pretty lines; side effect: not
             [ "${staged:-0}" != "0" ] && d="$d  STAGED: $staged file(s)"
             [ "${unstaged:-0}" != "0" ] && d="$d  UNSTAGED: $unstaged modified file(s)"
             info "$clone @ $branch $sha ($cdate)$d"
+            [ -n "$worktree_of" ] && warn "$svc: $clone is a linked git worktree of $worktree_of, not a clone of its own — shared branch refs; a pull in either can move the other's HEAD without a checkout (site profile: replace with a real clone)"
             note_sha "${role:-$svc}" "$full" "head"
             if [ -n "$disk" ]; then
                 warn "$svc: files on disk are commit $disk ($disk_date), not HEAD $sha — HEAD moved without a checkout, or a staged rollback is pending; what RUNS is $disk. Confirm which tree is intended before touching (skill: the STAGED/UNSTAGED row)"

--- a/scripts/fleet_table.py
+++ b/scripts/fleet_table.py
@@ -159,6 +159,8 @@ def notes(rec: dict[str, str]) -> list[str]:
         out.append("no systemd unit")
     if rec.get("baked"):
         out.append("baked venv")
+    if rec.get("worktree_of"):
+        out.append(f"WORKTREE of {rec['worktree_of']} (not a clone)")
     if rec.get("disk"):
         out.append(f"disk ≠ HEAD ({rec.get('disk_date', '')})")
     staged, unstaged = rec.get("staged", "0"), rec.get("unstaged", "0")


### PR DESCRIPTION
## What

`deploy/bootstrap_host.sh` distinguishes a linked `git worktree` from a real clone (`git rev-parse --git-dir` ≠ `--git-common-dir`), warns, and leaves it untouched instead of trying to `git clone` into the existing directory (the previous `-d .git` test is false for a worktree, whose `.git` is a file). `docs/platform/site_profile.md` records the rule: a clone means a clone, not a worktree. No package code; `deploy/` + docs only.

## Why

Phase 3 preflight on the interim host (today): `qs-checkout` is a worktree of the gateway's clone `~/GEECS-Plugins`, both with `master` checked out. A `git pull` in one advances the shared branch pointer without touching the other's files — which is the root cause of the 2026-09-03 gateway disk≠HEAD incident (`/fleet-status` found the gateway running an August tree under a September HEAD). Phase 3 replaces the worktree with a real clone during the maintenance window; the bootstrap must not mistake it for one in the meantime.

## Tests

`bash -n`; lint clean. Local reproduction: a scratch root where `qs-checkout` is a linked worktree of `gateway-checkout` — `bootstrap_host.sh --dry-run --no-install` fetches the clone, plans the missing clone, and prints the WARNING for the worktree (verified output in the commit message's scenario).

## Hardware verification

Non-invasive live use is next: this is the version of the bootstrap that runs on the host for Phase 3 staging (a fresh `gateway-checkout` clone + env; `qs-checkout` is replaced in the cutover window).

🤖 Generated with [Claude Code](https://claude.com/claude-code)