### PR TITLE
Planning: clean-room rebuild direction for native Bluesky (#807)

### DIFF
--- a/Planning/native_bluesky/00_overview.md
+++ b/Planning/native_bluesky/00_overview.md
@@ -1,5 +1,10 @@
 # GeecsBluesky as a thin layer on stock Bluesky
 
+> **Superseded 2026-09-09.** The phase plan below was replaced by
+> `03_clean_room_rebuild.md` (the document of record; its §8 has the
+> phases, its §11–12 the hardware facts). Kept for the rule in the next
+> section and the history; do not plan against it.
+
 **Plan of record: GEECS-Plugins issue #807** (companion: #806, the image
 writer). This directory holds the per-phase design notes; the issue holds
 the decision log and the running status. Read the issue first.

--- a/Planning/native_bluesky/03_clean_room_rebuild.md
+++ b/Planning/native_bluesky/03_clean_room_rebuild.md
@@ -60,7 +60,7 @@ is right in five years, not the one that is reachable in small steps.
 
 | thing | state |
 |---|---|
-| `feature/native-bluesky-plans` | integration branch off master; **#808 merged** into it 2026-09-09 (device namespace, phase 1) |
+| `feature/native-bluesky-plans` | integration branch off master; **#808 merged** into it 2026-09-09 (device namespace, phase 1); **phase 0 hardware-accepted 2026-09-09** (`phase/00-one-camera-detector`, Scan 065 — `04_phase0_measurements.md` M2), PR pending |
 | #809 `phase/02-preamble-preprocessor` | **OPEN, on hold, will not merge** (13 commits, GeecsBluesky 0.79.0, CI green). The evidence behind §3; close with a pointer here once this amendment lands (§8) |
 | #806 image writing | **OPEN, not started.** Phase 1, in parallel with the plan layer (§8). File plugin in GeecsPvaGateway + stock `ADHDFDataLogic`; capture daemon retired |
 | #807 | the decision log; its six-then-three phase plan is superseded by §8 here. Comments there point here |
@@ -406,6 +406,18 @@ not the docs:
 - **Naming has moved**: the writer base is not `DetectorWriter` in this
   version, and the flyer's controller is `FlyerController`, not
   `TriggerLogic`. Older docs and blog posts will disagree.
+- **On hardware (M2, Scan 065):** the three-logic split fits a GEECS camera
+  with no areaDetector IOC — `GeecsDetector` = `GeecsTriggerLogic` +
+  `GeecsAcquireLogic` + `ScalarsDataLogic` + `LvNativeFileDataLogic` under
+  stock `bp.count` / `bp.list_scan` with the strict `take_reading`; the
+  only GEECS line in the scan path is the fire between trigger and wait.
+  Learned on the way: the shot wait lives in the acquire logic's
+  `wait_for_idle` (a per-event data provider has no count to wait on); the
+  baseline must be synchronous in `trigger()` (pinned by a mock race test);
+  `stage()` resets the prepare context, so it must be waited on
+  (`stage_all` does, a bare `bps.stage` does not). N shots per point is
+  `bp.count`'s `per_shot` inside the step — fly-per-step is not needed
+  for strict; fly stays for gated mode (phase 2).
 
 **ASSUMED, must be verified before designing on it** (narrowed from the
 first draft; each names the phase that retires it):
@@ -451,7 +463,7 @@ the least-verified component while the scan path waited.
 
 ### Phases (each a PR into `feature/native-bluesky-plans`)
 
-0. **One camera as `GeecsDetector`** with `LvNativeFileDataLogic` (PNG),
+0. **DONE 2026-09-09 (Scan 065, M2).** One camera as `GeecsDetector` with `LvNativeFileDataLogic` (PNG),
    `ShotControl` as a device, the strict `per_step`; stock `bp.list_scan`
    on `U_S1H` on hardware. Measures: OFF latency, whether the gateway
    posts timeout events, drain offsets across amp4in, `exposure_timeout`

--- a/Planning/native_bluesky/03_clean_room_rebuild.md
+++ b/Planning/native_bluesky/03_clean_room_rebuild.md
@@ -60,7 +60,7 @@ is right in five years, not the one that is reachable in small steps.
 
 | thing | state |
 |---|---|
-| `feature/native-bluesky-plans` | integration branch off master; **#808 merged** into it 2026-09-09 (device namespace, phase 1); **phase 0 hardware-accepted 2026-09-09** (`phase/00-one-camera-detector`, Scan 065 — `04_phase0_measurements.md` M2), PR pending |
+| `feature/native-bluesky-plans` | integration branch off master; **#808 merged** into it 2026-09-09 (device namespace, phase 1); **phase 0 hardware-accepted 2026-09-09** (`phase/00-one-camera-detector`, Scan 065 — `04_phase0_measurements.md` M2; re-accepted after review as M3), **PR #811** reviewed, dispositioned and CI-green — awaiting Sam's merge |
 | #809 `phase/02-preamble-preprocessor` | **OPEN, on hold, will not merge** (13 commits, GeecsBluesky 0.79.0, CI green). The evidence behind §3; close with a pointer here once this amendment lands (§8) |
 | #806 image writing | **OPEN, not started.** Phase 1, in parallel with the plan layer (§8). File plugin in GeecsPvaGateway + stock `ADHDFDataLogic`; capture daemon retired |
 | #807 | the decision log; its six-then-three phase plan is superseded by §8 here. Comments there point here |

--- a/Planning/native_bluesky/03_clean_room_rebuild.md
+++ b/Planning/native_bluesky/03_clean_room_rebuild.md
@@ -194,8 +194,10 @@ Every DB device is one long-lived noun (#808, kept). Two classes:
     signal from the calibration store (§4.F).
 - **`ShotControl`** — one device, three protocols: `Movable` over
   `TriggerState` (the profile-defined writes per state — the existing
-  abstraction, §11.1), `Pausable` (`pause → OFF`, `resume → ARMED` — Sam's
-  call, §10.3: a paused scan emits no edges and orphans no frames;
+  abstraction, §11.1), `Pausable` (state-dependent, §10.3: in strict mode
+  the RE pausing simply stops the plan firing and the box stays ARMED —
+  `pause()` does nothing; in gated mode edges flow on their own, so
+  `pause() → OFF` and `resume()` restores SCAN;
   the RE calls these on every Pausable it has seen in a message, §7), and a
   `FlyerController` for gated mode (`prepare → OFF`, `kickoff → SCAN`,
   `complete → N shots then OFF`). Replaces `shot_controller.py`'s plan-stub
@@ -528,9 +530,12 @@ Still open, for Sam:
    devices — it is a test preset.** Phase 0 therefore exercises the strict
    path only; the two-list model gets its first real test later, on a
    preset with a slow or optional camera.
-3. ~~What `pause` drives~~ **Answered 2026-09-09 (Sam): OFF**, not
-   STANDBY — a paused scan emits no edges and orphans no frames; `resume`
-   re-arms.
+3. ~~What `pause` drives~~ **Answered 2026-09-09 (Sam): depends on the
+   mode.** Strict: nothing — the plan stops firing, the box stays ARMED;
+   that is the native Bluesky pause and needs no device action. Gated
+   (fly): edges flow on their own, so `pause() → OFF` and `resume()`
+   restores SCAN. `ShotControl.pause()` is therefore state-dependent:
+   ARMED → no-op, SCAN → OFF.
 4. **Where the baseline/monitor split is recorded** — the experiment
    defaults in the configs repo is the proposal; the first list comes from
    measuring one Tiled run.

--- a/Planning/native_bluesky/03_clean_room_rebuild.md
+++ b/Planning/native_bluesky/03_clean_room_rebuild.md
@@ -415,11 +415,18 @@ first draft; each names the phase that retires it):
   latest-wins slot — the substance of #806 (phase 1)
 - that Tiled 0.2.9 reads the plugin's NDFileHDF5-layout files through its
   stock HDF5 adapter with no adapter of ours (phase 1)
-- that OFF on the DG645 stops edges reaching the cameras within a known
-  latency, and that the CA gateway posts the device **timeout events**
-  (unchanged stamp) a liveness check would rely on (phase 0)
+- ~~OFF latency / timeout-event posting~~ **Measured 2026-09-09
+  (`04_phase0_measurements.md` M1):** OFF stops edges within one period
+  (put 155 ms, one in-flight edge, then silence); the gateway posts **no**
+  timeout events — its change suppression (`gateway.py`, "don't re-post an
+  unchanged value") drops them — so liveness is the `CONNECTED` PV, never
+  monitor silence. Also learned: a single shot fires on the **next external
+  edge** (stamps ~1 s after the put), so 1 Hz strict needs < ~550 ms of
+  software between stamp arrival and the next fire put completing.
 - that per-device drain latency is constant across exposure settings, as
-  §11.4 states (phase 0 measures it across the amp4in set)
+  §11.4 states. **First measurement** (M1): offsets span 0–220 ms across 42
+  live devices — wider than the ~100 ms estimate but inside period/2.
+  Constancy across shots and settings still to be shown (phase 0).
 
 ---
 
@@ -565,6 +572,10 @@ and every one of them changed a design choice.
    `acq_timestamp`. Nothing "stalls" on its own. **Consequence:** observing
    quiescence costs at least the longest device timeout in the set, so it
    belongs in a once-run calibration or a preflight, never in a scan.
+   **Measured (M1):** the timeout events never reach the CA gateway's
+   `acq_timestamp` PV — its change suppression drops unchanged values, so
+   monitors go silent in OFF — and they cannot serve as a miss signal
+   either; liveness is the `CONNECTED` PV.
 3. **`acq_timestamp` is a shot id in everything but name.** It advances
    only on a successful capture, deterministically, on domain time
    NTP-synced to ~5–10 ms. Cross-device values for one shot differ by a

--- a/Planning/native_bluesky/03_clean_room_rebuild.md
+++ b/Planning/native_bluesky/03_clean_room_rebuild.md
@@ -1,7 +1,8 @@
 # Clean-room rebuild: GeecsBluesky as a native Bluesky application
 
-**Status (2026-09-09): direction agreed with Sam — option 1½ in §8; phase 0
-is next.** Written at the end of the session that built #809 as a handoff,
+**Status (2026-09-10): direction agreed with Sam — option 1½ in §8; phase 0
+hardware-accepted (PR #811, awaiting merge); phase 1 decisions recorded in
+§10, #812 (test speed) first.** Written at the end of the session that built #809 as a handoff,
 then amended by the next session after the discussion recorded in §11 and
 §12. Read this before `00_overview.md`, because it supersedes that
 document's phase plan.
@@ -565,7 +566,33 @@ Still open, for Sam:
 4. **Where the baseline/monitor split is recorded** — the experiment
    defaults in the configs repo is the proposal; the first list comes from
    measuring one Tiled run.
-5. Two small carry-overs, unrelated to this direction: write
+5. **Phase-1 decisions (Sam, 2026-09-10):**
+   - **Deletion-led phase 1**, one PR series on the feature branch: delete
+     the funnel, free-run, named plans, `session.py`, the runner, the
+     funnel-only devices and their tests first; the plan layer lands in the
+     same series; the worker flips once at the end. The services stay on
+     `master` throughout, so the lab loses nothing until the flip.
+   - **Queue-item contract:** stock plan names registered once with the
+     strict `take_reading` pre-bound; `md["geecs"]` is provenance only.
+   - **Presets and save sets are disposable configs; the concepts stay** —
+     a preset because the same scan is run often, a save set as a grouping
+     of devices. **Per-scalar selection is deprecated**: it existed to
+     populate the s-file from the old console. **The s-file represents
+     every scalar in the run documents.**
+   - **Scan number claimed worker-side** (the `claim_scan` preprocessor).
+   - **Outputs kept as callbacks:** ScanInfo ini, the s-file from Tiled,
+     and **`scan.log`** (the trace of what went wrong in a scan).
+   - **Namespace rule:** `GeecsDetector` for every `looks_triggerable`
+     device; `native_save=True` iff the DB lists `save` and
+     `localsavingpath` for the device (so the gateway serves their `:SP`);
+     drain offsets from the calibration file, 0.0 until measured.
+   - **Telemetry in phase 1 = everything**: every subscribed scalar of the
+     experiment rides in the run, per event, monitor-backed; pare back
+     (baseline/monitors) later from evidence, not up front.
+   - Feature-branch → master: decide after phase 1 is complete and
+     exercised.
+   - **#812 (test speed) goes first.**
+6. Two small carry-overs, unrelated to this direction: write
    `Amplitude.Ch AB: 0.5` explicitly in every state of `HTU-NoGas` so "no
    gas" stops being order-dependent, and add a check that all profiles in
    an experiment manage the same variable set.

--- a/Planning/native_bluesky/03_clean_room_rebuild.md
+++ b/Planning/native_bluesky/03_clean_room_rebuild.md
@@ -17,6 +17,20 @@ And the constraint on that:
 > holding on to the requisite GEECS things, like DB as source of truth,
 > s-files etc.
 
+**The governing fact, and the reason this is worth doing now** (Sam,
+2026-09-09):
+
+> me and my team are the only users of all of this code. My goal is to make
+> it 'great' before trying to deploy at other facilities so that I don't
+> have to deal with these issues of backward compatibility. We are in a
+> unique 'clean slate' phase of development.
+
+There is no external user, no deprecation cycle and no migration burden.
+Backward compatibility is **not** a design input. Anything in this
+repository may be deleted outright rather than adapted, and the cost of a
+wrong turn is a rewrite, not a broken facility. Design for the shape that
+is right in five years, not the one that is reachable in small steps.
+
 ---
 
 ## 1. How to use this document
@@ -256,9 +270,10 @@ Three options, in the order I would recommend them:
 2. **Rebuild the plan layer first against today's devices**, accepting that
    the fly design waits. Faster feedback for Sam, at the cost of building
    the per-shot trigger machinery a second time and deleting it later.
-3. **Land #809 and continue incrementally.** Not recommended. It adds a
-   reconciliation engine to the feature branch that the target design
-   deletes.
+3. **Land #809 and continue incrementally.** Recommended against, and the
+   clean slate removes its only argument. Incrementalism buys backward
+   compatibility, which is worth nothing here, and it pays for it with a
+   reconciliation engine the target design deletes.
 
 **On #809 itself:** do not merge it. Leave it open as the evidence, or
 close it with a pointer to this document. Its two open P1 defects need no
@@ -267,9 +282,27 @@ salvaging by hand: the document-parity test, `GeecsNamespace.select`'s
 role assertions, `plan_session.py`, and the shared
 `fire_and_await_shot` if per-shot triggering survives at all.
 
-**What keeps working while this happens** must be answered explicitly
-before any deletion lands. Operators scan daily through the funnel and the
-Console. The rebuild has to run beside it, not replace it in place.
+**What keeps working while this happens.** Answered: Sam's team is the
+only user, so the answer is "whatever they choose to keep working that
+week." The rebuild does **not** need to run beside the funnel, and the
+old doors do not need a deprecation path. Keep the lab scannable between
+sessions and nothing more. In particular, do not spend design effort on
+dual-door parity — the parity test in #809 exists only because two doors
+had to coexist, and in the target there is one.
+
+**What the clean slate unlocks, and should be used for:**
+
+- delete free-run, the funnel, the named plans and the capture daemon
+  **eagerly**, as soon as each has a replacement, rather than in a phased
+  retirement
+- change the event schema, the s-file columns and the ScanRequest schema
+  freely where the native shape is better; there is no reader to break
+  that the team does not own
+- renumber, rename and restructure the package. A **total refactor of
+  GeecsBluesky**, or replacing it with a new package, is fully on the
+  table and is probably cheaper than incremental deletion
+- treat "we already built it" as carrying no weight. The only question is
+  whether a thing is right
 
 ---
 
@@ -283,6 +316,9 @@ Console. The rebuild has to run beside it, not replace it in place.
   change.
 - **New, and the reason for this document:** do not hold on to anything
   that does not slot in completely cleanly.
+- **Clean slate.** Sam's team is the only user. No backward compatibility,
+  no deprecation cycles, no migration paths. Deleting is cheaper than
+  adapting, and "we already built it" is not an argument.
 - Phase PRs land into `feature/native-bluesky-plans`. Each gets an
   adversarial review pass using the `/land` three-lens brief, with every
   finding dispositioned, before Sam reviews. Master merges are
@@ -299,13 +335,12 @@ Console. The rebuild has to run beside it, not replace it in place.
 
 ## 10. Open questions for Sam
 
-1. Sequencing: option 1, 2 or 3 in §8.
-2. Is a **total refactor of GeecsBluesky** on the table, or is the target
-   reached by deletion inside the existing package? The mapping is the same
-   either way; the difference is whether the package keeps its history.
-3. Does anything internal still depend on free-run, given it is already
-   slated for deletion? Same question for the named plans and the funnel,
-   whose retirement this accelerates.
+1. Sequencing: option 1, 2 or 3 in §8. This is the only substantial one.
+2. Refactor GeecsBluesky in place, or start a new package and let the old
+   one die? The mapping is identical either way; the difference is whether
+   the package keeps its history. The clean slate makes the second viable.
+3. How much lab downtime is acceptable between working states? That now
+   sets the pace, in place of any compatibility constraint.
 4. Two small carry-overs from the last session, unrelated to this
    direction: write `Amplitude.Ch AB: 0.5` explicitly in every state of
    `HTU-NoGas` so "no gas" stops being order-dependent, and add a check

--- a/Planning/native_bluesky/03_clean_room_rebuild.md
+++ b/Planning/native_bluesky/03_clean_room_rebuild.md
@@ -1,0 +1,312 @@
+# Clean-room rebuild: GeecsBluesky as a native Bluesky application
+
+**Status: proposed direction, not started.** Written 2026-09-09 at the end of
+the session that built #809, as a handoff to a fresh session. Read this
+before `00_overview.md`, because it supersedes that document's phase plan.
+
+Sam's framing, which is the point of the whole document:
+
+> Let's start with the assumption that we *only* have our CA gateway, PVA
+> gateway and bluesky/ophyd devices. How would we go from there? Blow up
+> everything except the bluesky/ophyd fundamentals and build a solid RE
+> that achieves what we want. […] Don't try to hold on to *anything* if it
+> doesn't slot in completely cleanly.
+
+And the constraint on that:
+
+> holding on to the requisite GEECS things, like DB as source of truth,
+> s-files etc.
+
+---
+
+## 1. How to use this document
+
+1. Read §3. It is the evidence, and it is the only part that is hard-won.
+   A fresh session given only the target architecture will re-litigate the
+   design; a fresh session given the failure catalogue will not.
+2. Treat §7 as a contract: anything marked **ASSUMED** must be verified
+   before it is designed on. The previous session asserted API details from
+   memory more than once and had to retract them publicly.
+3. §8 has the sequencing question. It is the one real decision, and it is
+   Sam's.
+
+---
+
+## 2. Where things actually stand (verified 2026-09-09)
+
+| thing | state |
+|---|---|
+| `feature/native-bluesky-plans` | integration branch off master; **#808 merged** into it 2026-09-09 (device namespace, phase 1) |
+| #809 `phase/02-preamble-preprocessor` | **OPEN, 13 commits, GeecsBluesky 0.79.0, CI green, not merged.** This is the code this document argues is scaffolding |
+| #806 image writing | **OPEN, not started.** File plugin in GeecsPvaGateway + stock ophyd-async detectors; capture daemon retired |
+| #807 | the plan of record; its six-then-three phase plan is what this document supersedes |
+| the worker (`geecs-gw`) | on **master**. Nothing from #809 is deployed, so none of its open defects is a live hazard |
+| hardware acceptance | scans **63 and 64** on 26_0909 via #809's preprocessor: stock `bp.count` as a noscan, stock `bp.list_scan` sweeping `U_S1H:Current` −1→+1 A at 0.5 A. Both in the Tiled catalog with s-files. Scans 56–62 are disposable artifacts of a `tiled=False` run |
+
+**What survives from the work so far, unconditionally:** the device
+namespace (#808). Every device of the experiment as a long-lived
+ophyd-async noun built from the DB roster, lazily connected. That is
+exactly the foundation the design below needs, and it is already merged.
+
+---
+
+## 3. What we learned, and why it changes the plan
+
+#809 put the GEECS scan preamble into a RunEngine preprocessor so that a
+stock `bluesky.plans` verb could run a full GEECS scan. It works, on
+hardware. It was then reviewed adversarially twice.
+
+**Sixteen findings in the first pass, five more in the verification pass.**
+Classified by cause, not by severity:
+
+### Artifacts of describing one scan twice (12 of 21)
+
+The plan says what to read and where to move. The ScanRequest says the same
+things through a save set and an axis list. The preprocessor's real job had
+become reconciling the two, and each of these findings is a missing
+reconciliation rule:
+
+- the plan need not read the devices the save set enables saving on, so
+  saved frames had no event row to join to
+- the request's shot count and the plan's point count could disagree, and
+  ScanInfo recorded the request's
+- the request's positions and the plan's positions could disagree
+- a first attempt to check that compared membership, not the sequence
+- background telemetry was prepared, connected and advertised in the start
+  document, but a stock plan reads only its own detectors, so no telemetry
+  column was ever emitted
+- once injected, the telemetry group was read **unstaged**, which
+  `GeecsBluesky/CLAUDE.md` already documents as the 0.7 s per row regression
+  that made 1 Hz scans run at 0.5 Hz
+- the scan motors were missing from the s-file header map
+- the namespace contributed headers for settable children no event carries
+- long-lived namespace devices kept the previous run's saving mode, save
+  path and asset definitions, so an unrelated later plan emitted asset
+  documents pointing into the previous scan's folder
+- and still did, on any pre-claim failure after the save set was applied
+- scan axes silently lost `confirm:` and `kind: motor` topology, because
+  the namespace builds children from the DB and the catalog describes them
+  separately
+- `kind: motor` disagreement between the two doors is still unresolved and
+  was waived
+
+### Real defects, independent of the architecture (9 of 21)
+
+Save-on ordering versus arming, the missing refire on the stock door, the
+refire then recursing through the mutator and firing extra shots, the
+stream-blind hooks, `install` re-deriving `connect_on_demand`'s kwargs, the
+missing `scan.log`, the missing eager save-off, the raw request riding into
+every start document, and a set of test-quality items.
+
+### The conclusion
+
+Twelve of twenty-one findings have one cause. Fixing them individually
+produces a reconciliation engine: a growing set of rules asserting that two
+descriptions of the same scan agree. The parity test added in #809 exists
+precisely to detect divergence between the two doors, which is a useful
+test and also an admission.
+
+The native answer is that there is only one description. Sam:
+
+> save sets are really just readbacks […] and the scan variables just the
+> settables with aliases. […] If you encounter a weird hack or workaround
+> to accommodate save sets we should think, "what is a save set doing and
+> how does Bluesky solve the same problem?"
+
+---
+
+## 4. The target architecture
+
+Assume only the two gateways and ophyd-async.
+
+**One namespace of devices, from the DB.** Anything that produces
+non-scalar data is a `StandardDetector` whose data logic writes through the
+PVA gateway file plugin (#806). Everything else is a `StandardReadable`
+over CA gateway PVs. Settables are children of their parent device. A
+device knows its own topology: a motor is a motor because the DB gives it a
+tolerance, not because a scan said so. **This layer is #808 and already
+exists**; what changes is that cameras become detectors.
+
+**The trigger box is a flyer.** At HTU the box is the master clock. The
+Bluesky expression for "hardware fires, detectors collect N frames" is
+`prepare(TriggerInfo(trigger=DetectorTrigger.EXTERNAL_EDGE, …))` then
+kickoff / complete / collect, with a `StandardFlyer` wrapping a
+`FlyerController`. Strict single-shot and free-run are then the same
+implementation with different counts: strict is one event per step,
+free-run is continuous. Today they are two subsystems, and free-run is
+already slated for deletion.
+
+**Everything persistent is a callback.** ScanInfo, the s-file, the Tiled
+catalog entry and the legacy column headers are all functions of the
+document stream. None belongs in a plan or a preprocessor. The s-file and
+catalog already work this way; ScanInfo does not.
+
+**The scan folder is a `PathProvider`.** ophyd-async ships
+`YMDPathProvider` and `AutoIncrementingPathProvider`, which between them
+are close to the `scans/YY_MMDD/ScanNNN/` convention. The day-scoped claim
+protocol is the part that stays ours.
+
+**Save sets and scan variables move to the client.** "Record amp4in" is a
+genuinely useful operator preset. It is a named list that a client expands
+into a plan's `detectors` argument before submission. It should never reach
+the worker as an instruction. This is what #807 phase C already said; #809
+did that job in the wrong place.
+
+---
+
+## 5. The mapping
+
+| GEECS today | Native replacement |
+|---|---|
+| save set, as a device list | the plan's `detectors` argument; a client-side preset |
+| save set `synchronous` flag | the `Triggerable` protocol |
+| `save_nonscalar_data`, `localsavingpath`, `save` | the detector's data logic, opened and closed per run |
+| save set explicit scalar list | the device's own readables |
+| save-set rituals, setup/closeout | plan stubs and `finalize_wrapper` (#647) |
+| `background_telemetry` | monitors, or simply more detectors in the list |
+| scan variable alias | the namespace attribute (`U_S1H.current`) |
+| `kind: motor`, `confirm:`, pseudo | the device class, chosen once at namespace build |
+| trigger profile states | a `FlyerController` |
+| strict single shot | fly, one event per step |
+| free run | fly, continuous |
+| Gate-2 save windowing | the detector's open/close window |
+| `acq_timestamp` as the shot join key | StreamDatum indices |
+| `shot_id`, `shot_offset`, `bin_number` | `seq_num` and per-stream indices |
+| scan number and folder | a `PathProvider` plus our claim protocol |
+| ScanInfo ini | a start-document callback |
+| s-file, Tiled catalog | callbacks (already true) |
+| capture daemon | deleted by #806 |
+| `ScanRequest` as a worker instruction | a client-side template that expands into a plan call |
+| the funnel, named plans, the #809 preprocessor | deleted |
+
+Almost every hard problem of the last two weeks is one row of this table.
+Orphan frames, save windowing, the refire, the shot join, bin numbers: all
+of them are the detector and flyer contract, hand-rolled because our
+cameras are not detectors yet.
+
+---
+
+## 6. What stays GEECS
+
+Five things have no native home, and none of them is in the scan path:
+
+1. **The DB as the source of truth** for the device roster, types,
+   tolerances and subscribed variables. The namespace builder owns this.
+2. **Day-scoped scan numbering** with a multi-writer claim protocol. A
+   custom `PathProvider`.
+3. **The s-file format** and its legacy `Device Variable` column headers.
+   A callback, plus header metadata on the devices.
+4. **ScanInfo ini.** A start-document callback.
+5. **PV naming and the served-set rules.** Already owned by the two
+   gateways and `geecs_core`.
+
+`ScanRequest` and its JSON Schema also survive, as the **client-side**
+record of intent the GUI needs. What dies is its role as a worker-side
+execution instruction.
+
+---
+
+## 7. Verified versus assumed
+
+**Verified 2026-09-09 against the installed environment** (ophyd-async
+**0.19.3**, bluesky **1.15.0**):
+
+- `StandardDetector`, `StandardFlyer`, `FlyerController`, `TriggerInfo`,
+  `DetectorTrigger`, `DetectorAcquireLogic`, `DetectorDataLogic`
+- `PathProvider`, `StaticPathProvider`, `AutoIncrementingPathProvider`,
+  `AutoMaxIncrementingPathProvider`, `YMDPathProvider`,
+  `AutoIncrementFilenameProvider`, `UUIDFilenameProvider`
+- `TriggerInfo` fields: `trigger`, `livetime`, `deadtime`,
+  `exposures_per_collection`, `collections_per_event`, `number_of_events`,
+  `exposure_timeout`
+- `DetectorTrigger`: `INTERNAL`, `EXTERNAL_EDGE`, `EXTERNAL_LEVEL`
+- `bps.prepare`, `kickoff`, `complete`, `collect`,
+  `collect_while_completing`, `declare_stream`
+- **Naming has moved**: the writer base is not `DetectorWriter` in this
+  version, and the flyer's controller is `FlyerController`, not
+  `TriggerLogic`. Older docs and blog posts will disagree.
+
+**ASSUMED, must be verified before designing on it:**
+
+- that the PVA gateway can be made to deliver **indexed, edge-triggered**
+  frames with a stable frame counter. The whole fly design rests on this
+  and it is the substance of #806
+- that `StandardDetector`'s acquire/data split can be satisfied by a GEECS
+  camera server without an areaDetector IOC
+- that a step scan with N shots per point composes cleanly as fly-per-step
+  in 0.19.3
+- that Tiled and the s-file exporter handle StreamResource/StreamDatum
+  from these detectors as well as they handle the current asset documents
+
+---
+
+## 8. Sequencing: the decision for Sam
+
+**#806 comes first.** Every row of the table that hurts most lives in the
+detector contract, and a rebuild that starts before cameras are detectors
+will re-derive the same workarounds we are trying to delete. This is a
+reversal of the current ordering, in which #806 sits behind the plan work.
+
+Three options, in the order I would recommend them:
+
+1. **#806, then rebuild.** Cameras become `StandardDetector`s, the capture
+   daemon dies, then the flyer and the plan layer follow. Slowest to first
+   visible change, cleanest result, and it is the only order in which the
+   twelve duplication findings actually disappear rather than move.
+2. **Rebuild the plan layer first against today's devices**, accepting that
+   the fly design waits. Faster feedback for Sam, at the cost of building
+   the per-shot trigger machinery a second time and deleting it later.
+3. **Land #809 and continue incrementally.** Not recommended. It adds a
+   reconciliation engine to the feature branch that the target design
+   deletes.
+
+**On #809 itself:** do not merge it. Leave it open as the evidence, or
+close it with a pointer to this document. Its two open P1 defects need no
+fix if it is not shipping, and nothing from it is deployed. Parts worth
+salvaging by hand: the document-parity test, `GeecsNamespace.select`'s
+role assertions, `plan_session.py`, and the shared
+`fire_and_await_shot` if per-shot triggering survives at all.
+
+**What keeps working while this happens** must be answered explicitly
+before any deletion lands. Operators scan daily through the funnel and the
+Console. The rebuild has to run beside it, not replace it in place.
+
+---
+
+## 9. Standing constraints (Sam, 2026-09-08/09)
+
+- Prefer a native Bluesky or ophyd-async mechanism wherever one plausibly
+  exists. Examine carefully before patching. Never close off adding a stock
+  plan or a Bluesky feature later.
+- Added lines must be justified. Never a second copy of a solved problem.
+  Where a better copy replaces an old one, the old one goes in the same
+  change.
+- **New, and the reason for this document:** do not hold on to anything
+  that does not slot in completely cleanly.
+- Phase PRs land into `feature/native-bluesky-plans`. Each gets an
+  adversarial review pass using the `/land` three-lens brief, with every
+  finding dispositioned, before Sam reviews. Master merges are
+  maintainer-only.
+- Hardware is available: trigger profile **HTU-NoGas**, scannable
+  `U_S1H:current` −1 → +1 A in 0.5 A steps, save set **amp4in**, restore
+  the setpoint. `ssh geecs-gw`; the worker checkout may be changed freely.
+- Run **one** test suite at a time on the Mac, unbuffered
+  (`python -u -m pytest -v`). A backgrounded pytest writing to a file looks
+  stalled for minutes because stdout is block-buffered; that cost an hour
+  in the last session and produced a retracted claim.
+
+---
+
+## 10. Open questions for Sam
+
+1. Sequencing: option 1, 2 or 3 in §8.
+2. Is a **total refactor of GeecsBluesky** on the table, or is the target
+   reached by deletion inside the existing package? The mapping is the same
+   either way; the difference is whether the package keeps its history.
+3. Does anything internal still depend on free-run, given it is already
+   slated for deletion? Same question for the named plans and the funnel,
+   whose retirement this accelerates.
+4. Two small carry-overs from the last session, unrelated to this
+   direction: write `Amplitude.Ch AB: 0.5` explicitly in every state of
+   `HTU-NoGas` so "no gas" stops being order-dependent, and add a check
+   that all profiles in an experiment manage the same variable set.

--- a/Planning/native_bluesky/03_clean_room_rebuild.md
+++ b/Planning/native_bluesky/03_clean_room_rebuild.md
@@ -1,8 +1,16 @@
 # Clean-room rebuild: GeecsBluesky as a native Bluesky application
 
-**Status: proposed direction, not started.** Written 2026-09-09 at the end of
-the session that built #809, as a handoff to a fresh session. Read this
-before `00_overview.md`, because it supersedes that document's phase plan.
+**Status (2026-09-09): direction agreed with Sam — option 1½ in §8; phase 0
+is next.** Written at the end of the session that built #809 as a handoff,
+then amended by the next session after the discussion recorded in §11 and
+§12. Read this before `00_overview.md`, because it supersedes that
+document's phase plan.
+
+**Staleness rule.** This is the document of record for the rebuild. Any PR
+that changes direction, sequencing, a §7 verdict or a §10 answer edits §2,
+§8 and §10 here **in the same PR**, and the matching #807 comment points
+here instead of restating. A plan of record that lags the code has already
+cost one reassessment; the rule is cheaper than the next one.
 
 Sam's framing, which is the point of the whole document:
 
@@ -41,8 +49,10 @@ is right in five years, not the one that is reachable in small steps.
 2. Treat §7 as a contract: anything marked **ASSUMED** must be verified
    before it is designed on. The previous session asserted API details from
    memory more than once and had to retract them publicly.
-3. §8 has the sequencing question. It is the one real decision, and it is
-   Sam's.
+3. §8 records the sequencing decision (taken 2026-09-09) and the phases.
+4. §11 and §12 are the facts Sam supplied about the hardware and the
+   conclusions drawn from them. They constrain every design choice in §4;
+   read them before proposing a change to §4 or §5.
 
 ---
 
@@ -51,9 +61,9 @@ is right in five years, not the one that is reachable in small steps.
 | thing | state |
 |---|---|
 | `feature/native-bluesky-plans` | integration branch off master; **#808 merged** into it 2026-09-09 (device namespace, phase 1) |
-| #809 `phase/02-preamble-preprocessor` | **OPEN, 13 commits, GeecsBluesky 0.79.0, CI green, not merged.** This is the code this document argues is scaffolding |
-| #806 image writing | **OPEN, not started.** File plugin in GeecsPvaGateway + stock ophyd-async detectors; capture daemon retired |
-| #807 | the plan of record; its six-then-three phase plan is what this document supersedes |
+| #809 `phase/02-preamble-preprocessor` | **OPEN, on hold, will not merge** (13 commits, GeecsBluesky 0.79.0, CI green). The evidence behind §3; close with a pointer here once this amendment lands (§8) |
+| #806 image writing | **OPEN, not started.** Phase 1, in parallel with the plan layer (§8). File plugin in GeecsPvaGateway + stock `ADHDFDataLogic`; capture daemon retired |
+| #807 | the decision log; its six-then-three phase plan is superseded by §8 here. Comments there point here |
 | the worker (`geecs-gw`) | on **master**. Nothing from #809 is deployed, so none of its open defects is a live hazard |
 | hardware acceptance | scans **63 and 64** on 26_0909 via #809's preprocessor: stock `bp.count` as a noscan, stock `bp.list_scan` sweeping `U_S1H:Current` −1→+1 A at 0.5 A. Both in the Tiled catalog with s-files. Scans 56–62 are disposable artifacts of a `tiled=False` run |
 
@@ -127,44 +137,168 @@ The native answer is that there is only one description. Sam:
 > to accommodate save sets we should think, "what is a save set doing and
 > how does Bluesky solve the same problem?"
 
+**A second leg the first pass undersold.** The leaked-state P1 (saving mode,
+save path and asset definitions persisting on namespace nouns) is not a
+reconciliation failure. It is **per-run device configuration done from
+outside the device**: a preamble wrote `localsavingpath`/`save` and the
+asset definitions onto long-lived objects. ophyd-async's answer is the
+detector's own lifecycle — `stage → prepare → trigger/kickoff → unstage`,
+with a `PathProvider` supplying the path — and that leak would exist even
+with one description of the scan if saving were still configured by a
+preamble. So the rebuild has two legs, and §4 is built on both:
+
+1. **one description** — the client expands a request into the plan's
+   `detectors` and points; nothing worker-side re-derives them;
+2. **devices own their per-run state** through the standard lifecycle;
+   nothing outside a device configures it for a run.
+
 ---
 
 ## 4. The target architecture
 
-Assume only the two gateways and ophyd-async.
+Assume only the two gateways and ophyd-async. Two rules drive every choice:
+a scan has **one description** (the plan's arguments), and every per-run
+fact about a device is set through **that device's own lifecycle**, never
+from outside it.
 
-**One namespace of devices, from the DB.** Anything that produces
-non-scalar data is a `StandardDetector` whose data logic writes through the
-PVA gateway file plugin (#806). Everything else is a `StandardReadable`
-over CA gateway PVs. Settables are children of their parent device. A
-device knows its own topology: a motor is a motor because the DB gives it a
-tolerance, not because a scan said so. **This layer is #808 and already
-exists**; what changes is that cameras become detectors.
+### A. Devices — the namespace, extended
 
-**The trigger box is a flyer.** At HTU the box is the master clock. The
-Bluesky expression for "hardware fires, detectors collect N frames" is
-`prepare(TriggerInfo(trigger=DetectorTrigger.EXTERNAL_EDGE, …))` then
-kickoff / complete / collect, with a `StandardFlyer` wrapping a
-`FlyerController`. Strict single-shot and free-run are then the same
-implementation with different counts: strict is one event per step,
-free-run is continuous. Today they are two subsystems, and free-run is
-already slated for deletion.
+Every DB device is one long-lived noun (#808, kept). Two classes:
 
-**Everything persistent is a callback.** ScanInfo, the s-file, the Tiled
-catalog entry and the legacy column headers are all functions of the
-document stream. None belongs in a plan or a preprocessor. The s-file and
-catalog already work this way; ScanInfo does not.
+- **`StandardReadable`** for scalar-only devices; settables as children
+  (`U_S1H.current`). Exists.
+- **`GeecsDetector(StandardDetector)`** for anything that captures —
+  cameras *and* LabVIEW-native non-scalar devices — composed of the three
+  logics ophyd-async 0.19.3 defines (§7):
+  - `GeecsTriggerLogic` — supports `prepare_edge` only (LabVIEW free-runs on
+    external edges; nothing to program). `config_sigs` = exposure + the
+    calibrated drain offset (§11.4); `get_deadtime` = exposure + offset.
+    That one method lets a plan derive `exposure_timeout` per detector and
+    lets the namespace **refuse** "essential at this rep rate" when
+    exposure + offset exceeds the period.
+  - `GeecsAcquireLogic` — near-empty: `ensure_ready` checks the gateway
+    `CONNECTED` PV; the rest are no-ops. LabVIEW is always acquiring.
+  - **Data logic, two implementations behind the same ABC**, chosen at
+    namespace build from the DB (PVA-served image variable → plugin;
+    `save_nonscalar_data` without one → LabVIEW-native):
+    - `ADHDFDataLogic` over the #806 plugin PVs — **stock**, nothing of
+      ours. Streamable; `collections_written` = `NumCaptured_RBV`.
+    - `LvNativeFileDataLogic` — writes path + name template to
+      `localsavingpath`, toggles `save`, describes the resource as
+      directory + template + per-shot index (we own the names, §11.6).
+      A per-event reading until a write-complete readback exists (§10.1);
+      streamable after.
+  - `acq_timestamp` as a readable child with the persistent monitor
+    (exists, `devices/ca/triggerable.py`); the drain offset as a config
+    signal from the calibration store (§4.F).
+- **`ShotControl`** — one device, three protocols: `Movable` over
+  `TriggerState` (the profile-defined writes per state — the existing
+  abstraction, §11.1), `Pausable` (`pause → STANDBY`, `resume → ARMED`;
+  the RE calls these on every Pausable it has seen in a message, §7), and a
+  `FlyerController` for gated mode (`prepare → OFF`, `kickoff → SCAN`,
+  `complete → N shots then OFF`). Replaces `shot_controller.py`'s plan-stub
+  methods and `plans/pause_semantics.py`.
 
-**The scan folder is a `PathProvider`.** ophyd-async ships
-`YMDPathProvider` and `AutoIncrementingPathProvider`, which between them
-are close to the `scans/YY_MMDD/ScanNNN/` convention. The day-scoped claim
-protocol is the part that stays ours.
+### B. Acquisition — three shapes, one mechanism each
 
-**Save sets and scan variables move to the client.** "Record amp4in" is a
-genuinely useful operator preset. It is a named list that a client expands
-into a plan's `detectors` argument before submission. It should never reach
-the worker as an instruction. This is what #807 phase C already said; #809
-did that job in the wrong place.
+**Strict (the default).** Stock plans with a GEECS `per_step` / `per_shot`
+— the one extension point with no stock equivalent, because the fire must
+sit *between* trigger and wait (§11.5 explains why free-running edges are
+not an exact substitute):
+
+```
+move_per_step(step, pos_cache)
+for each shot:
+    trigger(essential, wait=False)    # StandardDetector.trigger re-baselines its count
+    mv(shot_control, SINGLESHOT)
+    wait(group, timeout=max(exposure_timeout over essential))
+    create / read(essential) / save   # one event row
+```
+
+About 25 lines of pure `bps`, one of which is the non-stock idea. On a
+`FailedStatus` from the wait: device confirmed down (the existing
+`CONNECTED` liveness read) → `bps.pause()`, the operator fixes it, `resume`
+rewinds to the checkpoint; otherwise re-trigger **all** essential detectors
+and fire again — the whole-event redo, so positional joins stay exact for
+every essential detector (the orphan frame stays on disk, unreferenced by
+any document, which is Bluesky's normal model). This is
+`fire_and_await_shot`'s behaviour in its native shape; that function is the
+salvage.
+
+**Non-essential stream.** Those detectors are *not* in `detectors`. They
+are `SupplementalData.flyers` (or `fly_during_wrapper` per plan, §7):
+`prepare(TriggerInfo(EXTERNAL_EDGE, number_of_events=0))` — unbounded —
+`kickoff` at `open_run`, `complete`/`collect` at `close_run`, in their own
+stream, joined afterwards by offset-corrected stamp (§11.3). A 700 ms
+camera or a dying device there never holds a shot and never aborts a run.
+This is free-run's **second job** (§11.5), kept natively; its first job
+(the rep-rate hack) dies.
+
+**Gated batch (opt-in).** `bp.fly`-shaped: `prepare(detectors,
+TriggerInfo(EXTERNAL_EDGE, number_of_events=N))`, `prepare(shot_control)` →
+OFF, `kickoff` all → SCAN, `collect_while_completing`. Exact because the
+ordering is built into `prepare → kickoff`. Only for detectors that count
+(plugin-backed); replaces free-run's rep-rate role once #806 lands.
+
+**Telemetry.** `SupplementalData.baseline` for the scalars that do not
+change within a run (read at open and close), `monitors` for the changing
+few. Installed once on the RE from experiment defaults. Which variable goes
+where is an **experiment config fact**, not a DB fact (§10.4): derive it
+once by measurement over a Tiled run, then own the list; unknowns default
+to per-event. Removes the unstaged-read regression path entirely.
+
+### C. Run bookkeeping — a path provider and callbacks
+
+- **`GeecsScanPathProvider(PathProvider)`** returns
+  `PathInfo(scans/YY_MMDD/ScanNNN/<device>, filename, create_dir_depth=1)`.
+  The day-scoped claim is the one GEECS thing with no native home: a
+  ~60-line **`claim_scan` preprocessor** that, on `open_run`, claims the
+  number, injects it into `md`, and points the provider at the run;
+  releases on `close_run`. It does exactly one thing — it is **not** the
+  #809 preamble, and must never grow a second job.
+- **Callbacks:** ScanInfo ini on the start document (new, small); the
+  s-file export from Tiled at stop (exists, `sfile_callback.py`); the Tiled
+  writer (exists — drop the `geecs://` descriptor patch in
+  `tiled_integration.py` once stream documents replace those assets);
+  `scan.log` as a callback.
+
+### D. Clients
+
+The Console expands a `ScanRequest` into a stock plan item — `count`,
+`scan`, `list_scan`, `grid_scan`, `list_grid_scan`, `rel_*`, `fly` —
+registered once each with the GEECS `per_step` pre-bound and the **stock
+signature preserved** (#807's registration table). The save set becomes a
+client-side preset expanding to three lists: essential detectors,
+non-essential flyers, and scalar-only children (`cam.centroid_x` rather
+than `cam` when the preset says "scalars only" for a camera — readables are
+individually addressable). The request rides in `md["geecs"]` as
+provenance only. Blast radius: `GEECS-Console/geecs_console/app/main_window.py`
++ the request builder. GEECS-MCP follows later (§11.7).
+
+### E. Deletions (whole modules, in the same PR as their replacement)
+
+`plans/scan_request_plan.py`, `step_scan.py`, `free_run_step_scan.py`,
+`named_plans.py`, `pause_semantics.py`, `t0_sync.py`, `liveness.py`,
+`orchestration.py`; `session.py` and `scan_request_runner.py` (the resolver
+functions that survive move to the client); `capture/` after #806;
+`devices/contributor.py`, `nonscalar_save.py`, `shot_id.py`,
+`ca/timestamped_readable.py`. Roughly 9k of GeecsBluesky's 24.6k lines.
+**Kept:** `qs_client`, `optimization`, the `devices/ca` bases,
+`namespace.py`, `action_compiler.py`, the qserver deploy tree. The refactor
+is **in place** (§10, Q2 answered): the keepers are half the package and
+the Console and MCP import them; a new package would re-home them for no
+gain.
+
+### F. Calibration
+
+A standalone `measure_shot_offsets` plan (OFF → wait the longest device
+timeout in the set → one fire → read every stamp) writes each device's
+drain offset to the configs repo, from where the config signal reads it.
+Strict runs carry the same data for free (one fire, every device waited
+on, shot time known), so "sync" can also be recomputed from any recent
+strict scan. Sam's validation shortcut (OFF, stalled stamps within
+tolerance) becomes a `qserver_ready`-style preflight — never a scan step,
+because it costs at least the longest device timeout per check (§11.2).
 
 ---
 
@@ -173,46 +307,47 @@ did that job in the wrong place.
 | GEECS today | Native replacement |
 |---|---|
 | save set, as a device list | the plan's `detectors` argument; a client-side preset |
-| save set `synchronous` flag | the `Triggerable` protocol |
+| save set `synchronous` flag | essential (`detectors`) vs non-essential (`SupplementalData.flyers`) |
 | `save_nonscalar_data`, `localsavingpath`, `save` | the detector's data logic, opened and closed per run |
-| save set explicit scalar list | the device's own readables |
+| save set explicit scalar list | the device's own readables, individually addressable |
 | save-set rituals, setup/closeout | plan stubs and `finalize_wrapper` (#647) |
-| `background_telemetry` | monitors, or simply more detectors in the list |
+| `background_telemetry` | `SupplementalData.baseline` + `monitors` |
 | scan variable alias | the namespace attribute (`U_S1H.current`) |
 | `kind: motor`, `confirm:`, pseudo | the device class, chosen once at namespace build |
-| trigger profile states | a `FlyerController` |
-| strict single shot | fly, one event per step |
-| free run | fly, continuous |
-| Gate-2 save windowing | the detector's open/close window |
-| `acq_timestamp` as the shot join key | StreamDatum indices |
-| `shot_id`, `shot_offset`, `bin_number` | `seq_num` and per-stream indices |
-| scan number and folder | a `PathProvider` plus our claim protocol |
+| trigger profile states | `ShotControl`: `Movable` over the states, `Pausable`, `FlyerController` for gated mode |
+| strict single shot | stock `per_step` with the fire between trigger and wait |
+| free run — the rep-rate job | gated batch: fly, detectors count |
+| free run — the contributor job | the non-essential stream: `SupplementalData.flyers` |
+| Gate-2 save windowing | the detector's own capture window (open at prepare, close at unstage) |
+| `acq_timestamp` as the shot join key | **kept** — offset-corrected, it *is* the shot id (§11.3); positional for essential detectors, by stamp for the non-essential stream |
+| `shot_id`, `shot_offset`, `bin_number` | `seq_num`, the stamp, and the per-device drain offset as a config signal |
+| the t0-sync ritual | a once-run calibration plan + a preflight validation (§4.F) |
+| scan number and folder | a `PathProvider` plus the `claim_scan` preprocessor |
 | ScanInfo ini | a start-document callback |
 | s-file, Tiled catalog | callbacks (already true) |
 | capture daemon | deleted by #806 |
 | `ScanRequest` as a worker instruction | a client-side template that expands into a plan call |
 | the funnel, named plans, the #809 preprocessor | deleted |
 
-Almost every hard problem of the last two weeks is one row of this table.
-Orphan frames, save windowing, the refire, the shot join, bin numbers: all
-of them are the detector and flyer contract, hand-rolled because our
-cameras are not detectors yet.
-
 ---
 
 ## 6. What stays GEECS
 
-Five things have no native home, and none of them is in the scan path:
+Six things have no native home, and none of them is in the scan path's
+logic:
 
 1. **The DB as the source of truth** for the device roster, types,
    tolerances and subscribed variables. The namespace builder owns this.
-2. **Day-scoped scan numbering** with a multi-writer claim protocol. A
-   custom `PathProvider`.
+2. **Day-scoped scan numbering** with a multi-writer claim protocol. The
+   `claim_scan` preprocessor plus the path provider.
 3. **The s-file format** and its legacy `Device Variable` column headers.
    A callback, plus header metadata on the devices.
 4. **ScanInfo ini.** A start-document callback.
 5. **PV naming and the served-set rules.** Already owned by the two
    gateways and `geecs_core`.
+6. **The fire between trigger and wait** — one line in `per_step`. It
+   exists because the trigger box has no counter and the cameras stamp with
+   a per-device latency (§11.5).
 
 `ScanRequest` and its JSON Schema also survive, as the **client-side**
 record of intent the GUI needs. What dies is its role as a worker-side
@@ -223,72 +358,111 @@ execution instruction.
 ## 7. Verified versus assumed
 
 **Verified 2026-09-09 against the installed environment** (ophyd-async
-**0.19.3**, bluesky **1.15.0**):
+**0.19.3**, bluesky **1.15.0**, tiled **0.2.9**), by reading the source,
+not the docs:
 
-- `StandardDetector`, `StandardFlyer`, `FlyerController`, `TriggerInfo`,
-  `DetectorTrigger`, `DetectorAcquireLogic`, `DetectorDataLogic`
-- `PathProvider`, `StaticPathProvider`, `AutoIncrementingPathProvider`,
-  `AutoMaxIncrementingPathProvider`, `YMDPathProvider`,
-  `AutoIncrementFilenameProvider`, `UUIDFilenameProvider`
+- `StandardDetector` is a three-logic composition: `DetectorTriggerLogic`
+  (`prepare_internal/edge/level`, `get_deadtime`, `config_sigs`,
+  `default_trigger_info`), `DetectorAcquireLogic` (`ensure_ready`,
+  `start_acquiring`, `wait_for_idle`, `ensure_stopped`) and
+  `DetectorDataLogic`, composed by `add_detector_logics`
+  (`core/_detector.py`). **#806 swaps exactly one of the three.**
 - `TriggerInfo` fields: `trigger`, `livetime`, `deadtime`,
-  `exposures_per_collection`, `collections_per_event`, `number_of_events`,
-  `exposure_timeout`
-- `DetectorTrigger`: `INTERNAL`, `EXTERNAL_EDGE`, `EXTERNAL_LEVEL`
-- `bps.prepare`, `kickoff`, `complete`, `collect`,
-  `collect_while_completing`, `declare_stream`
+  `exposures_per_collection`, `collections_per_event`, `number_of_events`
+  (**0 means unbounded**), `exposure_timeout`. `DetectorTrigger`:
+  `INTERNAL`, `EXTERNAL_EDGE`, `EXTERNAL_LEVEL`. (An earlier #807 comment
+  wrote `number_of_triggers`; that name does not exist in 0.19.3.)
+- External triggering calls `start_acquiring()` inside `prepare`, so
+  detectors are capturing before any `kickoff` — the ordering that makes
+  gated mode exact.
+- `kickoff()` re-reads `collections_written` on every call and honours
+  `events_to_kickoff`, so `prepare(N)` then N × (kickoff → fire →
+  complete) composes, and a failed `complete` can be re-kicked.
+- `trigger()` re-baselines `collections_written` through
+  `_update_prepare_context` on every call, so it is repeatable per step
+  with `EXTERNAL_EDGE`; it refuses a context prepared with
+  `number_of_events != 1`.
+- `StandardFlyer`, `FlyerController` (`prepare/kickoff/complete/stop`);
+  `PathProvider`, `PathInfo(directory_path, filename, create_dir_depth)`,
+  `StaticPathProvider`, `AutoIncrementingPathProvider`, `YMDPathProvider`.
+- `ophyd_async.epics.adcore`: `ADHDFDataLogic`, `NDFileHDF5IO`,
+  `ADAcquireLogic`, `ADContAcqTriggerLogic` exist under those names.
+- bluesky: `Pausable` is called on **every object the RE has seen in any
+  message** (`run_engine.py:1268` for suspend, `:1531` for pause), so a
+  device that appears in a `set` is paused. `SupplementalData(baseline,
+  monitors, flyers)`, `fly_during_wrapper`, `monitor_during_wrapper`,
+  `baseline_wrapper`, `bps.prepare/kickoff/complete/collect/
+  collect_while_completing/declare_stream`, `bp.count(per_shot=)`, the
+  `per_step` hook on the scan plans, `one_nd_step`, `move_per_step`.
+- `TiledWriter` converts `Resource` → `StreamResource` and knows the
+  `application/x-hdf5` mimetype (`callbacks/tiled_writer.py:203-238`).
+- The s-file is exported **from Tiled** at the stop document
+  (`sfile_callback.py`), so Tiled's ingestion is load-bearing for the
+  s-file as well as the catalog.
 - **Naming has moved**: the writer base is not `DetectorWriter` in this
   version, and the flyer's controller is `FlyerController`, not
   `TriggerLogic`. Older docs and blog posts will disagree.
 
-**ASSUMED, must be verified before designing on it:**
+**ASSUMED, must be verified before designing on it** (narrowed from the
+first draft; each names the phase that retires it):
 
-- that the PVA gateway can be made to deliver **indexed, edge-triggered**
-  frames with a stable frame counter. The whole fly design rests on this
-  and it is the substance of #806
-- that `StandardDetector`'s acquire/data split can be satisfied by a GEECS
-  camera server without an areaDetector IOC
-- that a step scan with N shots per point composes cleanly as fly-per-step
-  in 0.19.3
-- that Tiled and the s-file exporter handle StreamResource/StreamDatum
-  from these detectors as well as they handle the current asset documents
+- that the PVA gateway plugin can count **distinct, fresh** frames
+  losslessly within a capture window, deduping on the stamp before the
+  latest-wins slot — the substance of #806 (phase 1)
+- that Tiled 0.2.9 reads the plugin's NDFileHDF5-layout files through its
+  stock HDF5 adapter with no adapter of ours (phase 1)
+- that OFF on the DG645 stops edges reaching the cameras within a known
+  latency, and that the CA gateway posts the device **timeout events**
+  (unchanged stamp) a liveness check would rely on (phase 0)
+- that per-device drain latency is constant across exposure settings, as
+  §11.4 states (phase 0 measures it across the amp4in set)
 
 ---
 
-## 8. Sequencing: the decision for Sam
+## 8. Sequencing: decided 2026-09-09
 
-**#806 comes first.** Every row of the table that hurts most lives in the
-detector contract, and a rebuild that starts before cameras are detectors
-will re-derive the same workarounds we are trying to delete. This is a
-reversal of the current ordering, in which #806 sits behind the plan work.
+**Option 1½ — a phase 0 on today's hardware, then #806 and the plan layer
+in parallel.** Sam chose this over the first draft's "#806 first".
 
-Three options, in the order I would recommend them:
+The reasoning that changed the recommendation: #806 replaces **one of the
+three detector logics**. The trigger logic (DG645 edge, LabVIEW free-runs)
+and the acquire logic survive #806 unchanged; only the data logic swaps
+from "LabVIEW native save" to `ADHDFDataLogic`. So making a GEECS camera a
+genuine `StandardDetector` *now*, with today's `NonScalarSaveSupport`
+relocated into a ~50-line `LvNativeFileDataLogic`, is not building twice —
+it is the same class with a throwaway third logic. It kills the
+preamble-configures-devices leak immediately, proves the fire between
+trigger and wait on hardware in days, and gives #806 a concrete target
+("replace this data logic") instead of four ASSUMED bullets. "#806 first"
+would have front-loaded every schedule risk (Windows NSSM + h5py
+re-bootstrap, HDF5 over SMB, emulating the areaDetector PV set in p4p) into
+the least-verified component while the scan path waited.
 
-1. **#806, then rebuild.** Cameras become `StandardDetector`s, the capture
-   daemon dies, then the flyer and the plan layer follow. Slowest to first
-   visible change, cleanest result, and it is the only order in which the
-   twelve duplication findings actually disappear rather than move.
-2. **Rebuild the plan layer first against today's devices**, accepting that
-   the fly design waits. Faster feedback for Sam, at the cost of building
-   the per-shot trigger machinery a second time and deleting it later.
-3. **Land #809 and continue incrementally.** Recommended against, and the
-   clean slate removes its only argument. Incrementalism buys backward
-   compatibility, which is worth nothing here, and it pays for it with a
-   reconciliation engine the target design deletes.
+### Phases (each a PR into `feature/native-bluesky-plans`)
 
-**On #809 itself:** do not merge it. Leave it open as the evidence, or
-close it with a pointer to this document. Its two open P1 defects need no
-fix if it is not shipping, and nothing from it is deployed. Parts worth
-salvaging by hand: the document-parity test, `GeecsNamespace.select`'s
-role assertions, `plan_session.py`, and the shared
-`fire_and_await_shot` if per-shot triggering survives at all.
+0. **One camera as `GeecsDetector`** with `LvNativeFileDataLogic` (PNG),
+   `ShotControl` as a device, the strict `per_step`; stock `bp.list_scan`
+   on `U_S1H` on hardware. Measures: OFF latency, whether the gateway
+   posts timeout events, drain offsets across amp4in, `exposure_timeout`
+   behaviour on a real trigger.
+1. **In parallel:** #806 (plugin + stock `ADHDFDataLogic`) ∥ the plan
+   layer (path provider + `claim_scan`, callbacks, client expansion +
+   registration table, deletions). Hardware acceptance each.
+2. Gated batch + the non-essential stream via `SupplementalData.flyers`;
+   free-run deleted.
+3. The calibration plan + the preflight validation.
 
-**What keeps working while this happens.** Answered: Sam's team is the
-only user, so the answer is "whatever they choose to keep working that
-week." The rebuild does **not** need to run beside the funnel, and the
-old doors do not need a deprecation path. Keep the lab scannable between
-sessions and nothing more. In particular, do not spend design effort on
-dual-door parity — the parity test in #809 exists only because two doors
-had to coexist, and in the target there is one.
+**On #809:** do not merge. Nothing from it is deployed; its two open P1s
+need no fix if it does not ship. Close it with a pointer here once this
+amendment lands, so a green PR does not tempt a later session. Salvage by
+hand: `fire_and_await_shot` (the strict refire, §4.B), the document-parity
+test, `GeecsNamespace.select`'s role assertions, `plan_session.py`.
+
+**What keeps working while this happens.** Sam's team is the only user.
+Master stays deployable; the feature branch rebuilds; the worker checkout
+flips per hardware-accepted milestone. Nothing runs beside the funnel and
+no dual-door parity is built — the parity test in #809 existed only because
+two doors had to coexist.
 
 **What the clean slate unlocks, and should be used for:**
 
@@ -298,9 +472,6 @@ had to coexist, and in the target there is one.
 - change the event schema, the s-file columns and the ScanRequest schema
   freely where the native shape is better; there is no reader to break
   that the team does not own
-- renumber, rename and restructure the package. A **total refactor of
-  GeecsBluesky**, or replacing it with a new package, is fully on the
-  table and is probably cheaper than incremental deletion
 - treat "we already built it" as carrying no weight. The only question is
   whether a thing is right
 
@@ -314,8 +485,7 @@ had to coexist, and in the target there is one.
 - Added lines must be justified. Never a second copy of a solved problem.
   Where a better copy replaces an old one, the old one goes in the same
   change.
-- **New, and the reason for this document:** do not hold on to anything
-  that does not slot in completely cleanly.
+- Do not hold on to anything that does not slot in completely cleanly.
 - **Clean slate.** Sam's team is the only user. No backward compatibility,
   no deprecation cycles, no migration paths. Deleting is cheaper than
   adapting, and "we already built it" is not an argument.
@@ -330,18 +500,137 @@ had to coexist, and in the target there is one.
   (`python -u -m pytest -v`). A backgrounded pytest writing to a file looks
   stalled for minutes because stdout is block-buffered; that cost an hour
   in the last session and produced a retracted claim.
+- Verify API details against the installed versions; never assert them
+  from memory. §7 is the ledger.
 
 ---
 
-## 10. Open questions for Sam
+## 10. Open questions
 
-1. Sequencing: option 1, 2 or 3 in §8. This is the only substantial one.
-2. Refactor GeecsBluesky in place, or start a new package and let the old
-   one die? The mapping is identical either way; the difference is whether
-   the package keeps its history. The clean slate makes the second viable.
-3. How much lab downtime is acceptable between working states? That now
-   sets the pace, in place of any compatibility constraint.
-4. Two small carry-overs from the last session, unrelated to this
-   direction: write `Amplitude.Ch AB: 0.5` explicitly in every state of
-   `HTU-NoGas` so "no gas" stops being order-dependent, and add a check
-   that all profiles in an experiment manage the same variable set.
+Answered 2026-09-09: Q1 sequencing → option 1½ (§8). Q2 refactor in place
+(§4.E). Q3 downtime → flip the worker per milestone, no coexistence (§8).
+
+Still open, for Sam:
+
+1. **Write-complete readback on LabVIEW-native devices.** Does the device
+   expose any signal that the file for shot k is *closed* (a variable, a
+   counter), or is the only signal that `acq_timestamp` advanced — which
+   says the capture succeeded, not that the write finished? Decides
+   whether `LvNativeFileDataLogic` can be streamable or stays a per-event
+   reading.
+2. **Which amp4in devices are non-essential by default** — a preset fact,
+   and the first real test of the two-list model.
+3. **What `pause` drives:** STANDBY (edges continue, GUIs stay live,
+   frames land on disk unreferenced) or OFF.
+4. **Where the baseline/monitor split is recorded** — the experiment
+   defaults in the configs repo is the proposal; the first list comes from
+   measuring one Tiled run.
+5. Two small carry-overs, unrelated to this direction: write
+   `Amplitude.Ch AB: 0.5` explicitly in every state of `HTU-NoGas` so "no
+   gas" stops being order-dependent, and add a check that all profiles in
+   an experiment manage the same variable set.
+
+---
+
+## 11. Facts from Sam (2026-09-09) that constrain the design
+
+Recorded verbatim in substance because a fresh session will not have them
+and every one of them changed a design choice.
+
+1. **Trigger states.** OFF = nothing leaves the DG645. STANDBY = the state
+   the machine idles in when not scanning — almost always external rising
+   edges, because the laser fires regardless and letting hardware trigger
+   keeps GUIs up to date. SCAN = the same edges at data-taking amplitude.
+   ARMED = strict only, source to single-shot. SINGLESHOT = the momentary
+   fire. The names are an abstraction so another trigger box can carry the
+   same five states with different writes. **Consequence:** OFF is the
+   only quiet state; STANDBY is not quiescent and was never meant to be.
+2. **Device timeouts.** A GEECS device emits a TCP event either on a
+   successful acquisition or, failing that, when its own timeout expires
+   (1.5 s for ~95 % of devices); the timeout event carries an *unchanged*
+   `acq_timestamp`. Nothing "stalls" on its own. **Consequence:** observing
+   quiescence costs at least the longest device timeout in the set, so it
+   belongs in a once-run calibration or a preflight, never in a scan.
+3. **`acq_timestamp` is a shot id in everything but name.** It advances
+   only on a successful capture, deterministically, on domain time
+   NTP-synced to ~5–10 ms. Cross-device values for one shot differ by a
+   per-device constant (point 4), so after subtracting that constant all
+   stamps land within NTP jitter and rounding to the nearest period has
+   ~490 ms of margin at 1 Hz. Naive rounding *without* the offset fails at
+   bucket boundaries as the laser's phase drifts. The re-pushed idle
+   frames and stale pre-scan frames the capture daemon filters are
+   **delivery** artefacts of the TCP push, not properties of the stamp.
+4. **What the stamp measures.** Exposure time and trigger delay are backed
+   out: `acq_timestamp` = trigger arrival + the latency of draining the
+   frame, a per-camera constant (~100 ms spread between a 4 MB and a 0.5 MB
+   camera). The TCP *message*, however, is sent only when the exposure
+   completes — a 700 ms exposure makes the message arrive most of a second
+   after the shot. **Consequence:** the stamp governs the join; the arrival
+   governs how long a plan waits (`exposure_timeout`); the two are
+   different quantities and the design keeps them apart.
+5. **Essential vs non-essential.** Sam wants per-device control over what
+   happens when camera A misses shot k: "we cannot miss shots from these
+   cameras, but missing shots from those is fine; throttle acquisition for
+   the first set, never for the second." A non-essential device dying
+   mid-scan must not force an abort. A 700 ms camera belongs on the
+   non-essential list precisely so nobody waits for it. **Consequence:**
+   the non-essential set is a separate stream joined by stamp, because its
+   frame for shot k may arrive during shot k+1; and deleting free-run must
+   keep this role, which free-run's "contributor" devices carried. Why the
+   fire is not stock: with edges free-running, `trigger()` baselines each
+   detector on its last seen stamp, and stamps for one edge arrive
+   50–100 ms apart across cameras; an edge inside that window while the
+   trigger messages go out leaves camera A waiting for k+1 while B records
+   k — roughly 5–10 % of steps misaligned at 1 Hz. Firing *after* every
+   baseline is set makes each row exact by construction.
+6. **Proprietary file formats.** Only the writer SDK is proprietary; the
+   file names and paths are ours to choose. **Consequence:** the
+   LabVIEW-native data logic can describe its resource the same way the
+   plugin does; the only remaining gap is the write-complete readback
+   (§10.1).
+7. **The sync ritual Sam built** — withhold the trigger, watch the stamps
+   stop advancing, fire one shot, watch every stamp step — measures each
+   device's drain offset for one known shot. The shortcut (OFF, stalled
+   stamps within ~200 ms ⇒ already synced) validates it. Sam does not want
+   it baked in as-is; a "sync" button that runs it and updates the
+   per-device offsets is the shape he imagines. **Consequence:** §4.F.
+8. **Scope notes.** GEECS-MCP was one-shotted and can be updated later —
+   not a constraint now. The Console follows the client-expansion change.
+   A service on the worker host that is a browser client of the qserver
+   ("the scanner through the browser") is the end point Sam has in mind;
+   GEECS-DataPortal is already a FastAPI service on that host speaking to
+   Tiled, so it is the natural landing — not now, but nothing here closes
+   it off.
+
+---
+
+## 12. What we lack, honestly
+
+Asked directly whether a Bluesky-native ecosystem can be delivered on
+these foundations: yes, and not cosmetically. Stock plans, documents,
+Tiled, the queueserver and the clients carry ~90 % of the leverage and do
+not care how frames are counted. Two writer paths is normal — every
+serious EPICS facility runs areaDetector file plugins beside detectors that
+write their own formats (Eiger/Odin, Pilatus CBF, PandA HDF5), and
+`DetectorDataLogic` exists precisely so the writer need not be an AD
+plugin. The gaps, after §11, are three, and none is in the scan path's
+logic:
+
+1. **Lossless frame delivery.** The re-push and stale-frame behaviours are
+   the TCP push's; the #806 plugin dedupes on the stamp before the
+   latest-wins slot, and that is the **only** place such logic may live.
+   (The gateway then has two consumers with opposite delivery contracts in
+   one process; its `DESIGN.md` should say so.)
+2. **A write-complete readback on the LabVIEW-native path** (§10.1).
+3. **A native home for the non-essential stream** when free-run goes —
+   `SupplementalData.flyers` (§4.B).
+
+Two hazards #806 already names that deserve more weight than the issue
+gives them: HDF5 written on Windows over SMB and read on Linux (disable
+file locking; never read during write — a rule, not best-effort), and the
+CA monitor as the shot signal (monitors can coalesce under load; fine at
+1 Hz, **verify the gateway's posting guarantee before any design above
+it**).
+
+Shot identity is **not** a gap (§11.3). The first draft of this document
+said it was, and was wrong.

--- a/Planning/native_bluesky/03_clean_room_rebuild.md
+++ b/Planning/native_bluesky/03_clean_room_rebuild.md
@@ -186,8 +186,9 @@ Every DB device is one long-lived noun (#808, kept). Two classes:
     - `LvNativeFileDataLogic` — writes path + name template to
       `localsavingpath`, toggles `save`, describes the resource as
       directory + template + per-shot index (we own the names, §11.6).
-      A per-event reading until a write-complete readback exists (§10.1);
-      streamable after.
+      A per-event reading — there is no write-complete readback (§10.1) —
+      with a bounded end-of-run check that every expected file exists and
+      has stopped growing.
   - `acq_timestamp` as a readable child with the persistent monitor
     (exists, `devices/ca/triggerable.py`); the drain offset as a config
     signal from the calibration store (§4.F).
@@ -512,12 +513,15 @@ Answered 2026-09-09: Q1 sequencing → option 1½ (§8). Q2 refactor in place
 
 Still open, for Sam:
 
-1. **Write-complete readback on LabVIEW-native devices.** Does the device
-   expose any signal that the file for shot k is *closed* (a variable, a
-   counter), or is the only signal that `acq_timestamp` advanced — which
-   says the capture succeeded, not that the write finished? Decides
-   whether `LvNativeFileDataLogic` can be streamable or stays a per-event
-   reading.
+1. ~~Write-complete readback on LabVIEW-native devices~~ **Answered
+   2026-09-09 (Sam): there is none.** `acq_timestamp` advancing says the
+   capture succeeded; nothing says the write finished. Consequence:
+   `LvNativeFileDataLogic` is a **per-event reading**, and because we own
+   the filenames the worker enforces the contract itself — at the run's end
+   it waits, bounded, for every expected file to exist and stop changing
+   size (two agreeing stats), and fails the run loudly otherwise. Once #806
+   moves the cameras to the plugin, this path serves only the few non-image
+   proprietary devices.
 2. **Which amp4in devices are non-essential by default** — a preset fact,
    and the first real test of the two-list model.
 3. **What `pause` drives:** STANDBY (edges continue, GUIs stay live,
@@ -621,7 +625,9 @@ logic:
    latest-wins slot, and that is the **only** place such logic may live.
    (The gateway then has two consumers with opposite delivery contracts in
    one process; its `DESIGN.md` should say so.)
-2. **A write-complete readback on the LabVIEW-native path** (§10.1).
+2. **No write-complete readback on the LabVIEW-native path** (§10.1) —
+   replaced by our own end-of-run file check; contained to the non-image
+   proprietary devices once #806 lands.
 3. **A native home for the non-essential stream** when free-run goes —
    `SupplementalData.flyers` (§4.B).
 

--- a/Planning/native_bluesky/03_clean_room_rebuild.md
+++ b/Planning/native_bluesky/03_clean_room_rebuild.md
@@ -221,13 +221,20 @@ for each shot:
 
 About 25 lines of pure `bps`, one of which is the non-stock idea. On a
 `FailedStatus` from the wait: device confirmed down (the existing
-`CONNECTED` liveness read) → `bps.pause()`, the operator fixes it, `resume`
-rewinds to the checkpoint; otherwise re-trigger **all** essential detectors
-and fire again — the whole-event redo, so positional joins stay exact for
-every essential detector (the orphan frame stays on disk, unreferenced by
-any document, which is Bluesky's normal model). This is
-`fire_and_await_shot`'s behaviour in its native shape; that function is the
-salvage.
+`CONNECTED` liveness read) → `GeecsDeviceDownError`, the run aborts with
+the device named; otherwise re-trigger **all** essential detectors and fire
+again — the whole-event redo, so positional joins stay exact for every
+essential detector (the orphan frame stays on disk, unreferenced by any
+document, which is Bluesky's normal model). This is `fire_and_await_shot`
+(`plans/single_shot.py`), shared with the funnel's shot — built in phase 0
+as `plans/strict.py`. **Why not `bps.pause()` on a dead device** (the
+first draft said pause-fix-resume): a pause inside `take_reading` is
+rewound on resume, and the RunEngine replays the stashed messages since the
+last checkpoint — the step's trigger and fire included — before the plan
+continues, so a retry after the pause would double-fire. The native
+"fix it and continue" is the operator resuming a *checkpointed* step, which
+needs the fire to be replay-safe; that is a plan-layer design item, not a
+`take_reading` one.
 
 **Non-essential stream.** Those detectors are *not* in `detectors`. They
 are `SupplementalData.flyers` (or `fly_during_wrapper` per plan, §7):

--- a/Planning/native_bluesky/03_clean_room_rebuild.md
+++ b/Planning/native_bluesky/03_clean_room_rebuild.md
@@ -194,7 +194,8 @@ Every DB device is one long-lived noun (#808, kept). Two classes:
     signal from the calibration store (§4.F).
 - **`ShotControl`** — one device, three protocols: `Movable` over
   `TriggerState` (the profile-defined writes per state — the existing
-  abstraction, §11.1), `Pausable` (`pause → STANDBY`, `resume → ARMED`;
+  abstraction, §11.1), `Pausable` (`pause → OFF`, `resume → ARMED` — Sam's
+  call, §10.3: a paused scan emits no edges and orphans no frames;
   the RE calls these on every Pausable it has seen in a message, §7), and a
   `FlyerController` for gated mode (`prepare → OFF`, `kickoff → SCAN`,
   `complete → N shots then OFF`). Replaces `shot_controller.py`'s plan-stub
@@ -522,10 +523,14 @@ Still open, for Sam:
    size (two agreeing stats), and fails the run loudly otherwise. Once #806
    moves the cameras to the plugin, this path serves only the few non-image
    proprietary devices.
-2. **Which amp4in devices are non-essential by default** — a preset fact,
-   and the first real test of the two-list model.
-3. **What `pause` drives:** STANDBY (edges continue, GUIs stay live,
-   frames land on disk unreferenced) or OFF.
+2. ~~Which amp4in devices are non-essential by default~~ **Answered
+   2026-09-09 (Sam): amp4in is one camera, essential, no non-essential
+   devices — it is a test preset.** Phase 0 therefore exercises the strict
+   path only; the two-list model gets its first real test later, on a
+   preset with a slow or optional camera.
+3. ~~What `pause` drives~~ **Answered 2026-09-09 (Sam): OFF**, not
+   STANDBY — a paused scan emits no edges and orphans no frames; `resume`
+   re-arms.
 4. **Where the baseline/monitor split is recorded** — the experiment
    defaults in the configs repo is the proposal; the first list comes from
    measuring one Tiled run.

--- a/Planning/native_bluesky/04_phase0_measurements.md
+++ b/Planning/native_bluesky/04_phase0_measurements.md
@@ -149,3 +149,47 @@ OFF put completed in 155 ms
   UC_BCaveMagSpecCam2                2478            8.0
 Trigger.Source restored: 'External rising edges'
 ```
+
+## M2 — phase-0 hardware acceptance: one camera as a StandardDetector (2026-09-09, Scan 065)
+
+**Purpose.** Retire §7's "acquire/data split can be satisfied by a GEECS
+camera" and "a step scan composes" assumptions; measure the strict per-shot
+cadence; prove the detector's own lifecycle brackets native saving.
+
+**Method.** `tests/test_phase0_hardware.py` on the worker host
+(`~/deploy-staging/GEECS-Plugins`, branch `phase/00-one-camera-detector`,
+commit 0f931c3f). `GeecsDetector("UC_Amp4_IR_input")` with 8 DB-subscribed
+scalars + `LvNativeFileDataLogic` on a `StaticPathProvider` into a claimed
+scan folder; `ShotControl.from_profile(HTU-NoGas)`; `bps.mv(shot_control,
+"ARMED")` → stock `bp.count([cam], 3, per_shot=geecs_per_shot)` → stock
+`bp.list_scan([cam], U_S1H.Current, [-1, -0.5, 0, 0.5, 1],
+per_step=geecs_per_step)` → finalize: STANDBY + restore the setpoint.
+
+**Findings.**
+
+1. **Both stock plans ran strict GEECS scans unchanged.** 3 + 5 events,
+   `exit_status: success`, every row carrying the camera's stamp, its 8
+   scalars, `save_path`, and (scan) the magnet readback within tolerance
+   (−0.9998 … 0.9999 A). Setpoint restored to 8e-05 A; trigger back in
+   STANDBY; `save` read `off` (enum `['on', 'off']`, index 1).
+2. **Native saving bracketed by the detector's lifecycle.** `Scan065/
+   UC_Amp4_IR_input/` holds exactly 8 PNGs, one per event, named with the
+   row's stamp (`UC_Amp4_IR_input_3871866045.102.png` ↔
+   `acq_timestamp 3871866045.102`); still 8 two minutes later — no orphans
+   in STANDBY. `localsavingpath` was written as the Windows share path
+   (`Z:\data\...\Scan065\UC_Amp4_IR_input`) by the config.ini mapping.
+3. **Cadence.** Count: 0.95 s, 0.99 s between shots — **1 Hz strict
+   achieved** with no motor. Scan: exactly 2.000 s per step — every other
+   edge. The step's move (`CaMotor` set + tolerance confirm) plus the
+   ~200 ms fire put pushes past the ~550 ms budget measured in M1, so the
+   single shot lands on the next-next edge. Expected from M1; the plan
+   layer can recover it (issue the fire earlier, overlap move and prepare)
+   — not a phase-0 concern.
+4. The drain offset rides in the descriptor's configuration
+   (`uc_amp4_ir_input-drain_offset: 0.0`, uncalibrated).
+5. 28 s wall for 8 shots including the DB roster, connects and the 7 s
+   first move (0 → −1 A).
+
+**Verdict.** Phase 0 accepted. The three-logic split fits a GEECS camera
+without an areaDetector IOC; the strict `take_reading` is the only GEECS
+code in the scan path.

--- a/Planning/native_bluesky/04_phase0_measurements.md
+++ b/Planning/native_bluesky/04_phase0_measurements.md
@@ -1,0 +1,151 @@
+# Phase 0 — hardware measurements
+
+Raw records behind the verdicts in `03_clean_room_rebuild.md` §7 and the
+facts in §11. Each measurement names what it was for, what was written to
+hardware, and what it showed. Read-only CA monitors unless stated.
+
+## M1 — OFF latency, timeout-event posting, single-shot stamp offsets (2026-09-09)
+
+**Purpose.** Retire three §7 ASSUMED items: does OFF stop edges and how
+fast; does the CA gateway post the devices' 1.5 s timeout events (unchanged
+stamp); what are the per-device drain offsets for one known shot (the §4.F
+calibration, in prototype form).
+
+**Method.** From the Mac over VPN (rtt ≈ 22 ms). `camonitor` on
+`acq_timestamp` of all 55 roster-triggerable Undulator devices
+(`looks_triggerable`); 3.5 s warm-up in STANDBY (edges free-running at
+1 Hz); `caput` `Trigger.Source:SP` → *Single shot external rising edges*
+(the OFF/ARMED source); 6 s observation; `caput`
+`Trigger.ExecuteSingleShot:SP` → *on*; 4 s observation; restore *External
+rising edges*. HTU-NoGas semantics (no amplitude variable).
+
+**Findings.**
+
+1. **OFF stops edges within one period.** The put completed in 155 ms;
+   every live device then received exactly one more stamp (+1.000 s — the
+   edge already in flight, arriving 0.02–0.48 s after the put), then
+   **silence for the remaining ~5.5 s**.
+2. **The CA gateway posts no timeout events.** Zero unchanged-value updates
+   reached any monitor during OFF. Whatever the device sends at its 1.5 s
+   timeout does not appear on the `acq_timestamp` PV. Consequences: monitor
+   silence cannot be read as liveness (use the `CONNECTED` PV, which
+   exists); the "positive miss signal" idea in §11.2 is dead unless the
+   gateway changes.
+3. **A single shot fires on the *next external edge*, not on the put.** The
+   `ExecuteSingleShot` put completed in 203 ms; stamps arrived 0.96–1.48 s
+   after the put started (one slow device at 2.48 s — its *stamp* agreed
+   with the others to 8 ms; only its message was late, exactly the §11.4
+   stamp-vs-arrival distinction). So the strict per-shot budget is: fire put
+   (~200 ms) + wait for the next 1 Hz edge + drain (≤ 220 ms) + transport.
+   **1 Hz strict is reachable only if the software between stamp arrival and
+   the next fire put completing stays under ~550 ms.**
+4. **Drain offsets span 0–220 ms**, wider than the ~100 ms estimate: the
+   spectrometers and MagSpec cameras 0–9 ms, the VISA line 37–62 ms, the
+   Amp cameras 47–104 ms, several transport/diagnostic cameras 150–220 ms
+   (`UC_OAPin2` 220, `UC_TopView` 182, `UC_FinalSteeringLeak` 178). All
+   well inside period/2, so offset-corrected rounding has ≥ 280 ms margin
+   at 1 Hz. Measured once; repeat across a few shots before storing as
+   calibration (§4.F).
+5. **Incidental:** `UC_BCaveMagSpecCam2` stepped +2.000 on the in-flight
+   edge — it had missed the previous shot (the ~1 % drop, seen live).
+   `UC_Stretcher_MI` stayed silent on the in-flight edge yet caught the
+   single shot. 13 of 55 triggerable devices were connected but not
+   stamping in STANDBY (idle acquirers: ICTs, DAQ, WFS, gauges, plungers).
+
+**Raw output.**
+
+```
+roster: 107 devices, 55 triggerable
+alive+stamping in STANDBY: 42/55: ['UC_ALineEBeam2', 'UC_ALineEBeam3', 'UC_ALineEbeam1', 'UC_Amp2Depletion_South', 'UC_Amp2_IR_input', 'UC_Amp3_IR_input', 'UC_Amp4Depletion_South', 'UC_Amp4_IR_input', 'UC_Amp4_IR_output', 'UC_BCaveIn', 'UC_BCaveMagSpecCam1', 'UC_BCaveMagSpecCam2', 'UC_ChicaneSlit', 'UC_DMSurface', 'UC_DiagnosticsPhosphor', 'UC_ExpanderIn1', 'UC_ExpanderIn1_Pulsed', 'UC_FinalSteeringLeak', 'UC_GaiaMode', 'UC_GratingMode', 'UC_ModeImager', 'UC_OAPin1', 'UC_OAPin2', 'UC_Phosphor1', 'UC_Stretcher', 'UC_Stretcher_MI', 'UC_TC_Output', 'UC_TargetIn', 'UC_TopView', 'UC_TubeIn', 'UC_UndulatorImagingSpec', 'UC_UndulatorRad2', 'UC_VisaEBeam1', 'UC_VisaEBeam2', 'UC_VisaEBeam3', 'UC_VisaEBeam4', 'UC_VisaEBeam5', 'UC_VisaEBeam6', 'UC_VisaEBeam7', 'UC_VisaEBeam8', 'U_148Spectrometer', 'U_HamaSpectro']
+connected but not stamping: ['UC_BCaveMagSpecCam3', 'UC_GhostFocus', 'UC_GhostUpstream', 'U_Aline3Filter', 'U_BCaveICT', 'U_FROG_Grenouille', 'U_GhostWFS', 'U_HP_Daq', 'U_UndulatorExitICT', 'U_VacuumGauge', 'U_VisaPlungers']
+Trigger.Source before: 'External rising edges'
+OFF put completed in 155 ms
+--- 6 s in OFF: updates after the put, per device
+  UC_ALineEBeam2               1 upd: +0.05s new(+1.000)
+  UC_ALineEBeam3               1 upd: +0.05s new(+1.000)
+  UC_ALineEbeam1               1 upd: +0.02s new(+1.000)
+  UC_Amp2Depletion_South       1 upd: +0.02s new(+0.999)
+  UC_Amp2_IR_input             1 upd: +0.02s new(+0.999)
+  UC_Amp3_IR_input             1 upd: +0.19s new(+1.000)
+  UC_Amp4Depletion_South       1 upd: +0.05s new(+1.000)
+  UC_Amp4_IR_input             1 upd: +0.05s new(+1.000)
+  UC_Amp4_IR_output            1 upd: +0.09s new(+1.000)
+  UC_BCaveIn                   1 upd: +0.48s new(+1.000)
+  UC_BCaveMagSpecCam1          1 upd: +0.05s new(+1.000)
+  UC_BCaveMagSpecCam2          1 upd: +0.31s new(+2.000)
+  UC_ChicaneSlit               1 upd: +0.05s new(+1.000)
+  UC_DMSurface                 1 upd: +0.16s new(+1.000)
+  UC_DiagnosticsPhosphor       1 upd: +0.19s new(+1.000)
+  UC_ExpanderIn1               1 upd: +0.02s new(+0.999)
+  UC_ExpanderIn1_Pulsed        1 upd: +0.38s new(+1.000)
+  UC_FinalSteeringLeak         1 upd: +0.13s new(+0.999)
+  UC_GaiaMode                  1 upd: +0.05s new(+1.000)
+  UC_GratingMode               1 upd: +0.06s new(+1.000)
+  UC_ModeImager                1 upd: +0.19s new(+0.999)
+  UC_OAPin1                    1 upd: +0.11s new(+0.999)
+  UC_OAPin2                    1 upd: +0.26s new(+0.999)
+  UC_Phosphor1                 1 upd: +0.19s new(+1.000)
+  UC_Stretcher                 1 upd: +0.02s new(+1.000)
+  UC_Stretcher_MI              0 upd: (silent)
+  UC_TC_Output                 1 upd: +0.23s new(+1.000)
+  UC_TargetIn                  1 upd: +0.23s new(+1.000)
+  UC_TopView                   1 upd: +0.21s new(+1.000)
+  UC_TubeIn                    1 upd: +0.05s new(+0.999)
+  UC_UndulatorImagingSpec      1 upd: +0.05s new(+0.989)
+  UC_UndulatorRad2             1 upd: +0.05s new(+1.000)
+  UC_VisaEBeam1                1 upd: +0.02s new(+1.000)
+  UC_VisaEBeam2                1 upd: +0.02s new(+1.000)
+  UC_VisaEBeam3                1 upd: +0.02s new(+1.000)
+  UC_VisaEBeam4                1 upd: +0.02s new(+0.999)
+  UC_VisaEBeam5                1 upd: +0.02s new(+1.000)
+  UC_VisaEBeam6                1 upd: +0.02s new(+0.999)
+  UC_VisaEBeam7                1 upd: +0.02s new(+1.000)
+  UC_VisaEBeam8                1 upd: +0.02s new(+1.000)
+  U_148Spectrometer            1 upd: +0.02s new(+1.001)
+  U_HamaSpectro                1 upd: +0.05s new(+1.000)
+--- SINGLESHOT put completed in 203 ms; waiting 4 s for stamps
+  device                       arrival ms   stamp-min ms
+  UC_Stretcher_MI                     959           28.0
+  UC_VisaEBeam8                       997           37.0
+  UC_Stretcher                        998           44.0
+  U_148Spectrometer                   998            0.0
+  UC_VisaEBeam3                       998           57.0
+  UC_VisaEBeam6                       998           43.0
+  UC_VisaEBeam2                       998           57.0
+  UC_VisaEBeam5                       998           43.0
+  UC_VisaEBeam7                       998           43.0
+  UC_VisaEBeam4                       998           57.0
+  UC_VisaEBeam1                       998           62.0
+  UC_ALineEbeam1                      998           47.0
+  UC_ExpanderIn1                      998           60.0
+  UC_Amp2Depletion_South              998           47.0
+  UC_Amp2_IR_input                    998           53.0
+  UC_Amp4Depletion_South             1041           65.0
+  UC_UndulatorImagingSpec            1041           63.0
+  U_HamaSpectro                      1041            5.0
+  UC_UndulatorRad2                   1041           73.0
+  UC_ALineEBeam3                     1041           46.0
+  UC_BCaveMagSpecCam1                1041            9.0
+  UC_TubeIn                          1041           76.0
+  UC_Amp4_IR_input                   1041           66.0
+  UC_ChicaneSlit                     1041           61.0
+  UC_GaiaMode                        1041           72.0
+  UC_ALineEBeam2                     1041           44.0
+  UC_GratingMode                     1068           81.0
+  UC_Amp4_IR_output                  1091          104.0
+  UC_OAPin1                          1117          151.0
+  UC_FinalSteeringLeak               1177          178.0
+  UC_DMSurface                       1178          162.0
+  UC_ModeImager                      1178          160.0
+  UC_Phosphor1                       1178          151.0
+  UC_DiagnosticsPhosphor             1178          151.0
+  UC_Amp3_IR_input                   1178          104.0
+  UC_TopView                         1204          182.0
+  UC_TargetIn                        1226          177.0
+  UC_TC_Output                       1226          115.0
+  UC_OAPin2                          1270          220.0
+  UC_ExpanderIn1_Pulsed              1385           56.0
+  UC_BCaveIn                         1476           27.0
+  UC_BCaveMagSpecCam2                2478            8.0
+Trigger.Source restored: 'External rising edges'
+```

--- a/Planning/native_bluesky/04_phase0_measurements.md
+++ b/Planning/native_bluesky/04_phase0_measurements.md
@@ -193,3 +193,16 @@ per_step=geecs_per_step)` → finalize: STANDBY + restore the setpoint.
 **Verdict.** Phase 0 accepted. The three-logic split fits a GEECS camera
 without an areaDetector IOC; the strict `take_reading` is the only GEECS
 code in the scan path.
+
+## M3 — re-acceptance after the adversarial review (2026-09-10, Scan 001 of 26_0910)
+
+**Purpose.** Re-run M2's acceptance on the review-fixed code (#811 commit
+79f24fba: `ShotControl` pause bookkeeping and never-raise notifications,
+`CaAcqTimestampReadable` composing `GeecsAcquireLogic`, the
+`-nonscalar_save_path` contract column, `native_save`).
+
+**Result.** `1 passed in 27.7 s`: 3 + 5 events, stamps advancing once per
+shot (count 1.0 / 0.999 s; scan 2.0 s/step as in M2), readbacks
+−0.99984 … 0.99989 A, setpoint restored to 8e-05 A, 8 native PNGs in
+`Scan001/UC_Amp4_IR_input/` named by the rows' stamps, 24.4 s wall for 8
+shots. Same shape as M2 — the fixes changed no behaviour on the strict path.


### PR DESCRIPTION
Docs only. A handoff written at the end of the #809 session, proposing a different starting point for #807. It supersedes `00_overview.md`'s phase plan; nothing is deleted or changed in code.

## Why

#809 moved the GEECS scan preamble into a RunEngine preprocessor so that a stock `bluesky.plans` verb could run a full GEECS scan. It works on hardware (scans 63 and 64) and CI is green. It was then reviewed adversarially twice: sixteen findings, then five more on the fixes.

Twelve of the twenty-one have a single cause. **A scan is described twice** — once by the plan, as detectors and points, and once by the ScanRequest, as a save set and an axis list. The preprocessor's real job had quietly become reconciling the two descriptions, and each of those twelve findings is a missing reconciliation rule: the plan need not read what the save set saves, the request's shot count need not match the plan's, the request's positions need not match the plan's, telemetry is advertised but never read, long-lived devices keep the previous run's saving state, axes lose their catalog topology. Fixing them individually produces a reconciliation engine, and the parity test #809 added exists precisely to detect divergence between the two doors, which is a useful test and also an admission.

Sam's response, which this document records:

> save sets are really just readbacks […] and the scan variables just the settables with aliases. If you encounter a weird hack or workaround to accommodate save sets we should think, "what is a save set doing and how does Bluesky solve the same problem?"

and then the framing for the rebuild:

> start with the assumption that we *only* have our CA gateway, PVA gateway and bluesky/ophyd devices […] don't try to hold on to *anything* if it doesn't slot in completely cleanly

with the DB as source of truth and the s-files kept.

## What the document contains

- **The evidence** (§3): all twenty-one findings classified by cause, twelve as artifacts of the duplication and nine as real defects independent of the architecture. This is the part worth reading; a fresh session given only a target architecture will re-litigate the design.
- **The target** (§4) and **the mapping** (§5): every GEECS concept to its native replacement. Save set to the `detectors` argument. Trigger profile to a `FlyerController`. Strict and free-run to one fly implementation with different counts. Gate-2 windowing to the detector's open/close. `acq_timestamp` joins to StreamDatum indices. Scan folder to a `PathProvider`. ScanInfo to a start-document callback.
- **What stays GEECS** (§6): the DB roster, day-scoped scan numbering, the s-file format, ScanInfo, and PV naming. None of them is in the scan path. `ScanRequest` survives as the client-side record of intent the GUI needs.
- **Verified versus assumed** (§7): the API surface checked against the installed ophyd-async **0.19.3** and bluesky **1.15.0**, including two names that have moved (`FlyerController`, not `TriggerLogic`; no `DetectorWriter` under that name). Everything resting on #806 is marked assumed, because the fly design depends on the PVA gateway delivering indexed edge-triggered frames.
- **Sequencing** (§8): recommends **#806 before the rebuild**, which reverses the current ordering, and recommends **not merging #809**.

## What this implies for the open work

- **#808 survives unconditionally.** The device namespace is exactly the foundation the target needs, and it is already merged.
- **#809 should not merge.** It is scaffolding between two descriptions of one scan. Its two open P1 defects need no fix if it does not ship, and nothing from it is deployed — the worker is on master. Salvageable by hand: the document-parity test, `GeecsNamespace.select`'s role assertions, `plan_session.py`.
- **#806 moves to the front.**

The one thing the document flags as needing an answer before any deletion lands: operators scan daily through the funnel and the Console, so the rebuild has to run beside them rather than replace them in place.
