### PR TITLE
GEECS-Console 0.28.1: warm cycle-bearing imports on the GUI thread before monitor threads start (#778)

### DIFF
--- a/GEECS-Console/CHANGELOG.md
+++ b/GEECS-Console/CHANGELOG.md
@@ -12,20 +12,23 @@ semantic.
   killed the bluesky document stream (`_DeadlockError` on
   `bluesky._vendor.super_state_machine`) and blanked the R6 idle
   "Scan NNN (previous)" display (`geecs_data_utils` "partially
-  initialized"). Four daemon threads spawned at construction — the
-  document stream, the manager status poll / console stream, the health
-  poll and the idle scan-number probe — each lazily first-imported a
-  package with internal import cycles (`bluesky`,
-  `bluesky_queueserver_api`, `geecs_data_utils`), and concurrent
-  first-imports of one cycle from different threads trip importlib's
-  per-module locks. `MainWindow.__init__` now calls
-  `services/warm_imports.py::warm_imports()` first — the cycle-bearing
-  modules import once on the GUI thread (~1.5 s, dominated by
+  initialized"). Daemon threads spawned at construction enter packages
+  with internal import cycles through *different* submodules at the
+  same time — `bluesky`: the document stream (`bluesky.callbacks.zmq`)
+  vs the health poll (`geecs_bluesky.devices.ca` → ophyd_async →
+  `bluesky.protocols`); `geecs_data_utils`: the idle scan-number probe
+  (`scan_paths`) vs the health poll (`geecs_bluesky.tiled_integration`
+  → `tiled_catalog`) — and Python's per-module import locks, which
+  serialize same-module imports, deadlock on that shape.
+  `MainWindow.__init__` now calls
+  `services/warm_imports.py::warm_imports()` first — one entry per
+  cycle-bearing package imports on the GUI thread (~1.3 s, dominated by
   `geecs_data_utils`/pandas; previously paid by the threads anyway)
   before any controller spawns a thread. The lazy import sites are
   unchanged; the warm-up is best-effort (a failure is logged and left to
-  the real call site to report). Pinned by an ordering test: the
-  warm-up precedes every `Thread.start` and the monitor's `start()`.
+  the real call site to report). Pinned by an ordering test (the
+  warm-up precedes every `Thread.start` and the monitor's `start()`)
+  and a source-grep pin over the thread-body modules.
 
 ## [0.28.0] - 2026-09-02
 

--- a/GEECS-Console/CHANGELOG.md
+++ b/GEECS-Console/CHANGELOG.md
@@ -4,6 +4,29 @@ All notable changes to GEECS-Console are documented here.  Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versioning is
 semantic.
 
+## [0.28.1] - 2026-09-03
+
+### Fixed
+
+- **Startup thread import race** (#778): every launch since 2026-08-24
+  killed the bluesky document stream (`_DeadlockError` on
+  `bluesky._vendor.super_state_machine`) and blanked the R6 idle
+  "Scan NNN (previous)" display (`geecs_data_utils` "partially
+  initialized"). Four daemon threads spawned at construction — the
+  document stream, the manager status poll / console stream, the health
+  poll and the idle scan-number probe — each lazily first-imported a
+  package with internal import cycles (`bluesky`,
+  `bluesky_queueserver_api`, `geecs_data_utils`), and concurrent
+  first-imports of one cycle from different threads trip importlib's
+  per-module locks. `MainWindow.__init__` now calls
+  `services/warm_imports.py::warm_imports()` first — the cycle-bearing
+  modules import once on the GUI thread (~1.5 s, dominated by
+  `geecs_data_utils`/pandas; previously paid by the threads anyway)
+  before any controller spawns a thread. The lazy import sites are
+  unchanged; the warm-up is best-effort (a failure is logged and left to
+  the real call site to report). Pinned by an ordering test: the
+  warm-up precedes every `Thread.start` and the monitor's `start()`.
+
 ## [0.28.0] - 2026-09-02
 
 ### Added

--- a/GEECS-Console/CLAUDE.md
+++ b/GEECS-Console/CLAUDE.md
@@ -152,6 +152,17 @@ are prefixed by region (`r3_radio_1d`, `r5_start_button`, …).
   qs_client method bodies.  Without a `[qserver]` config section the
   stub client refuses submission with a message naming the missing
   section — everything else works.
+- **Startup import warm-up (#778)**: `MainWindow.__init__` calls
+  `services/warm_imports.py::warm_imports()` before any controller spawns
+  a daemon thread.  The lazy imports above stay lazy (offline
+  import-safety of each module), but the cycle-bearing packages they
+  resolve (`bluesky`, `bluesky_queueserver_api`, `geecs_data_utils`) must
+  already be in `sys.modules` when several threads first-import them
+  concurrently, or importlib's `_DeadlockError` kills the document stream
+  and leaves data-utils "partially initialized".  A new daemon-thread lazy
+  import that reaches one of those packages through a new module goes in
+  `WARM_MODULES`; pinned by `tests/test_main_window.py::
+  TestStartupImportWarmUp` (warm-up precedes every `Thread.start`).
 - PySide6 only (LGPL, agent-editable `.ui` XML).  Never PyQt.
 - The `.ui` is hand-authored XML loaded at runtime via `QUiLoader` — no
   generated `*_ui.py` files to keep in sync.

--- a/GEECS-Console/CLAUDE.md
+++ b/GEECS-Console/CLAUDE.md
@@ -154,15 +154,23 @@ are prefixed by region (`r3_radio_1d`, `r5_start_button`, …).
   section — everything else works.
 - **Startup import warm-up (#778)**: `MainWindow.__init__` calls
   `services/warm_imports.py::warm_imports()` before any controller spawns
-  a daemon thread.  The lazy imports above stay lazy (offline
-  import-safety of each module), but the cycle-bearing packages they
-  resolve (`bluesky`, `bluesky_queueserver_api`, `geecs_data_utils`) must
-  already be in `sys.modules` when several threads first-import them
-  concurrently, or importlib's `_DeadlockError` kills the document stream
-  and leaves data-utils "partially initialized".  A new daemon-thread lazy
-  import that reaches one of those packages through a new module goes in
-  `WARM_MODULES`; pinned by `tests/test_main_window.py::
-  TestStartupImportWarmUp` (warm-up precedes every `Thread.start`).
+  a daemon thread.  The precise hazard: Python's per-module import lock
+  serializes two threads importing the *same* module, but two threads
+  entering a package through *different* submodules that its `__init__`
+  imports (`bluesky` via `bluesky.callbacks.zmq` vs via ophyd_async's
+  `bluesky.protocols`; `geecs_data_utils` via `scan_paths` vs via
+  `tiled_catalog`) deadlock — importlib raises `_DeadlockError` in one
+  (dead document stream) and the other sees a "partially initialized"
+  module (blank idle display).  The lazy imports above stay lazy (offline
+  import-safety of each module, and `geecs_bluesky.devices` stays heavy);
+  the warm-up just makes sure `bluesky` and `geecs_data_utils` are fully
+  in `sys.modules` first.  A new daemon-thread lazy import that reaches
+  one of those packages goes in `WARM_MODULES` (pinned by a source grep in
+  `tests/test_warm_imports.py`); the ordering is pinned by
+  `tests/test_main_window.py::TestStartupImportWarmUp` (warm-up precedes
+  every `Thread.start`).  The one-in-flight dedupes in `app/actions_menu.py`
+  and `app/now_panel.py` mitigate the same class of hazard for native
+  first-imports on their own threads.
 - PySide6 only (LGPL, agent-editable `.ui` XML).  Never PyQt.
 - The `.ui` is hand-authored XML loaded at runtime via `QUiLoader` — no
   generated `*_ui.py` files to keep in sync.

--- a/GEECS-Console/geecs_console/app/main_window.py
+++ b/GEECS-Console/geecs_console/app/main_window.py
@@ -73,6 +73,7 @@ from geecs_console.request_builder import (
 from geecs_console.services.configs import ConsoleConfigs
 from geecs_console.services.presets import PresetStore, PresetStoreError
 from geecs_console.services.settings import ConsoleSettings
+from geecs_console.services.warm_imports import warm_imports
 from geecs_console.services.device_panel import (
     DevicePanelBackend,
     StubDevicePanel,
@@ -239,6 +240,15 @@ class MainWindow(QMainWindow):
         scan_number_lookup: Optional[Callable[[str], Optional[int]]] = None,
     ) -> None:
         super().__init__()
+        # Import the cycle-bearing packages once, here on the GUI thread,
+        # BEFORE any controller below spawns a daemon thread (#778): the
+        # health poller, the idle scan-number probe, the actions fetch and
+        # the scan monitor each lazily import bluesky /
+        # bluesky_queueserver_api / geecs_data_utils on their own threads,
+        # and concurrent first-imports of one import cycle trip importlib's
+        # _DeadlockError — a dead document stream and a blank idle display
+        # on every launch.  Pinned by tests/test_main_window.py.
+        warm_imports()
         self._configs = configs if configs is not None else ConsoleConfigs(experiment)
         self._health = health if health is not None else StubHealth()
         self._device_panel = (

--- a/GEECS-Console/geecs_console/app/main_window.py
+++ b/GEECS-Console/geecs_console/app/main_window.py
@@ -243,9 +243,9 @@ class MainWindow(QMainWindow):
         # Import the cycle-bearing packages once, here on the GUI thread,
         # BEFORE any controller below spawns a daemon thread (#778): the
         # health poller, the idle scan-number probe, the actions fetch and
-        # the scan monitor each lazily import bluesky /
-        # bluesky_queueserver_api / geecs_data_utils on their own threads,
-        # and concurrent first-imports of one import cycle trip importlib's
+        # the scan monitor each lazily import bluesky / geecs_data_utils
+        # on their own threads, and two threads entering one of those
+        # packages through different submodules trip importlib's
         # _DeadlockError — a dead document stream and a blank idle display
         # on every launch.  Pinned by tests/test_main_window.py.
         warm_imports()

--- a/GEECS-Console/geecs_console/services/warm_imports.py
+++ b/GEECS-Console/geecs_console/services/warm_imports.py
@@ -1,38 +1,48 @@
 """Startup import warm-up: load the cycle-bearing packages on one thread (#778).
 
-Several console daemon threads lazily import packages whose module graphs
-contain import cycles, and they all spawn within the first second of a
-launch:
+Python's per-module import lock serialises two threads importing the
+*same* module.  It does NOT protect a package whose ``__init__`` imports
+its own submodules when two threads enter that package through
+*different* submodules: thread A holds submodule X's lock and, inside the
+package ``__init__``, waits for Y; thread B holds Y's lock and waits for
+X.  importlib detects the cycle and raises ``_DeadlockError`` in one
+thread while the other sees a "partially initialized module (most likely
+due to a circular import)".  Which thread loses is timing dependent.
 
-- ``qs-doc-stream`` (``app/scan_monitor.py``): ``bluesky.callbacks.zmq`` →
-  ``bluesky`` → ``bluesky._vendor.super_state_machine``.
-- ``qs-console-stream`` and the manager status poll
-  (``ZmqQueueClient._manager``): ``bluesky_queueserver_api`` →
-  ``bluesky_queueserver`` → ``bluesky``.
-- ``console-health-poll`` (``services/health.py``):
-  ``geecs_bluesky.tiled_integration`` → ``geecs_data_utils.tiled_catalog``
-  → the ``geecs_data_utils`` package ``__init__`` → ``tiled_catalog``.
-- ``console-idle-scan-probe`` (``services/ops_paths.py``):
-  ``geecs_data_utils.scan_paths`` → the same package ``__init__``.
+The console's daemon threads spawn within the first second of a launch
+and hit exactly this shape (the racing pairs were reproduced cold, and
+verified quiet after the warm-up, in the #784 review):
 
-A cycle imports fine on ONE thread — importlib hands back the partially
-initialised module — but when two threads first-import the same cycle
-concurrently each holds a per-module lock the other needs.  importlib
-detects that and raises ``_DeadlockError`` in one thread while the other
-sees a "partially initialized module (most likely due to a circular
-import)".  Which thread loses is timing dependent, so the symptom moved
-around between launches: a dead document stream one time, a blank idle
-scan-number display the next.
+- ``bluesky``: the document stream (``qs-doc-stream``,
+  ``DocumentStreamWorker._run`` → ``bluesky.callbacks.zmq``) vs the health
+  poll (``console-health-poll``, ``GatewayTiledDbHealth._check_gateway`` →
+  ``geecs_bluesky.devices.ca._pv`` → ophyd_async → ``bluesky.protocols``).
+  The observed ``_DeadlockError`` is on
+  ``bluesky._vendor.super_state_machine.errors``.
+- ``geecs_data_utils``: the idle scan-number probe
+  (``console-idle-scan-probe``, ``ops_paths.todays_scan_folder`` →
+  ``geecs_data_utils.scan_paths``) vs the health poll
+  (``GatewayTiledDbHealth._tiled_uri`` → ``geecs_bluesky.tiled_integration``
+  → ``geecs_data_utils.tiled_catalog``).  The observed error is
+  ``read_tiled_config`` "partially initialized".
 
-:func:`warm_imports` imports each such module once, synchronously, on the
-caller's thread; :class:`~geecs_console.app.main_window.MainWindow` calls
-it first thing, before any controller spawns a thread, so every later
-lazy import finds a fully initialised module in ``sys.modules``.  The lazy
-imports themselves stay where they are — this is a load-*order* fix, not a
+:func:`warm_imports` imports one entry per cycle-bearing package once,
+synchronously, on the caller's thread;
+:class:`~geecs_console.app.main_window.MainWindow` calls it first thing,
+before any controller spawns a thread, so every later lazy import finds
+the package fully initialised in ``sys.modules``.  The lazy imports
+themselves stay where they are — this is a load-*order* fix, not a
 dependency change: each module's offline import-safety is unchanged, and a
 missing dependency still surfaces at the call site that needs it.  The
 warm-up is best-effort: an import failure is logged and skipped, never
 raised.
+
+Deliberately NOT warmed (heavy — aioca/ophyd — and safe once ``bluesky``
+is loaded, because they reach it through an already-initialised package):
+``geecs_bluesky.devices`` (health poll, device panel) and
+``geecs_bluesky.plans`` (the console stream's ``_failed_move_prefix``).
+``bluesky_queueserver_api`` is not warmed either: it does not import
+``bluesky`` and has no cycle of its own.
 """
 
 from __future__ import annotations
@@ -44,20 +54,18 @@ from typing import Sequence
 
 logger = logging.getLogger(__name__)
 
-#: The modules the console's daemon threads lazily import that carry (or
-#: pull in) an import cycle.  Add to this tuple when a new daemon thread's
-#: lazy import reaches ``bluesky``, ``bluesky_queueserver_api`` or
-#: ``geecs_data_utils`` through a new module — the entries name the exact
-#: modules the threads import so a warm-up miss is greppable.
+#: The modules the console's daemon threads lazily import that enter a
+#: package with import cycles (``bluesky``, ``geecs_data_utils``).  One
+#: entry per racing import site, named exactly as the thread imports it so
+#: a miss is greppable.  A new daemon-thread lazy import that reaches one
+#: of those packages goes here; ``tests/test_warm_imports.py`` greps the
+#: thread-body modules for the ``bluesky`` / ``geecs_data_utils`` sites.
 WARM_MODULES: tuple[str, ...] = (
-    # DocumentStreamWorker._run (qs-doc-stream)
+    # DocumentStreamWorker._run (qs-doc-stream) — loads all of bluesky
     "bluesky.callbacks.zmq",
-    # ZmqQueueClient._manager (status poll) and ConsoleStreamWorker._run
-    "bluesky_queueserver_api.zmq",
-    "bluesky_queueserver_api.console_monitor",
-    # ops_paths.todays_scan_folder (idle scan-number probe)
+    # ops_paths.todays_scan_folder (console-idle-scan-probe)
     "geecs_data_utils.scan_paths",
-    # GatewayTiledDbHealth._tiled_uri (health poll)
+    # GatewayTiledDbHealth._tiled_uri (console-health-poll)
     "geecs_bluesky.tiled_integration",
 )
 

--- a/GEECS-Console/geecs_console/services/warm_imports.py
+++ b/GEECS-Console/geecs_console/services/warm_imports.py
@@ -1,0 +1,99 @@
+"""Startup import warm-up: load the cycle-bearing packages on one thread (#778).
+
+Several console daemon threads lazily import packages whose module graphs
+contain import cycles, and they all spawn within the first second of a
+launch:
+
+- ``qs-doc-stream`` (``app/scan_monitor.py``): ``bluesky.callbacks.zmq`` →
+  ``bluesky`` → ``bluesky._vendor.super_state_machine``.
+- ``qs-console-stream`` and the manager status poll
+  (``ZmqQueueClient._manager``): ``bluesky_queueserver_api`` →
+  ``bluesky_queueserver`` → ``bluesky``.
+- ``console-health-poll`` (``services/health.py``):
+  ``geecs_bluesky.tiled_integration`` → ``geecs_data_utils.tiled_catalog``
+  → the ``geecs_data_utils`` package ``__init__`` → ``tiled_catalog``.
+- ``console-idle-scan-probe`` (``services/ops_paths.py``):
+  ``geecs_data_utils.scan_paths`` → the same package ``__init__``.
+
+A cycle imports fine on ONE thread — importlib hands back the partially
+initialised module — but when two threads first-import the same cycle
+concurrently each holds a per-module lock the other needs.  importlib
+detects that and raises ``_DeadlockError`` in one thread while the other
+sees a "partially initialized module (most likely due to a circular
+import)".  Which thread loses is timing dependent, so the symptom moved
+around between launches: a dead document stream one time, a blank idle
+scan-number display the next.
+
+:func:`warm_imports` imports each such module once, synchronously, on the
+caller's thread; :class:`~geecs_console.app.main_window.MainWindow` calls
+it first thing, before any controller spawns a thread, so every later
+lazy import finds a fully initialised module in ``sys.modules``.  The lazy
+imports themselves stay where they are — this is a load-*order* fix, not a
+dependency change: each module's offline import-safety is unchanged, and a
+missing dependency still surfaces at the call site that needs it.  The
+warm-up is best-effort: an import failure is logged and skipped, never
+raised.
+"""
+
+from __future__ import annotations
+
+import importlib
+import logging
+import time
+from typing import Sequence
+
+logger = logging.getLogger(__name__)
+
+#: The modules the console's daemon threads lazily import that carry (or
+#: pull in) an import cycle.  Add to this tuple when a new daemon thread's
+#: lazy import reaches ``bluesky``, ``bluesky_queueserver_api`` or
+#: ``geecs_data_utils`` through a new module — the entries name the exact
+#: modules the threads import so a warm-up miss is greppable.
+WARM_MODULES: tuple[str, ...] = (
+    # DocumentStreamWorker._run (qs-doc-stream)
+    "bluesky.callbacks.zmq",
+    # ZmqQueueClient._manager (status poll) and ConsoleStreamWorker._run
+    "bluesky_queueserver_api.zmq",
+    "bluesky_queueserver_api.console_monitor",
+    # ops_paths.todays_scan_folder (idle scan-number probe)
+    "geecs_data_utils.scan_paths",
+    # GatewayTiledDbHealth._tiled_uri (health poll)
+    "geecs_bluesky.tiled_integration",
+)
+
+
+def warm_imports(modules: Sequence[str] = WARM_MODULES) -> list[str]:
+    """Import *modules* on the calling thread, tolerating failures.
+
+    Call this on the GUI thread **before** any daemon thread spawns.
+    Importing is idempotent (``sys.modules`` caches), so calling it again
+    costs nothing.
+
+    Parameters
+    ----------
+    modules : sequence of str
+        Fully qualified module names to import; defaults to
+        :data:`WARM_MODULES`.
+
+    Returns
+    -------
+    list of str
+        The names that failed to import (logged at WARNING; the lazy
+        import site that actually needs the module reports the real
+        error at use time).  Empty when every import succeeded.
+    """
+    started = time.perf_counter()
+    failed: list[str] = []
+    for name in modules:
+        try:
+            importlib.import_module(name)
+        except Exception as exc:  # noqa: BLE001 — best-effort; the real user of the module reports
+            logger.warning("startup import warm-up: %s failed: %s", name, exc)
+            failed.append(name)
+    logger.debug(
+        "startup import warm-up: %d module(s) in %.2f s (%d failed)",
+        len(modules),
+        time.perf_counter() - started,
+        len(failed),
+    )
+    return failed

--- a/GEECS-Console/main.py
+++ b/GEECS-Console/main.py
@@ -93,8 +93,10 @@ def main(argv: Optional[list[str]] = None) -> int:
     # loop and dispatches blocking :SP puts off the GUI thread.  The scan
     # service is the queueserver manager client (built by the window's
     # default submitter factory from the [qserver] config section); the
-    # optimization stack now lives worker-side, so the old GUI-process
-    # warm-up is gone with the in-process engine.
+    # optimization stack lives worker-side (its old GUI-process warm-up
+    # went with the in-process engine).  The window's own warm_imports()
+    # (#778) is a different thing: import load-order, run inside
+    # MainWindow.__init__ before its daemon threads spawn.
     window = MainWindow(
         health=GatewayTiledDbHealth(),
         device_panel=GatewayDevicePanel(),

--- a/GEECS-Console/pyproject.toml
+++ b/GEECS-Console/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-console"
-version = "0.28.0"
+version = "0.28.1"
 description = "Greenfield PySide6 operator console for GEECS (Bluesky/gateway architecture)"
 authors = ["Sam Barber <sbarber@lbl.gov>"]
 readme = "README.md"

--- a/GEECS-Console/tests/test_main_window.py
+++ b/GEECS-Console/tests/test_main_window.py
@@ -1987,3 +1987,63 @@ class TestStartupListingMessage:
         assert win.statusBar().currentMessage() == "No experiment selected."
         win.experiment_combo.setCurrentText("TestExp")
         assert win.statusBar().currentMessage() == ""
+
+
+class TestStartupImportWarmUp:
+    """#778: the cycle-bearing imports are warmed before any thread spawns.
+
+    Concurrent first-imports of one import cycle (bluesky,
+    bluesky_queueserver_api, geecs_data_utils) from several daemon threads
+    trip importlib's ``_DeadlockError``; the window must resolve them on
+    the GUI thread first.  A two-thread race test would be flaky by
+    nature, so the pin is the ORDER: ``warm_imports()`` precedes every
+    ``Thread.start`` and the scan monitor's ``start()`` during
+    construction — and the assertion is non-vacuous (threads did spawn).
+    """
+
+    def test_warm_up_precedes_every_thread_and_the_monitor_start(
+        self, qtbot, monkeypatch
+    ):
+        import threading
+
+        from geecs_console.app import main_window as module
+        from geecs_console.app.scan_monitor import ScanMonitorController
+
+        events: list[str] = []
+        monkeypatch.setattr(module, "warm_imports", lambda: events.append("warm"))
+
+        real_thread_start = threading.Thread.start
+
+        def spy_thread_start(thread):
+            events.append(f"thread:{thread.name}")
+            return real_thread_start(thread)
+
+        monkeypatch.setattr(threading.Thread, "start", spy_thread_start)
+
+        real_monitor_start = ScanMonitorController.start
+
+        def spy_monitor_start(controller, timer_parent):
+            events.append("monitor.start")
+            return real_monitor_start(controller, timer_parent)
+
+        monkeypatch.setattr(ScanMonitorController, "start", spy_monitor_start)
+
+        win = MainWindow(
+            configs=FakeConfigs(),
+            presets=FakePresetStore(),
+            settings=FakeSettings(last_experiment="TestExp"),
+            submitter=FakeSubmitter(),
+            health=FakeHealth(),
+        )
+        qtbot.addWidget(win)
+        if win._monitor is not None:
+            win._monitor.dispose()
+
+        assert events and events[0] == "warm", events
+        assert events.count("warm") == 1
+        assert "monitor.start" in events
+        # Non-vacuous: construction really did spawn daemon threads (the
+        # health poll at least), and every one of them came after the warm-up.
+        threads = [e for e in events if e.startswith("thread:")]
+        assert threads, events
+        assert all(events.index(t) > events.index("warm") for t in threads)

--- a/GEECS-Console/tests/test_warm_imports.py
+++ b/GEECS-Console/tests/test_warm_imports.py
@@ -3,9 +3,27 @@
 from __future__ import annotations
 
 import logging
+import re
 import sys
+from pathlib import Path
 
 from geecs_console.services.warm_imports import WARM_MODULES, warm_imports
+
+_PKG = Path(__file__).resolve().parents[1] / "geecs_console"
+
+#: The modules whose bodies run on the console's daemon threads and lazily
+#: import at function level (the racing sites #778 is about).
+_THREAD_BODY_MODULES = (
+    _PKG / "app" / "scan_monitor.py",
+    _PKG / "services" / "ops_paths.py",
+    _PKG / "services" / "health.py",
+)
+
+#: Top-level packages with internal import cycles (a package ``__init__``
+#: importing its own submodules) that the daemon threads first-import.
+_CYCLE_PACKAGES = {"bluesky", "geecs_data_utils"}
+
+_FUNCTION_LEVEL_FROM_IMPORT = re.compile(r"^[ \t]+from ([\w.]+) import ", re.MULTILINE)
 
 
 class TestWarmImports:
@@ -14,18 +32,33 @@ class TestWarmImports:
         for name in WARM_MODULES:
             assert name in sys.modules, name
 
-    def test_covers_the_threads_lazy_imports(self):
-        # Keep-in-sync pin against the daemon threads' lazy import sites:
-        # DocumentStreamWorker._run, ZmqQueueClient._manager,
-        # ConsoleStreamWorker._run, ops_paths.todays_scan_folder,
-        # GatewayTiledDbHealth._tiled_uri.  Rename there → rename here.
-        assert {
-            "bluesky.callbacks.zmq",
-            "bluesky_queueserver_api.zmq",
-            "bluesky_queueserver_api.console_monitor",
-            "geecs_data_utils.scan_paths",
-            "geecs_bluesky.tiled_integration",
-        } <= set(WARM_MODULES)
+    def test_resolves_the_cycle_bearing_packages(self):
+        # The outcome that matters, independent of entry names: after the
+        # warm-up both cycle-bearing packages — and the exact modules the
+        # issue's two errors named — are fully initialised.
+        warm_imports()
+        for name in (
+            "bluesky",
+            "bluesky._vendor.super_state_machine.errors",
+            "geecs_data_utils",
+            "geecs_data_utils.tiled_catalog",
+        ):
+            assert name in sys.modules, name
+
+    def test_covers_the_threads_lazy_cycle_imports(self):
+        # Keep-in-sync pin with teeth: every function-level `from X import`
+        # in a thread-body module that enters a cycle-bearing package must
+        # be warmed under exactly that name (renaming the import in
+        # DocumentStreamWorker._run, or adding a new geecs_data_utils
+        # import to a thread body, fails here until WARM_MODULES follows).
+        found: set[str] = set()
+        for path in _THREAD_BODY_MODULES:
+            for module in _FUNCTION_LEVEL_FROM_IMPORT.findall(path.read_text("utf-8")):
+                if module.split(".")[0] in _CYCLE_PACKAGES:
+                    found.add(module)
+        assert found, "grep found no cycle-package imports — the pin is broken"
+        missing = found - set(WARM_MODULES)
+        assert not missing, f"thread-side lazy imports not warmed: {sorted(missing)}"
 
     def test_a_failing_import_is_logged_and_skipped(self, caplog):
         with caplog.at_level(

--- a/GEECS-Console/tests/test_warm_imports.py
+++ b/GEECS-Console/tests/test_warm_imports.py
@@ -1,0 +1,44 @@
+"""services/warm_imports.py — the #778 startup import warm-up helper."""
+
+from __future__ import annotations
+
+import logging
+import sys
+
+from geecs_console.services.warm_imports import WARM_MODULES, warm_imports
+
+
+class TestWarmImports:
+    def test_imports_every_warm_module(self):
+        assert warm_imports() == []
+        for name in WARM_MODULES:
+            assert name in sys.modules, name
+
+    def test_covers_the_threads_lazy_imports(self):
+        # Keep-in-sync pin against the daemon threads' lazy import sites:
+        # DocumentStreamWorker._run, ZmqQueueClient._manager,
+        # ConsoleStreamWorker._run, ops_paths.todays_scan_folder,
+        # GatewayTiledDbHealth._tiled_uri.  Rename there → rename here.
+        assert {
+            "bluesky.callbacks.zmq",
+            "bluesky_queueserver_api.zmq",
+            "bluesky_queueserver_api.console_monitor",
+            "geecs_data_utils.scan_paths",
+            "geecs_bluesky.tiled_integration",
+        } <= set(WARM_MODULES)
+
+    def test_a_failing_import_is_logged_and_skipped(self, caplog):
+        with caplog.at_level(
+            logging.WARNING, logger="geecs_console.services.warm_imports"
+        ):
+            failed = warm_imports(("geecs_console_no_such_module_778", "os"))
+        assert failed == ["geecs_console_no_such_module_778"]
+        assert "geecs_console_no_such_module_778" in caplog.text
+
+    def test_is_idempotent(self):
+        assert warm_imports() == []
+        assert warm_imports() == []
+
+    def test_never_pulls_in_the_legacy_api(self):
+        warm_imports()
+        assert "geecs_python_api" not in sys.modules


### PR DESCRIPTION
## What

`MainWindow.__init__` now calls a new `services/warm_imports.py::warm_imports()` as its very first statement, importing one entry per cycle-bearing package the console's daemon threads lazily enter — `bluesky.callbacks.zmq` (all of `bluesky`), `geecs_data_utils.scan_paths` and `geecs_bluesky.tiled_integration` (both halves of the `geecs_data_utils` cycle) — once, synchronously, on the GUI thread, before any controller spawns a thread.

The lazy import sites themselves are untouched: this is a load-**order** fix, not a dependency change (each module's offline import-safety is unchanged; a missing dependency still surfaces at the call site that needs it). The warm-up is best-effort — a failed import is logged at WARNING and skipped, never raised.

Closes #778

## Why

On every launch since 2026-08-24 (9/9 in `console.log`) the bluesky document stream died with `_frozen_importlib._DeadlockError: deadlock detected by _ModuleLock('bluesky._vendor.super_state_machine.errors')` and the R6 idle "Scan NNN (previous)" display went blank with `cannot import name 'read_tiled_config' from partially initialized module 'geecs_data_utils.tiled_catalog'`.

Root cause, confirmed by reading the current code and reproduced cold by the adversarial reviewer (see the review comment): Python's per-module import lock serializes two threads importing the *same* module, but two threads entering a package through *different* submodules that its `__init__` imports deadlock — importlib raises `_DeadlockError` in one and the other sees a "partially initialized" module. Two such pairs spawn during window construction:

| package | racer A | racer B | observed error |
|---|---|---|---|
| `bluesky` | `qs-doc-stream`: `DocumentStreamWorker._run` → `bluesky.callbacks.zmq` | `console-health-poll`: `GatewayTiledDbHealth._check_gateway` → `geecs_bluesky.devices.ca._pv` → ophyd_async → `bluesky.protocols` | `_DeadlockError` on `bluesky._vendor.super_state_machine.errors` (reproduced 4/4 cold) |
| `geecs_data_utils` | `console-idle-scan-probe`: `ops_paths.todays_scan_folder` → `geecs_data_utils.scan_paths` | `console-health-poll`: `GatewayTiledDbHealth._tiled_uri` → `geecs_bluesky.tiled_integration` → `geecs_data_utils.tiled_catalog` | `read_tiled_config` "partially initialized" (reproduced 6/6 cold) |

**Corrections to the issue text** (found in review): `bluesky_queueserver_api` does **not** import `bluesky` and has no cycle of its own — the status poll / console stream are not racers, so they are not warmed. The second bluesky party is the health poll's CA import (deliberately left lazy — aioca/ophyd — and safe once `bluesky` is already loaded). Which thread loses is timing-dependent, hence the moving traceback.

Also: the `ops_paths.todays_scan_folder` import runs on the now-panel's `console-idle-scan-probe` daemon thread (via `BackgroundResult`), not on the GUI thread as the issue says. The mutation check below recorded the actual startup thread order: `console-health-poll`, `console-idle-scan-probe`, `console-action-names`, `monitor.start`, `console-health-poll` — all within construction.

Cost: the warm-up measured ~1.3 s on the GUI thread before the window shows (`bluesky.callbacks.zmq` 0.19 s, `geecs_data_utils` 1.09 s — pandas). The threads paid the same import cost before, in parallel with the window paint; now it is serialized in front of it. Judgment call, cheap to veto: an alternative would be a single warm-up *thread* that the others wait on, but that reintroduces ordering machinery for a ~1 s win.

Placement: `services/` (pure Python, no Qt — the console CLAUDE.md layering; the browser could reuse it). A `WARM_MODULES` tuple names the exact modules the threads import so a miss is greppable; a source-grep test over the thread-body modules (`scan_monitor.py`, `ops_paths.py`, `health.py`) fails if a function-level `bluesky` / `geecs_data_utils` import appears there without a matching entry.

## Version

GEECS-Console `0.28.0 → 0.28.1` (patch) + CHANGELOG entry + one CLAUDE.md architecture bullet. **Version collides with the #767 PR** (landing in parallel); whichever merges second rebases + re-bumps.

## Tests

- `GEECS-Console` suite from the worktree's own env (check.sh's CI runner, `QT_QPA_PLATFORM=offscreen`): **821 passed, 2 warnings** (814 pre-existing + 7 new: 6 in `tests/test_warm_imports.py`, 1 ordering pin `TestStartupImportWarmUp` in `tests/test_main_window.py`). The 2 warnings are the pre-existing libpyside disconnect warnings in `test_scan_monitor.py`.
- Ordering pin is non-vacuous: with the `warm_imports()` call removed the test fails (`events[0]` becomes `thread:console-health-poll`).
- `./scripts/check.sh --all` (run on the first commit; the review-fix commit re-ran the changed-scope check: lint clean, console 821 passed): lint (all files) clean; root-tests 2 passed / 62 deselected; ImageAnalysis 250 passed; ScanAnalysis 213 passed; GEECS-Data-Utils 328 passed; GEECS-Schemas 286 passed; GeecsBluesky 783 passed, 2 skipped; GeecsCAGateway 136 passed; GeecsPvaGateway 17 passed; GEECS-Console 820 passed (821 after the review fixes); GEECS-Core 90 passed; GEECS-LogTriage 59 passed; GEECS-MCP 102 passed, 1 skipped. **GEECS-DataPortal: not run locally** — 5 collection errors, env-shaped (`No module named 'fastapi'`; that package has no local Poetry env), untouched by this diff, CI covers it. Caveat: the untouched packages' suites ran against the main checkout's envs (symlinked into the worktree), i.e. their develop-installed source is the main clone's; only the GEECS-Console suite (the one this diff touches) ran from the worktree's own fresh env.
- Lint (`pre-commit` via check.sh): clean.

## Hardware verification

**OWED**: launch the console against the live manager and confirm `~/.config/geecs_console/logs/console.log` shows no `_DeadlockError` / "partially initialized" lines and the document stream stays up (start/stop docs arrive; "Scan NNN (previous)" idle display populated).

## Adversarial review

Fresh-context reviewer report + dispositions are in the PR comments (review fixes in 56b6c019).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
