### PR TITLE
GeecsPvaGateway 0.6.0 + fleet scripts: fleet subcommand, shared lab_env.sh, record contracts, facts vs findings (site-profile Phase 4)

### DIFF
--- a/.claude/skills/fleet-status/SKILL.md
+++ b/.claude/skills/fleet-status/SKILL.md
@@ -32,6 +32,7 @@ and bounded: no PV writes, no restarts, no pulls.
 | Situation | Command |
 |---|---|
 | The normal case (full log, for reasoning) | `scripts/fleet_status.sh` |
+| Just the PVA image fleet | `poetry -C GeecsPvaGateway run geecs-pva-gateway fleet --experiment NAME` |
 | One box table + attention list (for the user) | `scripts/fleet_status.sh --summary` |
 | Persistent dashboard pane (cmux/tmux) | `scripts/fleet_status.sh --watch 300` (summary every 300 s; add `--full` for the log) |
 | Off the lab network / just want the local worktree picture | `scripts/fleet_status.sh --local-only` |
@@ -63,13 +64,18 @@ answers with its environment closed knows zero plans and refuses every
 submission as "not in the list of allowed plans"; the script prints
 `NOT READY` for that, never `OK`, #793), MCP port liveness (no version
 endpoint; stage 2 reads its venv), the CA gateway's heartbeat /
-`devices_connected` / `version` PVs (reused from `lab_status.sh
---hardware`, read-only), and every PVA image gateway's `version` +
-`heartbeat` PVs. The roster is read live from the GEECS DB (endpoint
-IPs hosting the experiment's image devices, `geecs_pva_gateway.fleet`);
-a roster host absent from `config.ini [pva] addr_list` is **not
-deployed** — printed as a `[ -- ]` row, never `[DOWN]` — because no
-instance was installed there. A `[WARN] PVA fleet runs mixed
+`devices_connected` / `version` PVs (from `lab_status.sh --hardware`,
+read-only — its `role=CA gateway` record line is the contract, not the
+prose), and every PVA image gateway's `version` + `heartbeat` PVs via
+`geecs-pva-gateway fleet` (the package owns the roster, the PV names,
+and the probe; the script only relays its lines and its record). The
+roster is read live from the GEECS DB (endpoint IPs hosting the
+experiment's image devices, `geecs_pva_gateway.fleet`); a roster host
+absent from `config.ini [pva] addr_list` is **not deployed** — printed
+as a `[ -- ]` row, never `[DOWN]` — because no instance was installed
+there. MCP not listening is a `[WARN]` + ✗ row: the fleet map has it as
+a system unit on the worker host, so silence is a finding, not
+"pending deploy". A `[WARN] PVA fleet runs mixed
 versions` line means a rollout is incomplete or a box's
 pull-on-restart no-oped — the GeecsPvaGateway runbook's known failure.
 

--- a/.claude/skills/fleet-status/SKILL.md
+++ b/.claude/skills/fleet-status/SKILL.md
@@ -124,7 +124,7 @@ sha, package version). Quote versions and shas exactly as printed.
 
 When the observed picture contradicts `docs/platform/fleet_map.md`
 (a service on a different host, a checkout path the table doesn't
-name, a service the table calls "pending deploy" that is listening),
+name, a unit the map lists that is not listening),
 say so explicitly and offer to update the fleet map in the same PR as
 whatever change the user makes next — the map's own rule is "update
 this page in the same PR".

--- a/.claude/skills/lab-status/SKILL.md
+++ b/.claude/skills/lab-status/SKILL.md
@@ -15,8 +15,12 @@ description: >
 # /lab-status — what can this machine reach right now?
 
 `scripts/lab_status.sh` owns the endpoints, ports, and timeouts (derived
-from `~/.config/geecs_python_api/config.ini` — do not restate or hardcode
-them here or anywhere else). This skill is about running it at the right
+from `~/.config/geecs_python_api/config.ini` by `scripts/lib/lab_env.sh`,
+the config reader + endpoint derivation + printers it shares with
+`scripts/fleet_status.sh` — do not restate or hardcode them here or
+anywhere else). Tier 2 also prints one machine-readable
+`role=CA gateway<TAB>state=…<TAB>version=…` line: the contract
+`/fleet-status` consumes; the prose lines are for people. This skill is about running it at the right
 moment and acting on the answer. For *what code* the reachable services
 are running (checkout/branch/version per host) use `/fleet-status`,
 which runs this probe first as its gate.

--- a/GeecsPvaGateway/CHANGELOG.md
+++ b/GeecsPvaGateway/CHANGELOG.md
@@ -3,6 +3,21 @@
 All notable changes to this package will be documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.6.0] - 2026-09-05
+
+### Added
+
+- **`geecs-pva-gateway fleet --experiment NAME`** — the read-only fleet
+  liveness probe (`fleet.probe_fleet` / `fleet_main`): every deployed
+  host's `version` + `heartbeat` instance PVs by unicast, printed as the
+  `[ OK ]` / `[DOWN]` / `[ -- ] not deployed` / `[WARN] mixed versions`
+  lines plus one tab-separated `role=PVA image gateways` record for the
+  fleet table (`info=` facts, `note=` findings). `scripts/fleet_status.sh`
+  calls it instead of re-deriving the roster and the PV names in a bash
+  heredoc (#776 review item 7): the roster, the naming, and the probe now
+  live in this package. The serve form (`geecs-pva-gateway --experiment`)
+  is unchanged — `deploy/launch.bat` on every camera server uses it.
+
 ## [0.5.0] - 2026-09-04
 
 ### Added

--- a/GeecsPvaGateway/CLAUDE.md
+++ b/GeecsPvaGateway/CLAUDE.md
@@ -26,11 +26,14 @@ instance-PV semantics — as a contract.
 ```
 geecs_pva_gateway/
   __main__.py   # geecs-pva-gateway --experiment NAME [--host IP] [--devices A,B] [--list]
+                #   + `geecs-pva-gateway fleet` (read-only fleet probe, fleet.py)
   config.py     # CameraSpec / PvaGatewayConfig; DB-scoped served set
                 #   (enabled devices on this host's IP with image-typed vars)
   fleet.py      # fleet roster: camera servers from the DB per experiment,
                 #   each marked deployed by config.ini [pva] addr_list
-                #   (absent = not deployed: no instance, not an outage)
+                #   (absent = not deployed: no instance, not an outage);
+                #   probe_fleet/fleet_main = the `fleet` subcommand that
+                #   scripts/fleet_status.sh calls (lines + one role= record)
   server.py     # GeecsPvaGateway + per-camera worker: gated + supervised
                 #   subscription, decode off-loop, latest-wins posting,
                 #   version/heartbeat/restart instance PVs (restart -> exit 86)
@@ -49,7 +52,8 @@ deploy/
 tests/
   test_config.py  # scoping/naming units (fake DB rows, no network)
   test_fleet.py   # roster derivation, the [pva] addr_list deployed mark,
-                  #   the generated screen's rows (fake DB rows, no network)
+                  #   the generated screen's rows, the fleet probe's lines +
+                  #   record and the `fleet` dispatch (fake DB/getter, no network)
   test_server.py  # end-to-end over a binary wire-format fake camera +
                   #   isolate=True PVA server
   test_entrypoint.py # CLI exit codes (incl. the restart code 86 contract)

--- a/GeecsPvaGateway/DEPLOYMENT.md
+++ b/GeecsPvaGateway/DEPLOYMENT.md
@@ -219,6 +219,21 @@ If the fleet ever outgrows a hand-kept list, the standard escalation is a PVA
 nameserver — but that reintroduces a central hop; don't reach for it while a
 one-line list works.
 
+## Fleet probe from any client
+
+```bash
+poetry -C GeecsPvaGateway run geecs-pva-gateway fleet --experiment Undulator
+```
+
+reads every deployed host's `version` + `heartbeat` PVs (read-only, unicast
+to the `[pva] addr_list` hosts — no broadcast needed over a VPN) and prints
+one line per roster host: `[ OK ]` with version and heartbeat, `[DOWN]`
+with the error, `[ -- ] not deployed` for DB hosts absent from `addr_list`,
+and a `[WARN]` when versions are mixed (a rollout is incomplete). The last
+line is a tab-separated `role=PVA image gateways` record — the contract
+`scripts/fleet_status.sh` consumes for its table. Exit 0 when any host
+answered.
+
 ## Instance PVs
 
 | PV | Meaning |

--- a/GeecsPvaGateway/geecs_pva_gateway/__main__.py
+++ b/GeecsPvaGateway/geecs_pva_gateway/__main__.py
@@ -1,4 +1,9 @@
-"""CLI: ``geecs-pva-gateway --experiment NAME`` — DB-scoped serve, then run."""
+"""CLI: ``geecs-pva-gateway --experiment NAME`` — DB-scoped serve, then run.
+
+``geecs-pva-gateway fleet ...`` is the read-only fleet probe
+(:func:`geecs_pva_gateway.fleet.fleet_main`); the serve form stays flat
+because ``deploy/launch.bat`` on every camera server invokes it that way.
+"""
 
 from __future__ import annotations
 
@@ -13,8 +18,14 @@ from geecs_pva_gateway.server import RESTART_EXIT_CODE, GeecsPvaGateway, __versi
 
 def main(argv: list[str] | None = None) -> int:
     """Entry point for the ``geecs-pva-gateway`` console script."""
+    args_in = sys.argv[1:] if argv is None else argv
+    if args_in[:1] == ["fleet"]:
+        from geecs_pva_gateway.fleet import fleet_main
+
+        return fleet_main(args_in[1:])
     parser = argparse.ArgumentParser(
-        description="Serve this host's GEECS camera images as NTNDArray PVs."
+        description="Serve this host's GEECS camera images as NTNDArray PVs.",
+        epilog="`geecs-pva-gateway fleet --experiment NAME` probes the deployed fleet instead (read-only).",
     )
     parser.add_argument("--experiment", required=True, help="GEECS experiment name")
     parser.add_argument(

--- a/GeecsPvaGateway/geecs_pva_gateway/fleet.py
+++ b/GeecsPvaGateway/geecs_pva_gateway/fleet.py
@@ -14,8 +14,8 @@ Two facts, one home each — nothing hand-curated in code:
   the hosts running an instance, space-separated (commas tolerated; a
   ``host:port`` entry counts by its host) — the same list a cross-subnet
   client puts in ``EPICS_PVA_ADDR_LIST`` (DEPLOYMENT.md "Client access"),
-  mirroring ``[epics] ca_addr_list``. Only the fleet tooling reads the key;
-  ``scripts/fleet_status.sh`` exports it for its own probe. A roster host
+  mirroring ``[epics] ca_addr_list``. Only the fleet tooling reads the key
+  (``geecs-pva-gateway fleet`` searches exactly those hosts). A roster host
   absent from it is **not deployed**: the box hosts cameras only nominally
   and no instance was ever installed there — a failed probe is not an
   outage. When the key is absent every roster host counts as deployed (the
@@ -32,9 +32,9 @@ from __future__ import annotations
 import argparse
 import configparser
 import logging
-import os
 import sys
-from collections.abc import Callable
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager, nullcontext
 from pathlib import Path
 
 from pydantic import BaseModel, Field
@@ -248,24 +248,21 @@ class FleetProbe(BaseModel):
         return "\t".join(fields)
 
 
-def _p4p_getter(hosts: list[str], timeout: float) -> Callable[[str], object]:
-    """A ``get(pv) -> value`` over a p4p context searching *hosts* by unicast.
+@contextmanager
+def _p4p_context(hosts: list[str], timeout: float) -> Iterator[Callable[[str], object]]:
+    """Yield a ``get(pv) -> value`` over a p4p context searching *hosts* by unicast.
 
     UDP broadcast does not cross a VPN, so the address list is the deployed
-    hosts themselves (``EPICS_PVA_AUTO_ADDR_LIST=NO``).
+    hosts themselves (``EPICS_PVA_AUTO_ADDR_LIST=NO``) — passed as the
+    context's own ``conf``, never written to the process environment; the
+    context is closed on exit so a library caller leaks nothing.
     """
-    os.environ["EPICS_PVA_ADDR_LIST"] = " ".join(hosts)
-    os.environ["EPICS_PVA_AUTO_ADDR_LIST"] = "NO"
     from p4p.client.thread import Context
 
-    ctx = Context(
-        "pva", unwrap=False
-    )  # raw Values: str(NT wrapper) carries a timestamp
-
-    def get(pv: str) -> object:
-        return ctx.get(pv, timeout=timeout)["value"]
-
-    return get
+    conf = {"EPICS_PVA_ADDR_LIST": " ".join(hosts), "EPICS_PVA_AUTO_ADDR_LIST": "NO"}
+    # unwrap=False: raw Values (str(NT wrapper) would carry a timestamp).
+    with Context("pva", conf=conf, useenv=True, unwrap=False) as ctx:
+        yield lambda pv: ctx.get(pv, timeout=timeout)["value"]
 
 
 def probe_fleet(
@@ -285,15 +282,20 @@ def probe_fleet(
     )
     if not deployed:
         return result
-    get = getter or _p4p_getter([h.ip for h in deployed], timeout)
-    for host in deployed:
-        try:
-            version = str(get(host.instance_pv(experiment, "version")))
-            beats = int(get(host.instance_pv(experiment, "heartbeat")))
-        except Exception as exc:  # noqa: BLE001 — a failed probe is a finding
-            result.probes.append(HostProbe(host=host, error=type(exc).__name__))
-            continue
-        result.probes.append(HostProbe(host=host, version=version, heartbeat=beats))
+    source = (
+        nullcontext(getter)
+        if getter
+        else _p4p_context([h.ip for h in deployed], timeout)
+    )
+    with source as get:
+        for host in deployed:
+            try:
+                version = str(get(host.instance_pv(experiment, "version")))
+                beats = int(get(host.instance_pv(experiment, "heartbeat")))
+            except Exception as exc:  # noqa: BLE001 — a failed probe is a finding
+                result.probes.append(HostProbe(host=host, error=type(exc).__name__))
+                continue
+            result.probes.append(HostProbe(host=host, version=version, heartbeat=beats))
     return result
 
 

--- a/GeecsPvaGateway/geecs_pva_gateway/fleet.py
+++ b/GeecsPvaGateway/geecs_pva_gateway/fleet.py
@@ -22,13 +22,19 @@ Two facts, one home each — nothing hand-curated in code:
   pre-``[pva]`` behaviour).
 
 Consumers: ``deploy/gen_fleet_status.py`` (the Phoebus fleet screen) and
-``scripts/fleet_status.sh`` (the observed-fleet probe).
+``geecs-pva-gateway fleet`` (:func:`probe_fleet` / :func:`fleet_main`), the
+read-only liveness probe ``scripts/fleet_status.sh`` calls — so the roster,
+the instance PV names, and the probe live in one package.
 """
 
 from __future__ import annotations
 
+import argparse
 import configparser
 import logging
+import os
+import sys
+from collections.abc import Callable
 from pathlib import Path
 
 from pydantic import BaseModel, Field
@@ -142,3 +148,196 @@ def fleet_roster(
         )
         hosts.append(FleetHost(ip=ip, cameras=[], deployed=True))
     return sorted(hosts, key=lambda h: _ip_key(h.ip))
+
+
+# --- the liveness probe (`geecs-pva-gateway fleet`) ----------------------------
+
+FLEET_ROLE = "PVA image gateways"
+
+
+class HostProbe(BaseModel):
+    """One deployed host's answer to the version/heartbeat gets."""
+
+    host: FleetHost
+    version: str | None = None
+    heartbeat: int | None = None
+    error: str | None = None
+
+    @property
+    def up(self) -> bool:
+        """True when both instance PVs answered."""
+        return self.version is not None
+
+
+class FleetProbe(BaseModel):
+    """The whole fleet's probe: per-host results plus the roster's not-deployed hosts."""
+
+    experiment: str
+    probes: list[HostProbe] = Field(default_factory=list)
+    not_deployed: list[FleetHost] = Field(default_factory=list)
+
+    @property
+    def versions(self) -> dict[str, list[str]]:
+        """``{version: [ip, ...]}`` over the hosts that answered."""
+        out: dict[str, list[str]] = {}
+        for p in self.probes:
+            if p.up:
+                out.setdefault(str(p.version), []).append(p.host.ip)
+        return out
+
+    @property
+    def down(self) -> list[HostProbe]:
+        """Deployed hosts that did not answer."""
+        return [p for p in self.probes if not p.up]
+
+    def lines(self) -> list[str]:
+        """Human lines in the fleet_status.sh style (``[ OK ]``/``[DOWN]``/``[ -- ]``/``[WARN]``)."""
+        out = []
+        for p in self.probes:
+            n = len(p.host.cameras)
+            if p.up:
+                out.append(
+                    f"  [ OK ] PVA gateway  {p.host.ip:<15}  geecs-pva-gateway {p.version}"
+                    f"  heartbeat={p.heartbeat}  {n} cameras"
+                )
+            else:
+                out.append(
+                    f"  [DOWN] PVA gateway  {p.host.ip:<15}  ({p.error}; {n} cameras)"
+                )
+        for h in self.not_deployed:
+            out.append(
+                f"  [ -- ] PVA gateway  {h.ip:<15}  not deployed ({len(h.cameras)} cameras in the DB: "
+                f"{', '.join(h.cameras)}) — add to config.ini [pva] addr_list once installed"
+            )
+        if len(self.versions) > 1:
+            out.append(
+                "  [WARN] PVA fleet runs mixed versions — a rollout is incomplete or a box missed its pull-on-restart:"
+            )
+            for ver, hs in sorted(self.versions.items()):
+                out.append(f"         {ver}: {', '.join(hs)}")
+        return out
+
+    def record(self) -> str:
+        """One tab-separated ``key=value`` record for the fleet table.
+
+        ``info=`` carries facts (hosts up, hosts not deployed); ``note=``
+        carries findings (unreachable hosts, mixed versions) — the table
+        marks a row ``!`` on notes only.
+        """
+        versions = self.versions
+        n_ok = sum(len(hs) for hs in versions.values())
+        ver_txt = (
+            ", ".join(f"{v} ×{len(hs)}" for v, hs in sorted(versions.items())) or "?"
+        )
+        fields = [
+            f"role={FLEET_ROLE}",
+            f"state={'ok' if n_ok else 'down'}",
+            "runs=NSSM",
+            "checkout=share clone",
+            f"version={ver_txt}",
+            f"info={n_ok} of {len(self.probes)} deployed up",
+        ]
+        if self.not_deployed:
+            fields.append(f"info={len(self.not_deployed)} not deployed")
+        if self.down:
+            fields.append(
+                f"note={len(self.down)} unreachable: {' '.join(p.host.ip for p in self.down)}"
+            )
+        if len(versions) > 1:
+            fields.append("note=MIXED versions")
+        return "\t".join(fields)
+
+
+def _p4p_getter(hosts: list[str], timeout: float) -> Callable[[str], object]:
+    """A ``get(pv) -> value`` over a p4p context searching *hosts* by unicast.
+
+    UDP broadcast does not cross a VPN, so the address list is the deployed
+    hosts themselves (``EPICS_PVA_AUTO_ADDR_LIST=NO``).
+    """
+    os.environ["EPICS_PVA_ADDR_LIST"] = " ".join(hosts)
+    os.environ["EPICS_PVA_AUTO_ADDR_LIST"] = "NO"
+    from p4p.client.thread import Context
+
+    ctx = Context(
+        "pva", unwrap=False
+    )  # raw Values: str(NT wrapper) carries a timestamp
+
+    def get(pv: str) -> object:
+        return ctx.get(pv, timeout=timeout)["value"]
+
+    return get
+
+
+def probe_fleet(
+    experiment: str,
+    hosts: list[FleetHost],
+    *,
+    timeout: float = 2.0,
+    getter: Callable[[str], object] | None = None,
+) -> FleetProbe:
+    """Read every deployed host's ``version`` + ``heartbeat`` instance PVs (read-only).
+
+    *getter* is injectable (tests); the default opens a p4p context.
+    """
+    deployed = [h for h in hosts if h.deployed]
+    result = FleetProbe(
+        experiment=experiment, not_deployed=[h for h in hosts if not h.deployed]
+    )
+    if not deployed:
+        return result
+    get = getter or _p4p_getter([h.ip for h in deployed], timeout)
+    for host in deployed:
+        try:
+            version = str(get(host.instance_pv(experiment, "version")))
+            beats = int(get(host.instance_pv(experiment, "heartbeat")))
+        except Exception as exc:  # noqa: BLE001 — a failed probe is a finding
+            result.probes.append(HostProbe(host=host, error=type(exc).__name__))
+            continue
+        result.probes.append(HostProbe(host=host, version=version, heartbeat=beats))
+    return result
+
+
+def fleet_main(argv: list[str] | None = None) -> int:
+    """``geecs-pva-gateway fleet``: print the probe's lines and its record; exit 0 when any host is up."""
+    parser = argparse.ArgumentParser(
+        prog="geecs-pva-gateway fleet",
+        description="Probe every deployed PVA image gateway's version/heartbeat PVs (read-only).",
+    )
+    parser.add_argument(
+        "--experiment",
+        default=None,
+        help="GEECS experiment (default: config.ini [Experiment])",
+    )
+    parser.add_argument(
+        "--timeout", type=float, default=2.0, help="seconds per PVA get (default 2)"
+    )
+    parser.add_argument(
+        "--config",
+        type=Path,
+        default=None,
+        help="client config.ini (default: the user's)",
+    )
+    args = parser.parse_args(argv)
+    logging.basicConfig(level=logging.WARNING, format="  [WARN] PVA fleet: %(message)s")
+
+    experiment = args.experiment or default_experiment(args.config)
+    if not experiment:
+        print(
+            "no experiment: pass --experiment or set config.ini [Experiment]",
+            file=sys.stderr,
+        )
+        print(f"role={FLEET_ROLE}\tstate=down\tnote=no experiment name")
+        return 2
+    try:
+        hosts = fleet_roster(experiment, config_path=args.config)
+    except Exception as exc:  # noqa: BLE001 — an unreadable roster is a finding
+        print(
+            f"  [DOWN] PVA fleet    roster unreadable from the DB ({type(exc).__name__}: {exc})"
+        )
+        print(f"role={FLEET_ROLE}\tstate=down\tnote=DB roster unreadable")
+        return 1
+    result = probe_fleet(experiment, hosts, timeout=args.timeout)
+    for line in result.lines():
+        print(line)
+    print(result.record())
+    return 0 if result.versions else 1

--- a/GeecsPvaGateway/geecs_pva_gateway/fleet.py
+++ b/GeecsPvaGateway/geecs_pva_gateway/fleet.py
@@ -260,8 +260,10 @@ def _p4p_context(hosts: list[str], timeout: float) -> Iterator[Callable[[str], o
     from p4p.client.thread import Context
 
     conf = {"EPICS_PVA_ADDR_LIST": " ".join(hosts), "EPICS_PVA_AUTO_ADDR_LIST": "NO"}
+    # useenv=False: an exported EPICS_PVA_ADDR_LIST would otherwise merge in
+    # and the probe would search more than the deployed hosts.
     # unwrap=False: raw Values (str(NT wrapper) would carry a timestamp).
-    with Context("pva", conf=conf, useenv=True, unwrap=False) as ctx:
+    with Context("pva", conf=conf, useenv=False, unwrap=False) as ctx:
         yield lambda pv: ctx.get(pv, timeout=timeout)["value"]
 
 

--- a/GeecsPvaGateway/pyproject.toml
+++ b/GeecsPvaGateway/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-pva-gateway"
-version = "0.5.0"
+version = "0.6.0"
 description = "Distributed pvAccess gateway serving GEECS camera images as NTNDArray PVs"
 authors = ["Sam Barber <sbarber@lbl.gov>"]
 readme = "README.md"

--- a/GeecsPvaGateway/tests/test_fleet.py
+++ b/GeecsPvaGateway/tests/test_fleet.py
@@ -184,3 +184,101 @@ def test_generator_needs_an_experiment(tmp_path, capsys):
         == 2
     )
     assert "no experiment" in capsys.readouterr().err
+
+
+# --- the probe (`geecs-pva-gateway fleet`) ------------------------------------
+
+from geecs_pva_gateway import __main__ as cli  # noqa: E402
+from geecs_pva_gateway.fleet import probe_fleet  # noqa: E402
+
+
+def _hosts():
+    return [
+        FleetHost(ip="192.168.6.100", cameras=["UC_A", "UC_B"]),
+        FleetHost(ip="192.168.7.161", cameras=["UC_C"]),
+        FleetHost(ip="192.168.6.66", cameras=["UC_Lone"], deployed=False),
+    ]
+
+
+def _getter(answers: dict[str, object]):
+    def get(pv: str) -> object:
+        if pv in answers:
+            return answers[pv]
+        raise TimeoutError(pv)
+
+    return get
+
+
+def test_probe_lines_and_record_split_findings_from_facts():
+    """OK/DOWN/not-deployed lines; the record carries facts as info= and findings as note=."""
+    answers = {
+        "undulator:pvagateway:192_168_6_100:version": "0.5.0",
+        "undulator:pvagateway:192_168_6_100:heartbeat": 42,
+    }
+    result = probe_fleet("Undulator", _hosts(), getter=_getter(answers))
+    lines = result.lines()
+    assert (
+        lines[0].startswith("  [ OK ] PVA gateway  192.168.6.100")
+        and "0.5.0" in lines[0]
+    )
+    assert (
+        lines[1].startswith("  [DOWN] PVA gateway  192.168.7.161")
+        and "TimeoutError" in lines[1]
+    )
+    assert (
+        lines[2].startswith("  [ -- ] PVA gateway  192.168.6.66")
+        and "not deployed" in lines[2]
+    )
+    rec = dict(kv.split("=", 1) for kv in result.record().split("\t"))
+    assert rec["role"] == "PVA image gateways" and rec["state"] == "ok"
+    assert rec["version"] == "0.5.0 ×1"
+    fields = result.record().split("\t")
+    assert "info=1 of 2 deployed up" in fields and "info=1 not deployed" in fields
+    assert "note=1 unreachable: 192.168.7.161" in fields
+    assert not any(f.startswith("note=MIXED") for f in fields)
+
+
+def test_probe_flags_mixed_versions_and_all_down():
+    answers = {
+        "undulator:pvagateway:192_168_6_100:version": "0.5.0",
+        "undulator:pvagateway:192_168_6_100:heartbeat": 1,
+        "undulator:pvagateway:192_168_7_161:version": "0.4.4",
+        "undulator:pvagateway:192_168_7_161:heartbeat": 2,
+    }
+    result = probe_fleet("Undulator", _hosts(), getter=_getter(answers))
+    assert any("mixed versions" in line for line in result.lines())
+    assert "note=MIXED versions" in result.record().split("\t")
+    assert "version=0.4.4 ×1, 0.5.0 ×1" in result.record().split("\t")
+
+    result = probe_fleet("Undulator", _hosts(), getter=_getter({}))
+    assert "state=down" in result.record().split("\t")
+
+
+def test_fleet_subcommand_dispatch(monkeypatch, capsys, tmp_path):
+    """`geecs-pva-gateway fleet` prints the lines then the record; the serve form is untouched."""
+    from geecs_pva_gateway import fleet
+
+    monkeypatch.setattr(
+        fleet, "fleet_roster", lambda experiment, config_path=None: _hosts()
+    )
+    monkeypatch.setattr(
+        fleet,
+        "_p4p_getter",
+        lambda hosts, timeout: _getter(
+            {
+                "testexp:pvagateway:192_168_6_100:version": "0.5.0",
+                "testexp:pvagateway:192_168_6_100:heartbeat": 7,
+                "testexp:pvagateway:192_168_7_161:version": "0.5.0",
+                "testexp:pvagateway:192_168_7_161:heartbeat": 8,
+            }
+        ),
+    )
+    assert cli.main(["fleet", "--experiment", "testexp", "--timeout", "0.1"]) == 0
+    out = capsys.readouterr().out.splitlines()
+    assert out[-1].startswith("role=PVA image gateways\tstate=ok")
+    assert sum(line.startswith("  [ OK ]") for line in out) == 2
+    assert any(line.startswith("  [ -- ]") for line in out)
+
+    # No experiment anywhere: exit 2 and still a record line for the table.
+    assert cli.main(["fleet", "--config", str(tmp_path / "none.ini")]) == 2
+    assert "note=no experiment name" in capsys.readouterr().out

--- a/GeecsPvaGateway/tests/test_fleet.py
+++ b/GeecsPvaGateway/tests/test_fleet.py
@@ -261,17 +261,16 @@ def test_fleet_subcommand_dispatch(monkeypatch, capsys, tmp_path):
     monkeypatch.setattr(
         fleet, "fleet_roster", lambda experiment, config_path=None: _hosts()
     )
+    from contextlib import nullcontext
+
+    answers = {
+        "testexp:pvagateway:192_168_6_100:version": "0.5.0",
+        "testexp:pvagateway:192_168_6_100:heartbeat": 7,
+        "testexp:pvagateway:192_168_7_161:version": "0.5.0",
+        "testexp:pvagateway:192_168_7_161:heartbeat": 8,
+    }
     monkeypatch.setattr(
-        fleet,
-        "_p4p_getter",
-        lambda hosts, timeout: _getter(
-            {
-                "testexp:pvagateway:192_168_6_100:version": "0.5.0",
-                "testexp:pvagateway:192_168_6_100:heartbeat": 7,
-                "testexp:pvagateway:192_168_7_161:version": "0.5.0",
-                "testexp:pvagateway:192_168_7_161:heartbeat": 8,
-            }
-        ),
+        fleet, "_p4p_context", lambda hosts, timeout: nullcontext(_getter(answers))
     )
     assert cli.main(["fleet", "--experiment", "testexp", "--timeout", "0.1"]) == 0
     out = capsys.readouterr().out.splitlines()

--- a/docs/tutorials/getting_started.md
+++ b/docs/tutorials/getting_started.md
@@ -134,7 +134,7 @@ What each section is for, and who reads it:
 | `[Experiment] rep_rate_hz` | Machine rep rate, for shot-count estimates | Scanner/Console |
 | `[tiled] uri`, `[tiled] api_key` | Tiled data-server access (optional) | GeecsBluesky, Scan Browser |
 | `[epics] ca_addr_list` | EPICS client addressing (optional, gateway clients) | GeecsBluesky and other CA clients |
-| `[pva] addr_list` | The camera servers running a PVA image gateway — the deployed fleet (optional). A DB roster host absent here counts as *not deployed*. It is also the value a client on another subnet/VPN copies into `EPICS_PVA_ADDR_LIST` or the Phoebus settings by hand — nothing applies it to the environment automatically | `scripts/fleet_status.sh` (which exports it for its own probe), the fleet-screen generator |
+| `[pva] addr_list` | The camera servers running a PVA image gateway — the deployed fleet (optional). A DB roster host absent here counts as *not deployed*. It is also the value a client on another subnet/VPN copies into `EPICS_PVA_ADDR_LIST` or the Phoebus settings by hand — nothing applies it to the environment automatically | `geecs-pva-gateway fleet` (the probe `scripts/fleet_status.sh` calls; it searches exactly these hosts), the fleet-screen generator |
 | `[qserver] host` | The queueserver worker machine — scans submit to the RE Manager there. Without this section the Console runs but cannot submit scans. Optional per-address overrides: `control_addr` (`tcp://host:60615`), `info_addr` (`tcp://host:60625`), `doc_addr` (`host:5568`) | GEECS Console (queueserver client) |
 
 Database credentials are **not** stored here: tools follow

--- a/scripts/fleet_status.sh
+++ b/scripts/fleet_status.sh
@@ -39,12 +39,11 @@
 set -u  # deliberately not -e: a failed probe is a *finding*, not an error
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
-CONFIG="$HOME/.config/geecs_python_api/config.ini"
 PORTAL_PORT=8200       # fleet map: GEECS Data Portal
 MCP_PORT=8100          # fleet map: GEECS-MCP HTTP mode
 TCP_TIMEOUT=2          # seconds per port probe / HTTP get
 SSH_TIMEOUT=25         # seconds per host (one ssh call per host)
-PVA_TIMEOUT=2          # seconds per PVA get
+PVA_TIMEOUT=2          # seconds per PVA get (geecs-pva-gateway fleet --timeout)
 FETCH_TIMEOUT=20       # seconds for the local `git fetch origin`
 
 EXPERIMENT=""
@@ -100,24 +99,9 @@ if [ "$WATCH" != "0" ]; then
     done
 fi
 
-ini_get() {  # ini_get SECTION KEY — first match, trimmed
-    awk -F'=' -v s="[$1]" -v k="$2" '
-        $0 == s { insec = 1; next }
-        /^\[/   { insec = 0 }
-        insec && $1 ~ "^[ \t]*"k"[ \t]*$" { gsub(/^[ \t]+|[ \t\r]+$/, "", $2); print $2; exit }
-    ' "$CONFIG" 2>/dev/null
-}
-
-ok()   { printf '  [ OK ] %s\n' "$1"; }
-bad()  { printf '  [DOWN] %s\n' "$1"; }
-warn() { printf '  [WARN] %s\n' "$1"; }
-skip() { printf '  [ -- ] %s\n' "$1"; }
-info() { printf '         %s\n' "$1"; }
-
-# bounded / port_open / mysql_probe live once, in the shared lib — the DB
-# special case (never a bare TCP probe of 3306, #790) with them.
-# shellcheck source=lib/net_probes.sh
-. "$REPO_ROOT/scripts/lib/net_probes.sh"
+# config.ini reader, endpoints (LAB_HOST, TILED_PORT, WORKER_HOST), printers,
+# bounded() and port_open() — shared with lab_status.sh (scripts/lib/lab_env.sh).
+. "$REPO_ROOT/scripts/lib/lab_env.sh"
 
 # Every probe also appends a tab-separated key=value record (with a role=)
 # to REC_FILE; scripts/fleet_table.py renders those as the --summary table.
@@ -133,14 +117,8 @@ if [ "$SUMMARY" -eq 1 ]; then
     exec 3>&1 4>&2 1>"$LOG_FILE" 2>&1
 fi
 
-# --- endpoints from config.ini (never hardcode hosts here) -----------------
-TILED_URI="$(ini_get tiled uri)"
-LAB_HOST="$(printf '%s' "$TILED_URI" | sed -E 's|^[a-z]+://||; s|[:/].*$||')"
-TILED_PORT="$(printf '%s' "$TILED_URI" | sed -nE 's|^[a-z]+://[^:/]+:([0-9]+).*|\1|p')"
-TILED_PORT="${TILED_PORT:-8000}"
-WORKER_HOST="$(ini_get qserver host)"
-if [ -z "$EXPERIMENT" ]; then EXPERIMENT="$(ini_get Experiment expt)"; fi
-if [ -z "$EXPERIMENT" ]; then EXPERIMENT="$(ini_get Experiment exp_name)"; fi
+# Endpoints come from lab_env.sh (config.ini); only the experiment fallback is ours.
+[ -n "$EXPERIMENT" ] || EXPERIMENT="$(config_experiment)"
 
 # Hosts to visit over ssh: the lab server and the worker, deduplicated
 # (today they are one box; the fleet map says which services live where).
@@ -251,93 +229,41 @@ if [ "$NET_UP" -eq 1 ]; then
         ok "GEECS-MCP    ${WORKER_HOST:-$LAB_HOST}:$MCP_PORT  listening (version via ssh below)"
         rec "role=GEECS-MCP	state=ok"
     else
-        skip "GEECS-MCP    ${WORKER_HOST:-$LAB_HOST}:$MCP_PORT  not listening (HTTP mode is 'pending deploy' on the fleet map)"
-        rec "role=GEECS-MCP	state=absent	note=not listening (pending deploy)"
+        warn "GEECS-MCP    ${WORKER_HOST:-$LAB_HOST}:$MCP_PORT  not listening — the fleet map has systemd geecs-mcp on this host (unit down, or the port moved); stage 2 says which"
+        rec "role=GEECS-MCP	state=down	note=not listening"
     fi
 
-    # CA gateway — reuse /lab-status tier 2 (read-only CA gets of heartbeat,
-    # devices_connected, version). Contract: it prints "version=<str>".
+    # CA gateway — /lab-status tier 2 (read-only CA gets). Contract: its
+    # stdout carries one `role=CA gateway<TAB>...` record; the rest is prose.
     if [ -n "$EXPERIMENT" ]; then
         hw="$("$REPO_ROOT/scripts/lab_status.sh" --hardware --experiment "$EXPERIMENT" 2>&1 | sed -n '/Tier 2/,$p')"
+        ca_rec="$(printf '%s\n' "$hw" | grep -m1 '^role=CA gateway')"
         alive="$(printf '%s\n' "$hw" | grep -m1 'gateway alive')"
         if [ -n "$alive" ]; then
             ok "CA gateway   $LAB_HOST:5064  ${alive#*] }"
-            gver="$(printf '%s' "$alive" | sed -nE 's/.*version=([^, ]+).*/\1/p')"
-            gdev="$(printf '%s' "$alive" | sed -nE 's/.*devices_connected=([0-9]+).*/\1/p')"
-            rec "role=CA gateway	state=ok	version=$gver	note=$gdev devices connected"
             printf '%s\n' "$hw" | grep '\[WARN\]' | sed 's/^ *\[WARN\] /  [WARN] CA gateway: /'
         else
-            err="$(printf '%s\n' "$hw" | grep -m1 -E 'unreadable|not installed|no experiment' )"
-            bad "CA gateway   $LAB_HOST:5064  ${err#*] }"
-            rec "role=CA gateway	state=down"
+            # A [DOWN] verdict, else whatever tier 2 died with (a traceback's
+            # last line, an env error) — never an empty finding.
+            err="$(printf '%s\n' "$hw" | grep -m1 -E '\[DOWN\]' | sed 's/^ *\[DOWN\] //')"
+            [ -n "$err" ] || err="tier 2 gave no verdict: $(printf '%s\n' "$hw" | grep -v '^role=' | tail -1)"
+            bad "CA gateway   $LAB_HOST:5064  $err"
         fi
+        rec "${ca_rec:-role=CA gateway	state=down	note=$(printf '%s' "$err" | cut -c1-80 | tr '\t' ' ')}"
     else
         skip "CA gateway   no experiment name (config.ini [Experiment] expt, or --experiment NAME)"
     fi
 
-    # PVA image fleet — one gateway per camera server. Roster = the DB
-    # (endpoints hosting the experiment's image devices); deployed = the
-    # client config.ini [pva] addr_list (geecs_pva_gateway.fleet). A roster
-    # host absent from that list is NOT DEPLOYED — informational, not DOWN.
-    # Read-only gets.
+    # PVA image fleet — `geecs-pva-gateway fleet`: the package owns the roster
+    # (DB + config.ini [pva] addr_list), the instance PV names, and the
+    # probe; its stdout is prose plus one `role=PVA image gateways` record.
     if [ -z "$EXPERIMENT" ]; then
         skip "PVA fleet    no experiment name (config.ini [Experiment] expt, or --experiment NAME)"
     elif poetry -C "$REPO_ROOT/GeecsPvaGateway" env info --path >/dev/null 2>&1; then
-        EXPERIMENT="$EXPERIMENT" PVA_TIMEOUT="$PVA_TIMEOUT" REC_FILE="$REC_FILE" bounded 90 poetry -C "$REPO_ROOT/GeecsPvaGateway" run python - <<'PY'
-import logging
-import os
-
-logging.basicConfig(level=logging.WARNING, format="  [WARN] PVA fleet: %(message)s")
-from geecs_pva_gateway.fleet import fleet_roster  # noqa: E402
-
-experiment = os.environ["EXPERIMENT"]
-timeout = float(os.environ["PVA_TIMEOUT"])
-try:
-    hosts = fleet_roster(experiment)
-except Exception as exc:  # noqa: BLE001 — an unreadable roster is a finding
-    print(f"  [DOWN] PVA fleet    roster unreadable from the DB ({type(exc).__name__}: {exc})")
-    with open(os.environ["REC_FILE"], "a") as fh:
-        fh.write("role=PVA image gateways\tstate=down\tnote=DB roster unreadable\n")
-    raise SystemExit(0)
-deployed = [h for h in hosts if h.deployed]
-not_deployed = [h for h in hosts if not h.deployed]
-# Unicast search to each camera server: UDP broadcast does not cross a VPN.
-os.environ["EPICS_PVA_ADDR_LIST"] = " ".join(h.ip for h in deployed)
-os.environ["EPICS_PVA_AUTO_ADDR_LIST"] = "NO"
-from p4p.client.thread import Context  # noqa: E402
-
-versions = {}
-down = []
-with Context("pva", unwrap=False) as ctx:  # raw Values: str(NT wrapper) carries a timestamp
-    for host in deployed:
-        try:
-            ver = str(ctx.get(host.instance_pv(experiment, "version"), timeout=timeout)["value"])
-            beats = int(ctx.get(host.instance_pv(experiment, "heartbeat"), timeout=timeout)["value"])
-        except Exception as exc:  # noqa: BLE001 — a failed probe is a finding
-            print(f"  [DOWN] PVA gateway  {host.ip:<15}  ({type(exc).__name__}; {len(host.cameras)} cameras)")
-            down.append(host.ip)
-            continue
-        versions.setdefault(ver, []).append(host.ip)
-        print(f"  [ OK ] PVA gateway  {host.ip:<15}  geecs-pva-gateway {ver}  heartbeat={beats}  {len(host.cameras)} cameras")
-for host in not_deployed:
-    print(f"  [ -- ] PVA gateway  {host.ip:<15}  not deployed ({len(host.cameras)} cameras in the DB: {', '.join(host.cameras)}) — add to config.ini [pva] addr_list once installed")
-if len(versions) > 1:
-    print("  [WARN] PVA fleet runs mixed versions — a rollout is incomplete or a box missed its pull-on-restart:")
-    for ver, hs in sorted(versions.items()):
-        print(f"         {ver}: {', '.join(hs)}")
-n_ok = sum(len(hs) for hs in versions.values())
-ver_txt = ", ".join(f"{v} ×{len(hs)}" for v, hs in sorted(versions.items())) or "?"
-note = f"{n_ok} of {len(deployed)} deployed up"
-if down:
-    note += f", {len(down)} unreachable: {' '.join(down)}"
-if not_deployed:
-    note += f", {len(not_deployed)} not deployed"
-if len(versions) > 1:
-    note += "|MIXED versions"
-state = "ok" if n_ok else "down"
-with open(os.environ["REC_FILE"], "a") as fh:
-    fh.write(f"role=PVA image gateways\tstate={state}\truns=NSSM\tcheckout=share clone\tversion={ver_txt}\tnote={note}\n")
-PY
+        pva_out="$(bounded 90 poetry -C "$REPO_ROOT/GeecsPvaGateway" run geecs-pva-gateway fleet --experiment "$EXPERIMENT" --timeout "$PVA_TIMEOUT" 2>&1)"
+        printf '%s\n' "$pva_out" | grep -v '^role=' | grep -v '^$'
+        pva_rec="$(printf '%s\n' "$pva_out" | grep -m1 '^role=PVA image gateways')"
+        rec "${pva_rec:-role=PVA image gateways	state=down	note=no record from geecs-pva-gateway fleet}"
     else
         skip "PVA fleet    GeecsPvaGateway poetry env not installed (needs p4p; see /env-doctor)"
     fi
@@ -367,6 +293,7 @@ role_for_unit() { case "$1" in
     *) echo "$1";; esac; }
 FLEET_PORTS="5064 8000 8200 8100 60615 5568"
 SEEN=" "
+SEEN_UNITS=" "
 reflog_ts() {  # unix time HEAD last moved (checkout/pull/reset), from the reflog
     local f; f="$(git -C "$1" rev-parse --git-path logs/HEAD 2>/dev/null)"
     [ -f "$f" ] && tail -1 "$f" | sed -E "s/^[0-9a-f]+ [0-9a-f]+ .*> ([0-9]+) [-+][0-9]{4}\t.*/\1/"
@@ -521,6 +448,7 @@ for scope in "" "--user"; do
         wd="$(systemctl $scope show -p WorkingDirectory --value "$u")"
         label="$u"; [ -n "$scope" ] && label="$u (user unit)"
         [ "$pid" != "0" ] && SEEN="$SEEN$pid "
+        SEEN_UNITS="$SEEN_UNITS$u "
         emit "$(role_for_unit "$u")" "$label" "systemd" "$active" "$pid" "$wd" ""
     done
 done
@@ -531,6 +459,9 @@ for port in $FLEET_PORTS; do
     case "$SEEN" in *" $pid "*) continue;; esac
     SEEN="$SEEN$pid "
     unit="$(sed -nE "s#.*/([^/]+\.service)\$#\1#p" "/proc/$pid/cgroup" 2>/dev/null | head -1)"
+    # A child of a unit already listed (the RE Manager forked by the
+    # geecs-qserver launcher) is that unit, not a second process for the role.
+    case "$SEEN_UNITS" in *" $unit "*) continue;; esac
     if [ -n "$unit" ]; then managed="systemd ($unit)"; else managed="UNMANAGED"; fi
     emit "$(role_for_port "$port")" "$(role_for_port "$port") :$port" "$managed" "running pid $pid" "$pid" "" ""
 done

--- a/scripts/fleet_status.sh
+++ b/scripts/fleet_status.sh
@@ -238,18 +238,21 @@ if [ "$NET_UP" -eq 1 ]; then
     if [ -n "$EXPERIMENT" ]; then
         hw="$("$REPO_ROOT/scripts/lab_status.sh" --hardware --experiment "$EXPERIMENT" 2>&1 | sed -n '/Tier 2/,$p')"
         ca_rec="$(printf '%s\n' "$hw" | grep -m1 '^role=CA gateway')"
-        alive="$(printf '%s\n' "$hw" | grep -m1 'gateway alive')"
-        if [ -n "$alive" ]; then
-            ok "CA gateway   $LAB_HOST:5064  ${alive#*] }"
-            printf '%s\n' "$hw" | grep '\[WARN\]' | sed 's/^ *\[WARN\] /  [WARN] CA gateway: /'
-        else
-            # A [DOWN] verdict, else whatever tier 2 died with (a traceback's
-            # last line, an env error) — never an empty finding.
-            err="$(printf '%s\n' "$hw" | grep -m1 -E '\[DOWN\]' | sed 's/^ *\[DOWN\] //')"
-            [ -n "$err" ] || err="tier 2 gave no verdict: $(printf '%s\n' "$hw" | grep -v '^role=' | tail -1)"
+        rec_field() { printf '%s\n' "$ca_rec" | tr '\t' '\n' | sed -n "s/^$1=//p" | paste -sd';' -; }
+        if [ -z "$ca_rec" ]; then
+            # Tier 2 died before its verdict (a traceback, an env error):
+            # name its last line — never an empty finding — and record it.
+            err="tier 2 gave no verdict: $(printf '%s\n' "$hw" | tail -1)"
             bad "CA gateway   $LAB_HOST:5064  $err"
+            rec "role=CA gateway	state=down	note=$(printf '%s' "$err" | cut -c1-80)"
+        elif [ "$(rec_field state)" = "ok" ]; then
+            ok "CA gateway   $LAB_HOST:5064  version=$(rec_field version)  $(rec_field info)"
+            printf '%s\n' "$hw" | grep '\[WARN\]' | sed 's/^ *\[WARN\] /  [WARN] CA gateway: /'
+            rec "$ca_rec"
+        else
+            bad "CA gateway   $LAB_HOST:5064  $(rec_field note)"
+            rec "$ca_rec"
         fi
-        rec "${ca_rec:-role=CA gateway	state=down	note=$(printf '%s' "$err" | cut -c1-80 | tr '\t' ' ')}"
     else
         skip "CA gateway   no experiment name (config.ini [Experiment] expt, or --experiment NAME)"
     fi
@@ -459,9 +462,13 @@ for port in $FLEET_PORTS; do
     case "$SEEN" in *" $pid "*) continue;; esac
     SEEN="$SEEN$pid "
     unit="$(sed -nE "s#.*/([^/]+\.service)\$#\1#p" "/proc/$pid/cgroup" 2>/dev/null | head -1)"
-    # A child of a unit already listed (the RE Manager forked by the
-    # geecs-qserver launcher) is that unit, not a second process for the role.
-    case "$SEEN_UNITS" in *" $unit "*) continue;; esac
+    # A same-role child of a unit already listed (the RE Manager forked by
+    # the geecs-qserver launcher) is that unit, not a second process for the
+    # role. A different role in the same cgroup (the doc proxy the same
+    # launcher forks) is still its own row.
+    if [ -n "$unit" ] && [ "$(role_for_port "$port")" = "$(role_for_unit "$unit")" ]; then
+        case "$SEEN_UNITS" in *" $unit "*) continue;; esac
+    fi
     if [ -n "$unit" ]; then managed="systemd ($unit)"; else managed="UNMANAGED"; fi
     emit "$(role_for_port "$port")" "$(role_for_port "$port") :$port" "$managed" "running pid $pid" "$pid" "" ""
 done

--- a/scripts/fleet_status.sh
+++ b/scripts/fleet_status.sh
@@ -292,7 +292,8 @@ role_for_port() { case "$1" in
     60615) echo "Queueserver RE Manager";; 5568) echo "Bluesky doc proxy";; *) echo "port $1";; esac; }
 role_for_unit() { case "$1" in
     geecs-ca-gateway*) echo "CA gateway";; tiled*) echo "Tiled";; geecs-data-portal*) echo "Data Portal";;
-    geecs-mcp*) echo "GEECS-MCP";; geecs-qserver*) echo "Queueserver RE Manager";; geecs-capture*) echo "Capture daemon";;
+    geecs-mcp*) echo "GEECS-MCP";; geecs-qserver-ready*) echo "Queueserver readiness";;
+    geecs-qserver*) echo "Queueserver RE Manager";; geecs-capture*) echo "Capture daemon";;
     *) echo "$1";; esac; }
 FLEET_PORTS="5064 8000 8200 8100 60615 5568"
 SEEN=" "

--- a/scripts/fleet_table.py
+++ b/scripts/fleet_table.py
@@ -29,14 +29,17 @@ ROLE_ORDER = [
 HEADERS = ["", "Service", "Runs as", "Checkout", "Version", "Notes"]
 
 
-def _add_note(rec: dict[str, str], text: str) -> None:
-    rec["notes"] = (rec.get("notes", "") + "|" + text).strip("|")
+def _add_note(rec: dict[str, str], text: str, key: str = "notes") -> None:
+    rec[key] = (rec.get(key, "") + "|" + text).strip("|")
 
 
 def parse(lines: list[str]) -> dict[str, dict[str, str]]:
     """Merge records by role.
 
     Stage-1/3 records (no ``svc=``) describe the role and merge first-wins.
+    ``note=`` values are findings (they mark the row ``!``); ``info=`` values
+    are facts worth showing that need no attention (device counts, a baked
+    venv, a distance behind master that is only unmerged docs).
     Stage-2 records (``svc=``) each describe ONE process; a role can have
     several (a loaded-but-dead unit plus the hand-started process that
     really owns the port). The row is the live one; the others are named
@@ -53,7 +56,10 @@ def parse(lines: list[str]) -> dict[str, dict[str, str]]:
         for part in line.split("\t"):
             if "=" in part:
                 k, v = part.split("=", 1)
-                kv[k] = v
+                if k in ("note", "info") and kv.get(k):
+                    kv[k] = kv[k] + "|" + v  # a record may carry several
+                else:
+                    kv[k] = v
         role = kv.get("role")
         if not role:
             continue
@@ -67,6 +73,8 @@ def parse(lines: list[str]) -> dict[str, dict[str, str]]:
         for k, v in kv.items():
             if k == "note":
                 _add_note(rec, v)
+            elif k == "info":
+                _add_note(rec, v, "infos")
             elif v and not rec.get(k):
                 rec[k] = v
     merged: dict[str, dict[str, str]] = {}
@@ -83,6 +91,8 @@ def parse(lines: list[str]) -> dict[str, dict[str, str]]:
             for k, v in chosen.items():
                 if k == "note":
                     _add_note(rec, v)
+                elif k == "info":
+                    _add_note(rec, v, "infos")
                 elif k == "state":
                     # The service's own verdict (stage 1) stays the verdict;
                     # the process state is kept beside it for the glyph.
@@ -153,12 +163,14 @@ def version(rec: dict[str, str]) -> str:
 
 
 def notes(rec: dict[str, str]) -> list[str]:
-    """Everything that makes this row need attention, short form."""
+    """Everything that makes this row need attention, short form.
+
+    Facts that need no action (a baked venv, a clone behind master, device
+    counts) are :func:`infos`; they never mark a row ``!``.
+    """
     out: list[str] = []
     if rec.get("managed") == "UNMANAGED":
         out.append("no systemd unit")
-    if rec.get("baked"):
-        out.append("baked venv")
     if rec.get("worktree_of"):
         out.append(f"WORKTREE of {rec['worktree_of']} (not a clone)")
     if rec.get("disk"):
@@ -177,7 +189,9 @@ def notes(rec: dict[str, str]) -> list[str]:
             if "baked" not in rec.get("stale", "")
             else "reinstall pending"
         )
-    if rec.get("master_rel") and rec["master_rel"] != "= origin/master":
+    if rec.get("master_rel") and " ahead" in rec["master_rel"]:
+        # Ahead of master = running unmerged code: a fact to act on. Behind
+        # only = merges the host has not pulled; informational (see infos).
         out.append(rec["master_rel"].replace(" origin/master", " master"))
     if rec.get("disk_master_rel"):
         out.append(
@@ -188,6 +202,19 @@ def notes(rec: dict[str, str]) -> list[str]:
         out.append(f"unit {proc}")
     if rec.get("notes"):
         out.extend(n for n in rec["notes"].split("|") if n)
+    return out
+
+
+def infos(rec: dict[str, str]) -> list[str]:
+    """Facts shown in the Notes column that do not mark the row ``!``."""
+    out: list[str] = []
+    if rec.get("baked"):
+        out.append("baked venv")
+    rel = rec.get("master_rel", "")
+    if rel and rel != "= origin/master" and " ahead" not in rel:
+        out.append(rel.replace(" origin/master", " master"))
+    if rec.get("infos"):
+        out.extend(n for n in rec["infos"].split("|") if n)
     return out
 
 
@@ -224,7 +251,7 @@ def render(merged: dict[str, dict[str, str]], width: int) -> str:
                 runs_as(rec),
                 checkout(rec),
                 version(rec),
-                "; ".join(notes(rec)) or "—",
+                "; ".join(notes(rec) + infos(rec)) or "—",
             ]
         )
     # Column widths: fixed-ish for the first five, the notes column absorbs the rest.

--- a/scripts/fleet_table.py
+++ b/scripts/fleet_table.py
@@ -21,6 +21,7 @@ ROLE_ORDER = [
     "Tiled",
     "Data Portal",
     "Queueserver RE Manager",
+    "Queueserver readiness",
     "Bluesky doc proxy",
     "Capture daemon",
     "GEECS-MCP",
@@ -156,7 +157,12 @@ def version(rec: dict[str, str]) -> str:
         pkg
         and pkg not in ("tiled",)
         and rec.get("role")
-        in ("Capture daemon", "Queueserver RE Manager", "Bluesky doc proxy")
+        in (
+            "Capture daemon",
+            "Queueserver RE Manager",
+            "Queueserver readiness",
+            "Bluesky doc proxy",
+        )
     ):
         return f"{pkg} {ver}"
     return ver

--- a/scripts/lab_status.sh
+++ b/scripts/lab_status.sh
@@ -20,11 +20,8 @@
 # docs/platform/fleet_map.md, the MySQL admonition.
 set -u  # deliberately not -e: a failed probe is a *finding*, not an error
 
-CONFIG="$HOME/.config/geecs_python_api/config.ini"
-TCP_TIMEOUT=2   # seconds per port probe (read by the shared probes)
-# shellcheck source=lib/net_probes.sh
-. "$(cd "$(dirname "$0")" && pwd)/lib/net_probes.sh"   # bounded / port_open / mysql_probe
 CA_TIMEOUT=3    # seconds per CA read (tier 2)
+TCP_TIMEOUT=2   # seconds per port probe (lab_env.sh reads it)
 
 HARDWARE=0
 EXPERIMENT=""
@@ -37,37 +34,10 @@ while [ $# -gt 0 ]; do
     shift
 done
 
-ini_get() {  # ini_get SECTION KEY — first match, trimmed
-    awk -F'=' -v s="[$1]" -v k="$2" '
-        $0 == s { insec = 1; next }
-        /^\[/   { insec = 0 }
-        insec && $1 ~ "^[ \t]*"k"[ \t]*$" { gsub(/^[ \t]+|[ \t\r]+$/, "", $2); print $2; exit }
-    ' "$CONFIG" 2>/dev/null
-}
-
-# --- resolve endpoints from the shared config (one source of truth) --------
-TILED_URI="$(ini_get tiled uri)"
-LAB_HOST=""
-TILED_PORT="8000"
-if [ -n "$TILED_URI" ]; then
-    LAB_HOST="$(printf '%s' "$TILED_URI" | sed -E 's|^[a-z]+://||; s|[:/].*$||')"
-    p="$(printf '%s' "$TILED_URI" | sed -nE 's|^[a-z]+://[^:/]+:([0-9]+).*|\1|p')"
-    if [ -n "$p" ]; then TILED_PORT="$p"; fi
-fi
-# The Tiled server and CA gateway share one box (see GeecsCAGateway/DEPLOYMENT.md
-# "one box" section) — derive both from tiled uri. The DB host is
-# Configurations.INI's [Database] ipaddress when the probe can read it (the
-# server the real clients use); the Tiled host is only its fallback.
-DB_PORT=3306
-CA_PORT=5064
-DATA_ROOT="$(ini_get Paths GEECS_DATA_LOCAL_BASE_PATH)"
-if [ -z "$EXPERIMENT" ]; then EXPERIMENT="$(ini_get Experiment expt)"; fi
-if [ -z "$EXPERIMENT" ]; then EXPERIMENT="$(ini_get Experiment exp_name)"; fi
-
-ok()   { printf '  [ OK ] %s\n' "$1"; }
-bad()  { printf '  [DOWN] %s\n' "$1"; }
-warn() { printf '  [WARN] %s\n' "$1"; }
-skip() { printf '  [ -- ] %s\n' "$1"; }
+# config.ini reader, endpoints (LAB_HOST, TILED_PORT, DATA_ROOT, DB_PORT,
+# CA_PORT), printers and the bounded port probe — shared with fleet_status.sh.
+. "$(cd "$(dirname "$0")" && pwd)/lib/lab_env.sh"
+[ -n "$EXPERIMENT" ] || EXPERIMENT="$(config_experiment)"
 
 echo "== Tier 1: lab network (bounded, read-nothing) =="
 if [ ! -f "$CONFIG" ]; then
@@ -139,10 +109,12 @@ REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 BLUESKY_DIR="$REPO_ROOT/GeecsBluesky"
 if [ -z "$EXPERIMENT" ]; then
     bad "no experiment name (pass --experiment NAME); cannot build gateway PV names"
+    echo "role=CA gateway	state=down	note=no experiment name"
     exit 1
 fi
 if ! poetry -C "$BLUESKY_DIR" env info --path >/dev/null 2>&1; then
     bad "GeecsBluesky poetry env not installed — tier 2 needs its aioca (see /env-doctor)"
+    echo "role=CA gateway	state=down	note=GeecsBluesky env not installed"
     exit 1
 fi
 EXPERIMENT="$EXPERIMENT" CA_TIMEOUT="$CA_TIMEOUT" poetry -C "$BLUESKY_DIR" run python - <<'PY'
@@ -172,11 +144,16 @@ async def main():
     except Exception as exc:  # noqa: BLE001 — a failed probe is a finding
         print(f"  [DOWN] gateway PVs unreadable ({type(exc).__name__}: {exc})")
         print("         network may be up while the gateway service is not")
+        print(f"role=CA gateway\tstate=down\tnote=PVs unreadable ({type(exc).__name__})")
         raise SystemExit(1)
     print(f"  [ OK ] gateway alive: heartbeat={int(heartbeat)}, "
           f"devices_connected={int(connected)}, version={version}")
     if int(connected) == 0:
         print("  [WARN] zero devices connected — GEECS side likely down")
+    # The machine-readable form of the verdict, for fleet_status.sh (a stated
+    # contract: one tab-separated key=value record, same shape as its own).
+    note = "\tnote=zero devices connected" if int(connected) == 0 else ""
+    print(f"role=CA gateway\tstate=ok\tversion={version}\tinfo={int(connected)} devices connected{note}")
 
 
 asyncio.run(main())

--- a/scripts/lab_status.sh
+++ b/scripts/lab_status.sh
@@ -1,8 +1,10 @@
 #!/usr/bin/env bash
 # lab_status.sh — bounded probes of lab-network and hardware reachability.
 #
-# This script owns the canonical host/port/timeout facts (the /lab-status
-# skill points here; do not restate them in prose). Every probe is bounded
+# The canonical host/port/timeout facts live in scripts/lib/lab_env.sh (the
+# config.ini reader + endpoints this script and fleet_status.sh share; the
+# /lab-status skill points there — do not restate them in prose). Every
+# probe is bounded
 # to seconds — the point is to replace the 75-second GeecsDb hang and the
 # blind "is the trigger even firing?" scan attempt with one cheap command.
 #

--- a/scripts/lib/lab_env.sh
+++ b/scripts/lib/lab_env.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# lab_env.sh — the plumbing scripts/lab_status.sh and scripts/fleet_status.sh
+# share: the client config.ini reader, the endpoints derived from it, the
+# line printers, and (via net_probes.sh) the bounded probes. Sourced, never
+# executed.
+#
+#   . "$(dirname "$0")/lib/lab_env.sh"
+#
+# Facility values come from ~/.config/geecs_python_api/config.ini (the one
+# client contract); nothing lab-specific lives here beyond port numbers that
+# the fleet map (docs/platform/fleet_map.md) treats as constants.
+
+CONFIG="${CONFIG:-$HOME/.config/geecs_python_api/config.ini}"
+TCP_TIMEOUT="${TCP_TIMEOUT:-2}"   # seconds per port probe / HTTP get (net_probes.sh reads it)
+
+ini_get() {  # ini_get SECTION KEY — first match, trimmed
+    awk -F'=' -v s="[$1]" -v k="$2" '
+        $0 == s { insec = 1; next }
+        /^\[/   { insec = 0 }
+        insec && $1 ~ "^[ \t]*"k"[ \t]*$" { gsub(/^[ \t]+|[ \t\r]+$/, "", $2); print $2; exit }
+    ' "$CONFIG" 2>/dev/null
+}
+
+# --- endpoints from config.ini (never hardcode hosts in a script) ---------
+# The DB server, Tiled server, and CA gateway share one box (GeecsCAGateway/
+# DEPLOYMENT.md "one box") — the lab server host is derived from [tiled] uri.
+TILED_URI="$(ini_get tiled uri)"
+LAB_HOST="$(printf '%s' "$TILED_URI" | sed -E 's|^[a-z]+://||; s|[:/].*$||')"
+TILED_PORT="$(printf '%s' "$TILED_URI" | sed -nE 's|^[a-z]+://[^:/]+:([0-9]+).*|\1|p')"
+TILED_PORT="${TILED_PORT:-8000}"
+WORKER_HOST="$(ini_get qserver host)"          # the queueserver worker ([qserver] host)
+DATA_ROOT="$(ini_get Paths GEECS_DATA_LOCAL_BASE_PATH)"
+DB_PORT=3306
+CA_PORT=5064
+
+config_experiment() {  # [Experiment] expt, else the legacy exp_name key
+    local e; e="$(ini_get Experiment expt)"
+    [ -n "$e" ] || e="$(ini_get Experiment exp_name)"
+    printf '%s' "$e"
+}
+
+ok()   { printf '  [ OK ] %s\n' "$1"; }
+bad()  { printf '  [DOWN] %s\n' "$1"; }
+warn() { printf '  [WARN] %s\n' "$1"; }
+skip() { printf '  [ -- ] %s\n' "$1"; }
+info() { printf '         %s\n' "$1"; }
+
+# bounded / port_open / mysql_probe — the reachability probes (port_open
+# refuses the MySQL port; the DB is probed only by a completed handshake).
+# shellcheck source=net_probes.sh
+. "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/net_probes.sh"

--- a/scripts/lib/lab_env.sh
+++ b/scripts/lib/lab_env.sh
@@ -10,7 +10,9 @@
 # client contract); nothing lab-specific lives here beyond port numbers that
 # the fleet map (docs/platform/fleet_map.md) treats as constants.
 
-CONFIG="${CONFIG:-$HOME/.config/geecs_python_api/config.ini}"
+# GEECS_CONFIG_INI overrides the path (tests); never a bare CONFIG, which
+# build tooling commonly exports.
+CONFIG="${GEECS_CONFIG_INI:-$HOME/.config/geecs_python_api/config.ini}"
 TCP_TIMEOUT="${TCP_TIMEOUT:-2}"   # seconds per port probe / HTTP get (net_probes.sh reads it)
 
 ini_get() {  # ini_get SECTION KEY — first match, trimmed

--- a/tests/test_fleet_table.py
+++ b/tests/test_fleet_table.py
@@ -1,0 +1,67 @@
+"""Pin ``scripts/fleet_table.py``'s glyph rule: findings mark ``!``, facts do not."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+spec = importlib.util.spec_from_file_location(
+    "fleet_table", REPO_ROOT / "scripts" / "fleet_table.py"
+)
+assert spec and spec.loader
+fleet_table = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(fleet_table)
+
+
+def _merged(*lines: str) -> dict[str, dict[str, str]]:
+    return fleet_table.parse([line + "\n" for line in lines])
+
+
+def test_info_fields_show_but_do_not_mark_attention() -> None:
+    m = _merged("role=CA gateway\tstate=ok\tversion=0.20.2\tinfo=99 devices connected")
+    rec = m["CA gateway"]
+    assert fleet_table.glyph(rec) == "✓"
+    assert fleet_table.notes(rec) == []
+    assert fleet_table.infos(rec) == ["99 devices connected"]
+
+
+def test_note_fields_mark_attention() -> None:
+    m = _merged(
+        "role=PVA image gateways\tstate=ok\tversion=0.5.0 ×8\tinfo=8 of 9 deployed up\tinfo=2 not deployed\tnote=1 unreachable: 192.168.8.201"
+    )
+    rec = m["PVA image gateways"]
+    assert fleet_table.glyph(rec) == "!"
+    assert fleet_table.notes(rec) == ["1 unreachable: 192.168.8.201"]
+    assert fleet_table.infos(rec) == ["8 of 9 deployed up", "2 not deployed"]
+
+
+def test_baked_venv_and_behind_master_are_facts_ahead_is_a_finding() -> None:
+    base = "role=GEECS-MCP\tsvc=geecs-mcp.service\tmanaged=systemd\tstate=active/running\tsha=13a2a42c\tbaked=~/geecs-mcp-venv\tpkg=geecs-mcp\tpyproject=0.8.6\tinstalled=0.8.6"
+    m = _merged(
+        base, "role=GEECS-MCP\tfor_sha=13a2a42c\tmaster_rel=9 behind origin/master"
+    )
+    rec = m["GEECS-MCP"]
+    assert fleet_table.glyph(rec) == "✓"
+    assert fleet_table.infos(rec) == ["baked venv", "9 behind master"]
+
+    m = _merged(
+        base,
+        "role=GEECS-MCP\tfor_sha=13a2a42c\tmaster_rel=2 ahead, 0 behind origin/master",
+    )
+    assert fleet_table.glyph(m["GEECS-MCP"]) == "!"
+    assert "2 ahead, 0 behind master" in fleet_table.notes(m["GEECS-MCP"])
+
+
+def test_mcp_not_listening_is_down_not_absent() -> None:
+    m = _merged("role=GEECS-MCP\tstate=down\tnote=not listening")
+    assert fleet_table.glyph(m["GEECS-MCP"]) == "✗"
+
+
+def test_real_findings_still_mark_attention() -> None:
+    m = _merged(
+        "role=Data Portal\tsvc=geecs-data-portal.service\tmanaged=systemd\tstate=active/running\tpkg=geecs-data-portal\tpyproject=0.20.2\tinstalled=0.20.1"
+    )
+    rec = m["Data Portal"]
+    assert fleet_table.glyph(rec) == "!"
+    assert fleet_table.notes(rec) == ["venv 0.20.1 ≠ pyproject 0.20.2"]

--- a/tests/test_fleet_table.py
+++ b/tests/test_fleet_table.py
@@ -53,6 +53,18 @@ def test_baked_venv_and_behind_master_are_facts_ahead_is_a_finding() -> None:
     assert "2 ahead, 0 behind master" in fleet_table.notes(m["GEECS-MCP"])
 
 
+def test_readiness_oneshot_is_its_own_clean_row() -> None:
+    """The geecs-qserver-ready oneshot (active/exited) is not a second RE Manager process."""
+    m = _merged(
+        "role=Queueserver RE Manager\tsvc=geecs-qserver.service\tmanaged=systemd\tstate=active/running\tpkg=geecs-bluesky\tpyproject=0.76.0\tinstalled=0.76.0",
+        "role=Queueserver readiness\tsvc=geecs-qserver-ready.service\tmanaged=systemd\tstate=active/exited\tpkg=geecs-bluesky\tpyproject=0.76.0",
+    )
+    assert fleet_table.glyph(m["Queueserver RE Manager"]) == "✓"
+    assert fleet_table.notes(m["Queueserver RE Manager"]) == []
+    assert fleet_table.glyph(m["Queueserver readiness"]) == "✓"
+    assert fleet_table.version(m["Queueserver readiness"]) == "geecs-bluesky 0.76.0"
+
+
 def test_mcp_not_listening_is_down_not_absent() -> None:
     m = _merged("role=GEECS-MCP\tstate=down\tnote=not listening")
     assert fleet_table.glyph(m["GEECS-MCP"]) == "✗"

--- a/tests/test_lab_env_sh.py
+++ b/tests/test_lab_env_sh.py
@@ -1,0 +1,66 @@
+"""Pin ``scripts/lib/lab_env.sh``: the config.ini reader both fleet scripts share."""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+LIB = REPO_ROOT / "scripts" / "lib" / "lab_env.sh"
+
+pytestmark = pytest.mark.skipif(shutil.which("bash") is None, reason="needs bash")
+
+
+def _run(config: Path, snippet: str) -> str:
+    script = f'CONFIG="{config}"; . "{LIB}"; {snippet}'
+    return subprocess.run(
+        ["bash", "-c", script], capture_output=True, text=True, check=True
+    ).stdout
+
+
+def test_endpoints_and_experiment_derive_from_config(tmp_path: Path) -> None:
+    cfg = tmp_path / "config.ini"
+    cfg.write_text(
+        "[Experiment]\nexpt = Undulator\n\n[tiled]\nuri = http://192.168.6.14:8000\n"
+        "[qserver]\nhost = 192.168.6.14\n[Paths]\nGEECS_DATA_LOCAL_BASE_PATH = /Volumes/hdna2/data/\n"
+    )
+    out = _run(
+        cfg, 'echo "$LAB_HOST $TILED_PORT $WORKER_HOST $DATA_ROOT $(config_experiment)"'
+    )
+    assert out.split() == [
+        "192.168.6.14",
+        "8000",
+        "192.168.6.14",
+        "/Volumes/hdna2/data/",
+        "Undulator",
+    ]
+
+
+def test_legacy_exp_name_and_defaults(tmp_path: Path) -> None:
+    cfg = tmp_path / "config.ini"
+    cfg.write_text("[Experiment]\nexp_name = Thomson\n[tiled]\nuri = http://lab\n")
+    out = _run(cfg, 'echo "$LAB_HOST $TILED_PORT $(config_experiment)"')
+    assert out.split() == ["lab", "8000", "Thomson"]
+
+
+def test_missing_config_is_empty_not_an_error(tmp_path: Path) -> None:
+    out = _run(tmp_path / "absent.ini", 'echo "[$LAB_HOST][$(config_experiment)]"')
+    assert out.strip() == "[][]"
+
+
+def test_printers_and_bounded(tmp_path: Path) -> None:
+    out = _run(
+        tmp_path / "absent.ini",
+        "ok a; bad b; warn c; skip d; info e; bounded 5 true && echo bounded-ok",
+    )
+    assert out.splitlines() == [
+        "  [ OK ] a",
+        "  [DOWN] b",
+        "  [WARN] c",
+        "  [ -- ] d",
+        "         e",
+        "bounded-ok",
+    ]

--- a/tests/test_lab_env_sh.py
+++ b/tests/test_lab_env_sh.py
@@ -15,7 +15,7 @@ pytestmark = pytest.mark.skipif(shutil.which("bash") is None, reason="needs bash
 
 
 def _run(config: Path, snippet: str) -> str:
-    script = f'CONFIG="{config}"; . "{LIB}"; {snippet}'
+    script = f'GEECS_CONFIG_INI="{config}"; . "{LIB}"; {snippet}'
     return subprocess.run(
         ["bash", "-c", script], capture_output=True, text=True, check=True
     ).stdout


### PR DESCRIPTION
## What

Site-profile arc **Phase 4**, the `/fleet-status` cosmetics plus the two items waived in the #776 review (6: shared plumbing + a stated contract between the scripts; 7: the PVA probe belongs to GeecsPvaGateway). One PR because every concern is a change to how `scripts/fleet_status.sh` composes its picture, and they were live-verified together; per-concern breakdown below so any one is cheap to veto.

| # | Concern | Files | Δ |
|---|---|---|---|
| 1 | **`geecs-pva-gateway fleet --experiment NAME`** — the read-only PVA probe in the package (`fleet.probe_fleet` / `fleet_main`, injectable getter for tests). Prints the `[ OK ]`/`[DOWN]`/`[ -- ] not deployed`/`[WARN] mixed` lines plus one `role=PVA image gateways` record; `fleet_status.sh` relays them instead of re-deriving the roster and PV names in a heredoc. The serve form is untouched (`launch.bat` on every camera server). Minor bump 0.5.0 → 0.6.0 | `fleet.py`, `__main__.py`, `test_fleet.py`, `CLAUDE.md`, `DEPLOYMENT.md`, `CHANGELOG.md` | ~+250 |
| 2 | **`scripts/lib/lab_env.sh`** — `ini_get`, the endpoints from config.ini, `config_experiment`, the printers, and `net_probes.sh` sourced once; both scripts source it (the verbatim duplicates go). **`lab_status.sh` tier 2 prints one `role=CA gateway<TAB>…` record** (`info=N devices connected`, `note=` on zero devices / unreadable / no env) that `fleet_status.sh` consumes — a stated contract instead of `grep 'gateway alive'` + `sed` on prose | `lib/lab_env.sh` (new), `lab_status.sh`, `fleet_status.sh`, `tests/test_lab_env_sh.py` | ~+120 / −80 |
| 3 | **Facts vs findings in the table** — records carry `info=` (device counts, hosts up, not-deployed count) beside `note=`; `fleet_table.py` shows both in Notes but only findings mark `!`. `baked venv` and `N behind master` become facts; `N ahead` (running unmerged code) stays a finding. A record may carry several `note=`/`info=` | `fleet_table.py`, `tests/test_fleet_table.py` | ~+60 |
| 4 | **Port-record dedupe by cgroup unit** — a fleet-port owner whose unit is already listed is that unit's child (the RE Manager the qserver launcher forks), not a second process for the role | `fleet_status.sh` remote snippet | +5 |
| 5 | **MCP not listening = `[WARN]` + `state=down`** — the fleet map has `geecs-mcp` as a system unit on the worker host since Phase 3; silence is a finding, not "pending deploy" | `fleet_status.sh` | +2 / −2 |
| — | Skills: `/fleet-status` (stage 1 wording, the `fleet` one-liner), `/lab-status` (the lib + the record line) | 2 files | ~+15 |

## Tests

`./scripts/check.sh` (root env + GeecsPvaGateway env): lint clean; **GeecsPvaGateway 29 passed** (3 new: probe lines/record split, mixed versions + all down, `fleet` dispatch incl. the no-experiment exit 2 with a record line); **root-tests 57 passed** (9 new: `test_fleet_table.py` — info never marks `!`, note does, baked/behind are facts, ahead is a finding, MCP down is ✗, a real venv≠pyproject still `!`; `test_lab_env_sh.py` — endpoints + experiment from a temp config.ini, legacy `exp_name`, missing file is empty not an error, printers + `bounded` via `net_probes.sh`).

## Hardware verification

**Done 2026-09-05 from this worktree, on the lab network, `--summary` over ssh:**
- CA gateway row from the record contract: `0.20.1`, `95 devices connected` shown as a fact.
- PVA row from `geecs-pva-gateway fleet`: `0.4.4 ×9`, `9 of 9 deployed up; 2 not deployed` — ✓, no `!`.
- Queueserver row: one process (previously `2 processes for this role`), readiness from the #794 probe.
- `baked venv` (MCP) and `60 behind master` (portal) shown without `!`.
- The `!` rows are real: the host clones were pulled to 65da7183 while the venvs still hold geecs-ca-gateway 0.20.1 and geecs-bluesky 0.75.0 (pyproject 0.20.2 / 0.76.0) — `poetry install` + restart pending on the gateway and the qs-checkout services. That is the drift this table exists to show.
- MCP was listening, so the new not-listening branch is exercised only by its unit test (`state=down` → ✗).

## Facility-literal check

None added. `lab_env.sh` keeps the port constants the fleet map treats as constants; every host comes from config.ini.

## Judgment calls (cheap to veto)

- `N behind master` is informational. Ahead of master stays a finding because it means unmerged code is running.
- The `fleet` subcommand exits 1 when no deployed host answered and 2 without an experiment, and always prints a record line so the table has a row.
- `lab_status.sh` tier 2 keeps its prose lines for people; the record is one extra line at the end.

## Adversarial review

Posted as a PR comment below (either way).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014uheL9fSUG1CFmSrzsi7Ei