### PR TITLE
Phase 04: the editor — GeecsLogbook 0.4.0

### DIFF
--- a/GeecsLogbook/CHANGELOG.md
+++ b/GeecsLogbook/CHANGELOG.md
@@ -28,7 +28,35 @@ The editor: what makes people use it.
 
 - The day page's inline write-path script is gone; the page hands the
   editor its facts through `<main id="logbook" data-api data-day
-  data-book>` and loads `editor.js`.
+  data-book data-accept>` and loads `editor.js`.
+
+### Fixed (review of #837)
+
+- An uploaded image link was left selected, so the next keystroke — or
+  the second file of a multi-file drop — replaced it. Attachment links
+  now insert with the caret after them; only the table and callout
+  skeletons stay selected for overtyping.
+- Duplicate entries from a held ⌘↵ (key repeat), a double submit, or two
+  quick pastes on a new composer: one create per form (the pending POST
+  is shared), key-repeat ignored, Save/Discard exclusive with the buttons
+  disabled meanwhile.
+- The version is re-read after uploads even when a later file in the
+  batch failed, and written back to the article for an in-place edit so
+  Cancel-then-Edit does not start stale.
+- Attaching before entering a name no longer creates an entry attributed
+  to "unknown" forever: the name is required first.
+- Paste precedence: an HTML table on the clipboard wins over a bitmap of
+  the same cells (Excel); a file pasted alongside text keeps the text and
+  uploads the file.
+- Tab-indented prose is not turned into a table (consistent column count
+  and a non-empty header cell are required); list/task prefixing at the
+  start of the text and on a triple-clicked line; a failed preview leaves
+  nothing visible; a dropped file of a type the server does not take says
+  so instead of vanishing. Accepted types come from the page
+  (`data-accept`), one list not two. The theme guard walks `editor.js`.
+- Between-scan blocks collapse as well as expand (owner's hand-test):
+  they are `<details>` like the scans, with a count in the header, and
+  Expand all / Collapse all reaches them.
 
 ## [0.3.0] - 2026-09-11
 

--- a/GeecsLogbook/CHANGELOG.md
+++ b/GeecsLogbook/CHANGELOG.md
@@ -4,6 +4,32 @@ All notable changes to `geecs-logbook` are documented here. The format
 follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and this
 project adheres to semantic versioning.
 
+## [0.4.0] - 2026-09-11
+
+The editor: what makes people use it.
+
+### Added
+
+- `static/editor.js`, one implementation for every composer on the page
+  (per scan, per gap, the day, and in-place edits): a toolbar that writes
+  markdown around the selection (bold, italic, code, list, task list,
+  link, table, callout, image, preview); **paste or drop a screenshot**
+  into the composer — the file goes to the upload endpoint and a relative
+  image link lands at the cursor; a brand-new entry is saved first so the
+  upload has somewhere to go ("autosaved"), with Discard to delete the
+  stub; **paste a spreadsheet range** (tab-separated or an HTML table) as a
+  markdown table; a server-rendered Preview; ⌘/Ctrl+Enter saves.
+- `POST /api/preview` — the page's renderer, for the composer.
+- Two or more consecutive images render as one grid (`figgrid`): the
+  plot table, replacing LogMaker's `gdoc_slot` numbering — no slot
+  assignment, no ceiling at four.
+
+### Changed
+
+- The day page's inline write-path script is gone; the page hands the
+  editor its facts through `<main id="logbook" data-api data-day
+  data-book>` and loads `editor.js`.
+
 ## [0.3.0] - 2026-09-11
 
 The foundation for the operations book. Owner rulings 2026-09-11.

--- a/GeecsLogbook/CLAUDE.md
+++ b/GeecsLogbook/CLAUDE.md
@@ -153,7 +153,11 @@ stays the plain text the mirror holds. The two things people actually
 need — paste a screenshot, paste a spreadsheet — are events on the
 textarea: a pasted or dropped file goes to the upload endpoint and its
 relative link lands at the cursor; a tab-separated or HTML-table paste
-becomes a markdown table. A brand-new entry has no id until saved, so
+becomes a markdown table (a text-only paste must have a consistent
+column count and a non-empty first header cell — tab-indented prose is
+not a table, and a cross-tab with a blank corner from a text-only source
+is pasted as text; spreadsheet apps supply the HTML form, which has no
+such rule). A brand-new entry has no id until saved, so
 the first attachment saves it first ("autosaved", with Discard); Save is
 then an edit. The page hands the script its facts through
 `<main id="logbook" data-api data-day data-book>`; nothing is templated

--- a/GeecsLogbook/CLAUDE.md
+++ b/GeecsLogbook/CLAUDE.md
@@ -141,7 +141,23 @@ package. Rules the store enforces, each pinned in `tests/test_store.py`:
   `ALTER TABLE` with a fill expression. Nothing else, deliberately.
 
 `body_md` is opaque: `render.render_markdown` (markdown-it + nh3) is the
-only thing that reads it, and only to draw it.
+only thing that reads it, and only to draw it — plus the tag scan.
+
+## The editor
+
+`static/editor.js` is the whole write path in the browser, one
+implementation for every composer (per scan, per gap, the day, in-place
+edits, and the month page next). It is deliberately **not** a WYSIWYG
+editor: the toolbar writes markdown around the selection and the body
+stays the plain text the mirror holds. The two things people actually
+need — paste a screenshot, paste a spreadsheet — are events on the
+textarea: a pasted or dropped file goes to the upload endpoint and its
+relative link lands at the cursor; a tab-separated or HTML-table paste
+becomes a markdown table. A brand-new entry has no id until saved, so
+the first attachment saves it first ("autosaved", with Discard); Save is
+then an edit. The page hands the script its facts through
+`<main id="logbook" data-api data-day data-book>`; nothing is templated
+into the script. It sets no colours (the theme guard's rule).
 
 ## Status is reported, not inferred
 

--- a/GeecsLogbook/geecs_logbook/render.py
+++ b/GeecsLogbook/geecs_logbook/render.py
@@ -60,6 +60,13 @@ _CALLOUT = re.compile(
 #: Attachment references as the store writes them.
 _ATTACHMENT_REF = re.compile(r'(src|href)="attachments/')
 
+#: Two or more images in a row, each its own paragraph — what a run of
+#: pasted screenshots or published figures renders as. They become one
+#: grid, the plot-table LogMaker's ``gdoc_slot`` numbering used to fake:
+#: no slot assignment, no ceiling at four, no collisions.
+_IMAGE_RUN = re.compile(r"(?:<p>\s*<img\b[^>]*>\s*</p>\s*){2,}")
+_IMAGE = re.compile(r"<img\b[^>]*>")
+
 
 def render_markdown(body_md: str, *, attachment_base: str | None = None) -> str:
     """Render an entry body to safe HTML.
@@ -84,10 +91,23 @@ def render_markdown(body_md: str, *, attachment_base: str | None = None) -> str:
         rendered, tags=_TAGS, attributes=_ATTRIBUTES, link_rel="noopener noreferrer"
     )
     clean = _callouts(clean)
+    clean = _image_grids(clean)
     if attachment_base:
         base = attachment_base.rstrip("/")
         clean = _ATTACHMENT_REF.sub(rf'\1="{html.escape(base)}/', clean)
     return clean
+
+
+def _image_grids(fragment: str) -> str:
+    """Gather consecutive image paragraphs into a ``figgrid``."""
+
+    def swap(match: re.Match[str]) -> str:
+        imgs = "".join(
+            f"<figure>{img}</figure>" for img in _IMAGE.findall(match.group(0))
+        )
+        return f'<div class="figgrid">{imgs}</div>'
+
+    return _IMAGE_RUN.sub(swap, fragment)
 
 
 def _callouts(fragment: str) -> str:

--- a/GeecsLogbook/geecs_logbook/routes/day.py
+++ b/GeecsLogbook/geecs_logbook/routes/day.py
@@ -19,6 +19,7 @@ from geecs_schemas.log_entry import Book, LogEntry
 
 from geecs_logbook.models import DaySummary
 from geecs_logbook.render import render_markdown
+from geecs_logbook.routes.attachments import ATTACHMENT_TYPES
 from geecs_logbook.routes._common import (
     STATIC_DIR,
     Context,
@@ -87,6 +88,7 @@ def register(router: APIRouter, ctx: Context) -> None:
                 "entry_count": sum(len(v) for v in entries.values()),
                 "writable": ctx.writable,
                 "api_base": api_base(request),
+                "accept": ",".join(sorted(ATTACHMENT_TYPES)),
             },
         )
 

--- a/GeecsLogbook/geecs_logbook/routes/entries.py
+++ b/GeecsLogbook/geecs_logbook/routes/entries.py
@@ -15,11 +15,9 @@ from __future__ import annotations
 
 from typing import Optional
 
-from fastapi import APIRouter, HTTPException, Response
+from fastapi import APIRouter, HTTPException, Request, Response
 from geecs_schemas.log_entry import Book, EntryKind, EntryStatus, LogEntry
 from pydantic import BaseModel, Field
-
-from fastapi import Request
 
 from geecs_logbook.render import render_markdown
 from geecs_logbook.routes._common import Context, attachment_base
@@ -70,10 +68,6 @@ class PreviewRequest(BaseModel):
     """A body to render as the page would, before it is saved."""
 
     body_md: str = Field(max_length=200_000)
-    entry_id: Optional[str] = Field(
-        None,
-        description="Unused for now; attachment links resolve the same way for every entry.",
-    )
 
 
 class HistoryItem(BaseModel):

--- a/GeecsLogbook/geecs_logbook/routes/entries.py
+++ b/GeecsLogbook/geecs_logbook/routes/entries.py
@@ -19,7 +19,10 @@ from fastapi import APIRouter, HTTPException, Response
 from geecs_schemas.log_entry import Book, EntryKind, EntryStatus, LogEntry
 from pydantic import BaseModel, Field
 
-from geecs_logbook.routes._common import Context
+from fastapi import Request
+
+from geecs_logbook.render import render_markdown
+from geecs_logbook.routes._common import Context, attachment_base
 from geecs_logbook.store import ConflictError
 
 
@@ -63,6 +66,16 @@ class StatusUpdate(BaseModel):
     status: EntryStatus
 
 
+class PreviewRequest(BaseModel):
+    """A body to render as the page would, before it is saved."""
+
+    body_md: str = Field(max_length=200_000)
+    entry_id: Optional[str] = Field(
+        None,
+        description="Unused for now; attachment links resolve the same way for every entry.",
+    )
+
+
 class HistoryItem(BaseModel):
     """One earlier state, as served."""
 
@@ -76,6 +89,15 @@ def register(router: APIRouter, ctx: Context) -> None:
     """Add the entry routes to ``router``. Requires a store."""
     store = ctx.store
     assert store is not None
+
+    @router.post("/api/preview")
+    def _preview(request: Request, body: PreviewRequest) -> dict:
+        """Render a body as the page will, for the composer's preview."""
+        return {
+            "html": render_markdown(
+                body.body_md, attachment_base=attachment_base(request)
+            )
+        }
 
     @router.post("/api/entries", status_code=201)
     def _create(body: EntryCreate) -> LogEntry:

--- a/GeecsLogbook/geecs_logbook/static/editor.js
+++ b/GeecsLogbook/geecs_logbook/static/editor.js
@@ -1,0 +1,352 @@
+/* GeecsLogbook editor — everything a composer does, for every composer.
+ *
+ * One implementation serves the day page's per-scan, per-gap and day
+ * composers, the in-place edit form, and (next) the month page. The page
+ * hands it two facts through <main id="logbook" data-api data-day
+ * data-book>; nothing else is templated into this file.
+ *
+ * What it adds over a bare textarea:
+ *   - a toolbar that writes markdown around the selection (no WYSIWYG —
+ *     the body stays plain text the mirror can hold);
+ *   - paste or drop a screenshot: the file goes to the upload endpoint and
+ *     a relative image link lands at the cursor. A NEW entry has no id
+ *     until it is saved, so the first attachment saves it first (an
+ *     "autosave") and the Save button then edits it; Discard deletes the
+ *     stub;
+ *   - paste a spreadsheet range (tab-separated, or an HTML table): it
+ *     becomes a markdown table;
+ *   - Preview, rendered by the server exactly as the page will show it;
+ *   - ⌘/Ctrl+Enter saves.
+ *
+ * Styling is entirely through the page's tokens; this file sets no colours.
+ */
+(function () {
+  "use strict";
+
+  const host = document.getElementById("logbook");
+  if (!host) return;
+  const API = host.dataset.api;
+  const DAY = host.dataset.day;
+  const BOOK = host.dataset.book || "scans";
+  const AUTHOR_KEY = "geecs.author";
+
+  // ------------------------------------------------------------ plumbing
+
+  const who = () => { try { return localStorage.getItem(AUTHOR_KEY) || ""; } catch (e) { return ""; } };
+  const remember = (name) => { try { localStorage.setItem(AUTHOR_KEY, name); } catch (e) { /* private window */ } };
+
+  async function api(method, path, body) {
+    const res = await fetch(API + path, {
+      method,
+      headers: body ? { "Content-Type": "application/json" } : {},
+      body: body ? JSON.stringify(body) : undefined,
+    });
+    if (res.status === 204) return null;
+    const data = await res.json().catch(() => ({}));
+    const d = data.detail;
+    const text = Array.isArray(d) ? d.map((x) => x.msg || JSON.stringify(x)).join("; ")
+      : (d && d.message) || d || res.statusText;
+    if (!res.ok) throw Object.assign(new Error(text), { status: res.status, data });
+    return data;
+  }
+
+  function fail(el, err) {
+    let msg = el.querySelector(".errmsg");
+    if (!msg) { msg = document.createElement("div"); msg.className = "errmsg"; el.appendChild(msg); }
+    msg.textContent = err.status === 409
+      ? "Someone else saved this first. Reload to see their version, then re-apply your change."
+      : (err.message || "Could not save.");
+  }
+  function clearFail(el) { const m = el.querySelector(".errmsg"); if (m) m.remove(); }
+
+  // ------------------------------------------------------ text helpers
+
+  function replaceSelection(ta, text, selectFrom, selectTo) {
+    const s = ta.selectionStart, e = ta.selectionEnd;
+    ta.setRangeText(text, s, e, "end");
+    if (selectFrom !== undefined) ta.setSelectionRange(s + selectFrom, s + selectTo);
+    ta.focus();
+    ta.dispatchEvent(new Event("input", { bubbles: true }));
+  }
+
+  /** Surround the selection (or a placeholder) with before/after. */
+  function wrap(ta, before, after, placeholder) {
+    const s = ta.selectionStart, e = ta.selectionEnd;
+    const inner = s === e ? placeholder : ta.value.slice(s, e);
+    replaceSelection(ta, before + inner + after, before.length, before.length + inner.length);
+  }
+
+  /** Prefix every selected line (or the current one). */
+  function prefixLines(ta, prefix) {
+    const s = ta.selectionStart, e = ta.selectionEnd;
+    const lineStart = ta.value.lastIndexOf("\n", s - 1) + 1;
+    let lineEnd = ta.value.indexOf("\n", e);
+    if (lineEnd === -1) lineEnd = ta.value.length;
+    const block = ta.value.slice(lineStart, lineEnd);
+    const done = block.split("\n").map((l) => (l.startsWith(prefix) ? l : prefix + l)).join("\n");
+    ta.setRangeText(done, lineStart, lineEnd, "select");
+    ta.focus();
+    ta.dispatchEvent(new Event("input", { bubbles: true }));
+  }
+
+  /** Insert a block on its own lines at the cursor. */
+  function insertBlock(ta, text) {
+    const s = ta.selectionStart;
+    const before = ta.value.slice(0, s);
+    const lead = before.length === 0 || before.endsWith("\n\n") ? "" : before.endsWith("\n") ? "\n" : "\n\n";
+    replaceSelection(ta, lead + text + "\n", lead.length, lead.length + text.length);
+  }
+
+  // ------------------------------------------------------- tables
+
+  const cell = (v) => String(v).replace(/\|/g, "\\|").replace(/\s+/g, " ").trim();
+
+  function rowsToMarkdown(rows) {
+    const width = Math.max(...rows.map((r) => r.length));
+    const pad = (r) => Array.from({ length: width }, (_, i) => cell(r[i] === undefined ? "" : r[i]));
+    const [head, ...body] = rows.map(pad);
+    const line = (r) => "| " + r.join(" | ") + " |";
+    return [line(head), "|" + head.map(() => "---|").join(""), ...body.map(line)].join("\n");
+  }
+
+  /** A tab-separated block with two or more lines is a spreadsheet range. */
+  function tsvToRows(text) {
+    const lines = text.replace(/\r/g, "").split("\n").filter((l) => l.trim() !== "");
+    if (lines.length < 2 || !lines.every((l) => l.includes("\t"))) return null;
+    return lines.map((l) => l.split("\t"));
+  }
+
+  /** Excel/Sheets put an HTML table on the clipboard too; prefer it when present. */
+  function htmlTableToRows(html) {
+    const doc = new DOMParser().parseFromString(html, "text/html");
+    const table = doc.querySelector("table");
+    if (!table) return null;
+    const rows = [...table.querySelectorAll("tr")].map((tr) =>
+      [...tr.querySelectorAll("th,td")].map((td) => td.textContent));
+    return rows.length >= 2 ? rows : null;
+  }
+
+  // ----------------------------------------------------- attachments
+
+  const IMAGE_TYPES = ["image/png", "image/jpeg", "image/gif", "image/webp", "application/pdf"];
+
+  /** The entry this form edits, creating it first if it is brand new. */
+  async function ensureEntry(form) {
+    if (form.dataset.entry) return form.dataset.entry;
+    const ta = form.querySelector(".ta");
+    const name = form.querySelector(".who").value.trim() || who() || "unknown";
+    const body = { day: DAY, book: BOOK, author: name, body_md: ta.value || "" };
+    if (form.dataset.after !== undefined && form.dataset.after !== "") body.after = Number(form.dataset.after);
+    else if (form.dataset.scan !== undefined && form.dataset.scan !== "") body.scan = Number(form.dataset.scan);
+    const entry = await api("POST", "/entries", body);
+    form.dataset.entry = entry.entry_id;
+    form.dataset.version = String(entry.version);
+    form.classList.add("autosaved");
+    const discard = form.querySelector("[data-discard]");
+    if (discard) discard.hidden = false;
+    return entry.entry_id;
+  }
+
+  async function uploadFiles(form, files) {
+    const ta = form.querySelector(".ta");
+    const list = [...files].filter((f) => IMAGE_TYPES.includes(f.type));
+    if (!list.length) return;
+    clearFail(form);
+    form.classList.add("busy");
+    try {
+      const id = await ensureEntry(form);
+      for (const file of list) {
+        const fd = new FormData();
+        fd.append("file", file, file.name || "image.png");
+        const res = await fetch(`${API}/entries/${id}/attachments`, { method: "POST", body: fd });
+        const data = await res.json().catch(() => ({}));
+        if (!res.ok) throw Object.assign(new Error((data.detail && data.detail.message) || data.detail || res.statusText), { status: res.status });
+        const alt = (file.name || "image").replace(/\.[^.]+$/, "");
+        const md = file.type === "application/pdf" ? `[${alt}](${data.link})` : `![${alt}](${data.link})`;
+        insertBlock(ta, md);
+      }
+      // Uploads bump the version; the eventual Save must carry the current one.
+      const fresh = await api("GET", `/entries/${id}`);
+      form.dataset.version = String(fresh.version);
+    } catch (err) {
+      fail(form, err);
+    } finally {
+      form.classList.remove("busy");
+    }
+  }
+
+  // --------------------------------------------------------- preview
+
+  async function togglePreview(form) {
+    const ta = form.querySelector(".ta");
+    let pane = form.querySelector(".preview");
+    const btn = form.querySelector("[data-tool=preview]");
+    if (pane && !pane.hidden) { pane.hidden = true; ta.hidden = false; btn.classList.remove("is-on"); return; }
+    if (!pane) { pane = document.createElement("div"); pane.className = "entry-body preview"; ta.after(pane); }
+    try {
+      const data = await api("POST", "/preview", { body_md: ta.value, entry_id: form.dataset.entry || null });
+      pane.innerHTML = data.html;
+      pane.hidden = false; ta.hidden = true; btn.classList.add("is-on");
+    } catch (err) { fail(form, err); }
+  }
+
+  // --------------------------------------------------------- toolbar
+
+  const TOOLS = [
+    { key: "bold", label: "B", title: "Bold", run: (ta) => wrap(ta, "**", "**", "bold") },
+    { key: "italic", label: "I", title: "Italic", run: (ta) => wrap(ta, "_", "_", "italic") },
+    { key: "code", label: "</>", title: "Code", run: (ta) => wrap(ta, "`", "`", "code") },
+    { key: "list", label: "• list", title: "Bulleted list", run: (ta) => prefixLines(ta, "- ") },
+    { key: "task", label: "☐ task", title: "Task list", run: (ta) => prefixLines(ta, "- [ ] ") },
+    { key: "link", label: "link", title: "Link", run: (ta) => wrap(ta, "[", "](https://)", "text") },
+    { key: "table", label: "table", title: "Table (or paste a spreadsheet range)",
+      run: (ta) => insertBlock(ta, rowsToMarkdown([["Parameter", "Value", "Note"], ["", "", ""]])) },
+    { key: "callout", label: "callout", title: "Callout — NOTE, TIP, WARNING or CAUTION",
+      run: (ta) => insertBlock(ta, "> [!NOTE]\n> ") },
+    { key: "image", label: "image", title: "Attach an image or PDF (or paste / drop one)", run: null },
+    { key: "preview", label: "preview", title: "Show it as the page will", run: null },
+  ];
+
+  function buildToolbar(form) {
+    if (form.querySelector(".toolbar")) return;
+    const ta = form.querySelector(".ta");
+    const bar = document.createElement("div");
+    bar.className = "toolbar";
+    bar.setAttribute("role", "toolbar");
+    for (const t of TOOLS) {
+      const b = document.createElement("button");
+      b.type = "button"; b.className = "tool"; b.dataset.tool = t.key; b.title = t.title; b.textContent = t.label;
+      if (t.key === "bold") b.classList.add("tool-b");
+      if (t.key === "italic") b.classList.add("tool-i");
+      bar.appendChild(b);
+    }
+    const picker = document.createElement("input");
+    picker.type = "file"; picker.accept = IMAGE_TYPES.join(","); picker.multiple = true; picker.hidden = true;
+    picker.addEventListener("change", () => { uploadFiles(form, picker.files); picker.value = ""; });
+    bar.appendChild(picker);
+    bar.addEventListener("click", (ev) => {
+      const b = ev.target.closest("button.tool"); if (!b) return;
+      const tool = TOOLS.find((t) => t.key === b.dataset.tool);
+      if (tool.key === "image") picker.click();
+      else if (tool.key === "preview") togglePreview(form);
+      else tool.run(ta);
+    });
+    ta.before(bar);
+  }
+
+  // ---------------------------------------------------- paste & drop
+
+  function onPaste(form, ev) {
+    const cd = ev.clipboardData; if (!cd) return;
+    const files = [...cd.items].filter((i) => i.kind === "file").map((i) => i.getAsFile()).filter(Boolean);
+    if (files.length) { ev.preventDefault(); uploadFiles(form, files); return; }
+    const html = cd.getData("text/html");
+    const text = cd.getData("text/plain");
+    const rows = (html && htmlTableToRows(html)) || (text && tsvToRows(text));
+    if (rows) { ev.preventDefault(); insertBlock(form.querySelector(".ta"), rowsToMarkdown(rows)); }
+  }
+
+  function onDrop(form, ev) {
+    if (!ev.dataTransfer || !ev.dataTransfer.files.length) return;
+    ev.preventDefault(); form.classList.remove("dragover");
+    uploadFiles(form, ev.dataTransfer.files);
+  }
+
+  // ------------------------------------------------------------ save
+
+  async function save(form) {
+    const ta = form.querySelector(".ta");
+    const name = form.querySelector(".who").value.trim();
+    if (!name) { form.querySelector(".who").focus(); return; }
+    remember(name);
+    clearFail(form);
+    try {
+      if (form.dataset.entry) {
+        await api("PATCH", `/entries/${form.dataset.entry}`, {
+          body_md: ta.value, editor: name, expected_version: Number(form.dataset.version) });
+      } else {
+        if (!ta.value.trim()) return;
+        await ensureEntry(form);
+      }
+      location.reload();
+    } catch (err) { fail(form, err); }
+  }
+
+  async function discard(form) {
+    if (!form.dataset.entry) return;
+    try { await api("DELETE", `/entries/${form.dataset.entry}`); location.reload(); }
+    catch (err) { fail(form, err); }
+  }
+
+  // ----------------------------------------------------------- mount
+
+  function mount(form) {
+    if (form.dataset.mounted) return;
+    form.dataset.mounted = "1";
+    const ta = form.querySelector(".ta");
+    const whoInput = form.querySelector(".who");
+    if (whoInput && !whoInput.value) whoInput.value = who();
+    buildToolbar(form);
+    if (!form.classList.contains("editing") && !form.querySelector("[data-discard]")) {
+      const d = document.createElement("button");
+      d.type = "button"; d.className = "btn btn-sm"; d.dataset.discard = "1"; d.hidden = true; d.textContent = "Discard";
+      d.title = "This entry was saved when you attached a file; discard deletes it";
+      form.querySelector(".editor-bar").appendChild(d);
+      d.addEventListener("click", () => discard(form));
+    }
+    ta.addEventListener("paste", (ev) => onPaste(form, ev));
+    form.addEventListener("dragover", (ev) => { ev.preventDefault(); form.classList.add("dragover"); });
+    form.addEventListener("dragleave", () => form.classList.remove("dragover"));
+    form.addEventListener("drop", (ev) => onDrop(form, ev));
+    form.addEventListener("submit", (ev) => { ev.preventDefault(); save(form); });
+    ta.addEventListener("keydown", (ev) => {
+      if ((ev.metaKey || ev.ctrlKey) && ev.key === "Enter") { ev.preventDefault(); save(form); }
+    });
+  }
+
+  document.querySelectorAll("form.composer").forEach(mount);
+
+  // ------------------------------------------ entry buttons on the page
+
+  document.addEventListener("click", async (ev) => {
+    const b = ev.target.closest("button"); if (!b) return;
+    if (b.closest("[data-insert]")) {
+      const after = b.closest("[data-insert]").dataset.insert;
+      const hostEl = document.querySelector(`[data-between-host="${after}"]`);
+      if (hostEl) { hostEl.hidden = false; b.closest("[data-insert]").hidden = true; const ta = hostEl.querySelector(".ta"); if (ta) ta.focus(); }
+      return;
+    }
+    if (b.dataset.keep) {
+      try { await api("POST", `/entries/${b.dataset.keep}/status`, { status: "kept" }); location.reload(); }
+      catch (err) { fail(b.closest(".entry-main"), err); }
+      return;
+    }
+    if (b.dataset.del) {
+      if (b.dataset.armed !== "1") { b.dataset.armed = "1"; b.textContent = "Really delete"; return; }
+      try { await api("DELETE", `/entries/${b.dataset.del}`); location.reload(); }
+      catch (err) { fail(b.closest(".entry-main"), err); }
+      return;
+    }
+    if (b.dataset.edit) {
+      const art = document.getElementById("entry-" + b.dataset.edit);
+      const main = art.querySelector(".entry-main");
+      const raw = JSON.parse(art.querySelector(".raw").textContent);
+      const bodyEl = main.querySelector(".entry-body");
+      if (main.querySelector("form.editing")) return;
+      const form = document.createElement("form");
+      form.className = "composer editing";
+      form.dataset.entry = art.dataset.entry;
+      form.dataset.version = art.dataset.version;
+      form.innerHTML = `<div class="entry-main"><textarea class="ta" rows="8"></textarea>
+        <div class="editor-bar"><input class="who" placeholder="Your name" required aria-label="Your name">
+        <button class="btn btn-sm btn-primary" type="submit">Save</button>
+        <button class="btn btn-sm" type="button" data-cancel="1">Cancel</button>
+        <span class="editor-hint">&#8984;&#8629; saves</span></div></div>`;
+      form.querySelector(".ta").value = raw;
+      bodyEl.hidden = true; bodyEl.after(form);
+      mount(form);
+      form.querySelector(".ta").focus();
+      form.querySelector("[data-cancel]").addEventListener("click", () => { form.remove(); bodyEl.hidden = false; });
+    }
+  });
+})();

--- a/GeecsLogbook/geecs_logbook/static/editor.js
+++ b/GeecsLogbook/geecs_logbook/static/editor.js
@@ -28,6 +28,7 @@
   const API = host.dataset.api;
   const DAY = host.dataset.day;
   const BOOK = host.dataset.book || "scans";
+  const ACCEPT = (host.dataset.accept || "image/png,image/jpeg,image/gif,image/webp,application/pdf").split(",");
   const AUTHOR_KEY = "geecs.author";
 
   // ------------------------------------------------------------ plumbing
@@ -78,10 +79,14 @@
 
   /** Prefix every selected line (or the current one). */
   function prefixLines(ta, prefix) {
-    const s = ta.selectionStart, e = ta.selectionEnd;
-    const lineStart = ta.value.lastIndexOf("\n", s - 1) + 1;
+    const s = ta.selectionStart;
+    // A selection that ends just after a newline (a triple-clicked line)
+    // does not reach into the next line.
+    const e = ta.selectionEnd > s && ta.value[ta.selectionEnd - 1] === "\n" ? ta.selectionEnd - 1 : ta.selectionEnd;
+    const lineStart = s === 0 ? 0 : ta.value.lastIndexOf("\n", s - 1) + 1;
     let lineEnd = ta.value.indexOf("\n", e);
     if (lineEnd === -1) lineEnd = ta.value.length;
+    if (lineEnd < lineStart) lineEnd = lineStart;
     const block = ta.value.slice(lineStart, lineEnd);
     const done = block.split("\n").map((l) => (l.startsWith(prefix) ? l : prefix + l)).join("\n");
     ta.setRangeText(done, lineStart, lineEnd, "select");
@@ -89,12 +94,18 @@
     ta.dispatchEvent(new Event("input", { bubbles: true }));
   }
 
-  /** Insert a block on its own lines at the cursor. */
-  function insertBlock(ta, text) {
+  /** Insert a block on its own lines at the cursor.
+   *
+   * ``select`` leaves the block selected — right for a skeleton the author
+   * will overtype (a table, a callout), wrong for an attachment link, which
+   * the next keystroke or the next upload would otherwise replace.
+   */
+  function insertBlock(ta, text, select) {
     const s = ta.selectionStart;
     const before = ta.value.slice(0, s);
     const lead = before.length === 0 || before.endsWith("\n\n") ? "" : before.endsWith("\n") ? "\n" : "\n\n";
-    replaceSelection(ta, lead + text + "\n", lead.length, lead.length + text.length);
+    if (select) replaceSelection(ta, lead + text + "\n", lead.length, lead.length + text.length);
+    else replaceSelection(ta, lead + text + "\n");
   }
 
   // ------------------------------------------------------- tables
@@ -113,7 +124,12 @@
   function tsvToRows(text) {
     const lines = text.replace(/\r/g, "").split("\n").filter((l) => l.trim() !== "");
     if (lines.length < 2 || !lines.every((l) => l.includes("\t"))) return null;
-    return lines.map((l) => l.split("\t"));
+    const rows = lines.map((l) => l.split("\t"));
+    // Tab-indented prose is not a spreadsheet: every row has the same
+    // number of columns (2+) and the first cell of the header is not empty.
+    const width = rows[0].length;
+    if (width < 2 || rows[0][0].trim() === "" || !rows.every((r) => r.length === width)) return null;
+    return rows;
   }
 
   /** Excel/Sheets put an HTML table on the clipboard too; prefer it when present. */
@@ -128,33 +144,64 @@
 
   // ----------------------------------------------------- attachments
 
-  const IMAGE_TYPES = ["image/png", "image/jpeg", "image/gif", "image/webp", "application/pdf"];
+  /** The author's name from the form, or null (with the field focused). */
+  function authorName(form) {
+    const input = form.querySelector(".who");
+    const name = input.value.trim();
+    if (name) { remember(name); return name; }
+    input.focus();
+    fail(form, { message: "Enter your name first." });
+    return null;
+  }
 
-  /** The entry this form edits, creating it first if it is brand new. */
-  async function ensureEntry(form) {
-    if (form.dataset.entry) return form.dataset.entry;
+  /** The entry this form edits, creating it first if it is brand new.
+   *
+   * One create per form, ever: the pending promise is kept on the form so
+   * a second paste, a drop and a Save racing the first create all await
+   * the same POST instead of each making an entry.
+   */
+  function ensureEntry(form) {
+    if (form.dataset.entry) return Promise.resolve(form.dataset.entry);
+    if (form._creating) return form._creating;
+    const name = authorName(form);
+    if (!name) return Promise.reject(Object.assign(new Error("Enter your name first."), { silent: true }));
     const ta = form.querySelector(".ta");
-    const name = form.querySelector(".who").value.trim() || who() || "unknown";
     const body = { day: DAY, book: BOOK, author: name, body_md: ta.value || "" };
     if (form.dataset.after !== undefined && form.dataset.after !== "") body.after = Number(form.dataset.after);
     else if (form.dataset.scan !== undefined && form.dataset.scan !== "") body.scan = Number(form.dataset.scan);
-    const entry = await api("POST", "/entries", body);
-    form.dataset.entry = entry.entry_id;
-    form.dataset.version = String(entry.version);
-    form.classList.add("autosaved");
-    const discard = form.querySelector("[data-discard]");
-    if (discard) discard.hidden = false;
-    return entry.entry_id;
+    form._creating = api("POST", "/entries", body).then((entry) => {
+      form.dataset.entry = entry.entry_id;
+      form.dataset.version = String(entry.version);
+      form.classList.add("autosaved");
+      const discard = form.querySelector("[data-discard]");
+      if (discard) discard.hidden = false;
+      return entry.entry_id;
+    }).finally(() => { form._creating = null; });
+    return form._creating;
+  }
+
+  /** Record the entry's current version on the form and, for an in-place
+   *  edit, on the article too, so a Cancel-then-Edit does not start stale. */
+  function noteVersion(form, version) {
+    form.dataset.version = String(version);
+    const art = form.closest("article");
+    if (art && art.dataset.entry === form.dataset.entry) art.dataset.version = String(version);
   }
 
   async function uploadFiles(form, files) {
     const ta = form.querySelector(".ta");
-    const list = [...files].filter((f) => IMAGE_TYPES.includes(f.type));
+    const all = [...files];
+    const list = all.filter((f) => ACCEPT.includes(f.type));
+    if (all.length && !list.length) {
+      fail(form, { message: `Not an accepted type (${all.map((f) => f.type || "unknown").join(", ")}); accepted: ${ACCEPT.join(", ")}` });
+      return;
+    }
     if (!list.length) return;
     clearFail(form);
     form.classList.add("busy");
+    let id = null;
     try {
-      const id = await ensureEntry(form);
+      id = await ensureEntry(form);
       for (const file of list) {
         const fd = new FormData();
         fd.append("file", file, file.name || "image.png");
@@ -163,14 +210,17 @@
         if (!res.ok) throw Object.assign(new Error((data.detail && data.detail.message) || data.detail || res.statusText), { status: res.status });
         const alt = (file.name || "image").replace(/\.[^.]+$/, "");
         const md = file.type === "application/pdf" ? `[${alt}](${data.link})` : `![${alt}](${data.link})`;
-        insertBlock(ta, md);
+        insertBlock(ta, md, false);
       }
-      // Uploads bump the version; the eventual Save must carry the current one.
-      const fresh = await api("GET", `/entries/${id}`);
-      form.dataset.version = String(fresh.version);
     } catch (err) {
-      fail(form, err);
+      if (!err.silent) fail(form, err);
     } finally {
+      // Every upload that landed bumped the version — including the ones
+      // before a failure — so the eventual Save must carry the current one.
+      if (id) {
+        try { const fresh = await api("GET", `/entries/${id}`); noteVersion(form, fresh.version); }
+        catch (err) { fail(form, err); }
+      }
       form.classList.remove("busy");
     }
   }
@@ -182,9 +232,9 @@
     let pane = form.querySelector(".preview");
     const btn = form.querySelector("[data-tool=preview]");
     if (pane && !pane.hidden) { pane.hidden = true; ta.hidden = false; btn.classList.remove("is-on"); return; }
-    if (!pane) { pane = document.createElement("div"); pane.className = "entry-body preview"; ta.after(pane); }
+    if (!pane) { pane = document.createElement("div"); pane.className = "entry-body preview"; pane.hidden = true; ta.after(pane); }
     try {
-      const data = await api("POST", "/preview", { body_md: ta.value, entry_id: form.dataset.entry || null });
+      const data = await api("POST", "/preview", { body_md: ta.value });
       pane.innerHTML = data.html;
       pane.hidden = false; ta.hidden = true; btn.classList.add("is-on");
     } catch (err) { fail(form, err); }
@@ -200,9 +250,9 @@
     { key: "task", label: "☐ task", title: "Task list", run: (ta) => prefixLines(ta, "- [ ] ") },
     { key: "link", label: "link", title: "Link", run: (ta) => wrap(ta, "[", "](https://)", "text") },
     { key: "table", label: "table", title: "Table (or paste a spreadsheet range)",
-      run: (ta) => insertBlock(ta, rowsToMarkdown([["Parameter", "Value", "Note"], ["", "", ""]])) },
+      run: (ta) => insertBlock(ta, rowsToMarkdown([["Parameter", "Value", "Note"], ["", "", ""]]), true) },
     { key: "callout", label: "callout", title: "Callout — NOTE, TIP, WARNING or CAUTION",
-      run: (ta) => insertBlock(ta, "> [!NOTE]\n> ") },
+      run: (ta) => insertBlock(ta, "> [!NOTE]\n> ", true) },
     { key: "image", label: "image", title: "Attach an image or PDF (or paste / drop one)", run: null },
     { key: "preview", label: "preview", title: "Show it as the page will", run: null },
   ];
@@ -221,7 +271,7 @@
       bar.appendChild(b);
     }
     const picker = document.createElement("input");
-    picker.type = "file"; picker.accept = IMAGE_TYPES.join(","); picker.multiple = true; picker.hidden = true;
+    picker.type = "file"; picker.accept = ACCEPT.join(","); picker.multiple = true; picker.hidden = true;
     picker.addEventListener("change", () => { uploadFiles(form, picker.files); picker.value = ""; });
     bar.appendChild(picker);
     bar.addEventListener("click", (ev) => {
@@ -238,12 +288,22 @@
 
   function onPaste(form, ev) {
     const cd = ev.clipboardData; if (!cd) return;
-    const files = [...cd.items].filter((i) => i.kind === "file").map((i) => i.getAsFile()).filter(Boolean);
-    if (files.length) { ev.preventDefault(); uploadFiles(form, files); return; }
+    const ta = form.querySelector(".ta");
+    // A spreadsheet range often arrives as an HTML table AND a bitmap of
+    // the same cells (Excel); the table is what was meant.
     const html = cd.getData("text/html");
-    const text = cd.getData("text/plain");
-    const rows = (html && htmlTableToRows(html)) || (text && tsvToRows(text));
-    if (rows) { ev.preventDefault(); insertBlock(form.querySelector(".ta"), rowsToMarkdown(rows)); }
+    const tableRows = html ? htmlTableToRows(html) : null;
+    if (tableRows) { ev.preventDefault(); insertBlock(ta, rowsToMarkdown(tableRows), true); return; }
+    const files = [...cd.items].filter((i) => i.kind === "file").map((i) => i.getAsFile()).filter(Boolean);
+    if (files.length) {
+      // A file plus text (a rich paste from a page or a document): keep the
+      // browser's default text paste and upload the file as well.
+      if (!cd.getData("text/plain")) ev.preventDefault();
+      uploadFiles(form, files);
+      return;
+    }
+    const rows = tsvToRows(cd.getData("text/plain") || "");
+    if (rows) { ev.preventDefault(); insertBlock(ta, rowsToMarkdown(rows), true); }
   }
 
   function onDrop(form, ev) {
@@ -254,28 +314,43 @@
 
   // ------------------------------------------------------------ save
 
-  async function save(form) {
-    const ta = form.querySelector(".ta");
-    const name = form.querySelector(".who").value.trim();
-    if (!name) { form.querySelector(".who").focus(); return; }
-    remember(name);
-    clearFail(form);
-    try {
-      if (form.dataset.entry) {
-        await api("PATCH", `/entries/${form.dataset.entry}`, {
-          body_md: ta.value, editor: name, expected_version: Number(form.dataset.version) });
-      } else {
-        if (!ta.value.trim()) return;
-        await ensureEntry(form);
-      }
-      location.reload();
-    } catch (err) { fail(form, err); }
+  /** Run one save-shaped action per form at a time; the buttons follow. */
+  async function exclusive(form, action) {
+    if (form.dataset.saving === "1") return;
+    form.dataset.saving = "1";
+    form.querySelectorAll("button[type=submit],[data-discard]").forEach((b) => { b.disabled = true; });
+    try { await action(); }
+    finally {
+      form.dataset.saving = "";
+      form.querySelectorAll("button[type=submit],[data-discard]").forEach((b) => { b.disabled = false; });
+    }
   }
 
-  async function discard(form) {
-    if (!form.dataset.entry) return;
-    try { await api("DELETE", `/entries/${form.dataset.entry}`); location.reload(); }
-    catch (err) { fail(form, err); }
+  function save(form) {
+    return exclusive(form, async () => {
+      const ta = form.querySelector(".ta");
+      if (!ta.value.trim()) { ta.focus(); return; }
+      const name = authorName(form);
+      if (!name) return;
+      clearFail(form);
+      try {
+        if (form.dataset.entry) {
+          await api("PATCH", `/entries/${form.dataset.entry}`, {
+            body_md: ta.value, editor: name, expected_version: Number(form.dataset.version) });
+        } else {
+          await ensureEntry(form);
+        }
+        location.reload();
+      } catch (err) { if (!err.silent) fail(form, err); }
+    });
+  }
+
+  function discard(form) {
+    if (!form.dataset.entry) return Promise.resolve();
+    return exclusive(form, async () => {
+      try { await api("DELETE", `/entries/${form.dataset.entry}`); location.reload(); }
+      catch (err) { fail(form, err); }
+    });
   }
 
   // ----------------------------------------------------------- mount
@@ -300,7 +375,10 @@
     form.addEventListener("drop", (ev) => onDrop(form, ev));
     form.addEventListener("submit", (ev) => { ev.preventDefault(); save(form); });
     ta.addEventListener("keydown", (ev) => {
-      if ((ev.metaKey || ev.ctrlKey) && ev.key === "Enter") { ev.preventDefault(); save(form); }
+      if ((ev.metaKey || ev.ctrlKey) && ev.key === "Enter") {
+        ev.preventDefault();
+        if (!ev.repeat) save(form); // a held key must not save N times
+      }
     });
   }
 
@@ -313,7 +391,10 @@
     if (b.closest("[data-insert]")) {
       const after = b.closest("[data-insert]").dataset.insert;
       const hostEl = document.querySelector(`[data-between-host="${after}"]`);
-      if (hostEl) { hostEl.hidden = false; b.closest("[data-insert]").hidden = true; const ta = hostEl.querySelector(".ta"); if (ta) ta.focus(); }
+      if (hostEl) {
+        hostEl.hidden = false; hostEl.open = true; b.closest("[data-insert]").hidden = true;
+        const ta = hostEl.querySelector(".ta"); if (ta) ta.focus();
+      }
       return;
     }
     if (b.dataset.keep) {
@@ -341,7 +422,7 @@
         <div class="editor-bar"><input class="who" placeholder="Your name" required aria-label="Your name">
         <button class="btn btn-sm btn-primary" type="submit">Save</button>
         <button class="btn btn-sm" type="button" data-cancel="1">Cancel</button>
-        <span class="editor-hint">&#8984;&#8629; saves</span></div></div>`;
+        <span class="editor-hint">⌘↩ saves</span></div></div>`;
       form.querySelector(".ta").value = raw;
       bodyEl.hidden = true; bodyEl.after(form);
       mount(form);

--- a/GeecsLogbook/geecs_logbook/static/editor.js
+++ b/GeecsLogbook/geecs_logbook/static/editor.js
@@ -200,6 +200,10 @@
     clearFail(form);
     form.classList.add("busy");
     let id = null;
+    let done;
+    // Kept on the form so a Save that lands mid-upload waits for the link
+    // to be inserted and the version to be re-read, instead of racing it.
+    form._uploading = new Promise((resolve) => { done = resolve; });
     try {
       id = await ensureEntry(form);
       for (const file of list) {
@@ -222,6 +226,8 @@
         catch (err) { fail(form, err); }
       }
       form.classList.remove("busy");
+      form._uploading = null;
+      done();
     }
   }
 
@@ -294,6 +300,9 @@
     const html = cd.getData("text/html");
     const tableRows = html ? htmlTableToRows(html) : null;
     if (tableRows) { ev.preventDefault(); insertBlock(ta, rowsToMarkdown(tableRows), true); return; }
+    // A single row still comes with a <table> (and, from Excel, a bitmap
+    // of the cells): let the default text paste through, upload nothing.
+    if (html && /<table[\s>]/i.test(html)) return;
     const files = [...cd.items].filter((i) => i.kind === "file").map((i) => i.getAsFile()).filter(Boolean);
     if (files.length) {
       // A file plus text (a rich paste from a page or a document): keep the
@@ -319,7 +328,10 @@
     if (form.dataset.saving === "1") return;
     form.dataset.saving = "1";
     form.querySelectorAll("button[type=submit],[data-discard]").forEach((b) => { b.disabled = true; });
-    try { await action(); }
+    try {
+      if (form._uploading) await form._uploading; // let a paste finish landing first
+      await action();
+    }
     finally {
       form.dataset.saving = "";
       form.querySelectorAll("button[type=submit],[data-discard]").forEach((b) => { b.disabled = false; });
@@ -329,7 +341,13 @@
   function save(form) {
     return exclusive(form, async () => {
       const ta = form.querySelector(".ta");
-      if (!ta.value.trim()) { ta.focus(); return; }
+      if (!ta.value.trim()) {
+        ta.focus();
+        if (form.dataset.entry && form.classList.contains("autosaved")) {
+          fail(form, { message: "Nothing to save — Discard removes this entry." });
+        }
+        return;
+      }
       const name = authorName(form);
       if (!name) return;
       clearFail(form);

--- a/GeecsLogbook/geecs_logbook/static/scanlog.css
+++ b/GeecsLogbook/geecs_logbook/static/scanlog.css
@@ -232,7 +232,7 @@ details.campaign[hidden]{display:none}
 .callout-warning{border-left-color:var(--warn);background:var(--warn-soft)} .callout-warning .callout-label{color:var(--warn)}
 .callout-caution{border-left-color:var(--crit);background:var(--crit-soft)} .callout-caution .callout-label{color:var(--crit)}
 
-/* composer (minimal; the editor proper lands next) */
+/* composer + editor */
 .composer{background:var(--surface-2)}
 .ta{width:100%;resize:vertical;border:1px solid var(--rule);border-radius:4px;background:var(--surface);
   color:var(--ink);font-family:var(--ff-prose);font-size:14.5px;line-height:1.6;padding:8px 10px;outline:none}
@@ -258,3 +258,19 @@ details.campaign[hidden]{display:none}
   border-radius:20px;padding:2px 11px;cursor:pointer}
 .insert-btn:hover{border-color:var(--accent);color:var(--accent)}
 .insert[hidden],.between[hidden]{display:none}
+
+/* the editor: toolbar, preview, drop target, and the image grid */
+.toolbar{display:flex;gap:2px;flex-wrap:wrap;margin-bottom:5px}
+.tool{font:inherit;font-size:11.5px;color:var(--slate);background:var(--surface);border:1px solid var(--rule);
+  border-radius:3px;padding:2px 7px;cursor:pointer;line-height:1.4}
+.tool:hover{border-color:var(--accent);color:var(--accent)}
+.tool.is-on{background:var(--accent-soft);color:var(--accent);border-color:var(--accent)}
+.tool-b{font-weight:700} .tool-i{font-style:italic}
+.composer.dragover .ta{border-color:var(--accent);border-style:dashed;background:var(--accent-soft)}
+.composer.busy .ta{opacity:.6}
+.composer.autosaved .editor-hint::after{content:" · saved with attachment"}
+.preview{min-height:3em;border:1px dashed var(--rule);border-radius:4px;padding:8px 10px;background:var(--surface)}
+.errmsg{font-size:12px;color:var(--crit);margin-top:5px}
+.figgrid{display:grid;grid-template-columns:repeat(auto-fit,minmax(200px,1fr));gap:10px;margin:8px 0}
+.figgrid figure{margin:0}
+.figgrid img{max-width:100%;margin:0;display:block}

--- a/GeecsLogbook/geecs_logbook/static/scanlog.css
+++ b/GeecsLogbook/geecs_logbook/static/scanlog.css
@@ -248,7 +248,11 @@ details.campaign[hidden]{display:none}
 .card.intro .scanhead{cursor:default}
 .between{border-left:2px solid var(--agent-rule);background:var(--surface);border-radius:0 var(--r) var(--r) 0;
   border-top:1px solid var(--rule);border-right:1px solid var(--rule);border-bottom:1px solid var(--rule);overflow:hidden}
-.between > header{display:flex;align-items:center;gap:10px;flex-wrap:wrap;padding:9px 16px;background:var(--surface-2)}
+.between > summary{display:flex;align-items:center;gap:10px;flex-wrap:wrap;padding:9px 16px;background:var(--surface-2);cursor:pointer;list-style:none}
+.between > summary::-webkit-details-marker{display:none}
+.between > summary::before{content:"\25B8";color:var(--muted);font-size:11px;transition:transform .12s}
+.between[open] > summary::before{transform:rotate(90deg)}
+.between .count{margin-left:auto;font-family:var(--ff-mono);font-size:11px;color:var(--muted)}
 .between .tlabel{font-family:var(--ff-mono);font-size:11px;letter-spacing:.06em;text-transform:uppercase;color:var(--agent);font-weight:600}
 .between .trange{font-family:var(--ff-mono);font-size:11px;color:var(--muted)}
 .between .entries{border-top:0}

--- a/GeecsLogbook/geecs_logbook/templates/day.html
+++ b/GeecsLogbook/geecs_logbook/templates/day.html
@@ -76,7 +76,7 @@
         <div class="editor-bar">
           <input class="who" placeholder="Your name" required aria-label="Your name">
           <button class="btn btn-sm btn-primary" type="submit">Save</button>
-          <span class="editor-hint">&#8984;&#8629; saves</span>
+          <span class="editor-hint">&#8984;&#8629; saves &middot; paste or drop a screenshot</span>
         </div>
       </div>
     </form>
@@ -241,7 +241,7 @@
     {% endif %}
   </aside>
 
-  <main class="doc">
+  <main id="logbook" data-api="{{ api_base }}" data-day="{{ summary.day.isoformat() }}" data-book="scans">
 
     <div class="dayhead">
       <div>
@@ -372,97 +372,8 @@ document.querySelectorAll(".scanrow").forEach(a => a.addEventListener("click", (
   const camp = el.closest("details.campaign");
   if (camp) camp.open = true;
 }));
-
-/* ---- notes: the minimal write path. A real editor replaces this. ---- */
-const API = {{ api_base | tojson }};
-const AUTHOR_KEY = "geecs.author";
-const who = () => { try { return localStorage.getItem(AUTHOR_KEY) || ""; } catch (e) { return ""; } };
-document.querySelectorAll(".composer .who").forEach(i => { i.value = who(); });
-
-async function api(method, path, body){
-  const res = await fetch(API + path, {
-    method, headers: body ? {"Content-Type": "application/json"} : {},
-    body: body ? JSON.stringify(body) : undefined });
-  if (res.status === 204) return null;
-  const data = await res.json().catch(() => ({}));
-  const d = data.detail;
-  const text = Array.isArray(d) ? d.map(x => x.msg || JSON.stringify(x)).join("; ") : (d?.message || d || res.statusText);
-  if (!res.ok) throw Object.assign(new Error(text), {status: res.status, data});
-  return data;
-}
-function fail(el, err){
-  const msg = el.querySelector(".errmsg") || el.appendChild(Object.assign(document.createElement("div"), {className: "errmsg"}));
-  msg.textContent = err.status === 409
-    ? "Someone else saved this first. Reload to see their version, then re-apply your change."
-    : (err.message || "Could not save.");
-}
-
-document.addEventListener("submit", async ev => {
-  const form = ev.target.closest("form.composer"); if (!form) return;
-  ev.preventDefault();
-  const ta = form.querySelector(".ta"), name = form.querySelector(".who").value.trim();
-  if (!ta.value.trim() || !name) return;
-  try { localStorage.setItem(AUTHOR_KEY, name); } catch (e) {}
-  const body = { day: {{ summary.day.isoformat() | tojson }}, book: "scans", author: name, body_md: ta.value };
-  if (form.dataset.after !== "") body.after = Number(form.dataset.after);
-  else if (form.dataset.scan !== "") body.scan = Number(form.dataset.scan);
-  // neither: a day-level entry
-  try { await api("POST", "/entries", body); location.reload(); }
-  catch (err) { fail(form, err); }
-});
-
-document.addEventListener("keydown", ev => {
-  if ((ev.metaKey || ev.ctrlKey) && ev.key === "Enter" && ev.target.matches(".ta")){
-    ev.preventDefault(); ev.target.closest("form")?.requestSubmit();
-  }
-});
-
-document.addEventListener("click", async ev => {
-  const b = ev.target.closest("button"); if (!b) return;
-  if (b.closest("[data-insert]")){
-    const after = b.closest("[data-insert]").dataset.insert;
-    const host = document.querySelector(`[data-between-host="${after}"]`);
-    if (host){ host.hidden = false; b.closest("[data-insert]").hidden = true; host.querySelector(".ta")?.focus(); }
-    return;
-  }
-  if (b.dataset.keep){
-    try { await api("POST", `/entries/${b.dataset.keep}/status`, {status: "kept"}); location.reload(); }
-    catch (err) { fail(b.closest(".entry-main"), err); }
-    return;
-  }
-  if (b.dataset.del){
-    if (b.dataset.armed !== "1"){ b.dataset.armed = "1"; b.textContent = "Really delete"; return; }
-    try { await api("DELETE", `/entries/${b.dataset.del}`); location.reload(); }
-    catch (err) { fail(b.closest(".entry-main"), err); }
-    return;
-  }
-  if (b.dataset.edit){
-    const art = document.getElementById("entry-" + b.dataset.edit);
-    const main = art.querySelector(".entry-main"), raw = JSON.parse(art.querySelector(".raw").textContent);
-    const bodyEl = main.querySelector(".entry-body");
-    if (main.querySelector("form.editing")) return;
-    const form = document.createElement("form"); form.className = "composer editing";
-    form.innerHTML = `<div class="entry-main"><textarea class="ta" rows="6"></textarea>
-      <div class="editor-bar"><input class="who" placeholder="Your name" required aria-label="Your name">
-      <button class="btn btn-sm btn-primary" type="submit">Save</button>
-      <button class="btn btn-sm" type="button" data-cancel="1">Cancel</button></div></div>`;
-    form.querySelector(".ta").value = raw; form.querySelector(".who").value = who();
-    bodyEl.hidden = true; bodyEl.after(form); form.querySelector(".ta").focus();
-    form.addEventListener("submit", async e => {
-      e.preventDefault();
-      const name = form.querySelector(".who").value.trim(); if (!name) return;
-      try { localStorage.setItem(AUTHOR_KEY, name); } catch (x) {}
-      try {
-        await api("PATCH", `/entries/${art.dataset.entry}`, {
-          body_md: form.querySelector(".ta").value, editor: name,
-          expected_version: Number(art.dataset.version) });
-        location.reload();
-      } catch (err) { fail(form, err); }
-    });
-    form.querySelector("[data-cancel]").addEventListener("click", () => { form.remove(); bodyEl.hidden = false; });
-  }
-});
 </script>
+<script src="{{ url_for('_static', name='editor.js') }}" defer></script>
 <script src="{{ root }}/theme/theme.js" defer></script>
 </body>
 </html>

--- a/GeecsLogbook/geecs_logbook/templates/day.html
+++ b/GeecsLogbook/geecs_logbook/templates/day.html
@@ -89,22 +89,24 @@
   {% set anchor = 'after-%04d' % after %}
   {% set es = entries.get(anchor, []) %}
   {% if es %}
-  <section class="between">
-    <header><span class="tlabel">Between scans</span>
-      <span class="trange">{{ prev_label }} &rarr; {{ next_label }}</span></header>
+  <details class="between" open>
+    <summary><span class="tlabel">Between scans</span>
+      <span class="trange">{{ prev_label }} &rarr; {{ next_label }}</span>
+      <span class="count">{{ es | length }} note{{ '' if es | length == 1 else 's' }}</span></summary>
     {{ entries_block(anchor, none, after, entries, writable) }}
-  </section>
+  </details>
   {% elif writable %}
   <div class="insert" data-insert="{{ after }}">
     <div class="insert-rule"></div>
     <button class="insert-btn" type="button">+ note between {{ prev_label }} and {{ next_label }}</button>
     <div class="insert-rule"></div>
   </div>
-  <section class="between" hidden data-between-host="{{ after }}">
-    <header><span class="tlabel">Between scans</span>
-      <span class="trange">{{ prev_label }} &rarr; {{ next_label }}</span></header>
+  <details class="between" hidden data-between-host="{{ after }}">
+    <summary><span class="tlabel">Between scans</span>
+      <span class="trange">{{ prev_label }} &rarr; {{ next_label }}</span>
+      <span class="count">new note</span></summary>
     {{ entries_block(anchor, none, after, entries, writable) }}
-  </section>
+  </details>
   {% endif %}
 {% endmacro %}
 
@@ -241,7 +243,7 @@
     {% endif %}
   </aside>
 
-  <main id="logbook" data-api="{{ api_base }}" data-day="{{ summary.day.isoformat() }}" data-book="scans">
+  <main id="logbook" data-api="{{ api_base }}" data-day="{{ summary.day.isoformat() }}" data-book="scans" data-accept="{{ accept }}">
 
     <div class="dayhead">
       <div>
@@ -325,7 +327,7 @@ const btn = document.getElementById("toggle-all");
 /* Expand/collapse reaches BOTH levels: opening only the campaigns left
    every scan inside them shut, so the button appeared not to work. */
 const cards = () => [...document.querySelectorAll(
-  "details.campaign, details.scan")];
+  "details.campaign, details.scan, details.between")];
 
 function applyAll(expand){
   cards().forEach(c => { if (!c.hidden) c.open = expand; });

--- a/GeecsLogbook/pyproject.toml
+++ b/GeecsLogbook/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-logbook"
-version = "0.3.0"
+version = "0.4.0"
 description = "Scan logbook: a day-document view over scan folders, with human commentary stored beside the data"
 authors = ["GEECS-BELLA"]
 readme = "README.md"

--- a/GeecsLogbook/tests/test_render.py
+++ b/GeecsLogbook/tests/test_render.py
@@ -88,3 +88,36 @@ class TestMarkdownFeatures:
     def test_empty_body_is_empty(self) -> None:
         """No text, no markup."""
         assert render_markdown("") == ""
+
+
+class TestImageGrid:
+    """Consecutive images become one grid; a lone image does not."""
+
+    def test_two_or_more_images_in_a_row_grid(self) -> None:
+        """Pasted screenshots one after another render side by side."""
+        out = render_markdown(
+            "![a](attachments/x/a.png)\n\n![b](attachments/x/b.png)\n\n![c](attachments/x/c.png)\n"
+        )
+        assert out.count('<div class="figgrid">') == 1
+        assert out.count("<figure><img") == 3
+        assert "<p><img" not in out
+
+    def test_a_single_image_stays_a_paragraph(self) -> None:
+        """One figure is a figure, not a grid of one."""
+        out = render_markdown("text\n\n![a](attachments/x/a.png)\n\nmore")
+        assert "figgrid" not in out and "<p><img" in out
+
+    def test_a_paragraph_breaks_the_run(self) -> None:
+        """Images separated by prose are two runs, not one."""
+        out = render_markdown(
+            "![a](x/a.png)\n\n![b](x/b.png)\n\ncaption\n\n![c](x/c.png)\n\n![d](x/d.png)"
+        )
+        assert out.count('<div class="figgrid">') == 2
+
+    def test_grid_survives_the_link_rewrite(self) -> None:
+        """The serving base is applied inside the grid too."""
+        out = render_markdown(
+            "![a](attachments/x/a.png)\n\n![b](attachments/x/b.png)",
+            attachment_base="/log/attachments",
+        )
+        assert out.count('src="/log/attachments/x/') == 2 and "figgrid" in out

--- a/GeecsLogbook/tests/test_router.py
+++ b/GeecsLogbook/tests/test_router.py
@@ -460,6 +460,10 @@ class TestEditorHooks:
         page = writable.get("/log/day/2026-09-11").text
         assert 'id="logbook"' in page and 'data-api="/log/api"' in page
         assert 'data-day="2026-09-11"' in page and 'data-book="scans"' in page
+        assert (
+            'data-accept="application/pdf,image/gif,image/jpeg,image/png,image/webp"'
+            in page
+        )
         assert "editor.js" in page
         js = writable.get("/log/static/editor.js")
         assert js.status_code == 200 and "uploadFiles" in js.text

--- a/GeecsLogbook/tests/test_router.py
+++ b/GeecsLogbook/tests/test_router.py
@@ -448,3 +448,36 @@ class TestBooksTagsHistory:
         ]
         assert hist[2]["entry"]["status"] == "draft"
         assert writable.get("/log/api/entries/nope/history").status_code == 404
+
+
+class TestEditorHooks:
+    """What the page hands the editor script, and the preview it calls."""
+
+    def test_page_carries_the_editors_facts_and_the_script(
+        self, writable: TestClient
+    ) -> None:
+        """The editor reads api/day/book off <main id=logbook>; the script is served."""
+        page = writable.get("/log/day/2026-09-11").text
+        assert 'id="logbook"' in page and 'data-api="/log/api"' in page
+        assert 'data-day="2026-09-11"' in page and 'data-book="scans"' in page
+        assert "editor.js" in page
+        js = writable.get("/log/static/editor.js")
+        assert js.status_code == 200 and "uploadFiles" in js.text
+
+    def test_preview_renders_like_the_page(self, writable: TestClient) -> None:
+        """Preview is the same renderer with the same attachment base."""
+        r = writable.post(
+            "/log/api/preview",
+            json={"body_md": "> [!TIP]\n> ok\n\n![p](attachments/e/a.png)"},
+        )
+        assert r.status_code == 200
+        html = r.json()["html"]
+        assert 'class="callout callout-tip"' in html
+        assert 'src="/log/attachments/e/a.png"' in html
+
+    def test_preview_needs_a_store(self, client: TestClient) -> None:
+        """A read-only logbook has no composer, so no preview."""
+        assert client.post("/log/api/preview", json={"body_md": "x"}).status_code in (
+            404,
+            405,
+        )

--- a/GeecsWebTheme/tests/test_no_literal_colours.py
+++ b/GeecsWebTheme/tests/test_no_literal_colours.py
@@ -40,6 +40,7 @@ _SURFACES = [
     "GEECS-DataPortal/geecs_portal/templates/run.html",
     "GeecsLogbook/geecs_logbook/static/scanlog.css",
     "GeecsLogbook/geecs_logbook/templates/day.html",
+    "GeecsLogbook/geecs_logbook/static/editor.js",
     "ScanAnalysis/scan_analysis/config_editor/static/editor.css",
     "ScanAnalysis/scan_analysis/config_editor/templates/editor.html",
 ]


### PR DESCRIPTION
PR 2 of the path to a functional scans + ops logbook, into `feature/scan-logger` (not master). With this, the **scans logger is functionally complete**: writing, editing, screenshots, tables, on the day page, durable and mirrored.

## What

`static/editor.js` — the whole write path in the browser, one implementation for every composer on the page (per scan, per gap, the day, in-place edits; the month page next). Deliberately not WYSIWYG: the body stays the plain markdown the mirror holds.

- **Toolbar**: bold, italic, code, bulleted list, task list, link, table skeleton, callout, image (file picker), preview. Each writes markdown around the selection.
- **Paste or drop a screenshot** into the composer: the file goes to `POST /api/entries/{id}/attachments` and a relative image link lands at the cursor. A brand-new entry has no id until saved, so the first attachment **saves it first** (an "autosave"; the form shows *saved with attachment*) and Save becomes a PATCH; a **Discard** button deletes the stub. Uploads bump the version, so the form re-reads it before its eventual Save.
- **Paste a spreadsheet range**: an HTML table on the clipboard (Excel/Sheets) or tab-separated text with ≥2 lines becomes a markdown table; `|` in cells escaped.
- **Preview**: `POST /api/preview` renders with the page's renderer and the same attachment base, toggled in place of the textarea.
- **⌘/Ctrl+Enter** saves; a 409 shows what happened rather than a generic error.
- **Image grid** (`render._image_grids`): two or more consecutive image paragraphs render as one `figgrid` — the plot table that replaces LogMaker's `gdoc_slot` numbering (no slot assignment, no ceiling at four).

The template no longer carries an inline script; it hands the editor its three facts through `<main id="logbook" data-api data-day data-book>` and loads `editor.js` from the logbook's static route. `editor.js` sets no colours (the theme guard's rule; all styling through tokens in `scanlog.css`).

## Per-concern LOC

| Concern | ~LOC |
|---|---|
| `static/editor.js` (new; includes the ~110 lines moved out of the template) | +330 |
| Template: hooks, inline script removed | +6 / −100 |
| Renderer: image grid | +25 |
| Route: `POST /api/preview` | +20 |
| Styles: toolbar, preview, drop target, grid | +20 |
| Tests: grid (4), preview + page hooks (3) | +60 |
| CHANGELOG, CLAUDE.md "The editor" | +45 |

## Judgment calls (cheap to veto)

- **Autosave-on-first-attach.** The alternative — staging uploads under a temporary id until Save — is more machinery for the same outcome. The cost is a stub entry if someone pastes a screenshot and walks away; Discard exists, and the entry is visible on the page, not hidden.
- **The `who` field is still a free-text name** stored in `localStorage`; identity is a later concern (there is no login anywhere in the portal).
- **No JS unit tests** — the repo has no JS test runner, and adding one for one file is out of proportion. `editor.js` is syntax-checked with node in this session and exercised by hand on a local smoke server; the Python tests pin what the page hands the script and the routes it calls.

## Facility literals

None.

## Tests

GeecsLogbook 151 (was 144: +4 grid, +3 preview/page hooks), GeecsWebTheme 104 (the guard still walks the template and stylesheet).

## Hand-checked (local smoke server, temp share + temp db)

Page serves the hooks and the script; `node --check` on `editor.js`. Owner to click through: type → Save; Edit → toolbar → Save; paste a screenshot; paste a spreadsheet range; Preview.

## Review

Adversarial review per `/land` — posted as a comment when it completes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012m7DgJBqRD8Kg6DZQmBFsi