### PR TITLE
GeecsLogbook 0.5.0 / Portal 0.25.0: the ops book — month page, seed templates as type buttons, cross-links; portal memory ceiling (#834)

### DIFF
--- a/GEECS-DataPortal/CHANGELOG.md
+++ b/GEECS-DataPortal/CHANGELOG.md
@@ -3,6 +3,26 @@
 All notable changes to this package will be documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.25.0] - 2026-09-11
+
+### Added
+
+- The logbook's seed templates (its type buttons) are read from
+  `logbook_templates/` beside the `--processing-configs` tree — the
+  configs checkout the portal already has; no new flag. Without that
+  tree the composers are plain.
+- Unit template: `MemoryHigh=` / `MemoryMax=` on the portal service,
+  rendered from two new **required** site.env keys
+  `GEECS_PORTAL_MEMORY_HIGH` / `GEECS_PORTAL_MEMORY_MAX` (3G / 4G in the
+  example, sized per host), so a runaway portal is throttled and then
+  restarted by systemd instead of being the kernel's first OOM pick on
+  the shared box (#834). Existing hosts add the two keys and re-render.
+
+### Changed
+
+- `/log/month/{YYYY-MM}` (the ops book) is now served under `--scan-log`
+  alongside the day pages (GeecsLogbook 0.5.0).
+
 ## [0.24.1] - 2026-09-11
 
 ### Changed

--- a/GEECS-DataPortal/CLAUDE.md
+++ b/GEECS-DataPortal/CLAUDE.md
@@ -154,7 +154,9 @@ geecs_portal/
   static/        # the vendored Plotly bundle (the ONE committed JS asset)
   __main__.py    # CLI (geecs-data-portal): real TiledScanCatalog + uvicorn;
                  #   --config-editor mounts scan_analysis.config_editor at /configs
-                 #   --scan-log     mounts geecs_logbook at /log (needs --experiment)
+                 #   --scan-log     mounts geecs_logbook at /log (needs --experiment;
+                 #                  type buttons from <configs>/logbook_templates/,
+                 #                  the parent of --processing-configs)
                  #   --notes-db     the logbook's SQLite file; makes /log writable
                  #                  (default: $STATE_DIRECTORY/logbook.db under systemd)
   templates/     # base.html / day.html / run.html (Jinja2; every colour a GeecsWebTheme token)
@@ -166,7 +168,9 @@ tests/
 ```
 
 Routes: `/` (redirect to today) · `/day/{iso}` (run list; `?experiment=`)
-· `/log/day/{iso}` + `/log/api/day/{iso}` (the scan logbook, `--scan-log`)
+· `/log/day/{iso}` + `/log/api/day/{iso}` (the scans book, `--scan-log`)
+· `/log/month/{YYYY-MM}` + `/log/api/month/{YYYY-MM}/entries` (the ops book,
+same flag; store-only, never the share)
 · `/log/api/entries…` (the logbook's entry writes, only with `--notes-db`)
 · `/run/{uid}` (the scan page: rail + Overview/Plot/Images/Analysis tabs
 — Analysis only when runs are possible, see below;

--- a/GEECS-DataPortal/DEPLOYMENT.md
+++ b/GEECS-DataPortal/DEPLOYMENT.md
@@ -106,8 +106,21 @@ host's `site.env` with `deploy/render_units.sh` (or let
 `deploy/bootstrap_host.sh` do the whole host), then install the rendered
 unit and `enable --now` it — see the
 [Site Profile](../docs/platform/site_profile.md). The account, checkout
-root, poetry path, experiment, and timezone all come from `site.env`;
-nothing site-specific is typed into the unit by hand.
+root, poetry path, experiment, timezone, and the memory ceiling all come
+from `site.env`; nothing site-specific is typed into the unit by hand.
+
+**Memory ceiling.** The rendered unit carries `MemoryHigh=` and
+`MemoryMax=` from `GEECS_PORTAL_MEMORY_HIGH` / `GEECS_PORTAL_MEMORY_MAX`
+(both required; 3G / 4G in the example for a 16 GB host shared with
+Tiled, MySQL and the queueserver). Above HIGH systemd throttles and
+reclaims the portal; at MAX it kills it and `Restart=on-failure` brings
+it back — so a runaway portal evicts itself before the kernel picks a
+victim, and the victim is the portal rather than Tiled (#834). To change
+the numbers: edit `site.env`, re-render, `daemon-reload`, restart. For a
+quick change without a re-render, `sudo systemctl set-property
+geecs-data-portal MemoryMax=6G` writes a persistent drop-in;
+`systemctl revert geecs-data-portal` removes it. `systemctl status`
+shows the current `Memory:` line against the cap.
 
 Verify:
 
@@ -226,6 +239,19 @@ Two requirements, or it warn-and-skips rather than serving a broken page:
 Set it on the host through `GEECS_PORTAL_EXTRA_ARGS` in `site.env`
 alongside `--config-editor`; `deploy/bootstrap_host.sh` already installs
 the extra for the portal service.
+
+**Two books.** `/log/day/…` is the scans book; `/log/month/2026-09` is
+the ops book — day-level notes read by month, from the database alone
+(it never touches the share, so it stays fast when the share is slow).
+
+**Type buttons** on every composer are seed templates: `*.md` files in
+`logbook_templates/` at the top of the configs checkout — the parent of
+the `--processing-configs` tree, so the same `GEECS_CONFIGS_ROOT` serves
+both. Copy `GeecsLogbook/examples/logbook_templates/` there to start
+(commit it to the configs repo); each file's header names its label,
+colour (a theme token name), book and order, and its body is the
+prefill. Adding a file adds a button within a minute, no restart. Without
+the directory the composers are plain.
 
 Reading a day of ~100 scans off a VPN-mounted share takes a few seconds
 cold and milliseconds thereafter — per-scan summaries are cached on the

--- a/GEECS-DataPortal/deploy/geecs-data-portal.service
+++ b/GEECS-DataPortal/deploy/geecs-data-portal.service
@@ -54,6 +54,17 @@ ExecStart=@POETRY@ run geecs-data-portal --experiment ${GEECS_EXPERIMENT} --proc
 # here rather than in site.env. Back it up: what people wrote exists in
 # this file and in the markdown mirror on the share, nowhere else.
 StateDirectory=geecs-data-portal
+# Memory ceiling (#834): the portal shares the box with Tiled, MySQL and
+# the queueserver, and as the largest resident process it was the
+# kernel's first OOM pick. MemoryHigh= throttles and reclaims above the
+# soft line; MemoryMax= is the hard cap, at which systemd kills and
+# Restart= brings it back in seconds — the portal, not Tiled, pays for a
+# runaway. Sized per host in site.env (GEECS_PORTAL_MEMORY_HIGH/MAX;
+# systemd cannot expand ${VAR} here, so the render fills them). To change
+# without a re-render: `systemctl set-property geecs-data-portal
+# MemoryMax=4G` writes a persistent drop-in (`systemctl revert` removes).
+MemoryHigh=@PORTAL_MEMORY_HIGH@
+MemoryMax=@PORTAL_MEMORY_MAX@
 Restart=on-failure
 RestartSec=10
 # An analysis run in flight cannot be interrupted (DEPLOYMENT.md): give a

--- a/GEECS-DataPortal/geecs_portal/app.py
+++ b/GEECS-DataPortal/geecs_portal/app.py
@@ -342,6 +342,11 @@ class _DiagInfo:
         )
 
 
+#: The logbook's seed templates, a directory beside the analysis tree in
+#: the configs checkout (``<configs>/logbook_templates/*.md``).
+LOGBOOK_TEMPLATES_DIR = "logbook_templates"
+
+
 def create_app(
     catalog: ScanCatalog,
     *,
@@ -392,6 +397,10 @@ def create_app(
         each entry as markdown into the day's ``logbook/`` folder on the
         share (a sibling of ``scans/``; never inside it). Without it the
         logbook is the read-only day view. Ignored unless ``scan_log``.
+        The logbook's seed templates — its type buttons — are read from
+        ``logbook_templates/`` beside the ``processing_config_dir`` tree
+        (the configs checkout this portal already reads); none when that
+        tree is not configured.
     config_editor : bool, default False
         Mount the analysis config editor (``scan_analysis.config_editor``)
         at ``/configs`` over the same ``processing_config_dir`` tree, with a
@@ -1919,14 +1928,26 @@ def create_app(
             except ImportError as exc:  # the log extra is not installed
                 logger.warning("scan log requested but not installed: %s", exc)
             else:
+                # Type buttons are markdown files in the configs checkout,
+                # a sibling of the analysis tree: one checkout, one flag.
+                templates_dir = (
+                    Path(processing_config_dir).parent / LOGBOOK_TEMPLATES_DIR
+                    if processing_config_dir
+                    else None
+                )
                 app.include_router(
-                    create_log_router(default_experiment, notes_db=notes_db),
+                    create_log_router(
+                        default_experiment,
+                        notes_db=notes_db,
+                        templates_dir=templates_dir,
+                    ),
                     prefix="/log",
                 )
                 logger.info(
-                    "scan log mounted at /log for %s (%s)",
+                    "scan log mounted at /log for %s (%s; templates %s)",
                     default_experiment,
                     f"entries in {notes_db}" if notes_db else "read-only",
+                    templates_dir or "none",
                 )
 
     return app

--- a/GEECS-DataPortal/geecs_portal/app.py
+++ b/GEECS-DataPortal/geecs_portal/app.py
@@ -342,11 +342,6 @@ class _DiagInfo:
         )
 
 
-#: The logbook's seed templates, a directory beside the analysis tree in
-#: the configs checkout (``<configs>/logbook_templates/*.md``).
-LOGBOOK_TEMPLATES_DIR = "logbook_templates"
-
-
 def create_app(
     catalog: ScanCatalog,
     *,
@@ -373,7 +368,10 @@ def create_app(
         config resolution (the 03 design doc's finding 7: two
         competing resolution paths exist, so the portal names its
         tree explicitly). The selector also hides itself when
-        ImageAnalysis (the ``analysis`` extra) is not installed.
+        ImageAnalysis (the ``analysis`` extra) is not installed. With
+        ``scan_log``, the logbook's seed templates (its type buttons) are
+        read from ``logbook_templates/`` beside this tree — the configs
+        checkout the portal already reads; none when it is not configured.
     analysis_factory : callable, optional
         ``(analyzer_id, config_dir) -> ScanAnalyzer`` for the analysis
         runs (``/api/run/{uid}/analysis``, the 04 design). ``None``
@@ -397,10 +395,6 @@ def create_app(
         each entry as markdown into the day's ``logbook/`` folder on the
         share (a sibling of ``scans/``; never inside it). Without it the
         logbook is the read-only day view. Ignored unless ``scan_log``.
-        The logbook's seed templates — its type buttons — are read from
-        ``logbook_templates/`` beside the ``processing_config_dir`` tree
-        (the configs checkout this portal already reads); none when that
-        tree is not configured.
     config_editor : bool, default False
         Mount the analysis config editor (``scan_analysis.config_editor``)
         at ``/configs`` over the same ``processing_config_dir`` tree, with a
@@ -1925,13 +1919,14 @@ def create_app(
         else:
             try:
                 from geecs_logbook import create_log_router
+                from geecs_logbook.seed_templates import TEMPLATES_DIRNAME
             except ImportError as exc:  # the log extra is not installed
                 logger.warning("scan log requested but not installed: %s", exc)
             else:
                 # Type buttons are markdown files in the configs checkout,
                 # a sibling of the analysis tree: one checkout, one flag.
                 templates_dir = (
-                    Path(processing_config_dir).parent / LOGBOOK_TEMPLATES_DIR
+                    Path(processing_config_dir).parent / TEMPLATES_DIRNAME
                     if processing_config_dir
                     else None
                 )

--- a/GEECS-DataPortal/pyproject.toml
+++ b/GEECS-DataPortal/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-data-portal"
-version = "0.24.1"
+version = "0.25.0"
 description = "Scan-browsing web service (read-only except explicit analysis runs): a zero-install browser view over the Tiled catalog and the GEECS data share"
 authors = ["GEECS-BELLA"]
 readme = "README.md"

--- a/GEECS-DataPortal/tests/test_scan_log_mount.py
+++ b/GEECS-DataPortal/tests/test_scan_log_mount.py
@@ -95,3 +95,42 @@ class TestNotesDb:
         from geecs_logbook.store import NotesStore
 
         assert [e.body_md for e in NotesStore(db).unmirrored()] == ["hello"]
+
+
+class TestSeedTemplates:
+    """The logbook's type buttons come from the configs checkout the portal reads."""
+
+    def test_templates_dir_is_beside_the_analysis_tree(self, tmp_path: Path) -> None:
+        """``<configs>/logbook_templates/`` — a sibling of --processing-configs."""
+        configs = tmp_path / "configs"
+        analysis = configs / "scan_analysis_configs"
+        analysis.mkdir(parents=True)
+        (configs / "logbook_templates").mkdir()
+        (configs / "logbook_templates" / "laser.md").write_text(
+            "---\nlabel: Laser\ncolour: ok\nbook: ops\n---\n#laser\n"
+        )
+        client = TestClient(
+            create_app(
+                FakeCatalog(),
+                default_experiment="Undulator",
+                processing_config_dir=analysis,
+                scan_log=True,
+                notes_db=tmp_path / "logbook.db",
+            )
+        )
+        html = client.get("/log/month/2026-09").text
+        assert 'data-type="laser"' in html and "tone-ok" in html
+
+    def test_no_configs_tree_means_plain_composers(self, tmp_path: Path) -> None:
+        """Without --processing-configs there is no checkout to read templates from."""
+        client = TestClient(
+            create_app(
+                FakeCatalog(),
+                default_experiment="Undulator",
+                scan_log=True,
+                notes_db=tmp_path / "logbook.db",
+            )
+        )
+        html = client.get("/log/month/2026-09").text
+        assert client.get("/log/month/2026-09").status_code == 200
+        assert "typebtn" not in html

--- a/GeecsLogbook/CHANGELOG.md
+++ b/GeecsLogbook/CHANGELOG.md
@@ -58,6 +58,9 @@ The ops book: the second book gets its page, and entries get types.
   day page filters scans and was carrying a third copy of every body.
 - `TEMPLATES_DIRNAME` lives in `seed_templates` and the portal imports it;
   `PageSeeds` is a model rather than a dict.
+- An entry no longer shows a tag chip for a tag its type's prefill
+  carries ("Laser" beside "#laser" said one thing twice — owner's
+  hand-test). Tags the author added, or typed with no type, keep theirs.
 
 ## [0.4.0] - 2026-09-11
 

--- a/GeecsLogbook/CHANGELOG.md
+++ b/GeecsLogbook/CHANGELOG.md
@@ -41,6 +41,24 @@ The ops book: the second book gets its page, and entries get types.
   and sends `template` with a create.
 - `CLAUDE.md`: the owed ScanPaths review is filed as #839.
 
+### Fixed (review of #842)
+
+- The month page no longer runs the mirror sync on its request thread —
+  that put a share write on the one page whose promise is that the share
+  is never on its path; the day page pays the mirror debt (pinned).
+- An attachment autosave on the month composer pins the entry's day, so
+  the date picker locks once the entry exists instead of a later change
+  being silently ignored on Save; "+ note" respects the lock.
+- A template file named `blank`, `scan_note` or `day_intro` is refused
+  (`RESERVED_NAMES`): it would have put a chip on every hand-typed entry.
+  The names the pages render quietly come from the same constant.
+- `/log/month/9999-12` and `0001-01` are 400s, not 500s (their neighbour
+  month cannot exist).
+- The filter haystack (`data-hay`) is emitted only on the month page; the
+  day page filters scans and was carrying a third copy of every body.
+- `TEMPLATES_DIRNAME` lives in `seed_templates` and the portal imports it;
+  `PageSeeds` is a model rather than a dict.
+
 ## [0.4.0] - 2026-09-11
 
 The editor: what makes people use it.

--- a/GeecsLogbook/CHANGELOG.md
+++ b/GeecsLogbook/CHANGELOG.md
@@ -58,6 +58,9 @@ The ops book: the second book gets its page, and entries get types.
   day page filters scans and was carrying a third copy of every body.
 - `TEMPLATES_DIRNAME` lives in `seed_templates` and the portal imports it;
   `PageSeeds` is a model rather than a dict.
+- After an attachment autosave the type buttons lock along with the date
+  picker: an edit carries no `template`, so a type pressed after the
+  entry existed would show on screen and not in the store (Codex review).
 - An entry no longer shows a tag chip for a tag its type's prefill
   carries ("Laser" beside "#laser" said one thing twice — owner's
   hand-test). Tags the author added, or typed with no type, keep theirs.

--- a/GeecsLogbook/CHANGELOG.md
+++ b/GeecsLogbook/CHANGELOG.md
@@ -4,6 +4,43 @@ All notable changes to `geecs-logbook` are documented here. The format
 follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and this
 project adheres to semantic versioning.
 
+## [0.5.0] - 2026-09-11
+
+The ops book: the second book gets its page, and entries get types.
+
+### Added
+
+- `GET /log/month/{YYYY-MM}` — the ops book: every `ops` entry in the
+  month grouped by day, newest day first, one composer with a date
+  picker, prev/next month and a month picker, and tag chips that filter
+  through the URL (`?tag=laser`; chips count the whole month while the
+  list shows the filtered part). Reads only the notes store — never the
+  share — so it stays fast when the share is slow (pinned).
+  `GET /log/api/month/{YYYY-MM}/entries?book=&tag=` is its JSON peer.
+- **Seed templates as type buttons** (`seed_templates.py`): `*.md` files
+  in a directory the host names (`create_log_router(templates_dir=)`;
+  the portal points it at `logbook_templates/` in the configs checkout).
+  Front-matter `label` / `colour` / `book` / `order`, body = the prefill
+  with its `#tag`. A button press inserts the prefill and the entry
+  records the template's name as provenance; a stored entry shows its
+  template as a chip in the file's tone. `colour` is a theme token name
+  from a closed vocabulary (`TONES`, pinned against the stylesheet), never
+  a literal. Read once at start, refreshed in the background when stale;
+  a failed refresh keeps the last set. `examples/logbook_templates/` is
+  the documented starter set.
+- Cross-links between the books: the day page's "N ops notes today →"
+  strip (into the month page's day heading) and an "Ops book" link in its
+  topbar; each day on the month page links to its day document.
+
+### Changed
+
+- The entry and composer markup moved into shared macros
+  (`templates/_entries.html`) so both pages draw them identically.
+- `editor.js` takes the day per form (a `.when` date input or `data-day`,
+  falling back to the page's), reads the prefills from one JSON block,
+  and sends `template` with a create.
+- `CLAUDE.md`: the owed ScanPaths review is filed as #839.
+
 ## [0.4.0] - 2026-09-11
 
 The editor: what makes people use it.

--- a/GeecsLogbook/CLAUDE.md
+++ b/GeecsLogbook/CLAUDE.md
@@ -143,11 +143,25 @@ package. Rules the store enforces, each pinned in `tests/test_store.py`:
 `body_md` is opaque: `render.render_markdown` (markdown-it + nh3) is the
 only thing that reads it, and only to draw it — plus the tag scan.
 
+## The ops book reads by month, from the store alone
+
+`/log/month/2026-09` is the other book: every `ops` entry in the month,
+grouped by day, newest day first, with the tag chips as URL filters
+(`?tag=laser`) and one composer that takes a date. It reads **only the
+database** — `NotesStore.query`, one call — and never the share, which is
+the point: on a day the share is slow, this page is not (pinned in
+`tests/test_month.py`, which makes the share reader explode). The two
+books point at each other: the day page carries "N ops notes today →"
+into the month's day heading, and every day group on the month page
+links to its day document. The pages share one set of Jinja macros
+(`templates/_entries.html`): an entry and a composer look the same in
+either book, and the editor script meets one shape of form.
+
 ## The editor
 
 `static/editor.js` is the whole write path in the browser, one
 implementation for every composer (per scan, per gap, the day, in-place
-edits, and the month page next). It is deliberately **not** a WYSIWYG
+edits, and the month page). It is deliberately **not** a WYSIWYG
 editor: the toolbar writes markdown around the selection and the body
 stays the plain text the mirror holds. The two things people actually
 need — paste a screenshot, paste a spreadsheet — are events on the
@@ -160,8 +174,10 @@ is pasted as text; spreadsheet apps supply the HTML form, which has no
 such rule). A brand-new entry has no id until saved, so
 the first attachment saves it first ("autosaved", with Discard); Save is
 then an edit. The page hands the script its facts through
-`<main id="logbook" data-api data-day data-book>`; nothing is templated
-into the script. It sets no colours (the theme guard's rule).
+`<main id="logbook" data-api data-day data-book>` and the type prefills
+through one JSON block; nothing is templated into the script. A form on
+a page with no single day (the month page) carries its own `.when` date
+input. It sets no colours (the theme guard's rule).
 
 ## Status is reported, not inferred
 
@@ -202,14 +218,37 @@ fact on a card, and it is the thing nobody remembers three weeks later.
 
 ## Templates seed, they never enforce
 
-(Phase 03.) A template supplies the *initial text* of an entry body. The body
-is one opaque markdown string; first save is copy-on-write and the text is
-then entirely the author's. Changing a template never alters an existing
-entry.
+A template supplies the *initial text* of an entry body. The body is one
+opaque markdown string; first save is copy-on-write and the text is then
+entirely the author's. Changing a template never alters an existing
+entry — the entry keeps only the template's *name* (`template`), as
+provenance.
 
 Do **not** store entries as structured fields keyed by template headings.
 That is the trap: it makes a template edit retroactively change or hide
 historical content, and turns every "can we add a field" into a migration.
+
+**Templates are data, not code** (`seed_templates.py`): `*.md` files in
+`logbook_templates/` at the top of the configs checkout the portal
+already reads — the parent of its `--processing-configs` tree. Each file
+is a `key: value` header between `---` lines (`label`, `colour`, `book`,
+`order`, all optional) and a body that is the prefill, carrying the
+type's `#tag` so the button and a typed tag are the same thing. Adding a
+file adds a button on the composers of the book(s) it names; no code
+change, no restart (the set is re-read in the background when stale, and
+a failed re-read keeps the last set — the share is never on a page's
+critical path). `examples/logbook_templates/` is the documented set to
+copy into the configs repo.
+
+`colour` is a **theme token name** from the closed vocabulary
+`seed_templates.TONES` (`accent`, `ok`, `warn`, `crit`, `agent`,
+`muted`, `trace-1`…`trace-4`), never a literal: the page turns it into a
+`.tone-<name>` class whose value is `var(--<name>)`, so a type follows
+whichever palette the viewer picked and GeecsWebTheme's literal-colour
+guard stays true for a value it cannot see. `tests/test_seed_templates.py`
+pins the vocabulary against the stylesheet in both directions; an unknown
+name falls back to `accent` with a warning rather than dropping the
+button.
 
 ## Deferred decisions — do not re-litigate, do not lose
 
@@ -235,11 +274,11 @@ that needs fixing. The parse itself **is** shared
 doing now. A little duplication in the day-walking and the summary model is
 accepted in exchange.
 
-**OWED, at the arc's merge to `master`:** file an issue to review
-`ScanPaths` / `ScanData` and extract their pure parts into path-free
-utilities. This package's `scan_reader` is a sketch of what that looks
-like. Do not let the arc land without filing it — the whole point of
-accepting duplication now is that someone later removes it.
+**Filed as #839** (2026-09-11): review `ScanPaths` / `ScanData` and
+extract their pure parts into path-free utilities. This package's
+`scan_reader` is a sketch of what that looks like. The whole point of
+accepting duplication now is that someone later removes it — the issue
+is where that is tracked.
 
 ### Also deferred, no due date
 
@@ -252,7 +291,8 @@ accepting duplication now is that someone later removes it.
 | Off-site reading | The mirror tree is one folder, so a text-only `git push` of it to a private repository is cheap whenever wanted; the Google Doc exporter (blocked on credential rotation) is the route that carries images. Neither is needed for a functional logbook. |
 | The scan index | A month-partitioned redevelopment of `geecs_data_utils.scans_database` with an `update(day)` entry point, the portal as its writer. Parked by the owner (2026-09-11) until the two books are live. |
 | `EntryCreate` (the write shape) lives in the router, `LogEntry` (the stored shape) in `geecs_schemas` | An agent posts the create shape, so it belongs beside `LogEntry` for GEECS-MCP to validate. Moves with the agent-verbs phase, which is its first second consumer. |
-| A third private atomic-write helper (`_fs.replace_with`; `scan_analysis.config_store` and `task_queue` have their own) and `logbook_root` re-deriving the daily folder | Fold into the `ScanPaths`/`ScanData` review owed at master-merge — same home, same issue. |
+| A third private atomic-write helper (`_fs.replace_with`; `scan_analysis.config_store` and `task_queue` have their own) and `logbook_root` re-deriving the daily folder | Fold into the `ScanPaths`/`ScanData` review, #839 — same home, same issue. |
+| Which template "started" an entry when several buttons were pressed | The last one pressed is recorded. Provenance only; nothing reads it back but the chip. |
 
 ## Deployment
 
@@ -266,9 +306,10 @@ behind the portal's `log` extra and its `--scan-log` flag. It rides the
 portal's existing checkout and systemd unit. `--notes-db` names the SQLite
 file (the portal defaults it to systemd's `StateDirectory`); uploads go
 to `attachments/` beside it. Without a store the router has no write
-routes at all. The routes live in `routes/` — `day`, `entries`,
-`attachments`, one module per concern — and `router.create_log_router`
-only assembles them.
+routes at all. `templates_dir` names the seed-template directory (the
+portal derives it from its configs tree). The routes live in `routes/`
+— `day`, `month`, `entries`, `attachments`, one module per concern — and
+`router.create_log_router` only assembles them.
 
 `create_log_router` takes the experiment explicitly — this package carries no
 facility default, per the "facility values have one home" invariant.

--- a/GeecsLogbook/CLAUDE.md
+++ b/GeecsLogbook/CLAUDE.md
@@ -293,6 +293,7 @@ is where that is tracked.
 | `EntryCreate` (the write shape) lives in the router, `LogEntry` (the stored shape) in `geecs_schemas` | An agent posts the create shape, so it belongs beside `LogEntry` for GEECS-MCP to validate. Moves with the agent-verbs phase, which is its first second consumer. |
 | A third private atomic-write helper (`_fs.replace_with`; `scan_analysis.config_store` and `task_queue` have their own) and `logbook_root` re-deriving the daily folder | Fold into the `ScanPaths`/`ScanData` review, #839 — same home, same issue. |
 | Which template "started" an entry when several buttons were pressed | The last one pressed is recorded. Provenance only; nothing reads it back but the chip. |
+| `seed_templates.parse_template` is the package's first front-matter reader, while `mirror.render` is its writer | One reader, one writer, different shapes today (the template header has no lists). When the mirror *reader* lands (off-site/rebuild, deferred above), extract one `parse_front_matter` beside `mirror` and point both at it — not before there is a second caller. Waived in the review of #842. |
 
 ## Deployment
 

--- a/GeecsLogbook/README.md
+++ b/GeecsLogbook/README.md
@@ -1,10 +1,16 @@
 # GeecsLogbook
 
-The scan logbook: a day-document view over GEECS scan folders.
+The logbook: two books in one store, mounted by the Data Portal at `/log`.
 
-A day is a **query**, not a document — `/log/day/2026-09-11` lists whatever
-scans exist for that date at request time. Nothing creates a log; scans
-appear because their folders do.
+- **Scans** — `/log/day/2026-09-11`, a day-document view over GEECS scan
+  folders. A day is a **query**, not a document: the page lists whatever
+  scans exist for that date at request time. Nothing creates a log; scans
+  appear because their folders do.
+- **Ops** — `/log/month/2026-09`, routine operations read by month, from
+  the notes store alone (never the share), with tag filters.
+
+Type buttons on every composer come from `logbook_templates/*.md` in the
+configs checkout — see `examples/logbook_templates/README.md`.
 
 This package is a **consumer of scan folders** and never a producer. See
 the repository `CLAUDE.md` for the invariant.

--- a/GeecsLogbook/examples/logbook_templates/README.md
+++ b/GeecsLogbook/examples/logbook_templates/README.md
@@ -1,0 +1,30 @@
+# Seed templates — the logbook's type buttons
+
+Copy this directory to `logbook_templates/` at the top of the configs
+checkout the portal reads (the parent of the `--processing-configs`
+tree). Every `*.md` file here becomes a button on the composers; the file
+stem is what an entry records as its `template`.
+
+Format — a `key: value` header between `---` lines, then the prefill:
+
+```markdown
+---
+label: Laser
+colour: ok
+book: ops
+order: 10
+---
+#laser
+```
+
+| Key | Meaning | Default |
+|---|---|---|
+| `label` | button text | the stem, title-cased |
+| `colour` | a theme **token name**: `accent`, `ok`, `warn`, `crit`, `agent`, `muted`, `trace-1`…`trace-4` — never a literal colour | `accent` |
+| `book` | `scans`, `ops` or `both` — which composers offer it | `both` |
+| `order` | sort key for the button row | `100` |
+
+The body is the prefill. Keep the type's `#tag` in it: tags are read from
+the text at save, so a button press and a typed tag are the same thing.
+Templates seed, they never enforce — editing a file changes no stored
+entry. See `GeecsLogbook/CLAUDE.md` § "Templates seed, they never enforce".

--- a/GeecsLogbook/examples/logbook_templates/fault.md
+++ b/GeecsLogbook/examples/logbook_templates/fault.md
@@ -1,0 +1,13 @@
+---
+label: Fault
+colour: crit
+book: both
+order: 30
+---
+#fault
+
+**What failed:**
+
+**Impact:**
+
+**Fixed by / still open:**

--- a/GeecsLogbook/examples/logbook_templates/handover.md
+++ b/GeecsLogbook/examples/logbook_templates/handover.md
@@ -1,0 +1,13 @@
+---
+label: Handover
+colour: accent
+book: ops
+order: 20
+---
+#handover
+
+**State of the machine:**
+
+**Open problems:**
+
+**For the next shift:**

--- a/GeecsLogbook/examples/logbook_templates/laser.md
+++ b/GeecsLogbook/examples/logbook_templates/laser.md
@@ -1,0 +1,10 @@
+---
+label: Laser
+colour: ok
+book: ops
+order: 10
+---
+#laser
+
+- Energy / pointing / spectrum:
+- Changes made:

--- a/GeecsLogbook/examples/logbook_templates/maintenance.md
+++ b/GeecsLogbook/examples/logbook_templates/maintenance.md
@@ -1,0 +1,11 @@
+---
+label: Maintenance
+colour: warn
+book: ops
+order: 40
+---
+#maintenance
+
+**Done:**
+
+**Next due:**

--- a/GeecsLogbook/examples/logbook_templates/result.md
+++ b/GeecsLogbook/examples/logbook_templates/result.md
@@ -1,0 +1,11 @@
+---
+label: Result
+colour: trace-1
+book: scans
+order: 10
+---
+#result
+
+**Finding:**
+
+**Figure:** paste or drop it here.

--- a/GeecsLogbook/geecs_logbook/router.py
+++ b/GeecsLogbook/geecs_logbook/router.py
@@ -8,6 +8,8 @@ The routes live in :mod:`geecs_logbook.routes`, one module per concern:
 
 - ``routes.day`` — the scans book: the day document and its JSON peers.
   Always registered.
+- ``routes.month`` — the ops book: a month of day-level entries, read
+  from the store alone. Always registered (empty without a store).
 - ``routes.entries`` — the write verbs, the reason the logbook is a
   charter exception in the portal. Only with a store.
 - ``routes.attachments`` — uploads, stored on the host and served from
@@ -29,8 +31,9 @@ from fastapi.templating import Jinja2Templates
 
 from geecs_logbook.attachments import AttachmentStore
 from geecs_logbook.mirror import ATTACHMENTS_DIR
-from geecs_logbook.routes import attachments, day, entries
+from geecs_logbook.routes import attachments, day, entries, month
 from geecs_logbook.routes._common import TEMPLATES_DIR, Context, initials
+from geecs_logbook.seed_templates import SeedTemplates
 from geecs_logbook.store import NotesStore
 
 
@@ -38,6 +41,7 @@ def create_log_router(
     experiment: str,
     base_directory: Optional[Union[Path, str]] = None,
     notes_db: Optional[Union[Path, str]] = None,
+    templates_dir: Optional[Union[Path, str]] = None,
 ) -> APIRouter:
     """Build the logbook router.
 
@@ -53,6 +57,11 @@ def create_log_router(
         The SQLite file for commentary. Uploaded bytes go to an
         ``attachments/`` directory beside it. Without it the logbook is
         the read-only day view — no entries, no write routes.
+    templates_dir : Path or str, optional
+        A directory of ``*.md`` seed templates — the type buttons on every
+        composer (:mod:`geecs_logbook.seed_templates`). The portal points
+        this at ``logbook_templates/`` in the configs checkout it already
+        reads. Without it composers are plain.
 
     Returns
     -------
@@ -76,9 +85,11 @@ def create_log_router(
         store=store,
         attachments=blobs,
         templates=templates,
+        seeds=SeedTemplates(Path(templates_dir) if templates_dir else None),
     )
     router = APIRouter()
     day.register(router, ctx)
+    month.register(router, ctx)
     if store is not None:
         entries.register(router, ctx)
         attachments.register(router, ctx)

--- a/GeecsLogbook/geecs_logbook/routes/_common.py
+++ b/GeecsLogbook/geecs_logbook/routes/_common.py
@@ -1,10 +1,11 @@
 """What every route module shares: the mounted context and small helpers.
 
-The router is assembled from modules (day, entries, attachments — month
-next) that each take a :class:`Context` and register their routes on an
+The router is assembled from modules (day, month, entries, attachments)
+that each take a :class:`Context` and register their routes on an
 ``APIRouter``. The context carries the things ``create_log_router`` was
-given, the stores it built from them, and the two operations more than
-one module needs: reading a day off the share and mirroring an entry.
+given, the stores it built from them, and the operations more than one
+module needs: reading a day off the share, rendering a list of entries,
+and mirroring an entry.
 """
 
 from __future__ import annotations
@@ -12,9 +13,11 @@ from __future__ import annotations
 import logging
 import time
 from dataclasses import dataclass, field
+import calendar
+import re
 from datetime import date, datetime, timedelta
 from pathlib import Path
-from typing import Optional, Union
+from typing import Iterable, Optional, Union
 
 from fastapi import HTTPException, Request
 from fastapi.templating import Jinja2Templates
@@ -23,7 +26,9 @@ from geecs_schemas.log_entry import LogEntry
 from geecs_logbook import mirror
 from geecs_logbook.attachments import AttachmentStore
 from geecs_logbook.models import DaySummary
+from geecs_logbook.render import render_markdown
 from geecs_logbook.scan_reader import read_day
+from geecs_logbook.seed_templates import SeedTemplates
 from geecs_logbook.store import NotesStore
 
 logger = logging.getLogger(__name__)
@@ -66,6 +71,9 @@ class Context:
         Uploaded bytes, beside the database. Present exactly when ``store`` is.
     templates : Jinja2Templates
         The page templates, with the logbook's filters installed.
+    seeds : SeedTemplates
+        The type buttons — seed templates read from the configs checkout.
+        Empty when no directory was given.
     """
 
     experiment: str
@@ -73,6 +81,7 @@ class Context:
     store: Optional[NotesStore]
     attachments: Optional[AttachmentStore]
     templates: Jinja2Templates
+    seeds: SeedTemplates
     _last_sync: dict = field(default_factory=lambda: {"at": 0.0})
 
     @property
@@ -109,6 +118,32 @@ class Context:
         except Exception:  # noqa: BLE001 — a sync must never take down a view
             logger.exception("mirror sync failed")
 
+    def rendered(
+        self, request: Request, entries: Iterable[LogEntry]
+    ) -> list[RenderedEntry]:
+        """Render entries' bodies for a page, attachment links pointed at us."""
+        if self.store is None:
+            return []
+        base = attachment_base(request)
+        return [
+            RenderedEntry(e, render_markdown(e.body_md, attachment_base=base))
+            for e in entries
+        ]
+
+    def page_seeds(self, book: str) -> dict:
+        """What a page needs to draw type buttons and label stored entries.
+
+        ``buttons`` is the row for this book's composers; ``labels`` maps
+        every loaded template's name to its label and tone, so an entry
+        that started from a template offered in the *other* book (or one
+        since re-scoped) still shows its chip.
+        """
+        return {
+            "buttons": self.seeds.for_book(book),
+            "labels": self.seeds.by_name(),
+            "prefill": {t.name: t.body for t in self.seeds.current()},
+        }
+
     def mirror(self, entry_id: str) -> None:
         """Try to land one entry on the share; defer quietly if it cannot."""
         assert self.store is not None
@@ -139,6 +174,29 @@ def parse_day(raw: str) -> date:
         raise HTTPException(
             status_code=400, detail=f"day must be YYYY-MM-DD, got {raw!r}"
         ) from exc
+
+
+def parse_month(raw: str) -> date:
+    """Parse a ``YYYY-MM`` path segment into its first day, or 400."""
+    try:
+        if not re.fullmatch(r"\d{4}-\d{2}", raw):  # strptime takes "2026-9"
+            raise ValueError(raw)
+        return datetime.strptime(raw, "%Y-%m").date()
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=400, detail=f"month must be YYYY-MM, got {raw!r}"
+        ) from exc
+
+
+def month_last_day(first: date) -> date:
+    """Return the last date of the month ``first`` starts."""
+    return first.replace(day=calendar.monthrange(first.year, first.month)[1])
+
+
+def month_step(first: date, months: int) -> date:
+    """Return the first day of the month ``months`` away from ``first``."""
+    index = first.year * 12 + (first.month - 1) + months
+    return date(index // 12, index % 12 + 1, 1)
 
 
 def rail_days(centre: date) -> list[date]:
@@ -177,3 +235,9 @@ def api_base(request: Request) -> str:
     """``/log/api`` under whatever prefix the host mounted us at."""
     probe = request.url_for("_entries_json", day="0000-00-00").path
     return probe[: -len("/day/0000-00-00/entries")]
+
+
+def month_url(request: Request, day: date, *, anchor: bool = False) -> str:
+    """The month page holding ``day``; with ``anchor``, its day heading."""
+    path = request.url_for("_month_page", month=day.strftime("%Y-%m")).path
+    return f"{path}#day-{day.isoformat()}" if anchor else path

--- a/GeecsLogbook/geecs_logbook/routes/_common.py
+++ b/GeecsLogbook/geecs_logbook/routes/_common.py
@@ -28,7 +28,7 @@ from geecs_logbook.attachments import AttachmentStore
 from geecs_logbook.models import DaySummary
 from geecs_logbook.render import render_markdown
 from geecs_logbook.scan_reader import read_day
-from geecs_logbook.seed_templates import SeedTemplates
+from geecs_logbook.seed_templates import PageSeeds, SeedTemplates
 from geecs_logbook.store import NotesStore
 
 logger = logging.getLogger(__name__)
@@ -130,19 +130,9 @@ class Context:
             for e in entries
         ]
 
-    def page_seeds(self, book: str) -> dict:
-        """What a page needs to draw type buttons and label stored entries.
-
-        ``buttons`` is the row for this book's composers; ``labels`` maps
-        every loaded template's name to its label and tone, so an entry
-        that started from a template offered in the *other* book (or one
-        since re-scoped) still shows its chip.
-        """
-        return {
-            "buttons": self.seeds.for_book(book),
-            "labels": self.seeds.by_name(),
-            "prefill": {t.name: t.body for t in self.seeds.current()},
-        }
+    def page_seeds(self, book: str) -> PageSeeds:
+        """What a page needs to draw type buttons and label stored entries."""
+        return self.seeds.for_page(book)
 
     def mirror(self, entry_id: str) -> None:
         """Try to land one entry on the share; defer quietly if it cannot."""
@@ -181,7 +171,10 @@ def parse_month(raw: str) -> date:
     try:
         if not re.fullmatch(r"\d{4}-\d{2}", raw):  # strptime takes "2026-9"
             raise ValueError(raw)
-        return datetime.strptime(raw, "%Y-%m").date()
+        first = datetime.strptime(raw, "%Y-%m").date()
+        if not 1 < first.year < 9999:  # prev/next month must exist too
+            raise ValueError(raw)
+        return first
     except ValueError as exc:
         raise HTTPException(
             status_code=400, detail=f"month must be YYYY-MM, got {raw!r}"

--- a/GeecsLogbook/geecs_logbook/routes/day.py
+++ b/GeecsLogbook/geecs_logbook/routes/day.py
@@ -18,14 +18,13 @@ from fastapi.responses import FileResponse, HTMLResponse, RedirectResponse
 from geecs_schemas.log_entry import Book, LogEntry
 
 from geecs_logbook.models import DaySummary
-from geecs_logbook.render import render_markdown
 from geecs_logbook.routes.attachments import ATTACHMENT_TYPES
 from geecs_logbook.routes._common import (
     STATIC_DIR,
     Context,
     RenderedEntry,
     api_base,
-    attachment_base,
+    month_url,
     parse_day,
     rail_days,
 )
@@ -38,11 +37,9 @@ def register(router: APIRouter, ctx: Context) -> None:
         """The scans book's entries for a day, rendered and keyed by anchor."""
         if ctx.store is None:
             return {}
-        base = attachment_base(request)
         out: dict[str, list[RenderedEntry]] = {}
-        for entry in ctx.store.for_day(day, book="scans"):
-            html = render_markdown(entry.body_md, attachment_base=base)
-            out.setdefault(entry.anchor, []).append(RenderedEntry(entry, html))
+        for r in ctx.rendered(request, ctx.store.for_day(day, book="scans")):
+            out.setdefault(r.entry.anchor, []).append(r)
         return out
 
     @router.get("/", response_class=RedirectResponse)
@@ -74,6 +71,8 @@ def register(router: APIRouter, ctx: Context) -> None:
         summary = ctx.load_day(when)
         ctx.maybe_sync()
         entries = grouped(request, day)
+        # The other book's count is the cross-link: "3 ops notes today →".
+        ops_count = len(ctx.store.for_day(day, book="ops")) if ctx.store else 0
         return ctx.templates.TemplateResponse(
             request=request,
             name="day.html",
@@ -86,9 +85,13 @@ def register(router: APIRouter, ctx: Context) -> None:
                 "next_day": when + timedelta(days=1),
                 "entries": entries,
                 "entry_count": sum(len(v) for v in entries.values()),
+                "ops_count": ops_count,
+                "month_url": month_url(request, when),
+                "ops_url": month_url(request, when, anchor=True),
                 "writable": ctx.writable,
                 "api_base": api_base(request),
                 "accept": ",".join(sorted(ATTACHMENT_TYPES)),
+                "seeds": ctx.page_seeds("scans"),
             },
         )
 

--- a/GeecsLogbook/geecs_logbook/routes/month.py
+++ b/GeecsLogbook/geecs_logbook/routes/month.py
@@ -1,0 +1,124 @@
+"""The ops book: a month of day-level entries, read from the store alone.
+
+``GET /log/month/{YYYY-MM}``                 the month page (``?tag=`` filters)
+``GET /log/api/month/{YYYY-MM}/entries``     the month's entries as JSON
+
+The scans book is a day document over scan folders; the ops book is what
+happened around them — laser notes, maintenance, a shift handover — and
+it reads by month. Nothing here touches the share: the page is one
+database query, grouped by day, newest day first. That is its value on a
+bad day: when the share is slow the month page is not.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from datetime import date
+from typing import Optional
+
+from fastapi import APIRouter, Query, Request
+from fastapi.responses import HTMLResponse
+from geecs_schemas.log_entry import Book, LogEntry
+
+from geecs_logbook.routes.attachments import ATTACHMENT_TYPES
+from geecs_logbook.routes._common import (
+    Context,
+    RenderedEntry,
+    api_base,
+    month_last_day,
+    month_step,
+    parse_month,
+)
+
+#: The book the month page shows. The scans book has its own page.
+BOOK = "ops"
+
+
+def register(router: APIRouter, ctx: Context) -> None:
+    """Add the month routes to ``router``."""
+
+    def month_entries(first: date, last: date, **filters: object) -> list[LogEntry]:
+        if ctx.store is None:
+            return []
+        return ctx.store.query(
+            day_from=first.isoformat(),
+            day_to=last.isoformat(),
+            book=BOOK,
+            **filters,  # type: ignore[arg-type]
+        )
+
+    @router.get("/month/{month}", response_class=HTMLResponse)
+    def _month_page(
+        request: Request, month: str, tag: Optional[str] = Query(None, max_length=32)
+    ) -> HTMLResponse:
+        """Render one month of the ops book."""
+        first = parse_month(month)
+        last = month_last_day(first)
+        today = date.today()
+        ctx.maybe_sync()
+
+        # One query for the month; the tag chips count the whole month
+        # while the list shows the filtered part, so a chip never reads
+        # "0" for a tag that is right there.
+        everything = month_entries(first, last)
+        tag_counts = Counter(t for e in everything for t in e.tags)
+        active = tag.lower() if tag else None
+        shown = [e for e in everything if active is None or active in e.tags]
+
+        days: dict[str, list[RenderedEntry]] = {}
+        for r in ctx.rendered(request, shown):
+            days.setdefault(r.entry.day, []).append(r)
+        grouped = [
+            (date.fromisoformat(d), rs) for d, rs in sorted(days.items(), reverse=True)
+        ]
+
+        if first <= today <= last:
+            compose_day = today
+        elif today < first:
+            compose_day = first
+        else:
+            compose_day = last
+
+        return ctx.templates.TemplateResponse(
+            request=request,
+            name="month.html",
+            context={
+                "experiment": ctx.experiment,
+                "first": first,
+                "last": last,
+                "prev_month": month_step(first, -1),
+                "next_month": month_step(first, 1),
+                "today": today,
+                "days": grouped,
+                "entry_count": len(shown),
+                "month_count": len(everything),
+                "tags": sorted(tag_counts.items(), key=lambda kv: (-kv[1], kv[0])),
+                "active_tag": active,
+                "compose_day": compose_day,
+                "writable": ctx.writable,
+                "api_base": api_base(request),
+                "accept": ",".join(sorted(ATTACHMENT_TYPES)),
+                "seeds": ctx.page_seeds(BOOK),
+            },
+        )
+
+    @router.get("/api/month/{month}/entries")
+    def _month_json(
+        month: str,
+        book: Book = BOOK,
+        tag: Optional[str] = Query(None, max_length=32),
+    ) -> list[LogEntry]:
+        """Return one month's entries as JSON, oldest first.
+
+        ``?book=scans`` reads the other book (day-level and scan-anchored
+        alike); ``?tag=`` narrows to entries carrying that tag.
+        """
+        first = parse_month(month)
+        if ctx.store is None:
+            return []
+        return ctx.store.query(
+            day_from=first.isoformat(),
+            day_to=month_last_day(first).isoformat(),
+            book=book,
+            tag=tag,
+        )

--- a/GeecsLogbook/geecs_logbook/routes/month.py
+++ b/GeecsLogbook/geecs_logbook/routes/month.py
@@ -37,14 +37,11 @@ BOOK = "ops"
 def register(router: APIRouter, ctx: Context) -> None:
     """Add the month routes to ``router``."""
 
-    def month_entries(first: date, last: date, **filters: object) -> list[LogEntry]:
+    def month_entries(first: date, last: date) -> list[LogEntry]:
         if ctx.store is None:
             return []
         return ctx.store.query(
-            day_from=first.isoformat(),
-            day_to=last.isoformat(),
-            book=BOOK,
-            **filters,  # type: ignore[arg-type]
+            day_from=first.isoformat(), day_to=last.isoformat(), book=BOOK
         )
 
     @router.get("/month/{month}", response_class=HTMLResponse)
@@ -55,7 +52,9 @@ def register(router: APIRouter, ctx: Context) -> None:
         first = parse_month(month)
         last = month_last_day(first)
         today = date.today()
-        ctx.maybe_sync()
+        # No ctx.maybe_sync() here, deliberately: the sync writes to the
+        # share on the request thread, and this page's promise is that the
+        # share is never on its path. The day page pays the mirror debt.
 
         # One query for the month; the tag chips count the whole month
         # while the list shows the filtered part, so a chip never reads

--- a/GeecsLogbook/geecs_logbook/seed_templates.py
+++ b/GeecsLogbook/geecs_logbook/seed_templates.py
@@ -78,6 +78,16 @@ TONES: tuple[str, ...] = (
     "trace-4",
 )
 
+#: Where the files live: this directory at the top of the configs checkout
+#: (the portal derives it from its analysis tree's parent).
+TEMPLATES_DIRNAME = "logbook_templates"
+
+#: Template names an entry carries without a button: what the composer
+#: sends when none was pressed, and two the pages render quietly. A file
+#: with one of these stems is refused, or every hand-typed entry would
+#: wear its chip.
+RESERVED_NAMES: tuple[str, ...] = ("blank", "scan_note", "day_intro")
+
 #: A template's name is its file stem, and it is stored on every entry that
 #: started from it — so it is bounded like ``LogEntry.template``.
 _NAME = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_-]{0,63}$")
@@ -174,6 +184,13 @@ def load_templates(directory: Path) -> list[SeedTemplate]:
     for path in sorted(directory.glob("*.md")):
         if path.stem.upper() == "README":  # a browsed directory has one
             continue
+        if path.stem in RESERVED_NAMES:
+            logger.warning(
+                "logbook template %s: %r is reserved for entries with no template; skipped",
+                path.name,
+                path.stem,
+            )
+            continue
         if not _NAME.match(path.stem):
             logger.warning(
                 "logbook template %s: name is not usable; skipped", path.name
@@ -187,6 +204,22 @@ def load_templates(directory: Path) -> list[SeedTemplate]:
             )
     found.sort(key=lambda t: (t.order, t.label.lower(), t.name))
     return found
+
+
+class PageSeeds(BaseModel):
+    """What a page needs to draw type buttons and label stored entries.
+
+    ``buttons`` is the row for one book's composers; ``labels`` maps every
+    loaded template's name to itself, so an entry that started from a
+    template offered in the *other* book (or one since re-scoped) still
+    shows its chip; ``prefill`` is the one JSON block the editor reads;
+    ``quiet`` are the names rendered without a chip.
+    """
+
+    buttons: list[SeedTemplate] = Field(default_factory=list)
+    labels: dict[str, SeedTemplate] = Field(default_factory=dict)
+    prefill: dict[str, str] = Field(default_factory=dict)
+    quiet: tuple[str, ...] = RESERVED_NAMES
 
 
 class SeedTemplates:
@@ -250,3 +283,12 @@ class SeedTemplates:
     def by_name(self) -> dict[str, SeedTemplate]:
         """Return the loaded set keyed by name, for labelling stored entries."""
         return {t.name: t for t in self.current()}
+
+    def for_page(self, book: str) -> PageSeeds:
+        """Return what a page for ``book`` needs, from one read of the set."""
+        current = self.current()
+        return PageSeeds(
+            buttons=[t for t in current if t.offered_in(book)],
+            labels={t.name: t for t in current},
+            prefill={t.name: t.body for t in current},
+        )

--- a/GeecsLogbook/geecs_logbook/seed_templates.py
+++ b/GeecsLogbook/geecs_logbook/seed_templates.py
@@ -1,0 +1,252 @@
+"""Seed templates: the type buttons, read from a directory of markdown files.
+
+A *type* of entry — a laser note, a shift handover, a fault — is a
+template file in the configs checkout the portal already reads::
+
+    logbook_templates/
+      laser.md
+      handover.md
+      fault.md
+
+Each file is a small front-matter header and a body::
+
+    ---
+    label: Laser
+    colour: ok
+    book: ops
+    order: 10
+    ---
+    ### Laser
+    #laser
+
+The **body** is the prefill: pressing the button puts it in the composer
+and the author types from there. It carries the type's ``#tag`` so a
+button press and a typed tag are the same thing (see
+:mod:`geecs_logbook.tags`). The entry records the file's stem as its
+``template`` — provenance, never structure: the body is the author's from
+the first save and a later edit to the file changes no stored entry.
+Templates seed; they never enforce.
+
+The header keys, all optional:
+
+``label``
+    The button's text. Default: the stem, title-cased.
+``colour``
+    A *theme token name* — one of :data:`TONES` — never a literal colour,
+    so the button and the chip follow whichever palette the viewer picked
+    (GeecsWebTheme's guard walks the stylesheet, not the configs repo, so
+    the vocabulary is closed here). An unknown name falls back to
+    ``accent`` with a warning rather than dropping the button.
+``book``
+    ``scans``, ``ops`` or ``both`` (default): which composers offer it.
+``order``
+    Sort key for the button row; ties by label.
+
+Adding a file adds a button; no code change. The directory is on the
+share, so it is read once at start and refreshed in the background when
+stale — a page never waits on the share for its buttons, and a failed
+refresh keeps the last good set.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+import threading
+import time
+from pathlib import Path
+from typing import Literal, Optional
+
+from pydantic import BaseModel, Field
+
+logger = logging.getLogger(__name__)
+
+#: The colour vocabulary a template may name. Each is a GeecsWebTheme token
+#: with a ``.tone-<name>`` rule in ``scanlog.css`` (pinned by test), which
+#: is how a name in a file becomes a colour on the page without a literal
+#: anywhere.
+TONES: tuple[str, ...] = (
+    "accent",
+    "ok",
+    "warn",
+    "crit",
+    "agent",
+    "muted",
+    "trace-1",
+    "trace-2",
+    "trace-3",
+    "trace-4",
+)
+
+#: A template's name is its file stem, and it is stored on every entry that
+#: started from it — so it is bounded like ``LogEntry.template``.
+_NAME = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_-]{0,63}$")
+
+#: How long a loaded set is served before a background refresh is kicked.
+REFRESH_INTERVAL_S = 60.0
+
+TemplateBook = Literal["scans", "ops", "both"]
+
+
+class SeedTemplate(BaseModel):
+    """One type button: what it is called, how it is coloured, what it inserts."""
+
+    name: str = Field(description="The file stem; stored as the entry's template.")
+    label: str = Field(description="Button text.")
+    colour: str = Field("accent", description="A theme token name from TONES.")
+    book: TemplateBook = Field("both", description="Which book's composers offer it.")
+    order: int = Field(100, description="Button row sort key.")
+    body: str = Field("", description="The prefill, with its #tag.")
+
+    def offered_in(self, book: str) -> bool:
+        """Whether this template belongs on ``book``'s composers."""
+        return self.book == "both" or self.book == book
+
+
+def parse_template(name: str, text: str) -> SeedTemplate:
+    """Parse one template file's text.
+
+    The header is ``key: value`` lines between two ``---`` lines, read
+    without a YAML library so the format stays exactly what the docstring
+    says. A file with no header is all body.
+    """
+    header: dict[str, str] = {}
+    body = text
+    lines = text.splitlines()
+    if lines and lines[0].strip() == "---":
+        for i, line in enumerate(lines[1:], start=1):
+            if line.strip() == "---":
+                body = "\n".join(lines[i + 1 :])
+                break
+            key, sep, value = line.partition(":")
+            if sep and key.strip():
+                header[key.strip().lower()] = value.strip()
+        else:  # an opening fence with no close: the whole file is body
+            header = {}
+            body = text
+
+    colour = header.get("colour", header.get("color", "accent")).lower()
+    if colour not in TONES:
+        logger.warning(
+            "logbook template %s: colour %r is not a theme tone (%s); using accent",
+            name,
+            colour,
+            ", ".join(TONES),
+        )
+        colour = "accent"
+    book = header.get("book", "both").lower()
+    if book not in ("scans", "ops", "both"):
+        logger.warning(
+            "logbook template %s: book %r is not scans/ops/both; offering in both",
+            name,
+            book,
+        )
+        book = "both"
+    try:
+        order = int(header.get("order", "100"))
+    except ValueError:
+        logger.warning(
+            "logbook template %s: order %r is not a number", name, header["order"]
+        )
+        order = 100
+    label = header.get("label") or name.replace("_", " ").replace("-", " ").title()
+    return SeedTemplate(
+        name=name,
+        label=label,
+        colour=colour,
+        book=book,  # type: ignore[arg-type]
+        order=order,
+        body=body.lstrip("\n").rstrip() + ("\n" if body.strip() else ""),
+    )
+
+
+def load_templates(directory: Path) -> list[SeedTemplate]:
+    """Read every ``*.md`` in ``directory``, sorted for the button row.
+
+    A file whose stem is not a valid template name is skipped with a
+    warning, and a ``README.md`` silently — the directory is meant to be
+    browsed. A missing directory is an empty set, not an error: a site
+    without templates has plain composers.
+    """
+    if not directory.is_dir():
+        return []
+    found: list[SeedTemplate] = []
+    for path in sorted(directory.glob("*.md")):
+        if path.stem.upper() == "README":  # a browsed directory has one
+            continue
+        if not _NAME.match(path.stem):
+            logger.warning(
+                "logbook template %s: name is not usable; skipped", path.name
+            )
+            continue
+        try:
+            found.append(parse_template(path.stem, path.read_text(encoding="utf-8")))
+        except OSError as exc:
+            logger.warning(
+                "logbook template %s: unreadable (%s); skipped", path.name, exc
+            )
+    found.sort(key=lambda t: (t.order, t.label.lower(), t.name))
+    return found
+
+
+class SeedTemplates:
+    """The current template set, refreshed in the background when stale.
+
+    Parameters
+    ----------
+    directory : Path, optional
+        Where the ``*.md`` files live. ``None`` means no templates at all —
+        the set is empty and nothing is ever read.
+
+    The first load is synchronous, so the process starts with its buttons;
+    after that a request that finds the set older than
+    :data:`REFRESH_INTERVAL_S` kicks one daemon thread to re-read the
+    directory and returns the set it has. The share is never on a page's
+    critical path, which is the month page's whole promise.
+    """
+
+    def __init__(self, directory: Optional[Path]) -> None:
+        self.directory = Path(directory) if directory else None
+        self._templates: list[SeedTemplate] = []
+        self._loaded_at = 0.0
+        self._lock = threading.Lock()
+        self._refreshing = False
+        if self.directory is not None:
+            self._refresh()
+
+    def _refresh(self) -> None:
+        try:
+            fresh = load_templates(self.directory)  # type: ignore[arg-type]
+        except Exception:  # noqa: BLE001 — keep the last set; the share may be down
+            logger.exception("logbook templates: refresh of %s failed", self.directory)
+        else:
+            with self._lock:
+                self._templates = fresh
+        finally:
+            with self._lock:
+                self._loaded_at = time.monotonic()
+                self._refreshing = False
+
+    def current(self) -> list[SeedTemplate]:
+        """Return the loaded set, refreshing in the background if stale."""
+        if self.directory is None:
+            return []
+        with self._lock:
+            stale = time.monotonic() - self._loaded_at >= REFRESH_INTERVAL_S
+            kick = stale and not self._refreshing
+            if kick:
+                self._refreshing = True
+            templates = list(self._templates)
+        if kick:
+            threading.Thread(
+                target=self._refresh, name="logbook-templates", daemon=True
+            ).start()
+        return templates
+
+    def for_book(self, book: str) -> list[SeedTemplate]:
+        """Return the templates offered on ``book``'s composers."""
+        return [t for t in self.current() if t.offered_in(book)]
+
+    def by_name(self) -> dict[str, SeedTemplate]:
+        """Return the loaded set keyed by name, for labelling stored entries."""
+        return {t.name: t for t in self.current()}

--- a/GeecsLogbook/geecs_logbook/seed_templates.py
+++ b/GeecsLogbook/geecs_logbook/seed_templates.py
@@ -59,6 +59,8 @@ from typing import Literal, Optional
 
 from pydantic import BaseModel, Field
 
+from geecs_logbook.tags import parse_tags
+
 logger = logging.getLogger(__name__)
 
 #: The colour vocabulary a template may name. Each is a GeecsWebTheme token
@@ -107,6 +109,10 @@ class SeedTemplate(BaseModel):
     book: TemplateBook = Field("both", description="Which book's composers offer it.")
     order: int = Field(100, description="Button row sort key.")
     body: str = Field("", description="The prefill, with its #tag.")
+    tags: list[str] = Field(
+        default_factory=list,
+        description="The tags the prefill carries — what the type chip already says.",
+    )
 
     def offered_in(self, book: str) -> bool:
         """Whether this template belongs on ``book``'s composers."""
@@ -160,13 +166,15 @@ def parse_template(name: str, text: str) -> SeedTemplate:
         )
         order = 100
     label = header.get("label") or name.replace("_", " ").replace("-", " ").title()
+    body = body.lstrip("\n").rstrip() + ("\n" if body.strip() else "")
     return SeedTemplate(
         name=name,
         label=label,
         colour=colour,
         book=book,  # type: ignore[arg-type]
         order=order,
-        body=body.lstrip("\n").rstrip() + ("\n" if body.strip() else ""),
+        body=body,
+        tags=parse_tags(body),
     )
 
 

--- a/GeecsLogbook/geecs_logbook/static/editor.js
+++ b/GeecsLogbook/geecs_logbook/static/editor.js
@@ -1,9 +1,12 @@
 /* GeecsLogbook editor — everything a composer does, for every composer.
  *
  * One implementation serves the day page's per-scan, per-gap and day
- * composers, the in-place edit form, and (next) the month page. The page
- * hands it two facts through <main id="logbook" data-api data-day
- * data-book>; nothing else is templated into this file.
+ * composers, the in-place edit form, and the month page's composer. The
+ * page hands it its facts through <main id="logbook" data-api data-day
+ * data-book data-accept> and the type prefills through one JSON block
+ * (#logbook-seeds); nothing else is templated into this file. A form
+ * with no page-wide day (the month page) carries its own: a .when date
+ * input, or data-day.
  *
  * What it adds over a bare textarea:
  *   - a toolbar that writes markdown around the selection (no WYSIWYG —
@@ -16,6 +19,8 @@
  *   - paste a spreadsheet range (tab-separated, or an HTML table): it
  *     becomes a markdown table;
  *   - Preview, rendered by the server exactly as the page will show it;
+ *   - type buttons: a template's prefill lands in the textarea and the
+ *     entry records which template it started from;
  *   - ⌘/Ctrl+Enter saves.
  *
  * Styling is entirely through the page's tokens; this file sets no colours.
@@ -30,10 +35,20 @@
   const BOOK = host.dataset.book || "scans";
   const ACCEPT = (host.dataset.accept || "image/png,image/jpeg,image/gif,image/webp,application/pdf").split(",");
   const AUTHOR_KEY = "geecs.author";
+  const SEEDS = (() => {
+    const el = document.getElementById("logbook-seeds");
+    try { return el ? JSON.parse(el.textContent) : {}; } catch (e) { return {}; }
+  })();
 
   // ------------------------------------------------------------ plumbing
 
   const who = () => { try { return localStorage.getItem(AUTHOR_KEY) || ""; } catch (e) { return ""; } };
+
+  /** The day a form writes to: its own date field, its data-day, or the page's. */
+  function dayOf(form) {
+    const when = form.querySelector(".when");
+    return (when && when.value) || form.dataset.day || DAY || "";
+  }
   const remember = (name) => { try { localStorage.setItem(AUTHOR_KEY, name); } catch (e) { /* private window */ } };
 
   async function api(method, path, body) {
@@ -165,8 +180,15 @@
     if (form._creating) return form._creating;
     const name = authorName(form);
     if (!name) return Promise.reject(Object.assign(new Error("Enter your name first."), { silent: true }));
+    const day = dayOf(form);
+    if (!day) {
+      const when = form.querySelector(".when"); if (when) when.focus();
+      fail(form, { message: "Pick a day first." });
+      return Promise.reject(Object.assign(new Error("Pick a day first."), { silent: true }));
+    }
     const ta = form.querySelector(".ta");
-    const body = { day: DAY, book: BOOK, author: name, body_md: ta.value || "" };
+    const body = { day, book: BOOK, author: name, body_md: ta.value || "",
+      template: form.dataset.template || "blank" };
     if (form.dataset.after !== undefined && form.dataset.after !== "") body.after = Number(form.dataset.after);
     else if (form.dataset.scan !== undefined && form.dataset.scan !== "") body.scan = Number(form.dataset.scan);
     form._creating = api("POST", "/entries", body).then((entry) => {
@@ -244,6 +266,21 @@
       pane.innerHTML = data.html;
       pane.hidden = false; ta.hidden = true; btn.classList.add("is-on");
     } catch (err) { fail(form, err); }
+  }
+
+  // ---------------------------------------------------- type buttons
+
+  /** A template's prefill: replaces an empty textarea, else lands as a block. */
+  function applyType(form, name) {
+    const ta = form.querySelector(".ta");
+    const body = SEEDS[name];
+    if (body === undefined) return;
+    if (!ta.value.trim()) { ta.value = ""; ta.setSelectionRange(0, 0); }
+    insertBlock(ta, body.replace(/\n$/, ""), false);
+    // Provenance: which template the entry started from. The last one
+    // pressed wins; the body is the author's either way.
+    form.dataset.template = name;
+    form.querySelectorAll(".typebtn").forEach((b) => b.classList.toggle("is-on", b.dataset.type === name));
   }
 
   // --------------------------------------------------------- toolbar
@@ -392,6 +429,7 @@
     form.addEventListener("dragleave", () => form.classList.remove("dragover"));
     form.addEventListener("drop", (ev) => onDrop(form, ev));
     form.addEventListener("submit", (ev) => { ev.preventDefault(); save(form); });
+    form.querySelectorAll(".typebtn").forEach((b) => b.addEventListener("click", () => applyType(form, b.dataset.type)));
     ta.addEventListener("keydown", (ev) => {
       if ((ev.metaKey || ev.ctrlKey) && ev.key === "Enter") {
         ev.preventDefault();

--- a/GeecsLogbook/geecs_logbook/static/editor.js
+++ b/GeecsLogbook/geecs_logbook/static/editor.js
@@ -199,6 +199,12 @@
       // picker so a later change is not silently ignored (Discard frees it).
       const when = form.querySelector(".when");
       if (when) { when.disabled = true; when.title = "Saved on this day — Discard to pick another"; }
+      // Same for the type: the entry recorded its template at creation and
+      // an edit does not carry one, so a later press would show a type the
+      // store does not hold.
+      form.querySelectorAll(".typebtn").forEach((b) => {
+        b.disabled = true; b.title = "Saved as " + (form.dataset.template || "a plain note") + " — Discard to change the type";
+      });
       const discard = form.querySelector("[data-discard]");
       if (discard) discard.hidden = false;
       return entry.entry_id;
@@ -276,6 +282,7 @@
 
   /** A template's prefill: replaces an empty textarea, else lands as a block. */
   function applyType(form, name) {
+    if (form.dataset.entry) return; // saved already; its template is fixed
     const ta = form.querySelector(".ta");
     const body = SEEDS[name];
     if (body === undefined) return;

--- a/GeecsLogbook/geecs_logbook/static/editor.js
+++ b/GeecsLogbook/geecs_logbook/static/editor.js
@@ -195,6 +195,10 @@
       form.dataset.entry = entry.entry_id;
       form.dataset.version = String(entry.version);
       form.classList.add("autosaved");
+      // The entry now has its day; an edit cannot move it. Lock the
+      // picker so a later change is not silently ignored (Discard frees it).
+      const when = form.querySelector(".when");
+      if (when) { when.disabled = true; when.title = "Saved on this day — Discard to pick another"; }
       const discard = form.querySelector("[data-discard]");
       if (discard) discard.hidden = false;
       return entry.entry_id;

--- a/GeecsLogbook/geecs_logbook/static/scanlog.css
+++ b/GeecsLogbook/geecs_logbook/static/scanlog.css
@@ -278,3 +278,49 @@ details.campaign[hidden]{display:none}
 .figgrid{display:grid;grid-template-columns:repeat(auto-fit,minmax(200px,1fr));gap:10px;margin:8px 0}
 .figgrid figure{margin:0}
 .figgrid img{max-width:100%;margin:0;display:block}
+
+/* ---- types: seed templates as buttons and chips ----
+   .tone-<name> is the closed vocabulary a template file may name
+   (geecs_logbook.seed_templates.TONES, pinned by test): a name in the
+   configs repo becomes a token here, never a literal anywhere. */
+.tone-accent{--tone:var(--accent)} .tone-ok{--tone:var(--ok)} .tone-warn{--tone:var(--warn)}
+.tone-crit{--tone:var(--crit)} .tone-agent{--tone:var(--agent)} .tone-muted{--tone:var(--muted)}
+.tone-trace-1{--tone:var(--trace-1)} .tone-trace-2{--tone:var(--trace-2)}
+.tone-trace-3{--tone:var(--trace-3)} .tone-trace-4{--tone:var(--trace-4)}
+.chip-type{color:var(--tone);background:color-mix(in srgb,var(--tone) 14%,transparent);
+  border:1px solid color-mix(in srgb,var(--tone) 35%,transparent)}
+.types{display:flex;gap:5px;flex-wrap:wrap;margin-bottom:6px}
+.typebtn{font:inherit;font-size:11.5px;font-weight:500;color:var(--tone);background:var(--surface);
+  border:1px solid color-mix(in srgb,var(--tone) 45%,transparent);border-radius:20px;padding:2px 10px;cursor:pointer;line-height:1.5}
+.typebtn::before{content:"";display:inline-block;width:7px;height:7px;border-radius:50%;background:var(--tone);margin-right:6px;vertical-align:1px}
+.typebtn:hover,.typebtn.is-on{background:color-mix(in srgb,var(--tone) 14%,transparent);border-color:var(--tone)}
+.typebtn:focus-visible{outline:2px solid var(--accent);outline-offset:2px}
+
+/* ---- the two books: cross-links ---- */
+.booklink{text-decoration:none}
+.opsstrip{display:flex;align-items:center;gap:10px;padding:8px 14px;border:1px solid var(--rule);
+  border-left:3px solid var(--accent);border-radius:0 var(--r) var(--r) 0;background:var(--surface);
+  color:var(--ink);text-decoration:none;font-size:13px}
+.opsstrip:hover{border-color:var(--accent);color:var(--accent)}
+.opsstrip .tlabel{font-family:var(--ff-mono);font-size:10.5px;letter-spacing:.06em;text-transform:uppercase;color:var(--accent);font-weight:600}
+
+/* ---- the month page ---- */
+.daypick input[type="month"]{flex:1;min-width:0;font:inherit;font-size:12px;font-family:var(--ff-mono);
+  border:1px solid var(--rule);border-radius:4px;background:var(--surface);color:var(--ink);padding:4px 6px}
+.daypick input[type="month"]:focus-visible{outline:2px solid var(--accent);outline-offset:1px}
+.tagcloud{display:flex;flex-wrap:wrap;gap:4px}
+.tagchip{display:inline-flex;align-items:center;gap:5px;font-family:var(--ff-mono);font-size:11.5px;
+  color:var(--accent);background:var(--accent-soft);border:1px solid transparent;border-radius:3px;
+  padding:2px 7px;text-decoration:none}
+.tagchip .n{font-size:10px;color:var(--muted);font-variant-numeric:tabular-nums}
+.tagchip:hover{border-color:var(--accent)}
+.tagchip.is-active{background:var(--accent);color:var(--on-accent)}
+.tagchip.is-active .n{color:var(--on-accent);opacity:.8}
+.tagchip.clear{color:var(--muted);background:var(--surface-2)}
+.filternote{margin:0;color:var(--slate);font-size:13px}
+.card.compose .scanhead,.card.daygroup .scanhead{cursor:default}
+.card.daygroup .scanhead .hdr-actions{margin-left:auto;align-items:baseline}
+.daylink{text-decoration:none}
+.when{font:inherit;font-size:12px;font-family:var(--ff-mono);border:1px solid var(--rule);border-radius:4px;
+  background:var(--surface);color:var(--ink);padding:4px 6px}
+article.entry[hidden],section.daygroup[hidden]{display:none}

--- a/GeecsLogbook/geecs_logbook/templates/_entries.html
+++ b/GeecsLogbook/geecs_logbook/templates/_entries.html
@@ -8,6 +8,11 @@
   `seeds` is Context.page_seeds(book), a seed_templates.PageSeeds.
 #}
 
+{#
+  The type chip, then the tag chips — minus the tags the type's own
+  prefill carries: "Laser" next to "#laser" said one thing twice (owner,
+  2026-09-11). A tag the author added, or typed with no type, still shows.
+#}
 {% macro template_chip(entry, seeds) -%}
   {% set t = seeds.labels.get(entry.template) %}
   {% if t %}
@@ -15,6 +20,8 @@
   {% elif entry.template not in seeds.quiet %}
     <span class="chip chip-quiet">{{ entry.template }}</span>
   {% endif %}
+  {% set said = t.tags if t else [] %}
+  {% for tag in entry.tags if tag not in said %}<span class="chip chip-tag">#{{ tag }}</span>{% endfor %}
 {%- endmacro %}
 
 {# `hay` adds the filter haystack — only the month page filters entries,
@@ -32,7 +39,6 @@
             <span class="chip chip-agent">{{ 'agent · draft' if r.entry.status == 'draft' else 'agent' }}</span>
           {% endif %}
           {{ template_chip(r.entry, seeds) }}
-          {% for t in r.entry.tags %}<span class="chip chip-tag">#{{ t }}</span>{% endfor %}
           <span class="stamp" title="{{ r.entry.created_at.isoformat() }}">{{ r.entry.created_at.astimezone().strftime('%H:%M') }}{% if r.entry.edited_at %} · edited{% if r.entry.edited_by and r.entry.edited_by != r.entry.author %} by {{ r.entry.edited_by }}{% endif %}{% endif %}</span>
           {% if writable %}
           <span class="entry-tools">

--- a/GeecsLogbook/geecs_logbook/templates/_entries.html
+++ b/GeecsLogbook/geecs_logbook/templates/_entries.html
@@ -5,23 +5,25 @@
   same way and editor.js meets one shape of form. Every macro takes what
   it needs explicitly; nothing reads the page context.
 
-  `seeds` is Context.page_seeds(book): {buttons, labels, prefill}.
+  `seeds` is Context.page_seeds(book), a seed_templates.PageSeeds.
 #}
 
 {% macro template_chip(entry, seeds) -%}
   {% set t = seeds.labels.get(entry.template) %}
   {% if t %}
     <span class="chip chip-type tone-{{ t.colour }}">{{ t.label }}</span>
-  {% elif entry.template not in ('blank', 'scan_note', 'day_intro') %}
+  {% elif entry.template not in seeds.quiet %}
     <span class="chip chip-quiet">{{ entry.template }}</span>
   {% endif %}
 {%- endmacro %}
 
-{% macro entry_article(r, writable, seeds) %}
+{# `hay` adds the filter haystack — only the month page filters entries,
+   so the day page does not carry a third copy of every body. #}
+{% macro entry_article(r, writable, seeds, hay=false) %}
     <article class="entry{% if r.entry.kind.startswith('agent') %} entry-agent{% endif %}"
              id="entry-{{ r.entry.entry_id }}"
              data-entry="{{ r.entry.entry_id }}" data-version="{{ r.entry.version }}"
-             data-hay="{{ (r.entry.author ~ ' ' ~ r.entry.body_md ~ ' ' ~ r.entry.tags | join(' ')) | lower }}">
+             {%- if hay %} data-hay="{{ (r.entry.author ~ ' ' ~ r.entry.body_md ~ ' ' ~ r.entry.tags | join(' ')) | lower }}"{% endif %}>
       <div class="avatar{% if r.entry.kind.startswith('agent') %} avatar-agent{% endif %}">{{ r.entry.author | initials }}</div>
       <div class="entry-main">
         <div class="entry-head">

--- a/GeecsLogbook/geecs_logbook/templates/_entries.html
+++ b/GeecsLogbook/geecs_logbook/templates/_entries.html
@@ -1,0 +1,95 @@
+{#
+  Shared markup: one rendered entry, a composer, the type buttons.
+
+  Imported by day.html and month.html so both books draw an entry the
+  same way and editor.js meets one shape of form. Every macro takes what
+  it needs explicitly; nothing reads the page context.
+
+  `seeds` is Context.page_seeds(book): {buttons, labels, prefill}.
+#}
+
+{% macro template_chip(entry, seeds) -%}
+  {% set t = seeds.labels.get(entry.template) %}
+  {% if t %}
+    <span class="chip chip-type tone-{{ t.colour }}">{{ t.label }}</span>
+  {% elif entry.template not in ('blank', 'scan_note', 'day_intro') %}
+    <span class="chip chip-quiet">{{ entry.template }}</span>
+  {% endif %}
+{%- endmacro %}
+
+{% macro entry_article(r, writable, seeds) %}
+    <article class="entry{% if r.entry.kind.startswith('agent') %} entry-agent{% endif %}"
+             id="entry-{{ r.entry.entry_id }}"
+             data-entry="{{ r.entry.entry_id }}" data-version="{{ r.entry.version }}"
+             data-hay="{{ (r.entry.author ~ ' ' ~ r.entry.body_md ~ ' ' ~ r.entry.tags | join(' ')) | lower }}">
+      <div class="avatar{% if r.entry.kind.startswith('agent') %} avatar-agent{% endif %}">{{ r.entry.author | initials }}</div>
+      <div class="entry-main">
+        <div class="entry-head">
+          <span class="author">{{ r.entry.author }}</span>
+          {% if r.entry.kind.startswith('agent') %}
+            <span class="chip chip-agent">{{ 'agent · draft' if r.entry.status == 'draft' else 'agent' }}</span>
+          {% endif %}
+          {{ template_chip(r.entry, seeds) }}
+          {% for t in r.entry.tags %}<span class="chip chip-tag">#{{ t }}</span>{% endfor %}
+          <span class="stamp" title="{{ r.entry.created_at.isoformat() }}">{{ r.entry.created_at.astimezone().strftime('%H:%M') }}{% if r.entry.edited_at %} · edited{% if r.entry.edited_by and r.entry.edited_by != r.entry.author %} by {{ r.entry.edited_by }}{% endif %}{% endif %}</span>
+          {% if writable %}
+          <span class="entry-tools">
+            <button class="linkbtn" type="button" data-edit="{{ r.entry.entry_id }}">Edit</button>
+            <button class="linkbtn" type="button" data-del="{{ r.entry.entry_id }}">Delete</button>
+          </span>
+          {% endif %}
+        </div>
+        {% if r.entry.status == 'draft' %}
+        <div class="draftnote">Draft &mdash; nobody has reviewed this.
+          {% if writable %}<button class="linkbtn" type="button" data-keep="{{ r.entry.entry_id }}">Keep in log</button>{% endif %}
+        </div>
+        {% endif %}
+        <div class="entry-body">{{ r.html | safe }}</div>
+        {# JSON, not text: a <script> body is raw text, so HTML-escaped
+           entities would come back literally into the editor. #}
+        <script type="application/json" class="raw">{{ r.entry.body_md | tojson }}</script>
+      </div>
+    </article>
+{% endmacro %}
+
+{% macro types_row(seeds) -%}
+  {% if seeds.buttons %}
+  <div class="types" role="group" aria-label="Entry type">
+    {% for t in seeds.buttons %}
+    <button class="typebtn tone-{{ t.colour }}" type="button" data-type="{{ t.name }}"
+            title="Start from the {{ t.label }} template">{{ t.label }}</button>
+    {% endfor %}
+  </div>
+  {% endif %}
+{%- endmacro %}
+
+{#
+  The composer. `day` is set only where the page has no single day (the
+  month page); the day page's forms take theirs from <main data-day>.
+  A caller block lands in the editor bar before the name field — the
+  month page puts its date picker there.
+#}
+{% macro composer(seeds, scan=none, after=none, day=none, rows=3,
+                  placeholder='Add a note… Markdown works.') %}
+    <form class="composer" data-scan="{{ scan if scan is not none else '' }}"
+          data-after="{{ after if after is not none else '' }}"
+          {%- if day %} data-day="{{ day }}"{% endif %}>
+      <div class="avatar avatar-you">&hellip;</div>
+      <div class="entry-main">
+        {{ types_row(seeds) }}
+        <textarea class="ta" rows="{{ rows }}" placeholder="{{ placeholder }}"></textarea>
+        <div class="editor-bar">
+          {% if caller %}{{ caller() }}{% endif %}
+          <input class="who" placeholder="Your name" required aria-label="Your name">
+          <button class="btn btn-sm btn-primary" type="submit">Save</button>
+          <span class="editor-hint">&#8984;&#8629; saves &middot; paste or drop a screenshot</span>
+        </div>
+      </div>
+    </form>
+{% endmacro %}
+
+{# The prefills, once per page, for editor.js — JSON so a body can hold
+   anything (tojson escapes the characters that could close the tag). #}
+{% macro seeds_json(seeds) -%}
+<script type="application/json" id="logbook-seeds">{{ seeds.prefill | tojson }}</script>
+{%- endmacro %}

--- a/GeecsLogbook/geecs_logbook/templates/day.html
+++ b/GeecsLogbook/geecs_logbook/templates/day.html
@@ -28,59 +28,14 @@
   <dd{% if value is none %} class="none"{% endif %}>{{ value if value is not none else '—' }}</dd></div>
 {%- endmacro %}
 
+{% import "_entries.html" as shared %}
+
 {% macro entries_block(anchor, scan, after, entries, writable) %}
   {% set es = entries.get(anchor, []) %}
   {% if es or writable %}
   <div class="entries">
-    {% for r in es %}
-    <article class="entry{% if r.entry.kind.startswith('agent') %} entry-agent{% endif %}"
-             id="entry-{{ r.entry.entry_id }}"
-             data-entry="{{ r.entry.entry_id }}" data-version="{{ r.entry.version }}">
-      <div class="avatar{% if r.entry.kind.startswith('agent') %} avatar-agent{% endif %}">{{ r.entry.author | initials }}</div>
-      <div class="entry-main">
-        <div class="entry-head">
-          <span class="author">{{ r.entry.author }}</span>
-          {% if r.entry.kind.startswith('agent') %}
-            <span class="chip chip-agent">{{ 'agent · draft' if r.entry.status == 'draft' else 'agent' }}</span>
-          {% endif %}
-          {% if r.entry.template not in ('blank', 'scan_note', 'day_intro') %}
-            <span class="chip chip-quiet">{{ r.entry.template }}</span>
-          {% endif %}
-          {% for t in r.entry.tags %}<span class="chip chip-tag">#{{ t }}</span>{% endfor %}
-          <span class="stamp" title="{{ r.entry.created_at.isoformat() }}">{{ r.entry.created_at.astimezone().strftime('%H:%M') }}{% if r.entry.edited_at %} · edited{% if r.entry.edited_by and r.entry.edited_by != r.entry.author %} by {{ r.entry.edited_by }}{% endif %}{% endif %}</span>
-          {% if writable %}
-          <span class="entry-tools">
-            <button class="linkbtn" type="button" data-edit="{{ r.entry.entry_id }}">Edit</button>
-            <button class="linkbtn" type="button" data-del="{{ r.entry.entry_id }}">Delete</button>
-          </span>
-          {% endif %}
-        </div>
-        {% if r.entry.status == 'draft' %}
-        <div class="draftnote">Draft &mdash; nobody has reviewed this.
-          {% if writable %}<button class="linkbtn" type="button" data-keep="{{ r.entry.entry_id }}">Keep in log</button>{% endif %}
-        </div>
-        {% endif %}
-        <div class="entry-body">{{ r.html | safe }}</div>
-        {# JSON, not text: a <script> body is raw text, so HTML-escaped
-           entities would come back literally into the editor. #}
-        <script type="application/json" class="raw">{{ r.entry.body_md | tojson }}</script>
-      </div>
-    </article>
-    {% endfor %}
-    {% if writable %}
-    <form class="composer" data-scan="{{ scan if scan is not none else '' }}"
-          data-after="{{ after if after is not none else '' }}">
-      <div class="avatar avatar-you">&hellip;</div>
-      <div class="entry-main">
-        <textarea class="ta" rows="3" placeholder="Add a note&hellip; Markdown works."></textarea>
-        <div class="editor-bar">
-          <input class="who" placeholder="Your name" required aria-label="Your name">
-          <button class="btn btn-sm btn-primary" type="submit">Save</button>
-          <span class="editor-hint">&#8984;&#8629; saves &middot; paste or drop a screenshot</span>
-        </div>
-      </div>
-    </form>
-    {% endif %}
+    {% for r in es %}{{ shared.entry_article(r, writable, seeds) }}{% endfor %}
+    {% if writable %}{{ shared.composer(seeds, scan=scan, after=after) }}{% endif %}
   </div>
   {% endif %}
 {% endmacro %}
@@ -180,6 +135,7 @@
       <input id="q" type="search" placeholder="Filter scans…" autocomplete="off">
     </label>
     <div data-theme-picker></div>
+    <a class="btn booklink" href="{{ month_url }}">Ops book &rarr;</a>
     <button class="btn" type="button" id="toggle-all"
             data-expanded="{{ 'false' if many else 'true' }}">
       {{ 'Expand all' if many else 'Collapse all' }}
@@ -256,6 +212,13 @@
         {% if summary.failed %}<div>Failed<b>{{ summary.failed }}</b></div>{% endif %}
       </div>
     </div>
+
+    {% if ops_count %}
+    <a class="opsstrip" href="{{ ops_url }}">
+      <span class="tlabel">Ops book</span>
+      {{ ops_count }} ops note{{ '' if ops_count == 1 else 's' }} today &rarr;
+    </a>
+    {% endif %}
 
     {% if not summary.exists %}
       <p class="empty">No <code>scans/</code> directory for this date. Nothing ran,
@@ -375,6 +338,7 @@ document.querySelectorAll(".scanrow").forEach(a => a.addEventListener("click", (
   if (camp) camp.open = true;
 }));
 </script>
+{{ shared.seeds_json(seeds) }}
 <script src="{{ url_for('_static', name='editor.js') }}" defer></script>
 <script src="{{ root }}/theme/theme.js" defer></script>
 </body>

--- a/GeecsLogbook/geecs_logbook/templates/month.html
+++ b/GeecsLogbook/geecs_logbook/templates/month.html
@@ -1,0 +1,192 @@
+{#
+  The ops book: one month of day-level entries, newest day first.
+
+  Everything on this page comes from the notes store — nothing is read
+  off the share — so it stays fast when the share is slow. Each day
+  links to its scan-log day page; the tag chips filter through the URL.
+#}<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Ops Book — {{ first.strftime('%B %Y') }}</title>
+{% set root = request.scope.get('root_path', '').rstrip('/') %}
+<script src="{{ root }}/theme/theme-boot.js"></script>
+<link rel="stylesheet" href="{{ root }}/theme/theme.css">
+<link rel="stylesheet" href="{{ url_for('_static', name='scanlog.css').path }}">
+</head>
+<body>
+{% import "_entries.html" as shared %}
+{% set month_path = url_for('_month_page', month=first.strftime('%Y-%m')).path %}
+
+<div class="topbar">
+  <div class="wrap">
+    <div class="brand">
+      <strong>Ops Book</strong>
+      <span class="facility">{{ experiment }}</span>
+    </div>
+    <label class="searchbox">
+      <svg width="13" height="13" viewBox="0 0 16 16" fill="none" stroke="currentColor"
+           stroke-width="1.7" aria-hidden="true"><circle cx="7" cy="7" r="4.5"/><path d="M10.5 10.5 14 14"/></svg>
+      <input id="q" type="search" placeholder="Filter notes…" autocomplete="off">
+    </label>
+    <div data-theme-picker></div>
+    <a class="btn booklink" href="{{ url_for('_day_page', day=today.isoformat()).path }}">Scan log &rarr;</a>
+  </div>
+</div>
+
+<div class="wrap shell">
+
+  <aside class="rail">
+    <section>
+      <h4>Go to a month</h4>
+      <div class="daypick">
+        <a class="stepday" href="{{ url_for('_month_page', month=prev_month.strftime('%Y-%m')).path }}"
+           title="Previous month" aria-label="Previous month">&lsaquo;</a>
+        <input type="month" id="monthpicker" value="{{ first.strftime('%Y-%m') }}"
+               aria-label="Jump to a month">
+        <a class="stepday" href="{{ url_for('_month_page', month=next_month.strftime('%Y-%m')).path }}"
+           title="Next month" aria-label="Next month">&rsaquo;</a>
+      </div>
+      {% if not (first <= today <= last) %}
+      <a class="todaylink" href="{{ url_for('_month_page', month=today.strftime('%Y-%m')).path }}">
+        Back to this month</a>
+      {% endif %}
+    </section>
+
+    {% if tags %}
+    <section>
+      <h4>Tags</h4>
+      <div class="tagcloud">
+        {% if active_tag %}
+        <a class="tagchip clear" href="{{ month_path }}">&times; clear filter</a>
+        {% endif %}
+        {% for name, n in tags %}
+        <a class="tagchip{% if name == active_tag %} is-active{% endif %}"
+           href="{{ month_path }}?tag={{ name }}">#{{ name }}<span class="n">{{ n }}</span></a>
+        {% endfor %}
+      </div>
+    </section>
+    {% endif %}
+
+    {% if days %}
+    <section>
+      <h4>Days · {{ days | length }}</h4>
+      <div class="daylist">
+        {% for d, rs in days %}
+        <a class="day" href="#day-{{ d.isoformat() }}">
+          <span>{{ d.strftime('%a %d %b') }}</span>
+          <span class="n">{{ rs | length }}</span>
+        </a>
+        {% endfor %}
+      </div>
+    </section>
+    {% endif %}
+  </aside>
+
+  <main id="logbook" data-api="{{ api_base }}" data-book="ops" data-accept="{{ accept }}">
+
+    <div class="dayhead">
+      <div>
+        <h1>{{ first.strftime('%B %Y') }}</h1>
+        <div class="sub">operations &middot; day-level notes, newest day first</div>
+      </div>
+      <div class="daystats">
+        <div>Notes<b>{{ entry_count }}{% if active_tag %} / {{ month_count }}{% endif %}</b></div>
+        <div>Days<b>{{ days | length }}</b></div>
+      </div>
+    </div>
+
+    {% if active_tag %}
+    <p class="filternote">Showing notes tagged <span class="chip chip-tag">#{{ active_tag }}</span>
+      &middot; <a href="{{ month_path }}">show all</a></p>
+    {% endif %}
+
+    {% if writable %}
+    <section class="card compose">
+      <header class="scanhead">
+        <span class="scanid">New note</span>
+        <span class="scanpurpose">Something about the day &mdash; not a scan. Pick a type or just write.</span>
+      </header>
+      <div class="entries">
+        {% call shared.composer(seeds, day=compose_day.isoformat(), rows=4,
+                                placeholder='What happened? Markdown works; #tags are read from the text.') %}
+          <input type="date" class="when" value="{{ compose_day.isoformat() }}" required
+                 aria-label="Which day this note is about">
+        {% endcall %}
+      </div>
+    </section>
+    {% endif %}
+
+    {% if not days %}
+      <p class="empty">
+        {% if active_tag %}No notes tagged <code>#{{ active_tag }}</code> in {{ first.strftime('%B %Y') }}.
+        {% elif month_count == 0 %}No operations notes in {{ first.strftime('%B %Y') }}{% if writable %} yet{% endif %}.
+        {% endif %}
+      </p>
+    {% endif %}
+
+    {% for d, rs in days %}
+    <section class="card daygroup" id="day-{{ d.isoformat() }}">
+      <header class="scanhead">
+        <span class="scanid">{{ d.strftime('%a %-d %b') }}</span>
+        {% if d == today %}<span class="chip chip-quiet">today</span>{% endif %}
+        <span class="scanpurpose">{{ rs | length }} note{{ '' if rs | length == 1 else 's' }}</span>
+        <span class="hdr-actions">
+          {% if writable %}
+          <button class="linkbtn" type="button" data-compose-day="{{ d.isoformat() }}">+ note</button>
+          {% endif %}
+          <a class="linkbtn daylink" href="{{ url_for('_day_page', day=d.isoformat()).path }}">scan log &rarr;</a>
+        </span>
+      </header>
+      <div class="entries">
+        {% for r in rs %}{{ shared.entry_article(r, writable, seeds) }}{% endfor %}
+      </div>
+    </section>
+    {% endfor %}
+
+    {% if not writable %}
+    <p class="foot">Read-only: no notes store is configured, so there is nothing to
+    write here and nothing stored.</p>
+    {% endif %}
+  </main>
+</div>
+
+{{ shared.seeds_json(seeds) }}
+<script>
+"use strict";
+/* The picker navigates straight to any month. */
+document.getElementById("monthpicker").addEventListener("change", ev => {
+  if (ev.target.value) {
+    const url = new URL(window.location.href);
+    url.pathname = url.pathname.replace(/[^/]+$/, ev.target.value);
+    url.hash = "";
+    window.location.href = url.toString();
+  }
+});
+
+/* "+ note" on a day points the one composer at that day. */
+document.querySelectorAll("[data-compose-day]").forEach(b => b.addEventListener("click", () => {
+  const form = document.querySelector("form.composer");
+  if (!form) return;
+  const when = form.querySelector(".when");
+  if (when) when.value = b.dataset.composeDay;
+  form.scrollIntoView({ block: "start", behavior: "smooth" });
+  form.querySelector(".ta").focus();
+}));
+
+/* Filter hides entries, and a day whose entries are all hidden. */
+document.getElementById("q").addEventListener("input", ev => {
+  const f = ev.target.value.trim().toLowerCase();
+  document.querySelectorAll("article.entry").forEach(e => {
+    e.hidden = !!f && !e.dataset.hay.includes(f);
+  });
+  document.querySelectorAll("section.daygroup").forEach(g => {
+    g.hidden = !!f && ![...g.querySelectorAll("article.entry")].some(e => !e.hidden);
+  });
+});
+</script>
+<script src="{{ url_for('_static', name='editor.js') }}" defer></script>
+<script src="{{ root }}/theme/theme.js" defer></script>
+</body>
+</html>

--- a/GeecsLogbook/geecs_logbook/templates/month.html
+++ b/GeecsLogbook/geecs_logbook/templates/month.html
@@ -140,7 +140,7 @@
         </span>
       </header>
       <div class="entries">
-        {% for r in rs %}{{ shared.entry_article(r, writable, seeds) }}{% endfor %}
+        {% for r in rs %}{{ shared.entry_article(r, writable, seeds, hay=true) }}{% endfor %}
       </div>
     </section>
     {% endfor %}
@@ -170,7 +170,9 @@ document.querySelectorAll("[data-compose-day]").forEach(b => b.addEventListener(
   const form = document.querySelector("form.composer");
   if (!form) return;
   const when = form.querySelector(".when");
-  if (when) when.value = b.dataset.composeDay;
+  // An autosaved entry already has its day (the editor disables the
+  // picker); leave it and let the author see the date it is on.
+  if (when && !when.disabled) when.value = b.dataset.composeDay;
   form.scrollIntoView({ block: "start", behavior: "smooth" });
   form.querySelector(".ta").focus();
 }));

--- a/GeecsLogbook/pyproject.toml
+++ b/GeecsLogbook/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-logbook"
-version = "0.4.0"
+version = "0.5.0"
 description = "Scan logbook: a day-document view over scan folders, with human commentary stored beside the data"
 authors = ["GEECS-BELLA"]
 readme = "README.md"

--- a/GeecsLogbook/tests/test_month.py
+++ b/GeecsLogbook/tests/test_month.py
@@ -1,0 +1,252 @@
+"""The ops book: the month page, its filters, and the links between the books."""
+
+from __future__ import annotations
+
+from datetime import date
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from geecs_logbook.router import create_log_router
+
+HERE = Path(__file__).resolve().parent
+EXAMPLES = HERE.parent / "examples" / "logbook_templates"
+
+
+@pytest.fixture
+def app(share: Path, tmp_path: Path) -> TestClient:
+    """A writable logbook with the example templates, mounted as the portal does."""
+    app = FastAPI()
+    app.include_router(
+        create_log_router(
+            "Undulator",
+            base_directory=share,
+            notes_db=tmp_path / "notes.db",
+            templates_dir=EXAMPLES,
+        ),
+        prefix="/log",
+    )
+    return TestClient(app)
+
+
+@pytest.fixture
+def readonly(share: Path) -> TestClient:
+    """No store: the month page exists but holds nothing."""
+    app = FastAPI()
+    app.include_router(
+        create_log_router("Undulator", base_directory=share), prefix="/log"
+    )
+    return TestClient(app)
+
+
+def _ops(client: TestClient, day: str, body: str, **extra: object) -> dict:
+    payload = {"day": day, "book": "ops", "author": "S. Barber", "body_md": body}
+    payload.update(extra)
+    r = client.post("/log/api/entries", json=payload)
+    assert r.status_code == 201, r.text
+    return r.json()
+
+
+class TestMonthPage:
+    """One month of the ops book, newest day first, from the store alone."""
+
+    def test_groups_by_day_newest_first(self, app: TestClient) -> None:
+        """Days descend; within a day, entries read in the order written."""
+        _ops(app, "2026-09-03", "first on the 3rd")
+        _ops(app, "2026-09-11", "on the 11th")
+        _ops(app, "2026-09-03", "second on the 3rd")
+        _ops(app, "2026-08-31", "last month")
+        _ops(app, "2026-10-01", "next month")
+        html = app.get("/log/month/2026-09").text
+        assert html.index('id="day-2026-09-11"') < html.index('id="day-2026-09-03"')
+        assert html.index("first on the 3rd") < html.index("second on the 3rd")
+        assert "last month" not in html and "next month" not in html
+        assert "Days<b>2</b>" in html and "Notes<b>3</b>" in html
+
+    def test_scans_book_stays_out(self, app: TestClient) -> None:
+        """A note on the day page is not an ops note, anchored or not."""
+        r = app.post(
+            "/log/api/entries",
+            json={
+                "day": "2026-09-11",
+                "author": "a",
+                "body_md": "scan note",
+                "scan": 1,
+            },
+        )
+        assert r.status_code == 201
+        app.post(
+            "/log/api/entries",
+            json={"day": "2026-09-11", "author": "a", "body_md": "day intro"},
+        )
+        html = app.get("/log/month/2026-09").text
+        assert "scan note" not in html and "day intro" not in html
+        assert "No operations notes in September 2026 yet" in html
+
+    def test_never_reads_the_share(
+        self, app: TestClient, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The month page is the store's alone: a dead share changes nothing."""
+        from geecs_logbook import scan_reader
+        from geecs_logbook.routes import _common
+
+        def no_share(*a: object, **k: object) -> None:
+            raise AssertionError("month page touched the share")
+
+        monkeypatch.setattr(scan_reader, "read_day", no_share)
+        monkeypatch.setattr(_common, "read_day", no_share)
+        _ops(app, "2026-09-11", "still here")
+        assert "still here" in app.get("/log/month/2026-09").text
+
+    def test_tag_chips_filter_through_the_url(self, app: TestClient) -> None:
+        """Chips count the whole month; the list shows the filtered part."""
+        _ops(app, "2026-09-11", "chiller #maintenance")
+        _ops(app, "2026-09-10", "energy up #laser")
+        _ops(app, "2026-09-09", "amplifier #laser #maintenance")
+        html = app.get("/log/month/2026-09?tag=laser").text
+        assert "energy up" in html and "amplifier" in html and "chiller" not in html
+        assert "Notes<b>2 / 3</b>" in html
+        assert 'href="/log/month/2026-09?tag=laser"' in html
+        assert 'href="/log/month/2026-09?tag=maintenance"' in html
+        assert "clear filter" in html
+        assert 'class="tagchip is-active"' in html
+        empty = app.get("/log/month/2026-09?tag=nothing").text
+        assert "No notes tagged <code>#nothing</code>" in empty
+
+    def test_prev_next_and_day_links(self, app: TestClient) -> None:
+        """Month stepping across a year boundary; each day links to its day page."""
+        _ops(app, "2026-01-05", "january")
+        html = app.get("/log/month/2026-01").text
+        assert 'href="/log/month/2025-12"' in html
+        assert 'href="/log/month/2026-02"' in html
+        assert 'href="/log/day/2026-01-05"' in html
+        assert 'data-compose-day="2026-01-05"' in html
+
+    def test_malformed_month_is_a_400(self, app: TestClient) -> None:
+        """Not YYYY-MM is the caller's error."""
+        assert app.get("/log/month/2026-9").status_code == 400
+        assert app.get("/log/month/september").status_code == 400
+        assert app.get("/log/api/month/2026-13/entries").status_code == 400
+
+    def test_composer_defaults_to_today_when_in_the_month(
+        self, app: TestClient
+    ) -> None:
+        """Today in the shown month; the month's edge otherwise."""
+        today = date.today()
+        html = app.get(f"/log/month/{today.strftime('%Y-%m')}").text
+        assert f'class="when" value="{today.isoformat()}"' in html
+        assert (
+            'data-book="ops"' in html
+            and "data-day=" not in html.split("<main")[1].split(">")[0]
+        )
+        past = app.get("/log/month/2020-02").text
+        assert 'class="when" value="2020-02-29"' in past
+        future = app.get("/log/month/2099-03").text
+        assert 'class="when" value="2099-03-01"' in future
+
+    def test_read_only_mount_has_no_composer(self, readonly: TestClient) -> None:
+        """Without a store: the page exists, says so, and offers nothing to write."""
+        html = readonly.get("/log/month/2026-09").text
+        assert "Read-only" in html and 'class="composer"' not in html
+        assert readonly.get("/log/api/month/2026-09/entries").json() == []
+
+
+class TestMonthJson:
+    """The month's entries as JSON, either book, optionally one tag."""
+
+    def test_book_and_tag_filters(self, app: TestClient) -> None:
+        """Default is the ops book; ?book= and ?tag= narrow the same query."""
+        _ops(app, "2026-09-11", "#laser one")
+        _ops(app, "2026-09-12", "#jet two")
+        app.post(
+            "/log/api/entries",
+            json={"day": "2026-09-11", "author": "a", "body_md": "scan", "scan": 1},
+        )
+        ops = app.get("/log/api/month/2026-09/entries").json()
+        assert [e["body_md"] for e in ops] == ["#laser one", "#jet two"]
+        laser = app.get("/log/api/month/2026-09/entries?tag=laser").json()
+        assert [e["body_md"] for e in laser] == ["#laser one"]
+        scans = app.get("/log/api/month/2026-09/entries?book=scans").json()
+        assert [e["body_md"] for e in scans] == ["scan"]
+        assert app.get("/log/api/month/2026-09/entries?book=nope").status_code == 422
+
+
+class TestTypeButtons:
+    """Templates as buttons on both pages, and the chip on a stored entry."""
+
+    def test_each_page_offers_its_books_templates(self, app: TestClient) -> None:
+        """Ops buttons on the month page, scans buttons on the day page, both-book ones on each."""
+        month = app.get("/log/month/2026-09").text
+        day = app.get("/log/day/2026-09-11").text
+        assert 'data-type="laser"' in month and 'data-type="laser"' not in day
+        assert 'data-type="result"' in day and 'data-type="result"' not in month
+        assert 'data-type="fault"' in month and 'data-type="fault"' in day
+        # Row order follows the files' order key.
+        assert month.index('data-type="laser"') < month.index('data-type="handover"')
+        assert month.index('data-type="handover"') < month.index('data-type="fault"')
+
+    def test_buttons_carry_a_tone_class_never_a_colour(self, app: TestClient) -> None:
+        """The file said ``colour: crit``; the page says ``tone-crit``."""
+        html = app.get("/log/month/2026-09").text
+        assert 'class="typebtn tone-crit" type="button" data-type="fault"' in html
+        assert 'class="typebtn tone-ok" type="button" data-type="laser"' in html
+
+    def test_prefills_ship_once_as_json(self, app: TestClient) -> None:
+        """One JSON block carries every prefill; the editor reads it by name."""
+        html = app.get("/log/month/2026-09").text
+        assert html.count('id="logbook-seeds"') == 1
+        block = html.split('id="logbook-seeds">')[1].split("</script>")[0]
+        import json
+
+        seeds = json.loads(block)
+        assert seeds["laser"].startswith("#laser")
+        assert "result" in seeds  # every template, not only this book's
+
+    def test_stored_template_renders_as_its_chip(self, app: TestClient) -> None:
+        """An entry started from a template shows the label in the file's tone."""
+        _ops(app, "2026-09-11", "### Laser\n#laser\nenergy up", template="laser")
+        _ops(app, "2026-09-11", "plain", template="retired_type")
+        html = app.get("/log/month/2026-09").text
+        assert '<span class="chip chip-type tone-ok">Laser</span>' in html
+        assert '<span class="chip chip-quiet">retired_type</span>' in html
+        assert '<span class="chip chip-tag">#laser</span>' in html
+
+    def test_without_a_directory_composers_are_plain(
+        self, share: Path, tmp_path: Path
+    ) -> None:
+        """No templates configured: no button row, an empty prefill block."""
+        app = FastAPI()
+        app.include_router(
+            create_log_router(
+                "Undulator", base_directory=share, notes_db=tmp_path / "n.db"
+            ),
+            prefix="/log",
+        )
+        html = TestClient(app).get("/log/month/2026-09").text
+        assert 'class="types"' not in html and "typebtn" not in html
+        assert 'id="logbook-seeds">{}</script>' in html
+
+
+class TestCrossLinks:
+    """The two books point at each other."""
+
+    def test_day_page_counts_ops_notes_and_links_to_the_month(
+        self, app: TestClient
+    ) -> None:
+        """The strip appears only when there is something behind it."""
+        before = app.get("/log/day/2026-09-11").text
+        assert "opsstrip" not in before
+        assert 'href="/log/month/2026-09"' in before  # the topbar link, always
+        _ops(app, "2026-09-11", "a")
+        _ops(app, "2026-09-11", "b")
+        _ops(app, "2026-09-12", "other day")
+        after = app.get("/log/day/2026-09-11").text
+        assert "2 ops notes today" in after
+        assert 'href="/log/month/2026-09#day-2026-09-11"' in after
+
+    def test_month_page_links_back_to_the_scan_log(self, app: TestClient) -> None:
+        """Topbar: today's day page."""
+        html = app.get("/log/month/2026-09").text
+        assert f'href="/log/day/{date.today().isoformat()}"' in html

--- a/GeecsLogbook/tests/test_month.py
+++ b/GeecsLogbook/tests/test_month.py
@@ -99,10 +99,14 @@ class TestMonthPage:
         monkeypatch.setattr(_common, "read_day", no_share)
         # The mirror sync writes to the share on the request thread; the
         # day page pays that debt, this page must not (review of #842).
-        monkeypatch.setattr(_common.mirror, "sync", no_share)
-        monkeypatch.setattr(_common, "SYNC_INTERVAL_S", 0.0)
+        # Patched at Context.maybe_sync, not mirror.sync: maybe_sync
+        # swallows anything the sync raises, so a pin one level down
+        # would stay green if the call were re-added to the route.
+        monkeypatch.setattr(_common.Context, "maybe_sync", no_share)
         _ops(app, "2026-09-11", "still here")
         assert "still here" in app.get("/log/month/2026-09").text
+        with pytest.raises(AssertionError):
+            app.get("/log/day/2026-09-11")  # the day page does call it
 
     def test_tag_chips_filter_through_the_url(self, app: TestClient) -> None:
         """Chips count the whole month; the list shows the filtered part."""

--- a/GeecsLogbook/tests/test_month.py
+++ b/GeecsLogbook/tests/test_month.py
@@ -105,8 +105,6 @@ class TestMonthPage:
         monkeypatch.setattr(_common.Context, "maybe_sync", no_share)
         _ops(app, "2026-09-11", "still here")
         assert "still here" in app.get("/log/month/2026-09").text
-        with pytest.raises(AssertionError):
-            app.get("/log/day/2026-09-11")  # the day page does call it
 
     def test_tag_chips_filter_through_the_url(self, app: TestClient) -> None:
         """Chips count the whole month; the list shows the filtered part."""

--- a/GeecsLogbook/tests/test_month.py
+++ b/GeecsLogbook/tests/test_month.py
@@ -97,6 +97,10 @@ class TestMonthPage:
 
         monkeypatch.setattr(scan_reader, "read_day", no_share)
         monkeypatch.setattr(_common, "read_day", no_share)
+        # The mirror sync writes to the share on the request thread; the
+        # day page pays that debt, this page must not (review of #842).
+        monkeypatch.setattr(_common.mirror, "sync", no_share)
+        monkeypatch.setattr(_common, "SYNC_INTERVAL_S", 0.0)
         _ops(app, "2026-09-11", "still here")
         assert "still here" in app.get("/log/month/2026-09").text
 
@@ -129,6 +133,10 @@ class TestMonthPage:
         assert app.get("/log/month/2026-9").status_code == 400
         assert app.get("/log/month/september").status_code == 400
         assert app.get("/log/api/month/2026-13/entries").status_code == 400
+        # A month whose neighbour cannot exist is refused, not a 500.
+        assert app.get("/log/month/9999-12").status_code == 400
+        assert app.get("/log/month/0001-01").status_code == 400
+        assert app.get("/log/month/0002-01").status_code == 200
 
     def test_composer_defaults_to_today_when_in_the_month(
         self, app: TestClient
@@ -212,6 +220,25 @@ class TestTypeButtons:
         assert '<span class="chip chip-type tone-ok">Laser</span>' in html
         assert '<span class="chip chip-quiet">retired_type</span>' in html
         assert '<span class="chip chip-tag">#laser</span>' in html
+
+    def test_haystack_only_where_it_is_filtered(self, app: TestClient) -> None:
+        """The month page filters entries; the day page filters scans, so no third copy there."""
+        _ops(app, "2026-09-11", "needle in the ops book")
+        app.post(
+            "/log/api/entries",
+            json={
+                "day": "2026-09-11",
+                "author": "a",
+                "body_md": "needle on a scan",
+                "scan": 1,
+            },
+        )
+        assert (
+            'data-hay="s. barber needle in the ops book'
+            in app.get("/log/month/2026-09").text
+        )
+        day = app.get("/log/day/2026-09-11").text
+        assert "needle on a scan" in day and 'data-hay="a needle' not in day
 
     def test_without_a_directory_composers_are_plain(
         self, share: Path, tmp_path: Path

--- a/GeecsLogbook/tests/test_month.py
+++ b/GeecsLogbook/tests/test_month.py
@@ -221,7 +221,16 @@ class TestTypeButtons:
         html = app.get("/log/month/2026-09").text
         assert '<span class="chip chip-type tone-ok">Laser</span>' in html
         assert '<span class="chip chip-quiet">retired_type</span>' in html
-        assert '<span class="chip chip-tag">#laser</span>' in html
+        # The type chip already says #laser; the tag chip would say it twice.
+        assert '<span class="chip chip-tag">#laser</span>' not in html
+
+    def test_tags_the_type_did_not_bring_still_show(self, app: TestClient) -> None:
+        """A tag the author added keeps its chip; so does a typed tag with no type."""
+        _ops(app, "2026-09-11", "#laser and also #jet", template="laser")
+        _ops(app, "2026-09-11", "hand-typed #laser")
+        html = app.get("/log/month/2026-09").text
+        assert html.count('<span class="chip chip-tag">#jet</span>') == 1
+        assert html.count('<span class="chip chip-tag">#laser</span>') == 1
 
     def test_haystack_only_where_it_is_filtered(self, app: TestClient) -> None:
         """The month page filters entries; the day page filters scans, so no third copy there."""

--- a/GeecsLogbook/tests/test_seed_templates.py
+++ b/GeecsLogbook/tests/test_seed_templates.py
@@ -1,0 +1,161 @@
+"""Seed templates: files in, buttons out, and the closed colour vocabulary."""
+
+from __future__ import annotations
+
+import re
+import time
+from pathlib import Path
+
+import pytest
+
+from geecs_logbook import seed_templates
+from geecs_logbook.seed_templates import (
+    TONES,
+    SeedTemplates,
+    load_templates,
+    parse_template,
+)
+
+HERE = Path(__file__).resolve().parent
+EXAMPLES = HERE.parent / "examples" / "logbook_templates"
+CSS = HERE.parent / "geecs_logbook" / "static" / "scanlog.css"
+
+
+class TestParse:
+    """One file's text becomes one template."""
+
+    def test_header_and_body(self) -> None:
+        """Every header key is read; the body is the prefill with its tag."""
+        t = parse_template(
+            "laser",
+            "---\nlabel: Laser\ncolour: ok\nbook: ops\norder: 10\n---\n### Laser\n#laser\n",
+        )
+        assert (t.label, t.colour, t.book, t.order) == ("Laser", "ok", "ops", 10)
+        assert t.body == "### Laser\n#laser\n"
+        assert t.offered_in("ops") and not t.offered_in("scans")
+
+    def test_defaults_without_a_header(self) -> None:
+        """A bare file is all body, offered in both books, accent-coloured."""
+        t = parse_template("shift_handover", "**State:**\n")
+        assert t.label == "Shift Handover"
+        assert (t.colour, t.book, t.order) == ("accent", "both", 100)
+        assert t.body == "**State:**\n"
+        assert t.offered_in("ops") and t.offered_in("scans")
+
+    def test_unknown_colour_falls_back_not_through(self, caplog) -> None:
+        """A literal or a typo never reaches the page: it becomes accent, logged."""
+        t = parse_template("x", "---\ncolour: #ff0000\n---\nbody\n")
+        assert t.colour == "accent"
+        assert "not a theme tone" in caplog.text
+
+    def test_unknown_book_and_bad_order_are_tolerated(self) -> None:
+        """Bad header values cost the button nothing but its metadata."""
+        t = parse_template("x", "---\nbook: nope\norder: soon\n---\n")
+        assert (t.book, t.order) == ("both", 100)
+        assert t.body == ""
+
+    def test_unclosed_header_is_all_body(self) -> None:
+        """A lone --- fence is not a header; nothing is silently dropped."""
+        t = parse_template("x", "---\nlabel: Not a header\nreal text\n")
+        assert t.label == "X"
+        assert "real text" in t.body and "label: Not a header" in t.body
+
+    def test_color_spelling_accepted(self) -> None:
+        """Both spellings of the colour key are read."""
+        assert parse_template("x", "---\ncolor: warn\n---\n").colour == "warn"
+
+
+class TestLoad:
+    """A directory of files, sorted for the button row."""
+
+    def test_examples_load_and_sort(self) -> None:
+        """The shipped examples parse; order then label decides the row."""
+        found = load_templates(EXAMPLES)
+        assert [t.name for t in found] == [
+            "laser",
+            "result",
+            "handover",
+            "fault",
+            "maintenance",
+        ]
+        assert {t.colour for t in found} <= set(TONES)
+        assert all("#" + t.name in t.body for t in found)
+
+    def test_missing_directory_is_empty(self, tmp_path: Path) -> None:
+        """No directory, no buttons, no error."""
+        assert load_templates(tmp_path / "nope") == []
+
+    def test_unusable_stems_are_skipped(self, tmp_path: Path, caplog) -> None:
+        """A stem that cannot be a template name is skipped with a warning."""
+        (tmp_path / "ok.md").write_text("fine\n")
+        (tmp_path / ".hidden.md").write_text("no\n")
+        (tmp_path / ("x" * 70 + ".md")).write_text("too long\n")
+        (tmp_path / "notes.txt").write_text("not markdown\n")
+        assert [t.name for t in load_templates(tmp_path)] == ["ok"]
+        assert caplog.text.count("not usable") == 2
+
+
+class TestSeedTemplates:
+    """The live set: loaded at start, refreshed off the request path."""
+
+    def test_none_directory_means_nothing_ever(self) -> None:
+        """Without a directory the set is empty and stays that way."""
+        seeds = SeedTemplates(None)
+        assert seeds.current() == [] and seeds.for_book("ops") == []
+        assert seeds.by_name() == {}
+
+    def test_first_load_is_synchronous(self, tmp_path: Path) -> None:
+        """The process starts with its buttons."""
+        (tmp_path / "laser.md").write_text("---\nbook: ops\n---\n#laser\n")
+        seeds = SeedTemplates(tmp_path)
+        assert [t.name for t in seeds.for_book("ops")] == ["laser"]
+        assert seeds.for_book("scans") == []
+        assert seeds.by_name()["laser"].body == "#laser\n"
+
+    def test_a_new_file_arrives_after_the_interval_in_the_background(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A stale set is served as-is while one thread re-reads the directory."""
+        (tmp_path / "laser.md").write_text("#laser\n")
+        seeds = SeedTemplates(tmp_path)
+        (tmp_path / "fault.md").write_text("#fault\n")
+        assert [t.name for t in seeds.current()] == ["laser"]  # fresh: no re-read
+        monkeypatch.setattr(seed_templates, "REFRESH_INTERVAL_S", 0.0)
+        assert [t.name for t in seeds.current()] == ["laser"]  # served stale
+        deadline = time.monotonic() + 5
+        while time.monotonic() < deadline:
+            if len(seeds.current()) == 2:
+                break
+            time.sleep(0.02)
+        assert [t.name for t in seeds.current()] == ["fault", "laser"]
+
+    def test_a_failed_refresh_keeps_the_last_set(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The share going away costs the buttons nothing."""
+        (tmp_path / "laser.md").write_text("#laser\n")
+        seeds = SeedTemplates(tmp_path)
+
+        def boom(directory: Path) -> list:
+            raise OSError("share gone")
+
+        monkeypatch.setattr(seed_templates, "load_templates", boom)
+        monkeypatch.setattr(seed_templates, "REFRESH_INTERVAL_S", 0.0)
+        seeds.current()
+        deadline = time.monotonic() + 5
+        while seeds._refreshing and time.monotonic() < deadline:
+            time.sleep(0.02)
+        assert [t.name for t in seeds.current()] == ["laser"]
+
+
+def test_every_tone_has_a_css_rule() -> None:
+    """The vocabulary a file may name is exactly what the stylesheet maps.
+
+    A tone without a ``.tone-<name>`` rule would render with no colour at
+    all; a rule without a tone would be dead. Both directions are pinned.
+    """
+    rules = set(
+        re.findall(r"\.tone-([\w-]+)\s*\{--tone:var\(--([\w-]+)\)\}", CSS.read_text())
+    )
+    assert {name for name, _ in rules} == set(TONES)
+    assert all(name == token for name, token in rules)

--- a/GeecsLogbook/tests/test_seed_templates.py
+++ b/GeecsLogbook/tests/test_seed_templates.py
@@ -32,6 +32,7 @@ class TestParse:
         )
         assert (t.label, t.colour, t.book, t.order) == ("Laser", "ok", "ops", 10)
         assert t.body == "### Laser\n#laser\n"
+        assert t.tags == ["laser"]
         assert t.offered_in("ops") and not t.offered_in("scans")
 
     def test_defaults_without_a_header(self) -> None:

--- a/GeecsLogbook/tests/test_seed_templates.py
+++ b/GeecsLogbook/tests/test_seed_templates.py
@@ -85,6 +85,13 @@ class TestLoad:
         """No directory, no buttons, no error."""
         assert load_templates(tmp_path / "nope") == []
 
+    def test_reserved_stems_are_refused(self, tmp_path: Path, caplog) -> None:
+        """blank.md would put a chip on every hand-typed entry; it is skipped."""
+        for name in ("blank", "scan_note", "day_intro", "laser"):
+            (tmp_path / f"{name}.md").write_text(f"#{name}\n")
+        assert [t.name for t in load_templates(tmp_path)] == ["laser"]
+        assert caplog.text.count("is reserved") == 3
+
     def test_unusable_stems_are_skipped(self, tmp_path: Path, caplog) -> None:
         """A stem that cannot be a template name is skipped with a warning."""
         (tmp_path / "ok.md").write_text("fine\n")
@@ -146,6 +153,14 @@ class TestSeedTemplates:
         while seeds._refreshing and time.monotonic() < deadline:
             time.sleep(0.02)
         assert [t.name for t in seeds.current()] == ["laser"]
+
+
+def test_page_seeds_carry_the_reserved_names() -> None:
+    """The macro hides the chip for exactly the names the loader refuses."""
+    from geecs_logbook.seed_templates import RESERVED_NAMES
+
+    page = SeedTemplates(None).for_page("ops")
+    assert page.quiet == RESERVED_NAMES and page.buttons == [] and page.prefill == {}
 
 
 def test_every_tone_has_a_css_rule() -> None:

--- a/GeecsWebTheme/tests/test_no_literal_colours.py
+++ b/GeecsWebTheme/tests/test_no_literal_colours.py
@@ -40,6 +40,8 @@ _SURFACES = [
     "GEECS-DataPortal/geecs_portal/templates/run.html",
     "GeecsLogbook/geecs_logbook/static/scanlog.css",
     "GeecsLogbook/geecs_logbook/templates/day.html",
+    "GeecsLogbook/geecs_logbook/templates/month.html",
+    "GeecsLogbook/geecs_logbook/templates/_entries.html",
     "GeecsLogbook/geecs_logbook/static/editor.js",
     "ScanAnalysis/scan_analysis/config_editor/static/editor.css",
     "ScanAnalysis/scan_analysis/config_editor/templates/editor.html",
@@ -298,9 +300,15 @@ def test_every_referenced_token_is_defined() -> None:
     ref = re.compile(
         r"var\(\s*(--[\w-]+)|getPropertyValue\(\s*[\"'`](--[\w-]+)|\$tok:(--[\w-]+)"
     )
+    # A surface may define an indirection of its own — ``.tone-ok{--tone:
+    # var(--ok)}`` — so one rule can read ``var(--tone)`` for any of ten
+    # tones. It counts as defined only when its value is itself a token;
+    # a local property holding a literal is caught by the literal guard.
+    local = re.compile(r"(--[\w-]+)\s*:\s*var\(\s*--[\w-]+\s*\)")
     for relative in _SURFACES + ["GEECS-DataPortal/geecs_portal/figures.py"]:
         text = (_REPO / relative).read_text()
         names = {g for m in ref.finditer(text) for g in m.groups() if g}
+        names -= set(local.findall(text))
         # --trace-${i} is built from a prefix at runtime; "--name" is the
         # documentation placeholder in comments explaining the sentinel form.
         names = {n for n in names if not n.endswith("-") and n != "--name"}

--- a/deploy/bootstrap_host.sh
+++ b/deploy/bootstrap_host.sh
@@ -44,7 +44,7 @@ SITE_ENV="$(cd "$(dirname "$SITE_ENV")" && pwd)/$(basename "$SITE_ENV")"   # abs
 load_site_env "$SITE_ENV"
 check_site_env_consistency
 require_site_keys GEECS_SERVICE_USER GEECS_SERVICE_HOME GEECS_CHECKOUT_ROOT GEECS_POETRY GEECS_REPO_URL \
-    GEECS_TILED_URI GEECS_QSERVER_HOST GEECS_DATA_ROOT
+    GEECS_TILED_URI GEECS_QSERVER_HOST GEECS_DATA_ROOT GEECS_PORTAL_MEMORY_HIGH GEECS_PORTAL_MEMORY_MAX
 require_runtime_keys
 # Read AFTER site.env is loaded (it may set the knob) — the same one
 # render_units.sh honours, so the rendered EnvironmentFile= path and the

--- a/deploy/render_units.sh
+++ b/deploy/render_units.sh
@@ -15,7 +15,9 @@
 # EnvironmentFile= ONLY in command arguments — never in WorkingDirectory=,
 # User=, Environment= lines, or the executable path. So paths and identity
 # are filled here at install time (@CHECKOUT_ROOT@, @SERVICE_USER@,
-# @SERVICE_HOME@, @POETRY@, @SITE_ENV@) and runtime values (experiment,
+# @SERVICE_HOME@, @POETRY@, @SITE_ENV@, the portal's @PORTAL_MEMORY_HIGH@
+# / @PORTAL_MEMORY_MAX@ — resource directives take no variables either)
+# and runtime values (experiment,
 # EPICS addressing, TZ) reach the process through EnvironmentFile= at
 # start. See docs/platform/site_profile.md.
 #
@@ -41,7 +43,8 @@ check_site_env_consistency
 # Every key a template consumes: an unset ${VAR} in an ExecStart argument
 # expands to an EMPTY argument (not to nothing), so a missing key must fail
 # here, not on the host at 03:00.
-require_site_keys GEECS_SERVICE_USER GEECS_SERVICE_HOME GEECS_CHECKOUT_ROOT GEECS_POETRY
+require_site_keys GEECS_SERVICE_USER GEECS_SERVICE_HOME GEECS_CHECKOUT_ROOT GEECS_POETRY \
+    GEECS_PORTAL_MEMORY_HIGH GEECS_PORTAL_MEMORY_MAX
 require_runtime_keys
 
 # The templates: one per service family. Default = this clone's copies;
@@ -78,6 +81,8 @@ for t in "${TEMPLATES[@]}"; do
         -e "s|@CHECKOUT_ROOT@|$GEECS_CHECKOUT_ROOT|g" \
         -e "s|@POETRY@|$GEECS_POETRY|g" \
         -e "s|@SITE_ENV@|$SITE_ENV_INSTALLED|g" \
+        -e "s|@PORTAL_MEMORY_HIGH@|$GEECS_PORTAL_MEMORY_HIGH|g" \
+        -e "s|@PORTAL_MEMORY_MAX@|$GEECS_PORTAL_MEMORY_MAX|g" \
         "$src" > "$dst"
     # Comments may mention @PLACEHOLDER@ by name; only directive lines count.
     if unit_directives "$dst" | grep -q '@[A-Z_]*@'; then

--- a/deploy/site.env.example
+++ b/deploy/site.env.example
@@ -91,3 +91,11 @@ GEECS_CONFIGS_ROOT="/mnt/hdna2/software/control-all-loasis/HTU/Active Version/GE
 # a site value) and mirrored as markdown into each day's logbook/ folder on
 # the share; add --notes-db PATH here only to put the file elsewhere.
 GEECS_PORTAL_EXTRA_ARGS=--config-editor --scan-log
+# Memory ceiling for the portal service (install-time; rendered into the
+# unit's MemoryHigh=/MemoryMax=). systemd sizes: 3G, 4096M, 25%. Above
+# HIGH the portal is throttled and reclaimed; at MAX it is killed and
+# restarted — so a runaway portal evicts itself before the kernel picks a
+# victim on the shared box (#834). 3G/4G suit the 16 GB reference host;
+# size for the host's RAM and the other services on it.
+GEECS_PORTAL_MEMORY_HIGH=3G
+GEECS_PORTAL_MEMORY_MAX=4G

--- a/docs/platform/site_profile.md
+++ b/docs/platform/site_profile.md
@@ -54,7 +54,10 @@ Two kinds of keys, documented line by line in the example file:
   address, never the client `config.ini`.
 - **Install-time values** — the service account and its home, the
   checkout root, the absolute poetry path, the repo URL, the Tiled URI,
-  the queueserver host, the data-share mount, the configs-repo path.
+  the queueserver host, the data-share mount, the configs-repo path, and
+  the portal's memory ceiling (`GEECS_PORTAL_MEMORY_HIGH` /
+  `GEECS_PORTAL_MEMORY_MAX`, rendered into the unit's `MemoryHigh=` /
+  `MemoryMax=` — resource directives take no variables either).
   These fill the unit templates' placeholders and the rendered
   `config.ini`; they are harmless in the process environment.
 
@@ -72,7 +75,7 @@ arguments**. It does not expand in `WorkingDirectory=`, `User=`,
 
 | Hole | Filled | Examples |
 |---|---|---|
-| `@PLACEHOLDER@` | at render time, by `deploy/render_units.sh` (one `sed`) | `@SERVICE_USER@`, `@SERVICE_HOME@`, `@CHECKOUT_ROOT@`, `@POETRY@`, `@SITE_ENV@` |
+| `@PLACEHOLDER@` | at render time, by `deploy/render_units.sh` (one `sed`) | `@SERVICE_USER@`, `@SERVICE_HOME@`, `@CHECKOUT_ROOT@`, `@POETRY@`, `@SITE_ENV@`, `@PORTAL_MEMORY_HIGH@`, `@PORTAL_MEMORY_MAX@` |
 | `${VARIABLE}` | at start, by systemd from `site.env` | `--experiment ${GEECS_EXPERIMENT}`, `--doc-addr ${GEECS_QS_DOC_ADDR}`, `--processing-configs "${GEECS_CONFIGS_ROOT}/scan_analysis_configs"` (quoted: substituted as one argument, spaces survive) |
 | `$VARIABLE` (unbraced) | at start, by systemd from `site.env` | `$GEECS_PORTAL_EXTRA_ARGS` — split on whitespace into several arguments; unset adds nothing. For optional flag lists only (the portal's `--config-editor`) |
 


### PR DESCRIPTION
Phase 05 of the logbook arc (into `feature/scan-logger`; follows #825, #831, #832, #835, #837). After this PR the **ops book is functionally complete**: the second book gets its page, entries get types, and the two books point at each other.

## What

**GeecsLogbook 0.5.0**

- `GET /log/month/{YYYY-MM}` — the ops book. Every `ops` entry in the month grouped by day, newest day first; one composer with a date picker (defaults to today when the month is current, else the month's edge; "+ note" on a day group points it at that day); prev/next month + a month picker; tag chips as URL filters (`?tag=laser`) — chips count the whole month while the list shows the filtered part. **Reads only the notes store, never the share** (pinned: the test makes the share reader explode). `GET /log/api/month/{YYYY-MM}/entries?book=&tag=` is the JSON peer.
- **Seed templates as type buttons** (`seed_templates.py`): `*.md` files in a directory the host names (`create_log_router(templates_dir=)`). Front-matter `label` / `colour` / `book` / `order`, body = the prefill carrying its `#tag`. A button press inserts the prefill and the entry records the template's name (provenance only); a stored entry shows its template as a chip in the file's tone. `colour` is a **theme token name** from a closed vocabulary (`TONES`, pinned against `scanlog.css` in both directions; unknown → `accent` + warning), so the configs repo can never put a literal colour on a page. Loaded once at start, refreshed in a background thread when stale (60 s); a failed refresh keeps the last set — the share stays off every page's critical path. `examples/logbook_templates/` is the documented starter set (5 files + README).
- Cross-links: the day page's "N ops notes today →" strip (`ops_count` re-added, links into the month page's day heading) and an "Ops book" topbar link; each day group on the month page links to its day document; "Scan log →" in the month topbar.
- Entry + composer markup moved into shared macros (`templates/_entries.html`) so both books draw them identically; `editor.js` takes the day per form (`.when` input / `data-day` / page), reads prefills from one JSON block, sends `template` on create.
- `CLAUDE.md`: the owed ScanPaths review is now "filed as #839" (was "OWED at master-merge"); templates section documents the format and the vocabulary; month page section.

**GEECS-DataPortal 0.25.0**

- The logbook's templates directory is derived, not flagged: `<configs>/logbook_templates/`, the parent of `--processing-configs` (the checkout the portal already reads). Without that tree the composers are plain.
- **Memory ceiling (#834 tail, Sam: yes 2026-09-11):** `MemoryHigh=@PORTAL_MEMORY_HIGH@` / `MemoryMax=@PORTAL_MEMORY_MAX@` in the unit template, rendered by `render_units.sh` from two new **required** site.env keys `GEECS_PORTAL_MEMORY_HIGH` / `GEECS_PORTAL_MEMORY_MAX` (3G / 4G in the example for the 16 GB reference host). `bootstrap_host.sh` requires them too, so a profile missing them fails at render rather than at 03:00. `DEPLOYMENT.md` documents the shape and the `systemctl set-property` shortcut; `site_profile.md` lists the placeholders.

**GeecsWebTheme** (tests only, no version bump): `month.html` + `_entries.html` added to the guarded surfaces; the referenced-token test now accepts a surface-local indirection (`.tone-ok{--tone:var(--ok)}`) as defined *only when its value is itself a token* — a local property holding a literal is still caught by the literal guard.

## Per-concern LOC

| Concern | ± lines |
|---|---|
| GeecsLogbook (month route, seeds, templates, editor, CSS, tests, docs, examples) | 1546 |
| GEECS-DataPortal code + tests + changelog + CLAUDE/DEPLOYMENT | 124 |
| Unit template + site.env.example + render/bootstrap + site_profile.md (memory ceiling) | 37 |
| GeecsWebTheme guard | 8 |

The memory-ceiling ride-along is a separate concern bundled by the owner's prior yes; it is the 37-line block and is cheap to veto.

## Judgment calls (cheap to veto)

- **Memory keys are required**, not defaulted — matches the site-profile contract ("every runtime/install-time key is required"). Consequence: the running host's `/etc/geecs/site.env` needs the two lines before its next re-render of *any* unit.
- **Templates load synchronously at construction**, then in the background. If the share is dead at portal start, startup blocks on one directory listing (same exposure the day page already has per request).
- **README.md is skipped silently** in the templates directory (a browsed directory has one); any other unusable stem warns.
- **Last type button pressed wins** as the recorded `template` (provenance only; recorded in the deferred table).
- `?book=scans` on the month JSON returns scan-anchored entries too (it is the raw query); the month *page* is ops-only by design.

## Facility-literal check

No new lab literals outside `site.env.example` (3G/4G are host sizes, labelled as the reference deployment) and docstrings.

## Tests

- GeecsLogbook: **181** (was 151; +30: `test_seed_templates.py` 14, `test_month.py` 16)
- GEECS-DataPortal: **256** (+2 in `test_scan_log_mount.py`)
- GeecsWebTheme: **107** (+1 surface parametrisation)
- root `tests/test_render_units_sh.py` + `test_bootstrap_host_sh.py`: 10
- `scripts/check.sh --base origin/feature/scan-logger`: lint + all three suites green.

## Hardware verification

No device or scan-execution surface. **Smoke-tested** on a local server over a temporary share (never the real one): month page with four seeded ops entries across three days, tag chips, type buttons per book, tone chips on stored entries, the day page's ops strip — headless-Chrome screenshots inspected. **OWED at deploy**: the host's `site.env` gets the two memory keys; the configs repo gets `logbook_templates/` (copy the examples); `systemctl status geecs-data-portal` shows `Memory:` against the cap. Close #834 on merge to master.
