### PR TITLE
Redis becomes a fleet fact: fleet-status reports its supervision, bootstrap installs it (site-profile Phase 4, last gap)

### DIFF
--- a/.claude/skills/fleet-status/SKILL.md
+++ b/.claude/skills/fleet-status/SKILL.md
@@ -80,10 +80,17 @@ versions` line means a rollout is incomplete or a box's
 pull-on-restart no-oped — the GeecsPvaGateway runbook's known failure.
 
 **Stage 2 — host checkouts (ssh).** On each host derived from
-config.ini, services are discovered two ways and deduplicated by pid:
-every `geecs-*` (+ `tiled`) systemd unit in **both** system and user
+config.ini, services are discovered three ways. Two are deduplicated by
+pid: every `geecs-*` (+ `tiled`) systemd unit in **both** system and user
 scope, and **whoever owns each fleet port** — a queueserver started by
-hand in tmux has no unit and must still show up. Each process is mapped
+hand in tmux has no unit and must still show up. The third is **Redis**,
+deliberately *not* judged by pid: `ss -p` reveals a pid only for the ssh
+user's own processes (or root) and the packaged Redis runs as the `redis`
+account, so a pid comparison reports a healthy service as absent. Its
+listener is read without `-p`, its supervision comes from the unit state,
+and `redis-cli info server` supplies the version and the server's own pid.
+The `Redis` row appears only where it is relevant: a queueserver unit on
+that host, or something already on 6379. Each process is mapped
 to the clone it runs from (its cwd, or the baked venv's recorded source
 path for the MCP pattern), then: branch, short sha, commit date,
 staged/unstaged counts, pyproject version vs the version installed in
@@ -101,6 +108,10 @@ started (for a baked venv: after the install). The warnings to act on:
 | `Queueserver … NOT READY — worker environment CLOSED` | the unit is up but nothing opened the RE worker environment (every `geecs-qserver` restart recreates this until #793's readiness step lands); the console gets "Plan … is not in the list of allowed plans" | `qserver environment open` from any client env (GeecsBluesky's), then re-run; the plan name in the console's error is a red herring |
 | `Queueserver … readiness UNKNOWN (port only)` | no local env with `bluesky-queueserver` to ask the manager | `/env-doctor` for GeecsBluesky; the port is listening but that proves nothing about plans |
 | `Queueserver … readiness UNKNOWN — plans_allowed unanswered` | the manager answered `status` but not the plan list (a wedged or overloaded manager, or a refused user group) — readiness is an assertion about plans, so none is made | re-run; if it repeats, read the manager's journal on the host before touching the environment |
+| `Redis … answering on 6379 but redis-server.service is <state>` | the queueserver's state store is the **launcher's fallback**, not a supervised service: `launch_re_manager.sh` starts its own daemonized `redis-server` whenever nothing answers, and the unit only orders `After=` it. It dies with whatever started it, is gone after a reboot, and returns empty — the queue and history with it | install the distro package and enable the unit ([qserver runbook](https://github.com/GEECS-BELLA/GEECS-Plugins/blob/master/GeecsBluesky/qserver/deploy/redis.conf-notes.md)); note the pending queue and history do not survive, and **never** carry a `dump.rdb` from a newer Redis onto an older one |
+| `Redis … is disabled — no Redis after a reboot` | the unit runs now but is not enabled, so the next boot has none and the launcher's fallback takes over silently | `sudo systemctl enable redis-server.service` |
+| `Redis … active as pid N but the server on 6379 is pid M` | the unit is up yet something else holds the port; the queueserver talks to the one the unit does not supervise | read both before acting — stop the stray, then confirm the unit owns 6379 |
+| `Redis … nothing answering on 6379` | no state store at all; the next queueserver start manufactures an unsupervised one | install/enable the package **before** starting `geecs-qserver` |
 
 Any unit whose clone is on a branch other than `master` is a fact to
 surface, not a fault — feature-branch deploys for live checks are

--- a/GeecsBluesky/CHANGELOG.md
+++ b/GeecsBluesky/CHANGELOG.md
@@ -15,10 +15,11 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   package is 6.0.16 (reads to version 9): given the newer dump it exits with
   `Can't handle RDB format version 15`, logged to
   `/var/log/redis/redis-server.log` and *not* the journal, which shows only
-  `status=1/FAILURE`. The notes now say to start the packaged Redis empty
-  (only `qs_default_plan_history` is unrecoverable; permissions come from
-  `user_group_permissions.yaml` via the launcher's
-  `--user-group-permissions` every start) and record why a missing package
+  `status=1/FAILURE`. The notes now say to start the packaged Redis empty and
+  spell out what that discards — `qs_default_plan_queue` (the pending queue)
+  and `qs_default_plan_history` hold data nothing recreates, while
+  permissions come back from `user_group_permissions.yaml` via the launcher's
+  `--user-group-permissions` every start — and record why a missing package
   does not fail loudly: `launch_re_manager.sh` starts an unsupervised
   `redis-server --daemonize yes` whenever nothing answers on 6379, and
   `geecs-qserver.service` only orders after `redis-server.service` without

--- a/GeecsBluesky/CHANGELOG.md
+++ b/GeecsBluesky/CHANGELOG.md
@@ -4,6 +4,27 @@ All notable changes to `geecs-bluesky` are documented here.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.76.1] - 2026-09-06
+
+### Documentation
+
+- **`qserver/deploy/redis.conf-notes.md`: never carry a `dump.rdb` across
+  Redis major versions, and the launcher starts its own Redis when none
+  answers.** Migrating the interim host off its source-built Redis failed
+  because the spike binary was 8.10.1 (RDB format version 15) and the jammy
+  package is 6.0.16 (reads to version 9): given the newer dump it exits with
+  `Can't handle RDB format version 15`, logged to
+  `/var/log/redis/redis-server.log` and *not* the journal, which shows only
+  `status=1/FAILURE`. The notes now say to start the packaged Redis empty
+  (only `qs_default_plan_history` is unrecoverable; permissions come from
+  `user_group_permissions.yaml` via the launcher's
+  `--user-group-permissions` every start) and record why a missing package
+  does not fail loudly: `launch_re_manager.sh` starts an unsupervised
+  `redis-server --daemonize yes` whenever nothing answers on 6379, and
+  `geecs-qserver.service` only orders after `redis-server.service` without
+  requiring it. Closes the last site-profile Phase 4 gap; the detection side
+  is in `scripts/fleet_status.sh` and `deploy/bootstrap_host.sh`.
+
 ## [0.76.0] - 2026-09-04
 
 ### Changed

--- a/GeecsBluesky/pyproject.toml
+++ b/GeecsBluesky/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-bluesky"
-version = "0.76.0"
+version = "0.76.1"
 description = "Bluesky / ophyd-async bridge for the GEECS control system"
 authors = ["Sam Barber <sbarber@lbl.gov>"]
 readme = "README.md"

--- a/GeecsBluesky/qserver/deploy/redis.conf-notes.md
+++ b/GeecsBluesky/qserver/deploy/redis.conf-notes.md
@@ -20,6 +20,54 @@ protected-mode yes
 The source-built Redis used during sandbox testing was only a no-sudo
 workaround. It is not the deployment shape for the service host.
 
+## Never carry a dump.rdb across Redis major versions
+
+Migrating the interim host off its source-built Redis (2026-09-06) failed on
+exactly this. The spike binary was Redis 8.10.1, which writes **RDB format
+version 15**; the jammy package is 6.0.16, which reads up to version 9. Given
+the newer dump it refuses to start:
+
+```
+# Can't handle RDB format version 15
+# Fatal error loading the DB: Invalid argument. Exiting.
+```
+
+Two things make that hard to read. Redis logs it to
+`/var/log/redis/redis-server.log`, **not** the journal — `systemctl status`
+shows only `status=1/FAILURE` and a restart-throttle, so read that logfile
+first for any Redis start failure. And with nothing then answering on 6379,
+the launcher's fallback (below) starts an unsupervised Redis instead, which
+looks like a working queueserver.
+
+Start the packaged Redis on an **empty** dataset rather than downgrading the
+dump. Of the RE Manager's keys only `qs_default_plan_history` holds anything
+you cannot recreate: permissions are re-published from
+`user_group_permissions.yaml` by the launcher's `--user-group-permissions` on
+every start, `qs_default_running_plan` is empty unless a plan is mid-flight,
+and the autostart/stop-pending keys are transient flags. Archive the old dump
+rather than deleting it — reading it again needs a Redis of the version that
+wrote it.
+
+## The launcher starts its own Redis when none answers
+
+`launch_re_manager.sh` runs `${QS_REDIS_SERVER:-redis-server} --bind 127.0.0.1
+--port 6379 --daemonize yes` whenever nothing answers on 6379, and
+`geecs-qserver.service` is ordered `After=redis-server.service` without
+requiring it. So a host that never got the package does not fail loudly — it
+silently acquires an **unsupervised** Redis that dies with whatever started
+it, is absent after a reboot, and comes back empty. That is how the interim
+host ended up running a hand-built 8.10.1 for two weeks.
+
+`deploy/bootstrap_host.sh` now prints the package's root steps when
+`redis-server.service` is not enabled, and `scripts/fleet_status.sh` reports a
+`Redis` row whose finding is exactly this case: answering on 6379 but not
+supervised by the unit. After any Redis work, confirm the unit owns the port:
+
+```bash
+systemctl show -p MainPID --value redis-server.service   # must equal
+ss -ltnp 'sport = :6379'                                 # the pid here
+```
+
 Redis may warn at startup that `vm.overcommit_memory` is disabled. Apply the
 host-level sysctl fix once:
 

--- a/GeecsBluesky/qserver/deploy/redis.conf-notes.md
+++ b/GeecsBluesky/qserver/deploy/redis.conf-notes.md
@@ -40,13 +40,22 @@ the launcher's fallback (below) starts an unsupervised Redis instead, which
 looks like a working queueserver.
 
 Start the packaged Redis on an **empty** dataset rather than downgrading the
-dump. Of the RE Manager's keys only `qs_default_plan_history` holds anything
-you cannot recreate: permissions are re-published from
-`user_group_permissions.yaml` by the launcher's `--user-group-permissions` on
-every start, `qs_default_running_plan` is empty unless a plan is mid-flight,
-and the autostart/stop-pending keys are transient flags. Archive the old dump
-rather than deleting it — reading it again needs a Redis of the version that
-wrote it.
+dump — but know what that discards. Two of the RE Manager's keys hold data
+nothing recreates:
+
+- `qs_default_plan_queue` — the **pending queue**, what the console's queue
+  panel fills. Drain it or note its contents first; do not assume it is
+  empty. (On the 2026-09-06 migration the key was absent entirely, so
+  nothing was queued — that was luck, not a property of the procedure.)
+- `qs_default_plan_history` — the record of past plans.
+
+Everything else is re-derived on the next start: permissions are re-published
+from `user_group_permissions.yaml` by the launcher's
+`--user-group-permissions` (the manager reloads them on startup by default),
+`qs_default_running_plan` is empty unless a plan is mid-flight, and the
+queue-mode, lock, autostart and stop-pending keys are flags. Archive the old
+dump rather than deleting it — reading it again needs a Redis of the version
+that wrote it.
 
 ## The launcher starts its own Redis when none answers
 
@@ -64,9 +73,16 @@ host ended up running a hand-built 8.10.1 for two weeks.
 supervised by the unit. After any Redis work, confirm the unit owns the port:
 
 ```bash
-systemctl show -p MainPID --value redis-server.service   # must equal
-ss -ltnp 'sport = :6379'                                 # the pid here
+redis-cli -h 127.0.0.1 info server | grep -E 'process_id|redis_version'
+systemctl show -p MainPID --value redis-server.service
 ```
+
+The two pids must match. Ask the **server** for its pid, not `ss -p`: without
+`sudo`, `ss -p` omits the owner of another account's socket, and the packaged
+Redis runs as the `redis` account — so `ss` reports nothing to compare and
+reproduces the false absence this section warns about. `redis-cli` answers any
+client on loopback, no privileges needed, and also gives you the version that
+decides whether an existing `dump.rdb` can be loaded at all.
 
 Redis may warn at startup that `vm.overcommit_memory` is disabled. Apply the
 host-level sysctl fix once:

--- a/deploy/bootstrap_host.sh
+++ b/deploy/bootstrap_host.sh
@@ -92,7 +92,14 @@ echo "  git $(git --version 2>/dev/null | awk '{print $3}'), $(python3.11 --vers
 # Judge the packaged unit, not just a listener on the port.
 REDIS_ROOT_STEP=""
 if wanted qserver; then
-    redis_enabled="$(systemctl is-enabled redis-server.service 2>/dev/null || echo absent)"
+    # systemctl PRINTS the state and still exits non-zero (is-enabled 1 for
+    # disabled), so `$(cmd || echo default)` would capture both and split the
+    # warning across two lines. Take the first line; default only when empty.
+    # `|| true` inside the group is required, not decorative: this script runs
+    # under `set -e -o pipefail`, so an is-enabled exit of 1 (disabled) or 127
+    # (no systemd at all) would otherwise abort the whole bootstrap.
+    redis_enabled="$({ systemctl is-enabled redis-server.service 2>/dev/null || true; } | head -1)"
+    [ -n "$redis_enabled" ] || redis_enabled="absent"
     if [ "$redis_enabled" = "enabled" ]; then
         echo "  redis-server.service enabled (the queueserver state store)"
     else
@@ -263,7 +270,7 @@ if [ -n "$REDIS_ROOT_STEP" ]; then
     # First: geecs-qserver.service is ordered After= this unit, and its
     # launcher's fallback is what we are here to prevent. Never carry a
     # dump.rdb across Redis major versions — see the qserver runbook.
-    echo "  sudo apt-get install -y redis-server   # queueserver state store; the package default (loopback only) is correct"
+    echo "  sudo apt-get update && sudo apt-get install -y redis-server   # queueserver state store; the package default (loopback only) is correct"
     echo "  echo 'vm.overcommit_memory = 1' | sudo tee /etc/sysctl.d/99-redis-overcommit.conf >/dev/null && sudo sysctl --system >/dev/null"
     echo "  sudo systemctl enable --now redis-server.service"
 fi

--- a/deploy/bootstrap_host.sh
+++ b/deploy/bootstrap_host.sh
@@ -83,6 +83,23 @@ for tool in git python3.11; do command -v "$tool" >/dev/null || prereq_fail "mis
 echo "  git $(git --version 2>/dev/null | awk '{print $3}'), $(python3.11 --version 2>/dev/null || echo 'python3.11 ?'), poetry $("$GEECS_POETRY" --version 2>/dev/null | awk '{print $NF}' | tr -d ')')"
 [ -d "$GEECS_DATA_ROOT" ] && echo "  data share mounted at $GEECS_DATA_ROOT" || echo "  WARNING: data share not mounted at $GEECS_DATA_ROOT (services start without it, then fail loudly)"
 [ -d "$GEECS_CONFIGS_ROOT" ] && echo "  configs repo at $GEECS_CONFIGS_ROOT" || echo "  WARNING: configs repo not at $GEECS_CONFIGS_ROOT"
+# Redis is the state store the queueserver keeps its queue, history and
+# permissions in. A missing package does NOT fail loudly: the unit treats
+# redis-server.service as ordering only, and launch_re_manager.sh starts its
+# own "redis-server --daemonize yes" whenever nothing answers on 6379 — so the
+# omission silently becomes an UNSUPERVISED Redis that dies with the launcher,
+# is absent after a reboot, and comes back empty (host finding 2026-09-06).
+# Judge the packaged unit, not just a listener on the port.
+REDIS_ROOT_STEP=""
+if wanted qserver; then
+    redis_enabled="$(systemctl is-enabled redis-server.service 2>/dev/null || echo absent)"
+    if [ "$redis_enabled" = "enabled" ]; then
+        echo "  redis-server.service enabled (the queueserver state store)"
+    else
+        echo "  WARNING: redis-server.service is $redis_enabled — the queueserver launcher would start an UNSUPERVISED redis on 6379; the root steps below install the package"
+        REDIS_ROOT_STEP="yes"
+    fi
+fi
 
 say "clones (one per service family, at $REF)"
 # Clone dirs that are NOT usable clones are recorded here; every later stage
@@ -242,6 +259,14 @@ elif [ "$DRY" -eq 1 ]; then echo "  [dry] render_units.sh $SITE_ENV $STAGE ${TEM
 else RENDER_QUIET=1 "$REPO_ROOT/deploy/render_units.sh" "$SITE_ENV" "$STAGE" "${TEMPLATE_PATHS[@]}" | sed 's/^/  /'; fi
 
 say "root steps (a human runs these; nothing above needed sudo)"
+if [ -n "$REDIS_ROOT_STEP" ]; then
+    # First: geecs-qserver.service is ordered After= this unit, and its
+    # launcher's fallback is what we are here to prevent. Never carry a
+    # dump.rdb across Redis major versions — see the qserver runbook.
+    echo "  sudo apt-get install -y redis-server   # queueserver state store; the package default (loopback only) is correct"
+    echo "  echo 'vm.overcommit_memory = 1' | sudo tee /etc/sysctl.d/99-redis-overcommit.conf >/dev/null && sudo sysctl --system >/dev/null"
+    echo "  sudo systemctl enable --now redis-server.service"
+fi
 echo "  sudo install -D -m 0644 \"$SITE_ENV\" \"$SITE_ENV_INSTALLED\""
 if [ "${#TEMPLATE_PATHS[@]}" -gt 0 ]; then
     echo "  sudo install -m 0644 \"$STAGE\"/*.service /etc/systemd/system/"
@@ -265,6 +290,11 @@ if [ "$SKIP_CLONES" != " " ]; then
     # parsed as part of the name by bash 3.2 under UTF-8 (unbound variable).
     echo "WARNING: skipped clone dir(s):${SKIP_CLONES}— not clones of their own (linked worktree or unreadable .git)." >&2
     echo "         Replace each in a maintenance window per docs/platform/site_profile.md, then rerun this script." >&2
+    echo
+fi
+if [ -n "$REDIS_ROOT_STEP" ]; then
+    echo "WARNING: redis-server.service is not enabled on this host — run the Redis root step above BEFORE" >&2
+    echo "         enabling geecs-qserver, or its launcher will start an unsupervised Redis (see the qserver runbook)." >&2
     echo
 fi
 echo "Then: scripts/fleet_status.sh from any client — every row should read systemd / clean / matching versions."

--- a/docs/platform/fleet_map.md
+++ b/docs/platform/fleet_map.md
@@ -267,7 +267,11 @@ scan running:
    The launch script's own daemonized Redis is a fallback only: it lives
    in the `geecs-qserver` cgroup and dies with every unit restart, taking
    the queue and history with it. An inactive `redis-server` unit on a
-   service host is a finding.
+   service host is a finding — `scripts/fleet_status.sh` reports it as the
+   `Redis` row, and `deploy/bootstrap_host.sh` prints the package's root
+   steps when the unit is not enabled. Do not carry a `dump.rdb` from a
+   newer Redis onto an older one; start empty instead (the runbook's
+   notes give the RDB-version reason).
 2. **`geecs-qserver`** (it pulls in `geecs-qserver-ready`), then
    **`geecs-capture`**; `qserver status` (readiness, not just the port)
    and the capture heartbeat file are the checks.

--- a/scripts/fleet_status.sh
+++ b/scripts/fleet_status.sh
@@ -521,7 +521,10 @@ if [ "$redis_here" = "1" ]; then
         printf "%b\n" "role=Redis\tsvc=redis-server.service\tmanaged=none\tstate=$redis_state\tnote=nothing answering on 6379 — the queueserver has no state store, and its launcher will start an UNSUPERVISED redis on the next start"
     elif [ "$redis_active" = "active" ] && [ -n "$redis_pid" ] && [ -n "$redis_main" ] \
          && [ "$redis_main" != "0" ] && [ "$redis_pid" != "$redis_main" ]; then
-        printf "%b\n" "role=Redis\tsvc=redis :6379\tmanaged=$redis_state\tstate=running (not the unit)\tversion=${redis_ver:-?}\tnote=redis-server.service is active as pid $redis_main but the server on 6379 is pid $redis_pid — the queueserver talks to a Redis the unit does not supervise (the launcher fallback, with the unit bound elsewhere)"
+        # managed=UNMANAGED, not the unit state: the server on 6379 is
+        # precisely the thing no unit supervises, and fleet_table.runs_as
+        # renders anything else in this field as "?".
+        printf "%b\n" "role=Redis\tsvc=redis :6379\tmanaged=UNMANAGED\tstate=running (not the unit)\tversion=${redis_ver:-?}\tnote=redis-server.service is active as pid $redis_main but the server on 6379 is pid $redis_pid — the queueserver talks to a Redis the unit does not supervise (the launcher fallback, with the unit bound elsewhere)"
     elif [ "$redis_active" = "active" ]; then
         r="role=Redis\tsvc=redis-server.service\tmanaged=systemd\tstate=$redis_state\tversion=${redis_ver:-?}"
         if [ "$redis_enabled" != "enabled" ]; then

--- a/scripts/fleet_status.sh
+++ b/scripts/fleet_status.sh
@@ -494,15 +494,34 @@ redis_here=0
 case "$SEEN_UNITS" in *" geecs-qserver.service "*) redis_here=1;; esac
 [ "$redis_listening" = "1" ] && redis_here=1
 if [ "$redis_here" = "1" ]; then
-    redis_active="$(systemctl is-active redis-server.service 2>/dev/null || echo inactive)"
-    redis_enabled="$(systemctl is-enabled redis-server.service 2>/dev/null || echo absent)"
-    redis_ver="$(redis-cli -h 127.0.0.1 info server 2>/dev/null | sed -nE "s/^redis_version:([0-9.]+).*/\1/p" | head -1)"
+    # systemctl PRINTS the state and still exits non-zero (is-active 3 for
+    # inactive, is-enabled 1 for disabled), so `$(cmd || echo default)` would
+    # capture both strings and embed a newline — splitting this one-line
+    # record in two, which the table drops and the log misreads as an ssh
+    # notice. Take the first line; default only when nothing was printed.
+    # `|| true` guards the pipeline for a caller with -e/pipefail; this
+    # snippet itself runs under set -u only.
+    redis_active="$({ systemctl is-active redis-server.service 2>/dev/null || true; } | head -1)"
+    [ -n "$redis_active" ] || redis_active="inactive"
+    redis_enabled="$({ systemctl is-enabled redis-server.service 2>/dev/null || true; } | head -1)"
+    [ -n "$redis_enabled" ] || redis_enabled="absent"
+    redis_info="$(redis-cli -h 127.0.0.1 info server 2>/dev/null)"
+    redis_ver="$(printf "%s" "$redis_info" | sed -nE "s/^redis_version:([0-9.]+).*/\1/p" | head -1)"
+    # The listening server names its own pid to any loopback client — no
+    # privileges, unlike ss -p. This is what lets the verdict be exact.
+    redis_pid="$(printf "%s" "$redis_info" | sed -nE "s/^process_id:([0-9]+).*/\1/p" | head -1)"
+    redis_main="$(systemctl show -p MainPID --value redis-server.service 2>/dev/null | head -1)"
     # state= on a stage-2 record is the UNIT state (fleet_table maps it to
     # proc_state for the glyph), so it must be systemd-shaped.
     redis_state="$(systemctl show -p ActiveState --value redis-server.service 2>/dev/null)/$(systemctl show -p SubState --value redis-server.service 2>/dev/null)"
-    case "$redis_state" in /|"") redis_state="absent/no-unit";; esac
+    # NOT "absent/…": fleet_table.glyph reads a leading "absent" as the
+    # not-deployed dot, which would render this finding as benign.
+    case "$redis_state" in /|"") redis_state="inactive/no-unit";; esac
     if [ "$redis_listening" = "0" ]; then
         printf "%b\n" "role=Redis\tsvc=redis-server.service\tmanaged=none\tstate=$redis_state\tnote=nothing answering on 6379 — the queueserver has no state store, and its launcher will start an UNSUPERVISED redis on the next start"
+    elif [ "$redis_active" = "active" ] && [ -n "$redis_pid" ] && [ -n "$redis_main" ] \
+         && [ "$redis_main" != "0" ] && [ "$redis_pid" != "$redis_main" ]; then
+        printf "%b\n" "role=Redis\tsvc=redis :6379\tmanaged=$redis_state\tstate=running (not the unit)\tversion=${redis_ver:-?}\tnote=redis-server.service is active as pid $redis_main but the server on 6379 is pid $redis_pid — the queueserver talks to a Redis the unit does not supervise (the launcher fallback, with the unit bound elsewhere)"
     elif [ "$redis_active" = "active" ]; then
         r="role=Redis\tsvc=redis-server.service\tmanaged=systemd\tstate=$redis_state\tversion=${redis_ver:-?}"
         if [ "$redis_enabled" != "enabled" ]; then
@@ -514,8 +533,9 @@ if [ "$redis_here" = "1" ]; then
     else
         printf "%b\n" "role=Redis\tsvc=redis :6379\tmanaged=UNMANAGED\tstate=running (no unit)\tversion=${redis_ver:-?}\tnote=answering on 6379 but redis-server.service is $redis_active — this is the qserver launcher fallback: it dies with whatever started it and comes back empty. Install the distro package per the qserver runbook"
     fi
+    redis_reported=1
 fi
-[ "$SEEN" = " " ] && echo "nounits"
+[ "$SEEN" = " " ] && [ "${redis_reported:-0}" = "0" ] && echo "nounits"
 exit 0
 '
 
@@ -530,8 +550,8 @@ fmt_host_records() {  # stdin: service records -> pretty lines; side effect: not
             *) info "ssh: $line"; continue ;;   # known-hosts notices, remote warnings — not records
         esac
         rec "$line"
-        local role svc managed state since clone branch sha full cdate staged unstaged stale pkg pyproject installed baked pyexe disk disk_full disk_date worktree_of
-        role=""; svc=""; managed=""; state=""; since=""; clone=""; branch=""; sha=""; full=""; cdate=""; staged=""; unstaged=""; stale=""; pkg=""; pyproject=""; installed=""; baked=""; pyexe=""; disk=""; disk_full=""; disk_date=""; worktree_of=""
+        local role svc managed state since clone branch sha full cdate staged unstaged stale pkg pyproject installed baked pyexe disk disk_full disk_date worktree_of rnotes rinfos
+        role=""; svc=""; managed=""; state=""; since=""; clone=""; branch=""; sha=""; full=""; cdate=""; staged=""; unstaged=""; stale=""; pkg=""; pyproject=""; installed=""; baked=""; pyexe=""; disk=""; disk_full=""; disk_date=""; worktree_of=""; rnotes=""; rinfos=""
         local IFS=$'\t' kv
         for kv in $line; do
             case "$kv" in
@@ -542,13 +562,32 @@ fmt_host_records() {  # stdin: service records -> pretty lines; side effect: not
                 installed=*) installed="${kv#*=}" ;; baked=*) baked="${kv#*=}" ;; pyexe=*) pyexe="${kv#*=}" ;;
                 disk=*) disk="${kv#*=}" ;; disk_full=*) disk_full="${kv#*=}" ;; disk_date=*) disk_date="${kv#*=}" ;;
                 worktree_of=*) worktree_of="${kv#*=}" ;;
+                # A stage-2 record may carry its own findings and facts (the
+                # Redis row does): note= is a finding, info= is a fact — the
+                # same split fleet_table.py renders as ! vs plain. Without
+                # this the payload was parsed into nothing and the log showed
+                # only the header line.
+                note=*) rnotes="${rnotes:+$rnotes|}${kv#*=}" ;;
+                info=*) rinfos="${rinfos:+$rinfos|}${kv#*=}" ;;
             esac
         done
         unset IFS
         local tag="[ OK ]"
         case "$state" in active/*|running*) ;; *) tag="[DOWN]" ;; esac
         printf '  %s %-34s %-16s since %s\n' "$tag" "$svc" "$state" "${since:-?}"
-        [ "$managed" = "UNMANAGED" ] && warn "$svc: no systemd unit owns this process (started by hand — tmux/nohup?); it will not survive a reboot or crash"
+        if [ -n "$rnotes" ]; then
+            local n; local IFS='|'
+            for n in $rnotes; do [ -n "$n" ] && warn "$svc: $n"; done
+            unset IFS
+        fi
+        if [ -n "$rinfos" ]; then
+            local i; local IFS='|'
+            for i in $rinfos; do [ -n "$i" ] && info "$i"; done
+            unset IFS
+        fi
+        # An explicit note supersedes the generic guess: Redis on 6379 without
+        # a unit was started by the queueserver launcher, not by hand in tmux.
+        [ "$managed" = "UNMANAGED" ] && [ -z "$rnotes" ] && warn "$svc: no systemd unit owns this process (started by hand — tmux/nohup?); it will not survive a reboot or crash"
         if [ -n "$clone" ]; then
             local d=""
             [ "${staged:-0}" != "0" ] && d="$d  STAGED: $staged file(s)"

--- a/scripts/fleet_status.sh
+++ b/scripts/fleet_status.sh
@@ -473,6 +473,48 @@ for port in $FLEET_PORTS; do
     if [ -n "$unit" ]; then managed="systemd ($unit)"; else managed="UNMANAGED"; fi
     emit "$(role_for_port "$port")" "$(role_for_port "$port") :$port" "$managed" "running pid $pid" "$pid" "" ""
 done
+# 3) Redis — the state store the queueserver keeps (queue, history, permissions).
+# Not a GEECS package and not resolvable to a checkout, so it gets its own
+# record instead of the port-owner path above: what matters here is whether it
+# is SUPERVISED, not which code it runs. launch_re_manager.sh starts its own
+# "redis-server --daemonize yes" whenever nothing answers on 6379 (the unit
+# treats redis-server.service as ordering only, not a requirement), so
+# answering and supervised are different facts — a launcher-started Redis dies
+# with whatever started it and comes back empty.
+#
+# Deliberately NOT judged by pid: ss -p reveals the pid only for the ssh
+# user own processes (or root), and the packaged Redis runs as the redis
+# account, so a pid comparison reports a false absence. The listener is read
+# without -p and supervision comes from the unit state, both readable by any
+# account. Reported only where relevant: a queueserver unit here, or
+# something already on 6379.
+redis_listening=0
+ss -ltnH "sport = :6379" 2>/dev/null | grep -q . && redis_listening=1
+redis_here=0
+case "$SEEN_UNITS" in *" geecs-qserver.service "*) redis_here=1;; esac
+[ "$redis_listening" = "1" ] && redis_here=1
+if [ "$redis_here" = "1" ]; then
+    redis_active="$(systemctl is-active redis-server.service 2>/dev/null || echo inactive)"
+    redis_enabled="$(systemctl is-enabled redis-server.service 2>/dev/null || echo absent)"
+    redis_ver="$(redis-cli -h 127.0.0.1 info server 2>/dev/null | sed -nE "s/^redis_version:([0-9.]+).*/\1/p" | head -1)"
+    # state= on a stage-2 record is the UNIT state (fleet_table maps it to
+    # proc_state for the glyph), so it must be systemd-shaped.
+    redis_state="$(systemctl show -p ActiveState --value redis-server.service 2>/dev/null)/$(systemctl show -p SubState --value redis-server.service 2>/dev/null)"
+    case "$redis_state" in /|"") redis_state="absent/no-unit";; esac
+    if [ "$redis_listening" = "0" ]; then
+        printf "%b\n" "role=Redis\tsvc=redis-server.service\tmanaged=none\tstate=$redis_state\tnote=nothing answering on 6379 — the queueserver has no state store, and its launcher will start an UNSUPERVISED redis on the next start"
+    elif [ "$redis_active" = "active" ]; then
+        r="role=Redis\tsvc=redis-server.service\tmanaged=systemd\tstate=$redis_state\tversion=${redis_ver:-?}"
+        if [ "$redis_enabled" != "enabled" ]; then
+            r="$r\tnote=redis-server.service is $redis_enabled — no Redis after a reboot, and the launcher would then start an unsupervised one"
+        else
+            r="$r\tinfo=loopback 6379, enabled"
+        fi
+        printf "%b\n" "$r"
+    else
+        printf "%b\n" "role=Redis\tsvc=redis :6379\tmanaged=UNMANAGED\tstate=running (no unit)\tversion=${redis_ver:-?}\tnote=answering on 6379 but redis-server.service is $redis_active — this is the qserver launcher fallback: it dies with whatever started it and comes back empty. Install the distro package per the qserver runbook"
+    fi
+fi
 [ "$SEEN" = " " ] && echo "nounits"
 exit 0
 '

--- a/scripts/fleet_table.py
+++ b/scripts/fleet_table.py
@@ -25,6 +25,7 @@ ROLE_ORDER = [
     "Bluesky doc proxy",
     "Capture daemon",
     "GEECS-MCP",
+    "Redis",
     "PVA image gateways",
 ]
 HEADERS = ["", "Service", "Runs as", "Checkout", "Version", "Notes"]

--- a/tests/test_bootstrap_host_sh.py
+++ b/tests/test_bootstrap_host_sh.py
@@ -7,8 +7,15 @@ nothing answers on 6379 and ``geecs-qserver.service`` only orders after
 ``redis-server.service`` without requiring it. The omission silently became an
 unsupervised Redis that dies with the launcher and returns empty.
 
-``systemctl`` is stubbed so both branches are deterministic on any host,
-including runners with no systemd and hosts that really do run Redis.
+``systemctl`` is stubbed so both branches are deterministic on a runner with
+no systemd and on a host that really does run Redis, and ``site.env``'s
+checkout root is redirected into ``tmp_path`` so the run never inspects real
+service clones (on the services box itself, a clone there changes which
+``enable --now`` lines get printed).
+
+The stub uses systemd's real exit code: ``is-enabled`` prints ``disabled``
+and exits **1**, so ``$(systemctl … || echo absent)`` would capture both and
+split the warning across two lines.
 """
 
 from __future__ import annotations
@@ -36,10 +43,39 @@ case "$*" in
     *) exit 1 ;;
 esac
 """
-REDIS_ABSENT = "exit 1\n"
+# Present but off: prints the state AND exits non-zero, like the real thing.
+REDIS_DISABLED = """\
+case "$*" in
+    "is-enabled redis-server.service") echo disabled; exit 1 ;;
+    *) exit 1 ;;
+esac
+"""
+# No unit file: the message goes to stderr, stdout is empty, exit 1.
+REDIS_ABSENT = """\
+case "$*" in
+    "is-enabled redis-server.service") echo "Failed to get unit file state" >&2; exit 1 ;;
+    *) exit 1 ;;
+esac
+"""
 
 
-def _run(tmp_path: Path, systemctl_body: str) -> subprocess.CompletedProcess[str]:
+def _site_env(tmp_path: Path) -> Path:
+    """``site.env.example`` with its host paths redirected into ``tmp_path``."""
+    text = SITE_ENV.read_text()
+    root = tmp_path / "checkouts"
+    root.mkdir()
+    out = tmp_path / "site.env"
+    out.write_text(
+        text.replace(
+            "GEECS_CHECKOUT_ROOT=/home/geecs", f"GEECS_CHECKOUT_ROOT={root}"
+        ).replace("GEECS_SERVICE_HOME=/home/geecs", f"GEECS_SERVICE_HOME={root}")
+    )
+    return out
+
+
+def _run(
+    tmp_path: Path, systemctl_body: str, *extra: str
+) -> subprocess.CompletedProcess[str]:
     """Dry-run the bootstrap with a stub ``systemctl`` first on PATH."""
     stub_dir = tmp_path / "bin"
     stub_dir.mkdir()
@@ -48,7 +84,7 @@ def _run(tmp_path: Path, systemctl_body: str) -> subprocess.CompletedProcess[str
     stub.chmod(0o755)
     env = dict(os.environ, PATH=f"{stub_dir}:{os.environ.get('PATH', '')}")
     return subprocess.run(
-        ["bash", str(BOOTSTRAP), str(SITE_ENV), "--dry-run"],
+        ["bash", str(BOOTSTRAP), str(_site_env(tmp_path)), "--dry-run", *extra],
         capture_output=True,
         text=True,
         env=env,
@@ -60,6 +96,8 @@ def test_missing_redis_unit_prints_the_package_root_step(tmp_path: Path) -> None
     r = _run(tmp_path, REDIS_ABSENT)
     assert r.returncode == 0, r.stderr
     assert "redis-server.service is absent" in r.stdout
+    # One line, not "disabled\nabsent": the state must not be doubled.
+    assert "apt-get update && sudo apt-get install -y redis-server" in r.stdout
     assert "apt-get install -y redis-server" in r.stdout
     assert "enable --now redis-server.service" in r.stdout
     # The tail must not read clean after the prereq warning scrolled off.
@@ -84,22 +122,45 @@ def test_enabled_redis_unit_adds_no_root_step(tmp_path: Path) -> None:
 
 def test_redis_is_skipped_when_the_queueserver_is_not_wanted(tmp_path: Path) -> None:
     """``--only`` narrows the run; Redis belongs to the queueserver family."""
-    stub_dir = tmp_path / "bin"
-    stub_dir.mkdir()
-    stub = stub_dir / "systemctl"
-    stub.write_text("#!/usr/bin/env bash\n" + REDIS_ABSENT)
-    stub.chmod(0o755)
-    env = dict(os.environ, PATH=f"{stub_dir}:{os.environ.get('PATH', '')}")
-    r = subprocess.run(
-        ["bash", str(BOOTSTRAP), str(SITE_ENV), "--dry-run", "--only", "portal"],
-        capture_output=True,
-        text=True,
-        env=env,
-        cwd=REPO_ROOT,
-    )
+    r = _run(tmp_path, REDIS_ABSENT, "--only", "portal")
     assert r.returncode == 0, r.stderr
     # Match the emitted lines, not the bare word: a checkout path can
     # legitimately contain "redis" (this branch's own worktree does).
     assert "redis-server.service" not in r.stdout
     assert "apt-get install -y redis-server" not in r.stdout
     assert "run the Redis root step above BEFORE" not in r.stderr
+
+
+def test_a_present_but_disabled_unit_reports_one_state_not_two(
+    tmp_path: Path,
+) -> None:
+    """``is-enabled`` prints ``disabled`` and exits 1; capturing both doubles it."""
+    r = _run(tmp_path, REDIS_DISABLED)
+    assert r.returncode == 0, r.stderr
+    assert "redis-server.service is disabled" in r.stdout
+    assert "disabled\nabsent" not in r.stdout
+    warning = next(
+        ln for ln in r.stdout.splitlines() if "redis-server.service is" in ln
+    )
+    # The whole warning, remedy included, has to survive on its own line.
+    assert warning.rstrip().endswith("the root steps below install the package")
+
+
+def test_a_host_with_no_systemd_at_all_still_completes(tmp_path: Path) -> None:
+    """The script runs under ``set -e -o pipefail``.
+
+    With no ``systemctl`` on PATH the probe exits 127; if its pipeline is not
+    guarded, the whole bootstrap aborts in the prerequisites stage instead of
+    printing the plan. That is the CI and macOS condition.
+    """
+    env = dict(os.environ, PATH="/usr/bin:/bin")
+    r = subprocess.run(
+        ["bash", str(BOOTSTRAP), str(_site_env(tmp_path)), "--dry-run"],
+        capture_output=True,
+        text=True,
+        env=env,
+        cwd=REPO_ROOT,
+    )
+    assert r.returncode == 0, r.stdout + r.stderr
+    assert "redis-server.service is absent" in r.stdout
+    assert "root steps" in r.stdout

--- a/tests/test_bootstrap_host_sh.py
+++ b/tests/test_bootstrap_host_sh.py
@@ -1,0 +1,105 @@
+"""Pin ``deploy/bootstrap_host.sh``'s Redis prerequisite and root step.
+
+Host finding 2026-09-06: the bootstrap never mentioned Redis, so a fresh
+services box got none — and that did not fail loudly, because
+``launch_re_manager.sh`` starts its own daemonized ``redis-server`` whenever
+nothing answers on 6379 and ``geecs-qserver.service`` only orders after
+``redis-server.service`` without requiring it. The omission silently became an
+unsupervised Redis that dies with the launcher and returns empty.
+
+``systemctl`` is stubbed so both branches are deterministic on any host,
+including runners with no systemd and hosts that really do run Redis.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.skipif(
+    sys.platform == "win32" or shutil.which("bash") is None,
+    reason="bootstrap_host.sh and its test need bash",
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+BOOTSTRAP = REPO_ROOT / "deploy" / "bootstrap_host.sh"
+SITE_ENV = REPO_ROOT / "deploy" / "site.env.example"
+
+REDIS_ENABLED = """\
+case "$*" in
+    "is-enabled redis-server.service") echo enabled ;;
+    *) exit 1 ;;
+esac
+"""
+REDIS_ABSENT = "exit 1\n"
+
+
+def _run(tmp_path: Path, systemctl_body: str) -> subprocess.CompletedProcess[str]:
+    """Dry-run the bootstrap with a stub ``systemctl`` first on PATH."""
+    stub_dir = tmp_path / "bin"
+    stub_dir.mkdir()
+    stub = stub_dir / "systemctl"
+    stub.write_text("#!/usr/bin/env bash\n" + systemctl_body)
+    stub.chmod(0o755)
+    env = dict(os.environ, PATH=f"{stub_dir}:{os.environ.get('PATH', '')}")
+    return subprocess.run(
+        ["bash", str(BOOTSTRAP), str(SITE_ENV), "--dry-run"],
+        capture_output=True,
+        text=True,
+        env=env,
+        cwd=REPO_ROOT,
+    )
+
+
+def test_missing_redis_unit_prints_the_package_root_step(tmp_path: Path) -> None:
+    r = _run(tmp_path, REDIS_ABSENT)
+    assert r.returncode == 0, r.stderr
+    assert "redis-server.service is absent" in r.stdout
+    assert "apt-get install -y redis-server" in r.stdout
+    assert "enable --now redis-server.service" in r.stdout
+    # The tail must not read clean after the prereq warning scrolled off.
+    assert "run the Redis root step above BEFORE" in r.stderr
+
+
+def test_redis_root_step_precedes_enabling_the_queueserver(tmp_path: Path) -> None:
+    """geecs-qserver orders After= the Redis unit, so the install comes first."""
+    r = _run(tmp_path, REDIS_ABSENT)
+    assert r.stdout.index("apt-get install -y redis-server") < r.stdout.index(
+        "enable --now geecs-qserver"
+    )
+
+
+def test_enabled_redis_unit_adds_no_root_step(tmp_path: Path) -> None:
+    r = _run(tmp_path, REDIS_ENABLED)
+    assert r.returncode == 0, r.stderr
+    assert "redis-server.service enabled" in r.stdout
+    assert "apt-get install -y redis-server" not in r.stdout
+    assert "run the Redis root step above BEFORE" not in r.stderr
+
+
+def test_redis_is_skipped_when_the_queueserver_is_not_wanted(tmp_path: Path) -> None:
+    """``--only`` narrows the run; Redis belongs to the queueserver family."""
+    stub_dir = tmp_path / "bin"
+    stub_dir.mkdir()
+    stub = stub_dir / "systemctl"
+    stub.write_text("#!/usr/bin/env bash\n" + REDIS_ABSENT)
+    stub.chmod(0o755)
+    env = dict(os.environ, PATH=f"{stub_dir}:{os.environ.get('PATH', '')}")
+    r = subprocess.run(
+        ["bash", str(BOOTSTRAP), str(SITE_ENV), "--dry-run", "--only", "portal"],
+        capture_output=True,
+        text=True,
+        env=env,
+        cwd=REPO_ROOT,
+    )
+    assert r.returncode == 0, r.stderr
+    # Match the emitted lines, not the bare word: a checkout path can
+    # legitimately contain "redis" (this branch's own worktree does).
+    assert "redis-server.service" not in r.stdout
+    assert "apt-get install -y redis-server" not in r.stdout
+    assert "run the Redis root step above BEFORE" not in r.stderr

--- a/tests/test_bootstrap_host_sh.py
+++ b/tests/test_bootstrap_host_sh.py
@@ -146,21 +146,19 @@ def test_a_present_but_disabled_unit_reports_one_state_not_two(
     assert warning.rstrip().endswith("the root steps below install the package")
 
 
-def test_a_host_with_no_systemd_at_all_still_completes(tmp_path: Path) -> None:
+def test_a_systemctl_that_fails_hard_does_not_abort_the_bootstrap(
+    tmp_path: Path,
+) -> None:
     """The script runs under ``set -e -o pipefail``.
 
-    With no ``systemctl`` on PATH the probe exits 127; if its pipeline is not
-    guarded, the whole bootstrap aborts in the prerequisites stage instead of
-    printing the plan. That is the CI and macOS condition.
+    Exit 127 is what the shell reports for a missing ``systemctl`` (no systemd
+    on the host at all); an unguarded pipeline propagates it and aborts the
+    whole bootstrap in its prerequisites stage instead of printing the plan.
+    Stubbed rather than removed from PATH, because ``systemctl`` lives in
+    ``/usr/bin`` alongside the tools the script legitimately needs — a CI
+    runner cannot be given a PATH that has the latter but not the former.
     """
-    env = dict(os.environ, PATH="/usr/bin:/bin")
-    r = subprocess.run(
-        ["bash", str(BOOTSTRAP), str(_site_env(tmp_path)), "--dry-run"],
-        capture_output=True,
-        text=True,
-        env=env,
-        cwd=REPO_ROOT,
-    )
+    r = _run(tmp_path, "exit 127\n")
     assert r.returncode == 0, r.stdout + r.stderr
     assert "redis-server.service is absent" in r.stdout
     assert "root steps" in r.stdout

--- a/tests/test_fleet_status_redis_sh.py
+++ b/tests/test_fleet_status_redis_sh.py
@@ -173,6 +173,7 @@ def test_listening_without_the_unit_is_the_launcher_fallback(tmp_path: Path) -> 
     # Exits 3 while printing "inactive": the state must appear once, not twice.
     assert notes.count("inactive") == 1, notes
     assert "no systemd unit" in notes
+    assert fleet_table.runs_as(row) == "unmanaged"
 
 
 def test_nothing_listening_is_reported_with_the_consequence(tmp_path: Path) -> None:
@@ -209,6 +210,9 @@ def test_unit_active_but_another_server_holds_the_port(tmp_path: Path) -> None:
     )
     assert fleet_table.glyph(row) == "!"
     assert "the unit does not supervise" in " ".join(fleet_table.notes(row))
+    # The supervision field must be the supervision verdict: anything else
+    # here (the unit state, say) renders the Runs-as column as "?".
+    assert fleet_table.runs_as(row) == "unmanaged"
 
 
 def test_a_host_with_neither_a_queueserver_nor_a_listener_gets_no_redis_row(
@@ -233,6 +237,35 @@ def _fmt_host_records() -> str:
     return text[start:end]
 
 
+def _harness() -> str:
+    """``fmt_host_records`` plus stub printers, ready to run under bash."""
+    return (
+        "ok(){ printf '  [ OK ] %s\\n' \"$1\"; }\n"
+        "bad(){ printf '  [DOWN] %s\\n' \"$1\"; }\n"
+        "warn(){ printf '  [WARN] %s\\n' \"$1\"; }\n"
+        "info(){ printf '         %s\\n' \"$1\"; }\n"
+        "skip(){ printf '  [ -- ] %s\\n' \"$1\"; }\n"
+        "rec(){ :; }\nnote_sha(){ :; }\n" + _fmt_host_records() + "fmt_host_records\n"
+    )
+
+
+def _log_lines(tmp_path: Path, record: str) -> str:
+    """Run the real log formatter over one record.
+
+    The record arrives on the function's stdin, so the harness itself cannot
+    come from stdin — it goes in as ``-c`` and the record through the
+    environment.
+    """
+    r = subprocess.run(
+        ["bash", "-c", 'printf "%s\\n" "$REC_IN" | { ' + _harness() + " }"],
+        capture_output=True,
+        text=True,
+        env={"PATH": "/usr/bin:/bin", "HOME": str(tmp_path), "REC_IN": record},
+    )
+    assert r.returncode == 0, r.stderr
+    return r.stdout
+
+
 def test_the_full_log_surfaces_the_note_not_just_the_header(tmp_path: Path) -> None:
     """``--summary`` is not the only reader: the default log must warn too.
 
@@ -242,25 +275,33 @@ def test_the_full_log_surfaces_the_note_not_just_the_header(tmp_path: Path) -> N
     the attention lines an operator scans.
     """
     rec = _record(tmp_path, listening=True, active="inactive", enabled="absent")
-    harness = (
-        "ok(){ printf '  [ OK ] %s\\n' \"$1\"; }\n"
-        "bad(){ printf '  [DOWN] %s\\n' \"$1\"; }\n"
-        "warn(){ printf '  [WARN] %s\\n' \"$1\"; }\n"
-        "info(){ printf '         %s\\n' \"$1\"; }\n"
-        "skip(){ printf '  [ -- ] %s\\n' \"$1\"; }\n"
-        "rec(){ :; }\nnote_sha(){ :; }\n" + _fmt_host_records() + "fmt_host_records\n"
-    )
-    # The record arrives on the function's stdin, so the harness script
-    # itself cannot come from stdin — pass it as -c and the record via env.
-    r = subprocess.run(
-        ["bash", "-c", 'printf "%s\\n" "$REC_IN" | { ' + harness + " }"],
-        capture_output=True,
-        text=True,
-        env={"PATH": "/usr/bin:/bin", "HOME": str(tmp_path), "REC_IN": rec},
-    )
-    assert r.returncode == 0, r.stderr
-    assert "[WARN]" in r.stdout, r.stdout
-    assert "launcher fallback" in r.stdout, r.stdout
+    out = _log_lines(tmp_path, rec)
+    assert "[WARN]" in out, out
+    assert "launcher fallback" in out, out
+
+
+def test_an_explicit_note_replaces_the_generic_unmanaged_guess(
+    tmp_path: Path,
+) -> None:
+    """One explanation per row, and the accurate one.
+
+    ``managed=UNMANAGED`` normally earns "started by hand — tmux/nohup?",
+    which is wrong for Redis: the queueserver launcher started it. The
+    generic line is suppressed when the record carries its own note.
+    """
+    rec = _record(tmp_path, listening=True, active="inactive", enabled="absent")
+    out = _log_lines(tmp_path, rec)
+    assert "launcher fallback" in out
+    assert "tmux/nohup" not in out, out
+    assert out.count("[WARN]") == 1, out
+
+
+def test_an_info_only_record_still_renders_its_facts(tmp_path: Path) -> None:
+    """The healthy row's payload is an ``info=``, which must print as a fact."""
+    rec = _record(tmp_path, listening=True, active="active", enabled="enabled")
+    out = _log_lines(tmp_path, rec)
+    assert "loopback 6379, enabled" in out, out
+    assert "[WARN]" not in out, out
 
 
 def test_listening_with_no_unit_file_at_all_is_the_two_week_state(

--- a/tests/test_fleet_status_redis_sh.py
+++ b/tests/test_fleet_status_redis_sh.py
@@ -1,0 +1,166 @@
+"""Pin the Redis record ``scripts/fleet_status.sh`` emits over ssh.
+
+Two host findings, 2026-09-06:
+
+* The queueserver had run for two weeks against a hand-built Redis in no unit,
+  and ``/fleet-status`` could not see it — the script had no Redis awareness at
+  all.
+* The first attempt judged supervision by comparing the unit's ``MainPID`` with
+  the pid owning 6379. ``ss -p`` reveals a pid only for the ssh user's own
+  processes (or root) and the packaged Redis runs as the ``redis`` account, so
+  a healthy supervised Redis reported as absent. Supervision is therefore read
+  from the unit state and the listener, both visible to any account.
+
+The remote snippet is extracted from the script and driven against stubbed
+``systemctl`` / ``ss`` / ``redis-cli``, so every branch is exercised without a
+host.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.skipif(
+    sys.platform == "win32" or shutil.which("bash") is None,
+    reason="fleet_status.sh and its test need bash",
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+FLEET_STATUS = REPO_ROOT / "scripts" / "fleet_status.sh"
+
+
+def _remote_snippet() -> str:
+    """The single-quoted REMOTE_SNIPPET body, as it is piped to ``ssh bash -s``."""
+    text = FLEET_STATUS.read_text()
+    marker = "REMOTE_SNIPPET='"
+    start = text.index(marker) + len(marker)
+    end = text.index("\n'\n", start)
+    body = text[start:end]
+    assert "'" not in body, "a bare quote in the snippet would break ssh bash -s"
+    return body
+
+
+SS_LISTENING = "LISTEN 0 511 127.0.0.1:6379 0.0.0.0:*"
+
+
+def _stubs(
+    tmp_path: Path,
+    *,
+    listening: bool,
+    active: str,
+    enabled: str,
+    qserver_unit: bool = False,
+) -> Path:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    substate = "running" if active == "active" else "dead"
+    units = "geecs-qserver.service loaded active running" if qserver_unit else ""
+    (bin_dir / "systemctl").write_text(
+        f"""#!/usr/bin/env bash
+case "$*" in
+    *list-units*)                          [ -n "{units}" ] && echo "{units}"; exit 0 ;;
+    "is-active redis-server.service")      echo {active} ;;
+    "is-enabled redis-server.service")     echo {enabled} ;;
+    "show -p ActiveState --value redis-server.service") echo {active} ;;
+    "show -p SubState --value redis-server.service")    echo {substate} ;;
+    *)                                     exit 0 ;;
+esac
+"""
+    )
+    listener = SS_LISTENING if listening else ""
+    (bin_dir / "ss").write_text(
+        f"""#!/usr/bin/env bash
+case "$*" in
+    *"sport = :6379"*) [ -n "{listener}" ] && echo "{listener}" ;;
+    *)                 exit 0 ;;
+esac
+exit 0
+"""
+    )
+    (bin_dir / "redis-cli").write_text(
+        "#!/usr/bin/env bash\necho 'redis_version:6.0.16'\n"
+    )
+    for stub in bin_dir.iterdir():
+        stub.chmod(0o755)
+    return bin_dir
+
+
+def _redis_record(tmp_path: Path, **kw: object) -> str:
+    bin_dir = _stubs(tmp_path, **kw)  # type: ignore[arg-type]
+    r = subprocess.run(
+        ["bash", "-s"],
+        input=_remote_snippet(),
+        capture_output=True,
+        text=True,
+        env={"PATH": f"{bin_dir}:/usr/bin:/bin", "HOME": str(tmp_path)},
+    )
+    assert r.returncode == 0, r.stderr
+    lines = [ln for ln in r.stdout.splitlines() if ln.startswith("role=Redis")]
+    assert len(lines) == 1, f"expected one Redis record, got {r.stdout!r}"
+    return lines[0]
+
+
+def test_snippet_is_valid_bash() -> None:
+    r = subprocess.run(
+        ["bash", "-n"], input=_remote_snippet(), capture_output=True, text=True
+    )
+    assert r.returncode == 0, r.stderr
+
+
+def test_packaged_redis_owned_by_another_account_is_not_a_false_absence(
+    tmp_path: Path,
+) -> None:
+    """The regression: supervision must not be judged by a pid ``ss`` hides."""
+    rec = _redis_record(tmp_path, listening=True, active="active", enabled="enabled")
+    assert "managed=systemd" in rec
+    assert "state=active/running" in rec
+    assert "version=6.0.16" in rec
+    assert "info=loopback 6379, enabled" in rec
+    assert "note=" not in rec
+
+
+def test_listening_without_the_unit_is_the_launcher_fallback(tmp_path: Path) -> None:
+    """The two-week state: 6379 answers, redis-server.service does not run it."""
+    rec = _redis_record(tmp_path, listening=True, active="inactive", enabled="absent")
+    assert "managed=UNMANAGED" in rec
+    assert "note=answering on 6379 but redis-server.service is inactive" in rec
+    assert "launcher fallback" in rec
+
+
+def test_nothing_listening_is_reported_with_the_consequence(tmp_path: Path) -> None:
+    rec = _redis_record(
+        tmp_path,
+        listening=False,
+        active="inactive",
+        enabled="absent",
+        qserver_unit=True,
+    )
+    assert "note=nothing answering on 6379" in rec
+    assert "UNSUPERVISED redis on the next start" in rec
+
+
+def test_active_but_not_enabled_warns_about_the_next_reboot(tmp_path: Path) -> None:
+    rec = _redis_record(tmp_path, listening=True, active="active", enabled="disabled")
+    assert "managed=systemd" in rec
+    assert "no Redis after a reboot" in rec
+
+
+def test_a_host_with_neither_a_queueserver_nor_a_listener_gets_no_redis_row(
+    tmp_path: Path,
+) -> None:
+    """Redis is reported where it is relevant, not on every host in the fleet."""
+    bin_dir = _stubs(tmp_path, listening=False, active="inactive", enabled="absent")
+    r = subprocess.run(
+        ["bash", "-s"],
+        input=_remote_snippet(),
+        capture_output=True,
+        text=True,
+        env={"PATH": f"{bin_dir}:/usr/bin:/bin", "HOME": str(tmp_path)},
+    )
+    assert r.returncode == 0, r.stderr
+    assert "role=Redis" not in r.stdout

--- a/tests/test_fleet_status_redis_sh.py
+++ b/tests/test_fleet_status_redis_sh.py
@@ -1,23 +1,29 @@
-"""Pin the Redis record ``scripts/fleet_status.sh`` emits over ssh.
+"""Pin the Redis probe in ``scripts/fleet_status.sh``.
 
-Two host findings, 2026-09-06:
+Three host findings, 2026-09-06, each with a test below:
 
-* The queueserver had run for two weeks against a hand-built Redis in no unit,
-  and ``/fleet-status`` could not see it — the script had no Redis awareness at
-  all.
-* The first attempt judged supervision by comparing the unit's ``MainPID`` with
-  the pid owning 6379. ``ss -p`` reveals a pid only for the ssh user's own
-  processes (or root) and the packaged Redis runs as the ``redis`` account, so
-  a healthy supervised Redis reported as absent. Supervision is therefore read
-  from the unit state and the listener, both visible to any account.
+* ``/fleet-status`` had no Redis awareness at all, so the queueserver ran for
+  two weeks against a hand-built Redis in no unit and the tool could not see
+  it — while ``fleet_map.md`` already called an inactive ``redis-server`` unit
+  a finding.
+* Judging supervision by comparing the unit's ``MainPID`` with the pid owning
+  6379 reports a **false absence**: ``ss -p`` reveals a pid only for the ssh
+  user's own processes (or root) and the packaged Redis runs as the ``redis``
+  account.
+* ``systemctl is-active`` *prints* ``inactive`` and exits **3**;
+  ``is-enabled`` prints ``disabled`` and exits **1**. So
+  ``$(systemctl … || echo default)`` captures both strings with a newline
+  between them and splits the one-line record in two — the table drops the
+  second line and the log misreads it as an ssh notice. Every stub here uses
+  systemd's real exit codes, because a stub that exits 0 cannot catch it.
 
-The remote snippet is extracted from the script and driven against stubbed
-``systemctl`` / ``ss`` / ``redis-cli``, so every branch is exercised without a
-host.
+Records are asserted end-to-end through ``fleet_table.parse`` rather than by
+hand-copied fixtures, so the tests cannot fossilize apart from the script.
 """
 
 from __future__ import annotations
 
+import importlib.util
 import shutil
 import subprocess
 import sys
@@ -30,22 +36,27 @@ pytestmark = pytest.mark.skipif(
     reason="fleet_status.sh and its test need bash",
 )
 
+
+def _load(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
 REPO_ROOT = Path(__file__).resolve().parents[1]
+# The snippet extractor and its script-wide invariants live in the sibling
+# module; loaded by path because tests/ is not an importable package.
+_sh = _load(
+    "fleet_status_sh_tests", Path(__file__).with_name("test_fleet_status_sh.py")
+)
+remote_snippet = _sh.remote_snippet
+fleet_table = _load("fleet_table", REPO_ROOT / "scripts" / "fleet_table.py")
+
 FLEET_STATUS = REPO_ROOT / "scripts" / "fleet_status.sh"
-
-
-def _remote_snippet() -> str:
-    """The single-quoted REMOTE_SNIPPET body, as it is piped to ``ssh bash -s``."""
-    text = FLEET_STATUS.read_text()
-    marker = "REMOTE_SNIPPET='"
-    start = text.index(marker) + len(marker)
-    end = text.index("\n'\n", start)
-    body = text[start:end]
-    assert "'" not in body, "a bare quote in the snippet would break ssh bash -s"
-    return body
-
-
 SS_LISTENING = "LISTEN 0 511 127.0.0.1:6379 0.0.0.0:*"
+UNIT_PID = "924686"
 
 
 def _stubs(
@@ -55,112 +66,242 @@ def _stubs(
     active: str,
     enabled: str,
     qserver_unit: bool = False,
+    server_pid: str = UNIT_PID,
+    main_pid: str = UNIT_PID,
+    unit_absent: bool = False,
 ) -> Path:
+    """Stub ``systemctl``/``ss``/``redis-cli`` with systemd's real exit codes."""
     bin_dir = tmp_path / "bin"
     bin_dir.mkdir()
     substate = "running" if active == "active" else "dead"
     units = "geecs-qserver.service loaded active running" if qserver_unit else ""
-    (bin_dir / "systemctl").write_text(
-        f"""#!/usr/bin/env bash
+    # is-active: 0 only for "active". is-enabled: 0 only for "enabled". Both
+    # print the state on the failing paths too — the bug this file exists for.
+    # With no unit file at all (the real two-week state) systemd prints
+    # "inactive" for is-active, sends is-enabled's "Failed to get unit file
+    # state" to stderr with nothing on stdout, and `show` yields empty values.
+    if unit_absent:
+        systemctl = f"""#!/usr/bin/env bash
 case "$*" in
-    *list-units*)                          [ -n "{units}" ] && echo "{units}"; exit 0 ;;
-    "is-active redis-server.service")      echo {active} ;;
-    "is-enabled redis-server.service")     echo {enabled} ;;
-    "show -p ActiveState --value redis-server.service") echo {active} ;;
-    "show -p SubState --value redis-server.service")    echo {substate} ;;
-    *)                                     exit 0 ;;
+    *list-units*)                      [ -n "{units}" ] && echo "{units}"; exit 0 ;;
+    "is-active redis-server.service")  echo inactive; exit 3 ;;
+    "is-enabled redis-server.service") echo "Failed to get unit file state for redis-server.service: No such file or directory" >&2; exit 1 ;;
+    "show -p"*"redis-server.service")  exit 0 ;;
+    *) exit 0 ;;
 esac
 """
-    )
+    else:
+        systemctl = f"""#!/usr/bin/env bash
+case "$*" in
+    *list-units*)                      [ -n "{units}" ] && echo "{units}"; exit 0 ;;
+    "is-active redis-server.service")  echo {active};  [ "{active}" = active ] || exit 3 ;;
+    "is-enabled redis-server.service") echo {enabled}; [ "{enabled}" = enabled ] || exit 1 ;;
+    "show -p ActiveState --value redis-server.service") echo {active} ;;
+    "show -p SubState --value redis-server.service")    echo {substate} ;;
+    "show -p MainPID --value redis-server.service")     echo {main_pid} ;;
+    *) exit 0 ;;
+esac
+"""
+    (bin_dir / "systemctl").write_text(systemctl)
     listener = SS_LISTENING if listening else ""
     (bin_dir / "ss").write_text(
         f"""#!/usr/bin/env bash
 case "$*" in
     *"sport = :6379"*) [ -n "{listener}" ] && echo "{listener}" ;;
-    *)                 exit 0 ;;
 esac
 exit 0
 """
     )
-    (bin_dir / "redis-cli").write_text(
-        "#!/usr/bin/env bash\necho 'redis_version:6.0.16'\n"
+    body = (
+        f"echo 'redis_version:6.0.16'\necho 'process_id:{server_pid}'\n"
+        if listening
+        else "exit 1\n"
     )
+    (bin_dir / "redis-cli").write_text("#!/usr/bin/env bash\n" + body)
     for stub in bin_dir.iterdir():
         stub.chmod(0o755)
     return bin_dir
 
 
-def _redis_record(tmp_path: Path, **kw: object) -> str:
+def _stdout(tmp_path: Path, **kw: object) -> str:
     bin_dir = _stubs(tmp_path, **kw)  # type: ignore[arg-type]
     r = subprocess.run(
         ["bash", "-s"],
-        input=_remote_snippet(),
+        input=remote_snippet(),
         capture_output=True,
         text=True,
         env={"PATH": f"{bin_dir}:/usr/bin:/bin", "HOME": str(tmp_path)},
     )
     assert r.returncode == 0, r.stderr
-    lines = [ln for ln in r.stdout.splitlines() if ln.startswith("role=Redis")]
-    assert len(lines) == 1, f"expected one Redis record, got {r.stdout!r}"
-    return lines[0]
+    return r.stdout
 
 
-def test_snippet_is_valid_bash() -> None:
-    r = subprocess.run(
-        ["bash", "-n"], input=_remote_snippet(), capture_output=True, text=True
+def _record(tmp_path: Path, **kw: object) -> str:
+    """The one Redis record, asserting the protocol: exactly one line."""
+    out = _stdout(tmp_path, **kw)
+    redis_lines = [ln for ln in out.splitlines() if "Redis" in ln or "redis" in ln]
+    assert len(redis_lines) == 1, (
+        "the record protocol is one line per probe; a split record is dropped "
+        f"by fleet_table and misread as an ssh notice by the log. Got: {out!r}"
     )
-    assert r.returncode == 0, r.stderr
+    assert redis_lines[0].startswith("role=Redis"), out
+    return redis_lines[0]
+
+
+def _row(tmp_path: Path, **kw: object) -> dict[str, str]:
+    rec = _record(tmp_path, **kw)
+    return fleet_table.parse([rec + "\n"])["Redis"]
 
 
 def test_packaged_redis_owned_by_another_account_is_not_a_false_absence(
     tmp_path: Path,
 ) -> None:
     """The regression: supervision must not be judged by a pid ``ss`` hides."""
-    rec = _redis_record(tmp_path, listening=True, active="active", enabled="enabled")
-    assert "managed=systemd" in rec
-    assert "state=active/running" in rec
-    assert "version=6.0.16" in rec
-    assert "info=loopback 6379, enabled" in rec
-    assert "note=" not in rec
+    row = _row(tmp_path, listening=True, active="active", enabled="enabled")
+    assert fleet_table.glyph(row) == "✓"
+    assert fleet_table.notes(row) == []
+    assert fleet_table.version(row) == "6.0.16"
+    assert fleet_table.infos(row) == ["loopback 6379, enabled"]
 
 
 def test_listening_without_the_unit_is_the_launcher_fallback(tmp_path: Path) -> None:
     """The two-week state: 6379 answers, redis-server.service does not run it."""
-    rec = _redis_record(tmp_path, listening=True, active="inactive", enabled="absent")
-    assert "managed=UNMANAGED" in rec
-    assert "note=answering on 6379 but redis-server.service is inactive" in rec
-    assert "launcher fallback" in rec
+    row = _row(tmp_path, listening=True, active="inactive", enabled="absent")
+    assert fleet_table.glyph(row) == "!"
+    notes = " ".join(fleet_table.notes(row))
+    assert "launcher fallback" in notes
+    # Exits 3 while printing "inactive": the state must appear once, not twice.
+    assert notes.count("inactive") == 1, notes
+    assert "no systemd unit" in notes
 
 
 def test_nothing_listening_is_reported_with_the_consequence(tmp_path: Path) -> None:
-    rec = _redis_record(
+    row = _row(
         tmp_path,
         listening=False,
         active="inactive",
         enabled="absent",
         qserver_unit=True,
     )
-    assert "note=nothing answering on 6379" in rec
-    assert "UNSUPERVISED redis on the next start" in rec
+    # Not the "not deployed here" dot: a missing state store is a real finding.
+    assert fleet_table.glyph(row) == "✗"
+    assert "nothing answering on 6379" in " ".join(fleet_table.notes(row))
 
 
 def test_active_but_not_enabled_warns_about_the_next_reboot(tmp_path: Path) -> None:
-    rec = _redis_record(tmp_path, listening=True, active="active", enabled="disabled")
-    assert "managed=systemd" in rec
-    assert "no Redis after a reboot" in rec
+    row = _row(tmp_path, listening=True, active="active", enabled="disabled")
+    assert fleet_table.glyph(row) == "!"
+    notes = " ".join(fleet_table.notes(row))
+    assert "no Redis after a reboot" in notes
+    # is-enabled exits 1 while printing "disabled" — once, not "disabled absent".
+    assert "disabled" in notes and "absent" not in notes
+
+
+def test_unit_active_but_another_server_holds_the_port(tmp_path: Path) -> None:
+    """The residual hole: the unit is up, yet 6379 belongs to something else."""
+    row = _row(
+        tmp_path,
+        listening=True,
+        active="active",
+        enabled="enabled",
+        server_pid="453172",
+        main_pid=UNIT_PID,
+    )
+    assert fleet_table.glyph(row) == "!"
+    assert "the unit does not supervise" in " ".join(fleet_table.notes(row))
 
 
 def test_a_host_with_neither_a_queueserver_nor_a_listener_gets_no_redis_row(
     tmp_path: Path,
 ) -> None:
     """Redis is reported where it is relevant, not on every host in the fleet."""
-    bin_dir = _stubs(tmp_path, listening=False, active="inactive", enabled="absent")
+    out = _stdout(tmp_path, listening=False, active="inactive", enabled="absent")
+    assert "role=Redis" not in out
+
+
+def test_a_lone_redis_row_does_not_also_report_nothing_found(tmp_path: Path) -> None:
+    out = _stdout(tmp_path, listening=True, active="active", enabled="enabled")
+    assert "role=Redis" in out
+    assert "nounits" not in out
+
+
+def _fmt_host_records() -> str:
+    """The log formatter, sliced out of the script for direct testing."""
+    text = FLEET_STATUS.read_text()
+    start = text.index("fmt_host_records() {")
+    end = text.index("\n}\n", start) + len("\n}\n")
+    return text[start:end]
+
+
+def test_the_full_log_surfaces_the_note_not_just_the_header(tmp_path: Path) -> None:
+    """``--summary`` is not the only reader: the default log must warn too.
+
+    Before this, ``fmt_host_records`` parsed a fixed key list with no
+    ``note=``/``info=``, so the unsupervised Redis printed ``[ OK ]`` and the
+    missing one printed a bare ``[DOWN]`` with no explanation and nothing in
+    the attention lines an operator scans.
+    """
+    rec = _record(tmp_path, listening=True, active="inactive", enabled="absent")
+    harness = (
+        "ok(){ printf '  [ OK ] %s\\n' \"$1\"; }\n"
+        "bad(){ printf '  [DOWN] %s\\n' \"$1\"; }\n"
+        "warn(){ printf '  [WARN] %s\\n' \"$1\"; }\n"
+        "info(){ printf '         %s\\n' \"$1\"; }\n"
+        "skip(){ printf '  [ -- ] %s\\n' \"$1\"; }\n"
+        "rec(){ :; }\nnote_sha(){ :; }\n" + _fmt_host_records() + "fmt_host_records\n"
+    )
+    # The record arrives on the function's stdin, so the harness script
+    # itself cannot come from stdin — pass it as -c and the record via env.
     r = subprocess.run(
-        ["bash", "-s"],
-        input=_remote_snippet(),
+        ["bash", "-c", 'printf "%s\\n" "$REC_IN" | { ' + harness + " }"],
         capture_output=True,
         text=True,
-        env={"PATH": f"{bin_dir}:/usr/bin:/bin", "HOME": str(tmp_path)},
+        env={"PATH": "/usr/bin:/bin", "HOME": str(tmp_path), "REC_IN": rec},
     )
     assert r.returncode == 0, r.stderr
-    assert "role=Redis" not in r.stdout
+    assert "[WARN]" in r.stdout, r.stdout
+    assert "launcher fallback" in r.stdout, r.stdout
+
+
+def test_listening_with_no_unit_file_at_all_is_the_two_week_state(
+    tmp_path: Path,
+) -> None:
+    """The literal state found on the host: 6379 answers, no unit file exists.
+
+    ``systemctl is-enabled`` writes "Failed to get unit file state" to stderr
+    with nothing on stdout, and ``show`` yields empty values — the row must
+    still be a finding about supervision, not a dead service.
+    """
+    row = _row(
+        tmp_path,
+        listening=True,
+        active="inactive",
+        enabled="absent",
+        unit_absent=True,
+    )
+    assert fleet_table.glyph(row) == "!"
+    assert row.get("proc_state", "").startswith("running")
+    assert "launcher fallback" in " ".join(fleet_table.notes(row))
+
+
+def test_no_state_store_and_no_unit_is_down_not_the_not_deployed_dot(
+    tmp_path: Path,
+) -> None:
+    """With no unit file, ``show`` yields empty and the state would read ``/``.
+
+    Naming that ``absent/...`` made ``fleet_table.glyph`` treat it as the
+    "not deployed on this host" dot, rendering a missing state store as
+    benign. It must read as down.
+    """
+    row = _row(
+        tmp_path,
+        listening=False,
+        active="inactive",
+        enabled="absent",
+        unit_absent=True,
+        qserver_unit=True,
+    )
+    assert fleet_table.glyph(row) == "✗", (
+        "a missing state store must not read as benign"
+    )
+    assert "nothing answering on 6379" in " ".join(fleet_table.notes(row))

--- a/tests/test_fleet_status_sh.py
+++ b/tests/test_fleet_status_sh.py
@@ -1,0 +1,50 @@
+"""Invariants of ``scripts/fleet_status.sh``'s remote ssh snippet.
+
+These hold for the whole snippet regardless of which probe is being changed,
+so they live here rather than beside any one probe's tests.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.skipif(
+    sys.platform == "win32" or shutil.which("bash") is None,
+    reason="fleet_status.sh and its test need bash",
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+FLEET_STATUS = REPO_ROOT / "scripts" / "fleet_status.sh"
+
+
+def remote_snippet() -> str:
+    """The single-quoted REMOTE_SNIPPET body, as piped to ``ssh bash -s``."""
+    text = FLEET_STATUS.read_text()
+    marker = "REMOTE_SNIPPET='"
+    start = text.index(marker) + len(marker)
+    end = text.index("\n'\n", start)
+    return text[start:end]
+
+
+def test_snippet_contains_no_bare_single_quote() -> None:
+    """A quote inside it would end the shell string and break ssh bash -s."""
+    assert "'" not in remote_snippet()
+
+
+def test_snippet_is_valid_bash() -> None:
+    r = subprocess.run(
+        ["bash", "-n"], input=remote_snippet(), capture_output=True, text=True
+    )
+    assert r.returncode == 0, r.stderr
+
+
+def test_script_itself_is_valid_bash() -> None:
+    r = subprocess.run(
+        ["bash", "-n", str(FLEET_STATUS)], capture_output=True, text=True
+    )
+    assert r.returncode == 0, r.stderr

--- a/tests/test_fleet_table.py
+++ b/tests/test_fleet_table.py
@@ -77,3 +77,42 @@ def test_real_findings_still_mark_attention() -> None:
     rec = m["Data Portal"]
     assert fleet_table.glyph(rec) == "!"
     assert fleet_table.notes(rec) == ["venv 0.20.1 ≠ pyproject 0.20.2"]
+
+
+def test_supervised_redis_is_a_clean_row_unsupervised_is_a_finding() -> None:
+    """The Redis row's whole job: answering is not the same as supervised.
+
+    Host finding 2026-09-06 — the queueserver ran for two weeks against a
+    hand-built Redis in no unit, because ``launch_re_manager.sh`` starts its
+    own daemonized ``redis-server`` whenever nothing answers on 6379.
+    """
+    m = _merged(
+        "role=Redis\tsvc=redis-server.service\tmanaged=systemd\tstate=active/running\tversion=6.0.16\tinfo=loopback 6379, enabled"
+    )
+    rec = m["Redis"]
+    assert fleet_table.glyph(rec) == "✓"
+    assert fleet_table.notes(rec) == []
+    assert fleet_table.version(rec) == "6.0.16"
+
+    m = _merged(
+        "role=Redis\tsvc=redis :6379\tmanaged=geecs-qserver.service\tstate=running pid 453172\tversion=8.10.1\tnote=answering on 6379 but NOT supervised by redis-server.service (owner: geecs-qserver.service) — the launcher fallback"
+    )
+    rec = m["Redis"]
+    assert fleet_table.glyph(rec) == "!"
+    assert len(fleet_table.notes(rec)) == 1
+    assert "NOT supervised" in fleet_table.notes(rec)[0]
+
+
+def test_absent_redis_is_down() -> None:
+    m = _merged(
+        "role=Redis\tsvc=redis :6379\tmanaged=none\tstate=down\tnote=nothing on 6379 — the queueserver keeps no queue/history/permissions"
+    )
+    rec = m["Redis"]
+    assert fleet_table.glyph(rec) == "✗"
+
+
+def test_redis_sorts_after_the_services_that_depend_on_it() -> None:
+    """Display order: the state store reads below its consumers, not above."""
+    order = fleet_table.ROLE_ORDER
+    assert order.index("Redis") > order.index("Queueserver RE Manager")
+    assert order.index("Redis") > order.index("Capture daemon")

--- a/tests/test_fleet_table.py
+++ b/tests/test_fleet_table.py
@@ -79,40 +79,13 @@ def test_real_findings_still_mark_attention() -> None:
     assert fleet_table.notes(rec) == ["venv 0.20.1 ≠ pyproject 0.20.2"]
 
 
-def test_supervised_redis_is_a_clean_row_unsupervised_is_a_finding() -> None:
-    """The Redis row's whole job: answering is not the same as supervised.
-
-    Host finding 2026-09-06 — the queueserver ran for two weeks against a
-    hand-built Redis in no unit, because ``launch_re_manager.sh`` starts its
-    own daemonized ``redis-server`` whenever nothing answers on 6379.
-    """
-    m = _merged(
-        "role=Redis\tsvc=redis-server.service\tmanaged=systemd\tstate=active/running\tversion=6.0.16\tinfo=loopback 6379, enabled"
-    )
-    rec = m["Redis"]
-    assert fleet_table.glyph(rec) == "✓"
-    assert fleet_table.notes(rec) == []
-    assert fleet_table.version(rec) == "6.0.16"
-
-    m = _merged(
-        "role=Redis\tsvc=redis :6379\tmanaged=geecs-qserver.service\tstate=running pid 453172\tversion=8.10.1\tnote=answering on 6379 but NOT supervised by redis-server.service (owner: geecs-qserver.service) — the launcher fallback"
-    )
-    rec = m["Redis"]
-    assert fleet_table.glyph(rec) == "!"
-    assert len(fleet_table.notes(rec)) == 1
-    assert "NOT supervised" in fleet_table.notes(rec)[0]
-
-
-def test_absent_redis_is_down() -> None:
-    m = _merged(
-        "role=Redis\tsvc=redis :6379\tmanaged=none\tstate=down\tnote=nothing on 6379 — the queueserver keeps no queue/history/permissions"
-    )
-    rec = m["Redis"]
-    assert fleet_table.glyph(rec) == "✗"
-
-
 def test_redis_sorts_after_the_services_that_depend_on_it() -> None:
-    """Display order: the state store reads below its consumers, not above."""
+    """Display order: the state store reads below its consumers, not above.
+
+    The Redis row's glyph and notes are asserted in
+    ``test_fleet_status_redis_sh.py`` against records the script really
+    emits, not hand-copied fixtures that can fossilize apart from it.
+    """
     order = fleet_table.ROLE_ORDER
     assert order.index("Redis") > order.index("Queueserver RE Manager")
     assert order.index("Redis") > order.index("Capture daemon")


### PR DESCRIPTION
## What + why

Redis was the one service on the box that no part of our tooling knew about,
and that is how it went unnoticed for two weeks. The queueserver was running
against a **source-built Redis 8.10.1 in no unit**, started once by hand, in
nobody's dependency graph:

- `deploy/bootstrap_host.sh` never installed or enabled it, so a fresh box
  gets none.
- `scripts/fleet_status.sh` had **zero** references to it, so `/fleet-status`
  could not report it — even though `docs/platform/fleet_map.md` already
  states that "an inactive `redis-server` unit on a service host is a
  finding". The doc asserted a finding nothing checked.

What makes the gap self-concealing: `launch_re_manager.sh` starts its own
`${QS_REDIS_SERVER:-redis-server} --daemonize yes` whenever nothing answers
on 6379, and `geecs-qserver.service` merely orders `After=` the Redis unit
without requiring it. So a host that never got the package does not fail
loudly — it silently acquires an **unsupervised** Redis that dies with
whatever started it, is absent after a reboot, and comes back empty.

The host was migrated to the packaged Redis under its unit on 2026-09-06.
This PR closes the two code gaps that let it drift, plus the runbook trap
that migration hit. It is the last site-profile Phase 4 item.

## Per-concern LOC breakdown

| Concern | Files | +/- |
|---|---|---|
| fleet-status reports Redis supervision | `scripts/fleet_status.sh`, `scripts/fleet_table.py` | +43 |
| bootstrap installs/enables the package | `deploy/bootstrap_host.sh` | +30 |
| runbook: the RDB trap + launcher fallback | `GeecsBluesky/qserver/deploy/redis.conf-notes.md`, `CHANGELOG.md`, `pyproject.toml` | +71/-1 |
| fleet map: the finding is now detected | `docs/platform/fleet_map.md` | +5/-1 |
| tests | `tests/test_fleet_status_redis_sh.py`, `tests/test_bootstrap_host_sh.py`, `tests/test_fleet_table.py` | +310 |

## Supervision is judged by the unit, never by a pid

Worth flagging because the first attempt got it wrong and a live run caught
it. Comparing `redis-server.service`'s `MainPID` against the pid owning 6379
reports a **false absence**: `ss -p` reveals pids only for the ssh user's own
processes (or root), and the packaged Redis runs as the `redis` account. A
perfectly healthy supervised Redis showed as `[DOWN] nothing on 6379`. The
listener is now read without `-p` and supervision comes from the unit state,
both visible to any account. `tests/test_fleet_status_redis_sh.py::
test_packaged_redis_owned_by_another_account_is_not_a_false_absence` pins it.

The Redis row is emitted only where it is relevant — a queueserver unit on
the host, or something already on 6379 — so other fleet hosts stay quiet.

## The runbook trap

Carrying the spike's `dump.rdb` onto the package failed: Redis 8.10.1 writes
**RDB format version 15**, the jammy package is 6.0.16 and reads to version
9. It exits with `Can't handle RDB format version 15`, logged to
`/var/log/redis/redis-server.log` and **not** the journal, which shows only
`status=1/FAILURE` and a restart-throttle. The notes now send you to that
logfile first and say to start empty instead, spelling out what that
discards: `qs_default_plan_queue` (the **pending queue**) and
`qs_default_plan_history` hold data nothing recreates, while permissions come
back from `user_group_permissions.yaml` via the launcher's
`--user-group-permissions` on every start. (An earlier revision of this PR
claimed only history was at risk; adversarial review caught it, and the key
list was verified against the `bluesky_queueserver` installed on the host.)

## Tests

Run from this worktree:

- `tests/test_fleet_status_redis_sh.py` — **10 passed**. Extracts the remote
  ssh snippet and drives it against stubbed `systemctl`/`ss`/`redis-cli`:
  supervised-and-enabled, supervised-but-disabled, listening-without-the-unit
  (the two-week state), nothing-listening, no-Redis-row-on-an-unrelated-host,
  plus `bash -n` on the snippet and an assertion that it contains no bare
  quote (which would break `ssh bash -s`).
- `tests/test_bootstrap_host_sh.py` — **5 passed**. Stubs `systemctl` so both
  branches are deterministic: the root step appears when the unit is not
  enabled and precedes the `geecs-qserver` enable line, is absent when it is
  enabled, and is skipped under `--only portal`.
- `tests/test_fleet_table.py` — **7 passed** (1 new): `Redis` sorts below its
  consumers in `ROLE_ORDER`. The row's glyph and notes are asserted in the
  snippet tests against records the script really emits, so no fixture can
  fossilize apart from it.
- `tests/test_fleet_status_sh.py` — **3 passed** (new): script-wide snippet
  invariants (valid bash, no bare single quote, valid script).
- `./scripts/check.sh --lint` — **OK**, all hooks pass.
- `./scripts/check.sh` root suite — **64 passed, 1 skipped, 63 deselected**.
- `./scripts/check.sh GeecsBluesky` — **not runnable in this worktree**
  (`ModuleNotFoundError: No module named 'bluesky'`; the worktree has no
  GeecsBluesky env). The GeecsBluesky change is docs + version bump with no
  Python touched, so CI covers it.

## Live verification

`scripts/fleet_status.sh --summary` against the services box, after the
migration:

```
│ ✓ │ Redis        │ systemd    │ —                        │ 6.0.16         │ loopback 6379, enabled │
```

All other rows unchanged and green. The pre-fix run on the same host is the
false-absence bug described above, which is what prompted the pid rewrite.

No hardware verification section: this touches no scan execution or device
code.

## Adversarial review

Reviewed at commit eef3922c; seven findings, all fixed in ef8057c8 and
re-verified by the same reviewer. The report and disposition are in the PR
comments. Two were serious: `systemctl` prints a state *and* exits non-zero,
so `$(cmd || echo default)` captured both and split the one-line record in
two; and `fmt_host_records` never rendered `note=`/`info=`, so the default
full log showed a bare `[ OK ]` for the very state this PR exists to catch.
Each fix is mutation-tested — reintroducing the bug fails a named test.
