### PR TITLE
CI: console-windows job off by default, toggled by a repository variable

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -100,4 +100,5 @@ jobs:
   # The console-windows job (the GEECS-Console suite + the qs_client tests on
   # windows-latest) was retired 2026-09-12: the console is not being changed
   # and is slated for retirement, and the job added ~5 minutes to every
-  # check. Restore it from git history if a Windows leg is wanted again.
+  # check. It was the console suite's ONLY CI leg — the suite is now local
+  # only (scripts/check.sh runs it). Restore from git history if wanted.

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -97,49 +97,7 @@ jobs:
         working-directory: GeecsPvaGateway
         run: poetry run pytest tests --tb=short -q
 
-  console-windows:
-    # GEECS-Console is the operator-facing PySide6 GUI and control-room
-    # machines run Windows — this job pins that the console suite passes
-    # on windows-latest.  Console only; the rest of the monorepo is
-    # covered by the ubuntu job above.
-    runs-on: windows-latest
-
-    defaults:
-      run:
-        working-directory: GEECS-Console
-
-    steps:
-      - uses: actions/checkout@v5
-
-      - uses: actions/setup-python@v5
-        with:
-          python-version: '3.11'
-
-      - name: Install Poetry
-        run: pip install poetry
-
-      - name: Cache Poetry package cache
-        uses: actions/cache@v4
-        with:
-          path: ~\AppData\Local\pypoetry\Cache
-          key: poetry-console-windows-py311-${{ hashFiles('GEECS-Console/poetry.lock') }}
-          restore-keys: poetry-console-windows-py311-
-
-      - name: Install GEECS-Console dependencies
-        # Path deps (geecs-core, and geecs-bluesky -> geecs-core/
-        # geecs-schemas/geecs-data-utils) resolve relative to GEECS-Console/
-        # inside the checkout, same as on the ubuntu job.
-        run: poetry install --with dev
-
-      - name: Run GEECS-Console tests
-        env:
-          QT_QPA_PLATFORM: offscreen
-        run: poetry run pytest -q --tb=short
-
-      - name: Run qs_client tests on Windows
-        # The RE Manager client (geecs_bluesky.qs_client) moved out of the
-        # console but the console still runs it on Windows control-room
-        # machines — keep its Windows leg (tilde-expanding config reader
-        # included).  geecs-bluesky is installed in this env as a path dep
-        # with the qs-client extra, so the suite collects here directly.
-        run: poetry run pytest ../GeecsBluesky/tests/qs_client -q --tb=short -p no:cacheprovider
+  # The console-windows job (the GEECS-Console suite + the qs_client tests on
+  # windows-latest) was retired 2026-09-12: the console is not being changed
+  # and is slated for retirement, and the job added ~5 minutes to every
+  # check. Restore it from git history if a Windows leg is wanted again.

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -97,8 +97,58 @@ jobs:
         working-directory: GeecsPvaGateway
         run: poetry run pytest tests --tb=short -q
 
-  # The console-windows job (the GEECS-Console suite + the qs_client tests on
-  # windows-latest) was retired 2026-09-12: the console is not being changed
-  # and is slated for retirement, and the job added ~5 minutes to every
-  # check. It was the console suite's ONLY CI leg — the suite is now local
-  # only (scripts/check.sh runs it). Restore from git history if wanted.
+  console-windows:
+    # GEECS-Console is the operator-facing PySide6 GUI and control-room
+    # machines run Windows — this job pins that the console suite passes
+    # on windows-latest.  Console only; the rest of the monorepo is
+    # covered by the ubuntu job above.
+    #
+    # OFF BY DEFAULT since 2026-09-12: the console is not being changed
+    # and is slated for retirement, and this leg added ~5 minutes to
+    # every check. It is the console suite's only CI leg, so while it is
+    # off the suite is local-only (scripts/check.sh runs it). Turn it on
+    # without a commit: repository Settings → Secrets and variables →
+    # Actions → Variables → CI_CONSOLE_WINDOWS = true (the job reports
+    # "skipped" while off; no branch protection names it).
+    if: ${{ vars.CI_CONSOLE_WINDOWS == 'true' }}
+    runs-on: windows-latest
+
+    defaults:
+      run:
+        working-directory: GEECS-Console
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install Poetry
+        run: pip install poetry
+
+      - name: Cache Poetry package cache
+        uses: actions/cache@v4
+        with:
+          path: ~\AppData\Local\pypoetry\Cache
+          key: poetry-console-windows-py311-${{ hashFiles('GEECS-Console/poetry.lock') }}
+          restore-keys: poetry-console-windows-py311-
+
+      - name: Install GEECS-Console dependencies
+        # Path deps (geecs-core, and geecs-bluesky -> geecs-core/
+        # geecs-schemas/geecs-data-utils) resolve relative to GEECS-Console/
+        # inside the checkout, same as on the ubuntu job.
+        run: poetry install --with dev
+
+      - name: Run GEECS-Console tests
+        env:
+          QT_QPA_PLATFORM: offscreen
+        run: poetry run pytest -q --tb=short
+
+      - name: Run qs_client tests on Windows
+        # The RE Manager client (geecs_bluesky.qs_client) moved out of the
+        # console but the console still runs it on Windows control-room
+        # machines — keep its Windows leg (tilde-expanding config reader
+        # included).  geecs-bluesky is installed in this env as a path dep
+        # with the qs-client extra, so the suite collects here directly.
+        run: poetry run pytest ../GeecsBluesky/tests/qs_client -q --tb=short -p no:cacheprovider

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -142,13 +142,14 @@ Style: NumPy docstrings, type hints on public functions, Pydantic v2
 
 ## Tests
 
-CI (`.github/workflows/unit-tests.yml`) runs: root `tests/`, ImageAnalysis,
-ScanAnalysis, GEECS-Data-Utils, GEECS-Schemas from the **root env** and
-GeecsBluesky from its **own env** (Ubuntu); on the greenfield branch a
-second job runs the GEECS-Console suite from its own env on **Windows**
-(control-room machines run Windows). The GeecsCAGateway and
-GEECS-LogTriage suites are not in CI — run them locally when touching
-those packages. Everything is hermetic — no lab network, no hardware.
+CI (`.github/workflows/unit-tests.yml`, one Ubuntu job) runs: root
+`tests/`, ImageAnalysis, ScanAnalysis, GEECS-Data-Utils and GEECS-Schemas
+from the **root env**, and GEECS-DataPortal, GEECS-Core, GeecsCAGateway,
+GeecsBluesky (pure unit tests, `qs-client` extra included), GEECS-MCP and
+GeecsPvaGateway each from its **own env**. Not in CI — run locally via
+`scripts/check.sh` when touching them: GEECS-Console (its Windows job was
+retired 2026-09-12; the console is not being changed and is slated for
+retirement) and GEECS-LogTriage. Everything is hermetic — no lab network, no hardware.
 `integration`-marked tests need the lab and are deselected by default;
 never run the top-level hardware scripts without lab access and operator
 coordination.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -147,9 +147,11 @@ CI (`.github/workflows/unit-tests.yml`, one Ubuntu job) runs: root
 from the **root env**, and GEECS-DataPortal, GEECS-Core, GeecsCAGateway,
 GeecsBluesky (pure unit tests, `qs-client` extra included), GEECS-MCP and
 GeecsPvaGateway each from its **own env**. Not in CI — run locally via
-`scripts/check.sh` when touching them: GEECS-Console (its Windows job was
-retired 2026-09-12; the console is not being changed and is slated for
-retirement) and GEECS-LogTriage. Everything is hermetic — no lab network, no hardware.
+`scripts/check.sh` when touching them: GEECS-Console (its Windows job
+`console-windows` is off by default since 2026-09-12 — the console is not
+being changed and is slated for retirement; the repository Actions
+variable `CI_CONSOLE_WINDOWS=true` turns it on without a commit) and
+GEECS-LogTriage. Everything is hermetic — no lab network, no hardware.
 `integration`-marked tests need the lab and are deselected by default;
 never run the top-level hardware scripts without lab access and operator
 coordination.

--- a/GEECS-Console/CHANGELOG.md
+++ b/GEECS-Console/CHANGELOG.md
@@ -6,15 +6,16 @@ semantic.
 
 ## [0.30.1] - 2026-09-12
 
-### Removed
+### Changed
 
 - The `console-windows` CI job (the console suite and the qs_client tests
-  on `windows-latest`). The console is not being changed and is slated
-  for retirement; the job added ~5 minutes to every check. It was the
-  console suite's **only** CI leg, so the suite is now local-only —
+  on `windows-latest`) is **off by default**, gated on the repository
+  Actions variable `CI_CONSOLE_WINDOWS` (`true` turns it on from
+  Settings, no commit). The console is not being changed and is slated
+  for retirement; the job added ~5 minutes to every check. It is the
+  console suite's **only** CI leg, so while off the suite is local-only —
   `scripts/check.sh` still runs it when console files change. The
-  qs_client suite keeps its Ubuntu leg. Restore from git history if
-  wanted.
+  qs_client suite keeps its Ubuntu leg.
 
 ## [0.30.0] - 2026-09-04
 

--- a/GEECS-Console/CHANGELOG.md
+++ b/GEECS-Console/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to GEECS-Console are documented here.  Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versioning is
 semantic.
 
+## [0.30.1] - 2026-09-12
+
+### Removed
+
+- The `console-windows` CI job (the console suite and the qs_client tests
+  on `windows-latest`). The console is not being changed and is slated
+  for retirement; the job added ~5 minutes to every check. The Ubuntu job
+  still runs both suites. Restore from git history if a Windows leg is
+  wanted again.
+
 ## [0.30.0] - 2026-09-04
 
 ### Added

--- a/GEECS-Console/CHANGELOG.md
+++ b/GEECS-Console/CHANGELOG.md
@@ -10,9 +10,11 @@ semantic.
 
 - The `console-windows` CI job (the console suite and the qs_client tests
   on `windows-latest`). The console is not being changed and is slated
-  for retirement; the job added ~5 minutes to every check. The Ubuntu job
-  still runs both suites. Restore from git history if a Windows leg is
-  wanted again.
+  for retirement; the job added ~5 minutes to every check. It was the
+  console suite's **only** CI leg, so the suite is now local-only —
+  `scripts/check.sh` still runs it when console files change. The
+  qs_client suite keeps its Ubuntu leg. Restore from git history if
+  wanted.
 
 ## [0.30.0] - 2026-09-04
 

--- a/GEECS-Console/CLAUDE.md
+++ b/GEECS-Console/CLAUDE.md
@@ -688,6 +688,7 @@ cyclic GC would delete the C++ window at an arbitrary allocation — including
 inside `processEvents` while Qt is dispatching to it (a polish walk, a
 queued poll result), a segfault at a random test in isolated
 `test_main_window.py` runs (#767).  A test that drops a window *mid*-body
-and then pumps events (`qtbot.waitUntil`) must `gc.collect()` itself first.  CI also runs this suite on `windows-latest` (the
-`console-windows` job in `.github/workflows/unit-tests.yml`) — the console
-deploys to Windows control-room machines, so keep the suite green there too.
+and then pumps events (`qtbot.waitUntil`) must `gc.collect()` itself first.  CI ran this suite on `windows-latest` too
+(the `console-windows` job in `.github/workflows/unit-tests.yml`) until
+2026-09-12, when the job was retired — the console is not being changed and
+the leg cost ~5 minutes per check; it is in git history if wanted again.

--- a/GEECS-Console/CLAUDE.md
+++ b/GEECS-Console/CLAUDE.md
@@ -688,8 +688,10 @@ cyclic GC would delete the C++ window at an arbitrary allocation — including
 inside `processEvents` while Qt is dispatching to it (a polish walk, a
 queued poll result), a segfault at a random test in isolated
 `test_main_window.py` runs (#767).  A test that drops a window *mid*-body
-and then pumps events (`qtbot.waitUntil`) must `gc.collect()` itself first.  CI ran this suite on `windows-latest`
-(the `console-windows` job in `.github/workflows/unit-tests.yml`) until
-2026-09-12, when the job was retired — the console is not being changed and
-the leg cost ~5 minutes per check. That was the suite's only CI leg: it is
-now local-only (`scripts/check.sh`); the job is in git history if wanted.
+and then pumps events (`qtbot.waitUntil`) must `gc.collect()` itself first.  CI runs this suite on `windows-latest`
+(the `console-windows` job in `.github/workflows/unit-tests.yml`) only when
+the repository Actions variable `CI_CONSOLE_WINDOWS` is `true` — off since
+2026-09-12, because the console is not being changed and the leg cost ~5
+minutes per check. It is the suite's only CI leg, so while it is off the
+suite is local-only (`scripts/check.sh`); flip the variable in Settings to
+turn it back on, no commit needed.

--- a/GEECS-Console/CLAUDE.md
+++ b/GEECS-Console/CLAUDE.md
@@ -691,4 +691,5 @@ queued poll result), a segfault at a random test in isolated
 and then pumps events (`qtbot.waitUntil`) must `gc.collect()` itself first.  CI ran this suite on `windows-latest` too
 (the `console-windows` job in `.github/workflows/unit-tests.yml`) until
 2026-09-12, when the job was retired — the console is not being changed and
-the leg cost ~5 minutes per check; it is in git history if wanted again.
+the leg cost ~5 minutes per check. That was the suite's only CI leg: it is
+now local-only (`scripts/check.sh`); the job is in git history if wanted.

--- a/GEECS-Console/CLAUDE.md
+++ b/GEECS-Console/CLAUDE.md
@@ -688,7 +688,7 @@ cyclic GC would delete the C++ window at an arbitrary allocation — including
 inside `processEvents` while Qt is dispatching to it (a polish walk, a
 queued poll result), a segfault at a random test in isolated
 `test_main_window.py` runs (#767).  A test that drops a window *mid*-body
-and then pumps events (`qtbot.waitUntil`) must `gc.collect()` itself first.  CI ran this suite on `windows-latest` too
+and then pumps events (`qtbot.waitUntil`) must `gc.collect()` itself first.  CI ran this suite on `windows-latest`
 (the `console-windows` job in `.github/workflows/unit-tests.yml`) until
 2026-09-12, when the job was retired — the console is not being changed and
 the leg cost ~5 minutes per check. That was the suite's only CI leg: it is

--- a/GEECS-Console/pyproject.toml
+++ b/GEECS-Console/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-console"
-version = "0.30.0"
+version = "0.30.1"
 description = "Greenfield PySide6 operator console for GEECS (Bluesky/gateway architecture)"
 authors = ["Sam Barber <sbarber@lbl.gov>"]
 readme = "README.md"


### PR DESCRIPTION
Keeps the `console-windows` job (the GEECS-Console suite plus the qs_client tests on `windows-latest`) in `.github/workflows/unit-tests.yml` but gates it: `if: ${{ vars.CI_CONSOLE_WINDOWS == 'true' }}`. The console is not being changed and is slated for retirement, and the job added ~5 minutes to every CI check (owner request, 2026-09-12). The first cut deleted the job; the owner reconsidered and asked for a toggle instead — this is that.

**Turning it on/off, no commit:** repository Settings → Secrets and variables → Actions → Variables → `CI_CONSOLE_WINDOWS` = `true`. Unset or anything else = off. While off the job reports *skipped* on every run (no branch-protection rule names it — master is unprotected — so nothing blocks).

**What is off while it is off, stated plainly (review finding 1):** that job is the console suite's *only* CI leg — the Ubuntu job has never run GEECS-Console. So with the variable unset the console suite is local-only: `scripts/check.sh` still runs it when console files change. The qs_client suite keeps its Ubuntu leg (`--extras qs-client`).

Docs: `GEECS-Console/CLAUDE.md` records the gate and how to flip it; console CHANGELOG 0.30.1 (docs-only patch bump per convention); `CONTRIBUTING.md` § Tests rewritten to match the workflow as it actually is (it still described a greenfield-branch Windows job and mis-listed which suites are in CI).

Tests: none affected (workflow + docs). pre-commit (check-yaml) passed at commit; the workflow parses with both jobs present and the `if:` on `console-windows`. The CI run on the final commit is the live proof that the job skips.

Adversarial review: 2 findings, both fixed and verified by the same reviewer (comments below); the rework from delete to toggle post-dates the verification and touches the same three doc surfaces plus the workflow, so the reviewer's checks (YAML validity, CONTRIBUTING list vs workflow) were re-done by hand.

Hardware verification: none — CI only.