### PR TITLE
render_units.sh: refuse a unit file that is not a site-profile template

### DIFF
--- a/GEECS-DataPortal/DEPLOYMENT.md
+++ b/GEECS-DataPortal/DEPLOYMENT.md
@@ -167,7 +167,7 @@ without the processing selector.)
 | `/health` reports a catalog error | Tiled down, or `[tiled]` uri/api_key wrong — `curl http://<tiled-host>:8000/api/v1/` |
 | Day pages load, images 404 | share not mounted (or moved) at `geecs_data_local_base_path`; a 404 on one shot with others fine is the exact-match rule working (that device missed the shot) |
 | Slow day listings | measure `list_runs` against the catalog first — the fix is a portal-side cache, not a schema change (scope doc, open questions) |
-| Unit crash-loops at start | wrong absolute Poetry path in `ExecStart` (`status` shows 203/EXEC); env installed by a different account than `User=` (empty venv — reinstall as the service account); or port 8200 already taken. A down Tiled does **not** exit the service — that shows up as the `/health` row above |
+| Unit crash-loops at start | `status` shows **217/USER** — the installed unit is a pre-profile file (or a copy from an old staging run) with the generic `User=`; the clone it came from predates the templated units — pull it forward, re-render with `deploy/render_units.sh`, reinstall (site profile page). Wrong absolute Poetry path in `ExecStart` (`status` shows 203/EXEC); env installed by a different account than `User=` (empty venv — reinstall as the service account); or port 8200 already taken. A down Tiled does **not** exit the service — that shows up as the `/health` row above |
 | Evening scans 404 (or resolve oddly) while daytime scans work | host timezone differs from the scanner hosts' — daily folders are named by the scanner's local date. `site.env` sets `TZ`; keep it matching the lab's zone |
 
 The fleet-map page (`docs/platform/fleet_map.md`) carries the

--- a/GeecsCAGateway/deploy/README.md
+++ b/GeecsCAGateway/deploy/README.md
@@ -51,6 +51,11 @@ systemctl status geecs-ca-gateway
 journalctl -u geecs-ca-gateway -f     # expect the startup lines, then quiet
 ```
 
+`status=217/USER` in a crash loop means the installed unit is not a rendered
+one (generic `User=` — a pre-profile file, or a copy from an old staging
+run): the clone it was rendered from predates the templated units. Pull that
+clone forward, re-render, reinstall.
+
 Then the smoke tests from `DEPLOYMENT.md` §4 — from a *different* machine, so
 subnet scoping and firewalls are exercised:
 

--- a/deploy/bootstrap_host.sh
+++ b/deploy/bootstrap_host.sh
@@ -211,12 +211,16 @@ for s in $SERVICES; do
     t="$GEECS_CHECKOUT_ROOT/$(clone_of "$s")/$(template_of "$s")"
     if [ -f "$t" ]; then
         if ! is_unit_template "$t"; then
-            echo "  $s: WARNING — $(clone_of "$s") predates the templated units ($t has no placeholders); no unit rendered or enabled — pull that clone forward (a deploy of $s), then rerun"
+            echo "  $s: WARNING — $(clone_of "$s") predates the templated units ($t: directives lack User=@SERVICE_USER@ / EnvironmentFile=@SITE_ENV@); no unit rendered or enabled — pull that clone forward (a deploy of $s), then rerun"
             SKIP_SERVICES="$SKIP_SERVICES$s "; continue
         fi
         TEMPLATE_PATHS+=("$t")
     else echo "  $s: clone absent — template from this clone ($REPO_ROOT)"; TEMPLATE_PATHS+=("$REPO_ROOT/$(template_of "$s")"); fi
 done
+# The staging dir holds only THIS run's units: a stale .service from an
+# earlier run (a service since skipped) must never ride along on the
+# install line. cutover/other files in the dir are left alone.
+[ -d "$STAGE" ] && rm -f "$STAGE"/*.service
 if [ "${#TEMPLATE_PATHS[@]}" -eq 0 ]; then echo "  nothing to render (every wanted service was skipped)"
 elif [ "$DRY" -eq 1 ]; then echo "  [dry] render_units.sh $SITE_ENV $STAGE ${TEMPLATE_PATHS[*]}"
 else RENDER_QUIET=1 "$REPO_ROOT/deploy/render_units.sh" "$SITE_ENV" "$STAGE" "${TEMPLATE_PATHS[@]}" | sed 's/^/  /'; fi

--- a/deploy/bootstrap_host.sh
+++ b/deploy/bootstrap_host.sh
@@ -200,11 +200,22 @@ template_of() { case "$1" in
     qserver) echo "GeecsBluesky/qserver/deploy/geecs-qserver.service";; capture) echo "GeecsBluesky/capture/deploy/geecs-capture.service";;
     mcp) echo "GEECS-MCP/deploy/geecs-mcp.service";; esac; }
 TEMPLATE_PATHS=()
+# Services whose clone predates the templated units: no unit is rendered or
+# enabled for them (pulling that clone forward is a deploy of that service,
+# decided deliberately — never forced by a bootstrap rerun for another one).
+SKIP_SERVICES=" "
+skipped_service() { case "$SKIP_SERVICES" in *" $1 "*) return 0;; *) return 1;; esac; }
 for s in $SERVICES; do
     wanted "$s" || continue
     skipped_clone "$(clone_of "$s")" && { echo "  $s: skipped — $(clone_of "$s") is not a usable clone"; continue; }
     t="$GEECS_CHECKOUT_ROOT/$(clone_of "$s")/$(template_of "$s")"
-    if [ -f "$t" ]; then TEMPLATE_PATHS+=("$t"); else echo "  $s: clone absent — template from this clone ($REPO_ROOT)"; TEMPLATE_PATHS+=("$REPO_ROOT/$(template_of "$s")"); fi
+    if [ -f "$t" ]; then
+        if ! is_unit_template "$t"; then
+            echo "  $s: WARNING — $(clone_of "$s") predates the templated units ($t has no placeholders); no unit rendered or enabled — pull that clone forward (a deploy of $s), then rerun"
+            SKIP_SERVICES="$SKIP_SERVICES$s "; continue
+        fi
+        TEMPLATE_PATHS+=("$t")
+    else echo "  $s: clone absent — template from this clone ($REPO_ROOT)"; TEMPLATE_PATHS+=("$REPO_ROOT/$(template_of "$s")"); fi
 done
 if [ "${#TEMPLATE_PATHS[@]}" -eq 0 ]; then echo "  nothing to render (every wanted service was skipped)"
 elif [ "$DRY" -eq 1 ]; then echo "  [dry] render_units.sh $SITE_ENV $STAGE ${TEMPLATE_PATHS[*]}"
@@ -220,9 +231,15 @@ else
 fi
 for s in $SERVICES; do
     wanted "$s" || continue
-    if skipped_clone "$(clone_of "$s")"; then echo "  # $(unit_of "$s"): NOT enabled — $(clone_of "$s") is not a usable clone (see above)"; else echo "  sudo systemctl enable --now $(unit_of "$s")"; fi
+    if skipped_clone "$(clone_of "$s")"; then echo "  # $(unit_of "$s"): NOT enabled — $(clone_of "$s") is not a usable clone (see above)"
+    elif skipped_service "$s"; then echo "  # $(unit_of "$s"): NOT enabled — $(clone_of "$s") predates the templated units; pull it forward, then rerun (see above)"
+    else echo "  sudo systemctl enable --now $(unit_of "$s")"; fi
 done
 echo
+if [ "$SKIP_SERVICES" != " " ]; then
+    echo "WARNING: no unit rendered for:${SKIP_SERVICES}— their clone predates the templated units (see the units stage)." >&2
+    echo
+fi
 if [ "$SKIP_CLONES" != " " ]; then
     # ${VAR} braces on purpose: a bare $VAR abutting a non-ASCII character is
     # parsed as part of the name by bash 3.2 under UTF-8 (unbound variable).

--- a/deploy/bootstrap_host.sh
+++ b/deploy/bootstrap_host.sh
@@ -220,7 +220,7 @@ done
 # The staging dir holds only THIS run's units: a stale .service from an
 # earlier run (a service since skipped) must never ride along on the
 # install line. cutover/other files in the dir are left alone.
-[ -d "$STAGE" ] && rm -f "$STAGE"/*.service
+[ "$DRY" -eq 0 ] && [ -d "$STAGE" ] && rm -f "$STAGE"/*.service
 if [ "${#TEMPLATE_PATHS[@]}" -eq 0 ]; then echo "  nothing to render (every wanted service was skipped)"
 elif [ "$DRY" -eq 1 ]; then echo "  [dry] render_units.sh $SITE_ENV $STAGE ${TEMPLATE_PATHS[*]}"
 else RENDER_QUIET=1 "$REPO_ROOT/deploy/render_units.sh" "$SITE_ENV" "$STAGE" "${TEMPLATE_PATHS[@]}" | sed 's/^/  /'; fi

--- a/deploy/bootstrap_host.sh
+++ b/deploy/bootstrap_host.sh
@@ -9,6 +9,8 @@
 #
 #   --ref REF      git ref to check out in each clone (default: master)
 #   --only LIST    comma-separated subset of: gateway,portal,qserver,capture,mcp
+#                  (re-stages only these: the staging dir's units are cleared first,
+#                  so the printed install line covers exactly this run)
 #   --no-install   clone/fetch only; skip poetry/pip installs
 #   --dry-run      print what would happen
 #

--- a/deploy/render_units.sh
+++ b/deploy/render_units.sh
@@ -62,15 +62,13 @@ mkdir -p "$OUT_DIR"
 for t in "${TEMPLATES[@]}"; do
     case "$t" in /*) src="$t" ;; *) src="$REPO_ROOT/$t" ;; esac
     [ -f "$src" ] || { echo "template missing: $t" >&2; exit 1; }
-    # A template must BE a template. A unit file from before the site profile
-    # carries no placeholders (a hand-edit copy with the generic account and
-    # paths); passing it through would install a unit for a user that does
-    # not exist (Phase 3 live incident, 2026-09-04: the portal clone was
-    # pinned before #777, its old unit rendered "clean" and crash-looped
-    # with status=217/USER). Refuse, naming the clone to bring forward.
-    if ! grep -q '@SERVICE_USER@' "$src" || ! grep -q '@SITE_ENV@' "$src"; then
-        echo "not a site-profile template (no @SERVICE_USER@/@SITE_ENV@ placeholders): $src" >&2
-        echo "  the clone it comes from predates the templated units — pull it to a version with them, then re-render" >&2
+    # A template must BE a template (is_unit_template, site_env_lib.sh): a
+    # unit file from before the site profile would otherwise pass through as
+    # a "rendered" unit for an account that does not exist.
+    if ! is_unit_template "$src"; then
+        echo "not a site-profile template (directives lack User=@SERVICE_USER@ / EnvironmentFile=@SITE_ENV@): $src" >&2
+        echo "  the clone it comes from predates the templated units — pull it forward (that is a deploy of that service), then re-render;" >&2
+        echo "  bootstrap_host.sh --only <other services> renders the rest meanwhile" >&2
         exit 1
     fi
     dst="$OUT_DIR/$(basename "$t")"
@@ -81,8 +79,8 @@ for t in "${TEMPLATES[@]}"; do
         -e "s|@SITE_ENV@|$SITE_ENV_INSTALLED|g" \
         "$src" > "$dst"
     # Comments may mention @PLACEHOLDER@ by name; only directive lines count.
-    if grep -v '^[[:space:]]*#' "$dst" | grep -q '@[A-Z_]*@'; then
-        echo "unfilled placeholder in $dst:" >&2; grep -v '^[[:space:]]*#' "$dst" | grep -n '@[A-Z_]*@' >&2; exit 1
+    if unit_directives "$dst" | grep -q '@[A-Z_]*@'; then
+        echo "unfilled placeholder in $dst:" >&2; unit_directives "$dst" | grep -n '@[A-Z_]*@' >&2; exit 1
     fi
     echo "rendered $dst"
 done

--- a/deploy/render_units.sh
+++ b/deploy/render_units.sh
@@ -62,6 +62,17 @@ mkdir -p "$OUT_DIR"
 for t in "${TEMPLATES[@]}"; do
     case "$t" in /*) src="$t" ;; *) src="$REPO_ROOT/$t" ;; esac
     [ -f "$src" ] || { echo "template missing: $t" >&2; exit 1; }
+    # A template must BE a template. A unit file from before the site profile
+    # carries no placeholders (a hand-edit copy with the generic account and
+    # paths); passing it through would install a unit for a user that does
+    # not exist (Phase 3 live incident, 2026-09-04: the portal clone was
+    # pinned before #777, its old unit rendered "clean" and crash-looped
+    # with status=217/USER). Refuse, naming the clone to bring forward.
+    if ! grep -q '@SERVICE_USER@' "$src" || ! grep -q '@SITE_ENV@' "$src"; then
+        echo "not a site-profile template (no @SERVICE_USER@/@SITE_ENV@ placeholders): $src" >&2
+        echo "  the clone it comes from predates the templated units — pull it to a version with them, then re-render" >&2
+        exit 1
+    fi
     dst="$OUT_DIR/$(basename "$t")"
     sed -e "s|@SERVICE_USER@|$GEECS_SERVICE_USER|g" \
         -e "s|@SERVICE_HOME@|$GEECS_SERVICE_HOME|g" \

--- a/deploy/site_env_lib.sh
+++ b/deploy/site_env_lib.sh
@@ -31,6 +31,20 @@ check_site_env_consistency() {  # the duplicated experiment key must agree with 
 SITE_RUNTIME_KEYS="GEECS_EXPERIMENT QS_EXPERIMENT TZ EPICS_CA_ADDR_LIST EPICS_CA_AUTO_ADDR_LIST EPICS_CAS_INTF_ADDR_LIST EPICS_CAS_BEACON_ADDR_LIST GEECS_QS_DOC_ADDR GEECS_CONFIGS_ROOT"
 require_runtime_keys() { require_site_keys $SITE_RUNTIME_KEYS; }
 
+unit_directives() {  # unit_directives FILE — the non-comment, non-blank lines of a unit file
+    grep -vE '^[[:space:]]*#|^[[:space:]]*$' "$1"
+}
+
+# A unit file is a site-profile TEMPLATE only if its directives carry the
+# holes: User=@SERVICE_USER@ and an EnvironmentFile=@SITE_ENV@ line. A file
+# from before the site profile (a hand-edit copy with the generic account) has
+# neither — and must never be installed as if it had been rendered (Phase 3
+# live incident 2026-09-04: portal unit from a pre-#777 clone, status=217/USER).
+# Comments are ignored: every template header mentions the placeholders in prose.
+is_unit_template() {  # is_unit_template FILE
+    unit_directives "$1" | grep -q '^User=@SERVICE_USER@$' && unit_directives "$1" | grep -q '^EnvironmentFile=@SITE_ENV@$'
+}
+
 require_site_keys() {  # require_site_keys KEY... — exit 2 naming the first missing one
     local k
     for k in "$@"; do

--- a/docs/platform/site_profile.md
+++ b/docs/platform/site_profile.md
@@ -127,7 +127,11 @@ after a clone appears; it fetches existing clones but never moves their
 HEAD (a pull is a deploy — do it per service, deliberately, then restart
 that unit). Each unit is rendered from **its own service's clone**, so a
 unit always matches the code it runs even when the clones sit at
-different pins; re-rendering a unit is part of that service's deploy. The fleet map's bootstrap gotchas (login-shell PATH, CRLF on
+different pins; re-rendering a unit is part of that service's deploy. A
+clone pinned *before* the templated units exist has no template to
+render: the render refuses it by name ("not a site-profile template")
+rather than passing the old hand-edit unit through — pull that clone
+forward first. The fleet map's bootstrap gotchas (login-shell PATH, CRLF on
 the share-mounted configs checkout, quoting share paths with spaces) are
 baked into the scripts and the example file.
 

--- a/tests/test_render_units_sh.py
+++ b/tests/test_render_units_sh.py
@@ -1,0 +1,103 @@
+"""Pin ``deploy/render_units.sh``'s template-validity check.
+
+Phase 3 live incident (2026-09-04): the bootstrap renders each unit from its
+own service's clone; the portal's clone was pinned before the templated units
+existed, its old hand-edit unit had no placeholders, and the render passed it
+through as "clean" — a unit for an account that does not exist, crash-looping
+with ``status=217/USER``. The render now refuses a unit file that is not a
+site-profile template, judged on directive lines only (every template header
+mentions the placeholder names in prose).
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.skipif(
+    sys.platform == "win32" or shutil.which("bash") is None,
+    reason="render_units.sh and its test need bash",
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+RENDER = REPO_ROOT / "deploy" / "render_units.sh"
+SITE_ENV = REPO_ROOT / "deploy" / "site.env.example"
+TEMPLATES = [
+    REPO_ROOT / "GeecsCAGateway/deploy/geecs-ca-gateway.service",
+    REPO_ROOT / "GEECS-DataPortal/deploy/geecs-data-portal.service",
+    REPO_ROOT / "GeecsBluesky/qserver/deploy/geecs-qserver.service",
+    REPO_ROOT / "GeecsBluesky/capture/deploy/geecs-capture.service",
+    REPO_ROOT / "GEECS-MCP/deploy/geecs-mcp.service",
+]
+
+# The shape of a unit file from before the site profile: real-looking
+# directives, generic account, no placeholders anywhere in the directives.
+PRE_PROFILE_UNIT = """\
+[Unit]
+Description=GEECS Data Portal (read-only scan browser)
+After=network-online.target tiled.service
+
+[Service]
+Type=simple
+User=geecs
+Environment=HOME=/home/geecs
+WorkingDirectory=/home/geecs/GEECS-Plugins-portal/GEECS-DataPortal
+ExecStart=/home/geecs/.local/bin/poetry run geecs-data-portal --experiment Undulator
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target
+"""
+
+
+def _render(out_dir: Path, *templates: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["bash", str(RENDER), str(SITE_ENV), str(out_dir), *map(str, templates)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_pre_profile_unit_is_refused(tmp_path: Path) -> None:
+    """A placeholder-free unit must not pass through as a rendered unit."""
+    bad = tmp_path / "geecs-data-portal.service"
+    bad.write_text(PRE_PROFILE_UNIT, encoding="utf-8")
+    result = _render(tmp_path / "out", bad)
+    assert result.returncode != 0
+    assert "not a site-profile template" in result.stderr
+    assert not (tmp_path / "out" / "geecs-data-portal.service").exists()
+
+
+def test_placeholder_names_in_comments_do_not_make_a_template(tmp_path: Path) -> None:
+    """Only directive lines count: a prose header naming the holes is not enough."""
+    bad = tmp_path / "geecs-data-portal.service"
+    header = (
+        "# Template header: @SERVICE_USER@ and @SITE_ENV@ are filled at render time.\n"
+    )
+    bad.write_text(header + PRE_PROFILE_UNIT, encoding="utf-8")
+    result = _render(tmp_path / "out", bad)
+    assert result.returncode != 0
+    assert "not a site-profile template" in result.stderr
+
+
+def test_in_tree_templates_render(tmp_path: Path) -> None:
+    """Every service template renders from the example, with no hole left unfilled."""
+    result = _render(tmp_path / "out", *TEMPLATES)
+    assert result.returncode == 0, result.stderr
+    for t in TEMPLATES:
+        rendered = (tmp_path / "out" / t.name).read_text(encoding="utf-8")
+        directives = [
+            line
+            for line in rendered.splitlines()
+            if line.strip() and not line.lstrip().startswith("#")
+        ]
+        assert not any(
+            "@" in line and "@" in line.split("=", 1)[-1] for line in directives
+        ), t.name
+        assert "User=geecs\n" in rendered  # the example's GEECS_SERVICE_USER
+        assert "EnvironmentFile=/etc/geecs/site.env" in rendered


### PR DESCRIPTION
## What

`deploy/render_units.sh` refuses a template that lacks the `@SERVICE_USER@` / `@SITE_ENV@` placeholders, naming the file and telling the operator to pull that clone forward. `docs/platform/site_profile.md` states the rule. `deploy/` + docs only, no package code.

## Why

Phase 3 cutover, 2026-09-04: the bootstrap renders each unit from its own service's clone (by design, #777 review finding 3). The portal's clone was pinned at a1a23ae1, before #777, so its unit file was the pre-profile hand-edit copy with no placeholders. The unfilled-placeholder check had nothing to flag, the file was installed verbatim (`User=geecs`, `/home/geecs/GEECS-Plugins-portal`), and the portal crash-looped with `status=217/USER` until the clone was pulled to master and re-rendered. Every other unit rendered correctly. This closes the gap between "render from the service's clone" and "that clone may predate the templates".

## Tests

`bash -n`; lint clean. Negative: rendering a1a23ae1's portal unit through the script now exits 1 with `not a site-profile template … pull it to a version with them`. Positive: the five current templates still render from the example.

## Hardware verification

Live: the incident above is the reproduction; the corrected render (portal clone at master) produced the unit now installed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)