### PR TITLE
GEECS-Console 0.30.0: editor save-time target check (#772), Ops → Restart gateway (#773), every cross-thread signal on the background hop (#787)

### DIFF
--- a/GEECS-Console/CHANGELOG.md
+++ b/GEECS-Console/CHANGELOG.md
@@ -4,6 +4,61 @@ All notable changes to GEECS-Console are documented here.  Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versioning is
 semantic.
 
+## [0.30.0] - 2026-09-04
+
+### Added
+
+- **Save-time device/variable check in the editors** (#772 part 1).  The
+  scan-variable editor (simple target, confirm target, every composite
+  component row) and the save-set editor (entry device, listed scalars)
+  check every name against the fetched completions listing when Save is
+  clicked: an unknown device (case-insensitive, like the completer) or an
+  unknown variable for that device blocks the save with an inline error
+  naming the variable and row plus a difflib "did you mean" hint — the
+  live case was `Position.Axis1` for `Position.Axis 1`, which used to
+  save cleanly and fail 20 s into the first move as a bare connect
+  timeout.  Free text stays: with the DB unreachable a real provider
+  that came back empty saves with a "names were not checked" note, and
+  the `EmptyCompletions` default (no experiment) stays quiet.  Shared
+  helpers in `editors/base.py` (`target_problem`, `resolve_device`,
+  `near_miss`).
+- **Ops → Restart gateway…** (#773): writes `Restart` to the
+  experiment's `cagateway:restart` PV (the gateway's one client-writable
+  PV — the operator fix for frozen readbacks and the DB-resync after a
+  device edit) through `GatewaySetpointPut` on a `BackgroundResult`
+  worker (`services/gateway_restart.py`, import-safe offline, PV name
+  via `ca_pv`/`bare_pv`).  Enabled only with an experiment and a known
+  gateway chip; refused while a scan is active on the manager; one
+  confirmation modal states the cost (fleet-wide CA disconnect for a few
+  seconds; a gateway outside its restart-on-exit-86 supervisor stays
+  down); the health poll then narrates the bounce in the log tail
+  ("gateway restarting — heartbeat down" / "gateway back — heartbeat
+  OK").  Operator tooltips are now applied after the menus are built,
+  since the catalog names this action.
+
+### Changed
+
+- **Every cross-thread signal now rides the `services/background.py`
+  hop** (#787).  The three residual daemon-thread emitters inventoried
+  after 0.28.2 moved: the scan monitor's stream workers are
+  `_GuiHopWorker`s (the zmq thread posts tagged payloads; `document` /
+  `line` / `pause_reason` / `stream_failed` fire on the GUI thread, and
+  `stop()` also gates a payload already in flight), the movable panel's
+  aioca readback callback posts through the new public `GuiRelay` (the
+  controller's `value_ready(int, object)` signal is gone — `delivered`
+  carries `(index, value)`), and the editors' completions fetch is a
+  plain `BackgroundResult` (the dialogs' `completions_ready` signal is
+  gone).  Long-lived producers take the in-flight hold on their own
+  thread, so the counter is now lock-guarded.  `ScanMonitorController.
+  dispose()` severs the workers' public signals instead of
+  `QObject.disconnect()` on the whole worker (which cut the internal hop
+  and stranded an in-flight hold), and disconnects quietly — the
+  `libpyside: Failed to disconnect (None)` RuntimeWarning on a
+  never-connected poller is gone (`disconnect_quietly`).  Delivery takes
+  one more event-loop turn; tests that assumed a same-turn landing wait
+  for it.  Still open on #787: the window ↔ controller reference cycles
+  and the once-seen interpreter-exit segfault.
+
 ## [0.29.0] - 2026-09-04
 
 ### Removed

--- a/GEECS-Console/CHANGELOG.md
+++ b/GEECS-Console/CHANGELOG.md
@@ -60,6 +60,14 @@ semantic.
   and the once-seen interpreter-exit segfault.
 
 ### Fixed
+- Editors (#772): a device listing still *loading* no longer reads as
+  "DB unavailable" — Save refuses with "device listing still loading" until
+  the fetch lands, instead of persisting unchecked names one poll early
+  (`completions_pending`; Codex review of PR #796).
+- Ops → Restart gateway: the scan-active gate also reads the
+  document-driven state pill, so the window between a start document and
+  the matching status poll can no longer wave a restart through (Codex
+  review of PR #796).
 
 - **Restart gateway… (adversarial review of PR #796)**: the restart put
   rides the device-panel backend's persistent CA loop (new

--- a/GEECS-Console/CHANGELOG.md
+++ b/GEECS-Console/CHANGELOG.md
@@ -59,6 +59,25 @@ semantic.
   for it.  Still open on #787: the window ↔ controller reference cycles
   and the once-seen interpreter-exit segfault.
 
+### Fixed
+
+- **Restart gateway… (adversarial review of PR #796)**: the restart put
+  rides the device-panel backend's persistent CA loop (new
+  `GatewayDevicePanel.put_pv`, which the R7 `set` now delegates to)
+  instead of a per-call `asyncio.run` — aioca caches channels per loop,
+  so the gateway's own CONN_DOWN used to print `RuntimeError: Event loop
+  is closed` from the CA thread on every click; the gate is re-checked
+  after the confirmation modal (status polls keep landing during its
+  nested `exec()`) and also refuses while the movable panel's manual
+  set/move is in flight (a worker-side move never changes `re_state`);
+  and the bounce narration ignores reports from health polls that began
+  before the put completed (`HealthReport.sequence`, stamped by
+  `HealthPoller`) — a pre-put "OK" landing late no longer reads as
+  "gateway back".  The Ops menu now renders its actions' tooltips.
+- The save-set editor's scalar completer resolves the entry's device
+  case-insensitively, matching its save-time check; the scan-variable
+  editor's completer uses the shared `resolve_device` helper.
+
 ## [0.29.0] - 2026-09-04
 
 ### Removed

--- a/GEECS-Console/CLAUDE.md
+++ b/GEECS-Console/CLAUDE.md
@@ -215,17 +215,24 @@ are prefixed by region (`r3_radio_1d`, `r5_start_button`, …).
   over `Submitter.status()`), the document stream (`RemoteDispatcher`
   on the worker's proxy out-port — per-shot progress, totals, scan
   number, terminal states), and the manager console-output stream (log
-  tail + failed-move pause reasons).  Stream workers emit on
-  worker-owned signals connected `QueuedConnection`;
-  `stop()`/`dispose()` only gate emission and **abandon** the daemon
-  threads — a zmq socket must never be closed from another thread (a
-  libzmq assertion aborts the process; #653 review).  Stream setup
-  failure emits `stream_failed(str)`, which the window surfaces via
-  `_report` — degraded mode (no progress/log stream) is never silent.
+  tail + failed-move pause reasons).  **Since 0.30.0 (#787) the stream
+  workers are `_GuiHopWorker`s**: the zmq thread posts a tagged payload
+  through the worker's own queued hop and `document` / `line` /
+  `pause_reason` / `stream_failed` are emitted on the GUI thread (the
+  window still connects them `QueuedConnection`); `stop()`/`dispose()`
+  gate emission on **both** sides of the hop (a payload already in
+  flight lands and is dropped) and **abandon** the daemon threads — a
+  zmq socket must never be closed from another thread (a libzmq
+  assertion aborts the process; #653 review).  `dispose()` severs the
+  public signals only (`sever()`), never `QObject.disconnect()` on the
+  whole worker — that would cut the internal hop and strand an
+  in-flight hold.  Stream setup failure emits `stream_failed(str)`,
+  which the window surfaces via `_report` — degraded mode (no
+  progress/log stream) is never silent.
 - **Movable panel (R7)** — owned by
   `app/movable_panel.py::MovablePanelController` since 0.19.0 (the #534
   controller shape: no Qt parent, injected widgets + callables, its own
-  `BackgroundResult` set worker and queued `value_ready` signal, and a
+  `BackgroundResult` set worker and `GuiRelay` readback worker, and a
   `dispose()` the window's `closeEvent` calls).  Selection resolves
   catalog-first (`ConsoleConfigs.scan_variable_specs()` — the same
   catalog the R3 axis picker lists): a plain `ScanVariable` monitors its
@@ -252,8 +259,13 @@ are prefixed by region (`r3_radio_1d`, `r5_start_button`, …).
   `run_coroutine_threadsafe`) — the same **no-QThread** rule as the health
   poller (a worker QThread aborted under offscreen pytest: "QThread
   destroyed while running").  Values reach the GUI through the
-  controller's `value_ready(int, object)` signal, connected **queued** to
-  a `@Slot(int, object)` — never paint widgets off the GUI thread.  Selection
+  controller's `GuiRelay` readback worker (`services/background.py`):
+  the CA loop thread calls `post((index, value))`, the payload hops onto
+  the GUI thread and `delivered` fires there, connected **queued** to
+  `_apply_value` — never paint widgets off the GUI thread (until 0.30.0
+  the CA thread emitted a controller-owned `value_ready` directly; #787).
+  `dispose()` closes the relay so a readback still crossing the hop is
+  dropped, never emitted at a dying controller.  Selection
   commits (dropdown pick / Enter / focus leave) resubscribe; per-keystroke
   edits only regate the Set button (no CA-monitor churn while typing); a
   generation counter drops straggler callbacks from retired monitors.  Set
@@ -397,20 +409,30 @@ are prefixed by region (`r3_radio_1d`, `r5_start_button`, …).
   `QueuedConnection`; delivery now takes two event-loop turns, so a
   test that assumes a startup result has landed waits for it
   (`qtbot.waitUntil`).  **Since 0.28.2 `HealthPoller` rides the same
-  hop** (#767 — the last emitter of the old shape *in this module*; the
-  stream workers in `app/scan_monitor.py`, the aioca readback callback
-  in `app/movable_panel.py` and the editors' completions thread in
-  `editors/base.py` still emit from their threads toward a consumer
-  QObject — inventoried in #787, not yet moved): the hop lives once in
-  the private `_GuiHopWorker` base both workers subclass (`_hop` on the
-  daemon thread, `_forward` → the subclass's `_deliver` on the GUI
-  thread), and the poller's in-flight skip lasts until the report has
-  landed, so `_busy` is only written on the GUI thread.  Any new
-  background worker subclasses `_GuiHopWorker`; when one of the
-  residual emitters bites, move it onto the same base.  `closeEvent`
-  disconnects each window-owned worker's `result_ready`; the
-  actions-menu, now-panel and queue-panel controllers' workers are
-  detached inside their `dispose()` instead.
+  hop** (#767): the hop lives once in the private `_GuiHopWorker` base
+  (`_hop` on the daemon thread, `_forward` → the subclass's `_deliver`
+  on the GUI thread), and the poller's in-flight skip lasts until the
+  report has landed, so `_busy` is only written on the GUI thread.
+  **Since 0.30.0 every cross-thread signal in the console comes through
+  this module** (#787 — the three residual emitters moved): the stream
+  workers in `app/scan_monitor.py` subclass `_GuiHopWorker` directly
+  (typed signals, tagged payloads), the movable panel's aioca readback
+  callback posts through a `GuiRelay` (the public hop for long-lived
+  foreign-thread producers — `post()` from any thread, `delivered` on
+  the GUI thread, `close()` drops in-flight payloads), and the editors'
+  completions fetch is a plain `BackgroundResult`.  Long-lived producers
+  take the in-flight hold *on their own thread* per payload (`_post`),
+  so the `_INFLIGHT` counter is guarded by `_INFLIGHT_LOCK`.  Any new
+  background worker subclasses `_GuiHopWorker` or uses `GuiRelay`; a
+  daemon thread emitting a Qt signal at a consumer is a bug.  Teardown
+  paths use `disconnect_quietly` — a blind `disconnect()` on a
+  never-connected signal warns in PySide6.  `closeEvent` disconnects
+  each window-owned worker's `result_ready`; the actions-menu,
+  now-panel, queue-panel and movable-panel controllers' workers are
+  detached inside their `dispose()` instead.  Still open on #787: the
+  window ↔ controller reference cycles (a dropped window dies only at
+  the cyclic GC — the conftest safe-point collection covers the tests)
+  and the once-seen interpreter-exit segfault.
 - **Actions menu (G-actions v1)** — owned by
   `app/actions_menu.py::ActionsMenuController` since 0.18.1 (issue #534
   step 3): the window creates the QMenu (kept in `self._menus`) and the

--- a/GEECS-Console/CLAUDE.md
+++ b/GEECS-Console/CLAUDE.md
@@ -314,7 +314,7 @@ are prefixed by region (`r3_radio_1d`, `r5_start_button`, …).
   (recorded by the worker at the claim); `_on_scan_document` feeds it to
   `set_scan_number`, which delegates to `NowPanelController` (10 s
   expiry to "(previous)").
-- **Ops menu**: four items, handlers in `main_window.py`, path resolution
+- **Ops menu**: five items, handlers in `main_window.py`, path resolution
   factored into `services/ops_paths.py` as small pure `-> Path | None`
   functions (unit-tested against tmp trees, no Finder).  *Open experiment
   config folder* (configs-repo dir for the current experiment); *Open user
@@ -326,10 +326,24 @@ are prefixed by region (`r3_radio_1d`, `r5_start_button`, …).
   path construction) and NEVER creates directories — a missing folder
   reports "no scans today" (repo scan-folder invariant, pinned by
   tree-unchanged tests in `tests/test_ops_paths.py`); *GEECS-Plugins on
-  GitHub*.  All open via `QDesktopServices.openUrl`.  Menus created in
-  `_build_menus` must be referenced on the window (`self._menus`) —
-  PySide6 garbage-collects the `addMenu` wrapper and tears down the C++
-  menu with it.
+  GitHub*.  Those four open via `QDesktopServices.openUrl`.  *Restart
+  gateway…* (#773) writes `Restart` to `{experiment}:cagateway:restart`
+  (`services/gateway_restart.py`; PV via `ca_pv`/`bare_pv`) through the
+  device-panel backend's `put_pv` — the console's one CA put, on
+  `GatewayDevicePanel`'s **persistent** loop, never a per-call
+  `asyncio.run` (aioca's per-loop channel cache makes the gateway's own
+  CONN_DOWN hit the closed loop) — on the restart `BackgroundResult`
+  worker; enabled only with an experiment and a known gateway chip,
+  refused (`_restart_refusal`, checked before AND after the confirmation
+  modal) while a scan is active on the manager or the R7 panel's manual
+  set/move is in flight; the health poll then narrates the bounce in the
+  log tail, counting only reports whose `HealthReport.sequence` is past
+  the `HealthPoller.polls_started` recorded when the put completed (a
+  poll already out then read a pre-put heartbeat).  The Ops QMenu has
+  `setToolTipsVisible(True)` so that action's operator tooltip renders.
+  Menus created in `_build_menus` must be referenced on the window
+  (`self._menus`) — PySide6 garbage-collects the `addMenu` wrapper and
+  tears down the C++ menu with it.
 - **Per-shot beeps (Preferences)**: two checkable actions persisted via
   `ConsoleSettings`, both default off.  "Per-shot beep" sounds
   `QApplication.beep()` (no sound assets, no multimedia dep) on every

--- a/GEECS-Console/geecs_console/app/main_window.py
+++ b/GEECS-Console/geecs_console/app/main_window.py
@@ -1487,17 +1487,35 @@ class MainWindow(QMainWindow):
             and not self._restart_in_flight
         )
 
+    def _restart_refusal(self) -> Optional[str]:
+        """Why a gateway restart must not start now, or ``None`` when it may.
+
+        Two activities would see the CA disconnect mid-flight: a scan on
+        the manager (the Start gate's ``_scanning()`` — the worker's
+        ophyd-async signals) and the R7 panel's manual set/move (a
+        worker-side ``move_variable`` never changes ``re_state``, so
+        ``_scanning()`` alone would wave it through — review of PR #796).
+        """
+        if self._scanning():
+            return "Gateway restart refused — a scan is active on the manager."
+        if self._movable.set_in_flight:
+            return "Gateway restart refused — a manual set/move is in flight."
+        return None
+
     def _on_restart_gateway(self) -> None:
         """Ops: ask the CA gateway to restart itself (#773), after confirming.
 
-        Refused while a scan is active on the manager (the Start gate's
-        ``_scanning()`` — the worker's ophyd-async signals would see the
-        CA disconnect mid-scan).  The confirmation states the cost: a few
-        seconds of fleet-wide CA disconnect (every client's monitors
-        reconnect on their own), and that a gateway not run under the
-        restart-on-exit-86 supervisor stays down.  The put itself blocks,
-        so it runs on the restart worker; the health poll then narrates
-        the bounce (:meth:`_narrate_gateway_bounce`).
+        Refused while a scan is active on the manager or a manual set/move
+        is in flight (:meth:`_restart_refusal`) — checked before the
+        confirmation AND again after it: the modal's nested ``exec()``
+        keeps status polls landing, so a scan started while the operator
+        read the text must still refuse (review of PR #796).  The
+        confirmation states the cost: a few seconds of fleet-wide CA
+        disconnect (every client's monitors reconnect on their own), and
+        that a gateway not run under the restart-on-exit-86 supervisor
+        stays down.  The put itself blocks, so it runs on the restart
+        worker; the health poll then narrates the bounce
+        (:meth:`_narrate_gateway_bounce`).
         """
         experiment = self.experiment_combo.currentText().strip()
         if not experiment:
@@ -1505,8 +1523,9 @@ class MainWindow(QMainWindow):
             return
         if self._restart_in_flight:
             return
-        if self._scanning():
-            self._report("Gateway restart refused — a scan is active on the manager.")
+        refusal = self._restart_refusal()
+        if refusal is not None:
+            self._report(refusal)
             return
         confirmed = self._ask_binary(
             "Restart gateway",
@@ -1522,6 +1541,11 @@ class MainWindow(QMainWindow):
             abort_label="Cancel",
         )
         if not confirmed:
+            return
+        # Re-check after the modal: polls landed while it was open.
+        refusal = self._restart_refusal()
+        if refusal is not None:
+            self._report(refusal)
             return
         # The default put rides the device-panel backend's persistent CA
         # loop (put_pv) — the stub refuses offline with a clear message.

--- a/GEECS-Console/geecs_console/app/main_window.py
+++ b/GEECS-Console/geecs_console/app/main_window.py
@@ -55,7 +55,11 @@ from geecs_console.editors.shot_control_editor import open_shot_control_editor
 from geecs_console.services import ops_paths
 from geecs_console.services.action_library_store import ActionLibraryStore
 from geecs_console.app.tooltips import ToolTipSuppressor, apply_operator_tooltips
-from geecs_console.services.background import BackgroundResult, HealthPoller
+from geecs_console.services.background import (
+    BackgroundResult,
+    HealthPoller,
+    disconnect_quietly,
+)
 from geecs_console.services.device_completions import (
     CompletionsProvider,
     GeecsDbCompletions,
@@ -509,6 +513,9 @@ class MainWindow(QMainWindow):
         self._menus: list = []
         ops = self.menuBar().addMenu("Ops")
         self._menus.append(ops)
+        # QMenu shows its actions' tooltips only when asked (Restart
+        # gateway… carries an operator tooltip — review of PR #796).
+        ops.setToolTipsVisible(True)
         for text, handler in (
             ("Open experiment config folder", self._on_open_experiment_configs),
             ("Open user config (config.ini)", self._on_open_user_config),
@@ -1068,20 +1075,14 @@ class MainWindow(QMainWindow):
             self._set_tooltips_shown(True)
         poller = getattr(self, "_health_poller", None)
         if poller is not None:
-            try:
-                poller.report_ready.disconnect(self._apply_health_report)
-            except (RuntimeError, TypeError):
-                pass
+            disconnect_quietly(poller.report_ready, self._apply_health_report)
         monitor = getattr(self, "_monitor", None)
         if monitor is not None:
             monitor.dispose()
         for worker_name in ("_stop_worker", "_submit_worker", "_restart_worker"):
             worker = getattr(self, worker_name, None)
             if worker is not None:
-                try:
-                    worker.result_ready.disconnect()
-                except (RuntimeError, TypeError):
-                    pass
+                disconnect_quietly(worker.result_ready)
         movable = getattr(self, "_movable", None)
         if movable is not None:
             movable.dispose()

--- a/GEECS-Console/geecs_console/app/main_window.py
+++ b/GEECS-Console/geecs_console/app/main_window.py
@@ -78,6 +78,7 @@ from geecs_console.services.device_panel import (
     DevicePanelBackend,
     StubDevicePanel,
 )
+from geecs_console.services.gateway_restart import request_gateway_restart
 from geecs_console.services.health import (
     HealthProbe,
     HealthReport,
@@ -238,6 +239,7 @@ class MainWindow(QMainWindow):
         rng: Optional[random.Random] = None,
         completions_factory: Optional[Callable[[str], CompletionsProvider]] = None,
         scan_number_lookup: Optional[Callable[[str], Optional[int]]] = None,
+        gateway_restart: Optional[Callable[[str], str]] = None,
     ) -> None:
         super().__init__()
         # Import the cycle-bearing packages once, here on the GUI thread,
@@ -281,6 +283,17 @@ class MainWindow(QMainWindow):
         self._last_beep_shots = 0
         self._completions_factory = completions_factory
         self._scan_number_lookup = scan_number_lookup
+        #: Ops → Restart gateway… (#773): the blocking restart put, injected
+        #: for tests; ``None`` resolves to the module-level
+        #: ``request_gateway_restart`` at click time (test-patchable).
+        self._gateway_restart = gateway_restart
+        #: Latest R1 health report (gates the restart action on the chip).
+        self._health_report = HealthReport()
+        self._restart_in_flight = False
+        #: A restart was requested and the heartbeat has not come back yet
+        #: — the health poll narrates the bounce (down → back) meanwhile.
+        self._restart_pending = False
+        self._restart_seen_down = False
         #: Non-modal editor dialogs opened from the Editors menu.  PySide6
         #: garbage-collects an unreferenced dialog wrapper and tears down the
         #: C++ dialog with it, so every opened editor is kept here.
@@ -289,8 +302,10 @@ class MainWindow(QMainWindow):
         self._apply_stylesheet()
         self._load_ui()
         self._bind_widgets()
-        apply_operator_tooltips(self)
         self._build_menus()
+        # After the menus: the catalog names menu actions too (#773's
+        # Restart gateway…), and a missing name raises loudly.
+        apply_operator_tooltips(self)
         self._build_status_bar()
         self._wire_signals()
 
@@ -496,6 +511,14 @@ class MainWindow(QMainWindow):
             action = ops.addAction(text)
             action.triggered.connect(handler)
         ops.addSeparator()
+        # Restart gateway… (#773): the operator escape hatch for frozen
+        # readbacks (a stale GEECS subscription — #611 is the long-term
+        # self-detection) and the DB-resync after a device edit.  Enabled
+        # only with an experiment selected and a *known* gateway chip;
+        # refused while a scan is active (_on_restart_gateway).
+        self.restart_gateway_action = ops.addAction("Restart gateway…")
+        self.restart_gateway_action.triggered.connect(self._on_restart_gateway)
+        ops.addSeparator()
         github = ops.addAction("GEECS-Plugins on GitHub")
         github.triggered.connect(self._on_open_github)
 
@@ -641,6 +664,12 @@ class MainWindow(QMainWindow):
             self._on_stop_result, Qt.ConnectionType.QueuedConnection
         )
         self._stop_in_flight = False
+        # Gateway restart put (#773): a blocking CA write, so it rides its
+        # own worker; the (ok, message) outcome lands in _on_restart_result.
+        self._restart_worker = BackgroundResult()
+        self._restart_worker.result_ready.connect(
+            self._on_restart_result, Qt.ConnectionType.QueuedConnection
+        )
         self._stop_button_label = self.stop_button.text()
         # Submission worker: the pre-submit preflight (config + DB + CA
         # reads) and the queue submission (0MQ round trips) both block, so
@@ -775,6 +804,37 @@ class MainWindow(QMainWindow):
         self.gateway_chip.setText(self._chip_markup("gateway", report.gateway))
         self.tiled_chip.setText(self._chip_markup("tiled", report.tiled))
         self.db_chip.setText(self._chip_markup("db", report.db))
+        self._health_report = report
+        self._narrate_gateway_bounce(report.gateway)
+        self._refresh_restart_gateway_action()
+
+    def _narrate_gateway_bounce(self, gateway: HealthStatus) -> None:
+        """Log-tail lines for a requested gateway restart (#773).
+
+        After the put, the heartbeat check on the 5 s health poll does the
+        rest: the chip goes DOWN then OK.  This makes the bounce legible —
+        "restarting" on the first DOWN, "back" on the first OK — and clears
+        the pending flag once the gateway is back.  A gateway that stays
+        DOWN (not run under the restart-on-exit-86 supervisor) leaves the
+        flag armed; the confirmation text warned about that case.
+
+        Parameters
+        ----------
+        gateway : HealthStatus
+            The polled gateway chip state.
+        """
+        if not self._restart_pending:
+            return
+        if gateway == HealthStatus.DOWN and not self._restart_seen_down:
+            self._restart_seen_down = True
+            self._report("gateway restarting — heartbeat down")
+        elif gateway in (HealthStatus.OK, HealthStatus.WARN):
+            self._restart_pending = False
+            self._report(
+                "gateway back — heartbeat OK"
+                if self._restart_seen_down
+                else "gateway back — heartbeat OK (the bounce fell between polls)"
+            )
 
     def _start_health_poller(self) -> None:
         """Start the background health poller and its GUI-thread interval timer.
@@ -998,7 +1058,7 @@ class MainWindow(QMainWindow):
         monitor = getattr(self, "_monitor", None)
         if monitor is not None:
             monitor.dispose()
-        for worker_name in ("_stop_worker", "_submit_worker"):
+        for worker_name in ("_stop_worker", "_submit_worker", "_restart_worker"):
             worker = getattr(self, worker_name, None)
             if worker is not None:
                 try:
@@ -1407,6 +1467,100 @@ class MainWindow(QMainWindow):
         """Ops: open the GEECS-Plugins GitHub page in the browser."""
         QDesktopServices.openUrl(QUrl(ops_paths.GITHUB_URL))
 
+    def _refresh_restart_gateway_action(self) -> None:
+        """Enable Ops → Restart gateway… only when it can address a gateway.
+
+        Needs an experiment (the PV is experiment-prefixed) and a gateway
+        chip that has read *something* (OK / WARN / DOWN — a DOWN gateway
+        under its supervisor is exactly when a restart may help; UNKNOWN
+        means no experiment or no poll yet), and no restart put in flight.
+        """
+        action = getattr(self, "restart_gateway_action", None)
+        if action is None:  # _apply_health_report seeds before the menus exist
+            return
+        action.setEnabled(
+            bool(self.experiment_combo.currentText())
+            and self._health_report.gateway != HealthStatus.UNKNOWN
+            and not self._restart_in_flight
+        )
+
+    def _on_restart_gateway(self) -> None:
+        """Ops: ask the CA gateway to restart itself (#773), after confirming.
+
+        Refused while a scan is active on the manager (the Start gate's
+        ``_scanning()`` — the worker's ophyd-async signals would see the
+        CA disconnect mid-scan).  The confirmation states the cost: a few
+        seconds of fleet-wide CA disconnect (every client's monitors
+        reconnect on their own), and that a gateway not run under the
+        restart-on-exit-86 supervisor stays down.  The put itself blocks,
+        so it runs on the restart worker; the health poll then narrates
+        the bounce (:meth:`_narrate_gateway_bounce`).
+        """
+        experiment = self.experiment_combo.currentText().strip()
+        if not experiment:
+            self._report("Gateway restart needs an experiment selected.")
+            return
+        if self._restart_in_flight:
+            return
+        if self._scanning():
+            self._report("Gateway restart refused — a scan is active on the manager.")
+            return
+        confirmed = self._ask_binary(
+            "Restart gateway",
+            f"Restart the {experiment} CA gateway?\n\n"
+            "Every CA client — this console, Phoebus, the scan worker, the "
+            "archiver — loses the gateway for a few seconds while it "
+            "relaunches and re-reads the device database; monitors "
+            "reconnect on their own.\n\n"
+            "This only works when the gateway runs under its restart-on-exit "
+            "supervisor (the shipped systemd unit).  A foreground gateway "
+            "simply exits and stays down.",
+            continue_label="Restart",
+            abort_label="Cancel",
+        )
+        if not confirmed:
+            return
+        restart = (
+            self._gateway_restart
+            if self._gateway_restart is not None
+            else request_gateway_restart
+        )
+
+        # Same rule as every worker callable: a raise inside the job is
+        # swallowed by BackgroundResult without emitting, which would leave
+        # the in-flight hold stuck — capture into a failure tuple.
+        def call() -> tuple[bool, str]:
+            try:
+                pv = restart(experiment)
+            except Exception as exc:  # noqa: BLE001 — deliver as a failure
+                return (False, f"gateway restart failed: {exc}")
+            return (
+                True,
+                f"gateway restart requested ({pv}) — expect a few seconds of CA disconnect",
+            )
+
+        self._restart_in_flight = True
+        self._refresh_restart_gateway_action()
+        self._report(f"restarting the {experiment} gateway…")
+        self._restart_worker.run_async(call, "gateway-restart")
+
+    @Slot(object)
+    def _on_restart_result(self, payload: object) -> None:
+        """Report the restart put's outcome and arm the bounce narration.
+
+        Parameters
+        ----------
+        payload : tuple
+            ``(ok, message)`` from the worker callable.
+        """
+        ok, message = payload
+        self._restart_in_flight = False
+        if ok:
+            self._restart_pending = True
+            self._restart_seen_down = False
+        self._report(message)
+        self._refresh_restart_gateway_action()
+
     # ------------------------------------------------------------------
     # Editors menu (each entry point shows a non-modal dialog and returns it)
     # ------------------------------------------------------------------
@@ -1416,6 +1570,7 @@ class MainWindow(QMainWindow):
         enabled = bool(self.experiment_combo.currentText())
         for action in self._editor_actions:
             action.setEnabled(enabled)
+        self._refresh_restart_gateway_action()
 
     def _open_editor(self, opener: Callable[..., object]) -> None:
         """Open one editor for the current experiment, holding a reference.

--- a/GEECS-Console/geecs_console/app/main_window.py
+++ b/GEECS-Console/geecs_console/app/main_window.py
@@ -879,8 +879,9 @@ class MainWindow(QMainWindow):
             info_addr=getattr(submitter, "info_addr", None),
             doc_addr=getattr(submitter, "doc_addr", None),
         )
-        # Queued connections throughout — poll results and stream documents
-        # arrive from daemon threads and must never paint widgets directly.
+        # Queued connections throughout.  Since 0.30.0 (#787) every one of
+        # these signals is already emitted on the GUI thread (the workers'
+        # hop); queued keeps the delivery off the emitting call stack.
         self._monitor.status_ready.connect(
             self._on_queue_status, Qt.ConnectionType.QueuedConnection
         )

--- a/GEECS-Console/geecs_console/app/main_window.py
+++ b/GEECS-Console/geecs_console/app/main_window.py
@@ -296,6 +296,10 @@ class MainWindow(QMainWindow):
         #: — the health poll narrates the bounce (down → back) meanwhile.
         self._restart_pending = False
         self._restart_seen_down = False
+        #: ``HealthPoller.polls_started`` when the put completed: a report
+        #: from a poll that began earlier read the gateway *before* the put
+        #: and must not narrate (review of PR #796).
+        self._restart_arm_sequence = 0
         #: Non-modal editor dialogs opened from the Editors menu.  PySide6
         #: garbage-collects an unreferenced dialog wrapper and tears down the
         #: C++ dialog with it, so every opened editor is kept here.
@@ -807,10 +811,10 @@ class MainWindow(QMainWindow):
         self.tiled_chip.setText(self._chip_markup("tiled", report.tiled))
         self.db_chip.setText(self._chip_markup("db", report.db))
         self._health_report = report
-        self._narrate_gateway_bounce(report.gateway)
+        self._narrate_gateway_bounce(report)
         self._refresh_restart_gateway_action()
 
-    def _narrate_gateway_bounce(self, gateway: HealthStatus) -> None:
+    def _narrate_gateway_bounce(self, report: HealthReport) -> None:
         """Log-tail lines for a requested gateway restart (#773).
 
         After the put, the heartbeat check on the 5 s health poll does the
@@ -820,13 +824,23 @@ class MainWindow(QMainWindow):
         DOWN (not run under the restart-on-exit-86 supervisor) leaves the
         flag armed; the confirmation text warned about that case.
 
+        Only reports from polls that began *after* the put completed
+        count (``report.sequence`` vs the arm point): a poll already out
+        when the put landed read a pre-put heartbeat, and its late "OK"
+        would narrate "back" while the gateway is going down (review of
+        PR #796).  Unstamped reports (sequence 0 — a seed, a direct call)
+        never narrate.
+
         Parameters
         ----------
-        gateway : HealthStatus
-            The polled gateway chip state.
+        report : HealthReport
+            The polled chip states, sequence-stamped by the poller.
         """
         if not self._restart_pending:
             return
+        if report.sequence <= self._restart_arm_sequence:
+            return
+        gateway = report.gateway
         if gateway == HealthStatus.DOWN and not self._restart_seen_down:
             self._restart_seen_down = True
             self._report("gateway restarting — heartbeat down")
@@ -1585,6 +1599,10 @@ class MainWindow(QMainWindow):
         if ok:
             self._restart_pending = True
             self._restart_seen_down = False
+            poller = getattr(self, "_health_poller", None)
+            self._restart_arm_sequence = (
+                poller.polls_started if poller is not None else 0
+            )
         self._report(message)
         self._refresh_restart_gateway_action()
 

--- a/GEECS-Console/geecs_console/app/main_window.py
+++ b/GEECS-Console/geecs_console/app/main_window.py
@@ -12,6 +12,7 @@ network.
 
 from __future__ import annotations
 
+import functools
 import logging
 import os
 import random
@@ -285,7 +286,8 @@ class MainWindow(QMainWindow):
         self._scan_number_lookup = scan_number_lookup
         #: Ops → Restart gateway… (#773): the blocking restart put, injected
         #: for tests; ``None`` resolves to the module-level
-        #: ``request_gateway_restart`` at click time (test-patchable).
+        #: ``request_gateway_restart`` over the device-panel backend at
+        #: click time (test-patchable).
         self._gateway_restart = gateway_restart
         #: Latest R1 health report (gates the restart action on the chip).
         self._health_report = HealthReport()
@@ -1521,10 +1523,10 @@ class MainWindow(QMainWindow):
         )
         if not confirmed:
             return
-        restart = (
-            self._gateway_restart
-            if self._gateway_restart is not None
-            else request_gateway_restart
+        # The default put rides the device-panel backend's persistent CA
+        # loop (put_pv) — the stub refuses offline with a clear message.
+        restart = self._gateway_restart or functools.partial(
+            request_gateway_restart, backend=self._device_panel
         )
 
         # Same rule as every worker callable: a raise inside the job is

--- a/GEECS-Console/geecs_console/app/main_window.py
+++ b/GEECS-Console/geecs_console/app/main_window.py
@@ -131,6 +131,13 @@ _HEALTH_DOT_COLORS = {
 # RE returning to idle means the scan is over either way.  Deliberately NOT
 # "paused" — that state is resumable, the scan is not over.
 _TERMINAL_SCAN_STATES = frozenset({"aborted", "done", "idle"})
+#: Pill states under which no scan is in progress on the document stream.
+#: The restart gate reads the pill beside the polled status: a start
+#: document paints RUNNING before the matching status poll lands, and the
+#: poll alone would wave a restart through in that window (Codex review
+#: of PR #796).  "unknown" (manager unreachable) is quiet — there is
+#: nothing to protect that the poll could see either.
+_QUIET_PILL_STATES = frozenset({"idle", "done", "aborted", "unknown", ""})
 
 #: After a terminal document renders, live-state asserts from the status
 #: poll are suppressed this long — a snapshot *taken* pre-stop but
@@ -1507,11 +1514,13 @@ class MainWindow(QMainWindow):
 
         Two activities would see the CA disconnect mid-flight: a scan on
         the manager (the Start gate's ``_scanning()`` — the worker's
-        ophyd-async signals) and the R7 panel's manual set/move (a
+        ophyd-async signals — OR the document-driven pill, which a start
+        document paints RUNNING before the matching status poll lands;
+        Codex review of PR #796) and the R7 panel's manual set/move (a
         worker-side ``move_variable`` never changes ``re_state``, so
         ``_scanning()`` alone would wave it through — review of PR #796).
         """
-        if self._scanning():
+        if self._scanning() or self._scan_state_text not in _QUIET_PILL_STATES:
             return "Gateway restart refused — a scan is active on the manager."
         if self._movable.set_in_flight:
             return "Gateway restart refused — a manual set/move is in flight."

--- a/GEECS-Console/geecs_console/app/movable_panel.py
+++ b/GEECS-Console/geecs_console/app/movable_panel.py
@@ -48,7 +48,11 @@ from typing import Any, Callable, Optional
 from PySide6.QtCore import QObject, Qt, Slot
 from PySide6.QtWidgets import QComboBox, QLabel, QLineEdit, QPushButton
 
-from geecs_console.services.background import BackgroundResult, GuiRelay
+from geecs_console.services.background import (
+    BackgroundResult,
+    GuiRelay,
+    disconnect_quietly,
+)
 from geecs_console.services.device_panel import (
     DevicePanelBackend,
     format_readback,
@@ -458,21 +462,14 @@ class MovablePanelController(QObject):
             self._backend.unsubscribe()
         except Exception:  # noqa: BLE001 — teardown must not raise
             pass
-        for worker, slot in (
-            (self._set_worker, self._apply_set_result),
-            (self._completions_worker, self._apply_completions),
-        ):
-            try:
-                worker.result_ready.disconnect(slot)
-            except (RuntimeError, TypeError):
-                pass
+        disconnect_quietly(self._set_worker.result_ready, self._apply_set_result)
+        disconnect_quietly(
+            self._completions_worker.result_ready, self._apply_completions
+        )
         # A readback still crossing the hop lands and is dropped, never
         # emitted at a controller being torn down.
         self._readback_relay.close()
-        try:
-            self._readback_relay.delivered.disconnect(self._apply_value)
-        except (RuntimeError, TypeError):
-            pass
+        disconnect_quietly(self._readback_relay.delivered, self._apply_value)
         # Sever every controller → window edge (the #534 lifetime rule) —
         # the completions provider included: the window passes it as a
         # lambda closing over itself (review, PR #598).

--- a/GEECS-Console/geecs_console/app/movable_panel.py
+++ b/GEECS-Console/geecs_console/app/movable_panel.py
@@ -279,6 +279,17 @@ class MovablePanelController(QObject):
     # Set / move
     # ------------------------------------------------------------------
 
+    @property
+    def set_in_flight(self) -> bool:
+        """Whether a manual set/move is out on the set worker (GUI-thread state).
+
+        The window's gateway-restart gate reads this beside the manager's
+        ``re_state``: a worker-side ``move_variable`` (``function_execute``)
+        never changes ``re_state``, so without it a restart could pull the
+        gateway out from under an in-flight move (review of PR #796).
+        """
+        return self._set_in_flight
+
     def refresh_set_enabled(self, *_args: object) -> None:
         """Gate the Set button: resolvable selection, a value, nothing in flight."""
         name, targets = self._resolve_selection(self._combo.currentText())

--- a/GEECS-Console/geecs_console/app/movable_panel.py
+++ b/GEECS-Console/geecs_console/app/movable_panel.py
@@ -30,9 +30,13 @@ window↔controller cycle that defers C++ teardown to the cyclic GC — a
 segfault under offscreen pytest), every dependency constructor-injected,
 blocking work on the controller's own :class:`BackgroundResult` worker
 (issue #510: the daemon thread emits on the worker, never the window),
-monitor values delivered through the controller's **queued** ``value_ready``
-signal, and an idempotent :meth:`dispose` (called from the window's
-``closeEvent``) that unsubscribes, disconnects, and severs every
+monitor values posted from the CA loop thread through a
+:class:`~geecs_console.services.background.GuiRelay` — the readback
+worker — whose ``delivered`` signal is emitted **on the GUI thread**
+(#787; before 0.30.0 the CA thread emitted a controller-owned signal
+directly, the race class behind the offscreen segfaults), and an
+idempotent :meth:`dispose` (called from the window's ``closeEvent``) that
+unsubscribes, closes the relay, disconnects, and severs every
 controller→window reference.
 """
 
@@ -41,10 +45,10 @@ from __future__ import annotations
 import logging
 from typing import Any, Callable, Optional
 
-from PySide6.QtCore import QObject, Qt, Signal, Slot
+from PySide6.QtCore import QObject, Qt, Slot
 from PySide6.QtWidgets import QComboBox, QLabel, QLineEdit, QPushButton
 
-from geecs_console.services.background import BackgroundResult
+from geecs_console.services.background import BackgroundResult, GuiRelay
 from geecs_console.services.device_panel import (
     DevicePanelBackend,
     format_readback,
@@ -91,9 +95,6 @@ class MovablePanelController(QObject):
         One-arg callable for status-bar + log-tail messages.
     """
 
-    #: (target_index, value) from the CA monitor thread — connected queued.
-    value_ready = Signal(int, object)
-
     def __init__(
         self,
         *,
@@ -128,7 +129,12 @@ class MovablePanelController(QObject):
         self._set_in_flight = False
         self._disposed = False
 
-        self.value_ready.connect(self._apply_value, Qt.ConnectionType.QueuedConnection)
+        #: Readback worker: the backend calls ``post((index, value))`` on
+        #: the CA loop thread; ``delivered`` fires on the GUI thread.
+        self._readback_relay = GuiRelay()
+        self._readback_relay.delivered.connect(
+            self._apply_value, Qt.ConnectionType.QueuedConnection
+        )
         self._set_worker = BackgroundResult()
         self._set_worker.result_ready.connect(
             self._apply_set_result, Qt.ConnectionType.QueuedConnection
@@ -206,11 +212,12 @@ class MovablePanelController(QObject):
             return
         try:
             subscribe_many = getattr(self._backend, "subscribe_many", None)
+            post = self._readback_relay.post
             if subscribe_many is not None:
                 subscribe_many(
                     self._current_experiment(),
                     list(self._targets),
-                    self.value_ready.emit,
+                    lambda index, value: post((index, value)),
                 )
             elif len(self._targets) == 1:
                 # Older/injected single-monitor backends (duck-typed seam).
@@ -219,7 +226,7 @@ class MovablePanelController(QObject):
                     self._current_experiment(),
                     device,
                     variable,
-                    lambda value: self.value_ready.emit(0, value),
+                    lambda value: post((0, value)),
                 )
             else:
                 self._report(
@@ -254,9 +261,10 @@ class MovablePanelController(QObject):
         self._combo.blockSignals(False)
         self.resubscribe()
 
-    @Slot(int, object)
-    def _apply_value(self, index: int, value: object) -> None:
-        """Render one monitor value (GUI-thread slot, delivered queued)."""
+    @Slot(object)
+    def _apply_value(self, payload: object) -> None:
+        """Render one ``(index, value)`` monitor payload (GUI-thread slot)."""
+        index, value = payload
         if not (0 <= index < len(self._values)):
             return  # straggler from a retired subscription shape
         self._values[index] = value
@@ -447,8 +455,11 @@ class MovablePanelController(QObject):
                 worker.result_ready.disconnect(slot)
             except (RuntimeError, TypeError):
                 pass
+        # A readback still crossing the hop lands and is dropped, never
+        # emitted at a controller being torn down.
+        self._readback_relay.close()
         try:
-            self.value_ready.disconnect(self._apply_value)
+            self._readback_relay.delivered.disconnect(self._apply_value)
         except (RuntimeError, TypeError):
             pass
         # Sever every controller → window edge (the #534 lifetime rule) —

--- a/GEECS-Console/geecs_console/app/scan_monitor.py
+++ b/GEECS-Console/geecs_console/app/scan_monitor.py
@@ -15,13 +15,17 @@ manager client:
   (``FAILED_MOVE_LOG_PREFIX``) so a ``paused`` pill can say *why*.
 
 Controller rules (#534 checklist): ``QObject`` with **no Qt parent**;
-injected addresses and callables, never the window; every daemon thread
-emits on a **worker-owned** signal connected ``QueuedConnection`` by the
-consumer (emitting a window-owned signal from a daemon thread segfaults
-under offscreen pytest — ``services/background.py`` rule); an idempotent
-:meth:`dispose` the window's ``closeEvent`` calls.  The stream sockets are
-long-lived daemon threads: ``dispose()`` marks them stale (signals stop),
-closes what can be closed safely, and never joins.
+injected addresses and callables, never the window; **no daemon thread
+emits toward a consumer** — each stream worker is a
+``services/background.py::_GuiHopWorker``: the zmq thread posts a tagged
+payload through the worker's own queued hop and the public signal
+(``document`` / ``line`` / ``pause_reason`` / ``stream_failed``) is
+emitted on the GUI thread (#787 — the pre-0.30.0 shape emitted from the
+zmq thread at the window, the race class that segfaulted offscreen
+pytest); an idempotent :meth:`dispose` the window's ``closeEvent`` calls.
+The stream sockets are long-lived daemon threads: ``dispose()`` marks them
+stale (posting stops, and a payload already in flight lands and is
+dropped), severs the public signals, and never joins.
 """
 
 from __future__ import annotations
@@ -31,6 +35,8 @@ import threading
 from typing import Any, Optional
 
 from PySide6.QtCore import QObject, Signal
+
+from geecs_console.services.background import _GuiHopWorker, disconnect_quietly
 
 logger = logging.getLogger(__name__)
 
@@ -51,38 +57,95 @@ def _failed_move_prefix() -> str:
         return _FAILED_MOVE_PREFIX_FALLBACK
 
 
-class DocumentStreamWorker(QObject):
+class _StreamWorker(_GuiHopWorker):
+    """Shared shape of the two stream workers: a gated, abandoned thread.
+
+    ``start()`` spawns the daemon thread (idempotent); :meth:`stop` only
+    gates emission and **abandons** the thread: the socket/loop inside
+    must never be touched from another thread (pyzmq sockets are not
+    thread-safe — a cross-thread close can trip a libzmq assertion, which
+    *aborts* the process rather than raising; #653 review finding 3), and
+    the thread dies with the app anyway.  The gate is checked twice: on
+    the zmq thread before posting, and again in :meth:`_deliver` on the
+    GUI thread — so after ``stop()`` nothing is emitted, not even a
+    payload that was already in flight.
+    """
+
+    #: Public signals a consumer may have connected (severed by
+    #: :meth:`sever`; the internal hop connection is left alone).
+    PUBLIC_SIGNALS: tuple[str, ...] = ("stream_failed",)
+
+    stream_failed = Signal(str)
+
+    def __init__(self, addr: str, thread_name: str) -> None:
+        super().__init__()
+        self._addr = addr
+        self._thread_name = thread_name
+        self._stopped = False
+        self._thread: Optional[threading.Thread] = None
+
+    def start(self) -> None:
+        """Spawn the stream thread (idempotent)."""
+        if self._thread is not None:
+            return
+        self._thread = threading.Thread(
+            target=self._run, name=self._thread_name, daemon=True
+        )
+        self._thread.start()
+
+    def _run(self) -> None:  # pragma: no cover — subclasses own the socket loop
+        raise NotImplementedError
+
+    def stop(self) -> None:
+        """Gate further emissions (idempotent; touches nothing else, never joins)."""
+        self._stopped = True
+
+    def sever(self) -> None:
+        """Detach every consumer from the public signals (GUI thread, idempotent).
+
+        Deliberately **not** ``QObject.disconnect()`` on the whole worker:
+        that would also cut the internal ``_landed`` → ``_forward`` hop,
+        stranding an in-flight payload's hold forever.
+        """
+        for name in self.PUBLIC_SIGNALS:
+            disconnect_quietly(getattr(self, name))
+
+    def _fail(self, message: str) -> None:
+        """Post a setup failure (zmq thread) unless already stopped."""
+        if not self._stopped:
+            self._post(("failed", message))
+
+    def _deliver(self, payload: object) -> None:
+        """Dispatch one tagged payload on the GUI thread (gated on ``stop``)."""
+        if self._stopped:
+            return
+        tag, *args = payload  # type: ignore[misc]
+        if tag == "failed":
+            self.stream_failed.emit(*args)
+        else:
+            self._emit(tag, *args)
+
+    def _emit(self, tag: str, *args: Any) -> None:  # pragma: no cover — subclass
+        raise NotImplementedError
+
+
+class DocumentStreamWorker(_StreamWorker):
     """Daemon-thread consumer of the worker's bluesky document stream.
 
     Emits ``document(name, doc)`` for every document received and
     ``stream_failed(str)`` if the stream cannot be set up (bad address,
     missing import) — post-setup, the zmq SUB socket reconnects on its own
-    and needs no supervision.  Signals are worker-owned; consumers connect
-    them ``QueuedConnection``.  ``start()`` spawns the thread; :meth:`stop`
-    only gates emission and **abandons** the daemon thread: the
-    dispatcher's zmq socket/loop must never be touched from another thread
-    (pyzmq sockets are not thread-safe — a cross-thread close can trip a
-    libzmq assertion, which *aborts* the process rather than raising; #653
-    review finding 3).
+    and needs no supervision.  Both signals are emitted **on the GUI
+    thread** (the :class:`_StreamWorker` hop); consumers connect them
+    ``QueuedConnection`` as before.
     """
 
+    PUBLIC_SIGNALS = ("document", "stream_failed")
+
     document = Signal(str, object)
-    stream_failed = Signal(str)
 
     def __init__(self, doc_addr: str) -> None:
-        super().__init__()
-        self._addr = doc_addr
-        self._stopped = False
-        self._thread: Optional[threading.Thread] = None
-
-    def start(self) -> None:
-        """Spawn the dispatcher thread (idempotent)."""
-        if self._thread is not None:
-            return
-        self._thread = threading.Thread(
-            target=self._run, name="qs-doc-stream", daemon=True
-        )
-        self._thread.start()
+        super().__init__(doc_addr, "qs-doc-stream")
 
     def _run(self) -> None:
         try:
@@ -92,59 +155,39 @@ class DocumentStreamWorker(QObject):
 
             def _forward(name: str, doc: dict) -> None:
                 if not self._stopped:
-                    self.document.emit(name, dict(doc))
+                    self._post(("document", name, dict(doc)))
 
             dispatcher.subscribe(_forward)
             dispatcher.start()  # blocks for the thread's lifetime
         except Exception as exc:
             if not self._stopped:
                 logger.warning("document stream at %s ended", self._addr, exc_info=True)
-                try:
-                    self.stream_failed.emit(
-                        f"document stream unavailable ({exc}) — live "
-                        "per-shot progress is off"
-                    )
-                except RuntimeError:
-                    pass  # the worker was deleted during teardown
+                self._fail(
+                    f"document stream unavailable ({exc}) — live "
+                    "per-shot progress is off"
+                )
 
-    def stop(self) -> None:
-        """Gate further emissions (idempotent).
-
-        Deliberately touches nothing else: the dispatcher is abandoned
-        with its daemon thread (see the class docstring — a cross-thread
-        zmq close can abort the process, and the thread dies with the app
-        anyway).
-        """
-        self._stopped = True
+    def _emit(self, tag: str, *args: Any) -> None:
+        self.document.emit(*args)
 
 
-class ConsoleStreamWorker(QObject):
+class ConsoleStreamWorker(_StreamWorker):
     """Daemon-thread consumer of the manager's console-output text stream.
 
     Emits ``line(str)`` per received line, ``pause_reason(str)`` when a
     line carries the engine's failed-move prefix — the paused pill's "why"
-    — and ``stream_failed(str)`` if the monitor cannot be set up.
-    Text only: this stream never carries documents (see qserver/README.md).
+    — and ``stream_failed(str)`` if the monitor cannot be set up.  All on
+    the GUI thread (the :class:`_StreamWorker` hop).  Text only: this
+    stream never carries documents (see qserver/README.md).
     """
+
+    PUBLIC_SIGNALS = ("line", "pause_reason", "stream_failed")
 
     line = Signal(str)
     pause_reason = Signal(str)
-    stream_failed = Signal(str)
 
     def __init__(self, info_addr: str) -> None:
-        super().__init__()
-        self._addr = info_addr
-        self._stopped = False
-        self._thread: Optional[threading.Thread] = None
-
-    def start(self) -> None:
-        """Spawn the monitor thread (idempotent)."""
-        if self._thread is not None:
-            return
-        self._thread = threading.Thread(
-            target=self._run, name="qs-console-stream", daemon=True
-        )
-        self._thread.start()
+        super().__init__(info_addr, "qs-console-stream")
 
     def _run(self) -> None:
         try:
@@ -173,28 +216,28 @@ class ConsoleStreamWorker(QObject):
         except Exception as exc:
             if not self._stopped:
                 logger.warning("console stream at %s ended", self._addr, exc_info=True)
-                try:
-                    self.stream_failed.emit(
-                        f"console-output stream unavailable ({exc}) — the "
-                        "log tail and pause reasons are off"
-                    )
-                except RuntimeError:
-                    pass  # the worker was deleted during teardown
+                self._fail(
+                    f"console-output stream unavailable ({exc}) — the "
+                    "log tail and pause reasons are off"
+                )
 
     def _handle_text(self, text: str, prefix: str) -> None:
+        """Split *text* into lines and post each (plus any pause reason)."""
         for raw_line in text.splitlines():
             stripped = raw_line.rstrip()
             if not stripped or self._stopped:
                 continue
-            self.line.emit(stripped)
+            self._post(("line", stripped))
             if prefix in stripped:
                 # Everything after the prefix is the engine's reason text.
                 reason = stripped.split(prefix, 1)[1].lstrip(" :-")
-                self.pause_reason.emit(reason or stripped)
+                self._post(("pause_reason", reason or stripped))
 
-    def stop(self) -> None:
-        """Stop the loop and further emissions (idempotent; never joins)."""
-        self._stopped = True
+    def _emit(self, tag: str, *args: Any) -> None:
+        if tag == "line":
+            self.line.emit(*args)
+        elif tag == "pause_reason":
+            self.pause_reason.emit(*args)
 
 
 class _StatusProbe:
@@ -281,11 +324,7 @@ class ScanMonitorController(QObject):
         for worker in (self.documents, self.console):
             if worker is not None:
                 worker.stop()
-                try:
-                    worker.disconnect()
-                except (RuntimeError, TypeError):
-                    pass
-        try:
-            self._poller.report_ready.disconnect()
-        except (RuntimeError, TypeError):
-            pass
+                worker.sever()
+        # Quietly: a monitor whose status_ready nobody connected (tests)
+        # would otherwise warn "Failed to disconnect (None)".
+        disconnect_quietly(self._poller.report_ready)

--- a/GEECS-Console/geecs_console/app/tooltips.py
+++ b/GEECS-Console/geecs_console/app/tooltips.py
@@ -84,6 +84,12 @@ OPERATOR_TOOLTIPS: dict[str, str] = {
         "STANDBY / SCAN / ... device writes). Empty means the scan "
         "leaves the trigger alone."
     ),
+    "restart_gateway_action": (
+        "Ask the CA gateway to restart itself — the fix for frozen readbacks "
+        "(a stale GEECS subscription) and the way to pick up device-database "
+        "edits.  Every CA client loses the gateway for a few seconds; refused "
+        "while a scan is active."
+    ),
     "gateway_chip": (
         "CA gateway health: reads the experiment's heartbeat PV "
         "every few seconds. WARN means the gateway runs but reports "

--- a/GEECS-Console/geecs_console/editors/action_library_editor.py
+++ b/GEECS-Console/geecs_console/editors/action_library_editor.py
@@ -21,9 +21,9 @@ Design notes
 - Device/variable fields carry a ``QCompleter`` fed by an injectable
   :class:`~geecs_console.services.device_completions.CompletionsProvider`
   (the shared editor seam) — fetched **once on a short-lived daemon thread**
-  (the package's no-QThread rule) and marshaled back through the queued
-  ``completions_ready`` signal, so a slow or unreachable DB never blocks
-  the GUI thread.  The production ``GeecsDbCompletions`` degrades to empty
+  (the package's no-QThread rule) through the shared ``BackgroundResult``
+  worker, whose result lands on the GUI thread, so a slow or unreachable
+  DB never blocks the GUI thread.  The production ``GeecsDbCompletions`` degrades to empty
   on any failure; tests inject fakes; the constructor default is
   ``EmptyCompletions`` (offline).
 - Enter never accepts the dialog (every button is non-default and the

--- a/GEECS-Console/geecs_console/editors/base.py
+++ b/GEECS-Console/geecs_console/editors/base.py
@@ -61,7 +61,7 @@ from PySide6.QtWidgets import (
     QWidget,
 )
 
-from geecs_console.services.background import BackgroundResult
+from geecs_console.services.background import BackgroundResult, disconnect_quietly
 from geecs_console.services.device_completions import (
     CompletionsProvider,
     EmptyCompletions,
@@ -527,9 +527,6 @@ class ConfigEditorDialog(QDialog):
         # owner teardown) and a second disconnect warns.
         if not self._completions_disconnected:
             self._completions_disconnected = True
-            try:
-                self._completions_worker.result_ready.disconnect(
-                    self._apply_completions
-                )
-            except (RuntimeError, TypeError):
-                pass
+            disconnect_quietly(
+                self._completions_worker.result_ready, self._apply_completions
+            )

--- a/GEECS-Console/geecs_console/editors/base.py
+++ b/GEECS-Console/geecs_console/editors/base.py
@@ -13,12 +13,14 @@ What lives here:
 - The Enter-key guard, both mechanisms applied uniformly: no
   default/auto-default buttons (:meth:`_guard_enter_keys`) and a
   :meth:`keyPressEvent` that swallows Return/Enter.
-- The completions scaffold: one queued ``completions_ready`` signal, a
-  daemon-thread fetch with the ``EmptyCompletions`` inline fast-path (no
-  thread for a constant — offline construction stays thread-free), the
+- The completions scaffold: one fetch on the blessed
+  ``services/background.py::BackgroundResult`` worker (the daemon thread
+  never emits toward the dialog — the result hops onto the GUI thread
+  first; #787), with the ``EmptyCompletions`` inline fast-path (no thread
+  for a constant — offline construction stays thread-free), the
   normalized ``{device: [variable, ...]}`` word lists in
   :attr:`_device_vars`, the public ``completions_applied`` flag tests
-  wait on, and the one-shot signal disconnect at close.
+  wait on, and the one-shot worker disconnect at close.
 - The unified unsaved-changes flow: :meth:`_prompt_unsaved`
   (Save/Discard/Cancel, three-way string result) resolved by
   :meth:`_resolve_unsaved` through the per-editor hooks
@@ -43,12 +45,11 @@ from __future__ import annotations
 
 import difflib
 import logging
-import threading
 from collections.abc import Iterable, Mapping, Sequence
 from pathlib import Path
 from typing import Optional
 
-from PySide6.QtCore import QFile, Qt, Signal, Slot
+from PySide6.QtCore import QFile, Qt, Slot
 from PySide6.QtGui import QCloseEvent, QKeyEvent
 from PySide6.QtUiTools import QUiLoader
 from PySide6.QtWidgets import (
@@ -60,6 +61,7 @@ from PySide6.QtWidgets import (
     QWidget,
 )
 
+from geecs_console.services.background import BackgroundResult
 from geecs_console.services.device_completions import (
     CompletionsProvider,
     EmptyCompletions,
@@ -201,11 +203,6 @@ class ConfigEditorDialog(QDialog):
     #: recognizable thread dumps).
     COMPLETIONS_THREAD_NAME: str = "editor-completions-fetch"
 
-    #: One ``{device: [variable, ...]}`` mapping per finished provider
-    #: call (emitted from the fetch daemon thread; delivered queued to
-    #: :meth:`_apply_completions`).
-    completions_ready = Signal(object)
-
     # ------------------------------------------------------------------
     # UI loading
     # ------------------------------------------------------------------
@@ -261,11 +258,13 @@ class ConfigEditorDialog(QDialog):
     # ------------------------------------------------------------------
 
     def _init_completions(self, provider: Optional[CompletionsProvider]) -> None:
-        """Install the completions state and the queued signal connection.
+        """Install the completions state and the fetch worker.
 
-        Call early in ``__init__`` (before any fetch).  The connection is
-        forced queued: the fetch emits from a daemon thread, and a direct
-        delivery would touch state on the wrong thread.
+        Call early in ``__init__`` (before any fetch).  The worker's
+        ``result_ready`` is emitted on the GUI thread (the
+        ``BackgroundResult`` hop) and connected queued, so the mapping
+        lands in :meth:`_apply_completions` one event-loop turn later —
+        never touching dialog state from the fetch thread.
 
         Parameters
         ----------
@@ -286,43 +285,42 @@ class ConfigEditorDialog(QDialog):
         #: True once the (async) completions fetch has been delivered on
         #: the GUI thread — tests wait on this instead of sleeping.
         self.completions_applied = False
-        #: Guards the one-shot signal disconnect in :meth:`closeEvent`.
+        #: Guards the one-shot worker disconnect in :meth:`closeEvent`.
         self._completions_disconnected = False
-        self.completions_ready.connect(
+        self._completions_worker = BackgroundResult()
+        self._completions_worker.result_ready.connect(
             self._apply_completions, Qt.ConnectionType.QueuedConnection
         )
 
     def _start_completions_fetch(self) -> None:
-        """Fetch completions on a short-lived daemon thread (queued delivery).
+        """Fetch completions on the worker's short-lived daemon thread.
 
         The :class:`EmptyCompletions` default is answered inline (no
         thread to spawn for a constant) — offline construction stays
-        thread-free.
-
-        Known debt: the daemon thread emits a *dialog-owned* signal
-        instead of routing through the blessed
-        ``services/background.py::BackgroundResult`` worker, and an
-        Esc-closed dialog (``reject`` → ``done()``, no ``QCloseEvent``)
-        never runs the close-time disconnect.  Consolidate onto
-        ``BackgroundResult`` here, once — not per editor.
+        thread-free.  The fetch callable never raises (a failing provider
+        yields ``{}``) — ``BackgroundResult`` swallows a raise without
+        emitting, which would leave ``completions_applied`` False forever.
+        Since 0.30.0 (#787) this rides the blessed worker instead of a
+        dialog-owned signal emitted from the thread; a dialog closed by
+        Esc (``reject``, no ``QCloseEvent``) before the fetch lands is
+        therefore safe too — the result is emitted on the GUI thread, at
+        a dialog that is hidden, not half-destroyed.
         """
         if isinstance(self._completions, EmptyCompletions):
             self.completions_applied = True
             return
         provider = self._completions
 
-        def fetch() -> None:
+        def fetch() -> dict:
             """Run the provider's one blocking call off the GUI thread."""
             try:
                 mapping = provider.device_variables()
             except Exception as exc:  # noqa: BLE001 — providers should not raise
                 logger.info("completions fetch failed: %s", exc)
                 mapping = {}
-            self.completions_ready.emit(mapping or {})
+            return mapping or {}
 
-        threading.Thread(
-            target=fetch, name=self.COMPLETIONS_THREAD_NAME, daemon=True
-        ).start()
+        self._completions_worker.run_async(fetch, name=self.COMPLETIONS_THREAD_NAME)
 
     @Slot(object)
     def _apply_completions(self, mapping: object) -> None:
@@ -331,7 +329,7 @@ class ConfigEditorDialog(QDialog):
         Parameters
         ----------
         mapping : dict
-            The provider result delivered by the queued signal.
+            The provider result delivered by the worker's ``result_ready``.
         """
         self.completions_applied = True
         if not isinstance(mapping, dict):
@@ -510,7 +508,7 @@ class ConfigEditorDialog(QDialog):
         super().reject()
 
     def closeEvent(self, event: QCloseEvent) -> None:  # noqa: N802 (Qt override)
-        """Close via QDialog (one prompt), then disconnect the completions signal.
+        """Close via QDialog (one prompt), then detach the completions worker.
 
         :meth:`reject` is the **only** prompt owner: ``QDialog::closeEvent``
         routes a *visible* close through the virtual ``reject()`` (ours,
@@ -524,12 +522,14 @@ class ConfigEditorDialog(QDialog):
         super().closeEvent(event)
         if not event.isAccepted():
             return  # the operator canceled — the dialog stays open
-        # A still-running completions fetch must not queue an event onto a
-        # dialog being torn down.  Once only: closeEvent can run twice
-        # (explicit close + owner teardown) and a second disconnect warns.
+        # A still-running completions fetch must not land on a dialog being
+        # torn down.  Once only: closeEvent can run twice (explicit close +
+        # owner teardown) and a second disconnect warns.
         if not self._completions_disconnected:
             self._completions_disconnected = True
             try:
-                self.completions_ready.disconnect(self._apply_completions)
+                self._completions_worker.result_ready.disconnect(
+                    self._apply_completions
+                )
             except (RuntimeError, TypeError):
                 pass

--- a/GEECS-Console/geecs_console/editors/base.py
+++ b/GEECS-Console/geecs_console/editors/base.py
@@ -34,7 +34,13 @@ What lives here:
   pair name something in the fetched listing?  Free text + completer
   stays (the editors must work with the DB unreachable); the gate is at
   Save, where an unknown name blocks with a near-miss hint and an empty
-  listing downgrades to :data:`UNCHECKED_TARGETS_NOTE`.
+  listing downgrades to :data:`UNCHECKED_TARGETS_NOTE`, and a listing
+  still loading (:attr:`ConfigEditorDialog.completions_pending`) refuses
+  the save until it lands.  Wired into the save-set and scan-variable
+  editors (the two whose targets name device variables); the trigger
+  and action-plan editors do not run it — action steps' ``device`` /
+  ``variable`` texts are a deliberate follow-up (their steps also name
+  non-DB verbs such as waits).
 
 The prompt methods are plain bound methods so tests can monkeypatch them
 per instance (``editor._prompt_unsaved = lambda: "discard"``) — the
@@ -73,6 +79,7 @@ logger = logging.getLogger(__name__)
 #: could not be checked (no completions listing: offline, DB down, fetch
 #: failed).  The save goes through — the editors must stay usable off the
 #: lab network — but the operator is told what was skipped.
+COMPLETIONS_PENDING_NOTE = "device listing still loading — Save again in a moment"
 UNCHECKED_TARGETS_NOTE = (
     "device and variable names were not checked against the database "
     "(completions unavailable)"
@@ -353,14 +360,31 @@ class ConfigEditorDialog(QDialog):
         return bool(self._device_vars)
 
     @property
+    def completions_pending(self) -> bool:
+        """Whether a real listing was requested and has not landed yet.
+
+        Distinct from :attr:`targets_unchecked`: "still loading" is not
+        "DB down".  A Save in this window would persist unchecked names
+        against a provider that is about to answer (Codex review of PR
+        #796), so the editors refuse the save until the fetch lands.
+        """
+        return self._completions_expected and not self.completions_applied
+
+    @property
     def targets_unchecked(self) -> bool:
         """Whether a save should carry :data:`UNCHECKED_TARGETS_NOTE`.
 
-        True only when a listing was expected (a real provider) and none
-        arrived — the offline / DB-down case.  The ``EmptyCompletions``
-        default never expected one, so it stays quiet.
+        True only when a listing was expected (a real provider), the fetch
+        has landed (:attr:`completions_applied`), and it came back empty —
+        the offline / DB-down case.  The ``EmptyCompletions`` default never
+        expected one, so it stays quiet; a fetch still in flight is
+        :attr:`completions_pending`, not unchecked.
         """
-        return self._completions_expected and not self.completions_available
+        return (
+            self._completions_expected
+            and self.completions_applied
+            and not self.completions_available
+        )
 
     def _target_problem(
         self, device: str, variable: Optional[str] = None

--- a/GEECS-Console/geecs_console/editors/base.py
+++ b/GEECS-Console/geecs_console/editors/base.py
@@ -27,6 +27,12 @@ What lives here:
   :meth:`reject`).
 - One name-prompt convention (:meth:`_prompt_name`: stripped text or
   ``None`` on cancel) and one Yes/No confirm (:meth:`_confirm`).
+- The save-time **target check** (#772): :func:`target_problem` and the
+  :meth:`_target_problem` convenience — does a ``device`` / ``variable``
+  pair name something in the fetched listing?  Free text + completer
+  stays (the editors must work with the DB unreachable); the gate is at
+  Save, where an unknown name blocks with a near-miss hint and an empty
+  listing downgrades to :data:`UNCHECKED_TARGETS_NOTE`.
 
 The prompt methods are plain bound methods so tests can monkeypatch them
 per instance (``editor._prompt_unsaved = lambda: "discard"``) — the
@@ -35,8 +41,10 @@ pattern the editor test suites already use.
 
 from __future__ import annotations
 
+import difflib
 import logging
 import threading
+from collections.abc import Iterable, Mapping, Sequence
 from pathlib import Path
 from typing import Optional
 
@@ -58,6 +66,120 @@ from geecs_console.services.device_completions import (
 )
 
 logger = logging.getLogger(__name__)
+
+#: Appended to a successful save's message when the device/variable names
+#: could not be checked (no completions listing: offline, DB down, fetch
+#: failed).  The save goes through — the editors must stay usable off the
+#: lab network — but the operator is told what was skipped.
+UNCHECKED_TARGETS_NOTE = (
+    "device and variable names were not checked against the database "
+    "(completions unavailable)"
+)
+
+#: ``difflib`` similarity floor for a "did you mean" hint.  The live case
+#: (#772) was ``Position.Axis1`` vs ``Position.Axis 1`` — ratio 0.97; the
+#: default 0.6 still rejects unrelated names.
+_NEAR_MISS_CUTOFF = 0.6
+
+
+def resolve_device(
+    device_vars: Mapping[str, Sequence[str]], device: str
+) -> Optional[str]:
+    """Return the listing's key for *device*, or ``None`` when unknown.
+
+    An exact key wins; otherwise a *unique* case-insensitive match (the
+    completer already tolerates case, so the check must too — see the
+    editors' ``_refresh_variable_model``).
+
+    Parameters
+    ----------
+    device_vars : mapping
+        The fetched ``{device: [variable, ...]}`` listing.
+    device : str
+        The device text as typed (already stripped).
+
+    Returns
+    -------
+    str or None
+        The listing's spelling of the device, or ``None``.
+    """
+    if device in device_vars:
+        return device
+    lowered = device.lower()
+    matches = [known for known in device_vars if known.lower() == lowered]
+    return matches[0] if len(matches) == 1 else None
+
+
+def near_miss(text: str, candidates: Iterable[str]) -> Optional[str]:
+    """The candidate closest to *text* (case-insensitive), or ``None``.
+
+    Parameters
+    ----------
+    text : str
+        The unknown name.
+    candidates : iterable of str
+        The known names to compare against.
+
+    Returns
+    -------
+    str or None
+        The best candidate in its own spelling when one is close enough
+        (:data:`_NEAR_MISS_CUTOFF`), else ``None``.
+    """
+    by_lower = {candidate.lower(): candidate for candidate in candidates}
+    matches = difflib.get_close_matches(
+        text.lower(), list(by_lower), n=1, cutoff=_NEAR_MISS_CUTOFF
+    )
+    return by_lower[matches[0]] if matches else None
+
+
+def target_problem(
+    device_vars: Mapping[str, Sequence[str]],
+    device: str,
+    variable: Optional[str] = None,
+) -> Optional[str]:
+    """Why ``device`` (and ``variable``) name nothing in the listing, or ``None``.
+
+    The save-time check behind #772: the editors' device/variable fields are
+    free text with a *suggesting* completer, so a near miss like
+    ``Position.Axis1`` for ``Position.Axis 1`` is accepted silently and only
+    fails later — as a 20 s ophyd connect timeout on the worker that never
+    says "no such variable".  This names the problem at Save.
+
+    Parameters
+    ----------
+    device_vars : mapping
+        The fetched ``{device: [variable, ...]}`` listing.  **Empty means
+        unchecked**: with nothing to compare against the result is ``None``
+        and the caller downgrades to :data:`UNCHECKED_TARGETS_NOTE`.
+    device : str
+        The device text (stripped).
+    variable : str, optional
+        The variable text (stripped); ``None`` checks the device only (a
+        save-set entry names a device, its scalars name variables).
+
+    Returns
+    -------
+    str or None
+        One sentence naming the unknown name, with a "did you mean" hint
+        when a close spelling exists; ``None`` when the target checks out
+        or the listing is empty.
+    """
+    if not device_vars:
+        return None
+    known = resolve_device(device_vars, device)
+    if known is None:
+        hint = near_miss(device, device_vars)
+        suffix = f" — did you mean {hint!r}?" if hint else ""
+        return f"unknown device {device!r}{suffix}"
+    if variable is None:
+        return None
+    variables = device_vars[known]
+    if variable in variables:
+        return None
+    hint = near_miss(variable, variables)
+    suffix = f" — did you mean {hint!r}?" if hint else ""
+    return f"{variable!r} is not a variable of {known!r}{suffix}"
 
 
 class ConfigEditorDialog(QDialog):
@@ -156,6 +278,11 @@ class ConfigEditorDialog(QDialog):
         )
         #: The fetched completion word lists (empty until the fetch lands).
         self._device_vars: dict[str, list[str]] = {}
+        #: Whether a listing was ever expected: a dialog built on the
+        #: :class:`EmptyCompletions` default (no experiment, tests) has
+        #: nothing to check *by design* and gets no "unchecked" note; a
+        #: real provider that came back empty (offline, DB down) does.
+        self._completions_expected = not isinstance(self._completions, EmptyCompletions)
         #: True once the (async) completions fetch has been delivered on
         #: the GUI thread — tests wait on this instead of sleeping.
         self.completions_applied = False
@@ -221,6 +348,40 @@ class ConfigEditorDialog(QDialog):
         Default is a no-op — an editor whose cell editors read
         :attr:`_device_vars` lazily at edit-open needs no replumbing.
         """
+
+    @property
+    def completions_available(self) -> bool:
+        """Whether a non-empty listing arrived (so targets can be checked)."""
+        return bool(self._device_vars)
+
+    @property
+    def targets_unchecked(self) -> bool:
+        """Whether a save should carry :data:`UNCHECKED_TARGETS_NOTE`.
+
+        True only when a listing was expected (a real provider) and none
+        arrived — the offline / DB-down case.  The ``EmptyCompletions``
+        default never expected one, so it stays quiet.
+        """
+        return self._completions_expected and not self.completions_available
+
+    def _target_problem(
+        self, device: str, variable: Optional[str] = None
+    ) -> Optional[str]:
+        """:func:`target_problem` against this dialog's fetched listing.
+
+        Parameters
+        ----------
+        device : str
+            The device text (stripped).
+        variable : str, optional
+            The variable text (stripped); ``None`` checks the device only.
+
+        Returns
+        -------
+        str or None
+            The problem sentence, or ``None`` (known, or nothing to check).
+        """
+        return target_problem(self._device_vars, device, variable)
 
     # ------------------------------------------------------------------
     # Unsaved-changes flow (one prompt, both close paths)

--- a/GEECS-Console/geecs_console/editors/save_set_editor.py
+++ b/GEECS-Console/geecs_console/editors/save_set_editor.py
@@ -15,7 +15,10 @@ completions come from the shared
 queued signal (the no-QThread rule; see ``services/health.py``).  The
 production provider, ``GeecsDbCompletions``, imports ``GeecsDb`` lazily and
 degrades to empty on any failure, so offline means an empty completer, not
-an exception; ``EmptyCompletions`` is the no-fetch default.
+an exception; ``EmptyCompletions`` is the no-fetch default.  Save also
+checks every entry's device and listed scalars against that listing (#772):
+an unknown name blocks the save with a "did you mean" hint; with no listing
+the save goes through and the message says the names were not checked.
 
 The reserved ``at_scan_start`` / ``at_scan_end`` entry fields (not applied by
 the engine in this version) have no widgets; the editor carries them through
@@ -44,7 +47,7 @@ from PySide6.QtWidgets import (
 )
 from pydantic import ValidationError
 
-from geecs_console.editors.base import ConfigEditorDialog
+from geecs_console.editors.base import UNCHECKED_TARGETS_NOTE, ConfigEditorDialog
 from geecs_console.services.device_completions import (
     CompletionsProvider,
     GeecsDbCompletions,
@@ -851,6 +854,12 @@ class SaveSetEditor(ConfigEditorDialog):
         if model is None:
             self._refresh_gating()
             return False
+        # Shape is fine — now do the names exist?  (#772: the completer only
+        # suggests; free text stays so the editor works with the DB down.)
+        problems = self._entry_problems()
+        if problems:
+            self._show_message("Not saved — " + "; ".join(problems), error=True)
+            return False
         name = self._current_name()
         try:
             self._store.save(name, model)
@@ -861,8 +870,37 @@ class SaveSetEditor(ConfigEditorDialog):
         self._unsaved.discard(name)
         self._refresh_set_list(select=name)
         self._refresh_gating()
-        self._show_message(f"Saved {name!r}.")
+        if self.targets_unchecked:
+            self._show_message(f"Saved {name!r} — {UNCHECKED_TARGETS_NOTE}.")
+        else:
+            self._show_message(f"Saved {name!r}.")
         return True
+
+    def _entry_problems(self) -> list[str]:
+        """Name every entry device / scalar the fetched listing does not know.
+
+        Returns
+        -------
+        list of str
+            One sentence per unknown device (its scalars are then skipped —
+            they cannot be checked without a device) or unknown scalar
+            variable; empty when everything resolves or no listing is
+            loaded (the save then carries :data:`UNCHECKED_TARGETS_NOTE`).
+        """
+        if self._document is None or not self.completions_available:
+            return []
+        lines: list[str] = []
+        for entry in self._document.get("entries", []):
+            device = str(entry.get("device", "")).strip()
+            problem = self._target_problem(device)
+            if problem:
+                lines.append(problem)
+                continue
+            for variable in entry.get("scalars", []) or []:
+                problem = self._target_problem(device, str(variable).strip())
+                if problem:
+                    lines.append(problem)
+        return lines
 
     def _on_save(self) -> None:
         """Save button handler."""

--- a/GEECS-Console/geecs_console/editors/save_set_editor.py
+++ b/GEECS-Console/geecs_console/editors/save_set_editor.py
@@ -48,6 +48,7 @@ from PySide6.QtWidgets import (
 from pydantic import ValidationError
 
 from geecs_console.editors.base import (
+    COMPLETIONS_PENDING_NOTE,
     UNCHECKED_TARGETS_NOTE,
     ConfigEditorDialog,
     resolve_device,
@@ -869,6 +870,9 @@ class SaveSetEditor(ConfigEditorDialog):
             return False
         # Shape is fine — now do the names exist?  (#772: the completer only
         # suggests; free text stays so the editor works with the DB down.)
+        if self.completions_pending:
+            self._show_message(f"Not saved — {COMPLETIONS_PENDING_NOTE}.", error=True)
+            return False
         problems = self._entry_problems()
         if problems:
             self._show_message("Not saved — " + "; ".join(problems), error=True)

--- a/GEECS-Console/geecs_console/editors/save_set_editor.py
+++ b/GEECS-Console/geecs_console/editors/save_set_editor.py
@@ -47,7 +47,11 @@ from PySide6.QtWidgets import (
 )
 from pydantic import ValidationError
 
-from geecs_console.editors.base import UNCHECKED_TARGETS_NOTE, ConfigEditorDialog
+from geecs_console.editors.base import (
+    UNCHECKED_TARGETS_NOTE,
+    ConfigEditorDialog,
+    resolve_device,
+)
 from geecs_console.services.device_completions import (
     CompletionsProvider,
     GeecsDbCompletions,
@@ -301,10 +305,19 @@ class SaveSetEditor(ConfigEditorDialog):
         self._refresh_variable_completer()
 
     def _refresh_variable_completer(self) -> None:
-        """Point the scalar completer at the selected device's variables."""
+        """Point the scalar completer at the selected device's variables.
+
+        Case-insensitive on the device (:func:`resolve_device`) — the same
+        rule the save-time check applies, so an entry saved as
+        ``uc_alineebeam1`` still completes its scalars.
+        """
         entry = self._current_entry()
-        device = entry["device"] if entry is not None else ""
-        self._variable_model.setStringList(self._device_vars.get(device, []))
+        device = resolve_device(
+            self._device_vars, str(entry["device"]).strip() if entry else ""
+        )
+        self._variable_model.setStringList(
+            self._device_vars[device] if device is not None else []
+        )
 
     # ------------------------------------------------------------------
     # Document plumbing

--- a/GEECS-Console/geecs_console/editors/scan_variable_editor.py
+++ b/GEECS-Console/geecs_console/editors/scan_variable_editor.py
@@ -61,7 +61,11 @@ from PySide6.QtWidgets import (
     QWidget,
 )
 
-from geecs_console.editors.base import UNCHECKED_TARGETS_NOTE, ConfigEditorDialog
+from geecs_console.editors.base import (
+    UNCHECKED_TARGETS_NOTE,
+    ConfigEditorDialog,
+    resolve_device,
+)
 from geecs_console.services.device_completions import (
     CompletionsProvider,
     EmptyCompletions,
@@ -936,17 +940,11 @@ class ScanVariableEditor(ConfigEditorDialog):
             The variable completer's model.
         device_text : str
             The paired device field's current text (exact match wins, else a
-            unique case-insensitive match).
+            unique case-insensitive match — :func:`resolve_device`, the
+            same rule the save-time check applies).
         """
-        device = device_text.strip()
-        variables = self._device_vars.get(device)
-        if variables is None and device:
-            matches = [
-                known for known in self._device_vars if known.lower() == device.lower()
-            ]
-            if len(matches) == 1:
-                variables = self._device_vars[matches[0]]
-        model.setStringList(variables or [])
+        device = resolve_device(self._device_vars, device_text.strip())
+        model.setStringList(self._device_vars[device] if device is not None else [])
 
     # Close paths (keyPressEvent / reject / closeEvent): ConfigEditorDialog
     # — the unsaved-changes prompt now offers Save alongside Discard/Cancel.

--- a/GEECS-Console/geecs_console/editors/scan_variable_editor.py
+++ b/GEECS-Console/geecs_console/editors/scan_variable_editor.py
@@ -62,6 +62,7 @@ from PySide6.QtWidgets import (
 )
 
 from geecs_console.editors.base import (
+    COMPLETIONS_PENDING_NOTE,
     UNCHECKED_TARGETS_NOTE,
     ConfigEditorDialog,
     resolve_device,
@@ -799,6 +800,9 @@ class ScanVariableEditor(ConfigEditorDialog):
         # Shape is fine — now do the names exist?  (#772: the completer only
         # suggests; a near miss like `Position.Axis1` used to save cleanly
         # and fail 20 s into the first move as a bare connect timeout.)
+        if self.completions_pending:
+            self._show_error(f"Not saved — {COMPLETIONS_PENDING_NOTE}.")
+            return False
         problems = self._target_problems()
         if problems:
             self._show_error("\n".join(problems))

--- a/GEECS-Console/geecs_console/editors/scan_variable_editor.py
+++ b/GEECS-Console/geecs_console/editors/scan_variable_editor.py
@@ -18,8 +18,11 @@ the right pane is a form derived from the actual schema models:
 
 Edits accumulate in an in-memory draft of plain dicts (so *invalid
 intermediate* states are representable while typing); Save validates the
-whole draft through ``ScanVariables.model_validate`` and writes via the
-store — pydantic errors are shown inline in the error label, never a crash.
+whole draft through ``ScanVariables.model_validate``, then checks every
+``Device:Variable`` target against the fetched completions listing (#772 —
+an unknown device or variable blocks the save with a "did you mean" hint;
+with no listing the save goes through with a note), and writes via the
+store — errors are shown inline in the error label, never a crash.
 Revert reloads from disk; closing with unsaved changes prompts first.
 
 Ergonomics: device and variable fields carry ``QCompleter`` popups fed by an
@@ -58,7 +61,7 @@ from PySide6.QtWidgets import (
     QWidget,
 )
 
-from geecs_console.editors.base import ConfigEditorDialog
+from geecs_console.editors.base import UNCHECKED_TARGETS_NOTE, ConfigEditorDialog
 from geecs_console.services.device_completions import (
     CompletionsProvider,
     EmptyCompletions,
@@ -789,6 +792,13 @@ class ScanVariableEditor(ConfigEditorDialog):
         except ValidationError as exc:
             self._show_error(_format_validation_error(exc, self._variables))
             return False
+        # Shape is fine — now do the names exist?  (#772: the completer only
+        # suggests; a near miss like `Position.Axis1` used to save cleanly
+        # and fail 20 s into the first move as a bare connect timeout.)
+        problems = self._target_problems()
+        if problems:
+            self._show_error("\n".join(problems))
+            return False
         try:
             path = self._store.save(catalog)
         except ScanVariableStoreError as exc:
@@ -798,7 +808,49 @@ class ScanVariableEditor(ConfigEditorDialog):
         self._update_dirty()
         self._clear_error()
         self.dirty_label.setText(f"saved → {path}")
+        if self.targets_unchecked:
+            self._show_warning(f"saved, but {UNCHECKED_TARGETS_NOTE}")
         return True
+
+    def _target_problems(self) -> list[str]:
+        """Name every draft target the fetched listing does not know.
+
+        Returns
+        -------
+        list of str
+            One ``name → field: problem`` line per unknown device/variable
+            (simple ``target`` and ``confirm``; composite ``component N``),
+            empty when everything resolves — or when no listing is loaded
+            (nothing to check against; the save then carries
+            :data:`UNCHECKED_TARGETS_NOTE`).
+        """
+        if not self.completions_available:
+            return []
+        lines: list[str] = []
+        for name, draft in self._variables.items():
+            if draft.get("kind") == "pseudo":
+                for row, entry in enumerate(draft.get("targets", []), start=1):
+                    problem = self._check_target(str(entry.get("target", "")))
+                    if problem:
+                        lines.append(f"{name} → component {row}: {problem}")
+                continue
+            problem = self._check_target(str(draft.get("target", "")))
+            if problem:
+                lines.append(f"{name} → target: {problem}")
+            confirm = draft.get("confirm")
+            if confirm:
+                problem = self._check_target(str(confirm))
+                if problem:
+                    lines.append(f"{name} → confirm: {problem}")
+        return lines
+
+    def _check_target(self, target: str) -> Optional[str]:
+        """One ``Device:Variable`` string against the listing (shape is pydantic's)."""
+        device, variable = _split_target(target)
+        device, variable = device.strip(), variable.strip()
+        if not device or not variable:
+            return None
+        return self._target_problem(device, variable)
 
     def _on_save(self) -> None:
         """Save button handler."""
@@ -838,6 +890,17 @@ class ScanVariableEditor(ConfigEditorDialog):
             Status-bar-fit error text (may be multi-line).
         """
         self.error_label.setStyleSheet("color: #d9534f;")
+        self.error_label.setText(message)
+
+    def _show_warning(self, message: str) -> None:
+        """Show *message* inline in the error label, in the warning color.
+
+        Parameters
+        ----------
+        message : str
+            A non-blocking note (the save went through).
+        """
+        self.error_label.setStyleSheet("color: #d9a21b;")
         self.error_label.setText(message)
 
     def _clear_error(self) -> None:

--- a/GEECS-Console/geecs_console/services/background.py
+++ b/GEECS-Console/geecs_console/services/background.py
@@ -19,6 +19,7 @@ signal that crosses a thread boundary now comes through here.
 
 from __future__ import annotations
 
+import dataclasses
 import functools
 import logging
 import threading
@@ -26,6 +27,8 @@ import warnings
 from typing import TYPE_CHECKING, Any, Callable, Optional
 
 from PySide6.QtCore import QObject, Qt, QTimer, Signal, Slot
+
+from geecs_console.services.health import HealthReport
 
 if TYPE_CHECKING:
     from geecs_console.services.health import HealthProbe
@@ -222,6 +225,16 @@ class HealthPoller(_GuiHopWorker):
     report has landed on the GUI thread, so the ``_busy`` flag is only
     ever written there and at most one hop per poller is ever pending.
 
+    Every poll gets a 1-based **sequence** (:attr:`polls_started`, GUI
+    thread), and a delivered :class:`~geecs_console.services.health.HealthReport`
+    is stamped with its poll's sequence — exact, because one poll is in
+    flight at a time and the stamp is applied on the GUI thread before
+    the next can start.  A consumer that records ``polls_started`` at
+    some GUI-thread moment can then tell a report from a poll that began
+    before it (the window's gateway-restart narration; review of PR
+    #796).  Non-``HealthReport`` payloads (test probes) pass through
+    untouched.
+
     Parameters
     ----------
     probe :
@@ -237,6 +250,12 @@ class HealthPoller(_GuiHopWorker):
         super().__init__()
         self._probe = probe
         self._busy = False
+        self._sequence = 0
+
+    @property
+    def polls_started(self) -> int:
+        """How many polls have started (GUI-thread state); the last one's sequence."""
+        return self._sequence
 
     @Slot()
     def poll_async(self) -> None:
@@ -247,6 +266,7 @@ class HealthPoller(_GuiHopWorker):
         if self._busy:
             return
         self._busy = True
+        self._sequence += 1
         _hold(self)
         threading.Thread(
             target=self._run, name="console-health-poll", daemon=True
@@ -261,6 +281,10 @@ class HealthPoller(_GuiHopWorker):
         self._hop(report)
 
     def _deliver(self, payload: object) -> None:
+        # GUI thread, before _busy clears: the in-flight poll IS the latest
+        # started one, so its sequence is exactly self._sequence.
+        if isinstance(payload, HealthReport):
+            payload = dataclasses.replace(payload, sequence=self._sequence)
         self._busy = False
         if payload is not None:
             self.report_ready.emit(payload)

--- a/GEECS-Console/geecs_console/services/background.py
+++ b/GEECS-Console/geecs_console/services/background.py
@@ -9,7 +9,12 @@ landed).  :class:`HealthPoller` — the interval-polling shape
 ``BackgroundResult`` generalized — moved here from ``app/main_window.py``
 in the issue #534 slimming (step 1).  Both ride the one GUI-thread hop,
 :class:`_GuiHopWorker` (0.28.0 for ``BackgroundResult``, 0.28.2 for
-``HealthPoller`` — issue #767).
+``HealthPoller`` — issue #767).  :class:`GuiRelay` (0.30.0, #787) is the
+same hop for **long-lived foreign-thread producers** — a CA monitor
+callback, a zmq stream loop — that post many payloads over their lifetime
+rather than one result per call; the scan monitor's stream workers
+subclass the base directly for their typed signals.  Every console
+signal that crosses a thread boundary now comes through here.
 """
 
 from __future__ import annotations
@@ -17,7 +22,8 @@ from __future__ import annotations
 import functools
 import logging
 import threading
-from typing import TYPE_CHECKING, Callable, Optional
+import warnings
+from typing import TYPE_CHECKING, Any, Callable, Optional
 
 from PySide6.QtCore import QObject, Qt, QTimer, Signal, Slot
 
@@ -36,17 +42,52 @@ logger = logging.getLogger(__name__)
 #: switch), and the first landing must not release the second's hold.
 _INFLIGHT: dict = {}
 
+#: The one-shot workers take their hold on the GUI thread (before the
+#: thread spawns) and release it there; the long-lived producers
+#: (:class:`GuiRelay`, the stream workers) take it *on their own thread*
+#: per payload, so the counter's read-modify-write needs a lock.
+_INFLIGHT_LOCK = threading.Lock()
+
 
 def _hold(worker: QObject) -> None:
-    _INFLIGHT[worker] = _INFLIGHT.get(worker, 0) + 1
+    with _INFLIGHT_LOCK:
+        _INFLIGHT[worker] = _INFLIGHT.get(worker, 0) + 1
 
 
 def _release(worker: QObject) -> None:
-    remaining = _INFLIGHT.get(worker, 0) - 1
-    if remaining > 0:
-        _INFLIGHT[worker] = remaining
-    else:
-        _INFLIGHT.pop(worker, None)
+    with _INFLIGHT_LOCK:
+        remaining = _INFLIGHT.get(worker, 0) - 1
+        if remaining > 0:
+            _INFLIGHT[worker] = remaining
+        else:
+            _INFLIGHT.pop(worker, None)
+
+
+def disconnect_quietly(signal: Any, slot: Any = None) -> None:
+    """Disconnect *signal* (from *slot*, or from everything) without noise.
+
+    A teardown helper: a never-connected signal's blind ``disconnect()``
+    raises nothing in PySide6 but *warns* (``libpyside: Failed to
+    disconnect (None) from signal …``, a ``RuntimeWarning``), and a
+    signal on a half-torn-down object raises ``RuntimeError``/``TypeError``.
+    Dispose paths want neither.
+
+    Parameters
+    ----------
+    signal : Signal instance
+        The bound signal.
+    slot : callable, optional
+        The receiver to detach; ``None`` detaches every receiver.
+    """
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", RuntimeWarning)
+        try:
+            if slot is None:
+                signal.disconnect()
+            else:
+                signal.disconnect(slot)
+        except (RuntimeError, TypeError):
+            pass
 
 
 #: Sentinel routed through the GUI hop when the callable raised (no
@@ -70,8 +111,13 @@ class _GuiHopWorker(QObject):
     with a controller-owned slot, the queue panel's fetch landing while a
     test window was torn down; then with ``HealthPoller`` → window, the
     busiest emitter, in isolated ``test_main_window.py`` runs — #767;
-    the stream workers and the readback/completions callbacks outside
-    this module still emit from their threads, see #787).
+    the stream workers, the aioca readback callback and the editors'
+    completions fetch followed in 0.30.0 — #787).
+
+    Two ways to take the hold: the one-shot workers call :func:`_hold`
+    on the GUI thread before spawning their thread and then :meth:`_hop`
+    from it; a long-lived producer on a foreign thread calls
+    :meth:`_post` per payload, which takes the hold and hops in one step.
     """
 
     _landed = Signal(object)
@@ -89,7 +135,18 @@ class _GuiHopWorker(QObject):
             # A Qt-parented worker was deleted with its parent while the
             # call ran (the hold protects unparented workers only): drop
             # the dead wrapper's hold so the registry does not grow.
-            _INFLIGHT.pop(self, None)
+            with _INFLIGHT_LOCK:
+                _INFLIGHT.pop(self, None)
+
+    def _post(self, payload: object) -> None:
+        """Hold + hop in one step — for producers living on a foreign thread.
+
+        A CA monitor callback or a stream loop has no GUI-thread moment
+        before each payload to take the hold in, so it is taken here, on
+        the producer's thread (:data:`_INFLIGHT_LOCK` makes that safe).
+        """
+        _hold(self)
+        self._hop(payload)
 
     @Slot(object)
     def _forward(self, payload: object) -> None:
@@ -207,3 +264,39 @@ class HealthPoller(_GuiHopWorker):
         self._busy = False
         if payload is not None:
             self.report_ready.emit(payload)
+
+
+class GuiRelay(_GuiHopWorker):
+    """Hop payloads posted from a foreign thread onto the GUI thread.
+
+    For long-lived producers that call back on their own thread for the
+    life of a subscription — the movable panel's aioca readback monitors
+    (values arrive on the CA loop thread) — where neither one-shot worker
+    fits.  The producer calls :meth:`post` from its thread; the payload
+    lands on the GUI thread and :attr:`delivered` is emitted there.  The
+    owner connects ``delivered`` (``QueuedConnection`` by convention) and
+    calls :meth:`close` in its dispose path: a payload still in flight at
+    that moment lands and is dropped rather than emitted, so nothing
+    reaches a consumer that is being torn down.
+    """
+
+    delivered = Signal(object)
+    """One emission per posted payload, on the GUI thread."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._closed = False
+
+    def post(self, payload: object) -> None:
+        """Queue *payload* for GUI-thread delivery (any thread)."""
+        if self._closed:
+            return
+        self._post(payload)
+
+    def close(self) -> None:
+        """Stop delivering (idempotent; GUI thread) — in-flight payloads drop."""
+        self._closed = True
+
+    def _deliver(self, payload: object) -> None:
+        if not self._closed:
+            self.delivered.emit(payload)

--- a/GEECS-Console/geecs_console/services/device_panel.py
+++ b/GEECS-Console/geecs_console/services/device_panel.py
@@ -16,6 +16,13 @@ Threading model (mirrors the health-probe precedent — **no QThread**, ever):
 event loop running ``run_forever`` in a single daemon ``threading.Thread``,
 created lazily on first use.  ``camonitor`` / subscription close / ``caput``
 are submitted onto that loop via ``asyncio.run_coroutine_threadsafe``.
+That loop is also the console's one home for *any* CA put — the R7 ``:SP``
+set and the Ops gateway-restart write (``put_pv``, the seam
+``services/gateway_restart.py`` rides): aioca caches channels per event
+loop and its connection callback posts to that loop with no closed-loop
+guard, so a put on a throwaway ``asyncio.run`` loop strands a channel that
+later raises ``RuntimeError: Event loop is closed`` from the CA thread when
+the channel goes down (exactly what a gateway restart does).
 Nothing here ever blocks the GUI thread: ``subscribe`` / ``unsubscribe``
 return immediately, and the blocking ``set`` is dispatched by the window to
 a short-lived daemon thread.  Teardown never joins — the loop thread is
@@ -80,6 +87,12 @@ class DevicePanelBackend(Protocol):
         """Write *value* to the setpoint, blocking until done; raise on failure."""
         ...
 
+    def put_pv(
+        self, pv: str, value: Any, *, timeout: Optional[float] = None, name: str = ""
+    ) -> None:
+        """Write *value* to the bare *pv* (any gateway PV), blocking; raise on failure."""
+        ...
+
 
 class StubDevicePanel:
     """The no-network default: readback never updates, sets report unwired."""
@@ -127,6 +140,18 @@ class StubDevicePanel:
 
     def set(self, experiment: str, device: str, variable: str, value: Any) -> None:
         """Refuse the set so the window surfaces a clear offline message.
+
+        Raises
+        ------
+        RuntimeError
+            Always — the stub has no gateway to write to.
+        """
+        raise RuntimeError("device panel backend not wired (offline stub)")
+
+    def put_pv(
+        self, pv: str, value: Any, *, timeout: Optional[float] = None, name: str = ""
+    ) -> None:
+        """Refuse the put so the window surfaces a clear offline message.
 
         Raises
         ------
@@ -439,16 +464,49 @@ class GatewayDevicePanel:
             Whatever the put raises (timeout, GEECS rejection, no CA) — the
             window renders it in the status bar.
         """
-        from geecs_bluesky.devices.ca._pv import ca_pv
-        from geecs_bluesky.devices.ca._pv import setpoint_pv as sp
+        self.put_pv(
+            setpoint_pv(experiment, device, variable),
+            value,
+            name=f"{device}:{variable}",
+        )
+
+    def put_pv(
+        self, pv: str, value: Any, *, timeout: Optional[float] = None, name: str = ""
+    ) -> None:
+        """Blocking put of *value* to the bare *pv* on the persistent CA loop.
+
+        The one place a console CA put runs: :meth:`set` (the ``:SP``
+        setpoint) and the Ops gateway restart
+        (``services/gateway_restart.py``) both come here, so every put's
+        aioca channel lives on the long-lived loop — never on a per-call
+        ``asyncio.run`` loop whose closing strands the channel (see the
+        module docstring).  Called from a short-lived daemon thread, never
+        the GUI thread.
+
+        Parameters
+        ----------
+        pv : str
+            The bare PV name (from the naming contract — never hand-built).
+        value : Any
+            The scalar to write; wire-coerced by
+            :func:`~geecs_bluesky.devices.ca.gateway_put.wire_value`.
+        timeout : float, optional
+            Put budget in seconds; the backend's default when omitted.
+        name : str, optional
+            The put's label in error messages (defaults to the PV).
+
+        Raises
+        ------
+        Exception
+            Whatever the put raises (timeout, GEECS rejection, no CA) — the
+            caller renders it.
+        """
         from geecs_bluesky.devices.ca.gateway_put import GatewaySetpointPut, wire_value
 
+        budget = self._put_timeout if timeout is None else timeout
         put = GatewaySetpointPut(
-            setpoint_pv=sp(ca_pv(experiment or None, device, variable)),
-            coerce=wire_value,
-            timeout=self._put_timeout,
-            name=f"{device}:{variable}",
+            setpoint_pv=pv, coerce=wire_value, timeout=budget, name=name or pv
         )
         loop = self._ensure_loop()
         future = asyncio.run_coroutine_threadsafe(put.put(value), loop)
-        future.result(timeout=self._put_timeout + _DISPATCH_SLACK_S)
+        future.result(timeout=budget + _DISPATCH_SLACK_S)

--- a/GEECS-Console/geecs_console/services/gateway_restart.py
+++ b/GEECS-Console/geecs_console/services/gateway_restart.py
@@ -16,17 +16,28 @@ Rules this module keeps:
 
 - The PV name comes only from the naming contract (``ca_pv`` /
   ``bare_pv`` — never hand-built; issue #490).
-- The write is a :class:`~geecs_bluesky.devices.ca.gateway_put.GatewaySetpointPut`
-  — the one blessed put primitive — with ``wire_value`` coercion, even
-  though this PV carries no ``:SP`` suffix (it is the control PV itself).
-- Import-safe offline: every CA import is lazy, inside the functions.
+- The write goes through the device-panel backend's ``put_pv`` seam
+  (:class:`~geecs_console.services.device_panel.GatewayDevicePanel`) —
+  a :class:`~geecs_bluesky.devices.ca.gateway_put.GatewaySetpointPut`,
+  the one blessed put primitive, with ``wire_value`` coercion, even though
+  this PV carries no ``:SP`` suffix (it is the control PV itself) — on the
+  backend's **persistent** CA event loop.  Never a per-call
+  ``asyncio.run``: aioca caches channels per loop and its connection
+  callback posts to that loop unguarded, so the restart's own CONN_DOWN
+  (the gateway exiting because of this very click) would hit a closed
+  loop and print ``RuntimeError: Event loop is closed`` from the CA thread
+  on every click (adversarial review, PR #796).
+- Import-safe offline: every CA import is lazy, inside the backend.
 - Blocking: :func:`request_gateway_restart` is meant for a
   ``BackgroundResult`` daemon thread, never the GUI thread.
 """
 
 from __future__ import annotations
 
-import asyncio
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from geecs_console.services.device_panel import DevicePanelBackend
 
 #: The enum label that requests the restart (index 1; ``Idle``/0 is a no-op).
 RESTART_VALUE = "Restart"
@@ -67,7 +78,10 @@ def restart_pv(experiment: str) -> str:
 
 
 def request_gateway_restart(
-    experiment: str, *, timeout: float = RESTART_PUT_TIMEOUT_S
+    experiment: str,
+    *,
+    backend: DevicePanelBackend,
+    timeout: float = RESTART_PUT_TIMEOUT_S,
 ) -> str:
     """Write ``Restart`` to the experiment's gateway restart PV (blocking).
 
@@ -75,6 +89,10 @@ def request_gateway_restart(
     ----------
     experiment : str
         The selected experiment.
+    backend : DevicePanelBackend
+        The console's device-panel backend; its ``put_pv`` runs the write
+        on the persistent CA loop (the offline stub refuses with a clear
+        message instead).
     timeout : float, optional
         Put budget in seconds (:data:`RESTART_PUT_TIMEOUT_S`).
 
@@ -91,17 +109,12 @@ def request_gateway_restart(
 
     Notes
     -----
-    The put runs on a fresh ``asyncio.run`` loop rather than the shared
-    one-shot loop (``geecs_bluesky.devices.ca.oneshot`` serves *reads*
-    and keeps its loop private): aioca caches channels per loop, so each
-    call strands one channel for the process lifetime.  Accepted for an
-    incident-rate verb — one click per frozen gateway, not a poll.
+    The put rides the backend's persistent loop, not a per-call
+    ``asyncio.run`` (see the module docstring for why that loop's closing
+    is not survivable here) and not the shared one-shot loop either
+    (``geecs_bluesky.devices.ca.oneshot`` serves *reads* and keeps its
+    loop private).
     """
     pv = restart_pv(experiment)
-    from geecs_bluesky.devices.ca.gateway_put import GatewaySetpointPut, wire_value
-
-    put = GatewaySetpointPut(
-        setpoint_pv=pv, coerce=wire_value, timeout=timeout, name="cagateway:restart"
-    )
-    asyncio.run(put.put(RESTART_VALUE))
+    backend.put_pv(pv, RESTART_VALUE, timeout=timeout, name="cagateway:restart")
     return pv

--- a/GEECS-Console/geecs_console/services/gateway_restart.py
+++ b/GEECS-Console/geecs_console/services/gateway_restart.py
@@ -1,0 +1,107 @@
+"""The CA gateway's restart verb, from the console (#773).
+
+``{experiment}:cagateway:restart`` is the gateway's one *client-writable*
+PV (``GeecsCAGateway/PV_CONTRACT.md`` § ``cagateway:restart``): an enum
+``["Idle", "Restart"]``.  Writing ``Restart`` makes the gateway shut down
+cleanly and exit with code 86, which the shipped systemd unit turns into
+a relaunch — the operator fix for the frozen-readback symptom (a stale
+GEECS TCP subscription after a device-app restart: half-open socket, the
+supervisor only reconnects on socket *close*; live incident 2026-08-17)
+and the DB-resync mechanism after a device / get-list edit, since the
+served set rebuilds from the GEECS database at startup.  Outside that
+supervisor (a foreground run) the process simply exits and **stays down**
+— the console's confirmation text says so.
+
+Rules this module keeps:
+
+- The PV name comes only from the naming contract (``ca_pv`` /
+  ``bare_pv`` — never hand-built; issue #490).
+- The write is a :class:`~geecs_bluesky.devices.ca.gateway_put.GatewaySetpointPut`
+  — the one blessed put primitive — with ``wire_value`` coercion, even
+  though this PV carries no ``:SP`` suffix (it is the control PV itself).
+- Import-safe offline: every CA import is lazy, inside the functions.
+- Blocking: :func:`request_gateway_restart` is meant for a
+  ``BackgroundResult`` daemon thread, never the GUI thread.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+#: The enum label that requests the restart (index 1; ``Idle``/0 is a no-op).
+RESTART_VALUE = "Restart"
+
+#: Put budget.  The gateway completes the CA write as soon as it has taken
+#: the restart request — well under a second on a live gateway; a longer
+#: wait means it is not answering at all.
+RESTART_PUT_TIMEOUT_S = 5.0
+
+
+def restart_pv(experiment: str) -> str:
+    """The bare ``cagateway:restart`` PV name for *experiment*.
+
+    Parameters
+    ----------
+    experiment : str
+        The selected experiment (the PV prefix); must be non-empty.
+
+    Returns
+    -------
+    str
+        e.g. ``"undulator:cagateway:restart"`` — through the naming
+        contract (lowercased, ``ca://`` stripped), never string-built.
+
+    Raises
+    ------
+    ValueError
+        With no experiment there is no prefixed PV to address.
+    """
+    if not experiment:
+        raise ValueError(
+            "no experiment selected — the restart PV is experiment-prefixed"
+        )
+    from geecs_bluesky.devices.ca._pv import ca_pv
+    from geecs_bluesky.devices.ca.gateway_put import bare_pv
+
+    return bare_pv(ca_pv(experiment, "CAGateway", "RESTART"))
+
+
+def request_gateway_restart(
+    experiment: str, *, timeout: float = RESTART_PUT_TIMEOUT_S
+) -> str:
+    """Write ``Restart`` to the experiment's gateway restart PV (blocking).
+
+    Parameters
+    ----------
+    experiment : str
+        The selected experiment.
+    timeout : float, optional
+        Put budget in seconds (:data:`RESTART_PUT_TIMEOUT_S`).
+
+    Returns
+    -------
+    str
+        The PV written, for the status-bar line.
+
+    Raises
+    ------
+    Exception
+        Whatever the put raises (timeout — the gateway is not answering —,
+        no CA, a rejected value); the window renders it as a failure.
+
+    Notes
+    -----
+    The put runs on a fresh ``asyncio.run`` loop rather than the shared
+    one-shot loop (``geecs_bluesky.devices.ca.oneshot`` serves *reads*
+    and keeps its loop private): aioca caches channels per loop, so each
+    call strands one channel for the process lifetime.  Accepted for an
+    incident-rate verb — one click per frozen gateway, not a poll.
+    """
+    pv = restart_pv(experiment)
+    from geecs_bluesky.devices.ca.gateway_put import GatewaySetpointPut, wire_value
+
+    put = GatewaySetpointPut(
+        setpoint_pv=pv, coerce=wire_value, timeout=timeout, name="cagateway:restart"
+    )
+    asyncio.run(put.put(RESTART_VALUE))
+    return pv

--- a/GEECS-Console/geecs_console/services/health.py
+++ b/GEECS-Console/geecs_console/services/health.py
@@ -52,6 +52,13 @@ class HealthReport:
     gateway: HealthStatus = HealthStatus.UNKNOWN
     tiled: HealthStatus = HealthStatus.UNKNOWN
     db: HealthStatus = HealthStatus.UNKNOWN
+    #: Which poll produced it: the 1-based count of polls the
+    #: :class:`~geecs_console.services.background.HealthPoller` had started
+    #: (stamped at delivery; probes leave it 0).  Lets a consumer tell a
+    #: report from a poll that began *before* some GUI-thread event — the
+    #: gateway-restart narration must not read a pre-put "OK" as "back"
+    #: (review of PR #796).  0 = not from the poller (a seed or a test).
+    sequence: int = 0
 
 
 @runtime_checkable

--- a/GEECS-Console/pyproject.toml
+++ b/GEECS-Console/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-console"
-version = "0.29.0"
+version = "0.30.0"
 description = "Greenfield PySide6 operator console for GEECS (Bluesky/gateway architecture)"
 authors = ["Sam Barber <sbarber@lbl.gov>"]
 readme = "README.md"

--- a/GEECS-Console/tests/test_background.py
+++ b/GEECS-Console/tests/test_background.py
@@ -179,6 +179,35 @@ class TestHealthPollerGuiHop:
         assert consumer.results == []
         assert poller._busy is False
 
+    def test_health_reports_are_stamped_with_the_poll_sequence(self, qtbot):
+        from geecs_console.services.health import HealthReport, HealthStatus
+
+        probe = GatedProbe(HealthReport(gateway=HealthStatus.OK))
+        poller = HealthPoller(probe)
+        consumer = Consumer()
+        poller.report_ready.connect(consumer.take, Qt.ConnectionType.QueuedConnection)
+        assert poller.polls_started == 0
+        poller.poll_async()
+        _drain(qtbot, lambda: len(consumer.results) == 1)
+        poller.poll_async()
+        _drain(qtbot, lambda: len(consumer.results) == 2)
+        assert [r.sequence for r in consumer.results] == [1, 2]
+        assert all(r.gateway is HealthStatus.OK for r in consumer.results)
+        assert poller.polls_started == 2
+        assert probe.report.sequence == 0  # the probe's own report is untouched
+
+    def test_skipped_polls_do_not_take_a_sequence(self, qtbot):
+        probe = GatedProbe("r")
+        probe.gate.clear()
+        poller = HealthPoller(probe)
+        consumer = Consumer()
+        poller.report_ready.connect(consumer.take, Qt.ConnectionType.QueuedConnection)
+        poller.poll_async()
+        poller.poll_async()  # skipped: one is out
+        assert poller.polls_started == 1
+        probe.gate.set()
+        _drain(qtbot, lambda: consumer.results == ["r"])  # non-reports pass through
+
     def test_none_report_is_not_emitted(self, qtbot):
         probe = GatedProbe(None)
         poller = HealthPoller(probe)

--- a/GEECS-Console/tests/test_background.py
+++ b/GEECS-Console/tests/test_background.py
@@ -222,3 +222,77 @@ class TestHealthPollerGuiHop:
                 w for w in background._INFLIGHT if isinstance(w, HealthPoller)
             ],
         )
+
+
+class TestGuiRelay:
+    """The long-lived producer's hop (#787): post from any thread, land on the GUI."""
+
+    def test_posted_payloads_land_on_the_gui_thread_in_order(self, qtbot):
+        from geecs_console.services.background import GuiRelay
+
+        relay = GuiRelay()
+        consumer = Consumer()
+        relay.delivered.connect(consumer.take, Qt.ConnectionType.QueuedConnection)
+
+        def producer():
+            for index in range(5):
+                relay.post((index, index * 1.5))
+
+        thread = threading.Thread(target=producer)
+        thread.start()
+        thread.join()
+        _drain(qtbot, lambda: len(consumer.results) == 5)
+        assert consumer.results == [(i, i * 1.5) for i in range(5)]
+        assert set(consumer.threads) == {threading.get_ident()}
+        _drain(qtbot, lambda: relay not in background._INFLIGHT)
+
+    def test_close_drops_in_flight_payloads_and_releases_the_hold(self, qtbot):
+        from geecs_console.services.background import GuiRelay
+
+        relay = GuiRelay()
+        consumer = Consumer()
+        relay.delivered.connect(consumer.take, Qt.ConnectionType.QueuedConnection)
+        relay.post("in flight")
+        relay.close()
+        relay.post("after close")  # never even posted
+        _drain(qtbot, lambda: relay not in background._INFLIGHT)
+        assert consumer.results == []
+
+    def test_concurrent_posters_keep_the_hold_count_consistent(self, qtbot):
+        # Two threads posting at once exercise the locked read-modify-write
+        # of the in-flight counter; every hold must be released.
+        from geecs_console.services.background import GuiRelay
+
+        relay = GuiRelay()
+        received: list = []
+        relay.delivered.connect(received.append, Qt.ConnectionType.QueuedConnection)
+        threads = [
+            threading.Thread(target=lambda: [relay.post(n) for n in range(200)])
+            for _ in range(4)
+        ]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join()
+        _drain(qtbot, lambda: len(received) == 800, timeout=10000)
+        _drain(qtbot, lambda: relay not in background._INFLIGHT)
+
+
+class TestDisconnectQuietly:
+    def test_never_connected_signal_does_not_warn(self, qtbot, recwarn):
+        from geecs_console.services.background import disconnect_quietly
+
+        worker = BackgroundResult()
+        disconnect_quietly(worker.result_ready)
+        assert not [w for w in recwarn if "Failed to disconnect" in str(w.message)]
+
+    def test_detaches_a_connected_slot(self, qtbot):
+        from geecs_console.services.background import disconnect_quietly
+
+        worker = BackgroundResult()
+        consumer = Consumer()
+        worker.result_ready.connect(consumer.take, Qt.ConnectionType.QueuedConnection)
+        disconnect_quietly(worker.result_ready, consumer.take)
+        worker.run_async(lambda: 1, "t")
+        _drain(qtbot, lambda: worker not in background._INFLIGHT)
+        assert consumer.results == []

--- a/GEECS-Console/tests/test_device_panel.py
+++ b/GEECS-Console/tests/test_device_panel.py
@@ -130,6 +130,10 @@ class TestProtocolAndStub:
         with pytest.raises(RuntimeError, match="not wired"):
             StubDevicePanel().set("Exp", "Dev", "Var", 1.0)
 
+    def test_stub_put_pv_raises(self):
+        with pytest.raises(RuntimeError, match="not wired"):
+            StubDevicePanel().put_pv("exp:cagateway:restart", "Restart")
+
 
 # ----------------------------------------------------------------------
 # GatewayDevicePanel against a fake aioca (no live CA)
@@ -273,6 +277,49 @@ class TestGatewayDevicePanel:
         assert pv == "dev:trigger_source:SP"
         assert value == "Single shot"
         assert wait is True
+
+    def test_put_pv_writes_any_bare_pv_with_wire_coercion(self, fake_aioca):
+        panel = GatewayDevicePanel()
+        panel.put_pv("htu:cagateway:restart", "Restart", timeout=5.0)
+        panel.put_pv("htu:dev:var:SP", 2.5)  # backend default budget
+        assert fake_aioca.puts == [
+            ("htu:cagateway:restart", "Restart", True, 5.0),
+            ("htu:dev:var:SP", 2.5, True, 10.0),
+        ]
+
+    def test_put_pv_runs_every_put_on_the_one_persistent_loop(self, monkeypatch):
+        # Review of PR #796: aioca caches channels per event loop, so a put
+        # on a throwaway loop strands its channel; both the R7 set and the
+        # gateway restart must share the backend's long-lived loop.
+        import asyncio
+
+        fake = FakeAioca()
+        module = fake.make_module()
+        loops = []
+
+        async def recording_caput(pv, value, wait=False, timeout=None):
+            loops.append(asyncio.get_running_loop())
+
+        module.caput = recording_caput
+        monkeypatch.setitem(sys.modules, "aioca", module)
+        panel = GatewayDevicePanel()
+        panel.put_pv("htu:cagateway:restart", "Restart")
+        panel.set("HTU", "Dev", "Var", 1.0)
+        assert len(loops) == 2
+        assert loops[0] is loops[1] is panel._loop
+        assert panel._loop.is_running()  # persistent: never closed after a put
+
+    def test_put_pv_failure_propagates(self, monkeypatch):
+        fake = FakeAioca()
+        module = fake.make_module()
+
+        async def failing_caput(pv, value, wait=False, timeout=None):
+            raise TimeoutError("no gateway answered")
+
+        module.caput = failing_caput
+        monkeypatch.setitem(sys.modules, "aioca", module)
+        with pytest.raises(TimeoutError, match="no gateway answered"):
+            GatewayDevicePanel().put_pv("htu:cagateway:restart", "Restart")
 
     def test_set_failure_propagates(self, monkeypatch):
         fake = FakeAioca()

--- a/GEECS-Console/tests/test_editor_target_check.py
+++ b/GEECS-Console/tests/test_editor_target_check.py
@@ -1,0 +1,68 @@
+"""editors/base.py target check (#772): pure functions, no Qt."""
+
+from __future__ import annotations
+
+from geecs_console.editors.base import near_miss, resolve_device, target_problem
+
+LISTING = {
+    "U_Grating2Rotation": ["Position.Axis 1", "Position.Axis 2", "Velocity"],
+    "U_ESP_JetXYZ": ["Position.Axis 3"],
+}
+
+
+class TestResolveDevice:
+    def test_exact_key_wins(self):
+        assert resolve_device(LISTING, "U_ESP_JetXYZ") == "U_ESP_JetXYZ"
+
+    def test_unique_case_insensitive_match(self):
+        assert resolve_device(LISTING, "u_esp_jetxyz") == "U_ESP_JetXYZ"
+
+    def test_unknown_is_none(self):
+        assert resolve_device(LISTING, "U_Nope") is None
+
+    def test_ambiguous_case_match_is_none(self):
+        listing = {"U_Dev": ["a"], "u_dev": ["b"]}
+        assert resolve_device(listing, "U_DEV") is None
+
+
+class TestNearMiss:
+    def test_the_live_case_position_axis1(self):
+        assert near_miss("Position.Axis1", LISTING["U_Grating2Rotation"]) == (
+            "Position.Axis 1"
+        )
+
+    def test_case_only_difference_hints_the_listed_spelling(self):
+        assert near_miss("velocity", LISTING["U_Grating2Rotation"]) == "Velocity"
+
+    def test_nothing_close_is_none(self):
+        assert near_miss("Temperature", LISTING["U_Grating2Rotation"]) is None
+
+
+class TestTargetProblem:
+    def test_known_pair_is_fine(self):
+        assert target_problem(LISTING, "U_Grating2Rotation", "Position.Axis 1") is None
+
+    def test_device_only_check(self):
+        assert target_problem(LISTING, "U_Grating2Rotation") is None
+        assert "unknown device" in target_problem(LISTING, "U_Grating2")
+
+    def test_unknown_variable_names_it_with_a_hint(self):
+        problem = target_problem(LISTING, "U_Grating2Rotation", "Position.Axis1")
+        assert "'Position.Axis1'" in problem
+        assert "U_Grating2Rotation" in problem
+        assert "did you mean 'Position.Axis 1'" in problem
+
+    def test_unknown_variable_without_a_close_name_has_no_hint(self):
+        problem = target_problem(LISTING, "U_Grating2Rotation", "Temperature")
+        assert "'Temperature' is not a variable of 'U_Grating2Rotation'" == problem
+
+    def test_unknown_device_hints_the_close_spelling(self):
+        problem = target_problem(LISTING, "U_Grating2Rotatoin", "Position.Axis 1")
+        assert problem.startswith("unknown device 'U_Grating2Rotatoin'")
+        assert "did you mean 'U_Grating2Rotation'" in problem
+
+    def test_device_match_is_case_insensitive(self):
+        assert target_problem(LISTING, "u_grating2rotation", "Velocity") is None
+
+    def test_empty_listing_means_unchecked(self):
+        assert target_problem({}, "U_Anything", "Whatever") is None

--- a/GEECS-Console/tests/test_gateway_restart.py
+++ b/GEECS-Console/tests/test_gateway_restart.py
@@ -2,13 +2,30 @@
 
 from __future__ import annotations
 
+import inspect
+
 import pytest
 
+from geecs_console.services import gateway_restart as module
+from geecs_console.services.device_panel import StubDevicePanel
 from geecs_console.services.gateway_restart import (
     RESTART_VALUE,
     request_gateway_restart,
     restart_pv,
 )
+
+
+class RecordingBackend:
+    """DevicePanelBackend stand-in recording ``put_pv`` calls."""
+
+    def __init__(self, error: Exception | None = None):
+        self.puts = []
+        self.error = error
+
+    def put_pv(self, pv, value, *, timeout=None, name=""):
+        if self.error is not None:
+            raise self.error
+        self.puts.append((pv, value, timeout, name))
 
 
 class TestRestartPv:
@@ -28,36 +45,31 @@ class TestRestartPv:
 
 
 class TestRequestGatewayRestart:
-    def test_puts_restart_through_the_blessed_primitive(self, monkeypatch):
-        import geecs_bluesky.devices.ca.gateway_put as gateway_put
-
-        puts = []
-
-        class FakePut:
-            def __init__(self, setpoint_pv=None, *, coerce=None, timeout=None, name=""):
-                self.pv = setpoint_pv
-                self.coerce = coerce
-                self.timeout = timeout
-
-            async def put(self, value):
-                puts.append((self.pv, self.coerce(value), self.timeout))
-
-        monkeypatch.setattr(gateway_put, "GatewaySetpointPut", FakePut)
-        assert request_gateway_restart("TestExp", timeout=2.5) == (
+    def test_puts_restart_through_the_backend_seam(self):
+        backend = RecordingBackend()
+        assert request_gateway_restart("TestExp", backend=backend, timeout=2.5) == (
             "testexp:cagateway:restart"
         )
-        assert puts == [("testexp:cagateway:restart", "Restart", 2.5)]
+        assert backend.puts == [
+            ("testexp:cagateway:restart", "Restart", 2.5, "cagateway:restart")
+        ]
 
-    def test_put_failure_propagates(self, monkeypatch):
-        import geecs_bluesky.devices.ca.gateway_put as gateway_put
-
-        class DeadPut:
-            def __init__(self, *args, **kwargs):
-                pass
-
-            async def put(self, value):
-                raise TimeoutError("no gateway answered")
-
-        monkeypatch.setattr(gateway_put, "GatewaySetpointPut", DeadPut)
+    def test_put_failure_propagates(self):
+        backend = RecordingBackend(error=TimeoutError("no gateway answered"))
         with pytest.raises(TimeoutError):
-            request_gateway_restart("TestExp")
+            request_gateway_restart("TestExp", backend=backend)
+        assert backend.puts == []
+
+    def test_offline_stub_refuses_with_a_clear_message(self):
+        with pytest.raises(RuntimeError, match="not wired"):
+            request_gateway_restart("TestExp", backend=StubDevicePanel())
+
+    def test_no_per_call_event_loop(self):
+        # Review of PR #796: a put under ``asyncio.run`` strands its aioca
+        # channel on a loop that is then closed; the gateway's own exit
+        # (this click) fires CONN_DOWN on it and the CA thread prints
+        # "RuntimeError: Event loop is closed".  The put must ride the
+        # device-panel backend's persistent loop instead.
+        source = inspect.getsource(module)
+        assert "asyncio.run(" not in source
+        assert "import asyncio" not in source

--- a/GEECS-Console/tests/test_gateway_restart.py
+++ b/GEECS-Console/tests/test_gateway_restart.py
@@ -1,0 +1,63 @@
+"""services/gateway_restart.py — the #773 restart verb's pure parts."""
+
+from __future__ import annotations
+
+import pytest
+
+from geecs_console.services.gateway_restart import (
+    RESTART_VALUE,
+    request_gateway_restart,
+    restart_pv,
+)
+
+
+class TestRestartPv:
+    def test_is_the_contracts_prefixed_control_pv(self):
+        # Through ca_pv/bare_pv (the #490 rule): lowercased, no transport
+        # prefix, no :SP suffix — this PV is the control itself.
+        assert restart_pv("TestExp") == "testexp:cagateway:restart"
+
+    def test_no_experiment_is_refused_before_any_ca(self):
+        with pytest.raises(ValueError, match="no experiment"):
+            restart_pv("")
+
+    def test_restart_value_is_the_contract_label(self):
+        # PV_CONTRACT.md: enum ["Idle", "Restart"]; "Restart" (or index 1)
+        # requests the clean exit-86 shutdown, "Idle" is a no-op.
+        assert RESTART_VALUE == "Restart"
+
+
+class TestRequestGatewayRestart:
+    def test_puts_restart_through_the_blessed_primitive(self, monkeypatch):
+        import geecs_bluesky.devices.ca.gateway_put as gateway_put
+
+        puts = []
+
+        class FakePut:
+            def __init__(self, setpoint_pv=None, *, coerce=None, timeout=None, name=""):
+                self.pv = setpoint_pv
+                self.coerce = coerce
+                self.timeout = timeout
+
+            async def put(self, value):
+                puts.append((self.pv, self.coerce(value), self.timeout))
+
+        monkeypatch.setattr(gateway_put, "GatewaySetpointPut", FakePut)
+        assert request_gateway_restart("TestExp", timeout=2.5) == (
+            "testexp:cagateway:restart"
+        )
+        assert puts == [("testexp:cagateway:restart", "Restart", 2.5)]
+
+    def test_put_failure_propagates(self, monkeypatch):
+        import geecs_bluesky.devices.ca.gateway_put as gateway_put
+
+        class DeadPut:
+            def __init__(self, *args, **kwargs):
+                pass
+
+            async def put(self, value):
+                raise TimeoutError("no gateway answered")
+
+        monkeypatch.setattr(gateway_put, "GatewaySetpointPut", DeadPut)
+        with pytest.raises(TimeoutError):
+            request_gateway_restart("TestExp")

--- a/GEECS-Console/tests/test_main_window.py
+++ b/GEECS-Console/tests/test_main_window.py
@@ -1323,19 +1323,152 @@ class TestOpsMenu:
             "https://github.com/GEECS-BELLA/GEECS-Plugins"
         ]
 
-    def test_ops_menu_lists_the_four_items(self, window):
-        # Keep the QAction wrappers alive in a local: letting the temporary
-        # list from .actions() be garbage-collected tears down the QMenu
-        # underneath us (PySide6 wrapper-ownership hazard).
-        menu_actions = window.menuBar().actions()
-        (ops_menu,) = [a.menu() for a in menu_actions if a.text() == "Ops"]
-        texts = [action.text() for action in ops_menu.actions() if action.text()]
+    def test_ops_menu_lists_the_five_items(self, window):
+        # Read the menu through the window's own kept wrapper (``_menus``):
+        # a QMenu reached via ``menuBar().actions()[i].menu()`` is torn
+        # down with its actions when that temporary wrapper is collected
+        # (PySide6 wrapper-ownership hazard) — and since #773 the window
+        # re-gates ``restart_gateway_action`` on every health poll, so a
+        # dead Ops menu would surface as a RuntimeError after the test.
+        ops_menu = window._menus[0]
+        assert ops_menu.title() == "Ops"
+        ops_actions = ops_menu.actions()  # kept alive for the test's duration
+        texts = [action.text() for action in ops_actions if action.text()]
         assert texts == [
             "Open experiment config folder",
             "Open user config (config.ini)",
             "Open today's scan folder",
+            "Restart gateway…",
             "GEECS-Plugins on GitHub",
         ]
+
+
+class TestRestartGateway:
+    """Ops → Restart gateway… (#773): gating, confirmation, one put, narration."""
+
+    class FakeRestart:
+        def __init__(self, fail=False):
+            self.calls = []
+            self.fail = fail
+
+        def __call__(self, experiment):
+            self.calls.append(experiment)
+            if self.fail:
+                raise TimeoutError("no gateway answered")
+            return f"{experiment.lower()}:cagateway:restart"
+
+    class OkHealth:
+        def poll(self):
+            return HealthReport(gateway=HealthStatus.OK)
+
+    def make(self, qtbot, restart=None, configs=None, answer=True):
+        restart = restart if restart is not None else self.FakeRestart()
+        win = MainWindow(
+            configs=configs if configs is not None else FakeConfigs(),
+            presets=FakePresetStore(),
+            settings=FakeSettings(),
+            submitter=FakeSubmitter(),
+            health=self.OkHealth(),
+            gateway_restart=restart,
+        )
+        qtbot.addWidget(win)
+        if win._monitor is not None:
+            win._monitor.dispose()
+        # The constructor fires one immediate health poll; let it land (an
+        # OK gateway) and stop the timer so the tests drive the chip state
+        # themselves from here on.
+        win._health_timer.stop()
+        qtbot.waitUntil(lambda: "gateway: ok" in win.gateway_chip.text(), timeout=3000)
+        win._ask_binary = lambda *args, **kwargs: answer
+        return win, restart
+
+    def settle(self, qtbot, win):
+        qtbot.waitUntil(lambda: not win._restart_in_flight, timeout=3000)
+
+    def test_disabled_until_the_gateway_chip_is_known(self, qtbot):
+        win, _ = self.make(qtbot)
+        assert win.restart_gateway_action.isEnabled()  # the first poll read OK
+        win._apply_health_report(HealthReport())
+        assert not win.restart_gateway_action.isEnabled()  # UNKNOWN: no poll yet
+        win._apply_health_report(HealthReport(gateway=HealthStatus.OK))
+        assert win.restart_gateway_action.isEnabled()
+        win._apply_health_report(HealthReport(gateway=HealthStatus.DOWN))
+        assert win.restart_gateway_action.isEnabled()  # DOWN is when it may help
+        win._apply_health_report(HealthReport())
+        assert not win.restart_gateway_action.isEnabled()
+
+    def test_disabled_without_an_experiment(self, qtbot):
+        win, restart = self.make(
+            qtbot, configs=FakeConfigs(experiment="", experiments=("TestExp",))
+        )
+        win._apply_health_report(HealthReport(gateway=HealthStatus.OK))
+        assert win.experiment_combo.currentText() == ""
+        assert not win.restart_gateway_action.isEnabled()
+        win._on_restart_gateway()
+        assert restart.calls == []
+        assert "needs an experiment" in win.statusBar().currentMessage()
+
+    def test_refused_while_a_scan_is_active(self, qtbot):
+        win, restart = self.make(qtbot)
+        win._apply_health_report(HealthReport(gateway=HealthStatus.OK))
+        drive_status(win, "running")
+        win._on_restart_gateway()
+        assert restart.calls == []
+        assert "refused" in win.statusBar().currentMessage()
+        assert "scan is active" in win.statusBar().currentMessage()
+
+    def test_confirmation_abort_writes_nothing(self, qtbot):
+        win, restart = self.make(qtbot, answer=False)
+        win._apply_health_report(HealthReport(gateway=HealthStatus.OK))
+        win._on_restart_gateway()
+        assert restart.calls == []
+        assert not win._restart_in_flight
+        assert not win._restart_pending
+
+    def test_confirm_writes_exactly_one_put_and_narrates_the_bounce(self, qtbot):
+        win, restart = self.make(qtbot)
+        win._apply_health_report(HealthReport(gateway=HealthStatus.OK))
+        win._on_restart_gateway()
+        assert not win.restart_gateway_action.isEnabled()  # in flight
+        self.settle(qtbot, win)
+        assert restart.calls == ["TestExp"]
+        log = win.log_tail.toPlainText()
+        assert "gateway restart requested (testexp:cagateway:restart)" in log
+        assert win.restart_gateway_action.isEnabled()
+        # The health poll narrates DOWN → OK once, then disarms.
+        win._apply_health_report(HealthReport(gateway=HealthStatus.DOWN))
+        win._apply_health_report(HealthReport(gateway=HealthStatus.DOWN))
+        win._apply_health_report(HealthReport(gateway=HealthStatus.OK))
+        win._apply_health_report(HealthReport(gateway=HealthStatus.OK))
+        log = win.log_tail.toPlainText()
+        assert log.count("gateway restarting — heartbeat down") == 1
+        assert log.count("gateway back — heartbeat OK") == 1
+        assert not win._restart_pending
+
+    def test_second_click_while_in_flight_is_a_noop(self, qtbot):
+        win, restart = self.make(qtbot)
+        win._apply_health_report(HealthReport(gateway=HealthStatus.OK))
+        win._on_restart_gateway()
+        win._on_restart_gateway()
+        self.settle(qtbot, win)
+        assert restart.calls == ["TestExp"]
+
+    def test_put_failure_is_reported_and_rearms(self, qtbot):
+        win, restart = self.make(qtbot, restart=self.FakeRestart(fail=True))
+        win._apply_health_report(HealthReport(gateway=HealthStatus.OK))
+        win._on_restart_gateway()
+        self.settle(qtbot, win)
+        assert "gateway restart failed: no gateway answered" in (
+            win.log_tail.toPlainText()
+        )
+        assert not win._restart_pending
+        assert win.restart_gateway_action.isEnabled()
+
+    def test_no_narration_without_a_request(self, qtbot):
+        win, _ = self.make(qtbot)
+        win._apply_health_report(HealthReport(gateway=HealthStatus.DOWN))
+        win._apply_health_report(HealthReport(gateway=HealthStatus.OK))
+        assert "gateway back" not in win.log_tail.toPlainText()
 
 
 class TestBeeps:

--- a/GEECS-Console/tests/test_main_window.py
+++ b/GEECS-Console/tests/test_main_window.py
@@ -1470,6 +1470,40 @@ class TestRestartGateway:
         win._apply_health_report(HealthReport(gateway=HealthStatus.OK))
         assert "gateway back" not in win.log_tail.toPlainText()
 
+    def test_default_restart_rides_the_device_panel_backend(self, qtbot):
+        """No injected restart: the put goes through the backend's ``put_pv``
+        (the persistent CA loop — review of PR #796), never a private loop."""
+
+        class RecordingPanel(FakeDevicePanel):
+            def __init__(self):
+                super().__init__()
+                self.puts = []
+
+            def put_pv(self, pv, value, *, timeout=None, name=""):
+                self.puts.append((pv, value, name))
+
+        panel = RecordingPanel()
+        win = MainWindow(
+            configs=FakeConfigs(),
+            presets=FakePresetStore(),
+            settings=FakeSettings(),
+            submitter=FakeSubmitter(),
+            health=self.OkHealth(),
+            device_panel=panel,
+        )
+        qtbot.addWidget(win)
+        if win._monitor is not None:
+            win._monitor.dispose()
+        win._health_timer.stop()
+        qtbot.waitUntil(lambda: "gateway: ok" in win.gateway_chip.text(), timeout=3000)
+        win._ask_binary = lambda *args, **kwargs: True
+        win._on_restart_gateway()
+        self.settle(qtbot, win)
+        assert panel.puts == [
+            ("testexp:cagateway:restart", "Restart", "cagateway:restart")
+        ]
+        assert win._restart_pending
+
 
 class TestBeeps:
     @pytest.fixture

--- a/GEECS-Console/tests/test_main_window.py
+++ b/GEECS-Console/tests/test_main_window.py
@@ -1417,6 +1417,69 @@ class TestRestartGateway:
         assert "refused" in win.statusBar().currentMessage()
         assert "scan is active" in win.statusBar().currentMessage()
 
+    def test_scan_starting_during_the_confirmation_is_refused(self, qtbot):
+        """The modal's nested exec() keeps status polls landing (review of
+        PR #796): a scan that started while it was open must still refuse."""
+        win, restart = self.make(qtbot)
+        win._apply_health_report(HealthReport(gateway=HealthStatus.OK))
+
+        def confirm_while_a_scan_starts(*args, **kwargs):
+            drive_status(win, "running")
+            return True
+
+        win._ask_binary = confirm_while_a_scan_starts
+        win._on_restart_gateway()
+        assert restart.calls == []
+        assert not win._restart_in_flight
+        assert not win._restart_pending
+        assert "refused" in win.statusBar().currentMessage()
+        assert "scan is active" in win.statusBar().currentMessage()
+
+    def test_refused_while_a_manual_set_is_in_flight(self, qtbot):
+        """A worker-side manual move never changes re_state, so the gate
+        also reads the movable panel's in-flight flag (review of PR #796)."""
+        import threading
+
+        gate = threading.Event()
+
+        class GatedPanel(FakeDevicePanel):
+            def set(self, experiment, device, variable, value):
+                gate.wait(3.0)
+                super().set(experiment, device, variable, value)
+
+        panel = GatedPanel()
+        win = MainWindow(
+            configs=FakeConfigs(),
+            presets=FakePresetStore(),
+            settings=FakeSettings(),
+            submitter=FakeSubmitter(),
+            health=self.OkHealth(),
+            gateway_restart=self.FakeRestart(),
+            device_panel=panel,
+        )
+        qtbot.addWidget(win)
+        if win._monitor is not None:
+            win._monitor.dispose()
+        win._health_timer.stop()
+        qtbot.waitUntil(lambda: "gateway: ok" in win.gateway_chip.text(), timeout=3000)
+        win._ask_binary = lambda *args, **kwargs: True
+        win.device_combo.setCurrentText("U_Hexapod:ypos")
+        win.set_field.setText("2.5")
+        qtbot.mouseClick(win.set_button, Qt.MouseButton.LeftButton)
+        assert win._movable.set_in_flight
+        try:
+            win._on_restart_gateway()
+            assert win._gateway_restart.calls == []
+            assert not win._restart_in_flight
+            assert "manual set/move is in flight" in win.statusBar().currentMessage()
+        finally:
+            gate.set()
+        qtbot.waitUntil(lambda: not win._movable.set_in_flight, timeout=3000)
+        # Once the set has landed the restart is allowed again.
+        win._on_restart_gateway()
+        self.settle(qtbot, win)
+        assert win._gateway_restart.calls == ["TestExp"]
+
     def test_confirmation_abort_writes_nothing(self, qtbot):
         win, restart = self.make(qtbot, answer=False)
         win._apply_health_report(HealthReport(gateway=HealthStatus.OK))

--- a/GEECS-Console/tests/test_main_window.py
+++ b/GEECS-Console/tests/test_main_window.py
@@ -1342,6 +1342,14 @@ class TestOpsMenu:
             "GEECS-Plugins on GitHub",
         ]
 
+    def test_ops_menu_shows_its_actions_tooltips(self, window):
+        # QMenu only renders action tooltips under setToolTipsVisible(True);
+        # Restart gateway… carries one (review of PR #796).
+        ops = window._menus[0]
+        assert ops.title() == "Ops"
+        assert ops.toolTipsVisible()
+        assert window.restart_gateway_action.toolTip()
+
 
 class TestRestartGateway:
     """Ops → Restart gateway… (#773): gating, confirmation, one put, narration."""

--- a/GEECS-Console/tests/test_main_window.py
+++ b/GEECS-Console/tests/test_main_window.py
@@ -1498,14 +1498,106 @@ class TestRestartGateway:
         log = win.log_tail.toPlainText()
         assert "gateway restart requested (testexp:cagateway:restart)" in log
         assert win.restart_gateway_action.isEnabled()
-        # The health poll narrates DOWN → OK once, then disarms.
-        win._apply_health_report(HealthReport(gateway=HealthStatus.DOWN))
-        win._apply_health_report(HealthReport(gateway=HealthStatus.DOWN))
-        win._apply_health_report(HealthReport(gateway=HealthStatus.OK))
-        win._apply_health_report(HealthReport(gateway=HealthStatus.OK))
+        # The health poll narrates DOWN → OK once, then disarms.  Reports
+        # carry the poller's sequence; the constructor's poll was #1, so
+        # these are polls that began after the put landed.
+        win._apply_health_report(HealthReport(gateway=HealthStatus.DOWN, sequence=2))
+        win._apply_health_report(HealthReport(gateway=HealthStatus.DOWN, sequence=3))
+        win._apply_health_report(HealthReport(gateway=HealthStatus.OK, sequence=4))
+        win._apply_health_report(HealthReport(gateway=HealthStatus.OK, sequence=5))
         log = win.log_tail.toPlainText()
         assert log.count("gateway restarting — heartbeat down") == 1
         assert log.count("gateway back — heartbeat OK") == 1
+        assert not win._restart_pending
+
+    def test_a_report_from_a_pre_arm_poll_does_not_narrate_back(self, qtbot):
+        """Review of PR #796: a poll that began before the put completed
+        read a pre-put heartbeat; its late OK must not read as "back"."""
+        win, _restart = self.make(qtbot)
+        win._on_restart_gateway()
+        self.settle(qtbot, win)
+        assert win._restart_pending
+        assert win._restart_arm_sequence == win._health_poller.polls_started == 1
+        # Poll #1 (pre-arm) landing late, and an unstamped direct report.
+        win._apply_health_report(HealthReport(gateway=HealthStatus.OK, sequence=1))
+        win._apply_health_report(HealthReport(gateway=HealthStatus.OK))
+        assert "gateway back" not in win.log_tail.toPlainText()
+        assert win._restart_pending
+        # The chip itself still follows every report.
+        assert "gateway: ok" in win.gateway_chip.text()
+        # The first post-arm poll narrates as usual.
+        win._apply_health_report(HealthReport(gateway=HealthStatus.DOWN, sequence=2))
+        win._apply_health_report(HealthReport(gateway=HealthStatus.OK, sequence=3))
+        log = win.log_tail.toPlainText()
+        assert log.count("gateway restarting — heartbeat down") == 1
+        assert log.count("gateway back — heartbeat OK") == 1
+        assert not win._restart_pending
+
+    def test_a_poll_out_when_the_put_lands_is_ignored_end_to_end(self, qtbot):
+        """The real path: the poll thread is blocked on a pre-put read while
+        the put completes; its report lands after arming and is ignored."""
+        import threading
+
+        from geecs_console.services import background
+
+        class GatedHealth:
+            def __init__(self):
+                self.gate = threading.Event()
+                self.gate.set()
+                self.status = HealthStatus.OK
+
+            def poll(self):
+                self.gate.wait(3.0)
+                return HealthReport(gateway=self.status)
+
+        probe = GatedHealth()
+        restart = self.FakeRestart()
+        win = MainWindow(
+            configs=FakeConfigs(),
+            presets=FakePresetStore(),
+            settings=FakeSettings(),
+            submitter=FakeSubmitter(),
+            health=probe,
+            gateway_restart=restart,
+        )
+        qtbot.addWidget(win)
+        if win._monitor is not None:
+            win._monitor.dispose()
+        win._health_timer.stop()
+        qtbot.waitUntil(lambda: "gateway: ok" in win.gateway_chip.text(), timeout=3000)
+        win._ask_binary = lambda *args, **kwargs: True
+        poller = win._health_poller
+
+        def landed():
+            return poller not in background._INFLIGHT
+
+        # Poll #2 goes out and blocks (its heartbeat read is pre-put).
+        probe.gate.clear()
+        poller.poll_async()
+        assert poller.polls_started == 2
+        win._on_restart_gateway()
+        self.settle(qtbot, win)
+        assert win._restart_pending and win._restart_arm_sequence == 2
+        # Now poll #2 returns its pre-put OK, after arming.
+        probe.gate.set()
+        qtbot.waitUntil(landed, timeout=3000)
+        qtbot.wait(50)  # the queued report_ready delivery
+        assert "gateway back" not in win.log_tail.toPlainText()
+        assert win._restart_pending
+        # Post-arm polls narrate the bounce.
+        probe.status = HealthStatus.DOWN
+        poller.poll_async()
+        qtbot.waitUntil(
+            lambda: "gateway restarting — heartbeat down" in win.log_tail.toPlainText(),
+            timeout=3000,
+        )
+        probe.status = HealthStatus.OK
+        poller.poll_async()
+        qtbot.waitUntil(
+            lambda: "gateway back — heartbeat OK" in win.log_tail.toPlainText(),
+            timeout=3000,
+        )
+        assert win.log_tail.toPlainText().count("gateway back") == 1
         assert not win._restart_pending
 
     def test_second_click_while_in_flight_is_a_noop(self, qtbot):

--- a/GEECS-Console/tests/test_main_window.py
+++ b/GEECS-Console/tests/test_main_window.py
@@ -1443,6 +1443,21 @@ class TestRestartGateway:
         assert "refused" in win.statusBar().currentMessage()
         assert "scan is active" in win.statusBar().currentMessage()
 
+    def test_refused_while_the_document_stream_says_running(self, qtbot):
+        """A start document paints RUNNING before the matching status poll
+        lands; the poll alone would wave the restart through in that window
+        (Codex review of PR #796)."""
+        win, restart = self.make(qtbot)
+        win._apply_health_report(HealthReport(gateway=HealthStatus.OK))
+        drive_status(win, "idle")  # the poll has not caught up yet
+        win._on_scan_state("running")  # …but the start document has landed
+        win._on_restart_gateway()
+        assert restart.calls == []
+        assert "scan is active" in win.statusBar().currentMessage()
+        win._on_scan_state("done")  # a terminal pill is quiet again
+        win._on_restart_gateway()
+        assert len(restart.calls) == 1
+
     def test_refused_while_a_manual_set_is_in_flight(self, qtbot):
         """A worker-side manual move never changes re_state, so the gate
         also reads the movable panel's in-flight flag (review of PR #796)."""

--- a/GEECS-Console/tests/test_save_set_editor.py
+++ b/GEECS-Console/tests/test_save_set_editor.py
@@ -353,6 +353,26 @@ class TestCompleters:
         editor.device_list.setCurrentRow(1)
         assert editor._variable_model.stringList() == ["PressureTorr"]
 
+    def test_variable_completer_matches_the_device_case_insensitively(
+        self, qtbot, track, store
+    ):
+        # The save-time check resolves devices case-insensitively; the
+        # completer must agree (review of PR #796).
+        editor = track(
+            SaveSetEditor(
+                experiment="HTU",
+                store=store,
+                completions=FakeCompletions({"uc_alineebeam1": ["MaxCounts"]}),
+            )
+        )
+        qtbot.waitUntil(
+            lambda: editor._device_model.stringList() == ["uc_alineebeam1"],
+            timeout=2000,
+        )
+        select_set(editor, "diag")
+        editor.device_list.setCurrentRow(0)  # the set's entry: "UC_ALineEbeam1"
+        assert editor._variable_model.stringList() == ["MaxCounts"]
+
     def test_no_provider_means_empty_completers(self, editor):
         select_set(editor, "diag")
         assert editor._device_model.stringList() == []

--- a/GEECS-Console/tests/test_save_set_editor.py
+++ b/GEECS-Console/tests/test_save_set_editor.py
@@ -483,6 +483,41 @@ class TestSaveTimeTargetCheck:
         assert "not checked" in message
         assert store.load("diag").entries[0].scalars == ["MeanCount"]
 
+    def test_a_listing_still_loading_refuses_the_save(self, qtbot, track, store):
+        # Loading is not offline: refuse until the fetch lands (Codex
+        # review of PR #796), then the ordinary check applies.
+        import threading
+
+        gate = threading.Event()
+
+        class SlowCompletions(FakeCompletions):
+            def device_variables(self):
+                gate.wait(5.0)
+                return super().device_variables()
+
+        editor = self._editor(
+            track,
+            store,
+            SlowCompletions(
+                {
+                    "UC_ALineEbeam1": ["MeanCounts"],
+                    "U_HP_Daq": ["AnalogOutput.Channel 1"],
+                }
+            ),
+        )
+        select_set(editor, "diag")
+        editor.device_list.setCurrentRow(0)
+        editor.scalar_edit.setText("MeanCount")
+        editor._on_add_scalar()
+        assert editor.completions_pending
+        assert editor._save() is False
+        assert "still loading" in editor.message_label.text()
+        gate.set()
+        qtbot.waitUntil(lambda: editor.completions_applied, timeout=5000)
+        assert not editor.completions_pending
+        assert editor._save() is False  # the near miss now blocks properly
+        assert "MeanCount" in editor.message_label.text()
+
     def test_the_no_completions_default_saves_quietly(self, editor, store):
         select_set(editor, "diag")
         editor.device_list.setCurrentRow(0)

--- a/GEECS-Console/tests/test_save_set_editor.py
+++ b/GEECS-Console/tests/test_save_set_editor.py
@@ -392,3 +392,81 @@ class TestEnterGuard:
             for row in range(editor.device_list.count())
         ]
         assert "UC_NewCam" in devices
+
+
+class TestSaveTimeTargetCheck:
+    """#772: unknown devices / scalars block Save; no listing ⇒ save + note."""
+
+    COMPLETIONS = {
+        "UC_ALineEbeam1": ["MaxCounts", "MeanCounts"],
+        "U_HP_Daq": ["PressureTorr"],
+    }
+
+    def _editor(self, track, store, completions):
+        editor = track(
+            SaveSetEditor(experiment="HTU", store=store, completions=completions)
+        )
+        return editor
+
+    def test_unknown_scalar_blocks_save_with_a_hint(self, qtbot, track, store):
+        editor = self._editor(track, store, FakeCompletions(self.COMPLETIONS))
+        qtbot.waitUntil(lambda: editor.completions_applied, timeout=2000)
+        select_set(editor, "diag")
+        editor.device_list.setCurrentRow(0)  # UC_ALineEbeam1
+        editor.scalar_edit.setText("MeanCount")
+        editor._on_add_scalar()
+        assert editor._save() is False
+        message = editor.message_label.text()
+        assert message.startswith("Not saved")
+        assert "'MeanCount' is not a variable of 'UC_ALineEbeam1'" in message
+        assert "did you mean 'MeanCounts'" in message
+        assert store.load("diag").entries[0].scalars == []
+
+    def test_unknown_device_blocks_save_with_a_hint(self, qtbot, track, store):
+        editor = self._editor(track, store, FakeCompletions(self.COMPLETIONS))
+        qtbot.waitUntil(lambda: editor.completions_applied, timeout=2000)
+        select_set(editor, "diag")
+        editor.device_edit.setText("UC_ALineEbeam9")
+        editor._on_add_device()
+        assert editor._save() is False
+        message = editor.message_label.text()
+        assert "unknown device 'UC_ALineEbeam9'" in message
+        assert "did you mean 'UC_ALineEbeam1'" in message
+        assert [e.device for e in store.load("diag").entries] == [
+            "UC_ALineEbeam1",
+            "U_HP_Daq",
+        ]
+
+    def test_known_names_save_cleanly(self, qtbot, track, store):
+        editor = self._editor(track, store, FakeCompletions(self.COMPLETIONS))
+        qtbot.waitUntil(lambda: editor.completions_applied, timeout=2000)
+        select_set(editor, "diag")
+        editor.device_list.setCurrentRow(0)
+        editor.scalar_edit.setText("MeanCounts")
+        editor._on_add_scalar()
+        assert editor._save() is True
+        assert editor.message_label.text() == "Saved 'diag'."
+        assert store.load("diag").entries[0].scalars == ["MeanCounts"]
+
+    def test_without_a_listing_the_save_goes_through_with_a_note(
+        self, qtbot, track, store
+    ):
+        editor = self._editor(track, store, FakeCompletions({}))  # offline shape
+        qtbot.waitUntil(lambda: editor.completions_applied, timeout=2000)
+        select_set(editor, "diag")
+        editor.device_list.setCurrentRow(0)
+        editor.scalar_edit.setText("MeanCount")
+        editor._on_add_scalar()
+        assert editor._save() is True
+        message = editor.message_label.text()
+        assert message.startswith("Saved 'diag'")
+        assert "not checked" in message
+        assert store.load("diag").entries[0].scalars == ["MeanCount"]
+
+    def test_the_no_completions_default_saves_quietly(self, editor, store):
+        select_set(editor, "diag")
+        editor.device_list.setCurrentRow(0)
+        editor.scalar_edit.setText("MeanCount")
+        editor._on_add_scalar()
+        assert editor._save() is True
+        assert editor.message_label.text() == "Saved 'diag'."

--- a/GEECS-Console/tests/test_scan_monitor.py
+++ b/GEECS-Console/tests/test_scan_monitor.py
@@ -1,11 +1,19 @@
 """Hermetic tests for the scan monitor controller (app/scan_monitor.py).
 
 No sockets: the stream workers' parsing and lifecycle are tested without
-their daemon threads (the parse helpers are called directly; ``stop()``
-gates emission), and the controller runs against the stub queue client.
+their daemon threads (the parse helpers are called directly, or a payload
+is posted from a plain thread), and the controller runs against the stub
+queue client.  Since 0.30.0 (#787) every stream signal is emitted on the
+GUI thread through the ``_GuiHopWorker`` hop — the tests pin where the
+slot runs, that ``stop()`` gates a payload already in flight, and that
+``dispose()`` severs the public signals without cutting the hop.
 """
 
 from __future__ import annotations
+
+import threading
+
+from PySide6.QtCore import QObject, Slot
 
 from geecs_console.app.scan_monitor import (
     ConsoleStreamWorker,
@@ -14,7 +22,31 @@ from geecs_console.app.scan_monitor import (
     _FAILED_MOVE_PREFIX_FALLBACK,
     _failed_move_prefix,
 )
+from geecs_console.services import background
 from geecs_bluesky.qs_client import StubQueueClient
+
+
+class Sink(QObject):
+    """Records payloads and the thread each slot ran on."""
+
+    def __init__(self):
+        super().__init__()
+        self.items: list = []
+        self.threads: list[int] = []
+
+    @Slot(str)
+    def take_line(self, text):
+        self.items.append(text)
+        self.threads.append(threading.get_ident())
+
+    @Slot(str, object)
+    def take_doc(self, name, doc):
+        self.items.append((name, doc))
+        self.threads.append(threading.get_ident())
+
+
+def _settled(qtbot, worker):
+    qtbot.waitUntil(lambda: worker not in background._INFLIGHT, timeout=3000)
 
 
 class TestFailedMovePrefix:
@@ -43,10 +75,23 @@ class TestConsoleStreamWorker:
             "failed - see cause\n\ntrailing",
             prefix,
         )
+        qtbot.waitUntil(lambda: len(lines) == 3, timeout=3000)  # blank line dropped
         assert lines[0] == "some noise"
-        assert len(lines) == 3  # blank line dropped
         assert len(reasons) == 1
         assert reasons[0].startswith("commanded u_s1h")
+
+    def test_lines_are_delivered_on_the_gui_thread(self, qtbot):
+        worker = ConsoleStreamWorker("tcp://x:1")
+        sink = Sink()
+        worker.line.connect(sink.take_line)
+        thread = threading.Thread(
+            target=worker._handle_text, args=("from the zmq thread", "PREFIX")
+        )
+        thread.start()
+        thread.join()
+        qtbot.waitUntil(lambda: sink.items == ["from the zmq thread"], timeout=3000)
+        assert sink.threads == [threading.get_ident()]
+        _settled(qtbot, worker)
 
     def test_stop_gates_emission(self, qtbot):
         worker = ConsoleStreamWorker("tcp://x:1")
@@ -54,6 +99,31 @@ class TestConsoleStreamWorker:
         worker.line.connect(seen.append)
         worker.stop()
         worker._handle_text("a line", "PREFIX")
+        qtbot.wait(50)
+        assert seen == []
+        assert worker not in background._INFLIGHT  # nothing was even posted
+
+    def test_stop_drops_a_payload_already_in_flight(self, qtbot):
+        # Posted before stop(), landing after it: the GUI-side gate wins,
+        # so dispose() means "nothing more reaches the window" — not
+        # "nothing more is *posted*".
+        worker = ConsoleStreamWorker("tcp://x:1")
+        seen: list[str] = []
+        worker.line.connect(seen.append)
+        worker._handle_text("in flight", "PREFIX")
+        worker.stop()
+        _settled(qtbot, worker)
+        assert seen == []
+
+    def test_sever_detaches_consumers_but_keeps_the_hop(self, qtbot):
+        worker = ConsoleStreamWorker("tcp://x:1")
+        seen: list[str] = []
+        worker.line.connect(seen.append)
+        worker.sever()
+        worker._handle_text("after sever", "PREFIX")
+        # The hop still lands (hold released) — a whole-object disconnect
+        # would have cut _landed → _forward and leaked the hold forever.
+        _settled(qtbot, worker)
         assert seen == []
 
 
@@ -63,6 +133,28 @@ class TestDocumentStreamWorker:
         worker.stop()
         worker.stop()
         assert worker._stopped
+
+    def test_documents_are_delivered_on_the_gui_thread(self, qtbot):
+        worker = DocumentStreamWorker("x:5568")
+        sink = Sink()
+        worker.document.connect(sink.take_doc)
+        thread = threading.Thread(
+            target=worker._post, args=(("document", "start", {"scan_number": 7}),)
+        )
+        thread.start()
+        thread.join()
+        qtbot.waitUntil(lambda: bool(sink.items), timeout=3000)
+        assert sink.items == [("start", {"scan_number": 7})]
+        assert sink.threads == [threading.get_ident()]
+        _settled(qtbot, worker)
+
+    def test_setup_failure_reaches_stream_failed_on_the_gui_thread(self, qtbot):
+        worker = DocumentStreamWorker("x:5568")
+        failures: list[str] = []
+        worker.stream_failed.connect(failures.append)
+        threading.Thread(target=worker._fail, args=("boom",)).start()
+        qtbot.waitUntil(lambda: failures == ["boom"], timeout=3000)
+        _settled(qtbot, worker)
 
 
 class TestScanMonitorController:
@@ -96,3 +188,25 @@ class TestScanMonitorController:
         # After dispose, start must not resurrect the timer.
         controller.start(parent)
         assert controller._timer is None
+
+    def test_dispose_on_a_never_connected_poller_is_silent(self, qtbot, recwarn):
+        controller = ScanMonitorController(StubQueueClient())
+        controller.dispose()
+        assert not [w for w in recwarn if "Failed to disconnect" in str(w.message)]
+
+    def test_dispose_severs_stream_consumers_without_cutting_the_hop(self, qtbot):
+        # Streams exist (addresses given) but their threads are never
+        # started — dispose() must sever the window-facing signals and
+        # leave each worker able to land a straggling payload.
+        controller = ScanMonitorController(
+            StubQueueClient(), info_addr="tcp://x:1", doc_addr="tcp://x:2"
+        )
+        seen: list = []
+        controller.console.line.connect(seen.append)
+        controller.documents.document.connect(lambda n, d: seen.append(n))
+        controller.dispose()
+        controller.console._handle_text("late", "PREFIX")
+        controller.documents._post(("document", "late", {}))
+        _settled(qtbot, controller.console)
+        _settled(qtbot, controller.documents)
+        assert seen == []

--- a/GEECS-Console/tests/test_scan_variable_editor.py
+++ b/GEECS-Console/tests/test_scan_variable_editor.py
@@ -551,3 +551,108 @@ class TestEnterNeverAccepts:
         for button in editor.findChildren(QPushButton):
             assert not button.isDefault()
             assert not button.autoDefault()
+
+
+class TestSaveTimeTargetCheck:
+    """#772: an unknown device/variable blocks Save; no listing ⇒ save + note."""
+
+    MAPPING = {
+        "U_Grating2Rotation": ["Position.Axis 1", "Position.Axis 2"],
+        "U_S3H": ["Current"],
+        "U_S4H": ["Current"],
+    }
+
+    def _new_simple(self, editor, device, variable):
+        editor.new_simple_button.click()
+        editor.device_edit.setText(device)
+        editor.variable_edit.setText(variable)
+
+    def test_unknown_variable_blocks_save_with_a_hint(self, qtbot, tmp_path):
+        editor = make_editor(qtbot, tmp_path, completions=FakeCompletions(self.MAPPING))
+        self._new_simple(editor, "U_Grating2Rotation", "Position.Axis1")
+        editor.save_button.click()
+        message = editor.error_label.text()
+        assert "new_variable → target" in message
+        assert "'Position.Axis1' is not a variable of 'U_Grating2Rotation'" in message
+        assert "did you mean 'Position.Axis 1'" in message
+        path = tmp_path / EXPERIMENT / SCAN_VARIABLES_FOLDER / CATALOG_FILE
+        assert not path.exists()
+        assert editor.dirty
+
+    def test_unknown_device_blocks_save_with_a_hint(self, qtbot, tmp_path):
+        editor = make_editor(qtbot, tmp_path, completions=FakeCompletions(self.MAPPING))
+        self._new_simple(editor, "U_Grating2Rotatoin", "Position.Axis 1")
+        editor.save_button.click()
+        message = editor.error_label.text()
+        assert "unknown device 'U_Grating2Rotatoin'" in message
+        assert "did you mean 'U_Grating2Rotation'" in message
+        assert editor.dirty
+
+    def test_confirm_target_is_checked_too(self, qtbot, tmp_path):
+        editor = make_editor(qtbot, tmp_path, completions=FakeCompletions(self.MAPPING))
+        self._new_simple(editor, "U_S3H", "Current")
+        editor.confirm_device_edit.setText("U_S3H")
+        editor.confirm_variable_edit.setText("Curent")
+        editor.save_button.click()
+        message = editor.error_label.text()
+        assert "new_variable → confirm" in message
+        assert "did you mean 'Current'" in message
+
+    def test_composite_error_names_the_component_row(self, qtbot, tmp_path):
+        editor = make_editor(qtbot, tmp_path, completions=FakeCompletions(self.MAPPING))
+        editor.new_pseudo_button.click()
+        table = editor.components_table
+        table.cellWidget(0, 0).setText("U_S3H")
+        table.cellWidget(0, 1).setText("Current")
+        table.cellWidget(0, 2).setText("composite_var")
+        editor.add_component_button.click()
+        table.cellWidget(1, 0).setText("U_S4H")
+        table.cellWidget(1, 1).setText("Currnt")
+        table.cellWidget(1, 2).setText("composite_var * -1")
+        editor.save_button.click()
+        message = editor.error_label.text()
+        assert "new_composite → component 2" in message
+        assert "'Currnt' is not a variable of 'U_S4H'" in message
+        assert "component 1" not in message
+
+    def test_device_case_difference_is_accepted(self, qtbot, tmp_path):
+        editor = make_editor(qtbot, tmp_path, completions=FakeCompletions(self.MAPPING))
+        self._new_simple(editor, "u_s3h", "Current")
+        editor.save_button.click()
+        assert not editor.dirty
+        assert editor.error_label.text() == ""
+
+    def test_good_targets_save_cleanly(self, qtbot, tmp_path):
+        editor = make_editor(qtbot, tmp_path, completions=FakeCompletions(self.MAPPING))
+        self._new_simple(editor, "U_Grating2Rotation", "Position.Axis 1")
+        editor.save_button.click()
+        assert not editor.dirty
+        assert editor.error_label.text() == ""
+        document = catalog_document(tmp_path)
+        assert document["variables"]["new_variable"]["target"] == (
+            "U_Grating2Rotation:Position.Axis 1"
+        )
+
+    def test_without_a_listing_the_same_draft_saves_with_a_note(self, qtbot, tmp_path):
+        # A real provider that came back empty (offline / DB down) — the
+        # draft saves, and the label says the names went unchecked.
+        editor = make_editor(qtbot, tmp_path, completions=FakeCompletions({}))
+        self._new_simple(editor, "U_Grating2Rotation", "Position.Axis1")
+        editor.save_button.click()
+        assert not editor.dirty
+        note = editor.error_label.text()
+        assert "saved" in note
+        assert "not checked" in note
+        document = catalog_document(tmp_path)
+        assert document["variables"]["new_variable"]["target"] == (
+            "U_Grating2Rotation:Position.Axis1"
+        )
+
+    def test_the_no_completions_default_saves_quietly(self, qtbot, tmp_path):
+        # EmptyCompletions (no experiment / offline construction) never
+        # expected a listing, so there is nothing to nag about.
+        editor = make_editor(qtbot, tmp_path)
+        self._new_simple(editor, "U_Grating2Rotation", "Position.Axis1")
+        editor.save_button.click()
+        assert not editor.dirty
+        assert editor.error_label.text() == ""

--- a/GEECS-Console/tests/test_scan_variable_editor.py
+++ b/GEECS-Console/tests/test_scan_variable_editor.py
@@ -78,7 +78,7 @@ def catalog_document(tmp_path) -> dict:
     return yaml.safe_load(path.read_text())
 
 
-def make_editor(qtbot, tmp_path, experiment=EXPERIMENT, completions=None):
+def make_editor(qtbot, tmp_path, experiment=EXPERIMENT, completions=None, wait=True):
     """Build an editor with crash-safe test teardown (see module docstring)."""
     store = ScanVariableStore(experiment, experiments_root=tmp_path)
     editor = ScanVariableEditor(
@@ -88,7 +88,8 @@ def make_editor(qtbot, tmp_path, experiment=EXPERIMENT, completions=None):
     qtbot.addWidget(editor)
     editor._confirm_discard = lambda: True  # revert confirms (teardown safety)
     editor._prompt_unsaved = lambda: "discard"  # teardown close must never block
-    qtbot.waitUntil(lambda: editor.completions_applied, timeout=5000)
+    if wait:
+        qtbot.waitUntil(lambda: editor.completions_applied, timeout=5000)
     return editor
 
 
@@ -647,6 +648,40 @@ class TestSaveTimeTargetCheck:
         assert document["variables"]["new_variable"]["target"] == (
             "U_Grating2Rotation:Position.Axis1"
         )
+
+    def test_a_listing_still_loading_refuses_the_save(self, qtbot, tmp_path):
+        # A real provider that has not answered yet is "loading", not
+        # "DB down": saving now would persist unchecked names one poll
+        # before the check could run (Codex review of PR #796).
+        import threading
+
+        gate = threading.Event()
+
+        class SlowCompletions(FakeCompletions):
+            def device_variables(self):
+                gate.wait(5.0)
+                return super().device_variables()
+
+        editor = make_editor(
+            qtbot,
+            tmp_path,
+            completions=SlowCompletions({"U_Grating2Rotation": ["Position.Axis 1"]}),
+            wait=False,
+        )
+        self._new_simple(editor, "U_Grating2Rotation", "Position.Axis1")
+        assert editor.completions_pending
+        editor.save_button.click()
+        assert editor.dirty
+        assert "still loading" in editor.error_label.text()
+        assert not (
+            tmp_path / EXPERIMENT / "scan_devices" / "scan_variables.yaml"
+        ).exists()
+        gate.set()
+        qtbot.waitUntil(lambda: editor.completions_applied, timeout=5000)
+        assert not editor.completions_pending
+        editor.save_button.click()  # now the real check runs: near miss blocks
+        assert editor.dirty
+        assert "Position.Axis 1" in editor.error_label.text()
 
     def test_the_no_completions_default_saves_quietly(self, qtbot, tmp_path):
         # EmptyCompletions (no experiment / offline construction) never

--- a/GEECS-Console/tests/test_tooltips.py
+++ b/GEECS-Console/tests/test_tooltips.py
@@ -97,6 +97,7 @@ class TestMainWindowOperatorTooltips:
         "progress_bar",
         "queue_table",
         "queue_clear_button",
+        "restart_gateway_action",
         "device_combo",
         "set_field",
         "set_button",


### PR DESCRIPTION
## Summary

GEECS-Console 0.29.0 → **0.30.0**, three commits, one bump, one CHANGELOG entry. The operator-surface PR of the 2026-09-04 fix wave (PR A = tooling, PR C = GeecsBluesky readiness).

| Commit | Issue | Product | Tests | Docs/meta |
|---|---|---|---|---|
| `649452e6` editors: save-time device/variable check with near-miss hints | #772 part 1 | +268 / −6 | +251 | — |
| `91d97250` Ops → Restart gateway… | #773 | +270 / −2 | +204 / −7 | — |
| `e3eb39b6` every cross-thread signal rides the background hop | #787 | +290 / −146 | +191 / −3 | +102 / −25 |

Closes #773.
Part of #772 (part 1 — the editor gate; part 2, the manual-move unserved-variables preflight, is in the GeecsBluesky readiness PR).
Part of #787 (emitter consolidation; the window ↔ controller reference cycles and the once-seen interpreter-exit segfault remain open).

## What each commit does

**#772 part 1 — editor save gate.** The scan-variable editor (simple target, confirm target, every composite component row) and the save-set editor (entry device, listed scalars) check every name against the fetched completions listing at Save. An unknown device (case-insensitive match, like the completer) or an unknown variable for that device blocks the save with an inline error naming the variable and row plus a difflib "did you mean" hint. The live case, `Position.Axis1` for `Position.Axis 1`, scores 0.97 and hints correctly. Free text stays: with the DB unreachable a real provider that came back empty saves with a "names were not checked" note; the `EmptyCompletions` default (no experiment) saves quietly. Shared helpers (`target_problem`, `resolve_device`, `near_miss`) live once in `editors/base.py`.

**#773 — Ops → Restart gateway….** Writes `Restart` to `{experiment}:cagateway:restart` (the gateway's one client-writable PV) through `GatewaySetpointPut` with `wire_value` coercion on a `BackgroundResult` worker; PV name via `ca_pv`/`bare_pv` only (#490). Enabled only with an experiment selected and a *known* gateway chip (OK/WARN/DOWN; UNKNOWN = no poll yet); refused while a scan is active on the manager (`_scanning()`, the Start gate); one `_ask_binary` confirmation stating the cost (fleet-wide CA disconnect for a few seconds; a gateway outside its restart-on-exit-86 supervisor stays down). The health poll then narrates the bounce in the log tail: "gateway restarting — heartbeat down" on the first DOWN, "gateway back — heartbeat OK" on the first OK, then disarms.

**#787 — hop consolidation.** The three residual daemon-thread → consumer emitters moved onto `services/background.py`: the scan monitor's stream workers subclass `_GuiHopWorker` (zmq thread posts tagged payloads; `document`/`line`/`pause_reason`/`stream_failed` fire on the GUI thread; `stop()` gates *both* sides of the hop so an in-flight payload lands and is dropped; threads stay abandoned), the movable panel's aioca readback callback posts through a new public `GuiRelay` (controller `value_ready` removed), and the editors' completions fetch is a plain `BackgroundResult` (`completions_ready` removed). Long-lived producers take the in-flight hold on their own thread, so `_INFLIGHT` is now lock-guarded. `ScanMonitorController.dispose()` severs only the public signals (a whole-object `QObject.disconnect()` cut the internal hop and stranded an in-flight hold) and the never-connected-poller `libpyside: Failed to disconnect (None)` RuntimeWarning is gone (`disconnect_quietly`).

## Tests

- `./scripts/check.sh --base origin/master`: lint clean; **GEECS-Console 877 passed** (was 865 on master; +12 net, 35 new tests across `test_editor_target_check.py`, `test_gateway_restart.py`, `test_scan_variable_editor.py`, `test_save_set_editor.py`, `test_main_window.py`, `test_scan_monitor.py`, `test_background.py`).
- Isolated `QT_QPA_PLATFORM=offscreen pytest tests/test_main_window.py` (the #767/#787 segfault shape), macOS arm64, PySide 6.11.1: baseline on master **3/3 clean** (142 passed), after this branch **4/4 clean** (142 passed). The conftest safe-point collection from #788 already holds this file stable here; this PR removes the last three emitters of the racing shape rather than fixing a currently reproducing crash.
- Suite run with `-W error::RuntimeWarning` on the #787-touched files: clean.

## Judgment calls

- **Save-set editor had the same gap** (free text + completer, no save-time check) — fixed in the same commit, mapped onto its document shape (entry device, then that entry's scalars; an unknown device skips its scalars since they cannot be checked).
- **Variable match is case-sensitive, device match is not.** The issue asked for device case-insensitivity (the completer's behavior). A case-only variable mismatch gets a hint ("did you mean 'Velocity'") rather than silent acceptance, since the target string is stored verbatim.
- **"Unchecked" note only when a listing was expected**: a pre-existing pin (`test_error_clears_after_a_good_save`) showed that nagging on every save of an `EmptyCompletions` editor is wrong; the note now fires only when a real provider returned empty (offline/DB down).
- **Restart PV value** is the label `"Restart"` (contract: label or index 1); the put is `GatewaySetpointPut(setpoint_pv=<bare restart pv>)` even though the PV has no `:SP` suffix — it is the control PV itself, and the primitive normalizes the name.
- **The restart put runs on `asyncio.run`**, not the shared one-shot loop (`geecs_bluesky.devices.ca.oneshot` serves reads and keeps its loop private). aioca caches channels per loop, so each click strands one channel; accepted for an incident-rate verb, documented in the module.
- **Restart action enabled on DOWN**: a DOWN gateway under its supervisor is exactly when a restart may help; only UNKNOWN (no experiment / no poll yet) disables.
- **`apply_operator_tooltips` now runs after `_build_menus`** — the catalog names the new action and raises on a missing name.
- **Ops-menu pin reads the menu through `window._menus`**: a QMenu reached via `menuBar().actions()[i].menu()` is torn down with its actions when that temporary wrapper is collected, and since #773 the window re-gates the action on every health poll — the old enumeration surfaced as a RuntimeError after the test.
- **`GuiRelay` is public, `_GuiHopWorker` stays private**: the stream workers need typed signals so they subclass the base directly (the sanctioned pattern per CLAUDE.md); the movable panel needs only a payload relay.
- **`sever()` instead of `QObject.disconnect()`** in the monitor's dispose — the blanket disconnect was silently cutting the hop's own connection.

## Hardware verification (owed)

Everything here is hermetic; the #773 action needs the deployed gateway. Steps:

1. On a console with the lab network (VPN is fine), select the experiment, wait for the gateway chip to read `ok`, confirm **Ops → Restart gateway…** is enabled and that it is disabled while a scan is running.
2. Note `caget <experiment>:cagateway:devices_connected` and `…:uptime`.
3. Click **Restart gateway…**, confirm. Expect in the log tail: "restarting the <experiment> gateway…", then "gateway restart requested (<pv>) — expect a few seconds of CA disconnect".
4. Within ~10 s: chip `down` then `ok`; log tail "gateway restarting — heartbeat down" (may be skipped if the bounce falls between 5 s polls, in which case the "back" line says so) and "gateway back — heartbeat OK".
5. `…:uptime` reads ~0 and `…:devices_connected` recovers to its prior count; a previously frozen readback (if one exists) resumes.
6. Negative: with a scan running, click the action — status bar "Gateway restart refused — a scan is active on the manager", nothing written.

The #772 editor check can be tried live too: in Editors → Scan Variables, set a target to `U_Grating2Rotation:Position.Axis1` and Save — expect the inline error with the `Position.Axis 1` hint (DB completions must have loaded; offline the save goes through with the note).

## Review

Adversarial review done; findings 1–7 dispositioned (6 fixed on this branch in `33bd2e0c`, `b21fc131`, `faa78e1b`, `b81f1ad3`; the placement half of finding 1 waived as a cross-package follow-up) in https://github.com/GEECS-BELLA/GEECS-Plugins/pull/796#issuecomment-5549421897 — the same comment records the pre-existing isolated-run segfault (reproduces on the pre-fix head `e3eb39b6`, ~1 in 12).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

