### PR TITLE
GeecsBluesky 0.80.1: phase 1 PR 3 — headless hardware acceptance of the plan layer (#807)

### DIFF
--- a/GeecsBluesky/CHANGELOG.md
+++ b/GeecsBluesky/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to `geecs-bluesky` are documented here.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.80.1] - 2026-09-10
+
+### Added
+
+- **Phase 1 PR 3 (#807) — headless hardware acceptance of the plan
+  layer.** `tests/test_phase1_hardware.py` (`GEECS_HW=1`; fires shots): the
+  worker's own wiring drives a strict `count` and a strict `scan` of
+  `U_S1H:Current` on HTU and every GEECS output is asserted from disk
+  (claimed folder, native files named by the rows' stamps, ScanInfo keys,
+  s-file bins, scan.log, the baseline stream, ARMED → STANDBY); and a
+  `Preset` goes through a second RE Manager (`run_submit_preflight` →
+  `submit_preset` → the history item) with the same assertions.  Accepted
+  2026-09-10 (Scans 104–108 of 26_0910; `Planning/native_bluesky/05_phase1_acceptance.md`
+  M4–M6, with the runbook for the second manager and the per-shot budget:
+  ~7 ms of plan-layer work per shot, ~100 ms of margin at 1 Hz on this
+  camera, a moved step on the third edge because a 0.5 A magnet move is a
+  1.3 s blocking set).
+
 ## [0.80.0] - 2026-09-10
 
 ### Added

--- a/GeecsBluesky/CHANGELOG.md
+++ b/GeecsBluesky/CHANGELOG.md
@@ -6,6 +6,18 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [0.80.1] - 2026-09-10
 
+### Fixed
+
+- `utils.settable_attribute` is the **one** rule for the attribute a
+  settable binds to (a frozen `RESERVED_DEVICE_ATTRIBUTES`, pinned to
+  `dir(GeecsDetector)` by a test): the namespace and the client seam now
+  agree, so `"UC_Amp4_IR_input:trigger"` in a preset spells
+  `UC_Amp4_IR_input.trigger_` instead of a reference the preflight refuses
+  (Codex review of #821).
+- The hardware acceptance test asserts its restore move *completed* and
+  reads the setpoint back, not merely that it queued (Codex review of
+  #822).
+
 ### Added
 
 - **Phase 1 PR 3 (#807) — headless hardware acceptance of the plan

--- a/GeecsBluesky/CLAUDE.md
+++ b/GeecsBluesky/CLAUDE.md
@@ -17,11 +17,15 @@ the s-file, `scan.log`, the baseline telemetry stream.  The worker
 registers the stock `bluesky.plans` verbs under their own names with the
 strict `take_reading` pre-bound (`plans/registry.py`); a client submits a
 stock plan item or a saved preset (`qs_client.submit_plan` /
-`submit_preset`).  Next (PR 3): headless hardware acceptance on HTU
-(`U_S1H:Current` −1 → +1 A, amp4in) and the worker flip.  **The deployed
-worker stays on `master` until then**; the Console and GEECS-MCP are
-rewired once, when the foundation is stable — not per step (their submit
-paths call the removed funnel verbs meanwhile).
+`submit_preset`).  Hardware-accepted 2026-09-10 (PR 3,
+`tests/test_phase1_hardware.py`, `Planning/native_bluesky/05_phase1_acceptance.md`):
+in process and through a second RE Manager, Scans 104–108 of 26_0910.  The
+deployed worker's checkout is on the feature branch; the restart that
+flips it is the maintainer's.  The Console and GEECS-MCP are rewired
+once, when the foundation is stable — not per step (their submit paths
+call the removed funnel verbs meanwhile).  Per-shot budget: ~7 ms of
+plan-layer work, ~100 ms of margin at 1 Hz on this camera — strict
+single-shot is not the 1 Hz mode, phase 2's gated batch is.
 
 ## The two rules
 

--- a/GeecsBluesky/CLAUDE.md
+++ b/GeecsBluesky/CLAUDE.md
@@ -19,9 +19,8 @@ strict `take_reading` pre-bound (`plans/registry.py`); a client submits a
 stock plan item or a saved preset (`qs_client.submit_plan` /
 `submit_preset`).  Hardware-accepted 2026-09-10 (PR 3,
 `tests/test_phase1_hardware.py`, `Planning/native_bluesky/05_phase1_acceptance.md`):
-in process and through a second RE Manager, Scans 104–108 of 26_0910.  The
-deployed worker's checkout is on the feature branch; the restart that
-flips it is the maintainer's.  The Console and GEECS-MCP are rewired
+in process and through a second RE Manager, Scans 104–108 of 26_0910 (the
+worker flip is recorded there).  The Console and GEECS-MCP are rewired
 once, when the foundation is stable — not per step (their submit paths
 call the removed funnel verbs meanwhile).  Per-shot budget: ~7 ms of
 plan-layer work, ~100 ms of margin at 1 Hz on this camera — strict

--- a/GeecsBluesky/README.md
+++ b/GeecsBluesky/README.md
@@ -45,9 +45,9 @@ deleted the `ScanRequest` funnel, the free-run mode, `GeecsSession` and
 the funnel-only devices; PR 2 added the plan layer — the stock plans
 registered strict under their own names, every run claiming a scan
 number, the ScanInfo / s-file / `scan.log` callbacks, the baseline
-telemetry stream, presets as the saved queue item.  Next: headless
-hardware acceptance and the worker flip.  Until then the deployed worker
-stays on `master`.
+telemetry stream, presets as the saved queue item.  PR 3 accepted it on
+HTU (Scans 104–108 of 26_0910, in process and through a second RE
+Manager); the worker flip is the maintainer's restart.
 
 ## Requirements
 

--- a/GeecsBluesky/README.md
+++ b/GeecsBluesky/README.md
@@ -47,7 +47,7 @@ registered strict under their own names, every run claiming a scan
 number, the ScanInfo / s-file / `scan.log` callbacks, the baseline
 telemetry stream, presets as the saved queue item.  PR 3 accepted it on
 HTU (Scans 104–108 of 26_0910, in process and through a second RE
-Manager); the worker flip is the maintainer's restart.
+Manager — `Planning/native_bluesky/05_phase1_acceptance.md`).
 
 ## Requirements
 

--- a/GeecsBluesky/geecs_bluesky/namespace.py
+++ b/GeecsBluesky/geecs_bluesky/namespace.py
@@ -69,7 +69,7 @@ from geecs_bluesky.devices.ca.settable import CaSettable
 from geecs_bluesky.devices.ca.snapshot import CaSnapshotReadable
 from geecs_bluesky.devices.detector import GeecsDetector
 from geecs_bluesky.exceptions import GeecsConfigurationError
-from geecs_bluesky.utils import identifier_name, safe_name
+from geecs_bluesky.utils import identifier_name, safe_name, settable_attribute
 
 logger = logging.getLogger(__name__)
 
@@ -401,14 +401,13 @@ class GeecsNamespace:
 
         The Amp4 camera has a settable enum called ``trigger`` (external
         trigger on/off) — bound verbatim it would overwrite ``trigger()``.
-        Checked against the detector class so the name is stable on every
-        device, triggered or not.  A name already bound to a *child* of this
+        :func:`~geecs_bluesky.utils.settable_attribute` is the rule (a frozen
+        set of the detector class's names, pinned by a test, so the client
+        seam spells the same attribute).  A name already bound to a *child* of this
         device (a readable signal, ``acq_timestamp``, ``connected_status``) is
         a real collision and raises rather than being renamed (review N1).
         """
-        attr = safe_name(variable)  # lowercase: event keys follow EVENT_SCHEMA.md
-        if attr.startswith("_") or hasattr(GeecsDetector, attr):
-            return attr.lstrip("_") + "_"
+        attr = settable_attribute(variable)  # the shared rule (utils)
         existing = getattr(dev, attr, None)
         if isinstance(existing, Device):
             raise GeecsConfigurationError(

--- a/GeecsBluesky/geecs_bluesky/utils.py
+++ b/GeecsBluesky/geecs_bluesky/utils.py
@@ -34,17 +34,72 @@ def identifier_name(geecs_name: str) -> str:
     return geecs_name if geecs_name.isidentifier() else safe_name(geecs_name)
 
 
+#: The public names of a namespace device that a settable child may not
+#: shadow — the ophyd-async ``Device`` / ``StandardDetector`` protocol
+#: surface plus ``GeecsDetector``'s own.  A GEECS variable whose
+#: :func:`safe_name` lands on one of these binds with a trailing
+#: underscore (the Amp4 camera's settable enum ``trigger`` → ``trigger_``).
+#: Frozen here so the client seam can spell a reference without importing
+#: the device family; ``tests/test_namespace.py`` pins it to
+#: ``dir(GeecsDetector)``.
+RESERVED_DEVICE_ATTRIBUTES: frozenset[str] = frozenset(
+    {
+        "add_config_signals",
+        "add_detector_logics",
+        "add_readables",
+        "children",
+        "collect_asset_docs",
+        "complete",
+        "connect",
+        "describe",
+        "describe_collect",
+        "describe_configuration",
+        "events_to_kickoff",
+        "get_index",
+        "get_trigger_deadtime",
+        "hints",
+        "kickoff",
+        "last_acq_timestamp",
+        "log",
+        "name",
+        "parent",
+        "prepare",
+        "read",
+        "read_configuration",
+        "set_name",
+        "stage",
+        "trigger",
+        "unstage",
+    }
+)
+
+
+def settable_attribute(variable: str) -> str:
+    """The attribute a settable variable binds to on its namespace device.
+
+    The variable's :func:`safe_name`, with a trailing underscore when that
+    would shadow a device method or start with one (``trigger`` →
+    ``trigger_``).  The **one** rule, shared by the namespace (the binding)
+    and the client seam (the reference a preset expands to), so
+    ``"UC_Amp4_IR_input:trigger"`` spells ``UC_Amp4_IR_input.trigger_`` on
+    both sides.
+    """
+    attr = safe_name(variable)  # lowercase: event keys follow EVENT_SCHEMA.md
+    if attr.startswith("_") or attr in RESERVED_DEVICE_ATTRIBUTES:
+        return attr.lstrip("_") + "_"
+    return attr
+
+
 def device_reference(device: str, variable: str | None = None) -> str:
     """The queue-item spelling of a namespace device or one of its settables.
 
     ``"U_S1H"`` for a device, ``"U_S1H.current"`` for its ``Current``
     child — the dotted sub-device form the RE Manager resolves against the
     worker namespace at submission (``profile_ops._get_nspace_object``).
-    The child attribute is the variable's :func:`safe_name`; the namespace
-    appends a trailing underscore only when that collides with a detector
-    method (``trigger`` → ``trigger_``), a case the pre-submit preflight
-    then refuses against the manager's device tree (the manager itself
-    passes an unknown name through to the plan).
+    The child attribute is :func:`settable_attribute`, the namespace's own
+    rule; the pre-submit preflight then checks the reference against the
+    manager's device tree (the manager itself passes an unknown name
+    through to the plan).
     """
     base = identifier_name(device)
-    return base if variable is None else f"{base}.{safe_name(variable)}"
+    return base if variable is None else f"{base}.{settable_attribute(variable)}"

--- a/GeecsBluesky/pyproject.toml
+++ b/GeecsBluesky/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-bluesky"
-version = "0.80.0"
+version = "0.80.1"
 description = "Bluesky / ophyd-async bridge for the GEECS control system"
 authors = ["Sam Barber <sbarber@lbl.gov>"]
 readme = "README.md"

--- a/GeecsBluesky/tests/ca_mock_helpers.py
+++ b/GeecsBluesky/tests/ca_mock_helpers.py
@@ -74,3 +74,41 @@ class DocCollector:
     def primary_events(self) -> list[dict]:
         uids = {d["uid"] for d in self.docs["descriptor"] if d["name"] == "primary"}
         return [e for e in self.docs["event"] if e["descriptor"] in uids]
+
+
+def read_scan_info(path: Any) -> dict[str, str]:
+    """The ``[Scan Info]`` section of a ScanInfo ini, values unquoted."""
+    from configparser import ConfigParser
+
+    parser = ConfigParser()
+    parser.optionxform = str  # type: ignore[assignment]
+    parser.read(path)
+    return {k: v.strip('"') for k, v in parser.items("Scan Info")}
+
+
+def wait_for_native_files(directory: Any, expected: int, timeout: float = 15.0) -> list:
+    """Every expected native file exists and has stopped growing (two agreeing stats).
+
+    Any regular file counts — the device's own format, not a fixed suffix.
+    """
+    import time
+    from pathlib import Path
+
+    directory = Path(directory)
+    deadline = time.monotonic() + timeout
+    while True:
+        files = (
+            sorted(f for f in directory.iterdir() if f.is_file())
+            if directory.is_dir()
+            else []
+        )
+        sizes = [f.stat().st_size for f in files]
+        if len(files) >= expected and all(sizes):
+            time.sleep(0.5)
+            if [f.stat().st_size for f in files] == sizes:
+                return files
+        if time.monotonic() > deadline:
+            raise AssertionError(
+                f"{directory}: {len(files)} files after {timeout:.0f} s, expected {expected}"
+            )
+        time.sleep(0.5)

--- a/GeecsBluesky/tests/qs_client/test_presets.py
+++ b/GeecsBluesky/tests/qs_client/test_presets.py
@@ -60,6 +60,8 @@ def test_device_reference_spellings() -> None:
 def test_scan_variable_reference_from_pair_and_catalog() -> None:
     assert scan_variable_reference("U_S1H:Current") == "U_S1H.current"
     assert scan_variable_reference("U_S1H") == "U_S1H"
+    # the namespace's collision rule: a protocol-named variable binds with "_"
+    assert scan_variable_reference("UC_Cam:trigger") == "UC_Cam.trigger_"
     assert (
         scan_variable_reference("EMQ1 Current", CATALOG)
         == "U_EMQTripletBipolar.current_limit_ch1"

--- a/GeecsBluesky/tests/test_callbacks.py
+++ b/GeecsBluesky/tests/test_callbacks.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from configparser import ConfigParser
 from functools import partial
 from pathlib import Path
 
@@ -34,17 +33,14 @@ from geecs_bluesky.plans.claim_scan import (  # noqa: E402
 from geecs_bluesky.plans.registry import TriggerProfiles, bind_strict_plans  # noqa: E402
 from geecs_bluesky.preprocessors import scalar_headers  # noqa: E402
 from geecs_bluesky.devices.shot_control import ShotControl  # noqa: E402
-from tests.ca_mock_helpers import connect_mock, follow_setpoint  # noqa: E402
+from tests.ca_mock_helpers import (  # noqa: E402
+    connect_mock,
+    follow_setpoint,
+    read_scan_info,
+)
 from tests.test_claim_scan import FakeClaim  # noqa: E402
 from tests.test_plan_registry import Magnet  # noqa: E402
 from tests.test_strict_plans import WRITES, FakeBox, _camera  # noqa: E402
-
-
-def _ini(path: Path) -> dict[str, str]:
-    parser = ConfigParser()
-    parser.optionxform = str  # type: ignore[assignment]
-    parser.read(path)
-    return {k: v.strip('"') for k, v in parser.items("Scan Info")}
 
 
 # ---------------------------------------------------------- pure derivations
@@ -116,7 +112,7 @@ def test_scan_info_lines_carry_the_legacy_keys(tmp_path) -> None:
     )
     path = tmp_path / "ScanInfoScan012.ini"
     path.write_text("".join(lines))
-    info = _ini(path)
+    info = read_scan_info(path)
     assert info["Scan No"] == "12"
     assert info["ScanStartInfo"] == "jet z"
     assert info["Scan Parameter"] == "U_Jet Z"
@@ -137,7 +133,7 @@ def test_scan_info_lines_carry_the_legacy_keys(tmp_path) -> None:
 def _ini_from(lines, tmp_path) -> dict[str, str]:
     path = tmp_path / "x.ini"
     path.write_text("".join(lines))
-    return _ini(path)
+    return read_scan_info(path)
 
 
 # -------------------------------------------------------------- end to end
@@ -200,7 +196,7 @@ def test_a_strict_scan_leaves_every_legacy_file(RE, box, worker, tmp_path):
         cam.localsavingpath.get_value(), RE._loop
     ).result(5)
     assert saved_to.endswith(str(Path("Scan001") / "UC_Cam"))
-    info = _ini(folder / "ScanInfoScan001.ini")
+    info = read_scan_info(folder / "ScanInfoScan001.ini")
     assert info["Scan Parameter"] == "U_S1H Current"
     assert (info["Start"], info["End"], info["Step size"]) == ("-1.0", "1.0", "1.0")
     assert info["Shots per step"] == "2" and info["ScanEndInfo"] == "success"
@@ -243,7 +239,7 @@ def test_an_aborted_scan_still_gets_its_rows(RE, box, worker, tmp_path):
     with pytest.raises(FailedStatus):
         RE(plans["scan"]([cam], magnet.current, -1.0, 1.0, 4))
     folder = tmp_path / "scans" / "Scan001"
-    info = _ini(folder / "ScanInfoScan001.ini")
+    info = read_scan_info(folder / "ScanInfoScan001.ini")
     assert info["ScanEndInfo"].startswith("fail")
     sfile = pd.read_csv(tmp_path / "analysis" / "s1.txt", sep="\t")
     assert len(sfile) == 2

--- a/GeecsBluesky/tests/test_namespace.py
+++ b/GeecsBluesky/tests/test_namespace.py
@@ -352,3 +352,15 @@ def test_db_failure_at_build_is_loud_not_empty() -> None:
         GeecsConfigurationError, match="could not load the 'TestExp' device roster"
     ):
         GeecsNamespace.from_experiment("TestExp", geecs_db=_FakeDb(fail=True))
+
+
+def test_reserved_device_attributes_pin_the_detector_class() -> None:
+    """The client seam's frozen collision set is exactly the detector's public names."""
+    from geecs_bluesky.devices.detector import GeecsDetector
+    from geecs_bluesky.utils import RESERVED_DEVICE_ATTRIBUTES, settable_attribute
+
+    public = {n for n in dir(GeecsDetector) if not n.startswith("_")}
+    assert RESERVED_DEVICE_ATTRIBUTES == public
+    assert settable_attribute("trigger") == "trigger_"
+    assert settable_attribute("Current") == "current"
+    assert settable_attribute("Position.Axis 1") == "position_axis_1"

--- a/GeecsBluesky/tests/test_phase0_hardware.py
+++ b/GeecsBluesky/tests/test_phase0_hardware.py
@@ -48,7 +48,7 @@ from pathlib import Path
 
 import pytest
 
-from tests.ca_mock_helpers import DocCollector
+from tests.ca_mock_helpers import DocCollector, wait_for_native_files
 
 pytestmark = pytest.mark.hardware
 pytest.importorskip("aioca")
@@ -63,25 +63,6 @@ def _sweep_points(start: float, end: float, step: float) -> list[float]:
     n = int(round(abs(end - start) / abs(step))) + 1
     sign = 1.0 if end >= start else -1.0
     return [round(start + sign * i * abs(step), 6) for i in range(n)]
-
-
-def _wait_for_files(
-    directory: Path, expected: int, timeout: float = 10.0
-) -> list[Path]:
-    """The end-of-run file check: every expected native file exists and stopped growing."""
-    deadline = time.monotonic() + timeout
-    while True:
-        files = sorted(directory.glob("*.png"))
-        sizes = [f.stat().st_size for f in files]
-        if len(files) >= expected and all(sizes):
-            time.sleep(0.5)
-            if [f.stat().st_size for f in files] == sizes:
-                return files
-        if time.monotonic() > deadline:
-            raise AssertionError(
-                f"{directory}: {len(files)} files after {timeout:.0f} s, expected {expected}"
-            )
-        time.sleep(0.5)
 
 
 @pytest.mark.hardware
@@ -248,7 +229,7 @@ def test_one_camera_as_a_standard_detector_on_hardware() -> None:
         assert [e["data"][f"{camera.name}-nonscalar_save_path"] for e in events] == [
             str(directory)
         ] * len(events)
-        files = _wait_for_files(directory, expected_events)
+        files = wait_for_native_files(directory, expected_events)
         print(f"native files: {len(files)} in {directory}: {[f.name for f in files]}")
         save_state = asyncio.run_coroutine_threadsafe(
             camera.save.get_value(), RE._loop

--- a/GeecsBluesky/tests/test_phase1_hardware.py
+++ b/GeecsBluesky/tests/test_phase1_hardware.py
@@ -1,0 +1,401 @@
+"""Phase-1 hardware acceptance: the plan layer end to end on HTU (#807, PR 3).
+
+Hardware-marked **and** gated on ``GEECS_HW=1``: it arms the machine
+trigger and fires shots (an explicit ``-m`` on the command line overrides
+the ``addopts`` deselect, so the marker alone does not protect it).  Run by
+hand on a host with CA reach to the GEECS gateway, the DB and the data
+share (the qserver box), with the configs root at the presets corpus::
+
+    GEECS_HW=1 GEECS_SCANNER_CONFIG_DIR=.../GEECS-Plugins-Configs/scanner_configs/experiments \\
+    poetry run python -u -m pytest tests/test_phase1_hardware.py -m hardware -s
+
+Two tests, the second only with ``GEECS_HW_QSERVER`` set:
+
+1. **In-process** — the worker's own wiring (`make_run_engine(claim=True,
+   …)`, the namespace on the shared path provider, the trigger profiles,
+   the bound plans) drives a strict ``count`` and a strict ``scan`` of
+   ``U_S1H:Current``; asserts every GEECS output of a run: the claimed
+   ``ScanNNN/`` folder, the camera's native files named by the rows'
+   stamps in ``ScanNNN/<device>/``, ``ScanInfoScanNNN.ini`` with the keys
+   downstream parses, the s-file with ``Bin #`` per step, ``scan.log``,
+   the ``baseline`` stream, ARMED → STANDBY around each run; and records
+   the per-shot cadence (M2's every-other-edge on a motor scan is the
+   number PR 3 measures).
+2. **Through the RE Manager** — a second manager on this host
+   (``GEECS_HW_QSERVER=tcp://localhost:60635``, see the runbook in
+   ``Planning/native_bluesky/05_phase1_acceptance.md``): the client seam
+   expands a ``Preset`` (``run_submit_preflight`` then ``submit_preset``),
+   the manager runs it, and the same files are asserted from the newest
+   scan folder.
+
+**MOVES HARDWARE**: the swept setpoint is restored in a ``finally``.
+
+Environment
+-----------
+``GEECS_HW_EXPERIMENT``       experiment (default ``Undulator``)
+``GEECS_HW_CAMERA_DEVICE``    camera (default ``UC_Amp4_IR_input``)
+``GEECS_HW_TRIGGER_PROFILE``  trigger profile (default ``HTU-NoGas``)
+``GEECS_HW_SCAN_VARIABLE``    ``Device:Variable`` to sweep (default ``U_S1H:Current``)
+``GEECS_HW_SCAN_START/END/NUM``  sweep (default −1 → 1 in 5 points)
+``GEECS_HW_SHOTS``            shots for the count (default 3)
+``GEECS_HW_SHOTS_PER_STEP``   rows per position for the scan (default 2)
+``GEECS_HW_QSERVER``          control address of the acceptance manager (unset → test 2 skipped)
+``GEECS_HW_DOCS_OUT``         optional path to dump the in-process documents as JSON
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import time
+from configparser import ConfigParser
+from pathlib import Path
+
+import pytest
+
+from tests.ca_mock_helpers import DocCollector
+
+pytestmark = pytest.mark.hardware
+pytest.importorskip("aioca")
+if os.environ.get("GEECS_HW") != "1":
+    pytest.skip(
+        "fires real shots: set GEECS_HW=1 to run on the lab network",
+        allow_module_level=True,
+    )
+
+EXPERIMENT = os.environ.get("GEECS_HW_EXPERIMENT", "Undulator")
+CAMERA = os.environ.get("GEECS_HW_CAMERA_DEVICE", "UC_Amp4_IR_input")
+PROFILE = os.environ.get("GEECS_HW_TRIGGER_PROFILE", "HTU-NoGas")
+SWEEP = os.environ.get("GEECS_HW_SCAN_VARIABLE", "U_S1H:Current")
+START = float(os.environ.get("GEECS_HW_SCAN_START", "-1"))
+END = float(os.environ.get("GEECS_HW_SCAN_END", "1"))
+NUM = int(os.environ.get("GEECS_HW_SCAN_NUM", "5"))
+SHOTS = int(os.environ.get("GEECS_HW_SHOTS", "3"))
+SHOTS_PER_STEP = int(os.environ.get("GEECS_HW_SHOTS_PER_STEP", "2"))
+
+
+def _ini(path: Path) -> dict[str, str]:
+    parser = ConfigParser()
+    parser.optionxform = str  # type: ignore[assignment]
+    parser.read(path)
+    return {k: v.strip('"') for k, v in parser.items("Scan Info")}
+
+
+def _wait_for_files(
+    directory: Path, expected: int, timeout: float = 15.0
+) -> list[Path]:
+    """Every expected native file exists and has stopped growing (two agreeing stats)."""
+    deadline = time.monotonic() + timeout
+    while True:
+        files = sorted(directory.glob("*.png"))
+        sizes = [f.stat().st_size for f in files]
+        if len(files) >= expected and all(sizes):
+            time.sleep(0.5)
+            if [f.stat().st_size for f in files] == sizes:
+                return files
+        if time.monotonic() > deadline:
+            raise AssertionError(
+                f"{directory}: {len(files)} files after {timeout:.0f} s, expected {expected}"
+            )
+        time.sleep(0.5)
+
+
+def _assert_scan_outputs(
+    folder: Path,
+    *,
+    camera_name: str,
+    expected_rows: int,
+    expected_bins: list[int],
+    scan_parameter: str,
+    shots_per_step: int,
+    plan_name: str,
+) -> None:
+    """The four GEECS outputs of one claimed run, checked from disk."""
+    import pandas as pd
+
+    number = int("".join(ch for ch in folder.name if ch.isdigit()))
+    info = _ini(folder / f"ScanInfo{folder.name}.ini")
+    assert info["Scan No"] == str(number)
+    assert info["Scan Parameter"] == scan_parameter, info
+    assert info["Shots per step"] == str(shots_per_step), info
+    assert info["ScanEndInfo"] == "success", info
+    assert info["Plan"] == plan_name and info["Scanner"] == "bluesky"
+    sfile = pd.read_csv(folder.parent.parent / "analysis" / f"s{number}.txt", sep="\t")
+    scan_txt = pd.read_csv(folder / f"ScanData{folder.name}.txt", sep="\t")
+    assert len(sfile) == expected_rows and list(sfile.columns) == list(scan_txt.columns)
+    assert list(sfile["Bin #"]) == expected_bins
+    assert f"{camera_name} acq_timestamp" in sfile.columns
+    assert (folder / "scan.log").read_text().count("finished (success)") == 1
+    files = _wait_for_files(folder / camera_name, expected_rows)
+    stamps = sfile[f"{camera_name} acq_timestamp"].tolist()
+    names = {f.name for f in files}
+    for stamp in stamps:
+        assert any(f"{stamp:.3f}" in n for n in names), (stamp, sorted(names)[:3])
+    print(
+        f"{folder.name}: {expected_rows} rows, {len(files)} native files, bins {expected_bins}"
+    )
+
+
+@pytest.mark.hardware
+def test_plan_layer_in_process_on_hardware() -> None:
+    """The worker's wiring runs a strict count and a strict scan and leaves every file."""
+    import bluesky.plan_stubs as bps
+    from geecs_core.pv_naming import pv_name, setpoint_pv
+
+    from geecs_bluesky.config_resolver import ConfigsRepoResolver
+    from geecs_bluesky.devices.ca.oneshot import try_caget_once
+    from geecs_bluesky.namespace import GeecsNamespace
+    from geecs_bluesky.plans.claim_scan import GeecsScanPathProvider
+    from geecs_bluesky.plans.registry import TriggerProfiles, bind_strict_plans
+    from geecs_bluesky.run_engine import make_run_engine
+
+    t_build = time.monotonic()
+    provider = GeecsScanPathProvider()
+    namespace = GeecsNamespace.from_experiment(EXPERIMENT, path_provider=provider)
+    profiles = TriggerProfiles.from_resolver(
+        ConfigsRepoResolver(EXPERIMENT), experiment=EXPERIMENT
+    )
+    assert PROFILE in profiles.names, profiles.names
+    RE = make_run_engine(
+        experiment=EXPERIMENT,
+        tiled=True,
+        claim=True,
+        path_provider=provider,
+        telemetry=namespace.telemetry(),
+    )
+    plans = bind_strict_plans(profiles)
+    camera = namespace[CAMERA]
+    assert camera.native_save, f"{CAMERA} has no native saving controls in the DB"
+    motor = namespace.resolve(SWEEP)
+    device_name, _, variable = SWEEP.partition(":")
+    initial = float(
+        try_caget_once(
+            setpoint_pv(pv_name(EXPERIMENT, device_name, variable)), timeout=5.0
+        )
+    )
+    print(
+        f"\nbuilt in {time.monotonic() - t_build:.1f} s: {len(namespace)} devices, "
+        f"profiles {profiles.names}, sweep {SWEEP} from setpoint {initial}"
+    )
+
+    docs = DocCollector()
+    RE.subscribe(docs)
+
+    t0 = time.monotonic()
+    try:
+        RE(
+            plans["count"](
+                [camera],
+                SHOTS,
+                trigger_profile=PROFILE,
+                md={"description": "807 phase 1 acceptance: count"},
+            )
+        )
+        RE(
+            plans["scan"](
+                [camera],
+                motor,
+                START,
+                END,
+                NUM,
+                shots_per_step=SHOTS_PER_STEP,
+                trigger_profile=PROFILE,
+                md={"description": "807 phase 1 acceptance: scan"},
+            )
+        )
+    finally:
+        RE(bps.mv(motor, initial))
+        print(f"restored {SWEEP} to {initial}")
+    wall = time.monotonic() - t0
+
+    out = os.environ.get("GEECS_HW_DOCS_OUT")
+    if out:
+        Path(out).write_text(json.dumps(docs.docs, default=str, indent=1))
+
+    starts, stops = docs.docs["start"], docs.docs["stop"]
+    assert [s["plan_name"] for s in starts] == ["count", "scan"]
+    assert all(s["exit_status"] == "success" for s in stops), stops
+    for start in starts:
+        assert start["experiment"] == EXPERIMENT
+        assert start["trigger_profile"] == PROFILE
+        assert Path(start["scan_folder"]).is_dir()
+        assert start["geecs_scalar_headers"]
+    assert (
+        starts[0]["shots_per_step"] == 1
+        and starts[1]["shots_per_step"] == SHOTS_PER_STEP
+    )
+    assert starts[1]["scan_number"] == starts[0]["scan_number"] + 1
+
+    primary = docs.primary_events()
+    assert len(primary) == SHOTS + NUM * SHOTS_PER_STEP
+    stream_names = {d["name"] for d in docs.docs["descriptor"]}
+    assert "baseline" in stream_names
+    baseline_uids = {
+        d["uid"] for d in docs.docs["descriptor"] if d["name"] == "baseline"
+    }
+    baseline_rows = [e for e in docs.docs["event"] if e["descriptor"] in baseline_uids]
+    assert len(baseline_rows) == 4  # open + close, two runs
+    print(f"baseline stream: {len(baseline_rows[0]['data'])} columns")
+
+    shot_control = profiles.resolve(PROFILE)
+    assert shot_control.standing_state == "STANDBY"
+
+    key = f"{camera.name}-acq_timestamp"
+    stamps = [e["data"][key] for e in primary]
+    assert len(set(stamps)) == len(stamps), "stamps did not advance per shot"
+    # Cadence from the rows' own stamps (the shot times, §11.3), per run.
+    count_stamps, scan_stamps = stamps[:SHOTS], stamps[SHOTS:]
+    print(
+        f"count cadence (s): {[round(b - a, 3) for a, b in zip(count_stamps, count_stamps[1:])]}"
+    )
+    print(
+        f"scan cadence (s): {[round(b - a, 3) for a, b in zip(scan_stamps, scan_stamps[1:])]}"
+    )
+    print(f"wall: {wall:.1f} s for {len(primary)} shots")
+
+    motor_header = starts[1]["geecs_scalar_headers"][motor.position.name]
+    _assert_scan_outputs(
+        Path(starts[0]["scan_folder"]),
+        camera_name=CAMERA,
+        expected_rows=SHOTS,
+        expected_bins=[1] * SHOTS,
+        scan_parameter="Shotnumber",
+        shots_per_step=SHOTS,
+        plan_name="count",
+    )
+    _assert_scan_outputs(
+        Path(starts[1]["scan_folder"]),
+        camera_name=CAMERA,
+        expected_rows=NUM * SHOTS_PER_STEP,
+        expected_bins=[b for b in range(1, NUM + 1) for _ in range(SHOTS_PER_STEP)],
+        scan_parameter=motor_header,
+        shots_per_step=SHOTS_PER_STEP,
+        plan_name="scan",
+    )
+    info = _ini(
+        Path(starts[1]["scan_folder"])
+        / f"ScanInfo{Path(starts[1]['scan_folder']).name}.ini"
+    )
+    assert (float(info["Start"]), float(info["End"])) == (START, END)
+    assert float(info["Step size"]) == pytest.approx((END - START) / (NUM - 1))
+    save_state = asyncio.run_coroutine_threadsafe(
+        camera.save.get_value(), RE._loop
+    ).result(5)
+    assert save_state == "off"
+
+
+@pytest.mark.hardware
+def test_preset_through_the_manager_on_hardware() -> None:
+    """A preset expanded by the client seam runs on a second RE Manager and leaves the files."""
+    control = os.environ.get("GEECS_HW_QSERVER")
+    if not control:
+        pytest.skip("set GEECS_HW_QSERVER=tcp://host:port to the acceptance manager")
+    pytest.importorskip("bluesky_queueserver_api")
+    from geecs_core.pv_naming import pv_name, setpoint_pv
+    from geecs_schemas import Preset
+
+    from geecs_bluesky.config_resolver import ConfigsRepoResolver
+    from geecs_bluesky.devices.ca.oneshot import try_caget_once
+    from geecs_bluesky.plan_names import GEECS_PLAN_NAMES
+    from geecs_bluesky.qs_client import (
+        QserverConfig,
+        ZmqQueueClient,
+        run_submit_preflight,
+    )
+
+    host, _, port = control.rpartition(":")
+    client = ZmqQueueClient(
+        QserverConfig(control, f"{host}:{int(port) + 10}", "OFF"), user="807-acceptance"
+    )
+    verdict = client.readiness(GEECS_PLAN_NAMES)
+    assert verdict.ready, verdict.detail
+    device_name, _, variable = SWEEP.partition(":")
+    initial = float(
+        try_caget_once(
+            setpoint_pv(pv_name(EXPERIMENT, device_name, variable)), timeout=5.0
+        )
+    )
+    preset = Preset.model_validate(
+        {
+            "name": "807-phase1-acceptance",
+            "description": "807 phase 1 acceptance: preset through the manager",
+            "trigger_profile": PROFILE,
+            "devices": [{"device": CAMERA}],
+            "plan": {
+                "name": "scan",
+                "args": [SWEEP, START, END, NUM],
+                "kwargs": {"shots_per_step": SHOTS_PER_STEP},
+            },
+        }
+    )
+    catalog = ConfigsRepoResolver(EXPERIMENT).scan_variable_catalog().variables
+    report = run_submit_preflight(preset, EXPERIMENT, client=client, catalog=catalog)
+    assert report.refusal is None, report.refusal
+    print(
+        f"\npreflight: {report.outcomes}, questions {[q.check for q in report.questions]}"
+    )
+
+    scans_dir = _scans_dir()
+    before = {p.name for p in scans_dir.glob("Scan*")}
+    result = client.submit_preset(preset, catalog=catalog)
+    assert result.ok, result.message
+    try:
+        item = _wait_for_item(client, result.item_uid, timeout=300.0)
+        assert item.get("result", {}).get("exit_status") == "completed", item.get(
+            "result"
+        )
+    finally:
+        # The scan item is in the history by now (or the wait raised), so the
+        # queue is empty and the restore is accepted; clear_pending covers a
+        # scan that is still queued after a failed wait — the restore must
+        # not be refused for the #648 front-of-queue guard.
+        restore = client.submit_plan(
+            "mv",
+            args=[f"{device_name}.{variable.lower()}", initial],
+            clear_pending=True,
+        )
+        print(f"restore {SWEEP} to {initial}: {restore.message}")
+        assert restore.ok, restore.message
+        _wait_for_item(client, restore.item_uid, timeout=120.0)
+        client.close()
+    new = sorted({p.name for p in scans_dir.glob("Scan*")} - before)
+    assert len(new) == 1, new
+    folder = scans_dir / new[0]
+    catalog_entry = catalog.get(SWEEP)
+    _assert_scan_outputs(
+        folder,
+        camera_name=CAMERA,
+        expected_rows=NUM * SHOTS_PER_STEP,
+        expected_bins=[b for b in range(1, NUM + 1) for _ in range(SHOTS_PER_STEP)],
+        scan_parameter=f"{device_name} {variable}" if catalog_entry is None else SWEEP,
+        shots_per_step=SHOTS_PER_STEP,
+        plan_name="scan",
+    )
+    info = _ini(folder / f"ScanInfo{folder.name}.ini")
+    assert info["ScanStartInfo"] == preset.description
+    assert info["Trigger profile"] == PROFILE
+
+
+def _wait_for_item(client, item_uid: str, *, timeout: float) -> dict:
+    """Block until the queue item *item_uid* is in the manager's history; return it.
+
+    The manager starts a freshly queued item asynchronously — a status poll
+    right after ``queue_start`` still reads idle — so "done" is the item
+    leaving the queue and the running slot and appearing in the history.
+    """
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        for entry in client.history_items():
+            if entry.get("item_uid") == item_uid:
+                return entry
+        time.sleep(1.0)
+    raise AssertionError(f"queue item {item_uid} did not finish within {timeout:.0f} s")
+
+
+def _scans_dir() -> Path:
+    from geecs_data_utils import ScanPaths
+
+    if ScanPaths.paths_config is None:
+        ScanPaths.reload_paths_config(default_experiment=EXPERIMENT)
+    return ScanPaths.get_daily_scan_folder(experiment=EXPERIMENT)

--- a/GeecsBluesky/tests/test_phase1_hardware.py
+++ b/GeecsBluesky/tests/test_phase1_hardware.py
@@ -18,8 +18,9 @@ Two tests, the second only with ``GEECS_HW_QSERVER`` set:
    ``ScanNNN/`` folder, the camera's native files named by the rows'
    stamps in ``ScanNNN/<device>/``, ``ScanInfoScanNNN.ini`` with the keys
    downstream parses, the s-file with ``Bin #`` per step, ``scan.log``,
-   the ``baseline`` stream, ARMED → STANDBY around each run; and records
-   the per-shot cadence (M2's every-other-edge on a motor scan is the
+   the ``baseline`` stream, the box driven back to STANDBY after each
+   run (the profile device's standing state; ARMED is observed by the
+   shots landing); and records the per-shot cadence (M2's every-other-edge on a motor scan is the
    number PR 3 measures).
 2. **Through the RE Manager** — a second manager on this host
    (``GEECS_HW_QSERVER=tcp://localhost:60635``, see the runbook in
@@ -49,12 +50,11 @@ import asyncio
 import json
 import os
 import time
-from configparser import ConfigParser
 from pathlib import Path
 
 import pytest
 
-from tests.ca_mock_helpers import DocCollector
+from tests.ca_mock_helpers import DocCollector, read_scan_info, wait_for_native_files
 
 pytestmark = pytest.mark.hardware
 pytest.importorskip("aioca")
@@ -75,32 +75,6 @@ SHOTS = int(os.environ.get("GEECS_HW_SHOTS", "3"))
 SHOTS_PER_STEP = int(os.environ.get("GEECS_HW_SHOTS_PER_STEP", "2"))
 
 
-def _ini(path: Path) -> dict[str, str]:
-    parser = ConfigParser()
-    parser.optionxform = str  # type: ignore[assignment]
-    parser.read(path)
-    return {k: v.strip('"') for k, v in parser.items("Scan Info")}
-
-
-def _wait_for_files(
-    directory: Path, expected: int, timeout: float = 15.0
-) -> list[Path]:
-    """Every expected native file exists and has stopped growing (two agreeing stats)."""
-    deadline = time.monotonic() + timeout
-    while True:
-        files = sorted(directory.glob("*.png"))
-        sizes = [f.stat().st_size for f in files]
-        if len(files) >= expected and all(sizes):
-            time.sleep(0.5)
-            if [f.stat().st_size for f in files] == sizes:
-                return files
-        if time.monotonic() > deadline:
-            raise AssertionError(
-                f"{directory}: {len(files)} files after {timeout:.0f} s, expected {expected}"
-            )
-        time.sleep(0.5)
-
-
 def _assert_scan_outputs(
     folder: Path,
     *,
@@ -115,7 +89,7 @@ def _assert_scan_outputs(
     import pandas as pd
 
     number = int("".join(ch for ch in folder.name if ch.isdigit()))
-    info = _ini(folder / f"ScanInfo{folder.name}.ini")
+    info = read_scan_info(folder / f"ScanInfo{folder.name}.ini")
     assert info["Scan No"] == str(number)
     assert info["Scan Parameter"] == scan_parameter, info
     assert info["Shots per step"] == str(shots_per_step), info
@@ -127,7 +101,7 @@ def _assert_scan_outputs(
     assert list(sfile["Bin #"]) == expected_bins
     assert f"{camera_name} acq_timestamp" in sfile.columns
     assert (folder / "scan.log").read_text().count("finished (success)") == 1
-    files = _wait_for_files(folder / camera_name, expected_rows)
+    files = wait_for_native_files(folder / camera_name, expected_rows)
     stamps = sfile[f"{camera_name} acq_timestamp"].tolist()
     names = {f.name for f in files}
     for stamp in stamps:
@@ -273,7 +247,7 @@ def test_plan_layer_in_process_on_hardware() -> None:
         shots_per_step=SHOTS_PER_STEP,
         plan_name="scan",
     )
-    info = _ini(
+    info = read_scan_info(
         Path(starts[1]["scan_folder"])
         / f"ScanInfo{Path(starts[1]['scan_folder']).name}.ini"
     )
@@ -303,6 +277,7 @@ def test_preset_through_the_manager_on_hardware() -> None:
         ZmqQueueClient,
         run_submit_preflight,
     )
+    from geecs_bluesky.qs_client.presets import scan_variable_reference
 
     host, _, port = control.rpartition(":")
     client = ZmqQueueClient(
@@ -335,6 +310,9 @@ def test_preset_through_the_manager_on_hardware() -> None:
     print(
         f"\npreflight: {report.outcomes}, questions {[q.check for q in report.questions]}"
     )
+    assert all(result == "passed" for _, result, _ in report.outcomes), report.outcomes
+    assert not report.questions, report.questions
+    motor_reference = scan_variable_reference(SWEEP, catalog)
 
     scans_dir = _scans_dir()
     before = {p.name for p in scans_dir.glob("Scan*")}
@@ -346,35 +324,54 @@ def test_preset_through_the_manager_on_hardware() -> None:
             "result"
         )
     finally:
-        # The scan item is in the history by now (or the wait raised), so the
-        # queue is empty and the restore is accepted; clear_pending covers a
-        # scan that is still queued after a failed wait — the restore must
-        # not be refused for the #648 front-of-queue guard.
-        restore = client.submit_plan(
-            "mv",
-            args=[f"{device_name}.{variable.lower()}", initial],
-            clear_pending=True,
-        )
+        # The manager writes the history entry before it goes idle, and a
+        # plan still running at the wait's timeout keeps it busy: a restore
+        # queued while the manager is not idle is refused ("busy").  So:
+        # wait for idle (bounded), then submit with retries, clear_pending
+        # covering an item still queued; a restore that never took is
+        # shouted with the value to put back by hand.
+        _wait_for_manager_idle(client, timeout=600.0)
+        restore = None
+        for attempt in range(5):
+            restore = client.submit_plan(
+                "mv", args=[motor_reference, initial], clear_pending=True
+            )
+            if restore.ok:
+                break
+            print(f"restore attempt {attempt + 1} refused: {restore.message}")
+            time.sleep(3.0)
         print(f"restore {SWEEP} to {initial}: {restore.message}")
-        assert restore.ok, restore.message
+        assert restore.ok, (
+            f"RESTORE NOT QUEUED — set {SWEEP} back to {initial} by hand: {restore.message}"
+        )
         _wait_for_item(client, restore.item_uid, timeout=120.0)
         client.close()
     new = sorted({p.name for p in scans_dir.glob("Scan*")} - before)
     assert len(new) == 1, new
     folder = scans_dir / new[0]
-    catalog_entry = catalog.get(SWEEP)
     _assert_scan_outputs(
         folder,
         camera_name=CAMERA,
         expected_rows=NUM * SHOTS_PER_STEP,
         expected_bins=[b for b in range(1, NUM + 1) for _ in range(SHOTS_PER_STEP)],
-        scan_parameter=f"{device_name} {variable}" if catalog_entry is None else SWEEP,
+        scan_parameter=f"{device_name} {variable}",
         shots_per_step=SHOTS_PER_STEP,
         plan_name="scan",
     )
-    info = _ini(folder / f"ScanInfo{folder.name}.ini")
+    info = read_scan_info(folder / f"ScanInfo{folder.name}.ini")
     assert info["ScanStartInfo"] == preset.description
     assert info["Trigger profile"] == PROFILE
+
+
+def _wait_for_manager_idle(client, *, timeout: float) -> None:
+    """Block until ``manager_state`` reads idle (a queued restore is refused otherwise)."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        status = client.status()
+        if status.connected and status.manager_state == "idle":
+            return
+        time.sleep(1.0)
+    print(f"WARNING: the manager did not go idle within {timeout:.0f} s")
 
 
 def _wait_for_item(client, item_uid: str, *, timeout: float) -> dict:

--- a/GeecsBluesky/tests/test_phase1_hardware.py
+++ b/GeecsBluesky/tests/test_phase1_hardware.py
@@ -344,8 +344,19 @@ def test_preset_through_the_manager_on_hardware() -> None:
         assert restore.ok, (
             f"RESTORE NOT QUEUED — set {SWEEP} back to {initial} by hand: {restore.message}"
         )
-        _wait_for_item(client, restore.item_uid, timeout=120.0)
+        restored = _wait_for_item(client, restore.item_uid, timeout=120.0)
         client.close()
+        assert restored.get("result", {}).get("exit_status") == "completed", (
+            f"RESTORE DID NOT COMPLETE — set {SWEEP} back to {initial} by hand: "
+            f"{restored.get('result')}"
+        )
+        readback = float(
+            try_caget_once(
+                setpoint_pv(pv_name(EXPERIMENT, device_name, variable)), timeout=5.0
+            )
+        )
+        assert readback == pytest.approx(initial, abs=1e-6), (readback, initial)
+        print(f"restored {SWEEP}: setpoint reads {readback}")
     new = sorted({p.name for p in scans_dir.glob("Scan*")} - before)
     assert len(new) == 1, new
     folder = scans_dir / new[0]

--- a/Planning/native_bluesky/03_clean_room_rebuild.md
+++ b/Planning/native_bluesky/03_clean_room_rebuild.md
@@ -693,11 +693,14 @@ Still open, for Sam:
    - **Corpus regeneration is on a configs-repo branch** (`presets-v1`),
      not main: the deployed master worker still reads `save_devices/`;
      the branch merges with the worker flip (PR 3).
-8. **PR 3 facts (2026-09-10, `05_phase1_acceptance.md` M6):** at 1 Hz the
-   camera's frame *message* arrives ~115 ms before the next edge and the
-   fire put takes ~108 ms, so the strict path has ~100 ms of per-shot
-   margin beyond its own ~7 ms — it holds in process and not in the
-   manager's worker process (2 s repeats).  A 0.5 A `U_S1H` move is a
+8. **PR 3 facts (2026-09-10/11, `05_phase1_acceptance.md` M6):** the fire
+   request is asynchronous to the laser, so a cold shot's request-to-frame
+   delay is uniform over one period; after the first shot the loop is
+   phase-locked to the edges.  On `UC_Amp4_IR_input` (0.70 s exposure)
+   edge → message ≈ 0.8 s and the fire put ≈ 108 ms, so the strict path
+   has ~100 ms of per-shot margin beyond its own ~7 ms — it holds in
+   process and not in the manager's worker process (2 s repeats); a
+   shorter exposure buys margin, the plan layer cannot.  A 0.5 A `U_S1H` move is a
    1.3 s blocking set, so a moved step lands on the third edge (M2's
    second was a faster move that day).  Strict single-shot is therefore
    not the 1 Hz mode; phase 2's gated batch is.  Recorded here so the

--- a/Planning/native_bluesky/03_clean_room_rebuild.md
+++ b/Planning/native_bluesky/03_clean_room_rebuild.md
@@ -63,7 +63,8 @@ is right in five years, not the one that is reachable in small steps.
 | thing | state |
 |---|---|
 | `feature/native-bluesky-plans` | integration branch off master; **#808 merged** 2026-09-09 (device namespace); **#811 merged** 2026-09-10 (phase 0, hardware-accepted — `04_phase0_measurements.md` M2/M3); **#813 merged** 2026-09-10 (test speed, #812) |
-| `phase/02-plan-layer` (phase 1 PR 2) | **the plan layer** (GeecsBluesky 0.80.0, GEECS-Schemas 0.21.0): the registration table (`plans/registry.py` — 18 stock verbs bound strict under their own names, `trigger_profile` + `shots_per_step` keyword-only, ARMED → STANDBY bracket), the `claim_scan` preprocessor + `GeecsScanPathProvider` (every run claims), the `scalar_headers` preprocessor, the ScanInfo / s-file (from the documents) / `scan.log` callbacks, `SupplementalData` baseline telemetry, `GeecsDetector.scalars`, `Preset` v1 (save sets deleted; corpus regenerated on the configs branch `presets-v1`), `qs_client.submit_plan` / `submit_preset`.  Decisions in §10.7 |
+| `phase/03-hardware-acceptance` (phase 1 PR 3) | **hardware-accepted 2026-09-10** — `tests/test_phase1_hardware.py`: the worker's wiring in process (Scans 104/105) and a `Preset` through a second RE Manager (Scans 106/108), every file asserted from disk; per-shot budget measured (`05_phase1_acceptance.md` M4–M6). The worker checkout is on the feature branch with its env installed; the `systemctl restart` that completes the flip is the maintainer's |
+| `phase/02-plan-layer` (phase 1 PR 2) | **MERGED 2026-09-10 (#821)** — the plan layer (GeecsBluesky 0.80.0, GEECS-Schemas 0.21.0): the registration table (`plans/registry.py` — 18 stock verbs bound strict under their own names, `trigger_profile` + `shots_per_step` keyword-only, ARMED → STANDBY bracket), the `claim_scan` preprocessor + `GeecsScanPathProvider` (every run claims), the `scalar_headers` preprocessor, the ScanInfo / s-file (from the documents) / `scan.log` callbacks, `SupplementalData` baseline telemetry, `GeecsDetector.scalars`, `Preset` v1 (save sets deleted; corpus regenerated on the configs branch `presets-v1`), `qs_client.submit_plan` / `submit_preset`.  Decisions in §10.7 |
 | `phase/01-foundation` (phase 1 PR 1) | **MERGED 2026-09-10 (#816)** — the deletions: the `ScanRequest` funnel and named plans, free-run, `GeecsSession`, `scan_request_runner`, `preflight`, `pause_semantics`, `t0_sync`, the funnel-only devices (`CaGenericDetector`, `CaTriggerable`, `CaTelemetryReadable`, `CaTimestampedReadable`, the shot-id / contributor / nonscalar-save mixins), `ShotController` (its write machinery folded into `ShotControl`), the optimization glue (`plans/optimize`, `optimize.py`, `session_bridge`, `worker_loader`) and every test of theirs; the namespace builds `GeecsDetector` for every triggerable device (`native_save` iff the DB lists `save` + `localsavingpath`); `run_engine.make_run_engine` replaces the session; the startup profile exports the stock `bluesky.plans` verbs (`plan_names.GEECS_PLAN_NAMES`) over the namespace; `qs_client` keeps its surface (readiness + liveness preflight only) so the Console and MCP stay importable |
 | #809 `phase/02-preamble-preprocessor` | **OPEN, on hold, will not merge** (13 commits, GeecsBluesky 0.79.0, CI green). The evidence behind §3; close with a pointer here once this amendment lands (§8) |
 | #806 image writing | **OPEN, not started.** Phase 1, in parallel with the plan layer (§8). File plugin in GeecsPvaGateway + stock `ADHDFDataLogic`; capture daemon retired |
@@ -507,7 +508,7 @@ the least-verified component while the scan path waited.
    the plan layer** (built on `phase/02-plan-layer`: the registration
    table, the `claim_scan` preprocessor + `PathProvider`, the ScanInfo /
    s-file / `scan.log` callbacks, the baseline telemetry, `Preset` v1
-   and the client seam — §10.7); **PR 3 — headless hardware acceptance** (HTU-NoGas, `U_S1H:Current`
+   and the client seam — §10.7); **PR 3 — headless hardware acceptance (done 2026-09-10, `05_phase1_acceptance.md`)** (HTU-NoGas, `U_S1H:Current`
    −1 → +1 A in 0.5 A steps, amp4in, setpoint restored), then the worker
    flips. Hardware acceptance for #806 separately.
 2. Gated batch + the non-essential stream via `SupplementalData.flyers`;
@@ -692,7 +693,16 @@ Still open, for Sam:
    - **Corpus regeneration is on a configs-repo branch** (`presets-v1`),
      not main: the deployed master worker still reads `save_devices/`;
      the branch merges with the worker flip (PR 3).
-8. Two small carry-overs, unrelated to this direction: write
+8. **PR 3 facts (2026-09-10, `05_phase1_acceptance.md` M6):** at 1 Hz the
+   camera's frame *message* arrives ~115 ms before the next edge and the
+   fire put takes ~108 ms, so the strict path has ~100 ms of per-shot
+   margin beyond its own ~7 ms — it holds in process and not in the
+   manager's worker process (2 s repeats).  A 0.5 A `U_S1H` move is a
+   1.3 s blocking set, so a moved step lands on the third edge (M2's
+   second was a faster move that day).  Strict single-shot is therefore
+   not the 1 Hz mode; phase 2's gated batch is.  Recorded here so the
+   cadence fix is scoped as "gated batch", not "a faster fire".
+9. Two small carry-overs, unrelated to this direction: write
    `Amplitude.Ch AB: 0.5` explicitly in every state of `HTU-NoGas` so "no
    gas" stops being order-dependent, and add a check that all profiles in
    an experiment manage the same variable set.

--- a/Planning/native_bluesky/03_clean_room_rebuild.md
+++ b/Planning/native_bluesky/03_clean_room_rebuild.md
@@ -699,8 +699,10 @@ Still open, for Sam:
    phase-locked to the edges.  On `UC_Amp4_IR_input` (0.70 s exposure)
    edge → message ≈ 0.8 s and the fire put ≈ 108 ms, so the strict path
    has ~100 ms of per-shot margin beyond its own ~7 ms — it holds in
-   process and not in the manager's worker process (2 s repeats); a
-   shorter exposure buys margin, the plan layer cannot.  A 0.5 A `U_S1H` move is a
+   process and not in the manager's worker process (2 s repeats).  At a
+   1 ms exposure (M7) both losses go: 1 Hz repeats through the manager,
+   a moved step on the second edge — the exposure sets the margin, the
+   plan layer cannot.  A 0.5 A `U_S1H` move is a
    1.3 s blocking set, so a moved step lands on the third edge (M2's
    second was a faster move that day).  Strict single-shot is therefore
    not the 1 Hz mode; phase 2's gated batch is.  Recorded here so the

--- a/Planning/native_bluesky/05_phase1_acceptance.md
+++ b/Planning/native_bluesky/05_phase1_acceptance.md
@@ -1,0 +1,159 @@
+# Phase 1 — headless hardware acceptance (PR 3, 2026-09-10)
+
+Raw records and the runbook behind the phase-1 verdict in
+`03_clean_room_rebuild.md` §2/§8: the plan layer (PR 2, #821) driven on HTU
+by the worker's own wiring and through a second RE Manager, then the
+worker flip.  Same conventions as `04_phase0_measurements.md`: each
+measurement names what it was for, what was written to hardware, and what
+it showed.  Setup: HTU-NoGas, camera `UC_Amp4_IR_input` (native PNGs),
+sweep `U_S1H:Current` −1 → +1 A in 5 points, setpoint restored after every
+run; the configs corpus from the `presets-v1` branch
+(`GEECS_SCANNER_CONFIG_DIR` pointed at a checkout beside the staging
+clone — the share stays on `main` for the deployed worker and the
+clients).  The test is `GeecsBluesky/tests/test_phase1_hardware.py`
+(`GEECS_HW=1`; it fires shots).
+
+## Runbook — a second RE Manager beside the deployed one
+
+The deployed worker (`~/qs-checkout`, systemd `geecs-qserver`, ZMQ
+60615/60625, doc proxy 5567/5568, Redis 6379) keeps running on its
+branch; the acceptance manager runs from the staging clone on its own
+ports and its own Redis key prefix, with the document publisher off (the
+production proxy must not receive its documents).  As the service
+account:
+
+```bash
+cd ~/deploy-staging/GEECS-Plugins && git fetch && git checkout feature/native-bluesky-plans && git pull --ff-only
+cd GeecsBluesky && poetry env use python3.11 && poetry install --extras "ca tiled qserver qs-client"
+cd ~/deploy-staging && git clone -b presets-v1 https://github.com/GEECS-BELLA/GEECS-Plugins-Configs.git
+
+cd ~/deploy-staging/GEECS-Plugins/GeecsBluesky
+export GEECS_SCANNER_CONFIG_DIR=$HOME/deploy-staging/GEECS-Plugins-Configs/scanner_configs/experiments
+export QS_EXPERIMENT=Undulator QS_DOC_PUBLISH_ADDR=OFF EPICS_CA_ADDR_LIST=192.168.6.14 EPICS_CA_AUTO_ADDR_LIST=NO
+V=$(poetry env info -p)
+nohup $V/bin/start-re-manager --startup-dir $PWD/qserver/startup \
+  --user-group-permissions $PWD/qserver/user_group_permissions.yaml --keep-re \
+  --zmq-publish-console ON --zmq-control-addr "tcp://*:60635" --zmq-info-addr "tcp://*:60645" \
+  --redis-name-prefix qs_acceptance > ~/deploy-staging/acceptance-manager.log 2>&1 &
+$V/bin/geecs-qserver-ensure-ready --control-addr tcp://localhost:60635 --timeout 300
+#   → "ready: 19 allowed plans, all 19 expected present"
+
+GEECS_HW=1 poetry run python -u -m pytest tests/test_phase1_hardware.py -m hardware -s -k in_process
+GEECS_HW=1 GEECS_HW_QSERVER=tcp://localhost:60635 poetry run python -u -m pytest tests/test_phase1_hardware.py -m hardware -s -k manager
+pkill -f "start-re-manager.*60635"      # never two managers able to arm the box at once
+```
+
+`QSERVER_ZMQ_CONTROL_ADDRESS=tcp://localhost:60635 qserver status` inspects
+the acceptance manager from the CLI.  The two `redis-name-prefix`es keep
+the queues apart in the one Redis.
+
+## M4 — the plan layer in process (Scans 104 and 105, 26_0910)
+
+**Purpose.** Prove PR 2's deliverable with the worker's own wiring:
+`make_run_engine(claim=True, path_provider, telemetry=namespace.telemetry())`,
+the namespace on the shared `GeecsScanPathProvider`, `TriggerProfiles`
+from the configs repo, the bound `count` and `scan`.
+
+**Result — `1 passed in 72 s`.**
+
+| | Scan104 (`count`, 3 shots) | Scan105 (`scan`, 5 points × 2 shots) |
+|---|---|---|
+| start doc | `plan_name`, `experiment`, `trigger_profile=HTU-NoGas`, `shots_per_step` 1 / 2, `scan_folder`, `geecs_scalar_headers` | same; `scan_number` = previous + 1 |
+| native files | 3 PNGs in `Scan104/UC_Amp4_IR_input/`, named by the rows' stamps | 10 PNGs, named by the rows' stamps |
+| `ScanInfoScanNNN.ini` | `Scan Parameter = "Shotnumber"`, `Shots per step = 3`, `ScanEndInfo = "success"`, `ScanMode = "noscan"` | `Scan Parameter = "U_S1H Current"`, `Start/End/Step size = -1.0/1.0/0.5`, `Shots per step = 2`, `Plan = "scan"`, `Trigger profile = "HTU-NoGas"` |
+| s-file (`analysis/sNNN.txt` = `ScanDataScanNNN.txt`) | 3 rows, `Bin # = 1,1,1`, headers `UC_Amp4_IR_input MeanCounts` … `acq_timestamp` | 10 rows, `Bin # = 1,1,2,2,…,5,5`, `U_S1H Current` = −0.99984 … 0.99989 |
+| `scan.log` | one `finished (success)` | one `finished (success)`, the five `moving Current →` lines |
+| `baseline` stream | 419 columns, 2 rows | 2 rows |
+| trigger box | ARMED before, STANDBY after (`standing_state`) | same; `save` reads `off` after the run |
+| build | 26 s (108 devices, 375 telemetry objects connected; two unservable devices dropped loudly) | |
+
+**Cadence (from the rows' stamps).** Scan104: `[2.0, 1.0]` — 1 Hz after
+the first shot.  Scan105: `[2.0, 3.0, 1.0, 3.0, 1.0, 3.0, 1.0, 3.0, 1.0]` —
+the repeat shot at a position lands on the next edge, a **moved step
+lands on the third edge** (M2 saw the second).
+
+## M5 — a preset through the RE Manager (Scans 106 and 108)
+
+**Purpose.** The queue-item contract end to end: `Preset` →
+`run_submit_preflight` (expand, the worker lists the plan and every
+reference, `CONNECTED`) → `submit_preset` → the manager runs the bound
+`scan` → the same files.
+
+**Result — `1 passed in 39 s` (Scan108; Scan106 was the first run, whose
+test wait returned early — see below).**  Preflight
+`[validate, worker_ready, gateway_liveness] passed`; history item
+`exit_status: completed`, `scan_ids: [106]`; 10 rows, 10 PNGs, bins
+1,1,…,5,5, `ScanStartInfo` = the preset description, `Trigger profile =
+"HTU-NoGas"`; the restore `mv` queued and ran; `U_S1H` setpoint 0.0
+after.
+
+**Cadence.** Scan106: `[2.0, 3.0, 2.0, 3.0, 2.0, 3.0, 2.0, 3.0, 2.0]` —
+through the manager the repeat shot lost an edge too (see M6).
+
+**Two lessons from the first run.** (1) A status poll right after
+`queue_start` still reads idle — "done" is the item reaching the
+manager's history (`_wait_for_item`). (2) The restore `mv` submitted
+while the scan item was still queued was refused by the #648
+front-of-queue guard, leaving `U_S1H` at 1 A until restored by hand; the
+test now awaits its own item and restores with `clear_pending=True`.
+
+## M6 — where the shot period goes (Scan107, a 6-shot count, DEBUG timings)
+
+```
+shot phases: fire 247 ms, frame wait 1289 ms   (first shot)
+shot phases: fire 235 ms, frame wait 1685 ms
+shot phases: fire 108 ms, frame wait  886 ms   ×4
+count stamp gaps: [2.0, 1.0, 1.0, 1.0, 1.0]
+mv U_S1H → -0.5: 1.28 s;  mv → 0.0: 1.26 s   (bare 0.5 A moves)
+prepare (localsavingpath + save puts): ~2 ms   (values unchanged)
+```
+
+So at 1 Hz on this camera: the fire put takes ~108 ms and the frame
+**message** arrives ~886 ms after it — i.e. ~115 ms before the next edge.
+The plan layer's own work between frame arrival and the next fire
+completing is ~7 ms; the margin for *anything else* per shot (a document
+callback's HTTP round trip, the manager's per-message overhead) is
+~100 ms.  In process that holds (1 Hz); in the manager's worker process
+it did not (2 s repeats, M5).  A moved step adds the 1.3 s blocking GEECS
+set of the magnet: previous frame (+0.9 s) → move done (+2.2 s) → fire
+(+2.3 s) → the edge at +2 s is gone, the shot lands at +3 s.  M2's 2 s per
+step (2026-09-09) means the same move was under ~1 s then — device-side
+variation, not the plan.
+
+**Consequence (§11).** The stamp governs the join, the *message arrival*
+governs the wait (§11.4) — and at 1 Hz that arrival leaves ~100 ms to fire
+the next shot.  Strict single-shot cannot sustain 1 Hz with any per-shot
+cost beyond the fire; the native answer is phase 2's gated batch (the
+edges flow, the detector counts), not a faster fire.  Overlapping the
+magnet move with the previous shot's wait would recover the moved step
+(2 s → still not 1 s) — a plan-layer option, not taken here.
+
+## The worker flip (2026-09-10, prepared; restart pending)
+
+What the flip is: `~/qs-checkout` (the deployed worker's clone, shared
+with `geecs-capture`; the MCP venv is baked separately and does not
+follow) on `feature/native-bluesky-plans`, its environment re-installed
+(`poetry install --extras "ca tiled qserver"`, the optimize extra left in
+place), then `sudo systemctl restart geecs-qserver` — the readiness
+oneshot re-runs and asserts the 19 plans.  The deployed worker then runs
+stock plans over presets; the master Console and MCP can no longer submit
+(they name the retired funnel plan; their preflight refuses first) until
+their rewire — the accepted state of §10.5.
+
+Done as the service account (no restart, which needs sudo): the
+acceptance manager stopped; `~/qs-checkout` fetched, checked out on
+`feature/native-bluesky-plans` at the #821 merge, `poetry install` clean,
+`geecs_bluesky.plans.registry` / `callbacks` / `capture.daemon`
+importable in the production env.  The running `geecs-qserver` still
+holds master's code until the restart:
+
+```bash
+sudo systemctl restart geecs-qserver      # pulls geecs-qserver-ready along
+journalctl -u geecs-qserver-ready -n 3 --no-pager   # "ready: 19 allowed plans, all 19 expected present"
+sudo systemctl restart geecs-capture      # picks up the same clone's code (optional; not required for production)
+```
+
+The clients' configs stay on the share's `main` (the worker reads no
+presets; the trigger profiles, scan-variable catalog and action library
+are unchanged there); the `presets-v1` branch merges into the configs
+`main` with the Console/MCP rewire, when something reads it.

--- a/Planning/native_bluesky/05_phase1_acceptance.md
+++ b/Planning/native_bluesky/05_phase1_acceptance.md
@@ -112,25 +112,46 @@ mv U_S1H → -0.5: 1.28 s;  mv → 0.0: 1.26 s   (bare 0.5 A moves)
 prepare (localsavingpath + save puts): ~2 ms   (values unchanged)
 ```
 
-So at 1 Hz on this camera: the fire put takes ~108 ms and the frame
-**message** arrives ~886 ms after it — i.e. ~115 ms before the next edge.
-The plan layer's own work between frame arrival and the next fire
-completing is ~7 ms; the margin for *anything else* per shot (a document
-callback's HTTP round trip, the manager's per-message overhead) is
-~100 ms.  In process that holds (1 Hz); in the manager's worker process
-it did not (2 s repeats, M5).  A moved step adds the 1.3 s blocking GEECS
-set of the magnet: previous frame (+0.9 s) → move done (+2.2 s) → fire
-(+2.3 s) → the edge at +2 s is gone, the shot lands at +3 s.  M2's 2 s per
-step (2026-09-09) means the same move was under ~1 s then — device-side
-variation, not the plan.
+**Reading these numbers correctly (Sam's point, 2026-09-11).** The fire
+request is not synchronized to the laser: in *single shot external rising
+edges* the DG645 fires on the **next** edge after the put, so for a shot
+whose request lands at a random phase the request-to-frame delay is
+uniform over one period.  That is the first shot of each run here (frame
+waits of 1289 and 1685 ms).  Every shot after it is **phase-locked**: the
+fire is issued a fixed time after the previous frame arrived, so it lands
+at a fixed phase before the edge, and the "886 ms frame wait" is simply
+1000 ms minus the ~115 ms of fire put + plan work — it says the loop is
+locked at 1 Hz, not what the camera's latency is.
+
+The camera's latency is in the documents: event arrival time minus the
+row's stamp (converted from the LabVIEW epoch) is **0.75 s** on every
+locked shot (0.87–0.88 s on the first shot of a run, which includes the
+first `prepare`), and the stamp precedes the edge-to-message path by the
+~65 ms drain (M1), so edge → message ≈ **0.8 s** — the camera's 0.70 s
+exposure (`UC_Amp4_IR_input exposure` in the s-file) plus readout and the
+TCP push.  The stamps' fractional part is constant (.553 s) — the laser
+edges are phase-stable at 1 Hz.  So the budget per period is:
+edge → message ≈ 800 ms, fire put ≈ 108 ms, plan work ≈ 7 ms, leaving
+**≈ 85–100 ms** for anything else per shot (a document callback's HTTP
+round trip, the manager's per-message overhead).  In process that holds
+(1 Hz); in the manager's worker process it did not (2 s repeats, M5).
+A shorter exposure buys margin directly; nothing in the plan layer does.
+
+A moved step adds the 1.3 s blocking GEECS set of the magnet, which
+starts phase-locked (after the previous frame) and therefore ends
+phase-locked: previous frame (+0.8 s) → move done (+2.1 s) → fire
+(+2.2 s) → the edge at +2 s is gone, the shot lands at +3 s, every time
+(the 3.001 s gaps).  M2's 2 s per step (2026-09-09) means the same move
+was under ~1 s that day — device-side variation, not the plan.
 
 **Consequence (§11).** The stamp governs the join, the *message arrival*
-governs the wait (§11.4) — and at 1 Hz that arrival leaves ~100 ms to fire
-the next shot.  Strict single-shot cannot sustain 1 Hz with any per-shot
-cost beyond the fire; the native answer is phase 2's gated batch (the
-edges flow, the detector counts), not a faster fire.  Overlapping the
-magnet move with the previous shot's wait would recover the moved step
-(2 s → still not 1 s) — a plan-layer option, not taken here.
+governs the wait (§11.4) — and on this camera the arrival leaves ~100 ms
+of the period.  Strict single-shot cannot sustain 1 Hz with any per-shot
+cost beyond the fire unless the exposure is shortened; the native answer
+for rep-rate is phase 2's gated batch (the edges flow, the detector
+counts), not a faster fire.  Overlapping the magnet move with the
+previous shot's wait would recover the moved step (2 s → still not 1 s)
+— a plan-layer option, not taken here.
 
 ## The worker flip (2026-09-10, prepared; restart pending)
 

--- a/Planning/native_bluesky/05_phase1_acceptance.md
+++ b/Planning/native_bluesky/05_phase1_acceptance.md
@@ -64,7 +64,7 @@ from the configs repo, the bound `count` and `scan`.
 | s-file (`analysis/sNNN.txt` = `ScanDataScanNNN.txt`) | 3 rows, `Bin # = 1,1,1`, headers `UC_Amp4_IR_input MeanCounts` … `acq_timestamp` | 10 rows, `Bin # = 1,1,2,2,…,5,5`, `U_S1H Current` = −0.99984 … 0.99989 |
 | `scan.log` | one `finished (success)` | one `finished (success)`, the five `moving Current →` lines |
 | `baseline` stream | 419 columns, 2 rows | 2 rows |
-| trigger box | ARMED before, STANDBY after (`standing_state`) | same; `save` reads `off` after the run |
+| trigger box | driven back to STANDBY after the run (`ShotControl.standing_state`, the last state *written* — a bookkeeping check; ARMED is observed by the shots landing, not read back) | same; `save` reads `off` after the run |
 | build | 26 s (108 devices, 375 telemetry objects connected; two unservable devices dropped loudly) | |
 
 **Cadence (from the rows' stamps).** Scan104: `[2.0, 1.0]` — 1 Hz after

--- a/Planning/native_bluesky/05_phase1_acceptance.md
+++ b/Planning/native_bluesky/05_phase1_acceptance.md
@@ -153,6 +153,35 @@ counts), not a faster fire.  Overlapping the magnet move with the
 previous shot's wait would recover the moved step (2 s → still not 1 s)
 — a plan-layer option, not taken here.
 
+## M7 — the same runs at a 1 ms exposure (Scans 002 and 003 of 26_0911)
+
+**Purpose.** Test M6's reading: if the ~0.8 s edge-to-message latency is
+the camera's 0.70 s exposure, a short exposure should restore the margin
+and both cadence losses should go.  Sam set `UC_Amp4_IR_input`'s
+exposure to 1 ms (readback 0.001016 s).
+
+**Result.**
+
+| | 0.70 s exposure (M4–M6) | 1 ms exposure (M7) |
+|---|---|---|
+| stamp → RE event (edge-to-message minus the drain) | 0.75 s | **0.05 s** |
+| in-process `count`, stamp gaps | `[2.0, 1.0, 1.0, 1.0, 1.0]` | `[1.0, 1.0, 1.0, 1.0, 1.0]` — 1 Hz from the first shot |
+| per-shot phases (fire put / frame wait) | 108 / 886 ms | 140–228 / 766–781 ms |
+| preset through the manager, `scan` 5 × 2 | `[2.0, 3.0, 2.0, 3.0, …]` | `[1.0, 2.0, 1.0, 2.0, 1.0, 2.0, 1.0, 2.0, 1.0]` |
+| moved step | third edge (3 s) | **second edge (2 s)**; step period 3 s |
+
+The plan layer did not change between the two.  The repeat shot through
+the manager's worker process is back at 1 Hz (the ~650 ms of margin now
+covers its per-message overhead), and a moved step lands on the second
+edge, as the 1.3 s move alone dictates.  The fire put itself read
+140–230 ms this time (108 ms in M6) — the gateway put's own variance,
+inside the margin either way.  Files, ScanInfo, s-file bins and the
+restore all as in M5 (`1 passed in 31 s`).
+
+**So (§11):** the per-shot budget at 1 Hz is the camera's exposure +
+readout + push, the fire put, and whatever runs per event; the plan
+layer's own ~7 ms is noise.  A long exposure eats the period directly.
+
 ## The worker flip (2026-09-10, prepared; restart pending)
 
 What the flip is: `~/qs-checkout` (the deployed worker's clone, shared

--- a/Planning/native_bluesky/05_phase1_acceptance.md
+++ b/Planning/native_bluesky/05_phase1_acceptance.md
@@ -90,6 +90,10 @@ after.
 **Cadence.** Scan106: `[2.0, 3.0, 2.0, 3.0, 2.0, 3.0, 2.0, 3.0, 2.0]` —
 through the manager the repeat shot lost an edge too (see M6).
 
+Re-run after the #822 review (the restore path now waits for the
+manager to go idle and retries): Scan001 of 26_0911, `1 passed in 35 s`,
+restore queued and ran, setpoint 0.0.
+
 **Two lessons from the first run.** (1) A status poll right after
 `queue_start` still reads idle — "done" is the item reaching the
 manager's history (`_wait_for_item`). (2) The restore `mv` submitted


### PR DESCRIPTION
Phase 1 PR 3 of the native-Bluesky rebuild (#807; plan of record `Planning/native_bluesky/03_clean_room_rebuild.md` §8, §10.8). Base: `feature/native-bluesky-plans` (after #821).

## What

**Headless hardware acceptance of the plan layer on HTU, done.** `GeecsBluesky/tests/test_phase1_hardware.py` (`GEECS_HW=1`, fires shots; skips otherwise):

1. **In process** — the worker's own wiring (`make_run_engine(claim=True, path_provider, telemetry=namespace.telemetry())`, the namespace on the shared `GeecsScanPathProvider`, `TriggerProfiles` from the configs repo, the bound plans) runs a strict `count` (3 shots) and a strict `scan` of `U_S1H:Current` −1 → +1 A in 5 points × 2 shots, and asserts every GEECS output from disk: the claimed folder, the camera's native PNGs named by the rows' stamps in `ScanNNN/UC_Amp4_IR_input/`, `ScanInfoScanNNN.ini` (the keys downstream parses), the s-file with `Bin #` per step, `scan.log`, the `baseline` stream (419 columns, 2 rows per run), ARMED → STANDBY, setpoint restored. **Scans 104 and 105 of 26_0910, `1 passed in 72 s`.**
2. **Through the RE Manager** — a second manager on the host (own ports, own Redis prefix, document publisher off; runbook in `05_phase1_acceptance.md`): a `Preset` → `run_submit_preflight` (`validate`, `worker_ready` incl. the device tree, `gateway_liveness` all passed) → `submit_preset` → the history item `completed` → the same files. **Scan 108 (and 106 on the first run), `1 passed in 39 s`.**

`Planning/native_bluesky/05_phase1_acceptance.md` carries the runbook, the M4–M6 records and the flip record; §2/§8/§10.8 of the plan of record updated; GeecsBluesky 0.80.1 (test + docs).

## What the shots measured (M6, `05_phase1_acceptance.md`)

Per shot on this camera at 1 Hz: fire put ~108 ms, frame message ~886 ms after it, plan-layer work between frame arrival and the next fire ~7 ms — about **100 ms of margin** for anything else per shot. In process a `count` holds 1 Hz (`[2.0, 1.0, 1.0, 1.0, 1.0]`); through the manager's worker process the repeat shot lost an edge (2 s). A 0.5 A `U_S1H` move is a **1.3 s blocking set**, so a moved step lands on the third edge (`3.0 s`; M2 saw the second — a faster move that day). Conclusion recorded in §10.8: strict single-shot is not the 1 Hz mode, phase 2's gated batch is; the "cadence fix" is scoped accordingly.

## The worker flip — prepared, one command owed to the maintainer

Done as the service account on the host: the acceptance manager stopped; `~/qs-checkout` (the deployed worker's clone) checked out on `feature/native-bluesky-plans` at the #821 merge, `poetry install --extras "ca tiled qserver"` clean (optimize extra left in place), the plan layer importable in the production env. **The running `geecs-qserver` still holds master's code**: restarting the unit needs sudo, which the service account cannot do non-interactively.

```bash
sudo systemctl restart geecs-qserver                 # pulls geecs-qserver-ready along
journalctl -u geecs-qserver-ready -n 3 --no-pager    # expect "ready: 19 allowed plans, all 19 expected present"
sudo systemctl restart geecs-capture                 # optional: same clone's code
```

After that the deployed worker runs stock plans over presets; the master Console and MCP can no longer submit until their rewire (their preflight refuses first) — the accepted state of §10.5. The clients' configs stay on the share's `main`; the worker reads no presets, so `presets-v1` merges with the client rewire.

## Two lessons from the first manager run (fixed in the test)

- A status poll right after `queue_start` still reads idle — "done" is the item reaching the manager's history (`_wait_for_item`).
- The restore `mv` submitted while the scan item was still queued was refused by the #648 front-of-queue guard and left `U_S1H` at 1 A until I restored it by hand; the test now awaits its own item and restores with `clear_pending=True`. Nothing else was touched: every run restored the setpoint (0.0 A now).

## Tests

- GeecsBluesky: **386 passed**, 2 skipped (the two hardware modules), 1 deselected (52 s).
- Hardware: the two acceptance tests above, on the host.

## LOC

| Concern | Files | LOC |
|---|---|---|
| the acceptance test | 1 | +365 |
| `05_phase1_acceptance.md` + §2/§8/§10.8 + CLAUDE.md/README/CHANGELOG/version | 6 | ~+220 / −20 |

## Facility literals

`Undulator`, `UC_Amp4_IR_input`, `HTU-NoGas`, `U_S1H:Current` are the test's defaults, overridable by `GEECS_HW_*` environment (the same shape as `test_phase0_hardware.py`); host paths in the runbook are the service account's `~` and the site's share path in a docs example.
