### PR TITLE
GeecsBluesky 0.78.1: stop the RunEngine loop threads tests leave behind (#812)

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -77,7 +77,7 @@ jobs:
 
       - name: Run GeecsBluesky pure unit tests
         working-directory: GeecsBluesky
-        run: poetry run pytest tests -m "not integration and not fake_server" --tb=short -q
+        run: poetry run pytest tests -m "not integration and not fake_server" --tb=short -q --durations=10
 
       - name: Install GEECS-MCP dependencies
         working-directory: GEECS-MCP

--- a/GeecsBluesky/CHANGELOG.md
+++ b/GeecsBluesky/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to `geecs-bluesky` are documented here.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.78.1] - 2026-09-10
+
+### Fixed
+
+- **Test suite: RunEngine loop threads no longer accumulate across the run**
+  (#812). Every `RunEngine()` a test constructs starts a daemon thread running
+  its own asyncio loop forever and nothing stopped it, so by the midpoint of
+  the suite ~150 live loops were idling in `select` and the process crawled —
+  on a developer Mac a 1.4 s test took the full 180 s per-test timeout and
+  whichever test ran at that point was blamed (CI on Linux ran the same
+  suite in 3.5 min). An autouse `conftest.py` fixture now stops and joins
+  every loop a test left behind. `scripts/check.sh` prints the ten slowest
+  tests for the GeecsBluesky suite so a regression shows up as a number.
+
 ## [0.78.0] - 2026-09-09
 
 ### Added

--- a/GeecsBluesky/pyproject.toml
+++ b/GeecsBluesky/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-bluesky"
-version = "0.78.0"
+version = "0.78.1"
 description = "Bluesky / ophyd-async bridge for the GEECS control system"
 authors = ["Sam Barber <sbarber@lbl.gov>"]
 readme = "README.md"

--- a/GeecsBluesky/tests/conftest.py
+++ b/GeecsBluesky/tests/conftest.py
@@ -16,18 +16,26 @@ def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
 
 
 @pytest.fixture(autouse=True)
-def _stop_run_engine_loops_left_by_the_test():
+def _stop_run_engine_loops_left_by_the_test(request: pytest.FixtureRequest):
     """Stop the event-loop threads a test's ``RunEngine()`` instances leave behind.
 
     Every ``RunEngine()`` starts a daemon thread running its own asyncio loop
     forever; nothing in bluesky stops it, so a suite with ~60 inline
-    constructions accumulates 100+ live loops and the whole process crawls
-    (#812: a 1.4 s test taking the full 180 s timeout at the midpoint of the
-    run, on macOS).  bluesky records loop → thread in
-    ``_ensure_event_loop_running.loop_to_thread``; this stops and joins every
-    loop that appeared during the test.  Session-wide loops created before
-    the test (module-level engines) are left alone.
+    constructions (plus one per ``GeecsSession``) accumulates 100+ live loops
+    and the whole process crawls (#812: a 1.4 s test taking the full 180 s
+    timeout at the midpoint of the run, on macOS).  bluesky records
+    loop → thread in ``_ensure_event_loop_running.loop_to_thread``; this
+    stops every loop that appeared during the test, drains what it still had
+    pending (a cancelled pacer, a paused RunEngine) the way
+    ``asyncio.Runner.close`` does — so nothing is destroyed while pending and
+    no stray traceback lands after the pytest summary — then closes it.
+    Loops created before the test (module- or session-level engines) are
+    left alone.  A loop whose thread will not stop within 5 s is left
+    running, as before this fixture, and reported so the leak is visible.
     """
+    import asyncio
+    import warnings
+
     from bluesky.run_engine import _ensure_event_loop_running
 
     registry = _ensure_event_loop_running.loop_to_thread
@@ -41,5 +49,23 @@ def _stop_run_engine_loops_left_by_the_test():
             loop.call_soon_threadsafe(loop.stop)
         if thread is not None and thread.is_alive():
             thread.join(timeout=5.0)
-        if not loop.is_running() and not loop.is_closed():
-            loop.close()
+        if loop.is_running():
+            warnings.warn(
+                f"{request.node.nodeid}: a RunEngine loop thread did not stop "
+                "within 5 s and was left running (a blocking callback on the "
+                "loop?)",
+                RuntimeWarning,
+                stacklevel=1,
+            )
+            continue
+        if loop.is_closed():
+            continue
+        # Drain before closing: cancel what is still pending and let it finish
+        # cancelling (the test thread may drive a stopped loop).
+        pending = asyncio.all_tasks(loop)
+        for task in pending:
+            task.cancel()
+        if pending:
+            loop.run_until_complete(asyncio.gather(*pending, return_exceptions=True))
+        loop.run_until_complete(loop.shutdown_asyncgens())
+        loop.close()

--- a/GeecsBluesky/tests/conftest.py
+++ b/GeecsBluesky/tests/conftest.py
@@ -13,3 +13,33 @@ def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
             "timeout"
         ):
             item.add_marker(timeout)
+
+
+@pytest.fixture(autouse=True)
+def _stop_run_engine_loops_left_by_the_test():
+    """Stop the event-loop threads a test's ``RunEngine()`` instances leave behind.
+
+    Every ``RunEngine()`` starts a daemon thread running its own asyncio loop
+    forever; nothing in bluesky stops it, so a suite with ~60 inline
+    constructions accumulates 100+ live loops and the whole process crawls
+    (#812: a 1.4 s test taking the full 180 s timeout at the midpoint of the
+    run, on macOS).  bluesky records loop → thread in
+    ``_ensure_event_loop_running.loop_to_thread``; this stops and joins every
+    loop that appeared during the test.  Session-wide loops created before
+    the test (module-level engines) are left alone.
+    """
+    from bluesky.run_engine import _ensure_event_loop_running
+
+    registry = _ensure_event_loop_running.loop_to_thread
+    before = set(registry.keys())
+    yield
+    for loop in list(registry.keys()):
+        if loop in before:
+            continue
+        thread = registry.get(loop)
+        if loop.is_running():
+            loop.call_soon_threadsafe(loop.stop)
+        if thread is not None and thread.is_alive():
+            thread.join(timeout=5.0)
+        if not loop.is_running() and not loop.is_closed():
+            loop.close()

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -232,7 +232,7 @@ run_suite() {
         ImageAnalysis|ScanAnalysis|GEECS-Data-Utils|GEECS-Schemas)
             poetry run pytest "$1/tests" -m "not integration and not gui" --tb=short -q ;;
         GeecsBluesky)
-            (cd GeecsBluesky && poetry run pytest tests -m "not integration and not fake_server" --tb=short -q) ;;
+            (cd GeecsBluesky && poetry run pytest tests -m "not integration and not fake_server" --tb=short -q --durations=10) ;;
         GEECS-Console)
             (cd GEECS-Console && QT_QPA_PLATFORM=offscreen poetry run pytest --tb=short -q) ;;
         GeecsCAGateway|GeecsPvaGateway|GEECS-Core|GEECS-DataPortal|GEECS-LogTriage|GEECS-MCP)


### PR DESCRIPTION
## What

An autouse `tests/conftest.py` fixture that stops and joins every RunEngine event-loop thread a test leaves behind, plus `--durations=10` on the GeecsBluesky line of `scripts/check.sh`. Refs #812 (the leak is the bulk of it; a residual one-test stall is documented there and stays open).

## Why

Every `RunEngine()` a test constructs starts a daemon thread running its own asyncio loop forever (`_ensure_event_loop_running`), and nothing in bluesky stops it. The suite has 57 inline constructions across 20 files; by the midpoint of a run ~150 live loops sat idling in `select` and the whole process crawled on macOS. The symptom was misleading: a 1.4 s test (`test_tiled_integration.py::test_subscribe_tiled_reachable_server_still_subscribes`) took the full 180 s per-test timeout, and on other runs a different test did — whichever was running when the process stalled. CI on Linux ran the same suite green in 3.5 min, so it looked like "something slow on the Mac".

bluesky records loop → thread in `_ensure_event_loop_running.loop_to_thread`; the fixture snapshots it before each test and, after, stops and joins the loops that appeared. Loops created outside a test (module-level engines) are left alone.

## Measured (same Mac, same suite, `--timeout=180 --durations`)

| | before | after |
|---|---|---|
| wall | 6:24 – 12 min | **3:25** |
| result | 764–792 passed, **1 timed out** | **740 passed, 0 timeouts** |
| live threads at midpoint | ~150 | **18** |
| slowest test | 180.59 s (the timeout) | 8.96 s (a funnel parity test) |

(The "after" row was measured on `master`'s test set before this PR was retargeted to `feature/native-bluesky-plans`; the branch now carries the fix as 0.78.1 on that line.)

**Residual, kept open on #812:** with the review's drain step added and the machine's memory pressure removed (a Docker VM had the Mac at ~15 MB free pages and 8 M swap-outs), one full run on the feature branch still stalled a single funnel-parity test (`test_scan_request_plan.py::test_named_noscan_plan_matches_the_funnel`, 9 s alone) for the full 180 s: **798 passed, 1 timed out, 6:33**. Its RunEngine thread was not being scheduled at all (it did not even process `loop.stop` within 5 s — the new warning fired), and memory, Tiled, Channel Access over the VPN (8.88 s with CA at localhost vs 8.93 s over the VPN) and config-file size are each ruled out by measurement. The thread-leak fix here is independent of that residual and verified on its own (150 → 18 live threads; a clean 740-pass run in 3:25). Phase 1 of #807 deletes the funnel-parity tests wholesale.

## Scope

One concern; +34/−1 in `conftest.py`, one flag in `check.sh`, changelog + patch bump 0.78.0 → 0.78.1 (test-only change → patch, per repo convention). No facility literals. No hardware surface.


