### PR TITLE
GeecsBluesky 0.82.4: ensure-ready re-downloads an empty plan list through environment_update (#838)

### DIFF
--- a/GeecsBluesky/CHANGELOG.md
+++ b/GeecsBluesky/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to `geecs-bluesky` are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 
+## [0.82.4] - 2026-09-12
+
+### Fixed
+
+- `geecs-qserver-ensure-ready` heals the manager that is idle with its
+  environment open and `plans_allowed` **empty** (GEECS-Plugins#838: the
+  manager's own download of the lists from the worker timed out while the
+  host thrashed, and every submission was then refused "not in the list of
+  allowed plans" while `status` looked healthy): a list still empty or
+  incomplete after the settle window is downloaded again once through
+  `environment_update`, with the settle window applied again — so
+  `systemctl restart geecs-qserver-ready` recovers it without a manager
+  restart.  The shared `plans_empty` verdict (Console banner, MCP
+  preflight) names that cause and that gesture; `qserver/README.md`
+  Troubleshooting carries the entry.
+
 ## [0.82.3] - 2026-09-12
 
 ### Changed

--- a/GeecsBluesky/CHANGELOG.md
+++ b/GeecsBluesky/CHANGELOG.md
@@ -14,11 +14,14 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   manager's own download of the lists from the worker timed out while the
   host thrashed, and every submission was then refused "not in the list of
   allowed plans" while `status` looked healthy): a list still empty or
-  incomplete after the settle window is downloaded again once through
-  `environment_update`, with the settle window applied again — so
-  `systemctl restart geecs-qserver-ready` recovers it without a manager
-  restart.  The shared `plans_empty` verdict (Console banner, MCP
-  preflight) names that cause and that gesture; `qserver/README.md`
+  incomplete after the settle window is restored once from the worker's
+  on-disk copy through `permissions_reload(restore_plans_devices=True)`
+  — the copy the worker writes at every environment open — with the
+  settle window applied again, so `systemctl restart geecs-qserver-ready`
+  recovers it without a manager restart.  (`environment_update`, the fix
+  #838 first named, re-downloads only when the worker's namespace changed
+  and is not used.)  The shared `plans_empty` verdict (Console banner,
+  MCP preflight) names that cause and that gesture; `qserver/README.md`
   Troubleshooting carries the entry.
 
 ## [0.82.3] - 2026-09-12

--- a/GeecsBluesky/CLAUDE.md
+++ b/GeecsBluesky/CLAUDE.md
@@ -207,7 +207,9 @@ namespace, so never import a stray generator into the profile),
 `deploy/` (the manager and `geecs-qserver-ready` units + runbook).  **A
 running service means ready (#793)**: the readiness unit runs
 `geecs-qserver-ensure-ready` after every manager start — wait, open if
-closed, wait for idle, assert `plans_allowed ⊇ GEECS_PLAN_NAMES`.  Read
+closed, wait for idle, assert `plans_allowed ⊇ GEECS_PLAN_NAMES` (and,
+when the list is empty or incomplete with the environment up, restore it
+once from the worker's on-disk copy via `permissions_reload`, #838).  Read
 `qserver/README.md` first; its Troubleshooting section is the empirical
 contract (permissions file, `--keep-re`, manager-restart-after-install,
 failed-items-requeue-at-front, CLI parses Python literals not JSON).

--- a/GeecsBluesky/geecs_bluesky/qs_client/client.py
+++ b/GeecsBluesky/geecs_bluesky/qs_client/client.py
@@ -267,9 +267,12 @@ def readiness_verdict(
             False,
             "plans_empty",
             "The RE Manager lists no allowed plans although its worker environment "
-            "exists — the startup profile registered nothing (import error?) or the "
-            "permissions file allows nothing; see GeecsBluesky/qserver/README.md, "
-            "Troubleshooting.",
+            "exists — its download of the plan list from the worker timed out "
+            "(GEECS-Plugins#838), the startup profile registered nothing (import "
+            "error?), or the permissions file allows nothing. On the worker host "
+            "`systemctl restart geecs-qserver-ready` re-downloads the lists "
+            "(`environment_update`) without restarting the manager; see "
+            "GeecsBluesky/qserver/README.md, Troubleshooting.",
             allowed,
         )
     expected = (

--- a/GeecsBluesky/geecs_bluesky/qs_client/client.py
+++ b/GeecsBluesky/geecs_bluesky/qs_client/client.py
@@ -270,9 +270,10 @@ def readiness_verdict(
             "exists — its download of the plan list from the worker timed out "
             "(GEECS-Plugins#838), the startup profile registered nothing (import "
             "error?), or the permissions file allows nothing. On the worker host "
-            "`systemctl restart geecs-qserver-ready` re-downloads the lists "
-            "(`environment_update`) without restarting the manager; see "
-            "GeecsBluesky/qserver/README.md, Troubleshooting.",
+            "`systemctl restart geecs-qserver-ready` restores the lists from the "
+            "worker's on-disk copy (`permissions_reload`, restore_plans_devices) "
+            "without restarting the manager; see GeecsBluesky/qserver/README.md, "
+            "Troubleshooting.",
             allowed,
         )
     expected = (

--- a/GeecsBluesky/geecs_bluesky/qserver_ready.py
+++ b/GeecsBluesky/geecs_bluesky/qserver_ready.py
@@ -20,7 +20,12 @@ only that check catches it.  The plan list is read through the same
 ``qs_client.readiness_from_reads`` assembly the pre-submit ``worker_ready``
 check runs (one definition of ready); after an open this run requested it
 is re-read for a short settle window, because the manager reports the
-environment up before its own plan-list download has landed.  Exit codes:
+environment up before its own plan-list download has landed.  A list that
+is still empty or incomplete after that is downloaded again once through
+the manager's ``environment_update`` (#838: the manager's own download can
+time out and leave it idle, environment open, knowing no plans — the unit
+re-run, ``systemctl restart geecs-qserver-ready``, heals that without a
+manager restart), and the settle window applies again.  Exit codes:
 0 ready; 1 not ready (the message says exactly what was found); 2 usage.
 
 The address asserted is the manager on **this** host (loopback), or
@@ -89,6 +94,14 @@ PLAN_LIST_SETTLE_POLLS = 5
 #: The verdict states the post-open settle re-reads (never ``plans_unknown``
 #: — an unanswered list is not ready, full stop).
 _SETTLING_STATES = ("plans_empty", "plan_missing")
+#: After the settle window a list that is still empty or incomplete is
+#: re-downloaded ONCE through ``environment_update`` (#838): the manager's
+#: own download of the lists from the worker can time out — observed
+#: while the host thrashed in swap — and then leaves the manager idle,
+#: environment open, ``plans_allowed`` empty, refusing every submission.
+#: The update asks the worker for the lists again and regenerates the
+#: allowed lists; the re-read settle window applies again after it.
+_REDOWNLOAD_STATES = _SETTLING_STATES
 
 #: ``request(method, params) -> (msg, err_msg)``: the manager transport.
 Request = Callable[[str, dict[str, Any] | None], tuple[dict[str, Any] | None, str]]
@@ -279,6 +292,7 @@ def ensure_ready(
     # be in flight when the environment first reads up, so an empty or
     # incomplete list is re-read for a short settle window (F1, #795).
     settle_polls = PLAN_LIST_SETTLE_POLLS if opened else 0
+    redownloaded = False
     while True:
         verdict = readiness_from_reads(
             queue_status_from_manager(status), read_plans, list(expected_plans)
@@ -294,6 +308,25 @@ def ensure_ready(
             log(
                 "plan list not settled after the open (%s) — re-reading" % verdict.state
             )
+            time.sleep(POLL_S)
+            status = _wait_for_manager(request, deadline)
+            continue
+        if (
+            verdict.state in _REDOWNLOAD_STATES
+            and not redownloaded
+            and time.monotonic() < deadline
+        ):
+            # The list is still empty / incomplete with the environment up:
+            # the manager's download of it from the worker may have timed
+            # out (#838).  Ask it to download again, then settle-read anew.
+            redownloaded = True
+            log(
+                "plan list %s with the environment up — requesting "
+                "environment_update (a timed-out list download, "
+                "GEECS-Plugins#838)" % verdict.state
+            )
+            _call(request, "environment_update", {})
+            settle_polls = PLAN_LIST_SETTLE_POLLS
             time.sleep(POLL_S)
             status = _wait_for_manager(request, deadline)
             continue

--- a/GeecsBluesky/geecs_bluesky/qserver_ready.py
+++ b/GeecsBluesky/geecs_bluesky/qserver_ready.py
@@ -21,9 +21,10 @@ only that check catches it.  The plan list is read through the same
 check runs (one definition of ready); after an open this run requested it
 is re-read for a short settle window, because the manager reports the
 environment up before its own plan-list download has landed.  A list that
-is still empty or incomplete after that is downloaded again once through
-the manager's ``environment_update`` (#838: the manager's own download can
-time out and leave it idle, environment open, knowing no plans — the unit
+is still empty or incomplete after that is restored once from the worker's
+on-disk copy through the manager's ``permissions_reload(restore_plans_devices=True)``
+(#838: the manager's own download of the lists from the worker can time
+out and leave it idle, environment open, knowing no plans — the unit
 re-run, ``systemctl restart geecs-qserver-ready``, heals that without a
 manager restart), and the settle window applies again.  Exit codes:
 0 ready; 1 not ready (the message says exactly what was found); 2 usage.
@@ -95,13 +96,26 @@ PLAN_LIST_SETTLE_POLLS = 5
 #: — an unanswered list is not ready, full stop).
 _SETTLING_STATES = ("plans_empty", "plan_missing")
 #: After the settle window a list that is still empty or incomplete is
-#: re-downloaded ONCE through ``environment_update`` (#838): the manager's
-#: own download of the lists from the worker can time out — observed
-#: while the host thrashed in swap — and then leaves the manager idle,
-#: environment open, ``plans_allowed`` empty, refusing every submission.
-#: The update asks the worker for the lists again and regenerates the
-#: allowed lists; the re-read settle window applies again after it.
-_REDOWNLOAD_STATES = _SETTLING_STATES
+#: restored ONCE from disk through ``permissions_reload`` with
+#: ``restore_plans_devices=True`` (#838): the manager's own download of the
+#: lists from the worker can time out — observed while the host thrashed
+#: in swap — and then leaves the manager idle, environment open,
+#: ``plans_allowed`` empty, refusing every submission.  The worker writes
+#: ``existing_plans_and_devices.yaml`` from its namespace at every
+#: environment open (``--update-existing-plans-devices`` default
+#: ``ENVIRONMENT_OPEN``), so that file IS the running environment's list;
+#: the reload loads it into the manager and regenerates the allowed lists
+#: unconditionally (``manager.py: _update_allowed_plans_and_devices``).
+#: ``environment_update`` was considered and rejected: it re-downloads
+#: only when the worker's regenerated descriptions DIFFER from its own
+#: stored copy (``worker.py: _load_script_into_environment``), so on an
+#: unchanged namespace it is a no-op.  The settle window applies again
+#: after the restore.
+_RESTORE_STATES = _SETTLING_STATES
+#: The restore is one manager call; the manager answers it after reading
+#: the file and pushing the permissions to the worker, which can exceed
+#: the 2 s status-poll transport budget on a host in the #838 state.
+RESTORE_TIMEOUT_S = 10.0
 
 #: ``request(method, params) -> (msg, err_msg)``: the manager transport.
 Request = Callable[[str, dict[str, Any] | None], tuple[dict[str, Any] | None, str]]
@@ -116,11 +130,12 @@ def _zmq_request(control_addr: str) -> Request:
     from bluesky_queueserver.manager.comms import zmq_single_request
 
     def request(method: str, params: dict[str, Any] | None = None):
+        budget = RESTORE_TIMEOUT_S if method == "permissions_reload" else POLL_S
         return zmq_single_request(
             method,
             params or {},
             zmq_server_address=control_addr,
-            timeout=int(POLL_S * 1000),
+            timeout=int(budget * 1000),
         )
 
     return request
@@ -292,7 +307,7 @@ def ensure_ready(
     # be in flight when the environment first reads up, so an empty or
     # incomplete list is re-read for a short settle window (F1, #795).
     settle_polls = PLAN_LIST_SETTLE_POLLS if opened else 0
-    redownloaded = False
+    restored = False
     while True:
         verdict = readiness_from_reads(
             queue_status_from_manager(status), read_plans, list(expected_plans)
@@ -312,20 +327,31 @@ def ensure_ready(
             status = _wait_for_manager(request, deadline)
             continue
         if (
-            verdict.state in _REDOWNLOAD_STATES
-            and not redownloaded
+            verdict.state in _RESTORE_STATES
+            and not restored
             and time.monotonic() < deadline
         ):
             # The list is still empty / incomplete with the environment up:
             # the manager's download of it from the worker may have timed
-            # out (#838).  Ask it to download again, then settle-read anew.
-            redownloaded = True
+            # out (#838).  Restore it from the worker's on-disk copy, then
+            # settle-read anew.
+            restored = True
             log(
-                "plan list %s with the environment up — requesting "
-                "environment_update (a timed-out list download, "
+                "plan list %s with the environment up — restoring the lists "
+                "from the worker's on-disk copy (permissions_reload, "
+                "restore_plans_devices=True; a timed-out list download, "
                 "GEECS-Plugins#838)" % verdict.state
             )
-            _call(request, "environment_update", {})
+            try:
+                reply = _call(
+                    request, "permissions_reload", {"restore_plans_devices": True}
+                )
+            except NotReady as exc:
+                raise NotReady(
+                    f"{verdict.detail} (user_group={user_group!r}); "
+                    f"and the restore from disk failed: {exc}"
+                ) from exc
+            log("lists restored from disk: %s" % (reply.get("msg") or "accepted"))
             settle_polls = PLAN_LIST_SETTLE_POLLS
             time.sleep(POLL_S)
             status = _wait_for_manager(request, deadline)

--- a/GeecsBluesky/pyproject.toml
+++ b/GeecsBluesky/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-bluesky"
-version = "0.82.3"
+version = "0.82.4"
 description = "Bluesky / ophyd-async bridge for the GEECS control system"
 authors = ["Sam Barber <sbarber@lbl.gov>"]
 readme = "README.md"

--- a/GeecsBluesky/qserver/README.md
+++ b/GeecsBluesky/qserver/README.md
@@ -151,13 +151,20 @@ the plan of record).
   existing plans and devices from the worker process: Timeout`), seen
   while the host thrashed in swap (GEECS-Plugins#838). It is not a closed
   environment and needs no restart: `systemctl restart
-  geecs-qserver-ready` — `geecs-qserver-ensure-ready` now asks the manager
-  for an `environment_update` when the list is empty or incomplete with
-  the environment up, which re-downloads the lists and regenerates the
-  allowed ones (by hand: `qserver environment update`). Do NOT
-  `permissions_reload(restore_plans_devices=True)`: that reloads the
-  stale on-disk copy. The update runs as a foreground task and is refused
-  while a plan is running; run it when the manager is idle.
+  geecs-qserver-ready` — `geecs-qserver-ensure-ready` asks the manager to
+  restore the lists from the worker's on-disk copy when the list is empty
+  or incomplete with the environment up (`permissions_reload` with
+  `restore_plans_devices=True`; by hand: `qserver permissions reload
+  lists`). That copy (`existing_plans_and_devices.yaml` in the startup
+  dir) is written by the *worker* from its namespace at every environment
+  open (`--update-existing-plans-devices` default `ENVIRONMENT_OPEN`), so
+  it is the running environment's list, not a stale one. `qserver
+  environment update` is NOT the fix: the worker re-downloads only when
+  its regenerated descriptions differ from its stored copy, so on an
+  unchanged namespace it is a no-op (and it needs an idle manager). The
+  file is stale only after a deploy that changed the plan set without
+  re-opening the environment — and then the worker process is equally
+  stale, so `systemctl restart geecs-qserver` is the gesture.
 - **`queue add` returns `success: False` with no reason at the CLI** — the
   manager was launched without a permissions file, or the file lacks the
   group the client submits as (the `qserver` CLI uses `primary` by

--- a/GeecsBluesky/qserver/README.md
+++ b/GeecsBluesky/qserver/README.md
@@ -142,6 +142,22 @@ the plan of record).
   systemd event fires, `geecs-qserver-ready` stays `active (exited)` from
   its last successful run, and only the console/MCP preflight refusal
   names the gesture (`systemctl restart geecs-qserver-ready`).
+- **Allowed plans empty while the manager is idle with its environment
+  open** (`worker_environment_exists: True`, `re_state: idle`,
+  `plans_allowed: {}` for every user group, every submission refused
+  "not in the list of allowed plans", `geecs-qserver-ready` still
+  `active (exited)`) — the manager's own **download of the plan list
+  from the worker timed out** (journal: `Failed to download the list of
+  existing plans and devices from the worker process: Timeout`), seen
+  while the host thrashed in swap (GEECS-Plugins#838). It is not a closed
+  environment and needs no restart: `systemctl restart
+  geecs-qserver-ready` — `geecs-qserver-ensure-ready` now asks the manager
+  for an `environment_update` when the list is empty or incomplete with
+  the environment up, which re-downloads the lists and regenerates the
+  allowed ones (by hand: `qserver environment update`). Do NOT
+  `permissions_reload(restore_plans_devices=True)`: that reloads the
+  stale on-disk copy. The update runs as a foreground task and is refused
+  while a plan is running; run it when the manager is idle.
 - **`queue add` returns `success: False` with no reason at the CLI** — the
   manager was launched without a permissions file, or the file lacks the
   group the client submits as (the `qserver` CLI uses `primary` by

--- a/GeecsBluesky/qserver/deploy/DEPLOYMENT.md
+++ b/GeecsBluesky/qserver/deploy/DEPLOYMENT.md
@@ -158,8 +158,11 @@ allowed plans" while `qserver status` looks healthy (live 2026-09-04,
 GEECS-Plugins#793). For GEECS a running service means ready, so the
 readiness unit runs `geecs-qserver-ensure-ready`: wait for the manager,
 open the environment if closed, wait for idle, then **assert
-`plans_allowed` lists every GEECS plan** (`geecs_bluesky.plan_names`),
-exiting non-zero with a precise message otherwise. A separate unit on
+`plans_allowed` lists every GEECS plan** (`geecs_bluesky.plan_names`) —
+restoring the lists once from the worker's on-disk copy when they read
+empty or incomplete with the environment up (a timed-out list download,
+GEECS-Plugins#838) — exiting non-zero with a precise message otherwise. A
+separate unit on
 purpose: the manager's start is never blocked by the optimize-stack import
 warm-up, a failed open shows as one failed unit rather than a crash-looping
 manager, and `systemctl restart geecs-qserver-ready` is the recovery

--- a/GeecsBluesky/tests/qs_client/test_readiness.py
+++ b/GeecsBluesky/tests/qs_client/test_readiness.py
@@ -89,10 +89,10 @@ class TestReadinessVerdict:
         assert not verdict.ready and verdict.state == "plans_empty"
         assert "Troubleshooting" in verdict.detail
         # #838: the timed-out list download is a named cause, and the
-        # gesture is the readiness unit (environment_update), not a restart.
+        # gesture is the readiness unit (permissions_reload from disk), not a restart.
         assert "timed out" in verdict.detail and "#838" in verdict.detail
         assert "systemctl restart geecs-qserver-ready" in verdict.detail
-        assert "environment_update" in verdict.detail
+        assert "permissions_reload" in verdict.detail
 
     def test_missing_expected_plan_lists_what_is_allowed(self):
         verdict = readiness_verdict(UP, {"mv": {}}, SCAN_PLAN)

--- a/GeecsBluesky/tests/qs_client/test_readiness.py
+++ b/GeecsBluesky/tests/qs_client/test_readiness.py
@@ -88,6 +88,11 @@ class TestReadinessVerdict:
         verdict = readiness_verdict(UP, {}, None)
         assert not verdict.ready and verdict.state == "plans_empty"
         assert "Troubleshooting" in verdict.detail
+        # #838: the timed-out list download is a named cause, and the
+        # gesture is the readiness unit (environment_update), not a restart.
+        assert "timed out" in verdict.detail and "#838" in verdict.detail
+        assert "systemctl restart geecs-qserver-ready" in verdict.detail
+        assert "environment_update" in verdict.detail
 
     def test_missing_expected_plan_lists_what_is_allowed(self):
         verdict = readiness_verdict(UP, {"mv": {}}, SCAN_PLAN)

--- a/GeecsBluesky/tests/test_qserver_ready.py
+++ b/GeecsBluesky/tests/test_qserver_ready.py
@@ -48,7 +48,7 @@ class _Manager:
         # manager's plan list landing *after* the environment reads up.
         self.plans_sequence = [list(p) for p in (plans_sequence or [])]
         self.open_reply = open_reply or {"success": True}
-        self.update_reply = update_reply or {"success": True, "task_uid": "t1"}
+        self.update_reply = update_reply or {"success": True, "msg": ""}
         self.answer = answer
         self.plans_answer = plans_answer
         self.calls: list[tuple[str, dict | None]] = []
@@ -62,7 +62,8 @@ class _Manager:
             return snap, ""
         if method == "environment_open":
             return self.open_reply, ""
-        if method == "environment_update":
+        if method == "permissions_reload":
+            assert params == {"restore_plans_devices": True}, params
             return self.update_reply, ""
         if method == "plans_allowed":
             if not self.plans_answer:
@@ -124,15 +125,15 @@ def test_empty_plan_list_after_open_is_not_ready() -> None:
     """The exact #793 invariant: open 'succeeded', plan list still empty.
 
     The fake stays empty across the post-open settle re-reads, the one
-    ``environment_update`` re-download (#838) and its own settle window,
-    so the conclusion is reached only after both are exhausted.
+    restore from disk (#838) and its own settle window, so the conclusion
+    is reached only after both are exhausted.
     """
     manager = _Manager([_status(exists=False), _status(exists=True)], plans=[])
     log = []
     with pytest.raises(NotReady, match="lists no allowed plans"):
         ensure_ready(manager, timeout_s=30, log=log.append)
     methods = [m for m, _ in manager.calls]
-    assert methods.count("environment_update") == 1
+    assert methods.count("permissions_reload") == 1
     assert methods.count("plans_allowed") == 2 * (
         qserver_ready.PLAN_LIST_SETTLE_POLLS + 1
     )
@@ -163,24 +164,25 @@ def test_plan_list_landing_after_the_open_is_ready() -> None:
 def test_no_settle_window_without_our_open() -> None:
     """An environment someone else opened is judged on the first read.
 
-    An empty list there is the #838 shape, so ONE ``environment_update``
+    An empty list there is the #838 shape, so ONE restore from disk
     follows (with its settle window) before the verdict is final.
     """
     manager = _Manager([_status(exists=True)], plans=[])
     with pytest.raises(NotReady, match="lists no allowed plans"):
         ensure_ready(manager, timeout_s=30, log=lambda s: None)
     methods = [m for m, _ in manager.calls]
-    assert methods.index("environment_update") == methods.index("plans_allowed") + 1
-    assert methods.count("environment_update") == 1
+    assert methods.index("permissions_reload") == methods.index("plans_allowed") + 1
+    assert methods.count("permissions_reload") == 1
     assert methods.count("plans_allowed") == qserver_ready.PLAN_LIST_SETTLE_POLLS + 2
 
 
-def test_empty_list_with_the_environment_up_is_healed_by_environment_update() -> None:
+def test_empty_list_with_the_environment_up_is_healed_by_a_restore_from_disk() -> None:
     """#838: the manager idle, environment open, plans_allowed EMPTY.
 
     A timed-out download of the lists from the worker leaves the manager
-    this way; ``environment_update`` makes it download again, and the
-    list lands within the settle window — ready without a restart.
+    this way; ``permissions_reload(restore_plans_devices=True)`` loads the
+    copy the worker wrote at environment open, and the list reads back
+    within the settle window — ready without a restart.
     """
     manager = _Manager(
         [_status(exists=True)], plans_sequence=[[], [], GEECS_PLAN_NAMES]
@@ -189,42 +191,69 @@ def test_empty_list_with_the_environment_up_is_healed_by_environment_update() ->
     allowed = ensure_ready(manager, timeout_s=30, log=log.append)
     assert allowed == sorted(GEECS_PLAN_NAMES)
     methods = [m for m, _ in manager.calls]
-    assert methods.count("environment_update") == 1
+    assert methods.count("permissions_reload") == 1
     assert "environment_open" not in methods
-    assert ("environment_update", {}) in manager.calls
-    # first read empty → update → settle re-reads until the list lands
+    assert "environment_update" not in methods
+    assert ("permissions_reload", {"restore_plans_devices": True}) in manager.calls
+    # first read empty → restore → settle re-reads until the list lands
     assert methods.count("plans_allowed") == 3
-    assert any("environment_update" in line and "#838" in line for line in log)
+    assert any("permissions_reload" in line and "#838" in line for line in log)
     assert log[-1].startswith(f"ready: {len(GEECS_PLAN_NAMES)} allowed plans")
 
 
 def test_stale_list_is_redownloaded_then_ready() -> None:
-    """A list missing a plan gets the same one re-download (a stale copy)."""
+    """A list missing a plan gets the same one restore (the pre-open list)."""
     manager = _Manager(
         [_status(exists=True)], plans_sequence=[["mv"], GEECS_PLAN_NAMES]
     )
     allowed = ensure_ready(manager, timeout_s=30, log=lambda s: None)
     assert allowed == sorted(GEECS_PLAN_NAMES)
-    assert [m for m, _ in manager.calls].count("environment_update") == 1
+    assert [m for m, _ in manager.calls].count("permissions_reload") == 1
 
 
-def test_environment_update_refused_is_not_ready() -> None:
-    """The manager refuses the update (not idle): not ready, its reason named."""
+def test_restore_refused_is_not_ready_and_keeps_the_verdict() -> None:
+    """The manager refuses the restore: not ready, both reasons in the message."""
     manager = _Manager(
         [_status(exists=True)],
-        plans=[],
-        update_reply={"success": False, "msg": "RE Manager must be in idle state"},
+        plans=["mv"],
+        update_reply={"success": False, "msg": "Queue is locked"},
     )
-    with pytest.raises(NotReady, match="refused 'environment_update'.*idle state"):
+    with pytest.raises(NotReady) as excinfo:
         ensure_ready(manager, timeout_s=30, log=lambda s: None)
+    message = str(excinfo.value)
+    assert "does not list" in message and "rel_list_grid_scan" in message
+    assert "restore from disk failed" in message and "Queue is locked" in message
     assert [m for m, _ in manager.calls].count("plans_allowed") == 1
+
+
+def test_restore_call_gets_the_longer_transport_budget(monkeypatch) -> None:
+    """The one restore call is answered after a disk read + a worker push."""
+    import sys
+    import types
+
+    seen = {}
+
+    def fake_zmq(method, params, *, zmq_server_address, timeout):
+        seen[method] = timeout
+        return {"success": True}, ""
+
+    monkeypatch.setitem(
+        sys.modules,
+        "bluesky_queueserver.manager.comms",
+        types.SimpleNamespace(zmq_single_request=fake_zmq),
+    )
+    request = qserver_ready._zmq_request("tcp://localhost:1")
+    request("status", None)
+    request("permissions_reload", {"restore_plans_devices": True})
+    assert seen["status"] == int(qserver_ready.POLL_S * 1000)
+    assert seen["permissions_reload"] == int(qserver_ready.RESTORE_TIMEOUT_S * 1000)
 
 
 def test_unanswered_plan_list_after_open_is_not_retried() -> None:
     """plans_unknown is never a settling state — unanswered is not ready.
 
-    Nor is it re-downloaded: a manager that does not answer the list
-    request is not one to ask for an ``environment_update``.
+    Nor is it restored: a manager that does not answer the list request
+    is not one to ask for a ``permissions_reload``.
     """
     manager = _Manager(
         [_status(exists=False), _status(exists=True)], plans_answer=False
@@ -233,7 +262,7 @@ def test_unanswered_plan_list_after_open_is_not_retried() -> None:
         ensure_ready(manager, timeout_s=30, log=lambda s: None)
     methods = [m for m, _ in manager.calls]
     assert methods.count("plans_allowed") == 1
-    assert "environment_update" not in methods
+    assert "permissions_reload" not in methods
 
 
 def test_unanswered_plan_list_is_not_ready() -> None:

--- a/GeecsBluesky/tests/test_qserver_ready.py
+++ b/GeecsBluesky/tests/test_qserver_ready.py
@@ -38,6 +38,7 @@ class _Manager:
         plans=GEECS_PLAN_NAMES,
         plans_sequence=None,
         open_reply=None,
+        update_reply=None,
         answer=True,
         plans_answer=True,
     ):
@@ -47,6 +48,7 @@ class _Manager:
         # manager's plan list landing *after* the environment reads up.
         self.plans_sequence = [list(p) for p in (plans_sequence or [])]
         self.open_reply = open_reply or {"success": True}
+        self.update_reply = update_reply or {"success": True, "task_uid": "t1"}
         self.answer = answer
         self.plans_answer = plans_answer
         self.calls: list[tuple[str, dict | None]] = []
@@ -60,6 +62,8 @@ class _Manager:
             return snap, ""
         if method == "environment_open":
             return self.open_reply, ""
+        if method == "environment_update":
+            return self.update_reply, ""
         if method == "plans_allowed":
             if not self.plans_answer:
                 return None, "timeout"
@@ -119,18 +123,22 @@ def test_missing_plan_is_not_ready_and_names_it() -> None:
 def test_empty_plan_list_after_open_is_not_ready() -> None:
     """The exact #793 invariant: open 'succeeded', plan list still empty.
 
-    The fake stays empty across the post-open settle re-reads, so the
-    conclusion is reached only after the settle window is exhausted.
+    The fake stays empty across the post-open settle re-reads, the one
+    ``environment_update`` re-download (#838) and its own settle window,
+    so the conclusion is reached only after both are exhausted.
     """
     manager = _Manager([_status(exists=False), _status(exists=True)], plans=[])
     log = []
     with pytest.raises(NotReady, match="lists no allowed plans"):
         ensure_ready(manager, timeout_s=30, log=log.append)
-    reads = [m for m, _ in manager.calls].count("plans_allowed")
-    assert reads == qserver_ready.PLAN_LIST_SETTLE_POLLS + 1
+    methods = [m for m, _ in manager.calls]
+    assert methods.count("environment_update") == 1
+    assert methods.count("plans_allowed") == 2 * (
+        qserver_ready.PLAN_LIST_SETTLE_POLLS + 1
+    )
     assert (
         sum("re-reading" in line for line in log)
-        == qserver_ready.PLAN_LIST_SETTLE_POLLS
+        == 2 * qserver_ready.PLAN_LIST_SETTLE_POLLS
     )
 
 
@@ -153,21 +161,79 @@ def test_plan_list_landing_after_the_open_is_ready() -> None:
 
 
 def test_no_settle_window_without_our_open() -> None:
-    """An environment someone else opened is judged on the first read."""
+    """An environment someone else opened is judged on the first read.
+
+    An empty list there is the #838 shape, so ONE ``environment_update``
+    follows (with its settle window) before the verdict is final.
+    """
     manager = _Manager([_status(exists=True)], plans=[])
     with pytest.raises(NotReady, match="lists no allowed plans"):
+        ensure_ready(manager, timeout_s=30, log=lambda s: None)
+    methods = [m for m, _ in manager.calls]
+    assert methods.index("environment_update") == methods.index("plans_allowed") + 1
+    assert methods.count("environment_update") == 1
+    assert methods.count("plans_allowed") == qserver_ready.PLAN_LIST_SETTLE_POLLS + 2
+
+
+def test_empty_list_with_the_environment_up_is_healed_by_environment_update() -> None:
+    """#838: the manager idle, environment open, plans_allowed EMPTY.
+
+    A timed-out download of the lists from the worker leaves the manager
+    this way; ``environment_update`` makes it download again, and the
+    list lands within the settle window — ready without a restart.
+    """
+    manager = _Manager(
+        [_status(exists=True)], plans_sequence=[[], [], GEECS_PLAN_NAMES]
+    )
+    log = []
+    allowed = ensure_ready(manager, timeout_s=30, log=log.append)
+    assert allowed == sorted(GEECS_PLAN_NAMES)
+    methods = [m for m, _ in manager.calls]
+    assert methods.count("environment_update") == 1
+    assert "environment_open" not in methods
+    assert ("environment_update", {}) in manager.calls
+    # first read empty → update → settle re-reads until the list lands
+    assert methods.count("plans_allowed") == 3
+    assert any("environment_update" in line and "#838" in line for line in log)
+    assert log[-1].startswith(f"ready: {len(GEECS_PLAN_NAMES)} allowed plans")
+
+
+def test_stale_list_is_redownloaded_then_ready() -> None:
+    """A list missing a plan gets the same one re-download (a stale copy)."""
+    manager = _Manager(
+        [_status(exists=True)], plans_sequence=[["mv"], GEECS_PLAN_NAMES]
+    )
+    allowed = ensure_ready(manager, timeout_s=30, log=lambda s: None)
+    assert allowed == sorted(GEECS_PLAN_NAMES)
+    assert [m for m, _ in manager.calls].count("environment_update") == 1
+
+
+def test_environment_update_refused_is_not_ready() -> None:
+    """The manager refuses the update (not idle): not ready, its reason named."""
+    manager = _Manager(
+        [_status(exists=True)],
+        plans=[],
+        update_reply={"success": False, "msg": "RE Manager must be in idle state"},
+    )
+    with pytest.raises(NotReady, match="refused 'environment_update'.*idle state"):
         ensure_ready(manager, timeout_s=30, log=lambda s: None)
     assert [m for m, _ in manager.calls].count("plans_allowed") == 1
 
 
 def test_unanswered_plan_list_after_open_is_not_retried() -> None:
-    """plans_unknown is never a settling state — unanswered is not ready."""
+    """plans_unknown is never a settling state — unanswered is not ready.
+
+    Nor is it re-downloaded: a manager that does not answer the list
+    request is not one to ask for an ``environment_update``.
+    """
     manager = _Manager(
         [_status(exists=False), _status(exists=True)], plans_answer=False
     )
     with pytest.raises(NotReady, match="could not be read"):
         ensure_ready(manager, timeout_s=30, log=lambda s: None)
-    assert [m for m, _ in manager.calls].count("plans_allowed") == 1
+    methods = [m for m, _ in manager.calls]
+    assert methods.count("plans_allowed") == 1
+    assert "environment_update" not in methods
 
 
 def test_unanswered_plan_list_is_not_ready() -> None:


### PR DESCRIPTION
Closes #838.

## What

`geecs-qserver-ensure-ready` (the `geecs-qserver-ready` oneshot) heals the manager that is **idle, environment open, `plans_allowed` empty**. Observed 2026-09-11 on the worker host: the manager's own download of the lists from the worker timed out while the host thrashed in swap, and from then on every submission was refused "Plan 'X' is not in the list of allowed plans" while `status` reported everything healthy and the readiness unit stayed `active (exited)` from its last successful run.

- `qserver_ready.ensure_ready`: a list still empty or incomplete after the (post-open) settle window is **restored once from the worker's on-disk copy** through `permissions_reload(restore_plans_devices=True)`, and the settle window applies again. The worker writes `existing_plans_and_devices.yaml` from its namespace at every environment open (`--update-existing-plans-devices` default `ENVIRONMENT_OPEN`, `worker.py`), so that file *is* the running environment's list and the manager's `_update_allowed_plans_and_devices(restore_plans_devices=True)` loads it and regenerates the allowed lists unconditionally. Unanswered lists (`plans_unknown`) are never restored — a manager that does not answer is not one to ask. A refused restore (queue locked) is reported as not ready with both the verdict's detail and the manager's reason. The restore call gets a 10 s transport budget (the manager answers it after the disk read and a permissions push to the worker).
- **Correction to #838's own text** (found by the review, verified in the installed 0.0.25 source): `environment_update` is *not* a reliable fix — with an empty script the worker re-downloads only when its regenerated descriptions differ from its stored copy, so on an unchanged namespace it is a no-op (it also needs an idle manager). And `permissions_reload(restore_plans_devices=True)` does *not* load a stale copy: the file the issue saw "not rewritten since 20:09" was the worker's copy from that environment open — exactly the right list. The README says both.
- `qs_client.readiness_verdict`: the shared `plans_empty` sentence (Console banner, MCP preflight) names the timed-out download as a cause and `systemctl restart geecs-qserver-ready` (→ the restore from disk) as the gesture, instead of only "startup profile registered nothing".
- `qserver/README.md` Troubleshooting: the entry (allowed plans empty while idle = a timed-out list download; `qserver permissions reload lists` by hand; why `environment update` is not the fix; a plan set changed without re-opening needs `systemctl restart geecs-qserver`). `CLAUDE.md` and `deploy/DEPLOYMENT.md` prose describe the unit's heal step (the unit template is untouched: deployment files move once at the end of the feature branch).

## Why the shape

The issue proposed three things: (1) the verdict names the state — done; (2) a re-runnable ensure-ready mode that heals it — done as the default path (the unit is already re-run by `systemctl restart geecs-qserver-ready`, no new mode or flag; a periodic timer unit is *not* added: deployment files are touched once at the end of the feature branch, `03` §10.5); (3) the runbook entry — done.

## Judgment calls (cheap to veto)

- The restore also covers `plan_missing` (an incomplete list), not only `plans_empty`: the manager's pre-open list is the on-disk copy loaded at start, so a timed-out post-open download leaves a stale-but-non-empty list; same mechanism, same cost.
- One restore per run, never a loop: a second empty read after a restore is a real fault to surface.

## Tests

`./scripts/check.sh GeecsBluesky`: **374 passed, 3 skipped, 1 deselected** (was 369). New pins in `tests/test_qserver_ready.py`: empty list with the environment up → one `permissions_reload(restore_plans_devices=True)` → ready when the list reads back; incomplete list restored then ready; refused restore → not ready with the verdict's detail and the manager's reason; unanswered list never restored; the restore call's transport budget; the post-open and no-open exhaustion counts. `tests/qs_client/test_readiness.py`: the `plans_empty` sentence names #838 and the gesture.

## Hardware verification

**OWED** (worker host, manager idle, no scan, no PV write): (1) `systemctl restart geecs-qserver-ready` on a healthy manager must log `ready: N allowed plans` with **no** "restoring the lists" line in its journal (the heal path is not taken when the first read is complete). (2) The heal path: `qserver permissions reload lists` by hand on the idle manager must log the manager's "Reloading lists of allowed plans and devices" and leave `qserver plans allowed` complete — the deterministic part; reproducing the timed-out download itself on demand is not practical.
