### PR TITLE
GeecsLogbook 0.6.0: navigation polish (calendar, keys, prefetch, today) + the ARIEL change feed; portal run→log link

### DIFF
--- a/GEECS-DataPortal/CHANGELOG.md
+++ b/GEECS-DataPortal/CHANGELOG.md
@@ -12,7 +12,8 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   when the logbook is mounted, and `GET /api/run/{uid}` carries the same
   URL as `logbook` (null when there is nothing to link). Built from the
   mount prefix and the resolved day folder; the portal still never
-  imports the logbook.
+  imports the logbook. A run from another experiment than the logbook's
+  gets no link — scan numbers restart per experiment (review of #844).
 
 ## [0.25.0] - 2026-09-11
 

--- a/GEECS-DataPortal/CHANGELOG.md
+++ b/GEECS-DataPortal/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this package will be documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.26.0] - 2026-09-12
+
+### Added
+
+- The run page links to its scan's card in the scan logbook
+  (`/log/day/YYYY-MM-DD#ScanNNN`, in the rail beside the day steppers)
+  when the logbook is mounted, and `GET /api/run/{uid}` carries the same
+  URL as `logbook` (null when there is nothing to link). Built from the
+  mount prefix and the resolved day folder; the portal still never
+  imports the logbook.
+
 ## [0.25.0] - 2026-09-11
 
 ### Added

--- a/GEECS-DataPortal/CLAUDE.md
+++ b/GEECS-DataPortal/CLAUDE.md
@@ -168,10 +168,15 @@ tests/
 ```
 
 Routes: `/` (redirect to today) · `/day/{iso}` (run list; `?experiment=`)
-· `/log/day/{iso}` + `/log/api/day/{iso}` (the scans book, `--scan-log`)
+· `/log/day/{iso}` + `/log/api/day/{iso}` (the scans book, `--scan-log`;
+`/log/today` names today)
 · `/log/month/{YYYY-MM}` + `/log/api/month/{YYYY-MM}/entries` (the ops book,
-same flag; store-only, never the share)
-· `/log/api/entries…` (the logbook's entry writes, only with `--notes-db`)
+same flag; store-only, never the share; `/log/month/today`) ·
+`/log/api/month/{YYYY-MM}/days` (the rail calendar's marks: note counts
+from the store plus one listing of the month folder)
+· `/log/api/entries…` (the logbook's entry writes, only with `--notes-db`;
+`GET /log/api/entries?since=` is the change feed — tombstones included,
+cursor-paged — for synchronisers such as ARIEL)
 · `/run/{uid}` (the scan page: rail + Overview/Plot/Images/Analysis tabs
 — Analysis only when runs are possible, see below;
 `?tab=&y=&x=&view=&filters=&bincfg=&display=` is the Plot-tab state,
@@ -210,7 +215,9 @@ agent/script surface; served `no-cache`): `/api/day/{iso}?experiment=&filter=`
 (the run table, newest first, the page's filter haystack) ·
 `/api/run/{uid}` (summary + the Overview table verbatim + start/stop
 docs + `devices` + stepper `neighbours`/`day_runs` +
-`processing_options` + `analysis_enabled`) · `/api/run/{uid}/device?device=`
+`processing_options` + `analysis_enabled` + `logbook`, the run's card in
+the scan logbook or null — only when the logbook is mounted and the run
+belongs to its experiment) · `/api/run/{uid}/device?device=`
 (one device's tier/path via the same `device_kind` probe as the page) ·
 `/api/run/jump/{iso}?prefer=` (the day steppers' target as data).
 The page and JSON routes share `_list_day` / `_neighbours` /

--- a/GEECS-DataPortal/geecs_portal/app.py
+++ b/GEECS-DataPortal/geecs_portal/app.py
@@ -54,6 +54,7 @@ from geecs_data_utils.data.row_filters import filter_mask
 from geecs_data_utils.io.images import average_frames
 from geecs_data_utils.scan_frame import PROVENANCE_RUN, scan_frame
 from geecs_data_utils.tiled_catalog import (
+    RunDetail,
     RunSummary,
     ScanCatalog,
     fmt_time_of_day,
@@ -445,18 +446,24 @@ def create_app(
     scan_log_enabled = False  # set when the logbook router mounts (below)
 
     def _logbook_url(
-        request: Request, run_day: Optional[date], scan_number: int
+        request: Request, detail: RunDetail, run_day: Optional[date]
     ) -> str:
         """The run's entry in the scan logbook, or "" when there is none to link.
 
         The logbook's day page anchors each scan card by its folder name
         (``#Scan012``); the portal knows the mount prefix and the day, so
-        the link is built here without importing the logbook — a
-        peer view layer, reached by URL like any other page.
+        the link is built here without importing the logbook — a peer
+        view layer, reached by URL like any other page. The logbook is
+        mounted for the default experiment alone, and scan numbers
+        restart daily per experiment, so a run from another experiment
+        gets no link rather than a wrong one.
         """
-        if not (scan_log_enabled and run_day and scan_number):
+        summary = detail.summary
+        if not (scan_log_enabled and run_day and summary.scan_number):
             return ""
-        return f"{_root(request)}/log/day/{run_day.isoformat()}#Scan{scan_number:03d}"
+        if summary.experiment and summary.experiment != default_experiment:
+            return ""
+        return f"{_root(request)}/log/day/{run_day.isoformat()}#Scan{summary.scan_number:03d}"
 
     def _load_run(uid: str):
         """Load one run, mapping failures to honest HTTP status codes.
@@ -1391,8 +1398,7 @@ def create_app(
             "processing_options": _processing_names(),
             "analysis_enabled": _analysis_enabled_for(folder),
             "config_editor": config_editor_enabled,
-            "logbook": _logbook_url(request, run_day, detail.summary.scan_number or 0)
-            or None,
+            "logbook": _logbook_url(request, detail, run_day) or None,
             "page": f"{_root(request)}/run/{uid}",
             "portal_version": _portal_version(),
         }
@@ -1615,9 +1621,7 @@ def create_app(
                 "next_uid": next_uid,
                 "day_runs": day_runs,
                 "scan_number": detail.summary.scan_number or 0,
-                "logbook_url": _logbook_url(
-                    request, run_day, detail.summary.scan_number or 0
-                ),
+                "logbook_url": _logbook_url(request, detail, run_day),
                 "prev_day": (
                     (run_day - timedelta(days=1)).isoformat() if run_day else ""
                 ),

--- a/GEECS-DataPortal/geecs_portal/app.py
+++ b/GEECS-DataPortal/geecs_portal/app.py
@@ -442,6 +442,21 @@ def create_app(
     # 2026-08-29 — lazy stays the rule ACROSS scans only).
     data_cache = ShotDataCache()
     config_editor_enabled = False  # set when the editor router mounts (below)
+    scan_log_enabled = False  # set when the logbook router mounts (below)
+
+    def _logbook_url(
+        request: Request, run_day: Optional[date], scan_number: int
+    ) -> str:
+        """The run's entry in the scan logbook, or "" when there is none to link.
+
+        The logbook's day page anchors each scan card by its folder name
+        (``#Scan012``); the portal knows the mount prefix and the day, so
+        the link is built here without importing the logbook — a
+        peer view layer, reached by URL like any other page.
+        """
+        if not (scan_log_enabled and run_day and scan_number):
+            return ""
+        return f"{_root(request)}/log/day/{run_day.isoformat()}#Scan{scan_number:03d}"
 
     def _load_run(uid: str):
         """Load one run, mapping failures to honest HTTP status codes.
@@ -1376,6 +1391,8 @@ def create_app(
             "processing_options": _processing_names(),
             "analysis_enabled": _analysis_enabled_for(folder),
             "config_editor": config_editor_enabled,
+            "logbook": _logbook_url(request, run_day, detail.summary.scan_number or 0)
+            or None,
             "page": f"{_root(request)}/run/{uid}",
             "portal_version": _portal_version(),
         }
@@ -1598,6 +1615,9 @@ def create_app(
                 "next_uid": next_uid,
                 "day_runs": day_runs,
                 "scan_number": detail.summary.scan_number or 0,
+                "logbook_url": _logbook_url(
+                    request, run_day, detail.summary.scan_number or 0
+                ),
                 "prev_day": (
                     (run_day - timedelta(days=1)).isoformat() if run_day else ""
                 ),
@@ -1938,6 +1958,7 @@ def create_app(
                     ),
                     prefix="/log",
                 )
+                scan_log_enabled = True
                 logger.info(
                     "scan log mounted at /log for %s (%s; templates %s)",
                     default_experiment,

--- a/GEECS-DataPortal/geecs_portal/templates/run.html
+++ b/GEECS-DataPortal/geecs_portal/templates/run.html
@@ -145,6 +145,9 @@
         <a class="act" href="{{ root }}/day/{{ run_day }}?{{ qs(device="", shot="") }}" title="browse this day's list">{{ run_day }}</a>
         <a class="act" href="{{ root }}/run/jump/{{ next_day }}?prefer={{ scan_number }}&amp;{{ qs(device="", shot="") }}" title="next day (same scan number, else its latest)">day ›</a>
         {% endif %}
+        {% if logbook_url %}
+        <a class="act logbook" href="{{ logbook_url }}" title="this scan's card in the scan logbook">log ↗</a>
+        {% endif %}
       </div>
       <div class="steprow">
         <a class="act {{ "off" if not prev_uid }}" href="{{ root }}/run/{{ prev_uid }}?{{ qs() }}" title="previous scan">‹ scan</a>

--- a/GEECS-DataPortal/pyproject.toml
+++ b/GEECS-DataPortal/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-data-portal"
-version = "0.25.0"
+version = "0.26.0"
 description = "Scan-browsing web service (read-only except explicit analysis runs): a zero-install browser view over the Tiled catalog and the GEECS data share"
 authors = ["GEECS-BELLA"]
 readme = "README.md"

--- a/GEECS-DataPortal/tests/test_scan_log_mount.py
+++ b/GEECS-DataPortal/tests/test_scan_log_mount.py
@@ -134,3 +134,32 @@ class TestSeedTemplates:
         html = client.get("/log/month/2026-09").text
         assert client.get("/log/month/2026-09").status_code == 200
         assert "typebtn" not in html
+
+
+class TestRunPageLink:
+    """The run page points at its scan's card in the logbook — when there is one."""
+
+    _UID = "uid-002"  # TEST_DAY, Scan 002 in the fake catalog
+
+    def test_present_when_the_logbook_is_mounted(self) -> None:
+        client = TestClient(
+            create_app(FakeCatalog(), default_experiment="Undulator", scan_log=True)
+        )
+        html = client.get(f"/run/{self._UID}").text
+        assert 'href="/log/day/2026-07-12#Scan002"' in html
+        payload = client.get(f"/api/run/{self._UID}").json()
+        assert payload["logbook"] == "/log/day/2026-07-12#Scan002"
+
+    def test_carries_the_proxy_prefix(self) -> None:
+        client = TestClient(
+            create_app(FakeCatalog(), default_experiment="Undulator", scan_log=True)
+        )
+        prefix = {"X-Forwarded-Prefix": "/portal"}
+        html = client.get(f"/run/{self._UID}", headers=prefix).text
+        assert 'href="/portal/log/day/2026-07-12#Scan002"' in html
+
+    def test_absent_when_not_mounted(self) -> None:
+        client = TestClient(create_app(FakeCatalog(), default_experiment="Undulator"))
+        html = client.get(f"/run/{self._UID}").text
+        assert "/log/day/" not in html
+        assert client.get(f"/api/run/{self._UID}").json()["logbook"] is None

--- a/GEECS-DataPortal/tests/test_scan_log_mount.py
+++ b/GEECS-DataPortal/tests/test_scan_log_mount.py
@@ -163,3 +163,18 @@ class TestRunPageLink:
         html = client.get(f"/run/{self._UID}").text
         assert "/log/day/" not in html
         assert client.get(f"/api/run/{self._UID}").json()["logbook"] is None
+
+    def test_absent_for_a_run_from_another_experiment(self) -> None:
+        """The logbook is one experiment's; scan numbers restart per experiment."""
+        import dataclasses
+
+        catalog = FakeCatalog()
+        detail = catalog.details[self._UID]
+        catalog.details[self._UID] = dataclasses.replace(
+            detail, summary=dataclasses.replace(detail.summary, experiment="Thomson")
+        )
+        client = TestClient(
+            create_app(catalog, default_experiment="Undulator", scan_log=True)
+        )
+        assert "/log/day/" not in client.get(f"/run/{self._UID}").text
+        assert client.get(f"/api/run/{self._UID}").json()["logbook"] is None

--- a/GeecsLogbook/CHANGELOG.md
+++ b/GeecsLogbook/CHANGELOG.md
@@ -4,6 +4,43 @@ All notable changes to `geecs-logbook` are documented here. The format
 follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and this
 project adheres to semantic versioning.
 
+## [0.6.0] - 2026-09-12
+
+Navigation polish, and the synchroniser's feed.
+
+### Added
+
+- **A calendar in the rail** of both pages (`static/nav.js`, a
+  `<details class="cal">` drawn on open): a month grid whose days are
+  marked when they have notes (the store's per-day counts) and when a
+  day folder exists on the share. The marks come from a new
+  `GET /log/api/month/{YYYY-MM}/days`, fetched lazily by the open
+  calendar — the month page itself still never touches the share, and
+  the share side is **one** listing of the month folder
+  (`scan_reader.days_with_folders`), never a walk of the days. When the
+  experiment directory is missing the payload says `share: false` and
+  the store's marks stand alone.
+- **Keyboard stepping**: `←` / `→` go to the previous / next day (day
+  page) or month (month page), `t` to today, `c` toggles the calendar;
+  ignored while typing. The pages hand the targets to the script as
+  `data-prev` / `data-next` / `data-today` on `<main>`.
+- **Hover prefetch**: resting on a day or month link adds a
+  `<link rel="prefetch">` for it, so the click that follows is served
+  from the browser's cache. Only links the viewer is about to follow —
+  nothing is fetched speculatively on load.
+- **Today, by name**: `GET /log/today` (the day page) and
+  `GET /log/month/today` (this month, at today's day group). The month
+  rail's Today control is now always present, not only as a way back
+  from another month.
+- **The change feed** — `GET /log/api/entries?since=<aware ISO 8601>`:
+  every entry whose `updated_at` moved after `since`, oldest change
+  first, **tombstones included** (the one listing that returns them —
+  a delete is a change a downstream copy must learn). `until=`,
+  `book=`, `include_deleted=false` narrow it; `limit=` pages it with a
+  `next_cursor` that resumes after the last row even when rows share an
+  `updated_at`. `NotesStore.changed_since` and `NotesStore.count_by_day`
+  are the store methods behind the feed and the calendar.
+
 ## [0.5.0] - 2026-09-11
 
 The ops book: the second book gets its page, and entries get types.

--- a/GeecsLogbook/CHANGELOG.md
+++ b/GeecsLogbook/CHANGELOG.md
@@ -41,6 +41,18 @@ Navigation polish, and the synchroniser's feed.
   `updated_at`. `NotesStore.changed_since` and `NotesStore.count_by_day`
   are the store methods behind the feed and the calendar.
 
+### Changed
+
+- `NotesStore.create` takes its timestamp under the write lock, as every
+  other writer already did, so two concurrent creates cannot commit out
+  of stamp order and slip past a synchroniser's high-water mark (review
+  of #844). The feed's cursor is opaque and URL-safe (a pasted, unencoded
+  cursor no longer re-sends the boundary row) and a corrupted one is a
+  422, not a quiet "caught up". `/api/month/{m}/days` turns a share I/O
+  error into `share: false` and anything else into a 503, like the day
+  page. Keyboard stepping is refused while a composer holds unsaved text;
+  the prefetch dwell is 250 ms so a pass over the rail prefetches nothing.
+
 ## [0.5.0] - 2026-09-11
 
 The ops book: the second book gets its page, and entries get types.

--- a/GeecsLogbook/CLAUDE.md
+++ b/GeecsLogbook/CLAUDE.md
@@ -177,12 +177,17 @@ listing explode under the month page). A missing experiment directory
 comes back as `share: false` — said, not hidden — and the store's marks
 stand on their own.
 
-"Faster day switching" is keyboard stepping (`←` `→` `t` `c`) and a
-`<link rel="prefetch">` added when the viewer rests on a day or month
-link — the page they are about to open is served warm. Nothing is
-prefetched on load: every day page is a share read, and the rail offers
-fifteen of them. `/log/today` and `/log/month/today` are the bookmarkable
-names.
+"Faster day switching" is keyboard stepping (`←` `→` `t` `c`; refused
+while any composer holds unsaved text — a shortcut must never discard a
+note) and a `<link rel="prefetch">` added when the viewer **rests** on a
+day or month link for 250 ms — the page they are about to open is served
+warm. Nothing is prefetched on load: every day page is a share read, and
+the rail offers fifteen of them; the dwell is what keeps a pass over the
+rail from prefetching them all. The trade-off, stated: the pages send no
+freshness headers, and Chrome may reuse a prefetched document for a few
+minutes without asking, so a scan that landed between the hover and the
+click appears on the next reload. `/log/today` and `/log/month/today`
+are the bookmarkable names.
 
 ## The change feed
 
@@ -335,6 +340,7 @@ is where that is tracked.
 | `EntryCreate` (the write shape) lives in the router, `LogEntry` (the stored shape) in `geecs_schemas` | An agent posts the create shape, so it belongs beside `LogEntry` for GEECS-MCP to validate. Moves with the agent-verbs phase, which is its first second consumer. |
 | A third private atomic-write helper (`_fs.replace_with`; `scan_analysis.config_store` and `task_queue` have their own) and `logbook_root` re-deriving the daily folder | Fold into the `ScanPaths`/`ScanData` review, #839 — same home, same issue. |
 | Which template "started" an entry when several buttons were pressed | The last one pressed is recorded. Provenance only; nothing reads it back but the chip. |
+| `scan_reader.month_folder` / `days_with_folders` are a third copy of the share-layout walk (`.parent` chains up from `get_daily_scan_folder`; a `YY_MMDD` parser beside `ScanPaths.get_scan_tag`'s and `scans_database.builder`'s `strptime("%y_%m%d")`), after `mirror.logbook_root` and `read_day` | The layout has one builder in `geecs_data_utils.scan_paths` and should have one reader there (`day_folder_date(name)`, `list_day_folders(month)`), which is exactly #839's brief. Recorded on #839 at the review of #844; not lifted here so the logbook keeps depending on `ScanPaths` alone. |
 | `seed_templates.parse_template` is the package's first front-matter reader, while `mirror.render` is its writer | One reader, one writer, different shapes today (the template header has no lists). When the mirror *reader* lands (off-site/rebuild, deferred above), extract one `parse_front_matter` beside `mirror` and point both at it — not before there is a second caller. Waived in the review of #842. |
 
 ## Deployment

--- a/GeecsLogbook/CLAUDE.md
+++ b/GeecsLogbook/CLAUDE.md
@@ -118,8 +118,9 @@ package. Rules the store enforces, each pinned in `tests/test_store.py`:
   `GET /api/entries/{id}/history` serves it; undo is a new edit with an
   old body. Nothing rewrites history.
 - **One query.** `NotesStore.query(day range, book, tag, kind, status,
-  author, include_scan_anchored)` is the month page, its filter chips, a
-  search, and a synchroniser's "everything since" — one method, not four.
+  author, include_scan_anchored)` is the month page, its filter chips and
+  a search — one method, not three. A synchroniser asks a different
+  question ("what changed"), answered by `changed_since` below.
 - **An agent's entry is born a draft.** `kind` other than `note` with
   `status="kept"` is refused at creation. A person keeps it via the status
   route; an agent has no route to promote itself. A *promoted* agent entry
@@ -131,8 +132,9 @@ package. Rules the store enforces, each pinned in `tests/test_store.py`:
   "everything since".
 - **Delete is a tombstone.** `deleted_at` is set, listings hide the row,
   writes to it fail as if it were missing, and the mirror sync removes the
-  file. The row stays so a downstream copy can learn it went and an
-  accidental delete is a field to clear.
+  file. The row stays so a downstream copy can learn it went (through the
+  change feed, the one listing that shows it) and an accidental delete is
+  a field to clear.
 - **Optimistic locking.** Every edit carries the `version` it read; a
   mismatch is a 409 with the current entry, never a silently eaten
   paragraph.
@@ -156,6 +158,46 @@ into the month's day heading, and every day group on the month page
 links to its day document. The pages share one set of Jinja macros
 (`templates/_entries.html`): an entry and a composer look the same in
 either book, and the editor script meets one shape of form.
+
+## Navigation
+
+`static/nav.js` is the other script both pages load: the rail calendar,
+keyboard stepping and hover prefetch. Like the editor it reads its facts
+off `<main id="logbook">` (`data-api`, `data-day` or `data-month`,
+`data-prev`, `data-next`, `data-today`) and templates nothing.
+
+The **calendar** is a `<details>` the script fills when opened. Its marks
+come from `GET /api/month/{m}/days` — the store's per-day counts (one
+grouped query) plus which day folders exist. The share side of that is
+**one listing of the month folder** (`scan_reader.days_with_folders`),
+never thirty per-day walks, and it is a lazy fetch by the *open*
+calendar, so the month page keeps its promise: the page itself still
+reads the store alone (pinned in `tests/test_nav.py`, which makes the
+listing explode under the month page). A missing experiment directory
+comes back as `share: false` — said, not hidden — and the store's marks
+stand on their own.
+
+"Faster day switching" is keyboard stepping (`←` `→` `t` `c`) and a
+`<link rel="prefetch">` added when the viewer rests on a day or month
+link — the page they are about to open is served warm. Nothing is
+prefetched on load: every day page is a share read, and the rail offers
+fifteen of them. `/log/today` and `/log/month/today` are the bookmarkable
+names.
+
+## The change feed
+
+`GET /api/entries?since=<aware ISO 8601>` (`NotesStore.changed_since`) is
+the synchroniser's listing — ARIEL's, first: everything whose
+`updated_at` moved after `since`, oldest change first, **tombstones
+included**. It is the one listing that returns a deleted row, because a
+deletion is a change a downstream copy has to learn, and this is the
+only place it can. Rows are ordered `(updated_at, rowid)` and a full
+page carries a `next_cursor` that resumes after its last row, so two
+entries sharing an `updated_at` across a page boundary cannot lose one.
+`since` must carry a timezone — the columns are UTC `isoformat()`
+strings and a naive value would be compared in a zone nobody stated.
+Scans are not in this feed; a since-filtered scan list waits for a
+caller that finds walking the day endpoints too slow.
 
 ## The editor
 

--- a/GeecsLogbook/geecs_logbook/routes/day.py
+++ b/GeecsLogbook/geecs_logbook/routes/day.py
@@ -1,6 +1,7 @@
 """The scans book: the day document and its JSON peers.
 
 ``GET /log/``                         redirect to today
+``GET /log/today``                    the same, as a bookmarkable name
 ``GET /log/static/{name}``            the page's own assets
 ``GET /log/day/{day}``                the day document
 ``GET /log/api/day/{day}``            the derived half (scan folders) as JSON
@@ -45,6 +46,11 @@ def register(router: APIRouter, ctx: Context) -> None:
     @router.get("/", response_class=RedirectResponse)
     def _today() -> RedirectResponse:
         """Redirect to today's log."""
+        return RedirectResponse(url=f"day/{date.today().isoformat()}")
+
+    @router.get("/today", response_class=RedirectResponse)
+    def _today_named() -> RedirectResponse:
+        """Redirect to today's log — a name a bookmark or a link can use."""
         return RedirectResponse(url=f"day/{date.today().isoformat()}")
 
     @router.get("/static/{name}")

--- a/GeecsLogbook/geecs_logbook/routes/entries.py
+++ b/GeecsLogbook/geecs_logbook/routes/entries.py
@@ -129,18 +129,21 @@ def register(router: APIRouter, ctx: Context) -> None:
         until: Optional[datetime] = Query(None, description="Aware ISO 8601."),
         book: Optional[Book] = None,
         include_deleted: bool = True,
-        cursor: Optional[str] = Query(None, max_length=64),
+        cursor: Optional[str] = Query(None, max_length=128),
         limit: int = Query(500, ge=1, le=2000),
     ) -> ChangeFeed:
         """List what changed after ``since``, oldest change first.
 
         The synchroniser's endpoint. A promotion, an upload or a delete
         moves ``updated_at`` like an edit does, so a copy that asks for
-        "everything since my last ``updated_at``" misses nothing — and it
-        is the one listing that returns **tombstones**, since a deletion
-        is a change too. Either ``since`` or ``cursor`` is required; a
-        full page carries ``next_cursor``, which resumes after its last
-        row even when several rows share an ``updated_at``.
+        "everything since my last ``updated_at``" misses nothing (stamps
+        are taken under the store's write lock, so they commit in order;
+        overlapping ``since`` by a few seconds is belt and braces, and a
+        re-sent row is the same row) — and it is the one listing that
+        returns **tombstones**, since a deletion is a change too. Either
+        ``since`` or ``cursor`` is required; a full page carries
+        ``next_cursor`` — opaque, URL-safe — which resumes after its
+        last row even when several rows share an ``updated_at``.
         """
         if since is None and cursor is None:
             raise HTTPException(status_code=422, detail="since or cursor is required")

--- a/GeecsLogbook/geecs_logbook/routes/entries.py
+++ b/GeecsLogbook/geecs_logbook/routes/entries.py
@@ -9,13 +9,18 @@ and the share second; see :mod:`geecs_logbook.mirror` for why that order.
 ``DELETE /log/api/entries/{id}``                tombstone (204)
 ``GET    /log/api/entries/{id}``                one entry
 ``GET    /log/api/entries/{id}/history``        its earlier states
+``GET    /log/api/entries?since=``              the change feed: everything
+                                                whose ``updated_at`` moved
+                                                after ``since``, tombstones
+                                                included, in change order
 """
 
 from __future__ import annotations
 
+from datetime import datetime, timezone
 from typing import Optional
 
-from fastapi import APIRouter, HTTPException, Request, Response
+from fastapi import APIRouter, HTTPException, Query, Request, Response
 from geecs_schemas.log_entry import Book, EntryKind, EntryStatus, LogEntry
 from pydantic import BaseModel, Field
 
@@ -79,6 +84,19 @@ class HistoryItem(BaseModel):
     entry: LogEntry
 
 
+class ChangeFeed(BaseModel):
+    """A page of the change feed."""
+
+    entries: list[LogEntry] = Field(
+        description="Ordered by updated_at, then by row; tombstones included."
+    )
+    next_cursor: Optional[str] = Field(
+        None,
+        description="Pass back as ?cursor= to continue; null when this page"
+        " was the last.",
+    )
+
+
 def register(router: APIRouter, ctx: Context) -> None:
     """Add the entry routes to ``router``. Requires a store."""
     store = ctx.store
@@ -102,6 +120,47 @@ def register(router: APIRouter, ctx: Context) -> None:
             raise HTTPException(status_code=422, detail=str(exc)) from exc
         ctx.mirror(entry.entry_id)
         return store.get(entry.entry_id) or entry
+
+    @router.get("/api/entries")
+    def _changed(
+        since: Optional[datetime] = Query(
+            None, description="Aware ISO 8601; changes strictly after this."
+        ),
+        until: Optional[datetime] = Query(None, description="Aware ISO 8601."),
+        book: Optional[Book] = None,
+        include_deleted: bool = True,
+        cursor: Optional[str] = Query(None, max_length=64),
+        limit: int = Query(500, ge=1, le=2000),
+    ) -> ChangeFeed:
+        """List what changed after ``since``, oldest change first.
+
+        The synchroniser's endpoint. A promotion, an upload or a delete
+        moves ``updated_at`` like an edit does, so a copy that asks for
+        "everything since my last ``updated_at``" misses nothing — and it
+        is the one listing that returns **tombstones**, since a deletion
+        is a change too. Either ``since`` or ``cursor`` is required; a
+        full page carries ``next_cursor``, which resumes after its last
+        row even when several rows share an ``updated_at``.
+        """
+        if since is None and cursor is None:
+            raise HTTPException(status_code=422, detail="since or cursor is required")
+        for name, value in (("since", since), ("until", until)):
+            if value is not None and value.tzinfo is None:
+                raise HTTPException(
+                    status_code=422, detail=f"{name} must carry a timezone"
+                )
+        try:
+            page = store.changed_since(
+                since or datetime.min.replace(tzinfo=timezone.utc),
+                until=until,
+                book=book,
+                include_deleted=include_deleted,
+                cursor=cursor,
+                limit=limit,
+            )
+        except ValueError as exc:  # a malformed cursor
+            raise HTTPException(status_code=422, detail=str(exc)) from exc
+        return ChangeFeed(entries=page.entries, next_cursor=page.next_cursor)
 
     @router.get("/api/entries/{entry_id}")
     def _one(entry_id: str) -> LogEntry:

--- a/GeecsLogbook/geecs_logbook/routes/month.py
+++ b/GeecsLogbook/geecs_logbook/routes/month.py
@@ -1,7 +1,11 @@
 """The ops book: a month of day-level entries, read from the store alone.
 
+``GET /log/month/today``                     redirect to this month, at today
 ``GET /log/month/{YYYY-MM}``                 the month page (``?tag=`` filters)
 ``GET /log/api/month/{YYYY-MM}/entries``     the month's entries as JSON
+``GET /log/api/month/{YYYY-MM}/days``        calendar marks: which days have
+                                             notes (the store) and a day
+                                             folder (one listing of the share)
 
 The scans book is a day document over scan folders; the ops book is what
 happened around them — laser notes, maintenance, a shift handover — and
@@ -17,8 +21,9 @@ from datetime import date
 from typing import Optional
 
 from fastapi import APIRouter, Query, Request
-from fastapi.responses import HTMLResponse
+from fastapi.responses import HTMLResponse, RedirectResponse
 from geecs_schemas.log_entry import Book, LogEntry
+from pydantic import BaseModel, Field
 
 from geecs_logbook.routes.attachments import ATTACHMENT_TYPES
 from geecs_logbook.routes._common import (
@@ -27,11 +32,34 @@ from geecs_logbook.routes._common import (
     api_base,
     month_last_day,
     month_step,
+    month_url,
     parse_month,
 )
+from geecs_logbook.scan_reader import days_with_folders
 
 #: The book the month page shows. The scans book has its own page.
 BOOK = "ops"
+
+
+class DayMarks(BaseModel):
+    """What a calendar shows for one day."""
+
+    folder: bool = Field(description="A day folder exists on the share.")
+    notes: int = Field(0, description="Live entries in the scans book.")
+    ops: int = Field(0, description="Live entries in the ops book.")
+
+
+class MonthMarks(BaseModel):
+    """Calendar marks for a month — the lazy fetch behind the rail's calendar."""
+
+    month: str = Field(description="``YYYY-MM``.")
+    share: bool = Field(
+        description="Whether the share answered; when false, ``folder`` is"
+        " unknown for every day and only the store's marks are real."
+    )
+    days: dict[str, DayMarks] = Field(
+        description="Days with anything to mark, keyed ``YYYY-MM-DD``."
+    )
 
 
 def register(router: APIRouter, ctx: Context) -> None:
@@ -42,6 +70,14 @@ def register(router: APIRouter, ctx: Context) -> None:
             return []
         return ctx.store.query(
             day_from=first.isoformat(), day_to=last.isoformat(), book=BOOK
+        )
+
+    @router.get("/month/today", response_class=RedirectResponse)
+    def _this_month() -> RedirectResponse:
+        """Redirect to this month's page, at today's day group."""
+        today = date.today()
+        return RedirectResponse(
+            url=f"{today.strftime('%Y-%m')}#day-{today.isoformat()}"
         )
 
     @router.get("/month/{month}", response_class=HTMLResponse)
@@ -94,6 +130,7 @@ def register(router: APIRouter, ctx: Context) -> None:
                 "tags": sorted(tag_counts.items(), key=lambda kv: (-kv[1], kv[0])),
                 "active_tag": active,
                 "compose_day": compose_day,
+                "today_url": month_url(request, today, anchor=True),
                 "writable": ctx.writable,
                 "api_base": api_base(request),
                 "accept": ",".join(sorted(ATTACHMENT_TYPES)),
@@ -120,4 +157,41 @@ def register(router: APIRouter, ctx: Context) -> None:
             day_to=month_last_day(first).isoformat(),
             book=book,
             tag=tag,
+        )
+
+    @router.get("/api/month/{month}/days")
+    def _month_days(month: str) -> MonthMarks:
+        """Return the calendar's marks for one month.
+
+        Two cheap questions: the store's per-day counts (one grouped
+        query) and which day folders exist (one listing of the month
+        folder — never a walk of the days). The month **page** never calls
+        this on its own path; the calendar fetches it when opened, so a
+        slow share delays a popup, not a page.
+        """
+        first = parse_month(month)
+        last = month_last_day(first)
+        counts = (
+            ctx.store.count_by_day(first.isoformat(), last.isoformat())
+            if ctx.store is not None
+            else {}
+        )
+        folders = days_with_folders(first, ctx.experiment, ctx.base_directory)
+        days: dict[str, DayMarks] = {}
+        for day, by_book in counts.items():
+            days[day] = DayMarks(
+                folder=False,
+                notes=by_book.get("scans", 0),
+                ops=by_book.get("ops", 0),
+            )
+        for day in folders or ():
+            key = day.isoformat()
+            if key in days:
+                days[key].folder = True
+            else:
+                days[key] = DayMarks(folder=True)
+        return MonthMarks(
+            month=first.strftime("%Y-%m"),
+            share=folders is not None,
+            days=dict(sorted(days.items())),
         )

--- a/GeecsLogbook/geecs_logbook/routes/month.py
+++ b/GeecsLogbook/geecs_logbook/routes/month.py
@@ -16,11 +16,12 @@ bad day: when the share is slow the month page is not.
 
 from __future__ import annotations
 
+import logging
 from collections import Counter
 from datetime import date
 from typing import Optional
 
-from fastapi import APIRouter, Query, Request
+from fastapi import APIRouter, HTTPException, Query, Request
 from fastapi.responses import HTMLResponse, RedirectResponse
 from geecs_schemas.log_entry import Book, LogEntry
 from pydantic import BaseModel, Field
@@ -36,6 +37,8 @@ from geecs_logbook.routes._common import (
     parse_month,
 )
 from geecs_logbook.scan_reader import days_with_folders
+
+logger = logging.getLogger(__name__)
 
 #: The book the month page shows. The scans book has its own page.
 BOOK = "ops"
@@ -176,7 +179,13 @@ def register(router: APIRouter, ctx: Context) -> None:
             if ctx.store is not None
             else {}
         )
-        folders = days_with_folders(first, ctx.experiment, ctx.base_directory)
+        try:
+            folders = days_with_folders(first, ctx.experiment, ctx.base_directory)
+        except Exception as exc:  # noqa: BLE001 — the same honesty as load_day
+            logger.exception("listing the month folder for %s failed", month)
+            raise HTTPException(
+                status_code=503, detail=f"data share unavailable: {exc}"
+            ) from exc
         days: dict[str, DayMarks] = {}
         for day, by_book in counts.items():
             days[day] = DayMarks(

--- a/GeecsLogbook/geecs_logbook/scan_reader.py
+++ b/GeecsLogbook/geecs_logbook/scan_reader.py
@@ -377,12 +377,12 @@ def days_with_folders(
     different fact from "nothing happened this month" and the caller
     should say so. A month folder that does not exist is an empty set.
     """
-    folder = month_folder(first, experiment, base_directory)
-    if not folder.parent.parent.is_dir():  # {base}/{experiment}
-        logger.warning("experiment directory missing: %s", folder.parent.parent)
-        return None
     found: set[date] = set()
     try:
+        folder = month_folder(first, experiment, base_directory)
+        if not folder.parent.parent.is_dir():  # {base}/{experiment}
+            logger.warning("experiment directory missing: %s", folder.parent.parent)
+            return None
         with os.scandir(folder) as entries:
             for entry in entries:
                 match = _DAY_DIR.match(entry.name)
@@ -397,9 +397,9 @@ def days_with_folders(
                 except ValueError:
                     continue
     except FileNotFoundError:
-        return found
-    except OSError as exc:
-        logger.warning("cannot list %s: %s", folder, exc)
+        return found  # no month folder: nothing happened this month
+    except OSError as exc:  # EACCES, EIO, a wedged mount — the share, not the month
+        logger.warning("cannot list the month folder for %s: %s", first, exc)
         return None
     return found
 

--- a/GeecsLogbook/geecs_logbook/scan_reader.py
+++ b/GeecsLogbook/geecs_logbook/scan_reader.py
@@ -341,6 +341,69 @@ def _summarize(
     )
 
 
+#: ``YY_MMDD`` day folders inside a month folder.
+_DAY_DIR = re.compile(r"^(\d{2})_(\d{2})(\d{2})$")
+
+
+def month_folder(
+    first: date, experiment: str, base_directory: Optional[Union[Path, str]] = None
+) -> Path:
+    """Return the month directory holding a month's day folders.
+
+    ``{base}/{experiment}/Y2026/09-Sep`` — derived from the same builder
+    the day reader uses, so the two cannot disagree about the layout.
+    """
+    tag = ScanPaths.get_scan_tag(
+        first.year, first.month, 1, number=0, experiment=experiment
+    )
+    return ScanPaths.get_daily_scan_folder(
+        tag=tag, base_directory=base_directory
+    ).parent.parent
+
+
+def days_with_folders(
+    first: date,
+    experiment: str,
+    base_directory: Optional[Union[Path, str]] = None,
+) -> Optional[set[date]]:
+    """Return the dates in ``first``'s month that have a day folder.
+
+    **One** directory listing of the month folder — never a walk of
+    thirty day folders. A day folder exists because something wrote into
+    it (a scan, an analysis pass), which is what a calendar wants to mark.
+
+    Returns ``None`` when the experiment directory itself is missing: the
+    share is not mounted where this service expects it, which is a
+    different fact from "nothing happened this month" and the caller
+    should say so. A month folder that does not exist is an empty set.
+    """
+    folder = month_folder(first, experiment, base_directory)
+    if not folder.parent.parent.is_dir():  # {base}/{experiment}
+        logger.warning("experiment directory missing: %s", folder.parent.parent)
+        return None
+    found: set[date] = set()
+    try:
+        with os.scandir(folder) as entries:
+            for entry in entries:
+                match = _DAY_DIR.match(entry.name)
+                if not match or not entry.is_dir():
+                    continue
+                yy, mm, dd = (int(g) for g in match.groups())
+                # Only this month's shape; a stray folder is not a day.
+                if 2000 + yy != first.year or mm != first.month:
+                    continue
+                try:
+                    found.add(date(first.year, mm, dd))
+                except ValueError:
+                    continue
+    except FileNotFoundError:
+        return found
+    except OSError as exc:
+        logger.warning("cannot list %s: %s", folder, exc)
+        return None
+    return found
+
+
 def read_day(
     when: date,
     experiment: str,

--- a/GeecsLogbook/geecs_logbook/static/nav.js
+++ b/GeecsLogbook/geecs_logbook/static/nav.js
@@ -1,0 +1,204 @@
+/* GeecsLogbook navigation — the rail's calendar, keyboard stepping, and
+ * hover prefetch. One file for both pages: the day page steps by day,
+ * the month page by month; the calendar is the same grid on either.
+ *
+ * The page hands it its facts through <main id="logbook" data-api
+ * data-day|data-month data-prev data-next data-today>; nothing is
+ * templated into this file. Every URL the calendar builds is derived
+ * from data-api, so a mount prefix or a proxy root_path carries through.
+ *
+ *   - Calendar: a <details class="cal"> in the rail. Opening it fetches
+ *     /api/month/{m}/days — the store's per-day counts plus which day
+ *     folders exist (one listing of the month folder on the server). The
+ *     page itself never asks; only the open calendar does, so a slow
+ *     share delays a popup, not a page. Months are cached per page load.
+ *   - Keys: ← / → step to the previous / next day (or month), t goes to
+ *     today. Ignored while typing in a field.
+ *   - Prefetch: hovering a day or month link for a moment adds a
+ *     <link rel="prefetch">, so the click that follows is served warm.
+ *
+ * Styling is entirely through the page's tokens; this file sets no colours.
+ */
+(function () {
+  "use strict";
+
+  const host = document.getElementById("logbook");
+  if (!host) return;
+  const API = host.dataset.api || "";
+  const ROOT = API.replace(/\/api$/, "");
+  const PAGE_DAY = host.dataset.day || "";        // day page: YYYY-MM-DD
+  const PAGE_MONTH = host.dataset.month || "";    // month page: YYYY-MM
+  const OPEN_KEY = "scanlog.calendarOpen";
+
+  const pad = (n) => String(n).padStart(2, "0");
+  const iso = (y, m, d) => `${y}-${pad(m)}-${pad(d)}`;
+  const todayIso = () => { const t = new Date(); return iso(t.getFullYear(), t.getMonth() + 1, t.getDate()); };
+
+  /** Where a calendar day leads: the day document, or its group on the month page. */
+  function dayHref(day) {
+    return PAGE_MONTH
+      ? `${ROOT}/month/${day.slice(0, 7)}#day-${day}`
+      : `${ROOT}/day/${day}`;
+  }
+
+  // ------------------------------------------------------------ calendar
+
+  const cal = document.querySelector("details.cal");
+  const body = cal && cal.querySelector(".calbody");
+  const marks = new Map();  // "YYYY-MM" -> the /days payload (or null: failed)
+
+  async function fetchMarks(month) {
+    if (marks.has(month)) return marks.get(month);
+    let got = null;
+    try {
+      const res = await fetch(`${API}/month/${month}/days`);
+      if (res.ok) got = await res.json();
+    } catch (e) { /* offline: draw the grid without marks */ }
+    marks.set(month, got);
+    return got;
+  }
+
+  function stepMonth(month, by) {
+    const [y, m] = month.split("-").map(Number);
+    const idx = y * 12 + (m - 1) + by;
+    return `${Math.floor(idx / 12)}-${pad((idx % 12) + 1)}`;
+  }
+
+  const MONTHS = ["January", "February", "March", "April", "May", "June", "July",
+    "August", "September", "October", "November", "December"];
+
+  function title(day, m) {
+    const bits = [];
+    if (m && m.folder) bits.push("scans on the share");
+    if (m && m.notes) bits.push(`${m.notes} scan-log note${m.notes === 1 ? "" : "s"}`);
+    if (m && m.ops) bits.push(`${m.ops} ops note${m.ops === 1 ? "" : "s"}`);
+    return bits.length ? `${day} — ${bits.join(", ")}` : day;
+  }
+
+  async function draw(month) {
+    if (!body) return;
+    body.dataset.month = month;
+    const [y, m] = month.split("-").map(Number);
+    const first = new Date(y, m - 1, 1);
+    const days = new Date(y, m, 0).getDate();
+    const lead = (first.getDay() + 6) % 7;  // Monday first
+    const today = todayIso();
+
+    const head = document.createElement("div");
+    head.className = "calhead";
+    const prev = document.createElement("button");
+    prev.type = "button"; prev.className = "stepday"; prev.textContent = "\u2039";
+    prev.setAttribute("aria-label", "Previous month");
+    const label = document.createElement("b");
+    label.textContent = `${MONTHS[m - 1]} ${y}`;
+    const next = document.createElement("button");
+    next.type = "button"; next.className = "stepday"; next.textContent = "\u203a";
+    next.setAttribute("aria-label", "Next month");
+    prev.addEventListener("click", () => draw(stepMonth(month, -1)));
+    next.addEventListener("click", () => draw(stepMonth(month, 1)));
+    head.append(prev, label, next);
+
+    const grid = document.createElement("div");
+    grid.className = "calgrid";
+    for (const wd of ["Mo", "Tu", "We", "Th", "Fr", "Sa", "Su"]) {
+      const el = document.createElement("span"); el.className = "wd"; el.textContent = wd; grid.append(el);
+    }
+    for (let i = 0; i < lead; i++) {
+      const el = document.createElement("span"); el.className = "cell blank"; grid.append(el);
+    }
+    const cells = new Map();
+    for (let d = 1; d <= days; d++) {
+      const day = iso(y, m, d);
+      const a = document.createElement("a");
+      a.className = "cell";
+      a.href = dayHref(day);
+      a.textContent = String(d);
+      a.title = day;
+      if (day === today) a.classList.add("is-today");
+      if (day > today) a.classList.add("future");
+      if (day === PAGE_DAY) a.classList.add("is-active");
+      grid.append(a);
+      cells.set(day, a);
+    }
+
+    const legend = document.createElement("div");
+    legend.className = "callegend";
+    legend.innerHTML = '<span><i class="k"></i>scans</span><span><i class="kn"></i>notes</span>';
+    const note = document.createElement("div");
+    note.className = "calnote";
+    note.hidden = true;
+
+    body.replaceChildren(head, grid, legend, note);
+
+    const got = await fetchMarks(month);
+    if (body.dataset.month !== month) return;  // the viewer moved on
+    if (got === null) { note.textContent = "Marks unavailable."; note.hidden = false; return; }
+    if (!got.share) { note.textContent = "Share not reachable: scan days unmarked."; note.hidden = false; }
+    for (const [day, mk] of Object.entries(got.days || {})) {
+      const a = cells.get(day);
+      if (!a) continue;
+      if (mk.folder) a.classList.add("has-folder");
+      if (mk.notes || mk.ops) a.classList.add("has-notes");
+      a.title = title(day, mk);
+    }
+  }
+
+  if (cal && body) {
+    const start = PAGE_DAY ? PAGE_DAY.slice(0, 7) : (PAGE_MONTH || todayIso().slice(0, 7));
+    cal.addEventListener("toggle", () => {
+      try { localStorage.setItem(OPEN_KEY, String(cal.open)); } catch (e) { /* private window */ }
+      if (cal.open && !body.dataset.month) draw(start);
+    });
+    let remembered = null;
+    try { remembered = localStorage.getItem(OPEN_KEY); } catch (e) { /* private window */ }
+    if (remembered === "true") cal.open = true;  // fires toggle → draw
+  }
+
+  // ------------------------------------------------------------ keyboard
+
+  const typing = (el) => !!el && (
+    el.tagName === "INPUT" || el.tagName === "TEXTAREA" || el.tagName === "SELECT" || el.isContentEditable);
+
+  document.addEventListener("keydown", (ev) => {
+    if (ev.defaultPrevented || ev.metaKey || ev.ctrlKey || ev.altKey || typing(ev.target)) return;
+    let url = "";
+    if (ev.key === "ArrowLeft") url = host.dataset.prev;
+    else if (ev.key === "ArrowRight") url = host.dataset.next;
+    else if (ev.key === "t" || ev.key === "T") url = host.dataset.today;
+    else if (ev.key === "c" || ev.key === "C") { if (cal) { cal.open = !cal.open; ev.preventDefault(); } return; }
+    if (!url) return;
+    ev.preventDefault();
+    window.location.href = url;
+  });
+
+  // ------------------------------------------------------------ prefetch
+
+  const warmed = new Set();
+  const PAGES = new RegExp(`^${ROOT.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}/(day|month)/`);
+
+  function warm(a) {
+    let url;
+    try { url = new URL(a.href, window.location.href); } catch (e) { return; }
+    if (url.origin !== window.location.origin || !PAGES.test(url.pathname)) return;
+    const key = url.pathname;  // the page, not its fragment
+    if (warmed.has(key) || key === window.location.pathname) return;
+    warmed.add(key);
+    const link = document.createElement("link");
+    link.rel = "prefetch";
+    link.href = key;
+    document.head.append(link);
+  }
+
+  let timer = 0;
+  document.addEventListener("mouseover", (ev) => {
+    const a = ev.target && ev.target.closest && ev.target.closest("a[href]");
+    if (!a) return;
+    clearTimeout(timer);
+    timer = setTimeout(() => warm(a), 80);  // a pass-through hover costs nothing
+  });
+  document.addEventListener("mouseout", () => clearTimeout(timer));
+  document.addEventListener("focusin", (ev) => {
+    const a = ev.target && ev.target.closest && ev.target.closest("a[href]");
+    if (a) warm(a);
+  });
+})();

--- a/GeecsLogbook/geecs_logbook/static/nav.js
+++ b/GeecsLogbook/geecs_logbook/static/nav.js
@@ -13,9 +13,13 @@
  *     page itself never asks; only the open calendar does, so a slow
  *     share delays a popup, not a page. Months are cached per page load.
  *   - Keys: ← / → step to the previous / next day (or month), t goes to
- *     today. Ignored while typing in a field.
- *   - Prefetch: hovering a day or month link for a moment adds a
- *     <link rel="prefetch">, so the click that follows is served warm.
+ *     today. Ignored while typing in a field, and while any composer
+ *     holds unsaved text — a shortcut must never discard a note.
+ *   - Prefetch: resting on a day or month link (250 ms — a pass over the
+ *     rail's fifteen links prefetches nothing) adds a <link rel="prefetch">,
+ *     so the click that follows is served warm. The browser may reuse a
+ *     prefetched page for a few minutes; a reload shows a scan that landed
+ *     in between.
  *
  * Styling is entirely through the page's tokens; this file sets no colours.
  */
@@ -158,6 +162,8 @@
 
   const typing = (el) => !!el && (
     el.tagName === "INPUT" || el.tagName === "TEXTAREA" || el.tagName === "SELECT" || el.isContentEditable);
+  /** Any composer holding text: a keystroke must not throw it away. */
+  const drafting = () => [...document.querySelectorAll("textarea")].some((t) => t.value.trim());
 
   document.addEventListener("keydown", (ev) => {
     if (ev.defaultPrevented || ev.metaKey || ev.ctrlKey || ev.altKey || typing(ev.target)) return;
@@ -166,7 +172,7 @@
     else if (ev.key === "ArrowRight") url = host.dataset.next;
     else if (ev.key === "t" || ev.key === "T") url = host.dataset.today;
     else if (ev.key === "c" || ev.key === "C") { if (cal) { cal.open = !cal.open; ev.preventDefault(); } return; }
-    if (!url) return;
+    if (!url || drafting()) return;  // an unsaved note outranks a shortcut
     ev.preventDefault();
     window.location.href = url;
   });
@@ -194,7 +200,7 @@
     const a = ev.target && ev.target.closest && ev.target.closest("a[href]");
     if (!a) return;
     clearTimeout(timer);
-    timer = setTimeout(() => warm(a), 80);  // a pass-through hover costs nothing
+    timer = setTimeout(() => warm(a), 250);  // a real rest, not a pass-through
   });
   document.addEventListener("mouseout", () => clearTimeout(timer));
   document.addEventListener("focusin", (ev) => {

--- a/GeecsLogbook/geecs_logbook/static/scanlog.css
+++ b/GeecsLogbook/geecs_logbook/static/scanlog.css
@@ -324,3 +324,36 @@ details.campaign[hidden]{display:none}
 .when{font:inherit;font-size:12px;font-family:var(--ff-mono);border:1px solid var(--rule);border-radius:4px;
   background:var(--surface);color:var(--ink);padding:4px 6px}
 article.entry[hidden],section.daygroup[hidden]{display:none}
+
+/* ---- the rail calendar (nav.js draws it) ---- */
+.cal{margin:2px 0 9px}
+.cal>summary{cursor:pointer;list-style:none;display:flex;align-items:center;gap:6px;
+  font-size:12px;color:var(--slate);padding:3px 0;user-select:none}
+.cal>summary::-webkit-details-marker{display:none}
+.cal>summary::before{content:"\25B8";font-size:10px;color:var(--muted)}
+.cal[open]>summary::before{content:"\25BE"}
+.cal>summary:hover{color:var(--accent)}
+.cal>summary kbd{margin-left:auto}
+.calhead{display:flex;align-items:center;justify-content:space-between;margin:6px 0 4px}
+.calhead b{font-size:12.5px;font-weight:600}
+.calhead .stepday{cursor:pointer;font:inherit;font-size:15px;line-height:1;padding:0}
+.calgrid{display:grid;grid-template-columns:repeat(7,1fr);gap:2px}
+.calgrid .wd{font-family:var(--ff-mono);font-size:9.5px;color:var(--muted);text-align:center;text-transform:uppercase}
+.cell{position:relative;display:flex;align-items:center;justify-content:center;height:26px;border-radius:4px;
+  font-size:12px;color:var(--slate);text-decoration:none;font-variant-numeric:tabular-nums}
+.cell:hover{background:var(--surface-2)}
+.cell.blank{visibility:hidden}
+.cell.future{opacity:.4}
+.cell.has-notes{background:var(--accent-soft);color:var(--accent);font-weight:600}
+.cell.has-folder::after{content:"";position:absolute;bottom:2px;left:50%;transform:translateX(-50%);
+  width:4px;height:4px;border-radius:50%;background:var(--ok)}
+.cell.is-today{outline:1px solid var(--accent);outline-offset:-1px}
+.cell.is-active{background:var(--accent);color:var(--on-accent);font-weight:600}
+.cell.is-active.has-folder::after{background:var(--on-accent)}
+.callegend{display:flex;gap:12px;margin-top:6px;font-family:var(--ff-mono);font-size:10.5px;color:var(--muted)}
+.callegend .k{display:inline-block;width:5px;height:5px;border-radius:50%;background:var(--ok);margin-right:5px;vertical-align:middle}
+.callegend .kn{display:inline-block;width:8px;height:8px;border-radius:2px;background:var(--accent-soft);margin-right:5px;vertical-align:middle}
+.calnote{font-size:11px;color:var(--warn);margin-top:4px}
+.kbdhint{margin-top:8px;font-family:var(--ff-mono);font-size:10.5px;color:var(--muted);display:flex;gap:10px;flex-wrap:wrap}
+kbd{font:inherit;font-family:var(--ff-mono);font-size:10px;border:1px solid var(--rule);border-radius:3px;
+  padding:0 4px;background:var(--surface);color:var(--slate)}

--- a/GeecsLogbook/geecs_logbook/store.py
+++ b/GeecsLogbook/geecs_logbook/store.py
@@ -146,6 +146,19 @@ class HistoryRecord:
     entry: LogEntry
 
 
+@dataclass(frozen=True)
+class ChangePage:
+    """One page of the change feed: entries in ``updated_at`` order and a cursor.
+
+    ``next_cursor`` is ``None`` when the page was not full; otherwise pass
+    it back as ``cursor`` to continue exactly where this page stopped,
+    ties in ``updated_at`` included (the cursor carries the row too).
+    """
+
+    entries: list[LogEntry]
+    next_cursor: Optional[str]
+
+
 def _now() -> datetime:
     """Return an aware UTC timestamp.
 
@@ -153,6 +166,18 @@ def _now() -> datetime:
     timestamp is ambiguous the moment anyone reads it from another zone.
     """
     return datetime.now(timezone.utc)
+
+
+def _stamp(when: datetime) -> str:
+    """Render an aware datetime the way the store's columns hold them.
+
+    Columns are ``datetime.isoformat()`` of a UTC-aware value, so a
+    comparison against a value rendered the same way is a correct string
+    comparison. A naive datetime is refused: the caller's zone is unknown.
+    """
+    if when.tzinfo is None or when.utcoffset() is None:
+        raise ValueError("timestamp must be timezone-aware")
+    return when.astimezone(timezone.utc).isoformat()
 
 
 class NotesStore:
@@ -279,6 +304,80 @@ class NotesStore:
         with self._connect() as conn:
             rows = conn.execute(sql, params).fetchall()
         return [_from_row(row) for row in rows]
+
+    def count_by_day(self, day_from: str, day_to: str) -> dict[str, dict[str, int]]:
+        """Return live entry counts per day and book in an inclusive range.
+
+        One grouped query for a whole month — what a calendar needs to
+        mark the days that have notes, without loading a single body.
+        The result maps ``YYYY-MM-DD`` to ``{book: count}`` and lists only
+        days that have at least one live entry.
+        """
+        with self._connect() as conn:
+            rows = conn.execute(
+                "SELECT day, book, COUNT(*) AS n FROM entries"
+                " WHERE day BETWEEN ? AND ? AND deleted_at IS NULL"
+                " GROUP BY day, book",
+                (day_from, day_to),
+            ).fetchall()
+        out: dict[str, dict[str, int]] = {}
+        for row in rows:
+            out.setdefault(row["day"], {})[row["book"]] = row["n"]
+        return out
+
+    def changed_since(
+        self,
+        since: datetime,
+        *,
+        until: Optional[datetime] = None,
+        book: Optional[str] = None,
+        include_deleted: bool = True,
+        cursor: Optional[str] = None,
+        limit: int = _QUERY_CAP,
+    ) -> ChangePage:
+        """Return entries whose ``updated_at`` is after ``since``, oldest change first.
+
+        The synchroniser's question ("everything that changed since I last
+        asked"), and the one listing that includes **tombstones**: a
+        deleted entry is a change a downstream copy must learn about, and
+        this is the only place it can. ``include_deleted=False`` drops them.
+
+        Timestamps are aware. Rows are ordered by ``(updated_at, rowid)``
+        and a full page returns a cursor that resumes after its last row,
+        so two entries sharing an ``updated_at`` across a page boundary
+        cannot lose one. ``since`` is exclusive, ``until`` inclusive.
+        """
+        if limit < 1:
+            raise ValueError("limit must be at least 1")
+        sql = "SELECT rowid AS _rowid, * FROM entries WHERE "
+        params: list[object] = []
+        if cursor is not None:
+            stamp, _, row = cursor.rpartition("|")
+            if not stamp or not row.isdigit():
+                raise ValueError(f"malformed cursor: {cursor!r}")
+            sql += "(updated_at > ? OR (updated_at = ? AND rowid > ?))"
+            params += [stamp, stamp, int(row)]
+        else:
+            sql += "updated_at > ?"
+            params.append(_stamp(since))
+        if until is not None:
+            sql += " AND updated_at <= ?"
+            params.append(_stamp(until))
+        if book is not None:
+            sql += " AND book = ?"
+            params.append(book)
+        if not include_deleted:
+            sql += " AND deleted_at IS NULL"
+        limit = min(limit, _QUERY_CAP)
+        sql += " ORDER BY updated_at, rowid LIMIT ?"
+        params.append(limit + 1)  # one extra tells us whether a page follows
+        with self._connect() as conn:
+            rows = conn.execute(sql, params).fetchall()
+        more = len(rows) > limit
+        rows = rows[:limit]
+        entries = [_from_row(row) for row in rows]
+        next_cursor = f"{rows[-1]['updated_at']}|{rows[-1]['_rowid']}" if more else None
+        return ChangePage(entries=entries, next_cursor=next_cursor)
 
     def history(self, entry_id: str) -> list[HistoryRecord]:
         """Return an entry's earlier states, oldest first."""

--- a/GeecsLogbook/geecs_logbook/store.py
+++ b/GeecsLogbook/geecs_logbook/store.py
@@ -31,6 +31,7 @@ instead of a sentence that quietly vanished.
 
 from __future__ import annotations
 
+import base64
 import json
 import logging
 import sqlite3
@@ -178,6 +179,32 @@ def _stamp(when: datetime) -> str:
     if when.tzinfo is None or when.utcoffset() is None:
         raise ValueError("timestamp must be timezone-aware")
     return when.astimezone(timezone.utc).isoformat()
+
+
+def _encode_cursor(stamp: str, rowid: int) -> str:
+    """Render a feed cursor: opaque and URL-safe.
+
+    The stamp carries ``+00:00``, which a raw query string turns into a
+    space and thereby into a value that sorts *below* every real stamp —
+    the boundary row would be re-sent. Base64 (URL alphabet, unpadded)
+    keeps the cursor a token a client cannot half-encode.
+    """
+    raw = f"{stamp}|{rowid}".encode()
+    return base64.urlsafe_b64encode(raw).decode().rstrip("=")
+
+
+def _decode_cursor(cursor: str) -> tuple[str, int]:
+    """Parse a cursor back into ``(stamp, rowid)``; ``ValueError`` if it is not one."""
+    try:
+        padded = cursor + "=" * (-len(cursor) % 4)
+        raw = base64.urlsafe_b64decode(padded.encode()).decode()
+        stamp, _, row = raw.rpartition("|")
+        datetime.fromisoformat(stamp)  # a real timestamp, not merely a shape
+        if not row.isdigit():
+            raise ValueError(row)
+    except (ValueError, UnicodeDecodeError) as exc:  # binascii.Error is a ValueError
+        raise ValueError(f"malformed cursor: {cursor!r}") from exc
+    return stamp, int(row)
 
 
 class NotesStore:
@@ -352,11 +379,9 @@ class NotesStore:
         sql = "SELECT rowid AS _rowid, * FROM entries WHERE "
         params: list[object] = []
         if cursor is not None:
-            stamp, _, row = cursor.rpartition("|")
-            if not stamp or not row.isdigit():
-                raise ValueError(f"malformed cursor: {cursor!r}")
+            stamp, row = _decode_cursor(cursor)
             sql += "(updated_at > ? OR (updated_at = ? AND rowid > ?))"
-            params += [stamp, stamp, int(row)]
+            params += [stamp, stamp, row]
         else:
             sql += "updated_at > ?"
             params.append(_stamp(since))
@@ -376,7 +401,9 @@ class NotesStore:
         more = len(rows) > limit
         rows = rows[:limit]
         entries = [_from_row(row) for row in rows]
-        next_cursor = f"{rows[-1]['updated_at']}|{rows[-1]['_rowid']}" if more else None
+        next_cursor = (
+            _encode_cursor(rows[-1]["updated_at"], rows[-1]["_rowid"]) if more else None
+        )
         return ChangePage(entries=entries, next_cursor=next_cursor)
 
     def history(self, entry_id: str) -> list[HistoryRecord]:
@@ -478,24 +505,28 @@ class NotesStore:
                 f"a {kind} entry is created as a draft; a person keeps it afterwards"
             )
 
-        now = _now()
-        entry = LogEntry(
-            entry_id=uuid.uuid4().hex[:12],
-            day=day,
-            book=book,
-            scan=scan,
-            after=after,
-            author=author,
-            kind=kind,
-            status=status,
-            template=template,
-            body_md=body_md,
-            tags=parse_tags(body_md),
-            payload=payload,
-            created_at=now,
-            updated_at=now,
-        )
-        with self._connect() as conn:
+        # The stamp is taken under the write lock, as every other writer
+        # takes its own: taken before it, two concurrent creates could
+        # commit out of stamp order and the change feed's high-water mark
+        # would skip one for good.
+        with self._connect() as conn, _transaction(conn):
+            now = _now()
+            entry = LogEntry(
+                entry_id=uuid.uuid4().hex[:12],
+                day=day,
+                book=book,
+                scan=scan,
+                after=after,
+                author=author,
+                kind=kind,
+                status=status,
+                template=template,
+                body_md=body_md,
+                tags=parse_tags(body_md),
+                payload=payload,
+                created_at=now,
+                updated_at=now,
+            )
             conn.execute(
                 "INSERT INTO entries (entry_id, day, scan, after_scan, author, kind,"
                 " status, template, body_md, payload, attachments, created_at,"

--- a/GeecsLogbook/geecs_logbook/templates/_entries.html
+++ b/GeecsLogbook/geecs_logbook/templates/_entries.html
@@ -101,3 +101,19 @@
 {% macro seeds_json(seeds) -%}
 <script type="application/json" id="logbook-seeds">{{ seeds.prefill | tojson }}</script>
 {%- endmacro %}
+
+{#
+  The rail's calendar: a disclosure nav.js fills with a month grid when
+  opened. `unit` is what the arrow keys step ("day" or "month"), for the
+  hint line. It carries no data of its own — the marks are fetched.
+#}
+{% macro calendar(unit) %}
+  <details class="cal">
+    <summary>Calendar <kbd>c</kbd></summary>
+    <div class="calbody"></div>
+  </details>
+  <div class="kbdhint">
+    <span><kbd>&larr;</kbd> <kbd>&rarr;</kbd> {{ unit }}</span>
+    <span><kbd>t</kbd> today</span>
+  </div>
+{% endmacro %}

--- a/GeecsLogbook/geecs_logbook/templates/day.html
+++ b/GeecsLogbook/geecs_logbook/templates/day.html
@@ -157,9 +157,10 @@
            title="Next day" aria-label="Next day">&rsaquo;</a>
       </div>
       {% if summary.day != today %}
-      <a class="todaylink" href="{{ url_for('_day_page', day=today.isoformat()) }}">
+      <a class="todaylink" href="{{ url_for('_day_page', day=today.isoformat()).path }}">
         Back to today</a>
       {% endif %}
+      {{ shared.calendar('day') }}
       <div class="daylist">
         {% for d in rail_days %}
         <a class="day{% if d == summary.day %} is-active{% endif %}{% if d > today %} future{% endif %}"
@@ -199,7 +200,10 @@
     {% endif %}
   </aside>
 
-  <main id="logbook" data-api="{{ api_base }}" data-day="{{ summary.day.isoformat() }}" data-book="scans" data-accept="{{ accept }}">
+  <main id="logbook" data-api="{{ api_base }}" data-day="{{ summary.day.isoformat() }}" data-book="scans" data-accept="{{ accept }}"
+        data-prev="{{ url_for('_day_page', day=prev_day.isoformat()).path }}"
+        data-next="{{ url_for('_day_page', day=next_day.isoformat()).path }}"
+        data-today="{{ url_for('_day_page', day=today.isoformat()).path }}">
 
     <div class="dayhead">
       <div>
@@ -340,6 +344,7 @@ document.querySelectorAll(".scanrow").forEach(a => a.addEventListener("click", (
 </script>
 {{ shared.seeds_json(seeds) }}
 <script src="{{ url_for('_static', name='editor.js') }}" defer></script>
+<script src="{{ url_for('_static', name='nav.js').path }}" defer></script>
 <script src="{{ root }}/theme/theme.js" defer></script>
 </body>
 </html>

--- a/GeecsLogbook/geecs_logbook/templates/month.html
+++ b/GeecsLogbook/geecs_logbook/templates/month.html
@@ -48,10 +48,11 @@
         <a class="stepday" href="{{ url_for('_month_page', month=next_month.strftime('%Y-%m')).path }}"
            title="Next month" aria-label="Next month">&rsaquo;</a>
       </div>
-      {% if not (first <= today <= last) %}
-      <a class="todaylink" href="{{ url_for('_month_page', month=today.strftime('%Y-%m')).path }}">
-        Back to this month</a>
-      {% endif %}
+      {# Always present: today is a place in every month's rail, not only
+         a way back. Lands on today's day group when there is one. #}
+      <a class="todaylink" href="{{ today_url }}">
+        {{ 'Today' if first <= today <= last else 'Back to this month' }}</a>
+      {{ shared.calendar('month') }}
     </section>
 
     {% if tags %}
@@ -84,7 +85,11 @@
     {% endif %}
   </aside>
 
-  <main id="logbook" data-api="{{ api_base }}" data-book="ops" data-accept="{{ accept }}">
+  <main id="logbook" data-api="{{ api_base }}" data-book="ops" data-accept="{{ accept }}"
+        data-month="{{ first.strftime('%Y-%m') }}"
+        data-prev="{{ url_for('_month_page', month=prev_month.strftime('%Y-%m')).path }}"
+        data-next="{{ url_for('_month_page', month=next_month.strftime('%Y-%m')).path }}"
+        data-today="{{ today_url }}">
 
     <div class="dayhead">
       <div>
@@ -189,6 +194,7 @@ document.getElementById("q").addEventListener("input", ev => {
 });
 </script>
 <script src="{{ url_for('_static', name='editor.js') }}" defer></script>
+<script src="{{ url_for('_static', name='nav.js').path }}" defer></script>
 <script src="{{ root }}/theme/theme.js" defer></script>
 </body>
 </html>

--- a/GeecsLogbook/pyproject.toml
+++ b/GeecsLogbook/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-logbook"
-version = "0.5.0"
+version = "0.6.0"
 description = "Scan logbook: a day-document view over scan folders, with human commentary stored beside the data"
 authors = ["GEECS-BELLA"]
 readme = "README.md"

--- a/GeecsLogbook/tests/test_nav.py
+++ b/GeecsLogbook/tests/test_nav.py
@@ -1,0 +1,251 @@
+"""Navigation: the rail calendar's marks, the today names, keyboard wiring."""
+
+from __future__ import annotations
+
+from datetime import date
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from geecs_logbook.router import create_log_router
+from geecs_logbook.scan_reader import days_with_folders
+
+
+@pytest.fixture
+def app(share: Path, tmp_path: Path) -> TestClient:
+    """A writable logbook over the synthetic share."""
+    app = FastAPI()
+    app.include_router(
+        create_log_router(
+            "Undulator", base_directory=share, notes_db=tmp_path / "notes.db"
+        ),
+        prefix="/log",
+    )
+    return TestClient(app)
+
+
+def _note(client: TestClient, day: str, body: str, **extra: object) -> None:
+    payload = {"day": day, "author": "S. Barber", "body_md": body, **extra}
+    assert client.post("/log/api/entries", json=payload).status_code == 201
+
+
+class TestDaysWithFolders:
+    """One listing of the month folder, never a walk of the days."""
+
+    def test_lists_the_month_folder_once(
+        self, share: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The fixture's one day folder is found with a single scandir."""
+        import os
+
+        from geecs_logbook import scan_reader
+
+        calls: list[str] = []
+        real = os.scandir
+
+        def counted(path: object) -> object:
+            calls.append(str(path))
+            return real(path)
+
+        monkeypatch.setattr(scan_reader.os, "scandir", counted)
+        found = days_with_folders(date(2026, 9, 1), "Undulator", base_directory=share)
+        assert found == {date(2026, 9, 11)}
+        assert len(calls) == 1 and calls[0].endswith("09-Sep")
+
+    def test_ignores_strays_and_other_months(self, share: Path) -> None:
+        """Only ``YY_MMDD`` folders of this month are days; files and strays are not."""
+        month = share / "Undulator" / "Y2026" / "09-Sep"
+        (month / "26_1001").mkdir()  # October's shape, filed in the wrong month
+        (month / "26_0932").mkdir()  # not a date
+        (month / "notes").mkdir()
+        (month / "26_0912").write_text("a file, not a day")
+        assert days_with_folders(
+            date(2026, 9, 1), "Undulator", base_directory=share
+        ) == {date(2026, 9, 11)}
+
+    def test_missing_month_is_empty_missing_share_is_none(
+        self, share: Path, tmp_path: Path
+    ) -> None:
+        """No month folder means nothing happened; no experiment dir means no share."""
+        assert (
+            days_with_folders(date(2027, 1, 1), "Undulator", base_directory=share)
+            == set()
+        )
+        assert (
+            days_with_folders(
+                date(2026, 9, 1), "Undulator", base_directory=tmp_path / "unmounted"
+            )
+            is None
+        )
+
+    def test_never_creates_anything(
+        self, share: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The scan-folder invariant: a listing makes no directories."""
+
+        def explode(*a: object, **k: object) -> None:
+            raise AssertionError("days_with_folders called mkdir")
+
+        monkeypatch.setattr(Path, "mkdir", explode)
+        days_with_folders(date(2027, 1, 1), "Undulator", base_directory=share)
+
+
+class TestMonthMarks:
+    """``/api/month/{m}/days`` — what the calendar draws."""
+
+    def test_marks_folders_and_notes_per_book(self, app: TestClient) -> None:
+        """Folder days from the share, note counts from the store, merged."""
+        _note(app, "2026-09-11", "on a scan", scan=1)
+        _note(app, "2026-09-11", "ops that day", book="ops")
+        _note(app, "2026-09-03", "quiet day #laser", book="ops")
+        body = app.get("/log/api/month/2026-09/days").json()
+        assert body["month"] == "2026-09" and body["share"] is True
+        assert body["days"] == {
+            "2026-09-03": {"folder": False, "notes": 0, "ops": 1},
+            "2026-09-11": {"folder": True, "notes": 1, "ops": 1},
+        }
+
+    def test_share_down_is_said_not_hidden(self, tmp_path: Path) -> None:
+        """No experiment directory: the store's marks stand, ``share`` is false."""
+        app = FastAPI()
+        app.include_router(
+            create_log_router(
+                "Undulator",
+                base_directory=tmp_path / "unmounted",
+                notes_db=tmp_path / "notes.db",
+            ),
+            prefix="/log",
+        )
+        client = TestClient(app)
+        _note(client, "2026-09-11", "still counted", book="ops")
+        body = client.get("/log/api/month/2026-09/days").json()
+        assert body["share"] is False
+        assert body["days"] == {"2026-09-11": {"folder": False, "notes": 0, "ops": 1}}
+
+    def test_readonly_logbook_marks_folders_only(self, share: Path) -> None:
+        """Without a store there are no notes to count, and no error."""
+        app = FastAPI()
+        app.include_router(
+            create_log_router("Undulator", base_directory=share), prefix="/log"
+        )
+        body = TestClient(app).get("/log/api/month/2026-09/days").json()
+        assert body["days"] == {"2026-09-11": {"folder": True, "notes": 0, "ops": 0}}
+
+    def test_bad_month_is_400(self, app: TestClient) -> None:
+        """The same month grammar as the page."""
+        assert app.get("/log/api/month/2026-9/days").status_code == 400
+
+    def test_month_page_never_calls_it(
+        self, app: TestClient, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The marks are the calendar's lazy fetch, not the month page's path."""
+        from geecs_logbook.routes import month
+
+        def explode(*a: object, **k: object) -> None:
+            raise AssertionError("month page listed the share")
+
+        monkeypatch.setattr(month, "days_with_folders", explode)
+        assert app.get("/log/month/2026-09").status_code == 200
+
+
+class TestTodayNames:
+    """Bookmarkable names for today, in both books."""
+
+    def test_log_today_redirects_to_the_day(self, app: TestClient) -> None:
+        res = app.get("/log/today", follow_redirects=False)
+        assert res.status_code == 307
+        assert res.headers["location"] == f"day/{date.today().isoformat()}"
+
+    def test_month_today_lands_on_todays_group(self, app: TestClient) -> None:
+        res = app.get("/log/month/today", follow_redirects=False)
+        today = date.today()
+        assert res.status_code == 307
+        assert res.headers["location"] == (
+            f"{today.strftime('%Y-%m')}#day-{today.isoformat()}"
+        )
+
+
+class TestRailWiring:
+    """What the pages hand nav.js, and the controls they draw."""
+
+    def test_day_page_carries_step_targets_and_the_calendar(
+        self, app: TestClient
+    ) -> None:
+        html = app.get("/log/day/2026-09-11").text
+        assert 'data-prev="/log/day/2026-09-10"' in html
+        assert 'data-next="/log/day/2026-09-12"' in html
+        assert f'data-today="/log/day/{date.today().isoformat()}"' in html
+        assert '<details class="cal">' in html
+        assert 'src="/log/static/nav.js"' in html
+
+    def test_month_page_always_offers_today(self, app: TestClient) -> None:
+        """The month rail's Today control is present in every month."""
+        today = date.today()
+        target = f"/log/month/{today.strftime('%Y-%m')}#day-{today.isoformat()}"
+        this_month = app.get(f"/log/month/{today.strftime('%Y-%m')}").text
+        other = app.get("/log/month/2019-01").text
+        assert f'class="todaylink" href="{target}"' in this_month
+        assert f'class="todaylink" href="{target}"' in other
+        assert ">\n        Today</a>" in this_month
+        assert "Back to this month</a>" in other
+        assert 'data-month="2019-01"' in other and 'data-today="' + target in other
+        assert 'data-prev="/log/month/2018-12"' in other
+        assert '<details class="cal">' in other
+
+    def test_nav_script_is_served(self, app: TestClient) -> None:
+        res = app.get("/log/static/nav.js")
+        assert res.status_code == 200 and "prefetch" in res.text
+
+
+class TestChangeFeed:
+    """``GET /api/entries?since=`` — the synchroniser's listing."""
+
+    def test_requires_since_or_cursor_and_a_timezone(self, app: TestClient) -> None:
+        assert app.get("/log/api/entries").status_code == 422
+        naive = app.get("/log/api/entries", params={"since": "2026-09-11T08:00:00"})
+        assert naive.status_code == 422 and "timezone" in naive.text
+        assert app.get("/log/api/entries", params={"cursor": "junk"}).status_code == 422
+
+    def test_lists_changes_with_tombstones_and_pages(self, app: TestClient) -> None:
+        """Create, delete, and read the feed back: both rows, delete last."""
+        _note(app, "2026-09-11", "keep me", book="ops")
+        gone = app.post(
+            "/log/api/entries",
+            json={"day": "2026-09-11", "author": "a", "body_md": "drop me"},
+        ).json()
+        assert app.delete(f"/log/api/entries/{gone['entry_id']}").status_code == 204
+        since = "2000-01-01T00:00:00+00:00"
+        body = app.get("/log/api/entries", params={"since": since}).json()
+        assert [e["body_md"] for e in body["entries"]] == ["keep me", "drop me"]
+        assert body["entries"][1]["deleted_at"] is not None
+        assert body["next_cursor"] is None
+        # Hidden everywhere else.
+        listed = app.get("/log/api/day/2026-09-11/entries").json()
+        assert [e["body_md"] for e in listed] == ["keep me"]
+        # Paged: one per page, the cursor carries on.
+        first = app.get("/log/api/entries", params={"since": since, "limit": 1}).json()
+        assert [e["body_md"] for e in first["entries"]] == ["keep me"]
+        second = app.get(
+            "/log/api/entries", params={"cursor": first["next_cursor"], "limit": 1}
+        ).json()
+        assert [e["body_md"] for e in second["entries"]] == ["drop me"]
+        assert second["next_cursor"] is None
+        # Narrowed to a book, and to live rows.
+        ops = app.get("/log/api/entries", params={"since": since, "book": "ops"}).json()
+        assert [e["body_md"] for e in ops["entries"]] == ["keep me"]
+        live = app.get(
+            "/log/api/entries", params={"since": since, "include_deleted": "false"}
+        ).json()
+        assert [e["body_md"] for e in live["entries"]] == ["keep me"]
+
+    def test_not_served_without_a_store(self, share: Path) -> None:
+        app = FastAPI()
+        app.include_router(
+            create_log_router("Undulator", base_directory=share), prefix="/log"
+        )
+        res = TestClient(app).get(
+            "/log/api/entries", params={"since": "2000-01-01T00:00:00+00:00"}
+        )
+        assert res.status_code == 404

--- a/GeecsLogbook/tests/test_nav.py
+++ b/GeecsLogbook/tests/test_nav.py
@@ -80,6 +80,20 @@ class TestDaysWithFolders:
             is None
         )
 
+    def test_share_io_error_is_none_not_a_traceback(
+        self, share: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """EACCES / EIO on the share root reads as "share unavailable"."""
+
+        def denied(self: Path) -> bool:
+            raise PermissionError(13, "Permission denied", str(self))
+
+        monkeypatch.setattr(Path, "is_dir", denied)
+        assert (
+            days_with_folders(date(2026, 9, 1), "Undulator", base_directory=share)
+            is None
+        )
+
     def test_never_creates_anything(
         self, share: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
@@ -136,6 +150,19 @@ class TestMonthMarks:
     def test_bad_month_is_400(self, app: TestClient) -> None:
         """The same month grammar as the page."""
         assert app.get("/log/api/month/2026-9/days").status_code == 400
+
+    def test_an_unexpected_failure_is_a_503(
+        self, app: TestClient, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Anything the listing raises is an honest 503, as on the day page."""
+        from geecs_logbook.routes import month
+
+        def boom(*a: object, **k: object) -> None:
+            raise RuntimeError("paths config missing")
+
+        monkeypatch.setattr(month, "days_with_folders", boom)
+        res = app.get("/log/api/month/2026-09/days")
+        assert res.status_code == 503 and "unavailable" in res.text
 
     def test_month_page_never_calls_it(
         self, app: TestClient, monkeypatch: pytest.MonkeyPatch
@@ -239,6 +266,25 @@ class TestChangeFeed:
             "/log/api/entries", params={"since": since, "include_deleted": "false"}
         ).json()
         assert [e["body_md"] for e in live["entries"]] == ["keep me"]
+
+    def test_cursor_survives_a_raw_query_string(self, app: TestClient) -> None:
+        """A cursor pasted unencoded into a URL must not re-send the boundary row."""
+        for i in range(3):
+            _note(app, "2026-09-11", f"n{i}", book="ops")
+        since = "2000-01-01T00:00:00+00:00"
+        first = app.get("/log/api/entries", params={"since": since, "limit": 1}).json()
+        cursor = first["next_cursor"]
+        assert "+" not in cursor and "/" not in cursor and "=" not in cursor
+        second = app.get(f"/log/api/entries?cursor={cursor}&limit=1").json()
+        assert [e["body_md"] for e in second["entries"]] == ["n1"]
+
+    def test_a_shaped_but_bogus_cursor_is_refused(self, app: TestClient) -> None:
+        """A corrupted cursor is a 422, never a quiet "caught up"."""
+        import base64
+
+        bogus = base64.urlsafe_b64encode(b"junk|5").decode().rstrip("=")
+        assert app.get("/log/api/entries", params={"cursor": bogus}).status_code == 422
+        assert app.get("/log/api/entries", params={"cursor": "%%%"}).status_code == 422
 
     def test_not_served_without_a_store(self, share: Path) -> None:
         app = FastAPI()

--- a/GeecsLogbook/tests/test_store.py
+++ b/GeecsLogbook/tests/test_store.py
@@ -2,12 +2,13 @@
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 import pytest
 from geecs_schemas.log_entry import Attachment
 
+from geecs_logbook import store as store_module
 from geecs_logbook.store import ConflictError, NotesStore
 
 DAY = "2026-09-11"
@@ -486,3 +487,120 @@ class TestHistory:
         with pytest.raises(ConflictError):
             store.update(e.entry_id, body_md="x", editor="a", expected_version=9)
         assert store.history(e.entry_id) == []
+
+
+class TestCountByDay:
+    """The calendar's question: which days have notes, and how many."""
+
+    def test_counts_per_day_and_book_live_only(self, store: NotesStore) -> None:
+        """One grouped query; a deleted entry is not counted."""
+        store.create(day="2026-09-11", author="a", body_md="x", book="ops")
+        store.create(day="2026-09-11", author="a", body_md="y", book="ops")
+        store.create(day="2026-09-11", author="a", body_md="z", scan=1)
+        gone = store.create(day="2026-09-03", author="a", body_md="gone")
+        store.delete(gone.entry_id)
+        store.create(day="2026-10-01", author="a", body_md="next month")
+        assert store.count_by_day("2026-09-01", "2026-09-30") == {
+            "2026-09-11": {"ops": 2, "scans": 1}
+        }
+
+
+class TestChangedSince:
+    """The synchroniser's feed: every change after a moment, tombstones included."""
+
+    @staticmethod
+    def _at(store: NotesStore, monkeypatch: pytest.MonkeyPatch, stamp: datetime):
+        monkeypatch.setattr(store_module, "_now", lambda: stamp)
+
+    def test_orders_by_change_and_includes_tombstones(
+        self, store: NotesStore, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A delete is a change: the tombstone rides the feed, hidden elsewhere."""
+        t0 = datetime(2026, 9, 11, 8, 0, tzinfo=timezone.utc)
+        self._at(store, monkeypatch, t0)
+        first = store.create(day="2026-09-11", author="a", body_md="first")
+        self._at(store, monkeypatch, t0 + timedelta(minutes=1))
+        second = store.create(day="2026-09-11", author="a", body_md="second")
+        self._at(store, monkeypatch, t0 + timedelta(minutes=2))
+        store.delete(first.entry_id)
+        page = store.changed_since(t0 - timedelta(seconds=1))
+        assert [e.entry_id for e in page.entries] == [second.entry_id, first.entry_id]
+        assert page.entries[1].is_deleted and page.next_cursor is None
+        assert store.for_day("2026-09-11") == [second]
+        assert [
+            e.entry_id
+            for e in store.changed_since(
+                t0 - timedelta(seconds=1), include_deleted=False
+            ).entries
+        ] == [second.entry_id]
+
+    def test_since_is_exclusive_and_status_moves_an_entry(
+        self, store: NotesStore, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A promotion is invisible to "edited since"; it must not be to this."""
+        t0 = datetime(2026, 9, 11, 8, 0, tzinfo=timezone.utc)
+        self._at(store, monkeypatch, t0)
+        entry = store.create(
+            day="2026-09-11",
+            author="agent",
+            body_md="draft",
+            kind="agent_draft",
+            status="draft",
+        )
+        assert store.changed_since(t0).entries == []  # strictly after
+        self._at(store, monkeypatch, t0 + timedelta(minutes=5))
+        store.set_status(entry.entry_id, "kept")
+        got = store.changed_since(t0).entries
+        assert [e.status for e in got] == ["kept"]
+        assert store.changed_since(t0, until=t0 + timedelta(minutes=4)).entries == []
+        assert (
+            len(store.changed_since(t0, until=t0 + timedelta(minutes=5)).entries) == 1
+        )
+
+    def test_pagination_cannot_skip_a_shared_timestamp(
+        self, store: NotesStore, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Three rows on one updated_at across a page boundary all arrive once."""
+        t0 = datetime(2026, 9, 11, 8, 0, tzinfo=timezone.utc)
+        self._at(store, monkeypatch, t0)
+        ids = [
+            store.create(day="2026-09-11", author="a", body_md=str(i)).entry_id
+            for i in range(3)
+        ]
+        self._at(store, monkeypatch, t0 + timedelta(minutes=1))
+        ids.append(store.create(day="2026-09-11", author="a", body_md="later").entry_id)
+        seen: list[str] = []
+        cursor = None
+        pages = 0
+        while True:
+            page = store.changed_since(
+                t0 - timedelta(seconds=1), cursor=cursor, limit=2
+            )
+            seen += [e.entry_id for e in page.entries]
+            pages += 1
+            cursor = page.next_cursor
+            if cursor is None:
+                break
+        assert seen == ids and pages == 2
+        assert (
+            store.changed_since(t0 - timedelta(seconds=1), limit=4).next_cursor is None
+        )
+
+    def test_book_filter_and_bad_inputs(
+        self, store: NotesStore, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A naive timestamp and a malformed cursor are refused, not guessed."""
+        t0 = datetime(2026, 9, 11, 8, 0, tzinfo=timezone.utc)
+        self._at(store, monkeypatch, t0)
+        store.create(day="2026-09-11", author="a", body_md="ops", book="ops")
+        store.create(day="2026-09-11", author="a", body_md="scan", scan=2)
+        since = t0 - timedelta(seconds=1)
+        assert [e.book for e in store.changed_since(since, book="ops").entries] == [
+            "ops"
+        ]
+        with pytest.raises(ValueError):
+            store.changed_since(datetime(2026, 9, 11, 8, 0))
+        with pytest.raises(ValueError):
+            store.changed_since(since, cursor="nonsense")
+        with pytest.raises(ValueError):
+            store.changed_since(since, limit=0)

--- a/GeecsWebTheme/CHANGELOG.md
+++ b/GeecsWebTheme/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to `geecs-web-theme` are documented here. The format
 follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and this
 project adheres to semantic versioning.
 
+## [0.1.2] - 2026-09-12
+
+### Changed
+
+- The literal-colour guard walks the logbook's navigation script
+  (`static/nav.js`) too.
+
 ## [0.1.1] - 2026-09-11
 
 ### Changed

--- a/GeecsWebTheme/pyproject.toml
+++ b/GeecsWebTheme/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-web-theme"
-version = "0.1.1"
+version = "0.1.2"
 description = "One palette vocabulary for every GEECS web surface: tokens, themes, and the picker"
 authors = ["GEECS-BELLA"]
 readme = "README.md"

--- a/GeecsWebTheme/tests/test_no_literal_colours.py
+++ b/GeecsWebTheme/tests/test_no_literal_colours.py
@@ -43,6 +43,7 @@ _SURFACES = [
     "GeecsLogbook/geecs_logbook/templates/month.html",
     "GeecsLogbook/geecs_logbook/templates/_entries.html",
     "GeecsLogbook/geecs_logbook/static/editor.js",
+    "GeecsLogbook/geecs_logbook/static/nav.js",
     "ScanAnalysis/scan_analysis/config_editor/static/editor.css",
     "ScanAnalysis/scan_analysis/config_editor/templates/editor.html",
 ]


### PR DESCRIPTION
PR 4 of the logbook arc (`phase/06-nav` → `feature/scan-logger`): navigation polish, plus the ARIEL change feed that was deferred out of #832 and asked for in this PR.

## What

**GeecsLogbook 0.6.0**

1. **Calendar in the rail**, both pages — a `<details class="cal">` that `static/nav.js` fills on open with a month grid. Days are marked when they have notes (soft accent, from the store's per-day counts) and when a day folder exists on the share (a dot). Marks come from a new `GET /log/api/month/{YYYY-MM}/days`, fetched **lazily by the open calendar**: the month page itself still never touches the share (pinned — `test_nav.py` makes the listing explode under the month page). The share side is **one** `scandir` of the month folder (`scan_reader.days_with_folders`, pinned to a single call), never thirty per-day walks. A missing experiment directory comes back as `share: false` — said, not hidden — and the store's marks stand alone.
2. **Faster day switching** — Sam did not specify the mechanism; my reading, flagged for veto: keyboard `←` `→` (day on the day page, month on the month page), `t` today, `c` toggles the calendar (ignored while typing); and a `<link rel="prefetch">` added when the viewer rests on a day/month link for 80 ms, so the click that follows is served warm. Nothing is prefetched on load — every day page is a share read. Collapse state was already kept (localStorage). The rail links remain full reloads; a fetch-and-swap SPA would be a different shape and was not asked for.
3. **Today** — `GET /log/today` and `GET /log/month/today` (this month, anchored at today's day group). The month rail's Today control is always present now (it was only a "Back to this month" from another month).
4. **The change feed** — `GET /log/api/entries?since=<aware ISO 8601>` (`NotesStore.changed_since`): everything whose `updated_at` moved after `since`, oldest change first, **tombstones included** — the one listing that returns them. `until=`, `book=`, `include_deleted=false` narrow it; `limit=` pages with a `next_cursor` that resumes after `(updated_at, rowid)`, so rows sharing an `updated_at` across a boundary cannot lose one. `since` must carry a timezone (422 otherwise: the columns are UTC `isoformat()` strings). Envelope `{entries, next_cursor}`. Relayed from Sam via the OSPREY/ARIEL session as the deferred #832 chunk, now wanted; scans are not in it by their own ruling.

**GEECS-DataPortal 0.26.0** — the run page links its scan's card in the logbook (`/log/day/YYYY-MM-DD#ScanNNN`, in the rail's day-stepper row) when the logbook is mounted; `GET /api/run/{uid}` carries the same URL as `logbook` (null when unlinked). Built from the mount prefix and the resolved day folder — the portal still never imports the logbook. Pinned mounted → present, not mounted → absent, proxy prefix carried.

**GeecsWebTheme 0.1.2** — the literal-colour guard walks `nav.js`.

## Per-concern LOC (insertions)

| Concern | Code | Tests | Docs/meta |
|---|---|---|---|
| Calendar (nav.js, css, marks route, `days_with_folders`, templates) | ~330 | ~150 | — |
| Keyboard + prefetch (inside nav.js; `data-*` on `<main>`) | ~60 | ~25 | — |
| Today names + month-rail Today | ~15 | ~25 | — |
| Change feed (store + route) | ~130 | ~150 | — |
| Portal run → log link | 24 | 29 | 11 |
| Theme guard surface | 1 | — | 7 |
| CHANGELOGs, CLAUDE.md (Navigation + Change feed sections), versions | — | — | ~95 |

## Judgment calls (cheap to veto)

- The feed rides in this PR (a second concern) because it was asked for in exactly this PR; it is store-sized and independently tested, and could be split out in five minutes if preferred.
- `include_deleted` defaults to **true** on the feed only. Every other listing hides tombstones; the feed's whole purpose includes them.
- Calendar cell on the month page links to `/log/month/M#day-D` (the book you are in); on the day page to `/log/day/D`.
- A "day folder exists" mark means the `YY_MMDD` folder exists (something wrote there), not that `scans/` inside it is non-empty — that would be a second stat per day.

## Tests

- GeecsLogbook: **207** (was 185; +22: `test_nav.py` calendar marks / single listing / share-down / month page never lists / today names / rail wiring / feed route; `test_store.py` counts + feed ordering, tombstones, exclusive since, shared-timestamp pagination, bad inputs)
- GEECS-DataPortal: **259** (+3)
- GeecsWebTheme: **108** (+1)
- `scripts/check.sh --base origin/feature/scan-logger` rc=0 (captured unpiped).

Smoke-verified on a local temp-share server with headless Chrome: both pages render the open calendar with correct marks (scan days dotted, note days tinted, active day filled, today outlined); the `/days` payload for the smoke month matches the seeded data.

## Hardware verification

None needed — no scan execution or device path is touched. The share-side change is one directory listing.
