### PR TITLE
GeecsBluesky 0.78.0: single-shot refires only on an actual missing frame (#817)

### DIFF
--- a/GeecsBluesky/CHANGELOG.md
+++ b/GeecsBluesky/CHANGELOG.md
@@ -4,6 +4,28 @@ All notable changes to `geecs-bluesky` are documented here.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.77.0] - 2026-09-10
+
+### Fixed
+
+- `geecs_single_shot` no longer reports every attempt failure as a camera
+  frame drop. Its `try` spans the whole attempt (trigger + `fire()` +
+  wait), so a `fire()` whose gateway `:SP` write was refused also arrives
+  as `FailedStatus` — and was logged as "no frame from unknown device
+  (known camera frame-drop intermittency)", retried twice more against a
+  write that never landed, and propagated with the cameras blamed.
+  Observed live 2026-09-10 (Undulator Scan033): three attempts in 838 ms
+  against a 3.0 s trigger timeout, no device named, and no
+  `Shot controller -> SINGLESHOT` line for any of them.
+
+  Only a `GeecsTriggerTimeoutError` cause is a missing frame now. Anything
+  else is logged at ERROR with its real cause — `aioca.CANothing` carries
+  the PV name and the CA message — and propagates on the first attempt
+  instead of burning the refire budget. Frame-drop refire, the
+  `CONNECTED` device-down gate, and the strict one-row-per-shot semantics
+  are unchanged.
+
+
 ## [0.76.3] - 2026-09-08
 
 ### Changed

--- a/GeecsBluesky/CHANGELOG.md
+++ b/GeecsBluesky/CHANGELOG.md
@@ -16,7 +16,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   write that never landed, and propagated with the cameras blamed.
   Observed live 2026-09-10 (Undulator Scan033): three attempts in 838 ms
   against a 3.0 s trigger timeout, no device named, and no
-  `Shot controller -> SINGLESHOT` line for any of them.
+  `Shot controller → SINGLESHOT` line for any of them.
 
   Only a `GeecsTriggerTimeoutError` cause is a missing frame now. Anything
   else is logged at ERROR with its real cause — `aioca.CANothing` carries

--- a/GeecsBluesky/CHANGELOG.md
+++ b/GeecsBluesky/CHANGELOG.md
@@ -25,6 +25,26 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   `CONNECTED` device-down gate, and the strict one-row-per-shot semantics
   are unchanged.
 
+  Hardware-verified 2026-09-10 against the live gateway (a `:SP` put to a
+  nonexistent PV, `UC_ModeImager` armed read-only): one fire, no refire,
+  no event row, and the ERROR line naming the PV and the CA message.
+
+- Both plan-side error handlers selected the cause with
+  `exc.__cause__ or exc`, which discards exactly the object they exist to
+  report: `aioca.CANothing.__bool__` is `errorcode == ECA_NORMAL`, so a
+  *failed* CA put is falsy and `or` silently fell through to the
+  `FailedStatus`, whose text is only the status repr. The operator got
+  `<AsyncStatus …, done>` — `done` because `AsyncStatusBase.__repr__` also
+  tests the exception for truthiness. Now `is not None` in both
+  `plans/single_shot.py` and `plans/step_scan.py` (the `FAILED MOVE`
+  line, where the same bug hid any CA-layer move failure;
+  `GeecsMotorTimeoutError` is truthy, which is why the tolerance path
+  never exposed it).
+
+  Caught on hardware, not in tests: the mock stand-in was a plain
+  exception and therefore truthy. It now mirrors `CANothing`'s falsiness
+  and repr/str split.
+
 
 ## [0.76.3] - 2026-09-08
 

--- a/GeecsBluesky/geecs_bluesky/plans/single_shot.py
+++ b/GeecsBluesky/geecs_bluesky/plans/single_shot.py
@@ -39,18 +39,24 @@ from geecs_bluesky.exceptions import (
 logger = logging.getLogger(__name__)
 
 
-def _no_frame_device(exc: BaseException) -> str:
-    """Name the device that produced no frame, from a wait failure.
+def _no_frame_timeout(exc: BaseException) -> GeecsTriggerTimeoutError | None:
+    """The no-frame timeout behind a wait failure — or ``None`` if it is not one.
 
-    The RunEngine wraps the status's own error in
+    The RunEngine wraps the failing status's own error in
     :exc:`~bluesky.utils.FailedStatus` (``raise FailedStatus(ret) from exc``),
-    so the device-attributed :exc:`GeecsTriggerTimeoutError` rides on
+    so a device-attributed :exc:`GeecsTriggerTimeoutError` rides on
     ``__cause__``.
+
+    An attempt creates two kinds of status and only one of them is a frame
+    drop: the detectors' ``trigger()`` waits (which fail *only* as a named
+    :exc:`GeecsTriggerTimeoutError`) and ``fire()``'s own gateway ``:SP``
+    put (a rejected write surfaces as ``aioca.CANothing``, whose text
+    carries the PV and the CA message).  Returning ``None`` for the latter
+    is what keeps a failed *fire* from being reported — and retried — as a
+    camera frame drop.
     """
     cause = exc.__cause__
-    if isinstance(cause, GeecsTriggerTimeoutError):
-        return cause.device_name
-    return "unknown device"
+    return cause if isinstance(cause, GeecsTriggerTimeoutError) else None
 
 
 def _confirm_device_down(devices: Sequence[Any], device_name: str):
@@ -105,8 +111,16 @@ def geecs_single_shot(
     the recovery because a missed pulse never yields a frame (live-verified;
     numbers in ``GeecsBluesky/CHANGELOG.md`` 0.20.0).
 
-    Refire is gated on gateway liveness: a frameless device whose
-    ``CONNECTED`` PV reads Disconnected went down mid-scan, so
+    Refire is gated twice, because only one kind of failure is a frame drop.
+    First on **attribution**: the ``try`` spans the whole attempt (trigger +
+    ``fire()`` + wait), so a failed ``fire()`` — a rejected gateway ``:SP``
+    put — also arrives as ``FailedStatus``.  Only a
+    :exc:`~geecs_bluesky.exceptions.GeecsTriggerTimeoutError` cause is a
+    missing frame; anything else is logged with its real cause and
+    propagates on the first attempt rather than burning the budget against
+    a fault refire cannot fix (see :func:`_no_frame_timeout`).  Then on
+    **gateway liveness**: a frameless device whose ``CONNECTED`` PV reads
+    Disconnected went down mid-scan, so
     :exc:`~geecs_bluesky.exceptions.GeecsDeviceDownError` is raised instead
     of burning refires; a live or unreadable status (fail-open) keeps the
     bounded-refire behavior.
@@ -158,8 +172,28 @@ def geecs_single_shot(
             # so the stash is consumed right here at the wait; a straggler
             # that lands inside the next attempt is caught by this same try
             # (it wraps the whole attempt: trigger + fire + wait) and merely
-            # consumes one refire instead of aborting the scan.
-            device_name = _no_frame_device(exc)
+            # consumes one refire instead of aborting the scan.  That the try
+            # spans the whole attempt is also why the cause must be
+            # classified before anything is retried: a fire that never fired
+            # lands here too.
+            timeout = _no_frame_timeout(exc)
+            if timeout is None:
+                # Not a missing frame, so a refire cannot help and would only
+                # burn the budget against the real fault (live 2026-09-10,
+                # Scan033: a rejected SINGLESHOT put failed all three attempts
+                # in under a second and the scan died blaming the cameras).
+                # Name the actual cause - it is the only record of which PV
+                # failed and why.
+                logger.error(
+                    "single-shot attempt %d of %d failed, but not from a "
+                    "missing frame - re-firing cannot help, so the failure "
+                    "propagates: %r",
+                    attempt,
+                    attempts,
+                    exc.__cause__ or exc,
+                )
+                raise
+            device_name = timeout.device_name
             down = yield from _confirm_device_down(devices, device_name)
             if down:
                 raise GeecsDeviceDownError(

--- a/GeecsBluesky/geecs_bluesky/plans/single_shot.py
+++ b/GeecsBluesky/geecs_bluesky/plans/single_shot.py
@@ -192,7 +192,14 @@ def geecs_single_shot(
                 # the bare ECA errorcode).  Hence ``%s`` on the cause, with
                 # its type spelled out separately so an exception with an
                 # empty message still names itself.
-                cause = exc.__cause__ or exc
+                #
+                # ``is not None``, never ``or``: ``CANothing.__bool__`` is
+                # ``errorcode == ECA_NORMAL``, so the *failed* put whose
+                # identity this line exists to report is falsy, and
+                # ``exc.__cause__ or exc`` silently selects the useless
+                # ``FailedStatus`` instead (caught on hardware 2026-09-10 —
+                # the mock stand-in was truthy and could not see it).
+                cause = exc.__cause__ if exc.__cause__ is not None else exc
                 logger.error(
                     "single-shot attempt %d of %d failed, but not from a "
                     "missing frame — re-firing cannot help, so the failure "

--- a/GeecsBluesky/geecs_bluesky/plans/single_shot.py
+++ b/GeecsBluesky/geecs_bluesky/plans/single_shot.py
@@ -122,9 +122,8 @@ def geecs_single_shot(
     line is deliberately the record: the ``FailedStatus`` propagates
     unwrapped (the run's stop-document reason is the status repr), so the
     scan log is where the failing PV and its CA message are written down.
-    Then on
-    **gateway liveness**: a frameless device whose ``CONNECTED`` PV reads
-    Disconnected went down mid-scan, so
+    Then on **gateway liveness**: a frameless device whose ``CONNECTED`` PV
+    reads Disconnected went down mid-scan, so
     :exc:`~geecs_bluesky.exceptions.GeecsDeviceDownError` is raised instead
     of burning refires; a live or unreadable status (fail-open) keeps the
     bounded-refire behavior.

--- a/GeecsBluesky/geecs_bluesky/plans/single_shot.py
+++ b/GeecsBluesky/geecs_bluesky/plans/single_shot.py
@@ -182,11 +182,11 @@ def geecs_single_shot(
                 # burn the budget against the real fault (live 2026-09-10,
                 # Scan033: a rejected SINGLESHOT put failed all three attempts
                 # in under a second and the scan died blaming the cameras).
-                # Name the actual cause - it is the only record of which PV
+                # Name the actual cause — it is the only record of which PV
                 # failed and why.
                 logger.error(
                     "single-shot attempt %d of %d failed, but not from a "
-                    "missing frame - re-firing cannot help, so the failure "
+                    "missing frame — re-firing cannot help, so the failure "
                     "propagates: %r",
                     attempt,
                     attempts,

--- a/GeecsBluesky/geecs_bluesky/plans/single_shot.py
+++ b/GeecsBluesky/geecs_bluesky/plans/single_shot.py
@@ -118,7 +118,11 @@ def geecs_single_shot(
     :exc:`~geecs_bluesky.exceptions.GeecsTriggerTimeoutError` cause is a
     missing frame; anything else is logged with its real cause and
     propagates on the first attempt rather than burning the budget against
-    a fault refire cannot fix (see :func:`_no_frame_timeout`).  Then on
+    a fault refire cannot fix (see :func:`_no_frame_timeout`).  That ERROR
+    line is deliberately the record: the ``FailedStatus`` propagates
+    unwrapped (the run's stop-document reason is the status repr), so the
+    scan log is where the failing PV and its CA message are written down.
+    Then on
     **gateway liveness**: a frameless device whose ``CONNECTED`` PV reads
     Disconnected went down mid-scan, so
     :exc:`~geecs_bluesky.exceptions.GeecsDeviceDownError` is raised instead
@@ -182,15 +186,22 @@ def geecs_single_shot(
                 # burn the budget against the real fault (live 2026-09-10,
                 # Scan033: a rejected SINGLESHOT put failed all three attempts
                 # in under a second and the scan died blaming the cameras).
-                # Name the actual cause — it is the only record of which PV
-                # failed and why.
+                # Name the actual cause — this line is the only record of
+                # which PV failed and why: the FailedStatus that propagates
+                # carries the status object's repr, and ``aioca.CANothing``
+                # renders the CA message only through ``str`` (its repr is
+                # the bare ECA errorcode).  Hence ``%s`` on the cause, with
+                # its type spelled out separately so an exception with an
+                # empty message still names itself.
+                cause = exc.__cause__ or exc
                 logger.error(
                     "single-shot attempt %d of %d failed, but not from a "
                     "missing frame — re-firing cannot help, so the failure "
-                    "propagates: %r",
+                    "propagates: %s: %s",
                     attempt,
                     attempts,
-                    exc.__cause__ or exc,
+                    type(cause).__name__,
+                    cause,
                 )
                 raise
             device_name = timeout.device_name

--- a/GeecsBluesky/geecs_bluesky/plans/step_scan.py
+++ b/GeecsBluesky/geecs_bluesky/plans/step_scan.py
@@ -168,7 +168,13 @@ def move_with_failed_move_pause(
             f"{getattr(m, 'name', m)} -> {t!r}" for m, t in zip(motors, targets)
         )
         while True:
-            cause = exc.__cause__ or exc
+            # ``is not None``, never ``or``: a move that failed at the CA
+            # layer carries an ``aioca.CANothing`` cause, whose ``__bool__``
+            # is False for an error — ``or`` would discard exactly the
+            # object naming the PV and the CA message, leaving the operator
+            # the ``FailedStatus`` repr.  (``GeecsMotorTimeoutError`` is
+            # truthy, which is why the tolerance path never exposed this.)
+            cause = exc.__cause__ if exc.__cause__ is not None else exc
             logger.error(
                 "%s: commanded %s, one axis failed - see cause for which: "
                 "%s; resume retries the move from the last checkpoint, stop "

--- a/GeecsBluesky/pyproject.toml
+++ b/GeecsBluesky/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-bluesky"
-version = "0.76.3"
+version = "0.77.0"
 description = "Bluesky / ophyd-async bridge for the GEECS control system"
 authors = ["Sam Barber <sbarber@lbl.gov>"]
 readme = "README.md"

--- a/GeecsBluesky/tests/test_pause_semantics.py
+++ b/GeecsBluesky/tests/test_pause_semantics.py
@@ -593,6 +593,24 @@ def test_hard_pause_mid_move_resume_replays_only_the_move() -> None:
 # ---------------------------------------------------------------------------
 
 
+class _FalsyMoveError(Exception):
+    """A move failure that is falsy, as ``aioca.CANothing`` is on error.
+
+    ``CANothing.__bool__`` is ``errorcode == ECA_NORMAL``, so a move that
+    fails at the CA layer carries a *falsy* cause.  That is what makes this
+    class load-bearing rather than decorative: with a truthy stand-in, the
+    FAILED MOVE line's ``exc.__cause__ or exc`` and ``exc.__cause__ if ... is
+    not None`` select the same object and the reason assertion below cannot
+    tell them apart — which is how the ``or`` idiom survived here until it
+    was caught on hardware.  ``GeecsMotorTimeoutError`` is truthy, so the
+    tolerance path never exercised this.
+    """
+
+    def __bool__(self) -> bool:
+        """Falsy, like a ``CANothing`` carrying a CA error code."""
+        return False
+
+
 class _FlakyMotor:
     """Movable failing its move to *fail_at* the first *failures* times."""
 
@@ -613,7 +631,7 @@ class _FlakyMotor:
 
         async def _move() -> None:
             if fail:
-                raise RuntimeError(
+                raise _FalsyMoveError(
                     f"simulated move failure: {self.name} did not reach {value}"
                 )
             self._position = float(value)

--- a/GeecsBluesky/tests/test_single_shot_plan.py
+++ b/GeecsBluesky/tests/test_single_shot_plan.py
@@ -26,7 +26,7 @@ from geecs_bluesky.plans.step_scan import geecs_step_scan
 
 pytest.importorskip("aioca")
 
-from ophyd_async.core import set_mock_value  # noqa: E402
+from ophyd_async.core import AsyncStatus, set_mock_value  # noqa: E402
 
 from geecs_bluesky.devices.ca import CaGenericDetector, CaMotor  # noqa: E402
 from tests.ca_mock_helpers import connect_mock, follow_setpoint  # noqa: E402
@@ -280,6 +280,65 @@ def test_single_shot_refire_exhaustion_propagates() -> None:
         assert isinstance(excinfo.value.__cause__, GeecsTriggerTimeoutError)
         assert excinfo.value.__cause__.device_name == "U_Combined"
         assert events == []  # a failed shot records nothing
+
+
+class _PutRejected(RuntimeError):
+    """Stands in for ``aioca.CANothing``: a gateway ``:SP`` write GEECS refused."""
+
+
+class _RejectedPut:
+    """Minimal Movable whose put fails the way a rejected gateway ``:SP`` write does."""
+
+    name = "trigger_sp"
+    parent = None
+
+    def set(self, value: str) -> AsyncStatus:
+        """Fail immediately, carrying the PV name the way a CA error does."""
+
+        async def _put() -> None:
+            raise _PutRejected(
+                "Undulator:U_DG645:Trigger:SP: Channel write request failed"
+            )
+
+        return AsyncStatus(_put())
+
+
+def test_single_shot_failed_fire_propagates_without_refire(caplog) -> None:
+    """A rejected SINGLESHOT put is not a frame drop: fail on attempt 1, named.
+
+    Regression for the live 2026-09-10 Scan033 signature: the ``try`` spans
+    the whole attempt, so a ``fire()`` whose gateway put was refused arrived
+    as ``FailedStatus`` and was reported as "no frame from unknown device",
+    burning all three fires in under a second and failing the scan with the
+    cameras blamed.  Refire cannot fix a write that never landed, so the
+    failure must propagate on the first attempt with its real cause named.
+    """
+    with _setup_scan() as (_motor, cam, RE, events):
+        cam._trigger_timeout = 0.5
+        # Live per the gateway: nothing here is a device-down case either.
+        set_mock_value(cam.connected_status, "Connected")
+        calls = {"fire": 0}
+
+        def rejected_fire():
+            calls["fire"] += 1
+            yield from bps.abs_set(_RejectedPut(), "SINGLESHOT", group="fire")
+            yield from bps.wait("fire")
+
+        with caplog.at_level(logging.WARNING, logger="geecs_bluesky.plans.single_shot"):
+            with pytest.raises(FailedStatus) as excinfo:
+                RE(_single_shot_run([cam], rejected_fire, max_refires=2))
+
+        assert calls["fire"] == 1  # no refire against a write that never landed
+        assert events == []  # a failed shot records nothing
+        assert isinstance(excinfo.value.__cause__, _PutRejected)
+        records = [
+            r for r in caplog.records if r.name == "geecs_bluesky.plans.single_shot"
+        ]
+        assert [r.levelno for r in records] == [logging.ERROR]  # no refire warning
+        message = records[0].getMessage()
+        assert "Trigger:SP" in message  # names the PV that actually failed
+        assert "U_Combined" not in message  # never blamed on a camera
+        assert "unknown device" not in message
 
 
 def test_single_shot_partial_miss_drains_orphan_frame() -> None:

--- a/GeecsBluesky/tests/test_single_shot_plan.py
+++ b/GeecsBluesky/tests/test_single_shot_plan.py
@@ -306,6 +306,16 @@ class _PutRejected(Exception):
         """PV plus the decoded CA message — the operator-useful rendering."""
         return f"{self.name}: {self._message}"
 
+    def __bool__(self) -> bool:
+        """Falsy on error, exactly like ``CANothing`` (``ok`` is False).
+
+        Load-bearing for this test: the real object being falsy is what made
+        ``exc.__cause__ or exc`` silently select the useless ``FailedStatus``.
+        A truthy stand-in cannot see that bug — it was caught on hardware,
+        not here, and this method is why it cannot come back.
+        """
+        return False
+
 
 _REJECTED_PV = "Undulator:U_DG645:Trigger:SP"
 _REJECTED_MESSAGE = "Channel write request failed"

--- a/GeecsBluesky/tests/test_single_shot_plan.py
+++ b/GeecsBluesky/tests/test_single_shot_plan.py
@@ -282,8 +282,33 @@ def test_single_shot_refire_exhaustion_propagates() -> None:
         assert events == []  # a failed shot records nothing
 
 
-class _PutRejected(RuntimeError):
-    """Stands in for ``aioca.CANothing``: a gateway ``:SP`` write GEECS refused."""
+class _PutRejected(Exception):
+    """Stands in for ``aioca.CANothing``: a gateway ``:SP`` write GEECS refused.
+
+    Mirrors ``CANothing``'s repr/str split deliberately — ``__repr__`` shows
+    the PV and the bare ECA errorcode, and *only* ``__str__`` renders the CA
+    message.  A stand-in without that split (a plain ``RuntimeError``, whose
+    repr embeds its whole message) would let a ``%r`` log line pass the
+    assertions below while dropping the CA message in production.
+    """
+
+    def __init__(self, name: str, errorcode: int, message: str) -> None:
+        super().__init__(name, errorcode)
+        self.name = name
+        self.errorcode = errorcode
+        self._message = message
+
+    def __repr__(self) -> str:
+        """The bare errorcode — no CA message, exactly like ``CANothing``."""
+        return f"_PutRejected({self.name!r}, {self.errorcode})"
+
+    def __str__(self) -> str:
+        """PV plus the decoded CA message — the operator-useful rendering."""
+        return f"{self.name}: {self._message}"
+
+
+_REJECTED_PV = "Undulator:U_DG645:Trigger:SP"
+_REJECTED_MESSAGE = "Channel write request failed"
 
 
 class _RejectedPut:
@@ -296,9 +321,7 @@ class _RejectedPut:
         """Fail immediately, carrying the PV name the way a CA error does."""
 
         async def _put() -> None:
-            raise _PutRejected(
-                "Undulator:U_DG645:Trigger:SP: Channel write request failed"
-            )
+            raise _PutRejected(_REJECTED_PV, 80, _REJECTED_MESSAGE)
 
         return AsyncStatus(_put())
 
@@ -336,7 +359,11 @@ def test_single_shot_failed_fire_propagates_without_refire(caplog) -> None:
         ]
         assert [r.levelno for r in records] == [logging.ERROR]  # no refire warning
         message = records[0].getMessage()
-        assert "Trigger:SP" in message  # names the PV that actually failed
+        assert _REJECTED_PV in message  # names the PV that actually failed
+        # The CA message itself, not just the PV: CANothing renders it only
+        # through str(), so a %r log line would silently drop it.
+        assert _REJECTED_MESSAGE in message
+        assert "_PutRejected" in message  # and the exception type
         assert "U_Combined" not in message  # never blamed on a camera
         assert "unknown device" not in message
 

--- a/Planning/data_capture/01_central_pva_capture_scope.md
+++ b/Planning/data_capture/01_central_pva_capture_scope.md
@@ -372,8 +372,9 @@ own share; any design must handle h5py's non-thread-safety).
 
 ### Phase 5 — capture in the strict contract (small-medium)
 
-- Per-shot check between `bps.wait` and `create`
-  (`plans/single_shot.py:160-216`) reading the daemon's frames-captured
+- Per-shot check in `plans/single_shot.py`, between `bps.wait(group=grp)`
+  and `bps.create(name)` (named rather than numbered — the range went stale
+  twice in one PR), reading the daemon's frames-captured
   counter; must distinguish "no frame, refire helps" from "writer stalled,
   refire won't" (pattern: `_no_frame_timeout` `:42` — classify the cause
   before retrying — plus `_confirm_device_down` `:62` +

--- a/Planning/data_capture/01_central_pva_capture_scope.md
+++ b/Planning/data_capture/01_central_pva_capture_scope.md
@@ -373,9 +373,10 @@ own share; any design must handle h5py's non-thread-safety).
 ### Phase 5 — capture in the strict contract (small-medium)
 
 - Per-shot check between `bps.wait` and `create`
-  (`plans/single_shot.py:146-182`) reading the daemon's frames-captured
+  (`plans/single_shot.py:160-216`) reading the daemon's frames-captured
   counter; must distinguish "no frame, refire helps" from "writer stalled,
-  refire won't" (pattern: `_confirm_device_down` `:56` +
+  refire won't" (pattern: `_no_frame_timeout` `:42` — classify the cause
+  before retrying — plus `_confirm_device_down` `:62` +
   `plans/liveness.py:29`). Never insert between `create` and `save`.
 - `capture_policy` knob threaded through the exact `failed_move_policy`
   chain (`plans/step_scan.py:201` → `orchestration.py:83` →


### PR DESCRIPTION
Closes #817.

## What

`geecs_single_shot`'s `try` spans the whole attempt — `bps.trigger`,
`fire()`, and `bps.wait` — but its `except FailedStatus` treated everything
landing there as a camera frame drop. A `fire()` whose gateway `:SP` write
was refused (`aioca.caput(..., wait=True)` raises `aioca.CANothing`) got the
frame-drop wording, the `~1% observed` reassurance, its device identity
discarded as `"unknown device"`, and two more refires against a write that
never landed — before propagating.

`_no_frame_device` becomes `_no_frame_timeout`: it returns the attributed
`GeecsTriggerTimeoutError` or `None`. Only the former is a missing frame.
Anything else is logged at ERROR with its real cause (`CANothing` carries
the PV name and the CA message) and propagates on the first attempt.

Unchanged: frame-drop bounded refire, the `CONNECTED` device-down gate, the
strict one-row-per-shot semantics, and the no-cancellation reasoning for
abandoned statuses (a straggler `GeecsTriggerTimeoutError` still consumes
one refire rather than aborting the scan).

## Why

Undulator Scan033, 2026-09-10:

```
12:02:48.398 INFO    shot_controller   Shot controller → SINGLESHOT
12:02:49.156 INFO    devices.ca.motor  u_modeimageresp_position_axis_1: moving Position.Axis 1 → -10.5 (tol=0.005)
12:02:50.558 WARNING plans.single_shot single-shot attempt 1 of 3: no frame from unknown device — re-firing (known camera frame-drop intermittency, ~1% observed)
12:02:50.752 WARNING plans.single_shot single-shot attempt 2 of 3: no frame from unknown device — re-firing (known camera frame-drop intermittency, ~1% observed)
12:02:51.396 INFO    sfile_callback    Skipping legacy scalar file export for scan 33: exit_status='fail'
```

Three tells that this is not a frame drop: `"unknown device"` (a real miss
always carries `GeecsTriggerTimeoutError.device_name`); attempts 194 ms
apart against a 3.0 s `_trigger_timeout` with no overrides; and no
`Shot controller → SINGLESHOT` line for any of the three fires, which
`set_state` logs only after its writes complete.

The operator-visible failure named the wrong subsystem and no device. The
shot-control device shares a GEECS device server with `u_modeimageresp`, so
the real signal — one box taking out both the trigger write and the stage —
was hidden behind a message about camera intermittency.

## Scope

**Two concerns, bundled deliberately** — the same idiom, found by the same
investigation. Cheap to veto: the second is one line of source plus its pin.

| Concern | Files | LOC |
|---|---|---|
| 1. A failed `fire()` reported and retried as a camera frame drop | `plans/single_shot.py` (+73/-9), `tests/test_single_shot_plan.py` (+98/-1) | ~171 |
| 2. `exc.__cause__ or exc` discards a falsy `CANothing` — **pre-existing** on the `FAILED MOVE` line | `plans/step_scan.py` (+8/-1), `tests/test_pause_semantics.py` (+20/-1) | ~28 |
| Bookkeeping | `CHANGELOG.md` (+42), `pyproject.toml`, `Planning/data_capture/…` (+8/-4) | ~52 |

Total 233 insertions / 18 deletions across 7 files.

**The judgement call to veto if you disagree**: concern 2 fixes a bug this PR
did not introduce, on a different plan. Splitting it would leave a known
operator-facing defect in the `FAILED MOVE` line — the one your #820 work
touches — for the sake of a purer diff. I bundled it; say the word and I'll
lift it into its own PR.

The `Planning/` edit replaces stale `single_shot.py` line numbers this branch
invalidated with named landmarks. No facility literals added; no
`PV_CONTRACT.md` / `EVENT_SCHEMA.md` surface touched.

## Tests

- `tests/test_single_shot_plan.py` — **12 passed** (11 before + the new
  `test_single_shot_failed_fire_propagates_without_refire`).
- Verified the new test fails without the fix: on `master`'s
  `single_shot.py` it fires 3 times and emits 2 refire warnings.
- `./scripts/check.sh` (GeecsBluesky, own env, the way CI runs it) —
  **872 passed, 1 skipped, 4 deselected** in 253 s; lint clean.
- `./scripts/check.sh --all` — see the comment below.

## Hardware verification

**Done** — 2026-09-10, against the live CA gateway (0.20.2, 95 devices), run
from this branch's env. The queueserver was not involved and still runs
`master`.

Method, chosen to write nothing: `fire()` puts to a `:SP` PV that does not
exist, so no trigger can receive it; the only real hardware contact is a
read-only CA monitor on `UC_ModeImager` — the camera from the Scan033 incident.
No shot fired, no scan number claimed, no device variable written.

```
ERROR geecs_bluesky.plans.single_shot - single-shot attempt 1 of 3 failed,
  but not from a missing frame — re-firing cannot help, so the failure
  propagates: CANothing: undulator:u_dg645_shotcontrol:verify818:SP:
  User specified timeout on IO operation expired

fires      : 1   (no refire against a write that never landed)
event rows : 0
propagated : FailedStatus / cause CANothing
```

### The hardware run found a bug in the fix

The first run printed `FailedStatus: <AsyncStatus …, done>` — no PV, no CA
message. `aioca.CANothing.__bool__` is `errorcode == ECA_NORMAL`, so a
**failed** put is falsy and `exc.__cause__ or exc` fell through to the
`FailedStatus`. (`done` rather than `errored` for the same reason —
`AsyncStatusBase.__repr__` also tests the exception for truthiness.)

Fixed with `is not None` in both plans. `step_scan.py:171` carried the
identical idiom on the **`FAILED MOVE`** line, so any move failing at the CA
layer would have reported the same useless repr; `GeecsMotorTimeoutError` is
truthy, which is why the tolerance path never exposed it.

No mock could have caught this — a plain exception is truthy. The stand-in now
mirrors `CANothing`'s falsiness and fails against the old idiom.

## Note on the Scan033 root cause

The scan-side root cause is being addressed separately in #820 (per-axis move
tolerance from the DB). The Bluesky-side tolerance was tighter than the LV
device's, so the stage is marginal at −10.5: Scan034 shows two genuine
`FAILED MOVE` timeouts at that exact position, 30 s each.

That is **not** what killed Scan033 — 1.402 s to failure and zero ERROR lines
in the file — so what actually failed there remains unidentified. This PR does
not claim to fix it. It makes the next occurrence self-describing: one ERROR
line naming the PV and the CA message, instead of "no frame from unknown
device — known camera frame-drop intermittency".

**Merge order**: this lands *after* #820. Both are numbered 0.77.0; I'll merge
master in and renumber once #820 is in.

