### PR TITLE
GeecsWebTheme 0.2.0: the surface kit — one layout vocabulary for every web surface

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,7 @@ tooling. Each subdirectory is an independent Python package with its own
 | `GeecsPvaGateway/` | The PVA peer of GeecsCAGateway: distributed pvAccess server on each Windows camera server, exposing that host's GEECS camera images as NTNDArray PVs (gated subscriptions, latest-wins). Images stay off the central CA gateway by design |
 | `GEECS-MCP/` | The general GEECS MCP server for AI agents (OSPREY) — domains as modules, scans first: read tools (status/history/results/config listings/validation) + control verbs (submit with cap/etiquette/acknowledge-loop, ownership-gated stop, clear_queue) over `geecs_bluesky.qs_client` + the resolver + Tiled. Osprey integrates via `profile.yml` — central HTTP (the multi-machine mode) or stdio; see its `deploy/DEPLOYMENT.md` |
 | `GEECS-DataPortal/` | Scan-browsing web service (FastAPI, port 8200 on the worker host), read-only except explicit ScanAnalysis runs from its Analysis tab: day → scan → metadata/scalar plots/images in any browser, over the same `ScanCatalog` layer as the console's scan browser. Arc spec: `Planning/data_portal/` |
-| `GeecsWebTheme/` | One palette vocabulary for every GEECS web surface: three themes (`bella` red/black, `laser` 532 nm green, `plasma` hydrogen Balmer), each light and dark, plus the picker. No runtime dependencies — a stylesheet, a script and `static_dir()`. The rule it exists to enforce: surfaces style **through tokens, never with a literal colour**, pinned by its own test which walks the portal's and the editor's templates too |
+| `GeecsWebTheme/` | The shared look of every GEECS web surface, in two layers. `theme.css` settles **colour**: three themes (`bella` red/black, `laser` 532 nm green, `plasma` hydrogen Balmer), each light and dark, plus the picker. `kit.css` settles **everything else** — page shell, the three containers by role, one status vocabulary (`queued/running/ok/degraded/failed/unknown` + `agent`), controls, tables, the five pane states (incl. `stale` and `denied`), and the **overlay ladder** (`details` → inspector → drawer → `<dialog>` → route; take the lowest rung that fits). `kit.html` is its reference page, static beside the stylesheets so any host mounting it serves it at `<mount>/kit.html`. No runtime dependencies. Two rules it exists to enforce: surfaces style **through tokens, never with a literal colour**, and every kit rule is scoped to `.kit` so a surface adopts page by page — both pinned by its own tests, which walk the portal's and the editor's templates too. **Read its `CLAUDE.md` before building a new web surface** |
 | `GeecsLogbook/` | The logbook (successor to LogMaker4GoogleDocs): two books in one store — the **scans** book, a day-document view over scan folders, and the **ops** book, routine operations read by month — mounted by the Data Portal at `/log`. A day is a **query**, not a document — no daily job, no template stamping. Derived scan facts are rendered per request and stored nowhere; human commentary lives in the portal's state directory and is mirrored as markdown into `{experiment}/logbook/`, a tree of its own outside the data tree |
 | `LogMaker4GoogleDocs/` | Google Docs/Drive API wrapper for automated experiment logs — being replaced by `GeecsLogbook/` |
 
@@ -184,10 +184,14 @@ GEECS-DataPortal     →  GEECS-Data-Utils (tiled extra — the ScanCatalog
                         GeecsWebTheme (the shared palette; the portal is
                         the host that mounts it at /theme for every
                         surface inside this app)
-GeecsWebTheme        →  (no deps at all — a stylesheet, a script and a
-                        path helper. Everything web-facing depends on it;
-                        it depends on nothing, which is why it is its own
-                        package rather than living inside the portal)
+GeecsWebTheme        →  (no deps at all — stylesheets, two small scripts
+                        and a path helper. Everything web-facing depends
+                        on it; it depends on nothing, which is why it is
+                        its own package rather than living inside the
+                        portal. Carries BOTH the colour tokens and the
+                        layout kit, so a new surface inherits the shell,
+                        the status words and the overlay ladder instead
+                        of inventing a fourth set)
 GeecsLogbook         →  GEECS-Data-Utils (ScanPaths only — it reads scan
                         folders and nothing else; a peer VIEW LAYER of
                         GEECS-DataPortal, which mounts it at /log behind

--- a/GeecsWebTheme/CHANGELOG.md
+++ b/GeecsWebTheme/CHANGELOG.md
@@ -39,14 +39,46 @@ project adheres to semantic versioning.
   from `--r`, the control corner), `--bw`, `--tk`, `--pad`, `--row-h`,
   `--gap`, `--shell-max`, `--scrim`, `--lift`. Declared in the bare
   `:root` only, so every palette shares them until one wants its own.
-- `kit_css()`, `kit_js()`, `kit_html()` path helpers.
+- `kit_css()`, `kit_js()`, `kit_html()` path helpers, and `STATES` /
+  `PANE_STATES` constants so a host renders a vocabulary from a constant
+  rather than hand-typing a `data-state` that silently matches no rule.
+- A package `CLAUDE.md`: the kit's doctrine — the overlay ladder, the
+  container roles, the vocabularies — reachable from where an agent
+  building the next web surface actually looks.
 
 ### Changed
 
 - The literal-colour guard walks `kit.css`, `kit.html` and `kit.js`.
 - New tests: the kit introduces no token `theme.css` does not declare (one
   vocabulary, not two); every asset `kit.html` references exists; the
-  density list agrees across Python, the boot script and the CSS.
+  density list agrees across Python, the boot script and the CSS; both
+  vocabularies are pinned to `kit.css` in both directions; every kit rule
+  is scoped to `.kit`.
+- `README.md` and the root `CLAUDE.md` describe both layers, not just the
+  palette.
+
+### Fixed (from adversarial review, before first release)
+
+- **Every kit rule is scoped to `.kit` on `<body>`.** Ungated component
+  classes collided with both adoption targets, one load-bearingly: the
+  portal's run page is `.pane{display:none}` / `.pane.on{display:block}` —
+  its tab mechanism — which ties on specificity with an ungated `.pane`,
+  leaving which wins to stylesheet order. Every tab pane would have
+  rendered at once. Scoping also lets a surface convert one page at a time
+  instead of every page changing when the `<link>` lands.
+- The drawer honours `autofocus`. A selector list carries no priority, so
+  `querySelector("[autofocus],…")` returned the first match in *tree*
+  order — the header's Close button — while the adjacent `<dialog>` rung
+  honoured `autofocus` natively, so identical markup behaved differently
+  on two rungs.
+- A `data-drawer-open` / `data-dialog-open` naming a missing id warns
+  instead of producing a permanently dead control in silence.
+- `Esc` no longer closes the drawer underneath an open `<dialog>`.
+- The density picker builds into a host containing whitespace (ordinary
+  Jinja formatting previously counted as "already built").
+- The density pin asserted only that the selector existed — an *empty*
+  compact block passed it. It now asserts the block overrides exactly the
+  spacing tokens `theme.css` declares.
 
 ## [0.1.2] - 2026-09-12
 

--- a/GeecsWebTheme/CHANGELOG.md
+++ b/GeecsWebTheme/CHANGELOG.md
@@ -94,6 +94,13 @@ project adheres to semantic versioning.
 - `kit.html`'s dialog no longer carries `class="kit-dialog"`, which stopped
   matching anything when the rules were scoped. A dead class on the page
   people copy from is the wrong thing to copy.
+- **`.picklist`**, extracted from `.rail nav` (Codex review of #856). The
+  selectable-list styling was scoped to where it sat, so the inspector on
+  the reference page rendered three native browser buttons — a component
+  shown on the copy-from page that the kit did not actually style. It is
+  now a named component the rail, the inspector and the console's device
+  list all use, and a new guard fails when `kit.html` shows any class
+  nothing styles.
 
 ## [0.1.2] - 2026-09-12
 

--- a/GeecsWebTheme/CHANGELOG.md
+++ b/GeecsWebTheme/CHANGELOG.md
@@ -79,6 +79,21 @@ project adheres to semantic versioning.
 - The density pin asserted only that the selector existed — an *empty*
   compact block passed it. It now asserts the block overrides exactly the
   spacing tokens `theme.css` declares.
+- The scoping guard itself had three holes, found by re-review and each
+  reproduced before fixing. A regex over selectors consumed the `{` of
+  every `@media` prelude, so the **first rule inside each media block was
+  never examined** — four blocks, four unguarded rules, one of them the
+  mobile shell collapse. It also waved through `.kitchen` (a string
+  prefix, not a class token) and `:root .pane` (a fully global descendant
+  selector). The guard now walks braces instead of matching a regex, skips
+  `@keyframes` stops, and allows exactly two unscoped shapes. Each hole is
+  pinned as a probe case.
+- The vocabulary pins only recognised double-quoted attribute selectors,
+  so `[data-state='aborted']` slipped past — inconsistent with
+  `_INLINE_STYLE` in the same file, which already handled both.
+- `kit.html`'s dialog no longer carries `class="kit-dialog"`, which stopped
+  matching anything when the rules were scoped. A dead class on the page
+  people copy from is the wrong thing to copy.
 
 ## [0.1.2] - 2026-09-12
 

--- a/GeecsWebTheme/CHANGELOG.md
+++ b/GeecsWebTheme/CHANGELOG.md
@@ -4,6 +4,50 @@ All notable changes to `geecs-web-theme` are documented here. The format
 follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and this
 project adheres to semantic versioning.
 
+## [0.2.0] - 2026-09-12
+
+### Added
+
+- **`kit.css` — the layout vocabulary.** `theme.css` settled colour and
+  nothing else, so the portal and the logbook each answered the layout
+  questions separately and disagreed on all of them: two rails (17rem
+  fixed vs 228px sticky), fifteen status class names for about five
+  states, three overlay mechanisms, and a run page with no breakpoint at
+  all. The kit settles the shell (topbar / 216px rail / pane, one
+  breakpoint at 900px), three containers by role (`.panel`, `.group`,
+  `.well`), one status chip over six words, controls, tables, the five
+  states a pane owes its reader, and the overlay ladder. No consumer is
+  changed by this release — adoption is a separate step per surface.
+- **The overlay ladder**, as components rather than prose: `details.disc`
+  (rung 0), `.inspector` (1), `.drawer` (2), `<dialog>` (3), and a route
+  (4, which needs no CSS). The rule is to take the lowest rung that fits;
+  the decider is whether the user can lose work by pressing Esc.
+- **`kit.html` — the kit's reference page.** Every component in the real
+  theme, at whichever palette and density is picked. A static file beside
+  the stylesheets, so a host already mounting this package serves it at
+  `<mount>/kit.html` with no route of its own.
+- **`kit.js`** — the drawer (Esc, scrim, focus return), a `<dialog>`
+  helper with a fallback, and the density control, wired declaratively
+  through `data-drawer-open` / `data-dialog-open`. Entirely optional: with
+  it absent the page still renders and `<details>` still opens.
+- **Density as a viewer preference.** `theme-boot.js` stamps
+  `data-density` before first paint alongside the palette, and `kit.css`
+  redefines `--pad` / `--row-h` / `--gap` under `[data-density="compact"]`.
+  `geecs_web_theme.DENSITIES` / `DEFAULT_DENSITY` mirror the boot script
+  the way `THEMES` / `DEFAULT_THEME` already do, pinned by a test.
+- Structural tokens in `theme.css`: `--r-lg` (the panel corner, distinct
+  from `--r`, the control corner), `--bw`, `--tk`, `--pad`, `--row-h`,
+  `--gap`, `--shell-max`, `--scrim`, `--lift`. Declared in the bare
+  `:root` only, so every palette shares them until one wants its own.
+- `kit_css()`, `kit_js()`, `kit_html()` path helpers.
+
+### Changed
+
+- The literal-colour guard walks `kit.css`, `kit.html` and `kit.js`.
+- New tests: the kit introduces no token `theme.css` does not declare (one
+  vocabulary, not two); every asset `kit.html` references exists; the
+  density list agrees across Python, the boot script and the CSS.
+
 ## [0.1.2] - 2026-09-12
 
 ### Changed

--- a/GeecsWebTheme/CLAUDE.md
+++ b/GeecsWebTheme/CLAUDE.md
@@ -74,6 +74,17 @@ four on every block is why dense screens go flat.
 - `.well` — recessed fill, no border: output the reader did not write (a log
   tail, YAML, a repro snippet).
 
+## `.picklist`
+
+A vertical list of selectable things — the rail's navigation, the
+inspector's item list, whatever the console's device list becomes. It is a
+**named component, not a location**: the first cut styled `.rail nav`,
+which left the inspector on the reference page rendering native browser
+buttons and guaranteed a third use would need a third rule. Mark the
+current item with `aria-current="page"` (navigation) or
+`aria-pressed="true"` (selection); the state is the accessibility
+attribute, never a class.
+
 ## Status and pane states
 
 `queued · running · ok · degraded · failed · unknown`, plus `agent` — not a

--- a/GeecsWebTheme/CLAUDE.md
+++ b/GeecsWebTheme/CLAUDE.md
@@ -1,0 +1,111 @@
+# GeecsWebTheme — Developer Context for Claude
+
+The shared look of every GEECS web surface. Two layers: `theme.css` settles
+**colour**, `kit.css` settles **everything else** — shell, containers,
+status, controls, tables, pane states, overlays.
+
+**Read this before building a new web surface.** The whole point of the
+package is that the next surface inherits these answers instead of inventing
+a fourth set; a surface that hand-rolls its own rail, chip or modal has
+already lost the thing this package exists to protect.
+
+## Why the kit exists (do not re-litigate)
+
+Before it, the Data Portal and the GeecsLogbook each answered the layout
+questions separately, and disagreed on all of them: two rails (`17rem`
+fixed vs `228px` sticky), **zero** lines of shared layout, **fifteen**
+status class names for about five states, three overlay mechanisms — none a
+real `<dialog>`, so the portal's modal had no focus trap and ignored `Esc`.
+The forcing function was the third surface: the console, once web-based, is
+the one with the hardest requirements (live values, write actions, hazards,
+keyboard), so it sets the vocabulary rather than inheriting a compromise.
+
+## The rules
+
+- **Surfaces style through tokens, never with a literal colour.** Enforced
+  by `tests/test_no_literal_colours.py`, which walks *every* surface in the
+  repo — not just this package. Adding a web surface means adding it to
+  `_SURFACES` there.
+- **`theme.css` is the single token authority.** `kit.css` consumes tokens
+  and overrides them (the density blocks, `--shell-max`); it never
+  introduces one. Pinned by `test_kit_defines_no_token_the_theme_does_not`.
+- **Every kit rule is scoped to `.kit` on `<body>`.** Both adoption targets
+  already use several of these class names, one load-bearingly — the
+  portal's run page is `.pane{display:none}` / `.pane.on{display:block}`,
+  its tab mechanism, which ties on specificity with an ungated `.pane`.
+  Scoping also lets a surface convert one template at a time. Pinned by
+  `test_kit_rules_are_scoped_to_the_kit_class`.
+- **Vocabularies are constants, not strings you type.** `THEMES`,
+  `DENSITIES`, `STATES`, `PANE_STATES` are exported from `__init__.py` and
+  pinned to the CSS. A hand-typed `data-state="no_data"` matches no rule and
+  still renders a plausible neutral chip — it survives review *and* the
+  browser, which is why the pin runs both directions.
+- **`kit.js` is optional.** Every rule works with scripts off; the script
+  adds only the drawer, the dialog helper and the density control. Do not
+  make a component depend on it.
+- **`theme-boot.js` is the one definition** of which themes and densities
+  exist and what the defaults are. It loads in `<head>`, NOT deferred, so
+  the palette and density are stamped before first paint. `theme.js` reads
+  `window.GEECS_THEME` rather than carrying a copy, and the Python
+  constants are pinned to it by test.
+
+## The overlay ladder
+
+The rule for what happens when someone clicks a thing. **Take the lowest
+rung that fits.** The decider: *can the user lose work by pressing Esc?* If
+yes it is a route, whatever it looks like.
+
+| Rung | Component | Use it when |
+|---|---|---|
+| 0 | `details.disc` | The detail belongs to one row and the reader is still scanning. Native `<details>` — keyboard, no-JS and find-in-page all work. Tracking open state in JS means you are on the wrong rung. |
+| 1 | `.inspector` | The user steps through many items and compares them. The selection belongs in the URL; if the link cannot carry it, it is not finished. |
+| 2 | `.drawer` | A focused sub-task on the object already on screen. Never opens another drawer, never holds a destructive confirm, must survive `Esc` without losing typing. |
+| 3 | `<dialog>` | A question that must be answered before anything else proceeds. Real `showModal()` — that is where the focus trap, `Esc` and the inert background come from. One question, at most two buttons, no scrolling, no form. Focus never lands on the destructive button. |
+| 4 | a route | Long enough that someone will link to it, reload it, or return tomorrow. Needs no CSS, which is the point. |
+
+## Containers, by role
+
+Border, fill, radius and shadow each say *separate object*; spending all
+four on every block is why dense screens go flat.
+
+- `.panel` — a thing with an identity and its own state (a device, a scan, a
+  queue): border, header, shadow.
+- `.group` — controls belonging to the panel around them. **No edges.**
+- `.well` — recessed fill, no border: output the reader did not write (a log
+  tail, YAML, a repro snippet).
+
+## Status and pane states
+
+`queued · running · ok · degraded · failed · unknown`, plus `agent` — not a
+severity but *who wrote this*, because the logbook already separates what an
+analyzer wrote from what a person wrote and the console will want the same
+for agent-submitted actions. Colour is never the only carrier: every chip is
+a dot **and** a word.
+
+Every pane owes five states: `loading · empty · error · stale · denied`.
+`stale` is the one that matters for hardware — a live number that silently
+stops updating is worse than no number, so any live value carries its own
+age and the surface says so past a threshold rather than continuing to look
+confident.
+
+## The reference page
+
+`kit.html` is a static file beside the stylesheets, so any host mounting
+`static_dir()` already serves it (`/theme/kit.html` on the portal). Every
+component in the real theme, at whichever palette and density. **Look there
+before adding a component**, and change it in the same commit when you add
+one — `test_kit_reference_page_assets_all_exist` pins its assets, and it is
+the page people will copy from.
+
+## Sharp edges
+
+- The literal-colour guard blanks `/* */` comments but not `//` line
+  comments in a standalone `.js` file, so a `#765`-style reference in a JS
+  comment reads as a three-digit hex and fails the guard. Write it without
+  the `#`. (Naive `//` handling would blank the `//` in every URL, which is
+  why the guard does not try.)
+- `_blocks()` in that test file reads raw CSS text, so a `:root` mentioned
+  in a header comment runs together with the real selector. Strip comments
+  before keying its result by selector name.
+- Adding a spacing token means adding it to `_DENSITY_TOKENS` in the test
+  too, or the density blocks that forgot it will not fail.

--- a/GeecsWebTheme/README.md
+++ b/GeecsWebTheme/README.md
@@ -1,9 +1,13 @@
 # GeecsWebTheme
 
-One palette vocabulary shared by every GEECS web surface — the Data Portal,
-the analysis config editor, and the scan logbook.
+The shared look of every GEECS web surface — the Data Portal, the scan
+logbook, the analysis config editor, and the console once it is web-based.
 
-Three themes, each with a light and a dark variant:
+Two layers, because they answer two different questions.
+
+## `theme.css` — colour
+
+One token vocabulary, three themes, each light and dark:
 
 | Theme | Where it comes from |
 |---|---|
@@ -11,7 +15,78 @@ Three themes, each with a light and a dark variant:
 | `laser` | 532 nm pump green, with the breadboards' red for criticals |
 | `plasma` | Hydrogen Balmer — H-β cyan accent, H-α for the agent voice |
 
-A surface links `theme.css`, adds `theme.js`, and styles **through the
-tokens** — never with a literal colour. That one discipline is what makes a
-new theme a block of overrides instead of a hunt, and it is enforced by
-`tests/test_no_literal_colours.py`.
+A surface styles **through the tokens** — never with a literal colour. That
+one discipline is what makes a new theme a block of overrides instead of a
+hunt, and `tests/test_no_literal_colours.py` enforces it across every
+surface, not just this package.
+
+## `kit.css` — everything else
+
+The layout vocabulary: the page shell, three containers by role, one status
+chip, controls, tables, the states a pane owes its reader, and the overlay
+ladder. It exists because the portal and the logbook each answered those
+questions separately and disagreed on all of them — two rails, fifteen
+status class names for about five states, three overlay mechanisms none of
+which is a real `<dialog>`.
+
+- **Shell** — topbar / 216 px rail / pane, one breakpoint at 900 px.
+- **Containers** — `.panel` (a thing with its own state), `.group` (no
+  edges; controls belonging to the panel around them), `.well` (recessed;
+  output the reader did not write).
+- **Status** — `queued · running · ok · degraded · failed · unknown`, plus
+  `agent` for *who wrote this*. Named on `data-state`; every chip is a dot
+  **and** a word, so colour is never the only carrier.
+- **Pane states** — `loading · empty · error · stale · denied`.
+- **The overlay ladder** — `details.disc` → `.inspector` → `.drawer` →
+  `<dialog>` → a route. Take the lowest rung that fits; the decider is
+  whether the user can lose work by pressing Esc.
+- **Density** — a viewer preference stamped before first paint, driving
+  `--pad` / `--row-h` / `--gap`.
+
+Every kit rule is scoped to `.kit` on `<body>`, so a surface converts one
+page at a time and the kit's class names cannot collide with a surface's
+own. `kit.js` is optional: without it the page still renders and
+`<details>` still opens; only the drawer, the dialog helper and the density
+control go missing.
+
+## Using it
+
+```python
+from geecs_web_theme import static_dir
+app.mount("/theme", StaticFiles(directory=str(static_dir())), name="theme")
+```
+
+```html
+<!-- in <head>: the boot script NOT deferred, so the palette and density
+     are stamped before first paint -->
+<script src="/theme/theme-boot.js"></script>
+<link rel="stylesheet" href="/theme/theme.css">
+<link rel="stylesheet" href="/theme/kit.css">
+<script src="/theme/theme.js" defer></script>
+<script src="/theme/kit.js" defer></script>
+
+<body class="kit">
+  <div data-theme-picker></div>
+  <div data-density-picker></div>
+```
+
+Behind a reverse proxy, build those URLs from the request's `root_path` —
+the portal does this with its `{{ root }}` idiom.
+
+`THEMES`, `DENSITIES`, `STATES` and `PANE_STATES` are exported from the
+package so a host renders a vocabulary from a constant rather than
+hand-typing a `data-state` that silently matches no rule.
+
+## The reference page
+
+`kit.html` is a static file beside the stylesheets, so any host mounting
+this package already serves it — the portal has it at `/theme/kit.html`.
+It shows every component in the real theme at whichever palette and density
+you pick. It is the place to look before adding a component, and the place
+to argue with one.
+
+## No dependencies
+
+Deliberately: this package is stylesheets, two small scripts and a path
+helper. Anything that can serve a static directory can use it, and nothing
+it serves needs a Python import to work.

--- a/GeecsWebTheme/README.md
+++ b/GeecsWebTheme/README.md
@@ -33,6 +33,11 @@ which is a real `<dialog>`.
 - **Containers** — `.panel` (a thing with its own state), `.group` (no
   edges; controls belonging to the panel around them), `.well` (recessed;
   output the reader did not write).
+- **`.picklist`** — a vertical list of selectable things: the rail's
+  navigation, the inspector's item list, the console's device list. The
+  current item is marked with `aria-current="page"` or
+  `aria-pressed="true"` — the state is the accessibility attribute, never
+  a class, so it cannot be styled-but-unannounced.
 - **Status** — `queued · running · ok · degraded · failed · unknown`, plus
   `agent` for *who wrote this*. Named on `data-state`; every chip is a dot
   **and** a word, so colour is never the only carrier.

--- a/GeecsWebTheme/geecs_web_theme/__init__.py
+++ b/GeecsWebTheme/geecs_web_theme/__init__.py
@@ -1,6 +1,20 @@
-"""The shared GEECS web palette: where the files are, and what they offer.
+"""The shared GEECS web palette and layout kit: the files, and what they offer.
 
-This package ships a stylesheet and a small script and nothing else. It has
+Two layers ship here. ``theme.css`` settles **colour** — the token
+vocabulary and the palettes. ``kit.css`` settles **everything else** — the
+page shell, the three containers, the status chip, controls, tables, the
+five pane states and the overlay ladder. They are separate files because
+they answer separate questions and a surface may adopt the first without
+the second, but the kit is the layer that stops a third web surface from
+inventing a third set of answers.
+
+``kit.html`` is the kit's own reference page: every component rendered in
+the real theme, at whichever palette and density the viewer picks. It is a
+static file beside the stylesheets, so a host that mounts this package
+already serves it — the portal reaches it at ``/theme/kit.html`` with no
+route of its own.
+
+This package ships stylesheets and small scripts and nothing else. It has
 no runtime dependencies on purpose — anything that can serve a static
 directory can use it, and nothing it serves needs a Python import to work.
 
@@ -14,14 +28,18 @@ palette is stamped before first paint; the picker script deferred::
 
     <script src="/theme/theme-boot.js"></script>
     <link rel="stylesheet" href="/theme/theme.css">
+    <link rel="stylesheet" href="/theme/kit.css">
     <script src="/theme/theme.js" defer></script>
+    <script src="/theme/kit.js" defer></script>
 
 Behind a reverse proxy build those from the request's ``root_path``; the
 portal does this with its ``{{ root }}`` idiom.
 
-and wherever the control belongs::
+Give ``<body>`` the ``kit`` class so the kit's base rules apply, and put
+the two controls wherever they belong::
 
     <div data-theme-picker></div>
+    <div data-density-picker></div>
 """
 
 from pathlib import Path
@@ -29,10 +47,15 @@ from pathlib import Path
 __all__ = [
     "THEMES",
     "DEFAULT_THEME",
+    "DENSITIES",
+    "DEFAULT_DENSITY",
     "static_dir",
     "theme_css",
     "theme_js",
     "theme_boot_js",
+    "kit_css",
+    "kit_js",
+    "kit_html",
 ]
 
 #: The palettes on offer. Kept here as well as in the stylesheet so a host
@@ -46,6 +69,17 @@ THEMES: dict[str, str] = {
 #: What a viewer gets before they choose. The runtime authority is
 #: ``theme-boot.js``; ``tests/test_no_literal_colours.py`` pins the two.
 DEFAULT_THEME = "laser"
+
+#: The spacing scales ``kit.css`` implements. Same arrangement as THEMES:
+#: named here so a host can offer them, defined for real in
+#: ``theme-boot.js``, and the two pinned together by a test.
+DENSITIES: dict[str, str] = {
+    "comfortable": "Roomier rows — reading and writing",
+    "compact": "Tighter rows — tables and live panels",
+}
+
+#: What a viewer gets before they choose a density.
+DEFAULT_DENSITY = "comfortable"
 
 
 def static_dir() -> Path:
@@ -72,3 +106,31 @@ def theme_js() -> Path:
 def theme_boot_js() -> Path:
     """Return the path to the boot script (load in ``<head>``, not deferred)."""
     return static_dir() / "theme-boot.js"
+
+
+def kit_css() -> Path:
+    """Return the path to the layout kit stylesheet.
+
+    Load it *after* ``theme.css``: the kit styles through that file's
+    tokens and defines none of its own.
+    """
+    return static_dir() / "kit.css"
+
+
+def kit_js() -> Path:
+    """Return the path to the kit script (load deferred).
+
+    Optional. Without it the page still renders and ``<details>`` still
+    opens; only the drawer, the dialog helper and the density control go
+    missing.
+    """
+    return static_dir() / "kit.js"
+
+
+def kit_html() -> Path:
+    """Return the path to the kit's reference page.
+
+    A static file in the same directory, so any host already mounting
+    :func:`static_dir` serves it at ``<mount>/kit.html`` without a route.
+    """
+    return static_dir() / "kit.html"

--- a/GeecsWebTheme/geecs_web_theme/__init__.py
+++ b/GeecsWebTheme/geecs_web_theme/__init__.py
@@ -49,6 +49,8 @@ __all__ = [
     "DEFAULT_THEME",
     "DENSITIES",
     "DEFAULT_DENSITY",
+    "STATES",
+    "PANE_STATES",
     "static_dir",
     "theme_css",
     "theme_js",
@@ -80,6 +82,39 @@ DENSITIES: dict[str, str] = {
 
 #: What a viewer gets before they choose a density.
 DEFAULT_DENSITY = "comfortable"
+
+#: The status vocabulary, in the order a thing moves through it. These
+#: replace the fifteen class names the portal and the logbook each invented
+#: (``done``/``success``/``ok``, ``fail``/``failed``/``aborted``, …), and a
+#: surface names one through ``data-state`` on ``.chip`` or ``.dot``.
+#:
+#: Named here, and not only in the CSS, for the reason a mistyped state is
+#: dangerous: ``data-state="no_data"`` matches no rule and still renders a
+#: plausible neutral pill, so it survives review and the browser alike. A
+#: host that renders these from a constant cannot mistype one, and
+#: ``tests/test_no_literal_colours.py`` pins the list to ``kit.css``.
+STATES: dict[str, str] = {
+    "queued": "Accepted, not started",
+    "running": "In progress now",
+    "ok": "Finished as intended",
+    "degraded": "Finished, but less than asked",
+    "failed": "Did not finish",
+    "unknown": "We have no information",
+    "agent": "Written by software, not a person",
+}
+
+#: The states every pane owes its reader, named on ``.state`` and
+#: ``.banner``. ``loading`` and ``empty`` exist on both surfaces today in
+#: private forms; ``error``, ``stale`` and ``denied`` exist on neither, and
+#: a control surface cannot open without the last two — a live value that
+#: silently stops updating is worse than no value.
+PANE_STATES: dict[str, str] = {
+    "loading": "Named, so the reader knows whether to wait",
+    "empty": "The query succeeded and matched nothing",
+    "error": "The request failed; nothing was lost",
+    "stale": "Showing a value older than it should be",
+    "denied": "Someone else holds it, or you may only read",
+}
 
 
 def static_dir() -> Path:

--- a/GeecsWebTheme/geecs_web_theme/static/kit.css
+++ b/GeecsWebTheme/geecs_web_theme/static/kit.css
@@ -127,17 +127,6 @@ body.kit{
   letter-spacing:var(--tk);text-transform:uppercase;color:var(--muted);
   margin-bottom:8px;
 }
-.kit .rail nav{display:flex;flex-direction:column;gap:1px}
-.kit .rail nav a, .kit .rail nav button{
-  display:flex;justify-content:space-between;align-items:baseline;gap:8px;
-  font:inherit;font-size:13px;text-align:left;width:100%;
-  padding:5px 8px;border:0;border-radius:var(--r);
-  background:transparent;color:var(--slate);cursor:pointer;text-decoration:none;
-}
-.kit .rail nav a:hover, .kit .rail nav button:hover{background:var(--surface-2);color:var(--ink);text-decoration:none}
-.kit .rail nav [aria-current="page"], .kit .rail nav [aria-pressed="true"]{
-  background:var(--accent);color:var(--on-accent);font-weight:600;
-}
 
 .kit .pane{min-width:0;display:flex;flex-direction:column;gap:var(--gap)}
 
@@ -146,8 +135,8 @@ body.kit{
 @media (max-width:900px){
   .kit .shell{grid-template-columns:minmax(0,1fr);gap:18px}
   .kit .rail{position:static;max-height:none;flex-direction:row;flex-wrap:wrap;gap:12px}
-  .kit .rail nav{flex-direction:row;flex-wrap:wrap;gap:4px}
-  .kit .rail nav a, .kit .rail nav button{width:auto}
+  .kit .rail .picklist{flex-direction:row;flex-wrap:wrap;gap:4px}
+  .kit .rail .picklist a, .kit .rail .picklist button{width:auto}
 }
 
 /* ---------------------------------------------------------------------
@@ -280,6 +269,30 @@ body.kit{
 }
 .kit .field .hint{font-size:11.5px;color:var(--muted)}
 
+/* A vertical list of selectable things: the rail's navigation, the
+ * inspector's item list, and whatever the console's device list turns out
+ * to be. Styled as a NAMED component rather than by where it sits — the
+ * first version of this file styled `.rail nav`, which left the inspector
+ * on the reference page rendering three native browser buttons and
+ * guaranteed that a third use would need a third rule.
+ *
+ * Mark the current item with aria-current="page" (navigation) or
+ * aria-pressed="true" (selection) — the state is the accessibility
+ * attribute, never a class, so it cannot be styled-but-unannounced. */
+.kit .picklist{display:flex;flex-direction:column;gap:1px;min-width:0}
+.kit .picklist a, .kit .picklist button{
+  display:flex;justify-content:space-between;align-items:baseline;gap:8px;
+  font:inherit;font-size:13px;text-align:left;width:100%;
+  padding:5px 8px;border:0;border-radius:var(--r);
+  background:transparent;color:var(--slate);cursor:pointer;text-decoration:none;
+}
+.kit .picklist a:hover, .kit .picklist button:hover{
+  background:var(--surface-2);color:var(--ink);text-decoration:none;
+}
+.kit .picklist [aria-current="page"], .kit .picklist [aria-pressed="true"]{
+  background:var(--accent);color:var(--on-accent);font-weight:600;
+}
+
 /* A segmented choice: mode, density, per-shot vs binned. */
 .kit .seg{
   display:inline-flex;gap:2px;padding:2px;
@@ -395,6 +408,7 @@ body.kit{
   border:var(--bw) solid var(--rule);border-radius:var(--r);overflow:hidden;
 }
 .kit .inspector > .list{background:var(--surface);display:flex;flex-direction:column;min-width:0}
+/* The list itself is a .picklist — see Controls. */
 .kit .inspector > .detail{background:var(--surface-2);padding:var(--pad);min-width:0}
 @media (max-width:640px){.kit .inspector{grid-template-columns:minmax(0,1fr)}}
 

--- a/GeecsWebTheme/geecs_web_theme/static/kit.css
+++ b/GeecsWebTheme/geecs_web_theme/static/kit.css
@@ -1,0 +1,447 @@
+/* GEECS surface kit — the layout vocabulary every web surface shares.
+ *
+ * theme.css settles COLOUR. This file settles everything else: the page
+ * skeleton, the three containers, the status chip, controls, tables, the
+ * five states a pane owes its reader, and the overlay ladder. It exists
+ * because the portal and the logbook each answered those questions
+ * separately and disagreed on all of them — two rails (17rem fixed vs
+ * 228px sticky), fifteen status class names for about five states, three
+ * overlay mechanisms, and one page with no breakpoint at all. A third
+ * surface (the console, once it is web-based) would have been a third
+ * set of answers.
+ *
+ * Rules this file lives by
+ * ------------------------
+ * - **It defines no colour token.** theme.css is the single token
+ *   authority; kit.css only consumes. tests/test_no_literal_colours.py
+ *   pins that both ways — a literal here fails, and a var() naming a
+ *   token theme.css does not define fails too.
+ * - **It ships no JavaScript dependency.** Every rule here works with
+ *   scripts off. kit.js adds the drawer, the dialog and the density
+ *   control; without it the page still renders and <details> still opens.
+ * - **Class names are the contract.** A surface adopting the kit deletes
+ *   its own rules and uses these names; it does not re-skin them. Where a
+ *   surface needs something genuinely its own, it adds a class of its own
+ *   rather than overriding one of these.
+ *
+ * The overlay ladder (see kit.html for working specimens): take the
+ * LOWEST rung that fits.
+ *   0  details.disc   inline disclosure — the default
+ *   1  .inspector     a persistent region that fills with the selection
+ *   2  .drawer        a focused sub-task on the current object
+ *   3  <dialog>       a question that blocks everything else
+ *   4  a route        anything the user could lose work by dismissing
+ */
+
+/* ---------------------------------------------------------------------
+   Density. theme.css defines the comfortable values; theme-boot.js stamps
+   data-density before first paint. Nothing else in the system encodes a
+   padding — a surface that hardcodes one stops responding to this.
+   --------------------------------------------------------------------- */
+:root[data-density="compact"]{
+  --pad:9px;
+  --row-h:26px;
+  --gap:10px;
+}
+
+/* ---------------------------------------------------------------------
+   Base
+   --------------------------------------------------------------------- */
+.kit *,
+.kit *::before,
+.kit *::after{box-sizing:border-box}
+
+body.kit{
+  margin:0;
+  background:var(--paper);
+  color:var(--ink);
+  font-family:var(--ff-ui);
+  font-size:14px;
+  line-height:1.55;
+  -webkit-font-smoothing:antialiased;
+}
+.kit a{color:var(--accent);text-decoration:none}
+.kit a:hover{text-decoration:underline}
+.kit h1,.kit h2,.kit h3,.kit h4{margin:0;text-wrap:balance}
+.kit code,.kit kbd{font-family:var(--ff-mono);font-size:.92em}
+.kit kbd{
+  border:var(--bw) solid var(--rule);border-radius:var(--r);
+  padding:1px 5px;background:var(--surface-2);color:var(--ink);
+}
+.kit :focus-visible{outline:2px solid var(--accent);outline-offset:2px}
+
+/* The uppercase micro-label that names a region. Used everywhere; the one
+   place --tk earns its keep. */
+.eyebrow{
+  font-family:var(--ff-mono);font-size:10.5px;font-weight:500;
+  letter-spacing:var(--tk);text-transform:uppercase;color:var(--muted);
+}
+.mono{font-family:var(--ff-mono);font-variant-numeric:tabular-nums}
+.dim{color:var(--muted)}
+
+/* ---------------------------------------------------------------------
+   Shell — topbar, rail, pane. One skeleton, every surface.
+   --------------------------------------------------------------------- */
+.topbar{
+  position:sticky;top:0;z-index:30;
+  background:var(--surface);
+  border-bottom:var(--bw) solid var(--rule);
+}
+.topbar-in{
+  display:flex;flex-wrap:wrap;align-items:center;gap:10px 16px;
+  max-width:var(--shell-max);margin:0 auto;
+  padding-block:10px;padding-inline:20px;
+}
+.brand{
+  display:flex;align-items:baseline;gap:9px;margin-right:auto;
+  font-size:15px;font-weight:600;letter-spacing:-.01em;color:var(--ink);
+}
+.brand .sub{
+  font-family:var(--ff-mono);font-size:11px;font-weight:400;
+  letter-spacing:var(--tk);text-transform:uppercase;color:var(--muted);
+}
+
+.shell{
+  display:grid;grid-template-columns:216px minmax(0,1fr);gap:28px;
+  max-width:var(--shell-max);margin:0 auto;
+  padding-block:24px 64px;padding-inline:20px;
+}
+.shell.wide{--shell-max:none}
+.shell.solo{grid-template-columns:minmax(0,1fr)}
+
+.rail{
+  position:sticky;top:62px;align-self:start;
+  max-height:calc(100vh - 86px);overflow:auto;
+  display:flex;flex-direction:column;gap:22px;
+}
+.rail h4{
+  font-family:var(--ff-mono);font-size:10.5px;font-weight:600;
+  letter-spacing:var(--tk);text-transform:uppercase;color:var(--muted);
+  margin-bottom:8px;
+}
+.rail nav{display:flex;flex-direction:column;gap:1px}
+.rail nav a,.rail nav button{
+  display:flex;justify-content:space-between;align-items:baseline;gap:8px;
+  font:inherit;font-size:13px;text-align:left;width:100%;
+  padding:5px 8px;border:0;border-radius:var(--r);
+  background:transparent;color:var(--slate);cursor:pointer;text-decoration:none;
+}
+.rail nav a:hover,.rail nav button:hover{background:var(--surface-2);color:var(--ink);text-decoration:none}
+.rail nav [aria-current="page"],.rail nav [aria-pressed="true"]{
+  background:var(--accent);color:var(--on-accent);font-weight:600;
+}
+
+.pane{min-width:0;display:flex;flex-direction:column;gap:var(--gap)}
+
+/* The one breakpoint. Below it the rail stops being a column and becomes a
+   strip above the pane; nothing else moves. */
+@media (max-width:900px){
+  .shell{grid-template-columns:minmax(0,1fr);gap:18px}
+  .rail{position:static;max-height:none;flex-direction:row;flex-wrap:wrap;gap:12px}
+  .rail nav{flex-direction:row;flex-wrap:wrap;gap:4px}
+  .rail nav a,.rail nav button{width:auto}
+}
+
+/* ---------------------------------------------------------------------
+   Containers — three, by role. Border, fill, radius and shadow each say
+   "separate object"; spending all four on every block flattens a dense
+   screen, which is why .group has none of them.
+   --------------------------------------------------------------------- */
+
+/* A thing with an identity and its own state: a device, a scan, a queue. */
+.panel{
+  background:var(--surface);
+  border:var(--bw) solid var(--rule);
+  border-radius:var(--r-lg);
+  box-shadow:var(--shadow);
+  min-width:0;
+}
+.panel > header{
+  display:flex;align-items:center;gap:10px;flex-wrap:wrap;
+  padding:10px var(--pad);
+  border-bottom:var(--bw) solid var(--rule);
+}
+.panel > header .eyebrow{margin-right:auto}
+.panel > .body{
+  padding:var(--pad);
+  display:flex;flex-direction:column;gap:var(--gap);
+}
+.panel > footer{
+  padding:9px var(--pad);
+  border-top:var(--bw) solid var(--rule-soft);
+  background:var(--surface-2);
+}
+
+/* Related controls that belong to the panel around them. No edges — a
+   border here competes with the real one. */
+.group{display:flex;flex-direction:column;gap:8px;min-width:0}
+.row{display:flex;flex-wrap:wrap;gap:8px;align-items:center;min-width:0}
+.row.end{justify-content:flex-end}
+.spacer{flex:1 1 auto}
+
+/* Output the reader did not write: a log tail, YAML, a repro snippet. */
+.well{
+  background:var(--surface-2);
+  border-radius:var(--r);
+  padding:var(--pad);
+  font-family:var(--ff-mono);font-size:12px;color:var(--slate);
+  overflow-x:auto;
+}
+.well pre{margin:0}
+
+.grid{display:grid;gap:var(--gap);grid-template-columns:repeat(auto-fit,minmax(280px,1fr))}
+
+/* ---------------------------------------------------------------------
+   Status — six words, one component. Colour is never the only carrier:
+   every chip is a dot plus a word, so it survives a colour-vision
+   difference, a greyscale print and a forced-colours mode.
+
+   queued | running | ok | degraded | failed | unknown  (+ agent)
+   --------------------------------------------------------------------- */
+.chip{
+  display:inline-flex;align-items:center;gap:6px;
+  font-family:var(--ff-ui);font-size:11.5px;font-weight:500;
+  padding:2px 9px;border-radius:99px;white-space:nowrap;
+  border:var(--bw) solid transparent;
+}
+.chip::before{
+  content:"";width:6px;height:6px;border-radius:50%;
+  background:currentColor;flex:none;
+}
+.chip[data-state="queued"],
+.chip[data-state="unknown"]{color:var(--muted);background:var(--surface-2);border-color:var(--rule)}
+.chip[data-state="running"]{color:var(--accent);background:var(--accent-soft);border-color:var(--accent-soft)}
+.chip[data-state="ok"]{color:var(--ok);background:var(--ok-soft);border-color:var(--ok-soft)}
+.chip[data-state="degraded"]{color:var(--warn);background:var(--warn-soft);border-color:var(--warn-soft)}
+.chip[data-state="failed"]{color:var(--crit);background:var(--crit-soft);border-color:var(--crit-soft)}
+/* Not a severity: who wrote this. The logbook already separates what an
+   analyzer wrote from what a person wrote, and the console will want the
+   same for actions an agent submitted — that distinction carries trust,
+   so it belongs in the vocabulary rather than in each surface's styling. */
+.chip[data-state="agent"]{color:var(--agent);background:var(--agent-soft);border-color:var(--agent-rule)}
+
+.chip[data-state="running"]::before{animation:kit-pulse 1.6s ease-in-out infinite}
+@keyframes kit-pulse{0%,100%{opacity:1}50%{opacity:.25}}
+
+/* A bare dot for a dense list where the word is the row label beside it.
+   Still never alone: give it aria-label or a title. */
+.dot{width:8px;height:8px;border-radius:50%;flex:none;display:inline-block}
+.dot[data-state="queued"],.dot[data-state="unknown"]{background:var(--muted)}
+.dot[data-state="running"]{background:var(--accent)}
+.dot[data-state="ok"]{background:var(--ok)}
+.dot[data-state="degraded"]{background:var(--warn)}
+.dot[data-state="failed"]{background:var(--crit)}
+.dot[data-state="agent"]{background:var(--agent)}
+
+/* ---------------------------------------------------------------------
+   Controls
+   --------------------------------------------------------------------- */
+.btn{
+  display:inline-flex;align-items:center;gap:7px;
+  font:inherit;font-size:13px;font-weight:500;
+  height:var(--row-h);padding:0 13px;
+  border:var(--bw) solid var(--rule);border-radius:var(--r);
+  background:var(--surface);color:var(--ink);
+  cursor:pointer;white-space:nowrap;
+}
+.btn:hover{background:var(--surface-2)}
+.btn[disabled],.btn[aria-disabled="true"]{opacity:.5;cursor:not-allowed}
+.btn.primary{background:var(--accent);color:var(--on-accent);border-color:var(--accent)}
+.btn.primary:hover{filter:brightness(1.07)}
+/* Destructive. Never adjacent to an ordinary action — put a .spacer
+   between them — and always confirmed through rung 3. */
+.btn.danger{color:var(--crit);background:var(--crit-soft);border-color:var(--crit-soft)}
+.btn.danger:hover{filter:brightness(.97)}
+.btn.sm{height:26px;font-size:12px;padding:0 10px}
+.btn.ghost{background:transparent;border-color:transparent;color:var(--muted)}
+.btn.ghost:hover{background:var(--surface-2);color:var(--ink)}
+
+.field{display:flex;flex-direction:column;gap:4px;min-width:150px}
+.field label{
+  font-family:var(--ff-mono);font-size:10.5px;letter-spacing:var(--tk);
+  text-transform:uppercase;color:var(--muted);
+}
+.field input,.field select,.field textarea{
+  font:inherit;font-size:13px;
+  padding:0 10px;height:var(--row-h);
+  border:var(--bw) solid var(--rule);border-radius:var(--r);
+  background:var(--surface);color:var(--ink);
+}
+.field textarea{height:auto;padding:8px 10px;font-family:var(--ff-mono);font-size:12.5px;resize:vertical}
+.field input:focus,.field select:focus,.field textarea:focus{
+  border-color:var(--accent);outline:2px solid var(--accent);outline-offset:-1px;
+}
+.field .hint{font-size:11.5px;color:var(--muted)}
+
+/* A segmented choice: mode, density, per-shot vs binned. */
+.seg{
+  display:inline-flex;gap:2px;padding:2px;
+  border:var(--bw) solid var(--rule);border-radius:var(--r);
+  background:var(--surface);
+}
+.seg button{
+  font:inherit;font-size:11.5px;
+  border:0;border-radius:calc(var(--r) - 1px);
+  padding:4px 10px;background:transparent;color:var(--muted);
+  cursor:pointer;white-space:nowrap;
+}
+.seg button:hover{color:var(--ink);background:var(--surface-2)}
+.seg button[aria-pressed="true"]{color:var(--ink);background:var(--surface-2);font-weight:600}
+
+/* ---------------------------------------------------------------------
+   Tables. Wide ones go inside .tscroll so the page body never scrolls
+   sideways.
+   --------------------------------------------------------------------- */
+.tscroll{overflow-x:auto;max-width:100%}
+.kit table{width:100%;border-collapse:collapse;font-size:13px}
+.kit th{
+  text-align:left;vertical-align:bottom;
+  font-family:var(--ff-mono);font-size:10.5px;font-weight:500;
+  letter-spacing:var(--tk);text-transform:uppercase;color:var(--muted);
+  padding:7px var(--pad);white-space:nowrap;
+  border-bottom:var(--bw) solid var(--rule);
+}
+.kit td{
+  padding:7px var(--pad);vertical-align:top;
+  border-bottom:var(--bw) solid var(--rule-soft);
+}
+.kit tbody tr:last-child td{border-bottom:0}
+.kit tbody tr:hover td{background:var(--surface-2)}
+.kit td.num{font-family:var(--ff-mono);font-variant-numeric:tabular-nums;text-align:right}
+.kit td.id{font-family:var(--ff-mono);font-weight:500;color:var(--ink)}
+.kit tr[aria-selected="true"] td{background:var(--accent-soft)}
+.kit tr[aria-selected="true"] td.id{color:var(--accent);font-weight:600}
+
+/* ---------------------------------------------------------------------
+   The five states every pane owes its reader.
+
+   loading / empty / error / stale / denied. The first two exist on both
+   surfaces today in some private form; the last three exist nowhere,
+   and a control surface cannot open without stale and denied.
+   --------------------------------------------------------------------- */
+.state{
+  display:flex;flex-direction:column;align-items:center;justify-content:center;
+  gap:8px;text-align:center;
+  min-height:120px;padding:var(--pad);
+  border:var(--bw) solid var(--rule);border-radius:var(--r);
+  background:var(--surface);
+}
+.state .t{font-size:13px;font-weight:600;color:var(--ink)}
+.state .m{font-size:12.5px;color:var(--muted);max-width:38ch}
+.state[data-state="error"]{border-color:var(--crit-soft);background:var(--crit-soft)}
+.state[data-state="error"] .t,
+.state[data-state="error"] .m{color:var(--crit)}
+/* Stale is the one that matters for hardware: a number that silently
+   stops updating is worse than no number. Any live value carries its own
+   age, and past a threshold the surface says so instead of continuing to
+   look confident. */
+.state[data-state="stale"]{border-color:var(--warn-soft);background:var(--warn-soft)}
+.state[data-state="stale"] .t,
+.state[data-state="stale"] .m{color:var(--warn)}
+
+.bar{width:64%;max-width:220px;height:3px;border-radius:2px;background:var(--surface-2);overflow:hidden}
+.bar i{display:block;height:100%;width:38%;border-radius:2px;background:var(--accent)}
+@media (prefers-reduced-motion:no-preference){
+  .bar i{animation:kit-slide 1.5s ease-in-out infinite}
+  @keyframes kit-slide{0%{margin-left:-38%}100%{margin-left:100%}}
+}
+
+/* An inline banner for the same five states, when the pane has content
+   already and the state is a qualifier rather than a replacement. */
+.banner{
+  display:flex;align-items:center;gap:10px;flex-wrap:wrap;
+  padding:8px var(--pad);border-radius:var(--r);
+  border:var(--bw) solid var(--rule);background:var(--surface-2);
+  font-size:12.5px;color:var(--ink);
+}
+.banner[data-state="error"]{border-color:var(--crit-soft);background:var(--crit-soft);color:var(--crit)}
+.banner[data-state="stale"]{border-color:var(--warn-soft);background:var(--warn-soft);color:var(--warn)}
+.banner .spacer{flex:1 1 auto}
+
+/* ---------------------------------------------------------------------
+   Overlay ladder
+   --------------------------------------------------------------------- */
+
+/* Rung 0 — inline disclosure. Native <details>: keyboard, no-JS and
+   find-in-page all work once it is open, and there is no open/close state
+   to write. If a surface is tracking this in JavaScript, it is on the
+   wrong rung. */
+details.disc{
+  border:var(--bw) solid var(--rule);border-radius:var(--r);
+  background:var(--surface-2);
+}
+details.disc > summary{
+  display:flex;align-items:center;gap:8px;
+  padding:7px 11px;font-size:12.5px;color:var(--ink);
+  cursor:pointer;list-style:none;
+}
+details.disc > summary::-webkit-details-marker{display:none}
+details.disc > summary::before{content:"\25B8";color:var(--muted);font-size:10px}
+details.disc[open] > summary::before{content:"\25BE"}
+details.disc > .dbody{padding:0 11px 11px;font-size:12.5px;color:var(--slate)}
+
+/* Rung 1 — inspector: a persistent region that fills with the selection,
+   so stepping to the next item costs one click instead of close-then-open.
+   The selection belongs in the URL; if the link cannot carry it, it is
+   not finished. */
+.inspector{
+  display:grid;grid-template-columns:minmax(0,1fr) minmax(0,1.1fr);
+  gap:1px;background:var(--rule);
+  border:var(--bw) solid var(--rule);border-radius:var(--r);overflow:hidden;
+}
+.inspector > .list{background:var(--surface);display:flex;flex-direction:column;min-width:0}
+.inspector > .detail{background:var(--surface-2);padding:var(--pad);min-width:0}
+@media (max-width:640px){.inspector{grid-template-columns:minmax(0,1fr)}}
+
+/* Rung 2 — drawer: a focused sub-task on the object already on screen.
+   Never opens another drawer, never holds a destructive confirm, and must
+   survive Esc without losing typing — if it cannot, it is rung 4. */
+.drawer{
+  position:fixed;top:0;right:0;bottom:0;z-index:60;
+  width:min(560px,94vw);
+  display:flex;flex-direction:column;
+  background:var(--surface);
+  border-left:var(--bw) solid var(--rule);
+  box-shadow:var(--lift);
+  transform:translateX(100%);visibility:hidden;
+}
+.drawer[data-open="true"]{transform:none;visibility:visible}
+@media (prefers-reduced-motion:no-preference){
+  .drawer{transition:transform .22s cubic-bezier(.3,.8,.4,1),visibility .22s}
+}
+.drawer > header{
+  display:flex;align-items:center;gap:10px;
+  padding:11px var(--pad);
+  border-bottom:var(--bw) solid var(--rule);
+}
+.drawer > header .eyebrow{margin-right:auto}
+.drawer > .body{
+  flex:1;min-height:0;overflow:auto;
+  padding:var(--pad);
+  display:flex;flex-direction:column;gap:var(--gap);
+}
+.scrim{position:fixed;inset:0;z-index:50;background:var(--scrim);display:none}
+.scrim[data-open="true"]{display:block}
+
+/* Rung 3 — dialog. A real <dialog> opened with showModal(): the focus
+   trap, Esc, and the inert background come free, which is exactly what
+   the portal's hand-rolled .overlay/.modal never had. One question, at
+   most two buttons, no scrolling, no form. Focus never lands on the
+   destructive button — put autofocus on the safe one. */
+.kit dialog,
+dialog.kit-dialog{
+  padding:0;max-width:min(440px,92vw);
+  border:var(--bw) solid var(--rule);border-radius:var(--r-lg);
+  background:var(--surface);color:var(--ink);
+  font-family:var(--ff-ui);box-shadow:var(--lift);
+}
+.kit dialog::backdrop,
+dialog.kit-dialog::backdrop{background:var(--scrim)}
+.kit dialog > .body,
+dialog.kit-dialog > .body{padding:var(--pad);display:flex;flex-direction:column;gap:11px}
+.kit dialog h4,
+dialog.kit-dialog h4{font-size:15px;font-weight:600}
+.kit dialog p,
+dialog.kit-dialog p{margin:0;font-size:13px;color:var(--slate)}
+
+/* Rung 4 is a route and needs no CSS — which is the point. */

--- a/GeecsWebTheme/geecs_web_theme/static/kit.css
+++ b/GeecsWebTheme/geecs_web_theme/static/kit.css
@@ -23,6 +23,16 @@
  *   its own rules and uses these names; it does not re-skin them. Where a
  *   surface needs something genuinely its own, it adds a class of its own
  *   rather than overriding one of these.
+ * - **Every rule is scoped to `.kit` on <body>.** Not decoration: both
+ *   surfaces that will adopt this already use several of these names for
+ *   something else, and one of them load-bearingly — the portal's run page
+ *   is `.pane{display:none}` / `.pane.on{display:block}`, its tab
+ *   mechanism, which ties on specificity with an ungated `.pane{display:
+ *   flex}` and would resolve on stylesheet order alone. Every pane on that
+ *   page would render at once, decided by a link order nobody thinks
+ *   about. Scoping also means a surface converts one template at a time by
+ *   adding the class, instead of every page changing the moment the
+ *   <link> lands.
  *
  * The overlay ladder (see kit.html for working specimens): take the
  * LOWEST rung that fits.
@@ -47,9 +57,7 @@
 /* ---------------------------------------------------------------------
    Base
    --------------------------------------------------------------------- */
-.kit *,
-.kit *::before,
-.kit *::after{box-sizing:border-box}
+.kit *, .kit *::before, .kit *::after{box-sizing:border-box}
 
 body.kit{
   margin:0;
@@ -62,8 +70,8 @@ body.kit{
 }
 .kit a{color:var(--accent);text-decoration:none}
 .kit a:hover{text-decoration:underline}
-.kit h1,.kit h2,.kit h3,.kit h4{margin:0;text-wrap:balance}
-.kit code,.kit kbd{font-family:var(--ff-mono);font-size:.92em}
+.kit h1, .kit h2, .kit h3, .kit h4{margin:0;text-wrap:balance}
+.kit code, .kit kbd{font-family:var(--ff-mono);font-size:.92em}
 .kit kbd{
   border:var(--bw) solid var(--rule);border-radius:var(--r);
   padding:1px 5px;background:var(--surface-2);color:var(--ink);
@@ -72,74 +80,74 @@ body.kit{
 
 /* The uppercase micro-label that names a region. Used everywhere; the one
    place --tk earns its keep. */
-.eyebrow{
+.kit .eyebrow{
   font-family:var(--ff-mono);font-size:10.5px;font-weight:500;
   letter-spacing:var(--tk);text-transform:uppercase;color:var(--muted);
 }
-.mono{font-family:var(--ff-mono);font-variant-numeric:tabular-nums}
-.dim{color:var(--muted)}
+.kit .mono{font-family:var(--ff-mono);font-variant-numeric:tabular-nums}
+.kit .dim{color:var(--muted)}
 
 /* ---------------------------------------------------------------------
    Shell — topbar, rail, pane. One skeleton, every surface.
    --------------------------------------------------------------------- */
-.topbar{
+.kit .topbar{
   position:sticky;top:0;z-index:30;
   background:var(--surface);
   border-bottom:var(--bw) solid var(--rule);
 }
-.topbar-in{
+.kit .topbar-in{
   display:flex;flex-wrap:wrap;align-items:center;gap:10px 16px;
   max-width:var(--shell-max);margin:0 auto;
   padding-block:10px;padding-inline:20px;
 }
-.brand{
+.kit .brand{
   display:flex;align-items:baseline;gap:9px;margin-right:auto;
   font-size:15px;font-weight:600;letter-spacing:-.01em;color:var(--ink);
 }
-.brand .sub{
+.kit .brand .sub{
   font-family:var(--ff-mono);font-size:11px;font-weight:400;
   letter-spacing:var(--tk);text-transform:uppercase;color:var(--muted);
 }
 
-.shell{
+.kit .shell{
   display:grid;grid-template-columns:216px minmax(0,1fr);gap:28px;
   max-width:var(--shell-max);margin:0 auto;
   padding-block:24px 64px;padding-inline:20px;
 }
-.shell.wide{--shell-max:none}
-.shell.solo{grid-template-columns:minmax(0,1fr)}
+.kit .shell.wide{--shell-max:none}
+.kit .shell.solo{grid-template-columns:minmax(0,1fr)}
 
-.rail{
+.kit .rail{
   position:sticky;top:62px;align-self:start;
   max-height:calc(100vh - 86px);overflow:auto;
   display:flex;flex-direction:column;gap:22px;
 }
-.rail h4{
+.kit .rail h4{
   font-family:var(--ff-mono);font-size:10.5px;font-weight:600;
   letter-spacing:var(--tk);text-transform:uppercase;color:var(--muted);
   margin-bottom:8px;
 }
-.rail nav{display:flex;flex-direction:column;gap:1px}
-.rail nav a,.rail nav button{
+.kit .rail nav{display:flex;flex-direction:column;gap:1px}
+.kit .rail nav a, .kit .rail nav button{
   display:flex;justify-content:space-between;align-items:baseline;gap:8px;
   font:inherit;font-size:13px;text-align:left;width:100%;
   padding:5px 8px;border:0;border-radius:var(--r);
   background:transparent;color:var(--slate);cursor:pointer;text-decoration:none;
 }
-.rail nav a:hover,.rail nav button:hover{background:var(--surface-2);color:var(--ink);text-decoration:none}
-.rail nav [aria-current="page"],.rail nav [aria-pressed="true"]{
+.kit .rail nav a:hover, .kit .rail nav button:hover{background:var(--surface-2);color:var(--ink);text-decoration:none}
+.kit .rail nav [aria-current="page"], .kit .rail nav [aria-pressed="true"]{
   background:var(--accent);color:var(--on-accent);font-weight:600;
 }
 
-.pane{min-width:0;display:flex;flex-direction:column;gap:var(--gap)}
+.kit .pane{min-width:0;display:flex;flex-direction:column;gap:var(--gap)}
 
 /* The one breakpoint. Below it the rail stops being a column and becomes a
    strip above the pane; nothing else moves. */
 @media (max-width:900px){
-  .shell{grid-template-columns:minmax(0,1fr);gap:18px}
-  .rail{position:static;max-height:none;flex-direction:row;flex-wrap:wrap;gap:12px}
-  .rail nav{flex-direction:row;flex-wrap:wrap;gap:4px}
-  .rail nav a,.rail nav button{width:auto}
+  .kit .shell{grid-template-columns:minmax(0,1fr);gap:18px}
+  .kit .rail{position:static;max-height:none;flex-direction:row;flex-wrap:wrap;gap:12px}
+  .kit .rail nav{flex-direction:row;flex-wrap:wrap;gap:4px}
+  .kit .rail nav a, .kit .rail nav button{width:auto}
 }
 
 /* ---------------------------------------------------------------------
@@ -149,24 +157,24 @@ body.kit{
    --------------------------------------------------------------------- */
 
 /* A thing with an identity and its own state: a device, a scan, a queue. */
-.panel{
+.kit .panel{
   background:var(--surface);
   border:var(--bw) solid var(--rule);
   border-radius:var(--r-lg);
   box-shadow:var(--shadow);
   min-width:0;
 }
-.panel > header{
+.kit .panel > header{
   display:flex;align-items:center;gap:10px;flex-wrap:wrap;
   padding:10px var(--pad);
   border-bottom:var(--bw) solid var(--rule);
 }
-.panel > header .eyebrow{margin-right:auto}
-.panel > .body{
+.kit .panel > header .eyebrow{margin-right:auto}
+.kit .panel > .body{
   padding:var(--pad);
   display:flex;flex-direction:column;gap:var(--gap);
 }
-.panel > footer{
+.kit .panel > footer{
   padding:9px var(--pad);
   border-top:var(--bw) solid var(--rule-soft);
   background:var(--surface-2);
@@ -174,22 +182,22 @@ body.kit{
 
 /* Related controls that belong to the panel around them. No edges — a
    border here competes with the real one. */
-.group{display:flex;flex-direction:column;gap:8px;min-width:0}
-.row{display:flex;flex-wrap:wrap;gap:8px;align-items:center;min-width:0}
-.row.end{justify-content:flex-end}
-.spacer{flex:1 1 auto}
+.kit .group{display:flex;flex-direction:column;gap:8px;min-width:0}
+.kit .row{display:flex;flex-wrap:wrap;gap:8px;align-items:center;min-width:0}
+.kit .row.end{justify-content:flex-end}
+.kit .spacer{flex:1 1 auto}
 
 /* Output the reader did not write: a log tail, YAML, a repro snippet. */
-.well{
+.kit .well{
   background:var(--surface-2);
   border-radius:var(--r);
   padding:var(--pad);
   font-family:var(--ff-mono);font-size:12px;color:var(--slate);
   overflow-x:auto;
 }
-.well pre{margin:0}
+.kit .well pre{margin:0}
 
-.grid{display:grid;gap:var(--gap);grid-template-columns:repeat(auto-fit,minmax(280px,1fr))}
+.kit .grid{display:grid;gap:var(--gap);grid-template-columns:repeat(auto-fit,minmax(280px,1fr))}
 
 /* ---------------------------------------------------------------------
    Status — six words, one component. Colour is never the only carrier:
@@ -198,45 +206,44 @@ body.kit{
 
    queued | running | ok | degraded | failed | unknown  (+ agent)
    --------------------------------------------------------------------- */
-.chip{
+.kit .chip{
   display:inline-flex;align-items:center;gap:6px;
   font-family:var(--ff-ui);font-size:11.5px;font-weight:500;
   padding:2px 9px;border-radius:99px;white-space:nowrap;
   border:var(--bw) solid transparent;
 }
-.chip::before{
+.kit .chip::before{
   content:"";width:6px;height:6px;border-radius:50%;
   background:currentColor;flex:none;
 }
-.chip[data-state="queued"],
-.chip[data-state="unknown"]{color:var(--muted);background:var(--surface-2);border-color:var(--rule)}
-.chip[data-state="running"]{color:var(--accent);background:var(--accent-soft);border-color:var(--accent-soft)}
-.chip[data-state="ok"]{color:var(--ok);background:var(--ok-soft);border-color:var(--ok-soft)}
-.chip[data-state="degraded"]{color:var(--warn);background:var(--warn-soft);border-color:var(--warn-soft)}
-.chip[data-state="failed"]{color:var(--crit);background:var(--crit-soft);border-color:var(--crit-soft)}
+.kit .chip[data-state="queued"], .kit .chip[data-state="unknown"]{color:var(--muted);background:var(--surface-2);border-color:var(--rule)}
+.kit .chip[data-state="running"]{color:var(--accent);background:var(--accent-soft);border-color:var(--accent-soft)}
+.kit .chip[data-state="ok"]{color:var(--ok);background:var(--ok-soft);border-color:var(--ok-soft)}
+.kit .chip[data-state="degraded"]{color:var(--warn);background:var(--warn-soft);border-color:var(--warn-soft)}
+.kit .chip[data-state="failed"]{color:var(--crit);background:var(--crit-soft);border-color:var(--crit-soft)}
 /* Not a severity: who wrote this. The logbook already separates what an
    analyzer wrote from what a person wrote, and the console will want the
    same for actions an agent submitted — that distinction carries trust,
    so it belongs in the vocabulary rather than in each surface's styling. */
-.chip[data-state="agent"]{color:var(--agent);background:var(--agent-soft);border-color:var(--agent-rule)}
+.kit .chip[data-state="agent"]{color:var(--agent);background:var(--agent-soft);border-color:var(--agent-rule)}
 
-.chip[data-state="running"]::before{animation:kit-pulse 1.6s ease-in-out infinite}
+.kit .chip[data-state="running"]::before{animation:kit-pulse 1.6s ease-in-out infinite}
 @keyframes kit-pulse{0%,100%{opacity:1}50%{opacity:.25}}
 
 /* A bare dot for a dense list where the word is the row label beside it.
    Still never alone: give it aria-label or a title. */
-.dot{width:8px;height:8px;border-radius:50%;flex:none;display:inline-block}
-.dot[data-state="queued"],.dot[data-state="unknown"]{background:var(--muted)}
-.dot[data-state="running"]{background:var(--accent)}
-.dot[data-state="ok"]{background:var(--ok)}
-.dot[data-state="degraded"]{background:var(--warn)}
-.dot[data-state="failed"]{background:var(--crit)}
-.dot[data-state="agent"]{background:var(--agent)}
+.kit .dot{width:8px;height:8px;border-radius:50%;flex:none;display:inline-block}
+.kit .dot[data-state="queued"], .kit .dot[data-state="unknown"]{background:var(--muted)}
+.kit .dot[data-state="running"]{background:var(--accent)}
+.kit .dot[data-state="ok"]{background:var(--ok)}
+.kit .dot[data-state="degraded"]{background:var(--warn)}
+.kit .dot[data-state="failed"]{background:var(--crit)}
+.kit .dot[data-state="agent"]{background:var(--agent)}
 
 /* ---------------------------------------------------------------------
    Controls
    --------------------------------------------------------------------- */
-.btn{
+.kit .btn{
   display:inline-flex;align-items:center;gap:7px;
   font:inherit;font-size:13px;font-weight:500;
   height:var(--row-h);padding:0 13px;
@@ -244,55 +251,55 @@ body.kit{
   background:var(--surface);color:var(--ink);
   cursor:pointer;white-space:nowrap;
 }
-.btn:hover{background:var(--surface-2)}
-.btn[disabled],.btn[aria-disabled="true"]{opacity:.5;cursor:not-allowed}
-.btn.primary{background:var(--accent);color:var(--on-accent);border-color:var(--accent)}
-.btn.primary:hover{filter:brightness(1.07)}
+.kit .btn:hover{background:var(--surface-2)}
+.kit .btn[disabled], .kit .btn[aria-disabled="true"]{opacity:.5;cursor:not-allowed}
+.kit .btn.primary{background:var(--accent);color:var(--on-accent);border-color:var(--accent)}
+.kit .btn.primary:hover{filter:brightness(1.07)}
 /* Destructive. Never adjacent to an ordinary action — put a .spacer
    between them — and always confirmed through rung 3. */
-.btn.danger{color:var(--crit);background:var(--crit-soft);border-color:var(--crit-soft)}
-.btn.danger:hover{filter:brightness(.97)}
-.btn.sm{height:26px;font-size:12px;padding:0 10px}
-.btn.ghost{background:transparent;border-color:transparent;color:var(--muted)}
-.btn.ghost:hover{background:var(--surface-2);color:var(--ink)}
+.kit .btn.danger{color:var(--crit);background:var(--crit-soft);border-color:var(--crit-soft)}
+.kit .btn.danger:hover{filter:brightness(.97)}
+.kit .btn.sm{height:26px;font-size:12px;padding:0 10px}
+.kit .btn.ghost{background:transparent;border-color:transparent;color:var(--muted)}
+.kit .btn.ghost:hover{background:var(--surface-2);color:var(--ink)}
 
-.field{display:flex;flex-direction:column;gap:4px;min-width:150px}
-.field label{
+.kit .field{display:flex;flex-direction:column;gap:4px;min-width:150px}
+.kit .field label{
   font-family:var(--ff-mono);font-size:10.5px;letter-spacing:var(--tk);
   text-transform:uppercase;color:var(--muted);
 }
-.field input,.field select,.field textarea{
+.kit .field input, .kit .field select, .kit .field textarea{
   font:inherit;font-size:13px;
   padding:0 10px;height:var(--row-h);
   border:var(--bw) solid var(--rule);border-radius:var(--r);
   background:var(--surface);color:var(--ink);
 }
-.field textarea{height:auto;padding:8px 10px;font-family:var(--ff-mono);font-size:12.5px;resize:vertical}
-.field input:focus,.field select:focus,.field textarea:focus{
+.kit .field textarea{height:auto;padding:8px 10px;font-family:var(--ff-mono);font-size:12.5px;resize:vertical}
+.kit .field input:focus, .kit .field select:focus, .kit .field textarea:focus{
   border-color:var(--accent);outline:2px solid var(--accent);outline-offset:-1px;
 }
-.field .hint{font-size:11.5px;color:var(--muted)}
+.kit .field .hint{font-size:11.5px;color:var(--muted)}
 
 /* A segmented choice: mode, density, per-shot vs binned. */
-.seg{
+.kit .seg{
   display:inline-flex;gap:2px;padding:2px;
   border:var(--bw) solid var(--rule);border-radius:var(--r);
   background:var(--surface);
 }
-.seg button{
+.kit .seg button{
   font:inherit;font-size:11.5px;
   border:0;border-radius:calc(var(--r) - 1px);
   padding:4px 10px;background:transparent;color:var(--muted);
   cursor:pointer;white-space:nowrap;
 }
-.seg button:hover{color:var(--ink);background:var(--surface-2)}
-.seg button[aria-pressed="true"]{color:var(--ink);background:var(--surface-2);font-weight:600}
+.kit .seg button:hover{color:var(--ink);background:var(--surface-2)}
+.kit .seg button[aria-pressed="true"]{color:var(--ink);background:var(--surface-2);font-weight:600}
 
 /* ---------------------------------------------------------------------
    Tables. Wide ones go inside .tscroll so the page body never scrolls
    sideways.
    --------------------------------------------------------------------- */
-.tscroll{overflow-x:auto;max-width:100%}
+.kit .tscroll{overflow-x:auto;max-width:100%}
 .kit table{width:100%;border-collapse:collapse;font-size:13px}
 .kit th{
   text-align:left;vertical-align:bottom;
@@ -319,44 +326,42 @@ body.kit{
    surfaces today in some private form; the last three exist nowhere,
    and a control surface cannot open without stale and denied.
    --------------------------------------------------------------------- */
-.state{
+.kit .state{
   display:flex;flex-direction:column;align-items:center;justify-content:center;
   gap:8px;text-align:center;
   min-height:120px;padding:var(--pad);
   border:var(--bw) solid var(--rule);border-radius:var(--r);
   background:var(--surface);
 }
-.state .t{font-size:13px;font-weight:600;color:var(--ink)}
-.state .m{font-size:12.5px;color:var(--muted);max-width:38ch}
-.state[data-state="error"]{border-color:var(--crit-soft);background:var(--crit-soft)}
-.state[data-state="error"] .t,
-.state[data-state="error"] .m{color:var(--crit)}
+.kit .state .t{font-size:13px;font-weight:600;color:var(--ink)}
+.kit .state .m{font-size:12.5px;color:var(--muted);max-width:38ch}
+.kit .state[data-state="error"]{border-color:var(--crit-soft);background:var(--crit-soft)}
+.kit .state[data-state="error"] .t, .kit .state[data-state="error"] .m{color:var(--crit)}
 /* Stale is the one that matters for hardware: a number that silently
    stops updating is worse than no number. Any live value carries its own
    age, and past a threshold the surface says so instead of continuing to
    look confident. */
-.state[data-state="stale"]{border-color:var(--warn-soft);background:var(--warn-soft)}
-.state[data-state="stale"] .t,
-.state[data-state="stale"] .m{color:var(--warn)}
+.kit .state[data-state="stale"]{border-color:var(--warn-soft);background:var(--warn-soft)}
+.kit .state[data-state="stale"] .t, .kit .state[data-state="stale"] .m{color:var(--warn)}
 
-.bar{width:64%;max-width:220px;height:3px;border-radius:2px;background:var(--surface-2);overflow:hidden}
-.bar i{display:block;height:100%;width:38%;border-radius:2px;background:var(--accent)}
+.kit .bar{width:64%;max-width:220px;height:3px;border-radius:2px;background:var(--surface-2);overflow:hidden}
+.kit .bar i{display:block;height:100%;width:38%;border-radius:2px;background:var(--accent)}
 @media (prefers-reduced-motion:no-preference){
-  .bar i{animation:kit-slide 1.5s ease-in-out infinite}
+  .kit .bar i{animation:kit-slide 1.5s ease-in-out infinite}
   @keyframes kit-slide{0%{margin-left:-38%}100%{margin-left:100%}}
 }
 
 /* An inline banner for the same five states, when the pane has content
    already and the state is a qualifier rather than a replacement. */
-.banner{
+.kit .banner{
   display:flex;align-items:center;gap:10px;flex-wrap:wrap;
   padding:8px var(--pad);border-radius:var(--r);
   border:var(--bw) solid var(--rule);background:var(--surface-2);
   font-size:12.5px;color:var(--ink);
 }
-.banner[data-state="error"]{border-color:var(--crit-soft);background:var(--crit-soft);color:var(--crit)}
-.banner[data-state="stale"]{border-color:var(--warn-soft);background:var(--warn-soft);color:var(--warn)}
-.banner .spacer{flex:1 1 auto}
+.kit .banner[data-state="error"]{border-color:var(--crit-soft);background:var(--crit-soft);color:var(--crit)}
+.kit .banner[data-state="stale"]{border-color:var(--warn-soft);background:var(--warn-soft);color:var(--warn)}
+.kit .banner .spacer{flex:1 1 auto}
 
 /* ---------------------------------------------------------------------
    Overlay ladder
@@ -366,37 +371,37 @@ body.kit{
    find-in-page all work once it is open, and there is no open/close state
    to write. If a surface is tracking this in JavaScript, it is on the
    wrong rung. */
-details.disc{
+.kit details.disc{
   border:var(--bw) solid var(--rule);border-radius:var(--r);
   background:var(--surface-2);
 }
-details.disc > summary{
+.kit details.disc > summary{
   display:flex;align-items:center;gap:8px;
   padding:7px 11px;font-size:12.5px;color:var(--ink);
   cursor:pointer;list-style:none;
 }
-details.disc > summary::-webkit-details-marker{display:none}
-details.disc > summary::before{content:"\25B8";color:var(--muted);font-size:10px}
-details.disc[open] > summary::before{content:"\25BE"}
-details.disc > .dbody{padding:0 11px 11px;font-size:12.5px;color:var(--slate)}
+.kit details.disc > summary::-webkit-details-marker{display:none}
+.kit details.disc > summary::before{content:"\25B8";color:var(--muted);font-size:10px}
+.kit details.disc[open] > summary::before{content:"\25BE"}
+.kit details.disc > .dbody{padding:0 11px 11px;font-size:12.5px;color:var(--slate)}
 
 /* Rung 1 — inspector: a persistent region that fills with the selection,
    so stepping to the next item costs one click instead of close-then-open.
    The selection belongs in the URL; if the link cannot carry it, it is
    not finished. */
-.inspector{
+.kit .inspector{
   display:grid;grid-template-columns:minmax(0,1fr) minmax(0,1.1fr);
   gap:1px;background:var(--rule);
   border:var(--bw) solid var(--rule);border-radius:var(--r);overflow:hidden;
 }
-.inspector > .list{background:var(--surface);display:flex;flex-direction:column;min-width:0}
-.inspector > .detail{background:var(--surface-2);padding:var(--pad);min-width:0}
-@media (max-width:640px){.inspector{grid-template-columns:minmax(0,1fr)}}
+.kit .inspector > .list{background:var(--surface);display:flex;flex-direction:column;min-width:0}
+.kit .inspector > .detail{background:var(--surface-2);padding:var(--pad);min-width:0}
+@media (max-width:640px){.kit .inspector{grid-template-columns:minmax(0,1fr)}}
 
 /* Rung 2 — drawer: a focused sub-task on the object already on screen.
    Never opens another drawer, never holds a destructive confirm, and must
    survive Esc without losing typing — if it cannot, it is rung 4. */
-.drawer{
+.kit .drawer{
   position:fixed;top:0;right:0;bottom:0;z-index:60;
   width:min(560px,94vw);
   display:flex;flex-direction:column;
@@ -405,43 +410,38 @@ details.disc > .dbody{padding:0 11px 11px;font-size:12.5px;color:var(--slate)}
   box-shadow:var(--lift);
   transform:translateX(100%);visibility:hidden;
 }
-.drawer[data-open="true"]{transform:none;visibility:visible}
+.kit .drawer[data-open="true"]{transform:none;visibility:visible}
 @media (prefers-reduced-motion:no-preference){
-  .drawer{transition:transform .22s cubic-bezier(.3,.8,.4,1),visibility .22s}
+  .kit .drawer{transition:transform .22s cubic-bezier(.3,.8,.4,1),visibility .22s}
 }
-.drawer > header{
+.kit .drawer > header{
   display:flex;align-items:center;gap:10px;
   padding:11px var(--pad);
   border-bottom:var(--bw) solid var(--rule);
 }
-.drawer > header .eyebrow{margin-right:auto}
-.drawer > .body{
+.kit .drawer > header .eyebrow{margin-right:auto}
+.kit .drawer > .body{
   flex:1;min-height:0;overflow:auto;
   padding:var(--pad);
   display:flex;flex-direction:column;gap:var(--gap);
 }
-.scrim{position:fixed;inset:0;z-index:50;background:var(--scrim);display:none}
-.scrim[data-open="true"]{display:block}
+.kit .scrim{position:fixed;inset:0;z-index:50;background:var(--scrim);display:none}
+.kit .scrim[data-open="true"]{display:block}
 
 /* Rung 3 — dialog. A real <dialog> opened with showModal(): the focus
    trap, Esc, and the inert background come free, which is exactly what
    the portal's hand-rolled .overlay/.modal never had. One question, at
    most two buttons, no scrolling, no form. Focus never lands on the
    destructive button — put autofocus on the safe one. */
-.kit dialog,
-dialog.kit-dialog{
+.kit dialog{
   padding:0;max-width:min(440px,92vw);
   border:var(--bw) solid var(--rule);border-radius:var(--r-lg);
   background:var(--surface);color:var(--ink);
   font-family:var(--ff-ui);box-shadow:var(--lift);
 }
-.kit dialog::backdrop,
-dialog.kit-dialog::backdrop{background:var(--scrim)}
-.kit dialog > .body,
-dialog.kit-dialog > .body{padding:var(--pad);display:flex;flex-direction:column;gap:11px}
-.kit dialog h4,
-dialog.kit-dialog h4{font-size:15px;font-weight:600}
-.kit dialog p,
-dialog.kit-dialog p{margin:0;font-size:13px;color:var(--slate)}
+.kit dialog::backdrop{background:var(--scrim)}
+.kit dialog > .body{padding:var(--pad);display:flex;flex-direction:column;gap:11px}
+.kit dialog h4{font-size:15px;font-weight:600}
+.kit dialog p{margin:0;font-size:13px;color:var(--slate)}
 
 /* Rung 4 is a route and needs no CSS — which is the point. */

--- a/GeecsWebTheme/geecs_web_theme/static/kit.html
+++ b/GeecsWebTheme/geecs_web_theme/static/kit.html
@@ -36,7 +36,7 @@
   <nav class="rail" aria-label="Sections">
     <div>
       <h4>Components</h4>
-      <nav>
+      <nav class="picklist">
         <a href="#shell" aria-current="page">Shell</a>
         <a href="#containers">Containers</a>
         <a href="#status">Status</a>
@@ -48,7 +48,7 @@
     </div>
     <div>
       <h4>Live sample</h4>
-      <nav>
+      <nav class="picklist">
         <button type="button" aria-pressed="true">Scan 043 <span class="dim">now</span></button>
         <button type="button">Scan 042 <span class="dim">14:02</span></button>
         <button type="button">Scan 041 <span class="dim">13:31</span></button>
@@ -269,7 +269,7 @@
           <span class="eyebrow">rung 1 &middot; inspector &middot; stepping through many items</span>
           <div class="inspector">
             <div class="list">
-              <nav>
+              <nav class="picklist">
                 <button type="button" aria-pressed="true">U_ICT</button>
                 <button type="button">U_Hexapod</button>
                 <button type="button">UC_HASO</button>

--- a/GeecsWebTheme/geecs_web_theme/static/kit.html
+++ b/GeecsWebTheme/geecs_web_theme/static/kit.html
@@ -341,7 +341,7 @@
   </div>
 </aside>
 
-<dialog id="k-dialog" class="kit-dialog" aria-labelledby="k-dialog-title">
+<dialog id="k-dialog" aria-labelledby="k-dialog-title">
   <div class="body">
     <h4 id="k-dialog-title">Clear the queue?</h4>
     <p>Three queued scans will be removed: Scan 044, 045 and 046. The run in

--- a/GeecsWebTheme/geecs_web_theme/static/kit.html
+++ b/GeecsWebTheme/geecs_web_theme/static/kit.html
@@ -58,6 +58,15 @@
 
   <main class="pane">
 
+    <section class="group">
+      <div class="banner">
+        <span><strong>Reference page.</strong> Every device name, scan number and
+          reading below is sample content chosen to make the components legible
+          &mdash; it is not this installation&rsquo;s data, and nothing here is a
+          default in code.</span>
+      </div>
+    </section>
+
     <section id="shell" class="group">
       <h2>The shell</h2>
       <p class="dim">This page is the specimen: sticky topbar, 216&nbsp;px rail, one

--- a/GeecsWebTheme/geecs_web_theme/static/kit.html
+++ b/GeecsWebTheme/geecs_web_theme/static/kit.html
@@ -1,0 +1,350 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>GEECS surface kit</title>
+<!--
+  The kit's own reference page: every component the kit ships, rendered in
+  the real theme, at whichever density and palette you pick.
+
+  It is a STATIC file in the same directory as the stylesheets, so any host
+  that already mounts this package gets it for free at <mount>/kit.html —
+  the portal serves it at /theme/kit.html with no route of its own. That is
+  also why every asset below is referenced relatively: the page must work
+  under any mount prefix and behind a reverse proxy.
+
+  Its job is to be looked at. When a component here is wrong, it is cheap
+  to change; once three surfaces use it, it is not.
+-->
+<script src="theme-boot.js"></script>
+<link rel="stylesheet" href="theme.css">
+<link rel="stylesheet" href="kit.css">
+</head>
+<body class="kit">
+
+<header class="topbar">
+  <div class="topbar-in">
+    <span class="brand">GEECS surface kit <span class="sub">reference</span></span>
+    <div data-density-picker></div>
+    <div data-theme-picker></div>
+  </div>
+</header>
+
+<div class="shell">
+
+  <nav class="rail" aria-label="Sections">
+    <div>
+      <h4>Components</h4>
+      <nav>
+        <a href="#shell" aria-current="page">Shell</a>
+        <a href="#containers">Containers</a>
+        <a href="#status">Status</a>
+        <a href="#controls">Controls</a>
+        <a href="#tables">Tables</a>
+        <a href="#states">Pane states</a>
+        <a href="#overlays">Overlay ladder</a>
+      </nav>
+    </div>
+    <div>
+      <h4>Live sample</h4>
+      <nav>
+        <button type="button" aria-pressed="true">Scan 043 <span class="dim">now</span></button>
+        <button type="button">Scan 042 <span class="dim">14:02</span></button>
+        <button type="button">Scan 041 <span class="dim">13:31</span></button>
+      </nav>
+    </div>
+  </nav>
+
+  <main class="pane">
+
+    <section id="shell" class="group">
+      <h2>The shell</h2>
+      <p class="dim">This page is the specimen: sticky topbar, 216&nbsp;px rail, one
+        pane. Below 900&nbsp;px the rail becomes a strip and nothing else moves —
+        narrow the window. Both controls in the topbar are the kit's own, and both
+        persist across every GEECS surface on this origin.</p>
+    </section>
+
+    <section id="containers" class="group">
+      <h2>Containers</h2>
+      <p class="dim">Border, fill, radius and shadow each say <em>separate object</em>.
+        Three containers, by role — spending all four on every block is why dense
+        screens go flat.</p>
+
+      <div class="grid">
+        <article class="panel">
+          <header>
+            <span class="eyebrow">panel &middot; a thing with its own state</span>
+            <span class="chip" data-state="ok">ok</span>
+          </header>
+          <div class="body">
+            <div class="row">
+              <span class="mono">U_ICT</span>
+              <span class="spacer"></span>
+              <span class="mono">187 pC</span>
+            </div>
+            <p class="dim">A device, a scan, a queue: something that can be addressed
+              and can be wrong on its own.</p>
+          </div>
+          <footer class="eyebrow">last update 0.4 s ago</footer>
+        </article>
+
+        <div class="group">
+          <span class="eyebrow">group &middot; no edges</span>
+          <p class="dim">Controls that belong to the panel around them. Spacing does
+            the work; a border here competes with the real one.</p>
+          <div class="row">
+            <button class="btn sm" type="button">Per-shot</button>
+            <button class="btn sm" type="button">Binned</button>
+          </div>
+        </div>
+
+        <div class="group">
+          <span class="eyebrow">well &middot; output you did not write</span>
+          <div class="well"><pre>scan_variables:
+  jet_pressure:
+    device: U_HP_Daq
+    variable: Jet pressure
+    start: 2.0   stop: 5.0   step: 0.5</pre></div>
+        </div>
+      </div>
+    </section>
+
+    <section id="status" class="group">
+      <h2>Status</h2>
+      <p class="dim">Six words replacing the fifteen class names the portal and the
+        logbook invented separately, plus <code>agent</code> — not a severity, but
+        <em>who wrote this</em>. Colour is never the only carrier: every chip is a
+        dot plus a word.</p>
+      <div class="row">
+        <span class="chip" data-state="queued">queued</span>
+        <span class="chip" data-state="running">running</span>
+        <span class="chip" data-state="ok">ok</span>
+        <span class="chip" data-state="degraded">degraded</span>
+        <span class="chip" data-state="failed">failed</span>
+        <span class="chip" data-state="unknown">unknown</span>
+        <span class="chip" data-state="agent">agent</span>
+      </div>
+
+      <div class="panel">
+        <header><span class="eyebrow">device health &middot; the dot form</span></header>
+        <div class="body">
+          <div class="row"><span class="dot" data-state="ok" aria-hidden="true"></span>
+            <span class="mono">U_ChicaneSpec</span><span class="spacer"></span>
+            <span class="mono dim">102.4 MeV</span></div>
+          <div class="row"><span class="dot" data-state="ok" aria-hidden="true"></span>
+            <span class="mono">U_Hexapod</span><span class="spacer"></span>
+            <span class="mono dim">&minus;0.42 mm</span></div>
+          <div class="row"><span class="dot" data-state="degraded" aria-hidden="true"></span>
+            <span class="mono">UC_HASO</span><span class="spacer"></span>
+            <span class="mono dim">stale 41 s</span></div>
+          <div class="row"><span class="dot" data-state="failed" aria-hidden="true"></span>
+            <span class="mono">U_S4H</span><span class="spacer"></span>
+            <span class="mono dim">no reply</span></div>
+        </div>
+      </div>
+    </section>
+
+    <section id="controls" class="group">
+      <h2>Controls</h2>
+      <div class="panel"><div class="body">
+        <div class="row">
+          <div class="field">
+            <label for="k-var">Scan variable</label>
+            <select id="k-var">
+              <option>U_HP_Daq:Jet pressure</option>
+              <option>U_Hexapod:ypos</option>
+              <option>U_S4H:Current</option>
+            </select>
+          </div>
+          <div class="field">
+            <label for="k-shots">Shots / step</label>
+            <input id="k-shots" type="text" inputmode="numeric" value="30">
+            <span class="hint">30 &times; 7 steps = 210 shots</span>
+          </div>
+        </div>
+        <div class="row">
+          <button class="btn primary" type="button">Submit scan</button>
+          <button class="btn" type="button">Validate</button>
+          <button class="btn ghost" type="button">Reset</button>
+          <span class="spacer"></span>
+          <button class="btn danger" type="button" data-dialog-open="k-dialog">Abort run&hellip;</button>
+        </div>
+        <p class="dim">Destructive actions sit behind a <code>.spacer</code>, wear
+          their own colour, and confirm through rung&nbsp;3 — never adjacent to an
+          ordinary button.</p>
+      </div></div>
+    </section>
+
+    <section id="tables" class="group">
+      <h2>Tables</h2>
+      <div class="panel"><div class="tscroll">
+        <table>
+          <thead><tr><th>Scan</th><th>Plan</th><th class="num">Shots</th><th>State</th></tr></thead>
+          <tbody>
+            <tr aria-selected="true"><td class="id">Scan 043</td><td>scan_1d</td>
+              <td class="num">120 / 180</td><td><span class="chip" data-state="running">running</span></td></tr>
+            <tr><td class="id">Scan 042</td><td>count</td><td class="num">50 / 50</td>
+              <td><span class="chip" data-state="ok">ok</span></td></tr>
+            <tr><td class="id">Scan 041</td><td>scan_1d</td><td class="num">208 / 210</td>
+              <td><span class="chip" data-state="degraded">degraded</span></td></tr>
+            <tr><td class="id">Scan 040</td><td>grid_scan</td><td class="num">64 / 256</td>
+              <td><span class="chip" data-state="failed">failed</span></td></tr>
+            <tr><td class="id">Scan 039</td><td>scan_1d</td><td class="num">&mdash;</td>
+              <td><span class="chip" data-state="queued">queued</span></td></tr>
+          </tbody>
+        </table>
+      </div></div>
+    </section>
+
+    <section id="states" class="group">
+      <h2>The five states every pane owes</h2>
+      <p class="dim">Loading and empty exist on both surfaces today in private forms.
+        Error, stale and denied exist nowhere — and a control surface cannot open
+        without the last two.</p>
+
+      <div class="grid">
+        <div class="state" data-state="loading">
+          <div class="t">Loading Scan 043</div>
+          <div class="bar"><i></i></div>
+          <div class="m">Name what is loading. A bare spinner tells nobody whether to wait.</div>
+        </div>
+        <div class="state" data-state="empty">
+          <div class="t">No scans on 11 Sep</div>
+          <div class="m">The folder exists and holds nothing.</div>
+          <button class="btn sm" type="button">Jump to last day with data</button>
+        </div>
+        <div class="state" data-state="error">
+          <div class="t">Tiled refused the connection</div>
+          <div class="m">The portal host may be down. Nothing was lost.</div>
+          <button class="btn sm" type="button">Retry</button>
+        </div>
+        <div class="state" data-state="stale">
+          <div class="t">Showing the value from 41 s ago</div>
+          <div class="m">UC_HASO stopped updating. A number that silently goes stale
+            is worse than no number.</div>
+        </div>
+        <div class="state" data-state="denied">
+          <div class="t">Another operator holds the run</div>
+          <div class="m">Read-only until they release it.</div>
+        </div>
+      </div>
+
+      <div class="banner" data-state="stale">
+        <span>Live values last updated 41 s ago.</span>
+        <span class="spacer"></span>
+        <button class="btn sm" type="button">Reconnect</button>
+      </div>
+    </section>
+
+    <section id="overlays" class="group">
+      <h2>The overlay ladder</h2>
+      <p class="dim">Take the lowest rung that fits. The decider: <strong>can the user
+        lose work by pressing Esc?</strong> If yes it is a route, whatever it looks
+        like. All four below work — click them.</p>
+
+      <div class="panel"><div class="body">
+
+        <div class="group">
+          <span class="eyebrow">rung 0 &middot; inline disclosure &middot; the default</span>
+          <details class="disc">
+            <summary>Scan 041 &middot; 2 shots excluded</summary>
+            <div class="dbody">Shots 88 and 141 dropped on <code>UC_ALineEBeam3</code>
+              (trigger miss) and were excluded from the bin means. Native
+              <code>&lt;details&gt;</code>: keyboard, no-JS and find-in-page all work.</div>
+          </details>
+        </div>
+
+        <div class="group">
+          <span class="eyebrow">rung 1 &middot; inspector &middot; stepping through many items</span>
+          <div class="inspector">
+            <div class="list">
+              <nav>
+                <button type="button" aria-pressed="true">U_ICT</button>
+                <button type="button">U_Hexapod</button>
+                <button type="button">UC_HASO</button>
+              </nav>
+            </div>
+            <div class="detail">
+              <div class="mono">U_ICT</div>
+              <p class="dim">The selection belongs in the URL. If the link cannot carry
+                it, the inspector is not finished.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="group">
+          <span class="eyebrow">rung 2 &middot; drawer &middot; a sub-task on this object</span>
+          <div class="row">
+            <button class="btn" type="button" data-drawer-open="k-drawer">Edit save set&hellip;</button>
+            <span class="dim">Esc closes it; nothing here can be lost.</span>
+          </div>
+        </div>
+
+        <div class="group">
+          <span class="eyebrow">rung 3 &middot; dialog &middot; must be answered now</span>
+          <div class="row">
+            <button class="btn danger" type="button" data-dialog-open="k-dialog">Clear queue&hellip;</button>
+            <span class="dim">A real <code>&lt;dialog&gt;</code>: focus trap, Esc and an
+              inert background, free.</span>
+          </div>
+        </div>
+
+        <div class="group">
+          <span class="eyebrow">rung 4 &middot; route &middot; needs no component</span>
+          <div class="well">/run/{uid}/plot?x=shot&amp;y=charge&amp;view=bin</div>
+        </div>
+
+      </div></div>
+    </section>
+
+  </main>
+</div>
+
+<div class="scrim"></div>
+
+<aside class="drawer" id="k-drawer" role="dialog" aria-modal="false"
+       aria-labelledby="k-drawer-title" aria-hidden="true" data-open="false">
+  <header>
+    <span class="eyebrow" id="k-drawer-title">Save set &middot; HTU_standard</span>
+    <button class="btn sm" type="button" data-drawer-close>Close</button>
+  </header>
+  <div class="body">
+    <p class="dim">The page is still behind you and the scrim is dismissible. A drawer
+      never opens another drawer and never holds a destructive confirm.</p>
+    <div class="group">
+      <span class="eyebrow">Devices in this set</span>
+      <div class="row">
+        <span class="chip" data-state="ok">U_ICT</span>
+        <span class="chip" data-state="ok">U_ChicaneSpec</span>
+        <span class="chip" data-state="degraded">UC_HASO</span>
+        <span class="chip" data-state="queued">U_Hexapod</span>
+      </div>
+    </div>
+    <div class="well"><pre>save_set: HTU_standard
+  db_scalars: true
+  devices: [U_ICT, U_ChicaneSpec, UC_HASO, U_Hexapod]</pre></div>
+    <div class="row end">
+      <button class="btn" type="button" data-drawer-close>Cancel</button>
+      <button class="btn primary" type="button" data-drawer-close>Save</button>
+    </div>
+  </div>
+</aside>
+
+<dialog id="k-dialog" class="kit-dialog" aria-labelledby="k-dialog-title">
+  <div class="body">
+    <h4 id="k-dialog-title">Clear the queue?</h4>
+    <p>Three queued scans will be removed: Scan 044, 045 and 046. The run in
+      progress (Scan 043) is not affected. This cannot be undone.</p>
+    <div class="row end">
+      <button class="btn" type="button" data-dialog-close autofocus>Keep them</button>
+      <button class="btn danger" type="button" data-dialog-close>Clear 3 scans</button>
+    </div>
+  </div>
+</dialog>
+
+<script src="theme.js" defer></script>
+<script src="kit.js" defer></script>
+</body>
+</html>

--- a/GeecsWebTheme/geecs_web_theme/static/kit.js
+++ b/GeecsWebTheme/geecs_web_theme/static/kit.js
@@ -62,7 +62,10 @@
     if (!CFG || !CFG.densities) return;
     var hosts = document.querySelectorAll("[data-density-picker]");
     Array.prototype.forEach.call(hosts, function (host) {
-      if (host.firstChild) return; // already built
+      // Not firstChild: `<div data-density-picker>\n</div>` — ordinary Jinja
+      // formatting — has a whitespace text node and would silently ship no
+      // control at all.
+      if (host.querySelector("button")) return; // already built
       host.className = host.className ? host.className + " seg" : "seg";
       host.setAttribute("role", "group");
       host.setAttribute("aria-label", "Row density");
@@ -129,10 +132,28 @@
     }
     el.setAttribute("data-open", "true");
     el.setAttribute("aria-hidden", "false");
-    var first = el.querySelector("[autofocus],[data-drawer-close],button,a[href],input,select,textarea");
+    // A selector list carries no priority — querySelector returns the first
+    // match in TREE order, which here is the header's Close button, so the
+    // one-call form silently ignores [autofocus]. <dialog>.showModal() does
+    // honour it, and two rungs disagreeing on identical markup gets debugged
+    // as a browser quirk. Ask for the preferred element first, on its own.
+    var first =
+      el.querySelector("[autofocus]") ||
+      el.querySelector("[data-drawer-close],button,a[href],input,select,textarea");
     if (first) {
       try { first.focus(); } catch (e) { /* nothing focusable: leave it */ }
     }
+  }
+
+  //: A missing target is always a typo in a template, and it fails by doing
+  //  nothing at all — the exact "dead button" shape a past review caught in
+  //  this repo before. Say so rather than returning quietly.
+  function need(id, what) {
+    var el = document.getElementById(id);
+    if (!el && window.console && console.warn) {
+      console.warn("[geecs-kit] no " + what + ' with id "' + id + '" — dead control');
+    }
+    return el;
   }
 
   function drawer(el) {
@@ -177,11 +198,11 @@
       var t = e.target && e.target.closest ? e.target.closest("[data-drawer-open],[data-drawer-close],[data-dialog-open],[data-dialog-close]") : null;
       if (!t) return;
       if (t.hasAttribute("data-drawer-open")) {
-        showDrawer(document.getElementById(t.getAttribute("data-drawer-open")), t);
+        showDrawer(need(t.getAttribute("data-drawer-open"), "drawer"), t);
       } else if (t.hasAttribute("data-drawer-close")) {
         closeDrawer();
       } else if (t.hasAttribute("data-dialog-open")) {
-        confirmDialog(document.getElementById(t.getAttribute("data-dialog-open"))).open();
+        confirmDialog(need(t.getAttribute("data-dialog-open"), "dialog")).open();
       } else if (t.hasAttribute("data-dialog-close")) {
         var host = t.closest("dialog");
         if (host) confirmDialog(host).close();
@@ -192,6 +213,9 @@
     // drawer's, which the platform does not give us.
     document.addEventListener("keydown", function (e) {
       if (e.key !== "Escape" || !openDrawer) return;
+      // A modal <dialog> above the drawer owns Esc and closes itself; taking
+      // it here would dismiss the drawer underneath instead.
+      if (document.querySelector("dialog[open]")) return;
       e.preventDefault();
       closeDrawer();
     });

--- a/GeecsWebTheme/geecs_web_theme/static/kit.js
+++ b/GeecsWebTheme/geecs_web_theme/static/kit.js
@@ -1,0 +1,217 @@
+/* GEECS surface kit — the three behaviours kit.css cannot express.
+ *
+ * Load deferred, beside theme.js. Everything here is additive: with this
+ * file absent the page still renders correctly, <details> still opens, and
+ * the density stamped by theme-boot.js still applies — only the drawer,
+ * the dialog helper and the density control go missing.
+ *
+ *   <div data-density-picker></div>   the spacing control, built here
+ *   GeecsKit.drawer(el)               rung 2 — open/close with Esc, scrim,
+ *                                     focus return
+ *   GeecsKit.confirm(el)              rung 3 — <dialog>.showModal() with a
+ *                                     fallback for browsers without it
+ *
+ * Why a drawer needs script at all, when rungs 0 and 3 do not: the browser
+ * gives us <details> and <dialog> outright, but there is no element for "a
+ * panel over the page that Esc dismisses and that hands focus back where
+ * it came from". That is the whole of this file's drawer half, and it is
+ * deliberately small — if it grows, the thing being built is probably a
+ * route (rung 4) wearing a drawer's clothes.
+ *
+ * It dispatches `geecs:density` on window with {density} so anything that
+ * measures itself — a Plotly figure sizing to its container — can relayout.
+ */
+(function () {
+  "use strict";
+
+  var CFG = window.GEECS_THEME;
+  var root = document.documentElement;
+
+  var DENSITY_LABEL = {
+    comfortable: { label: "Comfortable", hint: "Roomier rows — reading and writing" },
+    compact: { label: "Compact", hint: "Tighter rows — tables and live panels" }
+  };
+
+  function write(key, value) {
+    try { window.localStorage.setItem(key, value); } catch (e) { /* private window */ }
+  }
+
+  /* ---- density ---------------------------------------------------- */
+
+  function setDensity(value) {
+    if (!CFG || CFG.densities.indexOf(value) === -1) return;
+    root.setAttribute("data-density", value);
+    write(CFG.keys.density, value);
+    sync();
+    try {
+      window.dispatchEvent(
+        new CustomEvent("geecs:density", { detail: { density: value } })
+      );
+    } catch (e) { /* very old browser: the attribute is still stamped */ }
+  }
+
+  function sync() {
+    var now = root.getAttribute("data-density");
+    var buttons = document.querySelectorAll("[data-density-picker] button[data-density]");
+    Array.prototype.forEach.call(buttons, function (b) {
+      b.setAttribute("aria-pressed", String(b.getAttribute("data-density") === now));
+    });
+  }
+
+  function buildDensityPickers() {
+    if (!CFG || !CFG.densities) return;
+    var hosts = document.querySelectorAll("[data-density-picker]");
+    Array.prototype.forEach.call(hosts, function (host) {
+      if (host.firstChild) return; // already built
+      host.className = host.className ? host.className + " seg" : "seg";
+      host.setAttribute("role", "group");
+      host.setAttribute("aria-label", "Row density");
+      CFG.densities.forEach(function (value) {
+        var meta = DENSITY_LABEL[value] || { label: value, hint: value };
+        var b = document.createElement("button");
+        b.type = "button";
+        b.setAttribute("data-density", value);
+        b.title = meta.hint;
+        b.textContent = meta.label;
+        b.addEventListener("click", function () { setDensity(value); });
+        host.appendChild(b);
+      });
+    });
+    sync();
+  }
+
+  /* ---- rung 2: drawer --------------------------------------------- */
+
+  //: The drawer currently open, so Esc and the scrim know what to close.
+  //  One at a time by design: a drawer never opens another drawer.
+  var openDrawer = null;
+  var returnFocusTo = null;
+
+  function scrimFor(el) {
+    var id = el.getAttribute("data-scrim");
+    if (id) return document.getElementById(id);
+    var found = document.querySelector(".scrim");
+    if (found) return found;
+    found = document.createElement("div");
+    found.className = "scrim";
+    document.body.appendChild(found);
+    return found;
+  }
+
+  function closeDrawer() {
+    if (!openDrawer) return;
+    var el = openDrawer;
+    var scrim = scrimFor(el);
+    openDrawer = null;
+    el.setAttribute("data-open", "false");
+    el.setAttribute("aria-hidden", "true");
+    if (scrim) scrim.setAttribute("data-open", "false");
+    // Focus goes back where it came from, or the opener is gone and the
+    // page keeps it — never left on a hidden element.
+    if (returnFocusTo && document.contains(returnFocusTo)) {
+      try { returnFocusTo.focus(); } catch (e) { /* not focusable any more */ }
+    }
+    returnFocusTo = null;
+  }
+
+  function showDrawer(el, opener) {
+    if (!el) return;
+    if (openDrawer && openDrawer !== el) closeDrawer();
+    returnFocusTo = opener || document.activeElement;
+    openDrawer = el;
+    var scrim = scrimFor(el);
+    if (scrim) {
+      scrim.setAttribute("data-open", "true");
+      if (!scrim.getAttribute("data-kit-wired")) {
+        scrim.setAttribute("data-kit-wired", "1");
+        scrim.addEventListener("click", closeDrawer);
+      }
+    }
+    el.setAttribute("data-open", "true");
+    el.setAttribute("aria-hidden", "false");
+    var first = el.querySelector("[autofocus],[data-drawer-close],button,a[href],input,select,textarea");
+    if (first) {
+      try { first.focus(); } catch (e) { /* nothing focusable: leave it */ }
+    }
+  }
+
+  function drawer(el) {
+    return {
+      open: function (opener) { showDrawer(el, opener); },
+      close: closeDrawer,
+      get isOpen() { return openDrawer === el; }
+    };
+  }
+
+  /* ---- rung 3: dialog --------------------------------------------- */
+
+  function confirmDialog(el) {
+    if (!el) return { open: function () {}, close: function () {} };
+    return {
+      open: function () {
+        if (typeof el.showModal === "function") {
+          if (!el.open) el.showModal();
+        } else {
+          // No <dialog> support: it still renders and is still dismissible,
+          // it just does not make the background inert.
+          el.setAttribute("open", "");
+        }
+      },
+      close: function () {
+        if (typeof el.close === "function") el.close();
+        else el.removeAttribute("open");
+      }
+    };
+  }
+
+  /* ---- wiring ------------------------------------------------------ */
+
+  // Declarative openers/closers, so a surface needs no script of its own
+  // for the common case:
+  //   <button data-drawer-open="save-set">Edit…</button>
+  //   <button data-drawer-close>Cancel</button>
+  //   <button data-dialog-open="clear-queue">Clear queue…</button>
+  //   <button data-dialog-close>Keep them</button>
+  function wire() {
+    document.addEventListener("click", function (e) {
+      var t = e.target && e.target.closest ? e.target.closest("[data-drawer-open],[data-drawer-close],[data-dialog-open],[data-dialog-close]") : null;
+      if (!t) return;
+      if (t.hasAttribute("data-drawer-open")) {
+        showDrawer(document.getElementById(t.getAttribute("data-drawer-open")), t);
+      } else if (t.hasAttribute("data-drawer-close")) {
+        closeDrawer();
+      } else if (t.hasAttribute("data-dialog-open")) {
+        confirmDialog(document.getElementById(t.getAttribute("data-dialog-open"))).open();
+      } else if (t.hasAttribute("data-dialog-close")) {
+        var host = t.closest("dialog");
+        if (host) confirmDialog(host).close();
+      }
+    });
+
+    // Esc closes the top rung. <dialog> handles its own Esc; this is the
+    // drawer's, which the platform does not give us.
+    document.addEventListener("keydown", function (e) {
+      if (e.key !== "Escape" || !openDrawer) return;
+      e.preventDefault();
+      closeDrawer();
+    });
+  }
+
+  function init() {
+    buildDensityPickers();
+    wire();
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", init);
+  } else {
+    init();
+  }
+
+  window.GeecsKit = {
+    setDensity: setDensity,
+    drawer: drawer,
+    confirm: confirmDialog,
+    closeDrawer: closeDrawer
+  };
+})();

--- a/GeecsWebTheme/geecs_web_theme/static/theme-boot.js
+++ b/GeecsWebTheme/geecs_web_theme/static/theme-boot.js
@@ -10,6 +10,9 @@
  * EFFECTIVE mode. That is why theme.css needs exactly one dark block per
  * theme and no @media copy of it — the copy is what drifted before.
  *
+ * It also stamps the spacing density the kit (kit.css) keys off, for the
+ * same pre-paint reason.
+ *
  * Everything is guarded: a private window, blocked storage, or a stale or
  * foreign value under our localStorage key (every page on this origin
  * shares it) must fall back to the default, never leave the page unstamped.
@@ -20,7 +23,13 @@
     themes: ["bella", "laser", "plasma"],
     defaultTheme: "laser",
     modes: ["system", "light", "dark"],
-    keys: { theme: "geecs.theme", mode: "geecs.mode" }
+    densities: ["comfortable", "compact"],
+    defaultDensity: "comfortable",
+    keys: {
+      theme: "geecs.theme",
+      mode: "geecs.mode",
+      density: "geecs.density"
+    }
   };
   window.GEECS_THEME = CFG;
 
@@ -39,8 +48,15 @@
     effective = mq && mq.matches ? "dark" : "light";
   }
 
+  var density = read(CFG.keys.density);
+  if (CFG.densities.indexOf(density) === -1) density = CFG.defaultDensity;
+
   var root = document.documentElement;
   root.setAttribute("data-theme", theme);
+  // Spacing scale. Stamped here for the same reason as the palette: the
+  // kit's padding and row heights key off it, so choosing it after first
+  // paint would reflow every panel on the page.
+  root.setAttribute("data-density", density);
   root.setAttribute("data-mode", effective);
   // What the viewer CHOSE, distinct from what is showing; theme.js reads it.
   root.setAttribute("data-mode-pref", mode);

--- a/GeecsWebTheme/geecs_web_theme/static/theme.css
+++ b/GeecsWebTheme/geecs_web_theme/static/theme.css
@@ -52,7 +52,38 @@
   --ff-ui:"IBM Plex Sans",ui-sans-serif,system-ui,-apple-system,"Segoe UI",sans-serif;
   --ff-mono:"IBM Plex Mono",ui-monospace,SFMono-Regular,Menlo,monospace;
   --ff-prose:"Source Serif 4",Georgia,"Times New Roman",serif;
+
+  /* Structure. These live in the bare :root ONLY — no palette overrides one
+   * yet, so every theme shares them and kit.css can read them unconditionally.
+   * When a palette wants its own corner radius or tracking (a drafting theme
+   * with square corners, a control-room theme with hairline rules), it adds
+   * the override to its own block and nothing else changes.
+   *
+   * --r is the CONTROL corner (a button, an input); --r-lg is the PANEL
+   * corner. One value cannot say both: a 26px button and a full-width card
+   * want different answers, and which pair a theme picks is most of what
+   * makes it read as sharp or soft.
+   */
   --r:6px;
+  --r-lg:8px;
+  --bw:1px;
+  --tk:.06em;
+
+  /* Spacing scale. theme-boot.js stamps data-density before first paint and
+   * kit.css redefines these three under [data-density="compact"]; nothing
+   * else in the system encodes a padding. */
+  --pad:14px;
+  --row-h:34px;
+  --gap:14px;
+
+  /* How wide the shell runs before it centres. A surface that wants the
+   * full window (a wall display) sets --shell-max:none on its own .shell. */
+  --shell-max:1240px;
+
+  /* Opacity over whatever is behind them, so they read on every ground and
+   * take no palette colour — the same reason --shadow is a literal here. */
+  --scrim:rgba(0,0,0,.5);
+  --lift:0 8px 30px -10px rgba(0,0,0,.35);
 }
 
 /* ---- bella ---- */

--- a/GeecsWebTheme/pyproject.toml
+++ b/GeecsWebTheme/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-web-theme"
-version = "0.1.2"
+version = "0.2.0"
 description = "One palette vocabulary for every GEECS web surface: tokens, themes, and the picker"
 authors = ["GEECS-BELLA"]
 readme = "README.md"

--- a/GeecsWebTheme/tests/test_no_literal_colours.py
+++ b/GeecsWebTheme/tests/test_no_literal_colours.py
@@ -612,3 +612,30 @@ def test_probe_scoping(css: str, expected: bool) -> None:
         if not _KIT_SCOPED.match(s) and not _UNSCOPED_OK.match(s)
     ]
     assert bool(ungated) is expected, (css, ungated)
+
+
+def test_reference_page_demonstrates_only_what_the_kit_provides() -> None:
+    """Every class ``kit.html`` uses is styled by the kit or the theme.
+
+    ``kit.html`` is the page adopters copy from, so a component shown there
+    that the kit does not actually style is worse than one that is missing:
+    it gets copied, renders as browser defaults in the surface, and the
+    adopter writes their own CSS for it — which is the per-surface
+    divergence this package exists to stop. The inspector shipped exactly
+    that way (a selection list of bare ``<button>`` elements, styled only
+    by ``.rail nav``, which the inspector is not inside).
+
+    A class here with no rule anywhere is either a component the kit owes,
+    or a stray on the demo page. Both want fixing.
+    """
+    used: set[str] = set()
+    for attr in re.finditer(r'class="([^"]+)"', _KIT_HTML.read_text()):
+        used |= set(attr.group(1).split())
+    styled = set(
+        re.findall(r"\.([A-Za-z][\w-]*)", _KIT_CSS.read_text() + _THEME_CSS.read_text())
+    )
+    missing = sorted(used - styled)
+    assert not missing, (
+        f"kit.html shows {missing} but nothing styles them — either the kit "
+        "owes the component or the page should not be demonstrating it"
+    )

--- a/GeecsWebTheme/tests/test_no_literal_colours.py
+++ b/GeecsWebTheme/tests/test_no_literal_colours.py
@@ -31,6 +31,13 @@ import pytest
 _REPO = Path(__file__).resolve().parents[2]
 _THEME_CSS = _REPO / "GeecsWebTheme/geecs_web_theme/static/theme.css"
 _KIT_CSS = _REPO / "GeecsWebTheme/geecs_web_theme/static/kit.css"
+
+#: The spacing scale a density block owns. theme.css declares these in the
+#: bare :root (the comfortable values) and every non-default density block
+#: in kit.css overrides exactly this set. Adding a fourth spacing token
+#: means adding it here too — at which point the density blocks that forgot
+#: it fail, which is the point.
+_DENSITY_TOKENS = {"--pad", "--row-h", "--gap"}
 _KIT_HTML = _REPO / "GeecsWebTheme/geecs_web_theme/static/kit.html"
 
 #: The web surfaces bound by the rule. Adding a surface means adding it
@@ -396,7 +403,25 @@ def test_python_and_boot_script_agree_on_the_density_list() -> None:
     for name in DENSITIES:
         if name == DEFAULT_DENSITY:
             continue
-        assert f':root[data-density="{name}"]' in kit, f"{name} has no kit block"
+        block = re.search(r':root\[data-density="%s"\]\s*\{([^}]*)\}' % name, kit)
+        assert block, f"{name} has no kit block"
+        # Not just "the selector is present": an EMPTY block passed the first
+        # version of this test, which is exactly the drift it has to catch —
+        # the comfortable values live in theme.css and the overrides here, so
+        # forgetting one leaves compact silently showing a comfortable value.
+        defined = set(re.findall(r"(--[\w-]+)\s*:", block.group(1)))
+        assert defined == _DENSITY_TOKENS, (
+            f'[data-density="{name}"] defines {sorted(defined)}, '
+            f"expected {sorted(_DENSITY_TOKENS)}"
+        )
+
+    # _blocks() reads raw text, and theme.css's header comment mentions
+    # ":root" — which the selector regex then runs together with the real
+    # block. Existing callers only take max(...) by length so they never
+    # noticed; keying by name needs the comments gone first.
+    bare = re.sub(r"/\*.*?\*/", " ", _THEME_CSS.read_text(), flags=re.S)
+    missing = _DENSITY_TOKENS - _blocks(bare)[":root"]
+    assert not missing, f"theme.css :root does not declare {sorted(missing)}"
 
 
 def test_kit_defines_no_token_the_theme_does_not() -> None:
@@ -432,3 +457,86 @@ def test_kit_reference_page_assets_all_exist() -> None:
     assert refs, "kit.html references nothing — did the page lose its head?"
     for ref in refs:
         assert (_KIT_HTML.parent / ref).is_file(), f"kit.html references missing {ref}"
+
+
+def test_status_vocabulary_is_pinned_to_the_kit() -> None:
+    """``geecs_web_theme.STATES`` and ``kit.css`` name the same statuses.
+
+    A mistyped state is the dangerous case and it is silent: a
+    ``data-state="no_data"`` matches no rule, and ``.chip`` still renders a
+    pill with ``border-color:transparent``, inherited colour and a
+    ``currentColor`` dot — a plausible neutral chip that survives both
+    review and the browser. Pinning both directions means the CSS cannot
+    style a status the vocabulary does not have, and the vocabulary cannot
+    name one the CSS does not colour.
+    """
+    import sys
+
+    sys.path.insert(0, str(_REPO / "GeecsWebTheme"))
+    from geecs_web_theme import STATES  # noqa: E402
+
+    kit = _KIT_CSS.read_text()
+    styled = set(re.findall(r'\.chip\[data-state="([\w-]+)"\]', kit))
+    assert styled == set(STATES), (
+        f"kit.css styles {sorted(styled)}; STATES names {sorted(STATES)}"
+    )
+    # Every status also needs the dot form, used where the row label carries
+    # the word instead.
+    dots = set(re.findall(r'\.dot\[data-state="([\w-]+)"\]', kit))
+    assert dots == set(STATES), (
+        f"kit.css dots {sorted(dots)}; STATES names {sorted(STATES)}"
+    )
+
+
+def test_pane_states_are_pinned_to_the_kit() -> None:
+    """No surface names a pane state outside ``PANE_STATES``.
+
+    Unlike the statuses, not every pane state needs its own rule — loading,
+    empty and denied share the neutral ground on purpose, and only error and
+    stale take a colour. So the pin runs one way for the CSS (it may style a
+    subset, never something outside the vocabulary) and strictly for the
+    reference page, which is the copy people will imitate.
+    """
+    import sys
+
+    sys.path.insert(0, str(_REPO / "GeecsWebTheme"))
+    from geecs_web_theme import PANE_STATES, STATES  # noqa: E402
+
+    kit = _KIT_CSS.read_text()
+    styled = set(re.findall(r'\.(?:state|banner)\[data-state="([\w-]+)"\]', kit))
+    unknown = styled - set(PANE_STATES)
+    assert not unknown, (
+        f"kit.css styles pane states {sorted(unknown)} not in PANE_STATES"
+    )
+
+    page = _KIT_HTML.read_text()
+    used = set(re.findall(r'data-state="([\w-]+)"', page))
+    stray = used - set(PANE_STATES) - set(STATES)
+    assert not stray, (
+        f"kit.html uses {sorted(stray)}, which is neither a status nor a pane "
+        "state — a typo here is invisible in a browser"
+    )
+
+
+def test_kit_rules_are_scoped_to_the_kit_class() -> None:
+    """Every kit rule is gated on ``.kit``, so a surface can adopt per page.
+
+    Both surfaces that will adopt this already use several of these class
+    names, one of them load-bearingly: the portal's run page is
+    ``.pane{display:none}`` / ``.pane.on{display:block}`` — its tab
+    mechanism — which ties on specificity with an ungated ``.pane`` here and
+    would be decided by stylesheet order alone. The only ungated selectors
+    allowed are the density blocks (which must hit the root element) and
+    ``body.kit`` itself.
+    """
+    css = _KIT_CSS.read_text()
+    css = re.sub(r"/\*.*?\*/", " ", css, flags=re.S)
+    ungated = []
+    for selector in re.findall(r"(?:^|[}{])\s*([^{}@][^{}]*?)\s*\{", css):
+        for part in (s.strip() for s in selector.split(",")):
+            if not part or part.startswith((":root", "body.kit", ".kit", "@")):
+                continue
+            if re.match(r"^\d|^from$|^to$", part):  # keyframe stops
+                continue
+            ungated.append(part)
+    assert not ungated, f"kit.css rules not scoped to .kit: {sorted(set(ungated))}"

--- a/GeecsWebTheme/tests/test_no_literal_colours.py
+++ b/GeecsWebTheme/tests/test_no_literal_colours.py
@@ -30,11 +30,16 @@ import pytest
 
 _REPO = Path(__file__).resolve().parents[2]
 _THEME_CSS = _REPO / "GeecsWebTheme/geecs_web_theme/static/theme.css"
+_KIT_CSS = _REPO / "GeecsWebTheme/geecs_web_theme/static/kit.css"
+_KIT_HTML = _REPO / "GeecsWebTheme/geecs_web_theme/static/kit.html"
 
 #: The web surfaces bound by the rule. Adding a surface means adding it
 #: here — a new page that skips the tokens should fail loudly, not quietly.
 _SURFACES = [
     "GeecsWebTheme/geecs_web_theme/static/theme.css",
+    "GeecsWebTheme/geecs_web_theme/static/kit.css",
+    "GeecsWebTheme/geecs_web_theme/static/kit.html",
+    "GeecsWebTheme/geecs_web_theme/static/kit.js",
     "GEECS-DataPortal/geecs_portal/templates/base.html",
     "GEECS-DataPortal/geecs_portal/templates/day.html",
     "GEECS-DataPortal/geecs_portal/templates/run.html",
@@ -278,8 +283,27 @@ def test_every_palette_defines_every_token() -> None:
     """
     blocks = _blocks(_THEME_CSS.read_text())
     assert len(blocks) >= 7, f"expected root + 3×(light,dark); found {list(blocks)}"
-    fonts = {"--ff-ui", "--ff-mono", "--ff-prose", "--r"}  # root-only by design
-    expected = max(blocks.values(), key=len) - fonts
+    # Root-only by design: a palette block carries colour, and these are
+    # the typeface and structure defaults every theme shares until one
+    # wants its own. Adding a palette override for one is a deliberate act
+    # — it means that theme reads differently, which is the point — and it
+    # then has to appear in every block, which this test will say.
+    root_only = {
+        "--ff-ui",
+        "--ff-mono",
+        "--ff-prose",
+        "--r",
+        "--r-lg",
+        "--bw",
+        "--tk",
+        "--pad",
+        "--row-h",
+        "--gap",
+        "--shell-max",
+        "--scrim",
+        "--lift",
+    }
+    expected = max(blocks.values(), key=len) - root_only
     for selector, tokens in sorted(blocks.items()):
         missing = expected - tokens
         assert not missing, f"{selector} is missing {sorted(missing)}"
@@ -343,3 +367,68 @@ def test_python_and_boot_script_agree_on_the_theme_list() -> None:
     css = _THEME_CSS.read_text()
     for name in THEMES:
         assert f':root[data-theme="{name}"]' in css, f"{name} has no CSS block"
+
+
+def test_python_and_boot_script_agree_on_the_density_list() -> None:
+    """``geecs_web_theme.DENSITIES`` and ``theme-boot.js`` agree, and the
+    kit implements every density that is not the default.
+
+    Same arrangement as the theme list, for the same reason: the JS stamps
+    the page, the Python is what a host reads, and a third copy of the
+    names lives in the CSS. The default needs no block — it is what
+    ``theme.css`` already defines.
+    """
+    import sys
+
+    sys.path.insert(0, str(_REPO / "GeecsWebTheme"))
+    from geecs_web_theme import DEFAULT_DENSITY, DENSITIES  # noqa: E402
+
+    boot = (_REPO / "GeecsWebTheme/geecs_web_theme/static/theme-boot.js").read_text()
+    js_list = re.findall(
+        r'"(\w+)"', re.search(r"densities:\s*\[([^\]]*)\]", boot).group(1)
+    )
+    js_default = re.search(r'defaultDensity:\s*"(\w+)"', boot).group(1)
+    assert js_list == list(DENSITIES), (js_list, list(DENSITIES))
+    assert js_default == DEFAULT_DENSITY, (js_default, DEFAULT_DENSITY)
+    assert DEFAULT_DENSITY in DENSITIES
+
+    kit = _KIT_CSS.read_text()
+    for name in DENSITIES:
+        if name == DEFAULT_DENSITY:
+            continue
+        assert f':root[data-density="{name}"]' in kit, f"{name} has no kit block"
+
+
+def test_kit_defines_no_token_the_theme_does_not() -> None:
+    """``kit.css`` overrides tokens; it never introduces one.
+
+    This is what keeps ``theme.css`` the single place to look for the
+    vocabulary. The kit legitimately redefines the spacing scale under
+    ``[data-density]`` and ``--shell-max`` on a wide shell — both are
+    overrides of tokens the theme already declares. A *new* name here
+    would be a second authority, and the next surface would have two
+    files to read instead of one.
+    """
+    theme_tokens: set[str] = set()
+    for tokens in _blocks(_THEME_CSS.read_text()).values():
+        theme_tokens |= tokens
+    kit_defined = set(re.findall(r"(--[\w-]+)\s*:", _KIT_CSS.read_text()))
+    introduced = kit_defined - theme_tokens
+    assert not introduced, (
+        f"kit.css introduces {sorted(introduced)} — declare it in theme.css "
+        "so there is one token vocabulary, not two"
+    )
+
+
+def test_kit_reference_page_assets_all_exist() -> None:
+    """Every file ``kit.html`` pulls in sits beside it.
+
+    The page is static and relative on purpose, so it works under any mount
+    prefix. That also means a renamed asset fails silently in a browser —
+    a blank page nobody sees until they open it. Here it fails loudly.
+    """
+    page = _KIT_HTML.read_text()
+    refs = re.findall(r'(?:src|href)="([^"#:]+)"', page)
+    assert refs, "kit.html references nothing — did the page lose its head?"
+    for ref in refs:
+        assert (_KIT_HTML.parent / ref).is_file(), f"kit.html references missing {ref}"

--- a/GeecsWebTheme/tests/test_no_literal_colours.py
+++ b/GeecsWebTheme/tests/test_no_literal_colours.py
@@ -476,13 +476,13 @@ def test_status_vocabulary_is_pinned_to_the_kit() -> None:
     from geecs_web_theme import STATES  # noqa: E402
 
     kit = _KIT_CSS.read_text()
-    styled = set(re.findall(r'\.chip\[data-state="([\w-]+)"\]', kit))
+    styled = set(re.findall(r'\.chip\[data-state=["\']([\w-]+)["\']\]', kit))
     assert styled == set(STATES), (
         f"kit.css styles {sorted(styled)}; STATES names {sorted(STATES)}"
     )
     # Every status also needs the dot form, used where the row label carries
     # the word instead.
-    dots = set(re.findall(r'\.dot\[data-state="([\w-]+)"\]', kit))
+    dots = set(re.findall(r'\.dot\[data-state=["\']([\w-]+)["\']\]', kit))
     assert dots == set(STATES), (
         f"kit.css dots {sorted(dots)}; STATES names {sorted(STATES)}"
     )
@@ -503,19 +503,73 @@ def test_pane_states_are_pinned_to_the_kit() -> None:
     from geecs_web_theme import PANE_STATES, STATES  # noqa: E402
 
     kit = _KIT_CSS.read_text()
-    styled = set(re.findall(r'\.(?:state|banner)\[data-state="([\w-]+)"\]', kit))
+    styled = set(
+        re.findall(r'\.(?:state|banner)\[data-state=["\']([\w-]+)["\']\]', kit)
+    )
     unknown = styled - set(PANE_STATES)
     assert not unknown, (
         f"kit.css styles pane states {sorted(unknown)} not in PANE_STATES"
     )
 
     page = _KIT_HTML.read_text()
-    used = set(re.findall(r'data-state="([\w-]+)"', page))
+    used = set(re.findall(r'data-state=["\']([\w-]+)["\']', page))
     stray = used - set(PANE_STATES) - set(STATES)
     assert not stray, (
         f"kit.html uses {sorted(stray)}, which is neither a status nor a pane "
         "state — a typo here is invisible in a browser"
     )
+
+
+def _rule_selectors(css: str) -> list[str]:
+    """Every rule selector in a stylesheet, at any nesting depth.
+
+    A regex cannot do this. The first version of the caller used one, and
+    it consumed the ``{`` of each ``@media`` prelude — so the FIRST rule
+    inside every media block lost its anchor and was never examined. Four
+    blocks, four invisible rules, one of them the mobile shell collapse.
+    A brace walk has no such blind spot: at-rule preludes are recognised
+    and skipped, ``@keyframes`` bodies are skipped whole (their ``0%`` and
+    ``from`` stops are not selectors), and everything else yields.
+    """
+    css = re.sub(r"/\*.*?\*/", " ", css, flags=re.S)
+    out: list[str] = []
+
+    def walk(text: str) -> None:
+        i, n = 0, len(text)
+        while i < n:
+            brace = text.find("{", i)
+            if brace == -1:
+                return
+            head = text[i:brace].strip()
+            depth, k = 0, brace
+            while k < n:
+                if text[k] == "{":
+                    depth += 1
+                elif text[k] == "}":
+                    depth -= 1
+                    if depth == 0:
+                        break
+                k += 1
+            body = text[brace + 1 : k]
+            if head.startswith("@keyframes"):
+                pass  # stops are not selectors
+            elif head.startswith("@"):
+                walk(body)  # @media and friends: the rules inside still count
+            else:
+                out.extend(s.strip() for s in head.split(",") if s.strip())
+            i = k + 1
+
+    walk(css)
+    return out
+
+
+#: The only selectors allowed to escape the ``.kit`` scope: the density
+#: blocks, which must match the root element, and the body rule that
+#: carries the class itself.
+_UNSCOPED_OK = re.compile(r'^(?::root\[data-density="[\w-]+"\]|body\.kit)$')
+#: ``.kit`` as a whole class token — ``.kitchen`` is a different class and
+#: must not be waved through by a bare string prefix.
+_KIT_SCOPED = re.compile(r"^\.kit(?![\w-])")
 
 
 def test_kit_rules_are_scoped_to_the_kit_class() -> None:
@@ -525,18 +579,36 @@ def test_kit_rules_are_scoped_to_the_kit_class() -> None:
     names, one of them load-bearingly: the portal's run page is
     ``.pane{display:none}`` / ``.pane.on{display:block}`` — its tab
     mechanism — which ties on specificity with an ungated ``.pane`` here and
-    would be decided by stylesheet order alone. The only ungated selectors
-    allowed are the density blocks (which must hit the root element) and
-    ``body.kit`` itself.
+    would be decided by stylesheet order alone.
     """
-    css = _KIT_CSS.read_text()
-    css = re.sub(r"/\*.*?\*/", " ", css, flags=re.S)
-    ungated = []
-    for selector in re.findall(r"(?:^|[}{])\s*([^{}@][^{}]*?)\s*\{", css):
-        for part in (s.strip() for s in selector.split(",")):
-            if not part or part.startswith((":root", "body.kit", ".kit", "@")):
-                continue
-            if re.match(r"^\d|^from$|^to$", part):  # keyframe stops
-                continue
-            ungated.append(part)
+    ungated = [
+        s
+        for s in _rule_selectors(_KIT_CSS.read_text())
+        if not _KIT_SCOPED.match(s) and not _UNSCOPED_OK.match(s)
+    ]
     assert not ungated, f"kit.css rules not scoped to .kit: {sorted(set(ungated))}"
+
+
+@pytest.mark.parametrize(
+    "css,expected",
+    [
+        # The three shapes the first version of this test waved through.
+        ("@media (max-width:900px){\n  .shell{gap:1px}\n}\n", True),
+        (".kitchen{display:flex}\n", True),
+        (":root .pane{display:flex}\n", True),
+        # …and the legitimate ones stay legitimate.
+        ("@media (max-width:900px){\n  .kit .shell{gap:1px}\n}\n", False),
+        (':root[data-density="compact"]{--pad:9px}\n', False),
+        ("body.kit{margin:0}\n", False),
+        ("@keyframes k{0%,100%{opacity:1}}\n", False),
+        (".kit .panel > header{gap:1px}\n", False),
+    ],
+)
+def test_probe_scoping(css: str, expected: bool) -> None:
+    """Each hole the re-review found, pinned, plus the cases that must pass."""
+    ungated = [
+        s
+        for s in _rule_selectors(css)
+        if not _KIT_SCOPED.match(s) and not _UNSCOPED_OK.match(s)
+    ]
+    assert bool(ungated) is expected, (css, ungated)


### PR DESCRIPTION
## What

`theme.css` settled **colour** and nothing else. Everything structural — the
shell, panels, chips, overlays, empty states — is re-authored per surface, and
the two surfaces that exist disagree about all of it. This PR adds `kit.css`
(plus `kit.js` and a reference page) as the layer that settles the rest.

Measured on `origin/master` before this change:

| | Data Portal | GeecsLogbook |
|---|---|---|
| Shell | `.frame`, grid `17rem`, **no breakpoint at all** | `.shell`, grid `228px`, sticky, collapses @860 |
| Panel | `.sect` / `.bincard`, ad hoc | `.card` + `> header` |
| Overlay | `.overlay`+`.modal` hand-rolled, `.cedrawer` | `<details>`, inline `.composer` |
| Status | `queued running done failed no_data dup` | `ok success fail failed warn aborted incomplete unknown quiet` |
| Radius | `3px` / `4px` / `6px` literals | `var(--r)` |

**0** lines of layout are shared between them; **15** status class names cover
about five states; none of the three overlay mechanisms is a real `<dialog>`,
so the portal's modal has no focus trap and does not close on `Esc`.

The forcing function is the third surface: when the console becomes web-based
it would be a third independent set of answers — and it is the surface with the
hardest requirements (live values, write actions, hazards, keyboard), so it
should set them rather than inherit a compromise from two read-mostly surfaces.

## What is in the kit

- **Shell** — topbar / 216px rail / pane, one breakpoint at 900px.
- **Three containers by role** — `.panel` (a thing with its own state),
  `.group` (no edges; controls belonging to the panel around them), `.well`
  (recessed; output the reader did not write). Border, fill, radius and shadow
  each say *separate object*; spending all four everywhere is why dense screens
  go flat.
- **One status vocabulary** — `queued · running · ok · degraded · failed ·
  unknown`, plus `agent` (not a severity — *who wrote this*). Every chip is a
  dot **and** a word, so colour is never the only carrier.
- **Five pane states** — loading, empty, error, **stale**, **denied**. The last
  two exist on neither surface today and a control surface cannot open without
  them: a live number that silently stops updating is worse than no number.
- **The overlay ladder**, as components rather than prose:
  `details.disc` (0) → `.inspector` (1) → `.drawer` (2) → `<dialog>` (3) →
  a route (4, needs no CSS). Rule: take the lowest rung that fits. Decider:
  *can the user lose work by pressing Esc?* → then it is a route.
- **Density as a viewer preference** — `theme-boot.js` stamps `data-density`
  pre-paint beside the palette; `kit.css` redefines `--pad` / `--row-h` /
  `--gap` under `[data-density="compact"]`.

`kit.html` is the kit's reference page: every component in the real theme, at
whichever palette and density is picked. It is a **static file beside the
stylesheets**, so a host already mounting this package serves it at
`<mount>/kit.html` — the portal gets `/theme/kit.html` with no route of its own.

## Scope

**One concern, and no consumer is touched** — the portal, the logbook and the
config editor are byte-identical after this PR. Adoption is a separate PR per
surface, deliberately: the point of landing the kit alone is that the reference
page can be argued with while changing it is still free.

Per-concern LOC: `kit.css` 447 · `kit.html` 350 · `kit.js` 217 ·
tests +93/−8 · `theme.css` +31 · `__init__.py` +70 · `theme-boot.js` +18 ·
CHANGELOG +44.

**Judgment calls, cheap to veto:**
- Rail width **216px** and a single breakpoint at **900px** — neither surface's
  current number (272px / 228px, 860px). Splitting the difference on the rail;
  900 because 860 clipped the topbar controls at common tablet widths.
- **Six status words**, which collapses `dup` and `no_data` into `degraded` and
  `aborted` into `failed`. If either distinction is load-bearing for you, say so
  and it becomes a seventh word rather than a lost one.
- `--r-lg` **as a separate token from `--r`** rather than deriving it. One value
  cannot say both "26px button" and "full-width card".
- **No facility literals added** (root CLAUDE.md § "Facility values have one
  home") — the kit is generic; the example device names in `kit.html`
  (`U_ICT`, `UC_HASO`) are sample content on a static demo page, not defaults
  in code.

## Tests

`GeecsWebTheme`: **114 passed, exit 0**. `./scripts/check.sh` (scoped) exit 0 —
it selects GeecsWebTheme, which is the only package whose files changed.

New guards:
- the literal-colour test walks `kit.css`, `kit.html` and `kit.js`
- `test_kit_defines_no_token_the_theme_does_not` — the kit *overrides* tokens
  and introduces none, keeping `theme.css` the single vocabulary
- `test_kit_reference_page_assets_all_exist` — a renamed asset fails here
  instead of silently blanking the page in a browser
- `test_python_and_boot_script_agree_on_the_density_list` — density pinned
  across Python, the boot script and the CSS, as the theme list already was

`./scripts/check.sh --all` is env-blocked in a fresh worktree (the other 12
packages have no poetry env there); CI covers them, and this diff cannot reach
them — no consumer file changed.

## Hardware verification

**Not applicable** — no scan-execution, device or gateway surface is touched.
This is a stylesheet, a script and a static page.