### PR TITLE
GeecsLogbook 0.8.0: the log reports the scans, it does not group them

### DIFF
--- a/GeecsLogbook/CHANGELOG.md
+++ b/GeecsLogbook/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Changelog
+
+All notable changes to `geecs-logbook` are documented here. The format
+follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and this
+project adheres to semantic versioning.
+
 ## [0.8.0] - 2026-09-12
 
 ### Removed
@@ -51,12 +57,6 @@
   described the mapping as it was *before* the severity correction —
   claiming `aborted` and `incomplete` share `degraded`. Prose is not
   covered by a test suite; both now say what the code does.
-
-# Changelog
-
-All notable changes to `geecs-logbook` are documented here. The format
-follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and this
-project adheres to semantic versioning.
 
 ## [0.7.0] - 2026-09-12
 

--- a/GeecsLogbook/CHANGELOG.md
+++ b/GeecsLogbook/CHANGELOG.md
@@ -49,14 +49,36 @@ project adheres to semantic versioning.
   else), so invented content must never be seeded into it; but a day with
   no notes shows none of what the page is for, which is how an unstyled
   composer shipped unnoticed. Entries say in their own body that they are
-  seeded, and the script refuses to write to a file that already exists.
+  seeded, and the script refuses to write to a file that already exists —
+  or, on import, to a database that already holds entries for the day.
+
+  One entry is anchored to the day rather than a scan, because it is the
+  only shape that renders whether or not the share is reachable: an anchor
+  naming a scan the day folder does not contain is stored and counted in
+  "Notes N" but never drawn, so seeding on a checkout with no share
+  mounted otherwise produced exactly the empty page the script exists to
+  prevent.
 
 ### Fixed
 
-- The `KIT_STATE` comment and the 0.7.0 changelog entry both still
-  described the mapping as it was *before* the severity correction —
-  claiming `aborted` and `incomplete` share `degraded`. Prose is not
-  covered by a test suite; both now say what the code does.
+- **A dangling selector left `.insert[hidden]` visible.** Removing
+  `.between[hidden]` from `.insert[hidden],.between[hidden]{display:none}`
+  took the declaration block with it, so `.insert[hidden],` merged into the
+  *next* rule and inherited `display:flex`. Clicking "+ note after …" hid
+  nothing: the row stayed on screen above the composer it had just opened,
+  mis-spaced, accumulating until a save reloaded the page. There is no
+  global `[hidden]{display:none}` to fall back on.
+- **The filter left notes between scans floating unlabelled.** Deleting the
+  wrapper removed the only thing that said which gap a note sat in, and the
+  `#q` handler hid scans only — so filtering to one scan left a note from
+  a different gap sitting directly above it, reading as commentary on it.
+  Notes and insert rows now carry the bracketing scan labels as a
+  haystack and hide in the same pass.
+- `editor.js` no longer sets `.open` on the reveal target, which stopped
+  being a `<details>` in this release.
+- Dead after the deletion: `.scanrow .count` (the grouped rail row was its
+  only emitter), and the package `CLAUDE.md`'s "campaign shaping" and
+  "curated campaign record", which named the concept this release removes.
 
 ## [0.7.0] - 2026-09-12
 

--- a/GeecsLogbook/CHANGELOG.md
+++ b/GeecsLogbook/CHANGELOG.md
@@ -1,3 +1,57 @@
+## [0.8.0] - 2026-09-12
+
+### Removed
+
+- **The `Campaign` concept, entirely.** It grouped consecutive scans that
+  shared a `Scan Parameter` and a `ScanStartInfo`, and rendered them in a
+  second collapsible above the scans themselves. Two things were wrong with
+  it. It **inferred** — nothing in `ScanInfo` says those scans belong
+  together — which is the one rule this package already holds itself to
+  ("Status is reported, not inferred": *report what the files say and do
+  not guess*). And it borrowed a word the lab uses for something else: a
+  campaign here is weeks of work, so a day page announcing "Campaigns · 15"
+  was telling an operator it held fifteen multi-week efforts.
+
+  It also did not pay. Measured across four real days, grouping collapsed
+  108 scans into 11 on a sweep day — but on an acceptance run of 21 scans
+  it produced **15 groups, 11 of them wrapping a single scan**, because the
+  threshold asked "is the day long?" when the question was "does grouping
+  help?". Gone: the model, the property, seven CSS classes, the grouped
+  template branch, and the filter and jump logic that had to reach two
+  nesting levels.
+
+  What survives is the honest part: **a long day opens collapsed**, which
+  is a fact about volume, not a claim about meaning.
+
+### Changed
+
+- **A note between two scans is just a note.** It had worn a
+  `<details class="between">` announcing "Between scans" and the range it
+  fell in; that was ceremony, and it made identical content look like a
+  different kind of thing from the same note in the ops book. Now it
+  renders as an ordinary entry at document level, carrying its own
+  timestamp — usually out of step with the scans either side, which is the
+  point. The day reads as what happened, in the order it happened.
+- Notes between scans render **between** scan blocks rather than inside the
+  following one. Under the old grouping a note "after Scan005" was emitted
+  inside Scan006's group.
+
+### Added
+
+- `scripts/seed_demo_notes.py` — worked-example entries for a **separate**
+  database. The store is authoritative (what people wrote exists nowhere
+  else), so invented content must never be seeded into it; but a day with
+  no notes shows none of what the page is for, which is how an unstyled
+  composer shipped unnoticed. Entries say in their own body that they are
+  seeded, and the script refuses to write to a file that already exists.
+
+### Fixed
+
+- The `KIT_STATE` comment and the 0.7.0 changelog entry both still
+  described the mapping as it was *before* the severity correction —
+  claiming `aborted` and `incomplete` share `degraded`. Prose is not
+  covered by a test suite; both now say what the code does.
+
 # Changelog
 
 All notable changes to `geecs-logbook` are documented here. The format

--- a/GeecsLogbook/CHANGELOG.md
+++ b/GeecsLogbook/CHANGELOG.md
@@ -76,6 +76,16 @@ project adheres to semantic versioning.
   haystack and hide in the same pass.
 - `editor.js` no longer sets `.open` on the reveal target, which stopped
   being a `<details>` in this release.
+- **The filter and the editor were writing the same property.** `editor.js`
+  uses `hidden` on an insert row to mean "this one has been used"; the new
+  filter wrote `hidden` too, so clearing the box un-hid every used row and
+  put the affordance back above the composer it had just opened. Filtering
+  moved to its own `data-filtered` channel.
+- **Filtering by a scan parameter hid every note on the page.** The
+  bracketing-label haystack held only two labels, while a scan's held its
+  parameter, purpose and devices — so typing the string the rail prints in
+  every row left all the scans and hid all the notes, and nothing brought
+  them back. Notes now borrow the haystacks of the scans that bracket them.
 - Dead after the deletion: `.scanrow .count` (the grouped rail row was its
   only emitter), and the package `CLAUDE.md`'s "campaign shaping" and
   "curated campaign record", which named the concept this release removes.

--- a/GeecsLogbook/CLAUDE.md
+++ b/GeecsLogbook/CLAUDE.md
@@ -1,7 +1,7 @@
 # GeecsLogbook — Developer Context for Claude
 
 The logbook: two books in one store. The **scans** book is the curated
-campaign record — a day document over scan folders, the successor to
+per-scan record — a day document over scan folders, the successor to
 `LogMaker4GoogleDocs`, which this package will eventually replace
 outright. The **ops** book is routine operations, read by month. They
 share every mechanism below and differ only in which page you write from.
@@ -61,7 +61,7 @@ the folder (the analysis task queue's `analysis_status/`, for one) moves it,
 and it has been measured over an hour off the real start.
 
 What this package owns is the *logbook's* reading of those facts: the status
-classification, campaign shaping, and the day document.
+classification, day shaping, and the day document.
 
 Pinned by `tests/test_scan_reader.py::TestScanFolderCreationInvariant`, which
 monkeypatches `Path.mkdir` to explode.

--- a/GeecsLogbook/geecs_logbook/models.py
+++ b/GeecsLogbook/geecs_logbook/models.py
@@ -127,57 +127,6 @@ class ScanSummary(BaseModel):
         return f"Scan{self.number:03d}"
 
 
-class Campaign(BaseModel):
-    """A run of consecutive scans sharing a parameter and a purpose.
-
-    A busy day is a handful of campaigns, not a hundred unrelated scans:
-    an operator sweeps one variable for twenty scans, changes something,
-    sweeps another. Grouping is *derived* from what the scanner already
-    wrote — nobody declares a campaign — so it costs no new input and
-    cannot be forgotten.
-
-    Attributes
-    ----------
-    parameter : str or None
-        The shared ``Scan Parameter``.
-    purpose : str or None
-        The shared ``ScanStartInfo``.
-    scans : list of ScanSummary
-        The run, in scan order.
-    """
-
-    parameter: Optional[str] = None
-    purpose: Optional[str] = None
-    scans: list["ScanSummary"] = Field(default_factory=list)
-
-    @property
-    def span(self) -> str:
-        """Return the scan range, e.g. ``"Scan012–Scan033"``."""
-        first, last = self.scans[0], self.scans[-1]
-        if first.number == last.number:
-            return first.label
-        return f"{first.label}\u2013{last.label}"
-
-    @property
-    def failed(self) -> int:
-        """Return how many scans in this campaign failed."""
-        return sum(1 for s in self.scans if s.status == "failed")
-
-    @property
-    def is_empty_run(self) -> bool:
-        """Whether this run is folders with no scan metadata at all.
-
-        A real day carries these: folders claimed by a scan that never
-        wrote ``ScanInfo`` — an aborted run, or development churn. They
-        group together because they share ``(None, None)``, which is the
-        right outcome (one row, not sixty-five) but needs saying plainly
-        rather than rendering as an em dash and "No purpose recorded".
-        """
-        return self.parameter is None and all(
-            s.status == "incomplete" and not s.has_scan_info for s in self.scans
-        )
-
-
 class DaySummary(BaseModel):
     """Every scan folder present for one date.
 
@@ -207,27 +156,3 @@ class DaySummary(BaseModel):
     def failed(self) -> int:
         """Return how many scans on this day ended in a failure."""
         return sum(1 for s in self.scans if s.status == "failed")
-
-    @property
-    def campaigns(self) -> list[Campaign]:
-        """Group consecutive scans sharing a parameter and purpose.
-
-        Returns
-        -------
-        list of Campaign
-            One entry per run, in scan order. A day of unrelated scans
-            yields one single-scan campaign each, which is why the view
-            only groups above a threshold — see ``day.html``.
-        """
-        runs: list[Campaign] = []
-        for scan in self.scans:
-            key = (scan.parameter, scan.purpose)
-            if runs and (runs[-1].parameter, runs[-1].purpose) == key:
-                runs[-1].scans.append(scan)
-            else:
-                runs.append(
-                    Campaign(
-                        parameter=scan.parameter, purpose=scan.purpose, scans=[scan]
-                    )
-                )
-        return runs

--- a/GeecsLogbook/geecs_logbook/scan_reader.py
+++ b/GeecsLogbook/geecs_logbook/scan_reader.py
@@ -8,7 +8,7 @@ simply there on the next call.
 What this module owns, and what it borrows
 ------------------------------------------
 It owns the *logbook's* view of a scan: the status classification and the
-day/campaign shaping. The parsing primitives live one layer down in
+day shaping. The parsing primitives live one layer down in
 ``geecs_data_utils``, which already owns scan folders, so there is one
 surface to fix when the formats change:
 

--- a/GeecsLogbook/geecs_logbook/static/editor.js
+++ b/GeecsLogbook/geecs_logbook/static/editor.js
@@ -459,7 +459,7 @@
       const after = b.closest("[data-insert]").dataset.insert;
       const hostEl = document.querySelector(`[data-between-host="${after}"]`);
       if (hostEl) {
-        hostEl.hidden = false; hostEl.open = true; b.closest("[data-insert]").hidden = true;
+        hostEl.hidden = false; b.closest("[data-insert]").hidden = true;
         const ta = hostEl.querySelector(".ta"); if (ta) ta.focus();
       }
       return;

--- a/GeecsLogbook/geecs_logbook/static/scanlog.css
+++ b/GeecsLogbook/geecs_logbook/static/scanlog.css
@@ -69,10 +69,6 @@ svg{display:block;max-width:100%}
 .entry-body code{font-family:var(--ff-mono);font-size:12.5px;background:var(--surface-2);padding:1px 4px;border-radius:3px}
 .entry-body img{max-width:min(100%,430px);border:1px solid var(--rule);border-radius:4px;margin:8px 0 4px;display:block}
 .entry-body strong{font-weight:600}
-/* interscan block — deliberately NOT a card: it sits between things */
-.between{display:flex;flex-direction:column;gap:0;border-left:2px solid var(--agent-rule);
-  background:var(--surface);border-radius:0 var(--r) var(--r) 0;border-top:1px solid var(--rule);
-  border-right:1px solid var(--rule);border-bottom:1px solid var(--rule);overflow:hidden}
 /* insert affordance */
 .insert{display:flex;align-items:center;gap:10px;padding:2px 0}
 @media (prefers-reduced-motion:reduce){*{transition:none!important}}
@@ -97,28 +93,6 @@ details.scan[open] > .scanhead .twisty{transform:rotate(45deg)}
 .foot{color:var(--muted);font-size:12.5px;margin:4px 0 0}
 details.scan[hidden]{display:none}
 
-/* ---- campaigns: consecutive scans sharing a parameter and purpose ---- */
-.campaign{background:var(--surface);border:1px solid var(--rule);
-  border-radius:var(--r);box-shadow:var(--shadow);overflow:hidden}
-.camphead{display:flex;align-items:center;gap:12px;flex-wrap:wrap;padding:13px 16px;
-  cursor:pointer;list-style:none;user-select:none;background:var(--surface-2)}
-.camphead::-webkit-details-marker{display:none}
-.camphead:hover{background:var(--accent-soft)}
-.camphead:focus-visible{outline:2px solid var(--accent);outline-offset:-2px}
-details.campaign[open] > .camphead{border-bottom:1px solid var(--rule)}
-details.campaign[open] > .camphead .twisty{transform:rotate(45deg)}
-.campspan{font-family:var(--ff-mono);font-size:13.5px;font-weight:600;
-  font-variant-numeric:tabular-nums;white-space:nowrap}
-.campcount{font-family:var(--ff-mono);font-size:10.5px;letter-spacing:.05em;
-  text-transform:uppercase;color:var(--muted);white-space:nowrap}
-.campparam{font-family:var(--ff-mono);font-size:12px;color:var(--accent);
-  white-space:nowrap;overflow:hidden;text-overflow:ellipsis;max-width:100%}
-.camppurpose{font-size:13px;color:var(--slate);flex:1 1 180px;min-width:0;
-  overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
-.campbody{display:flex;flex-direction:column;padding:10px 12px 12px;gap:8px;
-  background:var(--paper)}
-.campbody .panel{box-shadow:none}
-details.campaign[hidden]{display:none}
 .scanrow .count{font-family:var(--ff-mono);font-size:10.5px;color:var(--muted);
   font-variant-numeric:tabular-nums}
 
@@ -134,7 +108,6 @@ details.campaign[hidden]{display:none}
 .stepday:hover{border-color:var(--accent);color:var(--accent)}
 .todaylink{display:inline-block;font-size:11.5px;margin-bottom:9px}
 .day.future{opacity:.45}
-.camppurpose.none{color:var(--muted);font-style:italic}
 .scantime.approx{color:var(--muted);font-style:italic}
 
 
@@ -207,23 +180,12 @@ details.campaign[hidden]{display:none}
 
 /* the day intro and interscan blocks */
 .panel.intro .scanhead{cursor:default}
-.between{border-left:2px solid var(--agent-rule);background:var(--surface);border-radius:0 var(--r) var(--r) 0;
-  border-top:1px solid var(--rule);border-right:1px solid var(--rule);border-bottom:1px solid var(--rule);overflow:hidden}
-.between > summary{display:flex;align-items:center;gap:10px;flex-wrap:wrap;padding:9px 16px;background:var(--surface-2);cursor:pointer;list-style:none}
-.between > summary::-webkit-details-marker{display:none}
-.between > summary::before{content:"\25B8";color:var(--muted);font-size:11px;transition:transform .12s}
-.between[open] > summary::before{transform:rotate(90deg)}
-.between .count{margin-left:auto;font-family:var(--ff-mono);font-size:11px;color:var(--muted)}
-.between .tlabel{font-family:var(--ff-mono);font-size:11px;letter-spacing:.06em;text-transform:uppercase;color:var(--agent);font-weight:600}
-.between .trange{font-family:var(--ff-mono);font-size:11px;color:var(--muted)}
-.between .entries{border-top:0}
 .insert{display:flex;align-items:center;gap:10px;padding:0}
 .insert-rule{flex:1;height:1px;background:var(--rule)}
 .insert-btn{border:1px solid var(--rule);background:var(--surface);color:var(--muted);font:inherit;font-size:11.5px;
   border-radius:20px;padding:2px 11px;cursor:pointer}
 .insert-btn:hover{border-color:var(--accent);color:var(--accent)}
-.insert[hidden],.between[hidden]{display:none}
-
+.insert[hidden],
 /* the editor: toolbar, preview, drop target, and the image grid */
 .toolbar{display:flex;gap:2px;flex-wrap:wrap;margin-bottom:5px}
 .tool{font:inherit;font-size:11.5px;color:var(--slate);background:var(--surface);border:1px solid var(--rule);

--- a/GeecsLogbook/geecs_logbook/static/scanlog.css
+++ b/GeecsLogbook/geecs_logbook/static/scanlog.css
@@ -93,8 +93,6 @@ details.scan[open] > .scanhead .twisty{transform:rotate(45deg)}
 .foot{color:var(--muted);font-size:12.5px;margin:4px 0 0}
 details.scan[hidden]{display:none}
 
-.scanrow .count{font-family:var(--ff-mono);font-size:10.5px;color:var(--muted);
-  font-variant-numeric:tabular-nums}
 
 /* ---- day navigation ---- */
 .daypick{display:flex;align-items:center;gap:5px;margin-bottom:7px}
@@ -185,7 +183,12 @@ details.scan[hidden]{display:none}
 .insert-btn{border:1px solid var(--rule);background:var(--surface);color:var(--muted);font:inherit;font-size:11.5px;
   border-radius:20px;padding:2px 11px;cursor:pointer}
 .insert-btn:hover{border-color:var(--accent);color:var(--accent)}
-.insert[hidden],
+/* On its own line, not merged into a list whose block was deleted with the
+   rule that followed it: a dangling `.insert[hidden],` swallowed the NEXT
+   rule's block, so a hidden insert row inherited display:flex and stayed
+   on screen. There is no global [hidden]{display:none} to fall back on. */
+.insert[hidden],.betweens[hidden]{display:none}
+
 /* the editor: toolbar, preview, drop target, and the image grid */
 .toolbar{display:flex;gap:2px;flex-wrap:wrap;margin-bottom:5px}
 .tool{font:inherit;font-size:11.5px;color:var(--slate);background:var(--surface);border:1px solid var(--rule);

--- a/GeecsLogbook/geecs_logbook/static/scanlog.css
+++ b/GeecsLogbook/geecs_logbook/static/scanlog.css
@@ -188,6 +188,12 @@ details.scan[hidden]{display:none}
    rule's block, so a hidden insert row inherited display:flex and stayed
    on screen. There is no global [hidden]{display:none} to fall back on. */
 .insert[hidden],.betweens[hidden]{display:none}
+/* The filter uses its OWN channel. editor.js writes `hidden` on an insert
+   row to mean "this one has been used"; a filter that also wrote `hidden`
+   un-hid every used row the moment the box was cleared, putting the
+   affordance back above the composer it had just opened. Two meanings,
+   two attributes. */
+[data-filtered]{display:none!important}
 
 /* the editor: toolbar, preview, drop target, and the image grid */
 .toolbar{display:flex;gap:2px;flex-wrap:wrap;margin-bottom:5px}

--- a/GeecsLogbook/geecs_logbook/static/scanlog.css
+++ b/GeecsLogbook/geecs_logbook/static/scanlog.css
@@ -91,7 +91,6 @@ details.scan[open] > .scanhead .twisty{transform:rotate(45deg)}
   border-radius:var(--r);padding:16px;margin:0}
 .empty code{font-family:var(--ff-mono);font-size:12.5px}
 .foot{color:var(--muted);font-size:12.5px;margin:4px 0 0}
-details.scan[hidden]{display:none}
 
 
 /* ---- day navigation ---- */
@@ -193,7 +192,7 @@ details.scan[hidden]{display:none}
    un-hid every used row the moment the box was cleared, putting the
    affordance back above the composer it had just opened. Two meanings,
    two attributes. */
-[data-filtered]{display:none!important}
+#logbook [data-filtered]{display:none}
 
 /* the editor: toolbar, preview, drop target, and the image grid */
 .toolbar{display:flex;gap:2px;flex-wrap:wrap;margin-bottom:5px}

--- a/GeecsLogbook/geecs_logbook/store.py
+++ b/GeecsLogbook/geecs_logbook/store.py
@@ -306,7 +306,7 @@ class NotesStore:
         month view (a book, a range, a tag), a search, and later a
         synchroniser. ``day_from``/``day_to`` are inclusive ``YYYY-MM-DD``.
         ``include_scan_anchored=False`` drops entries on or after a scan,
-        which is how the month page hides the campaign record by default.
+        which is how the month page hides the per-scan record by default.
         """
         sql = "SELECT * FROM entries WHERE day BETWEEN ? AND ? AND deleted_at IS NULL"
         params: list[object] = [day_from, day_to]

--- a/GeecsLogbook/geecs_logbook/templates/day.html
+++ b/GeecsLogbook/geecs_logbook/templates/day.html
@@ -56,9 +56,15 @@
   {% set anchor = 'after-%04d' % after %}
   {% set es = entries.get(anchor, []) %}
   {% if es %}
-  {{ entries_block(anchor, none, after, entries, writable) }}
+  {# data-hay so the filter reaches these too. Deleting the wrapper removed
+     the only thing that said which gap a note sat in, so a filtered page
+     used to leave an unlabelled note floating above whichever scan
+     survived — reading as commentary on a scan it has nothing to do with. #}
+  <div class="betweens" data-hay="{{ (prev_label ~ ' ' ~ next_label) | lower }}">
+    {{ entries_block(anchor, none, after, entries, writable) }}
+  </div>
   {% elif writable %}
-  <div class="insert" data-insert="{{ after }}">
+  <div class="insert" data-insert="{{ after }}" data-hay="{{ (prev_label ~ ' ' ~ next_label) | lower }}">
     <div class="insert-rule"></div>
     <button class="insert-btn" type="button">+ note after {{ prev_label }}</button>
     <div class="insert-rule"></div>
@@ -294,8 +300,8 @@ document.getElementById("daypicker").addEventListener("change", ev => {
    the box puts the page back exactly as it was. */
 document.getElementById("q").addEventListener("input", ev => {
   const f = ev.target.value.trim().toLowerCase();
-  const blocks = [...document.querySelectorAll("details.scan")];
-  blocks.forEach(c => { c.hidden = !!f && !c.dataset.hay.includes(f); });
+  const blocks = [...document.querySelectorAll("details.scan, .betweens, .insert")];
+  blocks.forEach(c => { c.hidden = !!f && !(c.dataset.hay || "").includes(f); });
 });
 
 /* Jumping from the rail should reveal what you jumped to. */

--- a/GeecsLogbook/geecs_logbook/templates/day.html
+++ b/GeecsLogbook/geecs_logbook/templates/day.html
@@ -44,28 +44,29 @@
   {% endif %}
 {% endmacro %}
 
+{# A note between two scans is just a note. It carries its own timestamp,
+   which is usually out of step with the scans on either side, and that is
+   the point — the day reads as what happened in the order it happened.
+
+   It used to wear a <details class="between"> wrapper announcing "Between
+   scans" and the range it fell in. That was ceremony: where the entry sits
+   already says where it sits, and the wrapper made the same content look
+   like a different kind of thing from the identical note in the ops book. #}
 {% macro between_block(after, entries, writable, prev_label, next_label) %}
   {% set anchor = 'after-%04d' % after %}
   {% set es = entries.get(anchor, []) %}
   {% if es %}
-  <details class="between" open>
-    <summary><span class="tlabel">Between scans</span>
-      <span class="trange">{{ prev_label }} &rarr; {{ next_label }}</span>
-      <span class="count">{{ es | length }} note{{ '' if es | length == 1 else 's' }}</span></summary>
-    {{ entries_block(anchor, none, after, entries, writable) }}
-  </details>
+  {{ entries_block(anchor, none, after, entries, writable) }}
   {% elif writable %}
   <div class="insert" data-insert="{{ after }}">
     <div class="insert-rule"></div>
-    <button class="insert-btn" type="button">+ note between {{ prev_label }} and {{ next_label }}</button>
+    <button class="insert-btn" type="button">+ note after {{ prev_label }}</button>
     <div class="insert-rule"></div>
   </div>
-  <details class="between" hidden data-between-host="{{ after }}">
-    <summary><span class="tlabel">Between scans</span>
-      <span class="trange">{{ prev_label }} &rarr; {{ next_label }}</span>
-      <span class="count">new note</span></summary>
+  {# editor.js reveals this when the button above is used. #}
+  <div hidden data-between-host="{{ after }}">
     {{ entries_block(anchor, none, after, entries, writable) }}
-  </details>
+  </div>
   {% endif %}
 {% endmacro %}
 
@@ -125,6 +126,9 @@
   </details>
 {% endmacro %}
 
+{# Volume only: a long day opens collapsed so it reads as a list.
+   This is a fact about how many scans there are, not a claim about
+   what they were for. #}
 {% set many = summary.scans | length > 20 %}
 
 <div class="topbar">
@@ -179,28 +183,15 @@
 
     {% if summary.scans %}
     <section>
-      <h4>{{ 'Campaigns' if many else 'Scans' }} ·
-        {{ summary.campaigns | length if many else summary.scans | length }}</h4>
+      <h4>Scans &middot; {{ summary.scans | length }}</h4>
       <nav class="picklist">
-        {% if many %}
-          {% for c in summary.campaigns %}
-          <a class="scanrow" href="#{{ c.scans[0].label }}">
-            <span class="dot" data-state="{{ kit_state['failed' if c.failed else c.scans[0].status] }}"
-                  aria-hidden="true"></span>
-            <span class="id">{{ '%03d' % c.scans[0].number }}</span>
-            <span class="lbl">{{ c.parameter or '—' }}</span>
-            <span class="count">{{ c.scans | length }}</span>
-          </a>
-          {% endfor %}
-        {% else %}
-          {% for s in summary.scans %}
+        {% for s in summary.scans %}
           <a class="scanrow" href="#{{ s.label }}">
             <span class="dot" data-state="{{ kit_state[s.status] }}" aria-hidden="true"></span>
             <span class="id">{{ '%03d' % s.number }}</span>
             <span class="lbl">{{ s.parameter or '—' }}</span>
           </a>
-          {% endfor %}
-        {% endif %}
+        {% endfor %}
       </nav>
     </section>
     {% endif %}
@@ -248,38 +239,14 @@
     {% endif %}
 
     {% set ns = namespace(prev=0, prev_label='the start of the day') %}
-    {% if many %}
-      {% for c in summary.campaigns %}
-      <details class="campaign" {% if c.scans | length == 1 %}open{% endif %}>
-        <summary class="camphead">
-          <span class="twisty" aria-hidden="true"></span>
-          <span class="campspan">{{ c.span }}</span>
-          <span class="campcount">{{ c.scans | length }}
-            scan{{ '' if c.scans | length == 1 else 's' }}</span>
-          {% if c.is_empty_run %}
-          <span class="camppurpose none">No scan metadata &mdash; folders only</span>
-          {% else %}
-          <span class="campparam">{{ c.parameter or '—' }}</span>
-          <span class="camppurpose">{{ c.purpose or 'No purpose recorded' }}</span>
-          {% endif %}
-          {% if c.failed %}<span class="chip" data-state="failed">{{ c.failed }} failed</span>{% endif %}
-        </summary>
-        <div class="campbody">
-          {% for s in c.scans %}
-            {{ between_block(ns.prev, entries, writable, ns.prev_label, s.label) }}
-            {{ scan_block(s, false, entries, writable) }}
-            {% set ns.prev = s.number %}{% set ns.prev_label = s.label %}
-          {% endfor %}
-        </div>
-      </details>
-      {% endfor %}
-    {% else %}
-      {% for s in summary.scans %}
-        {{ between_block(ns.prev, entries, writable, ns.prev_label, s.label) }}
-        {{ scan_block(s, true, entries, writable) }}
-        {% set ns.prev = s.number %}{% set ns.prev_label = s.label %}
-      {% endfor %}
-    {% endif %}
+    {# These are the scans that happened, in the order they happened. The
+       log reports them; it does not group them by what it thinks they were
+       for. Notes fall between them wherever their timestamps put them. #}
+    {% for s in summary.scans %}
+      {{ between_block(ns.prev, entries, writable, ns.prev_label, s.label) }}
+      {{ scan_block(s, not many, entries, writable) }}
+      {% set ns.prev = s.number %}{% set ns.prev_label = s.label %}
+    {% endfor %}
 
     {% if summary.scans %}
       {{ between_block(ns.prev, entries, writable, ns.prev_label, 'the end of the day') }}
@@ -297,10 +264,10 @@
    home for it — it never needs to reach another viewer or the server. */
 const KEY = "scanlog.expandAll";
 const btn = document.getElementById("toggle-all");
-/* Expand/collapse reaches BOTH levels: opening only the campaigns left
-   every scan inside them shut, so the button appeared not to work. */
-const cards = () => [...document.querySelectorAll(
-  "details.campaign, details.scan, details.between")];
+/* One level now: every scan is its own block at the top of the document,
+   and a note between scans is an ordinary entry rather than a container
+   to open. */
+const cards = () => [...document.querySelectorAll("details.scan")];
 
 function applyAll(expand){
   cards().forEach(c => { if (!c.hidden) c.open = expand; });
@@ -329,14 +296,6 @@ document.getElementById("q").addEventListener("input", ev => {
   const f = ev.target.value.trim().toLowerCase();
   const blocks = [...document.querySelectorAll("details.scan")];
   blocks.forEach(c => { c.hidden = !!f && !c.dataset.hay.includes(f); });
-  /* A campaign disappears only when every scan in it is filtered out, and
-     opens automatically so matches inside it are actually visible. */
-  document.querySelectorAll("details.campaign").forEach(camp => {
-    const kids = [...camp.querySelectorAll("details.scan")];
-    const any = kids.some(k => !k.hidden);
-    camp.hidden = !any;
-    if (f && any) camp.open = true;
-  });
 });
 
 /* Jumping from the rail should reveal what you jumped to. */
@@ -344,8 +303,6 @@ document.querySelectorAll(".scanrow").forEach(a => a.addEventListener("click", (
   const el = document.querySelector(a.getAttribute("href"));
   if (!el) return;
   el.open = true;
-  const camp = el.closest("details.campaign");
-  if (camp) camp.open = true;
 }));
 </script>
 {{ shared.seeds_json(seeds) }}

--- a/GeecsLogbook/geecs_logbook/templates/day.html
+++ b/GeecsLogbook/geecs_logbook/templates/day.html
@@ -286,7 +286,11 @@ const btn = document.getElementById("toggle-all");
 const cards = () => [...document.querySelectorAll("details.scan")];
 
 function applyAll(expand){
-  cards().forEach(c => { if (!c.hidden) c.open = expand; });
+  /* Visible ones only. The guard used to read `hidden`, which the filter
+     wrote; moving filtering to data-filtered made it inert and silently
+     widened "Expand all" from the scans you can see to every scan on the
+     page. Nobody decided that, so it goes back. */
+  cards().forEach(c => { if (!c.dataset.filtered) c.open = expand; });
   btn.dataset.expanded = String(expand);
   btn.textContent = expand ? "Collapse all" : "Expand all";
   try { localStorage.setItem(KEY, String(expand)); } catch (e) {}

--- a/GeecsLogbook/geecs_logbook/templates/day.html
+++ b/GeecsLogbook/geecs_logbook/templates/day.html
@@ -52,7 +52,7 @@
    scans" and the range it fell in. That was ceremony: where the entry sits
    already says where it sits, and the wrapper made the same content look
    like a different kind of thing from the identical note in the ops book. #}
-{% macro between_block(after, entries, writable, prev_label, next_label) %}
+{% macro between_block(after, entries, writable, prev_label, next_label, hay='') %}
   {% set anchor = 'after-%04d' % after %}
   {% set es = entries.get(anchor, []) %}
   {% if es %}
@@ -60,25 +60,32 @@
      the only thing that said which gap a note sat in, so a filtered page
      used to leave an unlabelled note floating above whichever scan
      survived — reading as commentary on a scan it has nothing to do with. #}
-  <div class="betweens" data-hay="{{ (prev_label ~ ' ' ~ next_label) | lower }}">
+  <div class="betweens" data-hay="{{ (prev_label ~ ' ' ~ next_label ~ ' ' ~ hay) | lower }}">
     {{ entries_block(anchor, none, after, entries, writable) }}
   </div>
   {% elif writable %}
-  <div class="insert" data-insert="{{ after }}" data-hay="{{ (prev_label ~ ' ' ~ next_label) | lower }}">
+  <div class="insert" data-insert="{{ after }}" data-hay="{{ (prev_label ~ ' ' ~ next_label ~ ' ' ~ hay) | lower }}">
     <div class="insert-rule"></div>
     <button class="insert-btn" type="button">+ note after {{ prev_label }}</button>
     <div class="insert-rule"></div>
   </div>
   {# editor.js reveals this when the button above is used. #}
-  <div hidden data-between-host="{{ after }}">
+  <div hidden data-between-host="{{ after }}"
+       data-hay="{{ (prev_label ~ ' ' ~ next_label ~ ' ' ~ hay) | lower }}">
     {{ entries_block(anchor, none, after, entries, writable) }}
   </div>
   {% endif %}
 {% endmacro %}
 
+{# One definition of what a scan matches on, so a note bracketed by two
+   scans can borrow theirs. Filtering by the parameter — the string the
+   rail prints in every row — used to hide every note on the page while
+   leaving all the scans, because a note's hay held only the two labels. #}
+{% macro scan_hay(s) %}{{ (s.label ~ ' ' ~ (s.parameter or '') ~ ' ' ~ (s.purpose or '') ~ ' ' ~ s.devices|join(' ')) | lower }}{% endmacro %}
+
 {% macro scan_block(s, expanded, entries, writable) %}
   <details class="panel scan" id="{{ s.label }}"
-           data-hay="{{ (s.label ~ ' ' ~ (s.parameter or '') ~ ' ' ~ (s.purpose or '') ~ ' ' ~ s.devices|join(' ')) | lower }}"
+           data-hay="{{ scan_hay(s) }}"
            {% if expanded %}open{% endif %}>
     <summary class="scanhead">
       <span class="twisty" aria-hidden="true"></span>
@@ -244,18 +251,21 @@
     </section>
     {% endif %}
 
-    {% set ns = namespace(prev=0, prev_label='the start of the day') %}
+    {% set ns = namespace(prev=0, prev_label='the start of the day', prev_hay='') %}
     {# These are the scans that happened, in the order they happened. The
        log reports them; it does not group them by what it thinks they were
        for. Notes fall between them wherever their timestamps put them. #}
     {% for s in summary.scans %}
-      {{ between_block(ns.prev, entries, writable, ns.prev_label, s.label) }}
+      {{ between_block(ns.prev, entries, writable, ns.prev_label, s.label,
+                       ns.prev_hay ~ ' ' ~ scan_hay(s)) }}
       {{ scan_block(s, not many, entries, writable) }}
       {% set ns.prev = s.number %}{% set ns.prev_label = s.label %}
+      {% set ns.prev_hay = scan_hay(s) %}
     {% endfor %}
 
     {% if summary.scans %}
-      {{ between_block(ns.prev, entries, writable, ns.prev_label, 'the end of the day') }}
+      {{ between_block(ns.prev, entries, writable, ns.prev_label,
+                       'the end of the day', ns.prev_hay) }}
     {% endif %}
     {% if not writable %}
     <p class="foot">Read-only: no notes store is configured, so this view renders
@@ -300,8 +310,15 @@ document.getElementById("daypicker").addEventListener("change", ev => {
    the box puts the page back exactly as it was. */
 document.getElementById("q").addEventListener("input", ev => {
   const f = ev.target.value.trim().toLowerCase();
-  const blocks = [...document.querySelectorAll("details.scan, .betweens, .insert")];
-  blocks.forEach(c => { c.hidden = !!f && !(c.dataset.hay || "").includes(f); });
+  const blocks = [...document.querySelectorAll(
+    "details.scan, .betweens, .insert, [data-between-host]")];
+  blocks.forEach(c => {
+    /* data-filtered, never `hidden`: editor.js owns `hidden` on an insert
+       row as its used-flag, and a revealed composer is `hidden=false` for
+       a reason the filter must not overwrite. */
+    if (!!f && !(c.dataset.hay || "").includes(f)) c.dataset.filtered = "1";
+    else delete c.dataset.filtered;
+  });
 });
 
 /* Jumping from the rail should reveal what you jumped to. */

--- a/GeecsLogbook/pyproject.toml
+++ b/GeecsLogbook/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geecs-logbook"
-version = "0.7.0"
+version = "0.8.0"
 description = "Scan logbook: a day-document view over scan folders, with human commentary stored beside the data"
 authors = ["GEECS-BELLA"]
 readme = "README.md"

--- a/GeecsLogbook/scripts/seed_demo_notes.py
+++ b/GeecsLogbook/scripts/seed_demo_notes.py
@@ -23,6 +23,11 @@ Usage
 ::
 
     poetry run python scripts/seed_demo_notes.py /tmp/demo-notes.db
+
+The scan folders for ``DAY`` must be reachable for the scan-anchored
+entries to appear: an anchor naming a scan the day does not contain is
+stored and counted but never drawn. The day-level entry always renders,
+so it is the check that seeding worked.
     poetry run geecs-portal --scan-log --notes-db /tmp/demo-notes.db
 """
 
@@ -41,6 +46,21 @@ DAY = "2026-09-12"
 #: set, which the store enforces: an entry is anchored to a scan or after
 #: one, never both.
 ENTRIES: list[tuple[int | None, int | None, str, str]] = [
+    # A day-level entry, anchored to neither a scan nor a gap. It is the one
+    # shape that renders whether or not the share is reachable, so it is the
+    # signal that seeding worked: every other entry here hangs off a scan
+    # number, and an anchor naming a scan the day folder does not contain is
+    # accepted, counted in "Notes N", and never drawn.
+    (
+        None,
+        None,
+        "demo",
+        "> [!NOTE] Seeded example day\n"
+        "> Written by `scripts/seed_demo_notes.py`, not by a person.\n\n"
+        "Native-Bluesky phase-2b acceptance. If the scan blocks below are "
+        "missing, the data share for this day is not reachable from here — "
+        "the notes are stored either way.",
+    ),
     # --- the A1 gap: two failures, then a pass, with 18 minutes in between
     (
         None,
@@ -110,8 +130,15 @@ ENTRIES: list[tuple[int | None, int | None, str, str]] = [
 
 
 def seed(db_path: Path) -> int:
-    """Write the example entries into ``db_path`` and return how many."""
+    """Write the example entries into ``db_path`` and return how many.
+
+    Refuses a database that already holds entries: calling this twice on
+    one path silently doubles every row, and the CLI's ``exists()`` guard
+    does not cover an import.
+    """
     store = NotesStore(db_path)
+    if store.for_day(DAY):
+        raise ValueError(f"{db_path} already holds entries for {DAY}")
     for scan, after, author, body in ENTRIES:
         store.create(day=DAY, author=author, body_md=body, scan=scan, after=after)
     return len(ENTRIES)

--- a/GeecsLogbook/scripts/seed_demo_notes.py
+++ b/GeecsLogbook/scripts/seed_demo_notes.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python
+"""Fill a notes database with worked-example entries, for looking at.
+
+Why this exists
+---------------
+The logbook's own store is authoritative: what people wrote exists nowhere
+else, so it must never be seeded with invented content — six months later
+nobody can tell a demo entry from a real one. But a page that renders a
+day with no notes in it shows none of the thing it was built for, which is
+how an unstyled composer and an orphaned container both shipped unnoticed.
+
+So: a *separate* database, written by a script that is obviously a script,
+carrying entries plainly marked as examples. Point a development server at
+it with ``--notes-db``; never point it at the deployed one.
+
+The day it describes is real (the native-Bluesky phase-2b acceptance run),
+because test data shaped like the real thing exercises the real cases —
+long purposes that must ellipsize, a failure reason that must not, notes
+whose timestamps sit between two scans rather than on either.
+
+Usage
+-----
+::
+
+    poetry run python scripts/seed_demo_notes.py /tmp/demo-notes.db
+    poetry run geecs-portal --scan-log --notes-db /tmp/demo-notes.db
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from geecs_logbook.store import NotesStore
+
+#: The day these entries belong to, and the scans they hang off.
+DAY = "2026-09-12"
+
+#: ``(scan, after, author, body)`` — exactly one of ``scan``/``after`` is
+#: set, which the store enforces: an entry is anchored to a scan or after
+#: one, never both.
+ENTRIES: list[tuple[int | None, int | None, str, str]] = [
+    # --- the A1 gap: two failures, then a pass, with 18 minutes in between
+    (
+        None,
+        2,
+        "demo",
+        "> [!NOTE] Example entry\n"
+        "> Seeded by `scripts/seed_demo_notes.py` — not a real record.\n\n"
+        "A1 failed twice on `UC_Amp3_IR_input`: first the save directory "
+        "did not exist, then the HDF capture did not arm inside 10 s.\n\n"
+        "Created the per-scan directory on the camera server and restarted "
+        "the plugin. Third attempt took it.",
+    ),
+    (
+        3,
+        None,
+        "demo",
+        "Clean pass. Both plugin cameras armed on the first trigger.",
+    ),
+    # --- A3 fails, gets parked, comes back much later with a different clock
+    (
+        None,
+        6,
+        "demo",
+        "> [!WARNING] Example entry\n"
+        "> Seeded by `scripts/seed_demo_notes.py` — not a real record.\n\n"
+        "A3 wants a triggered scalar as the shot clock and `U_HP_Daq` never "
+        "produced one inside 3 s.\n\n"
+        "Parking it and moving to A4 rather than burning scan numbers on "
+        "retries. Worth trying a different device as the clock.",
+    ),
+    (
+        None,
+        14,
+        "demo",
+        "> [!TIP] Example entry\n"
+        "> Seeded by `scripts/seed_demo_notes.py` — not a real record.\n\n"
+        "Back to A3 with `U_BCaveICT` as the clock instead of `U_HP_Daq`. "
+        "It ticks on every shot, which is the property the sampler needs.\n\n"
+        "This is the note the scan record structurally cannot hold: the "
+        "28-minute gap above is invisible in `ScanInfo`, and the only "
+        "difference between the failure and the pass is a decision.",
+    ),
+    (
+        15,
+        None,
+        "demo",
+        "A3 passes. Clocked by `U_BCaveICT`.",
+    ),
+    # --- a code bug, which belongs against the scan that hit it
+    (
+        17,
+        None,
+        "demo",
+        "`unsupported operand type(s) for +: 'SignalR' and 'float'` — "
+        "`rel_scan` is adding a float to the signal object rather than to "
+        "its value. A real bug, not a hardware fault.",
+    ),
+    # --- and a note with no scan on either side of it, late in the day
+    (
+        None,
+        21,
+        "demo",
+        "Broader-set scans all green. Stopping here; the two plugin cameras "
+        "on separate servers were the case worth proving.",
+    ),
+]
+
+
+def seed(db_path: Path) -> int:
+    """Write the example entries into ``db_path`` and return how many."""
+    store = NotesStore(db_path)
+    for scan, after, author, body in ENTRIES:
+        store.create(day=DAY, author=author, body_md=body, scan=scan, after=after)
+    return len(ENTRIES)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Seed a demo database named on the command line."""
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "db",
+        type=Path,
+        help="Where to write. Its parent must exist; a name with 'demo' or "
+        "'test' in it is a good habit.",
+    )
+    args = parser.parse_args(argv)
+
+    if args.db.exists():
+        print(f"{args.db} already exists — refusing to add to it", file=sys.stderr)
+        return 1
+    if not args.db.parent.is_dir():
+        print(f"{args.db.parent} is not a directory", file=sys.stderr)
+        return 1
+
+    n = seed(args.db)
+    print(f"wrote {n} example entries for {DAY} to {args.db}")
+    print("point a development server at it with --notes-db; never the deployed one")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - thin CLI wrapper
+    raise SystemExit(main())

--- a/GeecsLogbook/scripts/seed_demo_notes.py
+++ b/GeecsLogbook/scripts/seed_demo_notes.py
@@ -23,21 +23,27 @@ Usage
 ::
 
     poetry run python scripts/seed_demo_notes.py /tmp/demo-notes.db
+    poetry run geecs-portal --scan-log --notes-db /tmp/demo-notes.db
 
 The scan folders for ``DAY`` must be reachable for the scan-anchored
 entries to appear: an anchor naming a scan the day does not contain is
 stored and counted but never drawn. The day-level entry always renders,
 so it is the check that seeding worked.
-    poetry run geecs-portal --scan-log --notes-db /tmp/demo-notes.db
 """
 
 from __future__ import annotations
 
 import argparse
+import sqlite3
 import sys
 from pathlib import Path
 
 from geecs_logbook.store import NotesStore
+
+#: What a deployment names its store (GeecsLogbook/CLAUDE.md, the portal's
+#: state directory). Refused outright: on a fresh host the file does not
+#: exist yet, so an existence check alone lets the worst case through.
+DEPLOYED_DB_NAME = "logbook.db"
 
 #: The day these entries belong to, and the scans they hang off.
 DAY = "2026-09-12"
@@ -132,16 +138,49 @@ ENTRIES: list[tuple[int | None, int | None, str, str]] = [
 def seed(db_path: Path) -> int:
     """Write the example entries into ``db_path`` and return how many.
 
-    Refuses a database that already holds entries: calling this twice on
-    one path silently doubles every row, and the CLI's ``exists()`` guard
-    does not cover an import.
+    Refuses anything that looks like a real store. The checks run *before*
+    :class:`NotesStore` opens the file, because constructing one runs the
+    schema and its column migration on whatever path it is handed — so a
+    guard that consults the store has already touched the thing it meant
+    to protect.
+
+    Two holes an earlier version had, both reachable by import rather than
+    through the CLI: it asked only whether :data:`DAY` had entries, so a
+    store holding a human's notes for every *other* day sailed through;
+    and it ignored tombstones, so re-seeding after a delete doubled the
+    rows.
     """
+    if db_path.name == DEPLOYED_DB_NAME:
+        raise ValueError(
+            f"{db_path} is named {DEPLOYED_DB_NAME}, which is what a deployment "
+            "calls its real store — seed a differently named file"
+        )
+    if db_path.exists() and _holds_anything(db_path):
+        raise ValueError(f"{db_path} already holds entries — seed a fresh file")
+
     store = NotesStore(db_path)
-    if store.for_day(DAY):
-        raise ValueError(f"{db_path} already holds entries for {DAY}")
     for scan, after, author, body in ENTRIES:
         store.create(day=DAY, author=author, body_md=body, scan=scan, after=after)
     return len(ENTRIES)
+
+
+def _holds_anything(db_path: Path) -> bool:
+    """Whether the database has any entry row at all, tombstones included.
+
+    Read-only and schema-free: it opens the file directly rather than
+    through :class:`NotesStore`, so a real store is never migrated by the
+    act of being checked.
+    """
+    conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+    try:
+        rows = conn.execute(
+            "SELECT 1 FROM sqlite_master WHERE type='table' AND name='entries'"
+        ).fetchall()
+        if not rows:
+            return False
+        return conn.execute("SELECT 1 FROM entries LIMIT 1").fetchone() is not None
+    finally:
+        conn.close()
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/GeecsLogbook/scripts/seed_demo_notes.py
+++ b/GeecsLogbook/scripts/seed_demo_notes.py
@@ -155,8 +155,8 @@ def seed(db_path: Path) -> int:
             f"{db_path} is named {DEPLOYED_DB_NAME}, which is what a deployment "
             "calls its real store — seed a differently named file"
         )
-    if db_path.exists() and _holds_anything(db_path):
-        raise ValueError(f"{db_path} already holds entries — seed a fresh file")
+    if db_path.exists() and _is_a_store(db_path):
+        raise ValueError(f"{db_path} is already a notes store — seed a fresh file")
 
     store = NotesStore(db_path)
     for scan, after, author, body in ENTRIES:
@@ -164,21 +164,32 @@ def seed(db_path: Path) -> int:
     return len(ENTRIES)
 
 
-def _holds_anything(db_path: Path) -> bool:
-    """Whether the database has any entry row at all, tombstones included.
+def _is_a_store(db_path: Path) -> bool:
+    """Whether this file is a notes store — not whether it has rows in it.
+
+    Asking about rows was not enough. Mounting ``--notes-db some.db`` on a
+    fresh host creates the file and the ``entries`` table with zero rows,
+    so a row check waved through the live store of a deployment that had
+    started but not yet been written in — exactly the case the reserved
+    filename was added to catch, except ``--notes-db`` takes any path.
 
     Read-only and schema-free: it opens the file directly rather than
-    through :class:`NotesStore`, so a real store is never migrated by the
-    act of being checked.
+    through :class:`NotesStore`, whose constructor would create and
+    migrate the very thing this is protecting.
     """
-    conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
     try:
-        rows = conn.execute(
-            "SELECT 1 FROM sqlite_master WHERE type='table' AND name='entries'"
-        ).fetchall()
-        if not rows:
-            return False
-        return conn.execute("SELECT 1 FROM entries LIMIT 1").fetchone() is not None
+        conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+    except sqlite3.Error:  # pragma: no cover - unreadable path
+        return True  # refuse what we cannot inspect
+    try:
+        return bool(
+            conn.execute(
+                "SELECT 1 FROM sqlite_master WHERE type='table' AND name='entries'"
+            ).fetchone()
+        )
+    except sqlite3.DatabaseError:
+        # Not a SQLite file at all. Refusing beats overwriting it.
+        return True
     finally:
         conn.close()
 

--- a/GeecsLogbook/tests/test_router.py
+++ b/GeecsLogbook/tests/test_router.py
@@ -475,14 +475,11 @@ def _scan_block_parents(html: str) -> set[tuple[str, ...]]:
         def handle_starttag(self, tag, attrs):
             d = dict(attrs)
             if tag == "details" and d.get("class") == "panel scan":
-                below = (
-                    self.stack[self.stack.index("main") + 1 :]
-                    if "main" in self.stack
-                    else tuple(self.stack)
-                )
-                self.found.add(
-                    ("main", *below) if "main" in self.stack else tuple(self.stack)
-                )
+                if "main" in self.stack:
+                    below = self.stack[self.stack.index("main") + 1 :]
+                    self.found.add(("main", *below))
+                else:
+                    self.found.add(tuple(self.stack))
             if tag not in {"br", "img", "input", "meta", "link", "hr"}:
                 self.stack.append(tag)
 
@@ -556,7 +553,21 @@ class TestLongDay:
         # around the loop is the shape a class-attribute check misses.
         assert _scan_block_parents(html) == {("main",)}, _scan_block_parents(html)
 
-    def test_the_rail_lists_scans(self, busy: TestClient) -> None:
-        """The rail names scans, never a grouping of them."""
+    def test_the_rail_lists_scans_and_nothing_else(self, busy: TestClient) -> None:
+        """The rail names scans, one row each, and groups nothing.
+
+        The document-structure check above pins the body — but a grouping
+        can come back without wrapping anything, as a rail section listing
+        runs. That is not a hypothetical: it is the shape this change
+        singles out as the harmful one, because "Campaigns · 15" rendered
+        in the rail and told an operator the day held fifteen multi-week
+        efforts. Verified by putting exactly that back and watching the
+        suite stay green.
+
+        So: one row per scan, and the rail's headings are exactly the two
+        it is allowed to have.
+        """
         html = busy.get("/log/day/2026-09-11").text
-        assert "Scans &middot; 25" in html or "Scans · 25" in html
+        assert html.count('class="scanrow"') == 25
+        headings = {h.strip() for h in re.findall(r"<h4>(.*?)</h4>", html, re.S)}
+        assert headings == {"Go to a day", "Scans &middot; 25"}, headings

--- a/GeecsLogbook/tests/test_router.py
+++ b/GeecsLogbook/tests/test_router.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import re
+
 import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
@@ -461,19 +463,51 @@ class TestLongDay:
     The grouped view this replaced inferred which scans belonged together
     from two matching fields. That is interpretation, and the logbook's
     rule is that it reports what the files say. What survives is the only
-    honest part of the old behaviour: past a certain number of scans the
-    day is easier to read as a closed list.
+    honest part of the old behaviour: past a threshold the day is easier
+    to read as a closed list.
+
+    The first version of this class took the four-scan fixture, so ``many``
+    was false in every test and it asserted nothing about collapsing at
+    all — replacing the threshold with a literal ``false`` left the whole
+    suite green. It needs a day that actually crosses the line.
     """
 
-    def test_a_long_day_renders_every_scan_at_the_top_level(
-        self, client: TestClient
-    ) -> None:
-        """No wrapper groups them; each scan is its own block."""
-        html = client.get("/log/day/2026-09-11").text
-        assert "campaign" not in html
-        assert html.count('<details class="panel scan"') == 4
+    @pytest.fixture
+    def busy(self, make_run) -> TestClient:
+        """A client over a day of 25 scans — past the 20 threshold."""
+        app = FastAPI()
+        app.include_router(
+            create_log_router("Undulator", base_directory=make_run(25)),
+            prefix="/log",
+        )
+        return TestClient(app)
 
-    def test_the_rail_lists_scans(self, client: TestClient) -> None:
-        """The rail names scans, never a grouping of them."""
+    def test_a_long_day_starts_collapsed(self, busy: TestClient) -> None:
+        """No scan block is open, and the button offers to expand."""
+        html = busy.get("/log/day/2026-09-11").text
+        assert html.count('<details class="panel scan"') == 25
+        assert " open>" not in html
+        assert "Expand all" in html
+
+    def test_a_short_day_starts_open(self, client: TestClient) -> None:
+        """Below the threshold every scan is readable without a click."""
         html = client.get("/log/day/2026-09-11").text
-        assert "Scans &middot;" in html or "Scans ·" in html
+        assert "Collapse all" in html
+        assert " open>" in html
+
+    def test_no_day_groups_its_scans(self, busy: TestClient) -> None:
+        """Every scan is a top-level block, whatever the day's length.
+
+        Asserting on the rendered markup, not on the absence of the word
+        "campaign": the old inline script carried `details.campaign` as a
+        selector string, so a substring check passed for the wrong reason
+        and would miss a grouping reintroduced under any other name.
+        """
+        html = busy.get("/log/day/2026-09-11").text
+        outer = re.findall(r'<details class="([^"]*)"', html)
+        assert set(outer) <= {"panel scan", "cal"}, outer
+
+    def test_the_rail_lists_scans(self, busy: TestClient) -> None:
+        """The rail names scans, never a grouping of them."""
+        html = busy.get("/log/day/2026-09-11").text
+        assert "Scans &middot; 25" in html or "Scans · 25" in html

--- a/GeecsLogbook/tests/test_router.py
+++ b/GeecsLogbook/tests/test_router.py
@@ -82,38 +82,6 @@ class TestDayPage:
         assert "Collapse all" in html
 
 
-class TestBusyDay:
-    """A day over the grouping threshold renders campaigns, not a flat list."""
-
-    @pytest.fixture
-    def busy(self, make_run) -> TestClient:
-        """Build a day of 25 identical scans — one campaign."""
-        root = make_run(25)
-        app = FastAPI()
-        app.include_router(
-            create_log_router("Undulator", base_directory=root), prefix="/log"
-        )
-        return TestClient(app)
-
-    def test_groups_into_campaigns(self, busy: TestClient) -> None:
-        """Twenty-five scans render inside one campaign block."""
-        html = busy.get("/log/day/2026-09-11").text
-        assert html.count('<details class="campaign"') == 1
-        assert html.count('<details class="panel scan"') == 25
-
-    def test_rail_lists_campaigns_not_scans(self, busy: TestClient) -> None:
-        """The rail shows one row per campaign so it stays scannable."""
-        html = busy.get("/log/day/2026-09-11").text
-        assert html.count('class="scanrow"') == 1
-        assert "Campaigns" in html
-
-    def test_busy_day_starts_collapsed(self, busy: TestClient) -> None:
-        """Nothing is expanded on arrival; the button offers Expand all."""
-        html = busy.get("/log/day/2026-09-11").text
-        assert " open>" not in html
-        assert "Expand all" in html
-
-
 class TestHonestChips:
     """The status chip must not contradict the card under it."""
 
@@ -485,3 +453,27 @@ class TestEditorHooks:
             404,
             405,
         )
+
+
+class TestLongDay:
+    """A long day opens collapsed — a fact about volume, not about meaning.
+
+    The grouped view this replaced inferred which scans belonged together
+    from two matching fields. That is interpretation, and the logbook's
+    rule is that it reports what the files say. What survives is the only
+    honest part of the old behaviour: past a certain number of scans the
+    day is easier to read as a closed list.
+    """
+
+    def test_a_long_day_renders_every_scan_at_the_top_level(
+        self, client: TestClient
+    ) -> None:
+        """No wrapper groups them; each scan is its own block."""
+        html = client.get("/log/day/2026-09-11").text
+        assert "campaign" not in html
+        assert html.count('<details class="panel scan"') == 4
+
+    def test_the_rail_lists_scans(self, client: TestClient) -> None:
+        """The rail names scans, never a grouping of them."""
+        html = client.get("/log/day/2026-09-11").text
+        assert "Scans &middot;" in html or "Scans ·" in html

--- a/GeecsLogbook/tests/test_router.py
+++ b/GeecsLogbook/tests/test_router.py
@@ -457,6 +457,44 @@ class TestEditorHooks:
         )
 
 
+def _scan_block_parents(html: str) -> set[tuple[str, ...]]:
+    """Return the ancestor chains of every scan block, below ``<main>``.
+
+    A flat day gives exactly ``{("main",)}``. Anything else means something
+    was introduced around the loop — which is what a grouping is, whatever
+    element or class name it wears.
+    """
+    from html.parser import HTMLParser
+
+    class Walk(HTMLParser):
+        def __init__(self) -> None:
+            super().__init__()
+            self.stack: list[str] = []
+            self.found: set[tuple[str, ...]] = set()
+
+        def handle_starttag(self, tag, attrs):
+            d = dict(attrs)
+            if tag == "details" and d.get("class") == "panel scan":
+                below = (
+                    self.stack[self.stack.index("main") + 1 :]
+                    if "main" in self.stack
+                    else tuple(self.stack)
+                )
+                self.found.add(
+                    ("main", *below) if "main" in self.stack else tuple(self.stack)
+                )
+            if tag not in {"br", "img", "input", "meta", "link", "hr"}:
+                self.stack.append(tag)
+
+        def handle_endtag(self, tag):
+            if tag in self.stack:
+                del self.stack[len(self.stack) - 1 - self.stack[::-1].index(tag) :]
+
+    w = Walk()
+    w.feed(html)
+    return w.found
+
+
 class TestLongDay:
     """A long day opens collapsed — a fact about volume, not about meaning.
 
@@ -504,8 +542,19 @@ class TestLongDay:
         and would miss a grouping reintroduced under any other name.
         """
         html = busy.get("/log/day/2026-09-11").text
-        outer = re.findall(r'<details class="([^"]*)"', html)
+        # Structural, not spelling. A class-attribute regex missed two real
+        # reintroductions: a grouping that is a <section> rather than a
+        # <details> (the obvious next attempt, since the complaint was a
+        # second *collapsible*), and a <details> whose class is not its
+        # first attribute. Counting every <details> catches both.
+        assert html.count("<details") == 26, "25 scans + the calendar"
+        outer = re.findall(r'<details[^>]*class="([^"]*)"', html)
         assert set(outer) <= {"panel scan", "cal"}, outer
+        # and nothing wraps the run. A regex cannot see this — consecutive
+        # scan blocks legitimately sit next to each other — so parse, and
+        # check each scan block's ancestors. A <section class="batch">
+        # around the loop is the shape a class-attribute check misses.
+        assert _scan_block_parents(html) == {("main",)}, _scan_block_parents(html)
 
     def test_the_rail_lists_scans(self, busy: TestClient) -> None:
         """The rail names scans, never a grouping of them."""

--- a/GeecsLogbook/tests/test_scan_reader.py
+++ b/GeecsLogbook/tests/test_scan_reader.py
@@ -132,43 +132,6 @@ class TestScanFolderCreationInvariant:
         read_day(date(2026, 9, 12), "Undulator", base_directory=tmp_path)
 
 
-class TestCampaigns:
-    """Consecutive scans sharing a parameter and purpose group into a run.
-
-    A busy day is a handful of campaigns rather than a hundred unrelated
-    scans, and the grouping is derived from what the scanner already wrote
-    — nobody declares a campaign, so nobody can forget to.
-    """
-
-    def test_groups_consecutive_matching_scans(self, share: Path) -> None:
-        """Each distinct (parameter, purpose) run becomes one campaign."""
-        day = read_day(DAY, "Undulator", base_directory=share)
-        spans = [(c.span, len(c.scans)) for c in day.campaigns]
-        # Scan001/Scan040 share (U_S1H, same purpose) but are not adjacent;
-        # Scan031 has no ScanInfo at all.
-        assert spans == [
-            ("Scan001", 1),
-            ("Scan006", 1),
-            ("Scan031", 1),
-            ("Scan040", 1),
-        ]
-
-    def test_a_run_collapses_to_one_campaign(self, make_run) -> None:
-        """Twenty identical scans are one campaign, not twenty."""
-        root = make_run(20)
-        campaigns = read_day(DAY, "Undulator", base_directory=root).campaigns
-        assert len(campaigns) == 1
-        assert campaigns[0].span == "Scan001–Scan020"
-        assert len(campaigns[0].scans) == 20
-
-    def test_campaign_reports_failures_inside_it(self, share: Path) -> None:
-        """A failure inside a campaign is visible on the campaign itself."""
-        day = read_day(DAY, "Undulator", base_directory=share)
-        failing = [c for c in day.campaigns if c.failed]
-        assert len(failing) == 1
-        assert failing[0].scans[0].number == 6
-
-
 class TestCaching:
     """Scan folders are memoised on their modification time.
 
@@ -282,30 +245,6 @@ class TestLeanReads:
         from geecs_logbook.scan_reader import scan_contents
 
         assert scan_contents(tmp_path / "nope") == (None, None, None, None, ())
-
-
-class TestEmptyRuns:
-    """Folders with no ScanInfo group together and say so."""
-
-    def test_metadata_free_run_is_labelled(self, make_run, tmp_path) -> None:
-        """A run of bare folders reports itself as metadata-free."""
-        scans = tmp_path / "Undulator" / "Y2026" / "09-Sep" / "26_0911" / "scans"
-        scans.mkdir(parents=True)
-        for n in range(1, 6):
-            folder = scans / f"Scan{n:03d}"
-            folder.mkdir()
-            (folder / "scan.log").write_text("")
-
-        campaigns = read_day(DAY, "Undulator", base_directory=tmp_path).campaigns
-        assert len(campaigns) == 1
-        assert campaigns[0].is_empty_run is True
-        assert len(campaigns[0].scans) == 5
-
-    def test_a_real_run_is_not(self, share) -> None:
-        """A run with a scan parameter is never labelled metadata-free."""
-        campaigns = read_day(DAY, "Undulator", base_directory=share).campaigns
-        real = [c for c in campaigns if c.parameter]
-        assert real and all(c.is_empty_run is False for c in real)
 
 
 class TestStartTime:

--- a/GeecsLogbook/tests/test_store.py
+++ b/GeecsLogbook/tests/test_store.py
@@ -343,7 +343,7 @@ class TestBooks:
     """Two books, one store."""
 
     def test_default_book_is_scans(self, store: NotesStore) -> None:
-        """Existing callers get the campaign record."""
+        """Existing callers get the per-scan record."""
         assert store.create(day=DAY, scan=1, author="a", body_md="x").book == "scans"
 
     def test_ops_is_day_level_only(self, store: NotesStore) -> None:
@@ -409,7 +409,7 @@ class TestQuery:
         )
 
     def test_scan_anchored_can_be_hidden(self, store: NotesStore) -> None:
-        """The month page's default: the campaign record stays out of the way."""
+        """The month page's default: the per-scan record stays out of the way."""
         self._seed(store)
         day_level = store.query(
             day_from="2026-09-01", day_to="2026-09-30", include_scan_anchored=False

--- a/GeecsLogbook/tests/test_templates.py
+++ b/GeecsLogbook/tests/test_templates.py
@@ -46,7 +46,7 @@ def test_every_literal_data_state_is_a_kit_state() -> None:
     """A hand-written ``data-state`` names a state the kit actually colours.
 
     ``KIT_STATE`` is pinned by ``test_models.py``, but three call sites
-    write the attribute literally rather than through it — a campaign's
+    write the attribute literally rather than through it — a failed-scan
     "failed" count, the month page's "today", and an agent entry. A typo in
     any of those renders an uncoloured chip: ``.chip`` still gives a pill
     with inherited colour and a ``currentColor`` dot, so it looks plausible


### PR DESCRIPTION
Third step of the surface-kit arc. Targets `feature/web-surface-kit`.

Net **−19 lines** — this mostly removes a wrong idea.

## Two changes, one principle

The scan log had started **interpreting**. It grouped consecutive scans sharing a parameter and a purpose into a "campaign", and it wrapped notes falling between scans in a container announcing which gap they sat in. Neither is the log's job: it is note-taking about what happened, and this package already holds itself to exactly that rule in **"Status is reported, not inferred"** — *report what the files say and do not guess*.

## `Campaign` is deleted outright

Two things were wrong with it.

**It inferred.** Nothing in `ScanInfo` says those scans belong together; the code decided it from two fields matching.

**It borrowed a word that means something else here.** A campaign in this lab is *weeks* of work. A day page cannot contain one — it is a slice of one — so the rail reading **"Campaigns · 15"** told an operator it held fifteen multi-week efforts. That is the part that was actively misleading, and it rendered on screen.

**And it did not pay for itself.** Measured across four real days on the share:

| day | scans | groups | single-scan groups | longest |
|---|---|---|---|---|
| 26_0908 | 26 | 8 | 4 | 10 |
| 26_0909 | 65 | 11 | 9 | 50 |
| 26_0910 | 108 | 11 | 6 | 65 |
| **26_0912** | **21** | **15** | **11** | **3** |

A sweep day collapses 108 scans into 11. An acceptance run of 21 produced **15 groups, eleven of them wrapping a single scan** — because the threshold asked *"is the day long?"* when the question was *"does grouping help?"*.

Gone: the model, the property, seven CSS classes, the grouped template branch, and the filter and jump logic that had to reach two nesting levels. `grep campaign` across the package returns nothing.

What survives is the honest half: **a long day opens collapsed** — a fact about volume, not a claim about meaning. It keeps its own test (`TestLongDay`).

## A note between two scans is just a note

It wore a `<details class="between">` announcing "Between scans" and its range. That was ceremony, and it made identical content look like a different *kind* of thing from the same note in the ops book. It now renders as an ordinary entry at document level with its own timestamp — usually out of step with the scans either side, which is the point.

This also fixes a placement bug: under the grouping, a note anchored "after Scan005" was emitted **inside** Scan006's group.

## Seeded example notes

`scripts/seed_demo_notes.py` writes worked examples to a **separate** database. The store is authoritative — what people wrote exists nowhere else — so invented content must never be seeded into it. But a day with no notes shows none of what the page is for, which is how an unstyled composer shipped unnoticed in #857. The entries say in their own body that they are seeded, and the script refuses to write to a file that already exists.

## Scope

Two concerns, bundled deliberately because the second is only visible once the first lands — you cannot judge "notes in time order" while a grouping is reordering them.

Per-concern LOC: `Campaign` removal −91 `models.py` / −40 CSS / −70 `day.html` · between-block −20 · seed script +145 · tests −61/+56 · changelog.

**No facility literals added.** The seed script names real devices, but as example *content* in a dev-only script, not as defaults in code.

## Tests

**214 passed**, `./scripts/check.sh` exit 0.

Verified by rendering the real `2026-09-12` (21 scans) with seeded notes: **zero** campaign wrappers, **zero** "Between scans", 21 top-level scan blocks, notes interleaved by timestamp. Orphan check (every class used vs every class styled) clean but for `.calbody`, a `nav.js` hook orphaned before this arc.

## Hardware verification

**Not applicable** — no scan-execution, device or gateway surface is touched.