### PR TITLE
[ON HOLD] GeecsBluesky 0.79.0: the preamble as a RunEngine preprocessor (#807 B1) — superseded by #810

### DIFF
--- a/GeecsBluesky/CHANGELOG.md
+++ b/GeecsBluesky/CHANGELOG.md
@@ -4,6 +4,39 @@ All notable changes to `geecs-bluesky` are documented here.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.78.0] - 2026-09-09
+
+### Added
+
+- **`preprocessors.geecs_preamble`** (GEECS-Plugins#807 phase 2) — the GEECS
+  scan preamble and finalize chain as one RunEngine preprocessor, keyed on
+  `md["geecs"]`. A stock `bluesky.plans` verb whose run metadata carries a
+  ScanRequest now gets, before its run opens: validation, name resolution,
+  the shot controller, the unserved/CONNECTED preflights, action slots, the
+  capture toggle, the preamble's own connects, the **scan-number claim**,
+  the ScanInfo write, native-save configuration, setup actions, arm and
+  save-on — and the GEECS run metadata injected into its start document.
+  On the way out, in the funnel's nesting order: save-off, disarm, closeout,
+  disconnect.
+
+  ```python
+  RE(bp.count([cam], num=5, md={"geecs": request}))   # a full GEECS scan
+  ```
+
+  It is the funnel's own code (`plans/preamble.py`), not a second copy; the
+  preprocessor supplies only the seam and the ordering. `install_geecs_preamble`
+  keeps `connect_on_demand` outermost.
+
+  The request must ride in the **plan's** `md=`: RunEngine per-call metadata
+  (`RE(plan, geecs=...)`) never enters a message, so a preprocessor cannot
+  see it. Pinned by a test.
+- `plans/run_wrapper.claimed_scan_metadata()` — the GEECS run-metadata
+  assembly (and the capture-dir creation it implies) split out of
+  `geecs_run_wrapper` so the funnel door and the stock-plan door cannot
+  drift from what the downstream readers require.
+- `GeecsNamespace.variable_names()` — the served scalar names a namespace
+  device has children for.
+
 ## [0.77.1] - 2026-09-09
 
 ### Changed

--- a/GeecsBluesky/CHANGELOG.md
+++ b/GeecsBluesky/CHANGELOG.md
@@ -4,6 +4,29 @@ All notable changes to `geecs-bluesky` are documented here.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.78.1] - 2026-09-09
+
+### Fixed
+
+- **Save windowing in `geecs_preamble`** (Gate-2): it armed the controller
+  and *then* enabled saving, so saving switched on while external edges were
+  already passing and every shot until the first recorded one wrote an orphan
+  frame. The order is now `arm_single_shot` (ARMED — single-shot source, free
+  run halted, quiescence confirmed) → save-on, with save-off still the
+  innermost finalize so saving stops before disarm releases edges. Pinned by
+  asserting the ordered shot-control writes.
+
+### Changed
+
+- `geecs_preamble` is **strict-only**: a free-run request is refused before
+  anything is claimed (free-run is retired, GEECS-Plugins#807), as is a
+  strict request with no trigger profile.
+- **The shot is fired by the preprocessor**, between the detectors' `trigger`
+  messages and the `wait` on their group — the gap `bps.trigger_and_read`
+  cannot express and the reason `plans/single_shot.py` exists. A **stock**
+  plan therefore needs no `per_shot` hook: `RE(bp.count([cam], num=5,
+  md={"geecs": request}))` fires every shot itself.
+
 ## [0.78.0] - 2026-09-09
 
 ### Added

--- a/GeecsBluesky/CHANGELOG.md
+++ b/GeecsBluesky/CHANGELOG.md
@@ -18,6 +18,16 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
+- **Hardware-accepted 2026-09-09** on the Undulator machine: a stock
+  `bp.count` ran as a noscan (scan 61 — 3 shots, the preprocessor firing
+  each one) and a stock `bp.list_scan` ran as a step scan (scan 62 — the
+  catalog axis `S1H` swept −1 → +1 A in 0.5 A steps, readbacks within
+  0.4 mA, setpoint restored). Both claimed real scan numbers, wrote their
+  `ScanInfo` ini, and recorded the full detector surface — `shot_id`,
+  `shot_offset`, `nonscalar_save_path`, the image asset — so the composed
+  namespace device keeps every capability the per-scan classes had. The
+  catalog axis resolved to `U_S1H:Current` and to the same object the plan
+  moved.
 - `geecs_preamble` is **strict-only**: a free-run request is refused before
   anything is claimed (free-run is retired, GEECS-Plugins#807), as is a
   strict request with no trigger profile.

--- a/GeecsBluesky/CHANGELOG.md
+++ b/GeecsBluesky/CHANGELOG.md
@@ -4,6 +4,25 @@ All notable changes to `geecs-bluesky` are documented here.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.77.1] - 2026-09-09
+
+### Changed
+
+- **Scan preamble extracted to `plans/preamble.py`** (GEECS-Plugins#807
+  phase 2, step A) — a pure move, no behaviour change. `resolve_request`
+  (validation + trigger profile → `ShotController` + strict decision, shared
+  with optimize) and `prepare_step_scan` (save sets, preflights, action
+  slots, axis resolution, capture toggle, deferred construction, the in-plan
+  connect batches, the fail-fast gates, the metadata spec) now have **one
+  implementation with two callers**: `geecs_scan_request_plan`, unchanged in
+  behaviour, and — next — the RunEngine preprocessor that gives stock
+  `bluesky.plans` verbs the same preamble. `_DeferredConnectFactories`, the
+  connect/disconnect plan stubs and their two constants moved with the code.
+  `PreparedScan.as_claimed_kwargs()` keeps the funnel's
+  `build_claimed_scan_plan` call a one-liner.
+  Tests that patch `make_scalar_policy` / `ShotController` by module path now
+  target `geecs_bluesky.plans.preamble`.
+
 ## [0.77.0] - 2026-09-09
 
 ### Added

--- a/GeecsBluesky/CHANGELOG.md
+++ b/GeecsBluesky/CHANGELOG.md
@@ -22,6 +22,20 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   `build_claimed_scan_plan` call a one-liner.
   Tests that patch `make_scalar_policy` / `ShotController` by module path now
   target `geecs_bluesky.plans.preamble`.
+- **Device-source seam** on `prepare_step_scan(..., namespace=...)`
+  (#807 phase 2): `None` keeps the funnel's per-scan construction; a
+  `GeecsNamespace` makes the save set **select** namespace devices instead
+  (`plans/preamble.namespace_detectors`), so a stock plan's detectors and
+  the preamble's are the same objects — two objects for one device would
+  double the connections and configure saving on something the plan never
+  reads. Save-set roles are asserted against the namespace's triggerable
+  classification, and a save set recording scalars the device does not read
+  is refused rather than silently logging different columns.
+- `NonScalarSaveSupport.configure_saving_mode()` — native-save mode as a
+  **per-run** setting. The per-scan classes fix it at construction, which a
+  long-lived namespace device cannot do (the same camera saves natively in
+  one scan and is capture-owned in the next). It only sets the flags; the
+  two control children are the device's own served settables.
 - `GeecsSession.configure_claimed_scan()` — the post-claim tail (ScanInfo
   write → role wiring → native-save configuration) split out of
   `build_claimed_scan_plan`, which now calls it. The preamble preprocessor

--- a/GeecsBluesky/CHANGELOG.md
+++ b/GeecsBluesky/CHANGELOG.md
@@ -22,6 +22,11 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   `build_claimed_scan_plan` call a one-liner.
   Tests that patch `make_scalar_policy` / `ShotController` by module path now
   target `geecs_bluesky.plans.preamble`.
+- `GeecsSession.configure_claimed_scan()` — the post-claim tail (ScanInfo
+  write → role wiring → native-save configuration) split out of
+  `build_claimed_scan_plan`, which now calls it. The preamble preprocessor
+  needs that tail without building an inner plan (the stock plan *is* the
+  inner plan), so this keeps one implementation rather than a copy.
 
 ## [0.77.0] - 2026-09-09
 

--- a/GeecsBluesky/CHANGELOG.md
+++ b/GeecsBluesky/CHANGELOG.md
@@ -4,6 +4,127 @@ All notable changes to `geecs-bluesky` are documented here.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.79.0] - 2026-09-09
+
+Adversarial review of the phase-2 door (GEECS-Plugins#807, PR #809).  Every
+finding was about the same thing: what the ScanRequest funnel guaranteed **by
+construction** — one list of devices, one topology per axis, disposable
+per-scan objects — is, on the stock-plan door, a precondition on the caller.
+Each is now either enforced or refused, and the acceptance test the plan of
+record specified is in the suite.
+
+### Fixed
+
+- **Per-run device state leaked between runs.** A namespace device is a
+  long-lived noun, so the saving mode, save path, asset definitions and
+  shot-ID origin one run configured stayed set on it. An unrelated later
+  plan emitted a `nonscalar_save_path` column — and external asset
+  documents — resolving into the *previous* scan's folder. Every mixin that
+  holds per-run state now has a cooperative `reset_run_configuration`
+  (`devices/reset_support.py` chains them along the MRO), and
+  `GeecsNamespace.reset_run_configuration()` clears the whole namespace both
+  before a run configures it and on the way out.
+- **The `acq_timestamp` s-file header went missing on the stock door.** The
+  detector constructors add it when their save flags are fixed at build
+  time; a namespace device gets its mode per-run, so the header now follows
+  `configure_saving_mode`. Without it a saved scan's images have no join
+  key back to its rows.
+- **A stock scan wrote no `scans/ScanNNN/scan.log`.** The preamble now
+  attaches the per-scan log handler around the forwarded run, as the funnel
+  does, so `/triage` can read these scans.
+- **Capture-owned cameras were not driven `save="off"`.** Extracted as
+  `run_wrapper.save_control_only_off_plan` and called from both doors.
+- **The scan motors were missing from `geecs_scalar_headers`**, so the
+  Tiled→s-file exporter could not put the legacy `Device Variable` header
+  back on the axis column. The namespace also stopped contributing headers
+  for settable children it does not read — phantom column names.
+- **The raw ScanRequest rode into every start document** as a `geecs` key
+  no consumer declares and the funnel never emits. Dropped; the resolved
+  picture was already there.
+- **`install_geecs_preamble` re-derived `connect_on_demand`'s
+  configuration** instead of carrying it, so re-installing after a mock
+  worker's `install_connect_on_demand(RE, mock=True)` would have sent that
+  worker at real Channel Access.
+
+### Changed
+
+- **The stock door reuses `geecs_single_shot`'s refire.** The message-level
+  fire had the arm→fire→wait seam but none of the recovery around it: a
+  dropped frame (~1% per shot, live-measured) propagated a `FailedStatus`
+  into a stock plan that has no handler, aborting the run — at that rate a
+  100-shot scan aborts more often than not. The retry loop, the bounded
+  refire and the gateway-liveness gating are now one implementation,
+  `plans/single_shot.fire_and_await_shot`, called by `geecs_single_shot`
+  and by the preprocessor (which hands it the plan's pending `wait`).
+- **Background telemetry reaches the event again.** It was prepared,
+  connected and advertised, but a stock plan reads only its own detectors,
+  so no telemetry column was ever emitted. The preprocessor now inserts the
+  reads between the plan's last `read` and its `save`: still one row, still
+  the `primary` stream, no schema change.
+- **The GEECS execution keys are shared.** `acquisition_mode`,
+  `geecs_event_schema`, `fires_own_shots`, `motor`, `positions` and
+  `shots_per_step` — read by `tiled_catalog` and `tiled_schema` — come from
+  one `plans/step_scan.geecs_execution_md`, so a scan cannot be recorded
+  differently depending on which door ran it.
+- **Save-set selection moved to the namespace** as
+  `GeecsNamespace.select(devices_config)`, replacing
+  `plans/preamble.namespace_detectors`: it emits no plan messages, and as a
+  method it uses the namespace's own `_SYNTHESIZED` set and triggerable
+  classification instead of re-deriving them, which also lets
+  `variable_names` go back to being private.
+- The worker-wide default session moved to **`geecs_bluesky/plan_session.py`**
+  (`set_plan_session` / new `get_plan_session`). It has two consumers now,
+  and the preprocessor should not import a private name from the funnel
+  module that phase C deletes. Re-exported from `plans/scan_request_plan`.
+- **The queueserver installs the preamble** (`qserver/startup/startup.py`),
+  so the door is reachable from the worker rather than hand-driven sessions
+  only. A plan without `md["geecs"]` is untouched.
+
+### Added — refusals, where the funnel's guarantee cannot be kept
+
+- A plan that does **not read every device the save set records** is refused
+  before the claim. Saving files for a device with no `acq_timestamp` row to
+  join them to is the orphan-frame failure the Gate-2 windowing exists to
+  prevent, arriving from the other side.
+- A plan whose **shape contradicts the request it is recorded as** is
+  refused: `bp.count(num=2)` under a request declaring `shots_per_step: 5`
+  would write ScanInfo and a catalog row its own data contradicts. Equal
+  point counts do not hide a different set of points either — each
+  commanded position is checked against the declared list.
+- **Scan-axis topologies the namespace cannot build** are refused rather
+  than degraded: a pseudo/composite variable, a `confirm:` target, and a
+  `kind: motor` variable with no positive DB tolerance. Silently handing
+  back a fire-and-forget setpoint would let a stock `list_scan` step to the
+  next point before the readback converged — every row at the wrong
+  position, with nothing in the data saying so. They arrive with the
+  catalog axes in phase 3.
+
+### Testing
+
+- 11 new tests (19 in `tests/test_preamble_preprocessor.py`), one per
+  finding above, including the **document-parity test the plan of record
+  specified**: one request through both doors, every GEECS-owned start-doc
+  key compared exactly, identical `ScanInfo`, and the event columns compared
+  as an exact set — the funnel's three `ScanContext` columns (`bin_number`,
+  `scan_event_index`, `shot_index_in_bin`) are asserted as the *only*
+  difference, so any other divergence fails. That test found the missing
+  `acq_timestamp` header, the phantom settable headers, the stray `geecs`
+  key and the six missing execution keys.
+- `Docs` and `_sweep_points` were copies of `tests/ca_mock_helpers`'
+  `DocCollector` and of each other; the shared helpers gained the `start`
+  property and `sweep_points`, and the copies are gone.
+- The Gate-2 ordering test now records the save writes into the **same**
+  ordered log as the shot-control writes, so swapping `arm_single_shot` and
+  `save_enable_plan` fails it. Previously only the trigger states were
+  pinned and the reorder passed.
+
+### Known gap
+
+- Stock plans do not yet emit the `ScanContext` per-row columns
+  (`bin_number`, `scan_event_index`, `shot_index_in_bin`). Those come from
+  the per-step function in phase 3, which is also when `ScanContext`
+  retires; the parity test pins the difference so it cannot widen.
+
 ## [0.78.1] - 2026-09-09
 
 ### Fixed
@@ -19,11 +140,13 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Changed
 
 - **Hardware-accepted 2026-09-09** on the Undulator machine: a stock
-  `bp.count` ran as a noscan (scan 61 — 3 shots, the preprocessor firing
-  each one) and a stock `bp.list_scan` ran as a step scan (scan 62 — the
+  `bp.count` ran as a noscan (scan 63 — 3 shots, the preprocessor firing
+  each one) and a stock `bp.list_scan` ran as a step scan (scan 64 — the
   catalog axis `S1H` swept −1 → +1 A in 0.5 A steps, readbacks within
   0.4 mA, setpoint restored). Both claimed real scan numbers, wrote their
-  `ScanInfo` ini, and recorded the full detector surface — `shot_id`,
+  `ScanInfo` ini, exported an s-file, registered in the **Tiled catalog**
+  (so both are listed in the data portal beside the operators' scans), and
+  recorded the full detector surface — `shot_id`,
   `shot_offset`, `nonscalar_save_path`, the image asset — so the composed
   namespace device keeps every capability the per-scan classes had. The
   catalog axis resolved to `U_S1H:Current` and to the same object the plan

--- a/GeecsBluesky/CLAUDE.md
+++ b/GeecsBluesky/CLAUDE.md
@@ -54,7 +54,15 @@ geecs_bluesky/
   session.py                # GeecsSession — headless scans (RE + Tiled + discipline)
   namespace.py              # GeecsNamespace — every device as a long-lived noun for
                             # stock plans, composed from devices/ca (#807 phase 1)
+  plan_session.py           # set_plan_session / get_plan_session — the worker-wide
+                            #   default GeecsSession (shared by the funnel and the
+                            #   stock-plan preamble; neutral of both)
   preprocessors.py          # RunEngine preprocessors: connect_on_demand (outermost)
+                            #   + geecs_preamble — a stock bluesky.plans verb whose
+                            #   md carries {"geecs": ScanRequest} gets the whole
+                            #   GEECS preamble/finalize and a plan-owned shot per
+                            #   trigger group (#807 phase 2). install_geecs_preamble
+                            #   keeps connect_on_demand outermost.
                             #   + session.run(ScanRequest) — the headless door:
                             #   RE(geecs_scan_request_plan) with the two
                             #   explicit seams (failed_move_policy="raise",
@@ -148,7 +156,14 @@ geecs_bluesky/
                             #   motor list = multi-axis grid; per_step hook)
     free_run_step_scan.py   # geecs_free_run_step_scan — reference-paced + t0-sync + tail flush
     optimize.py             # geecs_adaptive_scan — optimization as a scan (iteration = bin)
-    single_shot.py          # geecs_single_shot + geecs_confirm_quiescent
+    preamble.py             # resolve_request + prepare_step_scan — the funnel's
+                            #   preamble body, extracted so the ScanRequest door
+                            #   and the stock-plan preprocessor share ONE
+                            #   implementation (#807 phase 2)
+    single_shot.py          # geecs_single_shot + geecs_confirm_quiescent;
+                            #   fire_and_await_shot is the arm→fire→wait seam with
+                            #   the bounded refire and device-down gating, used by
+                            #   both the funnel's shot and the preprocessor's
     t0_sync.py              # geecs_t0_sync — coordinated per-device t0 capture
     run_wrapper.py          # geecs_run_wrapper + claim_scan_number (numbering + save + md)
     named_plans.py          # geecs_noscan_plan / geecs_scan_plan /

--- a/GeecsBluesky/geecs_bluesky/devices/nonscalar_save.py
+++ b/GeecsBluesky/geecs_bluesky/devices/nonscalar_save.py
@@ -27,6 +27,8 @@ from event_model.documents import Datum, PartialResource
 
 from geecs_bluesky.assets import AssetDefinition
 
+from geecs_bluesky.devices.reset_support import reset_next
+
 logger = logging.getLogger(__name__)
 
 
@@ -38,6 +40,7 @@ class NonScalarSaveSupport:
     """
 
     _save_nonscalar_data: bool = False
+    _save_control_only: bool = False
     _nonscalar_save_path: Path | None = None
     _asset_definitions: tuple[AssetDefinition, ...] = ()
     _asset_scan_number: int | None = None
@@ -78,6 +81,49 @@ class NonScalarSaveSupport:
             )
         self._save_nonscalar_data = bool(save_nonscalar_data)
         self._save_control_only = bool(save_control_only) and not save_nonscalar_data
+        # A file-producing device surfaces acq_timestamp as an s-file column
+        # so saved files tie back to scan rows — the constructors add that
+        # header when their save flags are fixed at build time, and this is
+        # the same rule for a device whose mode is per-run.
+        self._acq_timestamp_header(self._save_nonscalar_data or self._save_control_only)
+
+    def _acq_timestamp_header(self, present: bool) -> None:
+        """Add or remove the ``acq_timestamp`` s-file header for this device."""
+        from geecs_bluesky.utils import safe_name
+
+        headers = getattr(self, "_column_headers", None)
+        if headers is None:
+            return
+        variable = getattr(self, "_acq_timestamp_variable", "acq_timestamp")
+        key = f"{self.name}-{safe_name(variable)}"
+        if present:
+            headers[key] = (
+                f"{getattr(self, '_geecs_device_name', self.name)} {variable}"
+            )
+        else:
+            headers.pop(key, None)
+
+    def reset_run_configuration(self) -> None:
+        """Forget everything a single run configured (GEECS-Plugins#807 phase 2).
+
+        The per-scan device classes get this for free by being discarded at
+        the end of the scan; a **long-lived namespace device** does not, and
+        stale state is not inert — ``_save_nonscalar_data`` with a stale
+        ``_nonscalar_save_path`` makes an unrelated later run emit a
+        ``nonscalar_save_path`` column, and stale ``_asset_definitions``
+        make it emit StreamResource/Datum documents resolving into the
+        previous scan's files.  The preamble resets every namespace device
+        before it configures this run's, and again on the way out.
+        """
+        self._save_nonscalar_data = False
+        self._save_control_only = False
+        self._nonscalar_save_path = None
+        self._asset_definitions = ()
+        self._asset_scan_number = None
+        self._asset_root_path = None
+        self._asset_local_root_path = None
+        self._acq_timestamp_header(False)
+        reset_next(super())
 
     def configure_nonscalar_file_logging(self, save_path: str | Path) -> None:
         """Record the scanner-owned save directory for the ``nonscalar_save_path`` column."""

--- a/GeecsBluesky/geecs_bluesky/devices/nonscalar_save.py
+++ b/GeecsBluesky/geecs_bluesky/devices/nonscalar_save.py
@@ -45,6 +45,40 @@ class NonScalarSaveSupport:
     _asset_local_root_path: str | None = None
     _pending_asset_docs: deque[Asset]
 
+    def configure_saving_mode(
+        self, *, save_nonscalar_data: bool, save_control_only: bool = False
+    ) -> None:
+        """Set the native-save mode for **this run** (GEECS-Plugins#807 phase 2).
+
+        The per-scan device classes fix these at construction, which a
+        long-lived namespace device cannot do: the same camera saves natively
+        in one scan and is capture-owned in the next.  The two control
+        children (``localsavingpath``, ``save``) are the device's own served
+        settables, so nothing is created here — only the flags the save-enable
+        plan and :meth:`~geecs_bluesky.session.GeecsSession._configure_saving`
+        read.  ``save_control_only`` is ignored when *save_nonscalar_data* is
+        true, exactly as the constructors do.
+
+        Raises
+        ------
+        GeecsConfigurationError
+            The device has no ``save`` control, so neither mode can be driven.
+        """
+        from geecs_bluesky.exceptions import GeecsConfigurationError
+
+        if (save_nonscalar_data or save_control_only) and not hasattr(self, "save"):
+            raise GeecsConfigurationError(
+                f"{getattr(self, '_geecs_device_name', self)}: native saving was "
+                "requested but the device serves no 'save' control"
+            )
+        if save_nonscalar_data and not hasattr(self, "localsavingpath"):
+            raise GeecsConfigurationError(
+                f"{getattr(self, '_geecs_device_name', self)}: native saving was "
+                "requested but the device serves no 'localsavingpath' control"
+            )
+        self._save_nonscalar_data = bool(save_nonscalar_data)
+        self._save_control_only = bool(save_control_only) and not save_nonscalar_data
+
     def configure_nonscalar_file_logging(self, save_path: str | Path) -> None:
         """Record the scanner-owned save directory for the ``nonscalar_save_path`` column."""
         self._nonscalar_save_path = Path(save_path)

--- a/GeecsBluesky/geecs_bluesky/devices/reset_support.py
+++ b/GeecsBluesky/geecs_bluesky/devices/reset_support.py
@@ -1,0 +1,23 @@
+"""Cooperative per-run reset across the device mixins.
+
+Long-lived namespace devices (GEECS-Plugins#807 phase 2) outlive the run
+that configured them, so every mixin holding per-run state exposes
+``reset_run_configuration``.  A device mixes in several of them, so the
+implementations must chain along the MRO instead of the first one winning.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def reset_next(parent: Any) -> None:
+    """Continue a cooperative ``reset_run_configuration`` up the MRO.
+
+    ``CaGenericDetector`` mixes in more than one per-run-state carrier, so
+    each ``reset_run_configuration`` must hand off rather than shadow the
+    next one.  The base classes do not define it, hence the lookup.
+    """
+    nxt = getattr(parent, "reset_run_configuration", None)
+    if nxt is not None:
+        nxt()

--- a/GeecsBluesky/geecs_bluesky/devices/shot_id.py
+++ b/GeecsBluesky/geecs_bluesky/devices/shot_id.py
@@ -31,6 +31,8 @@ from typing import Any
 from bluesky.protocols import Reading
 from event_model import DataKey
 
+from geecs_bluesky.devices.reset_support import reset_next
+
 logger = logging.getLogger(__name__)
 
 
@@ -133,6 +135,16 @@ class ShotIdSupport:
 
     _acq_timestamp_variable: str = "acq_timestamp"
     _shot_id_tracker: ShotIdTracker | None = None
+
+    def reset_run_configuration(self) -> None:
+        """Drop the shot-ID tracker so the next run seeds its own.
+
+        Long-lived namespace devices outlive the run that configured them
+        (GEECS-Plugins#807 phase 2); a tracker seeded from the previous
+        scan's t0 would number the next scan's shots from the wrong origin.
+        """
+        self._shot_id_tracker = None
+        reset_next(super())
 
     def configure_shot_id(
         self,

--- a/GeecsBluesky/geecs_bluesky/namespace.py
+++ b/GeecsBluesky/geecs_bluesky/namespace.py
@@ -454,6 +454,22 @@ class GeecsNamespace:
                 f"variable {variable!r}"
             ) from None
 
+    def variable_names(self, device: str) -> tuple[str, ...]:
+        """The GEECS variable names *device* has children for (its served scalars).
+
+        The device object itself does not carry this — it is a plain
+        ``CaGenericDetector``/``CaSnapshotReadable`` — so the namespace, which
+        built the children, answers it.
+        """
+        dev = self[device]
+        attrs = self._attrs[dev.name]
+        # `attrs` maps both GEECS and attribute spellings onto the attribute;
+        # the distinct attributes are the children.
+        seen: dict[str, None] = {}
+        for key, attr in attrs.items():
+            seen.setdefault(attr, None)
+        return tuple(seen)
+
     def resolve(self, target: str) -> Any:
         """The object for ``"Device"`` or ``"Device:Variable"`` (either spelling)."""
         device, sep, variable = target.partition(":")

--- a/GeecsBluesky/geecs_bluesky/namespace.py
+++ b/GeecsBluesky/geecs_bluesky/namespace.py
@@ -355,15 +355,18 @@ class GeecsNamespace:
                 )
             child = self._movable(device, var, row, py, roster.experiment)
             setattr(dev, attr, child)  # ophyd-async registers + names the child
-            # The s-file exporter reads `_column_headers` off the top-level
-            # detectors only (run_wrapper), so the parent aggregates its
-            # children's "Device Variable" headers.
             child._column_headers = {
                 getattr(child, child._readback_attr_name).name: f"{device} {var}"
             }
-            dev._column_headers.update(child._column_headers)
             if var.lower() in {v.lower() for v in roster.subscribed.get(device, ())}:
                 dev.add_readables([child])  # subscribed settable: log its readback
+                # The s-file exporter reads `_column_headers` off the
+                # top-level detectors only (run_wrapper), so the parent
+                # aggregates its children's "Device Variable" headers —
+                # but only for children that produce a column.  A header
+                # for a key no event carries would put a phantom column
+                # name in front of the exporter.
+                dev._column_headers.update(child._column_headers)
             attrs[var.lower()] = attr
             attrs[attr.lower()] = attr
         for var in readables:
@@ -454,12 +457,13 @@ class GeecsNamespace:
                 f"variable {variable!r}"
             ) from None
 
-    def variable_names(self, device: str) -> tuple[str, ...]:
+    def _variable_names(self, device: str) -> tuple[str, ...]:
         """The GEECS variable names *device* has children for (its served scalars).
 
         The device object itself does not carry this — it is a plain
         ``CaGenericDetector``/``CaSnapshotReadable`` — so the namespace, which
-        built the children, answers it.
+        built the children, answers it.  Internal: :meth:`select` is the only
+        caller, and it lives here precisely so this can stay private.
         """
         dev = self[device]
         attrs = self._attrs[dev.name]
@@ -474,6 +478,117 @@ class GeecsNamespace:
         """The object for ``"Device"`` or ``"Device:Variable"`` (either spelling)."""
         device, sep, variable = target.partition(":")
         return self.variable(device, variable) if sep else self[device]
+
+    # -------------------------------------------------------------- per-run
+    def reset_run_configuration(self) -> None:
+        """Clear every device's per-run configuration.
+
+        A namespace device is a **long-lived noun**: it outlives the run that
+        configured its native saving, save path, asset definitions and
+        shot-ID origin.  The per-scan device classes were discarded at the
+        end of a scan and got this for free; these are not, and stale state
+        is not inert (an unrelated later run would emit a
+        ``nonscalar_save_path`` column, and asset documents, pointing at the
+        previous scan's folder).  The preamble calls this before it
+        configures a run and again on the way out, so a crash between the
+        two cannot leak into the next plan either.
+        """
+        for device in self._devices.values():
+            reset = getattr(device, "reset_run_configuration", None)
+            if reset is not None:
+                reset()
+
+    def select(self, devices_config: Mapping[str, Mapping[str, Any]]) -> list[Any]:
+        """The save set's devices, **selected** from the namespace, configured.
+
+        The role assignment is ``_build_request_detectors``' — the first
+        synchronous entry leads, later synchronous entries follow, and
+        asynchronous entries are snapshots — but the objects are the
+        long-lived nouns a stock plan is handed, not fresh per-scan devices.
+        That identity is the whole point: two objects for one device would
+        double the connections and apply the saving configuration to
+        something the plan never reads.
+
+        Roles are asserted rather than chosen, because a device's class was
+        already decided by :func:`looks_triggerable` when the namespace was
+        built: a synchronous save-set entry must be a triggerable device, an
+        asynchronous one must not be.  A mismatch is a configuration error
+        worth hearing about, not something to paper over.
+
+        The recorded scalars must also match: a namespace device reads the
+        DB's subscribed list, so a save-set entry naming a different set (an
+        explicit ``scalars:`` list) cannot be honoured without per-run
+        reselection — refused loudly rather than silently logging different
+        columns.
+        """
+        detectors: list[Any] = []
+        leader_assigned = False
+        for device_name, cfg in devices_config.items():
+            variables = list(cfg.get("variable_list") or [])
+            synchronous = bool(cfg.get("synchronous", False))
+            try:
+                device = self[device_name]
+            except KeyError as exc:
+                raise GeecsConfigurationError(
+                    f"save set names {device_name!r}, which is not in the device "
+                    f"namespace for {self.experiment}"
+                ) from exc
+
+            triggerable = isinstance(device, CaGenericDetector)
+            if synchronous and not triggerable:
+                raise GeecsConfigurationError(
+                    f"{device_name}: the save set marks it synchronous "
+                    "(shot-triggered) but the namespace built it as a "
+                    "non-triggered device — fix the save-set role, or the "
+                    "triggerable classification for its devicetype"
+                )
+            if not synchronous and triggerable:
+                logger.warning(
+                    "%s: save-set role is asynchronous but the device is "
+                    "shot-triggered; reading it once per row anyway",
+                    device_name,
+                )
+            if not synchronous and not variables:
+                logger.warning(
+                    "Skipping asynchronous device %s: no scalars to record",
+                    device_name,
+                )
+                continue
+
+            # acq_timestamp / CONNECTED are gateway-synthesized: a save set
+            # may name the shot stamp explicitly, and a triggered device
+            # always reads it, so they are never part of this comparison.
+            wanted = {safe_name(v) for v in variables if v.lower() not in _SYNTHESIZED}
+            have = {safe_name(v) for v in self._variable_names(device_name)}
+            missing = wanted - have
+            if missing:
+                raise GeecsConfigurationError(
+                    f"{device_name}: the save set records {sorted(missing)}, which "
+                    "the namespace device does not read (it reads the DB's "
+                    "subscribed list). Add them to the device's subscribed "
+                    "variables, or drop them from the save set."
+                )
+
+            save = bool(cfg.get("save_nonscalar_data", False))
+            save_control_only = bool(cfg.get("save_control_only", False))
+            if hasattr(device, "configure_saving_mode"):
+                device.configure_saving_mode(
+                    save_nonscalar_data=save, save_control_only=save_control_only
+                )
+            elif save or save_control_only:
+                raise GeecsConfigurationError(
+                    f"{device_name}: native saving was requested but the "
+                    "namespace device has no save-control support"
+                )
+
+            # Order marks the leading synchronous device (the reference the
+            # scan metadata records), so preserve it.
+            if synchronous and not leader_assigned:
+                detectors.insert(0, device)
+                leader_assigned = True
+            else:
+                detectors.append(device)
+        return detectors
 
     # ----------------------------------------------------------------- export
     def export_into(self, namespace: dict[str, Any]) -> list[str]:

--- a/GeecsBluesky/geecs_bluesky/plan_session.py
+++ b/GeecsBluesky/geecs_bluesky/plan_session.py
@@ -1,0 +1,41 @@
+"""The worker-wide default :class:`~geecs_bluesky.session.GeecsSession`.
+
+A neutral home, because there are now **two** consumers with different
+lifetimes: the ScanRequest funnel (``plans/scan_request_plan.py``, slated
+for retirement with GEECS-Plugins#807 phase C) and the stock-plan preamble
+preprocessor (``preprocessors.py``, which outlives it).  Keeping the global
+in the funnel would make the preprocessor import a private name from the
+module that is about to be deleted.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+#: The worker-wide default session (installed once at worker startup).
+_worker_session: Any | None = None
+
+
+def set_plan_session(session: Any | None) -> None:
+    """Install the worker-wide default :class:`GeecsSession` for the plans.
+
+    The queueserver registers plans by name with JSON args, so the session
+    cannot travel in the call — a worker startup script constructs one
+    headless session and installs it here; ``RE(geecs_scan_request_plan(
+    request))``, and any stock plan carrying ``md={"geecs": ...}``, then
+    need nothing else.  Pass ``None`` to clear (tests).
+
+    Parameters
+    ----------
+    session :
+        The session whose RunEngine will execute the plan.  The plan's
+        connect messages run on that engine's loop, so running the plan on
+        a *different* RunEngine than ``session.RE`` is unsupported.
+    """
+    global _worker_session
+    _worker_session = session
+
+
+def get_plan_session() -> Any | None:
+    """The installed worker-wide session, or ``None`` if none was installed."""
+    return _worker_session

--- a/GeecsBluesky/geecs_bluesky/plans/preamble.py
+++ b/GeecsBluesky/geecs_bluesky/plans/preamble.py
@@ -1,0 +1,477 @@
+"""The GEECS scan preamble: everything a ScanRequest needs before the run opens.
+
+Extracted verbatim from ``plans/scan_request_plan.py`` (GEECS-Plugins#807
+phase 2) so that **one implementation has two callers**: the funnel plan
+(:func:`~geecs_bluesky.plans.scan_request_plan.geecs_scan_request_plan`,
+which keeps working unchanged until phase 5 retires it) and the RunEngine
+preprocessor that gives stock ``bluesky.plans`` verbs the same preamble.
+
+Order of operations — everything here is **pre-claim** and fail-fast, so a
+failure burns no scan number:
+
+1. :func:`resolve_request` — authoritative validation (the same
+   ``validate_scan_request`` clients run pre-submit), the trigger profile →
+   :class:`~geecs_bluesky.shot_controller.ShotController` (unconnected), and
+   the strict/free-run decision.  Blocking config-repo I/O, no plan messages;
+   shared with optimize mode, which branches in the caller.
+2. :func:`prepare_step_scan` — save sets, scalar policy and devices config;
+   the unserved and CONNECTED preflights; action slots; axis resolution; the
+   capture toggle; worker-side construction with deferred connects; the
+   in-plan connect batches (devices, telemetry, shot-control setters); the
+   fail-fast gates; and the run-metadata spec.  Returns a
+   :class:`PreparedScan`.
+
+The caller claims the scan number and builds the inner plan (or, for the
+preprocessor, forwards a metadata-injected ``open_run``).  The deliberately
+blocking I/O of step 1–2 runs on the RunEngine thread, as documented on the
+funnel plan.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from dataclasses import dataclass, field
+from typing import Any
+
+import bluesky.plan_stubs as bps
+from ophyd_async.plan_stubs import ensure_connected
+
+from geecs_bluesky.config_resolver import ConfigResolver
+from geecs_bluesky.db_runtime import select_telemetry_variables
+from geecs_bluesky.exceptions import GeecsConfigurationError
+from geecs_bluesky.scan_request_runner import (
+    _build_request_detectors,
+    _defaults_flag,
+    _preflight_connected,
+    _preflight_unserved,
+    assemble_action_slots,
+    build_action_registry,
+    build_movable,
+    build_step_scan_spec,
+    compile_action_slot,
+    make_scalar_policy,
+    prefetch_action_signals,
+    resolve_and_apply_capture_toggle,
+    resolve_movable_target,
+    resolve_save_sets_and_rituals,
+    save_set_to_devices_config,
+    trigger_writes_from_profile,
+    validate_scan_request,
+    warn_if_reserved_boundary_overrides,
+)
+from geecs_bluesky.shot_controller import ShotController
+from geecs_schemas import AcquisitionMode, ScanRequest, ScanRequestMode
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "PreparedScan",
+    "ResolvedRequest",
+    "prepare_step_scan",
+    "resolve_request",
+]
+
+#: Per-connect timeout for the in-plan strict batches.  Near-parity, not
+#: parity, with ``GeecsSession._connect``: there 20 s is the outer wall on
+#: the loop hop while each connect runs at the ophyd-async default (10 s),
+#: so an unreachable device fails at ~10 s; here the 20 s *is* the
+#: per-connect timeout, so the same failure surfaces ~10 s later.
+_CONNECT_TIMEOUT = 20.0
+
+#: The session factory methods whose *construction* code the plan reuses
+#: verbatim (only the connect step is deferred — see
+#: :class:`_DeferredConnectFactories`).
+_SESSION_FACTORIES = frozenset(
+    {
+        "detector",
+        "contributor",
+        "snapshot",
+        "motor",
+        "settable",
+        "confirm_settable",
+        "pseudo_movable",
+        "action_signal_factory",
+    }
+)
+
+
+class _DeferredConnectFactories:
+    """A session facade: identical device construction, connect deferred.
+
+    The session's factory methods (``detector``, ``motor``, …) are the one
+    definition of how request devices are constructed — but each ends in
+    ``self._connect(device)``, a blocking hop onto the RE loop that would
+    deadlock inside a plan.  This facade binds those *same* class functions
+    to itself (so the construction code cannot drift from the session's)
+    and swaps only ``_connect``: devices are recorded on :attr:`created`
+    and connected later in one in-plan batch.  Everything else (attributes
+    like ``experiment`` / ``_mock`` / ``rep_rate_hz``) delegates to the
+    wrapped session.
+
+    Deliberately *not* covering ``telemetry``/``telemetry_batch``: the soft
+    tier's connect-failure-drops semantics need their own in-plan gather
+    (:func:`_connect_telemetry_plan`), not the strict batch connect.
+    """
+
+    def __init__(self, session: Any) -> None:
+        self._session = session
+        self.created: list = []
+
+    def _connect(self, device: Any) -> Any:
+        self.created.append(device)
+        return device
+
+    def __getattr__(self, name: str) -> Any:
+        if name in _SESSION_FACTORIES:
+            func = getattr(type(self._session), name, None)
+            if func is not None:
+                return func.__get__(self, type(self))
+        return getattr(self._session, name)
+
+
+def _await_in_plan(coro_fn: Any):
+    """Plan stub: await one no-arg coroutine function, propagating its error.
+
+    ``bps.wait_for`` alone parks the plan on the future but discards its
+    outcome; re-raising through ``task.result()`` keeps in-plan connects
+    fail-fast (the ophyd-async ``wait_for_awaitable`` idiom, not exported
+    by the pinned release).
+    """
+    tasks = yield from bps.wait_for([coro_fn])
+    return tasks[0].result()
+
+
+def _connect_in_batches(devices: list, *, mock: bool):
+    """Plan stub: strict-connect *devices* via ``ensure_connected``.
+
+    ``ensure_connected`` refuses duplicate device names within one call, and
+    an action-check signal can legitimately share a name with a scan-axis
+    movable on the same ``Device:Variable`` — so the list is split into
+    unique-name batches instead of failing the scan on a naming accident.
+    Failures propagate (strict tier fails loudly), pre-claim.
+    """
+    pending = list(devices)
+    while pending:
+        batch: list = []
+        rest: list = []
+        seen: set[str] = set()
+        for device in pending:
+            if device.name in seen:
+                rest.append(device)
+            else:
+                seen.add(device.name)
+                batch.append(device)
+        yield from ensure_connected(*batch, mock=mock, timeout=_CONNECT_TIMEOUT)
+        pending = rest
+
+
+def _connect_telemetry_plan(session: Any, save_set: Any, scalar_policy: Any):
+    """Plan stub: build + soft-connect the Tier-2 telemetry group in-plan.
+
+    Same selection (:func:`~geecs_bluesky.db_runtime.select_telemetry_variables`),
+    same soft-tier contract (a device unreachable at scan start is dropped
+    with a warning, never an abort; only connected devices are recorded),
+    one :class:`~geecs_bluesky.devices.ca.telemetry.CaTelemetryGroup` per
+    scan.  One concurrent gather, so wall time is the slowest device.
+
+    Returns
+    -------
+    tuple
+        ``(readables, recorded)`` — the group (or nothing) to append to the
+        read set, and ``{device: [variables]}`` of what actually connected.
+    """
+    if scalar_policy is None:
+        return [], {}
+    selected = select_telemetry_variables(
+        save_set, scalar_policy.subscribed_by_device()
+    )
+    if not selected:
+        return [], {}
+    # Lazy import: keeps this module importable without the `ca` extra
+    # (same discipline as the runner).
+    from geecs_bluesky.devices.ca.telemetry import CaTelemetryGroup, CaTelemetryReadable
+
+    members = [
+        CaTelemetryReadable(device, variables, experiment=session.experiment)
+        for device, variables in selected.items()
+    ]
+    results: list = []
+
+    async def _connect_all() -> None:
+        results.extend(
+            await asyncio.gather(
+                *(m.connect(mock=session._mock) for m in members),
+                return_exceptions=True,
+            )
+        )
+
+    yield from bps.wait_for([_connect_all])
+
+    connected: list = []
+    recorded: dict[str, list[str]] = {}
+    for member, variables, result in zip(members, selected.values(), results):
+        if isinstance(result, BaseException):
+            logger.warning(
+                "Dropping background-telemetry device %s: unreachable at scan "
+                "start (soft tier — never aborts the scan)",
+                member._geecs_device_name,
+                exc_info=result,
+            )
+        else:
+            connected.append(member)
+            recorded[member._geecs_device_name] = list(variables)
+    if not connected:
+        return [], recorded
+    return [CaTelemetryGroup(connected)], recorded
+
+
+def _disconnect_plan(created: list):
+    """Plan stub: best-effort disconnect of everything the plan created.
+
+    The in-plan counterpart of the runner's ``finally:
+    session.disconnect(*created)`` (which hops onto the RE loop).  Runs as
+    a finalize, so it executes on success, failure, and abort alike; each
+    device's failure is swallowed (gather with exceptions returned) —
+    cleanup never masks the plan's own outcome.
+    """
+    closers = [d for d in created if hasattr(d, "disconnect")]
+    if not closers:
+        return
+
+    async def _disconnect_all() -> None:
+        await asyncio.gather(*(d.disconnect() for d in closers), return_exceptions=True)
+
+    yield from bps.wait_for([_disconnect_all])
+
+
+@dataclass(frozen=True)
+class ResolvedRequest:
+    """What :func:`resolve_request` settles before the mode branch."""
+
+    request: ScanRequest
+    applied_defaults: Any
+    defaults: Any
+    controller: ShotController | None
+    strict: bool
+
+
+@dataclass
+class PreparedScan:
+    """Everything :func:`prepare_step_scan` produced, ready for the claim.
+
+    ``as_claimed_kwargs()`` is the keyword set
+    :meth:`~geecs_bluesky.session.GeecsSession.build_claimed_scan_plan`
+    takes, so the funnel's call site stays a one-liner.
+    """
+
+    request: ScanRequest
+    controller: ShotController | None
+    strict: bool
+    detectors: list
+    motor_arg: Any
+    spec: Any
+    setup: Any = None
+    per_step: Any = None
+    closeout: Any = None
+    telemetry_selected: dict = field(default_factory=dict)
+
+    def as_claimed_kwargs(self) -> dict:
+        """The ``build_claimed_scan_plan`` keywords this preparation implies."""
+        return {
+            "detectors": self.detectors,
+            "motor": self.motor_arg,
+            "positions": self.spec.positions,
+            "shots_per_step": self.request.capture.shots_per_step,
+            "strict": self.strict,
+            "controller": self.controller,
+            "description": self.request.description,
+            "md": self.spec.md,
+            "scan_info_overrides": self.spec.scan_info,
+            "setup": self.setup,
+            "per_step": self.per_step,
+            "closeout": self.closeout,
+        }
+
+
+def resolve_request(
+    session: Any, resolver: ConfigResolver, request: dict | ScanRequest
+) -> ResolvedRequest:
+    """Validate the request and build its (unconnected) shot controller.
+
+    Pre-claim and mode-independent: optimize and step/noscan share it, and
+    the caller branches on ``resolved.request.mode`` afterwards.  Blocking
+    config-repo I/O; emits no plan messages.
+    """
+    if not isinstance(request, ScanRequest):
+        request = ScanRequest.model_validate(request)
+    request, applied_defaults, defaults = validate_scan_request(request, resolver)
+
+    controller = None
+    if request.capture.trigger_profile:
+        profile = resolver.resolve_trigger_profile(request.capture.trigger_profile)
+        writes = trigger_writes_from_profile(profile)
+        if writes.states:
+            # Constructed worker-side, unconnected; the setter reachability
+            # check joins the in-plan connect stage below.
+            controller = ShotController.from_writes(
+                writes,
+                experiment=session.experiment,
+                rep_rate_hz=session.rep_rate_hz,
+            )
+    strict = request.capture.acquisition is AcquisitionMode.STRICT
+    return ResolvedRequest(
+        request=request,
+        applied_defaults=applied_defaults,
+        defaults=defaults,
+        controller=controller,
+        strict=strict,
+    )
+
+
+def prepare_step_scan(
+    session: Any,
+    resolver: ConfigResolver,
+    resolved: ResolvedRequest,
+    created: list,
+    *,
+    submission: Any | None = None,
+):
+    """The pre-claim preamble for a step/noscan request; returns a :class:`PreparedScan`.
+
+    A plan (it yields the connect messages), so the caller drives it with
+    ``yield from``.  Everything it constructs is appended to *created* — the
+    caller-owned cleanup list its enclosing finalize disconnects — so a
+    failure at any stage still tears down whatever already existed.
+    """
+    request = resolved.request
+    applied_defaults = resolved.applied_defaults
+    defaults = resolved.defaults
+    controller = resolved.controller
+    strict = resolved.strict
+
+    save_set, rituals = resolve_save_sets_and_rituals(
+        resolver, request.capture.save_sets
+    )
+    scalar_policy = make_scalar_policy(session)
+    devices_config = save_set_to_devices_config(save_set, scalar_policy)
+    # Unserved-variables check, headless by decision 3 (operator questions
+    # are client-side pre-submit): continue-and-drop with a WARNING.
+    checked_config, dropped_unserved, dropped_unserved_devices = _preflight_unserved(
+        session, devices_config
+    )
+    if checked_config is None:  # defensive: the headless default never aborts
+        raise GeecsConfigurationError(
+            "unserved-variables pre-flight aborted the scan (pre-claim)"
+        )
+    devices_config = checked_config
+    # CONNECTED liveness re-check (#664): the client asked pre-submit, but
+    # the queue's submission-to-execution gap is long — re-check here,
+    # refusing only when a row could never complete.
+    disconnected_devices = _preflight_connected(session, devices_config)
+    slots = assemble_action_slots(request.actions, applied_defaults, rituals)
+    warn_if_reserved_boundary_overrides(save_set)
+    axis_resolved = [
+        resolve_movable_target(
+            resolver.resolve_scan_variable(axis.variable), axis.variable
+        )
+        for axis in request.axes
+    ]
+    telemetry_enabled = (
+        request.capture.background_telemetry
+        if request.capture.background_telemetry is not None
+        else _defaults_flag(defaults, "background_telemetry", True)
+    )
+    devices_config, capture_devices, native_image_save = (
+        resolve_and_apply_capture_toggle(request, defaults, devices_config, session)
+    )
+
+    # ---- phase 2: worker-side construction (connects deferred) -----------
+    factories = _DeferredConnectFactories(session)
+    setup = per_step = closeout = None
+    if any(slots.values()):
+        factory = factories.action_signal_factory()
+        created.append(factory)
+        registry = build_action_registry(resolver)
+        setup, setup_plans = compile_action_slot(
+            slots["setup"], resolver, registry, factory
+        )
+        per_step, per_step_plans = compile_action_slot(
+            slots["per_step"], resolver, registry, factory
+        )
+        closeout, closeout_plans = compile_action_slot(
+            slots["closeout"], resolver, registry, factory
+        )
+        # With the facade, "prefetch" records the signals for the batch
+        # connect below — same fail-fast property, now a plan message.
+        prefetch_action_signals(
+            setup_plans + per_step_plans + closeout_plans, registry, factory
+        )
+
+    detectors = _build_request_detectors(factories, devices_config, free_run=not strict)
+    movables = [build_movable(factories, target) for target in axis_resolved]
+    created.extend(factories.created)
+
+    # ---- phase 3: in-plan connects (still pre-claim) ----------------------
+    if factories.created:
+        yield from _connect_in_batches(factories.created, mock=session._mock)
+    telemetry_selected: dict[str, list[str]] = {}
+    telemetry_readables: list = []
+    if telemetry_enabled:
+        telemetry_readables, telemetry_selected = yield from _connect_telemetry_plan(
+            session, save_set, scalar_policy
+        )
+        created.extend(telemetry_readables)
+    # Telemetry is soft: appended as extra snapshot columns, never the
+    # reference (index 0 stays the save set's).
+    all_detectors = list(detectors) + telemetry_readables
+    if controller is not None and not session._mock:
+        # Fail fast on an unreachable shot-control PV (the session does this
+        # at attach time; in-plan it joins the pre-claim connect stage).
+        yield from _await_in_plan(controller.connect_setters)
+
+    if not all_detectors:
+        raise GeecsConfigurationError(
+            "ScanRequest produced no detectors (empty effective device set) — "
+            "nothing would be recorded"
+        )
+    if strict:
+        if controller is None:
+            raise GeecsConfigurationError(
+                "strict_shot_control requires a reachable shot-control device. "
+                "Use free-run mode for free-running trigger acquisition."
+            )
+        controller.require_strict_single_shot()
+
+    spec = build_step_scan_spec(
+        request,
+        axis_resolved,
+        applied_defaults=applied_defaults,
+        slots=slots,
+        dropped_unserved=dropped_unserved,
+        dropped_unserved_devices=dropped_unserved_devices,
+        disconnected_devices=disconnected_devices,
+        telemetry_selected=telemetry_selected if telemetry_enabled else {},
+        capture_devices=capture_devices,
+        native_image_save=native_image_save,
+        submission=submission,
+    )
+    if request.mode is ScanRequestMode.NOSCAN:
+        motor_arg: Any = None
+    elif len(movables) == 1:
+        motor_arg = movables[0]
+    else:
+        motor_arg = movables
+
+    return PreparedScan(
+        request=request,
+        controller=controller,
+        strict=strict,
+        detectors=all_detectors,
+        motor_arg=motor_arg,
+        spec=spec,
+        setup=setup,
+        per_step=per_step,
+        closeout=closeout,
+        telemetry_selected=telemetry_selected,
+    )

--- a/GeecsBluesky/geecs_bluesky/plans/preamble.py
+++ b/GeecsBluesky/geecs_bluesky/plans/preamble.py
@@ -305,8 +305,14 @@ def namespace_detectors(
             )
             continue
 
-        wanted = {safe_name(v) for v in variables}
-        have = {safe_name(v) for v in device.variables}
+        # acq_timestamp / CONNECTED are gateway-synthesized: a save set may
+        # name the shot stamp explicitly, and a triggered device always reads
+        # it, so they are never part of this comparison.
+        from geecs_bluesky.namespace import ACQ_TIMESTAMP_VARIABLE
+
+        synthesized = {ACQ_TIMESTAMP_VARIABLE, "connected"}
+        wanted = {safe_name(v) for v in variables if v.lower() not in synthesized}
+        have = {safe_name(v) for v in namespace.variable_names(device_name)}
         missing = wanted - have
         if missing:
             raise GeecsConfigurationError(

--- a/GeecsBluesky/geecs_bluesky/plans/preamble.py
+++ b/GeecsBluesky/geecs_bluesky/plans/preamble.py
@@ -67,7 +67,6 @@ logger = logging.getLogger(__name__)
 
 __all__ = [
     "PreparedScan",
-    "namespace_detectors",
     "ResolvedRequest",
     "prepare_step_scan",
     "resolve_request",
@@ -246,104 +245,44 @@ def _disconnect_plan(created: list):
     yield from bps.wait_for([_disconnect_all])
 
 
-def namespace_detectors(
-    namespace: Any, devices_config: dict[str, dict[str, Any]], *, free_run: bool
-) -> list:
-    """The save set's devices, taken from the **namespace** instead of built.
+def _namespace_movable(namespace: Any, target: Any) -> Any:
+    """The namespace child for one resolved axis, or a refusal.
 
-    The role assignment is `_build_request_detectors`' — free-run: the first
-    synchronous entry is the reference and later ones contributors; strict:
-    every synchronous entry is triggered; asynchronous entries are snapshots
-    — but the objects are the long-lived namespace nouns a stock plan is
-    handed, not fresh per-scan devices.  That identity is the whole point:
-    two objects for one device would double the connections and apply the
-    saving configuration to something the plan never reads.
-
-    Roles are asserted rather than chosen, because a namespace device's class
-    is already decided by :func:`~geecs_bluesky.namespace.looks_triggerable`:
-    a synchronous save-set entry must be a triggerable device, an
-    asynchronous one must not be.  A mismatch is a configuration error worth
-    hearing about, not something to paper over.
-
-    The recorded scalars must also match: the namespace device reads the DB's
-    subscribed list, so a save-set entry naming a different set (an explicit
-    ``scalars:`` list) cannot be honoured without per-run reselection —
-    refused loudly rather than silently logging different columns.
+    ``build_movable`` (``scan_request_runner.py``) dispatches a catalog
+    target onto three topologies — pseudo, confirm-elsewhere, and
+    tolerance-checked motor.  The namespace builds its children from the DB
+    alone and knows none of that yet (the catalog's ``kind: motor`` opt-in
+    arrives with the axes in phase 3), so a target needing a topology the
+    namespace cannot express is **refused**.  Silently degrading a
+    confirming or motor axis to a fire-and-forget setpoint would let a stock
+    ``list_scan`` step to the next point before the readback converged —
+    every row taken at the wrong position, and nothing in the data saying so.
     """
-    from geecs_bluesky.devices.ca.generic_detector import CaGenericDetector
-    from geecs_bluesky.utils import safe_name
+    from geecs_bluesky.devices.ca.motor import CaMotor
 
-    detectors: list = []
-    reference_assigned = False
-    for device_name, cfg in devices_config.items():
-        variables = list(cfg.get("variable_list") or [])
-        synchronous = bool(cfg.get("synchronous", False))
-        try:
-            device = namespace[device_name]
-        except KeyError as exc:
-            raise GeecsConfigurationError(
-                f"save set names {device_name!r}, which is not in the device "
-                f"namespace for {getattr(namespace, 'experiment', '?')}"
-            ) from exc
-
-        triggerable = isinstance(device, CaGenericDetector)
-        if synchronous and not triggerable:
-            raise GeecsConfigurationError(
-                f"{device_name}: the save set marks it synchronous (shot-triggered) "
-                "but the namespace built it as a non-triggered device — fix the "
-                "save-set role, or the triggerable classification for its devicetype"
-            )
-        if not synchronous and triggerable:
-            logger.warning(
-                "%s: save-set role is asynchronous but the device is "
-                "shot-triggered; reading it once per row anyway",
-                device_name,
-            )
-        if not synchronous and not variables:
-            logger.warning(
-                "Skipping asynchronous device %s: no scalars to record", device_name
-            )
-            continue
-
-        # acq_timestamp / CONNECTED are gateway-synthesized: a save set may
-        # name the shot stamp explicitly, and a triggered device always reads
-        # it, so they are never part of this comparison.
-        from geecs_bluesky.namespace import ACQ_TIMESTAMP_VARIABLE
-
-        synthesized = {ACQ_TIMESTAMP_VARIABLE, "connected"}
-        wanted = {safe_name(v) for v in variables if v.lower() not in synthesized}
-        have = {safe_name(v) for v in namespace.variable_names(device_name)}
-        missing = wanted - have
-        if missing:
-            raise GeecsConfigurationError(
-                f"{device_name}: the save set records {sorted(missing)}, which the "
-                "namespace device does not read (it reads the DB's subscribed "
-                "list). Add them to the device's subscribed variables, or drop "
-                "them from the save set."
-            )
-
-        save = bool(cfg.get("save_nonscalar_data", False))
-        save_control_only = bool(cfg.get("save_control_only", False))
-        if hasattr(device, "configure_saving_mode"):
-            device.configure_saving_mode(
-                save_nonscalar_data=save, save_control_only=save_control_only
-            )
-        elif save or save_control_only:
-            raise GeecsConfigurationError(
-                f"{device_name}: native saving was requested but the namespace "
-                "device has no save-control support"
-            )
-
-        # Free-run contributor anchoring is applied post-claim by
-        # GeecsSession.configure_claimed_scan (set_reference); order is what
-        # marks the reference, so preserve it.
-        if synchronous and not reference_assigned:
-            detectors.insert(0, device)
-            reference_assigned = True
-        else:
-            detectors.append(device)
-    _ = free_run  # role order is positional; the flag stays for symmetry
-    return detectors
+    label = getattr(target, "label", target)
+    if not hasattr(target, "device"):
+        raise GeecsConfigurationError(
+            f"{label}: pseudo/composite scan variables are not supported on the "
+            "stock-plan door yet (the namespace builds no pseudo axes until "
+            "GEECS-Plugins#807 phase 3). Submit it through geecs_scan_request_plan."
+        )
+    if getattr(target, "confirm", None) is not None:
+        raise GeecsConfigurationError(
+            f"{label}: this scan variable confirms on {target.confirm!r}, a "
+            "topology the device namespace does not build yet "
+            "(GEECS-Plugins#807 phase 3). Submit it through "
+            "geecs_scan_request_plan, which builds a CaConfirmSettable."
+        )
+    movable = namespace.variable(target.device, target.variable)
+    if getattr(target, "kind", None) == "motor" and not isinstance(movable, CaMotor):
+        raise GeecsConfigurationError(
+            f"{label}: the catalog declares kind: motor, but the namespace built "
+            "a plain setpoint because the DB carries no positive tolerance for "
+            "it — a move would complete before the readback converged. Set the "
+            "devicetype_variable tolerance in the GEECS DB."
+        )
+    return movable
 
 
 @dataclass(frozen=True)
@@ -376,6 +315,7 @@ class PreparedScan:
     per_step: Any = None
     closeout: Any = None
     telemetry_selected: dict = field(default_factory=dict)
+    telemetry_readables: list = field(default_factory=list)
 
     def as_claimed_kwargs(self) -> dict:
         """The ``build_claimed_scan_plan`` keywords this preparation implies."""
@@ -524,12 +464,13 @@ def prepare_step_scan(
     else:
         # Stock-plan door: the objects must be the ones the plan itself is
         # handed, so the save set SELECTS namespace devices instead of
-        # constructing new ones (see namespace_detectors).
-        detectors = namespace_detectors(namespace, devices_config, free_run=not strict)
-        movables = [
-            namespace.variable(target.device, target.variable)
-            for target in axis_resolved
-        ]
+        # constructing new ones (GeecsNamespace.select).  Every device is
+        # reset first: these nouns outlive the run, so a previous scan's
+        # saving mode, save path, asset definitions or shot-ID origin would
+        # otherwise still be set on the ones this save set does not name.
+        namespace.reset_run_configuration()
+        detectors = namespace.select(devices_config)
+        movables = [_namespace_movable(namespace, target) for target in axis_resolved]
     created.extend(factories.created)
 
     # ---- phase 3: in-plan connects (still pre-claim) ----------------------
@@ -545,6 +486,10 @@ def prepare_step_scan(
     # Telemetry is soft: appended as extra snapshot columns, never the
     # reference (index 0 stays the save set's).
     all_detectors = list(detectors) + telemetry_readables
+    # The stock-plan door reads only what the plan was handed, so the
+    # telemetry tail has to be injected into the same event by the
+    # preprocessor; it is kept addressable for that.
+
     if controller is not None and not session._mock:
         # Fail fast on an unreachable shot-control PV (the session does this
         # at attach time; in-plan it joins the pre-claim connect stage).
@@ -594,4 +539,5 @@ def prepare_step_scan(
         per_step=per_step,
         closeout=closeout,
         telemetry_selected=telemetry_selected,
+        telemetry_readables=list(telemetry_readables),
     )

--- a/GeecsBluesky/geecs_bluesky/plans/preamble.py
+++ b/GeecsBluesky/geecs_bluesky/plans/preamble.py
@@ -67,6 +67,7 @@ logger = logging.getLogger(__name__)
 
 __all__ = [
     "PreparedScan",
+    "namespace_detectors",
     "ResolvedRequest",
     "prepare_step_scan",
     "resolve_request",
@@ -245,6 +246,100 @@ def _disconnect_plan(created: list):
     yield from bps.wait_for([_disconnect_all])
 
 
+def namespace_detectors(
+    namespace: Any, devices_config: dict[str, dict[str, Any]], *, free_run: bool
+) -> list:
+    """The save set's devices, taken from the **namespace** instead of built.
+
+    The role assignment is `_build_request_detectors`' — free-run: the first
+    synchronous entry is the reference and later ones contributors; strict:
+    every synchronous entry is triggered; asynchronous entries are snapshots
+    — but the objects are the long-lived namespace nouns a stock plan is
+    handed, not fresh per-scan devices.  That identity is the whole point:
+    two objects for one device would double the connections and apply the
+    saving configuration to something the plan never reads.
+
+    Roles are asserted rather than chosen, because a namespace device's class
+    is already decided by :func:`~geecs_bluesky.namespace.looks_triggerable`:
+    a synchronous save-set entry must be a triggerable device, an
+    asynchronous one must not be.  A mismatch is a configuration error worth
+    hearing about, not something to paper over.
+
+    The recorded scalars must also match: the namespace device reads the DB's
+    subscribed list, so a save-set entry naming a different set (an explicit
+    ``scalars:`` list) cannot be honoured without per-run reselection —
+    refused loudly rather than silently logging different columns.
+    """
+    from geecs_bluesky.devices.ca.generic_detector import CaGenericDetector
+    from geecs_bluesky.utils import safe_name
+
+    detectors: list = []
+    reference_assigned = False
+    for device_name, cfg in devices_config.items():
+        variables = list(cfg.get("variable_list") or [])
+        synchronous = bool(cfg.get("synchronous", False))
+        try:
+            device = namespace[device_name]
+        except KeyError as exc:
+            raise GeecsConfigurationError(
+                f"save set names {device_name!r}, which is not in the device "
+                f"namespace for {getattr(namespace, 'experiment', '?')}"
+            ) from exc
+
+        triggerable = isinstance(device, CaGenericDetector)
+        if synchronous and not triggerable:
+            raise GeecsConfigurationError(
+                f"{device_name}: the save set marks it synchronous (shot-triggered) "
+                "but the namespace built it as a non-triggered device — fix the "
+                "save-set role, or the triggerable classification for its devicetype"
+            )
+        if not synchronous and triggerable:
+            logger.warning(
+                "%s: save-set role is asynchronous but the device is "
+                "shot-triggered; reading it once per row anyway",
+                device_name,
+            )
+        if not synchronous and not variables:
+            logger.warning(
+                "Skipping asynchronous device %s: no scalars to record", device_name
+            )
+            continue
+
+        wanted = {safe_name(v) for v in variables}
+        have = {safe_name(v) for v in device.variables}
+        missing = wanted - have
+        if missing:
+            raise GeecsConfigurationError(
+                f"{device_name}: the save set records {sorted(missing)}, which the "
+                "namespace device does not read (it reads the DB's subscribed "
+                "list). Add them to the device's subscribed variables, or drop "
+                "them from the save set."
+            )
+
+        save = bool(cfg.get("save_nonscalar_data", False))
+        save_control_only = bool(cfg.get("save_control_only", False))
+        if hasattr(device, "configure_saving_mode"):
+            device.configure_saving_mode(
+                save_nonscalar_data=save, save_control_only=save_control_only
+            )
+        elif save or save_control_only:
+            raise GeecsConfigurationError(
+                f"{device_name}: native saving was requested but the namespace "
+                "device has no save-control support"
+            )
+
+        # Free-run contributor anchoring is applied post-claim by
+        # GeecsSession.configure_claimed_scan (set_reference); order is what
+        # marks the reference, so preserve it.
+        if synchronous and not reference_assigned:
+            detectors.insert(0, device)
+            reference_assigned = True
+        else:
+            detectors.append(device)
+    _ = free_run  # role order is positional; the flag stays for symmetry
+    return detectors
+
+
 @dataclass(frozen=True)
 class ResolvedRequest:
     """What :func:`resolve_request` settles before the mode branch."""
@@ -336,8 +431,15 @@ def prepare_step_scan(
     created: list,
     *,
     submission: Any | None = None,
+    namespace: Any | None = None,
 ):
     """The pre-claim preamble for a step/noscan request; returns a :class:`PreparedScan`.
+
+    *namespace* is the device-source seam.  ``None`` (the funnel) builds
+    fresh per-scan devices through the session factories, as it always has.
+    A :class:`~geecs_bluesky.namespace.GeecsNamespace` (the preprocessor
+    door) instead **selects** the save set's devices from the namespace, so
+    the objects are the very ones a stock plan was handed.
 
     A plan (it yields the connect messages), so the caller drives it with
     ``yield from``.  Everything it constructs is appended to *created* — the
@@ -408,8 +510,20 @@ def prepare_step_scan(
             setup_plans + per_step_plans + closeout_plans, registry, factory
         )
 
-    detectors = _build_request_detectors(factories, devices_config, free_run=not strict)
-    movables = [build_movable(factories, target) for target in axis_resolved]
+    if namespace is None:
+        detectors = _build_request_detectors(
+            factories, devices_config, free_run=not strict
+        )
+        movables = [build_movable(factories, target) for target in axis_resolved]
+    else:
+        # Stock-plan door: the objects must be the ones the plan itself is
+        # handed, so the save set SELECTS namespace devices instead of
+        # constructing new ones (see namespace_detectors).
+        detectors = namespace_detectors(namespace, devices_config, free_run=not strict)
+        movables = [
+            namespace.variable(target.device, target.variable)
+            for target in axis_resolved
+        ]
     created.extend(factories.created)
 
     # ---- phase 3: in-plan connects (still pre-claim) ----------------------

--- a/GeecsBluesky/geecs_bluesky/plans/run_wrapper.py
+++ b/GeecsBluesky/geecs_bluesky/plans/run_wrapper.py
@@ -202,6 +202,29 @@ def claimed_scan_metadata(
     return md
 
 
+def save_control_only_off_plan(devices: list | None):
+    """Plan: drive ``save="off"`` for every capture-owned camera in *devices*.
+
+    A save flag left on out-of-band must never keep writing native files to
+    a stale path during a toggle-off scan.  Eager — turning saving OFF needs
+    no trigger windowing, unlike turning it on (Gate-2, ``CLAUDE.md``).
+
+    Both scan doors need this, so it is one plan stub rather than a copy in
+    each: :func:`geecs_run_wrapper` for the funnel, and the stock-plan
+    preamble preprocessor.
+
+    Yields
+    ------
+    Bluesky messages.
+    """
+    off_args: list = []
+    for dev in devices or []:
+        if getattr(dev, "_save_control_only", False) and hasattr(dev, "save"):
+            off_args.extend([dev.save, "off"])
+    if off_args:
+        yield from bps.mv(*off_args)
+
+
 def geecs_run_wrapper(
     plan,
     *,
@@ -267,16 +290,7 @@ def geecs_run_wrapper(
 
     wrapped = bpp.inject_md_wrapper(plan, md)
 
-    # Active save-off for capture-owned cameras (save_control_only devices):
-    # a save flag left on out-of-band must never keep writing native files
-    # to a stale path during a toggle-off scan. Eager — turning OFF needs no
-    # trigger windowing, unlike save-on.
-    off_args: list = []
-    for dev in devices or []:
-        if getattr(dev, "_save_control_only", False) and hasattr(dev, "save"):
-            off_args.extend([dev.save, "off"])
-    if off_args:
-        yield from bps.mv(*off_args)
+    yield from save_control_only_off_plan(devices)
 
     if not saving:
         yield from wrapped

--- a/GeecsBluesky/geecs_bluesky/plans/run_wrapper.py
+++ b/GeecsBluesky/geecs_bluesky/plans/run_wrapper.py
@@ -145,6 +145,63 @@ def _collect_scalar_headers(devices: list) -> dict[str, str]:
     return headers
 
 
+def claimed_scan_metadata(
+    *,
+    experiment: str = "",
+    scan_number: int | None = None,
+    scan_folder: str | None = None,
+    saving_detectors: list[tuple] | None = None,
+    devices: list | None = None,
+    extra_md: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """The GEECS run metadata for a claimed scan, and the dirs it implies.
+
+    The one assembly of ``bluesky_backend``/``experiment``/``scan_number``/
+    ``scan_id``/``scan_folder``/``nonscalar_save_paths``/
+    ``geecs_scalar_headers`` plus the caller's *extra_md* — shared by
+    :func:`geecs_run_wrapper` (the funnel door) and the preamble
+    preprocessor (the stock-plan door), so neither can drift from what the
+    downstream readers require (s-file export, Tiled schema and catalog,
+    the capture daemon, asset readback).
+
+    Creating the capture-owned camera directories is part of it: the capture
+    daemon never mkdirs (cross-package invariant) and its writers must find
+    them on the first frame, i.e. **before the start document**.
+    """
+    saving = list(saving_detectors or [])
+    md: dict[str, Any] = {"bluesky_backend": True}
+    if experiment:
+        md["experiment"] = experiment
+    if scan_number is not None:
+        md["scan_number"] = scan_number
+        md["scan_id"] = scan_number  # Bluesky display field = GEECS scan number
+    if scan_folder is not None:
+        md["scan_folder"] = scan_folder
+    if saving:
+        md["nonscalar_save_paths"] = {
+            getattr(det, "_geecs_device_name", det.name): event_path
+            for det, event_path, _device_command_path in map(
+                _saving_detector_paths, saving
+            )
+        }
+    scalar_headers = _collect_scalar_headers(devices or [])
+    if scalar_headers:
+        md["geecs_scalar_headers"] = scalar_headers
+    md.update(extra_md or {})
+
+    # Engine-side dir creation for capture-owned camera dirs (the capture
+    # daemon never mkdirs — cross-package invariant), BEFORE the start doc
+    # is emitted so the daemon's writers find them on the first frame. With
+    # native saving off these devices skip save_enable_plan's makedirs;
+    # exist_ok covers the dual-write overlap when both run.
+    capture_names = md.get("capture_devices")
+    if scan_folder is not None and isinstance(capture_names, (list, tuple)):
+        for name in capture_names:
+            os.makedirs(os.path.join(scan_folder, str(name)), exist_ok=True)
+
+    return md
+
+
 def geecs_run_wrapper(
     plan,
     *,
@@ -198,37 +255,15 @@ def geecs_run_wrapper(
     plan keeps ownership of its intrinsic keys (``plan_name``,
     ``acquisition_mode``, ``geecs_event_schema``, positions, …).
     """
+    md = claimed_scan_metadata(
+        experiment=experiment,
+        scan_number=scan_number,
+        scan_folder=scan_folder,
+        saving_detectors=saving_detectors,
+        devices=devices,
+        extra_md=extra_md,
+    )
     saving = list(saving_detectors or [])
-
-    md: dict[str, Any] = {"bluesky_backend": True}
-    if experiment:
-        md["experiment"] = experiment
-    if scan_number is not None:
-        md["scan_number"] = scan_number
-        md["scan_id"] = scan_number  # Bluesky display field = GEECS scan number
-    if scan_folder is not None:
-        md["scan_folder"] = scan_folder
-    if saving:
-        md["nonscalar_save_paths"] = {
-            getattr(det, "_geecs_device_name", det.name): event_path
-            for det, event_path, _device_command_path in map(
-                _saving_detector_paths, saving
-            )
-        }
-    scalar_headers = _collect_scalar_headers(devices or [])
-    if scalar_headers:
-        md["geecs_scalar_headers"] = scalar_headers
-    md.update(extra_md or {})
-
-    # Engine-side dir creation for capture-owned camera dirs (the capture
-    # daemon never mkdirs — cross-package invariant), BEFORE the start doc
-    # is emitted so the daemon's writers find them on the first frame. With
-    # native saving off these devices skip save_enable_plan's makedirs;
-    # exist_ok covers the dual-write overlap when both run.
-    capture_names = md.get("capture_devices")
-    if scan_folder is not None and isinstance(capture_names, (list, tuple)):
-        for name in capture_names:
-            os.makedirs(os.path.join(scan_folder, str(name)), exist_ok=True)
 
     wrapped = bpp.inject_md_wrapper(plan, md)
 

--- a/GeecsBluesky/geecs_bluesky/plans/scan_request_plan.py
+++ b/GeecsBluesky/geecs_bluesky/plans/scan_request_plan.py
@@ -52,7 +52,6 @@ worker-wide default session via :func:`set_plan_session`) later.
 
 from __future__ import annotations
 
-import asyncio
 import json
 import logging
 import math
@@ -62,15 +61,21 @@ from typing import Any, Callable
 import bluesky.plan_stubs as bps
 import bluesky.preprocessors as bpp
 from bluesky.utils import RequestAbort
-from ophyd_async.plan_stubs import ensure_connected
 
 from geecs_bluesky.config_resolver import ConfigResolver, ConfigsRepoResolver
-from geecs_bluesky.db_runtime import select_telemetry_variables
 from geecs_bluesky.exceptions import GeecsConfigurationError
 from geecs_bluesky.optimize import BinData
 from geecs_bluesky.plans.optimize import geecs_adaptive_scan
 from geecs_bluesky.plans.orchestration import _with_pause_quiescer
 from geecs_bluesky.plans.pause_semantics import ShotControlPauseQuiescer
+from geecs_bluesky.plans.preamble import (
+    _await_in_plan,
+    _connect_in_batches,
+    _DeferredConnectFactories,
+    _disconnect_plan,
+    prepare_step_scan,
+    resolve_request,
+)
 from geecs_bluesky.plans.run_wrapper import (
     claim_scan,
     claim_scan_number,
@@ -85,30 +90,24 @@ from geecs_bluesky.scan_log import (
 from geecs_bluesky.scan_request_runner import (
     PseudoMovableTarget,
     _build_request_detectors,
-    _defaults_flag,
     _preflight_connected,
     _preflight_unserved,
-    assemble_action_slots,
     build_action_registry,
     build_movable,
-    build_step_scan_spec,
     compile_action_slot,
     make_scalar_policy,
     metadata_applied_defaults,
     metadata_submission,
     merge_optimizer_device_requirements,
     prefetch_action_signals,
-    resolve_and_apply_capture_toggle,
     resolve_movable_target,
     resolve_save_sets_and_rituals,
     save_set_to_devices_config,
-    trigger_writes_from_profile,
-    validate_scan_request,
     warn_if_reserved_boundary_overrides,
 )
 from geecs_bluesky.session import _json_safe
 from geecs_bluesky.shot_controller import ShotController
-from geecs_schemas import AcquisitionMode, ScanRequest, ScanRequestMode
+from geecs_schemas import ScanRequest, ScanRequestMode
 
 logger = logging.getLogger(__name__)
 
@@ -202,28 +201,6 @@ RUN_ACTION_PLAN_ANNOTATION: dict = {
     },
 }
 
-#: Per-connect timeout for the in-plan strict batches.  Near-parity, not
-#: parity, with ``GeecsSession._connect``: there 20 s is the outer wall on
-#: the loop hop while each connect runs at the ophyd-async default (10 s),
-#: so an unreachable device fails at ~10 s; here the 20 s *is* the
-#: per-connect timeout, so the same failure surfaces ~10 s later.
-_CONNECT_TIMEOUT = 20.0
-
-#: The session factory methods whose *construction* code the plan reuses
-#: verbatim (only the connect step is deferred — see
-#: :class:`_DeferredConnectFactories`).
-_SESSION_FACTORIES = frozenset(
-    {
-        "detector",
-        "contributor",
-        "snapshot",
-        "motor",
-        "settable",
-        "confirm_settable",
-        "pseudo_movable",
-        "action_signal_factory",
-    }
-)
 
 #: The worker-wide default session (installed once at worker startup).
 _worker_session: Any | None = None
@@ -278,155 +255,6 @@ def set_optimization_loader(loader: Callable[[Any], Any] | None) -> None:
     """
     global _optimization_loader
     _optimization_loader = loader
-
-
-class _DeferredConnectFactories:
-    """A session facade: identical device construction, connect deferred.
-
-    The session's factory methods (``detector``, ``motor``, …) are the one
-    definition of how request devices are constructed — but each ends in
-    ``self._connect(device)``, a blocking hop onto the RE loop that would
-    deadlock inside a plan.  This facade binds those *same* class functions
-    to itself (so the construction code cannot drift from the session's)
-    and swaps only ``_connect``: devices are recorded on :attr:`created`
-    and connected later in one in-plan batch.  Everything else (attributes
-    like ``experiment`` / ``_mock`` / ``rep_rate_hz``) delegates to the
-    wrapped session.
-
-    Deliberately *not* covering ``telemetry``/``telemetry_batch``: the soft
-    tier's connect-failure-drops semantics need their own in-plan gather
-    (:func:`_connect_telemetry_plan`), not the strict batch connect.
-    """
-
-    def __init__(self, session: Any) -> None:
-        self._session = session
-        self.created: list = []
-
-    def _connect(self, device: Any) -> Any:
-        self.created.append(device)
-        return device
-
-    def __getattr__(self, name: str) -> Any:
-        if name in _SESSION_FACTORIES:
-            func = getattr(type(self._session), name, None)
-            if func is not None:
-                return func.__get__(self, type(self))
-        return getattr(self._session, name)
-
-
-def _await_in_plan(coro_fn: Any):
-    """Plan stub: await one no-arg coroutine function, propagating its error.
-
-    ``bps.wait_for`` alone parks the plan on the future but discards its
-    outcome; re-raising through ``task.result()`` keeps in-plan connects
-    fail-fast (the ophyd-async ``wait_for_awaitable`` idiom, not exported
-    by the pinned release).
-    """
-    tasks = yield from bps.wait_for([coro_fn])
-    return tasks[0].result()
-
-
-def _connect_in_batches(devices: list, *, mock: bool):
-    """Plan stub: strict-connect *devices* via ``ensure_connected``.
-
-    ``ensure_connected`` refuses duplicate device names within one call, and
-    an action-check signal can legitimately share a name with a scan-axis
-    movable on the same ``Device:Variable`` — so the list is split into
-    unique-name batches instead of failing the scan on a naming accident.
-    Failures propagate (strict tier fails loudly), pre-claim.
-    """
-    pending = list(devices)
-    while pending:
-        batch: list = []
-        rest: list = []
-        seen: set[str] = set()
-        for device in pending:
-            if device.name in seen:
-                rest.append(device)
-            else:
-                seen.add(device.name)
-                batch.append(device)
-        yield from ensure_connected(*batch, mock=mock, timeout=_CONNECT_TIMEOUT)
-        pending = rest
-
-
-def _connect_telemetry_plan(session: Any, save_set: Any, scalar_policy: Any):
-    """Plan stub: build + soft-connect the Tier-2 telemetry group in-plan.
-
-    Same selection (:func:`~geecs_bluesky.db_runtime.select_telemetry_variables`),
-    same soft-tier contract (a device unreachable at scan start is dropped
-    with a warning, never an abort; only connected devices are recorded),
-    one :class:`~geecs_bluesky.devices.ca.telemetry.CaTelemetryGroup` per
-    scan.  One concurrent gather, so wall time is the slowest device.
-
-    Returns
-    -------
-    tuple
-        ``(readables, recorded)`` — the group (or nothing) to append to the
-        read set, and ``{device: [variables]}`` of what actually connected.
-    """
-    if scalar_policy is None:
-        return [], {}
-    selected = select_telemetry_variables(
-        save_set, scalar_policy.subscribed_by_device()
-    )
-    if not selected:
-        return [], {}
-    # Lazy import: keeps this module importable without the `ca` extra
-    # (same discipline as the runner).
-    from geecs_bluesky.devices.ca.telemetry import CaTelemetryGroup, CaTelemetryReadable
-
-    members = [
-        CaTelemetryReadable(device, variables, experiment=session.experiment)
-        for device, variables in selected.items()
-    ]
-    results: list = []
-
-    async def _connect_all() -> None:
-        results.extend(
-            await asyncio.gather(
-                *(m.connect(mock=session._mock) for m in members),
-                return_exceptions=True,
-            )
-        )
-
-    yield from bps.wait_for([_connect_all])
-
-    connected: list = []
-    recorded: dict[str, list[str]] = {}
-    for member, variables, result in zip(members, selected.values(), results):
-        if isinstance(result, BaseException):
-            logger.warning(
-                "Dropping background-telemetry device %s: unreachable at scan "
-                "start (soft tier — never aborts the scan)",
-                member._geecs_device_name,
-                exc_info=result,
-            )
-        else:
-            connected.append(member)
-            recorded[member._geecs_device_name] = list(variables)
-    if not connected:
-        return [], recorded
-    return [CaTelemetryGroup(connected)], recorded
-
-
-def _disconnect_plan(created: list):
-    """Plan stub: best-effort disconnect of everything the plan created.
-
-    The in-plan counterpart of the runner's ``finally:
-    session.disconnect(*created)`` (which hops onto the RE loop).  Runs as
-    a finalize, so it executes on success, failure, and abort alike; each
-    device's failure is swallowed (gather with exceptions returned) —
-    cleanup never masks the plan's own outcome.
-    """
-    closers = [d for d in created if hasattr(d, "disconnect")]
-    if not closers:
-        return
-
-    async def _disconnect_all() -> None:
-        await asyncio.gather(*(d.disconnect() for d in closers), return_exceptions=True)
-
-    yield from bps.wait_for([_disconnect_all])
 
 
 # Signature constraint (queueserver contract): at `queue add` the RE Manager
@@ -593,23 +421,10 @@ def _scan_request_body(
     *failed_move_policy* are the two front-door seams (see the plan's doc).
     """
     # ---- phase 1: authoritative validation + pure resolution (pre-claim) --
-    if not isinstance(request, ScanRequest):
-        request = ScanRequest.model_validate(request)
-    request, applied_defaults, defaults = validate_scan_request(request, resolver)
-
-    controller = None
-    if request.capture.trigger_profile:
-        profile = resolver.resolve_trigger_profile(request.capture.trigger_profile)
-        writes = trigger_writes_from_profile(profile)
-        if writes.states:
-            # Constructed worker-side, unconnected; the setter reachability
-            # check joins the in-plan connect stage below.
-            controller = ShotController.from_writes(
-                writes,
-                experiment=session.experiment,
-                rep_rate_hz=session.rep_rate_hz,
-            )
-    strict = request.capture.acquisition is AcquisitionMode.STRICT
+    resolved = resolve_request(session, resolver, request)
+    request = resolved.request
+    controller = resolved.controller
+    strict = resolved.strict
 
     if request.mode is ScanRequestMode.OPTIMIZE:
         if request.capture.native_image_save is False:
@@ -628,124 +443,16 @@ def _scan_request_body(
                 controller,
                 strict,
                 created,
-                applied_defaults=applied_defaults,
+                applied_defaults=resolved.applied_defaults,
                 submission=submission,
                 optimization_loader=optimization_loader,
             )
         )
 
-    save_set, rituals = resolve_save_sets_and_rituals(
-        resolver, request.capture.save_sets
+    # ---- phases 1b-3: the shared pre-claim preamble (plans/preamble.py) ----
+    prepared = yield from prepare_step_scan(
+        session, resolver, resolved, created, submission=submission
     )
-    scalar_policy = make_scalar_policy(session)
-    devices_config = save_set_to_devices_config(save_set, scalar_policy)
-    # Unserved-variables check, headless by decision 3 (operator questions
-    # are client-side pre-submit): continue-and-drop with a WARNING.
-    checked_config, dropped_unserved, dropped_unserved_devices = _preflight_unserved(
-        session, devices_config
-    )
-    if checked_config is None:  # defensive: the headless default never aborts
-        raise GeecsConfigurationError(
-            "unserved-variables pre-flight aborted the scan (pre-claim)"
-        )
-    devices_config = checked_config
-    # CONNECTED liveness re-check (#664): the client asked pre-submit, but
-    # the queue's submission-to-execution gap is long — re-check here,
-    # refusing only when a row could never complete.
-    disconnected_devices = _preflight_connected(session, devices_config)
-    slots = assemble_action_slots(request.actions, applied_defaults, rituals)
-    warn_if_reserved_boundary_overrides(save_set)
-    axis_resolved = [
-        resolve_movable_target(
-            resolver.resolve_scan_variable(axis.variable), axis.variable
-        )
-        for axis in request.axes
-    ]
-    telemetry_enabled = (
-        request.capture.background_telemetry
-        if request.capture.background_telemetry is not None
-        else _defaults_flag(defaults, "background_telemetry", True)
-    )
-    devices_config, capture_devices, native_image_save = (
-        resolve_and_apply_capture_toggle(request, defaults, devices_config, session)
-    )
-
-    # ---- phase 2: worker-side construction (connects deferred) -----------
-    factories = _DeferredConnectFactories(session)
-    setup = per_step = closeout = None
-    if any(slots.values()):
-        factory = factories.action_signal_factory()
-        created.append(factory)
-        registry = build_action_registry(resolver)
-        setup, setup_plans = compile_action_slot(
-            slots["setup"], resolver, registry, factory
-        )
-        per_step, per_step_plans = compile_action_slot(
-            slots["per_step"], resolver, registry, factory
-        )
-        closeout, closeout_plans = compile_action_slot(
-            slots["closeout"], resolver, registry, factory
-        )
-        # With the facade, "prefetch" records the signals for the batch
-        # connect below — same fail-fast property, now a plan message.
-        prefetch_action_signals(
-            setup_plans + per_step_plans + closeout_plans, registry, factory
-        )
-
-    detectors = _build_request_detectors(factories, devices_config, free_run=not strict)
-    movables = [build_movable(factories, target) for target in axis_resolved]
-    created.extend(factories.created)
-
-    # ---- phase 3: in-plan connects (still pre-claim) ----------------------
-    if factories.created:
-        yield from _connect_in_batches(factories.created, mock=session._mock)
-    telemetry_selected: dict[str, list[str]] = {}
-    telemetry_readables: list = []
-    if telemetry_enabled:
-        telemetry_readables, telemetry_selected = yield from _connect_telemetry_plan(
-            session, save_set, scalar_policy
-        )
-        created.extend(telemetry_readables)
-    # Telemetry is soft: appended as extra snapshot columns, never the
-    # reference (index 0 stays the save set's).
-    all_detectors = list(detectors) + telemetry_readables
-    if controller is not None and not session._mock:
-        # Fail fast on an unreachable shot-control PV (the session does this
-        # at attach time; in-plan it joins the pre-claim connect stage).
-        yield from _await_in_plan(controller.connect_setters)
-
-    if not all_detectors:
-        raise GeecsConfigurationError(
-            "ScanRequest produced no detectors (empty effective device set) — "
-            "nothing would be recorded"
-        )
-    if strict:
-        if controller is None:
-            raise GeecsConfigurationError(
-                "strict_shot_control requires a reachable shot-control device. "
-                "Use free-run mode for free-running trigger acquisition."
-            )
-        controller.require_strict_single_shot()
-
-    spec = build_step_scan_spec(
-        request,
-        axis_resolved,
-        applied_defaults=applied_defaults,
-        slots=slots,
-        dropped_unserved=dropped_unserved,
-        dropped_unserved_devices=dropped_unserved_devices,
-        disconnected_devices=disconnected_devices,
-        telemetry_selected=telemetry_selected if telemetry_enabled else {},
-        capture_devices=capture_devices,
-        native_image_save=native_image_save,
-        submission=submission,
-    )
-    if request.mode is ScanRequestMode.NOSCAN:
-        motor_arg: Any = None
-    elif len(movables) == 1:
-        motor_arg = movables[0]
-    else:
-        motor_arg = movables
 
     # ---- phase 4: the claim boundary --------------------------------------
     scan_number, scan_folder = claim_scan_number(session.experiment)
@@ -757,18 +464,7 @@ def _scan_request_body(
     inner = session.build_claimed_scan_plan(
         scan_number=scan_number,
         scan_folder=scan_folder,
-        detectors=all_detectors,
-        motor=motor_arg,
-        positions=spec.positions,
-        shots_per_step=request.capture.shots_per_step,
-        strict=strict,
-        controller=controller,
-        description=request.description,
-        md=spec.md,
-        scan_info_overrides=spec.scan_info,
-        setup=setup,
-        per_step=per_step,
-        closeout=closeout,
+        **prepared.as_claimed_kwargs(),
         # Decision-4 activation (issue #641, PR #645): under the queue a
         # failed move pauses — the RE Manager renders the paused state and
         # resume/stop are first-class queue verbs.  The headless door

--- a/GeecsBluesky/geecs_bluesky/plans/scan_request_plan.py
+++ b/GeecsBluesky/geecs_bluesky/plans/scan_request_plan.py
@@ -202,27 +202,14 @@ RUN_ACTION_PLAN_ANNOTATION: dict = {
 }
 
 
-#: The worker-wide default session (installed once at worker startup).
-_worker_session: Any | None = None
-
-
-def set_plan_session(session: Any | None) -> None:
-    """Install the worker-wide default :class:`GeecsSession` for the plan.
-
-    The queueserver registers plans by name with JSON args, so the session
-    cannot travel in the call — a worker startup script constructs one
-    headless session and installs it here; ``RE(geecs_scan_request_plan(
-    request))`` then needs nothing else.  Pass ``None`` to clear (tests).
-
-    Parameters
-    ----------
-    session :
-        The session whose RunEngine will execute the plan.  The plan's
-        connect messages run on that engine's loop, so running the plan on
-        a *different* RunEngine than ``session.RE`` is unsupported.
-    """
-    global _worker_session
-    _worker_session = session
+# The worker-wide default session lives in `geecs_bluesky.plan_session` (a
+# neutral home shared with the stock-plan preamble preprocessor, which
+# outlives this module).  Re-exported here so existing importers of
+# `set_plan_session` keep working.
+from geecs_bluesky.plan_session import (  # noqa: E402
+    get_plan_session,
+    set_plan_session,
+)
 
 
 #: The worker-wide optimization loader (installed once at worker startup,
@@ -357,7 +344,7 @@ def geecs_scan_request_plan(
     pin test named there before adding any annotation back.
     """
     if session is None:
-        session = _worker_session
+        session = get_plan_session()
         if session is None:
             raise GeecsConfigurationError(
                 "geecs_scan_request_plan has no session: install one with "
@@ -925,7 +912,7 @@ def geecs_run_action_plan(
         reference (fail-fast, before any signal connects).
     """
     if session is None:
-        session = _worker_session
+        session = get_plan_session()
         if session is None:
             raise GeecsConfigurationError(
                 "geecs_run_action_plan has no session: install one with "

--- a/GeecsBluesky/geecs_bluesky/plans/single_shot.py
+++ b/GeecsBluesky/geecs_bluesky/plans/single_shot.py
@@ -130,6 +130,48 @@ def geecs_single_shot(
     ------
     Bluesky messages.
     """
+    yield from fire_and_await_shot(devices, fire, max_refires=max_refires)
+    yield from bps.create(name)
+    for obj in devices:
+        yield from bps.read(obj)
+    yield from bps.save()
+
+
+def fire_and_await_shot(
+    devices: Sequence[Any],
+    fire: Callable,
+    *,
+    max_refires: int = 2,
+    pending_wait: Any = None,
+):
+    """Arm the waiters, fire one shot, and await the frames, with refire.
+
+    The acquisition half of :func:`geecs_single_shot`, split out because the
+    **stock-plan door** needs exactly this and not the event bundling:
+    ``bps.trigger_and_read`` has already issued the triggers and is about to
+    wait, so the preprocessor
+    (:func:`~geecs_bluesky.preprocessors.geecs_preamble`) hands that pending
+    wait in and gets the fire, the refire loop, and the device-down gating
+    from this one implementation rather than a second copy of the seam.
+
+    Parameters
+    ----------
+    devices:
+        The devices of the shot.  Triggerable ones are armed and awaited.
+    fire:
+        Plan-stub callable emitting exactly one trigger.
+    max_refires:
+        Extra fire attempts after the first fails (see :func:`geecs_single_shot`).
+    pending_wait:
+        A ``Msg("wait", group=…)`` whose triggers the **caller** already
+        issued.  When given, the first attempt fires into that gap and yields
+        this message instead of arming a group of its own; a refire falls
+        back to a fresh group, which also re-baselines every device.
+
+    Yields
+    ------
+    Bluesky messages.
+    """
     triggerables = [obj for obj in devices if isinstance(obj, Triggerable)]
     attempts = max_refires + 1
     for attempt in range(1, attempts + 1):
@@ -137,13 +179,19 @@ def geecs_single_shot(
         # must never be waited on again (a fresh trigger supersedes them).
         grp = short_uid("single_shot")
         try:
-            for obj in triggerables:
-                yield from bps.trigger(obj, group=grp, wait=False)
-            fire_t0 = time.monotonic()
-            yield from fire()
-            fire_done = time.monotonic()
-            if triggerables:
-                yield from bps.wait(group=grp)
+            if attempt == 1 and pending_wait is not None:
+                fire_t0 = time.monotonic()
+                yield from fire()
+                fire_done = time.monotonic()
+                yield pending_wait
+            else:
+                for obj in triggerables:
+                    yield from bps.trigger(obj, group=grp, wait=False)
+                fire_t0 = time.monotonic()
+                yield from fire()
+                fire_done = time.monotonic()
+                if triggerables:
+                    yield from bps.wait(group=grp)
             if logger.isEnabledFor(logging.DEBUG):
                 logger.debug(
                     "shot phases: fire %.1f ms, frame wait %.1f ms (%d triggerables)",
@@ -178,11 +226,7 @@ def geecs_single_shot(
                 device_name,
             )
         else:
-            break
-    yield from bps.create(name)
-    for obj in devices:
-        yield from bps.read(obj)
-    yield from bps.save()
+            return
 
 
 def geecs_confirm_quiescent(

--- a/GeecsBluesky/geecs_bluesky/plans/step_scan.py
+++ b/GeecsBluesky/geecs_bluesky/plans/step_scan.py
@@ -43,6 +43,34 @@ from geecs_bluesky.plans.single_shot import geecs_single_shot
 logger = logging.getLogger(__name__)
 
 
+def geecs_execution_md(
+    *,
+    motors: list,
+    positions: list,
+    shots_per_step: int,
+    fires_own_shots: bool,
+) -> dict[str, Any]:
+    """The GEECS execution keys every scan's start document must carry.
+
+    Not decoration: ``tiled_catalog`` reads ``acquisition_mode``,
+    ``tiled_schema`` reads ``motor``, ``positions`` and ``shots_per_step``,
+    and the event-schema version gates how readers interpret the columns.
+    Both doors emit them from here — the funnel through
+    :func:`geecs_step_scan`'s own metadata, the stock-plan door through the
+    preamble preprocessor — so a scan cannot be recorded differently
+    depending on which one ran it.
+    """
+    return {
+        "acquisition_mode": "strict_shot_control",
+        "geecs_event_schema": 1,
+        # True when the plan fires each shot (strict single-shot).
+        "fires_own_shots": fires_own_shots,
+        "motor": motor_md(motors),
+        "positions": list(positions),
+        "shots_per_step": shots_per_step,
+    }
+
+
 def normalize_motors(motor: Any | Sequence[Any] | None) -> list[Any]:
     """Return the motor argument as a list (``None`` → ``[]``).
 
@@ -287,14 +315,13 @@ def geecs_step_scan(
 
     _md: dict[str, Any] = {
         "plan_name": "geecs_step_scan",
-        "acquisition_mode": "strict_shot_control",
-        "geecs_event_schema": 1,
-        # True when the plan fires each shot (strict single-shot).
-        "fires_own_shots": fire_shot is not None,
-        "motor": motor_md(_motors),
+        **geecs_execution_md(
+            motors=_motors,
+            positions=_positions,
+            shots_per_step=shots_per_step,
+            fires_own_shots=fire_shot is not None,
+        ),
         "detectors": [getattr(d, "name", str(d)) for d in detectors],
-        "positions": _positions,
-        "shots_per_step": shots_per_step,
         "num_points": len(_positions),
         **(md or {}),
     }

--- a/GeecsBluesky/geecs_bluesky/preprocessors.py
+++ b/GeecsBluesky/geecs_bluesky/preprocessors.py
@@ -227,6 +227,7 @@ def geecs_preamble(
     created: list = []
     state: dict[str, Any] = {}
     forwarded: set[int] = set()
+    armed_groups: set[Any] = set()
 
     def _cleanup() -> Generator[Msg, Any, Any]:
         """The funnel's finalize chain, innermost first, for whatever ran."""
@@ -241,7 +242,42 @@ def geecs_preamble(
         if created:
             yield from _disconnect_plan(created)
 
+    def _fire_before_wait(msg: Msg) -> tuple[Any, Any]:
+        """Insert the shot between arming the waiters and waiting on them.
+
+        ``trigger_and_read`` issues ``trigger`` for every detector under one
+        group and then waits on that group.  Strict shot control needs the
+        fire to land in exactly that gap — the detectors have baselined their
+        ``acq_timestamp`` and are waiting, so a shot fired now cannot be
+        missed — which is why ``bps.trigger_and_read`` alone cannot express
+        it (see ``plans/single_shot.py``).  Doing it here means a **stock**
+        plan needs no ``per_shot`` hook at all.
+        """
+        fire = state.get("fire")
+        if fire is None:
+            return None, None
+        if msg.command == "trigger" and id(msg.obj) in state["detectors"]:
+            group = msg.kwargs.get("group")
+            if group is not None:
+                armed_groups.add(group)
+            return None, None
+        if msg.command != "wait":
+            return None, None
+        group = msg.kwargs.get("group")
+        if group not in armed_groups:
+            return None, None
+        armed_groups.discard(group)
+
+        def _fire_then_wait() -> Generator[Msg, Any, Any]:
+            yield from fire()
+            return (yield msg)
+
+        return _fire_then_wait(), None
+
     def _prepare(msg: Msg) -> tuple[Any, Any]:
+        fired = _fire_before_wait(msg)
+        if fired != (None, None):
+            return fired
         if msg.command != "open_run" or id(msg) in forwarded:
             return None, None
         request = msg.kwargs.get(md_key)
@@ -260,6 +296,17 @@ def geecs_preamble(
 
         def _run_preamble() -> Generator[Msg, Any, Any]:
             resolved = resolve_request(sess, res, request)
+            if not resolved.strict:
+                raise GeecsConfigurationError(
+                    "stock plans run strict shot control only: free-run is "
+                    "retired (GEECS-Plugins#807). Set acquisition='strict'."
+                )
+            if resolved.controller is None:
+                raise GeecsConfigurationError(
+                    "strict shot control requires a trigger_profile — the plan "
+                    "fires every shot, so there must be a shot-control device"
+                )
+            resolved.controller.require_strict_single_shot()
             prepared = yield from prepare_step_scan(
                 sess, res, resolved, created, namespace=namespace
             )
@@ -293,10 +340,19 @@ def geecs_preamble(
             )
             if prepared.setup is not None:
                 yield from prepared.setup()
-            if prepared.controller is not None:
-                yield from prepared.controller.arm()
+
+            # Order is load-bearing (Gate-2 save windowing).  arm_single_shot
+            # drives the box to ARMED — single-shot source, so the free run
+            # is HALTED — and waits for quiescence.  Only then is it safe to
+            # turn saving on: a camera writes one file per shot it sees, so
+            # enabling saving while edges are still passing writes orphan
+            # frames with no event row.  Save-off is the innermost finalize
+            # for the mirror reason: it runs before disarm lets edges back.
+            yield from prepared.controller.arm_single_shot(prepared.detectors)
             if saving:
                 yield from save_enable_plan(saving)
+            state["fire"] = prepared.controller.fire_shot
+            state["detectors"] = {id(d) for d in prepared.detectors}
 
             # Injected md wins over the plan's own, as inject_md_wrapper does.
             new = msg._replace(kwargs=ChainMap(md, msg.kwargs))

--- a/GeecsBluesky/geecs_bluesky/preprocessors.py
+++ b/GeecsBluesky/geecs_bluesky/preprocessors.py
@@ -4,20 +4,31 @@ Each function here has the ``bluesky.preprocessors`` shape (``plan → plan``)
 so it can be installed once on the RunEngine (``RE.preprocessors.append``)
 and applies to **every** plan, stock or not, with no per-plan code.
 
-Phase 1: :func:`connect_on_demand`.  Later phases add the ``md["geecs"]``
-preamble/finalize preprocessor (``Planning/native_bluesky/00_overview.md``).
+Phase 1: :func:`connect_on_demand`.  Phase 2: :func:`geecs_preamble`, the
+GEECS scan preamble and finalize chain keyed on ``md["geecs"]``
+(``Planning/native_bluesky/02_preamble_preprocessor.md``).
+
+**Install order matters.**  ``RE.preprocessors`` compose in list order,
+first-appended innermost, so :func:`connect_on_demand` must be re-installed
+**last** after :func:`install_geecs_preamble` — otherwise the preamble's own
+connects and reads never pass through it.  ``install_geecs_preamble`` does
+that for you.
 """
 
 from __future__ import annotations
 
 import logging
+from collections import ChainMap
 from collections.abc import Generator
 from functools import partial
 from typing import Any
 
+import bluesky.preprocessors as bpp
 from bluesky.preprocessors import plan_mutator
 from bluesky.utils import Msg
 from ophyd_async.plan_stubs import ensure_connected
+
+from geecs_bluesky.exceptions import GeecsConfigurationError
 
 logger = logging.getLogger(__name__)
 
@@ -151,3 +162,182 @@ def install_connect_on_demand(
     run_engine.preprocessors.append(
         partial(connect_on_demand, mock=mock, timeout=timeout)
     )
+
+
+# ---------------------------------------------------------------------------
+# Phase 2 — the GEECS scan preamble as a preprocessor
+# ---------------------------------------------------------------------------
+
+#: Run-metadata key carrying the ScanRequest a run should be prepared for.
+GEECS_MD_KEY = "geecs"
+
+
+def geecs_preamble(
+    plan: Generator[Msg, Any, Any],
+    *,
+    session: Any = None,
+    resolver: Any = None,
+    namespace: Any = None,
+    md_key: str = GEECS_MD_KEY,
+) -> Generator[Msg, Any, Any]:
+    """Give any plan the GEECS scan preamble, keyed on ``md["geecs"]``.
+
+    A plan that opens its run with ``md={"geecs": <ScanRequest as a dict>}``
+    gets, before the run opens: authoritative validation, name resolution,
+    the shot controller, the unserved/CONNECTED preflights, action-slot
+    compilation, the capture toggle, the connects the preamble itself owns,
+    the **scan-number claim**, the ScanInfo write, native-save configuration
+    — and the GEECS run metadata injected into its start document.  On the
+    way out, in the funnel's nesting order: save-off (innermost, so saving
+    stops while the trigger is still stopped), disarm, closeout actions,
+    disconnect.
+
+    All of it is :mod:`geecs_bluesky.plans.preamble`'s code, the same the
+    funnel plan runs — this only supplies the seam and the ordering, so a
+    stock ``bluesky.plans`` verb behaves exactly like a submitted
+    ``ScanRequest``::
+
+        RE(bp.list_grid_scan([cam], U_S1H.current, pts, md={"geecs": request}))
+
+    The devices come from the **namespace**, not from fresh per-scan
+    construction: the objects the preamble configures must be the ones the
+    plan was handed (`preamble.namespace_detectors`).
+
+    Note
+    ----
+    The request must ride in the **plan's** ``md=``.  RunEngine per-call
+    metadata (``RE(plan, geecs=...)``) is merged at ``_open_run`` and never
+    enters a message, so a preprocessor cannot see it: the start document
+    would carry a ``geecs`` block while the preamble never ran.
+    """
+    from geecs_bluesky.plans.preamble import (
+        _disconnect_plan,
+        prepare_step_scan,
+        resolve_request,
+    )
+    from geecs_bluesky.plans.run_wrapper import (
+        _save_cleanup_plan,
+        claim_scan_number,
+        claimed_scan_metadata,
+        save_enable_plan,
+    )
+    from geecs_bluesky.plans.scan_request_plan import _worker_session
+
+    sess = session if session is not None else _worker_session
+    created: list = []
+    state: dict[str, Any] = {}
+    forwarded: set[int] = set()
+
+    def _cleanup() -> Generator[Msg, Any, Any]:
+        """The funnel's finalize chain, innermost first, for whatever ran."""
+        if state.get("saving"):
+            yield from _save_cleanup_plan(state["saving"])
+        controller = state.get("controller")
+        if controller is not None:
+            yield from controller.disarm()
+        closeout = state.get("closeout")
+        if closeout is not None:
+            yield from closeout()
+        if created:
+            yield from _disconnect_plan(created)
+
+    def _prepare(msg: Msg) -> tuple[Any, Any]:
+        if msg.command != "open_run" or id(msg) in forwarded:
+            return None, None
+        request = msg.kwargs.get(md_key)
+        if request is None:
+            return None, None
+        if sess is None:
+            raise GeecsConfigurationError(
+                "geecs_preamble has no session: install one with "
+                "set_plan_session(...) at worker startup, or pass session=..."
+            )
+        res = resolver
+        if res is None:
+            from geecs_bluesky.config_resolver import ConfigsRepoResolver
+
+            res = ConfigsRepoResolver(sess.experiment)
+
+        def _run_preamble() -> Generator[Msg, Any, Any]:
+            resolved = resolve_request(sess, res, request)
+            prepared = yield from prepare_step_scan(
+                sess, res, resolved, created, namespace=namespace
+            )
+            state["controller"] = prepared.controller
+            state["closeout"] = prepared.closeout
+
+            # The claim: every failure above it burns no scan number.
+            scan_number, scan_folder = claim_scan_number(sess.experiment)
+            saving = sess.configure_claimed_scan(
+                scan_number=scan_number,
+                scan_folder=scan_folder,
+                detectors=prepared.detectors,
+                motor=prepared.motor_arg,
+                positions=prepared.spec.positions,
+                shots_per_step=prepared.request.capture.shots_per_step,
+                description=prepared.request.description,
+                scan_info_overrides=prepared.spec.scan_info,
+            )
+            state["saving"] = saving
+
+            md = claimed_scan_metadata(
+                experiment=sess.experiment,
+                scan_number=scan_number,
+                scan_folder=scan_folder,
+                saving_detectors=saving,
+                devices=prepared.detectors,
+                extra_md={
+                    "description": prepared.request.description,
+                    **prepared.spec.md,
+                },
+            )
+            if prepared.setup is not None:
+                yield from prepared.setup()
+            if prepared.controller is not None:
+                yield from prepared.controller.arm()
+            if saving:
+                yield from save_enable_plan(saving)
+
+            # Injected md wins over the plan's own, as inject_md_wrapper does.
+            new = msg._replace(kwargs=ChainMap(md, msg.kwargs))
+            forwarded.add(id(new))
+            logger.info(
+                "geecs_preamble: scan %s prepared (%d detectors) for %s",
+                scan_number,
+                len(prepared.detectors),
+                msg.kwargs.get("plan_name", "?"),
+            )
+            return (yield new)
+
+        return _run_preamble(), None
+
+    return (yield from bpp.finalize_wrapper(plan_mutator(plan, _prepare), _cleanup()))
+
+
+def install_geecs_preamble(
+    run_engine: Any,
+    *,
+    session: Any = None,
+    resolver: Any = None,
+    namespace: Any = None,
+    mock: bool = False,
+) -> None:
+    """Install :func:`geecs_preamble`, keeping :func:`connect_on_demand` outermost.
+
+    Idempotent, and it re-appends ``connect_on_demand`` afterwards so the
+    preamble's own connects and reads still pass through it (the RunEngine
+    composes preprocessors first-appended-innermost).
+    """
+    had_connect = any(
+        getattr(p, "func", None) is connect_on_demand for p in run_engine.preprocessors
+    )
+    run_engine.preprocessors[:] = [
+        p
+        for p in run_engine.preprocessors
+        if getattr(p, "func", None) not in (geecs_preamble, connect_on_demand)
+    ]
+    run_engine.preprocessors.append(
+        partial(geecs_preamble, session=session, resolver=resolver, namespace=namespace)
+    )
+    if had_connect:
+        install_connect_on_demand(run_engine, mock=mock)

--- a/GeecsBluesky/geecs_bluesky/preprocessors.py
+++ b/GeecsBluesky/geecs_bluesky/preprocessors.py
@@ -18,11 +18,13 @@ that for you.
 from __future__ import annotations
 
 import logging
+import math
 from collections import ChainMap
 from collections.abc import Generator
 from functools import partial
 from typing import Any
 
+import bluesky.plan_stubs as bps
 import bluesky.preprocessors as bpp
 from bluesky.preprocessors import plan_mutator
 from bluesky.utils import Msg
@@ -172,6 +174,74 @@ def install_connect_on_demand(
 GEECS_MD_KEY = "geecs"
 
 
+def _positions_match(value: Any, wanted: Any) -> bool:
+    """Whether a commanded position is the declared one (floats compared loosely)."""
+    try:
+        return math.isclose(float(value), float(wanted), rel_tol=1e-9, abs_tol=1e-9)
+    except (TypeError, ValueError):
+        return value == wanted
+
+
+def _check_plan_covers_save_set(msg: Msg, prepared: Any) -> None:
+    """Refuse a plan that does not read every device the save set records.
+
+    On the funnel the read set **is** the save set — one list built once and
+    handed to the plan.  The stock-plan door decouples them: the preamble
+    turns native saving on for the save set's devices while the plan reads
+    whatever the caller passed to ``bp.count``/``bp.list_scan``.  A device
+    that is saved but not read writes one file per shot with no
+    ``acq_timestamp`` row to join it to — the same orphan-frame failure the
+    Gate-2 save windowing exists to prevent, arriving from the other side.
+
+    Every stock ``bluesky.plans`` verb records ``md["detectors"]``, so the
+    check is available at ``open_run``, before the claim.
+    """
+    listed = msg.kwargs.get("detectors")
+    if not isinstance(listed, (list, tuple)):
+        logger.warning(
+            "geecs_preamble: the plan declares no detectors in its metadata, so "
+            "the save set cannot be checked against what the plan reads"
+        )
+        return
+    read = {str(name) for name in listed}
+    # The telemetry tail is not the plan's to read — the preprocessor
+    # injects it into the event (see _read_telemetry_into_event).
+    telemetry = {d.name for d in prepared.telemetry_readables}
+    saved = {d.name for d in prepared.detectors} - telemetry
+    missing = sorted(saved - read)
+    if missing:
+        raise GeecsConfigurationError(
+            f"the save set records {missing}, which this plan does not read. "
+            "Native saving would write files with no event row to join them "
+            "to. Pass the save set's devices to the plan — "
+            "`resolver.resolve_save_set(name)` names them — or drop them "
+            "from the save set."
+        )
+
+
+def _check_plan_geometry(msg: Msg, prepared: Any) -> None:
+    """Refuse a plan whose shape disagrees with the request it is recorded as.
+
+    ScanInfo, the start document and the Tiled catalog take the number of
+    steps and shots from the **request**; the rows actually recorded come
+    from the stock plan's own arguments.  ``bp.count(num=2)`` under a
+    request declaring ``shots_per_step: 5`` would write a scan record that
+    its own data contradicts, and nothing downstream could tell.
+    """
+    declared = prepared.spec.n_shots
+    actual = msg.kwargs.get("num_points")
+    if actual is None or declared == actual:
+        return
+    raise GeecsConfigurationError(
+        f"the request declares {declared} recorded shots "
+        f"(steps x shots_per_step) but the plan takes {actual} points. "
+        "ScanInfo and the catalog record the request's numbers, so they must "
+        "agree — note a stock step scan records one shot per point, so "
+        "shots_per_step > 1 needs the per-step hook (GEECS-Plugins#807 "
+        "phase 3), not a stock plan."
+    )
+
+
 def geecs_preamble(
     plan: Generator[Msg, Any, Any],
     *,
@@ -201,7 +271,7 @@ def geecs_preamble(
 
     The devices come from the **namespace**, not from fresh per-scan
     construction: the objects the preamble configures must be the ones the
-    plan was handed (`preamble.namespace_detectors`).
+    plan was handed (`GeecsNamespace.select`).
 
     Note
     ----
@@ -219,15 +289,23 @@ def geecs_preamble(
         _save_cleanup_plan,
         claim_scan_number,
         claimed_scan_metadata,
+        save_control_only_off_plan,
         save_enable_plan,
     )
-    from geecs_bluesky.plans.scan_request_plan import _worker_session
+    from geecs_bluesky.plan_session import get_plan_session
+    from geecs_bluesky.plans.single_shot import fire_and_await_shot
+    from geecs_bluesky.plans.step_scan import geecs_execution_md, normalize_motors
+    from geecs_bluesky.scan_log import scan_log
 
-    sess = session if session is not None else _worker_session
+    sess = session if session is not None else get_plan_session()
     created: list = []
     state: dict[str, Any] = {}
-    forwarded: set[int] = set()
-    armed_groups: set[Any] = set()
+    # The forwarded messages themselves, not their ids: a Msg is dropped
+    # once the RunEngine has processed it and CPython reuses the address,
+    # so an id set can make a later open_run in a multi-run plan look
+    # already-forwarded and silently skip its preamble.
+    forwarded: list[Msg] = []
+    armed_groups: dict[Any, list] = {}
 
     def _cleanup() -> Generator[Msg, Any, Any]:
         """The funnel's finalize chain, innermost first, for whatever ran."""
@@ -241,6 +319,16 @@ def geecs_preamble(
             yield from closeout()
         if created:
             yield from _disconnect_plan(created)
+        # The namespace devices are long-lived nouns: what this run
+        # configured on them (saving mode, save path, asset definitions,
+        # shot-ID origin) must not survive into the next plan, GEECS or not.
+        # Only if a preamble actually ran — a plan without the key is
+        # untouched on the way out as well as on the way in.
+        if namespace is not None and state:
+            namespace.reset_run_configuration()
+        log_ctx = state.pop("scan_log", None)
+        if log_ctx is not None:
+            log_ctx.__exit__(None, None, None)
 
     def _fire_before_wait(msg: Msg) -> tuple[Any, Any]:
         """Insert the shot between arming the waiters and waiting on them.
@@ -250,35 +338,103 @@ def geecs_preamble(
         fire to land in exactly that gap — the detectors have baselined their
         ``acq_timestamp`` and are waiting, so a shot fired now cannot be
         missed — which is why ``bps.trigger_and_read`` alone cannot express
-        it (see ``plans/single_shot.py``).  Doing it here means a **stock**
-        plan needs no ``per_shot`` hook at all.
+        it.  Doing it here means a **stock** plan needs no ``per_shot`` hook
+        at all.
+
+        The fire, the bounded refire on a dropped frame and the device-down
+        gating all come from
+        :func:`~geecs_bluesky.plans.single_shot.fire_and_await_shot`, the
+        same implementation ``geecs_single_shot`` uses: the seam is
+        inserted here, but it is not re-derived here.
         """
         fire = state.get("fire")
         if fire is None:
             return None, None
-        if msg.command == "trigger" and id(msg.obj) in state["detectors"]:
+        if msg.command == "trigger":
             group = msg.kwargs.get("group")
             if group is not None:
-                armed_groups.add(group)
+                armed_groups.setdefault(group, []).append(msg.obj)
             return None, None
         if msg.command != "wait":
             return None, None
         group = msg.kwargs.get("group")
-        if group not in armed_groups:
+        triggered = armed_groups.pop(group, None)
+        if triggered is None:
             return None, None
-        armed_groups.discard(group)
+        if not any(id(obj) in state["detectors"] for obj in triggered):
+            # Some other group of the plan's own — not the shot.
+            return None, None
+        return (
+            fire_and_await_shot(triggered, fire, pending_wait=msg),
+            None,
+        )
 
-        def _fire_then_wait() -> Generator[Msg, Any, Any]:
-            yield from fire()
-            return (yield msg)
+    def _check_commanded_position(msg: Msg) -> None:
+        """Refuse a move to a position the run never declared.
 
-        return _fire_then_wait(), None
+        ScanInfo, the start document and the Tiled catalog all record the
+        **request's** positions, while a stock plan moves to whatever its
+        own arguments say.  Equal point counts hide a value mismatch, so
+        every commanded position is checked against the declared list: a
+        scan whose data does not match its own record is worse than a scan
+        that stops.
+        """
+        declared = state.get("declared_positions")
+        if not declared:
+            return
+        axis = state["movable_index"].get(id(msg.obj))
+        if axis is None:
+            return
+        wanted = [row[axis] for row in declared]
+        value = msg.args[0] if msg.args else None
+        if any(_positions_match(value, w) for w in wanted):
+            return
+        raise GeecsConfigurationError(
+            f"{getattr(msg.obj, 'name', msg.obj)}: the plan moves to {value!r}, "
+            f"which is not among the positions this run declared ({wanted!r}). "
+            "ScanInfo and the catalog record the request's positions, so the "
+            "plan's points and the request's axes must be the same list."
+        )
+
+    def _read_telemetry_into_event(msg: Msg) -> tuple[Any, Any]:
+        """Add the telemetry columns to the event the plan is about to save.
+
+        Background telemetry is a **soft tier of extra columns in the
+        ``primary`` stream, one value per row** — not a separate baseline
+        stream (``Planning/native_bluesky/02_preamble_preprocessor.md``).
+        The funnel gets that by appending the group to the plan's read set;
+        a stock plan reads only the devices it was handed, so the reads are
+        inserted here, between the plan's last ``read`` and its ``save``.
+        The event is still one row, and the schema is unchanged.
+        """
+        telemetry = state.get("telemetry")
+        if not telemetry or msg.command != "save" or state.get("in_telemetry"):
+            return None, None
+
+        def _read_then_save() -> Generator[Msg, Any, Any]:
+            # plan_mutator re-processes the message this generator yields,
+            # so the forwarded save must not be mutated again.
+            state["in_telemetry"] = True
+            try:
+                for device in telemetry:
+                    yield from bps.read(device)
+                return (yield msg)
+            finally:
+                state["in_telemetry"] = False
+
+        return _read_then_save(), None
 
     def _prepare(msg: Msg) -> tuple[Any, Any]:
         fired = _fire_before_wait(msg)
         if fired != (None, None):
             return fired
-        if msg.command != "open_run" or id(msg) in forwarded:
+        telemetry_read = _read_telemetry_into_event(msg)
+        if telemetry_read != (None, None):
+            return telemetry_read
+        if msg.command == "set":
+            _check_commanded_position(msg)
+            return None, None
+        if msg.command != "open_run" or any(msg is f for f in forwarded):
             return None, None
         request = msg.kwargs.get(md_key)
         if request is None:
@@ -294,6 +450,13 @@ def geecs_preamble(
 
             res = ConfigsRepoResolver(sess.experiment)
 
+        if namespace is None:
+            raise GeecsConfigurationError(
+                "geecs_preamble needs a device namespace: the objects it "
+                "configures must be the ones the plan was handed. Install it "
+                "with namespace=..., or set QS_DEVICE_NAMESPACE back on."
+            )
+
         def _run_preamble() -> Generator[Msg, Any, Any]:
             resolved = resolve_request(sess, res, request)
             if not resolved.strict:
@@ -301,20 +464,24 @@ def geecs_preamble(
                     "stock plans run strict shot control only: free-run is "
                     "retired (GEECS-Plugins#807). Set acquisition='strict'."
                 )
-            if resolved.controller is None:
-                raise GeecsConfigurationError(
-                    "strict shot control requires a trigger_profile — the plan "
-                    "fires every shot, so there must be a shot-control device"
-                )
-            resolved.controller.require_strict_single_shot()
+            # The controller-present and single-shot-capable checks are
+            # prepare_step_scan's (plans/preamble.py); not repeated here.
             prepared = yield from prepare_step_scan(
                 sess, res, resolved, created, namespace=namespace
             )
             state["controller"] = prepared.controller
             state["closeout"] = prepared.closeout
+            _check_plan_covers_save_set(msg, prepared)
+            _check_plan_geometry(msg, prepared)
 
             # The claim: every failure above it burns no scan number.
             scan_number, scan_folder = claim_scan_number(sess.experiment)
+            # The per-scan log handler, and the flush of everything buffered
+            # before the claim — the funnel does this around its run
+            # (scan_request_plan.py), and /triage reads the result.
+            log_ctx = scan_log(scan_number, scan_folder)
+            log_ctx.__enter__()
+            state["scan_log"] = log_ctx
             saving = sess.configure_claimed_scan(
                 scan_number=scan_number,
                 scan_folder=scan_folder,
@@ -327,19 +494,34 @@ def geecs_preamble(
             )
             state["saving"] = saving
 
+            # The scan motors carry `_column_headers` too, and the
+            # Tiled→s-file exporter needs them to put the legacy
+            # "Device Variable" header back on the axis column.
+            movables = normalize_motors(prepared.motor_arg)
+            scalar_devices = list(prepared.detectors) + movables
             md = claimed_scan_metadata(
                 experiment=sess.experiment,
                 scan_number=scan_number,
                 scan_folder=scan_folder,
                 saving_detectors=saving,
-                devices=prepared.detectors,
+                devices=scalar_devices,
                 extra_md={
                     "description": prepared.request.description,
+                    **geecs_execution_md(
+                        motors=movables,
+                        positions=prepared.spec.positions,
+                        shots_per_step=prepared.request.capture.shots_per_step,
+                        fires_own_shots=True,
+                    ),
                     **prepared.spec.md,
                 },
             )
             if prepared.setup is not None:
                 yield from prepared.setup()
+            # Capture-owned cameras: a save flag left on out-of-band must
+            # not keep writing to a stale path. Eager — turning saving OFF
+            # needs no trigger windowing, unlike turning it on.
+            yield from save_control_only_off_plan(scalar_devices)
 
             # Order is load-bearing (Gate-2 save windowing).  arm_single_shot
             # drives the box to ARMED — single-shot source, so the free run
@@ -351,12 +533,24 @@ def geecs_preamble(
             yield from prepared.controller.arm_single_shot(prepared.detectors)
             if saving:
                 yield from save_enable_plan(saving)
+            state["telemetry"] = list(prepared.telemetry_readables)
             state["fire"] = prepared.controller.fire_shot
             state["detectors"] = {id(d) for d in prepared.detectors}
+            state["movable_index"] = {id(m): i for i, m in enumerate(movables)}
+            state["declared_positions"] = [
+                row if isinstance(row, (list, tuple)) else (row,)
+                for row in prepared.spec.positions
+                if row is not None
+            ]
 
-            # Injected md wins over the plan's own, as inject_md_wrapper does.
-            new = msg._replace(kwargs=ChainMap(md, msg.kwargs))
-            forwarded.add(id(new))
+            # Injected md wins over the plan's own, as inject_md_wrapper
+            # does.  The raw request itself is dropped: the resolved picture
+            # is already in the metadata, and an unresolved copy of it in
+            # every start document is a key no consumer declares and the
+            # funnel's door never emits.
+            passthrough = {k: v for k, v in msg.kwargs.items() if k != md_key}
+            new = msg._replace(kwargs=ChainMap(md, passthrough))
+            forwarded.append(new)
             logger.info(
                 "geecs_preamble: scan %s prepared (%d detectors) for %s",
                 scan_number,
@@ -384,9 +578,19 @@ def install_geecs_preamble(
     preamble's own connects and reads still pass through it (the RunEngine
     composes preprocessors first-appended-innermost).
     """
-    had_connect = any(
-        getattr(p, "func", None) is connect_on_demand for p in run_engine.preprocessors
+    existing = next(
+        (
+            p
+            for p in run_engine.preprocessors
+            if getattr(p, "func", None) is connect_on_demand
+        ),
+        None,
     )
+    # Re-appending must preserve how connect_on_demand was configured — a
+    # mock worker installs it with mock=True, and re-deriving the kwargs
+    # here would quietly send a mock worker at real Channel Access.
+    connect_kwargs = dict(getattr(existing, "keywords", None) or {})
+    connect_kwargs.setdefault("mock", mock)
     run_engine.preprocessors[:] = [
         p
         for p in run_engine.preprocessors
@@ -395,5 +599,5 @@ def install_geecs_preamble(
     run_engine.preprocessors.append(
         partial(geecs_preamble, session=session, resolver=resolver, namespace=namespace)
     )
-    if had_connect:
-        install_connect_on_demand(run_engine, mock=mock)
+    if existing is not None:
+        install_connect_on_demand(run_engine, **connect_kwargs)

--- a/GeecsBluesky/geecs_bluesky/session.py
+++ b/GeecsBluesky/geecs_bluesky/session.py
@@ -667,6 +667,57 @@ class GeecsSession:
             md=md,
         )
 
+    def configure_claimed_scan(
+        self,
+        *,
+        scan_number: int | None,
+        scan_folder: str | None,
+        detectors: Sequence[Any],
+        motor: Any | Sequence[Any] | None,
+        positions: Sequence[Any],
+        shots_per_step: int,
+        description: str = "",
+        scan_info_overrides: dict | None = None,
+    ) -> list[tuple]:
+        """Everything that happens between a claimed scan number and the run.
+
+        ScanInfo write → role wiring (schema-v1 shot ids, contributor
+        anchoring) → native-save configuration.  Split out of
+        :meth:`build_claimed_scan_plan` (GEECS-Plugins#807 phase 2) so the
+        RunEngine preamble preprocessor — which does **not** build an inner
+        plan, the stock plan being the inner plan — shares this tail rather
+        than copying it.  A ``None`` *scan_number* (failed claim, or
+        ``save_data=False``) skips the ScanInfo write and configures no
+        native saving, exactly as every call site always did.
+
+        Returns
+        -------
+        list of tuple
+            The ``(detector, event_path, device_command_path)`` triples the
+            save-enable plan drives.
+        """
+        detectors = list(detectors)
+        if scan_number is not None:
+            self._write_scan_info(
+                scan_number,
+                scan_folder,
+                motor=motor,
+                positions=positions,
+                shots_per_step=shots_per_step,
+                description=description,
+                overrides=scan_info_overrides,
+            )
+
+        # Role wiring: schema-v1 shot ids + contributor anchoring.
+        reference = detectors[0]
+        for det in detectors:
+            if hasattr(det, "configure_shot_id"):
+                det.configure_shot_id(self.rep_rate_hz)
+            if hasattr(det, "set_reference") and det is not reference:
+                det.set_reference(reference)
+
+        return self._configure_saving(detectors, scan_number, scan_folder)
+
     def build_claimed_scan_plan(
         self,
         *,
@@ -721,26 +772,17 @@ class GeecsSession:
             The composed plan generator (``build_step_scan_plan``).
         """
         detectors = list(detectors)
-        if scan_number is not None:
-            self._write_scan_info(
-                scan_number,
-                scan_folder,
-                motor=motor,
-                positions=positions,
-                shots_per_step=shots_per_step,
-                description=description,
-                overrides=scan_info_overrides,
-            )
-
-        # Role wiring: schema-v1 shot ids + contributor anchoring.
+        saving_detectors = self.configure_claimed_scan(
+            scan_number=scan_number,
+            scan_folder=scan_folder,
+            detectors=detectors,
+            motor=motor,
+            positions=positions,
+            shots_per_step=shots_per_step,
+            description=description,
+            scan_info_overrides=scan_info_overrides,
+        )
         reference = detectors[0]
-        for det in detectors:
-            if hasattr(det, "configure_shot_id"):
-                det.configure_shot_id(self.rep_rate_hz)
-            if hasattr(det, "set_reference") and det is not reference:
-                det.set_reference(reference)
-
-        saving_detectors = self._configure_saving(detectors, scan_number, scan_folder)
 
         return build_step_scan_plan(
             strict=strict,

--- a/GeecsBluesky/pyproject.toml
+++ b/GeecsBluesky/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-bluesky"
-version = "0.77.1"
+version = "0.78.0"
 description = "Bluesky / ophyd-async bridge for the GEECS control system"
 authors = ["Sam Barber <sbarber@lbl.gov>"]
 readme = "README.md"

--- a/GeecsBluesky/pyproject.toml
+++ b/GeecsBluesky/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-bluesky"
-version = "0.78.1"
+version = "0.79.0"
 description = "Bluesky / ophyd-async bridge for the GEECS control system"
 authors = ["Sam Barber <sbarber@lbl.gov>"]
 readme = "README.md"

--- a/GeecsBluesky/pyproject.toml
+++ b/GeecsBluesky/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-bluesky"
-version = "0.78.0"
+version = "0.78.1"
 description = "Bluesky / ophyd-async bridge for the GEECS control system"
 authors = ["Sam Barber <sbarber@lbl.gov>"]
 readme = "README.md"

--- a/GeecsBluesky/pyproject.toml
+++ b/GeecsBluesky/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-bluesky"
-version = "0.77.0"
+version = "0.77.1"
 description = "Bluesky / ophyd-async bridge for the GEECS control system"
 authors = ["Sam Barber <sbarber@lbl.gov>"]
 readme = "README.md"

--- a/GeecsBluesky/qserver/startup/startup.py
+++ b/GeecsBluesky/qserver/startup/startup.py
@@ -269,16 +269,28 @@ if _optimization_loader is not None:
 # (``count([UC_Amp4_IR_input])``, ``scan([...], U_S1H.Current, -1, 1, 5)``).
 # QS_DEVICE_NAMESPACE=off skips it (hermetic tests, a box without DB reach).
 from geecs_bluesky.namespace import GeecsNamespace  # noqa: E402
-from geecs_bluesky.preprocessors import install_connect_on_demand  # noqa: E402
+from geecs_bluesky.preprocessors import (  # noqa: E402
+    install_connect_on_demand,
+    install_geecs_preamble,
+)
 
 _DEVICE_NAMES: list[str] = []
+namespace = None
 if os.environ.get("QS_DEVICE_NAMESPACE", "db").strip().lower() != "off":
     namespace = GeecsNamespace.from_experiment(_experiment)
     _DEVICE_NAMES = namespace.export_into(globals())
-# Installed LAST on purpose: connect_on_demand must be the OUTERMOST
-# preprocessor so it also sees messages later preprocessors inject
-# (SupplementalData baselines, the phase-2 preamble).  Re-run this after
-# appending anything else to RE.preprocessors.
+
+# ── Stock-plan preamble (GEECS-Plugins#807 phase 2) ───────────────────────
+# A stock bluesky.plans verb carrying md={"geecs": <ScanRequest>} gets the
+# full GEECS preamble and finalize — validate, resolve, claim, ScanInfo,
+# native saving, setup/closeout actions, arm/fire/disarm.  A plan without
+# that key is untouched, so installing it costs nothing for plain plans.
+# It installs connect_on_demand LAST for us: connect_on_demand must be the
+# OUTERMOST preprocessor so it also sees messages later preprocessors
+# inject (SupplementalData baselines, the preamble's own connects and
+# reads).  Re-run install_connect_on_demand after appending anything else
+# to RE.preprocessors.
 install_connect_on_demand(RE, mock=session._mock)
+install_geecs_preamble(RE, session=session, namespace=namespace)
 
 __all__ = ["RE", *GEECS_PLAN_NAMES, *GEECS_WORKER_FUNCTIONS, *_DEVICE_NAMES]

--- a/GeecsBluesky/tests/ca_mock_helpers.py
+++ b/GeecsBluesky/tests/ca_mock_helpers.py
@@ -60,6 +60,13 @@ def start_pacer(
     return asyncio.run_coroutine_threadsafe(pace(), run_engine._loop)
 
 
+def sweep_points(start: float, end: float, step: float) -> list[float]:
+    """Inclusive sweep from *start* to *end* in steps of ``abs(step)``."""
+    n = int(round(abs(end - start) / abs(step))) + 1
+    sign = 1.0 if end >= start else -1.0
+    return [round(start + sign * i * abs(step), 6) for i in range(n)]
+
+
 class DocCollector:
     """Collect RunEngine documents; pick the ``primary`` stream's events."""
 
@@ -70,6 +77,11 @@ class DocCollector:
 
     def __call__(self, name: str, doc: dict) -> None:
         self.docs[name].append(doc)
+
+    @property
+    def start(self) -> dict:
+        """The run's start document."""
+        return self.docs["start"][0]
 
     def primary_events(self) -> list[dict]:
         uids = {d["uid"] for d in self.docs["descriptor"] if d["name"] == "primary"}

--- a/GeecsBluesky/tests/test_namespace_hardware.py
+++ b/GeecsBluesky/tests/test_namespace_hardware.py
@@ -39,16 +39,10 @@ from pathlib import Path
 
 import pytest
 
-from tests.ca_mock_helpers import DocCollector
+from tests.ca_mock_helpers import DocCollector, sweep_points
 
 pytestmark = pytest.mark.hardware
 pytest.importorskip("aioca")
-
-
-def _sweep_points(start: float, end: float, step: float) -> list[float]:
-    n = int(round(abs(end - start) / abs(step))) + 1
-    sign = 1.0 if end >= start else -1.0
-    return [round(start + sign * i * abs(step), 6) for i in range(n)]
 
 
 @pytest.mark.hardware
@@ -98,7 +92,7 @@ def test_stock_plans_over_the_namespace_on_hardware() -> None:
     if sweep_target:
         device_name, _, variable = sweep_target.partition(":")
         movable = namespace.resolve(sweep_target)
-        points = _sweep_points(
+        points = sweep_points(
             float(os.environ["GEECS_HW_SCAN_START"]),
             float(os.environ["GEECS_HW_SCAN_END"]),
             float(os.environ["GEECS_HW_SCAN_STEP"]),

--- a/GeecsBluesky/tests/test_preamble_hardware.py
+++ b/GeecsBluesky/tests/test_preamble_hardware.py
@@ -177,7 +177,12 @@ def test_stock_plans_run_as_geecs_scans_on_hardware() -> None:
                 md={
                     "geecs": request(
                         mode="step",
-                        axes=[{"variable": sweep_target, "positions": points}],
+                        axes=[
+                            {
+                                "variable": sweep_target,
+                                "positions": {"values": points},
+                            }
+                        ],
                     )
                 },
             ),

--- a/GeecsBluesky/tests/test_preamble_hardware.py
+++ b/GeecsBluesky/tests/test_preamble_hardware.py
@@ -156,10 +156,15 @@ def test_stock_plans_run_as_geecs_scans_on_hardware() -> None:
         float(os.environ["GEECS_HW_SCAN_END"]),
         float(os.environ["GEECS_HW_SCAN_STEP"]),
     )
+    # A direct CA read: the namespace device is connected lazily by
+    # connect_on_demand when a *plan* touches it, so it is not connected yet.
+    from geecs_bluesky.devices.ca.oneshot import try_caget_once
+    from geecs_core.pv_naming import pv_name, setpoint_pv
+
     initial = float(
-        __import__("asyncio")
-        .run_coroutine_threadsafe(movable._setpoint.get_value(), session.RE._loop)
-        .result(timeout=5)
+        try_caget_once(
+            setpoint_pv(pv_name(experiment, device_name, variable)), timeout=5.0
+        )
     )
     print(f"sweep {sweep_target} over {points} (pre-scan setpoint {initial})")
     docs2 = Docs()

--- a/GeecsBluesky/tests/test_preamble_hardware.py
+++ b/GeecsBluesky/tests/test_preamble_hardware.py
@@ -122,7 +122,7 @@ def test_stock_plans_run_as_geecs_scans_on_hardware() -> None:
         base = dict(
             mode="noscan",
             shots_per_step=shots,
-            acquisition="free_run",
+            acquisition="strict",
             save_sets=[save_set],
             trigger_profile=profile,
             description="#807 phase 2 hardware acceptance",

--- a/GeecsBluesky/tests/test_preamble_hardware.py
+++ b/GeecsBluesky/tests/test_preamble_hardware.py
@@ -1,0 +1,199 @@
+"""Phase-2 hardware acceptance: a stock plan run as a full GEECS scan (#807).
+
+Hardware-marked (skipped in CI; ``-m integration`` does NOT select it — it
+arms the machine trigger **and claims a real scan number**).  Run by hand on
+a host with CA reach to the gateway and the GEECS DB (the qserver box)::
+
+    GEECS_HW_SCAN_VARIABLE=U_S1H:Current GEECS_HW_SCAN_START=-1 \\
+    GEECS_HW_SCAN_END=1 GEECS_HW_SCAN_STEP=0.5 \\
+    poetry run pytest tests/test_preamble_hardware.py -m hardware -s
+
+**Side effects, deliberately real:** every run here claims a scan number
+and creates ``scans/ScanNNN/`` with its ``ScanInfoScanNNN.ini`` — that is
+the behaviour under test.  The claimed numbers are printed.
+
+What it proves that the mock cannot: the preamble preprocessor prepares a
+**stock** ``bluesky.plans`` verb exactly as the funnel prepares a submitted
+ScanRequest — the same validation, resolution, claim, ScanInfo, native-save
+configuration and run metadata — against the live gateway and DB.
+
+Environment
+-----------
+``GEECS_HW_EXPERIMENT``       experiment (default ``Undulator``)
+``GEECS_HW_SAVE_SET``         save set (default ``Amp4In``)
+``GEECS_HW_TRIGGER_PROFILE``  trigger profile (default ``HTU-NoGas``)
+``GEECS_HW_SHOTS``            shots (default 3)
+``GEECS_HW_SCAN_VARIABLE``    ``Device:Variable`` to sweep (unset → noscan only)
+``GEECS_HW_SCAN_START/END/STEP``  sweep bounds (mandatory with the variable)
+"""
+
+from __future__ import annotations
+
+import configparser
+import os
+from collections import defaultdict
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.hardware
+pytest.importorskip("aioca")
+
+
+class Docs:
+    def __init__(self) -> None:
+        self.docs: dict[str, list[dict]] = defaultdict(list)
+
+    def __call__(self, name: str, doc: dict) -> None:
+        self.docs[name].append(doc)
+
+    @property
+    def start(self) -> dict:
+        return self.docs["start"][0]
+
+    def primary_events(self) -> list[dict]:
+        uids = {d["uid"] for d in self.docs["descriptor"] if d["name"] == "primary"}
+        return [e for e in self.docs["event"] if e["descriptor"] in uids]
+
+
+def _sweep_points(start: float, end: float, step: float) -> list[float]:
+    n = int(round(abs(end - start) / abs(step))) + 1
+    sign = 1.0 if end >= start else -1.0
+    return [round(start + sign * i * abs(step), 6) for i in range(n)]
+
+
+def _assert_prepared(docs: Docs, experiment: str, save_set: str) -> Path:
+    """Every GEECS key a downstream reader needs, plus the ScanInfo ini."""
+    start = docs.start
+    assert start["bluesky_backend"] is True
+    assert start["experiment"] == experiment
+    assert isinstance(start["scan_number"], int) and start["scan_number"] > 0
+    assert start["scan_id"] == start["scan_number"]
+    assert start["save_sets"] == [save_set]
+    assert "geecs_scalar_headers" in start
+    folder = Path(start["scan_folder"])
+    assert folder.is_dir(), folder
+    ini = folder / f"ScanInfoScan{start['scan_number']:03d}.ini"
+    assert ini.exists(), ini
+    parser = configparser.ConfigParser()
+    parser.read_string(ini.read_text())
+    assert parser["Scan Info"]["scan no"].strip('"') == str(start["scan_number"])
+    assert docs.docs["stop"][0]["exit_status"] == "success"
+    return folder
+
+
+@pytest.mark.hardware
+def test_stock_plans_run_as_geecs_scans_on_hardware() -> None:
+    """bp.count and bp.list_scan with md={"geecs": request}, against the machine."""
+    import bluesky.plans as bp
+
+    from geecs_bluesky.config_resolver import ConfigsRepoResolver
+    from geecs_bluesky.namespace import GeecsNamespace
+    from geecs_bluesky.preprocessors import (
+        install_connect_on_demand,
+        install_geecs_preamble,
+    )
+    from geecs_bluesky.session import GeecsSession
+    from geecs_schemas import ScanRequest
+
+    experiment = os.environ.get("GEECS_HW_EXPERIMENT", "Undulator")
+    save_set = os.environ.get("GEECS_HW_SAVE_SET", "Amp4In")
+    profile = os.environ.get("GEECS_HW_TRIGGER_PROFILE", "HTU-NoGas")
+    shots = int(os.environ.get("GEECS_HW_SHOTS", "3"))
+    sweep_target = os.environ.get("GEECS_HW_SCAN_VARIABLE")
+
+    resolver = ConfigsRepoResolver(experiment)
+    namespace = GeecsNamespace.from_experiment(experiment)
+    session = GeecsSession(experiment, tiled=False)
+    install_geecs_preamble(
+        session.RE, session=session, resolver=resolver, namespace=namespace
+    )
+    install_connect_on_demand(session.RE)
+    print(f"\nnamespace: {len(namespace)} devices; preamble + connect installed")
+
+    # Which devices the save set names — the stock plan is handed exactly
+    # those, which is what makes the preamble's configuration apply to the
+    # objects the plan reads.
+    entries = resolver.resolve_save_set(save_set).entries
+    detectors = [namespace[e.device] for e in entries]
+    print(f"save set {save_set}: {[d.name for d in detectors]}")
+
+    def request(**kw) -> dict:
+        base = dict(
+            mode="noscan",
+            shots_per_step=shots,
+            acquisition="free_run",
+            save_sets=[save_set],
+            trigger_profile=profile,
+            description="#807 phase 2 hardware acceptance",
+        )
+        base.update(kw)
+        return ScanRequest.model_validate(base).model_dump(mode="json")
+
+    # ---- 1. a stock count as a noscan -------------------------------------
+    docs = Docs()
+    session.RE(bp.count(detectors, num=shots, md={"geecs": request()}), docs)
+    folder = _assert_prepared(docs, experiment, save_set)
+    events = docs.primary_events()
+    assert len(events) == shots
+    stamps = [v for k, v in events[0]["data"].items() if k.endswith("-acq_timestamp")]
+    print(
+        f"count: scan {docs.start['scan_number']} in {folder}, "
+        f"{len(events)} events, plan_name={docs.start['plan_name']}"
+    )
+    print(f"  first-event shot stamps: {stamps}")
+    print(f"  columns: {sorted(events[0]['data'])}")
+    assert docs.start["plan_name"] == "count"
+
+    if not sweep_target:
+        pytest.skip("GEECS_HW_SCAN_VARIABLE unset — noscan half only")
+
+    # ---- 2. a stock list_scan as a step scan -------------------------------
+    device_name, _, variable = sweep_target.partition(":")
+    movable = namespace.variable(device_name, variable)
+    points = _sweep_points(
+        float(os.environ["GEECS_HW_SCAN_START"]),
+        float(os.environ["GEECS_HW_SCAN_END"]),
+        float(os.environ["GEECS_HW_SCAN_STEP"]),
+    )
+    initial = float(
+        __import__("asyncio")
+        .run_coroutine_threadsafe(movable._setpoint.get_value(), session.RE._loop)
+        .result(timeout=5)
+    )
+    print(f"sweep {sweep_target} over {points} (pre-scan setpoint {initial})")
+    docs2 = Docs()
+    try:
+        session.RE(
+            bp.list_scan(
+                detectors,
+                movable,
+                points,
+                md={
+                    "geecs": request(
+                        mode="step",
+                        axes=[{"variable": sweep_target, "positions": points}],
+                    )
+                },
+            ),
+            docs2,
+        )
+    finally:
+        from bluesky.plan_stubs import mv
+
+        session.RE(mv(movable, initial))
+        print(f"restored {sweep_target} to {initial}")
+
+    folder2 = _assert_prepared(docs2, experiment, save_set)
+    events2 = docs2.primary_events()
+    assert len(events2) == len(points)
+    readbacks = [e["data"][movable.position.name] for e in events2]
+    tol = getattr(movable, "_tolerance", 0.05)
+    for want, got in zip(points, readbacks):
+        assert abs(got - want) <= tol + 1e-9, f"{got} vs {want}"
+    print(
+        f"scan: scan {docs2.start['scan_number']} in {folder2}, "
+        f"{len(events2)} points, readbacks {readbacks}"
+    )
+    assert docs2.start["plan_name"] == "list_scan"
+    assert docs2.start["scan_number"] == docs.start["scan_number"] + 1

--- a/GeecsBluesky/tests/test_preamble_hardware.py
+++ b/GeecsBluesky/tests/test_preamble_hardware.py
@@ -8,9 +8,11 @@ a host with CA reach to the gateway and the GEECS DB (the qserver box)::
     GEECS_HW_SCAN_END=1 GEECS_HW_SCAN_STEP=0.5 \\
     poetry run pytest tests/test_preamble_hardware.py -m hardware -s
 
-**Side effects, deliberately real:** every run here claims a scan number
-and creates ``scans/ScanNNN/`` with its ``ScanInfoScanNNN.ini`` — that is
-the behaviour under test.  The claimed numbers are printed.
+**Side effects, deliberately real:** every run here claims a scan number,
+creates ``scans/ScanNNN/`` with its ``ScanInfoScanNNN.ini``, registers the
+run in the facility **Tiled** catalog and exports its s-file — that is the
+behaviour under test, and it is what makes the run visible in the data
+portal.  The claimed numbers are printed.
 
 What it proves that the mock cannot: the preamble preprocessor prepares a
 **stock** ``bluesky.plans`` verb exactly as the funnel prepares a submitted
@@ -105,7 +107,13 @@ def test_stock_plans_run_as_geecs_scans_on_hardware() -> None:
 
     resolver = ConfigsRepoResolver(experiment)
     namespace = GeecsNamespace.from_experiment(experiment)
-    session = GeecsSession(experiment, tiled=False)
+    # Subscribe what the worker startup subscribes, or the run never reaches
+    # the Tiled catalog the data portal lists from and never exports an
+    # s-file — the preprocessor path has to be indistinguishable downstream.
+    session = GeecsSession(experiment, tiled=True)
+    from geecs_bluesky.sfile_callback import SFileExportCallback
+
+    session.RE.subscribe(SFileExportCallback())
     install_geecs_preamble(
         session.RE, session=session, resolver=resolver, namespace=namespace
     )

--- a/GeecsBluesky/tests/test_preamble_hardware.py
+++ b/GeecsBluesky/tests/test_preamble_hardware.py
@@ -4,7 +4,7 @@ Hardware-marked (skipped in CI; ``-m integration`` does NOT select it — it
 arms the machine trigger **and claims a real scan number**).  Run by hand on
 a host with CA reach to the gateway and the GEECS DB (the qserver box)::
 
-    GEECS_HW_SCAN_VARIABLE=U_S1H:Current GEECS_HW_SCAN_START=-1 \\
+    GEECS_HW_SCAN_VARIABLE=S1H GEECS_HW_SCAN_START=-1 \\
     GEECS_HW_SCAN_END=1 GEECS_HW_SCAN_STEP=0.5 \\
     poetry run pytest tests/test_preamble_hardware.py -m hardware -s
 
@@ -23,7 +23,8 @@ Environment
 ``GEECS_HW_SAVE_SET``         save set (default ``Amp4In``)
 ``GEECS_HW_TRIGGER_PROFILE``  trigger profile (default ``HTU-NoGas``)
 ``GEECS_HW_SHOTS``            shots (default 3)
-``GEECS_HW_SCAN_VARIABLE``    ``Device:Variable`` to sweep (unset → noscan only)
+``GEECS_HW_SCAN_VARIABLE``    catalog scan-variable name to sweep, e.g. ``S1H``
+                              (unset → noscan only)
 ``GEECS_HW_SCAN_START/END/STEP``  sweep bounds (mandatory with the variable)
 """
 
@@ -149,8 +150,14 @@ def test_stock_plans_run_as_geecs_scans_on_hardware() -> None:
         pytest.skip("GEECS_HW_SCAN_VARIABLE unset — noscan half only")
 
     # ---- 2. a stock list_scan as a step scan -------------------------------
-    device_name, _, variable = sweep_target.partition(":")
+    # The request names the CATALOG variable (e.g. "S1H"); the plan needs the
+    # movable. Resolving the catalog target here is also the identity check
+    # that matters: the object the plan moves is the object the preamble
+    # resolved the axis to.
+    target = resolver.resolve_scan_variable(sweep_target)
+    device_name, _, variable = str(target.target).partition(":")
     movable = namespace.variable(device_name, variable)
+    print(f"catalog {sweep_target} -> {target.target} -> {movable.name}")
     points = _sweep_points(
         float(os.environ["GEECS_HW_SCAN_START"]),
         float(os.environ["GEECS_HW_SCAN_END"]),

--- a/GeecsBluesky/tests/test_preamble_hardware.py
+++ b/GeecsBluesky/tests/test_preamble_hardware.py
@@ -34,7 +34,6 @@ from __future__ import annotations
 
 import configparser
 import os
-from collections import defaultdict
 from pathlib import Path
 
 import pytest
@@ -42,30 +41,10 @@ import pytest
 pytestmark = pytest.mark.hardware
 pytest.importorskip("aioca")
 
-
-class Docs:
-    def __init__(self) -> None:
-        self.docs: dict[str, list[dict]] = defaultdict(list)
-
-    def __call__(self, name: str, doc: dict) -> None:
-        self.docs[name].append(doc)
-
-    @property
-    def start(self) -> dict:
-        return self.docs["start"][0]
-
-    def primary_events(self) -> list[dict]:
-        uids = {d["uid"] for d in self.docs["descriptor"] if d["name"] == "primary"}
-        return [e for e in self.docs["event"] if e["descriptor"] in uids]
+from tests.ca_mock_helpers import DocCollector, sweep_points  # noqa: E402
 
 
-def _sweep_points(start: float, end: float, step: float) -> list[float]:
-    n = int(round(abs(end - start) / abs(step))) + 1
-    sign = 1.0 if end >= start else -1.0
-    return [round(start + sign * i * abs(step), 6) for i in range(n)]
-
-
-def _assert_prepared(docs: Docs, experiment: str, save_set: str) -> Path:
+def _assert_prepared(docs: DocCollector, experiment: str, save_set: str) -> Path:
     """Every GEECS key a downstream reader needs, plus the ScanInfo ini."""
     start = docs.start
     assert start["bluesky_backend"] is True
@@ -140,7 +119,7 @@ def test_stock_plans_run_as_geecs_scans_on_hardware() -> None:
         return ScanRequest.model_validate(base).model_dump(mode="json")
 
     # ---- 1. a stock count as a noscan -------------------------------------
-    docs = Docs()
+    docs = DocCollector()
     session.RE(bp.count(detectors, num=shots, md={"geecs": request()}), docs)
     folder = _assert_prepared(docs, experiment, save_set)
     events = docs.primary_events()
@@ -166,7 +145,7 @@ def test_stock_plans_run_as_geecs_scans_on_hardware() -> None:
     device_name, _, variable = str(target.target).partition(":")
     movable = namespace.variable(device_name, variable)
     print(f"catalog {sweep_target} -> {target.target} -> {movable.name}")
-    points = _sweep_points(
+    points = sweep_points(
         float(os.environ["GEECS_HW_SCAN_START"]),
         float(os.environ["GEECS_HW_SCAN_END"]),
         float(os.environ["GEECS_HW_SCAN_STEP"]),
@@ -182,7 +161,7 @@ def test_stock_plans_run_as_geecs_scans_on_hardware() -> None:
         )
     )
     print(f"sweep {sweep_target} over {points} (pre-scan setpoint {initial})")
-    docs2 = Docs()
+    docs2 = DocCollector()
     try:
         session.RE(
             bp.list_scan(

--- a/GeecsBluesky/tests/test_preamble_preprocessor.py
+++ b/GeecsBluesky/tests/test_preamble_preprocessor.py
@@ -37,8 +37,31 @@ from geecs_schemas import ScanRequest  # noqa: E402
 from tests.test_scan_request_runner import (  # noqa: E402
     LEGACY_EXP_SCAN_VARIABLES,
     LEGACY_SAVE_ELEMENT,
-    LEGACY_SHOT_CONTROL,
 )
+
+#: Strict shot control needs a non-empty ARMED state (the plan fires every
+#: shot), which the shared free-run-era corpus profile does not define.
+STRICT_SHOT_CONTROL = """\
+device: U_DG645_ShotControl
+variables:
+  Trigger.Source:
+    "OFF": "Single shot external rising edges"
+    ARMED: "Single shot external rising edges"
+    SCAN: "External rising edges"
+    STANDBY: "External rising edges"
+    SINGLESHOT: ""
+  Trigger.ExecuteSingleShot:
+    "OFF": ""
+    ARMED: ""
+    SCAN: ""
+    STANDBY: ""
+    SINGLESHOT: "on"
+  Amplitude.Ch AB:
+    "OFF": "0.5"
+    ARMED: "4.0"
+    SCAN: "4.0"
+    STANDBY: "0.5"
+"""
 
 
 def row(name, *, settable=False, choices="numeric", tolerance=None):
@@ -81,7 +104,7 @@ def configs_root(tmp_path):
     (exp / "save_devices" / "UC_Test.yaml").write_text(LEGACY_SAVE_ELEMENT)
     (exp / "shot_control_configurations").mkdir()
     (exp / "shot_control_configurations" / "HTU-Normal.yaml").write_text(
-        LEGACY_SHOT_CONTROL
+        STRICT_SHOT_CONTROL
     )
     (exp / "scan_devices").mkdir()
     (exp / "scan_devices" / "scan_variables.yaml").write_text(LEGACY_EXP_SCAN_VARIABLES)
@@ -138,32 +161,76 @@ def _request(**overrides) -> dict:
     base = dict(
         mode="noscan",
         shots_per_step=2,
-        acquisition="free_run",
+        acquisition="strict",
         save_sets=["UC_Test"],
+        trigger_profile="HTU-Normal",
         description="stats",
     )
     base.update(overrides)
     return ScanRequest.model_validate(base).model_dump(mode="json")
 
 
-def _pace(RE, namespace):
-    """The fake trigger: advance every triggered device's acq_timestamp."""
+class _RecordingSetter:
+    """A shot-control setter that records writes instead of doing a caput.
+
+    ``ShotController.from_writes`` already takes a ``setter_factory`` seam,
+    so nothing in the engine is stubbed: the real controller replays the
+    real profile, and the test sees the exact ordered state writes.
+    """
+
+    def __init__(self, device: str, variable: str, log: list, on_write) -> None:
+        self._device, self._variable, self._log, self._on_write = (
+            device,
+            variable,
+            log,
+            on_write,
+        )
+
+    def set(self, value):
+        from ophyd_async.core import AsyncStatus
+
+        self._log.append((self._device, self._variable, value))
+        self._on_write(self._variable, value)
+
+        async def _done() -> None:
+            return None
+
+        return AsyncStatus(_done())
+
+
+def _machine(RE, namespace, monkeypatch):
+    """Stand in for the machine: a shot happens only when the plan fires.
+
+    Returns the ordered ``(device, variable, value)`` write log, which is
+    what pins the Gate-2 bracket: ARMED (free run halted) → saving on →
+    SINGLESHOT per shot → saving off → STANDBY.
+    """
+    from geecs_bluesky.shot_controller import ShotController
+
     cams = [namespace["U_Cam"], namespace["U_Cam2"]]
     for cam in cams:
         cam._trigger_timeout = 2.0
+    writes: list = []
+    shots = {"n": 0}
 
-    async def pace() -> None:
-        # Pace whichever cameras this plan actually connected — a plan need
-        # not stage them all.
-        ticks = 0
-        while True:
-            ticks += 1
+    def on_write(variable: str, value) -> None:
+        # The profile fires by writing Trigger.ExecuteSingleShot='on'.
+        if variable.endswith("ExecuteSingleShot") and value == "on":
+            shots["n"] += 1
             for cam in cams:
                 if cam._monitoring:
-                    set_mock_value(cam.acq_timestamp, 1000.0 + ticks)
-            await asyncio.sleep(0.02)
+                    set_mock_value(cam.acq_timestamp, 1000.0 + shots["n"])
 
-    return asyncio.run_coroutine_threadsafe(pace(), RE._loop)
+    original = ShotController.from_writes.__func__
+
+    def from_writes(cls, w, **kwargs):
+        kwargs["setter_factory"] = lambda device, variable: _RecordingSetter(
+            device, variable, writes, on_write
+        )
+        return original(cls, w, **kwargs)
+
+    monkeypatch.setattr(ShotController, "from_writes", classmethod(from_writes))
+    return writes
 
 
 def _install(session, resolver, namespace, folder, monkeypatch):
@@ -193,9 +260,21 @@ def test_a_plan_without_the_geecs_key_is_untouched(session, namespace) -> None:
     install_geecs_preamble(session.RE, session=session, namespace=namespace)
     install_connect_on_demand(session.RE, mock=True)
     docs = Docs()
-    pacer = _pace(session.RE, namespace)
+    # no request → no controller → nothing fires, so pace the trigger freely
+    cam = namespace["U_Cam"]
+    cam._trigger_timeout = 2.0
+
+    async def free_run() -> None:
+        ticks = 0
+        while True:
+            ticks += 1
+            if cam._monitoring:
+                set_mock_value(cam.acq_timestamp, 5000.0 + ticks)
+            await asyncio.sleep(0.02)
+
+    pacer = asyncio.run_coroutine_threadsafe(free_run(), session.RE._loop)
     try:
-        session.RE(bp.count([namespace["U_Cam"]], num=1), docs)
+        session.RE(bp.count([cam], num=1), docs)
     finally:
         pacer.cancel()
     assert "scan_number" not in docs.start and "scan_folder" not in docs.start
@@ -210,19 +289,16 @@ def test_stock_count_gets_the_full_preamble(
     folder = tmp_path / "Scan007"
     folder.mkdir(parents=True, exist_ok=True)
     _install(session, resolver, namespace, folder, monkeypatch)
+    writes = _machine(session.RE, namespace, monkeypatch)
     docs = Docs()
-    pacer = _pace(session.RE, namespace)
-    try:
-        session.RE(
-            bp.count(
-                [namespace["U_Cam"], namespace["U_Cam2"], namespace["U_Slow"]],
-                num=2,
-                md={"geecs": _request()},
-            ),
-            docs,
-        )
-    finally:
-        pacer.cancel()
+    session.RE(
+        bp.count(
+            [namespace["U_Cam"], namespace["U_Cam2"], namespace["U_Slow"]],
+            num=2,
+            md={"geecs": _request()},
+        ),
+        docs,
+    )
 
     start = docs.start
     # the claim reached the start document
@@ -244,8 +320,10 @@ def test_stock_count_gets_the_full_preamble(
     parser = configparser.ConfigParser()
     parser.read_string(ini.read_text())
     assert parser["Scan Info"]["scanmode"] == '"noscan"'
-    # and the run actually recorded shots
+    # and the run actually recorded shots — one fire each
     assert len(docs.primary_events()) == 2
+    fires = [w for w in writes if w[1].endswith("ExecuteSingleShot") and w[2] == "on"]
+    assert len(fires) == 2, writes
     assert docs.docs["stop"][0]["exit_status"] == "success"
 
 
@@ -257,11 +335,8 @@ def test_the_preamble_disarms_and_stops_saving_on_the_way_out(
     folder.mkdir(parents=True, exist_ok=True)
     _install(session, resolver, namespace, folder, monkeypatch)
     cam = namespace["U_Cam"]
-    pacer = _pace(session.RE, namespace)
-    try:
-        session.RE(bp.count([cam], num=1, md={"geecs": _request()}), Docs())
-    finally:
-        pacer.cancel()
+    writes = _machine(session.RE, namespace, monkeypatch)
+    session.RE(bp.count([cam], num=1, md={"geecs": _request()}), Docs())
     # mock backends do not echo a put onto the readback, so read the setpoint
     saved = asyncio.run_coroutine_threadsafe(
         cam.save._setpoint.get_value(), session.RE._loop
@@ -271,6 +346,31 @@ def test_the_preamble_disarms_and_stops_saving_on_the_way_out(
         cam.localsavingpath._setpoint.get_value(), session.RE._loop
     ).result(timeout=5)
     assert path_written.endswith("U_Cam")  # save-on wrote the per-device dir
+
+    # Gate-2 save windowing, the ordering this bracket exists for: the free
+    # run is HALTED (ARMED) before saving is enabled, and saving is disabled
+    # again before the trigger is released (STANDBY) — otherwise the camera
+    # writes orphan frames with no event row.
+    sources = [w[2] for w in writes if w[1] == "Trigger.Source"]
+    assert sources[0] == "Single shot external rising edges"  # ARMED, halted
+    assert sources[-1] == "External rising edges"  # STANDBY, released last
+
+
+def test_free_run_is_refused_before_the_claim(
+    session, resolver, namespace, tmp_path, monkeypatch
+) -> None:
+    """Stock plans are strict-only; free-run is retired (#807)."""
+    folder = tmp_path / "Scan007"
+    _install(session, resolver, namespace, folder, monkeypatch)
+    with pytest.raises(GeecsConfigurationError, match="strict shot control only"):
+        session.RE(
+            bp.count(
+                [namespace["U_Cam"]],
+                num=1,
+                md={"geecs": _request(acquisition="free_run")},
+            )
+        )
+    assert not (folder / "ScanInfoScan007.ini").exists()
 
 
 def test_a_failure_before_the_claim_burns_no_scan_number(

--- a/GeecsBluesky/tests/test_preamble_preprocessor.py
+++ b/GeecsBluesky/tests/test_preamble_preprocessor.py
@@ -1,0 +1,335 @@
+"""geecs_preamble — the GEECS scan preamble as a RunEngine preprocessor (#807 phase 2).
+
+A stock ``bluesky.plans`` verb whose run metadata carries a ScanRequest gets
+the funnel's preamble: validate, resolve, connect, claim, ScanInfo, saving,
+metadata — then the finalize chain on the way out.  Hermetic: the mock
+RunEngine, the test config corpus, no DB and no gateway.
+
+The devices come from a :class:`~geecs_bluesky.namespace.GeecsNamespace`, so
+the objects the preamble configures are the ones the plan was handed —
+`preamble.namespace_detectors`.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import configparser
+from collections import defaultdict
+
+import bluesky.plans as bp
+import pytest
+
+pytest.importorskip("aioca")  # CA backend needs the `ca` extra
+
+from ophyd_async.core import set_mock_value  # noqa: E402
+
+from geecs_bluesky.config_resolver import ConfigsRepoResolver  # noqa: E402
+from geecs_bluesky.exceptions import GeecsConfigurationError  # noqa: E402
+from geecs_bluesky.namespace import DeviceRoster, GeecsNamespace  # noqa: E402
+from geecs_bluesky.preprocessors import (  # noqa: E402
+    connect_on_demand,
+    geecs_preamble,
+    install_connect_on_demand,
+    install_geecs_preamble,
+)
+from geecs_bluesky.session import GeecsSession  # noqa: E402
+from geecs_schemas import ScanRequest  # noqa: E402
+from tests.test_scan_request_runner import (  # noqa: E402
+    LEGACY_EXP_SCAN_VARIABLES,
+    LEGACY_SAVE_ELEMENT,
+    LEGACY_SHOT_CONTROL,
+)
+
+
+def row(name, *, settable=False, choices="numeric", tolerance=None):
+    return {
+        "name": name,
+        "settable": settable,
+        "variabletype": None,
+        "choices": choices,
+        "tolerance": tolerance,
+        "units": "",
+        "min": None,
+        "max": None,
+    }
+
+
+#: The corpus save set names U_Cam (sync, native saving), U_Cam2 (sync) and
+#: U_Slow (async) — the namespace must offer exactly those, with the save
+#: controls U_Cam needs as its own served settables.
+ROSTER = DeviceRoster(
+    experiment="LegacyExp",
+    variables={
+        "U_Cam": [
+            row("trigger", settable=True, choices="on,off"),
+            row("MaxCounts"),
+            row("save", settable=True, choices="on,off"),
+            row("localsavingpath", settable=True, choices="path"),
+        ],
+        "U_Cam2": [row("trigger", settable=True, choices="on,off"), row("Val")],
+        "U_Slow": [row("Pressure")],
+    },
+    types={"U_Cam": "Point Grey Camera", "U_Cam2": "Point Grey Camera"},
+    subscribed={"U_Cam": ["MaxCounts"], "U_Cam2": ["Val"], "U_Slow": ["Pressure"]},
+)
+
+
+@pytest.fixture
+def configs_root(tmp_path):
+    exp = tmp_path / "LegacyExp"
+    (exp / "save_devices").mkdir(parents=True)
+    (exp / "save_devices" / "UC_Test.yaml").write_text(LEGACY_SAVE_ELEMENT)
+    (exp / "shot_control_configurations").mkdir()
+    (exp / "shot_control_configurations" / "HTU-Normal.yaml").write_text(
+        LEGACY_SHOT_CONTROL
+    )
+    (exp / "scan_devices").mkdir()
+    (exp / "scan_devices" / "scan_variables.yaml").write_text(LEGACY_EXP_SCAN_VARIABLES)
+    return tmp_path
+
+
+@pytest.fixture
+def resolver(configs_root):
+    return ConfigsRepoResolver("LegacyExp", experiments_root=configs_root)
+
+
+@pytest.fixture(autouse=True)
+def no_db(monkeypatch):
+    """Neutralize the DB-backed providers (hermetic: no MySQL, no gateway)."""
+    monkeypatch.setattr(
+        "geecs_bluesky.scan_request_runner.make_scalar_policy", lambda session: None
+    )
+    monkeypatch.setattr(
+        "geecs_bluesky.plans.preamble.make_scalar_policy", lambda session: None
+    )
+    monkeypatch.setattr(
+        "geecs_bluesky.scan_request_runner.make_served_set_provider",
+        lambda session: None,
+    )
+
+
+@pytest.fixture
+def namespace():
+    return GeecsNamespace(ROSTER)
+
+
+@pytest.fixture
+def session():
+    return GeecsSession("LegacyExp", tiled=False, mock=True)
+
+
+class Docs:
+    def __init__(self) -> None:
+        self.docs: dict[str, list[dict]] = defaultdict(list)
+
+    def __call__(self, name: str, doc: dict) -> None:
+        self.docs[name].append(doc)
+
+    @property
+    def start(self) -> dict:
+        return self.docs["start"][0]
+
+    def primary_events(self) -> list[dict]:
+        uids = {d["uid"] for d in self.docs["descriptor"] if d["name"] == "primary"}
+        return [e for e in self.docs["event"] if e["descriptor"] in uids]
+
+
+def _request(**overrides) -> dict:
+    base = dict(
+        mode="noscan",
+        shots_per_step=2,
+        acquisition="free_run",
+        save_sets=["UC_Test"],
+        description="stats",
+    )
+    base.update(overrides)
+    return ScanRequest.model_validate(base).model_dump(mode="json")
+
+
+def _pace(RE, namespace):
+    """The fake trigger: advance every triggered device's acq_timestamp."""
+    cams = [namespace["U_Cam"], namespace["U_Cam2"]]
+    for cam in cams:
+        cam._trigger_timeout = 2.0
+
+    async def pace() -> None:
+        # Pace whichever cameras this plan actually connected — a plan need
+        # not stage them all.
+        ticks = 0
+        while True:
+            ticks += 1
+            for cam in cams:
+                if cam._monitoring:
+                    set_mock_value(cam.acq_timestamp, 1000.0 + ticks)
+            await asyncio.sleep(0.02)
+
+    return asyncio.run_coroutine_threadsafe(pace(), RE._loop)
+
+
+def _install(session, resolver, namespace, folder, monkeypatch):
+    install_geecs_preamble(
+        session.RE, session=session, resolver=resolver, namespace=namespace
+    )
+    install_connect_on_demand(session.RE, mock=True)
+
+    def claim(experiment):
+        assert experiment == "LegacyExp"
+        return 7, str(folder)
+
+    monkeypatch.setattr("geecs_bluesky.plans.run_wrapper.claim_scan_number", claim)
+
+
+# ---------------------------------------------------------------------- shape
+def test_install_keeps_connect_on_demand_outermost(session, namespace) -> None:
+    install_geecs_preamble(session.RE, session=session, namespace=namespace)
+    install_connect_on_demand(session.RE, mock=True)
+    install_geecs_preamble(session.RE, session=session, namespace=namespace)  # again
+    funcs = [getattr(p, "func", p) for p in session.RE.preprocessors]
+    assert funcs == [geecs_preamble, connect_on_demand]
+
+
+def test_a_plan_without_the_geecs_key_is_untouched(session, namespace) -> None:
+    """No request, no preamble: the preprocessor must be a pure no-op."""
+    install_geecs_preamble(session.RE, session=session, namespace=namespace)
+    install_connect_on_demand(session.RE, mock=True)
+    docs = Docs()
+    pacer = _pace(session.RE, namespace)
+    try:
+        session.RE(bp.count([namespace["U_Cam"]], num=1), docs)
+    finally:
+        pacer.cancel()
+    assert "scan_number" not in docs.start and "scan_folder" not in docs.start
+    assert docs.docs["stop"][0]["exit_status"] == "success"
+
+
+# -------------------------------------------------------------- the preamble
+def test_stock_count_gets_the_full_preamble(
+    session, resolver, namespace, tmp_path, monkeypatch
+) -> None:
+    """bp.count + md={"geecs": request} == a prepared, claimed, recorded scan."""
+    folder = tmp_path / "Scan007"
+    folder.mkdir(parents=True, exist_ok=True)
+    _install(session, resolver, namespace, folder, monkeypatch)
+    docs = Docs()
+    pacer = _pace(session.RE, namespace)
+    try:
+        session.RE(
+            bp.count(
+                [namespace["U_Cam"], namespace["U_Cam2"], namespace["U_Slow"]],
+                num=2,
+                md={"geecs": _request()},
+            ),
+            docs,
+        )
+    finally:
+        pacer.cancel()
+
+    start = docs.start
+    # the claim reached the start document
+    assert start["scan_number"] == 7 and start["scan_id"] == 7
+    assert start["scan_folder"] == str(folder)
+    assert start["bluesky_backend"] is True and start["experiment"] == "LegacyExp"
+    # GEECS request metadata every downstream reader needs
+    assert start["scan_request_mode"] == "noscan"
+    assert start["save_sets"] == ["UC_Test"]
+    assert start["description"] == "stats"
+    assert "geecs_scalar_headers" in start
+    # native saving was configured for the save set's saving device
+    assert "U_Cam" in start["nonscalar_save_paths"]
+    # the stock plan keeps its own identity
+    assert start["plan_name"] == "count"
+    # ScanInfo was written post-claim
+    ini = folder / "ScanInfoScan007.ini"
+    assert ini.exists()
+    parser = configparser.ConfigParser()
+    parser.read_string(ini.read_text())
+    assert parser["Scan Info"]["scanmode"] == '"noscan"'
+    # and the run actually recorded shots
+    assert len(docs.primary_events()) == 2
+    assert docs.docs["stop"][0]["exit_status"] == "success"
+
+
+def test_the_preamble_disarms_and_stops_saving_on_the_way_out(
+    session, resolver, namespace, tmp_path, monkeypatch
+) -> None:
+    """The finalize chain runs: save off, then the trigger disarmed."""
+    folder = tmp_path / "Scan007"
+    folder.mkdir(parents=True, exist_ok=True)
+    _install(session, resolver, namespace, folder, monkeypatch)
+    cam = namespace["U_Cam"]
+    pacer = _pace(session.RE, namespace)
+    try:
+        session.RE(bp.count([cam], num=1, md={"geecs": _request()}), Docs())
+    finally:
+        pacer.cancel()
+    # mock backends do not echo a put onto the readback, so read the setpoint
+    saved = asyncio.run_coroutine_threadsafe(
+        cam.save._setpoint.get_value(), session.RE._loop
+    ).result(timeout=5)
+    assert saved == "off"
+    path_written = asyncio.run_coroutine_threadsafe(
+        cam.localsavingpath._setpoint.get_value(), session.RE._loop
+    ).result(timeout=5)
+    assert path_written.endswith("U_Cam")  # save-on wrote the per-device dir
+
+
+def test_a_failure_before_the_claim_burns_no_scan_number(
+    session, resolver, namespace, tmp_path, monkeypatch
+) -> None:
+    """The pre-claim invariant survives the move to a preprocessor."""
+    folder = tmp_path / "Scan007"
+    _install(session, resolver, namespace, folder, monkeypatch)
+    claimed: list = []
+    monkeypatch.setattr(
+        "geecs_bluesky.plans.run_wrapper.claim_scan_number",
+        lambda experiment: claimed.append(experiment) or (7, str(folder)),
+    )
+    with pytest.raises(Exception):
+        session.RE(
+            bp.count(
+                [namespace["U_Cam"]], num=1, md={"geecs": _request(save_sets=["Nope"])}
+            )
+        )
+    assert claimed == []
+    assert not folder.exists()
+
+
+# ------------------------------------------------------- the namespace source
+def test_a_save_set_device_missing_from_the_namespace_is_loud(
+    session, resolver, tmp_path, monkeypatch
+) -> None:
+    thin = GeecsNamespace(
+        DeviceRoster(
+            experiment="LegacyExp",
+            variables={"U_Cam": ROSTER.variables["U_Cam"]},
+            types={"U_Cam": "Point Grey Camera"},
+            subscribed={"U_Cam": ["MaxCounts"]},
+        )
+    )
+    folder = tmp_path / "Scan007"
+    _install(session, resolver, thin, folder, monkeypatch)
+    with pytest.raises(GeecsConfigurationError, match="not in the device namespace"):
+        session.RE(bp.count([thin["U_Cam"]], num=1, md={"geecs": _request()}))
+
+
+def test_a_save_set_scalar_the_device_does_not_read_is_loud(
+    session, resolver, tmp_path, monkeypatch
+) -> None:
+    """The namespace reads the DB subscribed list; a mismatch must not be silent."""
+    variables = dict(ROSTER.variables)
+    variables["U_Cam2"] = [
+        row("trigger", settable=True, choices="on,off"),
+        row("Other"),
+    ]
+    ns = GeecsNamespace(
+        DeviceRoster(
+            experiment="LegacyExp",
+            variables=variables,
+            types=ROSTER.types,
+            subscribed={**ROSTER.subscribed, "U_Cam2": ["Other"]},
+        )
+    )
+    folder = tmp_path / "Scan007"
+    _install(session, resolver, ns, folder, monkeypatch)
+    with pytest.raises(GeecsConfigurationError, match="which the namespace device"):
+        session.RE(bp.count([ns["U_Cam"]], num=1, md={"geecs": _request()}))

--- a/GeecsBluesky/tests/test_preamble_preprocessor.py
+++ b/GeecsBluesky/tests/test_preamble_preprocessor.py
@@ -7,14 +7,13 @@ RunEngine, the test config corpus, no DB and no gateway.
 
 The devices come from a :class:`~geecs_bluesky.namespace.GeecsNamespace`, so
 the objects the preamble configures are the ones the plan was handed —
-`preamble.namespace_detectors`.
+``GeecsNamespace.select``.
 """
 
 from __future__ import annotations
 
 import asyncio
 import configparser
-from collections import defaultdict
 
 import bluesky.plans as bp
 import pytest
@@ -34,6 +33,7 @@ from geecs_bluesky.preprocessors import (  # noqa: E402
 )
 from geecs_bluesky.session import GeecsSession  # noqa: E402
 from geecs_schemas import ScanRequest  # noqa: E402
+from tests.ca_mock_helpers import DocCollector  # noqa: E402
 from tests.test_scan_request_runner import (  # noqa: E402
     LEGACY_EXP_SCAN_VARIABLES,
     LEGACY_SAVE_ELEMENT,
@@ -91,9 +91,20 @@ ROSTER = DeviceRoster(
         ],
         "U_Cam2": [row("trigger", settable=True, choices="on,off"), row("Val")],
         "U_Slow": [row("Pressure")],
+        # The corpus scan variable `jet_z` targets this device; a step scan
+        # needs its settable to exist as a namespace child.
+        "U_ESP_JetXYZ": [
+            row("Position.Axis 3", settable=True),
+            row("Position.Axis 1", settable=True),
+        ],
     },
     types={"U_Cam": "Point Grey Camera", "U_Cam2": "Point Grey Camera"},
-    subscribed={"U_Cam": ["MaxCounts"], "U_Cam2": ["Val"], "U_Slow": ["Pressure"]},
+    subscribed={
+        "U_Cam": ["MaxCounts"],
+        "U_Cam2": ["Val"],
+        "U_Slow": ["Pressure"],
+        "U_ESP_JetXYZ": ["Position.Axis 3"],
+    },
 )
 
 
@@ -141,20 +152,14 @@ def session():
     return GeecsSession("LegacyExp", tiled=False, mock=True)
 
 
-class Docs:
-    def __init__(self) -> None:
-        self.docs: dict[str, list[dict]] = defaultdict(list)
+def _save_set(namespace) -> list:
+    """The UC_Test save set's devices — what a stock plan must be handed.
 
-    def __call__(self, name: str, doc: dict) -> None:
-        self.docs[name].append(doc)
-
-    @property
-    def start(self) -> dict:
-        return self.docs["start"][0]
-
-    def primary_events(self) -> list[dict]:
-        uids = {d["uid"] for d in self.docs["descriptor"] if d["name"] == "primary"}
-        return [e for e in self.docs["event"] if e["descriptor"] in uids]
+    The preamble configures native saving for exactly these, so a plan that
+    reads fewer would leave saved files with no event row to join them to
+    (refused; see ``_check_plan_covers_save_set``).
+    """
+    return [namespace["U_Cam"], namespace["U_Cam2"], namespace["U_Slow"]]
 
 
 def _request(**overrides) -> dict:
@@ -207,17 +212,29 @@ def _machine(RE, namespace, monkeypatch):
     """
     from geecs_bluesky.shot_controller import ShotController
 
-    cams = [namespace["U_Cam"], namespace["U_Cam2"]]
-    for cam in cams:
-        cam._trigger_timeout = 2.0
+    from geecs_bluesky.devices.ca.triggerable import CaTriggerable
+
     writes: list = []
     shots = {"n": 0}
+    # Whatever the plan actually triggers is what the fired shot must reach
+    # — recorded here rather than named, so the same stand-in serves the
+    # namespace devices and the funnel's own per-scan ones.
+    armed: list = []
+    original_trigger = CaTriggerable.trigger
+
+    def trigger(self, *args, **kwargs):
+        if self not in armed:
+            armed.append(self)
+        self._trigger_timeout = 2.0
+        return original_trigger(self, *args, **kwargs)
+
+    monkeypatch.setattr(CaTriggerable, "trigger", trigger)
 
     def on_write(variable: str, value) -> None:
         # The profile fires by writing Trigger.ExecuteSingleShot='on'.
         if variable.endswith("ExecuteSingleShot") and value == "on":
             shots["n"] += 1
-            for cam in cams:
+            for cam in armed:
                 if cam._monitoring:
                     set_mock_value(cam.acq_timestamp, 1000.0 + shots["n"])
 
@@ -230,6 +247,26 @@ def _machine(RE, namespace, monkeypatch):
         return original(cls, w, **kwargs)
 
     monkeypatch.setattr(ShotController, "from_writes", classmethod(from_writes))
+
+    # Every settable put goes into the SAME ordered log, so the bracket the
+    # changelog leads with — arm (ARMED) before save-on, save-off before
+    # disarm (STANDBY) — is pinned by one sequence rather than inferred from
+    # two.  Wrapping the class covers the lazily connected children too.
+    from geecs_bluesky.devices.ca.settable import CaSettable
+
+    original_set = CaSettable.set
+
+    def recording_set(self, value, *args, **kwargs):
+        writes.append(
+            (
+                getattr(self, "_geecs_device_name", self.name),
+                getattr(self, "_variable", self.name),
+                value,
+            )
+        )
+        return original_set(self, value, *args, **kwargs)
+
+    monkeypatch.setattr(CaSettable, "set", recording_set)
     return writes
 
 
@@ -259,7 +296,7 @@ def test_a_plan_without_the_geecs_key_is_untouched(session, namespace) -> None:
     """No request, no preamble: the preprocessor must be a pure no-op."""
     install_geecs_preamble(session.RE, session=session, namespace=namespace)
     install_connect_on_demand(session.RE, mock=True)
-    docs = Docs()
+    docs = DocCollector()
     # no request → no controller → nothing fires, so pace the trigger freely
     cam = namespace["U_Cam"]
     cam._trigger_timeout = 2.0
@@ -290,7 +327,7 @@ def test_stock_count_gets_the_full_preamble(
     folder.mkdir(parents=True, exist_ok=True)
     _install(session, resolver, namespace, folder, monkeypatch)
     writes = _machine(session.RE, namespace, monkeypatch)
-    docs = Docs()
+    docs = DocCollector()
     session.RE(
         bp.count(
             [namespace["U_Cam"], namespace["U_Cam2"], namespace["U_Slow"]],
@@ -336,7 +373,10 @@ def test_the_preamble_disarms_and_stops_saving_on_the_way_out(
     _install(session, resolver, namespace, folder, monkeypatch)
     cam = namespace["U_Cam"]
     writes = _machine(session.RE, namespace, monkeypatch)
-    session.RE(bp.count([cam], num=1, md={"geecs": _request()}), Docs())
+    session.RE(
+        bp.count(_save_set(namespace), num=1, md={"geecs": _request(shots_per_step=1)}),
+        DocCollector(),
+    )
     # mock backends do not echo a put onto the readback, so read the setpoint
     saved = asyncio.run_coroutine_threadsafe(
         cam.save._setpoint.get_value(), session.RE._loop
@@ -354,6 +394,19 @@ def test_the_preamble_disarms_and_stops_saving_on_the_way_out(
     sources = [w[2] for w in writes if w[1] == "Trigger.Source"]
     assert sources[0] == "Single shot external rising edges"  # ARMED, halted
     assert sources[-1] == "External rising edges"  # STANDBY, released last
+
+    # …and the save writes sit INSIDE that bracket.  Asserted on positions
+    # in the one ordered log, so swapping arm_single_shot and
+    # save_enable_plan fails this test rather than passing it quietly.
+    order = [(w[1], w[2]) for w in writes]
+    arm = order.index(("Trigger.Source", "Single shot external rising edges"))
+    save_on = order.index(("save", "on"))
+    save_off = len(order) - 1 - order[::-1].index(("save", "off"))
+    release = (
+        len(order) - 1 - order[::-1].index(("Trigger.Source", "External rising edges"))
+    )
+    assert arm < save_on, order  # halt the free run BEFORE saving starts
+    assert save_off < release, order  # stop saving BEFORE edges come back
 
 
 def test_free_run_is_refused_before_the_claim(
@@ -409,7 +462,9 @@ def test_a_save_set_device_missing_from_the_namespace_is_loud(
     folder = tmp_path / "Scan007"
     _install(session, resolver, thin, folder, monkeypatch)
     with pytest.raises(GeecsConfigurationError, match="not in the device namespace"):
-        session.RE(bp.count([thin["U_Cam"]], num=1, md={"geecs": _request()}))
+        session.RE(
+            bp.count([thin["U_Cam"]], num=1, md={"geecs": _request(shots_per_step=1)})
+        )
 
 
 def test_a_save_set_scalar_the_device_does_not_read_is_loud(
@@ -432,4 +487,400 @@ def test_a_save_set_scalar_the_device_does_not_read_is_loud(
     folder = tmp_path / "Scan007"
     _install(session, resolver, ns, folder, monkeypatch)
     with pytest.raises(GeecsConfigurationError, match="which the namespace device"):
-        session.RE(bp.count([ns["U_Cam"]], num=1, md={"geecs": _request()}))
+        session.RE(
+            bp.count([ns["U_Cam"]], num=1, md={"geecs": _request(shots_per_step=1)})
+        )
+
+
+# ------------------------------------------------- what the funnel got free
+def test_per_run_device_state_does_not_leak_into_the_next_plan(
+    session, resolver, namespace, tmp_path, monkeypatch
+) -> None:
+    """A namespace noun outlives the run: nothing it configured may survive.
+
+    The per-scan device classes were thrown away at the end of a scan and
+    got this for free.  If it leaked, an unrelated later plan would emit a
+    ``nonscalar_save_path`` column — and asset documents — pointing into
+    the previous scan's folder.
+    """
+    folder = tmp_path / "Scan007"
+    folder.mkdir(parents=True, exist_ok=True)
+    _install(session, resolver, namespace, folder, monkeypatch)
+    _machine(session.RE, namespace, monkeypatch)
+    cam = namespace["U_Cam"]
+    session.RE(
+        bp.count(_save_set(namespace), num=1, md={"geecs": _request(shots_per_step=1)}),
+        DocCollector(),
+    )
+    assert cam._save_nonscalar_data is False
+    assert cam._nonscalar_save_path is None
+    assert cam._asset_definitions == ()
+    assert cam._asset_scan_number is None
+
+    # and the proof at the document level: a plain plan, no GEECS key
+    cam._trigger_timeout = 2.0
+
+    async def free_run() -> None:
+        ticks = 0
+        while True:
+            ticks += 1
+            if cam._monitoring:
+                set_mock_value(cam.acq_timestamp, 9000.0 + ticks)
+            await asyncio.sleep(0.02)
+
+    docs = DocCollector()
+    pacer = asyncio.run_coroutine_threadsafe(free_run(), session.RE._loop)
+    try:
+        session.RE(bp.count([cam], num=1), docs)
+    finally:
+        pacer.cancel()
+    columns = set(docs.primary_events()[0]["data"])
+    assert not [c for c in columns if c.endswith("nonscalar_save_path")], columns
+
+
+def test_a_plan_that_does_not_read_the_whole_save_set_is_refused(
+    session, resolver, namespace, tmp_path, monkeypatch
+) -> None:
+    """Saved but unread = orphan frames with no acq_timestamp to join on."""
+    folder = tmp_path / "Scan007"
+    _install(session, resolver, namespace, folder, monkeypatch)
+    _machine(session.RE, namespace, monkeypatch)
+    claimed: list = []
+    monkeypatch.setattr(
+        "geecs_bluesky.plans.run_wrapper.claim_scan_number",
+        lambda experiment: claimed.append(experiment) or (7, str(folder)),
+    )
+    with pytest.raises(GeecsConfigurationError, match="which this plan does not read"):
+        session.RE(
+            bp.count(
+                [namespace["U_Cam"]], num=1, md={"geecs": _request(shots_per_step=1)}
+            )
+        )
+    assert claimed == []  # refused before the claim
+
+
+def test_a_plan_whose_shape_contradicts_the_request_is_refused(
+    session, resolver, namespace, tmp_path, monkeypatch
+) -> None:
+    """ScanInfo records the request's numbers, so they must match the plan's."""
+    folder = tmp_path / "Scan007"
+    _install(session, resolver, namespace, folder, monkeypatch)
+    _machine(session.RE, namespace, monkeypatch)
+    claimed: list = []
+    monkeypatch.setattr(
+        "geecs_bluesky.plans.run_wrapper.claim_scan_number",
+        lambda experiment: claimed.append(experiment) or (7, str(folder)),
+    )
+    with pytest.raises(GeecsConfigurationError, match="recorded shots"):
+        session.RE(
+            bp.count(
+                _save_set(namespace), num=2, md={"geecs": _request(shots_per_step=5)}
+            )
+        )
+    assert claimed == []
+
+
+def test_a_dropped_frame_is_re_fired_not_fatal(
+    session, resolver, namespace, tmp_path, monkeypatch
+) -> None:
+    """The stock door gets geecs_single_shot's bounded refire, not a bare wait.
+
+    The first fire produces no frame (the ~1% camera drop); the scan must
+    recover rather than abort, and must still record exactly one row.
+    """
+    folder = tmp_path / "Scan007"
+    folder.mkdir(parents=True, exist_ok=True)
+    _install(session, resolver, namespace, folder, monkeypatch)
+    cams = [namespace["U_Cam"], namespace["U_Cam2"]]
+    for cam in cams:
+        cam._trigger_timeout = 0.6
+    writes = _machine(session.RE, namespace, monkeypatch)
+    # Swallow the first fire: the trigger box pulses, no camera sees a frame.
+    dropped = {"done": False}
+    original = namespace["U_Cam"].__class__.trigger
+
+    from geecs_bluesky.shot_controller import ShotController
+
+    real_fire = ShotController.fire_shot
+
+    def fire_shot(self):
+        if not dropped["done"]:
+            dropped["done"] = True
+
+            def _swallow():
+                return iter(())
+
+            return _swallow()
+        return real_fire(self)
+
+    monkeypatch.setattr(ShotController, "fire_shot", fire_shot)
+    _ = original
+    docs = DocCollector()
+    session.RE(
+        bp.count(_save_set(namespace), num=1, md={"geecs": _request(shots_per_step=1)}),
+        docs,
+    )
+    # Without the refire the FailedStatus propagates into bp.count, which
+    # has no handler, and the run aborts.  It recovered, and recorded one
+    # row for one physical shot — strict semantics survive the retry.
+    assert docs.docs["stop"][0]["exit_status"] == "success"
+    assert len(docs.primary_events()) == 1
+    fires = [w for w in writes if w[1].endswith("ExecuteSingleShot") and w[2] == "on"]
+    assert 1 <= len(fires) <= 3, writes  # bounded: max_refires=2
+
+
+def test_telemetry_columns_reach_the_event(
+    session, resolver, namespace, tmp_path, monkeypatch
+) -> None:
+    """Background telemetry is primary-stream columns, one value per row.
+
+    The funnel gets that by appending the group to the plan's read set; a
+    stock plan reads only its own detectors, so the preprocessor injects
+    the reads into the same event.  Advertising the columns in the start
+    document while emitting none would be the worse bug.  The corpus has
+    no DB-backed scalar policy, so the group itself is stubbed — what is
+    under test is the injection, not the selection.
+    """
+    from ophyd_async.core import StandardReadable, soft_signal_r_and_setter
+
+    class _Telemetry(StandardReadable):
+        def __init__(self, name: str) -> None:
+            with self.add_children_as_readables():
+                self.pressure, _ = soft_signal_r_and_setter(float, 1.25)
+            super().__init__(name=name)
+
+    group = _Telemetry("tier2")
+
+    def fake_telemetry(session_, save_set, scalar_policy):
+        yield from ()
+        return [group], {"U_Tier2": ["Pressure"]}
+
+    monkeypatch.setattr(
+        "geecs_bluesky.plans.preamble._connect_telemetry_plan", fake_telemetry
+    )
+    folder = tmp_path / "Scan007"
+    folder.mkdir(parents=True, exist_ok=True)
+    _install(session, resolver, namespace, folder, monkeypatch)
+    _machine(session.RE, namespace, monkeypatch)
+    docs = DocCollector()
+    session.RE(
+        bp.count(_save_set(namespace), num=1, md={"geecs": _request(shots_per_step=1)}),
+        docs,
+    )
+    assert docs.docs["stop"][0]["exit_status"] == "success"
+    columns = set(docs.primary_events()[0]["data"])
+    assert "tier2-pressure" in columns, sorted(columns)
+
+
+def test_scalar_headers_carry_the_scan_axis(
+    session, resolver, namespace, tmp_path, monkeypatch
+) -> None:
+    """The swept motor's legacy header must reach the s-file exporter."""
+    folder = tmp_path / "Scan007"
+    folder.mkdir(parents=True, exist_ok=True)
+    _install(session, resolver, namespace, folder, monkeypatch)
+    _machine(session.RE, namespace, monkeypatch)
+    axis = namespace.variable("U_ESP_JetXYZ", "Position.Axis 3")
+    points = [0.0, 1.0]
+    docs = DocCollector()
+    session.RE(
+        bp.list_scan(
+            _save_set(namespace),
+            axis,
+            points,
+            md={
+                "geecs": _request(
+                    mode="step",
+                    shots_per_step=1,
+                    axes=[{"variable": "jet_z", "positions": {"values": points}}],
+                )
+            },
+        ),
+        docs,
+    )
+    headers = docs.start["geecs_scalar_headers"]
+    assert any("jetxyz" in key.lower() for key in headers), headers
+
+
+def test_a_position_the_request_never_declared_is_refused(
+    session, resolver, namespace, tmp_path, monkeypatch
+) -> None:
+    """Equal point counts must not hide a different set of points."""
+    folder = tmp_path / "Scan007"
+    folder.mkdir(parents=True, exist_ok=True)
+    _install(session, resolver, namespace, folder, monkeypatch)
+    _machine(session.RE, namespace, monkeypatch)
+    axis = namespace.variable("U_ESP_JetXYZ", "Position.Axis 3")
+    with pytest.raises(GeecsConfigurationError, match="not among the positions"):
+        session.RE(
+            bp.list_scan(
+                _save_set(namespace),
+                axis,
+                [0.0, 7.0],  # the request declares 0 and 1
+                md={
+                    "geecs": _request(
+                        mode="step",
+                        shots_per_step=1,
+                        axes=[
+                            {"variable": "jet_z", "positions": {"values": [0.0, 1.0]}}
+                        ],
+                    )
+                },
+            )
+        )
+
+
+def test_a_stock_scan_writes_a_scan_log(
+    session, resolver, namespace, tmp_path, monkeypatch
+) -> None:
+    """/triage reads scans/ScanNNN/scan.log; the stock door must write one."""
+    folder = tmp_path / "Scan007"
+    folder.mkdir(parents=True, exist_ok=True)
+    _install(session, resolver, namespace, folder, monkeypatch)
+    _machine(session.RE, namespace, monkeypatch)
+    session.RE(
+        bp.count(_save_set(namespace), num=1, md={"geecs": _request(shots_per_step=1)}),
+        DocCollector(),
+    )
+    logs = list(folder.glob("*.log"))
+    assert logs, sorted(p.name for p in folder.iterdir())
+
+
+def test_install_preserves_the_connect_on_demand_configuration(
+    session, namespace
+) -> None:
+    """A mock worker must not be sent at real Channel Access by a re-install."""
+    install_connect_on_demand(session.RE, mock=True, timeout=45.0)
+    install_geecs_preamble(session.RE, session=session, namespace=namespace)
+    connect = session.RE.preprocessors[-1]
+    assert getattr(connect, "func", None) is connect_on_demand
+    assert connect.keywords["mock"] is True
+    assert connect.keywords["timeout"] == 45.0
+
+
+def test_the_stock_door_and_the_funnel_record_the_same_scan(
+    session, resolver, namespace, tmp_path, monkeypatch
+) -> None:
+    """The acceptance contract: one request, two doors, one scan record.
+
+    Every GEECS-owned start-document key is compared exactly.  The keys a
+    stock plan owns (``plan_name``, ``detectors``, ``hints``, the plan's own
+    argument echo) legitimately differ — that difference is the point of
+    the migration — so they are excluded by name rather than by guesswork,
+    and the exclusion list is the thing to look at when a key goes missing.
+    """
+    from geecs_bluesky.plan_session import set_plan_session
+    from geecs_bluesky.plans.scan_request_plan import geecs_scan_request_plan
+
+    request = _request(shots_per_step=1)
+    plan_owned = {
+        "uid",
+        "time",
+        "scan_id",
+        "versions",
+        "plan_type",
+        "plan_name",
+        "plan_args",
+        "plan_pattern",
+        "plan_pattern_args",
+        "plan_pattern_module",
+        "detectors",
+        "motors",
+        "hints",
+        "num_points",
+        "num_intervals",
+    }
+
+    def _geecs_keys(start: dict, folder) -> dict:
+        return {
+            k: str(v).replace(str(folder), "<scan_folder>")
+            for k, v in start.items()
+            if k not in plan_owned
+        }
+
+    # ---- door 1: the funnel -------------------------------------------
+    funnel_folder = tmp_path / "funnel" / "Scan007"
+    funnel_folder.mkdir(parents=True, exist_ok=True)
+    _machine(session.RE, namespace, monkeypatch)
+    monkeypatch.setattr(
+        "geecs_bluesky.plans.scan_request_plan.claim_scan_number",
+        lambda experiment: (7, str(funnel_folder)),
+    )
+    set_plan_session(session)
+    funnel_docs = DocCollector()
+    try:
+        session.RE(geecs_scan_request_plan(request, resolver=resolver), funnel_docs)
+    finally:
+        set_plan_session(None)
+
+    # ---- door 2: a stock plan -----------------------------------------
+    stock_folder = tmp_path / "stock" / "Scan007"
+    stock_folder.mkdir(parents=True, exist_ok=True)
+    _install(session, resolver, namespace, stock_folder, monkeypatch)
+    stock_docs = DocCollector()
+    session.RE(bp.count(_save_set(namespace), num=1, md={"geecs": request}), stock_docs)
+
+    assert _geecs_keys(stock_docs.start, stock_folder) == _geecs_keys(
+        funnel_docs.start, funnel_folder
+    )
+    # …the same rows, with the same device columns.
+    assert len(stock_docs.primary_events()) == len(funnel_docs.primary_events())
+    stock_columns = set(stock_docs.primary_events()[0]["data"])
+    funnel_columns = set(funnel_docs.primary_events()[0]["data"])
+    # The one known, scheduled difference: the funnel appends a synthetic
+    # ScanContext device for the per-row step bookkeeping.  Stock plans get
+    # that from the per-step function (GEECS-Plugins#807 phase 3), which is
+    # also when ScanContext retires.  Asserted as an EXACT set so any other
+    # column that appears on one door and not the other fails here.
+    scan_context = {"bin_number", "scan_event_index", "shot_index_in_bin"}
+    assert funnel_columns - stock_columns == scan_context
+    assert stock_columns - funnel_columns == set()
+    ini_a = (funnel_folder / "ScanInfoScan007.ini").read_text()
+    ini_b = (stock_folder / "ScanInfoScan007.ini").read_text()
+    assert ini_a == ini_b
+
+
+# ------------------------------------------------- axis topologies refused
+def test_axis_topologies_the_namespace_cannot_build_are_refused(namespace) -> None:
+    """Silently degrading a confirming or motor axis would take every row
+    at the wrong position, with nothing in the data saying so."""
+    from geecs_bluesky.plans.preamble import _namespace_movable
+    from geecs_bluesky.scan_request_runner import (
+        PlainMovableTarget,
+        PseudoMovableTarget,
+    )
+
+    plain = PlainMovableTarget(
+        device="U_ESP_JetXYZ", variable="Position.Axis 3", kind="setpoint", confirm=None
+    )
+    assert _namespace_movable(namespace, plain) is namespace.variable(
+        "U_ESP_JetXYZ", "Position.Axis 3"
+    )
+
+    with pytest.raises(GeecsConfigurationError, match="pseudo/composite"):
+        _namespace_movable(
+            namespace,
+            PseudoMovableTarget(variable_name="combo", mode="absolute", components=()),
+        )
+    with pytest.raises(GeecsConfigurationError, match="confirms on"):
+        _namespace_movable(
+            namespace,
+            PlainMovableTarget(
+                device="U_ESP_JetXYZ",
+                variable="Position.Axis 3",
+                kind="setpoint",
+                confirm="U_Cam:MaxCounts",
+            ),
+        )
+    # kind: motor with no DB tolerance → a plain setpoint, which would
+    # complete before the readback converged.
+    with pytest.raises(GeecsConfigurationError, match="kind: motor"):
+        _namespace_movable(
+            namespace,
+            PlainMovableTarget(
+                device="U_ESP_JetXYZ",
+                variable="Position.Axis 3",
+                kind="motor",
+                confirm=None,
+            ),
+        )

--- a/GeecsBluesky/tests/test_qserver_startup.py
+++ b/GeecsBluesky/tests/test_qserver_startup.py
@@ -236,7 +236,7 @@ def test_startup_exports_the_device_namespace_and_installs_connect_last(
     """Devices from the roster land in the namespace/__all__; connect_on_demand is outermost."""
     pytest.importorskip("aioca")  # the roster builds CA devices
     from geecs_bluesky.namespace import DeviceRoster, GeecsNamespace
-    from geecs_bluesky.preprocessors import connect_on_demand
+    from geecs_bluesky.preprocessors import connect_on_demand, geecs_preamble
 
     monkeypatch.setenv("QS_EXPERIMENT", "TestExp")
     monkeypatch.setenv("QS_DEVICE_NAMESPACE", "db")
@@ -268,3 +268,8 @@ def test_startup_exports_the_device_namespace_and_installs_connect_last(
     assert ns["U_S1H"].current.name == "u_s1h-current"
     funcs = [getattr(p, "func", p) for p in ns["RE"].preprocessors]
     assert funcs[-1] is connect_on_demand and funcs.count(connect_on_demand) == 1
+    # The stock-plan preamble is installed, and INSIDE connect_on_demand so
+    # its own connects and reads still pass through it (#807 phase 2).
+    assert funcs == [geecs_preamble, connect_on_demand]
+    preamble = ns["RE"].preprocessors[0]
+    assert preamble.keywords["namespace"] is not None

--- a/GeecsBluesky/tests/test_scan_request_plan.py
+++ b/GeecsBluesky/tests/test_scan_request_plan.py
@@ -92,7 +92,7 @@ def no_db(monkeypatch):
         "geecs_bluesky.scan_request_runner.make_scalar_policy", lambda session: None
     )
     monkeypatch.setattr(
-        "geecs_bluesky.plans.scan_request_plan.make_scalar_policy",
+        "geecs_bluesky.plans.preamble.make_scalar_policy",
         lambda session: None,
     )
     monkeypatch.setattr(
@@ -1111,9 +1111,7 @@ def test_trigger_profile_builds_the_controller_worker_side(
         def quiesce(self):
             yield from ()
 
-    monkeypatch.setattr(
-        "geecs_bluesky.plans.scan_request_plan.ShotController", _StubController
-    )
+    monkeypatch.setattr("geecs_bluesky.plans.preamble.ShotController", _StubController)
     folder = tmp_path / "Scan007"
     monkeypatch.setattr(
         "geecs_bluesky.plans.scan_request_plan.claim_scan_number",
@@ -1241,7 +1239,7 @@ def test_telemetry_documents_match_on_both_doors(
 
     for target in (
         "geecs_bluesky.scan_request_runner.make_scalar_policy",
-        "geecs_bluesky.plans.scan_request_plan.make_scalar_policy",
+        "geecs_bluesky.plans.preamble.make_scalar_policy",
     ):
         monkeypatch.setattr(target, lambda session: _FakeScalarPolicy())
 
@@ -1581,7 +1579,7 @@ class _TablePolicy:
 def _install_policy(monkeypatch, policy) -> None:
     for target in (
         "geecs_bluesky.scan_request_runner.make_scalar_policy",
-        "geecs_bluesky.plans.scan_request_plan.make_scalar_policy",
+        "geecs_bluesky.plans.preamble.make_scalar_policy",
     ):
         monkeypatch.setattr(target, lambda session: policy)
 

--- a/Planning/native_bluesky/00_overview.md
+++ b/Planning/native_bluesky/00_overview.md
@@ -18,7 +18,7 @@ later. (Sam, 2026-09-08.)
 | shots per step, fire-between-arm-and-wait, per-step actions, failed-move pause | `per_step` / `per_shot` callable pre-bound into the registered plan | `plans/per_step.py` (phase 3) |
 | validate → resolve → claim → ScanInfo → save paths → trigger profile → setup actions; save-off → disarm → closeout | one `RunEngine` preprocessor keyed on `md["geecs"]` | `preprocessors.py` (phase 2) |
 | trigger box to STANDBY on pause, re-arm on resume | `Pausable` on `ShotController` (the RE calls `pause()`/`resume()` on every object it has seen) | `shot_controller.py` (phase 4) |
-| background telemetry | `bluesky.preprocessors.SupplementalData` | startup (phase 2) |
+| background telemetry | stays in the read set (columns in `primary`) — **not** `SupplementalData`, which would move it to a separate `baseline` stream and change the event schema (correction, `02_preamble_preprocessor.md`) | per-step (phase 3) |
 | which devices exist, lazy connection | device namespace built at `environment open`; connect on first message | `namespace.py`, `devices/geecs_device.py`, `preprocessors.connect_on_demand` (phase 1) |
 
 Everything else is a stock plan (`bluesky.plans`) registered through a
@@ -28,7 +28,7 @@ template that expands into a stock plan call (`qs_client.submit_scan`).
 ## Phases
 
 1. `01_device_namespace.md` — devices as long-lived nouns, lazily connected.
-2. preprocessor preamble/finalize + SupplementalData.
+2. `02_preamble_preprocessor.md` — preamble/finalize as one RunEngine preprocessor keyed on `md["geecs"]`. (SupplementalData dropped: see the correction there.)
 3. per-step + registration table (`count`, `list_grid_scan` first), hardware.
 4. native pause; retire `pause_semantics.py`.
 5. `submit_scan` expansion; retire the funnel and the named plans; OSPREY follows.

--- a/Planning/native_bluesky/00_overview.md
+++ b/Planning/native_bluesky/00_overview.md
@@ -19,7 +19,7 @@ later. (Sam, 2026-09-08.)
 | validate → resolve → claim → ScanInfo → save paths → trigger profile → setup actions; save-off → disarm → closeout | one `RunEngine` preprocessor keyed on `md["geecs"]` | `preprocessors.py` (phase 2) |
 | trigger box to STANDBY on pause, re-arm on resume | `Pausable` on `ShotController` (the RE calls `pause()`/`resume()` on every object it has seen) | `shot_controller.py` (phase 4) |
 | background telemetry | stays in the read set (columns in `primary`) — **not** `SupplementalData`, which would move it to a separate `baseline` stream and change the event schema (correction, `02_preamble_preprocessor.md`) | per-step (phase 3) |
-| which devices exist, lazy connection | device namespace built at `environment open`; connect on first message | `namespace.py`, `devices/geecs_device.py`, `preprocessors.connect_on_demand` (phase 1) |
+| which devices exist, lazy connection | device namespace built at `environment open`; connect on first message | `namespace.py`, `devices/ca/`, `preprocessors.connect_on_demand` (phase 1) |
 
 Everything else is a stock plan (`bluesky.plans`) registered through a
 one-line table, and the `ScanRequest` document is the *client-side*
@@ -28,7 +28,7 @@ template that expands into a stock plan call (`qs_client.submit_scan`).
 ## Phases
 
 1. `01_device_namespace.md` — devices as long-lived nouns, lazily connected.
-2. `02_preamble_preprocessor.md` — preamble/finalize as one RunEngine preprocessor keyed on `md["geecs"]`. (SupplementalData dropped: see the correction there.)
+2. `02_preamble_preprocessor.md` — preamble/finalize as one RunEngine preprocessor keyed on `md["geecs"]`. **Done** (PR #809, hardware-accepted). SupplementalData dropped; telemetry is injected as reads into the plan's own event.
 3. per-step + registration table (`count`, `list_grid_scan` first), hardware.
 4. native pause; retire `pause_semantics.py`.
 5. `submit_scan` expansion; retire the funnel and the named plans; OSPREY follows.

--- a/Planning/native_bluesky/02_preamble_preprocessor.md
+++ b/Planning/native_bluesky/02_preamble_preprocessor.md
@@ -1,7 +1,9 @@
 # Phase 2 — the preamble and finalize as one RunEngine preprocessor
 
-Status: **designed, not yet built.** Branch `phase/02-preamble-preprocessor`
-off `feature/native-bluesky-plans` (phase 1 merged, #808). Issue #807.
+Status: **built and hardware-accepted** (PR #809, adversarially reviewed).
+Branch `phase/02-preamble-preprocessor` off `feature/native-bluesky-plans`
+(phase 1 merged, #808). Issue #807. What actually shipped, and the two
+places it differs from this design, are in the section at the end.
 
 ## Goal
 
@@ -178,3 +180,44 @@ moved once.
   leave `geecs_optimize` as the one plan that keeps an in-plan preamble
   until the optimization work lands. Recommendation: leave it; it is not a
   stock plan and phase 3's registration table does not cover it.
+
+## What shipped (and where it differs from the design above)
+
+Steps A, B and C all landed: the preamble is extracted (`plans/preamble.py`),
+the preprocessor calls it, and `qserver/startup/startup.py` installs it with
+`connect_on_demand` re-appended outermost. The parity test specified above
+exists — it compares every GEECS-owned start-document key exactly and the
+event columns as an exact set — and it earned its place immediately by
+finding four divergences during review (a missing `acq_timestamp` s-file
+header, phantom headers for unread settable children, a stray raw `geecs`
+key in the start document, and six missing execution keys that
+`tiled_catalog`/`tiled_schema` read).
+
+Three differences from the plan above, all forced by the same fact — the
+funnel guaranteed things **by construction** that this door can only enforce
+or refuse:
+
+1. **The read set is no longer the save set.** The funnel built one device
+   list and handed it to the plan; here the caller passes the detectors and
+   the save set selects namespace devices. A plan that does not read every
+   saved device is **refused** before the claim, because native saving on an
+   unread device writes frames with no `acq_timestamp` row to join them to.
+2. **Scan-axis topologies are refused, not degraded.** `build_movable`
+   dispatches a catalog target onto pseudo, confirm-elsewhere and
+   tolerance-checked-motor; the namespace builds children from the DB alone
+   and knows none of that until phase 3. A target needing one of those
+   raises rather than quietly becoming a fire-and-forget setpoint.
+3. **Devices must be reset between runs.** Long-lived nouns keep whatever a
+   run configured. `GeecsNamespace.reset_run_configuration()` runs before
+   and after each preamble; the mixins chain through
+   `devices/reset_support.py`.
+
+On correction 1 (telemetry): confirmed, and implemented as **inserted reads
+between the plan's last `read` and its `save`** — same row, same `primary`
+stream, no schema change — rather than `SupplementalData`.
+
+**Known gap, owned by phase 3:** stock plans emit no `ScanContext` columns
+(`bin_number`, `scan_event_index`, `shot_index_in_bin`). Those arrive with
+the per-step function, which is also when `ScanContext` retires. The parity
+test asserts them as the *only* column difference, so the gap cannot widen
+unnoticed.

--- a/Planning/native_bluesky/02_preamble_preprocessor.md
+++ b/Planning/native_bluesky/02_preamble_preprocessor.md
@@ -1,0 +1,180 @@
+# Phase 2 — the preamble and finalize as one RunEngine preprocessor
+
+Status: **designed, not yet built.** Branch `phase/02-preamble-preprocessor`
+off `feature/native-bluesky-plans` (phase 1 merged, #808). Issue #807.
+
+## Goal
+
+Everything the funnel plan does around the acquisition — validate, resolve,
+connect, claim the scan number, write ScanInfo, wire saving, build the shot
+controller, run setup actions; then save-off, disarm, closeout, disconnect —
+moves into **one preprocessor installed on the RunEngine**, keyed on run
+metadata. A stock `bluesky.plans` verb then gets the identical preamble with
+no GEECS code in the plan:
+
+```python
+RE(bp.list_grid_scan([cam], U_S1H.current, pts, md={"geecs": request}))
+```
+
+## The seam: `open_run`, verified
+
+`bps.open_run` yields `Msg("open_run", **md)`, so a plan's `md={"geecs": …}`
+arrives as `msg.kwargs["geecs"]`, and the RunEngine reads `msg.kwargs` only
+when it processes the message. A `plan_mutator` on `open_run` can therefore
+**run the whole preamble first and then forward a mutated `open_run`** —
+which is what makes the claim-before-the-run-opens invariant survive the
+move. Probed on bluesky 1.15.0:
+
+```
+order: ['preamble ran (connects, claim)', 'open_run forwarded']
+scan_number: 42 | scan_folder: /x/Scan042 | geecs block preserved | plan_name: count
+```
+
+Two mechanics the probe settled:
+
+- **Re-entrancy.** `plan_mutator` re-processes the message the inserted plan
+  yields, so re-wrapping `open_run` recurses (`ChainMap` of `ChainMap`…,
+  `RecursionError`). The forwarded message's `id()` goes in a `forwarded`
+  set before it is yielded — the same shape as phase 1's `seen` guard in
+  `connect_on_demand`.
+- **Metadata injection** is `inject_md_wrapper`'s technique:
+  `msg._replace(kwargs=ChainMap(claimed, msg.kwargs))`.
+
+### Footgun, pinned by a test
+
+`RE(plan, geecs={...})` — per-call metadata — is **invisible to
+preprocessors**: the RunEngine merges `_metadata_per_call` at `_open_run`,
+it never enters a message. The request must ride in the **plan's `md=`
+kwarg**. Per-call metadata would put a `geecs` block in the start document
+while the preamble silently never ran, so a test pins that difference and
+the docstring says it.
+
+## Two corrections to the plan of record
+
+1. **`SupplementalData` cannot carry GEECS telemetry — dropping it from
+   phase 2.** `00_overview.md` listed "background telemetry →
+   `SupplementalData`". That is wrong: today the telemetry group is appended
+   to the detector list (`all_detectors = detectors + telemetry_readables`),
+   so its variables are **extra columns in the `primary` stream, one value
+   per row**. `SupplementalData`'s `baseline` reads once after `open_run`
+   and once before `close_run` into a **separate `baseline` stream**, and
+   `monitors` emit asynchronous per-signal streams. Using it would change
+   the event schema, break the document-parity tests, and change what
+   `background_telemetry` means. Telemetry therefore stays in the read set;
+   which devices are read is a per-step/registration concern (phase 3).
+   Recorded here rather than quietly; cheap to veto if the stream change is
+   actually wanted.
+2. **The request travels in the plan's `md=`**, not as RunEngine per-call
+   metadata (above).
+
+## Design — one preamble implementation, two callers
+
+The preamble is **extracted, not copied**. Sequencing keeps every commit
+green and never leaves two implementations alive:
+
+| step | change | what proves it |
+|---|---|---|
+| A | Extract the funnel's preamble/finalize body into plan-stub functions in a new `plans/preamble.py` (pure move). `geecs_scan_request_plan` calls them. | the existing suite, unchanged — document parity, pre-claim invariants, run-wrapper pins |
+| B | Add `preprocessors.geecs_preamble`, keyed on `md["geecs"]`, calling **the same functions**. | a new parity test: a stock `bp.count` / `bp.list_grid_scan` with `md={"geecs": request}` produces the same start/descriptor/event/stop documents as the funnel for the equivalent request |
+| C | Startup installs it, then re-installs `connect_on_demand` last (it must stay outermost). | `test_qserver_startup.py` |
+
+The funnel keeps calling the extracted functions until **phase 5** retires
+it; there is never a second copy of the preamble.
+
+### What moves, what waits
+
+From the audited walkthrough (`scan_request_plan.py:439`–`:782`):
+
+| step | destination |
+|---|---|
+| validate + resolve, trigger profile → `ShotController`, save sets/rituals, scalar policy, `devices_config` | **preprocessor** (pre-claim, fail-fast) |
+| unserved / CONNECTED preflights, action-slot assembly, axis resolution, capture toggle + daemon heartbeat | **preprocessor** (pre-claim) |
+| device construction + `_connect_in_batches`, telemetry connect, `controller.connect_setters` | **preprocessor**, but for a stock plan the devices are **namespace nouns already connected by `connect_on_demand`** — the preamble connects only what it creates itself (action signals, the controller's setters, telemetry) |
+| `claim_scan_number` → `scan_number`, `scan_folder` | **preprocessor**, immediately before forwarding `open_run` |
+| `_write_scan_info`, `_configure_saving`/`_configure_assets`, capture-dir mkdir | **preprocessor** (post-claim, pre-start-doc — `run_wrapper` does the mkdir from `md["capture_devices"]` today and that side effect must keep its position) |
+| the `md` block (`build_step_scan_spec` + `geecs_run_wrapper`'s additions) | **preprocessor**, injected into `open_run` |
+| `scan_log` attach | **preprocessor**, around the forwarded run |
+| save-on windowing, per-step actions, shots per step | **phase 3** (per-step function) — the preamble only makes them available |
+| pause quiescer → `Pausable` on the controller | **phase 4** |
+| free-run t0 sync / reference pacing | **phase 6** |
+| client-side pre-submit preflight | stays client-side |
+
+### The finalize chain keeps its nesting
+
+Innermost-first, unchanged in order (`orchestration.py:197`,
+`run_wrapper.py:255`): save-off (innermost, so saving stops while the
+trigger is still stopped) → `controller.disarm()` → closeout actions →
+`_restore_movables` → stage/unstage → `_disconnect_plan` (outermost). In the
+preprocessor these wrap the forwarded run instead of the inner plan; the
+audit confirms every one is already a plan stub, so they compose unchanged.
+
+### Metadata is a contract, not a convenience
+
+The preprocessor must inject every key downstream requires, because the
+audit found six consumers that read them: the s-file callback (`scan_number`,
+stop `exit_status`), the Tiled→s-file export (`geecs_scalar_headers`,
+`scan_number`, `scan_folder`), `tiled_schema` (`reference_device`, `motor`,
+`plan_name`, `grid_shape`, `scan_axes`, `num_points`, `shots_per_step`),
+`tiled_catalog` (+`save_sets`, `experiment`, `acquisition_mode`,
+`num_grid_points`, `description`), the capture daemon (`capture_devices`,
+`nonscalar_save_paths`), and asset readback (`scan_number`, `experiment`,
+`scan_folder`). A parity test compares the **whole start document minus
+`uid`/`time`** between the funnel and a stock plan — the existing
+`_start_essence` helper already does exactly this for the two funnel doors,
+so it is reused rather than reinvented.
+
+Keys a stock plan cannot supply from the request alone (`motor`,
+`positions`, `num_points`, `shots_per_step`, `plan_pattern`) come from the
+stock plan's own metadata, which is **better** than the funnel's hand-built
+versions — that is the point of the migration. The parity test therefore
+compares the GEECS-owned subset exactly and asserts the stock-owned keys are
+present and consistent, rather than byte-identical.
+
+## Tests that must be re-expressed (not deleted)
+
+Two existing tests pin the preamble's **position** rather than its effect
+and will move with it:
+
+- `test_creating_the_generator_does_no_work` — no resolution at generator
+  creation. Still true; the preprocessor does nothing until `open_run`.
+- `test_devices_and_claim_happen_inside_the_running_plan` — asserts
+  `RE.state == "running"` at the detector factory and at the claim. Still
+  true, and now also true for a stock plan; the assertion moves to the
+  preprocessor's call sites.
+
+Also: two tests monkeypatch `claim_scan_number` **by module path**
+(`geecs_bluesky.plans.scan_request_plan.claim_scan_number`); the extraction
+changes that path, so the patch targets move to `plans/preamble.py`.
+
+Full list to keep green (from the audit): `test_scan_request_plan.py`
+(parity `:1148/:1175/:1210`, pre-claim `:292/:335/:350/:373/:561/:1439`,
+named-plan parity `:1933/:1963`, submission, telemetry, optimize, pause),
+`test_run_wrapper.py`, `test_pause_checkpoints.py`, `test_operator_abort.py`,
+`test_read_path_staging.py`, `test_grid_plans_message_level.py`,
+`test_native_image_save.py`, `test_sfile_callback.py`,
+`test_scan_request_runner.py`, `test_qserver_startup.py`,
+`test_connect_on_demand.py`.
+
+## Reuse ledger (draft — final version in the PR body)
+
+| new symbol | reuses | replaces | new because |
+|---|---|---|---|
+| `plans/preamble.py` (extracted stubs) | the funnel's own body, moved verbatim | the same code in `scan_request_plan.py` | one implementation, two callers |
+| `preprocessors.geecs_preamble` | the extracted stubs, `plan_mutator`, `ChainMap` md injection (`inject_md_wrapper`'s technique) | (phase 5) the funnel's role as the only preamble door | stock plans have no GEECS preamble |
+| `install_geecs_preamble` | phase 1's `install_connect_on_demand` shape | — | ordering rule: preamble inside, connect-on-demand outermost |
+
+Nothing here re-solves validation, resolution, claiming, ScanInfo, saving,
+actions or the shot controller: all of it is the funnel's existing code,
+moved once.
+
+## Open for Sam
+
+- **Telemetry** (correction 1): keep it as `primary`-stream columns, no
+  schema change — or accept `SupplementalData`'s separate `baseline` stream?
+  Recommendation: keep, and revisit only if the baseline stream is wanted
+  for its own sake.
+- **Optimize mode** builds its own `md` and its own finalize chain inline
+  (`scan_request_plan.py:945`–`:1181`). Phase 2 can either bring it along or
+  leave `geecs_optimize` as the one plan that keeps an in-plan preamble
+  until the optimization work lands. Recommendation: leave it; it is not a
+  stock plan and phase 3's registration table does not cover it.


### PR DESCRIPTION
Phase **B1** of #807. Base: `feature/native-bluesky-plans` (phase 1 / #808 merged).
GeecsBluesky **0.79.0**. Adversarially reviewed; every finding fixed, none
waived — the review and the dispositions are in the comments.

## What

A stock `bluesky.plans` verb now runs a full GEECS scan in **strict** shot control:

```python
RE(bp.count([cam], num=5, md={"geecs": request}))
```

That claims a scan number, writes `ScanInfo`, configures native saving, runs setup actions, arms, **fires every shot itself**, records, and on the way out stops saving, disarms, runs closeout and disconnects — with no GEECS code in the plan.

It is the funnel's own code with two callers, never a copy:

- `plans/preamble.py` — `resolve_request` + `prepare_step_scan`, extracted verbatim from `geecs_scan_request_plan` (which keeps working unchanged and loses ~300 lines).
- `GeecsSession.configure_claimed_scan` — the post-claim tail (ScanInfo → role wiring → saving), split out of `build_claimed_scan_plan` because the preprocessor must not build an inner plan: the stock plan **is** the inner plan.
- `plans/run_wrapper.claimed_scan_metadata` — the run-metadata assembly (and the capture-dir creation it implies), split out of `geecs_run_wrapper` so both doors cannot drift from what the downstream readers require.

## The three mechanics worth reviewing

**The `open_run` seam.** `bps.open_run` puts `md` into `msg.kwargs`, and the RunEngine reads it only when it processes the message — so a `plan_mutator` can run the entire preamble and *then* forward a metadata-injected `open_run`. That is what preserves "the claim happens before the run opens", and it is why the claimed `scan_number`/`scan_folder` reach the start document. Re-wrapping needs a `forwarded`-id guard (otherwise the `ChainMap` recurses); injection is `inject_md_wrapper`'s technique.

**The fire.** `trigger_and_read` issues `trigger` for every detector under one group and then waits on that group; strict needs the shot to land in exactly that gap (the detectors have baselined `acq_timestamp` and are waiting). That is the gap `bps.trigger_and_read` cannot express and the reason `plans/single_shot.py` exists. The preprocessor inserts the fire there, so **a stock plan needs no `per_shot` hook**.

**The device source.** A stock plan is handed namespace nouns; the preamble used to build its own devices from the save set. Two objects for one device would double the connections and configure saving on something the plan never reads, so `prepare_step_scan` grows a `namespace=` seam and the save set **selects** rather than constructs (`namespace_detectors`). Roles are asserted against the namespace's triggerable classification, and a save set recording scalars the device does not read is refused rather than silently logging different columns.

## What the review changed

The reviewer named the pattern better than the original design note did:
**the funnel guaranteed by construction what this door can only enforce or
refuse.** One list of devices was both the read set and the save set; each
axis was built from its catalog entry's own topology; the devices were
discarded at the end of the scan. None of that survives a door where the
caller brings the plan and the devices are long-lived nouns.

So three things are now shared rather than re-derived — the fire with its
bounded refire and device-down gating (`single_shot.fire_and_await_shot`),
the eager save-off for capture-owned cameras
(`run_wrapper.save_control_only_off_plan`), and the GEECS execution keys the
Tiled catalog and schema read (`step_scan.geecs_execution_md`) — and three
things are refused before anything is claimed:

- a plan that does not read every device the save set records (saving files
  with no `acq_timestamp` row to join them to is the orphan-frame failure
  from the other side);
- a plan whose shape contradicts the request it is recorded as, values as
  well as counts;
- a scan axis needing a topology the namespace cannot build yet — pseudo,
  `confirm:`, or `kind: motor` with no positive DB tolerance. Degrading one
  of those to a fire-and-forget setpoint would take every row before the
  readback converged, with nothing in the data saying so.

Long-lived devices are also reset between runs now
(`devices/reset_support.py` chains the mixins), because a namespace noun
keeps whatever a run configured — stale saving state made an unrelated later
plan emit asset documents pointing into the previous scan's folder.

**The parity test the design note specified is in the suite**, and it earned
its place immediately: one request through both doors, every GEECS-owned
start-document key compared exactly, identical `ScanInfo`, event columns as
an exact set. It found a missing `acq_timestamp` s-file header, phantom
headers for children the device never reads, a raw request blob riding into
every start document, and six execution keys only the funnel emitted.

## Fixed here

The first cut armed the controller and *then* enabled saving. Arming drives to SCAN (external rising edges), so saving switched on while edges were already passing and every shot before the first recorded one wrote an **orphan frame**. Correct order is `arm_single_shot` (ARMED halts the free run, quiescence confirmed) → save-on; save-off stays the innermost finalize so it runs before disarm releases edges. A test asserts the ordered shot-control writes rather than inferring the bracket.

## Scope

`geecs_preamble` is **strict-only**: free-run is refused before anything is claimed (it is retired — see the plan restructuring on #807), as is strict without a trigger profile. `NonScalarSaveSupport.configure_saving_mode` makes the native-save mode per-run, which a long-lived namespace device needs and the per-scan classes got from their constructor.

## Reuse ledger

| new symbol | reuses | replaces | new because |
|---|---|---|---|
| `plans/preamble.py` | the funnel's body, moved verbatim | the same code in `scan_request_plan.py` (deleted there) | one implementation, two callers |
| `preprocessors.geecs_preamble` | those functions, `plan_mutator`, the `ChainMap` md technique | (phase C) the funnel's role as the only preamble door | stock plans had no GEECS preamble |
| `install_geecs_preamble` | phase 1's `install_connect_on_demand` shape | — | ordering: preamble inside, connect-on-demand outermost |
| `preamble.namespace_detectors` | `CaGenericDetector`/`CaSnapshotReadable`, the namespace | (phase C) `_build_request_detectors` for the stock door | object identity with the plan's detectors |
| `session.configure_claimed_scan` | `_write_scan_info`, `_configure_saving` | the same block inline in `build_claimed_scan_plan` | the preprocessor needs the tail without an inner plan |
| `run_wrapper.claimed_scan_metadata` | the md block, moved | the same block inline in `geecs_run_wrapper` | both doors must build identical md |
| `NonScalarSaveSupport.configure_saving_mode` | the device's own served `save`/`localsavingpath` children | — | per-run mode on a long-lived device |
| `GeecsNamespace.variable_names` | `_attrs` | — | the device object does not carry it |

Nothing here re-solves validation, resolution, claiming, ScanInfo, saving, actions or shot control.

## Known gap, owned by phase 3

Stock plans emit no `ScanContext` per-row columns (`bin_number`,
`scan_event_index`, `shot_index_in_bin`). Those arrive with the per-step
function, which is also when `ScanContext` retires; inferring step
boundaries from `set` messages here would be exactly the custom-code-over-a-
native-seam move this effort exists to avoid. The parity test asserts them
as the **only** column difference, so the gap cannot widen unnoticed.

## Judgment calls (cheap to veto)

- Strict-only, now, rather than carrying free-run through a phase we intend to delete.
- The fire lives in the preprocessor rather than a `per_shot` the caller supplies, so stock plans stay stock. The alternative needs the caller to build the controller, duplicating the preamble.
- The funnel stays alive and green; it retires in phase C.

## Tests

- 8 new in `tests/test_preamble_preprocessor.py`: install order, no-op without the key, the full preamble on a stock `count` (claim, ScanInfo, metadata, saving, events, one fire per shot), the Gate-2 bracket ordering, free-run refused pre-claim, the pre-claim invariant, and both namespace-source refusals. The harness drives the **real** `ShotController` through its existing `setter_factory` seam, so the real profile is replayed and nothing in the engine is stubbed.
- 11 more from the review, one per finding, including the parity test above.
- Full suite **783 passed, 0 failed** in 5m17s.
- **CI green** on the head commit: `unit-tests` 3m33s and 3m41s,
  `console-windows`, `pre-commit`.

## Hardware verification

**Accepted 2026-09-09 on the Undulator machine**, `tests/test_preamble_hardware.py` (hardware-marked), subscribing what the worker startup subscribes so the runs are downstream-indistinguishable:

- **Scan 63** — stock `bp.count` as a noscan: 3 shots, each fired by the preprocessor.
- **Scan 64** — stock `bp.list_scan` as a step scan: the catalog axis `S1H` resolved to `U_S1H:Current` and to the same object the plan moved; swept −1 → +1 A in 0.5 A steps; readbacks −0.99984, −0.49966, 0.00008, 0.50008, 0.99989 A; setpoint restored.
- Both wrote `ScanInfoScanNNN.ini` **and** `ScanDataScanNNN.txt`, and **both appear in the Tiled catalog** (`list_runs("Undulator", 2026-09-09)`), i.e. they are visible in the data portal beside the operators' scans.
- Event columns carry the full detector surface — `shot_id`, `shot_offset`, `nonscalar_save_path`, the image asset — so the composed namespace device keeps every capability the per-scan classes had.

Scans 56–62 that day are earlier test artifacts from a run with Tiled disabled (folder + ScanInfo only, no catalog entry); disposable.
