### PR TITLE
GeecsBluesky 0.78.0: phase 0 — one camera as a stock StandardDetector, ShotControl device, strict take_reading (#807)

### DIFF
--- a/GeecsBluesky/CHANGELOG.md
+++ b/GeecsBluesky/CHANGELOG.md
@@ -39,6 +39,19 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - `plans/single_shot.py` — the arm → fire → await → refire seam is
   `fire_and_await_shot`, called by `geecs_single_shot` (the funnel) and by
   `geecs_take_reading`: one implementation, two callers.
+- `devices/ca/triggerable.py` — `CaAcqTimestampReadable` / `CaTriggerable`
+  compose `GeecsAcquireLogic` for the stamp monitor, the synchronous
+  baseline and the shot wait instead of carrying their own copy (review of
+  #811); `_last_acq` / `_shot_queue` / `_monitoring` / `_trigger_timeout`
+  remain as views for the funnel-era callers.
+- `trigger_writes_from_profile` (TriggerProfile → `ShotControlWrites`) now
+  lives in `devices/shot_control.py` next to the device that consumes it;
+  `scan_request_runner` imports it from there.  `QUIESCE_FROM` (the
+  standing states a pause must quiesce from) has its one home in
+  `models/shot_control.py`; the device and `plans/pause_semantics.py` both
+  import it.
+- `ShotController._record_state` → `record_state` (public; the device
+  records through it so `last_state` is the one standing-state field).
 
 ## [0.77.0] - 2026-09-09
 

--- a/GeecsBluesky/CHANGELOG.md
+++ b/GeecsBluesky/CHANGELOG.md
@@ -41,6 +41,10 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - `plans/single_shot.py` — the arm → fire → await → refire seam is
   `fire_and_await_shot`, called by `geecs_single_shot` (the funnel) and by
   `geecs_take_reading`: one implementation, two callers.
+- The refire is gated on the failed status's cause being a detector's
+  `GeecsTriggerTimeoutError` (a dropped frame); a failed **fire** (the
+  SINGLESHOT put refused) or any other failed status re-raises untouched,
+  so a refire can never issue an extra physical shot (Codex review of #811).
 - `devices/ca/triggerable.py` — `CaAcqTimestampReadable` / `CaTriggerable`
   compose `GeecsAcquireLogic` for the stamp monitor, the synchronous
   baseline and the shot wait instead of carrying their own copy (review of

--- a/GeecsBluesky/CHANGELOG.md
+++ b/GeecsBluesky/CHANGELOG.md
@@ -4,6 +4,42 @@ All notable changes to `geecs-bluesky` are documented here.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.78.0] - 2026-09-09
+
+### Added
+
+- **Phase 0 of the native-Bluesky rebuild (#807, plan of record
+  `Planning/native_bluesky/03_clean_room_rebuild.md`):** a GEECS acquirer as
+  a stock ophyd-async `StandardDetector`.
+  - `devices/detector.py` — `GeecsDetector` composed of the three 0.19
+    logics: `GeecsTriggerLogic` (external edges only; the calibrated drain
+    offset is its one config signal and `get_deadtime`), `GeecsAcquireLogic`
+    (a shot is `acq_timestamp` advancing; the baseline is taken
+    synchronously in `trigger()` so the plan's fire can never land in a
+    blind window), `ScalarsDataLogic` (the device's own scalars as event
+    columns) and `LvNativeFileDataLogic` (LabVIEW native saving driven from
+    a `PathProvider`: `save=on` at prepare, `save=off` at stage and
+    unstage; the device directory is created only inside an existing scan
+    folder — a missing parent raises, never a `mkdir`).  A plain
+    `bp.count([cam])` is refused at prepare: a GEECS camera cannot
+    self-trigger.
+  - `devices/shot_control.py` — `ShotControl`, the trigger box as a
+    `Movable` over the profile's named states (ordered writes via the
+    existing `ShotController.from_writes`), `Pausable` (a no-op in ARMED;
+    SCAN → OFF and back), with the standing state as a config signal.
+  - `plans/strict.py` — `geecs_take_reading`, `bps.trigger_and_read` with
+    the one GEECS difference (the `SINGLESHOT` fire between the triggers
+    and the wait) plus the bounded refire; `geecs_per_shot` /
+    `geecs_per_step` bind it into the stock `one_shot` / `one_nd_step`
+    hooks, so `bp.count` and every N-d scan plan run strict GEECS scans
+    unchanged.
+
+### Changed
+
+- `plans/single_shot.py` — the arm → fire → await → refire seam is
+  `fire_and_await_shot`, called by `geecs_single_shot` (the funnel) and by
+  `geecs_take_reading`: one implementation, two callers.
+
 ## [0.77.0] - 2026-09-09
 
 ### Added

--- a/GeecsBluesky/CHANGELOG.md
+++ b/GeecsBluesky/CHANGELOG.md
@@ -21,8 +21,10 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
     a `PathProvider`: `save=on` at prepare, `save=off` at stage and
     unstage; the device directory is created only inside an existing scan
     folder — a missing parent raises, never a `mkdir`).  A plain
-    `bp.count([cam])` is refused at prepare: a GEECS camera cannot
-    self-trigger.
+    `bp.count([cam])` is refused at prepare — a GEECS camera cannot
+    self-trigger — unless `OPHYD_ASYNC_PRESERVE_DETECTOR_STATE=YES`, where
+    the implicit prepare takes the edge-triggered default and the shot
+    times out waiting for a fire nobody sends.
   - `devices/shot_control.py` — `ShotControl`, the trigger box as a
     `Movable` over the profile's named states (ordered writes via the
     existing `ShotController.from_writes`), `Pausable` (a no-op in ARMED;

--- a/GeecsBluesky/geecs_bluesky/devices/ca/triggerable.py
+++ b/GeecsBluesky/geecs_bluesky/devices/ca/triggerable.py
@@ -1,24 +1,15 @@
 """CA acq_timestamp-monitored readables: the shot-aware CA device bases.
 
 The GEECS shot signal is the device's ``acq_timestamp`` advancing once per
-shot.  A **persistent CA monitor** on that PV (started at ``connect()``,
-stopped by ``disconnect()``) feeds a local cache and a bounded drop-oldest
-event queue:
-
-* :class:`CaAcqTimestampReadable` — readable signals plus the monitor/cache
-  (``_last_acq``); free-run *contributors* build on this (no blocking trigger).
-* :class:`CaTriggerable` — adds ``trigger()``, which blocks until the queue
-  delivers a value different from the baseline.
-
-The stale-frame drain and baseline capture happen **synchronously inside**
-``trigger()`` so an immediately-fired shot cannot be missed — see
-:meth:`CaTriggerable.trigger`.  Design rationale: ``GeecsBluesky/CLAUDE.md``
-(Device Layer).
+acquisition.  The shot semantics — the persistent monitor, the synchronous
+baseline, the wait with the attributable timeout — live in **one** place,
+:class:`~geecs_bluesky.devices.detector.GeecsAcquireLogic`; these classes
+compose it so the funnel's readables keep working until the plan layer
+deletes them (#807 phase 1), and that deletion is purely subtractive.
 """
 
 from __future__ import annotations
 
-import asyncio
 import logging
 from collections.abc import Mapping
 from typing import Any
@@ -27,7 +18,7 @@ from ophyd_async.core import AsyncStatus, StandardReadable
 from ophyd_async.epics.core import epics_signal_r
 
 from geecs_bluesky.devices.ca._pv import ca_pv
-from geecs_bluesky.exceptions import GeecsTriggerTimeoutError
+from geecs_bluesky.devices.detector import GeecsAcquireLogic
 from geecs_bluesky.utils import safe_name
 
 logger = logging.getLogger(__name__)
@@ -37,10 +28,9 @@ class CaAcqTimestampReadable(StandardReadable):
     """Readable GEECS device over gateway PVs with a persistent shot monitor.
 
     One ``epics_signal_r`` child is created per data variable, plus an
-    ``acq_timestamp`` child that carries the shot stamp.  A monitor
-    subscription (started at ``connect()``, stopped by ``disconnect()``) keeps
-    ``_last_acq`` (latest value) and ``_shot_queue`` (bounded update stream)
-    current.
+    ``acq_timestamp`` child that carries the shot stamp; the stamp monitor
+    (started at ``connect()``, stopped by ``disconnect()``) is the composed
+    :class:`GeecsAcquireLogic`.
 
     A non-readable ``connected_status`` child reads the gateway's per-device
     liveness PV (``[Experiment:]Device:CONNECTED``): the authoritative
@@ -74,18 +64,12 @@ class CaAcqTimestampReadable(StandardReadable):
     _acq_timestamp_variable : str
         GEECS variable that advances per shot.  Default ``"acq_timestamp"``.
     _shot_queue_maxsize : int
-        Bound on the shot-update queue (default 128 — the worst case is
-        rep-rate × trigger-timeout updates between baseline and the awaited
-        get, i.e. 15 at the 5 Hz system limit, with a wide margin so the
-        bound never needs revisiting below ~40 Hz).  Only ``trigger()``
-        drains the queue, so an unbounded queue would grow one float per
-        machine shot on idle devices; overflow is drop-oldest and
-        correctness-preserving (any surviving post-baseline update passes
-        the ``!= t0`` shot test).
+        Bound on the shot-update queue (see :class:`GeecsAcquireLogic`).
     """
 
     _acq_timestamp_variable: str = "acq_timestamp"
     _shot_queue_maxsize: int = 128
+    _trigger_timeout_default: float = 3.0
 
     def __init__(
         self,
@@ -126,13 +110,12 @@ class CaAcqTimestampReadable(StandardReadable):
             str, ca_pv(experiment, device, "CONNECTED")
         )
         super().__init__(name=name)
-        # Persistent-monitor state (populated by _on_acq_timestamp): the latest
-        # seen value, and a bounded queue of updates trigger() waits on.
-        self._last_acq: float | None = None
-        self._shot_queue: asyncio.Queue[float] = asyncio.Queue(
-            maxsize=self._shot_queue_maxsize
+        self._acquire = GeecsAcquireLogic(
+            self.acq_timestamp,
+            device,
+            shot_timeout=self._trigger_timeout_default,
+            queue_maxsize=self._shot_queue_maxsize,
         )
-        self._monitoring = False
 
     async def connect(
         self,
@@ -144,120 +127,53 @@ class CaAcqTimestampReadable(StandardReadable):
         await super().connect(
             mock=mock, timeout=timeout, force_reconnect=force_reconnect
         )
-        if not self._monitoring:
-            self.acq_timestamp.subscribe_reading(self._on_acq_timestamp)
-            self._monitoring = True
+        self._acquire.attach()
 
     async def disconnect(self) -> None:
         """Stop the persistent ``acq_timestamp`` monitor and drop shot state.
 
         Per-scan teardown hook (the runner's ``session.disconnect`` cleanup).
-        Unsubscribing removes the signal cache's reference to this instance's
-        bound callback — without it every per-scan device object stays alive
-        and keeps enqueuing monitor updates for the rest of the process.
-
         Idempotent; ``connect()`` may be called again to resubscribe.
         """
-        if self._monitoring:
-            # SignalR.clear_sub removes the subscribe_reading callback; when
-            # no listeners remain it also drops the signal cache, closing the
-            # underlying CA monitor.
-            self.acq_timestamp.clear_sub(self._on_acq_timestamp)
-            self._monitoring = False
-        while not self._shot_queue.empty():
-            self._shot_queue.get_nowait()
-        self._last_acq = None
+        self._acquire.detach()
 
-    def _on_acq_timestamp(self, reading: dict[str, Any]) -> None:
-        """Monitor callback: cache the latest value and queue the update.
+    # Views onto the composed logic, kept for the funnel-era callers and
+    # tests (preflight's ``hasattr(d, "_last_acq")``, the trigger-timeout
+    # knob); they go with the funnel.
+    @property
+    def _last_acq(self) -> float | None:
+        return self._acquire.last_acq_timestamp
 
-        Non-positive values are ignored — ``0.0`` is the gateway channel's
-        pre-acquisition placeholder, so "never acquired" reads as ``None``.
-        The queue is a drop-oldest ring; this preserves ``trigger()``'s
-        no-blind-window guarantee: the queue is drained empty at baseline
-        capture, so anything dropped afterwards is older than a surviving
-        update, and every post-baseline update passes the ``!= t0`` shot
-        test.  Callback and consumers share the RE event loop, so the
-        two-step replace is race-free.
-        """
-        value = reading[self.acq_timestamp.name]["value"]
-        if value is None or value <= 0:
-            return
-        self._last_acq = value
-        try:
-            self._shot_queue.put_nowait(value)
-        except asyncio.QueueFull:
-            self._shot_queue.get_nowait()  # drop the oldest update
-            self._shot_queue.put_nowait(value)
+    @property
+    def _shot_queue(self):
+        return self._acquire.queue
+
+    @property
+    def _monitoring(self) -> bool:
+        return self._acquire.monitoring
+
+    @property
+    def _trigger_timeout(self) -> float:
+        return self._acquire.shot_timeout
+
+    @_trigger_timeout.setter
+    def _trigger_timeout(self, seconds: float) -> None:
+        self._acquire.shot_timeout = float(seconds)
 
 
 class CaTriggerable(CaAcqTimestampReadable):
     """A triggered GEECS detector whose ``trigger()`` waits for one real shot.
 
-    Parameters are those of :class:`CaAcqTimestampReadable`.
-
-    Class attributes subclasses may override
-    ----------------------------------------
-    _trigger_timeout : float
-        Seconds to wait for the next shot before raising
-        :exc:`~geecs_bluesky.exceptions.GeecsTriggerTimeoutError`.  Default 3.0.
+    Parameters are those of :class:`CaAcqTimestampReadable`; the per-shot
+    wait is ``_trigger_timeout`` seconds (default 3.0).
     """
-
-    _trigger_timeout: float = 3.0
 
     def trigger(self) -> AsyncStatus:
         """Return a status that completes once ``acq_timestamp`` has advanced.
 
-        The stale-update drain and baseline capture happen synchronously
-        *here*, not in the returned coroutine — so a shot fired immediately
-        after this call (the strict single-shot pattern) can never land in a
-        blind window and be missed (pinned by a mock race test).  The drain
-        can never discard a real requested shot: nothing fires before
-        ``trigger()`` returns.
+        The baseline is taken synchronously *here* so a shot fired
+        immediately after this call (the strict single-shot pattern) can
+        never land in a blind window.
         """
-        t0 = self._last_acq
-        while not self._shot_queue.empty():
-            self._shot_queue.get_nowait()
-        return AsyncStatus(self._wait_for_shot(t0))
-
-    async def _wait_for_shot(self, t0: float | None) -> None:
-        """Wait for the next monitor update carrying a new ``acq_timestamp``.
-
-        Cold-cache path (``t0 is None``): deliberately **no CA-get baseline**
-        — a baseline get raced the shot itself (a first acquisition landing
-        inside the get's round-trip became the baseline and the strict single
-        shot timed out).  ``trigger()`` already drained anything older, so on
-        a cold cache the first positive arrival *is* the shot.
-        """
-        logger.debug(
-            "%s: waiting for %s to advance past %s (timeout=%.1fs)",
-            self._geecs_device_name,
-            self._acq_timestamp_variable,
-            t0,
-            self._trigger_timeout,
-        )
-
-        loop = asyncio.get_running_loop()
-        deadline = loop.time() + self._trigger_timeout
-        while True:
-            remaining = deadline - loop.time()
-            if remaining <= 0:
-                raise GeecsTriggerTimeoutError(
-                    self._geecs_device_name, self._trigger_timeout
-                )
-            try:
-                value = await asyncio.wait_for(
-                    self._shot_queue.get(), timeout=remaining
-                )
-            except asyncio.TimeoutError:
-                raise GeecsTriggerTimeoutError(
-                    self._geecs_device_name, self._trigger_timeout
-                ) from None
-            if value != t0:
-                logger.debug(
-                    "%s: shot detected (%s → %s)",
-                    self._geecs_device_name,
-                    t0,
-                    value,
-                )
-                return
+        self._acquire.baseline()
+        return AsyncStatus(self._acquire.wait_for_idle())

--- a/GeecsBluesky/geecs_bluesky/devices/detector.py
+++ b/GeecsBluesky/geecs_bluesky/devices/detector.py
@@ -20,9 +20,12 @@ ophyd-async 0.19 composes a detector from three logics
 
 Every per-run fact about the device is set through its own lifecycle —
 ``stage → prepare → trigger → unstage`` — never from outside it (§3, the
-second leg).  A plain ``bp.count([cam])`` is refused with a clear error: a
-GEECS camera cannot self-trigger, so the fire must come from the plan
-(:mod:`geecs_bluesky.plans.strict`).
+second leg).  A plain ``bp.count([cam])`` is refused at prepare: a GEECS
+camera cannot self-trigger, so the fire must come from the plan
+(:mod:`geecs_bluesky.plans.strict`).  (With
+``OPHYD_ASYNC_PRESERVE_DETECTOR_STATE=YES`` ophyd-async takes
+:meth:`GeecsTriggerLogic.default_trigger_info` instead and the implicit
+prepare succeeds — the shot then times out waiting for a fire nobody sends.)
 """
 
 from __future__ import annotations
@@ -142,19 +145,32 @@ class GeecsAcquireLogic(DetectorAcquireLogic):
         device_name: str,
         *,
         shot_timeout: float = 3.0,
+        queue_maxsize: int | None = None,
     ) -> None:
         self._signal = acq_timestamp
         self._device = device_name
         self.shot_timeout = shot_timeout
         self._last: float | None = None
         self._t0: float | None = None
-        self._queue: asyncio.Queue[float] = asyncio.Queue(maxsize=self._queue_maxsize)
+        self._queue: asyncio.Queue[float] = asyncio.Queue(
+            maxsize=queue_maxsize or self._queue_maxsize
+        )
         self._monitoring = False
 
     @property
     def last_acq_timestamp(self) -> float | None:
         """Latest stamp seen by the monitor (``None`` before the first shot)."""
         return self._last
+
+    @property
+    def queue(self) -> asyncio.Queue[float]:
+        """The bounded drop-oldest queue of stamp updates (drained by ``baseline``)."""
+        return self._queue
+
+    @property
+    def monitoring(self) -> bool:
+        """Whether the persistent stamp monitor is attached."""
+        return self._monitoring
 
     def attach(self) -> None:
         """Start the persistent stamp monitor (from the detector's ``connect``)."""
@@ -194,7 +210,13 @@ class GeecsAcquireLogic(DetectorAcquireLogic):
         """Nothing to start: LabVIEW is always acquiring; the plan fires the box."""
 
     async def wait_for_idle(self) -> None:
-        """Wait for the stamp to advance past the baseline."""
+        """Wait for the stamp to advance past the baseline.
+
+        Cold cache (baseline ``None``, no update since the monitor attached):
+        deliberately **no** CA-get baseline — a get raced the shot itself, so
+        the first positive arrival *is* the shot; ``baseline()`` already
+        drained anything older.
+        """
         loop = asyncio.get_running_loop()
         deadline = loop.time() + self.shot_timeout
         while True:
@@ -208,6 +230,7 @@ class GeecsAcquireLogic(DetectorAcquireLogic):
                     self._device, self.shot_timeout
                 ) from None
             if value != self._t0:
+                logger.debug("%s: shot (%s → %s)", self._device, self._t0, value)
                 return
 
     async def ensure_stopped(self) -> None:
@@ -258,6 +281,14 @@ class _ConstantProvider(ReadableDataProvider):
         }
 
 
+class _NoProvider(ReadableDataProvider):
+    async def make_datakeys(self) -> dict[str, DataKey]:
+        return {}
+
+    async def make_readings(self) -> dict[str, Reading]:
+        return {}
+
+
 class LvNativeFileDataLogic(DetectorDataLogic):
     """LabVIEW's native file saving as the detector's data logic.
 
@@ -269,6 +300,11 @@ class LvNativeFileDataLogic(DetectorDataLogic):
     provider; closed (``save=off``) by :meth:`stop`, which ``stage`` and
     ``unstage`` both call, so a stale ``save=on`` left by a crash is switched
     off before the next run writes anywhere.
+
+    A camera whose frames are **not** wanted this run still carries the
+    logic (``native_save=True`` on the detector, no path provider): a
+    ``save=on`` left by a crash would otherwise write today's shots into
+    yesterday's folder (found live 26_0828) — so ``stage`` always clears it.
 
     The device directory is created with ``mkdir(exist_ok=True)`` **inside an
     existing scan folder** only — the scan folder itself is claimed by the
@@ -286,13 +322,16 @@ class LvNativeFileDataLogic(DetectorDataLogic):
         share path); defaults to the config.ini mapping.
     """
 
-    datakey_suffix = "-save_path"
+    #: The column name is the event-schema contract (``EVENT_SCHEMA.md``,
+    #: ``geecs_data_utils.tiled_schema.COMPANION_SUFFIXES``): renaming it is
+    #: a contract change that travels with those files, not a detector edit.
+    datakey_suffix = "-nonscalar_save_path"
 
     def __init__(
         self,
         localsavingpath: SignalRW[str],
         save: SignalRW[str],
-        path_provider: PathProvider,
+        path_provider: PathProvider | None,
         *,
         device_path: Callable[[str], str] = device_server_save_path,
     ) -> None:
@@ -303,7 +342,14 @@ class LvNativeFileDataLogic(DetectorDataLogic):
         self.directory: Path | None = None
 
     async def prepare_single(self, datakey_name: str) -> ReadableDataProvider:
-        """Point the device at this run's directory and switch saving on."""
+        """Point the device at this run's directory and switch saving on.
+
+        Without a path provider the device records scalars only: saving
+        stays off (``stop`` already cleared a stale flag at ``stage``) and no
+        column is produced.
+        """
+        if self._path_provider is None:
+            return _NoProvider()
         info = self._path_provider(datakey_name)
         directory = Path(info.directory_path)
         if not directory.parent.is_dir():
@@ -343,8 +389,13 @@ class GeecsDetector(StandardDetector):
         ``float`` otherwise.
     path_provider :
         When given, the device saves its native files there
-        (:class:`LvNativeFileDataLogic`); without it the detector records
-        scalars only.
+        (:class:`LvNativeFileDataLogic`).
+    native_save :
+        The device has ``localsavingpath``/``save`` controls.  Implied by
+        *path_provider*; set it without one for a camera whose frames are
+        not wanted this run, so a stale ``save=on`` is still cleared at
+        ``stage`` (see :class:`LvNativeFileDataLogic`).  Without either the
+        detector records scalars only.
     shot_timeout :
         Seconds to wait for the stamp after a fire.
     """
@@ -358,6 +409,7 @@ class GeecsDetector(StandardDetector):
         name: str = "",
         datatypes: Mapping[str, type | None] | None = None,
         path_provider: PathProvider | None = None,
+        native_save: bool = False,
         shot_timeout: float = 3.0,
     ) -> None:
         self._geecs_device_name = device
@@ -389,7 +441,7 @@ class GeecsDetector(StandardDetector):
             self._acquire,
             ScalarsDataLogic((*scalars, self.acq_timestamp)),
         ]
-        if path_provider is not None:
+        if native_save or path_provider is not None:
             path_pv = ca_pv(experiment, device, "localsavingpath")
             save_pv = ca_pv(experiment, device, "save")
             self.localsavingpath = epics_signal_rw(str, path_pv, setpoint_pv(path_pv))

--- a/GeecsBluesky/geecs_bluesky/devices/detector.py
+++ b/GeecsBluesky/geecs_bluesky/devices/detector.py
@@ -1,0 +1,463 @@
+"""GeecsDetector — a GEECS acquirer as a stock ophyd-async ``StandardDetector``.
+
+ophyd-async 0.19 composes a detector from three logics
+(``Planning/native_bluesky/03_clean_room_rebuild.md`` §4.A, §7):
+
+- :class:`GeecsTriggerLogic` — external edges only.  The DG645 fires,
+  LabVIEW acquires; there is nothing to program.  Its one config signal is
+  the calibrated **drain offset**, the per-device constant between the edge
+  and the stamp (§11.4), which ``get_deadtime`` returns so a plan can budget
+  the per-shot wait.
+- :class:`GeecsAcquireLogic` — the GEECS shot contract: a shot **is**
+  ``acq_timestamp`` advancing (§11.3).  LabVIEW is always acquiring, so
+  ``start_acquiring``/``ensure_stopped`` are no-ops; what this logic owns is
+  the wait, and the synchronous baseline that makes the wait exact.
+- data logics — :class:`ScalarsDataLogic` reads the device's own scalar
+  variables into the event row; :class:`LvNativeFileDataLogic` drives
+  LabVIEW's native file saving (``localsavingpath`` / ``save``) from a
+  ``PathProvider``.  #806 swaps the second for the stock
+  ``ADHDFDataLogic`` over the PVA-gateway plugin; the other two survive it.
+
+Every per-run fact about the device is set through its own lifecycle —
+``stage → prepare → trigger → unstage`` — never from outside it (§3, the
+second leg).  A plain ``bp.count([cam])`` is refused with a clear error: a
+GEECS camera cannot self-trigger, so the fire must come from the plan
+(:mod:`geecs_bluesky.plans.strict`).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from collections.abc import Callable, Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+from bluesky.protocols import Reading
+from event_model import DataKey
+from ophyd_async.core import (
+    DEFAULT_TIMEOUT,
+    AsyncStatus,
+    DetectorAcquireLogic,
+    DetectorDataLogic,
+    DetectorTrigger,
+    DetectorTriggerLogic,
+    PathProvider,
+    ReadableDataProvider,
+    SignalDict,
+    SignalR,
+    SignalRW,
+    StandardDetector,
+    TriggerInfo,
+    merge_gathered_dicts,
+    soft_signal_rw,
+)
+from ophyd_async.epics.core import epics_signal_r, epics_signal_rw
+
+from geecs_bluesky.data_paths import device_server_save_path
+from geecs_bluesky.devices.ca._pv import ca_pv, setpoint_pv
+from geecs_bluesky.exceptions import GeecsTriggerTimeoutError
+from geecs_bluesky.utils import safe_name
+
+logger = logging.getLogger(__name__)
+
+#: The GEECS shot stamp variable (generated inside LabVIEW, not a DB row yet).
+ACQ_TIMESTAMP = "acq_timestamp"
+
+#: How a strict shot prepares a GeecsDetector: one externally edge-triggered
+#: event.  The plan fires the box; the detector waits for its stamp.
+STRICT_TRIGGER_INFO = TriggerInfo(
+    trigger=DetectorTrigger.EXTERNAL_EDGE, number_of_events=1
+)
+
+
+class GeecsTriggerLogic(DetectorTriggerLogic):
+    """External edges only; the drain offset is the one configuration value.
+
+    Parameters
+    ----------
+    drain_offset :
+        Signal carrying the device's edge-to-stamp latency in seconds
+        (calibrated once, §4.F; ``0.0`` until then).
+    """
+
+    def __init__(self, drain_offset: SignalR[float]) -> None:
+        self.drain_offset = drain_offset
+
+    def config_sigs(self) -> set[SignalR]:
+        """The drain offset rides in ``read_configuration`` (every descriptor)."""
+        return {self.drain_offset}
+
+    def get_deadtime(self, config_values: SignalDict) -> float:
+        """Edge-to-stamp latency: the per-shot budget a plan adds to the period."""
+        return float(config_values[self.drain_offset])
+
+    async def prepare_edge(self, num: int, livetime: float) -> None:
+        """Nothing to program: LabVIEW acquires on every edge it receives.
+
+        The count is the plan's business; exposure is a camera setting, not a
+        per-scan livetime, so a non-zero *livetime* is refused.
+        """
+        if livetime:
+            raise ValueError(
+                "a GEECS camera's exposure is a device setting (set it as a "
+                "scan action), not a per-scan TriggerInfo livetime"
+            )
+
+    async def default_trigger_info(self) -> TriggerInfo:
+        """The truthful hardware state: externally edge-triggered, one event."""
+        return STRICT_TRIGGER_INFO
+
+
+class GeecsAcquireLogic(DetectorAcquireLogic):
+    """A shot is ``acq_timestamp`` advancing past the baseline.
+
+    The stamp PV is monitored from ``connect`` on (:meth:`attach`); updates
+    land in a bounded drop-oldest queue.  :meth:`baseline` — called
+    **synchronously** from :meth:`GeecsDetector.trigger` — records the
+    latest stamp and drains the queue, so a shot fired immediately after the
+    trigger message can never fall in a blind window (pinned by a mock race
+    test).  :meth:`wait_for_idle`, which ``StandardDetector.trigger`` awaits
+    after the plan's fire, returns on the first update that differs from the
+    baseline or raises :exc:`GeecsTriggerTimeoutError`.
+
+    Parameters
+    ----------
+    acq_timestamp :
+        The device's stamp signal.
+    device_name :
+        GEECS device name, for the timeout error.
+    shot_timeout :
+        Seconds to wait for the stamp after a fire.  The hardware budget is
+        one trigger period (the single shot fires on the *next* external
+        edge) plus the device's exposure and drain (§7, M1).
+    """
+
+    _queue_maxsize: int = 128
+
+    def __init__(
+        self,
+        acq_timestamp: SignalR[float],
+        device_name: str,
+        *,
+        shot_timeout: float = 3.0,
+    ) -> None:
+        self._signal = acq_timestamp
+        self._device = device_name
+        self.shot_timeout = shot_timeout
+        self._last: float | None = None
+        self._t0: float | None = None
+        self._queue: asyncio.Queue[float] = asyncio.Queue(maxsize=self._queue_maxsize)
+        self._monitoring = False
+
+    @property
+    def last_acq_timestamp(self) -> float | None:
+        """Latest stamp seen by the monitor (``None`` before the first shot)."""
+        return self._last
+
+    def attach(self) -> None:
+        """Start the persistent stamp monitor (from the detector's ``connect``)."""
+        if not self._monitoring:
+            self._signal.subscribe_reading(self._on_update)
+            self._monitoring = True
+
+    def detach(self) -> None:
+        """Stop the monitor and forget the shot state (``disconnect``)."""
+        if self._monitoring:
+            self._signal.clear_sub(self._on_update)
+            self._monitoring = False
+        self._drain()
+        self._last = None
+
+    def _on_update(self, reading: dict[str, Any]) -> None:
+        value = reading[self._signal.name]["value"]
+        if value is None or value <= 0:
+            return  # 0.0 is the gateway's pre-acquisition placeholder
+        self._last = value
+        try:
+            self._queue.put_nowait(value)
+        except asyncio.QueueFull:
+            self._queue.get_nowait()  # drop the oldest update
+            self._queue.put_nowait(value)
+
+    def _drain(self) -> None:
+        while not self._queue.empty():
+            self._queue.get_nowait()
+
+    def baseline(self) -> None:
+        """Record the current stamp and drop stale updates — synchronously."""
+        self._t0 = self._last
+        self._drain()
+
+    async def start_acquiring(self) -> None:
+        """Nothing to start: LabVIEW is always acquiring; the plan fires the box."""
+
+    async def wait_for_idle(self) -> None:
+        """Wait for the stamp to advance past the baseline."""
+        loop = asyncio.get_running_loop()
+        deadline = loop.time() + self.shot_timeout
+        while True:
+            remaining = deadline - loop.time()
+            if remaining <= 0:
+                raise GeecsTriggerTimeoutError(self._device, self.shot_timeout)
+            try:
+                value = await asyncio.wait_for(self._queue.get(), timeout=remaining)
+            except asyncio.TimeoutError:
+                raise GeecsTriggerTimeoutError(
+                    self._device, self.shot_timeout
+                ) from None
+            if value != self._t0:
+                return
+
+    async def ensure_stopped(self) -> None:
+        """Nothing to stop: acquisition is LabVIEW's, saving is the data logic's."""
+
+
+class _SignalsProvider(ReadableDataProvider):
+    """Read a fixed set of signals into the event row."""
+
+    def __init__(self, signals: Sequence[SignalR]) -> None:
+        self._signals = tuple(signals)
+
+    async def make_datakeys(self) -> dict[str, DataKey]:
+        return await merge_gathered_dicts(sig.describe() for sig in self._signals)
+
+    async def make_readings(self) -> dict[str, Reading]:
+        return await merge_gathered_dicts(sig.read() for sig in self._signals)
+
+
+class ScalarsDataLogic(DetectorDataLogic):
+    """The device's own scalar variables (and its stamp) as event columns."""
+
+    def __init__(self, signals: Sequence[SignalR]) -> None:
+        self._signals = tuple(signals)
+
+    async def prepare_single(self, datakey_name: str) -> ReadableDataProvider:
+        """One reading per event: the signals' current values."""
+        return _SignalsProvider(self._signals)
+
+
+class _ConstantProvider(ReadableDataProvider):
+    def __init__(self, datakey_name: str, value: str) -> None:
+        self._key = datakey_name
+        self._value = value
+
+    async def make_datakeys(self) -> dict[str, DataKey]:
+        return {
+            self._key: DataKey(
+                source=f"derived://{self._key}", dtype="string", shape=[]
+            )
+        }
+
+    async def make_readings(self) -> dict[str, Reading]:
+        return {
+            self._key: Reading(
+                value=self._value, timestamp=time.time(), alarm_severity=0
+            )
+        }
+
+
+class LvNativeFileDataLogic(DetectorDataLogic):
+    """LabVIEW's native file saving as the detector's data logic.
+
+    The device writes its own files (one per shot, named with the stamp —
+    ``geecs_data_utils.native_files``) once ``localsavingpath`` points at a
+    directory and ``save`` is on.  There is no write-complete readback
+    (§10.1), so the provider is a per-event reading — the save directory —
+    and files join to rows by stamp.  Opened in ``prepare`` from the path
+    provider; closed (``save=off``) by :meth:`stop`, which ``stage`` and
+    ``unstage`` both call, so a stale ``save=on`` left by a crash is switched
+    off before the next run writes anywhere.
+
+    The device directory is created with ``mkdir(exist_ok=True)`` **inside an
+    existing scan folder** only — the scan folder itself is claimed by the
+    scanner (root ``CLAUDE.md``, "Analysis code is a consumer of scan
+    folders"); a missing parent is an error here, never a ``mkdir``.
+
+    Parameters
+    ----------
+    localsavingpath, save :
+        The device's two save controls (gateway readback + ``:SP``).
+    path_provider :
+        Where this run's files go; called with the datakey name.
+    device_path :
+        Worker path → the path the device server understands (the Windows
+        share path); defaults to the config.ini mapping.
+    """
+
+    datakey_suffix = "-save_path"
+
+    def __init__(
+        self,
+        localsavingpath: SignalRW[str],
+        save: SignalRW[str],
+        path_provider: PathProvider,
+        *,
+        device_path: Callable[[str], str] = device_server_save_path,
+    ) -> None:
+        self._localsavingpath = localsavingpath
+        self._save = save
+        self._path_provider = path_provider
+        self._device_path = device_path
+        self.directory: Path | None = None
+
+    async def prepare_single(self, datakey_name: str) -> ReadableDataProvider:
+        """Point the device at this run's directory and switch saving on."""
+        info = self._path_provider(datakey_name)
+        directory = Path(info.directory_path)
+        if not directory.parent.is_dir():
+            raise FileNotFoundError(
+                f"{directory.parent} does not exist: the scan folder is claimed "
+                "by the scanner, never created by a detector"
+            )
+        directory.mkdir(exist_ok=True)
+        await self._localsavingpath.set(self._device_path(str(directory)))
+        await self._save.set("on")
+        self.directory = directory
+        logger.info("%s: native saving on → %s", datakey_name, directory)
+        return _ConstantProvider(datakey_name, str(directory))
+
+    async def stop(self) -> None:
+        """Switch saving off (``stage`` and ``unstage`` both call this)."""
+        await self._save.set("off")
+        self.directory = None
+
+
+class GeecsDetector(StandardDetector):
+    """One GEECS acquirer (camera, spectrometer, scope) as a StandardDetector.
+
+    Parameters
+    ----------
+    device :
+        GEECS device name (``"UC_Amp4_IR_input"``).
+    variables :
+        Scalar variables to read into the event row (the DB's subscribed
+        set).  ``acq_timestamp`` is always present as its own child.
+    experiment :
+        Experiment PV-namespace prefix.
+    name :
+        ophyd-async device name (event keys are ``<name>-<variable>``).
+    datatypes :
+        Per-variable CA datatypes (DB-derived), keyed by variable name;
+        ``float`` otherwise.
+    path_provider :
+        When given, the device saves its native files there
+        (:class:`LvNativeFileDataLogic`); without it the detector records
+        scalars only.
+    shot_timeout :
+        Seconds to wait for the stamp after a fire.
+    """
+
+    def __init__(
+        self,
+        device: str,
+        variables: Sequence[str],
+        *,
+        experiment: str | None = None,
+        name: str = "",
+        datatypes: Mapping[str, type | None] | None = None,
+        path_provider: PathProvider | None = None,
+        shot_timeout: float = 3.0,
+    ) -> None:
+        self._geecs_device_name = device
+        per_variable = {k.lower(): v for k, v in (datatypes or {}).items()}
+        scalars: list[SignalR] = []
+        for var in variables:
+            if var.lower() == ACQ_TIMESTAMP:
+                continue
+            signal = epics_signal_r(
+                per_variable.get(var.lower(), float), ca_pv(experiment, device, var)
+            )
+            setattr(self, safe_name(var), signal)
+            scalars.append(signal)
+        self.acq_timestamp = epics_signal_r(
+            float, ca_pv(experiment, device, ACQ_TIMESTAMP)
+        )
+        # The gateway's per-device liveness PV: never an event column, read by
+        # the refire gate to tell a dropped frame from a dead device.
+        self.connected_status = epics_signal_r(
+            str, ca_pv(experiment, device, "CONNECTED")
+        )
+        self.drain_offset = soft_signal_rw(float, 0.0, units="s")
+        self._scalars = tuple(scalars)
+        self._acquire = GeecsAcquireLogic(
+            self.acq_timestamp, device, shot_timeout=shot_timeout
+        )
+        logics: list[Any] = [
+            GeecsTriggerLogic(self.drain_offset),
+            self._acquire,
+            ScalarsDataLogic((*scalars, self.acq_timestamp)),
+        ]
+        if path_provider is not None:
+            path_pv = ca_pv(experiment, device, "localsavingpath")
+            save_pv = ca_pv(experiment, device, "save")
+            self.localsavingpath = epics_signal_rw(str, path_pv, setpoint_pv(path_pv))
+            self.save = epics_signal_rw(str, save_pv, setpoint_pv(save_pv))
+            logics.append(
+                LvNativeFileDataLogic(self.localsavingpath, self.save, path_provider)
+            )
+        self.add_detector_logics(*logics)
+        super().__init__(name=name)
+        # Legacy "Device Variable" headers for the Tiled → s-file exporter.
+        self._column_headers = {
+            f"{self.name}-{safe_name(var)}": f"{device} {var}"
+            for var in variables
+            if var.lower() != ACQ_TIMESTAMP
+        }
+        self._column_headers[f"{self.name}-{ACQ_TIMESTAMP}"] = (
+            f"{device} {ACQ_TIMESTAMP}"
+        )
+
+    @property
+    def last_acq_timestamp(self) -> float | None:
+        """Latest stamp seen by the persistent monitor."""
+        return self._acquire.last_acq_timestamp
+
+    async def connect(
+        self,
+        mock: Any = False,
+        timeout: float = DEFAULT_TIMEOUT,
+        force_reconnect: bool = False,
+    ) -> None:
+        """Connect every signal, then start the stamp monitor."""
+        await super().connect(
+            mock=mock, timeout=timeout, force_reconnect=force_reconnect
+        )
+        self._acquire.attach()
+
+    async def disconnect(self) -> None:
+        """Stop the stamp monitor; the signals drop their caches with it."""
+        self._acquire.detach()
+
+    @AsyncStatus.wrap
+    async def stage(self) -> None:
+        """Stage the scalar signals (monitor-backed reads), then the detector.
+
+        Staged signals read from their monitor cache: one CA get per column
+        per shot was the 0.7 s/row regression (``GeecsBluesky/CLAUDE.md``,
+        "Read path: staging & shot coherence").
+        """
+        await asyncio.gather(
+            *(sig.stage() for sig in (*self._scalars, self.acq_timestamp))
+        )
+        await super().stage()
+
+    @AsyncStatus.wrap
+    async def unstage(self) -> None:
+        """Unstage the detector (saving off), then release the signal caches."""
+        await super().unstage()
+        await asyncio.gather(
+            *(sig.unstage() for sig in (*self._scalars, self.acq_timestamp))
+        )
+
+    def trigger(self) -> AsyncStatus:
+        """Baseline the stamp **now**, then wait for it to advance.
+
+        The baseline must happen before this returns: the plan's very next
+        message is the fire, and a stamp that lands before an asynchronous
+        baseline would be counted as the pre-shot value and the real shot
+        missed.
+        """
+        self._acquire.baseline()
+        return super().trigger()

--- a/GeecsBluesky/geecs_bluesky/devices/shot_control.py
+++ b/GeecsBluesky/geecs_bluesky/devices/shot_control.py
@@ -1,0 +1,155 @@
+"""ShotControl — the trigger box as an ophyd-async device.
+
+One device, the protocols Bluesky already has for it
+(``Planning/native_bluesky/03_clean_room_rebuild.md`` §4.A):
+
+- **Movable** over the profile's named states: ``bps.mv(shot_control,
+  "ARMED")`` replays that state's ordered ``(device, variable, value)``
+  writes, each completing before the next (the TriggerProfile semantics).
+  ``"SINGLESHOT"`` is the momentary fire — a move that never becomes the
+  standing state.
+- **Pausable**, state-dependent (§10.3): in strict mode the RunEngine
+  pausing simply stops the plan firing and the box stays ``ARMED``, so
+  ``pause()`` does nothing; in gated mode edges flow on their own, so
+  ``pause()`` drives ``OFF`` and ``resume()`` restores ``SCAN``.  The
+  RunEngine calls both on every Pausable it has seen in a message
+  (bluesky 1.15.0 ``run_engine.py``), so being the ``set`` target is
+  enough to be paused.
+
+The write machinery is :class:`~geecs_bluesky.shot_controller.ShotController`
+(``from_writes``: one cached gateway ``:SP`` put per distinct target, the
+hardware-proven stringified-wire convention) — composed, not copied.  The
+standing state is a config signal, so every descriptor records which state
+the box was in.
+"""
+
+from __future__ import annotations
+
+import logging
+from enum import Enum
+from typing import Any, Callable
+
+from geecs_schemas.trigger_profile import TriggerProfile, TriggerState
+from ophyd_async.core import (
+    AsyncStatus,
+    StandardReadable,
+    StandardReadableFormat,
+    soft_signal_r_and_setter,
+)
+
+from geecs_bluesky.exceptions import GeecsConfigurationError
+from geecs_bluesky.models.shot_control import ShotControlWrites
+from geecs_bluesky.shot_controller import ShotController
+
+logger = logging.getLogger(__name__)
+
+
+class ShotControl(StandardReadable):
+    """The trigger box: ``Movable`` over its named states, ``Pausable``.
+
+    Parameters
+    ----------
+    writes :
+        Per-state ordered write lists (the adapted TriggerProfile).
+    experiment :
+        Experiment PV-namespace prefix for the gateway ``:SP`` puts.
+    name :
+        ophyd-async device name.
+    put_timeout :
+        CA put budget per write (each put completes when GEECS accepts the
+        set).
+    setter_factory :
+        ``factory(device, variable) → object with async put(value)``
+        override — tests inject recording setters; hardware uses the
+        default gateway puts.
+    """
+
+    def __init__(
+        self,
+        writes: ShotControlWrites,
+        *,
+        experiment: str | None = None,
+        name: str = "",
+        put_timeout: float = 10.0,
+        setter_factory: Callable[[str, str], Any] | None = None,
+    ) -> None:
+        self._writes = writes
+        self._controller = ShotController.from_writes(
+            writes,
+            experiment=experiment,
+            put_timeout=put_timeout,
+            setter_factory=setter_factory,
+        )
+        with self.add_children_as_readables(StandardReadableFormat.CONFIG_SIGNAL):
+            # The last *standing* state driven (never SINGLESHOT); "" until
+            # the first move.
+            self.state, self._set_state = soft_signal_r_and_setter(str, "")
+        self._resume_to: TriggerState | None = None
+        super().__init__(name=name)
+
+    @classmethod
+    def from_profile(
+        cls, profile: TriggerProfile, *, experiment: str | None = None, **kwargs: Any
+    ) -> ShotControl:
+        """Build from a TriggerProfile (the configs-repo document)."""
+        # Deferred: the adapter lives with the request runner until the plan
+        # layer relocates it (phase 1); importing it there is the one copy.
+        from geecs_bluesky.scan_request_runner import trigger_writes_from_profile
+
+        return cls(
+            trigger_writes_from_profile(profile), experiment=experiment, **kwargs
+        )
+
+    @property
+    def profile_name(self) -> str:
+        """The adapted profile's name (log/error messages)."""
+        return self._writes.name
+
+    def defines(self, state: str | TriggerState) -> bool:
+        """Whether the profile writes anything for *state*."""
+        return self._controller.defines_state(_state(state).value)
+
+    @property
+    def standing_state(self) -> str:
+        """The last standing state driven, ``""`` before the first move."""
+        return self._standing
+
+    _standing: str = ""
+
+    @AsyncStatus.wrap
+    async def set(self, value: str | TriggerState) -> None:
+        """Drive the box to *value*: that state's writes, in order."""
+        await self._drive(_state(value))
+
+    async def _drive(self, state: TriggerState) -> None:
+        setters = self._controller.state_setters(state.value)
+        if not setters:
+            raise GeecsConfigurationError(
+                f"trigger profile {self.profile_name!r} defines no writes for "
+                f"{state.value}; it cannot drive the box there"
+            )
+        for setter, value in setters:
+            await setter.put(value)
+        if state is not TriggerState.SINGLESHOT:
+            self._standing = state.value
+            self._set_state(state.value)
+
+    async def pause(self) -> None:
+        """Stop edges on a RunEngine pause only if they flow on their own (SCAN)."""
+        if self._standing == TriggerState.SCAN.value:
+            self._resume_to = TriggerState.SCAN
+            logger.info("%s: pause — SCAN → OFF", self.name)
+            await self._drive(TriggerState.OFF)
+
+    async def resume(self) -> None:
+        """Restore, on RunEngine resume, the state ``pause`` left."""
+        if self._resume_to is not None:
+            state, self._resume_to = self._resume_to, None
+            logger.info("%s: resume — → %s", self.name, state.value)
+            await self._drive(state)
+
+
+def _state(value: str | TriggerState) -> TriggerState:
+    if isinstance(value, Enum):
+        return TriggerState(value.value)
+    return TriggerState(str(value).upper())

--- a/GeecsBluesky/geecs_bluesky/devices/shot_control.py
+++ b/GeecsBluesky/geecs_bluesky/devices/shot_control.py
@@ -8,19 +8,26 @@ One device, the protocols Bluesky already has for it
   writes, each completing before the next (the TriggerProfile semantics).
   ``"SINGLESHOT"`` is the momentary fire — a move that never becomes the
   standing state.
-- **Pausable**, state-dependent (§10.3): in strict mode the RunEngine
-  pausing simply stops the plan firing and the box stays ``ARMED``, so
-  ``pause()`` does nothing; in gated mode edges flow on their own, so
-  ``pause()`` drives ``OFF`` and ``resume()`` restores ``SCAN``.  The
-  RunEngine calls both on every Pausable it has seen in a message
-  (bluesky 1.15.0 ``run_engine.py``), so being the ``set`` target is
-  enough to be paused.
+- **Pausable**, keyed on the standing state (§10.3): ``ARMED`` (strict) is
+  quiescent by construction — the single-shot source cannot free-run — so
+  the RunEngine pausing simply stops the plan firing and ``pause()`` does
+  nothing.  ``SCAN`` and ``STANDBY`` both pass external edges
+  (:data:`~geecs_bluesky.models.shot_control.QUIESCE_FROM`; §11.1 — STANDBY is the machine's idle state, not a
+  quiet one), so a pause there drives ``OFF`` and ``resume()`` restores
+  what the plan had.  The RunEngine calls both on every Pausable it has
+  seen in a message (bluesky 1.15.0 ``run_engine.py``), so being the
+  ``set`` target is enough to be paused.  Neither notification ever raises:
+  an exception out of ``pause()`` aborts the run the operator meant to
+  pause, and out of ``resume()`` lands after the RunEngine has already
+  rewound — failures are logged loudly instead.
 
 The write machinery is :class:`~geecs_bluesky.shot_controller.ShotController`
 (``from_writes``: one cached gateway ``:SP`` put per distinct target, the
-hardware-proven stringified-wire convention) — composed, not copied.  The
-standing state is a config signal, so every descriptor records which state
-the box was in.
+hardware-proven stringified-wire convention) — composed, not copied — and
+its ``last_state`` is the one standing-state field; the ``state`` config
+signal mirrors it so every descriptor records which state the box was in.
+:func:`trigger_writes_from_profile` adapts the configs-repo
+``TriggerProfile`` into the controller's ``ShotControlWrites``.
 """
 
 from __future__ import annotations
@@ -38,10 +45,67 @@ from ophyd_async.core import (
 )
 
 from geecs_bluesky.exceptions import GeecsConfigurationError
-from geecs_bluesky.models.shot_control import ShotControlWrites
+from geecs_bluesky.models.shot_control import QUIESCE_FROM, ShotControlWrites
 from geecs_bluesky.shot_controller import ShotController
 
 logger = logging.getLogger(__name__)
+
+
+def _state_write_triples(
+    profile: TriggerProfile, state: TriggerState
+) -> list[tuple[str | None, str, str]]:
+    """Normalize one state's writes to ``(device, variable, value)`` triples.
+
+    Handles both TriggerProfile generations (single-device dict shape and
+    multi-device ordered write lists); order is preserved exactly
+    (schema-documented: writes apply top to bottom).
+    """
+    writes = profile.writes_for(state)
+    if isinstance(writes, dict):
+        device = getattr(profile, "device", None)
+        return [(device, variable, value) for variable, value in writes.items()]
+    triples: list[tuple[str | None, str, str]] = []
+    for write in writes:
+        if isinstance(write, dict):
+            triples.append((write["device"], write["variable"], write["value"]))
+        else:
+            triples.append((write.device, write.variable, write.value))
+    return triples
+
+
+def trigger_writes_from_profile(profile: TriggerProfile) -> ShotControlWrites:
+    """Adapt a TriggerProfile into the controller's ``ShotControlWrites``.
+
+    Each state becomes the profile's **ordered** write list (possibly
+    spanning several devices); the controller replays them sequentially,
+    each write completing before the next.
+
+    Raises
+    ------
+    GeecsConfigurationError
+        The profile writes no device at all.
+    """
+    states: dict[str, list[tuple[str, str, str]]] = {}
+    any_device = False
+    for state in TriggerState:
+        triples: list[tuple[str, str, str]] = []
+        for device, variable, value in _state_write_triples(profile, state):
+            if device is None:
+                raise GeecsConfigurationError(
+                    f"trigger profile {profile.name!r} has a write to "
+                    f"{variable!r} with no device — it cannot be sent"
+                )
+            triples.append((device, variable, value))
+            any_device = True
+        if triples:
+            states[state.value] = triples
+    if not any_device:
+        raise GeecsConfigurationError(
+            f"trigger profile {profile.name!r} names no trigger device — "
+            "it cannot drive a scan's trigger"
+        )
+    name = getattr(profile, "name", "") or ""
+    return ShotControlWrites(name=name, states=states)
 
 
 class ShotControl(StandardReadable):
@@ -81,10 +145,10 @@ class ShotControl(StandardReadable):
             setter_factory=setter_factory,
         )
         with self.add_children_as_readables(StandardReadableFormat.CONFIG_SIGNAL):
-            # The last *standing* state driven (never SINGLESHOT); "" until
-            # the first move.
+            # Mirrors the controller's last standing state (never SINGLESHOT);
+            # "" until the first move.
             self.state, self._set_state = soft_signal_r_and_setter(str, "")
-        self._resume_to: TriggerState | None = None
+        self._resume_to: str | None = None
         super().__init__(name=name)
 
     @classmethod
@@ -92,10 +156,6 @@ class ShotControl(StandardReadable):
         cls, profile: TriggerProfile, *, experiment: str | None = None, **kwargs: Any
     ) -> ShotControl:
         """Build from a TriggerProfile (the configs-repo document)."""
-        # Deferred: the adapter lives with the request runner until the plan
-        # layer relocates it (phase 1); importing it there is the one copy.
-        from geecs_bluesky.scan_request_runner import trigger_writes_from_profile
-
         return cls(
             trigger_writes_from_profile(profile), experiment=experiment, **kwargs
         )
@@ -106,20 +166,30 @@ class ShotControl(StandardReadable):
         return self._writes.name
 
     def defines(self, state: str | TriggerState) -> bool:
-        """Whether the profile writes anything for *state*."""
-        return self._controller.defines_state(_state(state).value)
+        """Whether the profile writes anything for *state* (``False`` for unknown names)."""
+        try:
+            name = _state(state).value
+        except GeecsConfigurationError:
+            return False
+        return self._controller.defines_state(name)
 
     @property
     def standing_state(self) -> str:
         """The last standing state driven, ``""`` before the first move."""
-        return self._standing
-
-    _standing: str = ""
+        return self._controller.last_state or ""
 
     @AsyncStatus.wrap
     async def set(self, value: str | TriggerState) -> None:
-        """Drive the box to *value*: that state's writes, in order."""
-        await self._drive(_state(value))
+        """Drive the box to *value*: that state's writes, in order.
+
+        A standing state the plan drives supersedes any pause bookkeeping:
+        a run stopped while paused must not make a later, unrelated resume
+        re-assert the state it was paused from.
+        """
+        state = _state(value)
+        await self._drive(state)
+        if state is not TriggerState.SINGLESHOT:
+            self._resume_to = None
 
     async def _drive(self, state: TriggerState) -> None:
         setters = self._controller.state_setters(state.value)
@@ -130,26 +200,57 @@ class ShotControl(StandardReadable):
             )
         for setter, value in setters:
             await setter.put(value)
-        if state is not TriggerState.SINGLESHOT:
-            self._standing = state.value
-            self._set_state(state.value)
+        self._controller.record_state(state.value)
+        self._set_state(self.standing_state)
 
     async def pause(self) -> None:
-        """Stop edges on a RunEngine pause only if they flow on their own (SCAN)."""
-        if self._standing == TriggerState.SCAN.value:
-            self._resume_to = TriggerState.SCAN
-            logger.info("%s: pause — SCAN → OFF", self.name)
+        """Stop edges on a RunEngine pause if the standing state lets them flow."""
+        try:
+            standing = self.standing_state
+            if standing not in QUIESCE_FROM:
+                logger.debug("%s: pause — %r needs no quiesce", self.name, standing)
+                return
+            if not self.defines(TriggerState.OFF):
+                logger.warning(
+                    "%s: trigger profile %r defines no OFF writes — paused with "
+                    "the trigger still free-running (add an OFF state)",
+                    self.name,
+                    self.profile_name,
+                )
+                return
+            self._resume_to = standing
             await self._drive(TriggerState.OFF)
+            logger.info("%s: pause — %s → OFF", self.name, standing)
+        except Exception:
+            logger.exception(
+                "%s: pause quiesce failed — the scan is paused but the trigger "
+                "may still be running",
+                self.name,
+            )
 
     async def resume(self) -> None:
         """Restore, on RunEngine resume, the state ``pause`` left."""
-        if self._resume_to is not None:
-            state, self._resume_to = self._resume_to, None
-            logger.info("%s: resume — → %s", self.name, state.value)
-            await self._drive(state)
+        standing, self._resume_to = self._resume_to, None
+        if standing is None:
+            return
+        try:
+            await self._drive(TriggerState(standing))
+            logger.info("%s: resume — → %s", self.name, standing)
+        except Exception:
+            logger.exception(
+                "%s: could not re-assert %s on resume — check the trigger",
+                self.name,
+                standing,
+            )
 
 
 def _state(value: str | TriggerState) -> TriggerState:
     if isinstance(value, Enum):
-        return TriggerState(value.value)
-    return TriggerState(str(value).upper())
+        value = value.value
+    try:
+        return TriggerState(str(value).upper())
+    except ValueError:
+        names = ", ".join(s.value for s in TriggerState)
+        raise GeecsConfigurationError(
+            f"{value!r} is not a trigger state (one of {names})"
+        ) from None

--- a/GeecsBluesky/geecs_bluesky/models/shot_control.py
+++ b/GeecsBluesky/geecs_bluesky/models/shot_control.py
@@ -123,6 +123,15 @@ class ShotControlConfig(BaseModel):
         }
 
 
+#: Standing states in which external edges reach the devices, so a RunEngine
+#: pause must drive OFF (SCAN and STANDBY both pass edges — STANDBY is the
+#: machine's idle state, not a quiet one).  ARMED/OFF are quiescent by
+#: construction.  Consumed by the ShotControl device and the pause quiescer.
+QUIESCE_FROM: frozenset[str] = frozenset(
+    {ShotControlState.SCAN.value, ShotControlState.STANDBY.value}
+)
+
+
 class ShotControlWrites(BaseModel):
     """Generalized shot control: per-state **ordered** multi-device write lists.
 
@@ -137,7 +146,7 @@ class ShotControlWrites(BaseModel):
 
     This model stays pure data (no hardware, no schema imports) so the
     trigger-profile adapter lives bluesky-side
-    (:func:`~geecs_bluesky.scan_request_runner.trigger_writes_from_profile`)
+    (:func:`~geecs_bluesky.devices.shot_control.trigger_writes_from_profile`)
     and callers can store either generation in one slot.
 
     Parameters

--- a/GeecsBluesky/geecs_bluesky/plans/pause_semantics.py
+++ b/GeecsBluesky/geecs_bluesky/plans/pause_semantics.py
@@ -100,7 +100,7 @@ __all__ = ["FAILED_MOVE_LOG_PREFIX", "QUIESCE_FROM", "ShotControlPauseQuiescer"]
 #: deliberately absent: strict mode's single-shot source cannot free-run, so
 #: the paused state is quiescent by construction (pinned by test).  OFF and
 #: None (never driven) are already stopped / not the scan's to touch.
-QUIESCE_FROM = frozenset({ShotControlState.SCAN.value, ShotControlState.STANDBY.value})
+from geecs_bluesky.models.shot_control import QUIESCE_FROM  # noqa: E402 — one home for the rule
 
 
 class ShotControlPauseQuiescer:

--- a/GeecsBluesky/geecs_bluesky/plans/pause_semantics.py
+++ b/GeecsBluesky/geecs_bluesky/plans/pause_semantics.py
@@ -87,7 +87,7 @@ from bluesky.utils import Msg
 # Re-exported from its historical home here; defined in the import-light
 # log_markers so stream-parsing clients (qs_client) never pull bluesky.
 from geecs_bluesky.log_markers import FAILED_MOVE_LOG_PREFIX
-from geecs_bluesky.models.shot_control import ShotControlState
+from geecs_bluesky.models.shot_control import QUIESCE_FROM, ShotControlState
 
 if TYPE_CHECKING:  # import-light on purpose: step_scan imports this module
     from geecs_bluesky.shot_controller import ShotController
@@ -95,12 +95,6 @@ if TYPE_CHECKING:  # import-light on purpose: step_scan imports this module
 logger = logging.getLogger(__name__)
 
 __all__ = ["FAILED_MOVE_LOG_PREFIX", "QUIESCE_FROM", "ShotControlPauseQuiescer"]
-
-#: Standing states the quiescer must stop the trigger from.  ARMED is
-#: deliberately absent: strict mode's single-shot source cannot free-run, so
-#: the paused state is quiescent by construction (pinned by test).  OFF and
-#: None (never driven) are already stopped / not the scan's to touch.
-from geecs_bluesky.models.shot_control import QUIESCE_FROM  # noqa: E402 — one home for the rule
 
 
 class ShotControlPauseQuiescer:

--- a/GeecsBluesky/geecs_bluesky/plans/scan_request_plan.py
+++ b/GeecsBluesky/geecs_bluesky/plans/scan_request_plan.py
@@ -82,6 +82,7 @@ from geecs_bluesky.scan_log import (
     log_claimed_scan_failure,
     scan_log,
 )
+from geecs_bluesky.devices.shot_control import trigger_writes_from_profile
 from geecs_bluesky.scan_request_runner import (
     PseudoMovableTarget,
     _build_request_detectors,
@@ -102,7 +103,6 @@ from geecs_bluesky.scan_request_runner import (
     resolve_movable_target,
     resolve_save_sets_and_rituals,
     save_set_to_devices_config,
-    trigger_writes_from_profile,
     validate_scan_request,
     warn_if_reserved_boundary_overrides,
 )

--- a/GeecsBluesky/geecs_bluesky/plans/single_shot.py
+++ b/GeecsBluesky/geecs_bluesky/plans/single_shot.py
@@ -95,21 +95,8 @@ def geecs_single_shot(
 ):
     """Fire one plan-owned shot and bundle all *devices* into one event.
 
-    If a triggered device produces no frame for a fire (the group wait fails
-    with :exc:`~bluesky.utils.FailedStatus`), the shot is re-fired up to
-    *max_refires* times before the failure propagates.  Strict semantics
-    survive refire: a failed attempt records nothing, and the next attempt's
-    ``trigger()`` re-baselines and drains any orphan frame
-    (:class:`~geecs_bluesky.devices.ca.triggerable.CaTriggerable`), so every
-    recorded row is one physical shot.  Refire — not a longer timeout — is
-    the recovery because a missed pulse never yields a frame (live-verified;
-    numbers in ``GeecsBluesky/CHANGELOG.md`` 0.20.0).
-
-    Refire is gated on gateway liveness: a frameless device whose
-    ``CONNECTED`` PV reads Disconnected went down mid-scan, so
-    :exc:`~geecs_bluesky.exceptions.GeecsDeviceDownError` is raised instead
-    of burning refires; a live or unreadable status (fail-open) keeps the
-    bounded-refire behavior.
+    The acquisition half is :func:`fire_and_await_shot`; this adds the event
+    bundling (``create`` / ``read`` / ``save``).
 
     Parameters
     ----------
@@ -125,6 +112,54 @@ def geecs_single_shot(
         Extra fire attempts after the first one fails (default 2, so at most
         three physical fires per recorded shot).  ``0`` restores the old
         hard-fail-on-first-miss behavior.
+
+    Yields
+    ------
+    Bluesky messages.
+    """
+    yield from fire_and_await_shot(devices, fire, max_refires=max_refires)
+    yield from bps.create(name)
+    for obj in devices:
+        yield from bps.read(obj)
+    yield from bps.save()
+
+
+def fire_and_await_shot(
+    devices: Sequence[Any],
+    fire: Callable,
+    *,
+    max_refires: int = 2,
+):
+    """Arm the waiters, fire one shot, and await the frames, with refire.
+
+    The strict acquisition seam, shared by :func:`geecs_single_shot` (the
+    funnel's shot) and :func:`~geecs_bluesky.plans.strict.geecs_take_reading`
+    (the stock plans' ``take_reading``) so the refire and the device-down
+    gating exist once.
+
+    If a triggered device produces no frame for a fire (the group wait fails
+    with :exc:`~bluesky.utils.FailedStatus`), the shot is re-fired up to
+    *max_refires* times before the failure propagates.  Strict semantics
+    survive refire: a failed attempt records nothing, and the next attempt's
+    ``trigger()`` re-baselines and drains any orphan frame, so every recorded
+    row is one physical shot.  Refire — not a longer timeout — is the
+    recovery because a missed pulse never yields a frame (live-verified;
+    numbers in ``GeecsBluesky/CHANGELOG.md`` 0.20.0).
+
+    Refire is gated on gateway liveness: a frameless device whose
+    ``CONNECTED`` PV reads Disconnected went down mid-scan, so
+    :exc:`~geecs_bluesky.exceptions.GeecsDeviceDownError` is raised instead
+    of burning refires; a live or unreadable status (fail-open) keeps the
+    bounded-refire behavior.
+
+    Parameters
+    ----------
+    devices:
+        The devices of the shot.  Triggerable ones are armed and awaited.
+    fire:
+        Plan-stub callable emitting exactly one trigger.
+    max_refires:
+        Extra fire attempts after the first fails.
 
     Yields
     ------
@@ -178,11 +213,7 @@ def geecs_single_shot(
                 device_name,
             )
         else:
-            break
-    yield from bps.create(name)
-    for obj in devices:
-        yield from bps.read(obj)
-    yield from bps.save()
+            return
 
 
 def geecs_confirm_quiescent(

--- a/GeecsBluesky/geecs_bluesky/plans/single_shot.py
+++ b/GeecsBluesky/geecs_bluesky/plans/single_shot.py
@@ -39,20 +39,6 @@ from geecs_bluesky.exceptions import (
 logger = logging.getLogger(__name__)
 
 
-def _no_frame_device(exc: BaseException) -> str:
-    """Name the device that produced no frame, from a wait failure.
-
-    The RunEngine wraps the status's own error in
-    :exc:`~bluesky.utils.FailedStatus` (``raise FailedStatus(ret) from exc``),
-    so the device-attributed :exc:`GeecsTriggerTimeoutError` rides on
-    ``__cause__``.
-    """
-    cause = exc.__cause__
-    if isinstance(cause, GeecsTriggerTimeoutError):
-        return cause.device_name
-    return "unknown device"
-
-
 def _confirm_device_down(devices: Sequence[Any], device_name: str):
     """Plan: ``True`` iff the named device's gateway ``CONNECTED`` PV says down.
 
@@ -187,14 +173,20 @@ def fire_and_await_shot(
                     len(triggerables),
                 )
         except FailedStatus as exc:
-            # No cancellation of abandoned statuses is needed: the RunEngine
-            # stashes a late FailedStatus and throws it into the plan at the
-            # next yield, but co-missing devices share the same ~3 s deadline
-            # so the stash is consumed right here at the wait; a straggler
-            # that lands inside the next attempt is caught by this same try
-            # (it wraps the whole attempt: trigger + fire + wait) and merely
-            # consumes one refire instead of aborting the scan.
-            device_name = _no_frame_device(exc)
+            # Only a detector's no-frame timeout is a dropped frame.  A failed
+            # *fire* (the SINGLESHOT put refused or ambiguous) or any other
+            # failed status is not, and re-firing on it could issue extra
+            # physical shots — re-raise those untouched (Codex review of
+            # #811).  No cancellation of abandoned statuses is needed: the
+            # RunEngine stashes a late FailedStatus and throws it into the
+            # plan at the next yield, but co-missing devices share the same
+            # deadline so the stash is consumed right here at the wait; a
+            # straggler that lands inside the next attempt is caught by this
+            # same try and merely consumes one refire.
+            cause = exc.__cause__
+            if not isinstance(cause, GeecsTriggerTimeoutError):
+                raise
+            device_name = cause.device_name
             down = yield from _confirm_device_down(devices, device_name)
             if down:
                 raise GeecsDeviceDownError(

--- a/GeecsBluesky/geecs_bluesky/plans/strict.py
+++ b/GeecsBluesky/geecs_bluesky/plans/strict.py
@@ -1,0 +1,117 @@
+"""Strict single-shot acquisition as the stock ``take_reading`` hook.
+
+``bps.one_shot`` (``bp.count``'s ``per_shot``) and ``bps.one_nd_step`` (the
+scan plans' ``per_step``) take a ``take_reading`` callable whose default is
+``bps.trigger_and_read``.  A GEECS camera acquires only when the trigger box
+fires, so the one thing GEECS changes is **where the fire goes**: between
+the triggers and the wait.  :func:`geecs_take_reading` is
+``trigger_and_read`` with that one difference plus the bounded refire
+(``Planning/native_bluesky/03_clean_room_rebuild.md`` §4.B, §11.5 — why
+free-running edges are not an exact substitute).
+
+Everything else is the stock plan: ``bp.list_scan(dets, motor, points,
+per_step=geecs_per_step(shot_control))`` moves, checkpoints, rewinds and
+records run metadata exactly as it does for any other detector.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from functools import partial
+from typing import Any, Callable
+
+import bluesky.plan_stubs as bps
+from bluesky.preprocessors import contingency_wrapper, rewindable_wrapper
+from bluesky.utils import all_safe_rewind, separate_devices, short_uid
+from geecs_schemas.trigger_profile import TriggerState
+from ophyd_async.core import StandardDetector
+
+from geecs_bluesky.devices.detector import STRICT_TRIGGER_INFO
+from geecs_bluesky.plans.single_shot import fire_and_await_shot
+
+
+def geecs_take_reading(
+    shot_control: Any,
+    *,
+    max_refires: int = 2,
+    name: str = "primary",
+) -> Callable[[Sequence[Any]], Any]:
+    """Return a ``take_reading`` that fires the trigger box between trigger and wait.
+
+    Parameters
+    ----------
+    shot_control :
+        The :class:`~geecs_bluesky.devices.shot_control.ShotControl` device;
+        the fire is ``bps.mv(shot_control, "SINGLESHOT")``.
+    max_refires :
+        Extra fire attempts after a no-frame wait (see
+        :func:`~geecs_bluesky.plans.single_shot.fire_and_await_shot`).
+    name :
+        Event stream name.
+
+    Returns
+    -------
+    callable
+        ``take_reading(devices)`` — a plan yielding one event row.
+    """
+    fire = partial(bps.mv, shot_control, TriggerState.SINGLESHOT.value)
+
+    def take_reading(devices: Sequence[Any]):
+        devices = separate_devices(devices)
+        rewindable = all_safe_rewind(devices)
+
+        def inner():
+            # A GEECS detector is edge-triggered only, so the implicit
+            # prepare inside trigger() (INTERNAL) would be refused; prepare
+            # it for one externally triggered event.  Idempotent per
+            # detector: the providers are reused and the edge setup is a
+            # no-op, so repeating it per shot costs a few soft-signal awaits.
+            group = short_uid("prepare")
+            detectors = [d for d in devices if isinstance(d, StandardDetector)]
+            for det in detectors:
+                yield from bps.prepare(
+                    det, STRICT_TRIGGER_INFO, group=group, wait=False
+                )
+            if detectors:
+                yield from bps.wait(group=group)
+            yield from fire_and_await_shot(devices, fire, max_refires=max_refires)
+            yield from bps.create(name)
+
+            def read_plan():
+                ret: dict[str, Any] = {}
+                for obj in devices:
+                    reading = yield from bps.read(obj)
+                    if reading is not None:
+                        ret.update(reading)
+                return ret
+
+            def standard_path():
+                yield from bps.save()
+
+            def exception_path(exp):
+                yield from bps.drop()
+                raise exp
+
+            return (
+                yield from contingency_wrapper(
+                    read_plan(), except_plan=exception_path, else_plan=standard_path
+                )
+            )
+
+        return (yield from rewindable_wrapper(inner(), rewindable))
+
+    return take_reading
+
+
+def geecs_per_shot(shot_control: Any, **kwargs: Any) -> Callable[..., Any]:
+    """``bp.count(..., per_shot=geecs_per_shot(shot_control))``."""
+    return partial(
+        bps.one_shot, take_reading=geecs_take_reading(shot_control, **kwargs)
+    )
+
+
+def geecs_per_step(shot_control: Any, **kwargs: Any) -> Callable[..., Any]:
+    """``bp.scan(..., per_step=geecs_per_step(shot_control))`` (any N-d scan plan)."""
+    return partial(
+        bps.one_nd_step, take_reading=geecs_take_reading(shot_control, **kwargs)
+    )

--- a/GeecsBluesky/geecs_bluesky/scan_request_runner.py
+++ b/GeecsBluesky/geecs_bluesky/scan_request_runner.py
@@ -10,9 +10,11 @@ here.  They
 - union the named save sets into one effective SaveSet — the per-device
   union rule is documented on :func:`merge_save_sets`; everything downstream
   (devices config, telemetry exclusion, boundary warning) sees the merged set;
-- adapt schemas to engine shapes (:func:`save_set_to_devices_config`,
-  :func:`trigger_writes_from_profile`) — adapters live bluesky-side because
-  ``geecs_schemas`` must never import ``geecs_bluesky``;
+- adapt schemas to engine shapes (:func:`save_set_to_devices_config`; the
+  trigger-profile adapter is
+  :func:`geecs_bluesky.devices.shot_control.trigger_writes_from_profile`) —
+  adapters live bluesky-side because ``geecs_schemas`` must never import
+  ``geecs_bluesky``;
 - assemble and compile action slots in §4.4b nesting order
   (:func:`assemble_action_slots`), with fail-fast pre-claim name resolution
   and every plan signal prefetched (:func:`prefetch_action_signals`);

--- a/GeecsBluesky/geecs_bluesky/scan_request_runner.py
+++ b/GeecsBluesky/geecs_bluesky/scan_request_runner.py
@@ -69,7 +69,7 @@ from geecs_bluesky.exceptions import (
     GeecsUnservedVariablesError,
 )
 from geecs_bluesky.forward_expr import CompiledForward, compile_forward
-from geecs_bluesky.models.shot_control import ShotControlWrites
+from geecs_bluesky.devices.shot_control import trigger_writes_from_profile
 from geecs_bluesky.plans.action_compiler import compile_action_plan
 from geecs_bluesky.preflight import run_unserved_variables_check
 from geecs_schemas import (
@@ -83,8 +83,6 @@ from geecs_schemas import (
     ScanRequestMode,
     ScanVariable,
     ScanVariableSpec,
-    TriggerProfile,
-    TriggerState,
 )
 from geecs_schemas.action_plan import CheckStep, RunPlanStep, SetStep
 
@@ -99,68 +97,6 @@ logger = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 # Schema → engine-shape adapters
 # ---------------------------------------------------------------------------
-
-
-def _state_write_triples(
-    profile: TriggerProfile, state: "TriggerState"
-) -> list[tuple[str | None, str, str]]:
-    """Normalize one state's writes to ``(device, variable, value)`` triples.
-
-    Handles both TriggerProfile generations (single-device dict shape and
-    multi-device ordered write lists); order is preserved exactly
-    (schema-documented: writes apply top to bottom).
-    """
-    writes = profile.writes_for(state)
-    if isinstance(writes, dict):
-        device = getattr(profile, "device", None)
-        return [(device, variable, value) for variable, value in writes.items()]
-    triples: list[tuple[str | None, str, str]] = []
-    for write in writes:
-        if isinstance(write, dict):
-            triples.append((write["device"], write["variable"], write["value"]))
-        else:
-            triples.append((write.device, write.variable, write.value))
-    return triples
-
-
-def trigger_writes_from_profile(profile: TriggerProfile) -> ShotControlWrites:
-    """Adapt a TriggerProfile into the engine's ShotControlWrites.
-
-    Each state becomes the profile's **ordered** write list (possibly
-    spanning several devices); ``ShotController.from_writes`` replays them
-    sequentially, each write completing before the next.
-
-    Parameters
-    ----------
-    profile :
-        The trigger profile to adapt.
-
-    Raises
-    ------
-    GeecsConfigurationError
-        The profile writes no device at all.
-    """
-    states: dict[str, list[tuple[str, str, str]]] = {}
-    any_device = False
-    for state in TriggerState:
-        triples: list[tuple[str, str, str]] = []
-        for device, variable, value in _state_write_triples(profile, state):
-            if device is None:
-                raise GeecsConfigurationError(
-                    f"trigger profile {profile.name!r} has a write to "
-                    f"{variable!r} with no device — it cannot be sent"
-                )
-            triples.append((device, variable, value))
-            any_device = True
-        if triples:
-            states[state.value] = triples
-    if not any_device:
-        raise GeecsConfigurationError(
-            f"trigger profile {profile.name!r} names no trigger device — "
-            "it cannot drive a scan's trigger"
-        )
-    name = getattr(profile, "name", "") or ""
-    return ShotControlWrites(name=name, states=states)
 
 
 def save_set_to_devices_config(

--- a/GeecsBluesky/geecs_bluesky/shot_controller.py
+++ b/GeecsBluesky/geecs_bluesky/shot_controller.py
@@ -212,7 +212,7 @@ class ShotController:
                 yield from bps.abs_set(setter, value, group=group)
                 yield from bps.wait(group)
             if ordered:
-                self._record_state(name)
+                self.record_state(name)
                 logger.info("Shot controller → %s", name)
             return
         group = f"shot_ctrl_{state}"
@@ -223,7 +223,7 @@ class ShotController:
                 yield from bps.abs_set(setter, val, group=group)
         if writes:
             yield from bps.wait(group)
-            self._record_state(state)
+            self.record_state(state)
             logger.info("Shot controller → %s", state)
 
     def state_setters(self, state: str | ShotControlState) -> list[tuple[Any, str]]:
@@ -247,7 +247,7 @@ class ShotController:
             if var in self._setters
         ]
 
-    def _record_state(self, state: str | ShotControlState) -> None:
+    def record_state(self, state: str | ShotControlState) -> None:
         """Remember *state* as :attr:`last_state` if it is a standing state.
 
         ``SINGLESHOT`` is a momentary fire, not a standing state — recording

--- a/GeecsBluesky/pyproject.toml
+++ b/GeecsBluesky/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-bluesky"
-version = "0.77.0"
+version = "0.78.0"
 description = "Bluesky / ophyd-async bridge for the GEECS control system"
 authors = ["Sam Barber <sbarber@lbl.gov>"]
 readme = "README.md"

--- a/GeecsBluesky/tests/test_geecs_detector.py
+++ b/GeecsBluesky/tests/test_geecs_detector.py
@@ -1,0 +1,238 @@
+"""GeecsDetector — the GEECS acquirer as a stock StandardDetector (phase 0, #807).
+
+Device-level contracts on mock CA backends: the synchronous baseline that
+makes the shot wait exact, the timeout, the native-saving data logic's
+lifecycle and its scan-folder invariant, and the configuration the detector
+reports.  The plan-level behaviour is in ``test_strict_plans.py``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("aioca")  # CA backend needs the `ca` extra
+
+from bluesky import RunEngine  # noqa: E402
+from bluesky.utils import FailedStatus  # noqa: E402
+from ophyd_async.core import (  # noqa: E402
+    DetectorTrigger,
+    StaticFilenameProvider,
+    StaticPathProvider,
+    TriggerInfo,
+    set_mock_value,
+)
+
+from geecs_bluesky.devices.detector import (  # noqa: E402
+    STRICT_TRIGGER_INFO,
+    GeecsDetector,
+)
+from geecs_bluesky.exceptions import GeecsTriggerTimeoutError  # noqa: E402
+from tests.ca_mock_helpers import connect_mock  # noqa: E402
+
+
+async def _watch(signal, sink: list) -> None:
+    """Subscribe (on the loop) and collect every value the signal reports."""
+    signal.subscribe(lambda reading: sink.append(reading[signal.name]["value"]))
+
+
+def _run(RE: RunEngine, make_awaitable):
+    """Call *make_awaitable* inside the RE loop and await what it returns.
+
+    Device methods wrapped in ``AsyncStatus`` create their task at call time,
+    so the call itself must happen on the running loop.
+    """
+
+    async def call():
+        return await make_awaitable()
+
+    return asyncio.run_coroutine_threadsafe(call(), RE._loop).result(timeout=10.0)
+
+
+@pytest.fixture
+def RE() -> RunEngine:
+    return RunEngine()
+
+
+def _camera(RE: RunEngine, tmp_path: Path | None = None, **kwargs) -> GeecsDetector:
+    path_provider = None
+    if tmp_path is not None:
+        path_provider = StaticPathProvider(
+            StaticFilenameProvider("frame"), tmp_path / "Scan001" / "UC_TestCam"
+        )
+    cam = GeecsDetector(
+        "UC_TestCam",
+        ["MeanCounts", "MaxCounts", "acq_timestamp"],
+        experiment="TestExp",
+        name="uc_testcam",
+        path_provider=path_provider,
+        **kwargs,
+    )
+    connect_mock(RE, cam)
+    set_mock_value(cam.acq_timestamp, 1000.0)
+    return cam
+
+
+def test_children_and_headers(RE: RunEngine) -> None:
+    """Scalars, the stamp and liveness are children; headers map back to GEECS names."""
+    cam = _camera(RE)
+    assert cam.meancounts.name == "uc_testcam-meancounts"
+    assert cam.acq_timestamp.name == "uc_testcam-acq_timestamp"
+    assert cam.connected_status.name == "uc_testcam-connected_status"
+    assert cam._column_headers == {
+        "uc_testcam-meancounts": "UC_TestCam MeanCounts",
+        "uc_testcam-maxcounts": "UC_TestCam MaxCounts",
+        "uc_testcam-acq_timestamp": "UC_TestCam acq_timestamp",
+    }
+    # No path provider → no save controls, scalars only.
+    assert not hasattr(cam, "save")
+
+
+def test_only_external_edges_are_supported(RE: RunEngine) -> None:
+    """A GEECS camera cannot self-trigger: INTERNAL is refused at prepare."""
+    cam = _camera(RE)
+    assert cam._supported_triggers == {DetectorTrigger.EXTERNAL_EDGE}
+    with pytest.raises(ValueError, match="not supported"):
+        _run(RE, lambda: cam.prepare(TriggerInfo(trigger=DetectorTrigger.INTERNAL)))
+    with pytest.raises(ValueError, match="exposure"):
+        _run(
+            RE,
+            lambda: cam.prepare(
+                TriggerInfo(trigger=DetectorTrigger.EXTERNAL_EDGE, livetime=0.5)
+            ),
+        )
+
+
+def test_trigger_waits_for_the_stamp_to_advance(RE: RunEngine) -> None:
+    """trigger() completes only when acq_timestamp changes; the row carries it."""
+    cam = _camera(RE)
+    set_mock_value(cam.meancounts, 7.0)
+    _run(RE, lambda: cam.stage())
+    _run(RE, lambda: cam.prepare(STRICT_TRIGGER_INFO))
+
+    async def shot():
+        status = cam.trigger()
+        await asyncio.sleep(0.05)
+        assert not status.done  # nothing fired yet
+        set_mock_value(cam.acq_timestamp, 1001.0)  # the shot
+        await status
+        return await cam.read()
+
+    reading = _run(RE, lambda: shot())
+    assert reading["uc_testcam-acq_timestamp"]["value"] == 1001.0
+    assert reading["uc_testcam-meancounts"]["value"] == 7.0
+    _run(RE, lambda: cam.unstage())
+
+
+def test_baseline_is_taken_synchronously_in_trigger(RE: RunEngine) -> None:
+    """A shot landing right after trigger() returns is the awaited shot (no blind window).
+
+    The fire is the plan's very next message; with an asynchronous baseline a
+    stamp arriving before the coroutine's first step would be read as the
+    pre-shot value and the real shot missed.  Pinned here by firing
+    synchronously, before the event loop runs the trigger task at all.
+    """
+    cam = _camera(RE)
+    _run(RE, lambda: cam.stage())
+    _run(RE, lambda: cam.prepare(STRICT_TRIGGER_INFO))
+
+    async def race():
+        status = cam.trigger()
+        set_mock_value(cam.acq_timestamp, 1001.0)  # fires before any await
+        await asyncio.wait_for(status, timeout=1.0)
+
+    _run(RE, lambda: race())
+
+
+def test_no_shot_raises_the_attributable_timeout(RE: RunEngine) -> None:
+    """No stamp within shot_timeout → GeecsTriggerTimeoutError naming the device."""
+    cam = _camera(RE, shot_timeout=0.2)
+    _run(RE, lambda: cam.stage())
+    _run(RE, lambda: cam.prepare(STRICT_TRIGGER_INFO))
+    with pytest.raises(GeecsTriggerTimeoutError) as info:
+        _run(RE, lambda: cam.trigger())
+    assert info.value.device_name == "UC_TestCam"
+    assert "FailedStatus" not in type(info.value).__name__
+
+
+def test_stale_updates_before_trigger_are_not_a_shot(RE: RunEngine) -> None:
+    """Stamps that arrived before trigger() are drained; only a newer one counts."""
+    cam = _camera(RE)
+    _run(RE, lambda: cam.stage())
+    _run(RE, lambda: cam.prepare(STRICT_TRIGGER_INFO))
+    set_mock_value(cam.acq_timestamp, 1001.0)
+    set_mock_value(cam.acq_timestamp, 1002.0)
+
+    async def shot():
+        status = cam.trigger()  # baseline = 1002.0, queue drained
+        await asyncio.sleep(0.05)
+        assert not status.done
+        set_mock_value(cam.acq_timestamp, 1003.0)
+        await status
+
+    _run(RE, lambda: shot())
+
+
+def test_native_saving_lifecycle(RE: RunEngine, tmp_path: Path) -> None:
+    """prepare → dir created, path + save=on; stop/unstage → save=off."""
+    (tmp_path / "Scan001").mkdir()
+    cam = _camera(RE, tmp_path)
+    seen: list[str] = []
+    _run(RE, lambda: _watch(cam.save, seen))
+
+    _run(RE, lambda: cam.stage())  # eager save-off: a stale flag is cleared first
+    assert _run(RE, lambda: cam.save.get_value()) == "off"
+    _run(RE, lambda: cam.prepare(STRICT_TRIGGER_INFO))
+    directory = tmp_path / "Scan001" / "UC_TestCam"
+    assert directory.is_dir()
+    assert _run(RE, lambda: cam.save.get_value()) == "on"
+    # The device-side path: the config.ini mapping is not loaded under test,
+    # so the worker path passes through unchanged.
+    assert _run(RE, lambda: cam.localsavingpath.get_value()) == str(directory)
+    describe = _run(RE, lambda: cam.describe())
+    assert describe["uc_testcam-save_path"]["dtype"] == "string"
+    _run(RE, lambda: cam.unstage())
+    assert _run(RE, lambda: cam.save.get_value()) == "off"
+    assert seen[-1] == "off"
+
+
+def test_native_saving_never_creates_the_scan_folder(
+    RE: RunEngine, tmp_path: Path
+) -> None:
+    """A missing scan folder is an error, never a mkdir (the analysis-side invariant)."""
+    cam = _camera(RE, tmp_path)  # tmp_path/Scan001 does NOT exist
+    _run(RE, lambda: cam.stage())
+    with pytest.raises(FileNotFoundError, match="claimed by the scanner"):
+        _run(RE, lambda: cam.prepare(STRICT_TRIGGER_INFO))
+    assert not (tmp_path / "Scan001").exists()
+
+
+def test_drain_offset_is_configuration(RE: RunEngine) -> None:
+    """The calibrated drain offset rides in read_configuration."""
+    cam = _camera(RE)
+    _run(RE, lambda: cam.drain_offset.set(0.066))
+    config = _run(RE, lambda: cam.read_configuration())
+    assert config["uc_testcam-drain_offset"]["value"] == pytest.approx(0.066)
+    triggers, deadtime = _run(RE, lambda: cam.get_trigger_deadtime())
+    assert triggers == {DetectorTrigger.EXTERNAL_EDGE}
+    assert deadtime == pytest.approx(0.066)
+
+
+def test_failed_status_carries_the_geecs_error(RE: RunEngine) -> None:
+    """Through the RunEngine a no-frame wait surfaces as FailedStatus ← GeecsTriggerTimeoutError."""
+    import bluesky.plan_stubs as bps
+
+    cam = _camera(RE, shot_timeout=0.2)
+
+    def plan():
+        # stage() is asynchronous and resets the prepare context: wait for
+        # it, as the stock stage_wrapper does, or the prepare races it.
+        yield from bps.stage(cam, wait=True)
+        yield from bps.prepare(cam, STRICT_TRIGGER_INFO, wait=True)
+        yield from bps.trigger(cam, wait=True)
+
+    with pytest.raises(FailedStatus) as info:
+        RE(plan())
+    assert isinstance(info.value.__cause__, GeecsTriggerTimeoutError)

--- a/GeecsBluesky/tests/test_geecs_detector.py
+++ b/GeecsBluesky/tests/test_geecs_detector.py
@@ -192,7 +192,7 @@ def test_native_saving_lifecycle(RE: RunEngine, tmp_path: Path) -> None:
     # so the worker path passes through unchanged.
     assert _run(RE, lambda: cam.localsavingpath.get_value()) == str(directory)
     describe = _run(RE, lambda: cam.describe())
-    assert describe["uc_testcam-save_path"]["dtype"] == "string"
+    assert describe["uc_testcam-nonscalar_save_path"]["dtype"] == "string"
     _run(RE, lambda: cam.unstage())
     assert _run(RE, lambda: cam.save.get_value()) == "off"
     assert seen[-1] == "off"
@@ -236,3 +236,25 @@ def test_failed_status_carries_the_geecs_error(RE: RunEngine) -> None:
     with pytest.raises(FailedStatus) as info:
         RE(plan())
     assert isinstance(info.value.__cause__, GeecsTriggerTimeoutError)
+
+
+def test_native_save_without_a_path_clears_a_stale_flag_and_adds_no_column(
+    RE: RunEngine,
+) -> None:
+    """A camera whose frames are not wanted still owns ``save`` (found live 26_0828)."""
+    cam = GeecsDetector(
+        "UC_TestCam",
+        ["MeanCounts"],
+        experiment="TestExp",
+        name="uc_testcam",
+        native_save=True,
+    )
+    connect_mock(RE, cam)
+    set_mock_value(cam.acq_timestamp, 1000.0)
+    set_mock_value(cam.save, "on")  # left on by a crashed run
+    _run(RE, lambda: cam.stage())
+    assert _run(RE, lambda: cam.save.get_value()) == "off"
+    _run(RE, lambda: cam.prepare(STRICT_TRIGGER_INFO))
+    assert _run(RE, lambda: cam.save.get_value()) == "off"
+    assert "uc_testcam-nonscalar_save_path" not in _run(RE, lambda: cam.describe())
+    _run(RE, lambda: cam.unstage())

--- a/GeecsBluesky/tests/test_namespace_hardware.py
+++ b/GeecsBluesky/tests/test_namespace_hardware.py
@@ -63,7 +63,7 @@ def test_stock_plans_over_the_namespace_on_hardware() -> None:
     from geecs_bluesky.namespace import GeecsNamespace
     from geecs_bluesky.plans.scan_request_plan import _await_in_plan
     from geecs_bluesky.preprocessors import install_connect_on_demand
-    from geecs_bluesky.scan_request_runner import trigger_writes_from_profile
+    from geecs_bluesky.devices.shot_control import trigger_writes_from_profile
     from geecs_bluesky.session import GeecsSession
     from geecs_bluesky.shot_controller import ShotController
     from geecs_core.pv_naming import pv_name, setpoint_pv

--- a/GeecsBluesky/tests/test_phase0_hardware.py
+++ b/GeecsBluesky/tests/test_phase0_hardware.py
@@ -1,0 +1,256 @@
+"""Phase-0 hardware acceptance: one camera as a StandardDetector (#807).
+
+Hardware-marked (skipped in CI; ``-m integration`` does NOT select it — it
+arms the machine trigger and fires shots).  Run by hand on a host with CA
+reach to the GEECS gateway and the GEECS DB (the qserver box)::
+
+    GEECS_HW_SCAN_VARIABLE=U_S1H:Current GEECS_HW_SCAN_START=-1 \\
+    GEECS_HW_SCAN_END=1 GEECS_HW_SCAN_STEP=0.5 GEECS_HW_SAVE=1 \\
+    poetry run python -u -m pytest tests/test_phase0_hardware.py -m hardware -s
+
+What it proves (``Planning/native_bluesky/03_clean_room_rebuild.md`` §8,
+phase 0): a :class:`GeecsDetector` built for a real camera, a
+:class:`ShotControl` built from the trigger profile, and stock
+``bp.count`` / ``bp.list_scan`` with :func:`geecs_per_shot` /
+:func:`geecs_per_step` run a strict GEECS scan — the detector's own
+lifecycle turns native saving on and off, every row carries the shot's
+stamp, and the files land in the claimed scan folder.  Also records the
+per-shot timing the §7 budget depends on.
+
+**MOVES HARDWARE** when ``GEECS_HW_SCAN_VARIABLE`` is set: the swept
+setpoint is restored to its pre-scan setpoint in a ``finally``.  With
+``GEECS_HW_SAVE=1`` a scan number is **claimed** (the scanner-side action)
+and the camera writes its native files into that folder.
+
+Environment
+-----------
+``GEECS_HW_EXPERIMENT``       experiment (default ``Undulator``)
+``GEECS_HW_CAMERA_DEVICE``    GEECS camera device (default ``UC_Amp4_IR_input``)
+``GEECS_HW_TRIGGER_PROFILE``  trigger profile (default ``HTU-NoGas``)
+``GEECS_HW_SHOTS``            shots for the count (default 3)
+``GEECS_HW_SCAN_VARIABLE``    ``Device:Variable`` to sweep (unset → no scan)
+``GEECS_HW_SCAN_START/END/STEP``  sweep bounds (mandatory with the variable)
+``GEECS_HW_SAVE``             ``1`` → claim a scan number and save natively
+``GEECS_HW_DOCS_OUT``         optional path to dump the documents as JSON
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import time
+from pathlib import Path
+
+import pytest
+
+from tests.ca_mock_helpers import DocCollector
+
+pytestmark = pytest.mark.hardware
+pytest.importorskip("aioca")
+
+
+def _sweep_points(start: float, end: float, step: float) -> list[float]:
+    n = int(round(abs(end - start) / abs(step))) + 1
+    sign = 1.0 if end >= start else -1.0
+    return [round(start + sign * i * abs(step), 6) for i in range(n)]
+
+
+def _wait_for_files(
+    directory: Path, expected: int, timeout: float = 10.0
+) -> list[Path]:
+    """The end-of-run file check: every expected native file exists and stopped growing."""
+    deadline = time.monotonic() + timeout
+    while True:
+        files = sorted(directory.glob("*.png"))
+        sizes = [f.stat().st_size for f in files]
+        if len(files) >= expected and all(sizes):
+            time.sleep(0.5)
+            if [f.stat().st_size for f in files] == sizes:
+                return files
+        if time.monotonic() > deadline:
+            raise AssertionError(
+                f"{directory}: {len(files)} files after {timeout:.0f} s, expected {expected}"
+            )
+        time.sleep(0.5)
+
+
+@pytest.mark.hardware
+def test_one_camera_as_a_standard_detector_on_hardware() -> None:
+    """GeecsDetector + ShotControl under stock count/list_scan; strict shots; native files."""
+    import bluesky.plan_stubs as bps
+    import bluesky.plans as bp
+    import bluesky.preprocessors as bpp
+    from geecs_core.pv_naming import pv_name, setpoint_pv
+    from ophyd_async.core import StaticFilenameProvider, StaticPathProvider
+
+    from geecs_bluesky.config_resolver import ConfigsRepoResolver
+    from geecs_bluesky.devices.ca.oneshot import try_caget_once
+    from geecs_bluesky.devices.detector import GeecsDetector
+    from geecs_bluesky.devices.shot_control import ShotControl
+    from geecs_bluesky.namespace import DeviceRoster, GeecsNamespace, python_type
+    from geecs_bluesky.plans.run_wrapper import claim_scan_number
+    from geecs_bluesky.plans.strict import geecs_per_shot, geecs_per_step
+    from geecs_bluesky.preprocessors import install_connect_on_demand
+    from geecs_bluesky.session import GeecsSession
+
+    experiment = os.environ.get("GEECS_HW_EXPERIMENT", "Undulator")
+    camera_name = os.environ.get("GEECS_HW_CAMERA_DEVICE", "UC_Amp4_IR_input")
+    profile_name = os.environ.get("GEECS_HW_TRIGGER_PROFILE", "HTU-NoGas")
+    shots = int(os.environ.get("GEECS_HW_SHOTS", "3"))
+    sweep_target = os.environ.get("GEECS_HW_SCAN_VARIABLE")
+    save = os.environ.get("GEECS_HW_SAVE", "0") == "1"
+    docs_out = os.environ.get("GEECS_HW_DOCS_OUT")
+
+    # --- the camera, from the DB roster (the namespace's rule, for one device)
+    roster = DeviceRoster.from_geecs_db(experiment)
+    served = roster.served_for(camera_name)
+    rows = {str(r["name"]): r for r in roster.variables[camera_name]}
+    readables = [
+        v
+        for v in roster.subscribed.get(camera_name, ())
+        if v.lower() in served and v in rows and not rows[v].get("settable")
+    ]
+    datatypes = {v: python_type(rows[v]) for v in readables}
+    print(f"\n{camera_name}: {len(readables)} scalar readables {readables}")
+
+    path_provider = None
+    scan_number = folder = None
+    if save:
+        scan_number, folder = claim_scan_number(experiment)
+        assert scan_number is not None and folder, "could not claim a scan number"
+        print(f"claimed scan {scan_number} → {folder}")
+        path_provider = StaticPathProvider(
+            StaticFilenameProvider(camera_name), Path(folder) / camera_name
+        )
+    camera = GeecsDetector(
+        camera_name,
+        readables,
+        experiment=experiment,
+        name=camera_name.lower(),
+        datatypes=datatypes,
+        path_provider=path_provider,
+        shot_timeout=3.0,
+    )
+
+    # --- the trigger box, from the profile
+    resolver = ConfigsRepoResolver(experiment)
+    shot_control = ShotControl.from_profile(
+        resolver.resolve_trigger_profile(profile_name),
+        experiment=experiment,
+        name="shot_control",
+    )
+    assert shot_control.defines("ARMED") and shot_control.defines("SINGLESHOT")
+
+    session = GeecsSession(experiment, tiled=False)
+    RE = session.RE
+    install_connect_on_demand(RE)
+    for device in (camera, shot_control):
+        asyncio.run_coroutine_threadsafe(device.connect(timeout=20.0), RE._loop).result(
+            30
+        )
+    print(f"camera connected; last stamp {camera.last_acq_timestamp}")
+
+    # --- the scan variable, from the namespace (#808)
+    movable = initial = None
+    points: list[float] = []
+    if sweep_target:
+        namespace = GeecsNamespace.from_experiment(experiment)
+        device_name, _, variable = sweep_target.partition(":")
+        movable = namespace.resolve(sweep_target)
+        points = _sweep_points(
+            float(os.environ["GEECS_HW_SCAN_START"]),
+            float(os.environ["GEECS_HW_SCAN_END"]),
+            float(os.environ["GEECS_HW_SCAN_STEP"]),
+        )
+        initial = float(
+            try_caget_once(
+                setpoint_pv(pv_name(experiment, device_name, variable)), timeout=5.0
+            )
+        )
+        print(f"sweep {sweep_target} over {points} (pre-scan setpoint {initial})")
+
+    docs = DocCollector()
+    timeline: list[tuple[str, float]] = []
+    RE.subscribe(lambda name, doc: timeline.append((name, time.monotonic())), "event")
+
+    def acceptance():
+        yield from bps.mv(shot_control, "ARMED")
+        yield from bp.count(
+            [camera],
+            num=shots,
+            per_shot=geecs_per_shot(shot_control),
+            md={"purpose": "807-phase0-count", "scan_number": scan_number},
+        )
+        if movable is not None:
+            yield from bp.list_scan(
+                [camera],
+                movable,
+                points,
+                per_step=geecs_per_step(shot_control),
+                md={"purpose": "807-phase0-scan", "scan_number": scan_number},
+            )
+
+    def cleanup():
+        yield from bps.mv(shot_control, "STANDBY")
+        if movable is not None and initial is not None:
+            yield from bps.mv(movable, initial)
+            print(f"restored {sweep_target} to pre-scan setpoint {initial}")
+
+    t_start = time.monotonic()
+    RE(bpp.finalize_wrapper(acceptance(), cleanup()), docs)
+    if docs_out:
+        Path(docs_out).write_text(json.dumps(docs.docs, default=str, indent=1))
+        print(f"documents written to {docs_out}")
+
+    starts, stops = docs.docs["start"], docs.docs["stop"]
+    assert [s["plan_name"] for s in starts] == (
+        ["count", "list_scan"] if movable is not None else ["count"]
+    )
+    assert all(s["exit_status"] == "success" for s in stops), stops
+    events = docs.primary_events()
+    expected_events = shots + len(points)
+    assert len(events) == expected_events, (
+        f"{len(events)} events, expected {expected_events}"
+    )
+    stamps = [e["data"][f"{camera.name}-acq_timestamp"] for e in events]
+    assert len(set(stamps)) == expected_events, (
+        f"stamps did not advance per shot: {stamps}"
+    )
+    gaps = [round(b - a, 3) for a, b in zip(stamps, stamps[1:])]
+    cadence = [round(b - a, 3) for (_, a), (_, b) in zip(timeline, timeline[1:])]
+    print(f"stamps: {stamps}\nstamp gaps (s): {gaps}\nevent cadence (s): {cadence}")
+    print(f"columns: {sorted(events[0]['data'])}")
+    print(
+        f"configuration: {docs.docs['descriptor'][0]['configuration'][camera.name]['data']}"
+    )
+    print(f"wall: {time.monotonic() - t_start:.1f} s for {expected_events} shots")
+    assert shot_control.standing_state == "STANDBY"
+
+    if movable is not None:
+        scan_events = [e for e in events if _run_of(e, docs) == starts[1]["uid"]]
+        readback_key = movable.position.name
+        readbacks = [e["data"][readback_key] for e in scan_events]
+        tol = getattr(movable, "_tolerance", 0.05)
+        for want, got in zip(points, readbacks):
+            assert abs(got - want) <= tol + 1e-9, f"{readback_key}: {got} vs {want}"
+        print(f"scan: {len(points)} points, readbacks {readbacks}")
+
+    if save:
+        directory = Path(folder) / camera_name
+        assert [e["data"][f"{camera.name}-save_path"] for e in events] == [
+            str(directory)
+        ] * len(events)
+        files = _wait_for_files(directory, expected_events)
+        print(f"native files: {len(files)} in {directory}: {[f.name for f in files]}")
+        save_state = asyncio.run_coroutine_threadsafe(
+            camera.save.get_value(), RE._loop
+        ).result(5)
+        assert save_state == "off", f"save left {save_state!r}"
+
+
+def _run_of(event: dict, docs: DocCollector) -> str:
+    for d in docs.docs["descriptor"]:
+        if d["uid"] == event["descriptor"]:
+            return d["run_start"]
+    raise AssertionError("event without descriptor")

--- a/GeecsBluesky/tests/test_phase0_hardware.py
+++ b/GeecsBluesky/tests/test_phase0_hardware.py
@@ -221,9 +221,8 @@ def test_one_camera_as_a_standard_detector_on_hardware() -> None:
     cadence = [round(b - a, 3) for (_, a), (_, b) in zip(timeline, timeline[1:])]
     print(f"stamps: {stamps}\nstamp gaps (s): {gaps}\nevent cadence (s): {cadence}")
     print(f"columns: {sorted(events[0]['data'])}")
-    print(
-        f"configuration: {docs.docs['descriptor'][0]['configuration'][camera.name]['data']}"
-    )
+    configuration = docs.docs["descriptor"][0]["configuration"]
+    print(f"configuration: { {k: v['data'] for k, v in configuration.items()} }")
     print(f"wall: {time.monotonic() - t_start:.1f} s for {expected_events} shots")
     assert shot_control.standing_state == "STANDBY"
 

--- a/GeecsBluesky/tests/test_phase0_hardware.py
+++ b/GeecsBluesky/tests/test_phase0_hardware.py
@@ -237,7 +237,7 @@ def test_one_camera_as_a_standard_detector_on_hardware() -> None:
 
     if save:
         directory = Path(folder) / camera_name
-        assert [e["data"][f"{camera.name}-save_path"] for e in events] == [
+        assert [e["data"][f"{camera.name}-nonscalar_save_path"] for e in events] == [
             str(directory)
         ] * len(events)
         files = _wait_for_files(directory, expected_events)

--- a/GeecsBluesky/tests/test_phase0_hardware.py
+++ b/GeecsBluesky/tests/test_phase0_hardware.py
@@ -221,8 +221,10 @@ def test_one_camera_as_a_standard_detector_on_hardware() -> None:
     cadence = [round(b - a, 3) for (_, a), (_, b) in zip(timeline, timeline[1:])]
     print(f"stamps: {stamps}\nstamp gaps (s): {gaps}\nevent cadence (s): {cadence}")
     print(f"columns: {sorted(events[0]['data'])}")
-    configuration = docs.docs["descriptor"][0]["configuration"]
-    print(f"configuration: { {k: v['data'] for k, v in configuration.items()} }")
+    primary = next(d for d in docs.docs["descriptor"] if d["name"] == "primary")
+    print(
+        f"configuration: { {k: v['data'] for k, v in primary['configuration'].items()} }"
+    )
     print(f"wall: {time.monotonic() - t_start:.1f} s for {expected_events} shots")
     assert shot_control.standing_state == "STANDBY"
 

--- a/GeecsBluesky/tests/test_scan_request_runner.py
+++ b/GeecsBluesky/tests/test_scan_request_runner.py
@@ -26,6 +26,7 @@ from bluesky.utils import Msg
 from geecs_bluesky.exceptions import GeecsConfigurationError
 from geecs_bluesky.models.shot_control import ShotControlWrites
 from geecs_bluesky.plans.scan_request_plan import geecs_scan_request_plan
+from geecs_bluesky.devices.shot_control import trigger_writes_from_profile
 from geecs_bluesky.scan_request_runner import (
     ConfigResolver,
     ConfigsRepoResolver,
@@ -38,7 +39,6 @@ from geecs_bluesky.scan_request_runner import (
     resolve_save_sets_and_rituals,
     save_set_to_devices_config,
     snapshot_images_ignored,
-    trigger_writes_from_profile,
 )
 from geecs_schemas import (
     ActionPlan,

--- a/GeecsBluesky/tests/test_shot_control_device.py
+++ b/GeecsBluesky/tests/test_shot_control_device.py
@@ -1,0 +1,161 @@
+"""ShotControl — the trigger box as a Movable + Pausable device (phase 0, #807)."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+from bluesky import RunEngine
+from bluesky.plan_stubs import mv
+from geecs_schemas.trigger_profile import TriggerState
+
+from geecs_bluesky.devices.shot_control import ShotControl
+from geecs_bluesky.exceptions import GeecsConfigurationError
+from geecs_bluesky.models.shot_control import ShotControlWrites
+from tests.ca_mock_helpers import connect_mock
+
+WRITES = ShotControlWrites(
+    name="htu_test",
+    states={
+        # Ordered, multi-device: amplitude first, then the source (the
+        # TriggerProfile semantics).
+        "SCAN": [("DG", "Amplitude", "4.0"), ("DG", "Source", "edges")],
+        "STANDBY": [("DG", "Amplitude", "0.5"), ("DG", "Source", "edges")],
+        "OFF": [("DG", "Amplitude", "0.5"), ("DG", "Source", "single")],
+        "ARMED": [("DG", "Amplitude", "4.0"), ("DG", "Source", "single")],
+        "SINGLESHOT": [("DG", "Fire", "on")],
+    },
+)
+
+
+class Recorder:
+    """A setter recording every put, in order, across all targets."""
+
+    log: list[tuple[str, str, str]] = []
+
+    def __init__(self, device: str, variable: str) -> None:
+        self.key = (device, variable)
+
+    async def put(self, value: str) -> None:
+        Recorder.log.append((*self.key, value))
+
+
+@pytest.fixture
+def shot_control(RE: RunEngine) -> ShotControl:
+    Recorder.log = []
+    sc = ShotControl(
+        WRITES, experiment="TestExp", name="shot_control", setter_factory=Recorder
+    )
+    connect_mock(RE, sc)
+    return sc
+
+
+@pytest.fixture
+def RE() -> RunEngine:
+    return RunEngine()
+
+
+def _run(RE: RunEngine, make_awaitable):
+    """Call *make_awaitable* inside the RE loop and await what it returns.
+
+    Device methods wrapped in ``AsyncStatus`` create their task at call time,
+    so the call itself must happen on the running loop.
+    """
+
+    async def call():
+        return await make_awaitable()
+
+    return asyncio.run_coroutine_threadsafe(call(), RE._loop).result(timeout=10.0)
+
+
+def test_set_replays_the_state_writes_in_order(
+    RE: RunEngine, shot_control: ShotControl
+) -> None:
+    RE(mv(shot_control, "ARMED"))
+    assert Recorder.log == [("DG", "Amplitude", "4.0"), ("DG", "Source", "single")]
+    assert shot_control.standing_state == "ARMED"
+    assert _run(RE, lambda: shot_control.state.get_value()) == "ARMED"
+
+
+def test_enum_and_lowercase_are_accepted(
+    RE: RunEngine, shot_control: ShotControl
+) -> None:
+    RE(mv(shot_control, TriggerState.SCAN))
+    RE(mv(shot_control, "standby"))
+    assert shot_control.standing_state == "STANDBY"
+
+
+def test_singleshot_is_momentary(RE: RunEngine, shot_control: ShotControl) -> None:
+    """The fire never becomes the standing state."""
+    RE(mv(shot_control, "ARMED"))
+    RE(mv(shot_control, "SINGLESHOT"))
+    assert Recorder.log[-1] == ("DG", "Fire", "on")
+    assert shot_control.standing_state == "ARMED"
+
+
+def test_undefined_state_is_refused(RE: RunEngine) -> None:
+    sc = ShotControl(
+        ShotControlWrites(name="partial", states={"SCAN": [("DG", "Source", "edges")]}),
+        experiment="TestExp",
+        name="sc",
+        setter_factory=Recorder,
+    )
+    connect_mock(RE, sc)
+    assert sc.defines("SCAN") and not sc.defines("ARMED")
+    with pytest.raises(GeecsConfigurationError, match="ARMED"):
+        _run(RE, lambda: sc.set("ARMED"))
+
+
+def test_standing_state_is_configuration(
+    RE: RunEngine, shot_control: ShotControl
+) -> None:
+    RE(mv(shot_control, "SCAN"))
+    config = _run(RE, lambda: shot_control.read_configuration())
+    assert config["shot_control-state"]["value"] == "SCAN"
+    assert _run(RE, lambda: shot_control.read()) == {}  # nothing per event
+
+
+def test_pause_is_a_no_op_in_strict_mode(
+    RE: RunEngine, shot_control: ShotControl
+) -> None:
+    """ARMED: the plan simply stops firing; the box is left alone (§10.3)."""
+    RE(mv(shot_control, "ARMED"))
+    n = len(Recorder.log)
+    _run(RE, lambda: shot_control.pause())
+    _run(RE, lambda: shot_control.resume())
+    assert len(Recorder.log) == n
+    assert shot_control.standing_state == "ARMED"
+
+
+def test_pause_stops_edges_in_gated_mode(
+    RE: RunEngine, shot_control: ShotControl
+) -> None:
+    """SCAN: edges flow on their own, so pause → OFF and resume → SCAN."""
+    RE(mv(shot_control, "SCAN"))
+    _run(RE, lambda: shot_control.pause())
+    assert shot_control.standing_state == "OFF"
+    assert Recorder.log[-1] == ("DG", "Source", "single")
+    _run(RE, lambda: shot_control.resume())
+    assert shot_control.standing_state == "SCAN"
+    _run(RE, lambda: shot_control.resume())  # idempotent
+    assert Recorder.log[-1] == ("DG", "Source", "edges")
+
+
+def test_run_engine_pauses_the_box_it_set(
+    RE: RunEngine, shot_control: ShotControl
+) -> None:
+    """Having been a `set` target is enough: RE.request_pause reaches pause()."""
+    import bluesky.plan_stubs as bps
+
+    def plan():
+        yield from bps.open_run()
+        yield from bps.mv(shot_control, "SCAN")
+        yield from bps.checkpoint()
+        yield from bps.pause()
+        yield from bps.close_run()
+
+    with pytest.raises(Exception):  # RunEngineInterrupted
+        RE(plan())
+    assert shot_control.standing_state == "OFF"
+    RE.resume()
+    assert shot_control.standing_state == "SCAN"

--- a/GeecsBluesky/tests/test_shot_control_device.py
+++ b/GeecsBluesky/tests/test_shot_control_device.py
@@ -159,3 +159,69 @@ def test_run_engine_pauses_the_box_it_set(
     assert shot_control.standing_state == "OFF"
     RE.resume()
     assert shot_control.standing_state == "SCAN"
+
+
+def test_stop_from_a_paused_gated_run_does_not_leak_into_the_next(
+    RE: RunEngine, shot_control: ShotControl
+) -> None:
+    """Review P1: pause in SCAN, stop, then a strict run's pause/resume must not drive SCAN."""
+    RE(mv(shot_control, "SCAN"))
+    _run(RE, lambda: shot_control.pause())  # SCAN → OFF, remembers SCAN
+    assert shot_control.standing_state == "OFF"
+    # The run is stopped: finalize drives STANDBY, resume() is never called.
+    RE(mv(shot_control, "STANDBY"))
+    # Next run, strict: ARMED, pause (no-op), resume — must stay ARMED.
+    RE(mv(shot_control, "ARMED"))
+    _run(RE, lambda: shot_control.pause())
+    _run(RE, lambda: shot_control.resume())
+    assert shot_control.standing_state == "ARMED"
+    assert Recorder.log[-2:] == [("DG", "Amplitude", "4.0"), ("DG", "Source", "single")]
+
+
+def test_pause_from_standby_quiesces_too(
+    RE: RunEngine, shot_control: ShotControl
+) -> None:
+    """STANDBY passes external edges (§11.1): a pause there drives OFF as well."""
+    RE(mv(shot_control, "STANDBY"))
+    _run(RE, lambda: shot_control.pause())
+    assert shot_control.standing_state == "OFF"
+    _run(RE, lambda: shot_control.resume())
+    assert shot_control.standing_state == "STANDBY"
+
+
+def test_pause_without_off_logs_and_never_raises(RE: RunEngine, caplog) -> None:
+    """A profile with no OFF: the pause is logged, the box left alone, nothing raised."""
+    sc = ShotControl(
+        ShotControlWrites(name="no_off", states={"SCAN": [("DG", "Source", "edges")]}),
+        experiment="TestExp",
+        name="sc",
+        setter_factory=Recorder,
+    )
+    connect_mock(RE, sc)
+    RE(mv(sc, "SCAN"))
+    n = len(Recorder.log)
+    with caplog.at_level("WARNING"):
+        _run(RE, lambda: sc.pause())
+        _run(RE, lambda: sc.resume())
+    assert len(Recorder.log) == n
+    assert sc.standing_state == "SCAN"
+    assert "defines no OFF" in caplog.text
+
+
+def test_unknown_state_name_is_a_configuration_error(
+    RE: RunEngine, shot_control: ShotControl
+) -> None:
+    assert shot_control.defines("armed") and not shot_control.defines("FOO")
+    with pytest.raises(GeecsConfigurationError, match="not a trigger state"):
+        _run(RE, lambda: shot_control.set("FOO"))
+
+
+def test_standing_state_has_one_source(
+    RE: RunEngine, shot_control: ShotControl
+) -> None:
+    """The composed controller's last_state is the field; the config signal mirrors it."""
+    RE(mv(shot_control, "SCAN"))
+    assert shot_control._controller.last_state == "SCAN"
+    assert _run(RE, lambda: shot_control.state.get_value()) == "SCAN"
+    RE(mv(shot_control, "SINGLESHOT"))
+    assert shot_control._controller.last_state == "SCAN"

--- a/GeecsBluesky/tests/test_strict_plans.py
+++ b/GeecsBluesky/tests/test_strict_plans.py
@@ -1,0 +1,255 @@
+"""Stock plans run strict GEECS scans through ``take_reading`` (phase 0, #807).
+
+``bp.count`` / ``bp.scan`` from ``bluesky.plans`` over a
+:class:`GeecsDetector` and a :class:`CaMotor`, with
+:func:`geecs_per_shot` / :func:`geecs_per_step` supplying the one GEECS
+difference — the fire between trigger and wait — on mock CA backends.  The
+fake trigger box advances the camera's stamp **synchronously** inside the
+SINGLESHOT put, the worst case for the baseline.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("aioca")
+
+import bluesky.plan_stubs as bps  # noqa: E402
+import bluesky.plans as bp  # noqa: E402
+from bluesky import RunEngine  # noqa: E402
+from bluesky.utils import FailedStatus  # noqa: E402
+from ophyd_async.core import (  # noqa: E402
+    StaticFilenameProvider,
+    StaticPathProvider,
+    set_mock_value,
+)
+
+from geecs_bluesky.devices.ca import CaMotor  # noqa: E402
+from geecs_bluesky.devices.detector import GeecsDetector  # noqa: E402
+from geecs_bluesky.devices.shot_control import ShotControl  # noqa: E402
+from geecs_bluesky.exceptions import GeecsDeviceDownError  # noqa: E402
+from geecs_bluesky.models.shot_control import ShotControlWrites  # noqa: E402
+from geecs_bluesky.plans.strict import geecs_per_shot, geecs_per_step  # noqa: E402
+from tests.ca_mock_helpers import DocCollector, connect_mock, follow_setpoint  # noqa: E402
+
+WRITES = ShotControlWrites(
+    name="test",
+    states={
+        "ARMED": [("DG", "Trigger.Source", "single")],
+        "STANDBY": [("DG", "Trigger.Source", "edges")],
+        "SINGLESHOT": [("DG", "Trigger.ExecuteSingleShot", "on")],
+    },
+)
+
+
+class FakeBox:
+    """Setter factory: the SINGLESHOT put is the shot, landing on every camera now.
+
+    ``drop`` names (camera, attempt) pairs whose frame is lost — a dropped
+    shot advances every other camera's stamp but not that one's.
+    """
+
+    def __init__(self) -> None:
+        self.cameras: list[GeecsDetector] = []
+        self.stamp = 1000.0
+        self.fires = 0
+        self.puts: list[tuple[str, str, str]] = []
+        self.drop: set[tuple[str, int]] = set()
+
+    def __call__(self, device: str, variable: str):
+        box = self
+
+        class Setter:
+            async def put(self, value: str) -> None:
+                box.puts.append((device, variable, value))
+                if variable == "Trigger.ExecuteSingleShot":
+                    box.fires += 1
+                    box.stamp += 1.0
+                    for cam in box.cameras:
+                        if (cam.name, box.fires) in box.drop:
+                            continue
+                        set_mock_value(cam.acq_timestamp, box.stamp)
+
+        return Setter()
+
+
+@pytest.fixture
+def RE() -> RunEngine:
+    return RunEngine()
+
+
+@pytest.fixture
+def box() -> FakeBox:
+    return FakeBox()
+
+
+@pytest.fixture
+def shot_control(RE: RunEngine, box: FakeBox) -> ShotControl:
+    sc = ShotControl(
+        WRITES, experiment="TestExp", name="shot_control", setter_factory=box
+    )
+    connect_mock(RE, sc)
+    RE(bps.mv(sc, "ARMED"))
+    return sc
+
+
+def _camera(RE: RunEngine, box: FakeBox, name: str, tmp_path: Path | None = None, **kw):
+    provider = None
+    if tmp_path is not None:
+        provider = StaticPathProvider(
+            StaticFilenameProvider("f"), tmp_path / "Scan001" / name
+        )
+    cam = GeecsDetector(
+        name,
+        ["MeanCounts"],
+        experiment="TestExp",
+        name=name.lower(),
+        path_provider=provider,
+        **kw,
+    )
+    connect_mock(RE, cam)
+    set_mock_value(cam.acq_timestamp, box.stamp)
+    box.cameras.append(cam)
+    return cam
+
+
+def test_count_fires_once_per_shot(
+    RE: RunEngine, box: FakeBox, shot_control: ShotControl
+) -> None:
+    cam = _camera(RE, box, "UC_Cam")
+    set_mock_value(cam.meancounts, 3.0)
+    col = DocCollector()
+    RE.subscribe(col)
+    RE(bp.count([cam], num=4, per_shot=geecs_per_shot(shot_control)))
+    events = col.primary_events()
+    assert box.fires == 4
+    assert [e["data"]["uc_cam-acq_timestamp"] for e in events] == [
+        1001.0,
+        1002.0,
+        1003.0,
+        1004.0,
+    ]
+    assert [e["data"]["uc_cam-meancounts"] for e in events] == [3.0] * 4
+    start = col.docs["start"][0]
+    assert start["detectors"] == ["uc_cam"] and start["plan_name"] == "count"
+    assert shot_control.standing_state == "ARMED"
+
+
+def test_scan_moves_then_fires(
+    RE: RunEngine, box: FakeBox, shot_control: ShotControl
+) -> None:
+    cam = _camera(RE, box, "UC_Cam")
+    magnet = CaMotor(
+        "U_S1H", "Current", experiment="TestExp", tolerance=0.01, name="u_s1h-current"
+    )
+    connect_mock(RE, magnet)
+    follow_setpoint(magnet)
+    col = DocCollector()
+    RE.subscribe(col)
+    RE(bp.scan([cam], magnet, -1.0, 1.0, 5, per_step=geecs_per_step(shot_control)))
+    events = col.primary_events()
+    assert box.fires == 5
+    assert [e["data"]["u_s1h-current-position"] for e in events] == pytest.approx(
+        [-1.0, -0.5, 0.0, 0.5, 1.0]
+    )
+    assert [e["data"]["uc_cam-acq_timestamp"] for e in events] == [
+        1001.0 + i for i in range(5)
+    ]
+    assert list(col.docs["start"][0]["motors"]) == ["u_s1h-current"]
+
+
+def test_two_cameras_share_one_fire(
+    RE: RunEngine, box: FakeBox, shot_control: ShotControl
+) -> None:
+    a = _camera(RE, box, "UC_A")
+    b = _camera(RE, box, "UC_B")
+    col = DocCollector()
+    RE.subscribe(col)
+    RE(bp.count([a, b], num=3, per_shot=geecs_per_shot(shot_control)))
+    assert box.fires == 3
+    for event in col.primary_events():
+        assert (
+            event["data"]["uc_a-acq_timestamp"] == event["data"]["uc_b-acq_timestamp"]
+        )
+
+
+def test_dropped_frame_is_refired_and_rows_stay_one_shot(
+    RE: RunEngine, box: FakeBox, shot_control: ShotControl
+) -> None:
+    """Camera A misses fire 2: the shot is re-fired for everyone; B's orphan is not a row."""
+    a = _camera(RE, box, "UC_A", shot_timeout=0.3)
+    b = _camera(RE, box, "UC_B", shot_timeout=0.3)
+    box.drop = {("uc_a", 2)}
+    col = DocCollector()
+    RE.subscribe(col)
+    RE(bp.count([a, b], num=3, per_shot=geecs_per_shot(shot_control)))
+    events = col.primary_events()
+    assert len(events) == 3
+    assert box.fires == 4  # three shots, one refire
+    stamps = [
+        (e["data"]["uc_a-acq_timestamp"], e["data"]["uc_b-acq_timestamp"])
+        for e in events
+    ]
+    assert stamps == [(1001.0, 1001.0), (1003.0, 1003.0), (1004.0, 1004.0)]
+
+
+def test_refires_are_bounded(
+    RE: RunEngine, box: FakeBox, shot_control: ShotControl
+) -> None:
+    cam = _camera(RE, box, "UC_A", shot_timeout=0.2)
+    box.drop = {("uc_a", n) for n in range(1, 10)}
+    with pytest.raises(FailedStatus):
+        RE(bp.count([cam], num=1, per_shot=geecs_per_shot(shot_control, max_refires=1)))
+    assert box.fires == 2
+
+
+def test_a_dead_device_is_not_refired(
+    RE: RunEngine, box: FakeBox, shot_control: ShotControl
+) -> None:
+    """CONNECTED says Disconnected → GeecsDeviceDownError, no refire burnt."""
+    cam = _camera(RE, box, "UC_A", shot_timeout=0.2)
+    set_mock_value(cam.connected_status, "Disconnected")
+    box.drop = {("uc_a", n) for n in range(1, 10)}
+    with pytest.raises(GeecsDeviceDownError, match="UC_A"):
+        RE(bp.count([cam], num=1, per_shot=geecs_per_shot(shot_control)))
+    assert box.fires == 1
+
+
+def test_native_saving_brackets_the_run(
+    RE: RunEngine, box: FakeBox, shot_control: ShotControl, tmp_path: Path
+) -> None:
+    """save=on from the first prepare, the directory in every row, save=off at unstage."""
+    (tmp_path / "Scan001").mkdir()
+    cam = _camera(RE, box, "UC_Cam", tmp_path)
+    saves: list[str] = []
+
+    async def watch() -> None:
+        cam.save.subscribe(
+            lambda reading: saves.append(reading[cam.save.name]["value"])
+        )
+
+    asyncio.run_coroutine_threadsafe(watch(), RE._loop).result(5)
+    col = DocCollector()
+    RE.subscribe(col)
+    RE(bp.count([cam], num=2, per_shot=geecs_per_shot(shot_control)))
+    directory = str(tmp_path / "Scan001" / "UC_Cam")
+    assert [e["data"]["uc_cam-save_path"] for e in col.primary_events()] == [
+        directory
+    ] * 2
+    assert Path(directory).is_dir()
+    assert saves[-1] == "off" and "on" in saves
+    assert (
+        asyncio.run_coroutine_threadsafe(cam.save.get_value(), RE._loop).result(5)
+        == "off"
+    )
+
+
+def test_plain_count_is_refused_clearly(RE: RunEngine, box: FakeBox) -> None:
+    """Without the GEECS fire a camera cannot count: the stock plan fails at prepare."""
+    cam = _camera(RE, box, "UC_Cam")
+    with pytest.raises(FailedStatus) as info:
+        RE(bp.count([cam], num=1))
+    assert "EXTERNAL_EDGE" in str(info.value)

--- a/GeecsBluesky/tests/test_strict_plans.py
+++ b/GeecsBluesky/tests/test_strict_plans.py
@@ -236,7 +236,7 @@ def test_native_saving_brackets_the_run(
     RE.subscribe(col)
     RE(bp.count([cam], num=2, per_shot=geecs_per_shot(shot_control)))
     directory = str(tmp_path / "Scan001" / "UC_Cam")
-    assert [e["data"]["uc_cam-save_path"] for e in col.primary_events()] == [
+    assert [e["data"]["uc_cam-nonscalar_save_path"] for e in col.primary_events()] == [
         directory
     ] * 2
     assert Path(directory).is_dir()

--- a/GeecsBluesky/tests/test_strict_plans.py
+++ b/GeecsBluesky/tests/test_strict_plans.py
@@ -253,3 +253,33 @@ def test_plain_count_is_refused_clearly(RE: RunEngine, box: FakeBox) -> None:
     with pytest.raises(FailedStatus) as info:
         RE(bp.count([cam], num=1))
     assert "EXTERNAL_EDGE" in str(info.value)
+
+
+def test_a_failed_fire_is_not_a_dropped_frame(
+    RE: RunEngine, box: FakeBox, shot_control: ShotControl
+) -> None:
+    """Codex review of #811: a refused SINGLESHOT put re-raises; no refire, no extra shot."""
+    cam = _camera(RE, box, "UC_Cam", shot_timeout=0.5)
+
+    class RefusingBox(FakeBox):
+        def __call__(self, device: str, variable: str):
+            inner = super().__call__(device, variable)
+            outer = self
+
+            class Setter:
+                async def put(self, value: str) -> None:
+                    if variable == "Trigger.ExecuteSingleShot":
+                        outer.fires += 1
+                        raise RuntimeError("GEECS refused the set")
+                    await inner.put(value)
+
+            return Setter()
+
+    refusing = RefusingBox()
+    sc = ShotControl(WRITES, experiment="TestExp", name="sc2", setter_factory=refusing)
+    connect_mock(RE, sc)
+    RE(bps.mv(sc, "ARMED"))
+    with pytest.raises(FailedStatus) as info:
+        RE(bp.count([cam], num=1, per_shot=geecs_per_shot(sc, max_refires=2)))
+    assert isinstance(info.value.__cause__, RuntimeError)
+    assert refusing.fires == 1  # no refire on a failed fire


### PR DESCRIPTION
## What

Phase 0 of the native-Bluesky rebuild (#807; plan of record `Planning/native_bluesky/03_clean_room_rebuild.md` §8, on #810): **one GEECS camera as a stock ophyd-async `StandardDetector`**, the trigger box as a device, and strict single-shot acquisition as the stock `take_reading` hook — so `bp.count` and every N-d scan plan from `bluesky.plans` run a strict GEECS scan with no preamble and no preprocessor beyond `connect_on_demand`.

- `devices/detector.py` — `GeecsDetector`, composed of the three 0.19.3 logics:
  - `GeecsTriggerLogic`: external edges only (the DG645 fires, LabVIEW acquires; nothing to program). Its one config signal is the calibrated **drain offset** (§11.4), which `get_deadtime` returns.
  - `GeecsAcquireLogic`: a shot **is** `acq_timestamp` advancing. The baseline is taken **synchronously in `trigger()`** so the plan's fire — the very next message — can never land in a blind window. The wait lives in `wait_for_idle` (a per-event data provider has no count for `_wait_for_index` to watch).
  - `ScalarsDataLogic`: the device's own DB-subscribed scalars (+ the stamp) as event columns.
  - `LvNativeFileDataLogic`: LabVIEW native saving driven from a `PathProvider` — `localsavingpath` + `save=on` at `prepare`, `save=off` at `stage` (eager, clears a stale flag) and `unstage`. The device directory is created with `mkdir(exist_ok=True)` **only inside an existing scan folder**; a missing parent raises. There is no write-complete readback (§10.1), so the provider is a per-event reading (the directory); files join to rows by stamp.
  - A plain `bp.count([cam])` is refused at prepare (`INTERNAL not supported`): a GEECS camera cannot self-trigger.
- `devices/shot_control.py` — `ShotControl`: `Movable` over the profile's named states (ordered writes, composed over the existing `ShotController.from_writes`, not copied), `Pausable` (no-op in ARMED — the plan just stops firing; SCAN → OFF and `resume` → SCAN, §10.3), the standing state as a config signal.
- `plans/strict.py` — `geecs_take_reading`: `bps.trigger_and_read` with the one GEECS difference (the SINGLESHOT fire between the triggers and the wait) plus the bounded refire; `geecs_per_shot` / `geecs_per_step` bind it into the stock `one_shot` / `one_nd_step` hooks.
- `plans/single_shot.py` — the arm → fire → await → refire seam is now `fire_and_await_shot`, called by `geecs_single_shot` (the funnel) **and** `geecs_take_reading`: one implementation, two callers (#809's review finding, applied).

## Why

#809's twenty-one findings had two structural causes (§3): a scan described twice, and per-run device state set from *outside* the device. This PR removes the second at the device layer: every per-run fact (save path, saving on/off, the shot wait) is set through the detector's own `stage → prepare → trigger → unstage`. The first is the plan layer's job (phase 1). Sequencing per Sam's decision 2026-09-09 (§8, option 1½): this is the seam #806 swaps one logic into, and it lets the plan-layer rebuild and #806 proceed in parallel.

## Scope

One concern. LOC: `detector.py` 463, `shot_control.py` 155, `strict.py` 117, `single_shot.py` +67/−19 (extraction), tests 909, CHANGELOG 36.

**Judgment calls, cheap to veto:**
- `GeecsDetector.stage()` stages the scalar signals so reads come from the monitor cache (the 0.7 s/row regression in `GeecsBluesky/CLAUDE.md`); ophyd-async's `StandardDetector` does not do this for children by itself.
- The refire stays a `GeecsDeviceDownError` on a confirmed-dead device (abort), not `bps.pause()` as §4.B first said — a pause inside `take_reading` replays the stashed trigger/fire messages on resume (rewind), which would double-fire. Doc amended to match.
- `default_trigger_info()` returns the edge-triggered `TriggerInfo` (truthful hardware state), so `OPHYD_ASYNC_PRESERVE_DETECTOR_STATE=YES` environments work too; `take_reading` prepares explicitly regardless.
- Not touched: the namespace still builds `CaGenericDetector` nouns; switching it to `GeecsDetector` (and deleting `CaGenericDetector`, `CaTriggerable`, `nonscalar_save.py`, `shot_id.py`) is the plan-layer PR, with the funnel that uses them.

**Facility literals:** `tests/test_phase0_hardware.py` defaults (`Undulator`, `UC_Amp4_IR_input`, `HTU-NoGas`, `U_S1H:Current`) are env-overridable test parameters, same shape as `test_namespace_hardware.py`; none in package code.

## Tests

- `tests/test_geecs_detector.py` (10): children/headers; edge-only trigger + livetime refusal; the shot wait; **the synchronous-baseline race** (fire before the trigger task's first step); timeout attribution; stale-update drain; the saving lifecycle (stage → off, prepare → on, unstage → off); **the scan-folder invariant** (missing parent raises, nothing created); drain offset in `read_configuration`; the GEECS error on `FailedStatus.__cause__`.
- `tests/test_shot_control_device.py` (8): ordered writes; enum/lowercase; SINGLESHOT momentary; undefined state refused; standing state in configuration; pause no-op in ARMED; pause → OFF / resume → SCAN; **the RE pauses the box it `set`**.
- `tests/test_strict_plans.py` (8): stock `count` fires once per shot; stock `scan` moves then fires; two cameras share one fire; **dropped frame → whole-event refire, rows stay one shot**; refires bounded; dead device not refired; saving brackets the run; plain `count` refused.
- Review-driven additions (79f24fba): `test_shot_control_device.py` +5 (the stop-from-paused leak, STANDBY quiesce, no-OFF profile never raises, unknown state names, one standing-state field), `test_geecs_detector.py` +1 (`native_save` clears a stale flag without a path).
- Affected suites after the review fixes (new files + `test_ca_devices`, `test_pause_semantics`, `test_scan_request_runner`, `test_shot_control*`, `test_single_shot_plan`, `test_connect_on_demand`, `test_preflight_connected`, `test_free_run_plan`): **213 passed**; plan-level (`test_namespace`, `test_scan_request_plan`, `test_grid_and_action_plans`): **70 passed**. Lint clean.
- Full GeecsBluesky suite on this Mac (`--durations` run): **792 passed, 1 timed out** — `tests/test_tiled_integration.py::test_subscribe_tiled_reachable_server_still_subscribes` at 180.59 s; the next-slowest test is 9 s. The same suite on the base branch also times out one test (a different one, 764 passed), so the slowness pre-dates this PR and is a test-hygiene issue of its own — filed separately. CI runs the suite green in ~3.5 min.

## Hardware verification — done twice (Scan 065 of 26_0909 = M2; re-run on the review-fixed code, Scan 001 of 26_0910 = M3; `04_phase0_measurements.md`)

`tests/test_phase0_hardware.py` on the worker host: `GeecsDetector("UC_Amp4_IR_input")` with 8 scalars + native saving into a claimed scan folder, `ShotControl.from_profile("HTU-NoGas")`, `bps.mv(shot_control, "ARMED")` → stock `bp.count(3, per_shot=geecs_per_shot)` → stock `bp.list_scan(U_S1H.Current, [-1, -0.5, 0, 0.5, 1], per_step=geecs_per_step)` → STANDBY + restore.

- 3 + 5 events, `success`; every row carries the stamp, the 8 scalars, `save_path`, the magnet readback within tolerance (−0.9998 … 0.9999 A). Setpoint restored (8e-05 A); STANDBY restored; `save` reads `off`.
- `Scan065/UC_Amp4_IR_input/`: exactly 8 PNGs, one per row, named by the row's stamp; still 8 two minutes later (no orphans in STANDBY). `localsavingpath` written as the Windows share path via the config.ini mapping.
- Cadence: **1 Hz strict** on the count (0.95 / 0.99 s); 2.0 s/step on the scan — move + the ~200 ms fire put exceed the ~550 ms budget measured in M1 (the single shot fires on the *next* external edge), so the shot lands on the next-next edge. Recoverable in the plan layer; recorded in §7.
- M3 (79f24fba): `1 passed in 27.7 s` end to end — same shape as M2 (3 + 5 events, 8 files, 1 Hz count, 2.0 s/step, setpoint restored).

## Adversarial review

The reviewer's full report and the dispositions are comments on this PR. The original reviewer was cut off by a rate limit before confirming the fixes; a fresh-context verifier given only the findings and the fix commits did the confirm/deny (the `/land` substitution rule), noted in the disposition comment.
