### PR TITLE
GeecsBluesky 0.77.0: per-axis move tolerance from the DB, and stop losing on-boundary arrivals

### DIFF
--- a/GeecsBluesky/CHANGELOG.md
+++ b/GeecsBluesky/CHANGELOG.md
@@ -30,9 +30,13 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   per device rather than one per move) — an unreachable DB, a missing row, or
   the DB's "unset" spellings (NULL, `0.0`) fall back to `DEFAULT_TOLERANCE`,
   since a `0.0` tolerance would demand bit-exact float equality and never
-  converge. A DB tolerance more than 10x the default is served but logged as
-  suspect: that is the units-mismatch shape, and it would otherwise silently
-  confirm every move on the first poll. Mock sessions never query the DB.
+  converge. A DB tolerance larger than 1% of the variable's own `min`/`max`
+  travel span is served but logged as suspect: that is the units-mismatch
+  shape, and it would otherwise silently confirm every move on the first
+  poll. The comparison is span-relative rather than absolute because
+  tolerances carry each variable's own units (µm on `U_CompAeroTech`, mm on
+  the ESPs), so any fixed threshold flags correctly-configured axes for their
+  unit choice alone. Mock sessions never query the DB.
 
 - **The same on-boundary fix applied to `CaConfirmSettable`'s confirming
   poll** (`confirm.py`), which `build_movable` dispatches to *before*

--- a/GeecsBluesky/CHANGELOG.md
+++ b/GeecsBluesky/CHANGELOG.md
@@ -4,6 +4,33 @@ All notable changes to `geecs-bluesky` are documented here.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.77.0] - 2026-09-10
+
+### Fixed
+
+- **`CaMotor` no longer fails a converged move that lands exactly on its
+  tolerance.** `abs(-10.505 - -10.5)` is `0.005000000000000782` in binary
+  floating point, so a stage that arrived exactly one tolerance from target
+  failed `<= 0.005` by 8e-16, polled the full `move_timeout`, and paused the
+  scan for an operator (`U_ModeImagerESP/Position.Axis 1`, Scan034). The
+  arrival comparison now carries a relative epsilon — representation slack,
+  not a widened tolerance: a miss of twice the tolerance still times out.
+
+### Changed
+
+- **`GeecsSession.motor()` resolves the move tolerance from the GEECS DB**
+  (new `GeecsSession.variable_tolerance()`) instead of hardcoding `0.005` for
+  every axis on every device. The DB's per-variable `tolerance` is the
+  facility's own statement of what "arrived" means, and the hardcoded value
+  was wrong in both directions: `U_ModeImagerESP/Position.Axis 1` is
+  0.015 mm (where 0.005 failed converged moves) while axes 2 and 3 are
+  0.001 mm (where 0.005 silently accepted a position 5x outside spec).
+  Passing `tolerance=` still overrides. The lookup is best-effort and cached
+  per device — an unreachable DB, a missing row, or the DB's "unset"
+  spellings (NULL, `0.0`) fall back to `DEFAULT_TOLERANCE`, since a `0.0`
+  tolerance would demand bit-exact float equality and never converge. Mock
+  sessions never query the DB.
+
 ## [0.76.3] - 2026-09-08
 
 ### Changed

--- a/GeecsBluesky/CHANGELOG.md
+++ b/GeecsBluesky/CHANGELOG.md
@@ -19,17 +19,27 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Changed
 
 - **`GeecsSession.motor()` resolves the move tolerance from the GEECS DB**
-  (new `GeecsSession.variable_tolerance()`) instead of hardcoding `0.005` for
+  (new `GeecsSession.move_tolerance()`) instead of hardcoding `0.005` for
   every axis on every device. The DB's per-variable `tolerance` is the
   facility's own statement of what "arrived" means, and the hardcoded value
   was wrong in both directions: `U_ModeImagerESP/Position.Axis 1` is
   0.015 mm (where 0.005 failed converged moves) while axes 2 and 3 are
   0.001 mm (where 0.005 silently accepted a position 5x outside spec).
   Passing `tolerance=` still overrides. The lookup is best-effort and cached
-  per device — an unreachable DB, a missing row, or the DB's "unset"
-  spellings (NULL, `0.0`) fall back to `DEFAULT_TOLERANCE`, since a `0.0`
-  tolerance would demand bit-exact float equality and never converge. Mock
-  sessions never query the DB.
+  per device (failures too, so an off-network worker pays one connect timeout
+  per device rather than one per move) — an unreachable DB, a missing row, or
+  the DB's "unset" spellings (NULL, `0.0`) fall back to `DEFAULT_TOLERANCE`,
+  since a `0.0` tolerance would demand bit-exact float equality and never
+  converge. A DB tolerance more than 10x the default is served but logged as
+  suspect: that is the units-mismatch shape, and it would otherwise silently
+  confirm every move on the first poll. Mock sessions never query the DB.
+
+- **The same on-boundary fix applied to `CaConfirmSettable`'s confirming
+  poll** (`confirm.py`), which `build_movable` dispatches to *before*
+  `CaMotor` when a scan variable declares `confirm` — so for topology-C axes
+  it, not `CaMotor`, is the arrival check. `abs(1.20 - 1.15)` is
+  `0.050000000000000044`, so an EMQ set landing exactly on the 0.05 default
+  raised `GeecsConfirmTimeoutError` on a converged set.
 
 ## [0.76.3] - 2026-09-08
 

--- a/GeecsBluesky/geecs_bluesky/devices/ca/confirm.py
+++ b/GeecsBluesky/geecs_bluesky/devices/ca/confirm.py
@@ -27,6 +27,7 @@ from ophyd_async.core import AsyncStatus
 from ophyd_async.epics.core import epics_signal_r
 
 from geecs_bluesky.devices.ca._pv import ca_pv
+from geecs_bluesky.devices.ca.motor import _ULP_SLACK
 from geecs_bluesky.devices.ca.settable import CaSettable
 from geecs_bluesky.exceptions import GeecsConfirmTimeoutError
 
@@ -193,4 +194,9 @@ def _matches(
     """
     if datatype is str:
         return current == target
-    return abs(float(current) - float(target)) <= tolerance
+    # Same ULP slack as CaMotor's arrival check, and for the same reason: an
+    # exactly-on-tolerance match otherwise loses to representation error
+    # (|1.20 - 1.15| == 0.050000000000000044 > 0.05). This path takes
+    # precedence over kind: motor for topology-C axes, so it needs the fix too.
+    slack = _ULP_SLACK * max(abs(float(current)), abs(float(target)))
+    return abs(float(current) - float(target)) <= tolerance + slack

--- a/GeecsBluesky/geecs_bluesky/devices/ca/confirm.py
+++ b/GeecsBluesky/geecs_bluesky/devices/ca/confirm.py
@@ -27,7 +27,7 @@ from ophyd_async.core import AsyncStatus
 from ophyd_async.epics.core import epics_signal_r
 
 from geecs_bluesky.devices.ca._pv import ca_pv
-from geecs_bluesky.devices.ca.motor import _ULP_SLACK
+from geecs_bluesky.devices.ca.motor import ULP_SLACK
 from geecs_bluesky.devices.ca.settable import CaSettable
 from geecs_bluesky.exceptions import GeecsConfirmTimeoutError
 
@@ -198,5 +198,5 @@ def _matches(
     # exactly-on-tolerance match otherwise loses to representation error
     # (|1.20 - 1.15| == 0.050000000000000044 > 0.05). This path takes
     # precedence over kind: motor for topology-C axes, so it needs the fix too.
-    slack = _ULP_SLACK * max(abs(float(current)), abs(float(target)))
+    slack = ULP_SLACK * max(abs(float(current)), abs(float(target)))
     return abs(float(current) - float(target)) <= tolerance + slack

--- a/GeecsBluesky/geecs_bluesky/devices/ca/motor.py
+++ b/GeecsBluesky/geecs_bluesky/devices/ca/motor.py
@@ -37,10 +37,12 @@ _DEFAULT_MOVE_TIMEOUT = 30.0  # seconds
 #: resolves the per-axis DB value; this is what it returns when it cannot.
 DEFAULT_TOLERANCE = 0.005
 
-#: Layer-2 tolerances above this multiple of :data:`DEFAULT_TOLERANCE` are
-#: logged as suspect — almost certainly a units mismatch or an uncurated DB
-#: row rather than a genuinely coarse axis.
-_TOLERANCE_SANITY_FACTOR = 10.0
+#: A DB tolerance larger than this fraction of the variable's own travel span
+#: is logged as suspect.  Span-relative, not absolute: tolerances are in each
+#: variable's own units (µm on U_CompAeroTech, mm on the ESPs), so any fixed
+#: threshold flags correctly-configured axes purely for their unit choice —
+#: exactly the unit-blindness it is meant to detect.
+TOLERANCE_SPAN_FRACTION = 0.01
 
 # Binary floating point puts an exactly-on-tolerance arrival a few ULPs *over*
 # the limit: |-10.505 - -10.5| evaluates to 0.005000000000000782, not 0.005.
@@ -52,7 +54,7 @@ _TOLERANCE_SANITY_FACTOR = 10.0
 # epsilon under-covers exactly the large-coordinate axes (U_CompAeroTech reads
 # ~4e4). Four ULPs of the larger operand covers the subtraction plus the
 # comparison with room to spare, and stays far below any real tolerance.
-_ULP_SLACK = 4 * sys.float_info.epsilon
+ULP_SLACK = 4 * sys.float_info.epsilon
 
 
 class CaMotor(CaSettable):
@@ -136,7 +138,7 @@ class CaMotor(CaSettable):
         position = getattr(self, self._readback_attr_name)
         while True:
             current = float(await position.get_value())
-            slack = _ULP_SLACK * max(abs(current), abs(value))
+            slack = ULP_SLACK * max(abs(current), abs(value))
             if abs(current - value) <= self._tolerance + slack:
                 logger.debug(
                     "%s: arrived at %.6g (target=%.6g, tol=%.4g)",

--- a/GeecsBluesky/geecs_bluesky/devices/ca/motor.py
+++ b/GeecsBluesky/geecs_bluesky/devices/ca/motor.py
@@ -31,6 +31,18 @@ logger = logging.getLogger(__name__)
 
 _DEFAULT_MOVE_TIMEOUT = 30.0  # seconds
 
+#: Fallback move-completion tolerance, used only when the GEECS DB records no
+#: usable ``tolerance`` for the variable.  :meth:`GeecsSession.motor` resolves
+#: the per-axis DB value and passes it in; this is the floor when it cannot.
+DEFAULT_TOLERANCE = 0.005
+
+# Binary floating point puts an exactly-on-tolerance arrival a few ULPs *over*
+# the limit: |-10.505 - -10.5| evaluates to 0.005000000000000782, not 0.005.
+# A stage that landed exactly on tolerance therefore polled for the full
+# move_timeout and paused the scan for an operator (U_ModeImagerESP, Scan034).
+# Widen the comparison by a relative epsilon so on-boundary counts as arrived.
+_TOLERANCE_SLACK = 1.0 + 1e-9
+
 
 class CaMotor(CaSettable):
     """GEECS motor over gateway PVs, with position-feedback polling.
@@ -47,7 +59,11 @@ class CaMotor(CaSettable):
         ophyd-async device name (namespaces the event keys).
     tolerance : float
         Move completion tolerance.  ``set()`` resolves when
-        ``|readback − setpoint| ≤ tolerance``.  Default ``0.005``.
+        ``|readback − setpoint| ≤ tolerance``, with a relative epsilon so an
+        arrival landing exactly on the tolerance is not lost to binary
+        floating-point representation.  Defaults to
+        :data:`DEFAULT_TOLERANCE`; :meth:`GeecsSession.motor` normally passes
+        the GEECS DB's per-variable value instead.
     settle_time : float
         Extra seconds to wait after arrival before completing the status.
     move_timeout : float
@@ -62,7 +78,7 @@ class CaMotor(CaSettable):
         *,
         experiment: str | None = None,
         name: str = "motor",
-        tolerance: float = 0.005,
+        tolerance: float = DEFAULT_TOLERANCE,
         settle_time: float = 0.0,
         move_timeout: float = _DEFAULT_MOVE_TIMEOUT,
     ) -> None:
@@ -109,7 +125,7 @@ class CaMotor(CaSettable):
         position = getattr(self, self._readback_attr_name)
         while True:
             current = float(await position.get_value())
-            if abs(current - value) <= self._tolerance:
+            if abs(current - value) <= self._tolerance * _TOLERANCE_SLACK:
                 logger.debug(
                     "%s: arrived at %.6g (target=%.6g, tol=%.4g)",
                     self.name,

--- a/GeecsBluesky/geecs_bluesky/devices/ca/motor.py
+++ b/GeecsBluesky/geecs_bluesky/devices/ca/motor.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import sys
 
 from ophyd_async.core import AsyncStatus
 
@@ -32,16 +33,26 @@ logger = logging.getLogger(__name__)
 _DEFAULT_MOVE_TIMEOUT = 30.0  # seconds
 
 #: Fallback move-completion tolerance, used only when the GEECS DB records no
-#: usable ``tolerance`` for the variable.  :meth:`GeecsSession.motor` resolves
-#: the per-axis DB value and passes it in; this is the floor when it cannot.
+#: usable ``tolerance`` for the variable.  :meth:`GeecsSession.move_tolerance`
+#: resolves the per-axis DB value; this is what it returns when it cannot.
 DEFAULT_TOLERANCE = 0.005
+
+#: Layer-2 tolerances above this multiple of :data:`DEFAULT_TOLERANCE` are
+#: logged as suspect — almost certainly a units mismatch or an uncurated DB
+#: row rather than a genuinely coarse axis.
+_TOLERANCE_SANITY_FACTOR = 10.0
 
 # Binary floating point puts an exactly-on-tolerance arrival a few ULPs *over*
 # the limit: |-10.505 - -10.5| evaluates to 0.005000000000000782, not 0.005.
 # A stage that landed exactly on tolerance therefore polled for the full
 # move_timeout and paused the scan for an operator (U_ModeImagerESP, Scan034).
-# Widen the comparison by a relative epsilon so on-boundary counts as arrived.
-_TOLERANCE_SLACK = 1.0 + 1e-9
+#
+# The error in |current - value| scales with the *operands*, not the tolerance
+# (~ULP(|position|) = |x| * 2.2e-16), so the slack must too: a tolerance-relative
+# epsilon under-covers exactly the large-coordinate axes (U_CompAeroTech reads
+# ~4e4). Four ULPs of the larger operand covers the subtraction plus the
+# comparison with room to spare, and stays far below any real tolerance.
+_ULP_SLACK = 4 * sys.float_info.epsilon
 
 
 class CaMotor(CaSettable):
@@ -59,9 +70,9 @@ class CaMotor(CaSettable):
         ophyd-async device name (namespaces the event keys).
     tolerance : float
         Move completion tolerance.  ``set()`` resolves when
-        ``|readback − setpoint| ≤ tolerance``, with a relative epsilon so an
-        arrival landing exactly on the tolerance is not lost to binary
-        floating-point representation.  Defaults to
+        ``|readback − setpoint| ≤ tolerance``, with a few ULPs of the larger
+        operand as slack so an arrival landing exactly on the tolerance is not
+        lost to binary floating-point representation.  Defaults to
         :data:`DEFAULT_TOLERANCE`; :meth:`GeecsSession.motor` normally passes
         the GEECS DB's per-variable value instead.
     settle_time : float
@@ -125,7 +136,8 @@ class CaMotor(CaSettable):
         position = getattr(self, self._readback_attr_name)
         while True:
             current = float(await position.get_value())
-            if abs(current - value) <= self._tolerance * _TOLERANCE_SLACK:
+            slack = _ULP_SLACK * max(abs(current), abs(value))
+            if abs(current - value) <= self._tolerance + slack:
                 logger.debug(
                     "%s: arrived at %.6g (target=%.6g, tol=%.4g)",
                     self.name,

--- a/GeecsBluesky/geecs_bluesky/session.py
+++ b/GeecsBluesky/geecs_bluesky/session.py
@@ -51,6 +51,7 @@ from geecs_bluesky.devices.ca import (
     CaTelemetryReadable,
     CaTimestampedReadable,
 )
+from geecs_bluesky.devices.ca.motor import DEFAULT_TOLERANCE
 from geecs_bluesky.forward_expr import CompiledForward
 from geecs_bluesky.models.shot_control import ShotControlConfig, ShotControlWrites
 from geecs_bluesky.optimize import BinData, Suggester
@@ -229,6 +230,8 @@ class GeecsSession:
         # scan()/optimize()/run()/run_action() refuse while it is held, and
         # move_variable refuses while the RE is busy (review, PR #597).
         self._manual_move_lock = threading.Lock()
+        # device -> {variable: DB tolerance}; filled lazily by motor()
+        self._tolerance_cache: dict[str, dict[str, float]] = {}
         # Silence upstream's RequestAbort traceback (operator aborts are
         # quiet, intentional outcomes — #563 follow-up).  RE.log is a
         # LoggerAdapter over the PROCESS-WIDE ``bluesky`` logger shared by
@@ -488,10 +491,22 @@ class GeecsSession:
         device: str,
         variable: str,
         *,
-        tolerance: float = 0.005,
+        tolerance: float | None = None,
         name: str | None = None,
     ) -> CaMotor:
-        """Position-feedback motor (blocking :SP put + readback poll)."""
+        """Position-feedback motor (blocking :SP put + readback poll).
+
+        *tolerance* defaults to the GEECS DB's per-variable ``tolerance`` —
+        the facility's own statement of what "arrived" means for that axis —
+        resolved by :meth:`variable_tolerance`.  Passing a value overrides it.
+
+        The DB value matters in both directions: it is 0.015 mm on
+        ``U_ModeImagerESP/Position.Axis 1`` (where the old hardcoded 0.005
+        failed converged moves) and 0.001 mm on that device's axes 2 and 3
+        (where 0.005 silently accepted a position 5x outside spec).
+        """
+        if tolerance is None:
+            tolerance = self.variable_tolerance(device, variable)
         return self._connect(
             CaMotor(
                 device,
@@ -501,6 +516,60 @@ class GeecsSession:
                 tolerance=tolerance,
             )
         )
+
+    def variable_tolerance(self, device: str, variable: str) -> float:
+        """Return the GEECS DB set-convergence tolerance for *variable*.
+
+        Falls back to :data:`~geecs_bluesky.devices.ca.motor.DEFAULT_TOLERANCE`
+        when the DB records nothing usable.  "Nothing usable" covers a missing
+        device or variable row, a NULL tolerance, and a non-positive one (the
+        DB's unset spelling — ``Speed.Axis1`` carries ``0.0``); a zero
+        tolerance would demand bit-exact equality and never converge.
+
+        Best-effort by design: this is metadata enrichment on the way to a
+        move, so an unreachable DB degrades to the default rather than failing
+        the scan.  Results are cached per device for the life of the session —
+        device metadata does not change mid-scan, and a gateway restart is
+        already required for DB edits to take effect.
+        """
+        if self._mock:
+            return DEFAULT_TOLERANCE
+        try:
+            rows = self._variable_tolerances(device)
+        except Exception:
+            logger.warning(
+                "%s: could not read DB tolerances; using default %g for %s",
+                device,
+                DEFAULT_TOLERANCE,
+                variable,
+                exc_info=True,
+            )
+            return DEFAULT_TOLERANCE
+        tolerance = rows.get(variable)
+        if tolerance is None:
+            logger.info(
+                "%s/%s: no DB tolerance; using default %g",
+                device,
+                variable,
+                DEFAULT_TOLERANCE,
+            )
+            return DEFAULT_TOLERANCE
+        return tolerance
+
+    def _variable_tolerances(self, device: str) -> dict[str, float]:
+        """Cached ``{variable: tolerance}`` for *device*, positive values only."""
+        cached = self._tolerance_cache.get(device)
+        if cached is None:
+            from geecs_core.db.geecs_db import GeecsDb
+
+            cached = {}
+            for row in GeecsDb.get_device_variables(device):
+                name = row.get("name")
+                tolerance = row.get("tolerance")
+                if name and isinstance(tolerance, (int, float)) and tolerance > 0:
+                    cached[name] = float(tolerance)
+            self._tolerance_cache[device] = cached
+        return cached
 
     def settable(
         self,

--- a/GeecsBluesky/geecs_bluesky/session.py
+++ b/GeecsBluesky/geecs_bluesky/session.py
@@ -53,7 +53,7 @@ from geecs_bluesky.devices.ca import (
 )
 from geecs_bluesky.devices.ca.motor import (
     DEFAULT_TOLERANCE,
-    _TOLERANCE_SANITY_FACTOR,
+    TOLERANCE_SPAN_FRACTION,
 )
 from geecs_bluesky.forward_expr import CompiledForward
 from geecs_bluesky.models.shot_control import ShotControlConfig, ShotControlWrites
@@ -500,8 +500,12 @@ class GeecsSession:
         """Position-feedback motor (blocking :SP put + readback poll).
 
         *tolerance* defaults to :meth:`move_tolerance` — the GEECS DB's
-        per-variable convergence criterion with layer-2 headroom applied.
-        Passing a value overrides it.
+        per-variable convergence criterion.  Passing a value overrides it.
+
+        The DB value matters in both directions: it is 0.015 mm on
+        ``U_ModeImagerESP/Position.Axis 1`` (where the previously hardcoded
+        0.005 failed converged moves) and 0.001 mm on that device's axes 2
+        and 3 (where 0.005 silently accepted a position 5x outside spec).
         """
         if tolerance is None:
             tolerance = self.move_tolerance(device, variable)
@@ -558,22 +562,44 @@ class GeecsSession:
                 DEFAULT_TOLERANCE,
             )
             return DEFAULT_TOLERANCE
-        if db_tolerance > _TOLERANCE_SANITY_FACTOR * DEFAULT_TOLERANCE:
-            # A units mismatch or an uncurated row (whole-row type inheritance
-            # can land a devicetype default on an instance in other units)
-            # would make every readback "arrive" on the first poll — silently
-            # reinstating the false-arrival mode layer 2 exists to catch.
+        return db_tolerance
+
+    @staticmethod
+    def _warn_if_tolerance_implausible(
+        device: str, variable: str, row: dict[str, Any]
+    ) -> None:
+        """Log a DB tolerance that is large next to the variable's own travel.
+
+        A units mismatch or an uncurated row (whole-row type inheritance can
+        land a devicetype default on an instance in other units) would make
+        every readback "arrive" on the first poll — silently reinstating the
+        false-arrival mode this poll exists to catch.
+
+        The comparison is against the variable's **own** ``min``/``max`` span,
+        never an absolute number: tolerances carry each variable's units, so a
+        fixed threshold flags correctly-configured axes for their unit choice
+        alone.  ``U_CompAeroTech/Position.Axis1`` is a genuine 1.0 µm on
+        115000 µm of travel (0.0009% — silent); the same 1.0 on a 25 mm axis
+        is 4% and worth a look.  Rows without a usable span are not judged.
+        """
+        tolerance = row.get("tolerance")
+        lo, hi = row.get("min"), row.get("max")
+        if not isinstance(lo, (int, float)) or not isinstance(hi, (int, float)):
+            return
+        span = float(hi) - float(lo)
+        if span <= 0:
+            return
+        if float(tolerance) > TOLERANCE_SPAN_FRACTION * span:
             logger.warning(
-                "%s/%s: DB tolerance %g is over %gx the %g default — check the "
-                "variable's units and DB row; moves will confirm on almost any "
+                "%s/%s: DB tolerance %g is %.1f%% of the variable's %g span — "
+                "check its units and DB row; moves may confirm on almost any "
                 "readback",
                 device,
                 variable,
-                db_tolerance,
-                _TOLERANCE_SANITY_FACTOR,
-                DEFAULT_TOLERANCE,
+                tolerance,
+                100.0 * float(tolerance) / span,
+                span,
             )
-        return db_tolerance
 
     def _variable_tolerances(self, device: str) -> dict[str, float]:
         """Cached ``{variable: DB tolerance}`` for *device*, positive values only.
@@ -598,6 +624,7 @@ class GeecsSession:
                 tolerance = row.get("tolerance")
                 if name and isinstance(tolerance, (int, float)) and tolerance > 0:
                     tolerances[name] = float(tolerance)
+                    self._warn_if_tolerance_implausible(device, name, row)
         except Exception:
             logger.warning(
                 "%s: could not read DB tolerances; falling back to the default "

--- a/GeecsBluesky/geecs_bluesky/session.py
+++ b/GeecsBluesky/geecs_bluesky/session.py
@@ -51,7 +51,10 @@ from geecs_bluesky.devices.ca import (
     CaTelemetryReadable,
     CaTimestampedReadable,
 )
-from geecs_bluesky.devices.ca.motor import DEFAULT_TOLERANCE
+from geecs_bluesky.devices.ca.motor import (
+    DEFAULT_TOLERANCE,
+    _TOLERANCE_SANITY_FACTOR,
+)
 from geecs_bluesky.forward_expr import CompiledForward
 from geecs_bluesky.models.shot_control import ShotControlConfig, ShotControlWrites
 from geecs_bluesky.optimize import BinData, Suggester
@@ -230,7 +233,7 @@ class GeecsSession:
         # scan()/optimize()/run()/run_action() refuse while it is held, and
         # move_variable refuses while the RE is busy (review, PR #597).
         self._manual_move_lock = threading.Lock()
-        # device -> {variable: DB tolerance}; filled lazily by motor()
+        # device -> {variable: DB tolerance}; filled lazily by move_tolerance()
         self._tolerance_cache: dict[str, dict[str, float]] = {}
         # Silence upstream's RequestAbort traceback (operator aborts are
         # quiet, intentional outcomes — #563 follow-up).  RE.log is a
@@ -496,17 +499,12 @@ class GeecsSession:
     ) -> CaMotor:
         """Position-feedback motor (blocking :SP put + readback poll).
 
-        *tolerance* defaults to the GEECS DB's per-variable ``tolerance`` —
-        the facility's own statement of what "arrived" means for that axis —
-        resolved by :meth:`variable_tolerance`.  Passing a value overrides it.
-
-        The DB value matters in both directions: it is 0.015 mm on
-        ``U_ModeImagerESP/Position.Axis 1`` (where the old hardcoded 0.005
-        failed converged moves) and 0.001 mm on that device's axes 2 and 3
-        (where 0.005 silently accepted a position 5x outside spec).
+        *tolerance* defaults to :meth:`move_tolerance` — the GEECS DB's
+        per-variable convergence criterion with layer-2 headroom applied.
+        Passing a value overrides it.
         """
         if tolerance is None:
-            tolerance = self.variable_tolerance(device, variable)
+            tolerance = self.move_tolerance(device, variable)
         return self._connect(
             CaMotor(
                 device,
@@ -517,59 +515,99 @@ class GeecsSession:
             )
         )
 
-    def variable_tolerance(self, device: str, variable: str) -> float:
-        """Return the GEECS DB set-convergence tolerance for *variable*.
+    def move_tolerance(self, device: str, variable: str) -> float:
+        """Return ``CaMotor``'s layer-2 arrival tolerance for *variable*.
+
+        This is the GEECS DB's ``tolerance`` for the variable, used as-is.
+
+        That field is also GEECS's own *set-convergence* criterion
+        (``GeecsCAGateway/PV_CONTRACT.md`` § "The DB ``tolerance`` field is a
+        set-convergence criterion") — the number the blocking UDP set stops
+        on — so layer 2 checks the same threshold layer 1 did, against an
+        independently-timed readback sample.  That is deliberate: the DB
+        values are set per axis from operational experience, so they are the
+        facility's considered statement of what "arrived" means, and no
+        scaling here would be better informed than they are.  The cost is
+        that an axis parked at the very edge of its tolerance could fail
+        layer 2 on dither alone; measured convergence margins make that
+        unlikely (``U_CompAeroTech/Position.Axis1`` lands 4-11% into its
+        1.0 um tolerance, ``U_ModeImagerESP/Position.Axis 1`` 33% into its
+        0.015 mm).  Revisit here if a converged axis starts timing out.
 
         Falls back to :data:`~geecs_bluesky.devices.ca.motor.DEFAULT_TOLERANCE`
-        when the DB records nothing usable.  "Nothing usable" covers a missing
-        device or variable row, a NULL tolerance, and a non-positive one (the
-        DB's unset spelling — ``Speed.Axis1`` carries ``0.0``); a zero
-        tolerance would demand bit-exact equality and never converge.
+        (unscaled) when the DB records nothing usable: a missing device or
+        variable row, a NULL tolerance, or a non-positive one (the DB's unset
+        spelling — ``Speed.Axis1`` carries ``0.0``); a zero tolerance would
+        demand bit-exact equality and never converge.
 
-        Best-effort by design: this is metadata enrichment on the way to a
-        move, so an unreachable DB degrades to the default rather than failing
-        the scan.  Results are cached per device for the life of the session —
-        device metadata does not change mid-scan, and a gateway restart is
-        already required for DB edits to take effect.
+        Best-effort by design — this is metadata enrichment on the way to a
+        move, so an unreachable DB degrades to the default rather than
+        failing the scan.  Cached per device, successes and failures alike,
+        for the life of the session; a DB edit therefore needs the worker
+        session restarted (for the queueserver, closing and reopening its
+        environment) before it takes effect.
         """
         if self._mock:
             return DEFAULT_TOLERANCE
-        try:
-            rows = self._variable_tolerances(device)
-        except Exception:
-            logger.warning(
-                "%s: could not read DB tolerances; using default %g for %s",
-                device,
-                DEFAULT_TOLERANCE,
-                variable,
-                exc_info=True,
-            )
-            return DEFAULT_TOLERANCE
-        tolerance = rows.get(variable)
-        if tolerance is None:
+        db_tolerance = self._variable_tolerances(device).get(variable)
+        if db_tolerance is None:
             logger.info(
-                "%s/%s: no DB tolerance; using default %g",
+                "%s/%s: no usable DB tolerance; using default %g",
                 device,
                 variable,
                 DEFAULT_TOLERANCE,
             )
             return DEFAULT_TOLERANCE
-        return tolerance
+        if db_tolerance > _TOLERANCE_SANITY_FACTOR * DEFAULT_TOLERANCE:
+            # A units mismatch or an uncurated row (whole-row type inheritance
+            # can land a devicetype default on an instance in other units)
+            # would make every readback "arrive" on the first poll — silently
+            # reinstating the false-arrival mode layer 2 exists to catch.
+            logger.warning(
+                "%s/%s: DB tolerance %g is over %gx the %g default — check the "
+                "variable's units and DB row; moves will confirm on almost any "
+                "readback",
+                device,
+                variable,
+                db_tolerance,
+                _TOLERANCE_SANITY_FACTOR,
+                DEFAULT_TOLERANCE,
+            )
+        return db_tolerance
 
     def _variable_tolerances(self, device: str) -> dict[str, float]:
-        """Cached ``{variable: tolerance}`` for *device*, positive values only."""
+        """Cached ``{variable: DB tolerance}`` for *device*, positive values only.
+
+        Failures cache an empty map, matching ``db_runtime``'s providers
+        (``GeecsDbScalarPolicy`` caches ``{}``, ``GeecsDbServedSetProvider``
+        carries ``_attempted``).  Without it an off-network worker or a
+        host-blocked MySQL (error 1129) pays a fresh connect timeout per
+        ``motor()`` call — on the RunEngine's loop, since ``motor()`` runs
+        bound to the in-plan factory facade — and feeds ``max_connect_errors``
+        on the way.
+        """
         cached = self._tolerance_cache.get(device)
-        if cached is None:
+        if cached is not None:
+            return cached
+        tolerances: dict[str, float] = {}
+        try:
             from geecs_core.db.geecs_db import GeecsDb
 
-            cached = {}
             for row in GeecsDb.get_device_variables(device):
                 name = row.get("name")
                 tolerance = row.get("tolerance")
                 if name and isinstance(tolerance, (int, float)) and tolerance > 0:
-                    cached[name] = float(tolerance)
-            self._tolerance_cache[device] = cached
-        return cached
+                    tolerances[name] = float(tolerance)
+        except Exception:
+            logger.warning(
+                "%s: could not read DB tolerances; falling back to the default "
+                "%g for this device (cached, not retried this session)",
+                device,
+                DEFAULT_TOLERANCE,
+                exc_info=True,
+            )
+        self._tolerance_cache[device] = tolerances
+        return tolerances
 
     def settable(
         self,

--- a/GeecsBluesky/pyproject.toml
+++ b/GeecsBluesky/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-bluesky"
-version = "0.76.3"
+version = "0.77.0"
 description = "Bluesky / ophyd-async bridge for the GEECS control system"
 authors = ["Sam Barber <sbarber@lbl.gov>"]
 readme = "README.md"

--- a/GeecsBluesky/tests/test_ca_devices.py
+++ b/GeecsBluesky/tests/test_ca_devices.py
@@ -950,3 +950,17 @@ class TestSaveControlOnly:
         assert snap._save_control_only is True
         assert hasattr(snap, "save")
         assert not hasattr(snap, "localsavingpath")
+
+
+async def test_confirm_exactly_on_tolerance_counts_as_matched() -> None:
+    """The same on-boundary fix applies to the confirming poll.
+
+    build_movable dispatches to confirm_settable *before* motor when a scan
+    variable declares confirm, so for topology-C axes this is the arrival
+    check.  |1.20 - 1.15| is 0.050000000000000044, not 0.05.
+    """
+    device = _emq_confirm_device(tolerance=0.05)
+    await device.connect(mock=True)
+    set_mock_value(device._confirm_readback, 1.20)
+    assert abs(1.20 - 1.15) > 0.05  # the representation error is real
+    await asyncio.wait_for(device.set(1.15), timeout=2.0)

--- a/GeecsBluesky/tests/test_ca_devices.py
+++ b/GeecsBluesky/tests/test_ca_devices.py
@@ -203,6 +203,44 @@ async def test_motor_set_completes_on_arrival() -> None:
     assert reading["jet-position"]["value"] == 4.5
 
 
+async def test_motor_arrival_exactly_on_tolerance_counts_as_arrived() -> None:
+    """A readback exactly one tolerance from target resolves, not times out.
+
+    Regression for U_ModeImagerESP Scan034: the stage reached -10.505 against
+    a -10.5 target with tolerance 0.005, but ``abs(-10.505 - -10.5)`` is
+    0.005000000000000782 in binary floating point, so the plain ``<=``
+    comparison polled the full move_timeout and paused the scan.
+    """
+    motor = CaMotor(
+        "U_ModeImagerESP",
+        "Position.Axis 1",
+        experiment="Undulator",
+        name="mode",
+        tolerance=0.005,
+        move_timeout=0.3,
+    )
+    await motor.connect(mock=True)
+    set_mock_value(motor.position, -10.505)
+    assert abs(-10.505 - -10.5) > 0.005  # the representation error is real
+    await asyncio.wait_for(motor.set(-10.5), timeout=2.0)
+
+
+async def test_motor_beyond_tolerance_still_times_out() -> None:
+    """The epsilon is representation slack, not a widened tolerance."""
+    motor = CaMotor(
+        "U_ModeImagerESP",
+        "Position.Axis 1",
+        experiment="Undulator",
+        name="mode",
+        tolerance=0.005,
+        move_timeout=0.3,
+    )
+    await motor.connect(mock=True)
+    set_mock_value(motor.position, -10.51)  # 0.01 out — twice the tolerance
+    with pytest.raises(GeecsMotorTimeoutError):
+        await motor.set(-10.5)
+
+
 async def test_motor_set_times_out_when_stuck() -> None:
     """Readback never converging raises GeecsMotorTimeoutError."""
     motor = CaMotor(

--- a/GeecsBluesky/tests/test_session.py
+++ b/GeecsBluesky/tests/test_session.py
@@ -553,11 +553,46 @@ def test_implausible_db_tolerance_warns(
 ) -> None:
     """A units-mismatched row is served but flagged, not silently trusted.
 
-    A tolerance far above the default makes every readback "arrive" on the
-    first poll -- the silent false-arrival mode layer 2 exists to catch.
+    A tolerance that is a large fraction of the axis's own travel makes every
+    readback "arrive" on the first poll -- the silent false-arrival mode this
+    poll exists to catch.  1.0 on 25 mm of travel is 4%.
     """
-    rows = [{"name": "Position.Axis 1", "tolerance": 1.0}]  # mm axis, um value
+    rows = [{"name": "Position.Axis 3", "min": 0.0, "max": 25.0, "tolerance": 1.0}]
     s = _db_session(monkeypatch, rows, [])
     with caplog.at_level(logging.WARNING):
-        assert s.move_tolerance("U_ModeImagerESP", "Position.Axis 1") == 1.0
-    assert "check the variable's units" in caplog.text
+        assert s.move_tolerance("U_ModeImagerESP", "Position.Axis 3") == 1.0
+    assert "check its units" in caplog.text
+
+
+def test_real_aerotech_tolerance_does_not_warn(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """The production U_CompAeroTech row must stay silent.
+
+    Its genuine 1.0 um tolerance on 115000 um of travel is 0.0009% of range --
+    correctly configured.  An absolute threshold flagged it on every move,
+    which is the unit-blindness the span comparison exists to avoid.
+    """
+    rows = [
+        {"name": "Position.Axis1", "min": -60000.0, "max": 55000.0, "tolerance": 1.0},
+        {"name": "DelayAfterMove", "min": 0.0, "max": 10000.0, "tolerance": 1.0},
+    ]
+    s = _db_session(monkeypatch, rows, [])
+    with caplog.at_level(logging.WARNING):
+        assert s.move_tolerance("U_CompAeroTech", "Position.Axis1") == 1.0
+    assert caplog.text == ""
+
+
+def test_tolerance_without_a_usable_span_is_not_judged(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Rows with no min/max (or a degenerate span) are served without comment."""
+    rows = [
+        {"name": "A", "tolerance": 5.0},
+        {"name": "B", "min": 1.0, "max": 1.0, "tolerance": 5.0},
+    ]
+    s = _db_session(monkeypatch, rows, [])
+    with caplog.at_level(logging.WARNING):
+        assert s.move_tolerance("U_Thing", "A") == 5.0
+        assert s.move_tolerance("U_Thing", "B") == 5.0
+    assert caplog.text == ""

--- a/GeecsBluesky/tests/test_session.py
+++ b/GeecsBluesky/tests/test_session.py
@@ -19,6 +19,7 @@ pytest.importorskip("aioca")  # session is CA-only
 
 from ophyd_async.core import callback_on_mock_put, set_mock_value  # noqa: E402
 
+from geecs_bluesky.devices.ca.motor import DEFAULT_TOLERANCE  # noqa: E402
 from geecs_bluesky.exceptions import GeecsConfigurationError  # noqa: E402
 from geecs_bluesky.session import GeecsSession, _json_safe, _positions  # noqa: E402
 from geecs_bluesky.shot_controller import CaPutSetter, ShotController  # noqa: E402
@@ -407,3 +408,95 @@ def test_scan_info_stamps_bluesky_scanner(tmp_path: Path) -> None:
     content = (tmp_path / f"ScanInfo{tmp_path.name}.ini").read_text()
     assert 'Scanner = "bluesky"' in content
     assert "[Scan Info]" in content  # legacy section intact
+
+
+# --------------------------------------------------------------------------
+# Per-variable move tolerance from the GEECS DB
+# --------------------------------------------------------------------------
+
+#: Shape of GeecsDb.get_device_variables() for a three-axis ESP stage.
+_ESP_ROWS = [
+    {"name": "Position.Axis 1", "tolerance": 0.015},
+    {"name": "Position.Axis 2", "tolerance": 0.001},
+    {"name": "Speed.Axis1", "tolerance": 0.0},  # the DB's "unset" spelling
+    {"name": "Home.Axis1", "tolerance": None},
+]
+
+
+def _db_session(monkeypatch: pytest.MonkeyPatch, rows: list, calls: list) -> object:
+    """A non-mock session whose DB lookup returns *rows*, recording each call."""
+
+    def _get(device_name: str) -> list:
+        calls.append(device_name)
+        return rows
+
+    monkeypatch.setattr(
+        "geecs_core.db.geecs_db.GeecsDb.get_device_variables", staticmethod(_get)
+    )
+    return GeecsSession("Undulator", tiled=False, mock=False)
+
+
+def test_variable_tolerance_reads_the_db_value(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The per-axis DB tolerance wins over the hardcoded default."""
+    s = _db_session(monkeypatch, _ESP_ROWS, [])
+    assert s.variable_tolerance("U_ModeImagerESP", "Position.Axis 1") == 0.015
+    # Tighter than the old hardcoded 0.005, not just looser — both directions.
+    assert s.variable_tolerance("U_ModeImagerESP", "Position.Axis 2") == 0.001
+
+
+@pytest.mark.parametrize("variable", ["Speed.Axis1", "Home.Axis1", "Nonexistent"])
+def test_variable_tolerance_falls_back_when_db_has_nothing_usable(
+    monkeypatch: pytest.MonkeyPatch, variable: str
+) -> None:
+    """Zero, NULL and missing all mean "unset" — never a 0.0 tolerance.
+
+    A 0.0 tolerance would demand bit-exact equality of a float readback and
+    never converge, turning every move into a move_timeout.
+    """
+    s = _db_session(monkeypatch, _ESP_ROWS, [])
+    assert s.variable_tolerance("U_ModeImagerESP", variable) == DEFAULT_TOLERANCE
+
+
+def test_variable_tolerance_survives_an_unreachable_db(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A DB outage degrades to the default rather than failing the scan."""
+
+    def _boom(device_name: str) -> list:
+        raise RuntimeError("2003: Can't connect to MySQL server")
+
+    monkeypatch.setattr(
+        "geecs_core.db.geecs_db.GeecsDb.get_device_variables", staticmethod(_boom)
+    )
+    s = GeecsSession("Undulator", tiled=False, mock=False)
+    assert s.variable_tolerance("U_ModeImagerESP", "Position.Axis 1") == (
+        DEFAULT_TOLERANCE
+    )
+
+
+def test_variable_tolerance_is_cached_per_device(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """One DB round trip per device, not one per variable."""
+    calls: list = []
+    s = _db_session(monkeypatch, _ESP_ROWS, calls)
+    s.variable_tolerance("U_ModeImagerESP", "Position.Axis 1")
+    s.variable_tolerance("U_ModeImagerESP", "Position.Axis 2")
+    assert calls == ["U_ModeImagerESP"]
+
+
+def test_mock_session_never_touches_the_db(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Hermetic tests must not need a database."""
+
+    def _boom(device_name: str) -> list:
+        raise AssertionError("mock session must not query the DB")
+
+    monkeypatch.setattr(
+        "geecs_core.db.geecs_db.GeecsDb.get_device_variables", staticmethod(_boom)
+    )
+    s = _session()
+    assert s.variable_tolerance("U_ModeImagerESP", "Position.Axis 1") == (
+        DEFAULT_TOLERANCE
+    )

--- a/GeecsBluesky/tests/test_session.py
+++ b/GeecsBluesky/tests/test_session.py
@@ -436,18 +436,18 @@ def _db_session(monkeypatch: pytest.MonkeyPatch, rows: list, calls: list) -> obj
     return GeecsSession("Undulator", tiled=False, mock=False)
 
 
-def test_variable_tolerance_reads_the_db_value(
+def test_move_tolerance_reads_the_db_value(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """The per-axis DB tolerance wins over the hardcoded default."""
     s = _db_session(monkeypatch, _ESP_ROWS, [])
-    assert s.variable_tolerance("U_ModeImagerESP", "Position.Axis 1") == 0.015
+    assert s.move_tolerance("U_ModeImagerESP", "Position.Axis 1") == 0.015
     # Tighter than the old hardcoded 0.005, not just looser — both directions.
-    assert s.variable_tolerance("U_ModeImagerESP", "Position.Axis 2") == 0.001
+    assert s.move_tolerance("U_ModeImagerESP", "Position.Axis 2") == 0.001
 
 
 @pytest.mark.parametrize("variable", ["Speed.Axis1", "Home.Axis1", "Nonexistent"])
-def test_variable_tolerance_falls_back_when_db_has_nothing_usable(
+def test_move_tolerance_falls_back_when_db_has_nothing_usable(
     monkeypatch: pytest.MonkeyPatch, variable: str
 ) -> None:
     """Zero, NULL and missing all mean "unset" — never a 0.0 tolerance.
@@ -456,10 +456,10 @@ def test_variable_tolerance_falls_back_when_db_has_nothing_usable(
     never converge, turning every move into a move_timeout.
     """
     s = _db_session(monkeypatch, _ESP_ROWS, [])
-    assert s.variable_tolerance("U_ModeImagerESP", variable) == DEFAULT_TOLERANCE
+    assert s.move_tolerance("U_ModeImagerESP", variable) == DEFAULT_TOLERANCE
 
 
-def test_variable_tolerance_survives_an_unreachable_db(
+def test_move_tolerance_survives_an_unreachable_db(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """A DB outage degrades to the default rather than failing the scan."""
@@ -471,19 +471,17 @@ def test_variable_tolerance_survives_an_unreachable_db(
         "geecs_core.db.geecs_db.GeecsDb.get_device_variables", staticmethod(_boom)
     )
     s = GeecsSession("Undulator", tiled=False, mock=False)
-    assert s.variable_tolerance("U_ModeImagerESP", "Position.Axis 1") == (
-        DEFAULT_TOLERANCE
-    )
+    assert s.move_tolerance("U_ModeImagerESP", "Position.Axis 1") == (DEFAULT_TOLERANCE)
 
 
-def test_variable_tolerance_is_cached_per_device(
+def test_move_tolerance_is_cached_per_device(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """One DB round trip per device, not one per variable."""
     calls: list = []
     s = _db_session(monkeypatch, _ESP_ROWS, calls)
-    s.variable_tolerance("U_ModeImagerESP", "Position.Axis 1")
-    s.variable_tolerance("U_ModeImagerESP", "Position.Axis 2")
+    s.move_tolerance("U_ModeImagerESP", "Position.Axis 1")
+    s.move_tolerance("U_ModeImagerESP", "Position.Axis 2")
     assert calls == ["U_ModeImagerESP"]
 
 
@@ -497,6 +495,69 @@ def test_mock_session_never_touches_the_db(monkeypatch: pytest.MonkeyPatch) -> N
         "geecs_core.db.geecs_db.GeecsDb.get_device_variables", staticmethod(_boom)
     )
     s = _session()
-    assert s.variable_tolerance("U_ModeImagerESP", "Position.Axis 1") == (
-        DEFAULT_TOLERANCE
+    assert s.move_tolerance("U_ModeImagerESP", "Position.Axis 1") == (DEFAULT_TOLERANCE)
+
+
+def test_motor_receives_the_resolved_db_tolerance(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """motor() actually passes the DB value into the device.
+
+    Pins the headline behaviour change: without this, deleting the resolution
+    in motor() and restoring the old hardcoded 0.005 leaves the suite green.
+    """
+    s = _db_session(monkeypatch, _ESP_ROWS, [])
+    monkeypatch.setattr(GeecsSession, "_connect", lambda self, device: device)
+    assert s.motor("U_ModeImagerESP", "Position.Axis 1")._tolerance == 0.015
+    assert s.motor("U_ModeImagerESP", "Position.Axis 2")._tolerance == 0.001
+
+
+def test_motor_explicit_tolerance_still_overrides(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An explicit tolerance= wins over the DB."""
+    s = _db_session(monkeypatch, _ESP_ROWS, [])
+    monkeypatch.setattr(GeecsSession, "_connect", lambda self, device: device)
+    motor = s.motor("U_ModeImagerESP", "Position.Axis 1", tolerance=0.5)
+    assert motor._tolerance == 0.5
+
+
+def test_failed_db_lookup_is_cached_not_retried(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A DB outage costs one connect per device, not one per call.
+
+    Without negative caching an off-network worker pays a fresh 10 s connect
+    timeout on every motor() -- on the RunEngine loop -- and feeds MySQL's
+    max_connect_errors on the way.
+    """
+    calls: list = []
+
+    def _boom(device_name: str) -> list:
+        calls.append(device_name)
+        raise RuntimeError("2003: Can't connect to MySQL server")
+
+    monkeypatch.setattr(
+        "geecs_core.db.geecs_db.GeecsDb.get_device_variables", staticmethod(_boom)
     )
+    s = GeecsSession("Undulator", tiled=False, mock=False)
+    for _ in range(3):
+        assert s.move_tolerance("U_ModeImagerESP", "Position.Axis 1") == (
+            DEFAULT_TOLERANCE
+        )
+    assert calls == ["U_ModeImagerESP"]
+
+
+def test_implausible_db_tolerance_warns(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A units-mismatched row is served but flagged, not silently trusted.
+
+    A tolerance far above the default makes every readback "arrive" on the
+    first poll -- the silent false-arrival mode layer 2 exists to catch.
+    """
+    rows = [{"name": "Position.Axis 1", "tolerance": 1.0}]  # mm axis, um value
+    s = _db_session(monkeypatch, rows, [])
+    with caplog.at_level(logging.WARNING):
+        assert s.move_tolerance("U_ModeImagerESP", "Position.Axis 1") == 1.0
+    assert "check the variable's units" in caplog.text


### PR DESCRIPTION
## What

Two defects in `CaMotor`'s readback-confirmation poll (layer 2), both surfaced
by a live scan pausing for an operator on a move that had actually converged:

```
2026-09-10 12:10:28 ERROR geecs_bluesky.plans.step_scan scan=Scan034 -
FAILED MOVE - pausing for operator: commanded u_modeimageresp_position_axis_1
-> -10.5, one axis failed - see cause for which:
U_ModeImagerESP/Position.Axis 1: position -10.505 did not reach -10.5 within 30.0s
```

### 1. Exactly-on-tolerance arrivals failed (bug)

The stage landed exactly one tolerance from target and lost the comparison to
binary floating point:

```
|-10.505 - -10.5| = 0.005000000000000782
             <= 0.005 ?  False    (loses by 7.8e-16)
```

`motor.py` polled the full `move_timeout` and raised `GeecsMotorTimeoutError`
over 8e-16 mm. The arrival comparison now carries a relative epsilon.

This is **representation slack, not a widened tolerance** — a second test pins
that a miss of twice the tolerance still times out. Note `math.isclose` does
not help here: with `abs_tol=0.005` it reduces to the same comparison.

### 2. Every axis on every device used a hardcoded 0.005 (behaviour change)

`CaMotor.__init__` and `GeecsSession.motor()` both hardcoded `tolerance=0.005`,
and the scan path (`scan_request_runner.py:1263`) never passes one — so every
axis in every scan got that number. The GEECS DB already records a
per-variable `tolerance`, and the hardcoded value was wrong in **both**
directions:

| device / variable | DB tolerance | old hardcoded |
|---|---|---|
| `U_ModeImagerESP` / `Position.Axis 1` | 0.015 mm | 0.005 — failed converged moves |
| `U_ModeImagerESP` / `Position.Axis 2`, `Axis 3` | 0.001 mm | 0.005 — accepted 5x outside spec |
| `U_CompAeroTech` / `Position.Axis1` | 1.0 µm | 0.005 |

`GeecsSession.motor()` now resolves it through the new
`GeecsSession.variable_tolerance()`. Passing `tolerance=` still overrides.

The lookup is best-effort and cached per device: an unreachable DB, a missing
device/variable row, and the DB's "unset" spellings (NULL, `0.0`) all fall
back to `DEFAULT_TOLERANCE`. The `0.0` guard matters — `Speed.Axis1` carries
`0.0`, and a zero tolerance would demand bit-exact equality of a float
readback and never converge, turning every move into a `move_timeout`. Mock
sessions never query the DB, so hermetic tests stay hermetic.

## Heads-up for the first scan after this lands

This is **tighter** on `U_ModeImagerESP` axes 2 and 3 (0.001 vs 0.005), not
only looser on axis 1. Those axes have been silently accepting positions 5x
outside spec, so moves that used to pass may now legitimately time out. That
is the correct behaviour, but it will read as a new failure.

## Scope

One concern: the motor arrival check. LOC is ~55 in `session.py` (the resolver
+ cache), ~15 in `motor.py` (the epsilon + constants), the rest tests and
CHANGELOG. Three adjacent problems found during the same debugging session are
deliberately **not** here:

- **`U_CompAeroTech` short-move failures** — device-side, not ours. The
  LabVIEW `check values` step read the pre-move position verbatim (reported
  `actual value= 40965.810000` for a move that started at exactly that
  position), racing its own ~0.6-1.0 s position refresh. Fixed on the device
  by raising `DelayAfterMove` 200 ms -> 800 ms; 10 µm moves now clean. Layer 1
  failed there, so layer 2 never ran — this PR could not have fixed it.
- **`udp_client.py:334` `%.12f` set formatting** — filed as #819. Sends
  `40854.246249999997` for `40854.24625`; 86% of 5-decimal positions in the
  Aerotech's working range get a garbage tail. Whole-facility blast radius,
  needs its own PR and hardware verification.
- **Readback freshness gate** — `CaMotor` still reads the readback with zero
  delay after the put, into a lag measured at 0.6-1.0 s. Raising axis 1's
  tolerance to 0.015 makes a stale-read false arrival more reachable when the
  scan step is under 15 µm. Layer 1 blocks on device convergence so this does
  not corrupt data for honest devices, but it does quietly defeat layer 2 for
  exactly the early-ack devices (#779) layer 2 exists to catch. Judgment call
  to defer — cheap to veto if you want it bundled.

No facility literals added; no scan-folder paths touched; no gateway
PV-contract surface changed.

## Tests

`GeecsBluesky`: **847 passed, 2 skipped, 4 deselected** (deselected are
`integration`-marked — lab network, out of scope by design). Full
`./scripts/check.sh --all` results posted as a comment.

New pinning tests:

- `test_motor_arrival_exactly_on_tolerance_counts_as_arrived` — verified it
  reproduces the exact production error message when the epsilon is removed,
  and passes with it.
- `test_motor_beyond_tolerance_still_times_out` — the epsilon is slack, not a
  wider tolerance.
- `test_variable_tolerance_reads_the_db_value` — both directions (0.015 and
  the tighter 0.001).
- `test_variable_tolerance_falls_back_when_db_has_nothing_usable` —
  parametrized over `0.0`, NULL, and missing.
- `test_variable_tolerance_survives_an_unreachable_db`
- `test_variable_tolerance_is_cached_per_device` — one round trip per device.
- `test_mock_session_never_touches_the_db`

## Hardware verification

**OWED.** All findings above were measured on live hardware
(`U_CompAeroTech` move sweeps through the gateway, `U_ModeImagerESP` DB
tolerances read from the production DB), but the *fix itself* has only been
exercised against mock backends.

To verify after merge:

1. A step scan on `U_ModeImagerESP/Position.Axis 1` with steps that previously
   landed on the tolerance boundary — expect no `FAILED MOVE - pausing for
   operator`, where Scan034 paused.
2. Confirm `variable_tolerance("U_ModeImagerESP", "Position.Axis 1")` returns
   `0.015` against the live DB (not the `0.005` fallback) — a silent fallback
   would look like success while changing nothing.
3. A scan touching axes 2 or 3, which now run at the tighter 0.001 — this is
   where a new timeout would legitimately appear.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>